### PR TITLE
docs: bring DERIVED_SOURCE_ADDRESSES up to what #543 actually shipped

### DIFF
--- a/docs/DERIVED_SOURCE_ADDRESSES.md
+++ b/docs/DERIVED_SOURCE_ADDRESSES.md
@@ -1,7 +1,8 @@
 # Per-client derived source addresses
 
 **Audience:** IRC network operators and staff evaluating whether to let a grappa instance connect to their network.
-> **Status: design, not yet shipped.** The kernel behaviour and the cost figures below are measured on a real host, but the feature itself does not exist in any release. It is tracked in [#454](https://github.com/vjt/grappa-irc/issues/454) (the derivation and its rulings) and [#543](https://github.com/vjt/grappa-irc/issues/543) (the operator-facing addressing mode and the per-platform plumbing). Do not read any of this as a description of current behaviour, and do not hand it to a network as a promise: when the code lands, this banner comes off in the same change, and not before.
+
+> **Status: shipped, opt-in, and narrower than the design this document used to describe.** The derivation, the addressing mode that selects it, and the per-platform plumbing landed with [#543](https://github.com/vjt/grappa-irc/issues/543) (closed). It is **off by default** — an instance runs the pre-existing pool mode unless an operator switches it on. [#454](https://github.com/vjt/grappa-irc/issues/454), which framed the original hierarchical `/48` design, is still open and its title no longer matches what exists. Two things this document previously promised are **not** shipped, and are called out where they belong: the hierarchical ban-escalation ladder (the derivation is flat) and the blast-radius report before a prefix ban.
 
 ## The problem this solves
 
@@ -14,41 +15,66 @@ Both problems have the same root: the network cannot tell the bouncer's users ap
 
 ## The mechanism
 
-The instance is given a routed IPv6 block — a `/72` — and **derives one address inside it per client**, deterministically, from that client's own real source address:
+The instance is given a routed IPv6 block — a **`/80`** — and **derives one address inside it per client network**, deterministically, from that client's own real source address:
 
 ```
-derived = block_prefix || H_key(client /32) || H_key(client /48) || H_key(client /64)
-                          24 bits             24 bits             8 bits
+derived = block_prefix (80 bits) || first 48 bits of SHA-256("grappa/source-mapping/v1" || client_key)
+
+client_key = the client's /64   (IPv6 — interface id dropped)
+             the client's /32   (IPv4 — the whole address)
 ```
 
-`H_key` is a keyed hash with an instance-level key that does not rotate. For IPv4 clients the same three-level shape applies to `/16`, `/24`, and the host address, and addresses are canonicalized first so that a v4-mapped-in-v6 client cannot pick up a second identity by changing how it connects.
+The hash is **not keyed**. There is no secret and no key management: the mapping is client-prefix → our own block, not a privacy secret, so the only property that matters is a near-uniform spread over the host bits, and a plain SHA-256 gives that. The `"grappa/source-mapping/v1"` string is domain separation — a namespace label, so this derivation can never alias some other SHA-256 use over the same bytes — not a secret.
 
-Three properties follow, and they are the whole point:
+The interface id is deliberately ignored because RFC 8981 rotates it (privacy extensions) roughly daily; hashing the full 128 bits would silently expire every ban you set.
 
-- **Stable.** The same client always arrives as the same address, so a ban you set stays effective and a throttle key keeps counting the right person. The hash deliberately ignores the interface ID, because clients rotate temporary addresses (RFC 8981) roughly daily; hashing the full 128 bits would silently expire every ban you set.
+For a `/80` the host part is 48 bits, so by the birthday bound the first collision is expected around `2^24 ≈ 16.7M` distinct client prefixes. Real instances map thousands, not millions.
+
+Two properties follow, and they are what the feature buys:
+
+- **Stable.** The same client network always arrives as the same address, so a ban you set stays effective and a throttle key keeps counting the right person, across reconnects and across privacy-extension rotations.
 - **Deterministic from the client's real address.** A user cannot shed their derived address without changing the address you would have banned anyway. That is the anti-evasion half: the bouncer stops laundering identity.
-- **Hierarchical, so escalation works at the granularity you already use.** The high bits come from the client's upstream allocation, the low bits from the client itself.
+
+### The ban ladder is two rungs, not four
 
 | ban this | catches |
 | --- | --- |
-| the derived `/128` | one client |
-| the derived `/120` | one customer site (the client's `/48`) |
-| the derived `/96` | one upstream allocation (the client's `/32`) |
-| the whole `/72` | every derived session on the instance |
+| the derived `/128` | one client network — one `/64` (IPv6) or one address (IPv4) |
+| the whole `/80` | every derived session on the instance |
 
-That last row is the honest one: banning the block is always available, and it is exactly as blunt as banning a bouncer is today. The other three rows are what the feature adds.
+**There is nothing in between, and that is a real limitation.** The derivation is *flat*: the whole client key goes through one hash and lands anywhere in the 48 host bits, so two `/64`s inside the same customer `/48` — or the same upstream `/32` — produce two completely unrelated derived addresses. Aggregating a range of derived addresses catches nothing meaningful.
+
+An earlier version of this document described a hierarchical derivation where the high bits came from the client's upstream allocation and offered `/120` and `/96` escalation rungs. **That design was not built.** Consequences, stated plainly:
+
+- A client with a large delegation (`/56`, `/48`) can hop `/64`s and collect a fresh derived address per hop, and there is **no intermediate prefix that covers the delegation**. Against a determined evader with a routed `/48`, per-address bans are a treadmill; the only backstop is banning the `/80`, which is exactly as blunt as banning a bouncer is today.
+- Conversely, the flat mapping leaks *less*: derived addresses that share high bits tell you nothing about the clients, because they share nothing but our block.
+
+If the escalation ladder matters to your network, it is fair to say so — it is a design that can be revisited, but do not plan around it existing today.
 
 ## What it does not do, stated plainly
 
-- **It is not a privacy or cloaking mechanism, and it is not sold as one.** Derived addresses that share high bits do tell you "same upstream allocation" — that is the escalation feature working as designed, not a leak. Cloaking, if a network wants it, is the network's job and is applied on top.
-- **Derived addresses have no PTR.** Reverse DNS is per-address and this space is combinatorial, so anything that expects forward-confirmed reverse DNS from a derived source will fail. Curated, named addresses — the ones an instance reserves for specific users — keep their PTR and their FCrDNS. If your network requires FCrDNS, you get the curated block, not the derived one.
-- **A client with a large delegation can still move.** An ISP that delegates a `/56` or a `/48` to the customer lets that customer hop `/64`s and collect a fresh derived address each time. No choice of hash input prevents this. The answer is the escalation ladder above: ban the derived `/120` and the whole delegation is covered.
-- **IPv4 behind CGNAT collapses, and that limit is real.** Thousands of subscribers sharing one carrier address hash to one derived address, so for those clients the collateral problem is reduced to the same granularity your own IPv4 bans already have — no worse than today, but no better either. The full benefit is an IPv6 benefit.
-- **It does not make the operator trustworthy.** It makes the operator's users *separable*, which is the part you can verify from the outside: ban one derived address, observe that exactly one client loses its connection.
+- **It is not a privacy or cloaking mechanism, and it is not sold as one.** Cloaking, if a network wants it, is the network's job and is applied on top.
+- **Derived addresses have no PTR.** Reverse DNS is per-address and this space is combinatorial, so anything that expects forward-confirmed reverse DNS from a derived source will fail. Reserved, named addresses — the ones an instance grants to specific users — live outside the derived block, keep their PTR and their FCrDNS, and win over derivation. If your network requires FCrDNS, you get the reserved addresses, not the derived ones.
+- **IPv4 behind CGNAT collapses, and that limit is real.** Thousands of subscribers sharing one carrier address hash to one derived address, so for those clients the collateral problem is reduced to the same granularity your own IPv4 bans already have — no worse than today, but no better either. This is intended: clients sharing an upstream vantage point share an egress.
+- **The derived address is always IPv6, so this only applies to IPv6-reachable networks.** The connect path binds the derived source and then resolves the upstream in the *same* family; a network reachable only over IPv4 fails the bind with a source-family mismatch rather than silently falling back. An instance connecting to a v4-only network uses a different addressing mode.
+- **The blast-radius report is not implemented.** The previous version of this document placed a requirement on ourselves: any interface offering a prefix-level ban must report how many live sessions the candidate prefix would hit *before* it is set. That interface does not exist yet. The ingredient does: every session that binds a derived source registers under it in a Registry, and `Session.live_derived_sources/0` returns the live set on a node as a pure ETS read. The scan on top of it is still to be written. Since the ladder above only has two rungs, the missing report is currently less load-bearing than it was in the original design — but it is missing, and this document is not going to pretend otherwise.
+- **It does not make the operator trustworthy.** It makes the operator's users *separable*, which is the part you can verify from the outside: ban one derived address, observe that exactly one client network loses its connection.
 
-## Reservations
+## Reservations, and what happens when derivation cannot run
 
 Named addresses (vanity reverse DNS, per-user assignments) are granted explicitly and **win over derivation**. They live outside the derived block so that a derivation can never land on an address reserved for someone else — two users sharing an address is precisely the collateral this feature exists to remove. In this mode there is **no random pool**: a user either holds a reservation or arrives on their derived address. Nobody gets an address that was somebody else's yesterday.
+
+An address pinned by the instance's admin for a specific network overrides everything, including derivation. That is an operator decision, visible to the operator, and it is the one way a session in this mode leaves the block.
+
+When derivation *cannot* produce an address, the session is **held, not silently egressed from a shared source**. That is the load-bearing invariant of the whole feature, and it is enforced at every failure point:
+
+| situation | outcome |
+| --- | --- |
+| the host cannot bind addresses in the block at all | session held (`mode2_disarmed`) |
+| no block configured, or it is unparseable | session held (`no_static_prefix`) |
+| the client's own address was never observed | session held (`no_client_source`) |
+
+A held session is parked with its reason and reported as failed. It does not connect from the instance's default address, which would put an unseparated user on your network — the exact thing the feature exists to prevent.
 
 ## Operational cost, measured
 
@@ -61,12 +87,13 @@ Reference figures from a FreeBSD 14.3 host, 5000 concurrent derived addresses:
 | outbound `connect` latency with 5000 present | 5-6ms, indistinguishable from baseline |
 | kernel memory for 5000 | ~4MB, fully reclaimed on removal |
 
-The size of the address *space* is not the cost; the number of *live sessions* is. Linux needs no per-session work at all (the whole prefix is made locally deliverable with AnyIP, plus non-local bind for the outbound half). FreeBSD has no AnyIP equivalent — measured, including the non-local bind option, which fixes the bind and then leaves the return path broken — so each live derived address is configured on the loopback for the lifetime of the session and swept on restart.
+These were measured against a larger block than the `/80` that shipped; they hold as orders of magnitude because **the size of the address *space* is not the cost — the number of *live sessions* is.**
+
+- **Linux** needs no per-session work at all: an AnyIP local route makes the whole block locally deliverable and `net.ipv6.ip_nonlocal_bind=1` covers the outbound half, so binding a derived address is a no-op. Both prerequisites are probed at boot, and a host missing either refuses to arm rather than arming and failing every session.
+- **FreeBSD** has no AnyIP equivalent — measured, including the non-local bind option, which fixes the bind and then leaves the return path broken — so each live derived address is configured as a `/128` alias on the loopback for the lifetime of the session, reference-counted across sessions sharing it, and reconciled against the interface at boot. The privilege boundary is a purpose-built wrapper that hard-codes the interface and the prefix length and refuses any address outside the configured block; it is not an unconstrained `sudo ifconfig`. At boot the wrapper is exercised for real — it adds and removes a canary inside the block — so a substrate that cannot actually alias (a non-VNET jail, a drifted prefix) refuses to arm with a concrete reason.
 
 ## What we ask of a network, and what we offer
 
 We are not asking for an exemption. We are asking that the exemption you might otherwise have to grant a bouncer — "please do not ban this address, there are innocents behind it" — becomes unnecessary, because you can ban the guilty client and only the guilty client.
 
-In return we expect to be held to it: if a derived address misbehaves, ban it and it stays banned; if the escalation is not doing what this document says, that is a bug and we want the report.
-
-One requirement we are placing on ourselves, worth stating because it protects your users too: any interface that offers a prefix-level ban has to report **how many live sessions the candidate prefix would hit before it is set**. Escalation power without a blast-radius number is a footgun for everyone.
+In return we expect to be held to it: if a derived address misbehaves, ban it and it stays banned; if what this document describes is not what you observe, that is a bug and we want the report.


### PR DESCRIPTION
`docs/DERIVED_SOURCE_ADDRESSES.md` is the document we hand to a network operator who is deciding whether to let a grappa instance connect. It still carried a **"Status: design, not yet shipped"** banner and described a derivation that is not the one in the tree. Everything below was measured on `origin/main` `5a976978`, not recalled.

## What was wrong

| the doc said | the tree does |
| --- | --- |
| block is a `/72` | `::cb::/80` (`vhosts/source_mapping.ex`, the alias adapters, the sudo wrapper) |
| `H_key` — keyed hash, instance key that does not rotate | unkeyed `sha256("grappa/source-mapping/v1" <> key)`; the tag is domain separation, explicitly NOT a secret |
| hierarchical: `H(client /32) ‖ H(client /48) ‖ H(client /64)` | flat: the key is the client's whole `/64` (v6) or `/32` (v4), and all 48 host bits come off one digest |
| ban `/120` = one customer site, ban `/96` = one upstream allocation | **neither rung exists.** A flat hash destroys locality: two `/64`s in the same customer `/48` land at unrelated addresses |
| v4 hashes `/16` + `/24` + host | v4 keys on the full `/32` |
| "any interface that offers a prefix-level ban has to report the blast radius first" — stated as a self-imposed requirement | not implemented. `prefix_impact` appears only in a comment; `Session.live_derived_sources/0` exists as the live-holder source, the scan on top of it does not |
| feature does not exist in any release | shipped and opt-in (`addressing.mode = :static_mapping_with_reservations`, default is still the pool mode) |

## What the rewrite does

- Replaces the banner with an honest status: shipped, opt-in, **narrower than what this document used to promise**, and names the two promises that are not kept.
- Rewrites the mechanism section around the real derivation, including why the hash is unkeyed and why the interface id is dropped.
- Replaces the four-rung ban table with the two rungs that exist, and states the loss without softening it: against an evader with a routed `/48` there is no intermediate prefix, so per-address bans are a treadmill and the only backstop is the `/80`. If a network needs the ladder, better it says so now than discovers it after a ban does nothing.
- Adds the hold semantics, which are the load-bearing invariant of the whole feature and were entirely absent: a session that cannot produce or bind its derived address is **parked with a reason**, never egressed from a shared source. Table of the three hold reasons.
- Adds the IPv6-only constraint: the derived source is v6 and the connect path resolves the upstream in the same family, so a v4-only network fails the bind rather than falling back.
- Describes reservations, the absolute admin per-network pin, and the FreeBSD (`/128` alias on `lo0` through the sudoers-scoped wrapper, ref-counted, boot reconcile, real add/delete canary at arm time) vs Linux (AnyIP + `ip_nonlocal_bind`, per-address no-op) plumbing as built.
- Keeps the measured cost table, with a note that it was taken against a larger block and holds as an order of magnitude — the cost scales with live sessions, not with the size of the space.

## Note on the issues

- #543 is **closed** — it is the change that shipped this.
- #454 is still **open** and its title says `/48`, which is neither the block nor the derivation that exists. Worth retitling or closing separately; this PR does not touch it.