### PR TITLE
cicchetto CTCP send side: /ctcp + /ping (#591)

### DIFF
--- a/cicchetto/e2e/fixtures/ircClient.ts
+++ b/cicchetto/e2e/fixtures/ircClient.ts
@@ -154,6 +154,38 @@ export class IrcPeer {
     this.client.raw(["NOTICE", target, body]);
   }
 
+  // #591 — answer an inbound CTCP PING by echoing its token straight back as a
+  // CTCP PING NOTICE, exactly as a real client (or shottino) does. Parsed off
+  // the RAW wire line rather than irc-framework's CTCP middleware, so it works
+  // regardless of the library's own CTCP handling; a `done` latch makes it
+  // one-shot, so a stray library auto-response can't double-fire from here.
+  // Call BEFORE the operator's `/ping` so the listener is armed when the query
+  // arrives. Grappa routes the reply to `$server` (CTCP-framed, 96bedfdd) and
+  // cic's correlation gate synthesises the RTT in the window `/ping` was typed.
+  answerCtcpPing(): void {
+    const delim = String.fromCharCode(1);
+    const marker = `:${delim}PING`;
+    let done = false;
+    this.client.on("raw", (event: { line: string; from_server: boolean }) => {
+      if (done || !event.from_server || event.line[0] !== ":") return;
+      const line = event.line;
+      // ":asker!user@host PRIVMSG <me> :\x01PING <token>\x01"
+      if (!line.includes(" PRIVMSG ")) return;
+      const at = line.indexOf(marker);
+      if (at < 0) return;
+      done = true;
+      const asker = line.slice(1, line.search(/[! ]/));
+      // Token = the bytes after ":\x01PING " up to the closing \x01 (optional),
+      // echoed verbatim — the whole protocol is that it returns byte for byte.
+      let rest = line.slice(at + marker.length);
+      if (rest.startsWith(" ")) rest = rest.slice(1);
+      const end = rest.indexOf(delim);
+      const token = end >= 0 ? rest.slice(0, end) : rest;
+      const body = token === "" ? `${delim}PING${delim}` : `${delim}PING ${token}${delim}`;
+      this.client.raw(["NOTICE", asker, body]);
+    });
+  }
+
   // Register a nick with NickServ. Used by P-0a e2es to put a peer
   // into +r (registered) state so a subsequent /whois returns 307
   // RPL_WHOISREGNICK. With EMAIL:1 (the config since GH #349 wired the

--- a/cicchetto/e2e/tests/issue591-ctcp-ping.spec.ts
+++ b/cicchetto/e2e/tests/issue591-ctcp-ping.spec.ts
@@ -1,0 +1,91 @@
+// Issue #591 — cicchetto's CTCP send side: `/ctcp` + `/ping`.
+//
+// Two full-stack round-trips jsdom cannot see (per feedback_ux_e2e_mandatory
+// + feedback_cicchetto_browser_smoke — the compose → REST → self-echo/reply →
+// WS → render path only exists against a real bahamut + a real peer):
+//
+//   1. /ctcp <target> <VERB> [args] — the operator's OWN outbound CTCP query
+//      self-echoes as a :privmsg carrying the raw `\x01VERB args\x01` body.
+//      The server tags it with typed meta (Grappa.IRC.CTCP.verb_args/1) and
+//      ScrollbackPane renders "→ CTCP VERB args to <target>" — NOT the raw
+//      \x01, which pre-#591 surfaced as a bare "<nick> VERB" chat row. cic
+//      never parses \x01; the render keys off the typed meta only.
+//
+//   2. /ping <target> — CTCP PING sugar. compose stamps a client-timestamp
+//      token, the peer echoes it back verbatim as a CTCP PING NOTICE, grappa
+//      routes that CTCP-framed reply to `$server` (86416a21/96bedfdd — a CTCP
+//      reply is protocol, not a DM), and cic's correlation gate
+//      (subscribe.ts) synthesises "CTCP PING reply from <peer>: N ms" in the
+//      window the /ping was typed in (irssi behaviour; RTT decoupled from the
+//      reply's routing).
+
+import { expect, test } from "../fixtures/test";
+import {
+  composeSend,
+  composeTextarea,
+  loginAs,
+  scrollbackLine,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
+import { assertMessagePersisted } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+const PEER_NICK = "m591peer";
+
+test("#591 — own /ctcp query self-echoes as '→ CTCP VERB args to target', not raw \\x01", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+  await expect(composeTextarea(page)).toBeVisible();
+
+  // Per-run unique arg so the shared #bofh scrollback doesn't accumulate
+  // strict-mode-colliding duplicate lines across runs (mirrors issue14/m10).
+  const tag = `v591-${crypto.randomUUID().slice(0, 8)}`;
+  await composeSend(page, `/ctcp ${CHANNEL} VERSION ${tag}`);
+
+  // Server-side: the outbound self-echo persists as :privmsg with the raw
+  // \x01 body verbatim (round-trip fidelity) — the typed meta that drives the
+  // render rides alongside it.
+  await assertMessagePersisted({
+    token: vjt.token,
+    networkSlug: NETWORK_SLUG,
+    channel: CHANNEL,
+    sender: NETWORK_NICK,
+    body: `\x01VERSION ${tag}\x01`,
+    kind: "privmsg",
+  });
+
+  // DOM: rendered as the CTCP query line (data-kind=privmsg), envelope gone.
+  await expect(
+    scrollbackLine(page, "privmsg", `→ CTCP VERSION ${tag} to ${CHANNEL}`),
+  ).toBeVisible({ timeout: 10_000 });
+});
+
+test("#591 — /ping shows the round-trip time in the source window", async ({ page }) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+  await expect(composeTextarea(page)).toBeVisible();
+
+  const peer = await IrcPeer.connect({ nick: PEER_NICK });
+  try {
+    // Arm the peer to echo any CTCP PING token straight back (what a real
+    // client does). No shared channel needed — /ping DMs the nick directly.
+    peer.answerCtcpPing();
+    await composeSend(page, `/ping ${peer.nick}`);
+
+    // The reply is CTCP-framed → grappa routes it to $server with typed ctcp
+    // meta; cic ALWAYS subscribes to $server, correlates the token back to the
+    // pending /ping, and synthesises the round-trip line in the SOURCE window
+    // (#bofh, where /ping was typed). The ms is wall-clock — assert the shape.
+    await expect(
+      scrollbackLine(page, "notice", new RegExp(`CTCP PING reply from ${peer.nick}: \\d+ ms`)),
+    ).toBeVisible({ timeout: 15_000 });
+  } finally {
+    await peer.disconnect("#591 ping done");
+  }
+});

--- a/cicchetto/e2e/tests/issue591-ctcp-ping.spec.ts
+++ b/cicchetto/e2e/tests/issue591-ctcp-ping.spec.ts
@@ -32,7 +32,6 @@ import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
-const PEER_NICK = "m591peer";
 
 test("#591 — own /ctcp query self-echoes as '→ CTCP VERB args to target', not raw \\x01", async ({
   page,
@@ -71,7 +70,16 @@ test("#591 — /ping shows the round-trip time in the source window", async ({ p
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
   await expect(composeTextarea(page)).toBeVisible();
 
-  const peer = await IrcPeer.connect({ nick: PEER_NICK });
+  // Per-run unique peer nick. A fixed nick is a 433/ghost time bomb under CI
+  // rerun + bahamut per-IP clone/flood: a leftover ghost from a prior aborted
+  // run (or a QUIT not yet propagated) makes `connect` collide, irc-framework
+  // registers under an ALTERNATE nick, but `peer.nick` stays the requested one
+  // — so `/ping <peer.nick>` DMs a nick that isn't there and the RTT line
+  // never arrives (15s timeout, the #600 CI red). A fresh nick per run/retry
+  // sidesteps the ghost entirely; mirrors the sibling peer specs
+  // (k16peer/e2e263 → `crypto.randomUUID().slice(...)`).
+  const peerNick = `m591-${crypto.randomUUID().slice(0, 5)}`;
+  const peer = await IrcPeer.connect({ nick: peerNick });
   try {
     // Arm the peer to echo any CTCP PING token straight back (what a real
     // client does). No shared channel needed — /ping DMs the nick directly.

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -649,7 +649,28 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
   );
 
   switch (msg.kind) {
-    case "privmsg":
+    case "privmsg": {
+      // #591 — the operator's OWN outbound CTCP query (/ctcp, /ping) self-echoes
+      // here as a :privmsg whose body is the raw \x01VERB args\x01 frame, tagged
+      // by the server with typed meta.ctcp_verb / meta.ctcp_args (SSOT
+      // Grappa.IRC.CTCP.verb_args/1). Render a human "→ CTCP VERB [args] to
+      // <target>" line instead of the raw \x01 body. cic reads the TYPED meta,
+      // NEVER \x01 (the "one IRC parser, on the server" invariant). ACTION never
+      // reaches here carrying ctcp meta — it rides the :action kind, which the
+      // server excludes from ctcp classification. This is a control surface, so
+      // it renders as plain text (no mIRC \x02/\x1D emphasis, like the numeric /
+      // raw-event surfaces). A matched inbound PING reply is consumed upstream
+      // (subscribe.ts) and never reaches any render path.
+      const ctcpVerb = msg.meta.ctcp_verb;
+      if (typeof ctcpVerb === "string") {
+        const ctcpArgs = typeof msg.meta.ctcp_args === "string" ? msg.meta.ctcp_args : "";
+        const query = ctcpArgs === "" ? `CTCP ${ctcpVerb}` : `CTCP ${ctcpVerb} ${ctcpArgs}`;
+        return (
+          <span class="scrollback-body">
+            → {query} to {msg.channel}
+          </span>
+        );
+      }
       return (
         <>
           {senderSpan("<", ">", msg.sender)}{" "}
@@ -658,6 +679,7 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
           </span>
         </>
       );
+    }
     case "notice": {
       // No-silent-drops bucket 1: structured raw-event rendering.
       // EventRouter's catch-all persists unhandled command verbs as

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -371,6 +371,49 @@ describe("ScrollbackPane", () => {
     expect(line.textContent ?? "").not.toContain("ACTION ");
   });
 
+  it("renders an own outbound CTCP query self-echo as a human line, not raw \\x01 — #591", () => {
+    // #591 — the operator's own /ctcp + /ping self-echo back as a :privmsg
+    // whose body is the raw \x01VERB args\x01 frame, tagged by the server with
+    // typed meta.ctcp_verb / meta.ctcp_args (SSOT Grappa.IRC.CTCP.verb_args/1).
+    // The render layer shows "→ CTCP VERB [args] to <target>" instead of the
+    // raw \x01 the operator would otherwise see in the window they typed in.
+    // cic reads the TYPED meta, never \x01 (the "one IRC parser" invariant).
+    // The e2e (M-591) pins the same against a real send.
+    const ctcpSelfEcho: ScrollbackMessage[] = [
+      {
+        id: 1,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: 1,
+        kind: "privmsg",
+        sender: "alice",
+        body: "\x01VERSION\x01",
+        meta: { ctcp_verb: "VERSION", ctcp_args: "" },
+      },
+      {
+        id: 2,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: 2,
+        kind: "privmsg",
+        sender: "alice",
+        body: "\x01PING 1706743200000\x01",
+        meta: { ctcp_verb: "PING", ctcp_args: "1706743200000" },
+      },
+    ];
+    setScrollback({ "freenode #grappa": ctcpSelfEcho });
+    render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+    const lines = screen.getAllByTestId("scrollback-line");
+    expect(lines).toHaveLength(2);
+    // No-arg verb → "→ CTCP VERSION to #grappa"; the raw \x01 never renders.
+    expect(lines[0]?.dataset.kind).toBe("privmsg");
+    expect(lines[0]).toHaveTextContent("→ CTCP VERSION to #grappa");
+    expect(lines[0]?.textContent ?? "").not.toContain("\x01");
+    // Arg-carrying verb → the token rides after the verb.
+    expect(lines[1]).toHaveTextContent("→ CTCP PING 1706743200000 to #grappa");
+    expect(lines[1]?.textContent ?? "").not.toContain("\x01");
+  });
+
   it("renders the action row with one space between '*' and the nick (not two) — #457", () => {
     // Regression pin for #457: the :action arm rendered `*  nick` (two
     // spaces) while every sibling `*`-framed kind (join/part/quit/…) uses

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -134,6 +134,14 @@ vi.mock("../lib/scrollback", () => ({
   sendMessage: vi.fn(),
 }));
 
+// #591 — /ping registers a pending correlation entry; spy it so the test can
+// assert the (networkId, nick, token, sourceKey, sourceChannel, sentAtMs) tuple
+// without exercising the real store.
+vi.mock("../lib/pingCorrelation", () => ({
+  registerPing: vi.fn(),
+  resolvePing: vi.fn(),
+}));
+
 vi.mock("../lib/members", () => ({
   membersByChannel: vi.fn(() => ({})),
   applyPresenceEvent: vi.fn(),
@@ -360,6 +368,68 @@ describe("compose submit — slash command dispatch", () => {
     // CTCP ACTION wraps body as \x01ACTION <text>\x01
     expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "\x01ACTION waves\x01");
     expect(result).toEqual({ ok: true });
+  });
+
+  // #591 — /ctcp <target> <verb> reuses the /me framing seam to build a single
+  // \x01VERB\x01 frame, sent to the EXPLICIT target (not the current window).
+  // No args → no trailing space inside the frame.
+  it("/ctcp <target> <verb> sends \\x01VERB\\x01 to the target (#591)", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/ctcp bob version");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "bob", "\x01VERSION\x01");
+    expect(result).toEqual({ ok: true });
+  });
+
+  // #591 — /ctcp <target> <verb> <args> frames \x01VERB args\x01 (single space
+  // after the verb), preserving arg case + interior spaces.
+  it("/ctcp <target> <verb> <args> frames \\x01VERB args\\x01 (#591)", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/ctcp #chan action waves at Everyone");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(sb.sendMessage).toHaveBeenCalledWith(
+      "freenode",
+      "#chan",
+      "\x01ACTION waves at Everyone\x01",
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  // #591 — /ping <target> sends a CTCP PING carrying a client timestamp token
+  // to the target, and registers a pending correlation entry keyed on the
+  // source window (where /ping was typed). Date.now is pinned so the token is
+  // deterministic; the RTT math itself is unit-tested in pingCorrelation.test.
+  it("/ping <target> sends CTCP PING with a timestamp token + registers pending (#591)", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    vi.spyOn(Date, "now").mockReturnValue(1706743200000);
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const pc = await import("../lib/pingCorrelation");
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/ping bob");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    // CTCP PING frame with the timestamp token, to the EXPLICIT target.
+    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "bob", "\x01PING 1706743200000\x01");
+    // Pending registered: (networkId, nick, token, sourceKey, sourceChannel, sentAtMs).
+    expect(pc.registerPing).toHaveBeenCalledWith(1, "bob", "1706743200000", k, "#a", 1706743200000);
+    expect(result).toEqual({ ok: true });
+
+    vi.mocked(Date.now).mockRestore();
   });
 
   // #127 — /info, /version, /motd resolve the network id from the slug and

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -432,6 +432,48 @@ describe("compose submit — slash command dispatch", () => {
     vi.mocked(Date.now).mockRestore();
   });
 
+  // #600 — the pending correlation MUST be registered BEFORE the send is
+  // awaited. `sendPrivmsg` is a REST POST; on a slow/loaded runner its ack can
+  // resolve AFTER the peer's CTCP PING reply has already been processed on the
+  // (separate, already-open) WS. If registration waited on the send,
+  // `maybeConsumePingReply → resolvePing` would find no pending entry and drop
+  // the RTT line — the #600 CI timeout (deterministic on the slow CI runner,
+  // invisible on a fast local box). Model the slow send with a deferred promise
+  // and assert registerPing already fired while the send is still pending.
+  it("/ping registers the pending BEFORE the send resolves — a fast reply can't lose it (#600)", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    vi.spyOn(Date, "now").mockReturnValue(1706743200000);
+    const sb = await import("../lib/scrollback");
+    const pc = await import("../lib/pingCorrelation");
+
+    // A send that stays pending until we release it — models a slow REST POST
+    // while the CTCP reply already flows over the already-open WS.
+    let releaseSend!: () => void;
+    vi.mocked(sb.sendMessage).mockReturnValue(
+      new Promise<void>((resolve) => {
+        releaseSend = resolve;
+      }),
+    );
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/ping bob");
+    const submitP = compose.submit(k, "freenode", "#a"); // do NOT await — send is pending
+
+    // Flush microtasks so compose reaches (and blocks on) the send await.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // THE RACE: with the send still unresolved, a reply arriving now MUST find a
+    // registered pending entry. Pre-fix (register AFTER the await) this is 0 calls.
+    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "bob", "\x01PING 1706743200000\x01");
+    expect(pc.registerPing).toHaveBeenCalledWith(1, "bob", "1706743200000", k, "#a", 1706743200000);
+
+    releaseSend();
+    await submitP;
+    vi.mocked(Date.now).mockRestore();
+  });
+
   // #127 — /info, /version, /motd resolve the network id from the slug and
   // push the bare verb; the reply renders in ServerReplyModal (server side).
   it("/info pushes INFO via pushInfo(networkId)", async () => {

--- a/cicchetto/src/__tests__/pingCorrelation.test.ts
+++ b/cicchetto/src/__tests__/pingCorrelation.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { channelKey } from "../lib/channelKey";
+import { registerPing, resolvePing } from "../lib/pingCorrelation";
+
+// #591 — the /ping reply-correlation table. Pure register/resolve with time
+// passed in explicitly (sentAtMs at register, nowMs at resolve) so the RTT
+// math is testable WITHOUT touching the wall clock (spec requirement). Tests
+// use distinct (network, nick, token) triples so the shared identity-scoped
+// store can't cross-contaminate. sourceKey is a branded ChannelKey built via
+// channelKey(slug, name) (the SSOT encoder), never a hand-spelled string.
+describe("pingCorrelation", () => {
+  it("resolves a matching ping with the RTT delta and source window", () => {
+    registerPing(1, "bob", "tok-a", channelKey("freenode", "#chan"), "#chan", 1000);
+
+    expect(resolvePing(1, "bob", "tok-a", 1042)).toEqual({
+      sourceKey: channelKey("freenode", "#chan"),
+      sourceChannel: "#chan",
+      rttMs: 42,
+    });
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(resolvePing(1, "nobody", "tok-none", 5000)).toBeNull();
+  });
+
+  it("folds the nick (CASEMAPPING=ascii) — register Bob, resolve bob", () => {
+    registerPing(1, "Bob", "tok-b", channelKey("freenode", "#room"), "#room", 2000);
+
+    expect(resolvePing(1, "bob", "tok-b", 2100)).toEqual({
+      sourceKey: channelKey("freenode", "#room"),
+      sourceChannel: "#room",
+      rttMs: 100,
+    });
+  });
+
+  it("is one-shot: a second resolve of the same reply is null", () => {
+    registerPing(1, "carol", "tok-c", channelKey("freenode", "carol"), "carol", 3000);
+
+    expect(resolvePing(1, "carol", "tok-c", 3050)).not.toBeNull();
+    expect(resolvePing(1, "carol", "tok-c", 3060)).toBeNull();
+  });
+
+  it("does not match across networks or tokens", () => {
+    registerPing(1, "dave", "tok-d", channelKey("freenode", "dave"), "dave", 4000);
+
+    // Wrong network id.
+    expect(resolvePing(2, "dave", "tok-d", 4010)).toBeNull();
+    // Wrong token.
+    expect(resolvePing(1, "dave", "tok-other", 4010)).toBeNull();
+    // The real one still resolves.
+    expect(resolvePing(1, "dave", "tok-d", 4010)).not.toBeNull();
+  });
+});

--- a/cicchetto/src/__tests__/slashCommands.test.ts
+++ b/cicchetto/src/__tests__/slashCommands.test.ts
@@ -1320,3 +1320,65 @@ describe("#385 — expandAlias grammar edge cases", () => {
     expect(expandAlias("s", "", { s: "msg #c $*" })).toEqual({ verb: "msg", rest: "#c" });
   });
 });
+
+// #591 — /ctcp <target> <VERB> [args]. Pure-parser shape: first token is the
+// target, second is the CTCP verb (uppercased per convention), the trimmed
+// remainder is the (optional) args. compose.ts builds the \x01VERB args\x01
+// frame — the parser stays framing-free (no \x01, no SolidJS).
+describe("parseSlash — /ctcp (#591)", () => {
+  it("/ctcp <target> <verb> uppercases the verb, empty args", () => {
+    expect(parseSlash("/ctcp bob version")).toEqual({
+      kind: "ctcp",
+      target: "bob",
+      verb: "VERSION",
+      args: "",
+    });
+  });
+
+  it("/ctcp <target> <verb> <args> uppercases verb, preserves arg case + spaces", () => {
+    expect(parseSlash("/ctcp #chan action waves at Everyone")).toEqual({
+      kind: "ctcp",
+      target: "#chan",
+      verb: "ACTION",
+      args: "waves at Everyone",
+    });
+  });
+
+  it("/ctcp bare → error (target + verb required)", () => {
+    expect(parseSlash("/ctcp")).toEqual({
+      kind: "error",
+      verb: "ctcp",
+      message: "/ctcp requires a target and a verb",
+    });
+  });
+
+  it("/ctcp <target> with no verb → error", () => {
+    expect(parseSlash("/ctcp bob")).toEqual({
+      kind: "error",
+      verb: "ctcp",
+      message: "/ctcp requires a target and a verb",
+    });
+  });
+});
+
+// #591 — /ping <target>: sugar for CTCP PING with a client timestamp. The
+// parser only carries the target; compose.ts stamps the outbound token and
+// owns the reply-correlation state (RTT is synthesized locally in the source
+// window, not routed as a NOTICE).
+describe("parseSlash — /ping (#591)", () => {
+  it("/ping <target> parses to {kind:'ping', target}", () => {
+    expect(parseSlash("/ping bob")).toEqual({ kind: "ping", target: "bob" });
+  });
+
+  it("/ping bare → error (target required)", () => {
+    expect(parseSlash("/ping")).toEqual({
+      kind: "error",
+      verb: "ping",
+      message: "/ping requires a target",
+    });
+  });
+
+  it("/ping <target> <extra> ignores trailing tokens", () => {
+    expect(parseSlash("/ping bob junk here")).toEqual({ kind: "ping", target: "bob" });
+  });
+});

--- a/cicchetto/src/__tests__/subscribe.test.ts
+++ b/cicchetto/src/__tests__/subscribe.test.ts
@@ -1733,6 +1733,100 @@ describe("subscribe — DM-listener (own-nick topic, inbound DM re-key)", () => 
     expect(store.scrollbackByChannel()[ownKey]).toBeUndefined();
   });
 
+  // #591 — a peer's CTCP PING reply arrives as a server-typed :notice with
+  // meta.ctcp_verb === "PING" + meta.ctcp_args === <our token>. When it claims
+  // a /ping WE sent, the reply is CONSUMED: the round-trip line is synthesized
+  // into the SOURCE window where /ping was typed (irssi behavior) and the raw
+  // reply neither beeps nor renders in the peer window. cic NEVER parses \x01 —
+  // the server SSOT Grappa.IRC.CTCP.verb_args/1 classified the verb into the
+  // typed meta; the correlation table (pingCorrelation) does the matching.
+  it("CTCP PING reply matching a pending /ping is consumed into the source window (RTT), no beep, no raw render", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedDmListenerStubs();
+    const beep = await import("../lib/beep");
+    // Real pingCorrelation (unmocked) — same singleton subscribe.ts resolves
+    // against, since both load from the module registry vi.resetModules() just
+    // refreshed. Register the pending /ping BEFORE firing the reply.
+    const { registerPing } = await import("../lib/pingCorrelation");
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalledTimes(3);
+    });
+    // Operator typed `/ping vjt` in the #grappa window: compose stamped the
+    // token and registered the pending entry keyed on (networkId, nick, token).
+    const sourceKey = channelKey("freenode", "#grappa");
+    registerPing(1, "vjt", "tok-591", sourceKey, "#grappa", 9958);
+    const eventCalls = mockChannel.on.mock.calls.filter((c) => c[0] === "event");
+    const dmHandler = eventCalls[1]?.[1] as (p: unknown) => void;
+    // The reply lands at now = 10_000 → rtt = 42 ms (sentAtMs 9958). Fixed
+    // Date.now so the RTT math is deterministic (spec requirement).
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(10_000);
+    dmHandler({
+      kind: "message",
+      message: {
+        id: 600,
+        network: "freenode",
+        channel: "alice",
+        server_time: 0,
+        kind: "notice",
+        sender: "vjt",
+        // Raw \x01-framed reply body — cic MUST NOT render this; the gate
+        // consumes on the typed meta, never by parsing the body.
+        body: "\x01PING tok-591\x01",
+        meta: { ctcp_verb: "PING", ctcp_args: "tok-591" },
+      },
+    });
+    nowSpy.mockRestore();
+    // Synthesized RTT line landed in the SOURCE window (#grappa), cic-owned copy.
+    expect(store.scrollbackByChannel()[sourceKey]?.map((m) => m.body)).toEqual([
+      "CTCP PING reply from vjt: 42 ms",
+    ]);
+    // The peer window got NOTHING — the reply was swallowed, not re-keyed raw.
+    expect(store.scrollbackByChannel()[channelKey("freenode", "vjt")]).toBeUndefined();
+    // No audible alert for a consumed correlation reply.
+    expect(beep.playBeep).not.toHaveBeenCalled();
+  });
+
+  // #591 additive rule (ruling #2, decoupled from #546/#548): a CTCP PING
+  // NOTICE that matches NO pending /ping of ours must NOT be swallowed — it
+  // routes through normal DM handling like any other peer notice.
+  it("CTCP PING notice matching NO pending /ping is NOT consumed — routes to the peer window", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedDmListenerStubs();
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalledTimes(3);
+    });
+    const eventCalls = mockChannel.on.mock.calls.filter((c) => c[0] === "event");
+    const dmHandler = eventCalls[1]?.[1] as (p: unknown) => void;
+    // A CTCP PING NOTICE we never sent a /ping for — leave it to normal routing.
+    dmHandler({
+      kind: "message",
+      message: {
+        id: 601,
+        network: "freenode",
+        channel: "alice",
+        server_time: 0,
+        kind: "notice",
+        sender: "vjt",
+        body: "\x01PING stray-token\x01",
+        meta: { ctcp_verb: "PING", ctcp_args: "stray-token" },
+      },
+    });
+    // Not consumed: the raw reply lands in the sender's window like any DM notice.
+    expect(store.scrollbackByChannel()[channelKey("freenode", "vjt")]?.map((m) => m.body)).toEqual([
+      "\x01PING stray-token\x01",
+    ]);
+  });
+
   // Self-echo guard: own outbound NOTICEs (server fans out to the
   // own-nick topic too) MUST NOT auto-open a window with our own nick
   // as the target — that would be a self-DM phantom window. The

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -311,16 +311,28 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         // #591 — /ping <target>: CTCP PING sugar. The token is a client
         // timestamp; it travels in the frame, comes back verbatim in the
         // reply's server-typed meta.ctcp_args, and the RTT is `now - sentAt`.
-        // Register the pending entry AFTER a successful send (the reply cannot
-        // precede the send) keyed on the SOURCE window so the RTT line lands
-        // where /ping was typed (irssi behavior; synthesized in subscribe.ts).
+        // Keyed on the SOURCE window so the RTT line lands where /ping was typed
+        // (irssi behavior; synthesized in subscribe.ts).
+        //
+        // #600 — register the pending entry BEFORE the send, NOT after. The
+        // earlier "register after a successful send — the reply cannot precede
+        // the send" ordering held only for the WIRE: `sendPrivmsg` is a REST
+        // POST, and on a slow/loaded runner its ack resolves AFTER the peer's
+        // CTCP PING reply has already been processed on the (separate,
+        // already-open) WS. With registration behind the `await`,
+        // `maybeConsumePingReply → resolvePing` found no pending entry and
+        // dropped the reply — the RTT line never rendered → the 15s CI timeout
+        // (deterministic on the CI runner, invisible on a fast local box).
+        // Registering first makes the pending present for any reply; if the send
+        // below throws, the orphaned entry is inert (one-shot, identity-scoped
+        // clear, never resolves without a matching reply).
         case "ping": {
           const networkId = networkIdBySlug(networkSlug);
           if (networkId === undefined) return { error: "/ping: network not found" };
           const sentAtMs = Date.now();
           const token = String(sentAtMs);
-          await sendPrivmsg(networkSlug, cmd.target, ctcpFrame("PING", token));
           registerPing(networkId, cmd.target, token, key, channelName, sentAtMs);
+          await sendPrivmsg(networkSlug, cmd.target, ctcpFrame("PING", token));
           result = { ok: true };
           break;
         }

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -24,6 +24,7 @@ import { splitMessageLines } from "./messageLines";
 import { openModeModal } from "./modeModal";
 import { networkBySlug, networkIdBySlug, user } from "./networks";
 import { asciiFold, nickEquals } from "./nickEquals";
+import { registerPing } from "./pingCorrelation";
 import { ensureQueryTopicJoined } from "./queryTopicJoin";
 import { canonicalQueryNick, openQueryWindowState } from "./queryWindows";
 import { quitAll } from "./quit";
@@ -107,13 +108,21 @@ const empty = (): ComposeState => ({
   stashedDraft: "",
 });
 
+// #591 — the single CTCP frame builder: `\x01VERB\x01` (no args) or
+// `\x01VERB args\x01`. This is the ONE place that wraps a body in CTCP `\x01`
+// framing — shared by /me (verb ACTION, one frame per line) and /ctcp
+// (arbitrary verb, single frame). Empty args yield NO trailing space, so a
+// bare `/ctcp bob version` frames as `\x01VERSION\x01`, not `\x01VERSION \x01`.
+export const ctcpFrame = (verb: string, args: string): string =>
+  args === "" ? `\x01${verb}\x01` : `\x01${verb} ${args}\x01`;
+
 // Multiline fan-out: split a free-text body into one PRIVMSG per line
 // (see messageLines.ts for the wire-framing why) and send each.
-// `action` wraps every line in CTCP ACTION framing for /me. Sequential
-// await preserves wire order; a single-line body loops exactly once, so
-// the common path is unchanged from the pre-split behavior. Shared by
-// the privmsg, me, and msg send sites — the only free-text paths whose
-// body can contain an operator-typed newline.
+// `action` wraps every line in CTCP ACTION framing for /me (via the shared
+// `ctcpFrame` builder). Sequential await preserves wire order; a single-line
+// body loops exactly once, so the common path is unchanged from the pre-split
+// behavior. Shared by the privmsg, me, and msg send sites — the only free-text
+// paths whose body can contain an operator-typed newline.
 export const sendBodyLines = async (
   slug: string,
   target: string,
@@ -121,7 +130,7 @@ export const sendBodyLines = async (
   action: boolean,
 ): Promise<void> => {
   for (const line of splitMessageLines(body)) {
-    await sendPrivmsg(slug, target, action ? `\x01ACTION ${line}\x01` : line);
+    await sendPrivmsg(slug, target, action ? ctcpFrame("ACTION", line) : line);
   }
 };
 
@@ -290,6 +299,31 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           await sendBodyLines(networkSlug, channelName, cmd.body, true);
           result = { ok: true };
           break;
+        // #591 — /ctcp <target> <VERB> [args]: a single CTCP frame to an
+        // EXPLICIT target (not the current window), built via the shared
+        // `ctcpFrame` seam. Non-ACTION CTCP is single-line by convention
+        // (Grappa.IRC.LineSplit) so there is no multiline fan-out. AWAIT the
+        // send: a CTCP verb MUST NOT silently no-op when the WS is down.
+        case "ctcp":
+          await sendPrivmsg(networkSlug, cmd.target, ctcpFrame(cmd.verb, cmd.args));
+          result = { ok: true };
+          break;
+        // #591 — /ping <target>: CTCP PING sugar. The token is a client
+        // timestamp; it travels in the frame, comes back verbatim in the
+        // reply's server-typed meta.ctcp_args, and the RTT is `now - sentAt`.
+        // Register the pending entry AFTER a successful send (the reply cannot
+        // precede the send) keyed on the SOURCE window so the RTT line lands
+        // where /ping was typed (irssi behavior; synthesized in subscribe.ts).
+        case "ping": {
+          const networkId = networkIdBySlug(networkSlug);
+          if (networkId === undefined) return { error: "/ping: network not found" };
+          const sentAtMs = Date.now();
+          const token = String(sentAtMs);
+          await sendPrivmsg(networkSlug, cmd.target, ctcpFrame("PING", token));
+          registerPing(networkId, cmd.target, token, key, channelName, sentAtMs);
+          result = { ok: true };
+          break;
+        }
         case "join":
           await postJoin(t, networkSlug, cmd.channel, cmd.key);
           // CP17: server-driven `:pending` window-state origination.

--- a/cicchetto/src/lib/pingCorrelation.ts
+++ b/cicchetto/src/lib/pingCorrelation.ts
@@ -1,0 +1,73 @@
+import type { ChannelKey } from "./channelKey";
+import { identityScopedStore } from "./identityScopedStore";
+import { asciiFold } from "./nickEquals";
+
+// #591 — the /ping reply-correlation table (the cic twin of shottino's
+// (network, nick, stamp) table; see DESIGN_NOTES 2026-08-01). When the operator
+// runs `/ping <nick>`, compose sends a CTCP PING carrying a client timestamp
+// token and registers a pending entry here. The reply arrives as a server-typed
+// `:notice` with `meta.ctcp_verb == "PING"` + `meta.ctcp_args == <token>`
+// (cic NEVER parses \x01 — the server SSOT `Grappa.IRC.CTCP.verb_args/1`
+// classified it). subscribe.ts resolves the token back to the SOURCE window and
+// synthesizes the round-trip line there (irssi behavior), consuming the reply.
+//
+// Time is passed in explicitly (`sentAtMs` at register, `nowMs` at resolve) so
+// the RTT delta is a pure subtraction — no wall clock inside this module, which
+// is what makes it testable per the spec.
+//
+// Ephemeral + identity-scoped: cleared on logout / token rotation, like
+// `inviteAck`. A ping in flight across a logout is simply forgotten — the RTT
+// is an immediate cue, not an audit record.
+
+type PendingPing = {
+  sourceKey: ChannelKey;
+  sourceChannel: string;
+  sentAtMs: number;
+};
+
+// Key on (network id, ASCII-folded nick, opaque token). The fold matches the
+// server's CASEMAPPING=ascii nick fold (#525) so a reply from `Bob` claims a
+// `/ping bob` entry; the token is opaque (never re-tokenized).
+const pendingKey = (networkId: number, nick: string, token: string): string =>
+  `${networkId}\x00${asciiFold(nick)}\x00${token}`;
+
+const exports_ = identityScopedStore((onIdentityChange) => {
+  const pending = new Map<string, PendingPing>();
+  onIdentityChange(() => pending.clear());
+
+  const registerPing = (
+    networkId: number,
+    nick: string,
+    token: string,
+    sourceKey: ChannelKey,
+    sourceChannel: string,
+    sentAtMs: number,
+  ): void => {
+    pending.set(pendingKey(networkId, nick, token), { sourceKey, sourceChannel, sentAtMs });
+  };
+
+  // Returns the source window + RTT for a reply that CLAIMS a pending entry,
+  // deleting it (one-shot). Returns null for a reply that matches nothing —
+  // the caller then leaves that notice to its normal routing, untouched.
+  const resolvePing = (
+    networkId: number,
+    nick: string,
+    token: string,
+    nowMs: number,
+  ): { sourceKey: ChannelKey; sourceChannel: string; rttMs: number } | null => {
+    const key = pendingKey(networkId, nick, token);
+    const entry = pending.get(key);
+    if (entry === undefined) return null;
+    pending.delete(key);
+    return {
+      sourceKey: entry.sourceKey,
+      sourceChannel: entry.sourceChannel,
+      rttMs: nowMs - entry.sentAtMs,
+    };
+  };
+
+  return { registerPing, resolvePing };
+});
+
+export const registerPing = exports_.registerPing;
+export const resolvePing = exports_.resolvePing;

--- a/cicchetto/src/lib/slashCommands.ts
+++ b/cicchetto/src/lib/slashCommands.ts
@@ -189,6 +189,14 @@ export type SlashCommand =
   | { kind: "unalias"; name: string }
   | { kind: "quote"; line: string }
   | { kind: "oper"; name: string; password: string }
+  // #591 — /ctcp <target> <VERB> [args]: send an arbitrary CTCP query. The
+  // parser carries the raw parts (verb uppercased per convention); compose.ts
+  // reuses the /me framing seam to build the single \x01VERB args\x01 frame.
+  | { kind: "ctcp"; target: string; verb: string; args: string }
+  // #591 — /ping <target>: sugar for CTCP PING. The parser only carries the
+  // target; compose.ts stamps the outbound timestamp token and owns the
+  // reply-correlation state (RTT synthesized locally in the source window).
+  | { kind: "ping"; target: string }
   | { kind: "error"; verb: string; message: string };
 
 function err(verb: string, message: string): SlashCommand {
@@ -269,12 +277,45 @@ function parseDehilight(_verb: string, rest: string): SlashCommand {
   return { kind: "watchlist", action: "del", pattern };
 }
 
+// #591 — /ctcp <target> <VERB> [args]. First whitespace-delimited token is the
+// target, the second is the CTCP verb (uppercased per convention), the trimmed
+// remainder is the (optional) args. A missing target OR verb is a usage error.
+// The parser stays framing-free: compose.ts builds the \x01VERB args\x01 frame
+// via the shared /me send seam (no second CTCP writer).
+function parseCtcp(rest: string): SlashCommand {
+  const trimmed = rest.trim();
+  const sp1 = trimmed.search(/\s/);
+  // No target, or a target with no following verb token.
+  if (trimmed === "" || sp1 === -1) {
+    return err("ctcp", "/ctcp requires a target and a verb");
+  }
+  const target = trimmed.slice(0, sp1);
+  const afterTarget = trimmed.slice(sp1 + 1).trim();
+  const sp2 = afterTarget.search(/\s/);
+  const verb = (sp2 === -1 ? afterTarget : afterTarget.slice(0, sp2)).toUpperCase();
+  const args = sp2 === -1 ? "" : afterTarget.slice(sp2 + 1).trim();
+  return { kind: "ctcp", target, verb, args };
+}
+
+// #591 — /ping <target>. Only the target survives the parser; compose.ts owns
+// the timestamp token + reply correlation. Trailing tokens are ignored (a nick
+// is a single word), mirroring /whois <server> <nick> <junk>.
+function parsePing(rest: string): SlashCommand {
+  const [target] = tokens(rest);
+  if (target === undefined) return err("ping", "/ping requires a target");
+  return { kind: "ping", target };
+}
+
 // Dispatch table: verb (lowercased) → handler(verb, rest) → SlashCommand.
 // Every registered verb must appear here; unknown verbs produce {kind: "error"}.
 type Handler = (verb: string, rest: string) => SlashCommand;
 
 const DISPATCH: Readonly<Record<string, Handler>> = {
   me: (_verb, rest) => ({ kind: "me", body: rest }),
+
+  // #591 — CTCP send verbs. /ctcp is the general form; /ping is the RTT sugar.
+  ctcp: (_verb, rest) => parseCtcp(rest),
+  ping: (_verb, rest) => parsePing(rest),
 
   join: (verb, rest) => {
     // UX-4 bucket F: `/join #chan` OR `/join #chan key` (+k channel

--- a/cicchetto/src/lib/subscribe.ts
+++ b/cicchetto/src/lib/subscribe.ts
@@ -12,10 +12,18 @@ import { seedIsupport } from "./isupport";
 import { applyPresenceEvent, seedMembers } from "./members";
 import { matchesWatchlist } from "./mentionMatch";
 import { setServerMention } from "./mentions";
-import { channelsBySlug, networks, refetchChannels, refetchNetworks, user } from "./networks";
+import {
+  channelsBySlug,
+  networkIdBySlug,
+  networks,
+  refetchChannels,
+  refetchNetworks,
+  user,
+} from "./networks";
 import { nickEquals } from "./nickEquals";
 import { isOperatorActionEcho } from "./operatorActionEcho";
 import { isOwnPresenceEvent } from "./ownPresenceEvent";
+import { resolvePing } from "./pingCorrelation";
 import { setEnsureQueryTopicJoined } from "./queryTopicJoin";
 import { canonicalQueryNick, queryWindowsByNetwork } from "./queryWindows";
 import { applyJoinReply, applyReadCursorSet, renameReadCursorChannel } from "./readCursor";
@@ -170,6 +178,33 @@ createRoot(() => {
   //     DM window which may not be selected, but own-sent messages in an
   //     unselected window do still bump (correct — the operator changed
   //     windows between sending and receiving the echo).
+  // #591 — a peer's CTCP PING reply arrives as a server-typed :notice with
+  // `meta.ctcp_verb === "PING"` + `meta.ctcp_args === <our token>` (the SSOT
+  // `Grappa.IRC.CTCP.verb_args/1` classified it; cic NEVER parses \x01). If the
+  // token claims a `/ping` WE sent (pingCorrelation), CONSUME it: synthesize the
+  // round-trip line into the SOURCE window where /ping was typed (irssi
+  // behavior) and swallow the raw reply — no beep, no raw \x01 render. A reply
+  // that matches nothing is NOT consumed (returns false): the caller leaves it
+  // to normal DM routing, so this stays strictly additive (ruling #2, decoupled
+  // from the #546/#548 CTCP-routing work). The RTT body is a cic-owned display
+  // string (the server sends structured data only), keyed on the correlation's
+  // resolved source window, never the peer's.
+  const maybeConsumePingReply = (slug: string, message: ChannelEvent["message"]): boolean => {
+    if (message.kind !== "notice" || message.meta.ctcp_verb !== "PING") return false;
+    const token = message.meta.ctcp_args;
+    if (typeof token !== "string") return false;
+    const networkId = networkIdBySlug(slug);
+    if (networkId === undefined) return false;
+    const hit = resolvePing(networkId, message.sender, token, Date.now());
+    if (hit === null) return false;
+    appendToScrollback(hit.sourceKey, {
+      ...message,
+      channel: hit.sourceChannel,
+      body: `CTCP PING reply from ${message.sender}: ${hit.rttMs} ms`,
+    });
+    return true;
+  };
+
   const routeMessage = (
     slug: string,
     key: ChannelKey,
@@ -177,6 +212,10 @@ createRoot(() => {
     message: ChannelEvent["message"],
     ownNick: string | null,
   ): void => {
+    // #591 — swallow a matched CTCP PING reply before it renders raw in this
+    // window. Catches every routing path (channel/query/DM-listener); the
+    // DM-listener notice arm ALSO gates earlier to suppress its pre-route beep.
+    if (maybeConsumePingReply(slug, message)) return;
     appendToScrollback(key, message);
     // Message-replay-on-reconnect cluster — track high-water mark per
     // topic so the backfill on the NEXT reconnect knows where to
@@ -665,6 +704,11 @@ createRoot(() => {
             // NOTICEs (NickServ etc.) never hit this branch — our server
             // routes those to "$server" not the own-nick channel.
             //
+            // #591 — a peer's CTCP PING reply is DM-shaped (lands here at
+            // channel == ownNick). Consume a matched one BEFORE the beep below:
+            // routeMessage's own gate swallows the raw render, but this arm
+            // beeps PRE-route, so the suppression must happen here too.
+            if (maybeConsumePingReply(slug, message)) return;
             // #372: canonical peer re-key — see the PRIVMSG/ACTION arm.
             const peer = canonicalQueryNick(networkId, message.sender);
             const senderKey = channelKey(slug, peer);

--- a/config/config.exs
+++ b/config/config.exs
@@ -324,6 +324,12 @@ config :logger, :console,
     # re-prefix them. In the allowlist to satisfy the known_keys↔metadata
     # sync test even though no Logger call carries it today.
     :sender_prefix,
+    # #591 — CTCP frame classification (Grappa.IRC.CTCP.verb_args/1) tagged onto
+    # a :notice (peer's CTCP reply) or :privmsg (own /ctcp /ping self-echo) row.
+    # In the allowlist to satisfy the known_keys↔metadata sync test even though
+    # no Logger call carries them today.
+    :ctcp_verb,
+    :ctcp_args,
     # Auth context (Phase 2): bearer-token session lifecycle. `session_ref`
     # is a non-reversible SHA-256 handle of the session-id (S9: the raw id
     # IS the bearer token, so it must NEVER hit the log stream) — it rides

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -25162,3 +25162,72 @@ control inside the panel is `none`, under the active is-ios kill, mirroring
 (without the fix the panel computes `none`). Real long-press selection is not
 emulatable on Playwright webkit, so computed style is the testable boundary;
 device dogfood is the final iOS check.
+## 2026-08-01 — #591 CTCP send side: `/ctcp`, `/ping`, and one CTCP parser on the server
+
+cicchetto had no `/ctcp` and no `/ping` — both standard irssi client verbs.
+This is the SEND side (the receive side of `/me` ACTION shipped in #14). Two
+decisions drove the shape.
+
+**One IRC parser, on the server (the invariant held).** The tempting cic-side
+approach — inspect the incoming NOTICE body for `\x01PING <token>\x01` to
+correlate an RTT — was rejected: it would be the first place cic parses CTCP
+framing out of a body, breaking "one IRC parser, on the server; cic never
+parses IRC." Instead the server SSOT `Grappa.IRC.CTCP` gained `verb_args/1`
+(classify any `\x01VERB [args]\x01` into `{verb, args} | :none`), the sibling
+to the existing `action?/1`. The EventRouter NOTICE arm tags a peer's CTCP
+reply with typed **flat** meta `ctcp_verb` / `ctcp_args`, and the Session.Server
+outbound self-echo persist tags the operator's own `/ctcp`/`/ping` the same
+way — both through the ONE SSOT, so the two halves cannot drift (the #14
+lesson). cic reads `meta.ctcp_verb` / `meta.ctcp_args` typed and never touches
+`\x01`. The `\x01` body is preserved verbatim (round-trip fidelity).
+
+**Flat meta keys, not nested.** `Grappa.Scrollback.Meta` atomizes only
+top-level keys and its moduledoc bans nested string-keyed maps (the B6.1 note),
+so the shape is `ctcp_verb` + `ctcp_args`, not `ctcp: %{...}`. Adding them was
+the standard cost of any new meta field: `@known_keys` + `@type` + `@spec` in
+`meta.ex`, and the synced Logger `:metadata` allowlist in `config/config.exs`
+(the A18 sync test enforces the pair). This makes #591 **cold-forcing** via the
+config change.
+
+**The RTT line is synthesized client-side, in the source window.** Per the
+maintainer ruling: the RTT is NOT a routed NOTICE — cic correlates the reply's
+token (from `meta.ctcp_args`) against a pending-`/ping` table keyed by
+`(network, nick, token)`, and on a match synthesizes the round-trip line into
+the window where `/ping` was typed (irssi behavior), consuming the reply. No
+match → the notice falls through to its normal routing untouched (the #546/#548
+domain), so the change is strictly additive. (shottino's own `/ping` uses the
+same correlation-table shape — see the 2026-08-01 shottino note.)
+
+**Outbound self-echo cleanup is part of the feature, not scope creep.** Before
+#591 a CTCP frame could not be typed at all, so the raw-`\x01` self-echo is a
+wart this feature *creates*; shipping `/ctcp`/`/ping` with a raw control-char
+line in the sender's own window would be visibly broken every time. The fix is
+the same SSOT + the same persist call-site that already classifies ACTION —
+inbound and outbound classified identically. ACTION itself is never tagged into
+meta (it rides its dedicated `:action` kind).
+
+**Inbound PING answer re-landed (86416a21/96bedfdd) — the duplication this note
+predicted is now REAL, in the same file.** The "answer incoming CTCP PING"
+feature (reverted once as 3d690e0a → 6b96b199 for a Credo-strict `do_route`
+complexity 10>9) re-landed the same day as `86416a21` + `96bedfdd`: the answer
+moved into `ctcp_ping_reply/4` (out of the over-complex `do_route` clause) and
+`Grappa.IRC.CTCP.framed?/1` was added so a CTCP-framed reply NOTICE routes to
+`$server` instead of minting a peer query window. Two consequences for #591,
+both handled at the rebase onto `96bedfdd`:
+
+1. **Routing.** A peer's CTCP PING *reply* now persists on `$server` (not
+   `channel = peer`). #591's `ctcp_meta/1` tags it there all the same, and cic
+   is ALWAYS subscribed to `$server`, so the RTT-correlation gate
+   (`subscribe.ts maybeConsumePingReply`, top of `routeMessage`) receives it
+   with no query-window subscribe race. The event_router test asserts the
+   `$server` channel AND the typed meta together.
+2. **Duplication (the one this note predicted).** The re-land added
+   `ctcp_payload/1` — a byte-for-byte duplicate of `verb_args/1`'s
+   arg-extraction — while the pre-existing `ctcp_verb/1` already duplicates the
+   verb half. `framed?/1` is NOT a duplicate (it asks "opens with `\x01` at
+   all", true even for a bare `\x01`; `verb_args/1` returns `:none` there — a
+   distinct, correctly-co-located SSOT primitive). Routing `ctcp_verb/1` +
+   `ctcp_payload/1` through the single `CTCP.verb_args/1` is the correct "one
+   CTCP parser on the server" cleanup, but it touches another author's
+   just-landed code plus a pre-existing helper, so it is proposed to vjt
+   rather than folded silently into #591's send-side scope.

--- a/lib/grappa/irc/ctcp.ex
+++ b/lib/grappa/irc/ctcp.ex
@@ -52,4 +52,48 @@ defmodule Grappa.IRC.CTCP do
   @spec framed?(binary()) :: boolean()
   def framed?(<<0x01, _::binary>>), do: true
   def framed?(_), do: false
+
+  @doc """
+  Classifies any CTCP frame into its `{verb, args}` (#591).
+
+  A CTCP body is `\\x01<VERB>[ <args>]\\x01` (trailing `\\x01` optional, per
+  the same leniency as `action?/1`). Returns `{verb, args}` — `args` is `""`
+  when the verb carries none, and preserves interior spaces verbatim (the
+  argument is an opaque echo, e.g. a PING token, never re-tokenized). Returns
+  `:none` for a non-CTCP body, an empty body, a bare `\\x01`, or a frame whose
+  opening delimiter is not immediately followed by a verb.
+
+  This is the SINGLE CTCP verb parser shared by BOTH directions so they cannot
+  drift (the #14 lesson): the inbound EventRouter NOTICE arm tags a peer's CTCP
+  PING reply, and the outbound `Session.Server` self-echo persist tags the
+  operator's own `/ctcp`/`/ping` — both into a typed `meta.ctcp` cic consumes
+  WITHOUT ever touching `\\x01`. `ACTION` is classified here too, but callers
+  keep routing it through its dedicated `:action` kind (`action?/1`); every
+  OTHER verb rides `meta.ctcp`.
+  """
+  @spec verb_args(binary()) :: {String.t(), String.t()} | :none
+  def verb_args(<<0x01, rest::binary>>) do
+    case String.split(strip_trailing_delim(rest), " ", parts: 2) do
+      [verb | _] when verb == "" -> :none
+      [verb] -> {verb, ""}
+      [verb, args] -> {verb, args}
+    end
+  end
+
+  def verb_args(_), do: :none
+
+  # Drops a single trailing `\x01` (CTCP's optional closing delimiter) so the
+  # last argument doesn't carry the delimiter byte. Byte-level per "IRC is
+  # bytes"; safe on an empty binary.
+  @spec strip_trailing_delim(binary()) :: binary()
+  defp strip_trailing_delim(""), do: ""
+
+  defp strip_trailing_delim(bin) do
+    last_at = byte_size(bin) - 1
+
+    case binary_part(bin, last_at, 1) do
+      <<0x01>> -> binary_part(bin, 0, last_at)
+      _ -> bin
+    end
+  end
 end

--- a/lib/grappa/scrollback/meta.ex
+++ b/lib/grappa/scrollback/meta.ex
@@ -106,6 +106,18 @@ defmodule Grappa.Scrollback.Meta do
       :nick_change                  →  %{new_nick: String.t()}
       :mode                         →  %{modes: String.t(), args: [String.t()]}
       :kick                         →  %{target: String.t()}     (body carries reason)
+      :notice  | :privmsg           →  %{ctcp_verb: String.t(), ctcp_args: String.t()}
+                                                                 (#591: a CTCP frame classified by
+                                                                  Grappa.IRC.CTCP.verb_args/1 — a peer's
+                                                                  CTCP reply arriving as :notice (e.g.
+                                                                  the PING reply answering our /ping), OR
+                                                                  the operator's OWN outbound /ctcp /ping
+                                                                  self-echo as :privmsg. FLAT keys — cic
+                                                                  reads them typed, never \x01. Both keys
+                                                                  present or neither. args is "" for a
+                                                                  verb with no argument. ACTION is NOT
+                                                                  tagged here — it rides its own :action
+                                                                  kind.)
 
   Phase 1 only writes `:privmsg` rows where `meta = %{}` so Phase 1
   exercises only the empty-map path. The allowlist + atomization is
@@ -141,10 +153,12 @@ defmodule Grappa.Scrollback.Meta do
             | :sender_user
             | :sender_host
             | :sender_prefix
+            | :ctcp_verb
+            | :ctcp_args
           ) => term()
         }
 
-  @known_keys ~w[target new_nick modes args numeric severity who who_target names names_target raw_verb raw_sender raw_params sender_user sender_host sender_prefix]a
+  @known_keys ~w[target new_nick modes args numeric severity who who_target names names_target raw_verb raw_sender raw_params sender_user sender_host sender_prefix ctcp_verb ctcp_args]a
 
   @doc """
   The atom-key allowlist. Exposed so the test suite can assert that
@@ -169,7 +183,9 @@ defmodule Grappa.Scrollback.Meta do
           | :raw_params
           | :sender_user
           | :sender_host
-          | :sender_prefix,
+          | :sender_prefix
+          | :ctcp_verb
+          | :ctcp_args,
           ...
         ]
   def known_keys, do: @known_keys

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -394,8 +394,8 @@ defmodule Grappa.Session.EventRouter do
   defp do_route(%Message{command: :privmsg, params: [target, body]} = msg, state)
        when is_binary(target) and is_binary(body) and
               binary_part(body, 0, 1) == <<0x01>> do
-    case ctcp_verb(body) do
-      "VERSION" ->
+    case CTCP.verb_args(body) do
+      {"VERSION", _} ->
         sender = Message.sender_nick(msg)
         version = Grappa.Version.current()
         reply = "NOTICE #{sender} :\x01VERSION grappa #{version}\x01"
@@ -424,7 +424,7 @@ defmodule Grappa.Session.EventRouter do
 
         {:cont, state2, [{:reply, reply}, persist_eff]}
 
-      "PING" ->
+      {"PING", _} ->
         # Answered in its own function, not inline: this clause was at
         # cyclomatic complexity 9 (Credo's strict maximum) before the arm
         # existed, and the arm's own case + if took it to 10. The limit
@@ -2603,20 +2603,6 @@ defmodule Grappa.Session.EventRouter do
   # and the wire-frame splitter (LineSplit). See issue #14: the two paths
   # had drifted (inbound :action, outbound :privmsg).
 
-  # Extracts the CTCP verb from a `\x01VERB ...\x01` (or `\x01VERB\x01`)
-  # body. Returns nil if the body doesn't start with \x01 or has no
-  # parseable verb. Used by the CTCP-aware PRIVMSG arm to dispatch on
-  # verb name (VERSION today; PING / TIME / SOURCE / FINGER candidates).
-  @spec ctcp_verb(binary()) :: String.t() | nil
-  defp ctcp_verb(<<0x01, rest::binary>>) do
-    case :binary.split(rest, [" ", <<0x01>>]) do
-      ["" | _] -> nil
-      [verb | _] -> verb
-    end
-  end
-
-  defp ctcp_verb(_), do: nil
-
   # CTCP PING: echo the payload back, unchanged and uninspected.
   #
   # The token is the ASKER's — conventionally their clock, but it is
@@ -2635,12 +2621,17 @@ defmodule Grappa.Session.EventRouter do
   defp ctcp_ping_reply(msg, target, body, state) do
     sender = Message.sender_nick(msg)
 
-    # A token-less `\x01PING\x01` echoes back token-less, rather than
-    # with a stray separator the asker never sent.
+    # The echoed token comes from the single SSOT parser
+    # (`CTCP.verb_args/1`), not a local duplicate. A token-less
+    # `\x01PING\x01` echoes back token-less, rather than with a stray
+    # separator the asker never sent. `:none` cannot occur here (this arm
+    # is reached only on a `{"PING", _}` match) but is handled as the
+    # empty-token case for totality.
     reply =
-      case ctcp_payload(body) do
-        "" -> "NOTICE #{sender} :\x01PING\x01"
-        payload -> "NOTICE #{sender} :\x01PING #{payload}\x01"
+      case CTCP.verb_args(body) do
+        {_, ""} -> "NOTICE #{sender} :\x01PING\x01"
+        {_, token} -> "NOTICE #{sender} :\x01PING #{token}\x01"
+        :none -> "NOTICE #{sender} :\x01PING\x01"
       end
 
     dm_channel =
@@ -2653,22 +2644,6 @@ defmodule Grappa.Session.EventRouter do
 
     {:cont, state2, [{:reply, reply}, persist_eff]}
   end
-
-  # The argument of a `\x01VERB arg\x01` body, verbatim and NOT parsed:
-  # a CTCP PING token is the asker's to choose, and the only contract is
-  # that it comes back unchanged. Empty when the body carries no
-  # argument (`\x01PING\x01`), which echoes an empty token rather than
-  # inventing one. The trailing \x01 is stripped; anything after it
-  # cannot be part of this CTCP.
-  @spec ctcp_payload(binary()) :: String.t()
-  defp ctcp_payload(<<0x01, rest::binary>>) do
-    case :binary.split(rest, " ") do
-      [_, arg] -> arg |> :binary.split(<<0x01>>) |> hd()
-      _ -> ""
-    end
-  end
-
-  defp ctcp_payload(_), do: ""
 
   # #591 — the typed CTCP meta for a persisted row whose body is a CTCP frame,
   # or `%{}` for a plain (non-CTCP) body. FLAT keys (`ctcp_verb`/`ctcp_args`)

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -2226,7 +2226,14 @@ defmodule Grappa.Session.EventRouter do
               binary_part(target, 0, 1) not in ["#", "&", "!", "+"] do
     sender = Message.sender_nick(msg)
     {channel, body_to_persist} = route_non_channel_notice(sender, body, state)
-    {state, eff} = build_persist(state, :notice, channel, sender, body_to_persist, %{})
+    # #591 — a peer's CTCP reply (a NOTICE carrying `\x01VERB [args]\x01`, e.g.
+    # the CTCP PING reply answering our /ping) is classified ONCE here, on the
+    # server, into a typed `meta.ctcp`. The \x01 body is preserved verbatim
+    # (round-trip fidelity) but cic reads the TYPED meta — never \x01 — to
+    # correlate a PING reply's token back to the /ping it sent (RTT synthesized
+    # client-side). A non-CTCP notice (NickServ, MOTD, plain peer notice) is
+    # `:none` → empty meta, so this is strictly additive.
+    {state, eff} = build_persist(state, :notice, channel, sender, body_to_persist, ctcp_meta(body))
     {:cont, state, [eff]}
   end
 
@@ -2662,6 +2669,28 @@ defmodule Grappa.Session.EventRouter do
   end
 
   defp ctcp_payload(_), do: ""
+
+  # #591 — the typed CTCP meta for a persisted row whose body is a CTCP frame,
+  # or `%{}` for a plain (non-CTCP) body. FLAT keys (`ctcp_verb`/`ctcp_args`)
+  # per the `Grappa.Scrollback.Meta` allowlist convention — that type atomizes
+  # only top-level keys and its moduledoc bans nested string-keyed maps (the
+  # B6.1 note). Classification is single-sourced in the SSOT
+  # `Grappa.IRC.CTCP.verb_args/1` (shared with the outbound self-echo persist in
+  # Session.Server). cic reads `meta.ctcp_verb` / `meta.ctcp_args` (typed) —
+  # never \x01. A future INBOUND CTCP-PING answer (reverted from main as
+  # 3d690e0a) MUST also route through `CTCP.verb_args/1` rather than re-adding an
+  # inline match, so it does not re-collide with this SSOT (DESIGN_NOTES
+  # 2026-08-01).
+  @spec ctcp_meta(binary()) :: %{optional(:ctcp_verb) => String.t(), optional(:ctcp_args) => String.t()}
+  defp ctcp_meta(body) do
+    case CTCP.verb_args(body) do
+      # ACTION rides its own :action kind (a NOTICE-ACTION is non-standard
+      # anyway) — never double-tag it into meta.
+      {"ACTION", _} -> %{}
+      {verb, args} -> %{ctcp_verb: verb, ctcp_args: args}
+      :none -> %{}
+    end
+  end
 
   # Shared default PRIVMSG handler — used by both the generic arm and
   # the CTCP-aware arm's fallthrough for unknown verbs. Pulls out the

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -3446,7 +3446,15 @@ defmodule Grappa.Session.Server do
           # for the inbound side; nil → %{} for DM targets / plain grade.
           # Members-map lookup uses the folded `key` (EventRouter keys the
           # members map by the folded channel too).
-          meta: own_sender_prefix_meta(state, key),
+          #
+          # #591 — merge the typed `meta.ctcp` for the operator's OWN outbound
+          # CTCP self-echo (`/ctcp`, `/ping`), so cic renders "→ CTCP VERB"
+          # instead of the raw \x01 body of the query it just sent. Same SSOT
+          # (`Grappa.IRC.CTCP.verb_args/1`) and same call-site that already
+          # classifies ACTION at line ~3302 — inbound (EventRouter NOTICE arm)
+          # + outbound classified identically, per the #14 lesson. ACTION keeps
+          # its `:action` kind; cic ignores meta.ctcp on :action rows.
+          meta: Map.merge(own_sender_prefix_meta(state, key), ctcp_self_echo_meta(fragment)),
           # CP14 B3 — outbound DM detection. `Scrollback.dm_peer/4` is
           # the single source for the rule (channel msg vs DM): for
           # outbound, target is the peer iff target is nick-shaped (no
@@ -3488,6 +3496,25 @@ defmodule Grappa.Session.Server do
     case Identifier.member_prefix(sigils) do
       nil -> %{}
       prefix -> %{sender_prefix: prefix}
+    end
+  end
+
+  # #591 — the typed CTCP meta for the operator's OWN outbound CTCP self-echo,
+  # or `%{}` for a plain body. FLAT keys (`ctcp_verb`/`ctcp_args`) — mirrors
+  # `EventRouter.ctcp_meta/1` (the inbound half): both wrap the shared
+  # `Grappa.IRC.CTCP.verb_args/1` SSOT, kept per-site because each persist path
+  # assembles its own meta map. cic reads `meta.ctcp_verb`/`meta.ctcp_args`
+  # (typed) — never \x01. ACTION rides its dedicated `:action` kind; cic ignores
+  # meta.ctcp_* on :action rows.
+  @spec ctcp_self_echo_meta(binary()) ::
+          %{optional(:ctcp_verb) => String.t(), optional(:ctcp_args) => String.t()}
+  defp ctcp_self_echo_meta(fragment) do
+    case CTCP.verb_args(fragment) do
+      # /me ACTION rides its own :action kind (set at line ~3302) — never
+      # double-tag it into meta.
+      {"ACTION", _} -> %{}
+      {verb, args} -> %{ctcp_verb: verb, ctcp_args: args}
+      :none -> %{}
     end
   end
 

--- a/test/grappa/irc/ctcp_test.exs
+++ b/test/grappa/irc/ctcp_test.exs
@@ -38,4 +38,50 @@ defmodule Grappa.IRC.CTCPTest do
       refute CTCP.action?("\x01")
     end
   end
+
+  # #591 — general CTCP verb+args classifier in the SSOT. The single parser
+  # both the inbound NOTICE arm (a peer's CTCP PING reply → `meta.ctcp` with
+  # verb "PING" + the echoed token) and the outbound self-echo persist (the
+  # operator's own `/ctcp`/`/ping` → `meta.ctcp` so cic renders "→ CTCP VERB"
+  # instead of raw \x01) route through. cic reads the TYPED `meta.ctcp`, never
+  # \x01 (CLAUDE.md "one IRC parser, on the server; cic never parses IRC").
+  # ACTION keeps its own `:action` kind (action?/1) — this is the escape hatch
+  # for every OTHER verb.
+  describe "verb_args/1" do
+    test "verb with no argument (VERSION)" do
+      assert CTCP.verb_args("\x01VERSION\x01") == {"VERSION", ""}
+    end
+
+    test "verb with an argument token (PING)" do
+      assert CTCP.verb_args("\x01PING 1706743200000\x01") == {"PING", "1706743200000"}
+    end
+
+    test "args preserve interior spaces (opaque echo — don't re-tokenize)" do
+      assert CTCP.verb_args("\x01PING 1706 743\x01") == {"PING", "1706 743"}
+    end
+
+    test "classifies ACTION too (caller decides ACTION keeps its own kind)" do
+      assert CTCP.verb_args("\x01ACTION waves at the channel\x01") == {"ACTION", "waves at the channel"}
+    end
+
+    test "lenient when the trailing \\x01 is absent (mirrors action?/1)" do
+      assert CTCP.verb_args("\x01VERSION") == {"VERSION", ""}
+      assert CTCP.verb_args("\x01PING 1706743200000") == {"PING", "1706743200000"}
+    end
+
+    test "empty argument after the space yields an empty args string" do
+      assert CTCP.verb_args("\x01PING \x01") == {"PING", ""}
+    end
+
+    test ":none for a non-CTCP body, empty body, or a bare delimiter" do
+      assert CTCP.verb_args("hello world") == :none
+      assert CTCP.verb_args("") == :none
+      assert CTCP.verb_args("\x01") == :none
+    end
+
+    test ":none when no verb follows the opening delimiter" do
+      # `\x01 VERSION` — a space before any verb token means no verb.
+      assert CTCP.verb_args("\x01 VERSION") == :none
+    end
+  end
 end

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -870,6 +870,45 @@ defmodule Grappa.Session.EventRouterTest do
                EventRouter.route(m, state)
     end
 
+    # #591 — a peer's CTCP PING reply (a NOTICE from a regular nick carrying a
+    # \x01PING <token>\x01 frame) is PROTOCOL, not conversation: main's
+    # `route_non_channel_notice/3` sends any CTCP-framed NOTICE to `$server`
+    # (86416a21/96bedfdd — no query window minted; the "CTCP-framed NOTICE
+    # lands on $server" test above pins that routing). This test asserts the
+    # ADDITIVE half #591 layers on top: the \x01 body is PRESERVED and typed
+    # flat meta (ctcp_verb/ctcp_args) is attached to THAT $server row, so cic
+    # correlates the token back to the /ping WITHOUT ever parsing \x01.
+    test "peer CTCP PING reply persists on $server with preserved body + typed ctcp meta" do
+      state = base_state()
+
+      m = msg(:notice, ["vjt", "\x01PING 1706743200000\x01"], {:nick, "bob", "u", "h"})
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} =
+               EventRouter.route(m, state)
+
+      # CTCP-framed NOTICE → $server (protocol, not a DM — mints no window).
+      assert attrs.channel == "$server"
+      assert attrs.sender == "bob"
+      # \x01 preserved verbatim (round-trip fidelity — CLAUDE.md).
+      assert attrs.body == "\x01PING 1706743200000\x01"
+      # Typed classification cic reads instead of touching \x01.
+      assert attrs.meta == %{ctcp_verb: "PING", ctcp_args: "1706743200000"}
+    end
+
+    # #591 — a plain (non-CTCP) peer NOTICE stays exactly as before: empty
+    # meta, no ctcp tag. Proves the classification is strictly additive.
+    test "plain peer NOTICE gets no ctcp meta (additive)" do
+      state = base_state()
+
+      m = msg(:notice, ["vjt", "hey are you around?"], {:nick, "bob", "u", "h"})
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} =
+               EventRouter.route(m, state)
+
+      assert attrs.channel == "bob"
+      assert attrs.meta == %{}
+    end
+
     # #371 — Azzurra (bahamut) pseudo-services SeenServ / StatServ /
     # DebugServ were absent from the allowlist, so their NOTICE replies
     # fell through to the peer-nick query-window arm (a stray empty

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -3206,6 +3206,61 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  describe "#591 outbound CTCP self-echo classification" do
+    test "own /ctcp + /ping self-echo as :privmsg with typed flat ctcp meta" do
+      # Introducing /ctcp + /ping means the operator's own CTCP query now
+      # self-echoes back. Without classification it renders as a raw \x01 body
+      # in the window they just typed in — a visibly broken feature every time.
+      # Same SSOT (Grappa.IRC.CTCP.verb_args/1) + same persist call-site that
+      # already classifies ACTION → :action, so inbound + outbound agree (#14
+      # lesson). Non-ACTION CTCP keeps :privmsg and carries typed flat meta
+      # (ctcp_verb/ctcp_args) so cic renders "→ CTCP VERB", never \x01.
+      rfc_handler = fn state, line ->
+        if String.starts_with?(line, "USER ") do
+          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
+        else
+          {:reply, nil, state}
+        end
+      end
+
+      {server, port} = start_server(rfc_handler)
+      {user, network, _} = setup_user_and_network(port)
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+      {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
+
+      # /ctcp #sniffo VERSION → cic sends \x01VERSION\x01 as the PRIVMSG body.
+      assert {:ok, version_msg} =
+               Session.send_privmsg({:user, user.id}, network.id, "#sniffo", "\x01VERSION\x01")
+
+      # Non-ACTION CTCP keeps :privmsg (ACTION alone earns :action).
+      assert version_msg.kind == :privmsg
+
+      # /ping #sniffo → cic sends \x01PING <token>\x01.
+      assert {:ok, _} =
+               Session.send_privmsg(
+                 {:user, user.id},
+                 network.id,
+                 "#sniffo",
+                 "\x01PING 1706743200000\x01"
+               )
+
+      rows = Scrollback.fetch({:user, user.id}, network.id, "#sniffo", nil, 10, nil, false)
+
+      version_row = Enum.find(rows, &(&1.body == "\x01VERSION\x01"))
+      assert version_row.kind == :privmsg
+      # Flat keys, and body preserves \x01 verbatim (round-trip fidelity).
+      assert version_row.meta == %{ctcp_verb: "VERSION", ctcp_args: ""}
+
+      ping_row = Enum.find(rows, &(&1.body == "\x01PING 1706743200000\x01"))
+      assert ping_row.kind == :privmsg
+      assert ping_row.meta == %{ctcp_verb: "PING", ctcp_args: "1706743200000"}
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+
   describe "#25 outbound own sender-prefix snapshot" do
     test "own channel message snapshots the operator's op grade into meta.sender_prefix" do
       # Mirror of the inbound EventRouter capture for the outbound door:


### PR DESCRIPTION
## What

cicchetto's CTCP **send** side — `/ctcp <target> <VERB> [args]` and `/ping <nick>` sugar. Completes #591 (the `/me` ACTION **receive** side shipped in #14; inbound CTCP PING **answer** shipped upstream in 86416a21/96bedfdd).

## Design (rulings)

- **Server SSOT (Option 2):** `Grappa.IRC.CTCP.verb_args/1` classifies a CTCP frame into typed FLAT meta (`ctcp_verb` + `ctcp_args`). cic consumes the TYPED meta and **never parses `\x01`**.
- **Self-echo:** own `/ctcp` + `/ping` render as `→ CTCP VERB args to <target>`, never the raw `\x01` envelope (pre-#591 that leaked as a bare chat row).
- **RTT synthesised LOCALLY** in the `/ping` source window (irssi behaviour), decoupled from routing. A peer's CTCP PING **reply** NOTICE routes to `$server` (CTCP-framed — a reply is protocol, not a DM: 86416a21/96bedfdd); cic is always subscribed to `$server`, so the correlation gate consumes it with no query-window subscribe race.
- **Consume-on-match only:** an unmatched reply is left to normal routing (additive).

## Commits (6)

1. `feat(#591)` classify CTCP frames server-side into typed meta (`CTCP.verb_args/1` + `strip_trailing_delim/1` coexist with main's `framed?/1`; event_router `ctcp_meta/1` + NOTICE arm; `ctcp_self_echo_meta/1`).
2. `feat(#591)` cic send — `/ctcp`+`/ping` slash commands, `ctcpFrame` compose, `pingCorrelation` (register/resolve, RTT pure, ascii-fold nick).
3. `feat(#591)` cic receive — `subscribe.ts` `maybeConsumePingReply` gate → RTT into source window, no beep, no raw `\x01`.
4. `feat(#591)` cic render — ScrollbackPane renders the `→ CTCP …` line off `meta.ctcp_verb`.
5. `refactor` route `ctcp_verb/1` + `ctcp_payload/1` through the `CTCP.verb_args/1` SSOT. **Separate, revertible-alone, zero-behaviour-change** commit (it touches just-landed inbound-PING code 86416a21/96bedfdd).
6. `test(#591)` e2e — `/ctcp` self-echo render + `/ping` RTT (2 tests, full-stack round-trips jsdom cannot see).

## Gate

- `scripts/check.sh` green (compile `--warnings-as-errors`, credo `--strict`, doctor, ExUnit, dialyzer, wire-type drift, bats).
- cic `bun run check` / `test` / `build` green.
- **e2e (`scripts/integration.sh --grep "#591"`): 2 passed.** The **full** `scripts/integration.sh` on this PR is the ship gate (scoped `--grep` proves only the new spec).

Rebased clean onto `main` (`d53eeb9b`); the intervening #581/shottino commits touch no CTCP routing.

Refs #591