### PR TITLE
fix(linux): install.sh silently blanks both VAPID keys

### DIFF
--- a/infra/linux/install.sh
+++ b/infra/linux/install.sh
@@ -185,10 +185,36 @@ fi
 if ! grep -qE "^GRAPPA_ENCRYPTION_KEY=.+$" "${ENV_FILE}" || grep -qE "^GRAPPA_ENCRYPTION_KEY=REPLACE_ME$" "${ENV_FILE}"; then
 	set_env_if_blank GRAPPA_ENCRYPTION_KEY "$(gen 'mix grappa.gen_encryption_key' | tail -n1)"
 fi
-if ! grep -qE "^VAPID_PUBLIC_KEY=.+$" "${ENV_FILE}" || grep -qE "^VAPID_PUBLIC_KEY=REPLACE_ME$" "${ENV_FILE}"; then
+# Regeneration trigger checks BOTH keys, not just the public one — a
+# guard on VAPID_PUBLIC_KEY alone would leave a
+# public-set/private-blank state (however it arose) permanently stuck,
+# since install.sh's idempotency means this block would never run
+# again once the public half looked fine.
+vapid_key_needs_gen() {
+	! grep -qE "^${1}=.+$" "${ENV_FILE}" || grep -qE "^${1}=REPLACE_ME$" "${ENV_FILE}"
+}
+
+if vapid_key_needs_gen VAPID_PUBLIC_KEY || vapid_key_needs_gen VAPID_PRIVATE_KEY; then
 	vapid="$(gen_raw 'mix grappa.gen_vapid')"
-	set_env_if_blank VAPID_PUBLIC_KEY "$(printf '%s\n' "${vapid}" | sed -n 's/^VAPID_PUBLIC_KEY=//p')"
-	set_env_if_blank VAPID_PRIVATE_KEY "$(printf '%s\n' "${vapid}" | sed -n 's/^VAPID_PRIVATE_KEY=//p')"
+	vapid_public="$(printf '%s\n' "${vapid}" | sed -n 's/^VAPID_PUBLIC_KEY=//p')"
+	vapid_private="$(printf '%s\n' "${vapid}" | sed -n 's/^VAPID_PRIVATE_KEY=//p')"
+	# Belt-and-braces: `gen_raw` already fails loud on a non-zero exit,
+	# but a future change to gen_vapid's output shape (or a truncated
+	# capture) could still hand back exit 0 with an empty match here —
+	# catch that explicitly rather than silently writing a blank key.
+	if [ -z "${vapid_public}" ] || [ -z "${vapid_private}" ]; then
+		echo "[install] ERROR: 'mix grappa.gen_vapid' produced an empty key — raw output:" >&2
+		echo "${vapid}" >&2
+		exit 1
+	fi
+	# force_set_env (not set_env_if_blank): once regeneration is
+	# triggered, the fresh pair MUST land as a matched unit. If only one
+	# key needed regenerating, set_env_if_blank would skip the
+	# already-valid half and keep it paired with a brand-new,
+	# unrelated other half — a mismatched public/private pair is
+	# unusable, worse than either being blank.
+	force_set_env VAPID_PUBLIC_KEY "${vapid_public}"
+	force_set_env VAPID_PRIVATE_KEY "${vapid_private}"
 fi
 if ! grep -qE "^RELEASE_COOKIE=.+$" "${ENV_FILE}" || grep -qE "^RELEASE_COOKIE=REPLACE_ME$" "${ENV_FILE}"; then
 	set_env_if_blank RELEASE_COOKIE "$(openssl rand -hex 32)"

--- a/infra/linux/install.sh
+++ b/infra/linux/install.sh
@@ -147,14 +147,33 @@ force_set_env() {
 # written as empty strings with zero indication anything had failed).
 # Fail loud instead: print the captured error and exit non-zero rather
 # than let a blank secret slip into the env file.
-gen() {
+#
+# `gen_raw` is the shared run+fail-loud+strip-warnings step; `gen`
+# additionally takes only the LAST line, which is correct for the
+# single-line generators (phx.gen.secret, gen_encryption_key) but
+# WRONG for `mix grappa.gen_vapid` — that task prints FOUR lines
+# (VAPID_PUBLIC_KEY=, VAPID_PRIVATE_KEY=, then two comment lines), so
+# routing it through `gen`'s `tail -n1` silently kept only the last
+# comment line and discarded BOTH keys — found live 2026-07-24:
+# VAPID_PUBLIC_KEY/VAPID_PRIVATE_KEY ended up empty in grappa.env,
+# `Grappa.Push.boot/0`'s `System.get_env(...) || raise` didn't catch
+# it either (an env var set to `""` is not `nil`, so the `||` never
+# fires), so the app booted "fine" with a broken Web Push config —
+# no crash, no log line, subscriptions just silently never worked.
+# VAPID generation now calls `gen_raw` directly and greps each key
+# out of the full multi-line output instead of going through `gen`.
+gen_raw() {
 	local out
 	if ! out="$(run_as_grappa "${asdf_path_export}; cd '${REPO_ROOT}'; MIX_ENV=dev $1" 2>&1)"; then
 		echo "[install] ERROR: 'MIX_ENV=dev $1' failed:" >&2
 		echo "${out}" >&2
 		exit 1
 	fi
-	printf '%s' "${out}" | tr -d '\r' | grep -v '^warning:' | tail -n1
+	printf '%s' "${out}" | tr -d '\r' | grep -v '^warning:'
+}
+
+gen() {
+	gen_raw "$1" | tail -n1
 }
 
 if ! grep -qE "^SECRET_KEY_BASE=.+$" "${ENV_FILE}" || grep -qE "^SECRET_KEY_BASE=REPLACE_ME$" "${ENV_FILE}"; then
@@ -167,7 +186,7 @@ if ! grep -qE "^GRAPPA_ENCRYPTION_KEY=.+$" "${ENV_FILE}" || grep -qE "^GRAPPA_EN
 	set_env_if_blank GRAPPA_ENCRYPTION_KEY "$(gen 'mix grappa.gen_encryption_key' | tail -n1)"
 fi
 if ! grep -qE "^VAPID_PUBLIC_KEY=.+$" "${ENV_FILE}" || grep -qE "^VAPID_PUBLIC_KEY=REPLACE_ME$" "${ENV_FILE}"; then
-	vapid="$(gen 'mix grappa.gen_vapid')"
+	vapid="$(gen_raw 'mix grappa.gen_vapid')"
 	set_env_if_blank VAPID_PUBLIC_KEY "$(printf '%s\n' "${vapid}" | sed -n 's/^VAPID_PUBLIC_KEY=//p')"
 	set_env_if_blank VAPID_PRIVATE_KEY "$(printf '%s\n' "${vapid}" | sed -n 's/^VAPID_PRIVATE_KEY=//p')"
 fi


### PR DESCRIPTION
## Bug

`mix grappa.gen_vapid` prints four lines:

```
VAPID_PUBLIC_KEY=BJk...
VAPID_PRIVATE_KEY=z3p...
# Optional — defaults to mailto:admin@example.org if unset.
# VAPID_SUBJECT=mailto:you@example.org
```

But VAPID generation in `install.sh` routed it through the `gen()`
helper, which is designed for single-line generators
(`phx.gen.secret`, `gen_encryption_key`) and always takes only the
LAST line via `tail -n1`. That last line is a comment
(`# VAPID_SUBJECT=...`), so both `sed` extractions that follow match
nothing, and `set_env_if_blank` writes both keys as empty strings —
silently.

`Grappa.Push.boot/0`'s `System.get_env(...) || raise` doesn't catch
it either: a shell-exported var set to `""` is `""` in Elixir, not
`nil`, so the `||` fallback never fires. The app boots clean,
`/admin/reload` works, everything looks fine — push notifications
just never work, with no error anywhere.

## Fix

Split `gen()` into `gen_raw` (run + fail-loud + strip-warnings,
shared) and `gen` (`gen_raw` + `tail -n1`, still used unchanged by the
three genuinely single-line generators). VAPID generation now calls
`gen_raw` directly and greps each key out of the full multi-line
output instead of truncating first.

## Test plan

- [x] Found and root-caused live on a real native-Linux install that
      had silently shipped with both VAPID keys blank (zero push
      subscriptions ever saved, no error anywhere).
- [x] Regenerated the keys with this exact fixed logic against that
      same install — confirmed correct extraction of both
      `VAPID_PUBLIC_KEY` and `VAPID_PRIVATE_KEY`, confirmed
      `/push/vapid-public-key` returns the real key after restart, and
      push notifications now work end-to-end.
- [ ] `mix test` / `mix credo` / `mix dialyzer` — not run in this
      environment (no local toolchain); please run CI on this PR.