### PR TITLE
test(#604): reconcile IrcPeer.nick with the server-granted nick

### DIFF
--- a/cicchetto/e2e/fixtures/ircClient.ts
+++ b/cicchetto/e2e/fixtures/ircClient.ts
@@ -74,7 +74,28 @@ export class IrcPeer {
       });
     }
 
-    const registered = once(client, "registered", REGISTER_TIMEOUT_MS, `register ${opts.nick}`);
+    const registered = once<{ nick: string }>(
+      client,
+      "registered",
+      REGISTER_TIMEOUT_MS,
+      `register ${opts.nick}`,
+    );
+
+    // Ghost/collision hardening (#604). If the requested nick is already held —
+    // a residual ghost from a prior run, or a live collision under bahamut's
+    // per-IP limits — bahamut answers 433 ERR_NICKNAMEINUSE and waits for a
+    // fresh NICK. irc-framework (4.14.0) does NOT auto-retry during
+    // registration; it only emits `nick in use`, so `connect` would hang until
+    // REGISTER_TIMEOUT_MS and surface as a 15s locator timeout in whatever spec
+    // ran next (the #277 flake). Retry with a suffixed alternate until one is
+    // free; `peer.nick` is reconciled from the `registered` event below to
+    // whatever the server actually granted. Removed once registration lands.
+    let collisionAttempt = 0;
+    const onNickInUse = () => {
+      collisionAttempt += 1;
+      client.changeNick(`${opts.nick}_${collisionAttempt}`);
+    };
+    client.on("nick in use", onNickInUse);
 
     client.connect({
       // Default target is the azzurra leaf (`bahamut-test`); callers can
@@ -92,7 +113,14 @@ export class IrcPeer {
       auto_reconnect: false,
     });
 
-    await registered;
+    const welcome = await registered;
+    client.removeListener("nick in use", onNickInUse);
+    // Reconcile with the nick the server ACTUALLY registered (#604). The 001
+    // RPL_WELCOME nick is authoritative: it differs from the requested nick
+    // after a 433 retry above, or when bahamut truncated an over-NICKLEN nick.
+    // irc-framework already tracks it on client.user.nick; mirror it here so
+    // every downstream verb keyed on peer.nick addresses the peer that exists.
+    peer.nick = welcome.nick;
     return peer;
   }
 
@@ -483,13 +511,18 @@ export class IrcPeer {
   }
 }
 
-function once(client: Client, event: string, timeoutMs: number, label: string): Promise<unknown> {
+function once<T = unknown>(
+  client: Client,
+  event: string,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(
       () => reject(new Error(`IrcPeer: timeout waiting for ${label} (${timeoutMs}ms)`)),
       timeoutMs,
     );
-    client.once(event, (payload: unknown) => {
+    client.once(event, (payload: T) => {
       clearTimeout(timer);
       resolve(payload);
     });

--- a/cicchetto/e2e/tests/issue604-peer-nick-reconcile.spec.ts
+++ b/cicchetto/e2e/tests/issue604-peer-nick-reconcile.spec.ts
@@ -1,0 +1,64 @@
+// Issue #604 — IrcPeer.connect must survive a nick collision and reconcile
+// `peer.nick` with the nick the server ACTUALLY registered.
+//
+// The real flake (#277): a residual ghost from a prior run still holds the
+// nick a spec asks for. bahamut answers 433 ERR_NICKNAMEINUSE and waits for a
+// fresh NICK, but irc-framework (4.14.0) does NOT auto-retry during
+// registration — it only emits `nick in use`. So the peer either hangs until
+// the register timeout, or (had it registered under an alternate) keeps
+// believing the requested nick while the server granted a different one. Then
+// every later helper keyed on `peer.nick` addresses a phantom: a DM / `/ping`
+// to it lands nowhere and the spec waits out its full timeout, surfacing as an
+// unrelated 15s locator flake wherever it happens to run.
+//
+// A clean testnet won't hand you the ghost — "re-running is what triggers it".
+// So this FABRICATES the collision deterministically: a first peer holds the
+// nick, a second peer requests the SAME one and earns the 433. `IrcPeer.connect`
+// must then (a) retry onto a free alternate so registration completes, and
+// (b) reconcile `peer.nick` to whatever the 001 RPL_WELCOME granted.
+//
+// (Aside — the issue's phrasing that irc-framework itself "registers the peer
+// under an alternate nick" does not hold for 4.14.0: a plain 433 during
+// registration just stalls. The retry lives in the fixture; the reconcile then
+// mirrors irc-framework's own client.user.nick, which IS set from the 001.)
+//
+// Pure-peer test: no cic/browser, so it uses the bare @playwright/test `test`
+// (no vjt-reset / CSP auto-fixtures) and never touches `page`.
+
+import { expect, test } from "@playwright/test";
+import { IrcPeer } from "../fixtures/ircClient";
+
+// Unique-per-run so a KEEP_STACK rerun can't collide with its own ghost.
+function uniqueNick(prefix: string): string {
+  return `${prefix}${crypto.randomUUID().replace(/-/g, "").slice(0, 6)}`;
+}
+
+test("#604 — connect survives a 433 collision, reconciling peer.nick so a DM reaches the real peer", async () => {
+  const nick = uniqueNick("n604");
+
+  // The holder claims the nick, so the second identical request earns a
+  // deterministic 433 (the fabricated ghost).
+  const holder = await IrcPeer.connect({ nick });
+  try {
+    // Pre-fix this hangs on the 433 (no retry) and throws at REGISTER_TIMEOUT_MS.
+    const peer = await IrcPeer.connect({ nick });
+    try {
+      // Reconciled OFF the requested (held) nick to the server-granted alternate.
+      expect(peer.nick).not.toBe(nick);
+
+      // The outcome the flake actually cares about: a DM keyed on `peer.nick`
+      // reaches THIS peer, not the holder and not a phantom. If reconcile were
+      // missing, `peer.nick` would still be the held nick — the DM would land
+      // on the holder (irc-framework doesn't echo own sends) and this would
+      // time out. Arm the listener BEFORE the send.
+      const token = `dm604-${crypto.randomUUID().slice(0, 8)}`;
+      const received = peer.waitForPrivmsg(holder.nick, token);
+      holder.privmsg(peer.nick, token);
+      await received;
+    } finally {
+      await peer.disconnect("bye #604");
+    }
+  } finally {
+    await holder.disconnect("bye #604");
+  }
+});


### PR DESCRIPTION
## What

`IrcPeer.connect` now survives a nick collision and reconciles `peer.nick` with the nick the server actually granted.

Refs #604.

## Why

`connect` awaited `registered` but kept the **requested** nick. Two gaps, both proven against the testnet:

1. **No 433 retry.** irc-framework 4.14.0 does **not** auto-retry a `433 ERR_NICKNAMEINUSE` during registration — it only emits `nick in use`. A peer whose requested nick is held by a residual **ghost from a prior run** just stalls until the 10 s register timeout. (⚠️ The issue text assumed irc-framework picks the alternate itself; empirically it does not — a plain 433 hangs. Confirmed with a diagnostic run against the live testnet.)
2. **No reconcile.** Even when the server grants a *different* nick (after a 433 retry, or when bahamut truncates an over-`NICKLEN` nick), `peer.nick` kept the requested string, so every downstream helper keyed on it addressed a phantom nobody uses — a DM / `/ping` landed nowhere and the spec waited out its timeout, surfacing as an unrelated 15 s locator flake elsewhere in the suite (the mechanism behind #277).

## Fix — `cicchetto/e2e/fixtures/ircClient.ts`

- On `nick in use`, retry via `changeNick` with a suffixed alternate so registration completes despite the ghost.
- Reconcile `peer.nick` from the 001 `RPL_WELCOME` the `registered` event carries (mirrors irc-framework's own `client.user.nick`, which it already sets from that event).
- `once()` made generic so the reconcile reads a typed `{ nick }` payload.

Behaviour-neutral for existing specs: with a unique nick and no collision, `nick in use` never fires and `welcome.nick === requested`, so the code path is identical — it just gains ghost/collision resilience. The per-run unique-nick idiom (`k16peer`, `m591-<uuid>`, …) becomes belt-and-braces rather than the only line of defence, exactly as #604 intended.

## Test — TDD against the real testnet

New peer-only spec `issue604-peer-nick-reconcile.spec.ts` **fabricates** the collision deterministically (a clean testnet won't hand you the ghost — "re-running is what triggers it"): a holder peer claims the nick, a second peer requests the same one → deterministic 433.

- **RED** (unfixed fixture): `Error: IrcPeer: timeout waiting for register … (10000ms)` — the 433 stalls the connect.
- **GREEN** (fixed): passes in 59 ms; the reconciled `peer.nick` receives the holder's DM (proves both halves — retry *and* reconcile).

Test count: **+1** (one new `test()`).

## Scope notes

- `ircClient.ts` is the **only** e2e fixture that constructs an irc-framework `Client` — no sibling fixture carries this bug shape.
- The server-side twin (grappa's *own* upstream nick taking a 433, the #600 incident) is out of scope here — #604 is the `cicchetto/e2e` fixture only.
- `scripts/check.sh` is src-scoped and does **not** cover `e2e/` (the ~20 pre-existing e2e type errors are tracked in #484); the gate here is this PR's integration CI. Since the fixture change touches shared code, the **full** integration suite is the real regression check, not a scoped `--grep`.
