### PR TITLE
cicchetto: add /join guidance to visitor home pane

### DIFF
--- a/cicchetto/src/HomePane.tsx
+++ b/cicchetto/src/HomePane.tsx
@@ -42,6 +42,10 @@ const HomePaneVisitor: Component = () => {
         IRC channels appear in the sidebar. Pick one to start chatting. Your visitor session is
         ephemeral — when it expires, scrollback for this nick stays archived on the bouncer.
       </p>
+      <p class="muted">
+        This is IRC: to join a channel, tap the server tab below and <code>/join</code> it. To get
+        started, <code>/join #grappa</code>.
+      </p>
     </div>
   );
 };

--- a/cicchetto/src/HomePane.tsx
+++ b/cicchetto/src/HomePane.tsx
@@ -39,8 +39,10 @@ const HomePaneVisitor: Component = () => {
       <h2 class="home-pane-title">Welcome to Grappa</h2>
       <p>You are connected as a visitor.</p>
       <p class="muted">
-        IRC channels appear in the sidebar. Pick one to start chatting. Your visitor session is
-        ephemeral — when it expires, scrollback for this nick stays archived on the bouncer.
+        IRC channels appear in the sidebar. Pick one to start chatting. While your session is open
+        the bouncer keeps you connected — close cicchetto and reopen, and you're still on, right
+        where you left off. But a visitor session is ephemeral: when it expires its scrollback goes
+        with it. Nothing is kept for a visitor nick.
       </p>
       <p class="muted">
         This is IRC: to join a channel, tap the server tab below and <code>/join</code> it. To get


### PR DESCRIPTION
The visitor home pane told users that channels appear in the sidebar but never explained how to actually join one. This adds a short muted line pointing at the server tab and the `/join` command, with `/join #grappa` as a concrete first step.

Requested per chan request.

Leaves the existing scrollback/ephemeral-session copy untouched.