### PR TITLE
themes: snapshot visitor nick as published-theme author (#299)

### DIFF
--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -111,6 +111,58 @@ export async function mintVisitor(nick: string): Promise<MintedVisitor> {
   };
 }
 
+// #299 amendment (author model A) — thin theme REST helpers for the
+// author-nick e2e. The runner talks to grappa directly on port 4000
+// (bypassing nginx), so these mirror the cic `themesApi` verbs without the
+// browser. Only the fields the spec asserts on are typed.
+export type ThemeWire = { id: number; author: string; built_in: boolean };
+
+export async function listGalleryThemes(token: string): Promise<ThemeWire[]> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/themes`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    throw new Error(`grappaApi.listGalleryThemes: ${res.status} ${await res.text()}`);
+  }
+  const body = (await res.json()) as { themes: ThemeWire[] };
+  return body.themes;
+}
+
+export async function copyTheme(token: string, id: number): Promise<ThemeWire> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/themes/${id}/copy`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    throw new Error(`grappaApi.copyTheme: ${id} → ${res.status} ${await res.text()}`);
+  }
+  return (await res.json()) as ThemeWire;
+}
+
+export async function publishTheme(token: string, id: number): Promise<ThemeWire> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/themes/${id}/publish`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    throw new Error(`grappaApi.publishTheme: ${id} → ${res.status} ${await res.text()}`);
+  }
+  return (await res.json()) as ThemeWire;
+}
+
+// Admin deletes any theme (owner|admin authz) — teardown for the re-homed
+// system-owned gallery row the author-nick spec leaves behind. Idempotent:
+// 404 (already gone) is success.
+export async function adminDeleteTheme(adminToken: string, id: number): Promise<void> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/themes/${id}`, {
+    method: "DELETE",
+    headers: { authorization: `Bearer ${adminToken}` },
+  });
+  if (!res.ok && res.status !== 404) {
+    throw new Error(`grappaApi.adminDeleteTheme: ${id} → ${res.status} ${await res.text()}`);
+  }
+}
+
 // BUGHUNT-3 cascade fix (2026-05-25) — restore the seeded vjt's read
 // cursor on `(networkSlug, channel)` to the current tail row. Used in
 // `afterAll` hooks of specs that intentionally advance the cursor to

--- a/cicchetto/e2e/tests/issue299-theme-cards.spec.ts
+++ b/cicchetto/e2e/tests/issue299-theme-cards.spec.ts
@@ -14,7 +14,14 @@
 // spec exercises the client half.
 
 import { loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
-import { adminDeleteVisitor, mintVisitor } from "../fixtures/grappaApi";
+import {
+  adminDeleteTheme,
+  adminDeleteVisitor,
+  copyTheme,
+  listGalleryThemes,
+  mintVisitor,
+  publishTheme,
+} from "../fixtures/grappaApi";
 import {
   AUTOJOIN_CHANNELS,
   getSeededAdmin,
@@ -46,6 +53,16 @@ async function openThemesSubPageMobile(page: PWPage): Promise<void> {
 // Desktop path to the themes sub-page (settings cog → themes nav row).
 async function openThemesSubPageDesktop(page: PWPage): Promise<void> {
   await page.getByLabel(/open settings/i).click();
+  await page.getByTestId("themes-settings-entry").click();
+  await expect(page.getByTestId("theme-gallery")).toBeVisible({ timeout: 5_000 });
+}
+
+// Back out of the gallery and re-enter it — the ThemeGallery component
+// re-fetches on mount (`load()` in its on-entry effect), so this forces a
+// fresh gallery read after a server-side change (e.g. a visitor reap that
+// re-homes a published theme) without a full page reload.
+async function reopenGalleryDesktop(page: PWPage): Promise<void> {
+  await page.getByTestId("themes-back").click();
   await page.getByTestId("themes-settings-entry").click();
   await expect(page.getByTestId("theme-gallery")).toBeVisible({ timeout: 5_000 });
 }
@@ -130,6 +147,62 @@ test.describe("#299 — theme cards (tap-select + progressive disclosure)", () =
       await ctx.close();
       // The copy is a private (unpublished) theme, so it CASCADE-dies with the
       // visitor — no gallery residue to clean up.
+      await adminDeleteVisitor(getSeededAdmin().token, visitor.id).catch(() => {});
+    }
+  });
+
+  test("a visitor-published theme credits the publish-time nick and it survives reap", async ({
+    page,
+  }) => {
+    // Author model A (#299 amendment): a visitor-published theme is credited to
+    // the publishing visitor's nick, snapshotted at PUBLISH time and PERSISTED
+    // — so it survives the visitor being reaped, which re-homes the published
+    // theme to the system owner (visitor_id → nil). If attribution read the
+    // live owner instead of the snapshot, the card would flip to "system" (or
+    // the "guest" fallback) after reap. Set-up runs over REST (the runner talks
+    // to grappa directly); the assertion is the cic gallery RENDER.
+    const visitor = await mintVisitor(`e2e299n-${Date.now()}`);
+    let themeId: number | undefined;
+
+    try {
+      // The visitor copies a built-in (a guaranteed-valid payload) into their
+      // library, then publishes it → the server snapshots author_nick.
+      const gallery = await listGalleryThemes(visitor.token);
+      const builtin = gallery.find((t) => t.built_in);
+      if (builtin === undefined) throw new Error("no built-in theme in the gallery to copy");
+      const copy = await copyTheme(visitor.token, builtin.id);
+      themeId = copy.id;
+      const published = await publishTheme(visitor.token, copy.id);
+      // Server truth: the wire already credits the nick, not the guest label.
+      expect(published.author).toBe(visitor.nick);
+
+      // View the gallery as the seeded vjt; the card credits the visitor nick.
+      await loginAs(page, getSeededVjt());
+      await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+      await expect(sidebarWindow(page, NETWORK_SLUG, CHANNEL)).toBeVisible();
+      await openThemesSubPageDesktop(page);
+
+      const author = page.locator(`[data-testid="theme-card-${themeId}"] .theme-card-author`);
+      await expect(author).toBeVisible({ timeout: 5_000 });
+      await expect(author).toContainText(visitor.nick);
+
+      // Reap the publishing visitor → re-homes the published theme to system.
+      await adminDeleteVisitor(getSeededAdmin().token, visitor.id);
+
+      // Re-open the gallery (forces a fresh fetch): the nick snapshot STILL
+      // shows — NOT "system" (the new owner), NOT the "guest" fallback.
+      await reopenGalleryDesktop(page);
+      const authorAfter = page.locator(
+        `[data-testid="theme-card-${themeId}"] .theme-card-author`,
+      );
+      await expect(authorAfter).toBeVisible({ timeout: 5_000 });
+      await expect(authorAfter).toContainText(visitor.nick);
+    } finally {
+      // The re-homed theme is a published, system-owned gallery row — clean it
+      // up so it doesn't accrete as gallery residue across runs.
+      if (themeId !== undefined) {
+        await adminDeleteTheme(getSeededAdmin().token, themeId).catch(() => {});
+      }
       await adminDeleteVisitor(getSeededAdmin().token, visitor.id).catch(() => {});
     }
   });

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -24593,6 +24593,39 @@ source; `built_in` is always false for a visitor-owned theme. Considered and
 rejected: attributing to the visitor's current nick (impersonation risk + a
 reaped visitor's nick is meaningless).
 
+**Author model A (amendment, 2026-07-18 — SUPERSEDES model B).** vjt reversed
+the call: a visitor-published theme is credited to the **visitor's nick,
+snapshotted at PUBLISH time and PERSISTED** as `themes.author_nick` (nullable,
+expand-safe add-column migration riding the same HELD #299 COLD batch). vjt saw
+and ACCEPTED the impersonation caveat ("il nick che il visitor ha in quel
+momento, è ok"). Wire attribution now **prefers `author_nick` whenever
+present, regardless of current owner**: `author = author_nick || user.name ||
+"guest"`. That ordering is load-bearing — the reaping re-home (below) flips a
+published visitor theme to `user_id=system`, so a live-owner read would render
+"system"; the stored snapshot keeps crediting the original nick. `built_in`
+is now decoupled from `author` (pure ownership predicate = system user) — a
+re-homed row is `built_in: true` AND nick-credited. Legacy pre-amendment
+visitor themes (`author_nick` NULL) keep "guest"; user themes keep the owner's
+name — no behavior change for either.
+
+_Spec-vs-code deviation recorded (CLAUDE.md "challenge the spec"):_ the
+amendment brief said to read the nick from "the Visitor row / subject", but
+#211 phase 7 DROPPED the row's nick — it lives per-network on
+`network_credentials`, and the request `current_subject` carries no nick. The
+snapshot is instead derived server-side from
+`Networks.Credentials.representative_visitor_credential/1` (the identity-anchor
+= lowest-`network_id` credential's nick — the SAME "a visitor's nick" the
+subject wire + admin Visitors tab already show), keyed off the THEME's
+`visitor_id` (NOT the caller subject — an admin may publish another subject's
+theme). Raw nick, NOT rfc1459-folded: a display LABEL, not a fold-MATCH site
+(consistent with the raw-cased members map / `state.nick`). `author_nick` is
+written ONLY server-side via `set_published/3`'s `Ecto.Changeset.change/2`, NOT
+added to the public `cast/3` allowlist — a user-supplied author string would
+widen the surface past the accepted "publish under a nick you hold" caveat
+(tighter than the brief's "cast it", which the current controller never
+exercises anyway). Themes gained a one-way `Grappa.Networks` boundary dep.
+Follow-up (separate ticket, NOT built here): make the author label editable.
+
 **Reaping re-home (the one non-CASCADE dependent).** A reaped/deleted
 visitor's PUBLISHED themes must survive as gallery contributions; private ones
 die with the row. `Themes.rehome_visitor_published_to_system/1` moves published

--- a/lib/grappa/themes.ex
+++ b/lib/grappa/themes.ex
@@ -18,9 +18,12 @@ defmodule Grappa.Themes do
   shared daily quota AND a 50-total owned-theme cap (users have no lifetime
   cap). A reaped visitor's PUBLISHED themes re-home to the system user
   (`rehome_visitor_published_to_system/1`) so gallery contributions survive;
-  private ones die with the row. A visitor-owned theme is attributed to a
-  FIXED "guest" label on the wire — NEVER a nick (author model B: no
-  impersonation surface).
+  private ones die with the row. A visitor-published theme is attributed to
+  the publishing visitor's nick, snapshotted at publish time into
+  `author_nick` (#299 amendment, author model A) and surviving the re-home
+  above; a snapshot-less theme (user-owned, or a never-published visitor
+  theme) falls back to the owner's name or the fixed "guest" label. See
+  `Grappa.Themes.Wire` for the attribution ordering.
 
   ## Authz (owner-or-admin, in the context — one code path, every door)
 
@@ -42,6 +45,9 @@ defmodule Grappa.Themes do
     deps: [
       Grappa.Accounts,
       Grappa.Net.Ssrf,
+      # #299 amendment (author model A): publish snapshots the visitor's
+      # representative nick from the credential anchor.
+      Grappa.Networks,
       Grappa.RateLimit,
       Grappa.Repo,
       Grappa.Subject,
@@ -56,6 +62,7 @@ defmodule Grappa.Themes do
 
   alias Grappa.{
     Accounts.User,
+    Networks.Credentials,
     RateLimit.DailyQuota,
     Repo,
     Subject,
@@ -335,10 +342,12 @@ defmodule Grappa.Themes do
   hard-delete choke point BEFORE `Repo.delete(visitor)` (so re-homed rows no
   longer carry `visitor_id` and escape the CASCADE).
 
-  Author model B (vjt-locked): a re-homed theme becomes system-owned, so the
-  wire renders it as a built-in — the visitor's nick is NEVER surfaced (no
-  anchor-nick, no impersonation). Each re-homed name is de-duplicated against
-  the system user's existing names (a visitor may have published a theme named
+  Author model A (#299 amendment): a re-homed theme becomes system-owned, so
+  the wire renders it as a built-in — but its `author_nick` snapshot (captured
+  at publish time) is PRESERVED here (this only rewrites `user_id`/`visitor_id`/
+  `name`), so the wire keeps crediting the original visitor's nick rather than
+  collapsing to "system". Each re-homed name is de-duplicated against the
+  system user's existing names (a visitor may have published a theme named
   identically to a built-in), reusing the same suffixing as copy. Returns the
   number of themes re-homed.
   """
@@ -385,9 +394,39 @@ defmodule Grappa.Themes do
   defp set_published(subject, id, value) when is_integer(id) and is_boolean(value) do
     with {:ok, theme} <- get_theme(id),
          :ok <- authorize(subject, theme) do
-      theme |> Ecto.Changeset.change(published: value) |> Repo.update()
+      theme
+      |> Ecto.Changeset.change(published: value)
+      |> maybe_snapshot_author_nick(theme, value)
+      |> Repo.update()
     end
   end
+
+  # #299 amendment (author model A): snapshot the publishing visitor's
+  # representative (identity-anchor) nick into `author_nick` at PUBLISH time.
+  # A STORED snapshot, NOT a live lookup: visitors are reaped, and a reaped
+  # visitor's published theme re-homes to the system user (`visitor_id` → nil),
+  # so the author label must not depend on the visitor still existing. Derived
+  # from the credential anchor (`Networks.Credentials.representative_visitor_credential/1`,
+  # the same identity nick the subject wire + admin tab show), NOT the caller
+  # subject (an admin may publish another subject's theme) and NOT the Visitor
+  # row (#211 phase 7 dropped the row's nick — it lives per-network on the
+  # credential). Raw nick as displayed, NOT rfc1459-folded: a display LABEL,
+  # not a fold-MATCH site (consistent with the raw-cased members map / state.nick).
+  # Only on publish=true, only for a visitor-owned theme; a missing anchor (no
+  # credential — should not happen post-provision) leaves `author_nick`
+  # untouched so the wire falls back to the guest label.
+  defp maybe_snapshot_author_nick(changeset, %Theme{visitor_id: visitor_id}, true)
+       when is_binary(visitor_id) do
+    case Credentials.representative_visitor_credential(visitor_id) do
+      {:ok, %{nick: nick}} when is_binary(nick) ->
+        Ecto.Changeset.change(changeset, author_nick: nick)
+
+      _ ->
+        changeset
+    end
+  end
+
+  defp maybe_snapshot_author_nick(changeset, _, _), do: changeset
 
   # Admin: any. Owner: own (user OR visitor, #299 item 8). Everyone else
   # (non-owners, and every non-admin against a system-owned built-in): forbidden.

--- a/lib/grappa/themes/theme.ex
+++ b/lib/grappa/themes/theme.ex
@@ -34,6 +34,7 @@ defmodule Grappa.Themes.Theme do
           payload: map() | nil,
           published: boolean() | nil,
           apply_count: integer() | nil,
+          author_nick: String.t() | nil,
           inserted_at: DateTime.t() | nil,
           updated_at: DateTime.t() | nil
         }
@@ -43,6 +44,13 @@ defmodule Grappa.Themes.Theme do
     field :payload, :map
     field :published, :boolean, default: false
     field :apply_count, :integer, default: 0
+    # #299 amendment (author model A) — a stored snapshot of the publishing
+    # visitor's representative nick, written server-side at PUBLISH time by
+    # `Grappa.Themes.set_published/3` (NOT via `cast/3`: a user-supplied
+    # author string would widen the impersonation surface past the accepted
+    # "publish under a nick you hold" caveat). NULL for user themes + legacy
+    # pre-amendment visitor themes; the wire falls back accordingly.
+    field :author_nick, :string
     belongs_to :user, User, type: :binary_id
     belongs_to :visitor, Visitor, type: :binary_id
     timestamps(type: :utc_datetime_usec)

--- a/lib/grappa/themes/wire.ex
+++ b/lib/grappa/themes/wire.ex
@@ -19,9 +19,14 @@ defmodule Grappa.Themes.Wire do
       9 — the real usage metric, distinct from the copy-only `apply_count`).
       The context reader populates it on the `%Theme{}`; 0 if unpopulated.
 
-  `author` is the owning user's name for a user-owned theme, and a FIXED
-  `"guest"` label for a visitor-owned theme — #299 author model B: a visitor's
-  nick is NEVER surfaced (no impersonation surface, no anchor-nick).
+  `author` (#299 amendment, model A) prefers the theme's stored `author_nick`
+  snapshot whenever present — the publishing visitor's representative nick,
+  captured at publish time and surviving reap + system re-home (so a re-homed
+  row credits the original nick, NOT "system"). With no snapshot it falls back
+  to the owning user's name (user themes) or the fixed `"guest"` label (legacy
+  / never-published visitor themes). vjt accepted the impersonation caveat: a
+  visitor may publish under any nick they hold. `built_in` stays a pure
+  ownership predicate (system user) — decoupled from `author`.
 
   `in_use` (#299 item 9) is a derived, CONTEXT-SUPPLIED count — how many
   subjects currently have this theme active — passed in by the caller rather
@@ -40,8 +45,9 @@ defmodule Grappa.Themes.Wire do
   alias Grappa.Themes.Theme
   alias Grappa.Visitors.Visitor
 
-  # #299 author model B — the fixed attribution label for a visitor-owned
-  # theme. A closed constant, never a nick.
+  # #299 author model A — the fallback attribution label, used only when a
+  # theme carries no `author_nick` snapshot (legacy / never-published visitor
+  # themes). A closed constant.
   @guest_author "guest"
 
   # The rich viewer subject (as carried in `conn.assigns.current_subject`) is
@@ -63,7 +69,7 @@ defmodule Grappa.Themes.Wire do
           inserted_at: String.t()
         }
 
-  @doc "The fixed author label for a visitor-owned theme (author model B)."
+  @doc "The fallback author label for a snapshot-less visitor theme (author model A)."
   @spec guest_author() :: String.t()
   def guest_author, do: @guest_author
 
@@ -91,13 +97,20 @@ defmodule Grappa.Themes.Wire do
     }
   end
 
-  # User-owned: the user's name; built_in iff the system user. Visitor-owned
-  # (`:user` is nil — XOR guarantees `visitor_id` set): the fixed guest label,
-  # never built_in, NEVER the visitor's nick (author model B).
-  defp attribution(%Theme{user: %User{} = user}),
-    do: {user.name, user.name == Themes.system_user_name()}
+  # #299 author model A: author prefers the stored publish-time nick snapshot
+  # whenever present (so it survives reap + system re-home — a now-system-owned
+  # row still credits the visitor's nick), else the owning user's name, else
+  # the fixed guest label. `built_in` is a pure ownership predicate (system
+  # user), decoupled from `author` — a re-homed row is built_in AND
+  # nick-credited.
+  defp attribution(%Theme{} = theme), do: {author_label(theme), built_in?(theme)}
 
-  defp attribution(%Theme{user: nil}), do: {@guest_author, false}
+  defp author_label(%Theme{author_nick: nick}) when is_binary(nick) and nick != "", do: nick
+  defp author_label(%Theme{user: %User{name: name}}), do: name
+  defp author_label(%Theme{user: nil}), do: @guest_author
+
+  defp built_in?(%Theme{user: %User{name: name}}), do: name == Themes.system_user_name()
+  defp built_in?(%Theme{user: nil}), do: false
 
   # A theme is `mine` for the user OR visitor whose subject FK it carries. The
   # `is_binary` guard prevents a nil FK (the other subject branch) from

--- a/priv/repo/migrations/20260718130000_add_author_nick_to_themes.exs
+++ b/priv/repo/migrations/20260718130000_add_author_nick_to_themes.exs
@@ -1,0 +1,22 @@
+defmodule Grappa.Repo.Migrations.AddAuthorNickToThemes do
+  use Ecto.Migration
+
+  # #299 amendment (author model A) — a NULLABLE snapshot of the publishing
+  # visitor's representative nick, persisted at PUBLISH time so attribution
+  # survives the visitor's reap + system re-home.
+  # `rehome_visitor_published_to_system/1` flips a reaped visitor's PUBLISHED
+  # theme to the `system` owner (visitor_id → nil); without a stored snapshot
+  # the wire author would collapse to "system"/"guest". The snapshot is the
+  # single source the wire prefers whenever present, regardless of current
+  # owner.
+  #
+  # Expand-safe: add-column only — no drop, no rename, no blocking backfill —
+  # so it rides the already-HELD #299 COLD batch. Legacy rows keep NULL: the
+  # wire falls back to the user's name (user themes) or the fixed "guest"
+  # label (pre-amendment visitor themes), so no data change for existing rows.
+  def change do
+    alter table(:themes) do
+      add :author_nick, :string
+    end
+  end
+end

--- a/test/grappa/themes/wire_test.exs
+++ b/test/grappa/themes/wire_test.exs
@@ -3,7 +3,7 @@ defmodule Grappa.Themes.WireTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.{Repo, Themes, Themes.Theme, Themes.TokenModel, Themes.Wire, Visitors.Visitor}
+  alias Grappa.{Accounts.User, Repo, Themes, Themes.Theme, Themes.TokenModel, Themes.Wire, Visitors.Visitor}
 
   defp valid_payload do
     %{
@@ -89,15 +89,79 @@ defmodule Grappa.Themes.WireTest do
     end
   end
 
-  describe "to_wire/3 — visitor-owned (#299 author model B)" do
-    test "author is the fixed guest label (never a nick) and built_in is false" do
+  describe "to_wire/3 — visitor-owned (#299 author model A)" do
+    test "an un-snapshotted visitor theme falls back to the guest label; built_in false" do
+      # author model A snapshots the nick at PUBLISH time; a never-published
+      # (or legacy pre-amendment) visitor theme carries author_nick == nil, so
+      # attribution falls back to the fixed guest label.
       visitor = visitor_fixture()
       {:ok, created} = Themes.create_theme({:visitor, visitor}, %{name: "Guest", payload: valid_payload()})
       {:ok, theme} = Themes.get_theme(created.id)
 
+      assert theme.author_nick == nil
       wire = Wire.to_wire(theme, {:visitor, visitor}, 0)
       assert wire.author == Wire.guest_author()
       assert wire.built_in == false
+    end
+
+    test "prefers the stored author_nick over the guest label" do
+      theme = %Theme{
+        id: 1,
+        name: "V",
+        user: nil,
+        user_id: nil,
+        visitor_id: Ecto.UUID.generate(),
+        author_nick: "alk",
+        payload: valid_payload(),
+        published: true,
+        apply_count: 0,
+        inserted_at: DateTime.utc_now()
+      }
+
+      wire = Wire.to_wire(theme, visitor_subject(), 0)
+      assert wire.author == "alk"
+      assert wire.built_in == false
+    end
+
+    test "author_nick survives re-home: system-owned theme still credits the snapshot nick" do
+      # rehome_visitor_published_to_system/1 flips a reaped visitor's PUBLISHED
+      # theme to the system owner (user set, visitor_id nil). The snapshot must
+      # keep crediting the original author — NOT collapse to "system".
+      theme = %Theme{
+        id: 2,
+        name: "R",
+        user: %User{name: Themes.system_user_name()},
+        user_id: Ecto.UUID.generate(),
+        visitor_id: nil,
+        author_nick: "alk",
+        payload: valid_payload(),
+        published: true,
+        apply_count: 0,
+        inserted_at: DateTime.utc_now()
+      }
+
+      wire = Wire.to_wire(theme, {:user, user_fixture()}, 0)
+      assert wire.author == "alk"
+      # Still system-owned ⇒ still a built-in (house-maintained gallery row),
+      # but attributed to the snapshot nick.
+      assert wire.built_in == true
+    end
+
+    test "a user theme with no snapshot keeps the owner's name" do
+      theme = %Theme{
+        id: 3,
+        name: "U",
+        user: %User{name: "bob"},
+        user_id: Ecto.UUID.generate(),
+        visitor_id: nil,
+        author_nick: nil,
+        payload: valid_payload(),
+        published: false,
+        apply_count: 0,
+        inserted_at: DateTime.utc_now()
+      }
+
+      assert Wire.to_wire(theme, {:user, user_fixture()}, 0).author == "bob"
     end
 
     test "mine is true for the owning visitor, false for other subjects" do

--- a/test/grappa/themes_test.exs
+++ b/test/grappa/themes_test.exs
@@ -4,7 +4,7 @@ defmodule Grappa.ThemesTest do
   import Grappa.AuthFixtures
   import Grappa.UploadFixtures, only: [bytes: 1]
 
-  alias Grappa.{Repo, Themes, Themes.Theme, Themes.TokenModel, Uploads, Visitors.Visitor}
+  alias Grappa.{Networks, Repo, Themes, Themes.Theme, Themes.TokenModel, Themes.Wire, Uploads, Visitors.Visitor}
 
   defp valid_payload do
     %{
@@ -357,6 +357,63 @@ defmodule Grappa.ThemesTest do
       visitor = visitor_fixture()
       {:ok, _} = Themes.create_theme({:visitor, visitor}, %{name: "Priv", payload: valid_payload()})
       assert Themes.rehome_visitor_published_to_system(visitor.id) == 0
+    end
+  end
+
+  describe "author_nick snapshot (#299 amendment — author model A)" do
+    # visitor_fixture(nick: …) provisions the anon (visitor, network)
+    # credential that carries the nick — but only when the slug resolves to a
+    # real `networks` row (see the fixture moduledoc). The publish-path
+    # snapshot reads the visitor's representative (identity-anchor) credential
+    # nick, so the network MUST exist for the nick to be found.
+    setup do
+      {:ok, network} = Networks.find_or_create_network(%{slug: "azzurra"})
+      %{network: network}
+    end
+
+    test "publishing a visitor theme snapshots the visitor's representative nick" do
+      visitor = visitor_fixture(nick: "alk")
+      {:ok, theme} = Themes.create_theme({:visitor, visitor}, %{name: "V", payload: valid_payload()})
+      assert theme.author_nick == nil
+
+      {:ok, published} = Themes.publish_theme({:visitor, visitor}, theme.id)
+      assert published.author_nick == "alk"
+    end
+
+    test "attribution still credits the snapshot nick after re-home to system" do
+      visitor = visitor_fixture(nick: "alk")
+      {:ok, theme} = Themes.create_theme({:visitor, visitor}, %{name: "V", payload: valid_payload()})
+      {:ok, _} = Themes.publish_theme({:visitor, visitor}, theme.id)
+
+      assert Themes.rehome_visitor_published_to_system(visitor.id) == 1
+
+      {:ok, rehomed} = Themes.get_theme(theme.id)
+      assert rehomed.user_id == Themes.system_user().id
+      assert rehomed.visitor_id == nil
+      assert rehomed.author_nick == "alk"
+      assert Wire.to_wire(rehomed, {:user, user_fixture()}, 0).author == "alk"
+    end
+
+    test "publishing a user theme leaves author_nick nil (owner name is the author)" do
+      user = user_fixture(name: "bob")
+      {:ok, theme} = Themes.create_theme({:user, user}, %{name: "U", payload: valid_payload()})
+      {:ok, published} = Themes.publish_theme({:user, user}, theme.id)
+
+      assert published.author_nick == nil
+      assert Wire.to_wire(published, {:user, user}, 0).author == "bob"
+    end
+
+    test "an admin publishing a visitor's theme snapshots the VISITOR's nick, not the admin's" do
+      # The snapshot is keyed off the THEME's visitor_id, NOT the caller
+      # subject — so a moderator publishing someone else's theme credits the
+      # author, never the moderator. Guards against a future "snapshot from
+      # subject" regression (which would pass every owner-publishes-own test).
+      visitor = visitor_fixture(nick: "alk")
+      admin = user_fixture(is_admin: true)
+      {:ok, theme} = Themes.create_theme({:visitor, visitor}, %{name: "V", payload: valid_payload()})
+
+      {:ok, published} = Themes.publish_theme({:user, admin}, theme.id)
+      assert published.author_nick == "alk"
     end
   end
 


### PR DESCRIPTION
Amendment to the #299 themes epic — **author model A** supersedes the
fixed `"guest"` label for visitor-published themes.

## What
A visitor-published theme is now credited to the **publishing visitor's
nick, snapshotted at publish time and persisted** (`themes.author_nick`),
so the attribution survives the visitor being reaped — reaping re-homes a
published visitor theme to the `system` owner, and the snapshot keeps
crediting the original nick instead of collapsing to "system".

## How
- new nullable `themes.author_nick` — expand-safe add-column migration
  (rides the already-HELD #299 COLD batch).
- `set_published/3` snapshots the visitor's representative (identity-anchor)
  credential nick, keyed off the theme's `visitor_id` (so an admin
  publishing another subject's theme still credits the author, not the
  admin). Server-side only — never via `cast/3`, so no client-supplied
  author string.
- `Wire` attribution prefers `author_nick` whenever present, else the
  owner's name, else the `"guest"` fallback. `built_in` is now a pure
  ownership predicate, decoupled from `author`.
- cic renders `theme.author` verbatim — no src change; new e2e proves the
  gallery card shows the nick and it survives reap.

vjt accepted the impersonation caveat (a visitor may publish under any
nick they hold). An editable author label is a separate follow-up.

Deviation from the amendment brief (recorded in DESIGN_NOTES): the nick is
read from the credential anchor, not the Visitor row — the row's nick was
dropped in #211 phase 7.

## Gates
- `check.sh`: 3809 tests / 0 failures, dialyzer 0, credo/sobelow/doctor
  clean, wire-types no drift.
- cic: biome + tsc + vitest (2931) green.
- full `integration.sh`: 428 passed; the one flake (#219 image-viewer
  scroll, unrelated) is green 5/5 in isolation and green on main CI.

Ref #299. Deploy HELD — rides the #299 COLD batch, not shipped solo.