### PR TITLE
cic(#605): cap server-window rail width so the status card can't starve the centre

### DIFF
--- a/cicchetto/e2e/tests/issue605-rail-width-cap.spec.ts
+++ b/cicchetto/e2e/tests/issue605-rail-width-cap.spec.ts
@@ -19,16 +19,25 @@
 // content, never past the members-rail's declared width).
 //
 // This is the WIRING proof (feedback_ux_e2e_mandatory): vitest/jsdom is
-// blind to grid track sizing, so only real chromium layout can assert
-// the cap. We reproduce morph's condition deterministically by rewriting
-// the seeded network's `connection.server` to a long IPv6 at the
+// blind to grid track sizing, so only real browser layout can assert the
+// cap. We reproduce morph's condition deterministically by rewriting the
+// seeded network's `connection.server` to a long IPv6 at the
 // `GET /networks` boundary — the same store hydration path #474 asserts
 // against — then measure the rail's real bounding box.
 //
-// iPad Pro 11" portrait is 834×1194: WIDER than the 768px mobile
-// breakpoint, so Shell renders the desktop three-pane shell (not the
-// mobile drawer) — exactly where morph saw the starve.
+// TWO engines on purpose (feedback_playwright_webkit_not_ios_scroll:
+// "CSS=@webkit"). `fit-content()` never shrinks a track below its
+// min-content, so the cap works ONLY because `.rail-server-info-fields dd
+// { word-break: break-word }` makes the IPv6 character-breakable — an
+// engine-sensitive intrinsic-sizing behaviour. morph reported it on
+// iPadOS (WebKit), so the assertion runs on the chromium project AND, via
+// the @webkit tag, on the WebKit engine at the same 834px desktop shell
+// (iPhone-15 device's mobile emulation overridden off). iPad Pro 11"
+// portrait is 834×1194: WIDER than the 768px mobile breakpoint, so Shell
+// renders the desktop three-pane shell (not the mobile drawer) — exactly
+// where morph saw the starve.
 
+import type { Page } from "@playwright/test";
 import { expect, test } from "../fixtures/test";
 import { loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
@@ -40,9 +49,6 @@ const SERVER_WINDOW_LABEL = "Server";
 // morph's report. 39 chars + `:6697` → ~380px of unbreakable text.
 const LONG_IPV6 = "2001:1418:1000:2000:3000:4000:5000:6000";
 
-// iPad Pro 11" portrait. > 768 → desktop shell (the starve viewport).
-test.use({ viewport: { width: 834, height: 1194 } });
-
 // 14rem at the app's 14px root (--font-size) = 196px; allow a few px for
 // the aside's 1px left border + sub-pixel rounding.
 const RAIL_CAP_PX = 196;
@@ -51,61 +57,84 @@ const RAIL_CAP_TOLERANCE_PX = 18;
 // right rail (≤196px) = ≥382px. Assert a hair under to absorb rounding.
 const CENTRE_FLOOR_PX = 375;
 
-async function boxWidth(
-  page: import("@playwright/test").Page,
-  selector: string,
-): Promise<number> {
+// iPad Pro 11" portrait. > 768 → desktop shell (the starve viewport).
+const IPAD_PRO_11_PORTRAIT = { width: 834, height: 1194 } as const;
+
+async function boxWidth(page: Page, selector: string): Promise<number> {
   const box = await page.locator(selector).boundingBox();
   if (!box) throw new Error(`${selector} has no bounding box`);
   return Math.round(box.width);
 }
 
+// The shared assertion, run on both engines. Rewrites the seeded
+// network's dialled server to a long IPv6 BEFORE the SPA fetches
+// /networks (registered before loginAs, which goto's "/"), so the store
+// hydrates the wide-content card and any connection_state_changed refetch
+// stays patched. Then asserts the card renders that full IPv6 AND the
+// rail is capped — a pair that is unsatisfiable unless the cap binds (the
+// content wants ~380px), so it is not a tautology: the un-fixed
+// `max-content` baseline balloons and fails both assertions.
+async function assertServerRailCapped(page: Page): Promise<void> {
+  await page.route(
+    (url) => url.pathname === "/networks",
+    async (route) => {
+      const res = await route.fetch();
+      const rows = (await res.json()) as Array<{
+        connection?: { server?: string } | null;
+      }>;
+      const patched = rows.map((n) =>
+        n.connection ? { ...n, connection: { ...n.connection, server: LONG_IPV6 } } : n,
+      );
+      await route.fulfill({ response: res, json: patched });
+    },
+  );
+
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+
+  // Focus the server window (no WS-ready dance — server windows have no
+  // channel join / self-JOIN line).
+  await expect(sidebarWindow(page, NETWORK_SLUG, SERVER_WINDOW_LABEL)).toHaveCount(1);
+  await selectChannel(page, NETWORK_SLUG, SERVER_WINDOW_LABEL, { awaitWsReady: false });
+
+  // The card renders the long IPv6 — proves the injection landed AND that
+  // this is the wide-content path (the exact starve trigger).
+  const card = page.locator("[data-testid=rail-server-info]");
+  await expect(card).toBeVisible({ timeout: 10_000 });
+  await expect(card.locator('dt:text-is("server") + dd')).toContainText(LONG_IPV6);
+
+  // The rail is capped: without the fix the `max-content` track balloons
+  // to the IPv6's ~380px; with it, `fit-content(14rem)` clamps to ≤196px
+  // and the IPv6 wraps inside the card.
+  const railWidth = await boxWidth(page, ".shell-members");
+  expect(railWidth).toBeLessThanOrEqual(RAIL_CAP_PX + RAIL_CAP_TOLERANCE_PX);
+
+  // …and the centre keeps a usable share (the acceptance criterion).
+  const centreWidth = await boxWidth(page, ".shell-main");
+  expect(centreWidth).toBeGreaterThanOrEqual(CENTRE_FLOOR_PX);
+}
+
 test.describe("#605 server-window rail width cap", () => {
+  test.use({ viewport: IPAD_PRO_11_PORTRAIT });
+
   test("a long connection.server can't starve the centre on an 834px viewport", async ({
     page,
   }) => {
-    // Rewrite the seeded network's dialled server to a long IPv6 BEFORE
-    // the SPA fetches /networks, so the store hydrates the wide-content
-    // card. Registered before loginAs (which goto's "/") so the first
-    // fetch — and any connection_state_changed refetch — is patched.
-    await page.route(
-      (url) => url.pathname === "/networks",
-      async (route) => {
-        const res = await route.fetch();
-        const rows = (await res.json()) as Array<{
-          connection?: { server?: string } | null;
-        }>;
-        const patched = rows.map((n) =>
-          n.connection
-            ? { ...n, connection: { ...n.connection, server: LONG_IPV6 } }
-            : n,
-        );
-        await route.fulfill({ response: res, json: patched });
-      },
-    );
+    await assertServerRailCapped(page);
+  });
+});
 
-    const vjt = getSeededVjt();
-    await loginAs(page, vjt);
+// #605 code-review finding 1 — the bug was reported on iPadOS (WebKit),
+// and the cap's efficacy hinges on WebKit's fit-content/word-break
+// intrinsic sizing, so prove it on the WebKit engine too. The
+// webkit-iphone-15 project carries the iPhone-15 device (393×852, mobile
+// emulation); override that to a clean DESKTOP-shaped WebKit context at
+// the iPad Pro width so Shell renders the three-pane shell, not the
+// mobile drawer. Same assertion, different engine.
+test.describe("#605 server-window rail width cap (webkit)", () => {
+  test.use({ viewport: IPAD_PRO_11_PORTRAIT, isMobile: false, hasTouch: false });
 
-    // Focus the server window (no WS-ready dance — server windows have no
-    // channel join / self-JOIN line).
-    await expect(sidebarWindow(page, NETWORK_SLUG, SERVER_WINDOW_LABEL)).toHaveCount(1);
-    await selectChannel(page, NETWORK_SLUG, SERVER_WINDOW_LABEL, { awaitWsReady: false });
-
-    // The card renders the long IPv6 — proves the injection landed AND
-    // that this is the wide-content path (the exact starve trigger).
-    const card = page.locator("[data-testid=rail-server-info]");
-    await expect(card).toBeVisible({ timeout: 10_000 });
-    await expect(card.locator('dt:text-is("server") + dd')).toContainText(LONG_IPV6);
-
-    // The rail is capped: without the fix the `max-content` track balloons
-    // to the IPv6's ~380px; with it, `fit-content(14rem)` clamps to ≤196px
-    // and the IPv6 wraps inside the card.
-    const railWidth = await boxWidth(page, ".shell-members");
-    expect(railWidth).toBeLessThanOrEqual(RAIL_CAP_PX + RAIL_CAP_TOLERANCE_PX);
-
-    // …and the centre keeps a usable share (the acceptance criterion).
-    const centreWidth = await boxWidth(page, ".shell-main");
-    expect(centreWidth).toBeGreaterThanOrEqual(CENTRE_FLOOR_PX);
+  test("@webkit a long connection.server can't starve the centre on WebKit", async ({ page }) => {
+    await assertServerRailCapped(page);
   });
 });

--- a/cicchetto/e2e/tests/issue605-rail-width-cap.spec.ts
+++ b/cicchetto/e2e/tests/issue605-rail-width-cap.spec.ts
@@ -1,0 +1,111 @@
+// #605 — cap the server-window rail width so the ServerInfoCard can't
+// starve the message area on small desktop-class viewports (morph's
+// iPad Pro 11" report, 2026-08-01).
+//
+// The mechanism the fix targets (verified against origin/main, NOT the
+// issue's suggested direction — see below):
+//   * A SERVER window has kind !== "channel", so isActiveChannelJoined()
+//     is false (windowState.ts) and Shell.tsx tags `.shell-no-members`.
+//   * `.shell-no-members` sizes the RIGHT rail track as `max-content`
+//     (default.css) — it does NOT reference `--members-width`. So the
+//     rail sizes to the ServerInfoCard's widest UNWRAPPED line.
+//   * The card's `server` row renders `connection.server:port`. A long
+//     value — a real IPv6 peer (the #609 cutover), or a long disconnect
+//     reason — has no wrap point under `max-content`, so the track
+//     balloons and the centre scrollback becomes a sliver.
+// The issue's suggested `min(--members-width, Nvw)` cap would miss this
+// entirely: `--members-width` is not in the `.shell-no-members` track.
+// The fix caps the track itself with `fit-content(14rem)` (grows with
+// content, never past the members-rail's declared width).
+//
+// This is the WIRING proof (feedback_ux_e2e_mandatory): vitest/jsdom is
+// blind to grid track sizing, so only real chromium layout can assert
+// the cap. We reproduce morph's condition deterministically by rewriting
+// the seeded network's `connection.server` to a long IPv6 at the
+// `GET /networks` boundary — the same store hydration path #474 asserts
+// against — then measure the rail's real bounding box.
+//
+// iPad Pro 11" portrait is 834×1194: WIDER than the 768px mobile
+// breakpoint, so Shell renders the desktop three-pane shell (not the
+// mobile drawer) — exactly where morph saw the starve.
+
+import { expect, test } from "../fixtures/test";
+import { loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
+
+const SERVER_WINDOW_LABEL = "Server";
+
+// A full-length IPv6 literal — no wrap point under `max-content`, so it
+// balloons the uncapped rail. Ties to the #609 IPv6 cutover that surfaced
+// morph's report. 39 chars + `:6697` → ~380px of unbreakable text.
+const LONG_IPV6 = "2001:1418:1000:2000:3000:4000:5000:6000";
+
+// iPad Pro 11" portrait. > 768 → desktop shell (the starve viewport).
+test.use({ viewport: { width: 834, height: 1194 } });
+
+// 14rem at the app's 14px root (--font-size) = 196px; allow a few px for
+// the aside's 1px left border + sub-pixel rounding.
+const RAIL_CAP_PX = 196;
+const RAIL_CAP_TOLERANCE_PX = 18;
+// Centre floor: 834 − left rail (256px, --sidebar-width default) − capped
+// right rail (≤196px) = ≥382px. Assert a hair under to absorb rounding.
+const CENTRE_FLOOR_PX = 375;
+
+async function boxWidth(
+  page: import("@playwright/test").Page,
+  selector: string,
+): Promise<number> {
+  const box = await page.locator(selector).boundingBox();
+  if (!box) throw new Error(`${selector} has no bounding box`);
+  return Math.round(box.width);
+}
+
+test.describe("#605 server-window rail width cap", () => {
+  test("a long connection.server can't starve the centre on an 834px viewport", async ({
+    page,
+  }) => {
+    // Rewrite the seeded network's dialled server to a long IPv6 BEFORE
+    // the SPA fetches /networks, so the store hydrates the wide-content
+    // card. Registered before loginAs (which goto's "/") so the first
+    // fetch — and any connection_state_changed refetch — is patched.
+    await page.route(
+      (url) => url.pathname === "/networks",
+      async (route) => {
+        const res = await route.fetch();
+        const rows = (await res.json()) as Array<{
+          connection?: { server?: string } | null;
+        }>;
+        const patched = rows.map((n) =>
+          n.connection
+            ? { ...n, connection: { ...n.connection, server: LONG_IPV6 } }
+            : n,
+        );
+        await route.fulfill({ response: res, json: patched });
+      },
+    );
+
+    const vjt = getSeededVjt();
+    await loginAs(page, vjt);
+
+    // Focus the server window (no WS-ready dance — server windows have no
+    // channel join / self-JOIN line).
+    await expect(sidebarWindow(page, NETWORK_SLUG, SERVER_WINDOW_LABEL)).toHaveCount(1);
+    await selectChannel(page, NETWORK_SLUG, SERVER_WINDOW_LABEL, { awaitWsReady: false });
+
+    // The card renders the long IPv6 — proves the injection landed AND
+    // that this is the wide-content path (the exact starve trigger).
+    const card = page.locator("[data-testid=rail-server-info]");
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await expect(card.locator('dt:text-is("server") + dd')).toContainText(LONG_IPV6);
+
+    // The rail is capped: without the fix the `max-content` track balloons
+    // to the IPv6's ~380px; with it, `fit-content(14rem)` clamps to ≤196px
+    // and the IPv6 wraps inside the card.
+    const railWidth = await boxWidth(page, ".shell-members");
+    expect(railWidth).toBeLessThanOrEqual(RAIL_CAP_PX + RAIL_CAP_TOLERANCE_PX);
+
+    // …and the centre keeps a usable share (the acceptance criterion).
+    const centreWidth = await boxWidth(page, ".shell-main");
+    expect(centreWidth).toBeGreaterThanOrEqual(CENTRE_FLOOR_PX);
+  });
+});

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -1025,7 +1025,16 @@ html.overlay-open #root > div {
    suggested `min(--members-width, Nvw)` — `--members-width` is not in THIS
    track (it's `max-content` here, not the base `var()` track), and at the
    14px root (--font-size) any sane `Nvw` is ≥ 14rem across the whole
-   desktop range (≥769px), so the vw clause would be dead code. */
+   desktop range (≥769px), so the vw clause would be dead code.
+
+   Coupling (keep in sync): `fit-content` never shrinks a track BELOW its
+   min-content, so this cap only binds while the rail's content is
+   character-breakable — today via `.rail-server-info-fields dd`
+   (word-break: break-word) + `.rail-server-info-title` (break-all). A
+   future RailContext card (the deferred /whois card is earmarked for the
+   same slot, RailContext.tsx) that renders a `white-space: nowrap` value
+   or a long unbreakable token WITHOUT break-word would floor `fit-content`
+   at that min-content and re-starve the centre. */
 .shell.shell-no-members {
   grid-template-columns: var(--sidebar-width, 16rem) 1fr fit-content(14rem);
 }
@@ -1075,10 +1084,11 @@ html.overlay-open #root > div {
   .shell.shell-no-members {
     /* #71 INC-2 / #473 — narrow rail stays (RailActions buttons everywhere),
        not a dropped column. Was `8rem 1fr`. #605 — same server-card cap as
-       the base tier, but pinned to THIS tier's 7rem members width: a server
-       window's `max-content` card would otherwise blow straight past the
-       slim rails this compact tier exists to enforce, re-creating the
-       centre-starve inside the tier meant to prevent it. */
+       the base tier, capped near THIS tier's 7rem members width (fit-content
+       floors at the RailActions launcher's min-content, a few px over 7rem):
+       a server window's `max-content` card would otherwise blow straight
+       past the slim rails this compact tier exists to enforce, re-creating
+       the centre-starve inside the tier meant to prevent it. */
     grid-template-columns: 8rem 1fr fit-content(7rem);
   }
 }

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -1010,9 +1010,24 @@ html.overlay-open #root > div {
    longer suppressed: it narrows to `max-content`, sizing to the labelled
    button drawer instead of a 14rem members void. Was `… 1fr` (column dropped);
    now `… 1fr max-content` (narrow rail stays). Mobile-only .shell-mobile
-   is single-column so the modifier is a no-op there. */
+   is single-column so the modifier is a no-op there.
+
+   #605 — CAP the max-content track with `fit-content(14rem)`. On a SERVER
+   window the rail content (RailContext → ServerInfoCard) drives this
+   track, and a long `connection.server` (a real IPv6 peer — the #609
+   cutover) or a long disconnect reason has NO wrap point under bare
+   `max-content`, so the rail ballooned and starved the centre scrollback
+   on small desktop-class viewports (iPad Pro 11" 834px — morph's report,
+   2026-08-01). `fit-content` still sizes to content (a short card stays
+   narrow — no empty rail column), but never past 14rem, the members-rail's
+   declared width: a server window's context card can't claim more
+   horizontal space than a channel's member list would. NOT the issue's
+   suggested `min(--members-width, Nvw)` — `--members-width` is not in THIS
+   track (it's `max-content` here, not the base `var()` track), and at the
+   14px root (--font-size) any sane `Nvw` is ≥ 14rem across the whole
+   desktop range (≥769px), so the vw clause would be dead code. */
 .shell.shell-no-members {
-  grid-template-columns: var(--sidebar-width, 16rem) 1fr max-content;
+  grid-template-columns: var(--sidebar-width, 16rem) 1fr fit-content(14rem);
 }
 
 /* #319 — landscape-compact tier. A small phone (~5") rotated to landscape
@@ -1059,8 +1074,12 @@ html.overlay-open #root > div {
 
   .shell.shell-no-members {
     /* #71 INC-2 / #473 — narrow rail stays (RailActions buttons everywhere),
-       not a dropped column. Was `8rem 1fr`. */
-    grid-template-columns: 8rem 1fr max-content;
+       not a dropped column. Was `8rem 1fr`. #605 — same server-card cap as
+       the base tier, but pinned to THIS tier's 7rem members width: a server
+       window's `max-content` card would otherwise blow straight past the
+       slim rails this compact tier exists to enforce, re-creating the
+       centre-starve inside the tier meant to prevent it. */
+    grid-template-columns: 8rem 1fr fit-content(7rem);
   }
 }
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -25231,3 +25231,19 @@ both handled at the rebase onto `96bedfdd`:
    CTCP parser on the server" cleanup, but it touches another author's
    just-landed code plus a pre-existing helper, so it is proposed to vjt
    rather than folded silently into #591's send-side scope.
+
+## 2026-08-01 — #605 server-window rail width cap: the issue premise was wrong
+
+The issue proposed capping `var(--members-width, 14rem)`, but a SERVER window
+is `.shell-no-members` (kind !== "channel" → `isActiveChannelJoined()` false),
+whose right grid track is **`max-content`** — it never references
+`--members-width`. So the balloon is the ServerInfoCard's widest UNWRAPPED line
+(a long IPv6 `connection.server`, the #609 cutover; or a long disconnect
+reason), and the suggested `min(--members-width, Nvw)` cap would have missed the
+track entirely. Fix: cap the `max-content` track itself —
+`fit-content(14rem)` (base) / `fit-content(7rem)` (the #319 short-landscape
+tier). `fit-content` grows-to-content then caps (a short card stays narrow — no
+empty rail column, the concern that only applied to a *fixed* track), and binds
+only while the card content is character-breakable (word-break on the dd). The
+issue's `vw` term is dead on desktop: at the 14px root, 14rem < any sane `Nvw`
+for width ≥769px.


### PR DESCRIPTION
Refs #605.

## Problem
morph (IRC #grappa, 2026-08-01): on an iPad Pro 11" (834px) desktop shell a server window's `ServerInfoCard` eats the message area. Maintainer scope: a **width cap**, not a hide/collapse control.

## Root cause — the issue premise was wrong
The issue proposed capping `var(--members-width, 14rem)`. But a SERVER window is `kind !== "channel"` → `isActiveChannelJoined()` false → `Shell.tsx` applies `.shell-no-members`, whose right grid track is **`max-content`** — it never references `--members-width`. So the balloon is the card's widest UNWRAPPED line (a long IPv6 `connection.server` — the #609 cutover — or a long disconnect reason), and `min(--members-width, Nvw)` would have missed the track entirely.

## Fix (scope A, targeted)
Cap the two `.shell-no-members` `max-content` tracks: `fit-content(14rem)` (base) / `fit-content(7rem)` (the #319 short-landscape tier). `fit-content` grows-to-content then caps → a short card stays narrow (no empty rail column, the concern that only applied to a *fixed* track), never wider than the members-rail's declared width. No new affordance; drag + persisted `membersWidth` (a channel-window concept) untouched; the #319 iPad-landscape watch-out is respected (not gated on the short-landscape media query). Dropped the issue's `vw` term — dead on desktop at the 14px root (14rem < any sane Nvw for width ≥769px).

## Tests
`issue605-rail-width-cap.spec.ts` injects a 39-char IPv6 into `connection.server` at the `GET /networks` boundary on an 834px viewport, then asserts the card renders the full IPv6 **and** the rail ≤214px + centre ≥375px. That pair is unsatisfiable unless the cap binds (content wants ~380px) — not a tautology; the un-fixed `max-content` baseline balloons and fails. Runs on **chromium AND @webkit** — the bug's reported engine, and the cap is engine-sensitive (`fit-content` never floors below `word-break` min-content).

## Gates
- biome + tsc: exit 0
- vitest: 3747 passed
- scoped chromium e2e: passed locally; full integration (both engines) runs via this PR's CI.

Code review (10x-engineer:code-reviewer): PASS, three findings resolved (webkit coverage, fit-content↔word-break coupling comment, #319-tier wording). DESIGN_NOTES entry records the premise-was-wrong rationale.