### PR TITLE
fix(#576): exclude own-authored content from the unread count

### DIFF
--- a/cicchetto/e2e/tests/issue576-own-msg-unread-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue576-own-msg-unread-badge.spec.ts
@@ -1,0 +1,145 @@
+// GH #576 — the unread badge counted the operator's OWN content rows.
+//
+// Nothing filtered the unread count by sender: a line you typed was
+// "unread" until some later event moved the read cursor past it. The
+// optimistic send-time cursor advance (scrollback.ts) normally masks it,
+// but that advance has gaps — and a server `read_cursor_set` arriving from
+// another session (last-write-wins, no forward-only gate) can pull the
+// local cursor BELOW your own last message, re-exposing it as unread with
+// no peer line after it. The operator sees a badge on a window whose last
+// lines are all theirs and cannot clear it by reading (F5 fixed it: the
+// server cursor was already ahead, the client copy had fallen behind).
+//
+// The fix excludes own-authored CONTENT from the count — the content-row
+// twin of #532 A (own PRESENCE), on BOTH count doors: the client
+// `perChannelUnread` memo (selection.ts) AND the server cold-load seed
+// (`Scrollback.exclude_own_authored/3` + `ReadCursor` twin). This spec
+// pins the CLIENT surface in a real browser (per feedback_ux_e2e_mandatory
+// — vitest can't exercise the live WS echo + cross-device cursor regress +
+// Solid render path the badge depends on); the server exclusion is pinned
+// by the Elixir unit tests (scrollback_test / read_cursor_test /
+// window_counts_test).
+//
+// Method: send own lines in a focused DM (the belt advances the cursor),
+// then FORCE the read cursor BACK below them (the exact cross-device
+// regress the report describes) and focus away. Pre-fix the badge shows
+// the own lines; post-fix it shows nothing until a PEER line arrives.
+
+import { expect, test } from "../fixtures/test";
+import {
+  composeSend,
+  loginAs,
+  scrollbackLine,
+  selectChannel,
+  sidebarMessageBadge,
+  sidebarWindow,
+  waitForDmListenerReady,
+} from "../fixtures/cicchettoPage";
+import {
+  assertMessagePersisted,
+  fetchAllMessagesAsc,
+  restoreReadCursorToTail,
+  setReadCursorToId,
+} from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+const PEER_NICK = "i576-peer";
+const OPENER = "#576: peer opener — read, cursor baseline sits here";
+const OWN_A = "#576: my own line A — read by definition, must not badge";
+const OWN_B = "#576: my own line B — read by definition, must not badge";
+const REPLY = "#576: peer reply after my lines — this one DOES badge";
+
+test.afterEach(async () => {
+  const vjt = getSeededVjt();
+  // Restore the DM cursor to the tail so the own/peer rows this spec leaves
+  // in the shared backend don't poison a later spec (or a --repeat-each
+  // rerun) via a stale backward cursor. Idempotent + guarded.
+  await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, PEER_NICK).catch(() => {});
+});
+
+test("#576 — own content lines don't badge; a later peer line does", async ({ page }) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+
+  // Channel-first focus drives the WS-ready sync the own-nick DM-listener
+  // subscribe boots off (mirrors #532 B / ux-6-k / M4).
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+  await waitForDmListenerReady(page, NETWORK_SLUG);
+
+  const peer = await IrcPeer.connect({ nick: PEER_NICK });
+  try {
+    // Peer opens the DM. Focus it so it renders (the send-time advance's
+    // anti-poison gate #50 needs a non-empty pane), and read it — the
+    // cursor baseline will be restored to exactly this line below.
+    peer.privmsg(NETWORK_NICK, OPENER);
+    await assertMessagePersisted({
+      token: vjt.token,
+      networkSlug: NETWORK_SLUG,
+      channel: PEER_NICK,
+      sender: PEER_NICK,
+      body: OPENER,
+    });
+    await expect(sidebarWindow(page, NETWORK_SLUG, PEER_NICK)).toHaveCount(1, { timeout: 5_000 });
+    await selectChannel(page, NETWORK_SLUG, PEER_NICK, { awaitWsReady: false });
+    await expect(scrollbackLine(page, "privmsg", OPENER).last()).toBeVisible({ timeout: 5_000 });
+
+    // Send two OWN lines in the focused DM. They echo back over WS and
+    // render; the belt advances the cursor past them (that is the mask this
+    // fix is belt-and-braces over — we defeat it next).
+    await composeSend(page, OWN_A);
+    await composeSend(page, OWN_B);
+    for (const body of [OWN_A, OWN_B]) {
+      await assertMessagePersisted({
+        token: vjt.token,
+        networkSlug: NETWORK_SLUG,
+        channel: PEER_NICK,
+        sender: NETWORK_NICK,
+        body,
+      });
+      await expect(scrollbackLine(page, "privmsg", body).last()).toBeVisible({ timeout: 5_000 });
+    }
+
+    // Focus AWAY so the DM is neither selected nor visible — otherwise the
+    // focused-window suppression would zero its badge for an unrelated
+    // reason and the assertion would be vacuous.
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { awaitWsReady: false });
+
+    // Reproduce the report: FORCE the read cursor back to the peer opener,
+    // i.e. BELOW the two own lines (a cross-device / out-of-order
+    // `read_cursor_set` the last-write-wins client adopts). Now the only
+    // rows past the cursor are the operator's own — pre-fix a "2" badge the
+    // operator can't clear by reading; post-fix nothing at all.
+    const rows = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, PEER_NICK);
+    const openerRows = rows.filter((r) => r.body === OPENER);
+    const openerId = openerRows[openerRows.length - 1]?.id;
+    expect(openerId, "peer opener row must exist to seed the cursor baseline").toBeTruthy();
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, PEER_NICK, openerId as number);
+
+    // #576 assertion: NO message badge on the DM window whose only unread
+    // rows are the operator's own lines. Pre-fix `perChannelUnread` counted
+    // them → `.sidebar-msg-unread` rendered "2"; post-fix own content is
+    // excluded → the badge element is absent.
+    await expect(sidebarMessageBadge(page, NETWORK_SLUG, PEER_NICK)).toHaveCount(0, {
+      timeout: 5_000,
+    });
+
+    // A PEER line after the own ones DOES count — proving the badge
+    // mechanism is live (the 0 above is the own-exclusion, not a dead
+    // badge). Exactly one unread peer line ⟹ "1".
+    peer.privmsg(NETWORK_NICK, REPLY);
+    await assertMessagePersisted({
+      token: vjt.token,
+      networkSlug: NETWORK_SLUG,
+      channel: PEER_NICK,
+      sender: PEER_NICK,
+      body: REPLY,
+    });
+    await expect(sidebarMessageBadge(page, NETWORK_SLUG, PEER_NICK)).toHaveText("1", {
+      timeout: 5_000,
+    });
+  } finally {
+    await peer.disconnect("#576 done");
+  }
+});

--- a/cicchetto/src/__tests__/selection.test.ts
+++ b/cicchetto/src/__tests__/selection.test.ts
@@ -326,6 +326,137 @@ describe("selection store", () => {
     });
   });
 
+  // #576 — own-authored CONTENT is read BY DEFINITION and must not inflate the
+  // badge. `perChannelUnread` resolves the per-network own nick
+  // (`ownNickForNetwork` + `nickEquals`, the #372 client fold twin) and skips
+  // own-sender content rows — the client twin of the server
+  // `Scrollback.exclude_own_authored/3`. These seed the networks resource via
+  // setToken (the own nick is per-network, resolved through
+  // `networkBySlug(slug)`), UNLIKE the memo-derivation block above which leaves
+  // networks unhydrated → ownNick null → no exclusion (why those rows all count
+  // regardless of sender). The mocked `me().name` is "alice", so the own nick
+  // for the sole `nick: "alice"` network is "alice".
+  describe("own-authored content excluded from the badge (#576)", () => {
+    const aliceNet = {
+      kind: "user" as const,
+      id: 1,
+      slug: "freenode",
+      nick: "alice",
+      connection_state: "connected" as const,
+      connection_state_reason: null,
+      connection_state_changed_at: null,
+      inserted_at: "",
+      updated_at: "",
+    };
+
+    it("skips own-sender content; a peer line still counts (peer window)", async () => {
+      vi.resetModules();
+      const api = await import("../lib/api");
+      vi.mocked(api.listMessages).mockResolvedValue([]);
+      vi.mocked(api.listNetworks).mockResolvedValue([aliceNet]);
+      const auth = await import("../lib/auth");
+      const selection = await import("../lib/selection");
+      const scrollback = await import("../lib/scrollback");
+      const networks = await import("../lib/networks");
+      auth.setToken("tok576-peer");
+      // Wait until the own nick resolves — requires both the me() and the
+      // networks resource hydrated (perChannelUnread reads both).
+      await vi.waitFor(() => {
+        expect(networks.networkBySlug("freenode")?.nick).toBe("alice");
+      });
+
+      const key = channelKey("freenode", "bob");
+      const row = (id: number, sender: string) =>
+        scrollback.appendToScrollback(key, {
+          id,
+          network: "freenode",
+          channel: "bob",
+          server_time: id,
+          kind: "privmsg",
+          sender,
+          body: "x",
+          meta: {},
+        });
+      row(1, "alice"); // own outbound — read by definition, excluded
+      row(2, "bob"); // peer reply — counts
+
+      await vi.waitFor(() => {
+        expect(selection.messagesUnread()[key]).toBe(1);
+      });
+    });
+
+    it("folds the own-nick match (ASCII A-Z): a differently-cased own line is still skipped", async () => {
+      vi.resetModules();
+      const api = await import("../lib/api");
+      vi.mocked(api.listMessages).mockResolvedValue([]);
+      vi.mocked(api.listNetworks).mockResolvedValue([aliceNet]);
+      const auth = await import("../lib/auth");
+      const selection = await import("../lib/selection");
+      const scrollback = await import("../lib/scrollback");
+      const networks = await import("../lib/networks");
+      auth.setToken("tok576-fold");
+      await vi.waitFor(() => {
+        expect(networks.networkBySlug("freenode")?.nick).toBe("alice");
+      });
+
+      const key = channelKey("freenode", "#chan");
+      const row = (id: number, sender: string) =>
+        scrollback.appendToScrollback(key, {
+          id,
+          network: "freenode",
+          channel: "#chan",
+          server_time: id,
+          kind: "privmsg",
+          sender,
+          body: "x",
+          meta: {},
+        });
+      row(1, "ALICE"); // own, upper-cased — nickEquals folds it to own → skipped
+      row(2, "bob"); // peer — counts
+
+      await vi.waitFor(() => {
+        expect(selection.messagesUnread()[key]).toBe(1);
+      });
+    });
+
+    it("KEEPS own content in the own-nick SELF window (#576 × #396 carve-out)", async () => {
+      vi.resetModules();
+      const api = await import("../lib/api");
+      vi.mocked(api.listMessages).mockResolvedValue([]);
+      vi.mocked(api.listNetworks).mockResolvedValue([aliceNet]);
+      const auth = await import("../lib/auth");
+      const selection = await import("../lib/selection");
+      const scrollback = await import("../lib/scrollback");
+      const networks = await import("../lib/networks");
+      auth.setToken("tok576-self");
+      await vi.waitFor(() => {
+        expect(networks.networkBySlug("freenode")?.nick).toBe("alice");
+      });
+
+      // Window keyed to the operator's OWN nick: a note-to-self is that
+      // window's legitimate payload (#396), so own content is NOT excluded
+      // here (isSelfWindow gate). Mirrors the server self-window carve-out.
+      const key = channelKey("freenode", "alice");
+      const row = (id: number) =>
+        scrollback.appendToScrollback(key, {
+          id,
+          network: "freenode",
+          channel: "alice",
+          server_time: id,
+          kind: "privmsg",
+          sender: "alice",
+          body: "x",
+          meta: {},
+        });
+      row(1);
+      row(2);
+
+      await vi.waitFor(() => {
+        expect(selection.messagesUnread()[key]).toBe(2);
+      });
+    });
+  });
+
   // #239 — hidden/control messages must NOT leave the unread counter stuck.
   // Regression from #222: the render-layer presence filter hides
   // join/part/quit/nick_change on large / pref-hidden channels, but the

--- a/cicchetto/src/__tests__/subscribe.test.ts
+++ b/cicchetto/src/__tests__/subscribe.test.ts
@@ -951,7 +951,15 @@ describe("subscribe — WS join effect", () => {
         kind: "channel",
       });
 
-      fireMessageToAllHandlers("#grappa", { id: 100, body: "first-after-rotation" });
+      // #576 — an explicit PEER sender: the default "bob" is the current
+      // identity's own nick, and own-authored content is now excluded from
+      // the unread count. This test measures handler MULTIPLICITY (one
+      // handler ⟹ +1), so the bumping message must come from someone else.
+      fireMessageToAllHandlers("#grappa", {
+        id: 100,
+        sender: "alice",
+        body: "first-after-rotation",
+      });
 
       // Single message dispatched to ALL registered "event" handlers
       // for the channel. With the fix, exactly one handler runs —

--- a/cicchetto/src/lib/selection.ts
+++ b/cicchetto/src/lib/selection.ts
@@ -1,5 +1,5 @@
 import { createEffect, createMemo, createSignal, on, untrack } from "solid-js";
-import { isContentKind } from "./api";
+import { isContentKind, ownNickForNetwork } from "./api";
 import { token } from "./auth";
 import { type ChannelKey, channelKey, decodeChannelKey } from "./channelKey";
 import { isDocumentVisible } from "./documentVisibility";
@@ -379,6 +379,11 @@ const exports = identityScopedStore((onIdentityChange) => {
     // the memo re-run when membership crosses the large-channel threshold, in
     // lock-step with `presenceRowVisible`'s pref-signal dependency below.
     const members = membersByChannel();
+    // #576 — resolve the operator's per-network own nick to strip own-authored
+    // CONTENT from the count (see the content-row loop below). Read reactively
+    // so a NICK change / login re-runs the count. Per-key resolution uses
+    // `networkBySlug(slug)` inside the loop (a nick is per-network).
+    const me = user();
 
     const result: Record<ChannelKey, Computed> = {};
 
@@ -403,6 +408,16 @@ const exports = identityScopedStore((onIdentityChange) => {
       const cursorMapKey = `${decoded.slug} ${decoded.name}`;
       const cursor = cursors[cursorMapKey] ?? 0;
       const memberCount = (members[key] ?? []).length;
+      // #576 — the per-network own nick for this key's network. A nick is
+      // per-network (`net.nick`), so resolve it per key; null when the
+      // network isn't known yet (nickEquals is null-safe → no exclusion).
+      const net = networkBySlug(decoded.slug);
+      const ownNick = net ? ownNickForNetwork(net, me) : null;
+      // The own-nick SELF window (pane keyed to your own nick) is the ONE
+      // window where own content is legitimate payload — a note-to-self —
+      // so it is NOT excluded there (#396). Mirrors the server self-window
+      // carve-out in `Scrollback.exclude_own_authored/3`.
+      const isSelfWindow = nickEquals(decoded.name, ownNick);
 
       let msgs = 0;
       let evts = 0;
@@ -413,8 +428,21 @@ const exports = identityScopedStore((onIdentityChange) => {
         // operator can never clear by reading. Same predicate the pane's
         // `rows()` filter uses (reconcile-to-one, not a forked filter).
         if (!presenceRowVisible(key, memberCount, row.kind)) continue;
-        if (isContentKind(row.kind)) msgs++;
-        else evts++;
+        if (isContentKind(row.kind)) {
+          // #576 — a content row the operator authored is read BY DEFINITION;
+          // outside the self-window it must not inflate the badge (the
+          // content-row twin of the #532 A own-presence exclusion, mirrored
+          // server-side in `Scrollback.exclude_own_authored/3`). `sender` is
+          // compared via the ASCII nick fold (#372 `nickEquals`) — display
+          // stays raw, the MATCH folds. Belt-and-braces over the optimistic
+          // send-time cursor advance (scrollback.ts), which has gaps (the #50
+          // empty-pane gate; a cross-device / out-of-order cursor landing
+          // below your own line).
+          if (!isSelfWindow && nickEquals(row.sender, ownNick)) continue;
+          msgs++;
+        } else {
+          evts++;
+        }
       }
       result[key] = { messages: msgs, events: evts };
     }

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -24431,3 +24431,75 @@ through `Ecto.Migrator.with_repo` (the seeder's `mix ecto.migrate`,
 e2e-only `pool_size` hack. Verified: the faithful repro went from LOCK 15/16 to
 **PASS 16/16** (both pool sizes) with the fix in place. A new migrate/boot path
 that bypasses `with_repo`/repo start would not inherit the pre-init.
+## 2026-07-31 — #576: own-authored CONTENT is excluded from the unread count (the content-row twin of #532 A)
+
+**Problem.** The unread badge counted the operator's OWN content rows. Nothing
+filtered the count by sender: a line you typed was "unread" until some later
+event moved the read cursor past it. The optimistic send-time cursor advance
+(`cicchetto/src/lib/scrollback.ts`) normally masks this, but it has gaps — the
+#50 empty-pane gate skips the advance for a `/msg` window written into
+immediately, and a `read_cursor_set` arriving from another session
+(`applyReadCursorSet` is last-write-wins, no forward-only gate — deliberate for
+cross-device) can pull the local cursor BELOW your own last message. Both leave
+a badge whose count is only your own lines, with no peer line after them, that
+the operator cannot clear by reading (F5 fixed it: the server cursor was
+already ahead, the client copy had fallen behind). Reported on IRC.
+
+**Fix — a row you authored is read BY DEFINITION.** Exclude own-authored
+CONTENT from the count, mirroring #532 A (which already excludes own PRESENCE),
+on BOTH count doors, "one feature every door":
+
+  * **client** — `perChannelUnread` (`selection.ts`): a content row whose
+    `sender` folds to the per-network own nick (`ownNickForNetwork` +
+    `nickEquals`, the #372 client fold twin) no longer increments `messages`.
+    Reads `user()` reactively so a NICK change re-runs the count; the own nick
+    is resolved per key via `networkBySlug(slug)` (a nick is per-network).
+  * **server** — the cold-load seed twins that already stripped own presence
+    now strip own content too, EXCEPT in the self-window (below).
+    `Scrollback.exclude_own_presence/2` → **`exclude_own_authored/3`** (used by
+    `count_after_split/5`) and `ReadCursor.own_presence_dynamic/1` →
+    **`own_authored_dynamic/2`** (used by `bulk_unread_split/2`). Exclude a row
+    when `nick_fold(sender) == fold(own_nick)` (own content, own self-PART/kick,
+    case-only self-rename) OR `kind not in content AND nick_fold(meta.new_nick)
+    == fold(own_nick)` (presence-only terminal self-rename, `sender = OLD`).
+    NICK-FOLD MATCH site: `sender` stays RAW (display), only the compare folds
+    (`Identifier.nick_fold/1` / `canonical_target/1` server, `nickEquals`
+    client).
+
+**Belt-and-braces, not a replacement.** The optimistic send-time cursor advance
+STAYS — it keeps the in-pane divider honest. #576 makes the COUNT independent of
+cursor timing: own content is never counted whether or not the cursor has moved.
+Mentions are a SEPARATE predicate (own content never mentions self) and are
+untouched. `count_after/5` (the non-split total) has NO production caller — the
+join-reply + `/me` cold-load both route through `WindowCounts.snapshot/6` →
+`count_after_split/5` and `WindowCounts.bulk_snapshot/3` →
+`bulk_unread_split/2`, the two doors fixed here — so it was left as-is (no gap).
+
+**Self-window carve-out (#576 × #396) — restrict the predicate, not the tests.**
+#396 (DESIGN_NOTES 2026-07-25) deliberately made the own-nick SELF window
+(`channel == own_nick`) count self rows — a note-to-self (`/msg <ownnick>`) is
+that window's legitimate payload. A first cut of #576 used a UNIFORM
+`sender`-fold predicate (no window carve-out) and silently zeroed the
+self-window, which would have forced rewriting #396's asserts. That is the wrong
+move — the self-window IS a legitimate case, so the PREDICATE is restricted, not
+the assert (per the review directive). `exclude_own_authored/3` takes a
+`self_window?` boolean (`canonical(channel) == canonical(own_nick)`) and in the
+self-window strips own PRESENCE ONLY (byte-for-byte the pre-#576 #532 A
+predicate); own content still counts. `bulk_unread_split/2` spans all windows at
+once, so its per-row twin lives in the JOIN on-clause: the `sender`-content
+clause fires only when `Identifier.nick_fold(rc.channel) != folded` (i.e. NOT
+the self-window for that row's cursor). The client mirrors with an `isSelfWindow
+= nickEquals(name, ownNick)` gate in `perChannelUnread`. Net: own content is
+dropped in peer / channel windows (the reported bug) and KEPT in the self-window
+(#396 unchanged, its tests untouched). #532 A own-presence exclusion applies in
+BOTH.
+
+**Tests.** Server: `count_after_split` (own content excluded in a channel +
+ASCII-fold match + `own_nick=nil` boundary + COUNTS in the self-window),
+`bulk_unread_split` (own outbound DM excluded + fold + COUNTS in the
+self-window), `window_counts` (channel own-msg excluded; #396 self-window counts
+UNCHANGED). Client: `subscribe.test.ts` (a peer line bumps unread +1 — the
+own-sender default that used to lazily equal own nick is now an explicit peer).
+e2e (`issue576-own-msg-unread-badge.spec.ts`): send own lines in a peer DM, force
+the read cursor back below them (the reported cross-device regress), badge shows
+NOTHING; a later peer line makes it "1".

--- a/lib/grappa/read_cursor.ex
+++ b/lib/grappa/read_cursor.ex
@@ -282,10 +282,16 @@ defmodule Grappa.ReadCursor do
   def bulk_unread_split(subject, own_nicks) when is_map(own_nicks) do
     content = Message.content_kinds()
     {sub_field, sub_id} = subject_pair(subject)
-    own_presence = own_presence_dynamic(own_nicks)
+    own_authored = own_authored_dynamic(own_nicks, content)
 
-    # Full JOIN on-clause built as a dynamic so the per-network own-presence
-    # OR (`^own_presence`) can be interpolated into it (#532 A).
+    # Full JOIN on-clause built as a dynamic so the per-network own-authored
+    # exclusion (`^own_authored`) can be interpolated into it (#532 A + #576).
+    # An own-authored row — own CONTENT (a line the operator sent, #576) OR
+    # own PRESENCE (self-part / kick-issued / terminal self-rename, #532 A) —
+    # does not join, so it lands in NEITHER bucket. The kind gate for the
+    # presence-only `new_nick` clause now lives INSIDE `own_authored_dynamic`
+    # (the `sender` clause applies to every kind), so the wrap is a bare
+    # `not ^own_authored`.
     join_on =
       dynamic(
         [rc, _, m],
@@ -294,7 +300,7 @@ defmodule Grappa.ReadCursor do
           Identifier.nick_fold(fragment("COALESCE(?, ?)", m.dm_with, m.channel)) ==
             Identifier.nick_fold(rc.channel) and
           m.id > rc.last_read_message_id and
-          not (m.kind not in ^content and ^own_presence)
+          not (^own_authored)
       )
 
     query =
@@ -416,23 +422,38 @@ defmodule Grappa.ReadCursor do
   defp subject_pair({:user, user_id}) when is_binary(user_id), do: {:user_id, user_id}
   defp subject_pair({:visitor, visitor_id}) when is_binary(visitor_id), do: {:visitor_id, visitor_id}
 
-  # #532 A — a dynamic OR flagging a `messages` row as the subject's OWN
-  # presence for ITS network: `rc.network_id == nid AND (nick_fold(sender)
-  # == canonical_nick(own_nick) OR nick_fold(meta.new_nick) ==
-  # canonical_nick(own_nick))`, OR'd across every network in `own_nicks`
-  # (`%{slug => {network_id, own_nick}}`). Two clauses because a genuine
-  # self-rename's `:nick_change` row carries `sender = OLD nick` +
-  # `meta.new_nick = NEW`; the live `own_nick` is the NEW one, so only the
-  # `new_nick` clause catches the terminal rename (see
-  # `Scrollback.exclude_own_presence/2` for the full rationale + boundary).
-  # The fold is per-network because a subject may hold a different nick on
-  # each. Interpolated into `bulk_unread_split/2`'s join on-clause so an own
-  # presence row is dropped from the `events` bucket. Empty map / a `nil`
-  # nick entry contributes nothing → `dynamic(false)` = "no row is mine",
-  # which leaves that network's presence counts unchanged.
-  @spec own_presence_dynamic(%{String.t() => {integer(), String.t()}}) ::
+  # #532 A + #576 — a dynamic OR flagging a `messages` row as the subject's
+  # OWN (authored) row that should NOT count in ITS window, for ITS network,
+  # OR'd across every network in `own_nicks` (`%{slug => {network_id,
+  # own_nick}}`). Two match clauses because a rename splits identity:
+  #
+  #   * `nick_fold(sender) == folded` — own CONTENT (a line the operator
+  #     sent — #576, the DM-badge-of-your-own-lines bug), own self-PART /
+  #     KICK-issued, and a case-only self-rename (`sender` is the live nick).
+  #   * `kind not in content AND nick_fold(meta.new_nick) == folded` —
+  #     PRESENCE-only terminal self-rename (`sender = OLD`, live nick is the
+  #     NEW one, so only this clause catches it; content rows carry no
+  #     `new_nick`, so the kind gate is intent + belt-and-braces).
+  #
+  # ## Self-window carve-out (#576 × #396)
+  #
+  # `Identifier.nick_fold(rc.channel) != ^folded` is the PER-ROW self-window
+  # test: the own-nick SELF window (cursor keyed to own nick) is the ONE
+  # window where own content is legitimate payload (a note-to-self, #396), so
+  # there own CONTENT is NOT dropped — only own PRESENCE is. The `sender`
+  # clause therefore fires for a content row ONLY when it is NOT the
+  # self-window (`m.kind not in ^content OR nick_fold(rc.channel) != folded`);
+  # own presence (`kind not in content`) is dropped in EVERY window (#532 A).
+  # This is the per-row twin of `Scrollback.exclude_own_authored/3`'s
+  # `self_window?` branch — count_after_split knows the single `channel` it
+  # counts, but bulk_unread_split spans all windows so the test lives in the
+  # JOIN on-clause. `rc.channel` is stored canonical (#532 D). The fold is
+  # per-network because a subject may hold a different nick on each. Empty
+  # map / a `nil` nick entry contributes nothing → `dynamic(false)` = "no row
+  # is mine", leaving that network's counts unchanged.
+  @spec own_authored_dynamic(%{String.t() => {integer(), String.t()}}, [Message.kind()]) ::
           Ecto.Query.dynamic_expr()
-  defp own_presence_dynamic(own_nicks) do
+  defp own_authored_dynamic(own_nicks, content) do
     Enum.reduce(own_nicks, dynamic(false), fn
       {_, {network_id, own_nick}}, acc when is_binary(own_nick) ->
         folded = Identifier.canonical_target(own_nick)
@@ -441,8 +462,10 @@ defmodule Grappa.ReadCursor do
           [rc, _, m],
           ^acc or
             (rc.network_id == ^network_id and
-               (Identifier.nick_fold(m.sender) == ^folded or
-                  (not is_nil(fragment("json_extract(?, '$.new_nick')", m.meta)) and
+               ((Identifier.nick_fold(m.sender) == ^folded and
+                   (m.kind not in ^content or Identifier.nick_fold(rc.channel) != ^folded)) or
+                  (m.kind not in ^content and
+                     not is_nil(fragment("json_extract(?, '$.new_nick')", m.meta)) and
                      Identifier.nick_fold(fragment("json_extract(?, '$.new_nick')", m.meta)) ==
                        ^folded)))
         )

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -665,13 +665,20 @@ defmodule Grappa.Scrollback do
   def count_after_split(subject, network_id, channel, after_id, own_nick)
       when is_integer(network_id) and is_integer(after_id) and
              (is_binary(own_nick) or is_nil(own_nick)) do
+    # #576 — the own-nick SELF window (channel keyed to your own nick) is the
+    # ONE window where own content is legitimate payload (notes-to-self, #396),
+    # so own content is NOT excluded there — only in peer / channel windows.
+    self_window? =
+      is_binary(own_nick) and
+        Identifier.canonical_target(channel) == Identifier.canonical_target(own_nick)
+
     query =
       Message
       |> subject_where(subject)
       |> where([m], m.network_id == ^network_id)
       |> channel_or_dm_where(channel, own_nick)
       |> where([m], m.id > ^after_id)
-      |> exclude_own_presence(own_nick)
+      |> exclude_own_authored(own_nick, self_window?)
       # S17: the content bucket derives from `@content_kinds` (schema
       # SSOT) via Ecto's `in` — which renders the same
       # `kind IN (?, ?, ?)` predicate the hand-maintained raw-SQL list
@@ -689,39 +696,54 @@ defmodule Grappa.Scrollback do
     end)
   end
 
-  # #532 A — the subject's OWN presence/control rows are never "unread" to
-  # them: leaving a channel (self-PART), a KICK they issued, or renaming
-  # themselves is an action they performed, not something to catch up on.
-  # Excludes rows that are BOTH non-content (`kind not in @content_kinds`)
-  # AND the subject's own presence, matched two ways because a rename splits
+  # #532 A + #576 — the subject's OWN rows are never "unread" to them: a
+  # line they typed is read BY DEFINITION (#576 content), and leaving a
+  # channel (self-PART), a KICK they issued, or renaming themselves is an
+  # action they performed, not something to catch up on (#532 A presence).
+  # The two matched clauses in each branch below, because a rename splits
   # identity across the row:
   #
-  #   * `nick_fold(sender) == canonical_nick(own_nick)` — a self-PART or a
-  #     KICK the subject issued (`sender` is the current/live nick), and a
-  #     case-only self-rename (folds to the live nick).
-  #   * `nick_fold(meta.new_nick) == canonical_nick(own_nick)` — a genuine
-  #     self-rename's `:nick_change` row is persisted with `sender = OLD
-  #     nick` and `meta.new_nick = NEW nick` (EventRouter fan-out to every
-  #     shared channel + `$server`); the live nick is the NEW one, so the
-  #     `sender` clause misses it. Matching `new_nick` catches the TERMINAL
-  #     rename (`new_nick` == live nick), killing the recurring `$server`
-  #     "+1" every `/nick` left behind and the rename-then-part strand.
+  #   * `nick_fold(sender) == canonical_nick(own_nick)` — own CONTENT (a
+  #     PRIVMSG/ACTION/NOTICE the operator sent, #576), a self-PART or a KICK
+  #     the subject issued, and a case-only self-rename (`sender` is the
+  #     current/live nick in all of these).
+  #   * `nick_fold(meta.new_nick) == canonical_nick(own_nick)` — PRESENCE
+  #     ONLY: a genuine self-rename's `:nick_change` row is persisted with
+  #     `sender = OLD nick` and `meta.new_nick = NEW nick`; the live nick is
+  #     the NEW one, so only the `new_nick` clause catches the TERMINAL
+  #     rename, killing the recurring `$server` "+1" every `/nick` left
+  #     behind. Content rows carry no `new_nick`, so the `kind not in
+  #     @content_kinds` guard is intent + belt-and-braces.
   #
-  # so the `events` bucket no longer strands a permanent "1" behind an own
-  # leave. CONTENT rows are untouched (own content still counts toward
-  # `messages`; C's notify predicate — a separate concern — handles own
-  # content for the badge). Derive-don't-duplicate: no cursor is moved, so
-  # any legitimate unread CONTENT that arrived before the leave survives
-  # (and #532 B surfaces it), and it is timing-independent — the self-PART
-  # audit row is never counted whether or not the upstream echo has landed.
-  # Same rule applied in `ReadCursor.bulk_unread_split/2` (the #396
-  # cold-load twin). Boundary: an INTERMEDIATE row of a multi-hop rename
-  # (`alice→bob→vjt`: the `alice→bob` row folds to neither `alice`'s old
-  # sender nor `vjt`'s live nick) still counts and self-heals on the next
-  # view — a rare, narrow gap. `own_nick == nil` (unbound network) → no
-  # nick to match → no exclusion.
-  @spec exclude_own_presence(Ecto.Query.t(), String.t() | nil) :: Ecto.Query.t()
-  defp exclude_own_presence(query, own_nick) when is_binary(own_nick) do
+  # ## Self-window carve-out (#576 × #396)
+  #
+  # `self_window?` is TRUE when the window being counted is keyed to the
+  # subject's OWN nick (`channel == own_nick`). That is the ONE window where
+  # own content is legitimate payload — a note-to-self (`/msg <ownnick>`) —
+  # so #396 deliberately counts it. There, we strip own PRESENCE ONLY (the
+  # original #532 A predicate); own content still counts. Everywhere else (a
+  # peer DM or a channel) own content is read by definition and #576 strips
+  # it too. #532 A presence exclusion applies in BOTH branches. This keeps a
+  # DM/channel badge from being made of your own lines (the reported bug —
+  # the optimistic send-time cursor advance has gaps) WITHOUT silently
+  # zeroing the self-window's notes-to-self.
+  #
+  # Derive-don't-duplicate: no cursor is moved, so any legitimate unread PEER
+  # row that arrived before the own row survives, and it is timing-
+  # independent. Same rule applied in `ReadCursor.bulk_unread_split/2` (the
+  # #396 cold-load twin — the self-window test there is per-row on
+  # `rc.channel`). Boundary: an INTERMEDIATE row of a multi-hop rename
+  # (`alice→bob→vjt`) still counts and self-heals on the next view — a rare,
+  # narrow gap. `own_nick == nil` (unbound network / no live session) → no
+  # nick to match → no exclusion. Mentions stay a SEPARATE predicate (own
+  # content never mentions self), untouched here.
+  @spec exclude_own_authored(Ecto.Query.t(), String.t() | nil, boolean()) :: Ecto.Query.t()
+  defp exclude_own_authored(query, nil, _), do: query
+
+  # Self-window: own content is a legitimate note-to-self (#396) → count it;
+  # strip own PRESENCE only (#532 A). This is byte-for-byte the pre-#576
+  # exclusion.
+  defp exclude_own_authored(query, own_nick, true) when is_binary(own_nick) do
     folded = Identifier.canonical_target(own_nick)
 
     where(
@@ -735,7 +757,21 @@ defmodule Grappa.Scrollback do
     )
   end
 
-  defp exclude_own_presence(query, nil), do: query
+  # Peer / channel window: own CONTENT (#576) AND own PRESENCE (#532 A) both
+  # excluded.
+  defp exclude_own_authored(query, own_nick, false) when is_binary(own_nick) do
+    folded = Identifier.canonical_target(own_nick)
+
+    where(
+      query,
+      [m],
+      not (Identifier.nick_fold(m.sender) == ^folded or
+             (m.kind not in ^@content_kinds and
+                not is_nil(fragment("json_extract(?, '$.new_nick')", m.meta)) and
+                Identifier.nick_fold(fragment("json_extract(?, '$.new_nick')", m.meta)) ==
+                  ^folded))
+    )
+  end
 
   @doc """
   Returns up to `limit` unread CONTENT rows (`id > after_id`) for the

--- a/test/grappa/read_cursor_test.exs
+++ b/test/grappa/read_cursor_test.exs
@@ -53,6 +53,12 @@ defmodule Grappa.ReadCursorTest do
     network
   end
 
+  # Generic unread-content inserter: `sender: "peer"` so a row stands for
+  # someone ELSE's message. #576 excludes the subject's OWN content from the
+  # unread count, and every `bulk_unread_split/2` test here threads
+  # `own_nicks` as "vjt" — a "vjt" sender would fold to own and drop out,
+  # silently zeroing the very counts these tests assert. Own-authored rows
+  # are inserted explicitly (see the #532 A / #576 tests).
   defp insert_message(subject_attrs, network_id, channel, server_time, body \\ "msg") do
     attrs =
       Map.merge(subject_attrs, %{
@@ -60,7 +66,7 @@ defmodule Grappa.ReadCursorTest do
         channel: channel,
         server_time: server_time,
         kind: :privmsg,
-        sender: "vjt",
+        sender: "peer",
         body: body
       })
 
@@ -922,6 +928,121 @@ defmodule Grappa.ReadCursorTest do
 
       assert ReadCursor.bulk_unread_split(subject, own_nicks)[net.slug]["#chan"] ==
                %{messages: 0, events: 1}
+    end
+
+    test "excludes the subject's OWN content rows from messages (#576)" do
+      user = user_fixture()
+      subject = {:user, user.id}
+      attrs = %{user_id: user.id}
+      net = network_fixture()
+
+      # DM window "peer": anchor the cursor, then the operator's OWN
+      # outbound line + a peer reply. The reported bug is a DM badge whose
+      # count is only the operator's own lines — content is read BY
+      # DEFINITION, so the #396 cold-load twin must strip it exactly as
+      # count_after_split/5 does (one rule, both count doors).
+      a = dm_row(attrs, net.id, "vjt", "peer", 1, "anchor")
+      {:ok, _} = ReadCursor.set(subject, net.id, "peer", a.id)
+
+      # Own outbound (channel = peer ⟹ sender = own_nick) — must NOT count.
+      {:ok, _} =
+        ScrollbackHelpers.insert(
+          Map.merge(attrs, %{
+            network_id: net.id,
+            channel: "peer",
+            server_time: 2,
+            kind: :privmsg,
+            sender: "vjt",
+            body: "my line",
+            dm_with: "peer"
+          })
+        )
+
+      # Peer reply (channel = own_nick, dm_with = peer) — counts.
+      dm_row(attrs, net.id, "vjt", "peer", 3, "their line")
+
+      own_nicks = %{net.slug => {net.id, "vjt"}}
+
+      assert ReadCursor.bulk_unread_split(subject, own_nicks)[net.slug]["peer"] ==
+               %{messages: 1, events: 0}
+    end
+
+    test "own-content exclusion folds the nick (ASCII A-Z, #576/#372)" do
+      user = user_fixture()
+      subject = {:user, user.id}
+      attrs = %{user_id: user.id}
+      net = network_fixture()
+
+      a = insert_message(attrs, net.id, "#chan", 1)
+      {:ok, _} = ReadCursor.set(subject, net.id, "#chan", a.id)
+
+      # Own content with a DIFFERENT casing than the live own_nick — the
+      # fold MATCH (`nick_fold(sender)`) must still drop it (`sender` is
+      # stored RAW for display).
+      {:ok, _} =
+        ScrollbackHelpers.insert(
+          Map.merge(attrs, %{
+            network_id: net.id,
+            channel: "#chan",
+            server_time: 2,
+            kind: :privmsg,
+            sender: "VJT",
+            body: "shout"
+          })
+        )
+
+      # A peer line still counts.
+      insert_message(attrs, net.id, "#chan", 3, "peer line")
+
+      own_nicks = %{net.slug => {net.id, "vjt"}}
+
+      assert ReadCursor.bulk_unread_split(subject, own_nicks)[net.slug]["#chan"] ==
+               %{messages: 1, events: 0}
+    end
+
+    test "own content COUNTS in the own-nick SELF window (#576 × #396 carve-out)" do
+      user = user_fixture()
+      subject = {:user, user.id}
+      attrs = %{user_id: user.id}
+      net = network_fixture()
+
+      # Self window (cursor keyed to own nick "vjt"): a note-to-self is
+      # legitimate payload that must still count (#396). The per-row
+      # self-window test in `own_authored_dynamic` (`nick_fold(rc.channel) !=
+      # folded`) spares own content HERE while dropping it in peer / channel
+      # windows.
+      {:ok, a} =
+        ScrollbackHelpers.insert(
+          Map.merge(attrs, %{
+            network_id: net.id,
+            channel: "vjt",
+            server_time: 1,
+            kind: :privmsg,
+            sender: "vjt",
+            body: "self anchor",
+            dm_with: "vjt"
+          })
+        )
+
+      {:ok, _} = ReadCursor.set(subject, net.id, "vjt", a.id)
+
+      {:ok, _} =
+        ScrollbackHelpers.insert(
+          Map.merge(attrs, %{
+            network_id: net.id,
+            channel: "vjt",
+            server_time: 2,
+            kind: :privmsg,
+            sender: "vjt",
+            body: "note to self",
+            dm_with: "vjt"
+          })
+        )
+
+      own_nicks = %{net.slug => {net.id, "vjt"}}
+
+      assert ReadCursor.bulk_unread_split(subject, own_nicks)[net.slug]["vjt"] ==
+               %{messages: 1, events: 0}
     end
   end
 

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -1270,9 +1270,88 @@ defmodule Grappa.ScrollbackTest do
         })
 
       # 3 content (outbound privmsg + inbound privmsg + inbound notice),
-      # 1 event (orphan server_event). own_nick threads the narrowing rule.
-      assert Scrollback.count_after_split({:user, user.id}, net.id, "peer", 0, "vjt-grappa") ==
+      # 1 event (orphan server_event). `own_nick = nil` on purpose: this
+      # test proves the #393 COALESCE arm-invariance (the predicate matches
+      # inbound/outbound/orphan alike), and the outbound arm is own-authored
+      # BY CONSTRUCTION (channel = peer ⟹ sender = own_nick). Threading a
+      # live own_nick would let #576's own-content exclusion drop the
+      # outbound row and confound the arm-count — that exclusion has its own
+      # tests below.
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "peer", 0, nil) ==
                %{messages: 3, events: 1}
+    end
+
+    # #576 — own-authored CONTENT rows are read BY DEFINITION: a line the
+    # operator typed must never inflate the `messages` badge. This is the
+    # content-row twin of #532 A (which already strips own PRESENCE from
+    # `events`). Only fires when `own_nick` is threaded (the live cold-load
+    # / join-reply seed path); `own_nick = nil` (no live session) counts
+    # everything, as before.
+    test "excludes the subject's OWN content rows from the messages count (#576)",
+         %{user: user, network: net} do
+      # Two own-authored content rows (the DM lines the operator sent) plus
+      # one peer reply — the exact reported shape (a DM badge of only your
+      # own lines).
+      {:ok, _} =
+        ScrollbackHelpers.insert(sample(user, net, 0, %{kind: :privmsg, sender: "vjt-grappa"}))
+
+      {:ok, _} =
+        ScrollbackHelpers.insert(sample(user, net, 1, %{kind: :action, sender: "vjt-grappa"}))
+
+      {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 2, %{kind: :privmsg, sender: "peer"}))
+
+      # own_nick threaded → only the peer content row counts.
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 0, "vjt-grappa") ==
+               %{messages: 1, events: 0}
+    end
+
+    test "own-content exclusion folds the nick (ASCII A-Z, #576/#372)",
+         %{user: user, network: net} do
+      # `sender` is stored RAW (display); the MATCH folds. A differently
+      # cased live own_nick must still drop the operator's own row.
+      {:ok, _} =
+        ScrollbackHelpers.insert(sample(user, net, 0, %{kind: :privmsg, sender: "VJT-Grappa"}))
+
+      {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 1, %{kind: :privmsg, sender: "peer"}))
+
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 0, "vjt-grappa") ==
+               %{messages: 1, events: 0}
+    end
+
+    test "own_nick=nil applies NO own-content exclusion (#576 boundary)",
+         %{user: user, network: net} do
+      {:ok, _} =
+        ScrollbackHelpers.insert(sample(user, net, 0, %{kind: :privmsg, sender: "vjt-grappa"}))
+
+      {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 1, %{kind: :privmsg, sender: "peer"}))
+
+      # Unbound network / no live session → nothing to fold → both count.
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 0, nil) ==
+               %{messages: 2, events: 0}
+    end
+
+    test "own content COUNTS in the own-nick SELF window (#576 × #396 carve-out)",
+         %{user: user, network: net} do
+      # `channel == own_nick` is the ONE window where own content is
+      # legitimate payload — a note-to-self (`/msg <ownnick>`). #576 excludes
+      # own content ONLY in peer / channel windows, never here (else #396's
+      # self-window count would silently zero). Stored at channel = dm_with =
+      # own_nick, sender = own_nick.
+      {:ok, _} =
+        Scrollback.persist_event(%{
+          user_id: user.id,
+          network_id: net.id,
+          channel: "vjt-grappa",
+          server_time: 0,
+          kind: :privmsg,
+          sender: "vjt-grappa",
+          body: "note to self",
+          meta: %{},
+          dm_with: "vjt-grappa"
+        })
+
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "vjt-grappa", 0, "vjt-grappa") ==
+               %{messages: 1, events: 0}
     end
   end
 

--- a/test/grappa/window_counts_test.exs
+++ b/test/grappa/window_counts_test.exs
@@ -246,7 +246,10 @@ defmodule Grappa.WindowCountsTest do
     insert(c, "#chan", st: 3, sender: "bob", body: "vjt you there")
 
     result = snap(c, "#chan", anchor.id, "vjt")
-    assert result.messages == 2
+    # #576 — the own message is read BY DEFINITION and no longer counts; only
+    # bob's peer line does. mentions were already own-excluded (an own line
+    # naming own nick is not a self-mention), so this test's point stands.
+    assert result.messages == 1
     assert result.mentions == 1
     assert result.severity == :mention
   end
@@ -371,6 +374,11 @@ defmodule Grappa.WindowCountsTest do
       assert bulk[net.slug]["#chan"].mentions == 1
     end
 
+    # #576 self-window carve-out: the own-nick window is the ONE window where
+    # own content is legitimate payload (a note-to-self), so #576 does NOT
+    # exclude it there — #396's counts stand unchanged. (Own content IS
+    # excluded in peer / channel windows; see the #576 tests in
+    # scrollback_test / read_cursor_test and "own-sent message …" above.)
     test "own-nick self window: legacy (channel=own, dm_with NULL) rows now COUNT (#396)" do
       user = AuthFixtures.user_fixture()
       subject = {:user, user.id}


### PR DESCRIPTION
Refs #576. (No auto-close keyword — merge ≠ ship; vjt closes the issue post-deploy.)

## Problem
The cic unread badge counted the operator's OWN content rows. Nothing filtered
the count by sender, so a line you typed stayed "unread" until some later event
moved the read cursor past it. The optimistic send-time cursor advance
(`cicchetto/scrollback.ts`) normally masks this, but it has gaps — the #50
empty-pane gate skips the advance for a `/msg` window written into immediately,
and a cross-device `read_cursor_set` (last-write-wins, no forward-only gate) can
pull the local cursor BELOW your own last line. Both leave a DM/channel badge
made only of your own lines, with no peer line after them, that the operator
cannot clear by reading. Reported on IRC.

## Fix — a row you authored is read BY DEFINITION
Exclude own-authored CONTENT from the count, the content-row twin of #532 A
(which already excludes own PRESENCE), on BOTH count doors ("one feature every
door"):

- **client** — `perChannelUnread` (`selection.ts`): a content row whose `sender`
  folds to the per-network own nick no longer increments `messages`.
- **server** — the cold-load seed twins that stripped own presence now strip own
  content too: `Scrollback.exclude_own_presence/2` → `exclude_own_authored/3`
  (`count_after_split/5`), `ReadCursor.own_presence_dynamic/1` →
  `own_authored_dynamic/2` (`bulk_unread_split/2`).

**NICK-FOLD MATCH:** `sender` stays RAW (display), only the compare folds
(`Identifier.nick_fold/1` / `canonical_target/1` server, `nickEquals` client) —
never a bare `downcase`/`==`.

## Self-window carve-out (#576 × #396)
The own-nick SELF window (`channel == own_nick`) is the ONE window where own
content is legitimate payload — a note-to-self (`/msg <ownnick>`) — which #396
deliberately counts. The **predicate** is restricted, not the test:
`exclude_own_authored/3` takes a `self_window?` flag and there strips own
PRESENCE ONLY (byte-for-byte the pre-#576 #532 A predicate); own content still
counts. `bulk_unread_split/2` spans all windows, so its per-row twin lives in the
JOIN on-clause (`nick_fold(rc.channel) != folded`). Own content is dropped in
peer/channel windows (the reported bug) and KEPT in the self-window (#396
unchanged, its asserts untouched). #532 A presence exclusion applies in BOTH.
The optimistic cursor advance STAYS (belt-and-braces).

## Tests
- server: `count_after_split` + `bulk_unread_split` (own content excluded in
  peer/channel + ASCII fold + `own_nick=nil` boundary + COUNTS in self-window),
  `window_counts` (channel own-msg excluded; #396 self-window counts unchanged).
- client: `selection.test.ts` (peer-window exclusion + ASCII fold + self-window
  carve-out — the client twin of the server unit tests), `subscribe.test.ts`
  (explicit peer sender).
- e2e: `issue576-own-msg-unread-badge.spec.ts` — send own lines, force the read
  cursor back below them (the cross-device regress), badge shows nothing; a peer
  reply → "1".

## Gates (local)
`scripts/check.sh` green (4766 tests / 0 failures, credo/dialyzer/sobelow/bats);
cic `bun run check` exit 0; cic vitest green; `--grep "#576"` e2e passed.
DESIGN_NOTES entry appended (2026-07-31). No wire change → no CLIENT_PROTOCOL bump.