### PR TITLE
feat(#665): one-click AWS launch — CloudFormation over a shared, provider-agnostic first-boot.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,15 @@ jobs:
           dash -n infra/docker/assert-abi-lockstep.sh
           dash -n infra/docker/release-entrypoint.sh
           dash -n infra/docker/get.sh
+          # #665 cloud bootstrap + drift-guard (bash, not the POSIX-sh lib).
+          shellcheck -x infra/cloud/first-boot.sh infra/cloud/check-drift.sh
+
+      - name: Cloud provider-door drift-guard (#665)
+        # Prove every provider door (infra/aws today, infra/terraform later)
+        # references the shared infra/cloud/first-boot.sh AND exposes the same
+        # knob names from infra/cloud/params.contract. A hand-written second
+        # door that drifts from the contract fails here instead of silently.
+        run: infra/cloud/check-drift.sh
 
       - name: Upload coverage
         uses: codecov/codecov-action@v7

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,6 +16,73 @@ to run grappa yourself.
 > now serves the SPA and emits the CSP itself. Jump to
 > [Upgrading from the two-container topology](#upgrading-from-the-two-container-topology).
 
+## One-click on AWS (CloudFormation)
+
+Want grappa on its own cloud box over HTTPS, installing **nothing** locally?
+If you already have an AWS account, the CloudFormation template
+[`infra/aws/grappa-cloudformation.yaml`](infra/aws/grappa-cloudformation.yaml)
+stands up a single stock-Ubuntu EC2 instance that installs the latest release
+`.deb`, self-terminates TLS, and keeps a stable Elastic IP.
+
+**What you provide** (the five shared knobs + an SSH key pair):
+
+| Knob | Meaning |
+|------|---------|
+| **Domain** | public hostname (e.g. `irc.example.org`) |
+| **AdminEmail** | Let's Encrypt registration + web-push contact |
+| **InstanceType** | EC2 size — **amd64 only** (the `.deb` is amd64-only; no Graviton) |
+| **SshCidr** | CIDR allowed to SSH — required, lock it to your address (`x.x.x.x/32`) |
+| **DiskSizeGb** | root/data volume size |
+| **KeyName** | an existing EC2 key pair (AWS-specific, on top of the five) |
+
+**Version pin = latest.** There is no apt repo — first boot fetches the
+*latest* GitHub release asset (`grappa_<ver>_amd64.deb`). "Pinned version"
+therefore means *latest at launch time*.
+
+### Order matters — point DNS, then issue TLS
+
+1. **Launch the stack** (see the launch URL below). It resolves the Ubuntu
+   24.04 AMI via Canonical's SSM public parameter (so it works in every region
+   with no hardcoded AMI), creates a security group (443 + 80-for-ACME open, SSH
+   restricted to your CIDR), the instance, and an **Elastic IP**.
+2. **Read the Outputs.** `PublicIp` is the Elastic IP; `DnsRecord` is the exact
+   A record to create. **Point your domain's A record at that IP.**
+3. **Issue the cert.** TLS is *deferred* at first boot on purpose: the Elastic
+   IP is unknown until the stack finishes, so DNS cannot resolve yet, and
+   issuing blind would burn Let's Encrypt's failed-validation quota. Once DNS
+   resolves, SSH in and run:
+
+   ```sh
+   sudo grappa-tls
+   ```
+
+   (A boot oneshot also retries this best-effort, so a **reboot after you point
+   DNS** self-issues the cert without the manual step.)
+4. Open `https://<your-domain>/` and create your first user.
+
+### The launch URL
+
+The console "quick-create" URL wants a **`templateURL=` on S3** — it does *not*
+accept a raw `raw.githubusercontent.com` URL. Host the YAML in a public S3
+bucket and build:
+
+```
+https://<region>.console.aws.amazon.com/cloudformation/home?region=<region>#/stacks/create/review?templateURL=https://<bucket>.s3.<region>.amazonaws.com/grappa-cloudformation.yaml&stackName=grappa
+```
+
+Or, with no bucket, upload the file directly in the CloudFormation console
+(**Create stack → Upload a template file**).
+
+### Deleting
+
+Deleting the stack removes everything it created (instance, security group,
+Elastic IP). Nothing is retained.
+
+> The on-box bootstrap lives in [`infra/cloud/first-boot.sh`](infra/cloud/first-boot.sh),
+> shared verbatim with the future Terraform module (the CFN `UserData` curls it
+> at a git ref and execs it — it is never inlined). Operator runbook for the AWS
+> box: [`docs/OPERATIONS.md`](docs/OPERATIONS.md).
+
 ## Prerequisites
 
 - **Docker Engine** with the **Compose v2** plugin (`docker compose

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -26628,3 +26628,85 @@ acked item, keep the draft = the unsent residue, and pace on the refusing
 bucket's OWN advertised interval. When a 429 hint already flows on the wire
 (`retry-after` header, or a `retry_after_ms` JSON field), read it — don't
 back-to-back-refire and re-trip the throttle.
+## 2026-08-02 — #665: one-click AWS via a CloudFormation door over a SHARED, provider-agnostic `first-boot.sh`
+
+Ship a launch URL that stands up grappa on AWS over HTTPS for someone who has an
+AWS account and installs nothing locally. The perimeter was CLOSED at scoping
+(vjt, #it-opers 2026-08-02) and is NOT re-litigated here: **no** custom
+AMI/Packer (regional + per-arch rebuilds, marketplace paperwork buys nothing),
+**no** marketplace listing, **no** CDK/cdktf (a Node toolchain to save ~30 lines
+of resource graph), and **no** Terraform *first* (it needs a CLI + creds before
+anything happens — wrong first step for "easy to launch"). Terraform is a
+LATER door; the layout is built FOR it now so the second consumer is a wrapper,
+not a rewrite.
+
+**Shared ground, not shared graph.** The one thing both doors share is the
+after-boot logic: install the `.deb`, force the domain into the env file, stand
+up nginx, start the unit, terminate TLS. That lives in ONE script,
+`infra/cloud/first-boot.sh`, consumed VERBATIM — the CFN `UserData` curls it at
+a git ref and execs it, NEVER inlines it; a future Terraform `user_data` does
+the same. `infra/cloud/` holds the shared material (the script + a
+machine-readable `params.contract`); `infra/aws/` holds the CFN YAML that
+CONSUMES it. The resource graph is deliberately NOT shared — CFN YAML and
+Terraform HCL stay two hand-written files, because generating both from one
+source is exactly the CDK cost the perimeter rejected.
+
+**Five shared knobs, one name each (the contract):** `domain` (→ `PHX_HOST`),
+`admin_email` (→ ACME email + `VAPID_SUBJECT=mailto:`), `instance_type` (amd64 —
+the `.deb` is amd64-only, no arm64), `ssh_cidr` (SG ingress, REQUIRED, no
+default — an open SSH port is never a default), `disk_size_gb` (EBS). Keypair is
+an AWS-specific parameter ON TOP (no cross-cloud analogue). Only `domain` +
+`admin_email` reach `first-boot.sh` (env `GRAPPA_DOMAIN` / `GRAPPA_ADMIN_EMAIL`);
+the other three shape the resource graph.
+
+**Drift-guard, not a generator (`infra/cloud/check-drift.sh`, wired into CI).**
+Since the two doors are hand-written, a CHECK keeps them honest: every provider
+door must reference `first-boot.sh` and annotate the parameter implementing each
+knob with a `grappa-knob: <name>` marker. The guard greps for those markers, so
+it is agnostic to each tool's own naming (CFN `Domain`, Terraform `domain` both
+carry `grappa-knob: domain`). It runs against whatever doors exist and tolerates
+`infra/terraform/` being absent (an absent provider is not drift). It is proven
+to go RED on drift by `test/infra/cloud_drift_guard_test.bats`.
+
+**Pin = LATEST, stated out loud.** The `.deb`/`.rpm` exist ONLY as GitHub
+release assets — there is no apt/yum repo — so `first-boot.sh` fetches the
+LATEST release's `grappa_<ver>_amd64.deb` (grep of `.../releases/latest`, no
+`jq` on stock Ubuntu). "Pinned version" therefore means *latest at launch*; the
+template + script say so. Same posture as #503's `get.sh`. Ubuntu 24.04 AMI is
+resolved region-agnostically via Canonical's SSM public parameter
+(`AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>`), no per-region AMI copies.
+
+**Single-box TLS, DEFERRED until DNS resolves (the non-obvious part).** Unlike
+`infra/linux/` (a dumb HTTP proxy BEHIND an upstream TLS box), a cloud box is
+the whole world and terminates TLS itself. `first-boot.sh` installs nginx +
+certbot, writes an HTTP site that `include`s the FETCHED #485 proxy snippet
+(`infra/snippets/locations-api.conf` — the SSOT proxy surface, not re-typed),
+force-sets `PHX_HOST` + `VAPID_SUBJECT` (re-locking the env file 0640
+root:grappa, same discipline as `gen-secrets.sh`), starts grappa and waits on
+`/healthz`. It does NOT issue the cert at first boot: the Elastic IP — and thus
+DNS — is unknown until the stack Outputs show it, and issuing blind burns Let's
+Encrypt's 5-failed-validations-per-hour quota. Instead it installs
+`/usr/local/sbin/grappa-tls` (domain + email baked) and enables a
+`grappa-tls.service` boot oneshot (best-effort) so a **reboot after DNS
+self-issues**; the documented manual path is one `sudo grappa-tls` once the
+operator points the A record at the Elastic IP.
+
+**No Elixir change.** `config/runtime.exs` ALREADY hard-requires `PHX_HOST` in
+prod (raises when missing), so mapping domain→`PHX_HOST` is a pure shell set —
+this shipped shell-only, no `config/` or `lib/` touch, no COMPILE lane.
+
+**Launch-URL caveat.** The console quick-create `templateURL=` wants an S3
+https URL, not `raw.githubusercontent.com`; the YAML must be hosted in a public
+S3 bucket (or uploaded directly in the console). Documented in INSTALL.md, not
+faked with a working raw URL.
+
+**Testing.** bats mirrors #503's unit-D shape — `test/infra/cloud_first_boot_test.bats`
+(domain/email hard-required, latest-`.deb` install, enable+restart+health wait,
+`PHX_HOST`/`VAPID_SUBJECT` force-set + 0640 relock with the GNU-first
+`stat -c '%a' || stat -f '%Lp'` probe, nginx site + fetched snippet, grappa-tls
+helper + boot oneshot, TLS-deferred-vs-issued on DNS) and
+`test/infra/cloud_drift_guard_test.bats`. `shellcheck -x` on both scripts, wired
+into ci.yml next to the #503 deploy-script gate. cfn-lint is BEST-EFFORT (no AWS
+creds in CI). Acceptance — clean account → HTTPS, ≥2 regions, stack fully
+deletes — is a MANUAL vjt check, reported PENDING; the template + script were
+built and tested against their SHAPE, not a live AWS account.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -677,6 +677,58 @@ curl -fsSL https://raw.githubusercontent.com/vjt/grappa-irc/main/infra/docker/ge
 > `docker run` of the published image once a tag has cut before trusting these
 > one-liners in anger.
 
+### AWS one-click box (CloudFormation) — #665
+
+A checkout-less, install-nothing-locally path for someone with an AWS account:
+[`infra/aws/grappa-cloudformation.yaml`](../infra/aws/grappa-cloudformation.yaml)
+launches a single stock-Ubuntu EC2 box that installs the latest release `.deb`
+and terminates its OWN TLS. Operator-facing INSTALL flow (launch URL, the five
+knobs, delete) is in [`INSTALL.md`](../INSTALL.md#one-click-on-aws-cloudformation);
+this is the runbook.
+
+- **The shared bootstrap is `infra/cloud/first-boot.sh`.** The CFN `UserData`
+  curls it at a git ref (`main`) and execs it — it is NEVER inlined into the
+  template. The same script is the future Terraform `user_data`. The two doors
+  share ONLY this script + the knob names in `infra/cloud/params.contract`; the
+  resource graph (CFN YAML vs Terraform HCL) stays two hand-written files. CI
+  runs `infra/cloud/check-drift.sh` to prove both doors reference `first-boot.sh`
+  and expose the same knobs.
+- **AMI.** Resolved at stack-create time from Canonical's SSM public parameter
+  (`/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id`)
+  — region-agnostic, no hardcoded/per-region AMI ids. **amd64 only** (the `.deb`
+  is amd64-only; do not pick a Graviton instance type).
+- **Version pin = latest.** No apt repo exists — `first-boot.sh` fetches the
+  *latest* release's `grappa_<ver>_amd64.deb` (grep of
+  `api.github.com/repos/vjt/grappa-irc/releases/latest`, no `jq`). Same story as
+  the #503 `get.sh` path.
+- **TLS is single-box + DEFERRED.** Unlike `infra/linux/` (a dumb HTTP proxy
+  behind an upstream TLS box), this box terminates TLS itself: `first-boot.sh`
+  installs nginx + certbot, writes an HTTP site that `include`s the FETCHED #485
+  proxy snippet, then defers cert issuance because the Elastic IP — and thus DNS
+  — is unknown at first boot. Issuing blind would burn Let's Encrypt's
+  5-failed-validations-per-hour quota. It installs `/usr/local/sbin/grappa-tls`
+  (domain + email baked in) and enables a `grappa-tls.service` boot oneshot that
+  best-effort retries; issuance happens the moment DNS resolves — either the
+  operator runs `sudo grappa-tls`, or a reboot-after-DNS self-issues.
+- **DNS order.** Point the domain's A record at the stack's Elastic IP
+  (`PublicIp` / `DnsRecord` Outputs) BEFORE issuing TLS.
+- **Env + secrets.** The `.deb` postinstall creates `/etc/grappa/grappa.env`
+  (0640 root:grappa) and mints secrets via `gen-secrets.sh` (openssl-only);
+  `first-boot.sh` force-sets `PHX_HOST` (= Domain) + `VAPID_SUBJECT` (=
+  `mailto:AdminEmail`) and re-locks 0640. Back up `GRAPPA_ENCRYPTION_KEY`.
+- **Ongoing ops.** It is a native systemd host — `journalctl -u grappa -f`,
+  `systemctl restart grappa`, `sudo grappa migrate`, `sudo grappa gen-secrets`
+  all work exactly as the packaged native-Linux path. certbot installs its own
+  renewal timer.
+- **Delete.** The stack is fully deletable (instance + SG + Elastic IP, all
+  `DeleteOnTermination`/no-retain).
+
+> **Acceptance is a MANUAL check (vjt).** cfn-lint ran best-effort only (no AWS
+> creds in CI); a real launch from a clean account → HTTPS reachable, ≥2 regions,
+> stack fully deletes has NOT been run yet. The template + `first-boot.sh` were
+> built and bats-tested against their SHAPE (stubbed apt/systemctl/nginx/certbot),
+> not against a live AWS account.
+
 ### Running operator actions against the live jail (prod)
 
 Prod is a **bastille jail** (name `grappa`, `/usr/local/bastille/jails/grappa/root`,

--- a/infra/aws/grappa-cloudformation.yaml
+++ b/infra/aws/grappa-cloudformation.yaml
@@ -1,0 +1,180 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >-
+  grappa — one-click IRC bouncer on a single stock-Ubuntu EC2 box (#665).
+  Resolves the Ubuntu 24.04 AMI via the Canonical SSM public parameter (so the
+  template is region-agnostic with no per-region AMI copies), then UserData
+  curls the shared infra/cloud/first-boot.sh at a git ref and execs it — the
+  ONE bootstrap also used by the future Terraform module. The box installs the
+  LATEST grappa_<ver>_amd64.deb release asset (there is no apt repo — "pinned
+  version" here means *latest at launch*), self-terminates TLS via nginx +
+  certbot, and keeps its address across stop/start via an Elastic IP.
+
+# Console "quick-create" parameter grouping (the pre-filled one-click UX).
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label: { default: "grappa (shared knobs — same names as the Terraform door)" }
+        Parameters: [Domain, AdminEmail, InstanceType, SshCidr, DiskSizeGb]
+      - Label: { default: "AWS specifics" }
+        Parameters: [KeyName, UbuntuAmi]
+    ParameterLabels:
+      Domain: { default: "Public hostname (you must point DNS at the Elastic IP)" }
+      AdminEmail: { default: "Admin email (Let's Encrypt + web-push contact)" }
+      InstanceType: { default: "EC2 instance type (amd64)" }
+      SshCidr: { default: "CIDR allowed to SSH (e.g. 203.0.113.4/32)" }
+      DiskSizeGb: { default: "Root volume size (GiB)" }
+      KeyName: { default: "EC2 key pair for SSH" }
+
+Parameters:
+  # grappa-knob: domain
+  # → first-boot.sh GRAPPA_DOMAIN → PHX_HOST, nginx server_name, TLS SAN.
+  Domain:
+    Type: String
+    Description: >-
+      Public hostname the bouncer is reached at (e.g. irc.example.org). You
+      MUST create an A record pointing this at the stack's Elastic IP — see the
+      Outputs. TLS issuance is deferred until that DNS resolves.
+    AllowedPattern: "^(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))+$"
+    ConstraintDescription: must be a fully-qualified domain name.
+
+  # grappa-knob: admin_email
+  # → first-boot.sh GRAPPA_ADMIN_EMAIL → ACME registration + VAPID_SUBJECT.
+  AdminEmail:
+    Type: String
+    Description: >-
+      Admin contact. Used as the Let's Encrypt registration email and as the
+      web-push VAPID subject (mailto:).
+    AllowedPattern: "^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$"
+    ConstraintDescription: must be a valid email address.
+
+  # grappa-knob: instance_type
+  InstanceType:
+    Type: String
+    Default: t3.small
+    Description: >-
+      EC2 instance type. amd64 only — the grappa .deb is amd64-only, so do NOT
+      pick a Graviton (arm64) type. t3.small is a sane small default.
+    AllowedValues:
+      - t3.small
+      - t3.medium
+      - t3.large
+      - m5.large
+      - c5.large
+
+  # grappa-knob: ssh_cidr
+  # REQUIRED, no default — an SSH port open to the world is never a default.
+  SshCidr:
+    Type: String
+    Description: >-
+      Source IPv4 CIDR permitted to reach SSH (port 22). Lock this to your own
+      address, e.g. 203.0.113.4/32. There is deliberately NO default.
+    AllowedPattern: "^([0-9]{1,3}\\.){3}[0-9]{1,3}/([0-9]|[12][0-9]|3[0-2])$"
+    ConstraintDescription: must be a valid IPv4 CIDR (e.g. 203.0.113.4/32).
+
+  # grappa-knob: disk_size_gb
+  DiskSizeGb:
+    Type: Number
+    Default: 20
+    MinValue: 8
+    MaxValue: 16384
+    Description: Root/data EBS volume size in GiB (sqlite scrollback + uploads live here).
+
+  # AWS-specific parameter ON TOP of the five shared knobs (no cross-cloud
+  # analogue, so it is not part of params.contract).
+  KeyName:
+    Type: AWS::EC2::KeyPair::KeyName
+    Description: Existing EC2 key pair for SSH access to the box.
+
+  # Region-agnostic Ubuntu 24.04 AMI via the Canonical SSM public parameter —
+  # resolved at stack-create time, so no hardcoded per-region AMI ids.
+  UbuntuAmi:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id
+    Description: Leave as-is — Canonical's SSM public parameter for the latest Ubuntu 24.04 LTS amd64 AMI.
+
+Resources:
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: grappa — HTTPS + HTTP(ACME) open; SSH restricted to the given CIDR.
+      SecurityGroupIngress:
+        - Description: HTTPS
+          IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+        - Description: HTTP (Let's Encrypt ACME challenge + the 80->443 redirect)
+          IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+        - Description: SSH (restricted to SshCidr)
+          IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: !Ref SshCidr
+      Tags:
+        - { Key: Name, Value: grappa }
+
+  Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref UbuntuAmi
+      InstanceType: !Ref InstanceType
+      KeyName: !Ref KeyName
+      SecurityGroupIds:
+        - !Ref SecurityGroup
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            VolumeSize: !Ref DiskSizeGb
+            VolumeType: gp3
+            DeleteOnTermination: true
+      Tags:
+        - { Key: Name, Value: grappa }
+      # UserData curls the SHARED bootstrap at a git ref and execs it — it is
+      # NOT inlined here, so the CFN door and the future Terraform door run the
+      # exact same first-boot.sh. Pin = LATEST: first-boot.sh fetches the
+      # latest release's grappa_<ver>_amd64.deb (there is no apt repo).
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          set -euo pipefail
+          export GRAPPA_DOMAIN='${Domain}'
+          export GRAPPA_ADMIN_EMAIL='${AdminEmail}'
+          curl -fsSL https://raw.githubusercontent.com/vjt/grappa-irc/main/infra/cloud/first-boot.sh -o /root/grappa-first-boot.sh
+          bash /root/grappa-first-boot.sh
+
+  # Elastic IP so the public address survives a stop/start. Kept separate +
+  # associated so the address the operator points DNS at is stable.
+  ElasticIp:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+      Tags:
+        - { Key: Name, Value: grappa }
+
+  ElasticIpAssociation:
+    Type: AWS::EC2::EIPAssociation
+    Properties:
+      AllocationId: !GetAtt ElasticIp.AllocationId
+      InstanceId: !Ref Instance
+
+Outputs:
+  PublicIp:
+    Description: The Elastic IP — point your domain's A record here.
+    Value: !Ref ElasticIp
+  DnsRecord:
+    Description: The DNS record to create BEFORE TLS can be issued.
+    Value: !Sub "${Domain}  A  ${ElasticIp}"
+  Url:
+    Description: Open this once DNS resolves and 'sudo grappa-tls' has run.
+    Value: !Sub "https://${Domain}"
+  NextSteps:
+    Description: Post-launch checklist.
+    Value: !Sub >-
+      1) Create A record ${Domain} -> ${ElasticIp}.
+      2) Wait for DNS to resolve, then SSH in and run: sudo grappa-tls
+      (first boot defers TLS so it never burns the Let's Encrypt failed-validation quota).
+      3) Open https://${Domain} and create your first user.

--- a/infra/cloud/check-drift.sh
+++ b/infra/cloud/check-drift.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# check-drift.sh — the CI drift-guard for the #665 shared-ground layout.
+#
+# The design deliberately does NOT generate the provider templates from one
+# source (that would be CDK/cdktf — a Node toolchain + synthesized artifacts
+# committed anyway, to save ~30 lines of resource graph). Instead the two
+# doors are hand-written and a CHECK keeps them honest: every provider wrapper
+# must (1) reference the shared bootstrap `first-boot.sh` and (2) expose the
+# SAME knob names from infra/cloud/params.contract, marked `grappa-knob: <name>`.
+#
+# This is a guard, NOT a generator: it never edits a template, it only fails
+# loud when the doors drift. It runs against whatever doors exist today
+# (infra/aws/) and starts covering infra/terraform/ the day that lands — an
+# absent provider directory is not drift, so it is tolerated silently.
+#
+# Exit 0 = every present door references first-boot.sh and exposes all knobs.
+# Exit 1 = drift (a door missing the reference or a knob marker).
+# Exit 2 = misuse / missing contract.
+#
+# Pure filesystem + grep, no network, no cloud CLI — so it lives under bats
+# (test/infra/cloud_drift_guard_test.bats), which proves it goes RED on drift.
+# bash, `set -euo pipefail`, shellcheck-clean.
+
+set -euo pipefail
+
+# Self-locate so CI can invoke it from any cwd. REPO_ROOT overridable for bats.
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="${GRAPPA_REPO_ROOT:-$(cd "$SELF_DIR/../.." && pwd)}"
+CONTRACT="${GRAPPA_PARAMS_CONTRACT:-$REPO_ROOT/infra/cloud/params.contract}"
+
+# The bootstrap filename every door must reference (curl-at-ref + exec).
+BOOTSTRAP_NAME='first-boot.sh'
+
+# The provider doors. A glob that matches nothing (e.g. infra/terraform absent)
+# contributes zero files — tolerated, not an error.
+AWS_GLOB="$REPO_ROOT/infra/aws/*.yaml"
+TF_GLOB="$REPO_ROOT/infra/terraform/*.tf"
+
+say() { printf '[check-drift] %s\n' "$*"; }
+fail() { printf '[check-drift] DRIFT: %s\n' "$*" >&2; drift=1; }
+
+[ -f "$CONTRACT" ] || {
+	printf '[check-drift] missing params contract: %s\n' "$CONTRACT" >&2
+	exit 2
+}
+
+# Parse the canonical knob names from the KNOBS block (between the BEGIN/END
+# markers), skipping blanks + comments.
+read_knobs() {
+	awk '
+		/^# BEGIN KNOBS$/ { inb = 1; next }
+		/^# END KNOBS$/   { inb = 0 }
+		inb && $0 !~ /^#/ && NF { print $1 }
+	' "$CONTRACT"
+}
+
+# Collect present door files across every provider glob (nullglob so an absent
+# directory yields nothing rather than the literal glob string).
+door_files() {
+	shopt -s nullglob
+	# shellcheck disable=SC2206  # word-splitting the glob into paths is intended
+	local doors=($AWS_GLOB $TF_GLOB)
+	shopt -u nullglob
+	# Guard the empty case: `printf '%s\n' "${empty[@]}"` emits one blank line,
+	# which mapfile would read as a phantom door.
+	[ "${#doors[@]}" -gt 0 ] && printf '%s\n' "${doors[@]}"
+}
+
+mapfile -t KNOBS < <(read_knobs)
+[ "${#KNOBS[@]}" -gt 0 ] || {
+	printf '[check-drift] no knobs parsed from %s (empty KNOBS block?)\n' "$CONTRACT" >&2
+	exit 2
+}
+
+mapfile -t DOORS < <(door_files)
+if [ "${#DOORS[@]}" -eq 0 ]; then
+	# No provider template exists yet — nothing to guard, not a failure.
+	say "no provider doors found (infra/aws, infra/terraform) — nothing to check"
+	exit 0
+fi
+
+drift=0
+for door in "${DOORS[@]}"; do
+	say "checking $door"
+
+	# (1) references the shared bootstrap.
+	grep -q "$BOOTSTRAP_NAME" "$door" \
+		|| fail "$door does not reference $BOOTSTRAP_NAME (must curl+exec the shared bootstrap, not inline it)"
+
+	# (2) exposes every knob via its grappa-knob marker.
+	for knob in "${KNOBS[@]}"; do
+		grep -qE "grappa-knob:[[:space:]]*${knob}([[:space:]]|$)" "$door" \
+			|| fail "$door is missing knob marker 'grappa-knob: ${knob}'"
+	done
+done
+
+if [ "$drift" -ne 0 ]; then
+	printf '[check-drift] FAILED — the provider doors drifted from the shared contract.\n' >&2
+	exit 1
+fi
+
+say "OK — all ${#DOORS[@]} door(s) reference $BOOTSTRAP_NAME and expose all ${#KNOBS[@]} knobs"
+exit 0

--- a/infra/cloud/first-boot.sh
+++ b/infra/cloud/first-boot.sh
@@ -36,8 +36,10 @@
 # story as infra/docker/get.sh. amd64 only (the .deb is amd64-only).
 #
 # Idempotent: re-running re-applies the same config (apt install of the same
-# deb is a no-op, the env force-set writes the same values, the nginx site is
-# overwritten identically). bash, `set -euo pipefail`, shellcheck -x clean.
+# deb is a no-op, the env force-set writes the same values). The nginx site is
+# rewritten only until certbot has taken it over — once it is certbot-managed a
+# re-run leaves the TLS vhost intact (see write_nginx_site). bash,
+# `set -euo pipefail`, shellcheck -x clean.
 # Ubuntu always ships bash, so this is bash (not the strict-POSIX sh of the
 # shared deploy lib) for readable string handling.
 #
@@ -73,6 +75,14 @@ die() { printf '\033[1;31mxx\033[0m  %s\n' "$*" >&2; exit 1; }
 require_env() {
 	[ -n "$GRAPPA_DOMAIN" ] || die "GRAPPA_DOMAIN is required (the public hostname → PHX_HOST). Refusing to boot a grappa with no host — it would mint dead links and reject every WebSocket."
 	[ -n "$GRAPPA_ADMIN_EMAIL" ] || die "GRAPPA_ADMIN_EMAIL is required (ACME registration + VAPID_SUBJECT)."
+	# Validate format in the SHARED script, not only in a provider's param
+	# constraints — both doors consume this verbatim, and the values are
+	# interpolated into an nginx server_name and the baked grappa-tls heredoc,
+	# so a value carrying a quote/space/'$'/backtick must be rejected HERE.
+	[[ "$GRAPPA_DOMAIN" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+$ ]] \
+		|| die "GRAPPA_DOMAIN ('$GRAPPA_DOMAIN') is not a valid fully-qualified domain name."
+	[[ "$GRAPPA_ADMIN_EMAIL" =~ ^[^@[:space:]\'\"\$\`]+@[^@[:space:]\'\"\$\`]+\.[^@[:space:]\'\"\$\`]+$ ]] \
+		|| die "GRAPPA_ADMIN_EMAIL ('$GRAPPA_ADMIN_EMAIL') is not a valid email address."
 }
 
 require_root() {
@@ -90,12 +100,17 @@ fetch() {
 
 # ── Package install (.deb = LATEST release asset) ───────────────────────────
 # The latest release's amd64 .deb download URL, grep+sed (no jq on stock
-# Ubuntu). Empty stdout ⇒ no matching asset (caller dies).
+# Ubuntu). Empty stdout ⇒ no matching asset (caller dies). curl is consumed
+# fully into a var FIRST (not piped) so no early-terminating stage can SIGPIPE
+# the download under `set -o pipefail`; `sed -n '1p'` reads all input, so it
+# picks the first match without closing the pipe early either.
 latest_deb_url() {
-	curl -fsSL "$GITHUB_API" \
+	local json
+	json="$(curl -fsSL "$GITHUB_API")" || return 1
+	printf '%s\n' "$json" \
 		| grep -o '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]*_amd64\.deb"' \
-		| head -1 \
-		| sed 's/.*"\(https[^"]*_amd64\.deb\)".*/\1/'
+		| sed 's/.*"\(https[^"]*_amd64\.deb\)".*/\1/' \
+		| sed -n '1p'
 }
 
 install_grappa_deb() {
@@ -153,13 +168,26 @@ configure_env() {
 # ── nginx: single-box HTTP front (certbot upgrades it to HTTPS) ──────────────
 # The proxy surface is the #485 SSOT snippet, FETCHED at the same git ref this
 # script came from (the .deb does not ship it). certbot --nginx later injects
-# the 443 server + the 80→443 redirect into this same site file.
+# the 443 server + the 80→443 redirect INTO this same site file (marking its
+# edits `# managed by Certbot`). So a re-run must NOT blindly overwrite the site
+# once certbot owns it — that would strip TLS until maybe_issue_cert re-runs.
+# The included snippet is always safe to refresh (certbot never touches it).
 write_nginx_site() {
-	say "Writing nginx site for $GRAPPA_DOMAIN"
+	local site="$NGINX_SITES_AVAILABLE/grappa"
 	mkdir -p "$NGINX_SNIPPETS" "$NGINX_SITES_AVAILABLE" "$NGINX_SITES_ENABLED"
 	fetch "$GRAPPA_RAW_BASE/infra/snippets/locations-api.conf" "$NGINX_SNIPPETS/grappa-locations-api.conf"
 
-	cat >"$NGINX_SITES_AVAILABLE/grappa" <<EOF
+	# Idempotency vs certbot: once the site is certbot-managed, leave its TLS
+	# vhost intact rather than reverting to HTTP-only.
+	if grep -q "managed by Certbot" "$site" 2>/dev/null; then
+		say "nginx site is certbot-managed — leaving the TLS vhost intact (refreshed snippet only)"
+		nginx -t
+		systemctl reload nginx 2>/dev/null || systemctl restart nginx
+		return 0
+	fi
+
+	say "Writing nginx site for $GRAPPA_DOMAIN"
+	cat >"$site" <<EOF
 # grappa — single-box TLS-terminating front (#665). Written by first-boot.sh.
 # certbot --nginx adds the listen 443 ssl server + the 80→443 redirect here.
 upstream grappa_upstream {
@@ -177,7 +205,7 @@ server {
 }
 EOF
 
-	ln -sf "$NGINX_SITES_AVAILABLE/grappa" "$NGINX_SITES_ENABLED/grappa"
+	ln -sf "$site" "$NGINX_SITES_ENABLED/grappa"
 	# Drop the stock default so our server_name wins the ACME challenge.
 	rm -f "$NGINX_SITES_ENABLED/default"
 

--- a/infra/cloud/first-boot.sh
+++ b/infra/cloud/first-boot.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+# first-boot.sh — the ONE provider-agnostic bootstrap for a cloud grappa box
+# (#665). Everything that happens on the machine AFTER it boots — install the
+# release .deb, force the operator's domain into the env file, stand up nginx,
+# start the unit, and terminate TLS itself — lives HERE, consumed VERBATIM by:
+#
+#   - infra/aws/grappa-cloudformation.yaml  (today — CFN UserData curls this
+#     script at a git ref and execs it; it is NOT inlined into the template)
+#   - infra/terraform/*.tf                  (later — the same curl-at-ref+exec
+#     from a Terraform `user_data`)
+#
+# So the "second cloud" costs a wrapper, not a rewrite. The two doors share
+# THIS script + the parameter names in infra/cloud/params.contract, and
+# nothing else; the resource graph (CFN YAML vs Terraform HCL) stays two
+# hand-written files. The CI drift-guard (infra/cloud/check-drift.sh) proves
+# both doors reference this script and expose the same knob names.
+#
+# UNLIKE infra/linux/ (which sits BEHIND an upstream TLS box and runs a dumb
+# HTTP reverse proxy), a cloud box is the whole world: it terminates TLS
+# itself via nginx + certbot. See the TLS section below for why issuance is
+# DEFERRED until DNS resolves.
+#
+# ── The knobs this script consumes (env, REQUIRED, no defaults) ─────────────
+#   GRAPPA_DOMAIN       public hostname → PHX_HOST + nginx server_name + the
+#                       Let's Encrypt cert SAN.
+#   GRAPPA_ADMIN_EMAIL  admin contact → the ACME registration email AND
+#                       VAPID_SUBJECT (mailto:), the two places grappa needs a
+#                       human to reach.
+# The other three shared knobs (instance type, SSH CIDR, disk size) shape the
+# provider's resource graph, not this script — see params.contract.
+#
+# ── Version pin: LATEST, on purpose ─────────────────────────────────────────
+# The .deb exists ONLY as a GitHub release asset (there is no apt repo), so
+# first boot fetches the LATEST release's grappa_<ver>_amd64.deb. "Pinned
+# version" therefore means *latest at launch time* — there is no pin. Same
+# story as infra/docker/get.sh. amd64 only (the .deb is amd64-only).
+#
+# Idempotent: re-running re-applies the same config (apt install of the same
+# deb is a no-op, the env force-set writes the same values, the nginx site is
+# overwritten identically). bash, `set -euo pipefail`, shellcheck -x clean.
+# Ubuntu always ships bash, so this is bash (not the strict-POSIX sh of the
+# shared deploy lib) for readable string handling.
+#
+# The uppercase paths below are genuine config defaults (correct in
+# production); they exist as seams so test/infra/cloud_first_boot_test.bats can
+# sandbox the filesystem, mirroring gen-secrets.sh's GRAPPA_ENV_FILE and
+# get.sh's GRAPPA_HOME.
+
+set -euo pipefail
+
+# ── Required operator knobs ─────────────────────────────────────────────────
+GRAPPA_DOMAIN="${GRAPPA_DOMAIN:-}"
+GRAPPA_ADMIN_EMAIL="${GRAPPA_ADMIN_EMAIL:-}"
+
+# ── Config defaults (production-correct; overridable for tests) ──────────────
+GRAPPA_RAW_BASE="${GRAPPA_RAW_BASE:-https://raw.githubusercontent.com/vjt/grappa-irc/main}"
+GITHUB_API="${GRAPPA_GITHUB_API:-https://api.github.com/repos/vjt/grappa-irc/releases/latest}"
+GRAPPA_ENV_FILE="${GRAPPA_ENV_FILE:-/etc/grappa/grappa.env}"
+GRAPPA_USER="${GRAPPA_USER:-grappa}"
+NGINX_SITES_AVAILABLE="${GRAPPA_NGINX_SITES_AVAILABLE:-/etc/nginx/sites-available}"
+NGINX_SITES_ENABLED="${GRAPPA_NGINX_SITES_ENABLED:-/etc/nginx/sites-enabled}"
+NGINX_SNIPPETS="${GRAPPA_NGINX_SNIPPETS:-/etc/nginx/snippets}"
+TLS_HELPER="${GRAPPA_TLS_HELPER:-/usr/local/sbin/grappa-tls}"
+TLS_UNIT="${GRAPPA_TLS_UNIT:-/etc/systemd/system/grappa-tls.service}"
+HEALTH_URL="${GRAPPA_HEALTH_URL:-http://127.0.0.1:4000/healthz}"
+HEALTH_RETRIES="${GRAPPA_HEALTH_RETRIES:-60}"
+HEALTH_SLEEP="${GRAPPA_HEALTH_SLEEP:-2}"
+
+say() { printf '\033[1;32m==>\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31mxx\033[0m  %s\n' "$*" >&2; exit 1; }
+
+# ── Preconditions ───────────────────────────────────────────────────────────
+require_env() {
+	[ -n "$GRAPPA_DOMAIN" ] || die "GRAPPA_DOMAIN is required (the public hostname → PHX_HOST). Refusing to boot a grappa with no host — it would mint dead links and reject every WebSocket."
+	[ -n "$GRAPPA_ADMIN_EMAIL" ] || die "GRAPPA_ADMIN_EMAIL is required (ACME registration + VAPID_SUBJECT)."
+}
+
+require_root() {
+	[ "${GRAPPA_SKIP_PRIVCHECK:-}" = 1 ] && return 0
+	[ "$(id -u)" -eq 0 ] || die "first-boot.sh must run as root (apt, systemctl, /etc/grappa all need it)."
+}
+
+# fetch URL DEST — download to a temp then move into place, so a failed
+# download never leaves a half-written file behind (mirrors get.sh).
+fetch() {
+	say "Fetching $1"
+	curl -fsSL "$1" -o "$2.tmp" || die "download failed: $1"
+	mv "$2.tmp" "$2"
+}
+
+# ── Package install (.deb = LATEST release asset) ───────────────────────────
+# The latest release's amd64 .deb download URL, grep+sed (no jq on stock
+# Ubuntu). Empty stdout ⇒ no matching asset (caller dies).
+latest_deb_url() {
+	curl -fsSL "$GITHUB_API" \
+		| grep -o '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]*_amd64\.deb"' \
+		| head -1 \
+		| sed 's/.*"\(https[^"]*_amd64\.deb\)".*/\1/'
+}
+
+install_grappa_deb() {
+	export DEBIAN_FRONTEND=noninteractive
+	say "apt-get update + TLS/proxy prerequisites"
+	apt-get update -q
+	# nginx + certbot are only Recommends of the .deb (the bouncer self-serves
+	# without them); on a single TLS-terminating box we need them, so install
+	# explicitly. ca-certificates + curl are pulled by the .deb Depends too,
+	# but a minbase cloud image may lack curl before the .deb lands.
+	apt-get install -y -q nginx certbot python3-certbot-nginx ca-certificates curl
+
+	deb_url="$(latest_deb_url)"
+	[ -n "$deb_url" ] || die "no grappa_*_amd64.deb asset in the latest release ($GITHUB_API)"
+	say "Latest .deb: $deb_url"
+
+	tmp_dir="$(mktemp -d)"
+	tmp_deb="$tmp_dir/grappa.deb"
+	fetch "$deb_url" "$tmp_deb"
+	# apt (not dpkg -i) so the .deb's Depends resolve from the Ubuntu archive.
+	# A path with a slash is treated as a local file, not a package name.
+	apt-get install -y -q "$tmp_deb"
+	rm -rf "$tmp_dir"
+}
+
+# ── Env file: force the operator's domain + contact in ──────────────────────
+# The .deb postinstall created $GRAPPA_ENV_FILE from the template (PHX_HOST left
+# REPLACE_ME) and filled the secrets via gen-secrets.sh. We force-set the two
+# operator knobs, then RE-LOCK: a tmp+mv rewrite is born 0644 root:root under
+# root's umask, which would drop the 0640 root:grappa lock and leak secrets
+# (same discipline as gen-secrets.sh).
+relock_env() {
+	chown "root:${GRAPPA_USER}" "$GRAPPA_ENV_FILE" 2>/dev/null \
+		|| chown root:root "$GRAPPA_ENV_FILE" 2>/dev/null || true
+	chmod 0640 "$GRAPPA_ENV_FILE"
+}
+
+force_set_env() {
+	local key="$1" val="$2" tmp
+	tmp="$(mktemp)"
+	grep -vE "^${key}=" "$GRAPPA_ENV_FILE" >"$tmp" || true
+	printf '%s=%s\n' "$key" "$val" >>"$tmp"
+	cat "$tmp" >"$GRAPPA_ENV_FILE"
+	rm -f "$tmp"
+	relock_env
+}
+
+configure_env() {
+	[ -f "$GRAPPA_ENV_FILE" ] || die "$GRAPPA_ENV_FILE missing — the .deb postinstall should have created it. Aborting rather than booting a half-installed box."
+	say "Setting PHX_HOST=$GRAPPA_DOMAIN + VAPID_SUBJECT in $GRAPPA_ENV_FILE"
+	force_set_env PHX_HOST "$GRAPPA_DOMAIN"
+	force_set_env VAPID_SUBJECT "mailto:${GRAPPA_ADMIN_EMAIL}"
+}
+
+# ── nginx: single-box HTTP front (certbot upgrades it to HTTPS) ──────────────
+# The proxy surface is the #485 SSOT snippet, FETCHED at the same git ref this
+# script came from (the .deb does not ship it). certbot --nginx later injects
+# the 443 server + the 80→443 redirect into this same site file.
+write_nginx_site() {
+	say "Writing nginx site for $GRAPPA_DOMAIN"
+	mkdir -p "$NGINX_SNIPPETS" "$NGINX_SITES_AVAILABLE" "$NGINX_SITES_ENABLED"
+	fetch "$GRAPPA_RAW_BASE/infra/snippets/locations-api.conf" "$NGINX_SNIPPETS/grappa-locations-api.conf"
+
+	cat >"$NGINX_SITES_AVAILABLE/grappa" <<EOF
+# grappa — single-box TLS-terminating front (#665). Written by first-boot.sh.
+# certbot --nginx adds the listen 443 ssl server + the 80→443 redirect here.
+upstream grappa_upstream {
+    server 127.0.0.1:4000;
+    keepalive 32;
+}
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name ${GRAPPA_DOMAIN};
+
+    # #485 SSOT dumb-proxy surface (fetched, not copied). The BEAM self-serves
+    # the SPA + owns every header; nginx just forwards.
+    include snippets/grappa-locations-api.conf;
+}
+EOF
+
+	ln -sf "$NGINX_SITES_AVAILABLE/grappa" "$NGINX_SITES_ENABLED/grappa"
+	# Drop the stock default so our server_name wins the ACME challenge.
+	rm -f "$NGINX_SITES_ENABLED/default"
+
+	nginx -t
+	systemctl reload nginx 2>/dev/null || systemctl restart nginx
+}
+
+# ── Start grappa + wait for health ──────────────────────────────────────────
+wait_health() {
+	local i=0
+	while [ "$i" -lt "$HEALTH_RETRIES" ]; do
+		if curl -fsS "$HEALTH_URL" >/dev/null 2>&1; then
+			say "grappa is healthy ($HEALTH_URL)"
+			return 0
+		fi
+		i=$((i + 1))
+		sleep "$HEALTH_SLEEP"
+	done
+	die "grappa did not become healthy at $HEALTH_URL after $HEALTH_RETRIES tries"
+}
+
+start_grappa() {
+	say "Starting grappa"
+	systemctl daemon-reload 2>/dev/null || true
+	systemctl enable grappa.service 2>/dev/null || true
+	systemctl restart grappa.service
+	wait_health
+}
+
+# ── TLS: helper + boot oneshot + conditional first issue ────────────────────
+# The Elastic IP is not known until the stack's Outputs show it, so DNS cannot
+# resolve at first boot. Issuing certbot blind would burn Let's Encrypt's
+# 5-failed-validations-per-hour quota, so we DEFER: install grappa-tls (domain
+# + email baked in), enable a boot oneshot that runs it best-effort (so a
+# reboot AFTER the operator points DNS self-issues), and issue NOW only if DNS
+# already resolves.
+install_tls_helper() {
+	say "Installing $TLS_HELPER"
+	mkdir -p "$(dirname "$TLS_HELPER")"
+	cat >"$TLS_HELPER" <<EOF
+#!/usr/bin/env bash
+# grappa-tls — issue/renew this box's Let's Encrypt cert. Baked at first boot
+# (#665) with the stack's domain + admin email. Idempotent: certbot skips
+# re-issue inside the renewal window, and installs its own renew timer.
+set -euo pipefail
+DOMAIN='${GRAPPA_DOMAIN}'
+EMAIL='${GRAPPA_ADMIN_EMAIL}'
+if ! getent hosts "\$DOMAIN" >/dev/null 2>&1; then
+	echo "grappa-tls: DNS for \$DOMAIN does not resolve yet." >&2
+	echo "            Point an A record at this box's Elastic IP, then re-run: sudo grappa-tls" >&2
+	exit 1
+fi
+exec certbot --nginx -d "\$DOMAIN" --non-interactive --agree-tos -m "\$EMAIL" --redirect
+EOF
+	chmod 0755 "$TLS_HELPER"
+}
+
+install_tls_unit() {
+	say "Installing $TLS_UNIT (self-issue on reboot-after-DNS)"
+	mkdir -p "$(dirname "$TLS_UNIT")"
+	cat >"$TLS_UNIT" <<EOF
+[Unit]
+Description=grappa: issue Let's Encrypt cert once DNS resolves (#665)
+After=network-online.target nginx.service grappa.service
+Wants=network-online.target
+[Service]
+Type=oneshot
+# Best-effort: pre-DNS this exits non-zero and boot continues; the first boot
+# AFTER the operator points DNS at the Elastic IP self-issues the cert.
+ExecStart=${TLS_HELPER}
+[Install]
+WantedBy=multi-user.target
+EOF
+	systemctl daemon-reload 2>/dev/null || true
+	systemctl enable grappa-tls.service 2>/dev/null || true
+}
+
+maybe_issue_cert() {
+	if getent hosts "$GRAPPA_DOMAIN" >/dev/null 2>&1; then
+		say "DNS for $GRAPPA_DOMAIN resolves — issuing the TLS cert now"
+		"$TLS_HELPER" || say "grappa-tls failed (see above) — re-run 'sudo grappa-tls' once DNS settles"
+	else
+		say "DNS for $GRAPPA_DOMAIN does not resolve yet — TLS DEFERRED (not burning LE quota)."
+		say "Point an A record at this box's Elastic IP, then run: sudo grappa-tls"
+	fi
+}
+
+final_notice() {
+	cat <<EOF
+
+grappa first-boot complete.
+
+  Domain : $GRAPPA_DOMAIN
+  Health : $HEALTH_URL
+  Logs   : journalctl -u grappa -f
+
+  If TLS was deferred: create an A record ($GRAPPA_DOMAIN → this box's
+  Elastic IP, shown in the stack Outputs), then run:  sudo grappa-tls
+
+  Back up $GRAPPA_ENV_FILE's GRAPPA_ENCRYPTION_KEY — it encrypts stored IRC
+  credentials at rest; lose it and they are unrecoverable.
+EOF
+}
+
+main() {
+	require_env
+	require_root
+	install_grappa_deb
+	configure_env
+	write_nginx_site
+	start_grappa
+	install_tls_helper
+	install_tls_unit
+	maybe_issue_cert
+	final_notice
+}
+
+main "$@"

--- a/infra/cloud/params.contract
+++ b/infra/cloud/params.contract
@@ -1,0 +1,38 @@
+# grappa cloud parameter contract (#665) — the shared knob names.
+#
+# One canonical knob per line inside the KNOBS block below. This is the
+# provider-agnostic contract: whichever door an operator comes through (the
+# CloudFormation template today, a Terraform module later), the SAME answers
+# must produce the SAME machine. Two things keep the doors honest, both
+# enforced by infra/cloud/check-drift.sh (wired into CI):
+#
+#   1. Every provider wrapper (infra/aws/*.yaml today, infra/terraform/*.tf
+#      later) MUST reference the shared bootstrap by name: `first-boot.sh`.
+#   2. Every wrapper MUST annotate the parameter that implements each knob
+#      with a machine-readable marker:  grappa-knob: <name>
+#      (a YAML comment in the CFN template, an HCL comment in Terraform). The
+#      guard greps for `grappa-knob: <name>` per door, so it is agnostic to
+#      each tool's own naming convention — CFN's `Domain` and Terraform's
+#      `domain` both satisfy the `domain` knob by carrying the same marker.
+#
+# What each knob means (the semantic contract, not tool syntax):
+#   domain         public hostname → PHX_HOST, nginx server_name, TLS SAN.
+#   admin_email    admin contact → ACME registration email + VAPID_SUBJECT.
+#   instance_type  compute size (amd64 — the .deb is amd64-only).
+#   ssh_cidr       source CIDR allowed to SSH (security-group ingress; REQUIRED,
+#                  no default — an open-to-the-world SSH port is never a default).
+#   disk_size_gb   root/data volume size in GiB.
+#
+# Only `domain` + `admin_email` flow into first-boot.sh (env GRAPPA_DOMAIN /
+# GRAPPA_ADMIN_EMAIL). The other three shape the provider's resource graph
+# (EC2 InstanceType, the SG ingress rule, the EBS volume) and never reach the
+# script. Keypair is an AWS-specific parameter ON TOP of these five, not part
+# of the shared contract (it has no Terraform/other-cloud analogue).
+#
+# BEGIN KNOBS
+domain
+admin_email
+instance_type
+ssh_cidr
+disk_size_gb
+# END KNOBS

--- a/test/infra/cloud_drift_guard_test.bats
+++ b/test/infra/cloud_drift_guard_test.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+#
+# Bats suite for infra/cloud/check-drift.sh — the #665 shared-ground guard.
+#
+# The guard proves both provider doors (infra/aws/*.yaml today, infra/terraform/
+# *.tf later) reference the shared first-boot.sh AND expose the same knob names
+# from infra/cloud/params.contract. These tests prove it goes GREEN on a
+# faithful door and RED the moment a door drifts (a knob marker or the bootstrap
+# reference goes missing) — the whole point of a guard is that it fails on drift.
+#
+# The REAL params.contract is copied into a sandbox REPO_ROOT (production knob
+# list, not a re-typed one), and synthetic door files are written to exercise
+# each drift shape.
+
+setup() {
+    REPO_SRC="$BATS_TEST_DIRNAME/../.."
+    GUARD="$REPO_SRC/infra/cloud/check-drift.sh"
+
+    export GRAPPA_REPO_ROOT="$BATS_TEST_TMPDIR/repo"
+    mkdir -p "$GRAPPA_REPO_ROOT/infra/cloud" "$GRAPPA_REPO_ROOT/infra/aws"
+    # Use the real contract so the knob set under test is production truth.
+    cp "$REPO_SRC/infra/cloud/params.contract" "$GRAPPA_REPO_ROOT/infra/cloud/params.contract"
+
+    AWS_DOOR="$GRAPPA_REPO_ROOT/infra/aws/grappa.yaml"
+}
+
+# A faithful door: references first-boot.sh + carries every knob marker.
+write_good_aws_door() {
+    cat > "$AWS_DOOR" <<'EOF'
+# grappa-knob: domain
+# grappa-knob: admin_email
+# grappa-knob: instance_type
+# grappa-knob: ssh_cidr
+# grappa-knob: disk_size_gb
+UserData: curl .../infra/cloud/first-boot.sh | bash
+EOF
+}
+
+@test "GREEN: a faithful AWS door passes" {
+    write_good_aws_door
+    run "$GUARD"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"expose all"* ]]
+}
+
+@test "RED: a missing knob marker fails with exit 1" {
+    write_good_aws_door
+    # Drop the ssh_cidr marker.
+    grep -v "grappa-knob: ssh_cidr" "$AWS_DOOR" > "$AWS_DOOR.tmp"
+    mv "$AWS_DOOR.tmp" "$AWS_DOOR"
+    run "$GUARD"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"grappa-knob: ssh_cidr"* ]]
+}
+
+@test "RED: a door that does not reference first-boot.sh fails with exit 1" {
+    write_good_aws_door
+    grep -v "first-boot.sh" "$AWS_DOOR" > "$AWS_DOOR.tmp"
+    mv "$AWS_DOOR.tmp" "$AWS_DOOR"
+    run "$GUARD"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"first-boot.sh"* ]]
+}
+
+@test "tolerant: absent infra/terraform is NOT drift" {
+    write_good_aws_door
+    # No infra/terraform/ dir exists in the sandbox.
+    run "$GUARD"
+    [ "$status" -eq 0 ]
+}
+
+@test "GREEN: a faithful Terraform door is also checked once present" {
+    write_good_aws_door
+    mkdir -p "$GRAPPA_REPO_ROOT/infra/terraform"
+    cat > "$GRAPPA_REPO_ROOT/infra/terraform/main.tf" <<'EOF'
+# grappa-knob: domain
+# grappa-knob: admin_email
+# grappa-knob: instance_type
+# grappa-knob: ssh_cidr
+# grappa-knob: disk_size_gb
+# user_data runs infra/cloud/first-boot.sh
+EOF
+    run "$GUARD"
+    [ "$status" -eq 0 ]
+}
+
+@test "RED: a Terraform door missing a knob fails once present" {
+    write_good_aws_door
+    mkdir -p "$GRAPPA_REPO_ROOT/infra/terraform"
+    cat > "$GRAPPA_REPO_ROOT/infra/terraform/main.tf" <<'EOF'
+# grappa-knob: domain
+# grappa-knob: admin_email
+# grappa-knob: instance_type
+# grappa-knob: ssh_cidr
+# user_data runs infra/cloud/first-boot.sh
+EOF
+    run "$GUARD"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"disk_size_gb"* ]]
+}
+
+@test "no doors at all is not a failure (exit 0)" {
+    # No infra/aws door written.
+    run "$GUARD"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no provider doors"* ]]
+}
+
+@test "missing contract fails with exit 2 (misuse)" {
+    write_good_aws_door
+    rm "$GRAPPA_REPO_ROOT/infra/cloud/params.contract"
+    run "$GUARD"
+    [ "$status" -eq 2 ]
+}
+
+@test "the REAL repo passes its own guard" {
+    unset GRAPPA_REPO_ROOT
+    run "$GUARD"
+    [ "$status" -eq 0 ]
+}

--- a/test/infra/cloud_first_boot_test.bats
+++ b/test/infra/cloud_first_boot_test.bats
@@ -231,3 +231,36 @@ mode_of() {  # GNU-first, BSD fallback (macOS runner) — matches the packaging 
     [ "$(grep -c "^PHX_HOST=" "$GRAPPA_ENV_FILE")" -eq 1 ]
     [ "$(grep -c "^VAPID_SUBJECT=" "$GRAPPA_ENV_FILE")" -eq 1 ]
 }
+
+@test "re-run does NOT strip certbot's TLS vhost from the nginx site" {
+    run "$FBSH"
+    [ "$status" -eq 0 ]
+    # Simulate certbot --nginx having taken the site over (it appends a 443
+    # server + marks its edits '# managed by Certbot').
+    cat >> "$GRAPPA_NGINX_SITES_AVAILABLE/grappa" <<'EOF'
+server {
+    listen 443 ssl; # managed by Certbot
+    server_name irc.example.org;
+    ssl_certificate /etc/letsencrypt/live/irc.example.org/fullchain.pem; # managed by Certbot
+}
+EOF
+    run "$FBSH"
+    [ "$status" -eq 0 ]
+    # The TLS vhost must survive the re-run.
+    grep -q "listen 443 ssl; # managed by Certbot" "$GRAPPA_NGINX_SITES_AVAILABLE/grappa"
+    [[ "$output" == *"certbot-managed"* ]]
+}
+
+# ───────────────────────────── input validation ──────────────────────────────
+
+@test "rejects a malformed domain (SSOT-side validation)" {
+    GRAPPA_DOMAIN="not a domain'; rm -rf /" run "$FBSH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not a valid fully-qualified domain name"* ]]
+}
+
+@test "rejects a malformed admin email" {
+    GRAPPA_ADMIN_EMAIL="nope" run "$FBSH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not a valid email address"* ]]
+}

--- a/test/infra/cloud_first_boot_test.bats
+++ b/test/infra/cloud_first_boot_test.bats
@@ -1,0 +1,233 @@
+#!/usr/bin/env bats
+#
+# Bats suite for infra/cloud/first-boot.sh — the #665 shared cloud bootstrap.
+#
+# Scope: the decision logic + the on-disk effects, NOT a live apt/systemd box.
+# Every external tool (apt-get, systemctl, nginx, certbot, curl, getent) is
+# stubbed on PATH and logs to $ARGV_LOG; all filesystem targets are redirected
+# into $BATS_TEST_TMPDIR via the script's config-default env seams. The `curl`
+# stub serves the LATEST-release JSON, the .deb download, the locations-api.conf
+# snippet, and /healthz — mirroring the get.sh suite. The apt-get stub, on a
+# local-.deb install, seeds the env file to mimic the .deb postinstall.
+#
+# Proves: domain/email hard-required, latest-.deb install path, enable+restart+
+# health wait, PHX_HOST/VAPID_SUBJECT force-set + 0640 relock, nginx site +
+# fetched snippet, grappa-tls helper + boot oneshot, and the LE-quota-safe
+# TLS-deferred-until-DNS behaviour.
+
+setup() {
+    REPO_SRC="$BATS_TEST_DIRNAME/../.."
+    FBSH="$REPO_SRC/infra/cloud/first-boot.sh"
+
+    # ── Filesystem sandbox (the script's config-default seams) ──────────────
+    export GRAPPA_ENV_FILE="$BATS_TEST_TMPDIR/etc/grappa/grappa.env"
+    export GRAPPA_NGINX_SITES_AVAILABLE="$BATS_TEST_TMPDIR/nginx/sites-available"
+    export GRAPPA_NGINX_SITES_ENABLED="$BATS_TEST_TMPDIR/nginx/sites-enabled"
+    export GRAPPA_NGINX_SNIPPETS="$BATS_TEST_TMPDIR/nginx/snippets"
+    export GRAPPA_TLS_HELPER="$BATS_TEST_TMPDIR/sbin/grappa-tls"
+    export GRAPPA_TLS_UNIT="$BATS_TEST_TMPDIR/systemd/grappa-tls.service"
+
+    # ── Behaviour seams: never actually root, fast health loop ──────────────
+    export GRAPPA_SKIP_PRIVCHECK=1
+    export GRAPPA_HEALTH_RETRIES=3
+    export GRAPPA_HEALTH_SLEEP=0
+
+    # ── Operator knobs ──────────────────────────────────────────────────────
+    export GRAPPA_DOMAIN="irc.example.org"
+    export GRAPPA_ADMIN_EMAIL="ops@example.org"
+
+    # ── Stubs ────────────────────────────────────────────────────────────────
+    FAKE_DIR="$BATS_TEST_TMPDIR/fake"
+    mkdir -p "$FAKE_DIR"
+    ARGV_LOG="$FAKE_DIR/argv.log"
+    export ARGV_LOG
+    : > "$ARGV_LOG"
+
+    export ENV_EXAMPLE="$REPO_SRC/infra/packaging/grappa.env.example"
+    export SRC_LOCATIONS="$REPO_SRC/infra/snippets/locations-api.conf"
+
+    # curl: serves the latest-release JSON, the .deb, the snippet, and healthz.
+    cat > "$FAKE_DIR/curl" <<'EOF'
+#!/usr/bin/env bash
+printf 'curl %s\n' "$*" >> "$ARGV_LOG"
+url=''; dest=''
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) dest="$2"; shift 2 ;;
+    -*) shift ;;
+    *)  url="$1"; shift ;;
+  esac
+done
+case "$url" in
+  */releases/latest)
+    printf '{"tag_name":"v9.9.9","assets":[{"browser_download_url":"https://github.com/vjt/grappa-irc/releases/download/v9.9.9/grappa_9.9.9_amd64.deb"}]}\n' ;;
+  *_amd64.deb)
+    [ -n "$dest" ] && printf 'FAKE DEB\n' > "$dest" ;;
+  */infra/snippets/locations-api.conf)
+    [ -n "$dest" ] && cp "$SRC_LOCATIONS" "$dest" ;;
+  *healthz*)
+    exit 0 ;;
+  *) printf 'fake curl: unexpected url: %s\n' "$url" >&2; exit 1 ;;
+esac
+EOF
+    chmod +x "$FAKE_DIR/curl"
+
+    # apt-get: logs; on a local-.deb install, seed the env file (mimics the
+    # .deb postinstall creating /etc/grappa/grappa.env from the template).
+    cat > "$FAKE_DIR/apt-get" <<'EOF'
+#!/usr/bin/env bash
+printf 'apt-get %s\n' "$*" >> "$ARGV_LOG"
+case "$*" in
+  *install*.deb*)
+    if [ -z "${SKIP_ENV_SEED:-}" ]; then
+      mkdir -p "$(dirname "$GRAPPA_ENV_FILE")"
+      cp "$ENV_EXAMPLE" "$GRAPPA_ENV_FILE"
+    fi ;;
+esac
+exit 0
+EOF
+    chmod +x "$FAKE_DIR/apt-get"
+
+    for tool in systemctl nginx certbot; do
+        cat > "$FAKE_DIR/$tool" <<EOF
+#!/usr/bin/env bash
+printf '$tool %s\n' "\$*" >> "$ARGV_LOG"
+exit 0
+EOF
+        chmod +x "$FAKE_DIR/$tool"
+    done
+
+    # getent: DNS does NOT resolve by default (the deferred-TLS path). A test
+    # opts into "resolves now" with GETENT_RESOLVES=1.
+    cat > "$FAKE_DIR/getent" <<'EOF'
+#!/usr/bin/env bash
+printf 'getent %s\n' "$*" >> "$ARGV_LOG"
+[ -n "${GETENT_RESOLVES:-}" ] && exit 0
+exit 2
+EOF
+    chmod +x "$FAKE_DIR/getent"
+
+    export PATH="$FAKE_DIR:$PATH"
+}
+
+mode_of() {  # GNU-first, BSD fallback (macOS runner) — matches the packaging probe.
+    stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
+}
+
+# ───────────────────────────── required knobs ────────────────────────────────
+
+@test "hard-fails when GRAPPA_DOMAIN is unset" {
+    unset GRAPPA_DOMAIN
+    run "$FBSH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"GRAPPA_DOMAIN is required"* ]]
+}
+
+@test "hard-fails when GRAPPA_ADMIN_EMAIL is unset" {
+    unset GRAPPA_ADMIN_EMAIL
+    run "$FBSH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"GRAPPA_ADMIN_EMAIL is required"* ]]
+}
+
+# ───────────────────────────── install path ──────────────────────────────────
+
+@test "installs the LATEST release .deb via apt (no pin)" {
+    run "$FBSH"
+    [ "$status" -eq 0 ]
+    grep -q "curl .*/releases/latest" "$ARGV_LOG"
+    grep -q "curl .*grappa_9.9.9_amd64.deb" "$ARGV_LOG"
+    grep -qE "apt-get install .*grappa\.deb" "$ARGV_LOG"
+}
+
+@test "installs nginx + certbot for single-box TLS termination" {
+    run "$FBSH"
+    [ "$status" -eq 0 ]
+    grep -qE "apt-get install .*nginx.*certbot.*python3-certbot-nginx" "$ARGV_LOG"
+}
+
+@test "enables + restarts grappa, then waits on /healthz" {
+    run "$FBSH"
+    [ "$status" -eq 0 ]
+    grep -q "systemctl enable grappa.service" "$ARGV_LOG"
+    grep -q "systemctl restart grappa.service" "$ARGV_LOG"
+    grep -q "curl .*healthz" "$ARGV_LOG"
+}
+
+@test "fails loud if the env file is missing after install" {
+    SKIP_ENV_SEED=1 run "$FBSH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"missing"* ]]
+}
+
+# ───────────────────────────── env force-set ─────────────────────────────────
+
+@test "force-sets PHX_HOST and VAPID_SUBJECT from the knobs" {
+    run "$FBSH"
+    [ "$status" -eq 0 ]
+    grep -qx "PHX_HOST=irc.example.org" "$GRAPPA_ENV_FILE"
+    grep -qx "VAPID_SUBJECT=mailto:ops@example.org" "$GRAPPA_ENV_FILE"
+    # The template's REPLACE_ME host is gone.
+    ! grep -q "^PHX_HOST=REPLACE_ME$" "$GRAPPA_ENV_FILE"
+}
+
+@test "relocks the env file to 0640 after rewriting it" {
+    run "$FBSH"
+    [ "$status" -eq 0 ]
+    [ "$(mode_of "$GRAPPA_ENV_FILE")" = "640" ]
+}
+
+# ───────────────────────────── nginx site ────────────────────────────────────
+
+@test "writes the nginx site with server_name + the fetched proxy snippet" {
+    run "$FBSH"
+    [ "$status" -eq 0 ]
+    grep -q "server_name irc.example.org;" "$GRAPPA_NGINX_SITES_AVAILABLE/grappa"
+    grep -q "include snippets/grappa-locations-api.conf;" "$GRAPPA_NGINX_SITES_AVAILABLE/grappa"
+    # The #485 SSOT snippet was fetched, not re-typed.
+    grep -q "grappa_upstream" "$GRAPPA_NGINX_SNIPPETS/grappa-locations-api.conf"
+    grep -q "curl .*/infra/snippets/locations-api.conf" "$ARGV_LOG"
+}
+
+# ───────────────────────────── TLS helper + defer ────────────────────────────
+
+@test "installs the grappa-tls helper with domain + email baked in" {
+    run "$FBSH"
+    [ "$status" -eq 0 ]
+    [ -x "$GRAPPA_TLS_HELPER" ]
+    grep -q "DOMAIN='irc.example.org'" "$GRAPPA_TLS_HELPER"
+    grep -q "EMAIL='ops@example.org'" "$GRAPPA_TLS_HELPER"
+    grep -q "certbot --nginx" "$GRAPPA_TLS_HELPER"
+}
+
+@test "installs + enables the boot oneshot (self-issue on reboot-after-DNS)" {
+    run "$FBSH"
+    [ "$status" -eq 0 ]
+    grep -q "ExecStart=$GRAPPA_TLS_HELPER" "$GRAPPA_TLS_UNIT"
+    grep -q "systemctl enable grappa-tls.service" "$ARGV_LOG"
+}
+
+@test "DEFERS TLS when DNS does not resolve (does NOT burn LE quota)" {
+    run "$FBSH"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DEFERRED"* ]]
+    # certbot must NOT have been invoked at first boot.
+    ! grep -q "^certbot " "$ARGV_LOG"
+}
+
+@test "issues TLS immediately when DNS already resolves" {
+    GETENT_RESOLVES=1 run "$FBSH"
+    [ "$status" -eq 0 ]
+    grep -q "certbot --nginx -d irc.example.org" "$ARGV_LOG"
+}
+
+# ───────────────────────────── idempotency ───────────────────────────────────
+
+@test "idempotent: a second run re-applies cleanly with one PHX_HOST line" {
+    run "$FBSH"
+    [ "$status" -eq 0 ]
+    run "$FBSH"
+    [ "$status" -eq 0 ]
+    [ "$(grep -c "^PHX_HOST=" "$GRAPPA_ENV_FILE")" -eq 1 ]
+    [ "$(grep -c "^VAPID_SUBJECT=" "$GRAPPA_ENV_FILE")" -eq 1 ]
+}


### PR DESCRIPTION
Refs #665.

One-click grappa on AWS for someone who has an AWS account and installs nothing
locally: a CloudFormation template + a launch URL that opens the console
pre-filled and stands up a single stock-Ubuntu EC2 box on HTTPS.

## Perimeter (vjt-CLOSED at scoping — not re-litigated)
No AMI/Packer, no marketplace, no CDK/cdktf, no Terraform *now* (the layout is
built FOR it). Stock Ubuntu 24.04 via Canonical's SSM public parameter (region-
agnostic, no per-region AMI copies). Reuse the EXISTING release `.deb` — no new
build path, amd64-only.

## Design
- **ONE SSOT `infra/cloud/first-boot.sh`** consumed VERBATIM (the CFN `UserData`
  curls it at a git ref and execs it — never inlined) so the future Terraform
  door is a wrapper, not a rewrite. `infra/cloud/` = shared (script +
  `params.contract`); `infra/aws/` = the CFN YAML that consumes it. The resource
  graph stays two hand-written files (CFN YAML today, Terraform HCL later) — the
  CDK cost the perimeter rejected.
- **CI drift-guard, not a generator** (`infra/cloud/check-drift.sh`, wired into
  ci.yml): proves both doors reference `first-boot.sh` and expose the same five
  knobs (`domain`, `admin_email`, `instance_type`, `ssh_cidr`, `disk_size_gb`),
  each marked `grappa-knob: <name>`. Tolerates `infra/terraform/` being absent.
- **pin = LATEST**: the `.deb` exists only as a GitHub release asset (no apt
  repo), so first-boot fetches the latest `grappa_<ver>_amd64.deb`. "Pinned
  version" means *latest at launch* — stated in the template + script. Same
  posture as #503's `get.sh`.
- **Single-box TLS, DEFERRED until DNS resolves**: unlike `infra/linux/` (a dumb
  proxy behind an upstream TLS box), this box terminates TLS itself (nginx +
  certbot, `include`ing the FETCHED #485 proxy snippet). The Elastic IP — and
  thus DNS — is unknown at first boot, so issuing blind would burn Let's
  Encrypt's 5-failed-validations/hr quota. It bakes `/usr/local/sbin/grappa-tls`
  (domain+email) + a boot oneshot (so a reboot-after-DNS self-issues) and issues
  now only if DNS already resolves; otherwise the operator runs `sudo grappa-tls`
  after pointing the A record at the Elastic IP.
- **Shell-only**: `config/runtime.exs` ALREADY hard-requires `PHX_HOST`, so
  domain→PHX_HOST is a pure env set — no Elixir change, no COMPILE lane.
- **Launch-URL caveat**: the console quick-create `templateURL=` wants an S3
  https URL, not `raw.githubusercontent.com` — documented in INSTALL.md, not
  faked.

## Deliverables
1. `infra/cloud/first-boot.sh` — the SSOT bootstrap.
2. `infra/cloud/params.contract` — machine-readable knob contract.
3. `infra/aws/grappa-cloudformation.yaml` — the CFN template consuming (1).
4. `infra/cloud/check-drift.sh` + ci.yml wiring + `test/infra/cloud_drift_guard_test.bats`.
5. Docs: INSTALL.md (launch flow + point-DNS-first), docs/OPERATIONS.md (AWS-box
   runbook), DESIGN_NOTES (2026-08-02 entry).
TDD via `test/infra/cloud_first_boot_test.bats` (mirrors #503 unit-D).

## Code review
Synchronous `10x-engineer:code-reviewer`. Perimeter held; fail-loud + relock +
SG (443/80/SSH-CIDR only) + EIP + deletable + no-baked-secret all verified.
Fixed: F1 (Medium — a re-run stripped certbot's TLS vhost; now certbot-aware),
F2 (Low — SSOT-side domain/email validation, closes the unquoted-heredoc
injection vector), F4 (Low — pipefail-safe asset fetch). F3 (getent checks
"resolves", not "resolves to this box") left as a documented residual — an
EC2-metadata comparison would couple the provider-agnostic SSOT to AWS.

## Gates
- `shellcheck -x infra/cloud/first-boot.sh infra/cloud/check-drift.sh` → clean.
- bats `test/infra/cloud_first_boot_test.bats` + `test/infra/cloud_drift_guard_test.bats` → 26/26.
- Full bats set (test/bin + test/infra + test/scripts) → green (the interactive
  `iex_observer` suite hangs in the dev shell per docs/TESTING.md; green in CI).
- cfn-lint: BEST-EFFORT — not installed locally (no AWS creds), not run.

## Acceptance — PENDING (manual, vjt)
Clean AWS account → HTTPS reachable, ≥2 regions unchanged, stack fully deletes.
The template + first-boot.sh were built and bats-tested against their SHAPE
(stubbed apt/systemctl/nginx/certbot), NOT against a live AWS account.