### PR TITLE
test(shottino): free the captured defaults, unbreak the ASan suite

### DIFF
--- a/frontends/shottino/tests/test_windows.c
+++ b/frontends/shottino/tests/test_windows.c
@@ -1338,7 +1338,15 @@ TEST(a_configured_setting_survives_save_and_load) {
     prefs_load(third);
     CHECK_STR(third->voice_source, "alsa:hw:2");
 
-    free(app); free(next); free(third);
+    /* free_app, not a bare free: each of the three apps captured the
+     * defaults above, and those are 28 heap strings per app hanging off
+     * setting_default[] that only settings_free_defaults (which free_app
+     * calls) gives back. The bare free released the struct and left 84
+     * allocations behind — LeakSanitizer failed the suite and main with
+     * it. */
+    free_app(app);
+    free_app(next);
+    free_app(third);
 }
 
 /* The grid the call helper publishes is what ties a rectangle of the


### PR DESCRIPTION
main is red on `shottino (build + tests)` and has been since `1c52dd98` ("test: pin that a configured setting survives save and load"). Every open PR inherits the red — #715 and #716 are both red on that job and green on everything else.

## Cause

`TEST(a_configured_setting_survives_save_and_load)` in `frontends/shottino/tests/test_windows.c` builds three apps, calls `settings_capture_defaults` on each, and then ends with:

```c
free(app); free(next); free(third);
```

`settings_capture_defaults` (`shottino.c:10268`) fills `setting_default[]` with `xasprintf`'d strings — 28 per app. A bare `free()` gives back the struct and leaks all of them: 3 × 28 = 84 allocations, 263 bytes, which is exactly what LeakSanitizer reports:

```
SUMMARY: AddressSanitizer: 263 byte(s) leaked in 84 allocation(s).
make: *** [Makefile:151: check] Error 1
```

The suite already has the right teardown: `free_app()` (`test_windows.c:39`), whose own comment says *"the captured defaults are heap strings and ASan is watching"* and which calls `settings_free_defaults()`. The other `settings_capture_defaults` call site in the file (`:1749`) ends with `free_app()` and does not leak.

## Fix

Use `free_app()` for the three apps. No production code touched, no assertion changed.

## Verification

Built and ran the full suite on aarch64 (this box), before and after:

- before: `SUMMARY: AddressSanitizer: 263 byte(s) leaked in 84 allocation(s)`, `make check` exit 2 — same numbers as CI, so the leak is not runner-specific
- after: all suites pass, `make -C frontends/shottino check` exit 0