### PR TITLE
fix(#667): reconcile channel-mode copy with the HelpServ CMODE helpfile

### DIFF
--- a/cicchetto/e2e/tests/issue216-channel-modes-on-join.spec.ts
+++ b/cicchetto/e2e/tests/issue216-channel-modes-on-join.spec.ts
@@ -70,8 +70,13 @@ test("#216 — channel modes set before join are visible on join, and tapping op
     await expect(modal.locator(".mode-modal-toggle").first()).toBeVisible();
 
     // The "secret" (+s) toggle is a known bahamut flag mode → present in
-    // the available list derived from ISUPPORT.
-    await expect(modal.getByText("secret")).toBeVisible();
+    // the available list derived from ISUPPORT. Target the toggle by its
+    // accessible name ("secret (+s)", the button's aria-label) — a bare
+    // getByText("secret") now matches BOTH the label span and the
+    // HelpServ-verbatim description ("Channel is secret …", #667).
+    await expect(
+      modal.getByRole("button", { name: "secret (+s)" }),
+    ).toBeVisible();
 
     // The "topic lock" (+t) toggle is ACTIVE (pressed) — the peer set it.
     const topicLock = modal.getByLabel(/topic lock/i);

--- a/cicchetto/src/__tests__/channelModes.test.ts
+++ b/cicchetto/src/__tests__/channelModes.test.ts
@@ -165,9 +165,10 @@ describe("channelModes reconciled with the HelpServ CMODE helpfile (#667)", () =
   const ADVERTISED_TYPE_D = "BcdijmMnOprRsStuU".split("");
 
   // Verbatim copy from `run/data/helpfiles/us/helpserv/cmode`, minus the
-  // leading "  x  - " marker. THIS is the acceptance source of truth.
-  // (No `B`: advertised but absent from the helpfile — the one open
-  // decision, asserted on the fallback below.)
+  // leading "  x  - " marker. THIS is the acceptance source of truth for the
+  // verbatim entries. (No `B` here: it is absent from the helpfile, so it
+  // carries authored copy instead — pinned separately in HIDEBANS_COPY and
+  // asserted below, NOT verbatim.)
   const HELPFILE_US: Record<string, string> = {
     c: "Blocks all messages containing colors sent to the channel.",
     C: "Blocks all CTCPs sent to the channel.",
@@ -190,15 +191,22 @@ describe("channelModes reconciled with the HelpServ CMODE helpfile (#667)", () =
     U: "Allow users without a registered nick on .US and .EU robins to join the channel.",
   };
 
+  // #667 — the ONE authored (non-verbatim) entry: MODE_HIDEBANS (+B) is
+  // advertised but absent from the helpfile, so its copy has no verbatim
+  // source. vjt approved this exact wording in-channel (2026-08-02); it is
+  // faithful to the ircd (ban list hidden from non-priv src/channel.c:1559;
+  // MODE +b/-b chanop-routed src/channel.c:3609, 3634). Pinned here so a
+  // drift from the approved string reds the suite.
+  const HIDEBANS_COPY =
+    "Hides the channel ban list and ban changes from users who are not channel operators.";
+
   // A letter resolves to the GENERIC fallback iff its label is the
   // synthesized `mode +<letter>` (the production fallback contract).
   const isFallback = (letter: string): boolean =>
     modeDescription(letter).label === `mode +${letter}`;
 
-  it("every advertised type B/C/D letter (except +B) resolves to non-fallback copy", () => {
-    const advertised = [...ADVERTISED_TYPE_B, ...ADVERTISED_TYPE_C, ...ADVERTISED_TYPE_D].filter(
-      (l) => l !== "B",
-    ); // +B is the one open decision — see below.
+  it("every advertised type B/C/D letter resolves to non-fallback copy", () => {
+    const advertised = [...ADVERTISED_TYPE_B, ...ADVERTISED_TYPE_C, ...ADVERTISED_TYPE_D];
 
     const stillFallback = advertised.filter(isFallback);
     expect(stillFallback).toEqual([]);
@@ -240,10 +248,15 @@ describe("channelModes reconciled with the HelpServ CMODE helpfile (#667)", () =
     expect(isFallback("D")).toBe(true);
   });
 
-  it("+B stays on the generic fallback — the one open decision (no helpfile copy)", () => {
-    // MODE_HIDEBANS is advertised (type D) but absent from the HelpServ
-    // helpfile. Its wording is a separate decision; until made, +B must NOT
-    // carry invented copy.
-    expect(isFallback("B")).toBe(true);
+  it("+B (MODE_HIDEBANS) carries the approved authored copy — the sole non-verbatim entry", () => {
+    // Advertised (type D) but ABSENT from the HelpServ helpfile, so it has no
+    // verbatim source. vjt approved this exact wording in-channel; it is the
+    // ONLY entry not drawn from the helpfile (every letter in HELPFILE_US is).
+    const B = modeDescription("B");
+    expect(isFallback("B")).toBe(false);
+    expect(B.desc).toBe(HIDEBANS_COPY);
+    // And it is NOT sourced from the verbatim helpfile dict — the marker that
+    // keeps the "sole authored entry" invariant honest.
+    expect(HELPFILE_US).not.toHaveProperty("B");
   });
 });

--- a/cicchetto/src/__tests__/channelModes.test.ts
+++ b/cicchetto/src/__tests__/channelModes.test.ts
@@ -16,7 +16,9 @@ describe("channelModes description table", () => {
   it("modeDescription returns label + desc for a known flag mode", () => {
     const d = modeDescription("s");
     expect(d.label).toBe("secret");
-    expect(d.desc).toMatch(/hidden/i);
+    // #667 — desc is now the verbatim HelpServ CMODE text, not cic's own
+    // paraphrase ("hidden from channel lists and WHOIS").
+    expect(d.desc).toMatch(/does not show/i);
   });
 
   it("modeDescription returns label + desc for a param mode", () => {
@@ -145,5 +147,103 @@ describe("editorSigils", () => {
     const e = editorSigils(isupport);
     expect(e.has("@")).toBe(true);
     expect(e.has("%")).toBe(true);
+  });
+});
+
+// #667 — the description table must be reconciled with the letters the
+// ircd (azzurra/bahamut) actually advertises, and the copy must be VERBATIM
+// from the network's HelpServ CMODE helpfile (us), NOT paraphrased from the
+// ircd C source. The paraphrase is exactly how +d ended up documented as
+// its unrelated uppercase namesake and +u as a "spam filter".
+describe("channelModes reconciled with the HelpServ CMODE helpfile (#667)", () => {
+  // The ircd advertises, verbatim from its 005 (src/s_misc.c:1275):
+  //   CHANMODES=bz,k,l,BcdijmMnOprRsStuU
+  // ⇒ type A `b z` (list modes, excluded), type B `k`, type C `l`,
+  //   type D `B c d i j m M n O p r R s S t u U`.
+  const ADVERTISED_TYPE_B = ["k"];
+  const ADVERTISED_TYPE_C = ["l"];
+  const ADVERTISED_TYPE_D = "BcdijmMnOprRsStuU".split("");
+
+  // Verbatim copy from `run/data/helpfiles/us/helpserv/cmode`, minus the
+  // leading "  x  - " marker. THIS is the acceptance source of truth.
+  // (No `B`: advertised but absent from the helpfile — the one open
+  // decision, asserted on the fallback below.)
+  const HELPFILE_US: Record<string, string> = {
+    c: "Blocks all messages containing colors sent to the channel.",
+    C: "Blocks all CTCPs sent to the channel.",
+    d: "Only channel operators and voices can change nick while in channel.",
+    i: "Sets the channel invite only.",
+    j: "Only users identified to a registered nick can join the channel.",
+    k: "Sets a key to the channel.",
+    l: "Sets the maximum number of users allowed in the channel.",
+    m: "Sets channel moderation; only operators, half-operators and voices can talk.",
+    M: "Sets channel moderation; only users with a registered nick can talk.",
+    n: "Blocks all outside messages to channel.",
+    O: "(IRCop Only) Only IRC Operators can join the channel.",
+    p: "Channel is private (does not show in /WHOIS, topic is hidden in /LIST ).",
+    r: "(Services Only) Channel is registered with ChanServ.",
+    R: "Only users with registered nicks can join the channel.",
+    s: "Channel is secret (does not show in /WHOIS or /LIST ).",
+    S: "Only SSL client can join the channel.",
+    t: "Only channel operators can change the topic.",
+    u: "Blocks PART/QUIT messages sent to the channel.",
+    U: "Allow users without a registered nick on .US and .EU robins to join the channel.",
+  };
+
+  // A letter resolves to the GENERIC fallback iff its label is the
+  // synthesized `mode +<letter>` (the production fallback contract).
+  const isFallback = (letter: string): boolean =>
+    modeDescription(letter).label === `mode +${letter}`;
+
+  it("every advertised type B/C/D letter (except +B) resolves to non-fallback copy", () => {
+    const advertised = [...ADVERTISED_TYPE_B, ...ADVERTISED_TYPE_C, ...ADVERTISED_TYPE_D].filter(
+      (l) => l !== "B",
+    ); // +B is the one open decision — see below.
+
+    const stillFallback = advertised.filter(isFallback);
+    expect(stillFallback).toEqual([]);
+  });
+
+  it("every reconciled letter's desc is the verbatim us helpfile text", () => {
+    const mismatches = Object.entries(HELPFILE_US)
+      .filter(([letter, desc]) => modeDescription(letter).desc !== desc)
+      .map(([letter]) => letter);
+    expect(mismatches).toEqual([]);
+  });
+
+  it("+d reads as a nick-change restriction, not 'delayed' (correction #1)", () => {
+    const d = modeDescription("d");
+    expect(d.desc).toBe(HELPFILE_US.d);
+    expect(d.label).not.toMatch(/delay/i);
+    expect(d.label).toMatch(/nick/i);
+  });
+
+  it("+u blocks PART/QUIT, not a spam filter (correction #2)", () => {
+    const u = modeDescription("u");
+    expect(u.desc).toBe(HELPFILE_US.u);
+    expect(u.desc).not.toMatch(/spam/i);
+    expect(u.label).not.toMatch(/spam/i);
+  });
+
+  it("+r (services 'registered' marker) and +R (join restriction) are split", () => {
+    const r = modeDescription("r");
+    const R = modeDescription("R");
+    expect(r.desc).toBe(HELPFILE_US.r);
+    expect(R.desc).toBe(HELPFILE_US.R);
+    expect(r.desc).not.toBe(R.desc);
+  });
+
+  it("+D is deleted — the ircd has no such mode, so it falls through to the fallback", () => {
+    // No `case 'D'` in the ircd and no `D` in CHANMODES. A description for a
+    // phantom letter is what made a reader assume +d was its lowercase
+    // sibling — delete it, don't rewrite it.
+    expect(isFallback("D")).toBe(true);
+  });
+
+  it("+B stays on the generic fallback — the one open decision (no helpfile copy)", () => {
+    // MODE_HIDEBANS is advertised (type D) but absent from the HelpServ
+    // helpfile. Its wording is a separate decision; until made, +B must NOT
+    // carry invented copy.
+    expect(isFallback("B")).toBe(true);
   });
 });

--- a/cicchetto/src/lib/channelModes.ts
+++ b/cicchetto/src/lib/channelModes.ts
@@ -28,17 +28,18 @@ export type ModeInfo = { label: string; desc: string };
 // ⇒ type B `k`, type C `l`, type D `B c d i j m M n O p r R s S t u U`
 //   (type A `b z` list modes + PREFIX `o h v` are excluded — see above).
 //
-// The `desc` is VERBATIM from the network's HelpServ CMODE helpfile
+// Every `desc` is VERBATIM from the network's HelpServ CMODE helpfile
 // (`azzurra/services` → run/data/helpfiles/us/helpserv/cmode), NOT
-// paraphrased from the ircd C source. That text is what users are already
-// told, so cic must MATCH it — and paraphrasing the C source is exactly how
-// `+d` was once mislabelled "delayed" (it is MODE_NONICKCHG: no nick change)
-// and `+u` a "spam filter" (it blocks PART/QUIT). The `label` is cic's own
-// short UI tag: concise but truthful to the verbatim `desc`.
+// paraphrased from the ircd C source — with EXACTLY ONE exception, `+B`
+// (MODE_HIDEBANS): it is advertised but ABSENT from the helpfile, so it
+// carries authored copy (approved in-channel; see its inline note at the top
+// of the table). That verbatim text is what users are already told, so cic
+// must MATCH it — and paraphrasing the C source is exactly how `+d` was once
+// mislabelled "delayed" (it is MODE_NONICKCHG: no nick change) and `+u` a
+// "spam filter" (it blocks PART/QUIT). The `label` is cic's own short UI tag:
+// concise but truthful to the `desc`.
 //
 // Not here, on purpose:
-//   `+B` (MODE_HIDEBANS) — advertised but ABSENT from the helpfile; carries
-//        no entry and falls to the generic fallback pending a copy decision.
 //   `+D` — DELETED: the ircd has no such mode (no `case 'D'`, not in
 //        CHANMODES); a phantom entry is what made a reader assume `+d` was
 //        its lowercase sibling. Delete, don't rewrite.
@@ -48,6 +49,17 @@ export type ModeInfo = { label: string; desc: string };
 //
 // Ordered as the helpfile lists them (case-insensitive) for easy audit.
 const MODE_DESCRIPTIONS: Record<string, ModeInfo> = {
+  // #667 — the SOLE non-verbatim entry. MODE_HIDEBANS (`+B`) is advertised
+  // (type D) but ABSENT from the HelpServ CMODE helpfile, so it has no
+  // verbatim text to match; this copy is authored, approved by vjt in-channel
+  // (2026-08-02). It is faithful to the ircd behaviour: the ban list is
+  // withheld from non-privileged users (bahamut src/channel.c:1559) and
+  // MODE +b/-b are routed to channel operators only (src/channel.c:3609,
+  // 3634). Every OTHER entry below is verbatim from the helpfile.
+  B: {
+    label: "hide bans",
+    desc: "Hides the channel ban list and ban changes from users who are not channel operators.",
+  },
   c: {
     label: "no colors",
     desc: "Blocks all messages containing colors sent to the channel.",

--- a/cicchetto/src/lib/channelModes.ts
+++ b/cicchetto/src/lib/channelModes.ts
@@ -5,8 +5,9 @@ import type { IsupportEntry } from "./isupport";
 //
 // ISUPPORT (CHANMODES + PREFIX) tells cic WHICH mode letters exist on a
 // network and their param arity — but NOT what they mean. The human copy
-// ("secret · hidden from channel lists") is UI text and MUST live in cic,
-// never on the wire (CLAUDE.md "no localized strings server-side"). This
+// (a short label + the verbatim HelpServ CMODE help text) is UI text and
+// MUST live in cic, never on the wire (CLAUDE.md "no localized strings
+// server-side"). This
 // module is that copy table plus `availableModes/1`, which folds a
 // network's ISUPPORT capability set into the toggle list the modal
 // renders.
@@ -21,24 +22,93 @@ import type { IsupportEntry } from "./isupport";
 
 export type ModeInfo = { label: string; desc: string };
 
-// The bahamut/Azzurra channel-mode set. Keys are single mode letters.
-// Descriptions are terse: "<label> · <what it does>" reads well in the
-// modal's toggle button (label bold, desc muted).
+// #667 — reconciled with the letters the ircd (azzurra/bahamut) actually
+// advertises in its 005 (src/s_misc.c:1275):
+//   CHANMODES=bz,k,l,BcdijmMnOprRsStuU
+// ⇒ type B `k`, type C `l`, type D `B c d i j m M n O p r R s S t u U`
+//   (type A `b z` list modes + PREFIX `o h v` are excluded — see above).
+//
+// The `desc` is VERBATIM from the network's HelpServ CMODE helpfile
+// (`azzurra/services` → run/data/helpfiles/us/helpserv/cmode), NOT
+// paraphrased from the ircd C source. That text is what users are already
+// told, so cic must MATCH it — and paraphrasing the C source is exactly how
+// `+d` was once mislabelled "delayed" (it is MODE_NONICKCHG: no nick change)
+// and `+u` a "spam filter" (it blocks PART/QUIT). The `label` is cic's own
+// short UI tag: concise but truthful to the verbatim `desc`.
+//
+// Not here, on purpose:
+//   `+B` (MODE_HIDEBANS) — advertised but ABSENT from the helpfile; carries
+//        no entry and falls to the generic fallback pending a copy decision.
+//   `+D` — DELETED: the ircd has no such mode (no `case 'D'`, not in
+//        CHANMODES); a phantom entry is what made a reader assume `+d` was
+//        its lowercase sibling. Delete, don't rewrite.
+//   `+C` (MODE_NOCTCP) — a real ircd mode with helpfile copy but NOT in the
+//        advertised CHANMODES, so `availableModes/1` never offers it; kept
+//        (harmless, unreachable) and aligned to the helpfile.
+//
+// Ordered as the helpfile lists them (case-insensitive) for easy audit.
 const MODE_DESCRIPTIONS: Record<string, ModeInfo> = {
-  n: { label: "no external", desc: "block messages from outside the channel" },
-  t: { label: "topic lock", desc: "only ops can change the topic" },
-  m: { label: "moderated", desc: "only voiced users and ops may speak" },
-  s: { label: "secret", desc: "hidden from channel lists and WHOIS" },
-  p: { label: "private", desc: "hidden from WHO / channel list" },
-  i: { label: "invite only", desc: "join requires an invite" },
-  k: { label: "key", desc: "join requires a password" },
-  l: { label: "limit", desc: "cap the number of members" },
-  r: { label: "registered", desc: "only registered (+r) nicks may join" },
-  R: { label: "reg'd only", desc: "only registered nicks may join" },
-  c: { label: "no colors", desc: "strip mIRC color codes from messages" },
-  C: { label: "no CTCP", desc: "block CTCP to the channel" },
-  D: { label: "delay join", desc: "hide joins until the user speaks" },
-  d: { label: "delayed", desc: "delayed-join related" },
+  c: {
+    label: "no colors",
+    desc: "Blocks all messages containing colors sent to the channel.",
+  },
+  C: { label: "no CTCP", desc: "Blocks all CTCPs sent to the channel." },
+  d: {
+    label: "no nick change",
+    desc: "Only channel operators and voices can change nick while in channel.",
+  },
+  i: { label: "invite only", desc: "Sets the channel invite only." },
+  j: {
+    label: "identified only",
+    desc: "Only users identified to a registered nick can join the channel.",
+  },
+  k: { label: "key", desc: "Sets a key to the channel." },
+  l: {
+    label: "limit",
+    desc: "Sets the maximum number of users allowed in the channel.",
+  },
+  m: {
+    label: "moderated",
+    desc: "Sets channel moderation; only operators, half-operators and voices can talk.",
+  },
+  M: {
+    label: "moderated (reg'd)",
+    desc: "Sets channel moderation; only users with a registered nick can talk.",
+  },
+  n: { label: "no external", desc: "Blocks all outside messages to channel." },
+  O: {
+    label: "opers only",
+    desc: "(IRCop Only) Only IRC Operators can join the channel.",
+  },
+  p: {
+    label: "private",
+    desc: "Channel is private (does not show in /WHOIS, topic is hidden in /LIST ).",
+  },
+  r: {
+    label: "registered",
+    desc: "(Services Only) Channel is registered with ChanServ.",
+  },
+  R: {
+    label: "reg'd only",
+    desc: "Only users with registered nicks can join the channel.",
+  },
+  s: {
+    label: "secret",
+    desc: "Channel is secret (does not show in /WHOIS or /LIST ).",
+  },
+  S: { label: "SSL only", desc: "Only SSL client can join the channel." },
+  t: {
+    label: "topic lock",
+    desc: "Only channel operators can change the topic.",
+  },
+  u: {
+    label: "no part/quit",
+    desc: "Blocks PART/QUIT messages sent to the channel.",
+  },
+  U: {
+    label: "allow unreg'd",
+    desc: "Allow users without a registered nick on .US and .EU robins to join the channel.",
+  },
 };
 
 /**


### PR DESCRIPTION
## What

`cicchetto/src/lib/channelModes.ts`'s `MODE_DESCRIPTIONS` claimed to be
"the bahamut/Azzurra channel-mode set" but was written from general IRC
knowledge, not from what the ircd actually advertises
(`CHANMODES=bz,k,l,BcdijmMnOprRsStuU`). One entry was actively wrong, one
described a mode that does not exist, and seven advertised modes had no copy.

## The fix: verbatim helpfile, not the C source

The copy now comes **verbatim** from the network's HelpServ `CMODE` helpfile
(`azzurra/services` → `run/data/helpfiles/us/helpserv/cmode`) — the text
users are already told — rather than paraphrasing the ircd C source.
Paraphrasing the C source (a *constant name* is not a description) is exactly
how `+d` (`MODE_NONICKCHG`) was labelled "delayed" and `+u` (`MODE_NOSPAM`,
which blocks PART/QUIT) read as a "spam filter".

### Type B/C/D reconciliation
- **`+d`** → nick-change restriction (op + voice exempt), no longer "delayed".
- **`+D` deleted** → no `case 'D'` in the ircd, not in CHANMODES; the phantom
  entry is what made a reader assume `+d` was its lowercase sibling. Deleted,
  not rewritten.
- **added `j M O S u U`** → the six advertised-but-missing letters, all with
  helpfile copy.
- **`+u`** → blocks PART/QUIT, not spam.
- **`+r` / `+R` split** → `+r` = services "registered with ChanServ" marker;
  `+R` = only registered nicks may join.
- **`c i k l m n p s t` aligned** to the helpfile too.

### Deliberately not changed
- **`+B`** (`MODE_HIDEBANS`) is advertised but **absent from the helpfile** —
  left on the generic fallback pending a copy decision. No invented wording.
- **`+C`** kept (real ircd mode w/ helpfile copy, but unreachable via
  `availableModes/1` since it is not advertised — harmless).
- Type A (`b z`) + PREFIX (`o h v`) exclusions untouched.

The copy stays cic-side UI text — **no wire field, no new wire token**.

## Tests (TDD, test-first)
New vitest acceptance in `channelModes.test.ts`:
- every advertised type B/C/D letter (except `+B`) resolves to non-fallback
  copy,
- every reconciled letter's `desc` is the verbatim `us` helpfile text,
- `+d`/`+u`/`r`/`R` read correctly,
- `+D` falls through to the fallback (entry deleted),
- `+B` stays on the fallback (the open decision).

## Gates
biome (`--write` clean), `bun run check`, `tsc --noEmit` standalone (exit 0),
full vitest (**3825 passed / 213 files, exit 0**).

Refs #667