### PR TITLE
feat(#640): route CTCP query self-echo to the source window

### DIFF
--- a/cicchetto/e2e/tests/issue640-ping-self-echo.spec.ts
+++ b/cicchetto/e2e/tests/issue640-ping-self-echo.spec.ts
@@ -1,0 +1,121 @@
+// Issue #640 — /ctcp + /ping self-echo must land in the SOURCE window, and a
+// CTCP query must NEVER open a query window for the target.
+//
+// Pre-#640 the outbound CTCP self-echo was a plain PRIVMSG addressed to the
+// target: the server persisted it under the target's window AND auto-opened
+// that window (#422 outbound-DM auto-open, server-side), while the RTT line was
+// synthesised separately in the source window (subscribe.ts) — the two halves
+// split across two windows, and pinging anyone (even a nonexistent nick) left a
+// phantom query tab behind. #640 routes the echo to the SOURCE window with the
+// wire recipient in meta.ctcp_target and skips the auto-open (server
+// Session.send_ctcp / cic compose.ts).
+//
+// This is the acceptance gate per the issue: assert the USER-VISIBLE outcome —
+// the echo (and, for a live peer, the RTT) render in the window the operator
+// typed /ping in, and NO query window is opened for the target. jsdom cannot
+// see any of this: it is the compose → REST → self-echo + reply → WS → render
+// path against a real bahamut (feedback_ux_e2e_mandatory).
+
+import { expect, test } from "../fixtures/test";
+import {
+  composeSend,
+  composeTextarea,
+  loginAs,
+  scrollbackLine,
+  selectChannel,
+  sidebarWindow,
+} from "../fixtures/cicchettoPage";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+test("#640 — /ping <nonexistent> echoes in the SOURCE window and opens NO phantom query window", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+  await expect(composeTextarea(page)).toBeVisible();
+
+  // A dedicated per-run victim nick — NEVER the shared vjt subject, and unique
+  // so a phantom left by a regression can't be masked by (or collide with) a
+  // prior run's leftover (#5 blast-radius). Nonexistent on the wire: the server
+  // 401s it to $server, so there is no RTT — the echo is the sole signal, which
+  // is exactly the issue's "/ping <nonexistent> leaves a phantom" scenario.
+  const victim = `m640-${crypto.randomUUID().slice(0, 6)}`;
+  await composeSend(page, `/ping ${victim}`);
+
+  // The outbound self-echo renders in the SOURCE window (CHANNEL, where /ping
+  // was typed) — the target is read off meta.ctcp_target, not the routing key.
+  // We are viewing CHANNEL, so its visibility here IS "it landed in the source".
+  await expect(
+    scrollbackLine(page, "privmsg", new RegExp(`→ CTCP PING \\d+ to ${victim}`)),
+  ).toBeVisible({ timeout: 10_000 });
+
+  // And NO query window is opened for the victim — the #640 phantom. The echo
+  // above is the barrier: the send is fully processed (persist + broadcast +
+  // any auto-open would have fired), so this absence is meaningful, not a race
+  // that simply hasn't rendered the tab yet.
+  await expect(sidebarWindow(page, NETWORK_SLUG, victim)).toHaveCount(0);
+});
+
+test("#640 — /ping <peer> keeps BOTH the echo and the RTT in the source window, no phantom window", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+  await expect(composeTextarea(page)).toBeVisible();
+
+  // Per-run unique peer nick — a fixed nick is a 433/ghost time bomb under CI
+  // rerun + bahamut per-IP clone/flood (see issue591 for the full rationale),
+  // and doubles as the dedicated victim (#5).
+  const peerNick = `m640-${crypto.randomUUID().slice(0, 5)}`;
+  const peer = await IrcPeer.connect({ nick: peerNick });
+  try {
+    // Arm the peer to echo any CTCP PING token straight back (what a real
+    // client does). No shared channel needed — /ping DMs the nick directly.
+    peer.answerCtcpPing();
+    await composeSend(page, `/ping ${peer.nick}`);
+
+    // The self-echo lands in the SOURCE window (CHANNEL)...
+    await expect(
+      scrollbackLine(page, "privmsg", new RegExp(`→ CTCP PING \\d+ to ${peer.nick}`)),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // ...and so does the RTT reply — the two halves finally converge in ONE
+    // window (the whole point of #640; pre-fix the echo was in a phantom tab).
+    await expect(
+      scrollbackLine(page, "notice", new RegExp(`CTCP PING reply from ${peer.nick}: \\d+ ms`)),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // No query window was ever opened for the peer — a CTCP probe is not a DM.
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(0);
+  } finally {
+    await peer.disconnect("#640 ping done");
+  }
+});
+
+test("#640 — /ctcp <peer> VERSION self-echoes in the SOURCE window, opens no query window", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+  await expect(composeTextarea(page)).toBeVisible();
+
+  // /ctcp to a nick has the identical shape as /ping (the issue's "Same for
+  // /ctcp <target> <VERB>"). A nonexistent per-run victim is enough — VERSION
+  // needs no live replier to prove the echo routing + no-phantom-window.
+  const victim = `m640c-${crypto.randomUUID().slice(0, 6)}`;
+  const tag = crypto.randomUUID().slice(0, 8);
+  await composeSend(page, `/ctcp ${victim} VERSION ${tag}`);
+
+  // Echo in the SOURCE window, target from meta (not the routing key).
+  await expect(
+    scrollbackLine(page, "privmsg", `→ CTCP VERSION ${tag} to ${victim}`),
+  ).toBeVisible({ timeout: 10_000 });
+
+  await expect(sidebarWindow(page, NETWORK_SLUG, victim)).toHaveCount(0);
+});

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -675,9 +675,16 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
       if (typeof ctcpVerb === "string") {
         const ctcpArgs = typeof msg.meta.ctcp_args === "string" ? msg.meta.ctcp_args : "";
         const query = ctcpArgs === "" ? `CTCP ${ctcpVerb}` : `CTCP ${ctcpVerb} ${ctcpArgs}`;
+        // #640 — the echo is now keyed to the SOURCE window (msg.channel), so
+        // the wire recipient travels in meta.ctcp_target: read the target OFF
+        // the message, not the routing key. Fall back to msg.channel for
+        // pre-#640 rows (keyed to the target, no ctcp_target) so historical
+        // echoes still name the right peer.
+        const ctcpTarget =
+          typeof msg.meta.ctcp_target === "string" ? msg.meta.ctcp_target : msg.channel;
         return (
           <span class="scrollback-body">
-            → {query} to {msg.channel}
+            → {query} to {ctcpTarget}
           </span>
         );
       }

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -380,47 +380,79 @@ describe("ScrollbackPane", () => {
     expect(line.textContent ?? "").not.toContain("ACTION ");
   });
 
-  it("renders an own outbound CTCP query self-echo as a human line, not raw \\x01 — #591", () => {
+  it("renders an own CTCP query self-echo in the SOURCE window, target read from meta — #591/#640", () => {
     // #591 — the operator's own /ctcp + /ping self-echo back as a :privmsg
     // whose body is the raw \x01VERB args\x01 frame, tagged by the server with
     // typed meta.ctcp_verb / meta.ctcp_args (SSOT Grappa.IRC.CTCP.verb_args/1).
-    // The render layer shows "→ CTCP VERB [args] to <target>" instead of the
-    // raw \x01 the operator would otherwise see in the window they typed in.
+    // The render shows "→ CTCP VERB [args] to <target>" instead of the raw \x01.
     // cic reads the TYPED meta, never \x01 (the "one IRC parser" invariant).
-    // The e2e (M-591) pins the same against a real send.
+    //
+    // #640 — the echo is keyed to the SOURCE window the command was typed in
+    // (msg.channel = "#grappa"), and the wire recipient rides meta.ctcp_target
+    // ("bob"). The render MUST read the target OFF the message, not the routing
+    // key. This fixture pins channel (the source) DISTINCT from the target —
+    // exactly the conflation (channel == target) the pre-#640 fixture baked in,
+    // which is what hid the split-window bug. Never assert the buggy shape.
     const ctcpSelfEcho: ScrollbackMessage[] = [
       {
         id: 1,
         network: "freenode",
-        channel: "#grappa",
+        channel: "#grappa", // SOURCE window (where /ctcp was typed)
         server_time: 1,
         kind: "privmsg",
         sender: "alice",
         body: "\x01VERSION\x01",
-        meta: { ctcp_verb: "VERSION", ctcp_args: "" },
+        meta: { ctcp_verb: "VERSION", ctcp_args: "", ctcp_target: "bob" }, // wire recipient
       },
       {
         id: 2,
         network: "freenode",
-        channel: "#grappa",
+        channel: "#grappa", // SOURCE window
         server_time: 2,
         kind: "privmsg",
         sender: "alice",
         body: "\x01PING 1706743200000\x01",
-        meta: { ctcp_verb: "PING", ctcp_args: "1706743200000" },
+        meta: { ctcp_verb: "PING", ctcp_args: "1706743200000", ctcp_target: "bob" },
       },
     ];
     setScrollback({ "freenode #grappa": ctcpSelfEcho });
     render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
     const lines = screen.getAllByTestId("scrollback-line");
     expect(lines).toHaveLength(2);
-    // No-arg verb → "→ CTCP VERSION to #grappa"; the raw \x01 never renders.
+    // Target is the wire recipient (bob), read from meta.ctcp_target — NOT the
+    // routing key (#grappa, the source window). The raw \x01 never renders.
     expect(lines[0]?.dataset.kind).toBe("privmsg");
-    expect(lines[0]).toHaveTextContent("→ CTCP VERSION to #grappa");
+    expect(lines[0]).toHaveTextContent("→ CTCP VERSION to bob");
+    // The source window name must NEVER appear as the target (the #640 bug).
+    expect(lines[0]?.textContent ?? "").not.toContain("#grappa");
     expect(lines[0]?.textContent ?? "").not.toContain("\x01");
-    // Arg-carrying verb → the token rides after the verb.
-    expect(lines[1]).toHaveTextContent("→ CTCP PING 1706743200000 to #grappa");
+    // Arg-carrying verb → the token rides after the verb, still to bob.
+    expect(lines[1]).toHaveTextContent("→ CTCP PING 1706743200000 to bob");
+    expect(lines[1]?.textContent ?? "").not.toContain("#grappa");
     expect(lines[1]?.textContent ?? "").not.toContain("\x01");
+  });
+
+  it("falls back to the routing key for a pre-#640 echo with no ctcp_target", () => {
+    // Backward-compat: rows persisted before #640 were keyed to the TARGET
+    // (msg.channel) and carry no meta.ctcp_target. The render falls back to
+    // msg.channel so a historical "/ctcp #chan VERSION" echo still names the
+    // right peer instead of a blank/undefined target.
+    const legacy: ScrollbackMessage[] = [
+      {
+        id: 1,
+        network: "freenode",
+        channel: "#chan",
+        server_time: 1,
+        kind: "privmsg",
+        sender: "alice",
+        body: "\x01VERSION\x01",
+        meta: { ctcp_verb: "VERSION", ctcp_args: "" }, // no ctcp_target (pre-#640 row)
+      },
+    ];
+    setScrollback({ "freenode #chan": legacy });
+    render(() => <ScrollbackPane networkSlug="freenode" channelName="#chan" kind="channel" />);
+    const lines = screen.getAllByTestId("scrollback-line");
+    expect(lines[0]).toHaveTextContent("→ CTCP VERSION to #chan");
   });
 
   it("renders the action row with one space between '*' and the nick (not two) — #457", () => {

--- a/cicchetto/src/__tests__/api.test.ts
+++ b/cicchetto/src/__tests__/api.test.ts
@@ -402,6 +402,49 @@ describe("postTopic / postNick", () => {
   });
 });
 
+describe("sendMessage ctcp_target wire field (#640)", () => {
+  const okRow = JSON.stringify({
+    id: 1,
+    network: "azzurra",
+    channel: "#italia",
+    server_time: 0,
+    kind: "privmsg",
+    sender: "vjt",
+    body: "x",
+    meta: {},
+  });
+
+  it("a plain send POSTs { body } only — no ctcp_target (byte-identical to pre-#640)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(okRow, { status: 201 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.sendMessage("tok", "azzurra", "#italia", "ciao");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/networks/azzurra/channels/%23italia/messages",
+      expect.objectContaining({ method: "POST", body: JSON.stringify({ body: "ciao" }) }),
+    );
+  });
+
+  it("a CTCP query POSTs { body, ctcp_target } to the SOURCE window URL", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(okRow, { status: 201 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    // /ping bob typed in #italia: the URL channel is the SOURCE window, and the
+    // wire recipient rides the snake_case `ctcp_target` field (the additive wire
+    // token #640 introduces).
+    await api.sendMessage("tok", "azzurra", "#italia", "\x01PING 1\x01", "bob");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/networks/azzurra/channels/%23italia/messages",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ body: "\x01PING 1\x01", ctcp_target: "bob" }),
+      }),
+    );
+  });
+});
+
 describe("ownNickForNetwork (cic H3 fix + bucket F H4 type split)", () => {
   // Per-network IRC nick resolver — single source of truth for the
   // "what's my IRC nick on THIS network" question. Replaces the

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -370,10 +370,12 @@ describe("compose submit — slash command dispatch", () => {
     expect(result).toEqual({ ok: true });
   });
 
-  // #591 — /ctcp <target> <verb> reuses the /me framing seam to build a single
-  // \x01VERB\x01 frame, sent to the EXPLICIT target (not the current window).
-  // No args → no trailing space inside the frame.
-  it("/ctcp <target> <verb> sends \\x01VERB\\x01 to the target (#591)", async () => {
+  // #591/#640 — /ctcp <target> <verb> builds a single \x01VERB\x01 frame. #640:
+  // a CTCP QUERY is a control-surface probe, so the echo is keyed to the SOURCE
+  // window (the submit's channelName, "#a") and the wire recipient ("bob")
+  // rides the 4th `ctcpTarget` arg — NOT sent to the target as a DM (which
+  // spawned the phantom window). No args → no trailing space inside the frame.
+  it("/ctcp <target> <verb> echoes in the SOURCE window with ctcpTarget (#591/#640)", async () => {
     localStorage.setItem("grappa-token", "tok");
     const sb = await import("../lib/scrollback");
     vi.mocked(sb.sendMessage).mockResolvedValue();
@@ -383,13 +385,16 @@ describe("compose submit — slash command dispatch", () => {
     compose.setDraft(k, "/ctcp bob version");
     const result = await compose.submit(k, "freenode", "#a");
 
-    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "bob", "\x01VERSION\x01");
+    // source window "#a", frame, ctcpTarget "bob" — the recipient is NOT the
+    // send channel anymore (that is the whole #640 fix).
+    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "\x01VERSION\x01", "bob");
     expect(result).toEqual({ ok: true });
   });
 
-  // #591 — /ctcp <target> <verb> <args> frames \x01VERB args\x01 (single space
-  // after the verb), preserving arg case + interior spaces.
-  it("/ctcp <target> <verb> <args> frames \\x01VERB args\\x01 (#591)", async () => {
+  // #640 — ACTION is the exception: it IS conversation (/me to an explicit
+  // target), so it rides the normal send path INTO the target window (3 args,
+  // no ctcpTarget), exactly as before #640. The parser upper-cases the verb.
+  it("/ctcp <target> ACTION <args> sends to the TARGET window as conversation (#591/#640)", async () => {
     localStorage.setItem("grappa-token", "tok");
     const sb = await import("../lib/scrollback");
     vi.mocked(sb.sendMessage).mockResolvedValue();
@@ -399,6 +404,7 @@ describe("compose submit — slash command dispatch", () => {
     compose.setDraft(k, "/ctcp #chan action waves at Everyone");
     const result = await compose.submit(k, "freenode", "#a");
 
+    // Target #chan, no 4th arg — an action belongs in the target's window.
     expect(sb.sendMessage).toHaveBeenCalledWith(
       "freenode",
       "#chan",
@@ -423,8 +429,15 @@ describe("compose submit — slash command dispatch", () => {
     compose.setDraft(k, "/ping bob");
     const result = await compose.submit(k, "freenode", "#a");
 
-    // CTCP PING frame with the timestamp token, to the EXPLICIT target.
-    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "bob", "\x01PING 1706743200000\x01");
+    // #640 — CTCP PING frame with the timestamp token, echoed in the SOURCE
+    // window ("#a") with the wire recipient ("bob") in the 4th ctcpTarget arg —
+    // never a DM to the target (no phantom window).
+    expect(sb.sendMessage).toHaveBeenCalledWith(
+      "freenode",
+      "#a",
+      "\x01PING 1706743200000\x01",
+      "bob",
+    );
     // Pending registered: (networkId, nick, token, sourceKey, sourceChannel, sentAtMs).
     expect(pc.registerPing).toHaveBeenCalledWith(1, "bob", "1706743200000", k, "#a", 1706743200000);
     expect(result).toEqual({ ok: true });
@@ -466,7 +479,13 @@ describe("compose submit — slash command dispatch", () => {
 
     // THE RACE: with the send still unresolved, a reply arriving now MUST find a
     // registered pending entry. Pre-fix (register AFTER the await) this is 0 calls.
-    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "bob", "\x01PING 1706743200000\x01");
+    // #640 — the send targets the SOURCE window ("#a") with ctcpTarget "bob".
+    expect(sb.sendMessage).toHaveBeenCalledWith(
+      "freenode",
+      "#a",
+      "\x01PING 1706743200000\x01",
+      "bob",
+    );
     expect(pc.registerPing).toHaveBeenCalledWith(1, "bob", "1706743200000", k, "#a", 1706743200000);
 
     releaseSend();

--- a/cicchetto/src/__tests__/scrollback.test.ts
+++ b/cicchetto/src/__tests__/scrollback.test.ts
@@ -243,7 +243,42 @@ describe("scrollback verbs", () => {
     });
     const scrollback = await import("../lib/scrollback");
     await scrollback.sendMessage("freenode", "#grappa", "hello world");
-    expect(api.sendMessage).toHaveBeenCalledWith("tok", "freenode", "#grappa", "hello world");
+    // #640 — a plain send carries NO ctcp_target: the pass-through forwards it
+    // as `undefined`, so api.sendMessage's payload stays `{ body }` (byte-
+    // identical to the pre-#640 request). A CTCP query would pass a 5th arg.
+    expect(api.sendMessage).toHaveBeenCalledWith(
+      "tok",
+      "freenode",
+      "#grappa",
+      "hello world",
+      undefined,
+    );
+  });
+
+  it("sendMessage forwards ctcpTarget to api.sendMessage for a CTCP query — #640", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const api = await import("../lib/api");
+    vi.mocked(api.sendMessage).mockResolvedValue({
+      id: 2,
+      network: "freenode",
+      channel: "#grappa",
+      server_time: 0,
+      kind: "privmsg",
+      sender: "alice",
+      body: "\x01PING 123\x01",
+      meta: {},
+    });
+    const scrollback = await import("../lib/scrollback");
+    // #640 — /ping typed in #grappa (source) targeting bob (wire recipient):
+    // the source window rides the `channel` arg, the recipient the 5th.
+    await scrollback.sendMessage("freenode", "#grappa", "\x01PING 123\x01", "bob");
+    expect(api.sendMessage).toHaveBeenCalledWith(
+      "tok",
+      "freenode",
+      "#grappa",
+      "\x01PING 123\x01",
+      "bob",
+    );
   });
 
   // Bucket D — post-success cursor advance. The id from the 201 body

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -1991,18 +1991,27 @@ export async function listMessagesAfter(
 // id from this body and let the WS echo own the insert. Reading the
 // body for any other purpose risks double-rendering on the race where
 // WS lands first.
+//
+// #640 — `ctcpTarget` turns this into a CTCP QUERY send (/ctcp, /ping): the
+// URL `channelName` is the SOURCE window the echo renders in, and `ctcpTarget`
+// is the wire recipient. The server persists the echo to the source window
+// (NOT a query window for the recipient) and relays the frame to `ctcpTarget`.
+// Absent (a plain PRIVMSG) the POST body is unchanged, so every non-CTCP
+// caller is byte-identical to the pre-#640 request.
 export async function sendMessage(
   token: string,
   networkSlug: string,
   channelName: string,
   body: string,
+  ctcpTarget?: string,
 ): Promise<ScrollbackMessage> {
+  const payload = ctcpTarget === undefined ? { body } : { body, ctcp_target: ctcpTarget };
   const res = await fetch(
     `/networks/${encodeURIComponent(networkSlug)}/channels/${encodeURIComponent(channelName)}/messages`,
     {
       method: "POST",
       headers: buildHeaders(token),
-      body: JSON.stringify({ body }),
+      body: JSON.stringify(payload),
     },
   );
   if (!res.ok) throw await readError(res);

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -304,10 +304,29 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         // `ctcpFrame` seam. Non-ACTION CTCP is single-line by convention
         // (Grappa.IRC.LineSplit) so there is no multiline fan-out. AWAIT the
         // send: a CTCP verb MUST NOT silently no-op when the WS is down.
-        case "ctcp":
-          await sendPrivmsg(networkSlug, cmd.target, ctcpFrame(cmd.verb, cmd.args));
+        case "ctcp": {
+          // #640 — a CTCP QUERY (VERSION/PING/TIME/…) is a control-surface
+          // probe, not a conversation: its self-echo renders in the SOURCE
+          // window (`channelName`, where the operator typed it), NEVER a query
+          // window for the recipient. Send to the source window with the wire
+          // recipient in `ctcpTarget`; the server keys the echo to the source,
+          // carries the recipient in `meta.ctcp_target`, and never auto-opens a
+          // window for it.
+          //
+          // ACTION is the exception — it IS conversation (`/me` to an explicit
+          // target), so it belongs in the TARGET window and rides the normal
+          // send path unchanged (the server also rejects an ACTION via the CTCP
+          // route — `Session.send_ctcp`'s non-ACTION gate). The parser
+          // upper-cases the verb; guard case-insensitively regardless.
+          const frame = ctcpFrame(cmd.verb, cmd.args);
+          if (cmd.verb.toUpperCase() === "ACTION") {
+            await sendPrivmsg(networkSlug, cmd.target, frame);
+          } else {
+            await sendPrivmsg(networkSlug, channelName, frame, cmd.target);
+          }
           result = { ok: true };
           break;
+        }
         // #591 — /ping <target>: CTCP PING sugar. The token is a client
         // timestamp; it travels in the frame, comes back verbatim in the
         // reply's server-typed meta.ctcp_args, and the RTT is `now - sentAt`.
@@ -331,8 +350,14 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           if (networkId === undefined) return { error: "/ping: network not found" };
           const sentAtMs = Date.now();
           const token = String(sentAtMs);
+          // registerPing keys the RTT correlation on the SOURCE window
+          // (`key`/`channelName`) so the reply's RTT line lands where /ping was
+          // typed — the SAME window the #640 echo now renders in (the two halves
+          // finally converge).
           registerPing(networkId, cmd.target, token, key, channelName, sentAtMs);
-          await sendPrivmsg(networkSlug, cmd.target, ctcpFrame("PING", token));
+          // #640 — echo to the SOURCE window (`channelName`) with the wire
+          // recipient in `ctcpTarget`; never opens a query window for the peer.
+          await sendPrivmsg(networkSlug, channelName, ctcpFrame("PING", token), cmd.target);
           result = { ok: true };
           break;
         }

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -496,7 +496,18 @@ const exports = identityScopedStore((onIdentityChange) => {
     }
   };
 
-  const sendMessage = async (slug: string, name: string, body: string): Promise<void> => {
+  // #640 — `ctcpTarget` (optional) makes this a CTCP QUERY send: `name` is the
+  // SOURCE window the echo renders in (where the operator typed /ctcp or /ping),
+  // and `ctcpTarget` is the wire recipient. All the own-send bookkeeping
+  // (submit-snap, cursor advance, divider re-latch) is keyed on `name` = the
+  // source window — exactly where the echo + RTT land — so it is byte-identical
+  // to a plain send once `name` is the source. Absent, it is a normal PRIVMSG.
+  const sendMessage = async (
+    slug: string,
+    name: string,
+    body: string,
+    ctcpTarget?: string,
+  ): Promise<void> => {
     const t = token();
     if (!t) return;
     const key = channelKey(slug, name);
@@ -536,7 +547,7 @@ const exports = identityScopedStore((onIdentityChange) => {
     // (networks ↔ selection). Three-line inline body + the doc here
     // is cheaper than hoisting `setCursorIfAdvances` to a leaf module
     // for a single second caller.
-    const row = await apiSendMessage(t, slug, name, body);
+    const row = await apiSendMessage(t, slug, name, body, ctcpTarget);
     // Anti-poison gate (issue #50 / m6, 2026-06-09): only advance the
     // cursor when the local pane already holds a rendered row. Advancing
     // PAST an unrendered row poisons `refreshScrollback`'s resume cursor —

--- a/config/config.exs
+++ b/config/config.exs
@@ -354,6 +354,11 @@ config :logger, :console,
     # no Logger call carries them today.
     :ctcp_verb,
     :ctcp_args,
+    # #640 — the wire recipient of the operator's own outbound CTCP QUERY
+    # self-echo, carried in meta so the echo can be keyed to the SOURCE window
+    # (never a query window for the target). In the allowlist to satisfy the
+    # known_keys↔metadata sync test even though no Logger call carries it today.
+    :ctcp_target,
     # Auth context (Phase 2): bearer-token session lifecycle. `session_ref`
     # is a non-reversible SHA-256 handle of the session-id (S9: the raw id
     # IS the bearer token, so it must NEVER hit the log stream) — it rides

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -26214,3 +26214,69 @@ and the hamburger stays a sibling. The visual proof is device dogfood (Playwrigh
 webkit ≠ iOS) — owed on desktop AND iOS.
 
 Deploy class: cic-only (pure CSS + DOM restructure) → HOT / cic bundle.
+
+## 2026-08-02 — #640: a CTCP probe's 401 must not MINT a query window — the window-existence policy is the server's, the router stays syntactic (CP13 reconciled)
+
+**Bug.** `/ping <nonexistent>` and `/ctcp <peer> VERSION <nonexistent>`
+relay a `PRIVMSG <target> :\x01…\x01` upstream; bahamut answers `401
+ERR_NOSUCHNICK [own_nick, target, "No such nick/channel"]`. `NumericRouter`
+scans the nick-shaped `target` to `{:query, target}`, the server persists a
+`:notice` under `channel = target`, and `maybe_open_query_window/2`
+**auto-opens** a phantom query window for a nick that DOES NOT EXIST — a
+ghost tab. `Session.send_ctcp/5` (the #640 self-echo) was already correct
+(echo to the SOURCE window, `dm_with: nil`, opens no window); the gap was
+this INBOUND 401, invisible to the passing server unit test and caught only
+by the full e2e (`issue640-ping-self-echo`, the `/ping <nonexistent>` +
+`/ctcp … VERSION` cases). The live-peer case passes because a peer's reply
+is a CTCP NOTICE routed to `$server` (the #641 arm), not a 401.
+
+**The CP13 tension — and why the fix does NOT reverse it.** CP13 made
+`NumericRouter` a PURELY SYNTACTIC classifier: `build_router_state/1` stopped
+threading `open_query_nicks`, and `scan_params/2` resolves a nick-shaped
+param to `{:query, target}` on syntax alone, no window knowledge. That
+simplification is load-bearing (the router is a pure, sandbox-free "No Repo"
+function of its `router_state`) — and it is EXACTLY what mints the phantom: a
+syntactic scan cannot know that `/ctcp`'s target has no window while `/msg`'s
+does. The wrong fix is to teach the router about windows (reverses CP13) or
+to deny-list 401 to `$server` unconditionally (see below). The RIGHT fix
+splits the two concerns: **classification stays in the router (syntactic,
+CP13 preserved); the window-existence POLICY lives server-side**, where
+window state already is.
+
+**The gate.** `Session.Server.resolve_numeric_query_window/2` sits between
+`NumericRouter.route/2` and the persist: a `{:query, target}` decision is
+kept only if a query window is already OPEN for `target`
+(`state.query_window_open?` — the same injected predicate, defaulting to
+`QueryWindows.open?/3`, that `EventRouter.service_route_channel/2` uses for
+the identical "route to the window iff already open, else `$server`; never
+auto-open" decision on services traffic); otherwise it falls to `{:server,
+nil}`. `{:channel, _}` and `{:server, nil}` pass through untouched. A numeric
+now lands in an EXISTING conversation or on `$server` — it never MINTS a
+window.
+
+**Two arms, both preserved:**
+* `/ctcp`/`/ping <nonexistent>` — `send_ctcp` opened no window → gate finds
+  none → the 401 lands on `$server` (visible, no phantom, no Archive ghost).
+* `/msg <ghost>` — the outbound-DM auto-open (#422) already opened the query
+  window → gate keeps `{:query, ghost}` → the 401 "No such nick/channel"
+  lands IN that window as live feedback. This is the 2026-05-10
+  operator-action-echo behavior ("the operator must SEE the failure inline in
+  the query window") and the `cp13-s5-msg-ghost-401` e2e — both intact.
+
+**Why not deny-list 401 to `$server` (the rejected first attempt).** It fixes
+the phantom but REGRESSES the `/msg` arm: the error leaves the DM window the
+operator is staring at. #640 never asked to move `/msg`'s feedback, and doing
+it would require rewriting a legitimate test (`cp13-s5-msg-ghost-401`) — which
+is precisely what we do not do. The gate is superior: it is the root-cause
+class fix (no numeric ever mints a window) and it reuses the established
+`query_window_open?` seam rather than a per-numeric deny-list whack-a-mole.
+
+**Tests.** `NumericRouter` stays syntactic, so `numeric_router_test`'s
+`401 → {:query, target}` scan tests are UNCHANGED (they pin the router's
+correct contract; the policy is tested elsewhere). The behavioral
+reproduction lives at the right layer in `server_test.exs`: a raw 401 with NO
+open window → `$server` (no phantom); the same 401 WITH an open window (opened
+via a real `send_privmsg`) → lands in that window. Falsification: revert
+`resolve_numeric_query_window/2` (or make it identity) ⇒ the no-window
+server_test and the `issue640-ping-self-echo` e2e go RED. The e2e assert is
+the acceptance gate and stays untouched.

--- a/lib/grappa/scrollback/meta.ex
+++ b/lib/grappa/scrollback/meta.ex
@@ -118,6 +118,17 @@ defmodule Grappa.Scrollback.Meta do
                                                                   verb with no argument. ACTION is NOT
                                                                   tagged here — it rides its own :action
                                                                   kind.)
+      :privmsg (CTCP query echo)    →  + %{ctcp_target: String.t()}
+                                                                 (#640: the operator's OWN outbound CTCP
+                                                                  QUERY self-echo (/ctcp, /ping) is keyed
+                                                                  to the SOURCE window it was typed in, NOT
+                                                                  the wire recipient — a control-surface
+                                                                  probe never opens a query window. The
+                                                                  wire recipient rides here so the render
+                                                                  shows "→ CTCP VERB args to <ctcp_target>"
+                                                                  off the message, not off the routing key
+                                                                  (`channel`). Present alongside
+                                                                  ctcp_verb/ctcp_args on such echoes.)
 
   Phase 1 only writes `:privmsg` rows where `meta = %{}` so Phase 1
   exercises only the empty-map path. The allowlist + atomization is
@@ -155,10 +166,11 @@ defmodule Grappa.Scrollback.Meta do
             | :sender_prefix
             | :ctcp_verb
             | :ctcp_args
+            | :ctcp_target
           ) => term()
         }
 
-  @known_keys ~w[target new_nick modes args numeric severity who who_target names names_target raw_verb raw_sender raw_params sender_user sender_host sender_prefix ctcp_verb ctcp_args]a
+  @known_keys ~w[target new_nick modes args numeric severity who who_target names names_target raw_verb raw_sender raw_params sender_user sender_host sender_prefix ctcp_verb ctcp_args ctcp_target]a
 
   @doc """
   The atom-key allowlist. Exposed so the test suite can assert that
@@ -185,7 +197,8 @@ defmodule Grappa.Scrollback.Meta do
           | :sender_host
           | :sender_prefix
           | :ctcp_verb
-          | :ctcp_args,
+          | :ctcp_args
+          | :ctcp_target,
           ...
         ]
   def known_keys, do: @known_keys

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -74,7 +74,7 @@ defmodule Grappa.Session do
     ],
     exports: [Backoff, Server, Wire]
 
-  alias Grappa.IRC.{AuthFSM, Identifier}
+  alias Grappa.IRC.{AuthFSM, CTCP, Identifier}
   alias Grappa.Session.Server
 
   require Logger
@@ -554,6 +554,58 @@ defmodule Grappa.Session do
       )
     else
       {:error, :invalid_line}
+    end
+  end
+
+  @doc """
+  #640 — sends the operator's own outbound CTCP QUERY (`/ctcp`, `/ping`) and
+  self-echoes it into the SOURCE window, NEVER a query window for the wire
+  recipient.
+
+  `source` is the display/persist window the command was typed in (cic's URL
+  `channel_id`); `ctcp_target` is the wire recipient. The Session.Server relays
+  `PRIVMSG <ctcp_target> :<body>` upstream, persists the echo keyed to `source`
+  with `dm_with: nil` + `meta.ctcp_target`, and does NOT auto-open a query
+  window — that server-side auto-open (`handle_persisting_send`) is exactly the
+  phantom target window #640 reports.
+
+  `{:error, :invalid_line}` when `source`/`ctcp_target`/`body` carry CRLF/NUL,
+  or when `body` is not a non-ACTION CTCP frame (a plain PRIVMSG must go through
+  `send_privmsg/4`; a `/me` ACTION rides its own kind). `{:error, :no_session}`
+  when no live session. On success `{:ok, %Scrollback.Message{}}` — always
+  persisted (no `:no_persist` arm: the source echo is the whole point, even for
+  a services recipient, which never opened a window either).
+  """
+  @spec send_ctcp(subject(), integer(), String.t(), String.t(), String.t()) ::
+          {:ok, Grappa.Scrollback.Message.t()}
+          | {:error, :no_session | :invalid_line | send_transport_error()}
+          | {:error, Ecto.Changeset.t()}
+  def send_ctcp(subject, network_id, source, ctcp_target, body)
+      when is_subject(subject) and is_integer(network_id) and is_binary(source) and
+             is_binary(ctcp_target) and is_binary(body) do
+    # Injection + shape gates fire BEFORE the registry lookup (mirror
+    # send_privmsg/4): a malformed line against a non-existent session still
+    # surfaces as :invalid_line, and the row is never persisted on rejection.
+    # `body` MUST be a non-ACTION CTCP frame — ctcp_target is meaningless for a
+    # plain PRIVMSG (use send_privmsg/4) or a /me ACTION (rides its own kind).
+    if Identifier.safe_line_token?(source) and Identifier.safe_line_token?(ctcp_target) and
+         Identifier.safe_line_token?(body) and ctcp_query?(body) do
+      call_session(subject, network_id, {:send_ctcp, source, ctcp_target, body})
+    else
+      {:error, :invalid_line}
+    end
+  end
+
+  # #640 — a CTCP QUERY frame: `\x01VERB[ args]\x01` where VERB is not ACTION
+  # (/me's ACTION rides its own :action kind, never a ctcp_target send). The
+  # discriminant is the shared SSOT `Grappa.IRC.CTCP.verb_args/1`, so this
+  # facade gate and the Session.Server meta tag agree on what "is a CTCP query."
+  @spec ctcp_query?(binary()) :: boolean()
+  defp ctcp_query?(body) do
+    case CTCP.verb_args(body) do
+      {"ACTION", _} -> false
+      {_, _} -> true
+      :none -> false
     end
   end
 

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -3229,6 +3229,11 @@ defmodule Grappa.Session.Server do
         trailing = List.last(msg.params)
         sender = Message.sender_nick(msg)
 
+        # #640 — resolve a {:query, target} decision against actual window
+        # existence: a numeric lands in an EXISTING conversation or on $server,
+        # it never MINTS a query window (see resolve_numeric_query_window/2).
+        routing = resolve_numeric_query_window(routing, state)
+
         # Persist the numeric as a `:notice` row in the routed window —
         # iff the trailing param is a string (defensive: malformed numerics
         # with no trailing text are dropped silently rather than crashing
@@ -4187,6 +4192,36 @@ defmodule Grappa.Session.Server do
   # routes to the synthetic `"$server"` window; `{:channel, c}` and
   # `{:query, n}` route directly to the named target. Mirrors
   # `Grappa.Scrollback.Message.@valid_target?` accept set.
+  # #640 — a numeric routing to {:query, target} must land in an EXISTING
+  # query window, never MINT one. `NumericRouter` stays a pure SYNTACTIC
+  # classifier (CP13): it resolves a nick-shaped param to {:query, target}
+  # without knowing whether a window exists. The window-existence POLICY is
+  # the server's — it owns window state — so the gate lives here, using the
+  # SAME `state.query_window_open?` predicate EventRouter's
+  # `service_route_channel/2` uses for the identical "route to the window iff
+  # already open, else $server; never auto-open" decision.
+  #
+  # The concrete bug: a 401 ERR_NOSUCHNICK from a /ctcp or /ping to a
+  # nonexistent nick scans to {:query, target}; with no window open it used
+  # to mint a phantom query window for a nick that does not exist (#640's
+  # e2e). The SAME 401 for a nick the operator has an OPEN window with (they
+  # /msg'd it — the window was opened by the outbound-DM auto-open) belongs
+  # in that window (cp13-s5-msg-ghost-401). The open-window fact splits the
+  # two. {:channel, _} and {:server, nil} pass through untouched.
+  @spec resolve_numeric_query_window(
+          {:channel, String.t()} | {:query, String.t()} | {:server, nil},
+          t()
+        ) :: {:channel, String.t()} | {:query, String.t()} | {:server, nil}
+  defp resolve_numeric_query_window({:query, target}, state) when is_binary(target) do
+    open? = Map.get(state, :query_window_open?, &QueryWindows.open?/3)
+
+    if open?.(state.subject, state.network_id, target),
+      do: {:query, target},
+      else: {:server, nil}
+  end
+
+  defp resolve_numeric_query_window(routing, _), do: routing
+
   @spec routing_to_channel({:channel, String.t()} | {:query, String.t()} | {:server, nil}) ::
           String.t()
   defp routing_to_channel({:channel, c}) when is_binary(c), do: c

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -1631,6 +1631,28 @@ defmodule Grappa.Session.Server do
     end
   end
 
+  # #640 — /ctcp + /ping outbound CTCP QUERY. Unlike a plain PRIVMSG, a CTCP
+  # query to a nick is a control-surface probe, NOT a conversation: its
+  # self-echo belongs in the SOURCE window the operator typed it in (irssi
+  # behavior), and it must NEVER open a query window for the wire recipient.
+  # `source` is the display/persist window (the URL `channel_id` cic POSTed to);
+  # `ctcp_target` is the wire recipient. The wire line goes to `ctcp_target`;
+  # the echo persists+broadcasts keyed to `source`, with `dm_with: nil` and the
+  # recipient in `meta.ctcp_target` so the render reads the target OFF the
+  # message, not the routing key. Crucially: NO `maybe_open_query_window` — that
+  # server-side auto-open (`handle_persisting_send`) is exactly what spawned the
+  # phantom target window #640 reports. Uniform for humans AND services (a
+  # services CTCP query never opened a window either — it just gains the source
+  # echo now, strictly better; the inbound reply routing is unchanged).
+  # (No @impl here — a continuation clause of handle_call/3, whose @impl rides
+  # the {:send_privmsg, …} clause above, mirroring the sibling {:send_topic, …}.)
+  def handle_call({:send_ctcp, source, ctcp_target, body}, _, state)
+      when is_binary(source) and is_binary(ctcp_target) and is_binary(body) do
+    line = "PRIVMSG #{ctcp_target} :#{body}"
+    state = capture_outbound_ns_secret(state, line)
+    handle_ctcp_send(source, ctcp_target, body, state)
+  end
+
   # Sends `TOPIC <channel> :<body>` upstream. NO optimistic persist +
   # broadcast here — issue #22: the upstream IRC server echoes the TOPIC
   # back, EventRouter's unsolicited-TOPIC handler builds the canonical
@@ -3404,6 +3426,50 @@ defmodule Grappa.Session.Server do
 
       {:error, _} = err ->
         {:reply, err, state}
+    end
+  end
+
+  # #640 — persist the CTCP-query self-echo to the SOURCE window + relay the
+  # wire frame to the recipient, WITHOUT opening a query window. A CTCP query is
+  # single-frame (never line-split — splitting a `\x01`-framed body mid-frame
+  # would corrupt it), so this is a deliberately non-fragmenting sibling of
+  # `persist_and_send_fragments`: the wire target (`ctcp_target`) and the
+  # persist key (`fold_key(source)`) are distinct, `dm_with` is nil (control
+  # surface, not a DM), and the meta carries the typed CTCP verb/args PLUS
+  # `ctcp_target` so the render shows "→ CTCP VERB args to <recipient>" off the
+  # message. Reuses the shared `ctcp_self_echo_meta/1` (SSOT
+  # `Grappa.IRC.CTCP.verb_args/1`), `Persistor` (push: false — own outbound
+  # never self-notifies), and `send_privmsg_or_log/3`.
+  @spec handle_ctcp_send(String.t(), String.t(), String.t(), t()) ::
+          {:reply, {:ok, Scrollback.Message.t()} | {:error, term()}, t()}
+  defp handle_ctcp_send(source, ctcp_target, body, state) do
+    key = fold_key(state, source)
+
+    attrs =
+      Session.put_subject_id(
+        %{
+          network_id: state.network_id,
+          # #640 — persist/broadcast KEY is the SOURCE window, network-folded
+          # (NOT the wire recipient); the wire recipient rides `meta.ctcp_target`.
+          channel: key,
+          server_time: System.system_time(:millisecond),
+          kind: :privmsg,
+          sender: state.nick,
+          body: body,
+          meta: Map.merge(ctcp_self_echo_meta(body), %{ctcp_target: ctcp_target}),
+          # #640 — a CTCP query is a control-surface probe, NOT a DM: no dm_with
+          # (so no DM thread), and no `maybe_open_query_window` below (so no
+          # phantom query window for the recipient).
+          dm_with: nil
+        },
+        state.subject
+      )
+
+    with {:ok, message} <- Persistor.persist_and_broadcast(attrs, state, push: false),
+         :ok <- send_privmsg_or_log(state.client, ctcp_target, body) do
+      {:reply, {:ok, message}, state}
+    else
+      {:error, _} = err -> {:reply, err, state}
     end
   end
 

--- a/lib/grappa_web/controllers/messages_controller.ex
+++ b/lib/grappa_web/controllers/messages_controller.ex
@@ -12,7 +12,12 @@ defmodule GrappaWeb.MessagesController do
   `create/2` routes through `Grappa.Session.send_privmsg/4`, which
   persists the row, broadcasts on the per-channel PubSub topic, AND
   sends the PRIVMSG upstream — single source for both the scrollback
-  row and the wire event. The lookup is keyed by the
+  row and the wire event. #640: a POST carrying `"ctcp_target"` is a
+  CTCP QUERY (`/ctcp`, `/ping`) instead — it routes through
+  `Grappa.Session.send_ctcp/5`, where the URL `channel_id` is the SOURCE
+  window the echo renders in and `ctcp_target` is the wire recipient; no
+  query window is ever opened for the recipient (a control-surface probe
+  is not a conversation). The lookup is keyed by the
   `t:Grappa.Session.subject/0` ID-tuple resolved from
   `conn.assigns.current_subject` via `GrappaWeb.Subject.to_session/1`
   + `network.id` end-to-end (sub-task 2g) so two subjects on the same
@@ -162,6 +167,28 @@ defmodule GrappaWeb.MessagesController do
           Plug.Conn.t()
           | {:error, :bad_request | :no_session | :invalid_line | :rate_limited}
           | {:error, Ecto.Changeset.t()}
+  def create(conn, %{"channel_id" => channel, "body" => body, "ctcp_target" => ctcp_target})
+      when is_binary(body) and body != "" and is_binary(ctcp_target) and ctcp_target != "" do
+    subject = Subject.to_session(conn.assigns.current_subject)
+    network = conn.assigns.network
+
+    # #640 — a CTCP QUERY (/ctcp, /ping). `channel` (the URL) is the SOURCE
+    # window the echo renders in — `validate_target_name` (NOT the post variant)
+    # so `$server` is allowed (a /ping typed in the server window is legit).
+    # `ctcp_target` is the wire recipient — `validate_post_target_name` (a real
+    # channel/nick, never the read-only `$server`). The session persists the
+    # echo to `source`, relays the frame to `ctcp_target`, and NEVER opens a
+    # query window for it (the phantom-window bug). One send-token as for a
+    # plain PRIVMSG. `send_ctcp` always persists a row (no `:no_persist` arm).
+    with :ok <- BodyLimit.check(body),
+         :ok <- validate_target_name(channel),
+         :ok <- validate_post_target_name(ctcp_target),
+         :ok <- take_send_token(subject, network.id),
+         {:ok, result} <- Session.send_ctcp(subject, network.id, channel, ctcp_target, body) do
+      render_send_result(conn, result)
+    end
+  end
+
   def create(conn, %{"channel_id" => channel, "body" => body})
       when is_binary(body) and body != "" do
     subject = Subject.to_session(conn.assigns.current_subject)

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -3464,6 +3464,83 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  describe "#640 inbound 401 ERR_NOSUCHNICK from a CTCP probe" do
+    # #640 — pinging (or /ctcp'ing) a NONEXISTENT nick makes bahamut answer
+    # 401 ERR_NOSUCHNICK for the relayed frame. NumericRouter (a pure
+    # syntactic classifier — CP13) scans that 401 to {:query, target}; the
+    # server then gates the decision on window-existence
+    # (`resolve_numeric_query_window/2` via `state.query_window_open?`): a
+    # /ctcp or /ping opens NO query window (send_ctcp), so there is nothing to
+    # land in and the row is redirected to $server — no phantom. (The /msg
+    # case, where a window IS open, keeps landing in it — see the positive
+    # test beside 9902 + cp13-s5-msg-ghost-401.) The send_ctcp block above
+    # proves the OUTBOUND echo opens no window; this proves the INBOUND probe
+    # FAILURE opens none either. This is the behavioral falsification target:
+    # revert the server gate and this goes RED.
+    setup do
+      rfc_handler = fn state, line ->
+        if String.starts_with?(line, "USER ") do
+          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
+        else
+          {:reply, nil, state}
+        end
+      end
+
+      {server, port} = start_server(rfc_handler)
+      {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+      %{server: server, user: user, network: network, pid: pid}
+    end
+
+    test "routes the 401 to $server and opens NO phantom window for the target",
+         %{server: server, user: user, network: network, pid: pid} do
+      net_id = network.id
+
+      :ok =
+        Phoenix.PubSub.subscribe(
+          Grappa.PubSub,
+          Topic.channel(user.name, network.slug, "$server")
+        )
+
+      # /ctcp ghostpeer VERSION typed in #sniffo → the frame is relayed to the
+      # (nonexistent) recipient upstream.
+      assert {:ok, _} =
+               Session.send_ctcp(
+                 {:user, user.id},
+                 net_id,
+                 "#sniffo",
+                 "ghostpeer",
+                 "\x01VERSION\x01"
+               )
+
+      # Barrier: the probe frame reached the wire, so bahamut would now answer.
+      assert {:ok, _} =
+               IRCServer.wait_for_line(
+                 server,
+                 &String.starts_with?(&1, "PRIVMSG ghostpeer :\x01VERSION\x01"),
+                 1_000
+               )
+
+      # bahamut's reply for a nonexistent target (3-elem RFC 2812 shape).
+      IRCServer.feed(server, ":irc.azzurra.chat 401 vjt ghostpeer :No such nick/channel\r\n")
+
+      # The 401 lands as a $server :notice — the barrier proving it was fully
+      # processed. Pre-fix it routed to {:query, "ghostpeer"} instead, so this
+      # assert_receive (subscribed to the $server topic) times out (the RED).
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{message: %{channel: "$server", body: "No such nick/channel"}}
+                     },
+                     2_000
+
+      # The outcome: no phantom query window for the nonexistent probe target.
+      refute QueryWindows.open?({:user, user.id}, net_id, "ghostpeer")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+
   describe "#25 outbound own sender-prefix snapshot" do
     test "own channel message snapshots the operator's op grade into meta.sender_prefix" do
       # Mirror of the inbound EventRouter capture for the outbound door:
@@ -9825,17 +9902,68 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
-    test "401 ERR_NOSUCHNICK persists on the queried nick (query window)" do
+    test "401 ERR_NOSUCHNICK with NO open window is redirected to $server (#640)" do
+      # #640 — a raw 401 for a nick the operator has NO query window with (a
+      # /ctcp or /ping to a nonexistent nick opened none) scans syntactically
+      # to {:query, "ghost"}, then the server's window-existence gate
+      # (resolve_numeric_query_window/2 via state.query_window_open?) finds no
+      # window and redirects the row to $server — no phantom is minted. This
+      # test previously asserted the phantom (channel: "ghost"); correcting it
+      # is part of the #640 fix, not a weakening (CLAUDE.md "Never assert buggy
+      # behavior"). The OPEN-window counterpart is the very next test — the two
+      # together pin both arms of the gate.
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port)
 
-      topic = Topic.channel(user.name, network.slug, "ghost")
+      topic = Topic.channel(user.name, network.slug, "$server")
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
 
       pid = start_session_for(user, network)
       :ok = await_handshake(server)
       IRCServer.feed(server, ":irc.test.org 401 vjt ghost :No such nick/channel\r\n")
 
+      assert_message_event(
+        kind: :notice,
+        channel: "$server",
+        network: network.slug,
+        meta: %{numeric: 401, severity: :error, raw_params: ["vjt", "ghost", "No such nick/channel"]}
+      )
+
+      # The #640 outcome: no phantom query window for the nonexistent target.
+      refute QueryWindows.open?({:user, user.id}, network.id, "ghost")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "401 ERR_NOSUCHNICK with an OPEN query window lands in that window (#640 / cp13-s5)" do
+      # #640 Design-2 counterpart: when the operator HAS an open query window
+      # with the target (they /msg'd it — the outbound-DM auto-open minted the
+      # window), the 401 "No such nick/channel" is live feedback that belongs
+      # IN that window, NOT redirected to $server. resolve_numeric_query_window/2
+      # sees the open window (state.query_window_open?) and KEEPS {:query,
+      # "ghost"}. Server twin of the cp13-s5-msg-ghost-401 e2e; the
+      # falsification companion to the no-window test above — the gate must
+      # route to the window when it exists, never blanket-redirect.
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      # /msg ghost hi — the outbound DM opens the server-side query window for
+      # ghost (#422 maybe_open_query_window), exactly as compose.ts's /msg does.
+      assert {:ok, _} = Session.send_privmsg({:user, user.id}, network.id, "ghost", "hi")
+      assert QueryWindows.open?({:user, user.id}, network.id, "ghost")
+
+      # Subscribe AFTER the outbound send so only the 401 notice lands in the
+      # mailbox (assert_message_event grabs the first message-event, and the
+      # outbound "hi" privmsg already broadcast during send_privmsg).
+      topic = Topic.channel(user.name, network.slug, "ghost")
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, topic)
+
+      IRCServer.feed(server, ":irc.test.org 401 vjt ghost :No such nick/channel\r\n")
+
+      # The 401 lands in the OPEN query window, NOT $server.
       assert_message_event(
         kind: :notice,
         channel: "ghost",

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -3324,6 +3324,146 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  describe "#640 outbound CTCP QUERY routing (send_ctcp)" do
+    # #640 — a CTCP QUERY (/ctcp, /ping) to a nick is a control-surface probe,
+    # not a conversation. Its self-echo must land in the SOURCE window it was
+    # typed in — NOT a query window for the wire recipient — and it must NEVER
+    # auto-open that recipient's query window (the phantom-window bug). This is
+    # the server half: `send_ctcp/5` keys the echo to `source`, carries the wire
+    # recipient in `meta.ctcp_target`, sets `dm_with: nil`, and skips
+    # `maybe_open_query_window/2`. Sibling of the #591 classification block
+    # above; distinct verb (`send_ctcp` vs `send_privmsg`) so a plain DM still
+    # auto-opens.
+    setup do
+      rfc_handler = fn state, line ->
+        if String.starts_with?(line, "USER ") do
+          {:reply, ":server 001 grappa-test :Welcome\r\n", state}
+        else
+          {:reply, nil, state}
+        end
+      end
+
+      {server, port} = start_server(rfc_handler)
+      {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+      %{server: server, user: user, network: network, pid: pid}
+    end
+
+    test "keys the echo to the SOURCE window, tags meta.ctcp_target, dm_with nil, relays to recipient",
+         %{server: server, user: user, network: network, pid: pid} do
+      # /ping carol typed in #sniffo → source window is #sniffo, wire recipient
+      # is carol. The echo must persist keyed to #sniffo (the source), never
+      # carol.
+      assert {:ok, msg} =
+               Session.send_ctcp(
+                 {:user, user.id},
+                 network.id,
+                 "#sniffo",
+                 "carol",
+                 "\x01PING 1706743200000\x01"
+               )
+
+      # Persist KEY is the SOURCE window, NOT the wire recipient.
+      assert msg.channel == "#sniffo"
+      assert msg.kind == :privmsg
+      # The wire recipient travels in meta so the render reads it OFF the
+      # message, not the routing key (`channel`), alongside the typed verb/args.
+      assert msg.meta == %{ctcp_verb: "PING", ctcp_args: "1706743200000", ctcp_target: "carol"}
+      # A control probe is not a DM — no thread, no query window.
+      assert msg.dm_with == nil
+
+      # The frame still reaches the recipient on the wire.
+      assert {:ok, _} =
+               IRCServer.wait_for_line(
+                 server,
+                 &String.starts_with?(&1, "PRIVMSG carol :\x01PING 1706743200000\x01"),
+                 1_000
+               )
+
+      # The row lives in the SOURCE window's scrollback, not carol's.
+      source_rows = Scrollback.fetch({:user, user.id}, network.id, "#sniffo", nil, 10, nil, false)
+      assert Enum.any?(source_rows, &(&1.body == "\x01PING 1706743200000\x01"))
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "NEVER opens a query window for the recipient (#640 phantom-window fix)",
+         %{user: user, network: network, pid: pid} do
+      net_id = network.id
+
+      # send_privmsg to a peer WOULD auto-open (asserted above). send_ctcp must
+      # NOT — a probe never spawns a conversation window. The call is
+      # synchronous, so maybe_open_query_window would have run inside it if it
+      # were going to; the refute is deterministic, no timing.
+      assert {:ok, _} =
+               Session.send_ctcp(
+                 {:user, user.id},
+                 net_id,
+                 "#sniffo",
+                 "carol",
+                 "\x01PING 1706743200000\x01"
+               )
+
+      refute QueryWindows.open?({:user, user.id}, net_id, "carol")
+
+      # Same for a recipient nobody has a window with (the issue's
+      # "/ping <nonexistent>" phantom): the server can't know it's nonexistent,
+      # so the fix is uniform — it just never opens one.
+      assert {:ok, _} =
+               Session.send_ctcp(
+                 {:user, user.id},
+                 net_id,
+                 "#sniffo",
+                 "ghostpeer",
+                 "\x01VERSION\x01"
+               )
+
+      refute QueryWindows.open?({:user, user.id}, net_id, "ghostpeer")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "keying to a query-window SOURCE still opens no window for the recipient",
+         %{user: user, network: network, pid: pid} do
+      # Prove the recipient-window suppression is independent of the source
+      # SHAPE: a /ping typed in a query window (dm-eligible source) must still
+      # not spawn a window for the DIFFERENT recipient.
+      net_id = network.id
+
+      assert {:ok, msg} =
+               Session.send_ctcp(
+                 {:user, user.id},
+                 net_id,
+                 "dave",
+                 "carol",
+                 "\x01PING 1706743200000\x01"
+               )
+
+      assert msg.channel == "dave"
+      assert msg.meta.ctcp_target == "carol"
+      refute QueryWindows.open?({:user, user.id}, net_id, "carol")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "rejects a non-CTCP body (and a bare ACTION) as :invalid_line",
+         %{user: user, network: network, pid: pid} do
+      net_id = network.id
+
+      # A plain PRIVMSG must go through send_privmsg/4 — ctcp_target is
+      # meaningless without a CTCP frame.
+      assert {:error, :invalid_line} =
+               Session.send_ctcp({:user, user.id}, net_id, "#sniffo", "carol", "just text")
+
+      # A /me ACTION rides its own kind, never a ctcp_target send.
+      assert {:error, :invalid_line} =
+               Session.send_ctcp({:user, user.id}, net_id, "#sniffo", "carol", "\x01ACTION waves\x01")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+
   describe "#25 outbound own sender-prefix snapshot" do
     test "own channel message snapshots the operator's op grade into meta.sender_prefix" do
       # Mirror of the inbound EventRouter capture for the outbound door:

--- a/test/grappa_web/controllers/messages_controller_outbound_test.exs
+++ b/test/grappa_web/controllers/messages_controller_outbound_test.exs
@@ -175,6 +175,67 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    test "#640: ctcp_target routes the echo to the SOURCE window, wire to the recipient, no query window",
+         %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+
+      # /ping carol typed in #sniffo: cic POSTs to the SOURCE window (the URL
+      # channel_id, #sniffo) with ctcp_target=carol (the wire recipient). The
+      # echo persists in #sniffo; carol never gets a phantom query window.
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/networks/#{network.slug}/channels/%23sniffo/messages", %{
+          "body" => "\x01PING 1706743200000\x01",
+          "ctcp_target" => "carol"
+        })
+
+      body = json_response(conn, 201)
+      assert body["channel"] == "#sniffo"
+      assert body["kind"] == "privmsg"
+      assert body["meta"]["ctcp_verb"] == "PING"
+      assert body["meta"]["ctcp_args"] == "1706743200000"
+      assert body["meta"]["ctcp_target"] == "carol"
+
+      # The frame reaches carol on the wire, NOT #sniffo.
+      assert {:ok, "PRIVMSG carol :\x01PING 1706743200000\x01\r\n"} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "PRIVMSG carol"), 1_000)
+
+      # The echo lives in the SOURCE window's scrollback.
+      rows = Scrollback.fetch({:user, vjt.id}, network.id, "#sniffo", nil, 10, nil, false)
+      assert Enum.any?(rows, &(&1.body == "\x01PING 1706743200000\x01"))
+
+      # No phantom query window for the recipient — the whole point of #640.
+      refute Grappa.QueryWindows.open?({:user, vjt.id}, network.id, "carol")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "#640: ctcp_target = $server is rejected (read-only) as bad_request",
+         %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+
+      # The wire recipient is validated with validate_post_target_name, which
+      # rejects the read-only $server synthetic (a CTCP frame can't target it).
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/networks/#{network.slug}/channels/%23sniffo/messages", %{
+          "body" => "\x01VERSION\x01",
+          "ctcp_target" => "$server"
+        })
+
+      assert json_response(conn, 400)["error"] == "bad_request"
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
     test "#357: the send-path span [:grappa, :session, :send_privmsg] closes with outcome: :ok",
          %{conn: conn, vjt: vjt} do
       {server, port} = start_server()


### PR DESCRIPTION
## Problem

`/ping <nick>` and `/ctcp <nick> VERB` typed in a window **split**: the
outbound CTCP self-echo landed in (and *created*) a query window for the
TARGET, while the RTT line landed in the SOURCE window. Pinging a
nonexistent nick left a phantom tab. Query windows are server-authoritative
(`maybe_open_query_window` in `handle_persisting_send`), so a cic-only fix
was impossible — the phantom window is created server-side.

## Fix

A CTCP **QUERY** (verb ≠ ACTION/reply) is a control-surface probe, not a
conversation: its self-echo belongs in the **SOURCE** window it was typed
in, with the wire recipient carried in `meta.ctcp_target`, `dm_with: nil`,
and **no** auto-open. ACTION (`/me`) is the exception — a real conversation,
so it stays a normal send to the target window.

### Server (new `send_ctcp` verb, distinct from `send_privmsg`)
- `Grappa.Session.send_ctcp/5` facade + `ctcp_query?/1` gate (rejects
  non-CTCP bodies and bare ACTION as `:invalid_line`).
- `Session.Server` `handle_call({:send_ctcp, ...})` → `handle_ctcp_send/4`:
  echoes keyed to `fold_key(source)`, tags `meta.ctcp_verb/args/ctcp_target`,
  `dm_with: nil`, and **skips** `maybe_open_query_window`.
- `MessagesController` `create/2` clause matching `"ctcp_target"` (before
  the plain clause): source uses `validate_target_name` (allows `$server`),
  `ctcp_target` uses `validate_post_target_name` (rejects `$server` → 400).
- `Scrollback.Meta`: `:ctcp_target` added to `@type`/`@known_keys`/`@spec`;
  `config.exs` Logger `:metadata` allowlist synced (A18 pin test).

### cic (additive snake_case `ctcp_target` — new wire field)
- `api.sendMessage` / `scrollback.sendMessage` gain optional `ctcpTarget`
  (absent ⇒ byte-identical `{body}`).
- `compose.ts` `case "ping"`/`case "ctcp"` send to the SOURCE window with
  `ctcpTarget`; ACTION stays a normal target-window send.
- `ScrollbackPane` reads the render target from `msg.meta.ctcp_target ??
  msg.channel` (fallback = pre-#640 rows).

## Verification
- `scripts/check.sh` GREEN on the rebased tree (compile + Dialyzer + Credo
  strict + Sobelow + doctor + format + ExUnit: 4914 tests, 0 failures).
- cic vitest GREEN (3813) + `bun run build` (tsc) GREEN.
- Server tests: `server_test.exs` (#640 routing describe) +
  `messages_controller_outbound_test.exs` (201 path + no phantom window +
  `$server` → 400).
- E2E `issue640-ping-self-echo.spec.ts` (3 tests) pending the STACK lane.

Sibling of #591 (outbound CTCP classification); distinct from #641 (the
inbound `notice` arm — untouched here).

Refs #640