### PR TITLE
fix(#671): auto-away arms when the last visible socket goes stale before it dies

### DIFF
--- a/cicchetto/e2e/fixtures/ircClient.ts
+++ b/cicchetto/e2e/fixtures/ircClient.ts
@@ -314,6 +314,14 @@ export class IrcPeer {
     await ack;
   }
 
+  // Fire a WHOIS at `nick`. Fire-and-forget: the caller witnesses the
+  // reply lines via `waitForLine` (e.g. a `301` RPL_AWAY when `nick` is
+  // currently away). Used by the #671 auto-away-on-disconnect e2e to
+  // witness the bouncer's upstream AWAY after its last socket dies stale.
+  whois(nick: string): void {
+    this.client.raw(["WHOIS", nick]);
+  }
+
   async part(channel: string, reason: string): Promise<void> {
     const parted = onceMatching(
       this.client,

--- a/cicchetto/e2e/tests/issue671-auto-away-on-disconnect.spec.ts
+++ b/cicchetto/e2e/tests/issue671-auto-away-on-disconnect.spec.ts
@@ -1,0 +1,143 @@
+// #671 — auto-away must fire when the last VISIBLE socket goes STALE
+// before it dies.
+//
+// The bug: read-time visibility staleness (#318) also sat on the
+// `before?` side of every auto-away transition, so a device that stopped
+// heartbeating (phone asleep, JS timers suspended) aged out silently —
+// and when its socket finally died the `true → false` flip that arms
+// auto-away had already happened invisibly, so `:ws_all_hidden` never
+// fired and the bouncer never sent an upstream AWAY. A user's peer saw
+// them online for hours. The three existing away specs
+// (`p0b-peer-away`, `issue270-peer-away-overlap`, `issue276-away-emoji-
+// badge`) only drive EXPLICIT `/away`, so none exercises auto-away — and
+// none exercises the DISCONNECT path at all. This is the missing e2e
+// whose absence let the bug ship (per the issue).
+//
+// What this drives, end to end, asserting the USER-VISIBLE outcome (a
+// peer observing AWAY — never an internal timer flag):
+//   1. vjt logs in and reports VISIBLE (the initial `visibility` push).
+//   2. The device "suspends its JS" — we drop every SUBSEQUENT client
+//      `visibility` heartbeat frame at the WS boundary (via
+//      `routeWebSocket`) while forwarding phoenix heartbeats, so the
+//      socket stays connected but the server stops getting fresh
+//      visibility reports. This is exactly the field scenario (iOS holds
+//      the socket while backgrounded but suspends timers).
+//   3. We wait past the server staleness window (`@default_stale_ms`,
+//      60s — deliberately UNCHANGED so foreground push-suppression stays
+//      fresh) so the still-`:visible` pid ages out.
+//   4. The zombie socket dies (`__cic_dropSocketForTests`, drop-and-HOLD
+//      so no reconnect re-arms visible) → server sees DOWN on a STALE
+//      pid → the #671 fix fires `:ws_all_hidden` → the auto-away debounce
+//      arms → the bouncer sends `AWAY` upstream.
+//   5. A peer WHOISes vjt and witnesses the `301 RPL_AWAY`.
+//
+// The auto-away debounce is 600s in production (byte-identical); the
+// integration env shortens it via `config :grappa, Grappa.Session.Server,
+// auto_away_debounce_ms:` in `config/dev.exs` (grappa-test runs
+// MIX_ENV=dev) so this spec observes the AWAY in seconds, not 10 minutes
+// — the CLAUDE.md start_link-opts injection pattern, not a prod change.
+//
+// Per `feedback_ux_e2e_mandatory`: the fix touches server behavior a
+// client observes, so it ships with a Playwright e2e via
+// scripts/integration.sh.
+
+import { test, expect } from "../fixtures/test";
+import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const PEER_NICK = "i671-away-watcher";
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Server `@default_stale_ms` is 60_000; wait a beat past it so the last
+// (login-time) visibility report is unambiguously stale when the socket
+// dies. Kept as one named constant so the test-timeout math is honest.
+const STALE_WAIT_MS = 63_000;
+
+// A phoenix v2 wire frame is `[join_ref, ref, topic, event, payload]`.
+// The client visibility heartbeat is `_userChannel.push("visibility", …)`
+// — event at index 3. Everything else (phx `heartbeat`, channel joins,
+// replies) is forwarded so the socket stays healthy while stale.
+function isVisibilityReport(message: string | Buffer): boolean {
+  if (typeof message !== "string") return false;
+  try {
+    const frame = JSON.parse(message);
+    return Array.isArray(frame) && frame[3] === "visibility";
+  } catch {
+    return false;
+  }
+}
+
+test("#671 — a stale-then-dead last socket still drives the bouncer AWAY (peer observes it)", async ({
+  page,
+}) => {
+  // Login + the 60s stale window + the debounce + WHOIS round-trips.
+  test.setTimeout(120_000);
+
+  const vjt = getSeededVjt();
+
+  // Simulate "the device stopped reporting": forward the FIRST visibility
+  // report (so the pid legitimately becomes :visible), then drop every
+  // subsequent heartbeat report. `dropVisibility` is a Node-side closure
+  // variable the test flips once the initial report has been acked.
+  let dropVisibility = false;
+  await page.routeWebSocket(/\/socket\/websocket/, (ws) => {
+    const server = ws.connectToServer();
+    ws.onMessage((message) => {
+      if (dropVisibility && isVisibilityReport(message)) return;
+      server.send(message);
+    });
+    server.onMessage((message) => ws.send(message));
+  });
+
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  // The bouncer's upstream session (NETWORK_NICK on bahamut-test) is now
+  // live; a peer connects to witness its away state.
+  const peer = await IrcPeer.connect({ nick: PEER_NICK });
+  try {
+    // Wait for the server to ACK the initial VISIBLE report (#182 seam),
+    // so the pid is genuinely :visible before we start starving it.
+    await page.waitForFunction(
+      () => (window as unknown as { __visibilityAck?: boolean }).__visibilityAck === true,
+      null,
+      { timeout: 10_000 },
+    );
+
+    // From here the "device" is suspended: no fresh visibility reports
+    // reach the server. The pid stays :visible but its last report ages.
+    dropVisibility = true;
+
+    // Age past @default_stale_ms — the pid is now stale-but-:visible.
+    await page.waitForTimeout(STALE_WAIT_MS);
+
+    // The zombie socket dies. Drop-and-HOLD: no phoenix reconnect, so no
+    // fresh :visible report cancels the auto-away we're about to arm.
+    await page.evaluate(() =>
+      (
+        window as unknown as { __cic_dropSocketForTests?: () => Promise<void> }
+      ).__cic_dropSocketForTests?.(),
+    );
+
+    // Server: DOWN on a STALE pid → (#671) :ws_all_hidden → debounce →
+    // upstream AWAY. Witness it as a peer would: WHOIS returns 301
+    // RPL_AWAY once the bouncer is flagged away. Poll WHOIS until the
+    // AWAY lands (debounce + round-trip), bounded by the listener timeout.
+    const awaySeen = peer.waitForLine(
+      new RegExp(` 301 .* ${NETWORK_NICK} `),
+      `RPL_AWAY for ${NETWORK_NICK}`,
+      25_000,
+    );
+    peer.whois(NETWORK_NICK);
+    const poll = setInterval(() => peer.whois(NETWORK_NICK), 2_000);
+    try {
+      const line = await awaySeen;
+      expect(line).toContain(NETWORK_NICK);
+    } finally {
+      clearInterval(poll);
+    }
+  } finally {
+    await peer.disconnect("i671 done");
+  }
+});

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -88,6 +88,17 @@ config :grappa, Grappa.Vault,
 config :phoenix, :stacktrace_depth, 20
 config :phoenix, :plug_init_mode, :runtime
 
+# #671 — auto-away debounce, SHORT for the integration env only. The
+# cicchetto/e2e stack boots grappa-test under MIX_ENV=dev, so this is
+# how "the integration env sets it short" (Session.Server.boot/0 reads
+# it into :persistent_term; start_session/3 injects it). Production
+# (MIX_ENV=prod) sets no key and keeps the byte-identical 600_000 default.
+# The auto-away-on-disconnect e2e drops the client's visibility
+# heartbeats, waits out stale_ms (unchanged 60s — foreground push
+# suppression must stay fresh), drops the socket, and asserts a peer
+# observes AWAY after THIS window — so it must be short but non-zero.
+config :grappa, Grappa.Session.Server, auto_away_debounce_ms: 2_000
+
 # Push notifications cluster B5 (2026-05-14) — fixed VAPID keypair
 # for dev/e2e. The integration harness (cicchetto/e2e/compose.yaml)
 # boots grappa-test under MIX_ENV=dev; without this, Application.

--- a/lib/grappa/application.ex
+++ b/lib/grappa/application.ex
@@ -119,6 +119,15 @@ defmodule Grappa.Application do
     # CLAUDE.md-designated boundary (mirrors `Grappa.Uploads.boot/1`).
     :ok = Grappa.Cic.Bundle.boot(cic_dist_root())
 
+    # #671: resolve the auto-away debounce window into `:persistent_term`
+    # so `Grappa.Session.start_session/3` injects it into every session's
+    # start opts lock-free (dynamic children have no static-child inject
+    # point; boot → persistent_term → spawn-boundary inject is the
+    # start_link-opts pattern for them). Prod sets no config key → the
+    # compile-time 600_000 default; the integration env (config/dev.exs)
+    # sets it short. Mirrors `Grappa.Uploads.boot/1`.
+    :ok = Grappa.Session.Server.boot()
+
     # Child order is load-bearing — see CLAUDE.md "Don't touch supervision
     # tree ordering casually." Each comment below documents the WHY so a
     # reorder is a deliberate choice.

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -215,7 +215,16 @@ defmodule Grappa.Session do
   def start_session(subject, network_id, opts)
       when is_subject(subject) and is_integer(network_id) and is_map(opts) do
     ^subject = Map.fetch!(opts, :subject)
-    full_opts = Map.put(opts, :network_id, network_id)
+
+    # #671 — inject the boot-resolved auto-away debounce at the single
+    # spawn choke point (the CLAUDE.md start_link-opts pattern for a
+    # dynamically-spawned GenServer: boot reads env → persistent_term →
+    # the spawn boundary injects). `put_new` so a caller/test that already
+    # set the key (a substituted short window) wins.
+    full_opts =
+      opts
+      |> Map.put(:network_id, network_id)
+      |> Map.put_new(:auto_away_debounce_ms, Server.auto_away_debounce_ms())
 
     DynamicSupervisor.start_child(
       Grappa.SessionSupervisor,

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -135,7 +135,20 @@ defmodule Grappa.Session.Server do
   # twitchy for real mobile usage (a screen-lock immediately read as away).
   # The auto-away reason string itself lives on `AwayState.auto_away_reason/0`
   # (moved there in cluster #7 — single injection site is `set_auto_away/1`).
+  #
+  # This is the PRODUCTION DEFAULT, injectable per the CLAUDE.md
+  # start_link-opts pattern (#671): `boot/0` reads
+  # `config :grappa, Grappa.Session.Server, auto_away_debounce_ms: …` once
+  # at boot into `:persistent_term`; `Grappa.Session.start_session/3` (the
+  # spawn boundary) injects the value into the opts map; `do_init/1`
+  # stores it on `state.auto_away_debounce_ms`. Prod sets no config key, so
+  # the value stays byte-identical 600_000; the integration env
+  # (`config/dev.exs`, `MIX_ENV=dev`) sets it short so the auto-away
+  # disconnect e2e can observe the upstream AWAY without a 10-min wait.
   @auto_away_debounce_ms 600_000
+
+  # `:persistent_term` key holding the boot-resolved debounce default.
+  @auto_away_debounce_key {__MODULE__, :auto_away_debounce_ms}
 
   # 10s is generous for an upstream NickServ → +r MODE round-trip; even
   # a sluggish ircd should confirm in <2s. The timer is a fail-safe so
@@ -525,6 +538,10 @@ defmodule Grappa.Session.Server do
           # #347 deferred-autojoin fallback window — test seam. Production
           # omits it and inherits `@autojoin_defer_ms`.
           optional(:autojoin_defer_ms) => pos_integer(),
+          # #671 auto-away debounce window. Normally injected by
+          # `Grappa.Session.start_session/3` from the boot-resolved default;
+          # a test / integration env may substitute a short window.
+          optional(:auto_away_debounce_ms) => non_neg_integer(),
           # GH #189 / #509 — on-connect perform list + its `$oper_pass` /
           # `$nickserv_pass` secrets, decrypted plaintext from the credential
           # (nil when unset). Run at 001 before the built-in identify and before
@@ -645,6 +662,9 @@ defmodule Grappa.Session.Server do
           recover_settle_timer: reference() | nil,
           away_state: AwayState.t(),
           auto_away_timer: reference() | nil,
+          # #671 — the auto-away debounce window (ms), injected from
+          # `start_session/3` (boot-resolved default; opts override in tests).
+          auto_away_debounce_ms: non_neg_integer(),
           # S4.2: IRCv3 caps confirmed active by upstream CAP ACK. Keys are
           # lowercase cap names (e.g. "labeled-response"). Empty until the
           # upstream ACKs at least one cap. Caps added on ACK; never removed
@@ -890,6 +910,42 @@ defmodule Grappa.Session.Server do
   end
 
   @doc """
+  Reads the auto-away debounce config once at boot into
+  `:persistent_term`. Called from `Grappa.Application.start/2` (the
+  designated `Application.get_env` boundary — CLAUDE.md
+  "Application.{put,get}_env: boot-time only"). Mirrors the other
+  boot/0 DI-seams (`Grappa.Uploads.boot/1`, `Grappa.Admission.Config.boot/0`).
+
+  Absent config (prod) → the compile-time default (`600_000`), so
+  production stays byte-identical. The integration env
+  (`config/dev.exs`) overrides it short so the auto-away disconnect e2e
+  need not wait 10 minutes. `start_session/3` reads the resolved value
+  via `auto_away_debounce_ms/0` and injects it into the session's
+  start opts.
+  """
+  @spec boot() :: :ok
+  def boot do
+    debounce_ms =
+      :grappa
+      |> Application.get_env(__MODULE__, [])
+      |> Keyword.get(:auto_away_debounce_ms, @auto_away_debounce_ms)
+
+    :persistent_term.put(@auto_away_debounce_key, debounce_ms)
+  end
+
+  @doc """
+  Boot-resolved auto-away debounce (ms) — lock-free `:persistent_term`
+  read. Falls back to the compile-time default when `boot/0` has not run
+  (e.g. a unit test that starts a bare Server without the app tree).
+  Injected into the session opts by `Grappa.Session.start_session/3`;
+  a per-session opts override still wins in `do_init/1` (the test seam).
+  """
+  @spec auto_away_debounce_ms() :: non_neg_integer()
+  def auto_away_debounce_ms do
+    :persistent_term.get(@auto_away_debounce_key, @auto_away_debounce_ms)
+  end
+
+  @doc """
   Returns the registry key for `(subject, network_id)`. Single source
   of truth for the `{:session, subject, network_id}` shape — every
   caller that needs to look up or terminate a session by key must go
@@ -1124,6 +1180,10 @@ defmodule Grappa.Session.Server do
       # `maybe_resend_away/1` (the ircd connection is fresh and away-blind).
       away_state: restore_away_state(Map.get(opts, :restored_away)),
       auto_away_timer: nil,
+      # #671 — debounce window from the spawn boundary
+      # (`start_session/3`); an explicit opt still wins so a unit test can
+      # substitute a short window without runtime config tricks.
+      auto_away_debounce_ms: Map.get(opts, :auto_away_debounce_ms, @auto_away_debounce_ms),
       caps_active: MapSet.new(),
       labels_pending: %{},
       # S10 — sibling prime-stamp map for the labels_pending lazy TTL sweep.
@@ -2613,25 +2673,26 @@ defmodule Grappa.Session.Server do
   end
 
   # S3.2 / #182 — the last VISIBLE device for this user backgrounded or
-  # closed (sockets may still be connected but hidden). Schedule the 30s
-  # debounce before issuing auto-away. If already `:away_explicit`, skip
-  # entirely — the user intentionally went away.
+  # closed (sockets may still be connected but hidden). Schedule the
+  # `@auto_away_debounce_ms` (10-min) debounce before issuing auto-away.
+  # If already `:away_explicit`, skip entirely — the user intentionally
+  # went away.
   def handle_info({:ws_all_hidden, _}, %{away_state: %AwayState{state: :away_explicit}} = state) do
     {:noreply, state}
   end
 
   def handle_info({:ws_all_hidden, _}, state) do
     # Cancel any existing debounce timer + drain a possibly-already-fired
-    # :auto_away_debounce_fire from the mailbox. Two rapid hide transitions
-    # ~30s apart used to leave the OLD timer's fire queued ahead of the
-    # second handler, which then ran set_auto_away_internal at T=30s
-    # instead of T=60s — and the second timer would later fire again,
+    # :auto_away_debounce_fire from the mailbox. Two hide transitions
+    # within one debounce window used to leave the OLD timer's fire queued
+    # ahead of the second handler, which then ran set_auto_away_internal a
+    # full window early — and the second timer would later fire again,
     # producing a duplicate upstream AWAY + an away_started_at jump that
     # broke maybe_broadcast_mentions_bundle's window-boundary aggregation
     # (lifecycle review HIGH S3).
     :ok = cancel_and_drain(state.auto_away_timer, :auto_away_debounce_fire)
 
-    timer = Process.send_after(self(), :auto_away_debounce_fire, @auto_away_debounce_ms)
+    timer = Process.send_after(self(), :auto_away_debounce_fire, state.auto_away_debounce_ms)
     {:noreply, %{state | auto_away_timer: timer}}
   end
 

--- a/lib/grappa/ws_presence.ex
+++ b/lib/grappa/ws_presence.ex
@@ -16,7 +16,7 @@ defmodule Grappa.WSPresence do
   For brevity the rest of these docs say the page maps to the last visibility
   reported over the `"visibility"` channel event. When the set of
   VISIBLE devices for a user transitions, it notifies interested
-  listeners so `Session.Server`s can schedule / cancel their 30s
+  listeners so `Session.Server`s can schedule / cancel their 10-minute
   auto-away debounce.
 
   ## Why visibility, not connection count (#182)
@@ -29,8 +29,9 @@ defmodule Grappa.WSPresence do
 
   ## One raw signal, two consumers, two timings
 
-    * **Auto-away FSM** (`Session.Server`) — DEBOUNCED 30s. Transitions
-      on the `:ws_visible` / `:ws_all_hidden` lifecycle events below.
+    * **Auto-away FSM** (`Session.Server`) — DEBOUNCED (10 min,
+      `@auto_away_debounce_ms`). Transitions on the `:ws_visible` /
+      `:ws_all_hidden` lifecycle events below.
     * **Push suppression** (`Grappa.Push.Triggers`) — RAW/IMMEDIATE.
       Reads `any_visible?/1` synchronously at message time, no debounce
       (a debounced gate would miss mentions right after you set the
@@ -58,10 +59,18 @@ defmodule Grappa.WSPresence do
   and push resumes within `stale_ms` instead of ~90 min.
 
   Scope: read-time staleness fixes PUSH suppression only. The auto-away
-  FSM keys off the `any_visible?/1` TRANSITION (an emitted event), and no
-  event fires when a pid merely ages out with no write — so a stale
-  `:visible` pid does not itself trip auto-away. Auto-away stays bounded
-  by the real socket DOWN / `client_closing`, unchanged by this fix.
+  FSM keys off the visibility TRANSITION (an emitted event), and no event
+  fires when a pid merely ages out with no write — so a stale `:visible`
+  pid does not itself TRIP auto-away. But ageing out must not DISARM it
+  either: the transition doors (`set_visibility` / `client_closing` /
+  DOWN) compute `before?`/`after?` over RAW `:visible` membership
+  (`any_reported_visible_in?/2`), NOT the fresh push view — so a device
+  that went stale and THEN dies / closes / reports hidden still produces
+  the `true → false` flip that fires `:ws_all_hidden`. Auto-away stays
+  bounded by the real socket DOWN / `client_closing` / explicit hide;
+  the fresh filter is confined to `any_visible?/1` push suppression
+  (#671 — before this, a stale-then-dead socket lost the transition and
+  auto-away never armed).
 
   Efficacy caveat: whether a backgrounded iOS PWA actually stops sending
   fresh `visible` reports is unconfirmed off-device — the prod socket
@@ -81,8 +90,8 @@ defmodule Grappa.WSPresence do
     auto-away debounce + unaway.
   - **`:ws_all_hidden`** — the last visible device hid or left
     (`any_visible?` true → false, sockets may still be connected but
-    backgrounded). Session.Servers schedule a 30s debounce that fires
-    `set_auto_away`.
+    backgrounded). Session.Servers schedule a 10-minute debounce that
+    fires `set_auto_away`.
 
   Registering a socket defaults it to `:hidden`, so `register/2` alone
   never fires `:ws_visible` — a just-connected device is assumed
@@ -449,14 +458,14 @@ defmodule Grappa.WSPresence do
     existing = Map.get(state.sockets, user_name, %{})
 
     if Map.has_key?(existing, socket_pid) do
-      before? = any_visible_in?(state, user_name)
+      before? = any_reported_visible_in?(state, user_name)
       # #318 — stamp the monotonic freshness time on every visible report so
       # `any_visible?/1` can discount a stale-visible pid; a hidden report
       # clears the stamp (nil).
       entry = if visible, do: {:visible, now_ms()}, else: {:hidden, nil}
       updated = Map.put(existing, socket_pid, entry)
       state1 = put_user_sockets(state, user_name, updated)
-      after? = any_visible_in?(state1, user_name)
+      after? = any_reported_visible_in?(state1, user_name)
       emit_transition(user_name, before?, after?, state1)
       {:reply, :ok, state1}
     else
@@ -516,12 +525,12 @@ defmodule Grappa.WSPresence do
     existing = Map.get(state.sockets, user_name, %{})
 
     if Map.has_key?(existing, socket_pid) do
-      before? = any_visible_in?(state, user_name)
+      before? = any_reported_visible_in?(state, user_name)
       # A closing tab is not visible — mark it hidden now. The real pid
       # DOWN removes it later (idempotent).
       updated = Map.put(existing, socket_pid, {:hidden, nil})
       state1 = put_user_sockets(state, user_name, updated)
-      after? = any_visible_in?(state1, user_name)
+      after? = any_reported_visible_in?(state1, user_name)
       emit_transition(user_name, before?, after?, state1)
       {:reply, :ok, state1}
     else
@@ -573,13 +582,15 @@ defmodule Grappa.WSPresence do
       user_name ->
         state1 = %{state | refs_to_user: Map.delete(state.refs_to_user, ref)}
         existing = Map.get(state1.sockets, user_name, %{})
-        before? = any_visible_in?(state1, user_name)
+        before? = any_reported_visible_in?(state1, user_name)
         updated = Map.delete(existing, pid)
         state2 = put_user_sockets(state1, user_name, updated)
-        after? = any_visible_in?(state2, user_name)
-        # Only a VISIBLE pid leaving can flip any_visible? true→false. A
-        # hidden pid dying (or one already removed by client_closing) is a
-        # no-op transition — no duplicate :ws_all_hidden.
+        after? = any_reported_visible_in?(state2, user_name)
+        # Only a REPORTED-visible pid leaving can flip the transition
+        # predicate true→false (#671: raw membership, not the fresh push
+        # view). A hidden pid dying (or one already removed by
+        # client_closing) is a no-op transition — no duplicate
+        # :ws_all_hidden; a stale-but-visible pid dying DOES fire it.
         emit_transition(user_name, before?, after?, state2)
         {:noreply, state2}
     end
@@ -594,6 +605,11 @@ defmodule Grappa.WSPresence do
     %{state | sockets: Map.put(state.sockets, user_name, user_sockets)}
   end
 
+  # FRESH `:visible` membership — the PUSH-suppression predicate (#318).
+  # A `:visible` pid counts only while its last report is fresh, so a
+  # backgrounded PWA whose heartbeat suspended resumes push within
+  # `stale_ms`. Backs `any_visible?/1` + `snapshot/0`. NOT the auto-away
+  # transition predicate (see `any_reported_visible_in?/2`, #671).
   @spec any_visible_in?(t(), String.t()) :: boolean()
   defp any_visible_in?(state, user_name) do
     now = now_ms()
@@ -603,6 +619,27 @@ defmodule Grappa.WSPresence do
     |> Enum.any?(fn {_, {vis, last}} ->
       vis == :visible and fresh?(last, now, state.stale_ms)
     end)
+  end
+
+  # RAW `:visible` membership, IGNORING freshness — the AUTO-AWAY
+  # transition predicate (#671). The `before?`/`after?` of every
+  # lifecycle-event door (`set_visibility`, `client_closing`, DOWN) reads
+  # THIS, not `any_visible_in?/2`. Rationale: read-time staleness (#318)
+  # emits no event when a pid merely ages out, so a device that stopped
+  # heartbeating (phone asleep, JS timers suspended) is silently dropped
+  # from the FRESH view — and if `before?` also read the fresh view, the
+  # `true → false` flip on the eventual DOWN / close / hidden report would
+  # have ALREADY happened invisibly, so `emit_transition/4` saw
+  # `false → false` and never fired `:ws_all_hidden`, so auto-away never
+  # armed. A stale-but-still-`:visible` pid is a REPORTED-visible device:
+  # auto-away stays bounded by the real socket DOWN / close / explicit
+  # hide, NOT disarmed by silent ageout. (Ageout still does not TRIP
+  # auto-away — no event fires on ageout — it just no longer DISARMS it.)
+  @spec any_reported_visible_in?(t(), String.t()) :: boolean()
+  defp any_reported_visible_in?(state, user_name) do
+    state.sockets
+    |> Map.get(user_name, %{})
+    |> Enum.any?(fn {_, {vis, _}} -> vis == :visible end)
   end
 
   # A :visible pid counts as present only while its last report is fresh

--- a/test/grappa/ws_presence_test.exs
+++ b/test/grappa/ws_presence_test.exs
@@ -252,6 +252,88 @@ defmodule Grappa.WSPresenceTest do
     end
   end
 
+  describe "#671 — a STALE :visible pid still arms auto-away (every door)" do
+    # #671 — read-time staleness (#318) was scoped to push suppression, but
+    # `any_visible_in?/2` (fresh) also sat on the `before?` side of every
+    # auto-away transition. So a device that stopped heartbeating (phone
+    # asleep, JS timers suspended) aged out silently — and when its socket
+    # finally died / closed / reported hidden, `before?` was ALREADY false,
+    # the `true → false` flip never happened, `:ws_all_hidden` never fired,
+    # and auto-away never armed. The transition predicate now reads RAW
+    # `:visible` membership (a reported-visible device is still present for
+    # auto-away purposes, however stale its push-suppression view). Push
+    # suppression (`any_visible?/1`) stays FRESH — the two invariants below.
+
+    test "a STALE :visible pid dying still fires :ws_all_hidden (arms auto-away)" do
+      p = stub_pid()
+      :ok = WSPresence.register_with_notify("ivan", p, self())
+      :ok = WSPresence.set_visibility("ivan", p, true)
+      assert_receive {:ws_visible, "ivan"}, 200
+
+      # Device stops reporting; it ages past @stale_ms with no write.
+      :ok = WSPresence.mark_stale_for_test("ivan", p)
+      # Push-suppression view discounts it immediately (the #318 contract)...
+      refute WSPresence.any_visible?("ivan")
+
+      # ...but its DEATH is still the last reported-visible device leaving.
+      Process.exit(p, :kill)
+      :timer.sleep(50)
+
+      assert WSPresence.ws_count("ivan") == 0
+      assert_receive {:ws_all_hidden, "ivan"}, 200
+    end
+
+    test "client_closing on a STALE :visible pid still fires :ws_all_hidden" do
+      p = stub_pid()
+      :ok = WSPresence.register_with_notify("judy", p, self())
+      :ok = WSPresence.set_visibility("judy", p, true)
+      assert_receive {:ws_visible, "judy"}, 200
+
+      :ok = WSPresence.mark_stale_for_test("judy", p)
+      # pagehide arriving after the pid already went stale.
+      :ok = WSPresence.client_closing("judy", p)
+      assert_receive {:ws_all_hidden, "judy"}, 200
+
+      send(p, :stop)
+    end
+
+    test "set_visibility(false) on a STALE :visible pid still fires :ws_all_hidden" do
+      p = stub_pid()
+      :ok = WSPresence.register_with_notify("kev", p, self())
+      :ok = WSPresence.set_visibility("kev", p, true)
+      assert_receive {:ws_visible, "kev"}, 200
+
+      :ok = WSPresence.mark_stale_for_test("kev", p)
+      # An explicit hidden report after the pid already aged out.
+      :ok = WSPresence.set_visibility("kev", p, false)
+      assert_receive {:ws_all_hidden, "kev"}, 200
+
+      send(p, :stop)
+    end
+
+    test "one STALE + one fresh visible pid: the fresh one dying does NOT fire :ws_all_hidden" do
+      # Guard the other direction — the raw predicate must not over-fire.
+      # A stale pid is still raw-visible, so the user is still present when a
+      # sibling fresh pid dies.
+      stale = stub_pid()
+      fresh = stub_pid()
+      :ok = WSPresence.register_with_notify("lena", stale, self())
+      :ok = WSPresence.register_with_notify("lena", fresh, self())
+      :ok = WSPresence.set_visibility("lena", stale, true)
+      :ok = WSPresence.set_visibility("lena", fresh, true)
+      assert_receive {:ws_visible, "lena"}, 200
+
+      :ok = WSPresence.mark_stale_for_test("lena", stale)
+
+      Process.exit(fresh, :kill)
+      :timer.sleep(50)
+      # `stale` is still raw-visible — the user has not gone all-hidden.
+      refute_receive {:ws_all_hidden, "lena"}, 100
+
+      send(stale, :stop)
+    end
+  end
+
   describe "client_closing/2 immediate path" do
     test "client_closing on the last VISIBLE socket fires immediate :ws_all_hidden" do
       p = stub_pid()


### PR DESCRIPTION
## Summary

Auto-away stopped firing when the last visible socket went **stale before it died** — reported from the field as a peer showing online for hours after a device was left overnight.

Read-time visibility staleness (#318) was scoped to push suppression, but the FRESH predicate `any_visible_in?/2` also sat on the `before?` side of **every** auto-away transition door. A device that stopped heartbeating (phone asleep, JS timers suspended) aged out past `stale_ms` with no write and no event, so it was silently dropped from the fresh view. When its socket finally died / closed / reported hidden, `before?` was already `false`: the `true → false` flip that arms auto-away never happened, `:ws_all_hidden` never fired, and the bouncer never sent an upstream `AWAY`.

The hole sat on all three doors — `{:DOWN}`, `client_closing`, `set_visibility(false)`. **One fix, every door.**

## The fix

Split the transition predicate from the push-suppression predicate:

- New `any_reported_visible_in?/2` = **raw** `:visible` membership, ignoring freshness → the three transition doors compute `before?`/`after?` over it.
- `any_visible?/1` + `snapshot/0` keep the **fresh** filter → push suppression is byte-for-byte unchanged (#318 preserved).

Net: ageing out still does not *trip* auto-away (no event fires on ageout) but no longer *disarms* it — auto-away stays bounded by the real socket DOWN / close / explicit hide, exactly as the moduledoc always claimed.

Rejected the timer-edge alternative (emit `:ws_all_hidden` on ageout): it would fire auto-away on a backgrounded-but-connected device — the twitchy behavior the 600s debounce exists to avoid — and adds parallel timer state (CLAUDE.md "derive, don't duplicate").

Also corrects the moduledoc paragraph that asserted the opposite, and the stale "30s" debounce comments (the window is 600s since f63f4ff3). The debounce bump was a *concause* (10 min of extra latency), not the root cause — untouched.

## Tests

- **ExUnit (TDD, RED-first):** 4 new cases in `ws_presence_test.exs` — a stale `:visible` pid dying / closing / reporting-hidden each now fires `:ws_all_hidden`, plus a guard that a fresh sibling dying while a stale one remains does **not** over-fire. All RED on origin, GREEN after the fix.
- **e2e (+1, new file `issue671-auto-away-on-disconnect.spec.ts`):** vjt logs in + reports visible; the device "suspends its JS" (drop subsequent `visibility` heartbeat frames via `routeWebSocket`, forwarding phoenix heartbeats so the socket stays connected); wait past the 60s staleness window; the zombie socket dies (`__cic_dropSocketForTests`, drop-and-HOLD → no reconnect); a peer WHOISes vjt and witnesses `301 RPL_AWAY`. Asserts the **user-visible** outcome, never an internal timer flag. Scoped run: `1 passed (1.4m)`.
- The three existing away specs only drive explicit `/away` — none covered auto-away or the disconnect path; that gap is why the bug shipped.

## Injectable debounce (the seam the e2e needs)

A real e2e can't wait the 600s production debounce. Per the CLAUDE.md `start_link`-opts pattern: `Session.Server.boot/0` reads `config :grappa, Grappa.Session.Server, auto_away_debounce_ms:` once at boot into `:persistent_term`; `Session.start_session/3` (the single spawn choke point) injects it into the session opts; `do_init/1` stores it on state. **Production sets no config key → byte-identical 600_000 compile default.** The integration env (`config/dev.exs`, `MIX_ENV=dev`) sets it short. An explicit opts key still wins in `do_init` (unit-test seam, alongside `connection_stable_ms` / `autojoin_defer_ms`).

`stale_ms` is left at 60s untouched — foreground push-suppression must stay fresh (`ux-6-l-foreground-push-beep` / `freshness-on-activation`); staleness is induced by starving reports, not shrinking the window.

## Gates

`scripts/check.sh` green: 4932 tests / 50 properties / 8 doctests, 0 failures; Dialyzer passed; credo / sobelow / deps.audit / hex.audit / doctor / wire-types drift / bats 221 all green. No cic `src` change (only `e2e/` + fixture), no new wire token.

Refs #671