### PR TITLE
docs(#391): record cut-the-version-first release ordering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -615,9 +615,12 @@ is due. Don't just look at todo.md.
 3. **Merge BEFORE deploy, push BEFORE prod.** Prod is the **m42
    bastille jail** — `scripts/deploy-m42.sh` (server, auto hot/cold)
    / `--cic` (bundle only). The jail pulls origin/main, so: rebase
-   worktree onto main → merge to main → push origin main →
-   remove the now-merged worktree + delete its branch (step 0) →
-   deploy-m42 → verify health. Invoke deploy scripts by ABSOLUTE
+   worktree onto main → merge to main → remove the now-merged worktree +
+   delete its branch (step 0) → **bump `mix.exs @version` as the LAST
+   commit** → tag → push origin main → deploy-m42 → verify health. The
+   bump rides IN, never after — `Version.base/0` reads the compiled
+   `:vsn` so a hot reload never refreshes it (#391) and a `mix.exs`
+   change forces COLD regardless. Invoke deploy scripts by ABSOLUTE
    path (`/srv/grappa/scripts/…`) — cwd drift runs another
    checkout's copy. `scripts/deploy.sh` (Docker) drives the LOCAL
    dev stack only; nothing production runs on the pi.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -498,7 +498,21 @@ problem, defect #9) is solved differently here: the systemd unit runs
 exits — no custom wrapper needed. See
 `infra/linux/systemd/grappa.service`'s comments for the full rationale.
 
-### Release-cutting (post-deploy) — GitHub release + tag + News/Releases
+### Release-cutting — version-first, then GitHub release + tag + News/Releases
+
+**Cut the version FIRST, deploy SECOND — never bump after (vjt 2026-08-02).**
+The `mix.exs:5 @version` bump MUST ride into the deploy as the **last commit of
+the range being shipped**, be tagged on that commit, and only THEN deployed —
+the version bump is the *pre-deploy* half of release-cutting; the GH release +
+tag + News sequence below is the post-deploy half. WHY it cannot be bumped
+after: `Version.base/0` reads the **compiled `:vsn`**, so a HOT reload never
+refreshes the version string (that is the #391 bug); and `Preflight.mix_deps?`
+classifies any `mix.exs` change as **COLD**, so the bump forces an
+otherwise-hot range cold regardless — there is no "hot-patch the version"
+shortcut. Corollary: an **unplanned** prod move (a migration, a jail cutover)
+is something you version BEFORE, not after — a cutover that ships N commits
+while `mix.exs` still reads the old version is NOT corrected by a second cold
+restart to fix a string; the correct fix is to have bumped first.
 
 Standing order (vjt 2026-07-24): a batch deploy is not "done" until a GitHub
 release is cut AND the site's News/Releases entry is committed. After a **batch


### PR DESCRIPTION
## What

Records vjt's ruling (2026-08-02) in the living docs: **cut the version FIRST, deploy SECOND — never bump after.**

- **`docs/OPERATIONS.md`** — folded into the Release-cutting section as the *pre-deploy* half (the GH release + tag + News sequence is the post-deploy half). Header widened from "(post-deploy)" to "version-first, then …" for accuracy.
- **`CLAUDE.md`** — one minimal line in the Development Cycle step-3 deploy ordering. ⚠️ vjt's text — kept intentionally tiny for review.

## Why

The `mix.exs:5 @version` bump must ride into the deploy as the **last commit of the shipped range**:

- `Version.base/0` reads the **compiled `:vsn`**, so a HOT reload never refreshes the reported version string — that is the #391 bug.
- `Preflight.mix_deps?` classifies any `mix.exs` change as **COLD**, so a version bump forces an otherwise-hot range cold regardless. There is no hot-patch-the-version shortcut.
- Therefore an **unplanned** prod move (a migration, a jail cutover) is versioned BEFORE, not after. Tonight's cutover shipped a batch while `mix.exs` still read the old version; the correct fix is to have bumped first, not a second cold restart to correct a string.

Docs-only. No code, no deps.

Refs #391