### PR TITLE
fix(#593): a failed share-token mint leaves the link usable (claim-then-release)

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -24865,11 +24865,17 @@ the request. Classification is by CALLER, not by "is it a write": a delete
 reachable from a background sweeper is #590 no matter which web door also calls
 it. Its #590 best-effort-DROP hardening is tracked separately.
 
-**Known pre-existing edge (not changed here).** The one-shot share token is
-`mark_consumed` BEFORE the session mint, so a saturated mint burns the token —
-a property of the consume-before-mint order that predates B1. The retryable-later
-503 is still strictly better than the old 500; reordering was judged too risky
-to fold into B1.
+**Known pre-existing edge (not changed here) — CLOSED by #593 (2026-08-01).**
+The one-shot share token is `mark_consumed` BEFORE the session mint, so a
+saturated mint burns the token — a property of the consume-before-mint order
+that predates B1. The retryable-later 503 is still strictly better than the old
+500; reordering was judged too risky to fold into B1 (touching the order touches
+the one-shot double-redemption window). B1's caution held: #593 did NOT reorder.
+It kept `mark_consumed` first as the atomic CLAIM and added a compensating
+`ShareTokens.release/1` that a failed mint calls to roll the claim back — a
+failed mint now leaves the link usable, a successful one leaves it dead, and the
+double-redemption window B1 feared never opens (the claim is held across the
+whole mint by `:ets.insert_new/2` atomicity). See the 2026-08-01 #593 entry.
 ---
 
 ## 2026-08-01 — CTCP PING answered, and a CTCP reply is not a DM
@@ -25420,3 +25426,54 @@ off so a later resize does not tail (RED before the fix, GREEN after); it is the
 deterministic inverse of the existing thaw case whose snapshot sits at the tail.
 The e2e `issue219-overlay-scroll-hold` is the wiring gate (the real resize
 authority; the assert and the 50px threshold were left untouched).
+---
+
+## 2026-08-01 — #593: a failed share-token mint leaves the link usable (claim-then-release)
+
+**The bug.** `POST /auth/share/consume` `mark_consumed`s the one-shot token
+BEFORE minting the session. A mint that fails AFTER the claim (a `:not_found`
+if the visitor row was reaped, or — the case that surfaced it — a
+`:db_unavailable` 503 when `create_session`'s SQLite write is saturated) left
+the token spent with no session minted: a dead link. #518 made that mint a
+**retryable 503**, but the retry it invites could never succeed — the token was
+already burned. Documented as a known edge in the #523/#518 (B1) entry above;
+this closes it.
+
+**Why not the "obvious" fix (one SQL transaction).** The tempting shape —
+wrap consume+mint in one `Repo.transaction` so a failed mint rolls the consume
+back — does NOT apply here, on two counts. (1) The one-shot ledger is **ETS**
+(`ShareTokens` / `:ets.insert_new/2`), not the Repo — "ETS over DB by intent"
+(zero migrations, HOT-deploy-friendly); `Repo.transaction` cannot roll back an
+ETS write. A true SQL transaction would first require migrating the ledger
+ETS→SQLite: the LARGEST change, silently reversing a documented architectural
+choice. (2) Worse, holding the consume inside a transaction across the whole
+`create_session` **lengthens the SQLite write-lock hold under exactly the
+saturation #518 mitigates** — it would aggravate the `SQLITE_BUSY` that made the
+bug visible. A fix that worsens the triggering condition is not a fix.
+
+**The fix — claim-then-release (the issue's own second option, "make the
+consume conditional on the mint succeeding").** Keep `mark_consumed` first: it
+is the atomic CLAIM (`:ets.insert_new/2`), held for the whole mint. Add
+`ShareTokens.release/1` (`:ets.delete/2`); `mint_session/3`'s inner `with` calls
+it on ANY post-claim failure, rolling the claim back. Failed mint → link usable;
+successful mint → claim retained, link dead. B1's caution is preserved: the
+order is NOT changed, so the double-redemption window it feared never opens —
+`insert_new/2`'s atomicity means at every instant exactly one caller holds the
+key.
+
+**The subtlety that is the whole point — release MUST be scoped to THIS
+request's own post-claim failures.** A flat `else` over one `with` would fire
+release on a LOSING concurrent redemption's `:share_token_consumed` too —
+deleting the WINNER's claim and resurrecting a token that already minted a
+session (dead-link → double-redemption, strictly worse than the bug being
+fixed). So `consume/2` splits: the outer `with` (verify + `mark_consumed`) whose
+`else` NEVER releases, and `mint_session/3`'s inner `with` (fetch + mint) whose
+`else` releases — reached only after `mark_consumed` returned `:ok` for this
+request, so the claim is provably ours. Pinned by the test *"a losing concurrent
+redemption's 410 does NOT release the winner's claim"*.
+
+**Known limit, accepted (benign threat model).** A concurrent loser gets a
+spurious 410 during a mint that later fails, and must retry after the winner's
+release. The threat model is "operator clicks their own link twice"; genuinely
+simultaneous double-redemption is rare, and a retry succeeds once the failed
+claim is released. Not worth a pending-state machine.

--- a/lib/grappa/visitors/share_tokens.ex
+++ b/lib/grappa/visitors/share_tokens.ex
@@ -31,6 +31,14 @@ defmodule Grappa.Visitors.ShareTokens do
     * `mark_consumed/1 :: :ok | {:error, :already_consumed}` —
       atomic insert-if-absent. Caller MUST treat
       `{:error, :already_consumed}` as a hard reject (HTTP 410 Gone).
+    * `release/1 :: :ok` — the compensating action for claim-then-release
+      (#593). Deletes a token this caller previously claimed, so a mint
+      that failed AFTER the claim leaves the link usable for a retry.
+      Idempotent (deleting an absent key is a no-op). The caller MUST
+      only release a token whose claim IS its own — never one that
+      returned `{:error, :already_consumed}` (that claim belongs to the
+      winning request; releasing it would resurrect a token that already
+      minted a session).
     * `all_keys/0` — test helper, returns the set of recorded tokens.
 
   ## Crash boundary
@@ -102,6 +110,25 @@ defmodule Grappa.Visitors.ShareTokens do
     else
       {:error, :already_consumed}
     end
+  end
+
+  @doc """
+  Release a token this caller previously claimed via `mark_consumed/1`,
+  making it claimable again. The compensating action of claim-then-release
+  (#593): a share-token consume claims the token BEFORE minting the
+  session, and a failed mint calls this to roll the claim back so the
+  retryable-503 the client is invited to retry can actually succeed.
+
+  Always returns `:ok` — deleting an absent key is a harmless no-op
+  (`:ets.delete/2` semantics). NEVER call this for a token whose claim
+  belongs to another request (a `mark_consumed/1` that returned
+  `{:error, :already_consumed}`): that would delete the winner's claim
+  and resurrect a token that already minted a session.
+  """
+  @spec release(binary()) :: :ok
+  def release(token) when is_binary(token) do
+    _ = :ets.delete(@table, token)
+    :ok
   end
 
   @doc false

--- a/lib/grappa_web/controllers/share_token_controller.ex
+++ b/lib/grappa_web/controllers/share_token_controller.ex
@@ -116,16 +116,26 @@ defmodule GrappaWeb.ShareTokenController do
   @doc """
   `POST /auth/share/consume` — unauthenticated, body `{token}`.
 
-  Flow:
+  Flow (claim-then-release, #593):
     1. Validate body shape (token present + binary) → 400 otherwise.
     2. `Phoenix.Token.verify` with `@salt` + `@max_age_seconds` →
        401 on bad signature, 410 on TTL elapsed.
-    3. `ShareTokens.mark_consumed/1` (atomic ETS insert-if-absent) →
-       410 on second redemption.
+    3. `ShareTokens.mark_consumed/1` (atomic ETS insert-if-absent) —
+       the one-shot CLAIM → 410 on second redemption. From here the
+       token is held by THIS request.
     4. `Visitors.get/1` → 404 if the row was reaped between mint and
        consume.
     5. `Accounts.create_session/4` for the SAME visitor row →
        returns the new bearer + the visitor's subject envelope.
+
+  #593 — the claim (step 3) is taken BEFORE the mint (steps 4-5), so a
+  failed mint would strand the token consumed with no session minted: a
+  dead link the retryable-503 (#518) invites the client to retry in vain.
+  `mint_session/3` closes that: ANY failure after the claim calls
+  `ShareTokens.release/1` to roll the claim back, so a failed mint leaves
+  the link usable and a successful mint leaves it dead. The release is
+  scoped to THIS request's own post-claim failures — a second
+  redemption's 410 (step 3) never releases the winner's claim.
 
   IP + user-agent are captured for audit just like login.
   """
@@ -137,16 +147,40 @@ defmodule GrappaWeb.ShareTokenController do
              | :share_token_expired
              | :share_token_consumed
              | :not_found
-             | :db_unavailable}
+             | :db_unavailable
+             | Ecto.Changeset.t()}
   def consume(conn, %{"token" => token}) when is_binary(token) and token != "" do
     with {:ok, visitor_id} <- verify_token(token),
-         :ok <- mark_consumed(token),
-         {:ok, visitor} <- fetch_visitor(visitor_id),
-         # #523/#518 — a transient SQLITE_BUSY on the token mint degrades to a
-         # clean 503 instead of a MatchError→500. NB: the one-shot share token
-         # is already consumed (step 2 above) by this point, so a saturated mint
-         # burns it — a pre-existing property of the consume-before-mint order;
-         # the retryable-later 503 is still strictly better than the old 500.
+         :ok <- mark_consumed(token) do
+      # The one-shot claim is now HELD by this request (mark_consumed
+      # returned :ok — we won any race). #593 — every failure past this
+      # point MUST roll the claim back (claim-then-release), so a
+      # retryable mint failure (a 503 under transient SQLite saturation,
+      # #518) leaves the link usable instead of silently dead.
+      mint_session(conn, token, visitor_id)
+    else
+      # Pre-consume rejects (bad signature / expired / lost the one-shot
+      # race → :share_token_consumed). NOTHING to release here: either no
+      # claim was taken, or the claim belongs to the WINNING request —
+      # releasing it would resurrect a token that already minted a
+      # session (dead-link → double-redemption, a worse bug).
+      {:error, reason} -> reject(reason)
+    end
+  end
+
+  def consume(_, _), do: {:error, :bad_request}
+
+  # Mint the session for an already-CLAIMED token. On ANY failure the
+  # claim is released (#593 claim-then-release) — safe because
+  # `mark_consumed/1` returned `:ok` for THIS request just above, so the
+  # token is ours to roll back, never a concurrent winner's. A failed
+  # mint therefore leaves the link usable; a successful mint leaves the
+  # claim in place (link dead), honouring the one-shot guarantee.
+  @spec mint_session(Plug.Conn.t(), String.t(), Ecto.UUID.t()) ::
+          Plug.Conn.t()
+          | {:error, :not_found | :db_unavailable | Ecto.Changeset.t()}
+  defp mint_session(conn, token, visitor_id) do
+    with {:ok, visitor} <- fetch_visitor(visitor_id),
          {:ok, session} <-
            Accounts.create_session(
              {:visitor, visitor.id},
@@ -170,18 +204,36 @@ defmodule GrappaWeb.ShareTokenController do
           |> Map.put(:kind, "visitor")
       })
     else
-      {:error, reason} = err ->
-        :telemetry.execute(
-          [:grappa, :visitor, :share_token, :rejected],
-          %{count: 1},
-          %{reason: reason}
-        )
-
-        err
+      {:error, reason} ->
+        ShareTokens.release(token)
+        reject(reason)
     end
   end
 
-  def consume(_, _), do: {:error, :bad_request}
+  # The closed set of rejection reasons — pre-consume (bad sig / expired /
+  # lost the one-shot race) and post-consume (visitor reaped / saturated
+  # mint / mint changeset). Typed over a bare `atom()` per CLAUDE.md's
+  # closed-set rule.
+  @typep reject_reason ::
+           :unauthorized
+           | :share_token_expired
+           | :share_token_consumed
+           | :not_found
+           | :db_unavailable
+           | Ecto.Changeset.t()
+
+  # Emit the rejection telemetry and return the wire error tuple, so
+  # both the pre-consume and post-consume reject paths stay single-sourced.
+  @spec reject(reject_reason()) :: {:error, reject_reason()}
+  defp reject(reason) do
+    :telemetry.execute(
+      [:grappa, :visitor, :share_token, :rejected],
+      %{count: 1},
+      %{reason: reason}
+    )
+
+    {:error, reason}
+  end
 
   @spec verify_token(String.t()) ::
           {:ok, Ecto.UUID.t()}

--- a/test/grappa/visitors/share_tokens_test.exs
+++ b/test/grappa/visitors/share_tokens_test.exs
@@ -50,6 +50,27 @@ defmodule Grappa.Visitors.ShareTokensTest do
     end
   end
 
+  describe "release/1" do
+    # #593 — the compensating action for claim-then-release. A consume
+    # claims the token (mark_consumed) BEFORE the session mint; a failed
+    # mint must roll that claim back so the retryable-503 the client is
+    # invited to retry can actually succeed.
+    test "deletes a consumed token so a later mark_consumed succeeds again" do
+      :ok = ShareTokens.mark_consumed("token-rel")
+      assert {:error, :already_consumed} = ShareTokens.mark_consumed("token-rel")
+
+      assert :ok = ShareTokens.release("token-rel")
+      # The claim is gone: the token is once again claimable.
+      assert :ok = ShareTokens.mark_consumed("token-rel")
+    end
+
+    test "releasing a token that was never consumed is a harmless no-op" do
+      assert :ok = ShareTokens.release("never-claimed")
+      # Still fully claimable afterwards — the no-op didn't corrupt the set.
+      assert :ok = ShareTokens.mark_consumed("never-claimed")
+    end
+  end
+
   describe "table_name/0" do
     test "returns the named ETS table atom" do
       assert ShareTokens.table_name() == :visitor_share_tokens_used

--- a/test/grappa_web/controllers/share_token_controller_test.exs
+++ b/test/grappa_web/controllers/share_token_controller_test.exs
@@ -31,6 +31,7 @@ defmodule GrappaWeb.ShareTokenControllerTest do
 
   import Grappa.AuthFixtures
 
+  alias Grappa.Repo.BusyRetry
   alias Grappa.Visitors.ShareTokens
 
   @max_age_seconds 600
@@ -171,6 +172,53 @@ defmodule GrappaWeb.ShareTokenControllerTest do
       assert json_response(fresh_conn, 410) == %{"error" => "share_token_consumed"}
     end
 
+    test "transient DB saturation on the mint leaves the token usable for a retry", %{
+      conn: conn,
+      visitor: visitor,
+      token: token
+    } do
+      # #593 — the hard half of the contract. The one-shot claim is taken
+      # (mark_consumed) BEFORE the session mint. Force the mint (a
+      # BusyRetry-wrapped INSERT) to exhaust its budget → {:error,
+      # :db_unavailable} → a retryable 503. The claim MUST roll back, else
+      # the retry the 503 invites can never succeed — a dead link.
+      BusyRetry.inject_transient_faults(10_000)
+      conn1 = post(conn, "/auth/share/consume", %{"token" => token})
+      assert json_response(conn1, 503)["error"] == "db_unavailable"
+
+      # White-box confirmation the compensating release fired: the token is
+      # absent from the consumed ledger.
+      refute token in ShareTokens.all_keys()
+
+      # Black-box proof: with the transient faults cleared, the SAME link
+      # mints for real. A dead link would 410 here.
+      BusyRetry.inject_transient_faults(0)
+      body = Phoenix.ConnTest.build_conn() |> post("/auth/share/consume", %{"token" => token}) |> json_response(200)
+      assert body["subject"]["id"] == visitor.id
+    end
+
+    test "a losing concurrent redemption's 410 does NOT release the winner's claim", %{
+      conn: conn,
+      token: token
+    } do
+      # #593 — the release must be scoped to THIS request's own post-consume
+      # failure. A flat `else` would fire release on the LOSER's
+      # `:share_token_consumed` too, deleting the WINNER's claim and
+      # resurrecting a token that already minted a session (a worse bug:
+      # dead-link → double-redemption). Winner mints, claim retained:
+      assert conn |> post("/auth/share/consume", %{"token" => token}) |> json_response(200)
+
+      # Loser hits the same token → 410. This 410 must leave the claim intact.
+      assert Phoenix.ConnTest.build_conn()
+             |> post("/auth/share/consume", %{"token" => token})
+             |> json_response(410) == %{"error" => "share_token_consumed"}
+
+      # Proof the winner's claim survived the loser's 410: still 410, never 200.
+      assert Phoenix.ConnTest.build_conn()
+             |> post("/auth/share/consume", %{"token" => token})
+             |> json_response(410) == %{"error" => "share_token_consumed"}
+    end
+
     test "visitor deleted between mint and consume returns 404", %{
       conn: conn,
       visitor: visitor,
@@ -257,6 +305,23 @@ defmodule GrappaWeb.ShareTokenControllerTest do
 
       assert_receive {:telemetry, [:grappa, :visitor, :share_token, :rejected], %{count: 1},
                       %{reason: :share_token_expired}}
+    end
+
+    test "a saturated mint (503) emits exactly one :rejected{db_unavailable}, no :consumed", %{conn: conn} do
+      # #593 — the post-claim failure path is DRY'd through `reject/1`; assert
+      # it fires the reject telemetry once (not zero, not doubled) and never
+      # the :consumed event when the mint rolls its claim back.
+      visitor = visitor_fixture()
+      token = Phoenix.Token.sign(GrappaWeb.Endpoint, @salt, visitor.id)
+
+      BusyRetry.inject_transient_faults(10_000)
+      conn |> post("/auth/share/consume", %{"token" => token}) |> json_response(503)
+      BusyRetry.inject_transient_faults(0)
+
+      assert_receive {:telemetry, [:grappa, :visitor, :share_token, :rejected], %{count: 1}, %{reason: :db_unavailable}}
+
+      refute_received {:telemetry, [:grappa, :visitor, :share_token, :rejected], _, _}
+      refute_received {:telemetry, [:grappa, :visitor, :share_token, :consumed], _, _}
     end
   end
 end


### PR DESCRIPTION
Refs #593

## The bug
`POST /auth/share/consume` claims the one-shot share token (`ShareTokens.mark_consumed/1`, ETS `:ets.insert_new/2`) **before** minting the session. A mint that fails after the claim — `:not_found` if the visitor row was reaped, or the `:db_unavailable` **503** when `Accounts.create_session`'s SQLite write is saturated (#518) — left the token spent with no session minted: a **dead link**, and the retryable-503's retry could never succeed. Documented as a known edge in the #523/#518 (B1) DESIGN_NOTES entry; this closes it.

## Why not "one SQL transaction" (the issue's option 1)
It doesn't apply here, on two counts:
1. The one-shot ledger is **ETS**, not the Repo ("ETS over DB by intent" — zero migrations, HOT-deploy-friendly). `Repo.transaction` cannot roll back an ETS write; a true transaction would first require migrating the ledger ETS→SQLite — the *largest* change, silently reversing a documented architectural choice.
2. Holding the consume inside a transaction across `create_session` would **lengthen the SQLite write-lock hold under exactly the saturation #518 mitigates**, aggravating the `SQLITE_BUSY` that made the bug visible. A fix that worsens the trigger is not a fix.

## The fix — claim-then-release
The issue's own second option ("make the consume conditional on the mint succeeding"). `mark_consumed` stays first as the atomic **CLAIM**, held across the whole mint; the new `ShareTokens.release/1` (`:ets.delete/2`) rolls the claim back on any post-claim failure.

- **Failed mint ⇒ link usable** (claim released).
- **Successful mint ⇒ link dead** (claim retained).
- **No double-redemption window:** the order is NOT changed, so `:ets.insert_new/2` atomicity means exactly one key holder at every instant — the window B1 feared never opens.

## The subtlety (release scoping) — the load-bearing part
Release fires **only** for *this request's own* post-claim failures. A flat `else` over one `with` would release on a losing concurrent redemption's `:share_token_consumed` too, deleting the **winner's** claim and resurrecting a token that already minted a session (dead-link → double-redemption, worse than the bug). So `consume/2` splits: an outer `with` (verify + `mark_consumed`) whose `else` **never** releases, and `mint_session/3`'s inner `with` (fetch + mint) whose `else` releases — reached only after our own `mark_consumed` returned `:ok`. Pinned by the test *"a losing concurrent redemption's 410 does NOT release the winner's claim"*.

## Known limit (accepted)
A concurrent loser gets a **spurious 410** during a mint that later fails, and must retry after the winner's release. Threat model is "operator clicks their own link twice" — benign; genuinely simultaneous double-redemption is rare, and a retry succeeds once the failed claim is released. Not worth a pending-state machine.

## Tests
- `release/1` unit tests (rollback + idempotent no-op).
- **Both halves of the contract**: `transient DB saturation on the mint leaves the token usable for a retry` (via `BusyRetry.inject_transient_faults`) and the existing `already-consumed → 410` (success ⇒ dead).
- **Release scoping**: `a losing concurrent redemption's 410 does NOT release the winner's claim`.
- Telemetry exactly-once on the 503 path.

## Gate
Full `scripts/check.sh` green — 4864 tests 0 failures, dialyzer passed, sobelow clean, credo strict clean, format clean. DESIGN_NOTES updated (new 2026-08-01 #593 entry + the B1 "known edge" now marked CLOSED, not contradicted).