### PR TITLE
fix(#552): await join-ok scrollback backfill so the send-snap can't be undone

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -508,6 +508,39 @@ export async function waitForChannelReady(
   );
 }
 
+// Wait until cic's join-ok REST backfill (`refreshScrollback`) has COMPLETED
+// for a channel — the REST-catch-up twin of `waitForChannelReady`. Pure test
+// seam: scrollback.ts stamps `__cic_scrollbackRefreshed` (a Set of the module
+// composite key `channelKey(slug, name)`) in refreshScrollback's `finally`.
+// Production never reads it.
+//
+// Why: subscribe.ts's join-ok callback fires `void refreshScrollback` then
+// stamps `__cic_channelReady` SYNCHRONOUSLY right after — so
+// `waitForChannelReady` (and thus `selectChannel`) returns while the backfill
+// is still in flight. A spec that then acts on scroll geometry (issue168
+// send-snap, #552) races the backfill's late DOM recreation: the ref-keyed
+// <For> reset drops scrollTop → onScroll flips atBottom=false → the send-snap
+// is undone → the pane strands off the bottom. Green in isolation (the backfill
+// lands before the send), red under full-gate load (the flake #552 tracks).
+// Awaiting this seam makes the send-snap deterministic — it does NOT weaken any
+// assertion, it removes the race the assertion was silently depending on.
+export async function waitForScrollbackRefreshed(
+  page: Page,
+  networkSlug: string,
+  channelName: string,
+): Promise<void> {
+  const key = `${networkSlug} ${canonicalChannelName(channelName)}`;
+  await page.waitForFunction(
+    (k) => {
+      const set = (window as unknown as { __cic_scrollbackRefreshed?: Set<string> })
+        .__cic_scrollbackRefreshed;
+      return set?.has(k) === true;
+    },
+    key,
+    { timeout: 10_000 },
+  );
+}
+
 // Wait until cic's user-topic Channel has joined (Phoenix `phx.join()`
 // `ok` ack landed for `grappa:user:{userName}`). Pure test seam:
 // userTopic.ts stamps `__cic_userTopicReady` (a `Set<userName>`) in the

--- a/cicchetto/e2e/tests/issue168-scroll-authority.spec.ts
+++ b/cicchetto/e2e/tests/issue168-scroll-authority.spec.ts
@@ -44,6 +44,7 @@ import {
   loginAs,
   scrollbackLines,
   selectChannel,
+  waitForScrollbackRefreshed,
 } from "../fixtures/cicchettoPage";
 import { restoreReadCursorToTail, setReadCursorToId } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
@@ -126,6 +127,9 @@ test.describe("issue #168 — send pins to bottom, never jumps to the unread mar
 
     await loginAs(page, vjt);
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+    // #552 — await the join-ok REST backfill so its late DOM recreation can't
+    // undo the send-snap under full-gate load (see waitForScrollbackRefreshed).
+    await waitForScrollbackRefreshed(page, NETWORK_SLUG, CHANNEL);
 
     // REST page landed + the divider rendered (frozen-display contract).
     await expect
@@ -175,6 +179,9 @@ test.describe("issue #168 — send pins to bottom, never jumps to the unread mar
 
     await loginAs(page, vjt);
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+    // #552 — await the join-ok REST backfill so its late DOM recreation can't
+    // undo the send-snap under full-gate load (see waitForScrollbackRefreshed).
+    await waitForScrollbackRefreshed(page, NETWORK_SLUG, CHANNEL);
     await expect
       .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
       .toBeGreaterThanOrEqual(REST_PAGE_SIZE);

--- a/cicchetto/src/__tests__/scrollback.test.ts
+++ b/cicchetto/src/__tests__/scrollback.test.ts
@@ -1079,6 +1079,49 @@ describe("refreshScrollback (CP29 R-5)", () => {
     const list = scrollback.scrollbackByChannel()[key] ?? [];
     expect(list.map((m) => m.id)).toEqual([6, 7, 8, 20, 21]);
   });
+
+  it("stamps window.__cic_scrollbackRefreshed with the channel key on completion (#552 seam)", async () => {
+    // #552 — subscribe.ts fires `void refreshScrollback` in the join-ok
+    // callback and stamps `__cic_channelReady` SYNCHRONOUSLY right after, so
+    // waitForChannelReady (used by selectChannel) returns while the join-ok
+    // backfill is still in flight. A spec that then acts on scroll geometry
+    // (issue168 send-snap) races the backfill's late DOM recreation, which
+    // resets scrollTop → onScroll flips atBottom=false → the send-snap is
+    // undone. This seam marks backfill COMPLETION so specs can await it
+    // (waitForScrollbackRefreshed) — the REST-catch-up twin of
+    // __cic_channelReady. Production never reads it.
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    const key = channelKey("freenode", "#grappa");
+    mockGetResumeCursor.mockReturnValue(42);
+    vi.mocked(api.listMessagesAfter).mockResolvedValue([]);
+
+    await scrollback.refreshScrollback("freenode", "#grappa");
+
+    const w = window as unknown as { __cic_scrollbackRefreshed?: Set<string> };
+    expect(w.__cic_scrollbackRefreshed?.has(key)).toBe(true);
+  });
+
+  it("stamps __cic_scrollbackRefreshed even on REST error (backfill is done, not in flight)", async () => {
+    // The seam means "the backfill for this key is no longer in flight",
+    // whether it succeeded or errored — a spec waiting on it must not hang
+    // forever on a transient REST failure (no DOM recreation happens on the
+    // error path either, so it is safe to proceed).
+    localStorage.setItem("grappa-token", "tok");
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const api = await import("../lib/api");
+    const scrollback = await import("../lib/scrollback");
+    const key = channelKey("freenode", "#grappa");
+    mockGetResumeCursor.mockReturnValue(5);
+    vi.mocked(api.listMessagesAfter).mockRejectedValueOnce(new Error("network down"));
+
+    await scrollback.refreshScrollback("freenode", "#grappa");
+
+    const w = window as unknown as { __cic_scrollbackRefreshed?: Set<string> };
+    expect(w.__cic_scrollbackRefreshed?.has(key)).toBe(true);
+    consoleSpy.mockRestore();
+  });
 });
 
 describe("purgeScrollback (UX-7-B 2026-05-22)", () => {

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -577,6 +577,24 @@ const exports = identityScopedStore((onIdentityChange) => {
   const refreshInFlight = new Set<ChannelKey>();
   const REFRESH_LIMIT = 200;
 
+  // #552 — pure test seam: stamp `__cic_scrollbackRefreshed` (a Set of the
+  // module composite key) when a refreshScrollback COMPLETES for a key.
+  // subscribe.ts fires `void refreshScrollback` in the join-ok callback and
+  // stamps `__cic_channelReady` SYNCHRONOUSLY right after, so waitForChannelReady
+  // (used by selectChannel) returns while THIS REST backfill is still in flight.
+  // A spec that then acts on scroll geometry (issue168 send-snap) races the
+  // backfill's late DOM recreation, which resets scrollTop → onScroll flips
+  // atBottom=false → the send-snap is undone. This is the REST-catch-up twin of
+  // `__cic_channelReady`: specs await backfill COMPLETION via
+  // `waitForScrollbackRefreshed`. Production never reads it (mirror of
+  // subscribe.ts `stampChannelReady`).
+  const stampScrollbackRefreshed = (key: ChannelKey): void => {
+    if (typeof window === "undefined") return;
+    const w = window as Window & { __cic_scrollbackRefreshed?: Set<ChannelKey> };
+    if (!w.__cic_scrollbackRefreshed) w.__cic_scrollbackRefreshed = new Set();
+    w.__cic_scrollbackRefreshed.add(key);
+  };
+
   const refreshScrollback = async (slug: string, name: string): Promise<void> => {
     const t = token();
     if (!t) return;
@@ -625,6 +643,9 @@ const exports = identityScopedStore((onIdentityChange) => {
       console.error("[scrollback] refreshScrollback failed", slug, name, err);
     } finally {
       refreshInFlight.delete(key);
+      // #552 — mark this backfill DONE (success or error): no more in-flight
+      // DOM recreation for this key, so a spec awaiting it can safely proceed.
+      stampScrollbackRefreshed(key);
     }
   };
 


### PR DESCRIPTION
## #552 — issue168-scroll-authority:169 e2e flake under full-gate load

`issue168-scroll-authority.spec.ts:169` ("operator paged UP → send snaps back
to the bottom, unconditional") failed 3× under a full `scripts/integration.sh`
run, green in isolation and on GitHub CI. A load-only flake — same class as #79.

### Root cause (proven from code, not guessed)
`subscribe.ts`'s channel join-ok callback fires `void refreshScrollback` (the
REST catch-up backfill) then stamps `__cic_channelReady` **synchronously**, so
`waitForChannelReady`/`selectChannel` return while the backfill is still in
flight. Under load the backfill lands **after** the test's wheel-up+send:
it replaces rows → the ref-keyed `<For>` recreates the list DOM → `scrollTop`
resets to 0 → `onScroll` (`st < lastScrollTop`) flips `atBottom=false` → the
length-effect (marker already collapsed by the send) has neither the
marker-reassert branch nor the atBottom tail-follow → the send-snap is undone →
the pane strands off the bottom.

### Fix — deterministic setup, NO assert weakened, NO timeout lengthened
Make the test wait for the backfill it was racing:
- `cicchetto/src/lib/scrollback.ts`: stamp `__cic_scrollbackRefreshed` (the
  REST-catch-up twin of `__cic_channelReady`) in `refreshScrollback`'s
  `finally` (success **and** error). **Pure test seam — production never reads
  it** (mirror of `subscribe.ts`'s `stampChannelReady`).
- `cicchetto/e2e/fixtures/cicchettoPage.ts`: `waitForScrollbackRefreshed`
  fixture helper.
- `cicchetto/e2e/tests/issue168-scroll-authority.spec.ts`: await it after
  `selectChannel` in both tests.
- `cicchetto/src/__tests__/scrollback.test.ts`: pin the seam (success + error).

### Gates
- Full `scripts/integration.sh` (rebased on main incl. #540): **561 passed**,
  `INTEGRATION_EXIT=0`. Both `issue168:116` + `issue168:169` green.
- `bun.sh run test` (vitest): scrollback.test.ts seam RED→GREEN.
- `bun.sh run check` (biome + tsc): clean.

Deterministic setup only — no assertion weakened, no timeout lengthened.