### PR TITLE
fix(#666): resumable, self-pacing multi-line paste + send-door retry-after

### DIFF
--- a/cicchetto/e2e/tests/issue666-paste-resume.spec.ts
+++ b/cicchetto/e2e/tests/issue666-paste-resume.spec.ts
@@ -1,0 +1,101 @@
+// #666 — a multi-line paste that outruns the server's send-door throttle must
+// NOT lose the lines past the 429, and must NOT leave the whole body in the
+// composer (which duplicates the delivered lines on resend). The fix makes the
+// fan-out (compose.ts sendBodyLines) resumable + self-pacing: a send-door 429
+// PAUSES on the server's `retry-after` and retries the SAME (refused, never-
+// delivered) line, draining the whole paste over time; the draft holds ONLY the
+// unsent remainder throughout and empties once every line is out. No line is
+// dropped; the refused line is delivered exactly once (no dup).
+//
+// The dev/e2e stack runs the send throttle effectively OFF (config/dev.exs:
+// capacity 1000, refill 1000/s) so a plain paste can't trip it here — so this
+// spec SIMULATES the throttle at the network edge: one middle line is refused
+// ONCE with a real 429 + `retry-after` header (exactly what
+// messages_controller/#666 now emits), then admitted on retry; every other POST
+// passes to the LIVE server so its WS echo renders the row. That drives the
+// CLIENT's resumable/paced path against a real 429 frame end to end — the flow
+// jsdom can't observe (no live WS echo, no real retry-after round-trip). The
+// unit matrix (compose.test.ts) pins the residue mechanics; this pins the live
+// wire outcome (per feedback_cicchetto_browser_smoke).
+//
+// Safe on the shared vjt: the send-door 429 does NOT feed the coarse #630 sever
+// ladder (only RequestBudget.check does), and 9 POSTs are nowhere near the dev
+// coarse capacity (200), so nothing severs vjt's bearer.
+
+import { composeTextarea, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// POST /networks/{slug}/channels/{channel}/messages (no query string); the GET
+// pagination variant carries `?before=`/`?after=` and is let through untouched.
+const SEND_POST_RE = /\/channels\/[^/]+\/messages(\?|$)/;
+
+test.setTimeout(60_000);
+
+test("#666 — a throttled multi-line paste auto-paces: no drop, no dup, composer drains", async ({
+  page,
+}) => {
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  // Unique per run so prior runs' persisted rows don't satisfy the assertions.
+  const tag = crypto.randomUUID().slice(0, 8);
+  const lines = Array.from({ length: 8 }, (_, i) => `pr ${tag} L${i + 1}`);
+  const refusedLine = lines[3]; // the 4th line — refused ONCE, then admitted.
+  if (refusedLine === undefined) throw new Error("lines[3] missing");
+
+  // Simulate the send door: refuse the 4th line ONCE with a real 429 +
+  // retry-after (2s), then admit on retry; every other POST (and the 4th's
+  // retry) passes to the LIVE server so it persists + broadcasts the WS echo.
+  let refused = false;
+  await page.route(SEND_POST_RE, async (route) => {
+    const req = route.request();
+    if (req.method() !== "POST") {
+      await route.continue();
+      return;
+    }
+    const parsed = req.postDataJSON() as { body?: string };
+    if (parsed.body === refusedLine && !refused) {
+      refused = true;
+      await route.fulfill({
+        status: 429,
+        headers: { "retry-after": "2", "content-type": "application/json" },
+        body: JSON.stringify({ error: "rate_limited" }),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  // Paste the whole block + submit.
+  const ta = composeTextarea(page);
+  await ta.fill(lines.join("\n"));
+  await ta.press("Enter");
+
+  // While paused on the 429, the composer holds ONLY the unsent residue — it
+  // now STARTS at the refused line, proving the delivered lines are gone (the
+  // pre-#666 bug left the WHOLE body, starting at L1, which duplicated on
+  // resend). The `^…L4` anchor fails against a whole-body draft.
+  await expect(ta).toHaveValue(new RegExp(`^pr ${tag} L4`), { timeout: 10_000 });
+
+  // Every line eventually arrives — the refused one was PACED + retried, not
+  // dropped. (Playwright polls each assertion, so the ~2s pace is absorbed.)
+  for (const l of lines) {
+    await expect(scrollbackLine(page, "privmsg", l)).toBeVisible({ timeout: 20_000 });
+  }
+
+  // The refused line was delivered EXACTLY once (refused → never delivered →
+  // delivered on retry) — no duplicate from a whole-body resend.
+  await expect(scrollbackLine(page, "privmsg", refusedLine)).toHaveCount(1);
+
+  // The composer drained to empty: the residue was tracked + consumed, never
+  // left holding the whole body (the resend-duplicates bug).
+  await expect(ta).toHaveValue("", { timeout: 20_000 });
+
+  // Sanity: the throttle actually fired (guards against the route glob missing).
+  expect(refused).toBe(true);
+});

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -6,11 +6,16 @@ vi.mock("../lib/api", () => {
   class ApiError extends Error {
     readonly status: number;
     readonly code: string;
-    constructor(status: number, code: string) {
+    // #666 — the resumable fan-out reads `info.retry_after` off a 429 to pace
+    // the residue, so the stub MUST mirror the real class's `info` field (see
+    // api.ts ApiError) or `e.info` is undefined and the pacing throws.
+    readonly info: Record<string, unknown>;
+    constructor(status: number, code: string, info: Record<string, unknown> = {}) {
       super(`${status} ${code}`);
       this.name = "ApiError";
       this.status = status;
       this.code = code;
+      this.info = info;
     }
   }
   // compose.ts's catch does `e instanceof ChannelPushError` (#62) — the
@@ -353,6 +358,156 @@ describe("compose submit — slash command dispatch", () => {
 
     expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "hello");
     expect(result).toEqual({ ok: true });
+  });
+
+  // #666 — a multi-line paste fans out to one PRIVMSG per line, clears the
+  // draft on full success, and records the WHOLE original body as ONE history
+  // entry (not per-line).
+  it("#666 — a multi-line body sends one PRIVMSG per line and clears the draft", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+
+    compose.setDraft(k, "one\ntwo\nthree");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(vi.mocked(sb.sendMessage).mock.calls.map((c) => c[2])).toEqual(["one", "two", "three"]);
+    expect(compose.getDraft(k)).toBe("");
+    expect(result).toEqual({ ok: true });
+
+    // History records the WHOLE original paste (one recall entry), not per-line.
+    compose.recallPrev(k);
+    expect(compose.getDraft(k)).toBe("one\ntwo\nthree");
+  });
+
+  // #666 — the CORE bug. A fatal mid-paste error must leave ONLY the unsent
+  // remainder in the draft (never the whole body), so a resend sends ONLY that
+  // remainder — never re-delivering the lines that already went out.
+  it("#666 — fatal mid-paste keeps only the residue; resume sends only the remainder (no dup)", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    const api = await import("../lib/api");
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+
+    // l1..l3 delivered; the 4th send fails FATALLY (400 invalid_line, not a 429).
+    let n = 0;
+    vi.mocked(sb.sendMessage).mockImplementation(async () => {
+      n += 1;
+      if (n === 4) throw new api.ApiError(400, "invalid_line");
+      return undefined as never;
+    });
+
+    compose.setDraft(k, "l1\nl2\nl3\nl4\nl5");
+    const first = await compose.submit(k, "freenode", "#a");
+
+    // l1..l4 attempted once each (l4 failed); l5 NEVER attempted (no drop-and-forget).
+    expect(vi.mocked(sb.sendMessage).mock.calls.map((c) => c[2])).toEqual(["l1", "l2", "l3", "l4"]);
+    // Draft holds ONLY the unsent remainder — the delivered l1..l3 are gone.
+    expect(compose.getDraft(k)).toBe("l4\nl5");
+    expect(first).toHaveProperty("error");
+
+    // Resume: the door is open now. Resending sends ONLY l4, l5 — never l1..l3 again.
+    vi.mocked(sb.sendMessage).mockReset();
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const second = await compose.submit(k, "freenode", "#a");
+
+    expect(vi.mocked(sb.sendMessage).mock.calls.map((c) => c[2])).toEqual(["l4", "l5"]);
+    expect(compose.getDraft(k)).toBe(""); // fully drained
+    expect(second).toEqual({ ok: true });
+  });
+
+  // #666 — a send-door 429 is a PAUSE, not a failure: the fan-out waits the
+  // server's retry-after, then retries the SAME (refused, never-delivered) line
+  // and drains the rest. No line dropped; the refused line is not skipped; the
+  // draft holds the unsent remainder while it paces.
+  it("#666 — a send-door 429 auto-paces on retry-after and drains the full paste", async () => {
+    vi.useFakeTimers();
+    try {
+      localStorage.setItem("grappa-token", "tok");
+      const sb = await import("../lib/scrollback");
+      const api = await import("../lib/api");
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+
+      // a, b deliver; c (call 3) is refused ONCE with a 429 carrying
+      // retry_after: 2 (seconds); every later attempt succeeds.
+      let n = 0;
+      let refused = false;
+      vi.mocked(sb.sendMessage).mockImplementation(async () => {
+        n += 1;
+        if (n === 3 && !refused) {
+          refused = true;
+          throw new api.ApiError(429, "rate_limited", { retry_after: 2 });
+        }
+        return undefined as never;
+      });
+
+      compose.setDraft(k, "a\nb\nc\nd");
+      const done = compose.submit(k, "freenode", "#a");
+
+      // Flush microtasks up to the 429 pause: a, b delivered; c refused once.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(vi.mocked(sb.sendMessage).mock.calls.map((c) => c[2])).toEqual(["a", "b", "c"]);
+      // Residue after the refusal is the UNSENT remainder incl. the refused c.
+      expect(compose.getDraft(k)).toBe("c\nd");
+
+      // Honour the interval: advance the full 2s → c retried, then d.
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      // Every line delivered in order; c appears twice on the CALL log (refused
+      // then delivered) but only ever went out once (the first was a 429).
+      expect(vi.mocked(sb.sendMessage).mock.calls.map((c) => c[2])).toEqual([
+        "a",
+        "b",
+        "c",
+        "c",
+        "d",
+      ]);
+      expect(compose.getDraft(k)).toBe(""); // fully drained, no residue
+      expect(await done).toEqual({ ok: true });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // #666 — safety valve: a door that keeps 429ing PAST its own retry-after must
+  // NOT hang the composer forever. After the per-line retry cap the fan-out
+  // gives up and surfaces the throttle, leaving the unsent residue in the draft.
+  // `vi.runAllTimersAsync` would itself throw if the loop were unbounded (it
+  // aborts after 10k timers) — so this is also the regression guard against
+  // ever removing the cap.
+  it("#666 — a persistently throttled paste stops after the retry cap (no infinite loop), residue kept", async () => {
+    vi.useFakeTimers();
+    try {
+      localStorage.setItem("grappa-token", "tok");
+      const sb = await import("../lib/scrollback");
+      const api = await import("../lib/api");
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+
+      // a delivers; b (and every retry of it) is refused with a 429 forever.
+      let n = 0;
+      vi.mocked(sb.sendMessage).mockImplementation(async () => {
+        n += 1;
+        if (n >= 2) throw new api.ApiError(429, "rate_limited", { retry_after: 1 });
+        return undefined as never;
+      });
+
+      compose.setDraft(k, "a\nb\nc");
+      const done = compose.submit(k, "freenode", "#a");
+      // Drain every scheduled pace-sleep; bounded by the cap → settles.
+      await vi.runAllTimersAsync();
+      const result = await done;
+
+      expect(result).toHaveProperty("error");
+      // a went out and is gone from the draft; the unsent b, c remain.
+      expect(compose.getDraft(k)).toBe("b\nc");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("/me action sends as ACTION via scrollback.sendMessage with CTCP framing", async () => {

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -14,7 +14,7 @@ import { token } from "./auth";
 import { openBanlistModal } from "./banlistModal";
 import { buildBanMask } from "./banMask";
 import { setQuery } from "./channelDirectory";
-import { type ChannelKey, canonicalChannel } from "./channelKey";
+import { type ChannelKey, canonicalChannel, channelKey } from "./channelKey";
 import { friendlyError } from "./friendlyError";
 import { addHighlight, delHighlight } from "./highlightList";
 import { identityScopedStore } from "./identityScopedStore";
@@ -134,6 +134,12 @@ export const ctcpFrame = (verb: string, args: string): string =>
 // the header). Matches the send throttle's default 0.5/s refill (1 token / 2s).
 const DEFAULT_RETRY_AFTER_MS = 2_000;
 
+// Upper clamp on a server-supplied retry-after. grappa emits 2s; the clamp is
+// purely defensive so a hostile/misconfigured intermediary can't inject a huge
+// `retry-after` and freeze the composer (the retry cap bounds the COUNT of
+// waits, this bounds their DURATION).
+const MAX_RETRY_AFTER_MS = 60_000;
+
 // Safety valve: how many times ONE line is re-paced against a persistent 429
 // before the fan-out gives up and surfaces the throttle. An honest send door
 // admits on the FIRST retry once a token has refilled (we waited its own
@@ -155,9 +161,11 @@ const isSendThrottled = (e: unknown): e is ApiError => e instanceof ApiError && 
 // ms, falling back to the send-throttle default if it's missing/garbage.
 const retryAfterMs = (e: ApiError): number => {
   const seconds = e.info.retry_after;
-  return typeof seconds === "number" && Number.isFinite(seconds) && seconds > 0
-    ? seconds * 1_000
-    : DEFAULT_RETRY_AFTER_MS;
+  const ms =
+    typeof seconds === "number" && Number.isFinite(seconds) && seconds > 0
+      ? seconds * 1_000
+      : DEFAULT_RETRY_AFTER_MS;
+  return Math.min(ms, MAX_RETRY_AFTER_MS);
 };
 
 // Split a free-text body into one PRIVMSG per line (see messageLines.ts for
@@ -631,9 +639,19 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           // echo stays the sole render path (no optimistic local render — cf.
           // the #251 source_address abolition).
           await ensureQueryTopicJoined(networkSlug, canonical);
-          // #666 — resumable + paced. Residue keyed on the source window `key`
-          // (where /msg was typed), not the query window we just focused.
-          const r = await sendPacedBody(key, networkSlug, canonical, cmd.body, false);
+          // #666 — resumable + paced. Residue keyed on the QUERY window we just
+          // focused (`canonical`), NOT the source window: /msg already switched
+          // focus here, so a partial-send remainder + its error banner must
+          // co-locate in the window the operator is now looking at — and a
+          // resend of that plain-text residue from the query window goes to
+          // `canonical` (the intended peer), not back to the source channel.
+          const r = await sendPacedBody(
+            channelKey(networkSlug, canonical),
+            networkSlug,
+            canonical,
+            cmd.body,
+            false,
+          );
           if ("error" in r) return r;
           result = r;
           break;

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -1,6 +1,7 @@
 import { createSignal } from "solid-js";
 import { addAlias, aliases, delAlias } from "./aliasList";
 import {
+  ApiError,
   ownNickForNetwork,
   patchNetwork,
   postJoin,
@@ -116,21 +117,103 @@ const empty = (): ComposeState => ({
 export const ctcpFrame = (verb: string, args: string): string =>
   args === "" ? `\x01${verb}\x01` : `\x01${verb} ${args}\x01`;
 
-// Multiline fan-out: split a free-text body into one PRIVMSG per line
-// (see messageLines.ts for the wire-framing why) and send each.
-// `action` wraps every line in CTCP ACTION framing for /me (via the shared
-// `ctcpFrame` builder). Sequential await preserves wire order; a single-line
-// body loops exactly once, so the common path is unchanged from the pre-split
-// behavior. Shared by the privmsg, me, and msg send sites — the only free-text
-// paths whose body can contain an operator-typed newline.
+// #666 — resumable, self-pacing multiline fan-out.
+//
+// A paste sends one PRIVMSG per line, but the server's send door (the
+// per-(subject, network) token bucket, #340) refuses a burst past its
+// capacity with a 429. Pre-#666 the first 429 rejected the for-await loop and
+// EVERY remaining line was silently dropped, while the draft (cleared only on
+// success) still held the WHOLE body — so resending duplicated the delivered
+// lines AND immediately re-tripped the throttle. The fix makes a 429 a pause,
+// not a failure: wait the server's retry-after, then retry THIS line (a
+// refused line was never delivered, so retrying is neither a drop nor a dup).
+// Only a fatal error stops the drain.
+
+// Fallback wait when a 429 arrives with no parseable retry-after (the server
+// always sends one now — messages_controller/#666 — but a proxy could strip
+// the header). Matches the send throttle's default 0.5/s refill (1 token / 2s).
+const DEFAULT_RETRY_AFTER_MS = 2_000;
+
+// Safety valve: how many times ONE line is re-paced against a persistent 429
+// before the fan-out gives up and surfaces the throttle. An honest send door
+// admits on the FIRST retry once a token has refilled (we waited its own
+// retry-after), so the cap is only reached by a door that refuses PAST its own
+// hint (a misbehaving/severed server, or a proxy 429) — the guard that keeps
+// the composer from hanging on an unbounded retry loop. Generous enough to
+// absorb timer jitter around the refill boundary.
+const MAX_PACED_RETRIES_PER_LINE = 5;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+// A send-door 429 — the ONLY error class the fan-out paces-and-retries rather
+// than surfacing. Everything else (WS down, invalid_line, a severed-session
+// 401) is fatal and stops the drain.
+const isSendThrottled = (e: unknown): e is ApiError => e instanceof ApiError && e.status === 429;
+
+// ms to wait before retrying a throttled line. `api.ts readError` parses the
+// server's `retry-after` header (seconds) into `info.retry_after`; convert to
+// ms, falling back to the send-throttle default if it's missing/garbage.
+const retryAfterMs = (e: ApiError): number => {
+  const seconds = e.info.retry_after;
+  return typeof seconds === "number" && Number.isFinite(seconds) && seconds > 0
+    ? seconds * 1_000
+    : DEFAULT_RETRY_AFTER_MS;
+};
+
+// Split a free-text body into one PRIVMSG per line (see messageLines.ts for
+// the wire-framing why) and send each, in order. `action` wraps every line in
+// CTCP ACTION framing for /me (via the shared `ctcpFrame` builder). Sequential
+// await preserves wire order; a single-line body loops exactly once (the
+// common path). Shared by the privmsg, me, and msg send sites — the only
+// free-text paths whose body can contain an operator-typed newline.
+//
+// #666 — a send-door 429 retries the SAME line after the server's retry-after
+// (never advancing `sent` past a refusal → never a drop, never a dup); any
+// other error stops and propagates. `onProgress` (optional) fires after every
+// acked line AND before every pace/stop, with the count sent so far and the
+// unsent remainder joined back into a body — compose `submit` mirrors that
+// remainder into the draft so it holds ONLY what has not gone out. External
+// callers (ServiceModal, RegistrationWizardModal) pass no callback and simply
+// inherit the never-drop + pacing behaviour.
 export const sendBodyLines = async (
   slug: string,
   target: string,
   body: string,
   action: boolean,
+  onProgress?: (sent: number, total: number, residue: string) => void,
 ): Promise<void> => {
-  for (const line of splitMessageLines(body)) {
-    await sendPrivmsg(slug, target, action ? ctcpFrame("ACTION", line) : line);
+  const lines = splitMessageLines(body);
+  const total = lines.length;
+  let sent = 0;
+  // Consecutive paced retries of the CURRENT line; reset when `sent` advances.
+  let retries = 0;
+  while (sent < total) {
+    // `?? ""` satisfies noUncheckedIndexedAccess; `sent < total` guarantees a value.
+    const line = lines[sent] ?? "";
+    try {
+      await sendPrivmsg(slug, target, action ? ctcpFrame("ACTION", line) : line);
+      sent += 1;
+      retries = 0;
+      onProgress?.(sent, total, lines.slice(sent).join("\n"));
+    } catch (e) {
+      // The residue always starts at `sent` — the first line NOT yet acked.
+      // On a 429 that is the refused line (retry it after pacing); on a fatal
+      // error it is the line that failed (kept, not dropped). Either way the
+      // caller's draft must hold exactly lines[sent..].
+      onProgress?.(sent, total, lines.slice(sent).join("\n"));
+      // Auto-pace ONLY a multi-line paste (the #666 domain): a SINGLE throttled
+      // send surfaces immediately, preserving #342's throttle-copy affordance.
+      // `retries` caps the wait against a door that refuses past its own
+      // retry-after (misbehaving/severed server) so the composer never hangs —
+      // an honest throttle admits on the first retry once a token has refilled.
+      if (isSendThrottled(e) && total > 1 && retries < MAX_PACED_RETRIES_PER_LINE) {
+        retries += 1;
+        await sleep(retryAfterMs(e));
+        // loop retries the same `sent` index — never advanced past a refusal.
+      } else {
+        throw e;
+      }
+    }
   }
 };
 
@@ -213,6 +296,50 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     }));
   };
 
+  // #666 — send a free-text body as one PRIVMSG per line via the resumable,
+  // self-pacing `sendBodyLines`, mirroring the UNSENT remainder into the draft
+  // after every line so the composer holds ONLY what has not gone out — never
+  // the whole body (the pre-#666 resend-duplicates bug). A send-door 429 auto-
+  // paces and drains the rest over time (the composer stays busy while it
+  // does); a fatal error stops with the residue in the draft and surfaces how
+  // many lines made it out. Used by the privmsg / me / msg arms — the free-text
+  // paths whose body can be a multi-line paste. `key` is the SOURCE window (the
+  // one the operator submitted from), so a partial send leaves the remainder
+  // where it was typed. On error returns `{error}` — the caller MUST early-
+  // return it so the shared end-of-submit draft-clear + history-push never
+  // runs (which would wipe the residue and record a half-sent paste).
+  const sendPacedBody = async (
+    key: ChannelKey,
+    slug: string,
+    target: string,
+    body: string,
+    action: boolean,
+  ): Promise<SubmitResult> => {
+    let sentCount = 0;
+    let totalCount = 0;
+    try {
+      await sendBodyLines(slug, target, body, action, (sent, total, residue) => {
+        sentCount = sent;
+        totalCount = total;
+        // Residue-only draft, reset to the live bottom (historyCursor null):
+        // we're typing the remainder, not walking history.
+        writeState(key, (s) => ({ ...s, draft: residue, historyCursor: null }));
+      });
+      return { ok: true };
+    } catch (e) {
+      // Fatal mid-fan-out (WS down, invalid_line, severed 401). The residue
+      // draft is already set to the unsent remainder; surface the reason and,
+      // for a genuine multi-line paste, how many lines went out so the operator
+      // knows the send partially landed and the rest is queued in the box.
+      const reason = friendlyError(e);
+      return totalCount > 1
+        ? {
+            error: `${reason} — sent ${sentCount} of ${totalCount} lines; the rest are in the box`,
+          }
+        : { error: reason };
+    }
+  };
+
   const submit = async (
     key: ChannelKey,
     networkSlug: string,
@@ -288,17 +415,25 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     let result: SubmitResult;
     try {
       switch (cmd.kind) {
-        case "privmsg":
-          // One PRIVMSG per line — an embedded newline can't ride a
-          // single IRC frame (server rejects as :invalid_line).
-          await sendBodyLines(networkSlug, channelName, cmd.body, false);
-          result = { ok: true };
+        case "privmsg": {
+          // One PRIVMSG per line — an embedded newline can't ride a single IRC
+          // frame (server rejects as :invalid_line). #666 — resumable + paced:
+          // a send-door 429 drains the rest over time; a fatal error leaves ONLY
+          // the unsent remainder in the draft (early-return so the end-of-submit
+          // clear never wipes it).
+          const r = await sendPacedBody(key, networkSlug, channelName, cmd.body, false);
+          if ("error" in r) return r;
+          result = r;
           break;
-        case "me":
-          // CTCP ACTION framing per line: \x01ACTION <text>\x01.
-          await sendBodyLines(networkSlug, channelName, cmd.body, true);
-          result = { ok: true };
+        }
+        case "me": {
+          // CTCP ACTION framing per line: \x01ACTION <text>\x01. Same #666
+          // resumable + paced fan-out as privmsg.
+          const r = await sendPacedBody(key, networkSlug, channelName, cmd.body, true);
+          if ("error" in r) return r;
+          result = r;
           break;
+        }
         // #591 — /ctcp <target> <VERB> [args]: a single CTCP frame to an
         // EXPLICIT target (not the current window), built via the shared
         // `ctcpFrame` seam. Non-ACTION CTCP is single-line by convention
@@ -478,8 +613,10 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           const networkId = networkIdBySlug(networkSlug);
           if (networkId === undefined) return { error: "/msg: network not found" };
           if (isServicesSender(cmd.target)) {
-            await sendBodyLines(networkSlug, cmd.target, cmd.body, false);
-            result = { ok: true };
+            // #666 — resumable + paced; residue keyed on the source window `key`.
+            const svc = await sendPacedBody(key, networkSlug, cmd.target, cmd.body, false);
+            if ("error" in svc) return svc;
+            result = svc;
             break;
           }
           const canonical = canonicalQueryNick(networkId, cmd.target);
@@ -494,8 +631,11 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           // echo stays the sole render path (no optimistic local render — cf.
           // the #251 source_address abolition).
           await ensureQueryTopicJoined(networkSlug, canonical);
-          await sendBodyLines(networkSlug, canonical, cmd.body, false);
-          result = { ok: true };
+          // #666 — resumable + paced. Residue keyed on the source window `key`
+          // (where /msg was typed), not the query window we just focused.
+          const r = await sendPacedBody(key, networkSlug, canonical, cmd.body, false);
+          if ("error" in r) return r;
+          result = r;
           break;
         }
         case "service-modal": {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -26528,3 +26528,86 @@ design choice from #510. cic-only: two production files (`slashCommands.ts` type
 `channel:` to `channels:`. No wire token, no server/Elixir change. The
 IRC message-kind `"join"` (a JOIN *event* with `sender`/`body`) is a DIFFERENT
 type and was left untouched.
+
+---
+
+### 2026-08-02 — #666 — multi-line paste is resumable + self-pacing; the send-door 429 carries a retry-after (P0, cross-stack)
+
+Sonic + Mezmerize: pasting more than a handful of lines into the composer lost
+every line after the first throttled one, and left the box in a state where
+re-sending duplicated the lines that already went out. Four root causes, all
+verified on origin/main:
+
+1. **The client dropped lines.** `compose.ts sendBodyLines` fanned a body to one
+   PRIVMSG per line in a bare `for … await` loop with no `try`/`catch`. The
+   first refused line rejected the promise, the loop unwound, and **every
+   remaining line was dropped** — never attempted, never recorded.
+2. **The client couldn't resume, and duplicated.** `submit` cleared the draft
+   only on the success path, so on failure the composer still held the **whole**
+   body (including the delivered lines). Re-sending duplicated them AND re-tripped
+   the throttle.
+3. **The refusal is the #340 send door** — the per-`(subject, network)` token
+   bucket (`config :send_throttle`, capacity 5, refill 0.5/s). In a paste the
+   first 5 pass, the 6th 429s, the rest vanish.
+4. **The server omitted a retry hint.** The send-door 429 rendered as
+   `{error: "rate_limited"}` with **no `retry-after`**, so the client had no
+   principled interval to pace against.
+
+**Design fork (vjt-resolved): BOTH.** Auto-pace the remaining lines on the
+bucket's refill AND, at every instant, keep ONLY the unsent residue in the draft
+— not "send what you can then leave the residue for a manual resend." The paste
+drains itself over time; the composer visibly shrinks to the remainder.
+
+**Client (`compose.ts`).** `sendBodyLines` is now resumable + self-pacing. A
+send-door 429 (`ApiError.status === 429`) is a *pause*, not a failure: wait the
+server's `retry-after` (`info.retry_after`, seconds → ms), then retry the **same**
+line — a refused line was never delivered, so a retry is neither a drop nor a
+dup. `sent` never advances past a refusal. An optional `onProgress(sent, total,
+residue)` callback fires after every ack and before every pause; the new
+closure-scoped `sendPacedBody` (wrapping the privmsg / me / msg arms) mirrors the
+`residue` into the draft so it holds exactly `lines[sent..]`, and on a fatal error
+surfaces "sent N of M lines" with the residue preserved (early-return so the
+end-of-submit clear + history-push never wipe it). History still records the
+**whole** original body as one recall entry.
+
+Two deliberate bounds:
+
+* **Auto-pace only a multi-line paste** (`total > 1`). A *single* throttled send
+  still surfaces immediately — preserving #342's throttle-copy affordance
+  untouched (a lone "you're going too fast" message is worth showing; a batch is
+  the client's to meter out). This is why #342's e2e stays green with no edit.
+* **A per-line retry cap** (`MAX_PACED_RETRIES_PER_LINE`) is the safety valve
+  against a door that refuses *past* its own `retry-after` (a misbehaving /
+  severed server, or a proxy 429): an honest throttle admits on the first retry
+  once a token has refilled, so the cap is only reached pathologically — it keeps
+  the composer from hanging on an unbounded loop, then surfaces the throttle.
+
+External `sendBodyLines` callers (ServiceModal, RegistrationWizardModal) pass no
+callback and inherit the never-drop + pacing behaviour for free.
+
+**Server (`messages_controller.ex` + `fallback_controller.ex`).** The send-door
+429 now carries a `retry-after` header. `take_send_token/2` tags a refusal
+`{:error, {:rate_limited, secs}}` and a new `FallbackController` clause emits the
+header — the same "tuple carries the retry value" shape as
+`{:network_circuit_open, retry_after}` / `{:anon_collision, _}`. The value is the
+**send throttle's OWN** refill interval (`@send_throttle_retry_after_seconds =
+max(1, ceil(1.0 / refill_per_sec))` = 2s at 0.5/s), NOT
+`RequestBudget.retry_after_ms/0`: that reads the coarse #630 budget's much faster
+refill (20/s → 50ms) and would pace cic against the wrong bucket, re-429ing every
+line. The bare `:rate_limited` atom stays reserved for the #75 themes daily quota
+(a calendar-day reset that deliberately gets no seconds hint) — the two are now
+distinct clauses. Wire body is byte-identical (`error: "rate_limited"`), so this
+is **additive-only**: no new wire token (cic already parses `retry-after` in
+`api.ts readError`), no `protocol_version` bump.
+
+**Out of scope (vjt-declared):** #480 (send throttle mirroring the upstream oper
+allowance — that's *how much*, this is *not losing data when exceeded*) and the
+coarse `request_budget` sever ladder (a paste trips 1-2 over-budget events,
+nowhere near `sever_after`).
+
+**Apply:** a fan-out of independent sends over a rate-limited door is resumable
+by construction — never drop the tail on the first refusal, never re-send an
+acked item, keep the draft = the unsent residue, and pace on the refusing
+bucket's OWN advertised interval. When a 429 hint already flows on the wire
+(`retry-after` header, or a `retry_after_ms` JSON field), read it — don't
+back-to-back-refire and re-trip the throttle.

--- a/lib/grappa_web/controllers/fallback_controller.ex
+++ b/lib/grappa_web/controllers/fallback_controller.ex
@@ -76,6 +76,7 @@ defmodule GrappaWeb.FallbackController do
            | :share_token_expired
            | :share_token_consumed
            | :rate_limited
+           | {:rate_limited, pos_integer()}
            | :too_many_attempts
            | :theme_cap_reached
            | :list_full
@@ -220,6 +221,26 @@ defmodule GrappaWeb.FallbackController do
   # boundary, not a rolling window, so a seconds hint would mislead.
   def call(conn, {:error, :rate_limited}) do
     conn
+    |> put_status(:too_many_requests)
+    |> json(%{error: "rate_limited"})
+  end
+
+  # #666 — the #340 send-door token bucket (POST /messages) refused: the
+  # per-(subject, network) send throttle is empty. Distinct from the bare
+  # :rate_limited above (themes DailyQuota, a calendar-day reset that gets NO
+  # hint) — this bucket refills at a fixed rate, so the 429 carries a
+  # `retry-after` header (seconds) cic paces the remaining paste lines against
+  # instead of firing them back-to-back and re-tripping. The value is the send
+  # throttle's OWN refill interval, threaded through the tuple by
+  # `MessagesController.take_send_token/2` (NOT `RequestBudget.retry_after_ms/0`,
+  # the coarse #630 budget). cic reads the header in `api.ts readError` →
+  # `body.retry_after`. Same "tuple carries the retry value" shape as
+  # `{:network_circuit_open, retry_after}` / `{:anon_collision, _}`. Wire body
+  # is byte-identical to the bare clause (`error: "rate_limited"`) — additive,
+  # no new token, no protocol bump.
+  def call(conn, {:error, {:rate_limited, retry_after}}) when is_integer(retry_after) do
+    conn
+    |> put_resp_header("retry-after", Integer.to_string(retry_after))
     |> put_status(:too_many_requests)
     |> json(%{error: "rate_limited"})
   end

--- a/lib/grappa_web/controllers/messages_controller.ex
+++ b/lib/grappa_web/controllers/messages_controller.ex
@@ -78,6 +78,15 @@ defmodule GrappaWeb.MessagesController do
                                   0.5
                                 )
 
+  # #666 — seconds until one token refills; the client-facing retry hint on a
+  # send-door 429. Derived from THIS bucket's refill — NOT
+  # `RequestBudget.retry_after_ms/0`, which reads the coarse #630 budget's much
+  # faster refill and would pace cic against the wrong bucket (re-429ing every
+  # line of a paste). `ceil` so cic never under-waits and re-trips instantly;
+  # `max(1, _)` guards a sub-second config from flooring to 0. HTTP Retry-After
+  # is integer seconds (RFC 7231 §7.1.3) — coarse but honest for this bucket.
+  @send_throttle_retry_after_seconds max(1, ceil(1.0 / @send_throttle_refill_per_sec))
+
   @doc """
   `GET /networks/:network_id/channels/:channel_id/messages` —
   paginated scrollback fetch for the authenticated subject.
@@ -165,7 +174,7 @@ defmodule GrappaWeb.MessagesController do
   """
   @spec create(Plug.Conn.t(), map()) ::
           Plug.Conn.t()
-          | {:error, :bad_request | :no_session | :invalid_line | :rate_limited}
+          | {:error, :bad_request | :no_session | :invalid_line | {:rate_limited, pos_integer()}}
           | {:error, Ecto.Changeset.t()}
   def create(conn, %{"channel_id" => channel, "body" => body, "ctcp_target" => ctcp_target})
       when is_binary(body) and body != "" and is_binary(ctcp_target) and ctcp_target != "" do
@@ -217,16 +226,27 @@ defmodule GrappaWeb.MessagesController do
   def create(_, %{"channel_id" => _}), do: {:error, :bad_request}
 
   # #340 — consume one send-token for `(subject, network)`. `:ok` rides
-  # through the `with`; `{:error, :rate_limited}` short-circuits it to the
-  # FallbackController 429 clause.
-  @spec take_send_token(Session.subject(), integer()) :: :ok | {:error, :rate_limited}
+  # through the `with`; a refusal short-circuits it to the FallbackController
+  # 429 clause.
+  #
+  # #666 — a refused take is tagged `{:rate_limited, retry_after_seconds}`
+  # (the tuple shape `FallbackController` renders with a `retry-after` header),
+  # carrying THIS bucket's own refill interval so cic paces the remaining
+  # lines of a multi-line paste against the bucket that actually refused —
+  # NOT the coarse #630 budget. The bare `:rate_limited` atom stays reserved
+  # for the #75 themes daily quota (no meaningful seconds hint).
+  @spec take_send_token(Session.subject(), integer()) ::
+          :ok | {:error, {:rate_limited, pos_integer()}}
   defp take_send_token(subject, network_id) do
-    TokenBucket.take(
-      @send_throttle_bucket,
-      {subject, network_id},
-      @send_throttle_capacity,
-      @send_throttle_refill_per_sec
-    )
+    case TokenBucket.take(
+           @send_throttle_bucket,
+           {subject, network_id},
+           @send_throttle_capacity,
+           @send_throttle_refill_per_sec
+         ) do
+      :ok -> :ok
+      {:error, :rate_limited} -> {:error, {:rate_limited, @send_throttle_retry_after_seconds}}
+    end
   end
 
   # `Session.send_privmsg/4`'s contract returns either:

--- a/test/grappa_web/controllers/messages_controller_outbound_test.exs
+++ b/test/grappa_web/controllers/messages_controller_outbound_test.exs
@@ -539,6 +539,33 @@ defmodule GrappaWeb.MessagesControllerOutboundTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    # #666 — the send-door 429 MUST carry a `retry-after` header so cic can
+    # pace the remaining lines of a multi-line paste against THIS bucket's
+    # refill instead of firing them back-to-back (and re-429ing). The value is
+    # the send throttle's OWN refill interval — NOT the coarse #630 budget's
+    # (RequestBudget.retry_after_ms/0), which refills far faster and would
+    # mis-pace cic. Derived from config here so the assertion tracks the wire
+    # contract, not a magic constant.
+    test "a throttled POST (429) carries a retry-after header = the send-throttle refill interval",
+         %{conn: conn, vjt: vjt} do
+      {server, port} = start_server()
+      network = setup_network(vjt, port)
+      pid = start_session_for(vjt, network)
+      :ok = await_handshake(server)
+
+      # Drain the burst (capacity 3 in test config), then trip the empty bucket.
+      for n <- 1..3, do: assert(json_response(post_body(conn, network, "line #{n}"), 201))
+      throttled = post_body(conn, network, "flood")
+      assert %{"error" => "rate_limited"} = json_response(throttled, 429)
+
+      # seconds until one token refills = ceil(1 / refill_per_sec), floored at 1.
+      refill = Application.get_env(:grappa, :send_throttle)[:refill_per_sec]
+      expected = Integer.to_string(max(1, ceil(1.0 / refill)))
+      assert [^expected] = get_resp_header(throttled, "retry-after")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
     test "the bucket is per-(subject, network): a second network is unaffected by the first's flood",
          %{conn: conn, vjt: vjt} do
       {server1, port1} = start_server()


### PR DESCRIPTION
Refs #666 (P0).

## The bug (4 facts, verified on origin/main)

Pasting a multi-line body lost every line after the first throttled one, and left the composer holding the **whole** body so a resend duplicated the delivered lines.

1. **Client dropped lines.** `compose.ts sendBodyLines` fanned out in a bare `for … await` loop with no `try`/`catch` — the first refused line unwound the loop, dropping the tail (never attempted, never recorded).
2. **Client couldn't resume + duplicated.** `submit` cleared the draft only on success, so on failure the whole body (incl. delivered lines) stayed → resend duplicated them and re-tripped the throttle.
3. **The refusal** is the #340 send door — the per-`(subject, network)` token bucket (`:send_throttle`, capacity 5, refill 0.5/s).
4. **Server omitted the retry hint.** The send-door 429 rendered `{error: "rate_limited"}` with no `retry-after`, so the client had no principled interval to pace against.

## The fix

**Design fork (vjt-resolved): BOTH** — auto-pace the remaining lines on the bucket's refill **AND** keep only the unsent residue in the draft at every instant.

### Client (`cicchetto/src/lib/compose.ts`)
- `sendBodyLines` is resumable + self-pacing: a send-door 429 **pauses** on the server's `retry-after` and retries the **same** line (a refused line was never delivered → retry is neither a drop nor a dup); `sent` never advances past a refusal.
- `onProgress(sent, total, residue)` mirrors the unsent remainder into the draft (never the whole body); `sendPacedBody` wraps the privmsg/me/msg arms and, on a fatal error, surfaces **"sent N of M lines"** with the residue preserved (early-return so the end-of-submit clear + history-push never wipe it). History still records the full original body as one recall entry.
- **Two bounds:** auto-pace **only multi-line** pastes (a single throttled send surfaces immediately — #342's throttle-copy affordance untouched); a per-line retry **cap** guards against a door refusing past its own hint (no hung composer).
- `/msg` residue is keyed on the **query window** it focuses (residue + error banner co-located; a resend reaches the peer, not the source channel).

### Server (`messages_controller.ex`, `fallback_controller.ex`)
- `take_send_token/2` tags a refusal `{:error, {:rate_limited, secs}}`; a new `FallbackController` clause emits a `retry-after` header (same tuple shape as `{:network_circuit_open, retry_after}`).
- **Value is the send throttle's OWN refill interval** (`max(1, ceil(1.0 / refill_per_sec))` = 2s at 0.5/s), **not** `RequestBudget.retry_after_ms/0` — that reads the coarse #630 budget's far faster refill (20/s → 50ms) and would pace the client against the wrong bucket, re-429ing every line. The bare `:rate_limited` atom stays reserved for the #75 themes daily quota (no header — a calendar-day reset).
- **Additive-only:** wire body stays `error: "rate_limited"`, cic already parses the `retry-after` header (`api.ts readError`). No new wire token, **no `protocol_version` bump**.

## UX-fork decision taken
`vuole ENTRAMBE` — auto-pace on the bucket refill AND draft = only-the-residue, at every instant. No manual-resume model.

## Out of scope (vjt-declared)
- **#480** (send throttle mirroring the upstream oper allowance — that's *how much*; this is *not losing data when exceeded*).
- The coarse `request_budget` **sever ladder** (a paste trips 1-2 over-budget events, nowhere near `sever_after: 20`).

## Tests
- **cic vitest** (`compose.test.ts`): multi-line fan-out + full-body history; fatal mid-paste → residue-only draft + resume sends only the remainder (no dup); a 429 auto-paces honouring retry-after (fake timers), no drop/no wire-dup; a persistently-throttled paste stops after the cap (no infinite loop) keeping the residue.
- **cic e2e** (`issue666-paste-resume.spec.ts`): the dev send throttle is off, so the throttle is simulated at the network edge (one line 429'd once with a real `retry-after`, admitted on retry); asserts the composer holds only the residue, all lines arrive, the refused line is delivered exactly once, and the composer drains to empty.
- **server** (`messages_controller_outbound_test.exs`): the throttled POST 429 carries a `retry-after` header equal to the send-throttle-derived value (from config, not a magic number).

Local gates (cic, FREE): biome clean · `tsc --noEmit` 0 · vitest **3822/3822** · build ✓. Elixir gates run on CI (no local compile lane this session). Code-reviewed via `10x-engineer:code-reviewer` (verdict: correct, no Critical/Important; two Low findings addressed — /msg residue window + retry-after clamp).