### PR TITLE
fix(#644): auto-centre TopicBar text block via a header wrapper

### DIFF
--- a/cicchetto/src/TopicBar.tsx
+++ b/cicchetto/src/TopicBar.tsx
@@ -281,7 +281,17 @@ const TopicBar: Component<Props> = (props) => {
           `.topic-bar-hamburger` below (channel-only, CSS-hidden on
           desktop via @media) is now the SINGLE hamburger across the
           whole shell. */}
-      {/* #275 — channel name + modes STACKED in ONE width-capped clickable
+      {/* #644 — the two text columns (namebox + topic strip) are grouped under
+          ONE wrapper so `.topic-bar { align-items: center }` centres this block
+          and the hamburger as UNITS (auto-centre, no magic constant), while
+          `.topic-bar-header { align-items: flex-start }` PRESERVES #344's
+          intra-block line-registration (topic line-1 beside the channel name,
+          line-2 beside +modes). Before this wrapper the columns top-aligned to
+          the taller 48px hamburger / stretched bar and floated high with empty
+          space below (#644). The members hamburger stays a SIBLING of this
+          wrapper (below), outside the centred block. */}
+      <div class="topic-bar-header">
+        {/* #275 — channel name + modes STACKED in ONE width-capped clickable
           box. The whole box opens the /mode viewer/editor modal (reuse
           `openModeModal` — the SAME verb `/mode #chan`, bare `/mode`, and the
           old inline indicator used; "reuse the verbs, not the nouns"). The
@@ -294,35 +304,37 @@ const TopicBar: Component<Props> = (props) => {
           button-in-button); a tap anywhere on the box — name OR modes —
           bubbles to this onClick, so the `.topic-bar-modes` click paths that
           issue216 / issue240 exercise still open the modal. */}
-      <button
-        type="button"
-        class="topic-bar-namebox"
-        data-testid="channel-mode-box"
-        aria-label={`channel ${props.channelName} — view modes`}
-        title={modeStr().length > 0 ? (modesEntry()?.modes.join(", ") ?? "") : "view channel modes"}
-        onClick={() => openModeModal(props.networkSlug, props.channelName)}
-      >
-        <span class="topic-bar-channel">{props.channelName}</span>
-        {/* Compact mode string (e.g. "+nt") — rendered only when modes are
+        <button
+          type="button"
+          class="topic-bar-namebox"
+          data-testid="channel-mode-box"
+          aria-label={`channel ${props.channelName} — view modes`}
+          title={
+            modeStr().length > 0 ? (modesEntry()?.modes.join(", ") ?? "") : "view channel modes"
+          }
+          onClick={() => openModeModal(props.networkSlug, props.channelName)}
+        >
+          <span class="topic-bar-channel">{props.channelName}</span>
+          {/* Compact mode string (e.g. "+nt") — rendered only when modes are
             cached and non-empty (C3.1). Second line of the box. */}
-        <Show when={modeStr().length > 0}>
-          <span class="topic-bar-modes" title={modesEntry()?.modes.join(", ") ?? ""}>
-            {modeStr()}
-          </span>
-        </Show>
-      </button>
-      {/* Topic strip — always present; shows placeholder when no topic cached.
+          <Show when={modeStr().length > 0}>
+            <span class="topic-bar-modes" title={modesEntry()?.modes.join(", ") ?? ""}>
+              {modeStr()}
+            </span>
+          </Show>
+        </button>
+        {/* Topic strip — always present; shows placeholder when no topic cached.
           #263: view-only, its only action is to open the (read-only) modal for
           everyone; editing lives inside the modal. */}
-      <button
-        type="button"
-        class="topic-bar-topic"
-        onClick={openModal}
-        aria-label="expand topic"
-        title={topicTitle()}
-        data-testid="topic-strip"
-      >
-        {/* #307 — the clamped runs MUST be the direct children of a NON-button
+        <button
+          type="button"
+          class="topic-bar-topic"
+          onClick={openModal}
+          aria-label="expand topic"
+          title={topicTitle()}
+          data-testid="topic-strip"
+        >
+          {/* #307 — the clamped runs MUST be the direct children of a NON-button
             `-webkit-box` for `-webkit-line-clamp` to engage (a <button> wraps
             its children in an internal box and defeats the clamp — the #262
             bug: geometric clip with no ellipsis). This inner span carries the
@@ -330,15 +342,16 @@ const TopicBar: Component<Props> = (props) => {
             stay on the real <button> above, so no role/tabindex/keydown
             reimplementation is needed. MircBody emits its runs with no block
             wrapper, so they land as the span's direct line-box content. */}
-        <span class="topic-bar-topic-text">
-          <Show when={topicText() !== null} fallback={"(no topic set)"}>
-            {/* #220 — the bar NEVER navigates a link directly; a tap on a
+          <span class="topic-bar-topic-text">
+            <Show when={topicText() !== null} fallback={"(no topic set)"}>
+              {/* #220 — the bar NEVER navigates a link directly; a tap on a
                 link "surface-wins" (suppresses navigation) and bubbles to
                 the strip's onClick, which opens the modal. */}
-            <MircBody body={topicText() ?? ""} linkPolicy="surface-wins" emphasis />
-          </Show>
-        </span>
-      </button>
+              <MircBody body={topicText() ?? ""} linkPolicy="surface-wins" emphasis />
+            </Show>
+          </span>
+        </button>
+      </div>
       {/* #71 INC-2 — the presence-filter toggle (👁/🙈) moved to the right-rail
           RailActions drawer (channel-gated). It is no longer rendered here. */}
       {/* Members hamburger only when actively joined. Parked / failed

--- a/cicchetto/src/__tests__/TopicBar.test.tsx
+++ b/cicchetto/src/__tests__/TopicBar.test.tsx
@@ -632,4 +632,41 @@ describe("TopicBar", () => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();
     });
   });
+
+  // #644 — the topic block sat HIGH in the bar (empty space below it) because
+  // `.topic-bar` used `align-items: flex-start` while the taller 48px hamburger
+  // (mobile) / stretched bar drove the cross-axis height, pinning the two
+  // shorter text columns to the top. The fix groups the two text columns under
+  // ONE `.topic-bar-header` wrapper so `.topic-bar { align-items: center }`
+  // centres the header block + hamburger as UNITS (auto-centre, no magic
+  // constant — vjt's acceptance bar), while `.topic-bar-header { align-items:
+  // flex-start }` PRESERVES #344's intra-block line-registration (topic line-1
+  // beside the channel name, line-2 beside +modes). jsdom has no layout engine,
+  // so this pins the STRUCTURE the centring depends on — the visual proof is the
+  // device dogfood (webkit != iOS).
+  describe("#644 — topic block auto-centres via a header wrapper", () => {
+    it("groups the namebox + topic strip under a single .topic-bar-header wrapper", () => {
+      mockTopicByChannel.mockReturnValue({
+        "freenode #italia": { text: "A topic", set_by: "vjt", set_at: null },
+      });
+      const { container } = render(() => <TopicBar {...baseProps()} />);
+      const header = container.querySelector(".topic-bar > .topic-bar-header");
+      expect(header).not.toBeNull();
+      // Both text columns live INSIDE the header so they centre as one unit;
+      // the header's own flex-start keeps their lines registered (#344).
+      expect(header?.querySelector(":scope > .topic-bar-namebox")).not.toBeNull();
+      expect(header?.querySelector(":scope > .topic-bar-topic")).not.toBeNull();
+    });
+
+    it("keeps the members hamburger a SIBLING of the header, not inside it", () => {
+      // Joined → the hamburger renders (default mock). It must stay OUTSIDE the
+      // centred text block: inside the header it would centre WITH the text and
+      // drive the header's flex-start, reintroducing the #644 misalignment.
+      const { container } = render(() => <TopicBar {...baseProps()} />);
+      const ham = container.querySelector(".topic-bar-hamburger");
+      expect(ham).not.toBeNull();
+      expect(ham?.parentElement).toHaveClass("topic-bar");
+      expect(container.querySelector(".topic-bar-header .topic-bar-hamburger")).toBeNull();
+    });
+  });
 });

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -1696,17 +1696,41 @@ html.resize-dragging * {
 
 .topic-bar {
   display: flex;
-  /* #344 — top-align the two columns (namebox left / topic strip right) so
-     topic line-1 sits beside the channel name and topic line-2 beside the
-     +modes line, instead of both blocks centered as wholes. Was
-     `align-items: center`. Fine baseline rhythm between the columns (bold base
-     name vs 0.85rem mode vs 2× mono topic @ line-height 1.5) is a tune-by-eye
-     stretch — dogfood/device-verify owed (webkit != iOS). */
-  align-items: flex-start;
+  /* #644 — centre the header block (the two text columns, grouped in
+     `.topic-bar-header`) and the members hamburger as UNITS on the cross axis.
+     The taller 48px hamburger (mobile) / a stretched bar drives the height, and
+     `align-items: center` now AUTO-centres the shorter text block in it — no
+     magic padding/margin constant (vjt's acceptance bar for #644). #344's
+     top-alignment did NOT die: it moved INSIDE `.topic-bar-header` (flex-start
+     there keeps topic line-1 beside the channel name, line-2 beside +modes).
+     Centring `.topic-bar` directly instead would centre the two columns
+     INDEPENDENTLY and mis-register their lines — hence the wrapper. */
+  align-items: center;
+  /* gap now separates the header block from the hamburger; the intra-column
+     namebox↔topic gap lives on `.topic-bar-header`. */
   gap: 0.5rem;
   padding: 0.5rem 1rem;
   border-bottom: 1px solid var(--border);
   background: var(--bg);
+}
+
+/* #644 — groups the two text columns (namebox + topic strip) so `.topic-bar`
+   can centre them as ONE unit against the hamburger (see `.topic-bar` note).
+   `align-items: flex-start` PRESERVES #344's intra-block line-registration
+   (topic line-1 beside the channel NAME, line-2 beside the +modes line) —
+   moved here from `.topic-bar` verbatim. `flex: 1` + `min-width: 0` carry the
+   flex-grow + ellipsis chain the topic strip needs (the strip's own `flex: 1`
+   now resolves against THIS wrapper's width, the bar minus the hamburger); the
+   0.5rem gap is the former `.topic-bar` gap between namebox and topic. Fine
+   baseline rhythm between the columns (bold base name vs 0.85rem mode vs 2×
+   mono topic @ line-height 1.5) is a tune-by-eye stretch — #644 IS the owed
+   dogfood/device-verify pass (webkit != iOS). */
+.topic-bar-header {
+  display: flex;
+  align-items: flex-start;
+  flex: 1;
+  min-width: 0;
+  gap: 0.5rem;
 }
 
 /* #305 — the hamburger ADOPTS `.shell-chrome-btn` (base + size tokens) via

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -26161,3 +26161,56 @@ Defect 1 of #642 (the per-IP cap counting the reverse-proxy address) is
 DELIBERATELY out of scope here — it turns on whether prod records the proxy
 address and whether the cap should be per-connection or per-subject (the same
 axis as #632), an open product question owned by vjt.
+---
+
+### 2026-08-02 — #644 — TopicBar auto-centres its text block via a header wrapper (regression of #344, cic)
+
+vjt dogfood screenshot: cic's topic bar rendered the `#channel`/`+modes` namebox
+and the topic lines HIGH in the bar, with visibly more empty space below the
+text than above it, while the ☰ members hamburger on the right sat centred — the
+two halves disagreed and read as misaligned. His ask, verbatim: *"serve un po'
+più di padding o margin top, o meglio ancora usare qualsiasi cosa che lo centri
+in AUTOMATICO"* → **auto-centre, NOT a hand-tuned constant.**
+
+**Root cause.** `.topic-bar` is a flex row. #344 (2026-07-23, commit c02716ce)
+deliberately set `align-items: flex-start` so the two TEXT columns (namebox +
+topic strip) top-align to EACH OTHER — topic line-1 beside the channel name,
+line-2 beside the `+modes` line — instead of each column centring as a whole and
+mis-registering (the columns have different heights). But the members hamburger
+adopts `.shell-chrome-btn` whose `min-height: var(--chrome-tap-min)` (48px, the
+Apple-HIG tap floor) is TALLER than the ~2-line text columns, so on the mobile
+tier (where the hamburger shows, `@media max-width:768px`) it drives the bar's
+cross-axis height. With `align-items: flex-start` the shorter text columns then
+pin to the TOP of that taller bar → they float high, empty space below. The
+hamburger only *looked* centred because it IS the full bar height.
+
+**Why the obvious fixes are wrong.** Reverting `.topic-bar` to `align-items:
+center` alone re-breaks #344: the two columns then centre INDEPENDENTLY and,
+because they differ in height, their lines no longer register. `align-self:
+center` per column has the identical failure. A `padding-top`/`margin-top`
+constant is exactly what vjt rejected — it breaks on the next
+font-size/line-height change.
+
+**Fix.** Group the two text columns under ONE wrapper, sibling to the hamburger:
+`.topic-bar-header` holds `.topic-bar-namebox` + `.topic-bar-topic`. Then
+`.topic-bar { align-items: center }` centres the header block AND the hamburger
+as UNITS (auto-centre, no magic constant), while `.topic-bar-header {
+align-items: flex-start }` PRESERVES #344's intra-block line-registration —
+#344's top-alignment did not die, it moved one level in. The former `.topic-bar`
+0.5rem gap splits: `.topic-bar` gap now separates header|hamburger, the
+`.topic-bar-header` gap separates namebox|topic. The header carries `flex: 1` +
+`min-width: 0` so the topic strip's own `flex: 1` and the namebox 18% width cap
+resolve against the header width (the bar minus the hamburger) — visually
+identical on desktop (no hamburger → header ≈ bar) and marginally more correct
+on mobile (18% of the text area). The desktop tier (hamburger `display: none`,
+only two children) already filled the bar, so it is unchanged.
+
+**Apply:** when a flex row mixes a tall fixed-height control (a tap-floored
+button) with shorter content that must ALSO keep an internal top-alignment,
+don't fight `align-items` on the row — wrap the content and centre the wrapper as
+a unit, keeping `flex-start` inside it. Guard the STRUCTURE in vitest (jsdom has
+no layout engine, so it can't assert centring): the wrapper groups the columns
+and the hamburger stays a sibling. The visual proof is device dogfood (Playwright
+webkit ≠ iOS) — owed on desktop AND iOS.
+
+Deploy class: cic-only (pure CSS + DOM restructure) → HOT / cic bundle.


### PR DESCRIPTION
Refs #644.

## The bug
vjt dogfood: cic's topic bar rendered the `#channel`/`+modes` namebox and the
topic lines HIGH in the bar, with empty space below the text, while the ☰
members hamburger read as centred — the two halves disagreed and looked
misaligned. vjt's acceptance bar (verbatim): *"serve un po' più di padding o
margin top, o meglio ancora usare qualsiasi cosa che lo centri in AUTOMATICO"*
→ **auto-centre, NOT a hand-tuned constant.**

## Root cause (regression surface of #344)
`.topic-bar` is a flex row. #344 (c02716ce) set `align-items: flex-start` so the
two TEXT columns top-align to EACH OTHER (topic line-1 beside the channel name,
line-2 beside `+modes`). But on the mobile tier (`@media max-width:768px`, where
the hamburger shows) the hamburger adopts `.shell-chrome-btn`'s 48px min-height
(the HIG tap floor), taller than the ~2-line text columns, so it drives the
bar's cross-axis height — flex-start then pins the shorter columns to the TOP →
they float high. The hamburger only *looked* centred because it IS the full bar
height.

## Fix
Group the two text columns under one `.topic-bar-header` wrapper, sibling to the
hamburger. `.topic-bar { align-items: center }` centres the header block +
hamburger as UNITS (auto-centre, zero magic constant); `.topic-bar-header {
align-items: flex-start }` PRESERVES #344's intra-block line-registration
(#344's top-alignment moved one level in). Reverting `.topic-bar` to
`align-items: center` alone would re-break #344 (columns centre independently
and mis-register) — hence the wrapper. Desktop (hamburger hidden, two children)
already filled the bar and is unchanged.

## Tests / gates
- `bun run test` — full vitest **3790 passed / 211 files** (incl. 2 new #644
  structure guards: wrapper groups the columns, hamburger stays a sibling).
- `bun run check` — biome + tsc, **exit 0** (37 pre-existing `.is-ios` warnings,
  untouched by this change).
- honest build (fresh `tsbuildinfo` + `bun run build`) — **exit 0**.
- jsdom has no layout engine → the guards pin STRUCTURE, not centring.

## Still owed
Visual proof is **device dogfood** (Playwright webkit ≠ iOS) on desktop AND iOS.
DESIGN_NOTES entry (2026-08-02) lifts the WHY.

Deploy class: cic-only (pure CSS + DOM restructure) → HOT / cic bundle.