### PR TITLE
fix(#540): /who forwards full arg list; raw /quote WHO surfaces WhoModal

### DIFF
--- a/cicchetto/e2e/tests/issue540-who-flag-args.spec.ts
+++ b/cicchetto/e2e/tests/issue540-who-flag-args.spec.ts
@@ -1,0 +1,63 @@
+// #540 — `/who` with extended (bahamut) flag args, end-to-end. Two
+// independent breaks, both surfaced here against the live bahamut hub:
+//
+//   A. The cic `/who` parser kept only the FIRST token, so `/who +s <server>`
+//      reached the wire as `WHO +s` — bahamut's `s` flag needs a server arg,
+//      so with the arg eaten it answered 522 ERR_WHOSYNTAX and NO modal
+//      opened. The fix forwards the full argument string (and the server no
+//      longer folds it as a channel), so `WHO +s <server>` reaches upstream
+//      and the WhoModal renders.
+//
+//   B. A raw `/quote WHO +s <server>` primes no accumulator server-side, so
+//      the 352/315 replies were dropped silently (no error, no output) — the
+//      documented workaround for A failing too. The fix lazily creates the
+//      accumulator on the first unsolicited 352 and drains it on 315.
+//
+// vjt (network `bahamut-test`) dials the hub (bahamut-test:6667 →
+// hub.azzurra.chat), so `+s hub.azzurra.chat` matches at least vjt itself —
+// but per the #221 who-mask precedent the headline proof is that the modal
+// OPENS (feedback), not a specific matched row (bahamut cloaks hosts and the
+// membership varies).
+
+import { expect, test } from "../fixtures/test";
+import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+// The bahamut hub the default `bahamut-test` network dials (compose.yaml:
+// hub on 6667, SERVER_NAME hub.azzurra.chat). vjt is a client of it, so a
+// server-scoped WHO matches at least vjt.
+const HUB_SERVER = "hub.azzurra.chat";
+
+test("#540 A — /who +s <server> forwards flag args and opens the WhoModal (not pre-#540 522)", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  // Pre-#540 the parser dropped the server arg → `WHO +s` → 522
+  // ERR_WHOSYNTAX → no modal. Now the full arg string forwards verbatim and
+  // bahamut answers with 352 rows + 315, so the modal renders.
+  await composeSend(page, `/who +s ${HUB_SERVER}`);
+
+  const modal = page.getByTestId("who-modal");
+  await expect(modal).toBeVisible({ timeout: 8_000 });
+});
+
+test("#540 B — raw /quote WHO +s <server> surfaces the WhoModal (no longer a silent hole)", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  // The raw escape hatch a user reaches for when part A blocks them. It
+  // primes no accumulator server-side; pre-#540 the 352/315 burst was
+  // dropped (no error, no output). Now the first unsolicited 352 lazily
+  // creates the accumulator and the 315 drains it → modal opens.
+  await composeSend(page, `/quote WHO +s ${HUB_SERVER}`);
+
+  const modal = page.getByTestId("who-modal");
+  await expect(modal).toBeVisible({ timeout: 8_000 });
+});

--- a/cicchetto/src/__tests__/slashCommands.test.ts
+++ b/cicchetto/src/__tests__/slashCommands.test.ts
@@ -737,6 +737,26 @@ describe("parseSlash — info verbs (TODO — server-side missing)", () => {
     expect(parseSlash("/who alice")).toEqual({ kind: "who", target: "alice" });
   });
 
+  // #540 — /who must forward its FULL argument list, not just the first
+  // token. bahamut's extended WHO takes flag args (`+s <server>`, `+A
+  // <away-msg>`, `+c <channel>`, `+H <maxhits>`); `/who +s server.azzurra.chat`
+  // must reach the wire as `WHO +s server.azzurra.chat`. Pre-#540 the parser
+  // kept only `+s`, so the server arg was eaten → 522 ERR_WHOSYNTAX.
+  it("/who +s <server> → forwards the full arg string (#540)", () => {
+    expect(parseSlash("/who +s server.azzurra.chat")).toEqual({
+      kind: "who",
+      target: "+s server.azzurra.chat",
+    });
+  });
+
+  // #540 — a channel target with a trailing flag also forwards intact.
+  it("/who #chan +c → forwards flags after the channel (#540)", () => {
+    expect(parseSlash("/who #grappa +c")).toEqual({
+      kind: "who",
+      target: "#grappa +c",
+    });
+  });
+
   it("/names bare → names with no target", () => {
     expect(parseSlash("/names")).toEqual({ kind: "names", target: null });
   });
@@ -774,7 +794,8 @@ describe("parseSlash — info verbs (TODO — server-side missing)", () => {
   // `MOTD [<target>]`). Bare /motd = current server's MOTD (target null);
   // /motd <server> routes the MOTD query through that server. Pre-#374 the
   // argument was silently dropped, so the user got the wrong server's MOTD
-  // with no error. Mirrors the /who target shape (first token only).
+  // with no error. MOTD takes a single target token (unlike /who, which
+  // after #540 forwards its full multi-token arg string).
   it("/motd bare → motd with no target", () => {
     expect(parseSlash("/motd")).toEqual({ kind: "motd", target: null });
   });

--- a/cicchetto/src/lib/slashCommands.ts
+++ b/cicchetto/src/lib/slashCommands.ts
@@ -517,9 +517,17 @@ const DISPATCH: Readonly<Record<string, Handler>> = {
     return { kind: "mode", target: first, modes, params };
   },
 
+  // #540 — forward the FULL argument string, not just the first token.
+  // bahamut's extended WHO takes flag args (`+s <server>`, `+A <away-msg>`,
+  // `+c <chan>`, `+H <maxhits>`); dropping everything after the first token
+  // sent `WHO +s` to the wire, and bahamut answered 522 ERR_WHOSYNTAX (the
+  // `s` flag's server arg was eaten). cic is a thin pass-through for WHO
+  // syntax — the server forwards the args verbatim (line-safety gated).
+  // Bare `/who` (empty rest) → null, so compose defaults to the current
+  // channel (#122).
   who: (_verb, rest) => {
-    const [target] = tokens(rest);
-    return { kind: "who", target: target ?? null };
+    const target = rest.trim();
+    return { kind: "who", target: target === "" ? null : target };
   },
 
   names: (_verb, rest) => {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -23659,3 +23659,77 @@ serial). Healthy fleets are unaffected (both are instant state reads); the
 shape mirrors the established `fetch_joined_channels` pattern. A single
 combined introspection call would halve the degraded-scan cost — deferred as
 an optimization, not folded here to avoid scope creep.
+## 2026-07-30 — #540: `/who` forwards its full arg list; unsolicited WHO surfaces
+
+Two independent breaks in `/who` with bahamut's extended-WHO flags (reported
+by a user who tried `/who +s server.azzurra.chat` on Azzurra).
+
+**A. The whole WHO path was single-token, top to bottom.** The cic `/who`
+parser kept only the FIRST token (`tokens(rest)` → `[target]`), so `/who +s
+<server>` reached the wire as `WHO +s` — bahamut's `s` flag needs a server
+arg, so with the arg eaten it answered 522 ERR_WHOSYNTAX. But even a fixed
+parser could not have helped: the server's outbound gate (`Client.send_who/2`
++ the GrappaChannel `:who_target` validator) both used `safe_oper_token?/1`,
+which REJECTS spaces (the #221 "a space would splice extra WHO slots" rule).
+That rule was correct for a single mask/channel target but wrong for WHO's
+real grammar: bahamut's extended WHO takes flag ARGS separated by spaces
+(`+s <server>`, `+A <away-msg>`, `+c <chan>`, `+H <maxhits>`). The fix widens
+BOTH gates to `safe_line_token?/1` + non-empty — a space is a legitimate arg
+separator now; only CRLF (command injection) and NUL (framing) are rejected.
+cic's `/who` parser becomes a thin pass-through: `rest.trim()` forwards the
+full argument string verbatim (bare `/who` → null → current-channel default,
+#122 unchanged).
+
+**A2 — the target no longer folds as a channel.** `Session.send_who/3` ran
+the target through `Identifier.canonical_channel/1` before shipping it, which
+folds A–Z of everything after a `#&+!` sigil. On a `+`-sigil flag token that
+silently lowercases a case-sensitive arg (`+A HelloWorld` → `+a helloworld`,
+corrupting an away-message match). The raw target now ships upstream; the
+Server still derives the accumulator KEY via `canonical_channel/1` in its
+`:send_who` handler (so concurrent channel-WHOs stay separated by key)
+WITHOUT touching the wire form.
+
+**B. Unsolicited WHO (raw `/quote WHO`) was a silent hole.** A raw `/quote
+WHO ...` (the escape hatch a user reaches for precisely when A blocks them)
+went through `send_raw`, which — unlike the structured `send_who` — primes no
+`who_pending` accumulator. So its 352/315 reply was unsolicited server-side:
+`who_fold` dropped every 352 (nothing to fold into) and the 315 drain found no
+entry — no error, no output. This bit HARDEST on a zero-match WHO: on the
+testnet, `WHO +s <hub>` from the +i (invisible) bouncer session returns a bare
+315 with ZERO 352 rows, so there was nothing to surface at all (the first fix
+attempt — lazily creating an accumulator on the first 352 — could not fix the
+zero-352 case, and blanket-surfacing every lone 315 would have reversed #169's
+deliberate drop-silently; both rejected).
+
+**Fix — one code path: a raw WHO primes just like the structured verb.** The
+`:send_raw` handler now sniffs the outbound line (an anchored `^WHO(\s|$)`
+regex, mirroring the sibling `NSInterceptor` NickServ-capture — a raw IRC
+frame starts with its command verb; `Grappa.IRC.Parser` is inbound-only and
+NOT exported to the `Grappa.Session` boundary, so classification of an
+OUTBOUND verb is regex, per existing precedent). A detected WHO primes
+`who_pending` under the folded args, exactly as `:send_who` does — so the
+reply drains into an empty (zero-match) or populated WhoModal. `WHOIS`/
+`WHOWAS` share the prefix but are distinct verbs (their own caches own the
+reply) and never match. The 352 fold + 315 drain keep the single-in-flight
+fallback (a flag/mask WHO's 315 echoes only the leading arg — `+s`, not the
+full primed key — so exact-match can't fire; WHO is mailbox-serialized so
+"exactly one pending" resolves it).
+
+**#169 preserved.** A 315 (or 352) with NOTHING pending still drops silently
+(the pre-#540 "mirror 318 RPL_ENDOFWHOIS" behavior is UNCHANGED). Because both
+`/who` AND a raw `/quote WHO` now prime an accumulator at send time, the only
+reply that reaches the silent-drop path is one for a WHO that was never issued
+— surfacing that would be spurious. This is why the fix primes on-send rather
+than surfacing every lone terminator: the surfacing is scoped to "the user
+issued a WHO", not to "a 315 arrived".
+
+No wire-type change, no protocol bump: the `who` verb's `channel` field simply
+carries a multi-token argument string now (additive, back-compatible — an old
+client sending a single token still validates). `who_pending` shape is
+unchanged. Deploy: server is HOT (Map.get-defaulted GenServer state, no
+migration, no new child); cic ships in a `--cic` bundle (COLD).
+Regression-guarded by `issue540-who-flag-args.spec.ts` (two real bahamut
+cases: structured `/who +s <hub>` opens the WhoModal, and raw `/quote WHO +s
+<hub>` opens it too — the B1 hole), the `:send_raw`-primes-WHO server tests
+(WHO primes, WHOIS does not), plus unit coverage in `client_test`,
+`grappa_channel_test`, `event_router_test`, and the cic parser suite.

--- a/lib/grappa/irc/client.ex
+++ b/lib/grappa/irc/client.ex
@@ -695,24 +695,29 @@ defmodule Grappa.IRC.Client do
   Sends `WHO <target>\\r\\n` where `<target>` is a channel OR a host/nick
   mask (RFC 2812 §3.6.1). Returns `{:error, :invalid_line}` on rejection.
 
-  #221: the gate is `safe_oper_token?/1` (a single wire token — non-empty,
-  no whitespace/CRLF/NUL), NOT `valid_channel?/1`. A masked `/who *!*@host`
-  is a legitimate query; the pre-#221 channel-only gate rejected it outbound
-  so it never reached upstream — the first break in the `/who <mask>` "total
-  silence" chain. The single-token gate still blocks a space (which would
-  splice extra WHO wire slots) and CRLF (command injection).
+  #221: the pre-#221 channel-only gate rejected a mask outbound so it never
+  reached upstream — the first break in the `/who <mask>` "total silence"
+  chain. #540 widened the gate from `safe_oper_token?/1` (single token, no
+  spaces) to `safe_line_token?/1` + non-empty: bahamut's extended WHO takes
+  flag ARGS separated by spaces (`WHO +s <server>`, `+A <away-msg>`, `+c
+  <chan>`, `+H <maxhits>`), so a space is a legitimate arg separator, not a
+  "splice" to reject. The pre-#540 single-token gate meant cic's dropped-arg
+  bug (`WHO +s`) could never have been sent whole even after the client fix.
+  CRLF (command injection) and NUL (framing corruption) are still rejected;
+  an empty target is rejected (a bare `WHO` is not what grappa emits).
 
   Numerics 352 RPL_WHOREPLY (one per matching user) + 315 RPL_ENDOFWHO
   (terminator) reply with the WHO list. EventRouter folds each 352 into
   `state.who_pending` (also upserting `userhost_cache`) and, on 315, drains
   the accumulator into ONE ephemeral `{:who_reply, target, users}` effect
   (#169) — broadcast on the user topic for cic's WhoModal, never persisted.
-  For a mask WHO, solanum sets the 352 channel field to `"*"`; EventRouter's
-  who_fold correlates via the single-in-flight-WHO fallback.
+  For a mask/flag WHO the 352 channel field is `"*"` (or a per-user channel)
+  and the 315 echoes only the leading arg; EventRouter correlates via the
+  single-in-flight-WHO fallback.
   """
   @spec send_who(pid(), String.t()) :: send_result()
   def send_who(client, target) do
-    if Identifier.safe_oper_token?(target),
+    if Identifier.safe_line_token?(target) and target != "",
       do: send_line(client, "WHO #{target}\r\n"),
       else: reject_invalid_line(:who)
   end

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -1440,12 +1440,14 @@ defmodule Grappa.Session do
   when 315 RPL_ENDOFWHO arrives. `<target>` is a channel OR a host/nick
   mask (#221, RFC 2812 §3.6.1).
 
-  A channel target is case-folded via `canonical_channel/1` (so `#Chan` and
-  `#chan` share one accumulator key, matching the channel-fold invariant).
-  A mask is NOT a channel, so `canonical_channel/1` is a no-op on it and the
-  raw mask is the accumulator key — the 315 terminator echoes the same mask,
-  and EventRouter's who_fold correlates mask-reply rows (whose 352 channel
-  field solanum sets to `"*"`) via its single-in-flight-WHO fallback.
+  The target ships upstream RAW (#540 A2): it may be a channel, a mask
+  (#221), or bahamut's extended-WHO flag args (`+s <server>`), and folding
+  it as a channel would corrupt a case-sensitive arg. The Server derives the
+  accumulator KEY by folding via `canonical_channel/1` (so `#Chan`/`#chan`
+  share one key for concurrent channel-WHO separation) WITHOUT touching the
+  wire form. Reply correlation is robust to a key that never matches the
+  echoed 315/352 (mask, flag, unsolicited): EventRouter falls back to the
+  single-in-flight-WHO rule (WHO is mailbox-serialized).
 
   Returns `:ok`, `{:error, :no_session}`, or `{:error, :invalid_line}`
   if the target syntax is rejected by `Grappa.IRC.Client.send_who/2`.
@@ -1454,7 +1456,14 @@ defmodule Grappa.Session do
           :ok | {:error, :no_session | :invalid_line | send_transport_error()}
   def send_who(subject, network_id, target)
       when is_subject(subject) and is_integer(network_id) and is_binary(target) do
-    call_session(subject, network_id, {:send_who, Identifier.canonical_channel(target)})
+    # #540 A2 — the target is NOT necessarily a channel: it may be a mask
+    # (#221) or bahamut's extended-WHO flag args (`+s <server>`). Folding it
+    # via canonical_channel/1 corrupts a case-sensitive arg — the `+`-sigil
+    # token `+A HelloWorld` (away-message match) would lowercase to
+    # `+a helloworld` before it left the bouncer. The raw target ships
+    # upstream; the Server derives the accumulator KEY (canonical_channel/1
+    # for concurrent channel-WHO separation) separately in its handler.
+    call_session(subject, network_id, {:send_who, target})
   end
 
   @doc """

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -1523,13 +1523,26 @@ defmodule Grappa.Session.EventRouter do
   # `{:who_reply, target_display, users}` effect (mirror of the /names 366
   # drain → `{:names_reply, ...}`). server.ex broadcasts it on the user-level
   # topic and cic renders a dismissable WhoModal — NOTHING is persisted to
-  # scrollback. If no accumulator exists (target never primed via /who, or an
-  # unsolicited reply), drop silently — mirror of 318 RPL_ENDOFWHOIS.
+  # scrollback. If no accumulator exists (target never primed via /who or a
+  # raw-WHO /quote, or a genuinely unsolicited reply), drop silently — mirror
+  # of 318 RPL_ENDOFWHOIS. #540 keeps this: a raw `/quote WHO` is primed at
+  # send time (see `who_fold`), so its terminator DOES find an accumulator
+  # (empty modal on a zero-match, populated otherwise) — only a 315 with no
+  # WHO ever issued reaches the silent-drop path.
   #
   # Pre-#169 this built N+1 `:persist :notice` rows into the channel or
   # `$server` window (the scrollback-dump hack). The channel-vs-$server
   # routing distinction disappears: a who_reply is always a user-topic modal,
   # so even a joined-channel /who no longer pollutes that channel's buffer.
+  #
+  # #540 — correlation mirrors who_fold: exact channel-key match first
+  # (concurrent channel WHOs stay separated), else single-in-flight fallback
+  # (a mask/flag WHO's 315 echoes only the leading arg, and a raw-WHO bucket
+  # primed at send time is keyed by the /quote args — neither matches the
+  # terminator's target, but WHO is mailbox-serialized so "exactly one
+  # pending" resolves it). A 315 with nothing pending drops silently (#169) —
+  # since both /who AND a raw /quote WHO prime an accumulator, the only such
+  # 315 is one for a WHO that was never issued.
   defp do_route(
          %Message{command: {:numeric, 315}, params: [_, target | _]},
          state
@@ -1538,9 +1551,16 @@ defmodule Grappa.Session.EventRouter do
     pending = Map.get(state, :who_pending, %{})
     chan_key = normalize_channel(target)
 
-    case Map.fetch(pending, chan_key) do
+    drain_key =
+      cond do
+        Map.has_key?(pending, chan_key) -> chan_key
+        map_size(pending) == 1 -> pending |> Map.keys() |> hd()
+        true -> nil
+      end
+
+    case drain_key && Map.fetch(pending, drain_key) do
       {:ok, accum} ->
-        next_state = %{state | who_pending: Map.delete(pending, chan_key)}
+        next_state = %{state | who_pending: Map.delete(pending, drain_key)}
         target_display = Map.get(accum, :target_display, target)
 
         # Replies prepended LIFO in who_fold for O(1) fold — reverse to
@@ -1549,7 +1569,7 @@ defmodule Grappa.Session.EventRouter do
 
         {:cont, next_state, [{:who_reply, target_display, users}]}
 
-      :error ->
+      _ ->
         {:cont, state, []}
     end
   end
@@ -3372,6 +3392,12 @@ defmodule Grappa.Session.EventRouter do
   #   3. Otherwise → no fold (unsolicited 352, or ambiguous "*" row with
   #      multiple concurrent WHOs — drop rather than guess). The
   #      userhost_cache upsert in the 352 route still fired upstream.
+  #
+  # #540 — a raw `/quote WHO ...` still surfaces because its accumulator IS
+  # primed at send time: `Session.Server`'s `:send_raw` handler detects a WHO
+  # command and primes `who_pending` just like `:send_who`, so the raw-WHO
+  # 352 rows fold via case 2 (single-in-flight). A truly unsolicited 352 (no
+  # WHO was issued) stays dropped — no accumulator, no modal.
   @spec who_fold(state(), String.t(), map()) :: state()
   defp who_fold(state, channel, reply) when is_binary(channel) and is_map(reply) do
     pending = Map.get(state, :who_pending, %{})

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -1454,12 +1454,21 @@ defmodule Grappa.Session.Server do
   # verbatim. We log the byte size (not the body) to keep operator
   # observability without dumping arbitrary user input — operators
   # who need to debug the wire can use the existing IRC log stream.
+  #
+  # #540 B1 — a raw `/quote WHO ...` primes the WHO accumulator here, exactly
+  # like `:send_who`, so its 352/315 reply surfaces the WhoModal instead of
+  # being dropped as unsolicited (the "no error, no output" hole). This
+  # mirrors the sibling `capture_outbound_ns_secret/2` outbound-line sniff:
+  # both give a subsequent inbound reply the state it needs to be handled.
   def handle_call({:send_raw, line}, _, state) when is_binary(line) do
     Logger.debug("raw IRC line submitted via /quote (#{byte_size(line)} bytes)",
       verb: :raw
     )
 
-    state = capture_outbound_ns_secret(state, line)
+    state =
+      state
+      |> capture_outbound_ns_secret(line)
+      |> maybe_prime_raw_who(line)
 
     case Client.send_raw(state.client, line) do
       :ok -> {:reply, :ok, state}
@@ -1689,21 +1698,21 @@ defmodule Grappa.Session.Server do
     {:reply, Client.send_whowas(state.client, target), next_state}
   end
 
-  # CP22 cluster B (channel-client-polish #14) — /who <#channel>. Two
-  # effects: (1) prime the accumulator entry in state.who_pending so
-  # EventRouter folds 352 RPL_WHOREPLY rows into it; (2) emit
-  # `WHO #channel\r\n`. The entry's `target_display` matches `target`
-  # — UX-4 bucket A canonicalises the channel arg at `Session.send_who/3`
-  # so `target` here is already lowercase; the scrollback 315 EOF row
-  # body (`*** End of /WHO list for #chan`) shows the canonical form.
-  # Pre-bucket-A the docstring claimed "case preserved" — that was
-  # the upstream-echoed case; now the canonical form is the single
-  # form everywhere (members map, persist channel, EOF body).
-  # Replaces any prior accumulator for the same target (running /who
-  # twice without an 315 in between drops the first).
-  # On send_line failure the accumulator stays primed — a transient
-  # send error doesn't strand the WHO flow because no numerics will
-  # arrive to drain it; harmless until the next /who replaces the entry.
+  # CP22 cluster B (channel-client-polish #14) — /who. Two effects:
+  # (1) prime the accumulator entry in state.who_pending so EventRouter folds
+  # 352 RPL_WHOREPLY rows into it; (2) emit `WHO <target>\r\n`. The 315
+  # RPL_ENDOFWHO drain emits ONE ephemeral `{:who_reply, target_display,
+  # users}` (a user-topic WhoModal — #169; nothing is persisted to
+  # scrollback). #540 A2: `target` arrives RAW (Session.send_who/3 no longer
+  # folds it — it may be a channel, a mask, or extended-WHO flag args like
+  # `+s <server>`), so `target_display` preserves case for the modal header.
+  # The accumulator KEY is folded here via `canonical_channel/1` so
+  # `#Chan`/`#chan` share one key (concurrent channel-WHO separation) WITHOUT
+  # corrupting the raw wire form. Replaces any prior accumulator for the same
+  # key (running /who twice without a 315 in between drops the first).
+  # On send_line failure the accumulator stays primed — a transient send
+  # error doesn't strand the WHO flow because no numerics will arrive to
+  # drain it; the @pending_ttl_ms sweep on the next prime reaps it.
   def handle_call({:send_who, target}, _, state) when is_binary(target) do
     chan_key = Identifier.canonical_channel(target)
     next_pending = prime_pending(state.who_pending, chan_key, %{target_display: target, replies: []})
@@ -3219,6 +3228,38 @@ defmodule Grappa.Session.Server do
 
       :passthrough ->
         state
+    end
+  end
+
+  # #540 B1 — if the raw `/quote` line is a WHO command, prime the WHO
+  # accumulator so its 352/315 reply drains into a WhoModal, exactly like the
+  # structured `:send_who` verb (`who_pending` keyed by the folded target;
+  # `target_display` preserves the raw args for the modal header). Without
+  # this, a raw-WHO reply is unsolicited server-side and drops silently — the
+  # "no error, no output" hole #540 B reports. Detected by an anchored regex,
+  # mirroring the NickServ `NSInterceptor` sibling (a raw IRC frame starts
+  # with its command verb; `Grappa.IRC.Parser` is NOT exported to this
+  # boundary). `^WHO` followed by whitespace-or-EOL matches `WHO` and bare
+  # `WHO` ONLY — `WHOIS`/`WHOWAS` (their own caches own the reply) never
+  # match. The stripped args are the accumulator KEY (folded) + display ONLY;
+  # the wire line was already shipped verbatim by `Client.send_raw`. A
+  # malformed WHO the ircd never answers leaves a stranded entry that
+  # `prime_pending/3`'s TTL sweep reaps.
+  @who_line_re ~r/^WHO(\s|$)/i
+  @who_strip_re ~r/^WHO\s*/i
+
+  @spec maybe_prime_raw_who(t(), String.t()) :: t()
+  defp maybe_prime_raw_who(state, line) do
+    if Regex.match?(@who_line_re, line) do
+      target = line |> String.replace(@who_strip_re, "") |> String.trim()
+      chan_key = Identifier.canonical_channel(target)
+
+      pending =
+        prime_pending(state.who_pending, chan_key, %{target_display: target, replies: []})
+
+      %{state | who_pending: pending}
+    else
+      state
     end
   end
 

--- a/lib/grappa_web/channels/grappa_channel.ex
+++ b/lib/grappa_web/channels/grappa_channel.ex
@@ -828,10 +828,12 @@ defmodule GrappaWeb.GrappaChannel do
       when is_integer(network_id) and is_binary(channel) do
     dispatch_subject_verb(
       socket,
-      # #221 — WHO accepts a channel OR a host/nick mask (RFC 2812 §3.6.1),
-      # so the arg is validated as a single wire token (:who_target), not a
-      # channel. The map key stays `"channel"` for wire back-compat with cic
-      # (pushWho still sends `{network_id, channel}`); the value may be a mask.
+      # #221/#540 — WHO accepts a channel, a host/nick mask (RFC 2812
+      # §3.6.1), OR bahamut's extended-WHO flag args (`+s <server>`), so the
+      # arg is validated as line-safe `:who_target` (spaces allowed, only
+      # CRLF/NUL rejected), NOT a channel. The map key stays `"channel"` for
+      # wire back-compat with cic (pushWho still sends `{network_id,
+      # channel}`); the value may be a mask or a multi-token flag string.
       fn -> validate_args(who_target: channel) end,
       fn subject -> Session.send_who(subject, network_id, channel) end
     )
@@ -1490,13 +1492,15 @@ defmodule GrappaWeb.GrappaChannel do
       else: {:error, :invalid_mask}
   end
 
-  # #221 — /who target: a channel OR a host/nick mask (RFC 2812 §3.6.1).
-  # Gated as a single wire token (`safe_oper_token?/1`: non-empty, no
-  # whitespace/CRLF/NUL) to mirror `Client.send_who/2` — a space would
-  # splice extra WHO slots, CRLF would inject a command. `:invalid_mask` is
-  # the surfaced error class (a WHO target is a mask-or-channel).
+  # #221/#540 — /who args: a channel, a host/nick mask (RFC 2812 §3.6.1), OR
+  # bahamut's extended-WHO flag args (`+s <server>`, `+A <away>`, `+c <chan>`,
+  # `+H <maxhits>`). #540 widened the gate from `safe_oper_token?/1` (single
+  # token, no spaces) to `safe_line_token?/1` + non-empty, mirroring
+  # `Client.send_who/2`: a space is a legitimate WHO arg separator now, so
+  # only CRLF (command injection) and NUL (framing) are rejected.
+  # `:invalid_mask` stays the surfaced error class.
   defp validate_args([{:who_target, value} | rest]) do
-    if Identifier.safe_oper_token?(value),
+    if Identifier.safe_line_token?(value) and value != "",
       do: validate_args(rest),
       else: {:error, :invalid_mask}
   end

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -443,8 +443,10 @@ defmodule Grappa.IRC.ClientTest do
     # #221 — /who <mask>. WHO accepts a channel OR a host/nick mask (RFC 2812
     # §3.6.1). Pre-#221 send_who gated on valid_channel?, so a mask was
     # rejected outbound and never reached upstream — the first break in the
-    # "total silence" chain. The gate is now safe_oper_token? (single wire
-    # token, no whitespace/CRLF/NUL) so a mask forwards but injection can't.
+    # "total silence" chain. #540 widened the gate from safe_oper_token?
+    # (single token, no spaces) to safe_line_token? (only CRLF/NUL): bahamut's
+    # extended WHO takes flag ARGS separated by spaces (`+s <server>`), so a
+    # space is a legitimate arg separator, not a "splice" to reject.
     test "send_who/2 emits WHO #chan framing (channel target)" do
       {server, port} = start_server()
       client = start_client(port)
@@ -465,14 +467,34 @@ defmodule Grappa.IRC.ClientTest do
                IRCServer.wait_for_line(server, &(&1 == "WHO *!*@*.libera.chat\r\n"), 1_000)
     end
 
-    test "send_who/2 rejects a whitespace-splicing mask with {:error, :invalid_line}" do
+    # #540 — extended WHO flag args (bahamut: `+s <server>`, `+A <away>`,
+    # `+c <chan>`, `+H <maxhits>`). The space between the flag token and its
+    # argument is a legitimate WHO arg separator and forwards verbatim — the
+    # pre-#540 single-token gate (safe_oper_token?) dropped everything after
+    # the first token, so `WHO +s` reached upstream and bahamut answered
+    # 522 ERR_WHOSYNTAX (the `s` flag's server arg was NULL).
+    test "send_who/2 emits WHO with extended flag args, spaces forwarded (#540)" do
+      {server, port} = start_server()
+      client = start_client(port)
+
+      :ok = Client.send_who(client, "+s server.azzurra.chat")
+
+      assert {:ok, "WHO +s server.azzurra.chat\r\n"} =
+               IRCServer.wait_for_line(
+                 server,
+                 &(&1 == "WHO +s server.azzurra.chat\r\n"),
+                 1_000
+               )
+    end
+
+    test "send_who/2 rejects CRLF/NUL injection with {:error, :invalid_line} (#540)" do
       {_, port} = start_server()
       client = start_client(port)
 
-      # A space would splice extra WHO wire slots; CRLF would inject a
-      # follow-up command. Both rejected by the single-token gate.
-      assert {:error, :invalid_line} = Client.send_who(client, "*!*@x y")
+      # A space is a legitimate WHO arg separator now (#540); only CRLF
+      # (command injection) and NUL (framing corruption) are rejected.
       assert {:error, :invalid_line} = Client.send_who(client, "#chan\r\nQUIT")
+      assert {:error, :invalid_line} = Client.send_who(client, "x\x00y")
     end
 
     test "send_who/2 rejects an empty target with {:error, :invalid_line}" do

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -4188,6 +4188,11 @@ defmodule Grappa.Session.EventRouterTest do
       assert reply.channel == "#bofh"
     end
 
+    # A genuinely unsolicited 352 (no WHO was ever issued — neither /who nor a
+    # raw /quote WHO, so `who_pending` is empty) folds nowhere but still
+    # upserts userhost_cache (S2.4). #540 surfaces raw-WHO replies by priming
+    # the accumulator at send time (see server_test `:send_raw` primes WHO),
+    # NOT by lazily accumulating every stray 352 here.
     test "352 with no pending who entry still updates userhost_cache (S2.4 path)" do
       state = base_state(%{who_pending: %{}})
 
@@ -4257,6 +4262,10 @@ defmodule Grappa.Session.EventRouterTest do
       refute Enum.any?(effects, &match?({:persist, _, _}, &1))
     end
 
+    # A 315 with nothing pending is dropped silently (#169, mirror of 318
+    # RPL_ENDOFWHOIS). #540 keeps this: both /who AND a raw /quote WHO prime an
+    # accumulator at send time, so the only 315 that reaches this path is one
+    # for a WHO that was never issued — nothing to surface.
     test "315 with no pending entry is silently ignored (unsolicited)" do
       state = base_state(%{who_pending: %{}})
 
@@ -4264,6 +4273,44 @@ defmodule Grappa.Session.EventRouterTest do
 
       {:cont, new_state, []} = EventRouter.route(m, state)
       assert new_state.who_pending == %{}
+    end
+
+    # #540 A1 — a flag WHO (`WHO +s <server>`) is primed under the full arg
+    # string, but bahamut echoes only the flag token in the 315 (and sets the
+    # 352 channel to the user's channel / "*"), so neither fold nor drain can
+    # exact-match the key. The single-in-flight fallback (WHO is mailbox-
+    # serialized; cic shows one modal at a time) drains it so the modal opens.
+    test "315 drains a flag WHO via single-in-flight when the target doesn't match the key (#540)" do
+      state =
+        base_state(%{
+          who_pending: %{
+            "+s server.azzurra.chat" => %{
+              target_display: "+s server.azzurra.chat",
+              replies: [
+                %{
+                  nick: "alice",
+                  user: "u",
+                  host: "h",
+                  server: "s",
+                  modes: "H",
+                  hops: 0,
+                  realname: "Alice",
+                  channel: "*"
+                }
+              ]
+            }
+          }
+        })
+
+      # bahamut's 315 echoes the flag token, not the full primed key.
+      m = msg({:numeric, 315}, ["vjt", "+s", "End of /WHO list"], {:server, "irc.test.org"})
+
+      {:cont, new_state, effects} = EventRouter.route(m, state)
+      assert new_state.who_pending == %{}
+      assert [{:who_reply, target, users}] = effects
+      # target_display carries the full original arg string for the modal.
+      assert target == "+s server.azzurra.chat"
+      assert Enum.map(users, & &1.nick) == ["alice"]
     end
 
     test "315 lookup is case-insensitive on target channel (RFC 2812 §2.2)" do

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -5534,6 +5534,57 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  # #540 B1 — a raw `/quote WHO ...` must surface the WhoModal like the
+  # structured `/who`, not drop silently. `:send_raw` sniffs the outbound line
+  # (sibling of the NickServ `capture_outbound_ns_secret` sniff) and primes
+  # the WHO accumulator so the 352/315 reply drains into a who_reply. WHOIS /
+  # WHOWAS share the prefix but are DISTINCT verbs (their own caches own the
+  # reply) — they must NOT prime the WHO accumulator.
+  describe "#540 — raw /quote WHO primes the WHO accumulator" do
+    test "a /quote WHO line primes who_pending (keyed by folded args, display raw)" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+      pid = start_session_for(user, network)
+
+      :ok = await_handshake(server)
+
+      assert :ok =
+               Session.send_raw(
+                 {:user, user.id},
+                 network.id,
+                 "WHO +s hub.azzurra.chat"
+               )
+
+      # It reaches the wire verbatim (Client.send_raw)...
+      {:ok, _} =
+        IRCServer.wait_for_line(server, &(&1 == "WHO +s hub.azzurra.chat\r\n"), 1_000)
+
+      # ...AND the WHO accumulator is primed so a subsequent 352/315 surfaces.
+      # Key is the folded args (production fn, never hardcoded); display is raw.
+      key = Grappa.IRC.Identifier.canonical_channel("+s hub.azzurra.chat")
+      entry = Map.get(SessionStateHelpers.fetch(pid).who_pending, key)
+      assert entry.target_display == "+s hub.azzurra.chat"
+      assert entry.replies == []
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "a /quote WHOIS line does NOT prime the WHO accumulator" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+      pid = start_session_for(user, network)
+
+      :ok = await_handshake(server)
+
+      assert :ok = Session.send_raw({:user, user.id}, network.id, "WHOIS somebody")
+      {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "WHOIS somebody\r\n"), 1_000)
+
+      assert SessionStateHelpers.fetch(pid).who_pending == %{}
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+
   describe "+r MODE on own nick → USER registration commit (#349)" do
     test "user session: REGISTER stages the secret → +r commits password + flips auth_method" do
       {server, port} = start_server()

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -1802,14 +1802,39 @@ defmodule GrappaWeb.GrappaChannelTest do
         IRCServer.wait_for_line(irc_server, &(&1 == "WHO *!*@*.libera.chat\r\n"), 1_000)
     end
 
-    test "who: rejects a whitespace-splicing target with invalid_mask", %{
+    # #540 A1/A2 — extended WHO flag args forward verbatim, NOT folded as a
+    # channel. cic sends the full argument string (`+S HelloWorld`) in the
+    # `channel` slot; the server must (1) accept the space (multi-token WHO),
+    # and (2) NOT run it through canonical_channel/1 — folding the `+`-sigil
+    # token would lowercase the away-message/server arg (`+s helloworld`),
+    # corrupting a case-sensitive value. The raw args reach upstream.
+    test "who: forwards extended flag args upstream, case-preserved (#540 A1/A2)", %{
+      irc_server: irc_server,
       socket: socket,
       network: network
     } do
       ref =
         push(socket, "who", %{
           "network_id" => network.id,
-          "channel" => "*!*@x y"
+          "channel" => "+A HelloWorld"
+        })
+
+      assert_reply(ref, :ok)
+
+      {:ok, _} =
+        IRCServer.wait_for_line(irc_server, &(&1 == "WHO +A HelloWorld\r\n"), 1_000)
+    end
+
+    test "who: rejects a CRLF-injecting target with invalid_mask (#540)", %{
+      socket: socket,
+      network: network
+    } do
+      # A space is a legit WHO arg separator now (#540); the injection vector
+      # that still MUST bounce is CRLF (a spliced follow-up command).
+      ref =
+        push(socket, "who", %{
+          "network_id" => network.id,
+          "channel" => "#chan\r\nQUIT"
         })
 
       assert_reply(ref, :error, %{error: "invalid_mask"})


### PR DESCRIPTION
## #540 — `/who` drops all args after first + unsolicited 352 silently discarded

Two coupled bugs in the WHO path, fixed together.

### Bug A — `/who` truncated its arguments
`/who +s <server>` forwarded only the first token (`+s`), dropping the rest, so a flag+mask WHO degraded to a bare channel WHO (pre-#540 `522`/wrong query).

- **A1 (cic)** `slashCommands.ts` `who` now forwards the whole arg string via `rest.trim()` (was first-token-only). Bare `/who` → `null` → current channel.
- **A2 (server)** `Session.send_who/3` no longer folds the target — `canonical_channel` is used only for the accumulator KEY server-side, never on the wire.
- **Wire** `Client.send_who/2` + a new `:who_target` validator: `safe_line_token?` + non-empty (spaces OK, CRLF/NUL/empty rejected).

### Bug B — raw `/quote WHO` was a silent hole
An unsolicited/raw WHO returned `315`/`352` with nothing pending → results silently discarded (no WhoModal).

- **B1 (Design 2 — prime on-send)** the `:send_raw` handler sniffs the outbound line with an anchored regex `^WHO(\s|$)/i` (mirror of `NSInterceptor`; the Parser is inbound-only and not exported from the `Grappa.IRC` boundary) and primes `who_pending` exactly like `:send_who`. A raw `/quote WHO` now drains into the WhoModal (empty on zero-match, full otherwise). `WHOIS`/`WHOWAS` share the prefix but do **not** match. The `352` fold + `315` drain keep the single-in-flight fallback.

### Constraint honored — #169 not widened
A `315`/`352` with **nothing** pending still drops silently (mirror of `318` RPL_ENDOFWHOIS). Surfacing is scoped to "the user issued a WHO" (prime on-send), **not** to "a `315` arrived". The solitary-`315` silent drop is intentional and unchanged.

### Gates
- `scripts/check.sh` EXIT=0 (4568 test, dialyzer, credo, sobelow, doctor, 152 bats)
- cic vitest 3643 + parser; `bun run check` EXIT=0
- **Integration full: 561/561** (worker run: chromium 1 worker; vjt-confirmed 449 chromium + 112 webkit) — both `issue540-who-flag-args.spec.ts` cases green (#540 A structured + #540 B raw `/quote`)
- Code review: 1 reviewer, 4 findings all fixed
- `DESIGN_NOTES.md` 2026-07-30 #540 → Design 2

Rebased onto current `main`.

Closes #540
