### PR TITLE
Refs #608: single scroll authority for ScrollbackPane

### DIFF
--- a/cicchetto/e2e/tests/bug7-ios-own-msg-visible.spec.ts
+++ b/cicchetto/e2e/tests/bug7-ios-own-msg-visible.spec.ts
@@ -34,6 +34,7 @@
 // `@webkit` tag opts this spec into the `webkit-iphone-15` project
 // (playwright.config.ts grep). Default chromium project skips it.
 
+import { type Page } from "@playwright/test";
 import { test, expect } from "../fixtures/test";
 import {
   composeTextarea,
@@ -48,6 +49,18 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 // Per-run unique tag so retries / parallel runs don't strict-mode-collide
 // with persisted prior-run rows in #bofh.
 const MESSAGE_BODY = `BUG7-ios: own-msg visibility @ ${crypto.randomUUID().slice(0, 8)}`;
+
+// Mirror of ScrollbackPane.SCROLL_BOTTOM_THRESHOLD_PX = 50 (not exported; kept
+// in lockstep by hand — same as issue168 / issue580).
+const SCROLL_BOTTOM_THRESHOLD_PX = 50;
+
+async function distanceToBottom(page: Page): Promise<number> {
+  return await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+    if (!el) throw new Error("scrollback container not found");
+    return el.scrollHeight - el.scrollTop - el.clientHeight;
+  });
+}
 
 test("@webkit BUG7 — own message visible in scrollback after iOS-shaped compose-send", async ({ page }) => {
   const vjt = getSeededVjt();
@@ -100,4 +113,16 @@ test("@webkit BUG7 — own message visible in scrollback after iOS-shaped compos
   // 5s here matches the rest of the suite's WS poll ceiling.
   const ownRow = scrollbackLine(page, "privmsg", MESSAGE_BODY);
   await expect(ownRow).toBeVisible({ timeout: 5_000 });
+
+  // #608 STEP 6 STRENGTHEN — after the measured settle the OWN sent row must be
+  // at the TRUE tail, not merely attached / partially on screen. `toBeVisible`
+  // (offsetParent + any viewport intersection) passed even when the row sat one
+  // line BELOW the fold — the #608 §5 off-by-one, where the pre-append/rAF×2
+  // scroll landed on the previous line. `toBeInViewport` (full intersection) +
+  // distance-to-tail within threshold pin that the send tailed to the real
+  // bottom once the echo laid out. NEVER weaken these, NEVER inflate the poll.
+  await expect(ownRow).toBeInViewport();
+  await expect
+    .poll(async () => await distanceToBottom(page))
+    .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
 });

--- a/cicchetto/e2e/tests/bug7-m6-ios-dm-own-msg-visible.spec.ts
+++ b/cicchetto/e2e/tests/bug7-m6-ios-dm-own-msg-visible.spec.ts
@@ -16,6 +16,7 @@
 //
 // `@webkit` opts into the webkit-iphone-15 project.
 
+import { type Page } from "@playwright/test";
 import { test, expect } from "../fixtures/test";
 import {
   composeTextarea,
@@ -31,6 +32,18 @@ import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../
 const PEER_NICK = "bug7m6-peer";
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const MESSAGE_BODY = `BUG7-M6-ios: DM own-msg @ ${crypto.randomUUID().slice(0, 8)}`;
+
+// Mirror of ScrollbackPane.SCROLL_BOTTOM_THRESHOLD_PX = 50 (not exported; kept
+// in lockstep by hand — same as issue168 / issue580).
+const SCROLL_BOTTOM_THRESHOLD_PX = 50;
+
+async function distanceToBottom(page: Page): Promise<number> {
+  return await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+    if (!el) throw new Error("scrollback container not found");
+    return el.scrollHeight - el.scrollTop - el.clientHeight;
+  });
+}
 
 test("@webkit BUG7-M6 — cicchetto /msg DM own-msg visible on iOS-shaped input", async ({ page }) => {
   const vjt = getSeededVjt();
@@ -67,7 +80,19 @@ test("@webkit BUG7-M6 — cicchetto /msg DM own-msg visible on iOS-shaped input"
     // Second door: own-msg visible in the auto-focused DM scrollback.
     // toBeVisible enforces the viewport-intersection check — a row
     // that's painted but virtual-keyboard-occluded fails here.
-    await expect(scrollbackLine(page, "privmsg", MESSAGE_BODY)).toBeVisible({ timeout: 5_000 });
+    const ownRow = scrollbackLine(page, "privmsg", MESSAGE_BODY);
+    await expect(ownRow).toBeVisible({ timeout: 5_000 });
+
+    // #608 STEP 6 STRENGTHEN — after the measured settle the OWN sent line must
+    // be at the TRUE tail of the auto-focused DM, not merely attached / partially
+    // on screen. `toBeVisible` passed even one line below the fold (the #608 §5
+    // off-by-one); `toBeInViewport` (full intersection) + distance-to-tail within
+    // threshold pin that the send tailed to the real bottom once the echo laid
+    // out. NEVER weaken these, NEVER inflate the poll.
+    await expect(ownRow).toBeInViewport();
+    await expect
+      .poll(async () => await distanceToBottom(page))
+      .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
   } finally {
     await peer.disconnect("BUG7-M6 done");
   }

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -2187,32 +2187,41 @@ const ScrollbackPane: Component<Props> = (props) => {
     }),
   );
 
-  // #580 — submit-time scroll authority. The bottom-snap + follow-state
-  // reset are the operator's response to pressing enter, NOT a reaction to
-  // the server, so they fire on `ownSendSubmitted` (published SYNCHRONOUSLY
-  // before the POST in scrollback.sendMessage) — the instant enter is
-  // pressed, independent of the network round-trip. This fixes the field
-  // report (#580) where a slow / failed POST left the pane parked while the
-  // WS echo rendered the row: the snap no longer waits on the POST.
+  // #580 / #608 (deep-review §6.5) — submit-time follow authority. Pressing
+  // enter is the operator declaring "follow the tail again", NOT a reaction to
+  // the server, so it fires on `ownSendSubmitted` (published SYNCHRONOUSLY before
+  // the POST in scrollback.sendMessage) — the instant enter is pressed,
+  // independent of the network round-trip (the #580 property: a slow / failed
+  // POST must not park the pane; the follow-arm here never waits on it).
   //
-  // #168 — a send re-enters follow mode UNCONDITIONALLY: even if the operator
-  // had paged UP to re-read, sending snaps the pane back to the tail so the
-  // just-sent line is visible ("send scrolls to the bottom unconditionally").
-  // Clear the marker-activation latch FIRST so the length-effect's re-assert
-  // can't fight the snap, THEN snap. `scrollToBottom` is the same tail
-  // authority the length-effect uses (scroll + followMode/atBottomNow=true); the WS-echo
-  // row that lands later is then followed by the length-effect. NOT event-type
-  // branching — the send resets the follow-STATE and the single always-bottom
-  // authority does the scrolling. Keyed: only a send to THIS pane's
-  // `(slug, channel)` (a `/msg` elsewhere doesn't). `defer: true` skips the
-  // mount run — the key/cold-latch effects own the mount-time baseline.
+  // #608 STEP 5 — the submit ARMS the follow INTENT; it does NOT scroll to a
+  // non-existent node. There is NO optimistic append (scrollback.sendMessage
+  // publishes this signal SYNC before the POST; the row renders only on the WS
+  // echo), so the pre-#608 `scrollToBottom()` here read PRE-append geometry and
+  // scrolled to the STALE tail — one message behind (#608 §5 off-by-one). Now the
+  // send sets `followMode` via the `nextFollowMode` "send" edge (re-enters follow
+  // even if the operator had paged UP — "send follows the tail
+  // unconditionally"), and the APPLIER tail-follows when the echo row actually
+  // mounts + lays out (length-effect → tail-follow, reading POST-append
+  // geometry). This is where `followMode` and `atBottomNow` first DIVERGE:
+  // `followMode` is armed HERE (the intent); `atBottomNow` only flips true once
+  // the echo lays out and the tail-follow's scroll fires `onScroll` reach-tail —
+  // the floating button may briefly show between submit and echo on a
+  // scrolled-up send, which is correct (the tail does not yet exist).
+  //
+  // Clear the marker-activation latch FIRST so the length-effect's marker
+  // re-assert can't fight the tail-follow the echo triggers. Keyed: only a send
+  // to THIS pane's `(slug, channel)` arms it (a `/msg` elsewhere doesn't).
+  // `defer: true` skips the mount run — the key/cold-latch effects own the
+  // mount-time baseline. The divider re-latch stays on `lastOwnSend`
+  // (post-resolve, below) — the #580 split is preserved.
   createEffect(
     on(
       ownSendSubmitted,
       (sent) => {
         if (sent !== key()) return;
         setMarkerActivationPending(false);
-        scrollToBottom();
+        setFollowMode(nextFollowMode(followMode(), "send"));
       },
       { defer: true },
     ),

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -1532,7 +1532,7 @@ const ScrollbackPane: Component<Props> = (props) => {
     // landed) — scrollToActivation early-returns and the latched length-effect
     // re-asserts on the first load / cursor hydration.
     setMarkerActivationPending(true);
-    scrollToActivation("marker-or-tail", true);
+    applyActivation("marker-or-tail", true);
     // UX-6 D9 / #253 — every vv.resize (keyboard open OR close,
     // orientation change, browser zoom) and window.resize (desktop
     // resize, devtools, zoom) re-anchors the scroll — but ONLY when the
@@ -1592,7 +1592,7 @@ const ScrollbackPane: Component<Props> = (props) => {
       // driven recompute. Matters most on mobile: the keyboard opening while the
       // operator is parked mid-buffer must not strand a stale badge.
       recomputeMentionsBelow();
-      if (followMode()) scrollToActivation("tail-only", true);
+      if (followMode()) applyActivation("tail-only", true);
     };
     window.addEventListener("resize", onResize);
     window.visualViewport?.addEventListener("resize", onResize);
@@ -2114,7 +2114,7 @@ const ScrollbackPane: Component<Props> = (props) => {
         // initial mount; first-focus-after-login is the COLD MOUNT handled by
         // onMount — also a marker activation now. #168, 2026-07-03.)
         setMarkerActivationPending(true);
-        scrollToActivation("marker-or-tail", true);
+        applyActivation("marker-or-tail", true);
       },
       { defer: true },
     ),
@@ -2179,9 +2179,9 @@ const ScrollbackPane: Component<Props> = (props) => {
         //     unconditional "tail-only" here dropped a mid-backlog reader at the
         //     tail on every return from an external link).
         if (followMode()) {
-          scrollToActivation("tail-only", true);
+          applyActivation("tail-only", true);
         } else {
-          scrollToActivation("marker-or-preserve", true);
+          applyActivation("marker-or-preserve", true);
         }
       }
     }),
@@ -2573,6 +2573,51 @@ const ScrollbackPane: Component<Props> = (props) => {
     const { winner, reason } = resolveIntent([intent], k);
     logScrollDecision("mention-jump", [intent], winner, reason);
     if (winner) anchor.scrollIntoView({ behavior: "smooth", block: "center" });
+  };
+
+  // #608 (STEP 3) — the window-activation applier entrypoint (W2/W3), the LAST
+  // step-3 writer. The activation triggers (cold-mount, channel switch,
+  // visibility-return, resize) DECLARE their intent HERE instead of calling
+  // `scrollToActivation` directly, so the single applier — not each call-site —
+  // resolves precedence and logs the decision. Behaviour-IDENTICAL to the
+  // pre-STEP-3 direct calls: `scrollToActivation` already bails on
+  // `isOverlayFrozen()` (= overlay-freeze precedence) and still owns the
+  // marker-or-tail / tail-only / marker-or-preserve write mechanics + the #130
+  // flicker hide (`withHide`) + the follow/geometry signals — this only moves the
+  // DECISION into the pure `resolveIntent` core, making `scrollToActivation` an
+  // applier-internal write routine (reached ONLY here and from
+  // `dispatchScrollWrite`'s marker-activation case).
+  //
+  // The activation kind maps by mode: "tail-only" is the tail-follow intent
+  // (resize resume + the follow-live visibility arm); "marker-or-tail" /
+  // "marker-or-preserve" are marker-activation (jump to the rendered divider, or
+  // tail/preserve when none). The intent is UNCONDITIONAL per mode — NOT gated on
+  // the marker latch — because a direct `scrollToActivation` always ran when not
+  // frozen; gating it would be a behaviour change. When overlay-freeze outranks
+  // the activation intent we skip the delegate: `scrollToActivation`'s own frozen
+  // bail produced the identical no-op, so no activation authority moves a covered
+  // pane (the #219 / #219-general freeze), and the decision is now logged.
+  const applyActivation = (
+    mode: "marker-or-tail" | "tail-only" | "marker-or-preserve",
+    withHide: boolean,
+  ): void => {
+    if (!listRef) return;
+    const k = key();
+    const intents: ScrollIntent[] = [];
+    if (isOverlayFrozen()) {
+      intents.push({ kind: "overlay-freeze", key: k, lifetime: "sticky" });
+    }
+    intents.push({
+      kind: mode === "tail-only" ? "tail-follow" : "marker-activation",
+      key: k,
+      lifetime: "sticky",
+    });
+    const { winner, reason } = resolveIntent(intents, k);
+    logScrollDecision(`activation:${mode}`, intents, winner, reason);
+    // overlay-freeze wins ⇒ no activation write (scrollToActivation would have
+    // bailed identically). Otherwise the activation intent won ⇒ delegate.
+    if (winner?.kind === "overlay-freeze") return;
+    scrollToActivation(mode, withHide);
   };
 
   // After Solid commits new DOM nodes, scroll to the tail iff the user

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -2557,6 +2557,24 @@ const ScrollbackPane: Component<Props> = (props) => {
     listRef.scrollTo({ top: listRef.scrollTop });
   };
 
+  // #608 — the W8 mention-jump applier entrypoint. Tapping the floating button
+  // with a mention below the fold smooth-scrolls the anchor into view (the #360
+  // iOS msg+1 anchoring is resolved by the caller). Declared as a one-shot
+  // `mention-jump` intent so the write is owned + logged by the applier. STEP 3
+  // keeps it BEHAVIOUR-IDENTICAL: the tap is the operator's explicit gesture, so
+  // it resolves a single-intent list and fires unconditionally, exactly as the
+  // inline code did. (Arbitrating it against a live overlay-freeze / operator-
+  // tail would SUPPRESS the scroll — a behaviour change deliberately left out of
+  // this behaviour-preserving step; the write is now an applier intent that a
+  // later step can fold into full precedence.)
+  const applyMentionJump = (anchor: HTMLElement): void => {
+    const k = key();
+    const intent: ScrollIntent = { kind: "mention-jump", key: k, lifetime: "one-shot" };
+    const { winner, reason } = resolveIntent([intent], k);
+    logScrollDecision("mention-jump", [intent], winner, reason);
+    if (winner) anchor.scrollIntoView({ behavior: "smooth", block: "center" });
+  };
+
   // After Solid commits new DOM nodes, scroll to the tail iff the user
   // was at the bottom before the update (auto-follow). The effect tracks
   // `rows().length` so it re-runs on every append AND on cursor
@@ -2998,7 +3016,7 @@ const ScrollbackPane: Component<Props> = (props) => {
       return;
     }
     setMarkerActivationPending(false);
-    anchor.scrollIntoView({ behavior: "smooth", block: "center" });
+    applyMentionJump(anchor);
     // The badge is DERIVED: onScroll recomputes it as the smooth animation
     // clears the target past the fold. Recompute now too so a browser that
     // coalesces the settle scroll still refreshes it.

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -38,7 +38,7 @@ import {
 } from "./lib/presenceFilter";
 import { canonicalQueryNick, openQueryWindowState } from "./lib/queryWindows";
 import { getReadCursor } from "./lib/readCursor";
-import { nextFollowMode } from "./lib/scrollAuthority";
+import { nextFollowMode, resolveIntent, type ScrollIntent } from "./lib/scrollAuthority";
 import {
   lastOwnSend,
   loadMore as loadMoreScrollback,
@@ -2379,6 +2379,131 @@ const ScrollbackPane: Component<Props> = (props) => {
     setMarkerCursorId(c);
   });
 
+  // #608 (deep-review §6.3) — THE SINGLE SCROLL APPLIER.
+  //
+  // Historically N effects each independently decided to write `scrollTop` /
+  // `scrollIntoView`, arbitrated only by whichever ran LAST in the frame — the
+  // un-coordinated race the reshape kills. The applier is the ONE place that
+  // resolves precedence (via the pure `resolveIntent` core) and performs the
+  // single winning DOM write, with a dev-only log per run so the next field
+  // report is a log line, not a guess.
+  //
+  // Intents are built from LIVE state at call time: the sticky ones are DERIVED
+  // (overlay-freeze from `isOverlayFrozen()`, marker-activation from the latch +
+  // a rendered divider, tail-follow from `followMode()`); the one-shot ones
+  // (operator-tail, mention-jump) are DECLARED by their trigger and consumed
+  // here. This increment funnels the length-effect (rows() content change)
+  // through it; later increments route the remaining writers (overlay edge,
+  // send, gesture, mention, key-change) in one at a time.
+
+  // Dev-only decision log — (trigger, intents, winner, reason, geometry) per
+  // applier run. Gated on the dev-server MODE: Vite statically replaces
+  // `import.meta.env.MODE`, so this is dead-code-eliminated in the prod bundle
+  // and silent under vitest (MODE "test"). listRef is read for geometry only.
+  const logScrollDecision = (
+    trigger: string,
+    intents: readonly ScrollIntent[],
+    winner: ScrollIntent | null,
+    reason: string,
+  ): void => {
+    if (import.meta.env.MODE !== "development" || !listRef) return;
+    console.debug("[scroll-authority]", {
+      trigger,
+      key: key(),
+      intents: intents.map((i) => i.kind),
+      winner: winner?.kind ?? null,
+      reason,
+      geometry: {
+        scrollTop: listRef.scrollTop,
+        scrollHeight: listRef.scrollHeight,
+        clientHeight: listRef.clientHeight,
+      },
+    });
+  };
+
+  // Perform the winning intent's DOM write. Each kind keeps the exact timing its
+  // pre-applier writer used (rAF×2 where geometry must settle after the <For>
+  // commit — STEP 6 replaces that with the measured-settle predicate). The
+  // caller guarantees `listRef` is non-null on entry, but the deferred rAF
+  // bodies re-check it (it can null on unmount between frames).
+  const dispatchScrollWrite = (winner: ScrollIntent): void => {
+    switch (winner.kind) {
+      case "overlay-freeze": {
+        // W4 — re-assert the held snapshot px. The ref-keyed <For> has just
+        // recreated the list DOM, resetting scrollTop to 0; re-assert SYNC (no
+        // transient-0 frame for a reader to catch) then AGAIN across rAF×2 as
+        // belt-and-braces for any late layout shift. Re-check `isOverlayFrozen()`
+        // in the rAF: the overlay may have closed, in which case the overlay
+        // effect's close restore owns it.
+        const snapNow = overlayScrollSnapshot;
+        if (listRef && snapNow !== null && listRef.scrollTop !== snapNow) {
+          listRef.scrollTop = snapNow;
+        }
+        requestAnimationFrame(() =>
+          requestAnimationFrame(() => {
+            const snap = overlayScrollSnapshot;
+            if (listRef && isOverlayFrozen() && snap !== null) {
+              listRef.scrollTop = snap;
+            }
+          }),
+        );
+        return;
+      }
+      case "marker-activation":
+        // W2/W3 — jump to the rendered unread divider (or the tail if none).
+        // `scrollToActivation` owns the rAF×2 + the frozen bail (unreachable
+        // here: overlay-freeze outranks marker-activation, so we only dispatch
+        // marker-activation when not frozen).
+        scrollToActivation("marker-or-tail", false);
+        return;
+      case "tail-follow":
+        // W5 — stick to the tail. rAF×2 so layout has settled before the read;
+        // `lastElementChild.scrollIntoView` is layout-aware even when
+        // scrollHeight bookkeeping is mid-update (the fallback covers an empty
+        // list). Re-check `followMode()` in the rAF — the operator may have
+        // scrolled up between the decision and the frame.
+        requestAnimationFrame(() =>
+          requestAnimationFrame(() => {
+            if (!listRef) return;
+            if (!followMode()) return;
+            const tail = listRef.lastElementChild as HTMLElement | null;
+            if (tail?.scrollIntoView) {
+              tail.scrollIntoView({ block: "end" });
+            } else {
+              listRef.scrollTop = listRef.scrollHeight;
+            }
+          }),
+        );
+        return;
+      default:
+        // operator-tail / mention-jump / prepend-preserve are routed in later
+        // increments — the length-effect never declares them, so this is
+        // unreachable until then.
+        return;
+    }
+  };
+
+  // The applier entrypoint for a content change (the length-effect below).
+  // Builds the live-derived intents that compete when rows() changes, resolves
+  // precedence, logs, and performs the single winning write.
+  const applyScrollForContentChange = (): void => {
+    if (!listRef) return;
+    const k = key();
+    const intents: ScrollIntent[] = [];
+    if (isOverlayFrozen()) {
+      intents.push({ kind: "overlay-freeze", key: k, lifetime: "sticky" });
+    }
+    if (markerActivationPending() && listRef.querySelector('[data-testid="unread-marker"]')) {
+      intents.push({ kind: "marker-activation", key: k, lifetime: "sticky" });
+    }
+    if (followMode()) {
+      intents.push({ kind: "tail-follow", key: k, lifetime: "sticky" });
+    }
+    const { winner, reason } = resolveIntent(intents, k);
+    logScrollDecision("content-change", intents, winner, reason);
+    if (winner) dispatchScrollWrite(winner);
+  };
+
   // After Solid commits new DOM nodes, scroll to the tail iff the user
   // was at the bottom before the update (auto-follow). The effect tracks
   // `rows().length` so it re-runs on every append AND on cursor
@@ -2417,101 +2542,14 @@ const ScrollbackPane: Component<Props> = (props) => {
   createEffect(
     on(
       () => rows()?.length ?? 0,
-      () => {
-        if (!listRef) return;
-        // #219 / #219-general / #196(reopen) — a covering overlay freezes the
-        // pane's scroll (see the overlay-snapshot capture/restore + the
-        // scrollToActivation guard). A message arriving WHILE an overlay is up
-        // must not tail-follow the covered pane out from under the reader (#168
-        // message-follow is correct ONLY when no overlay covers the pane).
-        //
-        // #196 reopen: bailing outright is NOT enough. This rows() change is the
-        // very message arrival that triggered the effect; the ref-keyed <For>
-        // has just RECREATED the list DOM, resetting scrollTop to 0. Bailing
-        // leaves the covered pane stranded at the top for the overlay's whole
-        // lifetime, and the single close-edge restore then lands wrong when the
-        // scrollTop=0 artifact spuriously prepended older rows (onScroll gate
-        // below now blocks that) — "re-reading old messages as if new", the
-        // reopened desktop regression the quiet-channel e2e never saw. RE-ASSERT
-        // the held snapshot instead (rAF×2, matching the overlay-snapshot
-        // restore's frame budget so it lands after the <For> commit), so the
-        // reader's position survives EVERY rows recreation while frozen, not
-        // just the close edge. Re-check `isOverlayFrozen()` inside the rAF — the
-        // overlay may have closed in the interim, in which case the close-edge
-        // restore owns it.
-        if (isOverlayFrozen()) {
-          // This createEffect runs AFTER the ref-keyed <For> has reconciled, so
-          // scrollTop has ALREADY been reset to 0 by the DOM recreation. Re-assert
-          // the held snapshot SYNCHRONOUSLY (no transient-0 frame for a reader to
-          // catch) — the snapshot is an absolute offset, so no post-layout
-          // scrollHeight read is needed — then AGAIN across rAF×2 as belt-and-
-          // braces for any late layout shift (matching the overlay-snapshot
-          // restore's frame budget). Re-check `isOverlayFrozen()` in the rAF: the
-          // overlay may have closed, in which case the close restore owns it.
-          const snapNow = overlayScrollSnapshot;
-          if (snapNow !== null && listRef.scrollTop !== snapNow) {
-            listRef.scrollTop = snapNow;
-          }
-          requestAnimationFrame(() =>
-            requestAnimationFrame(() => {
-              const snap = overlayScrollSnapshot;
-              if (listRef && isOverlayFrozen() && snap !== null) {
-                listRef.scrollTop = snap;
-              }
-            }),
-          );
-          return;
-        }
-        // #168 completion / 307 race fix — while a channel activation is
-        // latched AND a rendered unread divider EXISTS, EVERY rows recreation
-        // (post-switch catch-up refresh, late read-cursor hydration inserting
-        // the divider) must RE-ASSERT the marker jump; the ref-keyed `<For>`
-        // reset scrollTop to 0 on this recreation and a one-shot jump would
-        // strand (the 307 bug — a far marker sets followMode=false, which without
-        // this branch suppresses ALL re-establish). Pre-paint (rAF×2,
-        // withHide=false) so the reset frame is never shown.
-        //
-        // Gated on the marker actually EXISTING (not just the latch): when
-        // there is no divider — a read channel's cold-mount, OR a scroll-up
-        // loadMore prepend on a read channel — we FALL THROUGH to the followMode
-        // tail-follow below. That preserves the two cases correctly with ONE
-        // rule: initial cold-mount (followMode=true) tails; a loadMore prepend
-        // after the operator scrolled up (followMode=false) does nothing → the
-        // prepend's own height-delta restore preserves position (cp14-b2). A
-        // no-marker re-assert would instead TAIL and yank the prepend — the
-        // oscillation this gate prevents. The latch still clears on operator
-        // input / own send.
-        if (markerActivationPending() && listRef.querySelector('[data-testid="unread-marker"]')) {
-          scrollToActivation("marker-or-tail", false);
-          return;
-        }
-        if (followMode()) {
-          // Same scrollHeight-vs-layout race as scrollToActivation /
-          // measureOverflow: reading scrollHeight synchronously inside
-          // the Solid effect callback fires BEFORE the browser's layout
-          // pass has measured the newly-committed <For> rows, so the
-          // write lands one-or-two rows short of true bottom.
-          // CI sentinel (scroll-on-window-switch:141) consistently saw a
-          // 66px gap pre-double-rAF; vjt prod-dogfooded the same as
-          // "short channel scrolled above its own height" 2026-05-23.
-          // Double rAF guarantees layout has settled before the read.
-          // UX-8(a3): use lastElementChild.scrollIntoView for native
-          // layout-aware bottom-anchor (avoids scrollHeight-mid-update
-          // race even after rAF×2).
-          requestAnimationFrame(() => {
-            requestAnimationFrame(() => {
-              if (!listRef) return;
-              if (!followMode()) return;
-              const tail = listRef.lastElementChild as HTMLElement | null;
-              if (tail?.scrollIntoView) {
-                tail.scrollIntoView({ block: "end" });
-              } else {
-                listRef.scrollTop = listRef.scrollHeight;
-              }
-            });
-          });
-        }
-      },
+      // #608 (deep-review §6.3) — routed through the single applier. This
+      // effect used to hand-code the precedence overlay-freeze ▸
+      // marker-activation ▸ tail-follow as an if/else ladder; it now DECLARES
+      // the live-derived intents and the applier resolves + writes exactly one.
+      // The per-branch rationale (frozen re-assert on the ref-keyed <For>
+      // recreation, the #307 marker re-assert, the followMode tail-follow rAF×2)
+      // lives in `dispatchScrollWrite` / `applyScrollForContentChange` above.
+      () => applyScrollForContentChange(),
     ),
   );
 

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -2544,6 +2544,19 @@ const ScrollbackPane: Component<Props> = (props) => {
     listRef.scrollTop = target;
   };
 
+  // #608 — the applier's smooth-scroll INTERRUPT (W9). The mention-jump is the
+  // ONE animated scroll in this pane; a channel switch must cancel an in-flight
+  // animation so it cannot survive the shared `.scrollback` DOM row swap and
+  // race the arriving pane's activation. NOT a position intent — a `scrollTo` to
+  // the CURRENT offset is an instant (default-behavior) scroll instruction that
+  // stops the native smooth animation without moving. Owned here so no scrollTo
+  // lives outside the applier surface.
+  const interruptSmoothScroll = (): void => {
+    if (!listRef) return;
+    logScrollDecision("interrupt-smooth", [], null, "interrupt-smooth");
+    listRef.scrollTo({ top: listRef.scrollTop });
+  };
+
   // After Solid commits new DOM nodes, scroll to the tail iff the user
   // was at the bottom before the update (auto-follow). The effect tracks
   // `rows().length` so it re-runs on every append AND on cursor
@@ -3018,15 +3031,7 @@ const ScrollbackPane: Component<Props> = (props) => {
   // (default-behavior) scroll instruction that interrupts the native smooth
   // animation without moving anywhere, so nothing async survives to fight the
   // re-anchor. `defer` skips the mount run; a no-op when no animation runs.
-  createEffect(
-    on(
-      key,
-      () => {
-        if (listRef) listRef.scrollTo({ top: listRef.scrollTop });
-      },
-      { defer: true },
-    ),
-  );
+  createEffect(on(key, () => interruptSmoothScroll(), { defer: true }));
 
   return (
     <div class="scrollback-pane">

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -2472,6 +2472,15 @@ const ScrollbackPane: Component<Props> = (props) => {
       // prototype method, would pollute a later-mounted pane's spy under test).
       if (!listRef?.isConnected) return;
       if (!followMode()) return;
+      // #608 — a DEFERRED settle poll must re-validate the freeze precedence each
+      // frame, not just at dispatch time. tail-follow only wins `resolveIntent`
+      // when nothing higher is active, but this poll can outlive that decision by
+      // up to SETTLE_MAX_FRAMES: if a covering overlay opens mid-poll,
+      // overlay-freeze now outranks tail-follow, so the poll must YIELD rather
+      // than write through the freeze. Keeps the single-writer precedence holding
+      // across the poll's whole lifetime (same class as the followMode/isConnected
+      // re-checks above), not just the frame it was scheduled.
+      if (isOverlayFrozen()) return;
       const tail = listRef.lastElementChild as HTMLElement | null;
       const currScrollHeight = listRef.scrollHeight;
       const targetNodeHeight = tail?.offsetHeight ?? 0;
@@ -2625,7 +2634,25 @@ const ScrollbackPane: Component<Props> = (props) => {
   // channel's px onto it) and skips a no-op write. `target` is the px captured on
   // the open edge; `snapKey` the channel it was captured on.
   const applyOverlayRestore = (target: number, snapKey: string): void => {
-    if (!listRef || snapKey !== key() || listRef.scrollTop === target) return;
+    if (!listRef || snapKey !== key()) return;
+    // #608 (regression fix) — reconcile the follow INTENT with the reader's
+    // trusted position. The snapshot is the authoritative position across the
+    // overlay's whole lifetime, so `followMode` must match whether it sits at the
+    // tail. Without this, a reader who scrolled up (snapshot mid-list) whose
+    // scroll-up `onScroll` edge was DROPPED by the freeze bail (a scroll racing
+    // the freeze engaging) is left with `followMode` stale-true; the deferred
+    // `tailFollowWhenSettled` poll — which gates on `followMode`, not the freeze —
+    // then fail-safe-tails the pane the instant the overlay closes, yanking the
+    // reader to the bottom (the #219 media-viewer close snap; e2e
+    // issue219-overlay-scroll-hold). Derived from the restored geometry — one-shot
+    // per overlay edge, NO separately-cleared latch (the freeze stays derived from
+    // the live `overlayCount()`). Runs even when the position is already held
+    // (`scrollTop === target`), so a scrolled-up reader whose px never moved still
+    // gets the stale intent corrected.
+    setFollowMode(
+      listRef.scrollHeight - target - listRef.clientHeight <= SCROLL_BOTTOM_THRESHOLD_PX,
+    );
+    if (listRef.scrollTop === target) return;
     const intent: ScrollIntent = { kind: "overlay-freeze", key: snapKey, lifetime: "sticky" };
     logScrollDecision("overlay-restore", [intent], intent, "overlay-restore");
     listRef.scrollTop = target;

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -38,6 +38,7 @@ import {
 } from "./lib/presenceFilter";
 import { canonicalQueryNick, openQueryWindowState } from "./lib/queryWindows";
 import { getReadCursor } from "./lib/readCursor";
+import { nextFollowMode } from "./lib/scrollAuthority";
 import {
   lastOwnSend,
   loadMore as loadMoreScrollback,
@@ -114,7 +115,7 @@ import WhowasCard from "./WhowasCard";
 //
 // C7.4: Scroll-to-bottom floating button — appears when scrolled more than
 // SCROLL_BOTTOM_THRESHOLD_PX from the tail. Click → instant scroll to the
-// tail + resume auto-follow (resets atBottom to true), AND (since #310) —
+// tail + resume auto-follow (re-arms followMode + atBottomNow), AND (since #310) —
 // like a manual scroll to the bottom — advances the read cursor to the newest
 // line and releases the marker-activation latch so the view does not snap back
 // to the divider. See `scrollToBottomGesture`.
@@ -326,7 +327,7 @@ const lastFullyVisibleRowId = (listRef: HTMLDivElement): number | null => {
   // BEFORE assigning it → the cursor lands one message short and the
   // channel keeps a phantom "1 unread" that re-appears on every leave.
   // Derive the SAME pane-level distance-to-bottom the authoritative
-  // `atBottom` signal uses (onScroll, below) — robust by construction
+  // `atBottomNow` geometry uses (onScroll, below) — robust by construction
   // against the rounding a per-row epsilon can't fix — and return the
   // DOM true-tail id directly. The true tail is always >= the geometric-
   // walk id, so the forward-only `setCursorIfAdvances` gate is preserved
@@ -951,7 +952,25 @@ const ScrollbackPane: Component<Props> = (props) => {
   // Both the freeze gate and the restore require this === key(); a switched-to
   // window activates normally. `null` when no overlay snapshot is held.
   let overlaySnapshotKey: string | null = null;
-  const [atBottom, setAtBottom] = createSignal(true);
+  // #608 (deep-review §6.1) — the overloaded `atBottom` split into its two
+  // independent concerns, the PRIMARY reshape of the single-scroll-authority
+  // work:
+  //   * `followMode` — the persistent "stick to the tail" INTENT. Drives
+  //     tail-follow (the length-effect gate), the resize re-anchor gate, and
+  //     the visibility-return gate. Transitions ONLY via `nextFollowMode`
+  //     edges (lib/scrollAuthority): an operator scroll-up turns it OFF;
+  //     reaching the tail or an own send turns it back ON; a programmatic
+  //     content-grow above the fold leaves it unchanged (the #168 distinction —
+  //     a prepend is not a leave).
+  //   * `atBottomNow` — the GEOMETRIC measurement (within threshold of the
+  //     tail). Drives ONLY the floating scroll-to-bottom button (`!atBottomNow`).
+  // Conflating the two was the source of the R-B/R-C races the leave-arm
+  // documents as "atBottom unreliable here". Both default true (a fresh pane
+  // follows the tail; the button is hidden). Until the send/settle reshapes
+  // land they are written together — this split is the foundation those later
+  // steps build the divergence on.
+  const [followMode, setFollowMode] = createSignal(true);
+  const [atBottomNow, setAtBottomNow] = createSignal(true);
   // #285 reopen — FAIL-OPEN touch-action gate. The CSS base is `pan-y`; this
   // signal drives the `.scrollback-locked` class that LOCKS the pane to
   // `touch-action: none` ONLY when a trustworthy measurement proves the content
@@ -982,7 +1001,7 @@ const ScrollbackPane: Component<Props> = (props) => {
   // recreation). A one-shot marker jump therefore does NOT survive the next
   // rows recreation — the post-switch catch-up `refreshScrollback`
   // (selection.ts) or a late read-cursor hydration recreates the DOM AFTER the
-  // jump, and because the jump set `atBottom=false` the length-effect's only
+  // jump, and because the jump set `followMode=false` the length-effect's only
   // re-establish path is suppressed → the marker strands off-screen (the 307
   // race). This latch marks "a channel activation is in effect; keep
   // re-asserting marker-or-tail on every rows recreation until the operator
@@ -990,7 +1009,7 @@ const ScrollbackPane: Component<Props> = (props) => {
   // app-startup / first-focus jumps to the marker too — vjt point-2, reverses
   // the #46 cold-mount-tail wontfix); cleared on real operator input or an own
   // send (both hand scroll authority back). Visibility-return / resize stay
-  // tail-only one-shot — their `atBottom=true` means the length-effect's
+  // tail-only one-shot — their `followMode=true` means the length-effect's
   // tail-follow already re-establishes them, no latch needed.
   const [markerActivationPending, setMarkerActivationPending] = createSignal(false);
 
@@ -1053,7 +1072,7 @@ const ScrollbackPane: Component<Props> = (props) => {
   // of mentions (own nick ∪ /hilight keywords, #370) currently below the fold
   // in THIS window; its length is the badge count, its head (`[0]`) the next
   // jump target. DERIVED from live geometry + scroll position (neither is a
-  // Solid signal), so it is recomputed at the same edges `atBottom` is: every
+  // Solid signal), so it is recomputed at the same edges `atBottomNow` is: every
   // onScroll (operator scroll AND the settle scrolls that activation /
   // message-arrival fire) and, belt-and-suspenders, after each rows()
   // recreation via rAF (a rows change that lands without a scroll event still
@@ -1519,22 +1538,23 @@ const ScrollbackPane: Component<Props> = (props) => {
     //
     // REUSE the length-effect's irssi-shape follow rule (~:2033), do
     // not invent a parallel one:
-    //   * atBottom() true  → the operator was following live; re-pin to
+    //   * followMode() true  → the operator was following live; re-pin to
     //     the tail (a shrinking viewport keeps the bottom visible) =
     //     resume family → TAIL, never the divider (#46), one-shot, no
     //     latch.
-    //   * atBottom() false → PRESERVE their scrollTop: do nothing, the
+    //   * followMode() false → PRESERVE their scrollTop: do nothing, the
     //     browser holds scrollTop across the clientHeight change (a
     //     shrink never clamps; content still overflows).
-    // atBottom() flips false ONLY on a real operator scroll-UP
-    // (onScroll, ~:2242), so it is an honest "parked above the tail"
-    // signal HERE — unlike the leave-arm at ~:1593, whose caveat is a
-    // key-change batch where a sibling activation effect races
-    // setAtBottom(true); a resize is not a key change, so atBottom() is
-    // trustworthy (the length-effect trusts it the same way).
+    // #608 — the resize gate reads the follow INTENT (`followMode`), not the
+    // geometric `atBottomNow`: it turns false ONLY on a real operator scroll-UP
+    // (onScroll), so it is an honest "parked above the tail" signal HERE —
+    // unlike the leave-arm below, whose caveat is a key-change batch where a
+    // sibling activation effect re-arms follow; a resize is not a key change,
+    // so `followMode()` is trustworthy (the length-effect trusts it the same
+    // way).
     //
     // #245 — ALSO re-measure the gate on resize, UNCONDITIONALLY: it runs
-    // BEFORE the atBottom() gate above, regardless of scroll position.
+    // BEFORE the followMode() gate above, regardless of scroll position.
     // `scrollLocked` drives the `.scrollback-locked` class (#285 reopen:
     // fail-open base `pan-y`, lock to `none` only on a trustworthy fit). The
     // gate is a function of `clientHeight`, which is viewport-derived (the
@@ -1559,7 +1579,7 @@ const ScrollbackPane: Component<Props> = (props) => {
       // driven recompute. Matters most on mobile: the keyboard opening while the
       // operator is parked mid-buffer must not strand a stale badge.
       recomputeMentionsBelow();
-      if (atBottom()) scrollToActivation("tail-only", true);
+      if (followMode()) scrollToActivation("tail-only", true);
     };
     window.addEventListener("resize", onResize);
     window.visualViewport?.addEventListener("resize", onResize);
@@ -1779,8 +1799,8 @@ const ScrollbackPane: Component<Props> = (props) => {
   //   3. `document.visibilitychange` → visible — PWA backgrounded then
   //      re-opened (the effect below tracks `isDocumentVisible` false→true).
   //      GATED on the follow-state at hide time (#535), no latch: resume ≠
-  //      switch (#46). atBottom() true → "tail-only" (the reader was following
-  //      live). atBottom() false → "marker-or-preserve" (the reader had
+  //      switch (#46). followMode() true → "tail-only" (the reader was following
+  //      live). followMode() false → "marker-or-preserve" (the reader had
   //      deliberately scrolled up; land on the divider or hold their scrollTop
   //      — NEVER tail-snap them).
   //
@@ -1804,15 +1824,16 @@ const ScrollbackPane: Component<Props> = (props) => {
   // the send-race (DESIGN_NOTES 2026-07-03):
   //   * "marker-or-tail" — channel activation (SWITCH + cold-mount). If the
   //     RENDERED frozen unread divider exists, scroll to it (`block:"start"`)
-  //     and set `atBottom` from the resulting distance; else the tail. The
-  //     divider is the frozen row the `rows()` memo already injected — we
-  //     read its DOM node, never a recomputed cursor geometry. While the latch
+  //     and set `followMode`/`atBottomNow` from the resulting distance; else the
+  //     tail. The divider is the frozen row the `rows()` memo already injected —
+  //     we read its DOM node, never a recomputed cursor geometry. While the latch
   //     is set the length-effect re-asserts this on every rows recreation, so
   //     the post-switch catch-up refresh / late cursor hydration can't strand
   //     it (307). Cleared on operator input / own send.
   //   * "tail-only" — resize (#46 resume family) + the follow-live arm of
-  //     visibility-return. Never the divider; `atBottom=true`; no latch (the
-  //     length-effect's `atBottom` tail-follow already re-establishes the tail).
+  //     visibility-return. Never the divider; `followMode`/`atBottomNow=true`; no
+  //     latch (the length-effect's `followMode` tail-follow already re-establishes
+  //     the tail).
   //   * "marker-or-preserve" — the scrolled-up arm of visibility-return (#535).
   //     Same marker DOM read as "marker-or-tail", but when NO divider renders it
   //     PRESERVES the reader's scrollTop instead of tailing. It is safe to skip
@@ -1823,7 +1844,7 @@ const ScrollbackPane: Component<Props> = (props) => {
   //     untouched. The sibling `refreshScrollback` (fired one line before this)
   //     is an ASYNC co-trigger that CAN recompute `rows()` later by appending
   //     rows missed while hidden, but a TAIL append preserves a scrolled-up
-  //     reader's position (the length-effect's `atBottom` gate does nothing +
+  //     reader's position (the length-effect's `followMode` gate does nothing +
   //     browser scroll anchoring holds the viewport) — empirically pinned by the
   //     #535 "messages missed while hidden" e2e case, not just asserted here. No
   //     latch (one-shot resume). Owner ruling 2026-07-29 (#535): the only
@@ -1832,9 +1853,9 @@ const ScrollbackPane: Component<Props> = (props) => {
   // Post-send / live-append stay at the BOTTOM via the length-effect +
   // `lastOwnSend`→`scrollToBottom` (both untouched; the send clears the latch
   // first). The divider still RENDERS at its frozen position (freeze-display
-  // contract, DESIGN_NOTES 2026-06-08) for every trigger. `atBottom` is set
+  // contract, DESIGN_NOTES 2026-06-08) for every trigger. `atBottomNow` is set
   // per branch so the floating "scroll to bottom" button doesn't flash
-  // mid-activation.
+  // mid-activation (and `followMode` alongside it drives the tail-follow gate).
   // `withHide` (#130 flicker gate) applies ONLY to the initial establish from
   // an activation trigger — a cross-key window swap paints the new content at
   // the old preserved scrollTop before the deferred scroll corrects it, so we
@@ -1919,24 +1940,26 @@ const ScrollbackPane: Component<Props> = (props) => {
             : null;
         if (marker?.scrollIntoView) {
           marker.scrollIntoView({ block: "start" });
-          // Set `atBottom` from the settled distance (layout is stable inside
-          // the rAF×2). A far divider ⇒ false: the floating "scroll to
-          // bottom" button shows AND the length-effect's `if (!atBottom())
-          // return` guard yields, so its tail-follow does not race this jump
-          // (same atBottom coordination the pre-#168 marker branch used). A
-          // near-tail divider (tiny unread) ⇒ true: effectively at the
-          // bottom, tail-follow is correct.
+          // Set both concerns from the settled distance (layout is stable
+          // inside the rAF×2). A far divider ⇒ false: `followMode` off so the
+          // length-effect's `if (!followMode()) return` guard yields (its
+          // tail-follow does not race this jump) AND `atBottomNow` off so the
+          // floating "scroll to bottom" button shows. A near-tail divider (tiny
+          // unread) ⇒ true: effectively at the bottom, tail-follow is correct.
           const distance = listRef.scrollHeight - listRef.scrollTop - listRef.clientHeight;
-          setAtBottom(distance <= SCROLL_BOTTOM_THRESHOLD_PX);
+          const near = distance <= SCROLL_BOTTOM_THRESHOLD_PX;
+          setFollowMode(near);
+          setAtBottomNow(near);
         } else if (mode === "marker-or-preserve") {
           // #535 — scrolled-up visibility-return with NO divider to land on
           // (e.g. a fully-read channel the reader paged up into). The re-latch
           // left `markerCursorId` — hence this synchronous `rows()`, hence
           // scrollTop — untouched. PRESERVE the reader's position: do NOT
-          // tail-snap, and leave `atBottom` false (they are still parked above
-          // the tail). Nothing to scroll here. (A later async `refreshScrollback`
-          // append can still recompute `rows()`, but a tail append preserves a
-          // scrolled-up viewport — guarded by the #535 gap e2e case.)
+          // tail-snap, and leave `followMode`/`atBottomNow` false (they are
+          // still parked above the tail). Nothing to scroll here. (A later async
+          // `refreshScrollback` append can still recompute `rows()`, but a tail
+          // append preserves a scrolled-up viewport — guarded by the #535 gap
+          // e2e case.)
         } else {
           const tail = listRef.lastElementChild as HTMLElement | null;
           if (tail?.scrollIntoView) {
@@ -1944,7 +1967,8 @@ const ScrollbackPane: Component<Props> = (props) => {
           } else {
             listRef.scrollTop = listRef.scrollHeight;
           }
-          setAtBottom(true);
+          setFollowMode(true);
+          setAtBottomNow(true);
         }
         // Scroll has settled at the correct position — reveal.
         if (withHide) setActivating(false);
@@ -1973,10 +1997,12 @@ const ScrollbackPane: Component<Props> = (props) => {
   // assigns `prevInput`, so the first real change carries a DEFINED
   // `prevKey` and the arm runs.
   //
-  // Which id: NOT `atBottom()`. That signal is unreliable HERE — the
-  // sibling activation effect runs in the SAME key-change batch and
-  // `setAtBottom(true)`s before this arm reads it (instrumentation caught
-  // `atBottom() === true` while the leaving pane sat 407px off the bottom).
+  // Which id: NOT the follow/geometry signals. They are unreliable HERE — the
+  // sibling activation effect runs in the SAME key-change batch and re-arms
+  // `followMode`/`atBottomNow` true before this arm reads them (instrumentation
+  // caught the old conflated `atBottom() === true` while the leaving pane sat
+  // 407px off the bottom; the #608 split keeps the same caveat — the batch
+  // re-arm is the reason, not the conflation).
   // Use the leaving pane's OWN captured onScroll `visibleTailSnapshot`
   // instead (a post-hoc `lastFullyVisibleRowId(listRef)` can't be used —
   // Solid's `<For>` has already swapped rows to the new key). At the bottom
@@ -2042,23 +2068,24 @@ const ScrollbackPane: Component<Props> = (props) => {
         // every window activation. The `[data-testid="scrollback"]`
         // <div> is the SAME DOM node across kind transitions (Shell.tsx
         // bundles channel|query|server into ONE Match), so its
-        // `scrollTop` survives the swap — and the `atBottom` signal,
-        // unless explicitly reset here, carries the LEAVING pane's
+        // `scrollTop` survives the swap — and the follow/geometry signals,
+        // unless explicitly reset here, carry the LEAVING pane's
         // user-scrolled-up state into the arriving pane. When the
         // arriving pane is cold (`messages()` empty/undefined),
-        // `scrollToActivation`'s rAF×2 body early-returns at :1089
-        // without resetting scroll OR `atBottom`. The length-effect
-        // at :1292 then reads stale `atBottom=false` once REST lands
-        // and skips the auto-snap, leaving the DOM at whatever
-        // scrollTop the browser preserved from the source pane. vjt
-        // prod-reported as "scroll contamination after few back and
+        // `scrollToActivation`'s rAF×2 body early-returns without resetting
+        // scroll OR the signals. The length-effect then reads stale
+        // `followMode=false` once REST lands and skips the auto-snap, leaving
+        // the DOM at whatever scrollTop the browser preserved from the source
+        // pane. vjt prod-reported as "scroll contamination after few back and
         // forths of focusing many windows". The auto-snap branch in
         // `scrollToActivation` writes the new pane's true bottom on
         // its own; if the operator scrolls up in the new pane, the
-        // first real onScroll restores `atBottom=false`. Re-arming
-        // here is therefore safe + correct — every activation starts
-        // tail-following, and the operator's own input takes it back.
-        setAtBottom(true);
+        // first real onScroll clears `followMode`. Re-arming both here is
+        // therefore safe + correct — every activation starts tail-following
+        // (followMode) with the button hidden (atBottomNow), and the operator's
+        // own input takes it back.
+        setFollowMode(true);
+        setAtBottomNow(true);
 
         // CP29 R-4: capture the boundary as the highest message id present
         // RIGHT NOW. `messages()` is the same store the rows memo reads;
@@ -2132,19 +2159,20 @@ const ScrollbackPane: Component<Props> = (props) => {
         void refreshScrollback(props.networkSlug, props.channelName);
         setMarkerCursorId(getReadCursor(props.networkSlug, props.channelName));
         // #535 — gate the resume scroll on the follow-state that was in effect
-        // when the document hid. `atBottom()` flips false ONLY on a real
-        // operator scroll-UP (onScroll), so it is an honest "the reader chose to
-        // leave the tail" signal — the SAME gate the resize re-anchor uses
-        // (onMount `onResize`). Both arms are one-shot with no latch: resume ≠
-        // switch, so only a channel activation (switch / cold-mount) latches a
-        // re-asserted marker jump (#168, 2026-07-03).
-        //   * atBottom() true  → the reader was following live → TAIL (#46).
-        //   * atBottom() false → the reader deliberately scrolled up mid-backlog
+        // when the document hid. `followMode()` (#608: the follow INTENT, not
+        // the geometric `atBottomNow`) turns false ONLY on a real operator
+        // scroll-UP (onScroll), so it is an honest "the reader chose to leave
+        // the tail" signal — the SAME gate the resize re-anchor uses (onMount
+        // `onResize`). Both arms are one-shot with no latch: resume ≠ switch, so
+        // only a channel activation (switch / cold-mount) latches a re-asserted
+        // marker jump (#168, 2026-07-03).
+        //   * followMode() true  → the reader was following live → TAIL (#46).
+        //   * followMode() false → the reader deliberately scrolled up mid-backlog
         //     → land on the re-latched divider if one renders, else PRESERVE
         //     their scrollTop. NEVER tail-snap them (the pre-#535 bug: the
         //     unconditional "tail-only" here dropped a mid-backlog reader at the
         //     tail on every return from an external link).
-        if (atBottom()) {
+        if (followMode()) {
           scrollToActivation("tail-only", true);
         } else {
           scrollToActivation("marker-or-preserve", true);
@@ -2166,7 +2194,7 @@ const ScrollbackPane: Component<Props> = (props) => {
   // just-sent line is visible ("send scrolls to the bottom unconditionally").
   // Clear the marker-activation latch FIRST so the length-effect's re-assert
   // can't fight the snap, THEN snap. `scrollToBottom` is the same tail
-  // authority the length-effect uses (scroll + atBottom=true); the WS-echo
+  // authority the length-effect uses (scroll + followMode/atBottomNow=true); the WS-echo
   // row that lands later is then followed by the length-effect. NOT event-type
   // branching — the send resets the follow-STATE and the single always-bottom
   // authority does the scrolling. Keyed: only a send to THIS pane's
@@ -2359,20 +2387,21 @@ const ScrollbackPane: Component<Props> = (props) => {
   // #168 (2026-07-02) — this length-effect (post-append / cursor-hydration)
   // is TAIL-ONLY and stays so. The former C7.3 scroll-to-marker branch here
   // was a second scrollTop authority that parked the viewport on the divider
-  // and set atBottom=false, so a send did not follow to the tail — removed.
-  // New content ⇒ bottom while following (atBottom); scrolled-up
-  // (atBottom=false) preserves position — irssi-shape, only the operator's
-  // own scroll leaves the tail. The scroll-to-marker jump was RESCOPED to the
-  // deliberate channel-SWITCH trigger inside `scrollToActivation`
-  // ("marker-or-tail" mode, #168 regression fix 2026-07-03) — NOT here: when
-  // a switch parks on the divider it sets atBottom=false first, so the
-  // `if (!atBottom()) return` guard below yields and never races that jump
-  // back to the tail. The frozen divider renders in place (DESIGN_NOTES
-  // 2026-06-08) for every trigger; this effect just never scrolls to it.
+  // and turned follow off, so a send did not follow to the tail — removed.
+  // New content ⇒ bottom while following (#608: gated on `followMode`);
+  // scrolled-up (followMode false) preserves position — irssi-shape, only the
+  // operator's own scroll leaves the tail. The scroll-to-marker jump was
+  // RESCOPED to the deliberate channel-SWITCH trigger inside
+  // `scrollToActivation` ("marker-or-tail" mode, #168 regression fix
+  // 2026-07-03) — NOT here: when a switch parks on the divider it sets
+  // `followMode=false` first, so the `if (!followMode()) return` guard below
+  // yields and never races that jump back to the tail. The frozen divider
+  // renders in place (DESIGN_NOTES 2026-06-08) for every trigger; this effect
+  // just never scrolls to it.
   //
-  // The `atBottom` gate stays honest through the #156 anchored initial load
+  // The `followMode` gate stays honest through the #156 anchored initial load
   // (which prepends the read-context page above the tail while following)
-  // because `onScroll` only flips `atBottom` false on a real scroll UP
+  // because `onScroll` only flips `followMode` false on a real scroll UP
   // (scrollTop decreases) — a content-grow-above keeps scrollTop put, so the
   // spurious scroll event it fires no longer lies "left the bottom" (#168).
   createEffect(
@@ -2428,16 +2457,16 @@ const ScrollbackPane: Component<Props> = (props) => {
         // (post-switch catch-up refresh, late read-cursor hydration inserting
         // the divider) must RE-ASSERT the marker jump; the ref-keyed `<For>`
         // reset scrollTop to 0 on this recreation and a one-shot jump would
-        // strand (the 307 bug — a far marker sets atBottom=false, which without
+        // strand (the 307 bug — a far marker sets followMode=false, which without
         // this branch suppresses ALL re-establish). Pre-paint (rAF×2,
         // withHide=false) so the reset frame is never shown.
         //
         // Gated on the marker actually EXISTING (not just the latch): when
         // there is no divider — a read channel's cold-mount, OR a scroll-up
-        // loadMore prepend on a read channel — we FALL THROUGH to the atBottom
+        // loadMore prepend on a read channel — we FALL THROUGH to the followMode
         // tail-follow below. That preserves the two cases correctly with ONE
-        // rule: initial cold-mount (atBottom=true) tails; a loadMore prepend
-        // after the operator scrolled up (atBottom=false) does nothing → the
+        // rule: initial cold-mount (followMode=true) tails; a loadMore prepend
+        // after the operator scrolled up (followMode=false) does nothing → the
         // prepend's own height-delta restore preserves position (cp14-b2). A
         // no-marker re-assert would instead TAIL and yank the prepend — the
         // oscillation this gate prevents. The latch still clears on operator
@@ -2446,7 +2475,7 @@ const ScrollbackPane: Component<Props> = (props) => {
           scrollToActivation("marker-or-tail", false);
           return;
         }
-        if (atBottom()) {
+        if (followMode()) {
           // Same scrollHeight-vs-layout race as scrollToActivation /
           // measureOverflow: reading scrollHeight synchronously inside
           // the Solid effect callback fires BEFORE the browser's layout
@@ -2462,7 +2491,7 @@ const ScrollbackPane: Component<Props> = (props) => {
           requestAnimationFrame(() => {
             requestAnimationFrame(() => {
               if (!listRef) return;
-              if (!atBottom()) return;
+              if (!followMode()) return;
               const tail = listRef.lastElementChild as HTMLElement | null;
               if (tail?.scrollIntoView) {
                 tail.scrollIntoView({ block: "end" });
@@ -2481,7 +2510,7 @@ const ScrollbackPane: Component<Props> = (props) => {
   // gesture (pointerdown / wheel / touchmove / scroll-keys) and reset to null
   // on key-change; a non-null transition means the operator is driving, so we
   // stop re-asserting the marker and hand scroll authority back (subsequent
-  // live appends then follow the `atBottom` rule below — preserve when scrolled
+  // live appends then follow the `followMode` rule below — preserve when scrolled
   // up, tail when at the bottom). The `null` guard skips the key-change reset
   // and the initial-mount run.
   createEffect(
@@ -2554,7 +2583,7 @@ const ScrollbackPane: Component<Props> = (props) => {
     if (listRef.scrollTop > LOAD_MORE_THRESHOLD_PX) return;
     // See the length-effect for how an active marker activation is kept from
     // yanking this (it re-asserts ONLY when a marker exists; a no-marker latch
-    // falls through to the atBottom-follow, which preserves here because the
+    // falls through to the followMode tail-follow, which preserves here because the
     // operator scrolled UP).
     const oldScrollHeight = listRef.scrollHeight;
     const oldScrollTop = listRef.scrollTop;
@@ -2630,8 +2659,8 @@ const ScrollbackPane: Component<Props> = (props) => {
     // event is an artifact of the ref-keyed <For> recreating the list DOM on a
     // rows() change (a message arriving under the overlay resets scrollTop to
     // 0), NOT operator intent: the modal + backdrop cover the pane, so the
-    // reader cannot scroll it. Acting on these artifacts flips `atBottom`,
-    // spuriously fires loadMore/loadNewer (whose prepend would STALE the
+    // reader cannot scroll it. Acting on these artifacts flips the follow +
+    // geometry signals, spuriously fires loadMore/loadNewer (whose prepend would STALE the
     // absolute-pixel freeze snapshot → wrong close-edge restore), snapshots a
     // bogus visible-tail, and advances the read cursor. Skip all of it; the
     // length-effect re-assert + the overlay-snapshot close restore own the
@@ -2639,24 +2668,29 @@ const ScrollbackPane: Component<Props> = (props) => {
     if (isOverlayFrozen()) return;
     const st = listRef.scrollTop;
     const distance = listRef.scrollHeight - st - listRef.clientHeight;
-    // #168 — the follow authority (`atBottom`) flips FALSE only on an
-    // operator scroll UP (scrollTop DECREASES). Reaching the tail (distance
-    // within threshold) always re-arms the follow. A programmatic content-
-    // grow ABOVE the viewport — the #156 anchored read-context page, or the
-    // WS join-ok `refreshScrollback` prepend, both landing while the pane is
+    // #168 / #608 — the follow INTENT (`followMode`) flips FALSE only on an
+    // operator scroll UP (scrollTop DECREASES); the GEOMETRIC `atBottomNow`
+    // tracks the same edges but drives only the button. Reaching the tail
+    // (distance within threshold) re-arms both. A programmatic content-grow
+    // ABOVE the viewport — the #156 anchored read-context page, or the WS
+    // join-ok `refreshScrollback` prepend, both landing while the pane is
     // following — fires a `scroll` event whose geometry shows a huge
     // distance-to-tail (older rows now sit above) even though scrollTop did
-    // NOT decrease. The old `setAtBottom(distance <= threshold)` treated
-    // that as "the operator left the bottom" and killed the always-bottom
-    // follow, stranding the pane mid-buffer on window open (P0 regression;
-    // ~1056px above the tail). Gating the false-flip on `st < lastScrollTop`
-    // keeps a prepend from lying about intent — only a real upward scroll
-    // (operator OR the programmatic scroll-to-top a loadMore test performs,
-    // both of which DECREASE scrollTop) leaves the tail.
+    // NOT decrease. Treating that as "the operator left the bottom" killed the
+    // always-bottom follow, stranding the pane mid-buffer on window open (P0
+    // regression; ~1056px above the tail). Gating the false-flip on
+    // `st < lastScrollTop` keeps a prepend from lying about intent — only a
+    // real upward scroll (operator OR the programmatic scroll-to-top a loadMore
+    // test performs, both of which DECREASE scrollTop) leaves the tail. The
+    // followMode edges route through `nextFollowMode` (lib/scrollAuthority, the
+    // SSOT transition table): reach-tail→on, scroll-up→off; the untouched
+    // middle branch is the table's content-grow no-op.
     if (distance <= SCROLL_BOTTOM_THRESHOLD_PX) {
-      setAtBottom(true);
+      setAtBottomNow(true);
+      setFollowMode(nextFollowMode(followMode(), "reach-tail"));
     } else if (st < lastScrollTop) {
-      setAtBottom(false);
+      setAtBottomNow(false);
+      setFollowMode(nextFollowMode(followMode(), "scroll-up"));
     }
     lastScrollTop = st;
 
@@ -2708,7 +2742,7 @@ const ScrollbackPane: Component<Props> = (props) => {
       // then would strand a late-hydration marker. A real operator scroll-down
       // to this boundary already clears the latch via the input gate; loadNewer
       // fetches only in the #156 >200-unread anchored case, where the length-
-      // effect's preserve (atBottom=false in the 50–200px band) still holds.
+      // effect's preserve (followMode=false in the 50–200px band) still holds.
       void loadNewerScrollback(props.networkSlug, props.channelName);
     }
 
@@ -2742,7 +2776,7 @@ const ScrollbackPane: Component<Props> = (props) => {
   };
 
   // C7.4: scroll-to-bottom click handler — forces scroll to tail and
-  // resumes auto-follow by setting atBottom(true).
+  // resumes auto-follow (#608: re-arms `followMode` + `atBottomNow`).
   //
   // 2026-06-02 (scroll-to-bottom button contamination): the snap is
   // INSTANT, not `behavior: "smooth"`. The `[data-testid="scrollback"]`
@@ -2765,7 +2799,8 @@ const ScrollbackPane: Component<Props> = (props) => {
     } else {
       listRef.scrollTop = listRef.scrollHeight;
     }
-    setAtBottom(true);
+    setFollowMode(true);
+    setAtBottomNow(true);
   };
 
   // #310 — the scroll-to-bottom GESTURE, shared by the floating button's
@@ -3088,7 +3123,7 @@ const ScrollbackPane: Component<Props> = (props) => {
         <Show when={isMobile()}>
           <NextActiveButton variant="mobile" />
         </Show>
-        <Show when={!atBottom()}>
+        <Show when={!atBottomNow()}>
           <button
             type="button"
             class="scroll-to-bottom-btn"

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -38,7 +38,7 @@ import {
 } from "./lib/presenceFilter";
 import { canonicalQueryNick, openQueryWindowState } from "./lib/queryWindows";
 import { getReadCursor } from "./lib/readCursor";
-import { nextFollowMode, resolveIntent, type ScrollIntent } from "./lib/scrollAuthority";
+import { isSettled, nextFollowMode, resolveIntent, type ScrollIntent } from "./lib/scrollAuthority";
 import {
   lastOwnSend,
   loadMore as loadMoreScrollback,
@@ -192,6 +192,15 @@ const LOAD_MORE_THRESHOLD_PX = 200;
 // gate against the settled geometry a few hundred ms after mount, bracketing a
 // fast and a slower settle. Belt-and-suspenders on top of the fail-open base.
 const SETTLE_REMEASURE_DELAYS_MS = [150, 500] as const;
+
+// #608 STEP 6 — bounded-wait cap for the measured-settle tail-follow. Each frame
+// forces a reflow and re-checks `isSettled`; if the appended content never
+// registers a measurable growth (an in-place rows change — e.g. a marker-row
+// toggle — or an already-at-tail replacement), the write fails SAFE after this
+// many frames and tails once, so a tail is never stranded waiting on a settle
+// that will not come. ~30 frames ≈ 500ms @60fps: generous headroom for a slow
+// iOS layout flush, still a hard bound (condition-based-waiting: bounded).
+const SETTLE_MAX_FRAMES = 30;
 
 // #230 — the pure underfill-rescue DECISION seam, shared by the desktop wheel
 // path and the mobile touch path (implement-once). Both detect an operator
@@ -934,6 +943,16 @@ const ScrollbackPane: Component<Props> = (props) => {
   // UP (scrollTop decreased → leave the tail) from a programmatic content-
   // grow above the viewport (scrollTop unchanged → keep following).
   let lastScrollTop = 0;
+  // #608 STEP 6 — the scrollHeight at the LAST tail-follow write: the baseline
+  // the measured-settle `isSettled` compares the current extent against. Using
+  // the last-tail extent (NOT a dispatch-time read, which on a fast engine
+  // already includes the just-appended row — reading scrollHeight forces layout —
+  // leaving nothing to detect as "grew") makes the settle exit reachable on BOTH
+  // a deferred iOS layout AND an immediate chromium one: "grew since we last
+  // tailed" is true the frame the new row's box lands. Reset to 0 on key change
+  // so a switched-to pane's first tail always registers growth (extent > 0).
+  // Plain let — pure mutation, no Solid reactivity.
+  let lastTailScrollHeight = 0;
   // #196 / #219-general — scrollTop snapshot captured when ANY covering
   // overlay opens, re-asserted across the overlay's open/close so a covered
   // pane never strands the reader (see the effect near the activation block
@@ -2071,6 +2090,11 @@ const ScrollbackPane: Component<Props> = (props) => {
         // must not inherit the leaving pane's timestamp.
         setLastInputEventAtMs(null);
 
+        // #608 STEP 6 — reset the measured-settle baseline for the arriving pane
+        // (a different channel has a different extent). 0 ⇒ its first tail-follow
+        // registers growth (real extent > 0) and settles once the tail lays out.
+        lastTailScrollHeight = 0;
+
         // 2026-06-01 (scroll-contamination fix): re-arm auto-follow on
         // every window activation. The `[data-testid="scrollback"]`
         // <div> is the SAME DOM node across kind transitions (Shell.tsx
@@ -2427,9 +2451,53 @@ const ScrollbackPane: Component<Props> = (props) => {
     });
   };
 
+  // #608 STEP 6 — the tail-follow's MEASURED-settle wait. Replaces the fixed
+  // rAF×2 (not a layout flush on iOS WebKit — it read the just-committed node's
+  // pre-layout geometry and scrolled to the PREVIOUS tail, the #608 §5
+  // off-by-one). Each frame forces a synchronous reflow (reading `scrollHeight` +
+  // the tail's `offsetHeight` are layout properties) and re-checks the pure
+  // `isSettled` core against the last-tail baseline: the extent has GROWN since we
+  // last tailed AND the new tail row has a laid-out box. Scrolls the frame that
+  // holds, updating the baseline. Bounded by `SETTLE_MAX_FRAMES` (fail-safe: a
+  // rows change with no measurable growth still tails once — never strands).
+  // Re-checks `followMode()`/`listRef` each frame (the operator may scroll up, or
+  // the pane unmount, mid-wait). condition-based-waiting: wait for the real
+  // layout state, not two guessed frames.
+  const tailFollowWhenSettled = (): void => {
+    let frame = 0;
+    const step = (): void => {
+      // Stop if the pane unmounted mid-wait: `listRef` is not nulled on cleanup,
+      // so gate on DOM attachment — otherwise a poll outliving the component
+      // keeps firing on the detached node (and, since scrollIntoView is a
+      // prototype method, would pollute a later-mounted pane's spy under test).
+      if (!listRef?.isConnected) return;
+      if (!followMode()) return;
+      const tail = listRef.lastElementChild as HTMLElement | null;
+      const currScrollHeight = listRef.scrollHeight;
+      const targetNodeHeight = tail?.offsetHeight ?? 0;
+      const settled = isSettled({
+        prevScrollHeight: lastTailScrollHeight,
+        currScrollHeight,
+        targetNodeHeight,
+      });
+      if (settled || frame >= SETTLE_MAX_FRAMES) {
+        if (tail?.scrollIntoView) {
+          tail.scrollIntoView({ block: "end" });
+        } else {
+          listRef.scrollTop = listRef.scrollHeight;
+        }
+        lastTailScrollHeight = listRef.scrollHeight;
+        return;
+      }
+      frame += 1;
+      requestAnimationFrame(step);
+    };
+    requestAnimationFrame(step);
+  };
+
   // Perform the winning intent's DOM write. Each kind keeps the exact timing its
-  // pre-applier writer used (rAF×2 where geometry must settle after the <For>
-  // commit — STEP 6 replaces that with the measured-settle predicate). The
+  // pre-applier writer used (rAF×2 / instant where geometry must settle after the
+  // <For> commit; tail-follow now uses the measured-settle wait above). The
   // caller guarantees `listRef` is non-null on entry, but the deferred rAF
   // bodies re-check it (it can null on unmount between frames).
   const dispatchScrollWrite = (winner: ScrollIntent): void => {
@@ -2463,23 +2531,11 @@ const ScrollbackPane: Component<Props> = (props) => {
         scrollToActivation("marker-or-tail", false);
         return;
       case "tail-follow":
-        // W5 — stick to the tail. rAF×2 so layout has settled before the read;
-        // `lastElementChild.scrollIntoView` is layout-aware even when
-        // scrollHeight bookkeeping is mid-update (the fallback covers an empty
-        // list). Re-check `followMode()` in the rAF — the operator may have
-        // scrolled up between the decision and the frame.
-        requestAnimationFrame(() =>
-          requestAnimationFrame(() => {
-            if (!listRef) return;
-            if (!followMode()) return;
-            const tail = listRef.lastElementChild as HTMLElement | null;
-            if (tail?.scrollIntoView) {
-              tail.scrollIntoView({ block: "end" });
-            } else {
-              listRef.scrollTop = listRef.scrollHeight;
-            }
-          }),
-        );
+        // W5 — stick to the tail via the MEASURED-settle wait (#608 STEP 6),
+        // replacing the fixed rAF×2 which is not a layout flush on iOS WebKit and
+        // scrolled to the STALE pre-layout tail (the #608 §5 off-by-one). See
+        // `tailFollowWhenSettled` — it re-checks `followMode()` each frame.
+        tailFollowWhenSettled();
         return;
       case "operator-tail": {
         // W7 — the explicit operator tail (scroll-to-bottom button / #243 re-tap /

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -1756,25 +1756,21 @@ const ScrollbackPane: Component<Props> = (props) => {
         }
         const target = overlayScrollSnapshot;
         const snapKey = overlaySnapshotKey;
-        if (target === null) return;
+        if (target === null || snapKey === null) return;
+        // Re-assert across rAF×2 (matching scrollToActivation's frame budget so
+        // it lands after the overlay's layout commits) via the applier's W1
+        // restore entrypoint — the single owner of this write, key-guarded there.
+        //
+        // #608 (deep-review §6.2) — NO snapshot clear. The freeze is DERIVED from
+        // the live `overlayCount()` (see `isOverlayFrozen`), so the snapshot no
+        // longer doubles as the freeze flag; it is only the px to restore,
+        // harmlessly stale once the count hits 0 and re-captured on the next open
+        // edge. Dropping the clear removes the separately-cleared latch that could
+        // drift from the count — the review's PLAUSIBLE stale-clear race (a
+        // close→reopen nulling a just-re-armed snapshot) is now structurally
+        // impossible, as is the field-bug "frozen forever under a leaked count".
         requestAnimationFrame(() =>
-          requestAnimationFrame(() => {
-            // Only restore onto the SAME window the snapshot was taken on —
-            // a mid-overlay channel switch (nick-click in /names or /who)
-            // owns its own activation; do not stamp the old offset onto it.
-            if (listRef && snapKey === key() && listRef.scrollTop !== target) {
-              listRef.scrollTop = target;
-            }
-            // #608 (deep-review §6.2) — NO snapshot clear. The freeze is now
-            // DERIVED from the live `overlayCount()` (see `isOverlayFrozen`), so
-            // the snapshot no longer doubles as the freeze flag; it is only the
-            // px to restore, harmlessly stale once the count hits 0 and re-
-            // captured on the next open edge. Dropping the clear removes the
-            // separately-cleared latch that could drift from the count — the
-            // review's PLAUSIBLE stale-clear race (a close→reopen nulling a
-            // just-re-armed snapshot) is now structurally impossible, as is the
-            // field-bug "frozen forever under a leaked count".
-          }),
+          requestAnimationFrame(() => applyOverlayRestore(target, snapKey)),
         );
       },
       { defer: true },
@@ -2530,6 +2526,22 @@ const ScrollbackPane: Component<Props> = (props) => {
     // The prepended rows sit ABOVE the viewport, so shifting scrollTop by the
     // growth keeps the row the reader was looking at in the same on-screen spot.
     listRef.scrollTop = newScrollHeight - oldScrollHeight + oldScrollTop;
+  };
+
+  // #608 (deep-review §6.2) — the W1 overlay-restore applier entrypoint: the
+  // overlay-freeze intent's RESTORE. Called from the overlay effect on BOTH
+  // refcount edges (the open-edge re-assert under the overlay + the close-edge
+  // final restore), so — UNLIKE the commit-frame overlay-freeze dispatch, which
+  // requires `isOverlayFrozen()` (count>0) — it must NOT gate on the live freeze:
+  // on the close edge the count is already 0. It gates only on the KEY (a
+  // mid-overlay channel switch owns its own activation; never stamp the leaving
+  // channel's px onto it) and skips a no-op write. `target` is the px captured on
+  // the open edge; `snapKey` the channel it was captured on.
+  const applyOverlayRestore = (target: number, snapKey: string): void => {
+    if (!listRef || snapKey !== key() || listRef.scrollTop === target) return;
+    const intent: ScrollIntent = { kind: "overlay-freeze", key: snapKey, lifetime: "sticky" };
+    logScrollDecision("overlay-restore", [intent], intent, "overlay-restore");
+    listRef.scrollTop = target;
   };
 
   // After Solid commits new DOM nodes, scroll to the tail iff the user

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -2504,6 +2504,34 @@ const ScrollbackPane: Component<Props> = (props) => {
     if (winner) dispatchScrollWrite(winner);
   };
 
+  // #608 (deep-review §6.4) — the prepend-preserve applier entrypoint. UNLIKE
+  // the commit-frame intents, loadMore preserve is POST-AWAIT: an older page is
+  // fetched, PREPENDED, and the reader's on-screen row must stay put across that
+  // mutation. It is a DISTINCT entrypoint (not `resolveIntent` at the commit
+  // frame) because the restore needs the geometry captured BEFORE the await and
+  // runs on the commit AFTER the prepend lands — the commit-frame length-effect
+  // already ran for that same rows() change and, per the followMode gate, left a
+  // scrolled-up reader in place. `prepend-preserve` is the LOWEST precedence in
+  // the array: it never fights a higher authority because it fires only on the
+  // operator's own scroll-to-top / #230 underfill-rescue, when nothing higher is
+  // arming. The single owner of the W6 write; logs via the shared dev-log.
+  // `oldScrollHeight` / `oldScrollTop` are the geometry captured pre-await.
+  const applyPrependPreserve = (oldScrollHeight: number, oldScrollTop: number): void => {
+    if (!listRef) return;
+    const intent: ScrollIntent = { kind: "prepend-preserve", key: key(), lifetime: "one-shot" };
+    const newScrollHeight = listRef.scrollHeight;
+    if (newScrollHeight === oldScrollHeight) {
+      // No growth (empty / already-exhausted page) — nothing prepended, nothing
+      // to preserve.
+      logScrollDecision("prepend-preserve", [intent], null, "no-growth");
+      return;
+    }
+    logScrollDecision("prepend-preserve", [intent], intent, "prepend-preserve");
+    // The prepended rows sit ABOVE the viewport, so shifting scrollTop by the
+    // growth keeps the row the reader was looking at in the same on-screen spot.
+    listRef.scrollTop = newScrollHeight - oldScrollHeight + oldScrollTop;
+  };
+
   // After Solid commits new DOM nodes, scroll to the tail iff the user
   // was at the bottom before the update (auto-follow). The effect tracks
   // `rows().length` so it re-runs on every append AND on cursor
@@ -2622,10 +2650,10 @@ const ScrollbackPane: Component<Props> = (props) => {
   // jump to the new top (scrollTop=0 stays pinned) — where they were already
   // looking — or stay numerically pinned to scrollTop=N relative to the OLD
   // scrollHeight, which is now a different position relative to the new
-  // content. We capture (scrollHeight, scrollTop) BEFORE the await, then after
-  // merge restore as `newScrollHeight - oldScrollHeight + oldScrollTop` so the
-  // rows the user was looking at remain in the same on-screen position. DOM
-  // mutation lives here in the component; lib/scrollback.ts stays DOM-free.
+  // content. We capture (scrollHeight, scrollTop) BEFORE the await, then the
+  // #608 applier's post-await `applyPrependPreserve` restores the reader's row
+  // via the height delta (see its doc). DOM mutation lives here in the
+  // component; lib/scrollback.ts stays DOM-free.
   const maybeLoadOlder = (): void => {
     if (!listRef) return;
     if (listRef.scrollTop > LOAD_MORE_THRESHOLD_PX) return;
@@ -2635,12 +2663,9 @@ const ScrollbackPane: Component<Props> = (props) => {
     // operator scrolled UP).
     const oldScrollHeight = listRef.scrollHeight;
     const oldScrollTop = listRef.scrollTop;
-    void loadMoreScrollback(props.networkSlug, props.channelName).then(() => {
-      if (!listRef) return;
-      const newScrollHeight = listRef.scrollHeight;
-      if (newScrollHeight === oldScrollHeight) return;
-      listRef.scrollTop = newScrollHeight - oldScrollHeight + oldScrollTop;
-    });
+    void loadMoreScrollback(props.networkSlug, props.channelName).then(() =>
+      applyPrependPreserve(oldScrollHeight, oldScrollTop),
+    );
   };
 
   const onWheel = (e: WheelEvent): void => {

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -941,9 +941,11 @@ const ScrollbackPane: Component<Props> = (props) => {
   // trigger from the media-viewer signal to the shared overlay refcount
   // (`overlayCount()`) — every covering modal/drawer already pushes into it,
   // so a single derived predicate ("a covering overlay is open") drives the
-  // freeze instead of one flag per modal. Plain let — pure mutation, no Solid
-  // reactivity; the reactive edge is the `overlayCount() > 0` memo in the
-  // effect below.
+  // freeze instead of one flag per modal. #608 (deep-review §6.2): this is now
+  // ONLY the px to restore — the freeze itself derives from the live
+  // `overlayCount()` in `isOverlayFrozen`, NOT from this being non-null — so it
+  // is captured on each open edge and left harmlessly stale after close (no
+  // clear). Plain let — pure mutation, no Solid reactivity.
   let overlayScrollSnapshot: number | null = null;
   // #219-general — the channel key the overlay snapshot was captured on. The
   // pane instance survives channel↔query switches (shared non-keyed Match), so
@@ -1092,17 +1094,28 @@ const ScrollbackPane: Component<Props> = (props) => {
 
   const key = () => channelKey(props.networkSlug, props.channelName);
   const messages = () => scrollbackByChannel()[key()];
-  // #219-general — "is THIS pane frozen under a covering overlay?" A snapshot
-  // is held (non-null) for the overlay's whole open→close-settle window, and
-  // it belongs to the channel it was captured on. Both scroll authorities
-  // (scrollToActivation + the length-effect) bail on this so no authority
-  // moves a covered pane; the overlay-snapshot effect owns the single restore.
+  // #219-general / #608 (deep-review §6.2) — "is THIS pane frozen under a
+  // covering overlay?" DERIVED from the LIVE overlay refcount, not a separately-
+  // cleared latch: a covering overlay is up NOW (`overlayCount() > 0`) and the
+  // snapshot belongs to the channel it was captured on (`overlaySnapshotKey ===
+  // key()`). Both scroll authorities (scrollToActivation + the length-effect)
+  // bail on this so no authority moves a covered pane; the overlay-snapshot
+  // effect owns the single restore.
+  //
+  // Pre-#608 this read `overlayScrollSnapshot !== null` — a latch cleared
+  // separately inside the overlay effect's rAF (gated on `overlayCount() === 0`).
+  // That parallel latch could DRIFT from the count: a leaked refcount (the
+  // Shell.tsx same-tick open→close, fixed in C1) meant the clear never fired and
+  // the pane stayed frozen for the session (the field bug). Deriving the freeze
+  // from the count makes that drift class structurally impossible ("derive,
+  // don't duplicate") and thaws the pane the instant the last overlay closes,
+  // without waiting on the deferred clear.
+  //
   // Key-scoped so a window switched-to WHILE an overlay is up (nick-click in
   // /names or /who opens a query + dismisses the modal) is not frozen — it
-  // activates normally. Plain-`let` reads, no reactivity (called imperatively
-  // from inside the authorities).
-  const isOverlayFrozen = (): boolean =>
-    overlayScrollSnapshot !== null && overlaySnapshotKey === key();
+  // activates normally. `overlayCount()` is reactive but read imperatively here
+  // (from inside the authorities), not in a tracking scope.
+  const isOverlayFrozen = (): boolean => overlayCount() > 0 && overlaySnapshotKey === key();
   // Per-network IRC nick for self-highlight + JOIN-banner + ownModes —
   // single-source via `ownNickForNetwork(net, me)` so account-name vs
   // IRC-nick drift cannot misfire highlights or own-action detection.
@@ -1752,18 +1765,15 @@ const ScrollbackPane: Component<Props> = (props) => {
             if (listRef && snapKey === key() && listRef.scrollTop !== target) {
               listRef.scrollTop = target;
             }
-            // Clear ONLY when no overlay is open NOW — not on the captured
-            // `open` boolean. A rapid close→reopen (refcount 1→0→1 in one
-            // frame batch — one modal closing as another opens) schedules
-            // this close-run's rAF BEFORE the reopen-run's; keying the clear
-            // on the stale `open=false` would null the snapshot the reopen
-            // just re-armed, thawing the pane while an overlay is still up
-            // (review PLAUSIBLE finding). `overlayCount() === 0` is the live
-            // truth: clear only when the last overlay is genuinely gone.
-            if (overlayCount() === 0) {
-              overlayScrollSnapshot = null;
-              overlaySnapshotKey = null;
-            }
+            // #608 (deep-review §6.2) — NO snapshot clear. The freeze is now
+            // DERIVED from the live `overlayCount()` (see `isOverlayFrozen`), so
+            // the snapshot no longer doubles as the freeze flag; it is only the
+            // px to restore, harmlessly stale once the count hits 0 and re-
+            // captured on the next open edge. Dropping the clear removes the
+            // separately-cleared latch that could drift from the count — the
+            // review's PLAUSIBLE stale-clear race (a close→reopen nulling a
+            // just-re-armed snapshot) is now structurally impossible, as is the
+            // field-bug "frozen forever under a leaked count".
           }),
         );
       },

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -1856,9 +1856,10 @@ const ScrollbackPane: Component<Props> = (props) => {
   //     latch (one-shot resume). Owner ruling 2026-07-29 (#535): the only
   //     legitimate jump-to-bottom is the operator's own send in the active
   //     window; every other trigger preserves position or lands on the divider.
-  // Post-send / live-append stay at the BOTTOM via the length-effect +
-  // `lastOwnSend`→`scrollToBottom` (both untouched; the send clears the latch
-  // first). The divider still RENDERS at its frozen position (freeze-display
+  // Post-send / live-append stay at the BOTTOM via the length-effect: the send
+  // ARMS `followMode` (#608 STEP 5, clearing the marker latch first) and the
+  // applier tail-follows the echo when it mounts. The divider still RENDERS at
+  // its frozen position (freeze-display
   // contract, DESIGN_NOTES 2026-06-08) for every trigger. `atBottomNow` is set
   // per branch so the floating "scroll to bottom" button doesn't flash
   // mid-activation (and `followMode` alongside it drives the tail-follow gate).
@@ -2480,10 +2481,31 @@ const ScrollbackPane: Component<Props> = (props) => {
           }),
         );
         return;
+      case "operator-tail": {
+        // W7 — the explicit operator tail (scroll-to-bottom button / #243 re-tap /
+        // active-window re-tap). INSTANT + SYNC (no rAF): the 2026-06-02
+        // contamination fix — a smooth/async animation on the SHARED `.scrollback`
+        // node would survive a window switch and race the arriving pane's
+        // activation, stranding scrollTop at a stale offset (vjt prod report). The
+        // rows are already in the DOM at gesture time (the operator taps after
+        // content exists), so `lastElementChild` is the true tail — no settle
+        // needed. Re-arm follow + geometry, exactly as the former scrollToBottom()
+        // helper did; running SYNC keeps the caller's post-scroll
+        // `lastFullyVisibleRowId` read on the pinned tail.
+        const tail = listRef.lastElementChild as HTMLElement | null;
+        if (tail?.scrollIntoView) {
+          tail.scrollIntoView({ block: "end" });
+        } else {
+          listRef.scrollTop = listRef.scrollHeight;
+        }
+        setFollowMode(true);
+        setAtBottomNow(true);
+        return;
+      }
       default:
-        // operator-tail / mention-jump / prepend-preserve are routed in later
-        // increments — the length-effect never declares them, so this is
-        // unreachable until then.
+        // mention-jump (applyMentionJump) + prepend-preserve (applyPrependPreserve)
+        // own dedicated entrypoints and never reach dispatchScrollWrite, so this
+        // arm stays unreachable.
         return;
     }
   };
@@ -2627,6 +2649,28 @@ const ScrollbackPane: Component<Props> = (props) => {
     // bailed identically). Otherwise the activation intent won ⇒ delegate.
     if (winner?.kind === "overlay-freeze") return;
     scrollToActivation(mode, withHide);
+  };
+
+  // #608 STEP 5 — the W7 operator-tail applier entrypoint: the explicit
+  // scroll-to-bottom gesture (floating button onClick, #243 re-tap). Declared as
+  // an `operator-tail` one-shot intent (2nd-highest precedence, below only
+  // overlay-freeze) so the write is OWNED + logged by the applier — this is where
+  // the last raw scrollIntoView/scrollTop= moves off the direct call surface into
+  // `dispatchScrollWrite`. Behaviour-identical to the former `scrollToBottom()`
+  // helper: a single-intent list fired unconditionally (the gesture is the
+  // operator's explicit action; full arbitration against a live overlay-freeze is
+  // the designed rank but unreachable — the overlay covers the button — and
+  // matching the pre-migration no-guard write keeps this behaviour-preserving,
+  // mirroring the W8 mention-jump migration). The dispatch is SYNC (instant), so
+  // the caller's post-scroll `lastFullyVisibleRowId` read still sees the pinned
+  // tail.
+  const applyOperatorTail = (): void => {
+    if (!listRef) return;
+    const k = key();
+    const intent: ScrollIntent = { kind: "operator-tail", key: k, lifetime: "one-shot" };
+    const { winner, reason } = resolveIntent([intent], k);
+    logScrollDecision("operator-tail", [intent], winner, reason);
+    if (winner) dispatchScrollWrite(winner);
   };
 
   // After Solid commits new DOM nodes, scroll to the tail iff the user
@@ -2945,40 +2989,12 @@ const ScrollbackPane: Component<Props> = (props) => {
     }, SCROLL_SETTLE_DEBOUNCE_MS);
   };
 
-  // C7.4: scroll-to-bottom click handler — forces scroll to tail and
-  // resumes auto-follow (#608: re-arms `followMode` + `atBottomNow`).
-  //
-  // 2026-06-02 (scroll-to-bottom button contamination): the snap is
-  // INSTANT, not `behavior: "smooth"`. The `[data-testid="scrollback"]`
-  // <div> is the SAME DOM node across selectedChannel changes (Shell.tsx
-  // bundles channel|query|server into one non-keyed Match). A smooth
-  // scroll is an ASYNCHRONOUS animation that lives on that node — tap the
-  // button on a tall window, switch away mid-animation and back, and the
-  // in-flight animation SURVIVES the row swap, racing `scrollToActivation`
-  // on the shared node and leaving scrollTop at a stale/overshot offset
-  // (viewport below content = blank; restored only by a real scroll
-  // event). vjt prod-reported 2026-06-02. Mirror `scrollToActivation`'s
-  // no-marker branch (instant, layout-aware tail anchor) — every other
-  // scroll path in this file is instant for exactly this reason; nothing
-  // async then survives a window switch.
-  const scrollToBottom = () => {
-    if (!listRef) return;
-    const tail = listRef.lastElementChild as HTMLElement | null;
-    if (tail?.scrollIntoView) {
-      tail.scrollIntoView({ block: "end" });
-    } else {
-      listRef.scrollTop = listRef.scrollHeight;
-    }
-    setFollowMode(true);
-    setAtBottomNow(true);
-  };
-
   // #310 — the scroll-to-bottom GESTURE, shared by the floating button's
   // onClick AND the #243 re-tap command below. Reaching the bottom via an
   // explicit operator gesture means they have read to the newest line, so —
-  // exactly like a manual scroll to the bottom — it does two things the pure
-  // `scrollToBottom()` helper (kept for the send-relatch, which owns its own
-  // marker + cursor bookkeeping) deliberately does NOT:
+  // exactly like a manual scroll to the bottom — it does two things the bare
+  // `applyOperatorTail()` tail write (#608 STEP 5b — the W7 operator-tail
+  // applier intent) deliberately does NOT:
   //
   //   1. Clears the marker-activation latch. A channel activation into an
   //      unread window leaves `markerActivationPending` set; only an operator
@@ -2997,15 +3013,16 @@ const ScrollbackPane: Component<Props> = (props) => {
   //      input-gated scroll-settle, which a button tap never arms — see
   //      cursor-forward-only.spec.ts).
   //
-  // The newest id is read AFTER the instant scroll: `scrollToBottom()` pins
-  // the tail synchronously, so `lastFullyVisibleRowId`'s at-bottom
-  // short-circuit returns the true DOM tail — never a stale pre-scroll id the
-  // #233 monotonic clamp would drop as non-advancing (candidate b). No second
-  // cursor authority, no window-state mutation. The frozen divider is left in
-  // place, same as a manual scroll — it re-latches only on the next focus
-  // acquisition or own send (freeze contract).
+  // The newest id is read AFTER the instant scroll: the operator-tail write pins
+  // the tail synchronously (dispatchScrollWrite's operator-tail case is instant,
+  // no rAF), so `lastFullyVisibleRowId`'s at-bottom short-circuit returns the
+  // true DOM tail — never a stale pre-scroll id the #233 monotonic clamp would
+  // drop as non-advancing (candidate b). No second cursor authority, no
+  // window-state mutation. The frozen divider is left in place, same as a manual
+  // scroll — it re-latches only on the next focus acquisition or own send
+  // (freeze contract).
   const scrollToBottomGesture = () => {
-    scrollToBottom();
+    applyOperatorTail();
     setMarkerActivationPending(false);
     if (!listRef) return;
     const id = lastFullyVisibleRowId(listRef);

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -4096,6 +4096,35 @@ describe("ScrollbackPane", () => {
       expect(scrollIntoViewSpy).not.toHaveBeenCalled();
     });
 
+    // #608 step 3 (characterization for the applier funnel) — the W1 overlay
+    // RESTORE write. When a covering overlay opens the pane's scrollTop is
+    // captured; if the ref-keyed <For> then resets it to 0 under the overlay (a
+    // message arriving beneath a modal), the overlay effect re-asserts the
+    // captured px across rAF×2. This pins that restore write observably BEFORE
+    // the applier extracts it into its own `applyOverlayRestore` entrypoint (W1
+    // restores on BOTH refcount edges, so it can't reuse the commit-frame
+    // overlay-freeze dispatch which requires `isOverlayFrozen()`). scrollIntoView
+    // is spied no-op by the block's beforeEach, so the mount tail-follow can't
+    // overwrite the restore.
+    it("re-asserts the captured scrollTop across the overlay edge (the W1 restore)", async () => {
+      seedRows();
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      const list = screen.getByTestId("scrollback") as HTMLDivElement;
+      await flushRaf();
+
+      // Reader parked at 250px.
+      Object.defineProperty(list, "scrollTop", { value: 250, writable: true, configurable: true });
+
+      // Overlay opens → the effect captures scrollTop (250) on the open edge.
+      pushOverlay(null);
+      // The ref-keyed <For> resets scrollTop to 0 under the overlay.
+      list.scrollTop = 0;
+      await flushRaf();
+
+      // The overlay restore re-asserts the captured 250 (same key).
+      expect(list.scrollTop).toBe(250);
+    });
+
     // Regression (review PLAUSIBLE): a rapid close→reopen of a covering
     // overlay (refcount 1→0→1) — one modal closing as another opens in the
     // same tick, e.g. /names dismissed by a nick-click that opens a query

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -1497,6 +1497,85 @@ describe("ScrollbackPane", () => {
     });
   });
 
+  // #608 STEP 5 (RED-GREEN behaviour change) — the SEND submit path ARMS the
+  // follow INTENT; it does NOT synchronously scroll to a non-existent node. The
+  // WS echo row is not in the DOM at submit (scrollback.ts publishes
+  // ownSendSubmitted SYNC before the POST — no optimistic append), so the old
+  // scrollToBottom() read PRE-append geometry and scrolled to the STALE tail
+  // (the #608 §5 off-by-one). Reshaped: submit sets followMode via nextFollowMode
+  // "send" (+ releases the marker latch); the applier tail-follows when the echo
+  // row mounts. followMode/atBottomNow first DIVERGE here — followMode is armed at
+  // submit; atBottomNow only flips once the echo lays out. e2e twin:
+  // issue580-send-snap-independent-of-post (asserts the end-state snap after the
+  // WS echo, which this reshape preserves — the follow-arm is independent of the
+  // POST, the tail fires on the WS echo).
+  describe("#608 — send arms followMode without scrolling the pre-echo tail (STEP 5)", () => {
+    let origScrollIntoView: typeof Element.prototype.scrollIntoView;
+    let scrollIntoViewSpy: ReturnType<typeof vi.fn>;
+    beforeEach(() => {
+      origScrollIntoView = Element.prototype.scrollIntoView;
+      scrollIntoViewSpy = vi.fn();
+      // biome-ignore lint/suspicious/noExplicitAny: jsdom Element type compat
+      (Element.prototype as any).scrollIntoView = scrollIntoViewSpy;
+    });
+    afterEach(() => {
+      Element.prototype.scrollIntoView = origScrollIntoView;
+    });
+    const overflowing = (list: HTMLDivElement, scrollTop: number): void => {
+      Object.defineProperty(list, "scrollHeight", { value: 5000, configurable: true });
+      Object.defineProperty(list, "clientHeight", { value: 500, configurable: true });
+      Object.defineProperty(list, "scrollTop", {
+        value: scrollTop,
+        writable: true,
+        configurable: true,
+      });
+    };
+    const flushRaf = async (): Promise<void> => {
+      await new Promise((r) =>
+        requestAnimationFrame(() => requestAnimationFrame(() => r(undefined))),
+      );
+    };
+
+    it("submit does NOT scroll the stale pre-echo tail; it arms followMode so the applier tails when the echo mounts", async () => {
+      setScrollback({ "freenode #grappa": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      const list = screen.getByTestId("scrollback") as HTMLDivElement;
+
+      // Operator scrolls UP → followMode flips false (scroll DOWN then UP; the
+      // #168 guard: followMode leaves the tail only when scrollTop DECREASES).
+      overflowing(list, 400);
+      list.dispatchEvent(new Event("scroll"));
+      list.scrollTop = 100;
+      list.dispatchEvent(new Event("scroll"));
+      await waitFor(() => expect(screen.queryByTestId("scroll-to-bottom")).not.toBeNull());
+      await flushRaf();
+      scrollIntoViewSpy.mockClear();
+
+      // SUBMIT — no echo row appended yet (WS-driven render; ownSendSubmitted is
+      // published SYNC before the POST in production).
+      pushOwnSendSubmitted("freenode #grappa");
+      await Promise.resolve();
+      await flushRaf();
+
+      // Reshaped: no scroll to the stale tail at submit. (RED pre-reshape: the
+      // submit effect's scrollToBottom() fired scrollIntoView on the OLD tail.)
+      expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+
+      // The WS echo lands (rows 3 → 4). followMode was ARMED at submit, so the
+      // applier's length-effect tail-follows the newly-mounted echo row.
+      const proto = fixture[0];
+      if (!proto) throw new Error("fixture[0] missing");
+      setScrollback({
+        "freenode #grappa": [
+          ...fixture,
+          { ...proto, id: 4, server_time: 1_700_000_003_000, sender: "vjt", body: "my echo" },
+        ],
+      });
+      await flushRaf();
+      expect(scrollIntoViewSpy).toHaveBeenCalledWith({ block: "end" });
+    });
+  });
+
   // #310 — the scroll-to-bottom GESTURE (floating button + #243 re-tap)
   // must advance the server read cursor to the NEWEST rendered message.
   // Pre-#310 both funnelled through the pure `scrollToBottom()` helper,

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -1576,6 +1576,47 @@ describe("ScrollbackPane", () => {
     });
   });
 
+  // #608 STEP 5b (characterization for the gesture migration) — the explicit
+  // scroll-to-bottom GESTURE (floating button / #243 re-tap) performs an INSTANT
+  // tail scrollIntoView. It is about to be routed through an operator-tail applier
+  // intent (the write moved into `dispatchScrollWrite` so no raw scrollIntoView
+  // lives OUTSIDE the applier surface). This pins the CURRENT sync tail write
+  // observably BEFORE the extraction; behaviour-identical (mirrors the W8
+  // mention-jump migration — a single-intent one-shot, fired unconditionally).
+  // Driven via the #243 re-tap command — the SAME `scrollToBottomGesture` the
+  // floating button's onClick invokes (jsdom's zero-geometry keeps the button
+  // unmounted, so the command is the harness for the shared gesture).
+  describe("#608 — scroll-to-bottom gesture performs an operator-tail write (STEP 5b)", () => {
+    let origScrollIntoView: typeof Element.prototype.scrollIntoView;
+    let scrollIntoViewSpy: ReturnType<typeof vi.fn>;
+    beforeEach(() => {
+      origScrollIntoView = Element.prototype.scrollIntoView;
+      scrollIntoViewSpy = vi.fn();
+      // biome-ignore lint/suspicious/noExplicitAny: jsdom Element type compat
+      (Element.prototype as any).scrollIntoView = scrollIntoViewSpy;
+    });
+    afterEach(() => {
+      Element.prototype.scrollIntoView = origScrollIntoView;
+    });
+
+    it("the #243 re-tap gesture instant-scrolls the tail into view", async () => {
+      setScrollback({ "freenode #grappa": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      await waitFor(() => expect(screen.getAllByTestId("scrollback-line")).toHaveLength(3));
+      // Drain the mount tail-follow so only the gesture's write is observed.
+      await new Promise((r) =>
+        requestAnimationFrame(() => requestAnimationFrame(() => r(undefined))),
+      );
+      scrollIntoViewSpy.mockClear();
+
+      // THE GESTURE — the #243 re-tap command the floating button's onClick shares.
+      requestScrollToBottom();
+      await Promise.resolve();
+
+      expect(scrollIntoViewSpy).toHaveBeenCalledWith({ block: "end" });
+    });
+  });
+
   // #310 — the scroll-to-bottom GESTURE (floating button + #243 re-tap)
   // must advance the server read cursor to the NEWEST rendered message.
   // Pre-#310 both funnelled through the pure `scrollToBottom()` helper,

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -4012,6 +4012,42 @@ describe("ScrollbackPane", () => {
       expect(scrollIntoViewSpy).toHaveBeenCalled();
     });
 
+    // #608 step 3 (characterization for the applier funnel) — a message
+    // arriving WHILE a covering overlay is up must NOT tail-follow the covered
+    // pane: the length-effect re-asserts the held snapshot (a `scrollTop`
+    // write), it never tails (`scrollIntoView`). This pins the
+    // overlay-freeze ▸ tail-follow precedence AT the length-effect — the exact
+    // branch order about to be routed through the pure `resolveIntent` core. The
+    // e2e twin is issue196-preview-scroll-live-arrival; this is the
+    // jsdom-observable half (the scrollIntoView spy).
+    it("a message arriving while an overlay is up does NOT tail-follow the covered pane (frozen)", async () => {
+      seedRows();
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      await flushRaf();
+
+      pushOverlay(null);
+      await flushRaf();
+      scrollIntoViewSpy.mockClear();
+
+      // A new message lands (rows length 20 → 21) → the length-effect runs.
+      setScrollback({
+        "freenode #grappa": Array.from({ length: 21 }, (_, i) => ({
+          id: i + 1,
+          network: "freenode",
+          channel: "#grappa",
+          server_time: i + 1,
+          kind: "privmsg" as const,
+          sender: "alice",
+          body: `row ${i + 1}`,
+          meta: {},
+        })),
+      });
+      await flushRaf();
+
+      // Frozen → the length-effect re-asserts the snapshot; it does not tail.
+      expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+    });
+
     // Regression (review PLAUSIBLE): a rapid close→reopen of a covering
     // overlay (refcount 1→0→1) — one modal closing as another opens in the
     // same tick, e.g. /names dismissed by a nick-click that opens a query

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -4532,6 +4532,53 @@ describe("ScrollbackPane", () => {
 
       expect(scrollIntoViewSpy).not.toHaveBeenCalled();
     });
+
+    // #608 (regression, media-viewer close snap) — the freeze holds the reader's
+    // position for the overlay's whole lifetime, but the follow INTENT could be
+    // left stale. When the reader is scrolled up (snapshot mid-list) but
+    // `followMode` is still true — the scroll-up onScroll edge dropped by the
+    // freeze bail (a scroll racing the freeze engaging) — the close edge restores
+    // the mid position AND a lingering `tailFollowWhenSettled` poll (which gates
+    // only on `followMode`/`isConnected`, not the freeze) fail-safe-tailed the
+    // pane the instant the overlay closed: the reader was yanked to the bottom on
+    // close (the #219 media-viewer report, e2e issue219-overlay-scroll-hold). The
+    // fix reconciles `followMode` with the RESTORED geometry on the overlay edges
+    // (the snapshot is the reader's trusted position): mid-list snapshot ⇒
+    // `followMode=false`, so a later content-change never tails. Derived from
+    // geometry — no separately-cleared latch. The e2e twin drives the real resize
+    // authority; this is the jsdom-observable half (the scrollIntoView spy).
+    it("reconciles followMode to a mid-list snapshot on overlay close (a later resize does NOT snap)", async () => {
+      seedRows();
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      const list = screen.getByTestId("scrollback") as HTMLDivElement;
+      await flushRaf();
+
+      // A tall, genuinely-scrollable pane with the reader parked mid-list. No
+      // scroll event is dispatched, so `followMode` stays at its stale mount value
+      // (true) — the exact stuck-follow state the freeze/onScroll race produces
+      // (the scroll-up onScroll edge dropped by the freeze bail). This is the
+      // inverse of the thaw case above (whose snapshot sits at the tail → the
+      // resize legitimately re-pins): here the reader is mid-list, so the follow
+      // intent must be reconciled OFF and the resize must be a no-op.
+      Object.defineProperty(list, "scrollHeight", { value: 2000, configurable: true });
+      Object.defineProperty(list, "clientHeight", { value: 500, configurable: true });
+      Object.defineProperty(list, "scrollTop", { value: 750, writable: true, configurable: true });
+
+      // Overlay opens at the mid position (snapshot=750) then closes.
+      pushOverlay(null);
+      await flushRaf();
+      popOverlay(null);
+      await flushRaf();
+      scrollIntoViewSpy.mockClear();
+
+      // A resize fires after the close (the e2e's real authority). Reader was
+      // mid-list → followMode reconciled false → onResize's follow gate is off →
+      // no tail snap. Pre-fix followMode was stale-true → the resize snapped.
+      window.dispatchEvent(new Event("resize"));
+      await flushRaf();
+
+      expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+    });
   });
 
   // affordances. Rendered as flex siblings BEFORE `.scrollback` they

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -1430,6 +1430,73 @@ describe("ScrollbackPane", () => {
     });
   });
 
+  // #608 step 3 (characterization for the applier funnel) — the W2/W3
+  // `scrollToActivation` CALL-SITES (cold-mount, channel switch, visibility-
+  // return, resize). They are about to be routed through a thin
+  // `applyActivation(mode, withHide)` entrypoint that resolves the
+  // overlay-freeze ▸ activation precedence via `resolveIntent` and delegates to
+  // `scrollToActivation` ONLY when the activation kind wins — behaviour-identical
+  // because `scrollToActivation` already bails on `isOverlayFrozen()` (so the
+  // overlay-freeze-wins branch is the same no-op either way). These pin the
+  // CURRENT call-site behaviour observably BEFORE the extraction:
+  //   * a channel switch still scrolls the ARRIVING pane — isolable: #a and #b
+  //     have the same row count, so `rows().length` is unchanged and the
+  //     length-effect does NOT fire; only the key-effect activation can move it.
+  //   * a cold mount into an unread window still jumps to the frozen divider
+  //     (the #168 marker branch — `block: "start"`), EXACT.
+  // The frozen-no-op HALF is already locked by the #219-general resize cases
+  // (`a resize WHILE a covering overlay is open does NOT snap to the tail`),
+  // which post-refactor exercise `applyActivation`'s overlay-freeze gate.
+  describe("#608 — activation call-sites fire the activation scroll (W2/W3)", () => {
+    let scrollIntoViewSpy: ReturnType<typeof vi.fn>;
+    beforeEach(() => {
+      scrollIntoViewSpy = vi.fn();
+      // biome-ignore lint/suspicious/noExplicitAny: jsdom Element type compat
+      (Element.prototype as any).scrollIntoView = scrollIntoViewSpy;
+    });
+    // rAF drain — scrollToActivation schedules its scroll inside a double-rAF
+    // (geometry-after-layout idiom); mirrors the #219-general block's helper.
+    const flushRaf = async (): Promise<void> => {
+      await new Promise((r) =>
+        requestAnimationFrame(() => requestAnimationFrame(() => r(undefined))),
+      );
+    };
+
+    it("a channel switch fires the arriving pane's activation tail scroll", async () => {
+      const [chan, setChan] = createSignal("#a");
+      setScrollback({ "freenode #a": fixture, "freenode #b": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName={chan()} kind="channel" />);
+      const list = screen.getByTestId("scrollback") as HTMLDivElement;
+      // jsdom leaves scrollTo undefined; the W9 key-change interrupt effect
+      // (interruptSmoothScroll) calls it on the switch. Stub a no-op so the
+      // switch completes (the .scrollback node is stable across the switch).
+      list.scrollTo = vi.fn();
+      await flushRaf();
+      // #b has the SAME row count as #a → rows().length unchanged → the
+      // length-effect does NOT fire; only the key-effect activation moves the
+      // arriving pane. Isolates the W2/W3 call-site from the length-effect funnel.
+      scrollIntoViewSpy.mockClear();
+
+      setChan("#b");
+      await flushRaf();
+
+      // No cursor on #b → no divider → the marker-or-tail activation tails.
+      expect(scrollIntoViewSpy).toHaveBeenCalledWith({ block: "end" });
+    });
+
+    it("a cold mount into an unread window jumps to the frozen divider (#168 marker branch)", async () => {
+      // Cursor mid-list (id 1) → ids 2,3 unread → the rows() memo injects the
+      // divider, and the cold-mount marker-or-tail activation scrolls to it
+      // (block: "start"), NOT the tail.
+      seedReadCursor("freenode", "#grappa", 1);
+      setScrollback({ "freenode #grappa": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      await flushRaf();
+
+      expect(scrollIntoViewSpy).toHaveBeenCalledWith({ block: "start" });
+    });
+  });
+
   // #310 — the scroll-to-bottom GESTURE (floating button + #243 re-tap)
   // must advance the server read cursor to the NEWEST rendered message.
   // Pre-#310 both funnelled through the pure `scrollToBottom()` helper,

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -1561,8 +1561,9 @@ describe("ScrollbackPane", () => {
       // submit effect's scrollToBottom() fired scrollIntoView on the OLD tail.)
       expect(scrollIntoViewSpy).not.toHaveBeenCalled();
 
-      // The WS echo lands (rows 3 → 4). followMode was ARMED at submit, so the
-      // applier's length-effect tail-follows the newly-mounted echo row.
+      // The WS echo lands (rows 3 → 4) AND lays out (the extent grows + the new
+      // tail row gains a box). followMode was ARMED at submit, so the applier's
+      // length-effect tail-follows once the measured settle holds (#608 STEP 6).
       const proto = fixture[0];
       if (!proto) throw new Error("fixture[0] missing");
       setScrollback({
@@ -1570,6 +1571,11 @@ describe("ScrollbackPane", () => {
           ...fixture,
           { ...proto, id: 4, server_time: 1_700_000_003_000, sender: "vjt", body: "my echo" },
         ],
+      });
+      Object.defineProperty(list, "scrollHeight", { value: 5200, configurable: true });
+      Object.defineProperty(list.lastElementChild as HTMLElement, "offsetHeight", {
+        value: 20,
+        configurable: true,
       });
       await flushRaf();
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({ block: "end" });
@@ -1612,6 +1618,84 @@ describe("ScrollbackPane", () => {
       // THE GESTURE — the #243 re-tap command the floating button's onClick shares.
       requestScrollToBottom();
       await Promise.resolve();
+
+      expect(scrollIntoViewSpy).toHaveBeenCalledWith({ block: "end" });
+    });
+  });
+
+  // #608 STEP 6 (RED-GREEN behaviour change) — the tail-follow write waits for a
+  // MEASURED settle (isSettled: the appended content's extent has GROWN vs the
+  // last tail AND the new tail row has a laid-out box) before scrolling, instead
+  // of a fixed rAF×2 — which is not a layout flush on iOS WebKit and scrolled to
+  // the STALE pre-layout tail (the #608 §5 off-by-one). The pure isSettled core
+  // is unit-tested in scrollAuthority.test.ts; this pins the WIRING: no scroll on
+  // stale geometry, then a scroll the frame the row lays out. e2e wiring =
+  // chromium bug7-ios-own-msg-visible (STRENGTHENED); real-iOS = device verify.
+  describe("#608 — tail-follow waits for measured settle before scrolling (STEP 6)", () => {
+    let origScrollIntoView: typeof Element.prototype.scrollIntoView;
+    let scrollIntoViewSpy: ReturnType<typeof vi.fn>;
+    beforeEach(() => {
+      // The module-level readCursorStore is NOT reset by the global beforeEach,
+      // so a prior test's seeded cursor leaks in; on a clean-cursor pane it would
+      // render an unread marker and the echo append below would fire a
+      // marker-activation scroll (block:"start"), polluting the "no scroll on
+      // stale geometry" assertion. Reset it here (mirrors the #219-general block's
+      // own resetOverlayLock) so this test owns a no-cursor baseline.
+      setReadCursorStore({});
+      origScrollIntoView = Element.prototype.scrollIntoView;
+      scrollIntoViewSpy = vi.fn();
+      // biome-ignore lint/suspicious/noExplicitAny: jsdom Element type compat
+      (Element.prototype as any).scrollIntoView = scrollIntoViewSpy;
+    });
+    afterEach(() => {
+      Element.prototype.scrollIntoView = origScrollIntoView;
+    });
+    const oneFrame = async (): Promise<void> => {
+      await new Promise((r) => requestAnimationFrame(() => r(undefined)));
+    };
+    const flushFrames = async (n: number): Promise<void> => {
+      for (let i = 0; i < n; i += 1) await oneFrame();
+    };
+    const setBox = (el: Element | null, px: number): void => {
+      if (el) Object.defineProperty(el, "offsetHeight", { value: px, configurable: true });
+    };
+
+    it("does not tail-follow on stale pre-layout geometry; scrolls once scrollHeight grows and the row has a box", async () => {
+      setScrollback({ "freenode #grappa": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      const list = screen.getByTestId("scrollback") as HTMLDivElement;
+
+      // Baseline: mount at the tail with a real extent + a laid-out tail row so
+      // the mount tail-follow SETTLES (establishes lastTailScrollHeight = 1000).
+      Object.defineProperty(list, "scrollHeight", {
+        value: 1000,
+        writable: true,
+        configurable: true,
+      });
+      setBox(list.lastElementChild, 18);
+      await flushFrames(3);
+      scrollIntoViewSpy.mockClear();
+
+      // Echo appends (rows 3 → 4). Simulate iOS: the new row is COMMITTED but not
+      // laid out — scrollHeight is STALE (still 1000) and the new tail's box is 0.
+      const proto = fixture[0];
+      if (!proto) throw new Error("fixture[0] missing");
+      setScrollback({
+        "freenode #grappa": [
+          ...fixture,
+          { ...proto, id: 4, server_time: 1_700_000_003_000, sender: "vjt", body: "echo" },
+        ],
+      });
+      await flushFrames(3);
+
+      // NOT settled (scrollHeight has not grown, new tail box is 0) → no scroll.
+      // RED pre-STEP-6: the fixed rAF×2 scrolled here regardless of layout.
+      expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+
+      // Layout lands: the extent grows AND the new tail row gains a box.
+      Object.defineProperty(list, "scrollHeight", { value: 1200, configurable: true });
+      setBox(list.lastElementChild, 18);
+      await flushFrames(3);
 
       expect(scrollIntoViewSpy).toHaveBeenCalledWith({ block: "end" });
     });

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -1205,6 +1205,77 @@ describe("ScrollbackPane", () => {
     });
   });
 
+  // #608 — CHARACTERIZATION of the geometric at-bottom → button contract, ahead
+  // of the `atBottom` → `followMode` + `atBottomNow` split (deep-review §6.1).
+  // jsdom has no layout, but `onScroll`'s distance is pure arithmetic over
+  // scrollTop/scrollHeight/clientHeight, so `defineProperty`'d geometry + a
+  // dispatched `scroll` event exercises the EXACT branches the split touches:
+  // `onScroll`'s at-bottom flip and the floating button's `<Show>` read. The
+  // full scroll physics live in the chromium e2e (issue280/289,
+  // login-advanced-scroll-reachability — webkit ≠ iOS scroll,
+  // feedback_playwright_webkit_not_ios_scroll); this locks the unit-observable
+  // half so the split (which moves the button onto `atBottomNow` and the
+  // tail-follow onto `followMode`) cannot silently regress the button. These
+  // assert CURRENT behavior and MUST stay green verbatim across the split.
+  describe("#608 — floating button tracks the geometric at-bottom state", () => {
+    const overflowing = (list: HTMLDivElement, scrollTop: number): void => {
+      Object.defineProperty(list, "scrollHeight", { value: 5000, configurable: true });
+      Object.defineProperty(list, "clientHeight", { value: 500, configurable: true });
+      Object.defineProperty(list, "scrollTop", {
+        value: scrollTop,
+        writable: true,
+        configurable: true,
+      });
+    };
+
+    it("surfaces the button on an operator scroll-up and hides it again at the tail", async () => {
+      setScrollback({ "freenode #grappa": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      const list = screen.getByTestId("scrollback") as HTMLDivElement;
+
+      // At the tail (initial state) → no button.
+      expect(screen.queryByTestId("scroll-to-bottom")).toBeNull();
+
+      // Scroll DOWN first (establishes lastScrollTop), then UP: the follow
+      // authority flips false ONLY when scrollTop DECREASES (the #168 guard).
+      overflowing(list, 400);
+      list.dispatchEvent(new Event("scroll"));
+      list.scrollTop = 100; // distance 5000-100-500 = 4400 > 50 AND 100 < 400 → scroll-up
+      list.dispatchEvent(new Event("scroll"));
+      await waitFor(() => {
+        expect(screen.queryByTestId("scroll-to-bottom")).not.toBeNull();
+      });
+
+      // Return to the tail → button hides again (distance within threshold).
+      list.scrollTop = 4500; // distance 5000-4500-500 = 0 <= 50 → reach-tail
+      list.dispatchEvent(new Event("scroll"));
+      await waitFor(() => {
+        expect(screen.queryByTestId("scroll-to-bottom")).toBeNull();
+      });
+    });
+
+    it("keeps the button hidden on a content-grow above the fold (scrollTop not decreased — #168)", async () => {
+      setScrollback({ "freenode #grappa": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      const list = screen.getByTestId("scrollback") as HTMLDivElement;
+
+      // Following the tail (distance 0 → at bottom, button hidden).
+      overflowing(list, 4500);
+      list.dispatchEvent(new Event("scroll"));
+      expect(screen.queryByTestId("scroll-to-bottom")).toBeNull();
+
+      // Older rows PREPEND above the viewport: scrollHeight grows, scrollTop is
+      // unchanged. The scroll event this fires shows a huge distance-to-tail, but
+      // scrollTop did NOT decrease → the follow state must NOT flip (#168), so the
+      // button stays hidden. Were the guard removed, distance>threshold would
+      // surface the button here.
+      Object.defineProperty(list, "scrollHeight", { value: 8000, configurable: true });
+      list.dispatchEvent(new Event("scroll")); // distance 8000-4500-500 = 3000 > 50, but 4500 !< 4500
+      await new Promise((r) => queueMicrotask(() => r(undefined)));
+      expect(screen.queryByTestId("scroll-to-bottom")).toBeNull();
+    });
+  });
+
   // #310 — the scroll-to-bottom GESTURE (floating button + #243 re-tap)
   // must advance the server read cursor to the NEWEST rendered message.
   // Pre-#310 both funnelled through the pure `scrollToBottom()` helper,

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -3984,6 +3984,34 @@ describe("ScrollbackPane", () => {
       expect(scrollIntoViewSpy).toHaveBeenCalled();
     });
 
+    // #608 step 2 — the freeze is DERIVED from the live overlay refcount, not a
+    // separately-cleared latch. The thaw must follow the count→0 edge the same
+    // tick it happens, independent of whether the deferred snapshot-clear rAF
+    // has run. Pre-fix (`isOverlayFrozen` = `overlayScrollSnapshot !== null`)
+    // the pane stayed frozen until the clear rAF fired — and a leaked / never-
+    // firing clear stranded it FOREVER (the field bug root). Post-fix
+    // `isOverlayFrozen` = `overlayCount() > 0`, so a resize snaps to the tail
+    // the instant the last overlay closes, with no reliance on the clear.
+    it("thaws the instant count→0, without awaiting the deferred snapshot clear (live-derived freeze)", async () => {
+      seedRows();
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      await flushRaf();
+
+      pushOverlay(null);
+      await flushRaf();
+
+      // Close the last overlay, then IMMEDIATELY resize — NO flushRaf between,
+      // so the deferred snapshot-clear rAF has NOT run. The live-derived freeze
+      // must already read false because `overlayCount() === 0`.
+      popOverlay(null);
+      scrollIntoViewSpy.mockClear();
+
+      window.dispatchEvent(new Event("resize"));
+      await flushRaf();
+
+      expect(scrollIntoViewSpy).toHaveBeenCalled();
+    });
+
     // Regression (review PLAUSIBLE): a rapid close→reopen of a covering
     // overlay (refcount 1→0→1) — one modal closing as another opens in the
     // same tick, e.g. /names dismissed by a nick-click that opens a query

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -175,6 +175,15 @@ vi.mock("../lib/socket", () => ({
 
 vi.mock("../lib/channelKey", () => ({
   channelKey: (slug: string, name: string) => `${slug} ${name}`,
+  // Faithful to the `${slug} ${name}` mock shape: split on the first space.
+  // Needed once a test drives a real channel switch (the key-change effects
+  // decode the leaving/arriving key); identity fold matches the mock's
+  // non-folding channelKey.
+  decodeChannelKey: (key: string) => {
+    const i = key.indexOf(" ");
+    return i < 0 ? null : { slug: key.slice(0, i), name: key.slice(i + 1) };
+  },
+  canonicalChannel: (name: string) => name,
 }));
 
 // C3.2: mock membersByChannel for JOIN-self banner tests
@@ -1321,6 +1330,35 @@ describe("ScrollbackPane", () => {
 
       // Post-await restore: 1500 - 1000 + 40 = 540 (the reader's row held).
       await waitFor(() => expect(list.scrollTop).toBe(540));
+    });
+  });
+
+  // #608 step 3 (characterization for the applier funnel) — the W9 smooth-scroll
+  // interrupt. The mention-jump is the ONE animated scroll in this pane; a
+  // channel switch must cancel any in-flight animation (the shared `.scrollback`
+  // DOM survives the row swap, so a live animation would race the arriving
+  // pane's activation). The cancel is a `scrollTo` to the CURRENT offset — an
+  // instant scroll instruction that stops the native smooth animation without
+  // moving. Pinned here BEFORE the applier extracts it into `interruptSmoothScroll`.
+  describe("#608 — key switch interrupts an in-flight smooth scroll (W9)", () => {
+    it("calls scrollTo to the current offset on a channel switch", async () => {
+      const scrollToSpy = vi.fn();
+      const [chan, setChan] = createSignal("#a");
+      setScrollback({ "freenode #a": fixture, "freenode #b": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName={chan()} kind="channel" />);
+      const list = screen.getByTestId("scrollback") as HTMLDivElement;
+      // jsdom leaves scrollTo undefined; assign a spy on this instance (the
+      // .scrollback node is stable across the non-keyed channel↔query switch).
+      list.scrollTo = scrollToSpy;
+      Object.defineProperty(list, "scrollTop", { value: 123, writable: true, configurable: true });
+      scrollToSpy.mockClear();
+
+      // Switch channels → key() changes → the interrupt (a deferred on(key)
+      // effect) fires synchronously, reading the current scrollTop.
+      setChan("#b");
+      await Promise.resolve();
+
+      expect(scrollToSpy).toHaveBeenCalledWith({ top: 123 });
     });
   });
 

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -1362,6 +1362,74 @@ describe("ScrollbackPane", () => {
     });
   });
 
+  // #608 step 3 (characterization for the applier funnel) — the W8 mention-jump.
+  // Tapping the floating button when a mention sits below the fold smooth-scrolls
+  // the anchor into view (`scrollIntoView({behavior:"smooth", block:"center"})`)
+  // instead of jumping to the tail. Pinned here BEFORE the applier routes it
+  // through a `mention-jump` one-shot intent. jsdom has no layout, so the mention
+  // row's offsetTop is faked (readMentionGeom reads offsetTop) — the REAL
+  // mentionsBelowViewport / mentionJumpTargetId then classify it below the fold,
+  // no shared-mock swap needed.
+  describe("#608 — mention-jump smooth-scrolls the anchor (W8)", () => {
+    it("smooth-scrolls the mention anchor into view on a tap with a mention below", async () => {
+      setUserNick("vjt");
+      // A peer privmsg mentioning "vjt" gets .scrollback-mention; it is the LAST
+      // row, so mentionJumpTargetId returns its own id (anchor = the mention row).
+      setScrollback({
+        "freenode #grappa": [
+          {
+            id: 1,
+            network: "freenode",
+            channel: "#grappa",
+            server_time: 1,
+            kind: "privmsg",
+            sender: "alice",
+            body: "hi",
+            meta: {},
+          },
+          {
+            id: 2,
+            network: "freenode",
+            channel: "#grappa",
+            server_time: 2,
+            kind: "privmsg",
+            sender: "bob",
+            body: "hey vjt",
+            meta: {},
+          },
+        ],
+      });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      const list = screen.getByTestId("scrollback") as HTMLDivElement;
+
+      // Overflowing; the mention row (id 2) sits far below the fold (offsetTop
+      // 1500 >> viewportBottom). scrollTop starts at 400 for the scroll-up below.
+      Object.defineProperty(list, "clientHeight", { value: 100, configurable: true });
+      Object.defineProperty(list, "scrollHeight", { value: 2000, configurable: true });
+      Object.defineProperty(list, "scrollTop", { value: 400, writable: true, configurable: true });
+      const mentionRow = list.querySelector<HTMLElement>('.scrollback-line[data-msg-id="2"]');
+      if (mentionRow === null) throw new Error("mention row not rendered");
+      Object.defineProperty(mentionRow, "offsetTop", { value: 1500, configurable: true });
+      const scrollIntoViewSpy = vi.fn();
+      mentionRow.scrollIntoView = scrollIntoViewSpy;
+
+      // Scroll DOWN (establishes lastScrollTop) then UP → atBottomNow false, so
+      // the floating button renders. followMode also flips false, so the mount
+      // tail-follow bails (never touches the spied row).
+      list.dispatchEvent(new Event("scroll"));
+      list.scrollTop = 200;
+      list.dispatchEvent(new Event("scroll"));
+      await waitFor(() => expect(screen.queryByTestId("scroll-to-bottom")).not.toBeNull());
+      scrollIntoViewSpy.mockClear();
+
+      // Tap the button → mention path: viewportBottom = 200+100 = 300, the
+      // mention (offsetTop 1500) is below it → smooth-scroll the anchor.
+      screen.getByTestId("scroll-to-bottom").click();
+
+      expect(scrollIntoViewSpy).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
+    });
+  });
+
   // #310 — the scroll-to-bottom GESTURE (floating button + #243 re-tap)
   // must advance the server read cursor to the NEWEST rendered message.
   // Pre-#310 both funnelled through the pure `scrollToBottom()` helper,

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -1276,6 +1276,54 @@ describe("ScrollbackPane", () => {
     });
   });
 
+  // #608 step 4 (characterization for the applier funnel) — the POST-AWAIT
+  // loadMore preserve (W6). When older rows PREPEND (scrollHeight grows),
+  // scrollTop shifts by the growth so the reader's on-screen row stays fixed:
+  // `newScrollHeight - oldScrollHeight + oldScrollTop`. Pinned in jsdom over
+  // defineProperty'd geometry (the e2e twins are cp14-b2 +
+  // issue230-wheel-underfill-loadmore); this locks the height-delta math
+  // observably BEFORE the applier extracts it into the distinct post-await
+  // `applyPrependPreserve` entrypoint. Asserts CURRENT behavior.
+  describe("#608 — loadMore preserve restores position via the prepend height delta", () => {
+    let origScrollIntoView: typeof Element.prototype.scrollIntoView;
+    beforeEach(() => {
+      // The tail-follow fallback is `scrollTop = scrollHeight` ONLY when
+      // scrollIntoView is absent (jsdom's default). Stub it as a no-op so the
+      // mount tail-follow authority never touches scrollTop — isolating the W6
+      // height-delta restore under test (else the mount rAF×2 tail overwrites
+      // the restore with scrollHeight, since followMode defaults true).
+      origScrollIntoView = Element.prototype.scrollIntoView;
+      Element.prototype.scrollIntoView = vi.fn();
+    });
+    afterEach(() => {
+      Element.prototype.scrollIntoView = origScrollIntoView;
+    });
+
+    it("shifts scrollTop by the prepend height growth, preserving the reader's row", async () => {
+      setScrollback({ "freenode #grappa": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      const list = screen.getByTestId("scrollback") as HTMLDivElement;
+
+      // Near the top (scrollTop 40 <= LOAD_MORE_THRESHOLD_PX 200) so onScroll
+      // fires maybeLoadOlder; overflowing so distance is large (no tail flip,
+      // and 40 is not a decrease from lastScrollTop 0 → followMode untouched).
+      Object.defineProperty(list, "clientHeight", { value: 300, configurable: true });
+      Object.defineProperty(list, "scrollTop", { value: 40, writable: true, configurable: true });
+      Object.defineProperty(list, "scrollHeight", { value: 1000, configurable: true });
+
+      // loadMore resolves AND simulates the prepend (scrollHeight 1000 → 1500).
+      vi.mocked(loadMore).mockImplementationOnce(() => {
+        Object.defineProperty(list, "scrollHeight", { value: 1500, configurable: true });
+        return Promise.resolve();
+      });
+
+      list.dispatchEvent(new Event("scroll"));
+
+      // Post-await restore: 1500 - 1000 + 40 = 540 (the reader's row held).
+      await waitFor(() => expect(list.scrollTop).toBe(540));
+    });
+  });
+
   // #310 — the scroll-to-bottom GESTURE (floating button + #243 re-tap)
   // must advance the server read cursor to the NEWEST rendered message.
   // Pre-#310 both funnelled through the pure `scrollToBottom()` helper,

--- a/cicchetto/src/lib/scrollAuthority.test.ts
+++ b/cicchetto/src/lib/scrollAuthority.test.ts
@@ -1,0 +1,123 @@
+// #608 — pure decision core of the single scroll authority. These pin the
+// three DOM-free pieces the applier is built on: intent precedence, the
+// followMode transition table (the primary reshape — split out of the
+// overloaded `atBottom`), and the measured-settle predicate (replaces the
+// iOS-unreliable fixed rAF×2). Playwright webkit ≠ real iOS scroll, so the
+// geometry/decision logic lives here as vitest; the DOM wiring stays in the
+// component.
+
+import { describe, expect, test } from "vitest";
+import { isSettled, nextFollowMode, resolveIntent, type ScrollIntent } from "./scrollAuthority";
+
+const K = "freenode #a";
+const intent = (kind: ScrollIntent["kind"], over: Partial<ScrollIntent> = {}): ScrollIntent => ({
+  kind,
+  key: K,
+  lifetime: "one-shot",
+  ...over,
+});
+
+describe("resolveIntent — precedence", () => {
+  test("no intents → no winner", () => {
+    const r = resolveIntent([], K);
+    expect(r.winner).toBeNull();
+    expect(r.reason).toBe("no-intent");
+  });
+
+  test("a single matching intent wins", () => {
+    const r = resolveIntent([intent("tail-follow")], K);
+    expect(r.winner?.kind).toBe("tail-follow");
+  });
+
+  test("overlay-freeze beats operator-tail (highest precedence)", () => {
+    const r = resolveIntent([intent("operator-tail"), intent("overlay-freeze")], K);
+    expect(r.winner?.kind).toBe("overlay-freeze");
+    expect(r.reason).toContain("overlay-freeze");
+  });
+
+  test("operator-tail beats mention-jump, marker-activation and tail-follow", () => {
+    const r = resolveIntent(
+      [
+        intent("tail-follow"),
+        intent("marker-activation"),
+        intent("mention-jump"),
+        intent("operator-tail"),
+      ],
+      K,
+    );
+    expect(r.winner?.kind).toBe("operator-tail");
+  });
+
+  test("mention-jump beats marker-activation", () => {
+    const r = resolveIntent([intent("marker-activation"), intent("mention-jump")], K);
+    expect(r.winner?.kind).toBe("mention-jump");
+  });
+
+  test("marker-activation beats tail-follow", () => {
+    const r = resolveIntent([intent("tail-follow"), intent("marker-activation")], K);
+    expect(r.winner?.kind).toBe("marker-activation");
+  });
+
+  test("prepend-preserve is the lowest — tail-follow wins over it", () => {
+    const r = resolveIntent([intent("prepend-preserve"), intent("tail-follow")], K);
+    expect(r.winner?.kind).toBe("tail-follow");
+  });
+
+  test("prepend-preserve wins when it is the only intent", () => {
+    const r = resolveIntent([intent("prepend-preserve")], K);
+    expect(r.winner?.kind).toBe("prepend-preserve");
+  });
+
+  test("foreign-key intents are dropped (a pane switch must not move the new pane)", () => {
+    const r = resolveIntent([intent("operator-tail", { key: "freenode #other" })], K);
+    expect(r.winner).toBeNull();
+    expect(r.reason).toBe("no-intent");
+  });
+
+  test("mixed keys: only the current-key intent is considered", () => {
+    const r = resolveIntent(
+      [intent("overlay-freeze", { key: "freenode #other" }), intent("tail-follow")],
+      K,
+    );
+    expect(r.winner?.kind).toBe("tail-follow");
+  });
+});
+
+describe("nextFollowMode — transition table", () => {
+  test("operator scroll-up turns follow OFF", () => {
+    expect(nextFollowMode(true, "scroll-up")).toBe(false);
+  });
+
+  test("reaching the tail turns follow ON", () => {
+    expect(nextFollowMode(false, "reach-tail")).toBe(true);
+  });
+
+  test("sending a message arms follow ON", () => {
+    expect(nextFollowMode(false, "send")).toBe(true);
+  });
+
+  test("a programmatic content-grow (scrollTop unchanged) leaves follow unchanged", () => {
+    expect(nextFollowMode(true, "content-grow")).toBe(true);
+    expect(nextFollowMode(false, "content-grow")).toBe(false);
+  });
+});
+
+describe("isSettled — measured-settle predicate", () => {
+  test("settled when the append grew the extent AND the tail node has a real box", () => {
+    expect(
+      isSettled({ prevScrollHeight: 1000, currScrollHeight: 1040, targetNodeHeight: 40 }),
+    ).toBe(true);
+  });
+
+  test("NOT settled when scrollHeight has not grown yet (append not laid out)", () => {
+    expect(
+      isSettled({ prevScrollHeight: 1000, currScrollHeight: 1000, targetNodeHeight: 40 }),
+    ).toBe(false);
+  });
+
+  test("NOT settled when the tail node still has a zero box (pre-layout on iOS)", () => {
+    expect(isSettled({ prevScrollHeight: 1000, currScrollHeight: 1040, targetNodeHeight: 0 })).toBe(
+      false,
+    );
+  });
+});

--- a/cicchetto/src/lib/scrollAuthority.ts
+++ b/cicchetto/src/lib/scrollAuthority.ts
@@ -1,0 +1,122 @@
+// #608 — the single scroll authority, pure decision core.
+//
+// ScrollbackPane historically had 13 uncoordinated DOM scroll writes
+// (`scrollTop =` / `scrollIntoView` / `scrollTo`) arbitrated only by
+// whichever effect ran last in a frame — engine-dependent ordering that
+// produced the iOS field bugs (#580, #608). The reshape: effects DECLARE an
+// intent; ONE applier resolves precedence and owns every DOM write.
+//
+// This module is the DOM-free core of that applier — the pieces worth
+// unit-testing on plain data (Playwright webkit ≠ real iOS scroll, so the
+// decision logic is pinned here as vitest; the component owns the DOM I/O):
+//   1. intent precedence resolution,
+//   2. the followMode transition table (the PRIMARY reshape — `followMode`,
+//      the persistent "stick to the tail" intent, split out of the overloaded
+//      `atBottom` whose other half is the geometric `atBottomNow`),
+//   3. the measured-settle predicate (replaces the iOS-unreliable fixed
+//      rAF×2 — the off-by-one root).
+
+// The intent kinds, in precedence order high → low (from the #608 deep
+// review). `scroll-up` is deliberately NOT a kind: an operator scroll-up
+// turns `followMode` off and writes nothing.
+export type ScrollIntentKind =
+  | "overlay-freeze" // hold the px captured at overlay-open while a covering overlay is up
+  | "operator-tail" // explicit tail: own send / gesture / re-tap
+  | "mention-jump" // smooth-scroll to a mention anchor below the fold
+  | "marker-activation" // jump to the unread divider on window activation
+  | "tail-follow" // stick to the tail because followMode is on
+  | "prepend-preserve"; // preserve position across a top prepend (loadMore)
+
+// Sticky intents persist until their end condition (overlay closes, operator
+// takes over, followMode turns off); one-shot intents are consumed the frame
+// they win. The lifetime is carried so the applier need not re-derive it.
+export type ScrollIntentLifetime = "sticky" | "one-shot";
+
+export type ScrollIntent = {
+  readonly kind: ScrollIntentKind;
+  // Pane key the intent was declared for. The applier drops intents whose key
+  // does not match the current pane — the pane instance survives channel↔query
+  // switches (shared non-keyed Match), so a leaving window's intent must never
+  // move the arriving one (the #219-general key-scope guard, generalised).
+  readonly key: string;
+  readonly lifetime: ScrollIntentLifetime;
+};
+
+// High → low. Index = priority; earlier wins. Single source of truth for the
+// ordering the review confirmed:
+//   overlay-freeze ▸ operator-tail ▸ mention-jump ▸ marker-activation ▸
+//   tail-follow ▸ prepend-preserve
+const PRECEDENCE: readonly ScrollIntentKind[] = [
+  "overlay-freeze",
+  "operator-tail",
+  "mention-jump",
+  "marker-activation",
+  "tail-follow",
+  "prepend-preserve",
+];
+
+export type Resolution = {
+  readonly winner: ScrollIntent | null;
+  // Dev-log line half: why this intent won (or "no-intent"). The applier logs
+  // (intent, winner, reason, geometry) per run so the next field report is a
+  // log line, not a guess.
+  readonly reason: string;
+};
+
+// Resolve the winning intent for `currentKey`. Foreign-key intents are
+// dropped; among the rest the highest-precedence kind wins, ties taking the
+// first declared. Pure: no DOM, no time, no reactivity.
+export function resolveIntent(intents: readonly ScrollIntent[], currentKey: string): Resolution {
+  let winner: ScrollIntent | null = null;
+  let winnerRank = PRECEDENCE.length;
+  for (const it of intents) {
+    if (it.key !== currentKey) continue;
+    const rank = PRECEDENCE.indexOf(it.kind);
+    if (rank !== -1 && rank < winnerRank) {
+      winner = it;
+      winnerRank = rank;
+    }
+  }
+  if (winner === null) return { winner: null, reason: "no-intent" };
+  return { winner, reason: `${winner.kind}@${winnerRank}` };
+}
+
+// followMode transition events. Only three edges CHANGE the persistent
+// follow intent; `content-grow` (a programmatic grow above the fold, scrollTop
+// unchanged — the #168 distinction from an operator scroll-up) is modelled as
+// an explicit no-op so the table is exhaustive and a future edit cannot
+// silently make a content-grow flip follow.
+export type FollowModeEvent = "scroll-up" | "reach-tail" | "send" | "content-grow";
+
+// The transition table. `followMode` turns OFF only on an operator scroll-up,
+// and back ON at reach-tail or send.
+export function nextFollowMode(current: boolean, event: FollowModeEvent): boolean {
+  switch (event) {
+    case "scroll-up":
+      return false;
+    case "reach-tail":
+      return true;
+    case "send":
+      return true;
+    case "content-grow":
+      return current;
+  }
+}
+
+// A geometry sample taken around a tail write: the scroll extent captured
+// before the append, the extent measured now (after forcing a reflow), and the
+// laid-out box height of the tail node (getBoundingClientRect / offsetHeight).
+export type SettleSample = {
+  readonly prevScrollHeight: number;
+  readonly currScrollHeight: number;
+  readonly targetNodeHeight: number;
+};
+
+// Has the just-appended content actually laid out? The applier tails only when
+// this holds — replacing the fixed rAF×2, which is not a layout flush on iOS
+// WebKit (the #608 off-by-one root). Both conditions are required: scrollHeight
+// alone can bump from an unrelated reflow, and a node can be present in the DOM
+// with a zero box before layout on iOS.
+export function isSettled(sample: SettleSample): boolean {
+  return sample.currScrollHeight > sample.prevScrollHeight && sample.targetNodeHeight > 0;
+}

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -25361,3 +25361,62 @@ asserts the own row `toBeInViewport` AND distance-to-tail ≤ threshold after th
 settle. The deliberate test-layer split holds throughout: core geometry is a
 vitest `isSettled` unit test, the wiring is a chromium e2e, and real iOS is a
 device verify — Playwright webkit is not iOS scroll.
+
+## 2026-08-01 — #608 (follow-up): the media-viewer close snap — reconcile the follow intent, and no deferred writer is exempt from precedence
+
+The scoped scroll e2e caught one regression the reshape's own unit tests missed:
+`issue219-overlay-scroll-hold` (a reader scrolled up, opens the media viewer,
+closes it → the pane must stay put) failed as a **race** (~2/3), snapping the
+reader to the tail on the CLOSE edge. Instrumentation pinned the mechanism, and
+it was NOT where the freeze lives.
+
+**Root cause — a stale follow intent, not a freeze gap.** `followMode` is meant
+to flip OFF when the reader scrolls up. But `onScroll` bails while the pane is
+frozen (`isOverlayFrozen()`) because scroll events under a covering overlay are
+DOM artifacts (the ref-keyed `<For>` resetting `scrollTop`), not operator intent.
+When the reader's genuine scroll-up event RACES the freeze engaging (the media
+open's deferred `pushOverlay` microtask), that real scroll-up edge is dropped and
+`followMode` is stranded TRUE. The freeze then holds the reader's position for the
+overlay's whole lifetime (correct), but on close the stale `followMode=true`
+drives a tail write. The writer was **`tailFollowWhenSettled`** (the STEP 6
+measured-settle poll): a lingering poll fail-safe-tailed the pane the instant the
+overlay closed. The overlay freeze/restore did its job; the follow *intent* was
+the bug.
+
+**Fix 1 — reconcile the follow intent with the reader's trusted position on the
+overlay edges.** The overlay snapshot IS the authoritative position across the
+overlay's lifetime, so `applyOverlayRestore` (which runs on both refcount edges)
+now sets `followMode` from the restored geometry — `followMode = (snapshot within
+SCROLL_BOTTOM_THRESHOLD_PX of the tail)` — even when the position is already held
+(a scrolled-up reader whose px never moved still gets the stale intent corrected).
+This is DERIVED from geometry, one-shot per edge — NOT a separately-cleared latch,
+so it does not reintroduce the drift/hang class STEP 2 killed (the freeze itself
+stays derived from the live `overlayCount()`). It composes cleanly with the thaw
+contract: a reader who WAS at the tail (snapshot at tail) reconciles to
+`followMode=true` and a post-close resize legitimately re-pins (the
+`#219-general` "thaws the instant count→0" case); a mid-list reader reconciles to
+`followMode=false` and the resize is a no-op.
+
+**Fix 2 — a deferred writer re-validates precedence for its whole lifetime, not
+just at dispatch.** `tailFollowWhenSettled` wins `resolveIntent` at dispatch (when
+nothing higher is active) but then polls up to `SETTLE_MAX_FRAMES`. It already
+re-checked `followMode()` and `listRef.isConnected` each frame; it now ALSO bails
+on `isOverlayFrozen()` each frame. So **the tail-follow is NOT exempt from the
+overlay-freeze precedence** — if a covering overlay opens mid-poll, overlay-freeze
+outranks tail-follow and the poll yields rather than writing through the freeze.
+The general rule: the applier's single-writer precedence must hold across a
+deferred write's entire lifetime; a poll that outlives its `resolveIntent`
+decision re-checks every sticky higher-precedence intent that can engage while it
+waits (freeze), plus its own liveness (followMode / connection). The remaining
+higher-precedence intents are user-triggered one-shots that cannot spuriously
+engage during a settle wait: operator-tail shares the tail destination (no
+conflict) and mention-jump requires a tap. Routing the poll's terminal write back
+through `resolveIntent` per frame was considered but rejected as heavier than the
+one live sticky intent (freeze) that the poll's lifetime can actually cross.
+
+Coverage: a jsdom LOCK (`ScrollbackPane.test.tsx`, `#219-general` block) pins the
+reconcile — a mid-list snapshot across an overlay open→close leaves `followMode`
+off so a later resize does not tail (RED before the fix, GREEN after); it is the
+deterministic inverse of the existing thaw case whose snapshot sits at the tail.
+The e2e `issue219-overlay-scroll-hold` is the wiring gate (the real resize
+authority; the assert and the 50px threshold were left untouched).

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -25247,3 +25247,117 @@ empty rail column, the concern that only applied to a *fixed* track), and binds
 only while the card content is character-breakable (word-break on the dd). The
 issue's `vw` term is dead on desktop: at the 14px root, 14rem < any sane `Nvw`
 for width ≥769px.
+
+## 2026-08-01 — #608: one scroll authority for ScrollbackPane — the applier, the atBottom split, and derive-don't-latch
+
+`ScrollbackPane.tsx` had grown to 13 physical scroll writes (`scrollTop=` /
+`scrollIntoView` / `scrollTo`) spread across 19 `createEffect` blocks with **no
+arbitration** — two writers routinely disagreed within one reactive batch, and
+there was no single place to instrument. The deep review (GH #608 comment
+5150844112) traced the field symptoms — a message renders but the pane does not
+scroll, the float-to-bottom button hidden, persistent until force-close; and, at
+send, the pane scrolls **one message behind** — to one root model: the
+length-effect (the only writer that should land the *true* tail) was either
+**suppressed** by a stuck overlay freeze or **read un-settled geometry** (rAF×2
+is not a layout flush on iOS WebKit). #608 rebuilds the pane around a single
+scroll authority so that class of bug becomes structurally impossible, not just
+patched.
+
+**The single scroll applier.** ScrollbackPane's effects no longer write the DOM
+directly; they **declare a `ScrollIntent`** `{kind, key, lifetime}` and ONE
+applier owns *every* DOM scroll write. The arbitration lives in a pure core,
+`lib/scrollAuthority.ts` — `resolveIntent` (precedence resolver: given N live
+intents, return the winner + reason), `nextFollowMode` (the follow transition
+table), and `isSettled` (the measured-settle predicate) — all unit-tested in
+isolation, no DOM. The component owns only the DOM I/O. Precedence, high → low:
+**overlay-freeze ▸ operator-tail ▸ mention-jump ▸ marker-activation ▸
+tail-follow ▸ prepend-preserve** (a scroll-up is not a write — it turns
+`followMode` off). Each applier run emits a dev-only intent log
+`(intent, winner, reason, geometry)`, gated on
+`import.meta.env.MODE === "development"` so it is dead-code-eliminated in prod and
+silent under vitest — that log is what turns the next field report into a single
+line. The invariant this buys: **a new scroll trigger DECLARES an intent; it
+never writes `scrollTop` directly.** Acceptance was verified as no raw
+`scrollTop=` / `scrollIntoView` / `scrollTo` anywhere outside the applier surface
+(`scrollToActivation`, `dispatchScrollWrite`, `applyPrependPreserve`,
+`applyOverlayRestore`, `applyMentionJump`, `interruptSmoothScroll` —
+`scrollToActivation` reachable only via `applyActivation` + `dispatchScrollWrite`).
+
+**The `atBottom` split (the primary reshape).** The old `atBottom` signal was
+overloaded — it meant BOTH "stick to the tail" (a persistent *intent*) and
+"the viewport is geometrically at the bottom" (a *measurement*) — and that
+conflation was the source of the two writer-disagreement races. It is split into
+`followMode` (the persistent intent: drives tail-follow, the resize re-anchor
+gate, and the visibility-return gate; transitions ONLY via `nextFollowMode` edges
+— scroll-up → off, reach-tail/send → on, content-grow → no-op) versus
+`atBottomNow` (pure geometry: drives ONLY the float scroll-to-bottom button, via
+`!atBottomNow`). They are behaviour-identical everywhere EXCEPT at send, where
+they deliberately **diverge**: send arms `followMode` immediately, while
+`atBottomNow` flips true only once the echo row lays out.
+
+**Derive the freeze from the count — don't latch it.** `isOverlayFrozen()` is now
+`overlayCount() > 0 && overlaySnapshotKey === key()`, evaluated LIVE — NOT a
+separately-cleared latch. The snapshot holds the restore-px ONLY (captured on each
+overlay-open edge, harmlessly stale after close, with no rAF clear to drift). This
+kills the drift class at the root: a leaked overlay count can no longer strand the
+freeze forever, because the freeze is *derived* from the count rather than being a
+second copy of the same state that must be reset in lockstep ("derive, don't
+duplicate"). The field bug's actual *trigger* — the `Shell.tsx` same-tick
+`pushOverlay` refcount leak (members drawer + admin pane pushed via a deferred
+`queueMicrotask` without the `createOverlayLock` re-check) — was fixed separately
+in C1 (`2cb64ca2`, cherry-picked HOT to prod main as `e3bc9923`); deriving the
+freeze from the count is what makes "frozen forever under a leaked count"
+impossible even if a future leak reappears.
+
+**Prepend-preserve is a post-await entrypoint, not a commit-frame intent.**
+`loadMore` (prepending older history) captures the pre-prepend `scrollHeight`
+before its await and restores by the height delta on the commit after the prepend
+lands — `applyPrependPreserve(oldScrollHeight, oldScrollTop)`, lowest precedence,
+a distinct entry into the applier rather than an intent resolved on a content-grow
+frame. Prepend mutates the top axis; it must preserve the reader's position across
+that mutation, which is a different lifecycle from every other (tail-oriented)
+write.
+
+**Send arms `followMode`; it does not scroll a non-existent node.** The old send
+path called `scrollToBottom()` synchronously on `ownSendSubmitted` — but there is
+no optimistic append (the echo is WS-driven), so it read *pre-append* geometry and
+scrolled to the old tail. That was the off-by-one at its source. Now the
+`ownSendSubmitted` effect sets `followMode` via `nextFollowMode "send"` and
+releases the marker latch; the applier tail-follows when the echo row actually
+mounts and settles. The #580 split is preserved: the follow-arm fires at submit,
+independent of the POST, while `lastOwnSend` (post-resolve) still owns the divider
+re-latch.
+
+**Measured-settle via `isSettled`, not a fixed rAF×2.** The rAF×2 "settle" was the
+§5 off-by-one root on iOS WebKit — two guessed frames are not a layout flush.
+`tailFollowWhenSettled()` polls per frame (bounded `SETTLE_MAX_FRAMES = 30`, with a
+fail-safe single tail if no growth is ever observed), forces a reflow, and scrolls
+on the frame where `isSettled` holds: `currScrollHeight` grew versus the
+`lastTailScrollHeight` baseline (the last-tail extent, reset on key change — NOT a
+dispatch-time read, which a fast engine can pre-grow) AND the tail node has a
+laid-out box. The poll stops on `!listRef.isConnected` so it can never outlive the
+component and fire on a shared prototype spy (a cross-test-pollution trap found
+during the build). This is the condition-based-waiting skill applied: wait for the
+real state, not a frame count.
+
+**Operator-tail is an instant, synchronous dispatch.** The gesture path (the
+float button and #243 retap) routes through `dispatchScrollWrite`'s `operator-tail`
+case + `applyOperatorTail()` and writes the tail INSTANTLY and synchronously — no
+async animation. This preserves the 2026-06-02 contamination fix: an async
+animation on the shared `.scrollback` node does not survive a window switch, so a
+deliberate operator tail must land in the same tick.
+
+The e2e/unit contract set (`issue168-scroll-authority`, `scroll-on-window-switch`,
+`scroll-multi-roundtrip-contamination`, `issue219(-general)-overlay-scroll-hold`,
+`issue196-preview-scroll-*`, `issue230-wheel-underfill-loadmore`, `issue239`,
+`issue280-button-coexist`, `issue289`, `issue360`, `unread-divider-beyond-window`,
+`marker-target-window-regression`, `freshness-on-activation`,
+`login-advanced-scroll-reachability`, `issue535`, `issue310`, `issue243`,
+`issue580`, and the rest) is unchanged in intent — the reshape is
+behaviour-preserving except at the two deliberate divergence points (send-arm,
+measured-settle). The off-by-one regression gate `bug7-ios-own-msg-visible` (+
+`bug7-m6-ios-dm-own-msg-visible`) was **strengthened, never weakened**: it now
+asserts the own row `toBeInViewport` AND distance-to-tail ≤ threshold after the
+settle. The deliberate test-layer split holds throughout: core geometry is a
+vitest `isSettled` unit test, the wiring is a chromium e2e, and real iOS is a
+device verify — Playwright webkit is not iOS scroll.


### PR DESCRIPTION
**HELD — do NOT merge before the v0.9.0 tag (vjt's order).**

Refs #608. This is the full ScrollbackPane scroll-authority refactor, held out of
prod until the 0.9.0 tag per vjt. On the PR to take CI for free while it waits.

## What this does
Collapses ScrollbackPane's 13 ad-hoc scroll writes / 19 createEffects (no
arbitration) into ONE scroll authority: effects DECLARE a `ScrollIntent`
`{kind, key, lifetime}`; a single applier owns every DOM scroll write; the pure
decision core lives in `lib/scrollAuthority.ts` (`resolveIntent` + `nextFollowMode`
+ `isSettled`, unit-tested). Precedence hi→lo: overlay-freeze ▸ operator-tail ▸
mention-jump ▸ marker-activation ▸ tail-follow ▸ prepend-preserve.

## Root causes killed
- **Stuck freeze**: Shell overlay locks went through a deferred `queueMicrotask`
  without the `createOverlayLock` re-check, leaking `overlayCount()` → freeze
  latched forever. Fixed by routing through `createOverlayLock` (already on main as
  e3bc9923, hot-shipped; dropped from this branch on rebase as a duplicate) + STEP2
  deriving freeze from the live refcount.
- **Off-by-one at send**: `sendMessage` does no optimistic append, so the old sync
  `scrollToBottom` scrolled the *old* tail by construction. STEP5 makes send ARM
  followMode instead; STEP6 replaces the rAF×2 guess with a MEASURED settle
  (`isSettled`).
- **Media-viewer close-snap regression** (caught by the scroll e2e): a genuine
  scroll-up edge racing the freeze engaging was dropped → followMode stranded true
  → deferred tail-follow fail-safe-tailed on overlay close. Fixed by reconciling
  followMode from snapshot geometry on both overlay edges + tail-follow bailing on
  `isOverlayFrozen()` each frame.

## Discipline
LOCK-then-REFACTOR on every writer (characterization test green on OLD code, then
the refactor — "identical" is falsifiable, not asserted). No raw scroll writes
outside the applier surface. bug7-ios / bug7-m6 asserts STRENGTHENED
(`toBeInViewport` + distance-to-tail), never weakened, no inflated timeouts.

## Verification (local, this branch after rebase onto d536ecba)
- cic `bun run check` (biome + tsc): EXIT 0 (37 pre-existing CSS warnings).
- full cic vitest: **3778 passed / 211 files**, EXIT 0 (delta vs the pre-rebase
  3759 = tests merged into main between the bases: #591 CTCP/ping, #600 ping RTT,
  #605 rail — none from #608).
- e2e `issue219-overlay-scroll-hold` `--repeat-each 5`: 5/5.
- full scroll-contract no-regression set (config-routed): 53 passed / 0 failed.

DESIGN_NOTES carries the rationale ("2026-08-01 — #608" + "#608 (follow-up)").