### PR TITLE
Refs #607: play external (cross-host) https audio in the docked mini-player

### DIFF
--- a/cicchetto/e2e/tests/nginx-csp-range-parity.spec.ts
+++ b/cicchetto/e2e/tests/nginx-csp-range-parity.spec.ts
@@ -35,7 +35,10 @@ import { uploadViaPicker } from "../fixtures/uploadJourney";
 // design leans on (default-src/frame-ancestors/base-uri).
 const LOAD_BEARING_DIRECTIVES = [
   "default-src 'self'",
-  "media-src 'self' blob:",
+  // #607 — the `https:` token must reach the wire (external audio in the
+  // docked mini-player); the old "media-src 'self' blob:" pin is a PREFIX
+  // of this, so `toContain` would pass silently without the widened token.
+  "media-src 'self' blob: https:",
   "worker-src 'self' blob:",
   "frame-ancestors 'none'",
   "base-uri 'self'",

--- a/cicchetto/src/__tests__/mediaLink.test.ts
+++ b/cicchetto/src/__tests__/mediaLink.test.ts
@@ -8,13 +8,16 @@ import { classifyMediaLink, sameHostHref } from "../lib/mediaLink";
 //     -> { kind: "image" | "video" | "audio", href: string } | null
 //
 // null = not modal-eligible; the scrollback anchor keeps its default
-// target=_blank behavior. The returned href is re-rooted on the page
-// origin (review fix: one parse, one return value — a separate
-// normalize step was a misuse footgun). A URL is admitted when its host
-// is the page origin's OR (#324) any of the deployment's server-provided
-// HTTP host aliases (`aliasHosts`); a genuinely third-party host is
-// ALWAYS null (the CSP img-src/media-src 'self' would block it, and
-// out-of-scope links already open correctly in the iOS Safari view).
+// target=_blank behavior. For same-host / alias links the returned href
+// is re-rooted on the page origin (review fix: one parse, one return
+// value — a separate normalize step was a misuse footgun). A URL is
+// admitted when its host is the page origin's OR (#324) any of the
+// deployment's server-provided HTTP host aliases (`aliasHosts`). #607
+// adds ONE exception: a genuinely third-party host is admitted only for
+// an https AUDIO link, returned with its absolute href UNCHANGED (never
+// re-rooted onto the page origin — that would 404 the foreign host).
+// Every other third-party link (http → mixed content; image/video →
+// #341 non-goal, Safari-view already opens them) is still null.
 
 const ORIGIN = "https://grappa.example";
 // 26 chars of lowercase base32 (a-z2-7) — mirrors Grappa.Uploads
@@ -116,7 +119,7 @@ describe("classifyMediaLink", () => {
     });
   });
 
-  describe("third-party (non-deployment) hosts are never modal-eligible", () => {
+  describe("third-party (non-deployment) non-audio links are never modal-eligible (#607 admits audio only)", () => {
     it("third-party uploads-shaped URL with emoji is null", () => {
       expect(
         classifyMediaLink(`https://other.example/uploads/${SLUG}`, "📸 ", ORIGIN, NO_ALIASES),
@@ -139,6 +142,68 @@ describe("classifyMediaLink", () => {
       expect(
         classifyMediaLink(`https://grappa.example:4000/uploads/${SLUG}`, "📸 ", ORIGIN, NO_ALIASES),
       ).toBeNull();
+    });
+  });
+
+  // #607 — a third-party host is admitted for an https AUDIO link only, so
+  // it opens in the docked mini-player (cross-channel playback) instead of
+  // navigating the tab. The href is returned UNCHANGED (never re-rooted onto
+  // the page origin — that would 404 the foreign host). http is rejected
+  // (mixed content on the https page); external image/video stay null (#341
+  // declared inline previews a non-goal, and the Safari view already opens
+  // them). The CSP `media-src` is widened to `https:` in the same change so
+  // the <audio> element is not blocked.
+  describe("external (cross-host) https audio is modal-eligible (#607)", () => {
+    const EXT_AUDIO = "https://media.example.org/podcast/ep1.mp3";
+
+    it("external https audio extension → audio with the absolute href UNCHANGED", () => {
+      expect(classifyMediaLink(EXT_AUDIO, "", ORIGIN, NO_ALIASES)).toEqual({
+        kind: "audio",
+        href: EXT_AUDIO,
+      });
+    });
+
+    it("external audio href is NOT re-rooted — path, query and media fragment stay on the foreign host", () => {
+      const href = "https://media.example.org/a/b/song.m4a?token=xyz#t=42";
+      expect(classifyMediaLink(href, "", ORIGIN, NO_ALIASES)).toEqual({ kind: "audio", href });
+    });
+
+    it("external https audio is admitted regardless of the advertised alias set", () => {
+      expect(classifyMediaLink(EXT_AUDIO, "", ORIGIN, WITH_ALIAS_B)).toEqual({
+        kind: "audio",
+        href: EXT_AUDIO,
+      });
+    });
+
+    it("external http audio is null (mixed content on the https page)", () => {
+      expect(
+        classifyMediaLink("http://media.example.org/podcast/ep1.mp3", "", ORIGIN, NO_ALIASES),
+      ).toBeNull();
+    });
+
+    it("external https image extension stays null (audio-only scope)", () => {
+      expect(
+        classifyMediaLink("https://media.example.org/shot.png", "", ORIGIN, NO_ALIASES),
+      ).toBeNull();
+    });
+
+    it("external https video extension stays null (audio-only scope)", () => {
+      expect(
+        classifyMediaLink("https://media.example.org/clip.mp4", "", ORIGIN, NO_ALIASES),
+      ).toBeNull();
+    });
+
+    it("external https non-media extension is null", () => {
+      expect(
+        classifyMediaLink("https://media.example.org/paper.pdf", "", ORIGIN, NO_ALIASES),
+      ).toBeNull();
+    });
+
+    it("external https audio ignores a mismatched emoji prefix (extension is the type source)", () => {
+      expect(classifyMediaLink(EXT_AUDIO, "📸 ", ORIGIN, NO_ALIASES)).toEqual({
+        kind: "audio",
+        href: EXT_AUDIO,
+      });
     });
   });
 

--- a/cicchetto/src/lib/mediaLink.ts
+++ b/cicchetto/src/lib/mediaLink.ts
@@ -23,11 +23,17 @@
 //    the page-origin host ∪ the deployment's server-provided HTTP host
 //    aliases (`aliasHosts` param, #324 — from `serverSettings()`'s
 //    `httpHostAliases`, ultimately `Grappa.HttpHosts`; NEVER a client-
-//    baked list). Two independent reasons a genuinely foreign host is
-//    excluded: (a) the CSP (`img-src 'self' data:`, `media-src 'self'
-//    blob:`) would block the modal's media element anyway — the modal
-//    must not require a CSP loosening; (b) genuinely cross-host links
-//    don't have the standalone bug and open fine in the iOS Safari view.
+//    baked list). A genuinely foreign host is excluded for image/video —
+//    two reasons: (a) the modal's `<img>`/`<video>` would need a CSP
+//    loosening this design refused for cross-origin images (#341 non-goal);
+//    (b) cross-host image/video links don't have the standalone bug and open
+//    fine in the iOS Safari view. #607 carves ONE exception: a foreign host
+//    IS admitted for an https AUDIO link (`externalAudioLink`), because audio
+//    wants the docked mini-player's cross-channel playback the Safari view
+//    can't give — the href is returned UNCHANGED (a foreign host is NEVER
+//    re-rooted; that would 404), http is rejected (mixed content), and the
+//    CSP `media-src` is widened to `https:` in the same change so the
+//    `<audio>` element is not blocked.
 //    #324 — a deployment can answer on several hostname aliases
 //    (`irc.sindro.me`, `irc.sniffo.org`) that reverse-proxy to ONE
 //    instance + shared /uploads store; a link minted under one alias
@@ -220,12 +226,19 @@ export function classifyMediaLink(
   aliasHosts: readonly string[],
 ): MediaLink | null {
   const match = sameHostUrl(href, origin, aliasHosts);
-  if (match === null) return null;
+  // Foreign host (or non-http(s) / unparseable): the only cross-host link
+  // that reaches the in-app viewer is #607 external https audio.
+  if (match === null) return externalAudioLink(href);
 
   const kind = kindOf(match.url, precedingText);
   if (kind === null) return null;
 
   return { kind, href: match.rooted };
+}
+
+function extensionKind(url: URL): MediaKind | null {
+  const extension = url.pathname.split(".").pop()?.toLowerCase() ?? "";
+  return EXTENSION_KIND[extension] ?? null;
 }
 
 function kindOf(url: URL, precedingText: string): MediaKind | null {
@@ -234,6 +247,38 @@ function kindOf(url: URL, precedingText: string): MediaKind | null {
     return emoji !== undefined ? (EMOJI_KIND[emoji] ?? null) : null;
   }
 
-  const extension = url.pathname.split(".").pop()?.toLowerCase() ?? "";
-  return EXTENSION_KIND[extension] ?? null;
+  return extensionKind(url);
+}
+
+/**
+ * #607 external branch. A genuinely third-party host is modal-eligible ONLY
+ * for an https AUDIO link, so it opens in the docked mini-player (#115) —
+ * cross-channel playback the iOS Safari view can't give — instead of
+ * navigating the tab. Returns the absolute href UNCHANGED: a foreign host is
+ * NEVER re-rooted onto the page origin (that would 404 / load the wrong file).
+ *
+ * - https only — an http media element on the https page is mixed content and
+ *   is blocked (the same-host branch stays scheme-agnostic for legacy uploads;
+ *   that leniency deliberately does NOT extend to foreign hosts).
+ * - audio only — external image/video stay null (#341 declared inline previews
+ *   a non-goal, and the Safari view already opens them fine).
+ *
+ * The CSP `media-src` is widened to `https:` in the same change (#607) so the
+ * <audio> element is not blocked. No `crossorigin` attribute on the element —
+ * it would require `Access-Control-Allow-Origin` from the foreign host and
+ * break otherwise-working playback; scrub/seek is best-effort on the remote
+ * server's Range support.
+ */
+function externalAudioLink(href: string): MediaLink | null {
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== "https:") return null;
+  if (extensionKind(url) !== "audio") return null;
+
+  return { kind: "audio", href };
 }

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -25769,3 +25769,56 @@ exact prod stacktrace RED; (b) adapter-agnostic proof of the ROOT — a Mox adap
 with NO `list_aliases` stub, so any boot-path call raises → `:DOWN`, forcing the
 early-return rather than merely a defensive adapter clause; plus (c/d) the
 `FreeBSD.list_aliases(nil)`/`IpLiteral.in_cidr6?(_, nil)` unit clauses.
+## 2026-08-01 — #607: external (cross-host) audio in the docked mini-player + the media-src https: loosening
+
+A `.mp3`/`.m4a` link to a THIRD-PARTY host now opens in the #115 audio
+mini-player (cross-channel playback the iOS Safari view can't give) instead of
+navigating the tab. vjt decided in channel (2026-08-01: "ammettiamo anche
+esterni"). This is a **feature**, not a bug fix: cross-host links never had the
+iOS-standalone navigate-in-place bug (they open fine in the Safari view) — the
+gain is keeping the user in the app with the docked transport bar.
+
+**The one thing that blocked it was the host gate.** `mediaLink.ts`
+`classifyMediaLink` admitted a URL only when its host was the page origin or a
+#324 deployment alias, re-rooting the href onto the page origin; every foreign
+host returned null. The fix adds ONE narrow exception: when `sameHostUrl`
+rejects (foreign / non-http(s) / unparseable), fall through to
+`externalAudioLink` — `https:` only, audio extension only, returning the
+absolute href **UNCHANGED**. Four deliberate boundaries:
+
+- **Never re-root a foreign host.** The same-host branch returns
+  `${origin}${pathname}…`; doing that to a third-party host would 404 or load
+  an unrelated same-path file. External returns the href verbatim.
+- **https only.** The same-host match is deliberately scheme-agnostic (legacy
+  prod minted `http://host/uploads/<slug>` bodies that are permanent history);
+  that leniency does NOT extend outward — an `http:` media element on the
+  `https:` page is mixed content and is blocked. External requires `https:`.
+- **Audio only.** External image/video stay null — #341 declared inline
+  previews a non-goal, and the Safari view already opens them, so cross-origin
+  image/video gains nothing (and would need `img-src`/`media-src` loosenings
+  this design refused).
+- **No `crossorigin` on the `<audio>`.** It would demand
+  `Access-Control-Allow-Origin` from the foreign host and break playback that
+  otherwise works. Scrub/seek is best-effort: it depends on the remote host
+  honouring `Range` requests; a host that doesn't will play but not seek.
+
+**CSP loosening.** The `<audio>` element would be blocked by `media-src 'self'
+blob:`, so `SecurityHeaders` widens it to `media-src 'self' blob: https:`. This
+is a documented, deliberate exception to the hard-won "restate only what
+`default-src` provided" rule (2026-06-10): the widening is scheme-scoped to
+`https` (never `http`, so no mixed content) and the client gate is audio-only,
+so the attack surface is "a page can `<audio src>` any https origin" — accepted
+for a text-only IRC client whose media is user-clicked links. `'self'` and
+`blob:` are kept (declaring `media-src` REPLACES the `default-src` fallback;
+`blob:` is the video-upload duration probe). The directive is pinned in TWO
+places that must move together or the plug and the e2e nginx layer drift
+silently: `security_headers_test.exs`'s golden pin and
+`nginx-csp-range-parity.spec.ts`'s `LOAD_BEARING_DIRECTIVES`. Trap noted in the
+spec: the old `"media-src 'self' blob:"` substring is a PREFIX of the new value,
+so `toContain` would have passed silently — it's pinned to the full widened
+token. Playback itself is device-only (Playwright webkit ≠ iOS) and external
+hosts are unreachable from the hermetic testnet, so the issue scopes real
+playback to a Manual check; the automated coverage is the classifier table
+(`mediaLink.test.ts`) + the CSP-on-the-wire parity spec.
+
+Deploy class: `security_headers.ex` is in `lib/` → HOT.

--- a/lib/grappa_web/plugs/security_headers.ex
+++ b/lib/grappa_web/plugs/security_headers.ex
@@ -62,11 +62,17 @@ defmodule GrappaWeb.Plugs.SecurityHeaders do
     * `img-src 'self' data:` — favicons + manifest icons + SolidJS inline `data:` SVGs.
     * `font-src 'self'` — system fonts only.
     * `manifest-src 'self'` — PWA install manifest.
-    * `media-src 'self' blob:` — `blob:` for the video-upload duration probe
-      (off-DOM `<video>` via `URL.createObjectURL`, videoPolicy.ts); `'self'`
-      because declaring `media-src` REPLACES the `default-src` fallback and
-      direct navigation to `/uploads/<slug>` videos (the 🎬 link — browsers
-      render mp4 in a media document governed by this header) needs it.
+    * `media-src 'self' blob: https:` — `blob:` for the video-upload duration
+      probe (off-DOM `<video>` via `URL.createObjectURL`, videoPolicy.ts);
+      `'self'` because declaring `media-src` REPLACES the `default-src`
+      fallback and direct navigation to `/uploads/<slug>` videos (the 🎬 link
+      — browsers render mp4 in a media document governed by this header) needs
+      it; `https:` (#607) so the docked audio mini-player can play a
+      third-party `.mp3`/`.m4a` link's `<audio>` element (external audio only,
+      admitted client-side by `mediaLink.ts` `externalAudioLink` — the widening
+      is scheme-scoped to https, never http, so no mixed content). This is a
+      deliberate, documented loosening of the "restate only `'self'`" rule
+      above; the plug test + `nginx-csp-range-parity.spec.ts` pin it.
     * `worker-src 'self' blob:` — the SW shell-cache worker, plus mediabunny
       spawns codec workers from `blob:` URLs.
     * `frame-src https://challenges.cloudflare.com https://*.hcaptcha.com` —
@@ -88,7 +94,7 @@ defmodule GrappaWeb.Plugs.SecurityHeaders do
 
   import Plug.Conn
 
-  @csp "default-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com https://litterbox.catbox.moe; script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' https://challenges.cloudflare.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://*.hcaptcha.com; img-src 'self' data:; font-src 'self'; manifest-src 'self'; media-src 'self' blob:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://*.hcaptcha.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+  @csp "default-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com https://litterbox.catbox.moe; script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' https://challenges.cloudflare.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://*.hcaptcha.com; img-src 'self' data:; font-src 'self'; manifest-src 'self'; media-src 'self' blob: https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://*.hcaptcha.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 
   # HTTP header names are lower-cased (HTTP/2 + Plug convention); the VALUES
   # are byte-identical to the retired nginx snippet.

--- a/test/grappa_web/plugs/security_headers_test.exs
+++ b/test/grappa_web/plugs/security_headers_test.exs
@@ -6,10 +6,12 @@ defmodule GrappaWeb.Plugs.SecurityHeadersTest do
   operator's own TLS front door). nginx — where it survives (jail + e2e) —
   is a dumb reverse proxy that emits none of these.
 
-  The golden literal below is the CSP that shipped byte-for-byte in the
-  retired `infra/snippets/security-headers.conf`. It is intentionally
-  hardcoded here (not read from the plug) so this test PINS the plug
-  against drift — a characterization contract, not a mirror.
+  The golden literal below started as the CSP that shipped byte-for-byte
+  in the retired `infra/snippets/security-headers.conf`; #607 widened
+  `media-src` to `https:` (external audio in the docked mini-player) — a
+  deliberate, pinned deviation. It is intentionally hardcoded here (not
+  read from the plug) so this test PINS the plug against drift — a
+  characterization contract, not a mirror.
   """
   use ExUnit.Case, async: true
 
@@ -17,10 +19,11 @@ defmodule GrappaWeb.Plugs.SecurityHeadersTest do
 
   alias GrappaWeb.Plugs.SecurityHeaders
 
-  # Byte-identical to the deleted nginx snippet's Content-Security-Policy
-  # value. If the app must change the policy, change it in ONE place
-  # (the plug) and update this pin deliberately.
-  @golden_csp "default-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com https://litterbox.catbox.moe; script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' https://challenges.cloudflare.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://*.hcaptcha.com; img-src 'self' data:; font-src 'self'; manifest-src 'self'; media-src 'self' blob:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://*.hcaptcha.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+  # The plug's Content-Security-Policy SSOT (was byte-identical to the
+  # deleted nginx snippet; #607 widened media-src to https:). If the app
+  # must change the policy, change it in ONE place (the plug) and update
+  # this pin deliberately.
+  @golden_csp "default-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://*.hcaptcha.com https://litterbox.catbox.moe; script-src 'self' 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM=' https://challenges.cloudflare.com https://*.hcaptcha.com; style-src 'self' 'unsafe-inline' https://*.hcaptcha.com; img-src 'self' data:; font-src 'self'; manifest-src 'self'; media-src 'self' blob: https:; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://*.hcaptcha.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 
   defp sent(status) do
     :get
@@ -29,7 +32,7 @@ defmodule GrappaWeb.Plugs.SecurityHeadersTest do
     |> send_resp(status, "body")
   end
 
-  test "csp/0 is byte-identical to the retired nginx snippet" do
+  test "csp/0 matches the golden pin (SSOT, incl. the #607 media-src https: widening)" do
     assert SecurityHeaders.csp() == @golden_csp
   end
 


### PR DESCRIPTION
Refs #607. Merge/deploy on the orchestrator's / vjt's order — not auto (no `Closes`).

## What
A `.mp3`/`.m4a` link to a **third-party host** now opens in the #115 docked
audio mini-player (cross-channel playback the iOS Safari view can't give)
instead of navigating the tab. Feature, not a bug fix: cross-host links never
had the iOS-standalone navigate-in-place bug.

## How
The only blocker was the host gate. `mediaLink.ts` `classifyMediaLink` now falls
through to a new `externalAudioLink` branch when the host is not admitted:

- **https only** — an `http:` media element on the `https:` page is mixed
  content, blocked (the same-host branch stays scheme-agnostic for legacy
  uploads; that leniency does NOT extend outward).
- **audio only** — external image/video stay `null` (#341 inline-preview
  non-goal; the Safari view already opens them).
- **href returned UNCHANGED** — a foreign host is NEVER re-rooted onto the page
  origin (that would 404 / load the wrong file). By-extension classification is
  extracted to `extensionKind/1`, shared with the same-host path.

The `<audio>` element needs the CSP widened: `SecurityHeaders` `media-src 'self'
blob:` → `media-src 'self' blob: https:` (scheme-scoped to https, never http).
Pinned in the two places that must move together — the plug-test golden pin and
`nginx-csp-range-parity.spec.ts` (the old `"media-src 'self' blob:"` substring
is a PREFIX of the new value, so `toContain` would have passed silently; pinned
to the full widened token). No `crossorigin` on the element (would demand CORS
from the foreign host and break otherwise-working playback); seek is best-effort
on the remote server's `Range` support.

## Acceptance (issue #607)
- ✅ `mediaLink.test.ts` table: external https audio → `{kind:"audio", href:
  <absolute href, unchanged>}`; external http → `null`; external image/video →
  `null`; every existing same-host / alias / legacy-slug case (incl. re-rooting
  asserts) unchanged. (+8 cases.)
- ✅ CSP assertions updated in both the plug test and the nginx parity spec.
- ⏳ Manual (device-only — Playwright webkit ≠ iOS, and external hosts are
  unreachable from the hermetic testnet): a third-party `.m4a` click opens the
  mini-player, plays, does not navigate the tab.

## Verification (local, branched off origin/main d536ecba)
- cic `bun run check` (biome + tsc): EXIT 0 (37 pre-existing CSS warnings).
- full cic vitest: **3755 passed / 210 files**, EXIT 0 (Δ +8 = the new
  external-audio table cases).
- Elixir plug test: RED (3 CSP failures) → GREEN (5/5) after the widening.
- `spa_serving_test` (CSP consumer via the `csp/0` SSOT): 22/22 green.
- e2e nginx-csp-range-parity: runs on PR CI (needs the full testnet).

DESIGN_NOTES carries the decision + the deliberate CSP loosening rationale.
**Deploy class: `security_headers.ex` is in `lib/` → HOT.**