### PR TITLE
cic: persist read cursor on scroll-to-bottom button tap (#310)

### DIFF
--- a/cicchetto/e2e/tests/cursor-forward-only.spec.ts
+++ b/cicchetto/e2e/tests/cursor-forward-only.spec.ts
@@ -148,13 +148,13 @@ async function scrollByPx(page: Page, deltaY: number): Promise<void> {
 }
 
 async function scrollToBottom(page: Page): Promise<void> {
-  // BUGHUNT-2: ALWAYS use a real wheel-down, never the
-  // scroll-to-bottom button. The button's onClick triggers a
-  // programmatic `scrollTo({behavior:"smooth"})` which the BUGHUNT-2
-  // input-event gate correctly suppresses (no preceding
-  // wheel/pointerdown/touchmove/keydown on the listRef) — cursor
-  // never advances. Single big wheel-down: fires ONE WheelEvent →
-  // gate arms → settle fires once 500ms later → POSTs visible-tail.
+  // BUGHUNT-2: use a real wheel-down here, NOT the scroll-to-bottom button.
+  // This helper is deliberately exercising the SCROLL-SETTLE path: a single
+  // big wheel-down fires ONE WheelEvent → the input-event gate arms → the
+  // 500ms settle fires once → POSTs the visible-tail. (Since #310 the button
+  // ALSO advances the cursor, but via a DIFFERENT path — a direct
+  // reached-bottom advance in `scrollToBottomGesture`, not the settle — so
+  // the wheel is what pins the settle contract these tests assert.)
   const box = await page.locator('[data-testid="scrollback"]').boundingBox();
   if (!box) throw new Error("scrollback bounding box null");
   await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);

--- a/cicchetto/e2e/tests/issue243-tap-active-scroll-bottom.spec.ts
+++ b/cicchetto/e2e/tests/issue243-tap-active-scroll-bottom.spec.ts
@@ -13,8 +13,12 @@
 // tests pin the seam up to the command nonce; this pins nonce → scroll.
 //
 // Why this is NOT a visitor/registered parity-matrix spec: the gesture is
-// a pure client-side scroll on the already-selected window — identical
-// across every user class (no server round-trip, no window-state change).
+// a client-side scroll on the already-selected window — identical across
+// every user class (since #310 it ALSO advances the read cursor via a
+// forward-only POST, but that reached-bottom behaviour is user-class-agnostic;
+// no window-state change, no focus steal). The read-cursor persist is pinned
+// by issue310-scroll-to-bottom-btn-cursor.spec.ts; this spec asserts the
+// re-tap SCROLL geometry only.
 // The parity matrix is for IRC FUNCTIONS whose behaviour differs by class;
 // this rides the scroll-spec precedent (issue168, contamination, cp14-b1),
 // which assert scroll geometry only.

--- a/cicchetto/e2e/tests/issue310-scroll-to-bottom-btn-cursor.spec.ts
+++ b/cicchetto/e2e/tests/issue310-scroll-to-bottom-btn-cursor.spec.ts
@@ -1,0 +1,195 @@
+// #310 — the floating scroll-to-bottom BUTTON must persist the read cursor and
+// must NOT snap back to the unread divider ~2s later. Regression of #233.
+//
+// ## The bug (vjt prod report, recurring on Libera #libera)
+//
+// Tapping the floating scroll-to-bottom button jumped the view to the newest
+// message, then ~2s later the view SNAPPED BACK up to the read marker — the read
+// cursor was not persisted at the bottom. A MANUAL scroll to the bottom persists
+// fine; only the button was affected.
+//
+// ## Root cause (cicchetto-side, two coupled defects)
+//
+// The button's onClick (and the #243 re-tap) funnelled through the pure
+// `scrollToBottom()` helper, which only scrolls + sets `atBottom(true)`. Unlike a
+// manual scroll it did NOT:
+//   (a) POST a read-cursor advance — the manual path advances via the input-gated
+//       scroll-settle, and a button tap never arms that gate (the button is a
+//       sibling OUTSIDE `.scrollback`, so no pointerdown/wheel/touchmove lands on
+//       the listRef). So "read to newest" never persisted (candidate a).
+//   (b) release the marker-activation latch — a channel activation into an unread
+//       window leaves `markerActivationPending` set; only operator INPUT or an own
+//       send cleared it. With it still set, the NEXT rows() recreation (a live
+//       message, or the switch-time refreshScrollback) re-asserted the marker jump
+//       → the ~2s snap-back.
+//
+// #310 routes the button + re-tap through `scrollToBottomGesture`, which does both:
+// clears the latch and advances the cursor to the newest rendered id (read AFTER
+// the instant scroll via the shared forward-only setCursorIfAdvances path).
+//
+// ## What this spec pins (RED pre-#310, GREEN post)
+//
+//   (1) PERSISTENCE — the core "POST fired with the newest id": after the tap the
+//       SERVER read cursor advances from the mid seed to the tail. Deterministic,
+//       peer-free. RED pre-#310: the button never POSTed → the cursor stays at the
+//       seed → the poll times out.
+//   (2) NO SNAP-BACK — the visible symptom: a peer line arriving AFTER the tap
+//       recreates rows() (the exact ~2s trigger on a busy channel). With the latch
+//       released the pane tail-follows and STAYS at the bottom. RED pre-#310: the
+//       latch was still set → the length-effect re-jumped to the divider.
+//
+// Two axes, one behaviour (mirror #243): DESKTOP (chromium, re-uses the #168
+// 800×300 harness so the 50-row REST page overflows) + MOBILE (@webkit, iPhone 15
+// device viewport). Playwright WebKit ≠ real iOS scroll physics
+// (feedback_playwright_webkit_not_ios_scroll), so the @webkit run is the layout/
+// touch CONTRACT, not a device-physics repro; the deterministic cursor-persist
+// assertion is the authoritative mechanism proof on both.
+
+import { type Page } from "@playwright/test";
+import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
+import { getReadCursor, restoreReadCursorToTail, setReadCursorToId } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Mirror of ScrollbackPane.SCROLL_BOTTOM_THRESHOLD_PX = 50 (not exported; kept in
+// lockstep by hand — same as #168 / cp14-b1).
+const SCROLL_BOTTOM_THRESHOLD_PX = 50;
+// REST default page size (Grappa.Web.MessagesController.@default_limit).
+const REST_PAGE_SIZE = 50;
+
+async function distFromBottom(page: Page): Promise<number> {
+  return await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+    if (!el) return 999;
+    return Math.round(el.scrollHeight - el.scrollTop - el.clientHeight);
+  });
+}
+
+// Latest REST page (DESC by server_time; rows[0] is the newest) — used to pick a
+// known message id for the mid-page cursor seed + the tail id we expect the tap
+// to advance to. Mirror of the #168 local helper.
+async function fetchScrollbackPage(
+  token: string,
+  channel: string,
+): Promise<Array<{ id: number }>> {
+  const url = `http://grappa-test:4000/networks/${encodeURIComponent(
+    NETWORK_SLUG,
+  )}/channels/${encodeURIComponent(channel)}/messages`;
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!res.ok) {
+    throw new Error(`fetchScrollbackPage: ${res.status} ${await res.text()}`);
+  }
+  return (await res.json()) as Array<{ id: number }>;
+}
+
+// Shared body: focus an unread #bofh, tap the floating button, assert the cursor
+// persists to the tail AND a subsequent peer line does not snap the view back.
+// `peerNick` is passed distinct per project so the two runs never collide on a
+// bahamut ghost-nick linger window (per-run-unique peer nicks, TESTING.md).
+async function tapButtonPersistsCursorAndHolds(page: Page, peerNick: string): Promise<void> {
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  const vjt = getSeededVjt();
+
+  // Seed a cursor 25 rows from the tail → an unread divider is injected on first
+  // focus and the activation parks ABOVE the fold (button shows). Same shape as
+  // #168. `setReadCursorToId` hits the test-only force endpoint (the production
+  // POST is advance-only since #233, so a backward seed through it would clamp).
+  const page0 = await fetchScrollbackPage(vjt.token, CHANNEL);
+  expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
+  const tailRow = page0[0];
+  const cursorRow = page0[25];
+  if (!tailRow || !cursorRow) throw new Error("seeded page too short for cursor placement");
+  await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, cursorRow.id);
+
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+  await expect
+    .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
+    .toBeGreaterThanOrEqual(REST_PAGE_SIZE);
+
+  // Divider present, activation parked above the fold, floating button visible.
+  await expect(page.locator('[data-testid="unread-marker"]')).toHaveCount(1);
+  await expect
+    .poll(async () => await distFromBottom(page), { timeout: 5_000 })
+    .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
+  const btn = page.locator('[data-testid="scroll-to-bottom"]');
+  await expect(btn).toBeVisible({ timeout: 5_000 });
+
+  // Pre-tap: the server cursor is still at the mid seed (a bare open does NOT
+  // advance it — the BUGHUNT-2 programmatic-scroll contract).
+  await expect
+    .poll(async () => await getReadCursor(vjt.token, NETWORK_SLUG, CHANNEL), { timeout: 3_000 })
+    .toBe(cursorRow.id);
+
+  // TAP the floating scroll-to-bottom button. `.click()` works on both the touch
+  // (@webkit) and non-touch (chromium) contexts; `.tap()` would throw on desktop.
+  await btn.click();
+
+  // (1) PERSISTENCE — the core fix. RED pre-#310: the button never POSTed, so the
+  // cursor stays at the mid seed and this poll times out.
+  await expect
+    .poll(async () => await getReadCursor(vjt.token, NETWORK_SLUG, CHANNEL), { timeout: 5_000 })
+    .toBe(tailRow.id);
+
+  // View is at the bottom; the floating button hides.
+  await expect
+    .poll(async () => await distFromBottom(page), { timeout: 5_000 })
+    .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
+  await expect(btn).toBeHidden({ timeout: 5_000 });
+
+  // (2) NO SNAP-BACK. A peer line arriving AFTER the tap recreates rows() (the
+  // exact ~2s trigger that re-asserted the marker jump on #libera). With the
+  // latch released the pane tail-follows and STAYS at the bottom. RED pre-#310:
+  // the latch was still set → the length-effect re-jumped to the divider.
+  const peer = await IrcPeer.connect({ nick: peerNick });
+  try {
+    await peer.join(CHANNEL);
+    const marker = `btn310-after-tap-${Date.now()}`;
+    peer.privmsg(CHANNEL, marker);
+    // Wait for the row to land (fakelag can delay arrival) so the rows()
+    // recreation has happened before we measure.
+    await expect(page.getByText(marker)).toBeVisible({ timeout: 15_000 });
+    await page.waitForTimeout(700); // past the 500ms settle + any re-assert window
+    await expect
+      .poll(async () => await distFromBottom(page), { timeout: 5_000 })
+      .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
+  } finally {
+    await peer.disconnect("#310 done");
+  }
+}
+
+// The mid-page cursor + the tap advance the shared seeded vjt's cursor across
+// spec boundaries; restore to the tail after EACH run so a downstream #bofh spec
+// inherits a fully-read channel (cascade hygiene — feedback_cascade_poisoner_pattern).
+test.describe("#310 — scroll-to-bottom button persists the read cursor (desktop)", () => {
+  test.use({ viewport: { width: 800, height: 300 } });
+
+  test.afterEach(async () => {
+    if (!CHANNEL) return;
+    const vjt = getSeededVjt();
+    await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
+  });
+
+  test("tapping the button advances the cursor to the tail and does not snap back", async ({
+    page,
+  }) => {
+    await tapButtonPersistsCursorAndHolds(page, `btn310-c${Date.now() % 100000}`);
+  });
+});
+
+test.describe("#310 — scroll-to-bottom button persists the read cursor (mobile)", () => {
+  test.afterEach(async () => {
+    if (!CHANNEL) return;
+    const vjt = getSeededVjt();
+    await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
+  });
+
+  test("@webkit tapping the button advances the cursor to the tail and does not snap back", async ({
+    page,
+  }) => {
+    await tapButtonPersistsCursorAndHolds(page, `btn310-w${Date.now() % 100000}`);
+  });
+});

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -104,8 +104,11 @@ import WhowasCard from "./WhowasCard";
 // below for the full contract.
 //
 // C7.4: Scroll-to-bottom floating button — appears when scrolled more than
-// SCROLL_BOTTOM_THRESHOLD_PX from the tail. Click → smooth-scroll to bottom
-// and resume auto-follow (resets atBottom to true).
+// SCROLL_BOTTOM_THRESHOLD_PX from the tail. Click → instant scroll to the
+// tail + resume auto-follow (resets atBottom to true), AND (since #310) —
+// like a manual scroll to the bottom — advances the read cursor to the newest
+// line and releases the marker-activation latch so the view does not snap back
+// to the divider. See `scrollToBottomGesture`.
 //
 // C7.6: Clickable nicks in scrollback — sender spans on PRIVMSG / NOTICE /
 // ACTION get .nick-clickable class. Left-click → open query window + focus.
@@ -2509,6 +2512,47 @@ const ScrollbackPane: Component<Props> = (props) => {
     setAtBottom(true);
   };
 
+  // #310 — the scroll-to-bottom GESTURE, shared by the floating button's
+  // onClick AND the #243 re-tap command below. Reaching the bottom via an
+  // explicit operator gesture means they have read to the newest line, so —
+  // exactly like a manual scroll to the bottom — it does two things the pure
+  // `scrollToBottom()` helper (kept for the send-relatch, which owns its own
+  // marker + cursor bookkeeping) deliberately does NOT:
+  //
+  //   1. Clears the marker-activation latch. A channel activation into an
+  //      unread window leaves `markerActivationPending` set; only an operator
+  //      INPUT event (`on(lastInputEventAtMs)`) or an own send cleared it. A
+  //      button tap is NOT a `listRef` input event (the button is a sibling
+  //      OUTSIDE `.scrollback`), so the latch stayed set — and the next rows()
+  //      recreation (a live message, or the switch-time `refreshScrollback`)
+  //      hit the length-effect's marker re-assert and yanked the view back to
+  //      the divider ~2s later (the #310 snap-back). Handing scroll authority
+  //      back here is exactly what the operator-input arm does for a manual
+  //      scroll.
+  //   2. Advances the server read cursor to the newest rendered id via the
+  //      existing forward-only `setCursorIfAdvances` POST path — so "read to
+  //      newest" persists across reload / cross-device. The button never
+  //      POSTed at all (candidate a; the manual path advances via the
+  //      input-gated scroll-settle, which a button tap never arms — see
+  //      cursor-forward-only.spec.ts).
+  //
+  // The newest id is read AFTER the instant scroll: `scrollToBottom()` pins
+  // the tail synchronously, so `lastFullyVisibleRowId`'s at-bottom
+  // short-circuit returns the true DOM tail — never a stale pre-scroll id the
+  // #233 monotonic clamp would drop as non-advancing (candidate b). No second
+  // cursor authority, no window-state mutation. The frozen divider is left in
+  // place, same as a manual scroll — it re-latches only on the next focus
+  // acquisition or own send (freeze contract).
+  const scrollToBottomGesture = () => {
+    scrollToBottom();
+    setMarkerActivationPending(false);
+    if (!listRef) return;
+    const id = lastFullyVisibleRowId(listRef);
+    if (id !== null) {
+      setCursorIfAdvances(props.networkSlug, props.channelName, id);
+    }
+  };
+
   // #243 — re-tap "jump to latest". The Sidebar / BottomBar tap handler
   // bumps `scrollToBottomRequest` when the operator re-taps the window
   // they're already on; this pane is the sole subscriber and the only one
@@ -2516,10 +2560,12 @@ const ScrollbackPane: Component<Props> = (props) => {
   // so the command always lands on the active scrollback. `defer: true`
   // skips the value read at mount, so a channel SWITCH (no nonce change) or
   // a stale nonce carried across identity rotation never fires a spurious
-  // jump — only a genuine re-tap does. Reuses the SAME instant, layout-
-  // aware `scrollToBottom()` the floating button uses (no second scroll
-  // authority; the #196/#230 anchor machinery is untouched).
-  createEffect(on(scrollToBottomRequest, () => scrollToBottom(), { defer: true }));
+  // jump — only a genuine re-tap does. Routes through the SHARED
+  // `scrollToBottomGesture` the floating button uses (#310) — same instant,
+  // layout-aware scroll (no second scroll authority; the #196/#230 anchor
+  // machinery is untouched) PLUS the reached-bottom cursor advance + latch
+  // release, since a re-tap to the bottom is the same "read to newest" intent.
+  createEffect(on(scrollToBottomRequest, () => scrollToBottomGesture(), { defer: true }));
 
   return (
     <div class="scrollback-pane">
@@ -2703,7 +2749,7 @@ const ScrollbackPane: Component<Props> = (props) => {
             type="button"
             class="scroll-to-bottom-btn"
             data-testid="scroll-to-bottom"
-            onClick={scrollToBottom}
+            onClick={scrollToBottomGesture}
             aria-label="Scroll to bottom"
           >
             ↓

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -228,6 +228,12 @@ import {
   LARGE_CHANNEL_THRESHOLD,
   setChannelPresencePref,
 } from "../lib/presenceFilter";
+// #310 — the #243 re-tap command signal. NOT mocked (real module): driving
+// it exercises the SAME `scrollToBottomGesture` the floating scroll-to-bottom
+// button's onClick invokes, so the unit test can prove the shared gesture
+// advances the read cursor without needing the button to render (jsdom's
+// zero-geometry keeps `atBottom` true, so the button never mounts).
+import { requestScrollToBottom } from "../lib/scrollToBottomCommand";
 import { dismissWhoisCard, setWhoisBundle } from "../lib/whoisCard";
 import ScrollbackPane, {
   resetAutoFocusedJoinsForTest,
@@ -984,6 +990,50 @@ describe("ScrollbackPane", () => {
       render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
       // Initially atBottom = true; button should not be visible.
       expect(screen.queryByTestId("scroll-to-bottom")).toBeNull();
+    });
+  });
+
+  // #310 — the scroll-to-bottom GESTURE (floating button + #243 re-tap)
+  // must advance the server read cursor to the NEWEST rendered message.
+  // Pre-#310 both funnelled through the pure `scrollToBottom()` helper,
+  // which never POSTed a cursor advance — so reaching the bottom did not
+  // persist "read to newest", and a later marker re-assert snapped the
+  // view back to the divider (~2s later; vjt prod report on #libera). The
+  // gesture now runs the same "reached bottom → advance to newest" logic a
+  // manual scroll does, capturing the tail id AFTER the (instant) scroll
+  // via the shared forward-only `setCursorIfAdvances` path.
+  //
+  // jsdom is blind to scroll geometry — the button only renders when
+  // `!atBottom()`, which never happens under jsdom's zero-geometry — so this
+  // drives the SHARED gesture through the #243 re-tap command
+  // (`requestScrollToBottom`), the same `scrollToBottomGesture` the button's
+  // onClick invokes. The real button DOM tap + the no-snap-back proof live
+  // in the issue310 Playwright spec (jsdom can't reproduce the scroll).
+  describe("#310 — scroll-to-bottom gesture advances the read cursor", () => {
+    it("advances the read cursor to the newest rendered message id on a jump-to-bottom gesture", async () => {
+      // Unread present: cursor mid-list at id 1 → ids 2 and 3 are unread.
+      seedReadCursor("freenode", "#grappa", 1);
+      setScrollback({ "freenode #grappa": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      // Pane mounted (the deferred re-tap effect is registered) and rows rendered.
+      await waitFor(() => {
+        expect(screen.getAllByTestId("scrollback-line")).toHaveLength(3);
+      });
+
+      // A bare mount/activation is a PROGRAMMATIC scroll — it must NOT advance
+      // the cursor (that's the BUGHUNT-2 input-gate contract).
+      expect(mockSetCursorIfAdvances).not.toHaveBeenCalled();
+
+      // THE GESTURE: the jump-to-bottom command the floating button + the #243
+      // re-tap share.
+      requestScrollToBottom();
+
+      // Reaching the bottom advances the cursor to the NEWEST rendered id (3),
+      // read AFTER the scroll via lastFullyVisibleRowId's at-bottom short-circuit
+      // (the true tail, never a stale pre-scroll id → no #233 clamp no-op).
+      await waitFor(() => {
+        expect(mockSetCursorIfAdvances).toHaveBeenCalledWith("freenode", "#grappa", 3);
+      });
     });
   });
 

--- a/cicchetto/src/lib/scrollToBottomCommand.ts
+++ b/cicchetto/src/lib/scrollToBottomCommand.ts
@@ -8,13 +8,21 @@ import { createSignal } from "solid-js";
 //
 // The tap handlers own the GESTURE (focus originates only from the user
 // tap — #200/#125 no-steal is untouched); ScrollbackPane owns the SCROLL
-// machinery (its instant, layout-aware `scrollToBottom()` helper — the
-// same one the floating button uses). This monotonic nonce is the one-way
-// bridge between them: the handler bumps it, the single mounted
-// ScrollbackPane subscribes via `on(scrollToBottomRequest, …, { defer:
-// true })` and calls `scrollToBottom()`. No second scroll authority, no
-// server round-trip, no window-state mutation — a pure client-side scroll
-// on the already-selected window.
+// machinery (its instant, layout-aware `scrollToBottomGesture()` — the same
+// one the floating button uses). This monotonic nonce is the one-way bridge
+// between them: the handler bumps it, the single mounted ScrollbackPane
+// subscribes via `on(scrollToBottomRequest, …, { defer: true })` and runs
+// `scrollToBottomGesture()`. No second scroll authority and no window-state
+// mutation — a pure client-side scroll on the already-selected window.
+//
+// #310 — reaching the bottom IS a "read to newest" signal, so the gesture
+// now advances the server read cursor to the newest rendered line (via the
+// existing forward-only `setCursorIfAdvances` POST) and releases the
+// marker-activation latch, exactly as a manual scroll to the bottom does.
+// So a re-tap to the bottom DOES make a server round-trip (a forward-only
+// cursor advance) — that persists "read to newest" and prevents the ~2s
+// snap-back to the divider. It is NOT a focus steal and NOT a window-state
+// change; the divider stays frozen until the next focus acquisition.
 //
 // A monotonic counter (not a boolean toggle) so back-to-back re-taps each
 // fire a DISTINCT transition — Solid's `===` equality would swallow a

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -25193,3 +25193,71 @@ state-shape change (already tracked in `HotReload.LongLivedModules` →
 `Deploy.Preflight` auto-classifies COLD), and the cic bundle carries the fold.
 **HELD** — rides the already-HELD #299 COLD batch (with #282 / #290 / #294 /
 #301 / #302 / #304 / #305 / #306 / #307 / #318)._
+
+### 2026-07-18 — #310: persist the read cursor on the scroll-to-bottom BUTTON tap
+
+**Gap.** Tapping the floating scroll-to-bottom button jumped the view to the
+newest line, then ~2s later the view SNAPPED BACK up to the read marker — the
+read cursor was not persisted at the bottom (reported live on Libera #libera,
+recurring; a regression of #233). The discriminator: a MANUAL scroll to the
+bottom persists the cursor fine — ONLY the button (and the #243 re-tap, which
+shares the same scroll helper) was broken. #233's fix was SERVER-side (the
+monotonic advance-only clamp in `ReadCursor.do_set/4`), and the working
+manual-scroll path proves that clamp is fine — so the regression lives in
+cicchetto's button handler, not the server.
+
+**Root cause (cic-side, two coupled defects).** The button's `onClick` and the
+#243 re-tap both funnelled through the pure `scrollToBottom()` helper, which only
+scrolls + sets `atBottom(true)`. Unlike a manual scroll it did NOT:
+- **(a) advance the read cursor.** The manual path advances via the input-gated
+  `onScroll` scroll-settle (`setCursorIfAdvances` after 500ms). A button tap
+  never arms that gate: the button is a sibling OUTSIDE `.scrollback`, so its tap
+  emits no `pointerdown`/`wheel`/`touchmove` on the `listRef` and
+  `lastInputEventAtMs` stays stale → the settle never fires → no cursor POST.
+  So "read to newest" never persisted (reload / cross-device kept the old
+  unread). `cursor-forward-only.spec.ts` had documented this gap from the other
+  side ("the button... cursor never advances").
+- **(b) release the marker-activation latch.** A channel activation into an
+  unread window leaves `markerActivationPending` set; only an operator INPUT
+  event (`on(lastInputEventAtMs)`) or an own send cleared it. With it still set,
+  the NEXT `rows()` recreation (a live message, or the switch-time
+  `refreshScrollback` completing ~1-2s later) hit the length-effect's re-assert
+  `if (markerActivationPending() && marker exists) scrollToActivation("marker-or-tail")`
+  → the view re-jumped to the divider: the ~2s snap-back. A manual scroll cleared
+  the latch (via the input arm), so it never snapped back.
+
+**Fix — one shared gesture (reuse the verbs, not the nouns).** Route the button
+`onClick` AND the #243 re-tap through a new `scrollToBottomGesture` that, exactly
+like a manual scroll to the bottom, does both: clears `markerActivationPending`
+(hands scroll authority back, the same thing the operator-input arm does) and
+advances the server read cursor to the newest rendered id via the EXISTING
+forward-only `setCursorIfAdvances` POST. The newest id is read AFTER the instant
+scroll — `scrollToBottom()` pins the tail synchronously, so
+`lastFullyVisibleRowId`'s at-bottom short-circuit returns the TRUE DOM tail, not
+a stale pre-scroll id the #233 monotonic clamp would drop as non-advancing
+(candidate b in the issue). No second cursor authority, no server-clamp change.
+The send-relatch (`on(lastOwnSend)`) keeps its own plain `scrollToBottom()` (it
+does its own latch clear + `markerCursorId` re-latch); the gesture deliberately
+does NOT call `setMarkerCursorId`, so the frozen divider is left in place — it
+re-latches only on the next focus acquisition or own send (freeze contract),
+matching the manual-scroll behaviour.
+
+**#243 re-tap.** Reaching the bottom via a re-tap is the same "read to newest"
+intent, so it advances too. The #243 spec asserts scroll GEOMETRY only (lands at
+bottom, button hides), never "no cursor POST", and #200/#125 no-steal is
+untouched (the gesture never calls `setSelectedChannel`) — so the re-tap advance
+regresses nothing. Its moduledoc's "no server round-trip" claim was corrected.
+
+**Tests.** vitest drives the shared gesture through the #243 re-tap command
+(`requestScrollToBottom` — jsdom can't render the geometry-gated button) and
+asserts the advance to the newest id — RED before, GREEN after. A Playwright spec
+(desktop chromium + @webkit iPhone 15) seeds a mid-page cursor, taps the button,
+and asserts (1) the server cursor advances from the mid seed to the tail
+(deterministic, peer-free) and (2) a peer PRIVMSG arriving AFTER the tap — the
+exact rows() recreation that re-asserted the marker jump — does NOT snap the view
+back.
+
+_Deploy: **cic-bundle only** — no `.ex` change, so hot-eligible via
+`deploy-m42.sh --cic`. **HELD** — rides the already-HELD #299 COLD batch's 4AM
+window, shipped together with `deploy-m42.sh --force-cold --cic` (with #249 /
+#282 / #290 / #294 / #301 / #302 / #304 / #305 / #306 / #307 / #318)._


### PR DESCRIPTION
Fixes the #310 regression (of #233): tapping the floating scroll-to-bottom button jumped to the newest line, then ~2s later the view **snapped back** up to the read marker — the read cursor was not persisted at the bottom. Reported live on Libera #libera. A **manual** scroll to the bottom persists fine; only the button (and the #243 re-tap, which shares the scroll helper) was affected. cic-only.

## Root cause (cic-side, two coupled defects)
The button `onClick` and the #243 re-tap both funnelled through the pure `scrollToBottom()` helper (scroll + `atBottom(true)` only). Unlike a manual scroll it did NOT:
- **(a)** advance the read cursor — the manual path advances via the input-gated `onScroll` scroll-settle, and a button tap never arms that gate (the button is a sibling OUTSIDE `.scrollback`, so no pointerdown/wheel/touchmove lands on the listRef). So "read to newest" never persisted (reload/cross-device kept the old unread).
- **(b)** release `markerActivationPending` — with the latch still set, the next `rows()` recreation (a live message, or the switch-time `refreshScrollback`) re-asserted the length-effect's marker jump → the ~2s snap-back.

#233's fix was server-side (the monotonic advance-only clamp in `ReadCursor.do_set/4`); the working manual-scroll path proves that clamp is fine — the regression is purely in cicchetto's button handler.

## Fix
Route the button + #243 re-tap through one `scrollToBottomGesture` that, exactly like a manual scroll to the bottom, **clears the marker-activation latch** and **advances the read cursor to the newest rendered id** — read AFTER the instant scroll via the shared `lastFullyVisibleRowId` at-bottom short-circuit (the true tail, not a stale pre-scroll id the #233 clamp would drop) through the existing forward-only `setCursorIfAdvances` POST. No second cursor authority, no server-clamp change. The send-relatch keeps its own plain `scrollToBottom()`; the gesture does not call `setMarkerCursorId`, so the frozen divider stays put (re-latches on the next focus/own send) — matching the manual-scroll behaviour.

## Tests
- **vitest** drives the shared gesture via the #243 re-tap command (jsdom can't render the geometry-gated button) and asserts the advance to the newest id — RED before, GREEN after. Full cic suite: 2961 passed.
- **Playwright** (desktop chromium + @webkit iPhone 15): seed a mid-page cursor, tap the button, assert (1) the server cursor advances from the seed to the tail (deterministic, peer-free) and (2) a peer PRIVMSG arriving after the tap does NOT snap the view back. Full integration: 432 passed locally.

## Deploy
cic-bundle only (no `.ex`) → hot-eligible via `--cic`, but **HELD** — rides the already-HELD #299 COLD batch's 4AM window (`deploy-m42.sh --force-cold --cic`).