### PR TITLE
fix(#573): build the .rpm + state partial releases out loud

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -415,6 +415,27 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
 
+      - name: Trust the checkout for the env-stripped version probe (#573)
+        # The .rpm is the ONLY leg that compiles from the .git checkout INSIDE a
+        # container: the host runner creates $GITHUB_WORKSPACE as its own uid
+        # while these steps run as root, so git trips "detected dubious
+        # ownership" and refuses to operate on it. actions/checkout forgives
+        # that by writing a safe.directory into ~/.gitconfig — but
+        # Grappa.Version.GitProbe shells out env-STRIPPED (System.cmd(_, _,
+        # env: []) so SECRET_KEY_BASE/CLOAK_KEY never reach the subprocess),
+        # which drops HOME, and with no HOME git never reads ~/.gitconfig. Every
+        # describe/rev-parse then fails, the git facts fold to nil,
+        # Grappa.Version reports -dev, and the #542 build-sha guard correctly
+        # refuses to assemble it → the .rpm never builds (v0.8.0 + v0.9.0 both
+        # shipped without one). /etc/gitconfig (SYSTEM config) IS read with no
+        # HOME (nothing sets GIT_CONFIG_NOSYSTEM), so writing the trust there —
+        # for $GITHUB_WORKSPACE, which equals GitProbe's @repo_root exactly —
+        # lets the env-stripped probe see the tag. Leaves the deliberate
+        # env-strip AND the #542 guard untouched; the deb job (no container, no
+        # uid mismatch) and the arch job (builds from the .git-less tarball) are
+        # both immune, so only this leg needs it.
+        run: git config --system --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Verify the tag matches the VERSION file
         run: |
           tag="${RELEASE_TAG#v}"
@@ -632,40 +653,53 @@ jobs:
       # uploads to the EXISTING release without any tag surgery.
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
     steps:
+      - name: Checkout (for the release-asset audit script)
+        uses: actions/checkout@v7
+        with:
+          # publish needs infra/packaging/release_assets.sh (the expected-vs-
+          # arrived audit + the partial-release body marker). NO ref override —
+          # take the TRIGGERING ref, exactly like the docker job: the pushed tag
+          # on a release (it carries the script, committed before the tag) or
+          # the dispatched branch on a #573 (b) repair (it carries the FIXED
+          # script, whereas an OLD tag like v0.8.0 predates this work entirely).
+          # submodules:false — the audit is pure shell; fetch-depth 1 — no git
+          # history is read here. MUST run before download-artifact: checkout's
+          # default clean (git clean -ffdx) would otherwise wipe assets/.
+          submodules: false
+
       - name: Download built artifacts
         uses: actions/download-artifact@v7
         with:
           path: assets
 
-      - name: Create the release and attach whatever built
+      - name: Attach whatever built, audit the set, mark a partial release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           find assets -type f -print
-          # #504 defect 2 — collect ONLY the assets that actually downloaded.
-          # A failed leg never uploaded its artifact, so its files simply are
-          # not here; attaching what IS present publishes the green artifacts
-          # regardless.
+          # #504 defect 2 — attach ONLY the assets that actually downloaded. A
+          # failed leg never uploaded its artifact, so its files simply are not
+          # here; attaching what IS present publishes the green artifacts
+          # regardless, and the dead leg stays red on its own.
           #
-          # Match by NAME at ANY DEPTH, never by path. In run 30399152630
-          # download-artifact unpacked the one green artifact FLAT into
-          # assets/ — despite announcing a per-artifact subdirectory — so the
-          # path-coupled `assets/grappa-deb/*.deb` glob matched nothing and
-          # this step claimed "every package job failed" with the .deb sitting
-          # right there. The layout is the action's business; ours is the file
-          # names. -name also sidesteps the dotglob trap on .SRCINFO.
-          mapfile -t assets < <(find assets -type f \
-            \( -name '*.deb' -o -name '*.rpm' -o -name '*.pkg.tar.zst' \
-               -o -name 'PKGBUILD' -o -name '.SRCINFO' \) | sort)
+          # `found` matches by NAME at ANY DEPTH from the SSOT expected-kinds
+          # table (infra/packaging/release_assets.sh), not a path-coupled glob:
+          # in run 30399152630 download-artifact unpacked the one green artifact
+          # FLAT into assets/ and a path glob matched nothing while the .deb sat
+          # right there. Extracting the glob into that script is what lets the
+          # audit below share ONE definition of "expected" — the whole #573 fix
+          # is that the attach list and the completeness check can never drift.
+          mapfile -t assets < <(infra/packaging/release_assets.sh found assets)
           if [ "${#assets[@]}" -eq 0 ]; then
             echo "::error::no build artifacts present — every package job failed; nothing to publish"
             exit 1
           fi
           printf 'attaching: %s\n' "${assets[@]}"
-          # Create the release on first run; on a re-run the release already
-          # exists, so fall back to uploading with --clobber. BUILD ≠ PUBLISH
-          # TO AUR: the regenerated PKGBUILD/.SRCINFO ride along as assets for
-          # a human to push to aur.archlinux.org — nothing here pushes there.
+
+          # Create the release on first run; on a re-run (or a #573 (b) repair
+          # dispatch to an existing release) fall back to uploading with
+          # --clobber. BUILD ≠ PUBLISH TO AUR: the PKGBUILD/.SRCINFO ride along
+          # as assets a human pushes to aur.archlinux.org — nothing here does.
           if ! gh release create "${RELEASE_TAG}" \
                 --repo "${GITHUB_REPOSITORY}" \
                 --title "grappa ${RELEASE_TAG}" \
@@ -674,4 +708,36 @@ jobs:
             gh release upload "${RELEASE_TAG}" \
               --repo "${GITHUB_REPOSITORY}" --clobber \
               "${assets[@]}"
+          fi
+
+          # State the hole out loud (#573). A partial release used to be
+          # indistinguishable from a complete one AT THE ARTIFACT LIST — two
+          # releases shipped without their .rpm and the red-and-ignored run was
+          # the only trace. Now: name every missing kind in the job summary AND
+          # in the release BODY. GitHub's own run-failure notification already
+          # fired for both losses and nobody acted, so the body marker — what a
+          # human landing on the release page actually reads — is the
+          # load-bearing signal, not the notification.
+          missing="$(infra/packaging/release_assets.sh missing assets)"
+          if [ -n "$missing" ]; then
+            {
+              echo "## ⚠️ Partial release"
+              echo
+              echo "\`${RELEASE_TAG}\` is missing expected package(s):"
+              echo
+              while IFS= read -r label; do echo "- ${label}"; done <<< "$missing"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          # Reconcile the body idempotently: apply-body PREPENDS a sentinel
+          # marker when the set is incomplete and STRIPS a stale one when a (b)
+          # repair dispatch has since completed the set (the converse). Edit
+          # only when the body actually changed, so a complete set on a clean
+          # body is a no-op and a re-run never accretes duplicate blocks.
+          old_body="$(gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --json body -q .body)"
+          new_body="$(printf '%s' "$old_body" | infra/packaging/release_assets.sh apply-body assets)"
+          if [ "$new_body" != "$old_body" ]; then
+            gh release edit "${RELEASE_TAG}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --notes "$new_body"
           fi

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -26358,3 +26358,61 @@ matrix firing on a one-character bump (lightweight over heavyweight).
 
 Deploy class: the migration commit touches `mix.exs` → COLD (once). AFTER it,
 a bump touches only `VERSION` → HOT.
+
+---
+
+## 2026-08-02 — #573: the .rpm leg's env-stripped version probe + the partial-release marker
+
+Two releases (v0.8.0, v0.9.0) shipped **without their `.rpm`**, and a partial
+release was indistinguishable from a complete one. Both runs were red and
+nobody looked — *red-and-ignored* was the actual defect. Two independent fixes,
+both in `.github/workflows/release.yml`; no `lib/` change.
+
+**Root cause of the missing .rpm — SYSTEM-config `safe.directory`.** The `rpm`
+job is the ONLY leg that compiles from the `.git` checkout INSIDE a container
+(`container: fedora:43`). The host runner creates `$GITHUB_WORKSPACE` as its
+own uid while the container's steps run as root, so git trips *"detected
+dubious ownership"*. `actions/checkout` forgives that by writing a
+`safe.directory` into `~/.gitconfig` — but `Grappa.Version.GitProbe` shells out
+**env-stripped** (`System.cmd(_, _, env: [])`, deliberate: keeps
+`SECRET_KEY_BASE`/`CLOAK_KEY` out of the subprocess), and `env: []` drops
+`HOME`, so git never reads `~/.gitconfig`. Every `describe`/`rev-parse` fails →
+git facts fold to `nil` → `Grappa.Version` reports `-dev` → the #542 build-sha
+guard **correctly** refuses to assemble → the `.rpm` never builds. The `deb`
+job (no container, no uid mismatch) and the `arch` job (builds from the
+`.git`-less tarball) are both immune. Fix: one step in the rpm job,
+`git config --system --add safe.directory "$GITHUB_WORKSPACE"` — `/etc/gitconfig`
+(SYSTEM config) IS read with no `HOME` (nothing sets `GIT_CONFIG_NOSYSTEM`), and
+`$GITHUB_WORKSPACE` equals GitProbe's `@repo_root` exactly. **Rejected:**
+relaxing the #542 guard (it caught a real `0.9.0-dev` artifact), giving GitProbe
+a full env (re-exposes the secrets the env-strip exists to hide), or chowning the
+tree (heavier; re-breaks on a runner uid change).
+
+**Stating the hole — the partial-release marker.** Publish stays
+`needs: [deb, arch, rpm]` + `if: !cancelled()` (#504 defect 2 is NOT reverted: a
+green artifact still ships when a sibling leg dies) and the run stays red (the
+dead leg fails on its own). What was missing is *visibility*. The set logic —
+which asset kinds SHOULD exist vs which arrived — used to be an inline `find`
+glob in YAML with no notion of "expected", so it failed silently. It is now a
+tested script, **`infra/packaging/release_assets.sh`**, the SSOT of the expected
+asset set: `found` (the attach glob), `missing` (labels of absent kinds),
+`notice` / `apply-body` (a sentinel-delimited `> [!WARNING]` block in the release
+body). The publish job checks out the repo (NO ref override — the triggering
+ref's tree carries the FIXED script, exactly like the docker job; an OLD tag
+predates it), attaches what `found` returns, writes a `## ⚠️ Partial release`
+section to `$GITHUB_STEP_SUMMARY` on a gap, and reconciles the body
+idempotently via `apply-body` (prepend when incomplete; STRIP a stale block
+when a (b) repair dispatch has since completed the set — the converse).
+Idempotent + converse are pinned by `test/infra/release_assets_test.bats`.
+
+**The body marker is load-bearing, not decoration.** GitHub's native
+run-failure notification already fired for BOTH lost releases and nobody acted,
+so the notification is not what makes the hole visible — the body marker (what a
+human landing on the release page reads) is. **Notification transport = GitHub
+native, decided (vjt, 2026-08-02).** No CI→IRC channel was built.
+
+**(b) retroactive reattach** of the `.rpm` to v0.8.0 + v0.9.0 via
+`workflow_dispatch` per tag (the rpm job takes `RELEASE_TAG` from `inputs.tag`,
+checks out that tag, `fetch-depth: 0`) is vjt-wanted, blocked on (a) landing,
+and the dispatch is an operator step (it publishes to real releases) — not part
+of this merge.

--- a/infra/packaging/release_assets.sh
+++ b/infra/packaging/release_assets.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# release_assets.sh — the single source of truth for grappa's EXPECTED
+# release asset set, and the completeness audit derived from it (#573).
+#
+# The release `publish` job used to inline its "collect what built" find
+# glob and had NO notion of what SHOULD have built. So two releases
+# (v0.8.0, v0.9.0) shipped without their .rpm — the rpm leg died, publish
+# attached whatever downloaded, and the artifact list was
+# INDISTINGUISHABLE from a complete one. Red-and-ignored: the run was red
+# both times and nobody looked. See #573.
+#
+# This script closes the hole by deriving BOTH the attach glob (`found`)
+# and the audit (`missing`/`notice`/`apply-body`) from ONE expected-kinds
+# table, so the two can never drift. It is pure filesystem + string logic
+# (no docker, no network, no mix), which is exactly why it can live under
+# bats (test/infra/release_assets_test.bats) rather than untested inside
+# release.yml — the bug lived in the untested inline YAML.
+#
+# Subcommands (the bats suite pins the contract — fit the script to it):
+#   found <dir>       every file under <dir> matching an expected kind BY
+#                     NAME at ANY depth, sorted, one per line. Name-, not
+#                     path-matched: download-artifact has unpacked the tree
+#                     flat before (run 30399152630), which a path-coupled
+#                     glob missed.
+#   missing <dir>     the human LABEL of each expected kind with no matching
+#                     file, one per line. Empty output = complete set.
+#   notice <dir>      nothing if complete; else a sentinel-delimited markdown
+#                     block naming the gap.
+#   apply-body <dir>  read a release body from STDIN, strip any existing
+#                     sentinel block, and — only if the set is incomplete —
+#                     PREPEND a fresh one. Print the result. Idempotent (run
+#                     twice = one block); the converse holds too, a
+#                     now-complete set REMOVES a stale block (the #573 (b)
+#                     repair reconciles the body back to clean).
+#   anything else     usage error (non-zero exit).
+#
+# Follows the sibling packaging scripts' shape (build.sh / version.sh):
+# bash, `set -euo pipefail`, self-locating, loud on misuse.
+set -euo pipefail
+
+# The EXPECTED release asset kinds: one `find -name` pattern + its human
+# label per line, TAB-separated. This table IS the contract — the attach
+# glob and the audit both read it, so a new package kind is added in ONE
+# place and both halves follow. Keep it byte-aligned with the bats suite.
+expected_kinds() {
+	printf '%s\n' \
+		'*.deb	Debian package (.deb)' \
+		'*.rpm	RPM package (.rpm)' \
+		'*.pkg.tar.zst	Arch package (.pkg.tar.zst)' \
+		'PKGBUILD	Arch PKGBUILD recipe' \
+		'.SRCINFO	Arch .SRCINFO recipe'
+}
+
+# Sentinel markers delimiting the partial-release block inside a release
+# body. `apply-body` keys strip/replace off these, never off the block
+# TEXT, so the block wording can change without breaking idempotency.
+SENTINEL_START='<!-- grappa:partial-release:start -->'
+SENTINEL_END='<!-- grappa:partial-release:end -->'
+
+# found <dir> — every expected-kind file under <dir>, by name at any depth,
+# sorted. The publish job's attach list.
+found() {
+	local dir="$1" pat label
+	while IFS=$'\t' read -r pat label; do
+		find "$dir" -type f -name "$pat"
+	done < <(expected_kinds) | sort
+}
+
+# missing <dir> — the label of every expected kind with no matching file.
+# Empty stdout means the set is complete.
+missing() {
+	local dir="$1" pat label
+	while IFS=$'\t' read -r pat label; do
+		if [ -z "$(find "$dir" -type f -name "$pat")" ]; then
+			printf '%s\n' "$label"
+		fi
+	done < <(expected_kinds)
+}
+
+# is_complete <dir> — true when nothing is missing.
+is_complete() {
+	[ -z "$(missing "$1")" ]
+}
+
+# notice_block <dir> — the sentinel-delimited markdown block naming the
+# gap. Caller must only invoke it on an incomplete set.
+notice_block() {
+	local dir="$1" label
+	printf '%s\n' "$SENTINEL_START"
+	printf '> [!WARNING]\n'
+	printf '> **Partial release** — the following expected package(s) failed to build and are NOT attached to this release:\n'
+	while IFS= read -r label; do
+		printf '> - %s\n' "$label"
+	done < <(missing "$dir")
+	printf '%s\n' "$SENTINEL_END"
+}
+
+# notice <dir> — the block if incomplete, nothing if complete.
+notice() {
+	local dir="$1"
+	if is_complete "$dir"; then
+		return 0
+	fi
+	notice_block "$dir"
+}
+
+# strip_block — remove every existing sentinel block (inclusive) from stdin.
+strip_block() {
+	awk -v s="$SENTINEL_START" -v e="$SENTINEL_END" '
+		index($0, s) { skip = 1 }
+		skip && index($0, e) { skip = 0; next }
+		!skip { print }
+	'
+}
+
+# apply-body <dir> — reconcile the STDIN release body with the current
+# asset set: strip any stale block, prepend a fresh one iff incomplete.
+apply_body() {
+	local dir="$1" body stripped
+	body="$(cat)"
+	# Strip the old block, then drop the leading blank lines it left behind
+	# so a re-run doesn't accrete whitespace above the changelog.
+	stripped="$(printf '%s\n' "$body" | strip_block | sed '/./,$!d')"
+	if is_complete "$dir"; then
+		printf '%s\n' "$stripped"
+	else
+		notice_block "$dir"
+		printf '\n'
+		printf '%s\n' "$stripped"
+	fi
+}
+
+main() {
+	local cmd="${1:-}"
+	case "$cmd" in
+		found | missing | notice)
+			[ "$#" -eq 2 ] || die_usage
+			"$cmd" "$2"
+			;;
+		apply-body)
+			[ "$#" -eq 2 ] || die_usage
+			apply_body "$2"
+			;;
+		*)
+			die_usage
+			;;
+	esac
+}
+
+die_usage() {
+	printf 'usage: %s {found|missing|notice|apply-body} <assets-dir>\n' "${0##*/}" >&2
+	exit 2
+}
+
+main "$@"

--- a/test/infra/release_assets_test.bats
+++ b/test/infra/release_assets_test.bats
@@ -1,0 +1,152 @@
+#!/usr/bin/env bats
+#
+# Bats suite for infra/packaging/release_assets.sh (#573).
+#
+# The release publish job used to inline its "collect what built" find glob
+# and had NO notion of what SHOULD have built — so two releases (v0.8.0,
+# v0.9.0) shipped without their .rpm and the artifact list was
+# indistinguishable from a complete one. This script is the SSOT of the
+# EXPECTED release asset set; both the attach glob (`found`) and the
+# completeness audit (`missing`/`notice`/`apply-body`) derive from that one
+# list, so a silent hole is now impossible.
+#
+# Scope: the SET LOGIC (expected vs arrived) + the idempotent partial-release
+# body marker — the bug-prone parts that must not live untested in YAML.
+# Pure filesystem + string logic; no docker, no network, no mix.
+
+setup() {
+    REPO_SRC="$BATS_TEST_DIRNAME/../.."
+    SCRIPT="$REPO_SRC/infra/packaging/release_assets.sh"
+
+    # A downloaded-artifacts tree, nested per-artifact subdir (the layout
+    # download-artifact usually produces).
+    ASSETS="$BATS_TEST_TMPDIR/assets"
+    mkdir -p "$ASSETS/grappa-deb" "$ASSETS/grappa-rpm" "$ASSETS/grappa-arch"
+}
+
+# Populate a COMPLETE, realistic asset tree (every expected kind present).
+seed_complete() {
+    : > "$ASSETS/grappa-deb/grappa_0.8.0_amd64.deb"
+    : > "$ASSETS/grappa-rpm/grappa-0.8.0-1.x86_64.rpm"
+    : > "$ASSETS/grappa-arch/grappa-0.8.0-1-x86_64.pkg.tar.zst"
+    : > "$ASSETS/grappa-arch/PKGBUILD"
+    : > "$ASSETS/grappa-arch/.SRCINFO"
+}
+
+@test "found: a complete nested tree lists every expected asset file" {
+    seed_complete
+    run "$SCRIPT" found "$ASSETS"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q 'grappa_0.8.0_amd64.deb'
+    echo "$output" | grep -q 'grappa-0.8.0-1.x86_64.rpm'
+    echo "$output" | grep -q 'grappa-0.8.0-1-x86_64.pkg.tar.zst'
+    echo "$output" | grep -q '/PKGBUILD$'
+    echo "$output" | grep -q '/.SRCINFO$'
+    [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 5 ]
+}
+
+@test "found: matches by NAME at any depth, not by a path-coupled glob (flat layout)" {
+    # Regression guard for run 30399152630: download-artifact unpacked the
+    # green artifact FLAT into assets/, so a path-coupled glob matched
+    # nothing. Names, at any depth, must still be found.
+    : > "$ASSETS/grappa_0.8.0_amd64.deb"
+    run "$SCRIPT" found "$ASSETS"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q 'grappa_0.8.0_amd64.deb'
+}
+
+@test "missing: a complete set reports nothing" {
+    seed_complete
+    run "$SCRIPT" missing "$ASSETS"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "missing: a dropped .rpm is named (the #573 instance)" {
+    seed_complete
+    rm "$ASSETS/grappa-rpm/grappa-0.8.0-1.x86_64.rpm"
+    run "$SCRIPT" missing "$ASSETS"
+    [ "$status" -eq 0 ]
+    [ "$output" = "RPM package (.rpm)" ]
+}
+
+@test "missing: a dead Arch leg names all three of its outputs" {
+    seed_complete
+    rm "$ASSETS/grappa-arch/grappa-0.8.0-1-x86_64.pkg.tar.zst"
+    rm "$ASSETS/grappa-arch/PKGBUILD"
+    rm "$ASSETS/grappa-arch/.SRCINFO"
+    run "$SCRIPT" missing "$ASSETS"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q 'Arch package (.pkg.tar.zst)'
+    echo "$output" | grep -q 'Arch PKGBUILD recipe'
+    echo "$output" | grep -q 'Arch .SRCINFO recipe'
+    [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 3 ]
+}
+
+@test "missing: an empty assets tree names every expected kind" {
+    run "$SCRIPT" missing "$ASSETS"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | wc -l | tr -d ' ')" -eq 5 ]
+}
+
+@test "notice: a complete set produces no marker block" {
+    seed_complete
+    run "$SCRIPT" notice "$ASSETS"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "notice: a partial set emits a sentinel-delimited block naming the gap" {
+    seed_complete
+    rm "$ASSETS/grappa-rpm/grappa-0.8.0-1.x86_64.rpm"
+    run "$SCRIPT" notice "$ASSETS"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q '<!-- grappa:partial-release:start -->'
+    echo "$output" | grep -q '<!-- grappa:partial-release:end -->'
+    echo "$output" | grep -q 'RPM package (.rpm)'
+}
+
+@test "apply-body: a partial set prepends the block, and is idempotent" {
+    seed_complete
+    rm "$ASSETS/grappa-rpm/grappa-0.8.0-1.x86_64.rpm"
+    printf '## What'\''s Changed\n\n- a real changelog line\n' > "$BATS_TEST_TMPDIR/body.md"
+
+    run bash -c "'$SCRIPT' apply-body '$ASSETS' < '$BATS_TEST_TMPDIR/body.md'"
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" > "$BATS_TEST_TMPDIR/body2.md"
+    # block present exactly once, changelog preserved
+    [ "$(grep -c 'grappa:partial-release:start' "$BATS_TEST_TMPDIR/body2.md")" -eq 1 ]
+    grep -q 'a real changelog line' "$BATS_TEST_TMPDIR/body2.md"
+    grep -q 'RPM package (.rpm)' "$BATS_TEST_TMPDIR/body2.md"
+
+    # Feeding the already-marked body back in must NOT double the block.
+    run bash -c "'$SCRIPT' apply-body '$ASSETS' < '$BATS_TEST_TMPDIR/body2.md'"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s\n' "$output" | grep -c 'grappa:partial-release:start')" -eq 1 ]
+}
+
+@test "apply-body: a now-complete set strips a stale marker block (the repair converse)" {
+    # A prior partial publish left a marker; the repair dispatch rebuilt the
+    # missing leg, so the set is complete now — the marker must be removed.
+    seed_complete
+    {
+        echo '<!-- grappa:partial-release:start -->'
+        echo '> [!WARNING]'
+        echo '> **Partial release.** Missing: RPM package (.rpm)'
+        echo '<!-- grappa:partial-release:end -->'
+        echo ''
+        echo '## What'\''s Changed'
+        echo ''
+        echo '- a real changelog line'
+    } > "$BATS_TEST_TMPDIR/body.md"
+
+    run bash -c "'$SCRIPT' apply-body '$ASSETS' < '$BATS_TEST_TMPDIR/body.md'"
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -q 'a real changelog line'
+    ! printf '%s\n' "$output" | grep -q 'grappa:partial-release'
+}
+
+@test "usage: an unknown subcommand fails loudly" {
+    run "$SCRIPT" frobnicate "$ASSETS"
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Refs #573.

Two releases (v0.8.0, v0.9.0) shipped **without their `.rpm`** and a partial release was indistinguishable from a complete one — both runs were red and nobody looked. Two fixes, both in `release.yml`; **no `lib/` change**.

## (a) Build the .rpm — SYSTEM-config `safe.directory`

The `rpm` job is the ONLY leg that compiles from the `.git` checkout **inside a container** (`fedora:43`). The host runner owns `$GITHUB_WORKSPACE` by its uid while the container runs as root → git trips *"dubious ownership"*. `actions/checkout` forgives it via `~/.gitconfig`, but `Grappa.Version.GitProbe` shells out **env-stripped** (`env: []` keeps `SECRET_KEY_BASE`/`CLOAK_KEY` out of the subprocess), which drops `HOME`, so git never reads `~/.gitconfig`. Every `describe`/`rev-parse` fails → facts `nil` → Version reports `-dev` → the #542 build-sha guard correctly refuses to assemble → no `.rpm`.

**Fix:** one step, `git config --system --add safe.directory "$GITHUB_WORKSPACE"`. `/etc/gitconfig` IS read with no `HOME` (nothing sets `GIT_CONFIG_NOSYSTEM`), and `$GITHUB_WORKSPACE` == GitProbe's `@repo_root`. Env-strip and the #542 guard left untouched; `deb` (no container) and `arch` (tarball build) are already immune.

## (c) State the hole out loud

The set logic (expected vs arrived assets) was an inline `find` glob in YAML with no notion of *expected*, so it failed silently. Now **`infra/packaging/release_assets.sh`** — the SSOT of the expected asset kinds — under bats (`found`/`missing`/`notice`/`apply-body`). `publish` checks out the script (no ref override, like the docker job), attaches what `found` returns, names any gap in `$GITHUB_STEP_SUMMARY`, and reconciles the release body **idempotently**: prepend a `> [!WARNING]` partial-release marker when incomplete; **strip** a stale one once a repair dispatch completes the set (the converse). The body marker is load-bearing — GitHub's native notification already fired for both losses and nobody acted.

## Constraints honoured

- `publish` stays `needs: [deb, arch, rpm]` + `if: !cancelled()` — **no revert of #504 defect 2** (a green artifact still ships when a sibling dies).
- The run **stays red** (the dead leg fails on its own).
- Notification transport = **GitHub native** (decided; no CI→IRC channel built).
- **(b)** retroactive `.rpm` reattach to v0.8.0/v0.9.0 is an **operator `workflow_dispatch`**, blocked on this landing — not in this PR.

## Gates (green)

- `scripts/bats.sh test/infra/release_assets_test.bats` → **11/11** (RED-proven before the script existed, then GREEN).
- `scripts/check.sh` → **RC 0**: 4924 tests / 0 failures (+ 8 doctests, 50 properties), Dialyzer *passed successfully*, Credo + Sobelow clean, full bats **219 ok / 0 fail**.
- `release.yml` YAML-valid; publish run-block + script **shellcheck clean**.
- No integration/e2e (CI/packaging + shell + bats only; no cic, no runtime).