### PR TITLE
fix(#661): the services console reads BOTH windows a service's replies can land in

### DIFF
--- a/cicchetto/src/RegistrationWizardModal.tsx
+++ b/cicchetto/src/RegistrationWizardModal.tsx
@@ -10,7 +10,6 @@ import {
   Show,
   Switch,
 } from "solid-js";
-import { channelKey } from "./lib/channelKey";
 import { sendBodyLines } from "./lib/compose";
 import { friendlyError } from "./lib/friendlyError";
 import { networkBySlug, networkIdBySlug } from "./lib/networks";
@@ -30,9 +29,8 @@ import {
   wizardBack,
   wizardNext,
 } from "./lib/registrationWizard";
-import { scrollbackByChannel } from "./lib/scrollback";
+import { serviceMirrorRows } from "./lib/serviceModal";
 import { umodesForNetwork } from "./lib/umodes";
-import { SERVER_WINDOW_NAME } from "./lib/windowKinds";
 import { MircBody } from "./MircText";
 
 // #349 — guided NickServ registration wizard. Launched from the Home
@@ -109,14 +107,18 @@ const RegistrationWizardModal: Component = () => {
         };
         onCleanup(clearTimer);
 
-        // NickServ NOTICE mirror for the current send-step: $server rows
-        // for this network with id > stepSinceId, raw via MircBody. Zero
-        // content parsing — a structural (id) bound only.
+        // NickServ NOTICE mirror for the current send-step: this network's
+        // rows from wherever the server routes the service's replies —
+        // `$server`, or the service's own query window when the operator has
+        // one open (#400/#661, `serviceMirrorRows`) — with id > stepSinceId,
+        // raw via MircBody. Zero content parsing — a structural (id) bound
+        // only. Reading `$server` alone left the wizard's mirror permanently
+        // empty for an operator with a NickServ query open, and step 4 is
+        // USER-advanced off reading that reply: not cosmetic, unadvanceable.
         const lines = () => {
           const s = st();
-          const rows = scrollbackByChannel()[channelKey(s.networkSlug, SERVER_WINDOW_NAME)] ?? [];
           const nick = template()?.servicesNick ?? "NickServ";
-          return rows.filter(
+          return serviceMirrorRows(s.networkSlug, nick).filter(
             (m) => m.id > s.stepSinceId && m.kind === "notice" && nickEquals(m.sender, nick),
           );
         };
@@ -139,7 +141,7 @@ const RegistrationWizardModal: Component = () => {
           setTimedOut(false);
           clearTimer();
           setWizardError(null);
-          setStepSince();
+          setStepSince(tmpl.servicesNick);
           setWizardPending(true);
           sendBodyLines(s.networkSlug, tmpl.servicesNick, body, false)
             .then(() => {

--- a/cicchetto/src/ServiceModal.tsx
+++ b/cicchetto/src/ServiceModal.tsx
@@ -1,20 +1,18 @@
 import { type Component, createEffect, createSignal, For, Show } from "solid-js";
-import { channelKey } from "./lib/channelKey";
 import { sendBodyLines } from "./lib/compose";
 import { friendlyError } from "./lib/friendlyError";
 import { nickEquals } from "./lib/nickEquals";
 import { createOverlayLock } from "./lib/overlayScrollLock";
-import { scrollbackByChannel } from "./lib/scrollback";
-import { closeServiceModal, serviceModalState } from "./lib/serviceModal";
-import { SERVER_WINDOW_NAME } from "./lib/windowKinds";
+import { closeServiceModal, serviceMirrorRows, serviceModalState } from "./lib/serviceModal";
 import { MircBody } from "./MircText";
 
 // #290 — dedicated services console modal. Opened ONLY by a bare services
 // command (`/ns`, `/cs`, `/ms`, …) via compose.ts's `service-modal` arm
 // (which also fires `help`). Titled by the service; the body is a
-// notice-mirror derived from the $server scrollback (where the server routes
-// services-sender NOTICEs), filtered CLIENT-SIDE to THIS service and to
-// while-open arrivals (`id > sinceId`). Nick is stripped per line — the
+// notice-mirror derived from the scrollback windows the server routes
+// services-sender NOTICEs to (`$server`, or the service's own query window
+// when one is open — #400/#661, `serviceMirrorRows`), filtered CLIENT-SIDE to
+// THIS service and to while-open arrivals (`id > sinceId`). Nick is stripped per line — the
 // service name lives in the title, not repeated on every row. A bottom `>`
 // prompt sends raw commands to the service (same wire path as `/ns <cmd>`),
 // whose reply NOTICEs mirror back into the body. The notices ALSO stay in the
@@ -51,15 +49,16 @@ const ServiceModal: Component = () => {
         // "no silent-swallow at boundaries"; same posture as ComposeBox).
         const [sendError, setSendError] = createSignal<string | null>(null);
 
-        // Notice-mirror: the $server rows for this network, filtered to this
-        // service's notices that arrived AFTER open. Reactive on the
-        // scrollback signal — live NOTICEs append and appear here.
-        const lines = () => {
-          const rows = scrollbackByChannel()[channelKey(st.networkSlug, SERVER_WINDOW_NAME)] ?? [];
-          return rows.filter(
+        // Notice-mirror: this network's rows from wherever the server routes
+        // this service's arrivals — `$server`, or the service's own query
+        // window when the operator has one open (#400; see
+        // `serviceMirrorRows`) — filtered to this service's notices that
+        // arrived AFTER open. Reactive on the scrollback signal, so live
+        // NOTICEs append and appear here whichever window they land in.
+        const lines = () =>
+          serviceMirrorRows(st.networkSlug, st.service).filter(
             (m) => m.id > st.sinceId && m.kind === "notice" && nickEquals(m.sender, st.service),
           );
-        };
 
         const send = (): void => {
           const line = draft().trim();

--- a/cicchetto/src/__tests__/ServiceModal.test.tsx
+++ b/cicchetto/src/__tests__/ServiceModal.test.tsx
@@ -19,10 +19,16 @@ vi.mock("../lib/compose", () => ({
   sendBodyLines: vi.fn().mockResolvedValue(undefined),
 }));
 
-const notice = (slug: string, id: number, sender: string, body: string): ScrollbackMessage => ({
+const noticeIn = (
+  slug: string,
+  id: number,
+  sender: string,
+  channel: string,
+  body: string,
+): ScrollbackMessage => ({
   id,
   network: slug,
-  channel: SERVER_WINDOW_NAME,
+  channel,
   server_time: id,
   kind: "notice",
   sender,
@@ -30,10 +36,18 @@ const notice = (slug: string, id: number, sender: string, body: string): Scrollb
   meta: {},
 });
 
+const notice = (slug: string, id: number, sender: string, body: string): ScrollbackMessage =>
+  noticeIn(slug, id, sender, SERVER_WINDOW_NAME, body);
+
 // Each test uses a distinct slug so the $server scrollback singleton stays
 // isolated across cases (no cross-test id/high-water-mark bleed).
 const seed = (slug: string, m: ScrollbackMessage): void =>
   appendToScrollback(channelKey(slug, SERVER_WINDOW_NAME), m);
+
+// #661 — seed the service's OWN query window, where the server (#400) re-keys
+// its arrivals whenever the operator has that window open.
+const seedQuery = (slug: string, service: string, m: ScrollbackMessage): void =>
+  appendToScrollback(channelKey(slug, service), m);
 
 describe("ServiceModal (#290)", () => {
   afterEach(() => {
@@ -68,6 +82,37 @@ describe("ServiceModal (#290)", () => {
     }
     // ...and the pre-open notice is NOT mirrored (capture only while open).
     expect(texts.some((t) => t.includes("stale line from a past session"))).toBe(false);
+  });
+
+  // #661 — the reported field bug: with a NickServ QUERY WINDOW open, the
+  // console looked dead (empty "waiting for NickServ to reply…" forever) while
+  // the help wall piled up in the query behind it. Cause: the server's #400
+  // rule re-keys a services arrival to that service's query window when one is
+  // open, so the reply NOTICEs never reach `$server` — the only window this
+  // mirror used to read. The modal is a view over wherever the service's
+  // notices land, so it reads both windows; a mid-open close of the query
+  // (arrivals switch back to `$server`) keeps rendering for the same reason.
+  it("mirrors notices re-keyed to the service's OPEN query window (#400), still capturing only while open", () => {
+    const slug = "svc-open-query";
+    seedQuery(slug, "NickServ", noticeIn(slug, 20, "NickServ", "NickServ", "stale query line"));
+    openServiceModal(slug, "NickServ"); // sinceId = 20 (high-water across both windows)
+    seedQuery(
+      slug,
+      "NickServ",
+      noticeIn(slug, 21, "NickServ", "NickServ", "help wall landed in the query"),
+    );
+    seed(slug, notice(slug, 22, "NickServ", "and this one landed on $server"));
+    render(() => <ServiceModal />);
+
+    const texts = screen.getAllByTestId("service-modal-line").map((l) => l.textContent ?? "");
+    expect(texts.some((t) => t.includes("help wall landed in the query"))).toBe(true);
+    expect(texts.some((t) => t.includes("and this one landed on $server"))).toBe(true);
+    expect(texts.some((t) => t.includes("stale query line"))).toBe(false);
+    // Merged in id order — the two windows interleave chronologically, they
+    // don't render as two concatenated blocks.
+    expect(texts.findIndex((t) => t.includes("in the query"))).toBeLessThan(
+      texts.findIndex((t) => t.includes("on $server")),
+    );
   });
 
   it("filters to THIS service — a different service's notice is not shown", () => {

--- a/cicchetto/src/__tests__/registrationWizard.test.ts
+++ b/cicchetto/src/__tests__/registrationWizard.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { ScrollbackMessage } from "../lib/api";
+import { channelKey } from "../lib/channelKey";
+import {
+  closeRegistrationWizard,
+  openRegistrationWizard,
+  registrationWizardState,
+  setStepSince,
+} from "../lib/registrationWizard";
+import { appendToScrollback } from "../lib/scrollback";
+import { SERVER_WINDOW_NAME } from "../lib/windowKinds";
+
+// #349 store — `stepSinceId` is the structural bound the wizard's NOTICE
+// mirror renders against: replies to THIS send-step are the rows above it.
+// #661 — the bound (like the ServiceModal mirror it shares `serviceMirrorRows`
+// with) spans BOTH windows a services reply can land in, because the server
+// (#400) re-keys the reply to the service's own query window whenever the
+// operator has one open. A `$server`-only high-water would sit BELOW that
+// window's pre-open history and dump it into the wizard as if it were this
+// step's reply.
+
+const notice = (
+  slug: string,
+  id: number,
+  sender: string,
+  channel: string,
+  body: string,
+): ScrollbackMessage => ({
+  id,
+  network: slug,
+  channel,
+  server_time: id,
+  kind: "notice",
+  sender,
+  body,
+  meta: {},
+});
+
+describe("registrationWizard store — setStepSince (#349/#661)", () => {
+  afterEach(() => closeRegistrationWizard());
+
+  it("high-waters across $server AND the services nick's open query window", () => {
+    const slug = "wiz-hw-open-query";
+    appendToScrollback(
+      channelKey(slug, SERVER_WINDOW_NAME),
+      notice(slug, 3, "NickServ", SERVER_WINDOW_NAME, "stale $server line"),
+    );
+    appendToScrollback(
+      channelKey(slug, "NickServ"),
+      notice(slug, 9, "NickServ", "NickServ", "stale line in the open query"),
+    );
+
+    openRegistrationWizard(slug);
+    setStepSince("NickServ");
+
+    expect(registrationWizardState()?.stepSinceId).toBe(9);
+  });
+
+  it("high-waters to 0 on a network with no history in either window", () => {
+    openRegistrationWizard("wiz-hw-empty");
+    setStepSince("NickServ");
+
+    expect(registrationWizardState()?.stepSinceId).toBe(0);
+  });
+
+  it("is a no-op once the wizard is closed (a late setter never resurrects it)", () => {
+    openRegistrationWizard("wiz-hw-closed");
+    closeRegistrationWizard();
+    setStepSince("NickServ");
+
+    expect(registrationWizardState()).toBeNull();
+  });
+});

--- a/cicchetto/src/__tests__/serviceModal.test.ts
+++ b/cicchetto/src/__tests__/serviceModal.test.ts
@@ -13,16 +13,25 @@ import { SERVER_WINDOW_NAME } from "../lib/windowKinds";
 
 const SLUG = "azzurra";
 
-const notice = (id: number, sender: string, body: string): ScrollbackMessage => ({
+const queryNotice = (
+  slug: string,
+  id: number,
+  sender: string,
+  channel: string,
+  body: string,
+): ScrollbackMessage => ({
   id,
-  network: SLUG,
-  channel: SERVER_WINDOW_NAME,
+  network: slug,
+  channel,
   server_time: id,
   kind: "notice",
   sender,
   body,
   meta: {},
 });
+
+const notice = (id: number, sender: string, body: string): ScrollbackMessage =>
+  queryNotice(SLUG, id, sender, SERVER_WINDOW_NAME, body);
 
 describe("serviceModal store (#290)", () => {
   afterEach(() => closeServiceModal());
@@ -40,6 +49,27 @@ describe("serviceModal store (#290)", () => {
     openServiceModal(SLUG, "NickServ");
 
     expect(serviceModalState()?.sinceId).toBe(42);
+  });
+
+  // #661 — the server (#400) re-keys a services arrival to the service's OWN
+  // query window when the operator has one open, so the high-water mark must
+  // span BOTH windows. Taking only $server would leave the query window's
+  // pre-open history above `sinceId` and leak it into the modal on open —
+  // exactly the "capture only while open" rule this field guards.
+  it("captures the high-water mark across $server AND the service's query window (#400 re-key)", () => {
+    const slug = "svc-hw-open-query";
+    appendToScrollback(
+      channelKey(slug, SERVER_WINDOW_NAME),
+      queryNotice(slug, 41, "NickServ", SERVER_WINDOW_NAME, "stale $server line"),
+    );
+    appendToScrollback(
+      channelKey(slug, "NickServ"),
+      queryNotice(slug, 55, "NickServ", "NickServ", "stale line in the open query"),
+    );
+
+    openServiceModal(slug, "NickServ");
+
+    expect(serviceModalState()?.sinceId).toBe(55);
   });
 
   it("sinceId is 0 when the $server window is empty (fresh network)", () => {

--- a/cicchetto/src/lib/registrationWizard.ts
+++ b/cicchetto/src/lib/registrationWizard.ts
@@ -1,7 +1,5 @@
 import { createRoot, createSignal } from "solid-js";
-import { channelKey } from "./channelKey";
-import { scrollbackByChannel } from "./scrollback";
-import { SERVER_WINDOW_NAME } from "./windowKinds";
+import { serviceMirrorRows } from "./serviceModal";
 
 // #349 — NickServ registration wizard open/close + step store.
 //
@@ -47,7 +45,7 @@ export type RegistrationWizardState = {
   email: string;
   password: string;
   code: string;
-  // High-water `$server` message id captured when a send-step (4 / 6)
+  // High-water mirror message id captured when a send-step (4 / 6)
   // fires (via `setStepSince`). The modal mirrors NickServ NOTICEs with
   // `id > stepSinceId` — a structural bound on "replies to THIS step",
   // NOT a parse of their text (#91 no-scraping rule).
@@ -102,12 +100,18 @@ const exports_ = createRoot(() => {
     patch((st) => ({ ...st, step: clampStep(st.step - 1), error: null }));
   };
 
-  // Capture the `$server` high-water mark for the wizard's network so the
-  // modal's NOTICE mirror shows only replies that arrive AFTER this
-  // send-step fired. Mirrors `openServiceModal`'s sinceId capture.
-  const setStepSince = (): void => {
+  // Capture the mirror high-water mark for the wizard's network so the modal's
+  // NOTICE mirror shows only replies that arrive AFTER this send-step fired.
+  // Shares `serviceMirrorRows` with `openServiceModal` — same capture, and the
+  // same #400/#661 reason for spanning both windows: with the operator's
+  // NickServ query window open the server re-keys every REGISTER/VERIFY reply
+  // THERE, so a `$server`-only high-water both misses the replies and leaves
+  // the query's pre-open history above the bound. `service` is the network's
+  // services nick (the wizard's `template.servicesNick`), passed in by the
+  // caller that already resolved the template.
+  const setStepSince = (service: string): void => {
     patch((st) => {
-      const rows = scrollbackByChannel()[channelKey(st.networkSlug, SERVER_WINDOW_NAME)] ?? [];
+      const rows = serviceMirrorRows(st.networkSlug, service);
       const stepSinceId = rows.reduce((max, m) => (m.id > max ? m.id : max), 0);
       return { ...st, stepSinceId };
     });

--- a/cicchetto/src/lib/serviceModal.ts
+++ b/cicchetto/src/lib/serviceModal.ts
@@ -1,4 +1,5 @@
 import { createRoot, createSignal } from "solid-js";
+import type { ScrollbackMessage } from "./api";
 import { channelKey } from "./channelKey";
 import { scrollbackByChannel } from "./scrollback";
 import { SERVER_WINDOW_NAME } from "./windowKinds";
@@ -12,12 +13,13 @@ import { SERVER_WINDOW_NAME } from "./windowKinds";
 // modal; ServiceModal.tsx derives its notice-mirror body from the $server
 // scrollback filtered to this service.
 //
-// `sinceId` is the $server high-water mark captured at open: the modal shows
+// `sinceId` is the mirror high-water mark captured at open: the modal shows
 // ONLY service notices with `id > sinceId`, i.e. those that arrive WHILE it
 // is open (spec: "capturing only while open" — shrinks the display-only
-// phishing surface). Derived from the EXISTING $server scrollback store, not
-// a duplicated capture buffer — the notices stay in $server (mirror, not
-// move; nothing lost), the modal is a filtered live view over them.
+// phishing surface). Derived from the EXISTING scrollback store, not a
+// duplicated capture buffer — the notices stay in their window (mirror, not
+// move; nothing lost), the modal is a filtered live view over them. Which
+// window that is depends on the server's #400 rule: see `serviceMirrorRows`.
 //
 // Module-singleton signal (like modeModal / umodeModal) — the modal is
 // transient UI, not identity-scoped survival state. A logout unmounts the
@@ -29,19 +31,43 @@ export type ServiceModalTarget = {
   sinceId: number;
 };
 
+// #661 — the two windows a service's arrivals can land in, merged in id order.
+//
+// The server routes a services-sender NOTICE/PRIVMSG to `$server` — UNLESS the
+// operator has that service's own query window open, in which case it lands
+// THERE (#400, `EventRouter.service_route_channel/2`). Reading only `$server`
+// made the console look dead exactly for the operator who had a NickServ query
+// open: modal up, help wall piling into the query behind it, mirror empty
+// forever. The mirror is a view over wherever the notices land, so it spans
+// both; the union also needs no open/closed flag of its own (a closed query
+// contributes an empty list) and survives the operator closing the query while
+// the modal is open — the two SSOTs cannot drift because there is no second
+// copy of the routing rule here, just both destinations.
+//
+// Ids are globally monotonic (`messages.id`), so a plain id sort interleaves
+// the two windows chronologically.
+export const serviceMirrorRows = (networkSlug: string, service: string): ScrollbackMessage[] => {
+  const byChannel = scrollbackByChannel();
+  const server = byChannel[channelKey(networkSlug, SERVER_WINDOW_NAME)] ?? [];
+  const query = byChannel[channelKey(networkSlug, service)] ?? [];
+  if (query.length === 0) return server;
+  return [...server, ...query].sort((a, b) => a.id - b.id);
+};
+
 const exports_ = createRoot(() => {
   const [serviceModalState, setServiceModalState] = createSignal<ServiceModalTarget | null>(null);
 
   const openServiceModal = (networkSlug: string, service: string): void => {
-    // High-water mark of the $server window at open time: the max message id
-    // currently loaded (0 for a fresh/empty window). Any service notice that
+    // High-water mark at open time: the max message id currently loaded across
+    // both mirror windows (0 for a fresh/empty pair). Any service notice that
     // arrives after open gets a higher id (ids are monotonic per the messages
-    // schema), so `id > sinceId` selects exactly the while-open arrivals.
+    // schema), so `id > sinceId` selects exactly the while-open arrivals — and
+    // spanning both windows keeps an open query's own history from leaking in.
     // Assumes the $server subscription has already seeded local history (the
-    // common case — cic subscribes at connect). If $server is empty here
+    // common case — cic subscribes at connect). If it is empty here
     // (sinceId=0) and a later reconnect refresh backfills pre-open notices,
     // they could surface once; display-only, so a benign, low-probability edge.
-    const rows = scrollbackByChannel()[channelKey(networkSlug, SERVER_WINDOW_NAME)] ?? [];
+    const rows = serviceMirrorRows(networkSlug, service);
     const sinceId = rows.reduce((max, m) => (m.id > max ? m.id : max), 0);
     setServiceModalState({ networkSlug, service, sinceId });
   };

--- a/cicchetto/src/lib/serviceModal.ts
+++ b/cicchetto/src/lib/serviceModal.ts
@@ -46,7 +46,13 @@ export type ServiceModalTarget = {
 //
 // Ids are globally monotonic (`messages.id`), so a plain id sort interleaves
 // the two windows chronologically.
-export const serviceMirrorRows = (networkSlug: string, service: string): ScrollbackMessage[] => {
+// Returns a READONLY view: the `$server`-only fast path hands back the live
+// store array itself (no copy on the hot reactive read), so the type is the
+// guard against a caller mutating the scrollback in place.
+export const serviceMirrorRows = (
+  networkSlug: string,
+  service: string,
+): readonly ScrollbackMessage[] => {
   const byChannel = scrollbackByChannel();
   const server = byChannel[channelKey(networkSlug, SERVER_WINDOW_NAME)] ?? [];
   const query = byChannel[channelKey(networkSlug, service)] ?? [];
@@ -63,9 +69,9 @@ const exports_ = createRoot(() => {
     // arrives after open gets a higher id (ids are monotonic per the messages
     // schema), so `id > sinceId` selects exactly the while-open arrivals — and
     // spanning both windows keeps an open query's own history from leaking in.
-    // Assumes the $server subscription has already seeded local history (the
-    // common case — cic subscribes at connect). If it is empty here
-    // (sinceId=0) and a later reconnect refresh backfills pre-open notices,
+    // Assumes both windows' subscriptions have already seeded local history
+    // (the common case — cic subscribes at connect). If either has not landed
+    // yet and a later refresh backfills its pre-open notices above the mark,
     // they could surface once; display-only, so a benign, low-probability edge.
     const rows = serviceMirrorRows(networkSlug, service);
     const sinceId = rows.reduce((max, m) => (m.id > max ? m.id : max), 0);

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -26710,3 +26710,49 @@ into ci.yml next to the #503 deploy-script gate. cfn-lint is BEST-EFFORT (no AWS
 creds in CI). Acceptance — clean account → HTTPS, ≥2 regions, stack fully
 deletes — is a MANUAL vjt check, reported PENDING; the template + script were
 built and tested against their SHAPE, not a live AWS account.
+
+## 2026-08-03 — #661: the services console mirrors BOTH windows a service's notices can land in (#400 re-key)
+
+**Field report.** With a NickServ **query window open**, a bare `/ns` looked
+like it did nothing; closing the query made the console work. Deterministic
+toggle, reported with a screenshot, never reproduced by the issue author.
+
+**Neither of the two hypothesised loci was the cause.** The dispatch is
+window-agnostic (`parseServiceShortcut` returns `{kind:"service-modal"}` on
+`rest === ""` without consulting the active window, and `ComposeBox`'s submit
+path has no query-window branch), and the mount is unconditional (`ServiceModal`
+sits at the root of BOTH Shell branches; `Show when={state()}` renders as soon
+as the store is non-null). The modal **did** open — it opened **empty**, stuck
+on `(waiting for NickServ to reply…)` while the help wall piled up in the query
+window behind it. An empty console reads as "it didn't open".
+
+**Root cause: two SSOTs disagreed about WHERE a service's replies land.** The
+server's #400 rule (`EventRouter.service_route_channel/2`, shared by the NOTICE
+and the DM-shaped-PRIVMSG arms, twinned by `resolve_numeric_query_window/2` on
+the numeric door) re-keys a services-sender arrival to `$server` **UNLESS the
+operator has that service's own query window open** — then it lands THERE. cic's
+mirror read `$server` and only `$server`, so the exact configuration #400 exists
+to serve was the one configuration the console could not see. cic had **zero**
+references to #400: the client half of that rule was never written.
+
+**Fix — one derivation, both destinations** (`serviceMirrorRows/2` in
+`lib/serviceModal.ts`, consumed by `ServiceModal.tsx`'s `lines()` **and** by
+`openServiceModal`'s high-water capture). The union needs no open/closed flag of
+its own: a closed query contributes an empty list, so there is no second copy of
+the routing rule on the client to drift from the server's — the mirror simply
+reads *both* places a notice can be. It also survives the operator closing the
+query mid-open (arrivals switch back to `$server`, rendering continues) and the
+reverse. `messages.id` is globally monotonic, so a plain id sort interleaves the
+two windows chronologically instead of concatenating two blocks.
+
+**`sinceId` had to widen with it.** The high-water mark now spans both windows;
+taking only `$server`'s max would leave an open query's *pre-open* history above
+the threshold and dump it into the modal on open — breaking the "capture only
+while open" rule that shrinks the display-only phishing surface.
+
+**Apply:** when the server routes the same domain event to one of N destinations
+by a rule, a client view over that event reads **all N** — it does not
+re-implement the rule (that is the parallel state machine CLAUDE.md forbids) and
+it does not read only the common one. A conditional server-side re-key is a
+contract the client half has to be written for; grep the issue number on the
+client side before assuming it was.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -26750,6 +26750,17 @@ taking only `$server`'s max would leave an open query's *pre-open* history above
 the threshold and dump it into the modal on open — breaking the "capture only
 while open" rule that shrinks the display-only phishing surface.
 
+**Second site, same blindness (found in review).** The #349 registration wizard
+mirrors NickServ the same way and carried the same `$server`-only read — in
+`setStepSince` (the step high-water) *and* in `RegistrationWizardModal`'s
+`lines()`, whose moduledoc already said it mirrored `openServiceModal`. There it
+is worse than cosmetic: step 4 (REGISTER) is USER-advanced off *reading* the
+reply — REGISTER has no structural success terminator — so an operator with a
+NickServ query open got an empty, unadvanceable-by-reading wizard. Both now
+consume `serviceMirrorRows`, and `setStepSince/1` takes the services nick from
+the caller that already resolved the template (no default argument). Fixing only
+the reported console would have left the same defect one modal away.
+
 **Apply:** when the server routes the same domain event to one of N destinations
 by a rule, a client view over that event reads **all N** — it does not
 re-implement the rule (that is the parallel state machine CLAUDE.md forbids) and


### PR DESCRIPTION
Refs #661.

## What the bug actually was

The field report — with a **NickServ query window open**, a bare `/ns` "doesn't open" the #290 services console; **close the query and it works** — is **neither of the two loci the issue proposed**.

* **Not dispatch.** `parseServiceShortcut` returns `{kind:"service-modal"}` on empty args without ever consulting the active window, and `ComposeBox`'s submit path has no query-window branch.
* **Not the mount.** `<ServiceModal />` is mounted unconditionally at the root of *both* Shell branches (`Shell.tsx:523` desktop, `:772` mobile); `Show when={state()}` renders the moment the store is non-null.

The modal **did** open. It opened **empty** — pinned on `(waiting for NickServ to reply…)` forever while the help wall piled up in the query window behind it. An empty console reads as a console that never opened, which is why the reporter's toggle is perfectly deterministic and the author could not reproduce it (no query window open → no symptom).

**Root cause: two sources of truth disagreed about WHERE a service's replies land.** The server's #400 rule (`EventRouter.service_route_channel/2:2581`, shared by the NOTICE and DM-shaped-PRIVMSG arms, twinned by `resolve_numeric_query_window/2` on the numeric door) re-keys a services-sender arrival to `$server` **unless the operator has that service's own query window open** — then it lands *there*. cic's mirror read `$server` and only `$server`. The exact configuration #400 exists to serve was the one configuration the console could not see; cic carried **zero** references to #400 — the client half of that rule was never written.

## The fix

`serviceMirrorRows(networkSlug, service)` (`lib/serviceModal.ts`) derives the mirror from **both** destinations, merged in id order (`messages.id` is globally monotonic, so the windows interleave chronologically instead of concatenating as two blocks). The union deliberately carries **no open/closed flag of its own**: a closed query contributes an empty list, so there is no client-side copy of the routing rule to drift from the server's (the parallel state machine CLAUDE.md forbids), and closing the query mid-open keeps rendering as arrivals switch back to `$server`.

`openServiceModal`'s `sinceId` widens to the same union — a `$server`-only high-water would leave an open query's **pre-open** history above the threshold and dump it into the modal, breaking the "capture only while open" rule that shrinks the display-only phishing surface.

## Second site, found in review (commit 2)

The #349 **registration wizard** had the identical `$server`-only blindness in `setStepSince` *and* `RegistrationWizardModal.lines()` — its moduledoc already said it mirrored `openServiceModal`, and it inherited the defect with the pattern. There it is worse than cosmetic: **step 4 (REGISTER) is USER-advanced off reading the reply** (REGISTER has no structural success terminator; +r only arrives after verify), so the same precondition yields a wizard that cannot be advanced by reading. Both sites now consume `serviceMirrorRows`; `setStepSince/1` takes the services nick as a **required** parameter from the caller that already resolved the template (no default argument).

## Tests — cic vitest **+3** (214 files/3854 tests → 215/3857)

Each new test was **run red before the fix**, not written after it:

* `ServiceModal.test.tsx` — a query-window notice arriving *while open* renders; one from *before* the open does not; the two windows interleave by id. Red pre-fix: `expected false to be true`.
* `serviceModal.test.ts` — the high-water spans both windows. Red pre-fix: `expected 41 to be 55`.
* `registrationWizard.test.ts` (new file) — same for `setStepSince`, plus the empty-network and closed-wizard cases. Verified red pre-fix by patching the fix back out: `expected 3 to be 9`.

**No e2e.** Driving this end-to-end needs a peer holding the nick `NickServ` on the test ircd so the server's services allowlist fires — reserved/killed on a real bahamut, and the fixtures it would touch (`cicchettoPage.ts`) are actively being edited in another lane. The server half of the rule already has ExUnit coverage (`event_router_test.exs:996`, `query_windows_test.exs:305`); these tests pin the client half at the exact seam that was missing. Flagging the gap rather than shipping a hollow spec.

## Gates

* `scripts/bun.sh run check` (biome + tsc) — exit 0
* `scripts/bun.sh run test` — exit 0, **215 files / 3857 tests passed**
* Code review — one finding (the wizard), fixed in commit 2; two nits (comment precision, `readonly` return) also applied.

cic-only diff; no server code, no wire change, no new wire token.