### PR TITLE
cic: fix umode table Azzurra semantics + fill missing letters (#301)

### DIFF
--- a/cicchetto/e2e/tests/issue229-umodes-on-connect.spec.ts
+++ b/cicchetto/e2e/tests/issue229-umodes-on-connect.spec.ts
@@ -23,6 +23,10 @@
 //
 // Anti-hollow-green: `/umode -i` in `finally` restores the seeded vjt's
 // umode set so the shared session doesn't leak +i into sibling specs.
+//
+// #301 — this spec ALSO asserts the corrected Azzurra umode copy (+d DEBUG,
+// +g GLOBOPS, +S SSL) renders in the modal. The modal shows the full known
+// table, so those toggles are present even though vjt holds none of them.
 
 import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
@@ -70,6 +74,20 @@ test("#229 — own umodes are visible from connect (cold-snapshot after reload),
     // The "invisible" (+i) toggle is ACTIVE (pressed) — the umode we set.
     const invisible = modal.getByLabel(/invisible/i);
     await expect(invisible).toHaveAttribute("aria-pressed", "true");
+
+    // #301 — the modal renders the FULL known umode table (not just the
+    // operator's active letters), so the three corrected Azzurra entries
+    // render even though vjt holds none of them. Proves the fixed COPY
+    // reaches the rendered DOM, not just the static table (the UX-behavior
+    // e2e gate). Each toggle's aria-label is `<label> (+<letter>)`; the
+    // human copy lives in `.mode-modal-toggle-desc`. Assert on the KEY
+    // phrase (DEBUG / GLOBOPS / SSL) so the copy stays tunable.
+    const debugDesc = modal.getByLabel(/\(\+d\)/).locator(".mode-modal-toggle-desc");
+    await expect(debugDesc).toContainText(/debug/i);
+    const globopsDesc = modal.getByLabel(/\(\+g\)/).locator(".mode-modal-toggle-desc");
+    await expect(globopsDesc).toContainText(/globops/i);
+    const sslDesc = modal.getByLabel(/\(\+S\)/).locator(".mode-modal-toggle-desc");
+    await expect(sslDesc).toContainText(/ssl/i);
 
     // The × close control dismisses the modal (gemello of the /mode modal).
     await modal.getByLabel("close user modes").click();

--- a/cicchetto/src/__tests__/umodeModes.test.ts
+++ b/cicchetto/src/__tests__/umodeModes.test.ts
@@ -18,7 +18,31 @@ describe("umodeModes description table", () => {
     expect(umodeDescription("o").settable).toBe(false); // operator
     expect(umodeDescription("r").settable).toBe(false); // registered
     expect(umodeDescription("a").settable).toBe(false); // services admin
-    expect(umodeDescription("S").settable).toBe(false); // network service
+    expect(umodeDescription("S").settable).toBe(false); // client connected via SSL
+  });
+
+  // #301 — the table shipped generic-ircd (charybdis/Unreal) copy for three
+  // letters that mean something else on Azzurra/bahamut. Authority: Azzurra's
+  // own `helpserv umode` helpfile. +d/+g are IRCop snomask-style RECEIVE flags
+  // (not user message filters) → NOT settable; +S is a connection property
+  // (SSL), not a services role.
+  it("uses Azzurra semantics for +d/+g/+S (not generic-ircd copy)", () => {
+    expect(umodeDescription("d").desc).toMatch(/debug/i);
+    expect(umodeDescription("g").desc).toMatch(/globops/i);
+    expect(umodeDescription("S").desc).toMatch(/ssl/i);
+  });
+
+  it("marks the IRCop receive flags +d/+g as read-only (not settable)", () => {
+    expect(umodeDescription("d").settable).toBe(false); // receive DEBUG
+    expect(umodeDescription("g").settable).toBe(false); // receive GLOBOPS
+  });
+
+  // #301 secondary — the table only knew 13 letters, so active-but-unlisted
+  // Azzurra umodes rendered "no description available". Representative fill
+  // letters are now KNOWN.
+  it("knows the previously-missing Azzurra umodes (no generic fallback)", () => {
+    expect(umodeDescription("b").desc).not.toMatch(/no description available/i);
+    expect(umodeDescription("z").desc).not.toMatch(/no description available/i);
   });
 
   it("umodeDescription falls back to a generic non-settable label for an unknown letter", () => {

--- a/cicchetto/src/lib/umodeModes.ts
+++ b/cicchetto/src/lib/umodeModes.ts
@@ -10,7 +10,9 @@
 // cic, never on the wire (CLAUDE.md "no localized strings server-side").
 //
 // `settable` marks umodes a normal user may flip themselves. Server-managed
-// umodes (o oper, r registered, a/A/S services/admin) are shown read-only —
+// umodes (o oper, r registered, a/A services/admin), IRCop snomask receive
+// flags (#301: b c d e f g k K m n y …), and connection-property flags (S SSL)
+// are shown read-only —
 // the operator SEES they hold +r but can't unset it via the modal (the ircd
 // is the real authority and rejects an unauthorized change anyway; this is
 // the umode twin of #216's param-modes-read-only decision). Toggling a
@@ -20,21 +22,49 @@ export type UmodeInfo = { label: string; desc: string; settable: boolean };
 
 // The bahamut/Azzurra user-mode set. Keys are single mode letters.
 // Descriptions read "<label> · <what it does>" in the modal toggle.
+//
+// AUTHORITY (#301): Azzurra's own `helpserv umode` helpfile is the source of
+// truth for what each letter means on Azzurra/bahamut — NOT generic-ircd
+// (charybdis/Unreal) convention. Several letters that look familiar from other
+// ircds mean something else here (+d is DEBUG receive, not "deaf"; +g is
+// GLOBOPS receive, not "caller ID"; +S is an SSL connection flag, not a
+// services role). The IRCop snomask-style RECEIVE flags and the
+// server/services-managed flags are read-only: a normal user cannot flip them,
+// so `settable:false` — the same conservative default an unknown letter gets
+// (cic can't grant itself an oper/services capability).
 const UMODE_DESCRIPTIONS: Record<string, UmodeInfo> = {
+  // User-settable — a normal user may flip these themselves.
   i: { label: "invisible", desc: "hidden from WHO / global nick lists", settable: true },
   w: { label: "wallops", desc: "receive network WALLOPS broadcasts", settable: true },
   s: { label: "server notices", desc: "receive server notice broadcasts", settable: true },
-  d: { label: "deaf", desc: "ignore all channel messages", settable: true },
-  g: { label: "caller ID", desc: "only accepted nicks may /msg you", settable: true },
   x: { label: "masked host", desc: "cloak your hostname from other users", settable: true },
   R: { label: "reg'd only", desc: "only registered nicks may /msg you", settable: true },
+  // IRCop snomask-style RECEIVE flags — the ircd grants these to opers; a
+  // normal user cannot set them → read-only in the modal.
+  b: { label: "chatops", desc: "IRCop: receive CHATOPS messages", settable: false },
+  c: { label: "client notices", desc: "IRCop: server connect/disconnect notices", settable: false },
+  d: { label: "debug notices", desc: "IRCop: receive DEBUG messages", settable: false },
+  e: { label: "invalid DCC", desc: "IRCop: receive invalid-DCC notices", settable: false },
+  f: { label: "flood notices", desc: "IRCop: receive FLOOD messages", settable: false },
+  g: { label: "globops", desc: "IRCop: receive GLOBOPS messages", settable: false },
+  k: { label: "kill notices", desc: "IRCop: receive KILL (non-U:Line)", settable: false },
+  K: { label: "U:Line kills", desc: "IRCop: receive KILL (U:Lined)", settable: false },
+  m: { label: "spam notices", desc: "IRCop: receive SPAM messages", settable: false },
+  n: { label: "routing notices", desc: "IRCop: receive ROUTING messages", settable: false },
+  y: { label: "command notices", desc: "IRCop: notify on /ADMIN /LINKS /WHOIS …", settable: false },
+  // Other IRCop / connection-property flags — server-managed, read-only.
+  F: { label: "flood immune", desc: "IRCop: immune from flood limits", settable: false },
+  I: { label: "hide idle", desc: "IRCop: hide idle time in WHOIS", settable: false },
+  j: { label: "java user", desc: "chatting from the web via Java", settable: false },
+  S: { label: "SSL", desc: "connected to the server via SSL", settable: false },
   // Server/services-managed — read-only in the modal (the ircd sets these).
   o: { label: "operator", desc: "IRC operator (server-granted)", settable: false },
   O: { label: "local op", desc: "local IRC operator (server-granted)", settable: false },
   r: { label: "registered", desc: "identified to NickServ (services-set)", settable: false },
   a: { label: "services admin", desc: "services administrator (services-set)", settable: false },
   A: { label: "server admin", desc: "server administrator (server-set)", settable: false },
-  S: { label: "network service", desc: "network service (services-set)", settable: false },
+  h: { label: "help operator", desc: "services: Help Operator", settable: false },
+  z: { label: "services agent", desc: "services: Services Agent", settable: false },
 };
 
 /**

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -24942,3 +24942,52 @@ used by both the #289 opacity test and the new #302 hover-latch test.
 _Deploy: **`--cic`** bundle only (cic-only, no server change). **HELD** —
 rides the already-HELD #299 COLD batch (with #282 / #290 / #294 / #304 /
 #305 / #307), NOT shipped solo._
+
+### 2026-07-18 — #301: umode description table — Azzurra semantics + missing letters
+
+The static umode copy table (`cicchetto/src/lib/umodeModes.ts`,
+`UMODE_DESCRIPTIONS`, added in #229) shipped **generic-ircd (charybdis/Unreal)
+conventions** for three letters that mean something else on Azzurra/bahamut.
+A user hit the umode viewer and reported the wrong text via #grappa.
+
+**Authority.** The source of truth is Azzurra's own `helpserv umode` helpfile
+(`azzurra/services/run/data/helpfiles/{it,us}/helpserv/umode`), NOT other
+ircds' conventions. These descriptions are UI copy and live ONLY in cic, never
+on the wire (CLAUDE.md "no localized strings server-side") — so this is a
+pure client-side copy fix: no Elixir, no Wire typespec, no protocol change.
+
+**Three corrected letters.**
+
+| letter | was (generic-ircd) | Azzurra actual | settable |
+|--------|--------------------|----------------|----------|
+| `+d` | "deaf · ignore all channel messages" | IRCop: receive DEBUG messages | true → **false** |
+| `+g` | "caller ID · only accepted nicks may /msg you" | IRCop: receive GLOBOPS messages | true → **false** |
+| `+S` | "network service · (services-set)" | connected to the server via SSL | false (unchanged) |
+
+The **`settable` flip on `+d`/`+g` (true → false)** is the load-bearing
+correction: they are IRCop snomask-style RECEIVE flags, not user message
+filters — a normal user cannot set them, so the modal shows them read-only
+(same conservative default as the unknown-letter fallback). `+S` was already
+read-only; only its label/desc were wrong.
+
+**Missing-letter fill (secondary).** The table only knew 13 letters, so any
+active-but-unlisted Azzurra umode rendered "user mode (no description
+available)". Added the full real Azzurra set from the reference —
+`b c e f F h I j k K m n y z` — all `settable:false` (IRCop / services /
+connection-property flags; cic can't grant itself an oper/services capability,
+so the same default the unknown-letter fallback uses). The existing correct
+entries (`i w s x R` settable; `o O r a A` read-only) are unchanged, and the
+`umodeDescription`/`availableUmodes` shapes are untouched — this is a DATA
+edit, not a refactor.
+
+**Witness.** Unlike a CSS change, umode copy is TEXT that jsdom SEES, so the
+vitest unit test is a real RED→GREEN gate: assertions on `/debug/i`,
+`/globops/i`, `/ssl/i` (KEY phrase, not exact string, so copy stays tunable) +
+the `+d`/`+g` `settable === false` flip + a previously-missing letter no longer
+hitting the generic fallback. The `#229` e2e is extended to prove the corrected
+copy reaches the rendered modal DOM (the modal renders the full known table, so
+the `+d`/`+g`/`+S` toggles show even though vjt holds none of them).
+
+_Deploy: **`--cic`** bundle only (cic-only, no server change). **HELD** —
+rides the already-HELD #299 COLD batch (with #282 / #290 / #294 / #302 /
+#304 / #305 / #307), NOT shipped solo._


### PR DESCRIPTION
Fixes the static umode description table (`cicchetto/src/lib/umodeModes.ts`, added in #229) that shipped generic-ircd (charybdis/Unreal) copy for three letters that mean something else on Azzurra/bahamut. A user reported the wrong text via #grappa. Ref #301.

Authority = Azzurra's own `helpserv umode` helpfile. These descriptions are UI copy that lives only in cic, never on the wire (`no localized strings server-side` invariant) — so this is a **pure client-side copy fix**: no Elixir, no Wire typespec, no protocol change.

### Corrected three wrong entries

| letter | was (generic-ircd) | Azzurra actual | settable |
|--------|--------------------|----------------|----------|
| `+d` | deaf · ignore channel messages | IRCop: receive DEBUG messages | true → **false** |
| `+g` | caller ID · accepted nicks only | IRCop: receive GLOBOPS messages | true → **false** |
| `+S` | network service (services-set) | connected via SSL | false (unchanged) |

The **settable flip on `+d`/`+g`** is load-bearing: they are IRCop snomask-style RECEIVE flags, not user message filters — a normal user cannot set them → shown read-only (same default the unknown-letter fallback uses). `+S` stays read-only; only its label/desc were wrong.

### Secondary — missing-letter fill

The table only knew 13 letters, so active-but-unlisted Azzurra umodes rendered "no description available". Added the full real Azzurra set (`b c e f F h I j k K m n y z`), all `settable:false`. Existing correct entries (`i w s x R` settable; `o O r a A` read-only) unchanged; `umodeDescription`/`availableUmodes` shapes untouched — a DATA edit, not a refactor.

### Tests

- **Unit** (`umodeModes.test.ts`): umode copy is TEXT jsdom sees → a real RED→GREEN gate. Asserts `/debug/i`, `/globops/i`, `/ssl/i` (key phrase, not exact string) + the `+d`/`+g` settable flip + a previously-missing letter no longer hitting the generic fallback.
- **e2e** (`issue229-umodes-on-connect.spec.ts` extended): proves the corrected copy reaches the rendered modal DOM (the modal renders the full known table, so `+d`/`+g`/`+S` toggles show even though vjt holds none).

### Deploy

`--cic` bundle only, **HELD** — rides the already-HELD #299 COLD batch, not shipped solo.