### PR TITLE
source-alias: root-owned prefix file, real capability probe, set-time 422 (#609)

### DIFF
--- a/cicchetto/src/__tests__/friendlyApiError.test.ts
+++ b/cicchetto/src/__tests__/friendlyApiError.test.ts
@@ -102,6 +102,19 @@ const CASES: Array<{ code: string; matches: RegExp; info?: Record<string, unknow
   { code: "unsupported_media_type", matches: /file type isn't supported/i },
   // Admin settings / vhost / admin-guard tokens.
   { code: "invalid_setting", matches: /setting value isn't valid/i },
+  // #609 — mode-2 (static mapping) refused at set time; the wire `reason`
+  // drives the copy. `no_static_prefix` is the operator-actionable branch;
+  // any other reason is a substrate-capability refusal, surfaced verbatim.
+  {
+    code: "addressing_unusable",
+    matches: /static-mapping prefix before switching to mode 2/i,
+    info: { reason: "no_static_prefix" },
+  },
+  {
+    code: "addressing_unusable",
+    matches: /can't be enabled on this server: substrate_disabled/i,
+    info: { reason: "substrate_disabled" },
+  },
   { code: "forbidden_vhost", matches: /vhost isn't available/i },
   { code: "source_not_local", matches: /address this server can send from/i },
   { code: "already_exists", matches: /already exists/i },

--- a/cicchetto/src/lib/friendlyApiError.ts
+++ b/cicchetto/src/lib/friendlyApiError.ts
@@ -268,6 +268,27 @@ function friendlyKnown(err: ApiError, code: ErrorTokensRestErrorToken): string {
       // UX-6-B1 — 422 admin `PUT /admin/settings` with an out-of-shape
       // value. Carries the offending `field` (AdminSettingsTab highlights it).
       return "That setting value isn't valid. Check it and try again.";
+    case "addressing_unusable": {
+      // #609 — `PUT /admin/settings` tried to switch to addressing mode 2
+      // (static mapping) but the capability probe (SourceAliasManager.arm/1)
+      // refused to arm the prefix on THIS host, so the mode was NOT stored
+      // (422, no state change — fallback_controller.ex). The wire `reason`
+      // (captured into err.info by readError) names WHY. `no_static_prefix`
+      // is the one operator-actionable case — mode 2 chosen with no prefix
+      // set; every other reason is a substrate-capability refusal
+      // (substrate_disabled, ip_nonlocal_bind_disabled, anyip_route_missing,
+      // alias_not_permitted, wrapper_unavailable, …) so we surface it
+      // verbatim rather than maintain a brittle per-atom copy table — the
+      // operator wants the concrete probe reason to diagnose the host, not a
+      // generic toast.
+      const reason = err.info.reason;
+      if (reason === "no_static_prefix") {
+        return "Set a static-mapping prefix before switching to mode 2 (static mapping).";
+      }
+      return typeof reason === "string" && reason.length > 0
+        ? `Mode 2 (static mapping) can't be enabled on this server: ${reason}.`
+        : "Mode 2 (static mapping) can't be enabled on this server.";
+    }
     case "forbidden_vhost":
       // #228 — a vhost selection outside the subject's allowed set (403).
       return "That vhost isn't available to your account.";

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -1336,6 +1336,7 @@ export const ERROR_TOKENS_REST_ERROR_TOKEN = [
   "insufficient_storage",
   "unsupported_media_type",
   "invalid_setting",
+  "addressing_unusable",
   "rate_limited",
   "too_many_attempts",
   "theme_cap_reached",

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -25862,7 +25862,17 @@ so a pre-existing alias is never disturbed. The elegant part: because the canary
 is derived from the **DB** prefix while the wrapper's in-prefix guard scopes
 against its **config-file** prefix, a DB↔substrate drift surfaces for free as
 exit 65 → `:prefix_mismatch`. No duplicated "compare the two prefixes" state —
-the mismatch falls out of the existing guard. Reasons: 65→`:prefix_mismatch`,
+the mismatch falls out of the existing guard. **Blind spot (accepted, review
+2026-08-01):** the canary is the network base (host-0), so a config prefix that
+is strictly NARROWER than the DB prefix but shares its base (e.g. DB `/64`,
+config `/80`, both `…cb::`) contains the base → the probe passes and arms, yet
+real derived sources (random 48-bit host bits) fall outside the narrower config
+and are refused at acquire → sessions HELD. It is fail-safe (held, never wrong
+egress) and requires a hand-edit that deviates from the deploy-render (which
+writes the config FROM the DB prefix, so they match). A canary carrying a
+host bit set just below the DB boundary would close this — deferred as a
+possible follow-up, not folded into the review fix on a held branch. Reasons:
+65→`:prefix_mismatch`,
 66→`:prefix_config_unavailable`, 69→`:alias_not_permitted`, sudo's own exit 1 /
 missing binary → `:wrapper_unavailable`, timeout → `:probe_timeout`.
 
@@ -25891,3 +25901,17 @@ DB prefix and the manager's `ensure_source` guard refuses it (`:outside_prefix`)
 so the session is HELD, never egressing wrong — and it self-corrects on the next
 successful set or at boot. The alternative (persist-then-arm) would violate the
 "probe FIRST, do not persist" contract, so this ordering is deliberate.
+
+**Second accepted limitation (runtime renumber, review 2026-08-01):** because
+`arm/1` adopts the new prefix as the manager's working prefix, changing the
+mode-2 prefix while mode-2 sessions are LIVE leaks their old-prefix `/128`
+aliases. The live sessions still bind the old addresses (correct — you must not
+`-alias` an in-use source), but when such a holder later releases,
+`release_source(D_old, prefix=P_new)` fails `in_cidr6?` (`:outside_prefix`) and
+the boot reconcile only sweeps within the CURRENT prefix, so `D_old` on `lo0`
+lingers until a manual `ifconfig -alias`. A full runtime renumber (tracking each
+alias's own prefix, or reconciling both) is out of #609's scope; the operator
+guidance (OPERATIONS.md) is to disconnect mode-2 sessions before renumbering, or
+accept the manual cleanup. This is not new to #609 in kind — any prefix change
+orphans out-of-current-prefix aliases from the reconcile sweep — but #609 makes
+a runtime prefix change take effect without a reboot, so it is now reachable.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -25822,3 +25822,72 @@ playback to a Manual check; the automated coverage is the classifier table
 (`mediaLink.test.ts`) + the CSP-on-the-wire parity spec.
 
 Deploy class: `security_headers.ex` is in `lib/` → HOT.
+---
+
+## 2026-08-01 — #609: the source-alias wrapper's prefix has one source of truth, and arm_check proves aliasing
+
+Two defects in the #543 static-mapping mode-2 machinery, both surfaced by a
+production IPv6-cutover incident (the wrapper still pinned `cb::/80` while the
+intended block was `cafe::/80`, which was not even routed).
+
+**1. The prefix was a compiled-in default.** `infra/freebsd/bin/grappa-source-alias`
+carried `PREFIX="${GRAPPA_SOURCE_ALIAS_PREFIX:-2a03:4000:20:2d3:cb::/80}"`, a
+literal that had to match `ServerSettings.static_mapping_prefix` by hand across
+two systems (a DB row and a root-owned file). On drift, every `ensure_source`
+was refused exit 65 and sessions stayed held. The wrapper now reads the prefix
+from a **root-owned config file** (`/usr/local/etc/grappa/source-alias.conf`,
+`PREFIX=<cidr>`), rendered from the DB prefix at deploy time. Missing /
+unreadable / malformed → **exit 66, fail closed** — never a wildcard fallback.
+`GRAPPA_SOURCE_ALIAS_PREFIX` stays a root-invoked / test-only override and stays
+OUT of `env_keep`: an env-controllable scope on a root wrapper is a privilege
+hole (a compromised BEAM could widen it to `::/0`), and `sudo` scrubs the env
+from the grappa caller anyway. **No new deploy substrate** (CLAUDE.md forbids
+one without discussion): the render is a documented manual step, and the drift
+is now caught structurally by the probes below rather than by a provisioning
+script.
+
+**2. `arm_check` was a false positive.** It ran `sudo -n grappa-source-alias
+check` — a no-op that exits 0 whenever the sudoers grant resolves. It proved
+nothing about whether the substrate can configure addresses: a NON-VNET jail
+passes `check` and then fails EVERY `ensure_source` with EPERM
+(`ifconfig: ioctl (SIOCAIFADDR): Operation not permitted`). `arm_check` now
+drives a real `probe <canary>` subcommand: add-then-delete a canary and exit 0
+only if the add succeeds; a refusing substrate → exit 69 → `:alias_not_permitted`.
+
+**The canary is the network-base address of the DB prefix** (`IpLiteral.network_address/1`).
+Two properties make it safe: it is guaranteed in-prefix for any length, and a
+live derived source (a near-uniform 48-bit SHA-256 spread over the host bits)
+practically never occupies host-0 — and the wrapper deletes ONLY what it added,
+so a pre-existing alias is never disturbed. The elegant part: because the canary
+is derived from the **DB** prefix while the wrapper's in-prefix guard scopes
+against its **config-file** prefix, a DB↔substrate drift surfaces for free as
+exit 65 → `:prefix_mismatch`. No duplicated "compare the two prefixes" state —
+the mismatch falls out of the existing guard. Reasons: 65→`:prefix_mismatch`,
+66→`:prefix_config_unavailable`, 69→`:alias_not_permitted`, sudo's own exit 1 /
+missing binary → `:wrapper_unavailable`, timeout → `:probe_timeout`.
+
+**3. The probe runs when the mode is SET, not only at boot (vjt, #grappa
+12:09).** `PUT /admin/settings` validated only the SHAPE of an addressing change
+and saved, so an operator got 200 and discovered the failure later as held
+sessions. The addressing subtree is now applied as a UNIT: resolve the target
+`(mode, prefix)` — each from the body or the current row — then, when the target
+is mode 2, run the probe FIRST via `SourceAliasManager.arm/1`. On refusal →
+**422 `addressing_unusable`** with the concrete reason, persisting nothing (a
+mode that cannot arm never reaches the DB); on success → persist prefix-then-mode.
+`arm/1` also ADOPTS the probed prefix and publishes `armed?`, so a mode-2 change
+goes live WITHOUT a reboot (B1) — and it changes no state on refusal, so a
+failed set-time probe never disarms a manager that is currently working. This
+does not replace the boot/arm check: the substrate mutates independently of the
+DB row (a jail restarted without VNET, a wrapper removed by a re-provision), so
+both checkpoints stay. The per-address hard-fail (`do_start_client/2` stops on
+acquire failure, no shared-source fallthrough) was already in place and is
+unchanged.
+
+**Known accepted wrinkle:** `arm/1` commits the manager's arm state (prefix +
+`armed?`) BEFORE the controller persists the settings row, so a transient
+`:db_unavailable` on the persist leaves the manager armed against a prefix the
+DB does not yet carry. This is safe — a session then derives against the (old)
+DB prefix and the manager's `ensure_source` guard refuses it (`:outside_prefix`),
+so the session is HELD, never egressing wrong — and it self-corrects on the next
+successful set or at boot. The alternative (persist-then-arm) would violate the
+"probe FIRST, do not persist" contract, so this ordering is deliberate.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -826,6 +826,14 @@ than egressing from the shared kernel-default source.
   Bootstrap spawns sessions) the `SourceAliasManager` sweeps orphan
   aliases a crashed prior run left bound (`ifconfig lo0` on FreeBSD;
   no-op on Linux/AnyIP), so a hard crash does not leak `/128` aliases.
+- **Renumbering (changing the prefix) with LIVE mode-2 sessions leaks the
+  old aliases.** A successful `PUT /admin/settings` prefix change takes effect
+  at runtime (#609), but sessions already bound to the OLD prefix keep those
+  `/128` aliases (correct — an in-use source must not be removed), and neither
+  a later release nor the reconcile sweep (both scoped to the NEW prefix) can
+  reclaim them, so the old `lo0` aliases linger until a manual `ifconfig lo0
+  inet6 <old-addr>/128 -alias`. To renumber cleanly, disconnect mode-2 sessions
+  first (or accept the manual cleanup). A full live-renumber is not supported.
 
 **fail2ban gotcha.** fail2ban runs on the **host** (9 jails incl.
 `http-404`, `http-ratelimit`, `recidive`). A cic client looping on a

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -772,20 +772,49 @@ than egressing from the shared kernel-default source.
 
   The wrapper — not a bare `sudo ifconfig` — is the privilege boundary:
   it hard-codes `lo0` + `/128` and refuses any address outside the
-  configured prefix (its compiled `PREFIX=` default,
-  `2a03:4000:20:2d3:cb::/80` — MUST match
-  `ServerSettings.static_mapping_prefix`). **For a non-default block, edit
-  the `PREFIX=` line in the root-owned wrapper — do NOT `env_keep`
-  `GRAPPA_SOURCE_ALIAS_PREFIX` through sudoers.** The prefix is the
-  wrapper's privilege SCOPE; env-keeping it hands that scope to the
+  configured prefix. **The prefix is NOT compiled in (#609).** The wrapper
+  reads it from a ROOT-OWNED config file it FAILS CLOSED without:
+
+  ```
+  # /usr/local/etc/grappa/source-alias.conf   root:wheel, 0444
+  PREFIX=2a03:4000:20:2d3:cb::/80
+  ```
+
+  Render this file from `ServerSettings.static_mapping_prefix` as part of the
+  SAME deploy step that installs the wrapper + sudoers line, so the DB prefix
+  and the wrapper's scope cannot drift by hand — that drift is the #609 prod
+  incident (the wrapper still pinned `cb::/80` while the intended block was
+  `cafe::/80`, which was not even routed, so every acquire failed exit 65 and
+  sessions stayed held). A missing / unreadable / malformed file makes the
+  wrapper exit 66 (fail closed), never a wildcard fallback.
+
+  **Do NOT `env_keep GRAPPA_SOURCE_ALIAS_PREFIX` through sudoers.** The prefix
+  is the wrapper's privilege SCOPE; env-keeping it hands that scope to the
   (untrusted) grappa caller, so a compromised BEAM could set
   `GRAPPA_SOURCE_ALIAS_PREFIX=::/0` and `sudo` an alias for ANY address —
-  including the trusted `::ca` block — defeating the exact accountable-vs-
-  untrusted egress separation this feature enforces. sudo scrubs the env by
-  default, so the hard-coded root-owned `PREFIX=` is the only scope that
-  applies; keep it that way. `arm_check` probes the grant with `sudo -n
-  grappa-source-alias check`; a missing wrapper/grant leaves mode 2 disarmed
-  with reason `:wrapper_unavailable`.
+  including the trusted `::ca` block — defeating the accountable-vs-untrusted
+  egress separation this feature enforces. `sudo` scrubs the env by default, so
+  from the grappa caller only the config file applies; the env override exists
+  ONLY for a root-invoked / test call. Keep it that way.
+
+  **A VNET jail is REQUIRED.** `arm_check` no longer trusts a no-op grant probe
+  — it drives `sudo -n grappa-source-alias probe <canary>`, which adds then
+  deletes a canary address (the prefix's network base) to prove the substrate
+  can actually alias. A NON-VNET jail (shared host network stack, `ip6.addr`
+  pinned by the host) refuses `ifconfig ... alias` with EPERM, so mode 2
+  disarms with `:alias_not_permitted` instead of arming and then failing every
+  acquire. Give the jail its own VNET (`vnet` + an `epair`/interface in the
+  bastille/jail config) before enabling mode 2. Other disarm reasons:
+  `:wrapper_unavailable` (missing wrapper/grant), `:prefix_mismatch` (the
+  config-file prefix differs from the DB prefix — the canary is derived from
+  the DB prefix, so the wrapper refuses it), `:prefix_config_unavailable`
+  (missing/malformed config file).
+
+  These same probes run at settings-SET time: `PUT /admin/settings` selecting
+  mode 2 — or changing the prefix while mode 2 is active — runs the probe FIRST
+  and, on failure, returns **422 `addressing_unusable`** with the specific
+  reason and persists NOTHING, so an operator learns in the curl/UI response
+  rather than later from held sessions.
 - **Native Linux (`GRAPPA_SUBSTRATE=linux`).** No per-address alias —
   an AnyIP local route makes the whole block bindable at once. Provision
   BOTH (persist in your netplan/rc): `sysctl -w

--- a/infra/freebsd/bin/grappa-source-alias
+++ b/infra/freebsd/bin/grappa-source-alias
@@ -1,40 +1,104 @@
 #!/bin/sh
 # grappa-source-alias — sudoers-scoped ifconfig wrapper for the #543
-# static-mapping outbound-addressing mode (INC-5).
+# static-mapping outbound-addressing mode.
 #
 # This wrapper — NOT a bare `sudo ifconfig` — is the privilege boundary. An
 # unconstrained `sudo ifconfig` would let the grappa user alias ANY address on
 # ANY interface (a privilege hole). This wrapper hard-codes the interface
 # (lo0), the netmask (/128), and refuses any address that is not strictly
-# inside the configured `::cb::/80` block, so the sudoers grant can only ever
-# add/remove a single derived source alias in the intended range.
+# inside the configured prefix, so the sudoers grant can only ever add/remove a
+# single derived source alias in the intended range.
 #
-# Subcommands (argv-validated; anything else exits non-zero):
-#   check           probe — exit 0. Used by the adapter's arm_check to prove
-#                   the sudoers NOPASSWD grant + this wrapper are present.
-#   add  <v6-addr>  ifconfig lo0 inet6 <addr>/128 alias   (addr must be in prefix)
-#   del  <v6-addr>  ifconfig lo0 inet6 <addr>/128 -alias  (addr must be in prefix)
+# ## Prefix source — root-owned config file, fail-closed (#609)
 #
-# The prefix is this wrapper's privilege SCOPE. For a non-default block, edit
-# the root-owned PREFIX= default below — it MUST match
-# ServerSettings.static_mapping_prefix so a derived address is never refused as
-# out-of-range. GRAPPA_SOURCE_ALIAS_PREFIX is read only as a root-invoked /
-# test override; NEVER `env_keep` it through sudoers — that hands the scope to
-# the (untrusted) grappa caller, who could then widen it to ::/0 and alias any
-# address (incl. the trusted ::ca block). sudo scrubs the env by default, so
-# without env_keep only the hard-coded default applies. See docs/OPERATIONS.md.
+# The prefix (this wrapper's privilege SCOPE) is read from a ROOT-OWNED config
+# file, NOT a compiled-in literal:
 #
-# Exit codes: 0 ok · 64 usage · 65 address outside the prefix / unparseable ·
-# ifconfig's own code on an add/del failure.
+#   /usr/local/etc/grappa/source-alias.conf   (root:wheel, 0444)
+#       PREFIX=<v6-cidr>
+#
+# It MUST match ServerSettings.static_mapping_prefix; the operator renders this
+# file from the DB prefix at deploy time so the two cannot drift by hand
+# (docs/OPERATIONS.md). A missing / unreadable / malformed file makes the
+# wrapper FAIL CLOSED (exit 66) — never a wildcard fallback that could alias an
+# unintended block.
+#
+# GRAPPA_SOURCE_ALIAS_PREFIX overrides the file, but ONLY for a root-invoked /
+# test call. NEVER `env_keep` it through sudoers — that hands the scope to the
+# (untrusted) grappa caller, who could widen it to ::/0 and alias any address
+# (incl. the trusted ::ca block). sudo scrubs the env by default, so from the
+# grappa caller only the config file applies. GRAPPA_SOURCE_ALIAS_CONF likewise
+# overrides the file PATH for tests only. See docs/OPERATIONS.md.
+#
+# ## Subcommands (argv-validated; anything else exits non-zero)
+#
+#   probe <v6-addr> real capability probe used by the adapter's arm_check: add
+#                   then delete the canary, exit 0 ONLY if the alias could be
+#                   added (proves the substrate can alias — a non-VNET jail
+#                   cannot). Deletes ONLY what it added.
+#   add   <v6-addr> ifconfig lo0 inet6 <addr>/128 alias   (addr must be in prefix)
+#   del   <v6-addr> ifconfig lo0 inet6 <addr>/128 -alias  (addr must be in prefix)
+#
+# ## Exit codes
+#
+#   0   ok
+#   64  usage (bad subcommand / argc)
+#   65  address outside the prefix / unparseable. This ALSO surfaces a
+#       DB↔substrate prefix drift: arm_check derives its probe canary from the
+#       DB prefix, so if this wrapper's config-file prefix differs the canary
+#       lands outside it and is refused here — the mismatch is caught at check
+#       time, never as a per-address failure after arming.
+#   66  prefix config unavailable (file missing / unreadable / malformed)
+#   69  substrate refused the alias during a probe (e.g. non-VNET jail)
+#   *   ifconfig's own exit code on an add/del failure (add/del use exec)
 
 set -u
 
-PREFIX="${GRAPPA_SOURCE_ALIAS_PREFIX:-2a03:4000:20:2d3:cb::/80}"
 IFACE="lo0"
+CONF="${GRAPPA_SOURCE_ALIAS_CONF:-/usr/local/etc/grappa/source-alias.conf}"
 
 usage() {
-	echo "usage: grappa-source-alias check | add <v6-addr> | del <v6-addr>" >&2
+	echo "usage: grappa-source-alias probe <v6-addr> | add <v6-addr> | del <v6-addr>" >&2
 	exit 64
+}
+
+# resolve_prefix → echoes the configured prefix on stdout (exit 0), or writes a
+# reason to stderr and returns non-zero (caller maps to exit 66). Precedence:
+# the root/test env override, else the root-owned config file's PREFIX= line.
+# The value is stripped of a trailing CR (CRLF files) and any trailing
+# whitespace — never of its colons — so a hand-edited file cannot corrupt it.
+resolve_prefix() {
+	if [ -n "${GRAPPA_SOURCE_ALIAS_PREFIX:-}" ]; then
+		printf '%s' "$GRAPPA_SOURCE_ALIAS_PREFIX"
+		return 0
+	fi
+
+	if [ ! -r "$CONF" ]; then
+		echo "grappa-source-alias: prefix config unavailable — cannot read ${CONF}" >&2
+		return 1
+	fi
+
+	_val=$(sed -n 's/^[[:space:]]*PREFIX=[[:space:]]*//p' "$CONF" | tail -n 1 | tr -d '\r')
+	_val="${_val%%[[:space:]]*}"
+	if [ -z "$_val" ]; then
+		echo "grappa-source-alias: no PREFIX= line in ${CONF}" >&2
+		return 1
+	fi
+
+	printf '%s' "$_val"
+}
+
+# valid_cidr6 CIDR → exit 0 if CIDR is a well-formed IPv6 network/len, else
+# non-zero. Guards the config-file value before it is trusted as the scope.
+valid_cidr6() {
+	perl -MSocket -e '
+		my ($cidr) = @ARGV;
+		my ($net, $len) = split m{/}, ($cidr // ""), 2;
+		exit 1 unless defined $len && $len =~ /^\d+$/ && $len >= 0 && $len <= 128;
+		my $n = eval { Socket::inet_pton(Socket::AF_INET6(), $net) };
+		exit 1 unless defined $n && length($n) == 16;
+		exit 0;
+	' "$1"
 }
 
 # in_prefix ADDR CIDR → exit 0 if ADDR is strictly inside CIDR, else non-zero.
@@ -66,24 +130,43 @@ in_prefix() {
 sub="$1"
 
 case "$sub" in
-check)
-	[ $# -eq 1 ] || usage
-	exit 0
-	;;
-add | del)
+probe | add | del)
 	[ $# -eq 2 ] || usage
 	addr="$2"
+
+	PREFIX=$(resolve_prefix) || exit 66
+	if ! valid_cidr6 "$PREFIX"; then
+		echo "grappa-source-alias: malformed prefix '${PREFIX}' (${CONF})" >&2
+		exit 66
+	fi
 
 	if ! in_prefix "$addr" "$PREFIX"; then
 		echo "grappa-source-alias: refusing '${addr}' — not inside ${PREFIX}" >&2
 		exit 65
 	fi
 
-	if [ "$sub" = "add" ]; then
+	case "$sub" in
+	add)
 		exec ifconfig "$IFACE" inet6 "${addr}/128" alias
-	else
+		;;
+	del)
 		exec ifconfig "$IFACE" inet6 "${addr}/128" -alias
-	fi
+		;;
+	probe)
+		# Prove the substrate can actually alias: add the canary, then remove
+		# ONLY what we added. A failed add means the substrate refuses aliasing
+		# (a non-VNET jail: ifconfig SIOCAIFADDR → EPERM) — report exit 69 so
+		# arm_check disarms with :alias_not_permitted rather than arming and
+		# failing every real acquire. We do NOT delete on a failed add, so a
+		# pre-existing alias (e.g. a live derived source) is never disturbed.
+		if ifconfig "$IFACE" inet6 "${addr}/128" alias 2>/dev/null; then
+			ifconfig "$IFACE" inet6 "${addr}/128" -alias 2>/dev/null || true
+			exit 0
+		fi
+		echo "grappa-source-alias: substrate refused alias of '${addr}' — non-VNET jail?" >&2
+		exit 69
+		;;
+	esac
 	;;
 *)
 	usage

--- a/lib/grappa/net/ip_literal.ex
+++ b/lib/grappa/net/ip_literal.ex
@@ -120,11 +120,31 @@ defmodule Grappa.Net.IpLiteral do
   def canonicalize_cidr6(value) when is_binary(value) do
     case parse_cidr6(value) do
       {:ok, {tuple, len}} ->
-        network = tuple |> ip6_to_integer() |> mask_prefix(len) |> integer_to_ip6()
-        {:ok, to_string(:inet.ntoa(network)) <> "/" <> Integer.to_string(len)}
+        {:ok, network_literal(tuple, len) <> "/" <> Integer.to_string(len)}
 
       :error ->
         :error
+    end
+  end
+
+  @doc """
+  Returns the network base address (host bits zeroed) of a v6 CIDR as a
+  canonical literal — the `<net>` of `canonicalize_cidr6/1` without the
+  trailing `/len`.
+
+  `Grappa.Net.SourceAlias.FreeBSD.arm_check/1` uses it as its probe canary: it
+  is the one address guaranteed inside the prefix for ANY length, and a
+  deterministic point that a live derived source (a near-uniform 48-bit
+  SHA-256 spread over the host bits) practically never occupies — so probing
+  it (add + immediate delete) does not disturb a real alias.
+
+  Returns `:error` for the same inputs `parse_cidr6/1` rejects.
+  """
+  @spec network_address(String.t()) :: {:ok, String.t()} | :error
+  def network_address(prefix_cidr) when is_binary(prefix_cidr) do
+    case parse_cidr6(prefix_cidr) do
+      {:ok, {tuple, len}} -> {:ok, network_literal(tuple, len)}
+      :error -> :error
     end
   end
 
@@ -175,5 +195,11 @@ defmodule Grappa.Net.IpLiteral do
   defp mask_prefix(n, len) do
     host_bits = 128 - len
     (n >>> host_bits) <<< host_bits
+  end
+
+  # Network base address of a (tuple, len) as a canonical v6 literal — the
+  # single mask+render pipeline shared by canonicalize_cidr6/1 + network_address/1.
+  defp network_literal(tuple, len) do
+    tuple |> ip6_to_integer() |> mask_prefix(len) |> integer_to_ip6() |> :inet.ntoa() |> to_string()
   end
 end

--- a/lib/grappa/net/source_alias/free_bsd.ex
+++ b/lib/grappa/net/source_alias/free_bsd.ex
@@ -44,8 +44,8 @@ defmodule Grappa.Net.SourceAlias.FreeBSD do
         # of THIS prefix (the DB prefix), so a wrapper scoped to a different
         # config-file prefix refuses it (exit 65) — surfacing a DB↔substrate
         # drift here as :prefix_mismatch rather than as per-address failures.
-        Config.cmd().run("sudo", ["-n", @wrapper, "probe", canary], @timeout_s)
-        |> arm_reason()
+        result = Config.cmd().run("sudo", ["-n", @wrapper, "probe", canary], @timeout_s)
+        arm_reason(result)
 
       :error ->
         {:error, :invalid_prefix}

--- a/lib/grappa/net/source_alias/free_bsd.ex
+++ b/lib/grappa/net/source_alias/free_bsd.ex
@@ -12,9 +12,12 @@ defmodule Grappa.Net.SourceAlias.FreeBSD do
   BEFORE shelling) so an out-of-prefix address never even reaches `sudo`.
 
   `ensure_source` / `release_source` add / delete the alias; `arm_check`
-  proves the sudoers grant works via the wrapper's no-op `check` subcommand;
-  `list_aliases` reads `ifconfig lo0` (unprivileged, no sudo) and returns the
-  inet6 addresses inside the prefix — the ground truth for boot reconcile.
+  proves the substrate can ACTUALLY alias — the wrapper's `probe` subcommand
+  adds then deletes a canary derived from the prefix, so a non-VNET jail (or a
+  DB↔substrate prefix drift) refuses to arm with a concrete reason instead of
+  arming and failing every acquire; `list_aliases` reads `ifconfig lo0`
+  (unprivileged, no sudo) and returns the inet6 addresses inside the prefix —
+  the ground truth for boot reconcile.
   """
 
   @behaviour Grappa.Net.SourceAlias
@@ -31,20 +34,37 @@ defmodule Grappa.Net.SourceAlias.FreeBSD do
 
   @impl Grappa.Net.SourceAlias
   def arm_check(prefix) do
-    case IpLiteral.parse_cidr6(prefix) do
-      {:ok, _} ->
-        # Prove the NOPASSWD sudoers grant + wrapper are actually present.
-        # `-n` (non-interactive) turns a missing grant into an immediate
-        # non-zero instead of a password prompt that would hang boot.
-        case Config.cmd().run("sudo", ["-n", @wrapper, "check"], @timeout_s) do
-          {:ok, _} -> :ok
-          {:error, _} -> {:error, :wrapper_unavailable}
-        end
+    case IpLiteral.network_address(prefix) do
+      {:ok, canary} ->
+        # Prove the substrate can ACTUALLY alias, not just that the sudoers
+        # grant resolves (the old no-op `check` was a false positive). The
+        # wrapper's `probe` adds then deletes the canary; `-n` (non-interactive)
+        # turns a missing grant into an immediate non-zero instead of a
+        # password prompt that would hang boot. The canary is the network base
+        # of THIS prefix (the DB prefix), so a wrapper scoped to a different
+        # config-file prefix refuses it (exit 65) — surfacing a DB↔substrate
+        # drift here as :prefix_mismatch rather than as per-address failures.
+        Config.cmd().run("sudo", ["-n", @wrapper, "probe", canary], @timeout_s)
+        |> arm_reason()
 
       :error ->
         {:error, :invalid_prefix}
     end
   end
+
+  # Map the wrapper's exit code (HardenedCmd surfaces it as {:exit, code, _})
+  # to the concrete refuse-to-arm reason — the wrapper's exit-code contract:
+  # 65 out-of-prefix (a DB↔substrate prefix drift), 66 prefix config
+  # unavailable, 69 substrate refused the alias (e.g. non-VNET jail). Any other
+  # non-zero (sudo's own exit 1 on a missing NOPASSWD grant) means the wrapper
+  # is not reachable at all.
+  defp arm_reason({:ok, _}), do: :ok
+  defp arm_reason({:error, {:exit, 65, _}}), do: {:error, :prefix_mismatch}
+  defp arm_reason({:error, {:exit, 66, _}}), do: {:error, :prefix_config_unavailable}
+  defp arm_reason({:error, {:exit, 69, _}}), do: {:error, :alias_not_permitted}
+  defp arm_reason({:error, {:exit, _, _}}), do: {:error, :wrapper_unavailable}
+  defp arm_reason({:error, :timeout}), do: {:error, :probe_timeout}
+  defp arm_reason({:error, {:exe_not_found, _}}), do: {:error, :wrapper_unavailable}
 
   @impl Grappa.Net.SourceAlias
   def ensure_source(addr, prefix), do: alias_op("add", addr, prefix)

--- a/lib/grappa/net/source_alias/free_bsd.ex
+++ b/lib/grappa/net/source_alias/free_bsd.ex
@@ -6,10 +6,11 @@ defmodule Grappa.Net.SourceAlias.FreeBSD do
   seam (`Grappa.Net.SourceAlias.Config.cmd/0`).
 
   The wrapper — not a bare `sudo ifconfig` — is the privilege boundary: it
-  hard-codes `lo0` + `/128` and refuses any address outside the compiled/env
-  prefix (an unconstrained `sudo ifconfig` is a privilege hole, Global
-  Constraint). This adapter mirrors that guard in-process (`in_cidr6?/2`
-  BEFORE shelling) so an out-of-prefix address never even reaches `sudo`.
+  hard-codes `lo0` + `/128` and refuses any address outside its configured
+  prefix (read from a root-owned config file, #609; an unconstrained `sudo
+  ifconfig` is a privilege hole, Global Constraint). This adapter mirrors that
+  guard in-process (`in_cidr6?/2` BEFORE shelling) so an out-of-prefix address
+  never even reaches `sudo`.
 
   `ensure_source` / `release_source` add / delete the alias; `arm_check`
   proves the substrate can ACTUALLY alias — the wrapper's `probe` subcommand
@@ -26,7 +27,7 @@ defmodule Grappa.Net.SourceAlias.FreeBSD do
   alias Grappa.Net.SourceAlias.Config
 
   # sudoers-scoped wrapper; resolved on the operator's secure_path (see
-  # docs/OPERATIONS.md). subcommands: add | del | check.
+  # docs/OPERATIONS.md). subcommands: add | del | probe.
   @wrapper "grappa-source-alias"
   # Wall-clock ceiling for the ifconfig shell-out — an alias add/del is
   # sub-second; 10s is generous slack, not a tuning knob.

--- a/lib/grappa/net/source_alias_manager.ex
+++ b/lib/grappa/net/source_alias_manager.ex
@@ -21,6 +21,13 @@ defmodule Grappa.Net.SourceAliasManager do
   `disarm_reason/0` are lock-free reads — no GenServer round-trip on the
   connect path.
 
+  `arm/1` re-runs the gate at RUNTIME: the admin settings write (#609) calls it
+  BEFORE persisting a mode-2 addressing change, so an unusable mode is rejected
+  with the concrete reason (422) and never reaches the DB, and a successful set
+  adopts the new prefix + publishes `armed?` without a reboot (B1). It changes
+  NO state on refusal — a failed set-time probe must not disarm a manager that
+  is currently working.
+
   ## Boot reconcile
 
   `reconcile/0` diffs the OS ground truth (`adapter.list_aliases/1`) against
@@ -51,6 +58,11 @@ defmodule Grappa.Net.SourceAliasManager do
   require Logger
 
   @arm_key {__MODULE__, :arm}
+
+  # arm/1 shells out to the wrapper's `probe` (up to the adapter's @timeout_s);
+  # the GenServer.call budget must exceed that so a slow probe returns a reason
+  # instead of crashing the caller on the default 5s call timeout.
+  @call_timeout 15_000
 
   @type state :: %{
           refcounts: %{optional(String.t()) => pos_integer()},
@@ -91,6 +103,20 @@ defmodule Grappa.Net.SourceAliasManager do
   """
   @spec reconcile() :: :ok
   def reconcile, do: GenServer.call(__MODULE__, :reconcile)
+
+  @doc """
+  Probe `prefix` and, on success, adopt it as the manager's working prefix and
+  publish `armed?`. Returns `{:error, reason}` WITHOUT changing state when the
+  probe refuses.
+
+  The admin settings write (#609) calls this BEFORE it persists a mode-2
+  change: on `{:error, reason}` the controller returns 422 with the reason and
+  does NOT persist (an unusable mode never reaches the DB); on `:ok` it persists
+  while the manager's `armed?`/prefix already reflect the new value, so mode 2
+  goes live without a reboot (B1).
+  """
+  @spec arm(String.t()) :: :ok | {:error, atom()}
+  def arm(prefix) when is_binary(prefix), do: GenServer.call(__MODULE__, {:arm, prefix}, @call_timeout)
 
   @doc """
   True when the platform adapter armed mode 2 at boot. Lock-free read
@@ -168,6 +194,22 @@ defmodule Grappa.Net.SourceAliasManager do
   @impl GenServer
   def handle_call(:reconcile, _, state) do
     {:reply, :ok, do_reconcile(state)}
+  end
+
+  @impl GenServer
+  def handle_call({:arm, prefix}, _, state) do
+    case compute_arm(state.adapter, prefix) do
+      {true, nil} = arm ->
+        publish_arm(arm)
+        {:reply, :ok, %{state | prefix: prefix}}
+
+      {false, reason} ->
+        # Refuse WITHOUT touching state: the current arm/prefix stand and the
+        # caller returns 422 without persisting. We deliberately do NOT publish
+        # the disarm — a failed set-time probe must not flip a currently-armed
+        # manager to disarmed (only boot + a SUCCESSFUL set change arm state).
+        {:reply, {:error, reason}, state}
+    end
   end
 
   # -- internals --------------------------------------------------------------

--- a/lib/grappa/net/source_alias_manager.ex
+++ b/lib/grappa/net/source_alias_manager.ex
@@ -59,9 +59,14 @@ defmodule Grappa.Net.SourceAliasManager do
 
   @arm_key {__MODULE__, :arm}
 
-  # arm/1 shells out to the wrapper's `probe` (up to the adapter's @timeout_s);
-  # the GenServer.call budget must exceed that so a slow probe returns a reason
-  # instead of crashing the caller on the default 5s call timeout.
+  # Every mailbox-serialized call here (acquire/release/reconcile/arm) shells
+  # out to the adapter (ifconfig add/del/probe, up to the adapter's @timeout_s
+  # ceiling); the GenServer.call budget must exceed that ceiling so a slow
+  # shell-out returns an {:error, _} the caller can handle instead of crashing
+  # it with the default 5s call-timeout EXIT (e.g. a set-time `arm` probe
+  # blocking a concurrent connect's `acquire`). A pathological QUEUE of several
+  # slow shell-outs can still exceed this — a pre-existing mailbox-serialization
+  # limit, not introduced by the runtime probe.
   @call_timeout 15_000
 
   @type state :: %{
@@ -86,7 +91,8 @@ defmodule Grappa.Net.SourceAliasManager do
   never created.
   """
   @spec acquire(String.t()) :: :ok | {:error, term()}
-  def acquire(addr) when is_binary(addr), do: GenServer.call(__MODULE__, {:acquire, addr})
+  def acquire(addr) when is_binary(addr),
+    do: GenServer.call(__MODULE__, {:acquire, addr}, @call_timeout)
 
   @doc """
   Drop a reference to `addr` (ref-count 1→0 unbinds via the adapter). A
@@ -95,14 +101,15 @@ defmodule Grappa.Net.SourceAliasManager do
   boot reconcile is the backstop that reclaims a stuck alias).
   """
   @spec release(String.t()) :: :ok
-  def release(addr) when is_binary(addr), do: GenServer.call(__MODULE__, {:release, addr})
+  def release(addr) when is_binary(addr),
+    do: GenServer.call(__MODULE__, {:release, addr}, @call_timeout)
 
   @doc """
   Release the alias orphans — bound at the OS layer but not in the held set.
   See the moduledoc + `held_addresses/1`.
   """
   @spec reconcile() :: :ok
-  def reconcile, do: GenServer.call(__MODULE__, :reconcile)
+  def reconcile, do: GenServer.call(__MODULE__, :reconcile, @call_timeout)
 
   @doc """
   Probe `prefix` and, on success, adopt it as the manager's working prefix and

--- a/lib/grappa/server_settings.ex
+++ b/lib/grappa/server_settings.ex
@@ -252,6 +252,28 @@ defmodule Grappa.ServerSettings do
   def static_mapping_prefix, do: get_raw(@key_static_mapping_prefix)
 
   @doc """
+  Validate + canonicalize a static-mapping prefix WITHOUT persisting.
+
+  The admin controller resolves the TARGET prefix this way to run the #609
+  capability probe BEFORE it decides whether to persist a mode-2 change (so an
+  unusable mode never reaches the DB). Same rule as `put_static_mapping_prefix/1`:
+  a strict IPv6 CIDR whose length is a 16-bit-group boundary, returned masked +
+  canonical. Any other input → `{:error, :invalid_prefix}`.
+  """
+  @spec validate_static_mapping_prefix(String.t()) :: {:ok, String.t()} | {:error, :invalid_prefix}
+  def validate_static_mapping_prefix(value) when is_binary(value) do
+    with {:ok, {_, len}} <- IpLiteral.parse_cidr6(value),
+         true <- len in @allowed_prefix_lengths,
+         {:ok, canonical} <- IpLiteral.canonicalize_cidr6(value) do
+      {:ok, canonical}
+    else
+      _ -> {:error, :invalid_prefix}
+    end
+  end
+
+  def validate_static_mapping_prefix(_), do: {:error, :invalid_prefix}
+
+  @doc """
   Pins the static-mapping derived-source prefix. Accepts a strict IPv6
   CIDR whose length is a 16-bit-group boundary (OperServ scan-width
   constraint: `64 | 80 | 96 | 112 | 128`); stores it masked + canonical.
@@ -259,18 +281,18 @@ defmodule Grappa.ServerSettings do
   """
   @spec put_static_mapping_prefix(String.t()) :: :ok | {:error, :invalid_prefix | :db_unavailable}
   def put_static_mapping_prefix(value) when is_binary(value) do
-    with {:ok, {_, len}} <- IpLiteral.parse_cidr6(value),
-         true <- len in @allowed_prefix_lengths,
-         {:ok, canonical} <- IpLiteral.canonicalize_cidr6(value) do
-      case put_raw(@key_static_mapping_prefix, canonical) do
-        :ok -> :ok
-        # A transient DB fault is backpressure, NOT a malformed prefix — keep
-        # it distinct so the controller surfaces a 503, never a 422 (#518).
-        {:error, :db_unavailable} = err -> err
-        {:error, _} -> {:error, :invalid_prefix}
-      end
-    else
-      _ -> {:error, :invalid_prefix}
+    case validate_static_mapping_prefix(value) do
+      {:ok, canonical} ->
+        case put_raw(@key_static_mapping_prefix, canonical) do
+          :ok -> :ok
+          # A transient DB fault is backpressure, NOT a malformed prefix — keep
+          # it distinct so the controller surfaces a 503, never a 422 (#518).
+          {:error, :db_unavailable} = err -> err
+          {:error, _} -> {:error, :invalid_prefix}
+        end
+
+      {:error, :invalid_prefix} = err ->
+        err
     end
   end
 

--- a/lib/grappa_web.ex
+++ b/lib/grappa_web.ex
@@ -29,6 +29,7 @@ defmodule GrappaWeb do
         Grappa.Net.HostAddresses,
         Grappa.Net.IpLiteral,
         Grappa.Net.PtrCache,
+        Grappa.Net.SourceAliasManager,
         Grappa.Networks,
         Grappa.Notify,
         Grappa.Operator,

--- a/lib/grappa_web/controllers/admin/settings_controller.ex
+++ b/lib/grappa_web/controllers/admin/settings_controller.ex
@@ -68,8 +68,8 @@ defmodule GrappaWeb.Admin.SettingsController do
 
   use GrappaWeb, :controller
 
-  alias Grappa.{PubSub, ServerSettings, WSPresence}
   alias Grappa.Net.SourceAliasManager
+  alias Grappa.{PubSub, ServerSettings, WSPresence}
   alias Grappa.PubSub.Topic
   alias Grappa.ServerSettings.Wire, as: SettingsWire
 

--- a/lib/grappa_web/controllers/admin/settings_controller.ex
+++ b/lib/grappa_web/controllers/admin/settings_controller.ex
@@ -69,6 +69,7 @@ defmodule GrappaWeb.Admin.SettingsController do
   use GrappaWeb, :controller
 
   alias Grappa.{PubSub, ServerSettings, WSPresence}
+  alias Grappa.Net.SourceAliasManager
   alias Grappa.PubSub.Topic
   alias Grappa.ServerSettings.Wire, as: SettingsWire
 
@@ -83,7 +84,11 @@ defmodule GrappaWeb.Admin.SettingsController do
   @doc false
   @spec update(Plug.Conn.t(), map()) ::
           Plug.Conn.t()
-          | {:error, atom() | {:invalid_setting, String.t()} | Ecto.Changeset.t()}
+          | {:error,
+             atom()
+             | {:invalid_setting, String.t()}
+             | {:addressing_unusable, atom()}
+             | Ecto.Changeset.t()}
   def update(conn, params) do
     with :ok <- apply_updates(params) do
       view = ServerSettings.public_view()
@@ -123,7 +128,7 @@ defmodule GrappaWeb.Admin.SettingsController do
 
   defp apply_updates(params) when is_map(params) do
     with :ok <- apply_subtree(params, "upload", &apply_upload_key/2) do
-      apply_subtree(params, "addressing", &apply_addressing_key/2)
+      apply_addressing(Map.get(params, "addressing"))
     end
   end
 
@@ -193,33 +198,104 @@ defmodule GrappaWeb.Admin.SettingsController do
     :ok
   end
 
-  # ---- addressing.* dispatch (#543) --------------------------------
+  # ---- addressing.* — probe-gated unit apply (#543 / #609) ----------
+  #
+  # Unlike `upload`, the addressing subtree is applied as a UNIT, not key by
+  # key: the #609 capability probe must run against the RESULTING (mode, prefix)
+  # — each taken from the body or, when the body omits it, the current row — and
+  # it must run BEFORE anything persists so an unusable mode-2 change never
+  # reaches the DB (vjt's order: preflight when the mode is SET, then hard-fail
+  # per-address at acquire).
+  defp apply_addressing(nil), do: :ok
 
-  defp apply_addressing_key("mode", "pool_with_reservations"),
-    do: ServerSettings.put_addressing_mode(:pool_with_reservations)
+  defp apply_addressing(subtree) when is_map(subtree) do
+    warn_unknown_addressing_keys(subtree)
 
-  defp apply_addressing_key("mode", "static_mapping_with_reservations"),
-    do: ServerSettings.put_addressing_mode(:static_mapping_with_reservations)
+    with {:ok, mode} <- resolve_addressing_mode(subtree),
+         {:ok, prefix} <- resolve_addressing_prefix(subtree),
+         :ok <- arm_if_static(mode, prefix),
+         :ok <- persist_addressing_prefix(subtree),
+         :ok <- persist_addressing_mode(subtree) do
+      :ok
+    end
+  end
 
-  defp apply_addressing_key("mode", _),
+  defp apply_addressing(_), do: {:error, :bad_request}
+
+  # Target mode = the body's mode (validated against the closed set) or, when
+  # the body omits it, the currently stored mode.
+  defp resolve_addressing_mode(%{"mode" => "pool_with_reservations"}),
+    do: {:ok, :pool_with_reservations}
+
+  defp resolve_addressing_mode(%{"mode" => "static_mapping_with_reservations"}),
+    do: {:ok, :static_mapping_with_reservations}
+
+  defp resolve_addressing_mode(%{"mode" => _}),
     do: {:error, {:invalid_setting, "addressing.mode"}}
 
-  defp apply_addressing_key("static_mapping_prefix", value) when is_binary(value) do
+  defp resolve_addressing_mode(_), do: {:ok, ServerSettings.addressing_mode()}
+
+  # Target prefix = the body's prefix (validated + canonicalized, no persist)
+  # or, when the body omits it, the currently stored prefix (may be nil).
+  defp resolve_addressing_prefix(%{"static_mapping_prefix" => value}) when is_binary(value) do
+    case ServerSettings.validate_static_mapping_prefix(value) do
+      {:ok, canonical} -> {:ok, canonical}
+      {:error, :invalid_prefix} -> {:error, {:invalid_setting, "addressing.static_mapping_prefix"}}
+    end
+  end
+
+  defp resolve_addressing_prefix(%{"static_mapping_prefix" => _}),
+    do: {:error, {:invalid_setting, "addressing.static_mapping_prefix"}}
+
+  defp resolve_addressing_prefix(_), do: {:ok, ServerSettings.static_mapping_prefix()}
+
+  # Capability gate: a mode-2 target must be armable on THIS substrate before it
+  # is stored. `SourceAliasManager.arm/1` probes and, on success, adopts the
+  # prefix + publishes armed? (so the set goes live without a reboot, B1); on
+  # refusal it changes no state and we surface the concrete reason as 422. Mode
+  # 1 (pool) has no substrate prerequisite. A nil prefix under mode 2 cannot arm.
+  defp arm_if_static(:static_mapping_with_reservations, nil),
+    do: {:error, {:addressing_unusable, :no_static_prefix}}
+
+  defp arm_if_static(:static_mapping_with_reservations, prefix) do
+    case SourceAliasManager.arm(prefix) do
+      :ok -> :ok
+      {:error, reason} -> {:error, {:addressing_unusable, reason}}
+    end
+  end
+
+  defp arm_if_static(:pool_with_reservations, _), do: :ok
+
+  # Persist only the keys the body carried (both already validated above).
+  # Prefix first, then mode, so mode 2 is never stored ahead of the prefix it
+  # needs.
+  defp persist_addressing_prefix(%{"static_mapping_prefix" => value}) when is_binary(value) do
     case ServerSettings.put_static_mapping_prefix(value) do
       :ok -> :ok
-      # #523/#518 — transient DB saturation halts the fold with :db_unavailable
-      # so `update/2`'s `with` routes it to a clean 503 (FallbackController),
+      # #523/#518 — transient DB saturation → :db_unavailable → clean 503,
       # NOT the 422 an invalid-setting tuple would render.
       {:error, :db_unavailable} = err -> err
       {:error, :invalid_prefix} -> {:error, {:invalid_setting, "addressing.static_mapping_prefix"}}
     end
   end
 
-  defp apply_addressing_key("static_mapping_prefix", _),
-    do: {:error, {:invalid_setting, "addressing.static_mapping_prefix"}}
+  defp persist_addressing_prefix(_), do: :ok
 
-  defp apply_addressing_key(k, _) do
-    Logger.warning("admin PUT /settings: unknown addressing key", setting_key: k)
+  defp persist_addressing_mode(%{"mode" => "pool_with_reservations"}),
+    do: ServerSettings.put_addressing_mode(:pool_with_reservations)
+
+  defp persist_addressing_mode(%{"mode" => "static_mapping_with_reservations"}),
+    do: ServerSettings.put_addressing_mode(:static_mapping_with_reservations)
+
+  defp persist_addressing_mode(_), do: :ok
+
+  # Unknown addressing key — ignore but log (tolerant of forward-compat shapes,
+  # discoverable on a typo). Same posture as `apply_upload_key/2`'s catch-all.
+  defp warn_unknown_addressing_keys(subtree) do
+    for {k, _} <- subtree, k not in ["mode", "static_mapping_prefix"] do
+      Logger.warning("admin PUT /settings: unknown addressing key", setting_key: k)
+    end
+
     :ok
   end
 

--- a/lib/grappa_web/controllers/fallback_controller.ex
+++ b/lib/grappa_web/controllers/fallback_controller.ex
@@ -85,6 +85,7 @@ defmodule GrappaWeb.FallbackController do
            | :fetch_failed
            | :image_reencode_failed
            | {:invalid_setting, String.t()}
+           | {:addressing_unusable, atom()}
            | {:file_too_large, pos_integer()}
            | {:metadata_strip, String.t()}
            | {:anon_collision, non_neg_integer()}
@@ -190,6 +191,20 @@ defmodule GrappaWeb.FallbackController do
     conn
     |> put_status(:unprocessable_entity)
     |> json(%{error: "invalid_setting", field: field})
+  end
+
+  # #609 — admin set mode 2 (static_mapping_with_reservations), or changed its
+  # prefix, but the substrate can't arm it: the capability probe ran at
+  # mode-set time and refused. 422 (well-formed + authorized, semantically
+  # unusable) carrying the concrete reason (:alias_not_permitted /
+  # :prefix_mismatch / :prefix_config_unavailable / :wrapper_unavailable /
+  # :probe_timeout / :no_static_prefix / …) so the admin UI shows WHY instead
+  # of the operator discovering it later as sessions stuck in hold. The
+  # settings row is NOT persisted — a mode that cannot arm never reaches the DB.
+  def call(conn, {:error, {:addressing_unusable, reason}}) when is_atom(reason) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{error: "addressing_unusable", reason: Atom.to_string(reason)})
   end
 
   def call(conn, {:error, :not_found}) do

--- a/lib/grappa_web/error_tokens.ex
+++ b/lib/grappa_web/error_tokens.ex
@@ -89,6 +89,7 @@ defmodule GrappaWeb.ErrorTokens do
           | :insufficient_storage
           | :unsupported_media_type
           | :invalid_setting
+          | :addressing_unusable
           | :rate_limited
           | :too_many_attempts
           | :theme_cap_reached

--- a/test/grappa/net/ip_literal_test.exs
+++ b/test/grappa/net/ip_literal_test.exs
@@ -123,6 +123,27 @@ defmodule Grappa.Net.IpLiteralTest do
     end
   end
 
+  describe "network_address/1" do
+    test "returns the network base literal (host bits zeroed, no /len)" do
+      assert {:ok, "2a03:4000:20:2d3:cb::"} =
+               IpLiteral.network_address("2a03:4000:20:2d3:cb::/80")
+    end
+
+    test "masks host bits below the prefix length and canonicalizes the spelling" do
+      assert {:ok, "2a03:4000:20:2d3:cb::"} =
+               IpLiteral.network_address("2A03:4000:20:2D3:00CB:0:0:5/80")
+    end
+
+    test "handles a /128 (the base is the address itself)" do
+      assert {:ok, "2001:db8::1"} = IpLiteral.network_address("2001:db8::1/128")
+    end
+
+    test "rejects an IPv4 CIDR and a non-literal" do
+      assert :error = IpLiteral.network_address("192.0.2.0/24")
+      assert :error = IpLiteral.network_address("nope/64")
+    end
+  end
+
   describe "in_cidr6?/2" do
     test "true when the v6 address sits inside the prefix" do
       assert IpLiteral.in_cidr6?("2a03:4000:20:2d3:cb::1", "2a03:4000:20:2d3:cb::/80")

--- a/test/grappa/net/source_alias_manager_test.exs
+++ b/test/grappa/net/source_alias_manager_test.exs
@@ -225,4 +225,41 @@ defmodule Grappa.Net.SourceAliasManagerTest do
       assert Manager.disarm_reason() == :no_static_prefix
     end
   end
+
+  describe "arm/1 — runtime re-arm (set-time probe, #609)" do
+    @new_prefix "2a03:4000:20:2d3:ca::/80"
+
+    test "probes the prefix, adopts it, and publishes armed on success" do
+      start_manager()
+      # start_manager stubbed arm_check(@prefix) for boot; arm/1 probes the NEW
+      # prefix, so expect that explicitly.
+      expect(Grappa.Net.SourceAliasMock, :arm_check, fn @new_prefix -> :ok end)
+
+      assert :ok = Manager.arm(@new_prefix)
+      assert Manager.armed?() == true
+      assert Manager.disarm_reason() == nil
+
+      # the adopted prefix is now the working prefix — a subsequent acquire binds
+      # against it, proving state.prefix moved.
+      addr = "2a03:4000:20:2d3:ca::1"
+      expect(Grappa.Net.SourceAliasMock, :ensure_source, fn ^addr, @new_prefix -> :ok end)
+      assert :ok = Manager.acquire(addr)
+    end
+
+    test "returns the reason and changes NO state on a refused probe" do
+      start_manager()
+      # boot armed true (@prefix); a refused arm/1 must NOT flip it to disarmed.
+      assert Manager.armed?() == true
+
+      expect(Grappa.Net.SourceAliasMock, :arm_check, fn @new_prefix ->
+        {:error, :alias_not_permitted}
+      end)
+
+      assert {:error, :alias_not_permitted} = Manager.arm(@new_prefix)
+
+      # unchanged: still armed against the boot prefix, no disarm published.
+      assert Manager.armed?() == true
+      assert Manager.disarm_reason() == nil
+    end
+  end
 end

--- a/test/grappa/net/source_alias_test.exs
+++ b/test/grappa/net/source_alias_test.exs
@@ -17,6 +17,8 @@ defmodule Grappa.Net.SourceAliasTest do
   @prefix "2a03:4000:20:2d3:cb::/80"
   @in_prefix "2a03:4000:20:2d3:cb::1"
   @outside "2a03:4000:20:2d3:ffff::1"
+  # arm_check derives its probe canary from the prefix — the network base.
+  @canary "2a03:4000:20:2d3:cb::"
 
   describe "Config" do
     test "substrate selects the adapter; put_test_config round-trips" do
@@ -73,17 +75,59 @@ defmodule Grappa.Net.SourceAliasTest do
   end
 
   describe "FreeBSD.arm_check/1" do
-    test "probes the sudoers grant via the wrapper's check subcommand" do
-      expect(Grappa.Sys.HardenedCmdMock, :run, fn "sudo", ["-n", "grappa-source-alias", "check"], _ ->
+    test "probes real aliasing capability via `probe <canary>` derived from the prefix" do
+      expect(Grappa.Sys.HardenedCmdMock, :run, fn "sudo", ["-n", "grappa-source-alias", "probe", canary], t ->
+        assert canary == @canary
+        assert is_integer(t) and t > 0
         {:ok, ""}
       end)
 
       assert :ok = FreeBSD.arm_check(@prefix)
     end
 
-    test "refuses to arm when the wrapper/sudoers grant is missing" do
-      expect(Grappa.Sys.HardenedCmdMock, :run, fn "sudo", ["-n", "grappa-source-alias", "check"], _ ->
+    test "maps exit 69 (substrate refused the alias) to :alias_not_permitted" do
+      expect(Grappa.Sys.HardenedCmdMock, :run, fn "sudo", ["-n", "grappa-source-alias", "probe", _], _ ->
+        {:error, {:exit, 69, "substrate refused alias — non-VNET jail?"}}
+      end)
+
+      assert {:error, :alias_not_permitted} = FreeBSD.arm_check(@prefix)
+    end
+
+    test "maps exit 65 (canary outside the wrapper prefix) to :prefix_mismatch" do
+      expect(Grappa.Sys.HardenedCmdMock, :run, fn "sudo", ["-n", "grappa-source-alias", "probe", _], _ ->
+        {:error, {:exit, 65, "not inside"}}
+      end)
+
+      assert {:error, :prefix_mismatch} = FreeBSD.arm_check(@prefix)
+    end
+
+    test "maps exit 66 (prefix config unavailable) to :prefix_config_unavailable" do
+      expect(Grappa.Sys.HardenedCmdMock, :run, fn "sudo", ["-n", "grappa-source-alias", "probe", _], _ ->
+        {:error, {:exit, 66, "prefix config unavailable"}}
+      end)
+
+      assert {:error, :prefix_config_unavailable} = FreeBSD.arm_check(@prefix)
+    end
+
+    test "refuses to arm when the wrapper/sudoers grant is missing (sudo exit 1)" do
+      expect(Grappa.Sys.HardenedCmdMock, :run, fn "sudo", ["-n", "grappa-source-alias", "probe", _], _ ->
         {:error, {:exit, 1, "sudo: a password is required"}}
+      end)
+
+      assert {:error, :wrapper_unavailable} = FreeBSD.arm_check(@prefix)
+    end
+
+    test "maps a probe timeout to :probe_timeout" do
+      expect(Grappa.Sys.HardenedCmdMock, :run, fn "sudo", ["-n", "grappa-source-alias", "probe", _], _ ->
+        {:error, :timeout}
+      end)
+
+      assert {:error, :probe_timeout} = FreeBSD.arm_check(@prefix)
+    end
+
+    test "maps a missing runner binary to :wrapper_unavailable" do
+      expect(Grappa.Sys.HardenedCmdMock, :run, fn "sudo", ["-n", "grappa-source-alias", "probe", _], _ ->
+        {:error, {:exe_not_found, "sudo"}}
       end)
 
       assert {:error, :wrapper_unavailable} = FreeBSD.arm_check(@prefix)

--- a/test/grappa_web/controllers/admin/settings_controller_test.exs
+++ b/test/grappa_web/controllers/admin/settings_controller_test.exs
@@ -2,7 +2,9 @@ defmodule GrappaWeb.Admin.SettingsControllerTest do
   use GrappaWeb.ConnCase, async: false
 
   import Grappa.AuthFixtures
+  import Mox
 
+  alias Grappa.Net.{SourceAliasManager, SourceAliasMock}
   alias Grappa.PubSub.Topic
   alias Grappa.{ServerSettings, WSPresence}
 
@@ -247,13 +249,27 @@ defmodule GrappaWeb.Admin.SettingsControllerTest do
     end
   end
 
-  describe "PUT /admin/settings — addressing (#543)" do
+  describe "PUT /admin/settings — addressing (#543/#609)" do
+    setup :set_mox_global
+    setup :verify_on_exit!
+
     setup do
       {_, session} = user_and_session(is_admin: true)
+
+      # The #609 set-time capability probe calls SourceAliasManager.arm/1, so a
+      # manager must be running. It is wired to the Mox adapter (no real
+      # ifconfig); a nil boot prefix skips the boot arm_check, and list_aliases
+      # is stubbed for the boot reconcile. Per-test arm_check expectations model
+      # the substrate's probe verdict.
+      stub(SourceAliasMock, :list_aliases, fn _ -> {:ok, []} end)
+      start_supervised!({SourceAliasManager, adapter: SourceAliasMock, prefix: nil})
+
       %{session: session}
     end
 
-    test "sets mode + prefix", %{conn: conn, session: session} do
+    test "sets mode + prefix after the probe arms", %{conn: conn, session: session} do
+      expect(SourceAliasMock, :arm_check, fn "2a03:4000:20:2d3:cb::/80" -> :ok end)
+
       conn =
         conn
         |> put_bearer(session.id)
@@ -269,6 +285,68 @@ defmodule GrappaWeb.Admin.SettingsControllerTest do
       assert addressing["static_mapping_prefix"] == "2a03:4000:20:2d3:cb::/80"
       assert ServerSettings.addressing_mode() == :static_mapping_with_reservations
       assert ServerSettings.static_mapping_prefix() == "2a03:4000:20:2d3:cb::/80"
+      # a successful set adopts the new prefix + arms without a reboot (B1).
+      assert SourceAliasManager.armed?() == true
+    end
+
+    test "422 addressing_unusable when the probe refuses — nothing is persisted",
+         %{conn: conn, session: session} do
+      expect(SourceAliasMock, :arm_check, fn _ -> {:error, :alias_not_permitted} end)
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/admin/settings", %{
+          "addressing" => %{
+            "mode" => "static_mapping_with_reservations",
+            "static_mapping_prefix" => "2a03:4000:20:2d3:cb::/80"
+          }
+        })
+
+      assert json_response(conn, 422) == %{
+               "error" => "addressing_unusable",
+               "reason" => "alias_not_permitted"
+             }
+
+      # a mode that cannot arm never reaches the DB.
+      assert ServerSettings.addressing_mode() == :pool_with_reservations
+      assert ServerSettings.static_mapping_prefix() == nil
+    end
+
+    test "422 addressing_unusable :no_static_prefix when enabling mode 2 with no prefix",
+         %{conn: conn, session: session} do
+      # arm_check is never reached — a nil prefix cannot arm (no Mox expect set).
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/admin/settings", %{
+          "addressing" => %{"mode" => "static_mapping_with_reservations"}
+        })
+
+      assert json_response(conn, 422) == %{
+               "error" => "addressing_unusable",
+               "reason" => "no_static_prefix"
+             }
+
+      assert ServerSettings.addressing_mode() == :pool_with_reservations
+    end
+
+    test "changing the prefix while mode 2 is active re-probes the NEW prefix",
+         %{conn: conn, session: session} do
+      :ok = ServerSettings.put_addressing_mode(:static_mapping_with_reservations)
+      :ok = ServerSettings.put_static_mapping_prefix("2a03:4000:20:2d3:cb::/80")
+
+      expect(SourceAliasMock, :arm_check, fn "2a03:4000:20:2d3:ca::/80" -> :ok end)
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> put("/admin/settings", %{
+          "addressing" => %{"static_mapping_prefix" => "2a03:4000:20:2d3:ca::/80"}
+        })
+
+      assert json_response(conn, 200)
+      assert ServerSettings.static_mapping_prefix() == "2a03:4000:20:2d3:ca::/80"
     end
 
     test "422 invalid_setting for an unknown mode", %{conn: conn, session: session} do
@@ -298,12 +376,17 @@ defmodule GrappaWeb.Admin.SettingsControllerTest do
     end
 
     test "applies upload AND addressing subtrees in one request", %{conn: conn, session: session} do
+      expect(SourceAliasMock, :arm_check, fn "2a03:4000:20:2d3:cb::/80" -> :ok end)
+
       conn =
         conn
         |> put_bearer(session.id)
         |> put("/admin/settings", %{
           "upload" => %{"active_host" => "litterbox"},
-          "addressing" => %{"mode" => "static_mapping_with_reservations"}
+          "addressing" => %{
+            "mode" => "static_mapping_with_reservations",
+            "static_mapping_prefix" => "2a03:4000:20:2d3:cb::/80"
+          }
         })
 
       assert %{

--- a/test/infra/grappa_source_alias_test.bats
+++ b/test/infra/grappa_source_alias_test.bats
@@ -1,16 +1,22 @@
 #!/usr/bin/env bats
 #
 # Bats suite for infra/freebsd/bin/grappa-source-alias — the sudoers-scoped
-# ifconfig wrapper (#543 INC-5). `ifconfig` is stubbed via PATH so no real
-# alias is touched; the test asserts the load-bearing security properties:
+# ifconfig wrapper (#543 / #609). `ifconfig` is stubbed via PATH so no real
+# alias is touched; the test asserts the load-bearing properties:
 #
 #   * the interface (lo0) + mask (/128) are hard-coded — argv never lets the
 #     caller pick them;
+#   * the prefix is read from a ROOT-OWNED config file — NO compiled-in literal
+#     (#609) — and the wrapper FAILS CLOSED (exit 66) when that file is missing
+#     / unreadable / malformed, never a wildcard fallback;
 #   * an address OUTSIDE the configured prefix is REFUSED without ever running
-#     ifconfig (the privilege-scope invariant — a bare `sudo ifconfig` hole is
-#     exactly what this wrapper exists to close);
-#   * `check` is a no-op probe (used by the adapter's arm_check);
-#   * unknown subcommands / bad argc are usage errors.
+#     ifconfig (the privilege-scope invariant a bare `sudo ifconfig` violates);
+#   * `probe` proves REAL aliasing capability — add-then-delete a canary, exit
+#     0 on success, 69 when the substrate refuses the alias (non-VNET jail),
+#     65 when the canary is outside the config-file prefix (DB↔substrate drift);
+#   * the GRAPPA_SOURCE_ALIAS_PREFIX env override still works for a root/test
+#     invocation (it is NEVER env_keep'd through sudoers);
+#   * unknown subcommands / bad argc are usage errors (64).
 
 setup() {
 	WRAP="$BATS_TEST_DIRNAME/../../infra/freebsd/bin/grappa-source-alias"
@@ -21,22 +27,30 @@ setup() {
 	: >"$IFCONFIG_LOG"
 	export IFCONFIG_LOG
 
+	# Stub ifconfig: log every invocation; fail (exit 1) only when
+	# IFCONFIG_FAIL is set, to model a non-VNET jail refusing the alias.
 	cat >"$FAKE_DIR/ifconfig" <<'EOF'
 #!/bin/sh
 printf 'ifconfig %s\n' "$*" >> "$IFCONFIG_LOG"
+[ -n "${IFCONFIG_FAIL:-}" ] && exit 1
 exit 0
 EOF
 	chmod +x "$FAKE_DIR/ifconfig"
 	export PATH="$FAKE_DIR:$PATH"
+
+	# Root-owned config file the wrapper reads its prefix from (#609). The real
+	# path is /usr/local/etc/grappa/source-alias.conf; the test points
+	# GRAPPA_SOURCE_ALIAS_CONF at a temp file.
+	CONF="$BATS_TEST_TMPDIR/source-alias.conf"
+	printf 'PREFIX=2a03:4000:20:2d3:cb::/80\n' >"$CONF"
+	export GRAPPA_SOURCE_ALIAS_CONF="$CONF"
+
+	# A GRAPPA_SOURCE_ALIAS_PREFIX leaking from the runner env would shadow the
+	# config-file path under test — clear it except where a case sets it.
+	unset GRAPPA_SOURCE_ALIAS_PREFIX
 }
 
-@test "check is a no-op probe returning 0 without touching ifconfig" {
-	run "$WRAP" check
-	[ "$status" -eq 0 ]
-	[ ! -s "$IFCONFIG_LOG" ]
-}
-
-@test "add runs ifconfig lo0 inet6 <addr>/128 alias for an in-prefix address" {
+@test "add reads the prefix from the config file and aliases an in-prefix address" {
 	run "$WRAP" add 2a03:4000:20:2d3:cb::1
 	[ "$status" -eq 0 ]
 	grep -q "ifconfig lo0 inet6 2a03:4000:20:2d3:cb::1/128 alias" "$IFCONFIG_LOG"
@@ -48,26 +62,78 @@ EOF
 	grep -q "ifconfig lo0 inet6 2a03:4000:20:2d3:cb::dead/128 -alias" "$IFCONFIG_LOG"
 }
 
-@test "add REFUSES an address outside the prefix without running ifconfig" {
+@test "probe adds then deletes an in-prefix canary and exits 0" {
+	run "$WRAP" probe 2a03:4000:20:2d3:cb::
+	[ "$status" -eq 0 ]
+	grep -q "ifconfig lo0 inet6 2a03:4000:20:2d3:cb::/128 alias" "$IFCONFIG_LOG"
+	grep -q "ifconfig lo0 inet6 2a03:4000:20:2d3:cb::/128 -alias" "$IFCONFIG_LOG"
+}
+
+@test "probe exits 69 when the substrate refuses the alias (non-VNET jail)" {
+	IFCONFIG_FAIL=1 run "$WRAP" probe 2a03:4000:20:2d3:cb::
+	[ "$status" -eq 69 ]
+	# the add was attempted; the delete must NOT run (nothing was added)
+	grep -q "ifconfig lo0 inet6 2a03:4000:20:2d3:cb::/128 alias" "$IFCONFIG_LOG"
+	! grep -q -- "-alias" "$IFCONFIG_LOG"
+}
+
+@test "probe REFUSES a canary outside the config-file prefix (drift, 65)" {
+	run "$WRAP" probe 2a03:4000:20:2d3:ffff::
+	[ "$status" -eq 65 ]
+	[ ! -s "$IFCONFIG_LOG" ]
+	[[ "$output" == *"not inside"* ]]
+}
+
+@test "add REFUSES an address outside the prefix without running ifconfig (65)" {
 	run "$WRAP" add 2a03:4000:20:2d3:ffff::1
 	[ "$status" -eq 65 ]
 	[ ! -s "$IFCONFIG_LOG" ]
 	[[ "$output" == *"not inside"* ]]
 }
 
-@test "add REFUSES a non-IPv6 / unparseable address" {
+@test "add REFUSES a non-IPv6 / unparseable address (65)" {
 	run "$WRAP" add not-an-address
 	[ "$status" -eq 65 ]
 	[ ! -s "$IFCONFIG_LOG" ]
 }
 
-@test "add REFUSES an IPv4 address (v6-only block)" {
+@test "add REFUSES an IPv4 address (v6-only block, 65)" {
 	run "$WRAP" add 192.0.2.1
 	[ "$status" -eq 65 ]
 	[ ! -s "$IFCONFIG_LOG" ]
 }
 
-@test "a custom GRAPPA_SOURCE_ALIAS_PREFIX changes the accepted range" {
+@test "a MISSING config file fails closed (66) without touching ifconfig" {
+	export GRAPPA_SOURCE_ALIAS_CONF="$BATS_TEST_TMPDIR/nonexistent.conf"
+	run "$WRAP" add 2a03:4000:20:2d3:cb::1
+	[ "$status" -eq 66 ]
+	[ ! -s "$IFCONFIG_LOG" ]
+}
+
+@test "a config file with no PREFIX= line fails closed (66)" {
+	printf '# nothing here\n' >"$CONF"
+	run "$WRAP" add 2a03:4000:20:2d3:cb::1
+	[ "$status" -eq 66 ]
+	[ ! -s "$IFCONFIG_LOG" ]
+}
+
+@test "a config file with a malformed PREFIX fails closed (66)" {
+	printf 'PREFIX=not-a-cidr\n' >"$CONF"
+	run "$WRAP" add 2a03:4000:20:2d3:cb::1
+	[ "$status" -eq 66 ]
+	[ ! -s "$IFCONFIG_LOG" ]
+}
+
+@test "the GRAPPA_SOURCE_ALIAS_PREFIX env override beats the config file (root/test)" {
+	# config says cb::/80; env widens to a different block — env wins for a
+	# root/test invocation (it is NEVER env_keep'd through sudoers).
+	GRAPPA_SOURCE_ALIAS_PREFIX="2001:db8:abcd::/48" run "$WRAP" add 2001:db8:abcd:1::9
+	[ "$status" -eq 0 ]
+	grep -q "ifconfig lo0 inet6 2001:db8:abcd:1::9/128 alias" "$IFCONFIG_LOG"
+}
+
+@test "the env override works even when the config file is absent" {
+	export GRAPPA_SOURCE_ALIAS_CONF="$BATS_TEST_TMPDIR/nonexistent.conf"
 	GRAPPA_SOURCE_ALIAS_PREFIX="2001:db8:abcd::/48" run "$WRAP" add 2001:db8:abcd:1::9
 	[ "$status" -eq 0 ]
 	grep -q "ifconfig lo0 inet6 2001:db8:abcd:1::9/128 alias" "$IFCONFIG_LOG"
@@ -81,6 +147,12 @@ EOF
 
 @test "add with no address is a usage error (64)" {
 	run "$WRAP" add
+	[ "$status" -eq 64 ]
+	[ ! -s "$IFCONFIG_LOG" ]
+}
+
+@test "probe with no address is a usage error (64)" {
+	run "$WRAP" probe
 	[ "$status" -eq 64 ]
 	[ ! -s "$IFCONFIG_LOG" ]
 }


### PR DESCRIPTION
## What & why (Refs #609)

Hardens the #543 mode-2 (`static_mapping_with_reservations`) source-alias machinery. Three defects, surfaced by a production IPv6-cutover incident (the wrapper still pinned `cb::/80` while the intended block was `cafe::/80`, which was not even routed → every acquire failed exit 65, sessions stayed held):

1. **Prefix was a compiled-in default.** The wrapper `infra/freebsd/bin/grappa-source-alias` now reads its prefix from a **root-owned config file** (`/usr/local/etc/grappa/source-alias.conf`, `PREFIX=<cidr>`), rendered from `ServerSettings.static_mapping_prefix` at deploy. Missing / unreadable / malformed → **exit 66, fail closed** — never a wildcard fallback. `GRAPPA_SOURCE_ALIAS_PREFIX` stays a root/test-only override, deliberately **NOT** `env_keep`'d through sudoers (an env-controllable scope on a root wrapper is a privilege hole).

2. **`arm_check` was a false positive** — the old no-op `check` proved only that the sudoers grant resolves, so a non-VNET jail armed and then failed every `ensure_source` with EPERM. It now drives a real `probe <canary>` (add-then-delete the network-base canary, deleting only what it added) → exit 69 → `:alias_not_permitted`. Because the canary is derived from the **DB** prefix while the wrapper scopes against its **config-file** prefix, a DB↔substrate drift surfaces for free as exit 65 → `:prefix_mismatch` (one documented blind spot: a config strictly narrower than and sharing the base of the DB prefix — fail-safe, held).

3. **The probe runs when the mode is SET, not only at boot** (vjt, #grappa 12:09). `PUT /admin/settings` selecting mode 2 — or changing the prefix while mode 2 is active — runs the probe FIRST via `SourceAliasManager.arm/1`; on refusal → **422 `addressing_unusable`** with the concrete reason, persisting **nothing**; on success it adopts the prefix + publishes `armed?` (mode 2 goes live without a reboot). The per-address hard-fail at acquire (`do_start_client/2` stops on failure, no shared-source fallthrough) was already in place.

## Gates
Full `scripts/check.sh` green: **4873 tests / 0 failures**, dialyzer 0, credo / sobelow / doctor clean, `wireTypes.ts` in sync, 178 bats. Code review done — no wrong-egress / security defect; 4 fail-safe findings addressed (mailbox call-timeout alignment; canary blind spot + runtime-renumber leak documented; stale comments).

## New wire token
`addressing_unusable` (+ a `reason` field), declared in `GrappaWeb.ErrorTokens.rest_error_token/0` and regenerated into `cicchetto/src/lib/wireTypes.ts`. cic ignores unknown tokens (non-fatal); rendering it in AdminSettingsTab is a likely cic follow-up.

## ⚠️ HELD — do NOT merge / deploy yet
Held during the in-progress IPv6 cutover (the mechanism is migrating by hand — shipping a change to it mid-migration is unsafe). Merge + deploy on vjt's explicit order only. No `Closes` keyword by design — #609 is closed post-deploy.
