### PR TITLE
fix(#247): route 512/734 presence-watch list-full numerics to $server

### DIFF
--- a/lib/grappa/session/numeric_router.ex
+++ b/lib/grappa/session/numeric_router.ex
@@ -193,7 +193,32 @@ defmodule Grappa.Session.NumericRouter do
                          # 437 ERR_UNAVAILRESOURCE — nick temporarily unavailable
                          437,
                          # 461 ERR_NEEDMOREPARAMS — command missing required params
-                         461
+                         461,
+                         # #247 — presence-watch list-full errors. EventRouter's
+                         # 512/734 handlers emit a {:presence_error, :list_full}
+                         # toast and return `:cont`, so the raw numeric ALSO
+                         # falls through here — and per the #247 contract it
+                         # must land as a `$server` :notice (the durable
+                         # "list full" record; the toast is transient). Their
+                         # params carry a nick-shaped token that is NOT a
+                         # routing destination — the WATCHed nick (512) / the
+                         # rejected MONITOR target (734). Pre-fix the param scan
+                         # routed it to `{:query, <nick>}`, ghosting a query
+                         # window named after the watched nick (and leaking it
+                         # into Archive via list_archive's
+                         # COALESCE(dm_with, channel)) — the exact disease as
+                         # the 004/042 connect-storm ghosts above. Both belong
+                         # on `$server`.
+                         #
+                         # 512 ERR_TOOMANYWATCH (bahamut/Azzurra) — params:
+                         #     [own_nick, watched_nick, "Maximum size for
+                         #      WATCH-list is <n>"]. Ghosts on WATCH add once
+                         #      the list is full.
+                         # 734 ERR_MONLISTFULL (solanum MONITOR) — params:
+                         #     [own_nick, limit, targets, "Monitor list is
+                         #      full."]. Ghosts when a single target is rejected.
+                         512,
+                         734
                        ]
                    )
 

--- a/test/grappa/session/numeric_router_test.exs
+++ b/test/grappa/session/numeric_router_test.exs
@@ -131,7 +131,11 @@ defmodule Grappa.Session.NumericRouterTest do
   # acks owned by EventRouter's away_confirmed handler and must NEVER
   # persist a scrollback row (the away STATE is the signal, the numeric
   # is noise). See the delegated-numerics section below.
-  @active_numerics [4, 42, 263, 421, 432, 433, 437, 461] ++
+  # #247 — 512/734 presence-watch list-full errors folded in: nick-shaped
+  # token (watched nick / rejected MONITOR target) that is metadata, not a
+  # query destination. The EventRouter toast is transient; the raw numeric
+  # must land on $server (durable "list full" record).
+  @active_numerics [4, 42, 263, 421, 432, 433, 437, 461, 512, 734] ++
                      Enum.to_list(211..219) ++ Enum.to_list(240..250)
 
   describe "@active_numerics deny list → {:server, nil}" do
@@ -184,6 +188,25 @@ defmodule Grappa.Session.NumericRouterTest do
 
     test "461 ERR_NEEDMOREPARAMS: command name is NOT a query destination" do
       m = msg(461, ["vjt", "MODE", "Not enough parameters"])
+      assert {:server, nil} = NumericRouter.route(m, state())
+    end
+
+    # #247 — presence-watch list-full errors. EventRouter emits a
+    # {:presence_error, :list_full} toast (:cont) and the raw numeric ALSO
+    # falls through here. Pre-fix the param scan ghosted it to a
+    # {:query, <nick>} window named after the watched/rejected nick (leaking
+    # into Archive); it must land on $server per the #247 contract.
+    test "512 ERR_TOOMANYWATCH: watched nick is NOT a query destination (#247)" do
+      # bahamut/Azzurra WATCH list-full. params[1] "watchednick" is
+      # nick-shaped → pre-fix {:query, "watchednick"}; now $server.
+      m = msg(512, ["vjt", "watchednick", "Maximum size for WATCH-list is 128"])
+      assert {:server, nil} = NumericRouter.route(m, state())
+    end
+
+    test "734 ERR_MONLISTFULL: rejected MONITOR target is NOT a query destination (#247)" do
+      # solanum MONITOR list-full. The single rejected target "rejectednick"
+      # is nick-shaped → pre-fix {:query, "rejectednick"}; now $server.
+      m = msg(734, ["vjt", "100", "rejectednick", "Monitor list is full."])
       assert {:server, nil} = NumericRouter.route(m, state())
     end
 


### PR DESCRIPTION
## What

Adds `ERR_TOOMANYWATCH` (512, bahamut WATCH) and `ERR_MONLISTFULL` (734, solanum MONITOR) to `NumericRouter`'s `@active_numerics` deny list, so they route to `{:server, nil}` instead of a `{:query, <nick>}` window.

## Why (bug)

Both handlers in `EventRouter` (734 emits at `event_router.ex:1665`, 512 at `:1680`) fire a `{:presence_error, :list_full}` toast and return `:cont`, so the raw numeric ALSO falls through to `NumericRouter`. Because neither code was in `@active_numerics`, `scan_params/2` matched the nick-shaped token in the params — the WATCHed nick (512) / the rejected MONITOR target (734) — and routed the persisted row to `{:query, <nick>}`.

Result: a ghost query window named after the watched nick, plus a leak into the per-network Archive via `Scrollback.list_archive`'s `COALESCE(dm_with, channel)` GROUP BY. This contradicts the #247 routing contract (the numeric must land on `$server`); the handler comment claiming "the numeric ALSO lands as a $server notice" was in fact false without a deny-list entry — same disease shape as the 004/042 connect-storm ghosts.

- **512** ghosts on every WATCH add once the list is full — reachable on Azzurra/bahamut, the live ircd.
- **734** ghosts when a single MONITOR target is rejected (solanum).

## What changed

- `numeric_router.ex` — `512`, `734` added to `@active_numerics` (same pattern as 421/432/433/461). The `EventRouter` list-full toast is unchanged (transient); the raw numeric now persists as the durable `$server` :notice the contract expects.
- `numeric_router_test.exs` — two drift-pin tests (512/734 → `{:server, nil}`) + the test-side `@active_numerics` mirror updated so the existing property covers them.

## Notes

- Server-side only, no cicchetto change → takes effect at the next **cold** deploy (BEAM restart), not hot.
- Surfaced by a security review of the #247 notify/presence-watch feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
