### PR TITLE
test(#713): stop asking a second-precision column a sub-second question

### DIFF
--- a/test/grappa/channel_directory_test.exs
+++ b/test/grappa/channel_directory_test.exs
@@ -12,6 +12,10 @@ defmodule Grappa.ChannelDirectoryTest do
   `captured_at` still NULL), `:fresh` (finalised within TTL), `:stale`
   (finalised but older than TTL).
 
+  An injected TTL must stay clear of the storage granularity: `captured_at`
+  is second-precision, so a sub-second window makes the branch depend on the
+  clock rather than on the code. See `@ample_ttl_ms` / `@expired_ttl_ms`.
+
   The property test pins the keyset-paging invariant that's easy to
   break: walking the cursor visits every row exactly once with no
   overlap, across the tie-heavy `:users` sort.
@@ -27,6 +31,24 @@ defmodule Grappa.ChannelDirectoryTest do
     {:ok, subject: {:user, user.id}, network_id: network.id}
   end
 
+  # `captured_at` is a `:utc_datetime` — SECOND precision (see
+  # `ChannelDirectory.Entry`) — so `finalize/2` MUST truncate, and a snapshot
+  # stamped at `…:18.940` is stored as `…:18.000`, i.e. born up to 999 ms old.
+  # A TTL at or below one second therefore makes `:fresh` depend on where in
+  # the wall-clock second the stamp happened to land: that is the intermittent
+  # CI red in #713, and it is the test asking a question a second-precision
+  # column cannot answer. Nothing here is about the boundary itself — every
+  # case is about WHICH branch `list/3` takes — so the window is set far wider
+  # than the storage granularity and the answer stops depending on the clock.
+  @ample_ttl_ms 60_000
+
+  # The mirror image, for the one case that wants `:stale` on purpose. Any
+  # non-negative age exceeds a negative window, so the branch is forced no
+  # matter where the truncated stamp fell. `0` is NOT equivalent: the
+  # comparison is `age_ms <= ttl_ms`, so a stamp and a read landing in the same
+  # millisecond as the second boundary would score `:fresh`.
+  @expired_ttl_ms -1
+
   defp rows(n), do: for(i <- 1..n, do: %{name: "#c#{i}", topic: "t#{i}", user_count: i})
 
   test "ttl_ms/0 returns the configured 48h" do
@@ -36,10 +58,10 @@ defmodule Grappa.ChannelDirectoryTest do
   test "replace_start nukes, ingest inserts, finalize stamps captured_at", %{subject: s, network_id: nid} do
     :ok = Dir.replace_start(s, nid)
     :ok = Dir.ingest(s, nid, rows(3))
-    assert %{status: :refreshing, total: 3} = Dir.list(s, nid, ttl_ms: 1_000)
+    assert %{status: :refreshing, total: 3} = Dir.list(s, nid, ttl_ms: @ample_ttl_ms)
 
     :ok = Dir.finalize(s, nid)
-    assert %{status: :fresh, total: 3, entries: entries, captured_at: ca} = Dir.list(s, nid, ttl_ms: 1_000)
+    assert %{status: :fresh, total: 3, entries: entries, captured_at: ca} = Dir.list(s, nid, ttl_ms: @ample_ttl_ms)
     assert ca != nil
     assert Enum.map(entries, & &1.name) == ["#c3", "#c2", "#c1"]
   end
@@ -51,40 +73,40 @@ defmodule Grappa.ChannelDirectoryTest do
     :ok = Dir.replace_start(s, nid)
     :ok = Dir.ingest(s, nid, rows(1))
     :ok = Dir.finalize(s, nid)
-    assert %{total: 1} = Dir.list(s, nid, ttl_ms: 1_000)
+    assert %{total: 1} = Dir.list(s, nid, ttl_ms: @ample_ttl_ms)
   end
 
   test "empty snapshot -> status :empty", %{subject: s, network_id: nid} do
-    assert %{status: :empty, total: 0, entries: []} = Dir.list(s, nid, ttl_ms: 1_000)
+    assert %{status: :empty, total: 0, entries: []} = Dir.list(s, nid, ttl_ms: @ample_ttl_ms)
   end
 
   test "stale snapshot (older than ttl) -> status :stale", %{subject: s, network_id: nid} do
     :ok = Dir.replace_start(s, nid)
     :ok = Dir.ingest(s, nid, rows(1))
     :ok = Dir.finalize(s, nid)
-    assert %{status: :stale} = Dir.list(s, nid, ttl_ms: 0)
+    assert %{status: :stale} = Dir.list(s, nid, ttl_ms: @expired_ttl_ms)
   end
 
   test "?q= filters by name substring (case-insensitive)", %{subject: s, network_id: nid} do
     :ok = Dir.replace_start(s, nid)
     :ok = Dir.ingest(s, nid, [%{name: "#elixir", topic: "", user_count: 5}, %{name: "#ruby", topic: "", user_count: 9}])
     :ok = Dir.finalize(s, nid)
-    assert %{entries: [%{name: "#elixir"}], total: 1} = Dir.list(s, nid, ttl_ms: 1_000, q: "ELIX")
+    assert %{entries: [%{name: "#elixir"}], total: 1} = Dir.list(s, nid, ttl_ms: @ample_ttl_ms, q: "ELIX")
   end
 
   test "sort: :name orders alphabetically", %{subject: s, network_id: nid} do
     :ok = Dir.replace_start(s, nid)
     :ok = Dir.ingest(s, nid, [%{name: "#b", topic: "", user_count: 9}, %{name: "#a", topic: "", user_count: 1}])
     :ok = Dir.finalize(s, nid)
-    assert %{entries: [%{name: "#a"}, %{name: "#b"}]} = Dir.list(s, nid, ttl_ms: 1_000, sort: :name)
+    assert %{entries: [%{name: "#a"}, %{name: "#b"}]} = Dir.list(s, nid, ttl_ms: @ample_ttl_ms, sort: :name)
   end
 
   test "keyset pagination is stable + non-overlapping", %{subject: s, network_id: nid} do
     :ok = Dir.replace_start(s, nid)
     :ok = Dir.ingest(s, nid, rows(5))
     :ok = Dir.finalize(s, nid)
-    %{entries: p1, next_cursor: c1} = Dir.list(s, nid, ttl_ms: 1_000, limit: 2)
-    %{entries: p2} = Dir.list(s, nid, ttl_ms: 1_000, limit: 2, cursor: c1)
+    %{entries: p1, next_cursor: c1} = Dir.list(s, nid, ttl_ms: @ample_ttl_ms, limit: 2)
+    %{entries: p2} = Dir.list(s, nid, ttl_ms: @ample_ttl_ms, limit: 2, cursor: c1)
     names = Enum.map(p1 ++ p2, & &1.name)
     assert names == Enum.uniq(names)
     assert Enum.map(p1, & &1.name) == ["#c5", "#c4"]
@@ -114,7 +136,9 @@ defmodule Grappa.ChannelDirectoryTest do
   end
 
   defp collect_all(s, nid, cursor, acc) do
-    %{entries: es, next_cursor: c} = Grappa.ChannelDirectory.list(s, nid, ttl_ms: 1_000, limit: 3, cursor: cursor)
+    %{entries: es, next_cursor: c} =
+      Grappa.ChannelDirectory.list(s, nid, ttl_ms: @ample_ttl_ms, limit: 3, cursor: cursor)
+
     acc = acc ++ Enum.map(es, & &1.name)
     if c, do: collect_all(s, nid, c, acc), else: acc
   end

--- a/test/grappa/session/directory_test.exs
+++ b/test/grappa/session/directory_test.exs
@@ -134,7 +134,12 @@ defmodule Grappa.Session.DirectoryTest do
     assert network_slug == network.slug
 
     # The broadcast proves 323 was processed; NOW the snapshot is durable.
-    page = ChannelDirectory.list({:user, user.id}, network.id, ttl_ms: 1_000)
+    # The TTL is deliberately far wider than one second: `captured_at` is a
+    # second-precision `:utc_datetime`, so a snapshot is born up to 999 ms old
+    # and a ~1s window would make `:fresh` depend on where the stamp fell in
+    # the wall-clock second — doubly so here, where the `assert_receive` above
+    # can burn most of that second before the read (#713).
+    page = ChannelDirectory.list({:user, user.id}, network.id, ttl_ms: 60_000)
     assert page.status == :fresh
     assert page.total == 2
     # Default sort is user_count DESC (1200 > 800), so #elixir precedes #ruby.


### PR DESCRIPTION
Refs #713

Test-only. No production code changes — per the call on the issue, this is a
defect in the test, not in `ChannelDirectory`.

## The defect

`ChannelDirectory.Entry` declares `field :captured_at, :utc_datetime` — second
precision — so `finalize/2` **must** truncate or Ecto refuses the cast. A
snapshot stamped at `…:18.940` is therefore stored as `…:18.000` and is born up
to 999 ms old. The tests then asserted `status: :fresh` against `ttl_ms: 1_000`,
so the whole freshness budget could be spent before `list/3` was called. Whether
CI went green depended on where in the wall-clock second `finalize` landed —
not on the code under test.

## Reproduced, not assumed

Aligning `finalize` to ~50 ms before a second boundary and reading just past it
fails **100% of the time**, with the exact CI signature:

```
match (=) failed
code:  assert %{status: :fresh} = Dir.list(s, nid, ttl_ms: 1000)
right: %{status: :stale, ...}
```

The same alignment passes under the new window. The probe was temporary and is
not in the diff — it existed to prove the diagnosis and to prove the fix
actually addresses it, rather than just moving a number until CI stopped
complaining.

## The fix

Both TTLs are named now, because the next person writing a case here needs to
know the floor exists:

* **`@ample_ttl_ms 60_000`** — applied to **all nine** call sites, not only the
  one that was failing. Leaving `1_000` in the others would keep the trap armed
  and invite the value to be copied into the next freshness assertion. Every
  case in this file is about *which branch* `list/3` takes; none is about the
  boundary itself.
* **`@expired_ttl_ms -1`** — for the one case that wants `:stale` on purpose.
  `0` is **not** equivalent: the comparison is `age_ms <= ttl_ms`, so a stamp
  and a read both landing in the same millisecond as the second boundary would
  score `:fresh`. Far rarer than the bug above, same class, fixed while here.

`test/grappa/session/directory_test.exs` carried the same assertion and is worse
exposed — an `assert_receive` with a 1s timeout sits between `finalize` and the
read, so most of the budget can be gone before it even asks. Widened, with the
reason inline.

## Deliberately not changed

The truncation, and `list/3` itself. The issue also floated rejecting a
`ttl_ms` below the column's granularity at the boundary, so the next caller
cannot ask an unanswerable question. That is a production change and this is a
test defect — it stays on #713 for a separate call.

## Gates

* `scripts/test.sh` on both touched files — **exit 0**: `1 property, 13 tests, 0 failures`
* `scripts/mix.sh format --check-formatted` on both — **exit 0**

Full `check.sh` is not quoted here because `main` currently fails its last gate
(`gen_wire_types --check`, #696 fallout); that fix is `467f3c07` on #700 and
reaches everyone from there.