### PR TITLE
cic(#589): make admin pane text selectable on iOS

### DIFF
--- a/cicchetto/e2e/tests/issue589-ios-admin-select.spec.ts
+++ b/cicchetto/e2e/tests/issue589-ios-admin-select.spec.ts
@@ -1,0 +1,105 @@
+// #589 (2026-08-01) — on iOS NO text inside the admin pane was selectable,
+// keyboard up or down. The admin tables are exactly the surfaces an operator
+// needs to copy off the device (IPs, session/visitor ids, vhosts, UA strings,
+// error text), so the bug forced retyping by hand.
+//
+// ROOT CAUSE (pure CSS): `html.is-ios` applies a blanket
+// `-webkit-user-select: none` (Telegram Web K pattern, themes/default.css) that
+// inherits to every descendant, paired with an explicit re-enable allowlist
+// (.scrollback, .topic-modal-text, input, textarea, select). The admin pane was
+// NOT in that list, so `.admin-tab-panel` and every table cell inherited `none`.
+// Fix: re-enable `.admin-tab-panel` (one wrapper covers all ten tabs) and
+// re-exclude the controls inside it (`button`) so a long-press on a control
+// doesn't pop the selection magnifier — the same carve-out `.scrollback-invite-join`
+// makes for the [Join] CTA.
+//
+// The keepKeyboard.ts SELECTABLE_TEXT_SURFACES list was deliberately NOT
+// touched: that list is compose-focus KEYBOARD policy, and the AdminPane <Match>
+// arm UNMOUNTS ComposeBox (Shell.tsx <Switch>), so no text input holds focus
+// behind the pane — handleMouseDown bails on document.activeElement. iOS native
+// long-press selection here is pure CSS.
+//
+// jsdom is blind to CSS + has a no-op Selection
+// (feedback_cicchetto_browser_smoke), so this regression can ONLY be pinned in a
+// real browser. Real iOS long-press selection (magnifier/handles) isn't
+// emulatable on Playwright webkit (feedback_playwright_webkit_not_ios_scroll),
+// so computed style is the testable boundary — same posture as
+// text-selection-restored.spec.ts's @webkit half. Real-device dogfood remains
+// the final iOS verification (vjt post-ship).
+
+import { expect, test } from "../fixtures/test";
+import { openAdminConsole } from "../fixtures/cicchettoPage";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
+
+test.setTimeout(60_000);
+
+test("@webkit iOS — admin pane content re-enables user-select under the is-ios global kill; controls stay unselectable", async ({
+  page,
+}) => {
+  const admin = getSeededAdmin();
+  // A minted visitor guarantees a populated Visitors table: a real `<td>` cell
+  // (the IP — exactly the copyable content #589 is about) plus a per-row Delete
+  // button that lives INSIDE `.admin-tab-panel` (the re-exclude target).
+  // Short prefix: `${Date.now()}` is 13 digits, so the nick must stay under
+  // the upstream NICKLEN (bahamut 30) — a longer prefix trips 400 malformed_nick.
+  const visitorNick = `ios589-${Date.now()}`;
+  const visitor = await mintVisitor(visitorNick);
+
+  try {
+    await page.addInitScript(
+      ([token, subjectJson]) => {
+        localStorage.setItem("grappa-token", token);
+        localStorage.setItem("grappa-subject", subjectJson);
+        localStorage.setItem("cic.installChoice", "browser");
+      },
+      [admin.token, admin.subjectJson] as const,
+    );
+    await page.goto("/");
+
+    // Viewport-aware single door to AdminPane — on the iPhone-15 (mobile)
+    // project this routes rail-drawer → cog → settings drawer → admin entry.
+    await openAdminConsole(page);
+    await page.getByTestId("admin-tab-visitors").click();
+    await expect(page.getByTestId("admin-visitors-table")).toBeVisible({ timeout: 10_000 });
+
+    const row = page.getByTestId(`admin-visitor-row-${visitor.id}`);
+    await expect(row).toBeVisible();
+
+    const styles = await page.evaluate((visitorId) => {
+      const panel = document.querySelector(".admin-tab-panel");
+      // First body cell of the visitors table — a real `<td>` (the copyable
+      // surface the bug killed), not a header.
+      const cell = document.querySelector(".admin-visitors-table tbody td");
+      const button = document.querySelector(`[data-testid="admin-visitor-delete-${visitorId}"]`);
+      if (panel === null || cell === null || button === null) {
+        return { missing: true } as const;
+      }
+      return {
+        missing: false,
+        htmlIsIos: document.documentElement.classList.contains("is-ios"),
+        htmlUserSelect: getComputedStyle(document.documentElement).webkitUserSelect,
+        panelUserSelect: getComputedStyle(panel).webkitUserSelect,
+        cellUserSelect: getComputedStyle(cell).webkitUserSelect,
+        buttonUserSelect: getComputedStyle(button).webkitUserSelect,
+      } as const;
+    }, visitor.id);
+
+    // Live-surface precondition — no hollow green if a selector drifted.
+    expect(styles.missing).toBe(false);
+    // iPhone 15 UA → applyIosClass marks the root; the blanket kill is active,
+    // so this test genuinely runs under the policy the fix re-enables.
+    expect(styles.htmlIsIos).toBe(true);
+    expect(styles.htmlUserSelect).toBe("none");
+
+    // THE fix: the panel wrapper + its table cells are selectable again.
+    expect(styles.panelUserSelect).toBe("text");
+    expect(styles.cellUserSelect).toBe("text");
+
+    // The re-exclude: a control inside the panel stays unselectable, so a
+    // long-press on it doesn't pop the selection magnifier over a button.
+    expect(styles.buttonUserSelect).toBe("none");
+  } finally {
+    await reapVisitors(admin.token, visitor.id);
+  }
+});

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -506,6 +506,32 @@ html.is-ios .scrollback-invite-join {
   user-select: none;
 }
 
+/* #589 — admin pane content selectable on iOS. The blanket `html.is-ios`
+   user-select:none above kills selection on every admin table — exactly the
+   surfaces (IPs, session/visitor ids, vhosts, UA strings, error text) an
+   operator needs to copy off the device. `.admin-tab-panel` is the single
+   wrapper around every tab's content (AdminPane.tsx), so ONE selector
+   re-enables all ten tabs. Mirrors the .scrollback re-enable above; NOT
+   mirrored into keepKeyboard.ts's SELECTABLE_TEXT_SURFACES — that list is
+   compose-focus KEYBOARD policy, and the AdminPane <Match> arm UNMOUNTS
+   ComposeBox (Shell.tsx <Switch>), so no text input holds focus behind the
+   pane (handleMouseDown bails on document.activeElement). iOS native
+   long-press selection here is pure CSS. See DESIGN_NOTES 2026-08-01. */
+html.is-ios .admin-tab-panel {
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+/* Re-exclude controls inside the panel — a long-press on a refresh/action
+   button must not pop the selection magnifier over a control (same carve-out
+   as .scrollback-invite-join). Buttons only: <input>/<select> stay selectable
+   via the global input/select re-enables above, and anchors keep their URL
+   text copyable (the .scrollback-link reasoning in keepKeyboard.ts). */
+html.is-ios .admin-tab-panel button {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
 html.is-ios body {
   height: calc(var(--vh, 1vh) * 100);
 }

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -25056,3 +25056,52 @@ asserts the VISIBLE terminal `recover-modal-success` after RECOVER frees the
 hold — no API-return assertion, no success-or-failure soft-assert (D4). A server
 integration test masking a critical behind an unrealistic mock is exactly why the
 happy-path e2e is mandatory: a feature without one is hollow green.
+
+## 2026-08-01 — #589: the admin pane joins the iOS user-select allowlist (CSS-only)
+
+On iOS NO text in the admin pane was selectable, keyboard up or down. The admin
+tables are the surfaces an operator most needs to copy off the device (IPs,
+session/visitor ids, vhosts, UA strings, error text), so the bug forced retyping
+by hand.
+
+Root cause is the Dispatch-1 (2026-06-11) iOS selection policy: `html.is-ios`
+applies a blanket `-webkit-user-select: none` (the Telegram Web K pattern) that
+inherits to every descendant, paired with an explicit re-enable allowlist
+(`.scrollback`, `.topic-modal-text`, `input`, `textarea`, plus #508's `select`).
+The admin pane was never added to that list, so `.admin-tab-panel` and every
+table cell inherited `none`. Admin form fields already worked — they are
+`input`/`textarea`, already on the allowlist — which is exactly the report shape:
+the fields fine, the tables and labels dead.
+
+Fix (`themes/default.css`): re-enable `html.is-ios .admin-tab-panel` — the single
+wrapper `AdminPane.tsx` puts around every tab's content, so ONE selector covers
+all ten tabs — and re-exclude `html.is-ios .admin-tab-panel button` so a
+long-press on a refresh/action button does not pop the selection magnifier over a
+control. That re-exclude is the twin of the `.scrollback-invite-join` carve-out
+for the `[Join]` CTA. Buttons ONLY: `input`/`select` stay selectable via the
+global re-enables, and anchors keep their URL text copyable (the
+`.scrollback-link` reasoning in `keepKeyboard.ts` — a clickable-but-copyable
+inline control stays `user-select: text`).
+
+The decision that mattered: `keepKeyboard.ts`'s `SELECTABLE_TEXT_SURFACES` was
+deliberately NOT touched, even though the CSS re-enable allowlist and that list
+must otherwise stay in sync. That list is compose-focus KEYBOARD policy — it only
+does anything while a text input holds focus (`handleMouseDown` bails on
+`!isTextEntry(document.activeElement)`). The AdminPane `<Match>` arm UNMOUNTS
+ComposeBox (`Shell.tsx` `<Switch>` renders AdminPane INSTEAD of the
+TopicBar/Scrollback/ComposeBox stack), so no text input can be focused behind the
+pane; and on real iOS a long-press synthesizes no mousedown at all (#366). So the
+pane's selection is governed purely by the `user-select` CSS. The issue's "open
+question" (could compose stay focused behind the pane, forcing a TS change too?)
+resolves to no — CSS-only is complete, and adding the admin pane to
+`SELECTABLE_TEXT_SURFACES` would be dead code the file's own comment warns
+against.
+
+Test: e2e (`@webkit` iPhone-15), not jsdom — jsdom is blind to CSS and has a
+no-op `Selection`, so a unit test passes against the broken CSS. Asserts the
+computed `user-select` on a real `.admin-visitors-table` cell is `text` and on a
+control inside the panel is `none`, under the active is-ios kill, mirroring
+`text-selection-restored.spec.ts`'s @webkit half. RED→GREEN verified locally
+(without the fix the panel computes `none`). Real long-press selection is not
+emulatable on Playwright webkit, so computed style is the testable boundary;
+device dogfood is the final iOS check.


### PR DESCRIPTION
Refs #589.

## Problem
On iOS NO text inside the admin pane could be selected, keyboard up or down — yet the admin tables are exactly the surfaces an operator needs to copy off the device (IPs, session/visitor ids, vhosts, UA strings, error text). The only escape was retyping by hand.

## Root cause (pure CSS)
`html.is-ios` applies a blanket `-webkit-user-select: none` (Telegram Web K pattern) that inherits to every descendant, paired with an explicit re-enable allowlist (`.scrollback`, `.topic-modal-text`, `input`, `textarea`, `select`). The admin pane was never in that list, so `.admin-tab-panel` and every table cell inherited `none`. Admin form fields already worked (they are `input`/`textarea`) — matching the report: the fields were fine, the tables and labels dead.

## Fix
- Re-enable `.admin-tab-panel` — the single wrapper around every tab's content, so ONE selector covers all ten tabs.
- Re-exclude the controls inside it (`button`) so a long-press on a refresh/action button doesn't pop the selection magnifier over a control — same carve-out `.scrollback-invite-join` makes for the `[Join]` CTA. Buttons only: `input`/`select` stay selectable via the global re-enables, anchors keep their URL text copyable.

## Open question — resolved
The spec asked whether compose can keep focus behind the pane (which would need a `keepKeyboard.ts` `SELECTABLE_TEXT_SURFACES` change too). It cannot: the AdminPane `<Match>` arm **unmounts** ComposeBox (`Shell.tsx` `<Switch>`), so no text input holds focus behind the pane and `handleMouseDown` bails on `document.activeElement`. On real iOS a long-press synthesizes no mousedown anyway. **CSS-only; `keepKeyboard.ts` deliberately untouched.**

## Test
e2e (`@webkit` iPhone-15), not jsdom — jsdom is blind to CSS and has a no-op `Selection`, so a unit test passes against the broken CSS. Asserts the computed `user-select` on a real `.admin-visitors-table` cell is `text` and on a control inside the panel is `none`, under the active is-ios global kill (same posture as `text-selection-restored.spec.ts`).

## Verification
- `bun run check` (biome + tsc): green
- `bun run test` (vitest): 3722 passed
- e2e RED→GREEN (scoped, `--project webkit-iphone-15`): without the fix `panelUserSelect === "none"` → **FAIL**; with the fix → **1 passed**
- Full `scripts/integration.sh` suite: NOT run here (ship gate — deferred to reviewer/merge)

Real-device dogfood remains the final iOS check.