### PR TITLE
fix(#673): render WHOIS extra_lines in the card

### DIFF
--- a/cicchetto/src/WhoisCard.tsx
+++ b/cicchetto/src/WhoisCard.tsx
@@ -95,7 +95,11 @@ const WhoisCard: Component<Props> = (props) => {
       // #221 — solanum-specific fields also count as "has data".
       b.account !== null ||
       b.secure ||
-      b.certfp !== null
+      b.certfp !== null ||
+      // #673 — an oper-only or privacy-stripped reply can carry nothing
+      // but an extra line; without this the card claims "no WHOIS
+      // information returned" while holding the line /whois was run for.
+      (b.extra_lines?.length ?? 0) > 0
     );
   };
 
@@ -227,6 +231,35 @@ const WhoisCard: Component<Props> = (props) => {
                 <dd>
                   <For each={b().channels ?? []}>
                     {(chan) => <span class="whois-card-channel">{chan}</span>}
+                  </For>
+                </dd>
+              </Show>
+              {/* #673 — every WHOIS-leg numeric with no typed field, which
+                  #221's generic catch collects and nothing rendered until
+                  now: 340 RPL_SHUNNED (bahamut, oper-only), 320
+                  RPL_WHOISSPECIAL (solanum), and whatever either ircd adds
+                  next. Rendered LAST so the typed rows keep their shape.
+
+                  Order is the wire's: the server accumulator prepends LIFO
+                  for O(1) fold and `Grappa.Session.Wire.reverse_extra_lines/1`
+                  reverses on emit, so this list arrives in arrival order —
+                  render as-is, never reverse here.
+
+                  The text is the ircd's trailing param, i.e. upstream
+                  English, NOT a grappa-authored string — the i18n pass must
+                  NOT translate it (same class as `oper_text` / `server_info`
+                  above). It routes through MircBody because a services-set
+                  line can carry mIRC colour (#142). The numeric is oper
+                  diagnostics, so it rides in `title` rather than the body. */}
+              <Show when={(b().extra_lines?.length ?? 0) > 0}>
+                <dt>info</dt>
+                <dd>
+                  <For each={b().extra_lines ?? []}>
+                    {(line) => (
+                      <div class="whois-card-extra-line" title={`numeric ${line.numeric}`}>
+                        <MircBody body={line.text} />
+                      </div>
+                    )}
                   </For>
                 </dd>
               </Show>

--- a/cicchetto/src/__tests__/WhoisCard.test.tsx
+++ b/cicchetto/src/__tests__/WhoisCard.test.tsx
@@ -318,3 +318,99 @@ describe("WhoisCard #221 solanum fields", () => {
     expect(card.textContent).not.toContain("account");
   });
 });
+
+// #673 — `extra_lines` rendered by nobody. #221 built the whole generic
+// catch (any WHOIS-leg numeric with no typed field folds into
+// `extra_lines`), the wire carried it, `userTopic.ts` validated it — and
+// the card discarded it. The reported symptom was Azzurra's 340
+// RPL_SHUNNED (oper-only) vanishing, but the perimeter is every untyped
+// WHOIS numeric: on Libera that also silently dropped 320
+// RPL_WHOISSPECIAL, the very case #221's generic catch was written for.
+//
+// Order note: the server accumulator prepends LIFO for O(1) fold and
+// `Grappa.Session.Wire.reverse_extra_lines/1` reverses on emit, so the
+// wire delivers ARRIVAL order. The card must render that order as-is —
+// a card-side reverse would ship lines backwards. Locked below.
+describe("WhoisCard #673 extra_lines", () => {
+  afterEach(() => {
+    dismissWhoisCard("azzurra");
+  });
+
+  it("renders the extra_line text for a shunned user (340 RPL_SHUNNED)", () => {
+    setWhoisBundle("azzurra", {
+      ...baseBundle,
+      extra_lines: [{ numeric: 340, text: "is currently shunned" }],
+    });
+    render(() => <WhoisCard networkSlug="azzurra" />);
+    expect(screen.getByTestId("whois-card").textContent).toContain("is currently shunned");
+  });
+
+  it("renders multiple extra_lines in ARRIVAL order", () => {
+    setWhoisBundle("azzurra", {
+      ...baseBundle,
+      extra_lines: [
+        { numeric: 320, text: "is a volunteer staff member" },
+        { numeric: 340, text: "is currently shunned" },
+      ],
+    });
+    render(() => <WhoisCard networkSlug="azzurra" />);
+    const lines = screen.getByTestId("whois-card").querySelectorAll(".whois-card-extra-line");
+    expect(Array.from(lines, (el) => el.textContent)).toEqual([
+      "is a volunteer staff member",
+      "is currently shunned",
+    ]);
+  });
+
+  it("exposes the numeric on hover, keeping it out of the card body text", () => {
+    // The bare trailing text keeps the card readable; the numeric is
+    // oper-facing diagnostics, so it rides in `title` instead.
+    setWhoisBundle("azzurra", {
+      ...baseBundle,
+      extra_lines: [{ numeric: 340, text: "is currently shunned" }],
+    });
+    render(() => <WhoisCard networkSlug="azzurra" />);
+    const card = screen.getByTestId("whois-card");
+    expect(card.querySelector(".whois-card-extra-line")?.getAttribute("title")).toContain("340");
+    expect(card.textContent).not.toContain("340");
+  });
+
+  it("routes extra_line text through the mIRC renderer, never leaking raw control bytes", () => {
+    // Same class as `oper_text` / swhois (#142): a services-set line can
+    // carry mIRC formatting, so it must not be interpolated raw.
+    setWhoisBundle("azzurra", {
+      ...baseBundle,
+      extra_lines: [{ numeric: 320, text: "\x0304is a volunteer staff member\x0f" }],
+    });
+    render(() => <WhoisCard networkSlug="azzurra" />);
+    const card = screen.getByTestId("whois-card");
+    expect(card.textContent).toContain("is a volunteer staff member");
+    for (const byte of ["\x03", "\x0f"]) {
+      expect(card.textContent).not.toContain(byte);
+    }
+  });
+
+  it("treats extra_lines as data — no empty banner when it is the ONLY field", () => {
+    // A privacy-stripped or oper-only reply can carry nothing but an
+    // extra_line. Without this the card renders "no WHOIS information
+    // returned" while holding the very line the user ran /whois for.
+    setWhoisBundle("azzurra", {
+      ...baseBundle,
+      user: null,
+      host: null,
+      realname: null,
+      server: null,
+      server_info: null,
+      extra_lines: [{ numeric: 340, text: "is currently shunned" }],
+    });
+    render(() => <WhoisCard networkSlug="azzurra" />);
+    const card = screen.getByTestId("whois-card");
+    expect(card.textContent).toContain("is currently shunned");
+    expect(card.textContent).not.toContain("no WHOIS information returned");
+  });
+
+  it("renders no extra-line row when extra_lines is null (the bahamut-plain path)", () => {
+    setWhoisBundle("azzurra", baseBundle);
+    render(() => <WhoisCard networkSlug="azzurra" />);
+    expect(screen.getByTestId("whois-card").querySelector(".whois-card-extra-line")).toBeNull();
+  });
+});

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -7284,6 +7284,14 @@ html.resize-dragging * {
   color: var(--fg);
 }
 
+/* #673 — untyped WHOIS-leg lines (340 shun / 320 swhois / future). Each is
+   a full free-form sentence from the ircd, so they stack one per row rather
+   than running inline like channel names. */
+.whois-card-extra-line {
+  display: block;
+  color: var(--fg);
+}
+
 /* P-0b — peer-away banner. Renders IN-FLOW at the top of `.scrollback`
    in DM windows when the operator /msg's an away peer (#270 — moved out of
    the floating `.scrollback-overlay` so it reserves its own space and never

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -3259,6 +3259,9 @@ defmodule Grappa.Session.EventRouter do
   # which for these codes is inherently free-form and network-defined).
   # Prepends for O(1) fold (mirror of who_fold/replies); the wire projection
   # `SessionWire.whois_bundle/3` reverses so cic sees arrival order.
+  # The reverse itself lives in `Grappa.Session.Wire.reverse_extra_lines/1`
+  # (`lib/grappa/session/wire.ex`) — named here because #673 was filed as an
+  # order bug on the strength of grepping only this file and `userTopic.ts`.
   @spec whois_extra_line_fold(state(), String.t(), 1..999, String.t()) :: state()
   defp whois_extra_line_fold(state, target, code, text)
        when is_binary(target) and is_integer(code) and is_binary(text) do

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -3768,6 +3768,31 @@ defmodule Grappa.Session.EventRouterTest do
              ]
     end
 
+    # #673 — the REAL numeric behind the bug report, not a hypothetical.
+    # 340 RPL_SHUNNED is bahamut's oper-only shun line, emitted inside the
+    # WHOIS block right after 311 (`azzurra/bahamut include/numeric.h:255`,
+    # `src/s_user.c:2217`). It has no typed field, so it MUST keep reaching
+    # the generic catch: the day someone deny-lists it — or types it into
+    # @delegated_numerics/@active_numerics without adding a fold — the shun
+    # silently disappears from the card again. The 617 case above proves the
+    # generic path works for an unknown code; this pins 340 in particular.
+    test "340 RPL_SHUNNED (bahamut, oper-only) folds into extra_lines" do
+      state = whois_pending_state("alice")
+
+      m =
+        msg(
+          {:numeric, 340},
+          ["vjt", "alice", "is currently shunned"],
+          {:server, "irc.azzurra.org"}
+        )
+
+      {:cont, new_state, []} = EventRouter.route(m, state)
+
+      assert new_state.whois_pending["alice"][:extra_lines] == [
+               %{numeric: 340, text: "is currently shunned"}
+             ]
+    end
+
     test "multiple unknown numerics surface in extra_lines in arrival order (via the bundle)" do
       state = whois_pending_state("alice")
 


### PR DESCRIPTION
## What

`WhoisCard.tsx` never read `extra_lines`, so every WHOIS-leg numeric with no typed field was collected by the server, carried over the wire, validated by the client, and then dropped at render time. Reported by an oper who ran `/whois` on a shunned user and saw no shun line.

The perimeter is wider than the reported symptom: this was never "the shun line is missing", it is **every untyped WHOIS numeric is invisible**. On Azzurra that is `340 RPL_SHUNNED` (oper-only); on Libera it also silently dropped `320 RPL_WHOISSPECIAL` — the free-form staff line that `#221`'s own comment names as the case its generic catch was written for.

Rendered after the typed rows, in wire order, with the text through `MircBody` and the numeric on hover.

## The second defect in the issue is a phantom — dropped

The issue reports a second bug: `extra_lines` emitted in reverse arrival order, with the comment above the accumulator lying about it. **It does not exist**, and no code change was made for it.

- The reverse is real: `Grappa.Session.Wire.reverse_extra_lines/1` (`lib/grappa/session/wire.ex:1296-1298`), applied at `wire.ex:1292`.
- It is on the only emit path: `server.ex:4936-4937` `{:whois_bundle, …}` → `SessionWire.whois_bundle/3`.
- `test/grappa/session/event_router_test.exs:3771` **already** asserts end-to-end arrival order by draining the bundle at `318`.

The issue's claim that "there is no `Enum.reverse/1` anywhere on this field, on either side of the wire" came from grepping `event_router.ex` and `userTopic.ts`. The reverse lives in a third module neither search touched. Applying the issue's preferred fix (reverse at the `318` emit) would have **double-reversed and shipped the exact bug it imagined**. Confirmed independently by vjt before I built.

## Anti-recurrence

The code was correct and its comment accurate, but *unfindable* — that is what produced the wrong root-cause. So:

- The accumulator comment now names `Grappa.Session.Wire.reverse_extra_lines/1` and its file explicitly.
- A card-side test pins two entries in **arrival order**, so a future "helpful" reverse in the card fails loudly.
- An `event_router` test pins `340` on the generic catch, so deny-listing it (or typing it without a fold) fails a test instead of a user.

## UI call

vjt delegated this one. Bare text in the card body, numeric in `title` on hover: the numeric is oper diagnostics and would be per-line noise for everyone else. Text routes through `MircBody` because a services-set line can carry mIRC colour — the `#142` lesson, where `oper_text` / `umodes` / `actually_host` were dumped raw and leaked control bytes into the DOM.

`extra_lines` also now counts toward `hasFields()`: an oper-only or privacy-stripped reply can carry nothing else, and the card was otherwise claiming "no WHOIS information returned" while holding the exact line the user asked for.

## Tests

- `WhoisCard.test.tsx` — 6 new: shun text renders; **two entries in arrival order**; numeric on hover and out of body text; mIRC routing with no raw control bytes; `extra_lines`-only bundle shows no empty banner; null stays inert.
- `event_router_test.exs` — `340 RPL_SHUNNED` folds into `extra_lines`. Teeth verified by mutation: guarding the generic arm with `code != 340` kills this test and *only* this test.

**No e2e** — deliberate, not an omission. Driving this end-to-end needs an oper session plus an active server-side shun on the testnet; there is no deterministic setup for it, and the alternative `320` path was explicitly ruled out by vjt rather than faked. The arrival-order + render assertions live in vitest instead. Flagging it here so the gate can veto.

## Gates

- `scripts/check.sh` exit 0 — Credo 0 issues, **4929 tests / 0 failures**, Dialyzer passed, Sobelow, bats 221 ok.
- cic: `bun run check` exit 0, standalone `tsc --noEmit` exit 0 (biome short-circuits tsc, so it was run separately).
- Full vitest: **3828/3828 green**. First run showed 2 failures in `subscribe.test.ts` / `selection.test.ts` — untouched by this diff, green in isolation (131/131) and green on a clean re-run. Suite-order pollution from the known family, recorded here rather than dismissed.

Refs #673