### PR TITLE
fix(#625): drop the redundant delayed tail-follow write on send

### DIFF
--- a/cicchetto/e2e/tests/issue625-single-send-scroll-jump.spec.ts
+++ b/cicchetto/e2e/tests/issue625-single-send-scroll-jump.spec.ts
@@ -1,0 +1,281 @@
+// Issue #625 — a single send must NOT jump the pane UP before it settles at
+// the tail. (Refs #608 — the single-scroll-authority refactor whose headline
+// promise "no double scroll" this pins.)
+//
+// ## The field report (vjt, staging serving main)
+//
+// After sending a message the pane scrolls "too far up" and then falls back
+// down to the bottom. Discriminating facts from vjt's observations:
+//   1. it happens on a SINGLE send, not only in rapid succession — so it is
+//      not two writes racing IN FLIGHT; it is two writes in sequence per send;
+//   2. "something resets the scroll after a while" — the errant write is
+//      DELAYED (a timer / a later render), NOT synchronous with the keypress.
+//
+// Consequence for the test: a snapshot taken right after the send finds the
+// pane at the bottom and FALSE-GREENs. The bug is only visible by sampling the
+// scroll geometry OVER TIME, across a window that outlasts every #608 deferred
+// writer (the tail-follow's SETTLE_MAX_FRAMES ≈ 0.5s poll, the 0.5s
+// scroll-settle / presence-settle timers). This spec samples for ~2.5s.
+//
+// ## The invariant
+//
+// The reader is following (or has just sent, which #608 arms follow). After a
+// send the pane is carried DOWN with the new tail and must STAY there — it must
+// never travel back UP. Appending one short line lifts distance-to-tail by ≪
+// the 50px bottom threshold, so any sample above the threshold AFTER the pane
+// first reached the tail means the pane was dragged away — the "too far up"
+// jump.
+//
+// Harness mirrors issue580 (DB-seeded 200-row #bofh; tiny 800×300 viewport so
+// the buffer overflows and scroll geometry is measurable).
+
+import { test, expect } from "../fixtures/test";
+import { type Page } from "@playwright/test";
+import {
+  composeSend,
+  loginAs,
+  scrollbackLines,
+  selectChannel,
+  waitForScrollbackRefreshed,
+} from "../fixtures/cicchettoPage";
+import { restoreReadCursorToTail, setReadCursorToId } from "../fixtures/grappaApi";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Mirror of ScrollbackPane.SCROLL_BOTTOM_THRESHOLD_PX = 50 (not exported; kept
+// in lockstep by hand — same as issue168 / cp14-b1 / issue580).
+const SCROLL_BOTTOM_THRESHOLD_PX = 50;
+
+// REST default page size (Grappa.Web.MessagesController.@default_limit).
+const REST_PAGE_SIZE = 50;
+
+// Sampling window — must outlast every #608 deferred writer. SETTLE_MAX_FRAMES
+// (30) ≈ 0.5s, SCROLL_SETTLE_DEBOUNCE_MS = 500, PRESENCE_CURSOR_SETTLE_MS = 500.
+const SAMPLE_WINDOW_MS = 2500;
+
+// A single send's ONE legitimate tail-follow fires at frame 0 of its poll (with
+// the WS echo). The regression's SECOND write is the fail-safe of a redundant
+// follow-on poll, landing SETTLE_MAX_FRAMES ≈ 0.5s LATER. We measure that gap
+// from the FIRST observed write, NOT from probe-install: the echo's own latency
+// (fill+press CDP round-trip + WS round-trip, tolerated up to 10s below) floats
+// the legitimate write's absolute timestamp, so an absolute cutoff would
+// false-RED on a slow run. The defect IS the ~0.5s gap between two writes.
+const SETTLE_GRACE_MS = 300;
+
+// The delayed double-scroll: any container scroll write that lands more than the
+// grace window AFTER the send's first (legitimate) tail-follow write.
+function delayedWrites(writes: readonly WriteEvent[]): WriteEvent[] {
+  if (writes.length === 0) return [];
+  const first = writes[0] as WriteEvent;
+  return writes.filter((w) => w.t - first.t > SETTLE_GRACE_MS);
+}
+
+type Sample = { t: number; top: number; height: number; client: number };
+type WriteEvent = { t: number; kind: string; detail: string; before: number };
+
+async function distanceToBottom(page: Page): Promise<number> {
+  return await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+    if (!el) throw new Error("scrollback container not found");
+    return el.scrollHeight - el.scrollTop - el.clientHeight;
+  });
+}
+
+async function fetchScrollbackPage(token: string, channel: string): Promise<Array<{ id: number }>> {
+  const url = `http://grappa-test:4000/networks/${encodeURIComponent(
+    NETWORK_SLUG,
+  )}/channels/${encodeURIComponent(channel)}/messages`;
+  const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!response.ok) {
+    throw new Error(`fetchScrollbackPage: ${response.status} ${await response.text()}`);
+  }
+  return (await response.json()) as Array<{ id: number }>;
+}
+
+// Install an in-page sampler + a scroll-write spy on the scrollback container,
+// BEFORE the send. The sampler records the geometry on every native `scroll`
+// event AND on a rAF tick (to catch a programmatic write that lands between
+// scroll events), for SAMPLE_WINDOW_MS. The spy wraps `scrollIntoView` + the
+// `scrollTop` setter (page-context only — no production behaviour changes).
+async function installScrollProbe(page: Page, windowMs: number): Promise<void> {
+  await page.evaluate((windowMsArg) => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+    if (!el) throw new Error("scrollback container not found for probe");
+    type Sample = { t: number; top: number; height: number; client: number };
+    type WriteEvent = { t: number; kind: string; detail: string; before: number };
+    const w = window as unknown as { __i625samples: Sample[]; __i625writes: WriteEvent[] };
+    w.__i625samples = [];
+    w.__i625writes = [];
+    const t0 = performance.now();
+    const now = () => performance.now() - t0;
+
+    const desc = Object.getOwnPropertyDescriptor(Element.prototype, "scrollTop");
+    const getTop = () => (desc?.get ? (desc.get.call(el) as number) : el.scrollTop);
+
+    if (desc?.get && desc?.set) {
+      Object.defineProperty(el, "scrollTop", {
+        configurable: true,
+        get() {
+          return desc.get?.call(this);
+        },
+        set(v: number) {
+          w.__i625writes.push({ t: Math.round(now()), kind: "scrollTop=", detail: String(Math.round(v)), before: Math.round(getTop()) });
+          desc.set?.call(this, v);
+        },
+      });
+    }
+
+    const rawSIV = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = function (arg?: boolean | ScrollIntoViewOptions) {
+      if (this === el || el.contains(this as Node)) {
+        w.__i625writes.push({ t: Math.round(now()), kind: "scrollIntoView", detail: JSON.stringify(arg ?? null), before: Math.round(getTop()) });
+      }
+      return rawSIV.call(this, arg as ScrollIntoViewOptions);
+    };
+
+    const sample = () => {
+      w.__i625samples.push({ t: Math.round(now()), top: Math.round(getTop()), height: el.scrollHeight, client: el.clientHeight });
+    };
+    sample();
+    el.addEventListener("scroll", sample, { passive: true });
+    const loop = () => {
+      sample();
+      if (now() < windowMsArg) requestAnimationFrame(loop);
+    };
+    requestAnimationFrame(loop);
+  }, windowMs);
+}
+
+// On failure this dump is the whole story: `writes` names every container scroll
+// write + its timestamp (the delayed double-scroll shows as a second entry ~0.5s
+// in), `topChanges` is the compressed scrollTop timeline.
+async function dumpEvidence(page: Page, tag: string): Promise<{ samples: Sample[]; writes: WriteEvent[] }> {
+  const samples = await page.evaluate(
+    () => (window as unknown as { __i625samples: Sample[] }).__i625samples,
+  );
+  const writes = await page.evaluate(
+    () => (window as unknown as { __i625writes: WriteEvent[] }).__i625writes,
+  );
+  const dist = (s: Sample) => Math.round(s.height - s.top - s.client);
+  const compact: Array<{ t: number; top: number; d: number }> = [];
+  let prevTop = Number.NaN;
+  for (const s of samples) {
+    if (s.top !== prevTop) {
+      compact.push({ t: s.t, top: s.top, d: dist(s) });
+      prevTop = s.top;
+    }
+  }
+  console.log(`[#625 ${tag}] writes=${JSON.stringify(writes)}`);
+  console.log(`[#625 ${tag}] topChanges=${JSON.stringify(compact)}`);
+  return { samples, writes };
+}
+
+const distOf = (s: Sample) => s.height - s.top - s.client;
+
+test.describe("issue #625 — a single send must not jump the pane up before settling", () => {
+  test.use({ viewport: { width: 800, height: 300 } });
+
+  // The cursor persists on the shared seeded vjt across specs (last-write-wins).
+  // Restore to the tail so downstream #bofh specs inherit a fully-read channel.
+  test.afterAll(async () => {
+    const vjt = getSeededVjt();
+    if (!CHANNEL) return;
+    await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
+  });
+
+  test("send while at the tail: distance-to-tail never spikes up over 2.5s", async ({ page }) => {
+    const vjt = getSeededVjt();
+    if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+
+    await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+    await waitForScrollbackRefreshed(page, NETWORK_SLUG, CHANNEL);
+
+    await expect
+      .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
+      .toBeGreaterThanOrEqual(REST_PAGE_SIZE);
+    await expect
+      .poll(async () => await distanceToBottom(page), { timeout: 10_000 })
+      .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
+
+    await installScrollProbe(page, SAMPLE_WINDOW_MS);
+    const marker = `i625 at-tail ${Date.now()}`;
+    await composeSend(page, marker);
+
+    const sentLine = scrollbackLines(page).filter({ hasText: marker });
+    await expect(sentLine).toHaveCount(1, { timeout: 10_000 });
+    await page.waitForTimeout(SAMPLE_WINDOW_MS + 200);
+
+    const { samples, writes } = await dumpEvidence(page, "at-tail");
+    expect(samples.length).toBeGreaterThan(10);
+
+    // #625 CORE — no DELAYED second scroll write. A single send performs ONE
+    // tail-follow; the regression's redundant follow-on poll fires its fail-safe
+    // scroll ~0.5s later. RED on main; GREEN once that write is suppressed.
+    expect(writes.length, `expected the send's tail-follow write; writes=${JSON.stringify(writes)}`).toBeGreaterThanOrEqual(1);
+    const late = delayedWrites(writes);
+    expect(late, `delayed scroll write(s) after the send's tail-follow: ${JSON.stringify(writes)}`).toEqual([]);
+
+    // Visible-symptom guard: following a send, the pane never travels UP.
+    const maxDist = Math.max(...samples.map(distOf));
+    expect(maxDist).toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
+    await expect(sentLine).toBeInViewport();
+  });
+
+  test("send while reading history (unread marker): pane settles at tail and stays", async ({
+    page,
+  }) => {
+    const vjt = getSeededVjt();
+    if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+
+    // Mid-page cursor → cold-mount lands on the unread marker, ABOVE the fold:
+    // the reader is parked in history when they send (vjt's scenario).
+    const page0 = await fetchScrollbackPage(vjt.token, CHANNEL);
+    expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
+    const cursorRow = page0[25];
+    if (!cursorRow) throw new Error("seeded page too short for cursor placement");
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, cursorRow.id);
+
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+    await waitForScrollbackRefreshed(page, NETWORK_SLUG, CHANNEL);
+
+    await expect
+      .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
+      .toBeGreaterThanOrEqual(REST_PAGE_SIZE);
+    await expect(page.locator('[data-testid="unread-marker"]')).toHaveCount(1);
+    // Parked in history, above the fold.
+    await expect
+      .poll(async () => await distanceToBottom(page), { timeout: 10_000 })
+      .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
+
+    await installScrollProbe(page, SAMPLE_WINDOW_MS);
+    const marker = `i625 from-history ${Date.now()}`;
+    await composeSend(page, marker);
+
+    const sentLine = scrollbackLines(page).filter({ hasText: marker });
+    await expect(sentLine).toHaveCount(1, { timeout: 10_000 });
+    await page.waitForTimeout(SAMPLE_WINDOW_MS + 200);
+
+    const { samples, writes } = await dumpEvidence(page, "from-history");
+    expect(samples.length).toBeGreaterThan(10);
+
+    // #625 CORE — same invariant as the at-tail case: a single send must not fire
+    // a DELAYED second scroll write. (Here the follow-on rows change is the marker
+    // collapse, which cannot settle and hits the fail-safe.)
+    expect(writes.length, `expected the send's tail-follow write; writes=${JSON.stringify(writes)}`).toBeGreaterThanOrEqual(1);
+    const late = delayedWrites(writes);
+    expect(late, `delayed scroll write(s) after the send's tail-follow: ${JSON.stringify(writes)}`).toEqual([]);
+
+    // #608: a send follows the tail unconditionally → the pane reaches the bottom.
+    // Once there, it STAYS (a delayed writer would drag it back UP).
+    const firstAtTail = samples.findIndex((s) => distOf(s) <= SCROLL_BOTTOM_THRESHOLD_PX);
+    expect(firstAtTail).toBeGreaterThanOrEqual(0);
+    const afterSettle = samples.slice(firstAtTail);
+    const maxAfterSettle = Math.max(...afterSettle.map(distOf));
+    expect(maxAfterSettle).toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
+    await expect(sentLine).toBeInViewport();
+  });
+});

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -2459,7 +2459,9 @@ const ScrollbackPane: Component<Props> = (props) => {
   // `isSettled` core against the last-tail baseline: the extent has GROWN since we
   // last tailed AND the new tail row has a laid-out box. Scrolls the frame that
   // holds, updating the baseline. Bounded by `SETTLE_MAX_FRAMES` (fail-safe: a
-  // rows change with no measurable growth still tails once — never strands).
+  // rows change with no measurable growth still tails once IF the pane is behind
+  // the tail — never strands; but #625: it does NOT fire when already at the tail,
+  // else a follow-on no-growth rows change on a single send double-scrolls).
   // Re-checks `followMode()`/`listRef` each frame (the operator may scroll up, or
   // the pane unmount, mid-wait). condition-based-waiting: wait for the real
   // layout state, not two guessed frames.
@@ -2490,10 +2492,27 @@ const ScrollbackPane: Component<Props> = (props) => {
         targetNodeHeight,
       });
       if (settled || frame >= SETTLE_MAX_FRAMES) {
-        if (tail?.scrollIntoView) {
-          tail.scrollIntoView({ block: "end" });
-        } else {
-          listRef.scrollTop = listRef.scrollHeight;
+        // #625 — the fail-safe must NOT fire a redundant DELAYED write. A single
+        // send fires MORE THAN ONE `rows().length` change (the echo append, then
+        // a follow-on change: the marker collapse / cursor advance). Each spawns
+        // a poll sharing `lastTailScrollHeight`; the echo's poll settles first and
+        // advances the baseline to the final extent, so the follow-on poll can
+        // NEVER measure growth (`currScrollHeight > lastTailScrollHeight` is false)
+        // and runs its whole SETTLE_MAX_FRAMES budget — firing a second
+        // `scrollIntoView` ~0.5s AFTER the send ("the scroll resets after a
+        // while", the #608-regression double-scroll). When that fail-safe reaches
+        // its budget WITHOUT measured growth AND the pane is already AT the tail,
+        // there is nothing to follow — skip the write. The genuine no-flush case
+        // (fail-safe reached but the pane is still BEHIND the tail, e.g. an iOS
+        // layout that never reported growth) still tails, so nothing strands.
+        const atTail =
+          currScrollHeight - listRef.scrollTop - listRef.clientHeight <= SCROLL_BOTTOM_THRESHOLD_PX;
+        if (settled || !atTail) {
+          if (tail?.scrollIntoView) {
+            tail.scrollIntoView({ block: "end" });
+          } else {
+            listRef.scrollTop = listRef.scrollHeight;
+          }
         }
         lastTailScrollHeight = listRef.scrollHeight;
         return;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -25655,3 +25655,56 @@ message never lands), too high lets the open succeed (the drop log is absent).
 A change in how many `BusyRetry.run` calls precede the open is MEANT to break
 that test — the empirical `fire_on: 3` is not hardcoded theory, it is the value
 the triangulating assertions accept.
+
+## 2026-08-01 — #625 (#608 regression): a single send double-scrolls — the tail-follow fail-safe must not fire when already at the tail
+
+Field report (vjt, staging serving main): after sending a message the
+scrollback "scrolls too far up and then falls back down". Reproduces on a SINGLE
+send, not only in bursts, and — the discriminating fact — "the scroll resets
+after a WHILE": the errant write is DELAYED (~0.5s), not synchronous with the
+keypress. A double scroll is exactly the defect #608's single-scroll-authority
+reshape claims to abolish, so this is a regression in its own headline promise.
+
+**Root cause (evidence, not theory — instrumented e2e trace).** A single send
+fires MORE THAN ONE `rows().length` change, hence more than one content-change
+tail-follow: (1) the WS echo append (`n → n+1`), then (2) a follow-on change —
+the marker collapse / read-cursor advance (`n+1 → n`, or a same-length re-key).
+Each spawns a `tailFollowWhenSettled` poll, and the polls SHARE the module-level
+`lastTailScrollHeight` baseline. Poll (1) settles at frame 0 (`scrollHeight`
+grew past the baseline), tails, and advances the baseline to the FINAL extent.
+Poll (2) then can never satisfy `currScrollHeight > lastTailScrollHeight` — the
+first poll already moved the goalpost — so it runs its whole `SETTLE_MAX_FRAMES`
+(~30 frames ≈ 0.5s) budget and fires the fail-safe `scrollIntoView` anyway. That
+is the DELAYED second write. On chromium it lands on the same tail (benign,
+which is why a plain e2e false-greens); under staging's timing/geometry it lands
+off-tail as the visible "up then down" bounce. The illegitimate writer is poll
+(2)'s fail-safe firing when there is nothing to follow.
+
+**Fix (remove the writer, no debounce/timeout).** The fail-safe branch now
+scrolls only when the poll actually has somewhere to go: `settled` (measured
+growth) OR `!atTail` (the pane is still BEHIND the tail — the genuine
+iOS-never-reported-growth case, which must still tail so nothing strands). A
+fail-safe that reaches its budget WITHOUT measured growth AND is already within
+`SCROLL_BOTTOM_THRESHOLD_PX` of the tail has nothing to follow → it skips the
+write. Poll (1) always fires (settled, or behind-the-tail); poll (2) skips. One
+send → one tail write. No timer hides the race; the redundant write is simply
+not performed. A genuine two-message burst still tails twice (both polls measure
+growth) — the fix only suppresses the no-growth-at-tail redundant poll.
+
+**Why not debounce / cancel-prior.** A `setTimeout`/debounce that swallows the
+second write is the exact anti-pattern this refactor exists to prevent (vjt).
+Cancel-the-previous-poll does NOT help either: poll (1) fires at frame 0, BEFORE
+poll (2)'s content-change even arrives, so they are sequential, not overlapping —
+there is no in-flight poll to cancel. The geometry guard is the correct place:
+the single applier decides "is there actually a tail to catch?" at fire time,
+after layout has settled.
+
+**The test (`cicchetto/e2e/tests/issue625-single-send-scroll-jump.spec.ts`).**
+A snapshot right after the send false-greens (the pane IS at the tail by then);
+the bug only shows by sampling scroll geometry OVER TIME. The spec installs an
+in-page write-spy + rAF sampler, sends ONE line (at the tail, and again while
+reading history above an unread marker), waits out a 2.5s window, and asserts NO
+container scroll write lands past a settle grace (300ms) — i.e. exactly one
+tail-follow per send. RED on main (a second `scrollIntoView` at t≈540–610ms),
+GREEN with the fix. Chromium (webkit ≠ real-iOS scroll, but the DEFECT — the
+redundant delayed write — is engine-independent and deterministically pinned).


### PR DESCRIPTION
## The bug (#625) — a regression of #608's headline promise

A **single** send double-scrolls: the pane jumps "too far up" then falls back
to the tail ~0.5s later (vjt's staging, serving `main`). A double scroll is
exactly the defect #608's single-scroll-authority reshape claims to abolish.

## Root cause (instrumented e2e trace — not theory)

A single send fires **more than one** `rows().length` change — the WS echo
append, then a follow-on change (the marker collapse / read-cursor advance).
Each spawns a `tailFollowWhenSettled` poll, and the polls **share** the
module-level `lastTailScrollHeight` baseline. The echo's poll settles at frame 0,
tails, and advances the baseline to the final extent; the follow-on poll then
can **never** satisfy `currScrollHeight > lastTailScrollHeight`, so it runs its
whole `SETTLE_MAX_FRAMES` (~0.5s) budget and fires the fail-safe `scrollIntoView`
anyway — the **delayed second write** ("the scroll resets after a while"). On
chromium it lands on the same tail (benign, why a plain e2e false-greens); under
staging's timing it lands off-tail as the visible bounce.

## The fix — remove the writer, no debounce/timeout

The fail-safe scrolls only when it actually has somewhere to go: `settled`
(measured growth) **or** `!atTail` (still behind the tail — the genuine
iOS-never-reported-growth case, preserved so nothing strands). A fail-safe that
reaches its budget without growth **and** is already within the bottom threshold
has nothing to follow → it skips the write. **One send → one tail write.** A
genuine two-message burst still tails twice (both polls measure growth). No
`setTimeout`, no debounce — the redundant write is simply not performed.

## Test — `issue625-single-send-scroll-jump.spec.ts`

A snapshot right after the send false-greens (the pane *is* at the tail by then);
the bug only shows by sampling scroll geometry **over time**. The spec installs
an in-page write-spy + rAF sampler, sends ONE line (at the tail, and again while
reading history above an unread marker), waits out a 2.5s window, and asserts no
container scroll write lands more than a 300ms grace **after the send's first
(legitimate) tail-follow** — i.e. exactly one tail write per send.

- **RED** on `main`: `2 failed` — a second `scrollIntoView` at a ~500ms gap
  (at-tail gap 504ms, from-history gap 498ms).
- **GREEN** with the fix: `2 passed` — one write each.

## Gates

- cic `bun.sh run check` → **exit 0** (biome: 37 pre-existing CSS warnings, 0
  errors; tsc clean).
- full cic vitest → **3778 passed / 211 files**.
- new e2e (chromium) → **RED on main → GREEN with fix**, re-verified with the
  final anchored assertion.

Decisions lifted to `docs/DESIGN_NOTES.md` (2026-08-01 — #625).

Refs #608