### PR TITLE
feat(#475): quickstart seeds an admin account and the built-in themes

### DIFF
--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -98,6 +98,12 @@ SEED_NICK="${SEED_NICK:-$SEED_USER}"
 SEED_AUTH="${SEED_AUTH:-none}"
 SEED_NICK_PASSWORD="${SEED_NICK_PASSWORD:-}"
 SEED_AUTOJOIN="${SEED_AUTOJOIN:-}"
+# #475 — the seeded account is an admin by DEFAULT. The admin console is
+# the only place some install-level switches live (visitor access, chiefly),
+# so a box seeded without it is one you cannot finish configuring from the
+# UI it just handed you. SEED_ADMIN=0 for a box that should deliberately
+# start with no administrator.
+SEED_ADMIN="${SEED_ADMIN:-1}"
 
 say()  { printf '\033[1;32m==>\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m!!\033[0m  %s\n' "$*" >&2; }
@@ -250,11 +256,25 @@ if [ -n "$SEED_USER" ]; then
     SEED_PASSWORD="$(head -c 18 /dev/urandom | base64 | tr -d '\n/+=' | cut -c1-20)"
   fi
 
-  say "Seeding account '${SEED_USER}'"
-  if ! "${COMPOSE[@]}" run --rm --no-deps -T grappa \
-      mix grappa.create_user --name "$SEED_USER" --password "$SEED_PASSWORD"; then
+  # #475 — `--admin` is part of the same command, not a second step:
+  # `create_user` grants the bit through `Accounts.update_admin_flags/2`
+  # right after creation. Note this only fires on CREATION — an account
+  # that already exists keeps whatever flags it has, which is why the
+  # re-run path below cannot promote anything.
+  create_args=(mix grappa.create_user --name "$SEED_USER" --password "$SEED_PASSWORD")
+  [ "$SEED_ADMIN" != "0" ] && create_args+=(--admin)
+
+  if [ "$SEED_ADMIN" != "0" ]; then
+    say "Seeding account '${SEED_USER}' (admin)"
+  else
+    say "Seeding account '${SEED_USER}'"
+  fi
+
+  SEED_ACCOUNT_EXISTED=0
+  if ! "${COMPOSE[@]}" run --rm --no-deps -T grappa "${create_args[@]}"; then
+    SEED_ACCOUNT_EXISTED=1
     warn "account '${SEED_USER}' was not created (it most likely already exists) — keeping the existing one."
-    warn "the password printed below is then NOT the account's password."
+    warn "the password printed below is then NOT the account's password, and its admin flag is unchanged."
   fi
 
   say "Binding ${SEED_USER} → ${SEED_NETWORK} (${SEED_SERVER}) as ${SEED_NICK}"
@@ -267,6 +287,23 @@ if [ -n "$SEED_USER" ]; then
     warn "binding not created — ${SEED_USER} is probably already bound to ${SEED_NETWORK}."
     warn "change an existing binding with: ${COMPOSE[*]} run --rm grappa mix grappa.update_network_credential --help"
   fi
+fi
+
+# ---- 6c. seed the built-in theme gallery ------------------------------
+# #475 — deliberately OUTSIDE the SEED_USER block: the curated gallery is
+# a property of the install, not of the optional seeded account, so a box
+# with no seeded user still ships its themes instead of landing with an
+# empty picker. Idempotent by construction — the task upserts each
+# built-in on `(system owner, name)`, so re-running refreshes rows in
+# place and adds new schemes without duplicating anything.
+#
+# Not fatal: an empty gallery is a cosmetic defect, and failing the whole
+# install over it would be a worse trade than a warning on a box that is
+# otherwise healthy.
+say "Seeding the built-in theme gallery"
+if ! "${COMPOSE[@]}" run --rm --no-deps -T grappa mix grappa.seed_themes; then
+  warn "theme seeding failed — the box works, but the gallery starts empty."
+  warn "retry with: ${COMPOSE[*]} run --rm grappa mix grappa.seed_themes"
 fi
 
 # ---- 7. bring up the full stack ---------------------------------------
@@ -334,12 +371,29 @@ EOF
 fi
 
 if [ -n "$SEED_USER" ]; then
-  cat <<EOF
+  # #475 — on a re-run the account already existed, so `create_user` never
+  # ran and the password above is one this script invented and threw away.
+  # Printing it as "the credentials" is how someone spends ten minutes
+  # failing to log into their own box.
+  if [ "${SEED_ACCOUNT_EXISTED:-0}" -eq 1 ]; then
+    cat <<EOF
+
+  Account:         ${SEED_USER} — already exists, left untouched.
+                   The password shown above does not apply to it, and its
+                   admin flag was not changed. Rotate the password with:
+                     ${COMPOSE[*]} run --rm grappa mix run -e \\
+                       'Grappa.Accounts.get_user_by_name("${SEED_USER}") |> Grappa.Accounts.update_password(%{password: "new-one"})'
+  Seeded network:  ${SEED_NETWORK} → ${SEED_SERVER} as ${SEED_NICK}${SEED_AUTOJOIN:+ (autojoin ${SEED_AUTOJOIN})}
+EOF
+  else
+    cat <<EOF
 
   Seeded account:  ${SEED_USER} / ${SEED_PASSWORD}
+  Account role:    $([ "$SEED_ADMIN" != "0" ] && printf 'admin — the console is at the cog, "admin console"' || printf 'plain user (SEED_ADMIN=0)')
   Seeded network:  ${SEED_NETWORK} → ${SEED_SERVER} as ${SEED_NICK}${SEED_AUTOJOIN:+ (autojoin ${SEED_AUTOJOIN})}
   Test-grade credentials — the account is a login for this box, nothing else.
 EOF
+  fi
 else
   cat <<EOF
 

--- a/test/scripts/quickstart_staging_test.bats
+++ b/test/scripts/quickstart_staging_test.bats
@@ -221,3 +221,67 @@ EOF
     run "$BOX/scripts/quickstart.sh"
     [ "$status" -eq 0 ]
 }
+
+# ── #475: an install you can actually administer and theme ─────────────
+#
+# The box the staging mode produces was unusable in two ways vjt hit on a
+# real install: the seeded account was not an admin (so the console — the
+# ONLY place `visitor_enabled` can be flipped — was unreachable), and the
+# theme gallery was empty because nothing ever called `grappa.seed_themes`.
+# Both fixes call mix tasks that already existed; these tests pin that the
+# script actually calls them.
+
+@test "the seeded account is an admin, so the console is reachable" {
+    SEED_USER=tester SEED_PASSWORD=hunter2222 run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+
+    grep -q -- "grappa.create_user --name tester --password hunter2222 --admin" "$ARGV_LOG"
+}
+
+@test "SEED_ADMIN=0 opts out of the admin grant" {
+    SEED_USER=tester SEED_PASSWORD=hunter2222 SEED_ADMIN=0 \
+        run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+
+    grep -q -- "grappa.create_user --name tester --password hunter2222" "$ARGV_LOG"
+    ! grep -q -- "grappa.create_user .* --admin" "$ARGV_LOG"
+}
+
+@test "built-in themes are seeded, before the stack comes up" {
+    run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+
+    grep -q 'grappa.seed_themes' "$ARGV_LOG"
+
+    themes_line="$(grep -n 'grappa.seed_themes' "$ARGV_LOG" | head -n1 | cut -d: -f1)"
+    up_line="$(grep -n 'up -d' "$ARGV_LOG" | head -n1 | cut -d: -f1)"
+    [ -n "$themes_line" ] && [ -n "$up_line" ] && [ "$themes_line" -lt "$up_line" ]
+}
+
+@test "themes are seeded even when no account is seeded" {
+    # The gallery belongs to the install, not to the optional SEED_USER
+    # block — a box with no seeded account still ships its themes.
+    run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+    grep -q 'grappa.seed_themes' "$ARGV_LOG"
+    ! grep -q 'grappa.create_user' "$ARGV_LOG"
+}
+
+@test "a theme seeding failure is a warning, not a failed install" {
+    stub_docker_failing_on grappa.seed_themes
+
+    run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+    grep -q 'up -d' "$ARGV_LOG"
+}
+
+@test "an existing account is told, in the summary, that the password shown does not apply" {
+    stub_docker_failing_on grappa.create_user
+
+    SEED_USER=tester run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+    # The generated password is meaningless for an account that already
+    # exists; the summary must not present it as usable.
+    [[ "$output" == *"already exists"* ]]
+    [[ "$output" == *"password shown above does not apply"* ]]
+}


### PR DESCRIPTION
Closes #475 (items 1 and 2; item 3 has a ruling, below).

## Why

The staging box #469 produces could not be finished from the UI it hands you. The seeded account was not an admin, and the admin console is the only place install-level switches live — visitor access above all — so a box could not be opened to guests without dropping to a shell. @vjt hit exactly that: *"non li posso configurare perché non sono admin."*

Separately the theme gallery landed empty, because nothing called `grappa.seed_themes`. Same defect #435 records for `install.sh` and #440 for the deploy path — this is the third substrate.

Both fixes call mix tasks that **already existed**. No new install path, no new task.

## What

- **`--admin` on the seeded account**, on by default. `create_user` already supported it (`grappa.create_user.ex:13`); it grants through `Accounts.update_admin_flags/2`. `SEED_ADMIN=0` opts out for a box that should deliberately start with no administrator.
- **`grappa.seed_themes` runs for every install**, deliberately **outside** the `SEED_USER` block: the curated gallery belongs to the install, not to an optional seeded account, so a box with no seeded user still ships its themes. Idempotent by construction (upsert on `(system owner, name)`). Non-fatal — an empty gallery is cosmetic, and failing an otherwise healthy install over it is the worse trade.
- **The summary stops handing out a password that does not work.** On a re-run `create_user` fails on the duplicate name, so the generated password was never applied — printing it under "Seeded account" is how someone spends ten minutes failing to log into their own box. That path now states the account was left untouched, that the password shown does not apply, that the admin flag was not changed, and how to rotate it.

## Item 3 — visitor access — ruling

Not implemented here, on purpose. #475 offered two answers; @vjt ruled **(b)**: quickstart makes the seeded account an admin and enabling visitor access stays a console decision. No new `set_network_visitors` task. (Note that a box in that state currently fails guest login with a 500 — that is #472, fixed separately.)

## Verification

Not just the stubbed suite — the box was torn down for real (`down -v`, DB file and `.env` deleted) and reinstalled from scratch:

```
created user vjt (62502297-…) [admin]
UPDATE "users" SET "is_admin" = ? … [true, …]
==> Seeding the built-in theme gallery
seeded 13 curated built-in themes (owner=system)
==> grappa is up and healthy 🎉
  Seeded account:  vjt / …
  Account role:    admin — the console is at the cog, "admin console"
```

…and the session connected to Azzurra and joined its autojoin channel on its own.

**Suite: 73/73** via the runner CI uses (`vendor/bats-core/bin/bats test/bin/ test/scripts/`), including 6 new cases: admin by default, `SEED_ADMIN=0` opt-out, themes seeded before `up`, themes seeded with no account, a theme failure not failing the install, and the re-run summary telling the truth about the password.

One pre-existing test caught a real regression while I worked: appending `(admin)` to the `Seeded account:` line broke the assertion that parses the password out of it. The marker moved to its own `Account role:` line instead of the test being adjusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)