### PR TITLE
feat(#550): admin Sessions — upstream peer address + reverse DNS

### DIFF
--- a/cicchetto/src/AdminSessionsTab.tsx
+++ b/cicchetto/src/AdminSessionsTab.tsx
@@ -306,16 +306,16 @@ const AdminSessionsTab: Component = () => {
 // pid). The `null` (U-0 honesty) branch lives on /admin/visitors +
 // /admin/credentials, not here.
 //
-// #428 — the server's `SessionEntry.degraded_field` allowlist is
-// `:joined_channels` ONLY: `alive`/`mailbox_len`/`memory_bytes` come from
-// synchronous Process BIFs that never time out, so only the
-// `list_channels` GenServer.call can degrade. The prior "alive unknown"
-// branch (guarded on `"alive"` ∈ introspection_degraded, M4 reviewer)
-// checked a state the server can never emit; the codegen-tightened
-// `introspection_degraded: "joined_channels"[]` proved it dead code and
-// tsc rejected it. Removed. If per-field degradation of alive/mailbox/
-// memory is ever wanted, widen the SERVER `degraded_field` type first —
-// the client then inherits it through the generated mirror.
+// #428 / #550 — the server's `SessionEntry.degraded_field` allowlist is
+// `:joined_channels | :peer_address`: both are GenServer-call round-trips
+// that can time out, whereas `alive`/`mailbox_len`/`memory_bytes` come from
+// synchronous Process BIFs that never do. So there is NO "alive unknown"
+// state to render — the prior branch (guarded on `"alive"` ∈
+// introspection_degraded, M4 reviewer) checked a state the server can never
+// emit; the codegen-tightened union proved it dead code and tsc rejected it.
+// Removed. If per-field degradation of alive/mailbox/memory is ever wanted,
+// widen the SERVER `degraded_field` type first — the client then inherits it
+// through the generated mirror.
 const LiveBadge: Component<{ live: AdminSession["live_state"] }> = (props) => {
   if (props.live.alive === false) {
     return (

--- a/cicchetto/src/AdminSessionsTab.tsx
+++ b/cicchetto/src/AdminSessionsTab.tsx
@@ -240,6 +240,7 @@ const AdminSessionsTab: Component = () => {
               <th>state</th>
               <th>who</th>
               <th>network</th>
+              <th>upstream</th>
               <th>mailbox</th>
               <th>memory</th>
               <th>last seen</th>
@@ -259,6 +260,9 @@ const AdminSessionsTab: Component = () => {
                     <td>{renderWho(s)}</td>
                     <td data-testid={`admin-session-network-${id}`}>
                       {networkSlugById().get(s.network_id) ?? String(s.network_id)}
+                    </td>
+                    <td data-testid={`admin-session-upstream-${id}`}>
+                      {renderUpstream(s.live_state)}
                     </td>
                     <td>{s.live_state.mailbox_len}</td>
                     <td>{renderKb(s.live_state.memory_bytes)}</td>
@@ -370,6 +374,34 @@ function renderLastSeen(iso: string | null): string {
   if (h < 24) return `${h}h`;
   const d = Math.floor(h / 24);
   return `${d}d`;
+}
+
+// #550 — the upstream peer (destination) this session's socket landed on.
+// Reverse-DNS name first (the readable part), the raw address:port second
+// AND as the title — the address is authoritative, the name is
+// attacker-controlled for third-party networks, so it renders as plain
+// (Solid-escaped) text and NEVER replaces the numeric address. `null`
+// address = not connected (the degraded column carries the ⚠ peer_address
+// marker); a `null` name with a live address = cold cache / no PTR, where
+// the raw address stands on its own.
+function renderUpstream(live: AdminSession["live_state"]) {
+  const addr = live.peer_address;
+  if (addr === null) return "—";
+  const hostport = live.peer_port === null ? addr : `${addr}:${live.peer_port}`;
+  const name = live.peer_name;
+  if (name === null) {
+    return (
+      <span class="admin-session-upstream" title={hostport}>
+        {hostport}
+      </span>
+    );
+  }
+  return (
+    <span class="admin-session-upstream" title={hostport}>
+      {name}
+      <span class="admin-session-upstream-addr"> ({hostport})</span>
+    </span>
+  );
 }
 
 function renderDegraded(degraded: string[], id: string) {

--- a/cicchetto/src/__tests__/AdminSessionsTab.test.tsx
+++ b/cicchetto/src/__tests__/AdminSessionsTab.test.tsx
@@ -102,15 +102,17 @@ const DEAD_SESSION: AdminSession = {
     pid_inspect: "#PID<0.999.0>",
     mailbox_len: 0,
     memory_bytes: 0,
-    joined_channels: null,
+    // `alive: false` is trustworthy here (pid registered, Session.Server
+    // genuinely dead between BEAM crash + registry sweep). A dead pid's
+    // GenServer.calls both exit :noproc → {:error, :no_session}:
+    // list_channels maps that to `[]` (empty, NOT degraded); peer_address
+    // maps it to nil + the `:peer_address` marker — the realistic degraded
+    // shape a dead-but-registered pid actually produces (#550).
+    joined_channels: [],
     peer_address: null,
     peer_port: null,
     peer_name: null,
-    // `alive: false` is trustworthy here (pid registered, Session.Server
-    // genuinely dead between BEAM crash + registry sweep). The degraded set
-    // now spans `:joined_channels | :peer_address` (#550) — a dead pid
-    // times out both introspection calls.
-    introspection_degraded: ["joined_channels", "peer_address"],
+    introspection_degraded: ["peer_address"],
   },
 };
 

--- a/cicchetto/src/__tests__/AdminSessionsTab.test.tsx
+++ b/cicchetto/src/__tests__/AdminSessionsTab.test.tsx
@@ -43,6 +43,9 @@ const USER_SESSION: AdminSession = {
     mailbox_len: 3,
     memory_bytes: 250_000,
     joined_channels: ["#bofh", "#italia"],
+    peer_address: "2a01:4f8:201:2281:11::22",
+    peer_port: 6697,
+    peer_name: "allnight6.azzurra.chat",
     introspection_degraded: [],
   },
 };
@@ -59,6 +62,9 @@ const VISITOR_SESSION: AdminSession = {
     mailbox_len: 0,
     memory_bytes: 90_000,
     joined_channels: ["#guest"],
+    peer_address: "192.0.2.10",
+    peer_port: 6667,
+    peer_name: null,
     introspection_degraded: [],
   },
 };
@@ -75,7 +81,13 @@ const DEGRADED_SESSION: AdminSession = {
     mailbox_len: 0,
     memory_bytes: 100_000,
     joined_channels: null,
-    introspection_degraded: ["joined_channels"],
+    // A sick session degrading BOTH introspection calls: no peer known →
+    // nil address + the :peer_address marker (rendered "—" in the upstream
+    // column, never a fabricated/stale address).
+    peer_address: null,
+    peer_port: null,
+    peer_name: null,
+    introspection_degraded: ["joined_channels", "peer_address"],
   },
 };
 
@@ -91,11 +103,14 @@ const DEAD_SESSION: AdminSession = {
     mailbox_len: 0,
     memory_bytes: 0,
     joined_channels: null,
+    peer_address: null,
+    peer_port: null,
+    peer_name: null,
     // `alive: false` is trustworthy here (pid registered, Session.Server
-    // genuinely dead between BEAM crash + registry sweep) — it can never
-    // appear in introspection_degraded, whose only member is
-    // `:joined_channels` (#428, server-authoritative degraded_field set).
-    introspection_degraded: ["joined_channels"],
+    // genuinely dead between BEAM crash + registry sweep). The degraded set
+    // now spans `:joined_channels | :peer_address` (#550) — a dead pid
+    // times out both introspection calls.
+    introspection_degraded: ["joined_channels", "peer_address"],
   },
 };
 
@@ -114,6 +129,9 @@ const ORPHAN_SESSION: AdminSession = {
     mailbox_len: 0,
     memory_bytes: 80_000,
     joined_channels: [],
+    peer_address: "198.51.100.7",
+    peer_port: 6697,
+    peer_name: null,
     introspection_degraded: [],
   },
 };
@@ -204,6 +222,56 @@ describe("AdminSessionsTab", () => {
     expect(visitorRow.textContent).toContain("visitor: M\\Grappa");
     expect(userRow.textContent).not.toContain("11111111");
     expect(visitorRow.textContent).not.toContain("22222222");
+  });
+
+  it("renders the upstream peer: name + address, address-only, or — when not connected (#550)", async () => {
+    const api = await import("../lib/api");
+    vi.mocked(api.adminListSessions).mockResolvedValue([
+      USER_SESSION,
+      VISITOR_SESSION,
+      DEGRADED_SESSION,
+    ]);
+
+    render(() => <AdminSessionsTab />);
+    await screen.findByTestId(`admin-session-row-${rowId(USER_SESSION)}`);
+
+    // Reverse-DNS name first (readable), the raw address:port kept visible
+    // next to it (authoritative) — the name NEVER replaces the address.
+    const withName = screen.getByTestId(`admin-session-upstream-${rowId(USER_SESSION)}`);
+    expect(withName.textContent).toContain("allnight6.azzurra.chat");
+    expect(withName.textContent).toContain("2a01:4f8:201:2281:11::22");
+    expect(withName.textContent).toContain("6697");
+
+    // Cold cache / no PTR: no name → the raw address:port stands on its own.
+    const addrOnly = screen.getByTestId(`admin-session-upstream-${rowId(VISITOR_SESSION)}`);
+    expect(addrOnly.textContent).toContain("192.0.2.10");
+    expect(addrOnly.textContent).toContain("6667");
+
+    // Not connected (peer_address null): em-dash, never a fabricated address.
+    const notConnected = screen.getByTestId(`admin-session-upstream-${rowId(DEGRADED_SESSION)}`);
+    expect(notConnected.textContent).toContain("—");
+  });
+
+  it("renders an attacker-controlled reverse-DNS name as inert text, not HTML (#550)", async () => {
+    // PTR is attacker-controlled for third-party networks (issue failure
+    // mode #3). Solid escapes text interpolation, so a markup payload lands
+    // as literal characters and no live element is created.
+    const api = await import("../lib/api");
+    const hostile: AdminSession = {
+      ...USER_SESSION,
+      subject_id: "77777777-7777-7777-7777-777777777777",
+      live_state: {
+        ...USER_SESSION.live_state,
+        peer_name: "<img src=x onerror=alert(1)>",
+      },
+    };
+    vi.mocked(api.adminListSessions).mockResolvedValue([hostile]);
+
+    render(() => <AdminSessionsTab />);
+    const cell = await screen.findByTestId(`admin-session-upstream-${rowId(hostile)}`);
+
+    expect(cell.textContent).toContain("<img src=x onerror=alert(1)>");
+    expect(cell.querySelector("img")).toBeNull();
   });
 
   it("renders 'no DB row' for orphan-pid sessions (subject_label === null)", async () => {

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -16,7 +16,12 @@ export const IRCAUTH_FSMAUTH_METHOD = [
 ] as const;
 export type IRCAuthFSMAuthMethod = (typeof IRCAUTH_FSMAUTH_METHOD)[number];
 
-export type LiveIntrospectionSessionEntryDegradedField = "joined_channels";
+export const LIVE_INTROSPECTION_SESSION_ENTRY_DEGRADED_FIELD = [
+  "joined_channels",
+  "peer_address",
+] as const;
+export type LiveIntrospectionSessionEntryDegradedField =
+  (typeof LIVE_INTROSPECTION_SESSION_ENTRY_DEGRADED_FIELD)[number];
 
 export type NetworksCredentialAuthMethod = IRCAuthFSMAuthMethod;
 
@@ -440,6 +445,9 @@ export type LiveIntrospectionAdminWireLiveStateJson = {
   mailbox_len: number;
   memory_bytes: number;
   joined_channels: string[] | null;
+  peer_address: string | null;
+  peer_port: number | null;
+  peer_name: string | null;
   introspection_degraded: LiveIntrospectionSessionEntryDegradedField[];
 };
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -23583,3 +23583,79 @@ Regression-guarded by `issue535-visibility-return-preserve-scroll.spec.ts` (four
 visible-outcome e2e cases: preserve-scrollTop with no divider, land-on-divider,
 the follow-live tail-snap that must NOT regress, and messages-missed-while-hidden
 that must neither tail-snap nor strand the reader at the top).
+
+## 2026-07-30 — #550: the upstream peer each session landed on (netsplit triage)
+
+**What.** `GET /admin/sessions` (and the cic admin Sessions tab) now shows the
+destination each IRC session's socket is actually connected to — the peer IP
+(v6/v4) + port + its reverse-DNS name. The round-robin DNS name we dial
+(`azzurra.chat`) says nothing about where a session ended up; during a
+netsplit that is exactly the question ("which sessions are on the split-off
+server and need a bounce?"), and it used to require an `rpc` into the live
+BEAM — the kind of introspection the admin Sessions tab exists to replace.
+
+**Derivation — capture at connect, cache on `Session.Server`, NOT re-derived
+per read.** The socket lives in the `IRC.Client` pid; the admin scan reads
+from the `Session.Server` pid. Three shapes were on the table: (A) derive
+live via a nested `Session.Server → Client` call per admin read — rejected: it
+blocks a session-critical process on a cross-process round-trip for an admin
+page (a stuck `Client` stalls real user traffic); (C, chosen) the `Client`
+reads `peername` ONCE at connect (a transport-dispatched helper, twin of
+`transport_send/2`) and pushes `{:irc_peer, result}` upward; `Session.Server`
+caches `peer_address` (string, `:inet.ntoa/1` at store time) + `peer_port` and
+invalidates them on client EXIT + the next connect attempt
+(`do_start_client`). The peer is **immutable for the connection's lifetime**,
+so this is a connection fact captured at the one authoritative moment and
+cleared at the connection edges — NOT the drift-prone mutable duplication
+CLAUDE.md's "derive, don't duplicate" warns against (that rule targets
+parallel *mutable* state needing housekeeping). Today a client death tears the
+whole `Session.Server` down (`:transient` restart → fresh `peer_address: nil`
+init) — there is no in-process reconnect — so the EXIT/`do_start_client`
+clears are belt-and-suspenders that also future-proof a reconnect that reuses
+the process. `Session.peer_address/3` mirrors `list_channels/3`: an instant
+state read with a 250ms budget, `{:error, :no_peer}` in every not-connected
+window.
+
+**`{:irc_peer, _}` is a separate message from `:irc_connected`** on purpose —
+that signal's contract is load-bearing (#100 liveness, #215 SessionLog,
+visitor-login readiness), so the peer rides its own message and leaves it
+byte-unchanged.
+
+**Reverse DNS reuses `Grappa.Net.PtrCache` (#252), resolved in the
+controller.** The name is looked up in ONE batched, lock-free ETS read
+(`names_for/1`) that resolves cold entries out of band — NEVER a blocking PTR
+per row, which would hang the admin page on one unreachable resolver. A cold /
+no-PTR address yields a `nil` name; the raw address is authoritative on its
+own. The name is **attacker-controlled** for third-party (self-hosted)
+networks, so the wire keeps the numeric address alongside it and cic renders
+the name as untrusted (Solid-escaped) text, never replacing the address.
+
+**Honesty.** Peer absent for ANY reason (pre-connect / mid-reconnect / socket
+just closed / peername error / call timeout) → `peer_address: null` +
+`:peer_address` in `introspection_degraded` (the `SessionEntry.degraded_field`
+allowlist widened from `:joined_channels`). Never a fabricated or stale
+address. Unlike `joined_channels` (where an empty list is a meaningful
+"connected, no channels"), there is no meaningful empty address, so
+`fetch_peer_address/2` collapses `:no_session` to degraded too, not to a
+neutral value.
+
+**Scope + wire.** `live_state` gained `peer_address` / `peer_port` /
+`peer_name` — additive-only (#447), snake_case, no version bump; `wireTypes.ts`
+is the regenerated mirror. Scope is the **Sessions tab** (the netsplit-triage
+door): the operator CLI text formatter (`Grappa.Operator`) and the
+visitors/credentials admin tabs keep their existing `live_state` subset, and
+`peer_name` resolution is the Sessions controller's responsibility.
+
+**Deliberately deferred.** The session's *source* address
+(`:ssl.sockname/1` / `:inet.sockname/1`) is nearly free once this plumbing
+exists and is the natural surface for the per-session outbound source-address
+work — but it touches #454/#543, which have open decisions. Left OUT of this
+change and raised as an explicit PR question rather than decided here.
+
+**Known tradeoff (not changed).** The admin scan now issues two serial
+per-session `GenServer.call`s (`list_channels` + `peer_address`), doubling the
+worst-case latency for a fleet of mailbox-bloated pids (250ms→500ms each,
+serial). Healthy fleets are unaffected (both are instant state reads); the
+shape mirrors the established `fetch_joined_channels` pattern. A single
+combined introspection call would halve the degraded-scan cost — deferred as
+an optimization, not folded here to avoid scope creep.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -988,6 +988,24 @@ mapped to the three mechanisms the issue traced:
     `Process.info(pid, :message_queue_len)` loop against the target session
     pid (from `list-sessions`).
 
+**Which upstream server did a session land on? (netsplit triage, #550)** —
+`GET /admin/sessions` carries, per row, `live_state.peer_address` +
+`live_state.peer_port` (the destination the IRC socket actually connected to
+— the round-robin DNS name, e.g. `azzurra.chat`, says nothing about where a
+session ended up) plus `live_state.peer_name` (its reverse-DNS, resolved out
+of band via `Grappa.Net.PtrCache`, #252 — never a blocking lookup on the
+request path). During a netsplit, group the inventory by `peer_address`:
+every session sharing the split-off server's address (e.g.
+`2a01:4f8:201:2281:11::22` → `allnight6.azzurra.chat`) is a bounce candidate,
+the rest are left alone — the question that used to need an `rpc` into the
+live BEAM. A not-connected session (pre-connect, mid-reconnect, socket just
+closed) shows `peer_address: null` + `:peer_address` in
+`introspection_degraded` — never a stale address. cic renders this as the
+**upstream** column (reverse name first, raw `address:port` alongside; the
+reverse name is untrusted text for third-party networks). The reverse-DNS is
+resolved lazily, so the first scan after a fresh connect may show the raw
+address until the cache warms.
+
 **The consumer ships in code (#357 D1-completion, 2026-07-26).** The D1 spans
 originally emitted into the void ("no handler by default" — the Phase-5 PromEx
 exporter is the eventual consumer), so sampling meant hand-attaching a forwarder

--- a/lib/grappa/irc/client.ex
+++ b/lib/grappa/irc/client.ex
@@ -267,6 +267,17 @@ defmodule Grappa.IRC.Client do
   @spec start_link(opts()) :: GenServer.on_start()
   def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
 
+  @typedoc """
+  The upstream peer of the live socket, read via `transport_peername/1` at
+  connect: `{ip, port}` on success, or a tagged error when the socket is
+  absent / just-closed. Pushed to `dispatch_to` as `{:irc_peer, result}`.
+  #550 — the admin Sessions inventory derives the destination address
+  from this.
+  """
+  @type peername_result ::
+          {:ok, {:inet.ip_address(), :inet.port_number()}}
+          | {:error, :no_socket | :closed | :inet.posix()}
+
   @doc """
   Sends raw bytes verbatim to the upstream socket. The caller is
   responsible for CR/LF framing and IRC syntax. Used by the high-level
@@ -979,6 +990,13 @@ defmodule Grappa.IRC.Client do
         # rDNS-blocked welcome timeout — different upstream pathologies
         # with different Retry-After hints at the HTTP edge.
         send(state.dispatch_to, :irc_connected)
+        # #550 — capture the upstream peer ONCE, now that the socket is up,
+        # and push it upward. The peer is immutable for the connection's
+        # lifetime, so Session.Server caches it (invalidated on client EXIT +
+        # the next connect attempt) rather than round-tripping the socket per
+        # admin read. Separate message from :irc_connected to keep that
+        # load-bearing signal's contract byte-unchanged.
+        send(state.dispatch_to, {:irc_peer, transport_peername(connected)})
         {fsm, sends} = AuthFSM.initial_handshake(state.fsm)
         # `_ =`-discard: a peer RST between connect-success and the
         # first handshake byte will surface as `{:error, :closed}` from
@@ -1567,4 +1585,16 @@ defmodule Grappa.IRC.Client do
 
   defp transport_setopts(%{transport: :ssl, socket: sock}, opts),
     do: :ssl.setopts(sock, opts)
+
+  # #550 — peername dispatched over the transport tag, the read twin of
+  # transport_send/2. Nil-socket guard mirrors it: the bounded pre-connect
+  # window returns an honest tagged tuple rather than crashing on
+  # :inet.peername(nil).
+  defp transport_peername(%{socket: nil}), do: {:error, :no_socket}
+
+  defp transport_peername(%{transport: :tcp, socket: sock}),
+    do: :inet.peername(sock)
+
+  defp transport_peername(%{transport: :ssl, socket: sock}),
+    do: :ssl.peername(sock)
 end

--- a/lib/grappa/live_introspection.ex
+++ b/lib/grappa/live_introspection.ex
@@ -49,6 +49,10 @@ defmodule Grappa.LiveIntrospection do
   alias Grappa.Session.Server
 
   @list_channels_timeout_ms 250
+  # #550 — same honesty budget as list_channels: an instant state read on a
+  # healthy session, but a mailbox-bloated pid degrades to nil rather than
+  # blocking the admin scan on the default 5s exit cascade.
+  @peer_address_timeout_ms 250
 
   @doc """
   Enumerate every live `Session.Server` registered in
@@ -104,7 +108,8 @@ defmodule Grappa.LiveIntrospection do
 
   defp build_entry(subject, network_id, pid) do
     info = Process.info(pid, [:message_queue_len, :memory]) || []
-    {channels, degraded} = fetch_joined_channels(subject, network_id)
+    {channels, channels_degraded} = fetch_joined_channels(subject, network_id)
+    {peer_address, peer_port, peer_degraded} = fetch_peer_address(subject, network_id)
 
     %SessionEntry{
       subject: subject,
@@ -114,7 +119,9 @@ defmodule Grappa.LiveIntrospection do
       mailbox_len: Keyword.get(info, :message_queue_len, 0),
       memory_bytes: Keyword.get(info, :memory, 0),
       joined_channels: channels,
-      introspection_degraded: degraded
+      peer_address: peer_address,
+      peer_port: peer_port,
+      introspection_degraded: channels_degraded ++ peer_degraded
     }
   end
 
@@ -123,6 +130,21 @@ defmodule Grappa.LiveIntrospection do
       {:ok, channels} -> {channels, []}
       {:error, :no_session} -> {[], []}
       {:error, :timeout} -> {nil, [:joined_channels]}
+    end
+  end
+
+  # #550 — mirror of fetch_joined_channels/2 for the upstream peer. Unlike
+  # channels (where an empty list is a meaningful "connected, no channels"),
+  # there is no meaningful "empty address": every not-connected / stuck
+  # outcome (:no_peer, :no_session race, :timeout) collapses to nil + the
+  # :peer_address degraded marker — an honest "unknown", never fabricated.
+  defp fetch_peer_address(subject, network_id) do
+    case Session.peer_address(subject, network_id, @peer_address_timeout_ms) do
+      {:ok, {address, port}} ->
+        {address, port, []}
+
+      {:error, reason} when reason in [:no_peer, :no_session, :timeout] ->
+        {nil, nil, [:peer_address]}
     end
   end
 end

--- a/lib/grappa/live_introspection/admin_wire.ex
+++ b/lib/grappa/live_introspection/admin_wire.ex
@@ -45,6 +45,9 @@ defmodule Grappa.LiveIntrospection.AdminWire do
           mailbox_len: non_neg_integer(),
           memory_bytes: non_neg_integer(),
           joined_channels: [String.t()] | nil,
+          peer_address: String.t() | nil,
+          peer_port: :inet.port_number() | nil,
+          peer_name: String.t() | nil,
           introspection_degraded: [SessionEntry.degraded_field()]
         }
 
@@ -75,16 +78,36 @@ defmodule Grappa.LiveIntrospection.AdminWire do
   (Bootstrap-spawned bouncer with no browser login). Same U-0
   honesty rule as `subject_label`.
 
-  The caller (the controller) owns the resolution of BOTH the
-  label AND the last_seen lookup because `LiveIntrospection`'s
-  boundary explicitly excludes `Accounts` / `Visitors` deps.
-  Keeps the pure live-state module DB-free.
+  The caller (the controller) owns the resolution of the
+  `subject_label`, the `last_seen_at` lookup, AND the `peer_name`
+  reverse-DNS (#550) because `LiveIntrospection`'s boundary
+  explicitly excludes `Accounts` / `Visitors` / `Net.PtrCache` deps.
+  Keeps the pure live-state module DB- and resolver-free.
+
+  ## Upstream peer (#550)
+
+  `live_state.peer_address` (string) + `peer_port` come straight off
+  the `SessionEntry` — the destination the IRC socket landed on,
+  captured live (netsplit triage). `peer_name` is the reverse-DNS the
+  controller resolved out of band via `Grappa.Net.PtrCache` (never
+  inline — a blocking PTR per row would hang the admin page). All three
+  are `nil` when the session is not connected; `peer_name` is also `nil`
+  on a cold cache or an address with no PTR, in which case cic falls
+  back to the raw `peer_address`, which is authoritative on its own.
+  The name is attacker-controlled for third-party networks — cic MUST
+  render it as untrusted text next to (never instead of) the address.
   """
-  @spec session_to_admin_json(SessionEntry.t(), String.t() | nil, DateTime.t() | nil) :: t()
-  def session_to_admin_json(%SessionEntry{subject: {kind, id}} = entry, label, last_seen_at)
+  @spec session_to_admin_json(
+          SessionEntry.t(),
+          String.t() | nil,
+          DateTime.t() | nil,
+          String.t() | nil
+        ) :: t()
+  def session_to_admin_json(%SessionEntry{subject: {kind, id}} = entry, label, last_seen_at, peer_name)
       when kind in [:user, :visitor] and
              (is_binary(label) or is_nil(label)) and
-             (is_struct(last_seen_at, DateTime) or is_nil(last_seen_at)) do
+             (is_struct(last_seen_at, DateTime) or is_nil(last_seen_at)) and
+             (is_binary(peer_name) or is_nil(peer_name)) do
     %{
       subject_kind: kind,
       subject_id: id,
@@ -97,6 +120,9 @@ defmodule Grappa.LiveIntrospection.AdminWire do
         mailbox_len: entry.mailbox_len,
         memory_bytes: entry.memory_bytes,
         joined_channels: entry.joined_channels,
+        peer_address: entry.peer_address,
+        peer_port: entry.peer_port,
+        peer_name: peer_name,
         introspection_degraded: entry.introspection_degraded
       }
     }

--- a/lib/grappa/live_introspection/session_entry.ex
+++ b/lib/grappa/live_introspection/session_entry.ex
@@ -21,11 +21,20 @@ defmodule Grappa.LiveIntrospection.SessionEntry do
       `Grappa.Session.list_channels/2`. `nil` when the GenServer
       call timed out (busy / mailbox-bloated pid — see
       `introspection_degraded`).
+    * `peer_address` — the upstream peer IP (v6/v4) the session's
+      IRC socket is connected to, as a string, per
+      `Grappa.Session.peer_address/3` (#550, netsplit triage). `nil`
+      when the session is not connected (pre-connect, mid-reconnect,
+      socket just closed) OR the call timed out — both add
+      `:peer_address` to `introspection_degraded`. Never a fabricated
+      or stale address.
+    * `peer_port` — the peer TCP port alongside `peer_address`; `nil`
+      whenever `peer_address` is.
     * `introspection_degraded` — atom allowlist marking which
-      sub-fields fell back to a degraded shape. Today only
-      `:joined_channels`. The wire layer surfaces this so the
-      operator sees "this session is sick" rather than "this
-      session has no channels."
+      sub-fields fell back to a degraded shape (`:joined_channels`,
+      `:peer_address`). The wire layer surfaces this so the operator
+      sees "this session is sick / not connected" rather than "this
+      session has no channels / no upstream."
   """
 
   @enforce_keys [
@@ -36,6 +45,8 @@ defmodule Grappa.LiveIntrospection.SessionEntry do
     :mailbox_len,
     :memory_bytes,
     :joined_channels,
+    :peer_address,
+    :peer_port,
     :introspection_degraded
   ]
 
@@ -47,10 +58,12 @@ defmodule Grappa.LiveIntrospection.SessionEntry do
     :mailbox_len,
     :memory_bytes,
     :joined_channels,
+    :peer_address,
+    :peer_port,
     :introspection_degraded
   ]
 
-  @type degraded_field :: :joined_channels
+  @type degraded_field :: :joined_channels | :peer_address
 
   @type t :: %__MODULE__{
           subject: Grappa.Session.subject(),
@@ -60,6 +73,8 @@ defmodule Grappa.LiveIntrospection.SessionEntry do
           mailbox_len: non_neg_integer(),
           memory_bytes: non_neg_integer(),
           joined_channels: [String.t()] | nil,
+          peer_address: String.t() | nil,
+          peer_port: :inet.port_number() | nil,
           introspection_degraded: [degraded_field()]
         }
 end

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -854,6 +854,46 @@ defmodule Grappa.Session do
   end
 
   @doc """
+  Returns the upstream peer (`{address, port}`) the session at
+  `(subject, network_id)` is connected to — the destination the IRC
+  socket actually landed on (#550, netsplit triage).
+
+  `address` is the peer IP as a string (`:inet.ntoa/1` of the v6/v4
+  tuple). The peer is captured once at connect and cached on the
+  Session.Server (immutable for the connection's lifetime), so this is
+  an instant state read.
+
+  Returns `{:error, :no_peer}` in every not-connected window (pre-connect,
+  mid-reconnect, socket just closed) — the honest "unknown", never a
+  fabricated address — and `{:error, :no_session}` when no session is
+  registered for `(subject, network_id)`.
+  """
+  @spec peer_address(subject(), integer()) ::
+          {:ok, {String.t(), :inet.port_number()}} | {:error, :no_session | :no_peer}
+  def peer_address(subject, network_id)
+      when is_subject(subject) and is_integer(network_id) do
+    call_session(subject, network_id, {:peer_address})
+  end
+
+  @doc """
+  Variant of `peer_address/2` accepting an explicit per-call receive
+  `timeout_ms`. Returns `{:error, :timeout}` instead of exiting when the
+  target Session.Server's mailbox is too deep to respond within budget —
+  the operator surface (`Grappa.LiveIntrospection`) needs an honest signal
+  for stuck pids rather than the default 5s exit cascade.
+
+  `:infinity` is allowed (delegates to the underlying GenServer.call).
+  """
+  @spec peer_address(subject(), integer(), timeout()) ::
+          {:ok, {String.t(), :inet.port_number()}}
+          | {:error, :no_session | :no_peer | :timeout}
+  def peer_address(subject, network_id, timeout_ms)
+      when is_subject(subject) and is_integer(network_id) and
+             (is_integer(timeout_ms) or timeout_ms == :infinity) do
+    call_session(subject, network_id, {:peer_address}, timeout_ms)
+  end
+
+  @doc """
   Returns the live IRC nick for the session at `(subject, network_id)`.
 
   The live nick may differ from the credential's configured nick after

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -547,6 +547,15 @@ defmodule Grappa.Session.Server do
           autojoin_defer_ms: pos_integer(),
           autojoin_defer_timer: reference() | nil,
           client: pid() | nil,
+          # #550 — the upstream peer the live socket connected to, captured
+          # once from the Client at connect (`{:irc_peer, _}`) and invalidated
+          # on client EXIT + the next connect attempt. Cached (not re-derived
+          # per read) because it is immutable for the connection's lifetime;
+          # `nil` in every not-connected window is the honest degraded signal
+          # the admin Sessions inventory surfaces. Address stored as a string
+          # (`:inet.ntoa/1`) at capture so the read side stays format-free.
+          peer_address: String.t() | nil,
+          peer_port: :inet.port_number() | nil,
           notify_pid: pid() | nil,
           notify_ref: reference() | nil,
           pending_auth: nil | {String.t(), integer()},
@@ -930,6 +939,9 @@ defmodule Grappa.Session.Server do
       autojoin_defer_ms: Map.get(opts, :autojoin_defer_ms, @autojoin_defer_ms),
       autojoin_defer_timer: nil,
       client: nil,
+      # #550 — nil until the Client pushes {:irc_peer, _} at connect.
+      peer_address: nil,
+      peer_port: nil,
       notify_pid: Map.get(opts, :notify_pid),
       notify_ref: Map.get(opts, :notify_ref),
       pending_auth: nil,
@@ -1135,7 +1147,11 @@ defmodule Grappa.Session.Server do
 
     case Client.start_link(client_opts) do
       {:ok, client} ->
-        {:noreply, %{state | client: client}}
+        # #550 — a fresh connection attempt: clear any stale peer until this
+        # new Client pushes {:irc_peer, _} on connect (honest nil in the
+        # connect window; future-proofs an in-process reconnect that reuses
+        # this process instead of the transient full-restart today).
+        {:noreply, %{state | client: client, peer_address: nil, peer_port: nil}}
 
       {:error, reason} ->
         # Inline start failure (Client.init/1 rejected the opts —
@@ -1834,6 +1850,18 @@ defmodule Grappa.Session.Server do
     {:reply, {:ok, channels}, state}
   end
 
+  # #550 — the cached upstream peer (destination) for the admin Sessions
+  # inventory. Instant state read; `{:error, :no_peer}` in every
+  # not-connected window (pre-connect, mid-reconnect, socket just closed) is
+  # the honest degraded signal. Public via `Grappa.Session.peer_address/3`.
+  def handle_call({:peer_address}, _, %{peer_address: nil} = state) do
+    {:reply, {:error, :no_peer}, state}
+  end
+
+  def handle_call({:peer_address}, _, state) do
+    {:reply, {:ok, {state.peer_address, state.peer_port}}, state}
+  end
+
   # #247 — the authoritative /notify presence map for this session.
   # Public via `Grappa.Session.presence_snapshot/2`; consumed by the
   # channel after-join snapshot and the REST notify listing (DB list +
@@ -2187,6 +2215,21 @@ defmodule Grappa.Session.Server do
     {:noreply, state}
   end
 
+  # #550 — the Client captured the upstream peer at connect. Cache it
+  # (address as a string) so the admin Sessions inventory can read the
+  # destination this session landed on without round-tripping the socket.
+  # Invalidated on client EXIT + the next connect attempt (do_start_client).
+  def handle_info({:irc_peer, {:ok, {ip, port}}}, state) do
+    {:noreply, %{state | peer_address: List.to_string(:inet.ntoa(ip)), peer_port: port}}
+  end
+
+  # A socket that never came up / just closed (bounded pre-connect window,
+  # peer RST in flight): keep the peer nil — the honest "unknown" the
+  # inventory renders as a degraded row, never a fabricated address.
+  def handle_info({:irc_peer, {:error, _}}, state) do
+    {:noreply, %{state | peer_address: nil, peer_port: nil}}
+  end
+
   # S3.2 / #182 — a device became VISIBLE (foreground) when none was
   # before. Cancel any pending auto-away debounce timer and (if currently
   # :away_auto) unset auto-away. Explicit away is left untouched —
@@ -2267,7 +2310,7 @@ defmodule Grappa.Session.Server do
     # advances the failure counter. The `:client_exit` reason wrapper
     # is preserved for supervisor-log fidelity (distinguishes upstream
     # disconnect from a Session-internal crash).
-    {:stop, {:client_exit, reason}, %{state | client: nil}}
+    {:stop, {:client_exit, reason}, %{state | client: nil, peer_address: nil, peer_port: nil}}
   end
 
   # Clean linked-Client exit (operator stop / planned teardown / supervisor

--- a/lib/grappa_web/controllers/admin/sessions_controller.ex
+++ b/lib/grappa_web/controllers/admin/sessions_controller.ex
@@ -69,6 +69,7 @@ defmodule GrappaWeb.Admin.SessionsController do
 
   alias Grappa.{Accounts, LiveIntrospection, Operator, Session}
   alias Grappa.LiveIntrospection.AdminWire
+  alias Grappa.Net.PtrCache
   alias Grappa.Networks.Credentials
   alias GrappaWeb.Admin.AuthPlug
 
@@ -103,13 +104,25 @@ defmodule GrappaWeb.Admin.SessionsController do
     # the label resolution uses.
     user_last_seen = Accounts.max_last_seen_by_subject_ids(:user, user_ids)
     visitor_last_seen = Accounts.max_last_seen_by_subject_ids(:visitor, visitor_ids)
+    # #550 — resolve every connected session's upstream peer reverse-DNS in
+    # ONE batched, lock-free PtrCache read. Out of band (a cold/expired
+    # entry fires an async resolve so the NEXT scan is warm) — NEVER a
+    # blocking PTR per row, which would hang the admin page on one
+    # unreachable resolver. A cold / no-PTR address maps to `nil`; the raw
+    # peer_address is rendered on its own then.
+    peer_names =
+      entries
+      |> Enum.map(& &1.peer_address)
+      |> Enum.reject(&is_nil/1)
+      |> PtrCache.names_for()
 
     rows =
       Enum.map(entries, fn entry ->
         AdminWire.session_to_admin_json(
           entry,
           resolve_label(entry, users, visitor_nicks),
-          resolve_last_seen(entry, user_last_seen, visitor_last_seen)
+          resolve_last_seen(entry, user_last_seen, visitor_last_seen),
+          resolve_peer_name(entry, peer_names)
         )
       end)
 
@@ -148,6 +161,13 @@ defmodule GrappaWeb.Admin.SessionsController do
 
   defp resolve_last_seen(%{subject: {:visitor, id}}, _, visitor_last_seen),
     do: Map.get(visitor_last_seen, id)
+
+  # #550 — the reverse-DNS name for this entry's upstream peer, or nil when
+  # the session is not connected (no address to resolve) or the batched
+  # PtrCache read had no name yet (cold / no-PTR). Keyed on the address
+  # string, exactly what names_for/1 returns.
+  defp resolve_peer_name(%{peer_address: nil}, _), do: nil
+  defp resolve_peer_name(%{peer_address: address}, names), do: Map.get(names, address)
 
   @doc """
   T32 disconnect verb — parks the credential + stops the pid (user

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -130,6 +130,21 @@ defmodule Grappa.IRC.ClientTest do
     end
   end
 
+  describe "peer capture on connect" do
+    test "pushes {:irc_peer, {:ok, {ip, port}}} to dispatch_to once the socket is up" do
+      # #550 — the admin Sessions inventory surfaces the destination each
+      # session landed on (netsplit triage). The Client captures the peer
+      # ONCE at connect and pushes it upward (dispatch_to = self() here), so
+      # Session.Server can cache it without round-tripping the socket per
+      # admin read. The client dialed the in-process IRCServer on
+      # 127.0.0.1:<port>, so the pushed peer reflects exactly that.
+      {_, port} = start_server()
+      _ = start_client(port)
+
+      assert_receive {:irc_peer, {:ok, {{127, 0, 0, 1}, ^port}}}, 1_000
+    end
+  end
+
   describe "outbound: client → server" do
     test "send_line/2 writes the raw bytes to the server socket" do
       {server, port} = start_server()

--- a/test/grappa/live_introspection/admin_wire_test.exs
+++ b/test/grappa/live_introspection/admin_wire_test.exs
@@ -2,28 +2,49 @@ defmodule Grappa.LiveIntrospection.AdminWireTest do
   @moduledoc """
   Wire-shape contract for the operator-facing `GET /admin/sessions`
   endpoint (M-cluster M-4). Converts a `Grappa.LiveIntrospection.SessionEntry`
-  + a resolved subject_label + an optional last_seen_at to a
-  JSON-encodable map.
+  + a resolved subject_label + an optional last_seen_at + the resolved
+  upstream peer name (#550) to a JSON-encodable map.
   """
   use ExUnit.Case, async: true
 
   alias Grappa.LiveIntrospection.{AdminWire, SessionEntry}
 
-  test "session_to_admin_json/3 passes subject_kind atom through + projects live_state subfields + subject_label" do
-    uuid = Ecto.UUID.generate()
-
-    entry = %SessionEntry{
-      subject: {:visitor, uuid},
-      network_id: 42,
+  # #550 — SessionEntry now enforces peer_address/peer_port. A connected
+  # entry carries them; a not-connected one is nil + the :peer_address
+  # degraded marker. Helper keeps the literals honest without repeating the
+  # full 10-field struct per test.
+  defp entry(overrides) do
+    base = %{
+      subject: {:user, Ecto.UUID.generate()},
+      network_id: 1,
       pid: self(),
       alive: true,
-      mailbox_len: 3,
-      memory_bytes: 99_999,
-      joined_channels: ["#one", "#two"],
+      mailbox_len: 0,
+      memory_bytes: 512,
+      joined_channels: [],
+      peer_address: nil,
+      peer_port: nil,
       introspection_degraded: []
     }
 
-    json = AdminWire.session_to_admin_json(entry, "M\\Grappa", nil)
+    struct!(SessionEntry, Map.merge(base, Map.new(overrides)))
+  end
+
+  test "session_to_admin_json/4 passes subject_kind atom through + projects live_state subfields + subject_label" do
+    uuid = Ecto.UUID.generate()
+
+    entry =
+      entry(
+        subject: {:visitor, uuid},
+        network_id: 42,
+        mailbox_len: 3,
+        memory_bytes: 99_999,
+        joined_channels: ["#one", "#two"],
+        peer_address: "2a01:4f8:201:2281:11::22",
+        peer_port: 6697
+      )
+
+    json = AdminWire.session_to_admin_json(entry, "M\\Grappa", nil, "allnight6.azzurra.chat")
 
     # subject_kind is the `:user | :visitor` ATOM in the term — the closed
     # set is typed as an atom union, and Jason stringifies at the JSON edge
@@ -42,21 +63,65 @@ defmodule Grappa.LiveIntrospection.AdminWireTest do
     assert is_binary(json.live_state.pid_inspect)
   end
 
-  test "session_to_admin_json/3 user-subject shape" do
+  test "session_to_admin_json/4 projects the upstream peer address + port + resolved name" do
+    # #550 netsplit triage — the operator sees the destination each session
+    # landed on. peer_address/peer_port come off the SessionEntry (live
+    # capture); peer_name is the reverse-DNS the controller resolved out of
+    # band via Grappa.Net.PtrCache and passes in.
+    entry = entry(peer_address: "2a01:4f8:201:2281:11::22", peer_port: 6697)
+
+    json = AdminWire.session_to_admin_json(entry, "vjt", nil, "allnight6.azzurra.chat")
+
+    assert json.live_state.peer_address == "2a01:4f8:201:2281:11::22"
+    assert json.live_state.peer_port == 6697
+    assert json.live_state.peer_name == "allnight6.azzurra.chat"
+
+    decoded = Jason.decode!(Jason.encode!(json))
+    assert decoded["live_state"]["peer_address"] == "2a01:4f8:201:2281:11::22"
+    assert decoded["live_state"]["peer_port"] == 6697
+    assert decoded["live_state"]["peer_name"] == "allnight6.azzurra.chat"
+  end
+
+  test "session_to_admin_json/4 renders nil peer + nil name for a not-connected session" do
+    # Not connected (pre-connect / mid-reconnect / socket closed): nil
+    # address + nil port + the :peer_address degraded marker, and the
+    # controller passes nil for the name (nothing to resolve). Never a
+    # fabricated or stale address.
+    entry = entry(peer_address: nil, peer_port: nil, introspection_degraded: [:peer_address])
+
+    json = AdminWire.session_to_admin_json(entry, "vjt", nil, nil)
+
+    assert json.live_state.peer_address == nil
+    assert json.live_state.peer_port == nil
+    assert json.live_state.peer_name == nil
+    assert json.live_state.introspection_degraded == [:peer_address]
+  end
+
+  test "peer_name nil while peer_address present is the cold-cache / no-PTR shape" do
+    # #252 PtrCache is lazy: a cold or no-PTR address resolves to nil name;
+    # cic falls back to the raw address, which is always useful on its own.
+    entry = entry(peer_address: "192.0.2.7", peer_port: 6667)
+
+    json = AdminWire.session_to_admin_json(entry, "vjt", nil, nil)
+
+    assert json.live_state.peer_address == "192.0.2.7"
+    assert json.live_state.peer_port == 6667
+    assert json.live_state.peer_name == nil
+  end
+
+  test "session_to_admin_json/4 user-subject shape" do
     uuid = Ecto.UUID.generate()
 
-    entry = %SessionEntry{
-      subject: {:user, uuid},
-      network_id: 7,
-      pid: self(),
-      alive: true,
-      mailbox_len: 0,
-      memory_bytes: 1024,
-      joined_channels: nil,
-      introspection_degraded: [:joined_channels]
-    }
+    entry =
+      entry(
+        subject: {:user, uuid},
+        network_id: 7,
+        memory_bytes: 1024,
+        joined_channels: nil,
+        introspection_degraded: [:joined_channels]
+      )
 
-    json = AdminWire.session_to_admin_json(entry, "vjt", nil)
+    json = AdminWire.session_to_admin_json(entry, "vjt", nil, nil)
 
     assert json.subject_kind == :user
     assert json.subject_id == uuid
@@ -73,39 +138,29 @@ defmodule Grappa.LiveIntrospection.AdminWireTest do
     # opaque UUID.
     uuid = Ecto.UUID.generate()
 
-    entry = %SessionEntry{
-      subject: {:visitor, uuid},
-      network_id: 1,
-      pid: self(),
-      alive: true,
-      mailbox_len: 0,
-      memory_bytes: 512,
-      joined_channels: [],
-      introspection_degraded: []
-    }
+    entry = entry(subject: {:visitor, uuid})
 
-    json = AdminWire.session_to_admin_json(entry, nil, nil)
+    json = AdminWire.session_to_admin_json(entry, nil, nil, nil)
 
     assert json.subject_label == nil
     assert json.subject_id == uuid
   end
 
-  test "session_to_admin_json/3 rejects non-string non-nil labels at the guard" do
-    entry = %SessionEntry{
-      subject: {:user, Ecto.UUID.generate()},
-      network_id: 1,
-      pid: self(),
-      alive: true,
-      mailbox_len: 0,
-      memory_bytes: 0,
-      joined_channels: [],
-      introspection_degraded: []
-    }
+  test "session_to_admin_json/4 rejects non-string non-nil labels at the guard" do
+    entry = entry([])
 
     # Guard `is_binary(label) or is_nil(label)` — anything else is a
     # contract violation that surfaces as FunctionClauseError.
     assert_raise FunctionClauseError, fn ->
-      AdminWire.session_to_admin_json(entry, :atom_label, nil)
+      AdminWire.session_to_admin_json(entry, :atom_label, nil, nil)
+    end
+  end
+
+  test "session_to_admin_json/4 rejects non-string non-nil peer_name at the guard" do
+    entry = entry([])
+
+    assert_raise FunctionClauseError, fn ->
+      AdminWire.session_to_admin_json(entry, "vjt", nil, :atom_name)
     end
   end
 
@@ -114,21 +169,11 @@ defmodule Grappa.LiveIntrospection.AdminWireTest do
     # subject id and passes the DateTime (or nil) as the third arg.
     # Wire renders it via `DateTime.to_iso8601/1` so the cic admin
     # console can `new Date(...)` it directly.
-    uuid = Ecto.UUID.generate()
     {:ok, dt, _} = DateTime.from_iso8601("2026-05-27T18:30:00.123456Z")
 
-    entry = %SessionEntry{
-      subject: {:user, uuid},
-      network_id: 1,
-      pid: self(),
-      alive: true,
-      mailbox_len: 0,
-      memory_bytes: 0,
-      joined_channels: [],
-      introspection_degraded: []
-    }
+    entry = entry([])
 
-    json = AdminWire.session_to_admin_json(entry, "vjt", dt)
+    json = AdminWire.session_to_admin_json(entry, "vjt", dt, nil)
 
     assert json.last_seen_at == "2026-05-27T18:30:00.123456Z"
   end
@@ -138,38 +183,18 @@ defmodule Grappa.LiveIntrospection.AdminWireTest do
     # never logged in (operator boot path) has no cookie session —
     # nil signals "we have a live bouncer but no recent browser
     # touch", distinct from "browser logged in N seconds ago".
-    uuid = Ecto.UUID.generate()
+    entry = entry([])
 
-    entry = %SessionEntry{
-      subject: {:user, uuid},
-      network_id: 1,
-      pid: self(),
-      alive: true,
-      mailbox_len: 0,
-      memory_bytes: 0,
-      joined_channels: [],
-      introspection_degraded: []
-    }
-
-    json = AdminWire.session_to_admin_json(entry, "vjt", nil)
+    json = AdminWire.session_to_admin_json(entry, "vjt", nil, nil)
 
     assert json.last_seen_at == nil
   end
 
-  test "session_to_admin_json/3 rejects non-DateTime non-nil last_seen_at at the guard" do
-    entry = %SessionEntry{
-      subject: {:user, Ecto.UUID.generate()},
-      network_id: 1,
-      pid: self(),
-      alive: true,
-      mailbox_len: 0,
-      memory_bytes: 0,
-      joined_channels: [],
-      introspection_degraded: []
-    }
+  test "session_to_admin_json/4 rejects non-DateTime non-nil last_seen_at at the guard" do
+    entry = entry([])
 
     assert_raise FunctionClauseError, fn ->
-      AdminWire.session_to_admin_json(entry, "vjt", "2026-01-01T00:00:00Z")
+      AdminWire.session_to_admin_json(entry, "vjt", "2026-01-01T00:00:00Z", nil)
     end
   end
 end

--- a/test/grappa/live_introspection_test.exs
+++ b/test/grappa/live_introspection_test.exs
@@ -79,6 +79,57 @@ defmodule Grappa.LiveIntrospectionTest do
     end
   end
 
+  describe "upstream peer capture (#550)" do
+    test "captures the peer address string + port for a connected session" do
+      # #550 netsplit triage — the entry carries the destination the socket
+      # landed on. The Client dialed the in-process IRCServer on
+      # 127.0.0.1:<port>; USER is sent right after the Client pushes
+      # {:irc_peer, _}, so waiting for it guarantees the peer is captured
+      # before the registry scan reads it.
+      {server, port} = start_irc_server()
+      {visitor, network} = visitor_with_network(port)
+      _ = start_visitor_session_for(visitor, network)
+      on_exit(fn -> Session.stop_session({:visitor, visitor.id}, network.id) end)
+
+      {:ok, _} =
+        Grappa.IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
+
+      entry = LiveIntrospection.lookup_session({:visitor, visitor.id}, network.id)
+
+      assert entry.peer_address == "127.0.0.1"
+      assert entry.peer_port == port
+      assert entry.introspection_degraded == []
+    end
+
+    test "a non-responsive session pid degrades peer_address to nil + marker" do
+      # A registered pid that never answers a GenServer.call (mailbox-bloat /
+      # stuck session) → peer_address times out at 250ms → nil + the
+      # :peer_address degraded marker: the honest "sick session" signal, never
+      # a fabricated or stale address. Same dummy-pid trick as the
+      # count_sessions test — no real Session.Server needed.
+      subject = {:visitor, Ecto.UUID.generate()}
+      network_id = 424_242
+      key = {:session, subject, network_id}
+      parent = self()
+
+      {:ok, pid} =
+        Task.start_link(fn ->
+          {:ok, _} = Registry.register(Grappa.SessionRegistry, key, nil)
+          send(parent, :registered)
+          Process.sleep(:infinity)
+        end)
+
+      assert_receive :registered, 500
+      on_exit(fn -> if Process.alive?(pid), do: Process.exit(pid, :kill) end)
+
+      entry = LiveIntrospection.lookup_session(subject, network_id)
+
+      assert entry.peer_address == nil
+      assert entry.peer_port == nil
+      assert :peer_address in entry.introspection_degraded
+    end
+  end
+
   describe "count_sessions_by_user/0 (M-6 admin console)" do
     test "returns empty map when registry holds no user sessions" do
       assert LiveIntrospection.count_sessions_by_user() == %{}

--- a/test/grappa/networks/credentials/admin_wire_test.exs
+++ b/test/grappa/networks/credentials/admin_wire_test.exs
@@ -72,6 +72,8 @@ defmodule Grappa.Networks.Credentials.AdminWireTest do
         mailbox_len: 0,
         memory_bytes: 12_345,
         joined_channels: ["#bofh"],
+        peer_address: nil,
+        peer_port: nil,
         introspection_degraded: []
       }
 

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -146,6 +146,31 @@ defmodule Grappa.Session.ServerTest do
     # path which exercises a refused upstream port end-to-end.
   end
 
+  describe "peer_address/3 (#550)" do
+    test "returns {:ok, {address_string, port}} of the upstream peer once connected" do
+      # #550 netsplit triage — the admin Sessions inventory shows which
+      # upstream server each session landed on. The Client captures the peer
+      # at connect and pushes `{:irc_peer, _}`; Session.Server caches it and
+      # serves it here (address formatted to a string at store time). The
+      # session dialed the in-process IRCServer on 127.0.0.1:<port>, so the
+      # cached peer reflects exactly that. `await_handshake` blocks until the
+      # USER line reaches the server, which the Client sends AFTER pushing
+      # `{:irc_peer, _}` — so the peer is in the mailbox before this call.
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+      _ = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      assert {:ok, {"127.0.0.1", ^port}} =
+               Session.peer_address({:user, user.id}, network.id)
+    end
+
+    test "returns {:error, :no_session} when no session is registered" do
+      assert {:error, :no_session} =
+               Session.peer_address({:user, Ecto.UUID.generate()}, -1)
+    end
+  end
+
   describe "init/1 non-blocking (C2)" do
     # Pairs with `Grappa.IRC.ClientTest`'s C2 test. `Session.Server.init/1`
     # must NOT call `Client.start_link/1` synchronously: Bootstrap iterates

--- a/test/grappa/visitors/admin_wire_test.exs
+++ b/test/grappa/visitors/admin_wire_test.exs
@@ -47,6 +47,8 @@ defmodule Grappa.Visitors.AdminWireTest do
         mailbox_len: 0,
         memory_bytes: 12_345,
         joined_channels: ["#sbiffo"],
+        peer_address: nil,
+        peer_port: nil,
         introspection_degraded: []
       }
 

--- a/test/grappa_web/controllers/admin/sessions_controller_test.exs
+++ b/test/grappa_web/controllers/admin/sessions_controller_test.exs
@@ -133,6 +133,41 @@ defmodule GrappaWeb.Admin.SessionsControllerTest do
       assert is_integer(row["live_state"]["memory_bytes"])
     end
 
+    test "live_state carries the upstream peer address + port (#550)", %{conn: conn} do
+      # #550 netsplit triage — the row shows the destination the socket
+      # landed on. The session dialed the in-process IRCServer on
+      # 127.0.0.1:<port>. USER is sent right after the Client pushes
+      # {:irc_peer, _}, so waiting for it guarantees the peer is captured
+      # before the admin scan reads it.
+      {server, port} = start_irc_server()
+      {visitor, network} = visitor_with_network(port)
+      _ = start_visitor_session_for(visitor, network)
+      on_exit(fn -> Session.stop_session({:visitor, visitor.id}, network.id) end)
+
+      {:ok, _} =
+        Grappa.IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
+
+      session = admin_session()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> get("/admin/sessions")
+
+      body = json_response(conn, 200)
+      row = Enum.find(body["sessions"], &(&1["subject_id"] == visitor.id))
+
+      assert row["live_state"]["peer_address"] == "127.0.0.1"
+      assert row["live_state"]["peer_port"] == port
+      # peer_name resolves out of band (Grappa.Net.PtrCache is lazy): the key
+      # is present but `nil` on a cold cache (cic falls back to the raw
+      # address). Assert it's the honest nil-or-string, never fabricated.
+      assert Map.has_key?(row["live_state"], "peer_name")
+
+      assert is_nil(row["live_state"]["peer_name"]) or
+               is_binary(row["live_state"]["peer_name"])
+    end
+
     test "subject_label: null surfaces orphan pid when DB row is gone", %{conn: conn} do
       # Bucket B/C honesty signal: a Session.Server registered for a
       # visitor whose DB row was deleted (raw SQL, terminate race, or


### PR DESCRIPTION
## #550 — admin Sessions: upstream peer address + reverse DNS

`GET /admin/sessions` and the cic admin **Sessions** tab now surface the
upstream peer each IRC session's socket is actually connected to — IP
(v6/v4) + port + reverse DNS name — so netsplit triage ("which sessions
landed on the split-off server?") no longer needs an rpc into the live
BEAM.

### Design (approach C)
- The IRC `Client` reads the peername **once at connect**
  (`transport_peername/1`, twin of `transport_send/2`) and pushes a
  **separate** `{:irc_peer, result}` message to `Session.Server`
  (`:irc_connected` stays byte-unchanged). `Session.Server` caches
  `peer_address` (string via `:inet.ntoa` at store time) + `peer_port`,
  invalidated on client EXIT + `do_start_client`. An
  immutable-for-connection fact — not drift-prone duplication — and it
  avoids a blocking hop on the hot path.
- Read via `Session.peer_address/3` (mirrors `list_channels/3`; 250ms +
  degraded).
- Reverse DNS reuses `Grappa.Net.PtrCache` (#252) — **no new cache** —
  resolved in the `SessionsController` in one batched, lock-free,
  out-of-band call.
- **Honesty:** peer absent for any reason → `peer_address` null +
  `:peer_address` in `introspection_degraded` (the `degraded_field`
  allowlist widened from `:joined_channels` to
  `:joined_channels | :peer_address`). Never fabricated/stale.
- Wire is additive-only (#447), snake_case; `wireTypes.ts` is the
  regenerated mirror. Scope is the **Sessions tab only**.

### Verification
- `scripts/check.sh` exit 0: 4574 tests + 8 doctests + 48 properties, 0
  failures; Dialyzer 0 errors; Credo/Sobelow/Doctor pass;
  `gen_wire_types --check` in-sync.
- cic `scripts/bun.sh run check` exit 0 (biome + tsc) + vitest.
- Full local integration suite **555/555 green** (443 chromium + 112
  webkit), exit 0.
- Code review done (10x-engineer:code-reviewer): no correctness defects;
  2 LOW findings fixed, 1 LOW (two serial per-session GenServer.calls;
  mirrors the existing fetch pattern) documented in DESIGN_NOTES as a
  deliberate tradeoff.

### Open question — source address (sockname)
> **Open question — source address (sockname).** This change adds the
> DESTINATION peer only (which upstream server the session landed on). Adding the
> session's SOURCE address (`:ssl.sockname/1` / `:inet.sockname/1`) is nearly free
> now that the capture plumbing exists, and it's the natural surface for the
> per-session outbound source-address work (#454 / #543). Left OUT deliberately
> because those issues have open decisions that are yours to make — include it as
> a follow-up, or keep destination-only? Not decided in this change.
