### PR TITLE
fix(#653): bucket B — deterministic e2e setup for #277/#520/#530/#534

### DIFF
--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -665,17 +665,39 @@ export async function resetSubject(
     );
   }
 
-  const res = await fetch(`${GRAPPA_BASE_URL}/admin/test/reset-subject`, {
-    method: "POST",
-    headers: {
-      authorization: `Bearer ${adminToken}`,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify(body),
-  });
-  if (res.status !== 204) {
+  // #277/#653 — the reset restarts vjt's Session.Server, which reconnects to
+  // bahamut-test and re-registers `vjt-grappa`. Under full-gate load an
+  // earlier spec's upstream session may not have released the nick yet, so
+  // the re-register hits 433 ERR_NICKNAMEINUSE and the reset 500s with
+  // `{:client_exit, {:nick_rejected, 433, "vjt-grappa"}}`. That 433 is the
+  // OBSERVABLE "nick not free yet" signal from the testnet — retry the whole
+  // reset on it with bounded backoff until bahamut releases the ghost (204).
+  // This is NOT a blind pre-sleep: we retry ONLY while the server reports the
+  // nick still taken, and ONLY that one signal — every other non-204
+  // (404 user_not_found, 504 timeout, any other 500) throws IMMEDIATELY, so a
+  // real reset failure is never masked. Known bahamut ghost-race tail (the
+  // #268 class; see feedback_integration_bahamut_ip_autokill_flake).
+  const maxAttempts = 8;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const res = await fetch(`${GRAPPA_BASE_URL}/admin/test/reset-subject`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${adminToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    if (res.status === 204) return;
+
     const text = await res.text().catch(() => "<no body>");
-    throw new Error(`resetSubject(${userName}) failed: ${res.status} ${text}`);
+    const nickStillTaken = res.status === 500 && text.includes("nick_rejected");
+    if (!nickStillTaken || attempt === maxAttempts) {
+      throw new Error(`resetSubject(${userName}) failed: ${res.status} ${text}`);
+    }
+    // Observed 433 → the ghosted nick isn't released yet. Back off (capped)
+    // then re-register; each reset attempt also reconnects, which itself
+    // gives bahamut time to reap the prior connection's ghost.
+    await sleep(Math.min(500 * attempt, 2_000));
   }
 }
 

--- a/cicchetto/e2e/tests/channel-directory.spec.ts
+++ b/cicchetto/e2e/tests/channel-directory.spec.ts
@@ -81,14 +81,26 @@ test(
         ownNick: NETWORK_NICK,
       });
 
-      // Arm the /messages request collector from this point forward.
-      // Any /messages hit recorded after this point means the $list
-      // window selection bypassed the grappa-irc#81 kindHasScrollback
-      // guard — a real regression, not a stale initial fetch.
+      // Arm the /messages request collector from this point forward, SCOPED
+      // to the $list window under test (#534/#653). The regression the #81
+      // guard catches — a kindHasScrollback("list") slip — would fetch
+      // scrollback for the SELECTED window, i.e. cic's listMessages hits
+      // GET .../channels/%24list/messages (encodeURIComponent("$list")).
+      // Record ONLY that path: an unrelated forward gap-fill on the live
+      // autojoin #bofh (.../channels/%23bofh/messages?after=...) is legitimate
+      // background activity — a peer is connected and seed traffic is real —
+      // NOT the regression, and under full-gate load it can fire inside this
+      // window and trip a global-zero collector (the load-only flake).
+      // Keying on the $list channel segment keeps the assertion STRICT (a
+      // genuine $list scrollback fetch still reds it below) while making it
+      // deterministic — this is NOT a toHaveLength(<=1) relaxation nor a
+      // blanket substring filter that would blind the guard.
+      const listMessagesPath = `/channels/${encodeURIComponent(LIST_WINDOW_NAME)}/messages`;
       const messagesRequests: string[] = [];
       page.on("request", (req) => {
-        if (/\/messages(\?|$)/.test(req.url())) {
-          messagesRequests.push(req.url());
+        const url = req.url();
+        if (url.includes(listMessagesPath)) {
+          messagesRequests.push(url);
         }
       });
 

--- a/cicchetto/e2e/tests/freshness-on-activation.spec.ts
+++ b/cicchetto/e2e/tests/freshness-on-activation.spec.ts
@@ -25,6 +25,19 @@ import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
+// #520/#653 — key every message body on a value that cannot pre-exist. The
+// Phase-3 premise gate asserts the DURING-gap row is ABSENT (toHaveCount 0);
+// under full-gate load a residual `msg-159-*-during-gap` row persisted by a
+// PRIOR execution of this spec (a Playwright retry, or a slow `_vjtReset`
+// truncate that lost the DB-lock race under #506/#539 contention) can survive
+// into this run's #bofh scrollback and satisfy the `hasText` substring,
+// reddening the premise before the fix under test ever runs. A per-run UUID
+// makes THIS run's rows un-collidable with any neighbour's, so the premise
+// measures only the delivery gap it means to — never leftover state. Iso is
+// unaffected (the reset runs between repeats); this closes the load-only
+// residue class the issue flags ("cross-test residue / ordering").
+const RUN_ID = crypto.randomUUID().slice(0, 8);
+
 // Open the per-channel delivery gap: silence live `phx.on("event")` for
 // CHANNEL's topic while the socket + every other channel stay live.
 async function suppressChannelDelivery(
@@ -81,7 +94,7 @@ test("#159 — tab RE-SELECT after a socket-stays-open gap re-fetches the missed
 
     // Phase 1 — baseline live message. Rendered live sets the high-water
     // mark (recordSeen) that refreshScrollback's resume cursor uses.
-    const before = "msg-159-sel-before-gap";
+    const before = `msg-159-sel-before-gap-${RUN_ID}`;
     peer.privmsg(CHANNEL, before);
     await expect(scrollbackLine(page, "privmsg", before)).toBeVisible();
 
@@ -90,7 +103,7 @@ test("#159 — tab RE-SELECT after a socket-stays-open gap re-fetches the missed
 
     // Phase 3 — peer posts during the gap. Server persists + broadcasts;
     // this cic drops the push (topic suppressed), so it never renders.
-    const during = "msg-159-sel-during-gap";
+    const during = `msg-159-sel-during-gap-${RUN_ID}`;
     peer.privmsg(CHANNEL, during);
     // The gap is real: the row must NOT appear on its own. Settle window
     // long enough to rule out an in-flight push (delivery is deterministically
@@ -127,7 +140,7 @@ test("#159 — tab RE-FOREGROUND (hidden→visible) after a socket-stays-open ga
   try {
     await peer.join(CHANNEL);
 
-    const before = "msg-159-vis-before-gap";
+    const before = `msg-159-vis-before-gap-${RUN_ID}`;
     peer.privmsg(CHANNEL, before);
     await expect(scrollbackLine(page, "privmsg", before)).toBeVisible();
 
@@ -135,7 +148,7 @@ test("#159 — tab RE-FOREGROUND (hidden→visible) after a socket-stays-open ga
     await suppressChannelDelivery(page, NETWORK_SLUG, CHANNEL);
     await setTabHidden(page, true);
 
-    const during = "msg-159-vis-during-gap";
+    const during = `msg-159-vis-during-gap-${RUN_ID}`;
     peer.privmsg(CHANNEL, during);
     await page.waitForTimeout(750);
     await expect(scrollbackLine(page, "privmsg", during)).toHaveCount(0);

--- a/cicchetto/e2e/tests/nick-follow-query.spec.ts
+++ b/cicchetto/e2e/tests/nick-follow-query.spec.ts
@@ -27,6 +27,7 @@ import { expect, test } from "../fixtures/test";
 import {
   composeSend,
   loginAs,
+  scrollbackLine,
   selectChannel,
   waitForDmListenerReady,
   waitForQueryWindowReady,
@@ -57,6 +58,22 @@ test("query window follows a peer NICK change — relabels, keeps history, route
     // Share a channel so grappa observes the peer's NICK (IRC only relays a
     // NICK to users sharing a channel with the renamer).
     await peer.join(CHANNEL);
+
+    // #530/#653 — the STEP-3 relabel under test fires ONLY when grappa emits
+    // {:peer_nick_renamed}, and event_router.ex gates that on the renamer
+    // being a tracked member of a shared channel (peer_rename_effects:
+    // `channels != []`, i.e. OLD_NICK present in grappa's state.members).
+    // `peer.join` above awaits only the peer's OWN join echo from bahamut —
+    // NOT grappa's observation of it. Under full-gate load grappa can process
+    // the peer's #bofh JOIN late; a rename that lands first leaves
+    // `channels == []` → no peer_nick_renamed → the sidebar never relabels
+    // and STEP 3 fails. Gate on the peer's JOIN line rendering in our #bofh
+    // scrollback: grappa broadcasts that row from the SAME apply that adds
+    // OLD_NICK to state.members, so its presence is the observable proof the
+    // shared-membership precondition holds before we drive the rename.
+    await expect(
+      scrollbackLine(page, "join", OLD_NICK).filter({ hasText: CHANNEL }).first(),
+    ).toBeVisible({ timeout: 10_000 });
 
     // STEP 1 — open + focus the query window with the OLD nick.
     await composeSend(page, `/q ${OLD_NICK}`);


### PR DESCRIPTION
Epic #653 **bucket B** — the e2e setup/protocol non-determinism cluster
(#277 #520 #530 #534). All four are the same profile: **green in
isolation, red under full-gate load**. Cure pattern (locked by the epic):
make the SETUP deterministic — unique-per-run id, observable-settle wait,
bounded retry on an OBSERVABLE signal. **No assert weakened, no blind
sleep/retry/timeout bump.**

### #277 — testnet nick-release race (`resetSubject` 500s on 433)
The `_vjtReset` teardown restarts vjt's Session.Server → reconnect →
re-register `vjt-grappa`. Under load an earlier spec's upstream session
hasn't released the nick, so the re-register hits 433 and the reset 500s
(`{:client_exit, {:nick_rejected, 433, ...}}`), reddening the NEXT spec's
beforeEach (issue195:71 was the victim). Fix: retry the whole reset while
the server reports the nick still taken (500 + `nick_rejected`) with
bounded/capped backoff until it frees (204). NOT a blind pre-sleep — every
other non-204 (404/504/non-nick 500) throws immediately, so a real reset
failure is never masked.

### #520 — freshness-on-activation Phase-3 premise leaks under load
The premise gate asserts the during-gap row is ABSENT before the fix runs.
Under load a residual `msg-159-*-during-gap` row from a prior execution
(retry, or a slow `_vjtReset` truncate losing the DB-lock race) satisfies
the `hasText` substring. Fix: key both message bodies on a per-run UUID so
they cannot collide with any neighbour's leftover state. Suppression hook
is synchronous and already effective; iso unaffected.

### #530 — nick-follow-query relabel fails under load
`event_router.ex` emits `{:peer_nick_renamed}` (the relabel under test)
ONLY when the renamer is a tracked member of a shared channel
(`channels != []`). `peer.join` awaits only the peer's own echo, not
grappa's observation of it; under load grappa processes the #bofh JOIN
late → no rename effect → no relabel. Fix: after `peer.join`, wait for the
peer's JOIN line to render in our #bofh scrollback — grappa broadcasts it
from the SAME apply that adds the peer to `state.members`, so it is the
observable proof the shared-membership precondition holds. #373
rename-order assertion untouched.

### #534 — stray `#bofh` gap-fill trips the #81 `/messages` guard
The guard asserts ZERO `/messages` while selecting the `$list` window. A
legitimate forward gap-fill on the live autojoin `#bofh`
(`/channels/%23bofh/messages?after=...`) fires inside the collection
window and trips a global-zero collector. Fix: scope the collector to the
`$list` window's channel key — a `kindHasScrollback("list")` regression
would fetch `/channels/%24list/messages`, so recording only that path
ignores the `#bofh` gap-fill while still failing on a genuine `$list`
fetch. NOT a `toHaveLength(<=1)` relaxation nor a blanket substring filter.

### Gates
- biome (e2e) clean.
- Per-spec iso `--project chromium --grep "#159|NICK change|#81 guard|#195" --repeat-each 3` — exit 0 (all repeats green).
- **Full `scripts/integration.sh` × 2 consecutive: 584 passed (21.7m) then 584 passed (22.2m), 0 failed / 0 flaky both runs.** All four target specs green in both. Chromium + webkit-iphone-15. recover-identity lines 163/193 green (no out-of-scope red materialised).

Refs #653