### PR TITLE
feat(#557): /kill slash command (cicchetto)

### DIFF
--- a/cicchetto/e2e/tests/issue557-kill-slash-wiring.spec.ts
+++ b/cicchetto/e2e/tests/issue557-kill-slash-wiring.spec.ts
@@ -1,0 +1,133 @@
+// Issue #557 — /kill <nick> [reason] first-class operator KILL (cicchetto-ONLY).
+//
+// The TWIN of #375 (/rehash <option>) and #155 (/stats): the grappa side is a
+// clean raw passthrough — `/kill` rides the `pushRaw` transport and grappa's
+// `handle_in("raw", …)` ships the line VERBATIM via `Session.send_raw`
+// (grappa_channel.ex). All of #557 lives in cic: the slash parser gains a
+// `kill` verb and compose composes `KILL <nick> :<reason>`, composing the
+// trailing colon DOWNSTREAM so a multi-word reason stays one param instead of
+// truncating at the first space (the `/quote KILL nick reason` foot-gun where a
+// forgotten colon silently drops everything after the first word).
+//
+// OBSERVABLE — the raw outbound frame. As #375 established, the unforgeable
+// evidence is the raw frame cic SENDS: `pushRaw` ships `["raw",{network_id,
+// line}]` over the Phoenix WS, and `line` is exactly what grappa forwards to
+// the ircd. We capture every `framesent` and assert the reason rides `line`
+// behind the trailing colon. We do NOT oper (and MUST NOT — an OPER'd KILL
+// would actually disconnect a session): a non-oper's KILL gets 481 back, kept
+// as a belt-and-suspenders witness that the frame genuinely reached upstream
+// (matched leniently to tolerate whichever check bahamut's m_kill runs first).
+//
+// RED pre-fix: no `kill` verb → `/kill …` is an unknown command → NO raw frame
+// is ever sent → the "KILL spammer :flooding the channel" assertion times out.
+// GREEN post-fix: `/kill spammer flooding the channel` sends
+// `line: "KILL spammer :flooding the channel"`; bare `/kill spammer` sends
+// exactly `"KILL spammer"` (no trailing colon, no stray null/space).
+
+import { expect, test } from "../fixtures/test";
+import {
+  composeSend,
+  expectShellReady,
+  scrollbackLine,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
+import { adminDeleteVisitor, mintVisitor } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+
+// A non-oper KILL reply. bahamut's m_kill rejects a non-oper (481
+// ERR_NOPRIVILEGES) — routed to `$server` by the numeric_router :scan
+// fallback, same path #375 relies on. Matched leniently (permission-denied OR
+// no-such-nick) so the witness holds regardless of whether bahamut checks the
+// oper privilege or the target's existence first — the frame capture below is
+// the primary, order-independent proof; this only witnesses upstream delivery.
+const UPSTREAM_REPLY_TEXT = /permission denied|no such nick|isn't on your screen/i;
+
+test("issue #557 — /kill <nick> <reason> ships KILL nick :reason on the raw wire, bare /kill has no colon", async ({
+  browser,
+}) => {
+  const admin = getSeededAdmin();
+  const visitorNick = `v557-${Date.now()}`;
+  const visitor = await mintVisitor(visitorNick);
+
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+
+  // Every raw `line` cic ships upstream via pushRaw. Phoenix v2 frames are
+  // JSON arrays `[join_ref, ref, topic, "raw", {network_id, line}]`; guard on
+  // `"raw"` then pull out `line`. Attached BEFORE goto so we catch the app WS
+  // from the moment it opens (and any reconnect). Mirrors #375.
+  const sentRawLines: string[] = [];
+  page.on("websocket", (ws) => {
+    ws.on("framesent", ({ payload }) => {
+      if (typeof payload !== "string" || !payload.includes('"raw"')) return;
+      const m = payload.match(/"line":"([^"]*)"/);
+      if (m) sentRawLines.push(m[1]);
+    });
+  });
+
+  try {
+    const visitorSubject = {
+      kind: "visitor",
+      id: visitor.id,
+      nick: visitor.nick,
+      network_slug: visitor.network_slug,
+    };
+
+    // Boot cic straight into Shell as the visitor (no captcha/anon dance),
+    // exactly like #375/#155/#148.
+    await page.addInitScript(
+      ([token, subjectJson]) => {
+        localStorage.setItem("grappa-token", token);
+        localStorage.setItem("grappa-subject", subjectJson);
+        localStorage.setItem("cic.installChoice", "browser");
+      },
+      [visitor.token, JSON.stringify(visitorSubject)] as const,
+    );
+    await page.goto("/");
+    await expectShellReady(page);
+
+    // Focus the visitor's $server window and wait for the upstream registration
+    // numerics (:notice rows) — proves the session is connected and the pane is
+    // live, so the reply numeric won't race an empty pane.
+    await selectChannel(page, visitor.network_slug, "Server", { awaitWsReady: false });
+    await expect(
+      page.locator('[data-testid="scrollback-line"][data-kind="notice"]').first(),
+    ).toBeVisible({ timeout: 20_000 });
+
+    // (1) THE FIX — /kill <nick> <multi-word reason> must ship
+    // `KILL spammer :flooding the channel` on the raw wire. The trailing colon
+    // (composed downstream) keeps the whole reason as one param. Pre-fix `kill`
+    // is an unknown command → no raw frame at all → this times out.
+    await composeSend(page, "/kill spammer flooding the channel");
+    await expect
+      .poll(() => sentRawLines, {
+        timeout: 15_000,
+        message: "raw frame 'KILL spammer :flooding the channel' not sent",
+      })
+      .toContain("KILL spammer :flooding the channel");
+
+    // …and it genuinely reached upstream: the non-oper gets a reply back, the
+    // server's response to the frame we shipped, rendered as a :notice in
+    // $server. (A non-oper KILL is harmless — the ircd rejects it.)
+    await expect(scrollbackLine(page, "notice", UPSTREAM_REPLY_TEXT).first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // (2) REGRESSION GUARD — bare /kill (no reason) ships EXACTLY `KILL spammer`
+    // (no trailing colon, no stray null/space). The empty-reason branch must
+    // not leak a `KILL spammer :` or a stringified null into the frame.
+    await composeSend(page, "/kill spammer");
+    await expect
+      .poll(() => sentRawLines, { timeout: 15_000, message: "raw frame 'KILL spammer' not sent" })
+      .toContain("KILL spammer");
+    expect(
+      sentRawLines.some((l) => l === "KILL spammer :" || l.toLowerCase().includes("null")),
+    ).toBe(false);
+
+    // The native verb never surfaces the parser's unknown-command error.
+    await expect(page.getByText(/unknown command/i)).toHaveCount(0);
+  } finally {
+    await ctx.close();
+    await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+  }
+});

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -437,6 +437,36 @@ describe("compose submit — slash command dispatch", () => {
     expect(result).toEqual({ ok: true });
   });
 
+  // #557 — /kill <nick> <reason> composes `KILL <nick> :<reason>` and ships it
+  // via pushRaw (mirror of /quote/rehash). The trailing colon is added HERE,
+  // downstream — so a multi-word reason stays ONE param instead of truncating
+  // at the first space (the `/quote KILL nick reason` foot-gun #557 fixes). A
+  // regression in the ternary would ship green without this assertion.
+  it("/kill <nick> <reason> pushes KILL nick :reason via pushRaw (downstream colon)", async () => {
+    const socket = await import("../lib/socket");
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/kill spammer flooding the channel");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(socket.pushRaw).toHaveBeenCalledWith(1, "KILL spammer :flooding the channel");
+    expect(result).toEqual({ ok: true });
+  });
+
+  // #557 — bare /kill <nick> (no reason) ships EXACTLY `KILL <nick>`: the
+  // empty-reason branch of the ternary must NOT leak a trailing `:` or a
+  // stringified null into the frame.
+  it("/kill <nick> bare pushes KILL nick (no trailing colon) via pushRaw", async () => {
+    const socket = await import("../lib/socket");
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/kill spammer");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(socket.pushRaw).toHaveBeenCalledWith(1, "KILL spammer");
+    expect(result).toEqual({ ok: true });
+  });
+
   // #290 — a BARE services command opens the dedicated services console
   // modal (pinned to the active window's network) AND fires `help` so the
   // service's multi-NOTICE help wall lands confined in the modal instead of

--- a/cicchetto/src/__tests__/slashCommands.test.ts
+++ b/cicchetto/src/__tests__/slashCommands.test.ts
@@ -547,6 +547,31 @@ describe("parseSlash — channel ops verbs", () => {
     });
   });
 
+  // #557 — /kill <nick> [reason]: first-class operator KILL. Same grammar as
+  // /kick (first token = nick, remainder = reason), but the target is a NICK
+  // with NO channel — compose.ts composes `KILL <nick> :<reason>` and the
+  // trailing colon is added downstream, never typed by the user. Non-oper
+  // feedback is the server's 481; cic does NOT client-gate.
+  it("/kill <nick> bare (no reason)", () => {
+    expect(parseSlash("/kill spammer")).toEqual({ kind: "kill", nick: "spammer", reason: "" });
+  });
+
+  it("/kill <nick> <reason with spaces> (full reason, colon composed downstream)", () => {
+    expect(parseSlash("/kill spammer flooding the channel")).toEqual({
+      kind: "kill",
+      nick: "spammer",
+      reason: "flooding the channel",
+    });
+  });
+
+  it("/kill missing nick → error", () => {
+    expect(parseSlash("/kill")).toMatchObject({
+      kind: "error",
+      verb: "kill",
+      message: "/kill requires a nick",
+    });
+  });
+
   it("/banlist bare → banlist for the current channel (null)", () => {
     expect(parseSlash("/banlist")).toEqual({ kind: "banlist", channel: null });
   });

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -661,6 +661,26 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           result = { ok: true };
           break;
         }
+        // #557 — /kill <nick> [reason]: first-class operator KILL. Unlike
+        // /kick/kb this targets a NICK (no channel, no requireChannel) and
+        // ships a RAW frame via pushRaw, mirroring /quote — the server already
+        // accepts KILL through the raw passthrough (that is what operators do
+        // today with `/quote KILL ...`). The whole win is the trailing colon
+        // being composed HERE, downstream: `KILL <nick> :<reason>` keeps a
+        // multi-word reason intact instead of the /quote foot-gun where a
+        // forgotten `:` truncates the reason at its first space. A bare /kill
+        // (empty reason) sends `KILL <nick>` and lets the server answer (481
+        // for a non-oper, or the ircd's own missing-comment error). AWAIT the
+        // push so a WS-down / server {:error,_} surfaces as an inline compose
+        // alert, never a silent green ✓ (the #154 no-silent-drop lesson).
+        case "kill": {
+          const networkId = networkIdBySlug(networkSlug);
+          if (networkId === undefined) return { error: "/kill: network not found" };
+          const line = cmd.reason === "" ? `KILL ${cmd.nick}` : `KILL ${cmd.nick} :${cmd.reason}`;
+          await pushRaw(networkId, line);
+          result = { ok: true };
+          break;
+        }
         case "unban": {
           const chanOrErr = requireChannel("unban");
           if (typeof chanOrErr !== "string") return chanOrErr;

--- a/cicchetto/src/lib/slashCommands.ts
+++ b/cicchetto/src/lib/slashCommands.ts
@@ -118,6 +118,12 @@ export type SlashCommand =
   // from the server's userhost_cache, `*!*@host` fail-closed) followed by a
   // KICK — two frames, ban first, attempt both (vjt decisions #1/#4).
   | { kind: "kb"; nick: string; reason: string }
+  // #557 — /kill <nick> [reason]: first-class operator KILL, same grammar as
+  // /kick/kb (first token = nick, remainder = reason). Target is a NICK with
+  // NO channel; compose.ts composes `KILL <nick> :<reason>` and adds the
+  // trailing colon downstream (never typed by the user — the /quote foot-gun
+  // #557 fixes). No client permission-probe: the server's 481 is the feedback.
+  | { kind: "kill"; nick: string; reason: string }
   | { kind: "ban"; mask: string }
   | { kind: "unban"; mask: string }
   // #386 /banlist opens the ban-management modal. #536 — the list-mode
@@ -212,6 +218,23 @@ function parseNicksVerb(kind: NicksVerbKind, rest: string): SlashCommand {
   const nicks = tokens(rest);
   if (nicks.length === 0) return err(kind, `/${kind} requires at least one nick`);
   return { kind, nicks };
+}
+
+// #557 — shared grammar for the nick-then-optional-reason verbs (/kick, /kb,
+// /kill): first whitespace-delimited token is the nick, the trimmed remainder
+// is the (optional) reason. `kind` is the discriminated-union literal (as
+// `parseNicksVerb` does) so we never re-cast the loose `verb` string back to the
+// narrow set; `verb` supplies the error copy so an alias (/kickban) names what
+// the user typed. #557 collapsed the three copy-pasted handlers into this one
+// (kick/kb predate it — the divergent copy-paste CLAUDE.md forbids).
+type NickReasonKind = "kick" | "kb" | "kill";
+
+function parseNickReason(kind: NickReasonKind, verb: string, rest: string): SlashCommand {
+  if (rest === "") return err(verb, `/${verb} requires a nick`);
+  const sp = rest.search(/\s/);
+  const nick = sp === -1 ? rest : rest.slice(0, sp);
+  const reason = sp === -1 ? "" : rest.slice(sp + 1).trim();
+  return { kind, nick, reason };
 }
 
 // #356 — presence-watch parser, shared by /notify + /watch (alias).
@@ -402,24 +425,19 @@ const DISPATCH: Readonly<Record<string, Handler>> = {
   voice: (_verb, rest) => parseNicksVerb("voice", rest),
   devoice: (_verb, rest) => parseNicksVerb("devoice", rest),
 
-  kick: (verb, rest) => {
-    const sp = rest.search(/\s/);
-    if (rest === "") return err(verb, "/kick requires a nick");
-    const nick = sp === -1 ? rest : rest.slice(0, sp);
-    const reason = sp === -1 ? "" : rest.slice(sp + 1).trim();
-    return { kind: "kick", nick, reason };
-  },
+  kick: (verb, rest) => parseNickReason("kick", verb, rest),
 
   // #386 — /kb <nick> [reason] kickban. First token is the nick, the rest is
   // the (optional) reason — identical grammar to /kick. The ban-mask build
   // (`*!*@host` fail-closed) + MODE+KICK sequencing live in compose.ts.
-  kb: (verb, rest) => {
-    const sp = rest.search(/\s/);
-    if (rest === "") return err(verb, "/kb requires a nick");
-    const nick = sp === -1 ? rest : rest.slice(0, sp);
-    const reason = sp === -1 ? "" : rest.slice(sp + 1).trim();
-    return { kind: "kb", nick, reason };
-  },
+  kb: (verb, rest) => parseNickReason("kb", verb, rest),
+
+  // #557 — /kill <nick> [reason] operator KILL. Same nick-then-reason grammar
+  // as /kick/kb, but no channel — the target is a NICK. compose.ts composes
+  // `KILL <nick> :<reason>` (trailing colon added downstream) and ships it via
+  // pushRaw, mirroring /quote. A non-oper gets the server's 481; cic does not
+  // client-gate (issue #557 out-of-scope: no /gline, no confirm dialog).
+  kill: (verb, rest) => parseNickReason("kill", verb, rest),
 
   ban: (verb, rest) => {
     const [mask] = tokens(rest);


### PR DESCRIPTION
## What & why — Refs #557

cicchetto gains a first-class `/kill <nick> [reason]` slash command. Today the
only route to KILL is `/quote KILL nick :reason`, which forces the operator to
hand-write the trailing colon. Forget it and the reason **truncates at the
first space** — a still-valid wire frame, so no error, just a kill logged with
a one-word reason. Recurring foot-gun for daily-driver opers (requested by an
operator, approved by @vjt).

## Change (cic-only)

- **Parser** (`slashCommands.ts`): new `kill` verb + `{kind:"kill";nick;reason}`
  union member. Same grammar as `/kick` (first token = nick, remainder = reason).
- **Compose** (`compose.ts`): `case "kill"` composes `KILL <nick> :<reason>` and
  ships it via `pushRaw`, mirroring `/quote`/`/stats`/`/rehash`. **The trailing
  colon is composed downstream**, never typed by the user → a multi-word reason
  stays one param. Bare `/kill nick` → `KILL nick`. No server change (the raw
  passthrough already carries KILL). No client permission-probe / confirm
  dialog — a non-oper gets the server's 481, the correct feedback path.
- **DRY**: the nick-then-reason grammar was copy-pasted across `/kick` + `/kb`;
  a third copy for `/kill` would compound the divergence CLAUDE.md forbids, so
  all three now share one `parseNickReason/3` helper (precedent:
  `parseNicksVerb` for op/deop/voice/devoice). Behavior-preserving on every
  tested path.

Out of scope (per issue): `/gline`, `/akill`, services wrappers. `/quote` unchanged.

## TDD — literal RED before impl

Failing vitest run BEFORE the implementation (parser had no `kill` verb):

```
FAIL src/__tests__/slashCommands.test.ts > parseSlash — channel ops verbs > /kill missing nick → error
AssertionError: expected { kind: 'error', … } to match object { kind: 'error', … }
- Expected   "message": "/kill requires a nick"
+ Received   "message": "unknown command: /kill"

 Test Files  1 failed (1)
      Tests  3 failed | 198 passed (201)
```

## GREEN evidence

- **vitest (full):** `Test Files 205 passed (205)` · `Tests 3652 passed (3652)` · exit 0
- **biome:** 0 errors (28 pre-existing CSS warnings in `default.css`, untouched) · exit 0
- **tsc `--noEmit`:** clean

## Test coverage

- `slashCommands.test.ts`: bare / multi-word-reason / missing-nick (RED-first).
- `compose.test.ts`: **both** pushRaw branches — `KILL spammer :flooding the channel`
  vs bare `KILL spammer` (mirrors the `/rehash` pair; the empty-reason ternary is
  the one piece of genuinely new logic).
- `e2e/tests/issue557-kill-slash-wiring.spec.ts`: chromium wiring e2e — types
  `/kill`, captures the outbound raw frame off the Phoenix WS, asserts the colon
  rides `line`, with a lenient upstream-reply witness. **Runs in the E2E/STACK
  lane (real testnet ircd) — not run locally here; CI/lane to verify.**

## Review

One code-review pass (10x-engineer:code-reviewer). Addressed: added the compose
unit tests it flagged as the untested payload logic; corrected the commit-message
"zero behavior change" claim (the `/kickban` bare error now names the verb typed
— a deliberate, benign improvement). Leading-colon-in-reason left unstripped =
consistent with `/kick`/`/kb` (a cross-verb strip would need a separate call).

---
**NOT merged, NOT deployed.** @vjt merges on CI settled-green.