### PR TITLE
fix(#677): page the channel directory past 100 + clear its filter on close

### DIFF
--- a/cicchetto/e2e/tests/issue677-directory-pagination.spec.ts
+++ b/cicchetto/e2e/tests/issue677-directory-pagination.spec.ts
@@ -1,0 +1,143 @@
+// #677 — channel directory: pages past page 1, and the search key no
+// longer outlives its input. TWO defects, one pane, verified in a real
+// browser (jsdom is blind to IntersectionObserver + scroll layout):
+//
+//   Defect 1 — the directory never paged past the first 100 rows. The store
+//     dropped `next_cursor` and the pane had no load-more. Assert: scrolling
+//     to the bottom appends a second page → >100 rows actually appear.
+//   Defect 2 — the search key survived the pane unmount (it lives in the
+//     identity-scoped store) while the box remounted empty, so a reopened
+//     directory showed a filtered list with an empty box. Assert: reopening
+//     shows an UNFILTERED list and an EMPTY box (they agree).
+//
+// Why stub GET /directory (page.route) instead of a real LIST: the server
+// already keyset-paginates correctly (proven on origin/main); BOTH defects
+// are pure client wiring, so synthetic pages exercise the exact cursor
+// round-trip + append the fix adds — deterministically. A real Azzurra LIST
+// has thousands of channels but a non-deterministic count; the private
+// testnet only lists a handful of non-empty channels. Neither yields a
+// stable "exactly 100, then >100". page.route is the established idiom here
+// (21 specs); the real backend still serves login + everything else.
+
+import type { Page } from "@playwright/test";
+import { expect, test } from "../fixtures/test";
+import { loginAs, sidebarWindow } from "../fixtures/cicchettoPage";
+import { getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
+
+// LIST_WINDOW_NAME from src/lib/windowKinds.ts. Hardcoded — the e2e
+// tsconfig does not resolve src/ imports; a rename must be mirrored here.
+const LIST_WINDOW_NAME = "$list";
+
+const CAPTURED_AT = "2026-08-02T12:00:00Z";
+
+// A full synthetic page: 100 rows named `#<prefix>-000`..`#<prefix>-099`,
+// descending user_count so the "users" sort order is stable.
+function fullPage(prefix: string, nextCursor: string | null, total: number) {
+  const entries = Array.from({ length: 100 }, (_, i) => ({
+    name: `#${prefix}-${String(i).padStart(3, "0")}`,
+    topic: null,
+    user_count: 1000 - i,
+    featured: false,
+  }));
+  return {
+    entries,
+    next_cursor: nextCursor,
+    total,
+    captured_at: CAPTURED_AT,
+    status: "fresh",
+  };
+}
+
+// Matches GET /networks/<slug>/directory but NOT /directory/refresh (whose
+// pathname ends in /refresh).
+const isDirectoryGet = (url: URL) => url.pathname.endsWith("/directory");
+
+async function openList(page: Page): Promise<void> {
+  await sidebarWindow(page, NETWORK_SLUG, LIST_WINDOW_NAME)
+    .locator(".sidebar-window-btn")
+    .click();
+}
+
+test("#677 defect 1 — the directory pages past 100 rows on scroll", async ({ page }) => {
+  const vjt = getSeededVjt();
+
+  // Stub BEFORE login: page 1 has 100 rows + a next_cursor; the cursor'd
+  // GET returns page 2 (100 more rows, no further cursor).
+  await page.route(isDirectoryGet, async (route) => {
+    if (route.request().method() !== "GET") return route.continue();
+    const url = new URL(route.request().url());
+    const body = url.searchParams.get("cursor")
+      ? fullPage("page2", null, 250)
+      : fullPage("page1", "CURSOR2", 250);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    });
+  });
+
+  await loginAs(page, vjt);
+  await openList(page);
+
+  // Page 1: exactly 100 rows; the page-2 tail row is absent.
+  const rows = page.locator(".directory-row");
+  await expect(rows).toHaveCount(100, { timeout: 10_000 });
+  await expect(page.getByText("#page2-099")).toHaveCount(0);
+
+  // Scroll the load-more sentinel into view → IntersectionObserver fires →
+  // loadMore appends page 2. Rows accumulate to 200 (append, not replace).
+  await page.locator(".directory-sentinel").scrollIntoViewIfNeeded();
+  await expect(rows).toHaveCount(200, { timeout: 10_000 });
+  await expect(page.getByText("#page2-099")).toBeVisible();
+  // Page-1 rows are still present — the append kept them.
+  await expect(page.getByText("#page1-000")).toBeVisible();
+});
+
+test("#677 defect 2 — reopening the directory is unfiltered with an empty box", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+
+  // Unfiltered GET → page 1 (no further pages, to keep the DOM small). A
+  // GET carrying ?q= → a single matching row named after the query.
+  await page.route(isDirectoryGet, async (route) => {
+    if (route.request().method() !== "GET") return route.continue();
+    const url = new URL(route.request().url());
+    const q = url.searchParams.get("q") ?? "";
+    const body = q
+      ? {
+          entries: [{ name: `#match-${q}`, topic: null, user_count: 5, featured: false }],
+          next_cursor: null,
+          total: 1,
+          captured_at: CAPTURED_AT,
+          status: "fresh",
+        }
+      : fullPage("page1", null, 100);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    });
+  });
+
+  await loginAs(page, vjt);
+  await openList(page);
+
+  const search = page.locator(".directory-search");
+  await expect(page.getByText("#page1-000")).toBeVisible({ timeout: 10_000 });
+
+  // Type a filter → server-side re-GET returns only the matching row.
+  await search.fill("special");
+  await expect(page.getByText("#match-special")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("#page1-000")).toHaveCount(0);
+
+  // Close the directory window (✕).
+  await page.locator(".directory-close").click();
+  await expect(page.locator(".directory-pane")).toHaveCount(0, { timeout: 5_000 });
+
+  // Reopen: the box is EMPTY and the list is UNFILTERED — the two agree.
+  await openList(page);
+  await expect(search).toHaveValue("");
+  await expect(page.getByText("#page1-000")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText("#match-special")).toHaveCount(0);
+});

--- a/cicchetto/src/DirectoryPane.tsx
+++ b/cicchetto/src/DirectoryPane.tsx
@@ -1,9 +1,13 @@
-import { type Component, createEffect, createSignal, For, on, Show } from "solid-js";
+import { type Component, createEffect, createSignal, For, on, onCleanup, Show } from "solid-js";
 import { ApiError, type DirectoryEntry, postJoin } from "./lib/api";
 import { token } from "./lib/auth";
 import {
   directoryPage,
+  directorySort,
+  isLoadingMore,
   loadDirectory,
+  loadMore,
+  resetDirectory,
   setQuery,
   setSort,
   triggerRefresh,
@@ -29,15 +33,23 @@ import { MircBody } from "./MircText";
 // .directory-row-join grid in default.css): no horizontal scroll. The
 // close button returns to the previously active window.
 //
-// Data layer: channelDirectory.ts (directoryPage / loadDirectory / setSort /
-// setQuery / triggerRefresh). DirectoryPane owns LOCAL signals for the search
-// text and active sort (to render the controls) but every control change
-// routes through the store verbs so subsequent ping-driven re-GETs use the
-// correct view.
+// Data layer: channelDirectory.ts (directoryPage / loadDirectory / loadMore /
+// resetDirectory / directorySort / isLoadingMore / setSort / setQuery /
+// triggerRefresh). DirectoryPane owns LOCAL signals for the search text and
+// active sort (to render the controls) but every control change routes
+// through the store verbs so subsequent ping-driven re-GETs use the correct
+// view.
+//
+// Pagination (#677): the server keyset-paginates (100/page); the pane drives
+// load-more via a bottom sentinel + IntersectionObserver → loadMore, which
+// APPENDS the next page. Search text is cleared on window close
+// (resetDirectory in onCleanup) so a reopened directory is unfiltered with an
+// empty box; sort is a sticky preference and rehydrates from directorySort.
 //
 // Scroll preservation: the row container tracks scrollTop on scroll. A
-// createEffect on the page signal restores it via queueMicrotask so the
-// viewport stays steady while rows update from a progress ping.
+// createEffect on the page's entry COUNT restores it via queueMicrotask so
+// the viewport stays steady while rows update from a progress ping or an
+// append; a REPLACE that shrinks the list snaps back to the top.
 
 // Pure relative-time formatter. No external deps, exported for unit tests.
 // Thresholds: <60s → "just now", <60m → "Nm ago", <24h → "Nh ago", else "Nd ago".
@@ -157,11 +169,28 @@ const DirectoryRow: Component<DirectoryRowProps> = (props) => {
 
 const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
   const [searchText, setSearchText] = createSignal("");
-  const [activeSort, setActiveSort] = createSignal<"users" | "name">("users");
+  // #677 — the search key is cleared on window close (see the onCleanup /
+  // slug-switch resets below), so searchText always mounts "" and the store
+  // agrees. Sort, by contrast, is a sticky PREFERENCE: rehydrate the toggle
+  // from the store so a reopened pane's label matches the sorted list the
+  // store re-fetches (the drop-page reset would otherwise re-fetch the
+  // stored sort while the toggle showed the local default — a sibling of the
+  // very desync #677 fixes for the filter).
+  const [activeSort, setActiveSort] = createSignal<"users" | "name">(
+    directorySort(props.networkSlug),
+  );
   // Callback-ref so TypeScript accepts potential undefined (element is inside
   // <Show when={page()}> and only rendered once a page is in the store).
   let containerRef: HTMLDivElement | undefined;
   let savedScrollTop = 0;
+  // The slug currently shown — kept in sync by the effect so onCleanup can
+  // reset the right slug without reading props during disposal.
+  let mountedSlug = props.networkSlug;
+  // Tracks the rendered row count across page-signal updates so the scroll
+  // restore can tell an APPEND (grows → keep position) from a top-of-view
+  // REPLACE (shrinks → jump to top; a deep saved scrollTop is meaningless
+  // against the shorter list a ping reset produces). #677 constraint 4.
+  let prevEntryCount = 0;
 
   // Load on mount / slug change. `on` makes networkSlug the sole reactive
   // trigger — reading directoryPage(s) inside does NOT create a directoryPage
@@ -170,20 +199,40 @@ const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
   createEffect(
     on(
       () => props.networkSlug,
-      (s) => {
+      (s, prevS) => {
+        // #677 — an A-$list → B-$list direct switch reuses this component
+        // instance (the Shell <Match> stays true), so onCleanup does NOT
+        // fire for A. Reset A's browse state here so reopening A later starts
+        // fresh + unfiltered, exactly like closing via ✕ / switch-away.
+        if (prevS !== undefined && prevS !== s) resetDirectory(prevS);
+        mountedSlug = s;
+        setActiveSort(directorySort(s));
+        prevEntryCount = directoryPage(s)?.entries.length ?? 0;
         if (directoryPage(s) === undefined) void loadDirectory(s);
       },
     ),
   );
 
-  // Scroll preservation across live re-GETs (progress pings). After the
-  // page signal updates, restore the saved scroll position so the viewport
-  // stays steady while the row list repaints. queueMicrotask defers the
-  // write to after Solid commits DOM updates.
+  // #677 — clear the search key + drop the accumulated pages when the
+  // directory window closes. DirectoryPane lives under Shell's
+  // <Match when={selKind() === "list"}>, so ANY dismissal (the ✕, a
+  // switch-away, bucket-D park redirect, bucket-E close picker) unmounts it
+  // and fires this. A reopened directory is then unfiltered with an empty
+  // box — the box tells the truth.
+  onCleanup(() => resetDirectory(mountedSlug));
+
+  // Scroll preservation across live re-GETs (progress pings) and appends.
+  // After the page signal updates, restore the saved scroll position so the
+  // viewport stays steady while the row list repaints. A REPLACE that
+  // shrinks the list (a ping reset to page 1) invalidates a deep saved
+  // position, so snap back to the top in that case. queueMicrotask defers
+  // the write to after Solid commits DOM updates.
   createEffect(
     on(
-      () => directoryPage(props.networkSlug),
-      () => {
+      () => directoryPage(props.networkSlug)?.entries.length ?? 0,
+      (len) => {
+        if (len < prevEntryCount) savedScrollTop = 0;
+        prevEntryCount = len;
         const el = containerRef;
         if (!el) return;
         queueMicrotask(() => {
@@ -192,6 +241,27 @@ const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
       },
     ),
   );
+
+  // #677 — infinite scroll. A zero-height sentinel sits at the bottom of the
+  // scroll list; when it enters the container's viewport (with a 200px
+  // pre-fetch margin) we ask the store for the next keyset page, which
+  // APPENDS. loadMore self-guards (no next_cursor / already loading), so a
+  // burst of observer fires is harmless. The observer is (re)created on each
+  // sentinel mount — the sentinel is inside <Show when next_cursor>, so it
+  // unmounts once the list is exhausted — and disconnected on pane unmount.
+  let sentinelObserver: IntersectionObserver | undefined;
+  const attachSentinel = (el: HTMLDivElement): void => {
+    sentinelObserver?.disconnect();
+    const root = el.closest(".directory-list");
+    sentinelObserver = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) void loadMore(props.networkSlug);
+      },
+      { root, rootMargin: "200px" },
+    );
+    sentinelObserver.observe(el);
+  };
+  onCleanup(() => sentinelObserver?.disconnect());
 
   const page = () => directoryPage(props.networkSlug);
   const status = () => page()?.status;
@@ -287,6 +357,17 @@ const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
                   {(entry) => <DirectoryRow entry={entry} networkSlug={props.networkSlug} />}
                 </For>
               </ul>
+              {/* #677 — load-more sentinel: present only while the server
+                  reports another page (next_cursor). IntersectionObserver on
+                  it drives loadMore; it unmounts when the list is exhausted. */}
+              <Show when={p().next_cursor !== null}>
+                <div class="directory-sentinel" aria-hidden="true" ref={attachSentinel} />
+              </Show>
+              <Show when={isLoadingMore(props.networkSlug)}>
+                <div class="directory-loading-more muted" role="status">
+                  Loading more…
+                </div>
+              </Show>
             </div>
           </>
         )}

--- a/cicchetto/src/__tests__/DirectoryPane.test.tsx
+++ b/cicchetto/src/__tests__/DirectoryPane.test.tsx
@@ -45,10 +45,22 @@ const { tokenMock } = vi.hoisted(() => ({
   tokenMock: vi.fn<() => string | null>(() => "test-token"),
 }));
 const windowStateByChannelMock = vi.fn<() => Record<string, string>>(() => ({}));
+// #677 — new store verbs the pane consumes. directorySort seeds the sort
+// toggle's rehydration; isLoadingMore drives the sentinel spinner; loadMore
+// is the append verb the IntersectionObserver calls (observer is inert in
+// jsdom — see setupTests); resetDirectory is the on-close filter clear.
+const directorySortMock = vi.fn<(slug: string) => "users" | "name">(() => "users");
+const isLoadingMoreMock = vi.fn<(slug: string) => boolean>(() => false);
+const loadMoreMock = vi.fn<(slug: string) => Promise<void>>(() => Promise.resolve());
+const resetDirectoryMock = vi.fn<(slug: string) => void>(() => {});
 
 vi.mock("../lib/channelDirectory", () => ({
   directoryPage: (slug: string) => directoryPageMock(slug),
+  directorySort: (slug: string) => directorySortMock(slug),
+  isLoadingMore: (slug: string) => isLoadingMoreMock(slug),
   loadDirectory: (slug: string) => loadDirectoryMock(slug),
+  loadMore: (slug: string) => loadMoreMock(slug),
+  resetDirectory: (slug: string) => resetDirectoryMock(slug),
   setSort: (slug: string, sort: "users" | "name") => setSortMock(slug, sort),
   setQuery: (slug: string, q: string) => setQueryMock(slug, q),
   triggerRefresh: (slug: string) => triggerRefreshMock(slug),
@@ -140,6 +152,10 @@ describe("DirectoryPane", () => {
     windowStateByChannelMock.mockReturnValue({});
     setSelectedChannelMock.mockClear();
     closeToPreviousWindowMock.mockClear();
+    directorySortMock.mockReturnValue("users");
+    isLoadingMoreMock.mockReturnValue(false);
+    loadMoreMock.mockClear();
+    resetDirectoryMock.mockClear();
   });
 
   afterEach(() => {
@@ -522,6 +538,58 @@ describe("DirectoryPane", () => {
 
       expect(container.querySelector("textarea")).toBeNull();
       expect(container.querySelector(".compose-box")).toBeNull();
+    });
+  });
+
+  // #677 — the search key is cleared on window close. The pane's local
+  // searchText dies with the unmount; resetDirectory clears the store's
+  // sticky `q` (and drops the cached page) so a reopened directory is
+  // unfiltered with an empty box. Asserted here at the unmount boundary; the
+  // reopen-shows-unfiltered outcome is covered end-to-end in the e2e.
+  describe("clear-filter-on-close (#677)", () => {
+    it("resets the directory store for its slug on unmount", () => {
+      directoryPageMock.mockReturnValue(FRESH_PAGE);
+      const { unmount } = render(() => <DirectoryPane networkSlug={SLUG} />);
+      expect(resetDirectoryMock).not.toHaveBeenCalled();
+      unmount();
+      expect(resetDirectoryMock).toHaveBeenCalledWith(SLUG);
+    });
+  });
+
+  // #677 — sort is a sticky PREFERENCE (unlike the filter). A reopened pane
+  // rehydrates its toggle from the store's persisted sort so the label
+  // matches the order the store re-fetches. Without this, the drop-page
+  // reset would re-fetch by the stored sort while the toggle showed the
+  // local default — a sibling of the filter desync #677 fixes.
+  describe("sort rehydration (#677)", () => {
+    it("initializes the sort toggle from the store's persisted sort", () => {
+      directorySortMock.mockReturnValue("name");
+      directoryPageMock.mockReturnValue(FRESH_PAGE);
+      render(() => <DirectoryPane networkSlug={SLUG} />);
+      expect(screen.getByRole("button", { name: /sort:.*name/i })).toBeInTheDocument();
+    });
+  });
+
+  // #677 — the sentinel renders only while the server reports another page
+  // (next_cursor). Exhausted list → no sentinel (nothing left to observe).
+  describe("load-more sentinel (#677)", () => {
+    it("renders the sentinel when next_cursor is present", () => {
+      directoryPageMock.mockReturnValue({ ...FRESH_PAGE, next_cursor: "CURSOR2" });
+      const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
+      expect(container.querySelector(".directory-sentinel")).not.toBeNull();
+    });
+
+    it("omits the sentinel when next_cursor is null (last page)", () => {
+      directoryPageMock.mockReturnValue({ ...FRESH_PAGE, next_cursor: null });
+      const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
+      expect(container.querySelector(".directory-sentinel")).toBeNull();
+    });
+
+    it("shows the loading-more indicator while a next page is in flight", () => {
+      isLoadingMoreMock.mockReturnValue(true);
+      directoryPageMock.mockReturnValue({ ...FRESH_PAGE, next_cursor: "CURSOR2" });
+      const { container } = render(() => <DirectoryPane networkSlug={SLUG} />);
+      expect(container.querySelector(".directory-loading-more")).not.toBeNull();
     });
   });
 });

--- a/cicchetto/src/lib/channelDirectory.test.ts
+++ b/cicchetto/src/lib/channelDirectory.test.ts
@@ -3,10 +3,13 @@ import * as api from "./api";
 import { setToken } from "./auth";
 import {
   directoryPage,
+  directorySort,
   loadDirectory,
+  loadMore,
   onDirectoryComplete,
   onDirectoryFailed,
   onDirectoryProgress,
+  resetDirectory,
   setQuery,
   setSort,
   triggerRefresh,
@@ -134,5 +137,91 @@ describe("channelDirectory store", () => {
     const spy = vi.spyOn(api, "refreshDirectory");
     await triggerRefresh("freenode");
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  // --- #677 pagination: loadMore appends the next keyset page ---
+
+  describe("loadMore (#677 pagination)", () => {
+    const ROW = (name: string, users: number): api.DirectoryEntry => ({
+      name,
+      topic: null,
+      user_count: users,
+      featured: false,
+    });
+
+    test("appends the next page and threads the stored cursor back", async () => {
+      const spy = vi.spyOn(api, "listDirectory");
+      spy.mockResolvedValueOnce(
+        makePage({ entries: [ROW("#a", 9)], next_cursor: "CUR2", total: 3 }),
+      );
+      await loadDirectory("lm1");
+      spy.mockResolvedValueOnce(makePage({ entries: [ROW("#b", 8)], next_cursor: null, total: 3 }));
+      await loadMore("lm1");
+
+      // The page-1 cursor was fed back to the server verbatim (opaque).
+      expect(spy).toHaveBeenLastCalledWith(
+        TOKEN,
+        "lm1",
+        expect.objectContaining({ cursor: "CUR2" }),
+      );
+      // Rows ACCUMULATED (not replaced), cursor advanced to the new page's.
+      const p = directoryPage("lm1");
+      expect(p?.entries.map((e) => e.name)).toEqual(["#a", "#b"]);
+      expect(p?.next_cursor).toBeNull();
+    });
+
+    test("no-op when next_cursor is null (already at the end)", async () => {
+      const spy = vi
+        .spyOn(api, "listDirectory")
+        .mockResolvedValueOnce(makePage({ total: 1, next_cursor: null }));
+      await loadDirectory("lm2");
+      spy.mockClear();
+      await loadMore("lm2");
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    test("no-op when no page has been loaded yet", async () => {
+      const spy = vi.spyOn(api, "listDirectory");
+      spy.mockClear();
+      await loadMore("lm3");
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    test("no-op when token is null", async () => {
+      const spy = vi
+        .spyOn(api, "listDirectory")
+        .mockResolvedValueOnce(makePage({ total: 5, next_cursor: "CUR2" }));
+      await loadDirectory("lm4");
+      setToken(null);
+      spy.mockClear();
+      await loadMore("lm4");
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- #677 clear-on-close: resetDirectory ---
+
+  describe("resetDirectory (#677 clear-on-close)", () => {
+    test("clears the search key and drops the cached page", async () => {
+      vi.spyOn(api, "listDirectory").mockResolvedValue(makePage({ total: 4, next_cursor: "X" }));
+      await setQuery("rd1", "rust");
+      expect(directoryPage("rd1")).toBeDefined();
+
+      resetDirectory("rd1");
+      // Page dropped → a reopen re-fetches from the top.
+      expect(directoryPage("rd1")).toBeUndefined();
+
+      // q cleared → the reopen GET carries q: "" (unfiltered), NOT "rust".
+      const spy = vi.spyOn(api, "listDirectory").mockResolvedValue(makePage({ total: 4 }));
+      await loadDirectory("rd1");
+      expect(spy).toHaveBeenCalledWith(TOKEN, "rd1", expect.objectContaining({ q: "" }));
+    });
+
+    test("preserves sort as a sticky preference across a reset", async () => {
+      vi.spyOn(api, "listDirectory").mockResolvedValue(makePage({ total: 2 }));
+      await setSort("rd2", "name");
+      resetDirectory("rd2");
+      expect(directorySort("rd2")).toBe("name");
+    });
   });
 });

--- a/cicchetto/src/lib/channelDirectory.ts
+++ b/cicchetto/src/lib/channelDirectory.ts
@@ -20,15 +20,33 @@ type View = { sort: "users" | "name"; q: string };
 // and future divergence (e.g. "failed" surfaces an error toast, "complete"
 // scrolls back to the top) is additive — no call-site changes required.
 //
-// fetchInto is the shared private primitive: fetches page 1 of the current
-// view (sort + q) for the given slug. Pagination / load-more is the pane's
-// concern (task E3); the store always re-fetches from the top on any event.
+// fetchInto is the shared private primitive: fetches page 1 (no cursor) of
+// the current view (sort + q) for the given slug and REPLACES the stored
+// page. Every top-of-view event routes through it — load, sort-change,
+// query-change, and the three server pings — so all of those correctly
+// reset the accumulation back to page 1 (#677 constraint 3).
+//
+// loadMore (#677) is the SEPARATE append primitive: it fetches the NEXT
+// keyset page (cursor = the stored page's next_cursor) and APPENDS its
+// rows. It deliberately does NOT go through fetchInto — routing it there
+// would wipe the accumulated pages the user has scrolled through.
+//
+// Server-ping posture (#677 constraint 2): a progress/complete/failed ping
+// re-GETs page 1 via fetchInto, discarding any accumulated pages. This is
+// the honest behaviour — a ping means a NEW upstream LIST capture landed,
+// so the old pages' keyset cursors belong to a prior snapshot and can't be
+// spliced onto the new one. Reset-to-page-1 beats stitching two captures.
 const exports_ = identityScopedStore((onIdentityChange) => {
   const [pages, setPages] = createSignal<Record<string, api.DirectoryPage>>({});
   const [views, setViews] = createSignal<Record<string, View>>({});
+  // Per-slug load-more in-flight guard. Doubles as the sentinel's spinner
+  // source (isLoadingMore). Prevents a burst of IntersectionObserver fires
+  // from stacking concurrent page-2 GETs. Identity-scoped like the rest.
+  const [loadingMore, setLoadingMore] = createSignal<Record<string, boolean>>({});
 
   onIdentityChange(() => setPages({}));
   onIdentityChange(() => setViews({}));
+  onIdentityChange(() => setLoadingMore({}));
 
   const currentView = (slug: string): View => views()[slug] ?? { sort: "users", q: "" };
 
@@ -41,6 +59,65 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   };
 
   const directoryPage = (slug: string): api.DirectoryPage | undefined => pages()[slug];
+
+  // #677 — the sort a reopened pane should rehydrate its toggle from. Sort
+  // is a sticky PREFERENCE (unlike the search key, which is cleared on
+  // close); the pane reads this so the toggle label matches the sorted list
+  // fetchInto produces on reopen. Defaults to "users".
+  const directorySort = (slug: string): "users" | "name" => currentView(slug).sort;
+
+  // #677 — true while a loadMore for `slug` is in flight (sentinel spinner).
+  const isLoadingMore = (slug: string): boolean => loadingMore()[slug] ?? false;
+
+  // #677 — fetch the NEXT keyset page and APPEND. No-op when: no token, no
+  // page yet (nothing to page from), no next_cursor (already at the end),
+  // or a load is already in flight for this slug. The cursor is opaque —
+  // fed straight back to the server, which encodes sort into it.
+  const loadMore = async (slug: string): Promise<void> => {
+    const t = token();
+    if (!t) return;
+    const current = pages()[slug];
+    if (!current || current.next_cursor === null) return;
+    if (loadingMore()[slug]) return;
+    setLoadingMore((prev) => ({ ...prev, [slug]: true }));
+    try {
+      const view = currentView(slug);
+      const next = await api.listDirectory(t, slug, {
+        sort: view.sort,
+        q: view.q,
+        cursor: current.next_cursor,
+      });
+      // Merge: keep the accumulated entries, append the new page's rows,
+      // and adopt the new page's cursor/total/captured_at/status. Re-read
+      // pages()[slug] inside the setter so a fetchInto that landed while
+      // this GET was in flight isn't clobbered (append only when the base
+      // is still the page we started from).
+      setPages((prev) => {
+        const base = prev[slug];
+        if (!base || base.next_cursor !== current.next_cursor) return prev;
+        return { ...prev, [slug]: { ...next, entries: [...base.entries, ...next.entries] } };
+      });
+    } finally {
+      setLoadingMore((prev) => ({ ...prev, [slug]: false }));
+    }
+  };
+
+  // #677 — reset the per-slug browse state on window close. Clears the
+  // search key (the filter is NOT sticky — vjt's call) and DROPS the cached
+  // page so a reopen re-fetches page 1 fresh + unfiltered (the drop also
+  // discards the accumulated pages, so a reopened directory never inherits a
+  // deep scroll's worth of rows). Sort is preserved as a sticky preference.
+  const resetDirectory = (slug: string): void => {
+    setViews((prev) => ({ ...prev, [slug]: { ...currentView(slug), q: "" } }));
+    setPages((prev) => {
+      const { [slug]: _dropped, ...rest } = prev;
+      return rest;
+    });
+    setLoadingMore((prev) => {
+      const { [slug]: _dropped, ...rest } = prev;
+      return rest;
+    });
+  };
 
   const loadDirectory = (slug: string): Promise<void> => fetchInto(slug);
 
@@ -66,7 +143,11 @@ const exports_ = identityScopedStore((onIdentityChange) => {
 
   return {
     directoryPage,
+    directorySort,
+    isLoadingMore,
     loadDirectory,
+    loadMore,
+    resetDirectory,
     setSort,
     setQuery,
     triggerRefresh,
@@ -77,7 +158,11 @@ const exports_ = identityScopedStore((onIdentityChange) => {
 });
 
 export const directoryPage = exports_.directoryPage;
+export const directorySort = exports_.directorySort;
+export const isLoadingMore = exports_.isLoadingMore;
 export const loadDirectory = exports_.loadDirectory;
+export const loadMore = exports_.loadMore;
+export const resetDirectory = exports_.resetDirectory;
 export const setSort = exports_.setSort;
 export const setQuery = exports_.setQuery;
 export const triggerRefresh = exports_.triggerRefresh;

--- a/cicchetto/src/setupTests.ts
+++ b/cicchetto/src/setupTests.ts
@@ -82,6 +82,27 @@ class InertWebSocket {
   }
 }
 
+// jsdom ships no IntersectionObserver, but DirectoryPane (#677 infinite
+// scroll) constructs one at mount — an undefined global would throw and
+// break every pane render test. An inert stand-in satisfies construction
+// and observe/disconnect without ever firing a callback (jsdom has no
+// layout/scroll to intersect against anyway); the load-more → append
+// behaviour is asserted in the real-browser e2e
+// (issue677-directory-pagination.spec.ts). Production always runs in a
+// browser where IntersectionObserver is a baseline API.
+class InertIntersectionObserver {
+  readonly root: Element | null = null;
+  readonly rootMargin: string = "";
+  readonly thresholds: ReadonlyArray<number> = [];
+  constructor(_cb: unknown, _opts?: unknown) {}
+  observe(_target: Element): void {}
+  unobserve(_target: Element): void {}
+  disconnect(): void {}
+  takeRecords(): unknown[] {
+    return [];
+  }
+}
+
 beforeEach(() => {
   // Fresh in-memory localStorage for every test — no state bleeds between cases.
   vi.stubGlobal("localStorage", makeLocalStorage());
@@ -89,6 +110,8 @@ beforeEach(() => {
   // vi.unstubAllGlobals() in some file's afterEach can't resurrect the
   // real jsdom implementation for the rest of the worker's lifetime.
   vi.stubGlobal("WebSocket", InertWebSocket);
+  // Inert IntersectionObserver — see class comment. jsdom has none.
+  vi.stubGlobal("IntersectionObserver", InertIntersectionObserver);
 });
 
 // Solid testing-library doesn't auto-cleanup like RTL; missing this leaks

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -8537,6 +8537,23 @@ button.home-pane-network-title:hover .home-pane-network-slug {
   padding: 0;
 }
 
+/* #677 — load-more sentinel: a zero-height marker at the bottom of the
+ * scroll list. IntersectionObserver watches it to fetch + append the next
+ * keyset page. Invisible; occupies no vertical space of its own. */
+.directory-sentinel {
+  height: 1px;
+  margin: 0;
+  padding: 0;
+}
+
+/* #677 — brief "Loading more…" line shown while a next-page GET is in
+ * flight (below the last row, inside the scroll list). */
+.directory-loading-more {
+  padding: 0.5rem 1rem;
+  font-size: 0.85em;
+  text-align: center;
+}
+
 .directory-row {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## What & why

Two defects in the channel directory pane (`DirectoryPane` + `channelDirectory` store), one fix window per the issue. Both are pure **client wiring** — the server already keyset-paginates and filters correctly (verified on `origin/main`).

### Defect 1 — never paged past page 1
The store's `fetchInto` never passed a `cursor` and the pane had no load-more (E3 never landed), so a user on a 6585-channel network saw exactly `@default_limit` (100) rows.

- **`loadMore/1`** — new append primitive: GETs the next keyset page (`cursor = stored next_cursor`) and **appends**. Does **not** route through `fetchInto` (which *replaces* page 1 — used by load/sort/query/pings), self-guards (no token / no page / no `next_cursor` / already in-flight).
- **Sentinel + `IntersectionObserver`** in the pane (200px pre-fetch, root = the scroll list); rendered only while `next_cursor` is present.
- **Ping posture (issue constraint 2):** a progress/complete/failed ping still re-GETs page 1 and **discards** the accumulation — a ping is a new upstream LIST capture, so old cursors belong to a prior snapshot; splicing two captures would be wrong. Documented, deliberate.
- **Scroll preservation (constraint 4):** now keys on entry **count** — an append keeps position; a shrinking replace snaps to top.

### Defect 2 — search key outlived its input
`q` lives in the identity-scoped store (survives unmount); the input is a pane-local signal (mounts `""`). Close + reopen → filtered list, empty box.

- **`resetDirectory/1`** clears `q` and drops the cached page (reopen re-fetches fresh + unfiltered; the drop also resets the accumulation). vjt's call: the filter is **not** sticky. Fired from the pane's `onCleanup` — the pane lives under Shell's `<Match when list>`, so **every** dismissal (✕, switch-away, park redirect, close picker) clears it. An A-`$list` → B-`$list` direct switch (no unmount) resets the previous slug via the slug-change effect — same root cause.
- **Sort is a sticky preference** (unlike the filter): the toggle rehydrates from `directorySort/1`, so the drop-page refetch doesn't introduce a sort/label desync. The rejected alternative (sticky **filter** rehydration) is not implemented.

## Tests

- **Unit (vitest):** `channelDirectory` — `loadMore` (append + cursor thread + 4 no-op guards) and `resetDirectory` (clears `q`, drops page, keeps sort); `DirectoryPane` — reset-on-unmount, sort rehydration, sentinel gating. Full suite green (**3833 passed**).
- **e2e delta: +2** (`issue677-directory-pagination.spec.ts`) — stubs `GET /directory` with synthetic pages and asserts the outcomes jsdom can't: **>100 rows appear after scrolling**, and **a reopened directory is unfiltered with an empty box**.
- `setupTests` gains an inert `IntersectionObserver` stub (jsdom ships none; IO is browser-baseline so production needs no feature-detection).

cic-only; no new wire tokens (reuses the existing `next_cursor` / `cursor`).

Refs #677.