### PR TITLE
fix(linux): preserve cic build gitkeep

### DIFF
--- a/infra/linux/cic_build.sh
+++ b/infra/linux/cic_build.sh
@@ -39,5 +39,8 @@ if ! run_as_grappa "cd '${CIC_DIR}' && bun install && bun run build -- --outDir 
 	cat "${log}" >&2
 	exit 1
 fi
+# Vite's `emptyOutDir` wipes .gitkeep on every build. Restore the
+# tracked placeholder so a cold deploy leaves the worktree clean.
+run_as_grappa "touch '${OUT_DIR}/.gitkeep'"
 
 echo "[cic_build] done — ${OUT_DIR}"


### PR DESCRIPTION
## Summary

- restore the tracked `runtime/cicchetto-dist/.gitkeep` after Vite empties the output directory
- run the restore as the `grappa` user
- keep the worktree clean after cold Linux deploys

## Tests

- `bash -n infra/linux/cic_build.sh`
- `git diff --check`

Reproduced on a native Linux deployment: `--emptyOutDir` removed the tracked placeholder after a successful cold deploy.