### PR TITLE
feat(#596): mode 2 honours vhost_selection + clamps allowed set to grants

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -25080,3 +25080,37 @@ selection is unchanged; only a subject WITH a selection now keeps it. Part 1
 (this) reads the intersection at bind; part 2 (#596 follow-on) makes the write
 path + self-service allowed set mode-aware so a mode-2 subject can only select —
 and only be offered — its grants.
+
+## 2026-08-01 — #596 (part 2): allowed_vhosts is mode-aware — mode 2 clamps the selectable set to grants
+
+Part 1 reads the intersection at bind, but the write path + self-service UI still
+treated the FULL union (generally-available ∪ in_pool ∪ granted) as selectable in
+mode 2, where `in_pool` / `generally_available` are INERT at bind. So
+`set_selection` accepted an address the resolver ignores and the view offered
+options that silently did nothing — the same #596 bug from the presentation/authz
+side. `allowed_vhosts` is now mode-aware: mode 2 returns ONLY the granted vhosts;
+every other mode returns today's union (#251). With
+`allowed_vhosts(subject, :static_mapping_with_reservations) == granted`,
+`get_selection/2` in mode 2 IS selection ∩ granted, so `effective_source/3`'s
+mode-2 step 1 reuses it directly (part 1's manual intersection folds away).
+
+The mode is passed IN by callers — `user_settings_controller` reads
+`ServerSettings.addressing_mode/0`; the resolver threads `addressing.mode` — so
+`Vhosts` stays OFF a `ServerSettings` dep, the same pass-config-in shape as
+`effective_source/3`. Widening the signature made `get_selection` and
+`set_selection` take the mode too (they derive their clamp from `allowed_vhosts`);
+whoever widens a signature owns EVERY caller, so all of them moved in this commit
+(controller ×3, three test files) with NO default argument. A defaulted mode is
+exactly the trap CLAUDE.md bans: it would silently degrade a mode-2 server to
+mode-1 selectability, re-introducing #596 from the write side. The full caller
+audit found no admin / LiveView / mix-task / Wire caller — the admin settings
+surface pins the mode via `ServerSettings`, it never resolves a selection.
+
+The mode-1 clause reads `Map.get(addressing, :mode)` so a malformed addressing map
+(no `:mode`) falls to the non-mode-2 union clamp — today's behaviour — never a
+crash, preserving the defensive posture the mode-2 branch already had.
+
+Out of scope (separate issue, per the maintainer): `vhost_selection` stores
+address literals, so a prefix renumber that rewrites `vhosts.address` silently
+drops a stored selection at the read clamp. Keying selections by `vhost_id` is the
+fix — flagged, opened separately, not done here.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -25056,3 +25056,27 @@ asserts the VISIBLE terminal `recover-modal-success` after RECOVER frees the
 hold — no API-return assertion, no success-or-failure soft-assert (D4). A server
 integration test masking a critical behind an unrealistic mock is exactly why the
 happy-path e2e is mandatory: a feature without one is hollow green.
+
+## 2026-08-01 — #596: mode 2 ignored vhost_selection — granting the pool destroyed the choice
+
+`Grappa.Vhosts.effective_source/3`'s mode-2 (`static_mapping_with_reservations`)
+branch random-picked over EVERY granted address and never consulted the subject's
+persisted `vhost_selection` — `get_selection/1` was reached only from the mode-1
+clause below it. The operator policy for mode 2: a curated set of subjects holds
+grants covering the whole reserved pool and picks from it, keeping the selection
+they have today while free to move to any other reserved address. But a subject
+who deliberately selected one address and then received N grants stopped egressing
+from it and drew a fresh random one from all N per connect. The more availability
+granted, the LESS the selection meant — the inverse of the intent, and exactly
+what "grant the whole pool" produced.
+
+Fix: mode 2 resolves the shape mode 1 already has, with the granted set standing
+in for the allowed set — (1) selection ∩ granted non-empty → random-pick among it
+(matches mode-1 "random per connection" when more than one is active); (2) else
+ALL granted → random-pick (availability given, no preference expressed — the prior
+behaviour); (3) else derive-or-hold (unchanged). The Global Constraint holds: no
+branch returns `nil` or falls through to a shared source. A grant-holder with no
+selection is unchanged; only a subject WITH a selection now keeps it. Part 1
+(this) reads the intersection at bind; part 2 (#596 follow-on) makes the write
+path + self-service allowed set mode-aware so a mode-2 subject can only select —
+and only be offered — its grants.

--- a/lib/grappa/vhosts.ex
+++ b/lib/grappa/vhosts.ex
@@ -42,9 +42,12 @@ defmodule Grappa.Vhosts do
     3. else `nil` → the `Grappa.IRC.Client` DB-driven rotation pool /
        kernel default (zero-config still binds nothing).
 
-  The allowed set = generally-available ∪ in_pool ∪ granted-to-subject.
-  Selection is authz-clamped to this set at write (`set_selection/2`), and
-  re-clamped at read so a revoked grant can't leak a stale selection.
+  The allowed set is mode-dependent (#596): mode 1 = generally-available ∪
+  in_pool ∪ granted-to-subject; mode 2 = granted-to-subject ONLY (in_pool /
+  generally-available are inert at bind, so they are not self-selectable).
+  Selection is authz-clamped to this set at write (`set_selection/3`), and
+  re-clamped at read (`get_selection/2`) so a revoked grant — or, in mode 2,
+  a non-granted address — can't leak a stale selection.
 
   NOTE (#266 — REVERSES the #251 nuance): pre-#266, a subject's vhost
   self-selection OVERRODE `server_source` (`server_source` was only the
@@ -231,12 +234,34 @@ defmodule Grappa.Vhosts do
   # ---------------------------------------------------------------------------
 
   @doc """
-  The subject's allowed vhosts = generally-available ∪ in_pool ∪
-  granted-to-subject (#251 — in_pool joins the self-selectable set).
-  Ordered by address, de-duplicated.
+  The subject's allowed (self-selectable) vhosts, mode-dependent (#596):
+
+    * mode `:static_mapping_with_reservations` (mode 2) — ONLY the vhosts
+      the subject holds a grant for. `in_pool` / `generally_available` are
+      INERT at bind time in mode 2 (the resolver ignores them), so offering
+      them for self-selection would let the UI present options that silently
+      do nothing AND let a write persist an address the resolver drops. The
+      granted set IS the selectable set.
+    * any other mode (mode 1, default) — generally-available ∪ in_pool ∪
+      granted-to-subject (#251 — in_pool joins the self-selectable set).
+
+  Ordered by address, de-duplicated. `mode` is passed IN by the caller
+  (`Grappa.ServerSettings.addressing_mode/0` at the web edge; the resolver
+  threads `addressing.mode`) so `Vhosts` stays OFF a `ServerSettings` dep —
+  the same pass-config-in shape as `effective_source/3`. No default
+  argument: a defaulted mode would silently degrade a mode-2 server to
+  mode-1 selectability, re-introducing #596 from the write side.
   """
-  @spec allowed_vhosts(Subject.t()) :: [Vhost.t()]
-  def allowed_vhosts({_, _} = subject) do
+  @spec allowed_vhosts(Subject.t(), atom()) :: [Vhost.t()]
+  def allowed_vhosts({_, _} = subject, :static_mapping_with_reservations) do
+    granted_ids = granted_vhost_ids(subject)
+
+    query = from(v in Vhost, where: v.id in ^granted_ids, order_by: [asc: v.address])
+
+    Repo.all(query)
+  end
+
+  def allowed_vhosts({_, _} = subject, _) do
     granted_ids = granted_vhost_ids(subject)
 
     query =
@@ -270,8 +295,8 @@ defmodule Grappa.Vhosts do
   derived `::cb` address.
 
   Distinct from `granted_vhost_ids/1` (ids, for the self-service `granted`
-  flag) and from `allowed_vhosts/1` (which also folds in `in_pool` +
-  generally-available — both INERT in mode 2). Reserved grant addresses
+  flag) and from `allowed_vhosts/2` (which in mode 1 also folds in `in_pool`
+  + generally-available — both INERT in mode 2). Reserved grant addresses
   live OUTSIDE the `::cb::/80` derivation block by operator convention, so
   a grant can never collide with a derived address.
   """
@@ -286,12 +311,15 @@ defmodule Grappa.Vhosts do
 
   @doc """
   The subject's persisted self-selection, RE-CLAMPED to the currently
-  allowed set (a revoked grant silently drops its address). Stored in
-  `UserSettings` under `"vhost_selection"` as a list of addresses.
+  allowed set for `mode` (a revoked grant silently drops its address; in
+  mode 2 an address that is not granted drops too — #596). Stored in
+  `UserSettings` under `"vhost_selection"` as a list of addresses. In mode
+  2 the allowed set IS the granted set, so this is exactly selection ∩
+  granted — what `effective_source/3` binds.
   """
-  @spec get_selection(Subject.t()) :: [String.t()]
-  def get_selection({_, _} = subject) do
-    allowed = MapSet.new(allowed_vhosts(subject), & &1.address)
+  @spec get_selection(Subject.t(), atom()) :: [String.t()]
+  def get_selection({_, _} = subject, mode) do
+    allowed = MapSet.new(allowed_vhosts(subject, mode), & &1.address)
 
     subject
     |> raw_selection()
@@ -300,14 +328,15 @@ defmodule Grappa.Vhosts do
 
   @doc """
   Sets the subject's self-selection. Every address MUST be in the
-  subject's allowed set — `{:error, :forbidden_vhost}` otherwise (authz
-  at the boundary, not just the UI). Returns the persisted (canonical)
-  selection list.
+  subject's allowed set for `mode` — `{:error, :forbidden_vhost}` otherwise
+  (authz at the boundary, not just the UI). In mode 2 the allowed set is
+  the granted set, so a non-granted address is rejected here, not silently
+  ignored at bind (#596). Returns the persisted (canonical) selection list.
   """
-  @spec set_selection(Subject.t(), [String.t()]) ::
+  @spec set_selection(Subject.t(), [String.t()], atom()) ::
           {:ok, [String.t()]} | {:error, :forbidden_vhost | Ecto.Changeset.t() | :db_unavailable}
-  def set_selection({_, _} = subject, addresses) when is_list(addresses) do
-    allowed = MapSet.new(allowed_vhosts(subject), & &1.address)
+  def set_selection({_, _} = subject, addresses, mode) when is_list(addresses) do
+    allowed = MapSet.new(allowed_vhosts(subject, mode), & &1.address)
     requested = Enum.uniq(addresses)
 
     if Enum.all?(requested, &MapSet.member?(allowed, &1)) do
@@ -434,12 +463,10 @@ defmodule Grappa.Vhosts do
         # destroy a choice they deliberately made; the more availability given,
         # the LESS the selection meant under the old `Enum.random(granted)`.
         # This is mode-1's shape with the granted set standing in for the
-        # allowed set. `get_selection/1` is the union-clamped selection;
-        # intersecting with the grant set yields selection ∩ granted (C2 folds
-        # this into a mode-aware `get_selection/2`).
-        granted_set = MapSet.new(granted)
-
-        case Enum.filter(get_selection(subject), &MapSet.member?(granted_set, &1)) do
+        # allowed set. `get_selection/2` in mode 2 is ALREADY clamped to the
+        # granted set (`allowed_vhosts == granted`), so it IS selection ∩
+        # granted — no re-intersection needed.
+        case get_selection(subject, :static_mapping_with_reservations) do
           [] -> Enum.random(granted)
           selected -> Enum.random(selected)
         end
@@ -448,8 +475,11 @@ defmodule Grappa.Vhosts do
 
   # Mode 1 (default / any non-mode-2 config) — byte-for-byte pre-#543:
   # selection ∩ allowed random-picks, else nil → the Client's rotation pool.
-  def effective_source({_, _} = subject, nil, _) do
-    case get_selection(subject) do
+  # `Map.get(addressing, :mode)` keeps the defensive posture: a malformed
+  # addressing map (no `:mode`) → nil → the non-mode-2 clause of
+  # `allowed_vhosts/2` (the union) → today's behaviour; it never crashes.
+  def effective_source({_, _} = subject, nil, addressing) do
+    case get_selection(subject, Map.get(addressing, :mode)) do
       [] -> nil
       selected -> Enum.random(selected)
     end

--- a/lib/grappa/vhosts.ex
+++ b/lib/grappa/vhosts.ex
@@ -378,7 +378,10 @@ defmodule Grappa.Vhosts do
        vhost selection, the pool/derivation, AND #271 RR-DNS leaf
        distribution.
     2. mode `:static_mapping_with_reservations` — a subject with grants
-       random-picks one of ITS OWN granted addresses (reservations win);
+       resolves the SAME shape as mode 1 with the granted set standing in
+       for the allowed set (#596): its selection ∩ granted random-picks,
+       else ALL granted random-picks (availability given, no preference —
+       reservations still win over derivation);
        mode `:pool_with_reservations` (default) — the subject's selection
        (∩ allowed) random-picks (spec: "random per connection").
     3. mode 2, no grants — the subject's captured client `/64`
@@ -420,8 +423,26 @@ defmodule Grappa.Vhosts do
     armed? = Map.get(addressing, :armed?, false)
 
     case granted_vhost_addresses(subject) do
-      [] -> derive_or_hold(subject, prefix, armed?)
-      addresses -> Enum.random(addresses)
+      [] ->
+        derive_or_hold(subject, prefix, armed?)
+
+      granted ->
+        # #596 — honour the subject's persisted vhost_selection: selection ∩
+        # granted wins (random per connection when more than one is active),
+        # else ALL granted (availability given, no preference expressed — the
+        # prior behaviour). Granting a subject the whole reserved pool must NOT
+        # destroy a choice they deliberately made; the more availability given,
+        # the LESS the selection meant under the old `Enum.random(granted)`.
+        # This is mode-1's shape with the granted set standing in for the
+        # allowed set. `get_selection/1` is the union-clamped selection;
+        # intersecting with the grant set yields selection ∩ granted (C2 folds
+        # this into a mode-aware `get_selection/2`).
+        granted_set = MapSet.new(granted)
+
+        case Enum.filter(get_selection(subject), &MapSet.member?(granted_set, &1)) do
+          [] -> Enum.random(granted)
+          selected -> Enum.random(selected)
+        end
     end
   end
 

--- a/lib/grappa_web/controllers/user_settings_controller.ex
+++ b/lib/grappa_web/controllers/user_settings_controller.ex
@@ -45,7 +45,7 @@ defmodule GrappaWeb.UserSettingsController do
 
   use GrappaWeb, :controller
 
-  alias Grappa.{Subject, UserSettings, Vhosts}
+  alias Grappa.{ServerSettings, Subject, UserSettings, Vhosts}
 
   @doc """
   `GET /me/settings/notification-prefs` — return the authenticated
@@ -122,14 +122,17 @@ defmodule GrappaWeb.UserSettingsController do
 
   @doc """
   `GET /me/settings/vhost` — the subject's vhost self-service view
-  (#228, #251): the allowed set (generally-available ∪ in_pool ∪
-  granted-to-subject), each option marked `in_pool` + `granted`, plus the
-  current selection. No admin pin (#251) — the user always self-selects.
+  (#228, #251): the allowed set, each option marked `in_pool` + `granted`,
+  plus the current selection. The allowed set is mode-dependent (#596):
+  mode 1 = generally-available ∪ in_pool ∪ granted-to-subject; mode 2
+  (`static_mapping_with_reservations`) = granted-to-subject ONLY (in_pool /
+  generally-available are inert at bind, so they are not offered). No admin
+  pin (#251) — the user always self-selects within that set.
   """
   @spec show_vhost(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def show_vhost(conn, _) do
     subject = Subject.from_assigns(conn.assigns)
-    render(conn, :vhost, vhost_view(subject))
+    render(conn, :vhost, vhost_view(subject, ServerSettings.addressing_mode()))
   end
 
   @doc """
@@ -142,9 +145,10 @@ defmodule GrappaWeb.UserSettingsController do
           Plug.Conn.t() | {:error, :bad_request | :forbidden_vhost | Ecto.Changeset.t() | :db_unavailable}
   def update_vhost(conn, %{"selection" => selection}) when is_list(selection) do
     subject = Subject.from_assigns(conn.assigns)
+    mode = ServerSettings.addressing_mode()
 
-    with {:ok, _} <- Vhosts.set_selection(subject, selection) do
-      render(conn, :vhost, vhost_view(subject))
+    with {:ok, _} <- Vhosts.set_selection(subject, selection, mode) do
+      render(conn, :vhost, vhost_view(subject, mode))
     end
   end
 
@@ -229,9 +233,12 @@ defmodule GrappaWeb.UserSettingsController do
   # Builds the render assigns for the vhost view — allowed set (each option
   # marked in_pool + granted + a resolved rDNS name), current selection.
   # `granted` reflects a real per-subject grant row, NOT allow-set
-  # membership (which now also includes in_pool + generally-available
+  # membership (which in mode 1 also includes in_pool + generally-available
   # vhosts — #251), so cic V2 can bucket exclusive (granted) / in-pool /
-  # out-of-pool.
+  # out-of-pool. `mode` (from `ServerSettings.addressing_mode/0`) gates the
+  # allowed set: in mode 2 it is the granted set ONLY (#596), so the view
+  # never offers an in_pool / generally-available option the resolver would
+  # silently ignore at bind.
   #
   # `name` is the address's reverse-DNS (cloak) string — #252. The DNS is
   # the source of truth (nothing persisted); `Grappa.Net.PtrCache.names_for/1`
@@ -239,9 +246,9 @@ defmodule GrappaWeb.UserSettingsController do
   # cold/expired/no-PTR address reads back as `nil` and falls back to the
   # raw IP here; the cache resolves it out of band so a later GET shows the
   # name (cic re-reads the view on entering the vhost sub-page).
-  defp vhost_view(subject) do
+  defp vhost_view(subject, mode) do
     granted_ids = MapSet.new(Vhosts.granted_vhost_ids(subject))
-    allowed = Vhosts.allowed_vhosts(subject)
+    allowed = Vhosts.allowed_vhosts(subject, mode)
     names = Grappa.Net.PtrCache.names_for(Enum.map(allowed, & &1.address))
 
     available =
@@ -254,6 +261,6 @@ defmodule GrappaWeb.UserSettingsController do
         }
       end)
 
-    %{available: available, selection: Vhosts.get_selection(subject)}
+    %{available: available, selection: Vhosts.get_selection(subject, mode)}
   end
 end

--- a/test/grappa/networks/session_plan_vhost_test.exs
+++ b/test/grappa/networks/session_plan_vhost_test.exs
@@ -1,7 +1,7 @@
 defmodule Grappa.Networks.SessionPlanVhostTest do
   @moduledoc """
   #228 / #266 — `Grappa.Networks.SessionPlan.base_plan/7` resolves the
-  plan's `source_address` through `Grappa.Vhosts.effective_source/2` (the
+  plan's `source_address` through `Grappa.Vhosts.effective_source/3` (the
   per-subject vhost layer). #266 INVERTS the #251 precedence: an admin-set
   per-network `server.source_address` now WINS over a subject's vhost
   self-selection (Libera go-live: an admin-pinned, accountable egress).
@@ -41,7 +41,7 @@ defmodule Grappa.Networks.SessionPlanVhostTest do
     user = user_fixture()
     network = network_fixture()
     {:ok, vhost} = Vhosts.create_vhost(%{address: "2001:db8::def", generally_available: true})
-    {:ok, _} = Vhosts.set_selection({:user, user.id}, [vhost.address])
+    {:ok, _} = Vhosts.set_selection({:user, user.id}, [vhost.address], :pool_with_reservations)
 
     cred = %Credential{nick: "n", auth_method: :none, autojoin_channels: [], last_joined_channels: []}
     server = %Server{host: "irc.example.test", port: 6697, tls: true, source_address: "2001:db8::99"}
@@ -54,7 +54,7 @@ defmodule Grappa.Networks.SessionPlanVhostTest do
     user = user_fixture()
     network = network_fixture()
     {:ok, vhost} = Vhosts.create_vhost(%{address: "2001:db8::def", generally_available: true})
-    {:ok, _} = Vhosts.set_selection({:user, user.id}, [vhost.address])
+    {:ok, _} = Vhosts.set_selection({:user, user.id}, [vhost.address], :pool_with_reservations)
 
     cred = %Credential{nick: "n", auth_method: :none, autojoin_channels: [], last_joined_channels: []}
     server = %Server{host: "irc.example.test", port: 6697, tls: true, source_address: nil}

--- a/test/grappa/vhosts_test.exs
+++ b/test/grappa/vhosts_test.exs
@@ -388,6 +388,66 @@ defmodule Grappa.VhostsTest do
     end
   end
 
+  # #596 — mode 2 must HONOUR the subject's persisted `vhost_selection`, not
+  # random-pick over EVERY grant. Granting a subject the whole reserved pool
+  # used to DESTROY their choice: a subject who deliberately picked one address
+  # and then received N grants started drawing a fresh random one from all N on
+  # every connection (the more availability given, the less the selection meant
+  # — the inverse of the intent). Resolution mirrors mode-1's shape with the
+  # granted set standing in for the allowed set: (1) selection ∩ granted wins
+  # (random among it — "random per connection"); (2) else all granted
+  # (availability given, no preference expressed — today's behaviour); (3) else
+  # derive-or-hold (unchanged). No branch may return nil / fall through to a
+  # shared source (Global Constraint).
+  describe "effective_source/3 — mode-2 honours vhost_selection (#596)" do
+    test "a single selected grant pins that address, never a random other grant" do
+      user = user_fixture()
+      {:ok, a} = Vhosts.create_vhost(%{address: "2a03:4000:20:2d3:ca::a"})
+      {:ok, b} = Vhosts.create_vhost(%{address: "2a03:4000:20:2d3:ca::b"})
+      {:ok, c} = Vhosts.create_vhost(%{address: "2a03:4000:20:2d3:ca::c"})
+      for v <- [a, b, c], do: {:ok, _} = Vhosts.grant_vhost(v, {:user, user.id})
+      # The subject was granted the WHOLE reserved pool but deliberately picked
+      # exactly one — that choice must survive the wide availability.
+      {:ok, _} = Vhosts.set_selection({:user, user.id}, [b.address])
+
+      # Every connection binds the selected address — a & c never appear.
+      picks = for _ <- 1..50, do: Vhosts.effective_source({:user, user.id}, nil, @mode2)
+      assert Enum.uniq(picks) == [b.address]
+    end
+
+    test "a multi-selection among grants random-picks WITHIN the selection only" do
+      user = user_fixture()
+      {:ok, a} = Vhosts.create_vhost(%{address: "2a03:4000:20:2d3:ca::a"})
+      {:ok, b} = Vhosts.create_vhost(%{address: "2a03:4000:20:2d3:ca::b"})
+      {:ok, c} = Vhosts.create_vhost(%{address: "2a03:4000:20:2d3:ca::c"})
+      for v <- [a, b, c], do: {:ok, _} = Vhosts.grant_vhost(v, {:user, user.id})
+      {:ok, _} = Vhosts.set_selection({:user, user.id}, [a.address, b.address])
+
+      picks = for _ <- 1..50, do: Vhosts.effective_source({:user, user.id}, nil, @mode2)
+      assert Enum.all?(picks, &(&1 in [a.address, b.address]))
+      # The unselected grant is never drawn — this is the discriminator that
+      # separates "honours selection" from the old "random over all grants".
+      refute c.address in picks
+    end
+
+    test "a stored selection with NO granted address falls back to all grants" do
+      # A selection captured under mode 1 (an in_pool address) that is not in
+      # the grant set: selection ∩ granted is empty → step 2 (all grants),
+      # never nil / a shared pool.
+      user = user_fixture()
+      {:ok, pool} = Vhosts.create_vhost(%{address: addr(), in_pool: true})
+      {:ok, a} = Vhosts.create_vhost(%{address: "2a03:4000:20:2d3:ca::a"})
+      {:ok, b} = Vhosts.create_vhost(%{address: "2a03:4000:20:2d3:ca::b"})
+      for v <- [a, b], do: {:ok, _} = Vhosts.grant_vhost(v, {:user, user.id})
+      # in_pool is in the mode-1 allow-set, so this write persists.
+      {:ok, _} = Vhosts.set_selection({:user, user.id}, [pool.address])
+
+      picks = for _ <- 1..50, do: Vhosts.effective_source({:user, user.id}, nil, @mode2)
+      assert Enum.all?(picks, &(&1 in [a.address, b.address]))
+      refute pool.address in picks
+    end
+  end
+
   # #543 INC-6 — the single decision point that tells `Networks.SessionPlan`
   # whether a resolved source is a DERIVED `::cb` alias the session must
   # acquire/release via `SourceAliasManager`. Keeps the mode+prefix+in_prefix?

--- a/test/grappa/vhosts_test.exs
+++ b/test/grappa/vhosts_test.exs
@@ -1,7 +1,7 @@
 defmodule Grappa.VhostsTest do
   @moduledoc """
   #228 — `Grappa.Vhosts` context: inventory CRUD, per-subject grants,
-  selection (authz-clamped), and the `effective_source/2` resolution
+  selection (authz-clamped), and the `effective_source/3` resolution
   precedence that feeds the session plan.
   """
   use Grappa.DataCase, async: true
@@ -26,6 +26,10 @@ defmodule Grappa.VhostsTest do
   @mode1 %{mode: :pool_with_reservations, prefix: nil, armed?: false}
   @mode2 %{mode: :static_mapping_with_reservations, prefix: @cb_prefix, armed?: true}
   @mode2_disarmed %{mode: :static_mapping_with_reservations, prefix: @cb_prefix, armed?: false}
+  # #596 — the bare mode atoms threaded into allowed_vhosts/2, get_selection/2,
+  # set_selection/3. The web edge reads them from `ServerSettings.addressing_mode/0`.
+  @pool_mode :pool_with_reservations
+  @static_mode :static_mapping_with_reservations
 
   # Unique v6 literal — mask the counter into a single valid hextet
   # (0..0xffff) so the strict-literal changeset always accepts it.
@@ -113,13 +117,13 @@ defmodule Grappa.VhostsTest do
     end
   end
 
-  describe "allowed_vhosts/1 — union of generally-available + in_pool + granted" do
+  describe "allowed_vhosts/2 — mode 1 union of generally-available + in_pool + granted" do
     test "includes generally-available vhosts" do
       user = user_fixture()
       {:ok, ga} = Vhosts.create_vhost(%{address: addr(), generally_available: true})
       {:ok, _} = Vhosts.create_vhost(%{address: addr(), generally_available: false})
 
-      allowed = Enum.map(Vhosts.allowed_vhosts({:user, user.id}), & &1.id)
+      allowed = Enum.map(Vhosts.allowed_vhosts({:user, user.id}, @pool_mode), & &1.id)
       assert ga.id in allowed
     end
 
@@ -128,7 +132,7 @@ defmodule Grappa.VhostsTest do
       {:ok, granted} = Vhosts.create_vhost(%{address: addr(), generally_available: false})
       {:ok, _} = Vhosts.grant_vhost(granted, {:user, user.id})
 
-      allowed = Enum.map(Vhosts.allowed_vhosts({:user, user.id}), & &1.id)
+      allowed = Enum.map(Vhosts.allowed_vhosts({:user, user.id}, @pool_mode), & &1.id)
       assert granted.id in allowed
     end
 
@@ -138,7 +142,7 @@ defmodule Grappa.VhostsTest do
       {:ok, priv} = Vhosts.create_vhost(%{address: addr(), generally_available: false})
       {:ok, _} = Vhosts.grant_vhost(priv, {:user, other.id})
 
-      allowed = Enum.map(Vhosts.allowed_vhosts({:user, user.id}), & &1.id)
+      allowed = Enum.map(Vhosts.allowed_vhosts({:user, user.id}, @pool_mode), & &1.id)
       refute priv.id in allowed
     end
 
@@ -150,19 +154,46 @@ defmodule Grappa.VhostsTest do
       user = user_fixture()
       {:ok, pool} = Vhosts.create_vhost(%{address: addr(), in_pool: true, generally_available: false})
 
-      allowed = Enum.map(Vhosts.allowed_vhosts({:user, user.id}), & &1.id)
+      allowed = Enum.map(Vhosts.allowed_vhosts({:user, user.id}, @pool_mode), & &1.id)
       assert pool.id in allowed
     end
   end
 
-  describe "set_selection/2 — authz-clamped to allowed set" do
+  # #596 (part 2) — the allowed (self-selectable) set is mode-dependent. In
+  # mode 2 the granted set IS the allowed set: in_pool / generally_available
+  # are inert at bind, so offering them for self-selection would let the UI
+  # present options that do nothing AND let a write persist an address the
+  # resolver drops. The write path + view are clamped to grants, mirroring the
+  # bind-time fix.
+  describe "allowed_vhosts/2 — mode 2 clamps the selectable set to grants (#596)" do
+    test "mode 2 returns ONLY granted vhosts (in_pool + generally-available inert)" do
+      user = user_fixture()
+      {:ok, ga} = Vhosts.create_vhost(%{address: addr(), generally_available: true})
+      {:ok, pool} = Vhosts.create_vhost(%{address: addr(), in_pool: true})
+      {:ok, granted} = Vhosts.create_vhost(%{address: "2a03:4000:20:2d3:ca::d"})
+      {:ok, _} = Vhosts.grant_vhost(granted, {:user, user.id})
+
+      mode2 = Enum.map(Vhosts.allowed_vhosts({:user, user.id}, @static_mode), & &1.id)
+      assert mode2 == [granted.id]
+      refute ga.id in mode2
+      refute pool.id in mode2
+
+      # Mode 1 still folds them all in (the #251 union) — same subject.
+      mode1 = Enum.map(Vhosts.allowed_vhosts({:user, user.id}, @pool_mode), & &1.id)
+      assert ga.id in mode1
+      assert pool.id in mode1
+      assert granted.id in mode1
+    end
+  end
+
+  describe "set_selection/3 — authz-clamped to allowed set" do
     test "persists an allowed selection" do
       user = user_fixture()
       {:ok, ga} = Vhosts.create_vhost(%{address: addr(), generally_available: true})
 
-      assert {:ok, [addr]} = Vhosts.set_selection({:user, user.id}, [ga.address])
+      assert {:ok, [addr]} = Vhosts.set_selection({:user, user.id}, [ga.address], @pool_mode)
       assert addr == ga.address
-      assert Vhosts.get_selection({:user, user.id}) == [ga.address]
+      assert Vhosts.get_selection({:user, user.id}, @pool_mode) == [ga.address]
     end
 
     test "rejects a selection outside the allowed set" do
@@ -170,18 +201,59 @@ defmodule Grappa.VhostsTest do
       {:ok, forbidden} = Vhosts.create_vhost(%{address: addr(), generally_available: false})
 
       assert {:error, :forbidden_vhost} =
-               Vhosts.set_selection({:user, user.id}, [forbidden.address])
+               Vhosts.set_selection({:user, user.id}, [forbidden.address], @pool_mode)
     end
 
     test "get_selection re-clamps a stale selection whose grant was revoked" do
       user = user_fixture()
       {:ok, granted} = Vhosts.create_vhost(%{address: addr(), generally_available: false})
       {:ok, grant} = Vhosts.grant_vhost(granted, {:user, user.id})
-      {:ok, _} = Vhosts.set_selection({:user, user.id}, [granted.address])
+      {:ok, _} = Vhosts.set_selection({:user, user.id}, [granted.address], @pool_mode)
 
       :ok = Vhosts.revoke_grant(grant)
       # Selection persisted, but the address is no longer allowed → clamped out.
-      assert Vhosts.get_selection({:user, user.id}) == []
+      assert Vhosts.get_selection({:user, user.id}, @pool_mode) == []
+    end
+  end
+
+  describe "get_selection/2 + set_selection/3 — mode 2 authz clamps to grants (#596)" do
+    test "set_selection in mode 2 rejects an in_pool address that is not granted" do
+      user = user_fixture()
+      {:ok, pool} = Vhosts.create_vhost(%{address: addr(), in_pool: true})
+
+      # Mode 1 allows the write (#251); mode 2 does nothing at bind, so it is
+      # rejected at the authz boundary rather than silently kept.
+      assert {:ok, _} = Vhosts.set_selection({:user, user.id}, [pool.address], @pool_mode)
+
+      assert {:error, :forbidden_vhost} =
+               Vhosts.set_selection({:user, user.id}, [pool.address], @static_mode)
+    end
+
+    test "set_selection in mode 2 persists a granted address" do
+      user = user_fixture()
+      {:ok, granted} = Vhosts.create_vhost(%{address: "2a03:4000:20:2d3:ca::e"})
+      {:ok, _} = Vhosts.grant_vhost(granted, {:user, user.id})
+
+      assert {:ok, [addr]} =
+               Vhosts.set_selection({:user, user.id}, [granted.address], @static_mode)
+
+      assert addr == granted.address
+    end
+
+    test "get_selection in mode 2 drops a stored non-granted address (selected under mode 1)" do
+      user = user_fixture()
+      {:ok, pool} = Vhosts.create_vhost(%{address: addr(), in_pool: true})
+      {:ok, granted} = Vhosts.create_vhost(%{address: "2a03:4000:20:2d3:ca::f"})
+      {:ok, _} = Vhosts.grant_vhost(granted, {:user, user.id})
+      # Persist BOTH under mode 1 (both allowed there).
+      {:ok, _} =
+        Vhosts.set_selection({:user, user.id}, [pool.address, granted.address], @pool_mode)
+
+      # Mode 2 keeps only the granted one — the in_pool literal drops silently.
+      assert Vhosts.get_selection({:user, user.id}, @static_mode) == [granted.address]
+      # Mode 1 still sees both.
+      assert Enum.sort(Vhosts.get_selection({:user, user.id}, @pool_mode)) ==
+               Enum.sort([pool.address, granted.address])
     end
   end
 
@@ -194,7 +266,7 @@ defmodule Grappa.VhostsTest do
     test "1. an admin server_source WINS over an active vhost selection" do
       user = user_fixture()
       {:ok, sel} = Vhosts.create_vhost(%{address: addr(), generally_available: true})
-      {:ok, _} = Vhosts.set_selection({:user, user.id}, [sel.address])
+      {:ok, _} = Vhosts.set_selection({:user, user.id}, [sel.address], @pool_mode)
 
       # Subject HAS a selection, but the network pins a source → the pin binds.
       assert Vhosts.effective_source({:user, user.id}, "192.0.2.99", @mode1) == "192.0.2.99"
@@ -203,7 +275,7 @@ defmodule Grappa.VhostsTest do
     test "2. falls back to the vhost selection when there is no admin source" do
       user = user_fixture()
       {:ok, sel} = Vhosts.create_vhost(%{address: addr(), generally_available: true})
-      {:ok, _} = Vhosts.set_selection({:user, user.id}, [sel.address])
+      {:ok, _} = Vhosts.set_selection({:user, user.id}, [sel.address], @pool_mode)
 
       assert Vhosts.effective_source({:user, user.id}, nil, @mode1) == sel.address
     end
@@ -212,7 +284,7 @@ defmodule Grappa.VhostsTest do
       user = user_fixture()
       {:ok, a} = Vhosts.create_vhost(%{address: addr(), generally_available: true})
       {:ok, b} = Vhosts.create_vhost(%{address: addr(), generally_available: true})
-      {:ok, _} = Vhosts.set_selection({:user, user.id}, [a.address, b.address])
+      {:ok, _} = Vhosts.set_selection({:user, user.id}, [a.address, b.address], @pool_mode)
 
       picked = Vhosts.effective_source({:user, user.id}, nil, @mode1)
       assert picked in [a.address, b.address]
@@ -232,7 +304,7 @@ defmodule Grappa.VhostsTest do
       user = user_fixture()
       {:ok, granted} = Vhosts.create_vhost(%{address: addr(), generally_available: false})
       {:ok, grant} = Vhosts.grant_vhost(granted, {:user, user.id})
-      {:ok, _} = Vhosts.set_selection({:user, user.id}, [granted.address])
+      {:ok, _} = Vhosts.set_selection({:user, user.id}, [granted.address], @pool_mode)
       :ok = Vhosts.revoke_grant(grant)
 
       # The clamped-out selection is gone AND there is no admin source → nil.
@@ -408,7 +480,7 @@ defmodule Grappa.VhostsTest do
       for v <- [a, b, c], do: {:ok, _} = Vhosts.grant_vhost(v, {:user, user.id})
       # The subject was granted the WHOLE reserved pool but deliberately picked
       # exactly one — that choice must survive the wide availability.
-      {:ok, _} = Vhosts.set_selection({:user, user.id}, [b.address])
+      {:ok, _} = Vhosts.set_selection({:user, user.id}, [b.address], @static_mode)
 
       # Every connection binds the selected address — a & c never appear.
       picks = for _ <- 1..50, do: Vhosts.effective_source({:user, user.id}, nil, @mode2)
@@ -421,7 +493,7 @@ defmodule Grappa.VhostsTest do
       {:ok, b} = Vhosts.create_vhost(%{address: "2a03:4000:20:2d3:ca::b"})
       {:ok, c} = Vhosts.create_vhost(%{address: "2a03:4000:20:2d3:ca::c"})
       for v <- [a, b, c], do: {:ok, _} = Vhosts.grant_vhost(v, {:user, user.id})
-      {:ok, _} = Vhosts.set_selection({:user, user.id}, [a.address, b.address])
+      {:ok, _} = Vhosts.set_selection({:user, user.id}, [a.address, b.address], @static_mode)
 
       picks = for _ <- 1..50, do: Vhosts.effective_source({:user, user.id}, nil, @mode2)
       assert Enum.all?(picks, &(&1 in [a.address, b.address]))
@@ -440,7 +512,7 @@ defmodule Grappa.VhostsTest do
       {:ok, b} = Vhosts.create_vhost(%{address: "2a03:4000:20:2d3:ca::b"})
       for v <- [a, b], do: {:ok, _} = Vhosts.grant_vhost(v, {:user, user.id})
       # in_pool is in the mode-1 allow-set, so this write persists.
-      {:ok, _} = Vhosts.set_selection({:user, user.id}, [pool.address])
+      {:ok, _} = Vhosts.set_selection({:user, user.id}, [pool.address], @pool_mode)
 
       picks = for _ <- 1..50, do: Vhosts.effective_source({:user, user.id}, nil, @mode2)
       assert Enum.all?(picks, &(&1 in [a.address, b.address]))

--- a/test/grappa_web/controllers/user_settings_vhost_test.exs
+++ b/test/grappa_web/controllers/user_settings_vhost_test.exs
@@ -146,7 +146,56 @@ defmodule GrappaWeb.UserSettingsVhostTest do
 
       conn = conn |> put_bearer(session.id) |> put("/me/settings/vhost", %{selection: [ga.address]})
       assert json_response(conn, 200)["selection"] == [ga.address]
-      assert Vhosts.get_selection({:visitor, visitor.id}) == [ga.address]
+      # Default addressing mode is :pool_with_reservations (nothing pinned).
+      assert Vhosts.get_selection({:visitor, visitor.id}, :pool_with_reservations) == [ga.address]
+    end
+  end
+
+  # #596 — under addressing mode 2 the self-service surface clamps to the
+  # subject's grants: the view offers ONLY granted addresses (in_pool /
+  # generally-available are inert at bind, so offering them would silently do
+  # nothing) and a PUT of a non-granted address is 403, not a silent no-op.
+  describe "mode 2 (#596)" do
+    setup do
+      :ok = Grappa.ServerSettings.put_addressing_mode(:static_mapping_with_reservations)
+    end
+
+    test "GET shows ONLY granted addresses (in_pool + generally-available absent)", %{conn: conn} do
+      {user, session} = user_and_session()
+      {:ok, ga} = Vhosts.create_vhost(%{address: addr(), generally_available: true})
+      {:ok, pool} = Vhosts.create_vhost(%{address: addr(), in_pool: true})
+      {:ok, granted} = Vhosts.create_vhost(%{address: "2a03:4000:20:2d3:ca::d1"})
+      {:ok, _} = Vhosts.grant_vhost(granted, {:user, user.id})
+
+      conn = conn |> put_bearer(session.id) |> get("/me/settings/vhost")
+      addrs = Enum.map(json_response(conn, 200)["available"], & &1["address"])
+
+      assert granted.address in addrs
+      refute ga.address in addrs
+      refute pool.address in addrs
+    end
+
+    test "PUT rejects an in_pool non-granted address with 403 forbidden_vhost", %{conn: conn} do
+      {_, session} = user_and_session()
+      {:ok, pool} = Vhosts.create_vhost(%{address: addr(), in_pool: true})
+
+      conn =
+        conn |> put_bearer(session.id) |> put("/me/settings/vhost", %{selection: [pool.address]})
+
+      assert json_response(conn, 403)["error"] == "forbidden_vhost"
+    end
+
+    test "PUT persists a granted address and GET echoes it", %{conn: conn} do
+      {user, session} = user_and_session()
+      {:ok, granted} = Vhosts.create_vhost(%{address: "2a03:4000:20:2d3:ca::d2"})
+      {:ok, _} = Vhosts.grant_vhost(granted, {:user, user.id})
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/me/settings/vhost", %{selection: [granted.address]})
+
+      assert json_response(conn, 200)["selection"] == [granted.address]
     end
   end
 end


### PR DESCRIPTION
Refs #596.

Mode 2 (`static_mapping_with_reservations`) ignored the subject's persisted
`vhost_selection` and clamped the self-selectable set to the full union, so
granting a subject the whole reserved pool destroyed their deliberate choice —
the inverse of the operator intent.

**C1 — `effective_source/3` honours the selection at bind.** Mode 2 now resolves
the shape mode 1 already has, with the granted set standing in for the allowed
set: (1) `selection ∩ granted` → random-pick among it; (2) else ALL granted →
random-pick (availability given, no preference — the prior behaviour); (3) else
derive-or-hold. Global Constraint intact: no branch returns `nil` or falls
through to a shared source.

**C2 — the selectable set is mode-aware.** `allowed_vhosts/2`, `get_selection/2`,
`set_selection/3` now take the addressing mode: in mode 2 the allowed set is the
GRANTED set only (`in_pool` / `generally_available` are inert at bind, so they
are neither offered by the self-service view nor accepted by a write). The mode
is passed IN by callers (`user_settings_controller` reads
`ServerSettings.addressing_mode/0`; the resolver threads `addressing.mode`) so
`Vhosts` stays OFF a `ServerSettings` dep. NO default argument — a defaulted mode
would silently degrade a mode-2 server to mode-1 selectability, re-introducing
the bug from the write side. Every caller migrated (controller + three test
files); caller audit found no admin / LiveView / mix-task caller.

Server-only; no new wire field (the vhost view shape is unchanged), so no cic
cross-stack gate. `check.sh` green locally (4848 tests, dialyzer/credo/sobelow).
Code-reviewed (one sync reviewer, clean).

Out of scope, opened separately: `vhost_selection` stores address literals, so a
prefix renumber silently drops a stored selection at the read clamp — keying by
`vhost_id` is the fix.