### PR TITLE
test(#653): slice A — deterministic setup for 3 e2e render-race flakes (#639/#519/#531)

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -731,13 +731,36 @@ export async function composeSend(
 // synthetic) over `.tap()` for the same WebKit synthesis-race reason as
 // closeMembersDrawer below.
 export async function openMembersDrawer(page: Page): Promise<void> {
-  const topicHamburger = page.getByLabel(/open members sidebar/i);
-  if ((await topicHamburger.count()) > 0) {
-    await topicHamburger.first().click();
-  } else {
-    await page.getByTestId("shell-chrome-rail-opener").click();
+  const drawer = page.locator(".shell-members.open");
+  // #653/#519 — re-resolve per attempt instead of a single probe-then-click.
+  // The opener that renders depends on the focused window kind (channel →
+  // TopicBar hamburger `<Show when={windowIsJoined}>`; non-channel → rail
+  // opener), and under full-gate load a settling selection redirect (e.g. the
+  // post-PART close-watcher moving focus) can swap the focused window — and
+  // re-render the topic bar — BETWEEN the count probe and the click. The
+  // hamburger then detaches mid-click; Playwright's built-in detach-retry
+  // waits out its whole timeout for a node that has unmounted (the window is
+  // now a non-channel one with no hamburger). Looping re-picks the correct
+  // opener each attempt and absorbs the transient churn; the post-condition
+  // (`.shell-members.open` visible) stays exactly as strict, and a genuine
+  // failure still surfaces loudly when the deadline elapses. Green happy path
+  // is unchanged (one probe + click + visibility assert on the first pass).
+  const deadline = Date.now() + 15_000;
+  for (;;) {
+    if (await drawer.isVisible().catch(() => false)) return;
+    try {
+      const topicHamburger = page.getByLabel(/open members sidebar/i);
+      if ((await topicHamburger.count()) > 0) {
+        await topicHamburger.first().click({ timeout: 3_000 });
+      } else {
+        await page.getByTestId("shell-chrome-rail-opener").click({ timeout: 3_000 });
+      }
+      await expect(drawer).toBeVisible({ timeout: 3_000 });
+      return;
+    } catch (err) {
+      if (Date.now() >= deadline) throw err;
+    }
   }
-  await expect(page.locator(".shell-members.open")).toBeVisible({ timeout: 5_000 });
 }
 
 // #500 — reveal the RailActions launcher menu, the SINGLE door to every rail

--- a/cicchetto/e2e/tests/issue360-scroll-to-bottom-mention-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue360-scroll-to-bottom-mention-badge.spec.ts
@@ -116,6 +116,33 @@ async function lineVisibleInPane(page: Page, needle: string): Promise<boolean> {
   }, needle);
 }
 
+// #653/#639 — tap the floating scroll-to-bottom button, tolerating the
+// snap-to-bottom unmount race. The button lives under `<Show when=
+// {!atBottomNow()}>` (ScrollbackPane), so it UNMOUNTS the instant the pane
+// reaches bottom. On the empty-badge tap a settling scroll from the prior
+// jump can flip `atBottomNow` true BETWEEN the visibility check and this
+// click — Playwright resolves the button, the node detaches mid-click, and
+// its built-in detach-retry then waits out the full 10s for a node that will
+// never remount. Re-resolve per attempt and treat an already-unmounted button
+// as the snap having landed (button gone == at bottom == the tap's own goal);
+// the post-tap assertions at the call site stay the source of truth for the
+// end state, so an early return can never mask a wrong one — a button that
+// vanished WITHOUT reaching bottom fails the distFromBottom poll that follows.
+async function tapScrollToBottom(page: Page, selector: string): Promise<void> {
+  const btn = page.locator(selector);
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    if ((await btn.count()) === 0) return;
+    try {
+      await btn.click({ timeout: 1_500 });
+      return;
+    } catch (err) {
+      if ((await btn.count()) === 0) return;
+      if (Date.now() >= deadline) throw err;
+    }
+  }
+}
+
 test.describe("#360 — mention-aware scroll-to-bottom badge", () => {
   test("badge counts mentions below the fold; tap jumps to the next mention, decrementing; empty-badge tap snaps to bottom", async ({
     page,
@@ -218,7 +245,9 @@ test.describe("#360 — mention-aware scroll-to-bottom badge", () => {
       await expect(page.locator(SCROLL_TO_BOTTOM)).toBeVisible();
 
       // Tap 3 (empty badge) → classic snap-to-bottom: newest line, button hides.
-      await page.locator(SCROLL_TO_BOTTOM).click({ timeout: 10_000 });
+      // Re-resolve-tolerant tap: the button unmounts the instant the snap
+      // reaches bottom, which a settling scroll can trigger mid-click (#653/#639).
+      await tapScrollToBottom(page, SCROLL_TO_BOTTOM);
       await expect
         .poll(async () => (await distFromBottom(page)) ?? 999, { timeout: 5_000 })
         .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);

--- a/cicchetto/e2e/tests/ux-6-a-mobile-members-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-a-mobile-members-scroll.spec.ts
@@ -119,15 +119,29 @@ test("@webkit ux-6-a — html.overlay-open suspends root touch-action so gesture
   // when keyboard-up made the layout document-tall. v3 locks the
   // whole chain; the overlay's own pan-y carve-out still wins via
   // higher selector specificity inside its subtree.
-  await page.evaluate(() => document.documentElement.classList.add("overlay-open"));
-  const chain = await page.evaluate(() => ({
-    html: getComputedStyle(document.documentElement).touchAction,
-    body: getComputedStyle(document.body).touchAction,
-    root: getComputedStyle(document.getElementById("root") ?? document.body).touchAction,
-    rootChild: getComputedStyle(
-      document.querySelector("#root > div") ?? document.body,
-    ).touchAction,
-  }));
+  // #653/#531 — add the sentinel class AND read the computed chain in ONE
+  // synchronous evaluate. `overlay-open` is app-managed by a refcount
+  // (`lib/overlayScrollLock.ts` applyClass): any overlay push/pop settling
+  // during boot fires applyClass(), which — with the refcount at 0 — STRIPS
+  // the class the test just added. Split across two evaluates (the pre-fix
+  // shape), that reconciliation could run between the add and the read under
+  // full-gate load, reverting touch-action to `auto` before the snapshot;
+  // green in isolation because boot settles before the test acts. A single
+  // evaluate is atomic — getComputedStyle forces a synchronous style recalc
+  // while the class is guaranteed present, so no microtask (hence no Solid
+  // effect / applyClass) can interleave between add and read. Assertions stay
+  // exactly as strict.
+  const chain = await page.evaluate(() => {
+    document.documentElement.classList.add("overlay-open");
+    return {
+      html: getComputedStyle(document.documentElement).touchAction,
+      body: getComputedStyle(document.body).touchAction,
+      root: getComputedStyle(document.getElementById("root") ?? document.body).touchAction,
+      rootChild: getComputedStyle(
+        document.querySelector("#root > div") ?? document.body,
+      ).touchAction,
+    };
+  });
   expect(chain.html).toBe("none");
   expect(chain.body).toBe("none");
   expect(chain.root).toBe("none");


### PR DESCRIPTION
## Slice A of epic #653 — the three e2e render-race flakes

Diagnosis-first result (Phase 0): #499 (NetworkCircuit ETS bleed) is **ruled
out** as the epic's cause — it is real but already pervasively mitigated
(`AdmissionStateHelpers.reset_all/0` in ~20 touching test setups). The 8
symptoms are **3 distinct mechanisms**, not one. This PR is bucket **A** —
the e2e DOM render-race flakes, each cured by making the SETUP deterministic
(re-resolve a handle legitimately about to unmount / atomic observation),
never by weakening an assert or blindly bumping a timeout.

| # | spec | root cause (SETUP) | cure |
|---|------|--------------------|------|
| #639 | `issue360-scroll-to-bottom-mention-badge.spec.ts` tap 3 | button `<Show when={!atBottomNow()}>` unmounts the instant the pane hits bottom; a settling scroll flips `atBottomNow` between the visibility check and the click → detach mid-click → Playwright waits out 10s for a node that never remounts | `tapScrollToBottom` re-resolves per attempt, treats already-unmounted as snap-landed (button gone == at bottom == the tap's goal); applied to tap 3 only |
| #519 | `ux-2-mobile-archive.spec.ts` (@webkit) open-members step | shared `openMembersDrawer` fixture: a post-PART selection redirect swaps the focused window (and re-renders the topic bar) between the `count()` probe and the `.click()` → hamburger detaches → 30s timeout | fixture loops, re-picking the correct opener each attempt until `.shell-members.open` is visible or a bounded deadline throws loudly |
| #531 | `ux-6-a-mobile-members-scroll.spec.ts:108` (@webkit) | `overlay-open` is app-managed by a refcount (`overlayScrollLock.applyClass`); a push/pop settling during boot fires `applyClass()` and strips the class the test added, BETWEEN the two `page.evaluate`s (add / read) | add the class AND read the whole chain in ONE synchronous evaluate — no microtask/effect can interleave |

**Post-conditions unchanged in all three.** No assert weakened; the two
deadlines are retry ceilings, not slow-click timeout bumps.

## Verification

- Scoped (STACK lane): `--grep` the three titles, `--repeat-each=3` →
  **9 passed (2.1m)** (#639 chromium ×3, #519 webkit ×3, #531:108 webkit ×3).
- Full `scripts/integration.sh` (ship gate): **in flight** — result appended
  here when it lands. These are intermittent load flakes: a single green run
  is no proof the race is gone, so the evidence is mechanism-soundness (cures
  target the proven root causes above) + no full-suite regression from the
  shared-fixture change.

Merge is the orchestrator's call. Slice C (ExUnit DB-pool `assert_receive` +
the residual #499 `reset_all` gap in `grappa_channel_test`) is the next slice.

Refs #653