### PR TITLE
fix(#506): pre-init WAL to kill the fresh-DB journal-switch race (+#517 cleanup honesty)

### DIFF
--- a/cicchetto/e2e/tests/issue299-theme-cards.spec.ts
+++ b/cicchetto/e2e/tests/issue299-theme-cards.spec.ts
@@ -148,9 +148,12 @@ test.describe("#299 — theme cards (tap-select + progressive disclosure)", () =
       await expect(page.locator("[data-testid^='theme-delete-']").first()).toBeVisible();
     } finally {
       await ctx.close();
-      // The copy is a private (unpublished) theme, so it CASCADE-dies with the
-      // visitor — no gallery residue to clean up.
-      await adminDeleteVisitor(getSeededAdmin().token, visitor.id).catch(() => {});
+      // #517 — the copy is a private (unpublished) theme, so it CASCADE-dies
+      // with the visitor — no gallery residue to clean up. The visitor delete
+      // must NOT swallow its failure: a stranded live visitor poisons
+      // downstream exact-count canaries (m9b sessions, #481 accretion). Let it
+      // throw loud instead of the old `.catch(() => {})`.
+      await adminDeleteVisitor(getSeededAdmin().token, visitor.id);
     }
   });
 
@@ -201,12 +204,29 @@ test.describe("#299 — theme cards (tap-select + progressive disclosure)", () =
       await expect(authorAfter).toBeVisible({ timeout: 5_000 });
       await expect(authorAfter).toContainText(visitor.nick);
     } finally {
+      // #517 — cleanup must run BOTH steps AND surface any failure (no silent
+      // swallow). A stranded visitor/theme poisons downstream exact-count
+      // canaries (m9b sessions, #481 accretion). Collect errors so a failing
+      // theme delete can't SKIP the visitor delete (the dangerous one), then
+      // throw loud — never `.catch(() => {})`.
+      const cleanupErrors: unknown[] = [];
       // The re-homed theme is a published, system-owned gallery row — clean it
       // up so it doesn't accrete as gallery residue across runs.
       if (themeId !== undefined) {
-        await adminDeleteTheme(getSeededAdmin().token, themeId).catch(() => {});
+        try {
+          await adminDeleteTheme(getSeededAdmin().token, themeId);
+        } catch (err) {
+          cleanupErrors.push(err);
+        }
       }
-      await adminDeleteVisitor(getSeededAdmin().token, visitor.id).catch(() => {});
+      try {
+        await adminDeleteVisitor(getSeededAdmin().token, visitor.id);
+      } catch (err) {
+        cleanupErrors.push(err);
+      }
+      if (cleanupErrors.length > 0) {
+        throw new AggregateError(cleanupErrors, "issue299 cleanup failed");
+      }
     }
   });
 });

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -24387,3 +24387,47 @@ scope here. The server contract is now ready for cic (or any client) to supply
 the params. Regression-guarded by `client_test` (bare/mask/mask+server framing
 + injection + server-without-mask rejection) and `grappa_channel_test` (the
 same five cases through the channel door).
+
+---
+
+## 2026-07-31 — #506: eliminate the fresh-DB WAL-switch race (log noise, not a flake)
+
+**Symptom.** `Exqlite.Connection ("db_conn_N") failed to connect: (Exqlite.Error)
+database is locked` during `mix ecto.migrate` on a FRESH DB — seen in the e2e
+seeder logs, filed as the flake-campaign ROOT.
+
+**Diagnosis was overturned by an evidence-first repro.** The static diagnosis
+(pool of 5 racing the WAL switch → set the seeder to `pool_size: 1`) was wrong on
+two counts, both measured on a faithful repro (`mix ecto.create && mix ecto.migrate`
+in one container, real `config/dev.exs`, fresh dedicated DB, 8 iters/pool):
+
+- **`pool_size` is not the lever.** At `pool_size: 1` (confirmed effective via
+  `run -e`) the error STILL fired (7/8) and `db_conn_2` still appeared: **`mix
+  ecto.migrate` opens ≥2 connections regardless** — Ecto.Migrator's own lock
+  connection. So the switch always has ≥2 connections racing; `pool_size: 1` is
+  dead by construction.
+- **The lock is BENIGN.** `create && migrate` exited **rc=0 on all 16** pre-fix
+  runs — the connect fails transiently, DBConnection reconnects, migrations
+  complete. In CI the GREEN run (34bce335, 6554-line log) logged it **zero**
+  times; the RED run's only failure was `issue294`, not a seed. **No evidence the
+  lock ever failed a test.** This is log noise from a real race, NOT a flake
+  cause — the "disturbs seeds" premise is unproven and the fix is not sold as a
+  flake fix.
+
+**Mechanism.** ecto_sqlite3 applies `journal_mode: :wal` (its default) in every
+connection's setup. On a fresh non-WAL DB the first connection's rollback→WAL
+switch takes an exclusive lock; a concurrent connection's connect-time PRAGMA
+hits it and fails (busy_timeout does not cover the connect-time PRAGMA — same
+class as the #524 deferred→immediate upgrade). WAL is persisted in the DB header,
+so once switched every later connection's `journal_mode=WAL` is a no-op.
+
+**Fix.** `Grappa.Repo.init/2` pre-switches the DB to WAL on ONE connection
+(raw `Exqlite.Sqlite3`) before the pool opens. It runs ONLY on `:supervisor`
+(the actual pool start) — `:runtime` is `repo.config()`'s lookup path, invoked by
+`ecto.create`'s `storage_up` too, and MUST stay pure or it would pre-create /
+pre-WAL the file out from under storage_up. Covers every migrate path that goes
+through `Ecto.Migrator.with_repo` (the seeder's `mix ecto.migrate`,
+`Grappa.Release.migrate/0`, and normal app boot) — one seam, general fix, not the
+e2e-only `pool_size` hack. Verified: the faithful repro went from LOCK 15/16 to
+**PASS 16/16** (both pool sizes) with the fix in place. A new migrate/boot path
+that bypasses `with_repo`/repo start would not inherit the pre-init.

--- a/lib/grappa/repo.ex
+++ b/lib/grappa/repo.ex
@@ -15,6 +15,83 @@ defmodule Grappa.Repo do
     otp_app: :grappa,
     adapter: Ecto.Adapters.SQLite3
 
+  # #506 — pre-switch the database to WAL on a SINGLE connection before the pool
+  # (or `mix ecto.migrate`'s ≥2 Ecto.Migrator connections) open.
+  #
+  # ecto_sqlite3 applies `journal_mode: :wal` (its default) in EVERY connection's
+  # setup. On a FRESH non-WAL DB the first connection's rollback→WAL switch takes
+  # an exclusive lock; a concurrent connection's switch hits it with a
+  # connect-time `Exqlite.Error: database is locked` (busy_timeout does NOT cover
+  # the connect-time PRAGMA — same class as the #524 deferred→immediate upgrade).
+  # The error is BENIGN — DBConnection reconnects and migrations complete (proven
+  # rc=0 across every faithful repro; the green e2e run logged it ZERO times) —
+  # but it's log noise on every fresh-DB migrate (the one-shot e2e seeder). NOTE
+  # `pool_size` cannot fix it: `mix ecto.migrate` opens ≥2 connections regardless
+  # (Ecto.Migrator's own lock connection), so the race persists even at
+  # `pool_size: 1`.
+  #
+  # Doing the switch once, serially, up front makes it deterministic: WAL is
+  # persisted in the DB header, so every later connection's `journal_mode=WAL` is
+  # a no-op with no exclusive switch. Only `:supervisor` (the actual pool start)
+  # acts — `:runtime` is `repo.config()`'s lookup path (invoked by ecto.create's
+  # storage_up too) and MUST stay pure, or it would pre-create/pre-WAL the file
+  # out from under storage_up. See docs/DESIGN_NOTES.md 2026-07-31.
+  @impl Ecto.Repo
+  def init(context, config) do
+    if context == :supervisor, do: ensure_wal_journal!(config)
+    {:ok, config}
+  end
+
+  @spec ensure_wal_journal!(keyword()) :: :ok
+  defp ensure_wal_journal!(config) do
+    case Keyword.get(config, :database) do
+      path when is_binary(path) and path != "" and path != ":memory:" ->
+        switch_to_wal!(path, Keyword.get(config, :busy_timeout, 30_000))
+
+      _ ->
+        :ok
+    end
+  end
+
+  @spec switch_to_wal!(binary(), non_neg_integer()) :: :ok
+  defp switch_to_wal!(path, busy_timeout) when is_integer(busy_timeout) do
+    # Mirror the pool connection's own connect path, which mkdir_p's the parent
+    # (SQLITE_OPEN_CREATE does NOT create intermediary dirs) — a raw open on a
+    # missing dir would otherwise fail here before we ever reach the pool.
+    File.mkdir_p!(Path.dirname(path))
+    {:ok, conn} = Exqlite.Sqlite3.open(path)
+
+    try do
+      # busy_timeout FIRST so the exclusive rollback→WAL switch waits out any
+      # concurrent holder instead of failing — the deliberate opposite of
+      # exqlite's connect order (journal_mode before busy_timeout), the very
+      # ordering that makes the per-connection switch race (#506).
+      :ok = Exqlite.Sqlite3.execute(conn, "PRAGMA busy_timeout=#{busy_timeout}")
+      {:ok, stmt} = Exqlite.Sqlite3.prepare(conn, "PRAGMA journal_mode=WAL")
+      result = Exqlite.Sqlite3.step(conn, stmt)
+      :ok = Exqlite.Sqlite3.release(conn, stmt)
+
+      case result do
+        {:row, ["wal"]} ->
+          :ok
+
+        {:row, [other_mode]} ->
+          # PRAGMA journal_mode=WAL returns the PREVIOUS mode (no error) when the
+          # filesystem can't back WAL shared-memory (NFS/CIFS/some overlay FSes).
+          # grappa REQUIRES WAL (config/runtime.exs journal_mode: :wal + the #524
+          # BEGIN IMMEDIATE semantics), so fail LOUD over booting silently
+          # degraded — and name the cause.
+          raise "Grappa.Repo: #{path} could not switch to WAL (got #{inspect(other_mode)}) — " <>
+                  "the filesystem likely cannot back WAL shared-memory; grappa requires WAL."
+
+        other ->
+          raise "Grappa.Repo: unexpected result switching #{path} to WAL: #{inspect(other)}"
+      end
+    after
+      :ok = Exqlite.Sqlite3.close(conn)
+    end
+  end
+
   @doc """
   Runs `fun` inside a SQLite `BEGIN IMMEDIATE` transaction — the
   write-transaction variant of `transaction/2`.

--- a/test/grappa/repo_wal_journal_test.exs
+++ b/test/grappa/repo_wal_journal_test.exs
@@ -1,0 +1,63 @@
+defmodule Grappa.RepoWalJournalTest do
+  # #506 — `Grappa.Repo.init(:supervisor, _)` pre-switches a fresh database to
+  # WAL on ONE connection before the pool (or `mix ecto.migrate`'s ≥2
+  # Ecto.Migrator connections) open, so the rollback→WAL `journal_mode` switch
+  # never races at connect-time. Pure unit test of the callback — no Repo/pool,
+  # no Sandbox. See docs/DESIGN_NOTES.md 2026-07-31.
+  use ExUnit.Case, async: true
+
+  alias Exqlite.Sqlite3
+
+  defp journal_mode(path) do
+    {:ok, conn} = Sqlite3.open(path)
+    {:ok, stmt} = Sqlite3.prepare(conn, "PRAGMA journal_mode")
+    {:row, [mode]} = Sqlite3.step(conn, stmt)
+    :ok = Sqlite3.release(conn, stmt)
+    :ok = Sqlite3.close(conn)
+    mode
+  end
+
+  # A fresh, non-WAL (rollback/"delete") database file with one real table so
+  # the journal mode is persisted + meaningful.
+  defp fresh_non_wal_db do
+    path =
+      Path.join(System.tmp_dir!(), "grappa_wal_init_#{System.unique_integer([:positive])}.db")
+
+    {:ok, conn} = Sqlite3.open(path)
+    :ok = Sqlite3.execute(conn, "PRAGMA journal_mode=DELETE")
+    :ok = Sqlite3.execute(conn, "CREATE TABLE probe (x INTEGER)")
+    :ok = Sqlite3.close(conn)
+    on_exit(fn -> for s <- ["", "-wal", "-shm"], do: File.rm(path <> s) end)
+    path
+  end
+
+  test "init(:supervisor, _) switches a fresh non-WAL db file to WAL" do
+    path = fresh_non_wal_db()
+    assert journal_mode(path) == "delete"
+
+    assert {:ok, _} =
+             Grappa.Repo.init(:supervisor, database: path, busy_timeout: 30_000)
+
+    assert journal_mode(path) == "wal"
+  end
+
+  test "init(:supervisor, _) is idempotent on an already-WAL db" do
+    path = fresh_non_wal_db()
+    {:ok, _} = Grappa.Repo.init(:supervisor, database: path, busy_timeout: 30_000)
+    assert {:ok, _} = Grappa.Repo.init(:supervisor, database: path, busy_timeout: 30_000)
+    assert journal_mode(path) == "wal"
+  end
+
+  test "init(:runtime, _) leaves the database untouched (config-lookup path)" do
+    # `repo.config()` calls init(:runtime, _) — including inside ecto.create's
+    # storage_up. Acting here would pre-create/pre-WAL the file out from under
+    # storage_up, so :runtime MUST stay pure.
+    path = fresh_non_wal_db()
+    assert {:ok, _} = Grappa.Repo.init(:runtime, database: path, busy_timeout: 30_000)
+    assert journal_mode(path) == "delete"
+  end
+
+  test "init(:supervisor, _) is a no-op for an in-memory database" do
+    assert {:ok, _} = Grappa.Repo.init(:supervisor, database: ":memory:")
+  end
+end


### PR DESCRIPTION
## What

Two commits:

- `fix(#506)`: `Grappa.Repo.init/2` pre-switches a **fresh** DB to WAL on ONE raw
  `Exqlite.Sqlite3` connection *before* the Ecto pool opens. Guarded to the
  `:supervisor` context ONLY — the `:runtime` path (`repo.config()`, incl.
  `ecto.create`'s `storage_up`) MUST stay pure and is left untouched. Covers
  every migrate path via `Ecto.Migrator.with_repo` (seeder `mix ecto.migrate`,
  `Release.migrate/0`) plus app boot. `mkdir_p` before open, and a LOUD failure
  with an FS-named message on a WAL-incapable filesystem.

- `test(#517)`: the issue299 cleanup now **surfaces** failures instead of
  swallowing them.

## Why

The boot-time db-lock was a **benign race / log noise**, not a real failure:
green CI logged it ZERO times and there's no evidence it ever failed a test.
This is framed as **race-elimination** (remove the fresh-DB journal-mode switch
that the pool could contend on), not a flake fix. The seeder's `create &&
migrate` one-shot is the loudest emitter of the noise; pre-initing WAL on the
supervisor path removes the window.

## Evidence

- Full `scripts/check.sh` green locally: `CHECK_EXIT=0`
  (format / credo / sobelow / dialyzer / 275+ ExUnit / 162 bats).
- One synchronous `code-reviewer` pass: "fundamentally sound"; 2 hardening
  findings applied.
- Repro harness: LOCK 15/16 → PASS 16/16 at both pool sizes.

The **full** `scripts/integration.sh` gate runs here on GitHub CI.

Refs #506, #517.