### PR TITLE
fix(#578): /links radial map — angle-anchored labels, decluttered, fitted viewBox

### DIFF
--- a/cicchetto/e2e/tests/issue578-links-map-render.spec.ts
+++ b/cicchetto/e2e/tests/issue578-links-map-render.spec.ts
@@ -1,0 +1,118 @@
+// #578 — the /links map render fix (follow-up to #238). The geometry is
+// correct; everything AROUND it was wrong: on a small mesh the labels overlapped
+// and the viewBox was sized for a full disc the nodes never filled (a few dots
+// on a mostly-black square). The unit tests (linksLayout.test.ts) carry the
+// precise fitted-box + angle-anchor + declutter teeth on synthetic dense/chain
+// topologies; jsdom is blind to real layout, so THIS e2e asserts the VISIBLE
+// outcomes on the live azzurra testnet mesh:
+//
+//   1. no two RENDERED labels overlap (point 1 — the angle-derived anchor +
+//      greedy declutter);
+//   2. every rendered label sits fully INSIDE the svg (point 2 — the fitted
+//      viewBox now includes each label box; the old full-disc clipped them);
+//   3. the colour-ramp legend + the "you are here" root halo are painted
+//      (polish 3+4).
+//
+// The Map BUTTON stays hidden by product decision — the ONLY entry point is the
+// `/links` command, so the whole spec drives that path (never a button).
+
+import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// A screen-space rectangle in the test (Node) context — Playwright's
+// boundingBox() returns {x,y,width,height}; DOMRect is a browser global absent
+// in Node, so we keep a plain edge-box here.
+type Box = { left: number; top: number; right: number; bottom: number };
+
+// Two boxes overlap iff they intersect on BOTH axes (a shared edge/point is not
+// an overlap). A small epsilon tolerates sub-pixel touching.
+const boxesOverlap = (a: Box, b: Box): boolean => {
+  const EPS = 0.5;
+  return (
+    a.left < b.right - EPS && b.left < a.right - EPS && a.top < b.bottom - EPS && b.top < a.bottom - EPS
+  );
+};
+
+test("#578 — /links map: no overlapping labels, nothing clipped, legend + you-marker", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  // Enter the map ONLY via the /links command (the Map button is hidden).
+  await composeSend(page, "/links");
+
+  const modal = page.getByTestId("links-modal");
+  await expect(modal).toBeVisible({ timeout: 8_000 });
+  const svg = page.getByTestId("links-modal-svg");
+  await expect(svg).toBeVisible();
+  await expect(page.getByTestId("links-modal-empty")).toHaveCount(0);
+
+  // A real linked mesh (root + at least its hub).
+  const nodes = page.getByTestId("links-modal-node");
+  expect(await nodes.count()).toBeGreaterThanOrEqual(2);
+
+  // Point 4 — the root wears a single "you are here" halo ring.
+  await expect(page.locator(".links-modal-node-root")).toHaveCount(1);
+  await expect(page.locator(".links-modal-you-ring")).toHaveCount(1);
+
+  // Point 3 — the colour-ramp key is painted while a topology is drawn.
+  const legend = page.getByTestId("links-modal-legend");
+  await expect(legend).toBeVisible();
+  await expect(legend).toContainText("hops from your server");
+  await expect(legend).toContainText("you are here");
+
+  // The rendered label set (each is a <text.links-modal-label>). At least the
+  // root label is always drawn; a real mesh draws several.
+  const labels = page.locator(".links-modal-label");
+  const labelCount = await labels.count();
+  expect(labelCount).toBeGreaterThanOrEqual(1);
+
+  const labelRects: Box[] = [];
+  for (let i = 0; i < labelCount; i++) {
+    const box = await labels.nth(i).boundingBox();
+    if (box === null) continue;
+    labelRects.push({
+      left: box.x,
+      top: box.y,
+      right: box.x + box.width,
+      bottom: box.y + box.height,
+    });
+  }
+
+  // Point 1 — NO two rendered labels overlap (the #578 report showed two piled
+  // on the same ray). This is the visible-outcome jsdom cannot see.
+  for (let i = 0; i < labelRects.length; i++) {
+    for (let j = i + 1; j < labelRects.length; j++) {
+      const a = labelRects[i];
+      const b = labelRects[j];
+      if (a === undefined || b === undefined) continue;
+      expect(
+        boxesOverlap(a, b),
+        `labels ${i} and ${j} overlap — the declutter/anchor fix regressed`,
+      ).toBe(false);
+    }
+  }
+
+  // Point 2 — the fitted viewBox includes each label box, so no label is clipped
+  // by the svg edges (the old full-disc glyph-only bound cut outer labels off).
+  const svgBox = await svg.boundingBox();
+  expect(svgBox).not.toBeNull();
+  if (svgBox !== null) {
+    const EPS = 1;
+    for (const r of labelRects) {
+      expect(r.left).toBeGreaterThanOrEqual(svgBox.x - EPS);
+      expect(r.top).toBeGreaterThanOrEqual(svgBox.y - EPS);
+      expect(r.right).toBeLessThanOrEqual(svgBox.x + svgBox.width + EPS);
+      expect(r.bottom).toBeLessThanOrEqual(svgBox.y + svgBox.height + EPS);
+    }
+  }
+
+  // Dismiss via the × control.
+  await page.getByLabel("close links").click();
+  await expect(modal).toBeHidden();
+});

--- a/cicchetto/src/LinksModal.tsx
+++ b/cicchetto/src/LinksModal.tsx
@@ -366,7 +366,13 @@ const LinksModal: Component = () => {
                             // true), with the hovered/selected node forced on
                             // top. The pure layout guarantees no two BASELINE
                             // labels overlap; a transient active label is the
-                            // one the user asked for, so it always shows.
+                            // one the user asked for, so it always shows. Only
+                            // baseline-visible labels feed the fitted extent, so
+                            // hovering a DECLUTTERED edge node can push its label
+                            // a few units past the box edge (clipped on the fill
+                            // axis); it's transient and a pan recovers it —
+                            // reserving extent for every possible hover would
+                            // undo the fit.
                             const labelled = (): boolean => node.labelVisible || isActive();
                             return (
                               // biome-ignore lint/a11y/noStaticElementInteractions: SVG node glyph is a pointer-first inspect target (tap/hover), not a control; keyboard nav is a documented INC-3 follow-up
@@ -437,7 +443,16 @@ const LinksModal: Component = () => {
                   <div class="links-modal-legend" data-testid="links-modal-legend">
                     <span class="links-modal-legend-you">◎ you are here</span>
                     <span class="links-modal-legend-ramp">
-                      <span class="links-modal-legend-swatch" aria-hidden="true" />
+                      {/* Gradient stops come from the SAME depthColor ramp the
+                          nodes use (root→leaf), so a ramp tuning stays one
+                          source — no hardcoded hsl() duplicated in the CSS. */}
+                      <span
+                        class="links-modal-legend-swatch"
+                        aria-hidden="true"
+                        style={{
+                          background: `linear-gradient(90deg, ${depthColor(0, 1)}, ${depthColor(1, 1)})`,
+                        }}
+                      />
                       colour = hops from your server
                     </span>
                   </div>

--- a/cicchetto/src/LinksModal.tsx
+++ b/cicchetto/src/LinksModal.tsx
@@ -12,6 +12,7 @@ import {
   clampPan,
   clientToViewBox,
   DEFAULT_LAYOUT_OPTS,
+  glyphRadius,
   type LayoutNode,
   radialLayout,
   viewBoxFit,
@@ -45,31 +46,16 @@ import { MircBody } from "./MircText";
 const MIN_SCALE = 0.25;
 const MAX_SCALE = 6;
 
-// #238 fix — node glyph radii (viewBox units), bumped from 11/7 so the dots read
-// against the shortened edges (ringGap cut in lib/linksLayout). LABEL_GAP is the
-// clearance between a glyph edge and its label so text never sits on the dot.
-const ROOT_RADIUS = 14;
-const NODE_RADIUS = 10;
-const LABEL_GAP = 4;
-// Above this node count, per-node labels are shown only for the root + the
-// hovered/selected node (avoids an unreadable label pile-up on large nets like
-// Libera). Pan+zoom + tap-to-inspect cover the rest.
-const LABEL_ALL_THRESHOLD = 22;
+// #578 — radial gap between the root glyph and its "you are here" halo ring.
+const LABEL_HALO = 5;
 
 // Depth → hue ramp (teal root → violet leaves). Display-only; the layout is
 // pure geometry. cic owns all colour/label strings (no server display text).
+// The footer legend spells this out — the ramp keys "hops from your server".
 const depthColor = (depth: number, maxDepth: number): string => {
   const t = maxDepth === 0 ? 0 : depth / maxDepth;
   const hue = 190 + t * 160; // 190 (teal) → 350 (magenta)
   return `hsl(${hue} 68% 58%)`;
-};
-
-// Short label: the leftmost DNS label of the server name (irc.azzurra.org →
-// "irc"), which reads better in the dense tree. The full name + description
-// live in the detail footer on select/hover.
-const shortLabel = (server: string): string => {
-  const dot = server.indexOf(".");
-  return dot === -1 ? server : server.slice(0, dot);
 };
 
 const LinksModal: Component = () => {
@@ -229,7 +215,6 @@ const LinksModal: Component = () => {
         // `entries.length`, so sourcing the heading / aria-label / label
         // threshold from the layout keeps the "N servers" count honest.
         const nodeCount = (): number => layout().nodes.length;
-        const showAllLabels = (): boolean => nodeCount() <= LABEL_ALL_THRESHOLD;
         const detail = (): LayoutNode | null => {
           const sel = selected();
           if (sel !== null) return sel;
@@ -376,8 +361,13 @@ const LinksModal: Component = () => {
                           {(node) => {
                             const isActive = (): boolean =>
                               selected()?.server === node.server || hovered() === node.server;
-                            const labelled = (): boolean =>
-                              node.isRoot || showAllLabels() || isActive();
+                            // #578 — label visibility is the layout's greedy
+                            // declutter verdict (`labelVisible`, root always
+                            // true), with the hovered/selected node forced on
+                            // top. The pure layout guarantees no two BASELINE
+                            // labels overlap; a transient active label is the
+                            // one the user asked for, so it always shows.
+                            const labelled = (): boolean => node.labelVisible || isActive();
                             return (
                               // biome-ignore lint/a11y/noStaticElementInteractions: SVG node glyph is a pointer-first inspect target (tap/hover), not a control; keyboard nav is a documented INC-3 follow-up
                               <g
@@ -401,19 +391,31 @@ const LinksModal: Component = () => {
                                 <title>
                                   {node.server}
                                   {node.hopcount !== null ? ` (${node.hopcount} hops)` : ""}
+                                  {node.isRoot ? " — you are here" : ""}
                                 </title>
+                                {/* #578 — a "you are here" halo ring around the
+                                    root so the eye lands there first (the ramp's
+                                    teal root is only legible once you know the
+                                    ramp; the ring needs no key). */}
+                                <Show when={node.isRoot}>
+                                  <circle
+                                    class="links-modal-you-ring"
+                                    r={glyphRadius(node, DEFAULT_LAYOUT_OPTS) + LABEL_HALO}
+                                  />
+                                </Show>
                                 <circle
                                   class="links-modal-dot"
-                                  r={node.isRoot ? ROOT_RADIUS : NODE_RADIUS}
+                                  r={glyphRadius(node, DEFAULT_LAYOUT_OPTS)}
                                   style={{ fill: depthColor(node.depth, layout().maxDepth) }}
                                 />
                                 <Show when={labelled()}>
                                   <text
                                     class="links-modal-label"
-                                    x={node.isRoot ? 0 : NODE_RADIUS + LABEL_GAP}
-                                    y={-((node.isRoot ? ROOT_RADIUS : NODE_RADIUS) + LABEL_GAP)}
+                                    text-anchor={node.labelAnchor}
+                                    x={node.labelX}
+                                    y={node.labelY}
                                   >
-                                    {shortLabel(node.server)}
+                                    {node.label}
                                   </text>
                                 </Show>
                               </g>
@@ -427,6 +429,19 @@ const LinksModal: Component = () => {
               </div>
 
               <footer class="links-modal-footer">
+                {/* #578 (polish 3+4) — a one-line colour-ramp key + "you"
+                    marker so the teal-root / hop-ramp is legible without a full
+                    legend. Persistent while a topology is drawn; sits above the
+                    hint/detail swap. */}
+                <Show when={nodeCount() > 0}>
+                  <div class="links-modal-legend" data-testid="links-modal-legend">
+                    <span class="links-modal-legend-you">◎ you are here</span>
+                    <span class="links-modal-legend-ramp">
+                      <span class="links-modal-legend-swatch" aria-hidden="true" />
+                      colour = hops from your server
+                    </span>
+                  </div>
+                </Show>
                 <Show
                   when={detail()}
                   fallback={

--- a/cicchetto/src/__tests__/linksLayout.test.ts
+++ b/cicchetto/src/__tests__/linksLayout.test.ts
@@ -110,6 +110,9 @@ describe("radialLayout (#238) — empty + single-node degenerate cases", () => {
     expect(layout.width).toBeGreaterThan(0);
     expect(layout.height).toBeGreaterThan(0);
     expectContained(layout);
+    // The box hugs the lone glyph+label too (a loose degenerate-path box would
+    // still "contain" the glyph, so pin the tightness here as well).
+    expect(minExtremity(layout)).toBeCloseTo(margin, 6);
     // Its label always survives the declutter (root is placed first).
     expect(root?.labelVisible).toBe(true);
   });

--- a/cicchetto/src/__tests__/linksLayout.test.ts
+++ b/cicchetto/src/__tests__/linksLayout.test.ts
@@ -4,6 +4,10 @@ import {
   clampPan,
   clientToViewBox,
   DEFAULT_LAYOUT_OPTS,
+  glyphRadius,
+  type LayoutNode,
+  labelBox,
+  placeLabel,
   radialLayout,
   viewBoxFit,
 } from "../lib/linksLayout";
@@ -43,6 +47,40 @@ const serverSet = (layout: ReturnType<typeof radialLayout>): string[] =>
 const nodeBy = (layout: ReturnType<typeof radialLayout>, server: string) =>
   layout.nodes.find((n) => n.server === server);
 
+// #578 — the fitted-box invariants, expressed with the PRODUCTION geometry
+// helpers (glyphRadius / labelBox) so they track a tuning change instead of
+// re-deriving the box formula (which would be a mirror of the impl).
+
+// Every node glyph sits fully inside the fitted [0,width]×[0,height] box.
+const expectContained = (layout: ReturnType<typeof radialLayout>): void => {
+  for (const n of layout.nodes) {
+    const r = glyphRadius(n, DEFAULT_LAYOUT_OPTS);
+    expect(n.x - r).toBeGreaterThanOrEqual(-1e-6);
+    expect(n.y - r).toBeGreaterThanOrEqual(-1e-6);
+    expect(n.x + r).toBeLessThanOrEqual(layout.width + 1e-6);
+    expect(n.y + r).toBeLessThanOrEqual(layout.height + 1e-6);
+  }
+};
+
+// The distance from the box's left/top edge (x=0 / y=0) to the nearest node
+// extremity — glyph edge OR visible-label box edge. A tight fit puts this at
+// exactly one `margin` (the layout's requested padding).
+const minExtremity = (layout: ReturnType<typeof radialLayout>): number => {
+  let min = Number.POSITIVE_INFINITY;
+  for (const n of layout.nodes) {
+    const r = glyphRadius(n, DEFAULT_LAYOUT_OPTS);
+    min = Math.min(min, n.x - r, n.y - r);
+    if (n.labelVisible) {
+      const b = labelBox(n, DEFAULT_LAYOUT_OPTS);
+      min = Math.min(min, b.minX, b.minY);
+    }
+  }
+  return min;
+};
+
+const visibleLabels = (layout: ReturnType<typeof radialLayout>): LayoutNode[] =>
+  layout.nodes.filter((n) => n.labelVisible);
+
 describe("radialLayout (#238) — empty + single-node degenerate cases", () => {
   it("returns an empty layout for zero entries", () => {
     const layout = radialLayout([], DEFAULT_LAYOUT_OPTS);
@@ -53,7 +91,7 @@ describe("radialLayout (#238) — empty + single-node degenerate cases", () => {
     expect(layout.maxDepth).toBe(0);
   });
 
-  it("places a single self-linked node as the root, dead centre, with no edges", () => {
+  it("places a single self-linked node as the root, fully inside a fitted box, no edges", () => {
     const layout = radialLayout(
       [entry({ server: "hub", linked_to: "hub", hopcount: 0 })],
       DEFAULT_LAYOUT_OPTS,
@@ -65,12 +103,15 @@ describe("radialLayout (#238) — empty + single-node degenerate cases", () => {
     expect(root?.parent).toBeNull();
     expect(root?.depth).toBe(0);
     expect(root?.radius).toBe(0);
-    // Root sits at the exact canvas centre (width/2 == height/2).
-    expect(layout.width).toBe(sizeFor(0));
-    expect(layout.height).toBe(sizeFor(0));
-    expect(root?.x).toBe(layout.width / 2);
-    expect(root?.y).toBe(layout.height / 2);
-    expect(root?.x).toBe(centreFor(0));
+    // #578 — the box is FITTED to the node's real extent (glyph + label + margin),
+    // NOT the full-disc `2*outer` any more. A lone root can't fill a disc: the
+    // fitted box is strictly smaller than the old sizeFor(0) would demand once a
+    // label is measured in, and the glyph sits fully inside it.
+    expect(layout.width).toBeGreaterThan(0);
+    expect(layout.height).toBeGreaterThan(0);
+    expectContained(layout);
+    // Its label always survives the declutter (root is placed first).
+    expect(root?.labelVisible).toBe(true);
   });
 
   it("treats a lone node with no self-link as the root anyway (no entry dropped)", () => {
@@ -157,11 +198,19 @@ describe("radialLayout (#238) — depth, edges, and geometry", () => {
     expect(layout.edges).toHaveLength(2);
     expect(edgeSet(layout)).toEqual(new Set([edgeKey("hub", "mid"), edgeKey("mid", "leaf")]));
 
-    // Canvas fits maxDepth; root centred.
-    expect(layout.width).toBe(sizeFor(2));
-    expect(layout.height).toBe(sizeFor(2));
-    expect(nodeBy(layout, "hub")?.x).toBe(centreFor(2));
-    expect(nodeBy(layout, "hub")?.y).toBe(centreFor(2));
+    // #578 — a single-child chain is COLLINEAR (each internal node inherits its
+    // one child's angle), so the tree occupies a thin line, not a disc. The
+    // fitted box hugs that extent: strictly smaller than the old full-disc
+    // sizeFor(2) on BOTH axes, and much thinner across the line than along it.
+    expect(layout.width).toBeLessThan(sizeFor(2));
+    expect(layout.height).toBeLessThan(sizeFor(2));
+    expect(layout.height).toBeLessThan(layout.width);
+    // Every glyph is fully inside the fitted box.
+    expectContained(layout);
+    // Tightness: the extreme node (glyph or its visible label) is exactly one
+    // margin from the box edge — computed with the SAME production helpers the
+    // layout fits with, so this is not a mirror of the impl.
+    expect(minExtremity(layout)).toBeCloseTo(margin, 6);
   });
 
   it("reconstructs a star: one root with N leaf edges", () => {
@@ -364,5 +413,175 @@ describe("clampPan (#238 fix) — the map can't be dragged off-frame", () => {
   it("clamps the two axes independently", () => {
     // ty in range, tx over the high edge (k<1).
     expect(clampPan(9999, 42, 0.5, layout)).toEqual({ tx: 300, ty: 42 });
+  });
+});
+
+describe("placeLabel (#578) — label anchor is derived from the node ANGLE", () => {
+  const o = DEFAULT_LAYOUT_OPTS;
+
+  it("anchors an EAST (right-half) node to the start, label placed to its RIGHT", () => {
+    const p = placeLabel(0, false, o); // angle 0 = due east
+    expect(p.anchor).toBe("start");
+    expect(p.x).toBeGreaterThan(0);
+  });
+
+  it("anchors a WEST (left-half) node to the end, label placed to its LEFT", () => {
+    const p = placeLabel(Math.PI, false, o); // angle π = due west
+    expect(p.anchor).toBe("end");
+    expect(p.x).toBeLessThan(0);
+  });
+
+  it("centres a NORTH node above the glyph (middle, negative y)", () => {
+    const p = placeLabel(-Math.PI / 2, false, o); // straight up (SVG y grows down)
+    expect(p.anchor).toBe("middle");
+    expect(p.x).toBe(0);
+    expect(p.y).toBeLessThan(0);
+  });
+
+  it("centres a SOUTH node below the glyph (middle, positive y)", () => {
+    const p = placeLabel(Math.PI / 2, false, o); // straight down
+    expect(p.anchor).toBe("middle");
+    expect(p.x).toBe(0);
+    expect(p.y).toBeGreaterThan(0);
+  });
+
+  it("always centres the ROOT above, regardless of its (meaningless) angle", () => {
+    // Root radius 0 → its angle is arbitrary; the label must not swing sides.
+    for (const a of [0, Math.PI, Math.PI / 2, -Math.PI / 2, 1.234]) {
+      const p = placeLabel(a, true, o);
+      expect(p.anchor).toBe("middle");
+      expect(p.x).toBe(0);
+      expect(p.y).toBeLessThan(0);
+    }
+  });
+
+  it("gives a COLLINEAR parent/child pair non-stacked labels (the #578 overlap)", () => {
+    // The screenshot bug: a one-child internal node inherits its child's angle
+    // exactly, so both sit on the same ray one ring apart. A single leaf under
+    // the root lands due WEST (angle π); the root stays centred-above while the
+    // leaf swings to its LEFT — different anchors, so the labels no longer pile.
+    const layout = radialLayout(
+      [
+        entry({ server: "root", linked_to: "root", hopcount: 0 }),
+        entry({ server: "devel", linked_to: "root", hopcount: 1 }),
+      ],
+      DEFAULT_LAYOUT_OPTS,
+    );
+    const root = nodeBy(layout, "root");
+    const devel = nodeBy(layout, "devel");
+    expect(root?.labelAnchor).toBe("middle");
+    expect(devel?.labelAnchor).toBe("end"); // west → left side, not centred-above
+    // Both labels survive (a 2-node tree is nowhere near crowded)...
+    expect(root?.labelVisible).toBe(true);
+    expect(devel?.labelVisible).toBe(true);
+    // ...and their measured boxes do NOT overlap (the whole point of the fix).
+    const rb = labelBox(root as LayoutNode, DEFAULT_LAYOUT_OPTS);
+    const db = labelBox(devel as LayoutNode, DEFAULT_LAYOUT_OPTS);
+    const overlap =
+      rb.minX < db.maxX && db.minX < rb.maxX && rb.minY < db.maxY && db.minY < rb.maxY;
+    expect(overlap).toBe(false);
+  });
+});
+
+describe("radialLayout (#578) — the viewBox fits the real node extent", () => {
+  // A star: N leaves equally spaced around one self-linked hub.
+  const star = (leaves: number): LinksEntry[] => [
+    entry({ server: "hub", linked_to: "hub", hopcount: 0 }),
+    ...Array.from({ length: leaves }, (_, i) =>
+      entry({ server: `leaf-${i}`, linked_to: "hub", hopcount: 1 }),
+    ),
+  ];
+
+  it("fits TIGHTLY — the extreme node is exactly one margin from the edge", () => {
+    // The property that pins the whole fix: the nearest node extremity (glyph OR
+    // visible label) is exactly `margin` from x=0 / y=0. The old full-disc box
+    // left a half-canvas of dead black around a small mesh — this forbids it for
+    // ANY topology, and every glyph stays inside the box.
+    const layout = radialLayout(star(6), DEFAULT_LAYOUT_OPTS);
+    expectContained(layout);
+    expect(minExtremity(layout)).toBeCloseTo(margin, 6);
+  });
+
+  it("includes visible LABELS in the fitted extent (the old box clipped them)", () => {
+    // A single east/west leaf swings its label OUTWARD past the glyph; the fitted
+    // box must contain that label box, not just the glyph disc. This is exactly
+    // what the old glyph-only full-disc bound got wrong (labels clipped at the
+    // ring). Assert the leftmost VISIBLE label sits no further left than x=0.
+    const layout = radialLayout(star(6), DEFAULT_LAYOUT_OPTS);
+    for (const n of visibleLabels(layout)) {
+      const b = labelBox(n, DEFAULT_LAYOUT_OPTS);
+      expect(b.minX).toBeGreaterThanOrEqual(-1e-6);
+      expect(b.maxX).toBeLessThanOrEqual(layout.width + 1e-6);
+      expect(b.minY).toBeGreaterThanOrEqual(-1e-6);
+      expect(b.maxY).toBeLessThanOrEqual(layout.height + 1e-6);
+    }
+  });
+
+  it("collapses the box for a collinear CHAIN (the dead-space win)", () => {
+    // A single-child chain is a thin LINE, not a disc. The fitted box hugs it:
+    // strictly under the old full-disc bound on both axes, and much thinner
+    // across the line than along it — the exact dead black the bug reported.
+    const layout = radialLayout(
+      [
+        entry({ server: "hub", linked_to: "hub", hopcount: 0 }),
+        entry({ server: "aa", linked_to: "hub", hopcount: 1 }),
+        entry({ server: "bb", linked_to: "aa", hopcount: 2 }),
+        entry({ server: "cc", linked_to: "bb", hopcount: 3 }),
+      ],
+      DEFAULT_LAYOUT_OPTS,
+    );
+    expectContained(layout);
+    expect(layout.width).toBeLessThan(sizeFor(3));
+    expect(layout.height).toBeLessThan(sizeFor(3));
+    expect(layout.height).toBeLessThan(layout.width);
+  });
+
+  it("degrades to an empty box for an empty topology (unchanged)", () => {
+    const layout = radialLayout([], DEFAULT_LAYOUT_OPTS);
+    expect(layout.width).toBe(0);
+    expect(layout.height).toBe(0);
+  });
+});
+
+describe("radialLayout (#578) — greedy label declutter", () => {
+  const star = (leaves: number): LinksEntry[] => [
+    entry({ server: "hub", linked_to: "hub", hopcount: 0 }),
+    ...Array.from({ length: leaves }, (_, i) =>
+      entry({ server: `leaf-${i}`, linked_to: "hub", hopcount: 1 }),
+    ),
+  ];
+
+  it("shows ALL labels on a sparse star (angular gaps are wide)", () => {
+    const layout = radialLayout(star(3), DEFAULT_LAYOUT_OPTS);
+    expect(visibleLabels(layout)).toHaveLength(layout.nodes.length);
+  });
+
+  it("DROPS colliding labels on a dense star (angular distance, not node count)", () => {
+    // 40 leaves crammed onto one ring → adjacent labels overlap → most are
+    // dropped. The axis is ANGULAR crowding, which a node-count threshold missed.
+    const layout = radialLayout(star(40), DEFAULT_LAYOUT_OPTS);
+    const visible = visibleLabels(layout);
+    expect(visible.length).toBeLessThan(layout.nodes.length); // some dropped
+    expect(visible.length).toBeGreaterThanOrEqual(1); // not all dropped
+  });
+
+  it("ALWAYS keeps the root label (placed first, never decluttered away)", () => {
+    const layout = radialLayout(star(40), DEFAULT_LAYOUT_OPTS);
+    expect(nodeBy(layout, "hub")?.isRoot).toBe(true);
+    expect(nodeBy(layout, "hub")?.labelVisible).toBe(true);
+  });
+
+  it("never lets two VISIBLE labels overlap (the declutter guarantee)", () => {
+    const layout = radialLayout(star(40), DEFAULT_LAYOUT_OPTS);
+    const boxes = visibleLabels(layout).map((n) => labelBox(n, DEFAULT_LAYOUT_OPTS));
+    for (let i = 0; i < boxes.length; i++) {
+      for (let j = i + 1; j < boxes.length; j++) {
+        const a = boxes[i];
+        const b = boxes[j];
+        if (a === undefined || b === undefined) continue;
+        const overlap = a.minX < b.maxX && b.minX < a.maxX && a.minY < b.maxY && b.minY < a.maxY;
+        expect(overlap).toBe(false);
+      }
+    }
   });
 });

--- a/cicchetto/src/lib/linksLayout.ts
+++ b/cicchetto/src/lib/linksLayout.ts
@@ -33,7 +33,22 @@ export type LayoutNode = {
   radius: number;
   x: number;
   y: number;
+  // #578 — label placement, all resolved here so the modal is a dumb renderer
+  // and the geometry stays unit-testable. `label` is the short display string
+  // (leftmost DNS segment); `labelAnchor` + `labelX`/`labelY` are the
+  // node-RELATIVE (post-translate) text placement, derived from the node's
+  // polar angle so a side node's label sits outward instead of always centred
+  // above; `labelVisible` is the greedy-declutter verdict (root always true) —
+  // the modal ORs the hovered/selected node on top of it.
+  label: string;
+  labelAnchor: LabelAnchor;
+  labelX: number;
+  labelY: number;
+  labelVisible: boolean;
 };
+
+// SVG text-anchor, chosen per node from its angle (#578).
+export type LabelAnchor = "start" | "middle" | "end";
 
 export type LayoutEdge = {
   from: string;
@@ -47,8 +62,10 @@ export type LayoutEdge = {
 export type Layout = {
   nodes: LayoutNode[];
   edges: LayoutEdge[];
-  // Bounding box the SVG viewBox fits (origin at 0,0; the root sits at the
-  // centre). Deterministic from maxDepth + ringGap + margin.
+  // Bounding box the SVG viewBox fits (origin at 0,0). #578 — FITTED to the real
+  // node extent (every glyph disc + every visible label box, grown by margin),
+  // NOT the old full-disc `2*(maxDepth*ringGap+margin)`. A small mesh no longer
+  // opens as a few dots on a half-empty black square.
   width: number;
   height: number;
   maxDepth: number;
@@ -57,16 +74,46 @@ export type Layout = {
 export type LayoutOpts = {
   // Radial distance between successive depth rings.
   ringGap: number;
-  // Padding around the outermost ring so node glyphs + labels are not clipped.
+  // Padding around the fitted node extent so glyphs + labels are not clipped.
   margin: number;
+  // #578 — glyph radii + label metrics live in the opts so the LAYOUT (not the
+  // modal) owns every dimension that feeds the fitted viewBox + the declutter.
+  // The modal reads these back for the <circle r>, so there is ONE source.
+  rootRadius: number;
+  nodeRadius: number;
+  // Clearance between a glyph edge and its label.
+  labelGap: number;
+  // Deterministic estimate of the rendered label size in viewBox units. The CSS
+  // label is 11px `var(--font-mono)`; a monospace advance is ~0.6em, so
+  // `labelCharWidth` ≈ 6.6 and `labelHeight` ≈ the font size. Estimating (vs
+  // DOM getBBox) keeps radialLayout PURE + deterministic — the viewBox is an
+  // attribute computed BEFORE paint, so a measure-then-resize loop is neither
+  // testable nor race-free. A slightly generous estimate errs toward MORE
+  // decluttering, never toward a visible overlap.
+  labelCharWidth: number;
+  labelHeight: number;
 };
 
 // #238 fix — ringGap cut 120→72 so the parent→child edges read short instead
-// of stringy; paired with the bigger node radii in LinksModal.tsx (11/7 → 14/10)
-// this lifts the glyph-to-edge ratio from ~17:1 to ~7:1 (dots you can actually
-// hit, edges that don't dominate). margin unchanged — still clears the largest
-// glyph + its label at the outer ring.
-export const DEFAULT_LAYOUT_OPTS: LayoutOpts = { ringGap: 72, margin: 80 };
+// of stringy; paired with the bigger node radii (11/7 → 14/10) this lifts the
+// glyph-to-edge ratio from ~17:1 to ~7:1 (dots you can actually hit, edges that
+// don't dominate). #578 folds the display geometry (radii, label metrics) in
+// here so the fitted viewBox + declutter are computed from the SAME numbers the
+// modal renders with.
+export const DEFAULT_LAYOUT_OPTS: LayoutOpts = {
+  ringGap: 72,
+  // #578 — margin is now pure breathing room around the FITTED extent (which
+  // already includes each glyph + its label), so it dropped 80→32. The old 80
+  // padded past the outermost RING to clear a label the box otherwise clipped;
+  // that job now belongs to the extent union, and an 80-unit border would just
+  // reprint the dead space the fit exists to kill.
+  margin: 32,
+  rootRadius: 14,
+  nodeRadius: 10,
+  labelGap: 4,
+  labelCharWidth: 6.6,
+  labelHeight: 12,
+};
 
 // Internal tree node built before geometry is assigned.
 type TreeNode = {
@@ -190,6 +237,85 @@ function assignAngles(root: TreeNode): void {
   setInternal(root);
 }
 
+// Short label: the leftmost DNS label of the server name (irc.azzurra.org →
+// "irc"), which reads better in the dense tree. The full name + description live
+// in the modal's detail footer. Lives here (not the modal) so radialLayout can
+// size + declutter the exact string that gets rendered. #578.
+export function shortLabel(server: string): string {
+  const dot = server.indexOf(".");
+  return dot === -1 ? server : server.slice(0, dot);
+}
+
+// Glyph radius for a node — the root reads bigger. #578.
+export function glyphRadius(node: { isRoot: boolean }, opts: LayoutOpts): number {
+  return node.isRoot ? opts.rootRadius : opts.nodeRadius;
+}
+
+// #578 — choose a label's anchor + node-relative offset from the node's polar
+// ANGLE, not a fixed centred-above placement. Collisions are a function of
+// ANGULAR distance, not node count: a one-child internal node inherits its
+// child's angle exactly, so parent + child land on the same ray one ring apart;
+// centring both labels above their glyphs then stacks them. Swinging the label
+// to the OUTWARD side (right for the east half, left for the west) breaks that
+// pile-up for free, and near-vertical nodes keep the centred above/below
+// placement (a side label there would collide with the ring neighbours). The
+// root's radius is 0 so its angle is meaningless — it always centres above.
+export function placeLabel(
+  angle: number,
+  isRoot: boolean,
+  opts: LayoutOpts,
+): { anchor: LabelAnchor; x: number; y: number } {
+  const gap = opts.labelGap;
+  if (isRoot) {
+    return { anchor: "middle", x: 0, y: -(opts.rootRadius + gap) };
+  }
+  const off = opts.nodeRadius + gap;
+  const c = Math.cos(angle);
+  const s = Math.sin(angle);
+  // Horizontal-dominant → outward side; vertical-dominant → centred above/below.
+  if (Math.abs(c) >= Math.abs(s)) {
+    // `y = labelHeight/3` nudges the side label to vertically straddle the glyph
+    // (SVG text is baseline-anchored).
+    return c >= 0
+      ? { anchor: "start", x: off, y: opts.labelHeight / 3 } // east → right of glyph
+      : { anchor: "end", x: -off, y: opts.labelHeight / 3 }; // west → left of glyph
+  }
+  // SVG y grows downward: sin<0 is up (north), sin>0 is down (south).
+  return s < 0
+    ? { anchor: "middle", x: 0, y: -off } // north → above
+    : { anchor: "middle", x: 0, y: off + opts.labelHeight }; // south → below
+}
+
+// #578 — the ABSOLUTE (viewBox-unit) bounding box a node's label occupies, given
+// its already-resolved placement fields. The declutter + the fitted viewBox both
+// union these; the estimated text width is `label.length * labelCharWidth`. Pure
+// so tests assert extent/overlap with the very function the layout fits with.
+export function labelBox(
+  node: {
+    x: number;
+    y: number;
+    label: string;
+    labelAnchor: LabelAnchor;
+    labelX: number;
+    labelY: number;
+  },
+  opts: LayoutOpts,
+): { minX: number; minY: number; maxX: number; maxY: number } {
+  const textW = node.label.length * opts.labelCharWidth;
+  const bx = node.x + node.labelX;
+  const by = node.y + node.labelY;
+  const minX =
+    node.labelAnchor === "start" ? bx : node.labelAnchor === "end" ? bx - textW : bx - textW / 2;
+  return { minX, maxX: minX + textW, minY: by - opts.labelHeight, maxY: by };
+}
+
+const boxesOverlap = (
+  a: { minX: number; minY: number; maxX: number; maxY: number },
+  b: { minX: number; minY: number; maxX: number; maxY: number },
+  pad: number,
+): boolean =>
+  a.minX - pad < b.maxX && b.minX - pad < a.maxX && a.minY - pad < b.maxY && b.minY - pad < a.maxY;
+
 // Public entry point: entries → fully positioned layout. Empty input yields an
 // empty layout (the modal renders the "hidden topology" empty state instead).
 export function radialLayout(entries: LinksEntry[], opts: LayoutOpts): Layout {
@@ -209,29 +335,84 @@ export function radialLayout(entries: LinksEntry[], opts: LayoutOpts): Layout {
   };
   walk(root);
 
-  const outer = maxDepth * opts.ringGap + opts.margin;
-  const cx = outer;
-  const cy = outer;
-  const size = outer * 2;
-
+  // Raw polar positions with the root at the ORIGIN (0,0); the fitted box is
+  // shifted to a 0-origin viewBox at the end. Positioning around the origin (not
+  // a pre-guessed `outer` centre) is what lets the box hug the REAL extent — the
+  // #578 fix for a small mesh opening as a few dots on a mostly-black square.
   const nodes: LayoutNode[] = flat.map((n) => {
     const radius = n.depth * opts.ringGap;
-    // Root sits dead centre (radius 0); cos/sin of its angle is irrelevant.
-    const x = cx + radius * Math.cos(n.angle);
-    const y = cy + radius * Math.sin(n.angle);
+    const isRoot = n.depth === 0;
+    // Root sits at the origin (radius 0); cos/sin of its angle is irrelevant.
+    const x = radius * Math.cos(n.angle);
+    const y = radius * Math.sin(n.angle);
+    const label = shortLabel(n.server);
+    const place = placeLabel(n.angle, isRoot, opts);
     return {
       server: n.server,
       description: n.entry.description,
       hopcount: n.entry.hopcount,
       depth: n.depth,
-      parent: n.depth === 0 ? null : n.entry.linked_to,
-      isRoot: n.depth === 0,
+      parent: isRoot ? null : n.entry.linked_to,
+      isRoot,
       angle: n.angle,
       radius,
       x,
       y,
+      label,
+      labelAnchor: place.anchor,
+      labelX: place.x,
+      labelY: place.y,
+      labelVisible: false, // resolved by the declutter pass below
     };
   });
+
+  // Greedy declutter: place the root first (always kept), then by depth, then in
+  // flat order. A candidate whose label box hits an already-placed one is
+  // dropped. The label-anchor swing above minimises drops; this pass GUARANTEES
+  // no two SURVIVING labels overlap. The hovered/selected node is force-shown by
+  // the modal on top of this static baseline — dynamic state doesn't belong in
+  // the pure layout. `labelGap` pad keeps a breathing gap around each box.
+  const placed: ReturnType<typeof labelBox>[] = [];
+  for (const n of [...nodes].sort((a, b) => a.depth - b.depth)) {
+    const box = labelBox(n, opts);
+    if (n.isRoot || !placed.some((p) => boxesOverlap(box, p, opts.labelGap))) {
+      n.labelVisible = true;
+      placed.push(box);
+    }
+  }
+
+  // Fit the viewBox to the REAL extent: the union of every glyph disc and every
+  // VISIBLE label box, grown by one margin on each side. Then translate all
+  // coordinates so that extent's top-left maps to (0,0) — the modal renders a
+  // `viewBox="0 0 width height"` and clampPan/viewBoxFit assume that origin, so
+  // shifting the geometry (not the viewBox origin) keeps both intact.
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+  for (const n of nodes) {
+    const r = glyphRadius(n, opts);
+    minX = Math.min(minX, n.x - r);
+    minY = Math.min(minY, n.y - r);
+    maxX = Math.max(maxX, n.x + r);
+    maxY = Math.max(maxY, n.y + r);
+    if (n.labelVisible) {
+      const b = labelBox(n, opts);
+      minX = Math.min(minX, b.minX);
+      minY = Math.min(minY, b.minY);
+      maxX = Math.max(maxX, b.maxX);
+      maxY = Math.max(maxY, b.maxY);
+    }
+  }
+
+  const dx = opts.margin - minX;
+  const dy = opts.margin - minY;
+  const width = maxX - minX + 2 * opts.margin;
+  const height = maxY - minY + 2 * opts.margin;
+  for (const n of nodes) {
+    n.x += dx;
+    n.y += dy;
+  }
 
   const posByServer = new Map(nodes.map((n) => [n.server, n]));
   const edges: LayoutEdge[] = [];
@@ -247,7 +428,7 @@ export function radialLayout(entries: LinksEntry[], opts: LayoutOpts): Layout {
   };
   addEdges(root);
 
-  return { nodes, edges, width: size, height: size, maxDepth };
+  return { nodes, edges, width, height, maxDepth };
 }
 
 // Client-pixel → viewBox-unit mapping for the topology <svg>, laid out under

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -5440,7 +5440,8 @@ html.resize-dragging * {
   width: 2.5rem;
   height: 0.55rem;
   border-radius: 0.28rem;
-  background: linear-gradient(90deg, hsl(190 68% 58%), hsl(350 68% 58%));
+  /* The gradient is set inline from depthColor() (LinksModal.tsx) so the ramp
+     has one source; no hsl() stops duplicated here. */
 }
 
 .links-modal-detail {

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -5359,7 +5359,19 @@ html.resize-dragging * {
 
 .links-modal-node-root .links-modal-label {
   font-weight: bold;
-  text-anchor: middle;
+  /* #578 — text-anchor is now driven by the per-node `labelAnchor` attribute
+     (angle-derived; root resolves to "middle" in the layout), so no CSS
+     override here — a CSS `text-anchor` would win over the attribute and pin
+     every node to one side. */
+}
+
+/* #578 — "you are here" halo ring around the root glyph so the eye lands there
+   first (the depth-ramp's teal root only reads once you know the ramp). */
+.links-modal-you-ring {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 1.5;
+  opacity: 0.7;
 }
 
 .links-modal-node-active .links-modal-label {
@@ -5399,6 +5411,36 @@ html.resize-dragging * {
 
 .links-modal-hint {
   color: var(--muted);
+}
+
+/* #578 (polish 3+4) — the colour-ramp key + "you" marker. One muted line above
+   the hint/detail swap; the swatch mirrors the depthColor ramp (hue 190→350). */
+.links-modal-legend {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem 1rem;
+  margin-bottom: 0.35rem;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.links-modal-legend-you {
+  color: var(--accent);
+}
+
+.links-modal-legend-ramp {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.links-modal-legend-swatch {
+  display: inline-block;
+  width: 2.5rem;
+  height: 0.55rem;
+  border-radius: 0.28rem;
+  background: linear-gradient(90deg, hsl(190 68% 58%), hsl(350 68% 58%));
 }
 
 .links-modal-detail {


### PR DESCRIPTION
Refs #578 (follow-up di #238).

## Cosa

Il `/links` radial map aveva geometria corretta ma frame rotto: su reti
piccole pochi punti su un quadrato nero con label sovrapposte. Fix nelle
**funzioni pure** di `linksLayout.ts` (cic-only, ZERO server):

1. **Label anchor dall'angolo** (est→`start`, ovest→`end`, N/S→`middle`
   sopra/sotto) via helper puri esportati `placeLabel/labelBox/glyphRadius`;
   i nodi portano `label/labelAnchor/labelX/labelY/labelVisible`. **Declutter
   greedy** (root prima, poi per depth; scarta i box che collidono; root
   sempre tenuto) → garanzia no-overlap. Rimosso il vecchio
   `LABEL_ALL_THRESHOLD` (asse sbagliato: contava i nodi).
2. **viewBox fittato** all'estensione reale (glyph + label visibili + margin),
   coord shiftate a origine 0,0 così `clampPan`/`viewBoxFit` restano intatti;
   `margin` 80→32.
3. Polish: legend "colour = hops from your server" (gradiente da `depthColor`,
   una sola sorgente) + anello "you are here" sul root.

`LinksModal.tsx` resta un dumb renderer (legge i campi, `glyphRadius` per il
`<circle r>`). **Map button resta NASCOSTO**, `/links` è l'UNICO entry point.

## File

- `cicchetto/src/lib/linksLayout.ts`
- `cicchetto/src/LinksModal.tsx`
- `cicchetto/src/__tests__/linksLayout.test.ts`
- `cicchetto/src/themes/default.css`
- `cicchetto/e2e/tests/issue578-links-map-render.spec.ts` (nuovo)

## Gate

- vitest **3704/3704** (208 file)
- biome + tsc **EXIT=0** (32 warning pre-esistenti, non miei)
- **FULL integration suite VERDE: 567 passed, 0 failed** (chromium + webkit, 20.6m), `FULL_EXIT=0`
- e2e scoped #578 verde in isolamento
- code review sincrona (10x-engineer:code-reviewer): nessun bug di correttezza; 3 note LOW già applicate