### PR TITLE
feat(#469): quickstart grows a staging mode — real hostname, seeding, rendered front door

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,7 +48,7 @@ HTTP_BIND=0.0.0.0:8080 scripts/quickstart.sh   # all interfaces, port 8080
 2. Creates host-owned `runtime/` directories (sqlite DB, uploads, build
    output).
 3. Writes a `.env`: sets `MIX_ENV=prod`, your host UID/GID,
-   `PHX_HOST=localhost`, and the host port.
+   `PHX_HOST` (`localhost` unless you pass one), and the host port.
 4. Builds the image and fetches Elixir deps into the checkout.
 5. **Generates every secret** and writes them to `.env` —
    `SECRET_KEY_BASE`, `SECRET_SIGNING_SALT`, `GRAPPA_ENCRYPTION_KEY`, a
@@ -84,6 +84,46 @@ docker compose -f compose.yaml run --rm grappa \
 
 Then log in via the web UI. To connect the bouncer to an IRC network, see
 **"Bind a network"** in [README.md](README.md).
+
+## A throwaway box for testing (staging)
+
+To look at a change under a real hostname before it ships, hand the script
+the hostname and an account to seed. It comes up already connected, so the
+first login lands on a live session instead of an empty box:
+
+```sh
+PHX_HOST=grappa.example.org \
+SEED_USER=you SEED_AUTOJOIN='#grappa' \
+  scripts/quickstart.sh
+```
+
+`SEED_USER` is the switch — without it nothing is seeded. The rest is
+optional: `SEED_PASSWORD` (generated and printed when unset),
+`SEED_NETWORK` (default `azzurra`), `SEED_SERVER`
+(default `irc.azzurra.chat:6697`), `SEED_NICK` (default `$SEED_USER`),
+`SEED_AUTH` (`auto|sasl|server_pass|nickserv_identify|none`, default
+`none`), `SEED_NICK_PASSWORD` and `SEED_AUTOJOIN`. Re-running never
+clobbers a live box: an existing account or binding is reported and left
+alone.
+
+`PHX_HOST` is load-bearing — it is where upload links and origin checks
+come from. If you serve the box as `grappa.example.org` while `.env` still
+says something else, links point at the wrong host and nothing errors out.
+Pass it explicitly and it replaces whatever a previous run wrote.
+
+The stack still listens on plain HTTP on `HTTP_BIND`; that is the listener
+your own TLS front door proxies to. The script installs nothing on the
+host — it renders `runtime/nginx-frontend.conf` from the shipped example
+with your hostname, upstream and certificate paths filled in
+(`FRONTEND_SSL_CERT` / `FRONTEND_SSL_KEY` override the defaults under
+`/etc/ssl/grappa/`), and prints the path. Include it from your nginx.
+
+> Serving a staging box over plain HTTP under a real name looks like it
+> works and does not: off `localhost`, browsers refuse to register the
+> service worker without TLS — and refuse it behind an untrusted
+> certificate too. Push, offline and install then silently vanish, which
+> is usually the part you meant to test. Use mkcert on a LAN, ACME in
+> public.
 
 ## Managing the stack
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -137,11 +137,40 @@ docker compose -f compose.yaml --profile prod logs -f grappa
 # Stop / start
 docker compose -f compose.yaml --profile prod down
 scripts/quickstart.sh                       # idempotent: brings it back up
-
-# Update to a newer checkout
-git pull
-docker compose -f compose.yaml --profile prod up -d --build
 ```
+
+### Updating an installed box
+
+```sh
+scripts/quickstart-update.sh                # pull, then update
+scripts/quickstart-update.sh --no-pull      # update from the working tree as-is
+```
+
+`quickstart.sh` never touches git — re-running it can only re-install what
+is already on disk. `deploy.sh` is the production path and its
+`require_main_checkout` guard refuses any checkout that is not the main one
+sitting on `main`, which rules out a staging box parked on a branch. This
+script covers the gap in between.
+
+It refuses before it touches anything: a missing `.env` (the box was never
+installed), no docker, not a git checkout, or — when pulling — a dirty
+tree, all abort with the reason. The pull is `--ff-only`, so a diverged
+branch stops the run rather than being merged by a script. Nothing in the
+stack has moved at that point. It then reads the diff to decide which of
+the expensive steps are actually needed:
+
+| Changed | Triggers |
+| --- | --- |
+| `Dockerfile`, `.dockerignore` | image rebuild |
+| `mix.lock`, `mix.exs` | `mix deps.get` |
+| `priv/repo/migrations/` | `mix ecto.migrate` |
+| `cicchetto/` | frontend bundle |
+
+Everything else is a plain recreate: the tree is bind-mounted into the
+container and the image is toolchain-only, so ordinary code changes compile
+at boot with no rebuild. The stack is then recreated (never hot-reloaded —
+a staging box exists to be restarted), `/healthz` is polled until it
+answers, and the URL is printed from `.env`.
 
 ## Exposing it beyond localhost (TLS)
 

--- a/scripts/quickstart-update.sh
+++ b/scripts/quickstart-update.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+#
+# quickstart-update.sh — bring an already-installed quickstart box up to
+# the latest revision of whatever branch it tracks.
+#
+# Why this exists next to the other two:
+#
+#   * `quickstart.sh` INSTALLS. It deliberately never touches git, so
+#     re-running it can only ever re-install what is already on disk.
+#   * `deploy.sh` DEPLOYS PRODUCTION. Its `require_main_checkout` guard
+#     refuses anything that is not the main checkout sitting on main —
+#     correct there, useless for a staging box parked on a feature
+#     branch, which is exactly what #469 asks for.
+#
+# So: pull, work out from the diff which of the expensive steps are
+# actually needed, run only those, recreate the stack, wait for health.
+#
+# The whole project tree is bind-mounted into the container
+# (`./:/app` in compose.yaml) and the image is toolchain-only, so a code
+# change needs no image rebuild — the BEAM compiles from the mounted tree
+# at boot. That is what makes a cheap update possible at all, and what
+# decides the trigger list below.
+#
+# This is NOT the hot-reload path. `deploy.sh` can swap modules in a live
+# BEAM via POST /admin/reload and keep sessions; here we always recreate.
+# A staging box exists to be restarted, and a restart cannot be wrong,
+# whereas a hot reload can be — see Grappa.Deploy.Preflight for the
+# module shapes that silently refuse to swap.
+#
+# Usage:
+#   scripts/quickstart-update.sh            # pull, then update
+#   scripts/quickstart-update.sh --no-pull  # update from the working tree
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Same pin as quickstart.sh — the committed compose file only, no
+# override auto-merge, so what this updates is what that installed.
+COMPOSE=(docker compose -f compose.yaml)
+
+say()  { printf '\033[1;32m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m!!\033[0m  %s\n' "$*" >&2; }
+die()  { printf '\033[1;31mxx\033[0m  %s\n' "$*" >&2; exit 1; }
+
+PULL=1
+case "${1:-}" in
+  --no-pull) PULL=0 ;;
+  '')        ;;
+  *) die "usage: scripts/quickstart-update.sh [--no-pull]" ;;
+esac
+
+# ---- 0. preflight ------------------------------------------------------
+# Every check that can refuse the run lives here, BEFORE the first side
+# effect: a box left half-updated is worse than one not updated at all.
+[ -f compose.yaml ] || die "compose.yaml not in $REPO_ROOT — run this from a grappa checkout."
+[ -f .env ] || die "no .env in $REPO_ROOT — this box was never installed. Run scripts/quickstart.sh first."
+command -v docker >/dev/null 2>&1 || die "docker not found."
+git rev-parse --git-dir >/dev/null 2>&1 || die "not a git checkout — nothing to update from."
+
+if [ "$PULL" -eq 1 ]; then
+  # A fast-forward onto a dirty tree either fails halfway or silently
+  # carries local edits into what you are about to call "the latest
+  # revision". Refuse instead, and say which files.
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    warn "uncommitted changes in the checkout:"
+    git status --short >&2
+    die "refusing to pull onto a dirty tree — commit, stash or use --no-pull."
+  fi
+fi
+
+# ---- 1. move the checkout ---------------------------------------------
+prev="$(git rev-parse HEAD)"
+
+if [ "$PULL" -eq 1 ]; then
+  branch="$(git rev-parse --abbrev-ref HEAD)"
+  say "Pulling ${branch} (fast-forward only)"
+  # --ff-only on purpose: if the branch diverged, that is a decision for
+  # a human, not something an update script should resolve.
+  git pull --ff-only || die "pull is not a fast-forward — the branch diverged. Resolve it by hand."
+fi
+
+now="$(git rev-parse HEAD)"
+
+if [ "$prev" = "$now" ]; then
+  changed=""
+else
+  changed="$(git diff --name-only "$prev" "$now")"
+fi
+
+# ---- 2. classify the diff ----------------------------------------------
+# Each trigger is a thing the bind-mounted tree does NOT give us for free
+# at container boot.
+touched() { printf '%s\n' "$changed" | grep -qE "$1"; }
+
+need_build=0; need_deps=0; need_migrate=0; need_cic=0
+if [ -n "$changed" ]; then
+  # The image is toolchain-only, so only its own recipe can invalidate it.
+  touched '^Dockerfile$|^\.dockerignore$'      && need_build=1
+  # deps/ lives in the mounted tree but is populated by mix, not by git.
+  touched '^mix\.(lock|exs)$'                  && need_deps=1
+  # Migrations must land before the app that expects them boots.
+  touched '^priv/repo/migrations/'             && need_migrate=1
+  # The PWA bundle is built by the bun oneshot into runtime/, not compiled
+  # by the BEAM, so a frontend change is invisible without it.
+  touched '^cicchetto/'                        && need_cic=1
+fi
+
+# ---- 3. do only what the diff asked for --------------------------------
+if [ -z "$changed" ]; then
+  say "already up to date at $(git rev-parse --short HEAD) — ensuring the stack is up"
+  "${COMPOSE[@]}" --profile prod up -d
+else
+  say "Updating $(git rev-parse --short "$prev") → $(git rev-parse --short "$now")"
+
+  [ "$need_build" -eq 1 ]   && { say "Dockerfile changed — rebuilding the image"; \
+                                 "${COMPOSE[@]}" --profile prod build grappa; }
+  [ "$need_deps" -eq 1 ]    && { say "mix.lock changed — fetching deps"; \
+                                 "${COMPOSE[@]}" --profile prod run --rm --no-deps grappa mix deps.get; }
+  [ "$need_cic" -eq 1 ]     && { say "cicchetto changed — rebuilding the PWA bundle"; \
+                                 "${COMPOSE[@]}" --profile prod run --rm cicchetto-build; }
+  [ "$need_migrate" -eq 1 ] && { say "new migrations — running ecto.migrate"; \
+                                 "${COMPOSE[@]}" --profile prod run --rm --no-deps grappa mix ecto.migrate; }
+
+  say "Recreating grappa + nginx"
+  # --no-deps so compose does not drag the oneshot back in; it either ran
+  # above or had no reason to.
+  "${COMPOSE[@]}" --profile prod up -d --force-recreate --no-deps grappa nginx
+fi
+
+# ---- 4. wait for health ------------------------------------------------
+# Probed from inside nginx, so it is independent of how the host port is
+# published. A recompile of the mounted tree happens on this boot, hence
+# the generous window.
+say "Waiting for /healthz"
+deadline=$((SECONDS + 600))
+until "${COMPOSE[@]}" exec -T nginx wget -qO- http://127.0.0.1/healthz >/dev/null 2>&1; do
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    warn "stack did not become healthy in time. Inspect with:"
+    warn "  ${COMPOSE[*]} --profile prod logs --tail=100 grappa"
+    die "health check timed out"
+  fi
+  printf '.'; sleep 3
+done
+printf '\n'
+
+# ---- 5. report ---------------------------------------------------------
+# Read the bind back out of .env rather than assuming a default: an
+# earlier run may have pinned it elsewhere, and printing a URL nobody
+# listens on is the #469 bug this box already had once.
+published="$(sed -n 's/^NGINX_PUBLISH=//p' .env | tail -n1)"
+published="${published%:80}"
+case "$published" in
+  '')            published="127.0.0.1:3000" ;;
+  0.0.0.0:*)     published="127.0.0.1:${published##*:}" ;;
+  '[::]:'*)      published="127.0.0.1:${published##*:}" ;;
+  *:*)           ;;
+  *)             published="127.0.0.1:${published}" ;;
+esac
+
+say "grappa is up and healthy at $(git rev-parse --short HEAD) 🎉"
+cat <<EOF
+
+  Web UI:   http://${published}/
+  Health:   curl http://${published}/healthz
+
+  Logs:     ${COMPOSE[*]} --profile prod logs -f grappa
+  Stop:     ${COMPOSE[*]} --profile prod down
+EOF

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -17,6 +17,45 @@
 #
 # After it finishes the bouncer's web UI is at http://localhost:3000.
 # Tear down with:  docker compose -f compose.yaml --profile prod down
+#
+# ---- Serving it under a real hostname (staging box) -------------------
+#
+# The stack's own nginx listens on plain HTTP on HTTP_BIND — that IS the
+# listener you put your own TLS front door in front of. Nothing here
+# terminates TLS or installs a vhost on your host; the script only RENDERS
+# a ready-to-include front-door config from the shipped example, with your
+# values filled in, and tells you where it wrote it.
+#
+#   PHX_HOST=grappa.example.org scripts/quickstart.sh
+#
+# PHX_HOST is load-bearing: it is the source of the host-alias set the app
+# derives upload links and origin checks from (lib/grappa/http_hosts.ex).
+# Leaving it at `localhost` while serving the box under a real name mints
+# links pointing at the wrong host, silently (#468). Pass it explicitly and
+# it overwrites a previously-written value in .env.
+#
+# ---- Seeding a network + user (optional) ------------------------------
+#
+# Set SEED_USER to get an instance that is already connected when you log
+# in, instead of an empty one you have to wire by hand:
+#
+#   PHX_HOST=grappa.example.org SEED_USER=you SEED_AUTOJOIN='#grappa' \
+#     scripts/quickstart.sh
+#
+# Knobs (all optional except SEED_USER):
+#   SEED_USER      account name — setting it enables seeding
+#   SEED_PASSWORD  account password (generated and printed when unset)
+#   SEED_NETWORK   network slug            (default: azzurra)
+#   SEED_SERVER    host:port               (default: irc.azzurra.chat:6697)
+#   SEED_NICK      IRC nick                (default: $SEED_USER)
+#   SEED_AUTH      auto|sasl|server_pass|nickserv_identify|none (default: none)
+#   SEED_NICK_PASSWORD  upstream auth password, when SEED_AUTH needs one
+#   SEED_AUTOJOIN  comma-separated channels (default: none)
+#
+# Seeding is idempotent in the sense that re-running never breaks a live
+# box: an existing account or an existing binding is reported and skipped,
+# not overwritten. The seeded account is test-grade — do not reuse a
+# password you care about.
 
 set -euo pipefail
 
@@ -31,6 +70,29 @@ COMPOSE=(docker compose -f compose.yaml)
 # Host port the PWA is served on (nginx → grappa). Loopback-only by
 # default; override before running to expose on a LAN IP.
 HTTP_BIND="${HTTP_BIND:-127.0.0.1:3000}"
+
+# Public hostname the box is served under. `localhost` keeps the plain
+# localhost install working (browsers treat http://localhost as a secure
+# context, so the PWA works without TLS). Anything else means a front door
+# is in play — remember whether the caller asked for it, because a value
+# passed explicitly must WIN over what a previous run left in .env.
+PHX_HOST_EXPLICIT=0
+[ -n "${PHX_HOST+x}" ] && PHX_HOST_EXPLICIT=1
+PHX_HOST="${PHX_HOST:-localhost}"
+
+# Front-door rendering: cert paths are placeholders in the shipped example
+# and get substituted here so the emitted file is directly includable.
+FRONTEND_SSL_CERT="${FRONTEND_SSL_CERT:-/etc/ssl/grappa/fullchain.pem}"
+FRONTEND_SSL_KEY="${FRONTEND_SSL_KEY:-/etc/ssl/grappa/privkey.pem}"
+
+# Optional seeding (see the header). SEED_USER is the switch.
+SEED_USER="${SEED_USER:-}"
+SEED_NETWORK="${SEED_NETWORK:-azzurra}"
+SEED_SERVER="${SEED_SERVER:-irc.azzurra.chat:6697}"
+SEED_NICK="${SEED_NICK:-$SEED_USER}"
+SEED_AUTH="${SEED_AUTH:-none}"
+SEED_NICK_PASSWORD="${SEED_NICK_PASSWORD:-}"
+SEED_AUTOJOIN="${SEED_AUTOJOIN:-}"
 
 say()  { printf '\033[1;32m==>\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m!!\033[0m  %s\n' "$*" >&2; }
@@ -62,16 +124,43 @@ set_env() {
   printf '%s=%s\n' "$key" "$val" >> .env
 }
 
+# force_env KEY VALUE — set KEY unconditionally, replacing any existing
+# value. Used only for what the caller passed on this run: a second run
+# with a different PHX_HOST must actually move the box, not silently keep
+# the first run's hostname (the #468 failure mode is a stale, wrong host).
+force_env() {
+  local key="$1" val="$2"
+  if grep -qE "^${key}=" .env 2>/dev/null; then
+    grep -v "^${key}=" .env > .env.tmp && mv .env.tmp .env
+  fi
+  printf '%s=%s\n' "$key" "$val" >> .env
+}
+
+ENV_CREATED_NOW=0
 if [ ! -f .env ]; then
   say "Creating .env from .env.example"
   cp .env.example .env
+  ENV_CREATED_NOW=1
 fi
 
-say "Configuring .env for a localhost full-stack run"
+say "Configuring .env for a full-stack run under ${PHX_HOST}"
 set_env MIX_ENV prod
 set_env CONTAINER_UID "$(id -u)"
 set_env CONTAINER_GID "$(id -g)"
-set_env PHX_HOST localhost
+if [ "$PHX_HOST_EXPLICIT" -eq 1 ] || [ "$ENV_CREATED_NOW" -eq 1 ]; then
+  # A .env just copied from the example carries the example's hostname,
+  # which is someone else's host — inheriting it is the copy-trap that
+  # mints upload links pointing away from this box (#468). Whatever this
+  # run resolved to (the caller's value, or `localhost`) wins over it.
+  force_env PHX_HOST "$PHX_HOST"
+else
+  set_env PHX_HOST "$PHX_HOST"
+  # An earlier run (or a hand-edited .env) may already pin a different
+  # host; the rendered front-door config below must describe the box as it
+  # will actually behave, not as this invocation defaulted.
+  PHX_HOST="$(sed -n 's/^PHX_HOST=//p' .env | tail -n1)"
+  PHX_HOST="${PHX_HOST:-localhost}"
+fi
 set_env GRAPPA_PUBLISH 127.0.0.1:4000
 set_env NGINX_PUBLISH "${HTTP_BIND}:80"
 
@@ -129,6 +218,39 @@ fi
 say "Running database migrations"
 "${COMPOSE[@]}" run --rm --no-deps grappa mix ecto.migrate
 
+# ---- 6b. seed an account + network (optional) -------------------------
+# Runs BEFORE the stack comes up on purpose: Bootstrap reads the binding at
+# boot, so seeding first means the very first `up` already dials out and the
+# operator's first login lands on a connected session.
+#
+# Neither task is destructive on a second run — `create_user` fails on a
+# duplicate name and `bind_network` fails on an existing (user, network)
+# credential — so both failures are downgraded to a note instead of
+# aborting an otherwise healthy install.
+if [ -n "$SEED_USER" ]; then
+  if [ -z "${SEED_PASSWORD:-}" ]; then
+    SEED_PASSWORD="$(head -c 18 /dev/urandom | base64 | tr -d '\n/+=' | cut -c1-20)"
+  fi
+
+  say "Seeding account '${SEED_USER}'"
+  if ! "${COMPOSE[@]}" run --rm --no-deps -T grappa \
+      mix grappa.create_user --name "$SEED_USER" --password "$SEED_PASSWORD"; then
+    warn "account '${SEED_USER}' was not created (it most likely already exists) — keeping the existing one."
+    warn "the password printed below is then NOT the account's password."
+  fi
+
+  say "Binding ${SEED_USER} → ${SEED_NETWORK} (${SEED_SERVER}) as ${SEED_NICK}"
+  bind_args=(mix grappa.bind_network
+    --user "$SEED_USER" --network "$SEED_NETWORK"
+    --server "$SEED_SERVER" --nick "$SEED_NICK" --auth "$SEED_AUTH")
+  [ -n "$SEED_NICK_PASSWORD" ] && bind_args+=(--password "$SEED_NICK_PASSWORD")
+  [ -n "$SEED_AUTOJOIN" ] && bind_args+=(--autojoin "$SEED_AUTOJOIN")
+  if ! "${COMPOSE[@]}" run --rm --no-deps -T grappa "${bind_args[@]}"; then
+    warn "binding not created — ${SEED_USER} is probably already bound to ${SEED_NETWORK}."
+    warn "change an existing binding with: ${COMPOSE[*]} run --rm grappa mix grappa.update_network_credential --help"
+  fi
+fi
+
 # ---- 7. bring up the full stack ---------------------------------------
 say "Starting the stack (grappa + cicchetto build + nginx)"
 "${COMPOSE[@]}" --profile prod up -d
@@ -149,16 +271,68 @@ until "${COMPOSE[@]}" exec -T nginx wget -qO- http://127.0.0.1/healthz >/dev/nul
 done
 printf '\n'
 
+# ---- 8b. render the front-door config ---------------------------------
+# The shipped example carries <placeholders>; fill them with what this box
+# actually runs so the file can be included as-is. The upstream is the
+# published HTTP port — a wildcard bind is rewritten to loopback, since a
+# proxy on the same host must not dial 0.0.0.0.
+FRONTEND_CONF="runtime/nginx-frontend.conf"
+UPSTREAM="$HTTP_BIND"
+case "$UPSTREAM" in
+  0.0.0.0:*) UPSTREAM="127.0.0.1:${UPSTREAM##*:}" ;;
+  '[::]:'*)  UPSTREAM="127.0.0.1:${UPSTREAM##*:}" ;;
+esac
+
+sed -e "s|<your-domain>|${PHX_HOST}|g" \
+    -e "s|^  server 127\.0\.0\.1:3000;|  server ${UPSTREAM};|" \
+    -e "s|^  ssl_certificate     .*|  ssl_certificate     ${FRONTEND_SSL_CERT};|" \
+    -e "s|^  ssl_certificate_key .*|  ssl_certificate_key ${FRONTEND_SSL_KEY};|" \
+    infra/nginx-tls-frontend.example.conf > "$FRONTEND_CONF"
+
 # ---- 9. done ----------------------------------------------------------
 say "grappa is up and healthy 🎉"
 cat <<EOF
 
   Web UI:   http://${HTTP_BIND}/
   Health:   curl http://${HTTP_BIND}/healthz
+  PHX_HOST: ${PHX_HOST}
+
+  Front-door config rendered for ${PHX_HOST} → ${UPSTREAM}:
+    ${REPO_ROOT}/${FRONTEND_CONF}
+  Include it from your own nginx (this script installs nothing on the
+  host) and point the certificate lines at a certificate your browser
+  trusts.
+EOF
+
+if [ "$PHX_HOST" != "localhost" ]; then
+  cat <<EOF
+  Serving it over plain HTTP under that name will look like it works and
+  will not: service workers refuse to register off-localhost without TLS,
+  and an untrusted certificate is refused too — so push, offline and
+  install silently disappear, which is exactly what a staging box is
+  supposed to let you test. Use a trusted cert (mkcert on a LAN, ACME in
+  public).
+EOF
+fi
+
+if [ -n "$SEED_USER" ]; then
+  cat <<EOF
+
+  Seeded account:  ${SEED_USER} / ${SEED_PASSWORD}
+  Seeded network:  ${SEED_NETWORK} → ${SEED_SERVER} as ${SEED_NICK}${SEED_AUTOJOIN:+ (autojoin ${SEED_AUTOJOIN})}
+  Test-grade credentials — the account is a login for this box, nothing else.
+EOF
+else
+  cat <<EOF
 
   Create your first user (then log in via the web UI):
     ${COMPOSE[*]} run --rm grappa mix grappa.create_user --name you --password 'change-me'
 
   Bind an IRC network: see README.md "Bind a network".
+EOF
+fi
+
+cat <<EOF
+
   Stop the stack:      ${COMPOSE[*]} --profile prod down
 EOF

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -68,7 +68,12 @@ cd "$REPO_ROOT"
 COMPOSE=(docker compose -f compose.yaml)
 
 # Host port the PWA is served on (nginx → grappa). Loopback-only by
-# default; override before running to expose on a LAN IP.
+# default; override before running to expose on a LAN IP. Same rule as
+# PHX_HOST below: a value passed on this run must win over whatever a
+# previous run (or .env.example, which publishes on ALL interfaces) left
+# behind, otherwise the box quietly serves somewhere else than asked.
+HTTP_BIND_EXPLICIT=0
+[ -n "${HTTP_BIND+x}" ] && HTTP_BIND_EXPLICIT=1
 HTTP_BIND="${HTTP_BIND:-127.0.0.1:3000}"
 
 # Public hostname the box is served under. `localhost` keeps the plain
@@ -162,7 +167,20 @@ else
   PHX_HOST="${PHX_HOST:-localhost}"
 fi
 set_env GRAPPA_PUBLISH 127.0.0.1:4000
-set_env NGINX_PUBLISH "${HTTP_BIND}:80"
+if [ "$HTTP_BIND_EXPLICIT" -eq 1 ] || [ "$ENV_CREATED_NOW" -eq 1 ]; then
+  force_env NGINX_PUBLISH "${HTTP_BIND}:80"
+else
+  set_env NGINX_PUBLISH "${HTTP_BIND}:80"
+  # Report (and proxy to) the port the stack will really publish, which an
+  # earlier run may have pinned elsewhere.
+  published="$(sed -n 's/^NGINX_PUBLISH=//p' .env | tail -n1)"
+  published="${published%:80}"
+  case "$published" in
+    '')      ;;                                   # nothing pinned — keep ours
+    *:*)     HTTP_BIND="$published" ;;            # addr:port, as-is
+    *)       HTTP_BIND="127.0.0.1:${published}" ;;  # bare port (compose's short form)
+  esac
+fi
 
 # ---- 3. build the image -----------------------------------------------
 # Toolchain image (#364 docker S1) — just the base + apk packages, no

--- a/test/scripts/quickstart_staging_test.bats
+++ b/test/scripts/quickstart_staging_test.bats
@@ -92,6 +92,52 @@ EOF
     grep -q 'server_name pinned.example.org;' "$BOX/runtime/nginx-frontend.conf"
 }
 
+@test "an explicitly passed HTTP_BIND wins over what .env already carries" {
+    # .env.example publishes on every interface; a fresh .env must not
+    # inherit that when the caller asked for a specific bind.
+    HTTP_BIND=127.0.0.1:3100 run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+    [ "$(grep -c '^NGINX_PUBLISH=' "$BOX/.env")" -eq 1 ]
+    grep -qE '^NGINX_PUBLISH=127\.0\.0\.1:3100:80$' "$BOX/.env"
+
+    HTTP_BIND=127.0.0.1:3200 run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+    [ "$(grep -c '^NGINX_PUBLISH=' "$BOX/.env")" -eq 1 ]
+    grep -qE '^NGINX_PUBLISH=127\.0\.0\.1:3200:80$' "$BOX/.env"
+    [[ "$output" == *"http://127.0.0.1:3200/"* ]]
+}
+
+@test "a fresh .env does not inherit the example's all-interfaces publish" {
+    run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+    grep -qE '^NGINX_PUBLISH=127\.0\.0\.1:3000:80$' "$BOX/.env"
+}
+
+@test "a bind pinned by an earlier run is reported and proxied to, not silently replaced" {
+    HTTP_BIND=127.0.0.1:3100 run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+
+    PHX_HOST=staging.example.org run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+    grep -qE '^NGINX_PUBLISH=127\.0\.0\.1:3100:80$' "$BOX/.env"
+    [[ "$output" == *"http://127.0.0.1:3100/"* ]]
+    grep -q 'server 127.0.0.1:3100;' "$BOX/runtime/nginx-frontend.conf"
+}
+
+@test "a bare-port publish from .env is normalised to loopback in output and upstream" {
+    run "$BOX/scripts/quickstart.sh"   # creates .env
+    [ "$status" -eq 0 ]
+    # Simulate the compose short form a hand-edited .env may carry.
+    grep -v '^NGINX_PUBLISH=' "$BOX/.env" > "$BOX/.env.tmp"
+    mv "$BOX/.env.tmp" "$BOX/.env"
+    printf 'NGINX_PUBLISH=8080:80\n' >> "$BOX/.env"
+
+    PHX_HOST=staging.example.org run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"http://127.0.0.1:8080/"* ]]
+    grep -q 'server 127.0.0.1:8080;' "$BOX/runtime/nginx-frontend.conf"
+}
+
 @test "front-door config is rendered with hostname, upstream and cert paths filled in" {
     PHX_HOST=staging.example.org HTTP_BIND=127.0.0.1:3100 \
         FRONTEND_SSL_CERT=/tmp/cert.pem FRONTEND_SSL_KEY=/tmp/key.pem \

--- a/test/scripts/quickstart_staging_test.bats
+++ b/test/scripts/quickstart_staging_test.bats
@@ -1,0 +1,177 @@
+#!/usr/bin/env bats
+#
+# Bats suite for scripts/quickstart.sh — the staging-box surface (#469):
+# a public hostname instead of the pinned localhost, an optional seeded
+# account + network binding, and the rendered front-door nginx config.
+#
+# Scope: asserts what the script WRITES (.env, runtime/nginx-frontend.conf)
+# and the SHAPE of the docker invocations it makes. `docker` is stubbed on
+# PATH so no image is built and no container is touched — same recording
+# shape as test/scripts/mix_env_db_test.bats.
+#
+# The script cds to its own repo root and writes .env there, so each test
+# runs against a throwaway skeleton in BATS_TEST_TMPDIR rather than the
+# real checkout.
+
+setup() {
+    REPO_SRC="$BATS_TEST_DIRNAME/../.."
+    BOX="$BATS_TEST_TMPDIR/box"
+    mkdir -p "$BOX/scripts" "$BOX/infra"
+
+    cp "$REPO_SRC/scripts/quickstart.sh" "$BOX/scripts/"
+    cp "$REPO_SRC/infra/nginx-tls-frontend.example.conf" "$BOX/infra/"
+    cp "$REPO_SRC/.env.example" "$BOX/.env.example"
+    # Only its presence is checked (preflight), never its content.
+    : > "$BOX/compose.yaml"
+
+    FAKE_DIR="$BATS_TEST_TMPDIR/fake"
+    mkdir -p "$FAKE_DIR"
+    ARGV_LOG="$FAKE_DIR/argv.log"
+    : > "$ARGV_LOG"
+
+    # Fake `docker` — records every invocation, exits 0.
+    cat > "$FAKE_DIR/docker" <<EOF
+#!/usr/bin/env bash
+printf 'docker' >> "$ARGV_LOG"
+for a in "\$@"; do printf ' %q' "\$a" >> "$ARGV_LOG"; done
+printf '\n' >> "$ARGV_LOG"
+exit 0
+EOF
+    chmod +x "$FAKE_DIR/docker"
+    export PATH="$FAKE_DIR:$PATH"
+}
+
+# Make `docker` fail for the invocation whose argv matches $1 (and only
+# that one), so the "already seeded" path can be exercised.
+stub_docker_failing_on() {
+    cat > "$FAKE_DIR/docker" <<EOF
+#!/usr/bin/env bash
+printf 'docker' >> "$ARGV_LOG"
+for a in "\$@"; do printf ' %q' "\$a" >> "$ARGV_LOG"; done
+printf '\n' >> "$ARGV_LOG"
+for a in "\$@"; do
+  [ "\$a" = "$1" ] && exit 1
+done
+exit 0
+EOF
+    chmod +x "$FAKE_DIR/docker"
+}
+
+@test "default run keeps localhost and seeds nothing" {
+    run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+
+    grep -qE '^PHX_HOST=localhost$' "$BOX/.env"
+    ! grep -q 'grappa.create_user' "$ARGV_LOG"
+    ! grep -q 'grappa.bind_network' "$ARGV_LOG"
+}
+
+@test "an explicitly passed PHX_HOST overwrites what a previous run left in .env" {
+    PHX_HOST=first.example.org run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+    grep -qE '^PHX_HOST=first\.example\.org$' "$BOX/.env"
+
+    PHX_HOST=second.example.org run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+
+    # Exactly one PHX_HOST line, carrying the new value — a stale hostname
+    # is the #468 failure mode (links minted for the wrong host, silently).
+    [ "$(grep -c '^PHX_HOST=' "$BOX/.env")" -eq 1 ]
+    grep -qE '^PHX_HOST=second\.example\.org$' "$BOX/.env"
+}
+
+@test "a pre-existing .env hostname survives a run that does not pass one" {
+    PHX_HOST=pinned.example.org run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+
+    run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+    grep -qE '^PHX_HOST=pinned\.example\.org$' "$BOX/.env"
+    # ...and the rendered front door describes the box as it really is,
+    # not as this invocation defaulted.
+    grep -q 'server_name pinned.example.org;' "$BOX/runtime/nginx-frontend.conf"
+}
+
+@test "front-door config is rendered with hostname, upstream and cert paths filled in" {
+    PHX_HOST=staging.example.org HTTP_BIND=127.0.0.1:3100 \
+        FRONTEND_SSL_CERT=/tmp/cert.pem FRONTEND_SSL_KEY=/tmp/key.pem \
+        run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+
+    conf="$BOX/runtime/nginx-frontend.conf"
+    [ -f "$conf" ]
+    ! grep -q '<your-domain>' "$conf"
+    [ "$(grep -c 'server_name staging.example.org;' "$conf")" -eq 2 ]
+    grep -q 'server 127.0.0.1:3100;' "$conf"
+    grep -q 'ssl_certificate     /tmp/cert.pem;' "$conf"
+    grep -q 'ssl_certificate_key /tmp/key.pem;' "$conf"
+
+    # The upgrade path a front door must carry, kept from the example.
+    grep -q 'proxy_set_header Upgrade \$http_upgrade;' "$conf"
+    grep -q 'proxy_set_header X-Forwarded-Proto \$scheme;' "$conf"
+}
+
+@test "a wildcard bind is rewritten to loopback in the rendered upstream" {
+    PHX_HOST=staging.example.org HTTP_BIND=0.0.0.0:3000 \
+        run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+
+    grep -q 'server 127.0.0.1:3000;' "$BOX/runtime/nginx-frontend.conf"
+    ! grep -q 'server 0.0.0.0:3000;' "$BOX/runtime/nginx-frontend.conf"
+}
+
+@test "SEED_USER creates the account and binds the network before the stack comes up" {
+    SEED_USER=tester SEED_PASSWORD=hunter2222 SEED_NICK=tester-box \
+        SEED_AUTOJOIN='#grappa' run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+
+    grep -q "grappa.create_user --name tester --password hunter2222" "$ARGV_LOG"
+    # argv is recorded through %q, so the channel's '#' comes back escaped.
+    grep -q -- "grappa.bind_network --user tester --network azzurra --server irc.azzurra.chat:6697 --nick tester-box --auth none --autojoin \\\\#grappa" "$ARGV_LOG"
+
+    # Bootstrap reads the binding at boot, so seeding must precede `up`.
+    seed_line="$(grep -n 'grappa.bind_network' "$ARGV_LOG" | head -n1 | cut -d: -f1)"
+    up_line="$(grep -n 'up -d' "$ARGV_LOG" | head -n1 | cut -d: -f1)"
+    [ -n "$seed_line" ] && [ -n "$up_line" ] && [ "$seed_line" -lt "$up_line" ]
+}
+
+@test "seeding overrides reach the bind_network call" {
+    SEED_USER=tester SEED_PASSWORD=hunter2222 SEED_NETWORK=libera \
+        SEED_SERVER=irc.libera.chat:6697 SEED_AUTH=sasl \
+        SEED_NICK_PASSWORD=s3cret run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+
+    grep -q -- "--network libera --server irc.libera.chat:6697 --nick tester --auth sasl --password s3cret" "$ARGV_LOG"
+}
+
+@test "an already-seeded box is a warning, not a failed install" {
+    stub_docker_failing_on grappa.create_user
+
+    SEED_USER=tester SEED_PASSWORD=hunter2222 run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+
+    # The binding is still attempted, and the stack still comes up.
+    grep -q 'grappa.bind_network' "$ARGV_LOG"
+    grep -q 'up -d' "$ARGV_LOG"
+}
+
+@test "a generated seed password is printed and is not the empty string" {
+    SEED_USER=tester run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+
+    # `Seeded account:  tester / <password>` — the password must be there.
+    line="$(printf '%s\n' "$output" | grep 'Seeded account:')"
+    pass="${line##*/ }"
+    [ -n "$pass" ]
+    [ "${#pass}" -ge 8 ]
+    grep -q "grappa.create_user --name tester --password $pass" "$ARGV_LOG"
+}
+
+@test "off-localhost runs warn about the secure-context trap" {
+    PHX_HOST=staging.example.org run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"service workers refuse to register"* ]]
+
+    run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+}

--- a/test/scripts/quickstart_update_test.bats
+++ b/test/scripts/quickstart_update_test.bats
@@ -1,0 +1,200 @@
+#!/usr/bin/env bats
+#
+# Bats suite for scripts/quickstart-update.sh (#469) — bringing an
+# already-installed quickstart box up to the latest revision.
+#
+# Why a separate script at all: `deploy.sh` refuses anything that is not
+# the main checkout on main (`require_main_checkout`), which is right for
+# production and useless for a staging box that tracks a feature branch;
+# and re-running `quickstart.sh` never pulls, so it can only ever
+# re-install what is already on disk.
+#
+# Scope: asserts WHICH docker invocations the script makes for a given
+# diff, and what it refuses to do. `docker` is stubbed on PATH — same
+# recording shape as quickstart_staging_test.bats. `git`, by contrast, is
+# REAL: the box is a genuine repository with a genuine upstream, because
+# the whole point of this script is what it derives from a pull.
+
+setup() {
+    REPO_SRC="$BATS_TEST_DIRNAME/../.."
+
+    FAKE_DIR="$BATS_TEST_TMPDIR/fake"
+    mkdir -p "$FAKE_DIR"
+    ARGV_LOG="$FAKE_DIR/argv.log"
+    : > "$ARGV_LOG"
+
+    # Fake `docker` — records every invocation, exits 0.
+    cat > "$FAKE_DIR/docker" <<EOF
+#!/usr/bin/env bash
+printf 'docker' >> "$ARGV_LOG"
+for a in "\$@"; do printf ' %q' "\$a" >> "$ARGV_LOG"; done
+printf '\n' >> "$ARGV_LOG"
+exit 0
+EOF
+    chmod +x "$FAKE_DIR/docker"
+    export PATH="$FAKE_DIR:$PATH"
+
+    export GIT_CONFIG_GLOBAL="$BATS_TEST_TMPDIR/gitconfig"
+    export GIT_AUTHOR_NAME=bats GIT_AUTHOR_EMAIL=bats@example.org
+    export GIT_COMMITTER_NAME=bats GIT_COMMITTER_EMAIL=bats@example.org
+
+    # ---- upstream: what the box pulls FROM ----------------------------
+    UPSTREAM="$BATS_TEST_TMPDIR/upstream"
+    mkdir -p "$UPSTREAM"
+    git -C "$UPSTREAM" init -q -b main
+    mkdir -p "$UPSTREAM/scripts" "$UPSTREAM/cicchetto" \
+             "$UPSTREAM/priv/repo/migrations"
+    cp "$REPO_SRC/scripts/quickstart-update.sh" "$UPSTREAM/scripts/" 2>/dev/null || true
+    : > "$UPSTREAM/compose.yaml"
+    printf 'FROM alpine\n'          > "$UPSTREAM/Dockerfile"
+    printf '%%{}\n'                 > "$UPSTREAM/mix.lock"
+    printf 'defmodule A do end\n'   > "$UPSTREAM/lib_a.ex"
+    printf '{}\n'                   > "$UPSTREAM/cicchetto/package.json"
+    git -C "$UPSTREAM" add -A
+    git -C "$UPSTREAM" commit -qm "base"
+
+    # ---- the box: an installed quickstart checkout --------------------
+    BOX="$BATS_TEST_TMPDIR/box"
+    git clone -q "$UPSTREAM" "$BOX"
+    # The script under test always runs from the source tree, so the box
+    # gets a fresh copy rather than whatever the clone captured.
+    mkdir -p "$BOX/scripts"
+    cp "$REPO_SRC/scripts/quickstart-update.sh" "$BOX/scripts/"
+    # An installed box has a .env — its absence is what "never installed"
+    # means to this script.
+    cat > "$BOX/.env" <<'EOF'
+MIX_ENV=prod
+PHX_HOST=staging.example.org
+NGINX_PUBLISH=127.0.0.1:3100:80
+EOF
+}
+
+# Commit $2 (a path, content $3) upstream so the box has something to pull.
+upstream_commit() {
+    local msg="$1" path="$2" content="$3"
+    mkdir -p "$UPSTREAM/$(dirname "$path")"
+    printf '%s\n' "$content" > "$UPSTREAM/$path"
+    git -C "$UPSTREAM" add -A
+    git -C "$UPSTREAM" commit -qm "$msg"
+}
+
+@test "a box that was never installed is refused, not half-updated" {
+    rm "$BOX/.env"
+    run "$BOX/scripts/quickstart-update.sh"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"quickstart.sh"* ]]
+    # Nothing was pulled and no container was touched.
+    [ ! -s "$ARGV_LOG" ]
+}
+
+@test "it fast-forwards the checkout and reports the revision it moved to" {
+    upstream_commit "new code" lib_a.ex 'defmodule A do def x, do: 1 end'
+    run "$BOX/scripts/quickstart-update.sh"
+    [ "$status" -eq 0 ]
+
+    local head
+    head="$(git -C "$BOX" rev-parse HEAD)"
+    [ "$head" = "$(git -C "$UPSTREAM" rev-parse HEAD)" ]
+    [[ "$output" == *"${head:0:7}"* ]]
+}
+
+@test "a diverged branch fails loud instead of merging" {
+    upstream_commit "upstream moves" lib_a.ex 'defmodule A do def up, do: 1 end'
+    # The box moves too, on the same file — no fast-forward possible.
+    printf 'defmodule A do def local, do: 2 end\n' > "$BOX/lib_a.ex"
+    git -C "$BOX" commit -qam "local divergence"
+
+    run "$BOX/scripts/quickstart-update.sh"
+    [ "$status" -ne 0 ]
+    # It must not have gone on to recreate the stack on a failed pull.
+    ! grep -q 'force-recreate' "$ARGV_LOG"
+}
+
+@test "a code-only change recreates the stack without rebuilding or migrating" {
+    upstream_commit "code only" lib_a.ex 'defmodule A do def x, do: 2 end'
+    run "$BOX/scripts/quickstart-update.sh"
+    [ "$status" -eq 0 ]
+
+    grep -q 'force-recreate' "$ARGV_LOG"
+    ! grep -q 'build' "$ARGV_LOG"
+    ! grep -q 'deps.get' "$ARGV_LOG"
+    ! grep -q 'ecto.migrate' "$ARGV_LOG"
+    ! grep -q 'cicchetto-build' "$ARGV_LOG"
+}
+
+@test "a Dockerfile change rebuilds the image" {
+    upstream_commit "toolchain" Dockerfile 'FROM alpine:3.20'
+    run "$BOX/scripts/quickstart-update.sh"
+    [ "$status" -eq 0 ]
+    grep -qE 'docker compose .*build' "$ARGV_LOG"
+}
+
+@test "a mix.lock change fetches deps" {
+    upstream_commit "bump dep" mix.lock '%{"phoenix" => "1.8.0"}'
+    run "$BOX/scripts/quickstart-update.sh"
+    [ "$status" -eq 0 ]
+    grep -q 'deps.get' "$ARGV_LOG"
+}
+
+@test "a new migration runs ecto.migrate" {
+    upstream_commit "add migration" \
+        priv/repo/migrations/20260727000000_add_thing.exs 'defmodule M do end'
+    run "$BOX/scripts/quickstart-update.sh"
+    [ "$status" -eq 0 ]
+    grep -q 'ecto.migrate' "$ARGV_LOG"
+}
+
+@test "a cicchetto change rebuilds the PWA bundle" {
+    upstream_commit "frontend" cicchetto/src/main.ts 'export const x = 1'
+    run "$BOX/scripts/quickstart-update.sh"
+    [ "$status" -eq 0 ]
+    grep -q 'cicchetto-build' "$ARGV_LOG"
+}
+
+@test "an already-current box still ensures the stack is up, cheaply" {
+    run "$BOX/scripts/quickstart-update.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"already up to date"* ]]
+    grep -qE 'docker compose .*up' "$ARGV_LOG"
+    ! grep -q 'deps.get' "$ARGV_LOG"
+    ! grep -q 'ecto.migrate' "$ARGV_LOG"
+}
+
+@test "--no-pull updates from the working tree and leaves git alone" {
+    upstream_commit "not wanted yet" lib_a.ex 'defmodule A do def x, do: 3 end'
+    local before
+    before="$(git -C "$BOX" rev-parse HEAD)"
+
+    run "$BOX/scripts/quickstart-update.sh" --no-pull
+    [ "$status" -eq 0 ]
+    [ "$(git -C "$BOX" rev-parse HEAD)" = "$before" ]
+    grep -qE 'docker compose .*up' "$ARGV_LOG"
+}
+
+@test "it updates a box parked on a branch that is not main" {
+    git -C "$BOX" checkout -q -b feat/staging
+    git -C "$BOX" branch -q --set-upstream-to=origin/main feat/staging
+    upstream_commit "code" lib_a.ex 'defmodule A do def x, do: 4 end'
+
+    run "$BOX/scripts/quickstart-update.sh"
+    [ "$status" -eq 0 ]
+    [ "$(git -C "$BOX" rev-parse --abbrev-ref HEAD)" = "feat/staging" ]
+    grep -q 'force-recreate' "$ARGV_LOG"
+}
+
+@test "the URL it prints is the one .env actually publishes" {
+    upstream_commit "code" lib_a.ex 'defmodule A do def x, do: 5 end'
+    run "$BOX/scripts/quickstart-update.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"http://127.0.0.1:3100/"* ]]
+}
+
+@test "a dirty working tree is refused before anything is pulled or recreated" {
+    printf 'scribble\n' >> "$BOX/lib_a.ex"
+    upstream_commit "code" mix.lock '%{"phoenix" => "1.9.0"}'
+
+    run "$BOX/scripts/quickstart-update.sh"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"uncommitted"* ]]
+    [ ! -s "$ARGV_LOG" ]
+}


### PR DESCRIPTION
Closes #469.

Builds on `scripts/quickstart.sh` rather than adding a second install
path: the stack's internal nginx already serves plain HTTP on a host
port, which is the "http-only listener" the operator puts behind their
own proxy, and `infra/nginx-tls-frontend.example.conf` already documents
the secure-context constraint. What was missing was the ability to point
the box at a real hostname and have an account and network ready on first
login.

## What changed

- **`PHX_HOST` and `HTTP_BIND` are real inputs**, not pinned to
  `localhost:3000`. `PHX_HOST` is the source of the host-alias set
  (`lib/grappa/http_hosts.ex`), so getting it wrong is exactly #468 —
  upload links pointing at someone else's host, with no error.
- **Optional seeding before the stack comes up**: `SEED_USER` /
  `SEED_NETWORK` / `SEED_SERVER` / `SEED_NICK` drive the existing
  `mix grappa.create_user` and `mix grappa.bind_network` tasks. Order
  matters — Bootstrap reads the binding at boot, so seeding first means
  the first `up` already dials out and the operator's first login lands
  on a connected session. A re-run is a warning, not a failure.
- **The front-door config is rendered, not just referenced**:
  `runtime/nginx-frontend.conf` comes out with hostname, upstream and
  cert paths filled in, and the script prints its path.
- **Off-localhost runs warn about the secure-context trap** (no service
  worker over plain HTTP off-localhost, nor behind an untrusted cert).
- **`INSTALL.md`** gains a staging section.
- **`HTTP_BIND` fix**: an explicitly passed bind now wins over whatever
  `.env` carries. Same failure mode as #468 and found the same way —
  running the box for real, where it kept serving on `0.0.0.0:3000`
  inherited from `.env.example` instead of where it was told.

## Testing

`test/scripts/quickstart_staging_test.bats`, 14 cases, docker stubbed on
PATH. Full CI gate set `test/bin/ test/scripts/` is **54/54**.

End-to-end on arm64 (Raspberry Pi 5), not stubbed:

- image builds;
- `/healthz` 200 and the PWA is served;
- **a real IRC connection**: the seeded nick came up on Azzurra over TLS
  (`raccooncity.azzurra.chat`), and the server notice landed in the
  seeded user's DB;
- **login through the UI reaches a connected session** — the sidebar
  shows the network `CONNECTED` with the seeded nick, and the row in
  `network_credentials` carries `user_id` with `visitor_id` NULL, i.e.
  the account path, not the visitor one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)