### PR TITLE
feat(#543): INC-1 — addressing_mode + static_mapping_prefix server settings

### DIFF
--- a/lib/grappa/net/ip_literal.ex
+++ b/lib/grappa/net/ip_literal.ex
@@ -22,6 +22,8 @@ defmodule Grappa.Net.IpLiteral do
 
   use Boundary, top_level?: true, deps: []
 
+  import Bitwise
+
   @doc """
   Parses `value` as a strict IPv4 or IPv6 literal and returns it in
   canonical form (`:inet.ntoa/1` — lowercase compressed v6, unpadded v4).
@@ -82,5 +84,65 @@ defmodule Grappa.Net.IpLiteral do
           {:error, _} -> raise ArgumentError, "not a strict IP literal: #{inspect(value)}"
         end
     end
+  end
+
+  @doc """
+  Parses `value` as a strict IPv6 CIDR (`<v6-literal>/<0..128>`) and returns
+  `{tuple, prefix_len}`. The address part goes through the SAME strict parse
+  as `to_tuple/1`; the tuple is returned VERBATIM — host bits are NOT masked
+  here (use `canonicalize_cidr6/1` for the masked network form).
+
+  Returns `:error` for an IPv4 CIDR, a bare literal with no `/len`, a length
+  outside `0..128`, a non-strict address, or any malformed input. The #543
+  static-mapping derivation + prefix-impact scan consume `{tuple, len}`.
+  """
+  @spec parse_cidr6(String.t()) :: {:ok, {:inet.ip6_address(), 0..128}} | :error
+  def parse_cidr6(value) when is_binary(value) do
+    with [addr, len_str] <- String.split(value, "/", parts: 2),
+         {len, ""} <- Integer.parse(len_str),
+         true <- len in 0..128,
+         {:ok, tuple} <- :inet.parse_ipv6strict_address(String.to_charlist(addr)) do
+      {:ok, {tuple, len}}
+    else
+      _ -> :error
+    end
+  end
+
+  @doc """
+  Parses `value` as a strict IPv6 CIDR, masks the host bits below the prefix
+  length to zero, and renders the network in canonical form (`<net>/<len>`,
+  lowercase compressed). A prefix stored this way is stable regardless of how
+  the operator typed it (case, compression, or an address carrying host bits).
+
+  Returns `:error` for the same inputs `parse_cidr6/1` rejects.
+  """
+  @spec canonicalize_cidr6(String.t()) :: {:ok, String.t()} | :error
+  def canonicalize_cidr6(value) when is_binary(value) do
+    case parse_cidr6(value) do
+      {:ok, {tuple, len}} ->
+        network = tuple |> ip6_to_integer() |> mask_prefix(len) |> integer_to_ip6()
+        {:ok, to_string(:inet.ntoa(network)) <> "/" <> Integer.to_string(len)}
+
+      :error ->
+        :error
+    end
+  end
+
+  # ---- v6 bit helpers (128-bit int ↔ 8×16 tuple) -------------------
+
+  defp ip6_to_integer({a, b, c, d, e, f, g, h}) do
+    <<n::128>> = <<a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>>
+    n
+  end
+
+  defp integer_to_ip6(n) do
+    <<a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>> = <<n::128>>
+    {a, b, c, d, e, f, g, h}
+  end
+
+  # Zero the low (128 - len) host bits. len=128 → no-op; len=0 → all zero.
+  defp mask_prefix(n, len) do
+    host_bits = 128 - len
+    (n >>> host_bits) <<< host_bits
   end
 end

--- a/lib/grappa/server_settings.ex
+++ b/lib/grappa/server_settings.ex
@@ -19,6 +19,12 @@ defmodule Grappa.ServerSettings do
   | `"upload.document_per_file_cap_bytes"`  | `pos_integer()`            | 10_485_760 (10MB)| UX-6-B |
   | `"upload.audio_per_file_cap_bytes"`     | `pos_integer()`            | 26_214_400 (25MB)| audio-uploads |
   | `"upload.global_cap_bytes"`             | `pos_integer()`            | 10_737_418_240 (10GB) | UX-6-B |
+  | `"addressing.mode"`                     | `:pool_with_reservations \\| :static_mapping_with_reservations` | `:pool_with_reservations` | #543 |
+  | `"addressing.static_mapping_prefix"`    | `String.t()` (v6 CIDR) \\| `nil` | `nil`       | #543 |
+
+  `addressing.*` are **admin-only** — deliberately NOT in `public_view/0`
+  (that broadcasts to every cic client); the admin settings surface reads
+  the accessors directly.
 
   ## Public-subset shape (`public_view/0`)
 
@@ -60,8 +66,15 @@ defmodule Grappa.ServerSettings do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Repo, Grappa.PubSub, Grappa.ServerSettings.Wire, Grappa.HttpHosts]
+    deps: [
+      Grappa.Repo,
+      Grappa.PubSub,
+      Grappa.ServerSettings.Wire,
+      Grappa.HttpHosts,
+      Grappa.Net.IpLiteral
+    ]
 
+  alias Grappa.Net.IpLiteral
   alias Grappa.PubSub, as: GrappaPubSub
   alias Grappa.PubSub.Topic
   alias Grappa.Repo
@@ -87,7 +100,21 @@ defmodule Grappa.ServerSettings do
   @default_upload_audio_per_file_cap_bytes 25 * 1024 * 1024
   @default_upload_global_cap_bytes 10 * 1024 * 1024 * 1024
 
+  # #543 outbound addressing mode (admin-only — NOT in public_view/0).
+  @key_addressing_mode "addressing.mode"
+  @key_static_mapping_prefix "addressing.static_mapping_prefix"
+  @default_addressing_mode :pool_with_reservations
+  @addressing_modes [:pool_with_reservations, :static_mapping_with_reservations]
+  # OperServ (azzurra bahamut) counts scan width in 16-bit groups, so a
+  # ban mask is only expressible on these boundaries — /72 and /120 are NOT.
+  # Reject any other length so an operator never configures a prefix a
+  # network cannot ban on. (#543 vjt ruling 2026-07-30.)
+  @allowed_prefix_lengths [64, 80, 96, 112, 128]
+
   @type upload_host :: :embedded | :litterbox
+
+  @typedoc "Closed set of outbound addressing modes (#543)."
+  @type addressing_mode :: :pool_with_reservations | :static_mapping_with_reservations
 
   @typedoc "Closed set of upload categories — one per-file cap each."
   @type upload_category :: :image | :video | :document | :audio
@@ -189,6 +216,62 @@ defmodule Grappa.ServerSettings do
   end
 
   def put_upload_global_cap_bytes(_), do: {:error, :invalid_value}
+
+  # ---- addressing.mode (#543) --------------------------------------
+
+  @doc """
+  Returns the configured outbound addressing mode
+  (`:pool_with_reservations` default — today's behaviour). Admin-only;
+  read by the session-plan source resolver (#543 INC-4).
+  """
+  @spec addressing_mode() :: addressing_mode()
+  def addressing_mode do
+    case get_raw(@key_addressing_mode) do
+      "pool_with_reservations" -> :pool_with_reservations
+      "static_mapping_with_reservations" -> :static_mapping_with_reservations
+      _ -> @default_addressing_mode
+    end
+  end
+
+  @doc "Pins the outbound addressing mode. Validates against the closed set."
+  @spec put_addressing_mode(addressing_mode()) :: :ok | {:error, :invalid_value}
+  def put_addressing_mode(mode) when mode in @addressing_modes do
+    put_raw(@key_addressing_mode, Atom.to_string(mode))
+  end
+
+  def put_addressing_mode(_), do: {:error, :invalid_value}
+
+  # ---- addressing.static_mapping_prefix (#543) ---------------------
+
+  @doc """
+  Returns the configured static-mapping derived-source prefix as a
+  canonical IPv6 CIDR string, or `nil` when unset. This is the `::cb::/80`
+  untrusted block the source derivation maps client `/64`s into.
+  """
+  @spec static_mapping_prefix() :: String.t() | nil
+  def static_mapping_prefix, do: get_raw(@key_static_mapping_prefix)
+
+  @doc """
+  Pins the static-mapping derived-source prefix. Accepts a strict IPv6
+  CIDR whose length is a 16-bit-group boundary (OperServ scan-width
+  constraint: `64 | 80 | 96 | 112 | 128`); stores it masked + canonical.
+  Any other input → `{:error, :invalid_prefix}`.
+  """
+  @spec put_static_mapping_prefix(String.t()) :: :ok | {:error, :invalid_prefix}
+  def put_static_mapping_prefix(value) when is_binary(value) do
+    with {:ok, {_, len}} <- IpLiteral.parse_cidr6(value),
+         true <- len in @allowed_prefix_lengths,
+         {:ok, canonical} <- IpLiteral.canonicalize_cidr6(value) do
+      case put_raw(@key_static_mapping_prefix, canonical) do
+        :ok -> :ok
+        {:error, _} -> {:error, :invalid_prefix}
+      end
+    else
+      _ -> {:error, :invalid_prefix}
+    end
+  end
+
+  def put_static_mapping_prefix(_), do: {:error, :invalid_prefix}
 
   # ---- Public projection -------------------------------------------
 

--- a/lib/grappa_web/controllers/admin/settings_controller.ex
+++ b/lib/grappa_web/controllers/admin/settings_controller.ex
@@ -6,11 +6,12 @@ defmodule GrappaWeb.Admin.SettingsController do
   ## GET /admin/settings
 
   Returns the admin settings view — the `upload` subtree of
-  `public_view/0` (`render_view/1`). It deliberately OMITS the #324
-  `http_host_aliases` that the authenticated `/api/server-settings`
-  carries: those are deployment config (env-derived), not an
-  admin-editable DB setting. Admin-only settings, when added, land here
-  only. Wire shape:
+  `public_view/0` plus the admin-only `addressing` subtree (#543, read
+  straight from the `Grappa.ServerSettings` accessors, NOT part of
+  `public_view/0`). It deliberately OMITS the #324 `http_host_aliases`
+  that the authenticated `/api/server-settings` carries: those are
+  deployment config (env-derived), not an admin-editable DB setting.
+  Wire shape:
 
       %{
         settings: %{
@@ -20,6 +21,10 @@ defmodule GrappaWeb.Admin.SettingsController do
             video_per_file_cap_bytes: pos_integer(),
             document_per_file_cap_bytes: pos_integer(),
             global_cap_bytes: pos_integer()
+          },
+          addressing: %{
+            mode: "pool_with_reservations" | "static_mapping_with_reservations",
+            static_mapping_prefix: String.t() | nil
           }
         }
       }
@@ -35,14 +40,18 @@ defmodule GrappaWeb.Admin.SettingsController do
           "video_per_file_cap_bytes" => pos_integer(),
           "document_per_file_cap_bytes" => pos_integer(),
           "global_cap_bytes" => pos_integer()
+        },
+        "addressing" => %{
+          "mode" => "pool_with_reservations" | "static_mapping_with_reservations",
+          "static_mapping_prefix" => String.t()
         }
       }
 
-  Each key in `upload` is optional — the controller upserts only
-  the keys present in the body. Any invalid value (out-of-set host
-  string, non-positive integer cap) collapses to 422
-  `validation_failed` with a `field_errors` map naming the offending
-  key.
+  Both `upload` and `addressing` are independently optional subtrees, and
+  every key within each is optional — the controller upserts only the keys
+  present in the body. Any invalid value (out-of-set host/mode string,
+  non-positive integer cap, non-16-bit-group prefix length) collapses to
+  422 `invalid_setting` with the offending dotted key in `field`.
 
   On success: 200 with the new full settings view AND fan-out of a
   `server_settings_changed` push on every live `Topic.user(name)`
@@ -110,12 +119,29 @@ defmodule GrappaWeb.Admin.SettingsController do
 
   # ---- Internal ----------------------------------------------------
 
-  defp apply_updates(%{"upload" => upload}) when is_map(upload) do
-    Enum.reduce_while(upload, :ok, fn {k, v}, _ -> halt_or_cont(apply_upload_key(k, v)) end)
+  defp apply_updates(params) when is_map(params) do
+    with :ok <- apply_subtree(params, "upload", &apply_upload_key/2) do
+      apply_subtree(params, "addressing", &apply_addressing_key/2)
+    end
   end
 
-  defp apply_updates(%{}), do: :ok
   defp apply_updates(_), do: {:error, :bad_request}
+
+  # Fold a present subtree through its per-key applier. Absent subtree → :ok
+  # (each is independently optional — an empty body updates nothing); a
+  # non-map subtree → bad_request (no silent swallow of a malformed shape).
+  defp apply_subtree(params, key, fun) do
+    case Map.get(params, key) do
+      nil ->
+        :ok
+
+      subtree when is_map(subtree) ->
+        Enum.reduce_while(subtree, :ok, fn {k, v}, _ -> halt_or_cont(fun.(k, v)) end)
+
+      _ ->
+        {:error, :bad_request}
+    end
+  end
 
   # Per-key dispatch so the surrounding fold stays a 2-line lambda
   # and Credo's cyclomatic-complexity check on `apply_updates/1`
@@ -165,12 +191,48 @@ defmodule GrappaWeb.Admin.SettingsController do
     :ok
   end
 
+  # ---- addressing.* dispatch (#543) --------------------------------
+
+  defp apply_addressing_key("mode", "pool_with_reservations"),
+    do: ServerSettings.put_addressing_mode(:pool_with_reservations)
+
+  defp apply_addressing_key("mode", "static_mapping_with_reservations"),
+    do: ServerSettings.put_addressing_mode(:static_mapping_with_reservations)
+
+  defp apply_addressing_key("mode", _),
+    do: {:error, {:invalid_setting, "addressing.mode"}}
+
+  defp apply_addressing_key("static_mapping_prefix", value) when is_binary(value) do
+    case ServerSettings.put_static_mapping_prefix(value) do
+      :ok -> :ok
+      {:error, :invalid_prefix} -> {:error, {:invalid_setting, "addressing.static_mapping_prefix"}}
+    end
+  end
+
+  defp apply_addressing_key("static_mapping_prefix", _),
+    do: {:error, {:invalid_setting, "addressing.static_mapping_prefix"}}
+
+  defp apply_addressing_key(k, _) do
+    Logger.warning("admin PUT /settings: unknown addressing key", setting_key: k)
+    :ok
+  end
+
   # Translate per-key return to Enum.reduce_while continuation. `:ok`
   # → continue; `{:error, _}` → halt with the error preserved.
   defp halt_or_cont(:ok), do: {:cont, :ok}
   defp halt_or_cont({:error, _} = err), do: {:halt, err}
 
+  # Admin settings view. The `upload` subtree comes from public_view/0 via
+  # the shared Wire projection; the `addressing` subtree (#543) is admin-only
+  # so it is read straight from the accessors — deliberately NOT part of
+  # public_view/0, which broadcasts to every cic client.
   defp render_view(%{upload: upload}) do
-    %{upload: SettingsWire.upload_view(upload)}
+    %{
+      upload: SettingsWire.upload_view(upload),
+      addressing: %{
+        mode: ServerSettings.addressing_mode(),
+        static_mapping_prefix: ServerSettings.static_mapping_prefix()
+      }
+    }
   end
 end

--- a/lib/grappa_web/controllers/admin/settings_controller.ex
+++ b/lib/grappa_web/controllers/admin/settings_controller.ex
@@ -81,7 +81,9 @@ defmodule GrappaWeb.Admin.SettingsController do
   end
 
   @doc false
-  @spec update(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:error, atom() | Ecto.Changeset.t()}
+  @spec update(Plug.Conn.t(), map()) ::
+          Plug.Conn.t()
+          | {:error, atom() | {:invalid_setting, String.t()} | Ecto.Changeset.t()}
   def update(conn, params) do
     with :ok <- apply_updates(params) do
       view = ServerSettings.public_view()

--- a/test/grappa/net/ip_literal_test.exs
+++ b/test/grappa/net/ip_literal_test.exs
@@ -67,4 +67,59 @@ defmodule Grappa.Net.IpLiteralTest do
       assert :error = IpLiteral.to_tuple("192.000.002.001")
     end
   end
+
+  # #543 — the static-mapping addressing mode configures a derived-source
+  # prefix as an IPv6 CIDR. `parse_cidr6/1` yields the {network_tuple, len}
+  # the derivation + prefix-impact scan need; `canonicalize_cidr6/1` masks
+  # the host bits and renders the network canonical for stable storage.
+  describe "parse_cidr6/1" do
+    test "parses a strict IPv6 CIDR to {tuple, prefix_len}" do
+      assert {:ok, {{0x2A03, 0x4000, 0x20, 0x2D3, 0xCB, 0, 0, 0}, 80}} =
+               IpLiteral.parse_cidr6("2a03:4000:20:2d3:cb::/80")
+    end
+
+    test "parses a full /128" do
+      assert {:ok, {{0x2001, 0x0DB8, 0, 0, 0, 0, 0, 1}, 128}} =
+               IpLiteral.parse_cidr6("2001:db8::1/128")
+    end
+
+    test "rejects an IPv4 CIDR" do
+      assert :error = IpLiteral.parse_cidr6("192.0.2.0/24")
+    end
+
+    test "rejects a bare literal with no prefix length" do
+      assert :error = IpLiteral.parse_cidr6("2001:db8::1")
+    end
+
+    test "rejects a prefix length above 128" do
+      assert :error = IpLiteral.parse_cidr6("2001:db8::/129")
+    end
+
+    test "rejects a non-strict / malformed address part" do
+      assert :error = IpLiteral.parse_cidr6("2001:db8:::/64")
+    end
+
+    test "rejects an empty string" do
+      assert :error = IpLiteral.parse_cidr6("")
+    end
+  end
+
+  describe "canonicalize_cidr6/1" do
+    test "lowercases + compresses the network and keeps the length" do
+      assert {:ok, "2a03:4000:20:2d3:cb::/80"} =
+               IpLiteral.canonicalize_cidr6("2A03:4000:20:2D3:00CB:0:0:0/80")
+    end
+
+    test "masks host bits below the prefix length to zero" do
+      # An operator who pastes an address with host bits set gets the
+      # NETWORK back — a prefix is its network, not a host in it.
+      assert {:ok, "2a03:4000:20:2d3:cb::/80"} =
+               IpLiteral.canonicalize_cidr6("2a03:4000:20:2d3:cb::5/80")
+    end
+
+    test "rejects an IPv4 CIDR and a non-literal" do
+      assert :error = IpLiteral.canonicalize_cidr6("192.0.2.0/24")
+      assert :error = IpLiteral.canonicalize_cidr6("nope/64")
+    end
+  end
 end

--- a/test/grappa/server_settings_test.exs
+++ b/test/grappa/server_settings_test.exs
@@ -199,4 +199,74 @@ defmodule Grappa.ServerSettingsTest do
       assert {:ok, :server_settings} = Grappa.PubSub.Topic.parse(topic)
     end
   end
+
+  # #543 — outbound addressing mode. Admin-only: NOT exposed in
+  # public_view/0 (that broadcasts to every cic client). Read by the
+  # session-plan resolver (INC-4) + the admin vhost surface.
+  describe "addressing_mode/0 + put_addressing_mode/1" do
+    test "defaults to :pool_with_reservations (current behaviour)" do
+      assert ServerSettings.addressing_mode() == :pool_with_reservations
+    end
+
+    test "round-trips :static_mapping_with_reservations" do
+      assert :ok = ServerSettings.put_addressing_mode(:static_mapping_with_reservations)
+      assert ServerSettings.addressing_mode() == :static_mapping_with_reservations
+      assert :ok = ServerSettings.put_addressing_mode(:pool_with_reservations)
+      assert ServerSettings.addressing_mode() == :pool_with_reservations
+    end
+
+    test "rejects an unknown mode atom" do
+      assert {:error, :invalid_value} = ServerSettings.put_addressing_mode(:bogus)
+    end
+
+    test "rejects a string" do
+      assert {:error, :invalid_value} = ServerSettings.put_addressing_mode("static_mapping_with_reservations")
+    end
+  end
+
+  describe "static_mapping_prefix/0 + put_static_mapping_prefix/1" do
+    test "defaults to nil" do
+      assert ServerSettings.static_mapping_prefix() == nil
+    end
+
+    test "accepts a /80 v6 CIDR, stored canonical" do
+      assert :ok = ServerSettings.put_static_mapping_prefix("2A03:4000:20:2D3:00CB:0:0:0/80")
+      assert ServerSettings.static_mapping_prefix() == "2a03:4000:20:2d3:cb::/80"
+    end
+
+    test "masks host bits — a prefix is its network" do
+      assert :ok = ServerSettings.put_static_mapping_prefix("2a03:4000:20:2d3:cb::5/80")
+      assert ServerSettings.static_mapping_prefix() == "2a03:4000:20:2d3:cb::/80"
+    end
+
+    test "rejects a length OperServ cannot express (16-bit-group boundaries only)" do
+      # /72 and /120 are not expressible in azzurra OperServ's 16-bit-group
+      # scan-width — reject at the boundary so the operator never configures
+      # a prefix a network cannot ban on.
+      assert {:error, :invalid_prefix} = ServerSettings.put_static_mapping_prefix("2a03:4000:20:2d3:cb::/72")
+      assert {:error, :invalid_prefix} = ServerSettings.put_static_mapping_prefix("2a03:4000:20:2d3:cb::/120")
+    end
+
+    test "accepts every 16-bit-group boundary length" do
+      for len <- [64, 80, 96, 112, 128] do
+        assert :ok = ServerSettings.put_static_mapping_prefix("2a03:4000:20:2d3:cb::/#{len}")
+      end
+    end
+
+    test "rejects an IPv4 CIDR and a non-CIDR" do
+      assert {:error, :invalid_prefix} = ServerSettings.put_static_mapping_prefix("192.0.2.0/24")
+      assert {:error, :invalid_prefix} = ServerSettings.put_static_mapping_prefix("2a03:4000:20:2d3:cb::")
+    end
+  end
+
+  describe "public_view/0 — addressing stays admin-only" do
+    test "does NOT leak addressing config to the cic-facing view" do
+      :ok = ServerSettings.put_addressing_mode(:static_mapping_with_reservations)
+      :ok = ServerSettings.put_static_mapping_prefix("2a03:4000:20:2d3:cb::/80")
+      view = ServerSettings.public_view()
+      refute Map.has_key?(view, :addressing)
+      refute Map.has_key?(view, :addressing_mode)
+      refute Map.has_key?(view, :static_mapping_prefix)
+    end
+  end
 end

--- a/test/grappa_web/controllers/admin/settings_controller_test.exs
+++ b/test/grappa_web/controllers/admin/settings_controller_test.exs
@@ -223,6 +223,81 @@ defmodule GrappaWeb.Admin.SettingsControllerTest do
     end
   end
 
+  describe "GET /admin/settings — addressing subtree (#543)" do
+    setup do
+      {_, session} = user_and_session(is_admin: true)
+      %{session: session}
+    end
+
+    test "returns addressing mode + prefix (defaults)", %{conn: conn, session: session} do
+      conn = conn |> put_bearer(session.id) |> get("/admin/settings")
+      assert %{"settings" => %{"addressing" => addressing}} = json_response(conn, 200)
+      assert addressing["mode"] == "pool_with_reservations"
+      assert addressing["static_mapping_prefix"] == nil
+    end
+
+    test "reflects a configured mode + prefix", %{conn: conn, session: session} do
+      :ok = ServerSettings.put_addressing_mode(:static_mapping_with_reservations)
+      :ok = ServerSettings.put_static_mapping_prefix("2a03:4000:20:2d3:cb::/80")
+
+      conn = conn |> put_bearer(session.id) |> get("/admin/settings")
+      assert %{"settings" => %{"addressing" => addressing}} = json_response(conn, 200)
+      assert addressing["mode"] == "static_mapping_with_reservations"
+      assert addressing["static_mapping_prefix"] == "2a03:4000:20:2d3:cb::/80"
+    end
+  end
+
+  describe "PUT /admin/settings — addressing (#543)" do
+    setup do
+      {_, session} = user_and_session(is_admin: true)
+      %{session: session}
+    end
+
+    test "sets mode + prefix", %{conn: conn, session: session} do
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/admin/settings", %{
+          "addressing" => %{
+            "mode" => "static_mapping_with_reservations",
+            "static_mapping_prefix" => "2a03:4000:20:2d3:cb::/80"
+          }
+        })
+
+      assert %{"settings" => %{"addressing" => addressing}} = json_response(conn, 200)
+      assert addressing["mode"] == "static_mapping_with_reservations"
+      assert addressing["static_mapping_prefix"] == "2a03:4000:20:2d3:cb::/80"
+      assert ServerSettings.addressing_mode() == :static_mapping_with_reservations
+      assert ServerSettings.static_mapping_prefix() == "2a03:4000:20:2d3:cb::/80"
+    end
+
+    test "422 invalid_setting for an unknown mode", %{conn: conn, session: session} do
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/admin/settings", %{"addressing" => %{"mode" => "chaos"}})
+
+      assert json_response(conn, 422) == %{
+               "error" => "invalid_setting",
+               "field" => "addressing.mode"
+             }
+    end
+
+    test "422 invalid_setting for a prefix OperServ cannot express", %{conn: conn, session: session} do
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/admin/settings", %{
+          "addressing" => %{"static_mapping_prefix" => "2a03:4000:20:2d3:cb::/72"}
+        })
+
+      assert json_response(conn, 422) == %{
+               "error" => "invalid_setting",
+               "field" => "addressing.static_mapping_prefix"
+             }
+    end
+  end
+
   describe "PUT /admin/settings — fan-out (UX-6-B2)" do
     setup do
       {_, session} = user_and_session(is_admin: true)

--- a/test/grappa_web/controllers/admin/settings_controller_test.exs
+++ b/test/grappa_web/controllers/admin/settings_controller_test.exs
@@ -296,6 +296,38 @@ defmodule GrappaWeb.Admin.SettingsControllerTest do
                "field" => "addressing.static_mapping_prefix"
              }
     end
+
+    test "applies upload AND addressing subtrees in one request", %{conn: conn, session: session} do
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/admin/settings", %{
+          "upload" => %{"active_host" => "litterbox"},
+          "addressing" => %{"mode" => "static_mapping_with_reservations"}
+        })
+
+      assert %{
+               "settings" => %{
+                 "upload" => %{"active_host" => "litterbox"},
+                 "addressing" => %{"mode" => "static_mapping_with_reservations"}
+               }
+             } = json_response(conn, 200)
+
+      assert ServerSettings.get_upload_active_host() == :litterbox
+      assert ServerSettings.addressing_mode() == :static_mapping_with_reservations
+    end
+
+    test "400 for a malformed (non-map) subtree — no silent swallow", %{
+      conn: conn,
+      session: session
+    } do
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/admin/settings", %{"addressing" => "not-a-map"})
+
+      assert %{"error" => _} = json_response(conn, 400)
+    end
   end
 
   describe "PUT /admin/settings — fan-out (UX-6-B2)" do


### PR DESCRIPTION
**INC-1 of #543** (static-mapping outbound addressing). Server-only config surface; no behaviour change to the default mode.

## What this adds
- Two **admin-only** `ServerSettings` keys behind the existing k/v table (no new table):
  - `addressing.mode` — `:pool_with_reservations` (default, **today's behaviour bit-for-bit**) | `:static_mapping_with_reservations`
  - `addressing.static_mapping_prefix` — canonical IPv6 CIDR | `nil`
- `Grappa.Net.IpLiteral.parse_cidr6/1` + `canonicalize_cidr6/1` — the shared v6-CIDR primitive later increments consume (masks host bits, canonical storage).
- Admin `GET`/`PUT /admin/settings` expose an `addressing` subtree (behind `:admin_authn`).

## Deliberate design points
- Addressing config is **kept OUT of `ServerSettings.public_view/0`** — that projection broadcasts to every cic client; addressing is admin-only. The admin controller reads the accessors directly.
- Prefix length is restricted to 16-bit-group boundaries (`64|80|96|112|128`): azzurra OperServ counts ban-mask scan width in 16-bit groups, so `/72` and `/120` are not expressible and are rejected at the boundary.
- Wire typing for cic + the AdminVhostsTab selector land in a later increment; this PR is server-only, so `gen_wire_types --check` stays green.

## Verification
- Full `scripts/check.sh` green locally (compile/format/credo/sobelow/dialyzer/doctor/test/gen_wire_types/bats), rebased onto current `main` (atop #537) and re-verified green.
- Code-reviewed (clean; two review-driven test/spec follow-ups included).

Part of the #543 feature; subsequent increments (derivation, client-IP capture, effective_source branch, platform adapter, session wiring, admin UI, docs) ship as their own PRs. Not to be merged until CI is settled-green.