### PR TITLE
feat(#606): query windows get a rail context — heading + WHOIS card

### DIFF
--- a/cicchetto/e2e/tests/issue606-query-rail-whois.spec.ts
+++ b/cicchetto/e2e/tests/issue606-query-rail-whois.spec.ts
@@ -1,0 +1,102 @@
+// #606 — a query window gets its own rail context (the deferred half of
+// #474): a heading + a WHOIS card for the conversation partner, auto-fetched
+// on select. This e2e pins the LIVE end-to-end behaviour the vitest units
+// can't reach over the real socket + a real upstream WHOIS round-trip:
+//
+//   * selecting a query shows the heading `private conversation with <NICK>`
+//     AND a WHOIS card in the RAIL (NOT the scrollback overlay), auto-fetched;
+//   * the rail card is persistent — no × dismiss affordance (unlike the
+//     scrollback /whois card);
+//   * a peer NICK while the query is open re-labels the heading (#373 swaps
+//     selectedChannel in place, which the heading reads live);
+//   * an explicit `/whois` still renders its OWN card in the scrollback
+//     overlay, even though the rail already shows one — the two stores are
+//     disjoint by the server-marked `source` (#606 option 2), so `/whois` is
+//     undisturbed.
+//
+// The #605 rail-width cap on this same track is proven by
+// `issue605-rail-width-cap.spec.ts`; it binds here too because the reused
+// `.whois-card-fields dd` and the `.rail-query-heading` both `word-break`
+// (the coupling gotcha #605 flagged). Per `feedback_ux_e2e_mandatory` a
+// UX-behaviour change ships a Playwright e2e; the surface is subject-agnostic
+// (`feedback_e2e_user_class_parity_matrix`) so one user-class spec suffices.
+// Feature logic is engine-agnostic → chromium only (no `@webkit`), mirroring
+// nick-follow-query.spec.ts.
+
+import {
+  composeSend,
+  loginAs,
+  selectChannel,
+  waitForQueryWindowReady,
+} from "../fixtures/cicchettoPage";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+// Unique suffixes so retries / sibling specs don't collide on a nick already
+// in use upstream (same rule as nick-follow-query.spec.ts).
+const RUN_ID = crypto.randomUUID().slice(0, 8);
+const PEER = `Rail${RUN_ID}`;
+const PEER_RENAMED = `Rail2${RUN_ID}`;
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+test("query rail shows heading + auto-fetched WHOIS card, follows NICK, coexists with /whois", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  const peer = await IrcPeer.connect({ nick: PEER });
+  try {
+    // Share a channel so the peer is reachable AND grappa observes a later
+    // NICK (IRC only relays a NICK to channel-sharing users).
+    await peer.join(CHANNEL);
+
+    // Open + focus the query — this is what fires the rail's fetch-on-select.
+    await composeSend(page, `/q ${PEER}`);
+    await waitForQueryWindowReady(page, NETWORK_SLUG, PEER);
+
+    // Heading in the RAIL (scope to `.shell-members` so a regression that
+    // renders it elsewhere fails here).
+    const rail = page.locator(".shell-members");
+    const ctx = rail.getByTestId("rail-query-context");
+    await expect(ctx).toBeVisible({ timeout: 5_000 });
+    await expect(ctx.locator(".rail-query-heading")).toHaveText(
+      new RegExp(`private conversation with ${PEER}`, "i"),
+    );
+
+    // Auto-fetched WHOIS card in the RAIL (not the scrollback overlay). The
+    // card renders from the per-nick rail cache fed by the `source: rail`
+    // bundle the fetch-on-select requested.
+    const railCard = rail.getByTestId("whois-card");
+    await expect(railCard).toBeVisible({ timeout: 8_000 });
+    await expect(railCard.locator(".whois-card-target")).toHaveText(PEER);
+    // Persistent rail card → NO × dismiss (that affordance is the scrollback
+    // card's alone, gated on the onDismiss prop).
+    await expect(railCard.locator(".whois-card-close")).toHaveCount(0);
+    // The auto-fetch must NOT forge a scrollback-overlay card (the whole
+    // point of the disjoint stores): none present in the overlay layer.
+    await expect(page.locator(".scrollback-overlay").getByTestId("whois-card")).toHaveCount(0);
+
+    // A peer NICK while the query is open re-labels the heading (live).
+    await peer.changeNick(PEER_RENAMED);
+    await expect(ctx.locator(".rail-query-heading")).toHaveText(
+      new RegExp(`private conversation with ${PEER_RENAMED}`, "i"),
+      { timeout: 5_000 },
+    );
+
+    // Explicit /whois still renders its OWN card in the scrollback overlay,
+    // even though the rail already shows one — do not disturb the /whois card.
+    await composeSend(page, `/whois ${PEER_RENAMED}`);
+    const overlayCard = page.locator(".scrollback-overlay").getByTestId("whois-card");
+    await expect(overlayCard).toBeVisible({ timeout: 5_000 });
+    await expect(overlayCard.locator(".whois-card-target")).toHaveText(PEER_RENAMED);
+    // The overlay card DOES carry the × dismiss (the user asked for it)...
+    await expect(overlayCard.locator(".whois-card-close")).toHaveCount(1);
+    // ...and the rail card is STILL present (two disjoint cards at once).
+    await expect(railCard).toBeVisible();
+  } finally {
+    await peer.disconnect("#606 done");
+  }
+});

--- a/cicchetto/src/RailContext.tsx
+++ b/cicchetto/src/RailContext.tsx
@@ -48,13 +48,17 @@ const RailContext: Component = () => {
   const sel = () => selectedChannel();
 
   // #606 — fetch-on-select. When a query window is (re)focused, ask the rail
-  // WHOIS cache for its partner; the store de-dupes a fresh cache hit and an
-  // in-flight request, so re-selecting a query or fast A→B→A switching issues
-  // at most one WHOIS per nick. Keyed on the composed (slug, nick) string so
-  // the effect fires ONLY when the focused query's identity actually changes
-  // (a followQueryNick rename re-fetches for the new nick), not on every
-  // unrelated selection churn. A nick cannot contain a space, so the space
-  // separator is unambiguous.
+  // WHOIS cache for its partner; the store decides whether that costs an
+  // upstream command (it does not, for a nick already known). Keyed on the
+  // composed (slug, nick) string so the effect fires ONLY when the focused
+  // query's identity actually changes, not on every unrelated selection
+  // churn. A nick cannot contain a space, so the separator is unambiguous.
+  //
+  // A #373 rename DOES fire this effect — `followQueryNick` swaps the
+  // selection — but it must NOT cost a WHOIS: `subscribe.ts` migrates the
+  // rail cache old→new BEFORE that swap, so this lands on a hit. Solid
+  // flushes effects at the end of the write, so the ordering there is what
+  // holds this true; reverse it and every rename asks the ircd again.
   createEffect(
     on(
       () => {

--- a/cicchetto/src/RailContext.tsx
+++ b/cicchetto/src/RailContext.tsx
@@ -1,19 +1,34 @@
-import { type Component, createSignal, Match, onCleanup, Show, Switch } from "solid-js";
+import {
+  type Component,
+  createEffect,
+  createSignal,
+  Match,
+  on,
+  onCleanup,
+  Show,
+  Switch,
+} from "solid-js";
 import { networkBySlug } from "./lib/networks";
+import { railWhoisFor, requestRailWhois } from "./lib/railWhois";
 import { selectedChannel } from "./lib/selection";
 import ServerInfoCard from "./ServerInfoCard";
+import WhoisCard from "./WhoisCard";
 
 // #474 — the rail's GENERIC per-window-kind context surface. Mounted as a
 // sibling of the RailActions drawer inside `.shell-members` in BOTH Shell
 // rail branches (desktop + mobile). It reads the active window's kind and
 // grafts the matching context content:
 //   * server → ServerInfoCard (connection facts already in the store)
-//   * query  → a /whois card is the deferred other half of this design
-//              (issue #474 "follow-on, not scope here") — add a <Match>
-//              here when it lands, NOT a second Shell edit.
+//   * query  → the query context (#606, the deferred half of #474): a
+//              heading + a WHOIS card for the conversation partner,
+//              auto-fetched on select. The card REUSES the same `WhoisCard`
+//              presentation as the scrollback overlay but is fed by the
+//              per-nick `railWhois` cache (NOT the single-slot `whoisCard`
+//              store the user-issued /whois owns) and carries no × affordance
+//              (persistent, like the server card).
 // It renders NOTHING for kinds with no context content (channel already has
 // the MembersPane above; home/admin/list/mentions have none). Built as a
-// container, not a hardcoded server card, so the rail becomes the per-kind
+// container, not a hardcoded server card, so the rail is the per-kind
 // context surface the RailActions moduledoc (#473) always earmarked.
 
 const TICK_MS = 60_000;
@@ -32,12 +47,44 @@ const RailContext: Component = () => {
 
   const sel = () => selectedChannel();
 
+  // #606 — fetch-on-select. When a query window is (re)focused, ask the rail
+  // WHOIS cache for its partner; the store de-dupes a fresh cache hit and an
+  // in-flight request, so re-selecting a query or fast A→B→A switching issues
+  // at most one WHOIS per nick. Keyed on the composed (slug, nick) string so
+  // the effect fires ONLY when the focused query's identity actually changes
+  // (a followQueryNick rename re-fetches for the new nick), not on every
+  // unrelated selection churn. A nick cannot contain a space, so the space
+  // separator is unambiguous.
+  createEffect(
+    on(
+      () => {
+        const s = sel();
+        return s?.kind === "query" ? `${s.networkSlug} ${s.channelName}` : null;
+      },
+      (key) => {
+        if (key === null) return;
+        const sep = key.indexOf(" ");
+        requestRailWhois(key.slice(0, sep), key.slice(sep + 1));
+      },
+    ),
+  );
+
   return (
     <Switch>
       <Match when={sel()?.kind === "server"}>
         <Show when={networkBySlug(sel()?.networkSlug ?? "")}>
           {(net) => <ServerInfoCard network={net()} now={now()} />}
         </Show>
+      </Match>
+      <Match when={sel()?.kind === "query"}>
+        <div class="rail-query-context" data-testid="rail-query-context">
+          {/* Mirrors the MembersPane `<h3>members (n)</h3>` slot (uppercased
+              by CSS). The nick reads live off selectedChannel, so a NICK while
+              the query is open re-labels the heading — #373 swaps
+              selectedChannel in place on a rename. */}
+          <h3 class="rail-query-heading">private conversation with {sel()?.channelName}</h3>
+          <WhoisCard bundle={railWhoisFor(sel()?.networkSlug ?? "", sel()?.channelName ?? "")} />
+        </div>
       </Match>
     </Switch>
   );

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -55,6 +55,7 @@ import { scrollToBottomRequest } from "./lib/scrollToBottomCommand";
 import { setCursorIfAdvances, setSelectedChannel } from "./lib/selection";
 import { isMobile } from "./lib/theme";
 import { formatTimestamp } from "./lib/timeFormat";
+import { dismissWhoisCard, whoisCardBySlug } from "./lib/whoisCard";
 import { SERVER_WINDOW_NAME, type WindowKind } from "./lib/windowKinds";
 import { MircBody } from "./MircText";
 import NextActiveButton from "./NextActiveButton";
@@ -3323,7 +3324,10 @@ const ScrollbackPane: Component<Props> = (props) => {
       <div class="scrollback-overlay" data-testid="scrollback-overlay">
         {/* C2 — WHOIS card. Mounts on every window kind; the card itself
             short-circuits to null when no bundle is present. */}
-        <WhoisCard networkSlug={props.networkSlug} />
+        <WhoisCard
+          bundle={whoisCardBySlug()[props.networkSlug]}
+          onDismiss={() => dismissWhoisCard(props.networkSlug)}
+        />
         {/* P-0c — WHOWAS card. Mirrors WhoisCard mount shape (every window
             kind, not just $server). */}
         <WhowasCard networkSlug={props.networkSlug} />

--- a/cicchetto/src/WhoisCard.tsx
+++ b/cicchetto/src/WhoisCard.tsx
@@ -1,6 +1,7 @@
 import { type Component, For, Show } from "solid-js";
 import type { WhoisBundle } from "./lib/api";
 import { formatDuration } from "./lib/duration";
+import { whoisBundleHasFields } from "./lib/whoisBundle";
 import { MircBody } from "./MircText";
 import NickText from "./NickText";
 
@@ -81,36 +82,7 @@ const WhoisCard: Component<Props> = (props) => {
   const bundle = () => props.bundle;
   const hasFields = (): boolean => {
     const b = bundle();
-    if (!b) return false;
-    return (
-      b.user !== null ||
-      b.host !== null ||
-      b.realname !== null ||
-      b.server !== null ||
-      b.is_operator ||
-      b.idle_seconds !== null ||
-      b.channels !== null ||
-      // P-0a — extended flags also count as "has data"
-      b.using_ssl ||
-      b.is_registered ||
-      b.is_admin ||
-      b.is_services_admin ||
-      b.is_helper ||
-      b.is_chanop ||
-      b.is_agent ||
-      b.is_java ||
-      b.umodes !== null ||
-      b.away_message !== null ||
-      b.actually_host !== null ||
-      // #221 — solanum-specific fields also count as "has data".
-      b.account !== null ||
-      b.secure ||
-      b.certfp !== null ||
-      // #673 — an oper-only or privacy-stripped reply can carry nothing
-      // but an extra line; without this the card claims "no WHOIS
-      // information returned" while holding the line /whois was run for.
-      (b.extra_lines?.length ?? 0) > 0
-    );
+    return b !== undefined && whoisBundleHasFields(b);
   };
 
   return (

--- a/cicchetto/src/WhoisCard.tsx
+++ b/cicchetto/src/WhoisCard.tsx
@@ -1,7 +1,6 @@
 import { type Component, For, Show } from "solid-js";
 import type { WhoisBundle } from "./lib/api";
 import { formatDuration } from "./lib/duration";
-import { dismissWhoisCard, whoisCardBySlug } from "./lib/whoisCard";
 import { MircBody } from "./MircText";
 import NickText from "./NickText";
 
@@ -30,12 +29,23 @@ import NickText from "./NickText";
 // grappa-generated localized string, so the no-localized-strings policy
 // does not gate it. Same class as `server_info` / channel names.
 //
-// Close affordance: × button on the right calls `dismissWhoisCard` for
-// this network. Mounted by `ScrollbackPane.tsx` only when a bundle
-// exists for the selected window's network slug.
+// #606 — PROP-DRIVEN presentation. WhoisCard renders whatever `bundle` it
+// is handed and knows nothing about WHERE that bundle lives:
+//   * the scrollback overlay (`ScrollbackPane`) passes the single-slot
+//     `whoisCardBySlug` bundle for the active window's network AND an
+//     `onDismiss` — the × button that clears the user-issued /whois card;
+//   * the query rail context (`RailContext`, #606) passes its per-nick
+//     `railWhoisFor` bundle and OMITS `onDismiss` — the rail card is a
+//     persistent per-window-kind surface (like `ServerInfoCard`), so it has
+//     no × affordance.
+// Short-circuits to nothing when `bundle` is undefined, so both mount sites
+// can render it unconditionally.
 
 export type Props = {
-  networkSlug: string;
+  bundle: WhoisBundle | undefined;
+  /** When supplied, renders the × dismiss button wired to this handler
+      (the ephemeral scrollback card). Omit for the persistent rail card. */
+  onDismiss?: () => void;
 };
 
 const formatSignon = (epochSeconds: number | null): string | null => {
@@ -68,7 +78,7 @@ const collectTags = (b: WhoisBundle): TagChip[] => {
 };
 
 const WhoisCard: Component<Props> = (props) => {
-  const bundle = () => whoisCardBySlug()[props.networkSlug];
+  const bundle = () => props.bundle;
   const hasFields = (): boolean => {
     const b = bundle();
     if (!b) return false;
@@ -114,14 +124,16 @@ const WhoisCard: Component<Props> = (props) => {
                 <span class={`whois-card-tag whois-card-tag-${tag.cssMod}`}>{tag.label}</span>
               )}
             </For>
-            <button
-              type="button"
-              class="whois-card-close"
-              aria-label="Dismiss WHOIS"
-              onClick={() => dismissWhoisCard(props.networkSlug)}
-            >
-              ×
-            </button>
+            <Show when={props.onDismiss}>
+              <button
+                type="button"
+                class="whois-card-close"
+                aria-label="Dismiss WHOIS"
+                onClick={() => props.onDismiss?.()}
+              >
+                ×
+              </button>
+            </Show>
           </div>
           <Show
             when={hasFields()}

--- a/cicchetto/src/__tests__/RailContext.test.tsx
+++ b/cicchetto/src/__tests__/RailContext.test.tsx
@@ -1,25 +1,38 @@
 import { render, screen } from "@solidjs/testing-library";
-import { describe, expect, it, vi } from "vitest";
-import type { Network } from "../lib/api";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Network, WhoisBundle } from "../lib/api";
 import type { SelectedChannel } from "../lib/selection";
 import type { WindowKind } from "../lib/windowKinds";
 
 // #474 — RailContext is the GENERIC per-window-kind context surface grafted
 // as a sibling of the RailActions drawer. It dispatches on the active
-// window's kind: server → ServerInfoCard today; query → whois is the
-// deferred follow-on. It renders NOTHING for kinds with no context content.
-// Built as a container (not a hardcoded server card) so future per-kind
-// content grafts here without touching Shell's two rail mounts.
+// window's kind: server → ServerInfoCard; query → whois context (#606, the
+// deferred half of #474). It renders NOTHING for kinds with no context.
+// Built as a container so future per-kind content grafts here without
+// touching Shell's two rail mounts.
 
-const selectedChannelMock = vi.hoisted(() => vi.fn<() => SelectedChannel | null>());
 const networkBySlugMock = vi.hoisted(() => vi.fn<(slug: string) => Network | undefined>());
+const requestRailWhoisMock = vi.hoisted(() => vi.fn<(slug: string, nick: string) => void>());
+const railWhoisForMock = vi.hoisted(() =>
+  vi.fn<(slug: string, nick: string) => WhoisBundle | undefined>(),
+);
 
-vi.mock("../lib/selection", () => ({
-  selectedChannel: () => selectedChannelMock(),
-}));
+// selection is signal-backed so a live NICK change (followQueryNick swapping
+// selectedChannel) re-renders the container mid-mount, exercising #606's
+// "heading must follow the nick" contract.
+vi.mock("../lib/selection", async () => {
+  const { createSignal } = await import("solid-js");
+  const [sel, setSel] = createSignal<SelectedChannel | null>(null);
+  return { selectedChannel: sel, __setSelected: setSel };
+});
 
 vi.mock("../lib/networks", () => ({
   networkBySlug: (slug: string) => networkBySlugMock(slug),
+}));
+
+vi.mock("../lib/railWhois", () => ({
+  requestRailWhois: (slug: string, nick: string) => requestRailWhoisMock(slug, nick),
+  railWhoisFor: (slug: string, nick: string) => railWhoisForMock(slug, nick),
 }));
 
 const net: Network = {
@@ -44,44 +57,116 @@ const sel = (kind: WindowKind, channelName: string): SelectedChannel => ({
   kind,
 });
 
+async function setSelected(value: SelectedChannel | null): Promise<void> {
+  const mod = (await import("../lib/selection")) as unknown as {
+    __setSelected: (v: SelectedChannel | null) => void;
+  };
+  mod.__setSelected(value);
+  await Promise.resolve();
+}
+
 async function renderContainer() {
   const { default: RailContext } = await import("../RailContext");
-  return render(() => <RailContext />);
+  const result = render(() => <RailContext />);
+  await Promise.resolve();
+  return result;
 }
+
+beforeEach(() => {
+  networkBySlugMock.mockReset();
+  requestRailWhoisMock.mockReset();
+  railWhoisForMock.mockReset();
+  railWhoisForMock.mockReturnValue(undefined);
+});
+
+afterEach(async () => {
+  await setSelected(null);
+});
 
 describe("RailContext per-kind dispatch", () => {
   it("renders the ServerInfoCard on a server window when the network is live", async () => {
-    selectedChannelMock.mockReturnValue(sel("server", "$server"));
+    await setSelected(sel("server", "$server"));
     networkBySlugMock.mockReturnValue(net);
     await renderContainer();
-    const card = screen.getByTestId("rail-server-info");
-    expect(card.textContent).toContain("libera");
+    expect(screen.getByTestId("rail-server-info").textContent).toContain("libera");
   });
 
   it("renders nothing on a server window whose network is not live", async () => {
-    selectedChannelMock.mockReturnValue(sel("server", "$server"));
+    await setSelected(sel("server", "$server"));
     networkBySlugMock.mockReturnValue(undefined);
     await renderContainer();
     expect(screen.queryByTestId("rail-server-info")).toBeNull();
   });
 
   it("renders nothing on a channel window", async () => {
-    selectedChannelMock.mockReturnValue(sel("channel", "#italia"));
+    await setSelected(sel("channel", "#italia"));
     networkBySlugMock.mockReturnValue(net);
     await renderContainer();
     expect(screen.queryByTestId("rail-server-info")).toBeNull();
-  });
-
-  it("renders nothing on a query window (whois context is a deferred follow-on)", async () => {
-    selectedChannelMock.mockReturnValue(sel("query", "alice"));
-    networkBySlugMock.mockReturnValue(net);
-    await renderContainer();
-    expect(screen.queryByTestId("rail-server-info")).toBeNull();
+    expect(screen.queryByTestId("rail-query-context")).toBeNull();
   });
 
   it("renders nothing when no window is selected", async () => {
-    selectedChannelMock.mockReturnValue(null);
+    await setSelected(null);
     await renderContainer();
     expect(screen.queryByTestId("rail-server-info")).toBeNull();
+    expect(screen.queryByTestId("rail-query-context")).toBeNull();
+  });
+});
+
+describe("RailContext query context (#606)", () => {
+  it("renders the heading 'private conversation with <nick>' on a query window", async () => {
+    await setSelected(sel("query", "alice"));
+    await renderContainer();
+    const ctx = screen.getByTestId("rail-query-context");
+    expect(ctx.textContent).toContain("private conversation with");
+    expect(ctx.textContent).toContain("alice");
+    // The server-info card is NOT what a query renders.
+    expect(screen.queryByTestId("rail-server-info")).toBeNull();
+  });
+
+  it("fires requestRailWhois(slug, nick) when a query is selected", async () => {
+    await setSelected(sel("query", "alice"));
+    await renderContainer();
+    expect(requestRailWhoisMock).toHaveBeenCalledWith("libera", "alice");
+  });
+
+  it("updates the heading when the query's nick changes while open (followQueryNick)", async () => {
+    await setSelected(sel("query", "alice"));
+    await renderContainer();
+    expect(screen.getByTestId("rail-query-context").textContent).toContain("alice");
+    // A peer NICK alice→alice2 swaps selectedChannel in place (#373).
+    await setSelected(sel("query", "alice2"));
+    const ctx = screen.getByTestId("rail-query-context");
+    expect(ctx.textContent).toContain("alice2");
+    expect(ctx.textContent).not.toContain("with alice "); // no stale nick
+  });
+
+  it("re-fires requestRailWhois for the new nick after a rename", async () => {
+    await setSelected(sel("query", "alice"));
+    await renderContainer();
+    await setSelected(sel("query", "alice2"));
+    expect(requestRailWhoisMock).toHaveBeenCalledWith("libera", "alice");
+    expect(requestRailWhoisMock).toHaveBeenCalledWith("libera", "alice2");
+  });
+
+  it("renders the WhoisCard when a rail bundle exists for the selected nick", async () => {
+    railWhoisForMock.mockImplementation((_slug, nick) =>
+      nick === "alice"
+        ? ({ target: "alice", account: "AliceAcct" } as unknown as WhoisBundle)
+        : undefined,
+    );
+    await setSelected(sel("query", "alice"));
+    await renderContainer();
+    expect(screen.getByTestId("whois-card")).toBeInTheDocument();
+    expect(screen.getByTestId("whois-card").textContent).toContain("AliceAcct");
+  });
+
+  it("renders the heading but no WhoisCard when no rail bundle exists yet", async () => {
+    railWhoisForMock.mockReturnValue(undefined);
+    await setSelected(sel("query", "alice"));
+    await renderContainer();
+    expect(screen.getByTestId("rail-query-context")).toBeInTheDocument();
+    expect(screen.queryByTestId("whois-card")).toBeNull();
   });
 });

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -4855,6 +4855,7 @@ describe("ScrollbackPane", () => {
     const overlayBundle: WhoisBundle = {
       network: "overlaynet",
       target: "carol",
+      source: "user",
       user: "carol_u",
       host: "carol.host",
       realname: "Carol",

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -145,6 +145,15 @@ vi.mock("../lib/networks", () => ({
   networkBySlug: () => undefined,
 }));
 
+// #606 — RailContext's query context auto-fetches WHOIS on select via
+// railWhois. Shell's integration tests cover LAYOUT, not that fetch (railWhois
+// + RailContext own it), so stub it to a no-op — otherwise the real store
+// hits networkIdBySlug (not on this file's networks mock) and pushWhois.
+vi.mock("../lib/railWhois", () => ({
+  requestRailWhois: () => {},
+  railWhoisFor: () => undefined,
+}));
+
 vi.mock("../lib/selection", () => ({
   selectedChannel: () => selectionState.selSig(),
   setSelectedChannel: selectionState.setSelectedChannelMock,

--- a/cicchetto/src/__tests__/WhoisCard.test.tsx
+++ b/cicchetto/src/__tests__/WhoisCard.test.tsx
@@ -1,17 +1,23 @@
-import { render, screen } from "@solidjs/testing-library";
-import { afterEach, describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
 import type { WhoisBundle } from "../lib/api";
-import { dismissWhoisCard, setWhoisBundle } from "../lib/whoisCard";
 import WhoisCard from "../WhoisCard";
 
 // P-0a — Cluster `numeric-delegation-p0` 2026-05-13. Verifies WhoisCard
 // renders all 11 newly-folded WHOIS-leg flags as inline tag chips +
 // structured rows. Server emits typed booleans / strings; cic builds
 // the human-readable strings ("services agent" / "SSL" / etc) here.
+//
+// #606 — WhoisCard is now PROP-DRIVEN (presentational): it takes the
+// `bundle` to render + an optional `onDismiss`. The scrollback overlay
+// passes the single-slot `whoisCardBySlug` bundle + a dismiss handler;
+// the query rail (#606) passes its per-nick bundle and OMITS onDismiss
+// (the rail card is persistent, like ServerInfoCard — no × button).
 
 const baseBundle: WhoisBundle = {
   network: "azzurra",
   target: "alice",
+  source: "user",
   user: "alice_u",
   host: "alice.host",
   realname: "Alice Liddell",
@@ -41,39 +47,33 @@ const baseBundle: WhoisBundle = {
   extra_lines: null,
 };
 
-describe("WhoisCard P-0a flags", () => {
-  afterEach(() => {
-    dismissWhoisCard("azzurra");
-  });
+const renderCard = (overrides: Partial<WhoisBundle> = {}, onDismiss?: () => void) =>
+  render(() => <WhoisCard bundle={{ ...baseBundle, ...overrides }} onDismiss={onDismiss} />);
 
+describe("WhoisCard P-0a flags", () => {
   it("renders SSL tag when using_ssl: true", () => {
-    setWhoisBundle("azzurra", { ...baseBundle, using_ssl: true });
-    render(() => <WhoisCard networkSlug="azzurra" />);
+    renderCard({ using_ssl: true });
     expect(screen.getByText("SSL")).toBeInTheDocument();
   });
 
   it("renders 'registered' tag when is_registered: true", () => {
-    setWhoisBundle("azzurra", { ...baseBundle, is_registered: true });
-    render(() => <WhoisCard networkSlug="azzurra" />);
+    renderCard({ is_registered: true });
     expect(screen.getByText("registered")).toBeInTheDocument();
   });
 
   it("renders 'services agent' tag when is_agent: true", () => {
-    setWhoisBundle("azzurra", { ...baseBundle, is_agent: true });
-    render(() => <WhoisCard networkSlug="azzurra" />);
+    renderCard({ is_agent: true });
     expect(screen.getByText("services agent")).toBeInTheDocument();
   });
 
   it("renders 'server admin' / 'services admin' / 'helper' / 'chanop' / 'java' tags from typed flags", () => {
-    setWhoisBundle("azzurra", {
-      ...baseBundle,
+    renderCard({
       is_admin: true,
       is_services_admin: true,
       is_helper: true,
       is_chanop: true,
       is_java: true,
     });
-    render(() => <WhoisCard networkSlug="azzurra" />);
     expect(screen.getByText("server admin")).toBeInTheDocument();
     expect(screen.getByText("services admin")).toBeInTheDocument();
     expect(screen.getByText("helper")).toBeInTheDocument();
@@ -82,19 +82,13 @@ describe("WhoisCard P-0a flags", () => {
   });
 
   it("renders away row with the away message when away_message is non-null", () => {
-    setWhoisBundle("azzurra", { ...baseBundle, away_message: "Gone fishing" });
-    render(() => <WhoisCard networkSlug="azzurra" />);
+    renderCard({ away_message: "Gone fishing" });
     expect(screen.getByText("away")).toBeInTheDocument();
     expect(screen.getByText("Gone fishing")).toBeInTheDocument();
   });
 
   it("renders 'connecting from' row with host + ip when actually_host/ip set", () => {
-    setWhoisBundle("azzurra", {
-      ...baseBundle,
-      actually_host: "real.host.example",
-      actually_ip: "192.0.2.42",
-    });
-    render(() => <WhoisCard networkSlug="azzurra" />);
+    renderCard({ actually_host: "real.host.example", actually_ip: "192.0.2.42" });
     expect(screen.getByText("connecting from")).toBeInTheDocument();
     const card = screen.getByTestId("whois-card");
     expect(card.textContent).toContain("real.host.example");
@@ -102,15 +96,13 @@ describe("WhoisCard P-0a flags", () => {
   });
 
   it("renders modes row with the extracted umode string when umodes is set", () => {
-    setWhoisBundle("azzurra", { ...baseBundle, umodes: "+iZ" });
-    render(() => <WhoisCard networkSlug="azzurra" />);
+    renderCard({ umodes: "+iZ" });
     expect(screen.getByText("modes")).toBeInTheDocument();
     expect(screen.getByText("+iZ")).toBeInTheDocument();
   });
 
   it("does NOT render any P-0a tag chip when all flags are false (defaults)", () => {
-    setWhoisBundle("azzurra", baseBundle);
-    render(() => <WhoisCard networkSlug="azzurra" />);
+    renderCard();
     // Empty-flag header should NOT contain any of the localized tag labels.
     const card = screen.getByTestId("whois-card");
     expect(card.textContent).not.toContain("SSL");
@@ -127,8 +119,7 @@ describe("WhoisCard P-0a flags", () => {
   // modes lines still show control codes"). RED on the unfixed card: the
   // raw `\x03`/`\x02` bytes sit in textContent and no mIRC span exists.
   it("renders mIRC formatting in umodes / connecting-from / server_info, never raw control bytes", () => {
-    setWhoisBundle("azzurra", {
-      ...baseBundle,
+    renderCard({
       // \x02 bold, \x03 04 red, \x0f reset — the codes a colored vhost /
       // swhois / formatted gecos carries on the wire.
       umodes: "\x02+iZ\x02",
@@ -137,7 +128,6 @@ describe("WhoisCard P-0a flags", () => {
       server_info: "\x0303Azzurra\x03 Hub",
       realname: "\x1fAlice\x1f",
     });
-    render(() => <WhoisCard networkSlug="azzurra" />);
     const card = screen.getByTestId("whois-card");
 
     // The parser splits the formatted runs into styled <span>s — proof the
@@ -159,8 +149,7 @@ describe("WhoisCard P-0a flags", () => {
   });
 
   it("renders ALL chip labels in the same card for a fully-flagged services-agent user", () => {
-    setWhoisBundle("azzurra", {
-      ...baseBundle,
+    renderCard({
       is_operator: true,
       is_registered: true,
       is_agent: true,
@@ -170,7 +159,6 @@ describe("WhoisCard P-0a flags", () => {
       actually_ip: "10.0.0.1",
       away_message: "AFK",
     });
-    render(() => <WhoisCard networkSlug="azzurra" />);
     const card = screen.getByTestId("whois-card");
     expect(card.textContent).toContain("oper");
     expect(card.textContent).toContain("registered");
@@ -182,6 +170,28 @@ describe("WhoisCard P-0a flags", () => {
   });
 });
 
+// #606 — the presentational contract: bundle is prop-injected, and the ×
+// dismiss button is present ONLY when an onDismiss handler is supplied.
+describe("WhoisCard #606 prop-driven render", () => {
+  it("renders nothing when no bundle is supplied", () => {
+    render(() => <WhoisCard bundle={undefined} />);
+    expect(screen.queryByTestId("whois-card")).toBeNull();
+  });
+
+  it("renders the × dismiss button and fires onDismiss when supplied (scrollback card)", () => {
+    const onDismiss = vi.fn();
+    renderCard({}, onDismiss);
+    const close = screen.getByLabelText("Dismiss WHOIS");
+    fireEvent.click(close);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the × dismiss button when no onDismiss is supplied (persistent rail card)", () => {
+    renderCard();
+    expect(screen.queryByLabelText("Dismiss WHOIS")).toBeNull();
+  });
+});
+
 // #367 — 313 RPL_WHOISOPERATOR role text. bahamut (Azzurra) distinguishes
 // operator levels via the trailing text ("is an IRC Operator" vs "is a
 // Server Administrator" vs "is a Services Administrator"). The bug: the card
@@ -190,17 +200,8 @@ describe("WhoisCard P-0a flags", () => {
 // fix surfaces `oper_text` as a structured row while KEEPING the "oper"
 // badge as the always-on flag + the fallback for a bare 313.
 describe("WhoisCard #367 oper role text", () => {
-  afterEach(() => {
-    dismissWhoisCard("azzurra");
-  });
-
   it("renders the role text row AND the oper badge when oper_text is present", () => {
-    setWhoisBundle("azzurra", {
-      ...baseBundle,
-      is_operator: true,
-      oper_text: "is a Services Administrator",
-    });
-    render(() => <WhoisCard networkSlug="azzurra" />);
+    renderCard({ is_operator: true, oper_text: "is a Services Administrator" });
     const card = screen.getByTestId("whois-card");
     // The role text is surfaced verbatim (upstream ircd string).
     expect(card.textContent).toContain("is a Services Administrator");
@@ -212,12 +213,7 @@ describe("WhoisCard #367 oper role text", () => {
   it("routes oper_text through the mIRC renderer, never leaking raw control bytes", () => {
     // A services-set swhois can carry mIRC formatting — it must route
     // through MircBody like every other free-text whois field (#142 lesson).
-    setWhoisBundle("azzurra", {
-      ...baseBundle,
-      is_operator: true,
-      oper_text: "\x0304is a Services Administrator\x0f",
-    });
-    render(() => <WhoisCard networkSlug="azzurra" />);
+    renderCard({ is_operator: true, oper_text: "\x0304is a Services Administrator\x0f" });
     const card = screen.getByTestId("whois-card");
     expect(card.textContent).toContain("is a Services Administrator");
     for (const byte of ["\x03", "\x0f"]) {
@@ -226,8 +222,7 @@ describe("WhoisCard #367 oper role text", () => {
   });
 
   it("falls back to the bare oper badge with NO role row when oper_text is null (bare 313)", () => {
-    setWhoisBundle("azzurra", { ...baseBundle, is_operator: true, oper_text: null });
-    render(() => <WhoisCard networkSlug="azzurra" />);
+    renderCard({ is_operator: true, oper_text: null });
     const card = screen.getByTestId("whois-card");
     // Badge still present (is_operator latched)...
     expect(card.querySelector(".whois-card-tag-oper")).not.toBeNull();
@@ -245,47 +240,34 @@ describe("WhoisCard #367 oper role text", () => {
 // + certfp were never rendered at all. These lock the fix: a badge/field
 // keyed off the solanum fields, without regressing the bahamut path.
 describe("WhoisCard #221 solanum fields", () => {
-  afterEach(() => {
-    dismissWhoisCard("azzurra");
-  });
-
   it("renders 'registered' badge from account (330) even when is_registered is false", () => {
     // solanum: account present, is_registered false (no 307 emitted).
-    setWhoisBundle("azzurra", { ...baseBundle, account: "AliceAccount", is_registered: false });
-    render(() => <WhoisCard networkSlug="azzurra" />);
+    renderCard({ account: "AliceAccount", is_registered: false });
     expect(screen.getByText("registered")).toBeInTheDocument();
   });
 
   it("renders 'SSL' badge from secure (671) even when using_ssl is false", () => {
     // solanum: secure true, using_ssl false (no 275 emitted).
-    setWhoisBundle("azzurra", { ...baseBundle, secure: true, using_ssl: false });
-    render(() => <WhoisCard networkSlug="azzurra" />);
+    renderCard({ secure: true, using_ssl: false });
     expect(screen.getByText("SSL")).toBeInTheDocument();
   });
 
   it("renders the account name in a dedicated row when account is set", () => {
-    setWhoisBundle("azzurra", { ...baseBundle, account: "AliceAccount" });
-    render(() => <WhoisCard networkSlug="azzurra" />);
+    renderCard({ account: "AliceAccount" });
     expect(screen.getByText("account")).toBeInTheDocument();
     const card = screen.getByTestId("whois-card");
     expect(card.textContent).toContain("AliceAccount");
   });
 
   it("renders the TLS protocol string from secure_cipher when present", () => {
-    setWhoisBundle("azzurra", {
-      ...baseBundle,
-      secure: true,
-      secure_cipher: "TLSv1.3, TLS_AES_256_GCM_SHA384",
-    });
-    render(() => <WhoisCard networkSlug="azzurra" />);
+    renderCard({ secure: true, secure_cipher: "TLSv1.3, TLS_AES_256_GCM_SHA384" });
     expect(screen.getByText("secure")).toBeInTheDocument();
     const card = screen.getByTestId("whois-card");
     expect(card.textContent).toContain("TLSv1.3, TLS_AES_256_GCM_SHA384");
   });
 
   it("renders the certfp fingerprint row when certfp is set", () => {
-    setWhoisBundle("azzurra", { ...baseBundle, certfp: "deadbeefcafef00d" });
-    render(() => <WhoisCard networkSlug="azzurra" />);
+    renderCard({ certfp: "deadbeefcafef00d" });
     expect(screen.getByText("cert")).toBeInTheDocument();
     const card = screen.getByTestId("whois-card");
     expect(card.textContent).toContain("deadbeefcafef00d");
@@ -294,15 +276,13 @@ describe("WhoisCard #221 solanum fields", () => {
   it("renders registered badge + account name + SSL badge + TLS proto together for a solanum user", () => {
     // The full reopened-#221 bug scenario in one card: registered + TLS
     // Libera user must NOT look anonymous + insecure.
-    setWhoisBundle("azzurra", {
-      ...baseBundle,
+    renderCard({
       account: "AliceAccount",
       secure: true,
       secure_cipher: "TLSv1.3, TLS_AES_256_GCM_SHA384",
       is_registered: false,
       using_ssl: false,
     });
-    render(() => <WhoisCard networkSlug="azzurra" />);
     const card = screen.getByTestId("whois-card");
     expect(card.textContent).toContain("registered");
     expect(card.textContent).toContain("SSL");
@@ -311,8 +291,7 @@ describe("WhoisCard #221 solanum fields", () => {
   });
 
   it("does NOT render a 'registered' badge or account row when account is null and is_registered false", () => {
-    setWhoisBundle("azzurra", baseBundle);
-    render(() => <WhoisCard networkSlug="azzurra" />);
+    renderCard();
     const card = screen.getByTestId("whois-card");
     expect(card.textContent).not.toContain("registered");
     expect(card.textContent).not.toContain("account");

--- a/cicchetto/src/__tests__/WhoisCard.test.tsx
+++ b/cicchetto/src/__tests__/WhoisCard.test.tsx
@@ -311,28 +311,18 @@ describe("WhoisCard #221 solanum fields", () => {
 // wire delivers ARRIVAL order. The card must render that order as-is —
 // a card-side reverse would ship lines backwards. Locked below.
 describe("WhoisCard #673 extra_lines", () => {
-  afterEach(() => {
-    dismissWhoisCard("azzurra");
-  });
-
   it("renders the extra_line text for a shunned user (340 RPL_SHUNNED)", () => {
-    setWhoisBundle("azzurra", {
-      ...baseBundle,
-      extra_lines: [{ numeric: 340, text: "is currently shunned" }],
-    });
-    render(() => <WhoisCard networkSlug="azzurra" />);
+    renderCard({ extra_lines: [{ numeric: 340, text: "is currently shunned" }] });
     expect(screen.getByTestId("whois-card").textContent).toContain("is currently shunned");
   });
 
   it("renders multiple extra_lines in ARRIVAL order", () => {
-    setWhoisBundle("azzurra", {
-      ...baseBundle,
+    renderCard({
       extra_lines: [
         { numeric: 320, text: "is a volunteer staff member" },
         { numeric: 340, text: "is currently shunned" },
       ],
     });
-    render(() => <WhoisCard networkSlug="azzurra" />);
     const lines = screen.getByTestId("whois-card").querySelectorAll(".whois-card-extra-line");
     expect(Array.from(lines, (el) => el.textContent)).toEqual([
       "is a volunteer staff member",
@@ -343,11 +333,7 @@ describe("WhoisCard #673 extra_lines", () => {
   it("exposes the numeric on hover, keeping it out of the card body text", () => {
     // The bare trailing text keeps the card readable; the numeric is
     // oper-facing diagnostics, so it rides in `title` instead.
-    setWhoisBundle("azzurra", {
-      ...baseBundle,
-      extra_lines: [{ numeric: 340, text: "is currently shunned" }],
-    });
-    render(() => <WhoisCard networkSlug="azzurra" />);
+    renderCard({ extra_lines: [{ numeric: 340, text: "is currently shunned" }] });
     const card = screen.getByTestId("whois-card");
     expect(card.querySelector(".whois-card-extra-line")?.getAttribute("title")).toContain("340");
     expect(card.textContent).not.toContain("340");
@@ -356,11 +342,7 @@ describe("WhoisCard #673 extra_lines", () => {
   it("routes extra_line text through the mIRC renderer, never leaking raw control bytes", () => {
     // Same class as `oper_text` / swhois (#142): a services-set line can
     // carry mIRC formatting, so it must not be interpolated raw.
-    setWhoisBundle("azzurra", {
-      ...baseBundle,
-      extra_lines: [{ numeric: 320, text: "\x0304is a volunteer staff member\x0f" }],
-    });
-    render(() => <WhoisCard networkSlug="azzurra" />);
+    renderCard({ extra_lines: [{ numeric: 320, text: "\x0304is a volunteer staff member\x0f" }] });
     const card = screen.getByTestId("whois-card");
     expect(card.textContent).toContain("is a volunteer staff member");
     for (const byte of ["\x03", "\x0f"]) {
@@ -372,8 +354,7 @@ describe("WhoisCard #673 extra_lines", () => {
     // A privacy-stripped or oper-only reply can carry nothing but an
     // extra_line. Without this the card renders "no WHOIS information
     // returned" while holding the very line the user ran /whois for.
-    setWhoisBundle("azzurra", {
-      ...baseBundle,
+    renderCard({
       user: null,
       host: null,
       realname: null,
@@ -381,15 +362,13 @@ describe("WhoisCard #673 extra_lines", () => {
       server_info: null,
       extra_lines: [{ numeric: 340, text: "is currently shunned" }],
     });
-    render(() => <WhoisCard networkSlug="azzurra" />);
     const card = screen.getByTestId("whois-card");
     expect(card.textContent).toContain("is currently shunned");
     expect(card.textContent).not.toContain("no WHOIS information returned");
   });
 
   it("renders no extra-line row when extra_lines is null (the bahamut-plain path)", () => {
-    setWhoisBundle("azzurra", baseBundle);
-    render(() => <WhoisCard networkSlug="azzurra" />);
+    renderCard();
     expect(screen.getByTestId("whois-card").querySelector(".whois-card-extra-line")).toBeNull();
   });
 });

--- a/cicchetto/src/__tests__/railWhois.test.ts
+++ b/cicchetto/src/__tests__/railWhois.test.ts
@@ -96,20 +96,25 @@ describe("railWhois", () => {
     expect(pushWhoisMock).toHaveBeenCalledWith(1, "alice", null, "rail");
   });
 
-  it("does NOT re-issue WHOIS on a re-select inside the TTL once a bundle is cached", async () => {
+  it("never re-issues WHOIS for an answered nick, however old the bundle", async () => {
+    // The freshness TTL is deliberately gone. A WHOIS is not free and not
+    // invisible: on bahamut it shares PRIVMSG's fake-lag budget (~5 close
+    // commands and the ircd stops reading grappa's socket, so the operator's
+    // next message waits in the kernel buffer), and a +y target is TOLD it
+    // happened. A staleness refetch spends both on data nobody asked to
+    // refresh, so an answered nick is answered for good.
     const { requestRailWhois, ingestRailWhois } = await import("../lib/railWhois");
     requestRailWhois("azzurra", "alice");
     ingestRailWhois("azzurra", "alice", bundle("alice"));
-    vi.setSystemTime(T0 + 30_000); // still inside the 60s TTL
+    vi.setSystemTime(T0 + 6 * 60 * 60 * 1000); // six hours later
     requestRailWhois("azzurra", "alice");
     expect(pushWhoisMock).toHaveBeenCalledTimes(1);
   });
 
-  it("re-issues WHOIS on a re-select after the TTL lapses", async () => {
-    const { requestRailWhois, ingestRailWhois } = await import("../lib/railWhois");
-    requestRailWhois("azzurra", "alice");
-    ingestRailWhois("azzurra", "alice", bundle("alice"));
-    vi.setSystemTime(T0 + 61_000); // past the 60s TTL
+  it("re-issues only for a request that was never answered (pending TTL lapsed)", async () => {
+    const { requestRailWhois } = await import("../lib/railWhois");
+    requestRailWhois("azzurra", "alice"); // no bundle ever arrives
+    vi.setSystemTime(T0 + 31_000);
     requestRailWhois("azzurra", "alice");
     expect(pushWhoisMock).toHaveBeenCalledTimes(2);
   });
@@ -170,6 +175,102 @@ describe("railWhois", () => {
     const { requestRailWhois } = await import("../lib/railWhois");
     requestRailWhois("ghost", "alice");
     expect(pushWhoisMock).not.toHaveBeenCalled();
+  });
+
+  // #373 migration set (CLAUDE.md: a NEW nick-keyed store that skips it
+  // strands its old-nick rows). Stranded, a rename makes the rail card go
+  // blank and fires a SECOND upstream WHOIS on grappa's own IRC connection
+  // microseconds before the operator's next send — measured on the testnet at
+  // #379 of a full suite run, that WHOIS crossed bahamut's fake-lag threshold
+  // and deferred the following PRIVMSG by 8s (the nick-follow-query e2e red).
+  describe("renameRailWhois (#373 — the rail cache follows a peer NICK)", () => {
+    it("moves the cached bundle old→new and relabels its target", async () => {
+      const { ingestRailWhois, railWhoisFor, renameRailWhois } = await import("../lib/railWhois");
+      ingestRailWhois("azzurra", "Guest87449", bundle("Guest87449"));
+      renameRailWhois("azzurra", "Guest87449", "NickTemporaneo");
+      expect(railWhoisFor("azzurra", "Guest87449")).toBeUndefined();
+      expect(railWhoisFor("azzurra", "NickTemporaneo")?.host).toBe("Guest87449.host");
+      // The card renders `bundle.target`; leaving the dead nick there would
+      // label the live peer with the name it just abandoned.
+      expect(railWhoisFor("azzurra", "NickTemporaneo")?.target).toBe("NickTemporaneo");
+    });
+
+    it("leaves the migrated entry fresh, so the post-rename select issues NO WHOIS", async () => {
+      const { ingestRailWhois, renameRailWhois, requestRailWhois } = await import(
+        "../lib/railWhois"
+      );
+      ingestRailWhois("azzurra", "Guest87449", bundle("Guest87449"));
+      renameRailWhois("azzurra", "Guest87449", "NickTemporaneo");
+      requestRailWhois("azzurra", "NickTemporaneo");
+      expect(pushWhoisMock).not.toHaveBeenCalled();
+    });
+
+    it("is a no-op when the old nick holds nothing (a member rename, no query)", async () => {
+      const { railWhoisFor, renameRailWhois, requestRailWhois } = await import("../lib/railWhois");
+      renameRailWhois("azzurra", "stranger", "wanderer");
+      expect(railWhoisFor("azzurra", "wanderer")).toBeUndefined();
+      requestRailWhois("azzurra", "wanderer");
+      expect(pushWhoisMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("drops a still-pending entry instead of migrating the marker", async () => {
+      // The in-flight reply keys on the OLD nick, so a migrated pending marker
+      // would suppress the new nick's fetch while the answer lands on the dead
+      // key — blank card, no recovery while the operator stays in the window.
+      const { renameRailWhois, requestRailWhois, railWhoisFor } = await import("../lib/railWhois");
+      requestRailWhois("azzurra", "Guest87449"); // issued, unanswered
+      renameRailWhois("azzurra", "Guest87449", "NickTemporaneo");
+      expect(railWhoisFor("azzurra", "Guest87449")).toBeUndefined();
+      requestRailWhois("azzurra", "NickTemporaneo");
+      expect(pushWhoisMock).toHaveBeenCalledTimes(2);
+      expect(pushWhoisMock).toHaveBeenNthCalledWith(2, 1, "NickTemporaneo", null, "rail");
+    });
+
+    it("migrates a bundle whose refresh is in flight, and settles it", async () => {
+      // A stale bundle with a pending refresh DOES carry data worth moving;
+      // only the pending marker is dropped, so the card keeps rendering and
+      // the new nick is not re-asked.
+      const { ingestRailWhois, renameRailWhois, requestRailWhois, railWhoisFor } = await import(
+        "../lib/railWhois"
+      );
+      ingestRailWhois("azzurra", "Guest87449", bundle("Guest87449"));
+      renameRailWhois("azzurra", "Guest87449", "NickTemporaneo");
+      expect(railWhoisFor("azzurra", "NickTemporaneo")?.host).toBe("Guest87449.host");
+      requestRailWhois("azzurra", "NickTemporaneo");
+      expect(pushWhoisMock).not.toHaveBeenCalled();
+    });
+
+    it("clears is_registered — 307 attests the NICK, not the person", async () => {
+      const { ingestRailWhois, railWhoisFor, renameRailWhois } = await import("../lib/railWhois");
+      ingestRailWhois("azzurra", "Guest87449", { ...bundle("Guest87449"), is_registered: true });
+      renameRailWhois("azzurra", "Guest87449", "NickTemporaneo");
+      expect(railWhoisFor("azzurra", "NickTemporaneo")?.is_registered).toBe(false);
+      // Everything else describes the person and survives the rename.
+      expect(railWhoisFor("azzurra", "NickTemporaneo")?.user).toBe("Guest87449_u");
+    });
+
+    it("keeps the existing new-nick entry on a collision (mirrors the cursor merge)", async () => {
+      const { ingestRailWhois, railWhoisFor, renameRailWhois } = await import("../lib/railWhois");
+      ingestRailWhois("azzurra", "old", bundle("old"));
+      ingestRailWhois("azzurra", "new", bundle("new"));
+      renameRailWhois("azzurra", "old", "new");
+      expect(railWhoisFor("azzurra", "new")?.host).toBe("new.host");
+      expect(railWhoisFor("azzurra", "old")).toBeUndefined();
+    });
+
+    it("folds both ends, so a window opened `guest` follows a NICK from `Guest`", async () => {
+      const { ingestRailWhois, railWhoisFor, renameRailWhois } = await import("../lib/railWhois");
+      ingestRailWhois("azzurra", "guest", bundle("guest"));
+      renameRailWhois("azzurra", "Guest", "NEWNICK");
+      expect(railWhoisFor("azzurra", "newnick")?.host).toBe("guest.host");
+    });
+
+    it("is a no-op on a case-only shift (old ≡ new under the fold)", async () => {
+      const { ingestRailWhois, railWhoisFor, renameRailWhois } = await import("../lib/railWhois");
+      ingestRailWhois("azzurra", "alice", bundle("alice"));
+      renameRailWhois("azzurra", "alice", "Alice");
+      expect(railWhoisFor("azzurra", "alice")?.target).toBe("alice");
+    });
   });
 
   it("wipes the cache on identity rotation (logout/token change)", async () => {

--- a/cicchetto/src/__tests__/railWhois.test.ts
+++ b/cicchetto/src/__tests__/railWhois.test.ts
@@ -1,0 +1,185 @@
+import { createEffect, createRoot } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WhoisBundle } from "../lib/api";
+
+// #606 — rail whois store. Per-nick TTL cache + in-flight de-dupe that
+// backs the query-window rail context (the deferred half of #474). It is
+// DISTINCT from the single-slot `whoisCard.ts` store (which stays owned by
+// the user-issued `/whois` scrollback card): the rail auto-fetches on
+// select and must NOT clobber that store nor stack requests.
+//
+// Tests cover:
+//   1. requestRailWhois issues WHOIS on first select.
+//   2. re-select inside the TTL (bundle cached) does NOT re-issue.
+//   3. re-select after the TTL re-issues.
+//   4. two rapid selects for the same nick issue ONE WHOIS (in-flight).
+//   5. A→B→A inside the TTL issues one WHOIS per nick, not three.
+//   6. ingestRailWhois reports whether the bundle satisfied a rail request.
+//   7. railWhoisFor is reactive + case-folded.
+//   8. no live network id → no WHOIS, no throw.
+//   9. identity rotation wipes the cache.
+
+vi.mock("../lib/auth", async () => {
+  const { createSignal } = await import("solid-js");
+  const [tok, setTok] = createSignal<string | null>("tokA");
+  return { token: tok, setToken: setTok };
+});
+
+const pushWhoisMock = vi.hoisted(() =>
+  vi.fn<(id: number, nick: string, server: string | null, origin: string) => Promise<void>>(),
+);
+const networkIdBySlugMock = vi.hoisted(() => vi.fn<(slug: string) => number | undefined>());
+
+vi.mock("../lib/socket", () => ({
+  pushWhois: (id: number, nick: string, server: string | null, origin: string) =>
+    pushWhoisMock(id, nick, server, origin),
+}));
+
+vi.mock("../lib/networks", () => ({
+  networkIdBySlug: (slug: string) => networkIdBySlugMock(slug),
+}));
+
+const T0 = 1_700_000_000_000;
+
+const bundle = (target: string): WhoisBundle => ({
+  network: "azzurra",
+  target,
+  source: "rail",
+  user: `${target}_u`,
+  host: `${target}.host`,
+  realname: null,
+  server: null,
+  server_info: null,
+  is_operator: false,
+  oper_text: null,
+  idle_seconds: null,
+  signon: null,
+  channels: null,
+  using_ssl: false,
+  is_registered: false,
+  is_admin: false,
+  is_services_admin: false,
+  is_helper: false,
+  is_chanop: false,
+  is_agent: false,
+  is_java: false,
+  umodes: null,
+  away_message: null,
+  actually_host: null,
+  actually_ip: null,
+  account: null,
+  secure: false,
+  secure_cipher: null,
+  certfp: null,
+  extra_lines: null,
+});
+
+beforeEach(() => {
+  vi.resetModules();
+  pushWhoisMock.mockReset();
+  pushWhoisMock.mockResolvedValue(undefined);
+  networkIdBySlugMock.mockReset();
+  networkIdBySlugMock.mockImplementation((slug: string) => (slug === "azzurra" ? 1 : undefined));
+  vi.useFakeTimers();
+  vi.setSystemTime(T0);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("railWhois", () => {
+  it("requestRailWhois issues WHOIS(networkId, nick, null) tagged origin 'rail'", async () => {
+    const { requestRailWhois } = await import("../lib/railWhois");
+    requestRailWhois("azzurra", "alice");
+    expect(pushWhoisMock).toHaveBeenCalledTimes(1);
+    expect(pushWhoisMock).toHaveBeenCalledWith(1, "alice", null, "rail");
+  });
+
+  it("does NOT re-issue WHOIS on a re-select inside the TTL once a bundle is cached", async () => {
+    const { requestRailWhois, ingestRailWhois } = await import("../lib/railWhois");
+    requestRailWhois("azzurra", "alice");
+    ingestRailWhois("azzurra", "alice", bundle("alice"));
+    vi.setSystemTime(T0 + 30_000); // still inside the 60s TTL
+    requestRailWhois("azzurra", "alice");
+    expect(pushWhoisMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-issues WHOIS on a re-select after the TTL lapses", async () => {
+    const { requestRailWhois, ingestRailWhois } = await import("../lib/railWhois");
+    requestRailWhois("azzurra", "alice");
+    ingestRailWhois("azzurra", "alice", bundle("alice"));
+    vi.setSystemTime(T0 + 61_000); // past the 60s TTL
+    requestRailWhois("azzurra", "alice");
+    expect(pushWhoisMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("issues ONE WHOIS for two rapid selects of the same nick (in-flight de-dupe)", async () => {
+    const { requestRailWhois } = await import("../lib/railWhois");
+    requestRailWhois("azzurra", "alice");
+    requestRailWhois("azzurra", "alice"); // bundle not back yet
+    expect(pushWhoisMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("A→B→A inside the TTL issues one WHOIS per nick, not three", async () => {
+    const { requestRailWhois, ingestRailWhois } = await import("../lib/railWhois");
+    requestRailWhois("azzurra", "alice");
+    ingestRailWhois("azzurra", "alice", bundle("alice"));
+    requestRailWhois("azzurra", "bob");
+    ingestRailWhois("azzurra", "bob", bundle("bob"));
+    requestRailWhois("azzurra", "alice"); // back to A, still fresh
+    expect(pushWhoisMock).toHaveBeenCalledTimes(2);
+    expect(pushWhoisMock).toHaveBeenNthCalledWith(1, 1, "alice", null, "rail");
+    expect(pushWhoisMock).toHaveBeenNthCalledWith(2, 1, "bob", null, "rail");
+  });
+
+  it("ingestRailWhois caches a bundle even for a nick the rail never requested", async () => {
+    // Option 2's user-refresh path: userTopic feeds a `source: user` bundle
+    // for the currently-shown nick into the rail cache, with no prior rail
+    // request. The cache accepts it and it satisfies the TTL de-dupe after.
+    const { ingestRailWhois, requestRailWhois, railWhoisFor } = await import("../lib/railWhois");
+    ingestRailWhois("azzurra", "carol", bundle("carol"));
+    expect(railWhoisFor("azzurra", "carol")?.target).toBe("carol");
+    requestRailWhois("azzurra", "carol"); // fresh cache → no WHOIS
+    expect(pushWhoisMock).not.toHaveBeenCalled();
+  });
+
+  it("railWhoisFor returns the ingested bundle, reactively and case-folded", async () => {
+    const { requestRailWhois, ingestRailWhois, railWhoisFor } = await import("../lib/railWhois");
+    const seen: (string | undefined)[] = [];
+    createRoot(() => {
+      createEffect(() => seen.push(railWhoisFor("azzurra", "Alice")?.target));
+    });
+    expect(seen.at(-1)).toBeUndefined();
+    requestRailWhois("azzurra", "Alice");
+    ingestRailWhois("azzurra", "alice", bundle("alice")); // folded key matches "Alice"
+    await Promise.resolve();
+    expect(railWhoisFor("azzurra", "ALICE")?.target).toBe("alice");
+    expect(seen.at(-1)).toBe("alice");
+  });
+
+  it("a folded re-select (Alice → alice) inside the TTL issues one WHOIS", async () => {
+    const { requestRailWhois, ingestRailWhois } = await import("../lib/railWhois");
+    requestRailWhois("azzurra", "Alice");
+    ingestRailWhois("azzurra", "Alice", bundle("Alice"));
+    requestRailWhois("azzurra", "alice");
+    expect(pushWhoisMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not issue WHOIS (and does not throw) when the network has no live id", async () => {
+    const { requestRailWhois } = await import("../lib/railWhois");
+    requestRailWhois("ghost", "alice");
+    expect(pushWhoisMock).not.toHaveBeenCalled();
+  });
+
+  it("wipes the cache on identity rotation (logout/token change)", async () => {
+    const { requestRailWhois, ingestRailWhois, railWhoisFor } = await import("../lib/railWhois");
+    const auth = await import("../lib/auth");
+    requestRailWhois("azzurra", "alice");
+    ingestRailWhois("azzurra", "alice", bundle("alice"));
+    expect(railWhoisFor("azzurra", "alice")).toBeDefined();
+    (auth as unknown as { setToken: (t: string | null) => void }).setToken("tokB");
+    await Promise.resolve();
+    expect(railWhoisFor("azzurra", "alice")).toBeUndefined();
+  });
+});

--- a/cicchetto/src/__tests__/railWhois.test.ts
+++ b/cicchetto/src/__tests__/railWhois.test.ts
@@ -2,22 +2,29 @@ import { createEffect, createRoot } from "solid-js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { WhoisBundle } from "../lib/api";
 
-// #606 — rail whois store. Per-nick TTL cache + in-flight de-dupe that
-// backs the query-window rail context (the deferred half of #474). It is
-// DISTINCT from the single-slot `whoisCard.ts` store (which stays owned by
-// the user-issued `/whois` scrollback card): the rail auto-fetches on
-// select and must NOT clobber that store nor stack requests.
+// #606 — rail whois store. Per-nick cache backing the query-window rail
+// context (the deferred half of #474). DISTINCT from the single-slot
+// `whoisCard.ts` store (owned by the user-issued `/whois` scrollback card):
+// the rail fetches on select and must NOT clobber that store nor stack
+// requests.
+//
+// The contract these tests pin: a nick the rail KNOWS is never asked about
+// again (no freshness TTL — a WHOIS costs the operator's next send fake-lag
+// budget and tells a +y peer it happened), while an ask that produced
+// nothing — reply in flight, or an empty reply because the peer is offline —
+// stands only for the retry window.
 //
 // Tests cover:
 //   1. requestRailWhois issues WHOIS on first select.
-//   2. re-select inside the TTL (bundle cached) does NOT re-issue.
-//   3. re-select after the TTL re-issues.
-//   4. two rapid selects for the same nick issue ONE WHOIS (in-flight).
-//   5. A→B→A inside the TTL issues one WHOIS per nick, not three.
-//   6. ingestRailWhois reports whether the bundle satisfied a rail request.
+//   2. a known nick is never re-asked, however old the bundle.
+//   3. an unanswered ask is retried once the retry window lapses.
+//   4. an EMPTY answer is not an answer: it is retried, not cached forever.
+//   5. two rapid selects for the same nick issue ONE WHOIS.
+//   6. A→B→A issues one WHOIS per nick, not three.
 //   7. railWhoisFor is reactive + case-folded.
 //   8. no live network id → no WHOIS, no throw.
 //   9. identity rotation wipes the cache.
+//  10. #373 — the cache follows a peer NICK instead of stranding it.
 
 vi.mock("../lib/auth", async () => {
   const { createSignal } = await import("solid-js");
@@ -74,6 +81,15 @@ const bundle = (target: string): WhoisBundle => ({
   extra_lines: null,
 });
 
+// What the server emits for a nick nobody holds: the accumulator drained by
+// 318 never received a field, so every slot is null/false.
+const emptyBundle = (target: string): WhoisBundle => ({
+  ...bundle(target),
+  user: null,
+  host: null,
+  realname: null,
+});
+
 beforeEach(() => {
   vi.resetModules();
   pushWhoisMock.mockReset();
@@ -119,6 +135,21 @@ describe("railWhois", () => {
     expect(pushWhoisMock).toHaveBeenCalledTimes(2);
   });
 
+  it("retries an EMPTY answer later — an offline peer is not unknown forever", async () => {
+    // bahamut answers a WHOIS for a nick nobody holds with 401 + 318, so the
+    // bundle arrives carrying nothing. Caching that as "answered" would leave
+    // the card reading "no WHOIS information returned" for the rest of the
+    // session even after the peer signs on and messages you in that window.
+    const { requestRailWhois, ingestRailWhois } = await import("../lib/railWhois");
+    requestRailWhois("azzurra", "ghost");
+    ingestRailWhois("azzurra", "ghost", emptyBundle("ghost"));
+    requestRailWhois("azzurra", "ghost"); // straight away: still inside the retry window
+    expect(pushWhoisMock).toHaveBeenCalledTimes(1);
+    vi.setSystemTime(T0 + 31_000);
+    requestRailWhois("azzurra", "ghost");
+    expect(pushWhoisMock).toHaveBeenCalledTimes(2);
+  });
+
   it("issues ONE WHOIS for two rapid selects of the same nick (in-flight de-dupe)", async () => {
     const { requestRailWhois } = await import("../lib/railWhois");
     requestRailWhois("azzurra", "alice");
@@ -126,13 +157,13 @@ describe("railWhois", () => {
     expect(pushWhoisMock).toHaveBeenCalledTimes(1);
   });
 
-  it("A→B→A inside the TTL issues one WHOIS per nick, not three", async () => {
+  it("A→B→A issues one WHOIS per nick, not three", async () => {
     const { requestRailWhois, ingestRailWhois } = await import("../lib/railWhois");
     requestRailWhois("azzurra", "alice");
     ingestRailWhois("azzurra", "alice", bundle("alice"));
     requestRailWhois("azzurra", "bob");
     ingestRailWhois("azzurra", "bob", bundle("bob"));
-    requestRailWhois("azzurra", "alice"); // back to A, still fresh
+    requestRailWhois("azzurra", "alice"); // back to A, already known
     expect(pushWhoisMock).toHaveBeenCalledTimes(2);
     expect(pushWhoisMock).toHaveBeenNthCalledWith(1, 1, "alice", null, "rail");
     expect(pushWhoisMock).toHaveBeenNthCalledWith(2, 1, "bob", null, "rail");
@@ -145,7 +176,7 @@ describe("railWhois", () => {
     const { ingestRailWhois, requestRailWhois, railWhoisFor } = await import("../lib/railWhois");
     ingestRailWhois("azzurra", "carol", bundle("carol"));
     expect(railWhoisFor("azzurra", "carol")?.target).toBe("carol");
-    requestRailWhois("azzurra", "carol"); // fresh cache → no WHOIS
+    requestRailWhois("azzurra", "carol"); // already known → no WHOIS
     expect(pushWhoisMock).not.toHaveBeenCalled();
   });
 
@@ -163,7 +194,7 @@ describe("railWhois", () => {
     expect(seen.at(-1)).toBe("alice");
   });
 
-  it("a folded re-select (Alice → alice) inside the TTL issues one WHOIS", async () => {
+  it("a folded re-select (Alice → alice) issues one WHOIS", async () => {
     const { requestRailWhois, ingestRailWhois } = await import("../lib/railWhois");
     requestRailWhois("azzurra", "Alice");
     ingestRailWhois("azzurra", "Alice", bundle("Alice"));
@@ -226,18 +257,17 @@ describe("railWhois", () => {
       expect(pushWhoisMock).toHaveBeenNthCalledWith(2, 1, "NickTemporaneo", null, "rail");
     });
 
-    it("migrates a bundle whose refresh is in flight, and settles it", async () => {
-      // A stale bundle with a pending refresh DOES carry data worth moving;
-      // only the pending marker is dropped, so the card keeps rendering and
-      // the new nick is not re-asked.
+    it("drops an entry that only holds an EMPTY answer", async () => {
+      // Nothing known about this peer, so the rename has nothing to carry and
+      // the new nick must be free to ask.
       const { ingestRailWhois, renameRailWhois, requestRailWhois, railWhoisFor } = await import(
         "../lib/railWhois"
       );
-      ingestRailWhois("azzurra", "Guest87449", bundle("Guest87449"));
+      ingestRailWhois("azzurra", "Guest87449", emptyBundle("Guest87449"));
       renameRailWhois("azzurra", "Guest87449", "NickTemporaneo");
-      expect(railWhoisFor("azzurra", "NickTemporaneo")?.host).toBe("Guest87449.host");
+      expect(railWhoisFor("azzurra", "Guest87449")).toBeUndefined();
       requestRailWhois("azzurra", "NickTemporaneo");
-      expect(pushWhoisMock).not.toHaveBeenCalled();
+      expect(pushWhoisMock).toHaveBeenCalledTimes(1);
     });
 
     it("clears is_registered — 307 attests the NICK, not the person", async () => {

--- a/cicchetto/src/__tests__/subscribe.test.ts
+++ b/cicchetto/src/__tests__/subscribe.test.ts
@@ -1,4 +1,4 @@
-import { createSignal } from "solid-js";
+import { createEffect, createRoot, createSignal, on } from "solid-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { channelKey } from "../lib/channelKey";
 
@@ -1146,6 +1146,62 @@ describe("subscribe — WS join effect", () => {
 
       expect(rail.railWhoisFor("freenode", "Guest99")).toBeUndefined();
       expect(rail.railWhoisFor("freenode", "Renamed99")?.host).toBe("guest.example");
+    });
+
+    it("migrates the rail cache BEFORE the selection swap wakes its watchers", async () => {
+      // The load-bearing half of the fix. `followQueryNick` swaps the
+      // selection, and Solid flushes effects at the end of that write — so
+      // RailContext's fetch-on-select effect runs INSIDE the swap. If the
+      // rail cache were migrated after it, that effect would see a miss and
+      // send the very WHOIS this PR exists to stop (measured at 8s of delay
+      // on the operator's next message, and a "<nick> is doing a WHOIS on
+      // you" notice at a +y peer, for a rename nobody asked about).
+      //
+      // Pinned without mounting the component: an effect on the selection is
+      // scheduled exactly like RailContext's, so what it can see at wake time
+      // is what RailContext can see.
+      localStorage.setItem("grappa-token", "tok");
+      localStorage.setItem(
+        "grappa-subject",
+        JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+      );
+      await seedStubs();
+      const rail = await import("../lib/railWhois");
+      const store = await loadStores();
+      await vi.waitFor(() => {
+        expect(mockChannel.on).toHaveBeenCalled();
+      });
+
+      rail.ingestRailWhois("freenode", "Guest99", {
+        target: "Guest99",
+        host: "guest.example",
+      } as never);
+      store.setSelectedChannel({
+        networkSlug: "freenode",
+        channelName: "Guest99",
+        kind: "query",
+      });
+
+      let seenAtSwap: unknown = "the watcher never woke";
+      createRoot(() =>
+        createEffect(
+          on(
+            () => store.selectedChannel()?.channelName,
+            (name) => {
+              if (name === "Renamed99") seenAtSwap = rail.railWhoisFor("freenode", "Renamed99");
+            },
+          ),
+        ),
+      );
+
+      fireMessageEvent("#grappa", {
+        id: 21,
+        kind: "nick_change",
+        sender: "Guest99",
+        meta: { new_nick: "Renamed99" },
+      });
+
+      expect(seenAtSwap).toEqual(expect.objectContaining({ host: "guest.example" }));
     });
 
     it("logout (token → null) clears scrollback + unread + selection", async () => {

--- a/cicchetto/src/__tests__/subscribe.test.ts
+++ b/cicchetto/src/__tests__/subscribe.test.ts
@@ -1115,6 +1115,39 @@ describe("subscribe — WS join effect", () => {
       );
     });
 
+    it("a peer NICK migrates the rail WHOIS cache too (#373 migration set)", async () => {
+      // The rail's per-nick WHOIS cache (#606) joined the #373 set: without
+      // this wiring the rename strands the bundle under the dead nick, the
+      // card blanks, and the rail's fetch-on-select fires a redundant
+      // upstream WHOIS right before the operator's next send.
+      localStorage.setItem("grappa-token", "tok");
+      localStorage.setItem(
+        "grappa-subject",
+        JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+      );
+      await seedStubs();
+      const rail = await import("../lib/railWhois");
+      await loadStores();
+      await vi.waitFor(() => {
+        expect(mockChannel.on).toHaveBeenCalled();
+      });
+
+      rail.ingestRailWhois("freenode", "Guest99", {
+        target: "Guest99",
+        host: "guest.example",
+      } as never);
+
+      fireMessageEvent("#grappa", {
+        id: 20,
+        kind: "nick_change",
+        sender: "Guest99",
+        meta: { new_nick: "Renamed99" },
+      });
+
+      expect(rail.railWhoisFor("freenode", "Guest99")).toBeUndefined();
+      expect(rail.railWhoisFor("freenode", "Renamed99")?.host).toBe("guest.example");
+    });
+
     it("logout (token → null) clears scrollback + unread + selection", async () => {
       localStorage.setItem("grappa-token", "tokA");
       localStorage.setItem(

--- a/cicchetto/src/__tests__/userTopic.test.ts
+++ b/cicchetto/src/__tests__/userTopic.test.ts
@@ -114,6 +114,10 @@ vi.mock("../lib/whoisCard", () => ({
   setWhoisBundle: vi.fn(),
 }));
 
+vi.mock("../lib/railWhois", () => ({
+  ingestRailWhois: vi.fn(),
+}));
+
 vi.mock("../lib/archive", () => ({
   loadArchive: vi.fn(),
 }));
@@ -283,6 +287,112 @@ describe("userTopic", () => {
       expect(networks.mutateNetworkNick).toHaveBeenCalledTimes(2);
       expect(networks.mutateNetworkNick).toHaveBeenNthCalledWith(1, 1, "grappa-1");
       expect(networks.mutateNetworkNick).toHaveBeenNthCalledWith(2, 1, "grappa-2");
+    });
+  });
+
+  // #606 — whois_bundle routing by server-marked `source`. The single-slot
+  // scrollback card (setWhoisBundle) takes ONLY user bundles; the per-nick
+  // rail cache (ingestRailWhois) takes rail bundles AND user bundles for the
+  // nick the rail is currently showing (a free refresh, not a race).
+  describe("whois_bundle source routing (#606)", () => {
+    const whoisBundleEvent = (overrides: Record<string, unknown> = {}) => ({
+      kind: "whois_bundle",
+      network: "azzurra",
+      target: "alice",
+      source: "user",
+      user: null,
+      host: null,
+      realname: null,
+      server: null,
+      server_info: null,
+      is_operator: false,
+      oper_text: null,
+      idle_seconds: null,
+      signon: null,
+      channels: null,
+      using_ssl: false,
+      is_registered: false,
+      is_admin: false,
+      is_services_admin: false,
+      is_helper: false,
+      is_chanop: false,
+      is_agent: false,
+      is_java: false,
+      umodes: null,
+      away_message: null,
+      actually_host: null,
+      actually_ip: null,
+      account: null,
+      secure: false,
+      secure_cipher: null,
+      certfp: null,
+      extra_lines: null,
+      ...overrides,
+    });
+
+    it("routes a source:user bundle to the scrollback card ONLY (rail not showing it)", async () => {
+      const whoisCard = await import("../lib/whoisCard");
+      const railWhois = await import("../lib/railWhois");
+      channelMock.fireEvent(whoisBundleEvent({ source: "user" }));
+      expect(whoisCard.setWhoisBundle).toHaveBeenCalledWith(
+        "azzurra",
+        expect.objectContaining({ target: "alice", source: "user" }),
+      );
+      expect(railWhois.ingestRailWhois).not.toHaveBeenCalled();
+    });
+
+    it("routes a source:rail bundle to the rail cache ONLY (never the scrollback card)", async () => {
+      const whoisCard = await import("../lib/whoisCard");
+      const railWhois = await import("../lib/railWhois");
+      channelMock.fireEvent(whoisBundleEvent({ source: "rail" }));
+      expect(railWhois.ingestRailWhois).toHaveBeenCalledWith(
+        "azzurra",
+        "alice",
+        expect.objectContaining({ target: "alice", source: "rail" }),
+      );
+      expect(whoisCard.setWhoisBundle).not.toHaveBeenCalled();
+    });
+
+    it("routes a source:user bundle to BOTH when the rail is showing that nick", async () => {
+      const selection = await import("../lib/selection");
+      const whoisCard = await import("../lib/whoisCard");
+      const railWhois = await import("../lib/railWhois");
+      vi.mocked(selection.selectedChannel).mockReturnValue({
+        networkSlug: "azzurra",
+        channelName: "Alice", // case-shift: nickEquals folds (#525)
+        kind: "query",
+      });
+      channelMock.fireEvent(whoisBundleEvent({ source: "user" }));
+      expect(whoisCard.setWhoisBundle).toHaveBeenCalledTimes(1);
+      expect(railWhois.ingestRailWhois).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT refresh the rail from a user bundle for a DIFFERENT shown nick", async () => {
+      const selection = await import("../lib/selection");
+      const whoisCard = await import("../lib/whoisCard");
+      const railWhois = await import("../lib/railWhois");
+      vi.mocked(selection.selectedChannel).mockReturnValue({
+        networkSlug: "azzurra",
+        channelName: "bob",
+        kind: "query",
+      });
+      channelMock.fireEvent(whoisBundleEvent({ source: "user", target: "alice" }));
+      expect(whoisCard.setWhoisBundle).toHaveBeenCalledTimes(1);
+      expect(railWhois.ingestRailWhois).not.toHaveBeenCalled();
+    });
+
+    it("treats an absent source as 'user' (old server / replayed payload)", async () => {
+      const whoisCard = await import("../lib/whoisCard");
+      const railWhois = await import("../lib/railWhois");
+      const ev = whoisBundleEvent();
+      // biome-ignore lint/performance/noDelete: exercising an absent wire key
+      delete (ev as Record<string, unknown>).source;
+      channelMock.fireEvent(ev);
+      expect(whoisCard.setWhoisBundle).toHaveBeenCalledWith(
+        "azzurra",
+        expect.objectContaining({ target: "alice", source: "user" }),
+      );
+      expect(railWhois.ingestRailWhois).not.toHaveBeenCalled();
     });
   });
 

--- a/cicchetto/src/__tests__/whoisCard.test.ts
+++ b/cicchetto/src/__tests__/whoisCard.test.ts
@@ -1,0 +1,103 @@
+import { createEffect, createRoot } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WhoisBundle } from "../lib/api";
+
+// C2 — single-slot WHOIS card store: at most one bundle per network slug,
+// owned by the user-issued `/whois` scrollback card. Distinct from the
+// per-nick `railWhois.ts` cache (#606). Coverage lived inline in
+// WhoisCard.test until #606 made the component prop-driven; it moves here.
+
+vi.mock("../lib/auth", async () => {
+  const { createSignal } = await import("solid-js");
+  const [tok, setTok] = createSignal<string | null>("tokA");
+  return { token: tok, setToken: setTok };
+});
+
+const bundle = (target: string): WhoisBundle => ({
+  network: "azzurra",
+  target,
+  source: "user",
+  user: null,
+  host: null,
+  realname: null,
+  server: null,
+  server_info: null,
+  is_operator: false,
+  oper_text: null,
+  idle_seconds: null,
+  signon: null,
+  channels: null,
+  using_ssl: false,
+  is_registered: false,
+  is_admin: false,
+  is_services_admin: false,
+  is_helper: false,
+  is_chanop: false,
+  is_agent: false,
+  is_java: false,
+  umodes: null,
+  away_message: null,
+  actually_host: null,
+  actually_ip: null,
+  account: null,
+  secure: false,
+  secure_cipher: null,
+  certfp: null,
+  extra_lines: null,
+});
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("whoisCard store", () => {
+  it("setWhoisBundle stores one bundle per slug, reactively", async () => {
+    const { setWhoisBundle, whoisCardBySlug } = await import("../lib/whoisCard");
+    const seen: (string | undefined)[] = [];
+    createRoot(() => {
+      createEffect(() => seen.push(whoisCardBySlug().azzurra?.target));
+    });
+    expect(seen.at(-1)).toBeUndefined();
+    setWhoisBundle("azzurra", bundle("alice"));
+    await Promise.resolve();
+    expect(whoisCardBySlug().azzurra?.target).toBe("alice");
+    expect(seen.at(-1)).toBe("alice");
+  });
+
+  it("setWhoisBundle replaces the prior bundle for the same slug (single slot)", async () => {
+    const { setWhoisBundle, whoisCardBySlug } = await import("../lib/whoisCard");
+    setWhoisBundle("azzurra", bundle("alice"));
+    setWhoisBundle("azzurra", bundle("bob"));
+    expect(whoisCardBySlug().azzurra?.target).toBe("bob");
+  });
+
+  it("keeps bundles for different slugs independent", async () => {
+    const { setWhoisBundle, whoisCardBySlug } = await import("../lib/whoisCard");
+    setWhoisBundle("azzurra", bundle("alice"));
+    setWhoisBundle("libera", bundle("carol"));
+    expect(whoisCardBySlug().azzurra?.target).toBe("alice");
+    expect(whoisCardBySlug().libera?.target).toBe("carol");
+  });
+
+  it("dismissWhoisCard clears only the named slug", async () => {
+    const { setWhoisBundle, dismissWhoisCard, whoisCardBySlug } = await import("../lib/whoisCard");
+    setWhoisBundle("azzurra", bundle("alice"));
+    setWhoisBundle("libera", bundle("carol"));
+    dismissWhoisCard("azzurra");
+    expect(whoisCardBySlug().azzurra).toBeUndefined();
+    expect(whoisCardBySlug().libera?.target).toBe("carol");
+  });
+
+  it("wipes all bundles on identity rotation", async () => {
+    const { setWhoisBundle, whoisCardBySlug } = await import("../lib/whoisCard");
+    const auth = await import("../lib/auth");
+    setWhoisBundle("azzurra", bundle("alice"));
+    (auth as unknown as { setToken: (t: string | null) => void }).setToken("tokB");
+    await Promise.resolve();
+    expect(whoisCardBySlug().azzurra).toBeUndefined();
+  });
+});

--- a/cicchetto/src/lib/railWhois.ts
+++ b/cicchetto/src/lib/railWhois.ts
@@ -40,14 +40,13 @@ import { pushWhois } from "./socket";
 // is therefore noise delivered onto a peer for a refresh nobody requested.
 // The rule this store is built against:
 //
-//     NEVER send a WHOIS the user did not initiate.
+//     The rail NEVER sends a WHOIS on a timer or as a speculative prefetch.
+//     It sends exactly ONE when it has to show a nick it does not have.
 //
-// Accepted tradeoff, stated plainly: the card is fetched once and is NOT
-// refreshable. `idle_seconds` / `signon` age badly (host, realname, channels
-// do not), so a long-lived rail card will show a stale idle clock. The one
-// thing that does refresh it is the operator's own `/whois <peer>` —
-// `userTopic` routes a `source: "user"` bundle for the shown nick here too —
-// and that is a WHOIS the user asked for.
+// So the card is fetched once and is not refreshable; a long-lived rail shows
+// a stale idle clock. The operator's own `/whois <peer>` still lands here
+// (`userTopic` routes a `source: "user"` bundle for the shown nick into this
+// cache) — that one the user asked for.
 //
 // Both stores are fed by the SAME `whois_bundle` user-topic event. The
 // server marks each bundle's origin (`source: "user" | "rail"`, #606

--- a/cicchetto/src/lib/railWhois.ts
+++ b/cicchetto/src/lib/railWhois.ts
@@ -16,11 +16,38 @@ import { pushWhois } from "./socket";
 //     (opening two queries would stomp the card) nor forge a scrollback
 //     card the user never asked for.
 //
-// Fetch policy (issue #606 scope 2):
-//   * fire a WHOIS when a query is selected (`requestRailWhois`);
-//   * a per-nick TTL cache — re-selecting inside the TTL reuses the bundle
-//     instead of re-hitting the ircd (rate-limit avoidance);
+// Fetch policy (issue #606 scope 2, revised):
+//   * ONE WHOIS per nick, on FIRST select (`requestRailWhois`). Cached for
+//     the life of the identity — there is NO staleness refetch;
 //   * in-flight de-dupe — fast window switching cannot stack requests.
+//
+// The freshness TTL this store shipped with is deliberately GONE. It was not
+// a cost problem: on bahamut a WHOIS and a PRIVMSG carry the same fake-lag
+// flag and the same `since += 2 + len/120` (src/parse.c:236). The problem is
+// the CEILING — `s_bsd.c:1657` reads a client's socket only while
+// `since - now < 10`, so ~5 closely-spaced commands and the ircd STOPS
+// READING grappa's socket; whatever the operator sends next sits in the
+// kernel buffer until `since` drains. A TTL invites exactly that burst
+// (cycle back through N query windows after a minute and every one refires),
+// and the operator's next message pays for it. Not refetching removes the
+// burst by construction instead of policing it — the cheapest rate limiter
+// is the command you never send.
+//
+// There is a second, stronger reason, and it is not about cost at all: a
+// WHOIS is VISIBLE TO THE PERSON IT NAMES. A target carrying umode +y is sent
+// "<nick> is doing a WHOIS on you" (bahamut src/s_user.c:2200 — a
+// `sendto_one` to the target, not an oper broadcast). Every automatic refetch
+// is therefore noise delivered onto a peer for a refresh nobody requested.
+// The rule this store is built against:
+//
+//     NEVER send a WHOIS the user did not initiate.
+//
+// Accepted tradeoff, stated plainly: the card is fetched once and is NOT
+// refreshable. `idle_seconds` / `signon` age badly (host, realname, channels
+// do not), so a long-lived rail card will show a stale idle clock. The one
+// thing that does refresh it is the operator's own `/whois <peer>` —
+// `userTopic` routes a `source: "user"` bundle for the shown nick here too —
+// and that is a WHOIS the user asked for.
 //
 // Both stores are fed by the SAME `whois_bundle` user-topic event. The
 // server marks each bundle's origin (`source: "user" | "rail"`, #606
@@ -31,9 +58,6 @@ import { pushWhois } from "./socket";
 // hit rather than a race). `requestRailWhois` therefore issues its WHOIS
 // tagged `"rail"`; `ingestRailWhois` just caches by nick.
 
-// TTL a fetched rail whois stays fresh (ms). Re-selecting a query inside
-// this window reuses the cached bundle rather than re-hitting the ircd.
-const RAIL_WHOIS_TTL_MS = 60_000;
 // A pending (issued, not-yet-answered) request is honoured for this long
 // before a re-select re-issues, so a bundle that never arrives (peer
 // offline, disconnect) does not wedge the nick forever.
@@ -61,23 +85,27 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   const railWhoisFor = (slug: string, nick: string): WhoisBundle | undefined =>
     byNick()[slug]?.[normalizeNick(nick)]?.bundle ?? undefined;
 
-  // Called on query select (fetch-on-select). De-dupes: a fresh cached
-  // bundle OR a live in-flight request short-circuits, so re-selecting a
-  // query or fast A→B→A switching issues at most one WHOIS per nick.
+  // Called on query select. Issues at most ONE WHOIS per nick per identity:
+  // an already-answered nick short-circuits FOREVER (no staleness rule), and
+  // a live in-flight request short-circuits until the pending TTL lapses, so
+  // fast A→B→A switching cannot stack requests. A WHOIS is visible to the
+  // person it names — a target carrying umode +y is told "<nick> is doing a
+  // WHOIS on you" (bahamut src/s_user.c:2200) — so every avoided refetch is
+  // noise a peer does not receive, not merely a command grappa does not send.
   const requestRailWhois = (slug: string, nick: string): void => {
     const key = normalizeNick(nick);
     const now = Date.now();
     const entry = untrack(() => byNick()[slug]?.[key]);
     if (entry) {
       if (entry.pending && now - entry.at < RAIL_WHOIS_PENDING_TTL_MS) return; // in flight
-      if (!entry.pending && entry.bundle && now - entry.at < RAIL_WHOIS_TTL_MS) return; // fresh
+      if (entry.bundle) return; // answered once — never re-asked
     }
     const networkId = networkIdBySlug(slug);
     if (networkId === undefined) return;
-    // Keep any stale bundle visible while the refresh is in flight. Tagged
-    // "rail" so the server marks the bundle's origin and userTopic routes it
-    // here, NOT to the single-slot scrollback card (#606).
-    put(slug, key, { at: now, bundle: entry?.bundle ?? null, pending: true });
+    // Reaching here means there is nothing cached (a bundle would have
+    // returned above), so this only ever marks a first fetch or a retry after
+    // an unanswered one.
+    put(slug, key, { at: now, bundle: null, pending: true });
     // Fire-and-forget: unlike the operator /whois (compose.ts awaits and
     // surfaces the reject inline), the rail auto-fetch was not user-initiated,
     // so a transient push reject (socket not connected, rate-limit) is
@@ -87,17 +115,72 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   };
 
   // Feed the per-nick cache from an arriving `whois_bundle`. Clears the
-  // pending marker (the request settled), so a later re-select falls back on
-  // the TTL rule. Origin routing (which bundles reach here) is decided by the
-  // caller in `userTopic.ts` off the server-marked `source`.
+  // pending marker (the request settled) and settles the nick for good — the
+  // only later writes are a user-issued `/whois` refresh (routed here by
+  // `userTopic.ts` off the server-marked `source`) and a #373 rename.
   const ingestRailWhois = (slug: string, target: string, bundle: WhoisBundle): void => {
     const key = normalizeNick(target);
     put(slug, key, { at: Date.now(), bundle, pending: false });
   };
 
-  return { railWhoisFor, requestRailWhois, ingestRailWhois };
+  // #373 — a peer renamed: move its cached bundle old→new. This cache is a
+  // nick-keyed store, so it belongs to the rename migration set (CLAUDE.md:
+  // one that skips it strands its old-nick rows) alongside the scrollback,
+  // the read cursor and the selection. Stranding it costs three ways: the
+  // card blanks, `requestRailWhois` misses on the new nick and re-asks the
+  // ircd (one more closely-spaced command on a connection whose next PRIVMSG
+  // then waits behind it — measured at 8s), and that re-ask puts "<nick> is
+  // doing a WHOIS on you" in front of a +y peer for the crime of renaming.
+  // A rename is an identity MIGRATION, so the bundle describes the same
+  // person — host, realname, channels all still hold — and it is relabelled
+  // rather than refetched.
+  //
+  // ONLY an answered entry migrates. A still-pending one carries no bundle to
+  // move, and its reply keys on the OLD nick (`userTopic` routes on the wire
+  // `target`), so migrating the pending MARKER would suppress the new nick's
+  // fetch while the answer lands on the dead key — a card blank until the
+  // pending TTL lapses AND the selection identity changes, which it will not
+  // while the operator sits in the renamed window. Dropping it instead lets
+  // the new nick fetch once, which is the right outcome: nothing is known
+  // about this peer yet, so there is nothing a rename could carry over.
+  //
+  // Merge rule mirrors `renameReadCursorChannel`: an entry already under the
+  // new nick wins (it is the fresher observation of that identity).
+  const renameRailWhois = (slug: string, oldNick: string, newNick: string): void => {
+    const oldKey = normalizeNick(oldNick);
+    const newKey = normalizeNick(newNick);
+    if (oldKey === newKey) return;
+    setByNick((prev) => {
+      const net = prev[slug];
+      if (net === undefined || !(oldKey in net)) return prev;
+      const { [oldKey]: moved, ...rest } = net;
+      if (moved === undefined || moved.bundle === null || newKey in rest) {
+        return { ...prev, [slug]: rest };
+      }
+      const carried = moved.bundle;
+      return {
+        ...prev,
+        [slug]: {
+          ...rest,
+          [newKey]: {
+            at: moved.at,
+            // `pending` is dropped with the old key: any refresh still in
+            // flight will answer to the old nick, so the new key is settled.
+            pending: false,
+            // 307 RPL_WHOISREGNICK is "identified for THIS nick", not for the
+            // person — the one field a rename genuinely invalidates. Carrying
+            // it would badge the renamed peer "registered" on no evidence.
+            bundle: { ...carried, target: newNick, is_registered: false },
+          },
+        },
+      };
+    });
+  };
+
+  return { railWhoisFor, requestRailWhois, ingestRailWhois, renameRailWhois };
 });
 
 export const railWhoisFor = exports_.railWhoisFor;
 export const requestRailWhois = exports_.requestRailWhois;
 export const ingestRailWhois = exports_.ingestRailWhois;
+export const renameRailWhois = exports_.renameRailWhois;

--- a/cicchetto/src/lib/railWhois.ts
+++ b/cicchetto/src/lib/railWhois.ts
@@ -4,6 +4,7 @@ import { identityScopedStore } from "./identityScopedStore";
 import { networkIdBySlug } from "./networks";
 import { normalizeNick } from "./nickEquals";
 import { pushWhois } from "./socket";
+import { whoisBundleHasFields } from "./whoisBundle";
 
 // #606 — rail whois store: the per-nick WHOIS cache that backs the
 // query-window rail context (the deferred half of #474). It is DELIBERATELY
@@ -17,17 +18,21 @@ import { pushWhois } from "./socket";
 //     card the user never asked for.
 //
 // Fetch policy (issue #606 scope 2, revised):
-//   * ONE WHOIS per nick, on FIRST select (`requestRailWhois`). Cached for
-//     the life of the identity — there is NO staleness refetch;
-//   * in-flight de-dupe — fast window switching cannot stack requests.
+//   * ONE WHOIS per nick, on FIRST select (`requestRailWhois`). Once the nick
+//     is KNOWN it is never asked about again — there is NO staleness refetch;
+//   * an ask that produced nothing (reply in flight, or a reply carrying no
+//     fields because the peer is offline) stands for `RAIL_WHOIS_RETRY_MS`,
+//     which both de-dupes fast window switching and lets a peer who was
+//     offline at first select be resolved later in the session.
 //
 // The freshness TTL this store shipped with is deliberately GONE. It was not
 // a cost problem: on bahamut a WHOIS and a PRIVMSG carry the same fake-lag
 // flag and the same `since += 2 + len/120` (src/parse.c:236). The problem is
-// the CEILING — `s_bsd.c:1657` reads a client's socket only while
-// `since - now < 10`, so ~5 closely-spaced commands and the ircd STOPS
-// READING grappa's socket; whatever the operator sends next sits in the
-// kernel buffer until `since` drains. A TTL invites exactly that burst
+// the CEILING — `s_bsd.c:1657` gates the recvQ drain on
+// `since - now < 10`, so after ~5 closely-spaced commands the ircd keeps
+// reading grappa's socket but STOPS PARSING it: whatever the operator sends
+// next sits in the ircd's receive queue until `since` drains. A TTL invites
+// exactly that burst
 // (cycle back through N query windows after a minute and every one refires),
 // and the operator's next message pays for it. Not refetching removes the
 // burst by construction instead of policing it — the cheapest rate limiter
@@ -57,16 +62,18 @@ import { pushWhois } from "./socket";
 // hit rather than a race). `requestRailWhois` therefore issues its WHOIS
 // tagged `"rail"`; `ingestRailWhois` just caches by nick.
 
-// A pending (issued, not-yet-answered) request is honoured for this long
-// before a re-select re-issues, so a bundle that never arrives (peer
-// offline, disconnect) does not wedge the nick forever.
-const RAIL_WHOIS_PENDING_TTL_MS = 30_000;
+// How long an ASK stands before a re-select is allowed to ask again. It
+// covers both ways an ask can fail to produce data — a reply still in flight,
+// and a reply that arrived carrying nothing (the peer was offline, so bahamut
+// answered 401 + 318 and the bundle is all-null) — because from the rail's
+// side those are the same state: asked at `at`, still nothing to show. It is
+// NOT a freshness clock: a bundle WITH fields is never re-asked.
+const RAIL_WHOIS_RETRY_MS = 30_000;
 
 type RailWhoisEntry = {
-  /** Epoch ms of the last request (while pending) or ingest (once settled). */
+  /** Epoch ms of the ask (`requestRailWhois`) or of the reply (`ingest`). */
   at: number;
   bundle: WhoisBundle | null;
-  pending: boolean;
 };
 
 const exports_ = identityScopedStore((onIdentityChange) => {
@@ -84,10 +91,10 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   const railWhoisFor = (slug: string, nick: string): WhoisBundle | undefined =>
     byNick()[slug]?.[normalizeNick(nick)]?.bundle ?? undefined;
 
-  // Called on query select. Issues at most ONE WHOIS per nick per identity:
-  // an already-answered nick short-circuits FOREVER (no staleness rule), and
-  // a live in-flight request short-circuits until the pending TTL lapses, so
-  // fast A→B→A switching cannot stack requests. A WHOIS is visible to the
+  // Called on query select. A nick we already know short-circuits FOREVER
+  // (no staleness rule); a nick we asked about within the retry window
+  // short-circuits too, so fast A→B→A switching cannot stack. A WHOIS is
+  // visible to the
   // person it names — a target carrying umode +y is told "<nick> is doing a
   // WHOIS on you" (bahamut src/s_user.c:2200) — so every avoided refetch is
   // noise a peer does not receive, not merely a command grappa does not send.
@@ -96,30 +103,33 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     const now = Date.now();
     const entry = untrack(() => byNick()[slug]?.[key]);
     if (entry) {
-      if (entry.pending && now - entry.at < RAIL_WHOIS_PENDING_TTL_MS) return; // in flight
-      if (entry.bundle) return; // answered once — never re-asked
+      // Answered — the nick is known, and known is forever.
+      if (entry.bundle !== null && whoisBundleHasFields(entry.bundle)) return;
+      // Asked recently, nothing to show for it yet (in flight, or answered
+      // empty). One ask per retry window, so cycling windows cannot burst.
+      if (now - entry.at < RAIL_WHOIS_RETRY_MS) return;
     }
     const networkId = networkIdBySlug(slug);
     if (networkId === undefined) return;
-    // Reaching here means there is nothing cached (a bundle would have
-    // returned above), so this only ever marks a first fetch or a retry after
-    // an unanswered one.
-    put(slug, key, { at: now, bundle: null, pending: true });
+    // Keep any empty bundle visible (the card says "no WHOIS information
+    // returned" rather than blinking out) while the retry is in flight.
+    put(slug, key, { at: now, bundle: entry?.bundle ?? null });
     // Fire-and-forget: unlike the operator /whois (compose.ts awaits and
     // surfaces the reject inline), the rail auto-fetch was not user-initiated,
     // so a transient push reject (socket not connected, rate-limit) is
-    // non-actionable and stays silent. The pending-TTL covers the retry — a
-    // re-select after RAIL_WHOIS_PENDING_TTL_MS re-issues.
+    // non-actionable and stays silent. The retry window covers it — a
+    // re-select after RAIL_WHOIS_RETRY_MS asks again.
     void pushWhois(networkId, nick, null, "rail").catch(() => {});
   };
 
-  // Feed the per-nick cache from an arriving `whois_bundle`. Clears the
-  // pending marker (the request settled) and settles the nick for good — the
-  // only later writes are a user-issued `/whois` refresh (routed here by
-  // `userTopic.ts` off the server-marked `source`) and a #373 rename.
+  // Feed the per-nick cache from an arriving `whois_bundle`. A bundle WITH
+  // fields settles the nick for good; an empty one (401 + 318 for a nick
+  // nobody holds) is stored so the card can say so, but re-stamps `at` so the
+  // retry window governs when the rail may ask again. Origin routing is the
+  // caller's job in `userTopic.ts`, off the server-marked `source`.
   const ingestRailWhois = (slug: string, target: string, bundle: WhoisBundle): void => {
     const key = normalizeNick(target);
-    put(slug, key, { at: Date.now(), bundle, pending: false });
+    put(slug, key, { at: Date.now(), bundle });
   };
 
   // #373 — a peer renamed: move its cached bundle old→new. This cache is a
@@ -134,14 +144,12 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   // person — host, realname, channels all still hold — and it is relabelled
   // rather than refetched.
   //
-  // ONLY an answered entry migrates. A still-pending one carries no bundle to
-  // move, and its reply keys on the OLD nick (`userTopic` routes on the wire
-  // `target`), so migrating the pending MARKER would suppress the new nick's
-  // fetch while the answer lands on the dead key — a card blank until the
-  // pending TTL lapses AND the selection identity changes, which it will not
-  // while the operator sits in the renamed window. Dropping it instead lets
-  // the new nick fetch once, which is the right outcome: nothing is known
-  // about this peer yet, so there is nothing a rename could carry over.
+  // ONLY an entry that KNOWS something migrates. An ask still in flight, or
+  // one answered empty, has nothing to carry — and its reply keys on the OLD
+  // nick (`userTopic` routes on the wire `target`), so moving the marker
+  // would suppress the new nick's ask while the answer landed on the dead
+  // key. Dropping it lets the new nick ask once, which is the right outcome:
+  // nothing is known about this peer, so a rename has nothing to preserve.
   //
   // Merge rule mirrors `renameReadCursorChannel`: an entry already under the
   // new nick wins (it is the fresher observation of that identity).
@@ -153,7 +161,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       const net = prev[slug];
       if (net === undefined || !(oldKey in net)) return prev;
       const { [oldKey]: moved, ...rest } = net;
-      if (moved === undefined || moved.bundle === null || newKey in rest) {
+      if (moved?.bundle == null || !whoisBundleHasFields(moved.bundle) || newKey in rest) {
         return { ...prev, [slug]: rest };
       }
       const carried = moved.bundle;
@@ -163,12 +171,12 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           ...rest,
           [newKey]: {
             at: moved.at,
-            // `pending` is dropped with the old key: any refresh still in
-            // flight will answer to the old nick, so the new key is settled.
-            pending: false,
             // 307 RPL_WHOISREGNICK is "identified for THIS nick", not for the
-            // person — the one field a rename genuinely invalidates. Carrying
-            // it would badge the renamed peer "registered" on no evidence.
+            // person, so it is the one bahamut field a rename invalidates:
+            // carrying it would badge the renamed peer "registered" on no
+            // evidence. A services `account` (330) is connection-scoped and
+            // legitimately survives — on those networks the badge stays, and
+            // rightly, because there the account IS the person.
             bundle: { ...carried, target: newNick, is_registered: false },
           },
         },

--- a/cicchetto/src/lib/railWhois.ts
+++ b/cicchetto/src/lib/railWhois.ts
@@ -1,0 +1,103 @@
+import { createSignal, untrack } from "solid-js";
+import type { WhoisBundle } from "./api";
+import { identityScopedStore } from "./identityScopedStore";
+import { networkIdBySlug } from "./networks";
+import { normalizeNick } from "./nickEquals";
+import { pushWhois } from "./socket";
+
+// #606 — rail whois store: the per-nick WHOIS cache that backs the
+// query-window rail context (the deferred half of #474). It is DELIBERATELY
+// separate from the single-slot `whoisCard.ts` store:
+//
+//   * `whoisCard.ts` holds ONE bundle per network slug and is owned by the
+//     user-issued `/whois` scrollback card (compose + UserContextMenu).
+//   * this store holds one bundle PER NICK and is auto-populated when a
+//     query window is selected — it must NOT clobber the single-slot store
+//     (opening two queries would stomp the card) nor forge a scrollback
+//     card the user never asked for.
+//
+// Fetch policy (issue #606 scope 2):
+//   * fire a WHOIS when a query is selected (`requestRailWhois`);
+//   * a per-nick TTL cache — re-selecting inside the TTL reuses the bundle
+//     instead of re-hitting the ircd (rate-limit avoidance);
+//   * in-flight de-dupe — fast window switching cannot stack requests.
+//
+// Both stores are fed by the SAME `whois_bundle` user-topic event. The
+// server marks each bundle's origin (`source: "user" | "rail"`, #606
+// option 2) so `userTopic.ts` can route without ambiguity: the single-slot
+// store takes only `"user"` bundles; this store takes `"rail"` bundles PLUS
+// a `"user"` bundle for the nick the rail is currently showing (a free
+// refresh — which turns the shared-`whois_pending` collision into a cache
+// hit rather than a race). `requestRailWhois` therefore issues its WHOIS
+// tagged `"rail"`; `ingestRailWhois` just caches by nick.
+
+// TTL a fetched rail whois stays fresh (ms). Re-selecting a query inside
+// this window reuses the cached bundle rather than re-hitting the ircd.
+const RAIL_WHOIS_TTL_MS = 60_000;
+// A pending (issued, not-yet-answered) request is honoured for this long
+// before a re-select re-issues, so a bundle that never arrives (peer
+// offline, disconnect) does not wedge the nick forever.
+const RAIL_WHOIS_PENDING_TTL_MS = 30_000;
+
+type RailWhoisEntry = {
+  /** Epoch ms of the last request (while pending) or ingest (once settled). */
+  at: number;
+  bundle: WhoisBundle | null;
+  pending: boolean;
+};
+
+const exports_ = identityScopedStore((onIdentityChange) => {
+  const [byNick, setByNick] = createSignal<Record<string, Record<string, RailWhoisEntry>>>({});
+
+  onIdentityChange(() => setByNick({}));
+
+  const put = (slug: string, key: string, entry: RailWhoisEntry): void => {
+    setByNick((prev) => ({ ...prev, [slug]: { ...(prev[slug] ?? {}), [key]: entry } }));
+  };
+
+  // Reactive getter for the card — tracks `byNick` so the rail re-renders
+  // when the bundle lands or is refreshed. Case-folded (#525) so `Alice`
+  // and `alice` share one cache entry, matching the ircd + server fold.
+  const railWhoisFor = (slug: string, nick: string): WhoisBundle | undefined =>
+    byNick()[slug]?.[normalizeNick(nick)]?.bundle ?? undefined;
+
+  // Called on query select (fetch-on-select). De-dupes: a fresh cached
+  // bundle OR a live in-flight request short-circuits, so re-selecting a
+  // query or fast A→B→A switching issues at most one WHOIS per nick.
+  const requestRailWhois = (slug: string, nick: string): void => {
+    const key = normalizeNick(nick);
+    const now = Date.now();
+    const entry = untrack(() => byNick()[slug]?.[key]);
+    if (entry) {
+      if (entry.pending && now - entry.at < RAIL_WHOIS_PENDING_TTL_MS) return; // in flight
+      if (!entry.pending && entry.bundle && now - entry.at < RAIL_WHOIS_TTL_MS) return; // fresh
+    }
+    const networkId = networkIdBySlug(slug);
+    if (networkId === undefined) return;
+    // Keep any stale bundle visible while the refresh is in flight. Tagged
+    // "rail" so the server marks the bundle's origin and userTopic routes it
+    // here, NOT to the single-slot scrollback card (#606).
+    put(slug, key, { at: now, bundle: entry?.bundle ?? null, pending: true });
+    // Fire-and-forget: unlike the operator /whois (compose.ts awaits and
+    // surfaces the reject inline), the rail auto-fetch was not user-initiated,
+    // so a transient push reject (socket not connected, rate-limit) is
+    // non-actionable and stays silent. The pending-TTL covers the retry — a
+    // re-select after RAIL_WHOIS_PENDING_TTL_MS re-issues.
+    void pushWhois(networkId, nick, null, "rail").catch(() => {});
+  };
+
+  // Feed the per-nick cache from an arriving `whois_bundle`. Clears the
+  // pending marker (the request settled), so a later re-select falls back on
+  // the TTL rule. Origin routing (which bundles reach here) is decided by the
+  // caller in `userTopic.ts` off the server-marked `source`.
+  const ingestRailWhois = (slug: string, target: string, bundle: WhoisBundle): void => {
+    const key = normalizeNick(target);
+    put(slug, key, { at: Date.now(), bundle, pending: false });
+  };
+
+  return { railWhoisFor, requestRailWhois, ingestRailWhois };
+});
+
+export const railWhoisFor = exports_.railWhoisFor;
+export const requestRailWhois = exports_.requestRailWhois;
+export const ingestRailWhois = exports_.ingestRailWhois;

--- a/cicchetto/src/lib/socket.ts
+++ b/cicchetto/src/lib/socket.ts
@@ -669,6 +669,13 @@ export function pushRaw(networkId: number, line: string): Promise<void> {
 // still arrives asynchronously on the user topic, unchanged.
 // ---------------------------------------------------------------------------
 
+// #606 — the WHOIS request origin. `"user"` = an operator-issued /whois
+// (renders the single-slot scrollback card); `"rail"` = the query-rail
+// auto-fetch (feeds the per-nick rail cache, never the scrollback card).
+// Add-only wire field, so the server treats an absent/unknown value as
+// "user" and no protocol_version bumps.
+export type WhoisOrigin = "user" | "rail";
+
 // /whois [<server>] <nick> → WHOIS — pushes on the user-level channel.
 // `server` is the optional RFC 2812 §3.6.2 target-server (#198): non-null
 // for the two-arg `/whois <server> <nick>` form (bouncer emits `WHOIS
@@ -676,8 +683,15 @@ export function pushRaw(networkId: number, line: string): Promise<void> {
 // `WHOIS <nick>`). Sent explicitly (never omitted) so the server clause
 // selection is unambiguous — a null server binary-fails the two-arg
 // handle_in guard and falls through to the single-arg clause.
-export function pushWhois(networkId: number, nick: string, server: string | null): Promise<void> {
-  return pushUserChannelVerb("whois", { network_id: networkId, nick, server });
+// `origin` (#606) defaults to "user" — the existing /whois call sites
+// (compose, UserContextMenu) are unchanged; only the rail passes "rail".
+export function pushWhois(
+  networkId: number,
+  nick: string,
+  server: string | null,
+  origin: WhoisOrigin = "user",
+): Promise<void> {
+  return pushUserChannelVerb("whois", { network_id: networkId, nick, server, source: origin });
 }
 
 // P-0c — /whowas <nick> → WHOWAS nick — pushes on the user-level

--- a/cicchetto/src/lib/subscribe.ts
+++ b/cicchetto/src/lib/subscribe.ts
@@ -27,6 +27,7 @@ import { isOwnPresenceEvent } from "./ownPresenceEvent";
 import { resolvePing } from "./pingCorrelation";
 import { setEnsureQueryTopicJoined } from "./queryTopicJoin";
 import { canonicalQueryNick, queryWindowsByNetwork } from "./queryWindows";
+import { renameRailWhois } from "./railWhois";
 import { applyJoinReply, applyReadCursorSet, renameReadCursorChannel } from "./readCursor";
 import { recordSeen } from "./reconnectBackfill";
 import { appendToScrollback, refreshScrollback, renameScrollbackKey } from "./scrollback";
@@ -550,6 +551,13 @@ moduleRoot(() => {
               const oldNick = net ? canonicalQueryNick(net.id, message.sender) : message.sender;
               renameScrollbackKey(channelKey(slug, oldNick), channelKey(slug, newNick));
               renameReadCursorChannel(slug, oldNick, newNick);
+              // #606 — the rail's per-nick WHOIS cache is a nick-keyed store,
+              // so it migrates with the rest. ORDER IS LOAD-BEARING: it must
+              // run BEFORE `followQueryNick`, whose selection swap wakes the
+              // RailContext fetch-on-select effect. Migrate first and that
+              // effect finds a fresh cache entry and stays quiet; migrate
+              // after and it has already fired a redundant upstream WHOIS.
+              renameRailWhois(slug, oldNick, newNick);
               followQueryNick(slug, oldNick, newNick);
             }
           }

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -31,6 +31,7 @@ import { setMentionsBundle } from "./mentionsWindow";
 import { moduleRoot } from "./moduleRoot";
 import { setNamesReply } from "./namesModal";
 import { mutateNetworkNick, refetchChannels, refetchNetworks } from "./networks";
+import { nickEquals } from "./nickEquals";
 import {
   applyPresenceChange,
   applyPresenceError,
@@ -39,6 +40,7 @@ import {
 } from "./notifyWatch";
 import { setPeerAway } from "./peerAway";
 import { type QueryWindow, setQueryWindowsByNetwork } from "./queryWindows";
+import { ingestRailWhois } from "./railWhois";
 import { clearSeen } from "./reconnectBackfill";
 import { setReconnecting } from "./reconnectingStatus";
 import { applyRecoverProgress, applyRecoverResult } from "./recoverProgress";
@@ -93,6 +95,18 @@ import { NETWORKS_CREDENTIAL_CONNECTION_STATE } from "./wireTypes";
 // Every token transition rebuilds the socket (socket.ts), so the effect
 // leaves the orphaned prior Channel and re-joins on the fresh socket —
 // including a rotation that keeps the identity (#364 cicchetto S1).
+
+// #606 — is the rail currently showing the query whose partner is `target`
+// on `network`? Used to decide whether a `source: user` whois_bundle (an
+// operator /whois) should ALSO refresh the rail card. `nickEquals` folds
+// (#525) so a case-shift still matches. Read outside any reactive scope
+// (a channel event callback), so this is a plain current-value read.
+function railIsShowingNick(network: string, target: string): boolean {
+  const sel = selectedChannel();
+  return (
+    sel?.kind === "query" && sel.networkSlug === network && nickEquals(sel.channelName, target)
+  );
+}
 
 function parseWindowsMap(raw: Record<string, QueryWindowEntry[]>): Record<number, QueryWindow[]> {
   const result: Record<number, QueryWindow[]> = {};
@@ -592,6 +606,11 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
         kind: "whois_bundle",
         network: r.network,
         target: r.target,
+        // #606 — request origin (add-only). Absent/unknown (pre-#606 server,
+        // replayed payload) normalizes to "user" so the /whois card path is
+        // the safe default; only an explicit "rail" opts into rail-only
+        // routing. Tolerant, NOT a drop condition (old servers omit it).
+        source: r.source === "rail" ? "rail" : "user",
         user: r.user as string | null,
         host: r.host as string | null,
         realname: r.realname as string | null,
@@ -1191,14 +1210,25 @@ moduleRoot(() => {
 
         case "whois_bundle": {
           // C2 — WHOIS reply complete (server's 318 RPL_ENDOFWHOIS).
-          // Replace any prior bundle for this network and let the
-          // ScrollbackPane render the WhoisCard at the top of the
-          // active window. Focus-rule: per spec #2, the bundle renders
-          // INLINE in the window the user typed /whois from, NOT in
-          // the $server window. We don't switch focus — the user is
-          // already on the issuing window when the reply arrives.
+          // #606 — the server marks the request origin (`source`), so the two
+          // card stores stay disjoint by construction:
+          //   * single-slot scrollback card (whoisCard) — `user` bundles ONLY,
+          //     so a rail auto-fetch NEVER forges or clobbers the /whois card.
+          //     Renders INLINE in the window the user typed /whois from (spec
+          //     #2); we don't switch focus.
+          //   * per-nick rail cache (railWhois) — its own `rail` bundles AND a
+          //     `user` bundle for the nick the rail is CURRENTLY showing (a
+          //     free refresh — turns the shared-whois_pending collision into a
+          //     cache hit, not a race).
+          // An absent source (pre-#606 server, replayed payload) was already
+          // normalized to "user" by the narrower, so this is exhaustive.
           const { kind: _omit, ...bundle } = payload;
-          setWhoisBundle(payload.network, bundle);
+          if (bundle.source === "user") {
+            setWhoisBundle(payload.network, bundle);
+          }
+          if (bundle.source === "rail" || railIsShowingNick(payload.network, payload.target)) {
+            ingestRailWhois(payload.network, payload.target, bundle);
+          }
           return;
         }
 

--- a/cicchetto/src/lib/whoisBundle.ts
+++ b/cicchetto/src/lib/whoisBundle.ts
@@ -1,0 +1,47 @@
+import type { WhoisBundle } from "./api";
+
+// Does this bundle carry any actual WHOIS data?
+//
+// A WHOIS for a nick nobody is holding still produces a bundle: bahamut
+// answers 401 ERR_NOSUCHNICK and then 318 RPL_ENDOFWHOIS unconditionally
+// (src/s_user.c), so the server drains an accumulator that never got a
+// single field and emits an all-null bundle. Two callers need to tell that
+// apart from a real answer, so the predicate lives here rather than in
+// either of them:
+//
+//   * `WhoisCard` renders "no WHOIS information returned" instead of an
+//     empty field list;
+//   * `railWhois` treats it as NOT-an-answer, so a peer who was offline when
+//     their query window was first shown is asked about again later instead
+//     of being cached as unknown for the rest of the session.
+//
+// #221 — solanum-only fields (account / secure / certfp) count as data, or a
+// Libera user's card would claim "nothing returned" while holding plenty.
+// #673 — so does a lone extra line: an oper-only or privacy-stripped reply
+// can carry nothing else, and it is still the answer /whois asked for.
+export function whoisBundleHasFields(b: WhoisBundle): boolean {
+  return (
+    b.user !== null ||
+    b.host !== null ||
+    b.realname !== null ||
+    b.server !== null ||
+    b.is_operator ||
+    b.idle_seconds !== null ||
+    b.channels !== null ||
+    b.using_ssl ||
+    b.is_registered ||
+    b.is_admin ||
+    b.is_services_admin ||
+    b.is_helper ||
+    b.is_chanop ||
+    b.is_agent ||
+    b.is_java ||
+    b.umodes !== null ||
+    b.away_message !== null ||
+    b.actually_host !== null ||
+    b.account !== null ||
+    b.secure ||
+    b.certfp !== null ||
+    (b.extra_lines?.length ?? 0) > 0
+  );
+}

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -1015,6 +1015,7 @@ export type SessionWireWhoisBundlePayload = {
   kind: "whois_bundle";
   network: string;
   target: string;
+  source: "user" | "rail";
   user: string | null;
   host: string | null;
   realname: string | null;

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -7512,6 +7512,28 @@ html.resize-dragging * {
   font-size: 0.8rem;
 }
 
+/* #606 — query-window rail context: heading + reused WhoisCard. The card
+   itself is styled by `.whois-card*` (shared with the scrollback overlay).
+   The #605 rail-track cap (`fit-content(14rem)` on `.shell-no-members`)
+   binds here too because `.whois-card-fields dd` AND this heading both wrap
+   (`word-break`) — the coupling gotcha #605 flagged: a non-wrapping token
+   would floor `fit-content` above the cap. */
+.rail-query-context {
+  flex: 0 0 auto;
+}
+
+/* Mirrors `.members-pane h3` (uppercased, muted) so the query rail's
+   heading slot reads identically to the channel members slot. */
+.rail-query-heading {
+  font-size: 0.85rem;
+  font-weight: normal;
+  color: var(--muted);
+  margin: 0;
+  padding: 0.25rem 1rem;
+  text-transform: uppercase;
+  word-break: break-word;
+}
+
 .lusers-card {
   margin: 0.25rem 0.5rem 0.5rem 0.5rem;
   padding: 0.5rem 0.75rem;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -28067,8 +28067,9 @@ thread): no message counters / conversation stats.
 
 ## 2026-08-03 — #606: never send a WHOIS the user did not initiate
 
-#606 shipped with `nick-follow-query.spec.ts` red 3/3 — a spec it does not
-touch and main passes — and the fix turned out to be a rule, not a patch.
+#606 shipped with `nick-follow-query.spec.ts` red — a spec it does not touch
+and main passes; red in CI, and reproduced locally in every full-suite run
+attempted — and the fix turned out to be a rule, not a patch.
 
 **Measure before theorising.** The first reading of the trace said the send
 routed to the NEW nick and returned 201, so "routing is fine, the peer just
@@ -28091,12 +28092,17 @@ took 48ms.
 
 **The mechanism is a ceiling, not a unit cost.** WHOIS and PRIVMSG carry the
 same fake-lag flag and the same `since += 2 + len/120` (bahamut
-`src/parse.c:236`) — a WHOIS is not "expensive". But `src/s_bsd.c:1657` reads a
-client's socket only while `since - now < 10`, so ~5 closely-spaced commands
-and the ircd STOPS READING grappa's socket; whatever the operator sends next
-sits in the kernel buffer until `since` drains. The fix can therefore never be
-"make the WHOIS cheaper" — it is "put fewer closely-spaced commands on the
-connection", and the cheapest command is the one never sent.
+`src/parse.c:236`) — a WHOIS is not "expensive". But `src/s_bsd.c:1657` gates
+the recvQ drain on `since - now < 10`: past that the ircd keeps READING the
+socket and stops PARSING it, so at ~2s of penalty per command about five
+closely-spaced ones buy a 10s ceiling and whatever the operator sends next
+waits in the ircd's receive queue until `since` drains. (Not the kernel
+buffer — `read_packet` keeps `recv()`ing into `cptr->recvQ`. Which makes the
+accurate version the scarier one: un-parsed recvQ past `CLIENT_FLOOD`, 2560
+bytes in `include/config.h`, kills a non-oper client for Excess Flood.) The
+fix can therefore never be "make the WHOIS cheaper" — it is "put fewer
+closely-spaced commands on the connection", and the cheapest command is the
+one never sent.
 
 **But the deciding argument is not performance.** A WHOIS is visible to the
 person it names: a target carrying umode +y receives `<nick> is doing a WHOIS
@@ -28137,16 +28143,25 @@ Everything else — host, realname, channels — describes the person and surviv
 The card is therefore fetched once and is not refreshable; a long-lived rail
 shows a stale idle clock. The only refresh is the operator's own `/whois
 <peer>`, which `userTopic` already routes into this cache — a WHOIS the user
-asked for.
+asked for. One case is NOT "answered", though, and deleting the TTL is what
+made it matter: a WHOIS for a nick nobody holds still returns a bundle (401
+then an unconditional 318), so an offline peer would otherwise be cached as
+unknown for the whole session and the card would still read "no WHOIS
+information returned" an hour later when they sign on and message you. An
+empty bundle is therefore stored — the card must be able to say so — but not
+counted as an answer: the ask stands for a 30s retry window, shared with a
+reply still in flight, since from the rail's side those are one state.
 
-**Adjacent defect, filed as #785, fixed on main and NOT here.** `NumericRouter`
-delegates any scan-class numeric whose `params[1]` is a WHOIS in flight, so
-while a rail fetch is pending an ERR_NOSUCHNICK that actually answers the
-operator's `/msg` is folded into the WHOIS bundle instead of landing in the
-query window as the "message bounced" notice. That is a `main` defect — the
-window has always existed for the seconds after a typed `/whois` — which the
-auto-fetch widens into a routine race, so it is fixed there rather than here,
-where it would read as a branch artefact and vanish on merge.
-`cp13-s5-msg-ghost-401` caught it 2/2 in full local suites and passed CI on the
-same commit by timing luck alone. Durable rule: a pending WHOIS consumes at
-most ONE 401.
+**Adjacent defect, filed as #785 (OPEN) and deliberately NOT fixed here.**
+`NumericRouter` delegates any scan-class numeric whose `params[1]` is a WHOIS
+in flight, so while a rail fetch is pending an ERR_NOSUCHNICK that actually
+answers the operator's `/msg` is folded into the WHOIS bundle instead of
+landing in the query window as the "message bounced" notice. That is a `main`
+defect — the window has always existed for the seconds after a typed
+`/whois` — which the auto-fetch widens into a routine race. It belongs on main
+rather than in this branch, where it would read as a branch artefact and
+vanish on merge. `cp13-s5-msg-ghost-401` caught it 2/2 in full local suites
+and passed CI on the same commit by timing luck alone; it is the ONE red spec
+left in this branch's local run (476 passed, 1 failed), so per the CLAUDE.md
+ship gate #785 has to land on main BEFORE this merges. Durable rule: a pending
+WHOIS consumes at most ONE 401.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -28064,3 +28064,84 @@ reused `.whois-card-fields dd` and the new `.rail-query-heading` are
 `word-break`-able — the exact gotcha #605 flagged ("a future RailContext card
 without break-word would re-starve"). Explicitly out of scope (maintainer, same
 thread): no message counters / conversation stats.
+
+## 2026-08-03 — #606: never send a WHOIS the user did not initiate
+
+#606 shipped with `nick-follow-query.spec.ts` red 3/3 — a spec it does not
+touch and main passes — and the fix turned out to be a rule, not a patch.
+
+**Measure before theorising.** The first reading of the trace said the send
+routed to the NEW nick and returned 201, so "routing is fine, the peer just
+didn't get it". Measured instead, with a throwaway spec awaiting the followup
+for 60s instead of 5 and timestamping every WHOIS frame, run LAST in a full
+local suite (it does NOT reproduce on a cold single-spec run; it reproduces at
+#379 of the suite, exactly where CI sees it):
+
+```
++ 886ms  WS-> whois {nick: NickTmp…, source: "rail"}   ← rail refetch after the rename
++1004ms  HTTP 201 POST …/channels/NickTmp…/messages
++5008ms  WS<- whois_bundle          ← 4.1s for a reply the first one gave in 6ms
++9021ms  FOLLOWUP delivered 8047ms
++9144ms  SECOND   delivered   48ms
+```
+
+The message ARRIVES, 8s late. Not routing: the server puts the URL's RAW target
+on the wire (`handle_persisting_send/3`) and the next send to that same nick
+took 48ms.
+
+**The mechanism is a ceiling, not a unit cost.** WHOIS and PRIVMSG carry the
+same fake-lag flag and the same `since += 2 + len/120` (bahamut
+`src/parse.c:236`) — a WHOIS is not "expensive". But `src/s_bsd.c:1657` reads a
+client's socket only while `since - now < 10`, so ~5 closely-spaced commands
+and the ircd STOPS READING grappa's socket; whatever the operator sends next
+sits in the kernel buffer until `since` drains. The fix can therefore never be
+"make the WHOIS cheaper" — it is "put fewer closely-spaced commands on the
+connection", and the cheapest command is the one never sent.
+
+**But the deciding argument is not performance.** A WHOIS is visible to the
+person it names: a target carrying umode +y receives `<nick> is doing a WHOIS
+on you` (`src/s_user.c:2200`, a `sendto_one` to the TARGET — which is why
+grepping for `sendto_realops` finds nothing and proves nothing). Under the
+shipped TTL, a peer with +y would be told someone was whoising them every time
+anyone re-selected their query window after 60s — forever, for a refresh
+neither party asked for. Hence the durable rule, which outlives this PR:
+
+> **The client MUST NEVER send a WHOIS the user did not initiate.**
+
+It binds every future surface tempted to prefetch WHOIS — member-list hover,
+nick autocomplete preview, notify/watch enrichment.
+
+**What changed.** (1) The freshness TTL is DELETED: one WHOIS per nick on first
+select, cached for the life of the identity, no staleness refetch. Note there
+never was polling — the TTL was a ceiling on the NEXT select, not a timer — so
+the work was a deletion, not the dismantling of a loop. (2) The nick-keyed
+cache joins the #373 rename migration set (`renameRailWhois/3`, called from the
+`subscribe.ts` #373 block BEFORE `followQueryNick` — ORDER IS LOAD-BEARING: the
+selection swap synchronously wakes RailContext's fetch-on-select effect, so
+migrating first leaves it a cache hit; migrating after means it has already
+fired). CLAUDE.md already demanded (2) — "a NEW nick-keyed store MUST be added
+to this migration set" — and #606 simply missed it. Without it a peer who
+renames is told "is doing a WHOIS on you" for the crime of renaming, by a user
+who did nothing.
+
+Two migration details that are NOT mechanical: only an ANSWERED entry migrates
+(a pending one carries no bundle, and its reply keys on the OLD nick, so
+migrating the marker would suppress the new nick's fetch while the answer lands
+on the dead key — blank card with no recovery while the operator stays put);
+and `is_registered` is CLEARED (307 RPL_WHOISREGNICK attests the NICK, not the
+person — carrying it would badge a renamed peer "registered" on no evidence).
+Everything else — host, realname, channels — describes the person and survives.
+
+**Accepted, stated plainly:** the card is fetched once and is not refreshable;
+a long-lived rail shows a stale idle clock. The only refresh is the operator's
+own `/whois <peer>`, which `userTopic` already routes into this cache — a WHOIS
+the user asked for. No refresh affordance is promised here.
+
+**Adjacent finding, not fixed here.** `NumericRouter` delegates any scan-class
+numeric whose `params[1]` is a WHOIS in flight, so while a rail fetch is
+pending an ERR_NOSUCHNICK that actually answers the operator's `/msg` is folded
+into the WHOIS bundle instead of landing in the query window as the "message
+bounced" notice. Pre-#606 that state existed only just after someone typed
+`/whois`; the auto-fetch makes it routine. `cp13-s5-msg-ghost-401` (0 error
+notices) caught it in the same local run and passes in CI only on timing. The
+durable rule: `whois_pending` should consume at most ONE 401 per pending WHOIS.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -28006,3 +28006,61 @@ Record<string, unknown>`, opaque to the generator.
 actually depends on it. Before granting one, check whether the boundary code
 already does the work the exception was supposed to avoid — here it did, and
 the exception bought nothing but a footnote.
+## 2026-08-01 — #606: the query rail context, and why the server marks the WHOIS origin
+
+#606 lands the deferred half of #474: a query window's right rail gets its own
+context — a heading (`private conversation with <NICK>`, mirroring the
+MembersPane `<h3>` slot; the nick reads live off `selectedChannel` so a #373
+rename re-labels it) and a WHOIS card for the partner, auto-fetched on select.
+The card **reuses** the existing `WhoisCard`, now refactored to be
+prop-driven (`bundle` + optional `onDismiss`): the scrollback overlay passes
+the single-slot `whoisCardBySlug` bundle plus a dismiss handler; the rail
+passes its per-nick `railWhois` bundle and omits `onDismiss`, so the rail card
+is persistent (no ×, like `ServerInfoCard`).
+
+**The real design problem was disambiguation.** `whois_bundle` arrives on
+`Topic.user/1` and, pre-#606, always landed in the single-slot store. If the
+rail auto-fetched through that same path, opening two queries would clobber the
+card and an auto-fetch would forge a scrollback card the user never asked for.
+Two options were put to the maintainer: (1) **client-only** — the rail keeps
+its own per-nick store and suppresses the single-slot only for its own fetch;
+zero server change, but a sub-second race survives (a `/whois` on the same nick
+while the rail is mid-fetch delivers that bundle to the rail, not the user's
+card). (2) **server-marked** — the bundle carries its request origin, each
+consumer takes only what is addressed to it, race gone by construction.
+
+**Decision: option 2** ("se 2) non è costosa va bene 2"), on the maintainer's
+own #608 rule — kill the class of bug, don't patch the symptom. Cost accepted:
+three lines of server + one wire field, but it makes an issue labelled
+`cicchetto` a **cross-stack** change, so the gate is the full integration suite,
+not the client suite alone.
+
+**Wire shape.** Add-only field `source: :user | :rail` on `whois_bundle` (atom
+union → `"user" | "rail"`, following the `server_reply` source precedent), so
+**no `protocol_version` bump** and old clients ignore it. `"user"` is the
+default for every existing path. The origin threads: `pushWhois(…, origin)`
+(default `"user"`; only the rail passes `"rail"`) → channel `handle_in("whois")`
+normalizes an **untrusted** client token (only exact `"rail"` opts in, all else
+→ `:user`) → `Session.send_whois/5` → primes it in the per-target
+`whois_pending` accumulator as `:source` → 318 drains it into the bundle →
+`Wire.whois_bundle/3` projects `Map.get(accum, :source, :user)`.
+
+**The consumer rule is where option 2 can still go wrong.** `whois_pending` is
+keyed per target nick, not per request, so two concurrent requests for one nick
+share one accumulator and the last write of `:source` wins — deliberately NOT
+fixed by splitting the key (the ircd numerics carry no request identity to split
+on). It is resolved at the cic consumer instead: the single-slot store consumes
+only `source: "user"`; the rail store consumes `source: "rail"` **and** a
+`source: "user"` bundle whose target is the nick the rail is currently showing
+(a free refresh). With that rule the collision collapses into a cache hit, not a
+race: `/whois` always gets its card, the rail gets a refresh. An absent `source`
+(pre-#606 server, replayed payload) is normalized to `"user"` at the cic
+narrower — the narrower **reconstructs** the bundle field-by-field, so `source`
+had to be added there too or it would have been silently dropped.
+
+**#605 coupling.** The query rail lives in the same `.shell-no-members`
+`fit-content(14rem)` track #605 capped. The cap binds here because both the
+reused `.whois-card-fields dd` and the new `.rail-query-heading` are
+`word-break`-able — the exact gotcha #605 flagged ("a future RailContext card
+without break-word would re-starve"). Explicitly out of scope (maintainer, same
+thread): no message counters / conversation stats.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -28106,10 +28106,12 @@ shipped TTL, a peer with +y would be told someone was whoising them every time
 anyone re-selected their query window after 60s — forever, for a refresh
 neither party asked for. Hence the durable rule, which outlives this PR:
 
-> **The client MUST NEVER send a WHOIS the user did not initiate.**
+> **The rail NEVER sends a WHOIS on a timer or as a speculative prefetch. It
+> sends exactly ONE when it has to show a nick it does not have.**
 
 It binds every future surface tempted to prefetch WHOIS — member-list hover,
-nick autocomplete preview, notify/watch enrichment.
+nick autocomplete preview, notify/watch enrichment: enrichment nobody asked
+for is noise delivered onto a person.
 
 **What changed.** (1) The freshness TTL is DELETED: one WHOIS per nick on first
 select, cached for the life of the identity, no staleness refetch. Note there
@@ -28132,16 +28134,19 @@ and `is_registered` is CLEARED (307 RPL_WHOISREGNICK attests the NICK, not the
 person — carrying it would badge a renamed peer "registered" on no evidence).
 Everything else — host, realname, channels — describes the person and survives.
 
-**Accepted, stated plainly:** the card is fetched once and is not refreshable;
-a long-lived rail shows a stale idle clock. The only refresh is the operator's
-own `/whois <peer>`, which `userTopic` already routes into this cache — a WHOIS
-the user asked for. No refresh affordance is promised here.
+The card is therefore fetched once and is not refreshable; a long-lived rail
+shows a stale idle clock. The only refresh is the operator's own `/whois
+<peer>`, which `userTopic` already routes into this cache — a WHOIS the user
+asked for.
 
-**Adjacent finding, not fixed here.** `NumericRouter` delegates any scan-class
-numeric whose `params[1]` is a WHOIS in flight, so while a rail fetch is
-pending an ERR_NOSUCHNICK that actually answers the operator's `/msg` is folded
-into the WHOIS bundle instead of landing in the query window as the "message
-bounced" notice. Pre-#606 that state existed only just after someone typed
-`/whois`; the auto-fetch makes it routine. `cp13-s5-msg-ghost-401` (0 error
-notices) caught it in the same local run and passes in CI only on timing. The
-durable rule: `whois_pending` should consume at most ONE 401 per pending WHOIS.
+**Adjacent defect, filed as #785, fixed on main and NOT here.** `NumericRouter`
+delegates any scan-class numeric whose `params[1]` is a WHOIS in flight, so
+while a rail fetch is pending an ERR_NOSUCHNICK that actually answers the
+operator's `/msg` is folded into the WHOIS bundle instead of landing in the
+query window as the "message bounced" notice. That is a `main` defect — the
+window has always existed for the seconds after a typed `/whois` — which the
+auto-fetch widens into a routine race, so it is fixed there rather than here,
+where it would read as a branch artefact and vanish on merge.
+`cp13-s5-msg-ghost-401` caught it 2/2 in full local suites and passed CI on the
+same commit by timing luck alone. Durable rule: a pending WHOIS consumes at
+most ONE 401.

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -1619,16 +1619,24 @@ defmodule Grappa.Session do
   Per spec #2: ephemeral — NOT persisted in scrollback. Bundle replaces
   any prior bundle for the same target.
 
+  `origin` (#606) marks who asked: `:user` for an operator-issued `/whois`
+  (the single-slot scrollback card), `:rail` for the query-rail
+  auto-fetch. It rides in the per-target accumulator and re-emerges on the
+  `whois_bundle` wire event as `source`, so each cic store consumes only
+  what is addressed to it (a rail auto-fetch never forges the /whois card).
+  The channel boundary normalizes an unknown/absent client token to
+  `:user`, so the atom reaching here is always one of the two.
+
   Returns `:ok`, `{:error, :no_session}`, or `{:error, :invalid_line}`
   if the nick or server syntax is rejected by
   `Grappa.IRC.Client.send_whois/3`.
   """
-  @spec send_whois(subject(), integer(), String.t(), String.t() | nil) ::
+  @spec send_whois(subject(), integer(), String.t(), String.t() | nil, :user | :rail) ::
           :ok | {:error, :no_session | :invalid_line | send_transport_error()}
-  def send_whois(subject, network_id, nick, server)
+  def send_whois(subject, network_id, nick, server, origin)
       when is_subject(subject) and is_integer(network_id) and is_binary(nick) and
-             (is_binary(server) or is_nil(server)) do
-    call_session(subject, network_id, {:send_whois, nick, server})
+             (is_binary(server) or is_nil(server)) and origin in [:user, :rail] do
+    call_session(subject, network_id, {:send_whois, nick, server, origin})
   end
 
   @doc """

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -2050,10 +2050,21 @@ defmodule Grappa.Session.Server do
   # on `target` (the nick) — routing only changes which server answers, not
   # the bundle's target — so priming is identical; only the emitted frame
   # differs (`WHOIS <server> <nick>` vs `WHOIS <nick>`).
-  def handle_call({:send_whois, target, server}, _, state)
-      when is_binary(target) and (is_binary(server) or is_nil(server)) do
+  # #606 — `origin` (`:user | :rail`) rides in the accumulator as `:source`
+  # so it re-emerges on the `whois_bundle` wire event. `whois_pending` keys
+  # per target nick, so two concurrent requests for one nick share this
+  # accumulator and the last write of `:source` wins — deliberately NOT
+  # fixed by splitting the key (the ircd numerics carry no request identity):
+  # the cic consumer rule (rail takes its own + the shown nick's user bundle)
+  # turns that collapse into a harmless cache hit, not a race.
+  def handle_call({:send_whois, target, server, origin}, _, state)
+      when is_binary(target) and (is_binary(server) or is_nil(server)) and
+             origin in [:user, :rail] do
     nick_key = fold_key(state, target)
-    next_pending = prime_pending(state.whois_pending, nick_key, %{target_display: target})
+
+    next_pending =
+      prime_pending(state.whois_pending, nick_key, %{target_display: target, source: origin})
+
     next_state = %{state | whois_pending: next_pending}
     {:reply, Client.send_whois(state.client, target, server), next_state}
   end

--- a/lib/grappa/session/wire.ex
+++ b/lib/grappa/session/wire.ex
@@ -445,6 +445,11 @@ defmodule Grappa.Session.Wire do
           kind: :whois_bundle,
           network: String.t(),
           target: String.t(),
+          # #606 — request origin. `"user"` = operator-issued /whois (the
+          # single-slot scrollback card); `"rail"` = query-rail auto-fetch.
+          # Add-only (no protocol_version bump); an old client ignores it and
+          # cic treats an absent value as "user".
+          source: :user | :rail,
           user: String.t() | nil,
           host: String.t() | nil,
           realname: String.t() | nil,
@@ -1262,6 +1267,10 @@ defmodule Grappa.Session.Wire do
       kind: :whois_bundle,
       network: network_slug,
       target: target,
+      # #606 — request origin, defaulting to :user for a bundle primed by
+      # pre-#606 code (hot-deploy in-flight accumulator) or any path that
+      # somehow skipped it. Jason encodes the atom to "user"/"rail".
+      source: Map.get(accum, :source, :user),
       user: Map.get(accum, :user),
       host: Map.get(accum, :host),
       realname: Map.get(accum, :realname),

--- a/lib/grappa_web/channels/grappa_channel.ex
+++ b/lib/grappa_web/channels/grappa_channel.ex
@@ -730,27 +730,31 @@ defmodule GrappaWeb.GrappaChannel do
   # `:server` predicate (server name or routing nick — no whitespace/CRLF).
   defp do_handle_in(
          "whois",
-         %{"network_id" => network_id, "nick" => nick, "server" => server},
+         %{"network_id" => network_id, "nick" => nick, "server" => server} = params,
          socket
        )
        when is_integer(network_id) and is_binary(nick) and is_binary(server) do
+    origin = normalize_whois_origin(params)
+
     dispatch_subject_verb(
       socket,
       fn -> validate_args(nick: nick, server: server) end,
-      fn subject -> Session.send_whois(subject, network_id, nick, server) end
+      fn subject -> Session.send_whois(subject, network_id, nick, server, origin) end
     )
   end
 
   defp do_handle_in(
          "whois",
-         %{"network_id" => network_id, "nick" => nick},
+         %{"network_id" => network_id, "nick" => nick} = params,
          socket
        )
        when is_integer(network_id) and is_binary(nick) do
+    origin = normalize_whois_origin(params)
+
     dispatch_subject_verb(
       socket,
       fn -> validate_args(nick: nick) end,
-      fn subject -> Session.send_whois(subject, network_id, nick, nil) end
+      fn subject -> Session.send_whois(subject, network_id, nick, nil, origin) end
     )
   end
 
@@ -1563,6 +1567,13 @@ defmodule GrappaWeb.GrappaChannel do
     do: validate_args(server: mask, server: server)
 
   defp validate_lusers_args(_, _), do: {:error, :invalid_line}
+
+  # #606 — the WHOIS request origin the query rail tags its auto-fetch with.
+  # Untrusted client token, so ONLY the exact "rail" string opts into rail
+  # routing; absent / unknown / "user" all normalize to the :user default
+  # (an old client that never sends the key keeps working unchanged).
+  defp normalize_whois_origin(%{"source" => "rail"}), do: :rail
+  defp normalize_whois_origin(_), do: :user
 
   defp validate_args([]), do: {:ok, :ok}
 

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -9317,7 +9317,7 @@ defmodule Grappa.Session.ServerTest do
       assert {:ok, _} = Session.send_privmsg({:user, user.id}, network.id, "ghost", "hi")
       assert QueryWindows.open?({:user, user.id}, network.id, "ghost")
 
-      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil)
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil, :user)
       _ = IRCServer.wait_for_line(server, &(&1 == "WHOIS ghost\r\n"), 1_000)
 
       # Subscribe AFTER the outbound send so the mailbox holds only the 401s.
@@ -9369,7 +9369,7 @@ defmodule Grappa.Session.ServerTest do
       # row would ALSO be duplicated into the WHOIS card's extra_lines.
       assert {:ok, _} = Session.send_privmsg({:user, user.id}, network.id, "ghost", "hi")
 
-      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil)
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil, :user)
       _ = IRCServer.wait_for_line(server, &(&1 == "WHOIS ghost\r\n"), 1_000)
 
       :ok =
@@ -9422,7 +9422,7 @@ defmodule Grappa.Session.ServerTest do
       # bundle is approximate by construction (P-0a).
       assert {:ok, _} = Session.send_privmsg({:user, user.id}, network.id, "ghost", "hi")
 
-      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil)
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil, :user)
       _ = IRCServer.wait_for_line(server, &(&1 == "WHOIS ghost\r\n"), 1_000)
 
       :ok =
@@ -9434,7 +9434,7 @@ defmodule Grappa.Session.ServerTest do
 
       # Re-prime BETWEEN the absorption and the first WHOIS's own reply — the
       # interleaving that actually destroys the record.
-      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil)
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil, :user)
 
       IRCServer.feed(server, ":irc.test.org 401 grappa-test ghost :No such nick/channel\r\n")
       IRCServer.feed(server, ":irc.test.org 318 grappa-test ghost :End of /WHOIS list\r\n")

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -9105,7 +9105,7 @@ defmodule Grappa.Session.ServerTest do
       assert {:error, :no_session} = Session.send_banlist({:user, uid}, 9_999, "#x")
       assert {:error, :no_session} = Session.send_umode({:user, uid}, 9_999, "+i")
       assert {:error, :no_session} = Session.send_mode({:user, uid}, 9_999, "#x", "+m", [])
-      assert {:error, :no_session} = Session.send_whois({:user, uid}, 9_999, "alice", nil)
+      assert {:error, :no_session} = Session.send_whois({:user, uid}, 9_999, "alice", nil, :user)
       assert {:error, :no_session} = Session.send_who({:user, uid}, 9_999, "#bofh")
       assert {:error, :no_session} = Session.send_names({:user, uid}, 9_999, "#bofh")
     end
@@ -9131,7 +9131,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "/whois <nick> sends WHOIS upstream", %{server: server, user: user, network: network, pid: pid} do
-      assert :ok = Session.send_whois({:user, user.id}, network.id, "alice", nil)
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "alice", nil, :user)
 
       assert {:ok, "WHOIS alice\r\n"} =
                IRCServer.wait_for_line(server, &(&1 == "WHOIS alice\r\n"), 1_000)
@@ -9157,7 +9157,7 @@ defmodule Grappa.Session.ServerTest do
           %{state | whois_pending: %{"ghost" => %{target_display: "ghost", __primed_at_ms: stale_at}}}
         end)
 
-      assert :ok = Session.send_whois({:user, user.id}, network.id, "fresh", nil)
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "fresh", nil, :user)
       _ = IRCServer.wait_for_line(server, &(&1 == "WHOIS fresh\r\n"), 1_000)
 
       state = SessionStateHelpers.fetch(pid)
@@ -9180,7 +9180,7 @@ defmodule Grappa.Session.ServerTest do
           %{state | whois_pending: %{"recent" => %{target_display: "recent", __primed_at_ms: recent_at}}}
         end)
 
-      assert :ok = Session.send_whois({:user, user.id}, network.id, "fresh", nil)
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "fresh", nil, :user)
       _ = IRCServer.wait_for_line(server, &(&1 == "WHOIS fresh\r\n"), 1_000)
 
       state = SessionStateHelpers.fetch(pid)
@@ -9227,7 +9227,7 @@ defmodule Grappa.Session.ServerTest do
     } do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
-      assert :ok = Session.send_whois({:user, user.id}, network.id, "alice", nil)
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "alice", nil, :user)
       _ = IRCServer.wait_for_line(server, &(&1 == "WHOIS alice\r\n"), 1_000)
 
       IRCServer.feed(server, ":irc.test.org 311 grappa-test alice alice_u alice.host * :Alice Liddell\r\n")
@@ -9249,6 +9249,33 @@ defmodule Grappa.Session.ServerTest do
       assert bundle.idle_seconds == 42
       assert bundle.signon == 1_700_000_000
       assert bundle.channels == ["@#italia", "+#grappa"]
+      # #606 — an operator-issued /whois marks the bundle :user so cic routes
+      # it to the single-slot scrollback card.
+      assert bundle.source == :user
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # #606 — a rail auto-fetch marks the bundle :source == :rail, the signal
+    # cic uses to route it to the per-nick rail cache WITHOUT forging a
+    # scrollback card. Same 311→318 fold path; only the origin differs.
+    test "a :rail-origin /whois marks the broadcast bundle source: :rail", %{
+      server: server,
+      user: user,
+      network: network,
+      pid: pid
+    } do
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "alice", nil, :rail)
+      _ = IRCServer.wait_for_line(server, &(&1 == "WHOIS alice\r\n"), 1_000)
+
+      IRCServer.feed(server, ":irc.test.org 311 grappa-test alice alice_u alice.host * :Alice\r\n")
+      IRCServer.feed(server, ":irc.test.org 318 grappa-test alice :End of /WHOIS list\r\n")
+
+      assert_receive %Phoenix.Socket.Broadcast{event: "event", payload: %{kind: :whois_bundle} = bundle}, 1_500
+      assert bundle.target == "alice"
+      assert bundle.source == :rail
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
@@ -9261,7 +9288,7 @@ defmodule Grappa.Session.ServerTest do
     } do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
-      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil)
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil, :user)
       _ = IRCServer.wait_for_line(server, &(&1 == "WHOIS ghost\r\n"), 1_000)
 
       IRCServer.feed(server, ":irc.test.org 318 grappa-test ghost :End of /WHOIS list\r\n")
@@ -9438,7 +9465,7 @@ defmodule Grappa.Session.ServerTest do
     } do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
-      assert :ok = Session.send_whois({:user, user.id}, network.id, "alice", nil)
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "alice", nil, :user)
       _ = IRCServer.wait_for_line(server, &(&1 == "WHOIS alice\r\n"), 1_000)
 
       IRCServer.feed(server, ":irc.test.org 311 grappa-test ALICE alice_u alice.host * :Alice\r\n")

--- a/test/grappa/session/wire_test.exs
+++ b/test/grappa/session/wire_test.exs
@@ -599,6 +599,9 @@ defmodule Grappa.Session.WireTest do
                kind: :whois_bundle,
                network: "azzurra",
                target: "alice",
+               # #606 — request origin; defaults to :user for an accum with no
+               # :source (this test primes none).
+               source: :user,
                user: "alice_u",
                host: "alice.host",
                realname: "Alice Liddell",
@@ -642,6 +645,8 @@ defmodule Grappa.Session.WireTest do
                kind: :whois_bundle,
                network: "azzurra",
                target: "ghost",
+               # #606 — empty accum → origin defaults to :user.
+               source: :user,
                user: nil,
                host: nil,
                realname: nil,
@@ -695,6 +700,14 @@ defmodule Grappa.Session.WireTest do
       assert payload.actually_host == "real-host.example.net"
       assert payload.actually_ip == "203.0.113.7"
       assert payload.extra_lines == [%{numeric: 320, text: "is a volunteer staff member"}]
+    end
+
+    # #606 — the request origin rides in the accum as :source and projects
+    # verbatim. :rail is the query-rail auto-fetch; anything else defaults to
+    # :user (proven by the two exact-map tests above, which prime no :source).
+    test "projects the accum :source (rail auto-fetch) into the wire shape" do
+      payload = Wire.whois_bundle("azzurra", "alice", %{source: :rail})
+      assert payload.source == :rail
     end
   end
 

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -2230,6 +2230,43 @@ defmodule GrappaWeb.GrappaChannelTest do
 
       assert_reply(ref, :error, %{error: "invalid_nick"})
     end
+
+    # #606 — the query rail tags its auto-fetch `"source" => "rail"`. The
+    # channel boundary (`normalize_whois_origin/1`) maps that to `:rail`,
+    # which rides the accumulator and re-emerges on the broadcast bundle so
+    # cic routes it to the per-nick rail cache instead of the /whois card.
+    # An absent/unknown token normalizes to :user (covered by the tests
+    # above, which never send "source").
+    test "whois with source: rail marks the broadcast bundle source: :rail" do
+      {irc_server, port} = start_irc_server()
+      {visitor, network} = setup_visitor_and_network_with_session(port)
+      :ok = await_handshake(irc_server)
+      IRCServer.feed(irc_server, ":irc.test.org 001 #{visitor_nick(visitor)} :Welcome\r\n")
+      flush_server(irc_server)
+
+      visitor_name = "visitor:#{visitor.id}"
+      topic = Topic.user(visitor_name)
+
+      {:ok, _, visitor_socket} =
+        visitor_name
+        |> build_socket()
+        |> subscribe_and_join(topic, %{})
+
+      ref =
+        push(visitor_socket, "whois", %{
+          "network_id" => network.id,
+          "nick" => "alice",
+          "source" => "rail"
+        })
+
+      assert_reply(ref, :ok)
+      {:ok, _} = IRCServer.wait_for_line(irc_server, &(&1 == "WHOIS alice\r\n"), 1_000)
+
+      IRCServer.feed(irc_server, ":irc.test.org 311 #{visitor_nick(visitor)} alice u h * :Alice\r\n")
+      IRCServer.feed(irc_server, ":irc.test.org 318 #{visitor_nick(visitor)} alice :End\r\n")
+
+      assert_push("event", %{kind: :whois_bundle, target: "alice", source: :rail})
+    end
   end
 
   # Issue #62: `/away` returned a bare "Send failed" for visitors because


### PR DESCRIPTION
Refs #606 — the deferred half of #474 (server-info rail).

## What

A query (DM) window's right rail now renders a context, mirroring `MembersPane` for channels:

1. **Heading** `private conversation with <NICK>` — reads live off `selectedChannel`, so a #373 peer-nick rename re-labels it (`followQueryNick` already swaps the selection).
2. **A persistent WHOIS card** for the partner, **auto-fetched on select**. `WhoisCard` is refactored **prop-driven** (`bundle` + optional `onDismiss`): the scrollback overlay keeps its `×` dismiss; the rail card omits `onDismiss` → no `×`, persistent, like `ServerInfoCard`.

## How — Option 2: server marks the WHOIS origin

Kills the `whois_pending` collapse race **by construction** rather than papering over it client-side.

- Add-only wire field `source: :user | :rail` on `whois_bundle` (atom-union → `"user"`/`"rail"`; **no `protocol_version` bump**, additive-only; absent → `"user"`).
- Flow: `pushWhois(…, origin)` (only the rail passes `"rail"`) → channel `handle_in("whois")` `normalize_whois_origin/1` (**untrusted**: only `"rail"` opts in, everything else → `:user`) → `Session.send_whois/5` primes `:source` in the per-target `whois_pending` accumulator → `Wire.whois_bundle/3` projects `Map.get(accum, :source, :user)`.
- **Consumer rule** (the collision point — `whois_pending` is keyed per nick; concurrent requests share one accumulator, last `:source` wins, since ircd numerics carry no request id): the single-slot store (`whoisCard.ts`) consumes **only** `source:user`; the per-nick rail cache (`railWhois.ts`) consumes `source:rail` **and** a `source:user` bundle for the nick the rail is currently showing (free refresh). A collapse becomes a cache hit, not a race — `/whois` always gets its card, the rail gets a refresh.
- Rail cache: per-nick TTL 60s + in-flight de-dupe; fetch is fire-and-forget (`.catch(()=>{})`, pending-TTL 30s covers retry), unlike compose's awaited `/whois`.

## #605 coupling

The query rail lives in the `fit-content(14rem)` `.shell-no-members` track (landed with #605). The cap binds because both the reused `.whois-card-fields dd` and the new `.rail-query-heading` `word-break` — the exact #605 gotcha.

## Out of scope

No message counters / stats (maintainer's call, per issue #606).

## Tests

- server: `wire_test`, `server_test`, `grappa_channel_test` (origin normalize + `:source` projection).
- cic: `railWhois.test.ts` (new), `whoisCard.test.ts` (new), `WhoisCard.test.tsx`, `RailContext.test.tsx`, `userTopic.test.ts`, `ScrollbackPane.test.tsx`, `Shell.test.tsx`.
- e2e: `issue606-query-rail-whois.spec.ts` (new; chromium; live stack).

## Gates (local, this branch @ c0e6e3ba)

- cic `bun run check` → exit 0 (biome + tsc).
- cic `bun run test` → **3775/3775** (212 files).
- Server `check.sh` verified green pre-rebase (tree byte-identical after rebase; full suite runs in PR CI).