### PR TITLE
fix(#592): pass protocol.file.allow=always on submodule auto-init

### DIFF
--- a/scripts/bats.sh
+++ b/scripts/bats.sh
@@ -14,6 +14,7 @@
 # container is only invoked transitively when a test exercises a verb
 # that shells out to docker (those tests stub `docker` via PATH).
 
+# shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
 
 cd "$SRC_ROOT"
@@ -27,9 +28,14 @@ if [ ! -x "$bats_bin" ]; then
     # tree). Init it rather than making the operator run the incantation
     # by hand — mirrors the testnet.sh submodule auto-init pattern so
     # check.sh works first-try from any worktree.
+    # `-c protocol.file.allow=always` is REQUIRED, not cosmetic (#592): in a
+    # worktree git clones the submodule from the superproject's LOCAL module
+    # store over the file:// transport, which the CVE-2022-39253 mitigation
+    # blocks by default — without it a fresh worktree dies with
+    # `fatal: transport 'file' not allowed`.
     printf 'scripts/bats.sh: vendor/bats-core missing — initialising submodule...\n' >&2
-    git -C "$SRC_ROOT" submodule update --init vendor/bats-core >&2 \
-        || die "vendor/bats-core init failed. Run: git -C \"$SRC_ROOT\" submodule update --init vendor/bats-core"
+    git -C "$SRC_ROOT" -c protocol.file.allow=always submodule update --init vendor/bats-core >&2 \
+        || die "vendor/bats-core init failed. Run: git -C \"$SRC_ROOT\" -c protocol.file.allow=always submodule update --init vendor/bats-core"
 fi
 
 if [ ! -x "$bats_bin" ]; then

--- a/scripts/testnet.sh
+++ b/scripts/testnet.sh
@@ -23,6 +23,7 @@
 
 set -euo pipefail
 
+# shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
 
 E2E_DIR="$SRC_ROOT/cicchetto/e2e"
@@ -41,9 +42,15 @@ if [ ! -d "$E2E_DIR/infra/bahamut" ]; then
     # Git worktrees do NOT inherit the parent checkout's submodules, so a
     # fresh worktree always lands here. Auto-init instead of dying on a
     # manual step everyone forgets — idempotent and a no-op once present.
+    # `-c protocol.file.allow=always` is REQUIRED, not cosmetic (#592): in a
+    # worktree git clones the submodule from the superproject's LOCAL module
+    # store ($REPO/.git/modules/…) over the file:// transport, which the
+    # CVE-2022-39253 mitigation blocks by default — without the flag every
+    # fresh worktree dies with `fatal: transport 'file' not allowed`, so the
+    # auto-init that exists precisely to spare the manual step never spared it.
     echo "testnet: azzurra-testnet submodule empty (fresh worktree?) — initialising…" >&2
-    git -C "$SRC_ROOT" submodule update --init cicchetto/e2e/infra >&2 \
-        || die "submodule auto-init failed — run: git -C '$SRC_ROOT' submodule update --init cicchetto/e2e/infra"
+    git -C "$SRC_ROOT" -c protocol.file.allow=always submodule update --init cicchetto/e2e/infra >&2 \
+        || die "submodule auto-init failed — run: git -C '$SRC_ROOT' -c protocol.file.allow=always submodule update --init cicchetto/e2e/infra"
     [ -d "$E2E_DIR/infra/bahamut" ] \
         || die "azzurra-testnet submodule still empty after init — check $E2E_DIR/infra"
 fi

--- a/test/scripts/submodule_init_flag_test.bats
+++ b/test/scripts/submodule_init_flag_test.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+#
+# #592 — the submodule auto-init in scripts/testnet.sh AND scripts/bats.sh
+# must pass `-c protocol.file.allow=always`.
+#
+# In a git worktree the submodule is cloned from the superproject's LOCAL
+# module store ($REPO/.git/modules/…) over the file:// transport, which the
+# CVE-2022-39253 mitigation blocks by default. Without the flag every fresh
+# worktree dies with `fatal: transport 'file' not allowed`, so the auto-init
+# that exists precisely to spare the manual `git submodule update --init`
+# never spares it — it just fails more verbosely. This is a CLASS (both
+# scripts share the pattern), not a single case.
+#
+# Cloning for real in a worktree under bats is impractical (it needs a
+# populated superproject module store hit under the exact CVE conditions),
+# so — per the issue and the orchestrator's steer — this asserts on the
+# CONSTRUCTED command instead of faking a clone: a `git` stub on PATH
+# records every invocation, forwards everything except `submodule update`
+# to real git, and the test asserts the recorded submodule-update line
+# carries the flag. Honest + tight: it proves the flag reaches the
+# invocation, not that a clone succeeds. RED before the fix (the recorded
+# line lacks the flag), GREEN after.
+
+setup() {
+    TESTNET_SH="$BATS_TEST_DIRNAME/../../scripts/testnet.sh"
+    BATS_SH="$BATS_TEST_DIRNAME/../../scripts/bats.sh"
+    LIB_SH="$BATS_TEST_DIRNAME/../../scripts/_lib.sh"
+    VERSION_SH="$BATS_TEST_DIRNAME/../../infra/packaging/version.sh"
+
+    FAKE_DIR="$BATS_TEST_TMPDIR/fake"
+    mkdir -p "$FAKE_DIR"
+    GIT_LOG="$FAKE_DIR/git-argv.log"
+    : > "$GIT_LOG"
+
+    # Capture the real git BEFORE the stub shadows it on PATH.
+    REAL_GIT="$(command -v git)"
+
+    # Physical (symlink-resolved) base so _lib.sh's pwd-derived SRC_ROOT
+    # and git's --git-common-dir agree on macOS (/var → /private/var).
+    TMP="$(cd "$BATS_TEST_TMPDIR" && pwd -P)"
+
+    MAIN="$TMP/main"
+    git init -q -b main "$MAIN"
+    git -C "$MAIN" config user.email test@grappa.local
+    git -C "$MAIN" config user.name bats
+    mkdir -p "$MAIN/scripts" "$MAIN/infra/packaging" "$MAIN/lib" "$MAIN/cicchetto/e2e"
+    cp "$TESTNET_SH" "$MAIN/scripts/testnet.sh"
+    cp "$BATS_SH" "$MAIN/scripts/bats.sh"
+    cp "$LIB_SH" "$MAIN/scripts/_lib.sh"
+    # testnet.sh derives GRAPPA_VERSION from mix.exs @version via version.sh
+    # BEFORE the submodule branch — under set -e it must succeed or the
+    # script dies before we reach the code under test.
+    cp "$VERSION_SH" "$MAIN/infra/packaging/version.sh"
+    chmod +x "$MAIN/infra/packaging/version.sh"
+    printf 'defmodule Grappa.MixProject do\n  @version "9.9.9"\nend\n' > "$MAIN/mix.exs"
+    # testnet.sh's compose.yaml existence check must pass; the infra
+    # submodule dir must be ABSENT so the auto-init branch fires. lib/ is the
+    # marker _lib.sh uses (with the .git FILE) to detect a worktree.
+    : > "$MAIN/cicchetto/e2e/compose.yaml"
+    echo base > "$MAIN/lib/base.ex"
+    git -C "$MAIN" add -A
+    git -C "$MAIN" commit -qm base
+
+    # A REAL worktree so _lib.sh derives SRC_ROOT=WT and `git rev-parse
+    # --git-common-dir` resolves MAIN's .git — the exact worktree condition
+    # the bug needs. A fresh worktree has NO cicchetto/e2e/infra and NO
+    # vendor/bats-core, so each script's auto-init branch fires.
+    WT="$TMP/wt"
+    git -C "$MAIN" worktree add -q -b wt "$WT"
+
+    # git stub: record every invocation; short-circuit `submodule update`
+    # (record + exit 0, NO real clone) so the test never needs a populated
+    # module store; forward everything else (rev-parse, …) to real git so
+    # _lib.sh resolves REPO_ROOT normally.
+    cat > "$FAKE_DIR/git" <<EOF
+#!/usr/bin/env bash
+{ printf 'git'; for a in "\$@"; do printf ' %q' "\$a"; done; printf '\n'; } >> "$GIT_LOG"
+for a in "\$@"; do
+    [ "\$a" = "submodule" ] && exit 0
+done
+exec "$REAL_GIT" "\$@"
+EOF
+    chmod +x "$FAKE_DIR/git"
+    export PATH="$FAKE_DIR:$PATH"
+}
+
+@test "testnet.sh submodule auto-init passes protocol.file.allow=always in a worktree" {
+    cd "$WT"
+    # Any verb reaches the auto-init branch (it sits above the verb
+    # dispatch); an unknown one exits at the usage die without needing docker.
+    run "$WT/scripts/testnet.sh" __no_such_verb__
+    [[ "$output" == *"initialising"* ]]
+    grep -q 'submodule update --init cicchetto/e2e/infra' "$GIT_LOG"
+    grep -q -- '-c protocol.file.allow=always submodule update' "$GIT_LOG"
+}
+
+@test "bats.sh submodule auto-init passes protocol.file.allow=always in a worktree" {
+    cd "$WT"
+    run "$WT/scripts/bats.sh"
+    [[ "$output" == *"initialising submodule"* ]]
+    grep -q 'submodule update --init vendor/bats-core' "$GIT_LOG"
+    grep -q -- '-c protocol.file.allow=always submodule update' "$GIT_LOG"
+}


### PR DESCRIPTION
## What

The git-submodule auto-init in **both** `scripts/testnet.sh` and `scripts/bats.sh` now passes `-c protocol.file.allow=always`.

Refs #592.

## Why

In a git worktree, git clones the submodule from the superproject's **local** module store (`$REPO/.git/modules/…`) over the `file://` transport — which the CVE-2022-39253 mitigation blocks by default. So each auto-init died with `fatal: transport 'file' not allowed`, retried once, and `die`d. The auto-init that exists precisely to spare the manual `git submodule update --init` never spared it — it just failed more verbosely, and everyone ended up hand-running the same command **plus** the flag. The flag is **required, not cosmetic**: without it every fresh worktree's first e2e / bats run fails.

## It's a class, not a case

`grep -rn "submodule update" scripts/` surfaced **two** sites with the identical pattern (bats.sh's comment even says it "mirrors the testnet.sh submodule auto-init pattern"). Both are fixed in one pass:

- `scripts/testnet.sh:45` — `cicchetto/e2e/infra`
- `scripts/bats.sh:31` — `vendor/bats-core`

Each `die` message's manual-heal command gets the flag too — the fallback advice must not reproduce the bug it's recovering from.

## Test — TDD, asserts on the constructed command

New bats spec `test/scripts/submodule_init_flag_test.bats` (2 tests, one per script). Reproducing the real `file://` clone failure under bats is impractical (it needs a populated superproject module store hit under the exact CVE conditions), so — per the issue's explicit steer — it **asserts on the constructed command** instead of faking a clone: a `git` stub on PATH records every invocation, forwards everything except `submodule update` to real git, and the test runs each script from a **real** throwaway worktree and asserts the recorded `submodule update` line carries `-c protocol.file.allow=always`. An honest, tight assert beats a test that pretends to clone.

- **RED** (verified by reverting the two scripts): both tests fail exactly at the flag grep.
- **GREEN** (with the fix): both pass.

## Gates

- **bats**: full suite green — `171 → 173` tests, exit 0 (the +2 are this spec; no regressions).
- **shellcheck**: `shellcheck -x scripts/testnet.sh scripts/bats.sh` clean. Both files gained the `# shellcheck source=scripts/_lib.sh` directive (the `deploy.sh` convention) so shellcheck follows the include, sees `set -euo pipefail`, and lints them clean — neither file was in CI's shellcheck list before.

## Scope

Fix + directive + test only. Did **not** take the issue's *optional* "move the submodule check below the verb dispatch so `down` doesn't require it" — that touches testnet flow and the orchestrator scoped this to the flag + the class hunt.
