### PR TITLE
feat(#648): clickable #channel in scrollback → confirm → join

### DIFF
--- a/cicchetto/e2e/tests/issue648-clickable-channel.spec.ts
+++ b/cicchetto/e2e/tests/issue648-clickable-channel.spec.ts
@@ -1,0 +1,137 @@
+// #648 — a `#channel` in a scrollback message body is a click-to-join
+// affordance.
+//
+// Two user-visible outcomes, both proven end-to-end against the live
+// bahamut-test leaf:
+//   1. NOT joined → tap the `#channel` → the shared ConfirmModal opens
+//      ("Join #channel?") → confirm → grappa JOINs it and cic switches to
+//      the new window (the tab goes `.selected`).
+//   2. ALREADY joined → tap → cic switches straight to that window with NO
+//      modal (asking to join a window that's already open is noise, #648).
+//
+// The token is rendered by `MircBody` (the shared mIRC formatter) as an
+// inline `.channel-clickable` <button> — the SAME single-pass tokenizer that
+// linkifies URLs (see linkify.ts) — so this exercises the real render path a
+// peer's PRIVMSG takes, not a synthetic DOM. Structural sibling of
+// cp13-s10-mirc-bold (peer PRIVMSG → MircBody inline element) crossed with
+// issue195-leave-confirm-modal (the shared ConfirmModal drive + the
+// count-0 "no modal" negative assertion).
+
+import { test, expect } from "../fixtures/test";
+import {
+  confirmModal,
+  confirmModalBody,
+  confirmModalYes,
+  loginAs,
+  scrollbackLine,
+  selectChannel,
+  sidebarWindow,
+} from "../fixtures/cicchettoPage";
+import { joinChannel, partChannel } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+// vjt is autojoined here (seedData.AUTOJOIN_CHANNELS) — the window the peer
+// posts the `#channel`-bearing PRIVMSG into.
+const HOST_CHANNEL = "#bofh";
+
+// A fresh peer nick per run — a static nick rotates to `<nick>1` on a 433
+// collision under the shared leaf, and the join matcher waits on the
+// REQUESTED nick, so a rotated static nick hangs (e2e-peer distinct-nick trap).
+const peerNick = () => `p648-${crypto.randomUUID().slice(0, 6)}`;
+
+// Lowercase channel names → raw == ASCII-folded, so the sidebar window key
+// (folded, "the folded key IS the display") equals the spelling we assert on.
+// The raw-vs-folded casing split is pinned separately by the channelJoin unit
+// test (`#Sniffo`); the e2e proves the user-visible wiring.
+const freshChannel = (label: string) => `#i648${label}-${crypto.randomUUID().slice(0, 6)}`;
+
+// Cheapest "live WS + members_seeded processed" signal (cp13-s10): the members
+// pane rendering our own nick proves the per-channel subscription is live, so a
+// following peer PRIVMSG broadcast isn't fastlaned into the void.
+const MEMBERS_PANE_SELF = { hasText: NETWORK_NICK };
+
+test("a #channel in scrollback is clickable → confirm → joins and switches (#648)", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  const target = freshChannel("join");
+
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, HOST_CHANNEL, { awaitWsReady: false });
+  await expect(page.locator(".members-pane li", MEMBERS_PANE_SELF)).toBeVisible({
+    timeout: 10_000,
+  });
+
+  const peer = await IrcPeer.connect({ nick: peerNick() });
+  try {
+    await peer.join(HOST_CHANNEL);
+    peer.privmsg(HOST_CHANNEL, `come join ${target} now`);
+
+    // The token renders as a clickable button inside the privmsg body.
+    const channelBtn = scrollbackLine(page, "privmsg", target).locator(".channel-clickable");
+    await expect(channelBtn).toHaveText(target, { timeout: 10_000 });
+
+    await channelBtn.click();
+
+    // Confirm modal names the RAW channel; the affirmative button reads "Join".
+    await expect(confirmModal(page)).toBeVisible();
+    await expect(confirmModalBody(page)).toHaveText(`Join ${target}?`);
+
+    await confirmModalYes(page);
+
+    // Joined AND switched: the new window's tab is now the selected one, and
+    // the modal is gone (count-0, not not-visible — an absent node passes
+    // toBeVisible for the wrong reason).
+    await expect(sidebarWindow(page, NETWORK_SLUG, target)).toHaveClass(/selected/, {
+      timeout: 10_000,
+    });
+    await expect(confirmModal(page)).toHaveCount(0);
+  } finally {
+    await peer.disconnect("done");
+    // Fresh channel — restore state (teardown reseeds/restores autojoin too,
+    // but this keeps the leaf clean; partChannel tolerates a 404).
+    await partChannel(vjt.token, NETWORK_SLUG, target);
+  }
+});
+
+test("clicking a #channel we're already in switches to it with NO modal (#648)", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  const already = freshChannel("have");
+
+  // Pre-join BEFORE login so window_states carries it as "joined" once the WS
+  // hydrates — the already-joined branch's source of truth.
+  await joinChannel(vjt.token, NETWORK_SLUG, already);
+
+  await loginAs(page, vjt);
+  // Prove the pre-joined window is live, then focus a DIFFERENT window so the
+  // switch is observable.
+  await selectChannel(page, NETWORK_SLUG, already, { ownNick: NETWORK_NICK });
+  await selectChannel(page, NETWORK_SLUG, HOST_CHANNEL, { awaitWsReady: false });
+  await expect(page.locator(".members-pane li", MEMBERS_PANE_SELF)).toBeVisible({
+    timeout: 10_000,
+  });
+
+  const peer = await IrcPeer.connect({ nick: peerNick() });
+  try {
+    await peer.join(HOST_CHANNEL);
+    peer.privmsg(HOST_CHANNEL, `see you in ${already}`);
+
+    const channelBtn = scrollbackLine(page, "privmsg", already).locator(".channel-clickable");
+    await expect(channelBtn).toHaveText(already, { timeout: 10_000 });
+
+    await channelBtn.click();
+
+    // Switched straight to the already-joined window, and NO confirm modal
+    // ever appeared.
+    await expect(sidebarWindow(page, NETWORK_SLUG, already)).toHaveClass(/selected/, {
+      timeout: 10_000,
+    });
+    await expect(confirmModal(page)).toHaveCount(0);
+  } finally {
+    await peer.disconnect("done");
+    await partChannel(vjt.token, NETWORK_SLUG, already);
+  }
+});

--- a/cicchetto/src/MircText.tsx
+++ b/cicchetto/src/MircText.tsx
@@ -83,13 +83,40 @@ const renderEmphasis = (text: string): JSX.Element => (
   </For>
 );
 
+// #648 — a linkify `channel` segment (`#sniffo`) renders as a click-to-join
+// affordance, but ONLY on surfaces that wire `onChannelClick` (scrollback
+// message bodies). Everywhere else (topic bar, whois cards, /list, service
+// modals) it degrades to plain text — the identical posture a url segment
+// takes on a non-tappable surface. A channel is ALWAYS exempt from the
+// textual-emphasis pass (like a url), so `#foo_bar_baz` never has its
+// underscores eaten, on ANY surface. Rendered as a <button> — not a styled
+// span — so it inherits keyboard focus + activation for free, mirroring the
+// `.nick-clickable` sender affordance (ScrollbackPane #354) and satisfying
+// biome's a11y rules without a manual keydown handler.
+const renderChannel = (
+  channel: string,
+  onChannelClick: ((channel: string) => void) | undefined,
+): JSX.Element => {
+  if (!onChannelClick) return channel;
+  return (
+    <button type="button" class="channel-clickable" onClick={() => onChannelClick(channel)}>
+      {channel}
+    </button>
+  );
+};
+
 // CP13 S10: render an IRC body string with mIRC formatting expanded into
 // per-run <span> elements. Plain text (no control chars) collapses into a
 // single Run and renders as one <span>; the no-formatting fast path is
 // the common case so this stays cheap. Each Run gets a class for each
 // active toggle attribute + inline style for fg/bg colors (the palette is
 // 16 fixed values — we don't generate per-color CSS classes).
-const renderRun = (run: Run, linkPolicy: LinkPolicy, emphasis: boolean): JSX.Element => {
+const renderRun = (
+  run: Run,
+  linkPolicy: LinkPolicy,
+  emphasis: boolean,
+  onChannelClick: ((channel: string) => void) | undefined,
+): JSX.Element => {
   const style: Record<string, string> = {};
   // Reverse swaps fg/bg. mIRC reverses the rendered colors AND falls back
   // to the terminal default when fg/bg aren't set, but in a web context
@@ -127,7 +154,10 @@ const renderRun = (run: Run, linkPolicy: LinkPolicy, emphasis: boolean): JSX.Ele
     >
       <For each={segments}>
         {(seg, i) => {
-          if (seg.type !== "url") return emphasis ? renderEmphasis(seg.value) : seg.value;
+          if (seg.type === "text") return emphasis ? renderEmphasis(seg.value) : seg.value;
+          // #648 — channel segment: click-to-join affordance (scrollback) or
+          // plain text (elsewhere). Structurally exempt from emphasis, like url.
+          if (seg.type === "channel") return renderChannel(seg.value, onChannelClick);
           // Media-link cluster (2026-06-11): same-origin media URLs get
           // a click intercept → in-app viewer modal (lib/mediaViewer),
           // because in-PWA-scope links navigate the iOS standalone
@@ -246,6 +276,13 @@ export const MircBody: Component<{
   // generated surfaces leave it off. Like linkPolicy, a per-surface flag
   // is inherently static — pass a stable literal, not a reactive signal.
   emphasis?: boolean;
+  // #648 — opt in to the click-to-join channel affordance. ONLY the
+  // scrollback message-body surfaces (privmsg / notice / action) pass this;
+  // when absent, `#channel` segments render as plain text (see
+  // renderChannel). The handler receives the RAW, display-cased channel
+  // (`#Sniffo`); the callee folds for keys. Same stable-value contract as
+  // linkPolicy / emphasis — a per-surface handler, not a reactive signal.
+  onChannelClick?: (channel: string) => void;
 }> = (props) => {
   const runs = (): Run[] => parseMircFormat(props.body);
   // Default "navigate" is the genuine config default — correct
@@ -259,7 +296,14 @@ export const MircBody: Component<{
   // documented so a future reactive caller isn't surprised by a stale one.
   return (
     <For each={runs()}>
-      {(run) => renderRun(run, props.linkPolicy ?? "navigate", props.emphasis ?? false)}
+      {(run) =>
+        renderRun(
+          run,
+          props.linkPolicy ?? "navigate",
+          props.emphasis ?? false,
+          props.onChannelClick,
+        )
+      }
     </For>
   );
 };

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -13,6 +13,7 @@ import {
 import LusersCard from "./LusersCard";
 import { isContentKind, ownNickForNetwork, postJoin, type ScrollbackMessage } from "./lib/api";
 import { token } from "./lib/auth";
+import { confirmJoinChannel } from "./lib/channelJoin";
 import { channelKey, decodeChannelKey } from "./lib/channelKey";
 import { type TopicJoinLine, topicByChannel, topicJoinLine } from "./lib/channelTopic";
 import { isDocumentVisible } from "./lib/documentVisibility";
@@ -610,6 +611,16 @@ const renderNumeric = (raw: NumericEvent): JSX.Element => {
 };
 
 const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element => {
+  // #648 — click-to-join affordance for a `#channel` in a CONTENT body. Passed
+  // ONLY to the privmsg / notice / action MircBody calls below — the same set
+  // the `.nick-clickable` sender affordance covers (#354), and the "user-typed
+  // text" surfaces (they pass `emphasis`). Presence/topic/raw-event lines and
+  // out-of-scope surfaces (topic bar, whois, /list) get no handler, so their
+  // `#channel` segments render as plain text. `confirmJoinChannel` owns the
+  // confirm-or-switch decision; here we only supply the network + raw channel.
+  const onChannelClick = (channel: string): void =>
+    confirmJoinChannel(handlers.networkSlug, channel);
+
   // UX-5 bucket BC2 + #25: per-message sender prefix glyph (@/%/+).
   //
   // For a CONTENT row (privmsg/action/notice) the SENDER's glyph is the
@@ -709,7 +720,7 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
         <>
           {senderSpan("<", ">", msg.sender)}{" "}
           <span class="scrollback-body">
-            <MircBody body={msg.body ?? ""} emphasis />
+            <MircBody body={msg.body ?? ""} emphasis onChannelClick={onChannelClick} />
           </span>
         </>
       );
@@ -777,7 +788,7 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
         <>
           {senderSpan("-", "-", msg.sender)}{" "}
           <span class="scrollback-body">
-            <MircBody body={msg.body ?? ""} emphasis />
+            <MircBody body={msg.body ?? ""} emphasis onChannelClick={onChannelClick} />
           </span>
         </>
       );
@@ -785,7 +796,8 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
     case "action":
       return (
         <span class="scrollback-body">
-          * {bareSenderSpan(msg.sender)} <MircBody body={stripCtcpAction(msg.body)} emphasis />
+          * {bareSenderSpan(msg.sender)}{" "}
+          <MircBody body={stripCtcpAction(msg.body)} emphasis onChannelClick={onChannelClick} />
         </span>
       );
     case "join":

--- a/cicchetto/src/__tests__/MircText.test.tsx
+++ b/cicchetto/src/__tests__/MircText.test.tsx
@@ -195,3 +195,45 @@ describe("MircText textual emphasis markers (#455)", () => {
     });
   });
 });
+
+// #648 — a `#channel` linkify segment renders as a click-to-join affordance,
+// but ONLY on surfaces that pass `onChannelClick` (scrollback). Everywhere
+// else it degrades to plain text — exactly how a url segment renders on a
+// non-tappable surface. The crux is the emphasis exclusion: a channel token
+// MUST be exempt from the textual-emphasis pass the same way a url is, or
+// `#foo_bar_baz` gets its underscores eaten.
+describe("MircText channel affordance (#648)", () => {
+  it("renders a #channel as a .channel-clickable button; clicking calls onChannelClick with the RAW channel", () => {
+    const spy = vi.fn();
+    const { container } = render(() => (
+      <MircBody body="join #Sniffo now" emphasis onChannelClick={spy} />
+    ));
+    const btn = container.querySelector(".channel-clickable") as HTMLButtonElement;
+    expect(btn).not.toBeNull();
+    // display-cased, raw (keys fold downstream; the affordance shows what
+    // the sender typed).
+    expect(btn.textContent).toBe("#Sniffo");
+    btn.click();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith("#Sniffo");
+  });
+
+  it("excludes a channel from the emphasis pass — #foo_bar_baz keeps its underscores (THE TRAP)", () => {
+    const { container } = render(() => (
+      <MircBody body="#foo_bar_baz" emphasis onChannelClick={vi.fn()} />
+    ));
+    // The emphasis pass would have italic/underline-wrapped `_bar_`; a
+    // channel segment must never reach it.
+    expect(container.querySelector(".scrollback-mirc-underline")).toBeNull();
+    expect(container.querySelector(".scrollback-mirc-italic")).toBeNull();
+    const btn = container.querySelector(".channel-clickable") as HTMLButtonElement;
+    expect(btn?.textContent).toBe("#foo_bar_baz");
+    expect(container.textContent).toBe("#foo_bar_baz");
+  });
+
+  it("renders a channel as PLAIN TEXT (no button) on a surface WITHOUT onChannelClick", () => {
+    const { container } = render(() => <MircBody body="join #chan" emphasis />);
+    expect(container.querySelector(".channel-clickable")).toBeNull();
+    expect(container.textContent).toBe("join #chan");
+  });
+});

--- a/cicchetto/src/__tests__/channelJoin.test.ts
+++ b/cicchetto/src/__tests__/channelJoin.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { canonicalChannel, channelKey } from "../lib/channelKey";
+import { acceptConfirm, confirmRequest, dismissConfirm } from "../lib/confirmDialog";
+
+// #648 — confirmJoinChannel is the verb behind a click-to-join `#channel`
+// affordance in scrollback. It REUSES the same join primitive as compose.ts
+// `/join` and DirectoryPane row taps — postJoin (the one REST/socket call) +
+// setSelectedChannel (client-side focus) — and the server-owned
+// window_states map for the already-joined test. No new socket call, no
+// parallel join path.
+//
+// Boundaries mocked (api.postJoin, auth.token, selection.setSelectedChannel,
+// windowState.windowStateByChannel); the REAL confirmDialog store drives the
+// modal flow (requestConfirm → acceptConfirm), and the REAL channelKey /
+// canonicalChannel fold — same "production key builder" posture as
+// DirectoryPane.test.tsx.
+
+const postJoinMock = vi.fn<
+  (t: string, slug: string, name: string, key: string | null) => Promise<void>
+>(() => Promise.resolve());
+const { tokenMock } = vi.hoisted(() => ({
+  tokenMock: vi.fn<() => string | null>(() => "tok"),
+}));
+const setSelectedChannelMock = vi.fn();
+const windowStateByChannelMock = vi.fn<() => Record<string, string>>(() => ({}));
+
+vi.mock("../lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/api")>();
+  return {
+    ...actual,
+    postJoin: (t: string, slug: string, name: string, key: string | null) =>
+      postJoinMock(t, slug, name, key),
+  };
+});
+
+vi.mock("../lib/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/auth")>();
+  return { ...actual, token: () => tokenMock() };
+});
+
+vi.mock("../lib/selection", () => ({
+  setSelectedChannel: (...args: unknown[]) => setSelectedChannelMock(...args),
+}));
+
+vi.mock("../lib/windowState", () => ({
+  windowStateByChannel: () => windowStateByChannelMock(),
+}));
+
+const SLUG = "azzurra";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  windowStateByChannelMock.mockReturnValue({});
+  tokenMock.mockReturnValue("tok");
+  dismissConfirm();
+});
+
+describe("confirmJoinChannel — already joined (#648)", () => {
+  it("switches straight to the window with NO confirm and NO join (asking to join an open window is noise)", async () => {
+    windowStateByChannelMock.mockReturnValue({
+      [channelKey(SLUG, "#Sniffo")]: "joined",
+    });
+    const { confirmJoinChannel } = await import("../lib/channelJoin");
+    confirmJoinChannel(SLUG, "#Sniffo");
+
+    expect(confirmRequest()).toBeNull();
+    expect(postJoinMock).not.toHaveBeenCalled();
+    // Focus lands on the FOLDED key (window_states + selection are keyed
+    // folded, #510) — mixed-case would target a phantom window.
+    expect(setSelectedChannelMock).toHaveBeenCalledWith({
+      networkSlug: SLUG,
+      channelName: canonicalChannel("#Sniffo"),
+      kind: "channel",
+    });
+  });
+});
+
+describe("confirmJoinChannel — not joined (#648)", () => {
+  it("opens a confirm naming the RAW channel, and does NOT join until confirmed", async () => {
+    const { confirmJoinChannel } = await import("../lib/channelJoin");
+    confirmJoinChannel(SLUG, "#Sniffo");
+
+    const req = confirmRequest();
+    expect(req).not.toBeNull();
+    expect(req?.body).toContain("#Sniffo");
+    // Nothing happens on the wire or focus until the user says yes.
+    expect(postJoinMock).not.toHaveBeenCalled();
+    expect(setSelectedChannelMock).not.toHaveBeenCalled();
+  });
+
+  it("on confirm: joins with the RAW channel then focuses the FOLDED key", async () => {
+    const { confirmJoinChannel } = await import("../lib/channelJoin");
+    confirmJoinChannel(SLUG, "#Sniffo");
+    acceptConfirm();
+    // performJoin awaits postJoin before focusing — let the microtask drain.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Wire/display spelling on the JOIN (the server does its own casemapping).
+    expect(postJoinMock).toHaveBeenCalledWith("tok", SLUG, "#Sniffo", null);
+    // Focus on the folded key, and only AFTER the join resolved (#244: a
+    // failed join never foregrounds a phantom window).
+    expect(setSelectedChannelMock).toHaveBeenCalledWith({
+      networkSlug: SLUG,
+      channelName: canonicalChannel("#Sniffo"),
+      kind: "channel",
+    });
+  });
+
+  it("on cancel: no join, no focus", async () => {
+    const { confirmJoinChannel } = await import("../lib/channelJoin");
+    confirmJoinChannel(SLUG, "#chan");
+    dismissConfirm();
+    await Promise.resolve();
+    expect(postJoinMock).not.toHaveBeenCalled();
+    expect(setSelectedChannelMock).not.toHaveBeenCalled();
+  });
+
+  it("no-ops the join when no token is set (post-logout race)", async () => {
+    tokenMock.mockReturnValue(null);
+    const { confirmJoinChannel } = await import("../lib/channelJoin");
+    confirmJoinChannel(SLUG, "#chan");
+    acceptConfirm();
+    await Promise.resolve();
+    expect(postJoinMock).not.toHaveBeenCalled();
+  });
+});

--- a/cicchetto/src/__tests__/linkify.test.ts
+++ b/cicchetto/src/__tests__/linkify.test.ts
@@ -245,4 +245,121 @@ describe("linkify", () => {
       ]);
     });
   });
+
+  // #648 — channel tokens (`#channel`) tokenised in the SAME single pass as
+  // URLs so the URL branch wins over a `#` inside a URL fragment and the
+  // trailing-punctuation cleanup is shared. Prefix decision: `#` ONLY —
+  // Azzurra (all prod) serves only `#`; `&`/`+`/`!` are false-positive
+  // magnets in prose (`&`=entities, `+`="C++", `!`=exclamations) so they
+  // stay PLAIN TEXT, the explicit non-silent handling.
+  describe("channel tokens (#648)", () => {
+    it("tokenises a bare #channel", () => {
+      expect(linkify("join #sniffo now")).toEqual([
+        { type: "text", value: "join " },
+        { type: "channel", value: "#sniffo" },
+        { type: "text", value: " now" },
+      ]);
+    });
+
+    it("tokenises multiple channels in one body", () => {
+      expect(linkify("#a and #beta")).toEqual([
+        { type: "channel", value: "#a" },
+        { type: "text", value: " and " },
+        { type: "channel", value: "#beta" },
+      ]);
+    });
+
+    it("allows hyphens in a channel name", () => {
+      expect(linkify("see #it-opers ok")).toEqual([
+        { type: "text", value: "see " },
+        { type: "channel", value: "#it-opers" },
+        { type: "text", value: " ok" },
+      ]);
+    });
+
+    it("allows underscores WITHOUT the emphasis pass eating them (charset)", () => {
+      expect(linkify("#foo_bar_baz")).toEqual([{ type: "channel", value: "#foo_bar_baz" }]);
+    });
+
+    it("tokenises a channel whose name STARTS with a digit but has letters", () => {
+      expect(linkify("play #7dtd tonight")).toEqual([
+        { type: "text", value: "play " },
+        { type: "channel", value: "#7dtd" },
+        { type: "text", value: " tonight" },
+      ]);
+    });
+
+    it("a # inside a URL fragment stays part of the URL (URL branch wins)", () => {
+      expect(linkify("https://example.org/page#section")).toEqual([
+        {
+          type: "url",
+          value: "https://example.org/page#section",
+          href: "https://example.org/page#section",
+        },
+      ]);
+    });
+
+    it("tokenises a channel AND a URL in the same body", () => {
+      expect(linkify("see #foo at https://x.example/y")).toEqual([
+        { type: "text", value: "see " },
+        { type: "channel", value: "#foo" },
+        { type: "text", value: " at " },
+        { type: "url", value: "https://x.example/y", href: "https://x.example/y" },
+      ]);
+    });
+
+    it("strips a trailing period from a sentence-final channel", () => {
+      expect(linkify("join #sniffo.")).toEqual([
+        { type: "text", value: "join " },
+        { type: "channel", value: "#sniffo" },
+        { type: "text", value: "." },
+      ]);
+    });
+
+    it("strips an unbalanced trailing ) from a parenthesised channel", () => {
+      expect(linkify("(#sniffo)")).toEqual([
+        { type: "text", value: "(" },
+        { type: "channel", value: "#sniffo" },
+        { type: "text", value: ")" },
+      ]);
+    });
+
+    it("stops a channel at a comma (multi-channel list)", () => {
+      expect(linkify("#foo,#bar")).toEqual([
+        { type: "channel", value: "#foo" },
+        { type: "text", value: "," },
+        { type: "channel", value: "#bar" },
+      ]);
+    });
+
+    it("does NOT tokenise a bare # with no name", () => {
+      expect(linkify("a lone # here")).toEqual([{ type: "text", value: "a lone # here" }]);
+    });
+
+    it("does NOT tokenise a digits-only #1 (issue ref / hashtag)", () => {
+      expect(linkify("see #1 for details")).toEqual([
+        { type: "text", value: "see #1 for details" },
+      ]);
+    });
+
+    it("does NOT tokenise a digits-only #123", () => {
+      expect(linkify("bug #123 filed")).toEqual([{ type: "text", value: "bug #123 filed" }]);
+    });
+
+    it("does NOT tokenise &, +, ! prefixes (prefix decision: # only)", () => {
+      expect(linkify("&local +modeless !safe stay text")).toEqual([
+        { type: "text", value: "&local +modeless !safe stay text" },
+      ]);
+    });
+
+    it("caps a channel at 50 chars (RFC 2812) and leaves the overflow as text", () => {
+      // `#` + 60 name chars → channel is the first 50 chars total, the
+      // remaining 11 name chars fall through as text.
+      const name = "a".repeat(60);
+      expect(linkify(`#${name}`)).toEqual([
+        { type: "channel", value: `#${"a".repeat(49)}` },
+        { type: "text", value: "a".repeat(11) },
+      ]);
+    });
+  });
 });

--- a/cicchetto/src/lib/channelJoin.ts
+++ b/cicchetto/src/lib/channelJoin.ts
@@ -1,0 +1,76 @@
+import { postJoin } from "./api";
+import { token } from "./auth";
+import { canonicalChannel, channelKey } from "./channelKey";
+import { requestConfirm } from "./confirmDialog";
+import { setSelectedChannel } from "./selection";
+import { windowStateByChannel } from "./windowState";
+
+// #648 — the verb behind a click-to-join `#channel` affordance rendered in
+// scrollback (linkify.ts `channel` segment → MircText.renderChannel). It is a
+// thin COMPOSITION of verbs that already exist — it opens no new socket call
+// and holds no parallel state:
+//
+//   * postJoin            — THE join REST call, shared with compose.ts `/join`
+//                           and DirectoryPane row taps.
+//   * setSelectedChannel  — the ONLY cic-originated focus origin (#244): the
+//                           tap. Automatic re-joins never steal focus.
+//   * windowStateByChannel — the server-owned window_states projection, the
+//                           already-joined source of truth.
+//   * requestConfirm      — the shared confirm-modal store (#195), the sibling
+//                           of windowClose.ts's confirmLeaveChannel.
+//
+// The confirm gate is the 20% that differs from a DirectoryPane row tap: a
+// `#channel` in prose is NOT an unambiguous join intent (a row tap is), so a
+// scrollback click asks first — UNLESS we're already in the channel, where a
+// confirm to "join" a window that's already open is noise (#648): switch to it
+// directly.
+//
+// Casing split, mirroring compose.ts `/join` (#510/#516/#525): the JOIN goes on
+// the wire RAW/display-cased (`#Sniffo` — the server does its own casemapping);
+// focus + the already-joined lookup use the FOLDED key (`canonicalChannel` /
+// `channelKey`, which folds internally), because window_states + selection are
+// keyed folded — a mixed-case focus target opens a phantom window.
+
+function switchTo(networkSlug: string, rawChannel: string): void {
+  setSelectedChannel({
+    networkSlug,
+    channelName: canonicalChannel(rawChannel),
+    kind: "channel",
+  });
+}
+
+async function performJoin(networkSlug: string, rawChannel: string): Promise<void> {
+  const t = token();
+  if (!t) return; // post-logout race — nothing to join with.
+  try {
+    // RAW on the wire (display spelling); the server casemaps it.
+    await postJoin(t, networkSlug, rawChannel, null);
+    // Focus originates HERE (the tap), AFTER the awaited join — a rejected
+    // join (+i / +k / +b) never foregrounds a phantom window (#244).
+    switchTo(networkSlug, rawChannel);
+  } catch (err) {
+    // Fire-and-forget UI action with no dedicated error surface (unlike the
+    // DirectoryPane row's inline error signal). Log, don't throw — the same
+    // posture windowClose.ts's disconnectNetwork PATCH takes. A join
+    // REJECTION (channel modes) is not this path: postJoin succeeds and the
+    // server reports the failure as a window_state broadcast; this catch is
+    // only the REST-level failure (401 / network down).
+    console.warn(`[#648 join] failed to join ${rawChannel} on ${networkSlug}:`, err);
+  }
+}
+
+// Already in the channel ⇒ switch, no modal. Otherwise confirm, then join on
+// yes. The confirm body names the RAW channel (display casing).
+export function confirmJoinChannel(networkSlug: string, rawChannel: string): void {
+  const joined = windowStateByChannel()[channelKey(networkSlug, rawChannel)] === "joined";
+  if (joined) {
+    switchTo(networkSlug, rawChannel);
+    return;
+  }
+  requestConfirm({
+    title: "Join channel",
+    body: `Join ${rawChannel}?`,
+    confirmLabel: "Join",
+    onConfirm: () => void performJoin(networkSlug, rawChannel),
+  });
+}

--- a/cicchetto/src/lib/keepKeyboard.ts
+++ b/cicchetto/src/lib/keepKeyboard.ts
@@ -95,7 +95,14 @@ const SELECTABLE_TEXT_SURFACES = ".scrollback, .topic-modal-text";
 //     (inside `.scrollback`, not excluded), so a TAP dropped the keyboard and
 //     a LONG-PRESS select-all'd the row — both wrong for a control. Same
 //     class of bug as #350. See DESIGN_NOTES 2026-07-26 (#354).
-const SELECTABLE_TEXT_EXCLUDE = ".scrollback-invite-join, .scrollback-link, .nick-clickable";
+//   * `.channel-clickable` (#648 — a `#channel` in scrollback rendered inline
+//     as a click-to-join control, MircText.renderChannel) is the SAME class of
+//     inline control as `.nick-clickable`: a tap opens the join-confirm (keep
+//     the keyboard), its text stays copyable (NOT in the CSS `user-select`
+//     re-exclude, so a spanning drag-selection still grabs it), and a
+//     long-press must not select-all the row.
+const SELECTABLE_TEXT_EXCLUDE =
+  ".scrollback-invite-join, .scrollback-link, .nick-clickable, .channel-clickable";
 
 // #79 (2026-07-04) — long-press threshold, shared by BOTH the mousedown
 // tap-vs-hold split and the #366 touchend select-all. For a TAP, iOS

--- a/cicchetto/src/lib/linkify.ts
+++ b/cicchetto/src/lib/linkify.ts
@@ -1,9 +1,22 @@
-// Tiny URL linkifier — vendored to avoid pulling linkify-it (>10kB
-// minified) for one regex. Detects http/https/ftp + bare-domain
-// (`www.something`, `host.tld/path`) shapes common in IRC.
+// Tiny URL + channel tokenizer — vendored to avoid pulling linkify-it
+// (>10kB minified) for one regex. Detects http/https/ftp + bare-domain
+// (`www.something`, `host.tld/path`) shapes common in IRC, PLUS IRC
+// channel tokens (`#sniffo`, #648) in the SAME single pass.
 //
-// Returns an ordered list of segments — text + url alternating.
-// Empty input → single empty text segment.
+// Returns an ordered list of segments — text, url, and channel. Empty
+// input → single empty text segment.
+//
+// ## Channel prefix (#648)
+//
+// `#` is the ONLY channel prefix tokenised. Azzurra (all of prod) serves
+// only `#`; the other RFC 2812 prefixes (`&` local, `+` modeless, `!`
+// safe) are near-nonexistent on modern networks AND heavy false-positive
+// magnets in chat prose (`&`=HTML entities/"and", `+`="C++"/"+1", `!`=
+// every exclamation). So `&foo`/`+foo`/`!foo` stay PLAIN TEXT — the
+// explicit, non-silent handling: they are neither misrendered as channels
+// nor swallowed. The `channel` segment type is the extension point — a
+// future network needing `&` channels adds the prefix to TOKEN_REGEX's
+// char class (one line) with its own false-positive tests.
 //
 // ## Regex shape + trade-offs
 //
@@ -43,6 +56,10 @@
 // - negative: trailing-`.`/`,`/`)` exclusion, sentence boundaries,
 //   bare-domain false-positive guards (no-path, versions, node.js)
 // - balanced parens, IDN pass-through
+// - channels (#648): positive (`#chan`, hyphen/underscore, digit-led
+//   `#7dtd`), URL-wins-over-`#section`, trailing-punct + paren strip,
+//   comma-stop, negatives (bare `#`, digits-only `#1`, `&`/`+`/`!`
+//   prefixes), 50-char cap
 //
 // ## Why a separate file
 //
@@ -52,11 +69,20 @@
 
 export type LinkifySegment =
   | { type: "text"; value: string }
-  | { type: "url"; value: string; href: string };
+  | { type: "url"; value: string; href: string }
+  // #648 — an IRC channel token (`#sniffo`). Tokenised in the SAME single
+  // pass as URLs (see TOKEN_REGEX below), so a `#` inside a URL fragment
+  // stays part of the URL and the trailing-punctuation cleanup is shared.
+  // The renderer (MircText) turns it into a click-to-join affordance in
+  // scrollback; surfaces without a channel-click handler render `value` as
+  // plain text — exactly how a url segment degrades. `value` is the RAW,
+  // display-cased channel (`#Sniffo`); keys fold downstream via
+  // `canonicalChannel`.
+  | { type: "channel"; value: string };
 
-// Match a fully-qualified URL (scheme://), a bare www. domain, or a
-// scheme-less `host.tld/path` (GH #212). Stop on whitespace; trailing
-// punctuation is stripped after the match.
+// Match a fully-qualified URL (scheme://), a bare www. domain, a
+// scheme-less `host.tld/path` (GH #212), OR an IRC channel token (#648).
+// Stop on whitespace; trailing punctuation is stripped after the match.
 //
 // `[^\s]+?` would be nicer but matches too greedily — we want to
 // match URL-shaped chars then strip terminal punctuation in a
@@ -66,20 +92,35 @@ export type LinkifySegment =
 // The bare-domain alternative requires ≥1 label + an alpha TLD (≥2
 // letters) + a slash before consuming the rest with `\S*` — the slash
 // is what disambiguates a URL from ordinary prose (see moduledoc).
-// The scheme/www alternative is listed FIRST so a scheme-qualified URL
-// is matched whole and the bare-domain branch never fires inside it.
-const URL_REGEX = /(?:https?:\/\/|ftp:\/\/|www\.)\S+|(?:[a-z0-9-]+\.)+[a-z]{2,}\/\S*/gi;
+//
+// The URL/www/bare-domain alternatives are listed FIRST so a single
+// left-to-right scan resolves all overlaps (the #648 single-pass
+// invariant): a scheme-qualified URL is matched whole, and neither the
+// bare-domain nor the channel branch fires inside it — a `#section`
+// fragment is consumed by the URL's `\S+`, never re-tokenised as a
+// channel. A `#` and a URL char never START at the same offset (`#` isn't
+// in `[a-z0-9-]` and no scheme starts with `#`), so ordering fully
+// resolves the URL-vs-channel overlap.
+//
+// Channel alternative (#648): `#` + 1..49 non-terminator octets (total
+// ≤ 50 per RFC 2812), stopping at space / comma / BELL (`\x07`) — the
+// RFC 2812 chanstring terminators relevant in a chat body. `#` is the
+// ONLY prefix (see moduledoc "Channel prefix"). Trailing punctuation and
+// the digits-only (`#1`) rejection are handled in `linkify` after the match.
+const TOKEN_REGEX =
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: `\x07` (BELL) is an RFC 2812 chanstring terminator — a channel name MUST stop at it, so matching it as a boundary is deliberate, not an accidental control char.
+  /(?:https?:\/\/|ftp:\/\/|www\.)\S+|(?:[a-z0-9-]+\.)+[a-z]{2,}\/\S*|#[^\s,\x07]{1,49}/gi;
 
 const TRAILING_PUNCT_RE = /[.,;:!?)\]}>]+$/;
 
-function stripTrailingPunctuation(url: string): { url: string; trailing: string } {
+function stripTrailingPunctuation(token: string): { value: string; trailing: string } {
   // Special-case: balanced parens count -- if `(` count === `)` count,
   // preserve the trailing `)` (common in Wikipedia links). Strip only
   // unbalanced trailing closing-parens.
-  const opens = (url.match(/\(/g) ?? []).length;
-  const closes = (url.match(/\)/g) ?? []).length;
+  const opens = (token.match(/\(/g) ?? []).length;
+  const closes = (token.match(/\)/g) ?? []).length;
 
-  let stripped = url;
+  let stripped = token;
   let trailing = "";
 
   // Iteratively strip terminal punct except for the balanced-parens case.
@@ -92,7 +133,17 @@ function stripTrailingPunctuation(url: string): { url: string; trailing: string 
     stripped = stripped.slice(0, -1);
   }
 
-  return { url: stripped, trailing };
+  return { value: stripped, trailing };
+}
+
+// #648 — a matched `#…` token is a real channel only if, AFTER trailing-punct
+// stripping, its NAME (the part past `#`) is non-empty AND not digits-only. A
+// bare `#` can't reach here (the regex requires ≥1 name char), but `#1` / `#123`
+// can — those are issue refs / prose hashtags, not channels. A name that merely
+// STARTS with a digit but carries any non-digit (`#7dtd`) IS a channel.
+function isChannelName(value: string): boolean {
+  const name = value.slice(1);
+  return name.length > 0 && !/^\d+$/.test(name);
 }
 
 function toHref(matched: string): string {
@@ -112,34 +163,50 @@ export function linkify(input: string): LinkifySegment[] {
 
   // Reset regex state — global flag means lastIndex would persist
   // across calls otherwise.
-  URL_REGEX.lastIndex = 0;
+  TOKEN_REGEX.lastIndex = 0;
 
   while (true) {
-    const match = URL_REGEX.exec(input);
+    const match = TOKEN_REGEX.exec(input);
     if (!match) break;
 
     const matchStart = match.index;
     const rawMatch = match[0];
-    const { url, trailing } = stripTrailingPunctuation(rawMatch);
+    const { value, trailing } = stripTrailingPunctuation(rawMatch);
 
     // Pre-match text segment.
     if (matchStart > lastIndex) {
       segments.push({ type: "text", value: input.slice(lastIndex, matchStart) });
     }
 
-    segments.push({ type: "url", value: url, href: toHref(url) });
-
-    lastIndex = matchStart + url.length;
-
-    if (trailing) {
-      segments.push({ type: "text", value: trailing });
-      lastIndex += trailing.length;
+    // `#` prefix ⇒ channel branch; anything else the regex admits is a URL.
+    // (`#` never starts a URL alternative, so this dispatch is exact.)
+    if (rawMatch[0] === "#") {
+      if (isChannelName(value)) {
+        segments.push({ type: "channel", value });
+        lastIndex = matchStart + value.length;
+        if (trailing) {
+          segments.push({ type: "text", value: trailing });
+          lastIndex += trailing.length;
+        }
+      } else {
+        // Bare-`#` can't match; a digits-only `#1`/`#123` reaches here — emit
+        // the whole raw token (name + any stripped trailing) as plain text.
+        segments.push({ type: "text", value: rawMatch });
+        lastIndex = matchStart + rawMatch.length;
+      }
+    } else {
+      segments.push({ type: "url", value, href: toHref(value) });
+      lastIndex = matchStart + value.length;
+      if (trailing) {
+        segments.push({ type: "text", value: trailing });
+        lastIndex += trailing.length;
+      }
     }
 
     // Defensive: prevent zero-width-match infinite loop (shouldn't
     // happen with this regex but the `\S+` shape could in theory
     // match empty after trailing-strip — guard anyway).
-    if (URL_REGEX.lastIndex === matchStart) URL_REGEX.lastIndex++;
+    if (TOKEN_REGEX.lastIndex === matchStart) TOKEN_REGEX.lastIndex++;
   }
 
   // Tail text after last match.

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2402,6 +2402,29 @@ html.resize-dragging * {
   text-decoration: underline;
 }
 
+/* #648: clickable #channel in scrollback — an inline <button> (same
+   transparent-inline shape as .nick-clickable) tinted with the accent so a
+   channel token reads as a link-like join affordance, distinct from a plain
+   nick. user-select: text mirrors .nick-clickable (#250): the token stays
+   inside a drag text-selection on every platform while the tap-to-join
+   handler stays intact; keyboard/focus policy is owned separately by
+   keepKeyboard.ts's SELECTABLE_TEXT_EXCLUDE (#354, #648). */
+.channel-clickable {
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  display: inline;
+  color: var(--accent);
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+.channel-clickable:hover {
+  text-decoration: underline;
+}
+
 /* No-silent-drops bucket 2: [Join] CTA inline button on INVITE rows.
    Same shape as .nick-clickable (transparent button rendered inline)
    but with explicit accent color + bracketed visual weight so the


### PR DESCRIPTION
Refs #648.

Tapping a `#channel` in a scrollback message body opens a confirm
("Join #channel?") and, on yes, joins and switches to that window. If
we're **already** in the channel it just switches — no modal (asking to
join an open window is noise).

## Built by extending the four existing seams (no parallel anything)

Per vjt's *"estendere non stratificare"*:

1. **Tokenizing — `linkify.ts`.** `LinkifySegment` gains a `channel`
   variant tokenised in the **same single left-to-right pass** as URLs.
   URL alternatives stay first, so a `#section` inside a URL fragment is
   consumed by the URL and never re-tokenised, and `stripTrailingPunctuation`
   is reused (`#sniffo.` / `(#sniffo)` shed the `.` / `)`).
2. **Rendering — `MircText.tsx`.** The one consumer gains a `channel`
   branch. It is **exempt from the textual-emphasis pass exactly like a
   url** (the `#foo_bar_baz` trap), and renders as a `.channel-clickable`
   `<button>` (keyboard/a11y for free, mirroring `.nick-clickable`) — but
   **only** when the surface wires `onChannelClick`; elsewhere it degrades
   to plain text. Wired on the privmsg/notice/action bodies only (the
   nick-clickable set); topic bar / whois / /list stay plain.
3. **Confirm — reuses `ConfirmModal` / `confirmDialog`.** No new modal.
4. **Joining — `channelJoin.ts` composes existing verbs:** `postJoin`
   (THE join REST call, shared with `/join` + DirectoryPane),
   `setSelectedChannel` (the sole cic-originated focus, #244),
   `windowStateByChannel` (server-owned already-joined truth). **No new
   socket call.** Casing split mirrors `/join`: JOIN goes on the wire RAW
   (server casemaps); focus + the joined lookup use the folded key.

`.channel-clickable` joins `keepKeyboard`'s `SELECTABLE_TEXT_EXCLUDE`
(iOS tap keeps keyboard, copyable, long-press ≠ select-all).

## Prefix decision — `#` ONLY (deliberate, stated per the issue)

Azzurra (all prod) serves only `#`. `&`/`+`/`!` are near-nonexistent on
modern nets **and** false-positive magnets in prose (`&`=entities/"and",
`+`="C++"/"+1", `!`=every exclamation), so they stay **plain text** — the
explicit, non-silent handling (neither misrendered nor swallowed). The
`channel` segment type is the extension point: a future net adds the
prefix to one char class + its own tests.

## Tests (deltas)

- **`linkify.test.ts`: +18** (23 → 41) — URL-wins-over-`#section`,
  trailing-punct + paren strip, comma-stop, bare-`#`, digits-only
  `#1`/`#123`, `&`/`+`/`!` rejection, 50-char cap, digit-led `#7dtd`,
  hyphen/underscore.
- **`MircText.test.tsx`: +3** (16 → 19) — the emphasis-exclusion trap,
  the click→`onChannelClick(raw)` wiring, and the plain-text degrade
  without a handler.
- **`channelJoin.test.ts`: +5 (new)** — already-joined→switch (no modal),
  confirm→join+folded-focus, cancel→nothing, no-token no-op.
- **`e2e/tests/issue648-clickable-channel.spec.ts`: +2 (new spec file)** —
  REAL end-to-end: a peer's `#channel` PRIVMSG renders clickable → confirm
  → joins + switches; and already-joined → switch with NO modal
  (count-0). **e2e delta: +2.**

Local gates green: biome ✅, tsc ✅, full vitest **214 files / 3845
tests ✅**. e2e gated via PR CI (not run locally).