### PR TITLE
feat(#543): deterministic /64→::cb source derivation (INC-2)

### DIFF
--- a/lib/grappa/vhosts/source_mapping.ex
+++ b/lib/grappa/vhosts/source_mapping.ex
@@ -1,0 +1,131 @@
+defmodule Grappa.Vhosts.SourceMapping do
+  @moduledoc """
+  Pure derivation of a deterministic outbound source address from a
+  client's network prefix — the core of the #543
+  `static_mapping_with_reservations` addressing mode.
+
+  Each untrusted subject egresses from ONE stable address inside the
+  configured `::cb::/80`, derived from the subject's OWN client `/64`
+  (v6) or `/32` (v4). This replaces the random pool for mode 2: an
+  address is `derive(client_key(client_ip), prefix)` — same client, same
+  address, forever (until the operator renumbers the prefix).
+
+  ## The mapping key (`client_key/1`)
+
+  The key is the client's routable prefix, NOT its full address:
+
+    * IPv6 → the first 64 bits (the `/64`). The interface id is IGNORED
+      because RFC 8981 rotates it (privacy extensions) — keying on it
+      would hand a single roaming laptop a new outbound address every
+      few hours, defeating accountability. Keying on the `/64` gives a
+      home/mobile subscriber ONE address for the life of their prefix.
+    * IPv4 → all 32 bits (the `/32`).
+
+  A NAT/CGNAT that collapses many clients behind one prefix to a single
+  derived address is INTENDED ("come se si collegassero direttamente"):
+  they share an upstream vantage point, so they share an egress.
+
+  ## The hash is NOT keyed (#543)
+
+  `derive/2` fills the host bits of the prefix from
+  `sha256(@domain_tag <> client_key)`. There is deliberately NO secret
+  key: reversibility is irrelevant here (the mapping is client-prefix →
+  our-own-block, not a privacy secret), so the only property that
+  matters is collision-freedom, and an unkeyed SHA-256 already gives a
+  near-uniform spread over the host space. A keyed MAC would add key
+  management for zero benefit.
+
+  `@domain_tag` provides domain separation so this derivation never
+  aliases some other SHA-256 use over the same client bytes — it is a
+  namespace label, NOT a secret.
+
+  ## Collision math
+
+  For a `/80` prefix the host part is 48 bits. By the birthday bound the
+  expected first collision arrives around `2^(48/2) = 2^24 ≈ 16.7M`
+  distinct client prefixes mapped into the block. Real deployments map
+  thousands, not millions, of distinct `/64`s, so in practice the map is
+  injective; reservations (which win over derivation) live OUTSIDE the
+  `::cb` block, so a derived address can never shadow a reserved one.
+
+  ## Boundary
+
+  Sub-module of the `Grappa.Vhosts` boundary (which already deps
+  `Grappa.Net.IpLiteral`); it declares no boundary of its own and is not
+  exported — every caller (`Vhosts.effective_source/*`,
+  `Vhosts.record_client_source/*`, `Vhosts.prefix_impact/*`) sits inside
+  the same boundary.
+  """
+
+  alias Grappa.Net.IpLiteral
+
+  # Domain separation for the SHA-256 input — a namespace label, NOT a secret.
+  @domain_tag "grappa/source-mapping/v1"
+
+  @doc """
+  Reduces a client IP tuple to its routable-prefix key: the v6 `/64`
+  (first 8 bytes, interface id dropped) or the v4 `/32` (4 bytes). This
+  binary is the mapping key fed to `derive/2` and persisted per subject.
+  """
+  @spec client_key(:inet.ip_address()) :: binary()
+  def client_key({a, b, c, d, _, _, _, _}), do: <<a::16, b::16, c::16, d::16>>
+  def client_key({a, b, c, d}), do: <<a, b, c, d>>
+
+  @doc """
+  Derives the deterministic source address for `key` inside `prefix_cidr`.
+
+  Keeps the prefix's network bits verbatim and fills the host bits from
+  `sha256(@domain_tag <> key)`, returning a canonical v6 literal strictly
+  inside `prefix_cidr`. Deterministic and idempotent for a given
+  `(key, prefix_cidr)`.
+
+  Returns `{:error, :invalid_prefix}` when `prefix_cidr` is not a strict
+  IPv6 CIDR (`parse_cidr6/1` rejects it).
+  """
+  @spec derive(binary(), String.t()) :: {:ok, String.t()} | {:error, :invalid_prefix}
+  def derive(key, prefix_cidr) when is_binary(key) do
+    case IpLiteral.parse_cidr6(prefix_cidr) do
+      {:ok, {net_tuple, len}} ->
+        host_bits = 128 - len
+        <<net::size(len), _::bitstring>> = ip6_bits(net_tuple)
+        # SHA-256 is 256 bits ≥ host_bits (≤128) for any len, so this
+        # match holds for EVERY prefix length — no /8-alignment needed.
+        <<host::size(host_bits), _::bitstring>> = :crypto.hash(:sha256, @domain_tag <> key)
+        # net ‖ host is exactly 128 bits regardless of where `len` falls,
+        # so re-slice it straight into the 8×16 tuple (no integer round-trip).
+        <<a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>> =
+          <<net::size(len), host::size(host_bits)>>
+
+        {:ok, {a, b, c, d, e, f, g, h} |> :inet.ntoa() |> to_string()}
+
+      :error ->
+        {:error, :invalid_prefix}
+    end
+  end
+
+  @doc """
+  True when `addr` (a v6 literal) sits inside `prefix_cidr`. Any non-v6
+  address, malformed literal, or malformed prefix returns `false`. Used
+  by the INC-7 prefix-impact scan and the adapter's in-prefix guard.
+  """
+  @spec in_prefix?(String.t(), String.t()) :: boolean()
+  def in_prefix?(addr, prefix_cidr) do
+    with {:ok, {_, _, _, _, _, _, _, _} = addr_tuple} <- IpLiteral.to_tuple(addr),
+         {:ok, {net_tuple, len}} <- IpLiteral.parse_cidr6(prefix_cidr) do
+      <<addr_net::size(len), _::bitstring>> = ip6_bits(addr_tuple)
+      <<pfx_net::size(len), _::bitstring>> = ip6_bits(net_tuple)
+      addr_net == pfx_net
+    else
+      _ -> false
+    end
+  end
+
+  # ---- v6 bit helper (8×16 tuple → 128-bit binary) --------------------------
+  #
+  # Bitstring-space, distinct from IpLiteral's integer-space helpers: the
+  # network/host split lands on arbitrary (non-byte) bit boundaries, which
+  # the shift-based `IpLiteral.mask_prefix/2` can't express.
+
+  defp ip6_bits({a, b, c, d, e, f, g, h}),
+    do: <<a::16, b::16, c::16, d::16, e::16, f::16, g::16, h::16>>
+end

--- a/test/grappa/vhosts/source_mapping_test.exs
+++ b/test/grappa/vhosts/source_mapping_test.exs
@@ -1,0 +1,160 @@
+defmodule Grappa.Vhosts.SourceMappingTest do
+  @moduledoc """
+  Unit + property tests for the #543 static-mapping derivation.
+
+  `SourceMapping.derive/2` maps a client's `/64` (v6) or `/32` (v4) to a
+  deterministic address inside the configured `::cb::/80`. The invariants
+  under test are the ones the whole feature leans on: determinism,
+  interface-id insensitivity (RFC 8981 — a roaming client keeps ONE
+  outbound address), the network bits pinning inside the prefix, IPv4
+  collapse onto the `/32`, and collision-freedom across a large sample.
+  """
+
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Grappa.Vhosts.SourceMapping
+
+  @prefix "2a03:4000:20:2d3:cb::/80"
+
+  # ---------------------------------------------------------------------------
+  # Unit — determinism / inside-prefix / interface-id insensitivity
+  # ---------------------------------------------------------------------------
+
+  test "derive is deterministic and lands inside the prefix" do
+    {:ok, ip} = SourceMapping.derive(SourceMapping.client_key({0x2001, 0xDB8, 1, 2, 3, 4, 5, 6}), @prefix)
+    {:ok, ip2} = SourceMapping.derive(SourceMapping.client_key({0x2001, 0xDB8, 1, 2, 0, 0, 0, 0}), @prefix)
+
+    # same /64, different interface id → SAME address (RFC 8981)
+    assert ip == ip2
+    assert SourceMapping.in_prefix?(ip, @prefix)
+  end
+
+  test "distinct /64 → distinct address; the /80 network bits are fixed" do
+    {:ok, a} = SourceMapping.derive(SourceMapping.client_key({0x2001, 0xDB8, 1, 2, 0, 0, 0, 0}), @prefix)
+    {:ok, b} = SourceMapping.derive(SourceMapping.client_key({0x2001, 0xDB8, 1, 3, 0, 0, 0, 0}), @prefix)
+
+    refute a == b
+    assert String.starts_with?(a, "2a03:4000:20:2d3:cb:")
+    assert String.starts_with?(b, "2a03:4000:20:2d3:cb:")
+  end
+
+  test "IPv4 collapses on the /32 and lands inside the prefix" do
+    k = SourceMapping.client_key({203, 0, 113, 7})
+    {:ok, a} = SourceMapping.derive(k, @prefix)
+    {:ok, a2} = SourceMapping.derive(SourceMapping.client_key({203, 0, 113, 7}), @prefix)
+
+    assert a == a2
+    assert SourceMapping.in_prefix?(a, @prefix)
+    assert String.starts_with?(a, "2a03:4000:20:2d3:cb:")
+  end
+
+  test "a /128 prefix degenerates to the prefix address itself" do
+    prefix128 = "2a03:4000:20:2d3:cb::1/128"
+    {:ok, a} = SourceMapping.derive(SourceMapping.client_key({0x2001, 0xDB8, 1, 2, 0, 0, 0, 0}), prefix128)
+    {:ok, b} = SourceMapping.derive(SourceMapping.client_key({0x2001, 0xDB8, 9, 9, 0, 0, 0, 0}), prefix128)
+
+    # host_bits == 0 → hash contributes nothing; every client derives the prefix host.
+    assert a == b
+    assert a == "2a03:4000:20:2d3:cb::1"
+    assert SourceMapping.in_prefix?(a, prefix128)
+  end
+
+  test "client_key ignores the v6 interface id (folds to the /64)" do
+    assert SourceMapping.client_key({0x2001, 0xDB8, 1, 2, 0xAAAA, 0xBBBB, 0xCCCC, 0xDDDD}) ==
+             SourceMapping.client_key({0x2001, 0xDB8, 1, 2, 0, 0, 0, 0})
+
+    assert byte_size(SourceMapping.client_key({0x2001, 0xDB8, 1, 2, 0, 0, 0, 0})) == 8
+    assert byte_size(SourceMapping.client_key({203, 0, 113, 7})) == 4
+  end
+
+  # ---------------------------------------------------------------------------
+  # Unit — error / boundary handling
+  # ---------------------------------------------------------------------------
+
+  test "derive rejects a malformed or non-v6 prefix" do
+    assert {:error, :invalid_prefix} = SourceMapping.derive(<<0, 0, 0, 0, 0, 0, 0, 0>>, "not-a-cidr")
+    assert {:error, :invalid_prefix} = SourceMapping.derive(<<0, 0, 0, 0, 0, 0, 0, 0>>, "2a03:4000:20:2d3:cb::")
+    assert {:error, :invalid_prefix} = SourceMapping.derive(<<0, 0, 0, 0, 0, 0, 0, 0>>, "203.0.113.0/24")
+  end
+
+  test "in_prefix? is false for an address outside the prefix or a bad input" do
+    refute SourceMapping.in_prefix?("2a03:4000:20:2d3:ffff::1", @prefix)
+    refute SourceMapping.in_prefix?("203.0.113.7", @prefix)
+    refute SourceMapping.in_prefix?("not-an-ip", @prefix)
+    refute SourceMapping.in_prefix?("2a03:4000:20:2d3:cb::1", "not-a-cidr")
+  end
+
+  # ---------------------------------------------------------------------------
+  # Collision-freedom — 100k distinct /64s derive to 100k distinct addresses
+  # ---------------------------------------------------------------------------
+
+  test "100k distinct /64s derive to 100k distinct addresses (no in-sample collision)" do
+    derived =
+      for i <- 1..100_000, into: MapSet.new() do
+        key = SourceMapping.client_key({0x2001, 0xDB8, div(i, 0x10000), rem(i, 0x10000), 0, 0, 0, 0})
+        {:ok, ip} = SourceMapping.derive(key, @prefix)
+        ip
+      end
+
+    assert MapSet.size(derived) == 100_000
+  end
+
+  # ---------------------------------------------------------------------------
+  # Property — StreamData
+  # ---------------------------------------------------------------------------
+
+  property "any v6 /64 derives inside the prefix, interface-id-stable and idempotent" do
+    group = StreamData.integer(0..0xFFFF)
+
+    check all(
+            net <- StreamData.list_of(group, length: 4),
+            iface_a <- StreamData.list_of(group, length: 4),
+            iface_b <- StreamData.list_of(group, length: 4)
+          ) do
+      tuple_a = List.to_tuple(net ++ iface_a)
+      tuple_b = List.to_tuple(net ++ iface_b)
+
+      {:ok, ip_a} = SourceMapping.derive(SourceMapping.client_key(tuple_a), @prefix)
+      {:ok, ip_a2} = SourceMapping.derive(SourceMapping.client_key(tuple_a), @prefix)
+      {:ok, ip_b} = SourceMapping.derive(SourceMapping.client_key(tuple_b), @prefix)
+
+      assert SourceMapping.in_prefix?(ip_a, @prefix)
+      assert ip_a == ip_a2, "derive must be idempotent"
+      assert ip_a == ip_b, "different interface id on the same /64 must derive the same address"
+    end
+  end
+
+  property "any prefix length 0..128 derives a valid in-prefix address (no /8-alignment)" do
+    group = StreamData.integer(0..0xFFFF)
+
+    check all(
+            net_groups <- StreamData.list_of(group, length: 8),
+            key_tuple <- StreamData.list_of(group, length: 8),
+            len <- StreamData.integer(0..128)
+          ) do
+      # Random, deliberately non-/8-aligned lengths (/70, /83, /50, /0 …):
+      # the whole module rests on derive/2 not MatchError-ing on a
+      # non-byte host_bits and still landing strictly inside the prefix.
+      prefix = (net_groups |> List.to_tuple() |> :inet.ntoa() |> to_string()) <> "/#{len}"
+      key = SourceMapping.client_key(List.to_tuple(key_tuple))
+
+      assert {:ok, ip} = SourceMapping.derive(key, prefix)
+      assert SourceMapping.in_prefix?(ip, prefix)
+    end
+  end
+
+  property "any v4 /32 derives inside the prefix, deterministically" do
+    octet = StreamData.integer(0..255)
+
+    check all(v4 <- StreamData.list_of(octet, length: 4)) do
+      key = SourceMapping.client_key(List.to_tuple(v4))
+      {:ok, ip} = SourceMapping.derive(key, @prefix)
+      {:ok, ip2} = SourceMapping.derive(key, @prefix)
+
+      assert SourceMapping.in_prefix?(ip, @prefix)
+      assert ip == ip2
+      assert String.starts_with?(ip, "2a03:4000:20:2d3:cb:")
+    end
+  end
+end


### PR DESCRIPTION
## INC-2 of #543 — pure derivation module

Second increment of static-mapping outbound addressing. Adds `Grappa.Vhosts.SourceMapping`, a **pure** module that maps an untrusted subject's client prefix to ONE deterministic outbound address inside the configured `::cb::/80`. This is what replaces the random pool in mode 2 (wired up in INC-4/6).

Stacks on INC-1 (#562, now merged to main).

### Surface
- `client_key/1` — folds a v6 IP to its `/64` (interface id dropped, RFC 8981) or a v4 IP to its `/32`. This is the mapping key.
- `derive/2` — `sha256(@domain_tag <> key)` fills the host bits of the prefix; returns a canonical v6 literal strictly inside it. Deterministic + idempotent.
- `in_prefix?/2` — v6-only membership test (false on v4 / malformed input / malformed prefix). Feeds the INC-7 prefix-impact scan.

### Locked design decisions (#543)
- Key on the routable prefix, not the full address — a roaming client keeps ONE egress; NAT/CGNAT collapse is intended.
- Hash is **unkeyed** — reversibility is irrelevant, collision-freedom is the only property that matters; `@domain_tag` is namespace separation, not a secret.
- Reservations live OUTSIDE `::cb`, so a derived address never shadows a reserved one.

### Implementation note
`derive/2` extracts host bits via bitstring pattern (`<<host::size(host_bits), _::bitstring>>`) rather than a byte-aligned `:binary.part` slice, and re-slices `net‖host` straight into the 8×16 tuple with no integer round-trip — so it holds for EVERY prefix length (not just `/8`-aligned) and duplicates no bit helper from `IpLiteral`.

### Tests
Unit (determinism, interface-id insensitivity, IPv4 collapse, `/128` degenerate, invalid-prefix + out-of-prefix rejection) + a 100k distinct-`/64` injectivity check + StreamData properties over random v6 `/64`s, v4 `/32`s, and **arbitrary non-`/8`-aligned prefix lengths 0..128** (inside-prefix, interface-id-stable, idempotent).

### Gates
- Full `scripts/check.sh` — **exit 0** (`ok 152` bats tail), run twice (pre- and post-review-fix).
- Code review: `10x-engineer:code-reviewer`, synchronous — verdict *correctness CLEAN*; two nice-to-have items (arbitrary-length property gap + a duplicated bit helper) both applied before this push.