### PR TITLE
fix(#627): skip source-alias reconcile when mode 2 has no prefix

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -25708,3 +25708,64 @@ container scroll write lands past a settle grace (300ms) — i.e. exactly one
 tail-follow per send. RED on main (a second `scrollIntoView` at t≈540–610ms),
 GREEN with the fix. Chromium (webkit ≠ real-iOS scroll, but the DEFECT — the
 redundant delayed write — is engine-independent and deterministically pinned).
+
+---
+
+## 2026-08-02 — #627: an unconfigured mode 2 must never crash boot — the arm gate guarded the bind, not the reconcile
+
+Field report (vjt, the 2026-08-02 jail cutover): the release refused to boot on
+the FreeBSD substrate. The DB was still in **mode 1** — no `addressing.mode`, no
+`addressing.static_mapping_prefix` row in `server_settings` — which is the
+DEFAULT of a fresh install and of any DB restored from before #543. The log even
+said so, then crashed anyway:
+
+```
+[info]  source-alias mode 2 disarmed (:no_static_prefix) — static-mapping sessions will be held
+[error] GenServer Grappa.Net.SourceAliasManager terminating
+** (FunctionClauseError) no function clause matching in Grappa.Net.IpLiteral.in_cidr6?/2
+    lib/grappa/net/ip_literal.ex:144: Grappa.Net.IpLiteral.in_cidr6?("::1", nil)
+    lib/grappa/net/source_alias/free_bsd.ex:58: …FreeBSD.list_aliases/1
+    lib/grappa/net/source_alias_manager.ex:214: …do_reconcile/1
+    lib/grappa/net/source_alias_manager.ex:132: …handle_continue/2
+```
+
+`SourceAliasManager` is a supervised child of the app supervisor, so the crash in
+its boot `{:continue, :reconcile}` escalated and took the **whole node** down —
+the BEAM never reached the HTTP listener. The bouncer was fully down, not
+degraded.
+
+**Root cause — the arm gate and the reconcile path disagreed.** `init/1`
+correctly runs `compute_arm(adapter, nil) → {false, :no_static_prefix}` and
+publishes the disarmed state (a nil prefix short-circuits before `arm_check`).
+But `do_reconcile/1` then called `state.adapter.list_aliases(state.prefix)`
+**unconditionally**. On FreeBSD that parses `ifconfig lo0` and filters every
+address through `IpLiteral.in_cidr6?(addr, prefix)`, whose sole clause is
+`is_binary/1`-guarded on BOTH arguments. `lo0` always carries `::1`, so the first
+element blew the clause with `prefix = nil`. **The arm gate guarded the BIND
+decisions; it did not guard the reconcile.** (Linux + Disabled never showed it —
+their `list_aliases(_)` already returns `{:ok, []}`; only FreeBSD shells out.)
+
+**Fix — at the root, plus belt-and-braces (neither alone is the fix).**
+1. **Root:** `do_reconcile(%{prefix: nil} = state), do: state` — with no prefix
+   there is no block to reconcile against and nothing can be a managed alias, so
+   the manager does NO reconcile work. This is the fix: the manager must not do
+   work it has no business doing when mode 2 is unconfigured.
+2. `FreeBSD.list_aliases(nil) → {:ok, []}` (without shelling) — keeps the adapter
+   contract total for the nil prefix, matching Linux/Disabled.
+3. `IpLiteral.in_cidr6?(_, nil) → false` — "no prefix ⇒ no membership". Narrowed
+   to nil ONLY: a non-binary addr with a real prefix still crashes (a genuine
+   caller bug worth surfacing, per the CLAUDE.md let-it-crash rule). #2 and #3 on
+   their own would only HIDE the manager doing work it shouldn't — they harden
+   the contract, they do not replace the root guard.
+
+**The invariant the test encodes: a nil/absent `static_mapping_prefix` must NEVER
+take the application down.** The gap that let this ship was a test masking:
+`source_alias_manager_test.exs` already booted the manager with `prefix: nil`,
+but stubbed the Mox adapter's `list_aliases` with `fn _ -> {:ok, []} end`, which
+tolerates nil where the real FreeBSD adapter raises. The regression tests
+(`#627`): (a) the manager on the **real** FreeBSD adapter (cmd Mox'd) with
+`prefix: nil` boots without a `:DOWN` and reconciles to a no-op — reproducing the
+exact prod stacktrace RED; (b) adapter-agnostic proof of the ROOT — a Mox adapter
+with NO `list_aliases` stub, so any boot-path call raises → `:DOWN`, forcing the
+early-return rather than merely a defensive adapter clause; plus (c/d) the
+`FreeBSD.list_aliases(nil)`/`IpLiteral.in_cidr6?(_, nil)` unit clauses.

--- a/lib/grappa/net/ip_literal.ex
+++ b/lib/grappa/net/ip_literal.ex
@@ -140,7 +140,7 @@ defmodule Grappa.Net.IpLiteral do
   block — a privilege-scope invariant), so the membership math lives here
   once (CLAUDE.md "implement once, reuse everywhere").
   """
-  @spec in_cidr6?(String.t(), String.t()) :: boolean()
+  @spec in_cidr6?(String.t(), String.t() | nil) :: boolean()
   def in_cidr6?(addr, prefix_cidr) when is_binary(addr) and is_binary(prefix_cidr) do
     with {:ok, {_, _, _, _, _, _, _, _} = addr_tuple} <- to_tuple(addr),
          {:ok, {net_tuple, len}} <- parse_cidr6(prefix_cidr) do
@@ -150,6 +150,14 @@ defmodule Grappa.Net.IpLiteral do
       _ -> false
     end
   end
+
+  # #627 — no prefix configured (mode 2 unconfigured) ⇒ no membership. A nil
+  # prefix is `false`, never a FunctionClauseError: the sole clause above was
+  # `is_binary/1`-guarded on BOTH args, so `in_cidr6?("::1", nil)` raised
+  # inside the FreeBSD `list_aliases` filter and took the node down at boot.
+  # This narrows ONLY the "no prefix" case — a non-binary addr with a real
+  # prefix still crashes (a genuine caller bug worth surfacing, CLAUDE.md).
+  def in_cidr6?(_, nil), do: false
 
   # ---- v6 bit helpers (128-bit int ↔ 8×16 tuple) -------------------
 

--- a/lib/grappa/net/source_alias/free_bsd.ex
+++ b/lib/grappa/net/source_alias/free_bsd.ex
@@ -53,7 +53,14 @@ defmodule Grappa.Net.SourceAlias.FreeBSD do
   def release_source(addr, prefix), do: alias_op("del", addr, prefix)
 
   @impl Grappa.Net.SourceAlias
-  def list_aliases(prefix) do
+  # #627 — no prefix means mode 2 is unconfigured: no block to list aliases
+  # inside, so the answer is empty WITHOUT shelling `ifconfig`. Belt-and-braces
+  # with the manager's reconcile early-return — keeps the adapter contract
+  # total (never raises) for the nil prefix of a mode-1 / fresh install, rather
+  # than parsing `lo0` and filtering `::1` through `in_cidr6?(_, nil)`.
+  def list_aliases(nil), do: {:ok, []}
+
+  def list_aliases(prefix) when is_binary(prefix) do
     case Config.cmd().run("ifconfig", ["lo0"], @timeout_s) do
       {:ok, output} -> {:ok, parse_lo0_inet6(output, prefix)}
       {:error, _} = err -> err

--- a/lib/grappa/net/source_alias_manager.ex
+++ b/lib/grappa/net/source_alias_manager.ex
@@ -210,6 +210,16 @@ defmodule Grappa.Net.SourceAliasManager do
   @spec held_addresses(state()) :: [String.t()]
   defp held_addresses(state), do: Map.keys(state.refcounts) ++ state.held_source_fn.()
 
+  # #627 — with no prefix, mode 2 is unconfigured (the arm gate already
+  # disarmed it, see `compute_arm/2`): there is no `::cb::/80` block to
+  # reconcile against and nothing can be a managed alias, so the sweep is not
+  # merely unnecessary — it has no business running. Doing it anyway shelled
+  # `ifconfig lo0` and filtered `::1` through `in_cidr6?(_, nil)`, raising in
+  # the boot `handle_continue` and escalating to the whole application, so a
+  # mode-1 / fresh install (no `addressing.static_mapping_prefix` row) could
+  # not start. The arm gate guarded the bind decisions but not this path.
+  defp do_reconcile(%{prefix: nil} = state), do: state
+
   defp do_reconcile(state) do
     case state.adapter.list_aliases(state.prefix) do
       {:ok, os_bound} ->

--- a/test/grappa/net/ip_literal_test.exs
+++ b/test/grappa/net/ip_literal_test.exs
@@ -145,5 +145,15 @@ defmodule Grappa.Net.IpLiteralTest do
       refute IpLiteral.in_cidr6?("2a03::2", "2a03::1/128")
       assert IpLiteral.in_cidr6?("2a03:4000:20:2d3:cb::1", "::/0")
     end
+
+    # #627 — with mode 2 unconfigured there is NO prefix, so nothing can be a
+    # managed alias: a nil prefix is `false`, never a FunctionClauseError. The
+    # sole clause was `is_binary/1`-guarded on both args, so `in_cidr6?("::1",
+    # nil)` raised inside the FreeBSD list_aliases filter and took the node
+    # down at boot. Semantically "no prefix ⇒ no membership", so `false`.
+    test "false for a nil prefix (no mode-2 prefix configured)" do
+      refute IpLiteral.in_cidr6?("2a03:4000:20:2d3:cb::1", nil)
+      refute IpLiteral.in_cidr6?("::1", nil)
+    end
   end
 end

--- a/test/grappa/net/source_alias_manager_test.exs
+++ b/test/grappa/net/source_alias_manager_test.exs
@@ -11,6 +11,7 @@ defmodule Grappa.Net.SourceAliasManagerTest do
 
   import Mox
 
+  alias Grappa.Net.SourceAlias.FreeBSD
   alias Grappa.Net.SourceAliasManager, as: Manager
 
   @prefix "2a03:4000:20:2d3:cb::/80"
@@ -163,6 +164,64 @@ defmodule Grappa.Net.SourceAliasManagerTest do
       drain_boot_reconcile(pid)
 
       assert Manager.armed?() == false
+      assert Manager.disarm_reason() == :no_static_prefix
+    end
+  end
+
+  # #627 — a nil/absent `static_mapping_prefix` (mode 2 unconfigured, the
+  # default of a fresh install or a pre-#543 DB) must NEVER take the node down.
+  # In prod (FreeBSD jail, on the release deployed at `b41b8d09`) `do_reconcile`
+  # shelled `ifconfig lo0` and filtered `::1` through `in_cidr6?(_, nil)`,
+  # raising in the boot `handle_continue` and escalating to the whole
+  # application. The bug rode in with #543's source-alias reconcile; the arm
+  # gate already disarms mode 2 for a nil prefix — the reconcile path must too.
+  describe "nil prefix (#627) — mode 2 unconfigured must not crash the node" do
+    # The ROOT of the fix, proven adapter-agnostically: the Mox adapter has NO
+    # `list_aliases` (or `arm_check`) stub, so ANY boot-path adapter call would
+    # raise inside the GenServer and surface as a DOWN. Green requires the
+    # manager to early-return from reconcile — not merely a defensive adapter
+    # clause — because it must do NO reconcile work with no prefix to diff.
+    test "the manager never calls the adapter when there is no prefix" do
+      pid =
+        start_supervised!(%{
+          id: Manager,
+          start: {Manager, :start_link, [[adapter: Grappa.Net.SourceAliasMock, prefix: nil]]},
+          restart: :temporary
+        })
+
+      ref = Process.monitor(pid)
+      # handle_continue(:reconcile) runs async right after init; a nil-prefix
+      # crash arrives as a DOWN within milliseconds.
+      refute_receive {:DOWN, ^ref, :process, ^pid, _reason}, 500
+      assert Process.alive?(pid)
+
+      # An explicit reconcile is a no-op too — still no adapter call.
+      assert :ok = Manager.reconcile()
+      assert Process.alive?(pid)
+    end
+
+    # The faithful prod reproduction: the REAL FreeBSD adapter (cmd Mox'd) with
+    # prefix nil. Pre-fix, the manager shells `ifconfig` and crashes on `::1`;
+    # the `stub` feeds exactly that line. Post-fix the reconcile early-returns,
+    # so `run/3` is never reached (stub tolerates zero calls).
+    test "boots on the real FreeBSD adapter with prefix nil without crashing" do
+      stub(Grappa.Sys.HardenedCmdMock, :run, fn "ifconfig", ["lo0"], _ ->
+        {:ok, "lo0: flags=8049\n\tinet6 ::1 prefixlen 128\n"}
+      end)
+
+      pid =
+        start_supervised!(%{
+          id: Manager,
+          start: {Manager, :start_link, [[adapter: FreeBSD, prefix: nil]]},
+          restart: :temporary
+        })
+
+      ref = Process.monitor(pid)
+      refute_receive {:DOWN, ^ref, :process, ^pid, _reason}, 500
+      assert Process.alive?(pid)
+
+      assert :ok = Manager.reconcile()
+      assert Process.alive?(pid)
       assert Manager.disarm_reason() == :no_static_prefix
     end
   end

--- a/test/grappa/net/source_alias_test.exs
+++ b/test/grappa/net/source_alias_test.exs
@@ -122,6 +122,15 @@ defmodule Grappa.Net.SourceAliasTest do
 
       assert {:ok, ["2a03:4000:20:2d3:cb::5"]} = FreeBSD.list_aliases(@prefix)
     end
+
+    # #627 — a nil prefix means mode 2 is unconfigured: there is no block to
+    # list aliases inside, so the answer is empty WITHOUT touching `ifconfig`.
+    # Before the fix this shelled out and filtered `::1` through
+    # `in_cidr6?(_, nil)`, raising and crashing the boot reconcile. No cmd
+    # `expect` here — a shell-out would fail `verify_on_exit!`.
+    test "returns an empty list for a nil prefix WITHOUT shelling (#627)" do
+      assert {:ok, []} = FreeBSD.list_aliases(nil)
+    end
   end
 
   describe "Linux (AnyIP no-op adapter)" do
@@ -136,6 +145,12 @@ defmodule Grappa.Net.SourceAliasTest do
 
     test "list_aliases is empty — AnyIP has no per-address alias to reconcile" do
       assert {:ok, []} = Linux.list_aliases(@prefix)
+    end
+
+    # #627 — the reconcile-safety contract holds for a nil prefix too (mode 2
+    # unconfigured): AnyIP already makes this a no-op for any argument.
+    test "list_aliases is empty for a nil prefix too (#627)" do
+      assert {:ok, []} = Linux.list_aliases(nil)
     end
 
     test "arm_check passes when nonlocal_bind=1 and the AnyIP route is present" do


### PR DESCRIPTION
## The bug (P0 boot blocker)

Refs #627. On the FreeBSD/jail substrate, a **mode-1 DB** (no
`addressing.static_mapping_prefix` — the default of a fresh install or a
pre-#543 restore) crashed the **whole node** at boot. Hit in prod during the
2026-08-02 jail cutover.

`SourceAliasManager.init/1` correctly disarmed mode 2 for a nil prefix, but
`do_reconcile/1` then called `adapter.list_aliases(nil)` **unconditionally**.
The FreeBSD adapter parsed `ifconfig lo0` and filtered `::1` through
`IpLiteral.in_cidr6?(_, nil)`, whose sole clause is `is_binary/1`-guarded on
both args → `FunctionClauseError` in the supervised child's
`{:continue, :reconcile}` → escalated to the app supervisor → BEAM down before
the HTTP listener. **The arm gate guarded the bind decisions, not the
reconcile.**

## The fix

- **Root:** `do_reconcile(%{prefix: nil} = state), do: state` — with no prefix
  there is no block to reconcile against and nothing can be a managed alias, so
  the manager does no reconcile work when mode 2 is unconfigured.
- **Belt-and-braces (neither alone is the fix):**
  `FreeBSD.list_aliases(nil) -> {:ok, []}` (without shelling) keeps the adapter
  contract total; `IpLiteral.in_cidr6?(_, nil) -> false` ("no prefix ⇒ no
  membership"), narrowed to `nil` only so a genuine non-binary caller bug still
  crashes (let-it-crash). Linux/Disabled already return `{:ok, []}` for any arg.

## Tests (TDD — RED first)

Invariant encoded: **a nil/absent `static_mapping_prefix` must NEVER take the
app down.** The bug shipped because the existing nil-prefix manager test stubbed
the Mox adapter's `list_aliases` to tolerate `nil`, masking the real FreeBSD
raise. New regression tests:

- Manager on the **real FreeBSD adapter** with `prefix: nil` boots with no
  `:DOWN` and reconciles to a no-op — reproduced the **exact prod stacktrace**
  RED.
- Adapter-agnostic proof of the **root**: a Mox adapter with no `list_aliases`
  stub, so any boot-path call → `:DOWN` (forces the early-return, not merely a
  defensive adapter clause).
- Unit clauses: `FreeBSD.list_aliases(nil)` / `Linux.list_aliases(nil)` /
  `IpLiteral.in_cidr6?(_, nil)`.

## Gates

`scripts/check.sh` green from the worktree root: ExUnit **4877 tests, 0
failures** (8 doctests, 50 properties), Dialyzer **0 errors**, Credo (strict),
Sobelow, Doctor (292 modules), bats 201/201. DESIGN_NOTES entry added.