### PR TITLE
auth: mode-1 login throttle + admin-demotion socket disconnect (S6 + S27)

### DIFF
--- a/cicchetto/src/AdminEventsTab.tsx
+++ b/cicchetto/src/AdminEventsTab.tsx
@@ -97,6 +97,9 @@ function renderEvent(ev: WireAdminEvent): string {
       return `${ev.user_name}@${ev.network_slug} credential updated (${ev.session_action})${actorSuffix(ev.actor_user_name)}`;
     case "credential_unbound":
       return `${ev.user_name} unbound from ${ev.network_slug}${actorSuffix(ev.actor_user_name)}`;
+    case "login_throttled":
+      // S6 — admin-login brute-force gate tripped for this source IP.
+      return `login throttled: ${ev.source_ip ?? "(unknown ip)"} hit ${ev.failures} failures in ${Math.round(ev.window_ms / 60000)}m`;
     default:
       return assertNever(ev);
   }

--- a/cicchetto/src/__tests__/friendlyApiError.test.ts
+++ b/cicchetto/src/__tests__/friendlyApiError.test.ts
@@ -65,6 +65,8 @@ const CASES: Array<{ code: string; matches: RegExp; info?: Record<string, unknow
   { code: "ssrf_blocked", matches: /url isn't allowed/i },
   { code: "fetch_failed", matches: /couldn't fetch that image url/i },
   { code: "image_reencode_failed", matches: /couldn't be processed/i },
+  // S6 (review 2026-07-19) — mode-1 login throttle.
+  { code: "too_many_attempts", matches: /too many login attempts/i },
 ];
 
 describe("friendlyApiError", () => {

--- a/cicchetto/src/lib/adminEvents.ts
+++ b/cicchetto/src/lib/adminEvents.ts
@@ -101,6 +101,7 @@ function ingest(ev: WireAdminEvent): void {
     case "credential_bound":
     case "credential_updated":
     case "credential_unbound":
+    case "login_throttled":
       setEvents((prev) => cap([ev, ...prev]));
       return;
     case "cap_counts_changed":

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -1409,6 +1409,17 @@ export type WireAdminEvent =
       actor_user_id: string;
       actor_user_name: string;
       at: string;
+    }
+  // S6 (review 2026-07-19) — a source IP crossed the mode-1 login
+  // failure threshold. Emitted once per (ip, window), on the crossing
+  // failure only. `source_ip` null mirrors the server's RemoteIP
+  // honesty (unresolvable peer).
+  | {
+      kind: "login_throttled";
+      source_ip: string | null;
+      failures: number;
+      window_ms: number;
+      at: string;
     };
 
 export type AdminSnapshotPayload = { events: WireAdminEvent[] };

--- a/cicchetto/src/lib/friendlyApiError.ts
+++ b/cicchetto/src/lib/friendlyApiError.ts
@@ -57,7 +57,8 @@ export type KnownApiErrorCode =
   | "too_large"
   | "ssrf_blocked"
   | "fetch_failed"
-  | "image_reencode_failed";
+  | "image_reencode_failed"
+  | "too_many_attempts";
 
 const KNOWN_CODES: ReadonlySet<KnownApiErrorCode> = new Set<KnownApiErrorCode>([
   "invalid_credentials",
@@ -87,6 +88,7 @@ const KNOWN_CODES: ReadonlySet<KnownApiErrorCode> = new Set<KnownApiErrorCode>([
   "ssrf_blocked",
   "fetch_failed",
   "image_reencode_failed",
+  "too_many_attempts",
 ]);
 
 function isKnownCode(code: string): code is KnownApiErrorCode {
@@ -234,6 +236,11 @@ function friendlyKnown(err: ApiError, code: KnownApiErrorCode): string {
       return "Couldn't fetch that image URL. Check the link, or upload a file instead.";
     case "image_reencode_failed":
       return "That image couldn't be processed. Try a different file.";
+    case "too_many_attempts":
+      // S6 (review 2026-07-19) — mode-1 login failure window tripped
+      // for this source IP. Time-bounded (15 min), unlike the
+      // themes-specific rate_limited "try tomorrow" copy.
+      return "Too many login attempts. Wait a few minutes and try again.";
     default:
       // Cic M2 reviewer fix: exhaustiveness assertion. Adding a token
       // to `KnownApiErrorCode` without a `case` arm above becomes a

--- a/cicchetto/src/lib/wireNarrow.ts
+++ b/cicchetto/src/lib/wireNarrow.ts
@@ -849,6 +849,22 @@ export function narrowAdminEvent(raw: unknown): WireAdminEvent | null {
         actor_user_name: r.actor_user_name,
         at: r.at as string,
       };
+    // S6 (review 2026-07-19) — mode-1 login throttle trip. source_ip
+    // is nullable (server RemoteIP honesty for unresolvable peers).
+    case "login_throttled":
+      if (
+        !isNullableString(r.source_ip) ||
+        typeof r.failures !== "number" ||
+        typeof r.window_ms !== "number"
+      )
+        return null;
+      return {
+        kind: "login_throttled",
+        source_ip: r.source_ip as string | null,
+        failures: r.failures,
+        window_ms: r.window_ms,
+        at: r.at as string,
+      };
     case "cap_counts_changed":
       // REV-H H5 (2026-05-22): network_slug is required non-null on
       // this arm. The server-side broadcaster early-returns when the

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -76,7 +76,8 @@ export type AdminEventsWireEventKind =
   | "server_removed"
   | "credential_bound"
   | "credential_updated"
-  | "credential_unbound";
+  | "credential_unbound"
+  | "login_throttled";
 
 export type AdminEventsWireCircuitOpenEvent = {
   kind: "circuit_open";
@@ -325,6 +326,14 @@ export type AdminEventsWireCredentialUnboundEvent = {
   at: string;
 };
 
+export type AdminEventsWireLoginThrottledEvent = {
+  kind: "login_throttled";
+  source_ip: string | null;
+  failures: number;
+  window_ms: number;
+  at: string;
+};
+
 export type AdminEventsWireEvent =
   | AdminEventsWireCircuitOpenEvent
   | AdminEventsWireCircuitCloseEvent
@@ -350,7 +359,8 @@ export type AdminEventsWireEvent =
   | AdminEventsWireServerRemovedEvent
   | AdminEventsWireCredentialBoundEvent
   | AdminEventsWireCredentialUpdatedEvent
-  | AdminEventsWireCredentialUnboundEvent;
+  | AdminEventsWireCredentialUnboundEvent
+  | AdminEventsWireLoginThrottledEvent;
 
 // === Grappa.ChannelDirectory.Wire ===
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -25694,3 +25694,37 @@ the burst source) is noted there too.
 
 _Deploy: **COLD** (server release rebuild — new module code). **HELD** — merge
 to main + push + HOLD; joins the batch, vjt deploys later._
+
+---
+
+## 2026-07-19 — Bucket B (review remediation): mode-1 login throttle + demotion disconnect
+
+Codebase review 2026-07-19, Bucket B. Closes the last open security
+MEDIUM (S6) and the S27 demotion residual.
+
+* **`Grappa.RateLimit.FailureWindow`** — per-(bucket, key) failure
+  counter over a fixed window. Check/record are SEPARATE verbs (unlike
+  DailyQuota's atomic pair): failure is only known after the bcrypt
+  compare, so `check/3` is a lock-free pre-gate and `record_failure/3`
+  advances only on failed attempts — successes never count, so an
+  operator cannot lock themselves out. Rows carry their own window and
+  a new-window insert sweeps every expired row (`select_delete`): keys
+  are unbounded source IPs, so the table bounds itself to keys with a
+  LIVE window rather than every IP ever seen (the DailyQuota
+  "bounded by subjects" argument doesn't transfer).
+* **Mode-1 gate** (`AuthController`): 10 failures / 15 min / source IP,
+  checked before the bcrypt work; trip → 422-sibling 429
+  `too_many_attempts` (distinct from `rate_limited`, whose cic copy is
+  themes-"try tomorrow"). The `:login_throttled` AdminEvents kind is
+  emitted ONCE per (ip, window) — on the exact crossing failure, never
+  on subsequent rejected requests — so a spray cannot flood the admin
+  stream. Kept separate from the visitor #171 admission cap on purpose:
+  same counter infrastructure, different policy axis (credential
+  guessing vs network capacity). nginx fail2ban (#160) remains
+  defense-in-depth, not the primary control.
+* **Demotion disconnect** (S27): admin `PATCH is_admin true→false` now
+  closes the target's WebSocket (mirror of the S8 rotation fix);
+  reconnect re-evaluates `is_admin` at `UserSocket.connect/3`, so
+  AdminChannel keeps its snapshot-at-connect design. Bearer sessions
+  are NOT revoked — demotion is a privilege change, not a credential
+  compromise.

--- a/lib/grappa/admin_events/wire.ex
+++ b/lib/grappa/admin_events/wire.ex
@@ -70,6 +70,7 @@ defmodule Grappa.AdminEvents.Wire do
           | :credential_bound
           | :credential_updated
           | :credential_unbound
+          | :login_throttled
 
   @type circuit_open_event :: %{
           kind: :circuit_open,
@@ -337,6 +338,21 @@ defmodule Grappa.AdminEvents.Wire do
           at: String.t()
         }
 
+  @typedoc """
+  S6 (review 2026-07-19) — a source IP crossed the mode-1 login
+  failure threshold and is now throttled for the rest of its window.
+  Emitted ONCE per (ip, window) — on the exact limit-crossing failure,
+  not on every subsequently rejected request — so a spray can't flood
+  the admin stream with its own rejections.
+  """
+  @type login_throttled_event :: %{
+          kind: :login_throttled,
+          source_ip: String.t() | nil,
+          failures: pos_integer(),
+          window_ms: pos_integer(),
+          at: String.t()
+        }
+
   @type event ::
           circuit_open_event()
           | circuit_close_event()
@@ -363,6 +379,7 @@ defmodule Grappa.AdminEvents.Wire do
           | credential_bound_event()
           | credential_updated_event()
           | credential_unbound_event()
+          | login_throttled_event()
 
   ## ----- Constructors --------------------------------------------------
   ##
@@ -1065,6 +1082,21 @@ defmodule Grappa.AdminEvents.Wire do
       network_slug: network_slug,
       actor_user_id: actor_user_id,
       actor_user_name: actor_user_name,
+      at: now()
+    }
+  end
+
+  @doc false
+  @spec login_throttled(String.t() | nil, pos_integer(), pos_integer()) ::
+          login_throttled_event()
+  def login_throttled(source_ip, failures, window_ms)
+      when (is_binary(source_ip) or is_nil(source_ip)) and is_integer(failures) and
+             failures > 0 and is_integer(window_ms) and window_ms > 0 do
+    %{
+      kind: :login_throttled,
+      source_ip: source_ip,
+      failures: failures,
+      window_ms: window_ms,
       at: now()
     }
   end

--- a/lib/grappa/application.ex
+++ b/lib/grappa/application.ex
@@ -158,6 +158,12 @@ defmodule Grappa.Application do
         # missing table. No upstream deps; writes funnel through its
         # GenServer for atomic check-and-record.
         Grappa.RateLimit.DailyQuota,
+        # S6 (review 2026-07-19) — per-(bucket, key) failure window.
+        # ETS-backed singleton, sibling of DailyQuota above: must exist
+        # before Endpoint so AuthController's mode-1 login throttle
+        # never races a missing table. Reads are lock-free; failure
+        # writes funnel through its GenServer.
+        Grappa.RateLimit.FailureWindow,
         # #252 — vhost reverse-DNS (PTR) name cache. ETS-backed singleton
         # sibling of Backoff / NetworkCircuit / ShareTokens: must exist
         # before Endpoint so `UserSettingsController.show_vhost/2`'s

--- a/lib/grappa/rate_limit.ex
+++ b/lib/grappa/rate_limit.ex
@@ -14,7 +14,10 @@ defmodule Grappa.RateLimit do
     * `DailyQuota` — per-(bucket, subject, day) creation quota
       (ETS-backed GenServer), consumed by `Grappa.Themes` for the
       ~5/day theme save+copy anti-abuse cap (#75).
+    * `FailureWindow` — per-(bucket, key) failure counter over a fixed
+      window (ETS-backed GenServer), consumed by the mode-1 login
+      brute-force gate (S6, codebase review 2026-07-19).
   """
 
-  use Boundary, top_level?: true, deps: [], exports: [JitteredCooldown, DailyQuota]
+  use Boundary, top_level?: true, deps: [], exports: [JitteredCooldown, DailyQuota, FailureWindow]
 end

--- a/lib/grappa/rate_limit/failure_window.ex
+++ b/lib/grappa/rate_limit/failure_window.ex
@@ -1,0 +1,146 @@
+defmodule Grappa.RateLimit.FailureWindow do
+  @moduledoc """
+  Per-`(bucket, key)` failure counter over a fixed time window —
+  brute-force friction for the mode-1 (admin) login path (S6, codebase
+  review 2026-07-19) and any future "N failures per window per key"
+  gate.
+
+  ## Check / record are separate verbs
+
+  Unlike `Grappa.RateLimit.DailyQuota`'s atomic `check_and_record/3`,
+  the caller here cannot know at check time whether the attempt will
+  fail — the failure is known only after the (expensive) credential
+  compare. So `check/3` is a lock-free ETS read gating the request
+  BEFORE the bcrypt work, and `record_failure/3` is called only on a
+  failed attempt. Successes never advance the counter, so a legitimate
+  operator can never lock themselves out. Two concurrent requests can
+  both pass `check/3` and both record — the threshold is approximate
+  by ±concurrency, which is fine for login friction (the bound matters
+  at 10s-to-100s of attempts, not ±2).
+
+  ## Self-resetting, self-bounding
+
+  Row shape: `{ {bucket, key}, window_started_ms, window_ms, count }`
+  (monotonic ms; each row carries its own window length so buckets with
+  different windows can share the table). A row past its window is
+  treated as absent by both verbs — the counter resets with no sweeper
+  process. Because keys are caller-controlled (source IPs — unbounded,
+  unlike DailyQuota's subject keys), starting a NEW window additionally
+  `select_delete`s every expired row: the table scan is amortized over
+  first-failures (rare) and keeps table size bounded by keys with a
+  LIVE window, not by every key ever seen.
+
+  Writes are serialized through the GenServer (Backoff / DailyQuota
+  model); reads are direct ETS.
+  """
+  use GenServer
+
+  @table :rate_limit_failure_window
+
+  @typep key :: {atom(), term()}
+
+  @doc """
+  ETS table atom, single-sourced for substrate checks and tests.
+  """
+  @spec table_name() :: :rate_limit_failure_window
+  def table_name, do: @table
+
+  @doc false
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @doc """
+  Whether `(bucket, key)` is under `limit` failures in its live window.
+  `:ok` when under (or no live window); `{:error, :limited}` at/over.
+  Lock-free read — call this BEFORE the expensive work it gates.
+  """
+  @spec check(atom(), term(), pos_integer()) :: :ok | {:error, :limited}
+  def check(bucket, key, limit) when is_atom(bucket) and is_integer(limit) and limit > 0 do
+    check(bucket, key, limit, now_ms())
+  end
+
+  @doc """
+  Same as `check/3` with an explicit monotonic `now_ms` — the test seam
+  for deterministic window-expiry coverage.
+  """
+  @spec check(atom(), term(), pos_integer(), integer()) :: :ok | {:error, :limited}
+  def check(bucket, key, limit, now_ms)
+      when is_atom(bucket) and is_integer(limit) and limit > 0 and is_integer(now_ms) do
+    case live_count({bucket, key}, now_ms) do
+      count when count >= limit -> {:error, :limited}
+      _ -> :ok
+    end
+  end
+
+  @doc """
+  Records one failure for `(bucket, key)`, opening a fresh `window_ms`
+  window when none is live. Returns the count within the live window
+  AFTER this record — the caller can detect the exact limit-crossing
+  (`count == limit`) to emit once-per-window operator signals.
+  """
+  @spec record_failure(atom(), term(), pos_integer()) :: pos_integer()
+  def record_failure(bucket, key, window_ms)
+      when is_atom(bucket) and is_integer(window_ms) and window_ms > 0 do
+    record_failure(bucket, key, window_ms, now_ms())
+  end
+
+  @doc """
+  Same as `record_failure/3` with an explicit monotonic `now_ms` (test
+  seam).
+  """
+  @spec record_failure(atom(), term(), pos_integer(), integer()) :: pos_integer()
+  def record_failure(bucket, key, window_ms, now_ms)
+      when is_atom(bucket) and is_integer(window_ms) and window_ms > 0 and is_integer(now_ms) do
+    GenServer.call(__MODULE__, {:record_failure, {bucket, key}, window_ms, now_ms})
+  end
+
+  ## GenServer
+
+  @impl GenServer
+  def init(_) do
+    _ = :ets.new(@table, [:named_table, :set, :public, read_concurrency: true])
+    {:ok, %{}}
+  end
+
+  @impl GenServer
+  def handle_call({:record_failure, key, window_ms, now_ms}, _, state) do
+    count =
+      case :ets.lookup(@table, key) do
+        [{^key, started, row_window, count}] when now_ms - started < row_window ->
+          true = :ets.insert(@table, {key, started, row_window, count + 1})
+          count + 1
+
+        _ ->
+          # New window — sweep every expired row first so the table is
+          # bounded by keys with a LIVE window (keys are unbounded IPs).
+          sweep_expired(now_ms)
+          true = :ets.insert(@table, {key, now_ms, window_ms, 1})
+          1
+      end
+
+    {:reply, count, state}
+  end
+
+  @spec live_count(key(), integer()) :: non_neg_integer()
+  defp live_count(key, now_ms) do
+    case :ets.lookup(@table, key) do
+      [{^key, started, window_ms, count}] when now_ms - started < window_ms -> count
+      _ -> 0
+    end
+  end
+
+  @spec sweep_expired(integer()) :: :ok
+  defp sweep_expired(now_ms) do
+    match_spec = [
+      {{:_, :"$1", :"$2", :_}, [{:>=, {:-, now_ms, :"$1"}, :"$2"}], [true]}
+    ]
+
+    _ = :ets.select_delete(@table, match_spec)
+    :ok
+  end
+
+  @spec now_ms() :: integer()
+  defp now_ms, do: System.monotonic_time(:millisecond)
+end

--- a/lib/grappa_web.ex
+++ b/lib/grappa_web.ex
@@ -34,6 +34,7 @@ defmodule GrappaWeb do
         Grappa.PubSub,
         Grappa.Push,
         Grappa.Push.BadgeCount,
+        Grappa.RateLimit,
         Grappa.QueryWindows,
         Grappa.ReadCursor,
         Grappa.Scrollback,

--- a/lib/grappa_web/controllers/admin/users_controller.ex
+++ b/lib/grappa_web/controllers/admin/users_controller.ex
@@ -71,6 +71,7 @@ defmodule GrappaWeb.Admin.UsersController do
     with {:ok, attrs} <- admin_attrs(params),
          %Grappa.Accounts.User{} = user <- Accounts.get_user(id),
          {:ok, updated} <- Accounts.update_admin_flags(user, attrs) do
+      :ok = maybe_disconnect_on_demotion(user, updated)
       :ok = maybe_emit_user_updated(user, updated, conn)
       counts = LiveIntrospection.count_sessions_by_user()
       json(conn, AdminWire.user_to_admin_json(updated, Map.get(counts, updated.id, 0)))
@@ -79,6 +80,23 @@ defmodule GrappaWeb.Admin.UsersController do
       other -> other
     end
   end
+
+  # S27 (review 2026-07-19) — a demoted admin's already-open socket kept
+  # `is_admin: true` in its connect-time assigns and went on receiving
+  # the `grappa:admin:events` stream until it happened to reconnect.
+  # Mirror the S8 rotation fix one field over: close the socket on the
+  # true→false transition; reconnect re-evaluates `is_admin` at
+  # `UserSocket.connect/3`, so AdminChannel keeps its snapshot-at-connect
+  # design with no per-message re-check. Bearer sessions are NOT revoked
+  # (demotion is a privilege change, not a credential compromise — the
+  # user stays logged in as a non-admin after the reconnect); promotion
+  # keeps the socket (no privilege to withdraw mid-flight).
+  @spec maybe_disconnect_on_demotion(Grappa.Accounts.User.t(), Grappa.Accounts.User.t()) :: :ok
+  defp maybe_disconnect_on_demotion(%{is_admin: true}, %{is_admin: false} = updated) do
+    :ok = UserSocket.disconnect_subject({:user, updated})
+  end
+
+  defp maybe_disconnect_on_demotion(_, _), do: :ok
 
   @doc """
   Admin-panel bucket 2 — create a user. Body: `name`, `password`,

--- a/lib/grappa_web/controllers/auth_controller.ex
+++ b/lib/grappa_web/controllers/auth_controller.ex
@@ -32,8 +32,10 @@ defmodule GrappaWeb.AuthController do
   """
   use GrappaWeb, :controller
 
-  alias Grappa.{Accounts, Networks, Session, Visitors}
+  alias Grappa.{Accounts, AdminEvents, Networks, Session, Visitors}
+  alias Grappa.AdminEvents.Wire, as: AdminEventsWire
   alias Grappa.Auth.IdentifierClassifier
+  alias Grappa.RateLimit.FailureWindow
   alias Grappa.Visitors.{Login, Visitor}
   alias GrappaWeb.RemoteIP
 
@@ -78,6 +80,7 @@ defmodule GrappaWeb.AuthController do
              | :network_ambiguous
              | :network_unconfigured
              | :invalid_credentials
+             | :too_many_attempts
              | :upstream_unreachable
              | :connect_timeout
              | :welcome_timeout
@@ -274,12 +277,14 @@ defmodule GrappaWeb.AuthController do
     # column; for now the dispatch routes by `@` presence but the lookup
     # uses the local-part as the user `name`.
     name = email |> String.split("@", parts: 2) |> List.first()
+    ip = format_ip(conn)
 
-    with {:ok, user} <- Accounts.get_user_by_credentials(name, password) do
+    with :ok <- check_mode1_throttle(ip),
+         {:ok, user} <- authenticate_mode1(name, password, ip) do
       {:ok, session} =
         Accounts.create_session(
           {:user, user.id},
-          format_ip(conn),
+          ip,
           user_agent(conn),
           client_id: conn.assigns[:current_client_id]
         )
@@ -287,6 +292,51 @@ defmodule GrappaWeb.AuthController do
       conn
       |> put_status(:ok)
       |> render(:login, token: session.id, subject: {:user, user})
+    end
+  end
+
+  # S6 (review 2026-07-19) — brute-force friction for the mode-1 branch.
+  # The visitor branch has the #171 per-IP admission cap + captcha; this
+  # branch had only bcrypt cost. Per-source-IP FAILURE counter, checked
+  # BEFORE the bcrypt compare (a throttled IP costs no hashing work) and
+  # advanced only on failed attempts — a legitimate operator's correct
+  # login never counts toward their own lockout, and a spraying attacker
+  # gets `@mode1_max_failures` bcrypt-priced guesses per window per IP.
+  # Distinct from the visitor admission machinery on purpose: same
+  # counter INFRASTRUCTURE (Grappa.RateLimit), separate bucket — merging
+  # them would couple network-capacity policy to credential-guessing
+  # policy. nginx fail2ban (#160) is defense-in-depth on top, not the
+  # primary control.
+  @mode1_bucket :mode1_login
+  @mode1_max_failures 10
+  @mode1_window_ms :timer.minutes(15)
+
+  @spec check_mode1_throttle(String.t() | nil) :: :ok | {:error, :too_many_attempts}
+  defp check_mode1_throttle(ip) do
+    case FailureWindow.check(@mode1_bucket, ip, @mode1_max_failures) do
+      :ok -> :ok
+      {:error, :limited} -> {:error, :too_many_attempts}
+    end
+  end
+
+  @spec authenticate_mode1(String.t() | nil, String.t(), String.t() | nil) ::
+          {:ok, Grappa.Accounts.User.t()} | {:error, :invalid_credentials}
+  defp authenticate_mode1(name, password, ip) do
+    case Accounts.get_user_by_credentials(name, password) do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, _} = err ->
+        count = FailureWindow.record_failure(@mode1_bucket, ip, @mode1_window_ms)
+
+        # Exactly-once-per-window operator signal: emit on the crossing
+        # failure only, never on the (attacker-driven) rejected requests
+        # that follow — a spray can't flood the admin stream.
+        if count == @mode1_max_failures do
+          AdminEvents.record(AdminEventsWire.login_throttled(ip, count, @mode1_window_ms))
+        end
+
+        err
     end
   end
 

--- a/lib/grappa_web/controllers/fallback_controller.ex
+++ b/lib/grappa_web/controllers/fallback_controller.ex
@@ -202,6 +202,16 @@ defmodule GrappaWeb.FallbackController do
     |> json(%{error: "rate_limited"})
   end
 
+  # S6 (review 2026-07-19) — mode-1 login source IP crossed the failure
+  # window (`AuthController.check_mode1_throttle/1`). 429 with a
+  # DISTINCT token: `rate_limited` carries themes-specific "try
+  # tomorrow" copy on cic; this one needs "wait a few minutes".
+  def call(conn, {:error, :too_many_attempts}) do
+    conn
+    |> put_status(:too_many_requests)
+    |> json(%{error: "too_many_attempts"})
+  end
+
   # #299 item 8 — a visitor hit the 50-total owned-theme cap. 429 like
   # :rate_limited, but a DISTINCT wire string so cic can render a
   # cap-specific "delete a theme to make room" hint (vs "try tomorrow").

--- a/test/grappa/admin_events/wire_test.exs
+++ b/test/grappa/admin_events/wire_test.exs
@@ -73,6 +73,22 @@ defmodule Grappa.AdminEvents.WireTest do
     end
   end
 
+  describe "login_throttled/3" do
+    test "renders the typed wire shape" do
+      event = Wire.login_throttled("203.0.113.7", 10, 900_000)
+      assert event.kind == :login_throttled
+      assert event.source_ip == "203.0.113.7"
+      assert event.failures == 10
+      assert event.window_ms == 900_000
+      assert is_binary(event.at)
+    end
+
+    test "accepts nil source_ip (unresolvable peer honesty)" do
+      event = Wire.login_throttled(nil, 10, 900_000)
+      assert event.source_ip == nil
+    end
+  end
+
   describe "visitor_deleted/4" do
     test "renders with actor" do
       event =

--- a/test/grappa/rate_limit/failure_window_test.exs
+++ b/test/grappa/rate_limit/failure_window_test.exs
@@ -1,0 +1,61 @@
+defmodule Grappa.RateLimit.FailureWindowTest do
+  # async: false — asserts against the shared, application-started ETS singleton.
+  use ExUnit.Case, async: false
+
+  alias Grappa.RateLimit.FailureWindow
+
+  @window :timer.minutes(15)
+
+  setup do
+    :ets.delete_all_objects(FailureWindow.table_name())
+    :ok
+  end
+
+  test "check/3 is :ok with no recorded failures" do
+    assert :ok == FailureWindow.check(:test_bucket, "10.0.0.1", 10)
+  end
+
+  test "check blocks at the limit, not before" do
+    key = "10.0.0.2"
+    for _ <- 1..9, do: FailureWindow.record_failure(:test_bucket, key, @window)
+    assert :ok == FailureWindow.check(:test_bucket, key, 10)
+
+    FailureWindow.record_failure(:test_bucket, key, @window)
+    assert {:error, :limited} == FailureWindow.check(:test_bucket, key, 10)
+  end
+
+  test "record_failure returns the running count — the crossing is detectable" do
+    key = "10.0.0.3"
+    counts = for _ <- 1..3, do: FailureWindow.record_failure(:test_bucket, key, @window)
+    assert counts == [1, 2, 3]
+  end
+
+  test "a window expires: blocked key is clean again past window_ms" do
+    key = "10.0.0.4"
+    for _ <- 1..10, do: FailureWindow.record_failure(:test_bucket, key, @window, 0)
+
+    assert {:error, :limited} == FailureWindow.check(:test_bucket, key, 10, @window - 1)
+    assert :ok == FailureWindow.check(:test_bucket, key, 10, @window)
+
+    # A failure past expiry opens a FRESH window at count 1.
+    assert 1 == FailureWindow.record_failure(:test_bucket, key, @window, @window + 1)
+  end
+
+  test "distinct keys and distinct buckets are independent" do
+    for _ <- 1..10, do: FailureWindow.record_failure(:test_bucket, "10.0.0.5", @window)
+
+    assert {:error, :limited} == FailureWindow.check(:test_bucket, "10.0.0.5", 10)
+    assert :ok == FailureWindow.check(:test_bucket, "10.0.0.6", 10)
+    assert :ok == FailureWindow.check(:other_bucket, "10.0.0.5", 10)
+  end
+
+  test "opening a new window sweeps every expired row (table stays bounded)" do
+    stale = {:test_bucket, "10.9.9.9"}
+    FailureWindow.record_failure(:test_bucket, "10.9.9.9", @window, 0)
+    assert [_] = :ets.lookup(FailureWindow.table_name(), stale)
+
+    # A first-failure far past the stale row's expiry triggers the sweep.
+    FailureWindow.record_failure(:test_bucket, "10.8.8.8", @window, @window * 2)
+    assert [] == :ets.lookup(FailureWindow.table_name(), stale)
+  end
+end

--- a/test/grappa_web/controllers/admin/users_controller_test.exs
+++ b/test/grappa_web/controllers/admin/users_controller_test.exs
@@ -28,6 +28,7 @@ defmodule GrappaWeb.Admin.UsersControllerTest do
 
   alias Grappa.{Accounts, AdminEvents, AdmissionStateHelpers}
   alias Grappa.PubSub.Topic
+  alias GrappaWeb.UserSocket
 
   setup do
     AdmissionStateHelpers.reset_session_supervisor()
@@ -136,6 +137,37 @@ defmodule GrappaWeb.Admin.UsersControllerTest do
 
       body = json_response(conn, 200)
       assert body["is_admin"] == false
+    end
+
+    test "S27: demotion broadcasts disconnect on the target's socket topic", %{conn: conn} do
+      target = user_fixture(name: "demote-#{System.unique_integer([:positive])}")
+      {:ok, promoted} = Accounts.update_admin_flags(target, %{is_admin: true})
+      :ok = GrappaWeb.Endpoint.subscribe(UserSocket.id_for_subject({:user, promoted}))
+
+      session = admin_session()
+
+      conn
+      |> put_bearer(session.id)
+      |> put_req_header("content-type", "application/json")
+      |> patch("/admin/users/#{target.id}", Jason.encode!(%{is_admin: false}))
+      |> json_response(200)
+
+      assert_receive %Phoenix.Socket.Broadcast{event: "disconnect"}, 500
+    end
+
+    test "S27: promotion does NOT disconnect the socket", %{conn: conn} do
+      target = user_fixture(name: "promote-#{System.unique_integer([:positive])}")
+      :ok = GrappaWeb.Endpoint.subscribe(UserSocket.id_for_subject({:user, target}))
+
+      session = admin_session()
+
+      conn
+      |> put_bearer(session.id)
+      |> put_req_header("content-type", "application/json")
+      |> patch("/admin/users/#{target.id}", Jason.encode!(%{is_admin: true}))
+      |> json_response(200)
+
+      refute_receive %Phoenix.Socket.Broadcast{event: "disconnect"}, 200
     end
 
     test "404 on unknown id", %{conn: conn} do

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -826,4 +826,93 @@ defmodule GrappaWeb.AuthControllerTest do
       assert is_nil(Repo.get(Visitor, visitor.id))
     end
   end
+
+  # ----- mode-1 throttle helpers (S6) — module level; ExUnit forbids
+  # defp inside describe. Each test gets its own source IP: the
+  # throttle is per-IP, so a unique address isolates the counter from
+  # the sibling describes (all on 127.0.0.1) and across reruns.
+  defp with_ip(conn, d), do: %{conn | remote_ip: {10, 66, 0, d}}
+
+  defp wrong_login(conn, user, d) do
+    conn
+    |> with_ip(d)
+    |> post("/auth/login", %{"identifier" => "#{user.name}@x.com", "password" => "WRONG-pw"})
+  end
+
+  describe "POST /auth/login mode-1 throttle (S6, review 2026-07-19)" do
+    # The counter table is a global ETS singleton; clear it so failures
+    # recorded by the sibling describes can't bleed into these
+    # assertions, and vice versa.
+    setup do
+      :ets.delete_all_objects(Grappa.RateLimit.FailureWindow.table_name())
+      :ok
+    end
+
+    test "the 11th attempt is 429 too_many_attempts even with the correct password", %{
+      conn: conn
+    } do
+      {user, password} = user_fixture_with_password()
+
+      for _ <- 1..10 do
+        assert json_response(wrong_login(conn, user, 1), 401)["error"] == "invalid_credentials"
+      end
+
+      conn =
+        conn
+        |> with_ip(1)
+        |> post("/auth/login", %{"identifier" => "#{user.name}@x.com", "password" => password})
+
+      assert json_response(conn, 429) == %{"error" => "too_many_attempts"}
+      assert session_count() == 0
+    end
+
+    test "successful logins never advance the counter", %{conn: conn} do
+      {user, password} = user_fixture_with_password()
+
+      for _ <- 1..9, do: wrong_login(conn, user, 2)
+
+      ok_conn =
+        conn
+        |> with_ip(2)
+        |> post("/auth/login", %{"identifier" => "#{user.name}@x.com", "password" => password})
+
+      assert json_response(ok_conn, 200)["token"]
+
+      # 10th FAILURE (not 11th attempt) — still 401: the success above
+      # did not count, and the limit check precedes this failure.
+      assert json_response(wrong_login(conn, user, 2), 401)["error"] == "invalid_credentials"
+    end
+
+    test "a tripped IP doesn't affect logins from another IP", %{conn: conn} do
+      {user, password} = user_fixture_with_password()
+
+      for _ <- 1..10, do: wrong_login(conn, user, 3)
+      assert json_response(wrong_login(conn, user, 3), 429)["error"] == "too_many_attempts"
+
+      other =
+        conn
+        |> with_ip(4)
+        |> post("/auth/login", %{"identifier" => "#{user.name}@x.com", "password" => password})
+
+      assert json_response(other, 200)["token"]
+    end
+
+    test "crossing the limit emits :login_throttled exactly once", %{conn: conn} do
+      {user, _} = user_fixture_with_password()
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Grappa.PubSub.Topic.admin_events())
+
+      for _ <- 1..10, do: wrong_login(conn, user, 5)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: "grappa:admin:events",
+                       payload: %{kind: :login_throttled, source_ip: "10.66.0.5", failures: 10}
+                     },
+                     500
+
+      # Post-trip rejected requests must NOT re-emit (the spray would
+      # flood the admin stream with its own rejections).
+      _ = wrong_login(conn, user, 5)
+      refute_receive %Phoenix.Socket.Broadcast{payload: %{kind: :login_throttled}}, 200
+    end
+  end
 end


### PR DESCRIPTION
Bucket B of the 2026-07-19 codebase-review remediation — closes the last open security MEDIUM (S6) and the S27 demotion residual. Sibling of the Bucket A commits already on #328.

## S6 — mode-1 login brute-force gate

The visitor branch has the #171 per-IP admission cap + captcha; the mode-1 (admin) branch had only bcrypt cost, so operator passwords could be brute-forced at hashing speed.

- **`Grappa.RateLimit.FailureWindow`** (new) — per-(bucket, key) failure counter over a fixed window. Check/record are deliberately SEPARATE verbs (unlike `DailyQuota`'s atomic pair): failure is only known after the bcrypt compare, so `check/3` is a lock-free ETS pre-gate and `record_failure/3` advances on failures only — a legitimate operator's correct login never counts toward their own lockout. Rows carry their own window; opening a new window sweeps every expired row (`select_delete`), so the table bounds itself to keys with a LIVE window rather than every source IP ever seen.
- **Gate**: 10 failures / 15 min / source IP in `mode1_login`, checked before the bcrypt work. Trip → **429 `too_many_attempts`** (distinct token — `rate_limited` carries themes-specific "try tomorrow" copy on cic).
- **Operator visibility**: new `:login_throttled` AdminEvents kind, emitted exactly ONCE per (ip, window) on the crossing failure — never on the rejected requests that follow, so a spray can't flood the admin stream with its own rejections. cic mirrors the arm (narrower + Events-tab label + ring ingest; the `assertNever` gates forced every site) and localizes the 429.
- Deliberately separate from the visitor admission machinery: same counter infrastructure, different policy axis (credential guessing vs network capacity). nginx fail2ban (#160) stays defense-in-depth, not the primary control.

## S27 — demotion closes the socket

A demoted admin's already-open socket kept `is_admin: true` in its connect-time assigns and went on receiving `grappa:admin:events` until it happened to reconnect. `PATCH is_admin true→false` now closes the target's WebSocket — the S8 rotation fix one field over. Reconnect re-evaluates `is_admin` at `UserSocket.connect/3`, so AdminChannel keeps its snapshot-at-connect design. Bearer sessions are NOT revoked (demotion is a privilege change, not a credential compromise); promotion keeps the socket.

## Testing

- New: `FailureWindow` unit suite (threshold edge, crossing-count, window expiry via the explicit-now seam, per-key/per-bucket independence, sweep-bounds-the-table); auth throttle request specs (11th-attempt 429 even with the correct password, successes never count, per-IP independence, exactly-once `:login_throttled` emit); demotion/promotion socket-broadcast specs; `login_throttled/3` wire-shape specs.
- Gates run locally: scoped ExUnit for every touched suite (auth 36, users 42+2, wire 59, failure_window), `mix format`, `credo --strict`, `dialyzer` (0 errors), `sobelow`, `mix grappa.gen_wire_types --check` (regen committed), cic `bun run check` + scoped vitest. Full e2e left to CI per the Windows-host constraint discussed on #328.

Deploy note: **COLD** — supervision-tree child addition (`FailureWindow`) + cic bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)