### PR TITLE
cic: #282 explicit vhost Reconnect button (park→reconnect connected nets)

### DIFF
--- a/cicchetto/e2e/tests/issue282-vhost-reconnect-button.spec.ts
+++ b/cicchetto/e2e/tests/issue282-vhost-reconnect-button.spec.ts
@@ -143,22 +143,29 @@ test.describe("issue #282 — explicit vhost Reconnect button", () => {
       const { page, patches } = booted;
 
       // The button is ALWAYS available (D2 — never gated on pending-detection)
-      // and communicates intent in its label.
+      // and communicates intent in its idle label.
       const reconnect = page.getByTestId("vhost-reconnect");
       await expect(reconnect).toBeEnabled();
       await expect(reconnect).toHaveText(/reconnect to apply/i);
 
-      // SAFETY: leaving via ‹ back must NOT reconnect (explicit-only).
+      // SAFETY: leaving via ‹ back must NOT reconnect (explicit-only). Arming
+      // the button but leaving without confirming must also fire nothing.
+      await reconnect.click(); // arm only
+      await expect(reconnect).toHaveText(/reconnect now/i);
       await page.getByTestId("vhost-back").click();
       await expect(page.getByTestId("vhost-subpage")).toHaveCount(0);
       await page.waitForTimeout(300); // let any (buggy) async reconnect fire
       expect(patches).toEqual([]);
 
-      // ACTION: re-enter the sub-page and press Reconnect → the connected
-      // network is bounced park→reconnect (the clean same-account teardown).
+      // ACTION: re-enter the sub-page (arm auto-reset on unmount) and confirm
+      // the two-tap Reconnect → the connected network is bounced
+      // park→reconnect (the clean same-account teardown).
       await page.getByTestId("vhost-settings-entry").click();
       await expect(page.getByTestId("vhost-subpage")).toBeVisible();
-      await page.getByTestId("vhost-reconnect").click();
+      const reconnect2 = page.getByTestId("vhost-reconnect");
+      await expect(reconnect2).toHaveText(/reconnect to apply/i); // arm reset
+      await reconnect2.click(); // arm
+      await reconnect2.click(); // confirm
 
       await expect.poll(() => patches.length, { timeout: 10_000 }).toBe(2);
       expect(patches).toEqual(["parked", "connected"]);

--- a/cicchetto/e2e/tests/issue282-vhost-reconnect-button.spec.ts
+++ b/cicchetto/e2e/tests/issue282-vhost-reconnect-button.spec.ts
@@ -1,0 +1,174 @@
+// #282 (P2, cic-only) — explicit "Reconnect to apply" button at the bottom
+// of the vhost sub-page.
+//
+// The vhost (source-bind address) is edited server-side on every toggle but
+// is INERT until the upstream reconnects (`Grappa.Vhosts.effective_source/2`
+// resolves the bind per connect). This spec proves the NEW cic wiring that
+// closes that gap:
+//
+//   1. The sub-page carries an always-available "Reconnect to apply" footer
+//      button. Pressing it BOUNCES every connected network — park then
+//      reconnect — via the per-network `PATCH /networks/:slug
+//      {connection_state}` path (the clean SAME-ACCOUNT teardown the
+//      home-page Reconnect uses, reused verbatim by
+//      `reconnectConnectedNetworks`).
+//   2. The reconnect is EXPLICIT only: leaving the panel via ‹ back NEVER
+//      reconnects. (Least-astonishment — a heavyweight, externally-visible
+//      QUIT/JOIN must not hide behind navigation; this is the #281 self-ban
+//      class the explicit button exists to avoid.)
+//
+// SCOPE — this proves the cic TRIGGER (the button issues the correct clean
+// park→reconnect sequence, and back issues nothing), NOT the server-side
+// reconnect mechanics: those (park→reconnect re-JOINs, members heal) are
+// already proven end-to-end by issue211-phase6-matrix + issue211-phase7.
+// So the `PATCH /networks/:slug` calls are recorded and short-circuited
+// (fulfilled 200) — the live `azzurra` session is minted real (the
+// connection_state filter needs a genuinely `connected` network) but never
+// actually bounced, keeping the assertion deterministic and free of
+// IRC-reconnect flake. GET /me/settings/vhost is stubbed so the sub-page
+// renders regardless of whether the e2e testnet seeds a vhost inventory.
+
+import type { Browser, Page } from "@playwright/test";
+import { expect, test } from "../fixtures/test";
+import { waitForUserTopicReady } from "../fixtures/cicchettoPage";
+import { adminDeleteVisitor, GRAPPA_BASE_URL, mintVisitor } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+
+const ANCHOR = "azzurra";
+
+// Mint (live azzurra connect) + a clean cic boot + two settings navigations.
+test.setTimeout(90_000);
+
+// A vhost view so the drawer nav row + sub-page render regardless of testnet
+// vhost seeding (targeted stub of the vhost READ only — boot/auth untouched).
+const VHOST_VIEW = {
+  available: [{ address: "2001:db8::1", in_pool: true, granted: false, name: "e2e-vhost.cloak" }],
+  selection: [],
+};
+
+async function waitForNetworkState(
+  token: string,
+  slug: string,
+  state: string,
+  attempts = 60,
+): Promise<void> {
+  for (let i = 0; i < attempts; i++) {
+    const res = await fetch(`${GRAPPA_BASE_URL}/networks`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) throw new Error(`waitForNetworkState: /networks → ${res.status}`);
+    const rows = (await res.json()) as Array<{ slug: string; connection_state: string }>;
+    if (rows.find((r) => r.slug === slug)?.connection_state === state) return;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`waitForNetworkState: ${slug} never reached ${state}`);
+}
+
+// Boot cic as the minted visitor, wire the recording routes, open the drawer
+// and land on the vhost sub-page. Returns the recorded connection_state
+// PATCH spellings (mutated as the test drives the button).
+async function bootToVhostPage(
+  browser: Browser,
+  visitor: { id: string; token: string },
+): Promise<{ ctx: Awaited<ReturnType<Browser["newContext"]>>; page: Page; patches: string[] }> {
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+  const patches: string[] = [];
+
+  await page.addInitScript(
+    ([token, subjectJson]) => {
+      localStorage.setItem("grappa-token", token);
+      localStorage.setItem("grappa-subject", subjectJson);
+      localStorage.setItem("cic.installChoice", "browser");
+    },
+    [visitor.token, JSON.stringify({ kind: "visitor", id: visitor.id })] as const,
+  );
+
+  // Stub the vhost view (GET only); a PUT would fall through to the server.
+  await page.route("**/me/settings/vhost", (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(VHOST_VIEW),
+      });
+    }
+    return route.continue();
+  });
+
+  // Record + short-circuit the connection_state PATCH (the reconnect verb's
+  // wire trace). Non-PATCH requests to this exact path fall through.
+  await page.route(`**/networks/${ANCHOR}`, (route) => {
+    if (route.request().method() === "PATCH") {
+      const body = route.request().postDataJSON() as { connection_state?: string } | null;
+      if (typeof body?.connection_state === "string") patches.push(body.connection_state);
+      return route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+    }
+    return route.continue();
+  });
+
+  await page.goto("/");
+  await expect(page.getByLabel(/open settings/i)).toBeVisible({ timeout: 10_000 });
+  // Gate on cic hydration: the reconnect verb reads cic's networks() store,
+  // so azzurra must be loaded before the button can bounce it. User-topic
+  // ready is downstream of the networks() load (subscribe.ts).
+  await waitForUserTopicReady(page, `visitor:${visitor.id}`);
+
+  await page.getByLabel(/open settings/i).click();
+  await expect(page.getByRole("dialog", { name: /settings/i })).toHaveClass(/open/);
+  await page.getByTestId("vhost-settings-entry").click();
+  await expect(page.getByTestId("vhost-subpage")).toBeVisible();
+
+  return { ctx, page, patches };
+}
+
+test.describe("issue #282 — explicit vhost Reconnect button", () => {
+  test("‹ back never reconnects, but the footer button bounces the connected network", async ({
+    browser,
+  }) => {
+    const admin = getSeededAdmin();
+    const stamp = Date.now();
+    let visitor: Awaited<ReturnType<typeof mintVisitor>> | null = null;
+    let ctx: Awaited<ReturnType<Browser["newContext"]>> | null = null;
+
+    try {
+      // A real, genuinely-connected network — the reconnect verb filters on
+      // connection_state === "connected", so the button is inert without one.
+      visitor = await mintVisitor(`p282-${stamp}`);
+      expect(visitor.network_slug).toBe(ANCHOR);
+      await waitForNetworkState(visitor.token, ANCHOR, "connected");
+
+      const booted = await bootToVhostPage(browser, visitor);
+      ctx = booted.ctx;
+      const { page, patches } = booted;
+
+      // The button is ALWAYS available (D2 — never gated on pending-detection)
+      // and communicates intent in its label.
+      const reconnect = page.getByTestId("vhost-reconnect");
+      await expect(reconnect).toBeEnabled();
+      await expect(reconnect).toHaveText(/reconnect to apply/i);
+
+      // SAFETY: leaving via ‹ back must NOT reconnect (explicit-only).
+      await page.getByTestId("vhost-back").click();
+      await expect(page.getByTestId("vhost-subpage")).toHaveCount(0);
+      await page.waitForTimeout(300); // let any (buggy) async reconnect fire
+      expect(patches).toEqual([]);
+
+      // ACTION: re-enter the sub-page and press Reconnect → the connected
+      // network is bounced park→reconnect (the clean same-account teardown).
+      await page.getByTestId("vhost-settings-entry").click();
+      await expect(page.getByTestId("vhost-subpage")).toBeVisible();
+      await page.getByTestId("vhost-reconnect").click();
+
+      await expect.poll(() => patches.length, { timeout: 10_000 }).toBe(2);
+      expect(patches).toEqual(["parked", "connected"]);
+
+      // The in-flight guard resolves and the button returns to its idle,
+      // intent-communicating label (never wedged in "Reconnecting…").
+      await expect(page.getByTestId("vhost-reconnect")).toHaveText(/reconnect to apply/i);
+    } finally {
+      if (ctx) await ctx.close();
+      if (visitor) await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+    }
+  });
+});

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -577,6 +577,10 @@ const SettingsDrawer: Component<Props> = (props) => {
   const enterVhostPage = (): void => {
     const t = token();
     if (t !== null) void loadVhostSettings(t);
+    // #282 review — clear a stale reconnect error so a back→re-enter within an
+    // open drawer never strands a prior failure (close-effect clears it too,
+    // but the within-drawer re-entry path is the gap the drawer close misses).
+    setReconnectError(null);
     setSettingsPage("vhost");
   };
 

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -25,6 +25,7 @@ import {
   listPushDevices,
   type PushDeviceSummary,
 } from "./lib/push";
+import { reconnectConnectedNetworks } from "./lib/reconnect";
 import { getTimeFormat, setTimeFormat, type TimeFormatKey } from "./lib/timeFormat";
 import { activeHost } from "./lib/uploadHost";
 import {
@@ -100,6 +101,12 @@ const SettingsDrawer: Component<Props> = (props) => {
   // (the widget stays hidden until the first GET lands).
   const [vhostView, setVhostView] = createSignal<VhostSettingsView | null>(null);
   const [vhostError, setVhostError] = createSignal<string | null>(null);
+  // #282 — explicit "Reconnect to apply" state for the vhost sub-page. The
+  // vhost is inert until the upstream reconnects; the footer button bounces
+  // the connected networks. `reconnecting` is the in-flight/double-fire
+  // guard + drives the button label; `reconnectError` surfaces a failure.
+  const [reconnecting, setReconnecting] = createSignal(false);
+  const [reconnectError, setReconnectError] = createSignal<string | null>(null);
   // #252 — settings sub-page navigation. The drawer is a flat page ("main")
   // that can push into a dedicated sub-page ("vhost"); the pattern mirrors
   // AdminPane's tab signal and is reusable for future sub-pages. cic never
@@ -284,6 +291,9 @@ const SettingsDrawer: Component<Props> = (props) => {
       setIdentitySaved(false);
       setIdentityError(null);
       setIdentitySeeded(false);
+      // #282 — clear a stale reconnect error so a reopened drawer that
+      // re-enters the vhost sub-page never strands the previous failure.
+      setReconnectError(null);
     }
   });
 
@@ -535,6 +545,28 @@ const SettingsDrawer: Component<Props> = (props) => {
     } catch (err) {
       const code = err instanceof ApiError ? err.code : "save_failed";
       setVhostError(code);
+    }
+  };
+
+  // #282 — explicit "Reconnect to apply". Bounces every connected network
+  // via `reconnectConnectedNetworks` (park→reconnect per network — the clean
+  // same-account path the home-page Reconnect uses, NOT the #281
+  // account-switch client purge) so the new source address binds on the
+  // fresh upstream. The `reconnecting` guard blocks double-fire; a failure
+  // surfaces inline via friendlyApiError (errors MUST be visible —
+  // feedback_silent_retry_anti_pattern).
+  const reconnectSession = async (): Promise<void> => {
+    if (reconnecting()) return;
+    setReconnectError(null);
+    setReconnecting(true);
+    try {
+      await reconnectConnectedNetworks();
+    } catch (err) {
+      setReconnectError(
+        err instanceof ApiError ? friendlyApiError(err) : "reconnect failed (unknown error)",
+      );
+    } finally {
+      setReconnecting(false);
     }
   };
 
@@ -1047,6 +1079,11 @@ const SettingsDrawer: Component<Props> = (props) => {
               void saveVhostSelection(addresses);
             }}
             onBack={() => setSettingsPage("main")}
+            onReconnect={() => {
+              void reconnectSession();
+            }}
+            reconnecting={reconnecting()}
+            reconnectError={reconnectError()}
           />
         </Show>
 

--- a/cicchetto/src/VhostSettingsPage.tsx
+++ b/cicchetto/src/VhostSettingsPage.tsx
@@ -1,4 +1,5 @@
 import { type Component, createMemo, createSignal, For, type JSX, Show } from "solid-js";
+import InlineConfirmButton from "./InlineConfirmButton";
 import type { VhostOption, VhostSettingsView } from "./lib/userSettings";
 
 // #252 — the vhost (source address) settings SUB-PAGE.
@@ -30,10 +31,15 @@ export type Props = {
   // "Reconnect to apply" footer button (the drawer owns the reconnect
   // orchestration → `reconnectConnectedNetworks`). The button is ALWAYS
   // available on-demand — deliberately NOT gated on pending-detection
-  // (unreliable client-side; hiding a heavyweight externally-visible
-  // action behind detection violates least-astonishment). `reconnecting`
-  // disables + relabels it while the bounce is in flight (double-fire
-  // guard); `reconnectError` surfaces a failure inline.
+  // (unreliable client-side; hiding a heavyweight externally-visible action
+  // behind detection violates least-astonishment). It fires through a
+  // two-tap `InlineConfirmButton` arm — the SAME confirm gate the drawer's
+  // other disruptive reconnect/teardown actions use (`quit`, visitor "apply
+  // identity") — so a single stray tap can't drop + rejoin every network. An
+  // arm is not a disable and not a pending-gate, so this preserves the
+  // always-available contract. `reconnecting` relabels the idle button while
+  // the bounce is in flight (the drawer's own guard blocks re-fire);
+  // `reconnectError` surfaces a failure inline.
   onReconnect: () => void;
   reconnecting: boolean;
   reconnectError: string | null;
@@ -45,6 +51,11 @@ const VhostSettingsPage: Component<Props> = (props) => {
   // an explicit user override (so ON can reveal the sections before any
   // address is picked, and OFF survives the reset-to-[] round-trip).
   const [override, setOverride] = createSignal<boolean | null>(null);
+  // #282 — local two-tap arm for the Reconnect footer button. The sub-page
+  // unmounts on ‹ back (it's a `<Show>` branch in SettingsDrawer), so this
+  // ephemeral flag auto-resets on leave — no drawer-side disarm needed
+  // (unlike the always-mounted `quitArmed`/`identityArmed`).
+  const [reconnectArmed, setReconnectArmed] = createSignal(false);
   const customizeOn = (): boolean => {
     const o = override();
     if (o !== null) return o;
@@ -181,15 +192,18 @@ const VhostSettingsPage: Component<Props> = (props) => {
           available; the drawer's onReconnect bounces the connected
           networks so the new source address binds on the fresh upstream. */}
       <footer class="vhost-reconnect-footer">
-        <button
-          type="button"
-          class="vhost-reconnect"
-          data-testid="vhost-reconnect"
-          disabled={props.reconnecting}
-          onClick={props.onReconnect}
-        >
-          {props.reconnecting ? "Reconnecting…" : "Reconnect to apply"}
-        </button>
+        <InlineConfirmButton
+          idleLabel={props.reconnecting ? "Reconnecting…" : "Reconnect to apply"}
+          confirmLabel="reconnect now (drops + rejoins)"
+          testId="vhost-reconnect"
+          extraClass="vhost-reconnect"
+          armed={reconnectArmed()}
+          onArm={() => setReconnectArmed(true)}
+          onConfirm={() => {
+            setReconnectArmed(false);
+            props.onReconnect();
+          }}
+        />
         <p class="vhost-reconnect-hint">
           your source address takes effect on reconnect — you'll briefly drop and rejoin your
           channels

--- a/cicchetto/src/VhostSettingsPage.tsx
+++ b/cicchetto/src/VhostSettingsPage.tsx
@@ -25,6 +25,18 @@ export type Props = {
   error: string | null;
   onSetSelection: (addresses: string[]) => void;
   onBack: () => void;
+  // #282 — the vhost is INERT until the upstream reconnects (source-bind
+  // resolves per connect), so the sub-page carries an explicit sticky
+  // "Reconnect to apply" footer button (the drawer owns the reconnect
+  // orchestration → `reconnectConnectedNetworks`). The button is ALWAYS
+  // available on-demand — deliberately NOT gated on pending-detection
+  // (unreliable client-side; hiding a heavyweight externally-visible
+  // action behind detection violates least-astonishment). `reconnecting`
+  // disables + relabels it while the bounce is in flight (double-fire
+  // guard); `reconnectError` surfaces a failure inline.
+  onReconnect: () => void;
+  reconnecting: boolean;
+  reconnectError: string | null;
 };
 
 const VhostSettingsPage: Component<Props> = (props) => {
@@ -162,6 +174,32 @@ const VhostSettingsPage: Component<Props> = (props) => {
           {props.error}
         </p>
       </Show>
+
+      {/* #282 — sticky "Reconnect to apply" footer. Single instance at the
+          bottom of the list (no top+bottom duplication — a duplicated
+          disruptive action invites accidental double-fire). Always
+          available; the drawer's onReconnect bounces the connected
+          networks so the new source address binds on the fresh upstream. */}
+      <footer class="vhost-reconnect-footer">
+        <button
+          type="button"
+          class="vhost-reconnect"
+          data-testid="vhost-reconnect"
+          disabled={props.reconnecting}
+          onClick={props.onReconnect}
+        >
+          {props.reconnecting ? "Reconnecting…" : "Reconnect to apply"}
+        </button>
+        <p class="vhost-reconnect-hint">
+          your source address takes effect on reconnect — you'll briefly drop and rejoin your
+          channels
+        </p>
+        <Show when={props.reconnectError !== null}>
+          <p class="vhost-reconnect-error" role="alert" data-testid="vhost-reconnect-error">
+            {props.reconnectError}
+          </p>
+        </Show>
+      </footer>
     </section>
   );
 };

--- a/cicchetto/src/__tests__/VhostSettingsPage.test.tsx
+++ b/cicchetto/src/__tests__/VhostSettingsPage.test.tsx
@@ -26,7 +26,14 @@ const view = (over: Partial<VhostSettingsView> = {}): VhostSettingsView => ({
 
 const renderPage = (
   v: VhostSettingsView | null,
-  opts: { error?: string | null; onSetSelection?: (a: string[]) => void; onBack?: () => void } = {},
+  opts: {
+    error?: string | null;
+    onSetSelection?: (a: string[]) => void;
+    onBack?: () => void;
+    onReconnect?: () => void;
+    reconnecting?: boolean;
+    reconnectError?: string | null;
+  } = {},
 ) =>
   render(() => (
     <VhostSettingsPage
@@ -34,6 +41,9 @@ const renderPage = (
       error={opts.error ?? null}
       onSetSelection={opts.onSetSelection ?? vi.fn()}
       onBack={opts.onBack ?? vi.fn()}
+      onReconnect={opts.onReconnect ?? vi.fn()}
+      reconnecting={opts.reconnecting ?? false}
+      reconnectError={opts.reconnectError ?? null}
     />
   ));
 
@@ -48,6 +58,53 @@ describe("VhostSettingsPage — chrome", () => {
   it("shows the error message when error is set", () => {
     renderPage(view(), { error: "forbidden_vhost" });
     expect(screen.getByTestId("vhost-error")).toHaveTextContent("forbidden_vhost");
+  });
+});
+
+describe("VhostSettingsPage — #282 reconnect footer", () => {
+  it("renders an always-available Reconnect button that fires onReconnect", () => {
+    const onReconnect = vi.fn();
+    // Empty view = no pending change; the button is STILL available (D2:
+    // reconnect is on-demand, never gated on pending-detection).
+    renderPage(view(), { onReconnect });
+    const btn = screen.getByTestId("vhost-reconnect") as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    fireEvent.click(btn);
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays available even with a customized selection (no pending-gate)", () => {
+    renderPage(
+      view({
+        available: [opt({ address: "2001:db8::1", in_pool: true })],
+        selection: ["2001:db8::1"],
+      }),
+    );
+    expect((screen.getByTestId("vhost-reconnect") as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("communicates intent in the idle label", () => {
+    renderPage(view());
+    expect(screen.getByTestId("vhost-reconnect")).toHaveTextContent(/reconnect to apply/i);
+  });
+
+  it("disables + relabels the button ONLY while a reconnect is in flight", () => {
+    renderPage(view(), { reconnecting: true });
+    const btn = screen.getByTestId("vhost-reconnect") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn).toHaveTextContent(/reconnecting/i);
+  });
+
+  it("does not fire onReconnect on a second click while a reconnect is in flight", () => {
+    const onReconnect = vi.fn();
+    renderPage(view(), { onReconnect, reconnecting: true });
+    fireEvent.click(screen.getByTestId("vhost-reconnect"));
+    expect(onReconnect).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a reconnect error inline", () => {
+    renderPage(view(), { reconnectError: "network_circuit_open" });
+    expect(screen.getByTestId("vhost-reconnect-error")).toHaveTextContent("network_circuit_open");
   });
 });
 

--- a/cicchetto/src/__tests__/VhostSettingsPage.test.tsx
+++ b/cicchetto/src/__tests__/VhostSettingsPage.test.tsx
@@ -62,18 +62,16 @@ describe("VhostSettingsPage — chrome", () => {
 });
 
 describe("VhostSettingsPage — #282 reconnect footer", () => {
-  it("renders an always-available Reconnect button that fires onReconnect", () => {
-    const onReconnect = vi.fn();
-    // Empty view = no pending change; the button is STILL available (D2:
-    // reconnect is on-demand, never gated on pending-detection).
-    renderPage(view(), { onReconnect });
+  it("renders an always-available Reconnect button (no pending-gate, even with an empty view)", () => {
+    // Empty view = no change; the button is STILL available (D2: reconnect is
+    // on-demand, never gated on pending-detection).
+    renderPage(view());
     const btn = screen.getByTestId("vhost-reconnect") as HTMLButtonElement;
     expect(btn.disabled).toBe(false);
-    fireEvent.click(btn);
-    expect(onReconnect).toHaveBeenCalledTimes(1);
+    expect(btn).toHaveTextContent(/reconnect to apply/i);
   });
 
-  it("stays available even with a customized selection (no pending-gate)", () => {
+  it("stays available with a customized selection", () => {
     renderPage(
       view({
         available: [opt({ address: "2001:db8::1", in_pool: true })],
@@ -83,23 +81,31 @@ describe("VhostSettingsPage — #282 reconnect footer", () => {
     expect((screen.getByTestId("vhost-reconnect") as HTMLButtonElement).disabled).toBe(false);
   });
 
-  it("communicates intent in the idle label", () => {
-    renderPage(view());
-    expect(screen.getByTestId("vhost-reconnect")).toHaveTextContent(/reconnect to apply/i);
-  });
-
-  it("disables + relabels the button ONLY while a reconnect is in flight", () => {
-    renderPage(view(), { reconnecting: true });
-    const btn = screen.getByTestId("vhost-reconnect") as HTMLButtonElement;
-    expect(btn.disabled).toBe(true);
-    expect(btn).toHaveTextContent(/reconnecting/i);
-  });
-
-  it("does not fire onReconnect on a second click while a reconnect is in flight", () => {
+  it("arms on the first tap and fires onReconnect ONLY on the confirm (second) tap", () => {
     const onReconnect = vi.fn();
-    renderPage(view(), { onReconnect, reconnecting: true });
-    fireEvent.click(screen.getByTestId("vhost-reconnect"));
+    renderPage(view(), { onReconnect });
+    const btn = screen.getByTestId("vhost-reconnect");
+    // First tap → arm (confirm label), no reconnect yet — a single stray tap
+    // never bounces every network.
+    fireEvent.click(btn);
     expect(onReconnect).not.toHaveBeenCalled();
+    expect(btn).toHaveTextContent(/reconnect now/i);
+    // Second tap → confirm → reconnect fires exactly once.
+    fireEvent.click(btn);
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns to the idle label after confirming (the arm resets)", () => {
+    renderPage(view());
+    const btn = screen.getByTestId("vhost-reconnect");
+    fireEvent.click(btn); // arm
+    fireEvent.click(btn); // confirm
+    expect(btn).toHaveTextContent(/reconnect to apply/i);
+  });
+
+  it("relabels the idle button to Reconnecting… while a reconnect is in flight", () => {
+    renderPage(view(), { reconnecting: true });
+    expect(screen.getByTestId("vhost-reconnect")).toHaveTextContent(/reconnecting/i);
   });
 
   it("surfaces a reconnect error inline", () => {

--- a/cicchetto/src/__tests__/reconnect.test.ts
+++ b/cicchetto/src/__tests__/reconnect.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// #282 — reconnectConnectedNetworks(): the verb behind the vhost sub-page
+// footer "Reconnect to apply" button. The vhost (source-bind address) is
+// account-level and resolved fresh PER CONNECT
+// (`Grappa.Vhosts.effective_source/2`), so a changed selection only takes
+// effect once the upstream socket is re-established. This verb BOUNCES
+// every currently-`connected` network — park then reconnect — reusing the
+// per-network `PATCH /networks/:slug {connection_state}` path the
+// home-page Reconnect uses (the clean SAME-ACCOUNT teardown; NOT the #281
+// account-SWITCH client purge, NOT the visitor identity-apply path).
+
+type NetLocal = { slug: string; connection_state: "connected" | "parked" | "failed" };
+
+const patchNetworkMock = vi.fn<
+  (t: string, slug: string, body: { connection_state: string }) => Promise<void>
+>(() => Promise.resolve());
+const tokenMock = vi.fn<() => string | null>(() => "test-token");
+const networksMock = vi.fn<() => NetLocal[]>(() => []);
+
+vi.mock("../lib/api", () => ({
+  patchNetwork: (t: string, slug: string, body: { connection_state: string }) =>
+    patchNetworkMock(t, slug, body),
+}));
+vi.mock("../lib/auth", () => ({ token: () => tokenMock() }));
+vi.mock("../lib/networks", () => ({ networks: () => networksMock() }));
+
+import { reconnectConnectedNetworks } from "../lib/reconnect";
+
+afterEach(() => {
+  vi.clearAllMocks();
+  tokenMock.mockReturnValue("test-token");
+  networksMock.mockReturnValue([]);
+});
+
+// Per-network ordered spellings actually PATCHed, in call order.
+const spellingsFor = (slug: string): string[] =>
+  patchNetworkMock.mock.calls
+    .filter((c) => c[1] === slug)
+    .map((c) => (c[2] as { connection_state: string }).connection_state);
+
+describe("reconnectConnectedNetworks — bounce every connected network", () => {
+  it("parks then reconnects each connected network (park before connect, per network)", async () => {
+    networksMock.mockReturnValue([
+      { slug: "libera", connection_state: "connected" },
+      { slug: "oftc", connection_state: "connected" },
+    ]);
+
+    await reconnectConnectedNetworks();
+
+    expect(spellingsFor("libera")).toEqual(["parked", "connected"]);
+    expect(spellingsFor("oftc")).toEqual(["parked", "connected"]);
+  });
+
+  it("skips networks NOT in the connected state (parked/failed left untouched)", async () => {
+    networksMock.mockReturnValue([
+      { slug: "libera", connection_state: "connected" },
+      { slug: "oftc", connection_state: "parked" },
+      { slug: "efnet", connection_state: "failed" },
+    ]);
+
+    await reconnectConnectedNetworks();
+
+    const touched = new Set(patchNetworkMock.mock.calls.map((c) => c[1]));
+    expect(touched).toEqual(new Set(["libera"]));
+  });
+
+  it("no-ops when the bearer is null (never PATCHes)", async () => {
+    tokenMock.mockReturnValue(null);
+    networksMock.mockReturnValue([{ slug: "libera", connection_state: "connected" }]);
+
+    await reconnectConnectedNetworks();
+
+    expect(patchNetworkMock).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when there are no connected networks", async () => {
+    networksMock.mockReturnValue([
+      { slug: "libera", connection_state: "parked" },
+      { slug: "oftc", connection_state: "failed" },
+    ]);
+
+    await reconnectConnectedNetworks();
+
+    expect(patchNetworkMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT reconnect a network whose park PATCH failed", async () => {
+    networksMock.mockReturnValue([{ slug: "libera", connection_state: "connected" }]);
+    // park (first call) rejects → the reconnect half must not fire.
+    patchNetworkMock.mockRejectedValueOnce(new Error("park failed"));
+
+    await expect(reconnectConnectedNetworks()).rejects.toThrow("park failed");
+
+    expect(spellingsFor("libera")).toEqual(["parked"]);
+  });
+
+  it("propagates a failure so the caller can surface it, but still bounces the healthy networks", async () => {
+    networksMock.mockReturnValue([
+      { slug: "libera", connection_state: "connected" },
+      { slug: "oftc", connection_state: "connected" },
+    ]);
+    // Fail ONLY libera's park; oftc must still complete its park→connect.
+    patchNetworkMock.mockImplementation((_t, slug, body) => {
+      if (slug === "libera" && body.connection_state === "parked") {
+        return Promise.reject(new Error("park failed"));
+      }
+      return Promise.resolve();
+    });
+
+    await expect(reconnectConnectedNetworks()).rejects.toThrow("park failed");
+
+    expect(spellingsFor("oftc")).toEqual(["parked", "connected"]);
+    expect(spellingsFor("libera")).toEqual(["parked"]);
+  });
+});

--- a/cicchetto/src/lib/reconnect.ts
+++ b/cicchetto/src/lib/reconnect.ts
@@ -1,0 +1,59 @@
+import { patchNetwork } from "./api";
+import { token } from "./auth";
+import { networks } from "./networks";
+
+// #282 — explicit "Reconnect to apply" verb behind the vhost sub-page
+// footer button.
+//
+// The vhost (source-bind address) is ACCOUNT-level and resolved fresh PER
+// CONNECT (`Grappa.Vhosts.effective_source/2`: the subject's selection,
+// intersected with its allowed set, picked at connect time). So a changed
+// selection is INERT until the upstream socket is re-established. This verb
+// BOUNCES every currently-`connected` network — park then reconnect — so
+// each fresh connection re-binds from the (new) selection; the server
+// re-JOINs and emits `connection_state_changed`, which `userTopic.ts`
+// patches in place.
+//
+// This reuses the SAME per-network `PATCH /networks/:slug {connection_state}`
+// path the home-page Reconnect (`HomePane` `DisconnectedRow`) drives — the
+// clean SAME-ACCOUNT teardown. It is deliberately NOT:
+//   * the #281 identity-change client purge (`identityScopedStore`
+//     `onIdentityChange`) — that's account-SWITCH semantics, keyed on a
+//     token rotation a same-account bounce never triggers, and its
+//     404-storm risk (stale CROSS-account state) does not apply here; nor
+//   * the visitor identity-apply path (`updateIdentity` → PATCH
+//     /networks/:slug/identity) — that carries nick/ident/realname, not
+//     the vhost selection.
+//
+// Only `:connected` networks are bounced. A `:parked` / `:failed` network
+// was left down deliberately (home-page park, admission failure); it will
+// pick up the new vhost whenever the user reconnects it from the home
+// page. Bouncing it here would be an unrelated state change.
+//
+// Each network's park→reconnect is sequential (the park must settle before
+// the reconnect), but networks are independent so the whole set runs
+// concurrently. `Promise.allSettled` — a failure on one network must not
+// abort the others (mirrors `quitAll`); failures are logged per-network,
+// then the FIRST is re-thrown so the caller can surface it (the button
+// renders `friendlyApiError`). A network whose park PATCH fails is never
+// reconnected (the sequential await short-circuits its `bounce`).
+
+async function bounce(t: string, slug: string): Promise<void> {
+  await patchNetwork(t, slug, { connection_state: "parked" });
+  await patchNetwork(t, slug, { connection_state: "connected" });
+}
+
+export async function reconnectConnectedNetworks(): Promise<void> {
+  const t = token();
+  if (t === null) return;
+  const connected = (networks() ?? []).filter((n) => n.connection_state === "connected");
+  if (connected.length === 0) return;
+
+  const results = await Promise.allSettled(connected.map((n) => bounce(t, n.slug)));
+  const failures = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+  for (const f of failures) {
+    console.warn("[reconnect] bounce failed:", f.reason);
+  }
+  const first = failures[0];
+  if (first !== undefined) throw first.reason;
+}

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -5406,6 +5406,57 @@ html.resize-dragging * {
   margin: 0.25rem 0;
 }
 
+/* #282 — sticky "Reconnect to apply" footer for the vhost sub-page. A
+   single instance pinned to the bottom of the drawer's scroll viewport so
+   the (heavyweight, externally-visible) reconnect action is always
+   reachable without scrolling to the end of a long allow-set. The opaque
+   backdrop + top border let the option rows scroll UNDER it. */
+.vhost-reconnect-footer {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding-top: 0.5rem;
+  background: var(--bg);
+  border-top: 1px solid var(--border);
+}
+
+.vhost-reconnect {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  padding: 0.5rem 1rem;
+  font-family: var(--font-mono);
+  font-size: var(--font-size);
+  cursor: pointer;
+}
+
+.vhost-reconnect:hover:not(:disabled) {
+  background: var(--accent);
+  color: var(--bg);
+}
+
+.vhost-reconnect:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.vhost-reconnect-hint {
+  color: var(--muted);
+  font-size: 0.75rem;
+  margin: 0;
+}
+
+.settings-drawer .vhost-reconnect-error {
+  background: var(--bg);
+  border: 1px solid var(--mode-op);
+  color: var(--mode-op);
+  padding: 0.4rem 0.5rem;
+  font-size: 0.8rem;
+  margin: 0.25rem 0;
+}
+
 /* #127 — /info, /version, /motd modal. Same overlay/panel/header/footer
  * scaffolding as the WHO/NAMES modals (backdrop scrim, keyboard-aware
  * max-height, pinned header/footer, `.server-reply-modal-body` scroller),

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -5422,24 +5422,20 @@ html.resize-dragging * {
   border-top: 1px solid var(--border);
 }
 
-.vhost-reconnect {
-  background: transparent;
+/* The button is an InlineConfirmButton (two-tap arm, like `quit`); override
+   the compact base sizing + the base reddish idle colour to a full-size
+   accent primary. The base `.inline-confirm-btn.confirming` rule supplies
+   the red armed treatment on the confirm tap. */
+.settings-drawer .inline-confirm-btn.vhost-reconnect {
   color: var(--accent);
-  border: 1px solid var(--accent);
+  border-color: var(--accent);
   padding: 0.5rem 1rem;
-  font-family: var(--font-mono);
-  font-size: var(--font-size);
-  cursor: pointer;
+  font-size: inherit;
 }
 
-.vhost-reconnect:hover:not(:disabled) {
+.settings-drawer .inline-confirm-btn.vhost-reconnect:hover:not(.confirming) {
   background: var(--accent);
   color: var(--bg);
-}
-
-.vhost-reconnect:disabled {
-  opacity: 0.5;
-  cursor: default;
 }
 
 .vhost-reconnect-hint {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -24721,3 +24721,60 @@ mirror + `>` prompt reply → nick-strip-vs-$server contrast).
 
 _Deploy: **`--cic`** bundle only (cic-only, no server change). **HELD** —
 batched into the next COLD window with #299, NOT shipped solo._
+
+## 2026-07-18 — #282 (P2, cic): explicit vhost Reconnect button
+
+The vhost sub-page (#252) PUTs the source-address selection on every toggle,
+but the change is INERT until the upstream reconnects — `Grappa.Vhosts`
+`effective_source/2` resolves the source-bind per connect, so a new selection
+only binds on a fresh socket. There was no first-class way to apply it. #282
+adds a single sticky "Reconnect to apply" footer button to the sub-page.
+
+### Design decisions (challenged against CLAUDE.md)
+
+- **The teardown path — reuse the per-network park→reconnect, NOT the #281
+  purge.** The spec framed this as "same clean teardown as Switch identity"
+  and "the clean path #281 establishes." Traced against the code, that's a
+  category mismatch: there is no "Switch identity" button, and the #281 clean
+  path is the `identityScopedStore` `onIdentityChange` client purge keyed on a
+  **token rotation** (logout / account-SWITCH). A same-account vhost reconnect
+  never rotates the token, and #281's 404-storm risk (stale CROSS-account
+  network/channel state replayed under a new bearer) does not arise — the same
+  account keeps the same networks/channels, so history-fetches 200, not 404.
+  The genuinely-clean same-account path is the home-page Reconnect (`HomePane`
+  `DisconnectedRow`): a per-network `PATCH /networks/:slug {connection_state}`
+  bounce. `reconnectConnectedNetworks` (`lib/reconnect.ts`, sibling of
+  `quit.ts`) reuses that verb: park→reconnect every `:connected` network
+  concurrently (`Promise.allSettled`; a failed park never reconnects that net;
+  the first failure re-throws so the button surfaces it). Only `:connected`
+  nets are bounced — a `:parked`/`:failed` net was left down deliberately and
+  picks up the new vhost when the user reconnects it from the home page.
+
+- **Always-available button, NOT "disabled until pending" (autopilot D2 —
+  deviation from the written spec).** The spec's acceptance said "disabled /
+  greyed until a pending vhost change exists." But the vhost is account-level
+  with NO server field exposing the live-bound vs selected address, so
+  pending-detection is only a fragile client dirty-flag — and gating a
+  heavyweight, externally-visible action on unreliable detection is itself a
+  least-astonishment hazard. Ruling (vjt autopilot 2026-07-18): the button is
+  ALWAYS available on-demand, never gated on pending-detection. The static
+  "Reconnect to apply" label communicates intent (the spec's real goal); the
+  only disable is the in-flight double-fire guard (`reconnecting`). No
+  dirty-flag hint shipped in v1 (optional; deferred).
+
+- **Explicit only — never implicit on back/close.** ‹ back just navigates; it
+  issues no reconnect. A single sticky footer instance (no top+bottom
+  duplication — a duplicated disruptive action invites accidental double-fire).
+
+State + orchestration live in `SettingsDrawer` (`reconnectSession` →
+`reconnectConnectedNetworks`; `reconnecting`/`reconnectError` signals, error via
+`friendlyApiError`); `VhostSettingsPage` stays presentational (props in,
+`onReconnect` out). Pinned by `reconnect.test.ts` (park→reconnect sequence +
+skip-non-connected + propagate-failure), `VhostSettingsPage.test.tsx`
+(always-available + label + in-flight guard + inline error), and the
+`issue282-vhost-reconnect-button.spec.ts` browser e2e (back-fires-nothing /
+button-fires-`["parked","connected"]`, deterministic PATCH intercept on a real
+connected `azzurra`).
+
+_Deploy: **`--cic`** bundle only (cic-only, no server change). **HELD** —
+batched into the next COLD window with #299/#290, NOT shipped solo._

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -24758,9 +24758,21 @@ adds a single sticky "Reconnect to apply" footer button to the sub-page.
   heavyweight, externally-visible action on unreliable detection is itself a
   least-astonishment hazard. Ruling (vjt autopilot 2026-07-18): the button is
   ALWAYS available on-demand, never gated on pending-detection. The static
-  "Reconnect to apply" label communicates intent (the spec's real goal); the
-  only disable is the in-flight double-fire guard (`reconnecting`). No
+  "Reconnect to apply" label communicates intent (the spec's real goal). No
   dirty-flag hint shipped in v1 (optional; deferred).
+
+- **Two-tap confirm arm (`InlineConfirmButton`), NOT a single-tap fire (code
+  review 2026-07-18).** The button drops + rejoins EVERY connected network at
+  once, so — like the drawer's two other disruptive actions (`quit`, visitor
+  "apply identity", which reconnects a single network) — it fires through the
+  shared two-tap `InlineConfirmButton` arm. The spec asks to "mirror the
+  existing button, same pattern," and the existing reconnect-triggering button
+  IS a two-tap `InlineConfirmButton`; the arm also directly answers the spec's
+  own accidental-fire concern. An arm is neither a disable nor a
+  pending-detection gate, so the always-available D2 contract holds. The
+  `armed` flag is LOCAL to `VhostSettingsPage` (unlike the drawer-owned
+  `quitArmed`/`identityArmed`): the sub-page unmounts on ‹ back, so the arm
+  auto-resets on leave — no drawer-side disarm needed.
 
 - **Explicit only — never implicit on back/close.** ‹ back just navigates; it
   issues no reconnect. A single sticky footer instance (no top+bottom
@@ -24771,7 +24783,7 @@ State + orchestration live in `SettingsDrawer` (`reconnectSession` →
 `friendlyApiError`); `VhostSettingsPage` stays presentational (props in,
 `onReconnect` out). Pinned by `reconnect.test.ts` (park→reconnect sequence +
 skip-non-connected + propagate-failure), `VhostSettingsPage.test.tsx`
-(always-available + label + in-flight guard + inline error), and the
+(always-available + two-tap arm + idle-label + inline error), and the
 `issue282-vhost-reconnect-button.spec.ts` browser e2e (back-fires-nothing /
 button-fires-`["parked","connected"]`, deterministic PATCH intercept on a real
 connected `azzurra`).


### PR DESCRIPTION
## What

Adds a single sticky **"Reconnect to apply"** footer button to the vhost
(source-address) settings sub-page. The vhost selection is PUT server-side on
every toggle but is **inert until the upstream reconnects** (`Grappa.Vhosts`
`effective_source/2` binds the source address per connect). The button bounces
every currently-`connected` network — park→reconnect via `PATCH
/networks/:slug {connection_state}` — so the new source address binds on the
fresh upstream.

## Design (challenged against CLAUDE.md — see DESIGN_NOTES entry)

- **Reuses the per-network park→reconnect** (`reconnectConnectedNetworks`,
  `lib/reconnect.ts`, sibling of `quit.ts`) — the clean SAME-account teardown
  the home-page Reconnect uses. NOT the #281 identity-change client purge
  (that's account-SWITCH / token-rotation semantics; its 404-storm risk
  doesn't apply to a same-account bounce — channels persist → 200, not 404).
- **Always available on-demand** (autopilot D2 — deviates from the spec's
  "disabled until pending": the vhost is account-level with no server
  live-bound field, so pending-detection is only a fragile client dirty-flag).
- **Two-tap `InlineConfirmButton` arm** (code review) — mirrors the drawer's
  other disruptive actions (`quit`, visitor "apply identity") and the spec's
  "same pattern" ask; an arm is neither a disable nor a pending-gate, so D2
  holds. Prevents a single stray tap from bouncing every network.
- **Explicit only** — ‹ back never reconnects.
- **cic-only** — no server change.

## Tests

- `reconnect.test.ts` — park→reconnect sequence, skip-non-connected,
  propagate-failure.
- `VhostSettingsPage.test.tsx` — always-available + two-tap arm + idle-label +
  inline error.
- `issue282-vhost-reconnect-button.spec.ts` (e2e) — back fires nothing; the
  two-tap button fires exactly `["parked","connected"]` (deterministic PATCH
  intercept on a real connected `azzurra`).

## Deploy

`--cic` bundle only. **HELD** — batched into the next COLD window with
#299/#290, NOT shipped solo.

Refs #282