### PR TITLE
build(#515): pin @biomejs/biome exact 2.5.6 (drop the caret time-bomb)

### DIFF
--- a/cicchetto/biome.json
+++ b/cicchetto/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/cicchetto/bun.lock
+++ b/cicchetto/bun.lock
@@ -12,7 +12,7 @@
         "uqr": "^0.1.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.5.6",
+        "@biomejs/biome": "2.5.6",
         "@fontsource/cascadia-code": "^5.3.0",
         "@fontsource/fira-code": "^5.3.0",
         "@fontsource/ibm-plex-mono": "^5.3.0",

--- a/cicchetto/package.json
+++ b/cicchetto/package.json
@@ -22,7 +22,7 @@
     "uqr": "^0.1.3"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.6",
+    "@biomejs/biome": "2.5.6",
     "@fontsource/cascadia-code": "^5.3.0",
     "@fontsource/fira-code": "^5.3.0",
     "@fontsource/ibm-plex-mono": "^5.3.0",

--- a/cicchetto/src/__tests__/biomePin.test.ts
+++ b/cicchetto/src/__tests__/biomePin.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// #515 — @biomejs/biome MUST be pinned to an EXACT version (no `^`/`~`/range
+// operator). A formatter on a floating range is a time bomb: a newer 2.x minor
+// resolved in the container ships a stricter formatter that flips `bun run
+// check` RED on clean main with no code change of ours (the #508
+// `input:where(:not(...))` denylist selector in default.css got flagged as a
+// formatter error). Exact-pinning makes every biome change a DELIBERATE,
+// reviewed diff in its own commit — never a silent between-session red.
+//
+// This guard fails fast in a unit test the moment someone re-carets the pin,
+// instead of surfacing as a slow, mysterious check.sh red in a later session.
+// Sibling of versionSource.test.ts; vitest runs from the cicchetto dir, so
+// package.json is at cwd.
+describe("cic biome pin (#515 exact-pin the formatter)", () => {
+  it("pins @biomejs/biome to an exact version, not a floating range", () => {
+    const pkg = JSON.parse(readFileSync(resolve(process.cwd(), "package.json"), "utf8")) as {
+      devDependencies: Record<string, string>;
+    };
+
+    const pin = pkg.devDependencies["@biomejs/biome"];
+    expect(pin, "@biomejs/biome missing from devDependencies").toBeDefined();
+    expect(pin).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});

--- a/cicchetto/src/__tests__/pingCorrelation.test.ts
+++ b/cicchetto/src/__tests__/pingCorrelation.test.ts
@@ -106,7 +106,14 @@ describe("pingCorrelation", () => {
     registerPing(1, "eve", "tok-e1", channelKey("freenode", "eve"), "eve", 5000);
 
     // A later /ping registered exactly at the TTL horizon evicts the stale one.
-    registerPing(1, "frank", "tok-f1", channelKey("freenode", "frank"), "frank", 5000 + PENDING_TTL_MS);
+    registerPing(
+      1,
+      "frank",
+      "tok-f1",
+      channelKey("freenode", "frank"),
+      "frank",
+      5000 + PENDING_TTL_MS,
+    );
 
     // The stale entry's reply can no longer be correlated (it was swept).
     expect(resolvePing(1, "eve", "tok-e1", 5000 + PENDING_TTL_MS + 10)).toBeNull();
@@ -118,7 +125,14 @@ describe("pingCorrelation", () => {
     registerPing(1, "grace", "tok-g1", channelKey("freenode", "grace"), "grace", 6000);
 
     // A second register ONE ms inside the horizon must NOT evict the first.
-    registerPing(1, "heidi", "tok-h1", channelKey("freenode", "heidi"), "heidi", 6000 + PENDING_TTL_MS - 1);
+    registerPing(
+      1,
+      "heidi",
+      "tok-h1",
+      channelKey("freenode", "heidi"),
+      "heidi",
+      6000 + PENDING_TTL_MS - 1,
+    );
 
     expect(resolvePing(1, "grace", "tok-g1", 6000 + PENDING_TTL_MS)).not.toBeNull();
   });

--- a/cicchetto/src/lib/pingCorrelation.ts
+++ b/cicchetto/src/lib/pingCorrelation.ts
@@ -76,7 +76,11 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   ): { sourceKey: ChannelKey; sourceChannel: string; rttMs: number } | null => {
     const resolve = (key: string, entry: PendingPing) => {
       pending.delete(key);
-      return { sourceKey: entry.sourceKey, sourceChannel: entry.sourceChannel, rttMs: nowMs - entry.sentAtMs };
+      return {
+        sourceKey: entry.sourceKey,
+        sourceChannel: entry.sourceChannel,
+        rttMs: nowMs - entry.sentAtMs,
+      };
     };
 
     // Exact token match first — a well-behaved peer (or shottino) echoes the


### PR DESCRIPTION
Refs #515.

## Problem
`cicchetto/package.json` pinned `@biomejs/biome` on a **floating** caret
(`^2.5.6`). A formatter on a floating range is a time bomb: a Dependabot
minor bump (`a49d39c4`, `^2.4.13`→`^2.5.6`) already turned `bun run check`
**RED on clean main** with no code change of ours — biome 2.5.6's stricter
formatter rewraps three >100-char constructs in `pingCorrelation`. Because
**CI never runs biome/vitest** (`ci.yml` gates only elixir `test`,
`shottino`, `dialyzer`), the drift lands silently and only bites the next
session's local cic gate.

## Fix (two commits)
1. **`style(#515)`** — apply biome 2.5.6's formatter to
   `pingCorrelation.ts` + `pingCorrelation.test.ts` (pure line-wrapping,
   zero semantic change). Fixes the pre-existing red in its own commit,
   per CLAUDE.md dev-cycle step 1. Prior sessions kept reverting this exact
   reformat "to stay surgical" — which is precisely what left main red; the
   reformat **is** the fix.
2. **`build(#515)`** — pin `@biomejs/biome` `^2.5.6`→`2.5.6` (exact),
   resync `bun.lock` (near-noop, 2.5.6 already resolved), bump `biome.json`
   `$schema` 2.4.13→2.5.6 to match the pinned CLI, and add a vitest guard
   `biomePin.test.ts` asserting the pin carries no range operator
   (`/^\d+\.\d+\.\d+$/`) — **RED-proven** against `^2.5.6`. Scope is biome
   ONLY (the #103 lesson: keep a pin migration inside the family the issue
   names); other dev-deps keep their carets.

## Gates (cic lane — CI does not run these)
- `bun run check` (biome + tsc) → **exit 0** (0 errors, 37 pre-existing
  `noDescendingSpecificity` warnings in untouched `default.css`).
- `bun run test` (vitest) → **213 files / 3816 tests pass**, incl. the new
  guard.
- honest `bun run build` → **exit 0**.
- Code review: **PASS** (scope, lock-sync, pure-reformat, guard-bites-on-recaret,
  no leaked files all verified).