### PR TITLE
test(#574): reap e2e visitors loud via shared reapVisitors, kill the swallow

### DIFF
--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -313,6 +313,46 @@ export async function adminDeleteVisitor(
   }
 }
 
+// #574 — reap minted visitors LOUD in test cleanup. The single de-swallowing
+// primitive every spec's teardown must go through instead of the old
+// `adminDeleteVisitor(...).catch(() => {})`.
+//
+// WHY it's shared, not inlined 27×: a `.catch(() => {})` around the delete
+// silently strands a LIVE visitor when the delete fails (e.g. an aborted spec
+// whose cleanup also hits the #506 `database is locked` 500). The stranded
+// session then poisons downstream specs that assert an EXACT live-session /
+// visitor count on the serial (`workers: 1`) stack — m9b-admin-sessions-actions
+// (`toHaveCount(4)` observes 6), #481 accretion, #211 — and the red surfaces
+// FAR from its cause, reading as an unrelated flake. This is CLAUDE.md's
+// "No silent-swallow at boundaries", inside test cleanup (#517 fixed the one
+// instance in issue299; #574 is the class).
+//
+// COLLECT-then-throw, not drop-`.catch`-per-call: when a finally reaps more
+// than one visitor, letting the first delete throw would SKIP the rest
+// (masking-by-skip — the #517 lesson), stranding the tail. So every id is
+// attempted, failures are collected, and an AggregateError is thrown iff any
+// failed. null/undefined ids are skipped, so callers pass `visitor?.id`
+// without an `if` guard. adminDeleteVisitor is idempotent (404 == success),
+// so on a green run where the spec already deleted the visitor this is a
+// no-op — it only throws when a delete ACTUALLY fails.
+export async function reapVisitors(
+  adminToken: string,
+  ...visitorIds: Array<string | null | undefined>
+): Promise<void> {
+  const errors: unknown[] = [];
+  for (const visitorId of visitorIds) {
+    if (!visitorId) continue;
+    try {
+      await adminDeleteVisitor(adminToken, visitorId);
+    } catch (err) {
+      errors.push(err);
+    }
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(errors, "reapVisitors: visitor cleanup failed (#574)");
+  }
+}
+
 // Poll GET /networks/:network_slug/channels/:channel/messages for a
 // row matching {sender, body}. Channel id in the URL is the channel
 // NAME (`#bofh`) — grappa's REST surface keys channels by slug-shape,

--- a/cicchetto/e2e/tests/admin-visitors-layout.spec.ts
+++ b/cicchetto/e2e/tests/admin-visitors-layout.spec.ts
@@ -30,7 +30,7 @@
 import { expect, test } from "../fixtures/test";
 import { openSettingsDrawer } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
-import { mintVisitor, adminDeleteVisitor } from "../fixtures/grappaApi";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 
 test("admin Visitors tab: per-network cell is separated + delete button stays in its row", async ({
   page,
@@ -105,6 +105,6 @@ test("admin Visitors tab: per-network cell is separated + delete button stays in
       expect(btnBox.x).toBeGreaterThan(rowBox.x + rowBox.width / 2);
     }
   } finally {
-    await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+    await reapVisitors(admin.token, visitor.id);
   }
 });

--- a/cicchetto/e2e/tests/issue126-detach-lifecycle.spec.ts
+++ b/cicchetto/e2e/tests/issue126-detach-lifecycle.spec.ts
@@ -29,7 +29,7 @@
 import { test, expect } from "../fixtures/test";
 import { openSettingsDrawer, loginAs } from "../fixtures/cicchettoPage";
 import {
-  adminDeleteVisitor,
+  reapVisitors,
   GRAPPA_BASE_URL,
   login,
   mintVisitor,
@@ -135,9 +135,9 @@ test.describe("issue #126 — detach lifecycle", () => {
       await expect(page.getByText(/^log out$/i)).toHaveCount(0);
     } finally {
       await ctx.close();
-      // Best-effort: tear down the throwaway visitor's row + session.
+      // Tear down the throwaway visitor's row + session (loud — see reapVisitors).
       const admin = (await import("../fixtures/seedData")).getSeededAdmin();
-      await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+      await reapVisitors(admin.token, visitor.id);
     }
   });
 

--- a/cicchetto/e2e/tests/issue135-visitor-home-landing.spec.ts
+++ b/cicchetto/e2e/tests/issue135-visitor-home-landing.spec.ts
@@ -19,7 +19,7 @@
 
 import { test, expect } from "../fixtures/test";
 import { expectShellReady } from "../fixtures/cicchettoPage";
-import { adminDeleteVisitor, GRAPPA_BASE_URL, mintVisitor } from "../fixtures/grappaApi";
+import { GRAPPA_BASE_URL, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 
 // Unique per run: avoids featured-list bleed across retries / parallel
@@ -125,6 +125,6 @@ test("issue #135 — visitor home shows welcome + featured + a directory link", 
   } finally {
     await ctx.close();
     await deleteFeaturedBestEffort(admin.token, networkId, featuredId);
-    await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+    await reapVisitors(admin.token, visitor.id);
   }
 });

--- a/cicchetto/e2e/tests/issue148-visitor-oper.spec.ts
+++ b/cicchetto/e2e/tests/issue148-visitor-oper.spec.ts
@@ -27,7 +27,7 @@
 
 import { expect, test } from "../fixtures/test";
 import { expectShellReady, composeSend, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
-import { adminDeleteVisitor, mintVisitor } from "../fixtures/grappaApi";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 
 // Verbatim trailing text bahamut sends for numeric 381 RPL_YOUREOPER —
@@ -99,6 +99,6 @@ test("issue #148 — visitor /oper ships OPER upstream and renders the 381 notic
     await expect(page.getByText(/visitor_not_allowed/i)).toHaveCount(0);
   } finally {
     await ctx.close();
-    await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+    await reapVisitors(admin.token, visitor.id);
   }
 });

--- a/cicchetto/e2e/tests/issue152-ident-realname.spec.ts
+++ b/cicchetto/e2e/tests/issue152-ident-realname.spec.ts
@@ -29,7 +29,7 @@ import { expectShellReady,
   selectChannel,
   waitForUserTopicReady,
 } from "../fixtures/cicchettoPage";
-import { adminDeleteVisitor } from "../fixtures/grappaApi";
+import { reapVisitors } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { getSeededAdmin } from "../fixtures/seedData";
 
@@ -159,6 +159,6 @@ test("issue #152 — login-Advanced ident + settings live-apply reach upstream",
   } finally {
     if (peer) await peer.disconnect("issue152 done").catch(() => {});
     await ctx.close();
-    if (visitorId) await adminDeleteVisitor(admin.token, visitorId).catch(() => {});
+    await reapVisitors(admin.token, visitorId);
   }
 });

--- a/cicchetto/e2e/tests/issue153-visitor-state-verbs.spec.ts
+++ b/cicchetto/e2e/tests/issue153-visitor-state-verbs.spec.ts
@@ -34,7 +34,7 @@ import { expectShellReady,
   selectChannel,
   waitForUserTopicReady,
 } from "../fixtures/cicchettoPage";
-import { adminDeleteVisitor, mintVisitor } from "../fixtures/grappaApi";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { getSeededAdmin } from "../fixtures/seedData";
 
@@ -141,6 +141,6 @@ test("issue #153 — visitor /quote and /mode reach upstream and take effect", a
   } finally {
     if (peer) await peer.disconnect("issue153 done").catch(() => {});
     await ctx.close();
-    await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+    await reapVisitors(admin.token, visitor.id);
   }
 });

--- a/cicchetto/e2e/tests/issue154-mode-reliability.spec.ts
+++ b/cicchetto/e2e/tests/issue154-mode-reliability.spec.ts
@@ -40,7 +40,7 @@ import { expectShellReady,
   selectChannel,
   waitForUserTopicReady,
 } from "../fixtures/cicchettoPage";
-import { adminDeleteVisitor, mintVisitor } from "../fixtures/grappaApi";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 
 // Boot cic straight into Shell as a freshly-minted visitor (no captcha/anon
@@ -117,7 +117,7 @@ test("issue #154(1) — a rejected ops verb surfaces an inline compose error (no
     await expect(ta).toHaveValue("/op bad!nick");
   } finally {
     await ctx.close();
-    await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+    await reapVisitors(admin.token, visitor.id);
   }
 });
 
@@ -148,6 +148,6 @@ test("issue #154(2) — an own-nick /umode renders a 'sets user mode' row in $se
     ).toBeVisible({ timeout: 15_000 });
   } finally {
     await ctx.close();
-    await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+    await reapVisitors(admin.token, visitor.id);
   }
 });

--- a/cicchetto/e2e/tests/issue155-native-stats-rehash.spec.ts
+++ b/cicchetto/e2e/tests/issue155-native-stats-rehash.spec.ts
@@ -38,7 +38,7 @@
 
 import { expect, test } from "../fixtures/test";
 import { expectShellReady, composeSend, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
-import { adminDeleteVisitor, mintVisitor } from "../fixtures/grappaApi";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 
 // Verbatim trailing text bahamut-azzurra sends (src/s_err.c):
@@ -114,6 +114,6 @@ test("issue #155 — native /stats and /rehash ship upstream and render reply nu
     await expect(page.getByText(/unknown command/i)).toHaveCount(0);
   } finally {
     await ctx.close();
-    await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+    await reapVisitors(admin.token, visitor.id);
   }
 });

--- a/cicchetto/e2e/tests/issue157-delete-account.spec.ts
+++ b/cicchetto/e2e/tests/issue157-delete-account.spec.ts
@@ -28,7 +28,7 @@
 
 import { test, expect } from "../fixtures/test";
 import { openSettingsDrawer, expectShellReady } from "../fixtures/cicchettoPage";
-import { GRAPPA_BASE_URL, adminDeleteVisitor, login, mintVisitor } from "../fixtures/grappaApi";
+import { GRAPPA_BASE_URL, login, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 
 const PASSWORD = "test-password-not-secret";
@@ -159,7 +159,7 @@ test.describe("issue #157 — delete account", () => {
     } finally {
       await ctx.close();
       const admin = getSeededAdmin();
-      await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+      await reapVisitors(admin.token, visitor.id);
     }
   });
 });

--- a/cicchetto/e2e/tests/issue171-per-ip-clone-cap.spec.ts
+++ b/cicchetto/e2e/tests/issue171-per-ip-clone-cap.spec.ts
@@ -27,7 +27,7 @@ import { expect, test } from "../fixtures/test";
 import { ADMIN_IDENTIFIER, ADMIN_PASSWORD } from "../fixtures/seedData";
 import {
   GRAPPA_BASE_URL,
-  adminDeleteVisitor,
+  reapVisitors,
   login,
   mintVisitor,
 } from "../fixtures/grappaApi";
@@ -88,13 +88,12 @@ test("#171 — 2nd nil-client visitor from the same source IP is rejected 503 to
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("too_many_sessions");
   } finally {
-    if (visitorAId !== null) {
-      await adminDeleteVisitor(admin.token, visitorAId).catch(() => {});
-    }
-    // Restore the seeded headroom so the serial runner's shared IP does
-    // not throttle later specs' concurrent visitor logins.
+    // Restore the seeded headroom FIRST (best-effort) so the serial runner's
+    // shared IP does not throttle later specs — THEN reap the visitor loud,
+    // ordered benign-before-loud so the throw can't skip it (see reapVisitors).
     await adminPatchCaps(admin.token, AZZURRA, {
       max_per_ip: AZZURRA_SEED_MAX_PER_IP,
     }).catch(() => {});
+    await reapVisitors(admin.token, visitorAId);
   }
 });

--- a/cicchetto/e2e/tests/issue184-stats-window-routing.spec.ts
+++ b/cicchetto/e2e/tests/issue184-stats-window-routing.spec.ts
@@ -34,7 +34,7 @@ import { expectShellReady,
   sidebarWindow,
 } from "../fixtures/cicchettoPage";
 import {
-  adminDeleteVisitor,
+  reapVisitors,
   GRAPPA_BASE_URL,
   mintVisitor,
 } from "../fixtures/grappaApi";
@@ -126,6 +126,6 @@ test("issue #184 — /stats reply renders in $server, never a query window named
     expect(rows).toHaveLength(0);
   } finally {
     await ctx.close();
-    await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+    await reapVisitors(admin.token, visitor.id);
   }
 });

--- a/cicchetto/e2e/tests/issue187-visitor-window-restore.spec.ts
+++ b/cicchetto/e2e/tests/issue187-visitor-window-restore.spec.ts
@@ -29,7 +29,7 @@ import { expectShellReady,
   sidebarWindow,
   waitForUserTopicReady,
 } from "../fixtures/cicchettoPage";
-import { adminDeleteVisitor, mintVisitor } from "../fixtures/grappaApi";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 
 // Boot cic straight into Shell as a freshly-minted visitor (no captcha/anon
@@ -109,6 +109,6 @@ test("issue #187 — a visitor's last-open channel is restored on refresh/reopen
     });
   } finally {
     await ctx.close();
-    await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+    await reapVisitors(admin.token, visitor.id);
   }
 });

--- a/cicchetto/e2e/tests/issue211-phase3-multinet-visitor.spec.ts
+++ b/cicchetto/e2e/tests/issue211-phase3-multinet-visitor.spec.ts
@@ -30,7 +30,7 @@ import { test, expect } from "../fixtures/test";
 import { expectShellReady, composeSend, selectChannel, waitForUserTopicReady } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import {
-  adminDeleteVisitor,
+  reapVisitors,
   GRAPPA_BASE_URL,
   mintVisitor,
   type MintedVisitor,
@@ -138,7 +138,7 @@ test("issue #211 phase 3 — fresh visitor lands JOINED with own nick + a live P
   } finally {
     if (peer) await peer.disconnect("e2e cleanup").catch(() => {});
     await ctx.close();
-    await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+    await reapVisitors(admin.token, visitor.id);
   }
 });
 
@@ -225,17 +225,26 @@ test("issue #211 phase 3 — admin visitor_enabled toggle flips a network live (
       visitorId = (await after.json())?.subject?.id ?? null;
     }
   } finally {
-    if (visitorId) await adminDeleteVisitor(admin.token, visitorId).catch(() => {});
-    // Disable again so the network has no visitor credential blocking the
-    // delete, then remove it (DELETE keys on the integer id).
-    await fetch(`${GRAPPA_BASE_URL}/admin/networks/${slug}`, {
-      method: "PATCH",
-      headers: { "content-type": "application/json", authorization: `Bearer ${admin.token}` },
-      body: JSON.stringify({ visitor_enabled: false }),
-    }).catch(() => {});
-    await fetch(`${GRAPPA_BASE_URL}/admin/networks/${networkId}`, {
-      method: "DELETE",
-      headers: { authorization: `Bearer ${admin.token}` },
-    }).catch(() => {});
+    // Reap the visitor loud (reapVisitors), but the network teardown below
+    // MUST still run even if the reap throws (a leaked test network poisons
+    // downstream) — and it depends on the visitor being gone first (a live
+    // visitor credential blocks the network DELETE), so it can't be reordered
+    // ahead. An inner finally guarantees teardown runs, then the reap throw
+    // propagates.
+    try {
+      await reapVisitors(admin.token, visitorId);
+    } finally {
+      // Disable again so the network has no visitor credential blocking the
+      // delete, then remove it (DELETE keys on the integer id).
+      await fetch(`${GRAPPA_BASE_URL}/admin/networks/${slug}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json", authorization: `Bearer ${admin.token}` },
+        body: JSON.stringify({ visitor_enabled: false }),
+      }).catch(() => {});
+      await fetch(`${GRAPPA_BASE_URL}/admin/networks/${networkId}`, {
+        method: "DELETE",
+        headers: { authorization: `Bearer ${admin.token}` },
+      }).catch(() => {});
+    }
   }
 });

--- a/cicchetto/e2e/tests/issue211-phase6-matrix.spec.ts
+++ b/cicchetto/e2e/tests/issue211-phase6-matrix.spec.ts
@@ -39,7 +39,7 @@ import { test, expect } from "../fixtures/test";
 import { expectShellReady, selectChannel, waitForUserTopicReady } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import {
-  adminDeleteVisitor,
+  reapVisitors,
   GRAPPA_BASE_URL,
   joinChannel,
   mintVisitor,
@@ -176,8 +176,10 @@ test("issue #211 phase 6 — fresh visitor AUTO-CONNECTS the visitor_autoconnect
   } finally {
     for (const peer of peers) await peer.disconnect("e2e cleanup").catch(() => {});
     if (ctx) await ctx.close();
-    if (visitor) await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+    // Disable autoconnect FIRST (best-effort) so the network never respawns —
+    // THEN reap the visitor loud, ordered benign-before-loud (see reapVisitors).
     await setAutoconnect(admin.token, "azzurra2", false).catch(() => {});
+    await reapVisitors(admin.token, visitor?.id);
   }
 });
 
@@ -227,7 +229,7 @@ test("issue #211 phase 6 — per-network park azzurra keeps azzurra2 live; recon
     expect(connRes.status).toBe(200);
     expect((await connRes.json()).connection_state).toBe("connected");
   } finally {
-    await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+    await reapVisitors(admin.token, visitor.id);
   }
 });
 
@@ -261,6 +263,6 @@ test("issue #211 phase 6 — visitor one-tap connects the AVAILABLE (non-autocon
     const rows = await waitForNetworks(visitor.token, 2);
     expect(rows.map((r) => r.slug)).toContain("azzurra3");
   } finally {
-    await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+    await reapVisitors(admin.token, visitor.id);
   }
 });

--- a/cicchetto/e2e/tests/issue211-phase7-multinet-reconnect.spec.ts
+++ b/cicchetto/e2e/tests/issue211-phase7-multinet-reconnect.spec.ts
@@ -44,7 +44,7 @@ import { test, expect } from "../fixtures/test";
 import { expectShellReady, selectChannel, waitForUserTopicReady } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import {
-  adminDeleteVisitor,
+  reapVisitors,
   assertMessagePersisted,
   GRAPPA_BASE_URL,
   mintVisitor,
@@ -451,7 +451,7 @@ test("issue #211 phase 7 — one visitor on TWO networks survives a real cic WS 
   } finally {
     for (const peer of peers) await peer.disconnect("e2e cleanup").catch(() => {});
     if (ctx) await ctx.close();
-    if (visitor) await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+    await reapVisitors(admin.token, visitor?.id);
   }
 });
 

--- a/cicchetto/e2e/tests/issue257-vhost-subject-autocomplete.spec.ts
+++ b/cicchetto/e2e/tests/issue257-vhost-subject-autocomplete.spec.ts
@@ -17,7 +17,7 @@
 
 import { expect, test } from "../fixtures/test";
 import { openSettingsDrawer, expectShellReady } from "../fixtures/cicchettoPage";
-import { adminDeleteVisitor, GRAPPA_BASE_URL, mintVisitor } from "../fixtures/grappaApi";
+import { GRAPPA_BASE_URL, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 
 async function adminLogin(
@@ -127,6 +127,6 @@ test("#257 — picking a visitor from the grant autocomplete stores its stable i
     await expect(grantsTable).not.toContainText(visitor.nick);
   } finally {
     if (vhostId !== null) await deleteVhostBestEffort(admin.token, vhostId);
-    if (visitorId !== null) await adminDeleteVisitor(admin.token, visitorId);
+    await reapVisitors(admin.token, visitorId);
   }
 });

--- a/cicchetto/e2e/tests/issue260-sticky-network-tab.spec.ts
+++ b/cicchetto/e2e/tests/issue260-sticky-network-tab.spec.ts
@@ -30,7 +30,7 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "../fixtures/test";
 import { loginAs, waitForUserTopicReady } from "../fixtures/cicchettoPage";
 import {
-  adminDeleteVisitor,
+  reapVisitors,
   GRAPPA_BASE_URL,
   type MintedVisitor,
   mintVisitor,
@@ -313,6 +313,6 @@ test("@webkit #260 — the sticky header pins under scroll and the next network 
     expect(outgoing).toBeDefined();
     if (outgoing) expect(outgoing.right).toBeLessThanOrEqual(atEnd.barLeft + EDGE_EPS);
   } finally {
-    if (visitor) await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+    await reapVisitors(admin.token, visitor?.id);
   }
 });

--- a/cicchetto/e2e/tests/issue269-visitor-reconnect-toggle.spec.ts
+++ b/cicchetto/e2e/tests/issue269-visitor-reconnect-toggle.spec.ts
@@ -25,7 +25,7 @@
 import { expect, test } from "../fixtures/test";
 import { openSettingsDrawer } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
-import { mintVisitor, adminDeleteVisitor } from "../fixtures/grappaApi";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 
 async function adminOpenVisitorsTab(
   page: import("@playwright/test").Page,
@@ -98,6 +98,6 @@ test("#269 admin Visitors tab Disconnect ⇄ Reconnect toggles a per-network vis
     // Idempotent cleanup — Operator.delete_visitor stops every live
     // session + deletes the row, so a downed OR live victim is fully
     // reaped and never poisons a downstream spec.
-    await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+    await reapVisitors(admin.token, visitor.id);
   }
 });

--- a/cicchetto/e2e/tests/issue282-vhost-reconnect-button.spec.ts
+++ b/cicchetto/e2e/tests/issue282-vhost-reconnect-button.spec.ts
@@ -31,7 +31,7 @@
 import type { Browser, Page } from "@playwright/test";
 import { expect, test } from "../fixtures/test";
 import { openSettingsDrawer, expectShellReady, waitForUserTopicReady } from "../fixtures/cicchettoPage";
-import { adminDeleteVisitor, GRAPPA_BASE_URL, mintVisitor } from "../fixtures/grappaApi";
+import { GRAPPA_BASE_URL, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 
 const ANCHOR = "azzurra";
@@ -175,7 +175,7 @@ test.describe("issue #282 — explicit vhost Reconnect button", () => {
       await expect(page.getByTestId("vhost-reconnect")).toHaveText(/reconnect to apply/i);
     } finally {
       if (ctx) await ctx.close();
-      if (visitor) await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+      await reapVisitors(admin.token, visitor?.id);
     }
   });
 });

--- a/cicchetto/e2e/tests/issue333-themes-personal-gallery.spec.ts
+++ b/cicchetto/e2e/tests/issue333-themes-personal-gallery.spec.ts
@@ -18,7 +18,7 @@
 // before/after the fix targets. Desktop chromium: the sections + scroll are
 // layout-agnostic and the editor is a JS flow.
 
-import { adminDeleteVisitor, mintVisitor } from "../fixtures/grappaApi";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { openSettingsDrawer } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
@@ -77,7 +77,7 @@ test.describe("#333 — themes personal/gallery + copy UX + delete confirm", () 
       // The personal section holds at least one card (the copy).
       await expect(personal.locator("[data-testid^='theme-card-']")).not.toHaveCount(0);
     } finally {
-      await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+      await reapVisitors(admin.token, visitor.id);
     }
   });
 
@@ -120,7 +120,7 @@ test.describe("#333 — themes personal/gallery + copy UX + delete confirm", () 
       // The owned copy is gone → personal section empties + hides again.
       await expect(page.getByTestId("theme-section-personal")).toHaveCount(0, { timeout: 5_000 });
     } finally {
-      await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+      await reapVisitors(admin.token, visitor.id);
     }
   });
 
@@ -160,7 +160,7 @@ test.describe("#333 — themes personal/gallery + copy UX + delete confirm", () 
       if (errBox === null || saveBox === null) throw new Error("no box");
       expect(errBox.y).toBeLessThan(saveBox.y);
     } finally {
-      await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+      await reapVisitors(admin.token, visitor.id);
     }
   });
 });

--- a/cicchetto/e2e/tests/issue335-identity-card-share.spec.ts
+++ b/cicchetto/e2e/tests/issue335-identity-card-share.spec.ts
@@ -25,7 +25,7 @@
 // navigator.share is a JS API, not a touch gesture.
 
 import { openSettingsDrawer, openSettingsSection } from "../fixtures/cicchettoPage";
-import { adminDeleteVisitor, mintVisitor } from "../fixtures/grappaApi";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
@@ -79,7 +79,7 @@ test.describe("#335 — visitor identity card + share section + native share", (
         generalPage.locator("[data-testid='settings-section-identity'] #settings-nick"),
       ).toBeVisible();
     } finally {
-      await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+      await reapVisitors(admin.token, visitor.id);
     }
   });
 
@@ -115,7 +115,7 @@ test.describe("#335 — visitor identity card + share section + native share", (
       expect(payload?.url).toBe(shareUrl);
       expect(payload?.url).toMatch(/\/share\//);
     } finally {
-      await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+      await reapVisitors(admin.token, visitor.id);
     }
   });
 
@@ -139,7 +139,7 @@ test.describe("#335 — visitor identity card + share section + native share", (
       await expect(page.getByTestId("share-native")).toHaveCount(0);
       await expect(page.getByTestId("share-copy")).toBeVisible();
     } finally {
-      await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+      await reapVisitors(admin.token, visitor.id);
     }
   });
 });

--- a/cicchetto/e2e/tests/issue363-incognito.spec.ts
+++ b/cicchetto/e2e/tests/issue363-incognito.spec.ts
@@ -11,7 +11,7 @@
 // Copy is deliberately NOT asserted: the checkbox keys off its data-testid,
 // so vjt's final (pending) wording swap can never break this spec.
 
-import { adminDeleteVisitor, mintVisitor } from "../fixtures/grappaApi";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { openSettingsDrawer } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
@@ -77,7 +77,8 @@ test("#363 incognito session disables share-session; a normal visitor keeps it",
   } finally {
     await incog.ctx.close();
     await plain.ctx.close();
-    await adminDeleteVisitor(admin.token, ghost.id).catch(() => {});
-    await adminDeleteVisitor(admin.token, normal.id).catch(() => {});
+    // Reap BOTH visitors — the variadic collects so a failed first delete
+    // can't skip the second (see reapVisitors).
+    await reapVisitors(admin.token, ghost.id, normal.id);
   }
 });

--- a/cicchetto/e2e/tests/issue375-rehash-option.spec.ts
+++ b/cicchetto/e2e/tests/issue375-rehash-option.spec.ts
@@ -30,7 +30,7 @@
 
 import { expect, test } from "../fixtures/test";
 import { expectShellReady, composeSend, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
-import { adminDeleteVisitor, mintVisitor } from "../fixtures/grappaApi";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 
 // 481 ERR_NOPRIVILEGES trailing text bahamut-azzurra sends (src/s_err.c):
@@ -122,6 +122,6 @@ test("issue #375 — /rehash <option> forwards the option on the raw wire, bare 
     await expect(page.getByText(/unknown command/i)).toHaveCount(0);
   } finally {
     await ctx.close();
-    await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+    await reapVisitors(admin.token, visitor.id);
   }
 });

--- a/cicchetto/e2e/tests/issue392-home-restyle-share.spec.ts
+++ b/cicchetto/e2e/tests/issue392-home-restyle-share.spec.ts
@@ -18,7 +18,7 @@
 // Desktop chromium (untagged): the drawer + modal are layout-agnostic and
 // the QR is inline SVG, not a device camera.
 
-import { adminDeleteVisitor, mintVisitor } from "../fixtures/grappaApi";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { openSettingsDrawer } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
@@ -57,7 +57,7 @@ test.describe("#392 — home restyle + session-share modal", () => {
       await expect(url).not.toHaveValue("", { timeout: 10_000 });
       expect(await url.inputValue()).toMatch(/\/share\//);
     } finally {
-      await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+      await reapVisitors(admin.token, visitor.id);
     }
   });
 
@@ -77,7 +77,7 @@ test.describe("#392 — home restyle + session-share modal", () => {
       await expect(page.getByTestId("share-modal")).toBeVisible();
       await expect(page.getByTestId("share-qr").locator("svg")).toBeVisible({ timeout: 10_000 });
     } finally {
-      await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+      await reapVisitors(admin.token, visitor.id);
     }
   });
 
@@ -97,7 +97,7 @@ test.describe("#392 — home restyle + session-share modal", () => {
       // #392 — the Browse CTA carries the prominent accent-outlined class.
       await expect(browse).toHaveClass(/home-pane-network-browse/);
     } finally {
-      await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+      await reapVisitors(admin.token, visitor.id);
     }
   });
 });

--- a/cicchetto/e2e/tests/issue477-quit-persistence.spec.ts
+++ b/cicchetto/e2e/tests/issue477-quit-persistence.spec.ts
@@ -43,7 +43,7 @@
 // symmetrically for its ephemeral case).
 
 import { openSettingsDrawer, loginAs } from "../fixtures/cicchettoPage";
-import { adminDeleteVisitor, mintVisitor } from "../fixtures/grappaApi";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin, getSeededVjt } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 import { type Browser, type Page } from "@playwright/test";
@@ -88,7 +88,7 @@ async function bootVisitor(
     page,
     teardown: async () => {
       await ctx.close();
-      await adminDeleteVisitor(getSeededAdmin().token, visitor.id).catch(() => {});
+      await reapVisitors(getSeededAdmin().token, visitor.id);
     },
   };
 }

--- a/cicchetto/e2e/tests/issue496-home-restyle.spec.ts
+++ b/cicchetto/e2e/tests/issue496-home-restyle.spec.ts
@@ -24,7 +24,7 @@
 
 import type { Page } from "@playwright/test";
 import { loginAs } from "../fixtures/cicchettoPage";
-import { adminDeleteVisitor, type MintedVisitor, mintVisitor } from "../fixtures/grappaApi";
+import { type MintedVisitor, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin, getSeededVjt } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
@@ -90,7 +90,7 @@ const SUBJECTS: SubjectCase[] = [
       await page.goto("/");
       await gotoHome(page);
       return async () => {
-        await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+        await reapVisitors(admin.token, visitor.id);
       };
     },
   },
@@ -108,7 +108,7 @@ const SUBJECTS: SubjectCase[] = [
       await page.goto("/");
       await gotoHome(page);
       return async () => {
-        await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+        await reapVisitors(admin.token, visitor.id);
       };
     },
   },

--- a/cicchetto/e2e/tests/issue557-kill-slash-wiring.spec.ts
+++ b/cicchetto/e2e/tests/issue557-kill-slash-wiring.spec.ts
@@ -31,7 +31,7 @@ import {
   scrollbackLine,
   selectChannel,
 } from "../fixtures/cicchettoPage";
-import { adminDeleteVisitor, mintVisitor } from "../fixtures/grappaApi";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 
 // A non-oper KILL reply. bahamut's m_kill rejects a non-oper (481
@@ -128,6 +128,6 @@ test("issue #557 — /kill <nick> <reason> ships KILL nick :reason on the raw wi
     await expect(page.getByText(/unknown command/i)).toHaveCount(0);
   } finally {
     await ctx.close();
-    await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+    await reapVisitors(admin.token, visitor.id);
   }
 });

--- a/cicchetto/e2e/tests/m8-admin-visitors-delete.spec.ts
+++ b/cicchetto/e2e/tests/m8-admin-visitors-delete.spec.ts
@@ -23,7 +23,7 @@
 import { expect, test } from "../fixtures/test";
 import { openSettingsDrawer } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
-import { mintVisitor, adminDeleteVisitor } from "../fixtures/grappaApi";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 
 test("M-8 admin Visitors tab lists + deletes a minted visitor (inline confirm two-step)", async ({
   page,
@@ -74,6 +74,6 @@ test("M-8 admin Visitors tab lists + deletes a minted visitor (inline confirm tw
   } finally {
     // Idempotent — 404 if test already deleted it; safety net for
     // mid-arrange failures (so we don't leak a visitor row across runs).
-    await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+    await reapVisitors(admin.token, visitor.id);
   }
 });

--- a/cicchetto/e2e/tests/visitor-session-sharing.spec.ts
+++ b/cicchetto/e2e/tests/visitor-session-sharing.spec.ts
@@ -20,7 +20,7 @@
 
 import { expect, test } from "../fixtures/test";
 import { openSettingsDrawer, expectShellReady } from "../fixtures/cicchettoPage";
-import { adminDeleteVisitor, mintVisitor } from "../fixtures/grappaApi";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 
 test("visitor session-sharing — mint on device A, consume on device B, both connected", async ({
@@ -146,6 +146,6 @@ test("visitor session-sharing — mint on device A, consume on device B, both co
   } finally {
     await ctxA.close();
     await ctxB.close();
-    await adminDeleteVisitor(admin.token, visitor.id).catch(() => {});
+    await reapVisitors(admin.token, visitor.id);
   }
 });


### PR DESCRIPTION
Refs #574.

## The bug (a CLASS)
28 e2e spec files cleaned up their minted visitor with `adminDeleteVisitor(...).catch(() => {})`. The `.catch(() => {})` silently swallows a failed delete: when a spec aborts mid-way (e.g. a transient #506 `database is locked` → 500) the cleanup delete can also fail, and the swallow discards it — leaving the minted visitor **LIVE**. That stranded visitor poisons downstream specs that assert an EXACT live-session/visitor count on the serial (`workers: 1`) stack (`m9b-admin-sessions-actions` `toHaveCount(4)` observes 6; #481 accretion; #211). The red surfaces far from its cause and reads as an unrelated flake — CLAUDE.md's **"No silent-swallow at boundaries"**, inside test cleanup. #517 fixed the one instance in `issue299`; this is the class.

## Fix = ONE shared primitive, not 28 patches
`reapVisitors(adminToken, ...visitorIds)` in `cicchetto/e2e/fixtures/grappaApi.ts`:
- deletes every id, **COLLECTS** failures (no bail on first → avoids the masking-by-skip trap #517 flagged), throws `AggregateError` iff any failed;
- skips null/undefined so callers pass `visitor?.id` without an `if` guard; multiple visitors via the variadic (`issue363` reaps two);
- `adminDeleteVisitor` is idempotent (404 == success) → **no-op on green runs**, only throws when a delete ACTUALLY fails (behaviour-preserving).

Every spec cleanup that reaps a visitor now routes through this ONE door (`issue257` was already loud — folded in for total consistency). Only `issue299` still calls `adminDeleteVisitor` directly, mid-test, for its reap-attribution assertions.

## Masking-by-skip handled
- `issue171` (headroom restore) / `issue211-phase6` (autoconnect reset): benign sibling reordered **before** the loud reap so a throw can't skip it.
- `issue211-phase3`: network teardown must run AFTER the visitor delete (a live visitor credential blocks the network DELETE) yet must not be skipped by a throwing reap → wrapped in an inner `finally`.
- Benign best-effort swallows (`peer.disconnect` / `ctx.close` / `partChannel` / `deleteFeaturedBestEffort` / `setAutoconnect` / network PATCH+DELETE) strand no shared server state and are left as-is.

## Gates
- `scripts/bun.sh run check` → exit 0 (32 warn / 2 info = pre-existing CSS-specificity).
- `tsc -p e2e/tsconfig.json`: zero NEW errors vs baseline (e2e is outside biome; Playwright transpiles specs with esbuild without type-checking — the 21 baseline errors are pre-existing and untouched by this diff).
- Paren-safe swallow scan across the whole e2e suite (post-rebase, incl. new #576/#580 specs): **0** remaining.

Behaviour-preserving on green; the full integration suite is the ship gate (owned by the maintainer).