### PR TITLE
fix(#502): isolate the boot theme refresh from the dead-token handler

### DIFF
--- a/cicchetto/e2e/tests/crt-splash-font.spec.ts
+++ b/cicchetto/e2e/tests/crt-splash-font.spec.ts
@@ -45,13 +45,14 @@ test("crt splash text is bumped ~30% (#180)", async ({ page }) => {
   // resource is PENDING (not errored) for the lifetime of the test.
   await page.route("**/me", () => new Promise(() => {}));
 
-  // #75 — boot now fires GET /me/theme (customTheme.mountCustomThemeSync)
-  // whenever a token is present. The `**/me` glob does NOT match
-  // `/me/theme`, so against this test's FAKE bearer that request would
-  // hit the real server, 401, and the shared on401 handler would clear
-  // the token → RequireAuth bounces → the frozen splash vanishes. Stub it
-  // to a benign "no active theme" so the freeze holds. (Real specs use
-  // seeded tokens, so their /me/theme 200s.)
+  // #75 — boot fires GET /me/theme (customTheme.mountCustomThemeSync) whenever
+  // a token is present, and the `**/me` glob does NOT match `/me/theme`. Stub it
+  // to a benign "no active theme" so this test never makes a real round-trip
+  // against its FAKE bearer. (Real specs use seeded tokens, so their /me/theme
+  // 200s.) NOTE (#502): this stub is now network-isolation hygiene, NOT a
+  // logout guard — the boot theme refresh no longer shares the dead-token path
+  // (`getActiveThemePair` passes `fireDeadTokenHandler: false`), so even an
+  // un-stubbed 401 here would leave the token intact and the freeze holding.
   await page.route("**/me/theme", (route) =>
     route.fulfill({ status: 200, contentType: "application/json", body: "null" }),
   );

--- a/cicchetto/src/lib/__tests__/themesApi.test.ts
+++ b/cicchetto/src/lib/__tests__/themesApi.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { ApiError } from "../api";
+import { ApiError, setOn401Handler } from "../api";
 import {
   copyTheme,
   createTheme,
@@ -103,7 +103,12 @@ describe("themesApi", () => {
     fetchSpy.mockReset();
     vi.stubGlobal("fetch", fetchSpy);
   });
-  afterEach(() => vi.unstubAllGlobals());
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    // #502 — the isolation tests below install a spy handler; clear it so it
+    // never leaks the dead-token callback into a sibling test or file.
+    setOn401Handler(null);
+  });
 
   test("listGallery GETs /themes and unwraps the themes envelope", async () => {
     fetchSpy.mockResolvedValue(ok({ themes: [sampleTheme()] }));
@@ -217,6 +222,34 @@ describe("themesApi", () => {
     const pair = await getActiveThemePair(TOKEN);
     expect(pair.light?.id).toBe(3);
     expect(pair.dark?.id).toBe(7);
+  });
+
+  // #502 — the boot active-theme refresh is a COSMETIC fetch:
+  // `customTheme.mountCustomThemeSync` fires GET /me/theme on EVERY token
+  // presence (login, reload, cold boot). Like the #449 display-prefs sync, a
+  // cosmetic refresh must NEVER be able to kill a valid session, so its 401 is
+  // ISOLATED from the shared dead-token handler — it still throws (customTheme
+  // keeps its FOUC-free boot cache via the caller's .catch) but does NOT clear
+  // the token. Before the fix, a transient boot 401 logged the user out.
+  test("getActiveThemePair on 401 throws but does NOT fire the on401 dead-token handler", async () => {
+    const on401 = vi.fn();
+    setOn401Handler(on401);
+    fetchSpy.mockResolvedValue(err(401, "unauthorized"));
+
+    await expect(getActiveThemePair(TOKEN)).rejects.toBeInstanceOf(ApiError);
+    expect(on401).not.toHaveBeenCalled();
+  });
+
+  // CONTRAST: on-demand theme verbs stay on the dead-token path — a 401 while
+  // the user is actively managing themes genuinely means the session is dead,
+  // so the fix must NOT blanket-suppress the handler across the whole module.
+  test("CONTRAST: setActiveThemePair (user action) DOES fire the handler on 401", async () => {
+    const on401 = vi.fn();
+    setOn401Handler(on401);
+    fetchSpy.mockResolvedValue(err(401, "unauthorized"));
+
+    await expect(setActiveThemePair(TOKEN, 1, null)).rejects.toBeInstanceOf(ApiError);
+    expect(on401).toHaveBeenCalledTimes(1);
   });
 
   test("setActiveThemePair PUTs /me/theme with the {light,dark} pair", async () => {

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -1332,10 +1332,17 @@ export function setOn401Handler(fn: (() => void) | null): void {
 // the dead-token detection for those verbs.
 //
 // `fireDeadTokenHandler` (default true) gates ONLY the on401 side effect, not
-// the decoding. Pass `false` for boot-APPLIED cosmetic fetches (#449
-// display-prefs sync fires on every token presence) whose transient 401 must
-// NEVER clear a valid session's token — they still throw the decoded `ApiError`
-// so the caller can keep its boot cache, but they do not log the user out.
+// the decoding. THE RULE (#449, #502): pass `false` for boot-APPLIED cosmetic
+// fetches — the ones a `mount*Sync` effect fires on EVERY token presence, whose
+// failure mode is "the UI looks slightly wrong", NOT "the session is gone".
+// Today that is the #449 display-prefs sync (`getDisplayPrefs`/`putDisplayPrefs`)
+// and the #502 active-theme refresh (`getActiveThemePair`). Their transient 401
+// must NEVER clear a valid session's token — they still throw the decoded
+// `ApiError` so the caller keeps its boot cache, but they do not log the user
+// out. Everything else keeps the default: session-validating GETs (`/me`) and
+// on-demand user-action verbs, where a 401 genuinely means the token is dead.
+// A NEW boot cosmetic fetch MUST pass `false`, or a flaky-connection 401 at
+// boot will spuriously log the user out.
 export async function readError(res: Response, fireDeadTokenHandler = true): Promise<ApiError> {
   if (res.status === 401 && fireDeadTokenHandler && on401Handler !== null) on401Handler();
   let body: Record<string, unknown> = {};

--- a/cicchetto/src/lib/themesApi.ts
+++ b/cicchetto/src/lib/themesApi.ts
@@ -1,7 +1,12 @@
 // Typed REST client for the #75 themes surface. Mirrors `api.ts` and
 // reuses its `buildHeaders` (JSON + x-grappa-client-id) and `readError`
 // (wire-token → `ApiError.code`, plus the shared 401 dead-token handler)
-// so these verbs behave identically to the rest of the REST surface.
+// so these verbs behave identically to the rest of the REST surface —
+// with ONE deliberate exception: `getActiveThemePair` is a boot-APPLIED
+// cosmetic fetch and opts OUT of the dead-token handler (#502). The rule:
+// a boot fetch whose failure mode is "the UI looks slightly wrong" must
+// never share the dead-token path with fetches whose failure mode is "the
+// session is genuinely gone". See its comment + the `readError` moduledoc.
 //
 // Keep the wire shapes in lockstep with `lib/grappa/themes/wire.ex`
 // (`ThemesWireT`, generated in `wireTypes.ts`) and the token vocabulary
@@ -204,9 +209,19 @@ export type ActiveThemePair = {
 
 // GET /me/theme — the resolved pair. A bare `null` body (no theme set, or a
 // benign test stub) resolves to an empty pair so callers never branch on it.
+//
+// #502 — ISOLATED from the dead-token handler (`fireDeadTokenHandler: false`):
+// this is a boot-APPLIED cosmetic fetch (`customTheme.mountCustomThemeSync`
+// fires it on EVERY token presence — login, reload, cold boot), so a transient
+// 401 must NOT clear a valid session's token. Doing so also defeated the
+// caller's own tolerant `.catch`, which is written to keep the FOUC-free boot
+// cache on a transient failure. It still throws the decoded `ApiError` so that
+// catch runs. Mirrors the #449 display-prefs isolation; contrast the on-demand
+// theme verbs above/below, which KEEP the handler — a 401 while the user is
+// actively managing themes genuinely means the session is dead.
 export async function getActiveThemePair(token: string): Promise<ActiveThemePair> {
   const res = await fetch("/me/theme", { headers: buildHeaders(token) });
-  if (!res.ok) throw await readError(res);
+  if (!res.ok) throw await readError(res, false);
   const body = (await res.json()) as ActiveThemePair | null;
   return body ?? { light: null, dark: null };
 }


### PR DESCRIPTION
## The bug (P1)

`customTheme.mountCustomThemeSync` fires `getActiveThemePair()` (GET `/me/theme`) reactively on **every token presence** — login, reload, cold boot. It decoded errors through `readError(res)` with the default `fireDeadTokenHandler = true`, so a **transient 401** fired the shared `on401Handler()`, cleared the bearer, and logged the user out of a session that was perfectly valid. The caller's own tolerant `.catch` (written to keep the FOUC-free boot cache on a transient failure) was defeated — the token was already gone by the time it ran. Worst on a flaky connection or right after a token refresh, and invisible in logs as anything but "user logged out".

This is the `#75` instance of the exact class `#449` already fixed for its display-prefs boot sync.

## The fix (a rule, not a call-site patch)

Follow the shape `#449` landed — the `fireDeadTokenHandler` flag on the one shared decoder — do **not** invent a second pattern:

- `getActiveThemePair` now passes `readError(res, false)`: a transient boot 401 **still throws** the decoded `ApiError` (so the caller keeps its boot cache) but **no longer clears the session token**.
- The distinction is made **explicit at the seam**: `readError`'s moduledoc now states the cosmetic-vs-session rule as policy — *"A NEW boot cosmetic fetch MUST pass `false`"* — naming both current members of the class (`#449` display-prefs, `#502` theme). `themesApi`'s moduledoc flags the one deliberate opt-out.
- On-demand theme verbs (`setActiveThemePair`, `createTheme`, edit, …) **keep the default handler** — a 401 while the user is actively managing themes genuinely means the session is dead. Guarded by a **CONTRAST** test so the fix can't silently over-broaden.

## Audit of the other boot-time fetches (issue asked for it)

| boot fetch | path | failure mode | verdict |
| --- | --- | --- | --- |
| `getActiveThemePair` GET `/me/theme` | `mountCustomThemeSync` | UI theme wrong | **fixed here** |
| `getDisplayPrefs`/`putDisplayPrefs` | `mountDisplayPrefsSync` | UI prefs wrong | already isolated (`#449`) ✅ |
| `me()` GET `/me` | `mountBadgeReconcile` | session genuinely gone | correctly keeps handler ✅ |
| `postPushSubscription` POST | `installPushResubscribe` (boot + resume) | notifications degrade | **related near-miss — not fixed here** |

**Reported near-miss (not fixed):** `installPushResubscribe` fires a RENEW-ONLY `ensurePushSubscription` at boot + on resume, which can reach `postPushSubscription` → `readError(res)` (default `true`). A transient 401 there would also spuriously log the user out. It is **not** a one-line flag flip like `#502`: `postPushSubscription` is shared between this boot path **and** the user-action `enablePush`, so it needs a caller-level decision, not a module-level one. Its failure mode ("notifications degrade") is also outside `#502`'s "the UI looks slightly wrong" class. Flagging for a follow-up issue rather than conflating it here.

**The tell, confirmed:** `crt-splash-font.spec.ts` already stubbed `/me/theme` precisely because the real call could take the session down — the workaround the issue predicted. Its comment now records that the stub is network-isolation hygiene, **not** a logout guard (the fix removes the hazard); the stub is retained as a non-load-bearing safety net.

## Tests / gates

- **RED → GREEN**: new `themesApi.test.ts` test proved red on `main` (`on401` fired once), green after the fix; **CONTRAST** test pins that user-action verbs keep the handler.
- `bun run test`: **211 files, 3780 tests green**.
- `bun run check` (biome + tsc): exit 0, 0 TS errors. `bun run build` (real tsc gate + vite): exit 0.
- Code-reviewed (10x code-reviewer): correct, well-scoped, no blocking issues.

Refs #502