### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Grappa.MixProject do
   use Mix.Project
 
   @app :grappa
-  @version "0.4.0"
+  @version "0.5.0"
 
   def project do
     [


### PR DESCRIPTION
Bumps `@version` 0.4.0 → 0.5.0 for tonight's cold deploy.

**Why MINOR, not PATCH:** the batch carries two user-visible features (#385 user-definable `/alias`, #382 multi-target JOIN) plus #396's cold-load fan-out overhaul, whose own-nick SELF window now counts legacy `dm_with IS NULL` and mixed-case rows the old RAW compare missed — an observable behaviour change.

**Why 0.4.1 is skipped:** it was tagged and published on `af2dc724`, but `@version` was never bumped, so no build ever reported it and #391's "tag ≡ CTCP VERSION" contract was already broken. 0.5.0 steps past the phantom rather than minting a second release on an inconsistent one.

This is the release commit for the batch of ten already merged and held on main: #374 #375 #376 #382 #385 #386 #393 #395 #396 #397.

**#189 is deliberately not in this batch** — still mid-gate, and it rewrites the connect/identify ordering (built-in identify moved `AuthFSM` → `Session.Server`), too wide a blast radius to pass into a cold alongside ten other issues. It headlines the next one.

Deliberately no `closes #NNN` trailers — those auto-close on push and would strand the `status:soon` labels before the deploy actually happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)