### PR TITLE
Drop the WS query-string token fallback (subprotocol-only) (#202)

### DIFF
--- a/cicchetto/e2e/tests/issue95-ws-token-subprotocol.spec.ts
+++ b/cicchetto/e2e/tests/issue95-ws-token-subprotocol.spec.ts
@@ -1,8 +1,10 @@
-// #95 — the bearer token must ride the `Sec-WebSocket-Protocol`
+// #95 + #202 — the bearer token must ride the `Sec-WebSocket-Protocol`
 // subprotocol, OFF the WS upgrade URL (`?token=…` was pre-redaction
-// visible in access logs). The server keeps a query-string fallback for
-// old bundles mid-cold-deploy. This spec proves BOTH server paths accept
-// a connection, and that the NEW bundle never puts the token in the URL.
+// visible in access logs). #95 kept a query-string fallback for old
+// bundles mid-cold-deploy; #202 dropped it. This spec proves the NEW
+// bundle connects with the token off the URL AND that a raw `?token=`
+// handshake is now REJECTED (the e2e twin of the Elixir "ignores a
+// query-string token entirely" guard).
 //
 // chromium-only: raw WebSocket construction + framereceived inspection
 // need a real socket engine; the webkit-iphone-15 project adds nothing
@@ -46,7 +48,7 @@ test("subprotocol path — cic connects with the token OFF the URL, members seed
   });
 });
 
-test("legacy query-string path — a raw ?token= WS handshake still connects (server fallback)", async ({
+test("legacy query-string path — a raw ?token= WS handshake is now rejected (#202 dropped the fallback)", async ({
   page,
 }) => {
   const vjt = getSeededVjt();
@@ -55,8 +57,9 @@ test("legacy query-string path — a raw ?token= WS handshake still connects (se
   await loginAs(page, vjt);
 
   // Drive a RAW WebSocket with the bearer on the query string — exactly
-  // what an OLD (pre-#95) bundle does — and prove the server's
-  // params["token"] fallback in UserSocket.connect/3 still accepts it.
+  // what an OLD (pre-#95) bundle did — and prove the server NO LONGER
+  // honors it: #202 removed the params["token"] fallback in
+  // UserSocket.connect/3, so a query-string-only handshake is refused.
   // phoenix's WS transport lives at /socket/websocket and needs the
   // protocol version param (vsn) like phoenix.js appends.
   const result = await page.evaluate(async (token) => {
@@ -89,6 +92,8 @@ test("legacy query-string path — a raw ?token= WS handshake still connects (se
     });
   }, vjt.token);
 
-  // The server's query-string fallback accepted the handshake.
-  expect(result.opened).toBe(true);
+  // #202 — the server rejected the query-string handshake (no fallback):
+  // the socket closed without ever opening. Twin of the Elixir "ignores a
+  // query-string token entirely" guard.
+  expect(result.opened).toBe(false);
 });

--- a/cicchetto/src/lib/auth.ts
+++ b/cicchetto/src/lib/auth.ts
@@ -3,8 +3,10 @@ import * as api from "./api";
 
 // Auth state is a single module-level signal. The token is *the* identity
 // — REST calls attach it as `Authorization: Bearer ${token}`, the WS
-// connect (sub-task 4) appends it as `?token=...`, and the route guard
-// reads it to redirect unauthenticated users.
+// connect passes it via the `Sec-WebSocket-Protocol` subprotocol
+// (`authToken`, OFF the URL since #95; the `?token=` query-string
+// fallback was dropped in #202), and the route guard reads it to redirect
+// unauthenticated users.
 //
 // Persistence: localStorage. Simple, survives reloads + PWA cold-start,
 // and the iPhone "Add to Home Screen" surface keeps it across launches.

--- a/cicchetto/src/lib/socket.ts
+++ b/cicchetto/src/lib/socket.ts
@@ -91,10 +91,11 @@ function getSocket(): Socket {
       // We deliberately do NOT also pass `params: {token}`: phoenix.js's
       // `endPointURL()` appends `params()` to the query string, so
       // keeping the token there would defeat the entire point of this
-      // change (the token would still sit in the URL). The server-side
-      // `params["token"]` fallback in `UserSocket.connect/3` exists for
-      // OLD bundles still in the wild mid-cold-deploy — a NEW bundle must
-      // never put the bearer in the URL.
+      // change (the token would still sit in the URL). The server
+      // (`UserSocket.connect/3`) reads the bearer ONLY from the
+      // subprotocol — #202 dropped the legacy `params["token"]`
+      // query-string fallback that once accepted OLD bundles mid-cold-
+      // deploy, so a bearer in the URL is now ignored entirely.
       //
       // `authToken` is captured ONCE at construction (unlike a `params`
       // callback, which phoenix re-evaluates every handshake), so a fresh

--- a/config/config.exs
+++ b/config/config.exs
@@ -183,13 +183,15 @@ config :grappa, GrappaWeb.Endpoint,
 config :phoenix, :json_library, Jason
 
 # Phoenix.Logger redacts these keys from the params it logs on every
-# request + every Channels socket connect. The bearer token rides
-# `?token=…` on the WS upgrade URL because Phoenix.Socket transports
-# params as a query string — without this filter, the `[info] CONNECTED
-# TO …` line prints the bearer verbatim. Bearer is the entire identity
-# in this design; anything that lands in stdout persists across container
-# restarts and ships out with any log forwarder. Per CLAUDE.md Security:
-# "credentials … never logged."
+# request + every Channels socket connect. Since #95 the WS bearer rides
+# the `Sec-WebSocket-Protocol` subprotocol (and #202 dropped the legacy
+# `?token=` query-string fallback), so it no longer appears in the
+# logged connect params — but keeping `"token"` filtered is cheap
+# defense-in-depth (any REST body / future param named `token`), and
+# `"password"` still redacts the `/oper` + auth request bodies. Bearer is
+# the entire identity in this design; anything that lands in stdout
+# persists across container restarts and ships out with any log
+# forwarder. Per CLAUDE.md Security: "credentials … never logged."
 config :phoenix, :filter_parameters, ["password", "token"]
 
 config :logger, :console,
@@ -258,13 +260,6 @@ config :logger, :console,
     :affected,
     :authn_failure,
     :socket_id,
-    # #95: WS connect-time auth source — `:subprotocol` (bearer via the
-    # Sec-WebSocket-Protocol header) vs `:query_string` (legacy `?token=`
-    # fallback). METHOD ONLY, never the token value (the raw bearer IS
-    # the credential — S9). Rides the `ws connect authenticated` line so
-    # an operator grep can confirm zero query-string auth before the
-    # fallback is dropped.
-    :auth_method,
     # Client IP, post-RemoteIp plug rewrite (so what you see is the
     # real client, not the docker-bridge nginx IP). Useful for grep-
     # correlating an authn failure or captcha rejection back to the

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -25452,3 +25452,93 @@ supervision/cluster/env change — altitude (A) reuses the existing nullable
 column), but ships with a **cic bundle**, so this delivery is **HELD** to ride the
 next coordinated **COLD** window batched with the other HELD COLD work (#299
 batch). Not deployed this session — merge to main + push + HOLD._
+
+### 2026-07-19 — #202: drop the WS query-string token fallback (subprotocol-only)
+
+Follow-up to #95 (`a00aed3`). #95 moved the WS bearer onto the
+`Sec-WebSocket-Protocol` subprotocol (`connect_info.auth_token`) so it no longer
+rode the WS upgrade URL as `?token=…` (pre-redaction visible in access logs), but
+RETAINED the legacy `params["token"]` query-string path as a server-side fallback
+in `GrappaWeb.UserSocket.connect/3` for one deploy cycle — so a stale bundle
+mid-cold-deploy still authenticated. That fallback was the last place the bearer
+could ride the URL. #202 removes it: the subprotocol is now the SOLE bearer
+source.
+
+**Gate (already clean — the removal precondition).** #95 shipped a
+`[:grappa, :ws, :connect]` telemetry event + a greppable Logger line tagging the
+resolved auth METHOD (`:subprotocol | :query_string`), method-only, never the
+token — precisely so an operator could confirm zero clients still used the query
+string before pulling the fallback. vjt read the prod BEAM log: **0
+`auth_method=query_string` / 26 `auth_method=subprotocol`**, INCLUDING the
+reconnect wave after a cold deploy (long-lived PWA tabs + service-worker update
+lag being the risk #95 hedged against). Clean signal, so the fallback is safe to
+remove without re-breaking a not-yet-refreshed client (the #193-class
+stuck-on-splash the issue warned about).
+
+**Server (`user_socket.ex`).** `extract_token/2` → `extract_token/1`: the
+`params["token"]` arm is gone; it reads the bearer only from
+`connect_info.auth_token`, returning `{:ok, String.t()} | :error` (the third
+`method` element is dead — only `:subprotocol` survived, so it carried no
+information). `connect/3`'s first arg (the Phoenix `params`) is now unused →
+`_params`. `authenticate_and_assign/3` → `/2` (the `method` thread is gone). The
+"any failure → `:error`, no enumeration leak" posture is unchanged.
+
+**Telemetry decision — keep the counter, drop the tag.** The
+`[:grappa, :ws, :connect]` event has NO production handler (verified: only
+`user_socket_test.exs` attaches to it; the prod handlers are session_log /
+admin_events / admission). Two coherent options: drop the event entirely
+(unused), or keep it as a bare counter. Chose to KEEP it as `%{count: 1}` with
+EMPTY metadata + a bare `Logger.info("ws connect authenticated")` — a connect-churn
+counter is a cheap, legitimate ops/Phase-5-exporter signal, and keeping the event
+avoids re-adding it later; the now-constant `auth_method` tag is what's removed,
+not the event. (The unrelated IRC-credential `auth_method` —
+sasl/server_pass/nickserv/none in bind_network / credentials — is a different
+field and was NOT touched.)
+
+**nginx (`infra/snippets/locations-api.conf`).** The `/socket` block's
+`access_log off;` existed solely to keep the pre-#95 `?token=…` bearer out of
+nginx stdout / Docker JSON logs. With the token off the URL (subprotocol since
+#95, fallback gone in #202), the WS upgrade request line carries nothing
+sensitive (Phoenix appends only `vsn=…`), so the suppression is removed —
+re-enabling the default access log aids ops/debugging of connect churn. The block
+lives in the SHARED snippet included by BOTH the prod surface (`infra/nginx.conf`)
+and the e2e surface (`cicchetto/e2e/nginx-test.conf`, :80 + :443), so the one edit
+covers every server block and the two configs stay consistent by construction.
+
+**cic (`socket.ts`).** Comment-only. cic has been subprotocol-only since #95 and
+deliberately does NOT pass `params: {token}`; the stale comment describing the
+server-side `params["token"]` fallback for old bundles was rewritten to note the
+fallback is gone. No functional cic change.
+
+**Tests.** TDD failing-assert first: "ignores a query-string token entirely
+(subprotocol-only)" — a VALID bearer in the query string with no subprotocol now
+returns `:error` (ran RED against the live fallback, GREEN after removal). The
+whole `user_socket_test.exs` + the two `admin_channel_test.exs` connects migrated
+from the query-string helper to the subprotocol helper (`connect_info:
+%{auth_token: …}`); the rejection tests use the subprotocol path too so they still
+exercise the reject REASON. The telemetry describe block asserts a bare
+`%{count: 1}` counter with `metadata == %{}` (strong assert — catches a re-added
+tag) + no event on auth failure. e2e: no NEW spec, but the #95 spec
+(`issue95-ws-token-subprotocol.spec.ts`) had a "raw `?token=` handshake still
+connects (server fallback)" test that would now go RED — it was INVERTED to assert
+the query-string handshake is REJECTED, the e2e twin of the Elixir guard. Every
+other Playwright spec already opens the socket via the subprotocol, so a green
+full `integration.sh` is the end-to-end proof that no live client path broke.
+
+**Sweep of stale references (total consistency).** The fallback narrative had
+leaked into files outside the core surface; #202 reconciled them all: the
+`config/config.exs` Logger-metadata allowlist dropped the now-dead `:auth_method`
+key (nothing emits it after the Logger line went bare) and its
+`filter_parameters` comment (the WS bearer no longer rides `?token=`, though
+`"token"`/`"password"` stay filtered as defense-in-depth); the
+`infra/nginx-tls-frontend.example.conf` reference front-door re-enabled its
+`/socket` access log (a third `/socket` block the shared-snippet edit didn't
+cover); and the stale `?token=` comments in `cicchetto/src/lib/auth.ts` +
+`socket.ts` were corrected to the subprotocol reality.
+
+_Deploy: **COLD** — the nginx conf change needs an nginx reload (the auth-path
+code alone would be HOT-reloadable on the BEAM, but the nginx reload is the
+binding constraint) and it ships with a **cic bundle** (comment-only, but a rebuild
+bumps the hash). **HELD** to ride the next coordinated COLD window batched with the
+other HELD COLD work (#299 batch). Not deployed this session — merge to main +
+push + HOLD._

--- a/infra/nginx-tls-frontend.example.conf
+++ b/infra/nginx-tls-frontend.example.conf
@@ -55,8 +55,11 @@ server {
   # Must be >= the largest upload cap (50MB video + multipart overhead).
   client_max_body_size 160m;
 
-  # Phoenix Channels WebSocket. The bearer travels as ?token=, so the
-  # access log is muted to keep secrets out of nginx/journald.
+  # Phoenix Channels WebSocket. Since #95 the bearer rides the
+  # Sec-WebSocket-Protocol subprotocol (and #202 dropped the legacy
+  # ?token= query-string fallback), so nothing sensitive appears in the
+  # WS upgrade URL — the access log is left ON (nginx default) to aid ops
+  # debugging of connect churn.
   location /socket {
     proxy_pass http://grappa_stack;
     proxy_http_version 1.1;
@@ -68,7 +71,6 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_read_timeout 86400s;
     proxy_send_timeout 86400s;
-    access_log off;
   }
 
   # PWA service worker — never cache; SW rollouts must be immediate.

--- a/infra/snippets/locations-api.conf
+++ b/infra/snippets/locations-api.conf
@@ -83,12 +83,14 @@ location /socket {
     # connections (Phoenix's heartbeat keeps it warm).
     proxy_read_timeout  86400s;
     proxy_send_timeout  86400s;
-    # The WS upgrade URL carries the bearer token as `?token=…`
-    # (Phoenix.Socket transports params via query string). Suppress the
-    # access log so the bearer doesn't surface in nginx stdout / Docker
-    # JSON logs. Phoenix's connect log line is filtered separately via
-    # `:phoenix, :filter_parameters`.
-    access_log off;
+    # #202 — the access log is ON (nginx default). #95's `access_log off;`
+    # was here solely to keep the pre-#95 `?token=…` bearer out of nginx
+    # stdout / Docker JSON logs. Since #95 the bearer rides the
+    # `Sec-WebSocket-Protocol` subprotocol, and #202 dropped the legacy
+    # query-string fallback entirely — the WS upgrade request line now
+    # carries nothing sensitive (Phoenix appends only `vsn=…`), so logging
+    # the upgrade aids ops/debugging of connect churn. Phoenix's own
+    # connect log line stays filtered via `:phoenix, :filter_parameters`.
 }
 
 # REST API allowlist — explicit so future routes don't get auto-

--- a/lib/grappa_web/channels/user_socket.ex
+++ b/lib/grappa_web/channels/user_socket.ex
@@ -11,30 +11,30 @@ defmodule GrappaWeb.UserSocket do
   `GrappaWeb.GrappaChannel` does the topic discrimination + per-subject
   authz on join.
 
-  ## Connect-time auth (sub-task 2i + visitor-auth Task 12 + #95)
+  ## Connect-time auth (sub-task 2i + visitor-auth Task 12 + #95 + #202)
 
   `connect/3` verifies a bearer token against
   `Grappa.Accounts.authenticate/1` — same UUID PK that the REST
-  surface consumes via `Authorization: Bearer ...`. The token source
-  (#95) is resolved subprotocol-first:
+  surface consumes via `Authorization: Bearer ...`. The bearer's ONLY
+  source is the `Sec-WebSocket-Protocol` subprotocol (#95): it rides the
+  WS handshake's subprotocol as `base64url.bearer.phx.<token>`, which
+  Phoenix's websocket transport decodes into `connect_info.auth_token`
+  (`auth_token: true` in `endpoint.ex`). This keeps the token OFF the WS
+  upgrade URL (`?token=…`, which was pre-redaction visible in access
+  logs).
 
-    * **`Sec-WebSocket-Protocol`** — the bearer rides the WS handshake's
-      subprotocol as `base64url.bearer.phx.<token>`; Phoenix's websocket
-      transport decodes it into `connect_info.auth_token`
-      (`auth_token: true` in `endpoint.ex`). This is the primary path —
-      it keeps the token OFF the WS upgrade URL (`?token=…`), which was
-      pre-redaction visible.
-    * **`params["token"]`** — the legacy query-string bearer, retained
-      as a FALLBACK for one deploy cycle so a stale bundle mid-cold-
-      deploy still connects. A follow-up drops it once the auth-method
-      telemetry (below) shows sustained zero query-string auth.
+  #95 also retained the legacy `params["token"]` query-string bearer as
+  a one-deploy-cycle fallback so a stale bundle mid-cold-deploy still
+  connected; #202 dropped it once prod telemetry showed sustained zero
+  query-string auth. A bearer supplied via the query string is now
+  ignored entirely — `connect/3`'s `params` argument is unused.
 
-  The resolved auth METHOD (`:subprotocol` | `:query_string`) is
-  recorded on a Logger line (`auth_method:` metadata) and a
-  `[:grappa, :ws, :connect]` telemetry event — METHOD ONLY, never the
-  token value (the raw bearer IS the session credential — S9), so an
-  operator can confirm zero query-string auth before the fallback is
-  removed.
+  Every authenticated connect emits a `[:grappa, :ws, :connect]`
+  telemetry counter (`%{count: 1}`, empty metadata) + a greppable Logger
+  line — a cheap ops signal for connect churn. Neither carries the token
+  value (the raw bearer IS the session credential — S9). #95's
+  `auth_method` tag is gone (#202): once the query-string fallback was
+  removed it collapsed to a constant `:subprotocol`.
 
   The authenticated `Session` row carries an XOR FK (`user_id` xor
   `visitor_id`, per Q-A). `connect/3` dispatches on that XOR:
@@ -60,8 +60,9 @@ defmodule GrappaWeb.UserSocket do
   controller-side `Subject.from_assigns/1` lift — V4 visitor-parity
   (2026-05-15).
 
-  Any failure (missing param, malformed UUID, unknown row, revoked,
-  expired user session, expired or vanished visitor) returns `:error`
+  Any failure (missing / empty subprotocol token, malformed UUID,
+  unknown row, revoked, expired user session, expired or vanished
+  visitor) returns `:error`
   — Phoenix surfaces the WS rejection with no body; distinct error
   strings would just leak enumeration info on what went wrong with
   the token.
@@ -78,52 +79,39 @@ defmodule GrappaWeb.UserSocket do
   channel "grappa:admin:events", GrappaWeb.AdminChannel
 
   @impl Phoenix.Socket
-  def connect(params, socket, connect_info) do
-    case extract_token(params, connect_info) do
-      {:ok, token, method} ->
-        authenticate_and_assign(token, method, socket)
+  def connect(_, socket, connect_info) do
+    case extract_token(connect_info) do
+      {:ok, token} ->
+        authenticate_and_assign(token, socket)
 
       :error ->
         :error
     end
   end
 
-  # #95 — token source resolution + auth-method observability.
-  #
-  # Prefer the `Sec-WebSocket-Protocol` subprotocol
-  # (`connect_info.auth_token`, decoded by Phoenix's websocket transport
-  # from `base64url.bearer.phx.<token>`); fall back to the legacy
-  # `params["token"]` query-string bearer so a stale bundle mid-cold-
-  # deploy still connects. The fallback is temporary — a follow-up drops
-  # it once the telemetry below shows sustained zero query-string auth.
-  #
-  # `method` (`:subprotocol` | `:query_string`) is recorded on BOTH a
-  # Logger line and a `[:grappa, :ws, :connect]` telemetry event so the
-  # operator can confirm zero clients still use the query string before
-  # the fallback is removed. The token VALUE is never logged or emitted —
-  # only the method — because the raw bearer IS the session credential
-  # (S9), same redaction discipline as the rest of the auth path.
-  @spec extract_token(map(), map()) ::
-          {:ok, String.t(), :subprotocol | :query_string} | :error
-  defp extract_token(params, connect_info) do
+  # #95 + #202 — the bearer's ONLY source is the `Sec-WebSocket-Protocol`
+  # subprotocol (`connect_info.auth_token`, decoded by Phoenix's websocket
+  # transport from `base64url.bearer.phx.<token>`). #95 introduced this
+  # header path and kept the legacy `params["token"]` query-string bearer
+  # as a one-deploy-cycle fallback so a stale bundle mid-cold-deploy still
+  # connected; #202 dropped that fallback once prod telemetry showed
+  # sustained zero query-string auth. A bearer in the query string is now
+  # ignored entirely, so `connect/3`'s `params` argument is unused and the
+  # token never rides the WS upgrade URL again.
+  @spec extract_token(map()) :: {:ok, String.t()} | :error
+  defp extract_token(connect_info) do
     case connect_info do
       %{auth_token: token} when is_binary(token) and token != "" ->
-        {:ok, token, :subprotocol}
+        {:ok, token}
 
       _ ->
-        case params do
-          %{"token" => token} when is_binary(token) and token != "" ->
-            {:ok, token, :query_string}
-
-          _ ->
-            :error
-        end
+        :error
     end
   end
 
-  @spec authenticate_and_assign(String.t(), :subprotocol | :query_string, Phoenix.Socket.t()) ::
+  @spec authenticate_and_assign(String.t(), Phoenix.Socket.t()) ::
           {:ok, Phoenix.Socket.t()} | :error
-  defp authenticate_and_assign(token, method, socket) do
+  defp authenticate_and_assign(token, socket) do
     with {:ok, session} <- Accounts.authenticate(token),
          {:ok, socket} <- assign_subject(socket, session) do
       socket = assign(socket, :current_session_id, session.id)
@@ -151,16 +139,16 @@ defmodule GrappaWeb.UserSocket do
       #     with long-lived tabs never saw the refresh banner trigger.
       :ok = WSPresence.register(socket.assigns.user_name, self())
 
-      # #95 — auth-method observability (method only, NEVER the token).
-      # The Logger line is greppable; the telemetry event feeds the
-      # dashboard signal that gates removing the query-string fallback.
-      Logger.info("ws connect authenticated", auth_method: method)
+      # #95 + #202 — connect observability (NEVER the token). The Logger
+      # line is greppable; the `[:grappa, :ws, :connect]` counter is a
+      # cheap ops signal (a Phase-5 exporter can aggregate connect churn).
+      # #95's `auth_method` tag is gone (#202): it had collapsed to a
+      # constant `:subprotocol` once the query-string fallback was
+      # removed, so it carried no information. The token VALUE is never
+      # logged or emitted — the raw bearer IS the session credential (S9).
+      Logger.info("ws connect authenticated")
 
-      :telemetry.execute(
-        [:grappa, :ws, :connect],
-        %{count: 1},
-        %{auth_method: method}
-      )
+      :telemetry.execute([:grappa, :ws, :connect], %{count: 1}, %{})
 
       {:ok, socket}
     else

--- a/lib/grappa_web/endpoint.ex
+++ b/lib/grappa_web/endpoint.ex
@@ -54,10 +54,10 @@ defmodule GrappaWeb.Endpoint do
   # [:auth_token]` on the websocket transport then surfaces the decoded
   # token to `UserSocket.connect/3`.
   #
-  # The legacy `params["token"]` query-string path is retained as a
-  # fallback in `connect/3` for one deploy cycle (a stale bundle mid-cold-
-  # deploy still connects); dropping it is tracked as a follow-up gated on
-  # the auth-method telemetry showing sustained zero query-string auth.
+  # #202 dropped the legacy `params["token"]` query-string path that #95
+  # had retained as a one-deploy-cycle fallback: with prod telemetry
+  # showing sustained zero query-string auth, the subprotocol is now the
+  # SOLE bearer source and the token never rides the WS upgrade URL.
   socket "/socket", GrappaWeb.UserSocket,
     auth_token: true,
     websocket: [connect_info: [:auth_token]],

--- a/test/grappa_web/channels/admin_channel_test.exs
+++ b/test/grappa_web/channels/admin_channel_test.exs
@@ -199,7 +199,9 @@ defmodule GrappaWeb.AdminChannelTest do
       admin = user_fixture(is_admin: true)
       session = session_fixture(admin)
 
-      {:ok, socket} = Phoenix.ChannelTest.connect(UserSocket, %{"token" => session.id})
+      {:ok, socket} =
+        Phoenix.ChannelTest.connect(UserSocket, %{}, connect_info: %{auth_token: session.id})
+
       assert socket.assigns.is_admin == true
 
       assert {:ok, _, _} = subscribe_and_join(socket, "grappa:admin:events", %{})
@@ -209,7 +211,9 @@ defmodule GrappaWeb.AdminChannelTest do
       user = user_fixture(is_admin: false)
       session = session_fixture(user)
 
-      {:ok, socket} = Phoenix.ChannelTest.connect(UserSocket, %{"token" => session.id})
+      {:ok, socket} =
+        Phoenix.ChannelTest.connect(UserSocket, %{}, connect_info: %{auth_token: session.id})
+
       assert socket.assigns.is_admin == false
 
       assert {:error, %{error: "forbidden"}} =

--- a/test/grappa_web/channels/user_socket_test.exs
+++ b/test/grappa_web/channels/user_socket_test.exs
@@ -1,21 +1,28 @@
 defmodule GrappaWeb.UserSocketTest do
   @moduledoc """
-  WebSocket connect-time auth (sub-task 2i).
+  WebSocket connect-time auth (sub-task 2i + #95 + #202).
 
-  `UserSocket.connect/3` flips from the Phase 1 hardcoded
-  `user_name: "vjt"` to a token-derived assign chain:
+  `UserSocket.connect/3` derives its assigns from a bearer token that
+  rides the `Sec-WebSocket-Protocol` subprotocol
+  (`connect_info.auth_token`), entirely OFF the WS upgrade URL:
 
-    * params: `%{"token" => bearer}` — the same UUID PK that
-      `Accounts.create_session/3` returns + the REST surface
-      consumes via `Authorization: Bearer ...`.
+    * `connect_info.auth_token` — the bearer Phoenix decodes from the
+      `base64url.bearer.phx.<token>` subprotocol. The same UUID PK that
+      `Accounts.create_session/3` returns + the REST surface consumes
+      via `Authorization: Bearer ...`.
     * `Accounts.authenticate(token)` validates + bumps `last_seen_at`
       with the same 60 s threshold the REST plug uses.
     * On success: `socket.assigns.user_name` (from the User row) and
       `:current_session_id` (for future revocation hooks).
-    * On any failure (missing param, malformed UUID, unknown row,
+    * On any failure (missing / empty / malformed token, unknown row,
       revoked, expired): `:error` so Phoenix returns the standard
       WS rejection — distinct error strings would just leak
       enumeration info.
+
+  #202 dropped the legacy `params["token"]` query-string fallback that
+  #95 had retained for one deploy cycle: a bearer supplied only via the
+  query string is now IGNORED (see the "ignores a query-string token
+  entirely" regression guard below).
 
   Cross-user join authz at the channel layer
   (`GrappaWeb.GrappaChannel.authorize/2`) was wired in 2h against
@@ -30,50 +37,45 @@ defmodule GrappaWeb.UserSocketTest do
   alias Grappa.{Accounts, PubSub.Topic}
   alias GrappaWeb.UserSocket
 
-  defp connect_with(params) do
-    Phoenix.ChannelTest.connect(UserSocket, params, connect_info: %{})
-  end
-
-  # #95 — subprotocol path: the bearer arrives via
+  # #95 + #202 — the ONLY token source: the bearer arrives via
   # `connect_info.auth_token` (Phoenix decodes it from the
   # `Sec-WebSocket-Protocol` header), NOT via a query-string param.
   defp connect_via_subprotocol(token) do
     Phoenix.ChannelTest.connect(UserSocket, %{}, connect_info: %{auth_token: token})
   end
 
+  # #202 — a query-string `?token=` connect with NO subprotocol token.
+  # The fallback that once honored this is gone, so every such connect is
+  # rejected regardless of whether the query-string token is valid.
+  defp connect_with_query_string(token) do
+    Phoenix.ChannelTest.connect(UserSocket, %{"token" => token}, connect_info: %{})
+  end
+
   describe "connect/3" do
-    test "returns :error when no token param is given" do
-      assert :error = connect_with(%{})
+    test "returns :error when no token is given" do
+      assert :error = Phoenix.ChannelTest.connect(UserSocket, %{}, connect_info: %{})
     end
 
     test "returns :error for a malformed (non-UUID) token" do
-      assert :error = connect_with(%{"token" => "not-a-uuid"})
+      assert :error = connect_via_subprotocol("not-a-uuid")
     end
 
     test "returns :error for a UUID that does not match any session" do
-      assert :error = connect_with(%{"token" => Ecto.UUID.generate()})
+      assert :error = connect_via_subprotocol(Ecto.UUID.generate())
     end
 
     test "returns :error for a revoked token" do
       {_, session} = user_and_session(name: "vjt-#{System.unique_integer([:positive])}")
       _ = Accounts.revoke_session(session.id)
 
-      assert :error = connect_with(%{"token" => session.id})
+      assert :error = connect_via_subprotocol(session.id)
+    end
+
+    test "returns :error when the subprotocol auth_token is empty" do
+      assert :error = connect_via_subprotocol("")
     end
 
     test "assigns :user_name + :current_session_id on success" do
-      user_name = "vjt-#{System.unique_integer([:positive])}"
-      {_, session} = user_and_session(name: user_name)
-
-      assert {:ok, socket} = connect_with(%{"token" => session.id})
-      assert socket.assigns.user_name == user_name
-      assert socket.assigns.current_session_id == session.id
-    end
-
-    # #95 — the token now rides the Sec-WebSocket-Protocol subprotocol
-    # (connect_info.auth_token), OFF the WS upgrade URL. The query-string
-    # param path above is retained only as a temporary fallback.
-    test "authenticates via connect_info.auth_token (subprotocol path)" do
       user_name = "vjt-#{System.unique_integer([:positive])}"
       {_, session} = user_and_session(name: user_name)
 
@@ -82,38 +84,25 @@ defmodule GrappaWeb.UserSocketTest do
       assert socket.assigns.current_session_id == session.id
     end
 
-    test "prefers the subprotocol token over a query-string token when both are present" do
-      sub_name = "vjt-sub-#{System.unique_integer([:positive])}"
-      qs_name = "vjt-qs-#{System.unique_integer([:positive])}"
-      {_, sub_session} = user_and_session(name: sub_name)
-      {_, qs_session} = user_and_session(name: qs_name)
+    # #202 — the legacy `params["token"]` fallback is gone. A VALID
+    # bearer supplied only via the query string is now IGNORED, so the
+    # connect is rejected exactly as if no token were present. This is
+    # the regression guard that the URL can never again carry the bearer.
+    test "ignores a query-string token entirely (subprotocol-only)" do
+      {_, session} = user_and_session(name: "vjt-#{System.unique_integer([:positive])}")
 
-      # Both sources carry a valid (but DIFFERENT) session; the
-      # subprotocol must win so a stale query-string bearer can't shadow
-      # the header-supplied one.
-      assert {:ok, socket} =
-               Phoenix.ChannelTest.connect(UserSocket, %{"token" => qs_session.id},
-                 connect_info: %{auth_token: sub_session.id}
-               )
-
-      assert socket.assigns.user_name == sub_name
-    end
-
-    test "returns :error for a malformed token via the subprotocol path" do
-      assert :error = connect_via_subprotocol("not-a-uuid")
-    end
-
-    test "returns :error when connect_info.auth_token is empty and no param token" do
-      assert :error = Phoenix.ChannelTest.connect(UserSocket, %{}, connect_info: %{auth_token: ""})
+      assert :error = connect_with_query_string(session.id)
     end
   end
 
-  # #95 — auth-method observability: connect/3 emits a
-  # [:grappa, :ws, :connect] telemetry event tagging the source method
-  # (:subprotocol | :query_string), METHOD ONLY — never the token value.
-  # This is the operator signal that gates dropping the query-string
-  # fallback (follow-up), so the tag must be correct for each path.
-  describe "auth-method telemetry (#95)" do
+  # #95 + #202 — connect observability: connect/3 emits a
+  # [:grappa, :ws, :connect] counter on every authenticated connect. #202
+  # dropped the `auth_method` metadata tag — it had collapsed to a
+  # constant `:subprotocol` once the query-string fallback was removed —
+  # leaving a bare `%{count: 1}` measurement with EMPTY metadata. The
+  # token value is NEVER emitted (the raw bearer IS the session
+  # credential — S9).
+  describe "connect telemetry (#95 / #202)" do
     setup do
       ref = make_ref()
       handler_id = "ws-connect-test-#{System.unique_integer([:positive])}"
@@ -132,22 +121,17 @@ defmodule GrappaWeb.UserSocketTest do
       %{ref: ref}
     end
 
-    test "tags :subprotocol when the bearer rides the subprotocol", %{ref: ref} do
+    test "emits the connect counter with empty metadata on an authenticated connect", %{ref: ref} do
       {_, session} = user_and_session(name: "vjt-#{System.unique_integer([:positive])}")
 
       assert {:ok, _} = connect_via_subprotocol(session.id)
-      assert_receive {^ref, %{count: 1}, %{auth_method: :subprotocol}}
+      assert_receive {^ref, measurements, metadata}
+      assert measurements == %{count: 1}
+      assert metadata == %{}
     end
 
-    test "tags :query_string on the legacy fallback path", %{ref: ref} do
-      {_, session} = user_and_session(name: "vjt-#{System.unique_integer([:positive])}")
-
-      assert {:ok, _} = connect_with(%{"token" => session.id})
-      assert_receive {^ref, %{count: 1}, %{auth_method: :query_string}}
-    end
-
-    test "emits NO connect event on an auth failure (method tag is post-auth)", %{ref: ref} do
-      assert :error = connect_with(%{"token" => Ecto.UUID.generate()})
+    test "emits NO connect event on an auth failure (counter is post-auth)", %{ref: ref} do
+      assert :error = connect_via_subprotocol(Ecto.UUID.generate())
       refute_receive {^ref, _, _}
     end
   end
@@ -156,7 +140,7 @@ defmodule GrappaWeb.UserSocketTest do
     test "scopes the per-user socket id by user_name" do
       user_name = "vjt-#{System.unique_integer([:positive])}"
       {_, session} = user_and_session(name: user_name)
-      {:ok, socket} = connect_with(%{"token" => session.id})
+      {:ok, socket} = connect_via_subprotocol(session.id)
 
       assert UserSocket.id(socket) == "user_socket:#{user_name}"
     end
@@ -170,7 +154,7 @@ defmodule GrappaWeb.UserSocketTest do
       {_, alice_session} =
         user_and_session(name: "alice-#{System.unique_integer([:positive])}")
 
-      {:ok, socket} = connect_with(%{"token" => alice_session.id})
+      {:ok, socket} = connect_via_subprotocol(alice_session.id)
 
       assert {:error, %{error: "forbidden"}} =
                Phoenix.ChannelTest.subscribe_and_join(socket, Topic.user(vjt_name), %{})
@@ -182,7 +166,7 @@ defmodule GrappaWeb.UserSocketTest do
       visitor = visitor_fixture()
       {:ok, session} = Accounts.create_session({:visitor, visitor.id}, "1.2.3.4", "ua", [])
 
-      assert {:ok, socket} = connect_with(%{"token" => session.id})
+      assert {:ok, socket} = connect_via_subprotocol(session.id)
       assert socket.assigns.user_name == "visitor:" <> visitor.id
       assert socket.assigns.current_visitor_id == visitor.id
       assert socket.assigns.current_visitor.id == visitor.id
@@ -195,7 +179,7 @@ defmodule GrappaWeb.UserSocketTest do
       visitor = visitor_fixture(expires_at: past)
       {:ok, session} = Accounts.create_session({:visitor, visitor.id}, "1.2.3.4", "ua", [])
 
-      assert :error = connect_with(%{"token" => session.id})
+      assert :error = connect_via_subprotocol(session.id)
     end
 
     # CP24 bucket E web/S5: visitor connects must register with
@@ -212,7 +196,7 @@ defmodule GrappaWeb.UserSocketTest do
       visitor = visitor_fixture()
       {:ok, session} = Accounts.create_session({:visitor, visitor.id}, "1.2.3.4", "ua", [])
 
-      assert {:ok, _} = connect_with(%{"token" => session.id})
+      assert {:ok, _} = connect_via_subprotocol(session.id)
 
       visitor_name = "visitor:" <> visitor.id
       assert visitor_name in Grappa.WSPresence.list_user_names()
@@ -223,7 +207,7 @@ defmodule GrappaWeb.UserSocketTest do
     test "scopes the per-socket id by visitor:<id>" do
       visitor = visitor_fixture()
       {:ok, session} = Accounts.create_session({:visitor, visitor.id}, "1.2.3.4", "ua", [])
-      {:ok, socket} = connect_with(%{"token" => session.id})
+      {:ok, socket} = connect_via_subprotocol(session.id)
 
       assert UserSocket.id(socket) == "user_socket:visitor:" <> visitor.id
     end
@@ -240,7 +224,7 @@ defmodule GrappaWeb.UserSocketTest do
     test "user subject — equals UserSocket.id/1 of the matching connect" do
       user_name = "vjt-#{System.unique_integer([:positive])}"
       {user, session} = user_and_session(name: user_name)
-      {:ok, socket} = connect_with(%{"token" => session.id})
+      {:ok, socket} = connect_via_subprotocol(session.id)
 
       assert UserSocket.id_for_subject({:user, user}) == UserSocket.id(socket)
     end
@@ -248,7 +232,7 @@ defmodule GrappaWeb.UserSocketTest do
     test "visitor subject — equals UserSocket.id/1 of the matching connect" do
       visitor = visitor_fixture()
       {:ok, session} = Accounts.create_session({:visitor, visitor.id}, "1.2.3.4", "ua", [])
-      {:ok, socket} = connect_with(%{"token" => session.id})
+      {:ok, socket} = connect_via_subprotocol(session.id)
 
       assert UserSocket.id_for_subject({:visitor, visitor}) == UserSocket.id(socket)
     end


### PR DESCRIPTION
Follow-up to #95 (`a00aed3`). #95 moved the WS bearer onto the
`Sec-WebSocket-Protocol` subprotocol (`connect_info.auth_token`) but kept the
legacy `params["token"]` query-string path as a one-deploy-cycle fallback in
`UserSocket.connect/3` — the last place the bearer could ride the WS upgrade URL.
Refs #202.

## The removal

Prod telemetry showed **sustained zero query-string auth** (0
`auth_method=query_string` vs subprotocol, including the reconnect wave after a
cold deploy), so the fallback is safe to pull without re-breaking a not-yet-
refreshed client (the #193-class stuck-on-splash the issue warned about). The
subprotocol is now the **sole** bearer source.

- `extract_token/2` → `extract_token/1`: the `params["token"]` arm is gone; reads
  the bearer only from `connect_info.auth_token` → `{:ok, String.t()} | :error`.
  `connect/3`'s params arg is now unused; `authenticate_and_assign/3` → `/2`. The
  "any failure → `:error`, no enumeration leak" posture is unchanged.

## Telemetry decision — keep the counter, drop the tag

`[:grappa, :ws, :connect]` has **no** production handler (only the test attaches).
Kept it as a bare `%{count: 1}` counter (cheap ops/Phase-5-exporter connect-churn
signal) but dropped the now-constant `auth_method` metadata tag → `%{}`; the
Logger line becomes a bare `"ws connect authenticated"`. The unrelated
IRC-credential `auth_method` (sasl/server_pass/nickserv/none) is a different field
and is untouched.

## nginx

The `/socket` `access_log off;` existed solely to keep the pre-#95 `?token=`
bearer out of logs. With the token off the URL, the shared snippet
(`infra/snippets/locations-api.conf`, included by both prod nginx and the e2e
`nginx-test.conf`) re-enables the default access log; the reference front-door
example (`nginx-tls-frontend.example.conf`) was reconciled too.

## Sweep of stale references (total consistency)

`config/config.exs` dropped the dead `:auth_method` Logger-metadata key + fixed
the `filter_parameters` comment; `cicchetto/src/lib/{socket,auth}.ts` stale
`?token=` comments corrected to the subprotocol reality.

## Tests

- TDD failing-assert first: a VALID bearer supplied only via the query string now
  returns `:error` (RED against the live fallback, GREEN after removal). Whole
  `user_socket_test.exs` + the two `admin_channel_test.exs` connects migrated to
  the subprotocol helper; telemetry describe asserts `%{count: 1}` with
  `metadata == %{}` (strong assert).
- e2e: the #95 `issue95-ws-token-subprotocol.spec.ts` "raw `?token=` still
  connects (server fallback)" test was **inverted** to assert the query-string
  handshake is now **rejected** — the e2e twin of the Elixir guard.

## Gates

- `scripts/check.sh`: green modulo the pre-existing bats #44 baseline —
  `8 doctests, 43 properties, 3847 tests, 0 failures`, dialyzer `Total errors: 0`,
  `wireTypes.ts is in sync`, doctor passed.
- cic: honest build exit 0, `check` 0-error-TS / 23 warnings baseline, vitest
  2973 passed.
- FULL `scripts/integration.sh`: **436 passed (12.9m), 0 failed, 0 flaky**.

## Deploy

**COLD** (nginx conf reload is the binding constraint; the auth-path code alone
would be HOT-reloadable) + ships with a cic bundle. **HELD** — rides the next
coordinated COLD window batched with the other HELD COLD work. Not deployed from
this PR.