### PR TITLE
cic: #289 translucent mobile floating buttons so text shows through

### DIFF
--- a/cicchetto/e2e/tests/issue289-float-btn-opacity.spec.ts
+++ b/cicchetto/e2e/tests/issue289-float-btn-opacity.spec.ts
@@ -1,0 +1,186 @@
+// #289 (enhancement, fast-follow to #280) — the two MOBILE floating
+// buttons, next-active (`NextActiveButton` variant="mobile") and
+// scroll-to-bottom (`ScrollbackPane` `.scroll-to-bottom-btn`), used to be
+// fully OPAQUE and painted on top of the message list. Any message text
+// that wrapped behind a button became unreadable. #280 fixed them
+// overlapping EACH OTHER (one container-anchored stack); this is the next
+// polish pass on the same pair: now that they coexist cleanly, they must
+// not hide message CONTENT.
+//
+// Fix: both mobile floating variants get a translucent whole-element
+// opacity — the text behind stays legible while the control (large glyph
+// + accent fill + shadow) stays clearly tappable. Whole-element opacity
+// (not a per-color alpha) keeps the fix theme-agnostic: every built-in
+// theme inherits it without a per-theme translucent color. See
+// DESIGN_NOTES 2026-07-18.
+//
+// This is a rendered-computed-style witness on the mobile variants
+// (`.next-active-btn-mobile`, `.shell-mobile .scroll-to-bottom-btn`),
+// which mount ONLY on a real mobile WebKit engine (`@webkit` →
+// webkit-iphone-15, the only place variant="mobile" mounts + the
+// `.shell-mobile` gate applies). jsdom/vitest is blind to the mobile
+// gate + computed opacity, so this Playwright e2e is the RED→GREEN gate.
+//
+// Anti-false-green: BOTH buttons are asserted PRESENT + VISIBLE (a real
+// unread window lights next-active count "1"; a scrolled-up pane shows
+// scroll-to-bottom) BEFORE any opacity is read — a hidden/absent button
+// (an `opacity`-less element, or one gated out via `<Show>`) would
+// trivially satisfy an opacity check.
+
+import { type Page } from "@playwright/test";
+import {
+  composeTextarea,
+  loginAs,
+  scrollbackLines,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
+import { assertMessagePersisted, partChannel, restoreReadCursorToTail } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0]!;
+const SCROLL_BOTTOM_THRESHOLD_PX = 50;
+
+const SCROLL_TO_BOTTOM = '[data-testid="scroll-to-bottom"]';
+const NEXT_ACTIVE_BTN = '[data-testid="next-active-btn"]';
+const NEXT_ACTIVE_COUNT = '[data-testid="next-active-btn"] .next-active-count';
+
+// Translucency band: the fix makes the control see-through (opacity < 1 —
+// the bug was a fully opaque 1.0) while keeping it clearly tappable
+// (comfortably above a disabled-looking floor). The exact value is a
+// tuning knob; the CONTRACT is "translucent yet visible", not a magic
+// number, so we assert the band rather than an exact opacity.
+const OPAQUE = 1;
+const TAPPABLE_FLOOR = 0.4;
+
+async function opacityOf(page: Page, selector: string): Promise<number> {
+  return await page.evaluate((sel) => {
+    const el = document.querySelector(sel) as HTMLElement | null;
+    if (!el) return -1;
+    return parseFloat(getComputedStyle(el).opacity);
+  }, selector);
+}
+
+async function distFromBottom(page: Page): Promise<number | null> {
+  return await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+    if (!el) return null;
+    return Math.round(el.scrollHeight - el.scrollTop - el.clientHeight);
+  });
+}
+
+// Scroll to the top and fire a synthetic scroll so the Solid handler runs
+// loadMore (pulls older history, leaving the pane parked near the top).
+async function scrollToTop(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement;
+    el.scrollTop = 0;
+    el.dispatchEvent(new Event("scroll"));
+  });
+}
+
+// Drive CHANNEL up into history (loadMore) until the pane is genuinely
+// scrolled UP (not at bottom) so the floating scroll-to-bottom button
+// shows. Mirrors #280 / #243's scroll harness.
+async function scrollChannelUp(page: Page): Promise<void> {
+  await expect
+    .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
+    .toBeGreaterThanOrEqual(50);
+  let prev = -1;
+  for (let i = 0; i < 8; i++) {
+    const c = await scrollbackLines(page).count();
+    if (c === prev) break;
+    prev = c;
+    await scrollToTop(page);
+    await page.waitForTimeout(600);
+  }
+  await scrollToTop(page);
+  await expect
+    .poll(async () => (await distFromBottom(page)) ?? 0, { timeout: 5_000 })
+    .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
+  await expect(page.locator(SCROLL_TO_BOTTOM)).toBeVisible({ timeout: 5_000 });
+}
+
+// The read cursor is server-owned + persists across page loads; this test
+// leaves CHANNEL + the background channel unread. Restore to tail so a
+// later spec that assumes a clean cursor / exact next-active count is not
+// poisoned (cascade-poisoner discipline — mirror #280 / #243).
+test.afterEach(async () => {
+  const vjt = getSeededVjt();
+  await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
+});
+
+test.describe("#289 — mobile floating buttons are translucent (text shows through)", () => {
+  test("@webkit — next-active + scroll-to-bottom are translucent yet clearly tappable", async ({
+    page,
+  }) => {
+    const vjt = getSeededVjt();
+    const peerNick = `t289-${Date.now() % 100000}`;
+    const bgChannel = "#t289op";
+    await loginAs(page, vjt);
+
+    // Surface BOTH buttons at once (mirrors #280 test-1): scroll-to-bottom
+    // needs a scrolled-up window we STAY on; next-active needs a DIFFERENT
+    // window with unread (a focused window marks itself read on arrival),
+    // so the unread lives in a background channel while we sit on CHANNEL
+    // scrolled up.
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+    const peer = await IrcPeer.connect({ nick: peerNick });
+    try {
+      await peer.join(bgChannel);
+      await composeTextarea(page).fill(`/join ${bgChannel}`);
+      await composeTextarea(page).press("Enter");
+      await selectChannel(page, NETWORK_SLUG, bgChannel, { ownNick: NETWORK_NICK });
+
+      // Back to CHANNEL and scroll UP → scroll-to-bottom shows and the pane
+      // stays far from the tail (background arrivals will NOT auto-follow).
+      await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+      await scrollChannelUp(page);
+
+      // Background traffic → bgChannel unread → next-active mounts (count
+      // "1"), without touching CHANNEL's scroll or focus.
+      const line = "289 opacity traffic";
+      peer.privmsg(bgChannel, line);
+      await assertMessagePersisted({
+        token: vjt.token,
+        networkSlug: NETWORK_SLUG,
+        channel: bgChannel,
+        sender: peerNick,
+        body: line,
+      });
+
+      // Anti-false-green: BOTH affordances present + visible before any
+      // opacity is read.
+      await expect(page.locator(NEXT_ACTIVE_COUNT)).toHaveText("1", { timeout: 10_000 });
+      await expect(page.locator(NEXT_ACTIVE_BTN)).toBeVisible();
+      await expect(page.locator(SCROLL_TO_BOTTOM)).toBeVisible();
+
+      // ── The fix: both mobile floating buttons are translucent. ──────
+      const naOpacity = await opacityOf(page, NEXT_ACTIVE_BTN);
+      const sbOpacity = await opacityOf(page, SCROLL_TO_BOTTOM);
+
+      expect(
+        naOpacity,
+        `next-active must be translucent (< ${OPAQUE}) so text behind stays legible — got ${naOpacity}`,
+      ).toBeLessThan(OPAQUE);
+      expect(
+        naOpacity,
+        `next-active must stay clearly tappable (>= ${TAPPABLE_FLOOR}) — got ${naOpacity}`,
+      ).toBeGreaterThanOrEqual(TAPPABLE_FLOOR);
+
+      expect(
+        sbOpacity,
+        `scroll-to-bottom must be translucent (< ${OPAQUE}) so text behind stays legible — got ${sbOpacity}`,
+      ).toBeLessThan(OPAQUE);
+      expect(
+        sbOpacity,
+        `scroll-to-bottom must stay clearly tappable (>= ${TAPPABLE_FLOOR}) — got ${sbOpacity}`,
+      ).toBeGreaterThanOrEqual(TAPPABLE_FLOOR);
+    } finally {
+      await peer.disconnect("289 opacity done").catch(() => {});
+      await partChannel(vjt.token, NETWORK_SLUG, bgChannel).catch(() => {});
+    }
+  });
+});

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2057,6 +2057,22 @@ html.resize-dragging * {
   pointer-events: auto;
 }
 
+/* #289 — on mobile the float-stack buttons (next-active circle +
+   scroll-to-bottom) sit ON TOP of the message list; wrapped text behind
+   them was unreadable because they were fully opaque. Make them
+   translucent so the text shows through while the control (large glyph +
+   accent fill + shadow) stays clearly tappable. One rule on the stack's
+   children keeps the pair consistent by construction (#280's "same box")
+   and theme-agnostic — whole-element opacity needs no per-theme
+   translucent color. Scoped to `.shell-mobile` + the stack: desktop
+   scroll-to-bottom stays opaque (it's smaller and next-active is a
+   sidebar button there, not a floating overlay). Higher specificity than
+   `.scroll-to-bottom-btn:hover` (0.85), so a stray mobile hover can't
+   make it MORE opaque than this. */
+.shell-mobile .scrollback-float-stack > * {
+  opacity: 0.75;
+}
+
 /* C7.4: Scroll-to-bottom button. Now an in-flow child of the float stack
    (#280) — the stack owns the absolute anchor, so this is position:
    static. */

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -24370,3 +24370,51 @@ change. An e2e asserts the `sux` card renders in the seeded gallery.
 _Deploy unchanged: batched/HELD, SERVER COLD restart + `--cic` + `mix
 grappa.seed_themes` (the seed step is what publishes `sux` into the gallery).
 With `sux` seeded + gallery-verified, #75 + #291 finally move `cooking → soon`._
+
+## 2026-07-18 — #289 (enhancement, cic): mobile floating buttons translucent so message text shows through
+
+Fast-follow to **#280**. #280 fixed the two mobile floating buttons —
+next-active circle (`NextActiveButton` variant="mobile") + scroll-to-bottom
+(`.scroll-to-bottom-btn`) — overlapping EACH OTHER by pulling them into one
+container-anchored stack (`.scrollback-float-stack`, same box, same size).
+This is the next polish pass on the same pair: now that they coexist cleanly,
+they were still fully OPAQUE and painted on top of the message list, so any
+line that wrapped behind a button was unreadable. Make them translucent.
+
+**Fix — one rule, on the stack's children:**
+```css
+.shell-mobile .scrollback-float-stack > * { opacity: 0.75; }
+```
+
+**Why whole-element `opacity`, not a per-color alpha.** The alternative —
+`color-mix(... transparent)` / rgba on each `background` — would need a
+translucent variant baked per theme (13 built-ins + user-authored custom
+themes), i.e. a new token surface, and would leave the glyph/border/shadow
+fully opaque (less text bleed-through). Whole-element opacity is
+theme-agnostic (translucency is an interaction constant, NOT a color, so it
+does NOT belong in the per-theme token maps) and fades the whole control
+uniformly. 0.75 = text behind stays legible while the large glyph + accent
+fill stays clearly a tappable control (not disabled-looking).
+
+**Why ONE rule on `> *`, not two per-button rules.** Both buttons are direct
+children of the float stack, so a single rule keeps the pair's translucency
+consistent BY CONSTRUCTION (honoring #280's "same box" intent — no two
+literals to drift) and any future stack child inherits the correct
+floating-overlay default. Scoped to `.shell-mobile` + the stack: desktop
+scroll-to-bottom stays opaque (it's the smaller 2rem button and next-active
+is a sidebar button there, not a floating overlay). Specificity (0,3,0) beats
+`.scroll-to-bottom-btn:hover` (0,2,0), so a stray mobile hover can't make it
+MORE opaque than the base.
+
+**Proof.** e2e RED→GREEN (`@webkit` iPhone-15,
+`cicchetto/e2e/tests/issue289-float-btn-opacity.spec.ts`): surface BOTH
+buttons at once (mirror #280 test-1 — scrolled-up CHANNEL + a background
+channel unread lights next-active count "1"), assert both PRESENT + VISIBLE
+(anti-false-green) BEFORE reading computed opacity, then assert each button's
+opacity is in `[0.4, 1)` — translucent (the bug was 1.0) yet clearly tappable.
+The band, not a magic number, is the contract. jsdom is blind to the
+`.shell-mobile` gate + computed opacity, so the mobile-WebKit e2e is the gate.
+
+_Deploy: **cic-only (`--cic`)** bundle rebuild, no BEAM restart — pure CSS
+change in `default.css` + one e2e. No server, no schema, no config. HELD for
+the batched COLD ship._


### PR DESCRIPTION
Fast-follow to #280. The two mobile floating buttons — next-active circle + scroll-to-bottom — were fully opaque and painted on top of the message list, so any line wrapping behind a button was unreadable. #280 fixed them overlapping *each other*; this makes them translucent so the text behind stays legible while the control stays clearly tappable.

**Fix** — one rule on the shared float-stack children:

```css
.shell-mobile .scrollback-float-stack > * { opacity: 0.75; }
```

- **Whole-element opacity, not per-color alpha:** translucency is an interaction constant, not a color — it doesn't belong in the per-theme token maps (13 built-ins + custom themes). Theme-agnostic, fades the whole control uniformly.
- **One rule on `> *`:** both buttons are direct stack children, so the pair stays consistent by construction (#280's "same box"); future stack children inherit the correct floating-overlay default.
- **Scoped to `.shell-mobile` + the stack:** desktop scroll-to-bottom stays opaque. Specificity (0,3,0) beats `.scroll-to-bottom-btn:hover` (0,2,0).

**Proof:** `@webkit` iPhone-15 e2e (`issue289-float-btn-opacity.spec.ts`) surfaces both buttons, asserts PRESENT + VISIBLE before reading computed opacity, then asserts each is in `[0.4, 1)` — translucent (was 1.0) yet tappable. RED before → GREEN after. Local scoped webkit run: `1 passed`.

cic-only (`--cic`) bundle rebuild, no BEAM restart. Deploy **HELD** for the batched COLD ship.

Closes #289.