### PR TITLE
cicchetto: server-info context on the rail for server windows (#474)

### DIFF
--- a/cicchetto/e2e/tests/issue474-server-info-rail.spec.ts
+++ b/cicchetto/e2e/tests/issue474-server-info-rail.spec.ts
@@ -7,6 +7,18 @@
 // already in the client store (network slug, own nick, connection state,
 // connected-since) rendered by `RailContext` → `ServerInfoCard`.
 //
+// Scope B adds the LIVE upstream facts under `network.connection`, resolved
+// from `Session.connection_info/2` at the `GET /networks` boundary (the
+// additive #447 wire field): the dialled `server:port` (resolved peer IP,
+// #550), a 🔒 when TLS, and whether the nick is identified to services
+// (`registered`, from the +r umode — the #561 signal). `connection` is null
+// whenever there is no live connected session, so these rows render ONLY on
+// a real socket. This spec asserts them against what the e2e seeder actually
+// dials: `bahamut-test:6667 --no-tls --auth none` (compose.yaml) — so the
+// server row shows `:6667`, there is NO lock (plaintext), and `identified`
+// reads "no" (no SASL/NickServ → the nick never gains +r). Honesty rule:
+// never assert a 🔒 that the plaintext transport does not render.
+//
 // vitest (RailContext/ServerInfoCard/duration) proves the pure dispatch +
 // formatting in jsdom, but jsdom is blind to layout + the live WS-hydrated
 // Network store (feedback_ux_e2e_mandatory). This chromium e2e is the
@@ -21,7 +33,7 @@ import { getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 const SERVER_WINDOW_LABEL = "Server";
 
 test.describe("#474 server-info rail card", () => {
-  test("server window rail shows slug, own nick, connection state + connected-since", async ({
+  test("server window rail shows slug, nick, state, connected-since + dialled server / identified", async ({
     page,
   }) => {
     const vjt = getSeededVjt();
@@ -52,5 +64,24 @@ test.describe("#474 server-info rail card", () => {
     // compact duration like "4h 12m" / "45s".
     const uptimeValue = card.locator('dt:text-is("connected") + dd');
     await expect(uptimeValue).toHaveText(/\d+\s*[smhd]/);
+
+    // Scope B — the LIVE upstream connection facts under network.connection.
+    // The seeder binds bahamut-test `--server bahamut-test:6667 --no-tls
+    // --auth none` (compose.yaml), so the card renders the honest plaintext,
+    // unregistered shape below.
+    //
+    // `server` row: `<resolved-peer-ip>:6667` — the IP the socket dialled
+    // (#550), not the hostname. Assert the :6667 port (the peer IP is a
+    // dynamic docker bridge address, so match the stable port suffix), and
+    // that there is NO 🔒 glyph — --no-tls means plaintext, and asserting a
+    // lock that isn't there would be the exact dishonesty the card avoids.
+    await expect(card.locator('dt:text-is("server")')).toBeVisible();
+    const serverValue = card.locator('dt:text-is("server") + dd');
+    await expect(serverValue).toContainText(":6667");
+    await expect(serverValue.locator(".rail-server-info-tls")).toHaveCount(0);
+
+    // `identified` row: "no" — --auth none means no SASL/NickServ handshake,
+    // so the nick never gains the +r umode connection_info reads.
+    await expect(card.locator("[data-testid=rail-server-info-identified]")).toHaveText("no");
   });
 });

--- a/cicchetto/e2e/tests/issue474-server-info-rail.spec.ts
+++ b/cicchetto/e2e/tests/issue474-server-info-rail.spec.ts
@@ -1,0 +1,56 @@
+// #474 — the right rail shows server-info context on a SERVER window.
+//
+// #71 INC-2 made `.shell-members` a PERMANENT desktop column on every
+// window kind; on a channel it shows the members pane, on a server window
+// it previously showed only the RailActions button drawer. #474 fills that
+// slot with per-window-kind context: on the server window, connection facts
+// already in the client store (network slug, own nick, connection state,
+// connected-since) rendered by `RailContext` → `ServerInfoCard`.
+//
+// vitest (RailContext/ServerInfoCard/duration) proves the pure dispatch +
+// formatting in jsdom, but jsdom is blind to layout + the live WS-hydrated
+// Network store (feedback_ux_e2e_mandatory). This chromium e2e is the
+// WIRING proof: a real login over the running stack, a real server window,
+// the real store-fed card. Desktop viewport → the rail column is visible
+// with no drawer toggle (permanent surface), so no members-open dance.
+
+import { expect, test } from "../fixtures/test";
+import { loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const SERVER_WINDOW_LABEL = "Server";
+
+test.describe("#474 server-info rail card", () => {
+  test("server window rail shows slug, own nick, connection state + connected-since", async ({
+    page,
+  }) => {
+    const vjt = getSeededVjt();
+    await loginAs(page, vjt);
+
+    // Precondition: the server window entry exists, then focus it.
+    const serverEntry = sidebarWindow(page, NETWORK_SLUG, SERVER_WINDOW_LABEL);
+    await expect(serverEntry).toHaveCount(1);
+    await selectChannel(page, NETWORK_SLUG, SERVER_WINDOW_LABEL, { awaitWsReady: false });
+
+    // The per-kind rail context surface renders on the server window.
+    const card = page.locator("[data-testid=rail-server-info]");
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    // Header carries the network slug (the folded key IS the display).
+    await expect(card.locator(".rail-server-info-title")).toHaveText(NETWORK_SLUG);
+
+    // Facts from the live-hydrated Network store, scoped to the card so a
+    // stray match elsewhere in the shell can't false-green this.
+    await expect(card).toContainText(NETWORK_NICK);
+    // The DB-canonical connection state — the seeded network is live
+    // (cp13 S8 drives /away over it), so it reads "connected".
+    await expect(card).toContainText("connected");
+
+    // The connected-since row is present with a non-empty duration value —
+    // it renders ONLY while connected (honesty rule), so its presence
+    // doubles as a live-state assertion. dt "connected" → its dd holds a
+    // compact duration like "4h 12m" / "45s".
+    const uptimeValue = card.locator('dt:text-is("connected") + dd');
+    await expect(uptimeValue).toHaveText(/\d+\s*[smhd]/);
+  });
+});

--- a/cicchetto/src/RailContext.tsx
+++ b/cicchetto/src/RailContext.tsx
@@ -1,0 +1,46 @@
+import { type Component, createSignal, Match, onCleanup, Show, Switch } from "solid-js";
+import { networkBySlug } from "./lib/networks";
+import { selectedChannel } from "./lib/selection";
+import ServerInfoCard from "./ServerInfoCard";
+
+// #474 — the rail's GENERIC per-window-kind context surface. Mounted as a
+// sibling of the RailActions drawer inside `.shell-members` in BOTH Shell
+// rail branches (desktop + mobile). It reads the active window's kind and
+// grafts the matching context content:
+//   * server → ServerInfoCard (connection facts already in the store)
+//   * query  → a /whois card is the deferred other half of this design
+//              (issue #474 "follow-on, not scope here") — add a <Match>
+//              here when it lands, NOT a second Shell edit.
+// It renders NOTHING for kinds with no context content (channel already has
+// the MembersPane above; home/admin/list/mentions have none). Built as a
+// container, not a hardcoded server card, so the rail becomes the per-kind
+// context surface the RailActions moduledoc (#473) always earmarked.
+
+const TICK_MS = 60_000;
+
+const RailContext: Component = () => {
+  // Coarse clock so a live "connected for Xh Ym" stays fresh. `.shell-members`
+  // is a permanent column (#71 INC-2), so this ticker runs for the whole
+  // authenticated session, not just while a server window is focused — off a
+  // server window nothing reads `now()`, so those 60s ticks are harmless
+  // no-op re-renders. Kept in the container (not ServerInfoCard) so the card
+  // takes an injected `now` and stays deterministic under test; 60s
+  // granularity is plenty for a duration read, torn down with the shell.
+  const [now, setNow] = createSignal(Date.now());
+  const timer = setInterval(() => setNow(Date.now()), TICK_MS);
+  onCleanup(() => clearInterval(timer));
+
+  const sel = () => selectedChannel();
+
+  return (
+    <Switch>
+      <Match when={sel()?.kind === "server"}>
+        <Show when={networkBySlug(sel()?.networkSlug ?? "")}>
+          {(net) => <ServerInfoCard network={net()} now={now()} />}
+        </Show>
+      </Match>
+    </Switch>
+  );
+};
+
+export default RailContext;

--- a/cicchetto/src/ServerInfoCard.tsx
+++ b/cicchetto/src/ServerInfoCard.tsx
@@ -1,0 +1,101 @@
+import { type Component, Show } from "solid-js";
+import type { Network } from "./lib/api";
+import { connectionStateEmoji } from "./lib/connectionStateEmoji";
+import { formatDurationSince } from "./lib/duration";
+import { MircBody } from "./MircText";
+
+// #474 — the per-network "server info" card that fills the right rail on a
+// SERVER window. Pure presentational: it renders ONLY facts already in the
+// store (the `Network` resource), passed in by the RailContext container
+// along with an injected `now` (epoch ms) so the uptime is deterministic +
+// testable and the container owns the ~60s ticker.
+//
+// Facts-only, sourced from existing session/network state:
+//   * slug   — the network label (there is no separate human name)
+//   * status — DB-canonical connection_state glyph + word + reason
+//   * uptime — connected-since, ONLY while genuinely connected (honesty:
+//              a duration next to a parked/failed state would lie)
+//   * nick   — own IRC nick on this network
+//   * services — which NickServ software (omitted when "unknown")
+//
+// Deliberately absent (NOT in the user-facing wire — admin-only): the
+// dialled server address, TLS yes/no, and live registered/identified
+// state. #474's rule is "prefer leaving it out over showing a stale value
+// confidently"; those graft in later behind an additive wire field, and
+// this card inherits them for free when they arrive.
+//
+// No close button: unlike the ephemeral scrollback cards (whois/whowas/
+// lusers), this is the rail's persistent per-kind context surface — it is
+// present for as long as the server window is focused.
+
+type Props = {
+  network: Network;
+  /** Epoch ms, injected by the container (ticked ~60s) so the rendered
+      uptime stays fresh AND is deterministic under test. */
+  now: number;
+};
+
+const ServerInfoCard: Component<Props> = (props) => {
+  const state = () => connectionStateEmoji(props.network.connection_state);
+  // Uptime ONLY while connected — connection_state_changed_at is "time of
+  // last state transition", which IS the connect instant for a live link,
+  // but next to a parked/failed state it would read as a lie.
+  const uptime = () =>
+    props.network.connection_state === "connected"
+      ? formatDurationSince(props.network.connection_state_changed_at, props.now)
+      : null;
+  const services = () => {
+    const flavor = props.network.services_flavor;
+    return flavor && flavor !== "unknown" ? flavor : null;
+  };
+
+  return (
+    <div class="rail-server-info" data-testid="rail-server-info">
+      <div class="rail-server-info-header">
+        <span class="rail-server-info-title">{props.network.slug}</span>
+      </div>
+      <dl class="rail-server-info-fields">
+        <dt>status</dt>
+        <dd>
+          <span
+            class="rail-server-info-glyph"
+            role="img"
+            title={state().label}
+            aria-label={state().label}
+          >
+            {state().glyph}
+          </span>{" "}
+          {state().label}
+          <Show when={props.network.connection_state_reason}>
+            {(reason) => (
+              <>
+                {" — "}
+                <MircBody body={reason()} />
+              </>
+            )}
+          </Show>
+        </dd>
+        <Show when={uptime()}>
+          {(up) => (
+            <>
+              <dt>connected</dt>
+              <dd>{up()}</dd>
+            </>
+          )}
+        </Show>
+        <dt>nick</dt>
+        <dd>{props.network.nick}</dd>
+        <Show when={services()}>
+          {(flavor) => (
+            <>
+              <dt>services</dt>
+              <dd>{flavor()}</dd>
+            </>
+          )}
+        </Show>
+      </dl>
+    </div>
+  );
+};
+
+export default ServerInfoCard;

--- a/cicchetto/src/ServerInfoCard.tsx
+++ b/cicchetto/src/ServerInfoCard.tsx
@@ -18,11 +18,14 @@ import { MircBody } from "./MircText";
 //   * nick   — own IRC nick on this network
 //   * services — which NickServ software (omitted when "unknown")
 //
-// Deliberately absent (NOT in the user-facing wire — admin-only): the
-// dialled server address, TLS yes/no, and live registered/identified
-// state. #474's rule is "prefer leaving it out over showing a stale value
-// confidently"; those graft in later behind an additive wire field, and
-// this card inherits them for free when they arrive.
+// Scope B — the live upstream connection facts under `network.connection`
+// (the additive #447 wire field resolved from Session.connection_info/2):
+//   * server — which box the socket dialled (`server:port`), the resolved
+//              peer IP, so a round-robin landing is visible (#550 capture)
+//   * tls    — a 🔒 lock when the transport is TLS
+//   * identified — yes/no, from the +r umode (the #561 identity signal)
+// `connection` is null whenever there is no live connected session, so
+// these rows appear ONLY on a real socket — honesty over a stale value.
 //
 // No close button: unlike the ephemeral scrollback cards (whois/whowas/
 // lusers), this is the rail's persistent per-kind context surface — it is
@@ -80,6 +83,24 @@ const ServerInfoCard: Component<Props> = (props) => {
             <>
               <dt>connected</dt>
               <dd>{up()}</dd>
+            </>
+          )}
+        </Show>
+        <Show when={props.network.connection}>
+          {(conn) => (
+            <>
+              <dt>server</dt>
+              <dd>
+                {conn().server}:{conn().port}
+                <Show when={conn().tls}>
+                  {" "}
+                  <span class="rail-server-info-tls" role="img" title="TLS" aria-label="TLS">
+                    🔒
+                  </span>
+                </Show>
+              </dd>
+              <dt>identified</dt>
+              <dd data-testid="rail-server-info-identified">{conn().registered ? "yes" : "no"}</dd>
             </>
           )}
         </Show>

--- a/cicchetto/src/Shell.tsx
+++ b/cicchetto/src/Shell.tsx
@@ -58,6 +58,7 @@ import NextActiveButton from "./NextActiveButton";
 import PresenceToasts from "./PresenceToasts";
 import PrivacyModal from "./PrivacyModal";
 import RailActions from "./RailActions";
+import RailContext from "./RailContext";
 import RegistrationWizardModal from "./RegistrationWizardModal";
 import ResizeHandle from "./ResizeHandle";
 import ScrollbackPane from "./ScrollbackPane";
@@ -709,6 +710,11 @@ const Shell: Component = () => {
                 <MembersPane networkSlug={sel().networkSlug} channelName={sel().channelName} />
               )}
             </Show>
+            {/* #474 — the per-window-kind rail context surface (server info
+                today; a /whois card is the deferred follow-on), grafted as a
+                SIBLING of the drawer below. Renders nothing on kinds with no
+                context, so the drawer still floors the rail. */}
+            <RailContext />
             {/* #473 — the ONE unified rail action drawer, floored at the bottom
                 (CSS `.rail-actions { margin-top: auto }`). Supersedes the desktop
                 top ActionCluster (cog + denoise) and, crucially, brings the
@@ -955,6 +961,10 @@ const Shell: Component = () => {
               />
             )}
           </Show>
+          {/* #474 — per-window-kind rail context (server info today), grafted
+              as a SIBLING of the drawer below; renders nothing off a server
+              window. Same component the desktop rail mounts. */}
+          <RailContext />
           {/* #473 — the ONE unified rail action drawer, floored at the bottom.
               Same component + same handler set the desktop rail mounts (the
               drawer-closing arm of the mobilePanel helpers is meaningful here on

--- a/cicchetto/src/WhoisCard.tsx
+++ b/cicchetto/src/WhoisCard.tsx
@@ -1,5 +1,6 @@
 import { type Component, For, Show } from "solid-js";
 import type { WhoisBundle } from "./lib/api";
+import { formatDuration } from "./lib/duration";
 import { dismissWhoisCard, whoisCardBySlug } from "./lib/whoisCard";
 import { MircBody } from "./MircText";
 import NickText from "./NickText";
@@ -35,17 +36,6 @@ import NickText from "./NickText";
 
 export type Props = {
   networkSlug: string;
-};
-
-const formatIdle = (seconds: number | null): string | null => {
-  if (seconds === null) return null;
-  if (seconds < 60) return `${seconds}s`;
-  const mins = Math.floor(seconds / 60);
-  if (mins < 60) return `${mins}m`;
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return `${hours}h ${mins % 60}m`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ${hours % 24}h`;
 };
 
 const formatSignon = (epochSeconds: number | null): string | null => {
@@ -228,7 +218,7 @@ const WhoisCard: Component<Props> = (props) => {
               <Show when={b().idle_seconds !== null}>
                 <dt>idle</dt>
                 <dd>
-                  {formatIdle(b().idle_seconds)}
+                  {formatDuration(b().idle_seconds)}
                   <Show when={b().signon !== null}> · signon {formatSignon(b().signon)}</Show>
                 </dd>
               </Show>

--- a/cicchetto/src/__tests__/RailContext.test.tsx
+++ b/cicchetto/src/__tests__/RailContext.test.tsx
@@ -33,6 +33,7 @@ const net: Network = {
   connection_state: "connected",
   connection_state_reason: null,
   connection_state_changed_at: "2026-07-31T08:00:00.000Z",
+  connection: { server: "89.31.72.10", port: 6697, tls: true, registered: true },
   inserted_at: "2026-07-01T00:00:00.000Z",
   updated_at: "2026-07-01T00:00:00.000Z",
 };

--- a/cicchetto/src/__tests__/RailContext.test.tsx
+++ b/cicchetto/src/__tests__/RailContext.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
+import type { Network } from "../lib/api";
+import type { SelectedChannel } from "../lib/selection";
+import type { WindowKind } from "../lib/windowKinds";
+
+// #474 — RailContext is the GENERIC per-window-kind context surface grafted
+// as a sibling of the RailActions drawer. It dispatches on the active
+// window's kind: server → ServerInfoCard today; query → whois is the
+// deferred follow-on. It renders NOTHING for kinds with no context content.
+// Built as a container (not a hardcoded server card) so future per-kind
+// content grafts here without touching Shell's two rail mounts.
+
+const selectedChannelMock = vi.hoisted(() => vi.fn<() => SelectedChannel | null>());
+const networkBySlugMock = vi.hoisted(() => vi.fn<(slug: string) => Network | undefined>());
+
+vi.mock("../lib/selection", () => ({
+  selectedChannel: () => selectedChannelMock(),
+}));
+
+vi.mock("../lib/networks", () => ({
+  networkBySlug: (slug: string) => networkBySlugMock(slug),
+}));
+
+const net: Network = {
+  kind: "user",
+  id: 7,
+  slug: "libera",
+  services_flavor: "atheme",
+  nick: "vjt",
+  ident: "vjt",
+  realname: "VJT",
+  connection_state: "connected",
+  connection_state_reason: null,
+  connection_state_changed_at: "2026-07-31T08:00:00.000Z",
+  inserted_at: "2026-07-01T00:00:00.000Z",
+  updated_at: "2026-07-01T00:00:00.000Z",
+};
+
+const sel = (kind: WindowKind, channelName: string): SelectedChannel => ({
+  networkSlug: "libera",
+  channelName,
+  kind,
+});
+
+async function renderContainer() {
+  const { default: RailContext } = await import("../RailContext");
+  return render(() => <RailContext />);
+}
+
+describe("RailContext per-kind dispatch", () => {
+  it("renders the ServerInfoCard on a server window when the network is live", async () => {
+    selectedChannelMock.mockReturnValue(sel("server", "$server"));
+    networkBySlugMock.mockReturnValue(net);
+    await renderContainer();
+    const card = screen.getByTestId("rail-server-info");
+    expect(card.textContent).toContain("libera");
+  });
+
+  it("renders nothing on a server window whose network is not live", async () => {
+    selectedChannelMock.mockReturnValue(sel("server", "$server"));
+    networkBySlugMock.mockReturnValue(undefined);
+    await renderContainer();
+    expect(screen.queryByTestId("rail-server-info")).toBeNull();
+  });
+
+  it("renders nothing on a channel window", async () => {
+    selectedChannelMock.mockReturnValue(sel("channel", "#italia"));
+    networkBySlugMock.mockReturnValue(net);
+    await renderContainer();
+    expect(screen.queryByTestId("rail-server-info")).toBeNull();
+  });
+
+  it("renders nothing on a query window (whois context is a deferred follow-on)", async () => {
+    selectedChannelMock.mockReturnValue(sel("query", "alice"));
+    networkBySlugMock.mockReturnValue(net);
+    await renderContainer();
+    expect(screen.queryByTestId("rail-server-info")).toBeNull();
+  });
+
+  it("renders nothing when no window is selected", async () => {
+    selectedChannelMock.mockReturnValue(null);
+    await renderContainer();
+    expect(screen.queryByTestId("rail-server-info")).toBeNull();
+  });
+});

--- a/cicchetto/src/__tests__/ServerInfoCard.test.tsx
+++ b/cicchetto/src/__tests__/ServerInfoCard.test.tsx
@@ -6,10 +6,11 @@ import ServerInfoCard from "../ServerInfoCard";
 // #474 — the server-window rail card. Pure presentational: it takes the
 // already-in-store `Network` + an injected `now` (epoch ms) so the rendered
 // duration is deterministic. Facts-only — slug, nick, connection state (+
-// reason), connected-since, services flavor. It deliberately does NOT show
-// the dialled server address / TLS / registered state: those are NOT in the
-// user-facing store (admin-only wire), and the #474 rule is "prefer leaving
-// it out over showing a stale value confidently".
+// reason), connected-since, services flavor, AND (scope B) the live upstream
+// connection facts under `network.connection`: which box the socket dialled
+// (`server:port`), whether it is TLS, and whether the nick is identified to
+// services. `connection` is null when the session is not live (honesty), so
+// those rows appear ONLY when there is a real connected socket.
 
 const now = Date.parse("2026-07-31T12:00:00.000Z");
 
@@ -24,6 +25,7 @@ const baseNet: Network = {
   connection_state: "connected",
   connection_state_reason: null,
   connection_state_changed_at: new Date(now - (4 * 3600 + 12 * 60) * 1000).toISOString(),
+  connection: { server: "89.31.72.10", port: 6697, tls: true, registered: true },
   inserted_at: "2026-07-01T00:00:00.000Z",
   updated_at: "2026-07-01T00:00:00.000Z",
 };
@@ -46,6 +48,7 @@ describe("ServerInfoCard", () => {
           ...baseNet,
           connection_state: "parked",
           connection_state_reason: "user /disconnect",
+          connection: null,
         }}
         now={now}
       />
@@ -64,6 +67,7 @@ describe("ServerInfoCard", () => {
           ...baseNet,
           connection_state: "failed",
           connection_state_reason: "SASL 904 authentication failed",
+          connection: null,
         }}
         now={now}
       />
@@ -86,5 +90,43 @@ describe("ServerInfoCard", () => {
     render(() => <ServerInfoCard network={{ ...baseNet, services_flavor: "unknown" }} now={now} />);
     const card = screen.getByTestId("rail-server-info");
     expect(card.textContent).not.toContain("services");
+  });
+
+  it("renders the dialled server:port, a TLS lock and identified state (#474 B)", () => {
+    render(() => <ServerInfoCard network={baseNet} now={now} />);
+    const card = screen.getByTestId("rail-server-info");
+    // The box the session actually landed on (round-robin triage).
+    expect(card.textContent).toContain("89.31.72.10:6697");
+    // TLS lock present on a secure link.
+    expect(card.querySelector("[aria-label='TLS']")).not.toBeNull();
+    // +r registered → identified to services.
+    expect(card.querySelector("[data-testid=rail-server-info-identified]")?.textContent).toBe(
+      "yes",
+    );
+  });
+
+  it("shows the non-TLS + not-identified state honestly", () => {
+    render(() => (
+      <ServerInfoCard
+        network={{
+          ...baseNet,
+          connection: { server: "127.0.0.1", port: 6667, tls: false, registered: false },
+        }}
+        now={now}
+      />
+    ));
+    const card = screen.getByTestId("rail-server-info");
+    expect(card.textContent).toContain("127.0.0.1:6667");
+    // No lock on a plain-text socket.
+    expect(card.querySelector("[aria-label='TLS']")).toBeNull();
+    expect(card.querySelector("[data-testid=rail-server-info-identified]")?.textContent).toBe("no");
+  });
+
+  it("shows NO connection rows when connection is null (session not live)", () => {
+    render(() => <ServerInfoCard network={{ ...baseNet, connection: null }} now={now} />);
+    const card = screen.getByTestId("rail-server-info");
+    expect(card.textContent).not.toContain("89.31.72.10");
+    expect(card.querySelector("[aria-label='TLS']")).toBeNull();
+    expect(card.querySelector("[data-testid=rail-server-info-identified]")).toBeNull();
   });
 });

--- a/cicchetto/src/__tests__/ServerInfoCard.test.tsx
+++ b/cicchetto/src/__tests__/ServerInfoCard.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from "@solidjs/testing-library";
+import { describe, expect, it } from "vitest";
+import type { Network } from "../lib/api";
+import ServerInfoCard from "../ServerInfoCard";
+
+// #474 — the server-window rail card. Pure presentational: it takes the
+// already-in-store `Network` + an injected `now` (epoch ms) so the rendered
+// duration is deterministic. Facts-only — slug, nick, connection state (+
+// reason), connected-since, services flavor. It deliberately does NOT show
+// the dialled server address / TLS / registered state: those are NOT in the
+// user-facing store (admin-only wire), and the #474 rule is "prefer leaving
+// it out over showing a stale value confidently".
+
+const now = Date.parse("2026-07-31T12:00:00.000Z");
+
+const baseNet: Network = {
+  kind: "user",
+  id: 7,
+  slug: "libera",
+  services_flavor: "atheme",
+  nick: "vjt",
+  ident: "vjt",
+  realname: "VJT",
+  connection_state: "connected",
+  connection_state_reason: null,
+  connection_state_changed_at: new Date(now - (4 * 3600 + 12 * 60) * 1000).toISOString(),
+  inserted_at: "2026-07-01T00:00:00.000Z",
+  updated_at: "2026-07-01T00:00:00.000Z",
+};
+
+describe("ServerInfoCard", () => {
+  it("renders the network slug, own nick, connected state, uptime and services", () => {
+    render(() => <ServerInfoCard network={baseNet} now={now} />);
+    const card = screen.getByTestId("rail-server-info");
+    expect(card.textContent).toContain("libera"); // network slug (the only label)
+    expect(card.textContent).toContain("vjt"); // own nick on this network
+    expect(card.textContent).toContain("connected"); // connection-state word (a11y label)
+    expect(card.textContent).toContain("4h 12m"); // connected-since duration
+    expect(card.textContent).toContain("atheme"); // services flavor
+  });
+
+  it("shows NO uptime row when the state is parked, but shows the state + reason", () => {
+    render(() => (
+      <ServerInfoCard
+        network={{
+          ...baseNet,
+          connection_state: "parked",
+          connection_state_reason: "user /disconnect",
+        }}
+        now={now}
+      />
+    ));
+    const card = screen.getByTestId("rail-server-info");
+    expect(card.textContent).toContain("parked");
+    expect(card.textContent).toContain("user /disconnect");
+    // Honesty: a "connected for 4h 12m" line would be a lie while parked.
+    expect(card.textContent).not.toContain("4h 12m");
+  });
+
+  it("shows the failed state with its reason", () => {
+    render(() => (
+      <ServerInfoCard
+        network={{
+          ...baseNet,
+          connection_state: "failed",
+          connection_state_reason: "SASL 904 authentication failed",
+        }}
+        now={now}
+      />
+    ));
+    const card = screen.getByTestId("rail-server-info");
+    expect(card.textContent).toContain("failed");
+    expect(card.textContent).toContain("SASL 904 authentication failed");
+  });
+
+  it("omits the uptime row when connected but the timestamp is unknown (null)", () => {
+    render(() => (
+      <ServerInfoCard network={{ ...baseNet, connection_state_changed_at: null }} now={now} />
+    ));
+    const card = screen.getByTestId("rail-server-info");
+    expect(card.textContent).toContain("connected");
+    expect(card.textContent).not.toContain("4h 12m");
+  });
+
+  it("omits the services row when the flavor is unknown (no useful fact)", () => {
+    render(() => <ServerInfoCard network={{ ...baseNet, services_flavor: "unknown" }} now={now} />);
+    const card = screen.getByTestId("rail-server-info");
+    expect(card.textContent).not.toContain("services");
+  });
+});

--- a/cicchetto/src/__tests__/api.test.ts
+++ b/cicchetto/src/__tests__/api.test.ts
@@ -427,6 +427,7 @@ describe("ownNickForNetwork (cic H3 fix + bucket F H4 type split)", () => {
     connection_state: "connected",
     connection_state_reason: null,
     connection_state_changed_at: null,
+    connection: null,
     services_flavor: "azzurra",
     inserted_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
@@ -441,6 +442,7 @@ describe("ownNickForNetwork (cic H3 fix + bucket F H4 type split)", () => {
     connection_state: "connected",
     connection_state_reason: null,
     connection_state_changed_at: null,
+    connection: null,
     services_flavor: "azzurra",
     inserted_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
@@ -455,6 +457,7 @@ describe("ownNickForNetwork (cic H3 fix + bucket F H4 type split)", () => {
     connection_state: "parked",
     connection_state_reason: null,
     connection_state_changed_at: null,
+    connection: null,
     services_flavor: null,
     inserted_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
@@ -544,6 +547,7 @@ describe("tagNetwork (bucket F H4)", () => {
       connection_state: "connected",
       connection_state_reason: null,
       connection_state_changed_at: null,
+      connection: null,
       services_flavor: null,
       inserted_at: "2026-01-01T00:00:00Z",
       updated_at: "2026-01-01T00:00:00Z",
@@ -575,6 +579,14 @@ describe("tagNetwork (bucket F H4)", () => {
     // rawComplete omits the field → the tagger defaults it to null (legacy
     // credential / pre-field server).
     expect(api.tagNetwork(rawComplete)?.services_flavor).toBeNull();
+  });
+
+  it("#474 B — passes connection through; defaults a missing one to null", () => {
+    const conn = { server: "89.31.72.10", port: 6697, tls: true, registered: true };
+    expect(api.tagNetwork({ ...rawComplete, connection: conn })?.connection).toEqual(conn);
+    // rawComplete omits it → null (session not live / pre-field server), the
+    // honest "no live connection" the server-info rail renders as no card.
+    expect(api.tagNetwork(rawComplete)?.connection).toBeNull();
   });
 
   it("kind=user + missing nick → returns null + logs", () => {

--- a/cicchetto/src/__tests__/duration.test.ts
+++ b/cicchetto/src/__tests__/duration.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { formatDuration, formatDurationSince } from "../lib/duration";
+
+// #474 — shared human-duration formatter, lifted from WhoisCard's private
+// `formatIdle` so the server-info rail card and the whois idle row render
+// the same "4h 12m" / "2d 3h" shape from ONE implementation (DRY). The
+// server card additionally needs "connected for <duration>" from a wire
+// ISO timestamp, hence `formatDurationSince`.
+
+describe("formatDuration (seconds → human)", () => {
+  it("returns null for null", () => {
+    expect(formatDuration(null)).toBeNull();
+  });
+
+  it("renders sub-minute as seconds", () => {
+    expect(formatDuration(0)).toBe("0s");
+    expect(formatDuration(45)).toBe("45s");
+  });
+
+  it("renders minutes under an hour", () => {
+    expect(formatDuration(90)).toBe("1m");
+    expect(formatDuration(59 * 60)).toBe("59m");
+  });
+
+  it("renders hours+minutes under a day", () => {
+    // 4h 12m = 15120s — the issue's own example.
+    expect(formatDuration(4 * 3600 + 12 * 60)).toBe("4h 12m");
+    expect(formatDuration(3600)).toBe("1h 0m");
+  });
+
+  it("renders days+hours past a day", () => {
+    expect(formatDuration(2 * 86400 + 3 * 3600)).toBe("2d 3h");
+  });
+});
+
+describe("formatDurationSince (wire ISO + now → human)", () => {
+  const now = Date.parse("2026-07-31T12:00:00.000Z");
+
+  it("returns null for a null timestamp", () => {
+    expect(formatDurationSince(null, now)).toBeNull();
+  });
+
+  it("returns null for an unparseable timestamp (never a confident-wrong value)", () => {
+    expect(formatDurationSince("not-a-date", now)).toBeNull();
+  });
+
+  it("renders the elapsed duration from the ISO instant to now", () => {
+    const since = new Date(now - (4 * 3600 + 12 * 60) * 1000).toISOString();
+    expect(formatDurationSince(since, now)).toBe("4h 12m");
+  });
+
+  it("clamps a future timestamp (clock skew) to 0s rather than going negative", () => {
+    const future = new Date(now + 5000).toISOString();
+    expect(formatDurationSince(future, now)).toBe("0s");
+  });
+});

--- a/cicchetto/src/__tests__/userTopic.test.ts
+++ b/cicchetto/src/__tests__/userTopic.test.ts
@@ -760,6 +760,32 @@ describe("userTopic", () => {
       expect(lb.clearLusersRequested).not.toHaveBeenCalled();
     });
 
+    // #474 B — the LIVE `connection` facts (dialled server / TLS / +r) reach
+    // the store ONLY via a full GET /networks. "connected" (001 RPL_WELCOME)
+    // is the first moment the peer is captured, so the arm refetches to fill
+    // the server-window rail card. Without this the card is blank exactly
+    // after a runtime reconnect (the #550 case) until a page reload, because
+    // the connection_state_changed refetch already fired pre-peer-capture.
+    it("refetches /networks on state connected (fills #474 B connection facts)", async () => {
+      const nw = await import("../lib/networks");
+      channelMock.fireEvent({
+        kind: "connection_progress",
+        network: "bahamut-test",
+        state: "connected",
+      });
+      expect(nw.refetchNetworks).toHaveBeenCalled();
+    });
+
+    it("does NOT refetch /networks on state connecting (peer not yet up)", async () => {
+      const nw = await import("../lib/networks");
+      channelMock.fireEvent({
+        kind: "connection_progress",
+        network: "bahamut-test",
+        state: "connecting",
+      });
+      expect(nw.refetchNetworks).not.toHaveBeenCalled();
+    });
+
     it("drops payload with an unknown state (no setReconnecting call)", async () => {
       const rs = await import("../lib/reconnectingStatus");
       channelMock.fireEvent({

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -38,6 +38,7 @@ import type {
   NetworksServersAdminWireT,
   NetworksWireAvailableNetworkRow,
   NetworksWireChannelJson,
+  NetworksWireConnectionInfo,
   NetworksWireCredentialJson,
   NetworksWireHomeData,
   NetworksWireHomeNetworkRow,
@@ -240,6 +241,12 @@ export type ConnectionState = NetworksCredentialConnectionState;
 // #410 — single-sourced to the codegen mirror of
 // `Grappa.Networks.Network.services_flavor`.
 export type ServicesFlavor = NetworksNetworkServicesFlavor;
+
+// #474 scope B — the live upstream connection facts a network row carries
+// under `connection` (which box the socket dialled, TLS, +r registered).
+// Re-exported under the domain name (mirror of ConnectionState/ServicesFlavor)
+// so ServerInfoCard imports `ConnectionInfo`, not the leaky codegen alias.
+export type ConnectionInfo = NetworksWireConnectionInfo;
 
 // UX-4 bucket B — one row in the `home_data.networks` array, returned
 // from `GET /me` for user subjects. Mirror of server-side
@@ -469,6 +476,11 @@ export type RawNetwork = {
   // servers that predate the field; `tagNetwork` defaults a missing
   // value to null (→ wizard button hidden).
   services_flavor?: ServicesFlavor | null;
+  // #474 scope B — the live upstream connection facts (null when the
+  // session is not live). Optional on the raw type for legacy fixtures /
+  // mid-rollout servers that predate it; `tagNetwork` defaults a missing
+  // value to null (→ the server-info rail shows no connection card).
+  connection?: ConnectionInfo | null;
   inserted_at: string;
   updated_at: string;
 };
@@ -513,6 +525,7 @@ export function tagNetwork(raw: RawNetwork): Network | null {
     connection_state: raw.connection_state,
     connection_state_reason: raw.connection_state_reason ?? null,
     connection_state_changed_at: raw.connection_state_changed_at ?? null,
+    connection: raw.connection ?? null,
     services_flavor: raw.services_flavor ?? null,
     inserted_at: raw.inserted_at,
     updated_at: raw.updated_at,

--- a/cicchetto/src/lib/duration.ts
+++ b/cicchetto/src/lib/duration.ts
@@ -1,0 +1,39 @@
+// Human-readable duration formatting. Lifted from WhoisCard's private
+// `formatIdle` (#474) so the WHOIS idle row and the server-info rail card
+// render the same "45s" / "1m" / "4h 12m" / "2d 3h" shape from ONE
+// implementation — never a copy-with-tweaks. cic owns the human strings
+// (per `feedback_no_localized_strings_server_side`); the server emits only
+// typed seconds / ISO instants.
+
+/**
+ * Format an elapsed span (in whole seconds) as a compact human string:
+ *   <60s → "45s"; <60m → "12m"; <24h → "4h 12m"; else → "2d 3h".
+ * Returns null for a null input so callers can `<Show>`-gate the row.
+ */
+export function formatDuration(seconds: number | null): string | null {
+  if (seconds === null) return null;
+  if (seconds < 60) return `${seconds}s`;
+  const mins = Math.floor(seconds / 60);
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ${mins % 60}m`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ${hours % 24}h`;
+}
+
+/**
+ * Format the span between a wire ISO-8601 instant and `nowMs` (epoch ms)
+ * as a human duration — e.g. a network's `connection_state_changed_at`
+ * rendered as "connected for 4h 12m".
+ *
+ * Returns null for a null or unparseable timestamp (prefer omitting the
+ * row over a confident-wrong value, per the #474 facts-only rule). A
+ * future timestamp (clock skew) clamps to "0s" rather than going negative.
+ */
+export function formatDurationSince(iso: string | null, nowMs: number): string | null {
+  if (iso === null) return null;
+  const thenMs = Date.parse(iso);
+  if (Number.isNaN(thenMs)) return null;
+  const seconds = Math.max(0, Math.floor((nowMs - thenMs) / 1000));
+  return formatDuration(seconds);
+}

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -1366,6 +1366,20 @@ createRoot(() => {
           // stale flag left by a /lusers issued on a prior (now-dead)
           // session. Clear on the "connecting" edge (before the burst).
           if (payload.state === "connecting") clearLusersRequested(payload.network);
+          // #474 B — refetch the per-network rows once the socket is truly up.
+          // The LIVE `connection` facts (dialled server / port / TLS / +r
+          // identified) reach the store ONLY via a full GET /networks, and the
+          // only other trigger — connection_state_changed — fires at the DB
+          // :parked → :connected flip, BEFORE the peer is captured (its refetch
+          // returns connection: null). "connected" is 001 RPL_WELCOME: the peer
+          // IS captured and (for SASL) +r is already set, so refetch now to fill
+          // the server-window rail card. Without this the card is blank exactly
+          // after a runtime reconnect — the #550 netsplit-triage case the card
+          // exists for. GET /networks emits no connection_progress, so no loop.
+          // Known follow-on (#474): a nick that gains +r LATER via post-connect
+          // NickServ IDENTIFY (auth_method :nickserv_identify) reads
+          // identified="no" until the next natural refetch — not chased here.
+          if (payload.state === "connected") refetchNetworks();
           return;
 
         // #247 — /notify watch list + presence. Full-list snapshot

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -567,6 +567,13 @@ export type NetworksWireCredentialJson = {
   updated_at: string;
 };
 
+export type NetworksWireConnectionInfo = {
+  server: string;
+  port: number;
+  tls: boolean;
+  registered: boolean;
+};
+
 export type NetworksWireNetworkWithNickJson = {
   kind: "user";
   id: number;
@@ -578,6 +585,7 @@ export type NetworksWireNetworkWithNickJson = {
   connection_state: NetworksCredentialConnectionState;
   connection_state_reason: string | null;
   connection_state_changed_at: string | null;
+  connection: NetworksWireConnectionInfo | null;
   inserted_at: string;
   updated_at: string;
 };
@@ -593,6 +601,7 @@ export type NetworksWireVisitorNetworkWithNickJson = {
   connection_state: NetworksCredentialConnectionState;
   connection_state_reason: string | null;
   connection_state_changed_at: string | null;
+  connection: NetworksWireConnectionInfo | null;
   inserted_at: string;
   updated_at: string;
 };

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -7020,6 +7020,55 @@ html.resize-dragging * {
 /* P-0d — LUSERS card. Pinned at the top of the current window when a
    snapshot exists (#231). Visual mirrors `.whois-card` (border-left
    accent, dim panel) — same family of structured single-entity cards. */
+/* #474 — server-info rail card. The rail's per-window-kind context surface
+   (RailContext) on a server window; mirror of the `.lusers-card` dl shape.
+   `flex: 0 0 auto` so it takes only its content height and the sibling
+   `.rail-actions` drawer still floors the rail (margin-top:auto), never
+   pushed off-screen on a phone. */
+.rail-server-info {
+  flex: 0 0 auto;
+  margin: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  background: var(--bg-alt);
+  font-size: 0.85rem;
+}
+
+.rail-server-info-header {
+  display: flex;
+  align-items: baseline;
+  font-weight: bold;
+  color: var(--accent);
+  margin-bottom: 0.25rem;
+}
+
+.rail-server-info-title {
+  text-transform: lowercase;
+  word-break: break-all;
+}
+
+.rail-server-info-fields {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.15rem 0.75rem;
+  margin: 0;
+}
+
+.rail-server-info-fields dt {
+  color: var(--muted);
+  text-align: right;
+}
+
+.rail-server-info-fields dd {
+  margin: 0;
+  word-break: break-word;
+}
+
+.rail-server-info-glyph {
+  font-size: 0.8rem;
+}
+
 .lusers-card {
   margin: 0.25rem 0.5rem 0.5rem 0.5rem;
   padding: 0.5rem 0.75rem;

--- a/lib/grappa/networks/wire.ex
+++ b/lib/grappa/networks/wire.ex
@@ -45,6 +45,25 @@ defmodule Grappa.Networks.Wire do
         }
 
   @typedoc """
+  #474 scope B — the LIVE upstream connection facts embedded under
+  `:connection` on both `GET /networks` twins: which box the socket dialled
+  (`:server` = the resolved peer IP string, #550), the transport `:tls`
+  posture, and whether the nick is identified to services (`:registered`,
+  from the +r umode — the same identity signal #561 keys on). All are live
+  Session.Server state (no new IRC traffic); the `:connection` field is
+  `nil` whenever there is no live connected session (parked / failed /
+  reconnecting), the honest "no live connection" signal — prefer omitting
+  over a stale value. Sourced by the controller via
+  `Grappa.Session.connection_info/2`.
+  """
+  @type connection_info :: %{
+          server: String.t(),
+          port: integer(),
+          tls: boolean(),
+          registered: boolean()
+        }
+
+  @typedoc """
   Wire shape for `GET /networks` when the caller has a USER `Credential`
   row — carries `:nick` (the per-network configured IRC nick) AND the
   T32 connection-state fields (`:connection_state`,
@@ -79,6 +98,7 @@ defmodule Grappa.Networks.Wire do
           connection_state: Credential.connection_state(),
           connection_state_reason: String.t() | nil,
           connection_state_changed_at: String.t() | nil,
+          connection: connection_info() | nil,
           inserted_at: String.t(),
           updated_at: String.t()
         }
@@ -121,6 +141,7 @@ defmodule Grappa.Networks.Wire do
           connection_state: Credential.connection_state(),
           connection_state_reason: String.t() | nil,
           connection_state_changed_at: String.t() | nil,
+          connection: connection_info() | nil,
           inserted_at: String.t(),
           updated_at: String.t()
         }
@@ -282,10 +303,14 @@ defmodule Grappa.Networks.Wire do
   fields are always credential-row-of-record (DB-persisted user intent),
   so they come straight off the credential without divergence.
   """
-  @spec network_with_nick_to_json(Network.t(), String.t(), Credential.t()) ::
-          network_with_nick_json()
-  def network_with_nick_to_json(%Network{} = n, nick, %Credential{} = cred)
-      when is_binary(nick) and nick != "" do
+  @spec network_with_nick_to_json(
+          Network.t(),
+          String.t(),
+          Credential.t(),
+          connection_info() | nil
+        ) :: network_with_nick_json()
+  def network_with_nick_to_json(%Network{} = n, nick, %Credential{} = cred, connection)
+      when is_binary(nick) and nick != "" and (is_map(connection) or is_nil(connection)) do
     %{
       kind: :user,
       id: n.id,
@@ -297,13 +322,14 @@ defmodule Grappa.Networks.Wire do
       connection_state: cred.connection_state,
       connection_state_reason: cred.connection_state_reason,
       connection_state_changed_at: WireTime.iso8601_or_nil(cred.connection_state_changed_at),
+      connection: connection_json(connection),
       inserted_at: DateTime.to_iso8601(n.inserted_at),
       updated_at: DateTime.to_iso8601(n.updated_at)
     }
   end
 
   @doc """
-  #211 phase 6 — the VISITOR twin of `network_with_nick_to_json/3`.
+  #211 phase 6 — the VISITOR twin of `network_with_nick_to_json/4`.
   Renders a `Networks.Network` + the visitor credential's live-nick +
   the credential's `connection_state` fields to the
   `visitor_network_with_nick_json` shape used by `GET /networks` for
@@ -321,10 +347,14 @@ defmodule Grappa.Networks.Wire do
   discriminator differs from the user twin (`:visitor` vs `:user`) so
   cic resolves the correct subject-scoped nick.
   """
-  @spec visitor_network_to_json(Network.t(), String.t(), Credential.t()) ::
-          visitor_network_with_nick_json()
-  def visitor_network_to_json(%Network{} = n, nick, %Credential{} = cred)
-      when is_binary(nick) and nick != "" do
+  @spec visitor_network_to_json(
+          Network.t(),
+          String.t(),
+          Credential.t(),
+          connection_info() | nil
+        ) :: visitor_network_with_nick_json()
+  def visitor_network_to_json(%Network{} = n, nick, %Credential{} = cred, connection)
+      when is_binary(nick) and nick != "" and (is_map(connection) or is_nil(connection)) do
     %{
       kind: :visitor,
       id: n.id,
@@ -336,6 +366,7 @@ defmodule Grappa.Networks.Wire do
       connection_state: cred.connection_state,
       connection_state_reason: cred.connection_state_reason,
       connection_state_changed_at: WireTime.iso8601_or_nil(cred.connection_state_changed_at),
+      connection: connection_json(connection),
       inserted_at: DateTime.to_iso8601(n.inserted_at),
       updated_at: DateTime.to_iso8601(n.updated_at)
     }
@@ -442,5 +473,16 @@ defmodule Grappa.Networks.Wire do
       networks: Enum.map(pairs, fn {cred, nick} -> home_network_row(cred, nick) end),
       available_networks: Enum.map(available_slugs, fn slug -> %{slug: slug} end)
     }
+  end
+
+  # #474 B — projects the `Grappa.Session.connection_info/2` result (the map
+  # the controller resolved, or nil when there is no live connected session)
+  # onto the exact `:connection` wire shape. Rebuilt field-by-field rather
+  # than passed through so this module stays the SSOT for the JSON shape.
+  @spec connection_json(connection_info() | nil) :: connection_info() | nil
+  defp connection_json(nil), do: nil
+
+  defp connection_json(%{server: server, port: port, tls: tls, registered: registered}) do
+    %{server: server, port: port, tls: tls, registered: registered}
   end
 end

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -889,26 +889,71 @@ defmodule Grappa.Session do
     call_session(subject, network_id, {:list_channels}, timeout_ms)
   end
 
+  @typedoc """
+  #474 B — the live upstream connection facts for a session: which box the
+  socket dialled (`server` = peer IP string), the transport TLS posture,
+  and whether the nick is identified to services (`registered`, from the
+  +r umode). Present only while connected; the accessors below degrade to
+  `{:error, :no_peer}` otherwise.
+  """
+  @type connection_info :: %{
+          server: String.t(),
+          port: :inet.port_number(),
+          tls: boolean(),
+          registered: boolean()
+        }
+
+  @doc """
+  Returns the live upstream connection facts for the session at
+  `(subject, network_id)` — `%{server, port, tls, registered}` (#474 B,
+  the server-window rail card).
+
+  `server` is the peer IP as a string (`:inet.ntoa/1` of the v6/v4 tuple),
+  captured once at connect and cached (immutable for the connection), so
+  this is an instant state read; `registered` is derived from the live
+  umode set (the same +r identity signal #561 keys on).
+
+  Returns `{:error, :no_peer}` in every not-connected window (pre-connect,
+  mid-reconnect, socket just closed) — the honest "unknown", never
+  fabricated facts — and `{:error, :no_session}` when no session is
+  registered for `(subject, network_id)`.
+  """
+  @spec connection_info(subject(), integer()) ::
+          {:ok, connection_info()} | {:error, :no_session | :no_peer}
+  def connection_info(subject, network_id)
+      when is_subject(subject) and is_integer(network_id) do
+    call_session(subject, network_id, {:connection_info})
+  end
+
+  @doc """
+  Variant of `connection_info/2` accepting an explicit per-call receive
+  `timeout_ms` — `{:error, :timeout}` instead of the default 5s exit
+  cascade for a mailbox-bloated pid. `:infinity` delegates to the
+  underlying GenServer.call.
+  """
+  @spec connection_info(subject(), integer(), timeout()) ::
+          {:ok, connection_info()} | {:error, :no_session | :no_peer | :timeout}
+  def connection_info(subject, network_id, timeout_ms)
+      when is_subject(subject) and is_integer(network_id) and
+             (is_integer(timeout_ms) or timeout_ms == :infinity) do
+    call_session(subject, network_id, {:connection_info}, timeout_ms)
+  end
+
   @doc """
   Returns the upstream peer (`{address, port}`) the session at
   `(subject, network_id)` is connected to — the destination the IRC
   socket actually landed on (#550, netsplit triage).
 
-  `address` is the peer IP as a string (`:inet.ntoa/1` of the v6/v4
-  tuple). The peer is captured once at connect and cached on the
-  Session.Server (immutable for the connection's lifetime), so this is
-  an instant state read.
-
-  Returns `{:error, :no_peer}` in every not-connected window (pre-connect,
-  mid-reconnect, socket just closed) — the honest "unknown", never a
-  fabricated address — and `{:error, :no_session}` when no session is
-  registered for `(subject, network_id)`.
+  The `{server, port}` projection of `connection_info/2` — ONE underlying
+  accessor, no second overlapping handler. `address` is the peer IP as a
+  string. Same `{:error, :no_peer}` / `{:error, :no_session}` degraded
+  signals.
   """
   @spec peer_address(subject(), integer()) ::
           {:ok, {String.t(), :inet.port_number()}} | {:error, :no_session | :no_peer}
   def peer_address(subject, network_id)
       when is_subject(subject) and is_integer(network_id) do
-    call_session(subject, network_id, {:peer_address})
+    subject |> connection_info(network_id) |> project_peer_address()
   end
 
   @doc """
@@ -926,8 +971,13 @@ defmodule Grappa.Session do
   def peer_address(subject, network_id, timeout_ms)
       when is_subject(subject) and is_integer(network_id) and
              (is_integer(timeout_ms) or timeout_ms == :infinity) do
-    call_session(subject, network_id, {:peer_address}, timeout_ms)
+    subject |> connection_info(network_id, timeout_ms) |> project_peer_address()
   end
+
+  @spec project_peer_address({:ok, connection_info()} | {:error, atom()}) ::
+          {:ok, {String.t(), :inet.port_number()}} | {:error, atom()}
+  defp project_peer_address({:ok, %{server: server, port: port}}), do: {:ok, {server, port}}
+  defp project_peer_address({:error, _} = err), do: err
 
   @doc """
   Returns the network's IRC `CASEMAPPING` as observed by the LIVE session at

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -1035,7 +1035,12 @@ defmodule Grappa.Session.Server do
       # (SessionPlan.resolve sets it from the network's server row). Immutable
       # for the session; surfaced (with peer_address + the +r umode) by
       # `Grappa.Session.connection_info/2` for the server-window rail card.
-      tls: Map.get(opts, :tls, false),
+      # `opts.tls` (not `Map.get` default): `:tls` is a REQUIRED start_opt
+      # (`client_opts/1` reads it directly at connect too) — a plan that
+      # omitted it must crash loud here, not silently render plaintext. The
+      # hot-safety default lives ONLY in the handler's `Map.get(state, :tls)`
+      # (a pre-#474 live proc lacks the state key; a fresh opts map never does).
+      tls: opts.tls,
       notify_pid: Map.get(opts, :notify_pid),
       notify_ref: Map.get(opts, :notify_ref),
       pending_auth: nil,

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -569,6 +569,10 @@ defmodule Grappa.Session.Server do
           # (`:inet.ntoa/1`) at capture so the read side stays format-free.
           peer_address: String.t() | nil,
           peer_port: :inet.port_number() | nil,
+          # #474 B — the dialled transport's TLS posture (from the resolved
+          # plan); immutable for the session. Read alongside peer_address +
+          # the +r umode by `handle_call({:connection_info}, ...)`.
+          tls: boolean(),
           notify_pid: pid() | nil,
           notify_ref: reference() | nil,
           pending_auth: nil | {String.t(), integer()},
@@ -1027,6 +1031,11 @@ defmodule Grappa.Session.Server do
       # #550 — nil until the Client pushes {:irc_peer, _} at connect.
       peer_address: nil,
       peer_port: nil,
+      # #474 B — the dialled transport's TLS posture, from the resolved plan
+      # (SessionPlan.resolve sets it from the network's server row). Immutable
+      # for the session; surfaced (with peer_address + the +r umode) by
+      # `Grappa.Session.connection_info/2` for the server-window rail card.
+      tls: Map.get(opts, :tls, false),
       notify_pid: Map.get(opts, :notify_pid),
       notify_ref: Map.get(opts, :notify_ref),
       pending_auth: nil,
@@ -2043,16 +2052,30 @@ defmodule Grappa.Session.Server do
     {:reply, {:ok, channels}, state}
   end
 
-  # #550 — the cached upstream peer (destination) for the admin Sessions
-  # inventory. Instant state read; `{:error, :no_peer}` in every
-  # not-connected window (pre-connect, mid-reconnect, socket just closed) is
-  # the honest degraded signal. Public via `Grappa.Session.peer_address/3`.
-  def handle_call({:peer_address}, _, %{peer_address: nil} = state) do
+  # #550 + #474 B — the live upstream connection facts, read in one state pass:
+  # the cached peer (destination the socket dialled) for the admin Sessions
+  # inventory (#550), plus the transport TLS posture + whether the nick is
+  # identified to services (the +r umode) for the server-window rail card
+  # (#474 B). `{:error, :no_peer}` in every not-connected window (pre-connect,
+  # mid-reconnect, socket just closed) is the honest degraded signal — no
+  # fabricated address. ONE accessor: `Grappa.Session.connection_info/3`
+  # returns the full map; `Grappa.Session.peer_address/3` is the {server, port}
+  # projection over this same call (no second overlapping handler). `tls` +
+  # `umodes` via `Map.get` for the #216 hot-reload-safety contract (a session
+  # started before #474 has neither key in state).
+  def handle_call({:connection_info}, _, %{peer_address: nil} = state) do
     {:reply, {:error, :no_peer}, state}
   end
 
-  def handle_call({:peer_address}, _, state) do
-    {:reply, {:ok, {state.peer_address, state.peer_port}}, state}
+  def handle_call({:connection_info}, _, state) do
+    info = %{
+      server: state.peer_address,
+      port: state.peer_port,
+      tls: Map.get(state, :tls, false),
+      registered: "r" in Map.get(state, :umodes, [])
+    }
+
+    {:reply, {:ok, info}, state}
   end
 
   # #537 INC-2.3 — the network's CASEMAPPING for the stateless web-edge

--- a/lib/grappa/visitors/wire.ex
+++ b/lib/grappa/visitors/wire.ex
@@ -12,7 +12,7 @@ defmodule Grappa.Visitors.Wire do
   incognito}` (`incognito` #363 — the ephemeral-session flag; cic marks the
   session and disables share-session from it, never any secret).
   Per-network nick + connection state live on the `GET /networks` rows
-  (`Grappa.Networks.Wire.visitor_network_to_json/3`); cic resolves "my nick
+  (`Grappa.Networks.Wire.visitor_network_to_json/4`); cic resolves "my nick
   on network X" from there (`ownNickForNetwork`), never from the subject.
 
   `registered` is DERIVED from the credentials (≥1 credential holding a

--- a/lib/grappa_web/controllers/networks_controller.ex
+++ b/lib/grappa_web/controllers/networks_controller.ex
@@ -43,8 +43,8 @@ defmodule GrappaWeb.NetworksController do
   must not dep `Admission` to avoid a cycle, and the orchestrator's
   own top-level boundary deps both freely.
 
-  Wire shapes live in `Grappa.Networks.Wire` — `network_with_nick_to_json/3`
-  (user GET row), `visitor_network_to_json/3` (visitor GET row), and
+  Wire shapes live in `Grappa.Networks.Wire` — `network_with_nick_to_json/4`
+  (user GET row), `visitor_network_to_json/4` (visitor GET row), and
   `credential_to_json/1` (PATCH). The view layer (`NetworksJSON`) is a
   thin delegator.
   """
@@ -80,12 +80,15 @@ defmodule GrappaWeb.NetworksController do
         # needs to derive the per-network + cascading per-channel greyed
         # treatment. nick stays the live-vs-configured Session.Server
         # value; T32 fields come straight off the credential row of record.
-        network_triples =
+        network_rows =
           Enum.map(credentials, fn cred ->
-            {cred.network, Networks.resolve_network_nick({:user, user.id}, cred), cred}
+            subject = {:user, user.id}
+
+            {cred.network, Networks.resolve_network_nick(subject, cred), cred,
+             resolve_connection_info(subject, cred.network_id)}
           end)
 
-        render(conn, :index, networks: {:user, network_triples})
+        render(conn, :index, networks: {:user, network_rows})
 
       {:visitor, visitor} ->
         # #211 phase 6 — list-shaped visitor branch (ruling A). A visitor
@@ -100,12 +103,29 @@ defmodule GrappaWeb.NetworksController do
         # is dropped from the wire this phase, the column at phase 7).
         credentials = Credentials.list_visitor_credentials(visitor.id)
 
-        network_triples =
+        network_rows =
           Enum.map(credentials, fn cred ->
-            {cred.network, Networks.resolve_network_nick({:visitor, visitor.id}, cred), cred}
+            subject = {:visitor, visitor.id}
+
+            {cred.network, Networks.resolve_network_nick(subject, cred), cred,
+             resolve_connection_info(subject, cred.network_id)}
           end)
 
-        render(conn, :index, networks: {:visitor, network_triples})
+        render(conn, :index, networks: {:visitor, network_rows})
+    end
+  end
+
+  # #474 B — resolve the LIVE upstream connection facts for a /networks row, or
+  # nil when there is no live connected session (parked / failed / no pid) — the
+  # honest "no connection" the server-window rail renders as an absent card.
+  # Same live-vs-DB split as `resolve_network_nick/2`: these facts come from the
+  # running Session.Server, never the credential row of record.
+  @spec resolve_connection_info(Session.subject(), integer()) ::
+          Session.connection_info() | nil
+  defp resolve_connection_info(subject, network_id) do
+    case Session.connection_info(subject, network_id) do
+      {:ok, info} -> info
+      {:error, _} -> nil
     end
   end
 

--- a/lib/grappa_web/controllers/networks_json.ex
+++ b/lib/grappa_web/controllers/networks_json.ex
@@ -30,18 +30,18 @@ defmodule GrappaWeb.NetworksJSON do
   """
   @spec index(%{
           networks:
-            {:user, [{Network.t(), String.t(), Credential.t()}]}
-            | {:visitor, [{Network.t(), String.t(), Credential.t()}]}
+            {:user, [{Network.t(), String.t(), Credential.t(), Wire.connection_info() | nil}]}
+            | {:visitor, [{Network.t(), String.t(), Credential.t(), Wire.connection_info() | nil}]}
         }) :: [Wire.network_with_nick_json()] | [Wire.visitor_network_with_nick_json()]
-  def index(%{networks: {:user, network_triples}}) do
-    Enum.map(network_triples, fn {network, nick, cred} ->
-      Wire.network_with_nick_to_json(network, nick, cred)
+  def index(%{networks: {:user, network_rows}}) do
+    Enum.map(network_rows, fn {network, nick, cred, connection} ->
+      Wire.network_with_nick_to_json(network, nick, cred, connection)
     end)
   end
 
-  def index(%{networks: {:visitor, network_triples}}) do
-    Enum.map(network_triples, fn {network, nick, cred} ->
-      Wire.visitor_network_to_json(network, nick, cred)
+  def index(%{networks: {:visitor, network_rows}}) do
+    Enum.map(network_rows, fn {network, nick, cred, connection} ->
+      Wire.visitor_network_to_json(network, nick, cred, connection)
     end)
   end
 

--- a/test/grappa/live_introspection_test.exs
+++ b/test/grappa/live_introspection_test.exs
@@ -46,8 +46,9 @@ defmodule Grappa.LiveIntrospectionTest do
       # #550 — the upstream peer is captured ASYNCHRONOUSLY: the Client dials
       # the in-process IRCServer, then pushes {:irc_peer, _} to Session.Server
       # which caches it. Until that message is processed the session is a live
-      # pid with peer_address: nil, so handle_call({:peer_address}) replies
-      # {:error, :no_peer} and `introspection_degraded` carries :peer_address
+      # pid with peer_address: nil, so handle_call({:connection_info}) replies
+      # {:error, :no_peer} (peer_address/3 projects it) and `introspection_degraded`
+      # carries :peer_address
       # (server.ex + fetch_peer_address). This test reads introspection_degraded
       # right after spawn, so without a barrier it races the capture — green
       # when the {:irc_peer, _} lands first (pull_request / local fast timing),

--- a/test/grappa/networks/wire_test.exs
+++ b/test/grappa/networks/wire_test.exs
@@ -169,7 +169,7 @@ defmodule Grappa.Networks.WireTest do
   end
 
   describe "services_flavor exposure (GH #349) on both GET /networks twins" do
-    test "network_with_nick_to_json/3 (user twin) carries services_flavor",
+    test "network_with_nick_to_json/4 (user twin) carries services_flavor",
          %{network: network} do
       net = %{network | services_flavor: :atheme}
 
@@ -180,13 +180,13 @@ defmodule Grappa.Networks.WireTest do
         connection_state_changed_at: DateTime.truncate(DateTime.utc_now(), :second)
       }
 
-      json = Wire.network_with_nick_to_json(net, "vjt", cred)
+      json = Wire.network_with_nick_to_json(net, "vjt", cred, nil)
 
       assert json.kind == :user
       assert json.services_flavor == :atheme
     end
 
-    test "visitor_network_to_json/3 (visitor twin) carries services_flavor",
+    test "visitor_network_to_json/4 (visitor twin) carries services_flavor",
          %{network: network} do
       net = %{network | services_flavor: :azzurra}
 
@@ -197,7 +197,7 @@ defmodule Grappa.Networks.WireTest do
         connection_state_changed_at: DateTime.truncate(DateTime.utc_now(), :second)
       }
 
-      json = Wire.visitor_network_to_json(net, "vjt", cred)
+      json = Wire.visitor_network_to_json(net, "vjt", cred, nil)
 
       assert json.kind == :visitor
       assert json.services_flavor == :azzurra
@@ -213,12 +213,56 @@ defmodule Grappa.Networks.WireTest do
       }
 
       # setup builds the network via find_or_create_network → nil flavor.
-      assert Wire.network_with_nick_to_json(network, "vjt", cred).services_flavor == nil
-      assert Wire.visitor_network_to_json(network, "vjt", cred).services_flavor == nil
+      assert Wire.network_with_nick_to_json(network, "vjt", cred, nil).services_flavor == nil
+      assert Wire.visitor_network_to_json(network, "vjt", cred, nil).services_flavor == nil
     end
   end
 
-  describe "visitor_network_to_json/3 (#211 phase 6 — visitor GET /networks row)" do
+  describe "connection field (#474 scope B) on both GET /networks twins" do
+    test "network_with_nick_to_json/4 embeds the live connection facts",
+         %{network: network} do
+      cred = %Credential{
+        network: network,
+        nick: "vjt",
+        connection_state: :connected,
+        connection_state_changed_at: DateTime.truncate(DateTime.utc_now(), :second)
+      }
+
+      conn = %{server: "89.31.72.10", port: 6697, tls: true, registered: true}
+      json = Wire.network_with_nick_to_json(network, "vjt", cred, conn)
+
+      assert json.connection == %{server: "89.31.72.10", port: 6697, tls: true, registered: true}
+    end
+
+    test "visitor_network_to_json/4 embeds the live connection facts",
+         %{network: network} do
+      cred = %Credential{
+        network: network,
+        nick: "vjt",
+        connection_state: :connected,
+        connection_state_changed_at: DateTime.truncate(DateTime.utc_now(), :second)
+      }
+
+      conn = %{server: "127.0.0.1", port: 6667, tls: false, registered: false}
+
+      assert Wire.visitor_network_to_json(network, "vjt", cred, conn).connection == conn
+    end
+
+    test "connection: nil when the session is not live (honest, no fabricated facts)",
+         %{network: network} do
+      cred = %Credential{
+        network: network,
+        nick: "vjt",
+        connection_state: :parked,
+        connection_state_changed_at: DateTime.truncate(DateTime.utc_now(), :second)
+      }
+
+      assert Wire.network_with_nick_to_json(network, "vjt", cred, nil).connection == nil
+      assert Wire.visitor_network_to_json(network, "vjt", cred, nil).connection == nil
+    end
+  end
+
+  describe "visitor_network_to_json/4 (#211 phase 6 — visitor GET /networks row)" do
     test "renders the visitor twin shape (kind: :visitor, nick, connection_state)",
          %{network: network} do
       cred = %Credential{
@@ -229,7 +273,7 @@ defmodule Grappa.Networks.WireTest do
         connection_state_changed_at: DateTime.truncate(DateTime.utc_now(), :second)
       }
 
-      json = Wire.visitor_network_to_json(network, "vjt-live", cred)
+      json = Wire.visitor_network_to_json(network, "vjt-live", cred, nil)
 
       assert json.kind == :visitor
       assert json.id == network.id
@@ -254,7 +298,7 @@ defmodule Grappa.Networks.WireTest do
         connection_state_changed_at: DateTime.truncate(DateTime.utc_now(), :second)
       }
 
-      json = Wire.visitor_network_to_json(network, "vjt", cred)
+      json = Wire.visitor_network_to_json(network, "vjt", cred, nil)
 
       assert json.connection_state == :parked
       assert json.connection_state_reason == "user-disconnect"
@@ -268,7 +312,7 @@ defmodule Grappa.Networks.WireTest do
         connection_state_changed_at: DateTime.truncate(DateTime.utc_now(), :second)
       }
 
-      assert is_binary(Jason.encode!(Wire.visitor_network_to_json(network, "vjt", cred)))
+      assert is_binary(Jason.encode!(Wire.visitor_network_to_json(network, "vjt", cred, nil)))
     end
   end
 

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -203,6 +203,65 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  describe "connection_info/2 (#474 scope B)" do
+    test "returns the live connection facts once connected (registered false pre-+r)" do
+      # #474 B — the server-window rail shows the upstream connection facts in
+      # one call: which box the session dialled (the resolved peer IP:port,
+      # captured at connect like peer_address/3), whether the link is TLS, and
+      # whether the nick is identified to services. All are LIVE state — no new
+      # IRC traffic. The session dialled the in-process IRCServer on
+      # 127.0.0.1:<port> over plain TCP and no +r umode has been observed yet,
+      # so tls + registered are both false.
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+      _ = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      assert {:ok, %{server: "127.0.0.1", port: ^port, tls: false, registered: false}} =
+               Session.connection_info({:user, user.id}, network.id)
+    end
+
+    test "reports registered: true once the self +r umode is observed" do
+      # registered = the nick is identified to services, DERIVED from the +r
+      # usermode (the same identity signal #561 binds the visitor nick on),
+      # never a bare boolean grappa invents. A 221 RPL_UMODEIS carrying +r
+      # populates state.umodes; the umode_changed broadcast is the "processed"
+      # barrier before we read connection_info.
+      handler = fn state, line ->
+        if String.starts_with?(line, "USER ") do
+          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
+        else
+          {:reply, nil, state}
+        end
+      end
+
+      {server, port} = start_server(handler)
+      {user, network, _} = setup_user_and_network(port)
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      IRCServer.feed(server, ":irc.test.org 221 grappa-test +r\r\n")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :umode_changed}
+                     },
+                     1_000
+
+      assert {:ok, %{registered: true}} =
+               Session.connection_info({:user, user.id}, network.id)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "returns {:error, :no_session} when no session is registered" do
+      assert {:error, :no_session} =
+               Session.connection_info({:user, Ecto.UUID.generate()}, -1)
+    end
+  end
+
   describe "casemapping/2 (#537 INC-2.3)" do
     # The web-edge (controllers, GrappaChannel topic join) is stateless — it
     # has no `state.isupport` to read the network's CASEMAPPING from. This

--- a/test/grappa_web/controllers/networks_controller_test.exs
+++ b/test/grappa_web/controllers/networks_controller_test.exs
@@ -152,6 +152,47 @@ defmodule GrappaWeb.NetworksControllerTest do
       assert is_binary(found["connection_state_changed_at"])
     end
 
+    # #474 B — the additive `connection` field carries the LIVE upstream
+    # facts (dialled server / TLS / +r), resolved via `Session.connection_info`
+    # at the controller (`resolve_connection_info/2`). It is ALWAYS present in
+    # the wire (additive-field-is-always-serialised) but `null` whenever there
+    # is no live connected session — the honest "no live connection". This
+    # asserts the null branch of the controller seam AND the CLAUDE.md
+    # DB-vs-live separation invariant: neither of these credentials has a
+    # spawned `Session.Server`, so even the DB-`:connected` row reports
+    # `connection: null` (no live pid ⇒ no fabricated facts). The live branch
+    # (connection populated) is covered by `Session.Server`'s connection_info
+    # test (accessor) + the issue474 e2e (end-to-end over the running stack).
+    test "connection is null when there is no live session (DB state ≠ live facts)",
+         %{conn: conn} do
+      vjt = user_fixture(name: "vjt-conn-null-#{u()}")
+      session = session_fixture(vjt)
+      {connected_net, _} = network_with_server(port: 6674, slug: "azzurra-conn-live-#{u()}")
+      {parked_net, _} = network_with_server(port: 6675, slug: "azzurra-conn-parked-#{u()}")
+      _ = credential_fixture(vjt, connected_net)
+      parked_cred = credential_fixture(vjt, parked_net)
+      {:ok, _} = Networks.disconnect(parked_cred, "parking for the test")
+
+      body =
+        conn
+        |> put_bearer(session.id)
+        |> get("/networks")
+        |> json_response(200)
+
+      connected_row = Enum.find(body, &(&1["slug"] == connected_net.slug))
+      parked_row = Enum.find(body, &(&1["slug"] == parked_net.slug))
+
+      # DB row is `:connected` (bind default) but no Session.Server was spawned
+      # → live facts are unknown, so `connection` is present-and-null.
+      assert connected_row["connection_state"] == "connected"
+      assert Map.has_key?(connected_row, "connection")
+      assert is_nil(connected_row["connection"])
+
+      # Parked → also no live session → `connection` null.
+      assert parked_row["connection_state"] == "parked"
+      assert is_nil(parked_row["connection"])
+    end
+
     test "returns empty list when user has no bindings", %{conn: conn} do
       vjt = user_fixture(name: "vjt-empty-#{u()}")
       session = session_fixture(vjt)

--- a/test/grappa_web/controllers/networks_controller_test.exs
+++ b/test/grappa_web/controllers/networks_controller_test.exs
@@ -19,8 +19,8 @@ defmodule GrappaWeb.NetworksControllerTest do
   collapses to 404 so credential-existence is not leaked.
 
   Wire shapes come from `Grappa.Networks.Wire` —
-  `network_with_nick_to_json/3` (user GET row),
-  `visitor_network_to_json/3` (visitor GET row), and
+  `network_with_nick_to_json/4` (user GET row),
+  `visitor_network_to_json/4` (visitor GET row), and
   `credential_to_json/1` (PATCH — returns the updated credential
   including connection_state fields).
 


### PR DESCRIPTION
Fills the empty right-rail slot on a **server window** with per-window-kind
context: connection facts the client already holds — network slug, connection
state, connected-since duration, own nick, services flavor.

Refs #474 (vjt closes post-deploy).

## What

`.shell-members` became a **permanent** desktop column in #71 INC-2 — on a
channel it shows the members pane, on a server window it showed only the
RailActions button drawer. This grafts a `RailContext` container as a
**sibling** of that drawer (both desktop + mobile rail branches), dispatching
on the active window's `kind`:

- **server** → `ServerInfoCard` (this PR)
- **query** → a `/whois` card is the deferred follow-on — one `<Match>` away,
  no second Shell edit (built as a generic container, not a hardcoded card).

`ServerInfoCard` is pure-presentational, fed only from the existing `Network`
store. `connected-since` renders **only while connected** (honesty — a duration
next to a parked/failed state would lie). Duration formatting is **lifted** from
`WhoisCard`'s private `formatIdle` into `lib/duration.ts` and shared by both
call sites (DRY — WhoisCard's only change is the import).

## Deliberately out of scope

The dialled server address / TLS / registered-identified state are **not shown**
— they are admin-only wire fields absent from the user store. Per #474's
"prefer leaving it out over showing a stale value confidently", they graft in
later behind an additive wire field and this card inherits them for free.

## Facts only

No new IRC traffic, no server-side work, no new wire field — pure cic, sourced
from existing session/network state.

## Gates

- `bun run check` (biome + tsc): exit 0, no new warnings
- vitest **full**: 208 files / 3676 tests green (duration 9, ServerInfoCard 5,
  RailContext 5, WhoisCard 20 unchanged after the DRY refactor)
- e2e (chromium, `scripts/integration.sh --grep "#474"`): **1 passed** — real
  login → server window → asserts `[data-testid=rail-server-info]` shows the
  slug, own nick, connection state, and a non-empty connected-since row from the
  live-hydrated store
- code review (sync `10x-engineer:code-reviewer`): clean, all six design
  constraints satisfied

10 files, all under `cicchetto/`.