### PR TITLE
ci(#714): run the e2e suite on dependency and image changes too

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,6 +14,16 @@ name: integration
 # local mac dev (different bind-mount semantics). Operator scripts
 # (deploy.sh, observer.sh, etc.) stay out of scope deliberately.
 #
+# Dependency manifests are in scope on BOTH sides of the stack (#714).
+# mix.exs/mix.lock were already listed; cicchetto/package.json and
+# cicchetto/bun.lock were not, and the asymmetry meant a JavaScript
+# dependency bump ran no JavaScript at all — ci.yml's three jobs are
+# Elixir + bash only, and the SPA is built nowhere else but here. That
+# is how a bundler upgrade (vite 8.1.5 -> 8.2.0, #708) merged green on
+# `mix credo`. Same reasoning puts the root Dockerfile and compose.yaml
+# in scope: they define the images the suite boots. The e2e-local
+# Dockerfiles and compose files are already covered by cicchetto/e2e/**.
+#
 # Stack timing: cold ~6-8 min for the testnet+grappa+nginx images +
 # Playwright base pull; warm with cache it's faster but we don't cache
 # docker layers cross-runs (would need a registry push). Suite itself
@@ -34,6 +44,8 @@ on:
       - "lib/**"
       - "cicchetto/src/**"
       - "cicchetto/e2e/**"
+      - "cicchetto/package.json"
+      - "cicchetto/bun.lock"
       - "config/**"
       - "priv/**"
       - "scripts/integration.sh"
@@ -41,6 +53,8 @@ on:
       - "scripts/_lib.sh"
       - "mix.exs"
       - "mix.lock"
+      - "Dockerfile"
+      - "compose.yaml"
       - ".github/workflows/integration.yml"
   pull_request:
     branches: [main]
@@ -48,6 +62,8 @@ on:
       - "lib/**"
       - "cicchetto/src/**"
       - "cicchetto/e2e/**"
+      - "cicchetto/package.json"
+      - "cicchetto/bun.lock"
       - "config/**"
       - "priv/**"
       - "scripts/integration.sh"
@@ -55,6 +71,8 @@ on:
       - "scripts/_lib.sh"
       - "mix.exs"
       - "mix.lock"
+      - "Dockerfile"
+      - "compose.yaml"
       - ".github/workflows/integration.yml"
 
 # Avoid duplicate runs on PRs from same-repo branches; cancel an


### PR DESCRIPTION
Closes #714.

The integration workflow's path filter listed `mix.exs`/`mix.lock` but not `cicchetto/package.json` or `cicchetto/bun.lock`. An Elixir dependency bump therefore ran the full e2e matrix; a JavaScript dependency bump ran no JavaScript at all.

That is not an overstatement — `ci.yml`'s three jobs (`test + lint + audit`, `dialyzer`, `shottino`) are Elixir and bash only:

```
$ git grep -lE 'vitest|npm ci|npm run|biome|tsc --noEmit' origin/main -- .github/workflows/
(no matches)
```

and the SPA is built nowhere except inside this suite's compose stack (`scripts/integration.sh` → `docker compose build` of `cicchetto-build-test` + `playwright-runner`).

Concretely: #708 bumped **vite**, the bundler, and merged green on `mix credo` and dialyzer. #707 bumps `@solidjs/router` across a **major** (0.16.2 → 1.0.0) and is being held open until this lands.

Also adds the root `Dockerfile` and `compose.yaml` — they define the images the suite boots. The e2e-local Dockerfiles and compose files already fall under `cicchetto/e2e/**`.

**Cost:** dependency-bump PRs now wait on the ~30 min suite. Intended trade.

**Not included:** the fast JS job proposed in #714 (`bun install && tsc --noEmit && biome check && vitest run` on `cicchetto/**`) — that is a new job rather than a filter fix, and it is a complement to this, not a substitute. Say the word and I'll open it separately.

**Note on this PR's own CI:** it touches `.github/workflows/integration.yml`, which is in the filter, so the e2e suite runs on it — the change is self-exercising.