### PR TITLE
fix(#692): the self-hosted installer never exported GRAPPA_VERSION

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -26935,41 +26935,67 @@ the echo was the honest substitute sitting in the same line.
 path — never exported `GRAPPA_VERSION`. Since the #538/#652 guard landed in
 `cicchetto/vite.config.ts` (refuse to bake an empty `<meta cicchetto-version>`
 rather than ship a lying version), every self-hosted deploy that reached a cic
-build died. Nine other wrappers export it; the installer was the one that was
+build died. Ten other wrappers export it; the installer was the one that was
 missed, and nothing in CI exercised it, so it surfaced on a real box.
 
 **Two doors, not one.** The issue named `substrate_cic` (the `update` cold
 path's explicit `run --rm cicchetto-build`). `install` reaches the same oneshot
-by a different route: `--profile prod up -d` without `--no-deps`, where
-compose.yaml's grappa `depends_on: cicchetto-build` pulls it in as the
-safety net. Patching the hook would have left `install` broken — so the derive
-lands ONCE in the source-mode init block, next to `COMPOSE=(...)`, where every
-compose invocation in the script inherits it. Release-image mode does not
-derive: it has no checkout to read `VERSION` from, and the SPA is baked into
-the published image.
+by a different route: the service carries `profiles: [prod]`, so
+`--profile prod up -d` STARTS it outright (grappa's `depends_on` only orders
+it). Patching the hook would have left `install` broken.
 
-**Why no shared helper.** The derive+export pair is now in ten places, which
-reads like a refactor waiting to happen. It is not one: the copies live in bash
-(`scripts/*.sh`), POSIX sh (the FreeBSD jail — no bash port), a `Dockerfile`
-RUN layer and a PKGBUILD `build()`. No sourceable shim spans those four, and
-`infra/docker/deploy.sh` is deliberately standalone (it does not source
-`scripts/_lib.sh`, by design — it is the vanilla-box path). The real cost of
-the duplication is drift, so the cure is a guard, not a tenth file:
-`test/infra/cic_version_export_test.bats` pins the known roster (fails when an
-export is REMOVED) and rediscovers launchers from what they invoke (fails when
-one is ADDED without the export — exactly this bug). It proves itself RED
-against a synthetic launcher, because a guard that cannot fail guards nothing.
+**Derived at each launch point, not once at startup.** The first cut put the
+derive in the source-mode init block, where every compose call inherits it —
+and code review killed it. `update` pulls BEFORE it builds, and the re-exec
+guard only re-enters the script when the pulled range touched the deploy code,
+which a release pull does not: so a startup derive stamps the bundle with the
+version the box was ALREADY on. That build SUCCEEDS, which is what makes it
+worse than the crash it replaced — the refresh banner then advertises the old
+number as available. One `export_cic_version` helper, called from
+`cmd_install` before the prod `up` and from `substrate_cic` after the pull.
+The regression test bumps `VERSION` upstream and asserts the NEW number
+reaches the build; the naive "is it non-empty" assertion stayed green against
+the stale value. Release-image mode does not derive at all: no checkout to
+read `VERSION` from, and the SPA is baked into the published image.
+
+**A guard on every verb was the wrong blast radius, too.** A startup derive
+also made `stop` depend on a readable `VERSION` — and `cmd_stop` is written
+around the opposite principle: a box you cannot bring down because a file went
+missing is a trap. Deriving at the launch point keeps the failure where the
+need is.
+
+**Why a guard and not a shared helper.** The derive+export pair now sits in
+eleven launchers, which reads like a refactor waiting to happen. A partial one
+IS available and was deliberately not taken: the five `scripts/*.sh` launchers
+already source `scripts/_lib.sh`, so a helper there would serve them. It would
+not serve the other six — POSIX sh (the FreeBSD jail, no bash port), the native
+Linux builder, a `Dockerfile` RUN layer, a PKGBUILD `build()`, and
+`infra/docker/deploy.sh`, which is standalone BY DESIGN (the vanilla-box path
+that must run with nothing but a checkout). Five-of-eleven is the half-migration
+this repo's rules warn about: two patterns, and the next author copies whichever
+is nearer. The real cost of the duplication is drift, so the cure is aimed at
+drift — `test/infra/cic_version_export_test.bats` pins the known roster (fails
+when an export is REMOVED), rediscovers launchers from what their code invokes
+(fails when one is ADDED without the export — exactly this bug), and
+cross-checks the two halves so a discovered launcher missing from the roster is
+itself a failure. It proves itself RED against synthetic launchers that forget
+the export and that hardcode the number instead of deriving it, because a guard
+that cannot fail guards nothing. Its limit is stated where it lives: it reads
+text, so a launcher that resolves the service name through variables is roster
+business.
 
 **Fake repos got more real.** The `deploy_docker_*` bats harnesses build a
 throwaway checkout that copied `deploy.sh` and `deploy_common.sh` and nothing
-else. A source-mode script that reads `VERSION` at init needs the real carrier
-and the real extractor in there — so both are now copied in, and the assertions
-compare against the file's actual contents rather than "non-empty": a wrong
-version bakes into the bundle just as badly as a missing one.
+else. A script that reads `VERSION` needs the real carrier and the real
+extractor in there — so both are now copied in, and the assertions compare
+against the file's actual contents rather than "non-empty": a wrong version
+bakes into the bundle just as badly as a missing one.
 
 **Apply:** when a guard is added at the LAST mile (the build refusing bad
 input), audit every wrapper that feeds it in the same change — the guard turns
 a silent wrong value into a hard failure, which is an improvement only for the
-paths someone remembered to fix. And when duplication spans languages that
-cannot share code, make the invariant testable instead of pretending a helper
-is possible.
+paths someone remembered to fix. When duplication spans languages that cannot
+share code, make the invariant testable instead of pretending a helper is
+possible. And when a value is derived for a deploy, derive it where it is USED:
+anything read before the pull describes the box you are leaving, and a stale
+number that still builds is harder to notice than one that crashes.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -26928,3 +26928,48 @@ A unit-tested branch behind a guard no caller satisfies reads as working code.
 And when a spec cites a protocol value, verify the value has arrived by the time
 you need it: "use the advertised NICKLEN" is unimplementable at 433 time, and
 the echo was the honest substitute sitting in the same line.
+
+## 2026-08-03 — #692: the cic-build version export is derived once per wrapper, and drift is a test
+
+**What broke.** `infra/docker/deploy.sh` — the self-hoster `install`/`update`
+path — never exported `GRAPPA_VERSION`. Since the #538/#652 guard landed in
+`cicchetto/vite.config.ts` (refuse to bake an empty `<meta cicchetto-version>`
+rather than ship a lying version), every self-hosted deploy that reached a cic
+build died. Nine other wrappers export it; the installer was the one that was
+missed, and nothing in CI exercised it, so it surfaced on a real box.
+
+**Two doors, not one.** The issue named `substrate_cic` (the `update` cold
+path's explicit `run --rm cicchetto-build`). `install` reaches the same oneshot
+by a different route: `--profile prod up -d` without `--no-deps`, where
+compose.yaml's grappa `depends_on: cicchetto-build` pulls it in as the
+safety net. Patching the hook would have left `install` broken — so the derive
+lands ONCE in the source-mode init block, next to `COMPOSE=(...)`, where every
+compose invocation in the script inherits it. Release-image mode does not
+derive: it has no checkout to read `VERSION` from, and the SPA is baked into
+the published image.
+
+**Why no shared helper.** The derive+export pair is now in ten places, which
+reads like a refactor waiting to happen. It is not one: the copies live in bash
+(`scripts/*.sh`), POSIX sh (the FreeBSD jail — no bash port), a `Dockerfile`
+RUN layer and a PKGBUILD `build()`. No sourceable shim spans those four, and
+`infra/docker/deploy.sh` is deliberately standalone (it does not source
+`scripts/_lib.sh`, by design — it is the vanilla-box path). The real cost of
+the duplication is drift, so the cure is a guard, not a tenth file:
+`test/infra/cic_version_export_test.bats` pins the known roster (fails when an
+export is REMOVED) and rediscovers launchers from what they invoke (fails when
+one is ADDED without the export — exactly this bug). It proves itself RED
+against a synthetic launcher, because a guard that cannot fail guards nothing.
+
+**Fake repos got more real.** The `deploy_docker_*` bats harnesses build a
+throwaway checkout that copied `deploy.sh` and `deploy_common.sh` and nothing
+else. A source-mode script that reads `VERSION` at init needs the real carrier
+and the real extractor in there — so both are now copied in, and the assertions
+compare against the file's actual contents rather than "non-empty": a wrong
+version bakes into the bundle just as badly as a missing one.
+
+**Apply:** when a guard is added at the LAST mile (the build refusing bad
+input), audit every wrapper that feeds it in the same change — the guard turns
+a silent wrong value into a hard failure, which is an improvement only for the
+paths someone remembered to fix. And when duplication spans languages that
+cannot share code, make the invariant testable instead of pretending a helper
+is possible.

--- a/infra/docker/deploy.sh
+++ b/infra/docker/deploy.sh
@@ -103,6 +103,19 @@ if [ "$DEPLOY_MODE" = source ]; then
 	# Pin to the committed compose file only — no override auto-merge.
 	# Every compose invocation reuses this array.
 	COMPOSE=(docker compose -f compose.yaml)
+	# #538/#652 — vite bakes GRAPPA_VERSION into <meta cicchetto-version> and
+	# REFUSES to build without it. The cicchetto-build container mounts only
+	# ./cicchetto, so it cannot read the repo-root VERSION file itself: the
+	# wrapper must derive it and compose passes it through (compose.yaml
+	# `GRAPPA_VERSION: ${GRAPPA_VERSION:-}`). Derived ONCE here rather than at
+	# the cic hook because TWO paths reach that build — `update`'s cold
+	# substrate_cic runs it explicitly, and `install`'s `--profile prod up -d`
+	# pulls it in through grappa's depends_on — and a third would drift again
+	# (#692: the installer was the one wrapper that never got the export, so
+	# every self-hosted install/update that reached a cic build died).
+	GRAPPA_VERSION="$(infra/packaging/version.sh)" \
+		|| die "could not derive the version from $REPO_ROOT/VERSION — is this a complete checkout?"
+	export GRAPPA_VERSION
 else
 	# ---- release-image mode: checkout-less, docker-only ---------------
 	# State (the prod env file, with every secret) lives per-user so the

--- a/infra/docker/deploy.sh
+++ b/infra/docker/deploy.sh
@@ -103,19 +103,6 @@ if [ "$DEPLOY_MODE" = source ]; then
 	# Pin to the committed compose file only — no override auto-merge.
 	# Every compose invocation reuses this array.
 	COMPOSE=(docker compose -f compose.yaml)
-	# #538/#652 — vite bakes GRAPPA_VERSION into <meta cicchetto-version> and
-	# REFUSES to build without it. The cicchetto-build container mounts only
-	# ./cicchetto, so it cannot read the repo-root VERSION file itself: the
-	# wrapper must derive it and compose passes it through (compose.yaml
-	# `GRAPPA_VERSION: ${GRAPPA_VERSION:-}`). Derived ONCE here rather than at
-	# the cic hook because TWO paths reach that build — `update`'s cold
-	# substrate_cic runs it explicitly, and `install`'s `--profile prod up -d`
-	# pulls it in through grappa's depends_on — and a third would drift again
-	# (#692: the installer was the one wrapper that never got the export, so
-	# every self-hosted install/update that reached a cic build died).
-	GRAPPA_VERSION="$(infra/packaging/version.sh)" \
-		|| die "could not derive the version from $REPO_ROOT/VERSION — is this a complete checkout?"
-	export GRAPPA_VERSION
 else
 	# ---- release-image mode: checkout-less, docker-only ---------------
 	# State (the prod env file, with every secret) lives per-user so the
@@ -151,6 +138,25 @@ require_compose_file() {
 require_docker() {
 	command -v docker >/dev/null 2>&1 || die "docker not found — install Docker Engine first."
 	docker compose version >/dev/null 2>&1 || die "docker compose v2 not found — install the Compose plugin."
+}
+
+# ---- the cic build's version input (#538/#652, #692) ------------------
+# vite bakes GRAPPA_VERSION into <meta cicchetto-version> and REFUSES to build
+# without it rather than ship a bundle that lies about its version. The
+# cicchetto-build container mounts only ./cicchetto, so it cannot read the
+# repo-root VERSION file itself: this wrapper derives it and compose passes it
+# through (`GRAPPA_VERSION: ${GRAPPA_VERSION:-}`).
+#
+# Called AT each launch point rather than once at startup, for two reasons.
+# `update` pulls before it builds, so a startup derive would stamp the bundle
+# with the version the box was ALREADY on — the exact staleness #652 exists to
+# prevent, and invisible because the build still succeeds. And `stop` must not
+# depend on a readable VERSION: a box you cannot bring down because a file went
+# missing is the trap cmd_stop is written to avoid.
+export_cic_version() {
+	GRAPPA_VERSION="$(infra/packaging/version.sh)" \
+		|| die "could not derive the version from $REPO_ROOT/VERSION — is this a complete checkout?"
+	export GRAPPA_VERSION
 }
 
 # ---- one-box-per-host ownership guard ---------------------------------
@@ -433,6 +439,9 @@ cmd_install() {
 	fi
 
 	# ---- 7. bring up the stack ----------------------------------------
+	# cicchetto-build is IN the prod profile, so this `up` starts it — the
+	# bundle is built here, not by a separate step, and it needs the version.
+	export_cic_version
 	say "Starting the stack (grappa + cicchetto build)"
 	"${COMPOSE[@]}" --profile prod up -d --remove-orphans
 
@@ -690,6 +699,9 @@ cmd_update() {
 
 	substrate_cic() {
 		mkdir -p runtime/cicchetto-dist
+		# AFTER substrate_pull, so the bundle carries the version the box is
+		# moving TO, not the one it is on (the pull may have bumped VERSION).
+		export_cic_version
 		say "Rebuilding the cicchetto bundle"
 		"${COMPOSE[@]}" --profile prod run --rm cicchetto-build
 		touch runtime/cicchetto-dist/.gitkeep

--- a/test/infra/cic_version_export_test.bats
+++ b/test/infra/cic_version_export_test.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+#
+# Drift guard: every entrypoint that can launch a cicchetto build must derive
+# GRAPPA_VERSION from the repo-root VERSION file and export it (#538/#652).
+#
+# WHY a guard and not a shared helper: the derive+export pair is two lines, but
+# it lives in bash (scripts/*.sh), POSIX sh (the FreeBSD jail, which has no bash
+# port), a Dockerfile RUN layer and a PKGBUILD build() — no sourceable shim
+# reaches all four, and infra/docker/deploy.sh is deliberately standalone (it
+# does NOT source scripts/_lib.sh). What CAN be shared is the check: the cost of
+# the duplication is drift, so the fix for drift is a test, not a tenth file.
+#
+# #692 is the incident this encodes: the installer (infra/docker/deploy.sh) was
+# the one wrapper that never got the export, so since the guard landed in
+# cicchetto/vite.config.ts every self-hosted `install` / `update` that reached a
+# cic build died refusing to bake an empty <meta cicchetto-version>. Nothing in
+# CI exercised that path, so it went unnoticed until a real box updated.
+#
+# Two halves, because neither alone is enough:
+#   * the ROSTER pins the launchers we know about — it fails when someone
+#     REMOVES an export from one of them;
+#   * the SCAN discovers launchers by what they invoke — it fails when someone
+#     ADDS a launcher and forgets the export, which is exactly #692.
+
+setup() {
+    REPO_SRC="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+}
+
+# Every launcher, as of #692. A new one belongs here AND must export.
+ROSTER=(
+    scripts/bun.sh
+    scripts/deploy.sh
+    scripts/deploy-cic.sh
+    scripts/integration.sh
+    scripts/testnet.sh
+    infra/docker/deploy.sh
+    infra/freebsd/jail_cic_build.sh
+    infra/linux/cic_build.sh
+    infra/packaging/build.sh
+    infra/packaging/aur/PKGBUILD
+    Dockerfile.release
+)
+
+# Comments are prose, not behaviour: version.sh's own header NAMES every
+# carrier, and _lib.sh mentions cicchetto-build in a note. Matching them would
+# make the guard lie in both directions, so strip trailing comments first.
+code_of() {
+    sed -e 's/[[:space:]]*#.*$//' "$1"
+}
+
+# A launcher is a file that NAMES a cic build: the compose service, or the
+# package-manager verb the bun/npm substrates run.
+launches_cic_build() {
+    code_of "$1" | grep -qE 'cicchetto-build|(bun|npm) run build'
+}
+
+exports_version() {
+    code_of "$1" | grep -q 'export GRAPPA_VERSION'
+}
+
+derives_version() {
+    code_of "$1" | grep -q 'version\.sh'
+}
+
+# The shell/build entrypoints a cic build can be launched from. compose files
+# are excluded on purpose: they PASS THROUGH `GRAPPA_VERSION: ${GRAPPA_VERSION:-}`
+# from the wrapper's environment, they never derive it.
+candidate_files() {
+    local root="$1"
+    ls "$root"/scripts/*.sh 2>/dev/null || true
+    if [ -d "$root/infra" ]; then
+        find "$root/infra" -type f \( -name '*.sh' -o -name 'PKGBUILD' \) | sort
+    fi
+    if [ -f "$root/Dockerfile.release" ]; then
+        printf '%s\n' "$root/Dockerfile.release"
+    fi
+}
+
+# Echo every launcher under $1 that does NOT export GRAPPA_VERSION.
+unexported_launchers() {
+    local root="$1" f
+    while IFS= read -r f; do
+        [ -n "$f" ] || continue
+        launches_cic_build "$f" || continue
+        exports_version "$f" && continue
+        printf '%s\n' "${f#"$root"/}"
+    done < <(candidate_files "$root")
+}
+
+@test "roster: every known cic-build launcher derives GRAPPA_VERSION from version.sh and exports it" {
+    local missing=()
+    for rel in "${ROSTER[@]}"; do
+        local f="$REPO_SRC/$rel"
+        [ -f "$f" ] || { missing+=("$rel (file is gone)"); continue; }
+        derives_version "$f" || missing+=("$rel (no version.sh derive)")
+        exports_version "$f" || missing+=("$rel (no export GRAPPA_VERSION)")
+    done
+    [ "${#missing[@]}" -eq 0 ] || {
+        printf 'launchers that stopped deriving/exporting GRAPPA_VERSION:\n' >&2
+        printf '  %s\n' "${missing[@]}" >&2
+        return 1
+    }
+}
+
+@test "scan: no shell or build entrypoint launches a cic build without exporting GRAPPA_VERSION" {
+    run unexported_launchers "$REPO_SRC"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ] || {
+        printf 'cic-build launchers with no GRAPPA_VERSION export (see #692):\n%s\n' "$output" >&2
+        return 1
+    }
+}
+
+@test "scan: RED — a new launcher that forgets the export is caught" {
+    local fake="$BATS_TEST_TMPDIR/repo"
+    mkdir -p "$fake/scripts"
+    cat > "$fake/scripts/ship-the-bundle.sh" <<'EOF'
+#!/usr/bin/env bash
+docker compose --profile prod run --rm cicchetto-build
+EOF
+
+    run unexported_launchers "$fake"
+    [ "$status" -eq 0 ]
+    [ "$output" = "scripts/ship-the-bundle.sh" ]
+}
+
+@test "scan: GREEN — the same launcher passes once it derives and exports" {
+    local fake="$BATS_TEST_TMPDIR/repo"
+    mkdir -p "$fake/scripts"
+    cat > "$fake/scripts/ship-the-bundle.sh" <<'EOF'
+#!/usr/bin/env bash
+GRAPPA_VERSION="$(infra/packaging/version.sh)"
+export GRAPPA_VERSION
+docker compose --profile prod run --rm cicchetto-build
+EOF
+
+    run unexported_launchers "$fake"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}

--- a/test/infra/cic_version_export_test.bats
+++ b/test/infra/cic_version_export_test.bats
@@ -48,18 +48,36 @@ code_of() {
     sed -e 's/[[:space:]]*#.*$//' "$1"
 }
 
-# A launcher is a file that NAMES a cic build: the compose service, or the
-# package-manager verb the bun/npm substrates run.
+# A launcher is a file whose CODE can reach a cic build. Five signals, because
+# the launchers do not all name it the same way:
+#   cicchetto-build   the compose service (substring: also cicchetto-build-test)
+#   bun|npm run build the verb the bun/npm substrates run directly
+#   --profile prod    the profile the compose oneshot is gated behind, so any
+#                     `up` on it STARTS the build (not merely depends_on it)
+#   cicchetto/e2e     the e2e stack, whose bring-up builds cicchetto-build-test
+#                     (its drivers cd into the dir and run a bare `compose up`,
+#                     so the service name never appears in their code)
+#   oven/bun          the raw bun oneshot scripts/bun.sh runs by image
+# Known limit: this reads text, so a launcher that resolves everything through
+# variables can still hide. That is what ROSTER is for, and why the two halves
+# cross-check each other below.
 launches_cic_build() {
-    code_of "$1" | grep -qE 'cicchetto-build|(bun|npm) run build'
+    code_of "$1" | grep -qE 'cicchetto-build|(bun|npm) run build|--profile prod|cicchetto/e2e|oven/bun'
 }
 
+# Compliance is BOTH halves. `export GRAPPA_VERSION=0.10.0` alone would pass an
+# export-only check while planting a second hand-edited version carrier —
+# exactly what the VERSION file is the single source of truth against.
 exports_version() {
     code_of "$1" | grep -q 'export GRAPPA_VERSION'
 }
 
 derives_version() {
     code_of "$1" | grep -q 'version\.sh'
+}
+
+complies() {
+    derives_version "$1" && exports_version "$1"
 }
 
 # The shell/build entrypoints a cic build can be launched from. compose files
@@ -76,13 +94,23 @@ candidate_files() {
     fi
 }
 
-# Echo every launcher under $1 that does NOT export GRAPPA_VERSION.
+# Echo every launcher under $1 that does not derive AND export GRAPPA_VERSION.
 unexported_launchers() {
     local root="$1" f
     while IFS= read -r f; do
         [ -n "$f" ] || continue
         launches_cic_build "$f" || continue
-        exports_version "$f" && continue
+        complies "$f" && continue
+        printf '%s\n' "${f#"$root"/}"
+    done < <(candidate_files "$root")
+}
+
+# Echo every launcher the scan can SEE under $1, compliant or not.
+discovered_launchers() {
+    local root="$1" f
+    while IFS= read -r f; do
+        [ -n "$f" ] || continue
+        launches_cic_build "$f" || continue
         printf '%s\n' "${f#"$root"/}"
     done < <(candidate_files "$root")
 }
@@ -109,6 +137,41 @@ unexported_launchers() {
         printf 'cic-build launchers with no GRAPPA_VERSION export (see #692):\n%s\n' "$output" >&2
         return 1
     }
+}
+
+@test "roster: every launcher the scan can see is on the roster" {
+    run discovered_launchers "$REPO_SRC"
+    [ "$status" -eq 0 ]
+
+    local unrostered=() found
+    while IFS= read -r found; do
+        [ -n "$found" ] || continue
+        local known=0 rel
+        for rel in "${ROSTER[@]}"; do
+            [ "$rel" = "$found" ] && known=1
+        done
+        [ "$known" -eq 1 ] || unrostered+=("$found")
+    done <<< "$output"
+
+    [ "${#unrostered[@]}" -eq 0 ] || {
+        printf 'cic-build launchers missing from ROSTER (add them, see #692):\n' >&2
+        printf '  %s\n' "${unrostered[@]}" >&2
+        return 1
+    }
+}
+
+@test "scan: RED — a launcher that hardcodes the version instead of deriving it is caught" {
+    local fake="$BATS_TEST_TMPDIR/repo"
+    mkdir -p "$fake/scripts"
+    cat > "$fake/scripts/ship-the-bundle.sh" <<'EOF'
+#!/usr/bin/env bash
+export GRAPPA_VERSION=0.10.0
+docker compose --profile prod run --rm cicchetto-build
+EOF
+
+    run unexported_launchers "$fake"
+    [ "$status" -eq 0 ]
+    [ "$output" = "scripts/ship-the-bundle.sh" ]
 }
 
 @test "scan: RED — a new launcher that forgets the export is caught" {

--- a/test/infra/cic_version_export_test.bats
+++ b/test/infra/cic_version_export_test.bats
@@ -48,6 +48,16 @@ code_of() {
     sed -e 's/[[:space:]]*#.*$//' "$1"
 }
 
+# Every predicate below pipes `code_of` into grep and DISCARDS the match rather
+# than using `grep -q`. `-q` exits on the first hit, which SIGPIPEs the sed
+# upstream; GNU sed then prints `couldn't write N items to stdout: Broken pipe`
+# on stderr (BSD sed stays silent, so this only ever reddened CI). bats' `run`
+# folds stderr into `$output`, so that noise BECAME the diagnostic: the guard
+# reported pipe errors instead of the launchers at fault, and a clean scan read
+# as a failure. Only files larger than the pipe buffer trip it, which is why
+# the synthetic fixtures below never showed it. Reading the stream to EOF costs
+# nothing on files this size and keeps the diagnostic honest.
+
 # A launcher is a file whose CODE can reach a cic build. Five signals, because
 # the launchers do not all name it the same way:
 #   cicchetto-build   the compose service (substring: also cicchetto-build-test)
@@ -62,18 +72,18 @@ code_of() {
 # variables can still hide. That is what ROSTER is for, and why the two halves
 # cross-check each other below.
 launches_cic_build() {
-    code_of "$1" | grep -qE 'cicchetto-build|(bun|npm) run build|--profile prod|cicchetto/e2e|oven/bun'
+    code_of "$1" | grep -E 'cicchetto-build|(bun|npm) run build|--profile prod|cicchetto/e2e|oven/bun' > /dev/null
 }
 
 # Compliance is BOTH halves. `export GRAPPA_VERSION=0.10.0` alone would pass an
 # export-only check while planting a second hand-edited version carrier —
 # exactly what the VERSION file is the single source of truth against.
 exports_version() {
-    code_of "$1" | grep -q 'export GRAPPA_VERSION'
+    code_of "$1" | grep 'export GRAPPA_VERSION' > /dev/null
 }
 
 derives_version() {
-    code_of "$1" | grep -q 'version\.sh'
+    code_of "$1" | grep 'version\.sh' > /dev/null
 }
 
 complies() {
@@ -168,6 +178,35 @@ discovered_launchers() {
 export GRAPPA_VERSION=0.10.0
 docker compose --profile prod run --rm cicchetto-build
 EOF
+
+    run unexported_launchers "$fake"
+    [ "$status" -eq 0 ]
+    [ "$output" = "scripts/ship-the-bundle.sh" ]
+}
+
+# The pin for the GNU-sed EPIPE incident. Two conditions must BOTH hold to
+# reproduce it, which is why it only ever fired on the CI runner:
+#   * the signal matches near the top and megabytes of code follow, so an
+#     early-exiting matcher closes the pipe with the writer mid-stream;
+#   * SIGPIPE is IGNORED, so sed is not killed silently — the write returns
+#     EPIPE and GNU sed reports it on stderr. GitHub's runner hands steps that
+#     disposition; an interactive shell does not, which is why this passed
+#     locally and reddened in CI.
+# `trap '' PIPE` reproduces the runner's disposition here, so the pin holds on
+# every platform. The assertion is EQUALITY with the filename — a diagnostic
+# carrying one extra line of pipe noise is a diagnostic that lies.
+@test "scan: a launcher larger than the pipe buffer yields a clean diagnostic" {
+    local fake="$BATS_TEST_TMPDIR/repo"
+    mkdir -p "$fake/scripts"
+    {
+        printf '#!/usr/bin/env bash\n'
+        printf 'docker compose --profile prod run --rm cicchetto-build\n'
+        yes 'echo padding past the pipe buffer' | head -40000
+    } > "$fake/scripts/ship-the-bundle.sh"
+
+    # AFTER the fixture: `yes | head` is itself an early-exiting pipeline, so
+    # arming the trap first would make the generator the thing that complains.
+    trap '' PIPE
 
     run unexported_launchers "$fake"
     [ "$status" -eq 0 ]

--- a/test/infra/cic_version_export_test.bats
+++ b/test/infra/cic_version_export_test.bats
@@ -48,15 +48,16 @@ code_of() {
     sed -e 's/[[:space:]]*#.*$//' "$1"
 }
 
-# Every predicate below pipes `code_of` into grep and DISCARDS the match rather
-# than using `grep -q`. `-q` exits on the first hit, which SIGPIPEs the sed
-# upstream; GNU sed then prints `couldn't write N items to stdout: Broken pipe`
-# on stderr (BSD sed stays silent, so this only ever reddened CI). bats' `run`
-# folds stderr into `$output`, so that noise BECAME the diagnostic: the guard
-# reported pipe errors instead of the launchers at fault, and a clean scan read
-# as a failure. Only files larger than the pipe buffer trip it, which is why
-# the synthetic fixtures below never showed it. Reading the stream to EOF costs
-# nothing on files this size and keeps the diagnostic honest.
+# Every predicate below feeds grep a HERE-STRING, never a pipe. A pipe into
+# `grep -q` exits on the first hit and leaves sed mid-stream; where SIGPIPE is
+# ignored (the disposition GitHub's runner hands a step) the write returns
+# EPIPE and GNU sed reports it on stderr, which the `run` sites then folded
+# into `$output` — the guard printed pipe noise instead of the launchers at
+# fault, and a clean scan read as a failure. BSD sed is silent on EPIPE, so it
+# only ever reddened CI. A here-string has no reader to close, so the condition
+# cannot arise; `--separate-stderr` below closes the other half (any OTHER
+# stderr, e.g. an unreadable candidate file, must not masquerade as a finding
+# either).
 
 # A launcher is a file whose CODE can reach a cic build. Five signals, because
 # the launchers do not all name it the same way:
@@ -72,18 +73,18 @@ code_of() {
 # variables can still hide. That is what ROSTER is for, and why the two halves
 # cross-check each other below.
 launches_cic_build() {
-    code_of "$1" | grep -E 'cicchetto-build|(bun|npm) run build|--profile prod|cicchetto/e2e|oven/bun' > /dev/null
+    grep -qE 'cicchetto-build|(bun|npm) run build|--profile prod|cicchetto/e2e|oven/bun' <<< "$(code_of "$1")"
 }
 
 # Compliance is BOTH halves. `export GRAPPA_VERSION=0.10.0` alone would pass an
 # export-only check while planting a second hand-edited version carrier —
 # exactly what the VERSION file is the single source of truth against.
 exports_version() {
-    code_of "$1" | grep 'export GRAPPA_VERSION' > /dev/null
+    grep -q 'export GRAPPA_VERSION' <<< "$(code_of "$1")"
 }
 
 derives_version() {
-    code_of "$1" | grep 'version\.sh' > /dev/null
+    grep -q 'version\.sh' <<< "$(code_of "$1")"
 }
 
 complies() {
@@ -141,8 +142,15 @@ discovered_launchers() {
 }
 
 @test "scan: no shell or build entrypoint launches a cic build without exporting GRAPPA_VERSION" {
-    run unexported_launchers "$REPO_SRC"
+    run --separate-stderr unexported_launchers "$REPO_SRC"
     [ "$status" -eq 0 ]
+    # The scan's own errors are not findings, and must not pass silently
+    # either — an unreadable candidate means the guard covered less than it
+    # claims (see the stderr note above).
+    [ -z "$stderr" ] || {
+        printf 'the scan itself errored (coverage is incomplete):\n%s\n' "$stderr" >&2
+        return 1
+    }
     [ -z "$output" ] || {
         printf 'cic-build launchers with no GRAPPA_VERSION export (see #692):\n%s\n' "$output" >&2
         return 1
@@ -150,8 +158,12 @@ discovered_launchers() {
 }
 
 @test "roster: every launcher the scan can see is on the roster" {
-    run discovered_launchers "$REPO_SRC"
+    run --separate-stderr discovered_launchers "$REPO_SRC"
     [ "$status" -eq 0 ]
+    [ -z "$stderr" ] || {
+        printf 'the scan itself errored (coverage is incomplete):\n%s\n' "$stderr" >&2
+        return 1
+    }
 
     local unrostered=() found
     while IFS= read -r found; do
@@ -179,7 +191,7 @@ export GRAPPA_VERSION=0.10.0
 docker compose --profile prod run --rm cicchetto-build
 EOF
 
-    run unexported_launchers "$fake"
+    run --separate-stderr unexported_launchers "$fake"
     [ "$status" -eq 0 ]
     [ "$output" = "scripts/ship-the-bundle.sh" ]
 }
@@ -192,9 +204,10 @@ EOF
 #     EPIPE and GNU sed reports it on stderr. GitHub's runner hands steps that
 #     disposition; an interactive shell does not, which is why this passed
 #     locally and reddened in CI.
-# `trap '' PIPE` reproduces the runner's disposition here, so the pin holds on
-# every platform. The assertion is EQUALITY with the filename — a diagnostic
-# carrying one extra line of pipe noise is a diagnostic that lies.
+# `trap '' PIPE` reproduces the runner's disposition, so the pin holds on every
+# platform. It asserts the SCAN IS SILENT (empty stderr) as well as exact — a
+# reader that abandons its writer is caught even though `--separate-stderr` now
+# keeps the noise out of the finding itself.
 @test "scan: a launcher larger than the pipe buffer yields a clean diagnostic" {
     local fake="$BATS_TEST_TMPDIR/repo"
     mkdir -p "$fake/scripts"
@@ -208,8 +221,9 @@ EOF
     # arming the trap first would make the generator the thing that complains.
     trap '' PIPE
 
-    run unexported_launchers "$fake"
+    run --separate-stderr unexported_launchers "$fake"
     [ "$status" -eq 0 ]
+    [ -z "$stderr" ]
     [ "$output" = "scripts/ship-the-bundle.sh" ]
 }
 
@@ -221,7 +235,7 @@ EOF
 docker compose --profile prod run --rm cicchetto-build
 EOF
 
-    run unexported_launchers "$fake"
+    run --separate-stderr unexported_launchers "$fake"
     [ "$status" -eq 0 ]
     [ "$output" = "scripts/ship-the-bundle.sh" ]
 }
@@ -236,7 +250,7 @@ export GRAPPA_VERSION
 docker compose --profile prod run --rm cicchetto-build
 EOF
 
-    run unexported_launchers "$fake"
+    run --separate-stderr unexported_launchers "$fake"
     [ "$status" -eq 0 ]
     [ -z "$output" ]
 }

--- a/test/infra/deploy_docker_update_test.bats
+++ b/test/infra/deploy_docker_update_test.bats
@@ -36,10 +36,16 @@ setup() {
     # ---- throwaway upstream + clone ------------------------------------
     UPSTREAM="$BATS_TEST_TMPDIR/upstream"
     git init -q -b main "$UPSTREAM"
-    mkdir -p "$UPSTREAM/infra/docker" "$UPSTREAM/infra/lib" "$UPSTREAM/runtime" "$UPSTREAM/lib"
+    mkdir -p "$UPSTREAM/infra/docker" "$UPSTREAM/infra/lib" "$UPSTREAM/infra/packaging" \
+             "$UPSTREAM/runtime" "$UPSTREAM/lib"
     cp "$REPO_SRC/infra/docker/deploy.sh" "$UPSTREAM/infra/docker/deploy.sh"
     cp "$REPO_SRC/infra/lib/deploy_common.sh" "$UPSTREAM/infra/lib/deploy_common.sh"
-    chmod +x "$UPSTREAM/infra/docker/deploy.sh"
+    # The REAL version carrier + extractor (#538/#652): source mode derives
+    # GRAPPA_VERSION from them at init so every compose call inherits it, and a
+    # cic build with an empty value is refused by vite (#692).
+    cp "$REPO_SRC/VERSION" "$UPSTREAM/VERSION"
+    cp "$REPO_SRC/infra/packaging/version.sh" "$UPSTREAM/infra/packaging/version.sh"
+    chmod +x "$UPSTREAM/infra/docker/deploy.sh" "$UPSTREAM/infra/packaging/version.sh"
     # The ownership guard reads container_name out of compose.yaml.
     cat > "$UPSTREAM/compose.yaml" <<'EOF'
 services:
@@ -76,6 +82,12 @@ EOF
     cat > "$FAKE_DIR/docker" <<'EOF'
 #!/usr/bin/env bash
 printf 'docker %s\n' "$*" >> "$ARGV_LOG"
+# Record the value the cic build would actually SEE. compose passes
+# `GRAPPA_VERSION: ${GRAPPA_VERSION:-}` through from this environment, so an
+# unexported variable reaches vite empty and the build refuses to run (#692).
+case "$*" in
+    *cicchetto-build*) printf 'env GRAPPA_VERSION=%s\n' "${GRAPPA_VERSION:-}" >> "$ARGV_LOG" ;;
+esac
 if [ "$1" = inspect ]; then
     [ -n "${FAKE_OWNER_DIR:-}" ] || exit 1
     printf '%s\n' "$FAKE_OWNER_DIR"
@@ -182,6 +194,18 @@ run_update() {
     [ "$status" -eq 0 ]
     grep -q "up -d --force-recreate" "$ARGV_LOG"
     ! grep -q "exec -T grappa curl.*reload" "$ARGV_LOG"
+}
+
+@test "update: the cold cic rebuild carries GRAPPA_VERSION from the VERSION file (#692)" {
+    export PREFLIGHT_RC=3
+    commit_upstream lib/base.txt > /dev/null
+
+    run_update
+    [ "$status" -eq 0 ]
+    grep -q "run --rm cicchetto-build" "$ARGV_LOG"
+    # Exact value, not just "non-empty": the bundle bakes it into
+    # <meta cicchetto-version>, so a wrong number is as bad as a missing one.
+    grep -Fqx "env GRAPPA_VERSION=$(cat "$REPO_ROOT/VERSION")" "$ARGV_LOG"
 }
 
 @test "update: preflight non-verdict exit aborts and propagates the code" {

--- a/test/infra/deploy_docker_update_test.bats
+++ b/test/infra/deploy_docker_update_test.bats
@@ -124,6 +124,15 @@ commit_upstream() {
     git -C "$UPSTREAM" rev-parse HEAD
 }
 
+# Land a version bump upstream, the way a real release does: VERSION only, no
+# deploy-code change — so the re-exec guard does NOT fire and the running
+# process keeps whatever it derived before the pull.
+bump_upstream_version() {
+    printf '%s\n' "$1" > "$UPSTREAM/VERSION"
+    git -C "$UPSTREAM" add -A
+    git -C "$UPSTREAM" commit -qm "bump to $1"
+}
+
 run_update() {
     cd "$REPO_ROOT"
     run "$DEPLOY" update "$@"
@@ -206,6 +215,20 @@ run_update() {
     # Exact value, not just "non-empty": the bundle bakes it into
     # <meta cicchetto-version>, so a wrong number is as bad as a missing one.
     grep -Fqx "env GRAPPA_VERSION=$(cat "$REPO_ROOT/VERSION")" "$ARGV_LOG"
+}
+
+@test "update: the cic rebuild carries the version the pull brought IN, not the one the box was on (#692)" {
+    export PREFLIGHT_RC=3
+    was_on="$(cat "$REPO_ROOT/VERSION")"
+    bump_upstream_version 99.99.99
+
+    run_update
+    [ "$status" -eq 0 ]
+    # Deriving before the pull still "works" — the build succeeds and bakes the
+    # PREVIOUS number into <meta cicchetto-version>, which is the silent
+    # staleness #652 exists to prevent. Pin both halves.
+    grep -Fqx "env GRAPPA_VERSION=99.99.99" "$ARGV_LOG"
+    ! grep -Fqx "env GRAPPA_VERSION=$was_on" "$ARGV_LOG"
 }
 
 @test "update: preflight non-verdict exit aborts and propagates the code" {

--- a/test/infra/deploy_docker_verbs_test.bats
+++ b/test/infra/deploy_docker_verbs_test.bats
@@ -25,12 +25,18 @@
 setup() {
     REPO_SRC="$BATS_TEST_DIRNAME/../.."
     BOX="$BATS_TEST_TMPDIR/box"
-    mkdir -p "$BOX/infra/docker" "$BOX/infra/lib" "$BOX/infra"
+    mkdir -p "$BOX/infra/docker" "$BOX/infra/lib" "$BOX/infra/packaging" "$BOX/infra"
 
     cp "$REPO_SRC/infra/docker/deploy.sh" "$BOX/infra/docker/"
     cp "$REPO_SRC/infra/lib/deploy_common.sh" "$BOX/infra/lib/"
     cp "$REPO_SRC/infra/nginx-tls-frontend.example.conf" "$BOX/infra/"
     cp "$REPO_SRC/.env.example" "$BOX/.env.example"
+    # The REAL version carrier + extractor (#538/#652): source mode derives
+    # GRAPPA_VERSION from them at init, so the cic build the prod profile pulls
+    # in gets a real number instead of refusing to start (#692).
+    cp "$REPO_SRC/VERSION" "$BOX/VERSION"
+    cp "$REPO_SRC/infra/packaging/version.sh" "$BOX/infra/packaging/version.sh"
+    chmod +x "$BOX/infra/packaging/version.sh"
     # Preflight checks its presence, and the ownership guard reads the
     # pinned container names out of it — those pins are what makes two
     # checkouts collide on one docker daemon (#485 dropped the nginx one).
@@ -54,6 +60,14 @@ EOF
 printf 'docker' >> "$ARGV_LOG"
 for a in "\$@"; do printf ' %q' "\$a" >> "$ARGV_LOG"; done
 printf '\n' >> "$ARGV_LOG"
+# Record the value a cic build would actually SEE. compose passes
+# \`GRAPPA_VERSION: \${GRAPPA_VERSION:-}\` through from this environment — the
+# prod profile pulls the cicchetto-build oneshot in via depends_on, so \`up -d\`
+# counts as a cic build launch just like an explicit run does (#692).
+case "\$*" in
+    *cicchetto-build*|*"up -d"*)
+        printf 'env GRAPPA_VERSION=%s\n' "\${GRAPPA_VERSION:-}" >> "$ARGV_LOG" ;;
+esac
 if [ "\$1" = inspect ]; then
     [ -n "\${FAKE_OWNER_DIR:-}" ] || exit 1
     printf '%s\n' "\$FAKE_OWNER_DIR"
@@ -74,6 +88,14 @@ stub_docker_failing_on() {
 printf 'docker' >> "$ARGV_LOG"
 for a in "\$@"; do printf ' %q' "\$a" >> "$ARGV_LOG"; done
 printf '\n' >> "$ARGV_LOG"
+# Record the value a cic build would actually SEE. compose passes
+# \`GRAPPA_VERSION: \${GRAPPA_VERSION:-}\` through from this environment — the
+# prod profile pulls the cicchetto-build oneshot in via depends_on, so \`up -d\`
+# counts as a cic build launch just like an explicit run does (#692).
+case "\$*" in
+    *cicchetto-build*|*"up -d"*)
+        printf 'env GRAPPA_VERSION=%s\n' "\${GRAPPA_VERSION:-}" >> "$ARGV_LOG" ;;
+esac
 for a in "\$@"; do
   [ "\$a" = "$1" ] && exit 1
 done
@@ -201,6 +223,14 @@ EOF
     themes_line="$(grep -n 'grappa.seed_themes' "$ARGV_LOG" | head -n1 | cut -d: -f1)"
     up_line="$(grep -n 'up -d' "$ARGV_LOG" | head -n1 | cut -d: -f1)"
     [ -n "$themes_line" ] && [ -n "$up_line" ] && [ "$themes_line" -lt "$up_line" ]
+}
+
+@test "install: the stack comes up carrying GRAPPA_VERSION from the VERSION file (#692)" {
+    run "$DEPLOY" install
+    [ "$status" -eq 0 ]
+    # Exact value, not just "non-empty": the bundle bakes it into
+    # <meta cicchetto-version>, so a wrong number is as bad as a missing one.
+    grep -Fqx "env GRAPPA_VERSION=$(cat "$BOX/VERSION")" "$ARGV_LOG"
 }
 
 @test "install: a theme seeding failure is a warning, not a failed install" {


### PR DESCRIPTION
## What was broken

`infra/docker/deploy.sh` — the self-hosted Docker path documented in `INSTALL.md` — never exported `GRAPPA_VERSION`. Since the #538/#652 guard landed in `cicchetto/vite.config.ts` (refuse to build rather than bake an empty `<meta cicchetto-version>`), **every self-hosted `install` / `update` that reached a cic build died**. Ten other wrappers export it; this one was missed, and nothing in CI exercised it, so it surfaced on a real box.

## Two doors, not one

The issue named `substrate_cic` (the `update` cold path's explicit `run --rm cicchetto-build`). `install` reaches the same oneshot by a different route: the service carries `profiles: [prod]`, so `--profile prod up -d` starts it outright. Patching only the hook would have left `install` broken.

## Derived at each launch point, not once at startup

The first cut derived once in the source-mode init block. Code review killed it, and it was worth killing:

- `update` **pulls before it builds**, and `deploy_common`'s re-exec guard only re-enters the script when the pulled range touched the deploy code — which a release pull does not. A startup derive therefore stamps the bundle with the version the box was **already on**. That build *succeeds*, so the refresh banner quietly advertises the old number — worse than the crash it replaced.
- It also made `stop` depend on a readable `VERSION`, against `cmd_stop`'s own principle that a box you cannot bring down because a file went missing is a trap.

One `export_cic_version` helper, called from `cmd_install` before the prod `up` and from `substrate_cic` after the pull. Release-image mode does not derive at all — no checkout to read `VERSION` from, and the SPA is baked into the published image.

## Why a guard instead of a shared helper

The pair now sits in eleven launchers. A partial helper IS available and was declined: the five `scripts/*.sh` launchers already source `scripts/_lib.sh`, but the other six cannot use it (POSIX sh in the FreeBSD jail, the Linux builder, a `Dockerfile` RUN layer, a PKGBUILD `build()`, and this deliberately standalone installer). Five-of-eleven is a half-migration — two patterns, and the next author copies whichever is nearer. The cost of the duplication is drift, so the cure is aimed at drift.

`test/infra/cic_version_export_test.bats` pins the roster (fails when an export is **removed**), rediscovers launchers from what their code invokes (fails when one is **added** without it — this bug), requires the *derive* and not just the export (`export GRAPPA_VERSION=0.10.0` would plant a second hand-edited carrier), and cross-checks its halves so a discovered launcher missing from the roster fails too. It proves itself RED against synthetic launchers. Its limit is documented where it lives: it reads text, so a launcher hiding the service name behind variables is roster business.

## Test plan

- [x] `scripts/bats.sh` FULL set (bin + infra + scripts): **256 ok, 0 failed, rc=0**
- [x] New tests proven RED before the fix, on both doors (`install` and cold `update`)
- [x] Pre-pull staleness proven RED by re-injecting the startup derive: the freshness test fails, and the naive "exact VERSION contents" test stays green — which is why the freshness one exists
- [x] `shellcheck -x infra/docker/deploy.sh` clean (the CI gate's own invocation)
- [x] `deploy_docker_*` harnesses now copy the real `VERSION` + `infra/packaging/version.sh` into their throwaway checkouts

Not run: no Elixir touched, so no `mix` gate applies here — CI covers it.

Refs #692