### PR TITLE
feat(#543): Part C — capture client /64 at WS connect (trusted-IP SSOT)

### DIFF
--- a/lib/grappa_web/channels/user_socket.ex
+++ b/lib/grappa_web/channels/user_socket.ex
@@ -110,9 +110,52 @@ defmodule GrappaWeb.UserSocket do
     with :ok <- check_protocol_version(params),
          {:ok, token} <- extract_token(connect_info),
          {:ok, socket} <- authenticate_and_assign(token, socket) do
+      maybe_record_client_source(socket, connect_info)
       {:ok, socket}
     end
   end
+
+  # #543 Part C — capture the subject's client network prefix at connect so
+  # the static-mapping addressing mode (INC-4) has a last-known `/64` to
+  # derive an outbound source from. The trusted client IP is resolved via the
+  # `RemoteIpFromProxy` SSOT (peer-loopback + XFF ⇒ trust the header chain;
+  # else the peer) from `connect_info.peer_data.address` + `.x_headers` — the
+  # SAME trust matrix the HTTP plug applies, one door.
+  #
+  # Best-effort by construction — capture must NEVER fail a connect:
+  # `record_client_source/2` already returns `:ok` even on a persist failure
+  # (logged, not swallowed), and the guards here SKIP capture (return `:ok`)
+  # for every shape the real transport can't produce: an absent / non-map
+  # `peer_data`, or a `peer_data.address` that isn't an IP-arity tuple (4 v4
+  # / 8 v6 — the arities `SourceMapping.client_key/1` accepts). A non-list
+  # `x_headers` degrades to `[]` (resolves to the peer), it doesn't skip.
+  # `:current_subject` is always assigned post-auth (both branches), but the
+  # `{_, _}` match keeps it honest. The real Phoenix transport always
+  # supplies a valid `:inet.ip_address()` peer + a list of x-headers, so the
+  # happy path is the only one it exercises.
+  @spec maybe_record_client_source(Phoenix.Socket.t(), map()) :: :ok
+  defp maybe_record_client_source(socket, connect_info) do
+    with %{address: peer_ip} <- Map.get(connect_info, :peer_data),
+         true <- ip_tuple?(peer_ip),
+         {_, _} = subject <- socket.assigns[:current_subject] do
+      x_headers =
+        case Map.get(connect_info, :x_headers) do
+          headers when is_list(headers) -> headers
+          _ -> []
+        end
+
+      client_ip = GrappaWeb.Plugs.RemoteIpFromProxy.trusted_client_ip(peer_ip, x_headers)
+      Grappa.Vhosts.record_client_source(subject, client_ip)
+    else
+      _ -> :ok
+    end
+  end
+
+  # An IP tuple of an arity `SourceMapping.client_key/1` handles (v4 /32,
+  # v6 /64). Guards the derive+persist path from a structurally-invalid
+  # `peer_data.address` so capture can't crash a connect.
+  @spec ip_tuple?(term()) :: boolean()
+  defp ip_tuple?(ip), do: is_tuple(ip) and tuple_size(ip) in [4, 8]
 
   # #447 — pre-auth protocol-version gate. A client MAY declare the wire
   # protocol version it speaks via the `client_proto` QUERY PARAM on the WS

--- a/lib/grappa_web/endpoint.ex
+++ b/lib/grappa_web/endpoint.ex
@@ -96,10 +96,18 @@ defmodule GrappaWeb.Endpoint do
   # overrides the default `{Phoenix.Transports.WebSocket, :handle_error}`.
   # It fires ONLY for `{:error, reason}` returns; a bare `:error` (auth
   # failure) still gets the default 403, keeping the two failures distinct.
+  # #543 Part C — `:peer_data` (transport peer IP) + `:x_headers` (the
+  # forwarded `x-*` request headers) are surfaced to `UserSocket.connect/3`
+  # so it can resolve the TRUSTED client IP (via the `RemoteIpFromProxy`
+  # SSOT) and feed it to `Vhosts.record_client_source/2`. A WS `connect/3`
+  # gets `connect_info` (a map built ONLY from the declared keys), NOT a
+  # `Plug.Conn`, so the `RemoteIpFromProxy` PLUG above never runs for the
+  # socket — these keys are the socket's only path to the client IP. Additive
+  # to `:auth_token`; ordering of the other socket opts is untouched.
   socket "/socket", GrappaWeb.UserSocket,
     auth_token: true,
     websocket: [
-      connect_info: [:auth_token],
+      connect_info: [:auth_token, :peer_data, :x_headers],
       error_handler: {GrappaWeb.UserSocket, :handle_ws_error, []}
     ],
     longpoll: false

--- a/lib/grappa_web/plugs/remote_ip_from_proxy.ex
+++ b/lib/grappa_web/plugs/remote_ip_from_proxy.ex
@@ -15,7 +15,13 @@ defmodule GrappaWeb.Plugs.RemoteIpFromProxy do
       |-------------|-------------|-------------------------------------------|
       | loopback    | no          | trust peer (direct curl from inside box)  |
       | loopback    | yes         | trust XFF (local nginx is reverse-proxying) |
-      | non-loopback| any         | trust peer (direct client, ignore headers) |
+      | non-loopback| any         | delegate to `RemoteIp`: the forwarded-chain client if XFF is present (walked right-to-left, reserved ranges skipped), else the peer |
+
+  The `non-loopback` row is NOT "ignore headers and trust the peer":
+  a non-loopback peer WITH an XFF still has its chain walked (the
+  docker-bridge / operator-fronted-proxy shape) — see the plug tests.
+  The single source of truth for all three rows is
+  `trusted_client_ip/3`; the socket and HTTP doors both delegate to it.
 
   The middle row is the load-bearing one for the bastille jail
   (cp52 S2 incident): nginx runs in the same jail as grappa and
@@ -57,21 +63,87 @@ defmodule GrappaWeb.Plugs.RemoteIpFromProxy do
   it's an IPv4 address in IPv6 transport. Real clients that hit
   Phoenix via the v4-mapped form get treated as non-loopback
   peers, which is correct.
+
+  ## Shared trust SSOT (#543 Part C)
+
+  The trust DECISION lives in exactly one place — `trusted_client_ip/3`
+  — so callers OUTSIDE the plug pipeline reuse it verbatim instead of
+  reimplementing this (subtle, security-load-bearing) matrix. The HTTP
+  `call/2` delegates to it; `GrappaWeb.UserSocket.connect/3` calls the
+  zero-config `trusted_client_ip/2` with the `peer_data`/`x_headers` it
+  reads from `connect_info` (a WS `connect/3` gets `connect_info`, NOT a
+  `Plug.Conn`, so `RemoteIp` can't run as a plug there). Both paths land
+  the SAME trusted client IP — one door, one matrix.
   """
   @behaviour Plug
 
+  # The header allowlist SSOT — `init/1`'s default AND the set the
+  # zero-config `trusted_client_ip/2` uses. The endpoint plug is wired with
+  # this exact literal (`headers: ~w[x-forwarded-for x-real-ip]`), pinned by
+  # `RemoteIpFromProxyTest`'s "config wiring" drift test, so the HTTP and WS
+  # doors can't drift onto different header sets.
+  @default_headers ~w[x-forwarded-for x-real-ip]
+
+  @typedoc "Packed plug options: the header allowlist + the `RemoteIp` keyword opts."
+  @type opts :: {[binary()], keyword()}
+
   @impl Plug
+  @spec init(keyword()) :: opts()
   def init(opts) do
-    headers = Keyword.get(opts, :headers, ~w[x-forwarded-for x-real-ip])
-    {headers, RemoteIp.init(opts)}
+    headers = Keyword.get(opts, :headers, @default_headers)
+    # Keep the RAW keyword opts (not `RemoteIp.init/1`'s packed form): the
+    # SSOT resolves via `RemoteIp.from/2`, which re-packs internally and is
+    # the blessed non-`Plug.Conn` entry (RemoteIp moduledoc). `:headers` is
+    # forced so `from/2` honours the same allowlist the plug advertises.
+    {headers, Keyword.put(opts, :headers, headers)}
   end
 
   @impl Plug
-  def call(%Plug.Conn{remote_ip: peer} = conn, {headers, remote_ip_opts}) do
-    if loopback?(peer) and not has_forwarded_header?(conn, headers) do
-      conn
+  @spec call(Plug.Conn.t(), opts()) :: Plug.Conn.t()
+  def call(%Plug.Conn{remote_ip: peer, req_headers: req_headers} = conn, opts) do
+    ip = trusted_client_ip(peer, req_headers, opts)
+    # Preserve `RemoteIp.call/2`'s side-effect: it stamped the `:remote_ip`
+    # Logger metadata (config allowlists it — the HTTP log line carries the
+    # post-rewrite client IP). `RemoteIp.from/2` does NOT, so re-stamp it
+    # here. This is an HTTP-request logging concern local to the plug, not
+    # part of the shared trust decision.
+    put_remote_ip_metadata(ip)
+    %{conn | remote_ip: ip}
+  end
+
+  @doc """
+  Resolves the trusted client IP for a caller OUTSIDE the plug pipeline
+  (the WS `connect/3`), using the SAME default header allowlist the
+  endpoint plug is wired with. `req_headers` is the forwarded-header list
+  (`connect_info.x_headers`); `peer_ip` is `connect_info.peer_data.address`.
+  """
+  @spec trusted_client_ip(:inet.ip_address(), [{binary(), binary()}]) :: :inet.ip_address()
+  def trusted_client_ip(peer_ip, req_headers) when is_tuple(peer_ip) and is_list(req_headers) do
+    trusted_client_ip(peer_ip, req_headers, init([]))
+  end
+
+  @doc """
+  The trust-matrix SSOT: given the transport peer IP + the request's
+  forwarded headers, return the IP to trust as the client.
+
+      | peer         | XFF present | trusted                                   |
+      |--------------|-------------|-------------------------------------------|
+      | loopback     | no          | the peer (operator shell / direct curl)   |
+      | loopback     | yes         | the header-chain client (local nginx)     |
+      | non-loopback | any         | the header-chain client, else the peer    |
+
+  The non-loopback rows delegate to `RemoteIp.from/2`, which walks the
+  forwarded chain right-to-left and stops at the first non-reserved IP —
+  so a trusted proxy's appended real client wins over any forged leftmost
+  entry, and a header yielding no client falls back to the peer.
+  """
+  @spec trusted_client_ip(:inet.ip_address(), [{binary(), binary()}], opts()) ::
+          :inet.ip_address()
+  def trusted_client_ip(peer_ip, req_headers, {headers, remote_ip_opts}) do
+    if loopback?(peer_ip) and not has_forwarded_header?(req_headers, headers) do
+      peer_ip
     else
-      RemoteIp.call(conn, remote_ip_opts)
+      RemoteIp.from(req_headers, remote_ip_opts) || peer_ip
     end
   end
 
@@ -79,12 +151,17 @@ defmodule GrappaWeb.Plugs.RemoteIpFromProxy do
   defp loopback?({0, 0, 0, 0, 0, 0, 0, 1}), do: true
   defp loopback?(_), do: false
 
-  defp has_forwarded_header?(conn, headers) do
-    Enum.any?(headers, fn name ->
-      case Plug.Conn.get_req_header(conn, name) do
-        [] -> false
-        _ -> true
-      end
-    end)
+  defp has_forwarded_header?(req_headers, headers) do
+    Enum.any?(req_headers, fn {name, _} -> name in headers end)
+  end
+
+  # Replicates `RemoteIp.call/2`'s `add_metadata/1` (a private dep helper):
+  # stamp the client IP as `:remote_ip` Logger metadata via `:inet.ntoa/1`,
+  # skipping a malformed tuple rather than crashing the request.
+  defp put_remote_ip_metadata(ip) do
+    case :inet.ntoa(ip) do
+      {:error, _} -> :ok
+      str -> Logger.metadata(remote_ip: to_string(str))
+    end
   end
 end

--- a/test/grappa_web/channels/user_socket_test.exs
+++ b/test/grappa_web/channels/user_socket_test.exs
@@ -300,6 +300,105 @@ defmodule GrappaWeb.UserSocketTest do
     end
   end
 
+  # #543 Part C — at WS connect the trusted client IP is resolved (via the
+  # `RemoteIpFromProxy` SSOT, from `connect_info.peer_data`/`x_headers`) and
+  # fed to `Vhosts.record_client_source/2`, so INC-3's per-subject
+  # `last_client_prefix64` persistence is actually populated. Capture is
+  # best-effort: an absent/garbage peer_data must NOT fail the connect.
+  describe "connect/3 client-source capture (#543 Part C)" do
+    alias Grappa.Vhosts
+    alias Grappa.Vhosts.SourceMapping
+
+    # Mirrors the transport: `peer_data.address` is the peer IP tuple,
+    # `x_headers` are the forwarded (`x-*`) request headers, both riding
+    # `connect_info` alongside the subprotocol bearer.
+    defp connect_with_peer(token, peer_ip, x_headers) do
+      Phoenix.ChannelTest.connect(UserSocket, %{},
+        connect_info: %{
+          auth_token: token,
+          peer_data: %{address: peer_ip, port: 12_345, ssl_cert: nil},
+          x_headers: x_headers
+        }
+      )
+    end
+
+    test "records the resolved client /64 for a user subject (loopback proxy + XFF)" do
+      user_name = "vjt-#{System.unique_integer([:positive])}"
+      {user, session} = user_and_session(name: user_name)
+      subject = {:user, user.id}
+
+      assert Vhosts.last_client_prefix64(subject) == nil
+
+      assert {:ok, _} =
+               connect_with_peer(session.id, {127, 0, 0, 1}, [
+                 {"x-forwarded-for", "2001:db8:1:2:3:4:5:6"}
+               ])
+
+      # The stored key equals the production derivation of the RESOLVED IP —
+      # the /64 of the XFF client, NOT the loopback peer. No hardcoded bytes.
+      assert Vhosts.last_client_prefix64(subject) ==
+               SourceMapping.client_key({0x2001, 0xDB8, 1, 2, 3, 4, 5, 6})
+    end
+
+    test "records the peer directly for a direct (non-loopback, no-XFF) client" do
+      {user, session} = user_and_session(name: "vjt-#{System.unique_integer([:positive])}")
+      subject = {:user, user.id}
+
+      assert {:ok, _} = connect_with_peer(session.id, {203, 0, 113, 7}, [])
+
+      assert Vhosts.last_client_prefix64(subject) ==
+               SourceMapping.client_key({203, 0, 113, 7})
+    end
+
+    test "records for a visitor subject too (one door — user + visitor)" do
+      visitor = visitor_fixture()
+      {:ok, session} = Accounts.create_session({:visitor, visitor.id}, "1.2.3.4", "ua", [])
+      subject = {:visitor, visitor.id}
+
+      assert {:ok, _} =
+               connect_with_peer(session.id, {127, 0, 0, 1}, [
+                 {"x-forwarded-for", "203.0.113.42"}
+               ])
+
+      assert Vhosts.last_client_prefix64(subject) ==
+               SourceMapping.client_key({203, 0, 113, 42})
+    end
+
+    test "connect still succeeds and captures nothing when peer_data is absent" do
+      user_name = "vjt-#{System.unique_integer([:positive])}"
+      {user, session} = user_and_session(name: user_name)
+      subject = {:user, user.id}
+
+      # No peer_data key at all — the pre-Part-C connect_info shape. Connect
+      # proceeds; capture is silently skipped (no crash, nothing recorded).
+      assert {:ok, _} =
+               Phoenix.ChannelTest.connect(UserSocket, %{}, connect_info: %{auth_token: session.id})
+
+      assert Vhosts.last_client_prefix64(subject) == nil
+    end
+
+    test "connect succeeds and captures nothing for a structurally-invalid peer address" do
+      user_name = "vjt-#{System.unique_integer([:positive])}"
+      {user, session} = user_and_session(name: user_name)
+      subject = {:user, user.id}
+
+      # A tuple that is NOT an IP-arity tuple (4 v4 / 8 v6) is garbage
+      # peer_data the real transport can't produce; the `ip_tuple?/1` guard
+      # skips capture rather than letting `SourceMapping.client_key/1` raise
+      # and fail the connect.
+      assert {:ok, _} =
+               Phoenix.ChannelTest.connect(UserSocket, %{},
+                 connect_info: %{
+                   auth_token: session.id,
+                   peer_data: %{address: {1, 2, 3}, port: 12_345, ssl_cert: nil},
+                   x_headers: []
+                 }
+               )
+
+      assert Vhosts.last_client_prefix64(subject) == nil
+    end
+  end
+
   describe "id/1 visitor branch" do
     test "scopes the per-socket id by visitor:<id>" do
       visitor = visitor_fixture()

--- a/test/grappa_web/plugs/remote_ip_from_proxy_test.exs
+++ b/test/grappa_web/plugs/remote_ip_from_proxy_test.exs
@@ -122,6 +122,94 @@ defmodule GrappaWeb.Plugs.RemoteIpFromProxyTest do
     end
   end
 
+  # #543 Part C — the trust decision is factored into ONE public SSOT
+  # (`trusted_client_ip/2,3`) so the WS `connect/3` (which gets
+  # `peer_data`/`x_headers` from `connect_info`, NOT a `Plug.Conn`) resolves
+  # the trusted client IP through the SAME code the HTTP plug uses. These
+  # tests pin the matrix on the socket-facing zero-config entry so a fork
+  # (a reimplemented / inverted trust decision) fails here before it ships.
+  describe "trusted_client_ip/2 (shared SSOT — the WS connect/3 entry)" do
+    test "loopback peer + no forwarded header → the peer (operator shell / direct)" do
+      assert RemoteIpFromProxy.trusted_client_ip({127, 0, 0, 1}, []) == {127, 0, 0, 1}
+
+      assert RemoteIpFromProxy.trusted_client_ip({0, 0, 0, 0, 0, 0, 0, 1}, []) ==
+               {0, 0, 0, 0, 0, 0, 0, 1}
+    end
+
+    test "loopback peer + X-Forwarded-For → the real client (local nginx shape)" do
+      assert RemoteIpFromProxy.trusted_client_ip(
+               {127, 0, 0, 1},
+               [{"x-forwarded-for", "203.0.113.42"}]
+             ) == {203, 0, 113, 42}
+    end
+
+    test "loopback peer + X-Real-IP → the real client" do
+      assert RemoteIpFromProxy.trusted_client_ip(
+               {127, 0, 0, 1},
+               [{"x-real-ip", "198.51.100.7"}]
+             ) == {198, 51, 100, 7}
+    end
+
+    test "loopback peer + IPv6 X-Forwarded-For resolves the v6 client" do
+      assert RemoteIpFromProxy.trusted_client_ip(
+               {0, 0, 0, 0, 0, 0, 0, 1},
+               [{"x-forwarded-for", "2001:db8:1:2:3:4:5:6"}]
+             ) == {0x2001, 0xDB8, 1, 2, 3, 4, 5, 6}
+    end
+
+    test "non-loopback peer + no forwarded header → the peer" do
+      assert RemoteIpFromProxy.trusted_client_ip({203, 0, 113, 42}, []) == {203, 0, 113, 42}
+    end
+
+    # THREAT: an attacker injects a forged LEFTMOST XFF; the trusted proxy
+    # (local nginx) APPENDS the real client to the RIGHT, so the chain reads
+    # "1.2.3.4, <real-client>". The right-to-left walk stops at the first
+    # non-reserved IP (the appended real client) — the injected 1.2.3.4
+    # sits to its LEFT and is NEVER reached. Proves a forged header cannot
+    # override the proxy-appended real client, now through the socket SSOT.
+    test "forged leftmost XFF cannot override the proxy-appended real client" do
+      assert RemoteIpFromProxy.trusted_client_ip(
+               {127, 0, 0, 1},
+               [{"x-forwarded-for", "1.2.3.4, 198.51.100.99"}]
+             ) == {198, 51, 100, 99}
+    end
+
+    # THREAT: a forged XFF carrying only a RESERVED (RFC1918) address can't
+    # override the real peer — the reserved entry is treated as a proxy and
+    # skipped, the header yields no client, resolution falls back to the peer.
+    test "forged reserved-only XFF falls back to the peer (non-loopback)" do
+      assert RemoteIpFromProxy.trusted_client_ip(
+               {203, 0, 113, 7},
+               [{"x-forwarded-for", "10.0.0.5"}]
+             ) == {203, 0, 113, 7}
+    end
+  end
+
+  # #543 Part C — the plug `call/2` MUST delegate to the same SSOT the socket
+  # uses (no forked / duplicated trust matrix). If a refactor forks them, this
+  # equality fails.
+  describe "call/2 delegates to the shared SSOT (no forked matrix)" do
+    test "plug call/2 and trusted_client_ip/2 agree on the loopback+XFF-chain shape" do
+      peer = {127, 0, 0, 1}
+      headers = [{"x-forwarded-for", "203.0.113.42, 10.0.0.5"}]
+
+      conn = call(peer, headers)
+
+      assert conn.remote_ip == RemoteIpFromProxy.trusted_client_ip(peer, headers)
+    end
+
+    # The `:remote_ip` Logger metadata (config allowlists it — the HTTP log
+    # line carries the post-rewrite client IP) was set by `RemoteIp.call` as
+    # a side-effect. The SSOT resolution uses `RemoteIp.from`, which does NOT
+    # set metadata, so `call/2` re-sets it explicitly — this drift guard pins
+    # that the side-effect survived the factoring.
+    test "call/2 preserves the :remote_ip Logger metadata side-effect" do
+      Logger.metadata(remote_ip: nil)
+      _ = call({127, 0, 0, 1}, [{"x-forwarded-for", "203.0.113.42"}])
+      assert Logger.metadata()[:remote_ip] == "203.0.113.42"
+    end
+  end
+
   describe "config wiring (drift detection)" do
     test "Endpoint installs RemoteIpFromProxy with the configured headers" do
       # If a future refactor swaps the wrapper for bare RemoteIp, the


### PR DESCRIPTION
## What — Part C of #543 (static-mapping outbound addressing)

At WS connect, resolve the **trusted** client IP and call
`Vhosts.record_client_source/2` so INC-3's per-subject
`last_client_prefix64` persistence actually gets fed — it had no producer
until now.

- **`endpoint.ex`** — add `:peer_data` + `:x_headers` to the WS socket
  `connect_info` (additive to `:auth_token`). A Phoenix WS `connect/3`
  receives `connect_info` (a map built only from the declared keys), **not**
  a `Plug.Conn`, so the `RemoteIpFromProxy` HTTP plug never runs for the
  socket — these keys are the socket's only path to the client IP.
- **`remote_ip_from_proxy.ex`** — factor the trust decision into ONE public
  SSOT `trusted_client_ip/2,3`. The HTTP `call/2` delegates to it; the
  socket calls the zero-config `trusted_client_ip/2`. The trust matrix
  (peer-loopback + XFF ⇒ header chain; else the peer) lives in exactly one
  place — no forked/reimplemented matrix at a second door. The SSOT resolves
  via `RemoteIp.from/2`; `call/2` re-stamps the `:remote_ip` Logger metadata
  that `RemoteIp.call/2` set as a side-effect (config allowlists it) — an
  HTTP-log concern kept local to the plug, pinned by a drift-guard test.
- **`user_socket.ex`** — `maybe_record_client_source/2` after auth: resolve
  via the SSOT, call `record_client_source/2`. Best-effort by construction —
  an absent/garbage `peer_data` skips silently, capture NEVER fails a
  connect (`ip_tuple?/1` guard + a list-guard on `x_headers`).

## Tests — 52, all green
- **22** in `remote_ip_from_proxy_test.exs`: 14 pre-existing plug-behaviour
  tests (byte-for-byte preserved) + 8 new (SSOT socket-entry matrix, threat
  cases, plug↔SSOT agreement, `:remote_ip` metadata drift-guard).
- **30** in `user_socket_test.exs`: 25 pre-existing connect tests + 5 capture
  (user, direct-peer, visitor, peer_data-absent, garbage-address).
- Full `scripts/check.sh` was green on this change: dialyzer `Total errors:
  0`, credo `no issues`, sobelow clean (no Medium+), ExUnit `4673 tests, 0
  failures`, bats. Assertions use the production derivation
  `SourceMapping.client_key/1` — no hardcoded bytes.

## Spec challenge — the threat-tests
The plan (Task 3 Step 5) framed the threat as "non-loopback peer + forged
XFF ⇒ return the peer". That is **imprecise** vs how `RemoteIp` actually
behaves with the current config (empty `proxies` + the loopback
short-circuit). The **real** prod property — and what these threat-tests
pin — is: the local nginx proxy (loopback peer) **appends** the real client
to the RIGHT of XFF, so the right-to-left walk stops at the appended real
client and a forged **leftmost** entry is never reached. Reimplementing the
plan's phrasing would have inverted/forked the trust matrix and broken the
existing "surfaces spoofer's real public IP" plug test. Byte-for-byte plug
behaviour took precedence over the plan's wording.

## Provenance
Part C briefly landed on `main` as `78a1ada7` (pushed atop the INC-3 stack
by mistake — a stacked branch's push carries the whole stack) and was
immediately **reverted** (`822e3b14`, "out of tonight's batch"): it touches
the WS `connect_info` in production and carried no user value that night.
This is a **gating** decision, not a quality one — it had full `check.sh` +
code review green. This PR re-introduces Part C cleanly on top of `main` (a
cherry-pick of the original commit) for a proper base-`main` review + CI.
INC-3 (`e0faf535`) stays on `main`.

Part of the #543 arc (INC-4 next); depends on INC-3 (already on main).
