### PR TITLE
fix(auth): allow disabling passkey login

### DIFF
--- a/cicchetto/src/PasskeySettings.tsx
+++ b/cicchetto/src/PasskeySettings.tsx
@@ -62,6 +62,22 @@ const PasskeySettings: Component = () => {
     }
   };
 
+  const disablePasskeyLogin = async (): Promise<void> => {
+    setBusy(true);
+    setError(null);
+    try {
+      const options = await startPasskeyModeChange(currentToken(), password(), "disabled");
+      await finishPasskeyModeChange(currentToken(), await getPasskey(options));
+      setCodes([]);
+      setRecoveryToken(null);
+      await reload();
+    } catch (value) {
+      setError(value instanceof Error ? value.message : String(value));
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const preparePasswordlessMode = async (): Promise<void> => {
     setBusy(true);
     setError(null);
@@ -175,6 +191,15 @@ const PasskeySettings: Component = () => {
                 Passwordless mode disables password and TOTP login. Losing the passkey requires a
                 recovery code; without either, only the instance administrator can restore the
                 account. Shottino cannot log in.
+              </p>
+            </Show>
+            <Show when={current.mode !== "disabled"}>
+              <button type="button" disabled={busy()} onClick={() => void disablePasskeyLogin()}>
+                return to password login
+              </button>
+              <p role="note">
+                Requires your account password and current passkey. Passwordless recovery codes are
+                removed.
               </p>
             </Show>
           </>

--- a/cicchetto/src/__tests__/PasskeySettings.test.tsx
+++ b/cicchetto/src/__tests__/PasskeySettings.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const api = vi.hoisted(() => ({
+  finishPasskeyModeChange: vi.fn(),
+  getPasskeyStatus: vi.fn(),
+  startPasskeyModeChange: vi.fn(),
+}));
+
+vi.mock("../lib/api", () => ({
+  deletePasskey: vi.fn(),
+  finishPasskeyModeChange: api.finishPasskeyModeChange,
+  finishPasskeyRegistration: vi.fn(),
+  getPasskeyStatus: api.getPasskeyStatus,
+  preparePasswordless: vi.fn(),
+  startPasskeyModeChange: api.startPasskeyModeChange,
+  startPasskeyRegistration: vi.fn(),
+  startPasswordlessActivation: vi.fn(),
+}));
+
+vi.mock("../lib/auth", () => ({ token: () => "test-token" }));
+
+vi.mock("../lib/passkeys", () => ({
+  createPasskey: vi.fn(),
+  getPasskey: vi.fn().mockResolvedValue({ assertion: true }),
+}));
+
+import PasskeySettings from "../PasskeySettings";
+
+describe("PasskeySettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getPasskeyStatus.mockResolvedValue({
+      mode: "passwordless",
+      passkeys: [
+        {
+          id: "passkey-1",
+          name: "phone",
+          inserted_at: "2026-08-03T00:00:00Z",
+          last_used_at: null,
+        },
+      ],
+    });
+    api.startPasskeyModeChange.mockResolvedValue({ challenge_id: "challenge" });
+    api.finishPasskeyModeChange.mockResolvedValue({ mode: "disabled" });
+  });
+
+  it("returns a passwordless account to password login with password and passkey", async () => {
+    render(() => <PasskeySettings />);
+
+    await screen.findByText("Mode: passwordless");
+    await fireEvent.input(screen.getByLabelText("Account password"), {
+      target: { value: "correct horse battery staple" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "return to password login" }));
+
+    await waitFor(() =>
+      expect(api.startPasskeyModeChange).toHaveBeenCalledWith(
+        "test-token",
+        "correct horse battery staple",
+        "disabled",
+      ),
+    );
+    expect(api.finishPasskeyModeChange).toHaveBeenCalledWith("test-token", { assertion: true });
+  });
+});

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -1536,7 +1536,7 @@ export const finishPasskeyRegistration = (
 export const startPasskeyModeChange = (
   token: string,
   password: string,
-  mode: "second_factor" | "passwordless",
+  mode: "disabled" | "second_factor" | "passwordless",
 ): Promise<PasskeyOptions> =>
   passkeyRequest<PasskeyOptions>("/me/passkeys/mode/options", { password, mode }, token);
 export const preparePasswordless = (

--- a/lib/grappa/accounts/webauthn.ex
+++ b/lib/grappa/accounts/webauthn.ex
@@ -2,7 +2,7 @@ defmodule Grappa.Accounts.WebAuthn do
   @moduledoc "Passkey registration and assertion ceremonies for durable accounts."
   import Ecto.Query
 
-  alias Grappa.Accounts.{Passkey, RecoveryCodes, User, WebAuthnChallengeStore}
+  alias Grappa.Accounts.{Passkey, RecoveryCodes, TOTPRecoveryCode, User, WebAuthnChallengeStore}
   alias Grappa.Repo
 
   @type binding :: %{ip: String.t() | nil, client_id: String.t() | nil}
@@ -118,6 +118,10 @@ defmodule Grappa.Accounts.WebAuthn do
     run_mode_transaction(user, mode, current_session_id, [])
   end
 
+  def set_mode(user, "disabled" = mode, current_session_id, []) do
+    run_mode_transaction(user, mode, current_session_id, [])
+  end
+
   def set_mode(_, "passwordless", _, _),
     do: {:error, :recovery_codes_required}
 
@@ -211,6 +215,10 @@ defmodule Grappa.Accounts.WebAuthn do
 
   defp set_mode_transaction(user, mode, current_session_id, recovery_codes) do
     if mode == "passwordless", do: :ok = RecoveryCodes.replace(user.id, recovery_codes)
+
+    if mode == "disabled" and user.passkey_mode == "passwordless",
+      do: TOTPRecoveryCode |> where([r], r.user_id == ^user.id) |> Repo.delete_all()
+
     {1, _} = User |> where([u], u.id == ^user.id) |> Repo.update_all(set: [passkey_mode: mode])
     :ok = Grappa.Accounts.revoke_other_sessions_for_user(user, current_session_id)
     mode

--- a/lib/grappa_web/controllers/passkey_controller.ex
+++ b/lib/grappa_web/controllers/passkey_controller.ex
@@ -51,7 +51,7 @@ defmodule GrappaWeb.PasskeyController do
         %{assigns: %{current_subject: {:user, user}}} = conn,
         %{"password" => password, "mode" => mode}
       )
-      when mode == "second_factor" do
+      when mode in ["second_factor", "disabled"] do
     if Argon2.verify_pass(password, user.password_hash) do
       with {:ok, options} <-
              WebAuthn.begin_authentication(user, :mode_change, client_binding(conn), origin(), %{mode: mode}) do

--- a/test/grappa/accounts/passkey_test.exs
+++ b/test/grappa/accounts/passkey_test.exs
@@ -69,4 +69,32 @@ defmodule Grappa.Accounts.PasskeyTest do
     assert is_nil(Repo.get!(Accounts.Session, current.id).revoked_at)
     assert %DateTime{} = Repo.get!(Accounts.Session, other.id).revoked_at
   end
+
+  test "disabling passkey login removes recovery codes and revokes other sessions" do
+    user = user_fixture()
+    current = session_fixture(user)
+    codes = Accounts.prepare_recovery_codes()
+
+    assert {:ok, "passwordless"} = WebAuthn.set_mode(user, "passwordless", current.id, codes)
+
+    other = session_fixture(user)
+    user = Repo.get!(Accounts.User, user.id)
+    assert {:ok, "disabled"} = WebAuthn.set_mode(user, "disabled", current.id)
+    assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 0
+    assert Repo.get!(Accounts.User, user.id).passkey_mode == "disabled"
+    assert is_nil(Repo.get!(Accounts.Session, current.id).revoked_at)
+    assert %DateTime{} = Repo.get!(Accounts.Session, other.id).revoked_at
+  end
+
+  test "disabling second-factor passkeys preserves TOTP recovery codes" do
+    user = user_fixture()
+    current = session_fixture(user)
+    codes = Accounts.prepare_recovery_codes()
+    :ok = Accounts.RecoveryCodes.replace(user.id, codes)
+    user |> Ecto.Changeset.change(passkey_mode: "second_factor") |> Repo.update!()
+
+    user = Repo.get!(Accounts.User, user.id)
+    assert {:ok, "disabled"} = WebAuthn.set_mode(user, "disabled", current.id)
+    assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 10
+  end
 end

--- a/test/grappa/accounts/passkey_test.exs
+++ b/test/grappa/accounts/passkey_test.exs
@@ -78,10 +78,10 @@ defmodule Grappa.Accounts.PasskeyTest do
     assert {:ok, "passwordless"} = WebAuthn.set_mode(user, "passwordless", current.id, codes)
 
     other = session_fixture(user)
-    user = Repo.get!(Accounts.User, user.id)
-    assert {:ok, "disabled"} = WebAuthn.set_mode(user, "disabled", current.id)
+    passwordless_user = Repo.get!(Accounts.User, user.id)
+    assert {:ok, "disabled"} = WebAuthn.set_mode(passwordless_user, "disabled", current.id)
     assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 0
-    assert Repo.get!(Accounts.User, user.id).passkey_mode == "disabled"
+    assert Repo.get!(Accounts.User, passwordless_user.id).passkey_mode == "disabled"
     assert is_nil(Repo.get!(Accounts.Session, current.id).revoked_at)
     assert %DateTime{} = Repo.get!(Accounts.Session, other.id).revoked_at
   end
@@ -93,8 +93,8 @@ defmodule Grappa.Accounts.PasskeyTest do
     :ok = Accounts.RecoveryCodes.replace(user.id, codes)
     user |> Ecto.Changeset.change(passkey_mode: "second_factor") |> Repo.update!()
 
-    user = Repo.get!(Accounts.User, user.id)
-    assert {:ok, "disabled"} = WebAuthn.set_mode(user, "disabled", current.id)
+    second_factor_user = Repo.get!(Accounts.User, user.id)
+    assert {:ok, "disabled"} = WebAuthn.set_mode(second_factor_user, "disabled", current.id)
     assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 10
   end
 end

--- a/test/grappa_web/controllers/passkey_controller_test.exs
+++ b/test/grappa_web/controllers/passkey_controller_test.exs
@@ -73,10 +73,10 @@ defmodule GrappaWeb.PasskeyControllerTest do
 
     assert json_response(blocked, 409) == %{"error" => "passkey_required"}
 
-    user = Repo.get!(User, user.id)
-    assert {:ok, "disabled"} = WebAuthn.set_mode(user, "disabled", session.id)
+    passwordless_user = Repo.get!(User, user.id)
+    assert {:ok, "disabled"} = WebAuthn.set_mode(passwordless_user, "disabled", session.id)
 
-    conn = recycle(conn) |> put_req_header("authorization", "Bearer #{session.id}")
+    conn = put_req_header(recycle(conn), "authorization", "Bearer #{session.id}")
     assert response(delete(conn, "/me/passkeys/#{passkey.id}", %{"password" => password}), 204)
     assert Repo.aggregate(Passkey, :count, :id) == 0
   end

--- a/test/grappa_web/controllers/passkey_controller_test.exs
+++ b/test/grappa_web/controllers/passkey_controller_test.exs
@@ -4,7 +4,7 @@ defmodule GrappaWeb.PasskeyControllerTest do
   import Grappa.AuthFixtures
   import Ecto.Query
 
-  alias Grappa.Accounts.{Session, TOTP, TOTPRecoveryCode, User}
+  alias Grappa.Accounts.{Passkey, Session, TOTP, TOTPRecoveryCode, User, WebAuthn}
   alias Grappa.Repo
 
   test "passwordless mode rejects password and accepts a one-shot recovery code", %{conn: conn} do
@@ -47,5 +47,37 @@ defmodule GrappaWeb.PasskeyControllerTest do
     assert Repo.get!(User, user.id).passkey_mode == "disabled"
     assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 0
     assert is_nil(Repo.get!(Session, session.id).revoked_at)
+  end
+
+  test "last passkey can be deleted after returning to password login", %{conn: conn} do
+    {user, password} = user_fixture_with_password()
+    session = session_fixture(user)
+
+    passkey =
+      Repo.insert!(
+        Passkey.changeset(%Passkey{}, %{
+          user_id: user.id,
+          credential_id: <<1, 2, 3>>,
+          public_key: CBOR.encode(%{1 => 2, 3 => -7}),
+          name: "phone"
+        })
+      )
+
+    assert {:ok, "passwordless"} =
+             WebAuthn.set_mode(user, "passwordless", session.id, Grappa.Accounts.prepare_recovery_codes())
+
+    blocked =
+      conn
+      |> put_req_header("authorization", "Bearer #{session.id}")
+      |> delete("/me/passkeys/#{passkey.id}", %{"password" => password})
+
+    assert json_response(blocked, 409) == %{"error" => "passkey_required"}
+
+    user = Repo.get!(User, user.id)
+    assert {:ok, "disabled"} = WebAuthn.set_mode(user, "disabled", session.id)
+
+    conn = recycle(conn) |> put_req_header("authorization", "Bearer #{session.id}")
+    assert response(delete(conn, "/me/passkeys/#{passkey.id}", %{"password" => password}), 204)
+    assert Repo.aggregate(Passkey, :count, :id) == 0
   end
 end


### PR DESCRIPTION
## Summary

- add an explicit **Return to password login** control
- require both the account password and a current passkey assertion
- set `passkey_mode` back to `disabled`, remove passwordless recovery codes, and revoke other sessions
- preserve TOTP recovery codes when disabling passkey second-factor mode
- allow the existing guard to delete the last passkey only after the downgrade

## Tests

- `scripts/mix.sh --env=test test test/grappa/accounts/passkey_test.exs test/grappa_web/controllers/passkey_controller_test.exs --warnings-as-errors` (8 tests, 0 failures)
- `scripts/bun.sh run test -- src/__tests__/PasskeySettings.test.tsx` (1 test, 0 failures)
- `scripts/bun.sh run check`
- `scripts/mix.sh dialyzer --format short` (0 errors)

The local integration suite was intentionally not run; CI remains authoritative for integration coverage.

Closes #721