### PR TITLE
fix(#554): operator KILL/AKILL on own nick is terminal, not a Backoff reconnect

### DIFF
--- a/cicchetto/e2e/fixtures/ircClient.ts
+++ b/cicchetto/e2e/fixtures/ircClient.ts
@@ -362,6 +362,17 @@ export class IrcPeer {
     await kicked;
   }
 
+  // Issue a raw KILL <target> :<reason> (oper-only upstream) — #554 e2e:
+  // an opered peer KILLs the grappa session's upstream nick to prove the
+  // KILL-terminal path. Fire-and-forget: irc-framework doesn't echo own
+  // commands, and the victim's disconnect is observed SERVER-side (the
+  // credential goes connection_state :failed), not on this peer.
+  // `raw(array)` adds the trailing-param `:` itself, so the reason ships
+  // as one token. Requires a prior `oper(...)`.
+  kill(targetNick: string, reason: string): void {
+    this.client.raw(["KILL", targetNick, reason]);
+  }
+
   // /OPER up to ircop. Required to bypass bahamut's "no ops on new
   // channels in split-mode" gate that otherwise locks every freshly
   // created channel out of any kind of mode-setting (including +i, +k,

--- a/cicchetto/e2e/tests/issue554-operator-kill-terminal.spec.ts
+++ b/cicchetto/e2e/tests/issue554-operator-kill-terminal.spec.ts
@@ -1,0 +1,103 @@
+// #554 — an operator KILL / services AKILL is terminal, not a Backoff
+// reconnect.
+//
+// A peer OPERs up against the testnet O:line (testoper/testoperpass) and
+// KILLs the seeded vjt session's upstream nick (NETWORK_NICK). The proof
+// is server-side via REST: the credential transitions to connection_state
+// "failed" with a reason starting "killed:", and STAYS failed — no
+// Backoff auto-reconnect flip back to "connected". This also proves the
+// load-bearing domain assumption that bahamut delivers the KILL to the
+// victim with the victim's own nick as target (hybrid m_kill); if it did
+// not, the terminal path would never fire and this spec goes RED.
+//
+// cic's dedicated rendering of the "killed" reason is a follow-up; this
+// asserts the SERVER contract (the REST door of the same domain event,
+// per "one feature, one code path, every door").
+//
+// CLEANUP: afterEach reconnects the network + polls #bofh back to joined,
+// mirroring issue100-reconnecting-badge, so the next spec on the shared
+// testnet inherits a live session.
+
+import { test, expect } from "../fixtures/test";
+import { IrcPeer } from "../fixtures/ircClient";
+import {
+  AUTOJOIN_CHANNELS,
+  getSeededVjt,
+  NETWORK_NICK,
+  NETWORK_SLUG,
+} from "../fixtures/seedData";
+import { GRAPPA_BASE_URL, patchNetworkConnectionState } from "../fixtures/grappaApi";
+
+const OPER_NAME = "testoper";
+const OPER_PASS = "testoperpass";
+const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// 90s — precondition poll + oper + KILL propagation + the 8s
+// no-reconnect dwell + afterEach autojoin poll (~30s) + testnet-load
+// margin. Same budget as the sibling park/reconnect specs.
+test.setTimeout(90_000);
+
+async function networkState(
+  token: string,
+): Promise<{ state: string; reason: string | null }> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/networks`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`GET /networks → ${res.status}`);
+  const nets = (await res.json()) as Array<{
+    slug: string;
+    connection_state: string;
+    connection_state_reason: string | null;
+  }>;
+  const net = nets.find((n) => n.slug === NETWORK_SLUG);
+  if (!net) throw new Error(`network ${NETWORK_SLUG} not found in GET /networks`);
+  return { state: net.connection_state, reason: net.connection_state_reason };
+}
+
+test.afterEach(async () => {
+  const vjt = getSeededVjt();
+  await patchNetworkConnectionState(vjt.token, NETWORK_SLUG, {
+    connection_state: "connected",
+  }).catch(() => {});
+
+  const channelsUrl = `${GRAPPA_BASE_URL}/networks/${NETWORK_SLUG}/channels`;
+  for (let attempt = 0; attempt < 60; attempt++) {
+    const res = await fetch(channelsUrl, {
+      headers: { authorization: `Bearer ${vjt.token}` },
+    }).catch(() => null);
+    if (res?.ok) {
+      const channels = (await res.json()) as Array<{ name: string; joined: boolean }>;
+      if (channels.find((c) => c.name === SEED_CHANNEL)?.joined) return;
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+});
+
+test("#554 — operator KILL marks the network :failed with a killed reason and does not reconnect", async () => {
+  const vjt = getSeededVjt();
+
+  // Precondition: the seeded session is connected.
+  await expect
+    .poll(async () => (await networkState(vjt.token)).state, { timeout: 30_000 })
+    .toBe("connected");
+
+  const peer = await IrcPeer.connect({ nick: "kill554op" });
+  try {
+    await peer.oper(OPER_NAME, OPER_PASS);
+    peer.kill(NETWORK_NICK, "operator kill #554");
+
+    // The credential goes :failed with a "killed:" reason.
+    await expect
+      .poll(async () => (await networkState(vjt.token)).state, { timeout: 30_000 })
+      .toBe("failed");
+
+    const { reason } = await networkState(vjt.token);
+    expect(reason ?? "").toMatch(/^killed:/);
+
+    // ...and STAYS failed — no Backoff auto-reconnect for ~8s.
+    await new Promise((r) => setTimeout(r, 8_000));
+    expect((await networkState(vjt.token)).state).toBe("failed");
+  } finally {
+    await peer.disconnect();
+  }
+});

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -23900,3 +23900,69 @@ migrations; the `IdentifierTest` pin test fails on one byte of drift). Shipped
 as separate reviewable INCs on the `537-identifier-fold-casemapping` branch
 (INC-1 boundary folds → INC-2a/b/c + 2.2/2.3/2.4 the network-aware ingress →
 INC-3 the mechanical collapse), never a big-bang.
+
+## 2026-07-31 — #554: operator KILL/AKILL is terminal, not a Backoff reconnect
+
+**Problem.** An oper-initiated `KILL` (and an AKILL, which the upstream delivers
+as a `KILL` + socket close) was NOT modelled as terminal. `KILL` parses
+(`parser.ex` → `:kill`, typed in `message.ex`) but no `handle_info/2` in
+`Session.Server` matched `command: :kill`, so a self-KILL fell to the generic
+`delegate` → `EventRouter` catch-all `route_unhandled_command` → a
+`:server_event` row on `$server` (visible but non-terminal). The follow-on
+`tcp_closed` then handed the drop to `Backoff` — exactly the shape it retries —
+so the session respawned and reconnected straight into the just-applied ban.
+The ban surfaced only on the NEXT connect via numeric 465 (already terminal),
+costing one extra full connect per akill; reconnecting against a banned address
+is precisely what upstream throttling punishes, so recovery made it worse.
+
+**Decision.** Treat a `KILL` whose target folds equal to our own current nick
+as terminal, on the SAME path as 465 (Decision C family). A new
+`handle_info({:irc, %Message{command: :kill, params: [target | rest]}}, state)`
+clause sits next to the 465/904 handlers:
+
+- **Self-match, sender-agnostic.** Match on `target` only (folded via
+  `fold_key/2`, the network-aware `canonical_target`, #537/#121 — never a bare
+  `==`/`downcase`). An AKILL arrives from a server or service prefix, not an
+  oper nick, so keying on `target == own_nick` is the general rule, not the
+  oper example.
+- **`handle_terminal_failure/2`** marks the credential `:failed` (so Bootstrap
+  skips it on the next deploy, matching 465) with a DISTINCT `"killed: "` reason
+  (≠ `"k-line: "` 465, ≠ `"sasl: "` 904) carrying the KILL comment verbatim, and
+  returns `{:stop, :normal}` — `terminate/2` excludes `:normal` from
+  `Backoff.record_failure`, and `:transient` does not restart on a normal exit.
+  The reason ships to cic verbatim through the existing `Networks.mark_failed/2`
+  → `broadcast_state_change/4` → `{:connection_state_changed}` on `Topic.user`,
+  so cic shows a "killed" reason instead of a reconnect spinner (cic's dedicated
+  rendering of the prefix is a follow-up).
+- **KILL on any OTHER nick** delegates unchanged — ordinary traffic, still
+  persists its `$server_event`, socket stays open. Malformed KILL (empty/
+  non-binary params) falls to the generic clause; non-terminal.
+- **No user lockout.** `:failed` is not a dead end: `Networks.connect/2` accepts
+  `:parked | :failed → :connected` (clearing the reason), so a manual `/connect`
+  from cic still works. Terminal = no AUTO retry (Backoff + Bootstrap), not
+  "user shut out."
+
+**Mailbox-ordering proof (KILL beats the tcp_closed→Backoff EXIT).** The worry
+was that the disconnect signal could be processed before the KILL. It cannot,
+from `IRC.Client`: the socket is `packet: :line, active: :once`, and
+`process_line/2` `send`s each parsed line to the Session BEFORE re-arming the
+socket (`client.ex` forward-then-setopts), so the Client cannot even observe
+`{:tcp_closed}` until the KILL has been forwarded. `{:tcp_closed}` →
+`{:stop, :tcp_closed}` → the linked Client's `{:EXIT}` reaches the Session
+STRICTLY AFTER `{:irc, kill}` is already enqueued; FIFO means the Session
+processes the KILL (→ `{:stop, :normal}`) before it ever dequeues the EXIT, so
+the abnormal-EXIT clause that calls `Backoff.record_failure` never runs. ERROR
+is not terminal (no `handle_info` for `command: :error`; it delegates to a
+`$server_event`), so its order relative to the KILL is irrelevant — the only
+Backoff trigger is `tcp_closed`, which is strictly last.
+
+**Domain assumption — PROVEN.** The design rests on the upstream delivering the
+KILL to the victim with the victim's own nick as target. hybrid (bahamut) and
+ratbox (solanum) `m_kill` both `sendto_one(target, ":<killer> KILL <victim>
+:<comment>")` to the local victim before `exit_client`. The real integration
+e2e confirms it end-to-end against live bahamut (`bahamut(perimeter)-1.4(34)-
+azzurra`, `CASEMAPPING=ascii`, prod-identical): an opered peer KILLs the seeded
+session's upstream nick, and the credential goes `connection_state=failed` with
+a `killed:` reason and STAYS failed (no reconnect for 8s). If a future ircd did
+NOT deliver the KILL to the victim, the fallback would key off the
+`ERROR :Closing Link ... (Killed ...)` line — out of scope unless disproved.

--- a/docs/superpowers/specs/2026-07-31-issue-554-kill-terminal-design.md
+++ b/docs/superpowers/specs/2026-07-31-issue-554-kill-terminal-design.md
@@ -1,0 +1,148 @@
+# #554 — Operator KILL/AKILL must be terminal, not a Backoff reconnect
+
+## Problem
+
+An oper-initiated `KILL` (and an AKILL, delivered upstream as a `KILL` + socket
+close) is not modelled as a terminal condition. `KILL` is parsed
+(`parser.ex:90` → `:kill`, typed `message.ex:67`) but no `handle_info/2` clause
+in `server.ex` matches `command: :kill`. So a self-`KILL` falls through the
+generic `delegate` clause (`server.ex:2874`) → `EventRouter` catch-all
+`route_unhandled_command` (`event_router.ex:2359`) → persists a `:server_event`
+row on `$server` (visible but **not** terminal) → then the upstream socket
+closes → `tcp_closed` → `terminate/2` abnormal → `Backoff.record_failure` →
+`:transient` respawn → reconnect straight into the ban that was just applied.
+
+The ban is only discovered on the *next* connect, via numeric 465, which is
+already terminal (`server.ex:2633` → `handle_terminal_failure/2`). That costs
+one extra full connect per akill — and reconnecting against a banned address is
+exactly what upstream connection throttling punishes, so the current recovery
+path makes things worse.
+
+## Domain check (challenge the spec) — RESOLVED in favour
+
+The load-bearing assumption is that the upstream delivers the `KILL` to the
+victim with the victim's own nick as the target. This holds: `m_kill` in the
+hybrid lineage (bahamut / Azzurra, all of prod) and the ratbox lineage
+(solanum / Libera) both `sendto_one(target, ":<killer> KILL <victim> :<reason>")`
+to the *local* victim before calling `exit_client`. So `params = [own_nick,
+comment]`. The real integration e2e is what proves this end-to-end; if some
+ircd does NOT deliver the KILL to the victim, the fallback would be to key off
+the `ERROR :Closing Link ... (Killed ...)` line instead — out of scope unless
+the e2e disproves the assumption.
+
+## Design
+
+One new `handle_info` clause in `lib/grappa/session/server.ex`, placed BEFORE
+the generic `delegate` clause (`:2874`), mirroring the 465 handler (`:2633`):
+
+```elixir
+def handle_info({:irc, %Message{command: :kill, params: [target | rest]} = msg}, state)
+    when is_binary(target) do
+  if fold_key(state, target) == fold_key(state, state.nick) do
+    comment = List.last(rest) || "killed"
+    reason = "killed: #{comment}"
+    Logger.error(
+      "operator KILL received — session marked :failed (network_id=#{state.network_id})",
+      reason: reason
+    )
+    handle_terminal_failure(reason, state)
+  else
+    delegate(msg, state)
+  end
+end
+```
+
+### Decisions
+
+- **Self-match** via `fold_key/2` (`server.ex:2980`, the network-aware
+  `canonical_target`) so a cased KILL target (`OwnNick` vs `ownnick`) still
+  matches — respects the #537/#121 identifier-fold invariant. Never a bare `==`
+  or `String.downcase`.
+- **Match on TARGET only, sender-agnostic.** An AKILL/services kill may arrive
+  from a server or a service prefix, not an oper nick; keying on `target ==
+  own_nick` is the general rule (fix the class, not the oper-nick example).
+- **Distinct reason prefix** `"killed: "` — distinct from `"k-line: "` (465) and
+  `"sasl: "` (904) so the client can render "killed by an operator" instead of a
+  generic reconnect spinner. The reason ships to cic verbatim through the
+  existing `Networks.mark_failed/2` → `broadcast_state_change/4` →
+  `{:connection_state_changed, %{reason: ...}}` on `Topic.user`.
+- **No Backoff, no respawn, no Bootstrap-retry** — all free via
+  `handle_terminal_failure/2`: it fires the `credential_failer` (→
+  `Networks.mark_failed` → `connection_state=:failed`, which Bootstrap skips on
+  the next deploy) and returns `{:stop, :normal, state}`; `terminate/2` excludes
+  `:normal` from `Backoff.record_failure`, and `:transient` does not restart on
+  a normal exit.
+- **KILL targeting another nick** → `delegate(msg, state)` unchanged: it still
+  persists the `:server_event` row and the socket stays open. Ordinary traffic.
+- **Malformed KILL** (empty params / non-binary target) falls through to the
+  generic clause (`:2874`) → non-terminal. Correct: a malformed KILL is not a
+  ban signal.
+- **No scrollback row on self-KILL**, mirroring 465: the comment lives in the
+  credential reason, not a `$server` row. (Non-self KILL keeps its row.)
+- **cic UI rendering** of the distinct "killed" reason is a follow-up (separate
+  cic issue); this change is server-only. cic already surfaces
+  `connection_state_reason` for `:failed`, so no reconnect spinner is shown.
+
+## Mailbox ordering proof (KILL beats Backoff — proven, not assumed)
+
+The concern: after a KILL the ircd sends `ERROR :Closing Link ... (Killed ...)`
+then FINs the socket. If the disconnect signal (`tcp_closed` → `{:EXIT}` →
+`Backoff.record_failure`) were processed before the KILL, the session would
+respawn and the bug would return. It does not, proven from `IRC.Client`:
+
+1. **Line framing, `active: :once`** (`client.ex:1273`/`:1281`): socket is
+   `packet: :line, active: :once`. Each complete IRC line (`KILL x :reason\r\n`)
+   arrives as ONE `{:tcp, sock, line}` — OS-level framing, "immune to TCP packet
+   boundary races" (moduledoc `:18`).
+2. **Forward BEFORE anything** (`client.ex:1483`): `process_line/2` does
+   `send(state.dispatch_to, {:irc, msg})` to `Session.Server` before the FSM step
+   and before re-arming `active: :once` (`:1500`).
+3. **Re-arm only AFTER the forward** → moduledoc invariant (`:19-24`): the Client
+   does not receive line N+1 until line N has been parsed and forwarded. So the
+   Client cannot even observe `{:tcp_closed}` until the KILL has been forwarded.
+4. **`tcp_closed` → stop** (`client.ex:1032`): `{:stop, :tcp_closed, state}` → the
+   linked Client dies → `{:EXIT, client_pid, :tcp_closed}` reaches `Session.Server`.
+5. **FIFO mailbox**: `{:irc, kill}` was delivered strictly before the Client
+   processed `{:tcp_closed}`, so `Session.Server`'s mailbox is `{:irc, kill}`
+   (and any `{:irc, error}`) THEN `{:EXIT}`. It processes the KILL first →
+   `handle_terminal_failure` → `{:stop, :normal}` → stops before ever dequeuing
+   `{:EXIT}`, so the abnormal-EXIT clause that calls `Backoff.record_failure`
+   never runs.
+
+**ERROR is not terminal**: there is no `handle_info` for `command: :error` in
+`server.ex` (the only `:error` match, `:2261`, is `{:irc_peer, {:error, _}}` —
+the downstream facade, unrelated). ERROR falls to the generic `delegate` →
+`server_event`; its order relative to the KILL is irrelevant. The ONLY Backoff
+trigger is `tcp_closed`→`{:EXIT}`, which is strictly last.
+
+**The single assumption the code cannot self-prove** is that the ircd delivers
+the KILL as a complete line before the FIN. That is exactly what the integration
+e2e proves against real bahamut — hence it is load-bearing, not decorative.
+
+## Testing
+
+### Unit (TDD, `test/grappa/session/server_test.exs`)
+
+Mirror the 465 terminal test at `:6168` (describe block `:6154`):
+
+1. **self-KILL** (`params: [own_nick, comment]`) → calls `mark_failed` with
+   `"killed: <comment>"` reason, session terminates `:normal`, **no** Backoff
+   bump.
+2. **fold-case self-KILL** (`params: ["OwnNick", ...]` vs `state.nick =
+   "ownnick"`) → still terminal.
+3. **KILL targeting another nick** → delegates, persists a `:server_event` row,
+   session **stays alive** (process still `Process.alive?`).
+4. **malformed KILL** (`params: []`) → stays alive (falls to generic clause).
+
+### Integration e2e (real ircd)
+
+An oper peer issues `KILL` against the grappa session's nick on the real
+testnet; assert the credential transitions to `:failed` and there is **no**
+reconnect. Proves the ircd delivers the KILL to the victim AND the terminal
+path end-to-end. Requires a vjt-allocated e2e lane.
+
+## Out of scope
+
+- Address mapping / ban granularity (#454).
+- ERROR-line fallback (only if the e2e disproves KILL delivery).
+- cic dedicated "killed by an operator" rendering (follow-up cic issue).

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -2677,6 +2677,51 @@ defmodule Grappa.Session.Server do
     end
   end
 
+  # Operator KILL / services AKILL — terminal, non-recoverable (GH #554).
+  # The upstream delivers a KILL to the victim with the victim's own nick
+  # as the target (`:killer KILL <victim> :<comment>`, hybrid/ratbox
+  # m_kill), then FINs the socket. Without this clause the KILL falls to
+  # the generic delegate (persists a $server_event) and the follow-on
+  # tcp_closed hands the drop to Backoff, which reconnects straight into
+  # the just-applied ban — the exact shape 465 already treats as terminal.
+  #
+  # We match on TARGET only (sender-agnostic): an AKILL arrives from a
+  # server or service prefix, not an oper nick, so keying on
+  # `target == own_nick` is the general rule. The self-match folds via
+  # `fold_key/2` (network-aware canonical_target, #537/#121) so a cased
+  # target still matches; never a bare `==` / downcase.
+  #
+  # `handle_terminal_failure/2` marks the credential :failed (Bootstrap
+  # then skips it next deploy) with a DISTINCT "killed: " reason (≠
+  # "k-line: " / "sasl: ") so cic can render "killed by an operator", and
+  # returns {:stop, :normal} — terminate/2 excludes :normal from Backoff,
+  # so no respawn. A KILL on ANY other nick is ordinary traffic and
+  # delegates unchanged (still persists its $server_event, socket stays).
+  #
+  # Ordering: IRC.Client (packet: :line, active: :once) forwards each
+  # parsed line to us BEFORE re-arming the socket (client.ex:1483→:1500),
+  # so {:irc, kill} is enqueued strictly before the tcp_closed-driven
+  # {:EXIT}; FIFO guarantees we stop here before the Backoff clause runs.
+  def handle_info(
+        {:irc, %Message{command: :kill, params: [target | rest]} = msg},
+        state
+      )
+      when is_binary(target) do
+    if fold_key(state, target) == fold_key(state, state.nick) do
+      comment = List.last(rest) || "killed"
+      reason = "killed: #{comment}"
+
+      Logger.error(
+        "operator KILL received — session marked :failed (network_id=#{state.network_id})",
+        reason: reason
+      )
+
+      handle_terminal_failure(reason, state)
+    else
+      delegate(msg, state)
+    end
+  end
+
   # S4.2 — CAP ACK: detect labeled-response being granted by the upstream.
   # IRC.Client dispatches ALL parsed messages to Session.Server (including
   # CAP messages that AuthFSM also processes). This handler fires for any

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -6174,7 +6174,7 @@ defmodule Grappa.Session.ServerTest do
       # `Topic.user` (not `Topic.network`) and arrives as a
       # `%Phoenix.Socket.Broadcast{}` envelope from
       # `Grappa.PubSub.broadcast_event/2`.
-      topic = Grappa.PubSub.Topic.user(user.name)
+      topic = Topic.user(user.name)
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
 
       pid = start_session_for(user, network)
@@ -6221,11 +6221,145 @@ defmodule Grappa.Session.ServerTest do
       assert reloaded.connection_state_reason == "k-line: You are banned from this server."
     end
 
+    # #554 — an operator KILL / services AKILL on our OWN nick is terminal,
+    # same class as 465: the upstream delivers `:killer KILL <victim>
+    # :<comment>` to the victim then FINs. Without this the KILL fell to the
+    # generic delegate (persist $server_event) and the tcp_closed handed the
+    # drop to Backoff, which reconnected straight into the just-applied ban.
+    test "KILL targeting own nick: marks :failed with 'killed:' reason, session exits :normal" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port, %{autojoin_channels: ["#test"]})
+
+      topic = Topic.user(user.name)
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
+
+      pid = start_session_for(user, network)
+      ref = Process.monitor(pid)
+
+      :ok = await_handshake(server)
+      IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
+      {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
+
+      # params = [target, comment]; target == our own nick.
+      msg = %Message{
+        command: :kill,
+        params: ["grappa-test", "Killed (testoper (spam))"],
+        prefix: {:nick, "testoper", "op", "irc.test.org"},
+        tags: %{}
+      }
+
+      send(pid, {:irc, msg})
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 2_000
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{
+                         kind: :connection_state_changed,
+                         to: :failed,
+                         reason: "killed: Killed (testoper (spam))"
+                       }
+                     },
+                     3_000
+
+      reloaded =
+        Grappa.Repo.get_by!(Grappa.Networks.Credential,
+          user_id: user.id,
+          network_id: network.id
+        )
+
+      assert reloaded.connection_state == :failed
+      assert reloaded.connection_state_reason == "killed: Killed (testoper (spam))"
+    end
+
+    test "KILL targeting own nick with different case still terminal (fold match)" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+
+      topic = Topic.user(user.name)
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
+
+      pid = start_session_for(user, network)
+      ref = Process.monitor(pid)
+
+      :ok = await_handshake(server)
+
+      # state.nick == "grappa-test"; "GRAPPA-TEST" folds equal (ascii).
+      msg = %Message{
+        command: :kill,
+        params: ["GRAPPA-TEST", "Killed (testoper (bye))"],
+        prefix: {:server, "irc.test.org"},
+        tags: %{}
+      }
+
+      send(pid, {:irc, msg})
+
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 2_000
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       payload: %{kind: :connection_state_changed, to: :failed}
+                     },
+                     3_000
+    end
+
+    test "KILL targeting another nick keeps flowing: session stays alive, DB :connected" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+
+      pid = start_session_for(user, network)
+
+      :ok = await_handshake(server)
+
+      msg = %Message{
+        command: :kill,
+        params: ["someone-else", "Killed (testoper (unrelated))"],
+        prefix: {:nick, "testoper", "op", "irc.test.org"},
+        tags: %{}
+      }
+
+      send(pid, {:irc, msg})
+
+      # PING/PONG flush confirms the KILL was processed via FIFO.
+      IRCServer.feed(server, "PING :flush\r\n")
+      {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "PONG :flush\r\n"), 1_000)
+
+      assert Process.alive?(pid)
+
+      reloaded =
+        Grappa.Repo.get_by!(Grappa.Networks.Credential,
+          user_id: user.id,
+          network_id: network.id
+        )
+
+      assert reloaded.connection_state == :connected
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "malformed KILL (no params) is non-terminal, session stays alive" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+
+      pid = start_session_for(user, network)
+
+      :ok = await_handshake(server)
+
+      msg = %Message{command: :kill, params: [], prefix: {:server, "irc.test.org"}, tags: %{}}
+      send(pid, {:irc, msg})
+
+      IRCServer.feed(server, "PING :flush\r\n")
+      {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "PONG :flush\r\n"), 1_000)
+
+      assert Process.alive?(pid)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
     test "904 with 'SASL authentication failed' (permanent cred error): marks :failed, session exits :normal" do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
 
-      topic = Grappa.PubSub.Topic.user(user.name)
+      topic = Topic.user(user.name)
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
 
       pid = start_session_for(user, network)


### PR DESCRIPTION
## What

An oper `KILL` (and an AKILL, delivered upstream as `KILL` + socket close) on our own nick is now **terminal**, on the same path as numeric 465 — instead of falling through to the generic delegate and letting the follow-on `tcp_closed` hand the drop to `Backoff`, which reconnected straight into the just-applied ban.

New `handle_info(:kill)` clause in `Session.Server` (next to 465/904):
- **Self-match** on `target` folded vs own nick (`fold_key/2`, network-aware `canonical_target`, #537/#121). **Sender-agnostic** — an AKILL from a server/service prefix still matches (fix the class, not the oper example).
- `handle_terminal_failure/2` → mark `:failed` with a **distinct `"killed:"` reason** (≠ `"k-line:"`/`"sasl:"`; Bootstrap skips it next deploy; cic shows a killed reason, not a reconnect spinner), no Backoff, `{:stop, :normal}`.
- **KILL on any other nick** delegates unchanged (still a `$server_event`, socket stays). Malformed KILL is non-terminal.
- **No user lockout** — `Networks.connect/2` accepts `:failed → :connected`, so a manual `/connect` still works. Terminal = no *auto* retry.

Server-only; cic's dedicated rendering of the `"killed:"` reason is a follow-up.

## Ordering (proven, not assumed)

`IRC.Client` is `packet: :line, active: :once` and forwards each parsed line to the Session **before** re-arming the socket, so `{:irc, kill}` is enqueued strictly before the `tcp_closed`-driven `{:EXIT}`; FIFO stops us in the KILL clause before the Backoff clause ever runs. ERROR is not terminal (no handler); only `tcp_closed` triggers Backoff, and it's strictly last.

## TDD evidence

**RED** (4 unit tests, before writing the handler):

```
4 tests, 2 failures (320 excluded)

  test terminal failure triggers — lenient :failed (S1.4) KILL targeting own nick ...
  Assertion failed, no matching message after 2000ms
  code: assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
  stacktrace:
    test/grappa/session/server_test.exs:6253: (test)   # self-KILL
    test/grappa/session/server_test.exs:6297: (test)   # fold-case
```

**GREEN** after the handler: `4 tests, 0 failures`.

**Full `check.sh`**: `8 doctests, 47 properties, 4609 tests, 0 failures` · credo `found no issues` · dialyzer `Total errors: 0` · sobelow ok · bats `ok 152`.

**Real-ircd e2e** (scoped, live bahamut `bahamut(perimeter)-1.4(34)-azzurra`, `CASEMAPPING=ascii`): an opered peer (`381 :You are now an IRC Operator`) KILLs the seeded session's nick → credential `connection_state=failed` with a `killed:` reason, **stays failed** (no reconnect) → proves bahamut delivers the KILL to the victim and the terminal path end-to-end.

```
✓ issue554-operator-kill-terminal.spec.ts › #554 — operator KILL marks the network :failed with a killed reason and does not reconnect (9.2s)
1 passed (22.6s)
```

Full integration is the CI gate on this PR (base main).

Refs #554.