### PR TITLE
test(#653): slice C — GrappaChannelTest load-stability (#539) + admission-singleton reset gap (#499)

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -66,6 +66,23 @@ config :logger, level: :warning
 # Cost: ~22s async → ~45s sequential test-suite latency.
 config :ex_unit, max_cases: 1
 
+# #653/#539 — raise the assert_receive/assert_push/assert_reply patience
+# window from ExUnit's 100ms default. Phoenix.ChannelTest's `assert_push/2`
+# + `assert_reply/2` both default their timeout to
+# `Application.fetch_env!(:ex_unit, :assert_receive_timeout)`, so this one
+# knob covers every channel reply/push assertion suite-wide, not just the
+# three GrappaChannelTest cases #539 filed. Those flaked under full-gate
+# load because a DB-write-gated reply/push arrives LATE, not never: with
+# `pool_size: 1` (single SQLite writer) + `max_cases: 1` (serial) + a
+# generous `queue_target: 5_000`, a reply gated on a write queued behind the
+# single writer can land well past 100ms. The message IS the settled signal
+# — waiting longer for it (condition-based-waiting) is the cure, NOT a blind
+# bump: 2s comfortably clears realistic queue latency while a genuinely
+# broken path still fails within 2s. `refute_receive` is UNAFFECTED (it
+# reads the separate `:refute_receive_timeout`), so negative "nothing
+# arrives" assertions stay fast and strict.
+config :ex_unit, assert_receive_timeout: 2_000
+
 # Test runs invoke Grappa.Bootstrap explicitly via Bootstrap.run/0; we
 # don't want the application start to autoload bound credentials and
 # try to connect to real upstream IRC servers during `mix test`.

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -42,12 +42,37 @@ defmodule GrappaWeb.GrappaChannelTest do
   import Grappa.AuthFixtures
 
   alias Grappa.IRCServer
-  alias Grappa.{Networks, Protocol, QueryWindows, Repo, ScrollbackHelpers, Session, WSPresence}
+
+  alias Grappa.{
+    AdmissionStateHelpers,
+    Networks,
+    Protocol,
+    QueryWindows,
+    Repo,
+    ScrollbackHelpers,
+    Session,
+    WSPresence
+  }
+
   alias Grappa.Networks.{Credentials, Servers}
   alias Grappa.PubSub.Topic
   alias Grappa.Scrollback.Wire
   alias Grappa.Visitors.SessionPlan, as: VisitorSessionPlan
   alias GrappaWeb.UserSocket
+
+  # #653/#499 — this file spawns real `Session.Server`s (see
+  # `setup_user_and_network_with_session/2`), but the app-wide singletons
+  # those sessions touch — `NetworkCircuit` + `Backoff` ETS,
+  # `SessionSupervisor`/`SessionRegistry` — survive the `Sandbox` across
+  # tests, so a leftover row keyed by a sqlite-recycled `network_id` can
+  # bleed from an earlier test into a later one (the #499 class). Clear all
+  # three at the START of every test — the documented `AdmissionStateHelpers`
+  # pattern the ~20 other singleton-touching test files already follow; this
+  # file had only referenced it in a comment (the `on_exit` teardown below).
+  setup do
+    AdmissionStateHelpers.reset_all()
+    :ok
+  end
 
   # Mirrors `UserSocket.connect/3`'s assigns surface — assigns
   # `:user_name` AND `:current_subject` (V4: channel arms read the


### PR DESCRIPTION
## Slice C of epic #653 — the ExUnit full-gate load flakes

Two independent test-infra fixes, each a deterministic-setup cure (never an
assert weakening). `Refs #653`.

### 1. `#539` — GrappaChannelTest `assert_receive` timeouts under full-gate load
Three cases (ban reply, who reply, `server_settings_changed` push) flaked with
"no matching message after 100ms" — green 3/3 iso + on rerun. Root cause is the
100ms patience window, not the assertions: `Phoenix.ChannelTest.assert_push/2`
+ `assert_reply/2` default their timeout to
`Application.fetch_env!(:ex_unit, :assert_receive_timeout)` (100ms). Under
`pool_size: 1` (single SQLite writer) + `max_cases: 1` + `queue_target: 5_000`,
a reply/push gated on a DB write queued behind the single writer lands past
100ms — the message **arrives** (correctness holds), just late.

**Fix:** `config :ex_unit, assert_receive_timeout: 2_000` in `config/test.exs`
— one knob covers every channel reply/push assertion suite-wide (the message is
the settled signal; waiting for it = condition-based-waiting, not a blind bump).
`refute_receive` is untouched (separate `:refute_receive_timeout`), so negative
assertions stay fast + strict.

### 2. `#499` — residual admission-singleton reset gap in GrappaChannelTest
The file spawns real `Session.Server`s but never called
`AdmissionStateHelpers.reset_all/0` in setup (only referenced it in an `on_exit`
comment). The app-wide singletons those sessions touch — `NetworkCircuit` +
`Backoff` ETS, `SessionSupervisor`/`SessionRegistry` — survive the `Sandbox`
across tests, so a leftover row keyed by a sqlite-recycled `network_id` can
bleed across tests. **Fix:** add the module-level `setup reset_all()` the ~20
other singleton-touching test files already use.

## Verification — full `scripts/check.sh` GREEN (COMPILE lane)

```
8 doctests, 50 properties, 4927 tests, 0 failures
credo: found no issues · format: clean · dialyzer: Failed Modules: 0
sobelow ok · bats 221/221 · CHECK_EXIT=0
```

These are load flakes (green in isolation), so a single green run isn't proof
the race is gone; the cures target the proven root causes above and the full
suite shows zero regression. Merge is the orchestrator's call.

Refs #653