### PR TITLE
fix(#571): /lusers forwards its optional mask + server

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -24333,3 +24333,57 @@ goes through `release-entrypoint.sh`'s `ERL_ZFLAGS`, never a baked `rel/vm.args`
 that would leak into the jail/.deb/.rpm; the release image reports the bare
 version by construction (no `.git`), so anything asserting the image's version
 expects `X.Y.Z`, never a `-<sha>` suffix.
+
+## 2026-07-31 — #571: `/lusers` forwards its optional mask + server (was dropped)
+
+The `/lusers` path was param-less end to end: `GrappaChannel.handle_in("lusers",
+...)` pattern-matched only `network_id`, `Session.send_lusers/2` +
+`Client.send_lusers/1` emitted a bare `LUSERS`, and any client-supplied
+`<mask>`/`<server>` was silently discarded. Two consequences on bahamut (all of
+prod, Azzurra): an operator could never trigger the **forced live recount** of
+the "unknown connection(s)" figure — bahamut serves it from a 180s cache
+(`LUSERS_CACHE_TIME`) unless forced — and `LUSERS <mask> <server>` could not be
+routed to a remote server. Reported on IRC during the SSL unknown-client leak
+investigation.
+
+**Spec-challenge — the issue's `parc > 3` is a misquote.** The issue attributed
+the forced path to `forced = IsAnOper(sptr) && parc > 3`. The public bahamut
+(DALnet master) `send_lusers` actually gates on `IsAnOper(sptr) && (parc > 1) &&
+(*parv[1] != '*')` — i.e. an oper supplying a **non-`*` mask** forces the
+recount; no third argument is involved. The issue text also contradicts itself
+("the *3-argument* oper form ... triggers `parc > 3`", but `LUSERS mask server`
+is `parc == 3`, not `> 3`). vjt confirmed the source reading wins: the fix
+targets the real trigger, a non-`*` mask.
+
+**Fix — mirror `/motd` + `/links` exactly (RFC 2812 §3.4.2 `LUSERS [<mask>
+[<target>]]`).** `Client.send_lusers/3` forwards both optional params
+positionally: `nil`/`nil` → bare `LUSERS`; `mask`/`nil` → `LUSERS <mask>`;
+`mask`/`server` → `LUSERS <mask> <server>`. Each token is gated by
+`Identifier.safe_oper_token?/1` (a single wire token — no whitespace/CRLF/NUL)
+so it cannot splice an extra wire slot or inject a follow-up command; rejection
+funnels through `reject_invalid_line(:lusers)` for byte-boundary observability.
+A `server` with **no** mask cannot be framed positionally (RFC places
+`<server>` AFTER `<mask>`) and is rejected `{:error, :invalid_line}` rather than
+silently dropped. The channel door validates first via a new
+`validate_lusers_args/2` (reuses the `:server` → `safe_oper_token?/1` validator,
+like `/motd`'s target + `/links`'s mask); `Session.send_lusers/4` +
+`Client.send_lusers/3` re-validate so the context contract stays honest for
+every door. The internal GenServer message widened `:send_lusers` →
+`{:send_lusers, mask, server}`. The `lusers_pending` accumulator + the 251..266
+fold → `:lusers_bundle` broadcast are UNCHANGED (a mask/server only shapes the
+outbound line; the reply numerics fold identically).
+
+**Wire contract — additive, no protocol bump (#447).** The `lusers` verb gains
+two optional snake_case fields (`mask`, `server`); absent both, behaviour is
+byte-identical to pre-#571. An old client sending bare `%{network_id}` still
+validates and gets a bare `LUSERS`. Deploy: server is HOT (no migration, no new
+child, GenServer state unchanged).
+
+**Scope — server only.** This issue is grappa-server-scoped (its source refs are
+grappa files). cic currently DISCARDS `/lusers` args (`parseSlash("/lusers
+ignored")` → param-less by explicit test), so the operator-facing UX needs a
+separate cic follow-up (parse + push `mask`/`server`) — tracked by vjt, out of
+scope here. The server contract is now ready for cic (or any client) to supply
+the params. Regression-guarded by `client_test` (bare/mask/mask+server framing
++ injection + server-without-mask rejection) and `grappa_channel_test` (the
+same five cases through the channel door).

--- a/lib/grappa/irc/client.ex
+++ b/lib/grappa/irc/client.ex
@@ -800,16 +800,44 @@ defmodule Grappa.IRC.Client do
   end
 
   @doc """
-  Sends bare `LUSERS\\r\\n` upstream — server replies with the
-  251/252/253?/254/255/265/266 sequence which `EventRouter` folds into
-  `state.lusers_pending` and `Server.apply_effects` flushes as a
-  `{:lusers_bundle, accum}` effect on 266.
+  #571 — sends `LUSERS [<mask> [<server>]]\\r\\n` upstream (RFC 2812 §3.4.2).
+  Server replies with the 251/252/253?/254/255/265/266 sequence which
+  `EventRouter` folds into `state.lusers_pending` and `Server.apply_effects`
+  flushes as a `{:lusers_bundle, accum}` effect on 266.
 
-  No params, no validation: LUSERS is universally accepted.
+  `nil`/`nil` emits a bare `LUSERS` (the current server's cached figures). A
+  `mask` emits `LUSERS <mask>` — on bahamut a non-`*` mask forces a live
+  recount of the "unknown connection(s)" figure past the 180s cache. A
+  `mask` + `server` emits `LUSERS <mask> <server>` so the query routes to a
+  named remote server (RFC 2812 §3.4.2 places `<server>` positionally AFTER
+  `<mask>`).
+
+  Pre-#571 this dropped every param, so an oper could never trigger the
+  forced recount and `LUSERS <mask> <server>` could not be routed. `mask`
+  and `server` are each gated by `safe_oper_token?/1` (a single wire token —
+  no whitespace/CRLF/NUL) so they cannot splice an extra wire slot or inject
+  a follow-up command; rejection yields `{:error, :invalid_line}`. A
+  `server` with no `mask` cannot be framed positionally and is rejected.
   """
-  @spec send_lusers(pid()) :: send_result()
-  def send_lusers(client) do
+  @spec send_lusers(pid(), String.t() | nil, String.t() | nil) :: send_result()
+  def send_lusers(client, nil, nil) do
     send_line(client, "LUSERS\r\n")
+  end
+
+  def send_lusers(client, mask, nil) when is_binary(mask) do
+    if Identifier.safe_oper_token?(mask),
+      do: send_line(client, "LUSERS #{mask}\r\n"),
+      else: reject_invalid_line(:lusers)
+  end
+
+  def send_lusers(client, mask, server) when is_binary(mask) and is_binary(server) do
+    if Identifier.safe_oper_token?(mask) and Identifier.safe_oper_token?(server),
+      do: send_line(client, "LUSERS #{mask} #{server}\r\n"),
+      else: reject_invalid_line(:lusers)
+  end
+
+  def send_lusers(_, nil, server) when is_binary(server) do
+    reject_invalid_line(:lusers)
   end
 
   @doc """
@@ -917,6 +945,7 @@ defmodule Grappa.IRC.Client do
            | :names
            | :motd
            | :links
+           | :lusers
            | :oper
            | :raw
 

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -1298,16 +1298,26 @@ defmodule Grappa.Session do
   end
 
   @doc """
-  Sends bare `LUSERS` upstream. Server replies with the 7-numeric
-  bundle (251/252/253?/254/255/265/266) which `EventRouter` folds and
-  emits as a typed `:lusers_bundle` wire event on `Topic.user/1`.
-  Returns `:ok` or `{:error, :no_session}`.
+  #571 — sends `LUSERS [<mask> [<server>]]` upstream (RFC 2812 §3.4.2). `nil`
+  mask + `nil` server = the current server's cached figures; a `mask` filters
+  the reply AND (on bahamut, when non-`*`) forces a live recount past the
+  180s cache; a `mask` + `server` routes the query to a named remote server.
+  Server replies with the 7-numeric bundle (251/252/253?/254/255/265/266)
+  which `EventRouter` folds and emits as a typed `:lusers_bundle` wire event
+  on `Topic.user/1`.
+
+  Returns `:ok`, `{:error, :no_session}`, or `{:error, :invalid_line}` if a
+  non-nil mask/server's syntax is rejected by `Grappa.IRC.Client.send_lusers/3`
+  (mirror of `send_motd/3` + `send_links/3`; the channel door validates first,
+  but the context contract stays honest for every door). A `server` with no
+  `mask` is `{:error, :invalid_line}` (positional framing, RFC 2812 §3.4.2).
   """
-  @spec send_lusers(subject(), integer()) ::
-          :ok | {:error, :no_session | send_transport_error()}
-  def send_lusers(subject, network_id)
-      when is_subject(subject) and is_integer(network_id) do
-    call_session(subject, network_id, :send_lusers)
+  @spec send_lusers(subject(), integer(), String.t() | nil, String.t() | nil) ::
+          :ok | {:error, :no_session | :invalid_line | send_transport_error()}
+  def send_lusers(subject, network_id, mask, server)
+      when is_subject(subject) and is_integer(network_id) and
+             (is_binary(mask) or is_nil(mask)) and (is_binary(server) or is_nil(server)) do
+    call_session(subject, network_id, {:send_lusers, mask, server})
   end
 
   @doc """

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -1719,12 +1719,15 @@ defmodule Grappa.Session.Server do
     {:reply, Client.send_invite(state.client, channel, nick), state}
   end
 
-  # P-0d — bare LUSERS upstream. Reply numerics fold into
-  # state.lusers_pending; 266 RPL_GLOBALUSERS flushes the bundle.
-  # No accumulator priming needed — 251 RPL_LUSERCLIENT resets the
-  # accumulator on arrival.
-  def handle_call(:send_lusers, _, state) do
-    {:reply, Client.send_lusers(state.client), state}
+  # P-0d/#571 — LUSERS [<mask> [<server>]] upstream. Reply numerics fold into
+  # state.lusers_pending; 266 RPL_GLOBALUSERS flushes the bundle. No
+  # accumulator priming needed — 251 RPL_LUSERCLIENT resets the accumulator on
+  # arrival. #571 forwards the optional mask/server (was dropped): a non-`*`
+  # mask forces bahamut's live recount past the 180s cache; a server routes
+  # the query remotely. Client.send_lusers/3 gates each token at the byte
+  # boundary (nil/nil = bare LUSERS).
+  def handle_call({:send_lusers, mask, server}, _, state) do
+    {:reply, Client.send_lusers(state.client, mask, server), state}
   end
 
   # #127 — /info, /version, /motd. Each primes its accumulator BEFORE putting

--- a/lib/grappa_web/channels/grappa_channel.ex
+++ b/lib/grappa_web/channels/grappa_channel.ex
@@ -740,20 +740,28 @@ defmodule GrappaWeb.GrappaChannel do
     )
   end
 
-  # P-0d — /lusers. No args, read-only network query. Visitors are
-  # entitled to issue it (mirrors WHOIS post-C3); the LUSERS bundle's
-  # broadcast topic uses the issuing subject's `subject_label` so the
-  # visitor's own cic surface is the only consumer.
+  # P-0d/#571 — /lusers [<mask> [<server>]]. Read-only network query; visitors
+  # are entitled to issue it (mirrors WHOIS post-C3); the LUSERS bundle's
+  # broadcast topic uses the issuing subject's `subject_label` so the visitor's
+  # own cic surface is the only consumer. #571 threads the OPTIONAL mask +
+  # server through to the wire (RFC 2812 §3.4.2) — pre-#571 both were dropped,
+  # so an oper could never reach bahamut's forced live recount (non-`*` mask)
+  # and `LUSERS <mask> <server>` could not route remotely. Each is validated as
+  # a single wire token (`safe_oper_token?/1`) before it reaches the wire; a
+  # server with no mask is rejected (positional framing).
   def handle_in(
         "lusers",
-        %{"network_id" => network_id},
+        %{"network_id" => network_id} = params,
         socket
       )
       when is_integer(network_id) do
+    mask = Map.get(params, "mask")
+    server = Map.get(params, "server")
+
     dispatch_subject_verb(
       socket,
-      fn -> {:ok, :ok} end,
-      fn subject -> Session.send_lusers(subject, network_id) end
+      fn -> validate_lusers_args(mask, server) end,
+      fn subject -> Session.send_lusers(subject, network_id, mask, server) end
     )
   end
 
@@ -1490,6 +1498,19 @@ defmodule GrappaWeb.GrappaChannel do
   defp validate_links_mask(nil), do: {:ok, :ok}
   defp validate_links_mask(mask) when is_binary(mask), do: validate_args(server: mask)
   defp validate_links_mask(_), do: {:error, :invalid_line}
+
+  # #571 — /lusers [<mask> [<server>]] (RFC 2812 §3.4.2). Both optional; each
+  # binary token is gated as a single wire token (reuses the `:server`
+  # validator → `safe_oper_token?/1`), mirroring /motd's target + /links' mask.
+  # `<server>` is positional AFTER `<mask>`, so a server with no mask cannot be
+  # framed and is rejected rather than silently dropped.
+  defp validate_lusers_args(nil, nil), do: {:ok, :ok}
+  defp validate_lusers_args(mask, nil) when is_binary(mask), do: validate_args(server: mask)
+
+  defp validate_lusers_args(mask, server) when is_binary(mask) and is_binary(server),
+    do: validate_args(server: mask, server: server)
+
+  defp validate_lusers_args(_, _), do: {:error, :invalid_line}
 
   defp validate_args([]), do: {:ok, :ok}
 

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -539,6 +539,68 @@ defmodule Grappa.IRC.ClientTest do
       assert {:error, :invalid_line} = Client.send_motd(client, "srv\r\nQUIT")
     end
 
+    # #571 — /lusers [<mask> [<server>]] (RFC 2812 §3.4.2). Pre-#571
+    # send_lusers/1 always emitted a bare `LUSERS`, dropping any mask/server a
+    # client supplied — so an oper could never reach bahamut's forced live
+    # recount (gated on a non-`*` mask) and `LUSERS <mask> <server>` could not
+    # route to a remote server. send_lusers/3 forwards both optional params
+    # positionally: nil/nil → bare LUSERS; mask/nil → `LUSERS <mask>`;
+    # mask/server → `LUSERS <mask> <server>`. Each token is gated by
+    # safe_oper_token? (single wire token) so injection can't splice a slot.
+    test "send_lusers/3 with nil/nil emits bare LUSERS framing" do
+      {server, port} = start_server()
+      client = start_client(port)
+
+      :ok = Client.send_lusers(client, nil, nil)
+
+      assert {:ok, "LUSERS\r\n"} =
+               IRCServer.wait_for_line(server, &(&1 == "LUSERS\r\n"), 1_000)
+    end
+
+    test "send_lusers/3 with a mask emits LUSERS <mask> framing" do
+      {server, port} = start_server()
+      client = start_client(port)
+
+      :ok = Client.send_lusers(client, "*.azzurra.org", nil)
+
+      assert {:ok, "LUSERS *.azzurra.org\r\n"} =
+               IRCServer.wait_for_line(server, &(&1 == "LUSERS *.azzurra.org\r\n"), 1_000)
+    end
+
+    test "send_lusers/3 with mask + server emits LUSERS <mask> <server> framing" do
+      {server, port} = start_server()
+      client = start_client(port)
+
+      :ok = Client.send_lusers(client, "*.azzurra.org", "void.azzurra.chat")
+
+      assert {:ok, "LUSERS *.azzurra.org void.azzurra.chat\r\n"} =
+               IRCServer.wait_for_line(
+                 server,
+                 &(&1 == "LUSERS *.azzurra.org void.azzurra.chat\r\n"),
+                 1_000
+               )
+    end
+
+    test "send_lusers/3 rejects an injection mask/server with {:error, :invalid_line}" do
+      {_, port} = start_server()
+      client = start_client(port)
+
+      # A space would splice an extra LUSERS wire slot; CRLF would inject a
+      # follow-up command. Both rejected by the single-token gate.
+      assert {:error, :invalid_line} = Client.send_lusers(client, "m a", nil)
+      assert {:error, :invalid_line} = Client.send_lusers(client, "m\r\nQUIT", nil)
+      assert {:error, :invalid_line} = Client.send_lusers(client, "*.azzurra.org", "s\r\nQUIT")
+    end
+
+    test "send_lusers/3 rejects a server without a mask with {:error, :invalid_line}" do
+      {_, port} = start_server()
+      client = start_client(port)
+
+      # LUSERS routes <server> positionally AFTER <mask> (RFC 2812 §3.4.2), so
+      # a server with no mask cannot be framed — reject at the boundary.
+      assert {:error, :invalid_line} = Client.send_lusers(client, nil, "void.azzurra.chat")
+    end
+
     test "send_topic_clear/2 emits TOPIC #chan : framing (empty trailing param)" do
       {server, port} = start_server()
       client = start_client(port)

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -1953,6 +1953,78 @@ defmodule GrappaWeb.GrappaChannelTest do
       assert_reply(ref, :error, %{error: "invalid_line"})
     end
 
+    # #571 — /lusers bridge: cic pushes the bare verb (or with a mask/server)
+    # with %{network_id}; the channel relays to Session.send_lusers/4 which
+    # emits LUSERS upstream. Pre-#571 the handler pattern-matched only
+    # network_id and dropped mask/server, so an oper could never reach
+    # bahamut's forced live recount. Smoke-tests dispatch plumbing; the
+    # 251..266 fold + broadcast are covered by the server_test P-0d test.
+    test "lusers: sends bare LUSERS upstream", %{
+      irc_server: irc_server,
+      socket: socket,
+      network: network
+    } do
+      ref = push(socket, "lusers", %{"network_id" => network.id})
+
+      assert_reply(ref, :ok)
+      {:ok, _} = IRCServer.wait_for_line(irc_server, &(&1 == "LUSERS\r\n"), 1_000)
+    end
+
+    test "lusers: with a mask sends LUSERS <mask> upstream", %{
+      irc_server: irc_server,
+      socket: socket,
+      network: network
+    } do
+      ref = push(socket, "lusers", %{"network_id" => network.id, "mask" => "*.azzurra.org"})
+
+      assert_reply(ref, :ok)
+      {:ok, _} = IRCServer.wait_for_line(irc_server, &(&1 == "LUSERS *.azzurra.org\r\n"), 1_000)
+    end
+
+    test "lusers: with mask + server sends LUSERS <mask> <server> upstream", %{
+      irc_server: irc_server,
+      socket: socket,
+      network: network
+    } do
+      ref =
+        push(socket, "lusers", %{
+          "network_id" => network.id,
+          "mask" => "*.azzurra.org",
+          "server" => "void.azzurra.chat"
+        })
+
+      assert_reply(ref, :ok)
+
+      {:ok, _} =
+        IRCServer.wait_for_line(
+          irc_server,
+          &(&1 == "LUSERS *.azzurra.org void.azzurra.chat\r\n"),
+          1_000
+        )
+    end
+
+    # An injection-shaped mask/server is rejected at the channel boundary
+    # (safe_oper_token? via validate_args(server:)) before it reaches the wire.
+    test "lusers: rejects an injection mask with invalid_line", %{
+      socket: socket,
+      network: network
+    } do
+      ref = push(socket, "lusers", %{"network_id" => network.id, "mask" => "x\r\nQUIT"})
+
+      assert_reply(ref, :error, %{error: "invalid_line"})
+    end
+
+    # A server without a mask cannot be framed positionally (RFC 2812 §3.4.2)
+    # — rejected at the boundary rather than silently dropped.
+    test "lusers: rejects a server without a mask with invalid_line", %{
+      socket: socket,
+      network: network
+    } do
+      ref = push(socket, "lusers", %{"network_id" => network.id, "server" => "void.azzurra.chat"})
+
+      assert_reply(ref, :error, %{error: "invalid_line"})
+    end
+
     # #513b — a 2nd /links while the 1st is still in flight is REFUSED (not
     # clobbered) so the 1st bundle survives; the channel MUST surface the
     # typed `links_in_flight` token (→ cic "network map already loading"),


### PR DESCRIPTION
Refs #571 (no auto-close — vjt closes post-deploy).

## What

`/lusers` was param-less end to end: the `GrappaChannel` handler matched
only `network_id`, `Session.send_lusers/2` + `Client.send_lusers/1`
emitted a bare `LUSERS`, and any client-supplied `<mask>`/`<server>` was
discarded. On bahamut (all of prod) that made two things unreachable: an
operator forcing the live recount of the "unknown connection(s)" figure
(180s-cached unless a non-`*` mask forces it), and routing `LUSERS <mask>
<server>` to a remote server.

Fix mirrors `/motd` + `/links` (RFC 2812 §3.4.2 `LUSERS [<mask>
[<target>]]`): `Client.send_lusers/3` forwards both optional params
positionally, each gated by `safe_oper_token?/1` (single wire token — no
space/CRLF/NUL) so it can't splice a slot or inject a follow-up. A server
with no mask can't be framed positionally → rejected. Channel door
validates first (`validate_lusers_args/2`); `Session.send_lusers/4` +
`Client` re-validate for contract honesty.

## Spec-challenge

Issue quoted `forced = IsAnOper(sptr) && parc > 3`; the real bahamut
`send_lusers` gates on `IsAnOper && parc > 1 && *parv[1] != '*'` — a
non-`*` mask forces the recount, no 3rd arg. Source reading wins (vjt
confirmed); fix targets a non-`*` mask.

## Contract / scope

Wire contract additive, no protocol bump (#447): the `lusers` verb gains
two optional snake_case fields (`mask`, `server`); absent both, behaviour
is byte-identical to pre-#571. Server-only — cic currently discards
`/lusers` args, so operator UX needs a separate cic follow-up (vjt).
Server is HOT-deployable (no migration, no new child, GenServer state
unchanged).

## Gates

Full `scripts/check.sh` green + one synchronous code-review clean locally
(pre-rebase). Rebased onto `main` (`301ce48b`, includes #570); zero code
overlap, `docs/DESIGN_NOTES.md` append auto-merged clean. This PR's CI is
the independent gate — **do not merge until green + vjt's order.**