### PR TITLE
fix(#580): own-send bottom-snap fires at submit, not on POST resolve

### DIFF
--- a/cicchetto/e2e/tests/issue580-send-snap-independent-of-post.spec.ts
+++ b/cicchetto/e2e/tests/issue580-send-snap-independent-of-post.spec.ts
@@ -1,0 +1,178 @@
+// Issue #580 — own-send scroll authority must be INDEPENDENT of the POST.
+//
+// ## The field report (P0, intermittent)
+//
+// "own send sometimes does not scroll the list — the bottom-snap is gated on
+// the POST resolving, not on the send." Pre-fix, `scrollback.sendMessage`
+// published the ONLY scroll signal (`lastOwnSend`) AFTER `await
+// apiSendMessage(...)`. That single signal drove BOTH the network-dependent
+// work (divider re-latch + cursor advance, which genuinely need the persisted
+// row id) AND the network-INDEPENDENT bottom-snap. So a slow / failed POST
+// left the pane parked while the WS echo rendered the row.
+//
+// ## The fix (#580)
+//
+// Split the two concerns. `ownSendSubmitted` is published SYNCHRONOUSLY at
+// submit time (before the await) and drives the bottom-snap + follow-state
+// reset — the response to the operator pressing enter, independent of the
+// network outcome. `lastOwnSend` stays post-resolve for the divider re-latch.
+//
+// ## What this spec pins (the discriminating RENDER proof)
+//
+// The vitest suite proves the TRIGGER fires before the POST. This proves the
+// RENDER: even when the send POST FAILS at the client (case 1 — the server
+// accepted it, so the row still arrives over WS), the pane SNAPS to the
+// bottom and the just-sent line is visible.
+//
+// A fetch wrapper (addInitScript) forwards the send POST to the server —
+// which persists + WS-broadcasts the row — then rejects, so the client's
+// `apiSendMessage` sees a failure. RED pre-fix: `setLastOwnSend` sits after
+// the throwing await, never runs, the pane stays parked on the unread marker
+// (distance-to-tail stays above threshold) while the WS-echoed line renders
+// off-screen. GREEN post-fix: `setOwnSendSubmitted` fired before the await, so
+// the pane snaps to the tail regardless of the POST outcome.
+//
+// Harness mirrors issue168-scroll-authority (DB-seeded 200-row `#bofh`; tiny
+// 800×300 viewport so the REST page overflows and scroll geometry is
+// measurable; mid-page cursor so cold-mount lands on the marker, above the
+// fold).
+
+import { test, expect } from "../fixtures/test";
+import { type Page } from "@playwright/test";
+import {
+  composeTextarea,
+  loginAs,
+  scrollbackLines,
+  selectChannel,
+  waitForScrollbackRefreshed,
+} from "../fixtures/cicchettoPage";
+import { restoreReadCursorToTail, setReadCursorToId } from "../fixtures/grappaApi";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Mirror of ScrollbackPane.SCROLL_BOTTOM_THRESHOLD_PX = 50 (not exported;
+// kept in lockstep by hand — same as issue168 / cp14-b1).
+const SCROLL_BOTTOM_THRESHOLD_PX = 50;
+
+// REST default page size (Grappa.Web.MessagesController.@default_limit).
+const REST_PAGE_SIZE = 50;
+
+async function distanceToBottom(page: Page): Promise<number> {
+  return await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+    if (!el) throw new Error("scrollback container not found");
+    return el.scrollHeight - el.scrollTop - el.clientHeight;
+  });
+}
+
+// Latest REST page in wire shape (DESC by server_time) — used to pick a known
+// message id for the mid-page cursor seed (mirror of issue168).
+async function fetchScrollbackPage(
+  token: string,
+  channel: string,
+): Promise<Array<{ id: number }>> {
+  const url = `http://grappa-test:4000/networks/${encodeURIComponent(
+    NETWORK_SLUG,
+  )}/channels/${encodeURIComponent(channel)}/messages`;
+  const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!response.ok) {
+    throw new Error(`fetchScrollbackPage: ${response.status} ${await response.text()}`);
+  }
+  return (await response.json()) as Array<{ id: number }>;
+}
+
+// Test-only force endpoint (ReadCursor.force_set/4) — the production endpoint
+// is advance-only (#233), so a backward mid-page seed must go through force.
+async function seedCursor(channel: string, messageId: number): Promise<void> {
+  const vjt = getSeededVjt();
+  await setReadCursorToId(vjt.token, NETWORK_SLUG, channel, messageId);
+}
+
+test.describe("issue #580 — own send snaps to the bottom independent of the POST", () => {
+  test.use({ viewport: { width: 800, height: 300 } });
+
+  // The mid-page cursor persists on the shared seeded vjt across spec
+  // boundaries (last-write-wins). Restore to the tail so downstream #bofh
+  // specs inherit a fully-read channel (mirror of issue168).
+  test.afterAll(async () => {
+    const vjt = getSeededVjt();
+    if (!CHANNEL) return;
+    await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
+  });
+
+  test("send whose POST fails still snaps to the bottom (case 1)", async ({ page }) => {
+    const vjt = getSeededVjt();
+    if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+
+    // Fetch-wrap: the send POST reaches the server (which persists +
+    // WS-broadcasts the row) but the CLIENT sees a failure — the #580 case-1
+    // "server accepted, client POST dropped" shape. Only the send POST is
+    // intercepted; every other request (login, REST GETs, read-cursor POST)
+    // passes through untouched.
+    await page.addInitScript(() => {
+      const orig = window.fetch.bind(window);
+      window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+        const method = (
+          init?.method ?? (input instanceof Request ? input.method : "GET")
+        ).toUpperCase();
+        if (method === "POST" && /\/channels\/[^/]+\/messages(\?|$)/.test(url)) {
+          // Forward the real request so the server broadcasts the row over WS,
+          // THEN reject so apiSendMessage sees a failed POST.
+          try {
+            await orig(input, init);
+          } catch {
+            // even a genuinely failed forward still simulates the client
+            // failure — swallow and reject below.
+          }
+          throw new TypeError("#580 simulated send POST failure");
+        }
+        return orig(input, init);
+      };
+    });
+
+    // Mid-page cursor → cold-mount lands on the unread marker (above the fold),
+    // so distance-to-tail starts ABOVE threshold (mirror of issue168).
+    const page0 = await fetchScrollbackPage(vjt.token, CHANNEL);
+    expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
+    const cursorRow = page0[25];
+    if (!cursorRow) throw new Error("seeded page too short for cursor placement");
+    await seedCursor(CHANNEL, cursorRow.id);
+
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+    await waitForScrollbackRefreshed(page, NETWORK_SLUG, CHANNEL);
+
+    await expect
+      .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
+      .toBeGreaterThanOrEqual(REST_PAGE_SIZE);
+    await expect(page.locator('[data-testid="unread-marker"]')).toHaveCount(1);
+
+    // Reading history: cold-mount parked the view on the marker, above the fold.
+    await expect
+      .poll(async () => await distanceToBottom(page))
+      .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
+
+    // SEND — the POST will fail client-side, but the server broadcasts the row
+    // over WS. Send manually (composeSend awaits a draft-clear that a failed
+    // POST never produces); we assert on scroll geometry + the WS-echoed line,
+    // not on the textarea.
+    const marker = `#580 snap-on-fail ${Date.now()}`;
+    const ta = composeTextarea(page);
+    await ta.fill(marker);
+    await ta.press("Enter");
+
+    // The WS echo renders the row despite the failed POST.
+    const sentLine = scrollbackLines(page).filter({ hasText: marker });
+    await expect(sentLine).toHaveCount(1, { timeout: 10_000 });
+
+    // The pane snapped to the BOTTOM at submit time — NOT hostage to the POST.
+    // RED pre-fix: the snap sat after the throwing await, so the view stayed
+    // parked on the marker and distance-to-tail stayed above threshold.
+    await expect.poll(async () => await distanceToBottom(page)).toBeLessThanOrEqual(
+      SCROLL_BOTTOM_THRESHOLD_PX,
+    );
+    await expect(sentLine).toBeInViewport();
+  });
+});

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -42,6 +42,7 @@ import {
   lastOwnSend,
   loadMore as loadMoreScrollback,
   loadNewer as loadNewerScrollback,
+  ownSendSubmitted,
   refreshScrollback,
   scrollbackByChannel,
 } from "./lib/scrollback";
@@ -2130,37 +2131,56 @@ const ScrollbackPane: Component<Props> = (props) => {
     }),
   );
 
-  // Send-relatch (2026-06-09, vjt: "marker showing + you send → hide
-  // it"). An own send is an explicit caught-up action, so it re-latches
-  // the frozen marker to the now-advanced live cursor — collapsing the
-  // divider immediately instead of waiting for a window-switch. Keyed:
-  // only a send to THIS pane's `(slug, channel)` hides its marker (a
-  // `/msg` elsewhere doesn't). `lastOwnSend` fires ONLY on an own send,
-  // so passive advances (scroll-settle echo, cross-device) stay frozen.
-  // `defer: true` skips the mount run — the key/cold-latch effects own
-  // the mount-time baseline.
+  // #580 — submit-time scroll authority. The bottom-snap + follow-state
+  // reset are the operator's response to pressing enter, NOT a reaction to
+  // the server, so they fire on `ownSendSubmitted` (published SYNCHRONOUSLY
+  // before the POST in scrollback.sendMessage) — the instant enter is
+  // pressed, independent of the network round-trip. This fixes the field
+  // report (#580) where a slow / failed POST left the pane parked while the
+  // WS echo rendered the row: the snap no longer waits on the POST.
   //
-  // #168 — a send ALSO re-enters follow mode unconditionally: even if the
-  // operator had paged UP to re-read, sending snaps the pane back to the
-  // tail so the just-sent line is visible (issue #168 acceptance: "send
-  // scrolls to the bottom unconditionally"). `scrollToBottom` is the same
-  // tail authority the length-effect uses (scroll + atBottom=true); a
-  // pending WS-echo row is then followed by the length-effect. This is NOT
-  // event-type branching — the send resets the follow-STATE and the single
-  // always-bottom authority does the scrolling.
+  // #168 — a send re-enters follow mode UNCONDITIONALLY: even if the operator
+  // had paged UP to re-read, sending snaps the pane back to the tail so the
+  // just-sent line is visible ("send scrolls to the bottom unconditionally").
+  // Clear the marker-activation latch FIRST so the length-effect's re-assert
+  // can't fight the snap, THEN snap. `scrollToBottom` is the same tail
+  // authority the length-effect uses (scroll + atBottom=true); the WS-echo
+  // row that lands later is then followed by the length-effect. NOT event-type
+  // branching — the send resets the follow-STATE and the single always-bottom
+  // authority does the scrolling. Keyed: only a send to THIS pane's
+  // `(slug, channel)` (a `/msg` elsewhere doesn't). `defer: true` skips the
+  // mount run — the key/cold-latch effects own the mount-time baseline.
+  createEffect(
+    on(
+      ownSendSubmitted,
+      (sent) => {
+        if (sent !== key()) return;
+        setMarkerActivationPending(false);
+        scrollToBottom();
+      },
+      { defer: true },
+    ),
+  );
+
+  // Send-relatch (2026-06-09, vjt: "marker showing + you send → hide it").
+  // An own send is an explicit caught-up action, so it re-latches the frozen
+  // marker to the now-advanced live cursor — collapsing the `── XX unread ──`
+  // divider immediately instead of waiting for a window-switch. #580 split the
+  // network-independent snap (submit-time, above) from this divider re-latch:
+  // the re-latch reads the cursor `sendMessage` advanced from the CONFIRMED
+  // row id, so it stays on `lastOwnSend` (fired AFTER the POST resolves). A
+  // rejected send never confirms → `lastOwnSend` never fires → the divider
+  // stays put, which is correct (nothing was persisted to mark read). Keyed:
+  // only a send to THIS pane's `(slug, channel)` hides its marker (a `/msg`
+  // elsewhere doesn't); passive advances (scroll-settle echo, cross-device)
+  // stay frozen. `defer: true` skips the mount run — the key/cold-latch
+  // effects own the mount-time baseline.
   createEffect(
     on(
       lastOwnSend,
       (sent) => {
         if (sent !== key()) return;
-        // An own send ends the activation: clear the marker latch FIRST so the
-        // length-effect's re-assert can't fight the bottom snap, then re-latch
-        // the frozen divider to the now-advanced cursor (collapse it) and snap
-        // to the tail. Post-send stays unconditionally at the BOTTOM (#168 gate
-        // — do NOT re-open the send-jump).
-        setMarkerActivationPending(false);
         setMarkerCursorId(getReadCursor(props.networkSlug, props.channelName));
-        scrollToBottom();
       },
       { defer: true },
     ),

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -78,6 +78,13 @@ vi.mock("../lib/documentVisibility", () => ({
 // would otherwise drop it and the marker wouldn't re-hide).
 const [ownSend, setOwnSend] = createSignal<string | null>(null, { equals: false });
 const pushOwnSend = (key: string) => setOwnSend(key);
+// #580 — the submit-time send signal (published SYNCHRONOUSLY before the POST
+// in production). ScrollbackPane reads it to snap to the bottom + reset the
+// follow-state the instant enter is pressed, independent of the network. The
+// divider re-latch stays on `lastOwnSend` (post-resolve). Signal-backed
+// stand-in; `pushOwnSendSubmitted` is the test verb that fires a submit.
+const [ownSubmitted, setOwnSubmitted] = createSignal<string | null>(null, { equals: false });
+const pushOwnSendSubmitted = (key: string) => setOwnSubmitted(key);
 vi.mock("../lib/scrollback", () => ({
   scrollbackByChannel: () => scrollback(),
   // BUGHUNT-2 B5: ScrollbackPane's onScroll calls `loadMore` when
@@ -97,6 +104,7 @@ vi.mock("../lib/scrollback", () => ({
   // assert scroll/marker behavior, not the REST catch-up).
   refreshScrollback: vi.fn(() => Promise.resolve()),
   lastOwnSend: () => ownSend(),
+  ownSendSubmitted: () => ownSubmitted(),
 }));
 
 vi.mock("../lib/networks", () => ({
@@ -1567,6 +1575,47 @@ describe("ScrollbackPane", () => {
       pushOwnSend("freenode #grappa");
 
       // Divider collapses on the next flush — NO window-switch needed.
+      await waitFor(() => {
+        expect(screen.queryByTestId("unread-marker")).toBeNull();
+      });
+    });
+
+    // #580 — the divider re-latch must stay bound to the CONFIRMED cursor
+    // (post-POST `lastOwnSend`), NOT the submit-time snap signal. Model the
+    // production timing: enter is pressed (submit fires) and the POST later
+    // resolves + advances the LIVE cursor, but the frozen divider must not
+    // move on the submit signal — else a send would clear the "unread" marker
+    // reading a cursor before its own row was confirmed. This guards against
+    // re-coupling the two concerns #580 deliberately split.
+    it("submit-time signal does NOT re-latch the divider; only lastOwnSend does (#580 split)", async () => {
+      const proto = fixture[0];
+      if (!proto) throw new Error("fixture[0] missing");
+      const fourUnread: ScrollbackMessage[] = [
+        { ...proto, id: 10, server_time: 100, sender: "alice", body: "u1" },
+        { ...proto, id: 11, server_time: 101, sender: "alice", body: "u2" },
+        { ...proto, id: 12, server_time: 102, sender: "alice", body: "u3" },
+        { ...proto, id: 13, server_time: 103, sender: "alice", body: "u4" },
+      ];
+      setUserNick("vjt");
+      seedReadCursor("freenode", "#grappa", 9);
+      setScrollback({ "freenode #grappa": fourUnread });
+      setDocVisible(true);
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      expect(screen.getByTestId("unread-marker")).toHaveTextContent("4 unread");
+
+      // The POST resolves and advances the LIVE cursor to the sent row (13).
+      // The frozen divider (markerCursorId, latched at mount to 9) must NOT
+      // move on the submit-time signal — that signal owns only the network-
+      // independent snap. If the re-latch were (wrongly) coupled to submit,
+      // the divider would collapse here reading the advanced cursor.
+      seedReadCursor("freenode", "#grappa", 13);
+      pushOwnSendSubmitted("freenode #grappa");
+      await new Promise((r) => queueMicrotask(() => r(undefined)));
+      expect(screen.getByTestId("unread-marker")).toHaveTextContent("4 unread");
+
+      // Only the post-resolve `lastOwnSend` re-latches the divider to the
+      // confirmed cursor → it collapses.
+      pushOwnSend("freenode #grappa");
       await waitFor(() => {
         expect(screen.queryByTestId("unread-marker")).toBeNull();
       });

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -168,6 +168,12 @@ vi.mock("../lib/scrollback", () => ({
   loadNewer: vi.fn(),
   sendMessage: vi.fn(),
   lastOwnSend: () => null,
+  // #580 — ScrollbackPane (rendered by Shell) now reads this submit-time
+  // send signal via `on(ownSendSubmitted, …)` at component creation; the
+  // mock must export it or `on(undefined, …)` throws "deps is not a function"
+  // and crashes every Shell render test. Static null is enough — Shell tests
+  // don't exercise the send-snap (that's ScrollbackPane.test.tsx + the e2e).
+  ownSendSubmitted: () => null,
 }));
 
 vi.mock("../lib/members", () => ({

--- a/cicchetto/src/__tests__/scrollback.test.ts
+++ b/cicchetto/src/__tests__/scrollback.test.ts
@@ -453,6 +453,120 @@ describe("scrollback verbs", () => {
     dispose();
   });
 
+  // #580 — split the send's TWO scroll concerns. The bottom-snap +
+  // follow-state reset are the response to the operator pressing enter and
+  // do NOT need the server; the divider re-latch + cursor advance DO (they
+  // need the persisted row id). Pre-#580 both hung off `lastOwnSend`, fired
+  // ONLY after the POST resolved, so a slow/failed POST left the pane parked
+  // while the WS echo rendered the row ("own send sometimes doesn't scroll").
+  // `ownSendSubmitted` is the new submit-time producer: fired SYNCHRONOUSLY
+  // before the await, it drives the network-independent snap. `lastOwnSend`
+  // stays post-resolve for the parts that legitimately need the row id.
+  it("ownSendSubmitted fires synchronously before the POST resolves (#580)", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    // A POST that stays pending across the assertion window: proves the
+    // submit-time signal does not wait on the network round-trip.
+    let resolvePost: ((v: ScrollbackMessage) => void) | null = null;
+    vi.mocked(api.sendMessage).mockImplementation(
+      () =>
+        new Promise<ScrollbackMessage>((res) => {
+          resolvePost = res;
+        }),
+    );
+    const scrollback = await import("../lib/scrollback");
+    const key = channelKey("freenode", "#grappa");
+    expect(scrollback.ownSendSubmitted()).toBeNull();
+
+    // Fire WITHOUT awaiting — the POST is still in flight.
+    const pending = scrollback.sendMessage("freenode", "#grappa", "hi");
+    // The submit-time snap authority is already published; the post-resolve
+    // `lastOwnSend` (divider re-latch) has NOT fired yet.
+    expect(scrollback.ownSendSubmitted()).toBe(key);
+    expect(scrollback.lastOwnSend()).toBeNull();
+
+    // Settle the pending POST so the promise resolves cleanly.
+    if (!resolvePost) throw new Error("resolvePost never bound");
+    (resolvePost as (v: ScrollbackMessage) => void)({
+      id: 1,
+      network: "freenode",
+      channel: "#grappa",
+      server_time: 0,
+      kind: "privmsg",
+      sender: "alice",
+      body: "hi",
+      meta: {},
+    });
+    await pending;
+  });
+
+  // #580 case 1 — the server accepted the send but the client's POST
+  // failed/timed out. The row still arrives over WS and renders; the operator
+  // must be snapped to the bottom to watch it (whether it lands or fails).
+  // `ownSendSubmitted` fired at submit time so the snap is unaffected;
+  // `lastOwnSend` (post-resolve divider re-latch + cursor advance) is
+  // correctly SKIPPED — the send never confirmed, so nothing re-latches.
+  it("ownSendSubmitted fires even when the POST rejects; lastOwnSend does not (#580 case 1)", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    vi.mocked(api.sendMessage).mockRejectedValue(new Error("network down"));
+    const scrollback = await import("../lib/scrollback");
+    const key = channelKey("freenode", "#grappa");
+
+    await expect(scrollback.sendMessage("freenode", "#grappa", "hi")).rejects.toThrow(
+      "network down",
+    );
+
+    expect(scrollback.ownSendSubmitted()).toBe(key);
+    expect(scrollback.lastOwnSend()).toBeNull();
+  });
+
+  it("ownSendSubmitted does not fire without a token (#580)", async () => {
+    // No grappa-token → token() returns null → the whole send short-circuits
+    // before it can publish the submit-time signal.
+    const scrollback = await import("../lib/scrollback");
+    await scrollback.sendMessage("freenode", "#grappa", "ignored");
+    expect(scrollback.ownSendSubmitted()).toBeNull();
+  });
+
+  // `ownSendSubmitted` is an EVENT signal (`equals: false`) exactly like
+  // `lastOwnSend`: two sends to the SAME channel write the same key string,
+  // and the snap must re-fire on the second (operator paged up between sends
+  // → each enter must re-snap). Object.is dedup would drop the repeat.
+  it("ownSendSubmitted notifies on EVERY send, even repeats to the same channel (#580)", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    const row = (id: number): ScrollbackMessage => ({
+      id,
+      network: "freenode",
+      channel: "#grappa",
+      server_time: 0,
+      kind: "privmsg",
+      sender: "vjt",
+      body: "x",
+      meta: {},
+    });
+    vi.mocked(api.sendMessage).mockResolvedValueOnce(row(100)).mockResolvedValueOnce(row(101));
+    mockGetReadCursor.mockReturnValue(50);
+    const scrollback = await import("../lib/scrollback");
+
+    let fires = 0;
+    const dispose = createRoot((d) => {
+      createEffect(on(scrollback.ownSendSubmitted, () => void fires++, { defer: true }));
+      return d;
+    });
+
+    await scrollback.sendMessage("freenode", "#grappa", "one");
+    await new Promise((r) => queueMicrotask(() => r(undefined)));
+    expect(fires).toBe(1);
+
+    await scrollback.sendMessage("freenode", "#grappa", "two");
+    await new Promise((r) => queueMicrotask(() => r(undefined)));
+    expect(fires).toBe(2);
+
+    dispose();
+  });
+
   it("appendToScrollback dedupes by id (first wins)", async () => {
     localStorage.setItem("grappa-token", "tok");
     const scrollback = await import("../lib/scrollback");

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -174,10 +174,27 @@ const exports = identityScopedStore((onIdentityChange) => {
     equals: false,
   });
 
-  // Identity-transition cleanup. Seven registered resets fired by the
+  // #580 — submit-time send signal. `lastOwnSend` above fires only AFTER
+  // the POST resolves, and it drove BOTH the network-dependent work (divider
+  // re-latch + cursor advance, which genuinely need the persisted row id) AND
+  // the network-INDEPENDENT bottom-snap + follow-state reset (the response to
+  // the operator pressing enter). Binding the snap to the POST meant a slow /
+  // failed round-trip left the pane parked while the WS echo rendered the row
+  // ("own send sometimes doesn't scroll"). This signal is set SYNCHRONOUSLY at
+  // submit time — before the await — so ScrollbackPane snaps to the bottom the
+  // instant enter is pressed, independent of the network outcome (which is
+  // also correct when the send FAILS: you want to be at the bottom to watch
+  // it). `equals: false` for the same reason as `lastOwnSend` — a repeat send
+  // to the same channel must re-fire the snap.
+  const [ownSendSubmitted, setOwnSendSubmitted] = createSignal<ChannelKey | null>(null, {
+    equals: false,
+  });
+
+  // Identity-transition cleanup. Eight registered resets fired by the
   // factory's createEffect(on(token, ...)) — five Set.clear() (loadedChannels
   // + loadMore{InFlight,Exhausted} + loadNewer{InFlight,Exhausted}, #161) +
-  // two signal flushes. Order matches the pre-A3 inline shape.
+  // three signal flushes (scrollbackByChannel + lastOwnSend + ownSendSubmitted,
+  // #580). Order matches the pre-A3 inline shape.
   onIdentityChange(() => loadedChannels.clear());
   onIdentityChange(() => loadMoreInFlight.clear());
   onIdentityChange(() => loadMoreExhausted.clear());
@@ -185,6 +202,7 @@ const exports = identityScopedStore((onIdentityChange) => {
   onIdentityChange(() => loadNewerExhausted.clear());
   onIdentityChange(() => setScrollbackByChannel({}));
   onIdentityChange(() => setLastOwnSend(null));
+  onIdentityChange(() => setOwnSendSubmitted(null));
 
   // Insert an incoming message into the per-channel ascending list at its
   // (server_time, id) position, deduping by id. REST + WS can overlap: the
@@ -481,6 +499,16 @@ const exports = identityScopedStore((onIdentityChange) => {
   const sendMessage = async (slug: string, name: string, body: string): Promise<void> => {
     const t = token();
     if (!t) return;
+    const key = channelKey(slug, name);
+    // #580 — publish the submit-time snap authority SYNCHRONOUSLY, before the
+    // POST. This is the response to the operator pressing enter (bottom-snap +
+    // follow-state reset in ScrollbackPane) and must not wait on — or be lost
+    // to — the network round-trip. It fires even if `apiSendMessage` below
+    // rejects: the row can still arrive over WS, and the operator wants to be
+    // at the bottom to watch the send land or fail. The network-DEPENDENT
+    // half (divider re-latch + cursor advance) stays on `lastOwnSend` after
+    // the await, gated on the persisted row id.
+    setOwnSendSubmitted(key);
     // Server persists+broadcasts atomically — the WS push will deliver
     // the same row to this socket and `appendToScrollback` will display
     // it. The 201 body is the same persisted row; we keep ONLY its `id`
@@ -509,7 +537,6 @@ const exports = identityScopedStore((onIdentityChange) => {
     // is cheaper than hoisting `setCursorIfAdvances` to a leaf module
     // for a single second caller.
     const row = await apiSendMessage(t, slug, name, body);
-    const key = channelKey(slug, name);
     // Anti-poison gate (issue #50 / m6, 2026-06-09): only advance the
     // cursor when the local pane already holds a rendered row. Advancing
     // PAST an unrendered row poisons `refreshScrollback`'s resume cursor —
@@ -527,10 +554,13 @@ const exports = identityScopedStore((onIdentityChange) => {
     if (hasRenderedRow && (current === null || row.id > current)) {
       void setReadCursor(t, slug, name, row.id);
     }
-    // Send-relatch: fire AFTER the optimistic cursor advance above so the
-    // pane's hide-on-send effect reads the fresh cursor. Always fires on
-    // a successful send (even when the POST was skipped) — the marker
-    // must hide regardless.
+    // Send-relatch (post-resolve half): fire AFTER the optimistic cursor
+    // advance above so the pane's marker re-latch effect reads the fresh
+    // cursor and collapses the `── XX unread ──` divider. #580 moved the
+    // network-independent bottom-snap to `ownSendSubmitted` (submit time);
+    // this signal now drives ONLY the divider re-latch, which legitimately
+    // needs the confirmed row id. Reached only on a resolved POST — a
+    // rejected send never confirms, so it correctly does not re-latch.
     setLastOwnSend(key);
   };
 
@@ -720,6 +750,7 @@ const exports = identityScopedStore((onIdentityChange) => {
     refreshScrollback,
     sendMessage,
     lastOwnSend,
+    ownSendSubmitted,
     wasLoaded,
   };
 });
@@ -734,4 +765,5 @@ export const renameScrollbackKey = exports.renameScrollbackKey;
 export const refreshScrollback = exports.refreshScrollback;
 export const sendMessage = exports.sendMessage;
 export const lastOwnSend = exports.lastOwnSend;
+export const ownSendSubmitted = exports.ownSendSubmitted;
 export const wasLoaded = exports.wasLoaded;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -24431,3 +24431,56 @@ through `Ecto.Migrator.with_repo` (the seeder's `mix ecto.migrate`,
 e2e-only `pool_size` hack. Verified: the faithful repro went from LOCK 15/16 to
 **PASS 16/16** (both pool sizes) with the fix in place. A new migrate/boot path
 that bypasses `with_repo`/repo start would not inherit the pre-init.
+
+## 2026-07-31 — #580: own-send bottom-snap fires at submit, not on POST resolve
+
+**Symptom (field report, intermittent, never reproduced on demand).** "own send
+sometimes does not scroll the list — the bottom-snap is gated on the POST
+resolving, not on the send."
+
+**Root cause.** `cicchetto/src/lib/scrollback.ts` `sendMessage` published its ONLY
+scroll signal, `lastOwnSend`, AFTER `await apiSendMessage(...)`. That single
+signal drove BOTH concerns a send carries, which have DIFFERENT data
+dependencies:
+- **network-DEPENDENT** — the frozen-divider re-latch + the optimistic
+  read-cursor advance, which genuinely need the persisted row `id`; and
+- **network-INDEPENDENT** — the bottom-snap + follow-state reset, which are the
+  operator's response to pressing enter and need nothing from the server.
+
+Binding the snap to the POST produced two "sometimes" failure modes: (1) the POST
+fails/times out while the server ACCEPTED the send — the row still arrives over
+WS and renders, but `setLastOwnSend` (after the throwing await) is never reached,
+so the pane never snaps; (2) the WS echo beats the HTTP response — the ref-keyed
+`<For>` recreates the list DOM and resets `scrollTop`, and the only re-establish
+path at that instant (the length-effect) follows the tail ONLY when `atBottom`,
+so an operator who had paged up stays parked until the POST resolves.
+
+**Fix — split the signal by data dependency (not by event type).** A new
+`ownSendSubmitted` signal (`equals: false`, like `lastOwnSend`) is published
+SYNCHRONOUSLY before the await; `ScrollbackPane`'s `on(ownSendSubmitted, …)`
+effect does the network-independent half (`setMarkerActivationPending(false)` +
+`scrollToBottom()`). `lastOwnSend` stays post-resolve and its effect now does
+ONLY the divider re-latch (`setMarkerCursorId(getReadCursor(...))`), which reads
+the cursor `sendMessage` advanced from the CONFIRMED row id. A rejected send
+never confirms → `lastOwnSend` never fires → the divider is not re-latched, which
+is correct (nothing was persisted to mark read); the snap already happened at
+submit, so the operator is at the bottom to watch the send land or fail.
+
+**Why this is the same "reuse the verbs, not the nouns" shape.** The snap is not
+event-type-branched (#168 forbids that); it stays the single always-bottom
+authority (`scrollToBottom` = scroll + `atBottom=true`, the same one the
+length-effect uses). #580 only moves WHEN the follow-STATE is reset — to submit
+time — so the invariant holds and is in fact strengthened (the snap no longer
+waits on the network at all).
+
+**Preserves** #168 ("send scrolls to bottom UNCONDITIONALLY") and the
+frozen-divider / marker-latch freeze contract (2026-06-08): the re-latch still
+reads the confirmed cursor after the POST, identical ordering to pre-#580.
+
+**Regression class surfaced.** ScrollbackPane reads `ownSendSubmitted` via
+`on(...)` at component CREATION, so EVERY test file that mocks `../lib/scrollback`
+AND renders `ScrollbackPane` (directly or transitively) must export it or
+`on(undefined, …)` throws "deps is not a function" and crashes the render. Two
+such files exist — `ScrollbackPane.test.tsx` and `Shell.test.tsx` (Shell renders
+the pane) — both updated. This is the general rule for any new signal a rendered
+component subscribes to at creation.


### PR DESCRIPTION
Refs #580 (cicchetto P0, intermittent).

## Problem
Field report: "own send sometimes does not scroll the list — the bottom-snap is gated on the POST resolving, not on the send."

`scrollback.sendMessage` published its only scroll signal (`lastOwnSend`) AFTER `await apiSendMessage(...)`. That single signal drove BOTH the network-DEPENDENT work (divider re-latch + read-cursor advance — need the persisted row id) AND the network-INDEPENDENT bottom-snap + follow-state reset (the operator pressing enter). Binding the snap to the POST left the pane parked when the POST was slow/failed while the WS echo still rendered the row.

## Fix
Split the signal by data dependency. New `ownSendSubmitted` (`equals: false`) is published SYNCHRONOUSLY before the await and drives the snap + follow-state reset in `ScrollbackPane`. `lastOwnSend` stays post-resolve, its effect now doing ONLY the divider re-latch (reads the cursor advanced from the confirmed row id). A rejected send never confirms → no re-latch (correct — nothing was persisted to mark read); the snap already happened at submit, so you are at the bottom to watch the send land or fail.

Preserves #168 (send scrolls to bottom UNCONDITIONALLY — now independent of the network) and the frozen-divider / marker-latch freeze contract. Decision log: `docs/DESIGN_NOTES.md` 2026-07-31.

## Tests
- **vitest** (TRIGGER): `ownSendSubmitted` fires synchronously before the POST resolves; fires even when the POST rejects while `lastOwnSend` does not (case 1); no-token no-op; `equals:false` re-fires on repeats.
- **component** (RENDER wiring): the submit-time signal does NOT re-latch the divider — only `lastOwnSend` does — guarding the split from re-coupling.
- **e2e**: a send whose POST fails still snaps the pane to the bottom (fetch-wrap forwards the request so the server WS-broadcasts the row, then rejects the client leg). `1 passed` locally.

Shell.test.tsx's scrollback mock gains the `ownSendSubmitted` export — the pane reads it via `on(...)` at component creation, so any mock feeding a rendered `ScrollbackPane` must provide it.

Rebased onto `bdbba6b4` (#474). Local gates green: vitest 3687/3687, tsc, biome, scoped e2e #580.