### PR TITLE
fix(shottino): include <sys/time.h> for struct timeval in whip.c

### DIFF
--- a/frontends/shottino/call/whip.c
+++ b/frontends/shottino/call/whip.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <strings.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
 


### PR DESCRIPTION
One line. `main`'s `ci` has been red since `2709fe11` and this is the whole cause.

## What breaks

`dial()` declares a `struct timeval` for the connect timeout at `frontends/shottino/call/whip.c:295`,
but the translation unit never includes `<sys/time.h>` — where POSIX defines that type. Under the
Makefile's own flags (`-D_POSIX_C_SOURCE=200809L -std=c11`) the strict feature-test macro keeps the
other `<sys/*>` headers from leaking the definition in, so the type stays incomplete:

```
call/whip.c:295:16: error: variable 'tv' has initializer but incomplete type
call/whip.c:295:32: error: 'struct timeval' has no member named 'tv_sec'
call/whip.c:296:32: error: 'struct timeval' has no member named 'tv_usec'
call/whip.c:295:24: error: storage size of 'tv' isn't known
make: *** [Makefile:97: tests/test_whip] Error 1
```

## Why it passed locally and not in CI

On a glibc where some other header still pulls `<sys/time.h>` in transitively, the omission is
invisible. That path is not guaranteed and the Ubuntu runner does not offer it, so the declaration
has to be explicit.

**Being straight about the verification:** I could *not* reproduce the failure on the machine I built
this on — its headers provide the type transitively, the same reason the original slipped through.
So this is justified by the standard and by the CI log, not by a local red-to-green. The runner is
the authority here and it is the thing that has to go green.

## Scope

`#include <sys/time.h>` added in the existing alphabetical slot, between `<sys/socket.h>` and
`<sys/types.h>`. **Nothing else in the diff.**

Blast radius on the rest of the tree: none. `dialyzer` and `test + lint + audit` were green
throughout the red period — only the `shottino (build + tests)` job ever failed, so no Elixir-side
gate was implicated.

Refs `2709fe11`.