### PR TITLE
BusyRetry into background writers (#590) + pin the two out-of-process DB-busy terminals (#594)

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -25619,19 +25619,31 @@ from any test: (a) the WS `close_query_window` `close_failed` reply runs in the
 Phoenix Channel's own pid; (b) the session query-window auto-open
 (`maybe_open_query_window/2`) runs in the `Session.Server`'s pid. The existing
 process-dictionary fault seam only reaches work in the TEST process, so #594
-added a cross-process ETS seam keyed by the TARGET pid (`arm_faults(pid, n)`).
-That pins (a) directly. But (b) can't be isolated by a plain per-pid counter:
-the auto-open runs ONLY after the persist returns `{:ok, _}`, and with a single
-counter "persist succeeds ⟺ fault count is 0 ⟹ the open never faults." So the
-seam gained a POSITIONAL selector: `arm_faults(pid, n, fire_on: k)` rides out
-the first `k-1` fault-CHECKS in the pid (a "check" = one `maybe_inject_fault/0`
-at the top of a `BusyRetry.run/1` attempt) and fires from the `k`-th. For the
-inbound-DM flow the pre-open checks are persist insert (1) + persist preload (2)
-— the `push: true` obligations (`Push.Triggers`, `WindowCounts`) each run in
-their OWN Task, so they add ZERO checks to the session pid — making the open's
-insert check **3**. `fire_on:` counts checks, NOT operations, and was named for
-exactly that; it is a separate explicit arity (NO default-arg drift), so every
-existing channel/reaper caller of `arm_faults/2` is untouched.
+added a cross-process ETS seam keyed by the TARGET pid. That pins (a) directly.
+But (b) can't be isolated by a plain per-pid counter: the auto-open runs ONLY
+after the persist returns `{:ok, _}`, and with a single counter "persist
+succeeds ⟺ fault count is 0 ⟹ the open never faults." So the seam gained a
+POSITIONAL selector: `arm_faults(pid, n, fire_on: k)` rides out the first `k-1`
+fault-CHECKS in the pid (a "check" = one `maybe_inject_fault/0` at the top of a
+`BusyRetry.run/1` attempt) and fires from the `k`-th. For the inbound-DM flow
+the pre-open checks are persist insert (1) + persist preload (2) — the `push:
+true` obligations (`Push.Triggers`, `WindowCounts`) each run in their OWN Task,
+so they add ZERO checks to the session pid — making the open's insert check
+**3**. `fire_on:` counts checks, NOT operations, and was named for exactly that.
+
+**One arity, `fire_on:` required — no immediate-mode default.** The seam has a
+SINGLE `arm_faults/3`; there is deliberately no `arm_faults/2` "fire
+immediately" convenience. Two arities where the shorter one means "fire on the
+next check" is a default argument wearing a disguise — the exact
+silent-degradation path CLAUDE.md bans — because `arm_faults(pid, n)` never says
+WHEN the fault fires. `fire_on: 1` is the immediate case, explicit at all three
+call sites (the WS close terminal + the two cross-process unit tests). (This
+also happens to keep the module above doctor's 40% dev-env doc floor, which the
+extra test-gated arity had pushed it under — but that is a SIDE EFFECT of the
+right API, not the reason; the general doctor artifact behind that floor —
+`Mix.env() == :test` functions scored as undocumented in the dev beam — is
+tracked as its own repo-wide issue, #621, and the test-env doctor already scores
+this module 100%.)
 
 **Why a test, not a type.** Dialyzer does NOT flag a non-exhaustive `case` — a
 refactor dropping `maybe_open_query_window/2`'s `{:error, :db_unavailable}` arm

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -25577,3 +25577,69 @@ env-file (as a placeholder, to clear the `runtime.exs` raise) AND the real
 sibling, never by teaching the source-mode hook two behaviours. If the VAPID
 `eval` string changes, update the bats fake-docker `*generate_key*` match in
 lockstep (it is the only stdout the installer parses).
+## 2026-08-01 — #590 / #594 (B2): BusyRetry into the background writers — DROP, not 503; and the cross-process `fire_on:` seam
+
+**What (#590, B2).** B1 (2026-07-31) wired `Grappa.Repo.BusyRetry` into every
+web-reachable write (terminal → 503). B2 wires the SAME shared engine into the
+**background writers** — the ones with NO client waiting on the result. The
+engine, the classifier, and the budget are reused verbatim; only the *terminal*
+differs, per the three-doors split B1 recorded: a background write that
+outlasts the retry budget **DROPS best-effort (log + continue), never 503, never
+crash** — the same `:persist_unavailable` posture #336 gave the scrollback hot
+path, generalised.
+
+**Uniform contract, per-caller terminal.** Every context write fn returns the
+uniform `{:error, :db_unavailable}` (CLAUDE.md "total consistency"); each CALLER
+maps its own terminal. So `Visitors.delete/1` PROPAGATES `:db_unavailable`
+(operator/admin callers want the 503 / a raised CLI error) while
+`Visitors.purge_if_anon/1` ABSORBS it to `:ok` + a log (a failed/preempted login
+has no client; the anon row is left for `Visitors.Reaper` to collect on its
+next TTL sweep). The writers migrated: `Accounts.delete_expired_sessions`,
+`Visitors.destroy_visitor` (the whole rehome+delete — not a txn, idempotent
+retry self-heals), `Uploads.soft_delete/2`, `SessionLog` persist+prune,
+`AdminEvents` persist+prune+load_recent (a boot reload that degrades yields an
+empty ring, NOT a crash-loop), and `Push.delete_dead`. Each reaper's `sweep/0`
+maps the drop back to `{:ok, 0}` + a log so its `handle_info` stays total.
+
+**Small web fan-out.** Only `admin/uploads_controller.delete` changed on the web
+side (its `{:ok, _} =` hard match became a `with <-` so it 503s); every other
+`with`-based action already flows `:db_unavailable → 503` through the shared
+`action_fallback GrappaWeb.FallbackController` in the controller macro.
+
+**Notify is OUT (deliberate).** `Notify.remove/clear_all` have NO background
+sweep — every reachable caller is a web controller (`notify_controller`), so
+Notify belongs to the B1 web-503 door, not B2. It stays out of this change; the
+`notify_controller`'s `:ok = Notify.remove/clear` hard matches (which should
+become `with + 503`) are filed as #523 follow-up, NOT smuggled in here.
+Likewise `Push.touch_last_used` (a post-delivery UPDATE, not a sweep) is a
+separate candidate, out of scope.
+
+**Why the `fire_on:` seam (#594).** Two of the terminals live OUT OF PROCESS
+from any test: (a) the WS `close_query_window` `close_failed` reply runs in the
+Phoenix Channel's own pid; (b) the session query-window auto-open
+(`maybe_open_query_window/2`) runs in the `Session.Server`'s pid. The existing
+process-dictionary fault seam only reaches work in the TEST process, so #594
+added a cross-process ETS seam keyed by the TARGET pid (`arm_faults(pid, n)`).
+That pins (a) directly. But (b) can't be isolated by a plain per-pid counter:
+the auto-open runs ONLY after the persist returns `{:ok, _}`, and with a single
+counter "persist succeeds ⟺ fault count is 0 ⟹ the open never faults." So the
+seam gained a POSITIONAL selector: `arm_faults(pid, n, fire_on: k)` rides out
+the first `k-1` fault-CHECKS in the pid (a "check" = one `maybe_inject_fault/0`
+at the top of a `BusyRetry.run/1` attempt) and fires from the `k`-th. For the
+inbound-DM flow the pre-open checks are persist insert (1) + persist preload (2)
+— the `push: true` obligations (`Push.Triggers`, `WindowCounts`) each run in
+their OWN Task, so they add ZERO checks to the session pid — making the open's
+insert check **3**. `fire_on:` counts checks, NOT operations, and was named for
+exactly that; it is a separate explicit arity (NO default-arg drift), so every
+existing channel/reaper caller of `arm_faults/2` is untouched.
+
+**Why a test, not a type.** Dialyzer does NOT flag a non-exhaustive `case` — a
+refactor dropping `maybe_open_query_window/2`'s `{:error, :db_unavailable}` arm
+would crash the session with a `CaseClauseError` on every DB-saturated inbound
+DM, unseen. The test is the only thing pinning it, and it asserts the terminal
+SPECIFICALLY (the exact drop-log line + a surviving session pid + no window row
+minted), so a wrong `fire_on` fails LOUD: too low faults the persist (the
+message never lands), too high lets the open succeed (the drop log is absent).
+A change in how many `BusyRetry.run` calls precede the open is MEANT to break
+that test — the empirical `fire_on: 3` is not hardcoded theory, it is the value
+the triangulating assertions accept.

--- a/lib/grappa/account_deletion.ex
+++ b/lib/grappa/account_deletion.ex
@@ -83,7 +83,12 @@ defmodule Grappa.AccountDeletion do
   no negated guards (a bare `%User{is_admin: false}` / `%Visitor{}` after
   the nil/true clauses is necessarily the offered case).
   """
-  @spec delete_account(subject()) :: :ok | {:error, :forbidden | :not_found}
+  # #590 — the visitor self-delete branch returns `Visitors.delete/1`, which
+  # degrades a sustained SQLITE_BUSY to `{:error, :db_unavailable}`; `MeController`
+  # routes it through FallbackController to a 503 (a real client is waiting on
+  # the self-delete, so this is NOT a background drop).
+  @spec delete_account(subject()) ::
+          :ok | {:error, :forbidden | :not_found | :db_unavailable}
   def delete_account({:user, %User{is_admin: true}}), do: {:error, :forbidden}
 
   def delete_account({:user, %User{is_admin: false} = user}) do

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -581,7 +581,7 @@ defmodule Grappa.Accounts do
   rides the audit log so a no-op sweep stays distinguishable from a
   productive one.
   """
-  @spec delete_expired_sessions() :: {:ok, non_neg_integer()}
+  @spec delete_expired_sessions() :: {:ok, non_neg_integer()} | {:error, :db_unavailable}
   def delete_expired_sessions do
     cutoff = DateTime.add(DateTime.utc_now(), -@idle_timeout_seconds, :second)
 
@@ -590,17 +590,30 @@ defmodule Grappa.Accounts do
         where: not is_nil(s.user_id) and s.last_seen_at < ^cutoff
       )
 
-    {deleted, _} = Repo.delete_all(query)
+    # #590 — this is a BACKGROUND writer (the #223 idle-session reaper is the
+    # only caller). Ride out a transient SQLITE_BUSY on the bulk delete via
+    # the shared engine, and on sustained saturation degrade to
+    # `{:error, :db_unavailable}` rather than letting the raise escape and
+    # crash the reaper GenServer. Uniform with every other background-writer
+    # context fn: the atom is returned here, the reaper (`Accounts.Reaper`)
+    # owns the best-effort-DROP terminal — NO 503 (no web caller). Wrap the
+    # `delete_all` in an `{:ok, _}` so it honours the `BusyRetry.run/1`
+    # contract.
+    case Repo.BusyRetry.run(fn -> {:ok, Repo.delete_all(query)} end) do
+      {:ok, {deleted, _}} ->
+        # Suppressed on count=0: the reaper calls this every 60s, so an
+        # unconditional line would flood the log with 1440 idle "reaped 0"
+        # entries/day. A productive sweep logs once so the lifecycle stays
+        # greppable — same suppression the sibling reapers use for their
+        # AdminEvents summary. (CLAUDE.md log-honesty: the line states what
+        # was observed — N rows past the idle window — not merely "ran".)
+        if deleted > 0, do: Logger.info("expired sessions reaped", affected: deleted)
 
-    # Suppressed on count=0: the reaper calls this every 60s, so an
-    # unconditional line would flood the log with 1440 idle "reaped 0"
-    # entries/day. A productive sweep logs once so the lifecycle stays
-    # greppable — same suppression the sibling reapers use for their
-    # AdminEvents summary. (CLAUDE.md log-honesty: the line states what
-    # was observed — N rows past the idle window — not merely "ran".)
-    if deleted > 0, do: Logger.info("expired sessions reaped", affected: deleted)
+        {:ok, deleted}
 
-    {:ok, deleted}
+      {:error, :db_unavailable} = err ->
+        err
+    end
   end
 
   defp check_idle(session) do

--- a/lib/grappa/accounts/reaper.ex
+++ b/lib/grappa/accounts/reaper.ex
@@ -78,7 +78,23 @@ defmodule Grappa.Accounts.Reaper do
   Accounts context owns its schema; the reaper is just the cadence).
   """
   @spec sweep() :: {:ok, non_neg_integer()}
-  def sweep, do: Accounts.delete_expired_sessions()
+  def sweep do
+    # #590 — `delete_expired_sessions/0` degrades a sustained SQLITE_BUSY to
+    # `{:error, :db_unavailable}` (uniform with every background-writer context
+    # fn) rather than letting the raise escape. The reaper's terminal is
+    # best-effort DROP (there is no web caller to 503): log the skipped sweep
+    # and report `{:ok, 0}` so the tick's `{:ok, _} = sweep()` stays a total
+    # match — mirroring the sibling reapers, whose per-row drops likewise leave
+    # the count short and carry on. The next tick retries.
+    case Accounts.delete_expired_sessions() do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, :db_unavailable} ->
+        Logger.warning("accounts reaper: db unavailable — sweep dropped, retrying next tick")
+        {:ok, 0}
+    end
+  end
 
   @impl GenServer
   def init(opts) do
@@ -98,7 +114,9 @@ defmodule Grappa.Accounts.Reaper do
     # `delete_expired_sessions/0` logs productive sweeps (count > 0) and
     # deliberately suppresses count=0 to avoid 1440 idle lines/day under
     # the 60s cadence. The reaper stays quiet here so the context
-    # function is the single logging site (no double-line).
+    # function is the single logging site (no double-line). `sweep/0`
+    # absorbs a #590 best-effort DROP into `{:ok, 0}` (logged there), so
+    # this match stays total even when the pool saturates.
     {:ok, _} = sweep()
 
     {:noreply, state}

--- a/lib/grappa/admin_events.ex
+++ b/lib/grappa/admin_events.ex
@@ -310,14 +310,26 @@ defmodule Grappa.AdminEvents do
   defp persist_event(event) do
     attrs = %{kind: to_string(event.kind), payload: event}
 
-    case %Event{} |> Event.changeset(attrs) |> Repo.insert() do
+    # #590 — ride out a transient SQLITE_BUSY on the mirror insert; sustained
+    # saturation is a best-effort DROP (the ring is the live serving source, so
+    # only THIS event's restart-survival is lost) rather than a raise that
+    # crashes the singleton and wipes the whole in-memory ring.
+    case Repo.BusyRetry.run(fn -> %Event{} |> Event.changeset(attrs) |> Repo.insert() end) do
       {:ok, _} ->
         :ok
 
-      {:error, changeset} ->
+      {:error, %Ecto.Changeset{} = changeset} ->
         Logger.error("admin_events persist failed",
           kind: event.kind,
           reason: inspect(changeset)
+        )
+
+        :ok
+
+      {:error, :db_unavailable} ->
+        Logger.warning(
+          "admin_events persist dropped: db unavailable — ring serves in-memory, restart-survival lost for this event",
+          kind: event.kind
         )
 
         :ok
@@ -331,33 +343,62 @@ defmodule Grappa.AdminEvents do
   # opaque + serialized straight to cic, never atom-matched server-side.
   @spec load_recent(pos_integer()) :: [map()]
   def load_recent(retention) when is_integer(retention) and retention > 0 do
-    Event
-    |> order_by([e], desc: e.id)
-    |> limit(^retention)
-    |> select([e], e.payload)
-    |> Repo.all()
+    # #590 — this runs in `init/1` at boot. Ride out a transient SQLITE_BUSY on
+    # the reload read; sustained saturation degrades to an EMPTY ring (log +
+    # `[]`) rather than raising and crash-looping the supervised singleton at
+    # boot. The ring repopulates from live events immediately; only the
+    # restart-history reload is lost for this boot.
+    case Repo.BusyRetry.run(fn ->
+           {:ok,
+            Event
+            |> order_by([e], desc: e.id)
+            |> limit(^retention)
+            |> select([e], e.payload)
+            |> Repo.all()}
+         end) do
+      {:ok, rows} ->
+        rows
+
+      {:error, :db_unavailable} ->
+        Logger.warning("admin_events reload skipped: db unavailable at boot — ring starts empty")
+        []
+    end
   end
 
   # On-disk ring cap: delete every row older than the `retention`-th newest
   # (indexed id-range delete). Mirror of Grappa.SessionLog.prune/1.
+  #
+  # #590 — the cutoff read + range delete ride out a transient SQLITE_BUSY;
+  # sustained saturation is a best-effort DROP (log + skip) so a busy on the
+  # trim never crashes the singleton. Bounded overshoot (a few extra mirrored
+  # rows) until the next write's prune catches up — no correctness loss.
   @spec prune(pos_integer()) :: :ok
   defp prune(retention) do
-    cutoff =
-      Event
-      |> order_by([e], desc: e.id)
-      |> offset(^(retention - 1))
-      |> limit(1)
-      |> select([e], e.id)
-      |> Repo.one()
+    outcome =
+      Repo.BusyRetry.run(fn ->
+        cutoff =
+          Event
+          |> order_by([e], desc: e.id)
+          |> offset(^(retention - 1))
+          |> limit(1)
+          |> select([e], e.id)
+          |> Repo.one()
 
-    case cutoff do
-      nil ->
+        case cutoff do
+          nil -> :ok
+          id -> Event |> where([e], e.id < ^id) |> Repo.delete_all()
+        end
+
+        {:ok, :pruned}
+      end)
+
+    case outcome do
+      {:ok, _} ->
         :ok
 
-      id ->
-        Event |> where([e], e.id < ^id) |> Repo.delete_all()
+      {:error, :db_unavailable} ->
+        Logger.warning("admin_events prune skipped: db unavailable — ring trims on next write")
+        :ok
     end
-
-    :ok
   end
 end

--- a/lib/grappa/operator.ex
+++ b/lib/grappa/operator.ex
@@ -132,6 +132,12 @@ defmodule Grappa.Operator do
       {:error, :not_found} ->
         IO.puts(:stderr, "visitor #{id} not found")
         raise Ecto.NoResultsError, queryable: Visitor
+
+      # #590 — the pool stayed saturated past the retry budget. A `bin/grappa`
+      # operator must see it and exit non-zero (retryable, not a silent no-op).
+      {:error, :db_unavailable} ->
+        IO.puts(:stderr, "visitor #{id} delete failed — database busy, retry")
+        raise "visitor delete deferred: database busy"
     end
   end
 
@@ -154,10 +160,10 @@ defmodule Grappa.Operator do
   `:visitor_deleted` admin event so the operator console shows
   who triggered the delete.
   """
-  @spec delete_visitor(Ecto.UUID.t()) :: :ok | {:error, :not_found}
+  @spec delete_visitor(Ecto.UUID.t()) :: :ok | {:error, :not_found | :db_unavailable}
   def delete_visitor(id) when is_binary(id), do: delete_visitor(id, nil)
 
-  @spec delete_visitor(Ecto.UUID.t(), actor()) :: :ok | {:error, :not_found}
+  @spec delete_visitor(Ecto.UUID.t(), actor()) :: :ok | {:error, :not_found | :db_unavailable}
   def delete_visitor(id, actor) when is_binary(id) do
     case Visitors.get(id) do
       nil ->
@@ -165,9 +171,25 @@ defmodule Grappa.Operator do
 
       visitor ->
         :ok = stop_visitor_session(visitor)
-        :ok = log_delete_outcome(id, visitor, Visitors.delete(id))
-        :ok = emit_visitor_deleted(visitor, actor)
-        :ok
+
+        # #590 — `Visitors.delete/1` degrades a sustained SQLITE_BUSY to
+        # `{:error, :db_unavailable}`. This is a client-facing door (admin REST
+        # `DELETE /admin/visitors/:id` + `bin/grappa`), so PROPAGATE it: the
+        # HTTP path routes through FallbackController to a clean 503, the CLI
+        # path raises via `delete_visitor!/1`. Only on a real delete (or a
+        # concurrent-reaper `:not_found`) do we emit the `:visitor_deleted`
+        # event — a deferred-because-busy delete never fires a misleading
+        # "reaped" signal.
+        case Visitors.delete(id) do
+          {:error, :db_unavailable} = err ->
+            :ok = log_delete_outcome(id, visitor, err)
+            err
+
+          outcome ->
+            :ok = log_delete_outcome(id, visitor, outcome)
+            :ok = emit_visitor_deleted(visitor, actor)
+            :ok
+        end
     end
   end
 
@@ -279,6 +301,15 @@ defmodule Grappa.Operator do
   # else already had".
   defp log_delete_outcome(id, _, {:error, :not_found}) do
     IO.puts("visitor #{id} already deleted (concurrent reaper or operator)")
+    :ok
+  end
+
+  # #590 — a sustained SQLITE_BUSY degraded the delete. Operator-visible line
+  # (stderr, mirroring the not-found clause) so a `bin/grappa` invocation and
+  # the server log both show the deferral; the caller then propagates
+  # `:db_unavailable` (HTTP 503 / CLI raise).
+  defp log_delete_outcome(id, _, {:error, :db_unavailable}) do
+    IO.puts(:stderr, "visitor #{id} delete deferred — database busy (retry)")
     :ok
   end
 

--- a/lib/grappa/push.ex
+++ b/lib/grappa/push.ex
@@ -248,11 +248,23 @@ defmodule Grappa.Push do
   Returns `{deleted_count, nil}` per `Repo.delete_all/2` semantics.
   Idempotent — repeated calls with an already-deleted endpoint
   return `{0, nil}`.
+
+  #590 — `Push.Sender` is the only caller, a BACKGROUND delivery task with no
+  client waiting on this stale-endpoint sweep. Ride out a transient SQLITE_BUSY
+  via the shared engine and degrade sustained saturation to
+  `{:error, :db_unavailable}` rather than letting the raise escape and crash the
+  send task; the Sender maps it to a best-effort DROP (the endpoint is swept on
+  the next failed delivery). Wrap the `delete_all` in an `{:ok, _}` so it honours
+  the `BusyRetry.run/1` contract.
   """
-  @spec delete_dead(String.t()) :: {non_neg_integer(), nil}
+  @spec delete_dead(String.t()) :: {non_neg_integer(), nil} | {:error, :db_unavailable}
   def delete_dead(endpoint) when is_binary(endpoint) do
     query = from(s in Subscription, where: s.endpoint == ^endpoint)
-    Repo.delete_all(query)
+
+    case Repo.BusyRetry.run(fn -> {:ok, Repo.delete_all(query)} end) do
+      {:ok, {_count, nil} = deleted} -> deleted
+      {:error, :db_unavailable} = err -> err
+    end
   end
 
   @doc """

--- a/lib/grappa/push.ex
+++ b/lib/grappa/push.ex
@@ -262,7 +262,7 @@ defmodule Grappa.Push do
     query = from(s in Subscription, where: s.endpoint == ^endpoint)
 
     case Repo.BusyRetry.run(fn -> {:ok, Repo.delete_all(query)} end) do
-      {:ok, {_count, nil} = deleted} -> deleted
+      {:ok, {_, nil} = deleted} -> deleted
       {:error, :db_unavailable} = err -> err
     end
   end

--- a/lib/grappa/push/sender.ex
+++ b/lib/grappa/push/sender.ex
@@ -246,7 +246,7 @@ defmodule Grappa.Push.Sender do
         # the stale endpoint is swept on the next failed delivery. Either way the
         # subscription is treated as gone from this delivery's perspective.
         case Push.delete_dead(sub.endpoint) do
-          {deleted, _} ->
+          {deleted, nil} ->
             :telemetry.execute(
               [:grappa, :push, :delete_dead],
               %{count: deleted},

--- a/lib/grappa/push/sender.ex
+++ b/lib/grappa/push/sender.ex
@@ -240,19 +240,31 @@ defmodule Grappa.Push.Sender do
         end
 
       {:error, :expired} ->
-        {deleted, _} = Push.delete_dead(sub.endpoint)
+        # #590 — `delete_dead/1` degrades a sustained SQLITE_BUSY to
+        # `{:error, :db_unavailable}`. This is a background delivery task with no
+        # client waiting, so the terminal is best-effort DROP: log + carry on —
+        # the stale endpoint is swept on the next failed delivery. Either way the
+        # subscription is treated as gone from this delivery's perspective.
+        case Push.delete_dead(sub.endpoint) do
+          {deleted, _} ->
+            :telemetry.execute(
+              [:grappa, :push, :delete_dead],
+              %{count: deleted},
+              %{endpoint: sub.endpoint}
+            )
 
-        :telemetry.execute(
-          [:grappa, :push, :delete_dead],
-          %{count: deleted},
-          %{endpoint: sub.endpoint}
-        )
+            Logger.info(
+              "push.send subscription gone — deleted",
+              endpoint: sub.endpoint,
+              count: deleted
+            )
 
-        Logger.info(
-          "push.send subscription gone — deleted",
-          endpoint: sub.endpoint,
-          count: deleted
-        )
+          {:error, :db_unavailable} ->
+            Logger.warning(
+              "push.send: dead-subscription sweep deferred — db unavailable",
+              endpoint: sub.endpoint
+            )
+        end
 
         {:error, :gone}
 

--- a/lib/grappa/repo/busy_retry.ex
+++ b/lib/grappa/repo/busy_retry.ex
@@ -166,6 +166,19 @@ defmodule Grappa.Repo.BusyRetry do
   if Mix.env() == :test do
     @fault_pdict_key {__MODULE__, :inject_transient_faults}
 
+    # #594 — cross-process arming lives in a shared ETS table keyed by the
+    # TARGET pid. The process-dictionary seam above only reaches work in the
+    # caller's own process; a fault that must fire inside a Phoenix Channel,
+    # a Session.Server, or a sink GenServer needs to be armed against THAT
+    # pid from a test running in a DIFFERENT process. Keyed by the exact
+    # target pid, the isolation is identical to the process dictionary's (a
+    # concurrent async test operates on its OWN spawned pid and reads `[]`),
+    # only externally addressable — so async tests never bleed. The table is
+    # created ONCE by the ExUnit runner in `test_helper.exs` (owned by that
+    # long-lived process, never created lazily here — that would race
+    # `:ets.new` across async tests).
+    @fault_ets_table :grappa_busy_retry_cross_process_faults
+
     @doc false
     @spec inject_transient_faults(non_neg_integer()) :: :ok
     def inject_transient_faults(n) when is_integer(n) and n >= 0 do
@@ -173,20 +186,82 @@ defmodule Grappa.Repo.BusyRetry do
       :ok
     end
 
-    defp maybe_inject_fault do
-      case Process.get(@fault_pdict_key, 0) do
-        n when n > 0 ->
-          Process.put(@fault_pdict_key, n - 1)
-          # "Database busy" is the VERBATIM message a real write-lock
-          # SQLITE_BUSY raises through Ecto (proven by
-          # `Grappa.Repo.BusyRetryFidelityTest`, and the #523 prod evidence) —
-          # so the injected fault is byte-faithful to reality, not a shape we
-          # merely know our own classifier accepts.
-          raise %Exqlite.Error{message: "Database busy", statement: nil}
+    @doc false
+    # Arm `n` transient busy faults against `pid`. Callers MUST `on_exit` a
+    # `disarm_faults/1` — a fault left armed on a pid that outlives the test
+    # is a failure-at-a-distance (the worst kind to diagnose).
+    @spec arm_faults(pid(), non_neg_integer()) :: :ok
+    def arm_faults(pid, n) when is_pid(pid) and is_integer(n) and n >= 0 do
+      true = :ets.insert(@fault_ets_table, {pid, n})
+      :ok
+    end
+
+    @doc false
+    @spec disarm_faults(pid()) :: :ok
+    def disarm_faults(pid) when is_pid(pid) do
+      true = :ets.delete(@fault_ets_table, pid)
+      :ok
+    end
+
+    @doc false
+    # Create the cross-process fault table. Called ONCE by `test_helper.exs`
+    # from the ExUnit runner process so the `:public` table outlives every
+    # test. Idempotent (a re-run finds the table already there).
+    @spec ensure_fault_table() :: :ok
+    def ensure_fault_table do
+      case :ets.whereis(@fault_ets_table) do
+        :undefined ->
+          :ets.new(@fault_ets_table, [:named_table, :public, :set])
+          :ok
 
         _ ->
           :ok
       end
+    end
+
+    # pdict FIRST (the existing in-process seam — every already-green test
+    # keeps arming through it, untouched), ETS second (the #594 cross-process
+    # seam). Both are pid-scoped, so the order is a pure preference, not a
+    # correctness requirement.
+    defp maybe_inject_fault do
+      cond do
+        consume_pdict_fault?() -> raise_injected_busy()
+        consume_ets_fault?() -> raise_injected_busy()
+        true -> :ok
+      end
+    end
+
+    @spec consume_pdict_fault?() :: boolean()
+    defp consume_pdict_fault? do
+      case Process.get(@fault_pdict_key, 0) do
+        n when n > 0 ->
+          Process.put(@fault_pdict_key, n - 1)
+          true
+
+        _ ->
+          false
+      end
+    end
+
+    @spec consume_ets_fault?() :: boolean()
+    defp consume_ets_fault? do
+      case :ets.lookup(@fault_ets_table, self()) do
+        [{pid, n}] when n > 0 ->
+          :ets.insert(@fault_ets_table, {pid, n - 1})
+          true
+
+        _ ->
+          false
+      end
+    end
+
+    # "Database busy" is the VERBATIM message a real write-lock SQLITE_BUSY
+    # raises through Ecto (proven by `Grappa.Repo.BusyRetryFidelityTest`, and
+    # the #523 prod evidence) — so the injected fault is byte-faithful to
+    # reality, not a shape we merely know our own classifier accepts.
+    @spec raise_injected_busy() :: no_return()
+    defp raise_injected_busy do
+      raise %Exqlite.Error{message: "Database busy", statement: nil}
     end
   else
     defp maybe_inject_fault, do: :ok

--- a/lib/grappa/repo/busy_retry.ex
+++ b/lib/grappa/repo/busy_retry.ex
@@ -187,12 +187,34 @@ defmodule Grappa.Repo.BusyRetry do
     end
 
     @doc false
-    # Arm `n` transient busy faults against `pid`. Callers MUST `on_exit` a
-    # `disarm_faults/1` — a fault left armed on a pid that outlives the test
-    # is a failure-at-a-distance (the worst kind to diagnose).
+    # Arm `n` transient busy faults against `pid`, firing on the VERY NEXT
+    # fault-check in that pid. Callers MUST `on_exit` a `disarm_faults/1` — a
+    # fault left armed on a pid that outlives the test is a failure-at-a-
+    # distance (the worst kind to diagnose). Stored as a 3-tuple `{pid,
+    # remaining, skip}` where `skip` is the number of pre-fire checks to let
+    # pass (0 here — fire immediately, the existing channel/reaper behaviour).
     @spec arm_faults(pid(), non_neg_integer()) :: :ok
     def arm_faults(pid, n) when is_pid(pid) and is_integer(n) and n >= 0 do
-      true = :ets.insert(@fault_ets_table, {pid, n})
+      true = :ets.insert(@fault_ets_table, {pid, n, 0})
+      :ok
+    end
+
+    @doc false
+    # As `arm_faults/2`, but the fault does NOT fire on the first `fire_on - 1`
+    # fault-CHECKS in `pid` — it starts firing on the `fire_on`-th check
+    # (1-indexed) and keeps firing until `n` is exhausted. A "check" is one
+    # `maybe_inject_fault/0` at the top of a `BusyRetry.run/1` attempt — NOT a
+    # raw `Repo` call and NOT an operation. This positional selector is how
+    # #594 pins the query-window auto-open terminal: persist + its preload each
+    # make one wrapped call BEFORE the open, and a single per-pid counter can't
+    # otherwise distinguish "fault the open" from "fault the persist". The exact
+    # `fire_on` is DETERMINED EMPIRICALLY per flow (see the #594 session test) —
+    # a change in how many `BusyRetry.run` calls precede the open is MEANT to
+    # break that test, which asserts the open's terminal specifically.
+    @spec arm_faults(pid(), non_neg_integer(), [{:fire_on, pos_integer()}]) :: :ok
+    def arm_faults(pid, n, fire_on: fire_on)
+        when is_pid(pid) and is_integer(n) and n >= 0 and is_integer(fire_on) and fire_on >= 1 do
+      true = :ets.insert(@fault_ets_table, {pid, n, fire_on - 1})
       :ok
     end
 
@@ -246,8 +268,14 @@ defmodule Grappa.Repo.BusyRetry do
     @spec consume_ets_fault?() :: boolean()
     defp consume_ets_fault? do
       case :ets.lookup(@fault_ets_table, self()) do
-        [{pid, n}] when n > 0 ->
-          :ets.insert(@fault_ets_table, {pid, n - 1})
+        # Still inside the pre-fire window: count this check, let it pass.
+        [{pid, n, skip}] when skip > 0 ->
+          :ets.insert(@fault_ets_table, {pid, n, skip - 1})
+          false
+
+        # Fire window reached and faults remain: consume one and raise.
+        [{pid, n, 0}] when n > 0 ->
+          :ets.insert(@fault_ets_table, {pid, n - 1, 0})
           true
 
         _ ->

--- a/lib/grappa/repo/busy_retry.ex
+++ b/lib/grappa/repo/busy_retry.ex
@@ -187,30 +187,28 @@ defmodule Grappa.Repo.BusyRetry do
     end
 
     @doc false
-    # Arm `n` transient busy faults against `pid`, firing on the VERY NEXT
-    # fault-check in that pid. Callers MUST `on_exit` a `disarm_faults/1` — a
-    # fault left armed on a pid that outlives the test is a failure-at-a-
-    # distance (the worst kind to diagnose). Stored as a 3-tuple `{pid,
-    # remaining, skip}` where `skip` is the number of pre-fire checks to let
-    # pass (0 here — fire immediately, the existing channel/reaper behaviour).
-    @spec arm_faults(pid(), non_neg_integer()) :: :ok
-    def arm_faults(pid, n) when is_pid(pid) and is_integer(n) and n >= 0 do
-      true = :ets.insert(@fault_ets_table, {pid, n, 0})
-      :ok
-    end
-
-    @doc false
-    # As `arm_faults/2`, but the fault does NOT fire on the first `fire_on - 1`
-    # fault-CHECKS in `pid` — it starts firing on the `fire_on`-th check
-    # (1-indexed) and keeps firing until `n` is exhausted. A "check" is one
+    # Arm `n` transient busy faults against `pid`. `fire_on` is 1-indexed and
+    # REQUIRED — there is deliberately NO immediate-mode 2-arity: an
+    # `arm_faults(pid, n)` whose two args left "WHEN does the fault fire?"
+    # implicit is a default argument in disguise, the silent-degradation path
+    # CLAUDE.md bans. Making `fire_on:` explicit at every call site is the point
+    # (the 40%-doctor-floor artifact #621 is a side effect, not the reason).
+    #
+    # The fault rides out the first `fire_on - 1` fault-CHECKS in `pid`, then
+    # fires from the `fire_on`-th check until `n` is exhausted. A "check" is one
     # `maybe_inject_fault/0` at the top of a `BusyRetry.run/1` attempt — NOT a
-    # raw `Repo` call and NOT an operation. This positional selector is how
-    # #594 pins the query-window auto-open terminal: persist + its preload each
-    # make one wrapped call BEFORE the open, and a single per-pid counter can't
-    # otherwise distinguish "fault the open" from "fault the persist". The exact
-    # `fire_on` is DETERMINED EMPIRICALLY per flow (see the #594 session test) —
-    # a change in how many `BusyRetry.run` calls precede the open is MEANT to
-    # break that test, which asserts the open's terminal specifically.
+    # raw `Repo` call and NOT an operation. `fire_on: 1` fires on the VERY NEXT
+    # check (channel / reaper immediate case); a higher value is how #594 pins
+    # the query-window auto-open terminal — persist + its preload each make one
+    # wrapped call BEFORE the open, so a single per-pid counter cannot otherwise
+    # distinguish "fault the open" from "fault the persist". The exact `fire_on`
+    # is DETERMINED EMPIRICALLY per flow (see the #594 session test); a change in
+    # how many `BusyRetry.run` calls precede the open is MEANT to break it.
+    #
+    # Callers MUST `on_exit` a `disarm_faults/1` — a fault left armed on a pid
+    # that outlives the test is a failure-at-a-distance (the worst kind to
+    # diagnose). Stored as a 3-tuple `{pid, remaining, skip}` where `skip`
+    # counts down on each pre-fire check.
     @spec arm_faults(pid(), non_neg_integer(), [{:fire_on, pos_integer()}]) :: :ok
     def arm_faults(pid, n, fire_on: fire_on)
         when is_pid(pid) and is_integer(n) and n >= 0 and is_integer(fire_on) and fire_on >= 1 do

--- a/lib/grappa/session_log.ex
+++ b/lib/grappa/session_log.ex
@@ -206,12 +206,22 @@ defmodule Grappa.SessionLog do
       {:ok, event} ->
         broadcast(event)
 
-      {:error, changeset} ->
+      {:error, %Ecto.Changeset{} = changeset} ->
         # Best-effort persist — the Logger line (emit/3) is the reliable
         # record. Log honestly (no silent drop) and keep the sink alive.
         Logger.error("session_log persist failed",
           event: metadata[:event],
           reason: inspect(changeset)
+        )
+
+      {:error, :db_unavailable} ->
+        # #590 — a sustained SQLITE_BUSY on the insert. This is a BACKGROUND
+        # sink (a telemetry cast, no client waiting), so the terminal is
+        # best-effort DROP: the emit/3 Logger line already carried the
+        # reliable record; log the dropped persisted-row honestly (warning,
+        # not error — it is transient backpressure) and keep the sink alive.
+        Logger.warning("session_log persist dropped: db unavailable — sink continues",
+          event: metadata[:event]
         )
     end
 
@@ -224,9 +234,12 @@ defmodule Grappa.SessionLog do
     :ok = :telemetry.detach(@telemetry_handler_id)
   end
 
-  @spec persist(map()) :: {:ok, Event.t()} | {:error, Ecto.Changeset.t()}
+  # #590 — ride out a transient SQLITE_BUSY on the insert; sustained saturation
+  # degrades to `{:error, :db_unavailable}` (best-effort DROP at the handle_cast
+  # terminal) rather than raising and crashing the sink GenServer.
+  @spec persist(map()) :: {:ok, Event.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   defp persist(metadata) do
-    %Event{} |> Event.changeset(metadata) |> Repo.insert()
+    Repo.BusyRetry.run(fn -> %Event{} |> Event.changeset(metadata) |> Repo.insert() end)
   end
 
   @spec broadcast(Event.t()) :: :ok
@@ -247,25 +260,40 @@ defmodule Grappa.SessionLog do
 
   # On-disk ring: delete every row older than the `retention`-th newest.
   # id (PK autoincrement) is the insertion order — an indexed range delete.
+  #
+  # #590 — the cutoff read + range delete ride out a transient SQLITE_BUSY via
+  # the shared engine; sustained saturation is a best-effort DROP (log + skip),
+  # so a busy on the trim never crashes the sink. The ring simply carries a few
+  # extra rows until the next write's prune catches up — bounded overshoot, no
+  # correctness loss.
   @spec prune(pos_integer()) :: :ok
   defp prune(retention) do
-    cutoff =
-      Event
-      |> order_by([e], desc: e.id)
-      |> offset(^(retention - 1))
-      |> limit(1)
-      |> select([e], e.id)
-      |> Repo.one()
+    outcome =
+      Repo.BusyRetry.run(fn ->
+        cutoff =
+          Event
+          |> order_by([e], desc: e.id)
+          |> offset(^(retention - 1))
+          |> limit(1)
+          |> select([e], e.id)
+          |> Repo.one()
 
-    case cutoff do
-      nil ->
+        case cutoff do
+          nil -> :ok
+          id -> Event |> where([e], e.id < ^id) |> Repo.delete_all()
+        end
+
+        {:ok, :pruned}
+      end)
+
+    case outcome do
+      {:ok, _} ->
         :ok
 
-      id ->
-        Event |> where([e], e.id < ^id) |> Repo.delete_all()
+      {:error, :db_unavailable} ->
+        Logger.warning("session_log prune skipped: db unavailable — ring trims on next write")
+        :ok
     end
-
-    :ok
   end
 
   # ----- Human-readable Logger lines -----------------------------------

--- a/lib/grappa/uploads.ex
+++ b/lib/grappa/uploads.ex
@@ -311,11 +311,18 @@ defmodule Grappa.Uploads do
   `Admin.UploadsController.delete/2`). Idempotent: re-soft-delete
   of an already-deleted row is a no-op return.
   """
-  @spec soft_delete(Upload.t(), DateTime.t()) :: {:ok, Upload.t()} | {:error, Ecto.Changeset.t()}
+  @spec soft_delete(Upload.t(), DateTime.t()) ::
+          {:ok, Upload.t()} | {:error, Ecto.Changeset.t() | :db_unavailable}
   def soft_delete(%Upload{deleted_at: %DateTime{}} = up, _), do: {:ok, up}
 
   def soft_delete(%Upload{} = up, %DateTime{} = now) do
-    up |> Upload.soft_delete_changeset(now) |> Repo.update()
+    # #590 — `soft_delete/2` is shared by a BACKGROUND caller (the GC reaper)
+    # and a WEB caller (admin DELETE). Ride out a transient SQLITE_BUSY on the
+    # flip and degrade sustained saturation to `{:error, :db_unavailable}`
+    # rather than letting the raise escape; each caller maps its terminal —
+    # the reaper DROPS + logs (row left for the next tick, self-heals via the
+    # enoent path), the admin controller routes to a 503 via FallbackController.
+    Repo.BusyRetry.run(fn -> up |> Upload.soft_delete_changeset(now) |> Repo.update() end)
   end
 
   @doc """

--- a/lib/grappa/uploads/reaper.ex
+++ b/lib/grappa/uploads/reaper.ex
@@ -136,6 +136,12 @@ defmodule Grappa.Uploads.Reaper do
     case Uploads.soft_delete(up, now) do
       {:ok, _} -> :ok
       {:error, %Ecto.Changeset{} = cs} -> {:error, cs}
+      # #590 — a sustained SQLITE_BUSY degraded the row flip. Best-effort DROP:
+      # surface it as a per-row error so the sweep logs + continues (the file
+      # is already unlinked; the row stays expired and the next tick retries via
+      # the enoent path). WITHOUT this arm the `case` would CaseClauseError-crash
+      # the reaper — the exact non-exhaustive-case class #594 guards.
+      {:error, :db_unavailable} = err -> err
     end
   end
 

--- a/lib/grappa/visitors.ex
+++ b/lib/grappa/visitors.ex
@@ -1283,30 +1283,35 @@ defmodule Grappa.Visitors do
           # Registered — identity persists; its backoff history must survive.
           :ok
         else
-          # S11 — the anon subject is destroyed here (login case-1 failure /
-          # preempt). destroy_visitor re-homes published themes (#299), hard-
-          # deletes the row (CASCADE), and evicts its Backoff entries so the
-          # retired UUID leaves no orphan.
-          #
-          # #590 — this is a co-terminus BEST-EFFORT cleanup (a failed/preempted
-          # login has no HTTP client waiting on the purge), and every caller
-          # matches `:ok =`. A sustained SQLITE_BUSY therefore ABSORBS to `:ok`
-          # + a log rather than propagating: the anon row is simply left for
-          # `Visitors.Reaper` to collect once its TTL elapses. Distinct from
-          # `delete/1`, whose operator/admin callers want the 503.
-          case destroy_visitor(visitor) do
-            :ok ->
-              :ok
-
-            {:error, :db_unavailable} ->
-              Logger.warning(
-                "purge_if_anon: db unavailable — anon purge deferred to reaper",
-                visitor_id: visitor_id
-              )
-
-              :ok
-          end
+          purge_anon_visitor(visitor)
         end
+    end
+  end
+
+  # S11 — the anon subject is destroyed here (login case-1 failure /
+  # preempt). destroy_visitor re-homes published themes (#299), hard-
+  # deletes the row (CASCADE), and evicts its Backoff entries so the
+  # retired UUID leaves no orphan.
+  #
+  # #590 — this is a co-terminus BEST-EFFORT cleanup (a failed/preempted
+  # login has no HTTP client waiting on the purge), and every caller
+  # matches `:ok =`. A sustained SQLITE_BUSY therefore ABSORBS to `:ok`
+  # + a log rather than propagating: the anon row is simply left for
+  # `Visitors.Reaper` to collect once its TTL elapses. Distinct from
+  # `delete/1`, whose operator/admin callers want the 503.
+  @spec purge_anon_visitor(Visitor.t()) :: :ok
+  defp purge_anon_visitor(%Visitor{} = visitor) do
+    case destroy_visitor(visitor) do
+      :ok ->
+        :ok
+
+      {:error, :db_unavailable} ->
+        Logger.warning(
+          "purge_if_anon: db unavailable — anon purge deferred to reaper",
+          visitor_id: visitor.id
+        )
+
+        :ok
     end
   end
 end

--- a/lib/grappa/visitors.ex
+++ b/lib/grappa/visitors.ex
@@ -760,10 +760,13 @@ defmodule Grappa.Visitors do
   logs in again, so its per-network failure counters would otherwise
   orphan for the node lifetime.
   """
-  @spec delete(Ecto.UUID.t()) :: :ok | {:error, :not_found}
+  @spec delete(Ecto.UUID.t()) :: :ok | {:error, :not_found | :db_unavailable}
   def delete(visitor_id) when is_binary(visitor_id) do
     case Repo.get(Visitor, visitor_id) do
       nil -> {:error, :not_found}
+      # #590 — `destroy_visitor/1` degrades a sustained SQLITE_BUSY to
+      # `{:error, :db_unavailable}`; propagate it so each caller maps its
+      # terminal (reaper DROP, operator/admin 503, account-deletion 503).
       visitor -> destroy_visitor(visitor)
     end
   end
@@ -785,12 +788,34 @@ defmodule Grappa.Visitors do
   # rows have `visitor_id = NULL`), so a crash between the two steps self-heals
   # on the next reap/retry (re-home finds nothing, delete proceeds). Backoff
   # eviction is ETS, after the DB writes.
-  @spec destroy_visitor(Visitor.t()) :: :ok
+  #
+  # #590 — the whole (re-home + delete) is a BACKGROUND write (reap / operator
+  # / account-deletion / anon-cleanup, no HTTP client waiting mid-write). Ride
+  # out a transient SQLITE_BUSY via the shared engine and degrade sustained
+  # saturation to `{:error, :db_unavailable}` rather than letting the raise
+  # escape and crash the reaper GenServer. `BusyRetry.run/1` is NOT a
+  # transaction — it re-runs the (idempotent) op on a raise — so the "sequential
+  # single-statement writes, self-heals" property above is preserved: a retry
+  # re-homes (no-op the second time) then re-deletes. The atom is returned; each
+  # public verb maps its own terminal (`delete/1` propagates → reaper DROP /
+  # operator + account 503; `purge_if_anon/1` absorbs → best-effort cleanup).
+  @spec destroy_visitor(Visitor.t()) :: :ok | {:error, :db_unavailable}
   defp destroy_visitor(%Visitor{} = visitor) do
-    Themes.rehome_visitor_published_to_system(visitor.id)
-    {:ok, _} = Repo.delete(visitor)
-    :ok = Session.Backoff.forget({:visitor, visitor.id})
-    :ok
+    outcome =
+      Repo.BusyRetry.run(fn ->
+        Themes.rehome_visitor_published_to_system(visitor.id)
+        {:ok, _} = Repo.delete(visitor)
+        {:ok, :deleted}
+      end)
+
+    case outcome do
+      {:ok, :deleted} ->
+        :ok = Session.Backoff.forget({:visitor, visitor.id})
+        :ok
+
+      {:error, :db_unavailable} = err ->
+        err
+    end
   end
 
   @doc """
@@ -1262,7 +1287,25 @@ defmodule Grappa.Visitors do
           # preempt). destroy_visitor re-homes published themes (#299), hard-
           # deletes the row (CASCADE), and evicts its Backoff entries so the
           # retired UUID leaves no orphan.
-          destroy_visitor(visitor)
+          #
+          # #590 — this is a co-terminus BEST-EFFORT cleanup (a failed/preempted
+          # login has no HTTP client waiting on the purge), and every caller
+          # matches `:ok =`. A sustained SQLITE_BUSY therefore ABSORBS to `:ok`
+          # + a log rather than propagating: the anon row is simply left for
+          # `Visitors.Reaper` to collect once its TTL elapses. Distinct from
+          # `delete/1`, whose operator/admin callers want the 503.
+          case destroy_visitor(visitor) do
+            :ok ->
+              :ok
+
+            {:error, :db_unavailable} ->
+              Logger.warning(
+                "purge_if_anon: db unavailable — anon purge deferred to reaper",
+                visitor_id: visitor_id
+              )
+
+              :ok
+          end
         end
     end
   end

--- a/lib/grappa/visitors/reaper.ex
+++ b/lib/grappa/visitors/reaper.ex
@@ -156,7 +156,11 @@ defmodule Grappa.Visitors.Reaper do
     end
   end
 
-  @spec reap_visitor(Visitors.Visitor.t()) :: :ok | {:error, :not_found}
+  # #590 — `Visitors.delete/1` can now degrade a sustained SQLITE_BUSY to
+  # `{:error, :db_unavailable}`; the sweep's per-row `{:error, reason}` arm logs
+  # + continues (best-effort DROP — the row is left for the next tick), so the
+  # reaper rides transient contention rather than crashing.
+  @spec reap_visitor(Visitors.Visitor.t()) :: :ok | {:error, :not_found | :db_unavailable}
   defp reap_visitor(v) do
     with :ok <- stop_visitor_session(v),
          :ok <- Visitors.delete(v.id) do

--- a/lib/grappa_web/controllers/admin/uploads_controller.ex
+++ b/lib/grappa_web/controllers/admin/uploads_controller.ex
@@ -56,12 +56,18 @@ defmodule GrappaWeb.Admin.UploadsController do
   # row's slug against `^[a-z2-7]{26}$` — no traversal reachable.
   @sobelow_skip ["Traversal.FileModule"]
   @doc false
-  @spec delete(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:error, :not_found}
+  @spec delete(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:error, :not_found | :db_unavailable}
   def delete(conn, %{"id" => id}) when is_binary(id) do
-    with {:ok, row} <- Uploads.get_by_id(id) do
-      path = Uploads.storage_path(Uploads.storage_root(), row.slug)
-      _ = File.rm(path)
-      {:ok, _} = Uploads.soft_delete(row, DateTime.utc_now())
+    # #590 — `Uploads.soft_delete/2` now degrades a sustained SQLITE_BUSY to
+    # `{:error, :db_unavailable}`. Fold it into the `with` (was a hard
+    # `{:ok, _} =` match that would MatchError→500 on the degrade) so
+    # FallbackController renders a clean 503. The file is unlinked first and the
+    # flip is idempotent, so a 503-then-retry self-heals via the enoent path —
+    # same shape as the reaper's best-effort sweep.
+    with {:ok, row} <- Uploads.get_by_id(id),
+         path = Uploads.storage_path(Uploads.storage_root(), row.slug),
+         _ = File.rm(path),
+         {:ok, _} <- Uploads.soft_delete(row, DateTime.utc_now()) do
       send_resp(conn, :no_content, "")
     end
   end

--- a/test/grappa/accounts/reaper_test.exs
+++ b/test/grappa/accounts/reaper_test.exs
@@ -14,8 +14,11 @@ defmodule Grappa.Accounts.ReaperTest do
   """
   use Grappa.DataCase, async: false
 
+  import ExUnit.CaptureLog
+
   alias Grappa.Accounts
   alias Grappa.Accounts.{Reaper, Session}
+  alias Grappa.Repo.BusyRetry
 
   @idle_seconds 7 * 24 * 3600
 
@@ -43,6 +46,30 @@ defmodule Grappa.Accounts.ReaperTest do
 
     test "returns {:ok, 0} when nothing is expired" do
       assert {:ok, 0} = Reaper.sweep()
+    end
+
+    # #590 — a sustained SQLITE_BUSY on the bulk delete must be a best-effort
+    # DROP: the sweep rides it out, then reports `{:ok, 0}` + a log instead of
+    # raising and crashing the reaper (there is no web caller to 503). `sweep/0`
+    # runs synchronously in the test process, so the process-dictionary fault
+    # seam reaches it directly — no cross-process arming needed. The DROP must
+    # be OBSERVABLE (not merely "did not crash"): the row SURVIVES (the delete
+    # never landed) AND the saturation is logged.
+    test "sustained DB busy → best-effort drop: sweep survives, logs, and leaves the row" do
+      stale = stale_user_session()
+
+      log =
+        capture_log(fn ->
+          BusyRetry.inject_transient_faults(10_000)
+          assert {:ok, 0} = Reaper.sweep()
+          BusyRetry.inject_transient_faults(0)
+        end)
+
+      # The row was NOT deleted — the write degraded rather than landing.
+      assert Repo.get(Session, stale.id)
+      # The saturation surfaced honestly (BusyRetry budget-exhaust warning +
+      # the reaper's own dropped-sweep line).
+      assert log =~ "db unavailable"
     end
   end
 

--- a/test/grappa/repo/busy_retry_test.exs
+++ b/test/grappa/repo/busy_retry_test.exs
@@ -213,4 +213,27 @@ defmodule Grappa.Repo.BusyRetryTest do
       assert_receive {:target_result, {:ok, :wrote}}, 2_000
     end
   end
+
+  # #594 — the positional selector. A single per-pid counter cannot say
+  # "fault the auto-open, not the persist that precedes it" (both are
+  # `BusyRetry.run` in the same Session.Server pid, and the persist succeeds
+  # ⟺ the open never faults). `fire_on: k` lets the first k-1 fault-CHECKS in
+  # the pid ride through, then fires from the k-th — so a test can skip past
+  # the persist's checks and land the fault squarely on the open. A "check" is
+  # one `maybe_inject_fault/0` at the top of a `run/1` attempt.
+  describe "arm_faults/3 with fire_on: (positional selector, #594)" do
+    test "fire_on: k rides out the first k-1 checks, then degrades from the k-th" do
+      BusyRetry.arm_faults(self(), 10_000, fire_on: 3)
+      on_exit(fn -> BusyRetry.disarm_faults(self()) end)
+
+      # Checks 1 and 2 fall inside the pre-fire window — each run rides
+      # through and its op succeeds (one check per run, op succeeds attempt 1).
+      assert BusyRetry.run(fn -> {:ok, :wrote} end) == {:ok, :wrote}
+      assert BusyRetry.run(fn -> {:ok, :wrote} end) == {:ok, :wrote}
+
+      # The 3rd check is the fire point: this run faults on every attempt for
+      # the whole budget and degrades — proving the skip window is exactly 2.
+      assert BusyRetry.run(fn -> {:ok, :wrote} end) == {:error, :db_unavailable}
+    end
+  end
 end

--- a/test/grappa/repo/busy_retry_test.exs
+++ b/test/grappa/repo/busy_retry_test.exs
@@ -162,12 +162,13 @@ defmodule Grappa.Repo.BusyRetryTest do
   # (`inject_transient_faults/1`) can only reach work that runs in the
   # CALLER's own process; a fault that must fire inside a Phoenix Channel,
   # a Session.Server, or a sink GenServer needs to be armed against THAT
-  # pid. `arm_faults/2` stores the count in a shared ETS table keyed by the
+  # pid. `arm_faults/3` stores the count in a shared ETS table keyed by the
   # exact target pid — the same pid-scoped isolation the process dictionary
   # gives (a sibling async test operates on its OWN spawned pid), just
-  # externally addressable. These tests pin BOTH halves: the target degrades,
-  # and the arming process itself is untouched.
-  describe "arm_faults/2 (cross-process seam, #594)" do
+  # externally addressable. `fire_on: 1` is the immediate case (fire on the
+  # next check). These tests pin BOTH halves: the target degrades, and the
+  # arming process itself is untouched.
+  describe "arm_faults/3 (cross-process seam, #594)" do
     test "degrades a BusyRetry.run in the TARGET pid, leaving the caller's own run untouched" do
       test_pid = self()
 
@@ -181,7 +182,7 @@ defmodule Grappa.Repo.BusyRetryTest do
 
       on_exit(fn -> BusyRetry.disarm_faults(target) end)
 
-      BusyRetry.arm_faults(target, 10_000)
+      BusyRetry.arm_faults(target, 10_000, fire_on: 1)
       send(target, :go)
 
       # The armed target rides the budget out and degrades — proving the
@@ -204,7 +205,7 @@ defmodule Grappa.Repo.BusyRetryTest do
           end
         end)
 
-      BusyRetry.arm_faults(target, 10_000)
+      BusyRetry.arm_faults(target, 10_000, fire_on: 1)
       :ok = BusyRetry.disarm_faults(target)
 
       send(target, :go)

--- a/test/grappa/repo/busy_retry_test.exs
+++ b/test/grappa/repo/busy_retry_test.exs
@@ -157,4 +157,60 @@ defmodule Grappa.Repo.BusyRetryTest do
       assert Agent.get(counter, & &1) == 0
     end
   end
+
+  # #594 — cross-process fault arming. The process-dictionary seam
+  # (`inject_transient_faults/1`) can only reach work that runs in the
+  # CALLER's own process; a fault that must fire inside a Phoenix Channel,
+  # a Session.Server, or a sink GenServer needs to be armed against THAT
+  # pid. `arm_faults/2` stores the count in a shared ETS table keyed by the
+  # exact target pid — the same pid-scoped isolation the process dictionary
+  # gives (a sibling async test operates on its OWN spawned pid), just
+  # externally addressable. These tests pin BOTH halves: the target degrades,
+  # and the arming process itself is untouched.
+  describe "arm_faults/2 (cross-process seam, #594)" do
+    test "degrades a BusyRetry.run in the TARGET pid, leaving the caller's own run untouched" do
+      test_pid = self()
+
+      target =
+        spawn(fn ->
+          receive do
+            :go ->
+              send(test_pid, {:target_result, BusyRetry.run(fn -> {:ok, :wrote} end)})
+          end
+        end)
+
+      on_exit(fn -> BusyRetry.disarm_faults(target) end)
+
+      BusyRetry.arm_faults(target, 10_000)
+      send(target, :go)
+
+      # The armed target rides the budget out and degrades — proving the
+      # fault fired in a DIFFERENT process than the one that armed it.
+      assert_receive {:target_result, {:error, :db_unavailable}}, 2_000
+
+      # The CALLER (this test process) was never armed, so its own run
+      # succeeds — the fault did NOT bleed across the pid boundary.
+      assert BusyRetry.run(fn -> {:ok, :wrote} end) == {:ok, :wrote}
+    end
+
+    test "disarm_faults/1 clears a target's armed count" do
+      test_pid = self()
+
+      target =
+        spawn(fn ->
+          receive do
+            :go ->
+              send(test_pid, {:target_result, BusyRetry.run(fn -> {:ok, :wrote} end)})
+          end
+        end)
+
+      BusyRetry.arm_faults(target, 10_000)
+      :ok = BusyRetry.disarm_faults(target)
+
+      send(target, :go)
+
+      # With the count cleared, the target's run succeeds immediately.
+      assert_receive {:target_result, {:ok, :wrote}}, 2_000
+    end
+  end
 end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -2542,6 +2542,69 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  describe "inbound DM auto-open degrades cleanly under DB saturation (#594)" do
+    # #594 — the SECOND of the two out-of-process terminals (the first is the
+    # WS `close_query_window` `close_failed` reply, pinned in
+    # `GrappaWeb.GrappaChannelTest`). `maybe_open_query_window/2` runs inside
+    # the Session.Server's OWN pid, right after the persist, so the process-
+    # dictionary fault seam (which only reaches work in the TEST process)
+    # cannot arm it — it needs the #594 cross-process ETS seam armed against
+    # the SESSION pid, with `fire_on:` to skip the persist's checks and land on
+    # the open's. Pinning this matters because Dialyzer does NOT flag a
+    # non-exhaustive `case`: a refactor that dropped
+    # `maybe_open_query_window/2`'s `{:error, :db_unavailable}` arm would crash
+    # the session with a CaseClauseError on every DB-saturated inbound DM —
+    # exactly the class of bug that put the original arm in, and the only thing
+    # pinning it is this test.
+    test "a sustained DB busy on the auto-open logs + the session survives" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
+      net_id = network.id
+
+      # The inbound DM to our own nick persists at `channel = own_nick`, so the
+      # message broadcast lands on the own-nick channel topic. Receiving it is
+      # the "persist succeeded" barrier — the auto-open runs in the SAME
+      # handle_info immediately after, so the following sync state call
+      # guarantees the (dropped) open has already logged its terminal.
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.channel(user.name, network.slug, "vjt"))
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      # Arm the fault on the SESSION pid, firing on the auto-open's
+      # `BusyRetry.run` — NOT the persist's. The session-pid fault-CHECKS that
+      # precede the open are: persist insert (1) + persist preload (2). The
+      # `push: true` obligations (`Push.Triggers` + `WindowCounts`) each run in
+      # their OWN Task, so they add NO checks to this pid — the open's insert is
+      # the 3rd check, hence `fire_on: 3`. A wrong value fails LOUD, never
+      # silently passes: too low faults the persist (the message never lands →
+      # `assert_message_event` below times out); too high lets the open succeed
+      # (the terminal log is absent → the `log =~` assertion fails). So a change
+      # in how many `BusyRetry.run` calls precede the open BREAKS this test.
+      Repo.BusyRetry.arm_faults(pid, 10_000, fire_on: 3)
+      on_exit(fn -> Repo.BusyRetry.disarm_faults(pid) end)
+
+      log =
+        capture_log(fn ->
+          IRCServer.feed(server, ":alice!~a@host PRIVMSG vjt :hey there\r\n")
+          # persist rode out checks 1-2 + broadcast the message…
+          assert_message_event(sender: "alice", body: "hey there")
+          # …then drain the handle_info that also ran the dropped open.
+          _ = :sys.get_state(pid)
+        end)
+
+      # Observable terminal: the EXACT server.ex auto-open drop line AND a
+      # surviving session pid — a CaseClauseError would have taken it down.
+      assert log =~ "query-window auto-open db unavailable — session continues"
+      assert Process.alive?(pid)
+
+      # Not a no-op: the open genuinely dropped, so no window row was minted.
+      refute QueryWindows.open?({:user, user.id}, net_id, "alice")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+
   describe "PRIVMSG persistence + broadcast" do
     test "persists row and broadcasts canonical wire-shape event on PRIVMSG" do
       {server, port} = start_server()

--- a/test/grappa/uploads/reaper_test.exs
+++ b/test/grappa/uploads/reaper_test.exs
@@ -5,8 +5,10 @@ defmodule Grappa.Uploads.ReaperTest do
   # the suite honest but serialization avoids cross-test bleed.
   use Grappa.DataCase, async: false
 
+  import ExUnit.CaptureLog
   import Grappa.AuthFixtures, only: [user_fixture: 1]
 
+  alias Grappa.Repo.BusyRetry
   alias Grappa.Uploads
   alias Grappa.Uploads.Reaper
 
@@ -181,6 +183,40 @@ defmodule Grappa.Uploads.ReaperTest do
         )
 
       assert {:ok, 2} = Reaper.sweep(root, now)
+    end
+
+    # #590 — a sustained SQLITE_BUSY on the row soft-delete must be a
+    # best-effort DROP: the per-row failure logs + continues (sweep returns
+    # `{:ok, 0}`), and the row is LEFT un-soft-deleted for the next tick. The
+    # sweep runs in the test process, so the process-dictionary seam reaches
+    # `Uploads.soft_delete/2`'s BusyRetry directly. Observable: the row's
+    # `deleted_at` stays nil (the flip degraded) + the saturation is logged.
+    test "sustained DB busy → best-effort drop: sweep survives, logs, leaves row un-soft-deleted", %{
+      root: root
+    } do
+      user = user_fixture([])
+      now = DateTime.utc_now()
+      past = DateTime.add(now, -60, :second)
+
+      {:ok, expired} =
+        Uploads.create(
+          "img",
+          %{subject: {:user, user.id}, mime: "text/plain", expires_at: past},
+          storage_root: root
+        )
+
+      log =
+        capture_log(fn ->
+          BusyRetry.inject_transient_faults(10_000)
+          assert {:ok, 0} = Reaper.sweep(root, now)
+          BusyRetry.inject_transient_faults(0)
+        end)
+
+      # The row flip degraded — the upload is still live (deleted_at nil),
+      # to be retried by the next tick.
+      reloaded = Grappa.Repo.get!(Uploads.Upload, expired.id)
+      assert is_nil(reloaded.deleted_at)
+      assert log =~ "unavailable"
     end
   end
 

--- a/test/grappa/visitors/reaper_test.exs
+++ b/test/grappa/visitors/reaper_test.exs
@@ -13,9 +13,11 @@ defmodule Grappa.Visitors.ReaperTest do
   """
   use Grappa.DataCase, async: false
 
+  import ExUnit.CaptureLog
   import Grappa.AuthFixtures, only: [network_fixture: 1, start_visitor_session_for: 2, visitor_with_network: 2]
 
   alias Grappa.{AdmissionStateHelpers, Push, QueryWindows, ReadCursor, Session, UserSettings, Visitors}
+  alias Grappa.Repo.BusyRetry
   alias Grappa.Visitors.{Reaper, Visitor}
 
   setup do
@@ -50,6 +52,31 @@ defmodule Grappa.Visitors.ReaperTest do
 
     test "returns {:ok, 0} when nothing to reap" do
       assert {:ok, 0} = Reaper.sweep()
+    end
+
+    # #590 — a sustained SQLITE_BUSY on a visitor delete must be a best-effort
+    # DROP: the per-row failure logs + continues, the sweep survives (returns
+    # `{:ok, 0}` — nothing was actually deleted), and crucially the row is LEFT
+    # for the next tick. `sweep/0` runs in the test process, so the
+    # process-dictionary fault seam reaches `destroy_visitor/1`'s BusyRetry
+    # directly. The DROP must be OBSERVABLE (row survives + logged), not just
+    # "did not crash".
+    test "sustained DB busy → best-effort drop: sweep survives, logs, leaves the visitor row" do
+      slug = "azzurra-#{System.unique_integer([:positive])}"
+      _ = network_fixture(slug: slug)
+      {:ok, dead} = Visitors.find_or_provision_anon("dead", slug, nil)
+      expire(dead)
+
+      log =
+        capture_log(fn ->
+          BusyRetry.inject_transient_faults(10_000)
+          assert {:ok, 0} = Reaper.sweep()
+          BusyRetry.inject_transient_faults(0)
+        end)
+
+      # The visitor was NOT deleted — the write degraded rather than landing.
+      assert Repo.reload(dead)
+      assert log =~ "unavailable"
     end
 
     test "terminates live Session.Server before deleting expired visitor row" do

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -2708,7 +2708,13 @@ defmodule GrappaWeb.GrappaChannelTest do
 
       # Observable terminal: a typed error reply, NOT a crash — and the
       # channel process is still alive to serve the next push.
-      assert_reply(ref, :error, %{error: "close_failed"})
+      #
+      # QueryWindows.close routes the delete through BusyRetry.run, which
+      # retries against the test :busy_retry budget (config/test.exs — 300ms)
+      # before degrading to {:error, :db_unavailable}. The reply therefore
+      # lands at ~300ms, past assert_reply's 100ms default, so wait well past
+      # the budget for the deliberately-delayed terminal.
+      assert_reply(ref, :error, %{error: "close_failed"}, 2_000)
       assert Process.alive?(socket.channel_pid)
     end
 

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -2697,7 +2697,9 @@ defmodule GrappaWeb.GrappaChannelTest do
 
       # Arm the fault against the CHANNEL process — QueryWindows.close/4's
       # BusyRetry.run runs there, so its budget exhausts to :db_unavailable.
-      Grappa.Repo.BusyRetry.arm_faults(socket.channel_pid, 10_000)
+      # fire_on: 1 = the very next check: the close is the first (only)
+      # BusyRetry.run in the channel pid for this push, so it faults immediately.
+      Grappa.Repo.BusyRetry.arm_faults(socket.channel_pid, 10_000, fire_on: 1)
       on_exit(fn -> Grappa.Repo.BusyRetry.disarm_faults(socket.channel_pid) end)
 
       ref =

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -2678,6 +2678,40 @@ defmodule GrappaWeb.GrappaChannelTest do
       assert_push("event", %{kind: :query_windows_list})
     end
 
+    # #594 — the WS `close_failed` terminal. A sustained transient SQLITE_BUSY
+    # on the window delete must degrade to a clean channel error and leave the
+    # socket OPEN — never a raise that tears the connection down. This is one
+    # of the two out-of-process terminals the process-dictionary seam can't
+    # reach (the handler runs in the channel's own pid), so it is armed via the
+    # cross-process ETS seam on `socket.channel_pid`. Pinning it matters
+    # because Dialyzer does NOT flag a non-exhaustive `case` — a refactor
+    # dropping the `{:error, :db_unavailable}` arm would crash the channel
+    # here, unseen, exactly like the `maybe_open_query_window` CaseClauseError.
+    test "close_query_window: a sustained DB busy replies close_failed and keeps the socket open", %{
+      socket: socket,
+      user: user,
+      network: network
+    } do
+      {:ok, _} = QueryWindows.open({:user, user.id}, network.id, "dave", user.name)
+      assert_push("event", %{kind: :query_windows_list})
+
+      # Arm the fault against the CHANNEL process — QueryWindows.close/4's
+      # BusyRetry.run runs there, so its budget exhausts to :db_unavailable.
+      Grappa.Repo.BusyRetry.arm_faults(socket.channel_pid, 10_000)
+      on_exit(fn -> Grappa.Repo.BusyRetry.disarm_faults(socket.channel_pid) end)
+
+      ref =
+        push(socket, "close_query_window", %{
+          "network_id" => network.id,
+          "target_nick" => "dave"
+        })
+
+      # Observable terminal: a typed error reply, NOT a crash — and the
+      # channel process is still alive to serve the next push.
+      assert_reply(ref, :error, %{error: "close_failed"})
+      assert Process.alive?(socket.channel_pid)
+    end
+
     # V2 — visitor parity: visitors persist DM windows alongside users.
     # Pre-V2 the channel handlers short-circuited `visitor_not_allowed`;
     # V2 lifts the gate so visitor sockets get the same broadcast +

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -20,7 +20,7 @@ Ecto.Adapters.SQL.Sandbox.mode(Grappa.Repo, :manual)
 
 # #594 — the cross-process BusyRetry fault table, created ONCE here so it is
 # owned by the long-lived ExUnit runner process and survives every test. A
-# `:public :named_table` keyed by target pid; `arm_faults/2` writes it,
+# `:public :named_table` keyed by target pid; `arm_faults/3` writes it,
 # `maybe_inject_fault/0` reads it by `self()`. Creating it lazily in the first
 # test that arms would race `:ets.new` across async tests — hence here.
 Grappa.Repo.BusyRetry.ensure_fault_table()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -17,6 +17,13 @@
 # the sqlite-busy class with one knob.
 ExUnit.start(capture_log: true)
 Ecto.Adapters.SQL.Sandbox.mode(Grappa.Repo, :manual)
+
+# #594 — the cross-process BusyRetry fault table, created ONCE here so it is
+# owned by the long-lived ExUnit runner process and survives every test. A
+# `:public :named_table` keyed by target pid; `arm_faults/2` writes it,
+# `maybe_inject_fault/0` reads it by `self()`. Creating it lazily in the first
+# test that arms would race `:ets.new` across async tests — hence here.
+Grappa.Repo.BusyRetry.ensure_fault_table()
 Mox.defmock(Grappa.Admission.CaptchaMock, for: Grappa.Admission.Captcha)
 Mox.defmock(Grappa.Themes.ImageFetcherMock, for: Grappa.Themes.ImageFetcher)
 # #543 INC-5 — source-alias platform adapter + the hardened command seam.


### PR DESCRIPTION
Refs #590
Refs #594

## #590 — BusyRetry into the background writers (B2)

B1 wired `Grappa.Repo.BusyRetry` into every web-reachable write (terminal →
503). B2 wires the SAME shared engine — classifier + budget reused verbatim —
into the **background writers**, the ones with no client waiting. The terminal
differs per the three-doors split: a background write that outlasts the retry
budget **DROPS best-effort (log + continue)**, never a 503, never a crash (the
`:persist_unavailable` posture #336 gave the scrollback hot path, generalised).

- **Uniform contract, per-caller terminal.** Every context write fn returns
  `{:error, :db_unavailable}`; each CALLER maps its own terminal.
  `Visitors.delete/1` PROPAGATES (operator/admin want the 503 / a raised CLI
  error); `Visitors.purge_if_anon/1` ABSORBS to `:ok` + a log (a
  failed/preempted login has no client; the anon row waits for the reaper).
- **Writers migrated:** `Accounts.delete_expired_sessions`,
  `Visitors.destroy_visitor`, `Uploads.soft_delete/2`, `SessionLog`
  persist+prune, `AdminEvents` persist+prune+load_recent (a degraded boot
  reload yields an empty ring, not a crash-loop), `Push.delete_dead`. Each
  reaper's `sweep/0` maps the drop back to `{:ok, 0}` + a log so its
  `handle_info` stays total.
- **Small web fan-out:** only `admin/uploads_controller.delete` changed (its
  `{:ok, _} =` hard match became `with <-`); every other `with`-based action
  already flows `:db_unavailable → 503` via the shared `action_fallback`.
- **Notify is OUT (deliberate):** no background sweep — every caller is a web
  controller, so it belongs to B1's web-503 door, not B2. Its
  `notify_controller` `:ok =` hard matches are filed as a #523 follow-up, not
  smuggled in here. `Push.touch_last_used` (a post-delivery UPDATE) likewise.

## #594 — pin the two out-of-process DB-busy terminals

Two terminals live out of process from any test, and **Dialyzer does NOT flag a
non-exhaustive `case`** — so nothing but a test pins them; a refactor dropping
either `{:error, :db_unavailable}` arm would crash on every DB-saturated path,
unseen (exactly how the original `maybe_open` arm got in).

- **(a) WS `close_query_window`** (runs in the Channel's pid): a sustained busy
  replies `close_failed` and leaves the socket open.
- **(b) Session query-window auto-open** (`maybe_open_query_window/2`, runs in
  the `Session.Server`'s pid): a sustained busy logs + the session survives.

Both are armed via a new **cross-process ETS fault seam** keyed by the target
pid. (b) can't be isolated by a plain per-pid counter (the open runs only after
the persist succeeds ⟹ with one counter it never faults), so the seam grew a
**positional `fire_on:` selector**: it rides out the first `k-1` fault-CHECKS in
the pid, then fires from the `k`-th. For the inbound-DM flow `fire_on: 3`
(persist insert + preload, then the open — the push obligations run in their own
Tasks, adding no session-pid checks); a wrong value fails LOUD (too low faults
the persist, too high lets the open succeed), so `3` is empirically confirmed by
the triangulating assertions, not hardcoded.

`arm_faults` is a **single arity with a required `fire_on:`** — no immediate-mode
2-arity. Two arities where the shorter means "fire on the next check" is a
default argument in disguise (`arm_faults(pid, n)` never says WHEN it fires),
the silent-degradation path CLAUDE.md bans; `fire_on: 1` is the explicit
immediate case at every call site.

### Note on the doctor gate

The extra test-gated arity briefly pushed `Grappa.Repo.BusyRetry` under `mix
doctor`'s 40% dev-env doc floor. The single-arity refactor restores it as a
**side effect**, not the reason. The floor itself is a general artifact: doctor
counts functions from source but reads doc/spec presence from the **dev beam**,
where `Mix.env() == :test` helpers are compiled out and scored "missed" despite
`@doc false` + `@spec`. The **test-env doctor scores this module 100%** — the
seam is fully documented; this was never a docs-quality problem. The repo-wide
artifact is tracked as #621.

## Gate

`scripts/check.sh` → EXIT 0: 4867 tests / 0 failures, Dialyzer 0 errors, Credo
+ Sobelow + doctor (dev + test) + wire-types + bats 171/171 all green.