### PR TITLE
chore(deps): dependabot for the cicchetto frontend (bun)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,3 +73,49 @@ updates:
     labels:
       - dependencies
       - docker
+
+  # ── Bun (cicchetto PWA frontend)
+  #    bun, not npm: cicchetto ships package.json + bun.lock and no
+  #    package-lock.json, so an npm ecosystem would bump package.json
+  #    without ever regenerating the lockfile the CI actually installs from.
+  - package-ecosystem: bun
+    directory: "/cicchetto"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Rome
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: deps
+      include: scope
+    groups:
+      solid:
+        patterns:
+          - "solid-js"
+          - "@solidjs/*"
+        exclude-patterns:
+          - "@solidjs/testing-library"
+      fonts:
+        patterns:
+          - "@fontsource/*"
+          - "hack-font"
+      tooling:
+        patterns:
+          - "@biomejs/biome"
+          - "typescript"
+          - "vite"
+          - "vite-plugin-*"
+          - "vitest"
+      testing:
+        patterns:
+          - "@solidjs/testing-library"
+          - "@testing-library/*"
+          - "jsdom"
+          - "@types/jsdom"
+      workbox:
+        patterns:
+          - "workbox-*"
+    labels:
+      - dependencies
+      - cicchetto


### PR DESCRIPTION
Adds a fourth Dependabot ecosystem covering `cicchetto/`, which until now had no dependency updates at all.

## Why `bun` and not `npm`

`cicchetto/` ships `package.json` + `bun.lock` and **no** `package-lock.json`. The release workflow installs with `oven-sh/setup-bun@v2` and the Arch PKGBUILD installs `bun`. An `npm` ecosystem would open PRs that bump `package.json` without regenerating the lockfile that is actually installed from — a broken bump every time.

`package-ecosystem: bun` is supported by Dependabot (requires bun >= 1.1.39, which the repo already uses).

## Grouping

Ungrouped, a weekly run would open well over a dozen PRs — the `@fontsource/*` packages alone are five, plus `hack-font`. Groups mirror the style of the existing `mix` block:

| group | covers |
|---|---|
| `solid` | `solid-js`, `@solidjs/*` (excluding `@solidjs/testing-library`) |
| `fonts` | `@fontsource/*`, `hack-font` |
| `tooling` | `@biomejs/biome`, `typescript`, `vite`, `vite-plugin-*`, `vitest` |
| `testing` | `@solidjs/testing-library`, `@testing-library/*`, `jsdom`, `@types/jsdom` |
| `workbox` | `workbox-*` |

`@solidjs/testing-library` is explicitly excluded from `solid` so it groups with the rest of the test stack instead of with the framework.

Schedule, timezone, commit-message prefix and PR limit follow the existing blocks. Labels are `dependencies` + `cicchetto`, both of which already exist.