### PR TITLE
cicchetto: mobile float buttons — lower opacity + kill sticky :hover latch (#302)

### DIFF
--- a/cicchetto/e2e/tests/issue289-float-btn-opacity.spec.ts
+++ b/cicchetto/e2e/tests/issue289-float-btn-opacity.spec.ts
@@ -54,11 +54,27 @@ const NEXT_ACTIVE_COUNT = '[data-testid="next-active-btn"] .next-active-count';
 const OPAQUE = 1;
 const TAPPABLE_FLOOR = 0.4;
 
+// #302 — 0.75 (the #289 value) was still too opaque: wrapped text behind
+// the buttons stayed hard to read. Lowered to 0.5. This ceiling makes the
+// LOWERING itself a RED→GREEN witness: #289's `< OPAQUE` band stays green
+// at 0.75, so it never catches a regression back up toward opaque. 0.75 >
+// 0.6 (RED on the old value); 0.5 <= 0.6 (GREEN on the new one). Sits
+// comfortably above TAPPABLE_FLOOR so the pair is still clearly tappable.
+const TRANSLUCENT_CEIL = 0.6;
+
 async function opacityOf(page: Page, selector: string): Promise<number> {
   return await page.evaluate((sel) => {
     const el = document.querySelector(sel) as HTMLElement | null;
     if (!el) return -1;
     return parseFloat(getComputedStyle(el).opacity);
+  }, selector);
+}
+
+async function backgroundOf(page: Page, selector: string): Promise<string> {
+  return await page.evaluate((sel) => {
+    const el = document.querySelector(sel) as HTMLElement | null;
+    if (!el) return "";
+    return getComputedStyle(el).backgroundColor;
   }, selector);
 }
 
@@ -102,8 +118,56 @@ async function scrollChannelUp(page: Page): Promise<void> {
   await expect(page.locator(SCROLL_TO_BOTTOM)).toBeVisible({ timeout: 5_000 });
 }
 
-// The read cursor is server-owned + persists across page loads; this test
-// leaves CHANNEL + the background channel unread. Restore to tail so a
+// Surface BOTH floating buttons at once (mirrors #280 test-1): scroll-to-
+// bottom needs a scrolled-up window we STAY on; next-active needs a
+// DIFFERENT window with unread (a focused window marks itself read on
+// arrival), so the unread lives in a background channel while we sit on
+// CHANNEL scrolled up. Returns the peer + bg channel so the caller's
+// `finally` can tear them down. Shared by the #289 opacity test and the
+// #302 hover-latch test — one setup, two contracts.
+async function surfaceBothFloatButtons(
+  page: Page,
+): Promise<{ peer: IrcPeer; bgChannel: string }> {
+  const vjt = getSeededVjt();
+  const peerNick = `t289-${Date.now() % 100000}`;
+  const bgChannel = "#t289op";
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  const peer = await IrcPeer.connect({ nick: peerNick });
+  await peer.join(bgChannel);
+  await composeTextarea(page).fill(`/join ${bgChannel}`);
+  await composeTextarea(page).press("Enter");
+  await selectChannel(page, NETWORK_SLUG, bgChannel, { ownNick: NETWORK_NICK });
+
+  // Back to CHANNEL and scroll UP → scroll-to-bottom shows and the pane
+  // stays far from the tail (background arrivals will NOT auto-follow).
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+  await scrollChannelUp(page);
+
+  // Background traffic → bgChannel unread → next-active mounts (count "1"),
+  // without touching CHANNEL's scroll or focus.
+  const line = "289 opacity traffic";
+  peer.privmsg(bgChannel, line);
+  await assertMessagePersisted({
+    token: vjt.token,
+    networkSlug: NETWORK_SLUG,
+    channel: bgChannel,
+    sender: peerNick,
+    body: line,
+  });
+
+  // Anti-false-green: BOTH affordances present + visible before any style
+  // is read.
+  await expect(page.locator(NEXT_ACTIVE_COUNT)).toHaveText("1", { timeout: 10_000 });
+  await expect(page.locator(NEXT_ACTIVE_BTN)).toBeVisible();
+  await expect(page.locator(SCROLL_TO_BOTTOM)).toBeVisible();
+
+  return { peer, bgChannel };
+}
+
+// The read cursor is server-owned + persists across page loads; these
+// tests leave CHANNEL + the background channel unread. Restore to tail so a
 // later spec that assumes a clean cursor / exact next-active count is not
 // poisoned (cascade-poisoner discipline — mirror #280 / #243).
 test.afterEach(async () => {
@@ -116,47 +180,8 @@ test.describe("#289 — mobile floating buttons are translucent (text shows thro
     page,
   }) => {
     const vjt = getSeededVjt();
-    const peerNick = `t289-${Date.now() % 100000}`;
-    const bgChannel = "#t289op";
-    await loginAs(page, vjt);
-
-    // Surface BOTH buttons at once (mirrors #280 test-1): scroll-to-bottom
-    // needs a scrolled-up window we STAY on; next-active needs a DIFFERENT
-    // window with unread (a focused window marks itself read on arrival),
-    // so the unread lives in a background channel while we sit on CHANNEL
-    // scrolled up.
-    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
-
-    const peer = await IrcPeer.connect({ nick: peerNick });
+    const { peer, bgChannel } = await surfaceBothFloatButtons(page);
     try {
-      await peer.join(bgChannel);
-      await composeTextarea(page).fill(`/join ${bgChannel}`);
-      await composeTextarea(page).press("Enter");
-      await selectChannel(page, NETWORK_SLUG, bgChannel, { ownNick: NETWORK_NICK });
-
-      // Back to CHANNEL and scroll UP → scroll-to-bottom shows and the pane
-      // stays far from the tail (background arrivals will NOT auto-follow).
-      await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
-      await scrollChannelUp(page);
-
-      // Background traffic → bgChannel unread → next-active mounts (count
-      // "1"), without touching CHANNEL's scroll or focus.
-      const line = "289 opacity traffic";
-      peer.privmsg(bgChannel, line);
-      await assertMessagePersisted({
-        token: vjt.token,
-        networkSlug: NETWORK_SLUG,
-        channel: bgChannel,
-        sender: peerNick,
-        body: line,
-      });
-
-      // Anti-false-green: BOTH affordances present + visible before any
-      // opacity is read.
-      await expect(page.locator(NEXT_ACTIVE_COUNT)).toHaveText("1", { timeout: 10_000 });
-      await expect(page.locator(NEXT_ACTIVE_BTN)).toBeVisible();
-      await expect(page.locator(SCROLL_TO_BOTTOM)).toBeVisible();
-
       // ── The fix: both mobile floating buttons are translucent. ──────
       const naOpacity = await opacityOf(page, NEXT_ACTIVE_BTN);
       const sbOpacity = await opacityOf(page, SCROLL_TO_BOTTOM);
@@ -178,8 +203,82 @@ test.describe("#289 — mobile floating buttons are translucent (text shows thro
         sbOpacity,
         `scroll-to-bottom must stay clearly tappable (>= ${TAPPABLE_FLOOR}) — got ${sbOpacity}`,
       ).toBeGreaterThanOrEqual(TAPPABLE_FLOOR);
+
+      // ── #302: the pair is now MORE translucent (<= 0.6, was 0.75). ──
+      // A ceiling, not the floor, is what witnesses the lowering — the
+      // #289 `< OPAQUE` band alone stays green at 0.75.
+      expect(
+        naOpacity,
+        `#302: next-active must be MORE translucent (<= ${TRANSLUCENT_CEIL}) — got ${naOpacity}`,
+      ).toBeLessThanOrEqual(TRANSLUCENT_CEIL);
+      expect(
+        sbOpacity,
+        `#302: scroll-to-bottom must be MORE translucent (<= ${TRANSLUCENT_CEIL}) — got ${sbOpacity}`,
+      ).toBeLessThanOrEqual(TRANSLUCENT_CEIL);
     } finally {
       await peer.disconnect("289 opacity done").catch(() => {});
+      await partChannel(vjt.token, NETWORK_SLUG, bgChannel).catch(() => {});
+    }
+  });
+});
+
+// #302 — the same mobile float-stack pair had a second problem: after a
+// TAP the accent-fill "selected" look latched on release. Root cause is
+// the classic mobile sticky-`:hover` — touch has no real hover, so a
+// tapped `:hover` state sticks until you tap elsewhere. Both buttons
+// invert on `:hover` (next-active → accent fill; scroll-to-bottom →
+// brighter 0.85 opacity). The fix gates those `:hover` rules behind
+// `@media (hover: hover)` and drives the press feedback off `:active`, so a
+// hover-less pointer can NEVER latch the "selected" look.
+//
+// Witness (CSS contract, systematic-debugging): this is the touch project
+// (`webkit-iphone-15`), which emulates a hover-less pointer. Playwright
+// moves a virtual mouse over the element on `.hover()` → `:hover` matches
+// in the engine, standing in for the sticky post-tap hover on a real
+// device. On CURRENT code the ungated `:hover` inverts the fill even on a
+// hover-less pointer (RED); after the fix the `@media (hover: hover)` gate
+// keeps the fill at base (GREEN). The precondition `matchMedia(hover:none)`
+// is asserted first — if the project did NOT emulate a hover-less pointer
+// this contract could not witness the fix.
+test.describe("#302 — mobile float buttons don't latch :hover 'selected' after tap", () => {
+  test("@webkit — hover-less pointer keeps next-active + scroll-to-bottom at base (no latch)", async ({
+    page,
+  }) => {
+    const vjt = getSeededVjt();
+    const { peer, bgChannel } = await surfaceBothFloatButtons(page);
+    try {
+      // Precondition: this project emulates a hover-less (touch) pointer —
+      // the whole bug is that such a pointer must never latch `:hover`.
+      const hoverNone = await page.evaluate(
+        () => window.matchMedia("(hover: none)").matches,
+      );
+      expect(
+        hoverNone,
+        "webkit-iphone-15 must emulate a hover-less pointer for this contract to witness the fix",
+      ).toBe(true);
+
+      // next-active: base = bg-alt fill / accent text. The bug: `:hover`
+      // inverts to an ACCENT fill ("selected") and latches on touch.
+      const naBase = await backgroundOf(page, NEXT_ACTIVE_BTN);
+      await page.locator(NEXT_ACTIVE_BTN).hover();
+      const naHovered = await backgroundOf(page, NEXT_ACTIVE_BTN);
+      expect(
+        naHovered,
+        `#302: next-active must NOT latch the accent 'selected' fill on a hover-less pointer (base ${naBase}, hovered ${naHovered})`,
+      ).toBe(naBase);
+
+      // scroll-to-bottom: base opacity 0.5 on mobile. The bug: `:hover`
+      // brightens to 0.85 and latches. On a hover-less pointer it must stay
+      // at base.
+      const sbBase = await opacityOf(page, SCROLL_TO_BOTTOM);
+      await page.locator(SCROLL_TO_BOTTOM).hover();
+      const sbHovered = await opacityOf(page, SCROLL_TO_BOTTOM);
+      expect(
+        sbHovered,
+        `#302: scroll-to-bottom must NOT brighten-latch on a hover-less pointer (base ${sbBase}, hovered ${sbHovered})`,
+      ).toBeCloseTo(sbBase, 2);
+    } finally {
+      await peer.disconnect("302 hover done").catch(() => {});
       await partChannel(vjt.token, NETWORK_SLUG, bgChannel).catch(() => {});
     }
   });

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2104,11 +2104,15 @@ html.resize-dragging * {
    and theme-agnostic — whole-element opacity needs no per-theme
    translucent color. Scoped to `.shell-mobile` + the stack: desktop
    scroll-to-bottom stays opaque (it's smaller and next-active is a
-   sidebar button there, not a floating overlay). Higher specificity than
-   `.scroll-to-bottom-btn:hover` (0.85), so a stray mobile hover can't
-   make it MORE opaque than this. */
+   sidebar button there, not a floating overlay).
+
+   #302 — 0.75 was still too opaque; text behind stayed hard to read.
+   Lowered to 0.5 (translucent-yet-tappable, tuned on a mobile viewport).
+   The `.scroll-to-bottom-btn:hover` brighten (0.85) that used to fight
+   this on a stuck mobile hover is now gated behind `@media (hover: hover)`
+   (below), so a hover-less pointer never overrides this base. */
 .shell-mobile .scrollback-float-stack > * {
-  opacity: 0.75;
+  opacity: 0.5;
 }
 
 /* C7.4: Scroll-to-bottom button. Now an in-flow child of the float stack
@@ -2145,8 +2149,22 @@ html.resize-dragging * {
   font-size: 1.75rem;
 }
 
-.scroll-to-bottom-btn:hover {
+/* #302 — press feedback via `:active` (brighten only WHILE the finger is
+   down), not `:hover`. Touch has no real hover, so a bare
+   `.scroll-to-bottom-btn:hover` latched the 0.85 "brighter" look after tap
+   (read as stuck-selected). `:active` clears on release. The hover-brighten
+   is kept for true-hover pointers (mouse/trackpad) but gated behind
+   `@media (hover: hover)` so a hover-less pointer never latches it. Mirrors
+   the `.mentions-row:active` + `.member-name:hover @media(hover:hover)`
+   idioms already in this file. */
+.scroll-to-bottom-btn:active {
   opacity: 0.85;
+}
+
+@media (hover: hover) {
+  .scroll-to-bottom-btn:hover {
+    opacity: 0.85;
+  }
 }
 
 /* ComposeBox */
@@ -7226,9 +7244,22 @@ audio.media-viewer-media {
   padding: 0.25rem 0.6rem;
 }
 
-.next-active-btn:hover {
+/* #302 — the accent-fill "selected" look on tap must clear on release.
+   Touch has no real hover, so a bare `:hover` latched the accent fill after
+   tap (read as stuck-selected). Drive the press feedback off `:active`
+   (fill only WHILE the finger is down) and gate the hover-invert behind
+   `@media (hover: hover)` so a hover-less pointer never latches it. Mirrors
+   `.mentions-row:active` + `.member-name:hover @media(hover:hover)`. */
+.next-active-btn:active {
   background: var(--accent);
   color: var(--bg);
+}
+
+@media (hover: hover) {
+  .next-active-btn:hover {
+    background: var(--accent);
+    color: var(--bg);
+  }
 }
 
 .next-active-glyph {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -24897,3 +24897,48 @@ the full topic (`scrollHeight ≫ clientHeight`).
 _Deploy: **`--cic`** bundle only (cic-only, no server change). **HELD** —
 rides the already-HELD #299 COLD batch (with #282 / #290 / #294), NOT shipped
 solo._
+
+### 2026-07-18 — #302: mobile float-stack buttons — lower opacity + kill sticky-`:hover` latch
+
+The mobile float-stack button pair (`scroll-to-bottom` + `next-active`,
+`NextActiveButton` variant `"mobile"`) got two pure-CSS fixes on
+`src/themes/default.css`.
+
+**Item 1 — opacity.** #289 dropped the pair to `opacity: 0.75` on the single
+stack-child rule `.shell-mobile .scrollback-float-stack > *`; #302 lowers it
+to **`0.5`**. 0.75 was still too opaque and wrapped message text behind the
+buttons stayed hard to read. Kept on the ONE stack-child rule so the pair
+stays consistent by construction (#280 "same box") — never split per-button.
+`0.5` sits comfortably above the e2e's `TAPPABLE_FLOOR` (0.4), so the pair is
+still clearly tappable.
+
+**Item 2 — sticky-`:hover` "selected" latch.** Both buttons inverted to the
+accent look on `:hover` (`.next-active-btn:hover` → accent fill;
+`.scroll-to-bottom-btn:hover` → brighten to `opacity: 0.85`). Touch has no
+real hover, so after a TAP the `:hover` state latched on release and read as
+"still selected". Fix mirrors the file's existing idioms
+(`.mentions-row:active`, `.member-name:hover` inside `@media (hover: hover)`):
+drive the press feedback off **`:active`** (paints only WHILE the finger is
+down, clears on release) and gate the `:hover` invert behind
+**`@media (hover: hover)`** so a hover-less pointer never latches it.
+True-hover pointers (mouse/trackpad) keep the hover feedback; desktop
+scroll-to-bottom (base `opacity: 1`, hover `0.85`) is unchanged.
+
+**e2e witness path (systematic-debugging).** The webkit-iphone-15 Playwright
+project DOES emulate a hover-less pointer (`matchMedia('(hover: none)')` =
+`true`, asserted as a precondition) AND `.hover()` moves a virtual mouse that
+triggers the `:hover` pseudo-class — so this is a REAL RED→GREEN witness, not
+the CSS-contract fallback the issue-brief allowed for. RED on current code:
+after `.hover()` next-active bg = `rgb(0,0,127)` (accent) ≠ base
+`rgb(245,245,245)` (`--bg-alt`); GREEN after the fix: bg stays `--bg-alt`
+because the `@media (hover: hover)` gate never matches on the hover-less
+project. Same shape for scroll-to-bottom (`0.5` → would-be `0.85` latch →
+stays `0.5`). Item 1 got a ceiling assertion (`<= 0.6`) added to
+`issue289-float-btn-opacity.spec.ts` — the #289 `< 1` band alone stays green
+at 0.75 and never witnesses the lowering. The heavy "surface both float
+buttons" setup was factored into a shared `surfaceBothFloatButtons` helper
+used by both the #289 opacity test and the new #302 hover-latch test.
+
+_Deploy: **`--cic`** bundle only (cic-only, no server change). **HELD** —
+rides the already-HELD #299 COLD batch (with #282 / #290 / #294 / #304 /
+#305 / #307), NOT shipped solo._


### PR DESCRIPTION
Two pure-CSS fixes on the mobile float-stack button pair (scroll-to-bottom + next-active), plus e2e witnesses. Ref #302.

## Item 1 — opacity
Lower `.shell-mobile .scrollback-float-stack > *` from `0.75` to `0.5`. 0.75 still hid wrapped message text behind the buttons; 0.5 stays clearly tappable (above the e2e `TAPPABLE_FLOOR` of 0.4). Kept on the single stack-child rule so the pair stays consistent by construction (#280 "same box"), never split per-button.

## Item 2 — sticky `:hover` latch after tap
Touch has no real hover, so a tapped `:hover` state latched the accent "selected" look until you tapped elsewhere. Drive the press feedback off `:active` (paints only while the finger is down, clears on release) and gate the `:hover` colour-inversion behind `@media (hover: hover)` so a hover-less pointer never latches it. Applied to both `.next-active-btn` and `.scroll-to-bottom-btn`. Mirrors the existing `.mentions-row:active` + `.member-name:hover` `@media (hover: hover)` idioms. True-hover pointers keep the hover feedback; desktop scroll-to-bottom (base opacity 1) unchanged.

## Tests
- Added a `<= 0.6` ceiling to `issue289-float-btn-opacity.spec.ts` — the #289 `< 1` band alone stays green at 0.75 and never witnessed the lowering.
- New `#302` hover-latch test: `webkit-iphone-15` emulates a hover-less pointer (`matchMedia('(hover: none)')===true`, asserted as a precondition) and `.hover()` triggers `:hover`, giving a real RED→GREEN witness — next-active bg stays `--bg-alt` after hover instead of inverting to `--accent`; scroll-to-bottom stays at base opacity.
- Factored the shared "surface both float buttons" setup into `surfaceBothFloatButtons`.

Deploy: **HELD** — cic-only, rides the already-HELD #299 COLD batch. Not shipped solo.