### PR TITLE
cicchetto: cap rail actions menu to space above its launcher

### DIFF
--- a/cicchetto/e2e/tests/issue500-rail-launcher-overflow.spec.ts
+++ b/cicchetto/e2e/tests/issue500-rail-launcher-overflow.spec.ts
@@ -92,3 +92,57 @@ test("#500 — an overflowing member list keeps the rail launcher reachable and 
   await expect(page.locator(".rail-actions-menu")).toBeVisible();
   await expect(page.locator(".rail-actions-menu [data-testid='action-cluster-cog']")).toBeVisible();
 });
+
+// #588 — sibling guarantee to #500. #500 keeps the LAUNCHER reachable; this
+// covers what the launcher OPENS. The menu opens UPWARD from the bottom-pinned
+// launcher, but pre-fix it capped `max-height` at the WHOLE viewport height,
+// not the space that actually lies above the launcher. On a short viewport the
+// overflowing rows therefore grew straight off the top of the screen with NO
+// scroll (the menu was shorter than its own oversized cap, so `overflow-y:
+// auto` never engaged) — the topmost actions unreachable by any gesture.
+//
+// The trap the issue calls out: a menu that fits (tall viewport, few rows)
+// false-passes. So shrink the viewport until the menu GENUINELY overflows the
+// space above the launcher, then assert the topmost row (home) sits INSIDE the
+// viewport. No peers needed — menu overflow is a function of row count vs the
+// space above the launcher, independent of the member list length.
+//
+// A jsdom test cannot catch this (0-sized rects → any y is 0), which is exactly
+// why the cap is a pure unit (`spaceAbove` in menuPosition.test.ts) and the
+// visible proof lives here in a real layout.
+test("#588 — an overflowing rail menu keeps its topmost action inside the viewport", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  // Short viewport: the collapsed action rows (home · rooms · themes · archive
+  // · settings · denoise) cannot all fit in the space above the bottom-pinned
+  // launcher, forcing the overflow this test is about.
+  await page.setViewportSize(VIEWPORT);
+  await openRailMenu(page);
+
+  const menu = page.locator(".rail-actions-menu");
+  await expect(menu).toBeVisible();
+
+  // Precondition — the menu ACTUALLY overflows its box (more rows than fit).
+  // Without this a tall-viewport run would prove nothing (the issue's trap).
+  const overflows = await menu.evaluate((el) => el.scrollHeight > el.clientHeight + 1);
+  expect(overflows, "rail menu must overflow for this test to be meaningful").toBe(true);
+
+  // THE DEFECT: the topmost action (home) must be INSIDE the viewport, not
+  // grown off the top of the screen. boundingBox is viewport-relative and does
+  // NOT scroll; a pre-#588 menu capped at the full viewport height reports a
+  // NEGATIVE y here (the row sits above y=0, unreachable). Once the cap is the
+  // space above the launcher, the row lands at ~gap and `overflow-y: auto`
+  // scrolls the rest into reach.
+  const topRow = menu.locator("[data-testid='mobile-panel-home']");
+  await expect(topRow).toBeVisible();
+  const box = await topRow.boundingBox();
+  expect(box, "top menu row must have a layout box").not.toBeNull();
+  if (box) {
+    expect(box.y, "topmost menu row must not be above the viewport top").toBeGreaterThanOrEqual(0);
+    expect(box.y + box.height).toBeLessThanOrEqual(VIEWPORT.height + 1);
+  }
+});

--- a/cicchetto/src/RailActions.tsx
+++ b/cicchetto/src/RailActions.tsx
@@ -3,6 +3,7 @@ import { archiveSlugForSelection } from "./lib/archiveContext";
 import { channelKey } from "./lib/channelKey";
 import { syncedSetChannelPresencePref } from "./lib/displayPrefs";
 import { membersByChannel } from "./lib/members";
+import { spaceAbove } from "./lib/menuPosition";
 import {
   type MobilePanelSetters,
   openAdminPanel,
@@ -88,6 +89,11 @@ export type Props = {
   setters: MobilePanelSetters;
 };
 
+// #588 — px kept clear at the viewport top when the menu is capped to the space
+// above the launcher, so the topmost row isn't flush against the screen edge
+// (notch / status bar breathing room). Fed to `spaceAbove`.
+const RAIL_MENU_TOP_GAP = 8;
+
 const RailActions: Component<Props> = (props) => {
   // The channel this rail is currently showing, or null on non-channel windows
   // — drives the channel-gated denoise toggle (any channel: the toggle writes a
@@ -127,6 +133,39 @@ const RailActions: Component<Props> = (props) => {
     onCleanup(() => document.removeEventListener("pointerdown", onPointerDown, true));
   });
 
+  // #588 — the menu opens UPWARD from the launcher (`bottom: 100%`), so its
+  // usable height is ONLY the space above `rootRef` (the `.rail-actions`
+  // container the absolute menu anchors to), NOT the whole viewport. The CSS
+  // `max-height: var(--viewport-height)` capped it at the viewport, so on a
+  // short viewport the overflowing rows grew off the top of the screen with no
+  // scroll (menu shorter than its own oversized cap → `overflow-y: auto` never
+  // engaged) and the top actions were unreachable. Measure the real space above
+  // on open and cap `max-height` to it via the shared `menuPosition` seam
+  // (`spaceAbove`) — the same clamp `UserContextMenu` uses, rather than a
+  // second, differently-buggy CSS-only guess. Re-measure on `resize` /
+  // `visualViewport` resize: that is where the mobile-keyboard-up case lives
+  // (the visual viewport shrinks, the launcher rides up, the space above
+  // changes). Null while closed → the menu isn't mounted anyway, and the JSX
+  // falls back to the CSS var.
+  const [menuMaxHeight, setMenuMaxHeight] = createSignal<number | null>(null);
+  createEffect(() => {
+    if (!open()) {
+      setMenuMaxHeight(null);
+      return;
+    }
+    const measure = (): void => {
+      if (!rootRef) return;
+      setMenuMaxHeight(spaceAbove(rootRef.getBoundingClientRect().top, RAIL_MENU_TOP_GAP));
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    window.visualViewport?.addEventListener("resize", measure);
+    onCleanup(() => {
+      window.removeEventListener("resize", measure);
+      window.visualViewport?.removeEventListener("resize", measure);
+    });
+  });
+
   return (
     // biome-ignore lint/a11y/useSemanticElements: role="group" gives the button cluster an accessible name; biome suggests <fieldset>, a form-control grouping (needs <legend>, paints a border) — wrong for a rail toolbar of action buttons.
     <div class="rail-actions" role="group" aria-label="window actions" ref={rootRef}>
@@ -135,7 +174,16 @@ const RailActions: Component<Props> = (props) => {
             Holds every action, unchanged. `createOverlayLock` targets this
             element's selector; outside-click dismiss is the pointerdown listener
             above (no covering scrim). */}
-        <div class="rail-actions-menu" role="menu">
+        <div
+          class="rail-actions-menu"
+          role="menu"
+          style={
+            // #588 — cap to the space above the launcher (JS-measured); the CSS
+            // `max-height: var(--viewport-height)` stays as the pre-measure
+            // fallback. undefined → the CSS rule applies.
+            menuMaxHeight() !== null ? { "max-height": `${menuMaxHeight()}px` } : undefined
+          }
+        >
           {/* #291 — home launcher. Always visible; leftmost/topmost. */}
           <button
             type="button"

--- a/cicchetto/src/lib/menuPosition.test.ts
+++ b/cicchetto/src/lib/menuPosition.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { computeMenuPosition, placeAxis } from "./menuPosition";
+import { computeMenuPosition, placeAxis, spaceAbove } from "./menuPosition";
 
 // #487 — the member-list right-click context menu must stay inside the
 // viewport. The positioning math is a PURE fn so the arithmetic is
@@ -107,5 +107,36 @@ describe("computeMenuPosition (both axes)", () => {
       viewportHeight: 180,
     });
     expect(p.top).toBe(0);
+  });
+});
+
+// #588 — the rail actions menu opens UPWARD from a launcher pinned at the
+// bottom of the rail (`.rail-actions-menu { bottom: 100% }`). Its usable
+// height is NOT the whole viewport — it is only the space ABOVE the anchor
+// (the `.rail-actions` container top). Capping `max-height` at that space is
+// what makes the already-present `overflow-y: auto` engage instead of the
+// menu growing off the top of the screen (the #588 defect). `spaceAbove` is
+// that one-number cap: px available above `anchorTop`, minus a top gap for
+// breathing room, clamped at 0 so a launcher near y=0 never yields a NEGATIVE
+// max-height (invalid CSS → ignored → the bug returns). Pure fn, same
+// jsdom-hollow reasoning as `placeAxis`; the visible proof is the Playwright
+// e2e (issue500-rail-launcher-overflow.spec.ts short-viewport variant).
+describe("spaceAbove (rail upward-menu max-height cap)", () => {
+  it("returns the space above the anchor minus the top gap", () => {
+    // launcher top at 500px, keep 8px clear → menu may be 492px tall.
+    expect(spaceAbove(500, 8)).toBe(492);
+  });
+
+  it("clamps to 0 when the anchor sits within the gap of the top", () => {
+    // launcher near y=0 (tiny viewport) → 4 - 8 = -4 must NOT be negative.
+    expect(spaceAbove(4, 8)).toBe(0);
+  });
+
+  it("returns 0 when the anchor is exactly one gap below the top", () => {
+    expect(spaceAbove(8, 8)).toBe(0);
+  });
+
+  it("returns 0 for an anchor flush with the viewport top", () => {
+    expect(spaceAbove(0, 8)).toBe(0);
   });
 });

--- a/cicchetto/src/lib/menuPosition.ts
+++ b/cicchetto/src/lib/menuPosition.ts
@@ -39,3 +39,18 @@ export function computeMenuPosition(m: MenuMeasurement): MenuPlacement {
     top: placeAxis(m.clickY, m.menuHeight, m.viewportHeight),
   };
 }
+
+// #588 — max-height cap for a menu that opens UPWARD from a bottom-pinned
+// anchor (the rail actions launcher: `.rail-actions-menu { bottom: 100% }`).
+// The space such a menu actually has is only what lies ABOVE the anchor —
+// NOT the whole viewport, which is what the CSS `max-height:
+// var(--viewport-height)` wrongly capped it at (the menu then grew off the
+// top of the screen instead of scrolling). `anchorTop` is the anchor's
+// distance from the viewport top (getBoundingClientRect().top); `gap` keeps
+// a few px clear at the top for breathing room. Clamped at 0: an anchor near
+// y=0 must never produce a NEGATIVE max-height (invalid CSS → rule ignored →
+// the overflow bug returns). Sibling of `placeAxis`'s viewport-oversize
+// pin — both hand the CSS `overflow-y: auto` a valid, in-viewport box.
+export function spaceAbove(anchorTop: number, gap: number): number {
+  return Math.max(0, anchorTop - gap);
+}

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -1674,7 +1674,14 @@ html.resize-dragging * {
    inside a short viewport (e.g. mobile keyboard up); `overscroll-behavior:
    contain` stops the scroll chaining to the list behind. z-index sits at the
    context-menu layer so it clears the rail chrome; the fixed backdrop below is
-   one step under it. */
+   one step under it.
+   #588 — the `max-height: var(--viewport-height)` here is now only the
+   PRE-MEASURE FALLBACK. `var(--viewport-height)` is the WHOLE viewport, but a
+   menu opening upward only has the space ABOVE the launcher; capping at the
+   viewport let the overflowing rows grow off the top of the screen with no
+   scroll. RailActions.tsx measures the real space above on open (+ on resize /
+   visualViewport) and overrides `max-height` inline via `spaceAbove` — only
+   then does the `overflow-y: auto` below actually engage. */
 .rail-actions-menu {
   position: absolute;
   bottom: 100%;


### PR DESCRIPTION
## What

The rail **actions** menu opens UPWARD from a launcher pinned at the bottom of the rail (`.rail-actions-menu { position:absolute; bottom:100% }`), but its CSS capped `max-height: var(--viewport-height)` — the **whole viewport**, not the space that actually lies **above the launcher**. On a short viewport (a handful of rows already suffice; mobile keyboard-up makes it worse) the overflowing rows grew straight off the top of the screen: the menu was shorter than its own oversized cap, so the `overflow-y: auto` already present never engaged, and neither the menu nor the page scrolled. The topmost actions sat above `y=0`, unreachable by any gesture.

The sibling `UserContextMenu` never had this because it clamps through the pure `lib/menuPosition` seam. `RailActions` was pure-CSS placement and was the one menu never wired to it.

## Fix

Reuse the seam instead of a second, differently-buggy guess:

- `lib/menuPosition.ts`: add pure primitive `spaceAbove(anchorTop, gap) => Math.max(0, anchorTop - gap)` — px available above the anchor, **clamped at 0** so a launcher near `y=0` never yields a negative `max-height` (invalid CSS → ignored → the bug returns).
- `RailActions.tsx`: measure `rootRef` (the `.rail-actions` container the absolute menu anchors to) on open, and on `resize` / `visualViewport` resize (the mobile-keyboard case), capping the menu's inline `max-height` via `spaceAbove`. Listeners are registered only while open and removed on close + unmount.
- CSS `var(--viewport-height)` stays as the **pre-measure fallback**. Once the cap is right, the existing `overflow-y: auto` starts doing its job.

## Proof (TDD)

- **Pure unit** (`menuPosition.test.ts`): `spaceAbove` normal + clamp-at-0 boundaries (jsdom-safe, like `placeAxis`).
- **Real e2e** (`issue500-rail-launcher-overflow.spec.ts`, adjacent guarantee): short viewport, open the menu, assert the topmost row (`home`) sits inside the viewport — **RED at `y=-54` before the fix, green after**. Precondition asserts the menu genuinely overflows, guarding the tall-viewport false-pass the issue calls out.

## Gates

- `bun run check` (biome + tsc): clean.
- `bun run test` (vitest): 3726 passed.
- `scripts/integration.sh` full suite: **570 passed / 0 failed** (chromium + webkit-iphone-15). The new e2e is chromium-only (untagged; webkit project greps `@webkit`), so it adds exactly 1 test.

Refs #588