### PR TITLE
feat(#581): visitor recover-identity + self-NICK stale-+r fix

### DIFF
--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -119,6 +119,62 @@ export async function mintVisitor(nick: string, incognito = false): Promise<Mint
   };
 }
 
+// #581 — visitor login WITH a password (vs `mintVisitor`, which is anon —
+// no password). `POST /auth/login {identifier, password, network}` is the
+// visitor branch (identifier is a bare nick, not `email@host`); a password
+// on a fresh (never-committed) nick threads through
+// `Visitors.SessionPlan.with_login_identify/2` → the plan identifies to
+// services at 001, and on the resulting `+r` `commit_identity` persists a
+// `:nickserv_identify` credential — the RECOVERABLE state the /recover feature
+// (and its home button) needs. `network` is explicit (the testnet has several
+// visitor_enabled networks → an implicit login is `:network_ambiguous`).
+//
+// Returns `subjectJson` too, so a spec can boot cic with the exact persisted
+// visitor subject via `loginAs(page, {...} as SeededUser)` (loginAs reads only
+// `.token` + `.subjectJson`).
+export type VisitorLoginResult = {
+  id: string;
+  nick: string;
+  network_slug: string;
+  token: string;
+  subject: { kind: "visitor"; id: string; registered?: boolean; incognito?: boolean };
+  subjectJson: string;
+};
+
+export async function loginVisitor(
+  nick: string,
+  password: string,
+  networkSlug: string,
+): Promise<VisitorLoginResult> {
+  const response = await fetch(`${GRAPPA_BASE_URL}/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ identifier: nick, password, network: networkSlug }),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `grappaApi.loginVisitor: ${nick} → ${response.status} ${await response.text()}`,
+    );
+  }
+  const body = (await response.json()) as {
+    token: string;
+    subject: { kind: "visitor"; id: string; registered?: boolean; incognito?: boolean };
+  };
+  if (body.subject.kind !== "visitor") {
+    throw new Error(
+      `grappaApi.loginVisitor: expected visitor subject, got ${body.subject.kind}`,
+    );
+  }
+  return {
+    id: body.subject.id,
+    nick,
+    network_slug: networkSlug,
+    token: body.token,
+    subject: body.subject,
+    subjectJson: JSON.stringify(body.subject),
+  };
+}
+
 // #299 amendment (author model A) — thin theme REST helpers for the
 // author-nick e2e. The runner talks to grappa directly on port 4000
 // (bypassing nginx), so these mirror the cic `themesApi` verbs without the

--- a/cicchetto/e2e/tests/recover-identity-real.spec.ts
+++ b/cicchetto/e2e/tests/recover-identity-real.spec.ts
@@ -1,0 +1,275 @@
+// #581 — "recover my identity", REAL-SERVICES full round-trip e2e (path A).
+//
+// The NON-HOLLOW companion to the server integration + cic unit tests. Drives
+// the visitor recover flow through cicchetto against the LIVE stack —
+// grappa-test → bahamut-test (the azzurra leaf) → azzurra-services
+// (email-enabled) → mailpit — and proves an ACTUAL parked-on-a-held-nick
+// visitor reclaims a registered nick via NickServ RECOVER → `+r`. Success is
+// asserted on the VISIBLE modal outcome (D4), never an API return; no
+// soft-assert accepts success-or-failure.
+//
+// ── THE STAGING (why each step) ───────────────────────────────────────────
+// `recoverable` (the button gate + the /recover secret source) reads the
+// PERSISTENT `(visitor_id, network_id)` credential; it is recoverable ONLY
+// once that credential is `:nickserv_identify` + `password_encrypted` — the
+// state a PRIOR `+r` commit (`Visitors.commit_identity`) leaves. Login alone
+// does NOT persist it (a fresh first-login visitor gets an ANON credential +
+// an in-memory `with_login_identify` plan override — the button correctly
+// hides for it; test 1 proves exactly that). So the positive path must FIRST
+// make the visitor reach `+r` once (nick free).
+//
+// The MANUAL #581 recover serves a scenario DISJOINT from the automatic
+// GhostRecovery, split by connection phase (see DESIGN_NOTES + the plan
+// FINDING): auto owns the PRE-001 window (a held nick earns a 433 BEFORE 001
+// while `pending_password` is set → server auto NICK_→GHOST→IDENTIFY→+r,
+// server.ex:2876); the manual 🔑 owns POST-001 (already connected, on a
+// non-`+r` nick, target held → its 433 handler at server.ex:2862 sits ABOVE
+// ghost). A reconnect-with-held-nick staging can NOT surface the manual button
+// — auto-ghost reclaims it PRE-001 (measured: it timed out that way,
+// 2026-08-01). To reach POST-001 non-`+r` DETERMINISTICALLY the visitor does a
+// voluntary `/nick` (clears `+r` per bahamut m_nick.c, no ghost re-fire). That
+// only reveals the button because the companion EventRouter fix mirrors
+// bahamut's SILENT `+r`-strip on a self-rename — pre-fix grappa kept a phantom
+// `+r` and the button stayed hidden (that IS the state bug this e2e surfaced).
+//
+//   1. IrcPeer registers RECOVER_NICK with the real NickServ (REGISTER →
+//      emailed AUTH code via mailpit → AUTH → `+r`), then DISCONNECTS — the
+//      nick is now FREE but REGISTERED (password known).
+//   2. The visitor logs in WITH that password (`loginVisitor`) → grappa
+//      connects to the FREE nick → built-in IDENTIFY → `+r` → `commit_identity`
+//      persists the `:nickserv_identify` credential → `recoverable` flips true.
+//      (Barrier: poll GET /me until `recoverable === true`.) The button is
+//      HIDDEN here — the visitor is `+r`.
+//   3. The visitor voluntarily `/nick`s to a free Guest nick (composeSend from
+//      the $server window) → bahamut strips `+r` (silent), grappa MIRRORS it
+//      (the fix) → the visitor is now connected, POST-001, NON-`+r`, and
+//      RECOVER_NICK is FREE again. `recoverable` stays true → the 🔑 button
+//      APPEARS (the POST-001 barrier).
+//   4. IrcPeer RECONNECTS + IDENTIFYs RECOVER_NICK (a stable, legitimate hold).
+//   5. Click 🔑 Recover → the server-driven RecoverModal → NICK(433, held) →
+//      RECOVER (services free IrcPeer's hold — SPIKE-PROVEN 2026-07-31, FREED)
+//      → settle → NICK + IDENTIFY → `+r` → the modal shows terminal SUCCESS.
+//
+// ── EMAIL DOMAIN (source-verified, load-bearing) ──────────────────────────
+// azzurra/services `validate_email` is a HARDCODED ICANN-TLD allowlist (no
+// DNS). `.test` is rejected; use `example.com` (RFC-2606). msmtp relays ALL
+// mail to mailpit regardless of domain → fully hermetic. (Same note as
+// registration-wizard-real.spec.ts.)
+//
+// ── MEASURED on the lane (2026-08-01) ─────────────────────────────────────
+//  * (f) step-1 register reached real `+r` + "Password accepted" on `azzurra`
+//    → email + services work on the visitor network (shares the bahamut-test
+//    hub with `azzurra-reg`, which the wizard spec emails).
+//  * (c) `waitForRecoverable(true)` passed post-login → the `+r` commit
+//    persists the `:nickserv_identify` credential; no stubborn post-QUIT hold.
+// The obsolete park/reconnect staging (which auto-ghost reclaimed PRE-001) is
+// GONE — the voluntary-`/nick` path reaches POST-001 without touching the
+// network connection_state, so no visitor-token PATCH is needed here.
+//
+// ── RE-RUN NOTE ───────────────────────────────────────────────────────────
+// RECOVER_NICK registers exactly ONCE per fresh services container. CI is
+// fresh each run. For a LOCAL re-run against a persistent testnet the nick is
+// already registered — bring the testnet down + up first
+// (`scripts/testnet.sh down && scripts/integration.sh …`).
+
+import { expect, test } from "@playwright/test";
+import type { Browser } from "@playwright/test";
+import {
+  composeSend,
+  expectShellReady,
+  selectChannel,
+  waitForUserTopicReady,
+} from "../fixtures/cicchettoPage";
+import {
+  GRAPPA_BASE_URL,
+  loginVisitor,
+  mintVisitor,
+  reapVisitors,
+} from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { awaitMail, extractFromMail, resetMailpit } from "../fixtures/mailpit";
+import { IrcPeer } from "../fixtures/ircClient";
+
+// Boot cic as a visitor (local per-spec helper — the established pattern; each
+// visitor spec inlines its own). Seeds the two auth localStorage keys the SPA
+// reads at module init, navigates, and waits for the shell + user-topic to be
+// live so subsequent home-row assertions see settled state.
+async function bootVisitor(
+  browser: Browser,
+  visitor: { id: string; nick: string; token: string },
+): Promise<{ ctx: Awaited<ReturnType<Browser["newContext"]>>; page: import("@playwright/test").Page }> {
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+  await page.addInitScript(
+    ([token, subjectJson]) => {
+      localStorage.setItem("grappa-token", token);
+      localStorage.setItem("grappa-subject", subjectJson);
+      localStorage.setItem("cic.installChoice", "browser");
+    },
+    [visitor.token, JSON.stringify({ kind: "visitor", id: visitor.id, nick: visitor.nick })] as const,
+  );
+  await page.goto("/");
+  await expectShellReady(page);
+  await waitForUserTopicReady(page, `visitor:${visitor.id}`);
+  return { ctx, page };
+}
+
+const NETWORK_SLUG = "azzurra"; // visitor_enabled + real azzurra-services (bahamut-test hub)
+const RECOVER_NICK = "rec-id-nick";
+const RECOVER_PASSWORD = "recidpw1"; // 5–32 chars (NickServ floor)
+const REG_EMAIL = "rec-id@example.com"; // valid TLD (see EMAIL DOMAIN note)
+const AUTH_CODE_RE = /AUTH (\d+)/;
+
+// Poll GET /me until the `NETWORK_SLUG` home row's `recoverable` flag equals
+// `expected`. `recoverable` = `Credential.has_nickserv_secret?/1` server-side,
+// which flips true ONLY after the `+r` commit persists the `:nickserv_identify`
+// credential — the deterministic barrier for "the credential is now
+// recoverable" (step 2) and the honest server-side proof of the reverse
+// (an anon credential is NOT recoverable).
+async function waitForRecoverable(
+  token: string,
+  slug: string,
+  expected: boolean,
+  timeoutMs = 45_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let last: boolean | undefined;
+  while (Date.now() < deadline) {
+    const res = await fetch(`${GRAPPA_BASE_URL}/me`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      // GET /me → `{kind, …, home_data: {networks: [home_network_row], …}}`
+      // (me_json.ex). `recoverable` lives on each home_data.networks row.
+      const body = (await res.json()) as {
+        home_data?: { networks: Array<{ slug: string; recoverable: boolean }> };
+      };
+      const row = body.home_data?.networks.find((n) => n.slug === slug);
+      last = row?.recoverable;
+      if (last === expected) return;
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(
+    `waitForRecoverable(${slug}): never reached recoverable=${expected} (last=${last})`,
+  );
+}
+
+test.describe("#581 recover-identity (real services)", () => {
+  // Reverse (deterministic, no services): a first-login visitor's credential
+  // is anon, so `recoverable` is false and the 🔑 button is ABSENT. Proves
+  // `recoverable` is NOT always-true — the gate genuinely gates (orchestrator
+  // ask, 2026-08-01). Fast: pure anon mint, no register round-trip.
+  test("first-login (anon credential) → recoverable is false and the 🔑 button is absent", async ({
+    browser,
+  }) => {
+    const admin = getSeededAdmin();
+    const stamp = Date.now();
+    let visitor: Awaited<ReturnType<typeof mintVisitor>> | null = null;
+    let ctx: Awaited<ReturnType<Browser["newContext"]>> | null = null;
+
+    try {
+      visitor = await mintVisitor(`recno-${stamp % 100000}`);
+
+      // Server-side proof: the anon credential is NOT recoverable.
+      await waitForRecoverable(visitor.token, visitor.network_slug, false, 15_000);
+
+      const booted = await bootVisitor(browser, visitor);
+      ctx = booted.ctx;
+      const page = booted.page;
+
+      await page.locator(".sidebar-home-btn").click();
+      // The launcher never renders for an anon (non-recoverable) credential.
+      await expect(
+        page.getByTestId(`home-recover-identity-${visitor.network_slug}`),
+      ).toHaveCount(0);
+    } finally {
+      if (ctx) await ctx.close();
+      await reapVisitors(admin.token, visitor?.id);
+    }
+  });
+
+  // Positive (real services): the POST-001 /nick staging above.
+  test("a returning visitor on a Guest nick recovers a held registered nick via RECOVER → +r", async ({
+    browser,
+  }) => {
+    // Register round-trip (~45s) + login + /nick + recover (~15s).
+    test.setTimeout(150_000);
+
+    const admin = getSeededAdmin();
+    const stamp = Date.now();
+    const guestNick = `recguest${stamp % 100000}`; // free + unique per run
+    let visitor: Awaited<ReturnType<typeof loginVisitor>> | null = null;
+    let ctx: Awaited<ReturnType<Browser["newContext"]>> | null = null;
+    const peers: IrcPeer[] = [];
+
+    try {
+      await resetMailpit();
+
+      // ── Step 1: register RECOVER_NICK with the REAL NickServ, then free it ──
+      const registrar = await IrcPeer.connect({ nick: RECOVER_NICK });
+      peers.push(registrar);
+      await registrar.nickservRegister(RECOVER_PASSWORD, REG_EMAIL);
+      const mail = await awaitMail(REG_EMAIL, { timeoutMs: 45_000 });
+      const code = extractFromMail(mail, AUTH_CODE_RE);
+      await registrar.nickservAuth(code); // → +r on the registrar
+      await registrar.disconnect("free the nick for the visitor"); // nick FREE, still REGISTERED
+      peers.pop();
+
+      // ── Step 2: visitor logs in WITH the password → connects free → +r → commit ──
+      visitor = await loginVisitor(RECOVER_NICK, RECOVER_PASSWORD, NETWORK_SLUG);
+      // The +r commit persists the :nickserv_identify credential → recoverable.
+      await waitForRecoverable(visitor.token, NETWORK_SLUG, true);
+
+      const booted = await bootVisitor(browser, visitor);
+      ctx = booted.ctx;
+      const page = booted.page;
+
+      // Button HIDDEN while the visitor is +r (identified) — canRecover's !+r half.
+      await page.locator(".sidebar-home-btn").click();
+      await expect(page.getByTestId(`home-recover-identity-${NETWORK_SLUG}`)).toHaveCount(0);
+
+      // ── Step 3: voluntary /nick to a free Guest (from $server) → +r cleared ──
+      // Reaches POST-001, connected, non-+r (the manual-recover scenario) WITHOUT
+      // a reconnect (which auto-ghost would reclaim PRE-001). bahamut strips +r
+      // silently on the rename; the EventRouter fix mirrors it so cic's
+      // canRecover() flips true. The credential is :nickserv_identify, so its
+      // nick is HELD at RECOVER_NICK (update_visitor_credential_nick is
+      // anon-gated → :held_identified) — recover still targets RECOVER_NICK.
+      await selectChannel(page, NETWORK_SLUG, "Server", { awaitWsReady: false });
+      await composeSend(page, `/nick ${guestNick}`);
+
+      // Button REAPPEARS now that the visitor is no longer +r (on a Guest) and
+      // the credential is still recoverable — the POST-001 barrier.
+      await page.locator(".sidebar-home-btn").click();
+      const recoverBtn = page.getByTestId(`home-recover-identity-${NETWORK_SLUG}`);
+      await expect(recoverBtn).toBeVisible({ timeout: 30_000 });
+
+      // ── Step 4: IrcPeer takes + IDENTIFYs RECOVER_NICK (now free) → 433 on recover ──
+      const holder = await IrcPeer.connect({ nick: RECOVER_NICK });
+      peers.push(holder);
+      await holder.nickservIdentify(RECOVER_PASSWORD);
+
+      // ── Step 5: 🔑 Recover → NICK(433) → RECOVER frees the hold → +r → SUCCESS ──
+      await recoverBtn.click();
+
+      const modal = page.getByTestId("recover-modal");
+      await expect(modal).toBeVisible({ timeout: 10_000 });
+
+      // Visible progress: the recover step reaches ok at least once (the modal
+      // accumulates server-pushed steps; the recover verb is the reclaim path).
+      await expect(
+        modal.locator('[data-testid="recover-modal-step"][data-step="recover"]'),
+      ).toBeVisible({ timeout: 20_000 });
+
+      // THE SHIP GATE (D4): the VISIBLE terminal success — the nick genuinely
+      // reached `+r` after RECOVER freed the holder. No API return, no
+      // success-or-failure soft-assert.
+      await expect(page.getByTestId("recover-modal-success")).toBeVisible({ timeout: 30_000 });
+    } finally {
+      for (const peer of peers) await peer.disconnect("e2e cleanup").catch(() => {});
+      if (ctx) await ctx.close();
+      await reapVisitors(admin.token, visitor?.id);
+    }
+  });
+});

--- a/cicchetto/src/HomePane.tsx
+++ b/cicchetto/src/HomePane.tsx
@@ -24,7 +24,7 @@ import { flavorForSlug, registerableFlavor } from "./lib/registrationTemplates";
 import { openRegistrationWizard } from "./lib/registrationWizard";
 import { setSelectedChannel } from "./lib/selection";
 import { openShareModal } from "./lib/shareModal";
-import { pushLinks } from "./lib/socket";
+import { pushLinks, pushRecover } from "./lib/socket";
 import { umodesForNetwork } from "./lib/umodes";
 import { confirmDisconnectNetwork } from "./lib/windowClose";
 import { LIST_WINDOW_NAME, SERVER_WINDOW_NAME } from "./lib/windowKinds";
@@ -263,6 +263,9 @@ type HomeRow = {
   connection_state: ConnectionState;
   connection_state_reason: string | null;
   connection_state_changed_at: string | null;
+  // #581 (D2) — the credential carries a NickServ secret, so /recover has
+  // something to identify with. Drives the "Recover identity" CTA.
+  recoverable: boolean;
 };
 
 const ConnectedRow: Component<{ row: HomeRow }> = (props) => {
@@ -320,6 +323,28 @@ const ConnectedRow: Component<{ row: HomeRow }> = (props) => {
     const umodes = id === undefined ? [] : umodesForNetwork(id);
     return !umodes.includes("r");
   };
+  // #581 — the "Recover identity" launcher, sibling of canRegister(): shown
+  // when (a) the credential carries a NickServ secret (`recoverable`, D2),
+  // (b) this is a VISITOR session (recover is visitor-only server-side — a
+  // user seeing it would only earn a `forbidden`), and (c) we're NOT already
+  // identified (no live +r umode). All reactive, so the button auto-hides the
+  // instant recovery lands the +r flip. Mirrors canRegister's undefined-id
+  // "no umodes seeded yet" tolerance (button shows).
+  const canRecover = () => {
+    if (!props.row.recoverable) return false;
+    if (!isVisitorSubject()) return false;
+    const id = networkIdBySlug(props.row.slug);
+    const umodes = id === undefined ? [] : umodesForNetwork(id);
+    return !umodes.includes("r");
+  };
+  // Fire-and-forget like onTopology: the RecoverModal opens off the SERVER's
+  // first recover_progress event (cic never originates state), and the
+  // canonical error-surfacing door is the /recover slash command — a rejected
+  // push just leaves the modal unopened rather than crashing the row.
+  const onRecover = () => {
+    const id = networkIdBySlug(props.row.slug);
+    if (id !== undefined) void pushRecover(id).catch(() => {});
+  };
   // #529 — the connected-row layout: a horizontal rule opens each network
   // block; the heading carries the network title (slug + nick, clickable →
   // jump-to-$server) on the left and a STATUS group (state label + the
@@ -372,6 +397,18 @@ const ConnectedRow: Component<{ row: HomeRow }> = (props) => {
             onClick={() => openRegistrationWizard(props.row.slug)}
           >
             📝 Register nick
+          </button>
+        </Show>
+        <Show when={canRecover()}>
+          {/* #581 — same button set (equal weight) as Browse / Register;
+              identified in tests by its data-testid. */}
+          <button
+            type="button"
+            class="home-pane-network-browse"
+            data-testid={`home-recover-identity-${props.row.slug}`}
+            onClick={onRecover}
+          >
+            🔑 Recover identity
           </button>
         </Show>
       </div>

--- a/cicchetto/src/RecoverModal.tsx
+++ b/cicchetto/src/RecoverModal.tsx
@@ -1,0 +1,167 @@
+import { type Component, For, Match, Show, Switch } from "solid-js";
+import type { RecoverStatus, RecoverStep } from "./lib/api";
+import { createOverlayLock } from "./lib/overlayScrollLock";
+import { dismissRecover, recoverState } from "./lib/recoverProgress";
+
+// #581 — "recover my identity" progress modal. Server-driven: opens off the
+// first `recover_progress` user-topic event (recoverProgress.ts store), lists
+// each recovery step with a running / ok / failed indicator, and shows the
+// terminal success or failure state. cic NEVER originates recovery state — it
+// mirrors the server's step + result events; there is no client-side progress
+// guess, no optimistic success.
+//
+// NO retry button: a failure is TERMINAL (the reason is shown and the flow
+// stops — the user re-issues /recover to try again). Success shows a clear
+// success line; the user dismisses (× / backdrop / Esc). Mirrors the proven
+// RegistrationWizardModal / ServiceModal shell (backdrop scrim + role=dialog +
+// createOverlayLock).
+//
+// data-testid="recover-modal" + per-step data-step / data-status attributes so
+// an e2e can assert the visible outcome (each step's state + the final result).
+//
+// Mounted once per Shell branch (mobile + desktop); only one branch is live,
+// so a single instance exists.
+
+// Per-step human copy. cic owns the localized strings
+// (`feedback_no_localized_strings_server_side`); the server ships the closed
+// `step` atom only.
+const STEP_LABEL: Record<RecoverStep, string> = {
+  identify: "Identifying to services",
+  // review-#4: on the recover (re-identify) path the server emits `register`
+  // as the FINAL "+r confirmed" step (recover_progress_steps/:succeeded), NOT
+  // a fresh registration — so "Identity confirmed", not "Registering your nick".
+  register: "Identity confirmed",
+  nick: "Reclaiming your nick",
+  recover: "Recovering your nick",
+  release: "Releasing the held nick",
+};
+
+// Status indicator glyph. Running = a spinner-ish ellipsis; ok/failed are the
+// terminal per-step marks. Also exposed as data-status for e2e assertion.
+const STATUS_GLYPH: Record<RecoverStatus, string> = {
+  running: "…",
+  ok: "✓",
+  failed: "✗",
+};
+
+// Map the known terminal failure reason tokens to friendly copy; anything else
+// (a future server reason token, additive-only) falls back to generic copy —
+// the friendlyChannelError posture (known → copy, unknown → fallback), never a
+// dropped/blank failure.
+function reasonCopy(reason: string | null): string {
+  switch (reason) {
+    case "wrong_password":
+      return "The password didn't match — recovery was refused.";
+    case "nick_unavailable":
+      return "Your nick isn't available to recover right now.";
+    case "services_declined":
+      return "The network's services declined the recovery.";
+    default:
+      return "Recovery couldn't be completed. Try again.";
+  }
+}
+
+const RecoverModal: Component = () => {
+  const state = () => recoverState();
+  const close = (): void => dismissRecover();
+
+  // Refcounted overlay scroll-lock + shared Esc-to-close (topmost-first), same
+  // wiring as ServiceModal / RegistrationWizardModal. onEscape MUST equal the
+  // ×/backdrop close verb. A new pane-covering modal MUST push the overlay
+  // refcount or the iOS scroll-freeze mis-counts.
+  createOverlayLock(() => state() !== null, ".recover-modal-body", close);
+
+  return (
+    <Show when={state()}>
+      {(st) => (
+        // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
+        // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
+        <div class="recover-modal-backdrop" onClick={close}>
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="recover-modal-title"
+            class="recover-modal"
+            data-testid="recover-modal"
+            data-network={st().networkSlug}
+            data-outcome={st().outcome ?? "running"}
+            onClick={(e) => e.stopPropagation()}
+            tabIndex={-1}
+          >
+            <header class="recover-modal-header">
+              <h2 id="recover-modal-title">
+                <span class="recover-modal-sigil" aria-hidden="true">
+                  🔑
+                </span>
+                Recover your identity
+              </h2>
+              <button type="button" class="recover-modal-close" aria-label="close" onClick={close}>
+                ×
+              </button>
+            </header>
+
+            <div class="recover-modal-body">
+              <p class="recover-modal-copy muted">
+                Recovering your registered identity on <b>{st().networkSlug}</b>.
+              </p>
+
+              <ul class="recover-modal-steps">
+                <For each={st().steps}>
+                  {(s) => (
+                    <li
+                      class="recover-modal-step"
+                      classList={{
+                        "is-running": s.status === "running",
+                        "is-ok": s.status === "ok",
+                        "is-failed": s.status === "failed",
+                      }}
+                      data-testid="recover-modal-step"
+                      data-step={s.step}
+                      data-status={s.status}
+                    >
+                      <span class="recover-modal-step-glyph" aria-hidden="true">
+                        {STATUS_GLYPH[s.status]}
+                      </span>
+                      <span class="recover-modal-step-label">{STEP_LABEL[s.step]}</span>
+                    </li>
+                  )}
+                </For>
+              </ul>
+
+              <Switch>
+                <Match when={st().outcome === "succeeded"}>
+                  <p
+                    class="recover-modal-success"
+                    data-testid="recover-modal-success"
+                    role="status"
+                  >
+                    🎉 Your identity is recovered on {st().networkSlug}!
+                  </p>
+                </Match>
+                <Match when={st().outcome === "failed"}>
+                  <p class="recover-modal-failure" data-testid="recover-modal-failure" role="alert">
+                    {reasonCopy(st().reason)}
+                  </p>
+                </Match>
+              </Switch>
+            </div>
+
+            <footer class="recover-modal-footer">
+              <button
+                type="button"
+                class="recover-modal-dismiss"
+                data-testid="recover-modal-dismiss"
+                onClick={close}
+              >
+                {st().outcome === null ? "Close" : "Done"}
+              </button>
+            </footer>
+          </div>
+        </div>
+      )}
+    </Show>
+  );
+};
+
+export default RecoverModal;

--- a/cicchetto/src/Shell.tsx
+++ b/cicchetto/src/Shell.tsx
@@ -59,6 +59,7 @@ import PresenceToasts from "./PresenceToasts";
 import PrivacyModal from "./PrivacyModal";
 import RailActions from "./RailActions";
 import RailContext from "./RailContext";
+import RecoverModal from "./RecoverModal";
 import RegistrationWizardModal from "./RegistrationWizardModal";
 import ResizeHandle from "./ResizeHandle";
 import ScrollbackPane from "./ScrollbackPane";
@@ -552,6 +553,7 @@ const Shell: Component = () => {
           <ServerReplyModal />
           <ServiceModal />
           <RegistrationWizardModal />
+          <RecoverModal />
           <ShareSessionModal />
           <ConfirmModal />
           {/* #473 — ArchiveModal is the single archive surface on BOTH form
@@ -800,6 +802,7 @@ const Shell: Component = () => {
         <ServerReplyModal />
         <ServiceModal />
         <RegistrationWizardModal />
+        <RecoverModal />
         <ShareSessionModal />
         <ConfirmModal />
         <Show when={membersOpen()}>

--- a/cicchetto/src/__tests__/HomePane.test.tsx
+++ b/cicchetto/src/__tests__/HomePane.test.tsx
@@ -28,6 +28,10 @@ type HomeNetworkRowLocal = {
   connection_state: "connected" | "parked" | "failed";
   connection_state_reason: string | null;
   connection_state_changed_at: string | null;
+  // #581 (D2) — REQUIRED on the production wire (pinned by wireTypesAssert.ts);
+  // optional here so the many recover-agnostic mock rows omit it (absent →
+  // falsy → "not recoverable", a valid state). The #581 tests set it.
+  recoverable?: boolean;
 };
 type HomeDataLocal = {
   networks: HomeNetworkRowLocal[];
@@ -81,6 +85,9 @@ const openShareModalMock = vi.fn<() => void>();
 const pushLinksMock = vi.fn<(id: number, mask: string | null) => Promise<void>>(() =>
   Promise.resolve(),
 );
+// #581 — ConnectedRow's 🔑 Recover identity button pushes the recover verb.
+// Same socket-boundary mock rationale as pushLinks.
+const pushRecoverMock = vi.fn<(id: number) => Promise<void>>(() => Promise.resolve());
 
 vi.mock("../lib/home", () => ({
   homeData: () => homeDataMock(),
@@ -151,6 +158,7 @@ vi.mock("../lib/shareModal", () => ({
 
 vi.mock("../lib/socket", () => ({
   pushLinks: (id: number, mask: string | null) => pushLinksMock(id, mask),
+  pushRecover: (id: number) => pushRecoverMock(id),
 }));
 
 vi.mock("../lib/umodes", () => ({
@@ -199,6 +207,7 @@ describe("HomePane", () => {
     networkIdBySlugMock.mockReturnValue(undefined);
     openShareModalMock.mockClear();
     pushLinksMock.mockClear();
+    pushRecoverMock.mockClear();
   });
 
   afterEach(() => {
@@ -305,6 +314,70 @@ describe("HomePane", () => {
       render(() => <HomePane />);
 
       expect(screen.queryByTestId("home-register-nick-azzurra")).toBeNull();
+    });
+  });
+
+  describe("#581 recover-identity launcher", () => {
+    // A connected row carrying (or not) a recoverable credential (D2 wire flag).
+    const recoverableHome = (slug: string, recoverable: boolean): HomeDataLocal => ({
+      networks: [
+        {
+          slug,
+          nick: "guest",
+          connection_state: "connected",
+          connection_state_reason: null,
+          connection_state_changed_at: null,
+          recoverable,
+        },
+      ],
+      available_networks: [],
+    });
+
+    it("shows the button for a visitor with a recoverable credential and no +r, and pushes recover", async () => {
+      userMock.mockReturnValue({ kind: "visitor", id: "v1", nick: "guest" });
+      homeDataMock.mockReturnValue(recoverableHome("azzurra", true));
+      networkIdBySlugMock.mockReturnValue(7);
+      umodesForNetworkMock.mockReturnValue([]); // not identified yet
+      render(() => <HomePane />);
+
+      const btn = await screen.findByTestId("home-recover-identity-azzurra");
+      expect(btn).toBeInTheDocument();
+      // Paired with Browse in the CTA row, not the heading status area.
+      expect(btn.closest(".home-pane-network-cta")).not.toBeNull();
+      expect(btn.closest(".home-pane-network-status")).toBeNull();
+
+      fireEvent.click(btn);
+      expect(pushRecoverMock).toHaveBeenCalledWith(7);
+    });
+
+    it("hides the button once the +r umode is set (identified)", () => {
+      userMock.mockReturnValue({ kind: "visitor", id: "v1", nick: "guest" });
+      homeDataMock.mockReturnValue(recoverableHome("azzurra", true));
+      networkIdBySlugMock.mockReturnValue(7);
+      umodesForNetworkMock.mockReturnValue(["r"]); // identified → hidden
+      render(() => <HomePane />);
+
+      expect(screen.queryByTestId("home-recover-identity-azzurra")).toBeNull();
+    });
+
+    it("hides the button when the credential is not recoverable (no NickServ secret)", () => {
+      userMock.mockReturnValue({ kind: "visitor", id: "v1", nick: "guest" });
+      homeDataMock.mockReturnValue(recoverableHome("azzurra", false));
+      networkIdBySlugMock.mockReturnValue(7);
+      umodesForNetworkMock.mockReturnValue([]);
+      render(() => <HomePane />);
+
+      expect(screen.queryByTestId("home-recover-identity-azzurra")).toBeNull();
+    });
+
+    it("hides the button for a non-visitor (user) session — recover is visitor-only", () => {
+      userMock.mockReturnValue({ kind: "user", id: "u1", name: "vjt" });
+      homeDataMock.mockReturnValue(recoverableHome("azzurra", true));
+      networkIdBySlugMock.mockReturnValue(7);
+      umodesForNetworkMock.mockReturnValue([]);
+      render(() => <HomePane />);
+
+      expect(screen.queryByTestId("home-recover-identity-azzurra")).toBeNull();
     });
   });
 

--- a/cicchetto/src/__tests__/home.test.ts
+++ b/cicchetto/src/__tests__/home.test.ts
@@ -71,6 +71,7 @@ describe("home.ts (UX-4 bucket B)", () => {
         connection_state: "connected",
         connection_state_reason: null,
         connection_state_changed_at: null,
+        recoverable: false,
       }),
     ).not.toThrow();
   });
@@ -87,6 +88,7 @@ describe("home.ts (UX-4 bucket B)", () => {
         connection_state: "failed",
         connection_state_reason: "permanent k-line",
         connection_state_changed_at: "2026-05-18T12:00:00Z",
+        recoverable: false,
       }),
     ).not.toThrow();
   });

--- a/cicchetto/src/__tests__/recoverProgress.test.ts
+++ b/cicchetto/src/__tests__/recoverProgress.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { WireUserEvent } from "../lib/api";
+import {
+  applyRecoverProgress,
+  applyRecoverResult,
+  dismissRecover,
+  recoverState,
+} from "../lib/recoverProgress";
+
+// #581 — "recover my identity" progress store. Transient (createRoot)
+// singleton holding `{networkSlug, steps, outcome, reason} | null`. The server
+// drives: the FIRST recover_progress OPENS the modal, subsequent ones
+// accumulate/update the step list, recover_result concludes it — and a result
+// on a CLOSED store is dropped (the patch guard, so a dismissed modal is never
+// resurrected). cic NEVER originates recovery state.
+
+const SLUG = "azzurra";
+
+type RecoverStep = "identify" | "register" | "nick" | "recover" | "release";
+type RecoverStatus = "running" | "ok" | "failed";
+
+const progress = (
+  step: RecoverStep,
+  status: RecoverStatus,
+  reason: string | null = null,
+): Extract<WireUserEvent, { kind: "recover_progress" }> => ({
+  kind: "recover_progress",
+  network: SLUG,
+  step,
+  status,
+  reason,
+});
+
+const result = (
+  outcome: "succeeded" | "failed",
+  reason: string | null = null,
+): Extract<WireUserEvent, { kind: "recover_result" }> => ({
+  kind: "recover_result",
+  network: SLUG,
+  outcome,
+  reason,
+});
+
+describe("recoverProgress store (#581)", () => {
+  afterEach(() => dismissRecover());
+
+  it("opens on the first recover_progress event (server drives; cic never originates)", () => {
+    expect(recoverState()).toBeNull();
+    applyRecoverProgress(progress("identify", "running"));
+    expect(recoverState()).toMatchObject({ networkSlug: SLUG, outcome: null, reason: null });
+    expect(recoverState()?.steps).toEqual([{ step: "identify", status: "running", reason: null }]);
+  });
+
+  it("accumulates new steps and updates an existing step in place", () => {
+    applyRecoverProgress(progress("identify", "running"));
+    applyRecoverProgress(progress("identify", "ok")); // same step → update in place
+    applyRecoverProgress(progress("recover", "running")); // new step → append
+    expect(recoverState()?.steps).toEqual([
+      { step: "identify", status: "ok", reason: null },
+      { step: "recover", status: "running", reason: null },
+    ]);
+  });
+
+  it("carries a per-step failure reason", () => {
+    applyRecoverProgress(progress("identify", "failed", "wrong_password"));
+    expect(recoverState()?.steps).toEqual([
+      { step: "identify", status: "failed", reason: "wrong_password" },
+    ]);
+  });
+
+  it("sets the terminal success outcome on recover_result", () => {
+    applyRecoverProgress(progress("identify", "ok"));
+    applyRecoverResult(result("succeeded"));
+    expect(recoverState()?.outcome).toBe("succeeded");
+    expect(recoverState()?.reason).toBeNull();
+  });
+
+  it("sets the terminal failure outcome + reason on recover_result", () => {
+    applyRecoverProgress(progress("identify", "ok"));
+    applyRecoverResult(result("failed", "services_declined"));
+    expect(recoverState()?.outcome).toBe("failed");
+    expect(recoverState()?.reason).toBe("services_declined");
+  });
+
+  it("dismiss clears the state to null", () => {
+    applyRecoverProgress(progress("identify", "running"));
+    dismissRecover();
+    expect(recoverState()).toBeNull();
+  });
+
+  it("recover_result no-ops when closed (patch guard — never resurrects a dismissed modal)", () => {
+    // Closed from the start: a terminal result with no open modal is dropped.
+    applyRecoverResult(result("failed", "wrong_password"));
+    expect(recoverState()).toBeNull();
+
+    // Dismissed mid-flight: a late result must not reopen it.
+    applyRecoverProgress(progress("identify", "running"));
+    dismissRecover();
+    applyRecoverResult(result("succeeded"));
+    expect(recoverState()).toBeNull();
+  });
+
+  it("ignores a progress event for a DIFFERENT network than the open modal (review-#3)", () => {
+    applyRecoverProgress(progress("identify", "running")); // opens for SLUG
+    applyRecoverProgress({ ...progress("recover", "running"), network: "other-net" });
+    // The stray other-network step is NOT mixed into SLUG's modal.
+    expect(recoverState()?.networkSlug).toBe(SLUG);
+    expect(recoverState()?.steps).toEqual([{ step: "identify", status: "running", reason: null }]);
+  });
+
+  it("ignores a recover_result for a different network (review-#3)", () => {
+    applyRecoverProgress(progress("identify", "ok")); // opens for SLUG
+    applyRecoverResult({ ...result("succeeded"), network: "other-net" });
+    // The other-network terminal does NOT conclude SLUG's in-flight modal.
+    expect(recoverState()?.outcome).toBeNull();
+  });
+});

--- a/cicchetto/src/__tests__/slashCommands.test.ts
+++ b/cicchetto/src/__tests__/slashCommands.test.ts
@@ -839,6 +839,24 @@ describe("parseSlash — info verbs (TODO — server-side missing)", () => {
   });
 });
 
+// #581 — /recover [network]: guided "recover my identity". Optional first
+// token is the network slug (bare → current window's network, resolved in
+// compose.ts). Same optional-arg grammar as /links.
+describe("parseSlash — /recover (#581)", () => {
+  it("/recover bare → recover with no network", () => {
+    expect(parseSlash("/recover")).toEqual({ kind: "recover", network: null });
+  });
+
+  it("/recover <network> → recover carrying the network slug", () => {
+    expect(parseSlash("/recover azzurra")).toEqual({ kind: "recover", network: "azzurra" });
+  });
+
+  // Trailing tokens past the first are ignored (recover takes one network arg).
+  it("/recover <network> <extra> → only the first token is the network", () => {
+    expect(parseSlash("/recover azzurra junk")).toEqual({ kind: "recover", network: "azzurra" });
+  });
+});
+
 // #356 — keyword highlight is classic-IRC irssi-shaped now: /hilight
 // canonical, /highlight alias, /dehilight remove. irssi-direct (the whole
 // rest is one pattern, no add/del/list subverb). A BARE form opens the

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -879,6 +879,21 @@ export type LinksEntry = SessionWireLinksEntry;
 // `entries` list is the restricted/hidden-topology signal. NOT persisted.
 export type LinksReply = Omit<SessionWireLinksBundlePayload, "kind">;
 
+// #581 — "recover my identity" guided recovery. Two transient user-topic
+// events (recover_progress / recover_result) drive the RecoverModal progress
+// view. `step` / `status` / `outcome` are closed sets (atoms-in-allowlist,
+// narrowed strictly at ingress — an unknown value drops that one presentational
+// ping). The result `reason` stays a plain `string | null` on the wire arm
+// (NOT hardened to the known token union) so an additive server reason token
+// can never drop a TERMINAL result event (unknown-is-never-fatal, #447) — the
+// modal localizes the known tokens (`wrong_password` / `nick_unavailable` /
+// `services_declined`) and shows generic copy otherwise, the friendlyChannelError
+// posture.
+export type RecoverStep = "identify" | "register" | "nick" | "recover" | "release";
+export type RecoverStatus = "running" | "ok" | "failed";
+export type RecoverOutcome = "succeeded" | "failed";
+export type RecoverResultReason = "wrong_password" | "nick_unavailable" | "services_declined";
+
 // Mirror of the events fanned out on the user-level PubSub topic
 // (`Topic.user(user_name)`), pinned by:
 //   * `Grappa.Session.Wire.{channels_changed/0, own_nick_changed/2,
@@ -1134,6 +1149,26 @@ export type WireUserEvent =
   // transient reconnect; the badge is an ephemeral overlay. Rides the user
   // topic with the `network` slug discriminator (mirrors away_confirmed).
   | { kind: "connection_progress"; network: string; state: "connecting" | "connected" }
+  // #581 — "recover my identity" guided recovery. Two transient user-topic
+  // events, both carrying the network SLUG in `network`. `recover_progress`
+  // is one step transition (identify → register → nick → recover → release,
+  // each running → ok/failed); `recover_result` is the TERMINAL outcome. cic
+  // mirrors them into the RecoverModal progress view (recoverProgress.ts) —
+  // it NEVER originates recovery state; the first progress event opens the
+  // modal, the result event concludes it. `reason` is cic-localized copy.
+  | {
+      kind: "recover_progress";
+      network: string;
+      step: RecoverStep;
+      status: RecoverStatus;
+      reason: string | null;
+    }
+  | {
+      kind: "recover_result";
+      network: string;
+      outcome: RecoverOutcome;
+      reason: string | null;
+    }
   // #247 — /notify presence watch. `notify_list` is the full-list
   // snapshot broadcast on every Grappa.Notify mutation AND pushed on
   // user-topic after-join (same setState contract as

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -55,6 +55,7 @@ import {
   pushNames,
   pushOper,
   pushRaw,
+  pushRecover,
   pushVersion,
   pushWho,
   pushWhois,
@@ -872,6 +873,31 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           const networkId = networkIdBySlug(networkSlug);
           if (networkId === undefined) return { error: "/links: network not found" };
           await pushLinks(networkId, cmd.pattern); // S6 (#364): await verb-ack
+          result = { ok: true };
+          break;
+        }
+        // #581 — /recover [network]: guided "recover my identity". Push on the
+        // user-level channel; the server runs the NickServ recovery sequence and
+        // streams recover_progress / recover_result events on the user topic
+        // (RecoverModal mirrors them). The modal opens off the SERVER's first
+        // recover_progress — NOT optimistically here (cic never originates
+        // state). Bare /recover uses the active window's network. A rejection
+        // (nothing_to_recover / already_identified / not_visitor) maps to
+        // friendly copy; anything else (no_session, WS-down) delegates to the
+        // shared friendlyError catch.
+        case "recover": {
+          const targetSlug = cmd.network ?? networkSlug;
+          const networkId = networkIdBySlug(targetSlug);
+          if (networkId === undefined) return { error: "/recover: network not found" };
+          try {
+            await pushRecover(networkId);
+          } catch (e) {
+            // #581 — the recover rejection tokens (nothing_to_recover /
+            // already_identified / recovery_in_progress / forbidden) are now
+            // in the generated channel-error union, so `friendlyError` →
+            // `friendlyChannelError` owns the copy. No local bridge needed.
+            return { error: friendlyError(e) };
+          }
           result = { ok: true };
           break;
         }

--- a/cicchetto/src/lib/friendlyChannelError.ts
+++ b/cicchetto/src/lib/friendlyChannelError.ts
@@ -146,6 +146,22 @@ function friendlyKnown(code: ErrorTokensChannelErrorToken): string {
     case "close_failed":
       return "Couldn't close that conversation. Try again.";
 
+    // ── #581 — /recover ("recover my identity") push rejections. The
+    //    visitor-only guard emits the shared `forbidden` token (handled
+    //    above), so only these three are recover-specific.
+    case "nothing_to_recover":
+      // The visitor has no recoverable credential (no stored NickServ
+      // secret) — `handle_call(:recover_identity)` never blind-IDENTIFYs
+      // (#561 pt3). Also the unconditional "nothing to do" outcome.
+      return "There's nothing to recover — no saved identity on this network.";
+    case "already_identified":
+      // The session already holds `+r`, so there's nothing to reclaim.
+      return "You're already identified on this network.";
+    case "recovery_in_progress":
+      // A recover sequence is already armed for this session (one FSM per
+      // session — `{:error, :in_progress}`).
+      return "Identity recovery is already in progress.";
+
     default:
       // Exhaustiveness: adding a token to the generated union without a
       // `case` arm narrows `code` to `never` only when every member is

--- a/cicchetto/src/lib/homeSessionCopy.test.ts
+++ b/cicchetto/src/lib/homeSessionCopy.test.ts
@@ -45,6 +45,7 @@ function row(slug: string, nick: string): HomeNetworkRow {
     connection_state: "connected",
     connection_state_reason: null,
     connection_state_changed_at: null,
+    recoverable: false,
   };
 }
 

--- a/cicchetto/src/lib/recoverProgress.ts
+++ b/cicchetto/src/lib/recoverProgress.ts
@@ -1,0 +1,115 @@
+import { createRoot, createSignal } from "solid-js";
+import type { RecoverOutcome, RecoverStatus, RecoverStep, WireUserEvent } from "./api";
+
+// #581 — "recover my identity" progress store.
+//
+// Holds the whole recovery's transient state — or `null` when closed. The
+// server drives a short sequence of steps (identify → register → nick →
+// recover → release), each transitioning running → ok/failed, then a single
+// TERMINAL result (succeeded / failed). cic mirrors the server-pushed events
+// into this store; the RecoverModal renders it.
+//
+// cic NEVER originates recovery state (CLAUDE.md hard invariant): there is no
+// optimistic open, no client-side step machine, no success/failure guessed
+// from anything cic computes. The FIRST `recover_progress` event OPENS the
+// modal; subsequent progress events accumulate/update the step list; the
+// `recover_result` event concludes it. `patch` no-ops when closed EXCEPT the
+// opening event — a `recover_result` (or a late progress update) that lands
+// after the user dismissed the modal MUST NOT resurrect it.
+//
+// Module-singleton signal (like serviceModal / registrationWizard) — transient
+// UI, not identity-scoped survival state. A logout unmounts the shell so a
+// stale-open modal disappears with it.
+//
+// A `recover_result` arriving while CLOSED is dropped (patch no-op): either the
+// user dismissed mid-flight (don't reopen a modal they closed) or the progress
+// events were never seen this session (nothing to conclude). The dominant path
+// — progress-then-result on a modal the user just opened via /recover — is
+// unaffected.
+
+export type RecoverStepEntry = {
+  step: RecoverStep;
+  status: RecoverStatus;
+  reason: string | null;
+};
+
+export type RecoverState = {
+  networkSlug: string;
+  // Steps in server-arrival order; each `step` appears once (later events for
+  // the same step UPDATE it in place — a running row flips to ok/failed).
+  steps: RecoverStepEntry[];
+  // null while in flight; set by the terminal `recover_result` event.
+  outcome: RecoverOutcome | null;
+  // The failure reason token (cic-localized in RecoverModal), or null.
+  reason: string | null;
+};
+
+type RecoverProgressEvent = Extract<WireUserEvent, { kind: "recover_progress" }>;
+type RecoverResultEvent = Extract<WireUserEvent, { kind: "recover_result" }>;
+
+// Upsert a step by name: update the existing row in place, else append. Keeps
+// each step to a single row so a running → ok/failed transition replaces rather
+// than duplicating (the modal renders one row per step).
+function upsertStep(steps: RecoverStepEntry[], evt: RecoverProgressEvent): RecoverStepEntry[] {
+  const entry: RecoverStepEntry = { step: evt.step, status: evt.status, reason: evt.reason };
+  const idx = steps.findIndex((s) => s.step === evt.step);
+  if (idx === -1) return [...steps, entry];
+  const next = steps.slice();
+  next[idx] = entry;
+  return next;
+}
+
+const exports_ = createRoot(() => {
+  const [recoverState, setRecoverState] = createSignal<RecoverState | null>(null);
+
+  // Apply `fn` to the current open state; no-op when closed (a late event must
+  // not resurrect a dismissed modal). The opening event (first progress)
+  // bypasses this via setRecoverState directly.
+  const patch = (fn: (st: RecoverState) => RecoverState): void => {
+    setRecoverState((prev) => (prev === null ? null : fn(prev)));
+  };
+
+  // First `recover_progress` OPENS the modal (the sole cic-originated
+  // transition: presence of the modal mirrors the server sending recover
+  // events); subsequent events accumulate/update the step list.
+  const applyRecoverProgress = (evt: RecoverProgressEvent): void => {
+    setRecoverState((prev) => {
+      // The first progress OPENS the modal for its network.
+      if (prev === null) {
+        return {
+          networkSlug: evt.network,
+          steps: [{ step: evt.step, status: evt.status, reason: evt.reason }],
+          outcome: null,
+          reason: null,
+        };
+      }
+      // Per-network isolation (review-#3): an event for a DIFFERENT network
+      // than the open modal is not ours to apply — a multi-network visitor
+      // could have a recover in flight on network A while a stray B event
+      // lands. Ignore it rather than mix two networks' steps into one modal.
+      if (evt.network !== prev.networkSlug) return prev;
+      return { ...prev, steps: upsertStep(prev.steps, evt) };
+    });
+  };
+
+  // Terminal outcome. Routed through `patch` so it no-ops when the modal is
+  // closed (dismissed mid-flight, or never opened this session). The
+  // per-network guard mirrors applyRecoverProgress: only the open modal's OWN
+  // network concludes it (review-#3).
+  const applyRecoverResult = (evt: RecoverResultEvent): void => {
+    patch((st) =>
+      evt.network === st.networkSlug ? { ...st, outcome: evt.outcome, reason: evt.reason } : st,
+    );
+  };
+
+  const dismissRecover = (): void => {
+    setRecoverState(null);
+  };
+
+  return { recoverState, applyRecoverProgress, applyRecoverResult, dismissRecover };
+});
+
+export const recoverState = exports_.recoverState;
+export const applyRecoverProgress = exports_.applyRecoverProgress;
+export const applyRecoverResult = exports_.applyRecoverResult;
+export const dismissRecover = exports_.dismissRecover;

--- a/cicchetto/src/lib/slashCommands.ts
+++ b/cicchetto/src/lib/slashCommands.ts
@@ -155,6 +155,10 @@ export type SlashCommand =
   | { kind: "names"; target: string | null }
   | { kind: "list"; pattern: string | null }
   | { kind: "links"; pattern: string | null }
+  // #581 — /recover [network]: guided "recover my identity" (NickServ). The
+  // optional first token is the network slug (bare → the active window's
+  // network, resolved in compose.ts). Same optional-arg grammar as /links.
+  | { kind: "recover"; network: string | null }
   | { kind: "lusers" }
   | { kind: "info" }
   | { kind: "version" }
@@ -561,6 +565,14 @@ const DISPATCH: Readonly<Record<string, Handler>> = {
   links: (_verb, rest) => {
     const [pattern] = tokens(rest);
     return { kind: "links", pattern: pattern ?? null };
+  },
+
+  // #581 — /recover [network]. First token = optional network slug (bare →
+  // current window's network, resolved in compose.ts). Same optional-arg shape
+  // as /links; trailing tokens are ignored.
+  recover: (_verb, rest) => {
+    const [network] = tokens(rest);
+    return { kind: "recover", network: network ?? null };
   },
 
   lusers: (_verb, _rest) => ({ kind: "lusers" }),

--- a/cicchetto/src/lib/socket.ts
+++ b/cicchetto/src/lib/socket.ts
@@ -742,6 +742,18 @@ export function pushLinks(networkId: number, mask: string | null): Promise<void>
   );
 }
 
+// #581 — /recover. Push on the user-level channel; the server runs the guided
+// NickServ recovery sequence and streams `recover_progress` / `recover_result`
+// events back on the user topic (RecoverModal mirrors them). The Promise
+// resolves once the verb is ACCEPTED (validation + kickoff); the modal opens
+// off the first `recover_progress`, NOT this resolve — so the arm does NOT open
+// optimistically. A server rejection (`nothing_to_recover` / `already_identified`
+// / `not_visitor`, or a WS-down) rejects with a typed `ChannelPushError` the
+// compose arm maps to friendly copy. Mirror of pushLinks/pushLusers.
+export function pushRecover(networkId: number): Promise<void> {
+  return pushUserChannelVerb("recover", { network_id: networkId });
+}
+
 // #140 — /names <#channel>. Pushes on the user-level channel; server
 // primes names_pending + emits NAMES upstream. The 353/366 burst drains
 // into ONE ephemeral `names_reply` event on the user topic (NamesModal

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -39,6 +39,7 @@ import { setPeerAway } from "./peerAway";
 import { type QueryWindow, setQueryWindowsByNetwork } from "./queryWindows";
 import { clearSeen } from "./reconnectBackfill";
 import { setReconnecting } from "./reconnectingStatus";
+import { applyRecoverProgress, applyRecoverResult } from "./recoverProgress";
 import { purgeScrollback } from "./scrollback";
 import { selectedChannel, setSelectedChannel } from "./selection";
 import { setServerReply } from "./serverReplyModal";
@@ -517,6 +518,11 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
           connection_state: n.connection_state,
           connection_state_reason: n.connection_state_reason as string | null,
           connection_state_changed_at: n.connection_state_changed_at as string | null,
+          // #581 (D2) — additive field. NOT in the reject-guard above: a
+          // missing additive field must never be fatal (client-protocol
+          // invariant), so tolerate absence with a `false` default rather
+          // than dropping the whole connection_state_changed update.
+          recoverable: typeof n.recoverable === "boolean" ? n.recoverable : false,
         },
       };
     }
@@ -863,6 +869,46 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
     case "directory_failed":
       if (typeof r.network !== "string" || typeof r.reason !== "string") return null;
       return { kind: "directory_failed", network: r.network, reason: r.reason };
+    case "recover_progress":
+      // #581 — one recovery-step transition. `step` + `status` are closed
+      // sets, narrowed strictly (an unknown value drops this ONE presentational
+      // ping, not the terminal result). `reason` is a nullable string (cic
+      // localizes it in RecoverModal).
+      if (
+        typeof r.network !== "string" ||
+        (r.step !== "identify" &&
+          r.step !== "register" &&
+          r.step !== "nick" &&
+          r.step !== "recover" &&
+          r.step !== "release") ||
+        (r.status !== "running" && r.status !== "ok" && r.status !== "failed") ||
+        (r.reason !== null && typeof r.reason !== "string")
+      )
+        return null;
+      return {
+        kind: "recover_progress",
+        network: r.network,
+        step: r.step,
+        status: r.status,
+        reason: r.reason as string | null,
+      };
+    case "recover_result":
+      // #581 — terminal recovery outcome. `outcome` is a closed binary. `reason`
+      // stays a nullable string (NOT hardened to the known token union) so an
+      // additive server reason token can never drop a terminal result event
+      // (unknown-is-never-fatal, #447); RecoverModal localizes the known tokens.
+      if (
+        typeof r.network !== "string" ||
+        (r.outcome !== "succeeded" && r.outcome !== "failed") ||
+        (r.reason !== null && typeof r.reason !== "string")
+      )
+        return null;
+      return {
+        kind: "recover_result",
+        network: r.network,
+        outcome: r.outcome,
+        reason: r.reason as string | null,
+      };
     default:
       return null;
   }
@@ -1380,6 +1426,21 @@ createRoot(() => {
           // NickServ IDENTIFY (auth_method :nickserv_identify) reads
           // identified="no" until the next natural refetch — not chased here.
           if (payload.state === "connected") refetchNetworks();
+          return;
+
+        case "recover_progress":
+          // #581 — mirror one recovery-step transition into the RecoverModal
+          // progress store. The FIRST progress event OPENS the modal (cic never
+          // originates state — the server drives); later ones accumulate/update
+          // the step list.
+          applyRecoverProgress(payload);
+          return;
+
+        case "recover_result":
+          // #581 — terminal recovery outcome. No-ops when the modal is closed
+          // (dismissed mid-flight / never opened this session — store patch
+          // guard); otherwise sets the success/failure conclusion.
+          applyRecoverResult(payload);
           return;
 
         // #247 — /notify watch list + presence. Full-list snapshot

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -618,6 +618,7 @@ export type NetworksWireHomeNetworkRow = {
   connection_state: NetworksCredentialConnectionState;
   connection_state_reason: string | null;
   connection_state_changed_at: string | null;
+  recoverable: boolean;
 };
 
 export type NetworksWireAvailableNetworkRow = {
@@ -779,6 +780,8 @@ export const SESSION_WIRE_WIRE_EVENT_KIND = [
   "directory_complete",
   "directory_failed",
   "connection_progress",
+  "recover_progress",
+  "recover_result",
   "presence_changed",
   "presence_error",
   "presence_snapshot",
@@ -1117,6 +1120,43 @@ export type SessionWireConnectionProgressPayload = {
   state: "connecting" | "connected";
 };
 
+export const SESSION_WIRE_RECOVER_STEP = [
+  "identify",
+  "register",
+  "nick",
+  "recover",
+  "release",
+] as const;
+export type SessionWireRecoverStep = (typeof SESSION_WIRE_RECOVER_STEP)[number];
+
+export const SESSION_WIRE_RECOVER_STATUS = ["running", "ok", "failed"] as const;
+export type SessionWireRecoverStatus = (typeof SESSION_WIRE_RECOVER_STATUS)[number];
+
+export const SESSION_WIRE_RECOVER_REASON = [
+  "wrong_password",
+  "nick_unavailable",
+  "services_declined",
+] as const;
+export type SessionWireRecoverReason = (typeof SESSION_WIRE_RECOVER_REASON)[number];
+
+export type SessionWireRecoverProgressPayload = {
+  kind: "recover_progress";
+  network: string;
+  step: SessionWireRecoverStep;
+  status: SessionWireRecoverStatus;
+  reason: SessionWireRecoverReason | null;
+};
+
+export const SESSION_WIRE_RECOVER_OUTCOME = ["succeeded", "failed"] as const;
+export type SessionWireRecoverOutcome = (typeof SESSION_WIRE_RECOVER_OUTCOME)[number];
+
+export type SessionWireRecoverResultPayload = {
+  kind: "recover_result";
+  network: string;
+  outcome: SessionWireRecoverOutcome;
+  reason: SessionWireRecoverReason | null;
+};
+
 export type WireSessionEvent =
   | SessionWireChannelsChangedPayload
   | SessionWireOwnNickChangedPayload
@@ -1150,7 +1190,9 @@ export type WireSessionEvent =
   | SessionWireDirectoryProgressPayload
   | SessionWireDirectoryCompletePayload
   | SessionWireDirectoryFailedPayload
-  | SessionWireConnectionProgressPayload;
+  | SessionWireConnectionProgressPayload
+  | SessionWireRecoverProgressPayload
+  | SessionWireRecoverResultPayload;
 
 // === Grappa.SessionLog.Wire ===
 
@@ -1364,5 +1406,8 @@ export const ERROR_TOKENS_CHANNEL_ERROR_TOKEN = [
   "persist_failed",
   "invalid_channel",
   "links_in_flight",
+  "nothing_to_recover",
+  "already_identified",
+  "recovery_in_progress",
 ] as const;
 export type ErrorTokensChannelErrorToken = (typeof ERROR_TOKENS_CHANNEL_ERROR_TOKEN)[number];

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -6905,6 +6905,176 @@ html.resize-dragging * {
   color: var(--accent);
 }
 
+/* #581 — "recover my identity" progress modal. Server-driven step list +
+ * terminal outcome. Mirrors the registration-wizard / service-modal shell. */
+.recover-modal-backdrop {
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: var(--viewport-height, 100dvh);
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: max(1rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom)) 1rem;
+}
+
+.recover-modal {
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  width: 100%;
+  max-width: 30rem;
+  max-height: min(var(--viewport-height, 100dvh), 100%);
+  display: flex;
+  flex-direction: column;
+  font-family: var(--font-mono);
+  font-size: var(--font-size);
+  overflow: hidden;
+  box-shadow:
+    inset 0 0 0 1px var(--bg),
+    inset 0 0 0 2px var(--border);
+}
+
+.recover-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+  padding: 0.75rem 1rem;
+  flex: 0 0 auto;
+}
+
+.recover-modal-header h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: normal;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.recover-modal-sigil {
+  margin-right: 0.5rem;
+}
+
+.recover-modal-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: var(--tap-min);
+  min-height: var(--tap-min);
+  margin: -0.6rem -0.5rem -0.6rem 0;
+  padding: 0;
+  background: transparent;
+  color: var(--muted);
+  border: none;
+  font-family: var(--font-mono);
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.recover-modal-close:hover {
+  color: var(--fg);
+}
+
+.recover-modal-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 0.5rem 1rem 0.75rem;
+  touch-action: pan-y;
+  overscroll-behavior: contain;
+  min-height: 6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.recover-modal-copy {
+  margin: 0;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.recover-modal-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.recover-modal-step {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  line-height: 1.4;
+}
+
+.recover-modal-step-glyph {
+  flex: 0 0 auto;
+  width: 1.2em;
+  text-align: center;
+  color: var(--muted);
+}
+
+.recover-modal-step.is-ok .recover-modal-step-glyph {
+  color: var(--accent);
+}
+
+.recover-modal-step.is-failed .recover-modal-step-glyph {
+  color: var(--error, #e06c75);
+}
+
+.recover-modal-step.is-failed .recover-modal-step-label {
+  color: var(--error, #e06c75);
+}
+
+.recover-modal-success {
+  margin: 0;
+  color: var(--accent);
+  font-weight: bold;
+  line-height: 1.4;
+}
+
+.recover-modal-failure {
+  margin: 0;
+  color: var(--error, #e06c75);
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.recover-modal-footer {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.6rem;
+  border-top: 1px solid var(--border);
+  padding: 0.5rem 1rem;
+}
+
+.recover-modal-dismiss {
+  min-height: var(--tap-min);
+  border-radius: 3px;
+  padding: 0.3rem 1rem;
+  font-family: var(--font-mono);
+  font-size: var(--font-size);
+  background: var(--accent);
+  color: var(--bg);
+  border: 1px solid var(--accent);
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.recover-modal-dismiss:hover {
+  background: var(--bg);
+  color: var(--accent);
+}
+
 /* C2 — WHOIS card. Inline ephemeral surface above scrollback when a
  * /whois bundle exists for the active window's network. Single-card
  * stack — replaces in place on each new /whois. */

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -24949,3 +24949,110 @@ pre-empt it. shottino needed no change to match: it keys on the framing and its
 own outstanding-ping table, never on which window the row was filed under, so
 the reply still cards in the window the question was asked from — with a test
 driven at `channel = "$server"` to prove the routing change cannot break it.
+**The lesson, plainly:** a gate that cannot be run is not a gate. Writing "NOT
+RUN LOCALLY — CI is the gate" in a commit message documented the risk without
+reducing it, and the change was pushed to main anyway where the whole team's
+main went red. The correct order is: get the toolchain, run the gate, then
+land.
+---
+
+## 2026-08-01 — #581: "recover my identity" — one action, the +r-only signal, and the state bug the e2e found
+
+**The feature.** A visitor whose registered nick was taken can reclaim it: a
+`/recover` alias and a 🔑 home button are two doors on ONE server action,
+`Session.recover_identity/2`. The sequence, source-verified against bahamut
+(`m_nick.c`, `struct.h`), is `NICK <cred_nick>` + `IDENTIFY <cred_nick> <secret>`
+together → await `+r` = SUCCESS; a `433`→`RECOVER` / `437`→`RELEASE` → settle →
+NICK+IDENTIFY again → `+r` = success / a refused NICK = `nick_unavailable` (no
+retry — RECOVER was chosen precisely because an empty retry never wins the nick);
+a `+r` that never arrives after a clean NICK = `wrong_password`. **The only
+trusted signal is the `+r` umode — never a NickServ notice** (notices are
+per-network folklore the issue bans). Visitor subjects only; the button is gated
+on a recoverable credential existing so it never blind-IDENTIFYs.
+
+**`+r` is per-nick, set only when you IDENTIFY while ON the registered nick.**
+bahamut sets `+r` on `do_identify` only when `sameNick`, and clears it on ANY
+genuine nick change. So during recover, at the moment `+r` lands `state.nick`
+already IS `cred_nick` — the #561 identity-binding assumption ("`state.nick` at
+`+r` is the identified account, never a forced Guest") holds, and no corruption
+is reachable. (A defensive `bind cred_nick when a recover FSM is armed` was kept
+anyway.)
+
+**The recover secret comes from the PERSISTENT credential, not live state.** The
+first cut read `nickserv_secret(state)` (= `nickserv_pass` OR `pending_password`).
+For a real visitor `nickserv_pass` is nil and `pending_password` is one-shot,
+cleared at 001 — so post-001 (the whole point of recover) the action always
+returned `:nothing_to_recover` while the button (reading the persistent
+`password_encrypted`) still showed. Button and action MUST read ONE source:
+`Credential.recover_secret/1` (nickserv_pass OR the `:nickserv_identify`
+password), and `has_nickserv_secret?/1` is now `not is_nil(recover_secret/1)`.
+The action reads the live persistent credential each call via an INJECTED closure
+(`recover_source`, built by `Visitors.SessionPlan`) rather than a state snapshot —
+so a mid-session `SET PASSWORD` rotation is honoured, and, more importantly,
+`Grappa.Session` never grows a static edge to `Grappa.Networks`/`Visitors`
+(that would close the Boundary cycle Visitors→Session already has). This is the
+same injected-closure DI seam as `visitor_committer` / `last_joined_persister` —
+the plan's "read Credentials directly" was a Boundary violation the seam fixes.
+
+**Twin @types must move together.** `Grappa.Session.start_opts()` (session.ex)
+and `Grappa.Session.Server.init_opts()` (server.ex) are twin map types kept in
+sync by contract. Adding `optional(:recover_source)` to `init_opts` but NOT to
+`start_opts` desynced `Visitors.SessionPlan.resolve/2`'s `{:ok, start_opts()}`
+spec: the returned plan map carried a key `start_opts()` didn't declare, so
+Dialyzer proved `resolve/2` could only ever error — a 24-warning cascade across
+every `{:ok, plan}` consumer (bootstrap, operator, both controllers), NONE of
+which #581 touched. The fix is to complete the seam (declare the field in BOTH
+twins), not silence anything. Lesson: any new plan field — especially an injected
+closure — goes in `start_opts` AND `init_opts`, or the resolve spec desyncs.
+
+**Automatic GhostRecovery owns PRE-001; the manual recover owns POST-001.** These
+are disjoint by connection phase, not competitors. `GhostRecovery` fires when a
+held nick earns a `433` BEFORE 001 while `pending_password` is set
+(`server.ex:2876`): grappa auto-does underscore-NICK→GHOST→IDENTIFY→`+r`, so any
+reconnect onto a held nick auto-recovers. The manual 🔑 serves the OTHER case:
+already connected, POST-001, on a non-`+r` nick, the target held — its `433`
+handler (`server.ex:2862`, gated on recover-armed) sits ABOVE the ghost handler.
+This is why a "park → hold the nick → reconnect" e2e staging can NOT surface the
+manual button (auto-ghost reclaims it PRE-001, measured as a 150s timeout); the
+deterministic way to reach POST-001 non-`+r` is a voluntary `/nick` to a Guest.
+
+**The state bug the e2e surfaced: `+r` went stale after a self-NICK.** bahamut
+strips `+r` SILENTLY on a genuine nick change (no `MODE` echo). grappa's
+EventRouter self-NICK handler updated `state.nick` but never recomputed
+`state.umodes`; the umode-refresh query (`MODE <own_nick>`→221) fires ONCE at 001,
+never on a rename; and cic's `own_nick_changed` handler only re-keys the nick, not
+the umode store. So a visitor who `/nick`s away from their registered nick kept a
+PHANTOM `+r` in both grappa's state and cic's store → `canRecover() = recoverable
+&& !"r"` stayed false → the manual button was UNREACHABLE in exactly the POST-001
+scenario it serves. This was a real state-fidelity bug, not an e2e artifact — the
+`/nick` staging just made it deterministic (the manual button DOES work today via
+the auto-ghost-FAILURE path, where grappa never tracked `"r"` that session, but
+that path is not deterministically stageable). Fix: on OUR OWN genuine rename
+(`nick_eq?(old, state.nick) and not nick_eq?(old, new)` — matching bahamut's
+case-insensitive `mycmp`, so a pure case-change is a no-op, per the #373
+rename-vs-fold distinction) drop `"r"` from `state.umodes`, emit `:umode_changed`
++ `session_identity_effects/2` (→ `:lost`). Universally correct — a regular user
+who `/nick`s also loses services identification — and drops ONLY `"r"` (the
+documented invariant), leaving other umodes untouched.
+
+The genuine-rename gate uses the bare `nick_eq?/2` (plain ASCII fold), matching
+bahamut's `mycmp` on `CASEMAPPING=ascii` (all prod) and staying CONSISTENT with
+the four sibling self-NICK detection sites in the same clause — all use bare
+`nick_eq?(old, state.nick)`. Known rfc1459-only niche (out of scope, the same
+class CLAUDE.md documents): on solanum/Libera a national-char *case-change*
+(`foo[1]→foo{1}`) reads as a genuine rename to grappa and would emit a spurious
+`:lost` (cosmetic, self-heals on the next real MODE). Deliberately NOT special-
+cased here — tightening it means moving ALL FIVE self-NICK sites to
+`canonical_target/2` with `casemapping(state)` together (total-consistency rule),
+a separate change on the shared path, not a one-site patch inside #581.
+
+**The e2e is the non-hollow proof.** A first-login anon visitor proves
+`recoverable` genuinely gates (button ABSENT, GET /me `recoverable=false`). The
+positive path registers the nick with real services (mailpit AUTH), logs the
+visitor in to reach `+r` once (persisting the recoverable credential), does a
+voluntary `/nick` to a Guest (clears `+r` — now that the fix mirrors the strip),
+lets an IrcPeer take + IDENTIFY the freed registered nick, then clicks 🔑 and
+asserts the VISIBLE terminal `recover-modal-success` after RECOVER frees the
+hold — no API-return assertion, no success-or-failure soft-assert (D4). A server
+integration test masking a critical behind an unrealistic mock is exactly why the
+happy-path e2e is mandatory: a feature without one is hollow green.

--- a/lib/grappa/hot_reload/long_lived_modules.ex
+++ b/lib/grappa/hot_reload/long_lived_modules.ex
@@ -107,6 +107,7 @@ defmodule Grappa.HotReload.LongLivedModules do
   @state_helpers [
     Grappa.Session.AwayState,
     Grappa.Session.GhostRecovery,
+    Grappa.Session.RecoverIdentity,
     Grappa.Session.WindowState
   ]
 
@@ -133,6 +134,7 @@ defmodule Grappa.HotReload.LongLivedModules do
   @type state_helper ::
           Grappa.Session.AwayState
           | Grappa.Session.GhostRecovery
+          | Grappa.Session.RecoverIdentity
           | Grappa.Session.WindowState
 
   @doc """

--- a/lib/grappa/networks/credential.ex
+++ b/lib/grappa/networks/credential.ex
@@ -784,6 +784,57 @@ defmodule Grappa.Networks.Credential do
   def upstream_nickserv_pass(%__MODULE__{nickserv_pass_encrypted: pw}), do: pw
 
   @doc """
+  GH #581 — the NickServ secret VALUE this credential recovers an identity
+  with, or `nil` when none is on file. The SINGLE SOURCE OF TRUTH for BOTH
+  the `/recover` action (`Session.Server` IDENTIFYs with this value) AND the
+  `recoverable` button gate (`has_nickserv_secret?/1` below is
+  `not is_nil(recover_secret/1)`).
+
+  Mirrors EXACTLY the resolution `Session.Server`'s `nickserv_secret/1`
+  applies, but over the PERSISTENT credential rather than the one-shot
+  session state: the #509 `$nickserv_pass` (the FIRST source, decoupled from
+  `auth_method`) WINS; falling back, a `:nickserv_identify` upstream
+  password. Both must be non-empty — an empty secret is "nothing to identify
+  with" (same `pw != ""` posture as the live gate and
+  `pending_password_from_opts`).
+
+  Reading the PERSISTENT credential is the #581 review-#1 fix: the button
+  read this source (`password_encrypted`, never cleared) while the action
+  read `state.pending_password` (one-shot cleared at 001), so post-connect
+  the action refused a session the button offered. Both now resolve HERE, so
+  they can never diverge.
+  """
+  @spec recover_secret(t()) :: binary() | nil
+  def recover_secret(%__MODULE__{} = cred) do
+    cond do
+      secret_present?(upstream_nickserv_pass(cred)) ->
+        upstream_nickserv_pass(cred)
+
+      cred.auth_method == :nickserv_identify and secret_present?(upstream_password(cred)) ->
+        upstream_password(cred)
+
+      true ->
+        nil
+    end
+  end
+
+  @doc """
+  GH #581 — true iff this credential carries a NickServ secret to recover an
+  identity with, i.e. `recover_secret/1` resolves a value.
+
+  Drives the visitor home row's `recoverable` wire flag (D2) — the
+  "recoverable credential on file" half of the /recover button gate; the
+  "not already `+r`" (and visitor-only) half is applied client-side. Sharing
+  `recover_secret/1` with the action keeps button and action in lockstep BY
+  CONSTRUCTION (one source), closing the review-#1 divergence — the button
+  can never show for a session `/recover` would refuse.
+  """
+  @spec has_nickserv_secret?(t()) :: boolean()
+  def has_nickserv_secret?(%__MODULE__{} = cred), do: not is_nil(recover_secret(cred))
+
+  defp secret_present?(pw), do: is_binary(pw) and pw != ""
+
+  @doc """
   GH #189 — returns the post-Cloak-load plaintext on-connect perform list,
   or `nil` when none is configured. Threaded into the connect plan by
   `Grappa.Networks.SessionPlan.base_plan/6` and expanded at 001 by

--- a/lib/grappa/networks/wire.ex
+++ b/lib/grappa/networks/wire.ex
@@ -189,7 +189,13 @@ defmodule Grappa.Networks.Wire do
           nick: String.t(),
           connection_state: Credential.connection_state(),
           connection_state_reason: String.t() | nil,
-          connection_state_changed_at: String.t() | nil
+          connection_state_changed_at: String.t() | nil,
+          # #581 (D2) — the credential carries a NickServ secret, so the
+          # visitor "recover my identity" action has something to identify
+          # with. The "recoverable credential on file" half of the /recover
+          # button gate; cic ANDs the "not already +r" + visitor-only halves.
+          # Derived (not stored) via `Credential.has_nickserv_secret?/1`.
+          recoverable: boolean()
         }
 
   @typedoc """
@@ -452,7 +458,8 @@ defmodule Grappa.Networks.Wire do
       nick: nick,
       connection_state: cred.connection_state,
       connection_state_reason: cred.connection_state_reason,
-      connection_state_changed_at: WireTime.iso8601_or_nil(cred.connection_state_changed_at)
+      connection_state_changed_at: WireTime.iso8601_or_nil(cred.connection_state_changed_at),
+      recoverable: Credential.has_nickserv_secret?(cred)
     }
   end
 

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -171,6 +171,12 @@ defmodule Grappa.Session do
           optional(:credential_committer) => Server.credential_committer(),
           optional(:registration_committer) => Server.registration_committer(),
           optional(:last_joined_persister) => Server.last_joined_persister(),
+          # #581 — visitor-only /recover secret reader (the visitor plan injects
+          # it; user plans omit it). Twin of the `init_opts` entry in
+          # `Grappa.Session.Server` — MUST stay in sync (a build_plan map with a
+          # key absent here fails `resolve/2`'s `{:ok, start_opts()}` spec →
+          # dialyzer `missing_range` cascade across every resolve consumer).
+          optional(:recover_source) => Server.recover_source(),
           # GH #417 — persist/restore the EXPLICIT away across crash/reconnect
           # (user-only; the visitor plan omits both). Kept in sync with the
           # `Grappa.Session.Server.start_opts/0` twin.
@@ -276,6 +282,34 @@ defmodule Grappa.Session do
     case whereis(subject, network_id) do
       nil -> {:error, :not_connected}
       pid -> GenServer.call(pid, :refresh_directory)
+    end
+  end
+
+  @doc """
+  #581 — starts the visitor "recover my identity" sequence for
+  `(subject, network_id)`: `IDENTIFY` the credential nick → wait for the
+  `+r` umode → `NICK` to it (with a `RECOVER`/`RELEASE` detour if it's
+  held). The ONE action path both `/recover` and the home button ride
+  (A3). Acks immediately; the multi-step outcome arrives asynchronously
+  as `recover_progress`/`recover_result` events on the user topic (A1) —
+  this call never blocks for the sequence.
+
+  Gating (the Server enforces, being the authority on live state):
+  visitor subjects only (`:not_visitor` otherwise); a recoverable
+  credential must exist (`:nothing_to_recover` — never blind-`IDENTIFY`,
+  #561 pt3); an already-`+r` session has nothing to do
+  (`:already_identified`); a concurrent attempt is refused
+  (`:in_progress`). A missing live pid maps to `:not_connected` (same as
+  `refresh_directory/2`: no upstream, nothing to recover against).
+  """
+  @spec recover_identity(subject(), integer()) ::
+          :ok
+          | {:error, :not_connected | :not_visitor | :nothing_to_recover | :already_identified | :in_progress}
+  def recover_identity(subject, network_id)
+      when is_subject(subject) and is_integer(network_id) do
+    case whereis(subject, network_id) do
+      nil -> {:error, :not_connected}
+      pid -> GenServer.call(pid, :recover_identity)
     end
   end
 

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -845,7 +845,14 @@ defmodule Grappa.Session.EventRouter do
         []
       end
 
-    {:cont, new_state, persist_effects ++ self_server_effects ++ visitor_persist_effects ++ peer_rename_effects}
+    # #581 — mirror bahamut's SILENT +r-strip on our own genuine self-rename
+    # (see strip_r_on_self_rename/4) so the per-session umode set stays truthful.
+    {final_state, self_umode_effects} =
+      strip_r_on_self_rename(state, new_state, old_nick, new_nick)
+
+    {:cont, final_state,
+     persist_effects ++
+       self_server_effects ++ visitor_persist_effects ++ peer_rename_effects ++ self_umode_effects}
   end
 
   # Unsolicited TOPIC: a channel operator changed the topic mid-session.
@@ -2810,6 +2817,36 @@ defmodule Grappa.Session.EventRouter do
       "r" in next_umodes and "r" not in prev_umodes -> [{:session_identity_changed, :acquired}]
       "r" in prev_umodes and "r" not in next_umodes -> [{:session_identity_changed, :lost}]
       true -> []
+    end
+  end
+
+  # #581 — bahamut strips +r SILENTLY on a genuine nick change (m_nick.c:
+  # `mycmp(old,new) != 0 → umode &= ~UMODE_r`, no MODE echo — the same invariant
+  # Credentials.bind_identified_visitor_nick/3 documents). Mirror it so a
+  # self-rename leaves `state.umodes` truthful: on OUR OWN genuine rename drop
+  # "r" and emit `:umode_changed` + the identity transition (→ :lost, via
+  # session_identity_effects/2). A pure case-change is NOT a rename (mycmp is
+  # case-insensitive), so gate on `not nick_eq?(old, new)` — the #373
+  # rename-vs-fold distinction. Detection reads the ORIGINAL `state.nick` (the
+  # already-built `new_state.nick` holds the post-rename value); the strip
+  # applies to `new_state`. Without this a visitor who /nick's away from their
+  # registered nick keeps a PHANTOM +r and the #581 recover button
+  # (`canRecover() = recoverable && !"r"`) never appears. Drop ONLY "r" (the
+  # documented invariant), not other umodes; `Map.get`/`Map.put` (never
+  # `%{... | umodes:}`) for the #216 hot-reload contract.
+  @spec strip_r_on_self_rename(state(), state(), String.t(), String.t()) ::
+          {state(), [effect()]}
+  defp strip_r_on_self_rename(state, new_state, old_nick, new_nick) do
+    if nick_eq?(old_nick, state.nick) and not nick_eq?(old_nick, new_nick) do
+      prev_umodes = Map.get(new_state, :umodes, [])
+      next_umodes = prev_umodes -- ["r"]
+
+      changed_effects =
+        if next_umodes != prev_umodes, do: [{:umode_changed, next_umodes}], else: []
+
+      {Map.put(new_state, :umodes, next_umodes), changed_effects ++ session_identity_effects(prev_umodes, next_umodes)}
+    else
+      {new_state, []}
     end
   end
 

--- a/lib/grappa/session/recover_identity.ex
+++ b/lib/grappa/session/recover_identity.ex
@@ -1,0 +1,172 @@
+defmodule Grappa.Session.RecoverIdentity do
+  @moduledoc """
+  Pure FSM: a visitor-triggered "recover my identity" sequence —
+  re-take a registered nick after services parked the session on an
+  unidentified (non-`+r`) nick. Split from #561 point 4 (GH #581).
+
+  A **sibling** to `Grappa.Session.GhostRecovery`, not a generalisation
+  of it (GH #581 architecture ruling A2). GhostRecovery is
+  reconnect-triggered, underscore-first, and NickServ-**NOTICE**-driven;
+  this FSM is user-triggered, targets the credential nick directly, and
+  trusts the `+r` umode ONLY — it never parses a NickServ notice. Shared
+  is the *shape* (pure `step/2` returning `{:cont | :stop, state,
+  [iodata]}`, host owns I/O + timers), not the state machine.
+
+  ## Ordering is SOURCE-VERIFIED, not assumed (GH #581, 2026-07-31)
+
+  `+r` (`UMODE_r`) is a PER-NICK flag — "the nick you are wearing RIGHT
+  NOW is your identified registered nick". bahamut CLEARS it on any
+  genuine nick change (`bahamut/src/m_nick.c:594-602`:
+  `if (mycmp(old, new)) sptr->umode &= ~UMODE_r;`; the ircd's own comment
+  at `include/struct.h:226` says `+r` IS reset on `/nick`, unlike the
+  session `FLAGS_REGISTERED`). Azzurra services `do_identify` emits the
+  `+r` SVSMODE **only when `sameNick`** — identifying for a protected nick
+  while force-renamed to `Guest…` fires a NOTICE but NO `+r`
+  (`docs/DESIGN_NOTES.md` 2026-05-xx). `RECOVER`/`RELEASE` reclaim the nick
+  (password-authenticated) but do NOT set `+r`; the follow-up `IDENTIFY`
+  ON the reclaimed nick is what commits.
+
+  So `+r` cannot arrive while on a Guest nick. You must be ON the
+  credential nick AND `IDENTIFY` (sameNick) to get `+r`. The sequence
+  therefore sends `NICK` and `IDENTIFY` TOGETHER (mirroring
+  `GhostRecovery`'s `:succeeded` `["NICK …", "IDENTIFY …"]` emit) and
+  waits for `+r` as the SUCCESS signal:
+
+  1. `:start` → `NICK <cred_nick>` + `IDENTIFY <cred_nick> <secret>`,
+     transition `:awaiting_r`.
+  2. `:r_observed` (the `+r` umode landed — fed by the host from
+     `EventRouter`'s identity signal, NOT parsed here) → `:succeeded`.
+  3. `{:nick_error, 433}` (nick in use) → `RECOVER`; `{:nick_error, 437}`
+     (services hold) → `RELEASE`; transition `:awaiting_verb_settle`. (The
+     `IDENTIFY` sent in step 1 was a foreign-nick identify — no `+r`, per
+     the sameNick rule; it is harmless and re-sent below.)
+  4. `:settle` (host's short post-verb settle tick) → `NICK <cred_nick>` +
+     `IDENTIFY <cred_nick> <secret>`, transition `:awaiting_final_r`.
+  5. `:r_observed` → `:succeeded`. A refused final `NICK` (`{:nick_error,
+     _}`) is **terminal `:failed`** — F2 (vjt 2026-07-31): an empty retry
+     never wins the nick, which is exactly why the verb is `RECOVER`. No
+     retry loop.
+  6. `:timeout` (host's overall deadline) in any non-terminal phase →
+     `:failed`, phase-appropriate reason (`:wrong_password` if `+r` never
+     came after a clean NICK; `:services_declined` if the verb went
+     unanswered; `:nick_unavailable` if the reclaimed NICK still failed).
+
+  Wire lines carry the credential nick **RAW** — its case is
+  presentation (the key/display/wire split, GH #121/#537). The FSM emits
+  no broadcasts and arms no timers: the host (`Grappa.Session.Server`)
+  owns I/O, the overall deadline, the settle tick, and the progress
+  broadcasts.
+
+  Boundary: inherits the parent `Grappa.Session` boundary — same pattern
+  as sibling submodules `Server`, `EventRouter`, `GhostRecovery`. No `use
+  Boundary` here.
+  """
+
+  defstruct phase: :idle, cred_nick: nil, secret: nil, verb: nil, reason: nil
+
+  @type phase ::
+          :idle
+          | :awaiting_r
+          | :awaiting_verb_settle
+          | :awaiting_final_r
+          | :succeeded
+          | :failed
+
+  @type verb :: :recover | :release | nil
+
+  @type reason :: :wrong_password | :nick_unavailable | :services_declined | nil
+
+  @type input ::
+          :start
+          | :r_observed
+          | {:nick_error, 433 | 437}
+          | :settle
+          | :timeout
+
+  @type t :: %__MODULE__{
+          phase: phase(),
+          cred_nick: String.t() | nil,
+          secret: String.t() | nil,
+          verb: verb(),
+          reason: reason()
+        }
+
+  @doc """
+  Builds an initial FSM pinned to the credential nick to reclaim and the
+  NickServ secret to identify with. Both are required — the host gates on
+  a recoverable credential (a stored NickServ secret) BEFORE building the
+  FSM (#561 pt3: never blind-`IDENTIFY` a nick with no credential).
+  """
+  @spec init(String.t(), String.t()) :: t()
+  def init(cred_nick, secret) when is_binary(cred_nick) and is_binary(secret) do
+    %__MODULE__{phase: :idle, cred_nick: cred_nick, secret: secret}
+  end
+
+  @doc """
+  Drives one semantic input through the FSM. Returns `{:cont, state,
+  [lines]}` to continue or `{:stop, state, [lines]}` at a terminal phase;
+  `lines` are CRLF-framed IRC strings the host must push via
+  `Grappa.IRC.Client.send_line/2` (through `Server.flush_lines/2`, so the
+  outbound `IDENTIFY` still stages the `+r` rendezvous).
+
+  Inputs that don't match the current phase's expected transition are
+  no-ops (`{:cont, state, []}`), including terminal-phase passthrough.
+  """
+  @spec step(t(), input()) :: {:cont, t(), [String.t()]} | {:stop, t(), [String.t()]}
+
+  def step(%__MODULE__{phase: :idle} = s, :start) do
+    {:cont, %{s | phase: :awaiting_r}, take_and_identify(s)}
+  end
+
+  def step(%__MODULE__{phase: :awaiting_r} = s, :r_observed) do
+    {:stop, %{s | phase: :succeeded}, []}
+  end
+
+  def step(%__MODULE__{phase: :awaiting_r, cred_nick: nick, secret: secret} = s, {:nick_error, 433}) do
+    {:cont, %{s | phase: :awaiting_verb_settle, verb: :recover}, ["PRIVMSG NickServ :RECOVER #{nick} #{secret}\r\n"]}
+  end
+
+  def step(%__MODULE__{phase: :awaiting_r, cred_nick: nick, secret: secret} = s, {:nick_error, 437}) do
+    {:cont, %{s | phase: :awaiting_verb_settle, verb: :release}, ["PRIVMSG NickServ :RELEASE #{nick} #{secret}\r\n"]}
+  end
+
+  def step(%__MODULE__{phase: :awaiting_r} = s, :timeout) do
+    # NICK succeeded (else we'd have seen 433/437) but `+r` never came →
+    # the IDENTIFY was rejected → wrong password.
+    {:stop, %{s | phase: :failed, reason: :wrong_password}, []}
+  end
+
+  def step(%__MODULE__{phase: :awaiting_verb_settle} = s, :settle) do
+    {:cont, %{s | phase: :awaiting_final_r}, take_and_identify(s)}
+  end
+
+  def step(%__MODULE__{phase: :awaiting_verb_settle} = s, :timeout) do
+    {:stop, %{s | phase: :failed, reason: :services_declined}, []}
+  end
+
+  def step(%__MODULE__{phase: :awaiting_final_r} = s, :r_observed) do
+    {:stop, %{s | phase: :succeeded}, []}
+  end
+
+  # F2 (vjt 2026-07-31): the post-verb NICK gets ONE shot. A refusal is
+  # TERMINAL — no retry line, no loop. An empty retry never wins the nick.
+  def step(%__MODULE__{phase: :awaiting_final_r} = s, {:nick_error, _}) do
+    {:stop, %{s | phase: :failed, reason: :nick_unavailable}, []}
+  end
+
+  def step(%__MODULE__{phase: :awaiting_final_r} = s, :timeout) do
+    {:stop, %{s | phase: :failed, reason: :nick_unavailable}, []}
+  end
+
+  def step(state, _), do: {:cont, state, []}
+
+  # NICK to the credential nick + IDENTIFY for it, in ONE flush. Order
+  # matters: NICK first so the IDENTIFY that follows is `sameNick` and
+  # thus commits `+r` (mirrors `GhostRecovery`'s `:succeeded` emit). If
+  # the NICK fails, the IDENTIFY is a harmless foreign-nick identify (no
+  # `+r`) and the sequence reclaims off the 433/437.
+  @spec take_and_identify(t()) :: [String.t()]
+  defp take_and_identify(%__MODULE__{cred_nick: nick, secret: secret}) do
+    ["NICK #{nick}\r\n", "PRIVMSG NickServ :IDENTIFY #{nick} #{secret}\r\n"]
+  end
+end

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -110,6 +110,7 @@ defmodule Grappa.Session.Server do
     PerformList,
     Persistor,
     Presence,
+    RecoverIdentity,
     WindowState
   }
 
@@ -148,6 +149,20 @@ defmodule Grappa.Session.Server do
   # are typically sub-second; an 8s ceiling protects against an upstream
   # services outage holding the FSM open indefinitely.
   @ghost_recovery_timeout_ms 8_000
+
+  # #581 — overall deadline for the recover-identity sequence (IDENTIFY →
+  # +r → NICK → RECOVER/RELEASE → settle → NICK). Larger than the ghost
+  # budget: it spans an IDENTIFY round-trip, the +r MODE echo, a NICK, an
+  # optional services verb, the settle tick, and a final NICK. A blown
+  # deadline fails the modal (never hangs it).
+  @recover_timeout_ms 15_000
+
+  # #581 — the post-verb settle tick. After RECOVER/RELEASE, wait this
+  # long before the ONE final NICK (services need a beat to drop the
+  # hold / kill the ghost). This is STEP TIMING, not a retry: a refused
+  # final NICK is terminal (F2). Starting value — if it proves flaky it
+  # is a FINDING to raise, not a number to inflate until green.
+  @recover_settle_ms 800
 
   # #513b — /links in-flight window. A second `:send_links` within this many ms
   # of a still-pending one is REFUSED (rather than clobbering the un-keyed
@@ -327,6 +342,21 @@ defmodule Grappa.Session.Server do
   @type last_joined_persister :: ([String.t()] -> :ok | {:error, term()})
 
   @typedoc """
+  GH #581 — opaque reader the visitor `SessionPlan` injects so
+  `handle_call(:recover_identity, ...)` can resolve the PERSISTENT recover
+  target (the registered nick + NickServ secret) without a static
+  `Session → Networks/Visitors` alias (Boundary cycle — Visitors deps
+  Session via Login). Reads the LIVE credential each call
+  (`Credentials.get_visitor_credential` + `Credential.recover_secret/1`),
+  NOT `state.pending_password` (one-shot cleared at 001) — so it resolves the
+  SAME source as the `recoverable` button gate
+  (`Credential.has_nickserv_secret?/1`), the review-#1 fix. `nil` on state =
+  no reader injected (user sessions — recover is visitor-only).
+  """
+  @type recover_source ::
+          (-> {:ok, {String.t(), String.t()}} | {:error, :nothing_to_recover})
+
+  @typedoc """
   GH #417 — opaque closure that persists the EXPLICIT away snapshot to the
   producing context (Networks), forwarding `(reason, since)` to
   `Grappa.Networks.Credentials.update_away/4`. `(nil, nil)` clears it on
@@ -480,6 +510,9 @@ defmodule Grappa.Session.Server do
           optional(:credential_committer) => credential_committer(),
           optional(:registration_committer) => registration_committer(),
           optional(:last_joined_persister) => last_joined_persister(),
+          # #581 — visitor-only reader for the /recover secret source (user
+          # plans omit it; recover is visitor-only).
+          optional(:recover_source) => recover_source(),
           # GH #417 — persist/restore the EXPLICIT away across crash/reconnect.
           # User-only (visitor plans omit both).
           optional(:away_persister) => away_persister(),
@@ -595,12 +628,21 @@ defmodule Grappa.Session.Server do
           credential_committer: credential_committer() | nil,
           registration_committer: registration_committer() | nil,
           last_joined_persister: last_joined_persister() | nil,
+          # #581 — visitor-only /recover secret reader (nil for user sessions).
+          recover_source: recover_source() | nil,
           # GH #417 — persister for the EXPLICIT away snapshot; nil for
           # visitor sessions (away not persisted for the ephemeral subject).
           away_persister: away_persister() | nil,
           query_window_open?: EventRouter.query_window_open?(),
           ghost_recovery: GhostRecovery.t() | nil,
           ghost_timer: reference() | nil,
+          # #581 — the visitor "recover my identity" FSM + its two timers
+          # (overall deadline + the post-verb settle tick). All nil unless
+          # a recovery is in flight; the FSM is a sibling to
+          # `ghost_recovery`, driven by `advance_recover/2`.
+          recover_identity: RecoverIdentity.t() | nil,
+          recover_timer: reference() | nil,
+          recover_settle_timer: reference() | nil,
           away_state: AwayState.t(),
           auto_away_timer: reference() | nil,
           # S4.2: IRCv3 caps confirmed active by upstream CAP ACK. Keys are
@@ -1057,6 +1099,8 @@ defmodule Grappa.Session.Server do
       credential_committer: Map.get(opts, :credential_committer),
       registration_committer: Map.get(opts, :registration_committer),
       last_joined_persister: Map.get(opts, :last_joined_persister),
+      # #581 — visitor-only /recover secret reader (nil for user sessions).
+      recover_source: Map.get(opts, :recover_source),
       # GH #417 — persister for the EXPLICIT away snapshot (nil for visitors).
       away_persister: Map.get(opts, :away_persister),
       # #400 — open-query-window predicate EventRouter consults to re-key a
@@ -1069,6 +1113,11 @@ defmodule Grappa.Session.Server do
       query_window_open?: Map.get(opts, :query_window_open?, &QueryWindows.open?/3),
       ghost_recovery: nil,
       ghost_timer: nil,
+      # #581 — recover-identity FSM + timers idle until /recover (or the
+      # home button) fires `handle_call(:recover_identity, ...)`.
+      recover_identity: nil,
+      recover_timer: nil,
+      recover_settle_timer: nil,
       # GH #417 — restore a persisted EXPLICIT away (crash/respawn/reconnect)
       # from the plan; boots `:present` on first connect / when nothing was
       # persisted. The `AWAY :<reason>` is re-emitted upstream at 001 by
@@ -1829,6 +1878,52 @@ defmodule Grappa.Session.Server do
 
   def handle_call(:refresh_directory, _, state) do
     {:reply, {:error, :already_refreshing}, state}
+  end
+
+  # #581 — start the visitor "recover my identity" sequence (A3: ack
+  # immediately, steps ride async broadcasts). Clauses ordered: (1) a
+  # recovery already in flight is refused (one FSM per session); (2) a
+  # visitor subject is gated then started; (3) any other subject hits the
+  # visitor-only guard. The `recover_identity: %RecoverIdentity{}` guard
+  # also makes the numeric-feed `handle_info` clause below unambiguous.
+  def handle_call(:recover_identity, _, %{recover_identity: %RecoverIdentity{}} = state) do
+    {:reply, {:error, :in_progress}, state}
+  end
+
+  def handle_call(:recover_identity, _, %{subject: {:visitor, _}} = state) do
+    if "r" in Map.get(state, :umodes, []) do
+      # Already `+r` — identified, nothing to recover.
+      {:reply, {:error, :already_identified}, state}
+    else
+      # #581 review-#1 — resolve the secret + registered nick from the
+      # PERSISTENT credential (via the injected reader), NOT live state:
+      # `state.pending_password` is one-shot cleared at 001, so a session
+      # parked after connect would otherwise ALWAYS see `nothing_to_recover`
+      # while the button (reading `password_encrypted`) stays offered. Both
+      # now resolve `Credential.recover_secret/1`. A nil/absent secret =
+      # anon visitor / no stored NickServ secret → never blind-`IDENTIFY`
+      # (#561 pt3), the "nothing to recover" outcome `/recover` reports.
+      case recover_source(state) do
+        {:ok, {cred_nick, secret}} ->
+          fsm = RecoverIdentity.init(cred_nick, secret)
+          {_, next, lines} = RecoverIdentity.step(fsm, :start)
+
+          state =
+            state
+            |> flush_lines(lines)
+            |> broadcast_recover_events(:idle, next)
+
+          timer = Process.send_after(self(), :recover_timeout, @recover_timeout_ms)
+          {:reply, :ok, %{state | recover_identity: next, recover_timer: timer}}
+
+        {:error, :nothing_to_recover} ->
+          {:reply, {:error, :nothing_to_recover}, state}
+      end
+    end
+  end
+
+  def handle_call(:recover_identity, _, state) do
+    {:reply, {:error, :not_visitor}, state}
   end
 
   # #376 — /banlist <#chan>. Mirror of :send_whowas shape but keyed by
@@ -2752,6 +2847,22 @@ defmodule Grappa.Session.Server do
     {:noreply, %{state | pending_auth: nil, pending_auth_timer: nil}}
   end
 
+  # #581 — a 433/437 while a recover-identity is IN FLIGHT is the FSM's
+  # `{:nick_error, code}` signal (the credential nick is in use / held).
+  # MUST precede the ghost-recovery 433 clause below: a visitor with a
+  # cached password also has `pending_password` set, which would
+  # otherwise divert this 433 into GHOST recovery — an armed recover owns
+  # the numeric. The frame is CONSUMED here (not re-routed to a $server
+  # notice), keeping the managed sequence quiet, exactly like the ghost
+  # path consumes its 433.
+  def handle_info(
+        {:irc, %Message{command: {:numeric, code}}},
+        %{recover_identity: %RecoverIdentity{}} = state
+      )
+      when code in [433, 437] do
+    {:noreply, advance_recover(state, {:nick_error, code})}
+  end
+
   # Task 18 — visitor 433 with cached NickServ password starts ghost
   # recovery. AuthFSM's `:nickserv_identify`-specific 432/433 :cont
   # clause keeps the connection alive long enough for this handler to
@@ -2807,6 +2918,23 @@ defmodule Grappa.Session.Server do
   end
 
   def handle_info(:ghost_timeout, state), do: {:noreply, state}
+
+  # #581 — recover overall deadline: fail the sequence (never hang the
+  # modal). Armed-guard clause; a late/duplicate tick after the FSM
+  # already cleared its fields is the benign no-op catch-all below.
+  def handle_info(:recover_timeout, %{recover_identity: %RecoverIdentity{}} = state) do
+    {:noreply, advance_recover(state, :timeout)}
+  end
+
+  def handle_info(:recover_timeout, state), do: {:noreply, state}
+
+  # #581 — the post-verb settle tick fires the ONE final NICK. Same
+  # armed-guard + benign-late-tick pair as the overall deadline.
+  def handle_info(:recover_settle, %{recover_identity: %RecoverIdentity{}} = state) do
+    {:noreply, advance_recover(state, :settle)}
+  end
+
+  def handle_info(:recover_settle, state), do: {:noreply, state}
 
   # Channel directory (#84) refresh watchdog (merged C4). Armed by
   # `handle_call(:refresh_directory, ...)`; fires if 323 RPL_LISTEND never
@@ -3698,6 +3826,127 @@ defmodule Grappa.Session.Server do
     end)
   end
 
+  # #581 — resolve the PERSISTENT recover target (the registered nick + the
+  # NickServ secret) via the plan-injected `recover_source` closure. Session
+  # can't statically dep Networks/Visitors (Boundary cycle — Visitors deps
+  # Session via Login), so the plan injects the reader (mirroring
+  # `visitor_committer`). Reads the LIVE credential each call — NOT
+  # `state.nickserv_pass` / the one-shot-cleared `pending_password` — so the
+  # action resolves the SAME source as the `recoverable` button gate
+  # (`Credential.has_nickserv_secret?/1`); both go through
+  # `Credential.recover_secret/1`, so the action can never refuse a session the
+  # button offered (review #1). `Map.get` guards the hot-reload window (a proc
+  # predating the field): a state-shape change forces a COLD deploy, so in
+  # practice the reader is always present — the nil clause is pure defense.
+  @spec recover_source(t()) :: {:ok, {String.t(), String.t()}} | {:error, :nothing_to_recover}
+  defp recover_source(state) do
+    case Map.get(state, :recover_source) do
+      fun when is_function(fun, 0) -> fun.()
+      _ -> {:error, :nothing_to_recover}
+    end
+  end
+
+  # #581 — drive the RecoverIdentity FSM one input. Sibling to
+  # `advance_ghost/2`, but returns the STATE (not `{:noreply, _}`) so it
+  # composes from BOTH the numeric-feed `handle_info` clauses AND the
+  # `apply_effects` (+r) / `delegate` (nick_ok) hooks. Broadcasts the
+  # transition's progress step(s) on the user topic (A1); on entry to
+  # `:awaiting_verb_settle` arms the post-verb settle tick; on a terminal
+  # phase cancels both timers (nil-safe), broadcasts the terminal
+  # `recover_result`, and clears the recover fields.
+  @spec advance_recover(t(), RecoverIdentity.input()) :: t()
+  defp advance_recover(state, input) do
+    old_phase = state.recover_identity.phase
+    {_, next, lines} = RecoverIdentity.step(state.recover_identity, input)
+
+    state =
+      state
+      |> flush_lines(lines)
+      |> broadcast_recover_events(old_phase, next)
+
+    case next.phase do
+      terminal when terminal in [:succeeded, :failed] ->
+        :ok = cancel_and_drain(state.recover_timer, :recover_timeout)
+        :ok = cancel_and_drain(state.recover_settle_timer, :recover_settle)
+        %{state | recover_identity: nil, recover_timer: nil, recover_settle_timer: nil}
+
+      :awaiting_verb_settle ->
+        settle = Process.send_after(self(), :recover_settle, @recover_settle_ms)
+        %{state | recover_identity: next, recover_settle_timer: settle}
+
+      _ ->
+        %{state | recover_identity: next}
+    end
+  end
+
+  # #581 — broadcast the progress step(s) for a recover transition, plus
+  # the terminal `recover_result` when the FSM stops. Presentational +
+  # fire-and-forget (like `broadcast_connection_progress/2`): a dead WS
+  # consumer must never fail the recovery. Returns state unchanged.
+  @spec broadcast_recover_events(t(), RecoverIdentity.phase(), RecoverIdentity.t()) :: t()
+  defp broadcast_recover_events(state, old_phase, next) do
+    Enum.each(recover_progress_steps(old_phase, next), fn {step, status, reason} ->
+      _ =
+        Broadcaster.to_user(
+          state,
+          SessionWire.recover_progress(state.network_slug, step, status, reason)
+        )
+    end)
+
+    # Fire-and-forget: discard the broadcast result (a dead WS consumer
+    # must never fail the recovery — hence `_ =`, not a `:ok =` match).
+    _ =
+      case next.phase do
+        :succeeded ->
+          Broadcaster.to_user(state, SessionWire.recover_result(state.network_slug, :succeeded, nil))
+
+        :failed ->
+          Broadcaster.to_user(
+            state,
+            SessionWire.recover_result(state.network_slug, :failed, next.reason)
+          )
+
+        _ ->
+          :ok
+      end
+
+    state
+  end
+
+  # #581 — map an FSM transition (old phase → next state) to the progress
+  # step(s) the modal renders. Order mirrors the source-verified sequence:
+  # NICK + IDENTIFY go out together, `+r` is the success (`:register`),
+  # and a held nick detours through the reclaim verb. `verb` (`:recover |
+  # :release`) doubles as its own step atom.
+  @spec recover_progress_steps(RecoverIdentity.phase(), RecoverIdentity.t()) ::
+          [{SessionWire.recover_step(), SessionWire.recover_status(), SessionWire.recover_reason() | nil}]
+  defp recover_progress_steps(:idle, %{phase: :awaiting_r}),
+    do: [{:nick, :running, nil}, {:identify, :running, nil}]
+
+  defp recover_progress_steps(:awaiting_r, %{phase: :awaiting_verb_settle, verb: verb}),
+    do: [{:nick, :failed, nil}, {verb, :running, nil}]
+
+  defp recover_progress_steps(:awaiting_verb_settle, %{phase: :awaiting_final_r, verb: verb}),
+    do: [{verb, :ok, nil}, {:nick, :running, nil}, {:identify, :running, nil}]
+
+  defp recover_progress_steps(_, %{phase: :succeeded}),
+    do: [{:nick, :ok, nil}, {:identify, :ok, nil}, {:register, :ok, nil}]
+
+  defp recover_progress_steps(old, %{phase: :failed, reason: reason, verb: verb}),
+    do: [{recover_failed_step(old, verb), :failed, reason}]
+
+  defp recover_progress_steps(_, _), do: []
+
+  # The step that FAILED, keyed on the phase we failed OUT of: a clean
+  # NICK with no `+r` is an IDENTIFY (wrong password) failure; an
+  # unanswered verb is the verb; a reclaimed NICK that still can't land is
+  # the NICK.
+  @spec recover_failed_step(RecoverIdentity.phase(), RecoverIdentity.verb()) :: SessionWire.recover_step()
+  defp recover_failed_step(:awaiting_r, _), do: :identify
+  defp recover_failed_step(:awaiting_verb_settle, verb) when verb in [:recover, :release], do: verb
+  defp recover_failed_step(:awaiting_final_r, _), do: :nick
+  defp recover_failed_step(_, _), do: :nick
+
   # Build the IRC.Client opts map from the pre-resolved primitive
   # plan. Nick-fallback + Cloak password decryption already happened
   # in `Grappa.Networks.SessionPlan.resolve/1`'s `build_plan/4` — the
@@ -4226,12 +4475,32 @@ defmodule Grappa.Session.Server do
     event = if transition == :acquired, do: :identified, else: :deidentified
     SessionLog.emit(event, state, [])
 
-    # #347 — +r acquisition is the identify-confirmed signal the deferred
-    # `:nickserv_identify` autojoin waits for. Fire the JOINs now (cancelling
-    # the fallback timer) so they land AFTER identify — +R channels accept and
-    # ChanServ ops. No-op for any path that didn't defer (latch nil): SASL/:none
-    # fired on 001, and a `:lost` transition never triggers it.
-    state = if transition == :acquired, do: fire_deferred_autojoin(state), else: state
+    # On +r acquisition, TWO consumers fire (both gated on `:acquired`,
+    # nested under one rebind — Credo VariableRebinding):
+    #   #347 — +r is the identify-confirmed signal the deferred
+    #   `:nickserv_identify` autojoin waits for. Fire the JOINs now
+    #   (cancelling the fallback timer) so they land AFTER identify — +R
+    #   channels accept and ChanServ ops. No-op for any path that didn't
+    #   defer (latch nil): SASL/:none fired on 001.
+    #   #581 — +r IS the recover FSM's `:r_observed` signal. Reuse
+    #   EventRouter's `set_r_mode?` detection (it already produced this
+    #   effect) instead of re-parsing the MODE echo; only feed while a
+    #   recover is armed (`advance_recover/2` no-ops the FSM off-phase).
+    # A `:lost` transition triggers neither.
+    state =
+      if transition == :acquired do
+        after_autojoin = fire_deferred_autojoin(state)
+
+        # #229 hot-reload safety — `Map.get`, never `after_autojoin.recover_identity`
+        # dot-access: this runs on EVERY +r (not just recover), so a session
+        # predating the #581 field (force-hot-reloaded) would KeyError here on
+        # the common identify path. Absent key → nil → no armed recover.
+        if match?(%RecoverIdentity{}, Map.get(after_autojoin, :recover_identity)),
+          do: advance_recover(after_autojoin, :r_observed),
+          else: after_autojoin
+      else
+        state
+      end
 
     apply_effects(rest, state)
   end
@@ -4692,12 +4961,30 @@ defmodule Grappa.Session.Server do
   # somehow staged pending_auth (e.g. operator manually issued
   # NickServ IDENTIFY), the +r is logged and dropped.
   defp apply_effects([{:visitor_r_observed, password} | rest], state) do
+    # #561 — bind the password AND the nick this +r confirms. Normally
+    # that is `state.nick`: bahamut clears +r on a genuine nick change
+    # (`m_nick.c:594-602`) and services set it only on `sameNick`, so at
+    # ANY +r instant the live nick IS the identified account, never a
+    # forced Guest. #581 makes that explicit for the recover path — the
+    # sequence IDENTIFYs *for* `cred_nick` (and only lands +r once ON it),
+    # so bind that IDENTITY, not whatever nick is worn. The two are equal
+    # here by the sameNick rule; binding the target expresses intent and
+    # is robust if that invariant ever weakens (binding the worn nick
+    # instead of the identity is wrong regardless).
+    # #229 hot-reload safety — `Map.get`, never `state.recover_identity`
+    # dot-access: `visitor_r_observed` fires on EVERY visitor +r (whenever
+    # `pending_auth` was staged), so a session predating the #581 field
+    # (force-hot-reloaded) would KeyError here on the common identify path.
+    # Absent key → nil → the `state.nick` fallback (pre-#581 behaviour).
+    bind_nick =
+      case Map.get(state, :recover_identity) do
+        %RecoverIdentity{cred_nick: cred} when is_binary(cred) -> cred
+        _ -> state.nick
+      end
+
     case {state.subject, state.visitor_committer} do
       {{:visitor, visitor_id}, committer} when is_function(committer, 3) ->
-        # #561 — bind the password AND the nick held at this +r instant.
-        # bahamut strips +r on a genuine nick change, so `state.nick` here
-        # is guaranteed the identified account, never a forced Guest.
-        case committer.(visitor_id, password, state.nick) do
+        case committer.(visitor_id, password, bind_nick) do
           {:ok, _} ->
             # #561 — log ONLY the primary outcome (the password commit) here.
             # The secondary, best-effort nick bind logs its own honest line

--- a/lib/grappa/session/wire.ex
+++ b/lib/grappa/session/wire.ex
@@ -96,6 +96,8 @@ defmodule Grappa.Session.Wire do
           | :directory_complete
           | :directory_failed
           | :connection_progress
+          | :recover_progress
+          | :recover_result
           | :presence_changed
           | :presence_error
           | :presence_snapshot
@@ -717,6 +719,48 @@ defmodule Grappa.Session.Wire do
           kind: :connection_progress,
           network: String.t(),
           state: :connecting | :connected
+        }
+
+  @typedoc """
+  #581 — a step in the visitor-triggered "recover my identity" sequence
+  (`IDENTIFY` → `+r` → `NICK` → `RECOVER`/`RELEASE` → `NICK`). TRANSIENT
+  and PRESENTATIONAL: it drives the recover progress modal only, is never
+  persisted, and never enters `window_states` (A1). Broadcast on
+  `Topic.user/1` with the `network` slug discriminator — the modal is a
+  home affordance with no per-network channel to receive on.
+
+  `step` and `status` are atoms in the closed sets below, projected to
+  strings on the wire (like `connection_progress/2`'s `state`). `reason`
+  is non-nil only on a `:failed` status.
+  """
+  @type recover_step :: :identify | :register | :nick | :recover | :release
+
+  @type recover_status :: :running | :ok | :failed
+
+  @type recover_reason :: :wrong_password | :nick_unavailable | :services_declined
+
+  @type recover_progress_payload :: %{
+          kind: :recover_progress,
+          network: String.t(),
+          step: recover_step(),
+          status: recover_status(),
+          reason: recover_reason() | nil
+        }
+
+  @typedoc """
+  #581 — the TERMINAL event of a recover sequence, closing the progress
+  modal's outcome. `outcome` ∈ `:succeeded | :failed`; `reason` carries
+  the failure cause (nil on success). Distinct kind from
+  `recover_progress` per A1 ("a single progress event kind plus a
+  terminal event").
+  """
+  @type recover_outcome :: :succeeded | :failed
+
+  @type recover_result_payload :: %{
+          kind: :recover_result,
+          network: String.t(),
+          outcome: recover_outcome(),
+          reason: recover_reason() | nil
         }
 
   @doc """
@@ -1477,5 +1521,35 @@ defmodule Grappa.Session.Wire do
   def connection_progress(network_slug, state)
       when is_binary(network_slug) and state in [:connecting, :connected] do
     %{kind: :connection_progress, network: network_slug, state: state}
+  end
+
+  @doc """
+  #581 — a recover-sequence progress step for the recover modal. `step`
+  ∈ `#{inspect([:identify, :register, :nick, :recover, :release])}`,
+  `status` ∈ `#{inspect([:running, :ok, :failed])}`; `reason` is a
+  `t:recover_reason/0` on `:failed`, else `nil`. Atom→string projection
+  happens at the JSON edge. Broadcast on `Topic.user/1`.
+  """
+  @spec recover_progress(String.t(), recover_step(), recover_status(), recover_reason() | nil) ::
+          recover_progress_payload()
+  def recover_progress(network_slug, step, status, reason)
+      when is_binary(network_slug) and
+             step in [:identify, :register, :nick, :recover, :release] and
+             status in [:running, :ok, :failed] and
+             (is_nil(reason) or reason in [:wrong_password, :nick_unavailable, :services_declined]) do
+    %{kind: :recover_progress, network: network_slug, step: step, status: status, reason: reason}
+  end
+
+  @doc """
+  #581 — the terminal recover outcome for the recover modal. `outcome` ∈
+  `#{inspect([:succeeded, :failed])}`; `reason` is a `t:recover_reason/0`
+  on `:failed`, else `nil`. Broadcast on `Topic.user/1`.
+  """
+  @spec recover_result(String.t(), recover_outcome(), recover_reason() | nil) ::
+          recover_result_payload()
+  def recover_result(network_slug, outcome, reason)
+      when is_binary(network_slug) and outcome in [:succeeded, :failed] and
+             (is_nil(reason) or reason in [:wrong_password, :nick_unavailable, :services_declined]) do
+    %{kind: :recover_result, network: network_slug, outcome: outcome, reason: reason}
   end
 end

--- a/lib/grappa/visitors/session_plan.ex
+++ b/lib/grappa/visitors/session_plan.ex
@@ -34,7 +34,7 @@ defmodule Grappa.Visitors.SessionPlan do
   """
 
   alias Grappa.{Networks, Repo, Session, Visitors}
-  alias Grappa.Networks.{Credential, NoServerError, Servers}
+  alias Grappa.Networks.{Credential, Credentials, NoServerError, Servers}
   alias Grappa.Networks.SessionPlan, as: NetworksSessionPlan
   alias Grappa.Visitors.Visitor
 
@@ -110,6 +110,33 @@ defmodule Grappa.Visitors.SessionPlan do
     case Visitors.resolve_credential(visitor, network.id) do
       {:ok, %Credential{} = cred} -> {:ok, cred}
       {:error, :not_found} -> {:error, :network_unconfigured}
+    end
+  end
+
+  # #581 — resolve the /recover secret SOURCE from the LIVE persistent
+  # `(visitor_id, network_id)` credential: `Credential.recover_secret/1` (the
+  # SSOT the `recoverable` button gate also reads) + the registered nick to
+  # reclaim, from ONE fetch. `:nothing_to_recover` when the credential is gone
+  # or carries no secret. Injected as the `recover_source` closure by
+  # `build_plan/4`; extracted here so that closure body stays a one-liner.
+  @spec recover_secret_source(Ecto.UUID.t(), pos_integer()) ::
+          {:ok, {String.t(), String.t()}} | {:error, :nothing_to_recover}
+  defp recover_secret_source(visitor_id, network_id) do
+    # `is_binary` guards on BOTH nick and secret narrow the success tuple to
+    # `{String.t(), String.t()}` — the schema types `nick` as `String.t() | nil`
+    # and `recover_secret/1` as `binary() | nil`, so without the guards Dialyzer
+    # infers `{:ok, {nil | binary(), ...}}`, which is NOT a subtype of the
+    # `recover_source()` @type on `Session.start_opts` → build_plan's return
+    # stops matching `start_opts()` → `resolve/2` loses its `{:ok, plan}` success
+    # typing → every `{:ok, _plan}` caller (Bootstrap/Operator/Visitors/Login)
+    # dead-patterns. A persisted credential always has a non-nil nick
+    # (validate_required), so the guard is belt-and-braces, not a real branch.
+    with {:ok, %Credential{nick: nick} = cred} when is_binary(nick) <-
+           Credentials.get_visitor_credential(visitor_id, network_id),
+         secret when is_binary(secret) <- Credential.recover_secret(cred) do
+      {:ok, {nick, secret}}
+    else
+      _ -> {:error, :nothing_to_recover}
     end
   end
 
@@ -198,6 +225,14 @@ defmodule Grappa.Visitors.SessionPlan do
       last_joined_persister: fn channels ->
         Visitors.update_last_joined_channels(visitor.id, network.id, channels)
       end,
+      # #581 — the "recover my identity" secret SOURCE. Session.Server cannot
+      # statically alias Networks/Visitors (Boundary cycle — Visitors deps
+      # Session via Login), so the reader is injected here as an opaque
+      # closure, mirroring `visitor_committer`. Body extracted to
+      # `recover_secret_source/2` (keeps build_plan under the cyclomatic
+      # budget). Captures `visitor.id` + `network.id` (immutable) like
+      # `last_joined_persister`.
+      recover_source: fn -> recover_secret_source(visitor.id, network.id) end,
       # Re-resolve the plan from the DB on every `Session.Server.init/1`
       # invocation — both first boot AND `:transient` restart.
       # `DynamicSupervisor` caches the spawn-time child spec; without

--- a/lib/grappa_web/channels/grappa_channel.ex
+++ b/lib/grappa_web/channels/grappa_channel.ex
@@ -843,6 +843,24 @@ defmodule GrappaWeb.GrappaChannel do
     )
   end
 
+  # #581 — "recover my identity". The ONE action path both `/recover` and
+  # the home button ride (A3): acks immediately, and the multi-step
+  # outcome (`IDENTIFY` → `+r` → `NICK` → `RECOVER`/`RELEASE` → `NICK`)
+  # arrives asynchronously as `recover_progress`/`recover_result` events
+  # on the user topic. Visitor-only + credential gating live in the
+  # Server (the authority on live state), surfaced via the typed
+  # `not_visitor`/`nothing_to_recover`/`already_identified`/
+  # `recovery_in_progress` arms in `dispatch_subject_verb/3`. No args to
+  # validate beyond the guarded `network_id`.
+  def handle_in("recover", %{"network_id" => network_id}, socket)
+      when is_integer(network_id) do
+    dispatch_subject_verb(
+      socket,
+      fn -> {:ok, nil} end,
+      fn subject -> Session.recover_identity(subject, network_id) end
+    )
+  end
+
   # CP22 cluster B (channel-client-polish #14) — /who <#channel>. cic
   # pushes after the operator types `/who #chan`; the channel relays to
   # Session.send_who/3 which primes who_pending + emits WHO upstream.
@@ -1755,6 +1773,27 @@ defmodule GrappaWeb.GrappaChannel do
       # nothing ever emits.
       {:error, :links_in_flight} ->
         {:reply, {:error, %{error: "links_in_flight"}}, socket}
+
+      # #581 recover gating (Session.recover_identity/2). A missing live
+      # pid is the same "no upstream to act against" as `no_session`; a
+      # user subject reaching the visitor-only verb is `forbidden`. The
+      # rest are truthful recover-specific tokens cic's
+      # `friendlyChannelError` maps (and `/recover` reports
+      # `nothing_to_recover` as its "nothing to do" outcome).
+      {:error, :not_connected} ->
+        {:reply, {:error, %{error: "no_session"}}, socket}
+
+      {:error, :not_visitor} ->
+        {:reply, {:error, %{error: "forbidden"}}, socket}
+
+      {:error, :nothing_to_recover} ->
+        {:reply, {:error, %{error: "nothing_to_recover"}}, socket}
+
+      {:error, :already_identified} ->
+        {:reply, {:error, %{error: "already_identified"}}, socket}
+
+      {:error, :in_progress} ->
+        {:reply, {:error, %{error: "recovery_in_progress"}}, socket}
 
       # REV-F (H10, originally REV-E HIGH-1): `Session.send_*` post-U-
       # cluster CAN return `{:error, :no_socket | :closed |

--- a/lib/grappa_web/error_tokens.ex
+++ b/lib/grappa_web/error_tokens.ex
@@ -163,4 +163,7 @@ defmodule GrappaWeb.ErrorTokens do
           | :persist_failed
           | :invalid_channel
           | :links_in_flight
+          | :nothing_to_recover
+          | :already_identified
+          | :recovery_in_progress
 end

--- a/test/grappa/networks/credential_test.exs
+++ b/test/grappa/networks/credential_test.exs
@@ -54,6 +54,84 @@ defmodule Grappa.Networks.CredentialTest do
     end
   end
 
+  describe "has_nickserv_secret?/1 (#581 — /recover button gate)" do
+    # Post-Cloak-load, the `*_encrypted` fields carry DECRYPTED plaintext
+    # (accessor contract), so a plain struct exercises the predicate without
+    # the DB — mirrors the `effective_ident/1` unit tests above.
+    test "true when the #509 $nickserv_pass is present (decoupled from auth_method)" do
+      cred = %Credential{auth_method: :server_pass, nickserv_pass_encrypted: "hunter2"}
+      assert Credential.has_nickserv_secret?(cred)
+    end
+
+    test "true for :nickserv_identify with an upstream password (the fallback source)" do
+      cred = %Credential{auth_method: :nickserv_identify, password_encrypted: "hunter2"}
+      assert Credential.has_nickserv_secret?(cred)
+    end
+
+    test "false with no secret at all" do
+      refute Credential.has_nickserv_secret?(%Credential{auth_method: :none})
+    end
+
+    test "false when an :nickserv_identify credential has no password" do
+      refute Credential.has_nickserv_secret?(%Credential{auth_method: :nickserv_identify})
+    end
+
+    test "an empty-string secret is treated as absent (mirrors the live gate's pw != \"\")" do
+      refute Credential.has_nickserv_secret?(%Credential{
+               auth_method: :server_pass,
+               nickserv_pass_encrypted: ""
+             })
+    end
+
+    test "false for :server_pass with only an upstream password (spent on PASS, not NickServ)" do
+      cred = %Credential{auth_method: :server_pass, password_encrypted: "shibboleth"}
+      refute Credential.has_nickserv_secret?(cred)
+    end
+  end
+
+  describe "recover_secret/1 (#581 — the /recover secret VALUE, SSOT for button + action)" do
+    # The value `Session.Server`'s /recover action IDENTIFYs with.
+    # `has_nickserv_secret?/1` is `not is_nil(recover_secret/1)`, so button and
+    # action read ONE source and can never diverge (review-#1). Post-Cloak-load
+    # the `*_encrypted` fields carry DECRYPTED plaintext (accessor contract),
+    # so a plain struct exercises it without the DB.
+    test "returns the #509 $nickserv_pass (the FIRST source, decoupled from auth_method)" do
+      cred = %Credential{auth_method: :server_pass, nickserv_pass_encrypted: "hunter2"}
+      assert Credential.recover_secret(cred) == "hunter2"
+    end
+
+    test "$nickserv_pass WINS over the :nickserv_identify password when both are set" do
+      cred = %Credential{
+        auth_method: :nickserv_identify,
+        nickserv_pass_encrypted: "primary",
+        password_encrypted: "fallback"
+      }
+
+      assert Credential.recover_secret(cred) == "primary"
+    end
+
+    test "falls back to the :nickserv_identify upstream password" do
+      cred = %Credential{auth_method: :nickserv_identify, password_encrypted: "hunter2"}
+      assert Credential.recover_secret(cred) == "hunter2"
+    end
+
+    test "nil with no secret at all" do
+      assert Credential.recover_secret(%Credential{auth_method: :none}) == nil
+    end
+
+    test "nil for :server_pass with only an upstream password (spent on PASS, not NickServ)" do
+      cred = %Credential{auth_method: :server_pass, password_encrypted: "shibboleth"}
+      assert Credential.recover_secret(cred) == nil
+    end
+
+    test "an empty-string $nickserv_pass is treated as absent (falls through to nil)" do
+      assert Credential.recover_secret(%Credential{
+               auth_method: :server_pass,
+               nickserv_pass_encrypted: ""
+             }) == nil
+    end
+  end
+
   describe "connection_state field (T32)" do
     test "round-trips :connected | :parked | :failed via changeset" do
       # `get_field` (not `get_change`) — `:connected` is the schema

--- a/test/grappa/networks/wire_test.exs
+++ b/test/grappa/networks/wire_test.exs
@@ -435,7 +435,9 @@ defmodule Grappa.Networks.WireTest do
                  nick: "vjt-live",
                  connection_state: :parked,
                  connection_state_reason: nil,
-                 connection_state_changed_at: DateTime.to_iso8601(now)
+                 connection_state_changed_at: DateTime.to_iso8601(now),
+                 # #581 (D2) — :sasl credential, no NickServ secret.
+                 recoverable: false
                }
              }
     end
@@ -492,6 +494,22 @@ defmodule Grappa.Networks.WireTest do
       # wire boundary converts to ISO-8601.
       assert is_binary(row.connection_state_changed_at)
       assert {:ok, _, 0} = DateTime.from_iso8601(row.connection_state_changed_at)
+      # #581 (D2) — an :none credential carries no NickServ secret.
+      assert row.recoverable == false
+    end
+
+    test "recoverable is true when the credential carries a NickServ secret (#581 D2)",
+         %{user: user, network: network} do
+      {:ok, _} =
+        Credentials.bind_credential(user, network, %{
+          nick: "vjt",
+          auth_method: :nickserv_identify,
+          password: "hunter2"
+        })
+
+      cred = user |> Credentials.get_credential!(network) |> Repo.preload(:network)
+
+      assert Wire.home_network_row(cred, "vjt").recoverable == true
     end
 
     test "surfaces nil connection_state_changed_at as nil on the wire",

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -1715,6 +1715,40 @@ defmodule Grappa.Session.EventRouterTest do
       assert attrs.meta == %{new_nick: "vjt_"}
     end
 
+    # #581 — bahamut strips +r SILENTLY on a genuine nick change (m_nick.c:
+    # `mycmp(old,new) != 0 → umode &= ~UMODE_r`), with NO MODE echo, so the
+    # ONLY way grappa's per-session umode set stays truthful across a self-NICK
+    # is to mirror the strip here. Otherwise `state.umodes` keeps a phantom "r"
+    # and every +r-gated consumer (the #581 recover button, the identity badge)
+    # reads the visitor as still-identified after they /nick'd away from their
+    # registered nick. Drop ONLY "r" (the documented invariant), keep the rest.
+    test "NICK-self genuine rename drops +r + emits :umode_changed and :session_identity_changed :lost" do
+      state = base_state(%{nick: "vjt", umodes: ["i", "r"]})
+      m = msg(:nick, ["vjt_"], {:nick, "vjt", "u", "h"})
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+
+      assert new_state.nick == "vjt_"
+      assert new_state.umodes == ["i"]
+      assert {:umode_changed, ["i"]} in effects
+      assert {:session_identity_changed, :lost} in effects
+    end
+
+    # A pure CASE change (foo→Foo) is NOT a genuine rename — bahamut's mycmp is
+    # case-insensitive, so +r survives it. Gate on `not nick_eq?(old, new)` (the
+    # #373 rename-vs-fold distinction) so a case-only self-NICK is a umode no-op.
+    test "NICK-self case-only change keeps +r (no drop, no identity effect)" do
+      state = base_state(%{nick: "vjt", umodes: ["r"]})
+      m = msg(:nick, ["VJT"], {:nick, "vjt", "u", "h"})
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+
+      assert new_state.nick == "VJT"
+      assert new_state.umodes == ["r"]
+      refute Enum.any?(effects, &match?({:umode_changed, _}, &1))
+      refute Enum.any?(effects, &match?({:session_identity_changed, _}, &1))
+    end
+
     test "NICK-other for stranger emits no effects + no mutation" do
       state = base_state(%{members: %{"#italia" => %{"vjt" => []}}})
       m = msg(:nick, ["stranger_"], {:nick, "stranger", "u", "h"})

--- a/test/grappa/session/recover_identity_test.exs
+++ b/test/grappa/session/recover_identity_test.exs
@@ -1,0 +1,187 @@
+defmodule Grappa.Session.RecoverIdentityTest do
+  use ExUnit.Case, async: true
+
+  alias Grappa.Session.RecoverIdentity
+
+  # Source-verified ordering (GH #581): `+r` is per-nick and only lands
+  # when you IDENTIFY while ON the registered nick (sameNick). So the
+  # sequence sends NICK + IDENTIFY together and waits for `+r` as success;
+  # a 433/437 drives a RECOVER/RELEASE detour, then one retry.
+
+  describe "init/2" do
+    test "starts in :idle with cred_nick + secret populated, no verb/reason" do
+      assert %RecoverIdentity{
+               phase: :idle,
+               cred_nick: "vjt",
+               secret: "s3cret",
+               verb: nil,
+               reason: nil
+             } = RecoverIdentity.init("vjt", "s3cret")
+    end
+  end
+
+  describe "step/2 — happy path (nick free)" do
+    test ":idle + :start → :awaiting_r + NICK then IDENTIFY (sameNick), in order" do
+      state = RecoverIdentity.init("vjt", "s3cret")
+
+      assert {:cont, next, lines} = RecoverIdentity.step(state, :start)
+
+      assert next.phase == :awaiting_r
+      # NICK MUST precede IDENTIFY so the identify is sameNick and commits +r.
+      assert lines == ["NICK vjt\r\n", "PRIVMSG NickServ :IDENTIFY vjt s3cret\r\n"]
+    end
+
+    test ":awaiting_r + :r_observed → :succeeded, no lines" do
+      state = %RecoverIdentity{phase: :awaiting_r, cred_nick: "vjt", secret: "s3cret"}
+
+      assert {:stop, next, []} = RecoverIdentity.step(state, :r_observed)
+      assert next.phase == :succeeded
+      assert next.reason == nil
+    end
+  end
+
+  describe "step/2 — wrong password (clean NICK, no +r)" do
+    test ":awaiting_r + :timeout → :failed :wrong_password, no lines" do
+      state = %RecoverIdentity{phase: :awaiting_r, cred_nick: "vjt", secret: "s3cret"}
+
+      assert {:stop, next, []} = RecoverIdentity.step(state, :timeout)
+      assert next.phase == :failed
+      assert next.reason == :wrong_password
+    end
+  end
+
+  describe "step/2 — nick held → verb → settle → one retry" do
+    test ":awaiting_r + {:nick_error, 433} → :awaiting_verb_settle verb :recover + RECOVER" do
+      state = %RecoverIdentity{phase: :awaiting_r, cred_nick: "vjt", secret: "s3cret"}
+
+      assert {:cont, next, lines} = RecoverIdentity.step(state, {:nick_error, 433})
+
+      assert next.phase == :awaiting_verb_settle
+      assert next.verb == :recover
+      assert lines == ["PRIVMSG NickServ :RECOVER vjt s3cret\r\n"]
+    end
+
+    test ":awaiting_r + {:nick_error, 437} → :awaiting_verb_settle verb :release + RELEASE" do
+      state = %RecoverIdentity{phase: :awaiting_r, cred_nick: "vjt", secret: "s3cret"}
+
+      assert {:cont, next, lines} = RecoverIdentity.step(state, {:nick_error, 437})
+
+      assert next.phase == :awaiting_verb_settle
+      assert next.verb == :release
+      assert lines == ["PRIVMSG NickServ :RELEASE vjt s3cret\r\n"]
+    end
+
+    test ":awaiting_verb_settle + :settle → :awaiting_final_r + NICK then IDENTIFY" do
+      state = %RecoverIdentity{
+        phase: :awaiting_verb_settle,
+        cred_nick: "vjt",
+        secret: "s3cret",
+        verb: :recover
+      }
+
+      assert {:cont, next, lines} = RecoverIdentity.step(state, :settle)
+
+      assert next.phase == :awaiting_final_r
+      assert lines == ["NICK vjt\r\n", "PRIVMSG NickServ :IDENTIFY vjt s3cret\r\n"]
+    end
+
+    test ":awaiting_final_r + :r_observed → :succeeded" do
+      state = %RecoverIdentity{
+        phase: :awaiting_final_r,
+        cred_nick: "vjt",
+        secret: "s3cret",
+        verb: :recover
+      }
+
+      assert {:stop, next, []} = RecoverIdentity.step(state, :r_observed)
+      assert next.phase == :succeeded
+    end
+
+    test ":awaiting_verb_settle + :timeout → :failed :services_declined" do
+      state = %RecoverIdentity{phase: :awaiting_verb_settle, cred_nick: "vjt", verb: :recover}
+
+      assert {:stop, next, []} = RecoverIdentity.step(state, :timeout)
+      assert next.phase == :failed
+      assert next.reason == :services_declined
+    end
+  end
+
+  describe "step/2 — F2: a refused NICK after the verb is TERMINAL, never retried" do
+    # F2 (vjt 2026-07-31): a refused NICK after the verb has done its job is
+    # a FAILURE, not a retry. RECOVER was chosen precisely because an empty
+    # retry never wins the nick. The retry gets ONE shot; refusal = failed,
+    # and CRUCIALLY the FSM emits NO further NICK line — no loop.
+    test ":awaiting_final_r + {:nick_error, 433} → :failed :nick_unavailable, NO retry line" do
+      state = %RecoverIdentity{
+        phase: :awaiting_final_r,
+        cred_nick: "vjt",
+        secret: "s3cret",
+        verb: :recover
+      }
+
+      assert {:stop, next, lines} = RecoverIdentity.step(state, {:nick_error, 433})
+      assert next.phase == :failed
+      assert next.reason == :nick_unavailable
+      assert lines == []
+    end
+
+    test ":awaiting_final_r + {:nick_error, 437} → :failed :nick_unavailable, NO retry line" do
+      state = %RecoverIdentity{
+        phase: :awaiting_final_r,
+        cred_nick: "vjt",
+        secret: "s3cret",
+        verb: :release
+      }
+
+      assert {:stop, next, lines} = RecoverIdentity.step(state, {:nick_error, 437})
+      assert next.phase == :failed
+      assert next.reason == :nick_unavailable
+      assert lines == []
+    end
+
+    test ":awaiting_final_r + :timeout → :failed :nick_unavailable" do
+      state = %RecoverIdentity{phase: :awaiting_final_r, cred_nick: "vjt", verb: :recover}
+
+      assert {:stop, next, []} = RecoverIdentity.step(state, :timeout)
+      assert next.phase == :failed
+      assert next.reason == :nick_unavailable
+    end
+  end
+
+  describe "step/2 — wire lines keep the credential nick RAW (key/display/wire split)" do
+    # cred_nick is a DISPLAY/WIRE token: its case is presentation and must
+    # NOT be folded on the wire. The FSM never lower-cases it.
+    test "mixed-case cred_nick round-trips verbatim through NICK/IDENTIFY/RECOVER" do
+      state = RecoverIdentity.init("Vjt", "s3cret")
+      assert {:cont, r1, l1} = RecoverIdentity.step(state, :start)
+      assert l1 == ["NICK Vjt\r\n", "PRIVMSG NickServ :IDENTIFY Vjt s3cret\r\n"]
+
+      assert {:cont, _, l2} = RecoverIdentity.step(r1, {:nick_error, 433})
+      assert l2 == ["PRIVMSG NickServ :RECOVER Vjt s3cret\r\n"]
+    end
+  end
+
+  describe "step/2 — no-ops (off-phase inputs and terminal passthrough)" do
+    test "off-phase input is a no-op {:cont, state, []}" do
+      state = %RecoverIdentity{phase: :awaiting_r, cred_nick: "vjt", secret: "s3cret"}
+      # :settle is only valid in :awaiting_verb_settle
+      assert {:cont, ^state, []} = RecoverIdentity.step(state, :settle)
+    end
+
+    test "a :start on an already-started FSM is a no-op" do
+      state = %RecoverIdentity{phase: :awaiting_r, cred_nick: "vjt", secret: "s3cret"}
+      assert {:cont, ^state, []} = RecoverIdentity.step(state, :start)
+    end
+
+    test "terminal phases pass any input through unchanged with no lines" do
+      for phase <- [:succeeded, :failed] do
+        state = %RecoverIdentity{phase: phase, cred_nick: "vjt", secret: "s3cret"}
+        assert {:cont, ^state, []} = RecoverIdentity.step(state, :start)
+        assert {:cont, ^state, []} = RecoverIdentity.step(state, :r_observed)
+        assert {:cont, ^state, []} = RecoverIdentity.step(state, {:nick_error, 433})
+        assert {:cont, ^state, []} = RecoverIdentity.step(state, :settle)
+        assert {:cont, ^state, []} = RecoverIdentity.step(state, :timeout)
+      end
+    end
+  end
+end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -137,6 +137,72 @@ defmodule Grappa.Session.ServerTest do
     cred.password_encrypted
   end
 
+  # #581 — the credential nick a recover scaffold reclaims + the +r/collision
+  # MODE/numeric feeds target. State.nick adopts it from the 001 welcome.
+  @recover_nick "regnick"
+
+  # #581 — a REALISTIC recover scaffold (review-#1 fix). Stands up the
+  # PRODUCTION shape a returning REGISTERED visitor reconnects into: a
+  # PERSISTENT `(visitor_id, network_id)` credential carrying
+  # `:nickserv_identify` + a password (the state a prior `+r` commit leaves —
+  # `Visitors.commit_identity`), a session spawned via the real
+  # `VisitorSessionPlan.resolve/2` so the injected `recover_source` reader is
+  # present, and — crucially — driven PAST 001 so the one-shot
+  # `pending_password` is CLEARED. That cleared-live-state-but-live-persistent-
+  # secret condition is EXACTLY what the old `nickserv_secret(state)` read got
+  # wrong (returned nil → `:nothing_to_recover` while the button stayed
+  # offered); a hand-crafted `:none` + `nickserv_pass` plan (the pre-fix
+  # helper) masked it — "mock data must be realistic". `secret` nil → an anon
+  # visitor (`:none`, not recoverable). Returns the scaffold map; teardown via
+  # `start_visitor_session_for`'s on_exit.
+  defp start_recover_visitor(secret) do
+    handler = fn state, line ->
+      if String.starts_with?(line, "USER "),
+        do: {:reply, ":irc 001 #{@recover_nick} :Welcome\r\n", state},
+        else: {:reply, nil, state}
+    end
+
+    {server, port} = start_server(handler)
+
+    {network, _} =
+      network_with_server(port: port, slug: "test-#{System.unique_integer([:positive])}")
+
+    visitor = visitor_with_credential_fixture(nick: @recover_nick, network_slug: network.slug)
+
+    if is_binary(secret) do
+      {:ok, _} =
+        Credentials.upsert_visitor_credential(visitor.id, network.id, %{
+          nick: @recover_nick,
+          sasl_user: @recover_nick,
+          auth_method: :nickserv_identify,
+          password: secret
+        })
+    end
+
+    pid = start_visitor_session_for(visitor, network)
+    subject = {:visitor, visitor.id}
+    label = Grappa.Subject.label(subject)
+
+    # Barrier: drive PAST 001. A recoverable (:nickserv_identify) visitor fires
+    # the built-in one-arg `IDENTIFY <secret>` at 001, which ALSO nils
+    # `pending_password` — waiting for that line proves the persistent secret
+    # is the ONLY remaining live source (the review-#1 fix condition). An anon
+    # visitor sends no identify; the USER line is the past-001 barrier and
+    # `recover_source` reads the anon DB credential (→ nothing_to_recover).
+    if is_binary(secret) do
+      {:ok, _} =
+        IRCServer.wait_for_line(
+          server,
+          &(&1 == "PRIVMSG NickServ :IDENTIFY #{secret}\r\n"),
+          1_000
+        )
+    else
+      :ok = await_handshake(server)
+    end
+
+    %{server: server, pid: pid, network: network, subject: subject, label: label}
+  end
+
   describe "DB-driven init (sub-task 2g)" do
     test "threads credential password + auth_method to IRC.Client (server_pass branch)" do
       {server, port} = start_server()
@@ -9912,6 +9978,201 @@ defmodule Grappa.Session.ServerTest do
 
       state = SessionStateHelpers.fetch(pid)
       assert WindowState.state_of(SessionStateHelpers.window_state(state), "#secret") == :pending
+    end
+  end
+
+  # #581 — "recover my identity" SERVER wiring (the pure FSM is exhausted in
+  # RecoverIdentityTest). Proves: handle_call gating, the outbound
+  # NICK/IDENTIFY/RECOVER/RELEASE flush, the +r → success hook (reusing the
+  # `:session_identity_changed, :acquired` effect, NOT a new MODE detector),
+  # the 433/437 numeric consumption, the progress + terminal broadcasts, and
+  # the settle / overall-deadline timers (driven deterministically via
+  # `send(pid, :recover_settle | :recover_timeout)` rather than sleeping the
+  # 800ms / 15s wall-clock). The `IDENTIFY vsh s3cret` two-arg line is unique
+  # to recover (auth_method :none sends no built-in identify without a 001).
+  describe "recover_identity (#581) — server integration" do
+    test "a user subject is refused with :not_visitor" do
+      {_, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+      pid = start_session_for(user, network)
+
+      assert {:error, :not_visitor} =
+               Session.recover_identity({:user, user.id}, network.id)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "a visitor with no NickServ secret → :nothing_to_recover (never blind-IDENTIFY)" do
+      %{subject: subject, network: network} = start_recover_visitor(nil)
+
+      assert {:error, :nothing_to_recover} = Session.recover_identity(subject, network.id)
+    end
+
+    test "an already-+r visitor → :already_identified" do
+      %{server: server, subject: subject, network: network, label: label} =
+        start_recover_visitor("s3cret")
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(label))
+
+      # Flip +r first; the umode_changed broadcast is the "processed" barrier.
+      IRCServer.feed(server, ":irc.test.org MODE #{@recover_nick} :+r\r\n")
+
+      assert_receive %Phoenix.Socket.Broadcast{event: "event", payload: %{kind: :umode_changed}},
+                     1_000
+
+      assert {:error, :already_identified} = Session.recover_identity(subject, network.id)
+    end
+
+    test "a second concurrent recover → :in_progress" do
+      %{subject: subject, network: network} = start_recover_visitor("s3cret")
+
+      assert :ok = Session.recover_identity(subject, network.id)
+      assert {:error, :in_progress} = Session.recover_identity(subject, network.id)
+    end
+
+    test "happy path: reads the PERSISTENT secret past 001, NICK+IDENTIFY out, +r → succeeded" do
+      # RED-first vs the review-#1 bug: the session is PAST 001 so
+      # `pending_password` is already nil. Pre-fix, `nickserv_secret(state)`
+      # would read that nil and refuse with `:nothing_to_recover`; the fix
+      # reads the PERSISTENT `:nickserv_identify` credential (the same source
+      # the `recoverable` button gate reads), so the sequence proceeds.
+      %{server: server, subject: subject, network: network, label: label} =
+        start_recover_visitor("s3cret")
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(label))
+
+      assert :ok = Session.recover_identity(subject, network.id)
+
+      # NICK then IDENTIFY (sameNick, so the identify commits +r). The two-arg
+      # IDENTIFY carries the credential nick — unique to the recover sequence
+      # (the 001 built-in identify was one-arg, consumed by the scaffold).
+      assert {:ok, "PRIVMSG NickServ :IDENTIFY #{@recover_nick} s3cret\r\n"} =
+               IRCServer.wait_for_line(
+                 server,
+                 &(&1 == "PRIVMSG NickServ :IDENTIFY #{@recover_nick} s3cret\r\n"),
+                 1_000
+               )
+
+      # The first step broadcasts before the reply returns.
+      assert_receive %Phoenix.Socket.Broadcast{event: "event", payload: %{kind: :recover_progress}},
+                     1_000
+
+      # +r is the SUCCESS signal (reuses the :acquired identity effect).
+      IRCServer.feed(server, ":irc.test.org MODE #{@recover_nick} :+r\r\n")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :recover_result, outcome: :succeeded, reason: nil}
+                     },
+                     1_000
+    end
+
+    test "nick held (433) → RECOVER; then settle → +r → succeeded" do
+      %{server: server, pid: pid, subject: subject, network: network, label: label} =
+        start_recover_visitor("s3cret")
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(label))
+
+      assert :ok = Session.recover_identity(subject, network.id)
+
+      # The credential nick is in use → the FSM detours through RECOVER.
+      IRCServer.feed(server, ":irc.test.org 433 * #{@recover_nick} :Nickname is already in use\r\n")
+
+      assert {:ok, "PRIVMSG NickServ :RECOVER #{@recover_nick} s3cret\r\n"} =
+               IRCServer.wait_for_line(
+                 server,
+                 &(&1 == "PRIVMSG NickServ :RECOVER #{@recover_nick} s3cret\r\n"),
+                 1_000
+               )
+
+      # Drive the post-verb settle tick deterministically (no 800ms sleep) →
+      # the ONE final NICK+IDENTIFY; then +r closes it succeeded.
+      send(pid, :recover_settle)
+      IRCServer.feed(server, ":irc.test.org MODE #{@recover_nick} :+r\r\n")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :recover_result, outcome: :succeeded}
+                     },
+                     1_000
+    end
+
+    test "services hold (437) → RELEASE" do
+      %{server: server, subject: subject, network: network} = start_recover_visitor("s3cret")
+
+      assert :ok = Session.recover_identity(subject, network.id)
+
+      IRCServer.feed(
+        server,
+        ":irc.test.org 437 #{@recover_nick} :Nick/channel is temporarily unavailable\r\n"
+      )
+
+      assert {:ok, "PRIVMSG NickServ :RELEASE #{@recover_nick} s3cret\r\n"} =
+               IRCServer.wait_for_line(
+                 server,
+                 &(&1 == "PRIVMSG NickServ :RELEASE #{@recover_nick} s3cret\r\n"),
+                 1_000
+               )
+    end
+
+    test "wrong password: a clean NICK with no +r → overall timeout → :failed :wrong_password" do
+      %{pid: pid, subject: subject, network: network, label: label} =
+        start_recover_visitor("s3cret")
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(label))
+
+      assert :ok = Session.recover_identity(subject, network.id)
+
+      # No 433/437 (clean NICK) and no +r ever → the only signal is the overall
+      # deadline. Fire it deterministically rather than waiting @recover_timeout_ms.
+      send(pid, :recover_timeout)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :recover_result, outcome: :failed, reason: :wrong_password}
+                     },
+                     1_000
+    end
+
+    test "hot-reload safety: a live proc predating the :recover_source field survives" do
+      # #229/#581 hot-reload contract. A plain hot reload does NOT rewrite live
+      # process state, so a Session.Server spawned before the #581
+      # `:recover_source` field existed keeps its old keyless map. `handle_call`
+      # reads it via `Map.get` (never `state.recover_source`), so a /recover on
+      # a stale proc must degrade to `:nothing_to_recover`, never KeyError-crash.
+      %{pid: pid, subject: subject, network: network} = start_recover_visitor("s3cret")
+
+      # Simulate the stale-proc shape: strip :recover_source from live state.
+      _ = :sys.replace_state(pid, fn state -> Map.delete(state, :recover_source) end)
+
+      assert {:error, :nothing_to_recover} = Session.recover_identity(subject, network.id)
+
+      # Same pid — the stale proc never crashed/respawned.
+      assert Process.alive?(pid)
+    end
+
+    test "hot-reload safety: +r on a proc predating the :recover_identity field does not crash" do
+      # #581 review-#2 (the CRITICAL half). The `:acquired` identity effect
+      # runs on EVERY +r (not just recover), and it consults the recover FSM.
+      # A proc spawned before the #581 field keeps its old keyless map, so the
+      # read MUST be `Map.get(after_autojoin, :recover_identity)` — dot-access
+      # would KeyError on the common identify path, crash-waving every
+      # pre-#581 session that identifies after a hot deploy.
+      %{server: server, pid: pid, label: label} = start_recover_visitor("s3cret")
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(label))
+
+      # Simulate the stale-proc shape: strip :recover_identity from live state.
+      _ = :sys.replace_state(pid, fn state -> Map.delete(state, :recover_identity) end)
+
+      # +r fires the :acquired effect → the 4442 recover-FSM consult. Absent
+      # key → Map.get default nil → no armed recover, no KeyError.
+      IRCServer.feed(server, ":irc.test.org MODE #{@recover_nick} :+r\r\n")
+
+      assert_receive %Phoenix.Socket.Broadcast{event: "event", payload: %{kind: :umode_changed}},
+                     1_000
+
+      assert Process.alive?(pid)
     end
   end
 end


### PR DESCRIPTION
Refs #581

## What

Visitor **"recover my identity"**: a `/recover` alias + a 🔑 home button, one
action path (`Session.recover_identity/2`) + a server-pushed progress modal.
Lets a parked/renamed visitor reclaim their registered nick and re-`IDENTIFY`.

### Sequence (source-verified `+r` ordering)
`NICK <cred_nick>` + `IDENTIFY <cred_nick> <secret>` together → await `+r` = success.
`433`→`RECOVER` / `437`→`RELEASE` → settle → NICK+IDENTIFY again → `+r`=success /
refused=`nick_unavailable` (F2, **no retry** — RECOVER was chosen precisely
because an empty retry never wins the nick); `+r` never after a clean NICK =
`wrong_password`. **Signal trusted = ONLY the `+r` umode, never NickServ notices.**
Visitor subjects only.

## Companion fix — stale `+r` after a self-NICK (first-class)

A state-fidelity bug the e2e surfaced: bahamut strips `+r` **silently** on a
genuine nick change (no MODE echo), and grappa's EventRouter self-NICK handler
never recomputed umodes → a visitor who `/nick`s away kept a **phantom `+r`** →
the recover button (`canRecover = recoverable && !"r"`) never showed in exactly
its own POST-001 scenario. Fix: `event_router.ex` `strip_r_on_self_rename/4` —
on our own genuine rename drops `"r"`, emits `:umode_changed` +
`session_identity_effects(→:lost)`. Only `"r"`; case-change is a no-op.

## Design notes

- **Secret source:** action + button read ONE source — the persistent
  `Credential.recover_secret/1` (nickserv_pass OR `:nickserv_identify` password),
  via a plan-injected `recover_source` closure (Boundary-clean DI seam, mirrors
  `visitor_committer`; `Grappa.Session` does not dep `Grappa.Networks`).
- **Wire:** additive-only, snake_case, NO protocol bump — `recover_progress` /
  `recover_result` events + a `recoverable: bool` home-row flag. `wireTypes.ts`
  is codegen from `wire.ex`.
- **AUTO vs MANUAL boundary:** `GhostRecovery` owns PRE-001 (held nick 433 before
  001, `pending_password` set → auto reclaim); #581 manual recover owns POST-001
  (already connected, non-`+r`, target held). Disjoint by connection phase.

## Tests

- Pure FSM exhaustive (all transitions incl. 437, wrong-pass, timeout, F2 terminal).
- Server integration (fake IRC server): handle_call gating + full drive with a
  **real** `:nickserv_identify` visitor credential past 001 + hot-reload safety.
- 2 event_router tests for the stale-`+r` fix.
- Real e2e (`recover-identity-real.spec.ts`): test 1 reverse (anon → not
  recoverable, button absent); test 2 positive (real azzurra services REGISTER+AUTH
  via mailpit → POST-001 voluntary `/nick` → 🔑 → 433→RECOVER→`+r` → visible
  `recover-modal-success`).

## Gates

- `scripts/check.sh` RC=0 — 8 doctests, 50 properties, **4834 tests, 0 failures**;
  dialyzer **Total errors: 0**; sobelow clean; **171 bats**; credo/format clean;
  gen_wire_types drift check clean.
- cic biome+tsc RC=0 + `run test` 3722 passed.
- e2e scoped `--grep "#581 recover-identity"` = 2 passed (real services, mailpit).

Rebased onto main `6b96b199` (one cic-only conflict in `friendlyChannelError.ts`,
kept both arms). 36 files, +2679/-17.

**Known findings (design, for follow-up):** wrong-password ~15s latency (only
`+r`-or-timeout signals it, per the no-notice-parsing spec); rfc1459 national-char
self-NICK case-change → spurious `:lost` (documented out-of-scope niche — the 5
sibling self-NICK sites tighten together or none).