### PR TITLE
test(#550): fix peer-capture test race (main CI red)

### DIFF
--- a/test/grappa/live_introspection_test.exs
+++ b/test/grappa/live_introspection_test.exs
@@ -38,10 +38,26 @@ defmodule Grappa.LiveIntrospectionTest do
     end
 
     test "returns one entry per live Session.Server with introspection fields" do
-      {_, port} = start_irc_server()
+      {server, port} = start_irc_server()
       {visitor, network} = visitor_with_network(port)
       pid = start_visitor_session_for(visitor, network)
       on_exit(fn -> Session.stop_session({:visitor, visitor.id}, network.id) end)
+
+      # #550 — the upstream peer is captured ASYNCHRONOUSLY: the Client dials
+      # the in-process IRCServer, then pushes {:irc_peer, _} to Session.Server
+      # which caches it. Until that message is processed the session is a live
+      # pid with peer_address: nil, so handle_call({:peer_address}) replies
+      # {:error, :no_peer} and `introspection_degraded` carries :peer_address
+      # (server.ex + fetch_peer_address). This test reads introspection_degraded
+      # right after spawn, so without a barrier it races the capture — green
+      # when the {:irc_peer, _} lands first (pull_request / local fast timing),
+      # red when the registry scan wins (CI push slow timing, same sha: the
+      # flake this fixes). USER is sent right AFTER the Client pushes
+      # {:irc_peer, _}, so waiting for it guarantees the peer is captured before
+      # the scan — the same deterministic barrier the #550 peer-capture test
+      # below uses. NOT an assertion weakening: it makes `== []` honest.
+      {:ok, _} =
+        Grappa.IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
 
       entries = LiveIntrospection.list_sessions()
 


### PR DESCRIPTION
## Fix: main-branch CI red from #550 (peer-capture test race)

`ci` run 30553361186 on `3e6f10d4` (main) failed:
`test/grappa/live_introspection_test.exs:56` —
`introspection_degraded` left `[:peer_address]`, right `[]`.

### Root cause (race, not a broken capture)
The **pull_request** run on the SAME sha (30553303730) PASSED — only the
**push** run failed. Timing, not a hard break.

`live_introspection_test:40` reads `introspection_degraded` immediately
after spawning a session, **without waiting for the async upstream-peer
capture** #550 added:

- The Client dials the IRCServer, then pushes `{:irc_peer, _}` to
  `Session.Server`, which caches the peer.
- Until that message is processed the session is a live pid with
  `peer_address: nil`, so `handle_call({:peer_address})` replies
  `{:error, :no_peer}` (`server.ex:1857`) and `fetch_peer_address` folds
  `:peer_address` into `introspection_degraded` (`live_introspection.ex:146`).
- The test therefore raced the capture: green when `{:irc_peer, _}` lands
  first (pull_request + local, fast timing), red when the registry scan
  wins (push, slow timing).

The peer **is** captured in this exact setup — the #550 peer-capture test
at `:82` proves it, by waiting for `USER` first.

### Fix
Add the **same deterministic barrier** the `:82` test already uses:
`wait_for_line(USER)`, which the Client sends right after pushing
`{:irc_peer, _}`, so the peer is guaranteed captured before the scan.

**The `== []` assertion is unchanged.** The wait makes it honest; it does
not weaken it.

### Verification
- `scripts/test.sh test/grappa/live_introspection_test.exs`: 8 tests, 0
  failures.
- `--repeat-until-failure 30` on `:40`: 0 failures.
- `mix format`: no change (already compliant).
