### PR TITLE
media-modal: admit deployment host aliases (#324)

### DIFF
--- a/cicchetto/e2e/compose.yaml
+++ b/cicchetto/e2e/compose.yaml
@@ -346,6 +346,15 @@ services:
       # the Playwright runner browses — same shape as prod, where
       # PHX_HOST roots them at the public https host.
       PHX_HOST: nginx-test
+      # #324 media-alias e2e: advertise a synthetic sibling hostname
+      # alongside PHX_HOST so `Grappa.HttpHosts` (via runtime.exs) exposes
+      # http_host_aliases = [nginx-test, alias-b.test]. The
+      # media-link-alias spec composes a body carrying
+      # `https://alias-b.test/uploads/<slug>` (a host that is NOT the page
+      # origin) and asserts the in-app viewer opens re-rooted onto the
+      # page origin. Harmless for other specs (no browser reaches
+      # alias-b.test; MIX_ENV=dev leaves check_origin=false anyway).
+      EXTRA_CHECK_ORIGINS: "https://alias-b.test"
     command: ["mix", "phx.server"]
     networks:
       grappa-e2e:

--- a/cicchetto/e2e/tests/media-link-alias-modal.spec.ts
+++ b/cicchetto/e2e/tests/media-link-alias-modal.spec.ts
@@ -1,0 +1,112 @@
+// Media-link deployment-alias viewer (#324) — e2e for the on-click
+// in-app viewer opening on an upload link that carries a DIFFERENT
+// deployment hostname alias than the one cic is loaded from.
+//
+// Field bug: cic served from `irc.sindro.me`, a scrollback link
+// `📸 https://irc.sniffo.org/uploads/<slug>` (both aliases of the SAME
+// grappa instance, shared /uploads store). The pre-#324 single-host
+// gate rejected the sibling host → plain anchor → iOS standalone PWA
+// navigates IN PLACE (raw media doc, no chrome). Fix: cic admits any
+// host in the server-provided alias set (Grappa.HttpHosts →
+// serverSettings().httpHostAliases) and re-roots the click onto the
+// PAGE origin, so the modal's <img> stays same-origin → CSP
+// `img-src 'self'` is UNTOUCHED.
+//
+// Simulation: the e2e server advertises a synthetic sibling host via
+// `EXTRA_CHECK_ORIGINS=https://alias-b.test` (compose.yaml), so the WS
+// after-join snapshot delivers http_host_aliases = [nginx-test,
+// alias-b.test]. We upload a real PNG (valid slug + bytes nginx serves
+// back), then compose a body carrying that slug under `alias-b.test`
+// (NOT the page origin) and assert the click opens the viewer re-rooted
+// onto the page origin — real bytes, real prod CSP (the `_cspGuard`
+// fixture fails the spec on any securitypolicyviolation, so
+// naturalWidth>0 proves the re-rooted same-origin <img> is CSP-admitted).
+//
+// Two entries: untagged runs on chromium (grepInvert /@webkit/), the
+// `@webkit` copy runs on iPhone 15 (grep /@webkit/) — engine parity for
+// the classifier wiring on the platform where the standalone bug lives.
+
+import type { Page } from "@playwright/test";
+import { TINY_PNG_HEX } from "../fixtures/bytes";
+import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+import { mediaScrollbackRow, uploadViaPicker } from "../fixtures/uploadJourney";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+// Matches compose.yaml `EXTRA_CHECK_ORIGINS=https://alias-b.test` — the
+// synthetic sibling hostname the server advertises in http_host_aliases.
+const ALIAS_B_HOST = "alias-b.test";
+
+async function aliasModalJourney(page: Page): Promise<void> {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  // Real upload → a valid slug whose bytes nginx serves back at the page
+  // origin. `url` is the page-origin URL the re-rooted alias link must
+  // resolve to.
+  const { slug, url } = await uploadViaPicker(
+    page,
+    { name: "alias-viewer.png", mimeType: "image/png", buffer: Buffer.from(TINY_PNG_HEX, "hex") },
+    { postTimeout: 10_000 },
+  );
+  // Sanity: the served URL is on the page origin, NOT the alias host.
+  expect(url.startsWith(`https://${ALIAS_B_HOST}`)).toBe(false);
+
+  // Compose a body carrying the slug under the SERVER-ADVERTISED alias
+  // host (a host that is NOT the page origin). Pre-#324 this fell back
+  // to the plain anchor.
+  const aliasUrl = `https://${ALIAS_B_HOST}/uploads/${slug}`;
+  await composeSend(page, `📸 ${aliasUrl}`);
+
+  const { link } = await mediaScrollbackRow(page, "📸", ALIAS_B_HOST);
+  await expect(link).toHaveClass(/scrollback-media-link/);
+  // The anchor href stays the literal alias URL (copy-link / long-press
+  // fidelity); only the plain CLICK re-roots.
+  await expect(link).toHaveAttribute("href", aliasUrl);
+
+  const cicUrl = page.url();
+  await link.click();
+  const viewer = page.getByRole("dialog", { name: "Media viewer" });
+  await expect(viewer).toBeVisible({ timeout: 5_000 });
+  // No navigation — the modal opened in place.
+  expect(page.url()).toBe(cicUrl);
+
+  // Re-rooted onto the PAGE origin, NOT alias-b.test → same-origin <img>
+  // → CSP img-src 'self' untouched. naturalWidth>0 proves the bytes
+  // loaded through nginx under the prod CSP (the _cspGuard fixture fails
+  // the spec on a securitypolicyviolation).
+  const img = viewer.locator("img.media-viewer-media");
+  await expect(img).toHaveAttribute("src", url);
+  await expect(img).toHaveJSProperty("complete", true, { timeout: 10_000 });
+  const naturalWidth = await img.evaluate((el) => (el as HTMLImageElement).naturalWidth);
+  expect(naturalWidth).toBeGreaterThan(0);
+
+  await viewer.getByRole("button", { name: "Close media viewer" }).click();
+  await expect(viewer).toBeHidden({ timeout: 5_000 });
+
+  // Negative: a genuinely third-party host (NOT in the alias set) with
+  // the same emoji + uploads shape must still be rejected — plain
+  // anchor, no media class (never re-root a foreign host onto the page
+  // origin).
+  const thirdPartyUrl = `https://litter.catbox.moe/uploads/${slug}`;
+  await composeSend(page, `📸 ${thirdPartyUrl}`);
+  const thirdRow = scrollbackLine(page, "privmsg", "litter.catbox.moe");
+  await expect(thirdRow.first()).toBeVisible({ timeout: 15_000 });
+  const thirdLink = thirdRow.first().locator(".scrollback-link").first();
+  await expect(thirdLink).not.toHaveClass(/scrollback-media-link/);
+  await expect(thirdLink).toHaveAttribute("href", thirdPartyUrl);
+}
+
+test("upload link on a server-advertised host alias opens the in-app viewer re-rooted to the page origin (#324)", async ({
+  page,
+}) => {
+  await aliasModalJourney(page);
+});
+
+test("upload link on a server-advertised host alias opens the in-app viewer re-rooted to the page origin (#324) @webkit", async ({
+  page,
+}) => {
+  await aliasModalJourney(page);
+});

--- a/cicchetto/src/MircText.tsx
+++ b/cicchetto/src/MircText.tsx
@@ -5,6 +5,7 @@ import { classifyMediaLink, sameHostHref } from "./lib/mediaLink";
 import { openMediaViewer } from "./lib/mediaViewer";
 import { parseMircFormat, type Run } from "./lib/mircFormat";
 import { maybeEscapePwaClick } from "./lib/platform";
+import { serverSettings } from "./lib/serverSettings";
 
 // Shared mIRC-formatting renderer. Extracted from ScrollbackPane (#125) so
 // the channel-directory topic reuses the SAME typed-formatting render path
@@ -105,12 +106,22 @@ const renderRun = (run: Run, linkPolicy: LinkPolicy): JSX.Element => {
           // untouched: out-of-scope already opens correctly in the iOS
           // Safari view.
           const prev = segments[i() - 1];
+          // #324 — the deployment's server-provided HTTP host aliases:
+          // an upload link on ANY of them opens the in-app viewer, not
+          // just one on the page origin (aliases share the /uploads
+          // store). Read from the reactive serverSettings() store; []
+          // before the after-join snapshot (page origin only, pre-#324).
+          // Injected into the classifier so mediaLink.ts stays pure +
+          // table-testable (no store import there).
+          const aliasHosts = serverSettings()?.httpHostAliases ?? [];
           const media = classifyMediaLink(
             seg.href,
             prev?.type === "text" ? prev.value : "",
             window.location.origin,
+            aliasHosts,
           );
-          const escapeHref = media === null ? sameHostHref(seg.href, window.location.origin) : null;
+          const escapeHref =
+            media === null ? sameHostHref(seg.href, window.location.origin, aliasHosts) : null;
           // #220 — compose the per-surface policy with the existing
           // media/escape in-app handling. The click handler is only
           // BUILT and attached when there's something to do; the pure

--- a/cicchetto/src/__tests__/linkify.test.ts
+++ b/cicchetto/src/__tests__/linkify.test.ts
@@ -214,7 +214,7 @@ describe("linkify", () => {
       expect(urlSeg).toBeDefined();
       if (urlSeg?.type !== "url") throw new Error("expected url segment");
       expect(urlSeg.href).toBe("https://grappa.example/files/shot.png");
-      expect(classifyMediaLink(urlSeg.href, "look ", origin)).toEqual({
+      expect(classifyMediaLink(urlSeg.href, "look ", origin, [])).toEqual({
         kind: "image",
         href: "https://grappa.example/files/shot.png",
       });

--- a/cicchetto/src/__tests__/mediaLink.test.ts
+++ b/cicchetto/src/__tests__/mediaLink.test.ts
@@ -4,135 +4,198 @@ import { classifyMediaLink, sameHostHref } from "../lib/mediaLink";
 // Media-link cluster (2026-06-11) — classifier for the on-click media
 // viewer modal. Wire shape under test:
 //
-//   classifyMediaLink(href, precedingText, origin)
+//   classifyMediaLink(href, precedingText, origin, aliasHosts)
 //     -> { kind: "image" | "video" | "audio", href: string } | null
 //
 // null = not modal-eligible; the scrollback anchor keeps its default
 // target=_blank behavior. The returned href is re-rooted on the page
 // origin (review fix: one parse, one return value — a separate
-// normalize step was a misuse footgun). Cross-HOST URLs are ALWAYS
-// null: the CSP (img-src 'self', media-src 'self' blob:) would block
-// the modal's media element, and out-of-scope links already open
-// correctly in the iOS Safari view — only same-host (in-PWA-scope)
-// links have the standalone navigate-in-place bug.
+// normalize step was a misuse footgun). A URL is admitted when its host
+// is the page origin's OR (#324) any of the deployment's server-provided
+// HTTP host aliases (`aliasHosts`); a genuinely third-party host is
+// ALWAYS null (the CSP img-src/media-src 'self' would block it, and
+// out-of-scope links already open correctly in the iOS Safari view).
 
 const ORIGIN = "https://grappa.example";
 // 26 chars of lowercase base32 (a-z2-7) — mirrors Grappa.Uploads
 // @slug_regex. a-z are all members of the base32 alphabet.
 const SLUG = "abcdefghijklmnopqrstuvwxyz";
 const UPLOAD_URL = `${ORIGIN}/uploads/${SLUG}`;
+// #324 — a sibling deployment alias (alias B) sharing the /uploads store
+// with the page origin (alias A). The server advertises it in aliasHosts.
+const ALIAS_B = "irc.sniffo.org";
+const NO_ALIASES: readonly string[] = [];
+const WITH_ALIAS_B: readonly string[] = [ALIAS_B];
 
 describe("classifyMediaLink", () => {
   describe("own upload URLs (emoji-prefixed, same-host /uploads/<slug>)", () => {
     it("📸-prefixed own upload URL classifies as image", () => {
-      expect(classifyMediaLink(UPLOAD_URL, "📸 ", ORIGIN)).toEqual({
+      expect(classifyMediaLink(UPLOAD_URL, "📸 ", ORIGIN, NO_ALIASES)).toEqual({
         kind: "image",
         href: UPLOAD_URL,
       });
     });
 
     it("🎬-prefixed own upload URL classifies as video", () => {
-      expect(classifyMediaLink(UPLOAD_URL, "🎬 ", ORIGIN)).toEqual({
+      expect(classifyMediaLink(UPLOAD_URL, "🎬 ", ORIGIN, NO_ALIASES)).toEqual({
         kind: "video",
         href: UPLOAD_URL,
       });
     });
 
     it("🎵-prefixed own upload URL classifies as audio (GH #115 — slug has no extension)", () => {
-      expect(classifyMediaLink(UPLOAD_URL, "🎵 ", ORIGIN)).toEqual({
+      expect(classifyMediaLink(UPLOAD_URL, "🎵 ", ORIGIN, NO_ALIASES)).toEqual({
         kind: "audio",
         href: UPLOAD_URL,
       });
     });
 
     it("emoji at end of longer preceding text still classifies", () => {
-      expect(classifyMediaLink(UPLOAD_URL, "relayed by bot: 📸 ", ORIGIN)).toEqual({
+      expect(classifyMediaLink(UPLOAD_URL, "relayed by bot: 📸 ", ORIGIN, NO_ALIASES)).toEqual({
         kind: "image",
         href: UPLOAD_URL,
       });
     });
 
     it("own upload URL without emoji prefix is null (type unknowable — slug has no extension)", () => {
-      expect(classifyMediaLink(UPLOAD_URL, "look at ", ORIGIN)).toBeNull();
+      expect(classifyMediaLink(UPLOAD_URL, "look at ", ORIGIN, NO_ALIASES)).toBeNull();
     });
 
     it("📄-prefixed own upload URL is null (documents are not modal-renderable)", () => {
-      expect(classifyMediaLink(UPLOAD_URL, "📄 ", ORIGIN)).toBeNull();
+      expect(classifyMediaLink(UPLOAD_URL, "📄 ", ORIGIN, NO_ALIASES)).toBeNull();
     });
 
     it("uploads path with non-slug tail is null even with emoji", () => {
-      expect(classifyMediaLink(`${ORIGIN}/uploads/NOT-A-SLUG`, "📸 ", ORIGIN)).toBeNull();
+      expect(
+        classifyMediaLink(`${ORIGIN}/uploads/NOT-A-SLUG`, "📸 ", ORIGIN, NO_ALIASES),
+      ).toBeNull();
     });
 
     it("emoji prefix does NOT promote a non-uploads same-host path", () => {
-      expect(classifyMediaLink(`${ORIGIN}/some/page`, "📸 ", ORIGIN)).toBeNull();
+      expect(classifyMediaLink(`${ORIGIN}/some/page`, "📸 ", ORIGIN, NO_ALIASES)).toBeNull();
     });
   });
 
   describe("same-host media-extension URLs", () => {
     it(".png path classifies as image", () => {
-      expect(classifyMediaLink(`${ORIGIN}/files/shot.png`, "", ORIGIN)).toEqual({
+      expect(classifyMediaLink(`${ORIGIN}/files/shot.png`, "", ORIGIN, NO_ALIASES)).toEqual({
         kind: "image",
         href: `${ORIGIN}/files/shot.png`,
       });
     });
 
     it(".mp4 path classifies as video", () => {
-      expect(classifyMediaLink(`${ORIGIN}/files/clip.mp4`, "", ORIGIN)?.kind).toBe("video");
+      expect(classifyMediaLink(`${ORIGIN}/files/clip.mp4`, "", ORIGIN, NO_ALIASES)?.kind).toBe(
+        "video",
+      );
     });
 
     it(".mp3 path classifies as audio", () => {
-      expect(classifyMediaLink(`${ORIGIN}/files/song.mp3`, "", ORIGIN)?.kind).toBe("audio");
+      expect(classifyMediaLink(`${ORIGIN}/files/song.mp3`, "", ORIGIN, NO_ALIASES)?.kind).toBe(
+        "audio",
+      );
     });
 
     it("extension match is case-insensitive", () => {
-      expect(classifyMediaLink(`${ORIGIN}/files/SHOT.PNG`, "", ORIGIN)?.kind).toBe("image");
+      expect(classifyMediaLink(`${ORIGIN}/files/SHOT.PNG`, "", ORIGIN, NO_ALIASES)?.kind).toBe(
+        "image",
+      );
     });
 
     it("query string does not defeat the extension match and survives in the href", () => {
-      expect(classifyMediaLink(`${ORIGIN}/files/shot.png?cache=1`, "", ORIGIN)).toEqual({
-        kind: "image",
-        href: `${ORIGIN}/files/shot.png?cache=1`,
-      });
+      expect(classifyMediaLink(`${ORIGIN}/files/shot.png?cache=1`, "", ORIGIN, NO_ALIASES)).toEqual(
+        {
+          kind: "image",
+          href: `${ORIGIN}/files/shot.png?cache=1`,
+        },
+      );
     });
 
     it("non-media extension is null", () => {
-      expect(classifyMediaLink(`${ORIGIN}/files/doc.pdf`, "", ORIGIN)).toBeNull();
+      expect(classifyMediaLink(`${ORIGIN}/files/doc.pdf`, "", ORIGIN, NO_ALIASES)).toBeNull();
     });
   });
 
-  describe("cross-host URLs are never modal-eligible", () => {
-    it("cross-host uploads-shaped URL with emoji is null", () => {
-      expect(classifyMediaLink(`https://other.example/uploads/${SLUG}`, "📸 ", ORIGIN)).toBeNull();
+  describe("third-party (non-deployment) hosts are never modal-eligible", () => {
+    it("third-party uploads-shaped URL with emoji is null", () => {
+      expect(
+        classifyMediaLink(`https://other.example/uploads/${SLUG}`, "📸 ", ORIGIN, NO_ALIASES),
+      ).toBeNull();
     });
 
-    it("cross-host image-extension URL is null (litterbox path — Safari view already works)", () => {
-      expect(classifyMediaLink("https://litter.catbox.moe/abc.png", "📸 ", ORIGIN)).toBeNull();
+    it("third-party image-extension URL is null (litterbox path — Safari view already works)", () => {
+      expect(
+        classifyMediaLink("https://litter.catbox.moe/abc.png", "📸 ", ORIGIN, NO_ALIASES),
+      ).toBeNull();
+    });
+
+    it("a third-party host stays null even when an alias set is advertised", () => {
+      expect(
+        classifyMediaLink("https://litter.catbox.moe/abc.png", "📸 ", ORIGIN, WITH_ALIAS_B),
+      ).toBeNull();
     });
 
     it("same hostname but different port is null (host comparison includes the port)", () => {
       expect(
-        classifyMediaLink(`https://grappa.example:4000/uploads/${SLUG}`, "📸 ", ORIGIN),
+        classifyMediaLink(`https://grappa.example:4000/uploads/${SLUG}`, "📸 ", ORIGIN, NO_ALIASES),
       ).toBeNull();
     });
   });
 
-  describe("scheme handling (host-equality, page-origin re-rooted href)", () => {
+  describe("deployment host aliases (#324 — page origin ∪ server aliases)", () => {
+    it("📸 upload URL on an advertised alias classifies AND re-roots onto the page origin", () => {
+      expect(
+        classifyMediaLink(`https://${ALIAS_B}/uploads/${SLUG}`, "📸 ", ORIGIN, WITH_ALIAS_B),
+      ).toEqual({ kind: "image", href: UPLOAD_URL });
+    });
+
+    it("media-extension URL on an advertised alias re-roots onto the page origin", () => {
+      expect(
+        classifyMediaLink(`https://${ALIAS_B}/files/clip.mp4?x=1#t=9`, "", ORIGIN, WITH_ALIAS_B),
+      ).toEqual({ kind: "video", href: `${ORIGIN}/files/clip.mp4?x=1#t=9` });
+    });
+
+    it("the same alias URL is null when the alias set is empty (pre-snapshot / single-host)", () => {
+      expect(
+        classifyMediaLink(`https://${ALIAS_B}/uploads/${SLUG}`, "📸 ", ORIGIN, NO_ALIASES),
+      ).toBeNull();
+    });
+
+    it("page-origin host is still admitted when a non-empty alias set is present", () => {
+      expect(classifyMediaLink(UPLOAD_URL, "📸 ", ORIGIN, WITH_ALIAS_B)).toEqual({
+        kind: "image",
+        href: UPLOAD_URL,
+      });
+    });
+
+    it("emoji rule is unchanged on an alias host (no emoji → null)", () => {
+      expect(
+        classifyMediaLink(`https://${ALIAS_B}/uploads/${SLUG}`, "look ", ORIGIN, WITH_ALIAS_B),
+      ).toBeNull();
+    });
+
+    it("an alias host with a non-listed port is null (host membership includes the port)", () => {
+      expect(
+        classifyMediaLink(`https://${ALIAS_B}:4000/uploads/${SLUG}`, "📸 ", ORIGIN, WITH_ALIAS_B),
+      ).toBeNull();
+    });
+  });
+
+  describe("scheme handling (host-membership, page-origin re-rooted href)", () => {
     // Pre-fix prod minted `http://host/uploads/<slug>` (Endpoint url had
     // no scheme key) while the PWA runs at https://host — those bodies
     // are permanent scrollback history, so the classifier matches on
     // HOST and re-roots the returned href on the page origin (the
     // viewer must never load an http src on the https page).
     it("http URL on the page's https host classifies and re-roots the href", () => {
-      expect(classifyMediaLink(`http://grappa.example/uploads/${SLUG}`, "📸 ", ORIGIN)).toEqual({
-        kind: "image",
-        href: UPLOAD_URL,
-      });
+      expect(
+        classifyMediaLink(`http://grappa.example/uploads/${SLUG}`, "📸 ", ORIGIN, NO_ALIASES),
+      ).toEqual({ kind: "image", href: UPLOAD_URL });
     });
 
     it("re-rooting preserves path, query AND media-fragment hash", () => {
       expect(
-        classifyMediaLink(`http://grappa.example/files/clip.mp4?x=1#t=90`, "", ORIGIN),
+        classifyMediaLink(`http://grappa.example/files/clip.mp4?x=1#t=90`, "", ORIGIN, NO_ALIASES),
       ).toEqual({
         kind: "video",
         href: `${ORIGIN}/files/clip.mp4?x=1#t=90`,
@@ -140,17 +203,19 @@ describe("classifyMediaLink", () => {
     });
 
     it("ftp URL on the same host is null (linkify admits ftp; the viewer doesn't)", () => {
-      expect(classifyMediaLink("ftp://grappa.example/files/shot.png", "", ORIGIN)).toBeNull();
+      expect(
+        classifyMediaLink("ftp://grappa.example/files/shot.png", "", ORIGIN, NO_ALIASES),
+      ).toBeNull();
     });
   });
 
   describe("degenerate input", () => {
     it("unparseable href is null", () => {
-      expect(classifyMediaLink("not a url", "📸 ", ORIGIN)).toBeNull();
+      expect(classifyMediaLink("not a url", "📸 ", ORIGIN, NO_ALIASES)).toBeNull();
     });
 
     it("empty href is null", () => {
-      expect(classifyMediaLink("", "", ORIGIN)).toBeNull();
+      expect(classifyMediaLink("", "", ORIGIN, NO_ALIASES)).toBeNull();
     });
   });
 });
@@ -159,33 +224,45 @@ describe("classifyMediaLink", () => {
 // re-root half of classifyMediaLink, exported so ScrollbackPane can
 // apply the iOS-standalone escape to same-host NON-media links (📄
 // docs, emoji-split-run fallbacks) without re-implementing the
-// host/scheme/re-rooting rules.
+// host/scheme/re-rooting rules. #324 — widens with the SAME alias set.
 describe("sameHostHref", () => {
   const SLUG_PATH = "/uploads/abcdefghijklmnopqrstuvwxyz";
 
   it("same-host https URL returns the origin-rooted href", () => {
-    expect(sameHostHref(`${ORIGIN}${SLUG_PATH}`, ORIGIN)).toBe(`${ORIGIN}${SLUG_PATH}`);
+    expect(sameHostHref(`${ORIGIN}${SLUG_PATH}`, ORIGIN, NO_ALIASES)).toBe(`${ORIGIN}${SLUG_PATH}`);
   });
 
   it("historical http:// same-host URL is re-rooted onto the page origin", () => {
-    expect(sameHostHref(`http://grappa.example${SLUG_PATH}`, ORIGIN)).toBe(`${ORIGIN}${SLUG_PATH}`);
+    expect(sameHostHref(`http://grappa.example${SLUG_PATH}`, ORIGIN, NO_ALIASES)).toBe(
+      `${ORIGIN}${SLUG_PATH}`,
+    );
   });
 
   it("preserves path, query and hash through the re-root", () => {
-    expect(sameHostHref(`http://grappa.example/a/b?x=1#t=42`, ORIGIN)).toBe(
+    expect(sameHostHref(`http://grappa.example/a/b?x=1#t=42`, ORIGIN, NO_ALIASES)).toBe(
       `${ORIGIN}/a/b?x=1#t=42`,
     );
   });
 
-  it("cross-host URL is null", () => {
-    expect(sameHostHref("https://litter.catbox.moe/abc.png", ORIGIN)).toBe(null);
+  it("an advertised alias host re-roots onto the page origin (#324)", () => {
+    expect(sameHostHref(`https://${ALIAS_B}${SLUG_PATH}`, ORIGIN, WITH_ALIAS_B)).toBe(
+      `${ORIGIN}${SLUG_PATH}`,
+    );
+  });
+
+  it("an alias host is null when the alias set is empty", () => {
+    expect(sameHostHref(`https://${ALIAS_B}${SLUG_PATH}`, ORIGIN, NO_ALIASES)).toBe(null);
+  });
+
+  it("third-party host is null even with an alias set advertised", () => {
+    expect(sameHostHref("https://litter.catbox.moe/abc.png", ORIGIN, WITH_ALIAS_B)).toBe(null);
   });
 
   it("non-http(s) scheme is null (linkify also admits ftp)", () => {
-    expect(sameHostHref("ftp://grappa.example/file", ORIGIN)).toBe(null);
+    expect(sameHostHref("ftp://grappa.example/file", ORIGIN, NO_ALIASES)).toBe(null);
   });
 
   it("unparseable href is null", () => {
-    expect(sameHostHref("https://", ORIGIN)).toBe(null);
+    expect(sameHostHref("https://", ORIGIN, NO_ALIASES)).toBe(null);
   });
 });

--- a/cicchetto/src/__tests__/serverSettings.test.ts
+++ b/cicchetto/src/__tests__/serverSettings.test.ts
@@ -48,6 +48,8 @@ describe("applyServerSettings/1 — wire → store shape", () => {
         audio: 26_214_400,
       },
       uploadGlobalCapBytes: 10_737_418_240,
+      // #324 — absent on the wire → [] (page origin only).
+      httpHostAliases: [],
     });
   });
 
@@ -100,7 +102,31 @@ describe("applyServerSettings/1 — wire → store shape", () => {
       uploadActiveHost: "litterbox",
       uploadPerFileCapBytes: { image: 3, video: 4, document: 5, audio: 7 },
       uploadGlobalCapBytes: 6,
+      httpHostAliases: [],
     });
+  });
+
+  // #324 — the deployment's HTTP host aliases ride the same payload;
+  // mediaLink.ts reads them from this store.
+  it("maps http_host_aliases into httpHostAliases", () => {
+    applyServerSettings({
+      upload: {
+        active_host: "embedded",
+        image_per_file_cap_bytes: 1,
+        video_per_file_cap_bytes: 2,
+        document_per_file_cap_bytes: 3,
+        audio_per_file_cap_bytes: 5,
+        global_cap_bytes: 4,
+      },
+      http_host_aliases: ["irc.sindro.me", "irc.sniffo.org"],
+    });
+
+    expect(serverSettings()?.httpHostAliases).toEqual(["irc.sindro.me", "irc.sniffo.org"]);
+  });
+
+  it("defaults httpHostAliases to [] when the wire omits it (old server / pre-snapshot)", () => {
+    applyServerSettings({ upload: wireUpload("embedded") });
+    expect(serverSettings()?.httpHostAliases).toEqual([]);
   });
 });
 

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -1081,6 +1081,10 @@ export type WireUserEvent =
       // (drift-gated against `Grappa.ServerSettings.Wire`); the
       // `active_host` closed set is no longer re-hardcoded here.
       upload: ServerSettingsWireUploadView;
+      // #324 — the deployment's HTTP host aliases; mediaLink admits an
+      // upload link on any of them. Narrowed to string[] in userTopic.ts
+      // (malformed / absent → []), threaded into applyServerSettings.
+      http_host_aliases: string[];
     }
   | { kind: "archive_changed"; network_slug: string }
   // UX-7-B (2026-05-22) — `archive_purged` push after a destructive

--- a/cicchetto/src/lib/mediaLink.ts
+++ b/cicchetto/src/lib/mediaLink.ts
@@ -19,15 +19,28 @@
 //
 // ## Classification rules
 //
-// 1. Cross-HOST → null, always. Two independent reasons: (a) the
-//    CSP (`img-src 'self' data:`, `media-src 'self' blob:`) would
-//    block the modal's media element anyway — the modal must not
-//    require a CSP loosening; (b) cross-host links don't have the
-//    standalone bug in the first place.
-//    Host-equality, NOT full-origin equality: pre-fix prod minted
-//    `http://host/uploads/<slug>` (Endpoint `url:` carried no scheme
-//    key) while the PWA runs at `https://host`. Those bodies are
-//    permanent scrollback history — a strict origin check would dead-
+// 1. Host NOT in the admitted set → null, always. The admitted set is
+//    the page-origin host ∪ the deployment's server-provided HTTP host
+//    aliases (`aliasHosts` param, #324 — from `serverSettings()`'s
+//    `httpHostAliases`, ultimately `Grappa.HttpHosts`; NEVER a client-
+//    baked list). Two independent reasons a genuinely foreign host is
+//    excluded: (a) the CSP (`img-src 'self' data:`, `media-src 'self'
+//    blob:`) would block the modal's media element anyway — the modal
+//    must not require a CSP loosening; (b) genuinely cross-host links
+//    don't have the standalone bug and open fine in the iOS Safari view.
+//    #324 — a deployment can answer on several hostname aliases
+//    (`irc.sindro.me`, `irc.sniffo.org`) that reverse-proxy to ONE
+//    instance + shared /uploads store; a link minted under one alias
+//    viewed from another must still open the viewer. Because the
+//    returned `href` is re-rooted on the PAGE origin (below), the modal's
+//    `<img src>` stays SAME-ORIGIN even for an alias link → CSP
+//    `img-src 'self'` is UNTOUCHED (no loosening). A foreign host is
+//    NEVER re-rooted onto the page origin (that would 404 / load the
+//    wrong file) — only admitted hosts pass.
+//    Host-equality (hostname + port), NOT full-origin equality: pre-fix
+//    prod minted `http://host/uploads/<slug>` (Endpoint `url:` carried
+//    no scheme key) while the PWA runs at `https://host`. Those bodies
+//    are permanent scrollback history — a strict origin check would dead-
 //    letter every historical upload link. The viewer must NEVER load
 //    an http src on the https page (mixed content), so the returned
 //    `href` is re-rooted on the page origin (path + query + hash
@@ -125,9 +138,19 @@ function hostOf(origin: string): string | null {
 }
 
 // Shared host-match + re-root core: parse, admit only http(s), require
-// host equality with the page origin, and produce the origin-rooted
-// href (path + query + hash preserved).
-function sameHostUrl(href: string, origin: string): { url: URL; rooted: string } | null {
+// the host to be in the admitted set (page origin ∪ server-provided
+// deployment aliases), and produce the origin-rooted href (path + query
+// + hash preserved). `aliasHosts` are the deployment's #324 HTTP host
+// aliases — bare, lowercased hostnames the server advertised; the page-
+// origin host is ALWAYS admitted in addition, so a single-host or
+// pre-snapshot deployment (empty aliasHosts) keeps the pre-#324
+// behaviour. Injected (not read from a store here) so this module stays
+// pure + table-testable.
+function sameHostUrl(
+  href: string,
+  origin: string,
+  aliasHosts: readonly string[],
+): { url: URL; rooted: string } | null {
   let url: URL;
   try {
     url = new URL(href);
@@ -136,9 +159,11 @@ function sameHostUrl(href: string, origin: string): { url: URL; rooted: string }
   }
 
   if (url.protocol !== "http:" && url.protocol !== "https:") return null;
-  // Host (hostname + port) equality — see the moduledoc on why scheme
-  // is deliberately NOT compared.
-  if (url.host !== hostOf(origin)) return null;
+  // Host (hostname + port) membership — see the moduledoc on why scheme
+  // is deliberately NOT compared. Page origin always admitted; #324
+  // widens to any deployment alias so a sibling-hostname upload link
+  // opens the viewer too.
+  if (url.host !== hostOf(origin) && !aliasHosts.includes(url.host)) return null;
 
   return { url, rooted: `${origin}${url.pathname}${url.search}${url.hash}` };
 }
@@ -148,10 +173,16 @@ function sameHostUrl(href: string, origin: string): { url: URL; rooted: string }
  * for links that are not modal-eligible but still have the
  * iOS-standalone navigate-in-place bug (📄 docs, emoji-split-run
  * fallbacks; review fix 2026-06-11). Returns the origin-rooted href,
- * or null for cross-host / non-http(s) / unparseable hrefs.
+ * or null for cross-host / non-http(s) / unparseable hrefs. Widens with
+ * the SAME `aliasHosts` set as `classifyMediaLink` (#324) so the escape
+ * path also routes through the in-app handler on a deployment alias.
  */
-export function sameHostHref(href: string, origin: string): string | null {
-  return sameHostUrl(href, origin)?.rooted ?? null;
+export function sameHostHref(
+  href: string,
+  origin: string,
+  aliasHosts: readonly string[],
+): string | null {
+  return sameHostUrl(href, origin, aliasHosts)?.rooted ?? null;
 }
 
 /**
@@ -166,13 +197,20 @@ export function sameHostHref(href: string, origin: string): string | null {
  *   formatting run ("" when the URL starts the run).
  * @param origin window.location.origin at the call site — injected so
  *   the classifier stays pure and table-testable.
+ * @param aliasHosts the deployment's server-provided HTTP host aliases
+ *   (#324, bare lowercased hostnames from `serverSettings()`'s
+ *   `httpHostAliases`). A URL whose host is any of these — OR the page
+ *   origin's own host — is admitted and re-rooted onto the page origin;
+ *   a third-party host still returns null. Empty set = page origin only
+ *   (pre-#324 behaviour). Injected so the classifier stays pure.
  */
 export function classifyMediaLink(
   href: string,
   precedingText: string,
   origin: string,
+  aliasHosts: readonly string[],
 ): MediaLink | null {
-  const match = sameHostUrl(href, origin);
+  const match = sameHostUrl(href, origin, aliasHosts);
   if (match === null) return null;
 
   const kind = kindOf(match.url, precedingText);

--- a/cicchetto/src/lib/serverSettings.ts
+++ b/cicchetto/src/lib/serverSettings.ts
@@ -64,6 +64,12 @@ export type ServerSettingsView = {
   uploadActiveHost: ServerSettingsWireUploadView["active_host"];
   uploadPerFileCapBytes: Record<UploadCategory, number>;
   uploadGlobalCapBytes: number;
+  // #324 — the deployment's HTTP host aliases (bare lowercased
+  // hostnames the server advertised). `mediaLink.ts` admits an upload
+  // link on ANY of them (they share the /uploads store). Always an
+  // array — `[]` before the first snapshot / on an old server — so the
+  // classifier falls back to the page origin only.
+  httpHostAliases: string[];
 };
 
 // Public-subset wire shape — mirrors `GET /api/server-settings`
@@ -71,9 +77,13 @@ export type ServerSettingsView = {
 // `upload` reuses the GENERATED `ServerSettingsWireUploadView`
 // (wireTypes.ts, drift-gated against `Grappa.ServerSettings.Wire`) —
 // the only delta vs the generated changed-payload is that the REST
-// response carries no `kind` field.
+// response carries no `kind` field. `http_host_aliases` (#324) is
+// optional on the wire: an older server (mid-deploy) omits it, and the
+// REST path is a blind cast — absent → `[]` (page origin only). The WS
+// path narrows it strictly in userTopic.ts.
 export type ServerSettingsWirePayload = {
   upload: ServerSettingsWireUploadView;
+  http_host_aliases?: string[];
 };
 
 const exports_ = identityScopedStore((onIdentityChange) => {
@@ -96,6 +106,9 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         audio: raw.upload.audio_per_file_cap_bytes,
       },
       uploadGlobalCapBytes: raw.upload.global_cap_bytes,
+      // #324 — absent (old server / pre-snapshot / REST blind-cast) → []
+      // so mediaLink admits the page origin only (pre-#324 behaviour).
+      httpHostAliases: raw.http_host_aliases ?? [],
     });
   };
 

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -531,6 +531,14 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
         !posInt(u.global_cap_bytes)
       )
         return null;
+      // #324 — deployment HTTP host aliases. Lenient: a malformed /
+      // absent value degrades to [] (page origin only) rather than
+      // dropping the whole settings push (which would strand the upload
+      // caps too). Filter to strings so a proxy-mangled element can't
+      // poison mediaLink's host-membership check.
+      const httpHostAliases = Array.isArray(r.http_host_aliases)
+        ? r.http_host_aliases.filter((h): h is string => typeof h === "string")
+        : [];
       return {
         kind: "server_settings_changed",
         upload: {
@@ -541,6 +549,7 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
           audio_per_file_cap_bytes: u.audio_per_file_cap_bytes,
           global_cap_bytes: u.global_cap_bytes,
         },
+        http_host_aliases: httpHostAliases,
       };
     }
     case "peer_away":
@@ -932,10 +941,14 @@ createRoot(() => {
           // setter applies in both directions (last-write-wins,
           // idempotent). Destructure to drop the `kind` discriminator
           // — `applyServerSettings` takes the `ServerSettingsWirePayload`
-          // shape (upload subtree only) so structural-typing drift
-          // (e.g. a future log site reading `raw.kind`) can't surprise
-          // the REST call site whose response has no `kind`.
-          applyServerSettings({ upload: payload.upload });
+          // shape (upload subtree + #324 http_host_aliases) so
+          // structural-typing drift (e.g. a future log site reading
+          // `raw.kind`) can't surprise the REST call site whose response
+          // has no `kind`.
+          applyServerSettings({
+            upload: payload.upload,
+            http_host_aliases: payload.http_host_aliases,
+          });
           return;
 
         case "peer_away":

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -548,6 +548,7 @@ export type ServerSettingsWireUploadView = {
 export type ServerSettingsWireChangedPayload = {
   kind: string;
   upload: ServerSettingsWireUploadView;
+  http_host_aliases: string[];
 };
 
 // === Grappa.Session.Wire ===

--- a/compose.override.yaml.example
+++ b/compose.override.yaml.example
@@ -34,6 +34,11 @@ services:
   grappa:
     environment:
       PHX_HOST: voygrappa.bad.ass
+      # EXTRA_CHECK_ORIGINS: WS `check_origin` extras AND (with PHX_HOST,
+      # #324) the deployment's HTTP host-alias set — every hostname nginx
+      # reverse-proxies to this ONE instance. List a sibling public vhost
+      # here (comma-separated) and cic's media-link viewer opens uploads
+      # minted under it too; no cic redeploy, no second list.
       EXTRA_CHECK_ORIGINS: "http://192.168.53.12"
       # Push notifications cluster B2 (2026-05-14). Generate once per
       # deployment with `scripts/mix.sh grappa.gen_vapid` and paste

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -25,6 +25,22 @@ phx_host =
     host -> host
   end
 
+# Extra origins accepted by the WebSocket handshake's `check_origin`
+# gate alongside the canonical PHX_HOST, AND — with PHX_HOST — the
+# source of the deployment's HTTP host-alias set (#324, derived in the
+# `if phx_host` block below → Grappa.HttpHosts). Comma-separated, full
+# origin form (no trailing slash). Use case: operators reaching the
+# bouncer via raw IP or a secondary hostname (LAN testing, dev VLAN
+# bindings, a second public vhost) without rewriting nginx + DNS.
+# Hoisted OUT of the prod block (all envs) so the alias set is
+# derivable in the e2e harness (MIX_ENV=dev). Empty / unset = no extras.
+extra_origins =
+  case System.get_env("EXTRA_CHECK_ORIGINS") do
+    nil -> []
+    "" -> []
+    raw -> raw |> String.split(",") |> Enum.map(&String.trim/1) |> Enum.reject(&(&1 == ""))
+  end
+
 # Public-origin URL config — ALL envs, gated on PHX_HOST presence.
 # nginx terminates TLS at https://PHX_HOST, so URLs Phoenix generates
 # (today: only `UploadsController.public_url/1`, which lands in IRC
@@ -42,6 +58,30 @@ phx_host =
 # default.
 if phx_host do
   config :grappa, GrappaWeb.Endpoint, url: [host: phx_host, scheme: "https", port: 443]
+
+  # #324 — the deployment's HTTP host aliases: every hostname nginx
+  # reverse-proxies to this ONE instance (shared /uploads store, e.g.
+  # irc.sindro.me + irc.sniffo.org). Derived from the SAME env inputs
+  # that build `check_origin` below (PHX_HOST + EXTRA_CHECK_ORIGINS) —
+  # single source of truth, no second hand-maintained list. Bare,
+  # lowercased hostnames (URI.parse drops scheme / `//` AND port).
+  # Deployment aliases that mint uploads are default-port https, whose
+  # `new URL().host` in cic is bare too → they match. A non-default-port
+  # EXTRA_CHECK_ORIGINS entry (a raw-IP LAN escape hatch) won't match a
+  # link on that explicit port — acceptable: it just falls back to the
+  # plain anchor (never a WRONG re-root, since the page origin is always
+  # admitted and the re-root always targets the page origin). Stashed
+  # into `:persistent_term` by `Grappa.HttpHosts.boot/1` at app start and
+  # advertised to cic via `ServerSettings.public_view/0`, so cic's
+  # media-link classifier opens the in-app viewer for an upload link
+  # carrying ANY alias, not just the page origin.
+  http_host_aliases =
+    [phx_host | Enum.map(extra_origins, fn origin -> URI.parse(origin).host end)]
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.map(&String.downcase/1)
+    |> Enum.uniq()
+
+  config :grappa, :http_host_aliases, http_host_aliases
 end
 
 if config_env() == :prod do
@@ -170,19 +210,10 @@ if config_env() == :prod do
       (e.g. PHX_HOST=grappa.bad.ass) — see .env.example.
       """
 
-  # Extra origins accepted by the WebSocket handshake's `check_origin`
-  # gate alongside the canonical PHX_HOST. Comma-separated, full origin
-  # form (no trailing slash). Use case: operators reaching the bouncer
-  # via raw IP or a secondary hostname (LAN testing, dev VLAN bindings)
-  # without rewriting nginx + DNS. Production should pin to PHX_HOST
-  # only — this is escape-hatch, not default. Empty / unset = no extras.
-  extra_origins =
-    case System.get_env("EXTRA_CHECK_ORIGINS") do
-      nil -> []
-      "" -> []
-      raw -> raw |> String.split(",") |> Enum.map(&String.trim/1) |> Enum.reject(&(&1 == ""))
-    end
-
+  # `extra_origins` (hoisted to the top of this file, all envs) feeds
+  # both the WS `check_origin` gate here and the #324 HTTP host-alias
+  # set. Production should pin to PHX_HOST only — EXTRA_CHECK_ORIGINS is
+  # an escape-hatch (raw IP / secondary vhost), not a default.
   config :grappa, GrappaWeb.Endpoint,
     http: [ip: {0, 0, 0, 0}, port: port],
     check_origin: ["//#{phx_host}" | extra_origins],

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -25261,3 +25261,80 @@ _Deploy: **cic-bundle only** — no `.ex` change, so hot-eligible via
 `deploy-m42.sh --cic`. **HELD** — rides the already-HELD #299 COLD batch's 4AM
 window, shipped together with `deploy-m42.sh --force-cold --cic` (with #249 /
 #282 / #290 / #294 / #301 / #302 / #304 / #305 / #306 / #307 / #318)._
+
+### 2026-07-19 — #324: media-modal same-host gate rejects deployment hostname aliases (P0)
+
+**The gap.** cic's media-link classifier (`cicchetto/src/lib/mediaLink.ts`) gated
+an upload link on a SINGLE host equality — `url.host === page-origin host`. A
+deployment that answers on several hostname aliases (`irc.sindro.me` +
+`irc.sniffo.org`, both reverse-proxying to ONE grappa instance + a shared
+`/uploads` store) mints upload URLs under one alias while a session may be loaded
+from another. cic opened from `irc.sindro.me`, a scrollback link
+`📸 https://irc.sniffo.org/uploads/<slug>` → cross-host → `classifyMediaLink`
+returned `null` → the link fell back to the plain anchor. On the iOS standalone
+PWA (the manifest has no `scope`, so the whole origin is in-scope) that navigates
+IN PLACE: raw media document, no chrome, return reloads cic.
+
+**The fix — host ∈ (page origin ∪ server-provided alias set), re-root preserved.**
+The classifier now admits a URL whose host is the page origin's OR any of the
+deployment's server-provided HTTP host aliases, and re-roots the returned href
+onto the PAGE origin exactly as before (`${origin}${path}${search}${hash}`).
+Because the aliases share one backend + upload store, a link
+`https://irc.sniffo.org/uploads/x` viewed from `irc.sindro.me` re-roots to
+`https://irc.sindro.me/uploads/x` → the modal's `<img src>` stays SAME-ORIGIN →
+CSP `img-src 'self'` is UNTOUCHED (no loosening). ONE predicate widened
+(host-equality → host-membership) + the alias set threaded in; the re-root
+machinery is unchanged. A genuinely third-party host (litterbox) is still `null`
+— NEVER re-root a foreign host onto the page origin (would 404 / load the wrong
+file). `sameHostHref()` (the non-media 📄 / emoji-split escape path) widens with
+the SAME set.
+
+**Challenge-the-spec: server-settings (deployment-global), NOT per-network
+ISUPPORT.** #324 suggested the alias set could ride "a server-settings payload OR
+an ISUPPORT token." A hostname alias is a DEPLOYMENT-GLOBAL HTTP property — the
+whole instance answers on `irc.sindro.me` / `irc.sniffo.org` regardless of which
+IRC network a session is on. `Grappa.Session.ISupport` is per-(subject, network),
+the wrong altitude — a media link's host has nothing to do with the IRC network.
+So the alias set rides the existing deployment-global server-settings payload
+(`Grappa.ServerSettings.public_view/0` → `Grappa.ServerSettings.Wire` →
+`GET /api/server-settings` + the WS `server_settings_changed` snapshot / admin
+fan-out); cic reads it into `serverSettings().httpHostAliases` and threads it into
+the PURE classifier (mediaLink.ts stays store-free + table-testable). No new
+endpoint, no nginx allowlist route.
+
+**Single source of truth — derived, no client-baked or second list.** The alias
+set is DERIVED at boot from the SAME env inputs that already build the Endpoint's
+`check_origin` gate — `PHX_HOST` + `EXTRA_CHECK_ORIGINS` (`config/runtime.exs`) —
+into bare lowercased hostnames, stashed in `:persistent_term` by the new
+`Grappa.HttpHosts` (boot-read in `Grappa.Application.start/2`, the CLAUDE.md
+`Application.get_env` boot boundary; mirrors `Grappa.Uploads.boot/1`). Adding a
+vhost is one `EXTRA_CHECK_ORIGINS` edit — no cic redeploy, no hand-maintained
+duplicate. This is NOT `Grappa.Vhosts` (#228) — that is per-network IRC
+source-bind (outbound IP), a different axis. cic bakes NO host list; an empty set
+(single-host / pre-snapshot) → page origin only (pre-#324 behaviour).
+
+**Wire.** `changed_payload` + `public_view/0` gain `http_host_aliases:
+[String.t()]` → codegen emits `http_host_aliases: string[]` on
+`ServerSettingsWireChangedPayload` (drift-gated). REST `GET /api/server-settings`
+carries it too (sibling to `upload`, no `kind`). cic's userTopic narrower
+validates it (malformed / absent → `[]`, never drops the upload subtree);
+`serverSettings.ts` maps it to `httpHostAliases` (optional on the wire →
+old-server / pre-snapshot tolerant, mirroring the #292 bundle-version posture).
+
+**Tests.** Pure vitest table (mediaLink): alias host admitted + re-rooted onto the
+page origin, third-party still `null`, page origin always admitted, empty-set
+fallback, port + emoji rules preserved, `sameHostHref` parity — all meaningful
+against the old single-host gate. Server ExUnit: `Grappa.HttpHosts` boot/aliases;
+`public_view/0` + REST + Wire carry the alias set. e2e (chromium + @webkit): the
+server advertises a synthetic sibling `alias-b.test` via `EXTRA_CHECK_ORIGINS`, a
+composed body carrying that host opens the viewer re-rooted to the page origin
+(real bytes through nginx under the prod CSP — the `_cspGuard` fixture proves
+`img-src 'self'` admits the re-rooted same-origin `<img>`), and a third-party
+host stays a plain anchor.
+
+_Deploy: **COLD** — the alias set is boot-derived (`config/runtime.exs` env re-read
++ `Grappa.Application.start/2` `:persistent_term` stash); a hot module reload
+re-runs neither, so the set only populates on a full restart. server + cic bundle.
+**HELD** — rides the already-HELD #299 COLD batch's 4AM window
+(`deploy-m42.sh --force-cold --cic`, together with #249 / #282 / #290 / #294 /
+#301 / #302 / #304 / #305 / #306 / #307 / #318)._

--- a/lib/grappa/application.ex
+++ b/lib/grappa/application.ex
@@ -8,6 +8,7 @@ defmodule Grappa.Application do
       Grappa.AdminEvents,
       Grappa.Bootstrap,
       Grappa.Health,
+      Grappa.HttpHosts,
       Grappa.Net.PtrCache,
       Grappa.OutboundV6Pool,
       Grappa.PubSub,
@@ -57,6 +58,13 @@ defmodule Grappa.Application do
     # `apply_pool/1` before spawning any session (#228 — DB-driven, no
     # env var). Empty pool = kernel-default source selection.
     :ok = Grappa.OutboundV6Pool.boot()
+
+    # #324: stash the deployment's HTTP host aliases in `:persistent_term`
+    # so `ServerSettings.public_view/0` advertises them to cic lock-free
+    # (the media-link classifier admits any deployment alias, not just the
+    # page origin). Boot-time read of `Application.get_env/2` is the
+    # CLAUDE.md-designated boundary (mirrors `Grappa.Uploads.boot/1`).
+    :ok = Grappa.HttpHosts.boot(http_host_aliases())
 
     # Child order is load-bearing — see CLAUDE.md "Don't touch supervision
     # tree ordering casually." Each comment below documents the WHY so a
@@ -274,6 +282,13 @@ defmodule Grappa.Application do
   defp uploads_storage_root do
     Application.fetch_env!(:grappa, :uploads_storage_root)
   end
+
+  # #324 — the deployment's HTTP host aliases, boot-derived in
+  # `config/runtime.exs` from `PHX_HOST` + `EXTRA_CHECK_ORIGINS`.
+  # Boot-time read (the CLAUDE.md-designated boundary for
+  # `Application.get_env/2`); absent in dev/test without `PHX_HOST` →
+  # empty set, so cic admits only its own page origin (pre-#324).
+  defp http_host_aliases, do: Application.get_env(:grappa, :http_host_aliases, [])
 
   # #252 — the vhost PTR cache child spec. Boot-time read (the CLAUDE.md
   # designated boundary for `Application.get_env/2`) of an OPTIONAL

--- a/lib/grappa/http_hosts.ex
+++ b/lib/grappa/http_hosts.ex
@@ -1,0 +1,67 @@
+defmodule Grappa.HttpHosts do
+  @moduledoc """
+  The deployment's own HTTP hostname aliases — the set of hostnames
+  nginx serves this ONE grappa instance under (#324).
+
+  ## Why this exists
+
+  A deployment can answer on several hostname aliases that all
+  reverse-proxy to the SAME bouncer + upload store (e.g.
+  `irc.sindro.me` AND `irc.sniffo.org`). An upload link minted under
+  one alias (`📸 https://irc.sniffo.org/uploads/<slug>`) may be viewed
+  in cic loaded from another (`https://irc.sindro.me`). cic's media-
+  link classifier (`cicchetto/src/lib/mediaLink.ts`) must recognise
+  BOTH as same-deployment so the in-app media viewer opens instead of
+  the plain anchor (which navigates the iOS standalone PWA in place).
+
+  The alias set is SERVER-PROVIDED, single source of truth: cic never
+  bakes a host list. It rides the deployment-global server-settings
+  wire payload (`Grappa.ServerSettings.public_view/0` →
+  `Grappa.ServerSettings.Wire`), NOT a per-network ISUPPORT token — a
+  hostname alias is an HTTP/deployment property, not a per-(subject,
+  network) IRC property.
+
+  ## Source of truth — derived, not a second list
+
+  The set is DERIVED at boot from the SAME env inputs that already
+  build the Endpoint's `check_origin` gate — `PHX_HOST` +
+  `EXTRA_CHECK_ORIGINS` (see `config/runtime.exs`). Adding a vhost is
+  one `EXTRA_CHECK_ORIGINS` edit; no cic redeploy, no hand-maintained
+  duplicate. This is NOT `Grappa.Vhosts` (#228) — that is per-network
+  IRC source-bind (outbound IP), a different axis entirely.
+
+  ## Boot-time read → `:persistent_term`
+
+  Per CLAUDE.md "`Application.{put,get}_env`: boot-time only, runtime
+  banned", `config/runtime.exs` sets `:http_host_aliases` and
+  `Grappa.Application.start/2` reads it once and calls `boot/1` here,
+  stashing into `:persistent_term`. Runtime readers (the
+  `ServerSettings.public_view/0` assembler) call `aliases/0` — a
+  lock-free `:persistent_term` read. Mirrors `Grappa.Uploads.boot/1` +
+  `Grappa.Push.boot/0`.
+  """
+
+  use Boundary, top_level?: true, deps: []
+
+  @aliases_key {__MODULE__, :aliases}
+
+  @doc """
+  Stash the deployment's HTTP host aliases into `:persistent_term`.
+  Called once from `Grappa.Application.start/2` with the boot-derived
+  list (`Application.get_env(:grappa, :http_host_aliases, [])`).
+  """
+  @spec boot([String.t()]) :: :ok
+  def boot(aliases) when is_list(aliases) do
+    :persistent_term.put(@aliases_key, aliases)
+    :ok
+  end
+
+  @doc """
+  The deployment's HTTP host aliases (bare, lowercased hostnames).
+  Empty list before `boot/1` runs (dev without `PHX_HOST`, or a test
+  that hasn't stashed a set) — cic then admits only its own page
+  origin, the pre-#324 behaviour.
+  """
+  @spec aliases() :: [String.t()]
+  def aliases, do: :persistent_term.get(@aliases_key, [])
+end

--- a/lib/grappa/server_settings.ex
+++ b/lib/grappa/server_settings.ex
@@ -22,10 +22,12 @@ defmodule Grappa.ServerSettings do
 
   ## Public-subset shape (`public_view/0`)
 
-  Returns the operator-visible subset for `GET /api/server-settings`
-  — currently the upload block (active_host + the three per-category
-  per-file caps + global_cap_bytes). Admin-only settings (when added)
-  stay out of this view.
+  Returns the operator-visible subset for `GET /api/server-settings`:
+  the upload block (active_host + the per-category per-file caps +
+  global_cap_bytes) plus `http_host_aliases` — the deployment's HTTP
+  host aliases (#324, from `Grappa.HttpHosts`, config-derived not
+  DB-backed) that cic's media-link classifier admits. Admin-only
+  settings (when added) stay out of this view.
 
   ## PubSub broadcast on change
 
@@ -49,10 +51,16 @@ defmodule Grappa.ServerSettings do
 
   ## Boundary
 
-  Deps: `Grappa.PubSub`, `Grappa.Repo`. Pure persistence + broadcast.
+  Deps: `Grappa.PubSub`, `Grappa.Repo`, `Grappa.HttpHosts`.
+  `public_view/0` ASSEMBLES the cic-facing view from two sources: the
+  DB-backed `upload` knobs (Repo) and the deployment-global HTTP host
+  aliases (`Grappa.HttpHosts`, #324) — the latter is config, not DB
+  state, so it is derived at read time, never persisted here.
   """
 
-  use Boundary, top_level?: true, deps: [Grappa.Repo, Grappa.PubSub, Grappa.ServerSettings.Wire]
+  use Boundary,
+    top_level?: true,
+    deps: [Grappa.Repo, Grappa.PubSub, Grappa.ServerSettings.Wire, Grappa.HttpHosts]
 
   alias Grappa.PubSub, as: GrappaPubSub
   alias Grappa.PubSub.Topic
@@ -93,7 +101,8 @@ defmodule Grappa.ServerSettings do
             document_per_file_cap_bytes: pos_integer(),
             audio_per_file_cap_bytes: pos_integer(),
             global_cap_bytes: pos_integer()
-          }
+          },
+          http_host_aliases: [String.t()]
         }
 
   @doc "PubSub topic name for settings changes."
@@ -194,7 +203,11 @@ defmodule Grappa.ServerSettings do
         document_per_file_cap_bytes: get_upload_per_file_cap_bytes(:document),
         audio_per_file_cap_bytes: get_upload_per_file_cap_bytes(:audio),
         global_cap_bytes: get_upload_global_cap_bytes()
-      }
+      },
+      # #324 — deployment HTTP host aliases (config, not DB): boot-derived
+      # in config/runtime.exs, stashed via Grappa.HttpHosts. cic's media-
+      # link classifier admits an upload link on ANY alias.
+      http_host_aliases: Grappa.HttpHosts.aliases()
     }
   end
 

--- a/lib/grappa/server_settings/wire.ex
+++ b/lib/grappa/server_settings/wire.ex
@@ -39,6 +39,21 @@ defmodule Grappa.ServerSettings.Wire do
   a third host (`:s3`) is one edit there + here. Adding an upload
   subtree field is one edit in `upload_view/1`; no second wire-shape
   definition to keep in sync.
+
+  ## `http_host_aliases` — deployment-global, config-sourced (#324)
+
+  Alongside the DB-backed `upload` subtree the payload carries
+  `http_host_aliases`: the bare hostnames nginx serves this ONE
+  deployment under (`Grappa.HttpHosts.aliases/0`, boot-derived from
+  `PHX_HOST` + `EXTRA_CHECK_ORIGINS`). cic's media-link classifier
+  admits an upload link on ANY of them (they share the upload store),
+  opening the in-app viewer instead of navigating the iOS PWA in
+  place. It is deployment config, NOT an admin-editable DB setting —
+  `Grappa.ServerSettings.public_view/0` assembles it from
+  `Grappa.HttpHosts`, not the settings table — and NOT per-network
+  ISUPPORT (a hostname alias is an HTTP property, not a per-(subject,
+  network) IRC property). Static for the deployment lifetime, so it
+  rides the same snapshot/change payload idempotently.
   """
 
   use Boundary, top_level?: true, deps: []
@@ -65,7 +80,8 @@ defmodule Grappa.ServerSettings.Wire do
   """
   @type changed_payload :: %{
           kind: String.t(),
-          upload: upload_view()
+          upload: upload_view(),
+          http_host_aliases: [String.t()]
         }
 
   @doc """
@@ -96,13 +112,16 @@ defmodule Grappa.ServerSettings.Wire do
   @doc """
   Renders a `Grappa.ServerSettings.public_view/0` map to its public
   wire shape for the `server_settings_changed` event push. Delegates
-  the `upload` subtree projection to `upload_view/1`.
+  the `upload` subtree projection to `upload_view/1`; the
+  `http_host_aliases` list (#324) passes through unchanged.
   """
   @spec server_settings_changed(Grappa.ServerSettings.public_view()) :: changed_payload()
-  def server_settings_changed(%{upload: %{} = upload}) do
+  def server_settings_changed(%{upload: %{} = upload, http_host_aliases: aliases})
+      when is_list(aliases) do
     %{
       kind: "server_settings_changed",
-      upload: upload_view(upload)
+      upload: upload_view(upload),
+      http_host_aliases: aliases
     }
   end
 end

--- a/lib/grappa_web/controllers/admin/settings_controller.ex
+++ b/lib/grappa_web/controllers/admin/settings_controller.ex
@@ -5,9 +5,12 @@ defmodule GrappaWeb.Admin.SettingsController do
 
   ## GET /admin/settings
 
-  Returns the full settings view (today: the same `public_view/0` the
-  authenticated `/api/server-settings` returns; admin-only settings,
-  when added, will land here only). Wire shape:
+  Returns the admin settings view — the `upload` subtree of
+  `public_view/0` (`render_view/1`). It deliberately OMITS the #324
+  `http_host_aliases` that the authenticated `/api/server-settings`
+  carries: those are deployment config (env-derived), not an
+  admin-editable DB setting. Admin-only settings, when added, land here
+  only. Wire shape:
 
       %{
         settings: %{

--- a/lib/grappa_web/controllers/server_settings_controller.ex
+++ b/lib/grappa_web/controllers/server_settings_controller.ex
@@ -18,8 +18,14 @@ defmodule GrappaWeb.ServerSettingsController do
           image_per_file_cap_bytes: pos_integer(),
           video_per_file_cap_bytes: pos_integer(),
           document_per_file_cap_bytes: pos_integer(),
+          audio_per_file_cap_bytes: pos_integer(),
           global_cap_bytes: pos_integer()
-        }
+        },
+        # #324 — the deployment's HTTP host aliases; cic's media-link
+        # classifier admits an upload link on ANY of them. No `kind`
+        # field here (the WS `server_settings_changed` event carries it;
+        # this REST response does not).
+        http_host_aliases: [String.t()]
       }
   """
 
@@ -31,7 +37,7 @@ defmodule GrappaWeb.ServerSettingsController do
   @doc false
   @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def show(conn, _) do
-    %{upload: u} = ServerSettings.public_view()
-    json(conn, %{upload: SettingsWire.upload_view(u)})
+    %{upload: u, http_host_aliases: aliases} = ServerSettings.public_view()
+    json(conn, %{upload: SettingsWire.upload_view(u), http_host_aliases: aliases})
   end
 end

--- a/test/grappa/http_hosts_test.exs
+++ b/test/grappa/http_hosts_test.exs
@@ -1,0 +1,32 @@
+defmodule Grappa.HttpHostsTest do
+  # async: false — mutates the process-global `:persistent_term` key.
+  use ExUnit.Case, async: false
+
+  alias Grappa.HttpHosts
+
+  setup do
+    # Snapshot + restore so a stashed set doesn't leak into other
+    # suites that read HttpHosts.aliases/0 (server_settings_test etc).
+    prior = HttpHosts.aliases()
+    on_exit(fn -> :ok = HttpHosts.boot(prior) end)
+    :ok
+  end
+
+  describe "boot/1 + aliases/0" do
+    test "aliases/0 returns the booted list" do
+      :ok = HttpHosts.boot(["irc.sindro.me", "irc.sniffo.org"])
+      assert HttpHosts.aliases() == ["irc.sindro.me", "irc.sniffo.org"]
+    end
+
+    test "boot/1 overwrites (last write wins)" do
+      :ok = HttpHosts.boot(["a.example"])
+      :ok = HttpHosts.boot(["b.example", "c.example"])
+      assert HttpHosts.aliases() == ["b.example", "c.example"]
+    end
+
+    test "boot/1 with an empty list yields an empty alias set" do
+      :ok = HttpHosts.boot([])
+      assert HttpHosts.aliases() == []
+    end
+  end
+end

--- a/test/grappa/server_settings/wire_test.exs
+++ b/test/grappa/server_settings/wire_test.exs
@@ -3,20 +3,26 @@ defmodule Grappa.ServerSettings.WireTest do
 
   alias Grappa.ServerSettings.Wire
 
+  # A full public_view fixture — upload subtree + the #324
+  # http_host_aliases the wire builder now requires. Both params
+  # explicit (CLAUDE.md: no default args).
+  defp view(active_host, aliases) do
+    %{
+      upload: %{
+        active_host: active_host,
+        image_per_file_cap_bytes: 10_485_760,
+        video_per_file_cap_bytes: 52_428_800,
+        document_per_file_cap_bytes: 10_485_760,
+        audio_per_file_cap_bytes: 26_214_400,
+        global_cap_bytes: 10_737_418_240
+      },
+      http_host_aliases: aliases
+    }
+  end
+
   describe "server_settings_changed/1 — wire shape" do
     test "passes embedded host atom through (Jason stringifies at the edge)" do
-      view = %{
-        upload: %{
-          active_host: :embedded,
-          image_per_file_cap_bytes: 10_485_760,
-          video_per_file_cap_bytes: 52_428_800,
-          document_per_file_cap_bytes: 10_485_760,
-          audio_per_file_cap_bytes: 26_214_400,
-          global_cap_bytes: 10_737_418_240
-        }
-      }
-
-      payload = Wire.server_settings_changed(view)
+      payload = Wire.server_settings_changed(view(:embedded, ["irc.sindro.me"]))
 
       assert payload.kind == "server_settings_changed"
       # S15: the host atom passes through the term unchanged; the Jason
@@ -31,65 +37,36 @@ defmodule Grappa.ServerSettings.WireTest do
     end
 
     test "passes litterbox host atom through" do
-      view = %{
-        upload: %{
-          active_host: :litterbox,
-          image_per_file_cap_bytes: 5_000_000,
-          video_per_file_cap_bytes: 6_000_000,
-          document_per_file_cap_bytes: 7_000_000,
-          audio_per_file_cap_bytes: 8_000_000,
-          global_cap_bytes: 999_999
-        }
-      }
-
-      payload = Wire.server_settings_changed(view)
+      payload = Wire.server_settings_changed(view(:litterbox, ["irc.sindro.me"]))
 
       assert payload.upload.active_host == :litterbox
-      assert payload.upload.image_per_file_cap_bytes == 5_000_000
-      assert payload.upload.video_per_file_cap_bytes == 6_000_000
-      assert payload.upload.document_per_file_cap_bytes == 7_000_000
-      assert payload.upload.audio_per_file_cap_bytes == 8_000_000
-      assert payload.upload.global_cap_bytes == 999_999
+      assert payload.upload.image_per_file_cap_bytes == 10_485_760
+      assert payload.upload.global_cap_bytes == 10_737_418_240
     end
 
-    test "payload is Jason-encodable (no atom values other than keys)" do
-      view = %{
-        upload: %{
-          active_host: :embedded,
-          image_per_file_cap_bytes: 1,
-          video_per_file_cap_bytes: 2,
-          document_per_file_cap_bytes: 3,
-          audio_per_file_cap_bytes: 5,
-          global_cap_bytes: 4
-        }
-      }
+    test "carries the #324 http_host_aliases list through unchanged" do
+      payload = Wire.server_settings_changed(view(:embedded, ["irc.sindro.me", "irc.sniffo.org"]))
+      assert payload.http_host_aliases == ["irc.sindro.me", "irc.sniffo.org"]
+    end
 
-      payload = Wire.server_settings_changed(view)
-      json = Jason.encode!(payload)
-      decoded = Jason.decode!(json)
+    test "an empty alias set is a valid payload (single-host / no PHX_HOST deployment)" do
+      payload = Wire.server_settings_changed(view(:embedded, []))
+      assert payload.http_host_aliases == []
+    end
+
+    test "payload is Jason-encodable (no atom values other than keys), aliases survive" do
+      payload = Wire.server_settings_changed(view(:embedded, ["irc.sindro.me"]))
+      decoded = payload |> Jason.encode!() |> Jason.decode!()
 
       assert decoded["kind"] == "server_settings_changed"
       assert decoded["upload"]["active_host"] == "embedded"
-      assert decoded["upload"]["image_per_file_cap_bytes"] == 1
-      assert decoded["upload"]["video_per_file_cap_bytes"] == 2
-      assert decoded["upload"]["document_per_file_cap_bytes"] == 3
-      assert decoded["upload"]["audio_per_file_cap_bytes"] == 5
-      assert decoded["upload"]["global_cap_bytes"] == 4
+      assert decoded["upload"]["audio_per_file_cap_bytes"] == 26_214_400
+      assert decoded["http_host_aliases"] == ["irc.sindro.me"]
     end
 
     test "kind field is the discriminator cic dispatches on" do
-      view = %{
-        upload: %{
-          active_host: :embedded,
-          image_per_file_cap_bytes: 1,
-          video_per_file_cap_bytes: 2,
-          document_per_file_cap_bytes: 3,
-          audio_per_file_cap_bytes: 5,
-          global_cap_bytes: 4
-        }
-      }
-
-      assert %{kind: "server_settings_changed"} = Wire.server_settings_changed(view)
+      assert %{kind: "server_settings_changed"} =
+               Wire.server_settings_changed(view(:embedded, ["irc.sindro.me"]))
     end
   end
 
@@ -126,19 +103,9 @@ defmodule Grappa.ServerSettings.WireTest do
     end
 
     test "server_settings_changed/1 reuses the shared upload projection" do
-      view = %{
-        upload: %{
-          active_host: :litterbox,
-          image_per_file_cap_bytes: 7,
-          video_per_file_cap_bytes: 8,
-          document_per_file_cap_bytes: 9,
-          audio_per_file_cap_bytes: 11,
-          global_cap_bytes: 10
-        }
-      }
-
-      changed = Wire.server_settings_changed(view)
-      assert changed.upload == Wire.upload_view(view.upload)
+      v = view(:litterbox, ["irc.sindro.me", "irc.sniffo.org"])
+      changed = Wire.server_settings_changed(v)
+      assert changed.upload == Wire.upload_view(v.upload)
     end
   end
 end

--- a/test/grappa/server_settings_test.exs
+++ b/test/grappa/server_settings_test.exs
@@ -20,6 +20,30 @@ defmodule Grappa.ServerSettingsTest do
       assert view.upload.video_per_file_cap_bytes == 50 * 1024 * 1024
       assert view.upload.document_per_file_cap_bytes == 10 * 1024 * 1024
       assert view.upload.global_cap_bytes == 10 * 1024 * 1024 * 1024
+      # #324 — the deployment HTTP host alias set is always present (a
+      # list; empty when no PHX_HOST is configured, as in test env).
+      assert is_list(view.http_host_aliases)
+    end
+  end
+
+  describe "public_view/0 — http_host_aliases (#324)" do
+    setup do
+      # Snapshot + restore the process-global persistent_term so a
+      # stashed set doesn't leak into sibling tests (max_cases: 1
+      # serializes, but restore keeps this hermetic regardless).
+      prior = Grappa.HttpHosts.aliases()
+      on_exit(fn -> :ok = Grappa.HttpHosts.boot(prior) end)
+      :ok
+    end
+
+    test "reflects the deployment's HttpHosts alias set" do
+      :ok = Grappa.HttpHosts.boot(["irc.sindro.me", "irc.sniffo.org"])
+      assert ServerSettings.public_view().http_host_aliases == ["irc.sindro.me", "irc.sniffo.org"]
+    end
+
+    test "is an empty list when no aliases are configured" do
+      :ok = Grappa.HttpHosts.boot([])
+      assert ServerSettings.public_view().http_host_aliases == []
     end
   end
 

--- a/test/grappa_web/controllers/server_settings_controller_test.exs
+++ b/test/grappa_web/controllers/server_settings_controller_test.exs
@@ -25,6 +25,17 @@ defmodule GrappaWeb.ServerSettingsControllerTest do
       assert upload["global_cap_bytes"] == 10 * 1024 * 1024 * 1024
     end
 
+    test "response carries the deployment HTTP host aliases (#324)", %{conn: conn} do
+      prior = Grappa.HttpHosts.aliases()
+      on_exit(fn -> :ok = Grappa.HttpHosts.boot(prior) end)
+      :ok = Grappa.HttpHosts.boot(["irc.sindro.me", "irc.sniffo.org"])
+
+      {_, session} = user_and_session([])
+      conn = conn |> put_bearer(session.id) |> get("/api/server-settings")
+      body = json_response(conn, 200)
+      assert body["http_host_aliases"] == ["irc.sindro.me", "irc.sniffo.org"]
+    end
+
     test "visitor gets the upload view too (parity)", %{conn: conn} do
       {_, session} = visitor_and_session([])
       conn = conn |> put_bearer(session.id) |> get("/api/server-settings")


### PR DESCRIPTION
Refs #324 (P0). server + cic.

## Problem
cic's media-link classifier gated an upload link on a SINGLE host
equality (`url.host === page-origin host`). A deployment answering on
several hostname aliases that reverse-proxy to ONE instance + a shared
`/uploads` store (e.g. `irc.sindro.me` + `irc.sniffo.org`) mints upload
URLs under one alias while a session may be loaded from another →
cross-host → `classifyMediaLink` returns null → plain anchor → on the iOS
standalone PWA that navigates IN PLACE (raw media doc, no chrome).

## Fix — host ∈ (page origin ∪ server-provided alias set), re-root kept
The classifier admits a URL whose host is the page origin's OR any of the
deployment's server-provided HTTP host aliases, and re-roots the href
onto the PAGE origin exactly as before. The re-rooted `<img src>` stays
SAME-ORIGIN → **CSP `img-src 'self'` is UNTOUCHED** (no loosening). ONE
predicate widened; the re-root machinery is unchanged. A third-party host
still returns null (never re-root a foreign host); `sameHostHref()`
widens with the SAME set.

## Single source of truth (server-provided, no client-baked list)
The alias set is DERIVED at boot from the SAME env inputs that build the
Endpoint `check_origin` gate — `PHX_HOST` + `EXTRA_CHECK_ORIGINS` — into
`Grappa.HttpHosts` (`:persistent_term`), advertised via the existing
deployment-global server-settings payload (`public_view/0` → Wire → REST
`GET /api/server-settings` + WS `server_settings_changed`). cic reads it
into `serverSettings().httpHostAliases` and threads it into the PURE
classifier. NOT per-network ISUPPORT (a hostname alias is an HTTP,
deployment-global property). Adding a vhost is one `EXTRA_CHECK_ORIGINS`
edit — no cic redeploy, no second hand-maintained list.

## Tests
- Pure vitest table (mediaLink): alias admitted + re-rooted, third-party
  null, empty-set fallback, port + emoji rules, `sameHostHref` parity.
- Server ExUnit: `Grappa.HttpHosts`; `public_view/0` + REST + Wire carry
  the set. Full `check.sh` green modulo the pre-existing bats #44.
- e2e (chromium + @webkit): a body carrying a server-advertised sibling
  alias opens the viewer re-rooted to the page origin (real bytes through
  nginx under the prod CSP); a third-party host stays a plain anchor.
  Full `integration.sh` = 434 passed.

## Deploy
**COLD** (boot-derived: `config/runtime.exs` env + `Application.start/2`
persistent_term). **HELD** — rides the already-HELD #299 COLD batch's 4AM
window (`deploy-m42.sh --force-cold --cic`). Not deployed from this PR.