### PR TITLE
cic: audit + SAFE cleanup of default.css — dead rules + --tap-min token (#306)

### DIFF
--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -1145,15 +1145,6 @@ html.resize-dragging * {
   font-style: italic;
 }
 
-.sidebar-unread {
-  background: var(--accent);
-  color: var(--bg);
-  border-radius: 999px;
-  padding: 0 0.4rem;
-  font-size: 0.75rem;
-  margin-left: 0.5rem;
-}
-
 /* C7.5: split msg-vs-events badges. */
 .sidebar-msg-unread {
   background: var(--accent);
@@ -1265,15 +1256,6 @@ html.resize-dragging * {
 .compose-box-greyed textarea {
   color: var(--muted);
   font-style: italic;
-}
-
-.sidebar-footer {
-  margin-top: auto;
-  padding: 0.5rem 1rem;
-  border-top: 1px solid var(--border);
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
 }
 
 /* TopicBar */
@@ -2322,15 +2304,6 @@ html.resize-dragging * {
   color: var(--accent);
 }
 
-.compose-box-image-ttl {
-  background: var(--bg);
-  color: var(--fg);
-  border: 1px solid var(--border);
-  font-family: var(--font-mono);
-  font-size: 0.85rem;
-  padding: 0 0.25rem;
-}
-
 .compose-box-upload-progress,
 .compose-box-upload-error {
   display: flex;
@@ -3044,12 +3017,6 @@ html.resize-dragging * {
   height: 2rem;
   cursor: pointer;
   line-height: 1;
-}
-
-.admin-pane-placeholder {
-  font-family: var(--font-mono);
-  color: var(--muted);
-  font-size: 0.85rem;
 }
 
 /* M-cluster M-8 — admin tab nav + Visitors tab. M-9/M-10/M-11
@@ -4151,15 +4118,6 @@ html.resize-dragging * {
    ascends in source order (no descending-specificity lint). */
 .bottom-bar-network-header:not(.selected):not(:hover) {
   background: var(--bg-alt);
-}
-
-.bottom-bar-unread {
-  background: var(--accent);
-  color: var(--bg);
-  border-radius: 999px;
-  padding: 0 0.3rem;
-  font-size: 0.7rem;
-  line-height: 1.4;
 }
 
 /* C7.5: split msg-vs-events badges for mobile bottom-bar. */
@@ -6640,21 +6598,6 @@ html.resize-dragging * {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   opacity: 0.85;
-}
-
-/* #135 — the directory link is a PRIMARY affordance on the visitor
-   landing (not the low-emphasis secondary chip on registered rows), so
-   it bumps the base .home-pane-network-browse styling to full opacity
-   with a framed, tappable target. */
-.home-pane-directory-link {
-  opacity: 1;
-  border: 1px solid var(--border);
-  border-radius: 3px;
-  padding: 0.5rem 0.9rem;
-}
-
-.home-pane-directory-link:hover {
-  border-color: var(--accent);
 }
 
 .home-pane-network-slug {

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -187,6 +187,13 @@
      floor (feedback_cic_tap_target_rem_pitfall). */
   --chrome-icon-size: 1.4rem; /* glyph size for all chrome buttons */
   --chrome-tap-min: 48px; /* Apple HIG minimum tap-target floor */
+  /* #306 — the Apple-HIG 44px tap-target minimum used by non-chrome
+     controls (list rows, modal toggles, cards, close buttons). Sibling of
+     --chrome-tap-min (48px): ABSOLUTE px on purpose, since the html root
+     font-size is 14px a rem tap target would under-size below the HIG
+     floor (feedback_cic_tap_target_rem_pitfall). Theme-independent, so it
+     lives on base :root, NOT in the per-theme blocks. */
+  --tap-min: 44px;
   /* grappa-irc#69: theme the scrollbars. `scrollbar-color` and
      `scrollbar-width` inherit, so declaring them on :root themes every
      scrollable descendant (.scrollback, members pane, admin tables…)
@@ -640,7 +647,7 @@ html.overlay-open #root > div {
   border: 1px solid var(--border);
   /* #204 tap target: comfortable ≥44px touch height (iPad/mobile-first). */
   padding: 0.7rem 0.6rem;
-  min-height: 44px;
+  min-height: var(--tap-min);
   font-family: var(--font-mono);
   font-size: var(--font-size);
 }
@@ -657,7 +664,7 @@ html.overlay-open #root > div {
   border: none;
   /* #204 tap target: ≥44px, generous horizontal padding. */
   padding: 0.75rem 1rem;
-  min-height: 44px;
+  min-height: var(--tap-min);
   font-family: var(--font-mono);
   font-size: var(--font-size);
   cursor: pointer;
@@ -678,7 +685,7 @@ html.overlay-open #root > div {
   border: none;
   text-align: left;
   padding: 0.6rem 0.25rem;
-  min-height: 44px;
+  min-height: var(--tap-min);
   font-family: var(--font-mono);
   font-size: 0.9rem;
   cursor: pointer;
@@ -3902,8 +3909,8 @@ html.resize-dragging * {
      would shrink it to 33px) — a tap target is a physical constraint that
      must NOT shrink with the text size. */
   .shell-mobile .mobile-panel-actions .shell-chrome-btn {
-    min-width: 44px;
-    min-height: 44px;
+    min-width: var(--tap-min);
+    min-height: var(--tap-min);
   }
 
   .shell-drawer-backdrop {
@@ -4086,7 +4093,7 @@ html.resize-dragging * {
   cursor: pointer;
   white-space: nowrap;
   height: 100%;
-  min-width: 44px; /* Apple HIG minimum touch target */
+  min-width: var(--tap-min); /* Apple HIG minimum touch target */
   display: flex;
   align-items: center;
   gap: 0.25rem;
@@ -4294,7 +4301,7 @@ html.resize-dragging * {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  min-height: 44px; /* Apple HIG touch target */
+  min-height: var(--tap-min); /* Apple HIG touch target */
 }
 
 .archive-modal-entry-btn:hover {
@@ -4321,7 +4328,7 @@ html.resize-dragging * {
   font-size: var(--font-size);
   cursor: pointer;
   line-height: 1;
-  min-width: 44px;
+  min-width: var(--tap-min);
 }
 
 .archive-modal-delete:hover {
@@ -4423,8 +4430,8 @@ html.resize-dragging * {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 44px;
-  min-height: 44px;
+  min-width: var(--tap-min);
+  min-height: var(--tap-min);
   margin: -0.6rem -0.5rem -0.6rem 0;
   padding: 0;
   background: transparent;
@@ -4732,8 +4739,8 @@ html.resize-dragging * {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 44px;
-  min-height: 44px;
+  min-width: var(--tap-min);
+  min-height: var(--tap-min);
   margin: -0.6rem -0.5rem -0.6rem 0;
   padding: 0;
   background: transparent;
@@ -4862,7 +4869,7 @@ html.resize-dragging * {
 .mode-modal-param-input {
   flex: 1 1 auto;
   min-width: 0;
-  min-height: 44px;
+  min-height: var(--tap-min);
   padding: 0.35rem 0.5rem;
   background: var(--bg);
   color: var(--fg);
@@ -4878,7 +4885,7 @@ html.resize-dragging * {
 
 .mode-modal-param-btn {
   flex: 0 0 auto;
-  min-height: 44px;
+  min-height: var(--tap-min);
   padding: 0.35rem 0.9rem;
   background: var(--bg);
   color: var(--fg);
@@ -4991,7 +4998,7 @@ html.resize-dragging * {
   flex-direction: column;
   gap: 0.4rem;
   width: 100%;
-  min-height: 44px;
+  min-height: var(--tap-min);
   margin: 0;
   padding: 0.25rem;
   background: transparent;
@@ -5053,7 +5060,7 @@ html.resize-dragging * {
   align-items: center;
   /* ABSOLUTE 44px tap target (Apple HIG) — never rem (root font-size 14px,
      feedback_cic_tap_target_rem_pitfall). #299 item 7. */
-  min-height: 44px;
+  min-height: var(--tap-min);
   background: transparent;
   color: var(--accent);
   border: 1px solid var(--border);
@@ -5130,8 +5137,8 @@ html.resize-dragging * {
   font-size: 1.5rem;
   line-height: 1;
   cursor: pointer;
-  min-width: 44px;
-  min-height: 44px;
+  min-width: var(--tap-min);
+  min-height: var(--tap-min);
 }
 
 .theme-editor-error {
@@ -5161,7 +5168,7 @@ html.resize-dragging * {
   font-family: var(--font-mono);
   font-size: var(--font-size);
   padding: 0 0.5rem;
-  min-height: 44px;
+  min-height: var(--tap-min);
 }
 
 .theme-editor-group {
@@ -5184,7 +5191,7 @@ html.resize-dragging * {
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
-  min-height: 44px;
+  min-height: var(--tap-min);
 }
 
 .theme-editor-color-label {
@@ -5218,7 +5225,7 @@ html.resize-dragging * {
 
 .theme-editor-opacity {
   width: 100%;
-  min-height: 44px;
+  min-height: var(--tap-min);
 }
 
 /* #294 — built-in background picker. A responsive grid of cover-previewed
@@ -5280,7 +5287,7 @@ html.resize-dragging * {
   color: var(--accent);
   border: 1px solid var(--border);
   padding: 0 0.75rem;
-  min-height: 44px;
+  min-height: var(--tap-min);
   font-family: var(--font-mono);
   font-size: var(--font-size);
   cursor: pointer;
@@ -5534,8 +5541,8 @@ html.resize-dragging * {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 44px;
-  min-height: 44px;
+  min-width: var(--tap-min);
+  min-height: var(--tap-min);
   margin: -0.6rem -0.5rem -0.6rem 0;
   padding: 0;
   background: transparent;
@@ -5667,8 +5674,8 @@ html.resize-dragging * {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 44px;
-  min-height: 44px;
+  min-width: var(--tap-min);
+  min-height: var(--tap-min);
   margin: -0.6rem -0.5rem -0.6rem 0;
   padding: 0;
   background: transparent;
@@ -6039,8 +6046,8 @@ html.resize-dragging * {
   align-items: center;
   justify-content: center;
   align-self: center;
-  min-width: 44px;
-  min-height: 44px;
+  min-width: var(--tap-min);
+  min-height: var(--tap-min);
   margin-top: -0.6rem;
   margin-bottom: -0.6rem;
   padding: 0;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -24991,3 +24991,63 @@ the `+d`/`+g`/`+S` toggles show even though vjt holds none of them).
 _Deploy: **`--cic`** bundle only (cic-only, no server change). **HELD** —
 rides the already-HELD #299 COLD batch (with #282 / #290 / #294 / #302 /
 #304 / #305 / #307), NOT shipped solo._
+
+### 2026-07-18 — #306: default.css audit + SAFE cleanup (dead rules + tap-target token)
+
+The systemic follow-up to #305 (which consolidated the chrome-button cluster):
+a structured entropy audit of `cicchetto/src/themes/default.css` (7421 lines,
+the single stylesheet; 3 shipped palettes live in-file as base `:root`,
+`:root[data-theme="irssi-dark"]`, `:root[data-theme="mirc-light"]`). The full
+audit — grouped by the five #306 hunt buckets, with the SAFE-vs-VETO split — is
+posted as a comment on #306. This entry records what was APPLIED (the SAFE set
+only) and WHY the rest was deferred.
+
+**Removed — 6 dead rules.** Each class stem was proven to match no element
+anywhere in `src/**`, `e2e/**`, or `index.html`, checked per-selector including
+runtime class construction (template strings / `classList`):
+`.sidebar-unread` + `.bottom-bar-unread` (pre-**C7.5** single-badge remnants,
+superseded by the `-msg-unread` / `-events-unread` split), `.sidebar-footer`,
+`.compose-box-image-ttl`, `.admin-pane-placeholder`, and
+`.home-pane-directory-link` (+`:hover`, + its now-orphaned `#135` comment;
+superseded by the base `.home-pane-network-browse`). A selector matching no
+element paints nothing, so removal is behaviour-preserving by construction.
+Looks-dead-but-live variants built at runtime — `error-banner-${severity}`,
+`who-modal-flag-tag-${cssMod}`, `whois-card-tag-oper`,
+`next-active-btn-${variant}` — were checked against their component enums and
+KEPT.
+
+**Extracted — `--tap-min: 44px` token.** The Apple-HIG 44px tap-target minimum
+was hard-coded at 28 `min-width`/`min-height` sites (rows, modal close buttons,
+cards, theme editor). #305 had already established the tap-target-token pattern
+with `--chrome-tap-min: 48px` on `:root`; this promotes the sibling 44px value
+to `--tap-min` right beside it. Behaviour-preserving by construction: sizing
+tokens live on the base `:root`, and both the `data-theme` palette blocks and
+the runtime custom-theme system (`lib/customTheme.ts` applies a **closed**
+`THEME_CSS_VARS` colour set only) never touch `--tap-min`, so it resolves to
+44px in every theme. Absolute px on purpose (root font-size is 14px — a rem tap
+target would under-size below the HIG floor, `feedback_cic_tap_target_rem_pitfall`).
+Complete atomic adoption — 0 literal `min-*: 44px` remain, so no two-pattern
+drift; the fixed `44px` swatch square in `.theme-editor-color-input` is a
+different semantic (fixed size, not a tap floor) and is intentionally left.
+
+**Deferred to the maintainer (VETO list on #306).** The button-quartet
+consolidation (~21 buttons re-declaring `transparent + 1px var(--border) +
+font-mono`) is the systemic #305 follow-up but collapsing it touches N call-sites
+or shifts cascade — the "atomic-adoption, all-or-nothing" hazard — so it wants a
+dedicated issue, not this behaviour-preserving pass. The 23 baseline
+`noDescendingSpecificity` warnings are the highest-risk bucket (reordering can
+change which rule wins) and were left untouched (count unchanged). The
+float-button opacity token was deferred because `0.5` conflates two semantics
+(mobile float-stack idle vs generic `:disabled`).
+
+**Witness.** jsdom is blind to CSS, so there is no RED→GREEN unit gate here —
+the net is regression: full `scripts/integration.sh` (real chromium + webkit,
+~430 specs asserting visibility / computed layout / element presence) green,
+plus a real-browser theme-gallery smoke in a light and a dark shipped palette
+(`--border`/`--accent` contrast varies per theme). `bun run check` held at the
+23-warning baseline with 0 new warnings and 0 `error TS`; `bun run test`
+(vitest) green. No brittle mirror tests asserting the old literals were added.
+
+_Deploy: **`--cic`** bundle only (cic-only, no server change). **HELD** —
+rides the already-HELD #299 COLD batch (with #282 / #290 / #294 / #302 /
+#304 / #305 / #307), NOT shipped solo._


### PR DESCRIPTION
## #306 — `default.css` audit + SAFE cleanup

The systemic follow-up to #305. Full audit (5 buckets, SAFE-vs-VETO split) posted as a [comment on #306](https://github.com/vjt/grappa-irc/issues/306#issuecomment-5011927042). This PR applies **only the SAFE set** — behaviour-preserving by construction — and leaves the VETO items for the maintainer.

### Applied
- **Removed 6 dead rules** — each class stem proven to match no element across `src/**`, `e2e/**`, `index.html` (per-selector grep, incl. template-string / `classList` construction): `.sidebar-unread`, `.bottom-bar-unread` (pre-C7.5 single-badge remnants), `.sidebar-footer`, `.compose-box-image-ttl`, `.admin-pane-placeholder`, `.home-pane-directory-link` (+`:hover`, + its orphaned `#135` comment). Runtime-built variants (`error-banner-${severity}`, `who-modal-flag-tag-${cssMod}`, `whois-card-tag-oper`, `next-active-btn-${variant}`) were checked and **kept**.
- **Extracted `--tap-min: 44px`** — the Apple-HIG tap-target minimum was hard-coded at 28 `min-width`/`min-height` sites; promoted to a `:root` token beside #305's `--chrome-tap-min: 48px`. Identical computed value in every palette (sizing tokens live on base `:root`; `data-theme` blocks + custom themes override colours only). Complete adoption: 0 literal `min-*: 44px` remain; the fixed swatch square in `.theme-editor-color-input` is a different semantic and intentionally left.

### Deferred to maintainer (VETO list on #306)
- Button-quartet consolidation (~21 buttons) — touches N call-sites / shifts cascade; wants a dedicated issue (atomic-adoption hazard).
- 23 baseline `noDescendingSpecificity` warnings — reordering can change which rule wins; left untouched (count unchanged).
- Float-button opacity token — `0.5` conflates mobile-idle vs generic `:disabled`.

### Verification
- Full `scripts/integration.sh` (chromium + webkit) green.
- Real-browser theme-gallery smoke: `--tap-min` resolves to 44px in default / irssi-dark / mirc-light; sidebar + topic bar + mobile float stack eyeballed in light and dark.
- `bun run check` exit 0, held at 23-warning baseline (0 new, 0 `error TS`); `bun run test` (vitest) green; honest build green.
- Adversarial code review: all 6 rules proven dead, token behaviour-preserving across all themes, complete adoption, load-bearing comments preserved, no structural breakage.

Ref #306. **Deploy HELD** — `--cic` bundle only, rides the already-HELD #299 COLD batch.
