### PR TITLE
test(#585): barrier the boot reconcile before Mox expects

### DIFF
--- a/test/grappa/net/source_alias_manager_test.exs
+++ b/test/grappa/net/source_alias_manager_test.exs
@@ -27,8 +27,20 @@ defmodule Grappa.Net.SourceAliasManagerTest do
     stub(Grappa.Net.SourceAliasMock, :arm_check, fn @prefix -> :ok end)
     stub(Grappa.Net.SourceAliasMock, :list_aliases, fn @prefix -> {:ok, []} end)
 
-    start_supervised!({Manager, adapter: Grappa.Net.SourceAliasMock, prefix: @prefix})
+    pid = start_supervised!({Manager, adapter: Grappa.Net.SourceAliasMock, prefix: @prefix})
+    drain_boot_reconcile(pid)
+    pid
   end
+
+  # Barrier between "manager started" and "expectations declared". `init/1`
+  # returns `{:continue, :reconcile}`, so `handle_continue(:reconcile, …)` — and
+  # its `adapter.list_aliases/1` boot call — runs ASYNC after `start_supervised!`
+  # returns. A synchronous `:sys.get_state/1` is answered only from the receive
+  # loop, which the gen_server reaches strictly AFTER `handle_continue` finishes,
+  # so returning here proves the boot reconcile is done. Without it the boot
+  # `list_aliases` can land after a test's `expect/3` and consume it, making the
+  # explicit `Manager.reconcile()` a second (unexpected) call (#585).
+  defp drain_boot_reconcile(pid), do: :sys.get_state(pid)
 
   describe "acquire/release ref-counting" do
     test "binds once on 0→1, stays bound across a second acquire, unbinds on last release" do
@@ -84,9 +96,12 @@ defmodule Grappa.Net.SourceAliasManagerTest do
       stub(Grappa.Net.SourceAliasMock, :list_aliases, fn @prefix -> {:ok, []} end)
 
       # A live session holds @addr; the refcount table is empty (restart).
-      start_supervised!(
-        {Manager, adapter: Grappa.Net.SourceAliasMock, prefix: @prefix, held_source_fn: fn -> [@addr] end}
-      )
+      pid =
+        start_supervised!(
+          {Manager, adapter: Grappa.Net.SourceAliasMock, prefix: @prefix, held_source_fn: fn -> [@addr] end}
+        )
+
+      drain_boot_reconcile(pid)
 
       expect(Grappa.Net.SourceAliasMock, :list_aliases, fn @prefix -> {:ok, [@addr, @addr2]} end)
       # ONLY the orphan @addr2 is released; the live-held @addr survives even
@@ -101,9 +116,12 @@ defmodule Grappa.Net.SourceAliasManagerTest do
       stub(Grappa.Net.SourceAliasMock, :list_aliases, fn @prefix -> {:ok, []} end)
 
       # @addr2 is live-held (from the fn); @addr is ref-counted (acquired here).
-      start_supervised!(
-        {Manager, adapter: Grappa.Net.SourceAliasMock, prefix: @prefix, held_source_fn: fn -> [@addr2] end}
-      )
+      pid =
+        start_supervised!(
+          {Manager, adapter: Grappa.Net.SourceAliasMock, prefix: @prefix, held_source_fn: fn -> [@addr2] end}
+        )
+
+      drain_boot_reconcile(pid)
 
       expect(Grappa.Net.SourceAliasMock, :ensure_source, fn @addr, @prefix -> :ok end)
       assert :ok = Manager.acquire(@addr)
@@ -131,7 +149,8 @@ defmodule Grappa.Net.SourceAliasManagerTest do
         {:error, :wrapper_unavailable}
       end)
 
-      start_supervised!({Manager, adapter: Grappa.Net.SourceAliasMock, prefix: @prefix})
+      pid = start_supervised!({Manager, adapter: Grappa.Net.SourceAliasMock, prefix: @prefix})
+      drain_boot_reconcile(pid)
 
       assert Manager.armed?() == false
       assert Manager.disarm_reason() == :wrapper_unavailable
@@ -140,7 +159,8 @@ defmodule Grappa.Net.SourceAliasManagerTest do
     test "armed? false with :no_static_prefix when no prefix is configured" do
       stub(Grappa.Net.SourceAliasMock, :list_aliases, fn _ -> {:ok, []} end)
       # arm_check is NEVER invoked with a nil prefix — the manager short-circuits.
-      start_supervised!({Manager, adapter: Grappa.Net.SourceAliasMock, prefix: nil})
+      pid = start_supervised!({Manager, adapter: Grappa.Net.SourceAliasMock, prefix: nil})
+      drain_boot_reconcile(pid)
 
       assert Manager.armed?() == false
       assert Manager.disarm_reason() == :no_static_prefix


### PR DESCRIPTION
Refs #585

## Problem
`SourceAliasManagerTest` raced its own boot reconcile. `Manager.init/1`
returns `{:ok, state, {:continue, :reconcile}}`, so
`handle_continue(:reconcile, …)` — and its `adapter.list_aliases/1` boot
call — runs **async** after `start_supervised!` returns. Under CI load the
boot `list_aliases` could land **after** a test's `expect/3` and consume
it, turning the explicit `Manager.reconcile()` into a second call against a
`once` expectation → `Mox.UnexpectedCallError`. Green on `main` minutes
earlier, red on an unrelated (cic-only) PR — a load-sensitive **setup**
race, not a flaky assertion. Same family as #519 / #531 / #552.

## Fix (at the setup, not the assertion)
A private `drain_boot_reconcile/1` helper does one synchronous
`:sys.get_state/1`. A gen_server answers that system message only from its
receive loop, which it reaches strictly **after** `handle_continue`
finishes — so returning proves the boot reconcile is done before any
expectation exists. Applied after **every** `start_supervised!` in the file
(5 sites, not just the one that fell today), so no test in the class can
race and no future copy inherits the gap.

- **No production code touched. No assertion touched.** Diff is +29/-9 in
  the test file only.
- `arm_check` runs synchronously in `init/1`, so its pre-start `expect`
  never raced; the barrier only settles the async `list_aliases` reconcile.

## Evidence
- Scoped stress: `test.sh source_alias_manager_test.exs --repeat-until-failure 50`
  → 50/50, 8 tests each, 0 failures.
- Full gate `scripts/check.sh` → exit 0; **4777 tests, 0 failures** (8
  doctests, 50 properties) + bats 171 ok.
- Sync code review: clean, no findings (barrier soundness confirmed from
  the production `init` continue + `handle_continue`; all 5 sites covered;
  sibling `server_test.exs` confirmed correctly out of scope).

Merge ≠ ship: no `Closes` keyword; the issue is closed post-deploy.