### PR TITLE
feat(scripts): add quickstart-stop.sh

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -135,9 +135,19 @@ to the committed config (no local overrides).
 docker compose -f compose.yaml --profile prod logs -f grappa
 
 # Stop / start
-docker compose -f compose.yaml --profile prod down
+scripts/quickstart-stop.sh                  # takes the prod profile down too
 scripts/quickstart.sh                       # idempotent: brings it back up
 ```
+
+Use the script rather than a bare `docker compose down`: nginx lives
+behind the `prod` profile, so a down without `--profile prod` walks past
+it, leaves it running, and then fails to remove the project network with
+`Resource is still in use` — a half-stopped box under a command that
+reads like it stopped everything. `scripts/quickstart-stop.sh` also
+refuses to stop a box that belongs to a different checkout, and takes
+`--volumes` when you want the build caches gone as well. `runtime/` is a
+bind mount in the checkout, so no flag of this script can touch the
+database.
 
 ### Updating an installed box
 

--- a/scripts/quickstart-stop.sh
+++ b/scripts/quickstart-stop.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# quickstart-stop.sh — take a quickstart box all the way down.
+#
+# Why this exists next to the other two:
+#
+#   * `quickstart.sh` INSTALLS and `quickstart-update.sh` UPDATES; both
+#     end by printing a stop command, and both print it with the profile
+#     because without it the command is wrong.
+#   * The long-lived nginx sits behind the `prod` compose profile, so a
+#     plain `docker compose down` never considers it. It stays up, keeps
+#     the project network attached, and the down ends with
+#
+#         Network <project>_grappa_internal  Resource is still in use
+#
+#     which reads like a docker glitch and is really "half your box is
+#     still running". The fix is one flag nobody remembers at the moment
+#     they need it.
+#
+# So: the same preflight and the same ownership guard as the other two,
+# then the down that actually finishes.
+#
+# Usage:
+#   scripts/quickstart-stop.sh              # stop the stack
+#   scripts/quickstart-stop.sh --volumes    # ...and drop its named volumes
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Same pin as the other two — the committed compose file only, no
+# override auto-merge, so what this stops is what those started.
+COMPOSE=(docker compose -f compose.yaml)
+
+say()  { printf '\033[1;32m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m!!\033[0m  %s\n' "$*" >&2; }
+die()  { printf '\033[1;31mxx\033[0m  %s\n' "$*" >&2; exit 1; }
+
+DROP_VOLUMES=0
+case "${1:-}" in
+  --volumes|-v) DROP_VOLUMES=1 ;;
+  '')           ;;
+  *) die "usage: scripts/quickstart-stop.sh [--volumes]" ;;
+esac
+
+# ---- 0. preflight ------------------------------------------------------
+# Deliberately NOT requiring .env: that file is what "installed" means to
+# quickstart-update.sh, but a box you cannot stop because its config went
+# missing is a trap, and the containers exist either way.
+[ -f compose.yaml ] || die "compose.yaml not in $REPO_ROOT — run this from a grappa checkout."
+command -v docker >/dev/null 2>&1 || die "docker not found."
+
+# compose.yaml pins `container_name` on the long-lived services, so those
+# names are global to the docker daemon and not scoped by project: from
+# here, `down` would happily stop a box belonging to a different checkout
+# of grappa. Ask the running container who owns it — the label is
+# docker's own bookkeeping — and refuse if the answer is not us. Same
+# guard as quickstart.sh / quickstart-update.sh, mirrored on purpose:
+# three scripts that disagree about ownership would be worse than none.
+running=0
+for cname in $(sed -n 's/^[[:space:]]*container_name:[[:space:]]*//p' compose.yaml); do
+  owner="$(docker inspect --format \
+    '{{index .Config.Labels "com.docker.compose.project.working_dir"}}' \
+    "$cname" 2>/dev/null)" || continue        # not running: nothing to stop
+  running=1
+  if [ -n "$owner" ] && [ "$owner" != "$REPO_ROOT" ]; then
+    warn "container '$cname' is up, but it belongs to another checkout:"
+    warn "  $owner"
+    die "run scripts/quickstart-stop.sh from $owner — stopping it from here would take down somebody else's box."
+  fi
+done
+
+# ---- 1. down -----------------------------------------------------------
+# Run even when nothing is up: a previous half-down (the profile bug this
+# script exists for) can leave networks behind, and collecting them is
+# free. Report the no-op rather than refusing it.
+if [ "$running" -eq 0 ]; then
+  say "No grappa containers are up — collecting whatever is left"
+else
+  say "Stopping the stack (prod profile: grappa + nginx)"
+fi
+
+down=("${COMPOSE[@]}" --profile prod down)
+[ "$DROP_VOLUMES" -eq 1 ] && down+=(--volumes)
+"${down[@]}"
+
+# ---- 2. report ---------------------------------------------------------
+if [ "$running" -eq 0 ]; then
+  say "nothing was running 🫥"
+else
+  say "box is down 🛑"
+fi
+
+if [ "$DROP_VOLUMES" -eq 1 ]; then
+  warn "named volumes dropped — the next start recompiles from scratch."
+fi
+
+cat <<EOF
+
+  Start again:  scripts/quickstart-update.sh
+  Data:         runtime/ is a bind mount in this checkout — untouched.
+EOF

--- a/scripts/quickstart-update.sh
+++ b/scripts/quickstart-update.sh
@@ -79,7 +79,7 @@ for cname in $(sed -n 's/^[[:space:]]*container_name:[[:space:]]*//p' compose.ya
   if [ -n "$owner" ] && [ "$owner" != "$REPO_ROOT" ]; then
     warn "container '$cname' is already up, but it belongs to another checkout:"
     warn "  $owner"
-    die "run scripts/quickstart-update.sh from $owner, or stop that box first (docker compose -f compose.yaml --profile prod down)."
+    die "run scripts/quickstart-update.sh from $owner, or stop that box first ($owner/scripts/quickstart-stop.sh)."
   fi
 done
 
@@ -190,5 +190,5 @@ cat <<EOF
   Health:   curl http://${published}/healthz
 
   Logs:     ${COMPOSE[*]} --profile prod logs -f grappa
-  Stop:     ${COMPOSE[*]} --profile prod down
+  Stop:     scripts/quickstart-stop.sh
 EOF

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -16,7 +16,7 @@
 #   scripts/quickstart.sh           # install + start + validate
 #
 # After it finishes the bouncer's web UI is at http://localhost:3000.
-# Tear down with:  docker compose -f compose.yaml --profile prod down
+# Tear down with:  scripts/quickstart-stop.sh
 #
 # ---- Serving it under a real hostname (staging box) -------------------
 #
@@ -131,7 +131,7 @@ for cname in $(sed -n 's/^[[:space:]]*container_name:[[:space:]]*//p' compose.ya
   if [ -n "$owner" ] && [ "$owner" != "$REPO_ROOT" ]; then
     warn "container '$cname' is already up, but it belongs to another checkout:"
     warn "  $owner"
-    die "one box per host: update that one with $owner/scripts/quickstart-update.sh, or stop it first (docker compose -f compose.yaml --profile prod down)."
+    die "one box per host: update that one with $owner/scripts/quickstart-update.sh, or stop it first ($owner/scripts/quickstart-stop.sh)."
   fi
 done
 
@@ -425,5 +425,5 @@ fi
 
 cat <<EOF
 
-  Stop the stack:      ${COMPOSE[*]} --profile prod down
+  Stop the stack:      scripts/quickstart-stop.sh
 EOF

--- a/test/scripts/quickstart_stop_test.bats
+++ b/test/scripts/quickstart_stop_test.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+#
+# Bats suite for scripts/quickstart-stop.sh — taking a quickstart box
+# down, the whole way down.
+#
+# Why this exists: the stack's long-lived nginx sits behind the `prod`
+# compose profile, so a plain `docker compose down` walks past it. The
+# container stays up, keeps the project network attached, and the down
+# ends with
+#
+#   Network <project>_grappa_internal  Resource is still in use
+#
+# leaving half a box running under a command that reads like it stopped
+# everything. This script is the one-liner nobody remembers, with the
+# same ownership guard the other two quickstart scripts carry.
+#
+# Scope: asserts WHICH docker invocations the script makes and what it
+# refuses to do. `docker` is stubbed on PATH — same recording shape as
+# quickstart_update_test.bats.
+
+setup() {
+    REPO_SRC="$BATS_TEST_DIRNAME/../.."
+
+    FAKE_DIR="$BATS_TEST_TMPDIR/fake"
+    mkdir -p "$FAKE_DIR"
+    ARGV_LOG="$FAKE_DIR/argv.log"
+    : > "$ARGV_LOG"
+
+    # Fake `docker` — records every invocation, exits 0. `inspect` is the
+    # one subcommand that has to answer rather than only record: the
+    # ownership guard reads a compose label off the container. Default is
+    # "no such container" (exit 1, as the real one does), and
+    # FAKE_OWNER_DIR makes it exist, owned by that directory.
+    cat > "$FAKE_DIR/docker" <<EOF
+#!/usr/bin/env bash
+printf 'docker' >> "$ARGV_LOG"
+for a in "\$@"; do printf ' %q' "\$a" >> "$ARGV_LOG"; done
+printf '\n' >> "$ARGV_LOG"
+if [ "\$1" = inspect ]; then
+    [ -n "\${FAKE_OWNER_DIR:-}" ] || exit 1
+    printf '%s\n' "\$FAKE_OWNER_DIR"
+fi
+exit 0
+EOF
+    chmod +x "$FAKE_DIR/docker"
+    export PATH="$FAKE_DIR:$PATH"
+
+    # ---- the box: an installed quickstart checkout --------------------
+    BOX="$BATS_TEST_TMPDIR/box"
+    mkdir -p "$BOX/scripts"
+    cp "$REPO_SRC/scripts/quickstart-stop.sh" "$BOX/scripts/"
+    # The real compose.yaml pins container_name on both long-lived
+    # services; that pin is what the ownership guard reads.
+    cat > "$BOX/compose.yaml" <<'EOF'
+services:
+  grappa:
+    container_name: grappa
+  nginx:
+    container_name: grappa-nginx
+EOF
+    cat > "$BOX/.env" <<'EOF'
+MIX_ENV=prod
+PHX_HOST=staging.example.org
+NGINX_PUBLISH=127.0.0.1:3100:80
+EOF
+}
+
+@test "it takes the prod profile down, not just the default one" {
+    export FAKE_OWNER_DIR="$BOX"
+    run "$BOX/scripts/quickstart-stop.sh"
+    [ "$status" -eq 0 ]
+
+    # The bug this script exists for: without --profile prod the nginx
+    # container survives and the network refuses to go.
+    grep -qE 'docker compose .*--profile prod down' "$ARGV_LOG"
+}
+
+@test "it pins the committed compose file, ignoring any override" {
+    export FAKE_OWNER_DIR="$BOX"
+    run "$BOX/scripts/quickstart-stop.sh"
+    [ "$status" -eq 0 ]
+    grep -qE 'docker compose -f compose.yaml' "$ARGV_LOG"
+}
+
+@test "a box owned by another checkout is refused, not stopped" {
+    export FAKE_OWNER_DIR="/somewhere/else/grappa-irc-469"
+    run "$BOX/scripts/quickstart-stop.sh"
+    [ "$status" -ne 0 ]
+    # It must say WHERE the box lives, or the message is as useless as
+    # docker's own name-conflict error.
+    [[ "$output" == *"/somewhere/else/grappa-irc-469"* ]]
+    # And it must not have taken anything down.
+    ! grep -q ' down' "$ARGV_LOG"
+}
+
+@test "outside a grappa checkout it refuses before touching docker" {
+    rm "$BOX/compose.yaml"
+    run "$BOX/scripts/quickstart-stop.sh"
+    [ "$status" -ne 0 ]
+    [ ! -s "$ARGV_LOG" ]
+}
+
+@test "a box with no containers up is stopped anyway, and says so" {
+    # No FAKE_OWNER_DIR: `docker inspect` fails, as it does when nothing
+    # is running. Stale networks still need collecting, so `down` must
+    # run — reporting a no-op is the script's job, not refusing.
+    run "$BOX/scripts/quickstart-stop.sh"
+    [ "$status" -eq 0 ]
+    grep -qE 'docker compose .*--profile prod down' "$ARGV_LOG"
+    [[ "$output" == *"nothing was running"* ]]
+}
+
+@test "a box whose .env was deleted can still be stopped" {
+    # .env is what "installed" means to quickstart-update.sh, but a box
+    # you cannot stop because its config went missing is a trap.
+    rm "$BOX/.env"
+    export FAKE_OWNER_DIR="$BOX"
+    run "$BOX/scripts/quickstart-stop.sh"
+    [ "$status" -eq 0 ]
+    grep -qE 'docker compose .*--profile prod down' "$ARGV_LOG"
+}
+
+@test "--volumes is passed through to compose, plain down is not" {
+    export FAKE_OWNER_DIR="$BOX"
+    run "$BOX/scripts/quickstart-stop.sh" --volumes
+    [ "$status" -eq 0 ]
+    grep -qE 'docker compose .*down .*(-v|--volumes)' "$ARGV_LOG"
+
+    : > "$ARGV_LOG"
+    run "$BOX/scripts/quickstart-stop.sh"
+    [ "$status" -eq 0 ]
+    ! grep -qE 'down .*(-v|--volumes)' "$ARGV_LOG"
+}
+
+@test "an unknown flag is refused instead of being handed to compose" {
+    export FAKE_OWNER_DIR="$BOX"
+    run "$BOX/scripts/quickstart-stop.sh" --rm-rf-everything
+    [ "$status" -ne 0 ]
+    [ ! -s "$ARGV_LOG" ]
+}


### PR DESCRIPTION
## Why

`docker compose down` on a quickstart box does not stop the box. nginx is
gated behind the `prod` compose profile, so a down without `--profile prod`
walks past it: the container stays up, keeps the project network attached,
and the command ends with

```
Network <project>_grappa_internal  Resource is still in use
```

That reads like a docker glitch. It is really *half your box is still
running* — reported from a real box on this host today, and the reason a
later `up` from another checkout then died on the pinned `container_name`.

## What

`scripts/quickstart-stop.sh`, the third of the trio:

- takes the stack down **with the prod profile**, pinning `-f compose.yaml`
  like the other two (committed config, no override auto-merge);
- carries the same ownership guard as `quickstart.sh` / `quickstart-update.sh`
  — it asks the running container for its
  `com.docker.compose.project.working_dir` label and refuses to stop a box
  that belongs to a different checkout, naming the directory that owns it;
- **does not require `.env`.** That file is what "installed" means to the
  update script, but a box you cannot stop because its config went missing
  is a trap, and the containers exist either way;
- runs the down even when nothing is up (a previous half-down leaves
  networks behind; collecting them is free) and reports the no-op rather
  than refusing it;
- `--volumes` passes through for the build caches. `runtime/` is a bind
  mount in the checkout, so no flag of this script can reach the database.

The stop hints in `quickstart.sh`, `quickstart-update.sh` and `INSTALL.md`
now point at the script instead of repeating a command that is wrong
without the profile.

## Tests

TDD: `test/scripts/quickstart_stop_test.bats`, 8 cases, RED first (8/8
failing on the missing script) then GREEN. `docker` stubbed on PATH with
the same recording shape as the update suite, `inspect` answering via
`FAKE_OWNER_DIR`.

Full `test/scripts/ test/bin/` suite with the CI runner
(`vendor/bats-core/bin/bats`): **86/86**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)