### PR TITLE
feat(#695): throw the document away after a two-day absence

### DIFF
--- a/cicchetto/src/__tests__/staleResume.test.ts
+++ b/cicchetto/src/__tests__/staleResume.test.ts
@@ -1,0 +1,284 @@
+import { createRoot, createSignal } from "solid-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_STALE_RESUME_HOURS,
+  installStaleResumeReload,
+  isStaleResume,
+  markActive,
+  readLastActive,
+  STALE_RESUME_HOURS_KEY,
+  STALE_RESUME_STAMP_KEY,
+  staleResumeThresholdMs,
+} from "../lib/staleResume";
+
+// #695 — reload the whole client on resume after a prolonged absence.
+//
+// The interval is measured from a PERSISTED stamp, never from a timer: the
+// whole point is a document iOS suspended for two days, with no JS running
+// for the entire window. Every test here therefore drives `now` as a plain
+// value and never advances a fake clock — if a test needed a timer to trip
+// the threshold, the implementation would be measuring the wrong thing.
+
+const HOUR = 3_600_000;
+
+// setupTests.ts installs a fresh localStorage per test but leaves jsdom's
+// sessionStorage — where the stamp lives — untouched, so it would bleed the
+// stamp between cases.
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+// Solid's effect queue is flushed on a macrotask (same idiom as
+// badge.test.ts's mountBadgeSync case).
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+interface Harness {
+  visible: (v: boolean) => void;
+  pageshow: () => void;
+  // The verb `installStaleResumeReload` hands back — what main.tsx wires into
+  // the #318 foreground heartbeat.
+  heartbeatTick: () => void;
+  setNow: (t: number) => void;
+  reload: ReturnType<typeof vi.fn>;
+  dispose: () => void;
+}
+
+function install(startNow: number): Harness {
+  let now = startNow;
+  const reload = vi.fn();
+  const [isVisible, setVisible] = createSignal(true);
+  const handlers: Array<() => void> = [];
+  let dispose = (): void => {};
+  let check = (): void => {};
+  createRoot((d) => {
+    dispose = d;
+    check = installStaleResumeReload({
+      isVisible,
+      now: () => now,
+      reload,
+      win: {
+        addEventListener: (_event: "pageshow", handler: () => void) => {
+          handlers.push(handler);
+        },
+      },
+    });
+  });
+  return {
+    visible: setVisible,
+    pageshow: () => {
+      for (const h of handlers) h();
+    },
+    heartbeatTick: () => check(),
+    setNow: (t: number) => {
+      now = t;
+    },
+    reload,
+    dispose,
+  };
+}
+
+describe("staleResume — threshold resolution", () => {
+  it("defaults to 48h when no override is stored", () => {
+    expect(DEFAULT_STALE_RESUME_HOURS).toBe(48);
+    expect(staleResumeThresholdMs()).toBe(48 * HOUR);
+  });
+
+  it("honours a stored override, so the threshold moves without a deploy", () => {
+    localStorage.setItem(STALE_RESUME_HOURS_KEY, "6");
+    expect(staleResumeThresholdMs()).toBe(6 * HOUR);
+  });
+
+  it("falls back to the default on a non-numeric override", () => {
+    localStorage.setItem(STALE_RESUME_HOURS_KEY, "soon");
+    expect(staleResumeThresholdMs()).toBe(DEFAULT_STALE_RESUME_HOURS * HOUR);
+  });
+
+  it("falls back to the default on a non-positive override — a typo must not reload on every resume", () => {
+    localStorage.setItem(STALE_RESUME_HOURS_KEY, "0");
+    expect(staleResumeThresholdMs()).toBe(DEFAULT_STALE_RESUME_HOURS * HOUR);
+    localStorage.setItem(STALE_RESUME_HOURS_KEY, "-3");
+    expect(staleResumeThresholdMs()).toBe(DEFAULT_STALE_RESUME_HOURS * HOUR);
+  });
+});
+
+describe("staleResume — the persisted stamp", () => {
+  it("markActive writes the stamp and readLastActive reads it back", () => {
+    markActive(1_700_000_000_000);
+    expect(readLastActive()).toBe(1_700_000_000_000);
+  });
+
+  it("lives in sessionStorage, so a foreground tab in another window cannot refresh it", () => {
+    markActive(1_700_000_000_000);
+    expect(sessionStorage.getItem(STALE_RESUME_STAMP_KEY)).toBe("1700000000000");
+    expect(localStorage.getItem(STALE_RESUME_STAMP_KEY)).toBeNull();
+  });
+
+  it("readLastActive is null when nothing was ever stamped", () => {
+    expect(readLastActive()).toBeNull();
+  });
+
+  it("readLastActive is null on a corrupt stamp", () => {
+    sessionStorage.setItem(STALE_RESUME_STAMP_KEY, "yesterday");
+    expect(readLastActive()).toBeNull();
+  });
+});
+
+describe("isStaleResume — the decision", () => {
+  const t0 = 1_700_000_000_000;
+
+  it("is false under the threshold", () => {
+    expect(isStaleResume(t0 + 47 * HOUR, t0, 48 * HOUR)).toBe(false);
+  });
+
+  it("is false exactly at the threshold", () => {
+    expect(isStaleResume(t0 + 48 * HOUR, t0, 48 * HOUR)).toBe(false);
+  });
+
+  it("is true over the threshold", () => {
+    expect(isStaleResume(t0 + 48 * HOUR + 1, t0, 48 * HOUR)).toBe(true);
+  });
+
+  it("is false with no stamp — a first-ever boot has nothing to be stale against", () => {
+    expect(isStaleResume(t0 + 1000 * HOUR, null, 48 * HOUR)).toBe(false);
+  });
+
+  it("is false on a future-dated stamp — a backwards clock step must not reload", () => {
+    expect(isStaleResume(t0, t0 + 10 * HOUR, 48 * HOUR)).toBe(false);
+  });
+});
+
+describe("installStaleResumeReload", () => {
+  const t0 = 1_700_000_000_000;
+
+  it("stamps this document active at install, so the document that just reloaded does not reload again", async () => {
+    // The stale stamp survives the reload (same window, same sessionStorage).
+    // Without the pre-arm write the fresh document would read it, trip, and
+    // reload again — the loop the issue calls out by name.
+    markActive(t0 - 336 * HOUR);
+    const h = install(t0);
+    await flush();
+    expect(h.reload).not.toHaveBeenCalled();
+    expect(readLastActive()).toBe(t0);
+    h.dispose();
+  });
+
+  it("does not reload on a resume under the threshold", async () => {
+    const h = install(t0);
+    await flush();
+    h.visible(false);
+    await flush();
+    h.setNow(t0 + 47 * HOUR);
+    h.visible(true);
+    await flush();
+    expect(h.reload).not.toHaveBeenCalled();
+    h.dispose();
+  });
+
+  it("reloads on a resume over the threshold, driven by the stamp with no timer running", async () => {
+    const h = install(t0);
+    await flush();
+    h.visible(false);
+    await flush();
+    // The OS suspended the document here: no heartbeat tick, no
+    // visibilitychange, no JS at all for 50 hours. Only the stamp survives.
+    expect(readLastActive()).toBe(t0);
+    h.setNow(t0 + 50 * HOUR);
+    h.visible(true);
+    await flush();
+    expect(h.reload).toHaveBeenCalledTimes(1);
+    h.dispose();
+  });
+
+  it("refreshes the stamp as it reloads, so more triggers cannot stack a second reload", async () => {
+    const h = install(t0);
+    await flush();
+    h.visible(false);
+    await flush();
+    h.setNow(t0 + 50 * HOUR);
+    h.visible(true);
+    await flush();
+    // More resume triggers arrive before the navigation completes — a
+    // pageshow and another visibility round-trip.
+    h.pageshow();
+    h.visible(false);
+    await flush();
+    h.visible(true);
+    await flush();
+    expect(h.reload).toHaveBeenCalledTimes(1);
+    // And the document is left healthy rather than wedged: a reload that
+    // never lands must not disable the feature for this document's whole
+    // remaining life.
+    expect(readLastActive()).toBe(t0 + 50 * HOUR);
+    h.dispose();
+  });
+
+  it("re-arms after a reload that never landed — a later genuine absence still trips", async () => {
+    const h = install(t0);
+    await flush();
+    h.setNow(t0 + 50 * HOUR);
+    h.pageshow();
+    expect(h.reload).toHaveBeenCalledTimes(1);
+    // The navigation was blocked; this document lives on and is used again.
+    h.setNow(t0 + 200 * HOUR);
+    h.pageshow();
+    expect(h.reload).toHaveBeenCalledTimes(2);
+    h.dispose();
+  });
+
+  it("trips on the foreground heartbeat tick — the iOS thaw that fires no visibility transition", async () => {
+    const h = install(t0);
+    await flush();
+    // iOS froze the document without firing visibilitychange, so the signal
+    // never changed and pageshow never fired. The interval was frozen too;
+    // its first tick after the thaw is the only observer left.
+    h.setNow(t0 + 50 * HOUR);
+    h.heartbeatTick();
+    expect(h.reload).toHaveBeenCalledTimes(1);
+    h.dispose();
+  });
+
+  it("a heartbeat tick during genuine foreground use only refreshes the stamp", async () => {
+    const h = install(t0);
+    await flush();
+    h.setNow(t0 + 30_000);
+    h.heartbeatTick();
+    expect(h.reload).not.toHaveBeenCalled();
+    expect(readLastActive()).toBe(t0 + 30_000);
+    h.dispose();
+  });
+
+  it("reloads on a pageshow — the bfcache restore the visibility signal never sees", async () => {
+    const h = install(t0);
+    await flush();
+    h.setNow(t0 + 50 * HOUR);
+    h.pageshow();
+    expect(h.reload).toHaveBeenCalledTimes(1);
+    h.dispose();
+  });
+
+  it("refreshes the stamp on every trigger while still fresh", async () => {
+    const h = install(t0);
+    await flush();
+    h.setNow(t0 + 2 * HOUR);
+    h.visible(false);
+    await flush();
+    expect(readLastActive()).toBe(t0 + 2 * HOUR);
+    h.setNow(t0 + 3 * HOUR);
+    h.pageshow();
+    expect(readLastActive()).toBe(t0 + 3 * HOUR);
+    h.dispose();
+  });
+
+  it("honours the stored override — a 6h threshold trips on a 7h absence", async () => {
+    localStorage.setItem(STALE_RESUME_HOURS_KEY, "6");
+    const h = install(t0);
+    await flush();
+    h.visible(false);
+    await flush();
+    h.setNow(t0 + 7 * HOUR);
+    h.visible(true);
+    await flush();
+    expect(h.reload).toHaveBeenCalledTimes(1);
+    h.dispose();
+  });
+});

--- a/cicchetto/src/lib/staleResume.ts
+++ b/cicchetto/src/lib/staleResume.ts
@@ -1,0 +1,142 @@
+import { type Accessor, createEffect } from "solid-js";
+
+// #695 — reload the whole client on resume after a prolonged absence.
+//
+// A long-lived PWA document degrades ("Safari goes mad after a while"), so a
+// document iOS suspended for two days is worth throwing away rather than
+// resuming. Deliberately independent of the bundle-hash refresh (#674): that
+// one fires on a deploy, this one on elapsed inactivity whether or not a new
+// bundle exists. Both reach the SAME reload verb — `bundleHash.performRefresh`
+// — because a second reload path beside it would be a second consumer of the
+// same SW/cache dance (the three-presses-to-update bug it exists to fix).
+//
+// The interval is measured from a PERSISTED stamp, never from in-memory state
+// or a timer. That is the whole point: the document may have been frozen for
+// the entire window with no JS running, so nothing in the page can have
+// counted the hours. Only storage crosses the suspension.
+//
+// TWO STORES, on purpose:
+//   * the stamp lives in sessionStorage — it means "when was THIS document
+//     last alive", and sessionStorage is exactly per-window-lifetime: it
+//     survives a reload and a suspension, and it does not leak between tabs.
+//     In localStorage a foreground desktop tab would keep refreshing the
+//     shared stamp and the suspended PWA — the degraded document this whole
+//     feature exists for — would never trip.
+//   * the threshold override lives in localStorage: device-wide operator
+//     config that must outlive any one window.
+//
+// ONE RULE keeps "reload exactly once" true: every check stamps, and the
+// stale ones also reload. Because the stamp is refreshed as the reload is
+// requested, no later trigger in this document can see the same absence
+// twice, and a reload that never lands (a blocked navigation, the e2e
+// `__refreshProbe`) leaves the document healthy rather than wedged — a
+// boolean latch would have disabled the feature for that document's whole
+// remaining life. `installStaleResumeReload` also stamps BEFORE arming any
+// trigger, so the document that just reloaded cannot immediately reload on
+// the absence it was itself the answer to.
+//
+// Threshold: 48h by default (24h was considered and rejected as too eager),
+// overridable per device via `localStorage["cicchetto.staleResumeHours"]` so
+// the number can be tuned without a deploy-shaped argument. An absent,
+// non-numeric or non-positive override falls back to the default — a typo
+// must never turn into "reload on every resume".
+
+export const STALE_RESUME_STAMP_KEY = "cicchetto.lastActiveAt";
+export const STALE_RESUME_HOURS_KEY = "cicchetto.staleResumeHours";
+export const DEFAULT_STALE_RESUME_HOURS = 48;
+
+const MS_PER_HOUR = 3_600_000;
+
+// The `pageshow` seam. Narrow on purpose: `installStaleResumeReload` has no
+// uninstall path (a real listener outlives its test), so unit tests pass a
+// fake rather than the real window — the same shape #649 uses for the
+// viewport resume triggers.
+export interface ResumeWindowLike {
+  addEventListener(event: "pageshow", handler: () => void): void;
+}
+
+export interface StaleResumeDeps {
+  // The visibility SSOT (`documentVisibility.ts` — visibilitychange AND
+  // window focus/blur). Consumed as a signal rather than re-registering
+  // parallel listeners.
+  isVisible: Accessor<boolean>;
+  now: () => number;
+  reload: () => void;
+  win: ResumeWindowLike;
+}
+
+/** The effective inactivity threshold in ms — the stored override, else 48h. */
+export function staleResumeThresholdMs(): number {
+  const raw = localStorage.getItem(STALE_RESUME_HOURS_KEY);
+  const hours = raw === null ? Number.NaN : Number(raw);
+  const effective = Number.isFinite(hours) && hours > 0 ? hours : DEFAULT_STALE_RESUME_HOURS;
+  return effective * MS_PER_HOUR;
+}
+
+/** Record that this document was alive at `now`. */
+export function markActive(now: number): void {
+  sessionStorage.setItem(STALE_RESUME_STAMP_KEY, String(now));
+}
+
+/** The persisted stamp, or null when absent or unparseable. */
+export function readLastActive(): number | null {
+  const raw = sessionStorage.getItem(STALE_RESUME_STAMP_KEY);
+  if (raw === null) return null;
+  const stamp = Number(raw);
+  return Number.isFinite(stamp) ? stamp : null;
+}
+
+/**
+ * Has the document been away long enough to be worth throwing away?
+ *
+ * Strictly greater than the threshold, and false with no stamp — a
+ * first-ever boot has nothing to be stale against.
+ */
+export function isStaleResume(
+  now: number,
+  lastActive: number | null,
+  thresholdMs: number,
+): boolean {
+  return lastActive !== null && now - lastActive > thresholdMs;
+}
+
+/**
+ * Arm the stale-resume reload and return the check verb.
+ *
+ * Checks on every resume trigger: the visibility signal (tab switch,
+ * app-switch, desktop focus) and `pageshow` (the bfcache/PWA restore whose
+ * computed visibility never changed, so the signal never fires). The returned
+ * verb is that SAME check, handed to the #318 foreground heartbeat by
+ * `main.tsx` — on iOS the background transition frequently never fires at
+ * all, and the first tick after a thaw is then the only trigger that can
+ * observe the absence. Handing out the check rather than the stamp writer
+ * keeps ONE writer of the stamp: a caller that stamped without checking would
+ * erase the very evidence the feature runs on.
+ *
+ * Overlapping triggers are free: the check is idempotent once the stamp is
+ * refreshed, exactly as #649 argues for its three viewport resume triggers.
+ */
+export function installStaleResumeReload(deps: StaleResumeDeps): () => void {
+  const check = (): void => {
+    const now = deps.now();
+    const stale = isStaleResume(now, readLastActive(), staleResumeThresholdMs());
+    // Stamp FIRST, unconditionally: this is what makes the reload fire once
+    // per absence rather than once per trigger.
+    markActive(now);
+    if (stale) deps.reload();
+  };
+
+  // BEFORE arming anything — see the loop guard in the module header.
+  markActive(deps.now());
+
+  deps.win.addEventListener("pageshow", check);
+  createEffect(() => {
+    // Tracked: any visibility transition, in either direction. Going hidden
+    // stamps the precise moment the operator left, which is a better
+    // baseline than the last heartbeat tick.
+    deps.isVisible();
+    check();
+  });
+
+  return check;
+}

--- a/cicchetto/src/main.tsx
+++ b/cicchetto/src/main.tsx
@@ -15,6 +15,7 @@ import ShareConsume from "./ShareConsume";
 import "./lib/subscribe";
 import "./lib/userTopic";
 import { mountBadgeReconcile, mountBadgeSync } from "./lib/badge";
+import { performRefresh } from "./lib/bundleHash";
 import { applyCachedCustomTheme, mountCustomThemeSync } from "./lib/customTheme";
 import { mountDisplayPrefsSync } from "./lib/displayPrefs";
 import { isDocumentVisible } from "./lib/documentVisibility";
@@ -26,6 +27,7 @@ import { installPushResubscribe } from "./lib/pushResubscribe";
 import { applyPushTargetFromUrl, installPushTargetListener } from "./lib/pushTarget";
 import { applySidebarWidthsFromStorage } from "./lib/sidebarWidths";
 import { notifyClientClosing, reportVisibility } from "./lib/socket";
+import { installStaleResumeReload } from "./lib/staleResume";
 import { recordSwRegError, recordSwRegistered } from "./lib/swRegistration";
 import { applyTheme } from "./lib/theme";
 import { installSmartScrollPin, installViewportHeightTracker } from "./lib/viewportHeight";
@@ -228,8 +230,29 @@ window.addEventListener("beforeunload", notifyClientClosing);
 // suspend OR whose visibilityState silently flips (reportVisibility re-reads
 // the live property each tick). Reuses the `visibility` verb — see
 // lib/visibilityHeartbeat.ts. Stops the interval when hidden.
+// #695 — throw the document away on resume after a prolonged absence (48h by
+// default). A long-lived PWA document degrades, and after two days suspended
+// it is worth reloading rather than resuming. Measured from a persisted
+// stamp — no timer can have run across the suspension — and reloaded through
+// `performRefresh`, the SAME SW-aware verb the #674 refresh banner uses,
+// never a second reload path beside it.
+//
+// The heartbeat below runs the returned CHECK, not a bare stamp write: on iOS
+// the background transition frequently never fires, so the interval is simply
+// frozen with the document and its first tick after the thaw is the only
+// trigger that can observe the absence at all. A tick that stamped without
+// checking would erase the evidence instead of acting on it.
 createRoot(() => {
-  const heartbeat = createVisibilityHeartbeat(reportVisibility);
+  const checkStaleResume = installStaleResumeReload({
+    isVisible: isDocumentVisible,
+    now: () => Date.now(),
+    reload: () => void performRefresh(),
+    win: window,
+  });
+  const heartbeat = createVisibilityHeartbeat(() => {
+    reportVisibility();
+    checkStaleResume();
+  });
   createEffect(() => {
     const visible = isDocumentVisible();
     reportVisibility();

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -26999,3 +26999,138 @@ share code, make the invariant testable instead of pretending a helper is
 possible. And when a value is derived for a deploy, derive it where it is USED:
 anything read before the pull describes the box you are leaving, and a stale
 number that still builds is harder to notice than one that crashes.
+---
+
+## 2026-08-03 — #695: a two-day absence is worth throwing the document away, and only a stamp can measure it
+
+**The ask.** Reload the whole cic client on reopen after a prolonged absence.
+Threshold **48h**; 24h was considered and rejected as too eager. Reason: a
+long-lived PWA document degrades — *"Safari goes mad after a while"* — so a
+document iOS has kept suspended for two days is worth discarding rather than
+resuming.
+
+**Filed together with #693 on purpose, and that pairing is now satisfied.**
+Shipping the reload alone "would look like a fix and change nothing the
+operator can see", because a reload re-entered the same cursor-anchored
+scrollback branch and put the operator back exactly where they were stuck.
+#693 landed the tail-anchored resume; this is the other half.
+
+**Only a persisted stamp can measure the interval.** The premise is a document
+with NO JS running for the whole window — frozen or suspended by the OS. Every
+in-page mechanism for counting elapsed time (a timer, an in-memory `bootedAt`,
+a heartbeat counter) is by construction unable to observe an interval during
+which it did not run. Storage is the only thing that crosses the suspension, so
+the stamp — not a clock — is the measurement. The unit tests encode that: none
+of them advance a fake timer, they move `now` and assert on the stamp. A test
+that needed a timer to trip the threshold would be proving the implementation
+measures the wrong thing.
+
+**Two stores, two different lifetimes.** The stamp lives in **sessionStorage**;
+the threshold override in **localStorage**. The stamp answers "when was THIS
+document last alive", and sessionStorage is exactly per-window-lifetime — it
+survives a reload and a suspension, and it does not leak between tabs. In
+localStorage a foreground desktop tab's heartbeat would keep refreshing the
+shared key every 30s and the suspended iPhone PWA — the degraded document this
+whole feature exists for — would never trip. That is a false negative aimed
+squarely at the reported scenario, so the store choice is load-bearing, not
+incidental. The threshold, by contrast, is device-wide operator config and must
+outlive any one window.
+
+**"Exactly once" is ONE rule, not a latch.** Every check stamps; the stale ones
+also reload. Because the stamp is refreshed *as* the reload is requested, no
+later trigger in the same document can see the same absence twice. The first
+draft used a boolean latch instead and it was worse in a way that only shows up
+when the reload does not land: `performRefresh` swallows every error and ends
+in a `window.location.reload()` that a blocked navigation (or the e2e
+`__refreshProbe`) can decline, and a latched document would then have the
+feature disabled for its entire remaining life. Stamping instead of latching
+self-heals — a later genuine 3-day absence in the same document still trips —
+and removes state rather than adding it.
+
+The second half of the guard is that `installStaleResumeReload` stamps
+**before** it arms any trigger. The stale stamp survives the reload (same
+window, same sessionStorage), so without the pre-arm write the fresh document
+would read it, trip, and reload again: the loop the issue calls out by name.
+
+Both guards were mutation-checked rather than assumed. Removing the pre-arm
+stamp fails *"stamps this document active at install…"* with `expected
+"vi.fn()" to not be called at all, but actually been called 1 times`; making
+the stamp conditional (skipping it on the reload path) fails *"refreshes the
+stamp as it reloads…"* with `expected "vi.fn()" to be called 1 times, but got 4
+times`.
+
+**The heartbeat runs the CHECK, not a stamp write — and that is the whole iOS
+path.** The #318 foreground visibility heartbeat already ticks every 30s, so
+#695 adds no timer of its own. The first draft had the tick call `markActive`.
+That was a real bug, and it killed the feature on its primary target: per
+#318's own module header, iOS does not reliably fire `visibilitychange`, so an
+app-switch can freeze the document with no hidden transition at all. The
+interval freezes with it; on thaw the pending callback fires, the stamp gets
+refreshed, `isDocumentVisible()` never changed value so the Solid effect never
+re-runs, and `pageshow` does not fire for a freeze/resume. The one trigger that
+could have seen the absence had just erased the evidence. `installStaleResumeReload`
+therefore **returns** the check verb and the heartbeat calls that — which also
+leaves the stamp with exactly one writer.
+
+**Triggers: the visibility signal, `pageshow`, and that heartbeat tick.**
+`documentVisibility.ts` is the SSOT for "is the operator looking at this?"
+(visibilitychange AND window focus/blur — raw visibilitychange alone misses the
+unfocused-but-visible desktop tab, #192), so the check hangs off that signal
+rather than registering parallel listeners. `pageshow` covers the bfcache/PWA
+restore whose computed visibility never changed. Overlap between the three is
+free: once the stamp is refreshed the check is idempotent, exactly #649's
+argument for its three viewport triggers. The check runs on the hidden
+transition too, which stamps the precise moment the operator left — a better
+baseline than the last heartbeat tick.
+
+**Reload through `performRefresh`, never a second path.** `bundleHash.ts`
+already owns the SW-aware reload, and it exists because a bare
+`location.reload()` took THREE presses to pick up a new bundle on iPhone PWA.
+Extending its use is vjt's standing "non facciamo strati su quel che c'è già"
+rule — the same argument #649 made for the viewport writer. It also inherits
+the `__refreshProbe` e2e seam for free. #674 (auto-refresh on a new bundle) is
+still OPEN and unimplemented, so there is no rival auto-reload to merge with;
+keeping #695 on this verb is what lets #674 land on top of it later.
+
+**Threshold configurable, per device.** `localStorage["cicchetto.staleResumeHours"]`,
+defaulting to 48. Absent / non-numeric / non-positive falls back to the default
+— a typo must never become "reload on every resume". An AdminDebugTab field for
+on-device tuning was considered and **declined**: the issue asked for a tunable
+number, not a UI, and Safari Web Inspector reaches a PWA's storage. It is a
+~15-line follow-up if vjt wants it on-device.
+
+**Compose drafts: discarded, and there was nothing to decide.** The issue
+ordered an explicit decision. `compose.ts` holds drafts in
+`identityScopedStore` signals with no storage backing, so *every* reload
+already discards them — including the #674 refresh banner's. #695 introduces no
+new loss class. Persisting drafts would be a new feature with its own
+identity-scoping and staleness questions, and after 48h away a draft is more
+likely stale than precious.
+
+**Two review findings declined, on evidence.**
+
+*A forward clock jump larger than the threshold reloads spuriously.* The
+proposed mitigations do not survive contact: an absurd-delta ceiling would
+suppress genuine very-long absences (a 40-day-old document SHOULD reload), and
+a `performance.now()` monotonic cross-check cannot cross the reload boundary
+the feature is built around — worse, if any engine pauses that clock while a
+page is frozen, the guard would silently disable the feature on exactly the
+platform it exists for. The cost of the bug is one reload; the cost of a wrong
+guard is the whole feature, failing quietly. Flagged rather than guessed at.
+
+*The boot-path storage write is unguarded and a throwing `sessionStorage`
+(Safari "Block All Cookies") would white-screen the app.* True, but not a new
+failure class: `applyFontSizeFromStorage` (`fontSize.ts:30`),
+`applySidebarWidthsFromStorage` (`sidebarWidths.ts:53`) and the bare
+`localStorage.getItem(INSTALL_CHOICE_KEY)` at `main.tsx:258` all already touch
+storage unguarded before `render()`, so such a browser is already broken before
+staleResume runs. Guarding one of four is the half-migrated state CLAUDE.md
+calls out by name; the real fix is a codebase-wide storage boundary, which is
+not a #695 change.
+
+**Apply:** when a requirement is "detect that time passed while we weren't
+running", the only correct instrument is something that outlives the process —
+and pick its scope to match the thing you are measuring, because a
+device-shared key is not a document lifetime. Let the test suite refuse to
+advance a clock: if a timer can make the test pass, the production code is
+measuring something the real failure mode never gives it.


### PR DESCRIPTION
Refs #695, #693

Reloads the whole cic client on resume after a prolonged absence. Threshold
**48h** — 24h was considered and rejected as too eager, and is not quietly
"improved" back down here.

The pairing the issue insists on is satisfied: #695 shipped alone "would look
like a fix and change nothing the operator can see", because a reload used to
re-enter the same cursor-anchored scrollback branch. #693 (PR #700) landed the
tail-anchored resume; this is the other half.

## Design, and why each piece is the way it is

**Only a persisted stamp can measure this.** The premise is a document with NO
JS running for the whole window — frozen or suspended by the OS. A timer, an
in-memory `bootedAt`, a heartbeat counter: each is by construction unable to
observe an interval during which it did not run. The tests encode that — **none
of them advance a fake timer**, they move `now` and assert on the stamp. A test
that needed a timer to trip the threshold would be proving the implementation
measures the wrong thing.

**The stamp lives in `sessionStorage`, the threshold in `localStorage`.** The
stamp means "when was THIS document last alive", which is exactly a window
lifetime: it survives a reload and a suspension and does not leak between tabs.
Sharing it across the origin would let a foreground desktop tab's heartbeat
refresh the key every 30s while the suspended iPhone PWA — the degraded
document this whole feature exists for — never tripped. The threshold override
is device-wide operator config and must outlive any one window, so it stays in
localStorage.

**"Exactly once" is one rule, not a latch.** Every check stamps; the stale ones
also reload. A boolean latch looked equivalent until the reload does not land —
`performRefresh` swallows every error and ends in a `location.reload()` that a
blocked navigation (or the e2e `__refreshProbe`) can decline — and the latched
document would then have the feature dead for its entire remaining life.
Stamping self-heals and removes state instead of adding it. Install also stamps
**before** arming any trigger, so the document that just reloaded cannot
re-trip on the absence it was itself the answer to.

**The heartbeat runs the CHECK, not a stamp write.** This is the whole iOS
path. Per #318's own module header iOS often fires no `visibilitychange`, so an
app-switch freezes the document with no hidden transition; the interval freezes
with it, and on thaw its first tick is the only trigger that can observe the
absence — `pageshow` does not fire for a freeze and the visibility signal never
changed value. A tick that stamped without checking would erase the evidence
instead of acting on it, and would make the stamp a two-writer value.
`installStaleResumeReload` therefore returns the check verb.

**Triggers:** the `documentVisibility` signal (the SSOT — visibilitychange AND
window focus/blur, per #192), `pageshow` (the bfcache/PWA restore whose
computed visibility never changed), and that heartbeat tick. Overlap is free:
once the stamp is refreshed the check is idempotent, exactly #649's argument
for its three viewport triggers.

**Reload via `bundleHash.performRefresh`** — the SW-aware verb the refresh
banner already uses. Extend what is there rather than stratify a second reload
path beside it; inherits the `__refreshProbe` seam for free. #674 is still OPEN
and unimplemented, so there is no rival auto-reload to merge with, and keeping
#695 on this verb is what lets #674 land on top of it later.

**Compose drafts: discarded.** The issue ordered an explicit decision; there
turned out to be nothing to decide. `compose.ts` holds drafts in
`identityScopedStore` signals with no storage backing, so *every* reload
already discards them, including the refresh banner's. This introduces no new
loss class, and after 48h away a draft is more likely stale than precious.

## RED before GREEN, and the guards mutation-checked

New tests were seen red first — literal output:

```
Error: Failed to resolve import "../lib/staleResume" from
"src/__tests__/staleResume.test.ts". Does the file exist?
```

Both guards were then mutation-checked rather than assumed:

* remove the pre-arm stamp → *"stamps this document active at install, so the
  document that just reloaded does not reload again"* fails with
  `AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times`
* make the stamp conditional (skip it on the reload path) → *"refreshes the
  stamp as it reloads, so more triggers cannot stack a second reload"* fails
  with `AssertionError: expected "vi.fn()" to be called 1 times, but got 4 times`

## Review

One synchronous reviewer agent; five findings, each verified against the code
before acting.

**Fixed — three, and one of them was severe.** (1) The heartbeat originally
called `markActive` and so erased the staleness evidence on the exact iOS
freeze/thaw path #695 exists for — the feature would have been dead on its
primary target. (2) The boolean latch wedged the document permanently after a
reload that never landed. (3) The stamp in localStorage was suppressed by any
other foreground tab.

**Declined — two, on evidence.**

> *A forward clock jump larger than the threshold reloads spuriously.* The
> mitigations do not survive contact: an absurd-delta ceiling would suppress
> genuine very-long absences (a 40-day-old document SHOULD reload), and a
> `performance.now()` cross-check cannot cross the reload boundary the feature
> is built around — worse, if any engine pauses that clock while a page is
> frozen the guard would silently disable the feature on exactly the platform
> it targets. The bug costs one reload; a wrong guard costs the whole feature,
> quietly. Flagged for vjt rather than guessed at.

> *The boot-path storage write is unguarded; a throwing `sessionStorage`
> (Safari "Block All Cookies") would white-screen the app.* True, but not a new
> failure class: `fontSize.ts:30`, `sidebarWidths.ts:53` and the bare
> `localStorage.getItem(INSTALL_CHOICE_KEY)` at `main.tsx:258` all already
> touch storage unguarded before `render()`, so such a browser is broken before
> staleResume runs. Guarding one of four is the half-migrated state CLAUDE.md
> calls out by name; the real fix is a codebase-wide storage boundary, not a
> #695 change.

An AdminDebugTab field for on-device threshold tuning was also considered and
declined — the issue asked for a tunable number, not a UI, and Safari Web
Inspector reaches a PWA's storage. ~15-line follow-up if wanted.

## e2e — +0, and why

The e2e fixture surface (`cicchetto/e2e/**`) belongs to another worker this
cycle and the lane instruction forbids touching it. Every decision here is
pinned at the unit level, including the three trigger classes driven through
injected seams. What a unit test cannot prove is the real thing: that an actual
iOS PWA, frozen for two days and reopened, reaches one of these triggers at
all. That is **device-only verification and stays vjt's leg** — no hollow e2e
is offered in its place. An e2e for the desktop bfcache path is owed and should
be filed as a follow-up for whoever holds the fixture lane next.

## Gates

Run from the worktree root, on the final tree:

* `./scripts/bun.sh run test` — **exit 0**: `Test Files 216 passed (216)`,
  `Tests 3906 passed (3906)` (23 new)
* `./scripts/bun.sh run build` — **exit 0** (main.tsx is the entry point, so the
  import graph is verified, not assumed)
* biome — exit 0; **standalone** `tsc --noEmit` — exit 0 (run separately because
  `bun run check` short-circuits: a biome failure skips tsc entirely)

No Elixir or wire surface is touched — cic-only, plus the DESIGN_NOTES entry.
Branch is even with `origin/main` @ 365bc2ec.