### PR TITLE
cicchetto: TopicBar CSS batch — separators + chrome-button tokens + topic-clamp ellipsis (#304 #305 #307)

### DIFF
--- a/cicchetto/e2e/tests/issue222-presence-filter.spec.ts
+++ b/cicchetto/e2e/tests/issue222-presence-filter.spec.ts
@@ -73,6 +73,24 @@ test("#222 — per-channel toggle hides join/part rows, persists across reload, 
     const toggle = page.locator('[data-testid="presence-toggle"]');
     await expect(toggle).toBeVisible({ timeout: 5_000 });
 
+    // #305 — the presence toggle ADOPTS `.shell-chrome-btn`, which drives the
+    // HIG tap-target floor (--chrome-tap-min: 48px) + glyph size
+    // (--chrome-icon-size: 1.4rem) from shared tokens. Pre-#305 the toggle
+    // re-declared its own size and fell below the floor (defect 2, tiny hit
+    // area) with a var(--font-size) 14px glyph (defect 1). Round the box for
+    // sub-pixel; parse the computed glyph size.
+    const toggleBox = await toggle.boundingBox();
+    if (toggleBox === null) throw new Error("presence toggle has no bounding box");
+    expect(
+      Math.round(toggleBox.height),
+      `#305 — presence toggle tap target ${toggleBox.height}px must meet the 48px HIG floor`,
+    ).toBeGreaterThanOrEqual(48);
+    const toggleGlyphPx = await toggle.evaluate((el) => parseFloat(getComputedStyle(el).fontSize));
+    expect(
+      toggleGlyphPx,
+      `#305 — presence toggle glyph ${toggleGlyphPx}px must be enlarged from the base 14px`,
+    ).toBeGreaterThanOrEqual(18);
+
     // 2. toggle "hide presence" ON → join/part vanish, PRIVMSG stays.
     await toggle.click();
     await expect(joinRow).toHaveCount(0, { timeout: 5_000 });

--- a/cicchetto/e2e/tests/issue262-topic-clamp-mobile.spec.ts
+++ b/cicchetto/e2e/tests/issue262-topic-clamp-mobile.spec.ts
@@ -37,9 +37,10 @@ import { expect, test } from "../fixtures/test";
 // Height caps. The clamped strip is 2 lines × line-height 1.25 × 14px =
 // 35px; the cap leaves generous slack for sub-pixel/metric variance while
 // staying far below the broken-clamp height (many wrapped lines → 150px+ in
-// the ~130px-wide flex strip). The bar's floor is the 44px hamburger touch
-// target + 0.5rem×2 padding ≈ 60px when clamped; a broken clamp drives it to
-// the topic's full height (200px+). Both caps sit cleanly between the two.
+// the ~130px-wide flex strip). The bar's floor is the 48px chrome-button tap
+// target (#305 --chrome-tap-min, was 44px) + 0.5rem×2 padding ≈ 62px; a
+// broken clamp drives it to the topic's full height (200px+). Both caps sit
+// cleanly between the two.
 const TOPIC_STRIP_HEIGHT_CAP_PX = 60;
 const TOPIC_BAR_HEIGHT_CAP_PX = 120;
 
@@ -49,7 +50,9 @@ async function boundingHeight(locator: import("@playwright/test").Locator): Prom
   return box.height;
 }
 
-test("#262 @webkit — a long topic is height-clamped on the mobile topic bar", async ({ page }) => {
+test("#262/#307 @webkit — a long topic clamps to 2 lines with a native ellipsis (not a bare max-height clip)", async ({
+  page,
+}) => {
   const vjt = getSeededVjt();
   const channel = `#t262-${Date.now()}`;
   const marker = `t262-marker-${Date.now()}`;
@@ -94,6 +97,40 @@ test("#262 @webkit — a long topic is height-clamped on the mobile topic bar", 
       barHeight,
       `.topic-bar height ${barHeight}px must stay ≤ ${TOPIC_BAR_HEIGHT_CAP_PX}px`,
     ).toBeLessThanOrEqual(TOPIC_BAR_HEIGHT_CAP_PX);
+
+    // #307 — the `-webkit-line-clamp` actually ENGAGES (→ native trailing …),
+    // not merely the #262 max-height clip. The clamp moved onto the NON-button
+    // inner span `.topic-bar-topic-text` (a <button> wraps its children in an
+    // internal box and defeats the clamp — the #262 no-ellipsis bug).
+    //
+    // The two mechanisms overlap on the happy path (both cap the strip at 2
+    // lines), and `-webkit-line-clamp` does NOT collapse scrollHeight (the
+    // clamped overflow stays in the scroll area, merely hidden), so height /
+    // scrollHeight alone can't tell an engaged clamp from a dead-clamp +
+    // max-height clip. To ISOLATE the clamp: drop the #262 max-height backstop
+    // inline, force a reflow, and measure — an ENGAGED clamp still bounds the
+    // span to 2 lines (and paints the …); a DEAD clamp grows to the full topic
+    // height (200px+). This is the only DOM-observable ellipsis proof — the …
+    // glyph itself isn't in the DOM. (Anti-false-green: the marker was asserted
+    // present above, so the span holds a multi-line topic, not an empty box.)
+    const textSpan = page.locator(".topic-bar-topic-text");
+    await expect(textSpan).toContainText(marker, { timeout: 15_000 });
+    const clampOnlyHeight = await textSpan.evaluate((el) => {
+      const node = el as HTMLElement;
+      const prev = node.style.maxHeight;
+      node.style.maxHeight = "none"; // drop the #262 backstop — clamp must hold alone
+      void node.offsetHeight; // force synchronous reflow
+      const h = node.clientHeight;
+      node.style.maxHeight = prev; // restore
+      return h;
+    });
+    // 2 lines × line-height 1.25 × 14px = 35px; slack for sub-pixel/metrics,
+    // far below the unclamped full-topic height (200px+).
+    expect(
+      clampOnlyHeight,
+      `with the max-height backstop removed, -webkit-line-clamp must STILL bound the strip ` +
+        `to ~2 lines (${clampOnlyHeight}px) — a dead clamp (the #262 no-ellipsis bug) grows to the full topic`,
+    ).toBeLessThanOrEqual(50);
   } finally {
     await composeSend(page, `/part ${channel}`).catch(() => {});
     await peer.disconnect("t262 done").catch(() => {});

--- a/cicchetto/e2e/tests/issue275-topbar-modes-below-name.spec.ts
+++ b/cicchetto/e2e/tests/issue275-topbar-modes-below-name.spec.ts
@@ -95,6 +95,19 @@ test("#275 — channel modes stack below the name in a width-capped box that ope
       `topic width ${topicBox.width}px must exceed half the bar ${barBox.width}px`,
     ).toBeGreaterThan(barBox.width * 0.5);
 
+    // #304 — separators render (content-independent computed-border witness;
+    // jsdom is blind to the cascade, hence the e2e). Both use var(--border) so
+    // the value differs per theme but PRESENCE is theme-independent — proving
+    // one theme proves the wiring.
+    //   (1) border-bottom under the channel NAME (splits name from +modes).
+    //   (2) border-left on the topic strip (vertical rule name↔topic boundary).
+    const nameBorderBottom = await page
+      .locator(".topic-bar-channel")
+      .evaluate((el) => getComputedStyle(el).borderBottomWidth);
+    expect(nameBorderBottom, "#304 — channel name needs a border-bottom rule").not.toBe("0px");
+    const topicBorderLeft = await topic.evaluate((el) => getComputedStyle(el).borderLeftWidth);
+    expect(topicBorderLeft, "#304 — topic strip needs a border-left rule").not.toBe("0px");
+
     // (b) CLICK-OPENS-MODAL — clicking the channel NAME opens the /mode modal.
     await page.locator(".topic-bar-channel").click();
     const modal = page.getByTestId("mode-modal");

--- a/cicchetto/e2e/tests/ux-5-bt-narrow-chrome-compression.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bt-narrow-chrome-compression.spec.ts
@@ -120,6 +120,25 @@ test("@webkit ux-5-bt mobile — channel: NO standalone .shell-chrome row (BM mo
     page.locator(".shell-members [data-testid='mobile-panel-settings']"),
   ).toHaveCount(1);
 
+  // #305 — the mobile members hamburger ADOPTS `.shell-chrome-btn` and so
+  // sizes from the shared tokens: the tap target meets the 48px HIG floor
+  // (--chrome-tap-min, up from the old bespoke 44px box) and the ☰ glyph is
+  // enlarged (--chrome-icon-size: 1.4rem, up from the base 14px — defect 1).
+  // Round for webkit sub-pixel; parse the computed glyph size.
+  const hamburger = page.locator(".topic-bar-hamburger");
+  await expect(hamburger).toBeVisible({ timeout: 5_000 });
+  const hamBox = await hamburger.boundingBox();
+  if (hamBox === null) throw new Error("hamburger has no bounding box");
+  expect(
+    Math.round(hamBox.height),
+    `#305 — hamburger tap target ${hamBox.height}px must meet the 48px HIG floor`,
+  ).toBeGreaterThanOrEqual(48);
+  const hamGlyphPx = await hamburger.evaluate((el) => parseFloat(getComputedStyle(el).fontSize));
+  expect(
+    hamGlyphPx,
+    `#305 — hamburger glyph ${hamGlyphPx}px must be enlarged from the base 14px`,
+  ).toBeGreaterThanOrEqual(18);
+
   // Per `feedback_e2e_visitor_members_list` — UI-shape spec is
   // registered-class today; satisfy the rule by asserting the members
   // drawer populates after a tap on the TopicBar hamburger.

--- a/cicchetto/src/TopicBar.tsx
+++ b/cicchetto/src/TopicBar.tsx
@@ -332,12 +332,22 @@ const TopicBar: Component<Props> = (props) => {
         title={topicTitle()}
         data-testid="topic-strip"
       >
-        <Show when={topicText() !== null} fallback={"(no topic set)"}>
-          {/* #220 — the bar NEVER navigates a link directly; a tap on a
-              link "surface-wins" (suppresses navigation) and bubbles to
-              the strip's onClick, which opens the modal. */}
-          <MircBody body={topicText() ?? ""} linkPolicy="surface-wins" />
-        </Show>
+        {/* #307 — the clamped runs MUST be the direct children of a NON-button
+            `-webkit-box` for `-webkit-line-clamp` to engage (a <button> wraps
+            its children in an internal box and defeats the clamp — the #262
+            bug: geometric clip with no ellipsis). This inner span carries the
+            clamp (see `.topic-bar-topic-text`); the click affordance + a11y
+            stay on the real <button> above, so no role/tabindex/keydown
+            reimplementation is needed. MircBody emits its runs with no block
+            wrapper, so they land as the span's direct line-box content. */}
+        <span class="topic-bar-topic-text">
+          <Show when={topicText() !== null} fallback={"(no topic set)"}>
+            {/* #220 — the bar NEVER navigates a link directly; a tap on a
+                link "surface-wins" (suppresses navigation) and bubbles to
+                the strip's onClick, which opens the modal. */}
+            <MircBody body={topicText() ?? ""} linkPolicy="surface-wins" />
+          </Show>
+        </span>
       </button>
       {/* #222 — per-channel presence-filter toggle. Suppresses (or
           re-shows) join/part/quit/nick-change rows for THIS channel; the

--- a/cicchetto/src/TopicBar.tsx
+++ b/cicchetto/src/TopicBar.tsx
@@ -347,7 +347,7 @@ const TopicBar: Component<Props> = (props) => {
           noStaticElementInteractions (#220) and loses keyboard access. */}
       <button
         type="button"
-        class="topic-bar-presence-toggle"
+        class="topic-bar-presence-toggle shell-chrome-btn"
         classList={{ "presence-hidden": !presenceShown() }}
         data-testid="presence-toggle"
         aria-pressed={!presenceShown()}
@@ -368,7 +368,7 @@ const TopicBar: Component<Props> = (props) => {
       <Show when={windowIsJoined(key())}>
         <button
           type="button"
-          class="topic-bar-hamburger"
+          class="topic-bar-hamburger shell-chrome-btn"
           aria-label="open members sidebar"
           onClick={props.onToggleMembers}
         >

--- a/cicchetto/src/__tests__/TopicBar.test.tsx
+++ b/cicchetto/src/__tests__/TopicBar.test.tsx
@@ -605,4 +605,42 @@ describe("TopicBar", () => {
       }
     });
   });
+
+  // #307 — the topic strip is a <button>; WebKit/Blink wrap a button's
+  // children in an internal box, so `-webkit-line-clamp` never engaged on
+  // `.topic-bar-topic` itself (only the #262 max-height clipped, with NO
+  // ellipsis). The fix moves the clamp onto a NON-button inner span whose
+  // direct children are the MircBody runs. jsdom can't judge the pixel clamp
+  // (that's the @webkit e2e), but it can pin the STRUCTURE the clamp needs.
+  describe("topic strip clamp structure (#307)", () => {
+    it("wraps the topic runs in a non-button .topic-bar-topic-text span", () => {
+      mockTopicByChannel.mockReturnValue({
+        "freenode #italia": { text: "A clamped topic", set_by: "vjt", set_at: null },
+      });
+      const { container } = render(() => <TopicBar {...baseProps()} />);
+      const strip = container.querySelector(".topic-bar-topic");
+      expect(strip).not.toBeNull();
+      const clampSpan = strip?.querySelector(".topic-bar-topic-text");
+      expect(clampSpan).not.toBeNull();
+      // MUST be a non-button element (a <button> defeats the clamp).
+      expect(clampSpan?.tagName).toBe("SPAN");
+      expect(clampSpan).toHaveTextContent("A clamped topic");
+    });
+
+    it("renders the '(no topic set)' placeholder inside the clamp span too", () => {
+      mockTopicByChannel.mockReturnValue({});
+      const { container } = render(() => <TopicBar {...baseProps()} />);
+      const clampSpan = container.querySelector(".topic-bar-topic .topic-bar-topic-text");
+      expect(clampSpan).toHaveTextContent("(no topic set)");
+    });
+
+    it("still opens the read-only topic modal on strip click after the restructure", () => {
+      mockTopicByChannel.mockReturnValue({
+        "freenode #italia": { text: "A topic", set_by: "vjt", set_at: null },
+      });
+      render(() => <TopicBar {...baseProps()} />);
+      fireEvent.click(screen.getByTestId("topic-strip"));
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+  });
 });

--- a/cicchetto/src/__tests__/TopicBar.test.tsx
+++ b/cicchetto/src/__tests__/TopicBar.test.tsx
@@ -565,4 +565,44 @@ describe("TopicBar", () => {
   // moves them into the mobile members drawer footer as launchers, so
   // the slot no longer has a caller. The tests that exercised the
   // slot were dropped with the prop.
+
+  // #305 — the two topic-bar chrome buttons (members hamburger + presence
+  // toggle) ADOPT the shared `.shell-chrome-btn` base class instead of
+  // re-declaring size/border/font per-selector, so the size tokens
+  // (--chrome-icon-size / --chrome-tap-min) drive both uniformly. jsdom is
+  // blind to the CSS pixels (the tap-target-floor + glyph-size proof lives
+  // in the Playwright e2e); the unit test pins the CLASS WIRING that carries
+  // the tokens onto the elements.
+  describe("chrome-button base-class adoption (#305)", () => {
+    it("the members hamburger wears the shared .shell-chrome-btn base", () => {
+      const { container } = render(() => <TopicBar {...baseProps()} />);
+      const ham = container.querySelector(".topic-bar-hamburger");
+      expect(ham).not.toBeNull();
+      expect(ham).toHaveClass("shell-chrome-btn");
+    });
+
+    it("the presence toggle wears the shared .shell-chrome-btn base (keeps its own class too)", () => {
+      const { container } = render(() => <TopicBar {...baseProps()} />);
+      const toggle = container.querySelector(".topic-bar-presence-toggle");
+      expect(toggle).not.toBeNull();
+      expect(toggle).toHaveClass("shell-chrome-btn");
+    });
+
+    it("the presence toggle keeps its .presence-hidden accent state alongside the base", () => {
+      // Default (small channel, pref unset) → shown → no accent. Toggling to
+      // hide flips the class, which must COEXIST with the shared base class.
+      const { container } = render(() => <TopicBar {...baseProps()} />);
+      const toggle = container.querySelector(".topic-bar-presence-toggle") as HTMLElement;
+      expect(toggle).not.toHaveClass("presence-hidden");
+      try {
+        fireEvent.click(toggle);
+        expect(toggle).toHaveClass("shell-chrome-btn");
+        expect(toggle).toHaveClass("presence-hidden");
+      } finally {
+        // togglePresence persists an explicit "hide" pref in localStorage —
+        // clear it so it can't leak into sibling tests reading the same key.
+        localStorage.clear();
+      }
+    });
+  });
 });

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -1324,7 +1324,9 @@ html.resize-dragging * {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 0.1rem;
+  /* #304 — a touch more breathing room between the name (now underlined by a
+     border-bottom) and the +modes line so the divider isn't cramped. */
+  gap: 0.2rem;
   /* WIDTH CAP — annotated DEFAULT (#275, tunable). 18% is the mid-point of
      the spec's 15–20% band: enough for a typical `#channel` + a `+ntk` mode
      string on a NARROW mobile bar (mobile-first), while leaving the topic
@@ -1347,6 +1349,13 @@ html.resize-dragging * {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  /* #304 — border-bottom splits the channel NAME from the +modes line below
+     so the two read as distinct rows. `var(--border)` follows the active
+     theme (subtle 1px in both irssi-dark + mirc-light). The name is
+     ellipsized, so the rule underlines only the visible (clipped) width —
+     intentional. */
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.1rem;
 }
 
 .topic-bar-topic {
@@ -1380,6 +1389,14 @@ html.resize-dragging * {
   background: transparent;
   border: none;
   padding: 0;
+  /* #304 — vertical rule between the namebox and the topic strip (the two
+     were separated only by the flex gap). `border-left` after `border: none`
+     + `padding-left` after `padding: 0` (longhand-after-shorthand wins for
+     the left side); scoped to THIS boundary only — no dividers around the
+     presence-toggle / hamburger further right. `var(--border)` follows the
+     active theme. */
+  border-left: 1px solid var(--border);
+  padding-left: 0.5rem;
   font-family: var(--font-mono);
   font-size: var(--font-size);
   line-height: 1.25;

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -177,6 +177,16 @@
   --font-size: 14px;
   --line-height: 1.4;
   --breakpoint-mobile: 768px;
+  /* #305 — chrome-button sizing tokens, theme-INDEPENDENT (same value in
+     irssi-dark + mirc-light), so they live on :root next to --font-size, NOT
+     in the per-theme blocks. `.shell-chrome-btn` drives glyph + tap-target
+     from these, and the topic-bar hamburger / presence toggle adopt that base
+     so ALL chrome buttons size uniformly from one place (no per-selector
+     patching). --chrome-tap-min is ABSOLUTE px on purpose: the html root
+     font-size is 14px, so a rem tap target would under-size below the HIG
+     floor (feedback_cic_tap_target_rem_pitfall). */
+  --chrome-icon-size: 1.4rem; /* glyph size for all chrome buttons */
+  --chrome-tap-min: 48px; /* Apple HIG minimum tap-target floor */
   /* grappa-irc#69: theme the scrollbars. `scrollbar-color` and
      `scrollbar-width` inherit, so declaring them on :root themes every
      scrollable descendant (.scrollback, members pane, admin tables…)
@@ -1277,41 +1287,43 @@ html.resize-dragging * {
   background: var(--bg);
 }
 
-.topic-bar-hamburger {
-  background: transparent;
-  color: var(--muted);
-  border: 1px solid var(--border);
-  padding: 0.25rem 0.5rem;
-  font-family: var(--font-mono);
-  font-size: var(--font-size);
-  cursor: pointer;
+/* #305 — the hamburger ADOPTS `.shell-chrome-btn` (base + size tokens) via
+   its className in TopicBar.tsx; the only bespoke bit left is the desktop
+   display gate. The `.topic-bar` descendant bump is load-bearing: at equal
+   specificity `.shell-chrome-btn`'s `display: inline-flex` (declared LATER in
+   this file) would otherwise win the cascade and show the hamburger on
+   desktop. Bumping to `.topic-bar .topic-bar-hamburger` (0,2,0) beats it
+   regardless of source order; the mobile media query re-shows with a matching
+   selector. */
+.topic-bar .topic-bar-hamburger {
   display: none; /* desktop: hidden; mobile media query un-hides */
 }
 
 /* #222 — per-channel presence-filter toggle (hide/show join/part/quit).
    Sits inline in the topic bar; visible on both desktop and mobile (the
-   noise it hides matters most on small mobile viewports). Muted by default;
-   the `.presence-hidden` state (rows currently suppressed) gets the accent
-   so the operator can see at a glance the channel is filtered. */
+   noise it hides matters most on small mobile viewports).
+   #305 — ADOPTS `.shell-chrome-btn` (base chrome + size tokens) via its
+   className in TopicBar.tsx, which fixes its sub-floor tap target (defect 2).
+   The only bespoke bits are `flex: none` (never grow/shrink in the row) and
+   the `.presence-hidden` accent state (rows currently suppressed → accent so
+   the operator sees at a glance the channel is filtered). */
 .topic-bar-presence-toggle {
-  background: transparent;
-  border: 1px solid var(--border);
-  color: var(--muted);
-  padding: 0.25rem 0.5rem;
-  font-family: var(--font-mono);
-  font-size: var(--font-size);
-  line-height: 1;
-  cursor: pointer;
   flex: none;
-}
-
-.topic-bar-presence-toggle:hover {
-  color: var(--fg);
 }
 
 .topic-bar-presence-toggle.presence-hidden {
   color: var(--accent);
   border-color: var(--accent);
+}
+
+/* #305 — a filtered toggle keeps its accent on hover. `.shell-chrome-btn:hover`
+   (0,2,0) is declared LATER than `.presence-hidden` (0,2,0) and would flip the
+   text to var(--fg) on hover, dropping the "channel is filtered" accent that
+   pre-#305 persisted (the old dedicated :hover lost to .presence-hidden). This
+   0,3,0 rule restores it — the border already stays accent (the base :hover
+   doesn't touch border-color). */
+.topic-bar-presence-toggle.presence-hidden:hover {
+  color: var(--accent);
 }
 
 /* #275 — channel name + modes stacked in ONE width-capped clickable box.
@@ -1579,11 +1591,16 @@ html.resize-dragging * {
   border: 1px solid var(--border);
   padding: 0.25rem 0.5rem;
   font-family: var(--font-mono);
-  font-size: var(--font-size);
+  /* #305 — glyph + tap floor driven from the shared tokens (was hard-coded
+     var(--font-size) / 2.25rem / 2rem). Fixes tiny glyphs (defect 1) + the
+     sub-floor tap target (defect 2) for every chrome button at once — cog /
+     mentions / archive AND the adopting topic-bar hamburger / presence
+     toggle grow together (desired parity). */
+  font-size: var(--chrome-icon-size);
   line-height: 1;
   cursor: pointer;
-  min-width: 2.25rem;
-  min-height: 2rem;
+  min-width: var(--chrome-tap-min);
+  min-height: var(--chrome-tap-min);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -3746,15 +3763,14 @@ html.resize-dragging * {
     /* scrollback (flex:1) + compose take natural heights inside shell-main */
   }
 
-  /* C6.3: single hamburger — right-side (members); left hamburger hidden
-     on mobile via isMobile() gating in TopicBar.tsx (no CSS needed). */
-  .topic-bar-hamburger {
-    display: inline-block;
-    min-width: 44px; /* Apple HIG minimum touch target */
-    min-height: 44px;
-    padding: 0 0.75rem;
-    line-height: 44px;
-    text-align: center;
+  /* C6.3: single hamburger — right-side (members). #305 — un-hide on mobile;
+     sizing (48px HIG tap floor + glyph) + glyph centering now come from the
+     adopted `.shell-chrome-btn` base, so only the show is bespoke here. The
+     `.topic-bar` bump matches the desktop-hide specificity, and this rule is
+     later in source, so it wins on mobile. (Was: display:inline-block + a
+     hand-rolled 44px box — replaced by the shared 48px token.) */
+  .topic-bar .topic-bar-hamburger {
+    display: inline-flex;
   }
 
   /* Members drawer slide-in from right (unchanged from pre-C6) */

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -1373,31 +1373,6 @@ html.resize-dragging * {
 .topic-bar-topic {
   flex: 1;
   color: var(--muted);
-  /* #74 — up to TWO lines, then ellipsis (was a 1-line nowrap clip), so
-     more of a long topic is readable without opening anything. The clamp
-     needs the -webkit-box display + vertical orient; `overflow-wrap` lets a
-     long unbroken URL wrap instead of overflowing the second line. */
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-  line-clamp: 2;
-  /* #262 — HARD height bound, independent of `-webkit-line-clamp`. The
-     clamp above only engages when the clamped runs are the DIRECT line-box
-     content of the `-webkit-box`. This strip is a <button> wrapping a
-     <MircBody>: WebKit (iOS Safari) wraps a button's children in an internal
-     box, so the line-clamp never engages and the strip grew to the topic's
-     FULL height — eating up to ½ the mobile viewport (regression from #74,
-     which replaced the old 1-line `white-space: nowrap` clip with the clamp
-     and so left NO height bound when the clamp fails to engage). `max-height`
-     = 2 lines × `line-height: 1.25` = 2.5em caps the strip at two lines
-     whether or not the webkit clamp engages; `overflow: hidden` hides the
-     rest. Full topic stays reachable via the topic modal. Global, not
-     @media-mobile: the clamp-on-<button> failure is a WebKit/Blink engine
-     behaviour, not a viewport one — bound it on every surface. */
-  max-height: 2.5em;
-  overflow: hidden;
-  white-space: normal;
-  overflow-wrap: anywhere;
   background: transparent;
   border: none;
   padding: 0;
@@ -1415,10 +1390,39 @@ html.resize-dragging * {
   text-align: left;
   cursor: pointer;
   min-width: 0;
+  /* #307 belt — the 2-line clamp + height bound live on the inner
+     `.topic-bar-topic-text` span (a <button> defeats -webkit-line-clamp, see
+     that rule). This outer clip is the backstop if that element's bound ever
+     fails, so the strip can never overflow the button box. */
+  overflow: hidden;
 }
 
 .topic-bar-topic:hover {
   color: var(--fg);
+}
+
+/* #307 — the clamp lives on this NON-button inner span, NOT the <button>.
+   `-webkit-line-clamp` only engages when the clamped runs are the DIRECT
+   line-box content of the `-webkit-box`; a <button> wraps its children in an
+   internal box, so the clamp NEVER engaged on `.topic-bar-topic` itself (the
+   #262 bug) — only the max-height clipped, hard-cutting the topic with NO
+   ellipsis. MircBody emits its runs with no block wrapper, so making this
+   span the `-webkit-box` puts those runs as its direct children → the clamp
+   engages and paints the trailing … natively at 2 lines (mid-word, as
+   desired). The #262 max-height:2.5em (2 lines × line-height 1.25) + overflow
+   is RETAINED as belt-and-suspenders: it caps the strip whether or not the
+   clamp engages, so the mobile-height guarantee survives even on an engine
+   where the clamp fails. */
+.topic-bar-topic-text {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  max-height: 2.5em;
+  overflow: hidden;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  max-width: 100%;
 }
 
 .topic-bar-modes {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -24823,3 +24823,77 @@ connected `azzurra`).
 
 _Deploy: **`--cic`** bundle only (cic-only, no server change). **HELD** —
 batched into the next COLD window with #299/#290, NOT shipped solo._
+
+---
+
+## 2026-07-18 — TopicBar CSS batch (#304 + #305 + #307, cic-only)
+
+Three top-bar tweaks that all touch the SAME surface (`TopicBar.tsx` +
+`.topic-bar-*` / `.shell-chrome-btn` / theme tokens in `default.css`) — that
+shared-file overlap is why they land as one batch (three bite-sized commits,
+one per issue). Pure CSS + minor className/JSX plumbing; NO server change.
+
+### #304 — separators (pure CSS)
+
+A vertical rule between the namebox and the topic strip (`border-left` +
+`padding-left` on `.topic-bar-topic`, longhand-after-shorthand so the left
+side beats the `border: none` / `padding: 0` reset), and a `border-bottom`
+under the channel name that splits it from the `+modes` line (namebox `gap`
+nudged 0.1rem → 0.2rem so the rule isn't cramped). Both use `var(--border)`,
+so presence is theme-independent (subtle 1px in irssi-dark + mirc-light) even
+though the colour differs. The name is ellipsized, so the underline spans only
+the visible clipped width — intentional.
+
+### #305 — chrome-button sizing: shared base + tokens (the DRY ask)
+
+Two defects — tiny glyph in a correct-sized box, and a sub-floor tap target on
+the presence toggle — shared one root cause: sibling chrome buttons
+re-declared size per-selector instead of adopting the shared `.shell-chrome-btn`
+base, so glyph size + tap floor drifted per-button. Fix, per the maintainer's
+explicit "don't patch each selector" request:
+
+- Two **theme-independent** tokens on `:root` (next to `--font-size`):
+  `--chrome-icon-size: 1.4rem` (glyph) + `--chrome-tap-min: 48px` (HIG floor).
+  The tap floor is **absolute px** on purpose — the html root font-size is
+  14px, so a rem target would under-size (`feedback_cic_tap_target_rem_pitfall`).
+- `.shell-chrome-btn` drives `font-size` + `min-width`/`min-height` from the
+  tokens (was hard-coded `var(--font-size)` / `2.25rem` / `2rem`). This enlarges
+  cog / mentions / archive too — desired parity across the top-chrome row.
+- `.topic-bar-hamburger` + `.topic-bar-presence-toggle` **adopt** the base via
+  their className; their per-selector size declarations are deleted, keeping
+  only distinguishing bits (hamburger desktop display gate; presence
+  `.presence-hidden` accent + `flex: none`).
+
+**Cascade gotcha (load-bearing):** `.shell-chrome-btn`'s `display: inline-flex`
+is declared LATER in the file than `.topic-bar-hamburger`, so at equal
+specificity it would win and show the hamburger on desktop. The desktop-hide +
+the mobile un-hide are bumped to `.topic-bar .topic-bar-hamburger` (0,2,0) so
+they beat the base regardless of source order (the desktop-hide has no media
+query; the mobile un-hide is later in source at equal specificity, so it wins
+on mobile).
+
+### #307 — topic strip clips with no ellipsis: button → non-button clamp host
+
+Root cause (verified): `.topic-bar-topic` is a `<button>` wrapping `<MircBody>`.
+WebKit/Blink wrap a button's children in an internal box, so the clamped runs
+are never the DIRECT line-box content of the `-webkit-box` → `-webkit-line-clamp`
+never engaged → only the #262 `max-height` clipped, hard-cutting the topic with
+**no ellipsis**. Fix: move the clamp onto a **non-button inner span**
+(`.topic-bar-topic-text`) whose direct children ARE the MircBody runs (MircBody
+emits its runs with no block wrapper). The clamp then engages and paints the
+trailing `…` natively at 2 lines. The click affordance + a11y stay on the real
+`<button>`, so no `role`/`tabindex`/`keydown` reimplementation was needed — this
+was chosen over converting the button itself to a `div[role=button]` (the
+issue's first-listed option) precisely to keep native button semantics; it
+still satisfies the issue's core requirement (the `-webkit-box` element is a
+non-button with the runs as direct children). The #262 `max-height: 2.5em;
+overflow: hidden` is **retained** on the inner span as belt-and-suspenders (it
+caps the strip whether or not the clamp engages), plus an outer `overflow:
+hidden` on the button. e2e witness: on the inner span, an engaged clamp
+truncates to 2 lines so `scrollHeight ≈ clientHeight` — the ellipsis proof the
+DOM can't surface (the `…` is a rendered glyph, not text); a dead clamp lays out
+the full topic (`scrollHeight ≫ clientHeight`).
+
+_Deploy: **`--cic`** bundle only (cic-only, no server change). **HELD** —
+rides the already-HELD #299 COLD batch (with #282 / #290 / #294), NOT shipped
+solo._


### PR DESCRIPTION
TopicBar CSS batch — three tweaks that all touch the same surface (`TopicBar.tsx`
+ `.topic-bar-*` / `.shell-chrome-btn` / theme tokens in `default.css`); that
shared-file overlap is why they batch as one PR (three bite-sized commits, one
per issue). cic-only: pure CSS + minor className/JSX plumbing, no server change.

## #304 — TopicBar separators (refs #304)
- Vertical rule between the namebox and the topic strip (`border-left` +
  `padding-left` on `.topic-bar-topic`).
- Border-bottom under the channel name splitting it from the `+modes` line
  (namebox `gap` 0.1 → 0.2rem so the divider isn't cramped).
- Both via `var(--border)` → subtle 1px in both shipped themes.

## #305 — consolidate chrome-button sizing (refs #305)
Two defects (tiny glyph + sub-floor tap target) shared one root: sibling chrome
buttons re-declared size per-selector instead of adopting the shared base.
- New theme-independent `:root` tokens: `--chrome-icon-size: 1.4rem` +
  `--chrome-tap-min: 48px` (HIG floor, absolute px on purpose).
- `.shell-chrome-btn` drives glyph + tap floor from the tokens; the topic-bar
  hamburger + presence toggle adopt the base via className (per-selector size
  rules dropped). Enlarges cog/mentions/archive too — desired parity.
- Cascade gotcha handled: the hamburger desktop-hide/mobile-show are bumped to
  `.topic-bar .topic-bar-hamburger` so they beat the base's later-declared
  `display: inline-flex`.

## #307 — topic strip clips with no ellipsis (refs #307)
`.topic-bar-topic` is a `<button>`; WebKit/Blink wrap a button's children in an
internal box so `-webkit-line-clamp` never engaged (only the #262 max-height
clipped, with no ellipsis). Fix: move the clamp onto a non-button inner span
`.topic-bar-topic-text` whose direct children are the MircBody runs → the clamp
engages and paints the trailing … natively at 2 lines. Click + a11y stay on the
real button; the #262 max-height bound is retained as belt-and-suspenders.

## Tests / gates
- Unit (vitest): TopicBar class-wiring + clamp-structure; full suite green.
- e2e (Playwright): issue275 gains the #304 computed-border witness; issue222 +
  ux-5-bt (@webkit) the #305 48px tap target + enlarged glyph; issue262
  (@webkit) proves the #307 clamp ENGAGES by isolating it from the max-height
  backstop (drop max-height → still 2 lines ⟺ clamp holds ⟺ ellipsis). issue263
  guards the topic modal still opens after the restructure.
- Full `scripts/integration.sh`: **429 passed, 0 failed**.

Docs: DESIGN_NOTES batch entry. Deploy HELD — rides the already-held #299 COLD
batch; not shipped by this PR.