### PR TITLE
fix(#343): make the /msg-to-channel refusal explicit (cic, copy-only)

### DIFF
--- a/cicchetto/src/__tests__/slashCommands.test.ts
+++ b/cicchetto/src/__tests__/slashCommands.test.ts
@@ -327,16 +327,25 @@ describe("parseSlash — /msg", () => {
     expect(parseSlash("/msg alice")).toMatchObject({ kind: "error", verb: "msg" });
   });
 
-  // #12 — /msg is for nicks (queries). grappa does not relay a PRIVMSG to a
-  // channel addressed by name, so a channel-shaped target opened a phantom
+  // #12/#343 — /msg is for nicks (queries). grappa does not relay a PRIVMSG to
+  // a channel addressed by name, so a channel-shaped target opened a phantom
   // query window keyed by a channel name whose own-send never rendered.
-  // Reject every IRC channel sigil (# & ! +) up front, not just '#'.
+  // Reject every IRC channel sigil (# & ! +) up front, not just '#'. #343: the
+  // refusal STAYS but the message must be EXPLICIT — say THAT it is refused,
+  // WHY (/msg addresses nicks), and WHAT to type instead (open/join the
+  // channel window). Pin that actionable guidance so it can never regress to
+  // the bare "not supported" string.
   it.each(["#foo", "&local", "!12345chan", "+modeless"])(
-    "/msg to a channel (%s) is rejected (#12)",
+    "/msg to a channel (%s) is rejected with explicit guidance (#12/#343)",
     (chan) => {
       const r = parseSlash(`/msg ${chan} hello`);
       expect(r).toMatchObject({ kind: "error", verb: "msg" });
-      expect((r as { message: string }).message).toMatch(/channel/i);
+      const { message } = r as { message: string };
+      expect(message).toMatch(/channel/i);
+      // Actionable guidance — the whole point of #343.
+      expect(message).toMatch(/open|join|window|type/i);
+      // Names the offending target so the user knows what was refused.
+      expect(message).toContain(chan);
     },
   );
 });

--- a/cicchetto/src/lib/slashCommands.ts
+++ b/cicchetto/src/lib/slashCommands.ts
@@ -418,8 +418,16 @@ const DISPATCH: Readonly<Record<string, Handler>> = {
     // Reject every IRC channel sigil (# & ! +) up front, otherwise compose.ts
     // opens a phantom query window keyed by the channel name whose WS-driven
     // own-send never renders (cic only subscribes to JOINED channel topics).
+    // #343 — the refusal STAYS by design, but say so out loud: name the
+    // target, explain that /msg addresses nicks, and point at what to type
+    // instead (open the channel's window / /join it, then type there). The
+    // guard is unconditional — no joined-state check — so the guidance is
+    // "open its window", never "/msg after joining".
     if (["#", "&", "!", "+"].includes(target[0] ?? "")) {
-      return err(verb, "/msg to a channel is not supported");
+      return err(
+        verb,
+        `/msg is for private messages to a nick, not channels. To message ${target}, open its window (or /join ${target}) and type your message there.`,
+      );
     }
     return { kind: "msg", target, body };
   },

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -26469,3 +26469,33 @@ in each pin's inline comment + the test header.
 Deploy class: HOT (no `.ex`, no `mix.exs`/`mix.lock`; scripts + compose +
 Dockerfile.release + a bats test). The Dockerfile.release + e2e-compose pins are
 only exercised by the release/integration CI, not a running node.
+
+---
+
+## 2026-08-02 — #343: `/msg #chan` refusal is KEPT by design — the bare error becomes an explicit one (cic, copy-only)
+
+`/msg #chan text` in cic has always been refused at the parser
+(`slashCommands.ts`, rationale #12): grappa does not relay a name-addressed
+PRIVMSG to a channel, and cic only subscribes to the topics of channels it has
+**joined**, so letting `/msg #chan` through would make `compose.ts` open a
+phantom query window keyed by the channel name whose WS-driven own-send never
+renders — a dead window. The refusal is correct; the defect was that it read
+like a bug (`"/msg to a channel is not supported"` — flat, no *why*, no *what to
+do instead*).
+
+**Decision (vjt, 2026-08-02): the refusal stays — but it must say so out loud.**
+Making `/msg #chan` actually send would mean touching the SUBSCRIBE path (open a
+window for a non-joined channel), which is explicitly out of scope for this
+issue. So the ONLY change is the user-facing string: name the target, explain
+that `/msg` addresses nicks not channels, and point at what to type instead —
+open the channel's window (or `/join` it) and type there. The guard is
+unconditional (no joined-state check — that would be the subscribe path we are
+NOT touching), so the guidance is "open its window", never "/msg after joining".
+
+Scope: cic-only, copy-only. One production line changed
+(`slashCommands.ts`, the `msg:` handler's channel-sigil branch); the
+`kind:"error"` shape, the `compose.ts` render mechanism, the parser structure,
+and `subscribe.ts` are all UNCHANGED. No wire token, no server change. The
+unit test (`slashCommands.test.ts`, `describe("parseSlash — /msg")`) was
+strengthened to pin the actionable guidance (`/open|join|window|type/i` + the
+target name), so the message can never silently regress to the bare string.


### PR DESCRIPTION
## What

`/msg #chan text` is refused at the cic parser **by design** (rationale #12): grappa never relays a name-addressed PRIVMSG to a channel, and cic only subscribes to the topics of channels it has **joined** — letting it through would open a phantom query window whose WS-driven own-send never renders. The refusal is correct; the defect was that the bare error (`"/msg to a channel is not supported"`) read like a bug — no *why*, no *what to do instead*.

Per vjt (2026-08-02) **the refusal stays** — making `/msg #chan` actually send would mean touching the SUBSCRIBE path (open a window for a non-joined channel), which is explicitly out of scope. The only change is the user-facing string:

```
/msg is for private messages to a nick, not channels. To message #foo,
open its window (or /join #foo) and type your message there.
```

It names the target, explains that `/msg` addresses nicks not channels, and points at what to type instead. The guard stays **unconditional** (no joined-state check — that would be the subscribe path we are NOT touching), so the guidance is "open its window", never "/msg after joining".

## Scope

- **cic-only, copy-only.** One production line changed (`slashCommands.ts`, the `msg:` handler's channel-sigil branch).
- **Unchanged:** the `kind:"error"` shape, the `compose.ts` render mechanism, the parser structure, `subscribe.ts`. No wire token, no server change.
- The `/msg` unit test (`slashCommands.test.ts`) is **strengthened** (RED-first) to pin the actionable guidance (`/open|join|window|type/i` + the target name) so the message can never silently regress to the bare string.
- `DESIGN_NOTES.md` records the decision.

## Gates

- `bun run test` (full vitest): **212 files / 3815 tests green** (the strengthened `/msg` rejection cases included).
- `tsc --noEmit` (run **standalone** — see note below): **exit 0**.
- biome scoped to the two changed cic files: **clean** (no fixes, no diagnostics).
- No COMPILE lane (zero Elixir changes); no STACK/integration needed (no server/runtime/wire change).
- **e2e:** `grep -rn "to a channel is not supported" cicchetto/` → only the production line matched (now changed); **no spec/e2e asserts the old string**, so no e2e change is required and none was run. (`integration.yml` still triggers on `cicchetto/src/**`, so the e2e job runs on this PR; it doesn't assert this string.)

## ⚠️ Pre-existing main note (#515 — NOT this PR's scope, do NOT fix here)

`bun run check` exits 1 on **pristine main (bc80a7b0, clean tree)** too — 2 pre-existing biome **errors** (`src/themes/default.css` `noDescendingSpecificity`, `src/__tests__/BottomBar.test.tsx` `noNonNullAssertion`). These are **#515** (biome caret-float renders clean code red — already in queue; no new issue, out of scope for #343). My change is **zero-delta** on biome.

**Worse than a dirty lint, and worth escalating:** `check` = `biome check src && tsc --noEmit`, so **biome-red short-circuits tsc — tsc never runs**. On main the cic **type-check gate is BLIND** (and there's no cic biome/tsc/vitest job in `ci.yml` to catch it — only Elixir `test`, `shottino`, `dialyzer` + `integration.yml` e2e). This PR's type-safety was therefore verified via **standalone `tsc --noEmit` (exit 0)**, not the composite `check`.

Refs #343