### PR TITLE
web push: defeat stale-:visible suppression on iOS PWA (#318)

### DIFF
--- a/cicchetto/src/__tests__/visibilityHeartbeat.test.ts
+++ b/cicchetto/src/__tests__/visibilityHeartbeat.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createVisibilityHeartbeat, VISIBILITY_HEARTBEAT_MS } from "../lib/visibilityHeartbeat";
+
+describe("visibilityHeartbeat (#318)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("re-reports on the interval while foreground/visible", () => {
+    const report = vi.fn();
+    const hb = createVisibilityHeartbeat(report, 1000);
+
+    hb.setVisible(true);
+    vi.advanceTimersByTime(3000);
+
+    expect(report).toHaveBeenCalledTimes(3);
+    hb.stop();
+  });
+
+  it("stops re-reporting once hidden (the server then goes stale)", () => {
+    const report = vi.fn();
+    const hb = createVisibilityHeartbeat(report, 1000);
+
+    hb.setVisible(true);
+    vi.advanceTimersByTime(2000);
+    expect(report).toHaveBeenCalledTimes(2);
+
+    hb.setVisible(false);
+    vi.advanceTimersByTime(5000);
+    expect(report).toHaveBeenCalledTimes(2); // no further reports while hidden
+
+    hb.stop();
+  });
+
+  it("does not stack intervals when setVisible(true) is called repeatedly", () => {
+    const report = vi.fn();
+    const hb = createVisibilityHeartbeat(report, 1000);
+
+    hb.setVisible(true);
+    hb.setVisible(true);
+    hb.setVisible(true);
+    vi.advanceTimersByTime(2000);
+
+    expect(report).toHaveBeenCalledTimes(2); // one interval, not three
+    hb.stop();
+  });
+
+  it("stop() cancels the interval", () => {
+    const report = vi.fn();
+    const hb = createVisibilityHeartbeat(report, 1000);
+
+    hb.setVisible(true);
+    hb.stop();
+    vi.advanceTimersByTime(5000);
+
+    expect(report).toHaveBeenCalledTimes(0);
+  });
+
+  it("exposes a positive default heartbeat interval", () => {
+    expect(VISIBILITY_HEARTBEAT_MS).toBeGreaterThan(0);
+  });
+});

--- a/cicchetto/src/lib/visibilityHeartbeat.ts
+++ b/cicchetto/src/lib/visibilityHeartbeat.ts
@@ -1,0 +1,69 @@
+// #318 — foreground visibility heartbeat.
+//
+// Web Push was suppressed indefinitely for an iOS PWA the user
+// backgrounded/closed: the WebSocket stays open but iOS does not reliably
+// fire `visibilitychange`, so the server kept reading the socket as
+// `:visible` and skipped the push — self-healing only after ~90 min when the
+// zombie socket finally died.
+//
+// The server (Grappa.WSPresence) now trusts a `:visible` pid only while its
+// last report is FRESH (read-time staleness downgrade). This is the client
+// complement: while genuinely foreground, re-report visibility on a fixed
+// interval. A real foreground app therefore stays fresh (foreground
+// push-suppression preserved by construction), while a backgrounded app
+// either (a) stops firing the timer as iOS suspends JS, or (b) — since
+// `reportVisibility` re-reads the live `document.visibilityState` /
+// `hasFocus()` on every call — reports hidden the moment the property
+// silently flips. Either way the server goes stale and push resumes within
+// `stale_ms` instead of ~90 min.
+//
+// REUSES the existing `visibility` verb (`reportVisibility`) — no new
+// channel event (CLAUDE.md "reuse the verbs, not the nouns"). Timer logic is
+// isolated behind an injectable interval so vitest fake timers drive it
+// deterministically, mirroring socket.ts's `kickReconnect` testability.
+
+// Client heartbeat cadence. MUST stay ≤ half the server's `stale_ms`
+// (Grappa.WSPresence @default_stale_ms = 60_000) so a genuinely-foreground
+// PWA refreshes with a whole beat of margin before it would be counted
+// stale. Keep the two values in sync across the codebases.
+export const VISIBILITY_HEARTBEAT_MS = 30_000;
+
+export interface VisibilityHeartbeat {
+  // Start the periodic report when visible; stop it when hidden. Idempotent
+  // — repeated `setVisible(true)` does not stack intervals.
+  setVisible(visible: boolean): void;
+  // Cancel any running interval (teardown).
+  stop(): void;
+}
+
+export function createVisibilityHeartbeat(
+  report: () => void,
+  intervalMs: number = VISIBILITY_HEARTBEAT_MS,
+): VisibilityHeartbeat {
+  let id: ReturnType<typeof setInterval> | null = null;
+
+  const stop = (): void => {
+    if (id !== null) {
+      clearInterval(id);
+      id = null;
+    }
+  };
+
+  const start = (): void => {
+    // Guard against stacking: only one interval runs at a time.
+    if (id === null) {
+      id = setInterval(report, intervalMs);
+    }
+  };
+
+  return {
+    setVisible(visible: boolean): void {
+      if (visible) {
+        start();
+      } else {
+        stop();
+      }
+    },
+    stop,
+  };
+}

--- a/cicchetto/src/main.tsx
+++ b/cicchetto/src/main.tsx
@@ -27,6 +27,7 @@ import { notifyClientClosing, reportVisibility } from "./lib/socket";
 import { recordSwRegError, recordSwRegistered } from "./lib/swRegistration";
 import { applyTheme } from "./lib/theme";
 import { installSmartScrollPin, installViewportHeightTracker } from "./lib/viewportHeight";
+import { createVisibilityHeartbeat } from "./lib/visibilityHeartbeat";
 import Shell from "./Shell";
 import "./themes/default.css";
 
@@ -196,10 +197,22 @@ window.addEventListener("beforeunload", notifyClientClosing);
 // registration). The initial state is reported on user-channel join (see
 // socket.ts joinUser); this effect keeps it live on every focus/visibility
 // transition after.
+// #318 — plus a foreground HEARTBEAT. The edge report above fires only on
+// a visibility TRANSITION; on iOS PWA background the transition often never
+// fires (visibilitychange is unreliable), so the server kept reading the
+// socket as visible and suppressed push until the zombie socket died
+// (~90 min). While genuinely foreground the heartbeat re-reports on a fixed
+// interval so the server (WSPresence read-time staleness) can tell a live
+// foreground PWA (fresh reports) from a backgrounded one whose JS timers
+// suspend OR whose visibilityState silently flips (reportVisibility re-reads
+// the live property each tick). Reuses the `visibility` verb — see
+// lib/visibilityHeartbeat.ts. Stops the interval when hidden.
 createRoot(() => {
+  const heartbeat = createVisibilityHeartbeat(reportVisibility);
   createEffect(() => {
-    isDocumentVisible();
+    const visible = isDocumentVisible();
     reportVisibility();
+    heartbeat.setVisible(visible);
   });
 });
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -25051,3 +25051,87 @@ plus a real-browser theme-gallery smoke in a light and a dark shipped palette
 _Deploy: **`--cic`** bundle only (cic-only, no server change). **HELD** —
 rides the already-HELD #299 COLD batch (with #282 / #290 / #294 / #302 /
 #304 / #305 / #307), NOT shipped solo._
+
+### 2026-07-18 — #318: web push suppressed for a stale-`:visible` iOS PWA (P0)
+
+**Root cause (verified on prod).** An iOS cicchetto PWA the user
+backgrounded/closed kept its WebSocket open, but iOS does not reliably fire
+`visibilitychange` on the PWA background/terminate lifecycle. So the socket's
+pid stayed `:visible` in `Grappa.WSPresence`; `any_visible?/1` read the user as
+present; and `Grappa.Push.Triggers`' foreground-suppression gate (#182) skipped
+the ENTIRE push fan-out. Live-node introspection confirmed a single socket at
+`:visible`, `any_visible? = true`, and the subscription's `last_used_at` NULL
+(no push ever delivered) while other subscribers to the same channel were bumped
+at the test-message instant. The owner datapoint: delivery **self-resolved after
+~90 min with no user action** — i.e. only when the zombie socket finally died on
+its own did presence drop and push resume. Until then every push is suppressed.
+
+**Fix — read-time staleness (server) + foreground heartbeat (client).** The
+owner-blessed direction, and safe by construction:
+
+- **Server (`Grappa.WSPresence`, COLD).** Each pid now carries
+  `{visibility, last_visible_at}` (monotonic ms), stamped on every
+  `set_visibility(true)`. `any_visible?/1` counts a pid present iff it is
+  `:visible` AND `now - last_visible_at < stale_ms`. Read-time derivation — NO
+  periodic sweep, no parallel timer state (CLAUDE.md "derive, don't duplicate").
+  `stale_ms` (default 60s) is injected via `start_link/1` opts, never read from
+  Application env at runtime. `Push.Triggers` is UNCHANGED — the fix flows
+  through the one existing gate.
+- **Client (cicchetto `visibilityHeartbeat.ts`).** A foreground heartbeat
+  re-reports visibility every 30s (half `stale_ms`) WHILE foreground, stopping
+  when hidden. It reuses `reportVisibility` (the `visibility` verb) — no new
+  channel event. Because `reportVisibility` re-reads the live
+  `document.visibilityState`/`hasFocus()` each call, the tick catches a SILENT
+  iOS hide (property flips with no event), not only a full timer suspension.
+
+A genuinely-foreground app keeps its stamp fresh by construction, so foreground
+push-suppression (acceptance #2) is **preserved**; a backgrounded app goes stale
+and push resumes within `stale_ms` (~60s) instead of ~90 min.
+
+**Scope.** Read-time staleness fixes PUSH only. The auto-away FSM keys off the
+`any_visible?/1` TRANSITION (an emitted event), and no event fires when a pid
+merely ages out with no write, so a stale `:visible` pid does not itself trip
+auto-away — that stays bounded by the real socket DOWN / `client_closing`,
+unchanged. A sweep that flips state + emits `:ws_all_hidden` so auto-away also
+benefits is a deliberate NON-goal here (the P0 is push); flagged to the
+orchestrator as a possible follow-up rather than silently expanded.
+
+**★ iOS efficacy caveat (device-verify owed).** The efficacy hinges on an iOS
+behaviour that CANNOT be confirmed off-device: does a backgrounded PWA stop
+sending fresh `visible` reports? The prod socket survived ~90 min under
+Phoenix's default 60s WS idle timeout (`endpoint.ex` configures no custom
+`websocket: [timeout: …]`), which implies phx heartbeats — hence JS timers —
+kept running while backgrounded. If timers run AND `document.visibilityState`
+stays "visible" while backgrounded, neither the heartbeat nor the staleness
+downgrade engages and the fix is a no-op (never worse than today). The load-
+bearing hope is the silent-property-flip path (hypothesis c), which only a real
+device can decide. The fix is therefore shipped as a **safe backstop**, and the
+on-device confirmation is owed post-deploy via the reporter (vjt / #sniffo).
+
+**Diagnostic — `GET /admin/ws_presence`.** So the device run can be read back
+from the server (CLAUDE.md "debugging tools are infrastructure — build an
+endpoint, not a throwaway"), a read-only admin endpoint exposes
+`WSPresence.snapshot/0`: per-user / per-pid reported visibility, `age_ms` since
+the last visible report, computed freshness, `any_visible?` per user, and the
+active `stale_ms`. Behind `:admin_authn`; one `infra/snippets/locations-api.conf`
+regex edit adds it to the nginx allowlist (the snippet is mounted into both the
+prod/docker nginx and the e2e nginx-test). The reporter backgrounds the PWA and
+the operator reads whether the socket goes stale/hidden (fix effective) or stays
+fresh-visible (fix a no-op → hypothesis a, needs a different signal).
+
+**Witness.** Server: `mark_stale_for_test/2` (Mix.env-guarded, sibling of
+`reset_for_test`) backdates a pid's stamp past `stale_ms` so the real staleness
+comparison is a deterministic RED→GREEN gate without sleeping the window; the
+`/admin/ws_presence` controller test proves the 401/403 auth gate + the
+fresh-vs-stale snapshot shape. Client: vitest fake timers prove the heartbeat
+fires on the interval while visible, stops when hidden, and never stacks. jsdom
+sees timers/logic; the iOS-specific behaviour is deliberately NOT asserted (the
+harness cannot reproduce it — that is the owed device-verify), so no test
+encodes an unproven assumption.
+
+_Deploy: **COLD** — `Grappa.WSPresence` state-shape change (per-pid tuple +
+`stale_ms` field) is hot-reload-unsafe (already tracked in
+`HotReload.LongLivedModules`), and the cic bundle carries the heartbeat. **HELD**
+— rides the already-HELD #299 COLD batch (with #282 / #290 / #294 / #302 / #304 /
+#305 / #306 / #307). The COLD window MUST include the post-deploy iPhone efficacy
+verification with the reporter (vjt / #sniffo) reading `/admin/ws_presence`._

--- a/infra/snippets/locations-api.conf
+++ b/infra/snippets/locations-api.conf
@@ -139,7 +139,13 @@ location ~ ^/(auth|me|networks|push|api|session|uploads|healthz|themes)(/|$) {
 # Bare `/admin/networks` paths still resolve via the existing
 # `networks` alt; nginx's regex alternation doesn't care about path
 # nesting since both alternatives match the second path segment.
-location ~ ^/admin/(visitors|sessions|credentials|networks|servers|reaper|circuit|users|me|settings|uploads|vhosts|session_log|test)(/|$) {
+#
+# #318 (2026-07-18) — added `ws_presence`: read-only live WS presence +
+# visibility-freshness snapshot backing the iOS stale-`:visible` push
+# diagnostic. This snippet is mounted into BOTH the prod/docker nginx
+# (infra/nginx.conf) and the e2e nginx-test (cicchetto/e2e/compose.yaml
+# bind-mounts infra/snippets), so this one edit covers every server block.
+location ~ ^/admin/(visitors|sessions|credentials|networks|servers|reaper|circuit|users|me|settings|uploads|vhosts|session_log|ws_presence|test)(/|$) {
     proxy_pass http://grappa_upstream;
     proxy_http_version 1.1;
     proxy_set_header Connection "";

--- a/lib/grappa/ws_presence.ex
+++ b/lib/grappa/ws_presence.ex
@@ -10,8 +10,10 @@ defmodule Grappa.WSPresence do
   ## Responsibility
 
   One named `GenServer` (`:permanent`, single-node) that owns
-  `%{user_name => %{pid() => :visible | :hidden}}`. Each entry is a
-  live socket pid (monitored) mapped to the last visibility the page
+  `%{user_name => %{pid() => {:visible | :hidden, last_visible_at}}}`.
+  Each entry is a live socket pid (monitored) mapped to the last
+  visibility the page reported plus a monotonic freshness stamp (#318).
+  For brevity the rest of these docs say the page maps to the last visibility
   reported over the `"visibility"` channel event. When the set of
   VISIBLE devices for a user transitions, it notifies interested
   listeners so `Session.Server`s can schedule / cancel their 30s
@@ -33,6 +35,41 @@ defmodule Grappa.WSPresence do
       Reads `any_visible?/1` synchronously at message time, no debounce
       (a debounced gate would miss mentions right after you set the
       phone down).
+
+  ## Read-time staleness (#318)
+
+  A `:visible` pid is trusted only while its last visibility report is
+  FRESH. `any_visible?/1` discounts a `:visible` pid whose last
+  `set_visibility(true)` is older than `stale_ms` (default 60s, injected
+  via `start_link/1` opts). This is a READ-TIME derivation — no periodic
+  sweep, no parallel timer state (CLAUDE.md "derive, don't duplicate").
+
+  Root cause: an iOS PWA backgrounded/closed keeps its WebSocket open but
+  stops firing `visibilitychange`, so the pid stayed `:visible` and push
+  was suppressed until the zombie socket finally died (~90 min in the
+  field report). The client complements this with a foreground HEARTBEAT
+  (cicchetto `visibilityHeartbeat.ts`): while genuinely foreground it
+  re-reports `visibility` every ~`stale_ms/2` (reusing the existing
+  `set_visibility` verb, not a new event). A real foreground app keeps
+  its stamp fresh by construction, so foreground push-suppression is
+  PRESERVED; a backgrounded app whose JS timers suspend — OR whose
+  `document.visibilityState` silently flips to hidden (the heartbeat
+  re-reads the live property each tick) — stops refreshing, goes stale,
+  and push resumes within `stale_ms` instead of ~90 min.
+
+  Scope: read-time staleness fixes PUSH suppression only. The auto-away
+  FSM keys off the `any_visible?/1` TRANSITION (an emitted event), and no
+  event fires when a pid merely ages out with no write — so a stale
+  `:visible` pid does not itself trip auto-away. Auto-away stays bounded
+  by the real socket DOWN / `client_closing`, unchanged by this fix.
+
+  Efficacy caveat: whether a backgrounded iOS PWA actually stops sending
+  fresh `visible` reports is unconfirmed off-device — the prod socket
+  survived ~90 min under Phoenix's 60s WS idle timeout, implying phx
+  heartbeats (hence JS timers) kept running while backgrounded. The fix
+  is safe by construction (worst case: no improvement, never worse than
+  today); on-device confirmation is owed via a reporter run reading the
+  `/admin/ws_presence` diagnostic (see `snapshot/0`).
 
   ## Lifecycle events
 
@@ -118,19 +155,38 @@ defmodule Grappa.WSPresence do
   # State shape
   # ---------------------------------------------------------------------------
 
-  # `sockets` — %{user_name => %{pid() => :visible | :hidden}}
+  # `sockets` — %{user_name => %{pid() => {:visible | :hidden, last_visible_at}}}
+  #   `last_visible_at` is the monotonic-ms stamp of the pid's last
+  #   `set_visibility(true)` report, or nil when it has never reported
+  #   visible / is hidden. See "Read-time staleness (#318)" in the moduledoc.
   # `notify_pids` — %{user_name => pid()} for test overrides; in production nil
   # `refs_to_user` — %{reference() => user_name} for monitor → user lookup
+  # `stale_ms` — a :visible pid whose last report is older than this counts
+  #   as NOT present for `any_visible?/1`. Injected via `start_link/1` opts;
+  #   NEVER read from Application env at runtime (CLAUDE.md boot-time inject).
 
-  defstruct sockets: %{}, notify_pids: %{}, refs_to_user: %{}
+  # Default read-time staleness window. The client foreground heartbeat
+  # (cicchetto `visibilityHeartbeat.ts`) re-reports at ~half this cadence
+  # (30s), so a genuinely-foreground PWA stays fresh with a whole beat of
+  # margin; this MUST stay ≥ 2× the client heartbeat interval.
+  @default_stale_ms 60_000
+
+  defstruct sockets: %{}, notify_pids: %{}, refs_to_user: %{}, stale_ms: @default_stale_ms
 
   @typedoc "Per-pid reported PWA foreground visibility."
   @type visibility :: :visible | :hidden
 
+  @typedoc "Monotonic-ms stamp of the pid's last :visible report, or nil (#318)."
+  @type last_visible_at :: integer() | nil
+
+  @typedoc "Per-pid presence entry: reported visibility + freshness stamp (#318)."
+  @type pid_state :: {visibility(), last_visible_at()}
+
   @type t :: %__MODULE__{
-          sockets: %{String.t() => %{pid() => visibility()}},
+          sockets: %{String.t() => %{pid() => pid_state()}},
           notify_pids: %{String.t() => pid()},
-          refs_to_user: %{reference() => String.t()}
+          refs_to_user: %{reference() => String.t()},
+          stale_ms: non_neg_integer()
         }
 
   # ---------------------------------------------------------------------------
@@ -140,6 +196,10 @@ defmodule Grappa.WSPresence do
   @doc """
   Starts the WSPresence GenServer as a named singleton. Used by the
   application supervision tree.
+
+  Opts: `:stale_ms` — the read-time staleness window for `any_visible?/1`
+  (#318); defaults to `#{@default_stale_ms}`. Injected here (boot-time)
+  rather than read from Application env at runtime.
   """
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts) when is_list(opts) do
@@ -283,13 +343,35 @@ defmodule Grappa.WSPresence do
     end
   end
 
+  @doc """
+  Test-support: backdates `socket_pid`'s last-visible stamp past
+  `stale_ms` (keeping it `:visible` but stale) so `any_visible?/1`
+  treats it as no-longer-present WITHOUT sleeping the whole window —
+  mirrors the real "backgrounded PWA stopped heartbeating" state (#318).
+  A no-op when `socket_pid` is untracked. Not available in prod.
+  """
+  # Dialyzer sees two clauses depending on Mix.env() (test → :ok reply,
+  # non-test → raises no_return); a single @spec can't capture both.
+  @dialyzer {:nowarn_function, mark_stale_for_test: 2}
+  @spec mark_stale_for_test(String.t(), pid()) :: :ok
+  if Mix.env() == :test do
+    def mark_stale_for_test(user_name, socket_pid)
+        when is_binary(user_name) and is_pid(socket_pid) do
+      GenServer.call(__MODULE__, {:mark_stale_for_test, user_name, socket_pid})
+    end
+  else
+    def mark_stale_for_test(_, _) do
+      raise "mark_stale_for_test/2 is test-only and must not be called in production"
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # GenServer callbacks
   # ---------------------------------------------------------------------------
 
   @impl GenServer
-  def init(_) do
-    {:ok, %__MODULE__{}}
+  def init(opts) do
+    {:ok, %__MODULE__{stale_ms: Keyword.get(opts, :stale_ms, @default_stale_ms)}}
   end
 
   @impl GenServer
@@ -306,7 +388,7 @@ defmodule Grappa.WSPresence do
         state
       else
         ref = Process.monitor(socket_pid)
-        updated = Map.put(existing, socket_pid, :hidden)
+        updated = Map.put(existing, socket_pid, {:hidden, nil})
 
         %{
           state
@@ -331,7 +413,11 @@ defmodule Grappa.WSPresence do
 
     if Map.has_key?(existing, socket_pid) do
       before? = any_visible_in?(state, user_name)
-      updated = Map.put(existing, socket_pid, if(visible, do: :visible, else: :hidden))
+      # #318 — stamp the monotonic freshness time on every visible report so
+      # `any_visible?/1` can discount a stale-visible pid; a hidden report
+      # clears the stamp (nil).
+      entry = if visible, do: {:visible, now_ms()}, else: {:hidden, nil}
+      updated = Map.put(existing, socket_pid, entry)
       state1 = put_user_sockets(state, user_name, updated)
       after? = any_visible_in?(state1, user_name)
       emit_transition(user_name, before?, after?, state1)
@@ -371,7 +457,7 @@ defmodule Grappa.WSPresence do
       before? = any_visible_in?(state, user_name)
       # A closing tab is not visible — mark it hidden now. The real pid
       # DOWN removes it later (idempotent).
-      updated = Map.put(existing, socket_pid, :hidden)
+      updated = Map.put(existing, socket_pid, {:hidden, nil})
       state1 = put_user_sockets(state, user_name, updated)
       after? = any_visible_in?(state1, user_name)
       emit_transition(user_name, before?, after?, state1)
@@ -403,6 +489,19 @@ defmodule Grappa.WSPresence do
     {:reply, :ok, new_state}
   end
 
+  def handle_call({:mark_stale_for_test, user_name, socket_pid}, _, state) do
+    existing = Map.get(state.sockets, user_name, %{})
+
+    if Map.has_key?(existing, socket_pid) do
+      # Backdate strictly past stale_ms so the freshness check discounts it.
+      stale_ts = now_ms() - state.stale_ms - 1_000
+      updated = Map.put(existing, socket_pid, {:visible, stale_ts})
+      {:reply, :ok, put_user_sockets(state, user_name, updated)}
+    else
+      {:reply, :ok, state}
+    end
+  end
+
   @impl GenServer
   def handle_info({:DOWN, ref, :process, pid, _}, state) do
     case Map.get(state.refs_to_user, ref) do
@@ -428,17 +527,36 @@ defmodule Grappa.WSPresence do
   # Private helpers
   # ---------------------------------------------------------------------------
 
-  @spec put_user_sockets(t(), String.t(), %{pid() => visibility()}) :: t()
+  @spec put_user_sockets(t(), String.t(), %{pid() => pid_state()}) :: t()
   defp put_user_sockets(state, user_name, user_sockets) do
     %{state | sockets: Map.put(state.sockets, user_name, user_sockets)}
   end
 
   @spec any_visible_in?(t(), String.t()) :: boolean()
   defp any_visible_in?(state, user_name) do
+    now = now_ms()
+
     state.sockets
     |> Map.get(user_name, %{})
-    |> Enum.any?(fn {_, vis} -> vis == :visible end)
+    |> Enum.any?(fn {_, {vis, last}} ->
+      vis == :visible and fresh?(last, now, state.stale_ms)
+    end)
   end
+
+  # A :visible pid counts as present only while its last report is fresh
+  # (#318). Guard `is_integer(last)` FIRST — a nil (never-reported-visible)
+  # stamp would make `now - nil` a BadArithmeticError and `n <= nil`
+  # silently true (feedback_monotonic_guard_nil_term_order_footgun), so nil
+  # must fall through to `false`, never arithmetic.
+  @spec fresh?(last_visible_at(), integer(), non_neg_integer()) :: boolean()
+  defp fresh?(last, now, stale_ms) when is_integer(last), do: now - last < stale_ms
+  defp fresh?(_, _, _), do: false
+
+  # Monotonic clock — immune to wall-clock adjustments; the sole time base
+  # for the staleness comparison. Isolated so set_visibility, the freshness
+  # check, snapshot, and mark_stale_for_test all share one source.
+  @spec now_ms() :: integer()
+  defp now_ms, do: System.monotonic_time(:millisecond)
 
   # Fire the visibility lifecycle event when `any_visible?/1` transitions
   # for `user_name` (the single crux of the auto-away generalization).

--- a/lib/grappa/ws_presence.ex
+++ b/lib/grappa/ws_presence.ex
@@ -287,6 +287,43 @@ defmodule Grappa.WSPresence do
     GenServer.call(__MODULE__, :list_user_names)
   end
 
+  @typedoc """
+  JSON-encodable read-only snapshot of live presence for the
+  `/admin/ws_presence` diagnostic (#318). `age_ms` is `nil` for a pid
+  that has never reported visible.
+  """
+  @type snapshot :: %{
+          stale_ms: non_neg_integer(),
+          users: [
+            %{
+              user_name: String.t(),
+              any_visible: boolean(),
+              sockets: [
+                %{
+                  pid: String.t(),
+                  visibility: visibility(),
+                  age_ms: non_neg_integer() | nil,
+                  fresh: boolean()
+                }
+              ]
+            }
+          ]
+        }
+
+  @doc """
+  Returns a JSON-encodable snapshot of live presence for every connected
+  user — per-pid reported visibility, `age_ms` since the last visible
+  report, computed freshness, plus `any_visible?/1` per user and the
+  active `stale_ms`. Backs the `/admin/ws_presence` diagnostic (#318): a
+  backgrounded-iOS-PWA run reads back whether the socket went
+  stale/hidden or is (wrongly) still fresh-visible. Users with no live
+  socket are omitted.
+  """
+  @spec snapshot() :: snapshot()
+  def snapshot do
+    GenServer.call(__MODULE__, :snapshot)
+  end
+
   @doc """
   Immediate-close hint — the socket at `socket_pid` is about to close.
 
@@ -448,6 +485,31 @@ defmodule Grappa.WSPresence do
       |> Enum.map(fn {name, _} -> name end)
 
     {:reply, names, state}
+  end
+
+  def handle_call(:snapshot, _, state) do
+    now = now_ms()
+
+    users =
+      state.sockets
+      |> Enum.reject(fn {_, pids} -> map_size(pids) == 0 end)
+      |> Enum.map(fn {user_name, pids} ->
+        %{
+          user_name: user_name,
+          any_visible: any_visible_in?(state, user_name),
+          sockets:
+            Enum.map(pids, fn {pid, {vis, last}} ->
+              %{
+                pid: inspect(pid),
+                visibility: vis,
+                age_ms: if(is_integer(last), do: now - last, else: nil),
+                fresh: fresh?(last, now, state.stale_ms)
+              }
+            end)
+        }
+      end)
+
+    {:reply, %{stale_ms: state.stale_ms, users: users}, state}
   end
 
   def handle_call({:client_closing, user_name, socket_pid}, _, state) do

--- a/lib/grappa_web/controllers/admin/ws_presence_controller.ex
+++ b/lib/grappa_web/controllers/admin/ws_presence_controller.ex
@@ -1,0 +1,30 @@
+defmodule GrappaWeb.Admin.WSPresenceController do
+  @moduledoc """
+  Admin read surface over live WS presence + per-pid visibility freshness
+  (#318). Behind `:admin_authn` — visitor + non-admin user collapse to
+  403 upstream of the action.
+
+  ## GET /admin/ws_presence
+
+  A JSON-encodable snapshot (single-sourced by `Grappa.WSPresence.snapshot/0`):
+
+      %{stale_ms: <ms>,
+        users: [%{user_name, any_visible,
+                  sockets: [%{pid, visibility, age_ms, fresh}, ...]}, ...]}
+
+  This is the diagnostic for the iOS stale-`:visible` push bug: a reporter
+  backgrounds the PWA and the operator reads back whether the socket goes
+  stale/hidden (staleness downgrade working) or is still (wrongly)
+  fresh-visible — the on-device efficacy signal the fix cannot confirm
+  off-device. Read-only; no live state is mutated.
+  """
+  use GrappaWeb, :controller
+
+  alias Grappa.WSPresence
+
+  @doc false
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def index(conn, _) do
+    json(conn, WSPresence.snapshot())
+  end
+end

--- a/lib/grappa_web/router.ex
+++ b/lib/grappa_web/router.ex
@@ -159,6 +159,10 @@ defmodule GrappaWeb.Router do
     # #215 — persisted IRC session-lifecycle log (read-only tail).
     get "/session_log", SessionLogController, :index
 
+    # #318 — live WS presence + per-pid visibility freshness snapshot.
+    # Read-only diagnostic for the iOS stale-`:visible` push bug.
+    get "/ws_presence", WSPresenceController, :index
+
     # #228 — vhost (source-bind) inventory + per-subject grants.
     get "/vhosts", VhostsController, :index
     # #257 — subject autocomplete backing the grant form (users + visitors).

--- a/test/grappa/ws_presence_test.exs
+++ b/test/grappa/ws_presence_test.exs
@@ -142,6 +142,52 @@ defmodule Grappa.WSPresenceTest do
     end
   end
 
+  describe "read-time staleness downgrade (#318)" do
+    # #318 — an iOS PWA backgrounded/closed keeps its WS open but stops
+    # sending fresh `visibility` reports (visibilitychange is unreliable on
+    # the iOS PWA background lifecycle). A stale `:visible` pid must NOT
+    # count as present, so push resumes within @stale_ms instead of only
+    # when the zombie socket finally dies (~90 min in the field report).
+    # `mark_stale_for_test/2` backdates a pid's last-visible stamp past
+    # @stale_ms so we exercise the real staleness comparison without
+    # sleeping the whole window.
+
+    test "a :visible pid whose last report is older than @stale_ms is NOT counted present" do
+      :ok = WSPresence.register("vjt", self())
+      :ok = WSPresence.set_visibility("vjt", self(), true)
+      assert WSPresence.any_visible?("vjt")
+
+      :ok = WSPresence.mark_stale_for_test("vjt", self())
+
+      refute WSPresence.any_visible?("vjt")
+    end
+
+    test "a fresh re-report bumps a stale pid back to visible" do
+      :ok = WSPresence.register("vjt", self())
+      :ok = WSPresence.set_visibility("vjt", self(), true)
+      :ok = WSPresence.mark_stale_for_test("vjt", self())
+      refute WSPresence.any_visible?("vjt")
+
+      # The client foreground heartbeat re-asserts visibility — freshness resets.
+      :ok = WSPresence.set_visibility("vjt", self(), true)
+      assert WSPresence.any_visible?("vjt")
+    end
+
+    test "one stale + one fresh visible pid → any_visible? stays true" do
+      fresh = stub_pid()
+      :ok = WSPresence.register("vjt", self())
+      :ok = WSPresence.register("vjt", fresh)
+      :ok = WSPresence.set_visibility("vjt", self(), true)
+      :ok = WSPresence.set_visibility("vjt", fresh, true)
+      :ok = WSPresence.mark_stale_for_test("vjt", self())
+
+      # self() is stale, `fresh` is not — the user is still genuinely present.
+      assert WSPresence.any_visible?("vjt")
+
+      send(fresh, :stop)
+    end
+  end
+
   describe "socket pid DOWN handling" do
     test "count decrements when a tracked pid exits" do
       p1 = stub_pid()

--- a/test/grappa_web/controllers/admin/ws_presence_controller_test.exs
+++ b/test/grappa_web/controllers/admin/ws_presence_controller_test.exs
@@ -1,0 +1,103 @@
+defmodule GrappaWeb.Admin.WSPresenceControllerTest do
+  @moduledoc """
+  `GET /admin/ws_presence` (#318) — read-only live snapshot of the
+  per-user / per-pid WS presence + freshness. The diagnostic backing the
+  on-device efficacy verification for the iOS stale-`:visible` push bug:
+  a reporter backgrounds the PWA and the operator reads back whether the
+  socket goes stale/hidden (fix working) or stays fresh-visible (fix not
+  yet effective). Behind `:admin_authn`: visitor + non-admin collapse to
+  403 upstream of the action.
+
+  `async: false` — reads `Grappa.WSPresence`, an app-wide singleton
+  (config `max_cases: 1`); concurrent tests would collide on its state.
+  """
+  use GrappaWeb.ConnCase, async: false
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.{Accounts, WSPresence}
+
+  setup do
+    :ok = WSPresence.reset_for_test()
+    :ok
+  end
+
+  defp admin_session do
+    {user, session} = user_and_session()
+    {:ok, _} = Accounts.update_admin_flags(user, %{is_admin: true})
+    session
+  end
+
+  defp live_pid do
+    spawn(fn -> Process.sleep(:infinity) end)
+  end
+
+  describe "GET /admin/ws_presence — auth gate" do
+    test "no bearer returns 401", %{conn: conn} do
+      assert conn |> get("/admin/ws_presence") |> json_response(401) ==
+               %{"error" => "unauthorized"}
+    end
+
+    test "visitor subject returns 403", %{conn: conn} do
+      {_, session} = visitor_and_session()
+
+      assert conn |> put_bearer(session.id) |> get("/admin/ws_presence") |> json_response(403) ==
+               %{"error" => "forbidden"}
+    end
+
+    test "non-admin user returns 403", %{conn: conn} do
+      {_, session} = user_and_session()
+
+      assert conn |> put_bearer(session.id) |> get("/admin/ws_presence") |> json_response(403) ==
+               %{"error" => "forbidden"}
+    end
+  end
+
+  describe "GET /admin/ws_presence — admin snapshot" do
+    test "200 exposes stale_ms and an empty user list when nobody is connected",
+         %{conn: conn} do
+      session = admin_session()
+      body = conn |> put_bearer(session.id) |> get("/admin/ws_presence") |> json_response(200)
+
+      assert %{"stale_ms" => stale_ms, "users" => []} = body
+      assert is_integer(stale_ms) and stale_ms > 0
+    end
+
+    test "200 reports a fresh visible pid as present", %{conn: conn} do
+      device = live_pid()
+      :ok = WSPresence.register("vjt", device)
+      :ok = WSPresence.set_visibility("vjt", device, true)
+
+      session = admin_session()
+      body = conn |> put_bearer(session.id) |> get("/admin/ws_presence") |> json_response(200)
+
+      assert [user] = body["users"]
+      assert user["user_name"] == "vjt"
+      assert user["any_visible"] == true
+      assert [socket] = user["sockets"]
+      assert socket["visibility"] == "visible"
+      assert socket["fresh"] == true
+      assert is_integer(socket["age_ms"])
+
+      Process.exit(device, :kill)
+    end
+
+    test "200 reports a stale visible pid as not-fresh + user not present", %{conn: conn} do
+      device = live_pid()
+      :ok = WSPresence.register("vjt", device)
+      :ok = WSPresence.set_visibility("vjt", device, true)
+      :ok = WSPresence.mark_stale_for_test("vjt", device)
+
+      session = admin_session()
+      body = conn |> put_bearer(session.id) |> get("/admin/ws_presence") |> json_response(200)
+
+      assert [user] = body["users"]
+      assert user["any_visible"] == false
+      assert [socket] = user["sockets"]
+      assert socket["visibility"] == "visible"
+      assert socket["fresh"] == false
+
+      Process.exit(device, :kill)
+    end
+  end
+end


### PR DESCRIPTION
## Summary (ref #318, P0)

Web Push was suppressed indefinitely for an iOS cicchetto PWA the user
backgrounded/closed: the WebSocket stays open but iOS does not reliably
fire `visibilitychange`, so the socket's pid stayed `:visible` in
`Grappa.WSPresence`, `any_visible?/1` read the user as present, and
`Push.Triggers`' foreground-suppression gate (#182) skipped the entire
fan-out. In the field it self-healed only after **~90 min**, when the
zombie socket finally died.

## Fix — read-time staleness (server) + foreground heartbeat (client)

The owner-blessed direction, **safe by construction**:

- **Server (`Grappa.WSPresence`, COLD).** Each pid now carries
  `{visibility, last_visible_at}` (monotonic ms), stamped on every
  `set_visibility(true)`. `any_visible?/1` counts a pid present iff it is
  `:visible` **AND** `now - last_visible_at < stale_ms` (default 60s,
  injected via `start_link/1` opts — never runtime `Application.get_env`).
  Read-time derivation: no sweep, no parallel timer state.
  `Push.Triggers` is **unchanged** — the fix flows through the one gate.
- **Client (cicchetto `visibilityHeartbeat.ts`).** A foreground
  heartbeat re-reports visibility every 30s (half `stale_ms`) while
  foreground, stopping when hidden. Reuses the `visibility` verb — no new
  channel event. Because `reportVisibility` re-reads the live
  `document.visibilityState`/`hasFocus()` each call, the tick also
  catches a **silent** iOS hide (property flips with no event).

A genuinely-foreground app stays fresh by construction, so foreground
push-suppression (acceptance #2) is **preserved**; a backgrounded app
goes stale and push resumes within `stale_ms` (~60s) instead of ~90 min.

## ★ iOS efficacy caveat (device-verify owed)

Efficacy hinges on an iOS behaviour that **cannot be confirmed
off-device**: does a backgrounded PWA stop sending fresh `visible`
reports? The prod socket survived ~90 min under Phoenix's default **60s
WS idle timeout** (`endpoint.ex` sets no custom `websocket: [timeout:]`),
implying phx heartbeats — hence JS timers — kept running while
backgrounded. If timers run AND `document.visibilityState` stays
"visible", neither mechanism engages and the fix is a no-op (**never
worse than today**). The load-bearing hope is the silent-property-flip
path; only a real device decides it. Shipped as a **safe backstop** — the
on-device confirmation is owed post-deploy via the reporter.

## Diagnostic — `GET /admin/ws_presence`

Read-only admin endpoint (`WSPresence.snapshot/0`) exposing per-user /
per-pid visibility, `age_ms`, freshness, `any_visible?`, and `stale_ms`,
so the device run can be read back from the server. Behind `:admin_authn`;
one `infra/snippets/locations-api.conf` regex edit adds it to the nginx
allowlist (that snippet is mounted into both the prod/docker nginx and
the e2e nginx-test).

## Tests / gates

- Server: `mark_stale_for_test/2` (Mix.env-guarded) drives a
  deterministic RED→GREEN staleness gate without sleeping; controller
  test covers the 401/403 auth gate + fresh-vs-stale snapshot shape.
- Client: vitest fake timers prove the heartbeat fires while visible,
  stops when hidden, never stacks. The iOS-specific behaviour is
  deliberately **not** asserted (harness can't reproduce it — that's the
  owed device-verify).
- `scripts/check.sh`: 3818 tests / 43 properties / 8 doctests, 0
  failures; credo strict + dialyzer + sobelow clean (only the known
  pre-existing bats-#44 baseline fails). `bun run build`/`check` (0
  `error TS`, 23-warning baseline unchanged) / `test` (2945) green. Full
  `scripts/integration.sh` **430 passed**, 0 failures.

## Deploy

**COLD** — `Grappa.WSPresence` state-shape change is hot-reload-unsafe
(tracked in `HotReload.LongLivedModules`), and the cic bundle carries the
heartbeat. **HELD** — rides the already-HELD #299 COLD batch. The COLD
window MUST include the post-deploy iPhone efficacy verification.

Ref #318.