### PR TITLE
feat(#543): persist last client /64 per subject (INC-3 A+B)

### DIFF
--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -62,6 +62,9 @@ defmodule Grappa.UserSettings do
   |                        |                        | `put_display_prefs/2`,          |
   |                        |                        | `display_prefs_persisted?/1`    |
   |                        |                        | (#449)                          |
+  | `"last_client_prefix64"`| `String.t() \\| nil`  | `get_last_client_prefix64/1`,   |
+  |                        | (opaque base16)        | `put_last_client_prefix64/2`    |
+  |                        |                        | (#543)                          |
 
   ## Boundary
 
@@ -157,6 +160,14 @@ defmodule Grappa.UserSettings do
   @display_prefs_key "display_prefs"
   @display_time_formats ~w(hms hm)
   @display_presence_values ~w(show hide)
+
+  # #543 — the subject's last-known client network prefix key, sampled at
+  # client-connect and read at upstream-connect for the static_mapping
+  # addressing mode. The value is an OPAQUE base16 string here (a raw
+  # `client_key` binary is not JSON-safe); `Grappa.Vhosts` owns the
+  # client_key/base16 domain logic — this module is a dumb string store,
+  # mirroring the `vhost_selection` split.
+  @last_client_prefix64_key "last_client_prefix64"
 
   # Structural bounds for aliases — a user-writable JSON blob needs a boundary
   # or it becomes an unbounded storage/DOS vector (same rationale as
@@ -523,6 +534,70 @@ defmodule Grappa.UserSettings do
         %Settings{}
         |> Settings.changeset(attrs)
         |> Ecto.Changeset.add_error(:data, "vhost_selection elements must be non-empty strings")
+
+      {:error, cs}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # last_client_prefix64 accessor (#543 — dumb base16 string store)
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Returns the subject's last-known client prefix key as the RAW opaque
+  base16 string, or `nil` when no row exists, the key is absent, or the
+  stored value is malformed (not a non-empty binary).
+
+  This is a dumb string store — decoding the base16 back to the raw
+  `client_key` binary is `Grappa.Vhosts.last_client_prefix64/1`'s job.
+  Side-effect-free; reads the string key (`:map` JSON round-trip).
+  """
+  @spec get_last_client_prefix64(Subject.t()) :: String.t() | nil
+  def get_last_client_prefix64({_, _} = subject) do
+    case fetch_existing_or_nil(subject) do
+      nil ->
+        nil
+
+      %Settings{data: data} ->
+        case data[@last_client_prefix64_key] do
+          s when is_binary(s) and byte_size(s) > 0 -> s
+          _ -> nil
+        end
+    end
+  end
+
+  @doc """
+  Persists the subject's last-known client prefix key (an opaque base16
+  string), preserving other keys in `data` (merge semantics). Validates
+  the value is a non-empty base16 string; the client_key → base16
+  encoding is `Grappa.Vhosts.record_client_source/2`'s responsibility.
+  Last-write-wins (a roam replaces the stored key).
+  """
+  @spec put_last_client_prefix64(Subject.t(), String.t()) ::
+          {:ok, Settings.t()} | {:error, Ecto.Changeset.t()}
+  def put_last_client_prefix64({_, _} = subject, hex) when is_binary(hex) do
+    with :ok <- validate_base16(hex, subject),
+         {:ok, settings} <- get_or_init(subject) do
+      merged_data = Map.put(settings.data, @last_client_prefix64_key, hex)
+      cs = Settings.changeset(settings, %{data: merged_data})
+      Repo.update(cs)
+    end
+  end
+
+  @spec validate_base16(String.t(), Subject.t()) :: :ok | {:error, Ecto.Changeset.t()}
+  defp validate_base16(hex, subject) do
+    if byte_size(hex) > 0 and match?({:ok, _}, Base.decode16(hex)) do
+      :ok
+    else
+      attrs = Subject.put_subject_id(%{data: %{}}, subject)
+
+      cs =
+        %Settings{}
+        |> Settings.changeset(attrs)
+        |> Ecto.Changeset.add_error(
+          :last_client_prefix64,
+          "must be a non-empty base16 string"
+        )
 
       {:error, cs}
     end

--- a/lib/grappa/vhosts.ex
+++ b/lib/grappa/vhosts.ex
@@ -81,7 +81,9 @@ defmodule Grappa.Vhosts do
   import Ecto.Query
 
   alias Grappa.{Repo, Subject, UserSettings}
-  alias Grappa.Vhosts.{Grant, Vhost}
+  alias Grappa.Vhosts.{Grant, SourceMapping, Vhost}
+
+  require Logger
 
   # ---------------------------------------------------------------------------
   # Inventory CRUD
@@ -343,6 +345,68 @@ defmodule Grappa.Vhosts do
     case get_selection(subject) do
       [] -> nil
       selected -> Enum.random(selected)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Client-source capture (#543 INC-3 — last-known client /64 per subject)
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Records the subject's client network prefix, sampled from `remote_ip`
+  at client-connect.
+
+  Normalises the IP to its `/64` (v6) or `/32` (v4) mapping key via
+  `SourceMapping.client_key/1` (interface id dropped, RFC 8981) and
+  persists it base16 in `UserSettings`. Idempotent per connect;
+  last-write-wins on roam. Read back at upstream-connect by
+  `last_client_prefix64/1` when no client is attached then — the #543
+  mode-2 (`static_mapping_with_reservations`) "last-known /64" fallback.
+
+  Always returns `:ok`: a capture failure must never fail the client
+  connect. A persist error (e.g. the subject row vanished mid-connect)
+  is best-effort but LOGGED, never silently swallowed (CLAUDE.md
+  boundary rule).
+  """
+  @spec record_client_source(Subject.t(), :inet.ip_address()) :: :ok
+  def record_client_source({_, _} = subject, remote_ip) do
+    hex = Base.encode16(SourceMapping.client_key(remote_ip))
+
+    case UserSettings.put_last_client_prefix64(subject, hex) do
+      {:ok, _} ->
+        :ok
+
+      {:error, changeset} ->
+        Logger.warning(
+          "record_client_source: failed to persist client prefix for " <>
+            "#{inspect(subject)} — #{inspect(changeset.errors)}"
+        )
+
+        :ok
+    end
+  end
+
+  @doc """
+  The subject's last-known client prefix key — the RAW decoded `/64`|`/32`
+  binary — or `nil` when the subject was never seen OR the stored value is
+  malformed.
+
+  Decodes the base16 string `record_client_source/2` persisted. A decode
+  failure (a miscoded writer) falls back to `nil` rather than raising
+  (`Base.decode16/1`, never `decode16!/1`). The returned binary equals
+  `SourceMapping.client_key/1` of the originally-recorded IP.
+  """
+  @spec last_client_prefix64(Subject.t()) :: binary() | nil
+  def last_client_prefix64({_, _} = subject) do
+    case UserSettings.get_last_client_prefix64(subject) do
+      nil ->
+        nil
+
+      hex ->
+        case Base.decode16(hex) do
+          {:ok, key} -> key
+          :error -> nil
+        end
     end
   end
 

--- a/test/grappa/user_settings_test.exs
+++ b/test/grappa/user_settings_test.exs
@@ -810,4 +810,77 @@ defmodule Grappa.UserSettingsTest do
       assert UserSettings.get_aliases({:visitor, visitor.id}) == %{"wii" => "whois $1 $1"}
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # last_client_prefix64 accessors (#543 INC-3 — dumb base16 string store)
+  # ---------------------------------------------------------------------------
+
+  describe "get/put_last_client_prefix64 — opaque base16 string store" do
+    test "round-trips a base16 string" do
+      user = user_fixture()
+      hex = Base.encode16(<<0x20, 0x01, 0x0D, 0xB8, 0, 1, 0, 2>>)
+
+      assert {:ok, _} = UserSettings.put_last_client_prefix64({:user, user.id}, hex)
+      assert UserSettings.get_last_client_prefix64({:user, user.id}) == hex
+    end
+
+    test "last write wins (roam) — the putter replaces, not appends" do
+      user = user_fixture()
+      first = Base.encode16(<<1, 2, 3, 4>>)
+      second = Base.encode16(<<5, 6, 7, 8>>)
+
+      {:ok, _} = UserSettings.put_last_client_prefix64({:user, user.id}, first)
+      {:ok, _} = UserSettings.put_last_client_prefix64({:user, user.id}, second)
+      assert UserSettings.get_last_client_prefix64({:user, user.id}) == second
+    end
+
+    test "get returns nil when no settings row exists" do
+      user = user_fixture()
+      assert UserSettings.get_last_client_prefix64({:user, user.id}) == nil
+    end
+
+    test "get returns nil when the row exists but the key is absent" do
+      user = user_fixture()
+      {:ok, _} = UserSettings.get_or_init({:user, user.id})
+      assert UserSettings.get_last_client_prefix64({:user, user.id}) == nil
+    end
+
+    test "get returns nil for a malformed (non-string) stored value" do
+      user = user_fixture()
+      {:ok, settings} = UserSettings.get_or_init({:user, user.id})
+      # Bypass the typed putter to inject a bad shape (a miscoded writer).
+      {:ok, _} =
+        Repo.update(Settings.changeset(settings, %{data: %{"last_client_prefix64" => 123}}))
+
+      assert UserSettings.get_last_client_prefix64({:user, user.id}) == nil
+    end
+
+    test "put rejects an empty string" do
+      user = user_fixture()
+      assert {:error, %Ecto.Changeset{}} = UserSettings.put_last_client_prefix64({:user, user.id}, "")
+    end
+
+    test "put rejects a non-base16 string" do
+      user = user_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               UserSettings.put_last_client_prefix64({:user, user.id}, "not-hex-zz")
+    end
+
+    test "put preserves other data keys (highlight_patterns)" do
+      user = user_fixture()
+      {:ok, _} = UserSettings.set_highlight_patterns({:user, user.id}, ["foo", "bar"])
+
+      {:ok, _} = UserSettings.put_last_client_prefix64({:user, user.id}, Base.encode16(<<9, 9>>))
+      assert UserSettings.get_highlight_patterns({:user, user.id}) == ["foo", "bar"]
+    end
+
+    test "works for visitor subjects (visitor-parity)" do
+      visitor = visitor_fixture()
+      hex = Base.encode16(<<0xCA, 0xFE>>)
+
+      assert {:ok, _} = UserSettings.put_last_client_prefix64({:visitor, visitor.id}, hex)
+      assert UserSettings.get_last_client_prefix64({:visitor, visitor.id}) == hex
+    end
+  end
 end

--- a/test/grappa/vhosts_test.exs
+++ b/test/grappa/vhosts_test.exs
@@ -7,8 +7,11 @@ defmodule Grappa.VhostsTest do
   use Grappa.DataCase, async: true
 
   import Grappa.AuthFixtures
+  import ExUnit.CaptureLog
 
-  alias Grappa.Vhosts
+  alias Grappa.{Repo, UserSettings, Vhosts}
+  alias Grappa.UserSettings.Settings
+  alias Grappa.Vhosts.SourceMapping
 
   # Unique v6 literal — mask the counter into a single valid hextet
   # (0..0xffff) so the strict-literal changeset always accepts it.
@@ -254,6 +257,75 @@ defmodule Grappa.VhostsTest do
     test "an empty fixed-source list is the full in_pool set" do
       {:ok, a} = Vhosts.create_vhost(%{address: addr(), in_pool: true})
       assert a.address in Vhosts.effective_pool([])
+    end
+  end
+
+  # #543 INC-3 — capture the subject's last-known client /64 at connect so the
+  # mode-2 (static_mapping) derivation has a source when no client is attached
+  # at upstream-connect. Vhosts owns the domain logic (client_key + base16);
+  # UserSettings stays a dumb string store.
+  describe "record_client_source/2 + last_client_prefix64/1" do
+    test "record_client_source persists the /64 key and last write wins" do
+      subject = {:user, user_fixture().id}
+
+      :ok = Vhosts.record_client_source(subject, {0x2001, 0xDB8, 1, 2, 9, 9, 9, 9})
+      # Interface id (last 4 hextets) is dropped — the stored key is the /64.
+      assert Vhosts.last_client_prefix64(subject) ==
+               SourceMapping.client_key({0x2001, 0xDB8, 1, 2, 0, 0, 0, 0})
+
+      # Roam to a different /64 → last write wins.
+      :ok = Vhosts.record_client_source(subject, {0x2001, 0xDB8, 1, 3, 0, 0, 0, 0})
+
+      assert Vhosts.last_client_prefix64(subject) ==
+               SourceMapping.client_key({0x2001, 0xDB8, 1, 3, 0, 0, 0, 0})
+    end
+
+    test "record_client_source stores the /32 for a v4 client" do
+      subject = {:user, user_fixture().id}
+
+      :ok = Vhosts.record_client_source(subject, {203, 0, 113, 7})
+      assert Vhosts.last_client_prefix64(subject) == SourceMapping.client_key({203, 0, 113, 7})
+    end
+
+    test "last_client_prefix64 is nil for a never-seen subject" do
+      assert Vhosts.last_client_prefix64({:user, user_fixture().id}) == nil
+    end
+
+    test "last_client_prefix64 is nil when the stored value is not valid base16" do
+      subject = {:user, user_fixture().id}
+      {:ok, settings} = UserSettings.get_or_init(subject)
+
+      # A miscoded writer bypasses the validated putter — a non-empty, non-base16
+      # string reaches Vhosts, whose Base.decode16/1 (never decode16!/1) must
+      # fall back to nil rather than raise.
+      {:ok, _} =
+        Repo.update(Settings.changeset(settings, %{data: %{"last_client_prefix64" => "ZZZZ"}}))
+
+      assert Vhosts.last_client_prefix64(subject) == nil
+    end
+
+    test "record_client_source returns :ok and LOGS when the subject row is gone" do
+      # No backing row → put_last_client_prefix64 returns {:error, cs}. The
+      # capture must NEVER fail the connect (returns :ok), but must not silently
+      # swallow the error (CLAUDE.md boundary rule → LOGGED).
+      subject = {:user, Ecto.UUID.generate()}
+
+      log =
+        capture_log(fn ->
+          assert :ok = Vhosts.record_client_source(subject, {203, 0, 113, 7})
+        end)
+
+      assert log =~ "record_client_source"
+      assert Vhosts.last_client_prefix64(subject) == nil
+    end
+
+    test "works for visitor subjects (visitor-parity)" do
+      subject = {:visitor, visitor_fixture().id}
+
+      :ok = Vhosts.record_client_source(subject, {0x2001, 0xDB8, 0xCAFE, 1, 0, 0, 0, 1})
+
+      assert Vhosts.last_client_prefix64(subject) ==
+               SourceMapping.client_key({0x2001, 0xDB8, 0xCAFE, 1, 0, 0, 0, 0})
     end
   end
 end


### PR DESCRIPTION
Part of #543 (static-mapping outbound addressing) — increment **INC-3**, Parts A+B only. Stacked on INC-2 (`SourceMapping`), which is now in `main`; this PR is INC-3-only.

## Why
The `static_mapping_with_reservations` mode derives an untrusted subject's outbound source from the subject's OWN client `/64`. That derivation runs at **upstream-connect**, where no client socket may be attached — so the subject's last-known client prefix must be persisted out-of-band and read back there. This lands the persistence machinery.

## What
- **Part A — `UserSettings`**: a dumb `"last_client_prefix64"` accessor pair (`get_last_client_prefix64/1`, `put_last_client_prefix64/2`), mirroring the `vhost_selection` split. A raw `client_key` binary is not JSON-safe, so the value is stored as an OPAQUE base16 string; `UserSettings` validates only "non-empty base16" and stays domain-agnostic. Works for user AND visitor subjects.
- **Part B — `Vhosts`** owns the domain logic: `record_client_source/2` normalises the remote IP to its `/64` (v6) or `/32` (v4) via `SourceMapping.client_key/1` (interface id dropped, RFC 8981), base16-encodes it, persists last-write-wins. `last_client_prefix64/1` decodes back to the raw binary, `nil` on never-seen OR malformed (`Base.decode16`, never the raising `!`). A persist failure returns `:ok` (a capture miss must never fail the connect) but is LOGGED, not silently swallowed (CLAUDE.md boundary rule).

## Part C split to its own increment
The plan claimed "RemoteIp already resolves the real client IP per RemoteIpFromProxy" at WS connect — that is FALSE. The WS socket declares `connect_info: [:auth_token]` only; `RemoteIpFromProxy` is an HTTP Plug that never runs for `connect/3`, so the client remote IP is not available at `UserSocket.connect/3` today. Wiring it needs a load-bearing `connect_info` edit (+ `:peer_data`/`:x_headers`) and REUSE of the (subtle, inverted-`:clients`) trust matrix via a shared helper — its own worktree, gate, and review (approved direction).

## Gates
- Local `scripts/check.sh` full: Credo strict (no issues), ExUnit (0 failures), Dialyzer (0 errors), Sobelow, bats — all green.
- Synchronous code review (clean prod; two boundary test-coverage gaps applied: decode-failure→nil, :ok+LOG on subject-gone).
- TDD: RED → GREEN.