### PR TITLE
#249: drive the cic /umode modal from the server-advertised umode set

### DIFF
--- a/cicchetto/src/UmodeModal.tsx
+++ b/cicchetto/src/UmodeModal.tsx
@@ -2,6 +2,7 @@ import { type Component, For, Show } from "solid-js";
 import { networkIdBySlug } from "./lib/networks";
 import { createOverlayLock } from "./lib/overlayScrollLock";
 import { pushChannelUmode } from "./lib/socket";
+import { supportedUmodesForNetwork } from "./lib/supportedUmodes";
 import { closeUmodeModal, umodeModalState } from "./lib/umodeModal";
 import { type AvailableUmode, availableUmodes } from "./lib/umodeModes";
 import { umodesForNetwork } from "./lib/umodes";
@@ -16,8 +17,12 @@ import { umodesForNetwork } from "./lib/umodes";
 //
 // Data sources (all server-owned, cic mirrors — no client state
 // origination):
-//   * available toggles ← the static `umodeModes` table unioned with any
-//     active-but-unknown vendor letter (availableUmodes/1).
+//   * available toggles ← the SERVER-advertised supported-umode set
+//     (`supportedUmodesForNetwork`, from 004 RPL_MYINFO via the
+//     supported_umodes_changed wire event, #249), unioned with any active
+//     letter; falls back to the static `umodeModes` table when the server
+//     hasn't advertised (availableUmodes/2). This mirrors #216's channel-mode
+//     modal driving its toggles from server-advertised CHANMODES.
 //   * active umodes     ← `umodesForNetwork(networkId)` (from 221 / self-MODE
 //     echoes, seeded via the umode_changed wire event).
 //
@@ -45,7 +50,15 @@ const UmodeModal: Component = () => {
     return id === undefined ? [] : umodesForNetwork(id);
   };
 
-  const toggles = (): AvailableUmode[] => availableUmodes(activeModes());
+  // #249 — the server-advertised supported umode set (004 RPL_MYINFO). Empty
+  // when the network hasn't advertised → availableUmodes falls back to the
+  // static table.
+  const serverSet = (): string[] => {
+    const id = networkId();
+    return id === undefined ? [] : supportedUmodesForNetwork(id);
+  };
+
+  const toggles = (): AvailableUmode[] => availableUmodes(activeModes(), serverSet());
 
   const isActive = (letter: string): boolean => activeModes().includes(letter);
 

--- a/cicchetto/src/__tests__/UmodeModal.test.tsx
+++ b/cicchetto/src/__tests__/UmodeModal.test.tsx
@@ -21,6 +21,14 @@ vi.mock("../lib/umodes", () => ({
   umodesForNetwork: (id: number) => mockUmodes[id] ?? [],
 }));
 
+// #249 — server-advertised supported-umode set. Empty (unseeded) → the modal
+// falls back to the static table, exercising the pre-#249 behavior in every
+// test that doesn't set it.
+let mockSupported: Record<number, string[]> = {};
+vi.mock("../lib/supportedUmodes", () => ({
+  supportedUmodesForNetwork: (id: number) => mockSupported[id] ?? [],
+}));
+
 import { closeUmodeModal, openUmodeModal } from "../lib/umodeModal";
 import UmodeModal from "../UmodeModal";
 
@@ -28,6 +36,7 @@ describe("UmodeModal", () => {
   beforeEach(() => {
     socketMock.pushChannelUmode.mockClear();
     mockUmodes = {};
+    mockSupported = {};
     closeUmodeModal();
   });
 
@@ -90,5 +99,19 @@ describe("UmodeModal", () => {
     const vendor = getByLabelText(/\+Z/);
     expect(vendor.getAttribute("aria-pressed")).toBe("true");
     expect(vendor.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("renders only the server-advertised umodes when the server sent a set (#249)", () => {
+    // The server advertised only +i (invisible) and +x (masked host); the
+    // modal renders exactly those, NOT the full static table.
+    mockUmodes[1] = [];
+    mockSupported[1] = ["i", "x"];
+    openUmodeModal("bahamut");
+
+    const { getByText, queryByText } = render(() => <UmodeModal />);
+    expect(getByText("invisible")).toBeTruthy();
+    expect(getByText("masked host")).toBeTruthy();
+    // +w (wallops) is in the static table but was NOT advertised — absent.
+    expect(queryByText("wallops")).toBeNull();
   });
 });

--- a/cicchetto/src/__tests__/supportedUmodes.test.ts
+++ b/cicchetto/src/__tests__/supportedUmodes.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+// #249 — per-network SUPPORTED umode store. Seeded by the
+// `supported_umodes_changed` user-topic event (server parses 004 RPL_MYINFO).
+// The /umode modal drives its AVAILABLE toggles from this set, falling back to
+// a static table when a network hasn't advertised. Mirrors the umodes store
+// shape but holds the server-ADVERTISED letter list per network.
+
+import {
+  seedSupportedUmodes,
+  supportedUmodesByNetwork,
+  supportedUmodesForNetwork,
+} from "../lib/supportedUmodes";
+
+describe("supportedUmodes store", () => {
+  it("supportedUmodesForNetwork returns [] before any seed", () => {
+    expect(supportedUmodesForNetwork(9999)).toEqual([]);
+  });
+
+  it("seedSupportedUmodes stores the letter list keyed by network id", () => {
+    seedSupportedUmodes(7, ["i", "o", "w"]);
+    expect(supportedUmodesByNetwork()[7]).toEqual(["i", "o", "w"]);
+    expect(supportedUmodesForNetwork(7)).toEqual(["i", "o", "w"]);
+  });
+
+  it("seedSupportedUmodes is last-write-wins per network (idempotent re-seed)", () => {
+    seedSupportedUmodes(7, ["i"]);
+    seedSupportedUmodes(7, ["w"]);
+    expect(supportedUmodesForNetwork(7)).toEqual(["w"]);
+  });
+
+  it("supportedUmodesForNetwork falls back to [] for an unseeded network", () => {
+    seedSupportedUmodes(7, ["i"]);
+    expect(supportedUmodesForNetwork(12345)).toEqual([]);
+  });
+});

--- a/cicchetto/src/__tests__/umodeModes.test.ts
+++ b/cicchetto/src/__tests__/umodeModes.test.ts
@@ -53,9 +53,11 @@ describe("umodeModes description table", () => {
   });
 });
 
-describe("availableUmodes", () => {
+// #249 — with an empty serverSet, availableUmodes falls back to the static
+// KNOWN table (unioned with active letters) — the pre-#249 behavior.
+describe("availableUmodes — static-table fallback (empty serverSet)", () => {
   it("lists the KNOWN umode table with settable arity", () => {
-    const modes = availableUmodes([]);
+    const modes = availableUmodes([], []);
     const find = (letter: string) => modes.find((m) => m.letter === letter);
 
     const i = find("i");
@@ -69,14 +71,60 @@ describe("availableUmodes", () => {
   });
 
   it("surfaces an active-but-unknown letter (vendor umode) read-only, no crash", () => {
-    const modes = availableUmodes(["Z"]);
+    const modes = availableUmodes(["Z"], []);
     const z = modes.find((m) => m.letter === "Z");
     expect(z).toBeDefined();
     expect(z?.settable).toBe(false);
   });
 
   it("is sorted by label for a stable modal layout", () => {
-    const labels = availableUmodes([]).map((m) => m.label);
+    const labels = availableUmodes([], []).map((m) => m.label);
+    const sorted = [...labels].sort((a, b) => a.localeCompare(b));
+    expect(labels).toEqual(sorted);
+  });
+});
+
+// #249 — when the server advertised a supported set (004 RPL_MYINFO), the
+// modal renders exactly that set (unioned with active letters), NOT the full
+// static table. Known letters keep their description; advertised-but-unknown
+// letters get the generic non-settable copy.
+describe("availableUmodes — server-advertised set (#249)", () => {
+  it("renders one entry per advertised letter (known letters keep their copy)", () => {
+    const modes = availableUmodes([], ["i", "o", "x"]);
+    expect(modes.map((m) => m.letter).sort()).toEqual(["i", "o", "x"]);
+
+    const i = modes.find((m) => m.letter === "i");
+    expect(i?.label).toBe("invisible");
+    expect(i?.settable).toBe(true);
+
+    const o = modes.find((m) => m.letter === "o");
+    expect(o?.settable).toBe(false); // operator — server-managed
+  });
+
+  it("does NOT include static-table letters the server did not advertise", () => {
+    // "w" (wallops) is in the static table but not in this advertised set.
+    const modes = availableUmodes([], ["i", "x"]);
+    expect(modes.find((m) => m.letter === "w")).toBeUndefined();
+  });
+
+  it("gives an advertised-but-unknown vendor letter the generic non-settable copy", () => {
+    const modes = availableUmodes([], ["Q"]);
+    const q = modes.find((m) => m.letter === "Q");
+    expect(q).toBeDefined();
+    expect(q?.settable).toBe(false);
+    expect(q?.desc).toMatch(/no description available/i);
+  });
+
+  it("still surfaces an active letter the server omitted (union with active)", () => {
+    // The operator holds +Z but the server's 004 didn't list it — it must
+    // still render (read-only) so the active state is never hidden.
+    const modes = availableUmodes(["Z"], ["i"]);
+    expect(modes.map((m) => m.letter).sort()).toEqual(["Z", "i"]);
+    expect(modes.find((m) => m.letter === "Z")?.settable).toBe(false);
+  });
+
+  it("is sorted by label for a stable modal layout", () => {
+    const labels = availableUmodes([], ["i", "o", "x", "w"]).map((m) => m.label);
     const sorted = [...labels].sort((a, b) => a.localeCompare(b));
     expect(labels).toEqual(sorted);
   });

--- a/cicchetto/src/__tests__/userTopic.test.ts
+++ b/cicchetto/src/__tests__/userTopic.test.ts
@@ -131,6 +131,10 @@ vi.mock("../lib/umodes", () => ({
   seedUmodes: vi.fn(),
 }));
 
+vi.mock("../lib/supportedUmodes", () => ({
+  seedSupportedUmodes: vi.fn(),
+}));
+
 // #100 — builds a valid connection_state_changed payload (the narrower
 // requires the full set of top-level + nested `network` fields).
 function connectionStateChanged(slug: string, to: "connected" | "parked" | "failed") {
@@ -361,6 +365,59 @@ describe("userTopic", () => {
       vi.mocked(umodes.seedUmodes).mockClear();
       channelMock.fireEvent({ kind: "umode_changed", network_id: 7, modes: "iwS" });
       expect(umodes.seedUmodes).not.toHaveBeenCalled();
+    });
+  });
+
+  // #249 — supported_umodes_changed seeds the per-network supported-umode store.
+  describe("supported_umodes_changed event (#249)", () => {
+    it("calls seedSupportedUmodes with the narrowed advertised letter list", async () => {
+      const supported = await import("../lib/supportedUmodes");
+      channelMock.fireEvent({
+        kind: "supported_umodes_changed",
+        network_id: 7,
+        modes: ["g", "i", "k", "o", "r", "s", "w"],
+      });
+      expect(supported.seedSupportedUmodes).toHaveBeenCalledWith(7, [
+        "g",
+        "i",
+        "k",
+        "o",
+        "r",
+        "s",
+        "w",
+      ]);
+    });
+
+    it("accepts an empty advertised list", async () => {
+      const supported = await import("../lib/supportedUmodes");
+      vi.mocked(supported.seedSupportedUmodes).mockClear();
+      channelMock.fireEvent({ kind: "supported_umodes_changed", network_id: 7, modes: [] });
+      expect(supported.seedSupportedUmodes).toHaveBeenCalledWith(7, []);
+    });
+
+    it("drops supported_umodes_changed with a non-number network_id (narrower rejects)", async () => {
+      const supported = await import("../lib/supportedUmodes");
+      vi.mocked(supported.seedSupportedUmodes).mockClear();
+      channelMock.fireEvent({
+        kind: "supported_umodes_changed",
+        network_id: "seven",
+        modes: ["i"],
+      });
+      expect(supported.seedSupportedUmodes).not.toHaveBeenCalled();
+    });
+
+    it("drops supported_umodes_changed whose modes contain a non-string (narrower rejects)", async () => {
+      const supported = await import("../lib/supportedUmodes");
+      vi.mocked(supported.seedSupportedUmodes).mockClear();
+      channelMock.fireEvent({ kind: "supported_umodes_changed", network_id: 7, modes: ["i", 42] });
+      expect(supported.seedSupportedUmodes).not.toHaveBeenCalled();
+    });
+
+    it("drops supported_umodes_changed with a non-array modes (narrower rejects)", async () => {
+      const supported = await import("../lib/supportedUmodes");
+      vi.mocked(supported.seedSupportedUmodes).mockClear();
+      channelMock.fireEvent({ kind: "supported_umodes_changed", network_id: 7, modes: "iwS" });
+      expect(supported.seedSupportedUmodes).not.toHaveBeenCalled();
     });
   });
 

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -906,6 +906,19 @@ export type WireUserEvent =
       modes: string[];
     }
   | {
+      // #249 — per-session SUPPORTED user-mode set, parsed from 004 RPL_MYINFO
+      // server-side. The AVAILABILITY set (distinct from umode_changed's ACTIVE
+      // set): the `/umode` modal drives its togglable letters from this, exactly
+      // as #216's isupport CHANMODES drives channel-mode toggles. Rides
+      // `Topic.user/1` (per (subject, network)) and is cold-snapshotted on the
+      // user-topic after-join push (umodes are reachable with zero channels).
+      // userTopic.ts dispatches into `seedSupportedUmodes(network_id, modes)`.
+      // `modes` is the sorted letter list the server advertised.
+      kind: "supported_umodes_changed";
+      network_id: number;
+      modes: string[];
+    }
+  | {
       // #216 — per-network ISUPPORT channel-mode capability set, parsed
       // from 005 RPL_ISUPPORT CHANMODES= + PREFIX= server-side. The
       // `/mode` modal drives its available toggles from this. Rides

--- a/cicchetto/src/lib/supportedUmodes.ts
+++ b/cicchetto/src/lib/supportedUmodes.ts
@@ -1,0 +1,46 @@
+import { createRoot, createSignal } from "solid-js";
+
+// #249 — per-network SUPPORTED user-mode (umode) store.
+//
+// Seeded by the `supported_umodes_changed` user-topic event (userTopic.ts),
+// which the server emits from its 004 RPL_MYINFO parse — the AVAILABILITY set
+// the server advertises (distinct from the `umode_changed` ACTIVE set the
+// operator holds). The `/umode` modal (UmodeModal) drives its togglable
+// letters from this set, exactly as #216's isupport CHANMODES drives the
+// channel-mode modal — falling back to a static bahamut table when the server
+// never advertised (a network that omits 004 umodes, or a parked/pre-snapshot
+// session; see `availableUmodes`).
+//
+// Keyed by network id (umodes are per (subject, network), like isupport's
+// per-network capability set — unlike channelTopic's per-channel modes).
+// Module-singleton reactive signal, harmlessly overwritten on the next seed;
+// a logout leaves stale entries the next login's cold-snapshot re-seeds.
+//
+// The set is a sorted list of single-letter strings.
+// `supportedUmodesForNetwork/1` returns `[]` for an unseeded network, which
+// `availableUmodes` reads as "no server set → use the static fallback".
+
+const exports_ = createRoot(() => {
+  const [supportedUmodesByNetwork, setSupportedUmodesByNetwork] = createSignal<
+    Record<number, string[]>
+  >({});
+
+  const seedSupportedUmodes = (networkId: number, modes: string[]): void => {
+    setSupportedUmodesByNetwork((prev) => ({ ...prev, [networkId]: modes }));
+  };
+
+  return { supportedUmodesByNetwork, seedSupportedUmodes };
+});
+
+export const supportedUmodesByNetwork = exports_.supportedUmodesByNetwork;
+export const seedSupportedUmodes = exports_.seedSupportedUmodes;
+
+/**
+ * The server-advertised supported umode letters for a network, or `[]` when
+ * the network hasn't advertised (no 004 parsed yet / no live session). An
+ * empty result signals "no server set" to `availableUmodes`, which then falls
+ * back to the static umode table.
+ */
+export function supportedUmodesForNetwork(networkId: number): string[] {
+  return supportedUmodesByNetwork()[networkId] ?? [];
+}

--- a/cicchetto/src/lib/umodeModes.ts
+++ b/cicchetto/src/lib/umodeModes.ts
@@ -1,13 +1,15 @@
 // #229 — static USER-mode (umode) description table + the display
 // derivation for the /mode <nick> (umode) modal.
 //
-// Unlike channel modes (#216), umodes have NO ISUPPORT availability source
-// grappa parses (004 RPL_MYINFO carries the letters but is deliberately not
-// parsed — it's connect-storm server metadata). So this static table IS the
-// available set: the KNOWN bahamut/Azzurra umodes, plus any currently-active
-// letter the operator holds that isn't in the table (a vendor umode still
-// renders rather than vanishing). Descriptions are UI copy and MUST live in
-// cic, never on the wire (CLAUDE.md "no localized strings server-side").
+// As of #249 the AVAILABLE set is driven by the SERVER-advertised umode set
+// (004 RPL_MYINFO, parsed server-side into a `supported_umodes_changed` wire
+// event), exactly as #216 drives the channel-mode modal from server CHANMODES.
+// This static table is now the FALLBACK: its descriptions ARE the UI copy for
+// the known bahamut/Azzurra umodes, and its KEYS supply the available set only
+// when the server has not advertised one (a network that omits 004 umodes, or
+// a pre-snapshot session — see `availableUmodes`). Descriptions are UI copy and
+// MUST live in cic, never on the wire (CLAUDE.md "no localized strings
+// server-side").
 //
 // `settable` marks umodes a normal user may flip themselves. Server-managed
 // umodes (o oper, r registered, a/A services/admin), IRCop snomask receive
@@ -93,14 +95,30 @@ export type AvailableUmode = {
 };
 
 /**
- * The umodes the modal renders, given the operator's currently-active set.
- * The union of the KNOWN table letters and any active-but-unknown letter,
- * so a vendor umode the operator holds still shows (read-only). Each entry
- * carries the human copy + whether the user may toggle it. Sorted by label
- * for a stable modal layout.
+ * The umodes the modal renders. When the server advertised a supported set
+ * (004 RPL_MYINFO, #249), the available letters are that set unioned with any
+ * currently-active letter — an active umode always renders even if the server
+ * omitted it from the advertisement (defensive: never hide the operator's own
+ * active state). When `serverSet` is empty (a network that never advertised,
+ * or a pre-snapshot session), fall back to the KNOWN static table unioned with
+ * active letters — the pre-#249 behavior. This mirrors #216's `availableModes`
+ * folding server-advertised CHANMODES for channel modes; the server drives the
+ * WHICH-letters, cic owns the description copy. Known letters keep their
+ * description + settable arity; an advertised-but-unknown vendor letter gets
+ * the generic non-settable copy. Sorted by label for a stable modal layout.
+ *
+ * REPLACE (not union-with-static) when `serverSet` is non-empty is deliberate:
+ * 004 RPL_MYINFO is the ircd's AUTHORITATIVE supported-umode list — a
+ * well-behaved bahamut/solanum lists every supported letter (Azzurra's real 004
+ * carries the full settable set i/w/s/x/R), so honoring it faithfully is the
+ * whole point of #249. A hypothetical PARTIAL 004 would drop an omitted-but-
+ * settable letter from the modal; that degradation is accepted (the operator
+ * can still `/umode +x` by hand) rather than re-unioning the static guess this
+ * feature removes and offering toggles the server may reject.
  */
-export function availableUmodes(activeModes: string[]): AvailableUmode[] {
-  const letters = new Set<string>([...Object.keys(UMODE_DESCRIPTIONS), ...activeModes]);
+export function availableUmodes(activeModes: string[], serverSet: string[]): AvailableUmode[] {
+  const base = serverSet.length > 0 ? serverSet : Object.keys(UMODE_DESCRIPTIONS);
+  const letters = new Set<string>([...base, ...activeModes]);
 
   return [...letters]
     .map((letter) => {

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -29,6 +29,7 @@ import { selectedChannel, setSelectedChannel } from "./selection";
 import { setServerReply } from "./serverReplyModal";
 import { applyServerSettings } from "./serverSettings";
 import { joinUser } from "./socket";
+import { seedSupportedUmodes } from "./supportedUmodes";
 import { seedUmodes } from "./umodes";
 import { setWhoisBundle } from "./whoisCard";
 import { setWhoReply } from "./whoModal";
@@ -273,6 +274,19 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
       if (typeof r.network_id !== "number" || !Array.isArray(r.modes)) return null;
       if (!r.modes.every((m) => typeof m === "string")) return null;
       return { kind: "umode_changed", network_id: r.network_id, modes: r.modes as string[] };
+    }
+    case "supported_umodes_changed": {
+      // #249 — per-session SUPPORTED umode set. User-topic-only, narrowed
+      // inline here (mirror of umode_changed). `modes` must be a string[]
+      // (sorted advertised umode letters); any non-string element drops the
+      // whole payload.
+      if (typeof r.network_id !== "number" || !Array.isArray(r.modes)) return null;
+      if (!r.modes.every((m) => typeof m === "string")) return null;
+      return {
+        kind: "supported_umodes_changed",
+        network_id: r.network_id,
+        modes: r.modes as string[],
+      };
     }
     case "isupport_changed":
       // #216 — dual-topic event: this is the LIVE 005 edge on the user
@@ -785,6 +799,14 @@ createRoot(() => {
           // snapshot (user-topic after-join) both flow here; last-write-wins
           // idempotent.
           seedUmodes(payload.network_id, payload.modes);
+          return;
+
+        case "supported_umodes_changed":
+          // #249 — seed the per-network SUPPORTED umode set the /umode modal
+          // reads for its AVAILABLE toggles. Live edge (004 RPL_MYINFO) + cold
+          // snapshot (user-topic after-join) both flow here; last-write-wins
+          // idempotent.
+          seedSupportedUmodes(payload.network_id, payload.modes);
           return;
 
         case "connection_state_changed":

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -557,6 +557,7 @@ export type SessionWireWireEventKind =
   | "own_nick_changed"
   | "isupport_changed"
   | "umode_changed"
+  | "supported_umodes_changed"
   | "topic_changed"
   | "channel_modes_changed"
   | "channel_created"
@@ -603,6 +604,12 @@ export type SessionWireIsupportChangedPayload = {
 
 export type SessionWireUmodeChangedPayload = {
   kind: "umode_changed";
+  network_id: number;
+  modes: string[];
+};
+
+export type SessionWireSupportedUmodesChangedPayload = {
+  kind: "supported_umodes_changed";
   network_id: number;
   modes: string[];
 };
@@ -860,6 +867,7 @@ export type WireSessionEvent =
   | SessionWireOwnNickChangedPayload
   | SessionWireIsupportChangedPayload
   | SessionWireUmodeChangedPayload
+  | SessionWireSupportedUmodesChangedPayload
   | SessionWireTopicChangedPayload
   | SessionWireChannelModesChangedPayload
   | SessionWireChannelCreatedPayload

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -25135,3 +25135,61 @@ _Deploy: **COLD** — `Grappa.WSPresence` state-shape change (per-pid tuple +
 — rides the already-HELD #299 COLD batch (with #282 / #290 / #294 / #302 / #304 /
 #305 / #306 / #307). The COLD window MUST include the post-deploy iPhone efficacy
 verification with the reporter (vjt / #sniffo) reading `/admin/ws_presence`._
+
+### 2026-07-18 — #249: drive the cic /umode modal from the server-advertised umode set
+
+**Gap.** cicchetto's `UmodeModal` rendered its togglable letters from a STATIC
+bahamut umode table (`umodeModes.ts`), unioned with any active-but-unknown
+letter — a pure-cic best effort. That is the umode twin of the channel-mode
+modal, which #216 already drives from the network's SERVER-advertised CHANMODES
+(005 RPL_ISUPPORT). The umode side had no such source: the supported-umode set
+lives in 004 RPL_MYINFO (param index 3, e.g. `"oiwgrsk"`), which the server
+deliberately did NOT parse — 004 is on the connect-storm deny list
+(`NumericRouter.@active_numerics`), routed to `$server` for display with its
+params ignored (the bucket-I ghost-routing fix). `umode_changed` (#229) carries
+only the operator's ACTIVE set (221 RPL_UMODEIS), not the AVAILABILITY set.
+Split out of #240 part 3; was gated on #221 (generic upstream umode parsing),
+now closed — so buildable.
+
+**Fix — mirror the #216 ISUPPORT plumbing (reuse the verbs, not the nouns).**
+- **Parse (server).** A new `EventRouter` clause folds 004 param index 3 into a
+  per-session `supported_umodes` set and emits `{:supported_umodes_changed,
+  letters}`. It runs INSIDE the generic numeric handler's `EventRouter.route/2`
+  call — AFTER the `$server` `:notice` persist and WITHOUT touching
+  `NumericRouter` — so 004 still displays and the ghost-routing fix is preserved
+  (`numeric_router_test` guards the routing decision). `parse_supported_umodes/1`
+  (graphemes → dedupe → sort) is a DISTINCT helper from `apply_umode_string/2`:
+  the supported set is an availability advertisement, not a `+/-` delta — same
+  wire SHAPE, different MEANING (design-discipline #6).
+- **State + wire.** `Grappa.Session.Server` gains a `supported_umodes` field
+  (default `[]`, `Map.get`/`Map.put` hot-reload-safe reads mirroring
+  `:umodes` / `:isupport`); `apply_effects` broadcasts the typed
+  `supported_umodes_changed` payload on `Topic.user/1` (per (subject, network),
+  same carrier as `umode_changed` / `isupport_changed`). A
+  `get_supported_umodes` handle_call + `Session` facade + a
+  `push_supported_umodes_if_live/2` user-topic cold-WS-subscribe snapshot close
+  the always-on-session race (mirror of `push_umodes_if_live/2`).
+- **Fold (cic).** A `supportedUmodes` store (mirror of `umodes.ts`) is seeded
+  from the narrowed `supported_umodes_changed` event; `availableUmodes(active,
+  serverSet)` renders one toggle per ADVERTISED letter (known letters keep their
+  cic-side description, unknown get the generic non-settable copy), falling back
+  to the static table when `serverSet` is empty (a network that omits 004
+  umodes, or a pre-snapshot session). An active letter the server omitted still
+  renders (never hide the operator's own state). The description table (#301
+  Azzurra semantics) is unchanged — #249 only changes WHICH letters are
+  available, not what they mean.
+- **REPLACE, not union.** A non-empty advertised set REPLACES the static table
+  (union would reintroduce the static guess #249 removes and offer toggles a
+  server may reject). 004 is the ircd's AUTHORITATIVE supported-umode list —
+  Azzurra's real bahamut 004 carries the full settable set (`i w s x R`, e.g.
+  `iowghraAsORTVSCKBxNI`), so nothing is hidden on the target; the short
+  `oiwgrsk` used in the tests is an illustrative subset. A hypothetical PARTIAL
+  004 would drop an omitted-but-settable letter from the modal — an accepted
+  degradation (the operator can still `/umode +x` by hand), not a re-union of
+  the static table.
+
+_Deploy: **COLD** — the `supported_umodes` field is a `Grappa.Session.Server`
+state-shape change (already tracked in `HotReload.LongLivedModules` →
+`Deploy.Preflight` auto-classifies COLD), and the cic bundle carries the fold.
+**HELD** — rides the already-HELD #299 COLD batch (with #282 / #290 / #294 /
+#301 / #302 / #304 / #305 / #306 / #307 / #318)._

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -898,6 +898,22 @@ defmodule Grappa.Session do
     call_session(subject, network_id, :get_umodes)
   end
 
+  @doc """
+  Returns the per-session SUPPORTED USER-mode set (#249).
+
+  Serves the in-memory `supported_umodes` list — the umode letters the server
+  advertised in 004 RPL_MYINFO (or `[]` before it arrives). Returns
+  `{:ok, modes}` or `{:error, :no_session}` when no session is registered for
+  `(subject, network_id)`. Used by the user-topic cold-WS-subscribe snapshot
+  to seed the cic `/umode` modal's AVAILABLE toggles from connect.
+  """
+  @spec get_supported_umodes(subject(), integer()) ::
+          {:ok, [String.t()]} | {:error, :no_session}
+  def get_supported_umodes(subject, network_id)
+      when is_subject(subject) and is_integer(network_id) do
+    call_session(subject, network_id, :get_supported_umodes)
+  end
+
   @typedoc """
   CP15 B3 — snapshot-ready window-state payload returned by
   `get_window_state/3`. Byte-identical to the event-time broadcast cic

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -192,6 +192,7 @@ defmodule Grappa.Session.EventRouter do
           | {:lusers_bundle, accum :: map()}
           | {:whowas_bundle, target :: String.t(), accum :: map()}
           | {:umode_changed, modes :: [String.t()]}
+          | {:supported_umodes_changed, modes :: [String.t()]}
           | {:session_identity_changed, :acquired | :lost}
 
   @doc """
@@ -1016,6 +1017,36 @@ defmodule Grappa.Session.EventRouter do
     next_umodes = apply_umode_string([], mode_str)
     effects = if next_umodes != prev_umodes, do: [{:umode_changed, next_umodes}], else: []
     {:cont, Map.put(state, :umodes, next_umodes), effects}
+  end
+
+  # 004 RPL_MYINFO (#249): the connection-registration line advertising the
+  # server's supported feature set. Param layout:
+  # `[own_nick, servername, version, usermodes, chanmodes, chanmodes_with_param?]`.
+  # Param index 3 (usermodes, e.g. "oiwgrsk") is the SUPPORTED user-mode set —
+  # the umode analogue of 005 CHANMODES for channels. Fold it into the
+  # per-session `supported_umodes` set + emit `{:supported_umodes_changed,
+  # letters}` so cic drives the `/umode` modal's AVAILABLE toggles from the
+  # server's real set instead of a static bahamut table (#249).
+  #
+  # This does NOT alter 004's ROUTING: 004 stays deny-listed in NumericRouter
+  # (`@active_numerics`) → `{:server, nil}` display, and this fold runs INSIDE
+  # the generic numeric handler's `EventRouter.route/2` call (server.ex), AFTER
+  # the $server `:notice` persist — so the connect-storm display row is
+  # untouched (the #276 ghost-routing fix is preserved; numeric_router_test
+  # guards it). `Map.get`/`Map.put` (never `%{state | ...}`) for the #216
+  # hot-reload contract; emit only on a real change to keep fan-out minimal.
+  # `parse_supported_umodes/1` (NOT `apply_umode_string/2`) parses the token:
+  # the supported set is an availability advertisement, a DISTINCT domain
+  # concept from an active `+/-` umode delta (CLAUDE.md design-discipline #6).
+  defp do_route(
+         %Message{command: {:numeric, 4}, params: [_, _, _, usermodes | _]},
+         state
+       )
+       when is_binary(usermodes) do
+    prev = Map.get(state, :supported_umodes, [])
+    next = parse_supported_umodes(usermodes)
+    effects = if next != prev, do: [{:supported_umodes_changed, next}], else: []
+    {:cont, Map.put(state, :supported_umodes, next), effects}
   end
 
   # 366 RPL_ENDOFNAMES is the end-of-NAMES marker. Each preceding 353
@@ -2583,6 +2614,22 @@ defmodule Grappa.Session.EventRouter do
 
   defp walk_umodes(set, <<letter::binary-size(1), rest::binary>>, :remove),
     do: walk_umodes(MapSet.delete(set, letter), rest, :remove)
+
+  # #249 — parse the 004 RPL_MYINFO supported-usermode token (a signless
+  # concatenation of letters, e.g. "oiwgrsk") into a sorted, deduped
+  # single-letter list. This is the AVAILABILITY set the server advertises —
+  # a distinct domain concept from the active umode DELTA `apply_umode_string/2`
+  # applies, so it does NOT share that walker (same wire SHAPE, different
+  # MEANING; CLAUDE.md design-discipline #6). Any stray sign char is dropped
+  # defensively (the token is signless by spec).
+  @spec parse_supported_umodes(String.t()) :: [String.t()]
+  defp parse_supported_umodes(token) when is_binary(token) do
+    token
+    |> String.graphemes()
+    |> Enum.reject(&(&1 in ["+", "-"]))
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
 
   # Parse a full mode snapshot string (e.g. "+nt" or "+ntk") plus arg list
   # into a channel_mode_entry. Replaces any existing entry entirely (used by

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -518,6 +518,15 @@ defmodule Grappa.Session.Server do
           # cic as `umode_changed` on Topic.user for the `/mode <nick>` modal.
           # Defaults to `[]` until the 221 arrives.
           umodes: [String.t()],
+          # #249: per-session SUPPORTED user-mode set — the umode letters the
+          # server advertises in 004 RPL_MYINFO (param index 3), a sorted list
+          # of single-letter strings. Unlike `umodes` (the operator's ACTIVE
+          # set from 221), this is the AVAILABILITY set that drives the cic
+          # `/umode` modal's togglable letters (the umode analogue of #216's
+          # `isupport` CHANMODES for channels). Broadcast to cic as
+          # `supported_umodes_changed` on Topic.user. Defaults to `[]` until
+          # the 004 arrives.
+          supported_umodes: [String.t()],
           # #215 session-lifecycle log — `started_at` stamps process spawn
           # (init/1); `connected_at` stamps the upstream TCP/TLS connect
           # (`:irc_connected`), nil until then. `disconnected` duration is
@@ -771,6 +780,8 @@ defmodule Grappa.Session.Server do
       isupport: ISupport.default(),
       # #229: empty umode set until the 221 RPL_UMODEIS reply arrives.
       umodes: [],
+      # #249: empty supported-umode set until the 004 RPL_MYINFO arrives.
+      supported_umodes: [],
       # C2 — pending WHOIS accumulators keyed by lowercased target nick.
       # Set up on `:send_whois` (the operator issued /whois); 311/312/313/
       # 317/319 fold into the entry; 318 emits `{:whois_bundle, ...}` and
@@ -1629,6 +1640,16 @@ defmodule Grappa.Session.Server do
   # reaches here). See #229 umode hot-reload safety test.
   def handle_call(:get_umodes, _, state) do
     {:reply, {:ok, Map.get(state, :umodes, [])}, state}
+  end
+
+  # #249: returns the per-session SUPPORTED umode set (004 RPL_MYINFO). Always
+  # succeeds ([] before the 004 arrives). `Map.get` default (not
+  # `state.supported_umodes`) so a live proc whose state predates the field —
+  # a plain hot module reload does NOT rewrite process state — returns []
+  # instead of KeyError-crashing the :transient proc on the next user-topic
+  # after-join snapshot (which reaches here). See #249 hot-reload safety test.
+  def handle_call(:get_supported_umodes, _, state) do
+    {:reply, {:ok, Map.get(state, :supported_umodes, [])}, state}
   end
 
   # CP15 B3 + cluster #6: returns the snapshot-ready window-state
@@ -3210,6 +3231,21 @@ defmodule Grappa.Session.Server do
       Grappa.PubSub.broadcast_event(
         Topic.user(state.subject_label),
         SessionWire.umode_changed(state.network_id, modes)
+      )
+
+    apply_effects(rest, state)
+  end
+
+  # #249 — per-session SUPPORTED umode set changed (004 RPL_MYINFO parse from
+  # EventRouter). Broadcast on Topic.user (umodes are per (subject, network),
+  # not per-channel — same carrier as umode_changed / isupport_changed).
+  # `state.supported_umodes` was already updated by EventRouter (Map.put); this
+  # arm just fans out the payload.
+  defp apply_effects([{:supported_umodes_changed, modes} | rest], state) do
+    :ok =
+      Grappa.PubSub.broadcast_event(
+        Topic.user(state.subject_label),
+        SessionWire.supported_umodes_changed(state.network_id, modes)
       )
 
     apply_effects(rest, state)

--- a/lib/grappa/session/wire.ex
+++ b/lib/grappa/session/wire.ex
@@ -70,6 +70,7 @@ defmodule Grappa.Session.Wire do
           | :own_nick_changed
           | :isupport_changed
           | :umode_changed
+          | :supported_umodes_changed
           | :topic_changed
           | :channel_modes_changed
           | :channel_created
@@ -134,6 +135,24 @@ defmodule Grappa.Session.Wire do
   """
   @type umode_changed_payload :: %{
           kind: :umode_changed,
+          network_id: integer(),
+          modes: [String.t()]
+        }
+
+  @typedoc """
+  Per-session SUPPORTED USER-mode set (#249). The umode letters the server
+  advertises in 004 RPL_MYINFO — the AVAILABILITY set (a sorted list of
+  single-letter strings), distinct from `umode_changed`'s ACTIVE set. The cic
+  `/umode` modal renders one toggle per ADVERTISED letter (the description
+  table lives cic-side per `feedback_no_localized_strings_server_side`),
+  mirroring how #216's `isupport_changed` CHANMODES drives channel-mode
+  toggles; cic falls back to a static table when the server never advertised.
+  Carries `:network_id` (not slug) and rides `Topic.user/1` — per
+  (subject, network), the same carrier as `umode_changed/2` +
+  `isupport_changed/2`.
+  """
+  @type supported_umodes_changed_payload :: %{
+          kind: :supported_umodes_changed,
           network_id: integer(),
           modes: [String.t()]
         }
@@ -628,6 +647,21 @@ defmodule Grappa.Session.Wire do
   def umode_changed(network_id, modes)
       when is_integer(network_id) and is_list(modes) do
     %{kind: :umode_changed, network_id: network_id, modes: modes}
+  end
+
+  @doc """
+  Per-session SUPPORTED USER-mode set (#249). `modes` is the sorted letter
+  list the server advertised in 004 RPL_MYINFO — the AVAILABILITY set that
+  drives the cic `/umode` modal's togglable letters (distinct from
+  `umode_changed/2`'s ACTIVE set). Carries `:network_id` (not slug) and rides
+  `Topic.user/1` — per (subject, network) state on a non-network-scoped user
+  topic, the same carrier as `umode_changed/2` + `isupport_changed/2`.
+  """
+  @spec supported_umodes_changed(integer(), [String.t()]) ::
+          supported_umodes_changed_payload()
+  def supported_umodes_changed(network_id, modes)
+      when is_integer(network_id) and is_list(modes) do
+    %{kind: :supported_umodes_changed, network_id: network_id, modes: modes}
   end
 
   @doc """

--- a/lib/grappa_web/channels/grappa_channel.ex
+++ b/lib/grappa_web/channels/grappa_channel.ex
@@ -1028,6 +1028,7 @@ defmodule GrappaWeb.GrappaChannel do
       {:ok, subject} ->
         push_query_windows_list(subject, socket)
         push_umodes_if_live(subject, socket)
+        push_supported_umodes_if_live(subject, socket)
 
       :error ->
         :ok
@@ -1051,6 +1052,31 @@ defmodule GrappaWeb.GrappaChannel do
       case Session.get_umodes(subject, network.id) do
         {:ok, modes} ->
           push(socket, "event", SessionWire.umode_changed(network.id, modes))
+
+        {:error, _} ->
+          :ok
+      end
+    end
+
+    :ok
+  end
+
+  # #249: seed the cic `/umode` modal's AVAILABLE toggle set on the user-topic
+  # cold-WS-subscribe. Mirror of `push_umodes_if_live/2` (umodes are
+  # per-session, reachable with ZERO channels, so this rides the user topic —
+  # not the per-channel snapshot #216's isupport uses). The live edge is the
+  # 004 `supported_umodes_changed` broadcast; this closes the always-on-session
+  # race where the 004 fired long before the client subscribed.
+  # `get_supported_umodes` only misses on `{:error, :no_session}`
+  # (parked/failed) — cic falls back to its static umode table until a session
+  # is live. Best-effort: one network's resolve/push failure must not disturb
+  # the others (each push is independent).
+  @spec push_supported_umodes_if_live(Session.subject(), Phoenix.Socket.t()) :: :ok
+  defp push_supported_umodes_if_live(subject, socket) do
+    for %Network{} = network <- Networks.Credentials.list_networks_for_subject(subject) do
+      case Session.get_supported_umodes(subject, network.id) do
+        {:ok, modes} ->
+          push(socket, "event", SessionWire.supported_umodes_changed(network.id, modes))
 
         {:error, _} ->
           :ok

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -1866,6 +1866,93 @@ defmodule Grappa.Session.EventRouterTest do
     end
   end
 
+  describe "route/2 — 004 RPL_MYINFO supported umodes (#249)" do
+    test "004 folds the supported-umode set + emits :supported_umodes_changed" do
+      # 004 param index 3 is the signless supported-usermode concatenation
+      # (the availability set the server advertises). Fold into
+      # supported_umodes (sorted, deduped) + emit the effect.
+      state = base_state(%{nick: "vjt", supported_umodes: []})
+
+      m =
+        msg(
+          {:numeric, 4},
+          ["vjt", "irc.azzurra.chat", "bahamut-2.2.1", "oiwgrsk", "biklmnopstv", "bklov"],
+          {:server, "irc.azzurra.chat"}
+        )
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+      assert new_state.supported_umodes == ["g", "i", "k", "o", "r", "s", "w"]
+      assert {:supported_umodes_changed, ["g", "i", "k", "o", "r", "s", "w"]} in effects
+    end
+
+    test "004 with an unchanged set emits no effect (idempotent)" do
+      state = base_state(%{nick: "vjt", supported_umodes: ["i", "o", "w"]})
+
+      m =
+        msg(
+          {:numeric, 4},
+          ["vjt", "irc.azzurra.chat", "bahamut-2.2.1", "iow", "biklmnopstv", "bklov"],
+          {:server, "irc.azzurra.chat"}
+        )
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+      assert new_state.supported_umodes == ["i", "o", "w"]
+      refute Enum.any?(effects, &match?({:supported_umodes_changed, _}, &1))
+    end
+
+    test "004 on a state predating :supported_umodes folds from [] (hot-safe)" do
+      # A hot-reloaded proc's state map lacks :supported_umodes; Map.get
+      # default [] must let the 004 fold in without KeyError (mirror of the
+      # #216 :isupport / #229 :umodes hot-reload contract).
+      state = Map.delete(base_state(), :supported_umodes)
+
+      m =
+        msg(
+          {:numeric, 4},
+          ["vjt", "irc.azzurra.chat", "bahamut-2.2.1", "iw", "biklmnopstv", "bklov"],
+          {:server, "irc.azzurra.chat"}
+        )
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+      assert new_state.supported_umodes == ["i", "w"]
+      assert {:supported_umodes_changed, ["i", "w"]} in effects
+    end
+
+    test "004 supported-set parse is letter- and order-agnostic (solanum)" do
+      # solanum (Libera) advertises a different umode set; the parse is
+      # generic — no bahamut-letter assumption, no ordering dependence.
+      state = base_state(%{nick: "libera-user", supported_umodes: []})
+
+      m =
+        msg(
+          {:numeric, 4},
+          [
+            "libera-user",
+            "irc.libera.chat",
+            "solanum-1",
+            "DQZagiow",
+            "beI,k,l,CPcgimnpst",
+            "bklov"
+          ],
+          {:server, "irc.libera.chat"}
+        )
+
+      assert {:cont, new_state, _} = EventRouter.route(m, state)
+      assert new_state.supported_umodes == ["D", "Q", "Z", "a", "g", "i", "o", "w"]
+    end
+
+    test "004 with too-few params does not match (no crash, no fold)" do
+      # A malformed 004 lacking the usermodes param falls through to the
+      # catch-all; supported_umodes is untouched, no effect emitted.
+      state = base_state(%{nick: "vjt", supported_umodes: ["i"]})
+      m = msg({:numeric, 4}, ["vjt", "irc.azzurra.chat"], {:server, "irc.azzurra.chat"})
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+      assert new_state.supported_umodes == ["i"]
+      refute Enum.any?(effects, &match?({:supported_umodes_changed, _}, &1))
+    end
+  end
+
   describe "route/2 — :topic (TOPIC command only)" do
     test "TOPIC command stores in cache + emits :persist :topic + :topic_changed" do
       state = base_state()

--- a/test/grappa/session/numeric_router_test.exs
+++ b/test/grappa/session/numeric_router_test.exs
@@ -148,6 +148,11 @@ defmodule Grappa.Session.NumericRouterTest do
       # ≤30 chars per `Identifier.valid_nick?`) and pre-fix routed to
       # `{:query, "oiwgrsk"}`, leaking a ghost row into the Archive
       # section via list_archive's COALESCE(dm_with, channel).
+      #
+      # #249 — LOAD-BEARING: 004 now ALSO folds `oiwgrsk` into the
+      # supported-umode set (EventRouter, AFTER this routing decision, in
+      # the generic numeric handler). This test guards that the fold is
+      # display-safe: 004 must STILL route to $server here (no ghost).
       m = msg(4, ["vjt", "irc.example.org", "bahamut-2.2.1", "oiwgrsk", "biklmnopstvI"])
       assert {:server, nil} = NumericRouter.route(m, state())
     end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -2316,6 +2316,124 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  describe "#249 — supported umodes (server-advertised umode set from 004)" do
+    test "004 RPL_MYINFO stores supported umodes + broadcasts on Topic.user" do
+      # 004 advertises the server's supported usermode set (param index 3).
+      # Fold it onto the per-session supported_umodes field + broadcast the
+      # typed supported_umodes_changed payload on Topic.user (umodes are per
+      # (subject, network), like umode_changed / isupport_changed). The 004
+      # STILL routes to $server for display — see numeric_router_test.
+      handler = fn state, line ->
+        if String.starts_with?(line, "USER ") do
+          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
+        else
+          {:reply, nil, state}
+        end
+      end
+
+      {server, port} = start_server(handler)
+      {user, network, _} = setup_user_and_network(port)
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      IRCServer.feed(
+        server,
+        ":irc.test.org 004 grappa-test irc.test.org bahamut-2.2.1 oiwgrsk biklmnopstv bklov\r\n"
+      )
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{
+                         kind: :supported_umodes_changed,
+                         network_id: net_id,
+                         modes: modes
+                       }
+                     },
+                     1_000
+
+      assert net_id == network.id
+      # "oiwgrsk" parsed into a sorted, deduped letter set.
+      assert modes == ["g", "i", "k", "o", "r", "s", "w"]
+
+      # get_supported_umodes facade returns the stored set.
+      assert {:ok, ["g", "i", "k", "o", "r", "s", "w"]} =
+               Session.get_supported_umodes({:user, user.id}, network.id)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "get_supported_umodes returns [] before any 004 (always-succeeds)" do
+      handler = fn state, line ->
+        if String.starts_with?(line, "USER ") do
+          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
+        else
+          {:reply, nil, state}
+        end
+      end
+
+      {server, port} = start_server(handler)
+      {user, network, _} = setup_user_and_network(port)
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      assert {:ok, []} = Session.get_supported_umodes({:user, user.id}, network.id)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "hot-reload safety: a live proc whose state predates :supported_umodes survives" do
+      # Mirror of the #216 :isupport / #229 :umodes hot-reload test: a plain
+      # hot module reload does NOT rewrite live process state, so a proc
+      # spawned before the field existed keeps its keyless map. The read path
+      # (get_supported_umodes) and the write path (004 fold) must tolerate the
+      # absent key (Map.get default + Map.put) rather than KeyError-crashing
+      # the :transient proc on the next user-topic snapshot / 004.
+      handler = fn state, line ->
+        if String.starts_with?(line, "USER ") do
+          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
+        else
+          {:reply, nil, state}
+        end
+      end
+
+      {server, port} = start_server(handler)
+      {user, network, _} = setup_user_and_network(port)
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      # Simulate the stale-proc shape: strip :supported_umodes from live state.
+      _ = :sys.replace_state(pid, fn state -> Map.delete(state, :supported_umodes) end)
+
+      # Read path: returns default [], not KeyError.
+      assert {:ok, []} = Session.get_supported_umodes({:user, user.id}, network.id)
+
+      # Write path: a fresh 004 on the stale proc folds in + broadcasts.
+      IRCServer.feed(
+        server,
+        ":irc.test.org 004 grappa-test irc.test.org bahamut-2.2.1 iwx biklmnopstv bklov\r\n"
+      )
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :supported_umodes_changed, modes: ["i", "w", "x"]}
+                     },
+                     1_000
+
+      # Same pid — the stale proc never crashed/respawned (no session drop).
+      assert Process.alive?(pid)
+      assert Session.whereis({:user, user.id}, network.id) == pid
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+
   describe "CP15 B2 — in_flight_joins map" do
     test "Session.Server starts with empty in_flight_joins map" do
       {_, port} = start_server()

--- a/test/grappa/session/wire_test.exs
+++ b/test/grappa/session/wire_test.exs
@@ -54,6 +54,21 @@ defmodule Grappa.Session.WireTest do
     end
   end
 
+  describe "supported_umodes_changed/2 (#249)" do
+    test "carries network_id (integer) + modes (string list)" do
+      assert Wire.supported_umodes_changed(7, ["i", "o", "w"]) == %{
+               kind: :supported_umodes_changed,
+               network_id: 7,
+               modes: ["i", "o", "w"]
+             }
+    end
+
+    test "the payload is JSON-encodable (plain list, no leaks)" do
+      payload = Wire.supported_umodes_changed(3, ["i", "w"])
+      assert {:ok, _} = Jason.encode(payload)
+    end
+  end
+
   describe "isupport_changed/2" do
     test "projects ISupport.t() to a JSON-encodable payload (MapSets → sorted lists)" do
       isupport =


### PR DESCRIPTION
Refs #249. Split out of #240 part 3; was gated on #221 (now closed) — buildable.

## Gap
cicchetto's `UmodeModal` drove its togglable letters from a STATIC bahamut
umode table, unioned with any active-but-unknown letter — a pure-cic best
effort. That is the umode twin of the channel-mode modal, which #216 already
drives from the network's SERVER-advertised CHANMODES (005 RPL_ISUPPORT). The
umode side had no such source: the supported-umode set lives in 004 RPL_MYINFO
(param index 3, e.g. `oiwgrsk`), which the server deliberately did NOT parse —
004 is on the connect-storm deny list (`NumericRouter.@active_numerics`), routed
to `$server` for display with its params ignored (the bucket-I ghost-routing
fix). `umode_changed` (#229) carries only the operator's ACTIVE set (221
RPL_UMODEIS), not the AVAILABILITY set.

## Fix — mirror the #216 ISUPPORT plumbing (reuse the verbs, not the nouns)
- **Parse (server).** A new `EventRouter` clause folds 004 param index 3 into a
  per-session `supported_umodes` set and emits `{:supported_umodes_changed,
  letters}`. It runs INSIDE the generic numeric handler's `EventRouter.route/2`
  call — AFTER the `$server` `:notice` persist and WITHOUT touching
  `NumericRouter` — so 004 still displays and the ghost-routing fix is preserved
  (`numeric_router_test` guards the `{:server, nil}` routing). A dedicated
  `parse_supported_umodes/1` (graphemes → dedupe → sort) is used, not
  `apply_umode_string/2`: the supported set is an availability advertisement,
  not a `+/-` delta — same wire SHAPE, different MEANING.
- **State + wire.** `Grappa.Session.Server` gains a `supported_umodes` field
  (default `[]`, `Map.get`/`Map.put` hot-reload-safe reads mirroring
  `:umodes` / `:isupport`); `apply_effects` broadcasts the typed
  `supported_umodes_changed` payload on `Topic.user/1`. A `get_supported_umodes`
  handle_call + facade + a `push_supported_umodes_if_live/2` user-topic
  cold-WS-subscribe snapshot close the always-on-session race.
- **Fold (cic).** A `supportedUmodes` store (mirror of `umodes.ts`) is seeded
  from the narrowed `supported_umodes_changed` event; `availableUmodes(active,
  serverSet)` renders one toggle per ADVERTISED letter, falling back to the
  static table when `serverSet` is empty. An active-but-unadvertised letter
  still renders read-only (never hide the operator's own state). REPLACE (not
  union) is deliberate — 004 is the authoritative supported-umode list; the real
  bahamut 004 carries the full settable set.

The #301 description/settable table is unchanged — #249 only changes WHICH
letters are available, not what they mean.

## Deploy — COLD, HELD
`supported_umodes` is a `Grappa.Session.Server` state-shape change (tracked in
`HotReload.LongLivedModules` → `Deploy.Preflight` auto-classifies COLD), and the
cic bundle carries the fold. **HELD** — rides the already-HELD #299 COLD batch
(#282 / #290 / #294 / #301 / #302 / #304 / #305 / #306 / #307 / #318). NOT
deployed in this session.

## Gates
- `scripts/check.sh`: `mix test --warnings-as-errors` 3828 tests 0 failures,
  Dialyzer passed, Credo strict clean, Sobelow clean, format clean, wireTypes
  drift in-sync (regenerated). Baseline bats #44 red is pre-existing (deploy
  script test), unrelated.
- cic: honest build exit 0; `check` exit 0 (0 `error TS`, baseline 23 biome
  warnings, none added); vitest 2960 tests 0 failures.
- Full `scripts/integration.sh`: 429 passed, 1 flaky —
  `issue291-mobile-home-button @webkit` sub-pixel `boundingBox` rounding
  (43.99998 vs 44), unrelated to this change, confirmed 3/3 green iso.