### PR TITLE
fix(scripts): refuse to touch a box owned by another checkout

### DIFF
--- a/scripts/quickstart-update.sh
+++ b/scripts/quickstart-update.sh
@@ -59,6 +59,30 @@ esac
 command -v docker >/dev/null 2>&1 || die "docker not found."
 git rev-parse --git-dir >/dev/null 2>&1 || die "not a git checkout — nothing to update from."
 
+# compose.yaml pins `container_name` on the long-lived services, so those
+# names are global to the docker daemon and not scoped by project. Two
+# checkouts of grappa therefore cannot both have a box up: the second one
+# dies at `up` with
+#
+#   Error response from daemon: Conflict. The container name "/grappa" is
+#   already in use by container "…"
+#
+# which names neither who owns it nor what to do about it — and by then
+# the pull has already happened. Refuse here instead, pointing at the
+# directory the running box actually belongs to. The label is docker's own
+# bookkeeping (`com.docker.compose.project.working_dir`), so this asks the
+# running container who owns it rather than guessing from the project name.
+for cname in $(sed -n 's/^[[:space:]]*container_name:[[:space:]]*//p' compose.yaml); do
+  owner="$(docker inspect --format \
+    '{{index .Config.Labels "com.docker.compose.project.working_dir"}}' \
+    "$cname" 2>/dev/null)" || continue      # not running: nothing to clash with
+  if [ -n "$owner" ] && [ "$owner" != "$REPO_ROOT" ]; then
+    warn "container '$cname' is already up, but it belongs to another checkout:"
+    warn "  $owner"
+    die "run scripts/quickstart-update.sh from $owner, or stop that box first (docker compose -f compose.yaml --profile prod down)."
+  fi
+done
+
 if [ "$PULL" -eq 1 ]; then
   # A fast-forward onto a dirty tree either fails halfway or silently
   # carries local edits into what you are about to call "the latest

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -116,6 +116,25 @@ docker compose version >/dev/null 2>&1 || die "docker compose v2 not found — i
 docker info >/dev/null 2>&1 || die "cannot talk to the Docker daemon — is it running / do you have permission?"
 [ -f compose.yaml ] || die "compose.yaml not in $REPO_ROOT — run this from a grappa checkout."
 
+# compose.yaml pins `container_name`, so those names belong to the docker
+# daemon and not to a compose project: a second checkout that installs its
+# own box collides with the first at `up` — "The container name /grappa is
+# already in use" — after this script has already written .env, built the
+# image and seeded an account. Say who owns it now, while nothing has
+# happened yet. Asking the container for its own compose label beats
+# guessing the project name, which is the directory basename and can
+# coincide across checkouts.
+for cname in $(sed -n 's/^[[:space:]]*container_name:[[:space:]]*//p' compose.yaml); do
+  owner="$(docker inspect --format \
+    '{{index .Config.Labels "com.docker.compose.project.working_dir"}}' \
+    "$cname" 2>/dev/null)" || continue      # not running: nothing to clash with
+  if [ -n "$owner" ] && [ "$owner" != "$REPO_ROOT" ]; then
+    warn "container '$cname' is already up, but it belongs to another checkout:"
+    warn "  $owner"
+    die "one box per host: update that one with $owner/scripts/quickstart-update.sh, or stop it first (docker compose -f compose.yaml --profile prod down)."
+  fi
+done
+
 # ---- 1. host-owned runtime dirs (avoid root-owned bind-mount mkdir) ---
 # Compose would auto-create missing bind-mount sources as root; pre-make
 # them so the container (UID = you) can write.

--- a/test/scripts/quickstart_staging_test.bats
+++ b/test/scripts/quickstart_staging_test.bats
@@ -21,20 +21,35 @@ setup() {
     cp "$REPO_SRC/scripts/quickstart.sh" "$BOX/scripts/"
     cp "$REPO_SRC/infra/nginx-tls-frontend.example.conf" "$BOX/infra/"
     cp "$REPO_SRC/.env.example" "$BOX/.env.example"
-    # Only its presence is checked (preflight), never its content.
-    : > "$BOX/compose.yaml"
+    # Preflight checks its presence, and also reads the pinned container
+    # names out of it — those pins are what makes two checkouts collide on
+    # one docker daemon.
+    cat > "$BOX/compose.yaml" <<'EOF'
+services:
+  grappa:
+    container_name: grappa
+  nginx:
+    container_name: grappa-nginx
+EOF
 
     FAKE_DIR="$BATS_TEST_TMPDIR/fake"
     mkdir -p "$FAKE_DIR"
     ARGV_LOG="$FAKE_DIR/argv.log"
     : > "$ARGV_LOG"
 
-    # Fake `docker` — records every invocation, exits 0.
+    # Fake `docker` — records every invocation, exits 0. `inspect` is the
+    # exception: it has to answer, because the ownership guard reads a
+    # compose label off the running container. Unset FAKE_OWNER_DIR means
+    # "no such container", which is what an empty host looks like.
     cat > "$FAKE_DIR/docker" <<EOF
 #!/usr/bin/env bash
 printf 'docker' >> "$ARGV_LOG"
 for a in "\$@"; do printf ' %q' "\$a" >> "$ARGV_LOG"; done
 printf '\n' >> "$ARGV_LOG"
+if [ "\$1" = inspect ]; then
+    [ -n "\${FAKE_OWNER_DIR:-}" ] || exit 1
+    printf '%s\n' "\$FAKE_OWNER_DIR"
+fi
 exit 0
 EOF
     chmod +x "$FAKE_DIR/docker"
@@ -284,4 +299,25 @@ EOF
     # exists; the summary must not present it as usable.
     [[ "$output" == *"already exists"* ]]
     [[ "$output" == *"password shown above does not apply"* ]]
+}
+
+@test "installing next to a box owned by another checkout is refused before anything is written" {
+    export FAKE_OWNER_DIR="$BATS_TEST_TMPDIR/the-other-checkout"
+
+    run "$BOX/scripts/quickstart.sh"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"$FAKE_OWNER_DIR"* ]]
+    # docker's own error would only arrive at `up`, after .env exists and
+    # the image is built. Nothing may have been written yet, and the only
+    # docker calls allowed so far are the read-only preflight probes.
+    [ ! -f "$BOX/.env" ]
+    ! grep -qE 'compose .*(up|build|run)' "$ARGV_LOG"
+}
+
+@test "a box owned by this checkout does not block a re-run" {
+    export FAKE_OWNER_DIR="$BOX"
+
+    run "$BOX/scripts/quickstart.sh"
+    [ "$status" -eq 0 ]
+    grep -q 'up -d' "$ARGV_LOG"
 }

--- a/test/scripts/quickstart_update_test.bats
+++ b/test/scripts/quickstart_update_test.bats
@@ -24,11 +24,20 @@ setup() {
     : > "$ARGV_LOG"
 
     # Fake `docker` — records every invocation, exits 0.
+    #
+    # `docker inspect` is the one subcommand that has to answer rather
+    # than only record: the ownership guard reads a compose label off the
+    # container. Default is "no such container" (exit 1, as the real one
+    # does), and FAKE_OWNER_DIR makes it exist, owned by that directory.
     cat > "$FAKE_DIR/docker" <<EOF
 #!/usr/bin/env bash
 printf 'docker' >> "$ARGV_LOG"
 for a in "\$@"; do printf ' %q' "\$a" >> "$ARGV_LOG"; done
 printf '\n' >> "$ARGV_LOG"
+if [ "\$1" = inspect ]; then
+    [ -n "\${FAKE_OWNER_DIR:-}" ] || exit 1
+    printf '%s\n' "\$FAKE_OWNER_DIR"
+fi
 exit 0
 EOF
     chmod +x "$FAKE_DIR/docker"
@@ -45,7 +54,16 @@ EOF
     mkdir -p "$UPSTREAM/scripts" "$UPSTREAM/cicchetto" \
              "$UPSTREAM/priv/repo/migrations"
     cp "$REPO_SRC/scripts/quickstart-update.sh" "$UPSTREAM/scripts/" 2>/dev/null || true
-    : > "$UPSTREAM/compose.yaml"
+    # The real compose.yaml pins container_name on both long-lived
+    # services; that pin is what makes two checkouts collide, so the
+    # fixture has to carry it.
+    cat > "$UPSTREAM/compose.yaml" <<'EOF'
+services:
+  grappa:
+    container_name: grappa
+  nginx:
+    container_name: grappa-nginx
+EOF
     printf 'FROM alpine\n'          > "$UPSTREAM/Dockerfile"
     printf '%%{}\n'                 > "$UPSTREAM/mix.lock"
     printf 'defmodule A do end\n'   > "$UPSTREAM/lib_a.ex"
@@ -189,6 +207,42 @@ upstream_commit() {
     [[ "$output" == *"http://127.0.0.1:3100/"* ]]
 }
 
+@test "a box owned by another checkout is refused, and the owner is named" {
+    # compose.yaml pins container_name, so the names are global rather
+    # than project-scoped: the second checkout would get docker's bare
+    # "container name /grappa is already in use", which names neither the
+    # owner nor the fix.
+    export FAKE_OWNER_DIR="$BATS_TEST_TMPDIR/some-other-checkout"
+    upstream_commit "code" lib_a.ex 'defmodule A do def x, do: 6 end'
+
+    run "$BOX/scripts/quickstart-update.sh"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"$FAKE_OWNER_DIR"* ]]
+    # Refused BEFORE any side effect: nothing pulled, nothing recreated.
+    [ "$(git -C "$BOX" rev-parse HEAD)" != "$(git -C "$UPSTREAM" rev-parse HEAD)" ]
+    ! grep -q 'force-recreate' "$ARGV_LOG"
+}
+
+@test "a box owned by this very checkout is updated, not refused" {
+    export FAKE_OWNER_DIR="$BOX"
+    upstream_commit "code" lib_a.ex 'defmodule A do def x, do: 7 end'
+
+    run "$BOX/scripts/quickstart-update.sh"
+    [ "$status" -eq 0 ]
+    grep -q 'force-recreate' "$ARGV_LOG"
+}
+
+@test "no running box at all is not mistaken for a foreign one" {
+    # FAKE_OWNER_DIR unset — `docker inspect` exits non-zero, the way it
+    # does when the container does not exist. A first update after a
+    # `down` must still work.
+    upstream_commit "code" lib_a.ex 'defmodule A do def x, do: 8 end'
+
+    run "$BOX/scripts/quickstart-update.sh"
+    [ "$status" -eq 0 ]
+    grep -q 'force-recreate' "$ARGV_LOG"
+}
+
 @test "a dirty working tree is refused before anything is pulled or recreated" {
     printf 'scribble\n' >> "$BOX/lib_a.ex"
     upstream_commit "code" mix.lock '%{"phoenix" => "1.9.0"}'
@@ -196,5 +250,10 @@ upstream_commit() {
     run "$BOX/scripts/quickstart-update.sh"
     [ "$status" -ne 0 ]
     [[ "$output" == *"uncommitted"* ]]
-    [ ! -s "$ARGV_LOG" ]
+    # The ownership guard reads a label off the running container before
+    # this check, so the docker log is not empty — but it must contain
+    # nothing that CHANGES anything.
+    # (the guard's own inspect mentions the compose label namespace, so
+    # match the invocation shape, not the word)
+    ! grep -q '^docker compose' "$ARGV_LOG"
 }


### PR DESCRIPTION
## What happened

Running `scripts/quickstart-update.sh` from a checkout that is **not** the one that installed the box fails with docker's bare conflict:

```
Error response from daemon: Conflict. The container name "/grappa" is already in use by container "..."
```

Measured on the machine that hit it: the live box is owned by compose project `grappa-irc-469` (`working_dir=/home/vjt/code/grappa-irc-469`), and the run happened from a different checkout, which compose scoped as project `grappa`.

## Why

`compose.yaml` pins `container_name: grappa` (:34) and `container_name: grappa-nginx` (:180). A pinned name is global to the docker daemon — compose does **not** scope it by project — so two checkouts of this repo can never both have a stack up.

The failure is late and uninformative in both scripts:

* `quickstart-update.sh` has already **pulled** by then;
* `quickstart.sh` has already written `.env`, built the image and seeded an account.

Neither the owner nor the remedy appears in docker's message.

## Fix

Both scripts read the pinned names straight out of `compose.yaml` and ask each running container for its own `com.docker.compose.project.working_dir` label. Pointing anywhere but this checkout ⇒ refuse in preflight, before any side effect, naming the directory that owns the box.

Asking the container beats guessing the project name: the project name is the directory basename, which two checkouts can share.

## Tests

`docker` stub gained an `inspect` answer driven by `FAKE_OWNER_DIR`, so all three states are covered on both scripts: foreign box (refused, owner named, nothing pulled/written), own box (proceeds), no box at all (proceeds — `inspect` exits 1 like the real one).

`test/scripts/ test/bin/` → **78/78** with the CI runner (`vendor/bats-core/bin/bats`).

One existing assertion changed: the dirty-tree test asserted "no docker call at all", now "no *mutating* docker call" — the guard's read-only `inspect` runs before it.

Real-daemon check of the mechanism (not stubbed):

```
grappa       -> /home/vjt/code/grappa-irc-469
grappa-nginx -> /home/vjt/code/grappa-irc-469
nope-does-not-exist -> exit 1
```