### PR TITLE
build(#103): pin oven/bun + nginx:alpine base images to content digests

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -20,7 +20,10 @@
 # bun's binary is musl-built on alpine, so build the PWA in oven/bun's alpine
 # image (mirrors the release CI's setup-bun + infra/packaging/build.sh's
 # `bun run build`). node_modules is .dockerignore'd — installed fresh here.
-FROM oven/bun:1-alpine AS cic
+# Digest-pinned (#103 supply-chain — this is the alpine variant, a SEPARATE
+# tag/digest from the debian oven/bun:1 the dev scripts use). Refresh on a
+# bump: docker buildx imagetools inspect oven/bun:1-alpine --format '{{.Manifest.Digest}}'
+FROM oven/bun:1-alpine@sha256:5acc90a93e91ff07bf72aa90a7c9f0fa189765aec90b47bdbf2152d2196383c0 AS cic
 WORKDIR /cic
 # Lockfile + manifest first for a cache-friendly, frozen install layer.
 COPY cicchetto/package.json cicchetto/bun.lock ./

--- a/cicchetto/e2e/compose.yaml
+++ b/cicchetto/e2e/compose.yaml
@@ -490,7 +490,9 @@ services:
       retries: 30
 
   cicchetto-build-test:
-    image: oven/bun:1
+    # oven/bun digest-pinned (#103). Refresh on a bump:
+    # docker buildx imagetools inspect oven/bun:1 --format '{{.Manifest.Digest}}'
+    image: oven/bun:1@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4
     # Use the operator's UID/GID so writes to the bind-mounted host
     # cache dir + the dist named volume match host ownership. Mirrors
     # scripts/bun.sh's --user pattern. CONTAINER_UID/GID are exported
@@ -540,7 +542,9 @@ services:
     command: ["/bin/sh", "/certs/gen-cert.sh"]
 
   nginx-test:
-    image: nginx:alpine
+    # nginx:alpine digest-pinned (#103 — `alpine` floats). Refresh on a bump:
+    # docker buildx imagetools inspect nginx:alpine --format '{{.Manifest.Digest}}'
+    image: nginx:alpine@sha256:4a73073bd557c65b759505da037898b61f1be6cbcc3c2c3aeac22d2a470c1752
     container_name: grappa-e2e-nginx
     hostname: nginx-test
     depends_on:

--- a/compose.yaml
+++ b/compose.yaml
@@ -174,7 +174,9 @@ services:
   # and makes dist/ inspectable from the host.
   cicchetto-build:
     profiles: [prod]
-    image: oven/bun:1
+    # oven/bun digest-pinned (#103 supply-chain). Refresh on an intentional
+    # bump: docker buildx imagetools inspect oven/bun:1 --format '{{.Manifest.Digest}}'
+    image: oven/bun:1@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4
     user: "${CONTAINER_UID:-1000}:${CONTAINER_GID:-1000}"
     working_dir: /app
     volumes:

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -26416,3 +26416,56 @@ native, decided (vjt, 2026-08-02).** No CI→IRC channel was built.
 checks out that tag, `fetch-depth: 0`) is vjt-wanted, blocked on (a) landing,
 and the dispatch is an operator step (it publishes to real releases) — not part
 of this merge.
+## 2026-08-02 — #103: pin the moving base-image tags (oven/bun, nginx:alpine) to content digests
+
+**Problem.** `oven/bun:1` (dev scripts + the cicchetto-build compose oneshots)
+and `nginx:alpine` (the e2e stack) are MOVING tags — `oven/bun:1` advances
+across bun majors, `nginx:alpine` floats `alpine`. Two builds a week apart can
+pull different bytes, so a "reproducible" build isn't. (The prod nginx CONTAINER
+the issue originally named is gone since #485 — the BEAM serves the SPA and the
+jail's nginx is a FreeBSD package, not an image — so the only remaining
+`nginx:alpine` is the e2e one.)
+
+**Fix.** Pin every reference to `image:tag@sha256:<digest>`, keeping the tag for
+human readability and the digest for reproducibility. The digest pinned is the
+multi-arch INDEX digest (the tag's registry digest, from
+`docker buildx imagetools inspect <tag> --format '{{.Manifest.Digest}}'`), NOT
+a per-platform manifest — so Docker still resolves linux/amd64 (CI) and
+linux/arm64 (dev host) from within the index; the pin removes drift without
+locking to one architecture.
+
+**Two distinct oven/bun tags, two digests.** The dev/test paths use `oven/bun:1`
+(debian); `Dockerfile.release`'s cic stage uses `oven/bun:1-alpine` (bun is
+musl-built, matched to the alpine runtime) — a SEPARATE tag with its own digest.
+Both are pinned; they are not interchangeable.
+
+**Occurrences pinned:** `scripts/bun.sh` (one `BUN_IMAGE` constant, reused at the
+implicit-install + real-invocation call sites), `compose.yaml` cicchetto-build,
+`Dockerfile.release` cic stage (`:1-alpine`), `cicchetto/e2e/compose.yaml`
+(oven/bun + nginx:alpine).
+
+**Scope (deliberate).** Only the two tags the issue names. `elixir:1.19-otp-28-alpine`
+(dev Dockerfile + release build stage), `alpine:3.24`/`alpine:3.20`,
+`debian:trixie` (e2e ircd images), and `tonistiigi/binfmt:latest` (release CI)
+are LEFT as-is. Their drift risk varies — `elixir`/`alpine` float a patch,
+`debian:trixie` floats the whole Debian stable release, `binfmt:latest` floats
+everything — but none is the major-moving `oven/bun:1` the issue named, and
+pinning every base image in the tree (a `Dockerfile.release` half-pinned against
+its own `elixir`/`alpine` siblings is the sharpest instance) is a larger,
+separate task. The drift guard enforces consistency WITHIN the pinned families;
+a follow-up should file + pin the rest so the half-pin is a tracked TODO, not a
+silent divergence. Out of scope too: `oven-sh/setup-bun@v2` in release CI is a
+GitHub Action, not a container base image.
+
+**Drift guard.** `test/infra/base_image_digest_pin_test.bats` fails the moment a
+real `oven/bun`/`nginx:alpine` reference loses its `@sha256:` (root-cause fix,
+not just today's instances) — it `git grep`s tracked build files, excludes
+comment lines + the docs/test prose trees (which name the tags in prose and the
+`# Refresh:` hints), and refuses a vacuous pass (asserts ≥4 refs found). A
+second test pins the digest FORMAT (`sha256:<64 lowercase hex>`) so a truncated
+paste fails fast at unit time, not slowly at build time. Refresh procedure lives
+in each pin's inline comment + the test header.
+
+Deploy class: HOT (no `.ex`, no `mix.exs`/`mix.lock`; scripts + compose +
+Dockerfile.release + a bats test). The Dockerfile.release + e2e-compose pins are
+only exercised by the release/integration CI, not a running node.

--- a/scripts/bun.sh
+++ b/scripts/bun.sh
@@ -36,6 +36,13 @@
 
 . "$(dirname "$0")/_lib.sh"
 
+# oven/bun image, digest-pinned (#103 supply-chain: `oven/bun:1` is a
+# major-moving tag). The tag stays for human readability; the @sha256 index
+# digest enforces reproducibility and still resolves multi-arch (amd64 CI +
+# arm64 dev host). Refresh on an intentional bump:
+#   docker buildx imagetools inspect oven/bun:1 --format '{{.Manifest.Digest}}'
+readonly BUN_IMAGE="oven/bun:1@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4"
+
 CICCHETTO_DIR="$SRC_ROOT/cicchetto"
 BUN_CACHE_DIR="$REPO_ROOT/runtime/bun-cache"
 mkdir -p "$CICCHETTO_DIR" "$BUN_CACHE_DIR"
@@ -85,7 +92,7 @@ case "${1:-}" in
     *)
         if [ ! -d "$CICCHETTO_DIR/node_modules" ]; then
             printf 'scripts/bun.sh: cicchetto/node_modules missing — running bun install...\n' >&2
-            run_bun oven/bun:1 bun install >&2
+            run_bun "$BUN_IMAGE" bun install >&2
         fi
         ;;
 esac
@@ -99,4 +106,4 @@ if [ "${1:-}" = "run" ] && { [ "${2:-}" = "dev" ] || [ "${2:-}" = "preview" ]; }
     PORT_ARGS=(-p 5173:5173)
 fi
 
-run_bun "${PORT_ARGS[@]}" oven/bun:1 bun "$@"
+run_bun "${PORT_ARGS[@]}" "$BUN_IMAGE" bun "$@"

--- a/test/infra/base_image_digest_pin_test.bats
+++ b/test/infra/base_image_digest_pin_test.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+#
+# Bats suite for GH #103 — supply-chain: the moving base-image tags
+# (`oven/bun:1` / `oven/bun:1-alpine` and `nginx:alpine`) MUST be pinned to a
+# content digest (`image:tag@sha256:...`) for reproducible builds.
+#
+# `oven/bun:1` is a MAJOR-moving tag (it advances across bun majors) and
+# `nginx:alpine` floats `alpine`; a bare tag means two builds a week apart can
+# pull different bytes. Pinning the multi-arch INDEX digest (the tag's
+# registry digest) still resolves per-platform, so linux/amd64 (CI) and
+# linux/arm64 (dev host) both keep working — the pin only removes the drift.
+#
+# This is the drift GUARD, not the pin itself: it fails the moment any real
+# image reference to those families loses its `@sha256:` — the regression the
+# issue exists to prevent. It reads the worktree's tracked build files via
+# `git grep`, so it verifies the change under test (not MAIN). Comment lines
+# (prose, and the `# Refresh: docker buildx imagetools inspect …` hints) and
+# the docs/test trees (which name the tags in prose) are excluded — only
+# ACTUAL image references are held to the pin.
+#
+# Refresh a pin when intentionally bumping the base image:
+#   docker buildx imagetools inspect <tag> --format '{{.Manifest.Digest}}'
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+
+# Every reference to a pinned family in tracked build files, minus comments
+# and the docs/test prose trees. git grep -n → `path:line:content`.
+matched_refs() {
+    git -C "$REPO_ROOT" grep -nE 'oven/bun:|nginx:alpine' -- \
+        '*.sh' '*.yaml' '*.yml' '*Dockerfile*' ':!docs/**' ':!test/**' 2>/dev/null \
+        | while IFS= read -r line; do
+            content="${line#*:*:}"                        # strip `path:line:`
+            trimmed="$(printf '%s' "$content" | sed 's/^[[:space:]]*//')"
+            case "$trimmed" in
+                \#*) continue ;;                          # comment line — prose
+            esac
+            printf '%s\n' "$line"
+        done
+}
+
+@test "every oven/bun and nginx:alpine image reference is digest-pinned (#103)" {
+    refs="$(matched_refs)"
+
+    # Guard against a vacuous pass: if the grep matches nothing the assertion
+    # below would trivially "pass". We KNOW there are ≥4 real references
+    # (scripts/bun.sh, compose.yaml, Dockerfile.release, e2e compose ×2).
+    count="$(printf '%s\n' "$refs" | grep -c . || true)"
+    [ "$count" -ge 4 ] || {
+        echo "expected >=4 real base-image references, found $count — grep/filter is wrong:" >&2
+        printf '%s\n' "$refs" >&2
+        return 1
+    }
+
+    violations="$(printf '%s\n' "$refs" | grep -v '@sha256:' || true)"
+    [ -z "$violations" ] || {
+        echo "UNPINNED moving base-image reference(s) — pin to @sha256: (#103):" >&2
+        printf '%s\n' "$violations" >&2
+        return 1
+    }
+}
+
+@test "pinned base-image digests are well-formed sha256:<64 lowercase hex> (#103)" {
+    # A truncated or typo'd digest would fail the pull loudly at build time,
+    # but catching it here turns a slow CI-build failure into a fast unit fail.
+    # NB: `git grep -o` prefixes a line number (`<n>:<match>`) even with -h, so
+    # extract the token with a plain `grep -oE` over the matching lines instead.
+    bad="$(git -C "$REPO_ROOT" grep -hE '@sha256:' -- \
+              '*.sh' '*.yaml' '*.yml' '*Dockerfile*' ':!docs/**' ':!test/**' 2>/dev/null \
+           | grep -oE '@sha256:[0-9a-zA-Z]+' \
+           | grep -vE '^@sha256:[0-9a-f]{64}$' || true)"
+    [ -z "$bad" ] || {
+        echo "malformed digest(s) — expected sha256:<64 lowercase hex>:" >&2
+        printf '%s\n' "$bad" >&2
+        return 1
+    }
+}


### PR DESCRIPTION
Refs #103.

## Problem
`oven/bun:1` (dev scripts + cicchetto-build compose oneshots) and `nginx:alpine` (e2e stack) are **moving tags** — `oven/bun:1` advances across bun majors, `nginx:alpine` floats `alpine`. Two builds a week apart can pull different bytes; a "reproducible" build isn't.

## Fix
Every reference pinned to `image:tag@sha256:<digest>` (tag kept for readability, digest for reproducibility). Digests are the multi-arch **index** digests (`docker buildx imagetools inspect <tag> --format '{{.Manifest.Digest}}'`), so linux/amd64 (CI) + linux/arm64 (dev host) still resolve per-platform — the pin removes drift without locking architecture.

- `oven/bun:1` → `@sha256:e10577f0…` — `scripts/bun.sh` (as a reused `BUN_IMAGE` const), `compose.yaml` cicchetto-build, `cicchetto/e2e/compose.yaml` cicchetto-build-test.
- `oven/bun:1-alpine` → `@sha256:5acc90a9…` — `Dockerfile.release` cic stage (separate tag: bun is musl-built, matched to the alpine runtime).
- `nginx:alpine` → `@sha256:4a73073b…` — `cicchetto/e2e/compose.yaml` nginx-test.

The prod nginx **container** the issue originally named is gone since #485 (the BEAM serves the SPA), so the only remaining `nginx:alpine` is the e2e one.

## Drift guard (root-cause, not just today's instances)
`test/infra/base_image_digest_pin_test.bats` fails the moment a real `oven/bun`/`nginx:alpine` reference loses its `@sha256:` — git-greps tracked build files (`*Dockerfile*` at any depth), excludes comments + docs/test prose, refuses a vacuous pass (asserts ≥4 refs). A second test pins the digest **format** (`sha256:<64 hex>`) so a truncated paste fails fast at unit time. Refresh procedure in each pin's inline comment + the test header + DESIGN_NOTES.

## Scope (deliberate)
Only the two tags the issue named. `elixir:1.19-otp-28-alpine`, `alpine:*`, `debian:trixie`, `binfmt:latest` left as-is — none is a major-moving `:1`, and pinning every base image (incl. `Dockerfile.release`'s own elixir/alpine siblings) is a larger task worth a **tracked follow-up**, not a silent extension here. `oven-sh/setup-bun@v2` (release CI) is a GitHub Action, out of base-image scope.

## Gates (all green)
- `scripts/check.sh` rc=0 — **4927 tests / 0 failures**, dialyzer passed, credo/sobelow/doctor/format clean, **bats 210 ok / 0 not-ok** (incl the 2 new tests).
- Drift guard proven RED on an unpinned ref, GREEN when pinned (falsification, not a mirror).
- The pinned `oven/bun:1@sha256` **pulls + runs bun** end-to-end via `scripts/bun.sh` (digest valid + usable).
- Code review PASS: all three digests re-fetched live = exact match + confirmed multi-arch index; completeness total; test robustness confirmed.

Deploy class: HOT (no `.ex`/`mix.exs`/`mix.lock`).