### PR TITLE
cicchetto: refresh bar shows current vs available version (#292)

### DIFF
--- a/cicchetto/e2e/tests/bundle-refresh-banner.spec.ts
+++ b/cicchetto/e2e/tests/bundle-refresh-banner.spec.ts
@@ -65,6 +65,79 @@ test("BundleRefreshBanner appears on hash mismatch and click reloads the page", 
   await expect(page.locator(BANNER_SELECTOR)).toHaveCount(0);
 });
 
+test("refresh bar shows current vs available version, refresh still applies (#292)", async ({
+  page,
+}) => {
+  await loginAs(page, getSeededVjt());
+  await expect(page.locator(BANNER_SELECTOR)).toHaveCount(0);
+
+  const boot = await page.evaluate(() => {
+    const bh = window.__cic_bundleHash;
+    if (!bh) throw new Error("__cic_bundleHash hook missing");
+    return { hash: bh.bootHash(), version: bh.bootVersion() };
+  });
+
+  // The vite build MUST bake the <meta name="cicchetto-version"> tag, so the
+  // running version is observable end-to-end. If this trips, the meta
+  // injection regressed (the whole current-vs-available display depends on it).
+  expect(boot.version).not.toBeNull();
+  expect(typeof boot.version).toBe("string");
+  expect(boot.hash).not.toBeNull();
+
+  // Server advertises a DIFFERENT semver + hash (a real release).
+  await page.evaluate(() => {
+    const bh = window.__cic_bundleHash;
+    bh?.setServerVersion("99.0.0");
+    bh?.setServerHash("synthetic-release-hash-0001");
+  });
+
+  const banner = page.locator(BANNER_SELECTOR);
+  await expect(banner).toBeVisible();
+  const message = banner.locator(".error-banner-message");
+  // Both the running version and the available version are visible, side by
+  // side — the #292 ask. A real version bump shows clean semvers, no hash.
+  await expect(message).toContainText(`current ${boot.version}`);
+  await expect(message).toContainText("available 99.0.0");
+
+  // The refresh button STILL applies the update (reload) — the existing CTA
+  // is preserved.
+  const navPromise = page.waitForNavigation();
+  await banner.locator(".error-banner-action").click();
+  await navPromise;
+  await expect(page.locator(BANNER_SELECTOR)).toHaveCount(0);
+});
+
+test("refresh bar appends the short build hash when the semver is unchanged (#292)", async ({
+  page,
+}) => {
+  await loginAs(page, getSeededVjt());
+  await expect(page.locator(BANNER_SELECTOR)).toHaveCount(0);
+
+  const boot = await page.evaluate(() => {
+    const bh = window.__cic_bundleHash;
+    if (!bh) throw new Error("__cic_bundleHash hook missing");
+    return { hash: bh.bootHash(), version: bh.bootVersion() };
+  });
+  expect(boot.version).not.toBeNull();
+  expect(boot.hash).not.toBeNull();
+
+  // Same semver on both sides (a trivial rebuild with no version bump), but a
+  // different build hash. The refresh bar must still show a concrete diff via
+  // the short (7-char) hash suffix, so the "changed" signal never goes dead.
+  await page.evaluate((bootVersion: string) => {
+    const bh = window.__cic_bundleHash;
+    bh?.setServerVersion(bootVersion);
+    bh?.setServerHash("trivialrebuildhash999999");
+  }, boot.version as string);
+
+  const message = page.locator(`${BANNER_SELECTOR} .error-banner-message`);
+  await expect(message).toBeVisible();
+  // Same version, disambiguated by the hash suffix on both sides.
+  await expect(message).toContainText(`${boot.version} (`);
+  // First 7 chars of the synthetic server hash.
+  await expect(message).toContainText("trivial");
+});
+
 test("BundleRefreshBanner stays hidden when server pushes the same hash", async ({ page }) => {
   await loginAs(page, getSeededVjt());
 
@@ -237,8 +310,10 @@ declare global {
     // typing without an import (the spec doesn't run through tsc).
     __cic_bundleHash?: {
       setServerHash: (hash: string) => void;
+      setServerVersion: (version: string | null) => void;
       reset: () => void;
       bootHash: () => string | null;
+      bootVersion: () => string | null;
       __refreshProbe?: () => void;
     };
   }

--- a/cicchetto/src/__tests__/ErrorBanners.test.tsx
+++ b/cicchetto/src/__tests__/ErrorBanners.test.tsx
@@ -17,6 +17,9 @@ import {
 // behavior is covered by the bundle-refresh e2e specs.
 vi.mock("../lib/bundleHash", () => ({
   shouldShowRefreshBanner: vi.fn(() => false),
+  // #292 — the registry asks bundleHash for the current-vs-available message;
+  // the mock supplies a stand-in so the owner renders without the real signals.
+  refreshBannerMessage: vi.fn(() => "New version available — current 1.0.0 → available 2.0.0."),
   performRefresh: vi.fn(),
 }));
 

--- a/cicchetto/src/__tests__/bundleHash.test.ts
+++ b/cicchetto/src/__tests__/bundleHash.test.ts
@@ -2,16 +2,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetBundleHashForTests,
   bootBundleHashAccessor,
+  bootBundleVersionAccessor,
+  formatRefreshBanner,
   performRefresh,
   serverBundleHash,
+  serverBundleVersion,
   setServerBundleHash,
+  setServerBundleVersion,
   shouldShowRefreshBanner,
 } from "../lib/bundleHash";
 
 describe("bundleHash", () => {
   beforeEach(() => {
-    // Reset server hash to null so each test starts unsynced.
-    __resetBundleHashForTests(null);
+    // Reset server hash + version to null so each test starts unsynced.
+    __resetBundleHashForTests(null, null);
   });
 
   it("starts with serverBundleHash null and shouldShowRefreshBanner false", () => {
@@ -41,6 +45,65 @@ describe("bundleHash", () => {
     }
     setServerBundleHash("definitely-different-hash-xxx");
     expect(shouldShowRefreshBanner()).toBe(true);
+  });
+
+  describe("bundle version signals (#292)", () => {
+    it("starts with serverBundleVersion null", () => {
+      expect(serverBundleVersion()).toBeNull();
+    });
+
+    it("bootBundleVersion is null in jsdom (no <meta cicchetto-version> tag)", () => {
+      // The version is baked into a real vite build's index.html <meta> tag;
+      // setupTests provides none, so the running-version accessor is null and
+      // the display degrades to the build hash. e2e covers the built page.
+      expect(bootBundleVersionAccessor()).toBeNull();
+    });
+
+    it("setServerBundleVersion updates the serverBundleVersion signal", () => {
+      setServerBundleVersion("1.2.4");
+      expect(serverBundleVersion()).toBe("1.2.4");
+    });
+
+    it("setServerBundleVersion(null) clears the signal", () => {
+      setServerBundleVersion("1.2.4");
+      setServerBundleVersion(null);
+      expect(serverBundleVersion()).toBeNull();
+    });
+  });
+});
+
+describe("formatRefreshBanner (#292 — current vs available)", () => {
+  it("shows both semvers cleanly (no hash) when they are known and differ", () => {
+    const msg = formatRefreshBanner("1.2.3", "aaaaaaa1111", "1.2.4", "bbbbbbb2222");
+    expect(msg).toContain("current 1.2.3");
+    expect(msg).toContain("available 1.2.4");
+    // A real version bump tells the whole story — no build-hash noise.
+    expect(msg).not.toContain("aaaaaaa");
+    expect(msg).not.toContain("bbbbbbb");
+  });
+
+  it("appends the truncated build hash when the semver is unchanged (trivial rebuild)", () => {
+    const msg = formatRefreshBanner("1.2.3", "aaaaaaa1111", "1.2.3", "bbbbbbb2222");
+    // Same version on both sides → the short (7-char) hash disambiguates.
+    expect(msg).toContain("current 1.2.3 (aaaaaaa)");
+    expect(msg).toContain("available 1.2.3 (bbbbbbb)");
+  });
+
+  it("falls back to the build hash alone when no semver is known", () => {
+    const msg = formatRefreshBanner(null, "aaaaaaa1111", null, "bbbbbbb2222");
+    expect(msg).toContain("current aaaaaaa");
+    expect(msg).toContain("available bbbbbbb");
+  });
+
+  it("truncates the build hash to 7 characters", () => {
+    const msg = formatRefreshBanner(null, "0123456789abcdef", null, "fedcba9876543210");
+    expect(msg).toContain("0123456");
+    expect(msg).not.toContain("0123456789");
+  });
+
+  it("always leads with the 'New version available' signal (banner contract)", () => {
+    expect(formatRefreshBanner("1.0.0", "aaa", "2.0.0", "bbb")).toContain("New version available");
+    expect(formatRefreshBanner(null, "aaa", null, "bbb")).toContain("New version available");
   });
 
   describe("performRefresh (UX-6-I: single-press)", () => {

--- a/cicchetto/src/__tests__/errorBanners.test.ts
+++ b/cicchetto/src/__tests__/errorBanners.test.ts
@@ -32,6 +32,11 @@ import { __resetSwRegistrationForTests, recordSwRegError } from "../lib/swRegist
 // live behavior is covered by the bundle-refresh e2e specs.
 vi.mock("../lib/bundleHash", () => ({
   shouldShowRefreshBanner: vi.fn(() => false),
+  // #292 — the bundle-refresh entry's message is now composed by
+  // bundleHash (which owns the current/available version+hash signals).
+  // The registry just asks for it; the composition logic is unit-tested
+  // in bundleHash.test.ts (formatRefreshBanner).
+  refreshBannerMessage: vi.fn(() => "New version available — current 1.0.0 → available 2.0.0."),
   performRefresh: vi.fn(),
 }));
 
@@ -99,6 +104,14 @@ describe("errorBanners registry", () => {
     expect(bundle?.severity).toBe("info");
     expect(bundle?.actionHint?.label).toBe("Refresh");
     expect(typeof bundle?.actionHint?.onAction).toBe("function");
+  });
+
+  it("sources the bundle-refresh message from refreshBannerMessage (#292)", () => {
+    mockShouldShowRefresh.mockReturnValue(true);
+    const bundle = activeBanners().find((e) => e.source === "bundle-refresh");
+    // The registry delegates the current-vs-available string to bundleHash;
+    // it does not hard-code a message of its own.
+    expect(bundle?.message).toBe("New version available — current 1.0.0 → available 2.0.0.");
   });
 
   it("stacks all active sources simultaneously (N sources → N entries)", () => {

--- a/cicchetto/src/__tests__/userTopic.test.ts
+++ b/cicchetto/src/__tests__/userTopic.test.ts
@@ -76,6 +76,7 @@ vi.mock("../lib/selection", () => ({
 
 vi.mock("../lib/bundleHash", () => ({
   setServerBundleHash: vi.fn(),
+  setServerBundleVersion: vi.fn(),
 }));
 
 vi.mock("../lib/peerAway", () => ({
@@ -743,6 +744,19 @@ describe("userTopic", () => {
       const bh = await import("../lib/bundleHash");
       channelMock.fireEvent({ kind: "bundle_hash", hash: "RvD22cM9" });
       expect(bh.setServerBundleHash).toHaveBeenCalledWith("RvD22cM9");
+    });
+
+    it("dispatches the advertised version alongside the hash (#292)", async () => {
+      const bh = await import("../lib/bundleHash");
+      channelMock.fireEvent({ kind: "bundle_hash", hash: "RvD22cM9", version: "1.2.4" });
+      expect(bh.setServerBundleHash).toHaveBeenCalledWith("RvD22cM9");
+      expect(bh.setServerBundleVersion).toHaveBeenCalledWith("1.2.4");
+    });
+
+    it("normalises an absent version to null (#292 — hash-only wire)", async () => {
+      const bh = await import("../lib/bundleHash");
+      channelMock.fireEvent({ kind: "bundle_hash", hash: "RvD22cM9" });
+      expect(bh.setServerBundleVersion).toHaveBeenCalledWith(null);
     });
 
     it("drops bundle_hash with empty hash (no setServerBundleHash call)", async () => {

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -1053,7 +1053,10 @@ export type WireUserEvent =
       by: string | null;
       reason: string | null;
     }
-  | { kind: "bundle_hash"; hash: string }
+  // #292 — `version` is the deployed bundle's semver (server omits the wire
+  // key when unknown; the narrower normalises absent → null). Drives the
+  // refresh bar's "current X → available Y" display.
+  | { kind: "bundle_hash"; hash: string; version: string | null }
   // UX-6-B2 (2026-05-21) — operator-visible server-settings reactive
   // signal. Fired on `Admin.SettingsController.update/2` fan-out AND
   // on after-join snapshot from `GrappaChannel.push_server_settings/1`

--- a/cicchetto/src/lib/bundleHash.ts
+++ b/cicchetto/src/lib/bundleHash.ts
@@ -44,14 +44,40 @@ function readBootBundleHash(): string | null {
   return null;
 }
 
+// #292 — the running bundle's human-readable semver, baked into the page
+// as `<meta name="cicchetto-version" content="<pkg.version>">` by the
+// `transformIndexHtml` hook in vite.config.ts (server side reads the same
+// tag via `Grappa.Cic.Bundle.current_version/0`). Read once at module
+// init, same as `readBootBundleHash`. `null` when absent (jsdom unit env
+// with no meta tag, or a bundle built before this shipped) — the display
+// then degrades to the build hash alone.
+function readBootBundleVersion(): string | null {
+  if (typeof document === "undefined") return null;
+  const meta = document.querySelector<HTMLMetaElement>('meta[name="cicchetto-version"]');
+  const content = meta?.content ?? "";
+  return content !== "" ? content : null;
+}
+
 const [bootBundleHash] = createSignal<string | null>(readBootBundleHash());
 const [serverBundleHashSignal, setServerBundleHashInternal] = createSignal<string | null>(null);
+const [bootBundleVersion] = createSignal<string | null>(readBootBundleVersion());
+const [serverBundleVersionSignal, setServerBundleVersionInternal] = createSignal<string | null>(
+  null,
+);
 
 export const bootBundleHashAccessor: Accessor<string | null> = bootBundleHash;
 export const serverBundleHash: Accessor<string | null> = serverBundleHashSignal;
+export const bootBundleVersionAccessor: Accessor<string | null> = bootBundleVersion;
+export const serverBundleVersion: Accessor<string | null> = serverBundleVersionSignal;
 
 export function setServerBundleHash(hash: string): void {
   setServerBundleHashInternal(hash);
+}
+
+// The server advertises the deployed bundle's semver alongside the hash;
+// `null` when the deployed bundle carries no version (wire key omitted).
+export function setServerBundleVersion(version: string | null): void {
+  setServerBundleVersionInternal(version);
 }
 
 // True iff (1) we know what we booted with, (2) the server has told us
@@ -61,6 +87,63 @@ export function shouldShowRefreshBanner(): boolean {
   const boot = bootBundleHash();
   const server = serverBundleHashSignal();
   return boot !== null && server !== null && boot !== server;
+}
+
+// #292 — refresh bar "current vs available" version display.
+//
+// The hash mismatch is the TRIGGER (shouldShowRefreshBanner); the semver
+// is display enrichment. A short (7-char) slice of the build hash is the
+// disambiguator per vjt's ask: a trivial rebuild reuses the semver, so
+// without the hash suffix the two sides would read identically and the
+// signal would go dead. `git`-style 7 chars is a familiar, sufficient
+// content fingerprint.
+const SHORT_HASH_LEN = 7;
+
+function shortHash(hash: string | null): string | null {
+  return hash !== null && hash !== "" ? hash.slice(0, SHORT_HASH_LEN) : null;
+}
+
+// Compose one side's label: "<semver> (<hash7>)" when both are known,
+// the semver or the hash alone when only one is, "unknown" when neither
+// (the banner never actually shows in that case — both hashes are known
+// by construction). Pure so it's exhaustively unit-testable.
+function versionLabel(version: string | null, hash: string | null): string {
+  const sh = shortHash(hash);
+  if (version !== null && sh !== null) return `${version} (${sh})`;
+  if (version !== null) return version;
+  if (sh !== null) return sh;
+  return "unknown";
+}
+
+// Pure formatter for the refresh-bar message. When both semvers are known
+// AND differ, the version bump tells the whole story — clean
+// "current X → available Y", no hash noise. Otherwise (same semver = a
+// trivial rebuild, or a semver missing) fall back to the build-hash
+// suffix so the user still sees a concrete diff.
+export function formatRefreshBanner(
+  currentVersion: string | null,
+  currentHash: string | null,
+  availableVersion: string | null,
+  availableHash: string | null,
+): string {
+  if (currentVersion !== null && availableVersion !== null && currentVersion !== availableVersion) {
+    return `New version available — current ${currentVersion} → available ${availableVersion}.`;
+  }
+  const current = versionLabel(currentVersion, currentHash);
+  const available = versionLabel(availableVersion, availableHash);
+  return `New version available — current ${current} → available ${available}.`;
+}
+
+// Signal-reading wrapper — the message the error-banner registry renders.
+// Reads the current (baked-in) + available (server-advertised) version +
+// hash signals and delegates to the pure `formatRefreshBanner`.
+export function refreshBannerMessage(): string {
+  return formatRefreshBanner(
+    bootBundleVersion(),
+    bootBundleHash(),
+    serverBundleVersionSignal(),
+    serverBundleHashSignal(),
+  );
 }
 
 // UX-6-I (2026-05-22) — single-press refresh fix. Pre-fix this was a
@@ -158,9 +241,14 @@ export async function performRefresh(): Promise<void> {
   }
 }
 
-// Test-only — reset both signals. Production code never calls this.
-export function __resetBundleHashForTests(serverHash: string | null = null): void {
+// Test-only — reset the server-advertised signals. Production code never
+// calls this. Both params are required (no silent-default degradation).
+export function __resetBundleHashForTests(
+  serverHash: string | null,
+  serverVersion: string | null,
+): void {
   setServerBundleHashInternal(serverHash);
+  setServerBundleVersionInternal(serverVersion);
 }
 
 // E2E hook surface — Playwright runs against a vite build (no /src
@@ -179,8 +267,10 @@ declare global {
   interface Window {
     __cic_bundleHash?: {
       setServerHash: (hash: string) => void;
+      setServerVersion: (version: string | null) => void;
       reset: () => void;
       bootHash: () => string | null;
+      bootVersion: () => string | null;
       __refreshProbe?: () => void;
     };
   }
@@ -189,7 +279,9 @@ declare global {
 if (typeof window !== "undefined") {
   window.__cic_bundleHash = {
     setServerHash: setServerBundleHash,
-    reset: () => __resetBundleHashForTests(null),
+    setServerVersion: setServerBundleVersion,
+    reset: () => __resetBundleHashForTests(null, null),
     bootHash: () => bootBundleHash(),
+    bootVersion: () => bootBundleVersion(),
   };
 }

--- a/cicchetto/src/lib/errorBanners.ts
+++ b/cicchetto/src/lib/errorBanners.ts
@@ -1,5 +1,5 @@
 import { createSignal, untrack } from "solid-js";
-import { performRefresh, shouldShowRefreshBanner } from "./bundleHash";
+import { performRefresh, refreshBannerMessage, shouldShowRefreshBanner } from "./bundleHash";
 import { isOffline } from "./connectivity";
 import { shouldShowBanner, socketHealth } from "./socketHealth";
 import { shouldShowSwRegBanner, swRegistration } from "./swRegistration";
@@ -132,11 +132,14 @@ export function activeBanners(): BannerEntry[] {
   }
 
   // New cic bundle deployed — user-actionable refresh; persists until reload.
+  // #292 — the message now shows current-vs-available version (semver +
+  // short build-hash suffix), composed by bundleHash (the owner of the
+  // version+hash signals).
   if (shouldShowRefreshBanner()) {
     entries.push({
       source: "bundle-refresh",
       severity: "info",
-      message: "New version available — a fresh cicchetto build was deployed.",
+      message: refreshBannerMessage(),
       actionHint: { label: "Refresh", onAction: () => void performRefresh() },
     });
   }

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -10,7 +10,7 @@ import {
 import { loadArchive } from "./archive";
 import { socketUserName, token } from "./auth";
 import { setAwayState } from "./awayStatus";
-import { setServerBundleHash } from "./bundleHash";
+import { setServerBundleHash, setServerBundleVersion } from "./bundleHash";
 import { onDirectoryComplete, onDirectoryFailed, onDirectoryProgress } from "./channelDirectory";
 import { channelKey } from "./channelKey";
 import { patchHomeNetwork } from "./home";
@@ -490,9 +490,14 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
         channel: r.channel,
         peer: r.peer,
       };
-    case "bundle_hash":
+    case "bundle_hash": {
       if (typeof r.hash !== "string" || r.hash === "") return null;
-      return { kind: "bundle_hash", hash: r.hash };
+      // #292 — version is optional on the wire (omitted when the deployed
+      // bundle advertises none). Normalise absent / malformed → null so the
+      // consumer always sees `string | null`.
+      const version = typeof r.version === "string" && r.version !== "" ? r.version : null;
+      return { kind: "bundle_hash", hash: r.hash, version };
+    }
     case "server_settings_changed": {
       // UX-6-B2 (2026-05-21) — operator-visible server-settings push.
       // Wire shape mirrors `Grappa.ServerSettings.Wire.server_settings_
@@ -890,7 +895,10 @@ createRoot(() => {
           // bundleHash.ts compares against bootBundleHash (the hash
           // baked into the page the browser loaded); mismatch shows the
           // refresh banner. No focus change — banner is a passive cue.
+          // #292 — the deployed semver rides alongside the hash so the
+          // banner can show "current X → available Y".
           setServerBundleHash(payload.hash);
+          setServerBundleVersion(payload.version);
           return;
 
         case "server_settings_changed":

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -372,6 +372,7 @@ export type ChannelDirectoryWireIndexPayload = {
 export type CicWireBundleHashPayload = {
   kind: string;
   hash: string;
+  version: string;
 };
 
 // === Grappa.Networks.FeaturedChannels.Wire ===

--- a/cicchetto/vite.config.ts
+++ b/cicchetto/vite.config.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
 import solid from "vite-plugin-solid";
@@ -5,6 +6,18 @@ import solid from "vite-plugin-solid";
 // service-worker's Web Push notification icon (`src/lib/pwaIcons.ts`), so a
 // rename can't silently drift the SW into a 404 path.
 import { PWA_ICONS } from "./src/lib/pwaIcons";
+
+// #292 — bake the cic package.json semver into the built (and dev) index.html
+// as `<meta name="cicchetto-version">`. ONE source (package.json), ONE
+// injection point: cic reads this tag for the RUNNING version
+// (`bundleHash.readBootBundleVersion`), and the server reads the SAME tag
+// from the DEPLOYED dist (`Grappa.Cic.Bundle.current_version/0`) to advertise
+// the AVAILABLE version over the `bundle_hash` wire event. Bumping the semver
+// is `cicchetto/package.json` — trivial rebuilds that skip the bump are
+// disambiguated by the short bundle-hash suffix the refresh bar appends.
+const CIC_VERSION = JSON.parse(
+  readFileSync(new URL("./package.json", import.meta.url), "utf8"),
+).version as string;
 
 // Dev-only proxy: vite serves the SolidJS app on :5173 and forwards the
 // REST + Channels surfaces to grappa on :4000. In prod, sub-task 6's
@@ -49,6 +62,19 @@ import { PWA_ICONS } from "./src/lib/pwaIcons";
 export default defineConfig({
   plugins: [
     solid(),
+    // #292 — inject the semver <meta> tag into index.html (dev + build).
+    {
+      name: "cicchetto-version-meta",
+      transformIndexHtml() {
+        return [
+          {
+            tag: "meta",
+            attrs: { name: "cicchetto-version", content: CIC_VERSION },
+            injectTo: "head",
+          },
+        ];
+      },
+    },
     VitePWA({
       registerType: "autoUpdate",
       strategies: "injectManifest",

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -24494,3 +24494,59 @@ no spend of the shared `vjt` daily theme-create budget.
 _Deploy: **COLD** (server route + payload-model change) **+ `--cic`** (bundle
 carries the picker + the 8 WebP). No migration (payload is a JSON blob; the
 sanitizer defaults old rows forward). **HELD** for the batched 4am COLD ship._
+
+## 2026-07-18 — #292 (P1, cic): refresh bar shows current vs available version
+
+The refresh banner (a `bundle-refresh` entry in the #119 unified error region)
+went from an opaque "New version available" string to
+`current <X> → available <Y>`. The issue assumed the version strings "are
+presumably already available from the bundle/build metadata — wire them in."
+**They were not** — challenge-the-spec confirmed the cic bundle had NO semver
+anywhere: `cicchetto/package.json` was a never-bumped `0.0.1` placeholder never
+wired into the build, and the ONLY build identity was the opaque Vite asset hash
+(`index-<hash>.js`). The server's `@version` (`mix.exs` `0.3.2`,
+`Grappa.Version`) is the **bouncer** version (CTCP-VERSION-only, different
+artifact + deploy path) — semantically wrong as "the cic version". So this
+bucket had to **establish** a cic-bundle version scheme, not wire an existing
+one.
+
+**The decision (vjt): Option A + a short hash suffix for trivial changes.**
+The primary version is the `cicchetto/package.json` semver (bumped per cic
+release). But a semver alone goes dead the moment a rebuild ships without a
+bump — both sides read the same number and the "changed" signal vanishes. So
+the refresh bar **appends the short (7-char) bundle hash** whenever the two
+semvers match (a trivial rebuild) or a semver is missing:
+`current 0.1.0 (4f2a9c1) → available 0.1.0 (9c1bd3e)`. A real version bump
+shows clean semvers with no hash noise: `current 0.1.0 → available 0.2.0`. The
+hash mismatch remains the banner **trigger** (`shouldShowRefreshBanner`
+unchanged); the version is display enrichment only. Reusing the EXISTING
+bundle-hash signals as the suffix (not a second hash) keeps one identity source.
+
+**Cross-side source: ONE `<meta name="cicchetto-version">` in `index.html`.**
+Vite's `transformIndexHtml` bakes the `package.json` semver into the shell HTML
+(dev + build). cic reads it for the RUNNING version
+(`bundleHash.readBootBundleVersion`, parallel to `readBootBundleHash`). The
+**server** reads the SAME tag from the **deployed** dist
+(`Grappa.Cic.Bundle.current_version/0`, parallel to `current_hash/0`) — NOT the
+source `package.json` — so it advertises what is actually **served**, exactly
+as it already does for the bundle hash. Reading source `package.json` would be
+a second source of truth and wrong in prod (source can lead the deployed dist).
+
+**Wire: the semver rides the existing `bundle_hash` event, optional key.**
+`Grappa.Cic.Wire.bundle_hash/2` gains a `version` field; a `nil`/empty version
+(bundle predates the meta tag, or parse miss) **omits the key** rather than
+shipping `null`, and cic's `userTopic` narrower normalises absent → `null` so
+the consumer always sees `string | null`. Both push sites
+(`GrappaChannel.push_bundle_hash/1` after-join snapshot,
+`AdminController.cic_bundle_changed/2` deploy broadcast) pass
+`CicBundle.current_version()`. The generated `wireTypes.ts` regenerated (the
+`gen_wire_types` codegen can't emit optional keys, so the generated
+`CicWireBundleHashPayload` shows a required `version: string` — it is unused;
+the consumed type is the hand-written `WireUserEvent` arm in `api.ts`).
+
+**Going forward:** cic releases bump `cicchetto/package.json`. No bump needed
+for the mechanism to stay honest — the appended hash covers unbumped rebuilds.
+
+_Deploy: **`--cic` only** (cic bundle + the server-side wire read). **HELD** —
+batched into the next cic bundle ship; NOT shipped solo (the #294 4am COLD
+batch is separate)._

--- a/lib/grappa/cic/bundle.ex
+++ b/lib/grappa/cic/bundle.ex
@@ -1,6 +1,6 @@
 defmodule Grappa.Cic.Bundle do
   @moduledoc """
-  Single source of truth for the deployed cic bundle hash.
+  Single source of truth for the deployed cic bundle hash + version.
 
   Reads `runtime/cicchetto-dist/index.html` on every call and parses
   the Vite-emitted `<script src="/assets/index-<hash>.js">` tag. The
@@ -9,10 +9,23 @@ defmodule Grappa.Cic.Bundle do
   or hot-reload — same live-read pattern as `Grappa.Version` (CP23 S3
   memory `feedback_live_read_disk_for_hot_reload`).
 
+  #292 adds `current_version/0`: the human-readable semver Vite bakes
+  into the same `index.html` as a `<meta name="cicchetto-version">`
+  tag (from `cicchetto/package.json`). The refresh banner shows
+  "current X → available Y" — the *available* semver is read here, from
+  the DEPLOYED dist (not the source `package.json`), so the server
+  advertises what is actually served. The hash is still the trigger
+  (a trivial rebuild reuses the semver); the version is display
+  enrichment. When two builds share a semver (no bump), cic appends the
+  short bundle hash so the "changed" signal never goes dead.
+
   Returns `nil` when the file is absent (dev without a cic build, test
-  env, prod before the first cicchetto-build oneshot completes). The
-  user-topic join push (B4) and refresh-banner broadcast (B5) treat
-  `nil` as "no bundle to compare against" and skip the push.
+  env, prod before the first cicchetto-build oneshot completes), and
+  `current_version/0` also returns `nil` for a bundle built before the
+  meta tag existed. The user-topic join push (B4) and refresh-banner
+  broadcast (B5) treat a `nil` hash as "no bundle to compare against"
+  and skip the push; a `nil` version rides the wire as an omitted key
+  (cic falls back to the build-hash display).
 
   Standalone boundary so both `GrappaWeb.GrappaChannel` (after_join
   push) and `GrappaWeb.AdminController.cic_bundle_changed/2` (re-read
@@ -33,6 +46,13 @@ defmodule Grappa.Cic.Bundle do
   # accidental quote.
   @hash_re ~r{<script[^>]+src="/assets/index-([^."]+)\.js"}
 
+  # Vite injects `<meta name="cicchetto-version" content="<semver>">` via
+  # the `transformIndexHtml` hook in `cicchetto/vite.config.ts` (attrs in
+  # a deterministic `name`-then-`content` order). The semver is the
+  # `cicchetto/package.json` version, baked at build. `[^"]+` captures the
+  # content up to the closing quote.
+  @version_re ~r{<meta[^>]+name="cicchetto-version"[^>]+content="([^"]+)"}
+
   @doc """
   Returns the current cic bundle hash, or `nil` if the bundle is absent.
   """
@@ -40,6 +60,19 @@ defmodule Grappa.Cic.Bundle do
   def current_hash do
     case File.read(@bundle_path) do
       {:ok, html} -> parse_hash(html)
+      {:error, _} -> nil
+    end
+  end
+
+  @doc """
+  Returns the current cic bundle semver (from the deployed dist's
+  `<meta name="cicchetto-version">` tag), or `nil` if the bundle is
+  absent or predates the meta tag.
+  """
+  @spec current_version() :: String.t() | nil
+  def current_version do
+    case File.read(@bundle_path) do
+      {:ok, html} -> parse_version(html)
       {:error, _} -> nil
     end
   end
@@ -53,6 +86,20 @@ defmodule Grappa.Cic.Bundle do
   def parse_hash(html) when is_binary(html) do
     case Regex.run(@hash_re, html, capture: :all_but_first) do
       [hash] when is_binary(hash) and hash != "" -> hash
+      _ -> nil
+    end
+  end
+
+  @doc """
+  Parses a Vite-emitted `index.html` string and returns the bundle
+  semver from the `<meta name="cicchetto-version">` tag.
+
+  Exposed for unit tests + as the pure parsing core of `current_version/0`.
+  """
+  @spec parse_version(binary()) :: String.t() | nil
+  def parse_version(html) when is_binary(html) do
+    case Regex.run(@version_re, html, capture: :all_but_first) do
+      [version] when is_binary(version) and version != "" -> version
       _ -> nil
     end
   end

--- a/lib/grappa/cic/wire.ex
+++ b/lib/grappa/cic/wire.ex
@@ -18,7 +18,13 @@ defmodule Grappa.Cic.Wire do
   inline. CLAUDE.md "Wire conversion is per-context responsibility"
   + "implement once, reuse everywhere" → both sites now delegate
   here. Adding a field to the cic-bundle wire (e.g. build timestamp,
-  asset digests) is one edit in `bundle_hash/1` instead of two.
+  asset digests) is one edit in `bundle_hash/2` instead of two.
+
+  #292 added the `version` field — the human-readable semver of the
+  deployed bundle (from `Grappa.Cic.Bundle.current_version/0`). It is
+  OPTIONAL: a `nil` version (bundle predates the meta tag / parse miss)
+  omits the key entirely rather than shipping `null`, so cic's narrower
+  simply sees an absent field and falls back to the build-hash display.
 
   Sibling Wire modules (`Grappa.Scrollback.Wire`, `Grappa.Networks.Wire`,
   `Grappa.Accounts.Wire`, `Grappa.QueryWindows.Wire`,
@@ -31,18 +37,28 @@ defmodule Grappa.Cic.Wire do
   @typedoc """
   Wire shape pushed on the user-topic when the cic bundle hash
   changes (deploy-cic broadcast) OR is observed at after-join
-  (snapshot push).
+  (snapshot push). `version` is present only when the deployed bundle
+  advertises a semver.
   """
-  @type bundle_hash_payload :: %{kind: String.t(), hash: String.t()}
+  @type bundle_hash_payload :: %{
+          required(:kind) => String.t(),
+          required(:hash) => String.t(),
+          optional(:version) => String.t()
+        }
 
   @doc """
-  Renders the cic bundle hash to its public wire shape. Caller is
-  responsible for the `nil` short-circuit (no bundle on disk → no
-  broadcast); this fn requires a binary to keep the wire contract
-  unambiguous.
+  Renders the cic bundle hash + semver to its public wire shape. Caller
+  is responsible for the `nil`-hash short-circuit (no bundle on disk →
+  no broadcast); this fn requires a binary hash to keep the wire
+  contract unambiguous. A `nil`/empty version omits the `version` key.
   """
-  @spec bundle_hash(String.t()) :: bundle_hash_payload()
-  def bundle_hash(hash) when is_binary(hash) do
-    %{kind: "bundle_hash", hash: hash}
+  @spec bundle_hash(String.t(), String.t() | nil) :: bundle_hash_payload()
+  def bundle_hash(hash, version) when is_binary(hash) do
+    base = %{kind: "bundle_hash", hash: hash}
+
+    case version do
+      v when is_binary(v) and v != "" -> Map.put(base, :version, v)
+      _ -> base
+    end
   end
 end

--- a/lib/grappa_web/channels/grappa_channel.ex
+++ b/lib/grappa_web/channels/grappa_channel.ex
@@ -1070,7 +1070,7 @@ defmodule GrappaWeb.GrappaChannel do
   defp push_bundle_hash(socket) do
     case CicBundle.current_hash() do
       nil -> :ok
-      hash -> push(socket, "event", CicWire.bundle_hash(hash))
+      hash -> push(socket, "event", CicWire.bundle_hash(hash, CicBundle.current_version()))
     end
   end
 

--- a/lib/grappa_web/controllers/admin_controller.ex
+++ b/lib/grappa_web/controllers/admin_controller.ex
@@ -105,7 +105,7 @@ defmodule GrappaWeb.AdminController do
         send_resp(conn, :no_content, "")
 
       hash when is_binary(hash) ->
-        payload = CicWire.bundle_hash(hash)
+        payload = CicWire.bundle_hash(hash, CicBundle.current_version())
         user_names = WSPresence.list_user_names()
         attempted = length(user_names)
 

--- a/test/grappa/cic/bundle_test.exs
+++ b/test/grappa/cic/bundle_test.exs
@@ -45,4 +45,42 @@ defmodule Grappa.Cic.BundleTest do
       assert Bundle.current_hash() == nil or is_binary(Bundle.current_hash())
     end
   end
+
+  describe "parse_version/1 (#292)" do
+    test "extracts the semver from the vite-injected <meta> tag" do
+      html = """
+      <!doctype html>
+      <html>
+        <head>
+          <meta name="cicchetto-version" content="1.2.4">
+          <script type="module" crossorigin src="/assets/index-RvD22cM9.js"></script>
+        </head>
+      </html>
+      """
+
+      assert Bundle.parse_version(html) == "1.2.4"
+    end
+
+    test "returns nil when the version meta tag is absent" do
+      html = ~s(<html><head><meta name="theme-color" content="#0a0a0a"></head></html>)
+      assert Bundle.parse_version(html) == nil
+    end
+
+    test "returns nil for empty input" do
+      assert Bundle.parse_version("") == nil
+    end
+
+    test "does not match a different meta tag's content" do
+      html = ~s(<meta name="theme-color" content="#0a0a0a">)
+      assert Bundle.parse_version(html) == nil
+    end
+  end
+
+  describe "current_version/0 (#292)" do
+    # Live-read of the deployed dist, same contract as current_hash/0:
+    # the file may or may not exist in test env. Assert the type only.
+    test "returns a binary or nil" do
+      assert Bundle.current_version() == nil or is_binary(Bundle.current_version())
+    end
+  end
 end

--- a/test/grappa/cic/wire_test.exs
+++ b/test/grappa/cic/wire_test.exs
@@ -8,18 +8,32 @@ defmodule Grappa.Cic.WireTest do
 
   alias Grappa.Cic.Wire
 
-  describe "bundle_hash/1" do
-    test "wraps a hash binary in the canonical %{kind, hash} wire shape" do
-      assert Wire.bundle_hash("abc123") == %{kind: "bundle_hash", hash: "abc123"}
+  describe "bundle_hash/2" do
+    test "wraps hash + version in the canonical wire shape" do
+      assert Wire.bundle_hash("abc123", "1.2.4") == %{
+               kind: "bundle_hash",
+               hash: "abc123",
+               version: "1.2.4"
+             }
     end
 
     test "kind is always the string literal 'bundle_hash'" do
-      assert Wire.bundle_hash("zzz").kind == "bundle_hash"
+      assert Wire.bundle_hash("zzz", "9.9.9").kind == "bundle_hash"
     end
 
     test "preserves the hash binary verbatim (no transformation)" do
       hash = "RvD22cM9-fancy_hash.with.dots"
-      assert Wire.bundle_hash(hash).hash == hash
+      assert Wire.bundle_hash(hash, "0.0.1").hash == hash
+    end
+
+    test "omits the version key when the version is nil (#292 — unknown build)" do
+      # nil version = bundle predates the meta tag / parse miss. The wire
+      # carries hash-only; cic falls back to the build-hash display.
+      assert Wire.bundle_hash("abc123", nil) == %{kind: "bundle_hash", hash: "abc123"}
+    end
+
+    test "omits the version key when the version is an empty string" do
+      assert Wire.bundle_hash("abc123", "") == %{kind: "bundle_hash", hash: "abc123"}
     end
   end
 end


### PR DESCRIPTION
## What

The refresh banner now shows `current <X> → available <Y>  [Refresh]`
instead of an opaque "New version available" string — the legibility
ask in #292.

## Challenge-the-spec finding

The issue assumed the version strings "are presumably already available
from the bundle/build metadata — wire them in." They were not: the cic
bundle had **no semver** anywhere (`package.json` was a never-bumped
`0.0.1` placeholder never wired into the build); the only build identity
was the opaque Vite asset hash. The server's own version is the
**bouncer** version (different artifact + deploy path), semantically
wrong as "the cic version". So this establishes a cic-bundle version
scheme rather than wiring an existing one.

## Design (decided with maintainer)

- **Primary version = `cicchetto/package.json` semver**, bumped per cic
  release.
- **Short (7-char) build-hash suffix** appended when the two semvers
  match (a trivial rebuild with no bump) or a semver is missing — so the
  "changed" signal never goes dead. A real bump shows clean semvers, no
  hash noise.
- **One source, both sides:** Vite injects the semver into `index.html`
  as `<meta name="cicchetto-version">`. cic reads it for the running
  version; the server reads the SAME tag from the **deployed** dist
  (not source `package.json`) and advertises it over the existing
  `bundle_hash` wire event (optional key, omitted when unknown).
- The hash mismatch remains the banner **trigger**; the version is
  display enrichment.

## Tests

- **cic unit** (vitest): version signals + pure `formatRefreshBanner`
  (clean-semver vs trivial-rebuild-hash-suffix vs hash-only fallback +
  truncation), errorBanners/ErrorBanners message wiring, userTopic
  dispatch (version alongside hash, absent → null).
- **server unit** (ExUnit): `Cic.Bundle.parse_version/1` +
  `Cic.Wire.bundle_hash/2` (version included / omitted-when-nil).
- **Playwright e2e**: asserts both version strings render side by side,
  the trivial-rebuild hash suffix, and that Refresh still applies.

Local gates green: full ExUnit (3770), full cic vitest (2909),
biome+tsc, format, credo, dialyzer, sobelow, doctor, deps.audit,
wireTypes drift.

## Deploy

**HELD** — `--cic` bundle change, batched into the next cic ship (not
solo; the #294 4am COLD batch is separate).

Refs #292