### PR TITLE
infra: native Linux (systemd) deploy path, with hot/cold Preflight support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -578,8 +578,14 @@ is due. Don't just look at todo.md.
   change touches more than ~10 files unexpectedly, stop and confirm
   before continuing.
 - **Don't iterate through 10 wrong approaches.** Stop, think, ask.
-- **Don't propose split environments.** One Docker Compose stack. No
-  systemd, no bare `mix run`, no `infra/dev` vs `infra/prod`.
+- **Don't propose split dev environments.** Local dev is one Docker
+  Compose stack — no `infra/dev` vs `infra/prod` for development.
+  Production is substrate-plural by design: the FreeBSD bastille jail
+  (`infra/freebsd/`, prod since the m42 deploy) and the native Linux
+  systemd host (`infra/linux/`) are both supported, Docker-free
+  production paths — systemd and `mix release` for prod are not
+  off-limits, they're already how this ships. Don't propose a *third*
+  production substrate without discussing it first.
 - **NEVER run raw `docker compose`** — use `scripts/*.sh`. Always.
 - **NEVER `mix` on the host** — the container is the runtime.
 - **NEVER install hex packages on the host.** Add them to `mix.exs`,

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -439,13 +439,11 @@ infra/linux/release.sh   # bin/grappa wrapper: version / eval / remote
 ```
 
 No SSH-to-a-separate-host indirection — run these directly on the
-target box as root. **Cold-only in v1 scope** (per `LINUX.md`'s
-original decision): `deploy.sh` always does a full stop → rebuild →
-migrate → start cycle, no hot/cold `Preflight` classification like the
-Docker/jail substrates. If that gap starts to hurt (frequent deploys,
-session-drop-sensitive usage), port `Grappa.Deploy.Preflight` here
-following the same pattern — not done yet because a first install
-should stay simple.
+target box as root. `deploy.sh` is preflight-driven, same as the
+Docker/jail substrates: `Grappa.Deploy.Preflight` classifies each
+deploy's diff and picks hot (rebuild + `POST /admin/reload`, sessions
+preserved) or cold (full stop → rebuild → migrate → start cycle)
+automatically — see `infra/linux/README.md` "Day-2 operations".
 
 Stop/start synchronization (the FreeBSD jail's `jail_beam_wait.sh`
 problem, defect #9) is solved differently here: the systemd unit runs

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -425,6 +425,35 @@ at restart time — `--full-restart` does NOT touch it.** Never rehearsed
 against prod (it bounces the live jail + drops every session); bats-proven
 only — first real run is operator-driven.
 
+### Linux (systemd) — no host wrapper needed
+
+A third production substrate for a plain Ubuntu/Debian host, no
+Docker, no jail. Full setup + day-2 ops runbook lives in
+`infra/linux/README.md`; summary here for parity with the m42 section
+above:
+
+```
+infra/linux/install.sh   # first install, idempotent (see README.md for env)
+infra/linux/deploy.sh    # update: pull, rebuild, migrate, restart, healthcheck
+infra/linux/release.sh   # bin/grappa wrapper: version / eval / remote
+```
+
+No SSH-to-a-separate-host indirection — run these directly on the
+target box as root. **Cold-only in v1 scope** (per `LINUX.md`'s
+original decision): `deploy.sh` always does a full stop → rebuild →
+migrate → start cycle, no hot/cold `Preflight` classification like the
+Docker/jail substrates. If that gap starts to hurt (frequent deploys,
+session-drop-sensitive usage), port `Grappa.Deploy.Preflight` here
+following the same pattern — not done yet because a first install
+should stay simple.
+
+Stop/start synchronization (the FreeBSD jail's `jail_beam_wait.sh`
+problem, defect #9) is solved differently here: the systemd unit runs
+`bin/grappa start` in the **foreground** under `Type=exec`, so
+`systemctl stop`/`restart` block natively until the BEAM actually
+exits — no custom wrapper needed. See
+`infra/linux/systemd/grappa.service`'s comments for the full rationale.
+
 ### Running operator actions against the live jail (prod)
 
 Prod is a **bastille jail** (name `grappa`, `/usr/local/bastille/jails/grappa/root`,
@@ -753,7 +782,9 @@ don't hardcode hostnames there.
   the daemon), driven by `RELEASE_TMP=runtime` exported by
   `infra/freebsd/rc.d/grappa`. The rotation set survives
   `mix release --overwrite` (which would otherwise blow away
-  `_build/.../tmp/log/`).
+  `_build/.../tmp/log/`). On the Linux/systemd substrate, `bin/grappa
+  start` runs in the foreground (no `run_erl`), so logs go to
+  `journalctl -u grappa` instead — no `runtime/log/` file story there.
 - **Config**: DB-driven (Phase 2 sub-task 2j replaced the TOML loader).
   Operator binds users + networks via mix tasks: `mix grappa.create_user`
   creates a `User` row, `mix grappa.bind_network --auth ...` writes a
@@ -765,8 +796,11 @@ don't hardcode hostnames there.
 
 ## Monitoring
 
-- **Health**: `scripts/healthcheck.sh` (curl `/healthz`) — dev. Prod:
-  `ssh m42 "sudo bastille cmd grappa curl -fsS http://127.0.0.1:4000/healthz"`.
+- **Health**: `scripts/healthcheck.sh` (curl `/healthz`) — dev. Prod
+  (m42 jail): `ssh m42 "sudo bastille cmd grappa curl -fsS http://127.0.0.1:4000/healthz"`.
+  Prod (Linux/systemd host): `curl -fsS http://127.0.0.1:4000/healthz`
+  directly (no ssh-and-exec indirection needed), or
+  `systemctl status grappa` + `journalctl -u grappa -f`.
 - **Logs**: `scripts/monitor.sh` (docker compose logs -f) — dev. Prod:
   tail `runtime/log/erlang.log.*` inside the jail (see Runtime Data).
 - **Runtime introspection**: `scripts/observer.sh` (observer_cli — see

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -793,6 +793,13 @@ don't hardcode hostnames there.
   `Networks.list_credentials_for_all_users/0` and spawns one
   `Session.Server` per row. Adding a binding requires no config edit —
   next reboot picks it up.
+  **Safe to run against a live host without stopping the service**
+  (2026-07-23): every `grappa.*` operator mix task boots via
+  `Mix.Tasks.Grappa.Boot.start_app_silent/0`, which suppresses both
+  `Grappa.Bootstrap` (no upstream IRC connections) and
+  `GrappaWeb.Endpoint` (no HTTP port bind) — so it no longer conflicts
+  with an already-running release on the same port. Before this fix
+  every admin task required `systemctl stop grappa` first.
 
 ## Monitoring
 

--- a/infra/linux/README.md
+++ b/infra/linux/README.md
@@ -125,8 +125,22 @@ see `README.md` "Bind a network".
 systemctl status grappa
 systemctl restart grappa
 journalctl -u grappa -f              # live logs (no file-based log on this substrate)
-infra/linux/deploy.sh                # pull + rebuild + migrate + restart
+infra/linux/deploy.sh                # pull + rebuild, then hot-reload or cold-restart
 ```
+
+`deploy.sh` is preflight-driven: `Grappa.Deploy.Preflight` (the same
+classifier `scripts/deploy.sh` uses for Docker and
+`infra/freebsd/deploy.sh` uses for the jail — see its moduledoc for
+the full class list and the "in doubt, COLD" bias) classifies the
+diff since the last completed deploy and picks HOT (`mix release
+--overwrite`, no stop, then `POST /admin/reload` — Erlang's 2-version
+code-loading guarantee means already-running IRC sessions keep their
+state, only newly-called code paths pick up the change) or COLD (the
+full migrate → systemd-unit-refresh → `systemctl stop`/`start` cycle,
+sessions reset) automatically. A diff touching
+`infra/linux/systemd/grappa.service` always forces COLD on this
+substrate — a changed unit file needs `daemon-reload` + a restart to
+take effect, there's no hot-reload of a systemd unit's own definition.
 
 **`infra/linux/release.sh eval`/`remote`/`rpc` are currently broken on
 this substrate** (found live 2026-07-22) — even a trivial `eval '1 +
@@ -171,8 +185,6 @@ Deliberately out of v1 scope (to keep the first install simple) — add
 these later against the same conventions once the base install is
 proven, using the FreeBSD equivalents as the pattern to follow:
 
-- Hot/cold `Grappa.Deploy.Preflight` classification (`deploy.sh` here
-  is always a full cold cycle).
 - Cic-only hot bundle deploys (`infra/freebsd/jail_deploy_cic.sh`).
 - DB query/write helpers (`infra/freebsd/jail_db_query.sh` /
   `jail_db_write.sh`).

--- a/infra/linux/README.md
+++ b/infra/linux/README.md
@@ -1,0 +1,196 @@
+# Installing grappa on a native Linux host (systemd, no Docker)
+
+A third deploy substrate alongside Docker (`INSTALL.md`, dev/self-host)
+and the FreeBSD bastille jail (`infra/freebsd/`, `m42` production).
+This one targets a plain Ubuntu/Debian host managed by systemd — no
+Docker, no jail. See `infra/linux/README.md`'s sibling scripts for the
+implementation; this file is the operator runbook.
+
+## Prerequisites
+
+- A fresh Ubuntu 22.04+/Debian 11+ host, root/sudo access.
+- ~2GB+ free disk for the Erlang source build + deps + release
+  artifacts, more over time for the sqlite DB and uploads.
+- A public hostname you control (`PHX_HOST`).
+- **This host does not terminate TLS.** A separate upstream machine
+  must already reverse-proxy your public HTTP/HTTPS traffic to this
+  host's nginx on plain HTTP. If you don't have that, see "Exposing
+  beyond localhost" below before going further.
+
+## Quick start
+
+```sh
+git clone https://github.com/vjt/grappa-irc /home/grappa/grappa   # or let install.sh clone it
+PHX_HOST=irc.example.org infra/linux/install.sh
+```
+
+Run as root. Takes 10-20 minutes on first run (Erlang compiles from
+source — this is expected, not a hang). When it finishes, grappa is
+running under systemd, reachable at `http://127.0.0.1:4000/healthz`
+directly and through the locally-installed nginx.
+
+### What each step does
+
+1. **`install_prereqs.sh`** — apt packages (build toolchain,
+   `libsqlite3-dev`, `libimage-exiftool-perl`, `ffmpeg`,
+   `ca-certificates`, `nginx`, Erlang build deps), creates the
+   unprivileged `grappa` system user, creates `/etc/grappa`.
+2. **Clone/update** — the checkout lands at `$REPO_ROOT` (default
+   `/home/grappa/grappa`), owned by `grappa`.
+3. **`install_toolchain.sh`** — installs asdf (Go binary) + the exact
+   Elixir/Erlang versions pinned in `.tool-versions`, as the `grappa`
+   user. This is the slow step.
+4. **First build** — `mix local.hex/rebar`, `deps.get --only prod`,
+   `compile --warnings-as-errors`, `release --overwrite`.
+5. **Secrets bootstrap** — see below.
+6. **First migration** — `Grappa.Release.migrate()` via `release.sh`.
+7. **`cic_build.sh`** — builds the cicchetto PWA with bun into
+   `runtime/cicchetto-dist/`.
+8. **`install_systemd.sh`** — installs + enables (doesn't start) the
+   `grappa.service` unit.
+9. **`install_nginx.sh`** — installs nginx config + the shared
+   `infra/snippets/*.conf`, symlinks the PWA dist, starts/reloads nginx.
+10. **Start + healthcheck** — `systemctl start grappa`, poll
+    `/healthz` until it's green.
+
+Re-running `install.sh` is safe: it never regenerates an
+already-populated secret, never re-clones an existing checkout, and
+every sub-script is independently idempotent.
+
+## Secrets
+
+Only `PHX_HOST` is a required manual input. Everything else
+self-generates on first run into `/etc/grappa/grappa.env` (chmod 640,
+`root:grappa`):
+
+- `SECRET_KEY_BASE`, `SECRET_SIGNING_SALT` — Phoenix/Plug session
+  secrets.
+- `GRAPPA_ENCRYPTION_KEY` — Cloak vault key, encrypts stored
+  IRC/NickServ credentials at rest. **Back this up separately, now.**
+  Losing it makes every stored credential unrecoverable.
+- `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` — Web Push keypair.
+- `RELEASE_COOKIE` — BEAM distribution cookie (needed for
+  `release.sh remote`).
+
+See `infra/linux/grappa.env.example` for the full var reference
+(optional knobs: `POOL_SIZE`, `LOG_LEVEL`, captcha provider, BEAM
+resource caps).
+
+## Exposing beyond localhost
+
+Phoenix binds `0.0.0.0:$PORT` (not env-configurable — a
+`config/runtime.exs` fact, not a Linux-substrate limitation).
+**Firewall `$PORT` (default 4000) to localhost-only** before this host
+is reachable from the internet — only nginx (127.0.0.1) should talk to
+it directly.
+
+This host's own nginx does **not** terminate TLS. The expected
+topology (mirroring how the FreeBSD jail's `m42` host nginx works):
+a separate machine you already run reverse-proxies your public
+`https://` traffic to this host's nginx on port 80. Point that
+upstream machine at this host, then:
+
+```sh
+TRUSTED_UPSTREAM_CIDR=<upstream box's address/CIDR> infra/linux/install_nginx.sh
+```
+
+to restrict nginx to only accept connections from that upstream (skip
+this and nginx accepts from anywhere on port 80 — fine on a private
+network, not fine once this host has a public IP and no CIDR set).
+
+No certbot/ACME needed on this host — TLS is entirely the upstream
+machine's job.
+
+## Creating the first user
+
+```sh
+sudo -u grappa -H bash -c '
+  export PATH="$HOME/.local/bin:$HOME/.asdf/shims:$PATH"
+  set -a; . /etc/grappa/grappa.env; set +a
+  cd /home/grappa/grappa
+  MIX_ENV=prod mix grappa.create_user --name you --password "change-me"
+'
+```
+
+Same task `INSTALL.md` uses for the Docker path. Runs via the
+checkout's own mix/toolchain (not the compiled release) since it's a
+mix task, not a `Grappa.Release.*` function.
+
+Then log in via the web UI. To connect the bouncer to an IRC network,
+see `README.md` "Bind a network".
+
+## Day-2 operations
+
+```sh
+systemctl status grappa
+systemctl restart grappa
+journalctl -u grappa -f              # live logs (no file-based log on this substrate)
+infra/linux/deploy.sh                # pull + rebuild + migrate + restart
+```
+
+**`infra/linux/release.sh eval`/`remote`/`rpc` are currently broken on
+this substrate** (found live 2026-07-22) — even a trivial `eval '1 +
+1'` crashes the BEAM immediately at kernel boot:
+
+```
+(no logger present) unexpected logger message: {log,error,...
+Kernel pid terminated (logger) ({badarg,[{persistent_term,get,[code_server],...
+```
+
+This is a genuine BEAM/kernel-level crash, not application code (the
+same trace appears for `1 + 1` as for `Grappa.Release.migrate()`),
+isolated to the mix-release-generated `bin/grappa` script's `eval`
+code path specifically — `remote` (live IEx console) and `rpc` share
+the same boot variant, so they're presumed equally broken (not yet
+individually re-tested).
+
+What's confirmed NOT broken — ruled out a general toolchain/release
+problem: raw `erl -eval '...' -noshell` (asdf-installed Erlang
+directly, outside any release) works fine, and `bin/grappa start` —
+the FULL boot, exactly what `grappa.service`'s `ExecStart` uses —
+works fine too, getting as far as a real, expected, unrelated error
+(missing migrations) with no kernel-level crash at all. So the bug is
+specific to the release's minimal `start_clean` boot script variant
+(used for `eval`/`remote`/`rpc`), not the release packaging or the
+Erlang/Elixir installation in general. Root cause not yet identified —
+plausibly an OTP 28.5-specific interaction with `--boot-var
+RELEASE_LIB` and the persistent_term-based code-loading fast path.
+
+Workaround in place: `install.sh`/`deploy.sh` run migrations via plain
+`mix ecto.migrate` (sourcing the env file, `MIX_ENV=prod`) instead of
+`release.sh eval 'Grappa.Release.migrate()'` — viable here because
+this substrate keeps the full mix/asdf toolchain around permanently
+(unlike a minimal prod container), so routing through the packaged
+release for one-off tasks was never strictly necessary in the first
+place. For a live console, `iex -S mix` in a plain (non-release) dev
+checkout is the fallback until the actual boot-script bug is found.
+
+## What's NOT here yet
+
+Deliberately out of v1 scope (to keep the first install simple) — add
+these later against the same conventions once the base install is
+proven, using the FreeBSD equivalents as the pattern to follow:
+
+- Hot/cold `Grappa.Deploy.Preflight` classification (`deploy.sh` here
+  is always a full cold cycle).
+- Cic-only hot bundle deploys (`infra/freebsd/jail_deploy_cic.sh`).
+- DB query/write helpers (`infra/freebsd/jail_db_query.sh` /
+  `jail_db_write.sh`).
+- DB import/rollback tooling (`infra/freebsd/jail_import_db.sh`).
+
+## Design notes (why this isn't a literal port of `infra/freebsd/`)
+
+The FreeBSD jail's `rc.d` wrapper needed a hand-rolled synchronous
+stop/start guard (`jail_beam_wait.sh`) because `bin/grappa daemon`
+backgrounds via `run_erl` and `rc.d`'s async stop let a restart race a
+still-draining old node into an epmd name collision (defect #9,
+2026-06-11 outage). This substrate runs the release in the
+**foreground** instead (`bin/grappa start`, systemd `Type=exec`) —
+systemd tracks that PID directly, so `systemctl stop`/`restart` block
+natively until the process actually exits. `lib/grappa/session/server.ex`'s
+`terminate/2` already handles SIGTERM with a clean upstream QUIT
+(issue #215), so this closes the same race at the root cause without
+porting the FreeBSD wrapper's full machinery. `grappa_beam_wait.sh`'s
+`wait-name-free` is kept as a defense-in-depth `ExecStartPre` guard,
+not the primary sync mechanism. See comments in
+`infra/linux/systemd/grappa.service` for the full rationale.

--- a/infra/linux/cic_build.sh
+++ b/infra/linux/cic_build.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Build cicchetto's static SPA into runtime/cicchetto-dist, as the
+# grappa user.
+#
+# Port of infra/freebsd/jail_cic_build.sh — but FreeBSD pkg has no bun
+# port, so that script falls back to npm (regenerating package-lock.json
+# from the bun-canonical bun.lock). Linux has native bun packages, so
+# this uses bun directly — closer to dev tooling (scripts/bun.sh), no
+# lockfile-regeneration workaround needed.
+#
+# Usage: infra/linux/cic_build.sh [repo_root]
+# Idempotent — safe to re-run; `bun install` is a no-op when the
+# lockfile is already satisfied.
+
+set -euo pipefail
+
+REPO_ROOT="${1:-/home/grappa/grappa}"
+CIC_DIR="${REPO_ROOT}/cicchetto"
+OUT_DIR="${REPO_ROOT}/runtime/cicchetto-dist"
+GRAPPA_USER="${GRAPPA_USER:-grappa}"
+
+# PATH must include ~grappa/.local/bin (bun lives there, installed by
+# install_toolchain.sh) — `sudo -u ... bash -c` otherwise falls back to
+# the system default PATH, which doesn't have it (found live on
+# a native-Linux install, 2026-07-22: "bun: command not found" despite bun being
+# installed and working fine when install_toolchain.sh itself checked it).
+run_as_grappa() {
+	sudo -u "${GRAPPA_USER}" -H bash -c "export PATH=\"\$HOME/.local/bin:\$HOME/.asdf/shims:\$PATH\"; $1"
+}
+
+echo "[cic_build] bun install && bun run build (outDir=${OUT_DIR})"
+# Buffer output and only show it on failure — a clean build is noisy
+# (vite + tsc output) and the interesting signal is the exit code;
+# same pipefail-avoidance lesson as jail_cic_build.sh's header.
+log="$(mktemp)"
+trap 'rm -f "${log}"' EXIT
+if ! run_as_grappa "cd '${CIC_DIR}' && bun install && bun run build -- --outDir '${OUT_DIR}' --emptyOutDir" >"${log}" 2>&1; then
+	echo "[cic_build] ERROR: build failed — output:" >&2
+	cat "${log}" >&2
+	exit 1
+fi
+
+echo "[cic_build] done — ${OUT_DIR}"

--- a/infra/linux/deploy.sh
+++ b/infra/linux/deploy.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
 # grappa — update deploy for a native Linux (systemd) host. Run as
-# root. Cold-only by design: no hot/cold Grappa.Deploy.Preflight
-# classification, unlike infra/freebsd/deploy.sh — LINUX.md's v1 scope
-# deliberately skips that machinery until the base install is proven.
-# Every deploy does a full stop -> rebuild -> migrate -> start cycle
-# (sessions reset, ~seconds of downtime bounded by TimeoutStopSec).
+# root. Preflight-driven hot-vs-cold dispatcher, sharing the
+# Grappa.Deploy.Preflight classifier with scripts/deploy.sh (Docker)
+# and infra/freebsd/deploy.sh (jail) — see lib/grappa/deploy/preflight.ex.
+#
+# Hot path (preflight returns HOT):
+#   git pull -> mix release --overwrite -> POST /admin/reload
+#   Sessions preserved (Erlang's 2-version code-loading guarantee).
+#   No systemctl call at all.
+#
+# Cold path (preflight returns COLD):
+#   git pull -> mix release --overwrite -> cic build -> migrate ->
+#   refresh systemd unit -> systemctl stop/start -> healthcheck loop.
+#   Sessions reset, ~seconds of downtime bounded by TimeoutStopSec.
 #
 # Usage: infra/linux/deploy.sh
 #
@@ -18,6 +26,7 @@ GRAPPA_USER="${GRAPPA_USER:-grappa}"
 PORT="${PORT:-4000}"
 HEALTHCHECK_RETRIES="${HEALTHCHECK_RETRIES:-30}"
 HEALTHCHECK_SLEEP="${HEALTHCHECK_SLEEP:-2}"
+RELOAD_URL="${RELOAD_URL:-http://127.0.0.1:${PORT}/admin/reload}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -50,13 +59,88 @@ if [ -z "${DEPLOY_REEXECED:-}" ] \
 fi
 
 if [ "${prev_sha}" = "${new_sha}" ]; then
-	echo "[deploy] HEAD unchanged (${new_sha}) — proceeding anyway (cold-only, no nothing-to-do fast path in v1 scope)"
+	echo "[deploy] HEAD unchanged (${new_sha}) — proceeding anyway (no nothing-to-do fast path: this substrate has no separate cic-only deploy path, so a no-op pull cannot hide a pending change)"
 fi
+
+# ---- Preflight ----
+#
+# Source of truth: lib/grappa/deploy/preflight.ex (shared with
+# scripts/deploy.sh and infra/freebsd/deploy.sh). `mix run --no-start`
+# boots the BEAM without starting the application, so the check never
+# touches the live DB or steps on the running release. The env file is
+# sourced first: config/runtime.exs raises on missing DATABASE_PATH &
+# co, and `sudo -u ... bash -c` does not inherit the systemd unit's
+# EnvironmentFile.
+#
+# Preflight base is runtime/last-deployed-sha, NOT prev_sha (this run's
+# pre-pull HEAD) — a prior run that pulled fresh commits but then died
+# before finishing (release build failure, reload POST timeout, ssh
+# drop) leaves the repo HEAD already past those commits, so THIS run's
+# prev_sha==new_sha would classify an empty range as HOT and silently
+# skip the migrate/cic/systemd-refresh that the dead run never actually
+# applied. The marker is written as the last step of both paths below,
+# so it always lags behind by exactly the work not yet proven applied.
+last_deployed=$(run_as_grappa "cat runtime/last-deployed-sha 2>/dev/null || true" | tail -1)
+preflight_base="${prev_sha}"
+if [ -n "${last_deployed}" ]; then
+	# Shape-check first (full 40-hex sha) so a garbage/truncated marker
+	# never reaches a `bash -c` command line unvalidated, and confirm it
+	# names a real commit — a rewritten history or a hand-edited file
+	# must abort loudly here with a fix-it hint rather than crash the
+	# mix oneshot with an opaque exit 1 that the case-statement below
+	# would then have to guess the meaning of.
+	marker_ok=no
+	if [ "${#last_deployed}" -eq 40 ]; then
+		case "${last_deployed}" in
+			*[!0-9a-f]*) ;;
+			*)
+				if run_as_grappa "git cat-file -e '${last_deployed}^{commit}'" 2>/dev/null; then
+					marker_ok=yes
+				fi
+				;;
+		esac
+	fi
+	if [ "${marker_ok}" = "yes" ]; then
+		preflight_base="${last_deployed}"
+	else
+		echo "[deploy] ERROR: runtime/last-deployed-sha contains '${last_deployed}' — not a full sha of a commit in this repo" >&2
+		echo "[deploy]   fix the marker (write the last deployed sha to runtime/last-deployed-sha) before re-running" >&2
+		exit 1
+	fi
+fi
+
+echo "[deploy] preflight: classifying ${preflight_base}..${new_sha}"
+preflight_rc=0
+run_as_grappa "
+	set -a; . '${ENV_FILE}'; set +a
+	export MIX_ENV=prod
+	mix run --no-start -e 'Grappa.Deploy.Preflight.cli([\"${preflight_base}\", \"${new_sha}\", \"linux\"])'
+" || preflight_rc=$?
+
+case "${preflight_rc}" in
+	0) mode=hot ;;
+	3) mode=cold ;;
+	*)
+		# Mix crash or usage error, not a verdict — falling through to
+		# cold would silently convert a miswired call into "always
+		# restart", and falling through to hot would silently convert
+		# it into "never restart". Neither is a valid guess: abort loud.
+		echo "[deploy] ERROR: preflight exited ${preflight_rc} (crash/usage, not a verdict) — aborting" >&2
+		exit "${preflight_rc}"
+		;;
+esac
+
+echo "[deploy] ==> mode: ${mode}"
 
 echo "[deploy] mix deps.get --only prod / compile / release --overwrite"
 # MIX_ENV=prod required — see install.sh's matching comment: without
 # it mix defaults to :dev and compile fails on missing dev-only deps
 # that --only prod deliberately never fetched.
+#
+# mix release --overwrite runs on BOTH paths: it writes fresh .beam
+# into _build/prod/rel/grappa/lib/grappa-X.Y/ebin/, which is exactly
+# the directory the live daemon's code path already includes. Without
+# it the hot path's reload POST below would have nothing new to load.
 run_as_grappa '
 	export MIX_ENV=prod
 	mix deps.get --only prod
@@ -64,39 +148,61 @@ run_as_grappa '
 	mix release --overwrite
 '
 
-echo "[deploy] cic_build.sh"
-"${SCRIPT_DIR}/cic_build.sh" "${REPO_ROOT}"
+if [ "${mode}" = "hot" ]; then
+	# Hot path: tell the live BEAM to walk :code.modified_modules/0 and
+	# reload via :code.load_file/1. No systemctl call, no cic rebuild
+	# (preflight only returns HOT when neither changed), no migration
+	# (a new migration file classifies COLD on its own).
+	echo "[deploy] POST ${RELOAD_URL}"
+	if response=$(curl -fsS -X POST "${RELOAD_URL}"); then
+		echo "[deploy] reload response: ${response}"
+		# HTTP 200 is NOT success — the endpoint reports per-module
+		# failures in-band (e.g. :old_code_in_use when a process still
+		# runs a prior hot-reload's old code). Declaring success over a
+		# failed reload would leave prod silently running stale code.
+		case "${response}" in
+		*'"failed":[]'*) ;;
+		*)
+			echo "[deploy] ERROR: reload reported per-module failures (see response above)" >&2
+			echo "[deploy]   old code in use? retry once processes settle, or fix and re-run (a re-run reclassifies HOT again since nothing new changed)" >&2
+			exit 1
+			;;
+		esac
+	else
+		echo "[deploy] ERROR: POST /admin/reload failed — daemon may be down or unreachable" >&2
+		exit 1
+	fi
+else
+	echo "[deploy] cic_build.sh"
+	"${SCRIPT_DIR}/cic_build.sh" "${REPO_ROOT}"
 
-echo "[deploy] migrate"
-# Plain `mix ecto.migrate`, not release.sh eval — see install.sh's
-# matching comment: the packaged release's eval/remote/rpc boot path
-# crashes the BEAM on this substrate (isolated to start_clean boot,
-# not `bin/grappa start` — systemd's own path is unaffected).
-run_as_grappa "
-	set -a; . '${ENV_FILE}'; set +a
-	export MIX_ENV=prod
-	mix ecto.migrate
-"
+	echo "[deploy] migrate"
+	# Plain `mix ecto.migrate`, not release.sh eval — see install.sh's
+	# matching comment: the packaged release's eval/remote/rpc boot path
+	# crashes the BEAM on this substrate (isolated to start_clean boot,
+	# not `bin/grappa start` — systemd's own path is unaffected).
+	run_as_grappa "
+		set -a; . '${ENV_FILE}'; set +a
+		export MIX_ENV=prod
+		mix ecto.migrate
+	"
 
-echo "[deploy] refresh systemd unit + grappa_beam_wait.sh (safe before stop — daemon-reload doesn't touch the already-running unit)"
-"${SCRIPT_DIR}/install_systemd.sh"
+	echo "[deploy] refresh systemd unit + grappa_beam_wait.sh (safe before stop — daemon-reload doesn't touch the already-running unit)"
+	"${SCRIPT_DIR}/install_systemd.sh"
 
-echo "[deploy] systemctl stop grappa (blocks natively under Type=exec — no wait-loop needed)"
-systemctl stop grappa
+	echo "[deploy] systemctl stop grappa (blocks natively under Type=exec — no wait-loop needed)"
+	systemctl stop grappa
 
-echo "[deploy] systemctl start grappa"
-systemctl start grappa
+	echo "[deploy] systemctl start grappa"
+	systemctl start grappa
+fi
 
 echo "[deploy] healthcheck loop"
 i=0
 while [ "${i}" -lt "${HEALTHCHECK_RETRIES}" ]; do
 	if curl -fsS -o /dev/null "http://127.0.0.1:${PORT}/healthz"; then
-		# Kept for forward-compat with a future hot/cold port (not
-		# currently read back by anything on this substrate — the
-		# infra/freebsd equivalent uses it for Preflight's base-of-diff;
-		# this cold-only script always does a full cycle regardless).
 		run_as_grappa "printf '%s\n' '${new_sha}' > runtime/last-deployed-sha"
-		echo "[deploy] done (${new_sha})"
+		echo "[deploy] ✓ ${mode} deploy complete (${new_sha}) after ${i} retries"
 		exit 0
 	fi
 	i=$((i + 1))

--- a/infra/linux/deploy.sh
+++ b/infra/linux/deploy.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# grappa — update deploy for a native Linux (systemd) host. Run as
+# root. Cold-only by design: no hot/cold Grappa.Deploy.Preflight
+# classification, unlike infra/freebsd/deploy.sh — LINUX.md's v1 scope
+# deliberately skips that machinery until the base install is proven.
+# Every deploy does a full stop -> rebuild -> migrate -> start cycle
+# (sessions reset, ~seconds of downtime bounded by TimeoutStopSec).
+#
+# Usage: infra/linux/deploy.sh
+#
+# Env (same defaults as install.sh): REPO_ROOT, ENV_FILE, GRAPPA_USER, PORT
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-/home/grappa/grappa}"
+ENV_FILE="${ENV_FILE:-/etc/grappa/grappa.env}"
+GRAPPA_USER="${GRAPPA_USER:-grappa}"
+PORT="${PORT:-4000}"
+HEALTHCHECK_RETRIES="${HEALTHCHECK_RETRIES:-30}"
+HEALTHCHECK_SLEEP="${HEALTHCHECK_SLEEP:-2}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export REPO_ROOT ENV_FILE GRAPPA_USER
+
+run_as_grappa() {
+	sudo -u "${GRAPPA_USER}" -H bash -c "
+		export PATH=\"\$HOME/.local/bin:\$HOME/.asdf/shims:\$PATH\"
+		cd '${REPO_ROOT}'
+		$1
+	"
+}
+
+echo "[deploy] git pull --ff-only"
+prev_sha=$(run_as_grappa 'git rev-parse HEAD' | tail -1)
+run_as_grappa 'git pull --ff-only && git log --oneline -3'
+new_sha=$(run_as_grappa 'git rev-parse HEAD' | tail -1)
+
+# Self-modifying-deploy-script trap, ported from infra/freebsd/deploy.sh
+# (this is POSIX/git filesystem semantics, not FreeBSD-specific): git
+# pull replaces files by rename, so the running interpreter keeps
+# executing PRE-PULL bytes from the old inode — a fix to this script
+# would silently no-op on the first deploy that ships it. Re-exec so
+# the new bytes run for everything downstream of the pull.
+if [ -z "${DEPLOY_REEXECED:-}" ] \
+	&& run_as_grappa "git diff --name-only '${prev_sha}..${new_sha}'" | grep -qx 'infra/linux/deploy.sh'; then
+	echo "[deploy] deploy.sh changed in ${prev_sha}..${new_sha} — re-exec to load new bytes"
+	export DEPLOY_REEXECED=1
+	exec "${REPO_ROOT}/infra/linux/deploy.sh" "$@"
+fi
+
+if [ "${prev_sha}" = "${new_sha}" ]; then
+	echo "[deploy] HEAD unchanged (${new_sha}) — proceeding anyway (cold-only, no nothing-to-do fast path in v1 scope)"
+fi
+
+echo "[deploy] mix deps.get --only prod / compile / release --overwrite"
+# MIX_ENV=prod required — see install.sh's matching comment: without
+# it mix defaults to :dev and compile fails on missing dev-only deps
+# that --only prod deliberately never fetched.
+run_as_grappa '
+	export MIX_ENV=prod
+	mix deps.get --only prod
+	mix compile --warnings-as-errors
+	mix release --overwrite
+'
+
+echo "[deploy] cic_build.sh"
+"${SCRIPT_DIR}/cic_build.sh" "${REPO_ROOT}"
+
+echo "[deploy] migrate"
+# Plain `mix ecto.migrate`, not release.sh eval — see install.sh's
+# matching comment: the packaged release's eval/remote/rpc boot path
+# crashes the BEAM on this substrate (isolated to start_clean boot,
+# not `bin/grappa start` — systemd's own path is unaffected).
+run_as_grappa "
+	set -a; . '${ENV_FILE}'; set +a
+	export MIX_ENV=prod
+	mix ecto.migrate
+"
+
+echo "[deploy] refresh systemd unit + grappa_beam_wait.sh (safe before stop — daemon-reload doesn't touch the already-running unit)"
+"${SCRIPT_DIR}/install_systemd.sh"
+
+echo "[deploy] systemctl stop grappa (blocks natively under Type=exec — no wait-loop needed)"
+systemctl stop grappa
+
+echo "[deploy] systemctl start grappa"
+systemctl start grappa
+
+echo "[deploy] healthcheck loop"
+i=0
+while [ "${i}" -lt "${HEALTHCHECK_RETRIES}" ]; do
+	if curl -fsS -o /dev/null "http://127.0.0.1:${PORT}/healthz"; then
+		# Kept for forward-compat with a future hot/cold port (not
+		# currently read back by anything on this substrate — the
+		# infra/freebsd equivalent uses it for Preflight's base-of-diff;
+		# this cold-only script always does a full cycle regardless).
+		run_as_grappa "printf '%s\n' '${new_sha}' > runtime/last-deployed-sha"
+		echo "[deploy] done (${new_sha})"
+		exit 0
+	fi
+	i=$((i + 1))
+	sleep "${HEALTHCHECK_SLEEP}"
+done
+
+echo "[deploy] ERROR: healthcheck never returned 200 after $((HEALTHCHECK_RETRIES * HEALTHCHECK_SLEEP))s — see: journalctl -u grappa -n 200" >&2
+exit 1

--- a/infra/linux/grappa.env.example
+++ b/infra/linux/grappa.env.example
@@ -1,0 +1,76 @@
+# Grappa env file — chmod 640, owned by root:grappa.
+#
+# Loaded via `EnvironmentFile=` in infra/linux/systemd/grappa.service —
+# systemd's manager (running as root) reads this BEFORE dropping to
+# User=grappa, so the file itself need not be world/grappa-readable.
+# NOTE: this is systemd's env-file syntax, not a shell script — plain
+# KEY=VALUE lines only, no `export`, no shell expansion, no quoting.
+#
+# Per CLAUDE.md "Security": SECRET_KEY_BASE, RELEASE_COOKIE,
+# GRAPPA_ENCRYPTION_KEY, SASL passwords never logged, never committed.
+# This file is a template only — fill in real values on the target
+# host and `chmod 640`.
+
+# ── Phoenix / Plug ─────────────────────────────────────────────────────────
+# Generate with (from a built release):
+#   infra/linux/release.sh eval 'Base.encode64(:crypto.strong_rand_bytes(48))'
+# or (dev-env, before the release exists — see install.sh's secrets
+# bootstrap): mix phx.gen.secret
+SECRET_KEY_BASE=REPLACE_ME
+
+# Plug.Session signing salt (32+ random bytes).
+# Generate with: mix phx.gen.secret 32
+SECRET_SIGNING_SALT=REPLACE_ME
+
+# BEAM distribution cookie (any 32+ char random). Required for
+# infra/linux/release.sh remote to attach to the running node.
+# Generate with: openssl rand -hex 32
+RELEASE_COOKIE=REPLACE_ME
+
+# ── Cloak vault key ────────────────────────────────────────────────────────
+# Base64-encoded 32 bytes. Encrypts at-rest upstream credentials.
+# Generate ONCE per deployment with:
+#   infra/linux/release.sh eval 'IO.puts(Base.encode64(:crypto.strong_rand_bytes(32)))'
+# BACK THIS UP SEPARATELY. Lose the key = lose all stored credentials.
+GRAPPA_ENCRYPTION_KEY=REPLACE_ME
+
+# ── Web Push (VAPID) ───────────────────────────────────────────────────────
+# Generate ONCE per deployment with:
+#   infra/linux/release.sh eval 'Grappa.Push.Vapid.gen_keypair() |> IO.inspect()'
+VAPID_PUBLIC_KEY=REPLACE_ME
+VAPID_PRIVATE_KEY=REPLACE_ME
+VAPID_SUBJECT=mailto:operator@example.org
+
+# ── Storage paths ──────────────────────────────────────────────────────────
+# Absolute paths on the host. The DB + uploads dirs MUST be writable
+# by the grappa user.
+DATABASE_PATH=/home/grappa/grappa/runtime/grappa_prod.db
+UPLOADS_STORAGE_ROOT=/home/grappa/grappa/runtime/uploads
+
+# ── Phoenix host ───────────────────────────────────────────────────────────
+PHX_HOST=grappa.example.org
+PORT=4000
+
+# Sqlite pool size (read concurrency). Defaults to 10 if unset.
+POOL_SIZE=10
+
+# Logger level: debug | info | notice | warning | error
+# On this substrate, logs go to `journalctl -u grappa`, not a file
+# (systemd Type=exec runs the release in the foreground — no
+# run_erl/RELEASE_TMP file-logging story like the FreeBSD jail has).
+LOG_LEVEL=info
+
+# ── T31 admission captcha (optional) ───────────────────────────────────────
+# GRAPPA_CAPTCHA_PROVIDER=disabled
+# GRAPPA_CAPTCHA_SITE_KEY=
+# GRAPPA_CAPTCHA_SECRET=
+
+# ── BEAM resource caps (optional) ──────────────────────────────────────────
+# GRAPPA_MAX_USERS=100
+# GRAPPA_DIRTY_SCHEDULERS=
+
+# NOTE: GRAPPA_OUTBOUND_V6_POOL (present in infra/freebsd/grappa.env.example)
+# is intentionally NOT listed here — config/runtime.exs no longer reads
+# it; the multi-source-address story was superseded by the DB-driven
+# `vhosts` table (see docs/OPERATIONS.md). The FreeBSD example file is
+# stale on this point — don't copy it over.

--- a/infra/linux/grappa_beam_wait.sh
+++ b/infra/linux/grappa_beam_wait.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Trimmed port of infra/freebsd/jail_beam_wait.sh for the Linux/systemd
+# substrate.
+#
+# On FreeBSD this was the PRIMARY stop/start sync mechanism because
+# rc.d's `service grappa stop` is asynchronous (defect #9, 2026-06-11
+# outage: a restart raced the still-draining old node into an epmd
+# name collision). On Linux, `ExecStart=.../bin/grappa start` runs the
+# release in the FOREGROUND under systemd `Type=exec` — systemd tracks
+# that PID directly and `systemctl stop`/`restart` natively block until
+# it exits (bounded by TimeoutStopSec). That closes the defect #9 race
+# at the root cause, so this script is no longer load-bearing for the
+# stop path.
+#
+# It's kept for two narrower purposes:
+#   - `wait-name-free` wired into grappa.service as ExecStartPre — a
+#     defense-in-depth guard against a restart-cycling edge case
+#     where epmd hasn't yet reacted to a just-exited node.
+#   - `wait-stopped` kept as a standalone operator tool for manually
+#     troubleshooting a stuck stop (not invoked by any script here).
+#
+# Verbs (all args required — no defaults):
+#   wait-stopped <node> <timeout>    Block until beam.smp has exited
+#                                    AND epmd no longer lists <node>.
+#                                    Escalates: SIGKILL the BEAM after
+#                                    <timeout>s; restart epmd if the
+#                                    name is still listed <timeout>s
+#                                    after the BEAM is gone.
+#   wait-name-free <node> <timeout>  Block until epmd no longer lists
+#                                    <node>. NO escalation — the
+#                                    registered name may belong to a
+#                                    still-draining old node that must
+#                                    not be shot.
+#
+# Exit codes: 0 condition met, 1 timeout (after escalation for
+# wait-stopped), 64 usage.
+
+set -euo pipefail
+
+if ! command -v epmd >/dev/null 2>&1; then
+	echo "[beam-wait] WARNING: epmd binary not found on PATH — name-release checks degraded to BEAM-exit only" >&2
+fi
+
+# `epmd -names` exits non-zero when no epmd is running — no daemon, no
+# registrations, name trivially free.
+name_registered() {
+	local out
+	out=$(epmd -names 2>/dev/null) || return 1
+	printf '%s\n' "${out}" | grep -q "^name $1 at "
+}
+
+# Single-tenant host assumption carried over from FreeBSD: the only
+# BEAM expected on this host is grappa's, so matching on the emulator
+# binary name is unambiguous.
+beam_alive() {
+	pgrep -q beam.smp 2>/dev/null
+}
+
+wait_stopped() {
+	local node="$1" timeout="$2" i=0
+
+	while beam_alive; do
+		if [ "${i}" -ge "${timeout}" ]; then
+			echo "[beam-wait] WARNING: BEAM still alive ${timeout}s after stop — SIGKILL" >&2
+			pkill -9 beam.smp 2>/dev/null || true
+			sleep 1
+			break
+		fi
+		i=$((i + 1))
+		sleep 1
+	done
+
+	i=0
+	while name_registered "${node}"; do
+		if [ "${i}" -ge "${timeout}" ]; then
+			echo "[beam-wait] WARNING: epmd still lists '${node}' ${timeout}s after BEAM exit — restarting epmd" >&2
+			pkill epmd 2>/dev/null || true
+			sleep 1
+			break
+		fi
+		i=$((i + 1))
+		sleep 1
+	done
+
+	if beam_alive || name_registered "${node}"; then
+		echo "[beam-wait] ERROR: BEAM or epmd name '${node}' still present after escalation — manual intervention needed (pgrep beam.smp; epmd -names)" >&2
+		return 1
+	fi
+}
+
+wait_name_free() {
+	local node="$1" timeout="$2" i=0
+
+	while name_registered "${node}"; do
+		if [ "${i}" -ge "${timeout}" ]; then
+			echo "[beam-wait] ERROR: epmd name '${node}' still registered after ${timeout}s — an old node is still draining or stuck; wait for it (epmd -names) and retry" >&2
+			return 1
+		fi
+		i=$((i + 1))
+		sleep 1
+	done
+}
+
+usage() {
+	echo "usage: $0 wait-stopped|wait-name-free <node> <timeout-seconds>" >&2
+	exit 64
+}
+
+[ $# -eq 3 ] || usage
+
+case "$1" in
+	wait-stopped) wait_stopped "$2" "$3" ;;
+	wait-name-free) wait_name_free "$2" "$3" ;;
+	*) usage ;;
+esac

--- a/infra/linux/install.sh
+++ b/infra/linux/install.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# grappa — first-install orchestrator for a native Linux (systemd) host.
+# Run as root. Idempotent — safe to re-run (e.g. after fixing an error
+# partway through).
+#
+# Usage:
+#   PHX_HOST=irc.example.org infra/linux/install.sh
+#
+# Required env:
+#   PHX_HOST          public hostname (no default — fails loudly, same
+#                      hard-require as config/runtime.exs itself)
+#
+# Optional env (defaults shown):
+#   REPO_ROOT=/home/grappa/grappa
+#   GIT_REMOTE_URL=https://github.com/vjt/grappa-irc
+#   PORT=4000
+#   ENV_FILE=/etc/grappa/grappa.env
+#   GRAPPA_USER=grappa
+#   LISTEN_ADDR=0.0.0.0:80          (nginx, see install_nginx.sh)
+#   TRUSTED_UPSTREAM_CIDR=          (nginx, see install_nginx.sh)
+#
+# See infra/linux/README.md for the full runbook (what each step does,
+# what to do once this finishes, exposing beyond localhost).
+
+set -euo pipefail
+
+if [ -z "${PHX_HOST:-}" ]; then
+	echo "[install] ERROR: PHX_HOST is required (e.g. PHX_HOST=irc.example.org $0)" >&2
+	exit 1
+fi
+
+REPO_ROOT="${REPO_ROOT:-/home/grappa/grappa}"
+GIT_REMOTE_URL="${GIT_REMOTE_URL:-https://github.com/vjt/grappa-irc}"
+PORT="${PORT:-4000}"
+ENV_FILE="${ENV_FILE:-/etc/grappa/grappa.env}"
+GRAPPA_USER="${GRAPPA_USER:-grappa}"
+
+export REPO_ROOT GRAPPA_USER ENV_FILE
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+say()  { printf '\033[1;32m==>\033[0m %s\n' "$*"; }
+die()  { printf '\033[1;31mxx\033[0m  %s\n' "$*" >&2; exit 1; }
+
+run_as_grappa() {
+	sudo -u "${GRAPPA_USER}" -H bash -c "$1"
+}
+
+# $HOME resolves to grappa's own home once run_as_grappa's `sudo -u
+# ... -H` has switched user — no need to look it up here.
+asdf_path_export='export PATH="$HOME/.local/bin:$HOME/.asdf/shims:$PATH"'
+
+say "1/10 install_prereqs.sh"
+"${SCRIPT_DIR}/install_prereqs.sh"
+
+say "2/10 clone / update checkout at ${REPO_ROOT}"
+if [ ! -d "${REPO_ROOT}/.git" ]; then
+	mkdir -p "$(dirname "${REPO_ROOT}")"
+	run_as_grappa "git clone '${GIT_REMOTE_URL}' '${REPO_ROOT}'"
+else
+	echo "[install] ${REPO_ROOT} already a git checkout, leaving as-is"
+fi
+chown -R "${GRAPPA_USER}:${GRAPPA_USER}" "${REPO_ROOT}"
+
+say "3/10 install_toolchain.sh (erlang build from source — can take 10-20 min)"
+"${SCRIPT_DIR}/install_toolchain.sh" "${REPO_ROOT}"
+
+say "4/10 first build (mix deps.get / compile / release)"
+# Full `mix deps.get` (NOT --only prod) — the secrets bootstrap below
+# (step 5) runs several mix tasks under MIX_ENV=dev (the FreeBSD/
+# Docker-proven chicken-and-egg workaround: a prod-env mix task reads
+# config/runtime.exs, which raises on the very secrets being created).
+# Those dev-env invocations need dev-only deps (credo, dialyxir,
+# sobelow, ...) on disk; `--only prod` would skip them and every one
+# of those tasks fails with "the dependency is not available, run
+# mix deps.get" (found live on a fresh native-Linux install, 2026-07-22 — this is
+# exactly what INSTALL.md's Docker quickstart.sh already does: a full
+# deps.get once, then MIX_ENV=dev for secret generation). The
+# MIX_ENV=prod compile/release steps below only use the prod subset
+# of what's fetched; the extra dev/test deps on disk are otherwise
+# unused by the release, just harmless bytes.
+run_as_grappa "
+	${asdf_path_export}
+	cd '${REPO_ROOT}'
+	mix local.hex --force
+	mix local.rebar --force
+	mix deps.get
+	export MIX_ENV=prod
+	mix compile --warnings-as-errors
+	mix release --overwrite
+"
+
+say "5/10 secrets bootstrap (${ENV_FILE})"
+if [ ! -f "${ENV_FILE}" ]; then
+	install -o root -g "${GRAPPA_USER}" -m 0640 "${REPO_ROOT}/infra/linux/grappa.env.example" "${ENV_FILE}"
+fi
+chown "root:${GRAPPA_USER}" "${ENV_FILE}"
+chmod 0640 "${ENV_FILE}"
+
+set_env_if_blank() {
+	local key="$1" val="$2"
+	if grep -qE "^${key}=.+$" "${ENV_FILE}" 2>/dev/null && ! grep -qE "^${key}=REPLACE_ME$" "${ENV_FILE}"; then
+		return 0
+	fi
+	if grep -qE "^${key}=" "${ENV_FILE}"; then
+		grep -v "^${key}=" "${ENV_FILE}" > "${ENV_FILE}.tmp" && mv "${ENV_FILE}.tmp" "${ENV_FILE}"
+	fi
+	printf '%s=%s\n' "${key}" "${val}" >> "${ENV_FILE}"
+}
+
+# Unlike secrets (never silently regenerate — set_env_if_blank), these
+# are install.sh-computed config values that must always reflect THIS
+# invocation's parameters. grappa.env.example ships non-blank,
+# non-REPLACE_ME example values for readability (e.g.
+# PHX_HOST=grappa.example.org) — set_env_if_blank would see those as
+# "already set" and never overwrite them with the real PHX_HOST/PORT
+# the operator actually passed in (found live on a native-Linux install,
+# 2026-07-22: PHX_HOST stayed at the template's example.org forever).
+force_set_env() {
+	local key="$1" val="$2"
+	if grep -qE "^${key}=" "${ENV_FILE}"; then
+		grep -v "^${key}=" "${ENV_FILE}" > "${ENV_FILE}.tmp" && mv "${ENV_FILE}.tmp" "${ENV_FILE}"
+	fi
+	printf '%s=%s\n' "${key}" "${val}" >> "${ENV_FILE}"
+}
+
+# Generated under MIX_ENV=dev on purpose: prod-env mix tasks read
+# config/runtime.exs, which raises on the very secrets being created
+# (chicken-and-egg) — same workaround as INSTALL.md/quickstart.sh and
+# the FreeBSD deploy comment block.
+#
+# Captures stderr instead of discarding it: with `set -e` active, a
+# failing mix task inside this command substitution aborts the whole
+# script immediately — and with stderr thrown away, that abort was
+# SILENT (found live on a native-Linux install, 2026-07-22: three secrets got
+# written as empty strings with zero indication anything had failed).
+# Fail loud instead: print the captured error and exit non-zero rather
+# than let a blank secret slip into the env file.
+gen() {
+	local out
+	if ! out="$(run_as_grappa "${asdf_path_export}; cd '${REPO_ROOT}'; MIX_ENV=dev $1" 2>&1)"; then
+		echo "[install] ERROR: 'MIX_ENV=dev $1' failed:" >&2
+		echo "${out}" >&2
+		exit 1
+	fi
+	printf '%s' "${out}" | tr -d '\r' | grep -v '^warning:' | tail -n1
+}
+
+if ! grep -qE "^SECRET_KEY_BASE=.+$" "${ENV_FILE}" || grep -qE "^SECRET_KEY_BASE=REPLACE_ME$" "${ENV_FILE}"; then
+	set_env_if_blank SECRET_KEY_BASE "$(gen 'mix phx.gen.secret' | tail -n1)"
+fi
+if ! grep -qE "^SECRET_SIGNING_SALT=.+$" "${ENV_FILE}" || grep -qE "^SECRET_SIGNING_SALT=REPLACE_ME$" "${ENV_FILE}"; then
+	set_env_if_blank SECRET_SIGNING_SALT "$(gen 'mix phx.gen.secret 32' | tail -n1)"
+fi
+if ! grep -qE "^GRAPPA_ENCRYPTION_KEY=.+$" "${ENV_FILE}" || grep -qE "^GRAPPA_ENCRYPTION_KEY=REPLACE_ME$" "${ENV_FILE}"; then
+	set_env_if_blank GRAPPA_ENCRYPTION_KEY "$(gen 'mix grappa.gen_encryption_key' | tail -n1)"
+fi
+if ! grep -qE "^VAPID_PUBLIC_KEY=.+$" "${ENV_FILE}" || grep -qE "^VAPID_PUBLIC_KEY=REPLACE_ME$" "${ENV_FILE}"; then
+	vapid="$(gen 'mix grappa.gen_vapid')"
+	set_env_if_blank VAPID_PUBLIC_KEY "$(printf '%s\n' "${vapid}" | sed -n 's/^VAPID_PUBLIC_KEY=//p')"
+	set_env_if_blank VAPID_PRIVATE_KEY "$(printf '%s\n' "${vapid}" | sed -n 's/^VAPID_PRIVATE_KEY=//p')"
+fi
+if ! grep -qE "^RELEASE_COOKIE=.+$" "${ENV_FILE}" || grep -qE "^RELEASE_COOKIE=REPLACE_ME$" "${ENV_FILE}"; then
+	set_env_if_blank RELEASE_COOKIE "$(openssl rand -hex 32)"
+fi
+force_set_env DATABASE_PATH "${REPO_ROOT}/runtime/grappa_prod.db"
+force_set_env UPLOADS_STORAGE_ROOT "${REPO_ROOT}/runtime/uploads"
+force_set_env PHX_HOST "${PHX_HOST}"
+force_set_env PORT "${PORT}"
+
+mkdir -p "${REPO_ROOT}/runtime/uploads"
+chown -R "${GRAPPA_USER}:${GRAPPA_USER}" "${REPO_ROOT}/runtime"
+
+say "6/10 first migration"
+# Plain `mix ecto.migrate`, NOT `release.sh eval 'Grappa.Release.migrate()'`.
+# Found live on a native-Linux install (2026-07-22): the packaged release's `eval`
+# (and `remote`/`rpc`, which share the same `--boot
+# "$REL_VSN_DIR/$RELEASE_BOOT_SCRIPT_CLEAN"` code path in the
+# mix-release-generated bin/grappa script) crashes the BEAM at kernel
+# boot — "Kernel pid terminated (logger)", a persistent_term/code_server
+# badarg — even for a trivial `eval '1 + 1'`. This is NOT a Grappa
+# problem: raw `erl -eval` and, critically, `bin/grappa start` (the
+# FULL boot, i.e. exactly what systemd's ExecStart uses) both work
+# fine — it's isolated to the release's minimal "start_clean" boot
+# variant specifically. Root cause not yet fully identified (see
+# LINUX.md); `mix ecto.migrate` sidesteps it entirely and matches
+# what Docker's own deploy path already does (docs/OPERATIONS.md:
+# "Docker via `mix ecto.migrate`, the jail via
+# `Grappa.Release.migrate()`") — this substrate keeps the full mix
+# toolchain around (unlike a minimal prod container), so there's no
+# reason to route through the release's eval mechanism at all here.
+run_as_grappa "
+	${asdf_path_export}
+	set -a; . '${ENV_FILE}'; set +a
+	export MIX_ENV=prod
+	cd '${REPO_ROOT}'
+	mix ecto.migrate
+"
+
+say "7/10 cic_build.sh"
+"${SCRIPT_DIR}/cic_build.sh" "${REPO_ROOT}"
+
+say "8/10 install_systemd.sh"
+"${SCRIPT_DIR}/install_systemd.sh"
+
+say "9/10 install_nginx.sh"
+LISTEN_ADDR="${LISTEN_ADDR:-0.0.0.0:80}" TRUSTED_UPSTREAM_CIDR="${TRUSTED_UPSTREAM_CIDR:-}" REPO_ROOT="${REPO_ROOT}" "${SCRIPT_DIR}/install_nginx.sh"
+
+say "10/10 starting grappa + healthcheck"
+systemctl start grappa
+
+deadline=$((SECONDS + 120))
+until curl -fsS -o /dev/null "http://127.0.0.1:${PORT}/healthz" 2>/dev/null; do
+	if [ "${SECONDS}" -ge "${deadline}" ]; then
+		die "healthcheck timed out — inspect with: journalctl -u grappa -n 200"
+	fi
+	printf '.'
+	sleep 2
+done
+printf '\n'
+
+say "grappa is up and healthy"
+cat <<EOF
+
+  Health:   curl http://127.0.0.1:${PORT}/healthz
+  Logs:     journalctl -u grappa -f
+  Status:   systemctl status grappa
+
+  IMPORTANT — back up ${ENV_FILE}'s GRAPPA_ENCRYPTION_KEY now, somewhere
+  safe and separate. It encrypts stored IRC/NickServ passwords at rest —
+  lose it and those credentials are unrecoverable.
+
+  Phoenix binds 0.0.0.0:${PORT} (not env-configurable) — firewall
+  ${PORT} to localhost-only before exposing this host publicly. Only
+  nginx (127.0.0.1) and, at the network layer, the trusted upstream
+  reverse-proxy box should be able to reach it.
+
+  Create your first user (same mix task INSTALL.md uses for the Docker
+  path — runs via the checkout's own toolchain, not the release, since
+  it's a mix task rather than a Grappa.Release.* function):
+    sudo -u ${GRAPPA_USER} -H bash -c '
+      export PATH="\$HOME/.local/bin:\$HOME/.asdf/shims:\$PATH"
+      set -a; . ${ENV_FILE}; set +a
+      cd ${REPO_ROOT}
+      MIX_ENV=prod mix grappa.create_user --name you --password "change-me"
+    '
+
+  Bind an IRC network: see README.md "Bind a network".
+EOF

--- a/infra/linux/install.sh
+++ b/infra/linux/install.sh
@@ -183,7 +183,7 @@ say "6/10 first migration"
 # FULL boot, i.e. exactly what systemd's ExecStart uses) both work
 # fine — it's isolated to the release's minimal "start_clean" boot
 # variant specifically. Root cause not yet fully identified (see
-# LINUX.md); `mix ecto.migrate` sidesteps it entirely and matches
+# infra/linux/README.md "Day-2 operations"); `mix ecto.migrate` sidesteps it entirely and matches
 # what Docker's own deploy path already does (docs/OPERATIONS.md:
 # "Docker via `mix ecto.migrate`, the jail via
 # `Grappa.Release.migrate()`") — this substrate keeps the full mix

--- a/infra/linux/install_nginx.sh
+++ b/infra/linux/install_nginx.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Install nginx config + snippets on a native Linux host, symlink the
+# cicchetto dist, enable/reload the service.
+#
+# Port of infra/freebsd/jail_install_nginx.sh. Idempotent — re-run
+# after `git pull` (or to change LISTEN_ADDR/TRUSTED_UPSTREAM_CIDR) to
+# refresh the config.
+#
+# Env overrides:
+#   REPO_ROOT              default /home/grappa/grappa
+#   LISTEN_ADDR             default 0.0.0.0:80
+#   TRUSTED_UPSTREAM_CIDR   optional — if set, nginx only accepts
+#                            connections from this CIDR (the upstream
+#                            TLS-terminating box). If unset, installs
+#                            with no source-IP restriction and prints a
+#                            loud warning rather than silently
+#                            defaulting open.
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-/home/grappa/grappa}"
+LISTEN_ADDR="${LISTEN_ADDR:-0.0.0.0:80}"
+TRUSTED_UPSTREAM_CIDR="${TRUSTED_UPSTREAM_CIDR:-}"
+
+NGINX_ETC="/etc/nginx"
+# Shared anchor with every other substrate — Grappa.Cic.Bundle reads
+# runtime/cicchetto-dist regardless of which deploy path built it.
+CIC_DIST="${REPO_ROOT}/runtime/cicchetto-dist"
+SPA_LINK="/var/www/grappa/cic"
+
+if [ ! -d "${CIC_DIST}" ]; then
+	echo "[install_nginx] ERROR: ${CIC_DIST} not present — run cic_build.sh first" >&2
+	exit 1
+fi
+
+echo "[install_nginx] rendering nginx.conf (listen=${LISTEN_ADDR})"
+if [ -n "${TRUSTED_UPSTREAM_CIDR}" ]; then
+	trusted_block="        allow ${TRUSTED_UPSTREAM_CIDR};
+        deny all;"
+else
+	echo "[install_nginx] WARNING: TRUSTED_UPSTREAM_CIDR not set — no source-IP restriction installed. Set it once the upstream reverse-proxy box's address is known and re-run." >&2
+	trusted_block="        # TRUSTED_UPSTREAM_CIDR not set at install time — no source-IP allowlist."
+fi
+
+tmp_conf="$(mktemp)"
+trap 'rm -f "${tmp_conf}"' EXIT
+# Bash string substitution, not sed: @TRUSTED_UPSTREAM_BLOCK@ is
+# multi-line (the allow/deny pair), and sed's `s|find|replace|`
+# chokes on an unescaped embedded newline in the replacement text
+# ("unterminated `s' command" — found live on a native-Linux install,
+# 2026-07-22). `${var//find/replace}` handles multi-line values fine.
+template_content="$(cat "${REPO_ROOT}/infra/linux/nginx.conf")"
+template_content="${template_content//@LISTEN_ADDR@/${LISTEN_ADDR}}"
+template_content="${template_content//@TRUSTED_UPSTREAM_BLOCK@/${trusted_block}}"
+printf '%s\n' "${template_content}" >"${tmp_conf}"
+
+echo "[install_nginx] installing config + snippets"
+install -o root -g root -m 0644 "${tmp_conf}" "${NGINX_ETC}/nginx.conf"
+mkdir -p "${NGINX_ETC}/snippets"
+install -o root -g root -m 0644 "${REPO_ROOT}/infra/snippets/locations-api.conf" "${NGINX_ETC}/snippets/locations-api.conf"
+install -o root -g root -m 0644 "${REPO_ROOT}/infra/snippets/security-headers.conf" "${NGINX_ETC}/snippets/security-headers.conf"
+
+echo "[install_nginx] linking SPA dist -> ${SPA_LINK}"
+mkdir -p "$(dirname "${SPA_LINK}")"
+rm -f "${SPA_LINK}"
+ln -sf "${CIC_DIST}" "${SPA_LINK}"
+
+echo "[install_nginx] nginx -t"
+nginx -t
+
+echo "[install_nginx] enabling nginx"
+systemctl enable nginx >/dev/null
+
+if systemctl is-active --quiet nginx; then
+	echo "[install_nginx] reloading nginx"
+	systemctl reload nginx
+else
+	echo "[install_nginx] starting nginx"
+	systemctl start nginx
+fi
+
+echo "[install_nginx] done. probe:"
+curl -fsS -w "HTTP %{http_code}\n" "http://127.0.0.1/healthz" -o /dev/null || true

--- a/infra/linux/install_prereqs.sh
+++ b/infra/linux/install_prereqs.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Idempotent apt package install + grappa system user provisioning for
+# a native Linux (Debian/Ubuntu) grappa host. Run as root.
+#
+# Package notes:
+#   - libimage-exiftool-perl: the Debian/Ubuntu name for exiftool.
+#     NOT p5-Image-ExifTool (that's the FreeBSD pkg name — different
+#     package manager, different naming convention).
+#   - ca-certificates: this is the ENTIRE Linux upstream-TLS-trust
+#     story for Grappa.IRC.Client.tls_connect_opts/1
+#     (:public_key.cacerts_get/0 reads the OS CA store). No
+#     ca_root_nss-equivalent extra step needed, unlike FreeBSD.
+#   - The autoconf/m4/libncurses-dev/libssl-dev/unzip/zlib1g-dev group
+#     are Erlang build deps for install_toolchain.sh's asdf-erlang
+#     source build (Debian/Ubuntu apt has no pinned 28.5 package).
+#   - sudo: NOT preinstalled on a minimal Debian netinst/LXC template
+#     (found live on a fresh native-Linux host, 2026-07-22) — every
+#     other script here (release.sh, cic_build.sh, install_toolchain.sh,
+#     install.sh, deploy.sh) runs build/runtime steps as the grappa
+#     user via `sudo -u grappa`. Without this package those all fail
+#     with "sudo: command not found" before install_prereqs.sh even
+#     finishes, so it's installed FIRST, before anything else below
+#     could need it.
+
+set -euo pipefail
+
+GRAPPA_USER="${GRAPPA_USER:-grappa}"
+
+echo "[install_prereqs] apt-get update"
+apt-get update -qq
+
+echo "[install_prereqs] installing sudo first (every other script here depends on it)"
+DEBIAN_FRONTEND=noninteractive apt-get install -y sudo
+
+echo "[install_prereqs] installing remaining packages"
+DEBIAN_FRONTEND=noninteractive apt-get install -y \
+	build-essential \
+	git \
+	curl \
+	libsqlite3-dev \
+	libimage-exiftool-perl \
+	ffmpeg \
+	ca-certificates \
+	nginx \
+	autoconf \
+	m4 \
+	libncurses-dev \
+	libssl-dev \
+	unzip \
+	zlib1g-dev
+
+if ! id "${GRAPPA_USER}" >/dev/null 2>&1; then
+	echo "[install_prereqs] creating user ${GRAPPA_USER}"
+	useradd --system --create-home --home-dir "/home/${GRAPPA_USER}" \
+		--shell /usr/sbin/nologin "${GRAPPA_USER}"
+else
+	echo "[install_prereqs] user ${GRAPPA_USER} already exists"
+fi
+
+echo "[install_prereqs] provisioning /etc/grappa"
+mkdir -p /etc/grappa
+chown "root:${GRAPPA_USER}" /etc/grappa
+chmod 0750 /etc/grappa
+
+echo "[install_prereqs] done"

--- a/infra/linux/install_systemd.sh
+++ b/infra/linux/install_systemd.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Install/refresh the grappa systemd unit + grappa_beam_wait.sh.
+# Enables the unit but does NOT start it — starting is the caller's
+# job (install.sh / deploy.sh), keeping this script idempotent and
+# reusable from both (same separation-of-concerns as
+# infra/freebsd/jail_install_rcd.sh).
+#
+# Env overrides:
+#   REPO_ROOT      default /home/grappa/grappa
+#   RELEASE_ROOT   default ${REPO_ROOT}/_build/prod/rel/grappa
+#   ENV_FILE       default /etc/grappa/grappa.env
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-/home/grappa/grappa}"
+RELEASE_ROOT="${RELEASE_ROOT:-${REPO_ROOT}/_build/prod/rel/grappa}"
+ENV_FILE="${ENV_FILE:-/etc/grappa/grappa.env}"
+
+# grappa_beam_wait.sh is invoked directly from its checked-in repo
+# path (grappa.service's ExecStartPre references
+# @REPO_ROOT@/infra/linux/grappa_beam_wait.sh) — nothing to copy, just
+# re-assert it's executable after a fresh clone/pull.
+chmod 0755 "${REPO_ROOT}/infra/linux/grappa_beam_wait.sh"
+
+echo "[install_systemd] rendering grappa.service (REPO_ROOT=${REPO_ROOT} RELEASE_ROOT=${RELEASE_ROOT} ENV_FILE=${ENV_FILE})"
+tmp_unit="$(mktemp)"
+trap 'rm -f "${tmp_unit}"' EXIT
+sed \
+	-e "s|@REPO_ROOT@|${REPO_ROOT}|g" \
+	-e "s|@RELEASE_ROOT@|${RELEASE_ROOT}|g" \
+	-e "s|@ENV_FILE@|${ENV_FILE}|g" \
+	"${REPO_ROOT}/infra/linux/systemd/grappa.service" >"${tmp_unit}"
+
+install -o root -g root -m 0644 "${tmp_unit}" /etc/systemd/system/grappa.service
+
+echo "[install_systemd] daemon-reload + enable"
+systemctl daemon-reload
+systemctl enable grappa >/dev/null
+
+echo "[install_systemd] done (not started — caller starts/restarts explicitly)"

--- a/infra/linux/install_toolchain.sh
+++ b/infra/linux/install_toolchain.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Install asdf + the Elixir/Erlang toolchain pinned in .tool-versions,
+# plus bun (for cic_build.sh — not packaged for Debian/Ubuntu apt), as
+# the grappa user. Run as root (this script sudo's into grappa for
+# every step).
+#
+# Why asdf over distro packages or raw kerl: Debian/Ubuntu apt repos
+# don't reliably carry the exact pinned elixir 1.19.5-otp-28 / erlang
+# 28.5 from .tool-versions — a drifted version here silently diverges
+# from what CI (erlef/setup-beam, same pin) and the FreeBSD jail
+# (also pinned) actually run. The repo already ships .tool-versions in
+# asdf's native format, so a bare `asdf install` inside the checkout
+# installs everything it lists with zero extra config — one pin, every
+# consumer reads it. asdf over raw kerl specifically because kerl would
+# need a second, hand-maintained version pin instead of reading the
+# one that's already checked in.
+#
+# asdf itself ships as a single Go binary since v0.16 (no more
+# git-clone-the-repo-and-source-a-shell-function) — this downloads the
+# latest release binary + shims, verified against the published md5.
+# Installed into ~grappa's scope, not system-wide — builds run as
+# grappa (isolation-without-root, per LINUX.md).
+#
+# Erlang is built from source (no prebuilt asdf-erlang binary for an
+# arbitrary pin) — expect ~10-20 minutes on first run. This is a
+# one-time cost, not a bug; install.sh warns the operator before
+# calling this.
+#
+# Usage: infra/linux/install_toolchain.sh [repo_root]
+# Idempotent — skips the asdf binary download if already present,
+# `asdf install` itself skips already-installed pinned versions.
+
+set -euo pipefail
+
+REPO_ROOT="${1:-/home/grappa/grappa}"
+GRAPPA_USER="${GRAPPA_USER:-grappa}"
+GRAPPA_HOME="$(getent passwd "${GRAPPA_USER}" | cut -d: -f6)"
+ASDF_BIN_DIR="${GRAPPA_HOME}/.local/bin"
+
+run_as_grappa() {
+	sudo -u "${GRAPPA_USER}" -H bash -c "$1"
+}
+
+# PATH exported for every run_as_grappa call below: the asdf binary
+# itself, plus its shims dir (where `asdf install` links tool
+# executables — this is what makes `mix`/`elixir`/`erl` resolve once
+# installed).
+asdf_path_export="export PATH=\"${ASDF_BIN_DIR}:\${HOME}/.asdf/shims:\${PATH}\""
+
+if [ ! -x "${ASDF_BIN_DIR}/asdf" ]; then
+	echo "[install_toolchain] downloading asdf (latest release)"
+	arch="$(uname -m)"
+	case "${arch}" in
+		x86_64) asdf_arch=amd64 ;;
+		aarch64) asdf_arch=arm64 ;;
+		*) echo "[install_toolchain] ERROR: unsupported arch ${arch}" >&2; exit 1 ;;
+	esac
+
+	version="$(curl -fsS https://api.github.com/repos/asdf-vm/asdf/releases/latest | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)"
+	if [ -z "${version}" ]; then
+		echo "[install_toolchain] ERROR: could not determine latest asdf version from the GitHub API" >&2
+		exit 1
+	fi
+
+	tmp_dir="$(mktemp -d)"
+	trap 'rm -rf "${tmp_dir}"' EXIT
+	archive="asdf-${version}-linux-${asdf_arch}.tar.gz"
+	curl -fsSL -o "${tmp_dir}/${archive}" "https://github.com/asdf-vm/asdf/releases/download/${version}/${archive}"
+	curl -fsSL -o "${tmp_dir}/${archive}.md5" "https://github.com/asdf-vm/asdf/releases/download/${version}/${archive}.md5"
+	# asdf's .md5 sidecar is a bare hash with no filename (not the
+	# "HASH  filename" format `md5sum -c` expects) — compare directly.
+	expected_md5="$(tr -d ' \n' < "${tmp_dir}/${archive}.md5")"
+	actual_md5="$(md5sum "${tmp_dir}/${archive}" | awk '{print $1}')"
+	if [ "${expected_md5}" != "${actual_md5}" ]; then
+		echo "[install_toolchain] ERROR: md5 mismatch for ${archive} (expected ${expected_md5}, got ${actual_md5})" >&2
+		exit 1
+	fi
+	tar -xzf "${tmp_dir}/${archive}" -C "${tmp_dir}"
+
+	run_as_grappa "mkdir -p '${ASDF_BIN_DIR}'"
+	install -o "${GRAPPA_USER}" -g "${GRAPPA_USER}" -m 0755 "${tmp_dir}/asdf" "${ASDF_BIN_DIR}/asdf"
+	echo "[install_toolchain] installed asdf ${version} -> ${ASDF_BIN_DIR}/asdf"
+else
+	echo "[install_toolchain] asdf already present at ${ASDF_BIN_DIR}/asdf"
+fi
+
+echo "[install_toolchain] ensuring erlang + elixir asdf plugins"
+run_as_grappa "${asdf_path_export}; asdf plugin add erlang 2>/dev/null || true; asdf plugin add elixir 2>/dev/null || true"
+
+echo "[install_toolchain] asdf install (reads .tool-versions — can take 10-20 min for erlang, building from source)"
+# KERL_CONFIGURE_OPTIONS: headless host, skip wx/observer's X11/GTK
+# dependency chain and the debugger/javac interop — none of it is
+# used (scripts/observer.sh-equivalent tooling is observer_cli, not
+# OTP's :wx-based observer).
+run_as_grappa "
+	${asdf_path_export}
+	export KERL_CONFIGURE_OPTIONS='--without-wx --without-javac --without-debugger --without-observer'
+	cd '${REPO_ROOT}'
+	asdf install
+"
+
+if [ ! -x "${ASDF_BIN_DIR}/bun" ]; then
+	echo "[install_toolchain] downloading bun (latest release) — needed for cic_build.sh, not on Debian apt"
+	arch="$(uname -m)"
+	case "${arch}" in
+		x86_64) bun_arch=x64 ;;
+		aarch64) bun_arch=aarch64 ;;
+		*) echo "[install_toolchain] ERROR: unsupported arch ${arch}" >&2; exit 1 ;;
+	esac
+
+	tmp_dir="$(mktemp -d)"
+	trap 'rm -rf "${tmp_dir}"' EXIT
+	archive="bun-linux-${bun_arch}.zip"
+	curl -fsSL -o "${tmp_dir}/${archive}" "https://github.com/oven-sh/bun/releases/latest/download/${archive}"
+	curl -fsSL -o "${tmp_dir}/SHASUMS256.txt" "https://github.com/oven-sh/bun/releases/latest/download/SHASUMS256.txt"
+	( cd "${tmp_dir}" && sha256sum -c <(grep " ${archive}\$" SHASUMS256.txt) )
+	unzip -q "${tmp_dir}/${archive}" -d "${tmp_dir}"
+
+	run_as_grappa "mkdir -p '${ASDF_BIN_DIR}'"
+	install -o "${GRAPPA_USER}" -g "${GRAPPA_USER}" -m 0755 "${tmp_dir}/bun-linux-${bun_arch}/bun" "${ASDF_BIN_DIR}/bun"
+	echo "[install_toolchain] installed bun -> ${ASDF_BIN_DIR}/bun"
+else
+	echo "[install_toolchain] bun already present at ${ASDF_BIN_DIR}/bun"
+fi
+
+echo "[install_toolchain] done — versions in ${REPO_ROOT}:"
+run_as_grappa "${asdf_path_export}; cd '${REPO_ROOT}'; asdf current"
+run_as_grappa "${asdf_path_export}; bun --version"

--- a/infra/linux/install_toolchain.sh
+++ b/infra/linux/install_toolchain.sh
@@ -19,7 +19,7 @@
 # git-clone-the-repo-and-source-a-shell-function) — this downloads the
 # latest release binary + shims, verified against the published md5.
 # Installed into ~grappa's scope, not system-wide — builds run as
-# grappa (isolation-without-root, per LINUX.md).
+# grappa (isolation-without-root).
 #
 # Erlang is built from source (no prebuilt asdf-erlang binary for an
 # arbitrary pin) — expect ~10-20 minutes on first run. This is a

--- a/infra/linux/nginx.conf
+++ b/infra/linux/nginx.conf
@@ -1,0 +1,54 @@
+# grappa — nginx config for a native Linux (systemd) host.
+#
+# Mirrors infra/freebsd/nginx.conf's topology: this host's nginx does
+# NOT terminate TLS. A separate upstream machine already reverse-
+# proxies the operator's public http/https traffic and forwards here
+# over plain HTTP — same shape as the FreeBSD jail (host nginx on m42
+# → jail :80). Nothing below needs to change when that upstream
+# machine's address changes; nginx itself doesn't restrict by source
+# IP unless TRUSTED_UPSTREAM_CIDR is set at install time (see
+# install_nginx.sh) — set it once the upstream box's address is known.
+#
+# Installed by install_nginx.sh, which:
+#   1. cp this file → /etc/nginx/nginx.conf (substituting @LISTEN_ADDR@
+#      and the optional allow/deny block)
+#   2. cp ../snippets/*.conf → /etc/nginx/snippets/
+#   3. ln -s <repo>/runtime/cicchetto-dist → /var/www/grappa/cic
+#   4. nginx -t && systemctl enable --now nginx (or reload if already up)
+
+worker_processes auto;
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        on;
+    keepalive_timeout 65;
+    server_tokens   off;
+
+    upstream grappa_upstream {
+        server 127.0.0.1:4000;
+        keepalive 32;
+    }
+
+    server {
+        listen @LISTEN_ADDR@ default_server;
+        server_name _;
+
+@TRUSTED_UPSTREAM_BLOCK@
+
+        # SPA dist path — symlinked by install_nginx.sh from
+        # <repo>/runtime/cicchetto-dist (shared anchor with the Docker
+        # and FreeBSD substrates; see Grappa.Cic.Bundle).
+        root /var/www/grappa/cic;
+        index index.html;
+
+        # All routing rules live in the snippet shared with every
+        # other substrate — single source of truth for the REST
+        # allowlist, admin allowlist, /socket WS upgrade, SPA fallback.
+        include snippets/locations-api.conf;
+    }
+}

--- a/infra/linux/release.sh
+++ b/infra/linux/release.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Run `bin/grappa <args>` as the grappa user on a native Linux/systemd
+# host, with the secrets env file sourced first.
+#
+# Usage (as root, or any user that can sudo -u grappa):
+#   infra/linux/release.sh version
+#   infra/linux/release.sh eval 'Grappa.Release.migrate()'
+#   infra/linux/release.sh remote
+#   infra/linux/release.sh stop
+#
+# Port of infra/freebsd/jail_release.sh. Simpler here: no bastille-cmd
+# argv-eating quirk to work around, so no $0-vs-$@ reconstruction dance.
+
+set -euo pipefail
+
+RELEASE_PATH="${RELEASE_PATH:-/home/grappa/grappa/_build/prod/rel/grappa}"
+ENV_FILE="${ENV_FILE:-/etc/grappa/grappa.env}"
+GRAPPA_USER="${GRAPPA_USER:-grappa}"
+
+if [ ! -r "${ENV_FILE}" ]; then
+	echo "[release] ERROR: env file ${ENV_FILE} not readable" >&2
+	exit 1
+fi
+
+exec sudo -u "${GRAPPA_USER}" -H bash -c '
+set -euo pipefail
+set -a
+. "'"${ENV_FILE}"'"
+set +a
+exec "'"${RELEASE_PATH}"'/bin/grappa" "$@"
+' bash "$@"

--- a/infra/linux/systemd/grappa.service
+++ b/infra/linux/systemd/grappa.service
@@ -1,0 +1,65 @@
+# Grappa IRC bouncer — systemd unit for the native Linux deploy
+# substrate (mix release build, no Docker).
+#
+# Template: install_systemd.sh substitutes @REPO_ROOT@, @RELEASE_ROOT@,
+# @ENV_FILE@ via sed before installing to
+# /etc/systemd/system/grappa.service.
+#
+# Design note (see infra/linux/README.md for the full rationale): this
+# deliberately does NOT replicate infra/freebsd/rc.d/grappa's custom
+# stop/start synchronization wrapper. `ExecStart=... bin/grappa start`
+# runs the release in the FOREGROUND (not `daemon`, which backgrounds
+# via run_erl — the FreeBSD substrate needed that because rc.d isn't a
+# process supervisor). Under Type=exec, systemd tracks that PID
+# directly: `systemctl stop`/`restart` send SIGTERM and BLOCK until the
+# process actually exits (bounded by TimeoutStopSec) before proceeding.
+# lib/grappa/session/server.ex's terminate/2 already handles SIGTERM
+# with a clean upstream QUIT (issue #215) — so this closes the FreeBSD
+# defect #9 stop/start race (2026-06-11 outage: an async stop let a
+# restart collide with a still-draining old node's epmd registration)
+# at the root cause, without a custom ExecStop wrapper.
+#
+# grappa_beam_wait.sh's wait-name-free is kept as a defense-in-depth
+# ExecStartPre guard for restart-cycling edge cases, not as the primary
+# sync mechanism.
+
+[Unit]
+Description=Grappa IRC bouncer
+Documentation=https://github.com/vjt/grappa-irc
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=exec
+User=grappa
+Group=grappa
+WorkingDirectory=@REPO_ROOT@
+
+# Root reads this before dropping to User=grappa — the file itself
+# need not be world/grappa-readable (see infra/linux/grappa.env.example
+# header, chmod 640 root:grappa is fine).
+EnvironmentFile=@ENV_FILE@
+
+# Explicit PATH, belt-and-braces parity with the FreeBSD PATH-gap
+# incident (rc(8)/systemd both strip custom bin dirs by default;
+# exiftool/ffmpeg became invisible to System.find_executable/1,
+# fail-closed 422ing every upload). Debian/Ubuntu package exiftool
+# (libimage-exiftool-perl) and ffmpeg into /usr/bin by default, so this
+# is currently redundant — kept anyway as documented defense-in-depth,
+# not because it's known to be needed on this substrate.
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+ExecStartPre=@REPO_ROOT@/infra/linux/grappa_beam_wait.sh wait-name-free grappa 15
+ExecStart=@RELEASE_ROOT@/bin/grappa start
+
+TimeoutStartSec=30
+TimeoutStopSec=30
+
+# New capability vs. rc.d (which has no auto-restart at all) — safe to
+# add because systemd's restart sequencing (stop fully, then start) is
+# synchronous by construction under Type=exec.
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/lib/grappa/application.ex
+++ b/lib/grappa/application.ex
@@ -232,52 +232,62 @@ defmodule Grappa.Application do
         # rather than the front-line tolerance. See DESIGN_NOTES
         # 2026-05-02.
         {DynamicSupervisor,
-         name: Grappa.SessionSupervisor, strategy: :one_for_one, max_restarts: 10_000, max_seconds: 60},
-
+         name: Grappa.SessionSupervisor, strategy: :one_for_one, max_restarts: 10_000, max_seconds: 60}
+      ] ++
         # Endpoint after PubSub + Registry — HTTP requests (REST controller,
-        # WS Channel join) reach into both at request time.
-        GrappaWeb.Endpoint,
+        # WS Channel join) reach into both at request time. Conditional on
+        # :start_endpoint (mirrors :start_bootstrap below): the `grappa.*`
+        # one-shot operator mix tasks (Mix.Tasks.Grappa.Boot.start_app_silent/0)
+        # need Repo + the domain contexts but NOT the HTTP surface — starting
+        # it anyway used to force "stop the live service first" for every
+        # admin task (create_user, bind_network, seed_themes, ...), since a
+        # second bind of the same port crashes `:eaddrinuse`. An app that
+        # ships hot code-reload has no business demanding a full stop/start
+        # cycle just to run a one-off DB mutation alongside it. Found live
+        # 2026-07-23 running `grappa.seed_themes` against a live host.
+        endpoint_child() ++
+        [
+          # Reaper after Repo (it queries Visitors via Repo) and after
+          # Endpoint, WHEN PRESENT (so a slow boot doesn't sweep before the
+          # public surface is up — Reaper's sweep deletes rows that REST/WS
+          # might reach for; ordering it after Endpoint keeps the
+          # "everything visible to clients is also visible to Reaper"
+          # invariant honest). The default 60s interval is far longer
+          # than boot, so the first sweep waits anyway — ordering is
+          # belt-and-braces. Reaper consumes Grappa.Visitors; the
+          # Application boundary has it listed in deps for that reason.
+          Grappa.Visitors.Reaper,
 
-        # Reaper after Repo (it queries Visitors via Repo) and after
-        # Endpoint (so a slow boot doesn't sweep before the public
-        # surface is up — Reaper's sweep deletes rows that REST/WS
-        # might reach for; ordering it after Endpoint keeps the
-        # "everything visible to clients is also visible to Reaper"
-        # invariant honest). The default 60s interval is far longer
-        # than boot, so the first sweep waits anyway — ordering is
-        # belt-and-braces. Reaper consumes Grappa.Visitors; the
-        # Application boundary has it listed in deps for that reason.
-        Grappa.Visitors.Reaper,
+          # UX-6-B1 (2026-05-20): embedded image uploader Reaper. Same
+          # rationale as Visitors.Reaper for the ordering: after Repo
+          # (it queries `uploads`) + after Endpoint, when present (so the
+          # GET surface is up before sweeps remove rows + files clients
+          # might be reaching for). The Reaper also mkdir_p's the
+          # storage_root in `init/1` so a fresh deploy needs no separate
+          # bootstrap. `:storage_root` is read from
+          # `:grappa, :uploads_storage_root` at THIS boot-time boundary —
+          # the controller + Reaper read from `:persistent_term`
+          # thereafter (CLAUDE.md "Application.{put,get}_env: boot-time
+          # only").
+          {Grappa.Uploads.Reaper, storage_root: uploads_storage_root()},
 
-        # UX-6-B1 (2026-05-20): embedded image uploader Reaper. Same
-        # rationale as Visitors.Reaper for the ordering: after Repo
-        # (it queries `uploads`) + after Endpoint (so the GET surface
-        # is up before sweeps remove rows + files clients might be
-        # reaching for). The Reaper also mkdir_p's the storage_root
-        # in `init/1` so a fresh deploy needs no separate bootstrap.
-        # `:storage_root` is read from `:grappa, :uploads_storage_root`
-        # at THIS boot-time boundary — the controller + Reaper read
-        # from `:persistent_term` thereafter (CLAUDE.md
-        # "Application.{put,get}_env: boot-time only").
-        {Grappa.Uploads.Reaper, storage_root: uploads_storage_root()},
+          # #223: auth-session housekeeping GC. Sibling of Visitors.Reaper
+          # / Uploads.Reaper — a THIRD domain (Accounts) gets its OWN
+          # periodic sweep rather than folding into an unrelated reaper
+          # (CLAUDE.md rule 6 — reuse the verb, not the noun). Same
+          # ordering rationale: after Repo (it queries `sessions`) and
+          # after Endpoint, when present (so the auth surface is up before
+          # the sweep removes idle-expired rows). Bulk `delete_all` over
+          # USER sessions past the 7-day idle window that `authenticate/1`
+          # already rejects; visitor sessions are out of scope (they
+          # CASCADE from the visitor row via Visitors.Reaper). Default
+          # 60s interval >> boot, so the first sweep waits anyway.
+          Grappa.Accounts.Reaper
 
-        # #223: auth-session housekeeping GC. Sibling of Visitors.Reaper
-        # / Uploads.Reaper — a THIRD domain (Accounts) gets its OWN
-        # periodic sweep rather than folding into an unrelated reaper
-        # (CLAUDE.md rule 6 — reuse the verb, not the noun). Same
-        # ordering rationale: after Repo (it queries `sessions`) and
-        # after Endpoint (so the auth surface is up before the sweep
-        # removes idle-expired rows). Bulk `delete_all` over USER
-        # sessions past the 7-day idle window that `authenticate/1`
-        # already rejects; visitor sessions are out of scope (they
-        # CASCADE from the visitor row via Visitors.Reaper). Default
-        # 60s interval >> boot, so the first sweep waits anyway.
-        Grappa.Accounts.Reaper
-
-        # Bootstrap is appended LAST below: it depends on Registry +
-        # SessionSupervisor existing so it can spawn sessions. Conditional
-        # on :start_bootstrap so test boots empty.
-      ] ++ bootstrap_child()
+          # Bootstrap is appended LAST below: it depends on Registry +
+          # SessionSupervisor existing so it can spawn sessions. Conditional
+          # on :start_bootstrap so test boots empty.
+        ] ++ bootstrap_child()
 
     opts = [strategy: :one_for_one, name: Grappa.Supervisor]
 
@@ -304,6 +314,22 @@ defmodule Grappa.Application do
   defp bootstrap_child do
     if Application.get_env(:grappa, :start_bootstrap, true) do
       [Grappa.Bootstrap]
+    else
+      []
+    end
+  end
+
+  # Endpoint is opt-out via the `:start_endpoint` flag (true everywhere
+  # except when a one-shot operator mix task flips it off via
+  # `Mix.Tasks.Grappa.Boot.start_app_silent/0` — see that module).
+  # Mirrors `bootstrap_child/0` exactly: same shape, same reason (a
+  # caller that only needs the Repo-backed supervision tree shouldn't
+  # be forced to also take on a side effect it never asked for — here,
+  # binding the HTTP port a live release already owns).
+  @spec endpoint_child() :: [] | [GrappaWeb.Endpoint]
+  defp endpoint_child do
+    if Application.get_env(:grappa, :start_endpoint, true) do
+      [GrappaWeb.Endpoint]
     else
       []
     end

--- a/lib/grappa/deploy/preflight.ex
+++ b/lib/grappa/deploy/preflight.ex
@@ -29,13 +29,16 @@ defmodule Grappa.Deploy.Preflight do
 
   Classification is per-substrate (`:docker` for the dev/CI compose
   stack via `scripts/deploy.sh`, `:jail` for the m42 bastille jail via
-  `infra/freebsd/deploy.sh`). Most classes are substrate-independent
+  `infra/freebsd/deploy.sh`, `:linux` for a native systemd host via
+  `infra/linux/deploy.sh`). Most classes are substrate-independent
   (deps, supervision tree, migrations, nginx, config, state-shape),
   but the boot-substrate files are not: a `Dockerfile` diff is COLD
-  on Docker and irrelevant to the jail, and `infra/freebsd/rc.d/grappa`
-  is COLD on the jail and irrelevant to Docker. The 2026-06-10
-  metadata-strip deploy cold-restarted prod (ALL IRC sessions dropped)
-  for a Dockerfile diff the jail never reads — on an always-on bouncer
+  on Docker and irrelevant to the jail or a systemd host,
+  `infra/freebsd/rc.d/grappa` is COLD on the jail and irrelevant
+  elsewhere, and `infra/linux/systemd/grappa.service` is COLD on
+  `:linux` and irrelevant elsewhere. The 2026-06-10 metadata-strip
+  deploy cold-restarted prod (ALL IRC sessions dropped) for a
+  Dockerfile diff the jail never reads — on an always-on bouncer
   every needless restart is incident-grade, so the substrate is an
   explicit required argument, never a default.
 
@@ -56,13 +59,14 @@ defmodule Grappa.Deploy.Preflight do
 
   alias Grappa.HotReload.LongLivedModules
 
-  @type substrate :: :docker | :jail
+  @type substrate :: :docker | :jail | :linux
 
   @type reason ::
           {:mix_deps, [String.t()]}
           | {:application, [String.t()]}
           | {:image_substrate, [String.t()]}
           | {:rc_d, [String.t()]}
+          | {:systemd_unit, [String.t()]}
           | {:migration, [String.t()]}
           | {:nginx, [String.t()]}
           | {:config, [String.t()]}
@@ -70,7 +74,7 @@ defmodule Grappa.Deploy.Preflight do
 
   @type verdict :: {:hot, []} | {:cold, [reason()]}
 
-  @substrates [:docker, :jail]
+  @substrates [:docker, :jail, :linux]
   # CLI-boundary mirror of @substrates — derived, not hand-kept, so a
   # third substrate can't be accepted by classify_paths/2 yet rejected
   # at the cli/1 guard (or vice versa).
@@ -95,6 +99,7 @@ defmodule Grappa.Deploy.Preflight do
       |> add_reason(:application, Enum.filter(paths, &application?/1))
       |> add_reason(:image_substrate, filter_on(:docker, substrate, paths, &docker_image?/1))
       |> add_reason(:rc_d, filter_on(:jail, substrate, paths, &rc_d?/1))
+      |> add_reason(:systemd_unit, filter_on(:linux, substrate, paths, &systemd_unit?/1))
       |> add_reason(:migration, Enum.filter(paths, &migration?/1))
       |> add_reason(:nginx, Enum.filter(paths, &nginx?/1))
       |> add_reason(:config, Enum.filter(paths, &config?/1))
@@ -176,7 +181,7 @@ defmodule Grappa.Deploy.Preflight do
   @doc """
   CLI entry point invoked by the deploy orchestrators
   (`scripts/deploy.sh` passes `"docker"`, `infra/freebsd/deploy.sh`
-  passes `"jail"`).
+  passes `"jail"`, `infra/linux/deploy.sh` passes `"linux"`).
 
   Expects exactly three args: `from_sha`, `to_sha`, and the substrate
   string. A missing or unknown substrate is a usage error (exit 2) —
@@ -218,7 +223,7 @@ defmodule Grappa.Deploy.Preflight do
   def cli(_) do
     IO.puts(
       :stderr,
-      "usage: mix run -e 'Grappa.Deploy.Preflight.cli([from_sha, to_sha, \"docker\" | \"jail\"])'"
+      "usage: mix run -e 'Grappa.Deploy.Preflight.cli([from_sha, to_sha, \"docker\" | \"jail\" | \"linux\"])'"
     )
 
     System.halt(2)
@@ -332,6 +337,16 @@ defmodule Grappa.Deploy.Preflight do
   # cold path runs before every restart.
   defp rc_d?("infra/freebsd/rc.d/grappa"), do: true
   defp rc_d?(_), do: false
+
+  # Class 4c: Linux systemd unit — applies ONLY when classifying for
+  # :linux. Sibling of rc_d?/1 (4b) and docker_image?/1 (4a): a changed
+  # unit file needs `systemctl daemon-reload` + a restart to take
+  # effect (there is no hot-reload of a running unit's own
+  # definition), and neither Docker nor the jail read this file at
+  # all, so the rule must stay :linux-scoped via filter_on/4 the same
+  # way rc_d? is :jail-scoped.
+  defp systemd_unit?("infra/linux/systemd/grappa.service"), do: true
+  defp systemd_unit?(_), do: false
 
   # Class 5: migrations. The hot path skips `mix ecto.migrate`; new
   # tables/columns 500 on first query post-reload (REV-B repro'd this).

--- a/lib/grappa_web/controllers/admin_controller.ex
+++ b/lib/grappa_web/controllers/admin_controller.ex
@@ -4,15 +4,23 @@ defmodule GrappaWeb.AdminController do
 
   ## `POST /admin/reload`
 
-  Delegates to `Grappa.HotReload.reload_modified/0`: walks
-  `:code.modified_modules/0` (Erlang built-in: modules whose .beam on
-  disk has a different hash than the loaded BEAM) and reloads each
-  via `:code.soft_purge/1` + `:code.load_file/1` — see that module
-  for why soft-purge (the 2026-06-10 double-hot-deploy `:not_purged`
-  live repro, and why hard purge would drop IRC sessions). Returns
-  `200 OK` with JSON `%{"reloaded" => ["Elixir.Mod.Name", ...]}` —
-  the list is empty when nothing changed, useful as positive
-  evidence in deploy scripts.
+  Delegates to `Grappa.HotReload.reload_modified/0`: walks the app's
+  own `ebin` dir by absolute path and, per `.beam` file, reloads it
+  if it's new (module never loaded) or changed (on-disk md5 differs
+  from the loaded version's `module_info(:md5)`) via
+  `:code.soft_purge/1` + `:code.load_abs/1` — see that module's
+  moduledoc for why NOT `:code.modified_modules/0` +
+  `:code.load_file/1` (both were tried first and both have live-repro'd
+  blind spots: `modified_modules/0` never sees a module that's brand
+  new, and OTP's cached code path is blind to files added after boot),
+  and for why soft-purge (the 2026-06-10 double-hot-deploy
+  `:not_purged` live repro, and why hard purge would drop IRC
+  sessions). Returns `200 OK` with JSON
+  `%{"reloaded" => ["Elixir.Mod.Name", ...], "failed" => [%{"module" =>
+  ..., "reason" => ...}, ...]}` — both empty when nothing changed;
+  a non-empty `failed` is NOT itself surfaced as a non-200 status, so
+  callers (deploy scripts) MUST inspect the body, not just the HTTP
+  status.
 
   ### Why not `Phoenix.CodeReloader`
 
@@ -25,10 +33,11 @@ defmodule GrappaWeb.AdminController do
   no-ops. The previous shape "POST → :ok → trust it" hid the
   failure (see `feedback_hot_deploy_silent_noop_prod`).
 
-  `:code.modified_modules/0` is a release-friendly OTP built-in
-  that compares BEAM hash on disk vs in memory — no Mix dependency,
-  no compile-time config requirement. Works identically in dev,
-  Docker prod, and FreeBSD jail.
+  `Grappa.HotReload`'s own md5-walk is release-friendly by
+  construction — no Mix dependency, no compile-time config
+  requirement, and (unlike `:code.modified_modules/0`) it also
+  catches brand-new modules. Works identically in dev, Docker prod,
+  the FreeBSD jail, and this substrate's systemd unit.
 
   ### Hot-deploy responsibilities split
 
@@ -37,9 +46,10 @@ defmodule GrappaWeb.AdminController do
 
     * Docker (mix phx.server): `docker exec grappa mix compile`
       writes new .beam to `_build/${MIX_ENV}/lib/grappa/ebin/`.
-    * FreeBSD jail (release): `mix release --overwrite` writes new
-      .beam to `_build/prod/rel/grappa/lib/grappa-X.Y/ebin/` (the
-      path that the daemon's `code:get_path/0` includes).
+    * FreeBSD jail (release) and native Linux/systemd (release): both
+      run `mix release --overwrite`, writing new .beam to
+      `_build/prod/rel/grappa/lib/grappa-X.Y/ebin/` (the path that
+      the daemon's `code:get_path/0` includes).
 
   Either path → POST /admin/reload → live BEAM picks up the new
   .beam. Sessions (Session.Server, IRC.Client, etc.) keep state
@@ -54,12 +64,17 @@ defmodule GrappaWeb.AdminController do
       # Bastille jail
       sudo bastille cmd grappa /home/grappa/grappa/infra/freebsd/deploy.sh
 
+      # Native Linux/systemd
+      infra/linux/deploy.sh
+
   Module-shape changes that can't be hot-swapped (mix.lock bump,
   supervision tree restructure, struct shape change in long-lived
   GenServer state) require the cold path —
-  `scripts/deploy.sh` (Docker) or
-  `infra/freebsd/deploy.sh --force-cold` (jail). Both auto-detect
-  unsafe diffs via the shared `Grappa.Deploy.Preflight` classifier.
+  `scripts/deploy.sh` (Docker), `infra/freebsd/deploy.sh --force-cold`
+  (jail), or `infra/linux/deploy.sh` (Linux — always cold when the
+  diff needs it, no force flag exists yet on this substrate). All
+  three auto-detect unsafe diffs via the shared
+  `Grappa.Deploy.Preflight` classifier.
 
   ## `POST /admin/cic-bundle-changed`
 

--- a/lib/mix/tasks/grappa/boot.ex
+++ b/lib/mix/tasks/grappa/boot.ex
@@ -18,15 +18,27 @@ defmodule Mix.Tasks.Grappa.Boot do
   tasks call `start_app_silent/0` and stay focused on their domain
   work.
 
-  See `Grappa.Application.bootstrap_child/0` for the
-  `:start_bootstrap` flag's contract.
+  Also suppresses `GrappaWeb.Endpoint` (2026-07-23) — these tasks
+  mutate the DB, never serve HTTP, so there was never a reason for one
+  to bind port 4000. Before this fix it did anyway, which meant every
+  admin task (`create_user`, `bind_network`, `seed_themes`, ...) had to
+  `systemctl stop grappa` first against a live host or crash
+  `:eaddrinuse` — found live running `grappa.seed_themes` against a
+  live install while the service was up. An app built around hot code
+  reload has no business demanding a full stop/start cycle for a
+  one-off DB mutation.
+
+  See `Grappa.Application.bootstrap_child/0` and `endpoint_child/0` for
+  the `:start_bootstrap` / `:start_endpoint` flags' contracts.
   """
   use Boundary, top_level?: true
 
   @doc """
-  Starts the `:grappa` application with the Bootstrap supervisor
-  child suppressed, so the IRC supervision tree boots empty (no
-  upstream connections). Returns `:ok` on success.
+  Starts the `:grappa` application with the Bootstrap supervisor child
+  AND `GrappaWeb.Endpoint` both suppressed, so the app boots with just
+  Repo + Vault + the domain contexts — no upstream IRC connections, no
+  HTTP port bound (so it never conflicts with an already-running
+  release on the same host). Returns `:ok` on success.
 
   Runs `mix app.config` first — found live 2026-07-22 (native Linux
   systemd deploy, first `MIX_ENV=prod` install): a bare
@@ -60,6 +72,7 @@ defmodule Mix.Tasks.Grappa.Boot do
   def start_app_silent do
     Mix.Task.run("app.config")
     Application.put_env(:grappa, :start_bootstrap, false)
+    Application.put_env(:grappa, :start_endpoint, false)
 
     case Application.ensure_all_started(:grappa) do
       {:ok, _} -> :ok

--- a/lib/mix/tasks/grappa/boot.ex
+++ b/lib/mix/tasks/grappa/boot.ex
@@ -28,6 +28,24 @@ defmodule Mix.Tasks.Grappa.Boot do
   child suppressed, so the IRC supervision tree boots empty (no
   upstream connections). Returns `:ok` on success.
 
+  Runs `mix app.config` first — found live 2026-07-22 (native Linux
+  systemd deploy, first `MIX_ENV=prod` install): a bare
+  `Application.ensure_all_started/1`, unlike `mix run`/`mix
+  phx.server`, does NOT evaluate `config/runtime.exs` on its own. This
+  was invisible under Docker's default `MIX_ENV=dev` (where
+  `config/dev.exs` hardcodes `uploads_storage_root`/`database_path`,
+  no runtime.exs needed for those), but under `MIX_ENV=prod` — where
+  those values exist ONLY in runtime.exs — every one of the six
+  `grappa.*` operator tasks that call this function
+  (`create_user` included) crashed with `Application.fetch_env!/2`
+  raising "configuration ... was not set", not a Grappa bug in the
+  fetched key itself. `mix app.config` is Mix's own task for
+  "load app config, including runtime.exs, without starting the app"
+  — exactly what was missing. Idempotent within a single `mix`
+  invocation (`Mix.Task.run/2` only runs a given task once unless
+  `Mix.Task.rerun/2` is used), so this is safe even if a caller
+  already triggered it some other way.
+
   The list of started applications from
   `Application.ensure_all_started/1` is discarded — operator tasks
   don't act on it. Returning `:ok` (instead of `[Application.app()]`)
@@ -40,6 +58,7 @@ defmodule Mix.Tasks.Grappa.Boot do
   """
   @spec start_app_silent() :: :ok
   def start_app_silent do
+    Mix.Task.run("app.config")
     Application.put_env(:grappa, :start_bootstrap, false)
 
     case Application.ensure_all_started(:grappa) do

--- a/lib/mix/tasks/grappa/option_parsing.ex
+++ b/lib/mix/tasks/grappa/option_parsing.ex
@@ -13,8 +13,30 @@ defmodule Mix.Tasks.Grappa.OptionParsing do
   """
   use Boundary, top_level?: true
 
-  @auth_methods ~w(auto sasl server_pass nickserv_identify none)a
-  @auth_strings Enum.map(@auth_methods, &Atom.to_string/1)
+  # Explicit string->atom map, NOT `~w(...)a` + `String.to_existing_atom/1`.
+  # Found live 2026-07-23 (native Linux, MIX_ENV=prod mix task
+  # invocation): `~w(...)a` only exists as atoms during THIS module's
+  # own compile-time attribute evaluation — since the runtime function
+  # body below only ever touches the derived STRINGS, the atoms
+  # themselves never get compiled into this module's bytecode, so
+  # loading `OptionParsing` does not register them in the atom table.
+  # `to_existing_atom("nickserv_identify")` then raises unless some
+  # OTHER module that references that literal atom (e.g. the
+  # NetworkCredential schema's changeset validation) happened to load
+  # first — true under a full release boot (everything gets referenced
+  # eventually) but not guaranteed for a bare `mix grappa.bind_network`
+  # invocation. Writing the atoms as literal map values here makes them
+  # part of THIS module's own compiled bytecode, so they exist the
+  # moment `OptionParsing` itself loads — no dependency on load order
+  # elsewhere.
+  @auth_map %{
+    "auto" => :auto,
+    "sasl" => :sasl,
+    "server_pass" => :server_pass,
+    "nickserv_identify" => :nickserv_identify,
+    "none" => :none
+  }
+  @auth_strings Map.keys(@auth_map)
 
   @doc """
   Parses a `host:port` server spec into `{host, port}`. Raises on
@@ -43,10 +65,9 @@ defmodule Mix.Tasks.Grappa.OptionParsing do
   @spec parse_auth(String.t()) ::
           :auto | :sasl | :server_pass | :nickserv_identify | :none
   def parse_auth(str) when is_binary(str) do
-    if str in @auth_strings do
-      String.to_existing_atom(str)
-    else
-      Mix.raise("--auth must be one of #{Enum.join(@auth_strings, "|")} (got #{inspect(str)})")
+    case Map.fetch(@auth_map, str) do
+      {:ok, atom} -> atom
+      :error -> Mix.raise("--auth must be one of #{Enum.join(@auth_strings, "|")} (got #{inspect(str)})")
     end
   end
 

--- a/test/grappa/deploy/preflight_test.exs
+++ b/test/grappa/deploy/preflight_test.exs
@@ -4,7 +4,7 @@ defmodule Grappa.Deploy.PreflightTest do
 
   alias Grappa.Deploy.Preflight
 
-  @substrates [:docker, :jail]
+  @substrates [:docker, :jail, :linux]
 
   describe "classify_paths/2 — Class 1: dep / build config (substrate-independent)" do
     test "mix.lock → cold with :mix_deps reason on both substrates" do
@@ -55,6 +55,10 @@ defmodule Grappa.Deploy.PreflightTest do
       test "#{file} → hot on jail (jail never reads Docker image files)" do
         assert {:hot, []} = Preflight.classify_paths([unquote(file)], :jail)
       end
+
+      test "#{file} → hot on linux (linux never reads Docker image files)" do
+        assert {:hot, []} = Preflight.classify_paths([unquote(file)], :linux)
+      end
     end
   end
 
@@ -74,6 +78,27 @@ defmodule Grappa.Deploy.PreflightTest do
 
     test "#{@rc_d} → hot on docker (no rc(8) in the container)" do
       assert {:hot, []} = Preflight.classify_paths([@rc_d], :docker)
+    end
+
+    test "#{@rc_d} → hot on linux (no rc(8) on a systemd host either)" do
+      assert {:hot, []} = Preflight.classify_paths([@rc_d], :linux)
+    end
+  end
+
+  describe "classify_paths/2 — Class 4c: Linux systemd unit (COLD linux / HOT docker+jail)" do
+    @systemd_unit "infra/linux/systemd/grappa.service"
+
+    test "#{@systemd_unit} → cold (:systemd_unit) on linux (unit read only at service (re)start)" do
+      assert {:cold, reasons} = Preflight.classify_paths([@systemd_unit], :linux)
+      assert {:systemd_unit, [@systemd_unit]} = List.keyfind(reasons, :systemd_unit, 0)
+    end
+
+    test "#{@systemd_unit} → hot on docker (no systemd in the container)" do
+      assert {:hot, []} = Preflight.classify_paths([@systemd_unit], :docker)
+    end
+
+    test "#{@systemd_unit} → hot on jail (FreeBSD has no systemd)" do
+      assert {:hot, []} = Preflight.classify_paths([@systemd_unit], :jail)
     end
   end
 


### PR DESCRIPTION
## Summary

Adds a third Docker-free production substrate alongside the existing
FreeBSD bastille jail: plain systemd + `mix release` on any modern
Linux host (tested on Debian 13). No container runtime involved —
`infra/linux/install.sh` provisions a `grappa` system user + the
asdf-managed Erlang/Elixir/bun toolchain, builds the release, and
installs a systemd unit + nginx reverse proxy; `infra/linux/deploy.sh`
does the day-2 update cycle.

Along the way this also extends `Grappa.Deploy.Preflight` with a
`:linux` substrate + a new COLD class for a changed systemd unit file,
so `deploy.sh` picks hot (rebuild + `POST /admin/reload`, sessions
preserved) vs cold (full restart) automatically instead of always
doing a full stop/start cycle — same mechanism `scripts/deploy.sh`
(Docker) and `infra/freebsd/deploy.sh` (jail) already use.

Two small unrelated bugs found and fixed along the way (both
pre-existing, not Linux-specific — see individual commits for the
live-repro details):

- `Mix.Tasks.Grappa.OptionParsing.parse_auth/1` could crash with "not
  an already existing atom" outside a full release boot.
- `GrappaWeb.Endpoint` was hardcoded into the supervision tree even
  for the one-shot `grappa.*` operator mix tasks, forcing
  `systemctl stop grappa` (or the Docker/jail equivalent) before every
  admin task even though those tasks never serve HTTP.

Plus a doc-drift fix: `AdminController`'s moduledoc still described
`/admin/reload` via `:code.modified_modules/0`, which `Grappa.HotReload`
moved off back on 2026-06-10.

## Commits (6, each self-contained — see individual messages for full rationale)

1. `infra: add native Linux (systemd) deploy path`
2. `fix(mix): OptionParsing.parse_auth crashes under bare mix task invocation`
3. `feat(deploy): extend Preflight classifier + deploy.sh with :linux hot/cold support`
4. `fix(app): make GrappaWeb.Endpoint opt-out, skip it for one-shot mix tasks`
5. `docs(admin): fix AdminController moduledoc drift on the reload mechanism`
6. `docs: drop stale LINUX.md pointers, fix cold-only description drift`

## Test plan

- [x] Full install + deploy cycle exercised live on a real Debian 13
      host (install.sh, deploy.sh hot path, deploy.sh cold path,
      systemd unit, nginx reverse proxy).
- [x] Hot-deploy path verified: `mix release --overwrite` + `POST
      /admin/reload` with the systemd service never stopped, same BEAM
      PID before/after, `/healthz` 200 throughout.
- [x] `GrappaWeb.Endpoint` opt-out verified live: ran a `grappa.*`
      admin mix task (theme seeding) against a running release without
      stopping the service first — no port conflict, same PID
      before/after.
- [ ] `mix test` / `mix credo` / `mix dialyzer` — not run in this
      environment (no local toolchain here); please run CI on this PR.