### PR TITLE
refactor(#516): cic /join parser returns channels: string[] (type-lie fix)

### DIFF
--- a/cicchetto/src/__tests__/slashCommands.test.ts
+++ b/cicchetto/src/__tests__/slashCommands.test.ts
@@ -97,7 +97,7 @@ describe("parseSlash — /join", () => {
   it("/join <channel> (no key)", () => {
     expect(parseSlash("/join #grappa")).toEqual({
       kind: "join",
-      channel: "#grappa",
+      channels: ["#grappa"],
       key: null,
     });
   });
@@ -110,7 +110,7 @@ describe("parseSlash — /join", () => {
   it("/join <channel> <key> threads key", () => {
     expect(parseSlash("/join #priv secret")).toEqual({
       kind: "join",
-      channel: "#priv",
+      channels: ["#priv"],
       key: "secret",
     });
   });
@@ -126,7 +126,7 @@ describe("parseSlash — /join", () => {
   it("/join sniffo → auto-prepends # (UX shortcut)", () => {
     expect(parseSlash("/join sniffo")).toEqual({
       kind: "join",
-      channel: "#sniffo",
+      channels: ["#sniffo"],
       key: null,
     });
   });
@@ -134,7 +134,7 @@ describe("parseSlash — /join", () => {
   it("/j sniffo → alias of /join + auto-prepend", () => {
     expect(parseSlash("/j sniffo")).toEqual({
       kind: "join",
-      channel: "#sniffo",
+      channels: ["#sniffo"],
       key: null,
     });
   });
@@ -142,7 +142,7 @@ describe("parseSlash — /join", () => {
   it("/j #sniffo → alias, no double prepend", () => {
     expect(parseSlash("/j #sniffo")).toEqual({
       kind: "join",
-      channel: "#sniffo",
+      channels: ["#sniffo"],
       key: null,
     });
   });
@@ -150,7 +150,7 @@ describe("parseSlash — /join", () => {
   it("/j sniffo secret → alias + key", () => {
     expect(parseSlash("/j sniffo secret")).toEqual({
       kind: "join",
-      channel: "#sniffo",
+      channels: ["#sniffo"],
       key: "secret",
     });
   });
@@ -158,7 +158,7 @@ describe("parseSlash — /join", () => {
   it("/join &local → does not double-prepend on & prefix", () => {
     expect(parseSlash("/join &local")).toEqual({
       kind: "join",
-      channel: "&local",
+      channels: ["&local"],
       key: null,
     });
   });
@@ -174,10 +174,10 @@ describe("parseSlash — /join", () => {
     });
   });
 
-  it("/j #foo,#bar → passes through (already explicitly multi-prefixed)", () => {
+  it("/j #foo,#bar → parser splits the comma-list into channels[]", () => {
     expect(parseSlash("/j #foo,#bar")).toEqual({
       kind: "join",
-      channel: "#foo,#bar",
+      channels: ["#foo", "#bar"],
       key: null,
     });
   });

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -362,7 +362,11 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           break;
         }
         case "join":
-          await postJoin(t, networkSlug, cmd.channel, cmd.key);
+          // #516 — the parser now returns `channels: string[]`. Rejoin with
+          // `,` to reproduce the RFC1459 comma-list on the wire byte-for-byte
+          // (the server splits it and opens a `:pending` window per channel,
+          // #382) — behaviour is unchanged from the former single `channel`.
+          await postJoin(t, networkSlug, cmd.channels.join(","), cmd.key);
           // CP17: server-driven `:pending` window-state origination.
           // Server's `record_in_flight_join/2` writes
           // `window_states[ch] = :pending` and broadcasts
@@ -386,24 +390,21 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           // driven JOIN paths still go through the subscribe.ts handler
           // (no race for those — channel was already joined when JOIN
           // event arrives via WS).
-          // #510 — cmd.channel may be an RFC1459 comma-list (`/join
-          // #a,#b`). postJoin forwards it UNSPLIT above — the server
-          // splits it and opens a `:pending` window per channel (#382).
-          // Focus, though, must land on the FIRST channel, folded the
-          // SAME way the server folds window keys (`canonicalChannel` =
-          // the `Identifier.canonical_channel/1` twin, CASEMAPPING=ascii
-          // — A-Z only, brackets untouched; #525). Passing
-          // the raw list — or a mixed-case / bracketed first element —
-          // targets a key no `window_states` entry matches, opening the
-          // empty phantom window the issue reports. Single-channel
-          // `/join #foo` funnels through the same split (one element) so
-          // both paths canonicalise the focus key identically.
+          // #510/#516 — the parser owns the comma split now (`cmd.channels`
+          // is already the per-element list). Focus must land on the FIRST
+          // channel, folded the SAME way the server folds window keys
+          // (`canonicalChannel` = the `Identifier.canonical_channel/1` twin,
+          // CASEMAPPING=ascii — A-Z only, brackets untouched; #525). Passing
+          // a mixed-case / bracketed first element targets a key no
+          // `window_states` entry matches, opening the empty phantom window
+          // #510 reported. Single-channel `/join #foo` is a one-element list,
+          // so both paths canonicalise the focus key identically.
           setSelectedChannel({
             networkSlug,
-            // `split(",")` always yields >=1 element, so `[0]` is never
-            // undefined at runtime; the `?? cmd.channel` is unreachable and
-            // exists only to satisfy TS noUncheckedIndexedAccess.
-            channelName: canonicalChannel(cmd.channel.split(",")[0] ?? cmd.channel),
+            // `channels` is non-empty (the parser errors on a missing name),
+            // so `[0]` is never undefined at runtime; the `?? join(",")`
+            // fallback exists only to satisfy TS noUncheckedIndexedAccess.
+            channelName: canonicalChannel(cmd.channels[0] ?? cmd.channels.join(",")),
             kind: "channel",
           });
           result = { ok: true };

--- a/cicchetto/src/lib/slashCommands.ts
+++ b/cicchetto/src/lib/slashCommands.ts
@@ -89,7 +89,7 @@ export type SlashCommand =
   | { kind: "empty" }
   | { kind: "privmsg"; body: string }
   | { kind: "me"; body: string }
-  | { kind: "join"; channel: string; key: string | null }
+  | { kind: "join"; channels: string[]; key: string | null }
   | { kind: "part"; channel: string | null; reason: string | null }
   | { kind: "topic-show"; channel: string | null }
   | { kind: "topic-set"; channel: string | null; text: string }
@@ -344,9 +344,17 @@ const DISPATCH: Readonly<Record<string, Handler>> = {
         verb,
         `/${verb}: bare names with commas are ambiguous — spell each channel out (e.g. /${verb} #${raw.split(",").join(",#")})`,
       );
-    const channel = /^[#&+!]/.test(raw) ? raw : `#${raw}`;
+    // #516 — the parser owns the comma semantics: an RFC1459 JOIN target
+    // may be a comma-list (`#a,#b`), so return `channels: string[]` rather
+    // than lie about a single `channel: string`. The bare-name comma path
+    // already errored above; here `target` is sigil-normalised, so splitting
+    // on `,` yields one explicitly-prefixed channel per element (`["#a"]`
+    // for the single-join case). compose.ts rejoins with `,` for the wire
+    // (server splits it per #382) and focuses `channels[0]`.
+    const target = /^[#&+!]/.test(raw) ? raw : `#${raw}`;
+    const channels = target.split(",");
     const key = toks[1] ?? null;
-    return { kind: "join", channel, key };
+    return { kind: "join", channels, key };
   },
 
   part: (_verb, rest) => {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -26499,3 +26499,32 @@ and `subscribe.ts` are all UNCHANGED. No wire token, no server change. The
 unit test (`slashCommands.test.ts`, `describe("parseSlash — /msg")`) was
 strengthened to pin the actionable guidance (`/open|join|window|type/i` + the
 target name), so the message can never silently regress to the bare string.
+
+---
+
+## 2026-08-02 — #516: cic `/join` parser returns `channels: string[]` (type-lie fix, behaviour-preserving)
+
+The cic `/join` parser used to return `channel: string` — but an RFC1459 JOIN
+target may be a comma-list (`/join #a,#b`), so a two-channel form travelled as
+a single `channel: "#a,#b"` string. The type lied about the value: it named one
+channel and held several. This is the follow-up #510 filed after fixing the
+*symptom* in `compose.ts` (which was splitting the comma-list itself, at the
+consumer, to canonicalise the focus key).
+
+**Decision (from the issue body, vjt-triaged 2026-08-02): the PARSER owns the
+comma semantics.** `join:` now returns `channels: string[]` (the sigil-normalised
+target split on `,` — `["#a","#b"]` for a multi-join, `["#foo"]` for the single
+case). The sole consumer, `compose.ts`, does `postJoin(channels.join(","))` — the
+server contract is UNCHANGED (still a comma-list; the server splits it and opens
+a `:pending` window per channel, #382) — and focuses `channels[0]` (folded via
+`canonicalChannel`, the #525 fold, exactly as #510 established).
+
+Behaviour + wire are **byte-identical** — same frames upstream, same focus
+window; this is pure type hygiene. The deliberate rejection of bare-name comma
+forms (`/join a,b` → error, because auto-prepending `#` to `foo,bar` yields the
+ambiguous `#foo,bar`) is UNCHANGED — that guard fires above the split, a parser
+design choice from #510. cic-only: two production files (`slashCommands.ts` type
++ handler, `compose.ts` two reads) and the `/join` unit block migrated from
+`channel:` to `channels:`. No wire token, no server/Elixir change. The
+IRC message-kind `"join"` (a JOIN *event* with `sender`/`body`) is a DIFFERENT
+type and was left untouched.


### PR DESCRIPTION
## What

Two-file cic type-hygiene refactor. The `/join` parser used to return
`channel: string`, but an RFC1459 JOIN target may be a comma-list
(`/join #a,#b`) — so a multi-channel form travelled as a single
`channel: "#a,#b"` string. The type lied: it named one channel and held
several. Follow-up from #510 (which fixed the *symptom* at the consumer).

## Change

- `slashCommands.ts`: `SlashCommand` join variant `channel: string` →
  `channels: string[]`; the `join:` handler splits the sigil-normalised
  target on `,` (`["#a","#b"]` multi, `["#foo"]` single).
- `compose.ts` (the sole consumer): `postJoin(cmd.channels.join(","))`
  (server contract unchanged — comma-list, split server-side per #382)
  and focuses `cmd.channels[0]` (folded via `canonicalChannel`, #525).

## Behaviour + wire: byte-identical

`channels.join(",")` reproduces the old comma-list exactly — same upstream
frames, same focus window. **Pure type honesty, not a behaviour change.**
The bare-name comma rejection (`/join a,b` → error) and the arg-count guard
are unchanged (they fire *above* the split). The IRC message-kind `"join"`
event (`sender`/`body`) is a different type and is untouched.

## Proof

Unit split-proof: `parseSlash("/j #foo,#bar")` → `channels: ["#foo","#bar"]`
(was `channel: "#foo,#bar"`). TDD: flipped that assertion RED-first against
the old code, then made the parser+compose edits GREEN.

## Gates (cic-only, lane-free)

- **`tsc --noEmit` STANDALONE: exit 0, clean** (load-bearing — this is a
  type change; `bun run check` is tsc-blind on main via #515's biome-red
  short-circuit, so tsc was run standalone).
- Scoped biome on the 3 touched files: clean, zero-delta.
- Full vitest: **212 files / 3815 tests pass**.
- No e2e needed: behaviour + wire are byte-identical and unit-covered
  (the runtime multichannel spec `issue382-multichannel-join.spec.ts`
  drives unchanged behaviour). No server/COMPILE/STACK lane touched.

Refs #516