### PR TITLE
docs: codify worktree removal at merge (#296)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -463,6 +463,16 @@ is due. Don't just look at todo.md.
    main has unpushed commits. Branching from origin loses recent work.
    **Rebase before merge.** Before merging a worktree branch to main,
    rebase it onto main first: `git rebase main` from the worktree.
+   **Remove the worktree at merge — not someday.** A worktree is opened
+   here (step 0) and MUST be closed at the merge (step 3): once its
+   branch is merged to main, remove the worktree
+   (`git worktree remove <path>`) and delete the merged branch
+   (`git branch -d <branch>`) as PART OF the merge step, never a
+   deferred cleanup. Never leave merged worktrees lying around — dozens
+   accumulated on the worker host and ate real disk before #296 swept
+   them. If `git worktree remove` trips the submodule error, `--force`
+   is safe ONLY once the branch is proven merged (`git branch --merged
+   main`) AND the worktree is clean (`git status --porcelain` empty).
 1. **Fix pre-existing errors first.** Before starting any work, run
    `scripts/check.sh`. If there are existing failures, fix them in the
    first commit. Zero errors is the baseline. NEVER dismiss errors as
@@ -476,6 +486,7 @@ is due. Don't just look at todo.md.
    bastille jail** — `scripts/deploy-m42.sh` (server, auto hot/cold)
    / `--cic` (bundle only). The jail pulls origin/main, so: rebase
    worktree onto main → merge to main → push origin main →
+   remove the now-merged worktree + delete its branch (step 0) →
    deploy-m42 → verify health. Invoke deploy scripts by ABSOLUTE
    path (`/srv/grappa/scripts/…`) — cwd drift runs another
    checkout's copy. `scripts/deploy.sh` (Docker) drives the LOCAL


### PR DESCRIPTION
## What

Adds a **standing order** to `CLAUDE.md`'s Development Cycle: once a
worktree branch is merged to main, its worktree MUST be removed
(`git worktree remove`) and the merged branch deleted (`git branch -d`)
as part of the merge step — never a deferred cleanup.

## Why

Tens of merged worktrees had accumulated on the worker host and ate real
disk, because removal was never anyone's step. #75's producer + sux
worktrees couldn't even be removed later (submodule blocker). This fixes
the recurrence at the process level.

- Step 0 now spells out the worktree lifecycle (opened here, closed at
  the merge) and records that `--force` past the submodule error is safe
  ONLY once merged + clean are proven.
- Step 3's merge sequence gains the removal clause so the rule fires at
  the exact point it must.

Part 2 of the issue (surgical removal of the existing worktree sprawl on
the worker host) is host-local disk hygiene with no commit.

Docs + local-disk hygiene only — nothing runtime to ship.

Refs #296.