### PR TITLE
fix(#641): render uncorrelated CTCP notice from typed meta, never raw \x01

### DIFF
--- a/cicchetto/e2e/tests/issue641-ctcp-notice-render.spec.ts
+++ b/cicchetto/e2e/tests/issue641-ctcp-notice-render.spec.ts
@@ -1,0 +1,74 @@
+// Issue #641 — an inbound CTCP reply (a NOTICE carrying \x01VERB [args]\x01)
+// that matches no pending /ping rendered its RAW body — \x01 delimiters and
+// all — straight into $server (`-peer- ^AVERSION ...^A`), breaking the "cic
+// NEVER shows \x01" invariant that only the privmsg CTCP arm (#591) upheld.
+//
+// The full-stack proof jsdom cannot give (feedback_ux_e2e_mandatory): a REAL
+// peer sends an UNSOLICITED CTCP VERSION NOTICE to our upstream nick; grappa
+// classifies it (SSOT Grappa.IRC.CTCP.verb_args/1 → typed meta.ctcp_verb) and
+// routes the CTCP-framed reply to $server, keeping the body VERBATIM (the \x01
+// envelope survives, round-trip fidelity); cic's notice arm now reads the TYPED
+// meta and renders a human line "← CTCP VERSION reply from <peer>", with
+// U+0001 NEVER reaching the DOM.
+//
+// VERSION (NOT ping) is the genuinely uncorrelated class this fix must cover:
+// after #638, a /ping <service> reply CORRELATES and is consumed upstream
+// (subscribe.ts maybeConsumePingReply), so a PING fixture would pass for the
+// WRONG reason. A stray VERSION reply has NO correlation machinery — it hits
+// the exact fall-through the bug reports.
+
+import { expect, test } from "../fixtures/test";
+import { loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import { assertMessagePersisted } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+const SERVER_WINDOW_LABEL = "Server";
+
+test("#641 — an uncorrelated CTCP notice renders '← CTCP VERB reply from <peer>', never raw \\x01", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  // Per-run unique peer nick + tag: $server accumulates across runs, and a
+  // fixed nick is a 433/ghost time bomb under CI rerun (mirrors #591/#637).
+  const peerNick = `m641-${crypto.randomUUID().slice(0, 5)}`;
+  const tag = `v641-${crypto.randomUUID().slice(0, 8)}`;
+  const peer = await IrcPeer.connect({ nick: peerNick });
+  try {
+    // Unsolicited CTCP VERSION reply straight to our upstream nick — no /ctcp
+    // was ever sent, so nothing correlates it. No shared channel needed; a
+    // NOTICE to a nick is delivered directly.
+    peer.notice(NETWORK_NICK, `\x01VERSION ${tag}\x01`);
+
+    // Server-side: a CTCP-framed reply is protocol, not a DM, so grappa routes
+    // it to $server with the body kept VERBATIM (the \x01 envelope survives) —
+    // the typed meta.ctcp_verb that drives the render rides alongside it.
+    await assertMessagePersisted({
+      token: vjt.token,
+      networkSlug: NETWORK_SLUG,
+      channel: "$server",
+      sender: peer.nick,
+      body: `\x01VERSION ${tag}\x01`,
+      kind: "notice",
+    });
+
+    await selectChannel(page, NETWORK_SLUG, SERVER_WINDOW_LABEL, { awaitWsReady: false });
+
+    // DOM: the human INBOUND line built from typed meta (data-kind=notice),
+    // envelope gone. Assert the shape AND that no U+0001 survived to the DOM —
+    // the whole point of the fix (the invariant the generic fall-through broke).
+    const line = scrollbackLine(
+      page,
+      "notice",
+      new RegExp(`← CTCP VERSION reply from ${peer.nick}: ${tag}`),
+    );
+    await expect(line).toBeVisible({ timeout: 15_000 });
+    expect(await line.textContent()).not.toContain("\x01");
+  } finally {
+    await peer.disconnect("#641 done");
+  }
+});

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -475,6 +475,18 @@ type NickHandlers = {
 // atom-keyed fields keeps both the closed-set discipline and the
 // Logger metadata sync intact.
 type RawEvent = { raw_verb?: string; raw_sender?: string; raw_params?: string[] };
+
+// #641 — scrub the CTCP delimiter (U+0001) from a typed CTCP verb/args BEFORE
+// it renders. The server's SSOT classifier (Grappa.IRC.CTCP.verb_args/1) strips
+// only the ONE optional TRAILING \x01, so a malformed or concatenated frame
+// (`\x01VERSION a\x01b\x01`, `\x01V x\x01\x01PING y\x01`) can leave an INTERIOR
+// \x01 in the typed verb or args. A CTCP line is a control surface, and "cic
+// NEVER shows \x01" is absolute — scrub the display string. This is NOT parsing
+// \x01 (we still render off typed meta, never off delimiters); the stored body
+// stays verbatim (round-trip fidelity is a STORAGE property, not a display one).
+// Shared by BOTH CTCP arms — the outbound privmsg self-echo and the inbound
+// notice reply — so neither can leak (fix the class, not the instance).
+const stripCtcpDelim = (s: string): string => s.replaceAll("\u0001", "");
 const renderRawEvent = (
   raw: RawEvent,
   msg: ScrollbackMessage,
@@ -673,8 +685,13 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
       // (subscribe.ts) and never reaches any render path.
       const ctcpVerb = msg.meta.ctcp_verb;
       if (typeof ctcpVerb === "string") {
-        const ctcpArgs = typeof msg.meta.ctcp_args === "string" ? msg.meta.ctcp_args : "";
-        const query = ctcpArgs === "" ? `CTCP ${ctcpVerb}` : `CTCP ${ctcpVerb} ${ctcpArgs}`;
+        // #641 — scrub any interior \x01 the server's one-trailing-strip left
+        // behind (shared with the notice arm); "cic NEVER shows \x01" is absolute.
+        const verb = stripCtcpDelim(ctcpVerb);
+        const ctcpArgs = stripCtcpDelim(
+          typeof msg.meta.ctcp_args === "string" ? msg.meta.ctcp_args : "",
+        );
+        const query = ctcpArgs === "" ? `CTCP ${verb}` : `CTCP ${verb} ${ctcpArgs}`;
         // #640 — the echo is now keyed to the SOURCE window (msg.channel), so
         // the wire recipient travels in meta.ctcp_target: read the target OFF
         // the message, not the routing key. Fall back to msg.channel for
@@ -715,11 +732,14 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
       // control-surface text (no mIRC emphasis), like the numeric/raw surfaces.
       const noticeCtcpVerb = msg.meta.ctcp_verb;
       if (typeof noticeCtcpVerb === "string") {
-        const noticeCtcpArgs = typeof msg.meta.ctcp_args === "string" ? msg.meta.ctcp_args : "";
+        const verb = stripCtcpDelim(noticeCtcpVerb);
+        const args = stripCtcpDelim(
+          typeof msg.meta.ctcp_args === "string" ? msg.meta.ctcp_args : "",
+        );
         return (
           <span class="scrollback-body">
-            ← CTCP {noticeCtcpVerb} reply from {msg.sender}
-            {noticeCtcpArgs === "" ? "" : `: ${noticeCtcpArgs}`}
+            ← CTCP {verb} reply from {msg.sender}
+            {args === "" ? "" : `: ${args}`}
           </span>
         );
       }

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -698,6 +698,31 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
       );
     }
     case "notice": {
+      // #641 — an inbound CTCP reply arrives as a server-typed :notice whose
+      // body is the raw \x01VERB [args]\x01 frame, classified ONCE on the server
+      // (SSOT Grappa.IRC.CTCP.verb_args/1) into typed meta.ctcp_verb /
+      // meta.ctcp_args. A CORRELATED /ping reply is consumed upstream
+      // (subscribe.ts maybeConsumePingReply) and never reaches here; an
+      // UNCORRELATED CTCP reply (a stray VERSION/TIME, or a token-less PING that
+      // matched no pending /ping) does. Before this arm it fell through to the
+      // generic body render below and leaked the raw \x01 into the DOM. Render a
+      // human INBOUND line from the TYPED meta instead — cic NEVER parses \x01
+      // (the "one IRC parser, on the server" invariant). This is the notice twin
+      // of the privmsg CTCP arm (#591), but INBOUND: direction ← / "reply from
+      // <sender>", and ctcp_args is the reply PAYLOAD rendered irssi-style after
+      // the sender (a query's outbound args mean something different — see the
+      // privmsg arm — so the two are deliberately NOT a shared helper). Plain
+      // control-surface text (no mIRC emphasis), like the numeric/raw surfaces.
+      const noticeCtcpVerb = msg.meta.ctcp_verb;
+      if (typeof noticeCtcpVerb === "string") {
+        const noticeCtcpArgs = typeof msg.meta.ctcp_args === "string" ? msg.meta.ctcp_args : "";
+        return (
+          <span class="scrollback-body">
+            ← CTCP {noticeCtcpVerb} reply from {msg.sender}
+            {noticeCtcpArgs === "" ? "" : `: ${noticeCtcpArgs}`}
+          </span>
+        );
+      }
       // No-silent-drops bucket 1: structured raw-event rendering.
       // EventRouter's catch-all persists unhandled command verbs as
       // :notice rows on $server with FLAT atom-keyed meta:

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -512,6 +512,51 @@ describe("ScrollbackPane", () => {
     expect(lines[1]?.textContent ?? "").not.toContain("\x01");
   });
 
+  it("scrubs an INTERIOR \\x01 the server's one-trailing-strip left in typed CTCP meta — #641", () => {
+    // The server's SSOT classifier (Grappa.IRC.CTCP.verb_args/1) strips only the
+    // ONE optional TRAILING \x01, so a malformed or concatenated frame
+    // (`\x01VERSION a\x01b\x01`, `\x01V x\x01\x01PING y\x01`) leaves an INTERIOR
+    // \x01 in the TYPED verb/args. The plain not.toContain check on a clean
+    // payload passes trivially; this fixture carries the delimiter INSIDE the
+    // typed strings, so it goes red if the render stops scrubbing them. "cic
+    // NEVER shows \x01" is absolute — the fix must hold for adversarial input,
+    // not just a well-formed reply.
+    const adversarial: ScrollbackMessage[] = [
+      {
+        id: 1,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: 1,
+        kind: "notice",
+        sender: "mallory",
+        // verb + args each carry an interior delimiter (verb_args left them in).
+        body: "\x01VE\x01RSION 1.0\x01evil\x01",
+        meta: { ctcp_verb: "VE\x01RSION", ctcp_args: "1.0\x01evil" },
+      },
+      // The privmsg CTCP arm shares the same scrub (fix the class): an operator's
+      // own echo with a stray delimiter must not leak it either.
+      {
+        id: 2,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: 2,
+        kind: "privmsg",
+        sender: "alice",
+        body: "\x01PING to\x01ken\x01",
+        meta: { ctcp_verb: "PING", ctcp_args: "to\x01ken", ctcp_target: "bob" },
+      },
+    ];
+    setScrollback({ "freenode #grappa": adversarial });
+    render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+    const lines = screen.getAllByTestId("scrollback-line");
+    expect(lines).toHaveLength(2);
+    // Delimiters scrubbed from BOTH verb and args; NO U+0001 in the DOM.
+    expect(lines[0]).toHaveTextContent("← CTCP VERSION reply from mallory: 1.0evil");
+    expect(lines[0]?.textContent ?? "").not.toContain("\x01");
+    expect(lines[1]).toHaveTextContent("→ CTCP PING token to bob");
+    expect(lines[1]?.textContent ?? "").not.toContain("\x01");
+  });
+
   it("renders the action row with one space between '*' and the nick (not two) — #457", () => {
     // Regression pin for #457: the :action arm rendered `*  nick` (two
     // spaces) while every sibling `*`-framed kind (join/part/quit/…) uses

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -455,6 +455,63 @@ describe("ScrollbackPane", () => {
     expect(lines[0]).toHaveTextContent("→ CTCP VERSION to #chan");
   });
 
+  it("renders an uncorrelated inbound CTCP notice from typed meta, never raw \\x01 — #641", () => {
+    // #641 — an inbound CTCP reply (a NOTICE carrying \x01VERB [args]\x01) that
+    // matches no pending /ping is NOT consumed by subscribe.ts's
+    // maybeConsumePingReply (that swallows only CORRELATED PING replies). It
+    // reaches this render, where — before the fix — the notice arm fell through
+    // to the generic body render and leaked the raw \x01 delimiters into the DOM
+    // (`-NickServ- ^APING^A`), breaking the "cic NEVER shows \x01" invariant that
+    // only the privmsg arm (#591) had upheld.
+    //
+    // The server already classified it: meta.ctcp_verb is present (SSOT
+    // Grappa.IRC.CTCP.verb_args/1 tags EVERY inbound CTCP notice at
+    // event_router.ex:2236). cic reads the TYPED meta and renders a human INBOUND
+    // line (← ... from <sender>) — it NEVER parses \x01.
+    //
+    // TRAP (#638): /ping NickServ now CORRELATES (token-less service PING replies
+    // resolve), so a PING fixture would be consumed upstream and never reach this
+    // render — green for the WRONG reason. VERSION/TIME have NO correlation
+    // machinery: they are the genuinely uncorrelated class this fix must cover.
+    const ctcpNotice: ScrollbackMessage[] = [
+      {
+        id: 1,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: 1,
+        kind: "notice",
+        sender: "bob",
+        body: "\x01VERSION irssi 1.4.5\x01",
+        meta: { ctcp_verb: "VERSION", ctcp_args: "irssi 1.4.5" },
+      },
+      {
+        id: 2,
+        network: "freenode",
+        channel: "#grappa",
+        server_time: 2,
+        kind: "notice",
+        sender: "someclient",
+        body: "\x01TIME Sat Aug 02 2026\x01",
+        meta: { ctcp_verb: "TIME", ctcp_args: "Sat Aug 02 2026" },
+      },
+    ];
+    setScrollback({ "freenode #grappa": ctcpNotice });
+    render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+    const lines = screen.getAllByTestId("scrollback-line");
+    expect(lines).toHaveLength(2);
+    // Human INBOUND line from typed meta: direction ← and "reply from <sender>",
+    // reply payload (ctcp_args) rendered irssi-style after the sender.
+    expect(lines[0]?.dataset.kind).toBe("notice");
+    expect(lines[0]).toHaveTextContent("← CTCP VERSION reply from bob");
+    expect(lines[0]).toHaveTextContent("irssi 1.4.5");
+    // THE DEFECT: raw \x01 (U+0001) must NEVER reach the DOM.
+    expect(lines[0]?.textContent ?? "").not.toContain("\x01");
+    // General class, not the /ping instance: a stray TIME reply too.
+    expect(lines[1]).toHaveTextContent("← CTCP TIME reply from someclient");
+    expect(lines[1]).toHaveTextContent("Sat Aug 02 2026");
+    expect(lines[1]?.textContent ?? "").not.toContain("\x01");
+  });
+
   it("renders the action row with one space between '*' and the nick (not two) — #457", () => {
     // Regression pin for #457: the :action arm rendered `*  nick` (two
     // spaces) while every sibling `*`-framed kind (join/part/quit/…) uses

--- a/cicchetto/src/__tests__/subscribe.test.ts
+++ b/cicchetto/src/__tests__/subscribe.test.ts
@@ -1788,6 +1788,12 @@ describe("subscribe — DM-listener (own-nick topic, inbound DM re-key)", () => 
     expect(store.scrollbackByChannel()[sourceKey]?.map((m) => m.body)).toEqual([
       "CTCP PING reply from NickServ: 42 ms",
     ]);
+    // #641 regression guard: the synthesized RTT row is a cic-owned DISPLAY line,
+    // NOT a raw CTCP frame — it must NOT inherit the reply's ctcp_verb meta, or
+    // ScrollbackPane's notice CTCP arm intercepts it and renders
+    // "← CTCP PING reply from NickServ" instead of the "N ms" body (the PR #663
+    // red). Assert the meta was stripped at synthesis.
+    expect(store.scrollbackByChannel()[sourceKey]?.[0]?.meta?.ctcp_verb).toBeUndefined();
     // $server got NOTHING — the token-less reply was swallowed, never rendered raw.
     expect(store.scrollbackByChannel()[channelKey("freenode", "$server")]).toBeUndefined();
     // No audible alert for a consumed correlation reply (the $server handler
@@ -1840,6 +1846,10 @@ describe("subscribe — DM-listener (own-nick topic, inbound DM re-key)", () => 
     expect(store.scrollbackByChannel()[sourceKey]?.map((m) => m.body)).toEqual([
       "CTCP PING reply from vjt: 42 ms",
     ]);
+    // #641 regression guard: the synthesized RTT row must NOT inherit the reply's
+    // ctcp_verb meta (else the ScrollbackPane notice CTCP arm eats it and drops
+    // the "N ms" body — the PR #663 red). Meta is stripped at synthesis.
+    expect(store.scrollbackByChannel()[sourceKey]?.[0]?.meta?.ctcp_verb).toBeUndefined();
     // The peer window got NOTHING — the reply was swallowed, not re-keyed raw.
     expect(store.scrollbackByChannel()[channelKey("freenode", "vjt")]).toBeUndefined();
     // No audible alert for a consumed correlation reply.

--- a/cicchetto/src/lib/subscribe.ts
+++ b/cicchetto/src/lib/subscribe.ts
@@ -201,6 +201,12 @@ createRoot(() => {
       ...message,
       channel: hit.sourceChannel,
       body: `CTCP PING reply from ${message.sender}: ${hit.rttMs} ms`,
+      // #641 — this is a cic-OWNED display row, not the raw CTCP frame. Drop the
+      // reply's typed ctcp meta: the body IS the final human line, and carrying
+      // meta.ctcp_verb would make ScrollbackPane's notice CTCP arm render it as
+      // "← CTCP PING reply from <peer>" and swallow the "N ms" body. The raw
+      // reply itself is already swallowed (this branch returns true).
+      meta: {},
     });
     return true;
   };


### PR DESCRIPTION
Refs #641.

## Problem
An inbound CTCP reply (a NOTICE carrying `\x01VERB [args]\x01`) that matches no pending `/ping` fell through the `case "notice"` render arm's typed-meta checks straight to the generic body render, leaking the raw `\x01` delimiters into the DOM (`-NickServ- ^APING^A`). That broke the "one IRC parser, on the server / cic NEVER shows `\x01`" invariant — which until now only the `privmsg` arm (#591) upheld. Same shape as #14, for the notice path.

The server **already** classifies the frame: it tags every inbound CTCP notice with typed `meta.ctcp_verb` / `meta.ctcp_args` (SSOT `Grappa.IRC.CTCP.verb_args/1`, `lib/grappa/session/event_router.ex:2236`). Nothing needs to parse the delimiters to fix this — **cic-only, no server change** (spec verified before building).

## Fix
The `notice` arm now mirrors the `privmsg` CTCP arm (#591) but **inbound**: it reads the typed `meta.ctcp_verb` (typeof guard) and renders a human control-surface line `← CTCP VERB reply from <sender>[: <args>]` **before** the generic fall-through. cic reads typed meta only — it never parses `\x01`.

Deliberately **not** a shared render helper with the privmsg arm: there `ctcp_args` is the outbound query's args (`→ CTCP PING <token> to <target>`); here it is the inbound reply's payload rendered irssi-style after the sender — folding both into one fn would conflate query-args with reply-payload and read worse than two small arms (CLAUDE.md "reuse the verbs, not the nouns").

## Code-review hardening (2nd commit)
Review caught that the invariant is absolute but `verb_args/1` strips only the **one** optional trailing `\x01`, so an interior/concatenated delimiter (`\x01VERSION a\x01b\x01`) survives into the typed args and would still reach the DOM — and the inbound path takes **remote untrusted** input. Added a shared display-layer scrub (`stripCtcpDelim`) applied to verb + args in **both** CTCP arms (fix the class, not the instance). This scrubs the display string only; the stored body stays verbatim (round-trip fidelity is a storage property, not a display one).

## `#638` trap
A `/ping <service>` reply now **correlates** and is consumed upstream (`subscribe.ts` `maybeConsumePingReply`), so the issue's own `/ping NickServ` repro no longer reaches render. The genuinely uncorrelated class is a stray **VERSION/TIME** reply — no correlation machinery at all — so the tests exercise VERSION/TIME (a PING fixture would go green for the wrong reason).

## Tests
- **vitest** (`ScrollbackPane.test.tsx`): RED-proven — pre-fix the notice rendered its raw body; post-fix it renders the human line and the DOM contains no U+0001. Non-PING (VERSION + TIME). Plus an adversarial case carrying an interior `\x01` inside the typed verb/args (both arms) to pin the scrub.
- **e2e** (`issue641-ctcp-notice-render.spec.ts`): full-stack — a real peer sends an unsolicited CTCP VERSION notice to `$server`; asserts the human line renders and no `\x01` reaches the DOM. **Not yet run** — needs the STACK/testnet lane (orchestrator-allocated).

## Gates (cic, FREE — run from worktree root)
- `check:fix` rc 0 (surgical; no unrelated reformat)
- `check` (biome + tsc) rc 0 (37 pre-existing warnings, 0 errors)
- `test` (vitest) rc 0 — **3818 passed**
- `build` (clean-cache) rc 0

## e2e acceptance (CI-gated, watched by orchestrator)
Gated via **PR CI integration**, not locally (no local STACK lane). The Playwright e2e count **MUST rise by exactly +1** vs the prior run — that delta is the proof `issue641-ctcp-notice-render.spec.ts` actually **executed**, not silently skipped/uncollected. A 0-delta green is a false green (the #78 "green while broken" trap): the new spec must show up as one additional passing test.
