### PR TITLE
test(#647): cover mode-2 client-source at the plan seam + login door

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -26046,3 +26046,55 @@ guidance (OPERATIONS.md) is to disconnect mode-2 sessions before renumbering, or
 accept the manual cleanup. This is not new to #609 in kind — any prefix change
 orphans out-of-current-prefix aliases from the reconcile sweep — but #609 makes
 a runtime prefix change take effect without a reboot, so it is now reachable.
+
+## 2026-08-02 — #647: mode-2 held every first-time visitor (the P0), the fallback fix, and why its coverage lives at the plan layer
+
+**The incident.** Emergency COLD deploy at 10:49: since the mode-2
+(`static_mapping_with_reservations`) cutover, **no new user could connect** to a
+mode-2 deployment. Mode 2 derives a session's outbound source from the subject's
+last-known client `/64` (`Vhosts.last_client_prefix64/1`); with none recorded,
+`effective_source/3` returns `{:hold, :no_client_source}` and
+`Session.Server.init_or_hold/1` refuses the session rather than egress from a
+shared pool — correct by design. The defect was ORDERING: the only capture point
+was `UserSocket.connect/3` (#543 Part C), which runs AFTER `Visitors.Login` has
+already spawned the anchor session. A first-time visitor therefore reached the
+plan with nothing recorded, was held, and had its row expired.
+
+**Two fixes, and why the second masks the first.** `138e4b9e` records the client
+prefix at LOGIN, before the spawn, on both the fresh-provision and existing-row
+paths, best-effort (a login never fails because the sample could not be taken).
+`7b880769` then made `last_client_prefix64/1` FALL BACK, when no usable sample
+is recorded, to the address already on file — the visitor row's `ip` (written at
+login) or the newest `sessions.ip` for an account — deriving from it and
+persisting it (walked once per subject, not every reconnect). Still per-subject,
+still the subject's own client network, never a shared source; a subject with no
+address anywhere is still held. **Consequence for the visitor OUTCOME the two
+are redundant:** both derive from the same login `ip`, and the visitor row's `ip`
+is set at login before the spawn, so once `7b880769` is in place, reverting
+`138e4b9e` alone no longer produces a hold — the fallback admits via `visitor.ip`.
+The load-bearing fix for the visible outcome is `7b880769`; `138e4b9e` remains as
+defence-in-depth (records earlier, into the same store the fallback would).
+(Both commits mis-cite `fix(#645)`; #645 is the unrelated CTCP self-echo PR —
+#647 is the real home.)
+
+**Why the coverage sits at the plan layer, not a live spawn.** A mode-2 session
+cannot be spawned end-to-end in the test suite: `IRC.Client.source_bind/2` binds
+the derived source as `ifaddr`, and a derived public-IPv6 `2a03:…::cb` either
+family-mismatches the IPv4 fake IRCServer (`:inet.getaddr("127.0.0.1", :inet6)`
+fails → `:source_family_mismatch`) or, against an IPv6 fake, fails the bind
+itself (`:eaddrnotavail` — the host holds no such address). So a real mode-2
+login never returns `{:ok}`, admit or hold alike — the bind failure masks the
+admission decision. The whole codebase reflects this: every prior mode-2 test
+either hand-crafts `source_address: {:hold, _}`/`nil + managed_source_alias`
+opts, or asserts at `SessionPlan.base_plan`. #647's regression coverage
+therefore asserts the RESOLVED `source_address` at the `base_plan` seam
+(`addressing_config → effective_source → last_client_prefix64`), which the
+Session.Server hold tests never traverse — a whole addressing mode that was
+invisible to the composition. The synthetic mode-2 arming seam is the existing
+triad: `ServerSettings.put_addressing_mode/1` + `put_static_mapping_prefix/1`
+(DB, sandboxed) + `SourceAliasManager.put_test_armed/2` (persistent_term, global
+→ reset `on_exit`). The login-door guard (`login_test.exs`) composes a real
+`Visitors.Login` (default addressing, so it spawns and connects to the fake with
+no bind) with a mode-2 `base_plan` resolution afterward; it deliberately does
+NOT isolate either commit (either fix alone still admits), so its falsification
+is the DOUBLE revert of both commits ⇒ `{:hold, :no_client_source}` ⇒ RED.

--- a/test/grappa/networks/session_plan_vhost_test.exs
+++ b/test/grappa/networks/session_plan_vhost_test.exs
@@ -12,9 +12,9 @@ defmodule Grappa.Networks.SessionPlanVhostTest do
 
   import Grappa.AuthFixtures
 
+  alias Grappa.{Accounts, ServerSettings, UserSettings, Vhosts}
   alias Grappa.Net.SourceAliasManager
   alias Grappa.Networks.{Credential, Server, SessionPlan}
-  alias Grappa.{ServerSettings, Vhosts}
   alias Grappa.Vhosts.SourceMapping
 
   test "with no pin / no selection, source_address falls back to server.source_address" do
@@ -132,6 +132,95 @@ defmodule Grappa.Networks.SessionPlanVhostTest do
       # #543 INC-6 — an admin pin lives OUTSIDE ::cb, so it is never a managed
       # alias (it binds verbatim, no ref-counted lifecycle).
       assert plan.managed_source_alias == nil
+    end
+
+    # #647 — the P0 and its real fix (7b880769). A subject with NO recorded
+    # UserSettings sample used to HOLD under mode 2, even though its client
+    # address was sitting in the visitor row (or the newest sessions row): the
+    # sample was captured only at the WS connect, AFTER the anchor spawned, so
+    # every FIRST-TIME visitor reached the plan with nothing recorded, was held
+    # with :no_client_source, and had its row expired — "no new user can
+    # connect". `last_client_prefix64/1` now falls back to that last-known
+    # address and derives from it. These pin the resolved source at the exact
+    # seam the hold used to strand — the composition (addressing_config →
+    # effective_source → last_client_prefix64), which had ZERO end-to-end
+    # coverage (the Session.Server hold tests hand-craft `source_address:
+    # {:hold, _}` and never reach this path). Falsification target: revert
+    # 7b880769 → `last_client_prefix64` returns nil again → {:hold,
+    # :no_client_source} → RED.
+    test "no sample but a visitor.ip on record → derived from it, NOT held (#647)" do
+      client_ip = "2001:db8:11:22:33:44:55:66"
+      {:ok, ip_tuple} = :inet.parse_address(String.to_charlist(client_ip))
+      # A first-time visitor: the row carries its login `ip`, but NO client
+      # sample was ever recorded (the pre-#543 / lost-capture case).
+      visitor = visitor_fixture(ip: client_ip)
+      refute UserSettings.get_last_client_prefix64({:visitor, visitor.id})
+
+      cred = %Credential{nick: "n", auth_method: :none, autojoin_channels: [], last_joined_channels: []}
+      server = %Server{host: "irc.example.test", port: 6697, tls: true, source_address: nil}
+
+      plan = SessionPlan.base_plan({:visitor, visitor.id}, "label", cred, network_fixture(), server, "n")
+
+      {:ok, expected} = SourceMapping.derive(SourceMapping.client_key(ip_tuple), @cb_prefix)
+      assert plan.source_address == expected
+      assert SourceMapping.in_prefix?(plan.source_address, @cb_prefix)
+      # #543 INC-6 — a derived ::cb source is a managed alias.
+      assert plan.managed_source_alias == expected
+    end
+
+    test "no sample but a newest sessions.ip on record → derived from it, NOT held (#647, user path)" do
+      user = user_fixture()
+      client_ip = "2001:db8:aa:bb:cc:dd:ee:ff"
+      {:ok, ip_tuple} = :inet.parse_address(String.to_charlist(client_ip))
+      # An account whose sample was lost but whose newest session still carries
+      # the client address the operator can see in admin.
+      {:ok, _} = Accounts.create_session({:user, user.id}, client_ip, nil, [])
+      refute UserSettings.get_last_client_prefix64({:user, user.id})
+
+      cred = %Credential{nick: "n", auth_method: :none, autojoin_channels: [], last_joined_channels: []}
+      server = %Server{host: "irc.example.test", port: 6697, tls: true, source_address: nil}
+
+      plan = SessionPlan.base_plan({:user, user.id}, "label", cred, network_fixture(), server, "n")
+
+      {:ok, expected} = SourceMapping.derive(SourceMapping.client_key(ip_tuple), @cb_prefix)
+      assert plan.source_address == expected
+      assert plan.managed_source_alias == expected
+    end
+
+    test "no sample AND no address anywhere → still {:hold, :no_client_source} (Global Constraint)" do
+      # The fallback is per-subject and NEVER a shared source: a subject with no
+      # sample and no address on record (no visitor.ip, no sessions.ip) is STILL
+      # held. 7b880769 widened WHERE the /64 comes from; it did not open a pool
+      # fallthrough. Visitor-subject sibling of the user case above. This PASSES
+      # both pre- and post-7b880769 — it guards the fix against over-reach.
+      visitor = visitor_fixture(ip: nil)
+      refute UserSettings.get_last_client_prefix64({:visitor, visitor.id})
+
+      cred = %Credential{nick: "n", auth_method: :none, autojoin_channels: [], last_joined_channels: []}
+      server = %Server{host: "irc.example.test", port: 6697, tls: true, source_address: nil}
+
+      plan = SessionPlan.base_plan({:visitor, visitor.id}, "label", cred, network_fixture(), server, "n")
+      assert plan.source_address == {:hold, :no_client_source}
+      assert plan.managed_source_alias == nil
+    end
+
+    test "resolving via the fallback PERSISTS the sample (walked once per subject, #647)" do
+      # 7b880769 records the derived sample on the way through, so the next
+      # resolve reads a recorded value instead of re-deriving from the row —
+      # the fallback path is walked once per subject, not on every reconnect.
+      # Assert the persisted OUTCOME (the sample is now on record), not the call.
+      client_ip = "2001:db8:11:22:33:44:55:66"
+      {:ok, ip_tuple} = :inet.parse_address(String.to_charlist(client_ip))
+      visitor = visitor_fixture(ip: client_ip)
+      refute UserSettings.get_last_client_prefix64({:visitor, visitor.id})
+
+      cred = %Credential{nick: "n", auth_method: :none, autojoin_channels: [], last_joined_channels: []}
+      server = %Server{host: "irc.example.test", port: 6697, tls: true, source_address: nil}
+
+      _ = SessionPlan.base_plan({:visitor, visitor.id}, "label", cred, network_fixture(), server, "n")
+
+      assert UserSettings.get_last_client_prefix64({:visitor, visitor.id}) ==
+               Base.encode16(SourceMapping.client_key(ip_tuple))
     end
   end
 end

--- a/test/grappa/visitors/login_test.exs
+++ b/test/grappa/visitors/login_test.exs
@@ -18,8 +18,14 @@ defmodule Grappa.Visitors.LoginTest do
   alias Grappa.Accounts.Session, as: AccountsSession
   alias Grappa.Admission.NetworkCircuit
   alias Grappa.AdmissionStateHelpers
-  alias Grappa.Networks.{Credential, Credentials, Network}
+  alias Grappa.Net.SourceAliasManager
+  alias Grappa.Networks.{Credential, Credentials, Network, Server, SessionPlan}
+  alias Grappa.{ServerSettings, Vhosts}
+  alias Grappa.Vhosts.SourceMapping
   alias Grappa.Visitors.{Login, Visitor}
+
+  # #647 — the production static-mapping /80 (mirrors session_plan_vhost_test).
+  @cb_prefix "2a03:4000:20:2d3:cb::/80"
 
   # NetworkCircuit is ETS-backed and survives Ecto sandbox resets. Each
   # test that creates a network may get the same auto-increment id (sqlite
@@ -659,6 +665,111 @@ defmodule Grappa.Visitors.LoginTest do
                )
 
       assert is_integer(retry_after) and retry_after >= 0
+    end
+  end
+
+  # #647 — the login records the client source sample before the spawn
+  # (138e4b9e), best-effort: a login must NEVER fail because the sample could
+  # not be taken. `record_login_client_source/2` skips an absent (nil) or
+  # unparseable `input.ip` and returns :ok, so the login proceeds and simply
+  # takes no sample. Assert the visible outcome — login SUCCEEDS, no sample on
+  # record — not that the recorder was called (which would pass on the broken
+  # code too). Falsification: make the recorder raise on a bad ip → the login
+  # crashes → RED.
+  describe "#647 — client-source capture at login is best-effort" do
+    test "a login with an absent (nil) ip still succeeds — no sample taken" do
+      {server, port} = start_server()
+      {network, _} = setup_visitor_network(port)
+
+      task = Task.async(fn -> Login.login(login_input(%{ip: nil}), []) end)
+      :ok = await_handshake(server)
+      feed_001(server, "vjt")
+
+      assert {:ok, %{visitor: %Visitor{} = v}} = Task.await(task, 10_000)
+      # nil ip ⇒ nothing to record and nothing on the row to fall back to.
+      assert Grappa.Vhosts.last_client_prefix64({:visitor, v.id}) == nil
+
+      stop_visitor_session(v.id, network.id)
+    end
+
+    test "a login with an unparseable ip still succeeds — no sample taken" do
+      {server, port} = start_server()
+      {network, _} = setup_visitor_network(port)
+
+      task = Task.async(fn -> Login.login(login_input(%{ip: "not-an-ip"}), []) end)
+      :ok = await_handshake(server)
+      feed_001(server, "vjt")
+
+      assert {:ok, %{visitor: %Visitor{} = v}} = Task.await(task, 10_000)
+      # The parse fails, the recorder returns :ok, and the row's unparseable ip
+      # yields no fallback key either — a sample is simply never taken.
+      assert Vhosts.last_client_prefix64({:visitor, v.id}) == nil
+
+      stop_visitor_session(v.id, network.id)
+    end
+  end
+
+  # #647 — END-TO-END GUARD spanning the door where the P0 manifested (a
+  # first-time visitor login) through the mode-2 addressing gate that refused
+  # it. Emergency cold deploy: no new user could connect on a mode-2
+  # deployment, because the client /64 was captured only at the WS connect —
+  # AFTER the login had already spawned the anchor — so a first-time visitor
+  # reached the plan with nothing recorded, was held with :no_client_source,
+  # and had its row expired.
+  #
+  # This test deliberately does NOT isolate either commit — that is not its
+  # job (A, the effective_source unit seam, isolates 7b880769 per subject; R4
+  # isolates 138e4b9e's best-effort). Here BOTH fixes overlap on the outcome:
+  # the login records the sample (138e4b9e) AND, absent that, the plan falls
+  # back to the visitor row's own ip (7b880769). Either one ALONE still admits,
+  # so a single-commit revert stays GREEN. Its own falsification is the DOUBLE
+  # revert (138e4b9e AND 7b880769 both reverted): only then does the plan
+  # resolve {:hold, :no_client_source} and this goes RED. If it stays green
+  # under the double revert it proves nothing — delete it. Its value is nailing
+  # the visible outcome (first-time visitor → admitted, not held) at the login
+  # door, which the unit seams do not traverse.
+  describe "#647 — first-time visitor login → mode-2 admission (end-to-end guard)" do
+    setup do
+      # put_test_armed writes global persistent_term — reset so the armed state
+      # never leaks to a sibling test.
+      on_exit(fn -> SourceAliasManager.put_test_armed(false, :not_armed) end)
+      :ok
+    end
+
+    test "a fresh visitor login lets the mode-2 plan resolve a derived source, not a hold" do
+      {server, port} = start_server()
+      {network, _} = setup_visitor_network(port)
+      client_ip = "2001:db8:1:2:3:4:5:6"
+      {:ok, ip_tuple} = :inet.parse_address(String.to_charlist(client_ip))
+
+      # 1. First-time visitor logs in under the DEFAULT addressing (mode 1: the
+      #    plan's source_address is nil, so the anchor binds nothing and
+      #    connects to the fake cleanly). The login carries the trusted client
+      #    IP through to record_login_client_source.
+      task = Task.async(fn -> Login.login(login_input(%{ip: client_ip}), []) end)
+      :ok = await_handshake(server)
+      feed_001(server, "vjt")
+      assert {:ok, %{visitor: %Visitor{} = v}} = Task.await(task, 10_000)
+
+      # 2. Arm mode 2 and resolve the plan for THAT visitor — the source the
+      #    next connect would bind. It must DERIVE from the login-time client
+      #    /64, never {:hold, :no_client_source}: that hold, for every
+      #    first-time visitor, WAS the P0. (Resolved at the plan layer, not a
+      #    live spawn — a derived public-IPv6 source cannot be bound on the
+      #    test host, so no mode-2 session ever connects in the suite.)
+      :ok = ServerSettings.put_addressing_mode(:static_mapping_with_reservations)
+      :ok = ServerSettings.put_static_mapping_prefix(@cb_prefix)
+      :ok = SourceAliasManager.put_test_armed(true, nil)
+
+      cred = %Credential{nick: "n", auth_method: :none, autojoin_channels: [], last_joined_channels: []}
+      plan_server = %Server{host: "irc.example.test", port: 6697, tls: true, source_address: nil}
+      plan = SessionPlan.base_plan({:visitor, v.id}, "label", cred, network, plan_server, "n")
+
+      {:ok, expected} = SourceMapping.derive(SourceMapping.client_key(ip_tuple), @cb_prefix)
+      assert plan.source_address == expected
+      refute match?({:hold, _}, plan.source_address)
+
+      stop_visitor_session(v.id, network.id)
     end
   end
 end


### PR DESCRIPTION
## What

Regression coverage for the mode-2 P0 (#647): every first-time visitor on a
`static_mapping_with_reservations` deployment was held with
`:no_client_source` and had its row expired — "no new user can connect". The
fix shipped untested across two commits — 138e4b9e (record the client sample
at login, before the spawn) + 7b880769 (`last_client_prefix64/1` falls back to
the subject's last-known address — `visitor.ip` / newest `sessions.ip` — and
derives + persists). Their composition
(`addressing_config → effective_source → last_client_prefix64 → hold-or-derive`)
had **zero** end-to-end coverage; the Session.Server hold tests hand-craft
`source_address: {:hold, _}` and never traverse it.

> **Note:** the credo + dialyzer breakage that 7b880769 left on `vhosts.ex`
> (which was red-ing the check.sh gate on every branch) was fast-forwarded
> straight to `main` as a separate lint/type-only commit — it is NOT in this
> PR. This PR is the test coverage only.

## Why the coverage lives at the plan layer, not a live spawn

A mode-2 session cannot be spawned end-to-end in the suite: a derived
public-IPv6 source family-mismatches / cannot bind against the loopback fake
IRCServer (`IRC.Client.source_bind/2`), so a real mode-2 login never returns
`{:ok}` — the bind failure masks the admission decision. Coverage therefore
asserts the **resolved `source_address`** at the `SessionPlan.base_plan` seam,
mode-2 armed synthetically via the `ServerSettings` + `SourceAliasManager`
triad (this also closes the "a whole addressing mode is invisible to CI" gap).

## Tests

- **`session_plan_vhost_test.exs`** (mode-2 describe): `visitor.ip` fallback →
  derived source; newest `sessions.ip` fallback → derived (user path);
  no address anywhere → still `{:hold, :no_client_source}` (Global-Constraint
  guard, passes pre+post); the fallback **persists** the derived sample.
- **`login_test.exs`**: `record_login_client_source` best-effort — a login with
  a nil / unparseable ip still succeeds, no sample taken; plus an **end-to-end
  login-door guard** that deliberately does NOT isolate either commit (either
  fix alone still admits), whose falsification is the **DOUBLE revert** of both
  commits → `{:hold, :no_client_source}` → RED.
- **DESIGN_NOTES**: the P0, why 7b880769 masks 138e4b9e on the visitor outcome,
  and why coverage sits at the plan layer.

## Falsification gate (proven with real evidence)

- baseline (both fixes): 40 tests, 0 failures.
- revert **only** 7b880769 → 3 failures (the two fallback tests + the persist
  test); the login-door guard stays GREEN (proves it does not isolate).
- **double** revert (both commits) → the login-door guard goes RED.
- full `scripts/check.sh` on the rebased tree: green (4915 tests, 0 failures;
  Dialyzer 0 errors; Doctor passed).

Refs #647