### PR TITLE
deps: Elixir 1.20 / OTP 29 migration (parked — blocked on m42 jail 1.20 support)

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.19.5-otp-28
-erlang 28.5
+elixir 1.20.0-otp-29
+erlang 29.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # path. Elixir + OTP are still pinned via the tag; alpine version
 # floats with whatever Docker library publishes for that tag.
 
-FROM elixir:1.19-otp-28-alpine
+FROM elixir:1.20.0-otp-29-alpine
 
 # build-base + git for hex deps; sqlite-dev for ecto_sqlite3 NIF link;
 # curl for the in-container /healthz probe + future hot-deploy POST;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -16932,3 +16932,77 @@ read (trips an ErrorBoundary, kills the splash); a 401 would fire `on401`
 → clear the token → bounce to `/login`. Pending is the genuine cold-load
 state. This is the pattern for any future loading-only / transient-overlay
 e2e.
+
+---
+
+## 2026-07-05 — Elixir 1.20 / OTP 29 toolchain bump (PR #53) + the `opaque/1` negative-type-test convention
+
+dependabot bumped the Docker base image `elixir:1.19-otp-28-alpine →
+1.20.0-otp-29-alpine` (PR #53, Dockerfile-only). vjt authorised landing it
+as the FULL 1.20 migration (m42/prod confirmed OTP-29-ready). Validated in
+isolation under a clean 1.20/OTP-29 image *before* merge: the full suite
+(3156 tests) + dialyzer are runtime/type-clean under OTP 29 — the toolchain
+itself is compatible. The only blockers were **new compiler strictness**,
+fixed as a companion migration in the same merge:
+
+- **`.tool-versions`** bumped to `elixir 1.20.0-otp-29` / `erlang 29.0.1`
+  (was `1.19.5-otp-28` / `28.5`) to match the image tag. dependabot only
+  manages the docker ecosystem, so it left this drift; the pin is
+  load-bearing (CLAUDE.md "pinned in .tool-versions").
+- **Two dead `require Logger`** removed from `lib/grappa/log.ex` +
+  `lib/grappa/ws_presence.ex`. 1.20 tightened unused-`require` detection:
+  both modules call only Logger *functions* (`Logger.metadata/1`), never a
+  Logger *macro*, so the require was genuinely unused — and under
+  `--warnings-as-errors` it failed `mix compile`.
+- **Three mechanical test fixes:** two more dead `require Logger`
+  (`log_test.exs`, `resolve_network_test.exs`); one bitstring pin
+  (`parser_property_test.exs` — `size(pos)` → `size(^pos)`; 1.20 requires
+  the pin when the size var is bound outside the match).
+- **The `xref: [exclude: …]` deprecation notice is NOT ours.** grappa's
+  `mix.exs` has no such key (the `xref` hits in `lib/` are Boundary's
+  `dirty_xrefs:`, unrelated). The notice comes from dependencies' mix.exs
+  and is a mix-level notice, not a compiler diagnostic, so it never counts
+  toward `--warnings-as-errors`. No action.
+
+### The `opaque/1` convention (`Grappa.TypeLaundry`) — precedent for negative-type guard tests
+
+Elixir 1.20's set-theoretic type checker now **statically** flags a call
+that passes a literal wrong-typed value to a function whose guard/spec
+rejects it — even when asserting that rejection is the entire point of the
+test (`assert_raise FunctionClauseError, fn -> f(wrong_type) end`). 15 such
+intentional negative-type guard tests across 9 files tripped
+`"incompatible types given to …"`, failing `mix test --warnings-as-errors`.
+The tests are correct and valuable (defensive-guard / no-silent-drops
+coverage); the fix must not weaken them or the production guard.
+
+**Decision (vjt, option A1):** a dedicated **test-support** module
+`Grappa.TypeLaundry` (`test/support/type_laundry.ex`, test-env only)
+exposing a runtime-identity passthrough whose declared return type is
+`term()`:
+
+```elixir
+@spec opaque(term()) :: term()
+def opaque(value), do: value
+```
+
+Because the declared return is `term()`, the compile-time checker cannot
+narrow the argument type at the call site (stays silent) while runtime
+behaviour — and therefore the test's assertion — is unchanged. Verified on
+one site first (warning silenced, tests still pass) before fanning to all 15.
+
+**The rule going forward:** a negative-type guard test wraps ONLY the
+deliberately-wrong argument in `opaque/1` (after `import Grappa.TypeLaundry`):
+
+```elixir
+assert_raise FunctionClauseError, fn ->
+  PubSub.broadcast_event("grappa:user:test", opaque(%URI{scheme: "https"}))
+end
+```
+
+This is the single sanctioned pattern. Do NOT sprinkle `@dialyzer` /
+`@compile` suppressions, disable the type checker project-wide, or weaken a
+production guard to appease the checker. `opaque/1` also clears the sibling
+"conditional will always succeed" warning (e.g. `is_integer(opaque(x))`
+when the type system already proved `x :: integer()`). It lives in a
+dedicated, explicitly-imported module — NOT `Grappa.DataCase` — to keep the
+type-laundering visible at every call site.

--- a/lib/grappa/log.ex
+++ b/lib/grappa/log.ex
@@ -41,8 +41,6 @@ defmodule Grappa.Log do
 
   use Boundary, top_level?: true, deps: []
 
-  require Logger
-
   @type session_metadata :: [user: String.t(), network: String.t()]
 
   # Mirrored at `Grappa.IRC.Client.session_metadata` (irc/S6, 2026-05-12

--- a/lib/grappa/ws_presence.ex
+++ b/lib/grappa/ws_presence.ex
@@ -70,8 +70,6 @@ defmodule Grappa.WSPresence do
 
   alias Grappa.PubSub.Topic
 
-  require Logger
-
   # Test-only atom guarding `reset_for_test/0` — ONLY compiled in test mix env.
   # (A `@test_only` marker is the documented way to keep test helpers alive
   # without weakening the production contract.)

--- a/test/grappa/admin_events/wire_test.exs
+++ b/test/grappa/admin_events/wire_test.exs
@@ -13,6 +13,7 @@ defmodule Grappa.AdminEvents.WireTest do
       without a Wire arm fails loudly.
   """
   use Grappa.DataCase, async: true
+  import Grappa.TypeLaundry
 
   alias Grappa.AdminEvents.Wire
 
@@ -52,7 +53,7 @@ defmodule Grappa.AdminEvents.WireTest do
       # attribution; passing :operator_reset here would silently strip
       # the actor.
       assert_raise FunctionClauseError, fn ->
-        Wire.circuit_close(1, "azzurra", :operator_reset)
+        Wire.circuit_close(1, "azzurra", opaque(:operator_reset))
       end
     end
   end
@@ -128,7 +129,7 @@ defmodule Grappa.AdminEvents.WireTest do
 
     test "rejects unknown subject_kind" do
       assert_raise FunctionClauseError, fn ->
-        Wire.session_terminated(:robot, "id", 1, "n", "a", "b")
+        Wire.session_terminated(opaque(:robot), "id", 1, "n", "a", "b")
       end
     end
   end
@@ -378,7 +379,7 @@ defmodule Grappa.AdminEvents.WireTest do
 
     test "rejects unknown session_action" do
       assert_raise FunctionClauseError, fn ->
-        Wire.credential_updated("u-uuid", "alice", 7, "azzurra", :restarted, "a", "vjt")
+        Wire.credential_updated("u-uuid", "alice", 7, "azzurra", opaque(:restarted), "a", "vjt")
       end
     end
   end

--- a/test/grappa/admission_test.exs
+++ b/test/grappa/admission_test.exs
@@ -6,6 +6,7 @@ defmodule Grappa.AdmissionTest do
   skips).
   """
   use Grappa.DataCase, async: false
+  import Grappa.TypeLaundry
 
   alias Grappa.{Admission, AdmissionStateHelpers, Repo, SessionRegistry}
   alias Grappa.Admission.Captcha.{Disabled, HCaptcha, Turnstile}
@@ -44,7 +45,7 @@ defmodule Grappa.AdmissionTest do
       assert {:error, {:network_circuit_open, retry_after}} =
                Admission.check_capacity(input)
 
-      assert is_integer(retry_after) and retry_after >= 0
+      assert is_integer(opaque(retry_after)) and retry_after >= 0
     end
   end
 

--- a/test/grappa/deploy/preflight_test.exs
+++ b/test/grappa/deploy/preflight_test.exs
@@ -1,6 +1,7 @@
 defmodule Grappa.Deploy.PreflightTest do
   # async: true — pure logic, no global state.
   use ExUnit.Case, async: true
+  import Grappa.TypeLaundry
 
   alias Grappa.Deploy.Preflight
 
@@ -126,13 +127,13 @@ defmodule Grappa.Deploy.PreflightTest do
   describe "classify_paths/2 — substrate is a closed set" do
     test "unknown substrate raises FunctionClauseError (loud usage error, never a silent guess)" do
       assert_raise FunctionClauseError, fn ->
-        Preflight.classify_paths(["lib/grappa/scrollback.ex"], :freebsd)
+        Preflight.classify_paths(["lib/grappa/scrollback.ex"], opaque(:freebsd))
       end
     end
 
     test "string substrate raises FunctionClauseError (atoms only past the CLI boundary)" do
       assert_raise FunctionClauseError, fn ->
-        Preflight.classify_paths(["lib/grappa/scrollback.ex"], "docker")
+        Preflight.classify_paths(["lib/grappa/scrollback.ex"], opaque("docker"))
       end
     end
   end

--- a/test/grappa/irc/parser_property_test.exs
+++ b/test/grappa/irc/parser_property_test.exs
@@ -289,7 +289,7 @@ defmodule Grappa.IRC.Parser.PropertyTest do
   defp sprinkle_unsafe(base, inserts) do
     Enum.reduce(inserts, base, fn {sep, pos}, acc ->
       pos = min(pos, byte_size(acc))
-      <<head::binary-size(pos), tail::binary>> = acc
+      <<head::binary-size(^pos), tail::binary>> = acc
       head <> sep <> tail
     end)
   end

--- a/test/grappa/live_introspection/admin_wire_test.exs
+++ b/test/grappa/live_introspection/admin_wire_test.exs
@@ -6,6 +6,7 @@ defmodule Grappa.LiveIntrospection.AdminWireTest do
   JSON-encodable map.
   """
   use ExUnit.Case, async: true
+  import Grappa.TypeLaundry
 
   alias Grappa.LiveIntrospection.{AdminWire, SessionEntry}
 
@@ -101,7 +102,7 @@ defmodule Grappa.LiveIntrospection.AdminWireTest do
     # Guard `is_binary(label) or is_nil(label)` — anything else is a
     # contract violation that surfaces as FunctionClauseError.
     assert_raise FunctionClauseError, fn ->
-      AdminWire.session_to_admin_json(entry, :atom_label, nil)
+      AdminWire.session_to_admin_json(entry, opaque(:atom_label), nil)
     end
   end
 
@@ -165,7 +166,7 @@ defmodule Grappa.LiveIntrospection.AdminWireTest do
     }
 
     assert_raise FunctionClauseError, fn ->
-      AdminWire.session_to_admin_json(entry, "vjt", "2026-01-01T00:00:00Z")
+      AdminWire.session_to_admin_json(entry, "vjt", opaque("2026-01-01T00:00:00Z"))
     end
   end
 end

--- a/test/grappa/log_test.exs
+++ b/test/grappa/log_test.exs
@@ -8,8 +8,6 @@ defmodule Grappa.LogTest do
 
   alias Grappa.Log
 
-  require Logger
-
   describe "session_context/2" do
     test "returns canonical [user:, network:] keyword list" do
       assert Log.session_context("vjt", "azzurra") == [user: "vjt", network: "azzurra"]

--- a/test/grappa/networks/wire_test.exs
+++ b/test/grappa/networks/wire_test.exs
@@ -14,6 +14,7 @@ defmodule Grappa.Networks.WireTest do
   password to JSON.
   """
   use Grappa.DataCase, async: true
+  import Grappa.TypeLaundry
 
   alias Grappa.{Accounts, Networks, Repo}
   alias Grappa.Networks.{Credential, Credentials, Wire}
@@ -403,7 +404,7 @@ defmodule Grappa.Networks.WireTest do
       cred = user |> Credentials.get_credential!(network) |> Repo.preload(:network)
 
       assert_raise FunctionClauseError, fn -> Wire.home_network_row(cred, "") end
-      assert_raise FunctionClauseError, fn -> Wire.home_network_row(cred, nil) end
+      assert_raise FunctionClauseError, fn -> Wire.home_network_row(cred, opaque(nil)) end
     end
   end
 

--- a/test/grappa/pubsub/topic_test.exs
+++ b/test/grappa/pubsub/topic_test.exs
@@ -8,6 +8,7 @@ defmodule Grappa.PubSub.TopicTest do
   namespace, see DESIGN_NOTES 2026-04-25).
   """
   use ExUnit.Case, async: true
+  import Grappa.TypeLaundry
 
   alias Grappa.PubSub.Topic
 
@@ -118,7 +119,7 @@ defmodule Grappa.PubSub.TopicTest do
     end
 
     test "raises on non-binary user_name" do
-      assert_raise FunctionClauseError, fn -> Topic.ws_presence(nil) end
+      assert_raise FunctionClauseError, fn -> Topic.ws_presence(opaque(nil)) end
     end
   end
 

--- a/test/grappa/pubsub_test.exs
+++ b/test/grappa/pubsub_test.exs
@@ -12,6 +12,8 @@ defmodule Grappa.PubSubTest do
   """
   use ExUnit.Case, async: true
 
+  import Grappa.TypeLaundry
+
   alias Grappa.PubSub
   alias Phoenix.Socket.Broadcast
 
@@ -26,7 +28,7 @@ defmodule Grappa.PubSubTest do
     test "rejects struct payloads with FunctionClauseError" do
       # A schema-shaped struct stand-in: any defstruct'd module qualifies.
       assert_raise FunctionClauseError, fn ->
-        PubSub.broadcast_event("grappa:user:test", %URI{scheme: "https"})
+        PubSub.broadcast_event("grappa:user:test", opaque(%URI{scheme: "https"}))
       end
     end
 
@@ -42,17 +44,17 @@ defmodule Grappa.PubSubTest do
 
     test "rejects non-map payloads" do
       assert_raise FunctionClauseError, fn ->
-        PubSub.broadcast_event("grappa:user:test", "not a map")
+        PubSub.broadcast_event("grappa:user:test", opaque("not a map"))
       end
 
       assert_raise FunctionClauseError, fn ->
-        PubSub.broadcast_event("grappa:user:test", nil)
+        PubSub.broadcast_event("grappa:user:test", opaque(nil))
       end
     end
 
     test "rejects non-binary topic" do
       assert_raise FunctionClauseError, fn ->
-        PubSub.broadcast_event(:not_a_string, %{ok: true})
+        PubSub.broadcast_event(opaque(:not_a_string), %{ok: true})
       end
     end
   end

--- a/test/grappa/session/away_state_test.exs
+++ b/test/grappa/session/away_state_test.exs
@@ -27,6 +27,7 @@ defmodule Grappa.Session.AwayStateTest do
       symmetric with `in_flight_joins` from cluster #6.
   """
   use ExUnit.Case, async: true
+  import Grappa.TypeLaundry
 
   alias Grappa.Session.AwayState
 
@@ -175,7 +176,7 @@ defmodule Grappa.Session.AwayStateTest do
   describe "type guards" do
     test "set_explicit_away/2 requires a binary reason" do
       assert_raise FunctionClauseError, fn ->
-        AwayState.set_explicit_away(AwayState.new(), :not_a_string)
+        AwayState.set_explicit_away(AwayState.new(), opaque(:not_a_string))
       end
     end
   end

--- a/test/grappa/visitors/visitor_test.exs
+++ b/test/grappa/visitors/visitor_test.exs
@@ -6,6 +6,7 @@ defmodule Grappa.Visitors.VisitorTest do
   regression on one rule doesn't get hidden by an adjacent failure.
   """
   use ExUnit.Case, async: true
+  import Grappa.TypeLaundry
 
   alias Grappa.Visitors.Visitor
 
@@ -133,7 +134,7 @@ defmodule Grappa.Visitors.VisitorTest do
 
     test "rejects non-string non-nil via the guard", %{visitor: visitor} do
       assert_raise FunctionClauseError, fn ->
-        Visitor.ip_changeset(visitor, {1, 2, 3, 4})
+        Visitor.ip_changeset(visitor, opaque({1, 2, 3, 4}))
       end
     end
   end

--- a/test/grappa_web/plugs/resolve_network_test.exs
+++ b/test/grappa_web/plugs/resolve_network_test.exs
@@ -25,8 +25,6 @@ defmodule GrappaWeb.Plugs.ResolveNetworkTest do
   alias Grappa.Networks.{Credentials, Servers}
   alias GrappaWeb.Plugs.ResolveNetwork
 
-  require Logger
-
   setup do
     {:ok, network} = Networks.find_or_create_network(%{slug: "azzurra"})
     %{network: network}

--- a/test/support/type_laundry.ex
+++ b/test/support/type_laundry.ex
@@ -1,0 +1,39 @@
+defmodule Grappa.TypeLaundry do
+  @moduledoc """
+  Type-laundering helper for **negative-type guard tests** under Elixir 1.20+.
+
+  Elixir 1.20's set-theoretic type checker statically flags a call that
+  passes a literal wrong-typed value to a function whose guard/spec rejects
+  it — even when asserting that rejection is the entire point of the test
+  (e.g. `assert_raise FunctionClauseError`). Under `--warnings-as-errors`
+  those `"incompatible types given to …"` warnings fail the build.
+
+  `opaque/1` is a **runtime-identity passthrough** whose declared return
+  type is `term()`, so the compile-time checker cannot narrow the argument
+  type at the call site and stays silent, while runtime behaviour — and
+  therefore the test's assertion — is unchanged.
+
+  ## Convention
+
+  Wrap ONLY the deliberately-wrong argument, nothing else:
+
+      import Grappa.TypeLaundry
+
+      assert_raise FunctionClauseError, fn ->
+        PubSub.broadcast_event("grappa:user:test", opaque(%URI{scheme: "https"}))
+      end
+
+  This is the single sanctioned way to write negative-type guard tests under
+  1.20 — do not sprinkle `@dialyzer`/`@compile` suppressions or weaken the
+  production guard to appease the checker. See `docs/DESIGN_NOTES.md`
+  (2026-07-05, Elixir 1.20 / OTP 29 migration).
+  """
+
+  @doc """
+  Returns `value` unchanged at runtime; opaque to the compile-time type
+  checker (declared `term() :: term()` so no argument-type narrowing leaks
+  to the call site).
+  """
+  @spec opaque(term()) :: term()
+  def opaque(value), do: value
+end


### PR DESCRIPTION
Parks the full Elixir 1.20 / OTP 29 migration on a branch. Supersedes / continues #53 (whose dependabot head branch was deleted on close).

## Why parked (do NOT merge yet)
The prod host is the **m42 bastille jail**, which currently **cannot install Elixir 1.20 / OTP 29**, and vjt will **not** compile from source. So a COLD deploy of this would fail. This PR stays OPEN until the m42 jail can provide 1.20/OTP-29. Prod BEAM stays 1.19/OTP-28 on `main`.

This was briefly FF-merged to `main` (`8dedaa5`) and then un-merged: `main` is reset back to `2ccae72`, the four commits preserved here on `pr53-otp29`.

## What's in it (4 commits, `441dc83..8dedaa5`)
- `441dc83` bump Docker base `elixir:1.19-otp-28-alpine` → `1.20.0-otp-29-alpine` (originally #53)
- `99c67a3` bump `.tool-versions` → `elixir 1.20.0-otp-29` / `erlang 29.0.1`
- `0ff1722` clear Elixir 1.20 unused-`require` + bitstring-pin warnings (lib + test)
- `8dedaa5` add `Grappa.TypeLaundry.opaque/1` convention for negative-type guard tests under 1.20's stricter type checker (15 sites / 9 files)

## Verification (done before the park)
- `scripts/check.sh` **fully WAE-green** under 1.20/otp29 — all gates + bats (3156 tests + dialyzer clean).
- Integration e2e: **no 1.20 regression**. The only failures were pre-existing flakes (bug7 known; 2 WS-gap reconnect specs proven flaky on the **1.19** toolchain too — a 1.19 control ran 3 pass / 3 fail).

## To re-land later
When m42 supports 1.20/OTP-29: rebase `pr53-otp29` onto `main`, re-run `check.sh` + `integration.sh`, FF-merge, then COLD deploy (the jail must be verified to install 1.20 first).

Ref #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)