### PR TITLE
fix(deploy): fetch deps before preflight

### DIFF
--- a/infra/freebsd/deploy.sh
+++ b/infra/freebsd/deploy.sh
@@ -145,6 +145,11 @@ if [ -z "${DEPLOY_REEXECED:-}" ] \
 	exec "${REPO_ROOT}/infra/freebsd/deploy.sh" "$@"
 fi
 
+echo "[deploy] mix deps.get --only prod"
+# Preflight runs through Mix too, so dependencies must match the newly
+# pulled lockfile before it can classify a dependency-changing deploy.
+run_as_grappa 'mix deps.get --only prod'
+
 # ---- Preflight (auto mode only; explicit --force-* skips) ----
 #
 # Source of truth: `lib/grappa/deploy/preflight.ex` (the Elixir module
@@ -246,9 +251,6 @@ fi
 echo
 echo "[deploy] ==> mode: ${mode}"
 echo
-
-echo "[deploy] mix deps.get --only prod"
-run_as_grappa 'mix deps.get --only prod'
 
 echo "[deploy] mix compile --warnings-as-errors"
 run_as_grappa 'mix compile --warnings-as-errors'

--- a/infra/linux/deploy.sh
+++ b/infra/linux/deploy.sh
@@ -62,6 +62,14 @@ if [ "${prev_sha}" = "${new_sha}" ]; then
 	echo "[deploy] HEAD unchanged (${new_sha}) — proceeding anyway (no nothing-to-do fast path: this substrate has no separate cic-only deploy path, so a no-op pull cannot hide a pending change)"
 fi
 
+echo "[deploy] mix deps.get --only prod"
+# Preflight runs through Mix too, so dependencies must match the newly
+# pulled lockfile before it can classify a dependency-changing deploy.
+run_as_grappa '
+	export MIX_ENV=prod
+	mix deps.get --only prod
+'
+
 # ---- Preflight ----
 #
 # Source of truth: lib/grappa/deploy/preflight.ex (shared with
@@ -132,7 +140,7 @@ esac
 
 echo "[deploy] ==> mode: ${mode}"
 
-echo "[deploy] mix deps.get --only prod / compile / release --overwrite"
+echo "[deploy] mix compile / release --overwrite"
 # MIX_ENV=prod required — see install.sh's matching comment: without
 # it mix defaults to :dev and compile fails on missing dev-only deps
 # that --only prod deliberately never fetched.
@@ -143,7 +151,6 @@ echo "[deploy] mix deps.get --only prod / compile / release --overwrite"
 # it the hot path's reload POST below would have nothing new to load.
 run_as_grappa '
 	export MIX_ENV=prod
-	mix deps.get --only prod
 	mix compile --warnings-as-errors
 	mix release --overwrite
 '

--- a/test/infra/deploy_jail_test.bats
+++ b/test/infra/deploy_jail_test.bats
@@ -110,6 +110,18 @@ run_deploy() {
     run "$REPO_ROOT/infra/freebsd/deploy.sh" "$@"
 }
 
+# --- dependency sync before preflight ---------------------------------------
+
+@test "dependencies are fetched before the Mix preflight" {
+    commit_upstream lib/base.txt > /dev/null
+
+    run_deploy
+    [ "$status" -eq 0 ]
+    deps_line=$(grep -n "mix deps.get --only prod" "$ARGV_LOG" | head -1 | cut -d: -f1)
+    preflight_line=$(grep -n "mix run --no-start" "$ARGV_LOG" | head -1 | cut -d: -f1)
+    [ "$deps_line" -lt "$preflight_line" ]
+}
+
 # --- #7: preflight range base ----------------------------------------------
 
 @test "no marker: preflight falls back to pre-pull HEAD as range base" {


### PR DESCRIPTION
## Summary

- fetch production dependencies before running the Mix-based preflight on native Linux and FreeBSD deploys
- keep compilation and release assembly after mode classification
- add a regression test asserting dependency sync precedes preflight

## Problem

When a pull changes `mix.exs` or `mix.lock`, the native deploy scripts invoke `mix run --no-start` before `mix deps.get`. Mix aborts on stale dependencies, so preflight exits 1 and the deploy cannot reach the dependency-fetch step.

## Verification

- `bash -n infra/linux/deploy.sh`
- `sh -n infra/freebsd/deploy.sh`
- `scripts/bats.sh test/infra/` (30 tests)