### PR TITLE
fix(#693): a resume too big for one page lands at the tail, not the cursor

### DIFF
--- a/cicchetto/e2e/tests/issue161-forward-paging.spec.ts
+++ b/cicchetto/e2e/tests/issue161-forward-paging.spec.ts
@@ -1,42 +1,51 @@
 // #161 — the NEWEST messages become unreachable after the #156 anchored
 // fetch when unread exceeds the 200-row server cap.
 //
-// Root cause this pins: `loadInitialScrollback` (scrollback.ts) cursor-
-// present arm fetches the region AROUND the read cursor —
-// `listMessagesAfter(cursor, 200)` (the unread region, capped at the
-// server `@max_http_limit` = 200) + `listMessages(cursor + 1)` (before-
-// context). When true unread > 200 the after-page stops at `cursor + 200`,
-// so the very newest rows are NOT loaded. #156 assumed they "stream in via
-// the WS join-ok refreshScrollback" — but that path ALSO caps at 200 from
-// the same resume cursor, so it never reaches the tail either. And there
-// was NO forward-paging handler: `loadMore` pages OLDER rows on scroll-to-
-// TOP; nothing paged NEWER rows on scroll-to-BOTTOM. The gap
-// [cursor+200 .. true newest] was unreachable — the latest messages
-// inaccessible.
+// Original root cause: `loadInitialScrollback` (scrollback.ts) cursor-present
+// arm fetched the region AROUND the read cursor — `listMessagesAfter(cursor,
+// 200)` (capped at the server `@max_http_limit`) + `listMessages(cursor + 1)`
+// for before-context. With true unread > 200 the after-page stopped at
+// `cursor + 200`, so the newest rows were never loaded, and the WS join-ok
+// `refreshScrollback` capped from the same cursor so it never reached the tail
+// either. #161's answer was `loadNewer`: forward paging on scroll-to-bottom,
+// walking [cursor+200 .. tail] one 200-row page per gesture.
 //
-// The fix: a forward-paging verb (`loadNewer`) symmetric to `loadMore`,
-// fired from `ScrollbackPane.onScroll` when the pane nears the bottom of
-// the loaded content. It pulls `listMessagesAfter(highestLoadedId, 200)`
-// and merges via `mergeIntoScrollback`, page-by-page, until the true
-// server tail is reachable. (The no-storm / growing-tail-latch guarantee
-// is covered deterministically in scrollback.test.ts — asserting it here
-// would depend on distinguishing loadNewer's `?after=` from
-// refreshScrollback's identical request shape, which is flaky.)
+// #693 SUPERSEDED THAT MECHANISM FOR THIS SCENARIO, and this spec is rewritten
+// to the contract that replaced it. The observation behind #693 is that
+// forward-paging out of a day-sized gap is not a fix an operator can feel: it
+// still opens the pane at the OLDEST end of the gap and asks for one scroll
+// gesture per 200 rows. So when the gap exceeds one page, the resume no longer
+// anchors at the cursor at all — it probes the true (uncapped) unread count via
+// `GET /networks/:slug/channels/:chan/messages/count?after=<id>`, REPLACES the
+// pane with the newest page, and surfaces the abandoned region as a pinned
+// "N unread — jump back" bar. The in-pane divider is deliberately SUPPRESSED
+// while far behind (`ScrollbackPane` gates `injectMarker` on
+// `farBehindByChannel()[key()] === undefined`), because its count would
+// describe the ~50 loaded rows rather than the thousands missing.
 //
-// This spec is RED against the unmodified anchored-fetch code: the newest
-// row (well past cursor+200) never appears in the DOM no matter how far
-// the operator scrolls down. GREEN once forward-paging lands.
+// So #161's user-facing guarantee — "the newest message is reachable" — is now
+// satisfied by construction rather than by scrolling, and this spec asserts
+// that instead: with unread > 200 the tail is already rendered on arrival, the
+// jump-back bar carries the UNCAPPED count, and the divider is absent. The old
+// assertions were the exact inverse (wait for the unread-marker, then scroll
+// repeatedly to reach the tail) and went red on #693 precisely because they
+// encoded the superseded contract.
 //
-// Seeding: the shared seeder plants 200 rows in #bofh, but #161 needs
-// unread > 200, so this spec re-seeds #bofh with a LARGER corpus via the
-// admin `resetSubject(baselineSeed)` surface (the same verb the wrapped
-// `test` fixture uses for its per-test baseline). The wrapped fixture's
-// afterEach truncates #bofh back to the 200-row baseline, so no manual
-// row cleanup is needed; `restoreReadCursorToTail` in afterAll undoes the
-// early cursor (BUGHUNT-3 cascade rule).
+// `loadNewer` itself still exists and still pages forward on scroll for gaps
+// the tail-anchor does not claim; its no-storm / growing-tail-latch mechanics
+// stay deterministically covered in `src/__tests__/scrollback.test.ts`, which
+// is where they belong (asserting them here would depend on distinguishing
+// loadNewer's `?after=` from refreshScrollback's identical request shape).
+//
+// Seeding: the shared seeder plants 200 rows in #bofh, but this spec needs
+// unread > 200, so it re-seeds #bofh with a LARGER corpus via the admin
+// `resetSubject(baselineSeed)` surface (the same verb the wrapped `test`
+// fixture uses for its per-test baseline). The wrapped fixture's afterEach
+// truncates #bofh back to the 200-row baseline, so no manual row cleanup is
+// needed; `restoreReadCursorToTail` in afterAll undoes the early cursor
+// (BUGHUNT-3 cascade rule).
 
 import { expect, test } from "../fixtures/test";
-import { type Page } from "@playwright/test";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import {
   fetchAllMessagesAsc,
@@ -55,30 +64,18 @@ import {
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 // Re-seed #bofh with a corpus LARGER than the 200-row server cap so the
-// planted early cursor leaves > 200 unread — the exact condition under
-// which the anchored fetch + capped refresh both stop short of the tail.
+// planted early cursor leaves > 200 unread — the exact condition under which
+// #693 abandons the cursor anchor and lands at the tail instead.
 const LARGE_SEED_COUNT = 260;
 const SEED_SENDER = "seed-bot";
 
-// Server `@max_http_limit` — the anchored after-page cap. The newest row
-// must sit beyond `cursor + this` for the bug to bite.
+// Server `@max_http_limit`, and the client's `PAGE_LIMIT`. Both are 200: it is
+// the page size the old anchored fetch capped at AND the gap size above which
+// #693 switches to the tail anchor. The newest row must sit beyond
+// `cursor + this` for either behaviour to be under test.
 const MAX_HTTP_LIMIT = 200;
 
-// Scroll to the very bottom of the CURRENT loaded content (scrollHeight is
-// re-read each call so it tracks the growing list as forward pages merge),
-// and fire a synthetic `scroll` event so the Solid handler runs (mirrors
-// cp14-b2's helper — setting scrollTop fires `scroll` in real browsers, but
-// the harness can race the dispatch, so dispatchEvent is belt + braces).
-async function scrollToBottom(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
-    if (!el) throw new Error("scrollback container not found");
-    el.scrollTop = el.scrollHeight;
-    el.dispatchEvent(new Event("scroll"));
-  });
-}
-
-test.describe("#161 forward-paging — newest messages reachable via scroll-to-bottom", () => {
+test.describe("#161/#693 — a gap larger than one page opens at the tail, not the cursor", () => {
   test.use({ viewport: { width: 800, height: 300 } });
 
   test.afterAll(async () => {
@@ -87,17 +84,16 @@ test.describe("#161 forward-paging — newest messages reachable via scroll-to-b
     await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
   });
 
-  test("scroll-to-bottom pages forward to the true newest row (unread > 200)", async ({
+  test("unread > 200: the newest row is rendered on arrival, with an uncapped jump-back count and no divider", async ({
     page,
   }) => {
     if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
     const vjt = getSeededVjt();
     const admin = getSeededAdmin();
 
-    // Re-seed #bofh with > 200 rows so the anchored 200-cap can't reach
-    // the tail. resetSubject truncates then re-seeds `seedCount` synthetic
-    // privmsgs and re-JOINs the channel (own-nick JOIN lands as the max id
-    // row after the seed).
+    // Re-seed #bofh with > 200 rows. resetSubject truncates then re-seeds
+    // `seedCount` synthetic privmsgs and re-JOINs the channel (own-nick JOIN
+    // lands as the max id row after the seed).
     await resetSubject(
       admin.token,
       VJT_USER,
@@ -110,59 +106,67 @@ test.describe("#161 forward-paging — newest messages reachable via scroll-to-b
     // The corpus must dwarf the 200-row cap for the gap to exist.
     expect(rows.length).toBeGreaterThan(MAX_HTTP_LIMIT + 40);
 
-    // Plant the cursor early enough that unread ≫ 200: at least 240 rows
-    // sit after it, so the anchored after(cursor, 200) stops well short of
-    // the newest row.
+    // Plant the cursor early enough that unread ≫ 200: at least 240 rows sit
+    // after it, so the OLD anchored after(cursor, 200) would have stopped well
+    // short of the newest row, and #693's probe sees a gap it cannot drain in
+    // one page.
     const cursorIndex = rows.length - 240;
     const lastReadRow = rows[cursorIndex];
     if (!lastReadRow) throw new Error("#161 spec: seeded #bofh rows missing cursor index");
     const rowsAfterCursor = rows.filter((r) => r.id > lastReadRow.id).length;
-    // Guard the condition under test: the newest row is beyond cursor+200,
-    // so it is NOT in the anchored initial load.
+    // Guard the condition under test.
     expect(rowsAfterCursor).toBeGreaterThan(MAX_HTTP_LIMIT);
 
-    // The TRUE newest content row — the highest-id seed-bot privmsg (rows
-    // are ASC by id). This is the row that #161 makes unreachable; forward
-    // paging must bring it into the DOM.
+    // The TRUE newest content row — the highest-id seed-bot privmsg (rows are
+    // ASC by id). This is the row #161 made unreachable and #693 puts on
+    // screen without a gesture.
     const privmsgs = rows.filter((r) => r.kind === "privmsg" && r.sender === SEED_SENDER);
     const newestPrivmsg = privmsgs[privmsgs.length - 1];
     if (!newestPrivmsg) throw new Error("#161 spec: no seeded privmsg rows found");
     // Sanity: the newest row really is past the anchored window.
     expect(newestPrivmsg.id).toBeGreaterThan(lastReadRow.id + MAX_HTTP_LIMIT);
 
-    // Plant the early cursor BEFORE login so the channel hydrates with it
-    // and takes the anchored (cursor-present) fetch arm.
+    // Plant the early cursor BEFORE login so the channel hydrates with it and
+    // takes the cursor-present fetch arm — the arm #693 reroutes.
     await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, lastReadRow.id);
 
     await loginAs(page, vjt);
-    // Select WITHOUT the own-nick JOIN-line wait: with unread > 200 the
-    // self-JOIN is the TAIL row, which is exactly what #161 makes
-    // unreachable — the anchored fetch never loads it, so selectChannel's
-    // `ownNick` readiness probe would time out (pre-fix) AND stay
-    // unreachable until the operator scrolls down (post-fix, since forward
-    // paging only fires on scroll). Instead wait on the anchored fetch's
-    // own signal: the unread-marker, which requires the cursor-region rows
-    // to be loaded and is injected only by the cursor-present arm.
     await selectChannel(page, NETWORK_SLUG, CHANNEL);
-    await expect(page.locator('[data-testid="unread-marker"]')).toBeAttached({ timeout: 10_000 });
 
-    const newestLine = page.locator(
-      `[data-testid="scrollback-line"][data-msg-id="${newestPrivmsg.id}"]`,
-    );
+    // Readiness signal for the far-behind arm, the structural replacement for
+    // the unread-marker this spec used to wait on: the pinned bar renders only
+    // once `loadInitialScrollback` has probed the count, decided the gap is
+    // undrainable, and replaced the pane with the newest page.
+    const farBehindBar = page.locator('[data-testid="far-behind-bar"]');
+    await expect(farBehindBar).toBeAttached({ timeout: 10_000 });
 
-    // The anchored fetch scrolled the pane to the unread marker (top of the
-    // unread block), NOT the tail — the newest row is neither loaded nor in
-    // view. Scroll to the bottom of the loaded content repeatedly; each
-    // scroll-to-bottom must page forward until the true newest row is
-    // reachable and rendered.
-    //
-    // RED (pre-fix): no forward-paging handler exists, so no scroll-to-
-    // bottom ever fetches the gap — `newestLine` never attaches. GREEN
-    // (post-fix): forward paging pulls [cursor+200 .. tail] and the newest
-    // row renders.
-    await expect(async () => {
-      await scrollToBottom(page);
-      await expect(newestLine).toBeVisible({ timeout: 2_000 });
-    }).toPass({ timeout: 15_000 });
+    // 1. The tail is ALREADY here — no scrolling, no forward paging. This is
+    //    #161's guarantee, now satisfied on arrival.
+    await expect(
+      page.locator(`[data-testid="scrollback-line"][data-msg-id="${newestPrivmsg.id}"]`),
+    ).toBeVisible();
+
+    // 2. The jump-back count is the TRUE gap, not a page-capped one. A capped
+    //    count would read exactly 200 — the discriminating assertion is
+    //    "greater than the page limit", which is only answerable because the
+    //    resume probes the uncapped `.../messages/count?after=` door. Bounded
+    //    above by the real number of rows after the cursor so an inflated
+    //    count fails too. (Not pinned to an exact equality: the count honours
+    //    the subject's hide-presence preference, while `fetchAllMessagesAsc`
+    //    returns every row.)
+    const jumpLabel = await page.locator('[data-testid="far-behind-jump"]').innerText();
+    const missedMatch = jumpLabel.match(/(\d+)/);
+    if (!missedMatch?.[1]) {
+      throw new Error(`#693 spec: jump-back label carries no count: ${JSON.stringify(jumpLabel)}`);
+    }
+    const missed = Number(missedMatch[1]);
+    expect(missed).toBeGreaterThan(MAX_HTTP_LIMIT);
+    expect(missed).toBeLessThanOrEqual(rowsAfterCursor);
+
+    // 3. The in-pane divider is deliberately absent while far behind: its
+    //    count would describe the loaded page, not the abandoned region, so
+    //    the pinned bar is the single honest unread affordance here. This is
+    //    the assertion that inverts the pre-#693 spec.
+    await expect(page.locator('[data-testid="unread-marker"]')).toHaveCount(0);
   });
 });

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -41,6 +41,7 @@ import { canonicalQueryNick, openQueryWindowState } from "./lib/queryWindows";
 import { getReadCursor } from "./lib/readCursor";
 import { isSettled, nextFollowMode, resolveIntent, type ScrollIntent } from "./lib/scrollAuthority";
 import {
+  dismissFarBehind,
   farBehindByChannel,
   jumpToUnread,
   lastOwnSend,
@@ -3338,6 +3339,63 @@ const ScrollbackPane: Component<Props> = (props) => {
             interactive BanlistModal (opened by /banlist, mounted in Shell),
             mirroring how the #169 /who modal replaced the inline WHO dump. */}
       </div>
+      {/* #693 — the far-behind bar. This pane holds the tail because the gap
+          back to where the operator left off was bigger than one page;
+          everything above the first loaded row is loadable but NOT loaded.
+          PINNED rather than in-flow at that boundary (which is where it
+          semantically belongs, the #270 PeerAwayBanner shape): with no
+          divider to scroll to, the activation routine parks the pane at the
+          BOTTOM, so an in-flow row sits viewports above the fold and the one
+          signal that a region was abandoned is the one signal nobody sees.
+          It rides in the same container-anchored layer as the #133 overlay,
+          one z-index below it — an ephemeral WHOIS card the operator just
+          opened may cover it; it is persistent and they are not.
+          Two exits, both explicit: jump back into the region, or dismiss it
+          and accept the tail as read (nothing else can advance the cursor
+          while this is up — see `setCursorIfAdvances`). */}
+      <Show when={farBehindByChannel()[key()]}>
+        {(far) => (
+          <div class="scrollback-far-behind" data-testid="far-behind-bar">
+            <button
+              type="button"
+              class="scrollback-far-behind-jump"
+              data-testid="far-behind-jump"
+              onClick={() => {
+                // Arm the EXISTING marker-activation latch (#168) before the
+                // swap: clearing the far-behind flag re-injects the divider,
+                // and the rows-change that lands the anchor region is exactly
+                // the content change that latch scrolls to. Set synchronously
+                // so it is armed when the awaited rows arrive — one more
+                // trigger on the existing scroll writer, not a second scroll
+                // authority. Stood back down if the fetch failed, so a dead
+                // latch can't yank a later unrelated rows() change.
+                setMarkerActivationPending(true);
+                void jumpToUnread(props.networkSlug, props.channelName).then((jumped) => {
+                  if (!jumped) setMarkerActivationPending(false);
+                });
+              }}
+            >
+              {far().missed} unread — jump back
+            </button>
+            <button
+              type="button"
+              class="scrollback-far-behind-dismiss"
+              data-testid="far-behind-dismiss"
+              aria-label="Dismiss — mark everything up to here as read"
+              onClick={() => {
+                // Re-latch the frozen divider to whatever was marked read.
+                // Dismiss is an explicit "I've read to here" gesture — the
+                // same class as the send-relatch — so it is one of the few
+                // things allowed to move the freeze mid-session.
+                const readTo = dismissFarBehind(props.networkSlug, props.channelName);
+                if (readTo !== null) setMarkerCursorId(readTo);
+              }}
+            >
+              ×
+            </button>
+          </div>
+        )}
+      </Show>
       <div
         ref={listRef}
         class="scrollback"
@@ -3370,38 +3428,6 @@ const ScrollbackPane: Component<Props> = (props) => {
             the top even in an empty DM (the "no messages yet" fallback). */}
         <Show when={props.kind === "query"}>
           <PeerAwayBanner networkSlug={props.networkSlug} peer={props.channelName} />
-        </Show>
-        {/* #693 — the far-behind boundary row. This pane holds the tail
-            because the gap back to where the operator left off was bigger
-            than one page; everything above this line is loadable but NOT
-            loaded. In-flow at the top of the buffer (the #270 PeerAwayBanner
-            precedent) rather than floating: it marks a position in the
-            history, exactly like the unread divider it replaces, and it
-            belongs at the boundary it describes. Tapping it swaps this window
-            for the region around the anchor. */}
-        <Show when={farBehindByChannel()[key()]}>
-          {(far) => (
-            <button
-              type="button"
-              class="scrollback-far-behind"
-              data-testid="far-behind-jump"
-              onClick={() => {
-                // Arm the EXISTING marker-activation latch (#168) before the
-                // swap: clearing the far-behind flag re-injects the divider,
-                // and the rows-change that lands the anchor region is exactly
-                // the content change that latch scrolls to. Set synchronously
-                // so it is already armed when the awaited rows arrive — this
-                // is the "reuse the writer, add a trigger" shape, not a second
-                // scroll authority.
-                setMarkerActivationPending(true);
-                void jumpToUnread(props.networkSlug, props.channelName);
-              }}
-            >
-              <span class="scrollback-far-behind-line" />
-              <span class="scrollback-far-behind-label">{far().missed} unread — jump back</span>
-              <span class="scrollback-far-behind-line" />
-            </button>
-          )}
         </Show>
         <Show
           when={rows().length > 0}

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -41,6 +41,8 @@ import { canonicalQueryNick, openQueryWindowState } from "./lib/queryWindows";
 import { getReadCursor } from "./lib/readCursor";
 import { isSettled, nextFollowMode, resolveIntent, type ScrollIntent } from "./lib/scrollAuthority";
 import {
+  farBehindByChannel,
+  jumpToUnread,
   lastOwnSend,
   loadMore as loadMoreScrollback,
   loadNewer as loadNewerScrollback,
@@ -1357,7 +1359,19 @@ const ScrollbackPane: Component<Props> = (props) => {
     // Only inject the marker if there are unread messages AND some read messages
     // to show as context above it. When all messages are unread, put the marker
     // at the very top (before index 0). When none are unread, skip the marker.
-    const injectMarker = cursor !== null && sessionTop !== null && unreadCount > 0;
+    //
+    // #693 — except when this pane is FAR BEHIND. There the loader abandoned
+    // the cursor region and anchored at the tail, so the cursor sits below
+    // every loaded row: the divider would slam to the top of the buffer
+    // labelled with the count of the rows that happen to be loaded (~50)
+    // rather than the thousands actually unread — a confident wrong number in
+    // the one place the operator reads to decide where they left off. The
+    // jump-back affordance carries the true count instead.
+    const injectMarker =
+      cursor !== null &&
+      sessionTop !== null &&
+      unreadCount > 0 &&
+      farBehindByChannel()[key()] === undefined;
     const result: Row[] = [];
     let prevTime: number | null = null;
     let markerInjected = false;
@@ -3356,6 +3370,38 @@ const ScrollbackPane: Component<Props> = (props) => {
             the top even in an empty DM (the "no messages yet" fallback). */}
         <Show when={props.kind === "query"}>
           <PeerAwayBanner networkSlug={props.networkSlug} peer={props.channelName} />
+        </Show>
+        {/* #693 — the far-behind boundary row. This pane holds the tail
+            because the gap back to where the operator left off was bigger
+            than one page; everything above this line is loadable but NOT
+            loaded. In-flow at the top of the buffer (the #270 PeerAwayBanner
+            precedent) rather than floating: it marks a position in the
+            history, exactly like the unread divider it replaces, and it
+            belongs at the boundary it describes. Tapping it swaps this window
+            for the region around the anchor. */}
+        <Show when={farBehindByChannel()[key()]}>
+          {(far) => (
+            <button
+              type="button"
+              class="scrollback-far-behind"
+              data-testid="far-behind-jump"
+              onClick={() => {
+                // Arm the EXISTING marker-activation latch (#168) before the
+                // swap: clearing the far-behind flag re-injects the divider,
+                // and the rows-change that lands the anchor region is exactly
+                // the content change that latch scrolls to. Set synchronously
+                // so it is already armed when the awaited rows arrive — this
+                // is the "reuse the writer, add a trigger" shape, not a second
+                // scroll authority.
+                setMarkerActivationPending(true);
+                void jumpToUnread(props.networkSlug, props.channelName);
+              }}
+            >
+              <span class="scrollback-far-behind-line" />
+              <span class="scrollback-far-behind-label">{far().missed} unread — jump back</span>
+              <span class="scrollback-far-behind-line" />
+            </button>
+          )}
         </Show>
         <Show
           when={rows().length > 0}

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -89,7 +89,11 @@ const pushOwnSendSubmitted = (key: string) => setOwnSubmitted(key);
 const [farBehind, setFarBehind] = createSignal<
   Record<string, { missed: number; resumeFrom: number }>
 >({});
-const jumpToUnreadSpy = vi.fn();
+// Resolves TRUE by default (the swap happened) — the pane chains off the
+// result to stand the marker latch back down on a failed jump.
+const jumpToUnreadSpy = vi.fn((_slug: string, _name: string) => Promise.resolve(true));
+// Returns the id it marked read; the pane re-latches its frozen divider to it.
+const dismissFarBehindSpy = vi.fn((_slug: string, _name: string): number | null => 3);
 vi.mock("../lib/scrollback", () => ({
   scrollbackByChannel: () => scrollback(),
   // BUGHUNT-2 B5: ScrollbackPane's onScroll calls `loadMore` when
@@ -115,7 +119,10 @@ vi.mock("../lib/scrollback", () => ({
   // fires. Signal-backed so a spec can flip a window into the far-behind
   // state after mount, the same way `setScrollback` drives the row list.
   farBehindByChannel: () => farBehind(),
-  jumpToUnread: (...args: string[]) => jumpToUnreadSpy(...args),
+  // Wrapped, not passed by reference: `vi.mock` is hoisted above the spy
+  // declarations, so the factory may only DEFER to them.
+  jumpToUnread: (slug: string, name: string) => jumpToUnreadSpy(slug, name),
+  dismissFarBehind: (slug: string, name: string) => dismissFarBehindSpy(slug, name),
 }));
 
 vi.mock("../lib/networks", () => ({
@@ -1985,6 +1992,7 @@ describe("ScrollbackPane", () => {
       afterEach(() => {
         setFarBehind({});
         jumpToUnreadSpy.mockClear();
+        dismissFarBehindSpy.mockClear();
       });
 
       it("renders the jump affordance with the server's missed count", () => {
@@ -2039,6 +2047,52 @@ describe("ScrollbackPane", () => {
         ));
         screen.getByTestId("far-behind-jump").click();
         expect(jumpToUnreadSpy).toHaveBeenCalledWith("freenode", "#grappa");
+      });
+
+      it("offers the dismiss exit — the only way past the frozen cursor", () => {
+        // Without this the operator chats at the tail under a permanent
+        // "3000 unread": far-behind freezes the read cursor, so no amount of
+        // reading clears it.
+        seedReadCursor("freenode", "#grappa", 1);
+        setScrollback({ "freenode #grappa": fixture });
+        setFarBehind({ "freenode #grappa": { missed: 3000, resumeFrom: 1 } });
+        render(() => (
+          <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+        ));
+        screen.getByTestId("far-behind-dismiss").click();
+        expect(dismissFarBehindSpy).toHaveBeenCalledWith("freenode", "#grappa");
+      });
+
+      it("dismissing does not leave a top-slammed divider behind", async () => {
+        // The frozen `markerCursorId` snapshot is thousands of rows old. Un-
+        // suppressing the marker without re-latching would draw "2 unread"
+        // across the top of the buffer the instant the operator dismisses —
+        // the wrong number the suppression existed to prevent.
+        seedReadCursor("freenode", "#grappa", 1);
+        setScrollback({ "freenode #grappa": fixture });
+        setFarBehind({ "freenode #grappa": { missed: 3000, resumeFrom: 1 } });
+        render(() => (
+          <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+        ));
+        screen.getByTestId("far-behind-dismiss").click();
+        // The verb clears the flag server-side; mirror that here.
+        setFarBehind({});
+        await Promise.resolve();
+        expect(screen.queryByTestId("unread-marker")).toBeNull();
+      });
+
+      it("renders the bar OUTSIDE the scroll list so a tail-anchored pane shows it", () => {
+        // The pane opens at the BOTTOM (no divider to scroll to), so a row
+        // in the scroll flow would sit viewports above the fold — the one
+        // signal that a region was abandoned, where nobody looks.
+        seedReadCursor("freenode", "#grappa", 1);
+        setScrollback({ "freenode #grappa": fixture });
+        setFarBehind({ "freenode #grappa": { missed: 3000, resumeFrom: 1 } });
+        render(() => (
+          <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+        ));
+        const bar = screen.getByTestId("far-behind-bar");
+        expect(screen.getByTestId("scrollback").contains(bar)).toBe(false);
       });
     });
 

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -85,6 +85,11 @@ const pushOwnSend = (key: string) => setOwnSend(key);
 // stand-in; `pushOwnSendSubmitted` is the test verb that fires a submit.
 const [ownSubmitted, setOwnSubmitted] = createSignal<string | null>(null, { equals: false });
 const pushOwnSendSubmitted = (key: string) => setOwnSubmitted(key);
+// #693 — far-behind state for the pane under test (see the scrollback mock).
+const [farBehind, setFarBehind] = createSignal<
+  Record<string, { missed: number; resumeFrom: number }>
+>({});
+const jumpToUnreadSpy = vi.fn();
 vi.mock("../lib/scrollback", () => ({
   scrollbackByChannel: () => scrollback(),
   // BUGHUNT-2 B5: ScrollbackPane's onScroll calls `loadMore` when
@@ -105,6 +110,12 @@ vi.mock("../lib/scrollback", () => ({
   refreshScrollback: vi.fn(() => Promise.resolve()),
   lastOwnSend: () => ownSend(),
   ownSendSubmitted: () => ownSubmitted(),
+  // #693 — the far-behind record for the rendered window (empty by default,
+  // i.e. an ordinary contiguous pane) plus the jump verb the boundary row
+  // fires. Signal-backed so a spec can flip a window into the far-behind
+  // state after mount, the same way `setScrollback` drives the row list.
+  farBehindByChannel: () => farBehind(),
+  jumpToUnread: (...args: string[]) => jumpToUnreadSpy(...args),
 }));
 
 vi.mock("../lib/networks", () => ({
@@ -1964,6 +1975,71 @@ describe("ScrollbackPane", () => {
     afterEach(() => {
       localStorage.clear();
       setReadCursorStore({});
+    });
+
+    // #693 — a pane that gave up on contiguity and anchored at the tail.
+    // The cursor is still set (and still server-authoritative), but it points
+    // BELOW every loaded row, so the divider must stand down and the
+    // boundary row must carry the true count instead.
+    describe("far-behind boundary row (#693)", () => {
+      afterEach(() => {
+        setFarBehind({});
+        jumpToUnreadSpy.mockClear();
+      });
+
+      it("renders the jump affordance with the server's missed count", () => {
+        seedReadCursor("freenode", "#grappa", 1);
+        setScrollback({ "freenode #grappa": fixture });
+        setFarBehind({ "freenode #grappa": { missed: 3000, resumeFrom: 1 } });
+        render(() => (
+          <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+        ));
+        expect(screen.getByTestId("far-behind-jump")).toHaveTextContent("3000 unread");
+      });
+
+      it("suppresses the in-pane divider, whose count would describe the loaded rows", () => {
+        // Without the suppression this pane shows "2 unread" — the loaded
+        // rows past the cursor — while 3000 are actually missing.
+        seedReadCursor("freenode", "#grappa", 1);
+        setScrollback({ "freenode #grappa": fixture });
+        setFarBehind({ "freenode #grappa": { missed: 3000, resumeFrom: 1 } });
+        render(() => (
+          <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+        ));
+        expect(screen.queryByTestId("unread-marker")).toBeNull();
+      });
+
+      it("keeps the divider and shows no affordance for an ordinary pane", () => {
+        seedReadCursor("freenode", "#grappa", 1);
+        setScrollback({ "freenode #grappa": fixture });
+        render(() => (
+          <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+        ));
+        expect(screen.queryByTestId("far-behind-jump")).toBeNull();
+        expect(screen.getByTestId("unread-marker")).toHaveTextContent("2 unread");
+      });
+
+      it("does not leak another window's far-behind state into this pane", () => {
+        seedReadCursor("freenode", "#grappa", 1);
+        setScrollback({ "freenode #grappa": fixture });
+        setFarBehind({ "freenode #other": { missed: 3000, resumeFrom: 1 } });
+        render(() => (
+          <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+        ));
+        expect(screen.queryByTestId("far-behind-jump")).toBeNull();
+        expect(screen.getByTestId("unread-marker")).toBeInTheDocument();
+      });
+
+      it("tapping it asks for the anchor region of THIS window", () => {
+        seedReadCursor("freenode", "#grappa", 1);
+        setScrollback({ "freenode #grappa": fixture });
+        setFarBehind({ "freenode #grappa": { missed: 3000, resumeFrom: 1 } });
+        render(() => (
+          <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+        ));
+        screen.getByTestId("far-behind-jump").click();
+        expect(jumpToUnreadSpy).toHaveBeenCalledWith("freenode", "#grappa");
+      });
     });
 
     it("renders no unread-marker when no read cursor is set for the window", () => {

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -179,7 +179,8 @@ vi.mock("../lib/scrollback", () => ({
   // contiguous pane, which is what every Shell render test wants; the
   // far-behind rendering itself is pinned in ScrollbackPane.test.tsx.
   farBehindByChannel: () => ({}),
-  jumpToUnread: vi.fn(),
+  jumpToUnread: vi.fn(() => Promise.resolve(true)),
+  dismissFarBehind: vi.fn(),
 }));
 
 vi.mock("../lib/members", () => ({

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -174,6 +174,12 @@ vi.mock("../lib/scrollback", () => ({
   // and crashes every Shell render test. Static null is enough — Shell tests
   // don't exercise the send-snap (that's ScrollbackPane.test.tsx + the e2e).
   ownSendSubmitted: () => null,
+  // #693 — ScrollbackPane reads the far-behind record to decide between the
+  // in-pane divider and the jump-back boundary row. Empty map = an ordinary
+  // contiguous pane, which is what every Shell render test wants; the
+  // far-behind rendering itself is pinned in ScrollbackPane.test.tsx.
+  farBehindByChannel: () => ({}),
+  jumpToUnread: vi.fn(),
 }));
 
 vi.mock("../lib/members", () => ({

--- a/cicchetto/src/__tests__/friendlyApiError.test.ts
+++ b/cicchetto/src/__tests__/friendlyApiError.test.ts
@@ -152,6 +152,10 @@ const CASES: Array<{ code: string; matches: RegExp; info?: Record<string, unknow
   // #523 / #518 — a web-reachable write's typed 503 when SQLITE_BUSY exhausts
   // the BusyRetry budget (FallbackController :db_unavailable, retry-after 1).
   { code: "db_unavailable", matches: /service is momentarily busy/i },
+  // #696 — 409 refusing to delete the LAST passkey while passkey sign-in is
+  // still enabled (`PasskeyController.delete/2`). The copy has to name the
+  // two ways out, because the refusal is otherwise a dead end for the user.
+  { code: "passkey_required", matches: /only passkey/i },
 ];
 
 describe("friendlyApiError", () => {

--- a/cicchetto/src/lib/__tests__/loadInitialScrollback.test.ts
+++ b/cicchetto/src/lib/__tests__/loadInitialScrollback.test.ts
@@ -293,9 +293,12 @@ describe("#693 far-behind resume", () => {
 
     await refreshScrollback("net", "#resume");
 
+    // The DECISION is measured at the anchor just ingested (700)...
     expect(countMessagesAfterSpy).toHaveBeenCalledWith("test-bearer", "net", "#resume", 700);
     expect(tailOf(scrollbackByChannel()[key])).toBe(2900);
-    expect(farBehindByChannel()[key]).toEqual({ missed: 2000, resumeFrom: 700 });
+    // ...while the jump TARGET is the operator's read position (500) — see the
+    // re-probe case below.
+    expect(farBehindByChannel()[key]).toEqual({ missed: 2000, resumeFrom: 500 });
   });
 
   it("reconnect: a full backfill page that drains the gap keeps its rows", async () => {
@@ -328,5 +331,156 @@ describe("#693 far-behind resume", () => {
     await refreshScrollback("net", "#short");
 
     expect(countMessagesAfterSpy).not.toHaveBeenCalled();
+  });
+
+  it("reconnect: the jump target is the READ CURSOR, not the ingested high-water", async () => {
+    // Jumping back to the high-water mark would land a window whose every row
+    // is already past the cursor — the divider would inject at index 0
+    // labelled with the loaded count, the exact failure the suppression
+    // exists to prevent. So the target is where the operator actually left
+    // off, and the label is re-measured there rather than undercounting by
+    // the page already ingested.
+    const { refreshScrollback, farBehindByChannel } = await import("../scrollback");
+    const { applyJoinReply } = await import("../readCursor");
+    const { channelKey } = await import("../channelKey");
+    applyJoinReply("net", "#target", 500);
+    listMessagesAfterSpy.mockResolvedValue(Array.from({ length: 200 }, (_, i) => row(501 + i)));
+    // First probe (at the anchor 700) says 2000; the re-probe at the cursor
+    // says 2200 — the same region plus the 200 rows just ingested.
+    countMessagesAfterSpy.mockResolvedValueOnce(2000).mockResolvedValueOnce(2200);
+    listMessagesSpy.mockResolvedValue([row(2900)]);
+
+    await refreshScrollback("net", "#target");
+
+    expect(countMessagesAfterSpy).toHaveBeenNthCalledWith(1, "test-bearer", "net", "#target", 700);
+    expect(countMessagesAfterSpy).toHaveBeenNthCalledWith(2, "test-bearer", "net", "#target", 500);
+    expect(farBehindByChannel()[channelKey("net", "#target")]).toEqual({
+      missed: 2200,
+      resumeFrom: 500,
+    });
+  });
+
+  it("keeps a live row that landed while the tail page was in flight", async () => {
+    // `appendToScrollback` has already rolled the high-water mark past such a
+    // row, so a blind overwrite would drop it from the pane AND make it
+    // unfetchable — the next `?after=` starts above it. It sits at the tail,
+    // so keeping it opens no hole.
+    const { loadInitialScrollback, appendToScrollback, scrollbackByChannel } = await import(
+      "../scrollback"
+    );
+    const { applyJoinReply } = await import("../readCursor");
+    const { channelKey } = await import("../channelKey");
+    const key = channelKey("net", "#live");
+    applyJoinReply("net", "#live", 100);
+    countMessagesAfterSpy.mockResolvedValue(3000);
+    listMessagesSpy.mockImplementation(async () => {
+      // The WS delivers row 3101 while the tail page is in flight.
+      appendToScrollback(key, row(3101));
+      return [row(3100), row(3099)];
+    });
+
+    await loadInitialScrollback("net", "#live");
+
+    expect((scrollbackByChannel()[key] ?? []).map((m) => m.id)).toEqual([3099, 3100, 3101]);
+  });
+
+  it("drops a racing anchored page rather than splicing a hole into a tail-anchored pane", async () => {
+    // Cold-load and reconnect are not serialised for one key. If the refresh
+    // re-anchors at the tail while the anchored pages are in flight, merging
+    // them would draw [cursor+1..cursor+200] abutting the tail window with
+    // thousands of rows silently missing between them.
+    const { loadInitialScrollback, refreshScrollback, scrollbackByChannel } = await import(
+      "../scrollback"
+    );
+    const { applyJoinReply } = await import("../readCursor");
+    const { channelKey } = await import("../channelKey");
+    const key = channelKey("net", "#race");
+    applyJoinReply("net", "#race", 100);
+    // The cold load sees a small gap and takes the anchored branch...
+    countMessagesAfterSpy.mockResolvedValue(10);
+    let releaseAnchored: (rows: ScrollbackMessage[]) => void = () => {};
+    listMessagesAfterSpy.mockImplementation(
+      () =>
+        new Promise<ScrollbackMessage[]>((resolve) => {
+          releaseAnchored = resolve;
+        }),
+    );
+    listMessagesSpy.mockResolvedValue([row(100), row(99)]);
+    const cold = loadInitialScrollback("net", "#race");
+
+    // ...and while it is in flight, a reconnect anchors the same key at the tail.
+    const { farBehindByChannel } = await import("../scrollback");
+    expect(farBehindByChannel()[key]).toBeUndefined();
+    listMessagesSpy.mockResolvedValue([row(3100), row(3099)]);
+    countMessagesAfterSpy.mockResolvedValue(3000);
+    listMessagesAfterSpy.mockResolvedValueOnce(Array.from({ length: 200 }, (_, i) => row(101 + i)));
+    await refreshScrollback("net", "#race");
+    expect(farBehindByChannel()[key]).toBeDefined();
+
+    releaseAnchored([row(101), row(102)]);
+    await cold;
+
+    // The pane is the tail window the refresh left; the anchored pages are gone.
+    expect((scrollbackByChannel()[key] ?? []).map((m) => m.id)).toEqual([3099, 3100]);
+  });
+
+  it("a failed jump reports it, leaves the pane, and stays retryable", async () => {
+    const { loadInitialScrollback, jumpToUnread, farBehindByChannel, scrollbackByChannel } =
+      await import("../scrollback");
+    const { applyJoinReply } = await import("../readCursor");
+    const { channelKey } = await import("../channelKey");
+    const key = channelKey("net", "#flaky");
+    applyJoinReply("net", "#flaky", 100);
+    countMessagesAfterSpy.mockResolvedValue(3000);
+    listMessagesSpy.mockResolvedValue([row(3100)]);
+    await loadInitialScrollback("net", "#flaky");
+
+    listMessagesAfterSpy.mockRejectedValue(new Error("offline"));
+    const jumped = await jumpToUnread("net", "#flaky");
+
+    expect(jumped).toBe(false);
+    expect((scrollbackByChannel()[key] ?? []).map((m) => m.id)).toEqual([3100]);
+    // Still far behind → the affordance survives for a second attempt.
+    expect(farBehindByChannel()[key]).toBeDefined();
+  });
+
+  it("a peer rename carries the far-behind record with the window (#373 set)", async () => {
+    const { loadInitialScrollback, renameScrollbackKey, farBehindByChannel } = await import(
+      "../scrollback"
+    );
+    const { applyJoinReply } = await import("../readCursor");
+    const { channelKey } = await import("../channelKey");
+    applyJoinReply("net", "oldpeer", 100);
+    countMessagesAfterSpy.mockResolvedValue(3000);
+    listMessagesSpy.mockResolvedValue([row(3100)]);
+    await loadInitialScrollback("net", "oldpeer");
+
+    renameScrollbackKey(channelKey("net", "oldpeer"), channelKey("net", "newpeer"));
+
+    expect(farBehindByChannel()[channelKey("net", "newpeer")]).toEqual({
+      missed: 3000,
+      resumeFrom: 100,
+    });
+    expect(farBehindByChannel()[channelKey("net", "oldpeer")]).toBeUndefined();
+  });
+
+  it("dismissing marks the loaded tail read and drops the flag", async () => {
+    const { loadInitialScrollback, dismissFarBehind, farBehindByChannel } = await import(
+      "../scrollback"
+    );
+    const { applyJoinReply } = await import("../readCursor");
+    const { channelKey } = await import("../channelKey");
+    const key = channelKey("net", "#dismiss");
+    applyJoinReply("net", "#dismiss", 100);
+    countMessagesAfterSpy.mockResolvedValue(3000);
+    listMessagesSpy.mockResolvedValue([row(3100), row(3099)]);
+    await loadInitialScrollback("net", "#dismiss");
+
+    dismissFarBehind("net", "#dismiss");
+
+    // Advances to the newest LOADED row — the forward-only cursor contract
+    // still holds; nothing invents an id the pane never showed.
+    expect(setReadCursorSpy).toHaveBeenCalledWith("test-bearer", "net", "#dismiss", 3100);
+    expect(farBehindByChannel()[key]).toBeUndefined();
   });
 });

--- a/cicchetto/src/lib/__tests__/loadInitialScrollback.test.ts
+++ b/cicchetto/src/lib/__tests__/loadInitialScrollback.test.ts
@@ -54,12 +54,14 @@ vi.mock("../auth", () => ({
 // exists) returns a server-shaped ASC page.
 const listMessagesSpy = vi.fn<(...a: unknown[]) => Promise<ScrollbackMessage[]>>();
 const listMessagesAfterSpy = vi.fn<(...a: unknown[]) => Promise<ScrollbackMessage[]>>();
+const countMessagesAfterSpy = vi.fn<(...a: unknown[]) => Promise<number>>();
 vi.mock("../api", async () => {
   const actual = await vi.importActual<typeof import("../api")>("../api");
   return {
     ...actual,
     listMessages: (...args: unknown[]) => listMessagesSpy(...args),
     listMessagesAfter: (...args: unknown[]) => listMessagesAfterSpy(...args),
+    countMessagesAfter: (...args: unknown[]) => countMessagesAfterSpy(...args),
   };
 });
 
@@ -96,6 +98,9 @@ describe("loadInitialScrollback cursor baseline", () => {
     listMessagesSpy.mockReset();
     listMessagesAfterSpy.mockReset();
     listMessagesAfterSpy.mockResolvedValue([]);
+    countMessagesAfterSpy.mockReset();
+    // Default: a small gap, i.e. the pre-#693 contiguous resume.
+    countMessagesAfterSpy.mockResolvedValue(0);
     mockTokenValue = "test-bearer";
   });
 
@@ -153,5 +158,175 @@ describe("loadInitialScrollback cursor baseline", () => {
     await loadInitialScrollback("net", "#empty");
 
     expect(setReadCursorSpy).not.toHaveBeenCalled();
+  });
+});
+
+// #693 — returning after a long absence must land at the TAIL, not 200 rows
+// into the past. The trigger is the GAP SIZE, not the absence: any gap bigger
+// than one page leaves the anchored resume loading `[cursor .. cursor+200]`,
+// the OLDEST end of the region, with the present hundreds of rows further on.
+describe("#693 far-behind resume", () => {
+  const tailOf = (rows: ScrollbackMessage[] | undefined): number | undefined =>
+    rows && rows.length > 0 ? rows[rows.length - 1]?.id : undefined;
+
+  beforeEach(async () => {
+    const { clearReadCursors } = await import("../readCursor");
+    clearReadCursors();
+    setReadCursorSpy.mockClear();
+    listMessagesSpy.mockReset();
+    listMessagesAfterSpy.mockReset();
+    listMessagesAfterSpy.mockResolvedValue([]);
+    countMessagesAfterSpy.mockReset();
+    countMessagesAfterSpy.mockResolvedValue(0);
+    mockTokenValue = "test-bearer";
+  });
+
+  it("cold load with a gap LARGER than a page lands on the server tail", async () => {
+    const { loadInitialScrollback, scrollbackByChannel } = await import("../scrollback");
+    const { applyJoinReply } = await import("../readCursor");
+    const { channelKey } = await import("../channelKey");
+    applyJoinReply("net", "#flood", 100);
+    // 3000 rows accumulated while the operator was away; the tail is 3100.
+    countMessagesAfterSpy.mockResolvedValue(3000);
+    listMessagesSpy.mockResolvedValue([row(3100), row(3099), row(3098)]);
+
+    await loadInitialScrollback("net", "#flood");
+
+    // The newest loaded row is the TAIL, not cursor + one page.
+    expect(tailOf(scrollbackByChannel()[channelKey("net", "#flood")])).toBe(3100);
+    // The gap was MEASURED, at the anchor this branch would have used.
+    expect(countMessagesAfterSpy).toHaveBeenCalledWith("test-bearer", "net", "#flood", 100);
+    // ...and the oldest-end anchored page was never fetched.
+    expect(listMessagesAfterSpy).not.toHaveBeenCalled();
+  });
+
+  it("records the missed count and the anchor so the jump affordance can show them", async () => {
+    const { loadInitialScrollback, farBehindByChannel } = await import("../scrollback");
+    const { applyJoinReply } = await import("../readCursor");
+    const { channelKey } = await import("../channelKey");
+    applyJoinReply("net", "#missed", 100);
+    countMessagesAfterSpy.mockResolvedValue(3000);
+    listMessagesSpy.mockResolvedValue([row(3100)]);
+
+    await loadInitialScrollback("net", "#missed");
+
+    expect(farBehindByChannel()[channelKey("net", "#missed")]).toEqual({
+      missed: 3000,
+      resumeFrom: 100,
+    });
+  });
+
+  it("cold load with a gap SMALLER than a page keeps the contiguous resume", async () => {
+    const { loadInitialScrollback, farBehindByChannel } = await import("../scrollback");
+    const { applyJoinReply } = await import("../readCursor");
+    const { channelKey } = await import("../channelKey");
+    applyJoinReply("net", "#small", 100);
+    countMessagesAfterSpy.mockResolvedValue(12);
+    listMessagesAfterSpy.mockResolvedValue([row(101), row(102)]);
+    listMessagesSpy.mockResolvedValue([row(100), row(99)]);
+
+    await loadInitialScrollback("net", "#small");
+
+    // Unchanged #156 shape: anchored after + before, no tail-only fetch.
+    expect(listMessagesAfterSpy).toHaveBeenCalledWith("test-bearer", "net", "#small", 100, 200);
+    expect(listMessagesSpy).toHaveBeenCalledWith("test-bearer", "net", "#small", 101);
+    expect(listMessagesSpy).not.toHaveBeenCalledWith("test-bearer", "net", "#small");
+    expect(farBehindByChannel()[channelKey("net", "#small")]).toBeUndefined();
+  });
+
+  it("keeps the contiguous resume when the gap probe is unavailable", async () => {
+    // An older server has no /messages/count route. Degrade to the
+    // pre-#693 behaviour rather than guessing — never throw away a pane on
+    // an unanswered question.
+    const { loadInitialScrollback, farBehindByChannel } = await import("../scrollback");
+    const { applyJoinReply } = await import("../readCursor");
+    const { channelKey } = await import("../channelKey");
+    applyJoinReply("net", "#oldserver", 100);
+    countMessagesAfterSpy.mockRejectedValue(new Error("not_found"));
+    listMessagesAfterSpy.mockResolvedValue([row(101)]);
+    listMessagesSpy.mockResolvedValue([row(100)]);
+
+    await loadInitialScrollback("net", "#oldserver");
+
+    expect(listMessagesAfterSpy).toHaveBeenCalledWith("test-bearer", "net", "#oldserver", 100, 200);
+    expect(farBehindByChannel()[channelKey("net", "#oldserver")]).toBeUndefined();
+  });
+
+  it("jumping back swaps the tail window for the anchor region and drops the flag", async () => {
+    const { loadInitialScrollback, jumpToUnread, farBehindByChannel, scrollbackByChannel } =
+      await import("../scrollback");
+    const { applyJoinReply } = await import("../readCursor");
+    const { channelKey } = await import("../channelKey");
+    const key = channelKey("net", "#jump");
+    applyJoinReply("net", "#jump", 100);
+    countMessagesAfterSpy.mockResolvedValue(3000);
+    listMessagesSpy.mockResolvedValue([row(3100), row(3099)]);
+    await loadInitialScrollback("net", "#jump");
+
+    // Now the operator takes the affordance: after(100) + before(101).
+    listMessagesAfterSpy.mockResolvedValue([row(101), row(102)]);
+    listMessagesSpy.mockResolvedValue([row(100), row(99)]);
+    await jumpToUnread("net", "#jump");
+
+    const rows = scrollbackByChannel()[key] ?? [];
+    expect(rows.map((m) => m.id)).toEqual([99, 100, 101, 102]);
+    // REPLACED, not merged: keeping the tail rows next to these would render
+    // a hole — 2998 missing rows drawn as if they were consecutive.
+    expect(rows.some((m) => m.id === 3100)).toBe(false);
+    expect(farBehindByChannel()[key]).toBeUndefined();
+  });
+
+  it("reconnect: a full backfill page with more than a page still missing lands at the tail", async () => {
+    const { refreshScrollback, scrollbackByChannel, farBehindByChannel } = await import(
+      "../scrollback"
+    );
+    const { applyJoinReply } = await import("../readCursor");
+    const { channelKey } = await import("../channelKey");
+    const key = channelKey("net", "#resume");
+    applyJoinReply("net", "#resume", 500);
+    // A full 200-row page — which says "at least 200 more", not how many.
+    const fullPage = Array.from({ length: 200 }, (_, i) => row(501 + i));
+    listMessagesAfterSpy.mockResolvedValue(fullPage);
+    // ...and the probe says 2000 rows still sit past the last one ingested.
+    countMessagesAfterSpy.mockResolvedValue(2000);
+    listMessagesSpy.mockResolvedValue([row(2900), row(2899)]);
+
+    await refreshScrollback("net", "#resume");
+
+    expect(countMessagesAfterSpy).toHaveBeenCalledWith("test-bearer", "net", "#resume", 700);
+    expect(tailOf(scrollbackByChannel()[key])).toBe(2900);
+    expect(farBehindByChannel()[key]).toEqual({ missed: 2000, resumeFrom: 700 });
+  });
+
+  it("reconnect: a full backfill page that drains the gap keeps its rows", async () => {
+    const { refreshScrollback, scrollbackByChannel, farBehindByChannel } = await import(
+      "../scrollback"
+    );
+    const { applyJoinReply } = await import("../readCursor");
+    const { channelKey } = await import("../channelKey");
+    const key = channelKey("net", "#drained");
+    applyJoinReply("net", "#drained", 500);
+    const fullPage = Array.from({ length: 200 }, (_, i) => row(501 + i));
+    listMessagesAfterSpy.mockResolvedValue(fullPage);
+    // Only 10 rows behind after that page — one more scroll closes it, so the
+    // pane must NOT be thrown away.
+    countMessagesAfterSpy.mockResolvedValue(10);
+
+    await refreshScrollback("net", "#drained");
+
+    expect(tailOf(scrollbackByChannel()[key])).toBe(700);
+    expect(farBehindByChannel()[key]).toBeUndefined();
+    expect(listMessagesSpy).not.toHaveBeenCalled();
+  });
+
+  it("reconnect: a SHORT backfill page never pays for the probe", async () => {
+    const { refreshScrollback } = await import("../scrollback");
+    const { applyJoinReply } = await import("../readCursor");
+    applyJoinReply("net", "#short", 500);
+    listMessagesAfterSpy.mockResolvedValue([row(501), row(502)]);
+
+    await refreshScrollback("net", "#short");
+
+    expect(countMessagesAfterSpy).not.toHaveBeenCalled();
   });
 });

--- a/cicchetto/src/lib/__tests__/setCursorIfAdvances.test.ts
+++ b/cicchetto/src/lib/__tests__/setCursorIfAdvances.test.ts
@@ -57,12 +57,49 @@ vi.mock("../readCursor", async () => {
   };
 });
 
+// #693 — the far-behind freeze reads this map through selection.ts. Keep the
+// rest of scrollback live; the spec drives the one signal it needs.
+let farBehindMap: Record<string, { missed: number; resumeFrom: number }> = {};
+vi.mock("../scrollback", async () => {
+  const actual = await vi.importActual<typeof import("../scrollback")>("../scrollback");
+  return { ...actual, farBehindByChannel: () => farBehindMap };
+});
+
 describe("setCursorIfAdvances", () => {
   beforeEach(async () => {
     const { clearReadCursors } = await import("../readCursor");
     clearReadCursors();
     setReadCursorSpy.mockClear();
     mockTokenValue = null;
+    farBehindMap = {};
+  });
+
+  it("does NOT POST while the window is far behind (#693)", async () => {
+    // A tail-anchored pane renders rows thousands of ids past the operator's
+    // real read position. Taking one would mark the whole abandoned region
+    // read — server-side, on every device — destroying the position the jump
+    // affordance exists to return to. Only `dismissFarBehind` may do that.
+    const { setCursorIfAdvances } = await import("../selection");
+    const { applyJoinReply } = await import("../readCursor");
+    mockTokenValue = "test-bearer";
+    applyJoinReply("net", "#chan", 100);
+    farBehindMap = { "net #chan": { missed: 3000, resumeFrom: 100 } };
+
+    setCursorIfAdvances("net", "#chan", 3100);
+
+    expect(setReadCursorSpy).not.toHaveBeenCalled();
+  });
+
+  it("resumes POSTing for other windows while one is far behind", async () => {
+    const { setCursorIfAdvances } = await import("../selection");
+    const { applyJoinReply } = await import("../readCursor");
+    mockTokenValue = "test-bearer";
+    applyJoinReply("net", "#other", 100);
+    farBehindMap = { "net #chan": { missed: 3000, resumeFrom: 100 } };
+
+    setCursorIfAdvances("net", "#other", 150);
+
+    expect(setReadCursorSpy).toHaveBeenCalledWith("test-bearer", "net", "#other", 150);
   });
 
   it("POSTs when candidate is greater than current cursor", async () => {

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -2151,6 +2151,35 @@ export async function listMessagesAfter(
   return (await res.json()) as ScrollbackMessage[];
 }
 
+// #693 — the gap probe. Mirror of `GrappaWeb.MessagesController.count/2`:
+// how many rows sit after `afterId`, uncapped and with the same presence
+// filter a fetch would apply.
+//
+// `listMessagesAfter` above cannot answer this. It returns at most one page,
+// so a full page means "at least 200 more" — which is the same answer for a
+// 201-row gap (drain it, the operator barely notices) and a 3000-row one
+// (abandon the anchor, the operator wants the present). The resume paths in
+// `scrollback.ts` need to tell those apart, so they ask.
+//
+// Throws like its siblings on a non-2xx. Callers treat a throw as "unknown
+// gap" and keep the pre-#693 cursor-anchored resume — an older server has no
+// such route, and a client that hard-failed on that would be worse than one
+// that degrades.
+export async function countMessagesAfter(
+  token: string,
+  networkSlug: string,
+  channelName: string,
+  afterId: number,
+): Promise<number> {
+  const res = await fetch(
+    `/networks/${encodeURIComponent(networkSlug)}/channels/${encodeURIComponent(channelName)}/messages/count?after=${afterId}`,
+    { headers: buildHeaders(token) },
+  );
+  if (!res.ok) throw await readError(res);
+  const body = (await res.json()) as { count: number };
+  return body.count;
+}
+
 // Mirror of `GrappaWeb.MessagesController.create/2`. Server hardcodes
 // `kind = :privmsg` — only `body` is in the request envelope. Returns
 // 201 + the persisted Wire row; the same row also fires on the

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -2162,9 +2162,10 @@ export async function listMessagesAfter(
 // `scrollback.ts` need to tell those apart, so they ask.
 //
 // Throws like its siblings on a non-2xx. Callers treat a throw as "unknown
-// gap" and keep the pre-#693 cursor-anchored resume — an older server has no
-// such route, and a client that hard-failed on that would be worse than one
-// that degrades.
+// gap" and keep whatever recovery they were already committed to — the
+// anchored pages on a cold load, the page just ingested on a reconnect. An
+// older server has no such route, and a client that hard-failed on that would
+// be worse than one that degrades.
 export async function countMessagesAfter(
   token: string,
   networkSlug: string,

--- a/cicchetto/src/lib/friendlyApiError.ts
+++ b/cicchetto/src/lib/friendlyApiError.ts
@@ -62,6 +62,12 @@ function friendlyKnown(err: ApiError, code: ErrorTokensRestErrorToken): string {
       return "Two-factor challenge expired. Enter your password again.";
     case "already_enabled":
       return "Two-factor authentication is already enabled.";
+    case "passkey_required":
+      // #696 — 409 from `PasskeyController.delete/2`: this is the LAST
+      // passkey and passkey sign-in is still enabled, so removing it would
+      // lock the account out. Name both exits — a bare refusal reads as a
+      // dead end.
+      return "That's your only passkey. Add another, or turn off passkey sign-in first.";
     case "too_many_sessions":
       // U-3 (UD3): ip_cap_exceeded — this source IP already holds
       // its allotted session(s) for this network (`max_per_ip`,

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -1,6 +1,7 @@
 import { createSignal } from "solid-js";
 import {
   sendMessage as apiSendMessage,
+  countMessagesAfter,
   listMessages,
   listMessagesAfter,
   type ScrollbackMessage,
@@ -84,6 +85,25 @@ import { getResumeCursor, recordSeen } from "./reconnectBackfill";
 //     channel — the cursor advances and the now-read rows become evictable.
 export const SCROLLBACK_RING_CAP = 1000;
 
+// #693 — ONE page. The server's `@max_http_limit`, and the ceiling on every
+// recovery fetch: the #156 anchored `after(cursor)` page, the reconnect
+// `refreshScrollback` page, and the #161 forward page. It used to be three
+// separate literal 200s; the far-behind decision below has to compare a gap
+// against exactly this number, and three copies of a threshold's twin is how
+// thresholds drift apart.
+//
+// `loadMore` (the older end) deliberately does NOT use it: a human scrolling
+// UP rarely wants 200 rows at once, so that path takes the server default
+// (~50). The forward end is recovering unread that can run to the hundreds.
+const PAGE_LIMIT = 200;
+
+// #693 — "more than one page behind". Above this many rows after the anchor,
+// resuming contiguously from the anchor is a lie: the client would load the
+// OLDEST 200 rows of the gap and the operator would have to scroll to the
+// bottom (200 rows a gesture) to reach the present. At or below it, one more
+// fetch drains the rest, so contiguity is cheap and worth keeping.
+const isFarBehind = (gap: number): boolean => gap > PAGE_LIMIT;
+
 // Canonical scrollback ordering: `server_time` ASC, `id` ASC tie-break —
 // the client mirror of the server's `[desc: server_time, desc: id]`
 // (`Scrollback.fetch/5`). Single source so `mergeIntoScrollback` and
@@ -157,6 +177,27 @@ const exports = identityScopedStore((onIdentityChange) => {
     Record<ChannelKey, ScrollbackMessage[]>
   >({});
 
+  // #693 — "this pane holds the TAIL, and the region the operator left off in
+  // is NOT in it." Set when a resume found the gap too large to drain (see
+  // `anchorAtTail`), cleared when the operator jumps back into that region or
+  // the window is purged.
+  //
+  //   * `missed` — the server's true row count after the anchor, at the
+  //     moment of the decision. What the jump affordance shows.
+  //   * `resumeFrom` — the anchor itself: the newest row the pane held before
+  //     it gave up on contiguity (the read cursor on a cold open, the last
+  //     backfilled row on a reconnect). Where the jump lands.
+  //
+  // State that cannot be derived: with the tail loaded and the anchor far
+  // below the oldest loaded row, nothing local says how much is missing —
+  // that is exactly the measurement the client had to ask the server for.
+  // ScrollbackPane reads it to render the jump affordance and to suppress the
+  // in-pane unread divider (whose count would otherwise describe the loaded
+  // rows rather than the unread region).
+  const [farBehindByChannel, setFarBehindByChannel] = createSignal<
+    Record<ChannelKey, { missed: number; resumeFrom: number }>
+  >({});
+
   // Send-relatch (2026-06-09): the channel-key of THIS device's most
   // recent own send. `sendMessage` writes it; ScrollbackPane reads it to
   // hide the frozen unread-marker on a focused send ("marker showing +
@@ -190,11 +231,11 @@ const exports = identityScopedStore((onIdentityChange) => {
     equals: false,
   });
 
-  // Identity-transition cleanup. Eight registered resets fired by the
+  // Identity-transition cleanup. Nine registered resets fired by the
   // factory's createEffect(on(token, ...)) — five Set.clear() (loadedChannels
   // + loadMore{InFlight,Exhausted} + loadNewer{InFlight,Exhausted}, #161) +
-  // three signal flushes (scrollbackByChannel + lastOwnSend + ownSendSubmitted,
-  // #580). Order matches the pre-A3 inline shape.
+  // four signal flushes (scrollbackByChannel + lastOwnSend + ownSendSubmitted,
+  // #580 + farBehindByChannel, #693). Order matches the pre-A3 inline shape.
   onIdentityChange(() => loadedChannels.clear());
   onIdentityChange(() => loadMoreInFlight.clear());
   onIdentityChange(() => loadMoreExhausted.clear());
@@ -203,6 +244,7 @@ const exports = identityScopedStore((onIdentityChange) => {
   onIdentityChange(() => setScrollbackByChannel({}));
   onIdentityChange(() => setLastOwnSend(null));
   onIdentityChange(() => setOwnSendSubmitted(null));
+  onIdentityChange(() => setFarBehindByChannel({}));
 
   // Insert an incoming message into the per-channel ascending list at its
   // (server_time, id) position, deduping by id. REST + WS can overlap: the
@@ -295,6 +337,93 @@ const exports = identityScopedStore((onIdentityChange) => {
     });
   };
 
+  // #693 — how many rows sit after `anchor` on the server, or `null` when the
+  // question could not be answered (an older server with no
+  // `/messages/count` route, a transient error). `null` is NOT zero and NOT
+  // "far behind": callers fall back to the pre-#693 cursor-anchored resume,
+  // which is wrong-but-familiar rather than a destructive guess.
+  const probeGap = async (
+    t: string,
+    slug: string,
+    name: string,
+    anchor: number,
+  ): Promise<number | null> => {
+    try {
+      return await countMessagesAfter(t, slug, name, anchor);
+    } catch (err) {
+      console.warn("[scrollback] gap probe failed — resuming from the cursor", slug, name, err);
+      return null;
+    }
+  };
+
+  // #693 — REPLACE this key's rows with the server's newest page and record
+  // that the unread region is no longer in the pane.
+  //
+  // Replace, not merge: store order IS display order (`ScrollbackPane` renders
+  // the array verbatim) and there is no gap-marker row, so merging a tail page
+  // beside rows from hundreds of messages ago renders a silent hole — two
+  // regions abutting as if they were consecutive. Dropping the stale region is
+  // both honest and recoverable: scroll-up re-pages it through `loadMore`,
+  // which is why the exhausted latch is cleared here.
+  //
+  // The high-water mark rolls to the tail (`recordSeen`) so the NEXT
+  // `refreshScrollback` resumes from the present instead of re-fetching the
+  // abandoned region and re-deciding it is far behind, forever.
+  const anchorAtTail = async (
+    t: string,
+    slug: string,
+    name: string,
+    missed: number,
+    resumeFrom: number,
+  ): Promise<void> => {
+    const key = channelKey(slug, name);
+    const page = await listMessages(t, slug, name);
+    const rows = [...page].sort(byServerTimeThenId);
+    setScrollbackByChannel((prev) => ({ ...prev, [key]: rows }));
+    for (const msg of rows) recordSeen(key, msg);
+    loadMoreExhausted.delete(key);
+    setFarBehindByChannel((prev) => ({ ...prev, [key]: { missed, resumeFrom } }));
+  };
+
+  const clearFarBehind = (key: ChannelKey): void => {
+    setFarBehindByChannel((prev) => {
+      if (!(key in prev)) return prev;
+      const { [key]: _drop, ...rest } = prev;
+      return rest;
+    });
+  };
+
+  // #693 — the operator took the "N unread — jump back" affordance. Swap the
+  // tail window for the cursor-anchored one: exactly the fetch shape #156
+  // does on a small gap, so the in-pane divider lands between read context
+  // and the first unread row.
+  //
+  // Replace rather than merge, for the same reason `anchorAtTail` does — the
+  // two windows are not contiguous. Leaving the tail is the point of the
+  // gesture; getting back to it is `loadNewer` (scroll to the bottom) or a
+  // fresh open, the same as any other window sitting on old history.
+  const jumpToUnread = async (slug: string, name: string): Promise<void> => {
+    const t = token();
+    if (!t) return;
+    const key = channelKey(slug, name);
+    const far = farBehindByChannel()[key];
+    if (!far) return;
+    const [afterPage, beforePage] = await Promise.all([
+      listMessagesAfter(t, slug, name, far.resumeFrom, PAGE_LIMIT),
+      listMessages(t, slug, name, far.resumeFrom + 1),
+    ]);
+    // Disjoint by construction — `after(cursor)` is `id > cursor`,
+    // `before(cursor + 1)` is `id <= cursor` — so concat + sort needs no
+    // dedupe pass.
+    const rows = [...afterPage, ...beforePage].sort(byServerTimeThenId);
+    setScrollbackByChannel((prev) => ({ ...prev, [key]: rows }));
+    // The pane no longer holds the tail, and there IS older history below the
+    // new oldest row — both latches are stale.
+    loadNewerExhausted.delete(key);
+    loadMoreExhausted.delete(key);
+    clearFarBehind(key);
+  };
+
   const loadInitialScrollback = async (slug: string, name: string): Promise<void> => {
     const t = token();
     if (!t) return;
@@ -359,34 +488,47 @@ const exports = identityScopedStore((onIdentityChange) => {
         // oldest-id paging keeps working. Never re-baseline the cursor —
         // the existing read position (and its marker) is preserved.
         //
-        // UNCONDITIONAL when a cursor exists — NOT gated on a server
-        // unread count. The count lives in selection.ts (the sole caller),
-        // and reaching it from here means either an import cycle
-        // (selection → scrollback already) or threading it through the
-        // signature. Both are heavier than the cost: ONE extra small GET
-        // per cursor-present channel-open, behind the load-once gate, on a
-        // human click. A count-vs-window gate is also FRAGILE — it would
-        // couple cic to the server's ~50 page-size constant, and the seed
-        // count (messages+events) measures different rows than the marker's
-        // filtered count (own-presence / operator-echo excluded). The
-        // unconditional anchored fetch is window-size-agnostic and fixes
-        // the root cause for any window size. For a fully-read channel
-        // after(...) returns 0 rows and the load is just the before page;
-        // for the common few-unread case the two pages still cover the
-        // newest rows.
+        // For a fully-read channel after(...) returns 0 rows and the load is
+        // just the before page; for the common few-unread case the two pages
+        // cover the newest rows.
         //
-        // >200 cap (KNOWN EDGE): if true unread > 200, after(...) stops at
-        // cursor+200, so the very newest rows aren't in this initial load
-        // — they stream in via the WS join-ok `refreshScrollback`. The
-        // DIVIDER is still correctly anchored; only the in-pane count caps
-        // at the loaded window (sessionTopId = cursor+200) until the rest
-        // arrive.
-        const [afterPage, beforePage] = await Promise.all([
-          listMessagesAfter(t, slug, name, cursor, 200),
-          listMessages(t, slug, name, cursor + 1),
-        ]);
-        mergeIntoScrollback(key, afterPage);
-        mergeIntoScrollback(key, beforePage);
+        // #693 note on the gate below: the branch is no longer unconditional,
+        // but it is still NOT gated on the sidebar's unread seed. That number
+        // lives in selection.ts (reaching it from here is an import cycle),
+        // it is anchored at the read cursor rather than at an arbitrary
+        // anchor, and it counts a different row set than a fetch returns
+        // (own-presence / operator-echo). The gap probe asks the server about
+        // the exact anchor this branch is about to use, so the answer
+        // describes the rows this fetch would receive.
+        //
+        // #693 — the >200 case is NO LONGER handled by loading the oldest
+        // page of the gap and hoping. That was the bug: the anchored fetch
+        // returns `[cursor .. cursor+200]`, the tail stays hundreds or
+        // thousands of rows further on, and nothing but repeated
+        // scroll-to-bottom gestures walks forward to it. Coming back after a
+        // long absence therefore landed 200 rows into the past — reliably,
+        // and a reload only replayed the same window.
+        //
+        // So ask how big the gap really is, and when it is more than one page
+        // stop pretending contiguity is achievable: anchor at the tail and
+        // surface the unread region as a jump affordance instead of as the
+        // default viewport. Below the threshold nothing changes — the
+        // anchored fetch is right there, and the divider is worth keeping.
+        //
+        // The probe is ONE extra small GET per cursor-present channel-open,
+        // behind the load-once gate, on a human click; the pane is empty here
+        // so `anchorAtTail` has nothing to discard.
+        const gap = await probeGap(t, slug, name, cursor);
+        if (gap !== null && isFarBehind(gap)) {
+          await anchorAtTail(t, slug, name, gap, cursor);
+        } else {
+          const [afterPage, beforePage] = await Promise.all([
+            listMessagesAfter(t, slug, name, cursor, PAGE_LIMIT),
+            listMessages(t, slug, name, cursor + 1),
+          ]);
+          mergeIntoScrollback(key, afterPage);
+          mergeIntoScrollback(key, beforePage);
+        }
       }
     } catch {
       // First-load failure leaves the empty seed in place; the pane
@@ -436,15 +578,6 @@ const exports = identityScopedStore((onIdentityChange) => {
     }
   };
 
-  // #161: forward-page size. The server caps at `@max_http_limit` (200);
-  // fetch the full page so a large unread gap ([cursor+200 .. tail] — the
-  // #156 regression) drains in as few round-trips as possible. Mirrors
-  // `REFRESH_LIMIT` (same server max, same "recover a bounded-but-large
-  // backlog" job). `loadMore` (older end) uses the server default (~50)
-  // because a human scrolling UP rarely needs 200 at once; the forward end
-  // is recovering unread that can run to the hundreds, so 200 is right.
-  const FORWARD_PAGE_LIMIT = 200;
-
   // #161: forward-paging verb — symmetric to `loadMore` but pages NEWER
   // rows on scroll-to-bottom. After #156's anchored fetch, a channel with
   // > 200 unread loads only the region [cursor .. cursor+200]; the rows
@@ -479,7 +612,7 @@ const exports = identityScopedStore((onIdentityChange) => {
     if (!newest) return;
     loadNewerInFlight.add(key);
     try {
-      const page = await listMessagesAfter(t, slug, name, newest.id, FORWARD_PAGE_LIMIT);
+      const page = await listMessagesAfter(t, slug, name, newest.id, PAGE_LIMIT);
       // Empty forward page = the local tail IS the live server tail. Latch
       // so subsequent scroll-to-bottom events (including the auto-follow
       // scroll that fires when a live row appends at the tail) are no-ops.
@@ -616,7 +749,6 @@ const exports = identityScopedStore((onIdentityChange) => {
   // original cursor — same property the pre-CP29-R5 reconnectBackfill
   // ran inside `runBackfill`, preserved here for the same reason.
   const refreshInFlight = new Set<ChannelKey>();
-  const REFRESH_LIMIT = 200;
 
   // #552 — pure test seam: stamp `__cic_scrollbackRefreshed` (a Set of the
   // module composite key) when a refreshScrollback COMPLETES for a key.
@@ -658,7 +790,7 @@ const exports = identityScopedStore((onIdentityChange) => {
       // limit kept explicit at the call site so a future tuning (e.g.
       // dynamic per-channel cap) doesn't have to thread through the
       // api.ts helper signature.
-      const page = await listMessagesAfter(t, slug, name, cursor, REFRESH_LIMIT);
+      const page = await listMessagesAfter(t, slug, name, cursor, PAGE_LIMIT);
       for (const msg of page) {
         appendToScrollback(key, msg);
         // Roll the high-water mark forward as we ingest so a second
@@ -674,8 +806,24 @@ const exports = identityScopedStore((onIdentityChange) => {
       // stays valid. This is the ONLY latch-invalidation site: ordinary
       // live `appendToScrollback` rows are contiguous with the tail and
       // must NOT thrash the latch (see `loadNewerExhausted`).
-      if (page.length === REFRESH_LIMIT) {
+      if (page.length === PAGE_LIMIT) {
         loadNewerExhausted.delete(key);
+        // #693 — a full page says "at least one more page", which is not a
+        // measurement. Ask for the real remainder, measured from what we just
+        // ingested (NOT from the read cursor: a busy window the operator
+        // never focused holds every one of its "unread" rows already, and
+        // deciding off the cursor there would throw away a perfectly good
+        // pane). More than a page still missing means scroll-to-bottom
+        // paging cannot realistically close it — land at the tail instead.
+        //
+        // Measured AFTER the fetch, so the probe costs nothing on the
+        // ordinary short-page reconnect, which is nearly all of them.
+        const last = page[page.length - 1];
+        const anchor = last ? last.id : cursor;
+        const gap = await probeGap(t, slug, name, anchor);
+        if (gap !== null && isFarBehind(gap)) {
+          await anchorAtTail(t, slug, name, gap, anchor);
+        }
       }
     } catch (err) {
       // Transient error — leave the cursor alone so the next reconnect
@@ -729,6 +877,9 @@ const exports = identityScopedStore((onIdentityChange) => {
     loadMoreInFlight.delete(key);
     loadNewerExhausted.delete(key);
     loadNewerInFlight.delete(key);
+    // #693 — the rows the far-behind record points back to were just deleted
+    // server-side; offering to jump into them would 404 the affordance.
+    clearFarBehind(key);
     if (hasSignal) {
       setScrollbackByChannel((prev) => {
         const { [key]: _drop, ...rest } = prev;
@@ -753,6 +904,8 @@ const exports = identityScopedStore((onIdentityChange) => {
   return {
     scrollbackByChannel,
     appendToScrollback,
+    farBehindByChannel,
+    jumpToUnread,
     loadInitialScrollback,
     loadMore,
     loadNewer,
@@ -768,6 +921,8 @@ const exports = identityScopedStore((onIdentityChange) => {
 
 export const scrollbackByChannel = exports.scrollbackByChannel;
 export const appendToScrollback = exports.appendToScrollback;
+export const farBehindByChannel = exports.farBehindByChannel;
+export const jumpToUnread = exports.jumpToUnread;
 export const loadInitialScrollback = exports.loadInitialScrollback;
 export const loadMore = exports.loadMore;
 export const loadNewer = exports.loadNewer;

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -165,13 +165,14 @@ const exports = identityScopedStore((onIdentityChange) => {
   // ordinary live appends are CONTIGUOUS — each appended row IS the
   // server's newest, so `after(max)` stays empty and this latch stays
   // CORRECT even as `max` advances (we're still at the live tail). The
-  // ONLY way a forward gap re-opens after latching is a `refreshScrollback`
-  // batch that hit its 200-row cap on a >200-message reconnect: it appended
-  // a full page but the tail may be further ahead. So the latch is
-  // invalidated THERE (see `refreshScrollback`) and NOWHERE else —
-  // invalidating on every append would re-fire an empty forward probe on
-  // every auto-follow scroll at a busy live tail (a fetch-per-message
-  // storm). Cleared on identity transition alongside `loadedChannels`.
+  // way a forward gap re-opens after latching is a `refreshScrollback` batch
+  // that hit its 200-row cap on a >200-message reconnect: it appended a full
+  // page but the tail may be further ahead. So the latch is invalidated
+  // THERE — and, since #693, in `jumpToUnread`, the one verb that walks the
+  // pane AWAY from the tail on purpose. Nowhere else: invalidating on every
+  // append would re-fire an empty forward probe on every auto-follow scroll
+  // at a busy live tail (a fetch-per-message storm). Cleared on identity
+  // transition alongside `loadedChannels`.
   const loadNewerExhausted = new Set<ChannelKey>();
   const [scrollbackByChannel, setScrollbackByChannel] = createSignal<
     Record<ChannelKey, ScrollbackMessage[]>
@@ -323,6 +324,17 @@ const exports = identityScopedStore((onIdentityChange) => {
   // holds nothing (a member rename with no query window costs one lookup).
   const renameScrollbackKey = (oldKey: ChannelKey, newKey: ChannelKey): void => {
     if (oldKey === newKey) return;
+    // #693 — the far-behind record is nick-keyed for a DM, so it belongs to
+    // the #373 migration set (CLAUDE.md: a new nick-keyed store that skips it
+    // strands its old-nick rows). Stranded, the renamed pane loses its jump
+    // affordance AND its divider suppression — the marker comes back labelled
+    // with the loaded rows while thousands are missing, which is the wrong
+    // number the suppression exists to prevent.
+    setFarBehindByChannel((prev) => {
+      if (!(oldKey in prev)) return prev;
+      const { [oldKey]: moved, ...rest } = prev;
+      return moved === undefined ? rest : { ...rest, [newKey]: moved };
+    });
     setScrollbackByChannel((prev) => {
       if (!(oldKey in prev)) return prev;
       const oldRows = prev[oldKey] ?? [];
@@ -351,7 +363,7 @@ const exports = identityScopedStore((onIdentityChange) => {
     try {
       return await countMessagesAfter(t, slug, name, anchor);
     } catch (err) {
-      console.warn("[scrollback] gap probe failed — resuming from the cursor", slug, name, err);
+      console.warn("[scrollback] gap probe failed — keeping the anchored resume", slug, name, err);
       return null;
     }
   };
@@ -369,6 +381,14 @@ const exports = identityScopedStore((onIdentityChange) => {
   // The high-water mark rolls to the tail (`recordSeen`) so the NEXT
   // `refreshScrollback` resumes from the present instead of re-fetching the
   // abandoned region and re-deciding it is far behind, forever.
+  //
+  // The replace KEEPS any row newer than the page it just fetched. A live WS
+  // row can land during the await, and `appendToScrollback` has already rolled
+  // the high-water mark past it — a blind overwrite would drop it from the
+  // pane while making it unfetchable by the very path meant to recover it
+  // (the next `?after=` starts above it). Those rows sit at/after the tail, so
+  // keeping them opens no hole; everything OLDER than the page is the
+  // abandoned region and must go.
   const anchorAtTail = async (
     t: string,
     slug: string,
@@ -379,10 +399,45 @@ const exports = identityScopedStore((onIdentityChange) => {
     const key = channelKey(slug, name);
     const page = await listMessages(t, slug, name);
     const rows = [...page].sort(byServerTimeThenId);
-    setScrollbackByChannel((prev) => ({ ...prev, [key]: rows }));
+    const newest = rows[rows.length - 1]?.id ?? 0;
+    setScrollbackByChannel((prev) => {
+      const live = (prev[key] ?? []).filter((m) => m.id > newest);
+      return { ...prev, [key]: [...rows, ...live].sort(byServerTimeThenId) };
+    });
     for (const msg of rows) recordSeen(key, msg);
     loadMoreExhausted.delete(key);
     setFarBehindByChannel((prev) => ({ ...prev, [key]: { missed, resumeFrom } }));
+  };
+
+  // #693 — the DECISION is measured at the anchor the resume was about to use
+  // (never at the read cursor: see `refreshScrollback`). The LABEL and the
+  // jump target belong to the operator's READ POSITION, which on the reconnect
+  // path sits further back — the anchor there is the high-water mark, one
+  // ingested page ahead of it.
+  //
+  // Conflating the two costs both honesty and the divider: the row would
+  // undercount by up to a page, and jumping to the high-water mark lands a
+  // window whose every row is already past the cursor, so the marker injects
+  // at index 0 labelled with the loaded count — the exact failure the
+  // suppression exists to prevent, relocated. So re-probe at the cursor when
+  // it differs. One extra small GET, only on the reconnect path, only when
+  // already far behind. A failed re-probe keeps the anchor: a slightly
+  // conservative jump target beats no affordance at all.
+  const resolveJumpTarget = async (
+    t: string,
+    slug: string,
+    name: string,
+    anchor: number,
+    missedAtAnchor: number,
+  ): Promise<{ missed: number; resumeFrom: number }> => {
+    const cursor = getReadCursor(slug, name);
+    if (cursor === null || cursor >= anchor) {
+      return { missed: missedAtAnchor, resumeFrom: anchor };
+    }
+    const missed = await probeGap(t, slug, name, cursor);
+    return missed === null
+      ? { missed: missedAtAnchor, resumeFrom: anchor }
+      : { missed, resumeFrom: cursor };
   };
 
   const clearFarBehind = (key: ChannelKey): void => {
@@ -394,34 +449,80 @@ const exports = identityScopedStore((onIdentityChange) => {
   };
 
   // #693 — the operator took the "N unread — jump back" affordance. Swap the
-  // tail window for the cursor-anchored one: exactly the fetch shape #156
-  // does on a small gap, so the in-pane divider lands between read context
-  // and the first unread row.
+  // tail window for the one anchored at their read position: exactly the fetch
+  // shape #156 does on a small gap, so the in-pane divider lands between read
+  // context and the first unread row.
   //
   // Replace rather than merge, for the same reason `anchorAtTail` does — the
-  // two windows are not contiguous. Leaving the tail is the point of the
-  // gesture; getting back to it is `loadNewer` (scroll to the bottom) or a
-  // fresh open, the same as any other window sitting on old history.
-  const jumpToUnread = async (slug: string, name: string): Promise<void> => {
+  // two windows are not contiguous. Unlike `anchorAtTail` this DROPS rows
+  // newer than the fetched region instead of keeping them: there they abutted
+  // the tail, here they would sit thousands of rows above it. Leaving the tail
+  // is the point of the gesture; getting back is `loadNewer` (scroll to the
+  // bottom), the same as any other window sitting on old history.
+  //
+  // Returns whether the swap happened, so the caller can stand down whatever
+  // it armed for the arriving rows. A failed fetch leaves the pane untouched.
+  const jumpInFlight = new Set<ChannelKey>();
+  const jumpToUnread = async (slug: string, name: string): Promise<boolean> => {
     const t = token();
-    if (!t) return;
+    if (!t) return false;
     const key = channelKey(slug, name);
     const far = farBehindByChannel()[key];
-    if (!far) return;
-    const [afterPage, beforePage] = await Promise.all([
-      listMessagesAfter(t, slug, name, far.resumeFrom, PAGE_LIMIT),
-      listMessages(t, slug, name, far.resumeFrom + 1),
-    ]);
-    // Disjoint by construction — `after(cursor)` is `id > cursor`,
-    // `before(cursor + 1)` is `id <= cursor` — so concat + sort needs no
-    // dedupe pass.
-    const rows = [...afterPage, ...beforePage].sort(byServerTimeThenId);
-    setScrollbackByChannel((prev) => ({ ...prev, [key]: rows }));
-    // The pane no longer holds the tail, and there IS older history below the
-    // new oldest row — both latches are stale.
-    loadNewerExhausted.delete(key);
-    loadMoreExhausted.delete(key);
+    if (!far) return false;
+    if (jumpInFlight.has(key)) return false;
+    jumpInFlight.add(key);
+    try {
+      const [afterPage, beforePage] = await Promise.all([
+        listMessagesAfter(t, slug, name, far.resumeFrom, PAGE_LIMIT),
+        listMessages(t, slug, name, far.resumeFrom + 1),
+      ]);
+      // Disjoint by construction — `after(cursor)` is `id > cursor`,
+      // `before(cursor + 1)` is `id <= cursor` — so concat + sort needs no
+      // dedupe pass.
+      const rows = [...afterPage, ...beforePage].sort(byServerTimeThenId);
+      setScrollbackByChannel((prev) => ({ ...prev, [key]: rows }));
+      // The pane no longer holds the tail, and there IS older history below
+      // the new oldest row — both latches are stale.
+      loadNewerExhausted.delete(key);
+      loadMoreExhausted.delete(key);
+      clearFarBehind(key);
+      return true;
+    } catch (err) {
+      console.error("[scrollback] jumpToUnread failed", slug, name, err);
+      return false;
+    } finally {
+      jumpInFlight.delete(key);
+    }
+  };
+
+  // #693 — the other exit: "I don't care about those, I'm caught up now."
+  //
+  // Needed because the far-behind state FREEZES the read cursor (see
+  // `setCursorIfAdvances`): reading at the tail must not silently mark the
+  // abandoned region read, so without a deliberate exit the operator would
+  // chat at the tail under a permanent "3000 unread". This is that exit, and
+  // it is the ONE place the cursor jumps a region the operator never read —
+  // by their own explicit gesture, which is the only thing that makes it
+  // honest. Advancing to the newest LOADED row (not to `missed`) keeps the
+  // existing forward-only cursor contract intact.
+  //
+  // Returns the id it marked read (null if it did nothing), so the caller can
+  // re-latch its frozen divider to the same position. Without that the pane
+  // would un-suppress the marker against a cursor snapshot taken thousands of
+  // rows ago and draw "50 unread" across the top of the buffer — the wrong
+  // number the suppression existed to prevent, arriving the moment the
+  // operator dismisses it.
+  const dismissFarBehind = (slug: string, name: string): number | null => {
+    const t = token();
+    if (!t) return null;
+    const key = channelKey(slug, name);
+    if (!farBehindByChannel()[key]) return null;
+    const rows = scrollbackByChannel()[key] ?? [];
+    const newest = rows[rows.length - 1];
     clearFarBehind(key);
+    if (!newest) return null;
+    void setReadCursor(t, slug, name, newest.id);
+    return newest.id;
   };
 
   const loadInitialScrollback = async (slug: string, name: string): Promise<void> => {
@@ -526,8 +627,16 @@ const exports = identityScopedStore((onIdentityChange) => {
             listMessagesAfter(t, slug, name, cursor, PAGE_LIMIT),
             listMessages(t, slug, name, cursor + 1),
           ]);
-          mergeIntoScrollback(key, afterPage);
-          mergeIntoScrollback(key, beforePage);
+          // A rejoin's `refreshScrollback` can have re-anchored this key at
+          // the tail while these two pages were in flight (nothing serialises
+          // the cold-load and the reconnect path for one key). Splicing the
+          // anchored region into a tail-anchored pane is exactly the silent
+          // hole `anchorAtTail` refuses to create, so the loser drops its
+          // pages — they describe a window the pane has deliberately left.
+          if (farBehindByChannel()[key] === undefined) {
+            mergeIntoScrollback(key, afterPage);
+            mergeIntoScrollback(key, beforePage);
+          }
         }
       }
     } catch {
@@ -580,11 +689,14 @@ const exports = identityScopedStore((onIdentityChange) => {
 
   // #161: forward-paging verb — symmetric to `loadMore` but pages NEWER
   // rows on scroll-to-bottom. After #156's anchored fetch, a channel with
-  // > 200 unread loads only the region [cursor .. cursor+200]; the rows
-  // past that (up to the true server tail) were UNREACHABLE — `loadMore`
-  // pages older on scroll-to-top and nothing paged newer, and the WS
-  // join-ok `refreshScrollback` hits the SAME 200 cap from the same resume
-  // cursor. This verb pulls `listMessagesAfter(highestLoadedId, 200)` and
+  // more unread than one page loaded only the region [cursor .. cursor+200];
+  // the rows past that (up to the true server tail) were UNREACHABLE —
+  // `loadMore` pages older on scroll-to-top and nothing paged newer, and the
+  // WS join-ok `refreshScrollback` hit the SAME cap from the same resume
+  // cursor. #693 removed the need to WALK that gap (a resume that cannot
+  // drain it now anchors at the tail outright), but this verb still owns the
+  // ordinary forward end: a jumped-back pane, and any gap under the
+  // threshold. It pulls `listMessagesAfter(highestLoadedId, 200)` and
   // merges via `mergeIntoScrollback` (id-dedupe + ASC — the SAME merge as
   // loadMore/refresh), so the loaded set stays contiguous and grows toward
   // the tail one page per scroll-to-bottom.
@@ -803,9 +915,10 @@ const exports = identityScopedStore((onIdentityChange) => {
       // the forward gap). Invalidate the forward-tail latch so the next
       // scroll-to-bottom pages forward again. A short page drained
       // everything after the resume cursor → no gap → the latch (if set)
-      // stays valid. This is the ONLY latch-invalidation site: ordinary
-      // live `appendToScrollback` rows are contiguous with the tail and
-      // must NOT thrash the latch (see `loadNewerExhausted`).
+      // stays valid. Ordinary live `appendToScrollback` rows are contiguous
+      // with the tail and must NOT thrash the latch (see
+      // `loadNewerExhausted`); the only other site that may clear it is
+      // `jumpToUnread` (#693), which deliberately leaves the tail.
       if (page.length === PAGE_LIMIT) {
         loadNewerExhausted.delete(key);
         // #693 — a full page says "at least one more page", which is not a
@@ -822,7 +935,8 @@ const exports = identityScopedStore((onIdentityChange) => {
         const anchor = last ? last.id : cursor;
         const gap = await probeGap(t, slug, name, anchor);
         if (gap !== null && isFarBehind(gap)) {
-          await anchorAtTail(t, slug, name, gap, anchor);
+          const target = await resolveJumpTarget(t, slug, name, anchor, gap);
+          await anchorAtTail(t, slug, name, target.missed, target.resumeFrom);
         }
       }
     } catch (err) {
@@ -904,6 +1018,7 @@ const exports = identityScopedStore((onIdentityChange) => {
   return {
     scrollbackByChannel,
     appendToScrollback,
+    dismissFarBehind,
     farBehindByChannel,
     jumpToUnread,
     loadInitialScrollback,
@@ -921,6 +1036,7 @@ const exports = identityScopedStore((onIdentityChange) => {
 
 export const scrollbackByChannel = exports.scrollbackByChannel;
 export const appendToScrollback = exports.appendToScrollback;
+export const dismissFarBehind = exports.dismissFarBehind;
 export const farBehindByChannel = exports.farBehindByChannel;
 export const jumpToUnread = exports.jumpToUnread;
 export const loadInitialScrollback = exports.loadInitialScrollback;

--- a/cicchetto/src/lib/selection.ts
+++ b/cicchetto/src/lib/selection.ts
@@ -13,6 +13,7 @@ import { presenceRowVisible } from "./presenceFilter";
 import { queryWindowsByNetwork } from "./queryWindows";
 import { getReadCursor, readCursors, setReadCursor } from "./readCursor";
 import {
+  farBehindByChannel,
   loadInitialScrollback,
   refreshScrollback,
   scrollbackByChannel,
@@ -401,10 +402,19 @@ const exports = identityScopedStore((onIdentityChange) => {
     // Locally-hydrated channels — count rows past the cursor by kind.
     // Override any seed entry: local truth wins because the seed is
     // a sync-time snapshot that may be stale by the time we render.
+    const farBehind = farBehindByChannel();
     for (const [rawKey, rows] of Object.entries(sb)) {
       const key = rawKey as ChannelKey;
       const decoded = decodeChannelKey(key);
       if (decoded === null) continue;
+      // #693 — a far-behind window is the one case where local truth is the
+      // WORSE truth. Its rows are the tail, deliberately disjoint from the
+      // unread region, so counting them reports ~50 for a window that is
+      // thousands behind — and the operator would see a small, ignorable
+      // badge for the very state the change exists to surface. The seed
+      // (server-side, cursor-anchored, and the cursor is frozen while far
+      // behind) is the honest number here, so leave it standing.
+      if (farBehind[key]) continue;
       const cursorMapKey = `${decoded.slug} ${decoded.name}`;
       const cursor = cursors[cursorMapKey] ?? 0;
       const memberCount = (members[key] ?? []).length;
@@ -507,11 +517,24 @@ const exports = identityScopedStore((onIdentityChange) => {
   // them — kept as a single-source guard at the client boundary.
   //
   // Token guard: identity-rotation can null the bearer mid-effect.
+  // #693 — the far-behind freeze. A pane that anchored at the tail renders
+  // rows thousands of ids above the operator's real read position, and every
+  // writer that funnels through here (scroll-settle, focus-leave, the
+  // visibility-hide arm, the scroll-to-bottom gesture) offers the newest
+  // RENDERED id. Forward-only would happily take it and mark the entire
+  // abandoned region read — server-side, fanned to every other device,
+  // destroying the position the jump affordance exists to return to. Freeze
+  // the cursor for as long as the window is far behind; `dismissFarBehind`
+  // (scrollback.ts) is the one deliberate way past it.
+  //
+  // This is the single door for cursor advancement, so the guard belongs
+  // here, not in each of the four callers.
   const setCursorIfAdvances = (
     networkSlug: string,
     channelName: string,
     candidateId: number,
   ): void => {
+    if (farBehindByChannel()[channelKey(networkSlug, channelName)]) return;
     const current = getReadCursor(networkSlug, channelName);
     if (current !== null && candidateId <= current) return;
     const bearer = untrack(token);

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -1380,6 +1380,7 @@ export const ERROR_TOKENS_REST_ERROR_TOKEN = [
   "malformed_nick",
   "malformed_ident",
   "password_required",
+  "passkey_required",
   "password_mismatch",
   "network_not_visitor_enabled",
   "network_ambiguous",

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2720,6 +2720,44 @@ html.resize-dragging * {
   user-select: none;
 }
 
+/* #693 — far-behind boundary row. Same horizontal-rule-with-label form as
+   the unread marker above, because it marks the same kind of thing: a
+   position in the history. It differs in being TAPPABLE (it loads the region
+   above it) and in sitting at the very top of the buffer, so it gets a
+   button reset, a pointer cursor, and a 44px minimum height — the tap target
+   floor in absolute px, since the root font-size is 14px and a rem-based
+   target would come out short on mobile. */
+
+.scrollback-far-behind {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  min-height: 44px;
+  padding: 0.25rem 0;
+  border: none;
+  background: none;
+  color: var(--accent);
+  font: inherit;
+  font-size: 0.8em;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.scrollback-far-behind-line {
+  flex: 1;
+  height: 1px;
+  background: var(--accent);
+  opacity: 0.4;
+}
+
+.scrollback-far-behind-label {
+  white-space: nowrap;
+  text-decoration: underline;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
 /* #280 — floating action stack at the lower-right of `.scrollback-pane`.
    The scroll-to-bottom button (C7.4) and, on mobile, the "jump to next
    active window" affordance (#235) render into ONE container-anchored,

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2720,42 +2720,61 @@ html.resize-dragging * {
   user-select: none;
 }
 
-/* #693 — far-behind boundary row. Same horizontal-rule-with-label form as
-   the unread marker above, because it marks the same kind of thing: a
-   position in the history. It differs in being TAPPABLE (it loads the region
-   above it) and in sitting at the very top of the buffer, so it gets a
-   button reset, a pointer cursor, and a 44px minimum height — the tap target
-   floor in absolute px, since the root font-size is 14px and a rem-based
-   target would come out short on mobile. */
+/* #693 — far-behind bar. PINNED to the top of `.scrollback-pane`, not in the
+   scroll flow: a tail-anchored pane opens at the BOTTOM (there is no divider
+   to scroll to), so an in-flow row at the boundary it describes would sit
+   viewports above the fold and never be seen. Container-anchored like the
+   #133 overlay and the #280 float stack, at z-index 4 — one below the
+   overlay, whose cards are ephemeral and deliberately opened.
+
+   Opaque background: it paints OVER the first rows of the buffer, so it
+   cannot be translucent without both layers becoming unreadable. Both
+   buttons carry the 44px tap-target floor in absolute px — the root
+   font-size is 14px, so a rem-based target comes out short on mobile. */
 
 .scrollback-far-behind {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 4;
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  width: 100%;
-  min-height: 44px;
-  padding: 0.25rem 0;
-  border: none;
-  background: none;
+  padding: 0 0.5rem;
+  background: var(--bg);
+  border-bottom: 1px solid var(--accent);
   color: var(--accent);
-  font: inherit;
   font-size: 0.8em;
   font-weight: bold;
-  cursor: pointer;
 }
 
-.scrollback-far-behind-line {
+.scrollback-far-behind-jump {
   flex: 1;
-  height: 1px;
-  background: var(--accent);
-  opacity: 0.4;
-}
-
-.scrollback-far-behind-label {
-  white-space: nowrap;
+  min-height: 44px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
   text-decoration: underline;
+  cursor: pointer;
   -webkit-user-select: none;
   user-select: none;
+}
+
+.scrollback-far-behind-dismiss {
+  flex: none;
+  min-width: 44px;
+  min-height: 44px;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  font-size: 1.2em;
+  line-height: 1;
+  cursor: pointer;
 }
 
 /* #280 — floating action stack at the lower-right of `.scrollback-pane`.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -27192,12 +27192,46 @@ resume. Degrading to wrong-but-familiar beats a destructive guess.
 **The divider stands down while far behind.** The cursor is below every loaded
 row, so the in-pane marker would slam to the top of the buffer labelled with the
 count of the ~50 rows that happen to be loaded — a confident wrong number in the
-one place the operator reads to find where they left off. The boundary row
-carries the true count instead, in-flow at the top of the buffer (the #270
-PeerAwayBanner precedent): it marks a position in the history, exactly like the
-divider it replaces.
+one place the operator reads to find where they left off. A pinned bar carries
+the true count instead. It is NOT in-flow at the boundary it describes (the
+#270 PeerAwayBanner shape, which is where it semantically belongs): with no
+divider to scroll to, the activation routine parks the pane at the BOTTOM, so
+an in-flow row would sit viewports above the fold — the one signal that a
+region was abandoned, exactly where nobody looks.
+
+**Review found the change quietly destroying the thing it protects.** Every
+cursor writer — scroll-settle, focus-leave, the visibility-hide arm, the
+scroll-to-bottom gesture — funnels through `setCursorIfAdvances` and offers the
+newest RENDERED id. In a tail-anchored pane that is the tail, forward-only takes
+it, and one channel switch marks the whole abandoned region read, server-side
+and on every device. Three consequences follow, and all three are fixed here:
+
+* **The cursor freezes while far behind**, at that single door. Reading at the
+  tail cannot mark unread what was never shown.
+* **A frozen cursor needs a deliberate exit**, or the operator chats at the tail
+  under a permanent "3000 unread" that no amount of reading clears. Hence the
+  bar's second button: dismiss advances the cursor to the newest LOADED row and
+  drops the flag. It is the one place the cursor crosses a region the operator
+  never read — by their own gesture, which is what makes it honest.
+* **The badge has to stop deriving from the pane.** `unreadCounts` overrides the
+  server seed with a local count of rows past the cursor, which for a
+  tail-anchored pane is ~50 — a small ignorable number for the very state this
+  change exists to surface. Far-behind windows keep the seed.
+
+**Other review catches worth recording.** `anchorAtTail` keeps rows NEWER than
+the page it fetched: a live WS row landing during the await has already rolled
+the high-water mark past itself, so a blind overwrite would drop it from the
+pane AND make it unfetchable. The far-behind record joins the #373 rename
+migration set (it is nick-keyed for a DM). And the jump TARGET is the read
+cursor, not the anchor the decision was measured at — on the reconnect path the
+anchor is the high-water mark, one page ahead, and jumping there would land a
+window whose every row is past the cursor, re-creating the top-slammed divider
+one pane over.
 
 **Apply:** when a client decides between two recoveries, make it measure, not
 infer from a saturated page. And when the honest recovery is discontiguous with
 what is already loaded, drop the stale region — a store whose order IS its
-display cannot hold two regions without lying about the space between them.
+display cannot hold two regions without lying about the space between them. Then
+check what else reads the state you just changed the meaning of: here a pane
+that renders rows it has NOT read broke the assumption every cursor writer and
+the unread badge were built on.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -27134,3 +27134,70 @@ and pick its scope to match the thing you are measuring, because a
 device-shared key is not a document lifetime. Let the test suite refuse to
 advance a clock: if a timer can make the test pass, the production code is
 measuring something the real failure mode never gives it.
+## 2026-08-03 — #693: a resume that cannot be drained in one page anchors at the TAIL, not at the cursor
+
+**Field report.** After a day or more away, reopening the client did not show
+the recent scrollback: the pane sat on old rows, and scrolling to the bottom
+parked you at a stale position instead of the live tail.
+
+**The trigger is the GAP SIZE, not the absence.** Both recovery paths anchored
+at the read cursor and capped at 200 rows, so the client loaded
+`[cursor .. cursor+200]` — the OLDEST end of the gap — and never the tail. Cold
+load took `loadInitialScrollback`'s #156 anchored branch; a reconnect took
+`refreshScrollback` from `getResumeCursor`. The only thing that paged toward the
+present was `loadNewer`, at 200 rows per scroll-to-bottom gesture, so a busy
+channel took tens of gestures to reach now. A full page reload changed nothing:
+the read cursor is still there, so the reload re-entered the same branch (which
+is why #695 was filed WITH this and not before it).
+
+**A full page is not a measurement.** `page.length === limit` says "at least
+200 more" — the same answer for a 201-row gap (one more fetch drains it, keep
+the divider) and a 3000-row one (abandon the anchor, the operator wants the
+present). `Scrollback.count_after/6` already refuses the `@max_limit` cap for
+exactly this reason, but it had **no production caller** (its doc still claimed
+the join reply used it; that moved to `count_after_split/5` via `WindowCounts`
+long ago) and no door onto the wire. It gets one: `GET
+…/messages/count?after=<id>` → `{"count": N}`, additive, snake_case,
+`after` required and non-negative.
+
+**The count had to grow a `hide_presence` positional** to be the honest twin of
+`fetch_after/7`. The question is "how many rows would a fetch hand me", and a
+channel with 500 hidden JOINs and 5 messages is a 5-row gap for a client that
+renders neither. Required, not defaulted — the same rule `own_nick` follows.
+The badge path passes `false` explicitly: it counts events too.
+
+**Anchoring at the tail REPLACES the window, it does not extend it.** Store
+order IS display order in `ScrollbackPane` and there is no gap-marker row, so
+merging a tail page next to rows from thousands of messages ago would render a
+silent hole — two regions abutting as if consecutive. `anchorAtTail` therefore
+swaps the key's rows for the newest page, rolls the high-water mark to the tail
+(else the next refresh re-fetches the abandoned region and re-decides
+"far behind", forever), and clears the loadMore latch so scroll-up re-pages what
+was dropped. `jumpToUnread` is the same swap mirrored, back to the anchor.
+
+**Measured from the ANCHOR, never from the read cursor.** The cold-load anchor
+IS the cursor, so there the existing unread seed would have been exact — but the
+reconnect anchor is the high-water mark, and a busy window the operator never
+focused already holds every one of its "unread" rows. Deciding off the cursor
+there would throw away a perfectly good pane on a false premise. One probe, at
+whatever anchor the caller is about to use, is also one code path instead of two.
+
+**The probe's cost is gated, and its failure is not fatal.** Cold load pays one
+small GET per cursor-present open, behind the load-once gate, on a human click;
+the reconnect path pays only after a FULL page, which is the rare case. A throw
+(an older server with no such route, a transient error) returns `null` — not
+zero, not "far behind" — and the caller keeps the pre-#693 cursor-anchored
+resume. Degrading to wrong-but-familiar beats a destructive guess.
+
+**The divider stands down while far behind.** The cursor is below every loaded
+row, so the in-pane marker would slam to the top of the buffer labelled with the
+count of the ~50 rows that happen to be loaded — a confident wrong number in the
+one place the operator reads to find where they left off. The boundary row
+carries the true count instead, in-flow at the top of the buffer (the #270
+PeerAwayBanner precedent): it marks a position in the history, exactly like the
+divider it replaces.
+
+**Apply:** when a client decides between two recoveries, make it measure, not
+infer from a saturated page. And when the honest recovery is discontiguous with
+what is already loaded, drop the stale region — a store whose order IS its
+display cannot hold two regions without lying about the space between them.

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -514,63 +514,73 @@ defmodule Grappa.Scrollback do
   Counts rows for `(subject, network_id, channel)` whose `id` is
   strictly greater than `after_id`. Returns an integer.
 
-  Sole consumer: the unread-badges-from-cursor refactor (2026-06-01).
-  Phoenix Channel `join_reply/1` calls `count_after(subject,
-  network.id, channel, cursor || 0, own_nick)` to seed cic's per-channel
-  unread badge with the server-authoritative count at sync time; cic then
-  derives the live count by counting local scrollback rows with `id >
-  cursor` and falls back to this seed when scrollback hasn't been
-  hydrated yet (or for channels the user has never opened in this
-  session).
+  Sole consumer: the #693 gap probe
+  (`GrappaWeb.MessagesController.count/2`). cic asks "how many rows are
+  there after the newest row I hold?" to decide whether the region it is
+  about to resume into can be drained in one page, or whether it is so far
+  behind that the honest thing is to anchor at the tail instead. The
+  decision needs the TRUE size: a full page proves only "≥ limit", which
+  cannot tell a 201-row gap from a 3000-row one.
 
-  Same predicates as `fetch_after/6` so the count exactly matches what
-  a `fetch_after(..., :infinity)` would return — modulo the
-  `@max_limit` cap, which `count_after/5` deliberately does not apply.
-  Counts unbounded by definition: a channel with 10k unread rows
-  must surface as `10000`, not `@max_limit`.
+  (The unread badge does NOT come through here — the join reply +
+  `/me` cold-load seed it from `count_after_split/5` via
+  `Grappa.WindowCounts`, which splits content from presence.)
+
+  Same predicates as `fetch_after/7` so the count exactly matches what a
+  `fetch_after(..., :infinity)` would return — modulo the `@max_limit`
+  cap, which this function deliberately does not apply. Counts unbounded
+  by definition: a channel with 10k rows after the anchor must surface as
+  `10000`, not `@max_limit`.
 
   ## `own_nick`
 
-  Mirrors the `fetch_after/6` contract (CP14 B3 narrowing rule). When
+  Mirrors the `fetch_after/7` contract (CP14 B3 narrowing rule). When
   `own_nick` equals `channel` (case-insensitive), the count restricts
   to self-msgs so every inbound DM doesn't inflate the own-nick
-  window's unread count. `own_nick` is a REQUIRED positional (no
+  window's count. `own_nick` is a REQUIRED positional (no
   defaulting wrapper — same rule as `fetch/6`, REV-J M12: a default
   silently re-opens the CP14-B3 leak for a caller that forgets to
   thread it — S2, 2026-07-08 review). Pass `nil` explicitly when the
   caller doesn't have a session; the channel-shape narrowing then
-  applies. The Phoenix Channel `join_reply` path threads the live
-  session nick when it can resolve one, `nil` otherwise; the `/me`
-  cold-load threads the LIVE nick (via `Push.BadgeCount.live_nick_windows/1`,
-  a cheap `Registry` lookup — #498).
+  applies.
+
+  ## `hide_presence`
+
+  Also a REQUIRED positional, for the same reason and with the same
+  meaning as in `fetch_after/7`: the count answers "how many rows would
+  a fetch hand me", so it must apply the caller's presence filter (#458).
+  A channel with 500 hidden JOINs and 5 messages is a 5-row gap, not a
+  505-row one, for a client that renders neither.
 
   Returns `0` for the past-tail case (`after_id >= max(id)`), `0` for
   the impossible-subject case (no rows match the subject + network),
   and the total count for `after_id = 0` (the initial-cursor case
   before the user has ever clicked).
   """
-  @spec count_after(subject(), integer(), String.t(), integer(), String.t() | nil) ::
+  @spec count_after(subject(), integer(), String.t(), integer(), String.t() | nil, boolean()) ::
           non_neg_integer()
-  def count_after(subject, network_id, channel, after_id, own_nick)
+  def count_after(subject, network_id, channel, after_id, own_nick, hide_presence)
       when is_integer(network_id) and is_integer(after_id) and
-             (is_binary(own_nick) or is_nil(own_nick)) do
+             (is_binary(own_nick) or is_nil(own_nick)) and is_boolean(hide_presence) do
     Message
     |> subject_where(subject)
     |> where([m], m.network_id == ^network_id)
     |> channel_or_dm_where(channel, own_nick)
+    |> maybe_exclude_presence(hide_presence)
     |> where([m], m.id > ^after_id)
     |> select([m], count(m.id))
     |> Repo.one()
   end
 
   @doc """
-  Same predicate as `count_after/5` but returns the count split into a
+  Same predicate as `count_after/6` — minus its `hide_presence` filter,
+  which would be self-defeating here — but returns the count split into a
   `{content, presence}` pair as `%{messages: integer, events: integer}`.
 
   Sole consumer: the `/me` `unread_counts` envelope (bucket C, 2026-06-01)
   — cic's per-channel sidebar badge renders messages (bold) and events
   (faint) separately, so the cold-load seed needs the split too. A
-  single query with a CASE-WHEN GROUP BY beats two `count_after/5`
+  single query with a CASE-WHEN GROUP BY beats two `count_after/6`
   round-trips per (slug, channel) cursor at login time.
 
   Content kinds (`:privmsg | :notice | :action`) match the cic
@@ -585,7 +595,7 @@ defmodule Grappa.Scrollback do
   subject / empty partition — never a missing key, so callers can
   pattern-match without a default.
 
-  `own_nick` is a REQUIRED positional (same rule as `count_after/5` /
+  `own_nick` is a REQUIRED positional (same rule as `count_after/6` /
   `fetch/6`): a defaulting wrapper silently re-opens the CP14-B3
   own-nick DM over-count for any caller that forgets to thread it
   (S2, 2026-07-08 review — the `/me` cold-load did exactly that).
@@ -1081,7 +1091,7 @@ defmodule Grappa.Scrollback do
   # `list_archive/3`'s GROUP BY already uses (in-house precedent). Because
   # the match lives ONLY here, every consumer of the shared predicate
   # (`fetch/6`, `fetch_after/6`, `fetch_around/6`, `unread_content_tail/6`,
-  # `count_after/5`, `count_after_split/5` via `channel_or_dm_where/3`, and
+  # `count_after/6`, `count_after_split/5` via `channel_or_dm_where/3`, and
   # `delete_for_dm/3` directly) becomes sargable in one shot.
   @spec where_dm_peer(Ecto.Query.t(), String.t()) :: Ecto.Query.t()
   defp where_dm_peer(query, folded_peer) when is_binary(folded_peer) do

--- a/lib/grappa/window_counts.ex
+++ b/lib/grappa/window_counts.ex
@@ -18,7 +18,7 @@ defmodule Grappa.WindowCounts do
     * `messages` — unread CONTENT rows (`:privmsg | :notice | :action`),
       the same set `Scrollback.count_after_split/5` buckets as
       `:messages`. Unbounded (exact) — a channel with 10k unread must
-      surface 10k, matching `count_after/5`.
+      surface 10k, matching `count_after/6`.
     * `events` — unread PRESENCE/CONTROL rows (`:join | :part | :quit |
       :nick_change | :mode | :topic | :kick | :server_event`). #265: this
       is a SEPARATE low tier — presence churn never inflates the message
@@ -104,7 +104,7 @@ defmodule Grappa.WindowCounts do
   (`last_read_message_id`; `nil` counts from the beginning).
 
   `own_nick` and `patterns` are REQUIRED positionals — no defaulting
-  wrapper (same rule as `Scrollback.count_after/5`): a default silently
+  wrapper (same rule as `Scrollback.count_after/6`): a default silently
   re-opens the CP14-B3 own-nick DM over-count and the mention-fold
   hazard. `own_nick` MAY be `nil` for the unbound-but-retained network
   case (`/me` seed for a network the subject holds no credential on) —

--- a/lib/grappa_web/controllers/messages_controller.ex
+++ b/lib/grappa_web/controllers/messages_controller.ex
@@ -161,6 +161,58 @@ defmodule GrappaWeb.MessagesController do
   end
 
   @doc """
+  `GET /networks/:network_id/channels/:channel_id/messages/count?after=<id>`
+  — the #693 gap probe. Returns `{"count": N}`: how many rows this subject
+  would be handed by `index/2`'s `?after=<id>` page if that page had no
+  ceiling.
+
+  Exists because a full page is not a measurement. cic's resume paths
+  fetch `?after=<anchor>&limit=#{@max_http_limit}`; a full page proves
+  only "at least #{@max_http_limit} more", which cannot distinguish a gap
+  that one more fetch drains from one running to thousands of rows — and
+  the two want opposite recoveries (drain forward vs abandon the anchor
+  and land at the tail). `Grappa.Scrollback.count_after/6` is deliberately
+  uncapped, and applies the same subject / channel-or-DM / presence
+  predicates `index/2` applies, so the number describes the rows cic would
+  actually render.
+
+  `after` is REQUIRED and must be a non-negative integer — 400 otherwise.
+  There is no "count everything" default: every caller is asking about a
+  specific anchor it holds, and a silent `after=0` would answer a
+  question nobody asked.
+  """
+  @spec count(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:error, :bad_request}
+  def count(conn, %{"channel_id" => channel} = params) do
+    subject = Subject.to_session(conn.assigns.current_subject)
+    network = conn.assigns.network
+
+    with :ok <- validate_target_name(channel),
+         {:ok, after_id} <- parse_after(params["after"]) do
+      # Same ingress fold as `index/2` (#537): the caller's spelling resolves
+      # to the one window the Server keyed folded.
+      channel = Identifier.canonical_target(channel, Session.casemapping(subject, network.id))
+
+      own_nick =
+        case Session.current_nick(subject, network.id) do
+          {:ok, nick} -> nick
+          {:error, :no_session} -> nil
+        end
+
+      count =
+        Scrollback.count_after(
+          subject,
+          network.id,
+          channel,
+          after_id,
+          own_nick,
+          resolve_hide_presence(subject, network, channel)
+        )
+
+      render(conn, :count, count: count)
+    end
+  end
+
+  @doc """
   `POST /networks/:network_id/channels/:channel_id/messages` —
   delegates to `Grappa.Session.send_privmsg/4` for the active session
   registered as `(subject, network.id)` where `subject` is the
@@ -325,6 +377,18 @@ defmodule GrappaWeb.MessagesController do
       _ -> {:error, :bad_request}
     end
   end
+
+  # #693 — `?after=` for the count probe: required, and non-negative because
+  # an anchor is a row id (or 0 for "from the beginning"). A negative anchor
+  # is a client bug, not a request to count everything.
+  defp parse_after(s) when is_binary(s) do
+    case parse_int(s) do
+      {:ok, n} when n >= 0 -> {:ok, n}
+      _ -> {:error, :bad_request}
+    end
+  end
+
+  defp parse_after(nil), do: {:error, :bad_request}
 
   defp parse_int(s) when is_binary(s) do
     case Integer.parse(s) do

--- a/lib/grappa_web/controllers/messages_controller.ex
+++ b/lib/grappa_web/controllers/messages_controller.ex
@@ -388,7 +388,11 @@ defmodule GrappaWeb.MessagesController do
     end
   end
 
-  defp parse_after(nil), do: {:error, :bad_request}
+  # Absent, or any non-string shape Plug can hand us (`?after[]=1` parses to a
+  # LIST): 400, per this controller's documented "present and unparseable"
+  # contract. Without the catch-all the list case is a FunctionClauseError —
+  # a 500 with a stacktrace for what is plainly a malformed request.
+  defp parse_after(_), do: {:error, :bad_request}
 
   defp parse_int(s) when is_binary(s) do
     case Integer.parse(s) do

--- a/lib/grappa_web/controllers/messages_json.ex
+++ b/lib/grappa_web/controllers/messages_json.ex
@@ -23,4 +23,13 @@ defmodule GrappaWeb.MessagesJSON do
   @doc "Renders the `:show` action — a single serialized message map."
   @spec show(%{message: Message.t()}) :: Wire.t()
   def show(%{message: message}), do: Wire.to_json(message)
+
+  @doc """
+  Renders the `:count` action (#693) — the uncapped row count after an
+  anchor. An object rather than a bare integer so the shape stays
+  additive: a future sibling figure (say, a tail id) is a new key, not a
+  breaking change of the response type.
+  """
+  @spec count(%{count: non_neg_integer()}) :: %{count: non_neg_integer()}
+  def count(%{count: n}), do: %{count: n}
 end

--- a/lib/grappa_web/router.ex
+++ b/lib/grappa_web/router.ex
@@ -431,6 +431,13 @@ defmodule GrappaWeb.Router do
     get "/channels/:channel_id/messages", MessagesController, :index
     post "/channels/:channel_id/messages", MessagesController, :create
 
+    # #693 — gap probe: how many rows are there after `?after=<id>`. The
+    # true size, uncapped, so cic can tell a drainable gap from one that
+    # has to be abandoned in favour of the tail. Declared AFTER the
+    # collection route: Phoenix matches in order and `/messages/count` has
+    # its own segment count, so the two never shadow each other.
+    get "/channels/:channel_id/messages/count", MessagesController, :count
+
     post "/channels/:channel_id/read-cursor", ReadCursorController, :create
 
     get "/channels/:channel_id/members", MembersController, :index

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -1014,17 +1014,16 @@ defmodule Grappa.ScrollbackTest do
     end
   end
 
-  # Cursor-derived unread-badge primitive (2026-06-01). Mirrors
-  # `fetch_after/6`'s predicate so the count exactly matches what an
-  # uncapped fetch would return — Phoenix Channel `join_reply` + cic
-  # fallback seed share the same source of truth as the local
-  # scrollback-derived count cic computes on its own.
-  describe "count_after/5" do
+  # The gap probe behind #693 (was the 2026-06-01 unread-badge primitive;
+  # the badge moved to `count_after_split/5` via `WindowCounts`). Mirrors
+  # `fetch_after/7`'s predicate — presence filter included — so the count
+  # is exactly what an uncapped fetch would hand the same caller.
+  describe "count_after/6" do
     test "zero cursor counts every row for (subject, network, channel)",
          %{user: user, network: net} do
       for i <- 0..4, do: {:ok, _} = ScrollbackHelpers.insert(sample(user, net, i))
 
-      assert Scrollback.count_after({:user, user.id}, net.id, "#sniffo", 0, nil) == 5
+      assert Scrollback.count_after({:user, user.id}, net.id, "#sniffo", 0, nil, false) == 5
     end
 
     test "cursor at the newest row id returns 0",
@@ -1036,13 +1035,13 @@ defmodule Grappa.ScrollbackTest do
         end
         |> List.last()
 
-      assert Scrollback.count_after({:user, user.id}, net.id, "#sniffo", latest.id, nil) == 0
+      assert Scrollback.count_after({:user, user.id}, net.id, "#sniffo", latest.id, nil, false) == 0
     end
 
     test "past-tail cursor returns 0", %{user: user, network: net} do
       for i <- 0..2, do: {:ok, _} = ScrollbackHelpers.insert(sample(user, net, i))
 
-      assert Scrollback.count_after({:user, user.id}, net.id, "#sniffo", 999_999_999, nil) == 0
+      assert Scrollback.count_after({:user, user.id}, net.id, "#sniffo", 999_999_999, nil, false) == 0
     end
 
     test "counts only rows strictly greater than after_id",
@@ -1055,7 +1054,7 @@ defmodule Grappa.ScrollbackTest do
 
       [_, _, m2 | _] = rows
 
-      assert Scrollback.count_after({:user, user.id}, net.id, "#sniffo", m2.id, nil) == 2
+      assert Scrollback.count_after({:user, user.id}, net.id, "#sniffo", m2.id, nil, false) == 2
     end
 
     test "isolated by (subject, network, channel) — same shape as fetch_after",
@@ -1068,7 +1067,7 @@ defmodule Grappa.ScrollbackTest do
       {:ok, _} = ScrollbackHelpers.insert(sample(user, other_net, 2, %{body: "wrong-net"}))
       {:ok, _} = ScrollbackHelpers.insert(sample(alice, net, 3, %{sender: "alice", body: "wrong-user"}))
 
-      assert Scrollback.count_after({:user, user.id}, net.id, "#sniffo", 0, nil) == 1
+      assert Scrollback.count_after({:user, user.id}, net.id, "#sniffo", 0, nil, false) == 1
     end
 
     test "DM bidirectional — peer target counts inbound + outbound after the cursor",
@@ -1104,7 +1103,8 @@ defmodule Grappa.ScrollbackTest do
                net.id,
                "peer",
                outbound.id - 1,
-               "vjt-grappa"
+               "vjt-grappa",
+               false
              ) == 2
     end
 
@@ -1141,7 +1141,8 @@ defmodule Grappa.ScrollbackTest do
                net.id,
                "vjt-grappa",
                0,
-               "vjt-grappa"
+               "vjt-grappa",
+               false
              ) == 1
     end
 
@@ -1152,7 +1153,32 @@ defmodule Grappa.ScrollbackTest do
       for i <- 0..(cap + 4), do: {:ok, _} = ScrollbackHelpers.insert(sample(user, net, i))
 
       total = cap + 5
-      assert Scrollback.count_after({:user, user.id}, net.id, "#sniffo", 0, nil) == total
+      assert Scrollback.count_after({:user, user.id}, net.id, "#sniffo", 0, nil, false) == total
+    end
+
+    test "hide_presence: true counts only the rows a hiding fetch would return (#693)",
+         %{user: user, network: net} do
+      {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 0))
+      {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 1, %{kind: :join, body: nil}))
+      {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 2, %{kind: :quit, body: "bye"}))
+
+      assert Scrollback.count_after({:user, user.id}, net.id, "#sniffo", 0, nil, true) == 1
+      assert Scrollback.count_after({:user, user.id}, net.id, "#sniffo", 0, nil, false) == 3
+    end
+
+    test "the presence-filtered count equals the length of the equivalent fetch (#693)",
+         %{user: user, network: net} do
+      for i <- 0..3 do
+        {:ok, _} = ScrollbackHelpers.insert(sample(user, net, i))
+        {:ok, _} = ScrollbackHelpers.insert(sample(user, net, i, %{kind: :part, body: nil}))
+      end
+
+      for hide <- [true, false] do
+        page = Scrollback.fetch_after({:user, user.id}, net.id, "#sniffo", 0, 100, nil, hide)
+
+        assert Scrollback.count_after({:user, user.id}, net.id, "#sniffo", 0, nil, hide) ==
+                 length(page)
+      end
     end
   end
 
@@ -2916,7 +2942,7 @@ defmodule Grappa.ScrollbackTest do
 
   # #379 (P0, 2026-07-22) — CP29 R-2 index regression. R-2 switched the
   # scrollback since-cursor key from `server_time` to monotonic `id`, so
-  # every incremental read path — `fetch_after/6`, `count_after/5`,
+  # every incremental read path — `fetch_after/6`, `count_after/6`,
   # `count_after_split/5`, `unread_content_tail/6` — now filters
   # `id > cursor ORDER BY id`. But the `messages` composites all still
   # END in `server_time`, so `id > ?` was NOT index-eligible: SQLite fell
@@ -2964,7 +2990,7 @@ defmodule Grappa.ScrollbackTest do
           })
       end
 
-      # Mirrors `fetch_after/6` / `count_after/5`'s channel-shape query
+      # Mirrors `fetch_after/6` / `count_after/6`'s channel-shape query
       # verbatim: WHERE visitor_id AND network_id AND channel AND id > ?
       # ORDER BY id.
       %Exqlite.Result{rows: rows} =

--- a/test/grappa_web/controllers/me_controller_test.exs
+++ b/test/grappa_web/controllers/me_controller_test.exs
@@ -479,11 +479,18 @@ defmodule GrappaWeb.MeControllerTest do
       assert body["unread_counts"][network.slug][own_nick] ==
                %{"messages" => 1, "mentions" => 0, "events" => 0, "severity" => "message"}
 
-      # Door parity: the /me total equals what the WS `join_reply` seeds
-      # via the SAME predicate `Scrollback.count_after/5`, with own_nick
-      # resolved to the configured nick.
+      # Door parity: the /me total equals the SAME predicate read through
+      # `Scrollback.count_after/6`, with own_nick resolved to the configured
+      # nick. `hide_presence: false` — the badge counts events too.
       ws_count =
-        Grappa.Scrollback.count_after({:user, user.id}, network.id, own_nick, anchor.id, own_nick)
+        Grappa.Scrollback.count_after(
+          {:user, user.id},
+          network.id,
+          own_nick,
+          anchor.id,
+          own_nick,
+          false
+        )
 
       %{"messages" => m, "events" => e} = body["unread_counts"][network.slug][own_nick]
       assert m + e == ws_count

--- a/test/grappa_web/controllers/messages_controller_test.exs
+++ b/test/grappa_web/controllers/messages_controller_test.exs
@@ -411,6 +411,106 @@ defmodule GrappaWeb.MessagesControllerTest do
     assert json_response(conn, 401) == %{"error" => "unauthorized"}
   end
 
+  # #693 — the gap probe. cic decides "am I more than one page behind?" from
+  # this count, NOT from `page.length == limit` (a full page says "≥ limit",
+  # which cannot distinguish a 201-row gap from a 3000-row one).
+  describe "GET /networks/:network_id/channels/:channel_id/messages/count (#693)" do
+    test "?after=0 returns the total row count for the channel",
+         %{conn: conn, user: user, network: network} do
+      seed(user, network)
+
+      conn = get(conn, "/networks/azzurra/channels/%23sniffo/messages/count?after=0")
+
+      assert json_response(conn, 200) == %{"count" => 5}
+    end
+
+    test "the count is NOT capped at the page ceiling — a 201-row gap reads 201",
+         %{conn: conn, user: user, network: network} do
+      for i <- 0..200 do
+        {:ok, _} =
+          ScrollbackHelpers.insert(%{
+            user_id: user.id,
+            network_id: network.id,
+            channel: "#sniffo",
+            server_time: i,
+            kind: :privmsg,
+            sender: "vjt",
+            body: "m#{i}"
+          })
+      end
+
+      conn = get(conn, "/networks/azzurra/channels/%23sniffo/messages/count?after=0")
+
+      assert json_response(conn, 200) == %{"count" => 201}
+    end
+
+    test "?after=<tail id> returns 0", %{conn: conn, user: user, network: network} do
+      seed(user, network)
+      rows = json_response(get(conn, "/networks/azzurra/channels/%23sniffo/messages"), 200)
+      tail = rows |> Enum.map(& &1["id"]) |> Enum.max()
+
+      conn = get(conn, "/networks/azzurra/channels/%23sniffo/messages/count?after=#{tail}")
+
+      assert json_response(conn, 200) == %{"count" => 0}
+    end
+
+    test "counts only VISIBLE rows when the channel pref hides presence (#458)",
+         %{conn: conn, user: user, network: network} do
+      # The count feeds a "can I drain this in one page?" decision, so it MUST
+      # apply the same presence filter `index/2` applies — otherwise a channel
+      # with 500 hidden JOINs and 5 messages reads as a 505-row gap.
+      :ok = put_presence_pref(user, "azzurra #sniffo", "hide")
+      seed_mixed(user, network)
+
+      conn = get(conn, "/networks/azzurra/channels/%23sniffo/messages/count?after=0")
+
+      assert json_response(conn, 200) == %{"count" => 1}
+    end
+
+    test "a missing ?after returns 400", %{conn: conn, user: user, network: network} do
+      seed(user, network)
+
+      conn = get(conn, "/networks/azzurra/channels/%23sniffo/messages/count")
+
+      assert json_response(conn, 400)["error"] == "bad_request"
+    end
+
+    test "an unparseable ?after returns 400", %{conn: conn, user: user, network: network} do
+      seed(user, network)
+
+      conn = get(conn, "/networks/azzurra/channels/%23sniffo/messages/count?after=banana")
+
+      assert json_response(conn, 400)["error"] == "bad_request"
+    end
+
+    test "a negative ?after returns 400", %{conn: conn, user: user, network: network} do
+      seed(user, network)
+
+      conn = get(conn, "/networks/azzurra/channels/%23sniffo/messages/count?after=-1")
+
+      assert json_response(conn, 400)["error"] == "bad_request"
+    end
+
+    test "does not leak another channel's rows", %{conn: conn, user: user, network: network} do
+      seed(user, network)
+      seed(user, network, "#altro")
+
+      conn = get(conn, "/networks/azzurra/channels/%23altro/messages/count?after=0")
+
+      assert json_response(conn, 200) == %{"count" => 5}
+    end
+
+    test "without Bearer returns 401" do
+      conn =
+        get(
+          Phoenix.ConnTest.build_conn(),
+          "/networks/azzurra/channels/%23sniffo/messages/count?after=0"
+        )
+
+      assert json_response(conn, 401) == %{"error" => "unauthorized"}
+    end
+  end
+
   describe "POST /networks/:network_id/channels/:channel_id/messages — input validation" do
     test "unknown network slug returns 404 not found", %{conn: conn} do
       # Sub-task 2g: slug → integer FK resolution short-circuits with

--- a/test/grappa_web/controllers/messages_controller_test.exs
+++ b/test/grappa_web/controllers/messages_controller_test.exs
@@ -483,6 +483,16 @@ defmodule GrappaWeb.MessagesControllerTest do
       assert json_response(conn, 400)["error"] == "bad_request"
     end
 
+    test "a list-valued ?after returns 400, not a 500", %{conn: conn, user: user, network: network} do
+      # `?after[]=1` reaches the action as `["1"]`. A missing catch-all clause
+      # would raise FunctionClauseError — a stacktrace for a malformed request.
+      seed(user, network)
+
+      conn = get(conn, "/networks/azzurra/channels/%23sniffo/messages/count?after[]=1")
+
+      assert json_response(conn, 400)["error"] == "bad_request"
+    end
+
     test "a negative ?after returns 400", %{conn: conn, user: user, network: network} do
       seed(user, network)
 


### PR DESCRIPTION
Refs #693

## The symptom

After a day away, reopening cic shows stale scrollback and scrolling to the bottom never reaches
the live tail.

## Root cause

Both recovery paths anchored at the **read cursor** and capped at 200, so the client loaded
`[cursor .. cursor+200]` — the *oldest* end of the gap — and only `loadNewer` walked forward, 200
rows per scroll gesture. The trigger is **gap size**, not absence of a cursor: a small gap has
always worked, a day-sized one never could.

## What changed

**Server — a new wire token.** `Scrollback.count_after/5` (deliberately uncapped, and it had *no*
production caller; its doc still credited the join reply, which had moved to `count_after_split/5`
via `WindowCounts`) grew a required `hide_presence` positional → `/6`, and got a door:

    GET /networks/:slug/channels/:chan/messages/count?after=<id>  →  {"count": N}

⚠️ **This is a NEW WIRE TOKEN.** Per the cross-stack rule the ship runs the cic check + build gate;
the `DESIGN_NOTES.md` entry is written (search `#693`).

**cic lib (`scrollback.ts`).** Both resume paths probe the count at the anchor they are about to
use. Above one page (`PAGE_LIMIT = 200` — which also collapsed three copies of that literal) they
REPLACE the pane with the newest page (`anchorAtTail`), record `{missed, resumeFrom}` in
`farBehindByChannel`, and roll the high-water mark to the tail. A probe that throws returns `null`
and the caller keeps the pre-#693 behaviour — older servers degrade, they never guess.

**cic UI (`ScrollbackPane.tsx`).** A pinned bar at the top of the pane: *\"N unread — jump back\"*
plus a dismiss ×. The in-pane divider is suppressed while far behind: its count would describe the
~50 loaded rows, not the thousands missing.

**The cursor freezes while far behind** (`selection.ts setCursorIfAdvances`) and the badge keeps
the server seed instead of counting the pane. Dismiss is the one deliberate exit.

## The one review finding deliberately declined

A code-review agent raised ten issues. Nine are fixed in `55ea1937`. The tenth is declined on
evidence:

> Uncapped `COUNT(*)` behind an unmetered GET (`RequestBudget` passes reads through). **Declined:**
> capping it would defeat the issue's own requirement for the TRUE count, and it is not a new cost
> class — the `/me` cold-load already fans out ~2N uncapped `count_after_split/5` queries per login
> through the same unmetered door, and `index/2` on this very route does an index scan plus 200 row
> loads plus preload plus JSON render per call. Flagged for vjt rather than silently capped.

## e2e — +0, and why

The e2e fixture surface (`cicchetto/e2e/**`) belongs to another worker this cycle and the lane
instruction forbids touching it. The behaviour is pinned at the unit level (loader decisions,
cursor freeze, pane rendering). But jsdom cannot see the one thing that matters visually — that the
pinned bar is actually **visible** on a pane parked at the tail. An e2e is **owed** and should be
filed as a follow-up for whoever holds the fixture lane next.

## Gates

Both suites re-run detached on the final tree, from the worktree root:

* `./scripts/check.sh` — **exit 0**: `8 doctests, 50 properties, 4965 tests, 0 failures`
* `./scripts/bun.sh run test` — **exit 0**: `Test Files 215 passed (215)`, `Tests 3907 passed (3907)`
* biome + a **standalone** `tsc --noEmit` (the `bun run check` short-circuit means biome-red skips
  tsc entirely) — both exit 0.

Rebased onto `origin/main` @ 365bc2ec, no conflicts.