### PR TITLE
fix(#676): auto-fallback the nick on a 433 at connect instead of failing the login

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -26835,3 +26835,79 @@ variable is a missing TRIGGER, not a missing writer. Add the trigger to the
 existing writer and reuse its existing correction schedule. And when an umbrella
 issue bundles N symptoms, verify each one is actually the same code surface
 before writing N fixes — here only one of the three was.
+
+---
+
+## 2026-08-03 — #676: a nick collision at connect is a fallback, not a dead end
+
+**The report.** A user on #grappa logged in with the nick they were already
+using from their own client on Libera, collided, and got no session at all —
+just a 409. The UI told them the nick was in use; the friction was entirely
+*"now what do I type, and where"*. They had to go find the nick field in
+settings → general to get in.
+
+**The shape of the gap.** Everything downstream of the 433 was already correct
+and honest: `AuthFSM` stopped the Client with `{:nick_rejected, 433, _}`,
+`Visitors.Login.classify_down/1` mapped it to `:nick_in_use`, the controller
+rendered a 409, cic showed friendly copy. Nothing was broken — we simply
+stopped where every IRC client since the 1990s would have retried.
+
+**Where the retry went, and why not somewhere else.** The underscore mechanism
+already existed in `Session.GhostRecovery` — including a `password: nil` clause
+whose whole job is to emit `NICK <nick>_`. That clause was **unreachable in
+production**: its only call site (`Session.Server`'s 433 handler) guards on
+`is_binary(pending_password)`, and an anon visitor has none. It was unit-tested,
+so it looked alive. Reaching it would ALSO have required an `AuthFSM` change
+(the FSM stops the Client before the host can drive anything), and it stops
+after ONE underscore — no bound, no random suffix, none of the decided shape.
+
+So the ladder went into `AuthFSM` instead, where it belongs: a 433 *during
+registration* is a registration-handshake concern, and the FSM is the module
+that owns the handshake. `GhostRecovery` keeps its 433 untouched — the new
+clause sits AFTER the `:nickserv_identify` arm on purpose, so a ladder NICK can
+never race the GHOST / recover-identity sequence off its own nick (#676 point
+5). **432 is deliberately NOT laddered**: an erroneous nick is a SHAPE
+rejection, so `<badnick>_` re-sends the same bad shape.
+
+**The ladder.** `<nick>_` first — the classic client move, and the spelling a
+returning user recognises as themselves. Then random 3-char suffixes, per vjt's
+ruling: a second underscore just walks into the next occupied slot on a busy
+network. The bound IS the list length (3), drawn ONCE in `new/1` so `step/2`
+stays pure and deterministic — the suffixes are DATA on the struct, not a
+per-step `:rand` call. Unbounded retries against a hostile or duplicated nick
+space is a respawn flood, the same trap the e2e fixtures hit with shared-leaf
+433 autokill.
+
+**NICKLEN: the spec point we could not honour as written.** The issue asked to
+"truncate on our side using the network's advertised NICKLEN". We cannot:
+NICKLEN lives in 005 RPL_ISUPPORT, which only arrives **after** 001, and the 433
+happens before it. The 433 line carries the evidence instead — an ircd that
+silently truncated our NICK rejects the **shortened** spelling, so an echo
+shorter than what we sent IS the cap. A proven cap then STICKS on the FSM
+state: the clamped candidate fits, so the next echo comes back verbatim and
+offers no second proof. Without both halves, a 30-char nick on a NICKLEN=16
+network retries with a candidate the server truncates straight back into the
+same collision, burning the whole ladder on one unreachable nick.
+`Identifier.collision_fallback/3` trims the BASE, never the suffix, for the same
+reason.
+
+**Telling the user (point 3).** A silent rename becomes permanent by accident.
+At 001, when the welcomed nick differs from the requested one, `EventRouter`
+persists a `:server_event` row on `$server` naming both. The comparison folds
+(`canonical_target/1`): `VJT` → `vjt` is the ircd normalising our own nick, not
+a different person, and announcing it would be noise on every connect to a
+case-normalising network. The row carries the facts structured in
+`meta.nick_fallback` **and** a plain body, so it is legible with no cic change —
+additive-only, no new wire token, no `protocol_version` bump. This fires for
+every divergence class, not just the ladder: a services rename or a truncation
+is equally worth saying out loud.
+
+**Scope held.** The in-session `/nick` path still fails loudly (#676 point 4):
+an explicit rename that silently lands somewhere else is worse than an error.
+
+**Apply:** before building a recovery mechanism, grep for whether one already
+exists — and then check whether its production call site can actually REACH it.
+A unit-tested branch behind a guard no caller satisfies reads as working code.
+And when a spec cites a protocol value, verify the value has arrived by the time
+you need it: "use the advertised NICKLEN" is unimplementable at 433 time, and
+the echo was the honest substitute sitting in the same line.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -26891,6 +26891,23 @@ same collision, burning the whole ladder on one unreachable nick.
 `Identifier.collision_fallback/3` trims the BASE, never the suffix, for the same
 reason.
 
+Code review found the first cut of that heuristic too credulous, and both
+failure modes were reproduced before fixing. It read the echo *positionally* and
+took any shorter string as proof, so (a) a 433 whose second param is a reason
+string clamped against the reason text, and (b) a duplicate/stale 433 still
+echoing the ORIGINAL nick, arriving while a longer candidate was already in
+flight, derived a 3-char cap — which with a 3-char suffix drove
+`collision_fallback/3` through its own `cap > suffix` guard and crashed the
+Client on the very numeric it was meant to recover from (a 502, where #676 was
+supposed to preserve the 409 at the end of the ladder). Two guards close both:
+proof of truncation requires the echo to be a **folded proper prefix** of what
+we sent (truncation means the server CUT our nick; nothing else counts), and an
+inferred cap is floored at 9, RFC 1459's NICKLEN — no real ircd advertises less,
+so a smaller number is never a short network, only a stale echo.
+`collision_fallback/3` stays deliberately partial: a cap too small to hold the
+suffix has no correct answer, since trimming the suffix would re-send the
+rejected nick.
+
 **Telling the user (point 3).** A silent rename becomes permanent by accident.
 At 001, when the welcomed nick differs from the requested one, `EventRouter`
 persists a `:server_event` row on `$server` naming both. The comparison folds

--- a/lib/grappa/irc/auth_fsm.ex
+++ b/lib/grappa/irc/auth_fsm.ex
@@ -73,6 +73,21 @@ defmodule Grappa.IRC.AuthFSM do
                                         advertise / NAK'd it
       {:nick_rejected, 432 | 433, n} -- upstream rejected NICK during register
 
+  ## Nick-collision fallback (#676)
+
+  A 433 during registration is NOT immediately fatal. The FSM walks a
+  bounded ladder of alternate nicks — `<nick>_`, then random-suffixed
+  variants — re-sending NICK for each and only stopping with
+  `{:nick_rejected, 433, _}` once the ladder is spent. `state.nick`
+  tracks the candidate in flight; 001's `welcomed_nick` is the final
+  authority (`Grappa.Session.EventRouter` reconciles it, and tells the
+  user when it differs from what they asked for).
+
+  Two carve-outs: `:nickserv_identify` keeps its silent `:cont` (the host
+  drives GHOST / recover-identity off that numeric), and 432 still stops
+  outright — an erroneous nick is a SHAPE rejection, so a suffixed retry
+  would re-send the same bad shape.
+
   Caller is responsible for Logger emission on stop reasons; the FSM
   itself emits no side effect beyond the returned `[iodata]` frames.
   """
@@ -108,6 +123,9 @@ defmodule Grappa.IRC.AuthFSM do
 
   @type t :: %__MODULE__{
           nick: String.t(),
+          orig_nick: String.t(),
+          nick_suffixes: [String.t()],
+          nick_cap: pos_integer(),
           ident: String.t(),
           realname: String.t(),
           sasl_user: String.t(),
@@ -117,7 +135,16 @@ defmodule Grappa.IRC.AuthFSM do
           caps_buffer: [String.t()]
         }
 
-  @enforce_keys [:nick, :ident, :realname, :sasl_user, :auth_method, :phase]
+  @enforce_keys [
+    :nick,
+    :orig_nick,
+    :nick_cap,
+    :ident,
+    :realname,
+    :sasl_user,
+    :auth_method,
+    :phase
+  ]
   # `:password` is the only secret on the struct — `@derive Inspect`
   # excludes it so SASL-report dumps + IEx `:sys.get_state/1` (transitively
   # via the host Client struct) introspection never leak plaintext.
@@ -125,12 +152,15 @@ defmodule Grappa.IRC.AuthFSM do
   @derive {Inspect, except: [:password]}
   defstruct [
     :nick,
+    :orig_nick,
     :ident,
     :realname,
     :sasl_user,
     :password,
     :auth_method,
     :phase,
+    :nick_cap,
+    nick_suffixes: [],
     caps_buffer: []
   ]
 
@@ -161,6 +191,9 @@ defmodule Grappa.IRC.AuthFSM do
       {:ok,
        %__MODULE__{
          nick: opts.nick,
+         orig_nick: opts.nick,
+         nick_suffixes: nick_fallback_ladder(),
+         nick_cap: Identifier.max_nick_length(),
          ident: opts.ident,
          realname: opts.realname,
          sasl_user: opts.sasl_user,
@@ -170,6 +203,24 @@ defmodule Grappa.IRC.AuthFSM do
          caps_buffer: []
        }}
     end
+  end
+
+  # #676 — the bounded 433 fallback ladder, drawn ONCE per connection so
+  # `step/2` stays pure and deterministic: the suffixes are DATA on the
+  # struct, not a per-step `:rand` call. Underscore first (the classic IRC
+  # client move, and the spelling a returning user recognises as "that's
+  # me"), then random tails — vjt's ruling, because a second underscore
+  # just walks into the next occupied slot on a busy network.
+  #
+  # The bound IS the list length. Unbounded retries against a hostile or
+  # duplicated nick space is a respawn flood, the same trap the e2e
+  # fixtures hit with shared-leaf 433 autokill.
+  @nick_fallback_attempts 3
+
+  defp nick_fallback_ladder do
+    draws = Stream.repeatedly(&Identifier.random_nick_suffix/0)
+
+    ["_" | draws |> Stream.uniq() |> Enum.take(@nick_fallback_attempts - 1)]
   end
 
   defp validate_password_present(%{auth_method: :none}), do: :ok
@@ -357,6 +408,30 @@ defmodule Grappa.IRC.AuthFSM do
     {:cont, state, []}
   end
 
+  # #676 — 433 ERR_NICKNAMEINUSE with ladder left: retry under the next
+  # candidate instead of dead-ending the login. A visitor whose nick is
+  # taken upstream used to get no session at all (FSM stop → `:nick_in_use`
+  # → HTTP 409) and had to go hunt for the nick field in settings; now they
+  # land as `<nick>_` and can rename at leisure. `state.nick` moves to the
+  # candidate so the stop reason (once the ladder runs out) names the nick
+  # we last actually tried, and so 001's `welcomed_nick` reconciliation has
+  # something truthful to compare against.
+  #
+  # Placed AFTER the `:nickserv_identify` clause on purpose: that mode's
+  # 433 belongs to the host's GhostRecovery / RecoverIdentity flows, and a
+  # ladder NICK here would race the GHOST sequence off its own nick.
+  # 432 is deliberately NOT laddered — an erroneous nick is a SHAPE
+  # rejection, and retrying `<badnick>_` re-sends the same bad shape.
+  def step(
+        %__MODULE__{nick_suffixes: [suffix | rest]} = state,
+        %Message{command: {:numeric, 433}, params: params}
+      ) do
+    cap = learned_nick_cap(state, params)
+    candidate = Identifier.collision_fallback(state.orig_nick, suffix, cap)
+
+    {:cont, %{state | nick: candidate, nick_suffixes: rest, nick_cap: cap}, ["NICK #{candidate}\r\n"]}
+  end
+
   # 432 ERR_ERRONEUSNICKNAME / 433 ERR_NICKNAMEINUSE during registration.
   # Without an explicit handler the FSM would sit in `:pre_register` /
   # `:awaiting_cap_*` forever; surface as a structured stop reason so
@@ -385,6 +460,28 @@ defmodule Grappa.IRC.AuthFSM do
   end
 
   def step(state, _), do: {:cont, state, []}
+
+  # #676 — the upstream NICKLEN, learned from the 433 echo.
+  #
+  # 005 RPL_ISUPPORT (where NICKLEN lives) only arrives AFTER 001, so at
+  # 433 time the advertised cap is genuinely unknowable — the issue's
+  # "truncate using the network's advertised NICKLEN" cannot be honoured
+  # as written. The 433 line itself carries the evidence instead: an ircd
+  # that silently truncated our NICK rejects the SHORTENED spelling, so an
+  # echo shorter than what we sent IS the cap. Without this, a 30-char
+  # nick on a NICKLEN=16 network would retry with a candidate the server
+  # truncates straight back into the same collision, burning the whole
+  # ladder on one unreachable nick.
+  #
+  # A proven cap STICKS (`state.nick_cap`): the clamped candidate fits, so
+  # the next echo comes back verbatim and offers no second proof. Only a
+  # fresh truncation lowers it — an equal-length echo says nothing.
+  defp learned_nick_cap(%__MODULE__{nick: sent, nick_cap: cap}, [_, echoed | _])
+       when is_binary(echoed) do
+    if String.length(echoed) < String.length(sent), do: String.length(echoed), else: cap
+  end
+
+  defp learned_nick_cap(%__MODULE__{nick_cap: cap}, _), do: cap
 
   # CAP LS continuation: 4th param == "*" marks "more lines coming."
   # IRCv3.2 splits long cap lists; accumulate in `caps_buffer` until a

--- a/lib/grappa/irc/auth_fsm.ex
+++ b/lib/grappa/irc/auth_fsm.ex
@@ -217,6 +217,15 @@ defmodule Grappa.IRC.AuthFSM do
   # fixtures hit with shared-leaf 433 autokill.
   @nick_fallback_attempts 3
 
+  # Floor for a cap inferred from a 433 echo. RFC 1459's NICKLEN is 9 and no
+  # real ircd advertises less, so anything below it is not a short network —
+  # it is a stale/duplicate 433 still echoing an earlier, shorter nick while
+  # we already fly a longer candidate. Believing that echo derives an absurd
+  # cap and (with a 3-char suffix) drives `Identifier.collision_fallback/3`
+  # through its own `cap > suffix` guard, crashing the Client on a numeric
+  # it was supposed to recover from.
+  @min_learnable_nick_cap 9
+
   defp nick_fallback_ladder do
     draws = Stream.repeatedly(&Identifier.random_nick_suffix/0)
 
@@ -478,10 +487,26 @@ defmodule Grappa.IRC.AuthFSM do
   # fresh truncation lowers it — an equal-length echo says nothing.
   defp learned_nick_cap(%__MODULE__{nick: sent, nick_cap: cap}, [_, echoed | _])
        when is_binary(echoed) do
-    if String.length(echoed) < String.length(sent), do: String.length(echoed), else: cap
+    if truncation_of?(echoed, sent),
+      do: max(String.length(echoed), @min_learnable_nick_cap),
+      else: cap
   end
 
   defp learned_nick_cap(%__MODULE__{nick_cap: cap}, _), do: cap
+
+  # Truncation means the server took our nick and CUT it, so the echo is a
+  # proper prefix of what we sent — nothing else counts as evidence. Read
+  # positionally instead, and a 433 whose second param is a reason string
+  # (a short or hostile ircd shape) gets mistaken for a cap.
+  #
+  # The fold is the identity authority (#121/#537): an ircd may echo the
+  # nick case-normalised, and that is still us.
+  defp truncation_of?(echoed, sent) do
+    folded = Identifier.canonical_target(sent)
+
+    String.length(echoed) < String.length(sent) and
+      String.starts_with?(folded, Identifier.canonical_target(echoed))
+  end
 
   # CAP LS continuation: 4th param == "*" marks "more lines coming."
   # IRCv3.2 splits long cap lists; accumulate in `caps_buffer` until a

--- a/lib/grappa/irc/identifier.ex
+++ b/lib/grappa/irc/identifier.ex
@@ -138,6 +138,68 @@ defmodule Grappa.IRC.Identifier do
   @spec truncate_nick(String.t()) :: String.t()
   def truncate_nick(nick) when is_binary(nick), do: String.slice(nick, 0, @max_nick_length)
 
+  @doc """
+  The nick length ceiling this module enforces (`#{@max_nick_length}`).
+
+  Exposed for #676's 433 collision-fallback ladder, which needs an explicit
+  cap argument for `collision_fallback/3`: the upstream `NICKLEN` is NOT
+  knowable at 433 time (005 RPL_ISUPPORT only arrives after 001), so the
+  caller passes this ceiling until an ircd truncation proves a smaller one.
+  """
+  # The spec is the LITERAL, not `pos_integer()`: Dialyzer's success typing
+  # for a constant getter is the constant, and a supertype spec is a
+  # `contract_supertype` error under this project's settings. Change the
+  # constant and this spec fails loudly — as does `max_nick_length/0`'s
+  # test, which pins it against what `valid_nick?/1` actually accepts.
+  @spec max_nick_length() :: 30
+  def max_nick_length, do: @max_nick_length
+
+  @doc """
+  Builds a collision-fallback nick: `base` with `suffix` appended, clamped
+  to `cap` by trimming the BASE.
+
+  The suffix is load-bearing, so it is the part that always survives. An
+  ircd silently truncates an over-long NICK to its `NICKLEN`; a builder
+  that let the clamp eat the suffix would hand back the exact nick the
+  server just rejected, and #676's retry ladder would spin to exhaustion
+  against a collision it can never escape.
+
+  `cap` must leave room for at least one base character — callers derive
+  it from `max_nick_length/0` or from an observed truncation, both of
+  which are far above any suffix we generate.
+  """
+  @spec collision_fallback(String.t(), String.t(), pos_integer()) :: String.t()
+  def collision_fallback(base, suffix, cap)
+      when is_binary(base) and is_binary(suffix) and is_integer(cap) and
+             cap > byte_size(suffix) do
+    String.slice(base, 0, cap - String.length(suffix)) <> suffix
+  end
+
+  # Nick-tail charset for `random_nick_suffix/0`: lowercase alphanumerics
+  # only. A strict subset of `@nick_regex`'s tail class, so appending one
+  # to a valid base always yields a valid nick — and it dodges the
+  # national/bracket chars whose case-folding is CASEMAPPING-dependent
+  # (#537), keeping a generated nick identical under every fold table.
+  @nick_suffix_alphabet ~c"abcdefghijklmnopqrstuvwxyz0123456789"
+  @nick_suffix_length 3
+
+  @doc """
+  A random #{@nick_suffix_length}-char nick suffix for #676's collision
+  ladder (36³ = 46 656 draws).
+
+  Random, not another underscore: vjt's ruling is that once `<nick>_` is
+  ALSO taken, stacking underscores walks straight into the next occupied
+  slot on a busy network, while a random tail almost certainly does not.
+
+  The lone impure function in this module — it draws from `:rand`.
+  Callers that need determinism (the FSM `step/2` path) take the suffix as
+  DATA rather than calling this per step.
+  """
+  @spec random_nick_suffix() :: String.t()
+  def random_nick_suffix do
+    for _ <- 1..@nick_suffix_length, into: "", do: <<Enum.random(@nick_suffix_alphabet)>>
+  end
+
   @doc "True iff the input is a syntactically valid IRC channel name."
   @spec valid_channel?(term()) :: boolean()
   def valid_channel?(s) when is_binary(s), do: Regex.match?(@channel_regex, s)

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -1645,9 +1645,25 @@ defmodule Grappa.Session.EventRouter do
   # actually registered us as — may differ from requested due to
   # case-fold normalization, services rename, length truncation).
   # Reconcile state.nick to upstream's authority.
-  defp do_route(%Message{command: {:numeric, 1}, params: [welcomed_nick | _]}, state)
+  defp do_route(%Message{command: {:numeric, 1}, params: [welcomed_nick | _]} = msg, state)
        when is_binary(welcomed_nick) do
-    {:cont, %{state | nick: welcomed_nick}, []}
+    reconciled = %{state | nick: welcomed_nick}
+
+    # #676 point 3 — when upstream registered us under a DIFFERENT identity
+    # than we asked for (the 433 fallback ladder, a services rename, a
+    # NICKLEN truncation), say so on `$server`. A silent rename becomes
+    # permanent by accident: the user never learns they are `vjt_`, so the
+    # underscore outlives the collision that caused it.
+    #
+    # The fold is the identity authority (#121/#537): `VJT` → `vjt` is the
+    # ircd normalising our own nick, not a different person, and announcing
+    # it would be noise on every connect to a case-normalising network.
+    if Identifier.canonical_target(welcomed_nick) == Identifier.canonical_target(state.nick) do
+      {:cont, reconciled, []}
+    else
+      {reconciled, eff} = nick_fallback_row(reconciled, msg, state.nick, welcomed_nick)
+      {:cont, reconciled, [eff]}
+    end
   end
 
   # CP15 B2 — JOIN failure numerics. Six codes carry the same shape:
@@ -2938,6 +2954,24 @@ defmodule Grappa.Session.EventRouter do
 
   # #127 — flush the accumulator to wire-order lines.
   defp server_reply_drain(%{lines: lines}), do: Enum.reverse(lines)
+
+  # #676 — the "you are not the nick you asked for" row.
+  #
+  # `:server_event` (event-tier, not content): it is session chrome, not
+  # something anyone said. The facts live STRUCTURED in `meta.nick_fallback`
+  # so cic can render and localise them properly; `body` carries a plain
+  # spelling too, so the row is legible with no client change (the wire is
+  # additive-only — an old client ignores the meta and shows the body).
+  defp nick_fallback_row(state, msg, requested, registered) do
+    build_persist(
+      state,
+      :server_event,
+      "$server",
+      Message.sender_nick(msg),
+      "nick #{requested} was taken — you are registered as #{registered}",
+      %{nick_fallback: %{requested: requested, registered: registered}}
+    )
+  end
 
   # #127 — legacy `$server` :notice persist for an unprimed / connect-time
   # server-info numeric (connect MOTD, unsolicited INFO/VERSION). Extracted

--- a/test/grappa/irc/auth_fsm_test.exs
+++ b/test/grappa/irc/auth_fsm_test.exs
@@ -11,7 +11,14 @@ defmodule Grappa.IRC.AuthFSMTest do
   """
   use ExUnit.Case, async: true
 
-  alias Grappa.IRC.{AuthFSM, Message}
+  alias Grappa.IRC.{AuthFSM, Identifier, Message}
+
+  defp four_three_three(rejected) do
+    %Message{
+      command: {:numeric, 433},
+      params: ["*", rejected, "Nickname is already in use."]
+    }
+  end
 
   defp base_opts(overrides) do
     Map.merge(
@@ -508,7 +515,8 @@ defmodule Grappa.IRC.AuthFSMTest do
       %{state: new!(%{})}
     end
 
-    test "433 NICKNAMEINUSE -> :stop {:nick_rejected, 433, nick}", %{state: state} do
+    test "433 NICKNAMEINUSE with the ladder spent -> :stop {:nick_rejected, 433, nick}" do
+      state = %{new!(%{}) | nick_suffixes: []}
       msg = %Message{command: {:numeric, 433}}
 
       assert {:stop, {:nick_rejected, 433, "vjt"}, _, []} =
@@ -541,8 +549,7 @@ defmodule Grappa.IRC.AuthFSMTest do
       assert {:cont, ^state, []} = AuthFSM.step(state, msg)
     end
 
-    test "non-:nickserv_identify modes still :stop on 432/433" do
-      msg_433 = %Message{command: {:numeric, 433}, params: ["*", "vjt"]}
+    test "non-:nickserv_identify modes still :stop on 432 (no retry ladder)" do
       msg_432 = %Message{command: {:numeric, 432}, params: ["*", "vjt"]}
 
       for {method, opts} <- [
@@ -553,12 +560,131 @@ defmodule Grappa.IRC.AuthFSMTest do
           ] do
         state = new!(opts)
 
-        assert {:stop, {:nick_rejected, 433, "vjt"}, _, []} = AuthFSM.step(state, msg_433),
-               "expected mode #{inspect(method)} to stop on 433"
-
         assert {:stop, {:nick_rejected, 432, "vjt"}, _, []} = AuthFSM.step(state, msg_432),
                "expected mode #{inspect(method)} to stop on 432"
       end
+    end
+  end
+
+  # #676 — a 433 at registration used to be a dead end for every mode but
+  # `:nickserv_identify`: the FSM stopped the Client, `Visitors.Login`
+  # classified the exit as `:nick_in_use`, and the user got a 409 with no
+  # session. Now the FSM walks a bounded fallback ladder — `<nick>_` first,
+  # then random suffixes — and only stops once the ladder is spent.
+  describe "step/2 — 433 nick-collision fallback ladder (#676)" do
+    test "first 433 retries with <nick>_ and stays alive" do
+      state = new!(%{})
+
+      assert {:cont, next, sends} = AuthFSM.step(state, four_three_three("vjt"))
+      assert next.nick == "vjt_"
+      assert send_lines(sends) == ["NICK vjt_"]
+    end
+
+    test "a second 433 moves to a random suffix instead of stacking underscores" do
+      state = new!(%{})
+
+      {:cont, after_first, _} = AuthFSM.step(state, four_three_three("vjt"))
+      {:cont, after_second, sends} = AuthFSM.step(after_first, four_three_three("vjt_"))
+
+      refute after_second.nick == "vjt__",
+             "stacking underscores walks into the next occupied slot (vjt ruling)"
+
+      assert String.starts_with?(after_second.nick, "vjt")
+      assert Identifier.valid_nick?(after_second.nick)
+      assert send_lines(sends) == ["NICK #{after_second.nick}"]
+    end
+
+    test "the ladder is bounded — repeated 433s eventually stop, never loop forever" do
+      state = new!(%{})
+
+      final =
+        Enum.reduce_while(1..25, state, fn _, acc ->
+          case AuthFSM.step(acc, four_three_three(acc.nick)) do
+            {:cont, next, _} -> {:cont, next}
+            {:stop, reason, _, _} -> {:halt, reason}
+          end
+        end)
+
+      assert {:nick_rejected, 433, last} = final,
+             "an unbounded ladder is a respawn-flood against a hostile nick space"
+
+      assert Identifier.valid_nick?(last)
+    end
+
+    test "every candidate on the ladder is a distinct, valid nick" do
+      state = new!(%{})
+
+      {nicks, _} =
+        Enum.flat_map_reduce(1..25, state, fn _, acc ->
+          case AuthFSM.step(acc, four_three_three(acc.nick)) do
+            {:cont, next, _} -> {[next.nick], next}
+            {:stop, _, _, _} -> {:halt, acc}
+          end
+        end)
+
+      assert length(nicks) > 1
+      assert Enum.all?(nicks, &Identifier.valid_nick?/1)
+      assert Enum.uniq(nicks) == nicks, "a repeated candidate wastes an attempt: #{inspect(nicks)}"
+    end
+
+    # 005 RPL_ISUPPORT (and therefore NICKLEN) only lands AFTER 001, so at
+    # 433 time we cannot know the upstream cap. The 433 echo does: an ircd
+    # that truncated our NICK rejects the SHORTENED spelling. Read the cap
+    # off that echo, or a 30-char nick on a NICKLEN=16 network retries with
+    # a candidate the server truncates straight back into the collision.
+    test "learns the upstream cap from a truncated 433 echo" do
+      long = String.duplicate("a", 30)
+      state = new!(%{nick: long})
+
+      # Upstream took `long`, truncated it to 16, and rejected THAT.
+      echo = String.duplicate("a", 16)
+
+      assert {:cont, next, sends} = AuthFSM.step(state, four_three_three(echo))
+      assert String.length(next.nick) == 16
+      assert String.ends_with?(next.nick, "_")
+      assert send_lines(sends) == ["NICK #{next.nick}"]
+    end
+
+    # Truncation is proven ONCE. The clamped candidate that follows fits, so
+    # upstream echoes it back verbatim — no second proof. A cap re-derived
+    # per step would forget what it learned and send another over-long nick.
+    test "the learned cap sticks for the rest of the ladder" do
+      state = new!(%{nick: String.duplicate("a", 30)})
+
+      {:cont, first, _} = AuthFSM.step(state, four_three_three(String.duplicate("a", 16)))
+      {:cont, second, _} = AuthFSM.step(first, four_three_three(first.nick))
+
+      assert String.length(second.nick) <= 16,
+             "cap learned at the first 433 must survive into later attempts"
+    end
+
+    test "an untruncated echo does NOT clamp the candidate" do
+      state = new!(%{nick: "vjt"})
+
+      assert {:cont, next, _} = AuthFSM.step(state, four_three_three("vjt"))
+      assert next.nick == "vjt_"
+    end
+
+    test "a 433 with no echo param still retries (cap falls back to our ceiling)" do
+      state = new!(%{})
+
+      assert {:cont, next, sends} = AuthFSM.step(state, %Message{command: {:numeric, 433}})
+      assert next.nick == "vjt_"
+      assert send_lines(sends) == ["NICK vjt_"]
+    end
+
+    test ":nickserv_identify keeps its silent :cont — the host owns that wire" do
+      state = new!(%{auth_method: :nickserv_identify, password: "s3cret"})
+
+      assert {:cont, ^state, []} = AuthFSM.step(state, four_three_three("vjt")),
+             "the ladder must not pre-empt GhostRecovery / RecoverIdentity (#676 point 5)"
+    end
+
+    test "a 433 after registration is still absorbed, ladder untouched" do
+      {state, _} = AuthFSM.initial_handshake(new!(%{}))
+      {:cont, registered, _} = AuthFSM.step(state, %Message{command: {:numeric, 1}})
+
+      assert {:cont, ^registered, []} = AuthFSM.step(registered, four_three_three("vjt"))
     end
   end
 

--- a/test/grappa/irc/auth_fsm_test.exs
+++ b/test/grappa/irc/auth_fsm_test.exs
@@ -673,6 +673,54 @@ defmodule Grappa.IRC.AuthFSMTest do
       assert send_lines(sends) == ["NICK vjt_"]
     end
 
+    # A duplicate / stale 433 still echoing the ORIGINAL nick arrives while
+    # we are already flying a longer candidate. That echo is shorter, but it
+    # is not proof of truncation — believing it would derive an absurd
+    # 3-char cap and (with a 3-char suffix) drive
+    # `collision_fallback/3` straight through its own guard.
+    test "a stale 433 echoing the original nick does not derive an absurd cap" do
+      state = new!(%{nick: "vjt"})
+
+      {:cont, first, _} = AuthFSM.step(state, four_three_three("vjt"))
+      assert first.nick == "vjt_"
+
+      assert {:cont, second, _} = AuthFSM.step(first, four_three_three("vjt")),
+             "a repeated 433 for the original nick must not crash the ladder"
+
+      assert Identifier.valid_nick?(second.nick)
+      assert String.starts_with?(second.nick, "vjt")
+    end
+
+    # A 433 whose second param is NOT our nick (a short/odd ircd shape, or a
+    # hostile one) is not truncation evidence — it is noise. Reading it
+    # positionally would clamp against a reason string.
+    test "an echo that is not a prefix of what we sent is ignored, not believed" do
+      state = new!(%{nick: "verylongnickname"})
+
+      assert {:cont, next, _} =
+               AuthFSM.step(state, %Message{command: {:numeric, 433}, params: ["*", "nope"]})
+
+      assert next.nick == "verylongnickname_",
+             "an unrelated echo must not be mistaken for a truncation"
+    end
+
+    test "the ladder runs for every mode that is not :nickserv_identify" do
+      for opts <- [
+            %{auth_method: :none},
+            %{auth_method: :sasl, password: "s3cret"},
+            %{auth_method: :server_pass, password: "s3cret"},
+            %{auth_method: :auto, password: "s3cret"}
+          ] do
+        state = new!(opts)
+
+        assert {:cont, next, sends} = AuthFSM.step(state, four_three_three("vjt")),
+               "expected mode #{inspect(opts.auth_method)} to retry on 433"
+
+        assert next.nick == "vjt_"
+        assert send_lines(sends) == ["NICK vjt_"]
+      end
+    end
+
     test ":nickserv_identify keeps its silent :cont — the host owns that wire" do
       state = new!(%{auth_method: :nickserv_identify, password: "s3cret"})
 

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -32,6 +32,33 @@ defmodule Grappa.IRC.ClientTest do
     {server, IRCServer.port(server)}
   end
 
+  # #676 — a realistic 433: the numeric echoes the nick the SERVER rejected,
+  # i.e. the one we just sent (an ircd that truncates to its NICKLEN echoes
+  # the SHORTENED spelling, which is how the FSM learns the cap). A fake
+  # that echoed a hardcoded nick would feed the FSM a phantom truncation.
+  defp nick_in_use(nick_line) do
+    nick = nick_line |> String.trim() |> String.trim_leading("NICK ")
+    ":server 433 * #{nick} :Nickname is already in use\r\n"
+  end
+
+  # #676 — the passwordless (`:none`) shape the nick-collision ladder
+  # covers. Shared by both 433 tests so they differ only in what the fake
+  # upstream does, not in how the client is built.
+  defp start_collision_client(port) do
+    Client.start_link(%{
+      host: "127.0.0.1",
+      port: port,
+      tls: false,
+      dispatch_to: self(),
+      logger_metadata: [],
+      nick: "grappa-test",
+      ident: "grappa-test",
+      realname: "grappa-test",
+      sasl_user: "grappa-test",
+      auth_method: :none
+    })
+  end
+
   # Bind ephemeral port, capture number, release immediately. The kernel
   # may eventually reuse it; the C2 non-blocking-init test only needs the
   # port to be unbound for the ~10ms it takes the connect to refuse.
@@ -1285,33 +1312,55 @@ defmodule Grappa.IRC.ClientTest do
       assert %{fsm: %{phase: :registered, caps_buffer: []}} = :sys.get_state(client)
     end
 
-    test "433 ERR_NICKNAMEINUSE during registration crashes {:nick_rejected, 433, nick}" do
-      nick_clash_handler = fn state, line ->
-        if String.starts_with?(line, "USER ") do
-          {:reply, ":server 433 * grappa-test :Nickname is already in use\r\n", state}
+    # #676 — a 433 at registration is no longer fatal on the first hit: the
+    # FSM re-sends NICK under `<nick>_` and the handshake completes. This is
+    # the whole point of the issue — a visitor whose nick is taken upstream
+    # gets a working session instead of a dead login.
+    test "433 ERR_NICKNAMEINUSE during registration retries under <nick>_ and registers" do
+      retry_handler = fn state, line ->
+        cond do
+          String.starts_with?(line, "NICK grappa-test_") ->
+            {:reply, ":server 001 grappa-test_ :Welcome\r\n", state}
+
+          String.starts_with?(line, "NICK ") ->
+            {:reply, nick_in_use(line), state}
+
+          true ->
+            {:reply, nil, state}
+        end
+      end
+
+      {server, port} = start_server(retry_handler)
+
+      {:ok, client} = start_collision_client(port)
+
+      {:ok, _} =
+        IRCServer.wait_for_line(server, &String.starts_with?(&1, "NICK grappa-test_"), 1_000)
+
+      Process.sleep(50)
+
+      assert %{fsm: %{phase: :registered, nick: "grappa-test_"}} = :sys.get_state(client)
+    end
+
+    # The ladder is BOUNDED: an upstream that rejects every candidate must
+    # still terminate, and with the honest stop reason. An unbounded retry
+    # here would be a respawn flood under the supervisor.
+    test "433 on every candidate exhausts the ladder and stops {:nick_rejected, 433, _}" do
+      always_clash = fn state, line ->
+        if String.starts_with?(line, "NICK ") do
+          {:reply, nick_in_use(line), state}
         else
           {:reply, nil, state}
         end
       end
 
-      {_, port} = start_server(nick_clash_handler)
+      {_, port} = start_server(always_clash)
       Process.flag(:trap_exit, true)
 
-      {:ok, client} =
-        Client.start_link(%{
-          host: "127.0.0.1",
-          port: port,
-          tls: false,
-          dispatch_to: self(),
-          logger_metadata: [],
-          nick: "grappa-test",
-          ident: "grappa-test",
-          realname: "grappa-test",
-          sasl_user: "grappa-test",
-          auth_method: :none
-        })
+      {:ok, client} = start_collision_client(port)
 
-      assert_receive {:EXIT, ^client, {:nick_rejected, 433, "grappa-test"}}, 1_000
+      assert_receive {:EXIT, ^client, {:nick_rejected, 433, last_tried}}, 2_000
+      assert String.starts_with?(last_tried, "grappa-test")
     end
   end
 

--- a/test/grappa/irc/identifier_test.exs
+++ b/test/grappa/irc/identifier_test.exs
@@ -84,6 +84,16 @@ defmodule Grappa.IRC.IdentifierTest do
       assert Identifier.collision_fallback("abcdefghij", "x9", 9) == "abcdefgx9"
     end
 
+    # Deliberately PARTIAL. A cap that cannot hold the suffix has no correct
+    # answer — trimming the suffix to fit would re-send the rejected nick —
+    # so the guard refuses instead of inventing one. Callers are responsible
+    # for a sane cap; `AuthFSM` floors its inferred one for exactly this.
+    test "refuses a cap too small to hold the suffix" do
+      assert_raise FunctionClauseError, fn ->
+        Identifier.collision_fallback("vjt", "abc", 3)
+      end
+    end
+
     test "the result is always a valid nick and never exceeds the cap" do
       check all(
               base <- string(?a..?z, min_length: 1, max_length: 30),

--- a/test/grappa/irc/identifier_test.exs
+++ b/test/grappa/irc/identifier_test.exs
@@ -64,6 +64,68 @@ defmodule Grappa.IRC.IdentifierTest do
     end
   end
 
+  # #676 — the 433 collision-fallback candidate builder. The suffix is the
+  # part that MUST survive: a builder that let the cap eat it would hand the
+  # ircd back the very nick it just rejected, and the retry ladder would spin
+  # to exhaustion against a nick it can never win.
+  describe "collision_fallback/3" do
+    test "appends the suffix when the cap leaves room" do
+      assert Identifier.collision_fallback("vjt", "_", 30) == "vjt_"
+    end
+
+    test "trims the BASE (never the suffix) to fit the cap" do
+      base = String.duplicate("a", 30)
+
+      assert Identifier.collision_fallback(base, "_", 30) ==
+               String.duplicate("a", 29) <> "_"
+    end
+
+    test "honours a cap below our own nick ceiling (a short upstream NICKLEN)" do
+      assert Identifier.collision_fallback("abcdefghij", "x9", 9) == "abcdefgx9"
+    end
+
+    test "the result is always a valid nick and never exceeds the cap" do
+      check all(
+              base <- string(?a..?z, min_length: 1, max_length: 30),
+              suffix <- string(?a..?z, min_length: 1, max_length: 3),
+              cap <- integer(4..30)
+            ) do
+        out = Identifier.collision_fallback(base, suffix, cap)
+
+        assert Identifier.valid_nick?(out)
+        assert String.length(out) <= cap
+        assert String.ends_with?(out, suffix)
+      end
+    end
+  end
+
+  describe "random_nick_suffix/0" do
+    test "produces a tail-charset suffix that keeps a valid base valid" do
+      for _ <- 1..50 do
+        suffix = Identifier.random_nick_suffix()
+
+        assert String.match?(suffix, ~r/^[a-z0-9]+$/),
+               "expected a nick-tail-safe suffix, got #{inspect(suffix)}"
+
+        assert Identifier.valid_nick?("vjt" <> suffix)
+      end
+    end
+
+    test "is actually random (50 draws are not one repeated value)" do
+      draws = for _ <- 1..50, into: MapSet.new(), do: Identifier.random_nick_suffix()
+      assert MapSet.size(draws) > 1
+    end
+  end
+
+  describe "max_nick_length/0" do
+    test "matches the length valid_nick?/1 enforces" do
+      cap = Identifier.max_nick_length()
+
+      assert Identifier.valid_nick?(String.duplicate("a", cap))
+      refute Identifier.valid_nick?(String.duplicate("a", cap + 1))
+    end
+  end
+
   describe "valid_channel?/1" do
     test "accepts # / & / + / ! prefixed channels" do
       assert Identifier.valid_channel?("#sniffo")

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -2748,8 +2748,36 @@ defmodule Grappa.Session.EventRouterTest do
       state = base_state(%{nick: "vjt"})
       m = msg({:numeric, 1}, ["vjt_truncated", "Welcome to IRC"], {:server, "irc"})
 
-      assert {:cont, new_state, []} = EventRouter.route(m, state)
+      assert {:cont, new_state, [_]} = EventRouter.route(m, state)
       assert new_state.nick == "vjt_truncated"
+    end
+
+    # #676 point 3 — the fallback must ANNOUNCE itself. A silent underscore
+    # becomes permanent by accident: the user never learns they are `vjt_`,
+    # so they never rename. The row carries the facts in `meta` (structured,
+    # for cic to render properly) plus a body so it is legible today.
+    test "a different welcomed nick persists a $server row naming both nicks" do
+      state = base_state(%{nick: "vjt"})
+      m = msg({:numeric, 1}, ["vjt_", "Welcome to IRC"], {:server, "irc.test.org"})
+
+      assert {:cont, _, [{:persist, :server_event, attrs}]} =
+               EventRouter.route(m, state)
+
+      assert attrs.channel == "$server"
+      assert attrs.meta.nick_fallback == %{requested: "vjt", registered: "vjt_"}
+      assert attrs.body =~ "vjt"
+      assert attrs.body =~ "vjt_"
+    end
+
+    # A pure case difference is the ircd normalising, not a collision — the
+    # user is still who they asked to be, so there is nothing to announce.
+    # The fold is the identity authority here, not `==` (#121/#537).
+    test "a case-only difference reconciles silently (no row)" do
+      state = base_state(%{nick: "VJT"})
+      m = msg({:numeric, 1}, ["vjt", "Welcome to IRC"], {:server, "irc"})
+
+      assert {:cont, new_state, []} = EventRouter.route(m, state)
+      assert new_state.nick == "vjt"
     end
   end
 

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -7976,27 +7976,34 @@ defmodule Grappa.Session.ServerTest do
       {server, port} = start_server(ghost_handler(nick))
       {visitor, network} = visitor_with_network(port, nick: nick)
 
-      # Anon visitor has auth_method :none; AuthFSM stops on 433 with
-      # :nick_rejected, killing Client. Session restarts under the
-      # transient supervisor and the cycle repeats — capturing the log
-      # noise keeps it out of the test output. The wire-side assertion
-      # is the negative one: the underscore-variant NICK never appears,
-      # because Server doesn't run GhostRecovery for nil-password.
+      # Anon visitor has auth_method :none and no cached password, so
+      # GhostRecovery — which needs one to issue GHOST — must stay unarmed.
       #
-      # The wait may resolve as `:timeout` (deadline elapsed with no
-      # match) OR `:tcp_closed` (S7: post-cluster #10 the IRCServer
-      # drains pending waiters when the upstream socket closes mid-
-      # wait, and AuthFSM's :nick_rejected stop closes the socket
-      # promptly). Both encode "the NICK was never sent" — that is the
-      # load-bearing assertion.
+      # #676 flipped what the wire proves. The underscore NICK now DOES go
+      # out: it comes from AuthFSM's collision-fallback ladder, which is
+      # exactly the gap the issue closed (pre-#676 an anon visitor's 433
+      # killed the Client and the login dead-ended at 409). So the
+      # load-bearing assertion moved off "no NICK_ on the wire" and onto
+      # the two facts that still hold — no GHOST is issued, and no
+      # `ghost_recovery` FSM is armed on the Session.
       capture_log(fn ->
-        _ = start_visitor_session_for(visitor, network)
+        pid = start_visitor_session_for(visitor, network)
         :ok = await_handshake(server)
 
+        {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "NICK #{nick}_\r\n"), 1_000)
+
         assert {:error, reason} =
-                 IRCServer.wait_for_line(server, &(&1 == "NICK #{nick}_\r\n"), 200)
+                 IRCServer.wait_for_line(
+                   server,
+                   &String.starts_with?(&1, "PRIVMSG NickServ :GHOST"),
+                   200
+                 )
 
         assert reason in [:timeout, :tcp_closed]
+
+        state = SessionStateHelpers.fetch(pid)
+        assert SessionStateHelpers.ghost_recovery(state) == nil
+        assert SessionStateHelpers.ghost_timer(state) == nil
       end)
     end
 

--- a/test/grappa/visitors/login_test.exs
+++ b/test/grappa/visitors/login_test.exs
@@ -94,6 +94,13 @@ defmodule Grappa.Visitors.LoginTest do
     :ok = Session.stop_session({:visitor, visitor_id}, network_id)
   end
 
+  # #676 — 433 echoing the nick the server actually rejected. A hardcoded
+  # echo would look like an ircd truncation to the FSM's NICKLEN heuristic.
+  defp nick_in_use(nick_line) do
+    nick = nick_line |> String.trim() |> String.trim_leading("NICK ")
+    ":irc.test.org 433 * #{nick} :Nickname is already in use\r\n"
+  end
+
   describe "validation gates (independent of network state)" do
     test "malformed nick → {:error, :malformed_nick}" do
       assert {:error, :malformed_nick} = Login.login(login_input(%{nick: "9bad"}), [])
@@ -285,22 +292,52 @@ defmodule Grappa.Visitors.LoginTest do
       assert Visitors.resolve_identity_by_nick("vjt", network.id) == nil
     end
 
-    test "433 nick-in-use during registration → {:error, :nick_in_use}, anon row purged" do
-      {server, port} = start_server()
+    # #676 — THE issue's scenario: a user already connected to the network
+    # from their own client logs in here with the same nick. Before, they
+    # got a 409 and had to go dig the nick field out of settings → general;
+    # now the ladder lands them on `vjt_` with a working session, and the
+    # rename is something they can do later, at leisure.
+    test "433 nick-in-use during registration → login SUCCEEDS under the fallback nick" do
+      collide_once = fn state, line ->
+        cond do
+          String.starts_with?(line, "NICK vjt_") ->
+            {:reply, ":irc.test.org 001 vjt_ :Welcome\r\n", state}
+
+          String.starts_with?(line, "NICK ") ->
+            {:reply, nick_in_use(line), state}
+
+          true ->
+            {:reply, nil, state}
+        end
+      end
+
+      {_, port} = start_server(collide_once)
       {network, _} = setup_visitor_network(port)
 
-      task = Task.async(fn -> Login.login(login_input(), []) end)
+      assert {:ok, %{visitor: visitor}} = Login.login(login_input(), [])
+      on_exit(fn -> stop_visitor_session(visitor.id, network.id) end)
 
-      # Connect + NICK/USER handshake completes against the fake; instead
-      # of 001 the upstream rejects the nick with 433 ERR_NICKNAMEINUSE.
-      # AuthFSM stops the Client with `{:nick_rejected, 433, _}`, which
-      # propagates as the Session.Server DOWN reason. Login must classify
-      # that as :nick_in_use (issue #40) rather than the generic
-      # :upstream_unreachable / :welcome_timeout it used to surface.
-      :ok = await_handshake(server)
-      IRCServer.feed(server, ":irc.test.org 433 * vjt :Nickname is already in use\r\n")
+      pid = Grappa.Session.whereis({:visitor, visitor.id}, network.id)
+      assert is_pid(pid)
+      assert %{nick: "vjt_"} = :sys.get_state(pid)
+    end
 
-      assert {:error, :nick_in_use} = Task.await(task, 10_000)
+    # The dead end still exists — it just moved to the END of the ladder.
+    # An upstream that rejects every candidate must still surface the
+    # actionable :nick_in_use copy (issue #40), not a generic timeout.
+    test "433 on every candidate → {:error, :nick_in_use}, anon row purged" do
+      always_clash = fn state, line ->
+        if String.starts_with?(line, "NICK ") do
+          {:reply, nick_in_use(line), state}
+        else
+          {:reply, nil, state}
+        end
+      end
+
+      {_, port} = start_server(always_clash)
+      {network, _} = setup_visitor_network(port)
+
+      assert {:error, :nick_in_use} = Login.login(login_input(), [])
       assert Visitors.resolve_identity_by_nick("vjt", network.id) == nil
     end
 

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -601,15 +601,20 @@ defmodule GrappaWeb.AuthControllerTest do
       assert is_nil(Visitors.resolve_identity_by_nick("vjt", network.id))
     end
 
-    test "nick already in use → 409 nick_in_use (#40)", %{conn: conn} do
+    test "every nick candidate in use → 409 nick_in_use (#40)", %{conn: conn} do
       # Upstream completes the TCP/registration handshake then rejects the
-      # chosen nick with 433 ERR_NICKNAMEINUSE instead of 001. The handler
-      # replies the moment it sees the USER line, so the path resolves
-      # immediately — no probe-budget timeout. Pre-#40 this surfaced as the
-      # generic 502 upstream_unreachable ("handshake didn't complete" in cic).
+      # chosen nick with 433 ERR_NICKNAMEINUSE instead of 001. Pre-#40 this
+      # surfaced as the generic 502 upstream_unreachable ("handshake didn't
+      # complete" in cic).
+      #
+      # #676 — a SINGLE 433 no longer reaches here: the FSM retries under
+      # `vjt_` and the login succeeds. The 409 is now the END of the
+      # fallback ladder, so this fake must reject every candidate. The echo
+      # carries the nick the server rejected, as a real ircd's would.
       nick_in_use_handler = fn state, line ->
-        if String.starts_with?(line, "USER") do
-          {:reply, ":irc.test.org 433 * vjt :Nickname is already in use\r\n", state}
+        if String.starts_with?(line, "NICK ") do
+          nick = line |> String.trim() |> String.trim_leading("NICK ")
+          {:reply, ":irc.test.org 433 * #{nick} :Nickname is already in use\r\n", state}
         else
           {:reply, nil, state}
         end


### PR DESCRIPTION
Refs #676

## The gap

A visitor whose nick was already taken upstream got **no session at all** — just
a 409. Everything downstream of the 433 was already correct and honest
(`AuthFSM` stop → `classify_down/1` → `:nick_in_use` → 409 → friendly cic copy);
we simply stopped where every IRC client since the 1990s would have retried. The
user then had to go find the nick field in settings → general.

## What changed

`Grappa.IRC.AuthFSM` walks a **bounded fallback ladder** on a registration 433:
`<nick>_` first (the spelling a returning user recognises as themselves), then
two random 3-char suffixes — per vjt's ruling, since stacking underscores just
walks into the next occupied slot on a busy network. The bound IS the list
length; the suffixes are drawn once in `new/1` so `step/2` stays pure and
deterministic. Unbounded retries against a duplicated nick space would be a
respawn flood.

At 001, when the welcomed nick differs from the requested one,
`Session.EventRouter` persists a `:server_event` row on `$server` naming both —
a silent rename becomes permanent by accident (point 3). The compare **folds**:
`VJT` → `vjt` is the ircd normalising us, not a different person.

### Why the ladder is not in GhostRecovery

The underscore mechanism already existed there — including a `password: nil`
clause whose whole job is `NICK <nick>_`. That clause is **unreachable in
production**: its only call site guards on `is_binary(pending_password)`, which
an anon visitor never has. It looked alive because it is unit-tested. Reaching
it would ALSO have needed an `AuthFSM` change (the FSM stops the Client before
the host can drive anything), and it stops after ONE underscore — no bound, no
random suffix. A 433 *during registration* is a registration-handshake concern,
so it went where the handshake lives. The new clause sits **after** the
`:nickserv_identify` arm so it can never race GHOST / recover-identity off their
own nick (point 5). **432 is deliberately not laddered** — an erroneous nick is
a SHAPE rejection, so a suffixed retry re-sends the same bad shape.

### Spec point 2 could not be honoured as written

The issue asks to truncate using the network's advertised `NICKLEN`. **We
cannot**: NICKLEN lives in 005 RPL_ISUPPORT, which arrives *after* 001, and the
433 precedes it. The 433 line carries the evidence instead — an ircd that
truncated our NICK rejects the **shortened** spelling — and a proven cap sticks
on the FSM state, because the clamped candidate then fits and no second proof
ever comes. Without both halves, a 30-char nick on a NICKLEN=16 network burns
the whole ladder on one unreachable nick.

Two guards keep that heuristic honest (both found by code review and
**reproduced as RED tests before fixing**): the echo must be a folded **proper
prefix** of what we sent, and an inferred cap is floored at 9 (RFC 1459). Without
them a stale 433 echoing the original nick derived a 3-char cap and crashed the
Client through `collision_fallback/3`'s guard — a 502 where #676 is meant to
preserve the honest 409.

Out of scope, unchanged: the in-session `/nick` path still fails loudly (point
4). Wire is **additive-only** — new `meta.nick_fallback` plus a plain body, no
new token, no `protocol_version` bump.

## Tests

Every new test was seen RED first. Representative failures:

- `collision_fallback/3` / `random_nick_suffix/0` → `** (UndefinedFunctionError)`
  (7 failures) before the helpers existed.
- the learned cap sticking → `** (MatchError) no match of right hand side value:
  {:stop, {:nick_rejected, 433, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}` — a bug in my
  own first design, caught by writing the test before the code.
- the review findings → `** (FunctionClauseError) no function clause matching in
  Grappa.IRC.Identifier.collision_fallback/3` with `("vjt", "h5x", 3)`.

Four pre-existing tests encoded the dead end and were **re-pointed at the new
contract, not weakened**:

- `client_test` "433 … crashes" → now asserts the retry registers as
  `grappa-test_`, plus a sibling proving the ladder still terminates with the
  honest stop reason when every candidate is rejected.
- `login_test` / `auth_controller_test` → a single 433 now yields a **working
  session**; the `:nick_in_use` 409 moved to the END of the ladder and is still
  asserted there.
- `server_test` "anon visitor 433 does NOT arm ghost_recovery" → its wire
  assertion was *"no `NICK <nick>_` ever goes out"*, which is precisely the gap
  this closes. Re-pointed at what still holds: no GHOST is issued and no
  `ghost_recovery` FSM is armed.

Those fakes now echo the nick the server actually rejected, as a real ircd
would — the hardcoded echo in my first pass looked like a phantom truncation to
the NICKLEN heuristic.

**No e2e delta** (+0): this is a server-side handshake path with no cic surface
of its own; the `$server` row rides the existing scrollback rendering.

## Gate

`scripts/check.sh` exit 0 — format, credo strict, sobelow, dialyzer 0 errors,
**4978 tests / 8 doctests / 50 properties, 0 failures**, bats 221 ok. Full
integration suite is gated via CI on this PR.