### PR TITLE
feat(#542): mix release step fails if compiled version sha != HEAD

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -23733,3 +23733,56 @@ cases: structured `/who +s <hub>` opens the WhoModal, and raw `/quote WHO +s
 <hub>` opens it too — the B1 hole), the `:send_raw`-primes-WHO server tests
 (WHO primes, WHOIS does not), plus unit coverage in `client_test`,
 `grappa_channel_test`, `event_router_test`, and the cic parser suite.
+
+## 2026-07-30 — #542: deploy-time guard — a `mix release` step fails if the compiled version sha ≠ HEAD
+
+#533 fixed the ROOT cause of the stale version sha (the `@external_resource`
+watch set that missed the loose branch ref a `--ff-only` pull moves). #542's own
+"Suggested direction" asked for the belt-and-suspenders on top: a deploy-time
+assertion that the sha COMPILED into `Grappa.Version` equals `git rev-parse HEAD`,
+failing the build otherwise — because "a version string that can be stale is
+worse than no version string, because it is trusted." vjt's ruling: keep #542
+OPEN, scope it to exactly that hardening (the recompile fix is #533, not redone).
+
+**Where — one door, every substrate.** The guard is a `mix release` step
+(`steps: [:assemble, &assert_version_sha/1]` in `mix.exs`). It runs INSIDE every
+`mix release --overwrite`, which is how EVERY prod substrate assembles: the
+FreeBSD jail (`infra/freebsd/deploy.sh`), the `.deb` (`infra/packaging/build.sh`),
+the AUR source pkg (`PKGBUILD`). One code path — no deploy script can forget it.
+The alternative (an `eval`-based check wired into each deploy script, like
+release.yml's tag-proof) was rejected: three doors, forgettable. The step lives
+in `mix.exs`, NOT `lib/` — `Mix.raise`/`Mix.shell` don't exist at prod runtime and
+`mix.exs` never ships in the release; it reaches `Grappa.Version` through a
+variable so the compiler (which compiles `mix.exs` before the app) emits no
+undefined-function xref warning, the capture in `steps:` being lazy.
+
+**Why it is a real belt-and-suspenders, not a no-op after `mix compile`.** The
+step reads the sha ACTUALLY compiled into `Grappa.Version.beam`, not a fresh
+recompute. If a future `@external_resource` gap re-opens #542 and `mix compile`
+leaves `Version.beam` stale, the step reads that stale sha, sees it ≠ HEAD, and
+FAILS the release — regardless of whether compile did its job.
+
+**The verdict is total — no silent skip.** The two `nil`-carrying states are kept
+distinct (the exact hole #542 denounces): no `.git` at build (`@git_facts` nil, a
+package/tarball) is the ONLY skip, and it LOGS what it observed (log-honesty),
+because the artifact honestly reports the bare base and there is genuinely no
+HEAD to compare; BUT git-present-with-a-nil-sha (a source build degraded to
+`-dev`) is the drift itself and FAILS, as does an unresolvable HEAD, as does a
+compiled≠HEAD mismatch. The pure kernel `Grappa.Version.verify_build_sha/2` folds
+`(git_facts | nil, head_sha | nil)` → `:ok | {:skip, :no_git} | {:error, reason}`
+and is unit-tested across the full matrix (`test/grappa/version_test.exs`); `/1`
+reads `@git_facts` and delegates; the `mix.exs` step resolves HEAD via `git
+rev-parse --short HEAD` (env-stripped, mirroring `GitProbe`) and raises on error.
+
+**Runtime vs build-time posture.** `derive/2` (the CTCP-VERSION path) degrades a
+broken snapshot to `-dev` so a RUNNING node never crashes its reply; this guard
+is the opposite — at build time it refuses to ship rather than emit a trusted
+lie. Same facts, stricter verdict. release.yml's existing tag-proof (#419/#391)
+is unaffected: the `.deb` builds on a clean tag (git present, sha == HEAD → :ok)
+and the Arch tarball has no `.git` (→ `{:skip, :no_git}` + log).
+
+**Proven:** unit matrix RED→GREEN; a real `mix release` in the container logged
+`version guard (#542): Grappa.Version sha matches HEAD 32117b04` and assembled.
+A live-drift E2E is intentionally unreachable now — #533 recompiles `Version.beam`
+on any ref move — so the FAIL arms rest on the unit matrix plus the proven `:ok`
+wiring.

--- a/lib/grappa/version.ex
+++ b/lib/grappa/version.ex
@@ -131,4 +131,60 @@ defmodule Grappa.Version do
       true -> "#{base}-dev"
     end
   end
+
+  @typedoc """
+  The deploy-time build-sha guard verdict (#542):
+
+    * `:ok` — a source build whose compiled sha equals the current `HEAD`;
+    * `{:skip, :no_git}` — no `.git` at build (a package/tarball): the artifact
+      honestly reports the bare `base`, there is no `HEAD` to compare, so the
+      caller LOGS the observation and proceeds (the ONLY non-error outcome
+      without a comparison, and a positively-identified package — not an
+      anomalous fall-through);
+    * `{:error, reason}` — refuse to ship (the release step raises), one of:
+      * `{:stale, compiled, head}` — the compiled sha ≠ `HEAD`, the #542 drift:
+        `Grappa.Version` was not recompiled, so the beam carries a previous
+        build's sha;
+      * `:sha_snapshot_degraded` — git WAS present at build but no sha was
+        snapshotted (the build reports `-dev`), a trusted-but-unverifiable
+        version;
+      * `:head_unresolved` — a source build whose `HEAD` cannot be resolved at
+        deploy time, so the match cannot be proven.
+  """
+  @type build_sha_verdict ::
+          :ok
+          | {:skip, :no_git}
+          | {:error, {:stale, String.t(), String.t()} | :sha_snapshot_degraded | :head_unresolved}
+
+  @doc """
+  Deploy-time drift guard (#542): compares the git short-sha COMPILED into this
+  module (`@git_facts.short_sha`) against the caller-supplied current `HEAD`
+  short-sha, so a `mix release` step can REFUSE to assemble an artifact whose
+  reported version has gone stale.
+
+  `derive/2` (the runtime CTCP-VERSION path) degrades a broken snapshot to
+  `-dev` so a running node never crashes its reply; this guard is the opposite
+  posture — at build time it fails loudly rather than ship a version an operator
+  would trust: *a version string that can be stale is worse than no version
+  string, because it is trusted.* See `t:build_sha_verdict/0` for every outcome.
+  """
+  @spec verify_build_sha(String.t() | nil) :: build_sha_verdict()
+  def verify_build_sha(head_sha), do: verify_build_sha(@git_facts, head_sha)
+
+  @doc """
+  Pure kernel of the #542 guard: folds the build-time git snapshot and the
+  current `HEAD` short-sha into a verdict. Split from `verify_build_sha/1` (which
+  reads `@git_facts`) so the full matrix is unit-testable with explicit inputs —
+  the compile-time git state of the build itself is unstable.
+
+  `nil` facts (no git at build) skips; a facts map with a `nil` `short_sha` (git
+  present, snapshot failed) is the #542 failure itself and is an error, NOT a
+  silent skip — the two `nil`-carrying states are deliberately kept distinct.
+  """
+  @spec verify_build_sha(GitProbe.git_facts() | nil, String.t() | nil) :: build_sha_verdict()
+  def verify_build_sha(nil, _), do: {:skip, :no_git}
+  def verify_build_sha(%{short_sha: nil}, _), do: {:error, :sha_snapshot_degraded}
+  def verify_build_sha(%{short_sha: _}, nil), do: {:error, :head_unresolved}
+  def verify_build_sha(%{short_sha: sha}, sha), do: :ok
+  def verify_build_sha(%{short_sha: sha}, head_sha), do: {:error, {:stale, sha, head_sha}}
 end

--- a/mix.exs
+++ b/mix.exs
@@ -63,7 +63,17 @@ defmodule Grappa.MixProject do
       releases: [
         grappa: [
           include_executables_for: [:unix],
-          # `assemble` only — Docker deploys never used `mix release`
+          # #542 — deploy-time drift guard. After `:assemble`, assert the git
+          # short-sha COMPILED into `Grappa.Version` equals the current `HEAD`,
+          # else FAIL the release. This step runs inside EVERY `mix release
+          # --overwrite` (the FreeBSD jail, the .deb, the AUR source pkg) — one
+          # door, no substrate can skip it. #533 fixed the ROOT cause (the
+          # @external_resource watch set that let the sha go stale); this is the
+          # belt-and-suspenders that refuses to ship if a future gap reopens it,
+          # because a version string that can be stale is worse than none — it
+          # is trusted. See `assert_version_sha/1`.
+          steps: [:assemble, &assert_version_sha/1],
+          # `assemble` — Docker deploys never used `mix release`
           # (the container IS the runtime, see CLAUDE.md). The release
           # target is the FreeBSD bastille jail on m42 which has no
           # Docker. Build steps mirror what the container did at
@@ -105,6 +115,78 @@ defmodule Grappa.MixProject do
       mod: {Grappa.Application, []},
       extra_applications: [:logger, :runtime_tools, :ssl, :crypto, :inets]
     ]
+  end
+
+  # #542 — `mix release` step (runs after `:assemble`). Compares the git
+  # short-sha COMPILED into the just-built `Grappa.Version` (`@git_facts`)
+  # against the CURRENT `HEAD`, and raises — failing the release — on drift.
+  # The verdict matrix (skip-on-no-git-but-log, FAIL on a git build with a
+  # missing/mismatched sha) is the pure `Grappa.Version.verify_build_sha/2`,
+  # unit-tested in `test/grappa/version_test.exs`; this shell only resolves
+  # HEAD, logs, and raises.
+  #
+  # `Grappa.Version` is reached through a variable (`version = Grappa.Version`)
+  # on purpose: `mix.exs` is compiled by Mix BEFORE the app, so a static call
+  # would emit an "undefined function" xref warning on every mix invocation.
+  # The capture in `steps:` is lazy — the app is compiled by the time this runs.
+  defp assert_version_sha(release) do
+    version = Grappa.Version
+    head_sha = head_short_sha()
+
+    case version.verify_build_sha(head_sha) do
+      :ok ->
+        Mix.shell().info("version guard (#542): Grappa.Version sha matches HEAD #{head_sha}")
+        release
+
+      {:skip, :no_git} ->
+        # Log-honesty: a fast path states what it OBSERVED, never a silent no-op.
+        # Report the bare version from `release.version` (the %Mix.Release{}
+        # field) — NOT `Grappa.Version.base/0`, which returns "" unless `:grappa`
+        # is loaded into the mix VM, and would emit an empty version on this very
+        # honesty-logging path (the AUR-tarball substrate exercises it).
+        Mix.shell().info(
+          "version guard (#542): no .git at build — artifact reports the bare " <>
+            "#{release.version} (package/tarball); no HEAD to verify against"
+        )
+
+        release
+
+      {:error, {:stale, compiled, head}} ->
+        Mix.raise(
+          "version guard (#542): compiled Grappa.Version sha #{compiled} != HEAD #{head} — " <>
+            "Version.beam is STALE (mix compile did not re-snapshot the git ref). Refusing to " <>
+            "assemble a release that would misreport CTCP VERSION — clean-rebuild and retry."
+        )
+
+      {:error, :sha_snapshot_degraded} ->
+        Mix.raise(
+          "version guard (#542): git was present at build but Grappa.Version snapshotted no sha " <>
+            "(reports -dev) — a trusted-but-unverifiable version. Refusing to assemble."
+        )
+
+      {:error, :head_unresolved} ->
+        Mix.raise(
+          "version guard (#542): cannot resolve HEAD via `git rev-parse` though the build carries " <>
+            "a compiled sha — refusing to ship a version that can't be verified."
+        )
+    end
+  end
+
+  # Current `HEAD` short-sha, or `nil` when git can't answer. Mirrors
+  # `Grappa.Version.GitProbe.git/2`: `env: []` (git introspection needs none of
+  # grappa's secrets, and a cleared env keeps them out of the subprocess), and a
+  # `rescue`/`catch` so a MISSING git binary degrades to `nil` (→ the clean
+  # `:head_unresolved` verdict) rather than a raw `:enoent` stack trace — a
+  # clean-verdict guard deserves a clean failure.
+  defp head_short_sha do
+    case System.cmd("git", ["rev-parse", "--short", "HEAD"], env: [], stderr_to_stdout: true) do
+      {out, 0} -> String.trim(out)
+      {_, _} -> nil
+    end
+  rescue
+    _ -> nil
+  catch
+    _, _ -> nil
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]

--- a/test/grappa/version_test.exs
+++ b/test/grappa/version_test.exs
@@ -105,4 +105,103 @@ defmodule Grappa.VersionTest do
       assert String.starts_with?(current, Version.base())
     end
   end
+
+  describe "verify_build_sha/2 — deploy-time drift guard (#542): compiled sha ≡ HEAD or the build fails" do
+    # The runtime CTCP-VERSION path (derive/2) degrades a broken snapshot to
+    # `-dev` so a RUNNING node never crashes its VERSION reply. The DEPLOY guard
+    # is the opposite posture: at `mix release` assembly it REFUSES to ship a
+    # version it cannot prove, because "a version string that can be stale is
+    # worse than no version string, because it is trusted" (#542). Same facts,
+    # stricter verdict — build-time, not runtime.
+
+    test "compiled sha equals HEAD → :ok (the honest source build)" do
+      facts = %{exact_tag: nil, short_sha: "a40ad10", dirty?: false}
+
+      assert Version.verify_build_sha(facts, "a40ad10") == :ok
+    end
+
+    test "compiled sha differs from HEAD → {:error, {:stale, compiled, head}} (the #542 drift)" do
+      # The exact production reproduction: the node reported 0.6.0-6ba1235a
+      # while running a40ad10e — Version.beam kept the previous build's sha
+      # because the @external_resource watch set missed the loose branch ref.
+      facts = %{exact_tag: nil, short_sha: "6ba1235a", dirty?: false}
+
+      assert Version.verify_build_sha(facts, "a40ad10e") ==
+               {:error, {:stale, "6ba1235a", "a40ad10e"}}
+    end
+
+    test "git present at build but snapshot degraded (short_sha nil) → {:error, :sha_snapshot_degraded}" do
+      # This is the case that must NOT collapse into a silent skip: a source
+      # build (git WAS present, @git_facts is a map) whose sha snapshot failed
+      # reports `-dev` — a trusted-but-unverifiable version. That IS the #542
+      # failure the issue names, so the deploy must FAIL, not skip.
+      facts = %{exact_tag: nil, short_sha: nil, dirty?: false}
+
+      assert Version.verify_build_sha(facts, "a40ad10") == {:error, :sha_snapshot_degraded}
+    end
+
+    test "snapshot degraded AND HEAD unresolvable → :sha_snapshot_degraded (clause 2 beats clause 3)" do
+      # Pins the clause ordering the design hinges on: a git build with no
+      # snapshotted sha must report the degraded-snapshot drift even when HEAD is
+      # ALSO unresolvable — it must never fall through to :head_unresolved.
+      facts = %{exact_tag: nil, short_sha: nil, dirty?: false}
+
+      assert Version.verify_build_sha(facts, nil) == {:error, :sha_snapshot_degraded}
+    end
+
+    test "compiled sha present but HEAD unresolvable now → {:error, :head_unresolved}" do
+      # git was present at build (we hold a compiled sha) but the deploy cannot
+      # resolve HEAD to compare against — don't ship a version we can't verify.
+      facts = %{exact_tag: nil, short_sha: "a40ad10", dirty?: false}
+
+      assert Version.verify_build_sha(facts, nil) == {:error, :head_unresolved}
+    end
+
+    test "a dirty tree does not change the guard — the committed sha still governs" do
+      facts = %{exact_tag: "v1.2.3", short_sha: "a40ad10", dirty?: true}
+
+      assert Version.verify_build_sha(facts, "a40ad10") == :ok
+
+      assert Version.verify_build_sha(facts, "beefca7") ==
+               {:error, {:stale, "a40ad10", "beefca7"}}
+    end
+  end
+
+  describe "verify_build_sha/2 — no git at build (package/tarball): skip, but the caller logs the observation" do
+    test "nil git facts → {:skip, :no_git} (nothing to verify; release.yml's tag-proof covers packages)" do
+      # A package built from the source tarball has no `.git` → @git_facts is
+      # nil → the artifact honestly reports the bare base. There is genuinely no
+      # HEAD to compare, so the guard skips — but the release step LOGS what it
+      # observed (log-honesty: a fast path states what it saw, never a silent
+      # no-op). This is the ONLY non-error outcome without a sha comparison, and
+      # it is a positively-identified package, not an anomalous fall-through.
+      assert Version.verify_build_sha(nil, nil) == {:skip, :no_git}
+    end
+
+    test "nil git facts skips regardless of a HEAD that happens to resolve" do
+      # The beam's own claim (built without git → bare version) is
+      # authoritative; a HEAD appearing at deploy time does not retro-make a
+      # tarball build into a source build.
+      assert Version.verify_build_sha(nil, "a40ad10") == {:skip, :no_git}
+    end
+  end
+
+  describe "verify_build_sha/1 — reads the compiled @git_facts snapshot, delegates to /2" do
+    test "returns a valid tagged verdict for the build's own snapshot" do
+      # Like current/0, the compile-time git state of the test build is unstable
+      # (untagged worktree, possibly dirty), so we assert the CONTRACT SHAPE, not
+      # a fixed literal. A head that cannot equal any real short sha exercises
+      # the delegation without coupling the test to the build's actual sha.
+      result = Version.verify_build_sha("0000000")
+
+      # `:ok` is impossible — the build's real short-sha can't be "0000000" — so a
+      # git build (every real env) yields `{:error, {:stale, <real>, "0000000"}}`;
+      # the "0000000" we passed appearing in the verdict proves `/1` threads its
+      # argument into `/2` rather than ignoring it. A git-less build env degrades
+      # to `{:skip, :no_git}` / `:sha_snapshot_degraded`.
+      assert match?({:error, {:stale, _, "0000000"}}, result) or
+               match?({:skip, :no_git}, result) or
+               match?({:error, :sha_snapshot_degraded}, result)
+    end
+  end
 end


### PR DESCRIPTION
## #542 — deploy-time guard: refuse to ship a stale CTCP VERSION sha

`Grappa.Version` reports the running commit sha (CTCP VERSION / `/api/config`),
snapshotted at COMPILE time into `@git_facts`. On prod it once reported a sha ONE
build stale because `Version.beam` was not recompiled. Issue #533 (already on
main) corrected the ROOT cause — the `@external_resource` watch set that missed
the loose branch ref a `git pull --ff-only` moves. Per vjt's ruling, #542 is
scoped to the belt-and-suspenders its own "Suggested direction" asked for: a
deploy-time assertion that the sha compiled into `Grappa.Version` equals
`git rev-parse HEAD`, FAILING the build otherwise. The recompile fix is NOT
redone here.

### One door, every substrate
The guard is a `mix release` step (`steps: [:assemble, &assert_version_sha/1]`),
so it runs inside every `mix release --overwrite` — the FreeBSD jail, the `.deb`,
the AUR source pkg. An `eval`-based check wired into each deploy script was
rejected: three doors, forgettable. The step lives in `mix.exs` (not `lib/` —
`Mix.*` isn't a prod-runtime dep and `mix.exs` never ships in the release) and
reaches `Grappa.Version` through a variable so the compiler, which compiles
`mix.exs` before the app, emits no undefined-function xref warning.

### Real belt-and-suspenders, total verdict
It reads the sha ACTUALLY compiled into `Version.beam`, not a recompute — a
future watch-set gap that leaves the beam stale is read stale and FAILS. The pure
kernel `Grappa.Version.verify_build_sha/2` folds
`(git_facts | nil, head_sha | nil)` → `:ok | {:skip, :no_git} | {:error, reason}`,
keeping the two `nil`-carrying states distinct (the hole the issue denounces):

- no `.git` at build (package/tarball) → the ONLY skip, and it LOGS the observation;
- git present but the sha snapshot degraded to `-dev` → FAIL;
- an unresolvable HEAD → FAIL;
- compiled sha ≠ HEAD → FAIL (the drift).

`derive/2` (the runtime path) still degrades to `-dev` so a running node never
crashes its reply; this guard is the opposite posture — at build time it refuses
to ship a trusted lie. `release.yml`'s tag-proof (#419/#391) is unaffected: the
`.deb` builds on a clean tag (sha == HEAD → `:ok`), the Arch tarball has no
`.git` (→ `{:skip, :no_git}` + log).

### Gates
- `scripts/check.sh`: CHECK_EXIT=0 — 4588 tests, 0 failures; dialyzer 0 errors;
  credo --strict, sobelow, doctor all green.
- A real `mix release` logged `version guard (#542): Grappa.Version sha matches
  HEAD 32117b04` and assembled. A live-drift E2E is intentionally unreachable now
  (#533 recompiles `Version.beam` on any ref move), so the FAIL arms rest on the
  unit matrix plus the proven `:ok` wiring.
- Code review clean (no Critical); all four robustness/test refinements applied.

Files: `lib/grappa/version.ex`, `mix.exs`, `test/grappa/version_test.exs`,
`docs/DESIGN_NOTES.md`.