### PR TITLE
fix(#649): re-read the iOS viewport on resume — one writer, more triggers

### DIFF
--- a/cicchetto/src/__tests__/viewportHeight.test.ts
+++ b/cicchetto/src/__tests__/viewportHeight.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   installSmartScrollPin,
   installViewportHeightTracker,
+  type ResumeDocumentLike,
+  type ResumeWindowLike,
   type VisualViewportLike,
 } from "../lib/viewportHeight";
 
@@ -11,6 +13,13 @@ import {
 // boot AND on every resize event. Real keyboard behaviour is verified
 // by vjt on iPhone (Playwright doesn't emulate the OS keyboard);
 // these tests are the mechanical contract.
+//
+// #649/#654 — the resume triggers (visibilitychange / pageshow / focus)
+// are wiring, and wiring IS desktop-provable: each trigger must reach the
+// ONE writer and re-run the ONE settle schedule, with no resize event in
+// play. What is NOT provable here is the user-visible iOS behaviour (the
+// app-switch-return half-height itself) — that is vjt's device leg. These
+// tests assert the mechanical contract only, deliberately.
 
 function makeFakeVp(initialHeight: number): {
   vp: VisualViewportLike;
@@ -41,6 +50,46 @@ function makeFakeVp(initialHeight: number): {
   };
 }
 
+// #649 resume-trigger host. Fakes the window + document seams so a test can
+// fire a resume WITHOUT touching the real jsdom window — the module has no
+// uninstall path, so a real-window listener would outlive its test and keep a
+// stale `vp` closure alive for every later test in the file.
+function makeResumeHost(): {
+  win: ResumeWindowLike;
+  doc: ResumeDocumentLike;
+  setVisibility: (state: DocumentVisibilityState) => void;
+  firePageShow: () => void;
+  fireFocus: () => void;
+  fireVisibilityChange: () => void;
+  vvListenerEvents: () => string[];
+} {
+  const winHandlers = new Map<string, () => void>();
+  const docHandlers = new Map<string, () => void>();
+  let visibilityState: DocumentVisibilityState = "visible";
+  return {
+    win: {
+      addEventListener(event, h) {
+        winHandlers.set(event, h);
+      },
+    },
+    doc: {
+      get visibilityState() {
+        return visibilityState;
+      },
+      addEventListener(event, h) {
+        docHandlers.set(event, h);
+      },
+    },
+    setVisibility: (state: DocumentVisibilityState) => {
+      visibilityState = state;
+    },
+    firePageShow: () => winHandlers.get("pageshow")?.(),
+    fireFocus: () => winHandlers.get("focus")?.(),
+    fireVisibilityChange: () => docHandlers.get("visibilitychange")?.(),
+    vvListenerEvents: () => [...winHandlers.keys(), ...docHandlers.keys()],
+  };
+}
+
 describe("viewportHeight module", () => {
   beforeEach(() => {
     // Fake timers so the boot settle re-read schedule (#285 reopen) never
@@ -57,20 +106,23 @@ describe("viewportHeight module", () => {
 
   it("writes --viewport-height (px) on boot", () => {
     const { vp } = makeFakeVp(852);
-    installViewportHeightTracker(vp);
+    const host = makeResumeHost();
+    installViewportHeightTracker(vp, host.win, host.doc);
     expect(document.documentElement.style.getPropertyValue("--viewport-height")).toBe("852px");
   });
 
   it("writes --vh (px, height * 0.01) on boot — Telegram pattern", () => {
     const { vp } = makeFakeVp(852);
-    installViewportHeightTracker(vp);
+    const host = makeResumeHost();
+    installViewportHeightTracker(vp, host.win, host.doc);
     // 852 * 0.01 = 8.52
     expect(document.documentElement.style.getPropertyValue("--vh")).toBe("8.52px");
   });
 
   it("updates both vars on every resize event", () => {
     const { vp, fireResize } = makeFakeVp(852);
-    installViewportHeightTracker(vp);
+    const host = makeResumeHost();
+    installViewportHeightTracker(vp, host.win, host.doc);
     fireResize(620); // keyboard opens — viewport shrinks
     expect(document.documentElement.style.getPropertyValue("--viewport-height")).toBe("620px");
     expect(document.documentElement.style.getPropertyValue("--vh")).toBe("6.20px");
@@ -80,9 +132,12 @@ describe("viewportHeight module", () => {
   });
 
   it("is a no-op when the viewport argument is undefined", () => {
-    installViewportHeightTracker(undefined);
+    const host = makeResumeHost();
+    installViewportHeightTracker(undefined, host.win, host.doc);
     expect(document.documentElement.style.getPropertyValue("--viewport-height")).toBe("");
     expect(document.documentElement.style.getPropertyValue("--vh")).toBe("");
+    // No viewport to read → no resume listeners either (nothing to re-read).
+    expect(host.vvListenerEvents()).toEqual([]);
   });
 
   it("re-reads the settled viewport height on a post-boot timer, WITHOUT a resize event (#285 reopen)", () => {
@@ -94,7 +149,8 @@ describe("viewportHeight module", () => {
     // event-independently, so the settled (smaller) height overwrites the
     // inflated boot value even when no resize ever fires.
     const { vp, setHeight } = makeFakeVp(852); // boot reads the inflated full-screen height
-    installViewportHeightTracker(vp);
+    const host = makeResumeHost();
+    installViewportHeightTracker(vp, host.win, host.doc);
     expect(document.documentElement.style.getPropertyValue("--viewport-height")).toBe("852px");
 
     // Silent settle: the real usable height is 762 (safe-area/chrome settled),
@@ -112,9 +168,96 @@ describe("viewportHeight module", () => {
   it("subscribes to the resize event only (D9 dropped vv.scroll — vvOffsetTop unreliable per WebKit #297779)", () => {
     const addEventListener = vi.fn();
     const vp: VisualViewportLike = { height: 800, addEventListener };
-    installViewportHeightTracker(vp);
+    const host = makeResumeHost();
+    installViewportHeightTracker(vp, host.win, host.doc);
     expect(addEventListener).toHaveBeenCalledTimes(1);
     expect(addEventListener).toHaveBeenCalledWith("resize", expect.any(Function));
+  });
+
+  // #649/#654 — resume triggers. Each of the three fires the SAME writer via
+  // the SAME settle schedule; none of them is a second writer. Every case
+  // advances past the boot settle FIRST, so a pass can only come from the
+  // resume trigger (leaving the boot timers pending would let #285's schedule
+  // silently do the work and make these tests hollow).
+  const RESUME_TRIGGERS: ReadonlyArray<{
+    name: string;
+    fire: (host: ReturnType<typeof makeResumeHost>) => void;
+  }> = [
+    { name: "visibilitychange → visible", fire: (h) => h.fireVisibilityChange() },
+    { name: "pageshow (iOS bfcache/PWA resume)", fire: (h) => h.firePageShow() },
+    { name: "window focus", fire: (h) => h.fireFocus() },
+  ];
+
+  for (const trigger of RESUME_TRIGGERS) {
+    it(`re-reads the viewport on ${trigger.name}, WITHOUT a resize event (#649)`, () => {
+      // Foreground with the keyboard up: the last value written is the SHRUNK
+      // height. This is the value that survives the app-switch.
+      const { vp, setHeight } = makeFakeVp(620);
+      const host = makeResumeHost();
+      installViewportHeightTracker(vp, host.win, host.doc);
+      vi.advanceTimersByTime(2000); // drain the boot settle — it must not be the thing that passes
+      expect(document.documentElement.style.getPropertyValue("--viewport-height")).toBe("620px");
+
+      // App-switch away and back: iOS restores the FULL viewport but fires no
+      // `resize`, so the vars stay at the keyboard-open value → the shell is
+      // left at half height (the reported symptom).
+      setHeight(852);
+      expect(document.documentElement.style.getPropertyValue("--viewport-height")).toBe("620px");
+
+      trigger.fire(host);
+      vi.advanceTimersByTime(2000);
+      expect(document.documentElement.style.getPropertyValue("--viewport-height")).toBe("852px");
+      expect(document.documentElement.style.getPropertyValue("--vh")).toBe("8.52px");
+    });
+  }
+
+  it("ignores a visibilitychange to hidden — only a resume re-reads (#649)", () => {
+    const { vp, setHeight } = makeFakeVp(620);
+    const host = makeResumeHost();
+    installViewportHeightTracker(vp, host.win, host.doc);
+    vi.advanceTimersByTime(2000);
+
+    host.setVisibility("hidden");
+    setHeight(852);
+    host.fireVisibilityChange();
+    vi.advanceTimersByTime(2000);
+
+    // Backgrounding is not a resume: nothing re-read, the var is untouched.
+    expect(document.documentElement.style.getPropertyValue("--viewport-height")).toBe("620px");
+  });
+
+  it("keeps the resume settle honest: a genuine resize mid-settle wins, never a stale clobber (#649)", () => {
+    // The resume settle and the resize handler are the SAME writer reading the
+    // SAME live `vv.height` — so an overlapping real keyboard-open during a
+    // pending resume re-read must land on the CURRENT height, not replay the
+    // height that was live when the resume fired.
+    const { vp, fireResize, setHeight } = makeFakeVp(620);
+    const host = makeResumeHost();
+    installViewportHeightTracker(vp, host.win, host.doc);
+    vi.advanceTimersByTime(2000);
+
+    setHeight(852); // resumed full-screen
+    host.firePageShow(); // settle schedule armed at 100/400/900
+    vi.advanceTimersByTime(100); // first re-read lands the resumed height
+    expect(document.documentElement.style.getPropertyValue("--viewport-height")).toBe("852px");
+
+    // User taps compose → keyboard opens for real, mid-settle.
+    fireResize(620);
+    expect(document.documentElement.style.getPropertyValue("--viewport-height")).toBe("620px");
+
+    // The still-pending re-reads must NOT restore 852: they read live height.
+    vi.advanceTimersByTime(2000);
+    expect(document.documentElement.style.getPropertyValue("--viewport-height")).toBe("620px");
+    expect(document.documentElement.style.getPropertyValue("--vh")).toBe("6.20px");
+  });
+
+  it("registers exactly one listener per resume trigger — one writer, more triggers (#654)", () => {
+    const { vp } = makeFakeVp(852);
+    const host = makeResumeHost();
+    installViewportHeightTracker(vp, host.win, host.doc);
+    // No fourth mechanism, no wrapper, no second writer: the resume seams carry
+    // precisely the three documented triggers.
+    expect(host.vvListenerEvents().sort()).toEqual(["focus", "pageshow", "visibilitychange"]);
   });
 });
 

--- a/cicchetto/src/lib/viewportHeight.ts
+++ b/cicchetto/src/lib/viewportHeight.ts
@@ -42,14 +42,49 @@
 //                       rule but kept for now to avoid touching
 //                       every mobile-overlay surface.
 //
+// #649/#654 (2026-08-02) — resume triggers. The same no-resize-event
+// failure as #285 reopen, sign flipped: the last value written while
+// foregrounded with the keyboard up is a SHRUNK height; on returning
+// from an app-switch iOS restores the full visible viewport but the
+// `resize` that would correct the vars either never fires or fires
+// before the height settles. The vars stay at the keyboard-open value
+// and `body { height: calc(var(--vh)*100) }` keeps the shell at half
+// screen with no keyboard in sight.
+//
+// The fix is MORE TRIGGERS INTO THE ONE WRITER, never a second writer:
+// `visibilitychange` (→ visible), `pageshow` (iOS bfcache/PWA resume)
+// and window `focus` each re-run the EXISTING settle schedule below.
+// No new settle mechanism, no wrapper, no per-symptom patch that also
+// touches the vars — a second writer is exactly the conflicting-consumer
+// failure this surface has already produced three bug reports from.
+// `lib/documentVisibility.ts` owns a sibling visibility+focus signal for
+// Solid consumers; it deliberately does NOT write CSS vars, and this
+// module deliberately does not consume it — two consumers of one signal
+// is fine, two writers of one var is the conflict.
+//
 // Mock surface for vitest: `installViewportHeightTracker` accepts an
 // optional viewport argument so unit tests can pass a fake
 // `VisualViewport`-shaped object with a controllable height +
-// addEventListener.
+// addEventListener, plus optional window/document seams so the resume
+// triggers can be fired without touching the real globals (the module
+// has no uninstall path — a real listener outlives its test).
 
+// Deliberately `height`-only: reading `vv.offsetTop` to infer keyboard
+// geometry is WebKit bug #297779 (sticks at 24px after keyboard dismiss),
+// and leaving it off the type makes that mistake a compile error rather
+// than a regression waiting for a device to catch it.
 export interface VisualViewportLike {
   height: number;
   addEventListener(event: "resize", handler: () => void): void;
+}
+
+export interface ResumeWindowLike {
+  addEventListener(event: "pageshow" | "focus", handler: () => void): void;
+}
+
+export interface ResumeDocumentLike {
+  readonly visibilityState: DocumentVisibilityState;
+  addEventListener(event: "visibilitychange", handler: () => void): void;
 }
 
 const HEIGHT_VAR = "--viewport-height";
@@ -68,18 +103,37 @@ const VH_VAR = "--vh";
 // Brackets a fast, medium, and slow settle.
 const SETTLE_REREAD_DELAYS_MS = [100, 400, 900];
 
+// THE single writer of both CSS vars. Every trigger — boot, resize, and
+// each #649 resume trigger — reaches the vars through here and nowhere
+// else. Adding a second `setProperty` site for either var anywhere in the
+// codebase re-opens #79/#209/#649's shared root cause.
 function writeViewport(vp: VisualViewportLike): void {
   const style = document.documentElement.style;
   style.setProperty(HEIGHT_VAR, `${vp.height}px`);
   style.setProperty(VH_VAR, `${(vp.height * 0.01).toFixed(2)}px`);
 }
 
+// Write now, then re-read on the settle schedule — for the cases where the
+// corrective height arrives with NO resize event to announce it: cold boot
+// (#285 reopen) and app-switch resume (#649). Each re-read reads the LIVE
+// `vp.height`, so a genuine resize landing mid-schedule is never clobbered
+// by a stale replay; overlapping schedules from repeated resumes are for the
+// same reason harmless (they all converge on the current height).
+function writeAndSettle(vp: VisualViewportLike): void {
+  writeViewport(vp);
+  if (typeof setTimeout !== "function") return;
+  for (const ms of SETTLE_REREAD_DELAYS_MS) {
+    setTimeout(() => writeViewport(vp), ms);
+  }
+}
+
 /**
  * Boot-time entry. Writes `--vh` (Telegram pattern) AND
  * `--viewport-height` (legacy pattern) from `window.visualViewport`,
- * then re-writes on every resize event AND on a short post-boot settle
+ * then re-writes on every resize event, on a short post-boot settle
  * re-read schedule (#285 reopen — the cold-boot settle that fires no
- * resize event).
+ * resize event), and on each resume trigger (#649 — the app-switch
+ * return that likewise fires no resize event).
  *
  * Idempotent — main.tsx invokes once.
  *
@@ -91,15 +145,24 @@ export function installViewportHeightTracker(
   vp: VisualViewportLike | undefined = typeof window !== "undefined"
     ? (window.visualViewport ?? undefined)
     : undefined,
+  win: ResumeWindowLike | undefined = typeof window !== "undefined" ? window : undefined,
+  doc: ResumeDocumentLike | undefined = typeof document !== "undefined" ? document : undefined,
 ): void {
   if (!vp) return;
-  writeViewport(vp);
+  writeAndSettle(vp);
   vp.addEventListener("resize", () => writeViewport(vp));
-  if (typeof setTimeout === "function") {
-    for (const ms of SETTLE_REREAD_DELAYS_MS) {
-      setTimeout(() => writeViewport(vp), ms);
-    }
-  }
+  // #649 resume triggers. Three of them because no single one covers every
+  // return path: an installed iOS PWA coming back from an app-switch reports
+  // `visibilitychange`, a bfcache restore reports `pageshow`, and a
+  // same-visibility focus return (another app dismissed over the top) reports
+  // only `focus`. All three land on the same writer, so overlap costs one
+  // redundant re-read of the live height.
+  doc?.addEventListener("visibilitychange", () => {
+    if (doc.visibilityState !== "visible") return;
+    writeAndSettle(vp);
+  });
+  win?.addEventListener("pageshow", () => writeAndSettle(vp));
+  win?.addEventListener("focus", () => writeAndSettle(vp));
 }
 
 /**

--- a/cicchetto/src/main.tsx
+++ b/cicchetto/src/main.tsx
@@ -114,6 +114,11 @@ mountBadgeReconcile(async () => {
 // with the iOS on-screen keyboard. Without this, iOS scrolls the
 // body to keep focused inputs visible and pushes the top bar out
 // of view. Boot-time so the first frame already has the var.
+// #649 — ALSO re-reads on resume (visibilitychange / pageshow /
+// focus), for the app-switch return that restores the viewport
+// without firing a resize. One writer, more triggers: the window and
+// document listeners are installed by the tracker itself, so nothing
+// out here (and nothing anywhere else) touches the vars.
 installViewportHeightTracker();
 
 // UX-6 D10 (2026-05-21) — smart-pin window scroll. iOS PWA 18.7

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -26767,3 +26767,71 @@ re-implement the rule (that is the parallel state machine CLAUDE.md forbids) and
 it does not read only the common one. A conditional server-side re-key is a
 contract the client half has to be written for; grep the issue number on the
 client side before assuming it was.
+
+## 2026-08-02 — #654 (#649/#209/#79): the iOS viewport variable gets more triggers, never a second writer
+
+Three separately-filed iOS bugs (#79 selection won't start with the keyboard up,
+#209 layout breaks with the keyboard up on iPadOS PWA, #649 app-switch return
+leaves the shell at half height) were consolidated into epic #654 on the premise
+that they are three symptoms of ONE surface: the viewport-height custom property
+and its single writer.
+
+**vjt's constraint, verbatim:** *«non facciamo strati su quel che c'è già,
+cerchiamo di estendere e migliorare non stratificare che poi abbiamo consumer che
+vanno in conflitto»*. `installViewportHeightTracker` is the single writer of
+`--vh` + `--viewport-height` and must stay so — more triggers into that one
+writer, yes; a second writer, a wrapper, or a per-symptom patch that also touches
+the vars, no. Verified before designing, not assumed: a repo-wide `setProperty`
+grep finds exactly ONE writer of either var (`lib/viewportHeight.ts`); every
+other reference is a CSS consumer or a `getPropertyValue` read in
+`DiagFloat`/`AdminDebugTab`.
+
+**#649 is the only leg with code here.** The mechanism is #285-reopen with the
+sign flipped: the last value written while foregrounded with the keyboard up is a
+SHRUNK height; on returning from an app-switch iOS restores the full viewport but
+fires no `resize`, so the vars stay shrunk and `body { height: calc(var(--vh) *
+100) }` keeps the shell at half screen with no keyboard present. The fix adds
+three trigger points — `visibilitychange` (→ `visible`), `pageshow` (bfcache/PWA
+resume), window `focus` — each re-running the EXISTING `SETTLE_REREAD_DELAYS_MS`
+schedule via a new `writeAndSettle` that boot now shares. Three, because no one
+of them covers every return path (app-switch → visibilitychange, bfcache restore
+→ pageshow, an overlay app dismissed without a visibility change → focus only);
+overlap is free because every re-read reads the LIVE height, so a genuine resize
+landing mid-settle is never clobbered by a stale replay — the same argument #285
+reopen already made for its schedule. `lib/documentVisibility.ts` owns a sibling
+visibility+focus Solid signal and deliberately stays out of this: two consumers of
+one signal is fine, two writers of one var is the conflict.
+
+**#209 and #79 deliberately get NO code.** Writing speculative code for a symptom
+you cannot observe IS the per-symptom patching the epic exists to forbid.
+* #79 already carries a shipped, device-tuned fix in `keepKeyboard.ts` across
+  three iterations (v1 2026-07-03, the long-press duration gate 2026-07-04, the
+  #366 `touchend` select-all 2026-07-21) plus its CSS `user-select` re-enable.
+  There is nothing to add on the writer; a fresh repro is device-debugging.
+* #209's residual is most likely CSS geometry (`position: fixed` anchored to the
+  layout viewport, which iOS does not shrink for the keyboard) — a different
+  surface from the writer, diagnosable only on-device. Scope it after a real
+  DiagFloat trace says stale-vars (writer) vs mis-compute (CSS), not before.
+
+**Traps re-affirmed structurally, not by comment.** `VisualViewportLike` stays
+`height`-only, so reading `vv.offsetTop` (WebKit #297779 — sticks at 24px after
+dismiss) is a compile error rather than a regression waiting on a device.
+`installSmartScrollPin` is untouched, so its touch-gating (WebKit #226689, the
+1-3s scroll lock) still gates.
+
+**Verification honesty.** Only the wiring is desktop-provable, and it is unit-
+tested as wiring: each trigger reaches the one writer with no resize event in
+play, a `hidden` visibilitychange does nothing, a genuine resize mid-settle wins,
+and exactly three resume listeners are registered. Every test drains the boot
+settle FIRST — leaving those timers pending would let #285's schedule do the work
+and make the assertions hollow. The user-visible behaviour of all three symptoms
+is device-only: Playwright's `webkit-iphone-15` does not reproduce real iOS
+keyboard/scroll physics and desktop Safari does not speak CDP, so no e2e is
+written here — a green spec that cannot observe the behaviour is worse than no
+spec.
+
+**Apply:** when a variable has exactly one writer, a new failure mode on that
+variable is a missing TRIGGER, not a missing writer. Add the trigger to the
+existing writer and reuse its existing correction schedule. And when an umbrella
+issue bundles N symptoms, verify each one is actually the same code surface
+before writing N fixes — here only one of the three was.


### PR DESCRIPTION
Refs #654, #649, #209, #79

## What this is

Epic #654 bundles three iOS keyboard/viewport reports on the premise that they are
three symptoms of one surface. **Only one of them turned out to be this code
surface**, so only one gets code here. Writing speculative code for symptoms that
cannot be observed from a desktop IS the per-symptom patching the epic exists to
forbid.

| was | this PR |
|-----|---------|
| #649 — app-switch return leaves the shell at half height | **fixed** (trigger extension) |
| #209 — layout breaks with the keyboard up (iPadOS PWA) | no code — needs an on-device trace first (see below) |
| #79 — selection won't start with the keyboard up | no code — a device-tuned fix already shipped (see below) |

## #649 — the fix

Mechanism is #285-reopen with the sign flipped: the last value written while
foregrounded with the keyboard up is a **shrunk** height; on resume iOS restores the
full visible viewport but fires **no `resize`**, so `--vh` / `--viewport-height`
stay at the keyboard-open value and `body { height: calc(var(--vh) * 100) }` keeps
the shell at half screen.

`installViewportHeightTracker` is — and stays — the **single writer** of both vars.
Verified by grep before designing, not assumed: `lib/viewportHeight.ts:73-74` is the
only `setProperty` site for either var in the whole repo; every other reference is a
CSS consumer or a `getPropertyValue` read in `DiagFloat` / `AdminDebugTab`.

Three resume triggers now re-run the **existing** `SETTLE_REREAD_DELAYS_MS` schedule
through a shared `writeAndSettle` that boot also uses:

- `visibilitychange` (→ `visible`) — app-switch return
- `pageshow` — iOS bfcache / PWA resume
- window `focus` — an overlay app dismissed without a visibility change

Three because no single one covers every return path. Overlap is free: every re-read
reads the **live** height, so a genuine resize landing mid-settle is never clobbered
by a stale replay — the same argument #285 reopen already made for its schedule.

**No second writer, no wrapper, no new settle mechanism.** `documentVisibility.ts`
keeps its sibling visibility+focus Solid signal and still writes no CSS vars: two
consumers of one signal is fine, two writers of one var is the conflict.

Traps held structurally rather than by comment: `VisualViewportLike` stays
`height`-only, so reading `vv.offsetTop` (WebKit #297779 — sticks at 24px after
dismiss) is a **compile error**; `installSmartScrollPin` is untouched, so its
touch-gating (WebKit #226689, the 1-3s scroll lock) still gates.

## Verification — read this before believing the green checkmark

**Only the wiring is desktop-provable, and only the wiring is tested.** The unit
tests assert: each trigger reaches the one writer with no resize event in play; a
`hidden` visibilitychange does nothing; a genuine resize mid-settle wins over a
pending re-read; exactly three resume listeners are registered. Every case **drains
the boot settle first** — leaving those timers pending would let #285's schedule do
the work and make the assertions hollow.

**No e2e.** Playwright's `webkit-iphone-15` does not reproduce real iOS
keyboard/scroll physics and desktop Safari does not speak CDP, so an e2e here would
be a green spec that cannot observe the behaviour — worse than no spec.

### What vjt needs to check on a real device

Web Inspector over USB, watching `--vh` / `--viewport-height` / `visualViewport.height`
(`DiagFloat` and `AdminDebugTab` already surface all three):

1. **#649 (this PR's claim).** Focus compose so the keyboard opens → note the shrunk
   value → app-switch to something that raises its own keyboard → return to cic.
   Expect: the vars land back on the full height within ~1s and the shell fills the
   screen. This is the one behaviour this PR claims to fix.
2. **#209.** With the keyboard up (portrait **and** landscape, iPad worst): are the
   vars correct-but-the-layout-wrong, or are the vars themselves stale? That answer
   decides the fix location — stale vars means the writer, correct vars means CSS
   geometry (most likely `position: fixed` anchored to the layout viewport, which iOS
   does not shrink for the keyboard). Scope it after the trace, not before.
3. **#79.** Does tap-and-hold selection in scrollback still fail with the keyboard up?
   A device-tuned fix already shipped across three iterations (`keepKeyboard.ts`: v1
   2026-07-03, long-press duration gate 2026-07-04, #366 `touchend` select-all
   2026-07-21) plus the CSS `user-select` re-enable. If it still repros, it is
   device-debugging on that module — there is nothing to add on the writer.

## Gates

`bun run check` exit 0 · `tsc --noEmit` exit 0 · `bun run test` 214 files / 3858 tests
exit 0.