### PR TITLE
fix(#637): correlate token-less service CTCP PING replies + guard the leak

### DIFF
--- a/cicchetto/e2e/tests/issue637-service-ping.spec.ts
+++ b/cicchetto/e2e/tests/issue637-service-ping.spec.ts
@@ -1,0 +1,39 @@
+// Issue #637 — /ping <service> (NickServ) never renders the RTT line, while
+// /ping <human> works in the same session. The full round-trip regression gate
+// (compose → REST → real NickServ echo → WS → render) — the acceptance proof
+// jsdom + hand-fed unit tests cannot give.
+//
+// ROOT CAUSE (measured against the live azzurra-services on the bahamut-test
+// hub): NickServ answers a CTCP PING with a BARE `\x01PING\x01`, DROPPING the
+// token — unlike a normal client (or shottino), which echoes the token
+// verbatim. grappa routes the CTCP-framed reply to $server and hands cic an
+// EMPTY `ctcp_args`; pre-#637 the token-keyed pending entry never matched an
+// empty token, so the RTT never rendered (while /ping <human> did — the exact
+// human control the report cites). The fix: cic's pingCorrelation falls back to
+// the most-recent pending ping to that (network, nick) for a TOKEN-LESS reply.
+//
+// If NickServ ever stops echoing, this goes red loudly (element-not-found)
+// rather than silently passing — the #78 "green while broken" trap.
+
+import { expect, test } from "../fixtures/test";
+import { composeSend, composeTextarea, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+test("#637 — /ping NickServ (a real service, token-less echo) renders the round-trip line", async ({ page }) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+  await expect(composeTextarea(page)).toBeVisible();
+
+  // /ping NickServ from #bofh. NickServ echoes a TOKEN-LESS CTCP PING; grappa
+  // routes the CTCP-framed reply to $server; cic's correlation gate falls back
+  // to the pending ping by nick and synthesises the RTT row in the source
+  // window (#bofh).
+  await composeSend(page, "/ping NickServ");
+
+  await expect(
+    scrollbackLine(page, "notice", /CTCP PING reply from NickServ: \d+ ms/),
+  ).toBeVisible({ timeout: 20_000 });
+});

--- a/cicchetto/src/__tests__/pingCorrelation.test.ts
+++ b/cicchetto/src/__tests__/pingCorrelation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { channelKey } from "../lib/channelKey";
-import { registerPing, resolvePing } from "../lib/pingCorrelation";
+import { PENDING_TTL_MS, registerPing, resolvePing } from "../lib/pingCorrelation";
 
 // #591 — the /ping reply-correlation table. Pure register/resolve with time
 // passed in explicitly (sentAtMs at register, nowMs at resolve) so the RTT
@@ -40,14 +40,86 @@ describe("pingCorrelation", () => {
     expect(resolvePing(1, "carol", "tok-c", 3060)).toBeNull();
   });
 
-  it("does not match across networks or tokens", () => {
+  it("does not match across networks or NON-EMPTY tokens", () => {
     registerPing(1, "dave", "tok-d", channelKey("freenode", "dave"), "dave", 4000);
 
     // Wrong network id.
     expect(resolvePing(2, "dave", "tok-d", 4010)).toBeNull();
-    // Wrong token.
+    // Wrong (but present) token still misses — the token invariant holds for a
+    // well-behaved peer; only a TOKEN-LESS reply falls back (see #637 below).
     expect(resolvePing(1, "dave", "tok-other", 4010)).toBeNull();
     // The real one still resolves.
     expect(resolvePing(1, "dave", "tok-d", 4010)).not.toBeNull();
+  });
+
+  // #637 — Azzurra services (NickServ) echo a CTCP PING as a BARE `\x01PING\x01`,
+  // dropping the token, so grappa hands cic an EMPTY ctcp_args. A token-less
+  // reply must still correlate: fall back to the most-recent pending ping to
+  // that (network, folded-nick).
+  it("resolves a TOKEN-LESS reply against the most-recent pending ping to that nick (#637)", () => {
+    registerPing(1, "NickServ", "1706743200000", channelKey("azzurra", "#bofh"), "#bofh", 7000);
+
+    // Reply carries no token (empty string), sender folds to the same nick.
+    expect(resolvePing(1, "nickserv", "", 7050)).toEqual({
+      sourceKey: channelKey("azzurra", "#bofh"),
+      sourceChannel: "#bofh",
+      rttMs: 50,
+    });
+    // One-shot: the fallback deleted it.
+    expect(resolvePing(1, "nickserv", "", 7060)).toBeNull();
+  });
+
+  it("token-less fallback picks the MOST-RECENT ping to the same nick", () => {
+    registerPing(1, "helpserv", "t-old", channelKey("azzurra", "helpserv"), "helpserv", 8000);
+    registerPing(1, "helpserv", "t-new", channelKey("azzurra", "#ops"), "#ops", 8500);
+
+    // Token-less reply resolves the newer entry (source = #ops, rtt from 8500).
+    expect(resolvePing(1, "helpserv", "", 8600)).toEqual({
+      sourceKey: channelKey("azzurra", "#ops"),
+      sourceChannel: "#ops",
+      rttMs: 100,
+    });
+    // The older entry survives (a second token-less reply resolves it).
+    expect(resolvePing(1, "helpserv", "", 8700)).toEqual({
+      sourceKey: channelKey("azzurra", "helpserv"),
+      sourceChannel: "helpserv",
+      rttMs: 700,
+    });
+  });
+
+  it("token-less fallback is nick-scoped — cannot claim another nick's pending entry", () => {
+    registerPing(1, "chanserv", "t-cs", channelKey("azzurra", "#bofh"), "#bofh", 9000);
+
+    // A token-less reply from a DIFFERENT nick we never pinged matches nothing.
+    expect(resolvePing(1, "operserv", "", 9100)).toBeNull();
+    // The real target's own token-less reply still resolves.
+    expect(resolvePing(1, "chanserv", "", 9100)).not.toBeNull();
+  });
+
+  // #637 — the leak guard. Pre-fix the pending entry was one-shot but cleared
+  // ONLY by a matching reply or an identity change, so every unmatched /ping (a
+  // service that never echoes CTCP PING, a typo'd nick, a reply lost to a
+  // netsplit) left an inert entry behind until logout — an unbounded growth
+  // path. registerPing now sweeps entries older than PENDING_TTL_MS, using the
+  // caller-supplied sentAtMs (no wall clock in this module — the spec).
+  it("sweeps a stale pending entry on the next register (leak guard)", () => {
+    registerPing(1, "eve", "tok-e1", channelKey("freenode", "eve"), "eve", 5000);
+
+    // A later /ping registered exactly at the TTL horizon evicts the stale one.
+    registerPing(1, "frank", "tok-f1", channelKey("freenode", "frank"), "frank", 5000 + PENDING_TTL_MS);
+
+    // The stale entry's reply can no longer be correlated (it was swept).
+    expect(resolvePing(1, "eve", "tok-e1", 5000 + PENDING_TTL_MS + 10)).toBeNull();
+    // The fresh one still resolves.
+    expect(resolvePing(1, "frank", "tok-f1", 5000 + PENDING_TTL_MS + 20)).not.toBeNull();
+  });
+
+  it("keeps a pending entry still within the TTL horizon on a later register", () => {
+    registerPing(1, "grace", "tok-g1", channelKey("freenode", "grace"), "grace", 6000);
+
+    // A second register ONE ms inside the horizon must NOT evict the first.
+    registerPing(1, "heidi", "tok-h1", channelKey("freenode", "heidi"), "heidi", 6000 + PENDING_TTL_MS - 1);
+
+    expect(resolvePing(1, "grace", "tok-g1", 6000 + PENDING_TTL_MS)).not.toBeNull();
   });
 });

--- a/cicchetto/src/__tests__/subscribe.test.ts
+++ b/cicchetto/src/__tests__/subscribe.test.ts
@@ -1740,6 +1740,61 @@ describe("subscribe — DM-listener (own-nick topic, inbound DM re-key)", () => 
   // reply neither beeps nor renders in the peer window. cic NEVER parses \x01 —
   // the server SSOT Grappa.IRC.CTCP.verb_args/1 classified the verb into the
   // typed meta; the correlation table (pingCorrelation) does the matching.
+  // #637 — a service's CTCP PING reply is CTCP-framed, so the server routes it to
+  // the synthetic `$server` window (event_router route_non_channel_notice,
+  // 86416a21); cic subscribes to `$server` via installChannelHandler, whose
+  // `routeMessage` runs the `maybeConsumePingReply` gate. THE BUG: Azzurra
+  // services (NickServ) echo a CTCP PING as a BARE `\x01PING\x01` — token
+  // STRIPPED — so grappa hands cic an EMPTY `ctcp_args`. Before #637 that missed
+  // the token-keyed pending entry and rendered raw in $server (while /ping a
+  // human, which echoes the token verbatim, worked the same session). This pins
+  // the real end-to-end path with the REAL token-less service reply.
+  it("#637 — a TOKEN-LESS service CTCP PING reply on $server is consumed into the source window (RTT), no raw $server render", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedDmListenerStubs();
+    const beep = await import("../lib/beep");
+    const { registerPing } = await import("../lib/pingCorrelation");
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalledTimes(3);
+    });
+    // Operator typed `/ping NickServ` in the #grappa window (real timestamp token).
+    const sourceKey = channelKey("freenode", "#grappa");
+    registerPing(1, "NickServ", "9958", sourceKey, "#grappa", 9958);
+    const eventCalls = mockChannel.on.mock.calls.filter((c) => c[0] === "event");
+    // Handler index 2 is the $server handler (channels, dm-listener, $server).
+    const serverHandler = eventCalls[2]?.[1] as (p: unknown) => void;
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(10_000);
+    serverHandler({
+      kind: "message",
+      message: {
+        id: 700,
+        network: "freenode",
+        channel: "$server",
+        server_time: 0,
+        kind: "notice",
+        sender: "NickServ",
+        // The REAL service reply: bare \x01PING\x01, token dropped → empty ctcp_args.
+        body: "\x01PING\x01",
+        meta: { ctcp_verb: "PING", ctcp_args: "" },
+      },
+    });
+    nowSpy.mockRestore();
+    // The synthesized RTT line lands in the SOURCE window (#grappa), not $server.
+    expect(store.scrollbackByChannel()[sourceKey]?.map((m) => m.body)).toEqual([
+      "CTCP PING reply from NickServ: 42 ms",
+    ]);
+    // $server got NOTHING — the token-less reply was swallowed, never rendered raw.
+    expect(store.scrollbackByChannel()[channelKey("freenode", "$server")]).toBeUndefined();
+    // No audible alert for a consumed correlation reply (the $server handler
+    // installs with ownNick=null; consumption precedes any beep path).
+    expect(beep.playBeep).not.toHaveBeenCalled();
+  });
+
   it("CTCP PING reply matching a pending /ping is consumed into the source window (RTT), no beep, no raw render", async () => {
     localStorage.setItem("grappa-token", "tok");
     localStorage.setItem(

--- a/cicchetto/src/lib/pingCorrelation.ts
+++ b/cicchetto/src/lib/pingCorrelation.ts
@@ -18,6 +18,16 @@ import { asciiFold } from "./nickEquals";
 // Ephemeral + identity-scoped: cleared on logout / token rotation, like
 // `inviteAck`. A ping in flight across a logout is simply forgotten — the RTT
 // is an immediate cue, not an audit record.
+//
+// #637 leak guard — the pending entry is one-shot but was cleared ONLY by a
+// matching reply or an identity change. An UNMATCHED /ping (a service that
+// never echoes CTCP PING, a typo'd nick, a reply lost to a netsplit) therefore
+// left an inert entry behind until logout — an unbounded growth path. Each
+// register sweeps entries older than the horizon below (see registerPing), so
+// the table is bounded by the pings issued within the last PENDING_TTL_MS.
+// A reply that arrives past the horizon simply isn't correlated (it renders in
+// its normal $server routing) — a CTCP round-trip that slow is not worth an RTT.
+export const PENDING_TTL_MS = 60_000;
 
 type PendingPing = {
   sourceKey: ChannelKey;
@@ -43,6 +53,15 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     sourceChannel: string,
     sentAtMs: number,
   ): void => {
+    // #637 leak guard — evict entries older than the TTL horizon before
+    // inserting. The horizon is measured against THIS register's sentAtMs (the
+    // caller's clock), keeping the module wall-clock-free (spec). Bounds the
+    // table to the pings issued within the last PENDING_TTL_MS, so a run of
+    // unmatched /pings can no longer accumulate until logout.
+    const horizon = sentAtMs - PENDING_TTL_MS;
+    for (const [key, entry] of pending) {
+      if (entry.sentAtMs <= horizon) pending.delete(key);
+    }
     pending.set(pendingKey(networkId, nick, token), { sourceKey, sourceChannel, sentAtMs });
   };
 
@@ -55,15 +74,39 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     token: string,
     nowMs: number,
   ): { sourceKey: ChannelKey; sourceChannel: string; rttMs: number } | null => {
-    const key = pendingKey(networkId, nick, token);
-    const entry = pending.get(key);
-    if (entry === undefined) return null;
-    pending.delete(key);
-    return {
-      sourceKey: entry.sourceKey,
-      sourceChannel: entry.sourceChannel,
-      rttMs: nowMs - entry.sentAtMs,
+    const resolve = (key: string, entry: PendingPing) => {
+      pending.delete(key);
+      return { sourceKey: entry.sourceKey, sourceChannel: entry.sourceChannel, rttMs: nowMs - entry.sentAtMs };
     };
+
+    // Exact token match first — a well-behaved peer (or shottino) echoes the
+    // token VERBATIM, so this is the precise, disambiguating path.
+    const exactKey = pendingKey(networkId, nick, token);
+    const exact = pending.get(exactKey);
+    if (exact !== undefined) return resolve(exactKey, exact);
+
+    // #637 — TOKEN-LESS reply fallback. Azzurra services (NickServ) answer a
+    // CTCP PING with a BARE `\x01PING\x01`, dropping the token entirely — so the
+    // exact key never matches and `/ping <service>` never rendered its RTT
+    // (while `/ping <human>` did, the same session). ONLY when the reply carries
+    // no token: fall back to the most-recent pending ping to THIS (network,
+    // nick). Still scoped to the same ASCII-folded nick, so a reply cannot claim
+    // another window's entry (the token invariant holds for non-empty tokens: a
+    // wrong-but-present token still misses). Most-recent-wins is the sole
+    // ambiguity, and only when the same nick is pinged twice while in flight.
+    if (token !== "") return null;
+    const nickPrefix = `${networkId}\x00${asciiFold(nick)}\x00`;
+    let bestKey: string | undefined;
+    let best: PendingPing | undefined;
+    for (const [key, entry] of pending) {
+      if (!key.startsWith(nickPrefix)) continue;
+      if (best === undefined || entry.sentAtMs > best.sentAtMs) {
+        best = entry;
+        bestKey = key;
+      }
+    }
+    if (best === undefined || bestKey === undefined) return null;
+    return resolve(bestKey, best);
   };
 
   return { registerPing, resolvePing };


### PR DESCRIPTION
Refs #637

## Root cause (measured e2e against the live azzurra-services)

`/ping <service>` (NickServ) never rendered the RTT line while `/ping <human>` worked in the same session. NickServ answers a CTCP PING with a **bare `\x01PING\x01` — it drops the token** — whereas a normal client echoes the token verbatim:

```
:NickServ!service@azzurra.chat NOTICE <me> :␁PING␁     ← token stripped
$server: -NickServ- ␁PING␁                              ← rendered raw, no RTT
```

grappa faithfully routes the CTCP-framed reply to `$server` with an **empty `ctcp_args`**; cic's `pingCorrelation` keys on `(network, folded-nick, token)`, so the empty token missed the pending entry → the reply rendered raw in `$server` and no RTT line appeared. The human control worked precisely because a human echoes the token.

> Note: the framed short-circuit in `event_router route_non_channel_notice` sends **every** CTCP-framed NOTICE to `$server` before the `services_sender?` / `query_window_open?` branches, so this is not a query-window re-key issue — it is purely token-less correlation on the client.

## Fix

`cic pingCorrelation.resolvePing`: exact `(nick, token)` match first (the precise path a well-behaved peer takes). On a miss **and an empty token**, fall back to the most-recent pending ping to that `(network, ASCII-folded nick)`. Still nick-scoped, so a reply cannot claim another window's entry, and the token invariant holds for any non-empty token (a wrong-but-present token still misses).

## Leak (second defect from the issue)

The pending entry was one-shot but cleared only by a match or an identity change, so every unmatched `/ping` (a service that never echoes, a typo'd nick, a netsplit) leaked an inert entry until logout. `registerPing` now sweeps entries older than `PENDING_TTL_MS` (60s) before inserting, keyed on the caller's `sentAtMs` so the module stays wall-clock-free.

## Coverage

- **e2e** `issue637-service-ping.spec.ts` — drives cic → REST → **real token-less NickServ echo** → WS → render and asserts the visible `CTCP PING reply from NickServ: N ms` row. Red before the fix (20s timeout, element not found), green after (1.3s). Goes red loudly if NickServ ever stops echoing.
- **unit** `pingCorrelation.test.ts` — token-less fallback (most-recent + nick-scoped), the leak sweep, and the preserved non-empty-token invariant.
- **unit** `subscribe.test.ts` — the `$server` consume path with the real token-less reply (the prior #591 unit test only fired the DM-listener arm, a path the server never feeds a framed notice).

## Gates

- full cic vitest **3794/3794**
- `bun.sh run build` (tsc) green
- e2e green against the live stack