### PR TITLE
test(#619): unroute page.route handlers in one auto-fixture seam

### DIFF
--- a/cicchetto/e2e/fixtures/test.ts
+++ b/cicchetto/e2e/fixtures/test.ts
@@ -71,7 +71,11 @@ interface CspViolation {
   lineNumber: number;
 }
 
-export const test = base.extend<{ _vjtReset: void; _cspGuard: void }>({
+export const test = base.extend<{
+  _vjtReset: void;
+  _cspGuard: void;
+  _unrouteGuard: void;
+}>({
   _cspGuard: [
     async ({ context }, use) => {
       const violations: CspViolation[] = [];
@@ -129,6 +133,33 @@ export const test = base.extend<{ _vjtReset: void; _cspGuard: void }>({
           })),
         },
       );
+    },
+    { auto: true },
+  ],
+  // `_unrouteGuard` (#619) — one seam for the whole suite's page.route
+  // lifetime. 13 of 14 specs that call `page.route(` never unroute, so a
+  // route callback can still be mid-flight when the test body returns;
+  // Playwright then fails the test in TEARDOWN with
+  // `route.fetch: Target page, context or browser has been closed`. It is
+  // load-sensitive (the signature of a teardown bug, not a product bug):
+  // it reddened `issue605-rail-width-cap` in CI with the intercepted
+  // request returning 200 and NO assertion failing — that spec keeps a
+  // `/networks` route armed on purpose so a late `connection_state_changed`
+  // refetch stays patched, which is exactly the callback that outran the
+  // test. `unrouteAll({ behavior: "ignoreErrors" })` after the body drains
+  // in-flight callbacks and drops every registration, so no spec has to
+  // remember (CLAUDE.md: implement once, reuse everywhere).
+  //
+  // Teardown ORDER is load-bearing: the unroute MUST run while the page is
+  // still open. Declared LAST, it tears down FIRST (fixtures unwind in
+  // reverse of setup), and its `{ page }` dependency forces `page` to
+  // outlive this teardown — Playwright tears a fixture down only after its
+  // dependents — so the page is guaranteed live here. Verified against the
+  // `issue605-rail-width-cap` pin, not by reasoning alone.
+  _unrouteGuard: [
+    async ({ page }, use) => {
+      await use();
+      await page.unrouteAll({ behavior: "ignoreErrors" });
     },
     { auto: true },
   ],


### PR DESCRIPTION
Refs #619

## The defect
13 of the 14 e2e specs that call `page.route(` never unroute (only
`media-link-modal-viewer`, which aborts a route and needs it gone
mid-test). A route callback can still be in flight when the test body
returns, and Playwright then fails the test in **teardown** with
`route.fetch: Target page, context or browser has been closed`. It
reddened `issue605-rail-width-cap.spec.ts:120` (chromium) in #616's CI
with the intercepted request returning **200** and **no assertion
failing** — load-sensitive, the signature of a teardown bug, not a
product bug. That spec deliberately keeps a `/networks` route armed so a
late `connection_state_changed` refetch stays patched; that refetch is
exactly the callback that outran the test.

## The fix — one seam, not 13 patches
An `auto: true` fixture in `cicchetto/e2e/fixtures/test.ts` that calls
`page.unrouteAll({ behavior: "ignoreErrors" })` after the body — draining
in-flight callbacks and dropping every registration, so no spec has to
remember. Mirrors the existing `_cspGuard` / `_vjtReset` auto fixtures
(CLAUDE.md: *implement once, reuse everywhere*). Covers all 14 specs and
every future one.

**Teardown order is the whole risk** — the unroute must run while the
page is still open. `_unrouteGuard` is declared **last**, so it tears
down **first** (fixtures unwind in reverse of setup), and its `{ page }`
dependency forces `page` to outlive its teardown (Playwright tears a
fixture down only after its dependents). Proven empirically, not by
reasoning alone (below).

## Verification (full e2e, both projects, STACK lane)
`scripts/integration.sh` — **574 passed / 1 failed (22.3m)**, 575 total
across `chromium` + `webkit-iphone-15`.

- **Pin PASS:** `✓ issue605-rail-width-cap.spec.ts:120:3` (chromium,
  1.2s) — the exact spec+line that reddened in #616. Teardown-order proof.
- **Suite-wide `route.fetch` / "Target page… closed" count = 0.** The
  class is gone.
- **The 1 red is unrelated:** `recover-identity-real.spec.ts:193` — a
  30s timeout on `getByTestId("recover-modal-success")` in the RECOVER→+r
  real-services (Anope) flow. That's the **#277 / #618** real-services
  flake family (issue #619 pre-names this spec). It registers **no**
  `page.route`, so `_unrouteGuard` is a no-op for it and cannot have
  caused it.

## Scope
Test-only; **zero production code**. Only e2e **fixtures** change (not
`cicchetto/src`), so **no cic bundle rebuild is needed** — the e2e serves
its pre-built dist unchanged. Rebased onto `origin/main` before opening
so CI runs at the current base (not `CONFLICTING` with zero runs).