### PR TITLE
Per-network source_address: admin-configurable, absolute precedence (#266)

### DIFF
--- a/cicchetto/e2e/tests/admin-server-crud.spec.ts
+++ b/cicchetto/e2e/tests/admin-server-crud.spec.ts
@@ -124,6 +124,82 @@ test("admin toggles TLS on an existing server", async ({ page }) => {
   }
 });
 
+// #266 — a per-network source_address must be a LOCAL bindable address on
+// the host; a non-local literal is rejected at the boundary (422
+// source_not_local) and surfaces in the shared error banner. 192.0.2.1
+// (TEST-NET-1, RFC 5737) is a valid literal the host never binds, so the
+// rejection is deterministic in any environment. A local-address SUCCESS
+// round-trip is covered by the ExUnit ServersController conn test (which reads
+// HostAddresses.list/0) + the AdminNetworksTab vitest — the value of THIS e2e
+// is proving the 422 surfaces end-to-end (nginx → phoenix → cic banner).
+test("admin sees a per-network source rejected via the add-server form (non-local)", async ({
+  page,
+}) => {
+  const admin = getSeededAdmin();
+  const slug = `e2esrv-src-${Date.now()}`;
+  let networkId: number | null = null;
+
+  try {
+    networkId = await createNetwork(admin.token, slug);
+
+    await adminLogin(page, admin);
+    await openNetworksTab(page);
+    await page.getByTestId(`admin-network-expand-${slug}`).click();
+    await expect(page.getByTestId(`admin-network-add-server-form-${slug}`)).toBeVisible();
+
+    await page.getByTestId(`admin-network-add-server-host-${slug}`).fill("src.example.test");
+    await page.getByTestId(`admin-network-add-server-port-${slug}`).fill("6697");
+    await page.getByTestId(`admin-network-add-server-source-${slug}`).fill("192.0.2.1");
+    await page.getByTestId(`admin-network-add-server-submit-${slug}`).click();
+
+    // Error banner surfaces the rejection; the create was refused (no row).
+    await expect(page.getByTestId("admin-networks-error")).toContainText("source_not_local", {
+      timeout: 5_000,
+    });
+    await expect(
+      page.locator(`[data-testid^='admin-network-server-row-${slug}-']`),
+    ).toHaveCount(0);
+  } finally {
+    if (networkId !== null) await deleteNetworkBestEffort(admin.token, networkId);
+  }
+});
+
+test("admin sees an inline source edit rejected on an existing server (non-local)", async ({
+  page,
+}) => {
+  const admin = getSeededAdmin();
+  const slug = `e2esrv-srcedit-${Date.now()}`;
+  let networkId: number | null = null;
+
+  try {
+    networkId = await createNetwork(admin.token, slug);
+
+    const sRes = await fetch(`${GRAPPA_BASE_URL}/admin/networks/${networkId}/servers`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${admin.token}` },
+      body: JSON.stringify({ host: "srcedit.example.test", port: 6697 }),
+    });
+    expect(sRes.ok).toBe(true);
+    const sBody = (await sRes.json()) as { id: number };
+    const serverId = sBody.id;
+
+    await adminLogin(page, admin);
+    await openNetworksTab(page);
+    await page.getByTestId(`admin-network-expand-${slug}`).click();
+
+    const input = page.getByTestId(`admin-network-server-source-input-${slug}-${serverId}`);
+    await expect(input).toHaveValue("");
+    await input.fill("192.0.2.1");
+    await page.getByTestId(`admin-network-server-source-save-${slug}-${serverId}`).click();
+
+    await expect(page.getByTestId("admin-networks-error")).toContainText("source_not_local", {
+      timeout: 5_000,
+    });
+  } finally {
+    if (networkId !== null) await deleteNetworkBestEffort(admin.token, networkId);
+  }
+});
+
 test("admin deletes a server via inline-confirm", async ({ page }) => {
   const admin = getSeededAdmin();
   const slug = `e2esrv-del-${Date.now()}`;

--- a/cicchetto/src/AdminNetworksTab.tsx
+++ b/cicchetto/src/AdminNetworksTab.tsx
@@ -155,7 +155,9 @@ const AdminNetworksTab: Component = () => {
     {},
   );
   const [serverForm, setServerForm] = createStore<
-    Record<number, { host: string; port: string; tls: boolean }>
+    // #266 — `source` is the optional per-network outbound source bind (empty
+    // string = unset).
+    Record<number, { host: string; port: string; tls: boolean; source: string }>
   >({});
   const [serverConfirmKey, setServerConfirmKey] = createSignal<string | null>(null);
 
@@ -326,7 +328,7 @@ const AdminNetworksTab: Component = () => {
     setServerForm(
       produce((draft) => {
         if (draft[net.id] === undefined) {
-          draft[net.id] = { host: "", port: "6697", tls: true };
+          draft[net.id] = { host: "", port: "6697", tls: true, source: "" };
         }
       }),
     );
@@ -462,11 +464,20 @@ const AdminNetworksTab: Component = () => {
       return;
     }
     setError(null);
+    // #266 — an empty source field means "unset" (omit), a filled one pins the
+    // per-network outbound egress. Non-local literals are rejected server-side
+    // (422 source_not_local) and surface in the shared error banner.
+    const source = f.source.trim();
     try {
-      await adminAddServer(t, net.id, { host: f.host.trim(), port, tls: f.tls });
+      await adminAddServer(t, net.id, {
+        host: f.host.trim(),
+        port,
+        tls: f.tls,
+        ...(source === "" ? {} : { source_address: source }),
+      });
       setServerForm(
         produce((draft) => {
-          draft[net.id] = { host: "", port: "6697", tls: true };
+          draft[net.id] = { host: "", port: "6697", tls: true, source: "" };
         }),
       );
       await refreshServers(net);
@@ -486,6 +497,31 @@ const AdminNetworksTab: Component = () => {
     } catch (err) {
       const code = err instanceof ApiError ? err.code : "request_failed";
       setError(`update server (${s.host}:${s.port}): ${code}`);
+    }
+  };
+
+  // #266 — set/clear an existing server's per-network source_address. An empty
+  // input clears it (JSON null); a filled one pins it. Non-local literals are
+  // rejected server-side and surface in the shared error banner.
+  const onSaveServerSource = async (
+    net: AdminNetwork,
+    s: AdminServer,
+    raw: string,
+  ): Promise<void> => {
+    const t = token();
+    if (t === null) return;
+    const trimmed = raw.trim();
+    // No-op if unchanged (empty stays cleared / same literal).
+    if (trimmed === (s.source_address ?? "")) return;
+    setError(null);
+    try {
+      await adminUpdateServer(t, net.id, s.id, {
+        source_address: trimmed === "" ? null : trimmed,
+      });
+      await refreshServers(net);
+    } catch (err) {
+      const code = err instanceof ApiError ? err.code : "request_failed";
+      setError(`set source (${s.host}:${s.port}): ${code}`);
     }
   };
 
@@ -701,7 +737,9 @@ const AdminNetworksTab: Component = () => {
                         <ServersDisclosure
                           net={net}
                           servers={serversByNetworkId[net.id] ?? []}
-                          form={serverForm[net.id] ?? { host: "", port: "6697", tls: true }}
+                          form={
+                            serverForm[net.id] ?? { host: "", port: "6697", tls: true, source: "" }
+                          }
                           onFormChange={(patch) =>
                             setServerForm(
                               produce((draft) => {
@@ -709,6 +747,7 @@ const AdminNetworksTab: Component = () => {
                                   host: "",
                                   port: "6697",
                                   tls: true,
+                                  source: "",
                                 };
                                 draft[net.id] = { ...cur, ...patch };
                               }),
@@ -719,6 +758,9 @@ const AdminNetworksTab: Component = () => {
                           }}
                           onToggleTls={(s) => {
                             void onToggleServerTls(net, s);
+                          }}
+                          onSaveSource={(s, raw) => {
+                            void onSaveServerSource(net, s, raw);
                           }}
                           confirmingServerKey={serverConfirmKey()}
                           onArmServerDelete={(key) => setServerConfirmKey(key)}
@@ -875,10 +917,13 @@ function isDirtyAndValid(net: AdminNetwork, edit: RowEdit | undefined): boolean 
 const ServersDisclosure: Component<{
   net: AdminNetwork;
   servers: AdminServer[];
-  form: { host: string; port: string; tls: boolean };
-  onFormChange: (patch: Partial<{ host: string; port: string; tls: boolean }>) => void;
+  form: { host: string; port: string; tls: boolean; source: string };
+  onFormChange: (
+    patch: Partial<{ host: string; port: string; tls: boolean; source: string }>,
+  ) => void;
   onAddServer: (e: Event) => void;
   onToggleTls: (s: AdminServer) => void;
+  onSaveSource: (s: AdminServer, raw: string) => void;
   confirmingServerKey: string | null;
   onArmServerDelete: (key: string | null) => void;
   onDeleteServer: (s: AdminServer) => void;
@@ -921,6 +966,16 @@ const ServersDisclosure: Component<{
           />
           TLS
         </label>
+        <input
+          type="text"
+          placeholder="source (optional)"
+          value={props.form.source}
+          onInput={(e) =>
+            props.onFormChange({ source: (e.currentTarget as HTMLInputElement).value })
+          }
+          data-testid={`admin-network-add-server-source-${props.net.slug}`}
+          aria-label={`new server outbound source for ${props.net.slug}`}
+        />
         <button
           type="submit"
           disabled={props.form.host.trim() === ""}
@@ -946,6 +1001,7 @@ const ServersDisclosure: Component<{
               <th>tls</th>
               <th>priority</th>
               <th>enabled</th>
+              <th>source</th>
               <th>
                 <span class="sr-only">actions</span>
               </th>
@@ -953,33 +1009,57 @@ const ServersDisclosure: Component<{
           </thead>
           <tbody>
             <For each={props.servers}>
-              {(s) => (
-                <tr data-testid={`admin-network-server-row-${props.net.slug}-${s.id}`}>
-                  <td>{s.host}</td>
-                  <td>{s.port}</td>
-                  <td>{s.tls ? "yes" : "no"}</td>
-                  <td>{s.priority}</td>
-                  <td>{s.enabled ? "yes" : "no"}</td>
-                  <td>
-                    <button
-                      type="button"
-                      onClick={() => props.onToggleTls(s)}
-                      data-testid={`admin-network-server-toggle-tls-${props.net.slug}-${s.id}`}
-                    >
-                      {s.tls ? "Disable TLS" : "Enable TLS"}
-                    </button>
-                    <InlineConfirmButton
-                      idleLabel="Delete"
-                      confirmLabel="Confirm delete?"
-                      armed={props.confirmingServerKey === `${props.net.id}:${s.id}`}
-                      onArm={() => props.onArmServerDelete(`${props.net.id}:${s.id}`)}
-                      onConfirm={() => props.onDeleteServer(s)}
-                      testId={`admin-network-server-delete-${props.net.slug}-${s.id}`}
-                      extraClass="delete-btn"
-                    />
-                  </td>
-                </tr>
-              )}
+              {(s) => {
+                // #266 — per-row source editor. Seeded from the current source
+                // (re-seeded when a refetch replaces the row object). Empty on
+                // save clears it; a filled literal pins it (server rejects a
+                // non-local literal → shared error banner).
+                const [sourceDraft, setSourceDraft] = createSignal(s.source_address ?? "");
+                return (
+                  <tr data-testid={`admin-network-server-row-${props.net.slug}-${s.id}`}>
+                    <td>{s.host}</td>
+                    <td>{s.port}</td>
+                    <td>{s.tls ? "yes" : "no"}</td>
+                    <td>{s.priority}</td>
+                    <td>{s.enabled ? "yes" : "no"}</td>
+                    <td>
+                      <input
+                        type="text"
+                        placeholder="unset"
+                        value={sourceDraft()}
+                        onInput={(e) => setSourceDraft((e.currentTarget as HTMLInputElement).value)}
+                        data-testid={`admin-network-server-source-input-${props.net.slug}-${s.id}`}
+                        aria-label={`outbound source for ${s.host}:${s.port}`}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => props.onSaveSource(s, sourceDraft())}
+                        data-testid={`admin-network-server-source-save-${props.net.slug}-${s.id}`}
+                      >
+                        Save
+                      </button>
+                    </td>
+                    <td>
+                      <button
+                        type="button"
+                        onClick={() => props.onToggleTls(s)}
+                        data-testid={`admin-network-server-toggle-tls-${props.net.slug}-${s.id}`}
+                      >
+                        {s.tls ? "Disable TLS" : "Enable TLS"}
+                      </button>
+                      <InlineConfirmButton
+                        idleLabel="Delete"
+                        confirmLabel="Confirm delete?"
+                        armed={props.confirmingServerKey === `${props.net.id}:${s.id}`}
+                        onArm={() => props.onArmServerDelete(`${props.net.id}:${s.id}`)}
+                        onConfirm={() => props.onDeleteServer(s)}
+                        testId={`admin-network-server-delete-${props.net.slug}-${s.id}`}
+                        extraClass="delete-btn"
+                      />
+                    </td>
+                  </tr>
+                );
+              }}
             </For>
           </tbody>
         </table>

--- a/cicchetto/src/__tests__/AdminNetworksTab.test.tsx
+++ b/cicchetto/src/__tests__/AdminNetworksTab.test.tsx
@@ -585,6 +585,7 @@ describe("AdminNetworksTab", () => {
           tls: true,
           priority: 0,
           enabled: true,
+          source_address: null,
           inserted_at: "2026-05-31T00:00:00Z",
           updated_at: "2026-05-31T00:00:00Z",
         },
@@ -597,6 +598,7 @@ describe("AdminNetworksTab", () => {
         tls: true,
         priority: 0,
         enabled: true,
+        source_address: null,
         inserted_at: "2026-05-31T00:00:00Z",
         updated_at: "2026-05-31T00:00:00Z",
       });
@@ -625,6 +627,85 @@ describe("AdminNetworksTab", () => {
       });
     });
 
+    // #266 — an empty source field is omitted; a filled one is sent as
+    // source_address; the inline per-row editor sets/clears it via PUT.
+    it("adds a server WITH a source_address and clears an existing one", async () => {
+      const api = await import("../lib/api");
+      vi.mocked(api.adminListNetworks).mockResolvedValue([BAHAMUT]);
+      vi.mocked(api.adminListServers).mockResolvedValue([
+        {
+          id: 1,
+          network_id: BAHAMUT.id,
+          host: "irc.example.test",
+          port: 6697,
+          tls: true,
+          priority: 0,
+          enabled: true,
+          source_address: "203.0.113.5",
+          inserted_at: "2026-05-31T00:00:00Z",
+          updated_at: "2026-05-31T00:00:00Z",
+        },
+      ]);
+      vi.mocked(api.adminAddServer).mockResolvedValue({
+        id: 2,
+        network_id: BAHAMUT.id,
+        host: "irc.example2.test",
+        port: 6697,
+        tls: true,
+        priority: 0,
+        enabled: true,
+        source_address: "203.0.113.9",
+        inserted_at: "2026-05-31T00:00:00Z",
+        updated_at: "2026-05-31T00:00:00Z",
+      });
+      vi.mocked(api.adminUpdateServer).mockResolvedValue({
+        id: 1,
+        network_id: BAHAMUT.id,
+        host: "irc.example.test",
+        port: 6697,
+        tls: true,
+        priority: 0,
+        enabled: true,
+        source_address: null,
+        inserted_at: "2026-05-31T00:00:00Z",
+        updated_at: "2026-05-31T00:00:00Z",
+      });
+      render(() => <AdminNetworksTab />);
+      await screen.findByTestId(`admin-network-row-${BAHAMUT.slug}`);
+
+      fireEvent.click(screen.getByTestId(`admin-network-expand-${BAHAMUT.slug}`));
+      await waitFor(() =>
+        expect(screen.queryByTestId(`admin-network-servers-table-${BAHAMUT.slug}`)).not.toBeNull(),
+      );
+
+      // Add a server with a source pinned.
+      fireEvent.input(screen.getByTestId(`admin-network-add-server-host-${BAHAMUT.slug}`), {
+        target: { value: "irc.example2.test" },
+      });
+      fireEvent.input(screen.getByTestId(`admin-network-add-server-source-${BAHAMUT.slug}`), {
+        target: { value: "203.0.113.9" },
+      });
+      fireEvent.click(screen.getByTestId(`admin-network-add-server-submit-${BAHAMUT.slug}`));
+      await waitFor(() => {
+        expect(api.adminAddServer).toHaveBeenCalledWith(
+          "test-bearer",
+          BAHAMUT.id,
+          expect.objectContaining({ host: "irc.example2.test", source_address: "203.0.113.9" }),
+        );
+      });
+
+      // Clear the existing server's source via the inline editor (empty → null).
+      fireEvent.input(screen.getByTestId(`admin-network-server-source-input-${BAHAMUT.slug}-1`), {
+        target: { value: "" },
+      });
+      fireEvent.click(screen.getByTestId(`admin-network-server-source-save-${BAHAMUT.slug}-1`));
+      await waitFor(() => {
+        expect(api.adminUpdateServer).toHaveBeenCalledWith("test-bearer", BAHAMUT.id, 1, {
+          source_address: null,
+        });
+      });
+    });
+
     it("delete-server inline-confirm fires adminDeleteServer", async () => {
       const api = await import("../lib/api");
       vi.mocked(api.adminListNetworks).mockResolvedValue([BAHAMUT]);
@@ -637,6 +718,7 @@ describe("AdminNetworksTab", () => {
           tls: true,
           priority: 0,
           enabled: true,
+          source_address: null,
           inserted_at: "2026-05-31T00:00:00Z",
           updated_at: "2026-05-31T00:00:00Z",
         },

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -2518,6 +2518,11 @@ export type AdminServer = {
   tls: boolean;
   priority: number;
   enabled: boolean;
+  // #266 — admin-configured per-network outbound source bind (null = unset →
+  // vhost selection / pool / kernel default). Mirrors
+  // Grappa.Networks.Servers.AdminWire (hand-declared: admin_wire.ex is outside
+  // the gen_wire_types glob).
+  source_address: string | null;
   inserted_at: string;
   updated_at: string;
 };
@@ -2528,6 +2533,9 @@ export type AdminServerCreate = {
   tls?: boolean;
   priority?: number;
   enabled?: boolean;
+  // #266 — a bindable local IP literal to pin the outbound egress, or null to
+  // leave unset. Server rejects a non-local literal with 422 source_not_local.
+  source_address?: string | null;
 };
 
 export type AdminServerUpdate = Partial<AdminServerCreate>;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -25338,3 +25338,117 @@ re-runs neither, so the set only populates on a full restart. server + cic bundl
 **HELD** — rides the already-HELD #299 COLD batch's 4AM window
 (`deploy-m42.sh --force-cold --cic`, together with #249 / #282 / #290 / #294 /
 #301 / #302 / #304 / #305 / #306 / #307 / #318)._
+
+### 2026-07-19 — #266: per-network source_address — admin-configurable, absolute precedence (Libera go-live)
+
+**Re-scope (KEEP + admin-configure + absolute precedence, NOT remove).** The
+original #266 direction — drop `network_servers.source_address`, bind wildcard —
+was **annulled** by vjt (2026-07-17 body re-scope; the 2026-07-16 "remove the
+column" comment is dead context). New goal: keep a per-network outbound source,
+make it **admin-configurable** (set/clear), and give it **absolute precedence**.
+Going live on Libera, a user-driven rotating vhost reads as a **ban-evasion
+tool**; an admin-pinned, accountable, single egress per network is the honest
+posture.
+
+**Altitude decision (A — elevate the EXISTING per-server column, NOT a new
+network-level one).** The spec says "per-network," but the source column TODAY is
+per-SERVER (`network_servers.source_address` on `Grappa.Networks.Server`; a
+network has ≥1 server rows). Two options were weighed:
+  * (A) elevate + admin-expose the existing per-server column + flip its
+    precedence to win over the vhost layer;
+  * (B) add a network-level `networks.source_address` overriding the per-server
+    one.
+Chose **(A)**. A network's server rows ARE its endpoints; Azzurra/Libera run
+RR-DNS (one server row whose hostname resolves to multiple leaves — #271 rotates
+the leaves at the client), so one network = one server row = one source in the
+common case, and (A) delivers "one accountable egress per network" with zero
+schema churn. (B) would introduce a SECOND source column with a precedence
+between the two — exactly the "parallel structure that drifts" / "shared data
+model with a type flag" anti-pattern CLAUDE.md warns against. Multi-server
+networks (fallback endpoints) can pin per-endpoint egress under (A) — strictly
+more flexible, no new state. The admin surface + the pool-subtraction feed
+(`Servers.list_source_addresses/0`) already key on this column.
+
+**No migration (deviation from the plan's "migration expected").** (A) reuses the
+existing nullable column unchanged — nothing to migrate. This changes the
+hot/cold calculus the issue body assumed ("almost certainly COLD — schema +
+config"): the server-side change is PURE code (precedence inversion + admin
+whitelist + a boundary validation) and is HOT-reloadable on its own. It is HELD
++ batched with the coordinated COLD window only because it ships alongside a cic
+bundle + the other HELD COLD work — not because it needs a cold restart itself.
+
+**Precedence inversion (REVERSES the #251 nuance).** `Grappa.Vhosts.effective_source/2`
+is the single resolution point (threaded via `Networks.SessionPlan.base_plan/6`
+→ Session → `IRC.Client.source_bind/2`). Pre-#266 (#251), a subject's vhost
+self-selection OVERRODE `server_source` — the per-network source was only the
+no-selection default. #266 inverts: when `server_source` is set it WINS
+(returned verbatim before any selection lookup) over the vhost selection, the
+`OutboundV6Pool` rotation, AND #271 RR-DNS leaf distribution; when `nil` the
+existing selection/pool fallback is unchanged, and zero-config still binds
+nothing. The `effective_source/2` moduledoc precedence block + the SessionPlan
+call-site comment were rewritten to the new order (a stale invariant comment is a
+bug). The acceptance core is the ExUnit precedence table (assert WHICH address
+binds, not call sequences) + the SessionPlan-vhost test.
+
+**#271 override already holds at the client — proven, not rebuilt.** A pinned
+source constrains the destination-leaf FAMILY (`source_bind/2` picks fam from the
+literal; `connect_with_rotation` resolves only that family's leaves) and threads
+the SAME `ifaddr` through every rotated leaf. So a pinned source is an absolute
+bind regardless of which leaf the #271 shuffle picks or how many a connect
+failure burns through — no production change needed; a new `client_test` pins the
+cross-rotation invariant (first leaf refuses → second, distinct leaf → both dial
+the identical `ifaddr`).
+
+**Local-bindable validation (the genuinely new piece — admin boundary, NOT the
+changeset).** #266 requires "validate it's a bindable local address on the host
+(reject non-local)." The host's egressable address set already exists —
+`Grappa.Net.HostAddresses.list/0` (getifaddrs, loopback/link-local filtered) —
+so "does the infra already provide this?" → yes, REUSE it (no new injected
+resolver / process / env). The pure predicate `HostAddresses.local_bindable?/2`
+takes the universe IN (mirroring `Vhosts.effective_pool/1`), so the admin
+controller owns the single `list/0` read and the predicate is deterministically
+unit-testable with an explicit set. Enumerating interfaces is IO that does NOT
+belong in the pure `Server.changeset/2` validator, so the gate lives at the admin
+REST boundary (`ServersController` `with :ok <- validate_source_bindable/1`): a
+non-literal falls through to the changeset (`validation_failed` — literal-SHAPE
+stays the first gate); a valid literal not on the host → `{:error,
+:source_not_local}` → FallbackController 422 (distinct wire token from
+`validation_failed`); `nil`/absent (clear) is always valid. Threat test FIRST
+(non-local rejected) before the happy path. The mix-task path
+(`grappa.add_server --source`) stays UNGATED — operator-on-host is trusted; only
+the untrusted-ish REST admin surface enumerates + rejects.
+
+**Pool-subtraction safety net preserved (spec §3).** An admin-set source must
+never rotate back into the auto pool. `ServersController` already calls
+`resync_outbound_pool/0` (→ `Vhosts.resync_pool(Servers.list_source_addresses/0)`)
+on every create/update/delete; adding `source_address` to the create/update
+whitelist means an admin-set source automatically feeds the subtraction — no new
+wiring, verified by an assertion in the controller conn test.
+
+**Admin surface + cic.** `Servers.AdminWire.server_to_admin_json/1` emits
+`source_address` (hand-declared type — `admin_wire.ex` is OUTSIDE the
+`gen_wire_types` `**/wire.ex` glob, so `wireTypes.ts` is untouched, confirmed
+"in sync"). The cic admin Networks tab (`ServersDisclosure`) gains an optional
+"source" input on the add-server form + a per-row inline editor (set via PUT,
+clear via `source_address: null`); a non-local literal surfaces the 422 in the
+shared error banner (no client-side IP validation — the host's bindable set is
+server-only knowledge).
+
+**Tests.** ExUnit: `effective_source/2` precedence table (admin source wins over
+selection/pool; nil → selection; neither → nil); SessionPlan-vhost (admin source
+wins over a self-selection; nil → selection); `HostAddresses.local_bindable?/2`
+(threat-first, canonicalization, empty set); `ServersController` conn
+(set-local + feeds `list_source_addresses/0`, clear-via-null, non-local 422
+source_not_local on POST + PUT, garbage → validation_failed); `client_test`
+pinned-source-over-rotation. cic: vitest (add-with-source + inline clear wiring);
+Playwright e2e (chromium + @webkit) — non-local rejection surfaces end-to-end via
+BOTH the add-form and the inline editor (deterministic 192.0.2.1 / TEST-NET-1).
+A local-address SUCCESS round-trip is covered by the ExUnit conn test (reads
+`HostAddresses.list/0`) rather than the e2e — a guaranteed local address isn't
+tractable to discover browser-side (§3 allowance).
+
+_Deploy: server-side is **HOT-reloadable** on its own (no migration/schema/
+supervision/cluster/env change — altitude (A) reuses the existing nullable
+column), but ships with a **cic bundle**, so this delivery is **HELD** to ride the
+next coordinated **COLD** window batched with the other HELD COLD work (#299
+batch). Not deployed this session — merge to main + push + HOLD._

--- a/lib/grappa/net/host_addresses.ex
+++ b/lib/grappa/net/host_addresses.ex
@@ -17,7 +17,7 @@ defmodule Grappa.Net.HostAddresses do
   egress from those, so surfacing them in the picker is a footgun.
   """
 
-  use Boundary, top_level?: true, deps: []
+  use Boundary, top_level?: true, deps: [Grappa.Net.IpLiteral]
 
   import Bitwise, only: [band: 2]
 
@@ -42,6 +42,30 @@ defmodule Grappa.Net.HostAddresses do
 
       {:error, _} ->
         []
+    end
+  end
+
+  @doc """
+  True when `address` is a strict IP literal whose canonical form is a
+  member of `local_addresses` — i.e. an address the host can actually
+  bind as an outbound source. A non-literal (hostname / CIDR / garbage)
+  or a literal not in the set → `false`.
+
+  #266 — the admin API validates an operator-set per-network
+  `source_address` against `list/0` before persisting it, so a network
+  can't be pinned to an egress the host cannot bind. Pure over the passed
+  set (the universe is passed IN, not read here) — mirrors
+  `Grappa.Vhosts.effective_pool/1`: the admin-boundary caller owns the
+  single `getifaddrs`-backed `list/0` read, keeping this predicate
+  deterministically unit-testable with an explicit set. Canonicalizes via
+  `Grappa.Net.IpLiteral` so `2001:0DB8::1` matches a stored `2001:db8::1`.
+  """
+  @spec local_bindable?(String.t(), [String.t()]) :: boolean()
+  def local_bindable?(address, local_addresses)
+      when is_binary(address) and is_list(local_addresses) do
+    case Grappa.Net.IpLiteral.canonicalize(address) do
+      {:ok, canonical} -> canonical in local_addresses
+      :error -> false
     end
   end
 

--- a/lib/grappa/networks/servers/admin_wire.ex
+++ b/lib/grappa/networks/servers/admin_wire.ex
@@ -22,6 +22,7 @@ defmodule Grappa.Networks.Servers.AdminWire do
           tls: boolean(),
           priority: integer(),
           enabled: boolean(),
+          source_address: String.t() | nil,
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
         }
@@ -42,6 +43,10 @@ defmodule Grappa.Networks.Servers.AdminWire do
       tls: server.tls,
       priority: server.priority,
       enabled: server.enabled,
+      # #266 — the admin-configured per-network outbound source bind
+      # (nil = unset → vhost selection / pool / kernel default). Surfaced
+      # so the admin console can show + set/clear it per server.
+      source_address: server.source_address,
       inserted_at: server.inserted_at,
       updated_at: server.updated_at
     }

--- a/lib/grappa/networks/session_plan.ex
+++ b/lib/grappa/networks/session_plan.ex
@@ -203,12 +203,13 @@ defmodule Grappa.Networks.SessionPlan do
       host: server.host,
       port: server.port,
       tls: server.tls,
-      # #228 — resolve the source-bind through the per-subject vhost layer
-      # (pin / selection), falling back to the per-server fixed source
-      # (`server.source_address`, or nil → the DB-driven rotation pool /
-      # kernel default). The connect path in `Grappa.IRC.Client` is
-      # UNCHANGED — this only chooses WHICH value it binds. Re-resolved on
-      # every `Session.Server.init/1` via `refresh_plan`, so a live vhost
+      # #228 / #266 — resolve the source-bind through `effective_source/2`.
+      # #266 inverts the precedence: an admin-configured per-network
+      # `server.source_address` WINS (absolute bind), else the per-subject
+      # vhost selection, else nil → the DB-driven rotation pool / kernel
+      # default. The connect path in `Grappa.IRC.Client` is UNCHANGED — this
+      # only chooses WHICH value it binds. Re-resolved on every
+      # `Session.Server.init/1` via `refresh_plan`, so a live source/vhost
       # change takes effect on the next (re)connect.
       source_address: Grappa.Vhosts.effective_source(subject, server.source_address)
     }

--- a/lib/grappa/vhosts.ex
+++ b/lib/grappa/vhosts.ex
@@ -15,7 +15,9 @@ defmodule Grappa.Vhosts do
   **Admin decides AVAILABILITY; the user decides SELECTION.** The admin
   curates which vhosts a subject *can* use (`generally_available` /
   `in_pool` / a per-subject grant); the user freely picks among that set.
-  No admin hard-pin, no admin default.
+  No admin hard-pin, no admin default — EXCEPT a network-pinned
+  `source_address`, which #266 makes an ABSOLUTE bind that overrides the
+  user's selection entirely (see the `effective_source/2` NOTE below).
 
   ## Inventory model
 
@@ -30,27 +32,29 @@ defmodule Grappa.Vhosts do
 
   ## Resolution precedence (`effective_source/2`, per connect)
 
-    1. the subject's selection (`UserSettings` `"vhost_selection"`)
+    1. the passed `server_source` (`network_servers.source_address` — the
+       admin-configured per-network bind). #266: when set, it WINS. Bind
+       it, full stop — over the subject's vhost selection, the pool, and
+       #271 RR-DNS leaf distribution.
+    2. else the subject's selection (`UserSettings` `"vhost_selection"`)
        INTERSECTED with its allowed set → random pick (spec: "random per
        connection" when >1 active).
-    2. the passed `server_source` fallback (`network_servers.source_address`
-       — the per-network fixed bind, the operator "force egress from X"
-       mechanism, admin-only; the MECHANISM + its no-selection default is
-       unchanged — or `nil` → the `Grappa.IRC.Client` DB-driven rotation
-       pool / kernel default).
+    3. else `nil` → the `Grappa.IRC.Client` DB-driven rotation pool /
+       kernel default (zero-config still binds nothing).
 
   The allowed set = generally-available ∪ in_pool ∪ granted-to-subject.
   Selection is authz-clamped to this set at write (`set_selection/2`), and
   re-clamped at read so a revoked grant can't leak a stale selection.
 
-  NOTE (#251): `server_source` is only the DEFAULT for a no-selection
-  subject. A subject who self-selects (step 1) overrides it — and with the
-  admin pin removed there is no longer a per-subject *hard* force. A
-  network with a mandated `source_address` still egresses from it for any
-  subject who has NOT self-selected, but a subject CAN now pick a pool /
-  granted address instead. If an operator needs to hard-force a specific
-  account's egress, that capability was intentionally removed with the pin
-  (#251) and is not replaced in V1.
+  NOTE (#266 — REVERSES the #251 nuance): pre-#266, a subject's vhost
+  self-selection OVERRODE `server_source` (`server_source` was only the
+  no-selection default). #266 inverts this: an admin-set per-network
+  `source_address` is an ABSOLUTE bind that wins over everything, so a
+  network with a pinned source egresses ALL its subjects from that source
+  regardless of their vhost selection. The subject's selection/pool is the
+  fallback ONLY when no admin source is pinned. Rationale (Libera go-live):
+  a user-driven rotating vhost reads as ban-evasion; an admin-pinned,
+  accountable, single egress per network is the honest posture.
 
   ## No admin hard-pin (#251)
 
@@ -306,32 +310,38 @@ defmodule Grappa.Vhosts do
 
   @doc """
   Resolves the effective source address for `subject` on this connect,
-  given the per-network `server_source` fallback
+  given the admin-configured per-network `server_source`
   (`network_servers.source_address`, or `nil`).
 
-  Precedence (#251 — the admin hard-pin was removed):
+  Precedence (#266 — INVERTS the #251 order; admin source is absolute):
 
-    1. the subject's selection (∩ allowed) → random pick (spec: "random
-       per connection" when more than one is active).
-    2. `server_source` (the per-network fixed bind — the operator "force
-       egress from X" mechanism, admin-only; MECHANISM unchanged — or
-       `nil` → `Grappa.IRC.Client` falls through to the DB-driven pool /
-       kernel default, exactly as today).
+    1. `server_source` (the admin-configured per-network bind) — when set,
+       WINS. Returns it verbatim, overriding the subject's vhost selection,
+       the pool, AND #271 RR-DNS leaf distribution.
+    2. else the subject's selection (∩ allowed) → random pick (spec:
+       "random per connection" when more than one is active).
+    3. else `nil` → `Grappa.IRC.Client` falls through to the DB-driven pool
+       / kernel default (zero-config binds nothing).
 
-  A network WITH `source_address` set still binds it verbatim for a
-  no-selection subject (the no-selection DEFAULT is preserved); a network
-  with `nil` routes the no-selection subject to `OutboundV6Pool.pick/0`
-  (the in_pool rotation). NOTE (#251): a subject who self-selects (step 1)
-  overrides `server_source` — with the pin removed there is no per-subject
-  hard-force, so a subject CAN now egress from a pool/granted address
-  instead of the mandated one. Returns a canonical IP-literal string or
-  `nil`. The connect path (`Grappa.IRC.Client.source_bind/2`) is UNCHANGED
-  — this only chooses the value that `SessionPlan` threads through.
+  A network WITH `source_address` set binds it verbatim for EVERY subject
+  on that network (the Libera go-live "one accountable egress per network"
+  posture) — the subject's self-selection no longer overrides it, reversing
+  the #251 nuance. A network with `nil` routes the subject through the vhost
+  selection, else `OutboundV6Pool.pick/0` (the in_pool rotation). Returns a
+  canonical IP-literal string or `nil`. The connect path
+  (`Grappa.IRC.Client.source_bind/2`) is UNCHANGED — this only chooses the
+  value that `SessionPlan` threads through; the actual bind (and its #271
+  leaf-family constraint) already honors whatever source it is handed.
   """
   @spec effective_source(Subject.t(), String.t() | nil) :: String.t() | nil
-  def effective_source({_, _} = subject, server_source) do
+  # #266 — an admin-set per-network source is ABSOLUTE: it wins over the
+  # subject's vhost selection and the pool. Return it before consulting the
+  # (potentially expensive) selection lookup.
+  def effective_source({_, _}, server_source) when is_binary(server_source), do: server_source
+
+  def effective_source({_, _} = subject, nil) do
     case get_selection(subject) do
-      [] -> server_source
+      [] -> nil
       selected -> Enum.random(selected)
     end
   end

--- a/lib/grappa_web.ex
+++ b/lib/grappa_web.ex
@@ -26,6 +26,7 @@ defmodule GrappaWeb do
         Grappa.IRC,
         Grappa.LiveIntrospection,
         Grappa.Net.HostAddresses,
+        Grappa.Net.IpLiteral,
         Grappa.Net.PtrCache,
         Grappa.Networks,
         Grappa.Operator,

--- a/lib/grappa_web/controllers/admin/servers_controller.ex
+++ b/lib/grappa_web/controllers/admin/servers_controller.ex
@@ -31,6 +31,7 @@ defmodule GrappaWeb.Admin.ServersController do
 
   alias Grappa.{AdminEvents, Admission, Networks, Vhosts}
   alias Grappa.AdminEvents.Wire, as: AdminEventsWire
+  alias Grappa.Net.{HostAddresses, IpLiteral}
   alias Grappa.Networks.Servers
   alias Grappa.Networks.Servers.AdminWire, as: ServerWire
   alias GrappaWeb.Admin.AuthPlug
@@ -61,11 +62,13 @@ defmodule GrappaWeb.Admin.ServersController do
   """
   @spec create(Plug.Conn.t(), map()) ::
           Plug.Conn.t()
-          | {:error, :not_found | :already_exists | :bad_request | Ecto.Changeset.t()}
+          | {:error, :not_found | :already_exists | :bad_request | :source_not_local | Ecto.Changeset.t()}
   def create(conn, %{"network_id" => nid} = params) do
     with {:ok, parsed_nid} <- parse_id(nid),
          {:ok, net} <- fetch_network(parsed_nid),
-         {:ok, attrs} <- server_attrs(params, ["host", "port", "tls", "priority", "enabled"]),
+         {:ok, attrs} <-
+           server_attrs(params, ["host", "port", "tls", "priority", "enabled", "source_address"]),
+         :ok <- validate_source_bindable(attrs),
          {:ok, server} <- Servers.add_server(net, attrs) do
       :ok = emit_server_event(:added, net, server, conn)
       :ok = resync_outbound_pool()
@@ -82,13 +85,15 @@ defmodule GrappaWeb.Admin.ServersController do
   """
   @spec update(Plug.Conn.t(), map()) ::
           Plug.Conn.t()
-          | {:error, :not_found | :already_exists | :bad_request | Ecto.Changeset.t()}
+          | {:error, :not_found | :already_exists | :bad_request | :source_not_local | Ecto.Changeset.t()}
   def update(conn, %{"network_id" => nid, "id" => sid} = params) do
     with {:ok, parsed_nid} <- parse_id(nid),
          {:ok, parsed_sid} <- parse_id(sid),
          {:ok, net} <- fetch_network(parsed_nid),
          {:ok, server} <- Servers.get_server(net, parsed_sid),
-         {:ok, attrs} <- server_attrs(params, ["host", "port", "tls", "priority", "enabled"]),
+         {:ok, attrs} <-
+           server_attrs(params, ["host", "port", "tls", "priority", "enabled", "source_address"]),
+         :ok <- validate_source_bindable(attrs),
          {:ok, updated} <- Servers.update_server(server, attrs) do
       :ok = emit_server_event(:updated, net, updated, conn)
       :ok = resync_outbound_pool()
@@ -202,5 +207,43 @@ defmodule GrappaWeb.Admin.ServersController do
   # pickable until the next reboot / vhost-inventory edit.
   defp resync_outbound_pool do
     Vhosts.resync_pool(Servers.list_source_addresses())
+  end
+
+  # #266 — admin-boundary local-bindability gate. A per-network
+  # `source_address` must be an address the HOST can actually bind as an
+  # outbound source; a non-local literal (an address the jail/host doesn't
+  # own) would fail at connect time with an opaque family/bind error. We
+  # enumerate the host's egressable addresses here rather than in the pure
+  # `Server.changeset/2` because `getifaddrs/0` is an IO side-effect that
+  # doesn't belong in a changeset validator (CLAUDE.md
+  # Application.get_env / pure-changeset discipline). The changeset keeps
+  # the literal-SHAPE check as the first gate: a non-literal falls through
+  # here (`:ok`) and is rejected by `add_server`/`update_server` as
+  # `validation_failed`; a VALID literal that isn't local is rejected here
+  # as `:source_not_local` (422). `nil` (clear) / absent is always fine.
+  # This gate lives at the admin controller, NOT in the shared
+  # `Servers.update_server/2` — the mix-task path (`grappa.add_server
+  # --source`) runs on the host by the operator and is trusted; only the
+  # REST admin surface enumerates + rejects.
+  @spec validate_source_bindable(map()) :: :ok | {:error, :source_not_local}
+  defp validate_source_bindable(attrs) do
+    case Map.get(attrs, :source_address) do
+      addr when is_binary(addr) ->
+        case IpLiteral.canonicalize(addr) do
+          # Not a literal — defer shape rejection to the changeset.
+          :error -> :ok
+          {:ok, _} -> local_or_error(addr)
+        end
+
+      # nil (clear) or absent — nothing to bind, always valid.
+      _ ->
+        :ok
+    end
+  end
+
+  defp local_or_error(addr) do
+    if HostAddresses.local_bindable?(addr, HostAddresses.list()),
+      do: :ok,
+      else: {:error, :source_not_local}
   end
 end

--- a/lib/grappa_web/controllers/fallback_controller.ex
+++ b/lib/grappa_web/controllers/fallback_controller.ex
@@ -62,6 +62,7 @@ defmodule GrappaWeb.FallbackController do
            | :invalid_message
            | :nick_in_use
            | :cannot_disconnect_self
+           | :source_not_local
            | :insufficient_storage
            | :unsupported_media_type
            | :already_exists
@@ -584,6 +585,18 @@ defmodule GrappaWeb.FallbackController do
     conn
     |> put_status(:unprocessable_entity)
     |> json(%{error: "cannot_disconnect_self"})
+  end
+
+  # #266 — admin set a per-network `source_address` that isn't a bindable
+  # local address on the host (`GrappaWeb.Admin.ServersController`
+  # local-bindability gate). 422: the request is well-formed AND authorized,
+  # the literal shape is fine, but the host can't egress from that address.
+  # Distinct wire token from `validation_failed` (bad literal shape) so cic
+  # can render "not an address this server can bind" vs "not a valid IP."
+  def call(conn, {:error, :source_not_local}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: "source_not_local"})
   end
 
   # Admin-panel bucket 1 — strict-create REST surfaces. The

--- a/lib/mix/tasks/grappa.add_server.ex
+++ b/lib/mix/tasks/grappa.add_server.ex
@@ -20,8 +20,13 @@ defmodule Mix.Tasks.Grappa.AddServer do
 
   `--source <ip>` pins the outbound source address for this server.
   Must be a strict literal IPv4 or IPv6 address (no hostname, no CIDR).
-  This is the per-network FALLBACK source; a per-subject vhost pin or
-  selection (#228, admin panel) overrides it. See `Grappa.Vhosts`.
+  #266: this per-network source now takes ABSOLUTE precedence — when set
+  it WINS over a subject's vhost selection and the rotation pool (the
+  Libera go-live "one accountable egress per network" posture), reversing
+  the #251 nuance where a self-selection overrode it. See `Grappa.Vhosts`.
+  Unlike the REST admin surface, this trusted host-side path is NOT
+  local-bindable-gated: a non-local literal is accepted here and fails at
+  connect time.
 
   ## TLS default — port-sniffed
 

--- a/lib/mix/tasks/grappa.bind_network.ex
+++ b/lib/mix/tasks/grappa.bind_network.ex
@@ -22,8 +22,13 @@ defmodule Mix.Tasks.Grappa.BindNetwork do
 
   `--source <ip>` pins the outbound source address for this server.
   Must be a strict literal IPv4 or IPv6 address (no hostname, no CIDR).
-  This is the per-network FALLBACK source; a per-subject vhost pin or
-  selection (#228, admin panel) overrides it. See `Grappa.Vhosts`.
+  #266: this per-network source now takes ABSOLUTE precedence — when set
+  it WINS over a subject's vhost selection and the rotation pool (the
+  Libera go-live "one accountable egress per network" posture), reversing
+  the #251 nuance where a self-selection overrode it. See `Grappa.Vhosts`.
+  Unlike the REST admin surface, this trusted host-side path is NOT
+  local-bindable-gated: a non-local literal is accepted here and fails at
+  connect time.
 
   Valid `--auth` values: `auto | sasl | server_pass | nickserv_identify
   | none`. S29 H10: `--auth` lost its silent `auto` default — operator

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -1815,6 +1815,50 @@ defmodule Grappa.IRC.ClientTest do
       assert Keyword.fetch!(opts, :ifaddr) == source
     end
 
+    # #266 precedence rule #1 — an admin-pinned per-network source OVERRIDES
+    # #271 leaf distribution: the source bind is ABSOLUTE, so every rotated
+    # leaf is dialed from the SAME pinned ifaddr regardless of which leaf the
+    # shuffle picks (or how many leaves rotation burns through on connect
+    # failure). resolve/effective_source pins the source at the plan layer;
+    # here we prove the client's leaf rotation never re-overrides it.
+    test "a pinned source binds constant across rotated leaves (#266 over #271)" do
+      resolver = fn ~c"irc.azzurra.chat", :in, :aaaa -> @azzurra_aaaa end
+      parent = self()
+      source = {0x2A03, 0x4000, 0x2, 0x33C, 0, 0, 0, 0x1}
+      attempts = :counters.new(1, [])
+
+      # First leaf refuses → rotation rolls to a second, DIFFERENT leaf. Both
+      # dials must carry the identical pinned ifaddr.
+      connect_fun = fn _, target, _, opts, _ ->
+        n = :counters.get(attempts, 1)
+        :counters.add(attempts, 1, 1)
+        send(parent, {:dialed, target, Keyword.fetch!(opts, :ifaddr)})
+        if n == 0, do: {:error, :econnrefused}, else: {:ok, :fake_socket}
+      end
+
+      assert {:ok, :fake_socket} =
+               Client.__connect_with_rotation_for_test__(
+                 ~c"irc.azzurra.chat",
+                 6697,
+                 true,
+                 [ifaddr: source],
+                 :inet6,
+                 resolver,
+                 connect_fun
+               )
+
+      assert_received {:dialed, first_leaf, first_ifaddr}
+      assert_received {:dialed, second_leaf, second_ifaddr}
+
+      # Rotation actually happened (two distinct leaves dialed)...
+      assert first_leaf != second_leaf
+      assert first_leaf in @azzurra_aaaa and second_leaf in @azzurra_aaaa
+      # ...but the pinned source is the SAME bind on both — leaf rotation never
+      # overrode it. This is #266 precedence rule #1 at the connect layer.
+      assert first_ifaddr == source
+      assert second_ifaddr == source
+    end
+
     # (d) rotate-on-connect-fail: the first-picked leaf's connect failure must
     # roll to a DIFFERENT member of the set before the :transient give-up, so a
     # single dead leaf can't park every session.

--- a/test/grappa/net/host_addresses_test.exs
+++ b/test/grappa/net/host_addresses_test.exs
@@ -69,4 +69,32 @@ defmodule Grappa.Net.HostAddressesTest do
       assert Enum.all?(addrs, fn a -> match?({:ok, ^a}, Grappa.Net.IpLiteral.canonicalize(a)) end)
     end
   end
+
+  # #266 — the admin per-network source-address gate. The universe is passed
+  # IN (deterministic; no dependence on the host's real interfaces), so these
+  # are pure and stable in any container.
+  describe "local_bindable?/2" do
+    # Threat first: a valid literal that the host does NOT bind is rejected.
+    # 192.0.2.1 is TEST-NET-1 (RFC 5737) — never an interface address.
+    test "a non-local literal is NOT bindable (threat)" do
+      refute HostAddresses.local_bindable?("192.0.2.1", ["203.0.113.5", "2001:db8::1"])
+    end
+
+    test "a local literal in the set IS bindable" do
+      assert HostAddresses.local_bindable?("203.0.113.5", ["203.0.113.5", "2001:db8::1"])
+    end
+
+    test "canonicalizes before comparing (2001:0DB8::1 matches stored 2001:db8::1)" do
+      assert HostAddresses.local_bindable?("2001:0DB8::0001", ["2001:db8::1"])
+    end
+
+    test "a non-literal (hostname/garbage) is NOT bindable" do
+      refute HostAddresses.local_bindable?("not-an-ip", ["203.0.113.5"])
+      refute HostAddresses.local_bindable?("example.com", ["203.0.113.5"])
+    end
+
+    test "an empty universe binds nothing" do
+      refute HostAddresses.local_bindable?("203.0.113.5", [])
+    end
+  end
 end

--- a/test/grappa/networks/session_plan_vhost_test.exs
+++ b/test/grappa/networks/session_plan_vhost_test.exs
@@ -1,10 +1,12 @@
 defmodule Grappa.Networks.SessionPlanVhostTest do
   @moduledoc """
-  #228 — `Grappa.Networks.SessionPlan.base_plan/7` resolves the plan's
-  `source_address` through `Grappa.Vhosts.effective_source/2` (the
-  per-subject vhost layer) instead of copying `server.source_address`
-  verbatim. The per-server fixed source becomes the FALLBACK, not the
-  value — a self-selection overrides it (#251 — the admin pin was removed).
+  #228 / #266 — `Grappa.Networks.SessionPlan.base_plan/7` resolves the
+  plan's `source_address` through `Grappa.Vhosts.effective_source/2` (the
+  per-subject vhost layer). #266 INVERTS the #251 precedence: an admin-set
+  per-network `server.source_address` now WINS over a subject's vhost
+  self-selection (Libera go-live: an admin-pinned, accountable egress).
+  The per-server source is the value when set; the vhost selection is the
+  fallback ONLY when no source is pinned.
   """
   use Grappa.DataCase, async: true
 
@@ -33,7 +35,7 @@ defmodule Grappa.Networks.SessionPlanVhostTest do
     assert plan.source_address == nil
   end
 
-  test "a self-selected generally-available vhost overrides the server source" do
+  test "an admin server source WINS over a self-selected vhost (#266)" do
     user = user_fixture()
     network = network_fixture()
     {:ok, vhost} = Vhosts.create_vhost(%{address: "2001:db8::def", generally_available: true})
@@ -41,6 +43,19 @@ defmodule Grappa.Networks.SessionPlanVhostTest do
 
     cred = %Credential{nick: "n", auth_method: :none, autojoin_channels: [], last_joined_channels: []}
     server = %Server{host: "irc.example.test", port: 6697, tls: true, source_address: "2001:db8::99"}
+
+    plan = SessionPlan.base_plan({:user, user.id}, "label", cred, network, server, "n")
+    assert plan.source_address == "2001:db8::99"
+  end
+
+  test "with a nil server source, a self-selected vhost is used (#266 fallback)" do
+    user = user_fixture()
+    network = network_fixture()
+    {:ok, vhost} = Vhosts.create_vhost(%{address: "2001:db8::def", generally_available: true})
+    {:ok, _} = Vhosts.set_selection({:user, user.id}, [vhost.address])
+
+    cred = %Credential{nick: "n", auth_method: :none, autojoin_channels: [], last_joined_channels: []}
+    server = %Server{host: "irc.example.test", port: 6697, tls: true, source_address: nil}
 
     plan = SessionPlan.base_plan({:user, user.id}, "label", cred, network, server, "n")
     assert plan.source_address == "2001:db8::def"

--- a/test/grappa/vhosts_test.exs
+++ b/test/grappa/vhosts_test.exs
@@ -168,16 +168,30 @@ defmodule Grappa.VhostsTest do
     end
   end
 
-  describe "effective_source/2 — resolution precedence" do
-    test "1. selection (intersected with allowed) wins over server_source" do
+  # #266 — the precedence is INVERTED from #251: an admin-set per-network
+  # `server_source` now WINS over the subject's vhost self-selection (and the
+  # pool). Libera go-live posture: an admin-pinned, accountable egress is the
+  # honest answer; a user-driven rotating vhost reads as ban-evasion. When no
+  # admin source is set the vhost selection/pool fallback is unchanged.
+  describe "effective_source/2 — resolution precedence (#266: admin source wins)" do
+    test "1. an admin server_source WINS over an active vhost selection" do
       user = user_fixture()
       {:ok, sel} = Vhosts.create_vhost(%{address: addr(), generally_available: true})
       {:ok, _} = Vhosts.set_selection({:user, user.id}, [sel.address])
 
-      assert Vhosts.effective_source({:user, user.id}, "192.0.2.99") == sel.address
+      # Subject HAS a selection, but the network pins a source → the pin binds.
+      assert Vhosts.effective_source({:user, user.id}, "192.0.2.99") == "192.0.2.99"
     end
 
-    test "2b. multi-selection returns one of the selected (random per connection)" do
+    test "2. falls back to the vhost selection when there is no admin source" do
+      user = user_fixture()
+      {:ok, sel} = Vhosts.create_vhost(%{address: addr(), generally_available: true})
+      {:ok, _} = Vhosts.set_selection({:user, user.id}, [sel.address])
+
+      assert Vhosts.effective_source({:user, user.id}, nil) == sel.address
+    end
+
+    test "2b. multi-selection (no admin source) returns one of the selected (random per connection)" do
       user = user_fixture()
       {:ok, a} = Vhosts.create_vhost(%{address: addr(), generally_available: true})
       {:ok, b} = Vhosts.create_vhost(%{address: addr(), generally_available: true})
@@ -187,24 +201,25 @@ defmodule Grappa.VhostsTest do
       assert picked in [a.address, b.address]
     end
 
-    test "3. falls back to server_source when no selection" do
+    test "3. an admin server_source binds when there is no selection" do
       user = user_fixture()
       assert Vhosts.effective_source({:user, user.id}, "192.0.2.50") == "192.0.2.50"
     end
 
-    test "3b. falls back to nil (pool/kernel) when no selection, no server source" do
+    test "3b. nil (pool/kernel default) when neither an admin source nor a selection" do
       user = user_fixture()
       assert Vhosts.effective_source({:user, user.id}, nil) == nil
     end
 
-    test "a selection whose grant was revoked does NOT bind — falls through to server_source" do
+    test "a revoked-grant selection does NOT bind — nil admin source falls through to nil" do
       user = user_fixture()
       {:ok, granted} = Vhosts.create_vhost(%{address: addr(), generally_available: false})
       {:ok, grant} = Vhosts.grant_vhost(granted, {:user, user.id})
       {:ok, _} = Vhosts.set_selection({:user, user.id}, [granted.address])
       :ok = Vhosts.revoke_grant(grant)
 
-      assert Vhosts.effective_source({:user, user.id}, "192.0.2.50") == "192.0.2.50"
+      # The clamped-out selection is gone AND there is no admin source → nil.
+      assert Vhosts.effective_source({:user, user.id}, nil) == nil
     end
   end
 

--- a/test/grappa_web/controllers/admin/servers_controller_test.exs
+++ b/test/grappa_web/controllers/admin/servers_controller_test.exs
@@ -21,6 +21,7 @@ defmodule GrappaWeb.Admin.ServersControllerTest do
   import Grappa.AuthFixtures
 
   alias Grappa.{Accounts, Networks}
+  alias Grappa.Net.HostAddresses
   alias Grappa.Networks.Servers
   alias Grappa.PubSub.Topic
 
@@ -33,6 +34,16 @@ defmodule GrappaWeb.Admin.ServersControllerTest do
   defp fresh_network do
     {:ok, net} = Networks.find_or_create_network(%{slug: "srv-c-#{System.unique_integer([:positive])}"})
     net
+  end
+
+  # A real address the host CAN bind — the container always has at least one
+  # egressable interface (docker eth0). We assert non-empty so a getifaddrs-
+  # blind environment fails loudly rather than silently skipping the check.
+  defp local_source_address do
+    case HostAddresses.list() do
+      [addr | _] -> addr
+      [] -> flunk("host has no egressable interface — cannot exercise the local-source path")
+    end
   end
 
   describe "POST /admin/networks/:id/servers — auth gate" do
@@ -180,6 +191,121 @@ defmodule GrappaWeb.Admin.ServersControllerTest do
         )
 
       assert json_response(conn, 409) == %{"error" => "already_exists"}
+    end
+  end
+
+  # #266 — admin-configurable per-network source_address: set/clear via the
+  # REST admin surface, gated on local-bindability.
+  describe "source_address (#266) — set / clear / local-bindability gate" do
+    test "POST with a local source_address persists + surfaces it", %{conn: conn} do
+      net = fresh_network()
+      session = admin_session()
+      source = local_source_address()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put_req_header("content-type", "application/json")
+        |> post(
+          "/admin/networks/#{net.id}/servers",
+          Jason.encode!(%{host: "src.example.test", port: 6697, source_address: source})
+        )
+
+      body = json_response(conn, 201)
+      assert body["source_address"] == source
+      # Feeds the pool-subtraction set (spec §3): an admin source must never
+      # rotate back into the auto pool.
+      assert source in Servers.list_source_addresses()
+    end
+
+    test "POST rejects a non-local literal with 422 source_not_local", %{conn: conn} do
+      net = fresh_network()
+      session = admin_session()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put_req_header("content-type", "application/json")
+        |> post(
+          "/admin/networks/#{net.id}/servers",
+          # 192.0.2.1 is TEST-NET-1 — a valid literal the host never binds.
+          Jason.encode!(%{host: "src.example.test", port: 6697, source_address: "192.0.2.1"})
+        )
+
+      assert json_response(conn, 422) == %{"error" => "source_not_local"}
+    end
+
+    test "POST rejects a non-literal source with 422 validation_failed (shape gate first)",
+         %{conn: conn} do
+      net = fresh_network()
+      session = admin_session()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put_req_header("content-type", "application/json")
+        |> post(
+          "/admin/networks/#{net.id}/servers",
+          Jason.encode!(%{host: "src.example.test", port: 6697, source_address: "not-an-ip"})
+        )
+
+      # A bad SHAPE surfaces as the changeset error, NOT source_not_local.
+      assert json_response(conn, 422)["error"] == "validation_failed"
+    end
+
+    test "PUT sets a local source on an existing server", %{conn: conn} do
+      net = fresh_network()
+      {:ok, server} = Servers.add_server(net, %{host: "h", port: 6697})
+      session = admin_session()
+      source = local_source_address()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put_req_header("content-type", "application/json")
+        |> put(
+          "/admin/networks/#{net.id}/servers/#{server.id}",
+          Jason.encode!(%{source_address: source})
+        )
+
+      assert json_response(conn, 200)["source_address"] == source
+    end
+
+    test "PUT clears the source with an explicit null", %{conn: conn} do
+      net = fresh_network()
+      source = local_source_address()
+      {:ok, server} = Servers.add_server(net, %{host: "h", port: 6697, source_address: source})
+      session = admin_session()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put_req_header("content-type", "application/json")
+        |> put(
+          "/admin/networks/#{net.id}/servers/#{server.id}",
+          Jason.encode!(%{source_address: nil})
+        )
+
+      assert json_response(conn, 200)["source_address"] == nil
+      {:ok, reloaded} = Servers.get_server(net, server.id)
+      assert reloaded.source_address == nil
+    end
+
+    test "PUT rejects a non-local source with 422 source_not_local", %{conn: conn} do
+      net = fresh_network()
+      {:ok, server} = Servers.add_server(net, %{host: "h", port: 6697})
+      session = admin_session()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put_req_header("content-type", "application/json")
+        |> put(
+          "/admin/networks/#{net.id}/servers/#{server.id}",
+          Jason.encode!(%{source_address: "192.0.2.1"})
+        )
+
+      assert json_response(conn, 422) == %{"error" => "source_not_local"}
     end
   end
 


### PR DESCRIPTION
Re-scoped #266 (2026-07-17): **keep** a per-network outbound `source_address`, make it **admin-configurable** (set/clear), and give it **absolute precedence** — when set it WINS over the subject's vhost selection, the `OutboundV6Pool` rotation, and #271 RR-DNS leaf distribution. Libera go-live posture: a user-driven rotating vhost reads as ban-evasion; an admin-pinned, accountable, single egress per network is the honest answer. (The 2026-07-16 "remove the column" comment on #266 is annulled by the body re-scope.)

## Altitude decision (A)
Elevate the **existing per-server** `network_servers.source_address` column, NOT a new network-level one. A network's server rows ARE its endpoints; RR-DNS deployments run one server row per network (leaves rotate at the client via #271), so one network = one source in the common case. (B) would add a second source column with a precedence between the two — the "parallel structure that drifts" anti-pattern. **Consequence: no migration** (the existing nullable column is reused unchanged).

## What changed
- **Precedence inversion** (`Grappa.Vhosts.effective_source/2`): a binary `server_source` wins verbatim over the vhost selection/pool; `nil` keeps the existing selection→nil fallback. Reverses the #251 nuance. Moduledoc + call-site comments updated to the new order.
- **Admin set/clear** (`ServersController` create/update whitelist + `Servers.AdminWire` emits `source_address`; cic admin Networks tab add-form field + per-row inline editor; clear via JSON `null`).
- **Local-bindable validation** (NEW, admin boundary — not the pure changeset): `HostAddresses.local_bindable?/2` (reuses `HostAddresses.list/0` getifaddrs; universe passed in, pure). A valid literal not on the host → 422 `source_not_local`; a non-literal defers to the changeset (`validation_failed`); nil/absent (clear) always valid. The mix-task path stays ungated (operator-on-host trusted).
- **Pool subtraction** (spec §3): an admin-set source feeds `Servers.list_source_addresses/0` → `resync_pool/1` (already called on every mutation) so it can't rotate back into the auto pool.
- **#271 override** already holds at the client (a pinned source's `ifaddr` is constant across rotated leaves); new `client_test` pins the cross-rotation invariant — no production change.

## Tests
ExUnit precedence table + session-plan + `local_bindable?/2` (threat-first) + controller conn (set/clear/non-local 422/garbage validation_failed) + client pinned-over-rotation. cic vitest + Playwright e2e (chromium + @webkit): non-local rejection surfaces end-to-end via both the add-form and the inline editor (deterministic 192.0.2.1). Local-success round-trip is in the ExUnit conn test (reads `HostAddresses.list/0`) — not tractable browser-side.

## Deploy
Server-side is HOT-reloadable on its own (no migration/schema/supervision/cluster/env change — altitude A reuses the existing column), but ships with a cic bundle → **COLD + HELD**, rides the next coordinated COLD window batched with the other HELD COLD work. **Not deployed in this PR.**

Refs #266.