### PR TITLE
fix(nginx): serve manifest.webmanifest as application/manifest+json

### DIFF
--- a/infra/freebsd/nginx.conf
+++ b/infra/freebsd/nginx.conf
@@ -23,6 +23,14 @@ events {
 
 http {
     include       mime.types;
+    # Stock mime.types has no entry for `.webmanifest`, so the PWA manifest
+    # went out as `application/octet-stream` (the default_type below), which
+    # is not what browsers expect for a web app manifest. A second `types`
+    # block at this level ADDS to the table built by the include above — it
+    # does not replace it (verified: html/js/css still resolve correctly).
+    types {
+        application/manifest+json  webmanifest;
+    }
     default_type  application/octet-stream;
 
     sendfile        on;

--- a/infra/linux/nginx.conf
+++ b/infra/linux/nginx.conf
@@ -23,6 +23,14 @@ events {
 
 http {
     include       mime.types;
+    # Stock mime.types has no entry for `.webmanifest`, so the PWA manifest
+    # went out as `application/octet-stream` (the default_type below), which
+    # is not what browsers expect for a web app manifest. A second `types`
+    # block at this level ADDS to the table built by the include above — it
+    # does not replace it (verified: html/js/css still resolve correctly).
+    types {
+        application/manifest+json  webmanifest;
+    }
     default_type  application/octet-stream;
 
     sendfile        on;

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -29,6 +29,14 @@ events {
 
 http {
     include       /etc/nginx/mime.types;
+    # Stock mime.types has no entry for `.webmanifest`, so the PWA manifest
+    # went out as `application/octet-stream` (the default_type below), which
+    # is not what browsers expect for a web app manifest. A second `types`
+    # block at this level ADDS to the table built by the include above — it
+    # does not replace it (verified: html/js/css still resolve correctly).
+    types {
+        application/manifest+json  webmanifest;
+    }
     default_type  application/octet-stream;
 
     sendfile        on;


### PR DESCRIPTION
## What

Stock `mime.types` has no entry for `.webmanifest`, so every nginx in the tree fell through to `default_type` and shipped the PWA manifest as `application/octet-stream`.

Found while standing up the #469 staging box behind a TLS front door:

```
$ curl -sI https://<box>/manifest.webmanifest | grep -i content-type
Content-Type: application/octet-stream
```

Phoenix gets it right when it serves the file itself (`Plug.MIME` knows the extension — `curl` straight to `:4000` returns `application/manifest+json`), so the wrong type only surfaces on installs fronted by nginx, which is every non-localhost one.

## How

A second `types` block at `http` level. It **adds** to the table built by the `include` above rather than replacing it — checked on a live box, not assumed:

| path | before | after |
| --- | --- | --- |
| `/manifest.webmanifest` | `application/octet-stream` | `application/manifest+json` |
| `/` | `text/html` | `text/html` |
| `/service-worker.js` | `application/javascript` | `application/javascript` |
| `/assets/*.css` | `text/css` | `text/css` |

Applied to all three configs — `infra/nginx.conf` (docker), `infra/freebsd/nginx.conf` (jail), `infra/linux/nginx.conf` (native) — so the install paths don't drift apart on this.

## Verification

- `nginx -t` clean on all three (the freebsd and linux ones checked with their environment-specific bits substituted: jail IP, `@LISTEN_ADDR@`, `@TRUSTED_UPSTREAM_BLOCK@`).
- Live reload on the running staging box, then the table above re-measured through the TLS front door.

🤖 Generated with [Claude Code](https://claude.com/claude-code)