### PR TITLE
Retry the post-RECOVER reclaim leg, and stop firing a doomed IDENTIFY (#623)

### DIFF
--- a/cicchetto/e2e/tests/recover-identity-real.spec.ts
+++ b/cicchetto/e2e/tests/recover-identity-real.spec.ts
@@ -32,7 +32,7 @@
 // bahamut's SILENT `+r`-strip on a self-rename — pre-fix grappa kept a phantom
 // `+r` and the button stayed hidden (that IS the state bug this e2e surfaced).
 //
-//   1. IrcPeer registers RECOVER_NICK with the real NickServ (REGISTER →
+//   1. IrcPeer registers the (stamped) recover nick with the real NickServ
 //      emailed AUTH code via mailpit → AUTH → `+r`), then DISCONNECTS — the
 //      nick is now FREE but REGISTERED (password known).
 //   2. The visitor logs in WITH that password (`loginVisitor`) → grappa
@@ -43,9 +43,9 @@
 //   3. The visitor voluntarily `/nick`s to a free Guest nick (composeSend from
 //      the $server window) → bahamut strips `+r` (silent), grappa MIRRORS it
 //      (the fix) → the visitor is now connected, POST-001, NON-`+r`, and
-//      RECOVER_NICK is FREE again. `recoverable` stays true → the 🔑 button
+//      the recover nick is FREE again. `recoverable` stays true → the 🔑 button
 //      APPEARS (the POST-001 barrier).
-//   4. IrcPeer RECONNECTS + IDENTIFYs RECOVER_NICK (a stable, legitimate hold).
+//   4. IrcPeer RECONNECTS + IDENTIFYs the recover nick (a stable, legitimate hold).
 //   5. Click 🔑 Recover → the server-driven RecoverModal → NICK(433, held) →
 //      RECOVER (services free IrcPeer's hold — SPIKE-PROVEN 2026-07-31, FREED)
 //      → settle → NICK + IDENTIFY → `+r` → the modal shows terminal SUCCESS.
@@ -67,10 +67,15 @@
 // network connection_state, so no visitor-token PATCH is needed here.
 //
 // ── RE-RUN NOTE ───────────────────────────────────────────────────────────
-// RECOVER_NICK registers exactly ONCE per fresh services container. CI is
-// fresh each run. For a LOCAL re-run against a persistent testnet the nick is
-// already registered — bring the testnet down + up first
-// (`scripts/testnet.sh down && scripts/integration.sh …`).
+// The recover nick + its registration email are STAMPED per test run, because
+// a NickServ registration is once-per-nick-per-services-container: a fixed
+// nick made the second run on a persistent testnet answer "already
+// registered", which resolves the register barrier instantly and then hangs
+// the mail wait — so `--repeat-each`, the iso-rerun discipline this project
+// mandates for flake triage (docs/TESTING.md), could not be used on the one
+// spec that needed it (#623). Stamped, every iteration registers its own nick
+// against the same container and the spec is re-runnable N times on ONE
+// stack.
 
 import { expect, test } from "@playwright/test";
 import type { Browser } from "@playwright/test";
@@ -115,9 +120,7 @@ async function bootVisitor(
 }
 
 const NETWORK_SLUG = "azzurra"; // visitor_enabled + real azzurra-services (bahamut-test hub)
-const RECOVER_NICK = "rec-id-nick";
 const RECOVER_PASSWORD = "recidpw1"; // 5–32 chars (NickServ floor)
-const REG_EMAIL = "rec-id@example.com"; // valid TLD (see EMAIL DOMAIN note)
 const AUTH_CODE_RE = /AUTH (\d+)/;
 
 // Poll GET /me until the `NETWORK_SLUG` home row's `recoverable` flag equals
@@ -199,6 +202,10 @@ test.describe("#581 recover-identity (real services)", () => {
     const admin = getSeededAdmin();
     const stamp = Date.now();
     const guestNick = `recguest${stamp % 100000}`; // free + unique per run
+    // Stamped so the registration is fresh on a persistent testnet too (see
+    // the RE-RUN NOTE): NickServ registers a nick exactly once per container.
+    const recoverNick = `recid${stamp % 100000}`;
+    const regEmail = `${recoverNick}@example.com`; // valid TLD (see EMAIL DOMAIN note)
     let visitor: Awaited<ReturnType<typeof loginVisitor>> | null = null;
     let ctx: Awaited<ReturnType<Browser["newContext"]>> | null = null;
     const peers: IrcPeer[] = [];
@@ -206,18 +213,18 @@ test.describe("#581 recover-identity (real services)", () => {
     try {
       await resetMailpit();
 
-      // ── Step 1: register RECOVER_NICK with the REAL NickServ, then free it ──
-      const registrar = await IrcPeer.connect({ nick: RECOVER_NICK });
+      // ── Step 1: register the stamped nick with the REAL NickServ, free it ──
+      const registrar = await IrcPeer.connect({ nick: recoverNick });
       peers.push(registrar);
-      await registrar.nickservRegister(RECOVER_PASSWORD, REG_EMAIL);
-      const mail = await awaitMail(REG_EMAIL, { timeoutMs: 45_000 });
+      await registrar.nickservRegister(RECOVER_PASSWORD, regEmail);
+      const mail = await awaitMail(regEmail, { timeoutMs: 45_000 });
       const code = extractFromMail(mail, AUTH_CODE_RE);
       await registrar.nickservAuth(code); // → +r on the registrar
       await registrar.disconnect("free the nick for the visitor"); // nick FREE, still REGISTERED
       peers.pop();
 
       // ── Step 2: visitor logs in WITH the password → connects free → +r → commit ──
-      visitor = await loginVisitor(RECOVER_NICK, RECOVER_PASSWORD, NETWORK_SLUG);
+      visitor = await loginVisitor(recoverNick, RECOVER_PASSWORD, NETWORK_SLUG);
       // The +r commit persists the :nickserv_identify credential → recoverable.
       await waitForRecoverable(visitor.token, NETWORK_SLUG, true);
 
@@ -234,8 +241,8 @@ test.describe("#581 recover-identity (real services)", () => {
       // a reconnect (which auto-ghost would reclaim PRE-001). bahamut strips +r
       // silently on the rename; the EventRouter fix mirrors it so cic's
       // canRecover() flips true. The credential is :nickserv_identify, so its
-      // nick is HELD at RECOVER_NICK (update_visitor_credential_nick is
-      // anon-gated → :held_identified) — recover still targets RECOVER_NICK.
+      // nick is HELD at the recover nick (update_visitor_credential_nick is
+      // anon-gated → :held_identified) — recover still targets that nick.
       await selectChannel(page, NETWORK_SLUG, "Server", { awaitWsReady: false });
       await composeSend(page, `/nick ${guestNick}`);
 
@@ -245,8 +252,8 @@ test.describe("#581 recover-identity (real services)", () => {
       const recoverBtn = page.getByTestId(`home-recover-identity-${NETWORK_SLUG}`);
       await expect(recoverBtn).toBeVisible({ timeout: 30_000 });
 
-      // ── Step 4: IrcPeer takes + IDENTIFYs RECOVER_NICK (now free) → 433 on recover ──
-      const holder = await IrcPeer.connect({ nick: RECOVER_NICK });
+      // ── Step 4: IrcPeer takes + IDENTIFYs the recover nick (free) → 433 on recover ──
+      const holder = await IrcPeer.connect({ nick: recoverNick });
       peers.push(holder);
       await holder.nickservIdentify(RECOVER_PASSWORD);
 

--- a/cicchetto/src/RecoverModal.tsx
+++ b/cicchetto/src/RecoverModal.tsx
@@ -48,6 +48,11 @@ const STATUS_GLYPH: Record<RecoverStatus, string> = {
 // (a future server reason token, additive-only) falls back to generic copy —
 // the friendlyChannelError posture (known → copy, unknown → fallback), never a
 // dropped/blank failure.
+//
+// #623 — `identify_unconfirmed` (leg b: nick reclaimed, sameNick IDENTIFY sent,
+// but +r never confirmed) has NO bespoke case yet and intentionally hits the
+// generic fallback ("Recovery couldn't be completed. Try again.") — apt, since a
+// retry often succeeds. Bespoke copy is a product decision, not shipped here.
 function reasonCopy(reason: string | null): string {
   switch (reason) {
     case "wrong_password":

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -917,11 +917,17 @@ export type LinksReply = Omit<SessionWireLinksBundlePayload, "kind">;
 // can never drop a TERMINAL result event (unknown-is-never-fatal, #447) — the
 // modal localizes the known tokens (`wrong_password` / `nick_unavailable` /
 // `services_declined`) and shows generic copy otherwise, the friendlyChannelError
-// posture.
+// posture. #623 adds `identify_unconfirmed` (leg b) as a KNOWN token but with NO
+// bespoke copy yet — it deliberately renders the generic fallback until copy is
+// decided.
 export type RecoverStep = "identify" | "register" | "nick" | "recover" | "release";
 export type RecoverStatus = "running" | "ok" | "failed";
 export type RecoverOutcome = "succeeded" | "failed";
-export type RecoverResultReason = "wrong_password" | "nick_unavailable" | "services_declined";
+export type RecoverResultReason =
+  | "wrong_password"
+  | "nick_unavailable"
+  | "services_declined"
+  | "identify_unconfirmed";
 
 // Mirror of the events fanned out on the user-level PubSub topic
 // (`Topic.user(user_name)`), pinned by:

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -1153,6 +1153,11 @@ export type SessionWireRecoverStatus = (typeof SESSION_WIRE_RECOVER_STATUS)[numb
 export const SESSION_WIRE_RECOVER_REASON = [
   "wrong_password",
   "nick_unavailable",
+  // #623 — leg (b): the nick was reclaimed and the sameNick IDENTIFY went out,
+  // but +r never confirmed by the deadline (distinct from nick_unavailable, the
+  // nick-never-landed leg). RecoverModal has no bespoke copy for it yet → the
+  // generic reasonCopy fallback (additive-only, #447).
+  "identify_unconfirmed",
   "services_declined",
 ] as const;
 export type SessionWireRecoverReason = (typeof SESSION_WIRE_RECOVER_REASON)[number];

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -1153,12 +1153,8 @@ export type SessionWireRecoverStatus = (typeof SESSION_WIRE_RECOVER_STATUS)[numb
 export const SESSION_WIRE_RECOVER_REASON = [
   "wrong_password",
   "nick_unavailable",
-  // #623 — leg (b): the nick was reclaimed and the sameNick IDENTIFY went out,
-  // but +r never confirmed by the deadline (distinct from nick_unavailable, the
-  // nick-never-landed leg). RecoverModal has no bespoke copy for it yet → the
-  // generic reasonCopy fallback (additive-only, #447).
-  "identify_unconfirmed",
   "services_declined",
+  "identify_unconfirmed",
 ] as const;
 export type SessionWireRecoverReason = (typeof SESSION_WIRE_RECOVER_REASON)[number];
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -27301,3 +27301,67 @@ The guard deliberately does not flag `if ! cmd`, `while ! cmd` or
 point; in the third the `!` belongs to the `[` builtin, which returns
 non-zero itself, so errexit still fires. Flagging those would have taught
 people to work around the guard.
+## 2026-08-03 — #623: the post-RECOVER reclaim needed a retry, not a re-IDENTIFY
+
+**The failing signature.** `recover-identity-real.spec.ts:268` reddened in four
+CI runs across causally unrelated branches, always identically: modal
+`data-outcome="failed"`, step `nick=failed`, `recover=ok`, `identify=running`,
+~31s wall (the 30s assert burning down). Every reading of that shape was a
+guess, because the pre-#623 broadcast could not distinguish the two ways
+`:awaiting_final_r` dies: both mapped to `recover_failed_step = :nick` and the
+same `:nick_unavailable`.
+
+**Measured, not reasoned.** Ten local runs (six isolated, one full 588-spec
+suite, three with `azzurra-services` starved to 0.2 and 0.05 CPU) stayed GREEN
+— the flake wants a contended runner, not a laptop. What the wire trace showed
+instead is that the SUCCESS path was never the one the design assumed:
+
+* the initial leg's `NICK` + `IDENTIFY` go out together, the `NICK` earns a 433
+  (the holder has it), so the `IDENTIFY` is evaluated under the Guest nick.
+  Services answers `Password accepted for <nick>` ADDRESSED TO THE GUEST: no
+  `+r` (the sameNick rule), but the account IS authenticated;
+* `RECOVER` does not kill the holder — services force-renames it
+  (`NICK :Guest56004`), and completes on its own clock, 3-7s later;
+* when the rename lands, services volunteers `+r` ITSELF, 1ms after the NICK
+  echo and ~9ms BEFORE any IDENTIFY we could send in response.
+
+So `+r` is not ours in either design, and sequencing the reclaim leg cannot
+shorten it: the seconds belong to services. The sequencing (`NICK` alone →
+`:nick_observed` → `IDENTIFY`) is kept for what it demonstrably is — it stops
+firing an IDENTIFY that provably cannot commit `+r`, and leaves a sameNick one
+as the backstop for the day services stops volunteering. Backstop, not motor.
+
+**What actually failed.** The re-NICK can be refused with a 433 long after the
+settle beat — measured 5.0s after the send, in 1 run of 3 on one stack. F2 (the
+"one shot, terminal" rule from #581) treated that as permanent, so the run died
+exactly as CI dies. It is not permanent: it is a hold that has not cleared yet.
+A 433/437 in `:awaiting_nick` now re-arms the settle beat and re-sends the NICK,
+bounded by the untouched 15s deadline. That retry is the cure; the reproduction
+was a retry-absorbed red.
+
+**Diagnosability as a first-class deliverable.** Terminal legs are now distinct
+— `:nick_unavailable` (the re-NICK never landed) vs the new
+`:identify_unconfirmed` (reclaimed, `+r` never confirmed; distinct from
+`:wrong_password`, since RECOVER already proved the password) — and the
+terminal broadcast reconciles every in-flight step instead of one, so the modal
+stops stranding `identify` at `running`. Four reds told us nothing; the fifth
+will name its leg.
+
+**Both timing constants stay put.** 800ms settle, 15s overall. The happy path
+costs 3-7s of services clock, so the headroom is thinner than it reads — that
+is a FINDING for a real failing trace to settle, not a knob to turn while the
+suite is green (`server.ex` says as much in the comment above the constant).
+
+**Test ergonomics were part of the bug.** The spec pinned a constant recover
+nick, and a NickServ registration is once-per-nick-per-container: the second
+run on a persistent testnet answered "already registered", resolved the
+register barrier instantly and then hung the mail wait. So `--repeat-each` —
+the iso-rerun discipline `docs/TESTING.md` mandates for flake triage — was
+unusable on the one spec that needed it, and every attempt cost a full testnet
+cycle. Stamping the nick per run is what made the 433 show up at all.
+
+**Lesson.** A green test can be green for a reason nobody designed: here the
+success depended on services re-emitting `+r` after a foreign-nick IDENTIFY
+that the code believed was the thing committing it. Trace the wire before
+theorising about a flake, and when a spec cannot be re-run in place, fix that
+FIRST — the triage discipline is worthless against a spec that only runs once.

--- a/lib/grappa/session/recover_identity.ex
+++ b/lib/grappa/session/recover_identity.ex
@@ -27,35 +27,69 @@ defmodule Grappa.Session.RecoverIdentity do
   ON the reclaimed nick is what commits.
 
   So `+r` cannot arrive while on a Guest nick. You must be ON the
-  credential nick AND `IDENTIFY` (sameNick) to get `+r`. The sequence
-  therefore sends `NICK` and `IDENTIFY` TOGETHER (mirroring
-  `GhostRecovery`'s `:succeeded` `["NICK …", "IDENTIFY …"]` emit) and
-  waits for `+r` as the SUCCESS signal:
+  credential nick AND `IDENTIFY` (sameNick) to get `+r`.
 
-  1. `:start` → `NICK <cred_nick>` + `IDENTIFY <cred_nick> <secret>`,
-     transition `:awaiting_r`.
+  ## The RECLAIM leg is SEQUENCED, not raced (GH #623, 2026-08-01)
+
+  The reclaim leg (after a held-nick `RECOVER`/`RELEASE`) used to flush
+  `NICK` + `IDENTIFY` together, then wait a fixed 800ms and re-flush both
+  together. Against real, contended services that races two ways:
+
+    * the `IDENTIFY` is evaluated by services BEFORE the `NICK` change has
+      propagated → a foreign-nick (Guest) identify → NOTICE, **no `+r`**
+      (the sameNick rule); and
+    * the single fixed-800ms re-`NICK` can hit a `433` because `RECOVER`
+      freed the hold asynchronously and the hold is not clear YET — a
+      one-shot failure with no retry.
+
+  #623 fixes both without inflating any timing constant:
+
+  1. `:idle` → `NICK <cred_nick>` + `IDENTIFY <cred_nick> <secret>`,
+     transition `:awaiting_r`. (The INITIAL leg keeps them together: a
+     FREE nick lands with no hold to propagate, so the trailing IDENTIFY
+     is sameNick.)
   2. `:r_observed` (the `+r` umode landed — fed by the host from
      `EventRouter`'s identity signal, NOT parsed here) → `:succeeded`.
   3. `{:nick_error, 433}` (nick in use) → `RECOVER`; `{:nick_error, 437}`
      (services hold) → `RELEASE`; transition `:awaiting_verb_settle`. (The
      `IDENTIFY` sent in step 1 was a foreign-nick identify — no `+r`, per
      the sameNick rule; it is harmless and re-sent below.)
-  4. `:settle` (host's short post-verb settle tick) → `NICK <cred_nick>` +
-     `IDENTIFY <cred_nick> <secret>`, transition `:awaiting_final_r`.
-  5. `:r_observed` → `:succeeded`. A refused final `NICK` (`{:nick_error,
-     _}`) is **terminal `:failed`** — F2 (vjt 2026-07-31): an empty retry
-     never wins the nick, which is exactly why the verb is `RECOVER`. No
-     retry loop.
-  6. `:timeout` (host's overall deadline) in any non-terminal phase →
-     `:failed`, phase-appropriate reason (`:wrong_password` if `+r` never
-     came after a clean NICK; `:services_declined` if the verb went
-     unanswered; `:nick_unavailable` if the reclaimed NICK still failed).
+  4. `:settle` (host's short post-verb settle tick) → `NICK <cred_nick>`
+     **ALONE**, transition `:awaiting_nick`. The IDENTIFY is deliberately
+     withheld until the nick change is OBSERVED.
+  5. `:nick_observed` (the host saw `state.nick` become the credential
+     nick) → `IDENTIFY <cred_nick> <secret>` (now provably sameNick),
+     transition `:awaiting_final_r`.
+  6. `{:nick_error, 433 | 437}` on the re-NICK (`:awaiting_nick`) → the
+     hold has not cleared YET → a bounded **RETRY**: transition back to
+     `:awaiting_verb_settle` (no line — the host re-arms the settle beat,
+     which re-sends the `NICK`). `RECOVER` is NOT re-issued. The loop is
+     bounded by the host's overall 15s deadline, NOT this FSM. This
+     REVERSES the earlier F2 "one shot, terminal" rule: an empty retry
+     never wins the nick, but a re-NICK as an async hold clears does.
+  7. `:r_observed` → `:succeeded`.
+
+  ### Terminal legs are DISTINCT + trace-diagnosable (GH #623 pt3)
+
+  `:timeout` (host's overall deadline) in any non-terminal phase →
+  `:failed`, phase-appropriate reason:
+
+    * `:awaiting_r` → `:wrong_password` (a clean NICK with no `+r` — the
+      IDENTIFY was rejected).
+    * `:awaiting_verb_settle` → `:services_declined` (the verb went
+      unanswered).
+    * `:awaiting_nick` → `:nick_unavailable` (**leg a**: the re-NICK never
+      landed — the hold never cleared / services kept renaming us).
+    * `:awaiting_final_r` → `:identify_unconfirmed` (**leg b**: the nick
+      WAS reclaimed and the sameNick IDENTIFY went out, but `+r` never
+      confirmed). Distinct from `:wrong_password` — `RECOVER` already
+      password-authenticated, so the password is proven correct.
 
   Wire lines carry the credential nick **RAW** — its case is
   presentation (the key/display/wire split, GH #121/#537). The FSM emits
   no broadcasts and arms no timers: the host (`Grappa.Session.Server`)
-  owns I/O, the overall deadline, the settle tick, and the progress
-  broadcasts.
+  owns I/O, the overall deadline, the settle tick, the `:nick_observed`
+  feed, and the progress broadcasts.
 
   Boundary: inherits the parent `Grappa.Session` boundary — same pattern
   as sibling submodules `Server`, `EventRouter`, `GhostRecovery`. No `use
@@ -68,19 +102,26 @@ defmodule Grappa.Session.RecoverIdentity do
           :idle
           | :awaiting_r
           | :awaiting_verb_settle
+          | :awaiting_nick
           | :awaiting_final_r
           | :succeeded
           | :failed
 
   @type verb :: :recover | :release | nil
 
-  @type reason :: :wrong_password | :nick_unavailable | :services_declined | nil
+  @type reason ::
+          :wrong_password
+          | :nick_unavailable
+          | :services_declined
+          | :identify_unconfirmed
+          | nil
 
   @type input ::
           :start
           | :r_observed
           | {:nick_error, 433 | 437}
           | :settle
+          | :nick_observed
           | :timeout
 
   @type t :: %__MODULE__{
@@ -115,7 +156,7 @@ defmodule Grappa.Session.RecoverIdentity do
   @spec step(t(), input()) :: {:cont, t(), [String.t()]} | {:stop, t(), [String.t()]}
 
   def step(%__MODULE__{phase: :idle} = s, :start) do
-    {:cont, %{s | phase: :awaiting_r}, take_and_identify(s)}
+    {:cont, %{s | phase: :awaiting_r}, take(s) ++ identify(s)}
   end
 
   def step(%__MODULE__{phase: :awaiting_r} = s, :r_observed) do
@@ -136,37 +177,56 @@ defmodule Grappa.Session.RecoverIdentity do
     {:stop, %{s | phase: :failed, reason: :wrong_password}, []}
   end
 
+  # #623: the settle tick sends the re-NICK ALONE — the IDENTIFY waits for
+  # `:nick_observed` so it can never land under the old (Guest) nick.
   def step(%__MODULE__{phase: :awaiting_verb_settle} = s, :settle) do
-    {:cont, %{s | phase: :awaiting_final_r}, take_and_identify(s)}
+    {:cont, %{s | phase: :awaiting_nick}, take(s)}
   end
 
   def step(%__MODULE__{phase: :awaiting_verb_settle} = s, :timeout) do
     {:stop, %{s | phase: :failed, reason: :services_declined}, []}
   end
 
+  # #623: the re-NICK landed AND was observed → we are provably on the
+  # credential nick, so this IDENTIFY is sameNick and commits `+r`.
+  def step(%__MODULE__{phase: :awaiting_nick} = s, :nick_observed) do
+    {:cont, %{s | phase: :awaiting_final_r}, identify(s)}
+  end
+
+  # #623: a refused re-NICK means the hold has NOT cleared yet (RECOVER
+  # freed it asynchronously). Bounded RETRY — go back to
+  # `:awaiting_verb_settle` so the host re-arms the settle beat and
+  # re-sends the NICK. No line here (RECOVER is NOT re-issued); the loop is
+  # bounded by the host's 15s overall deadline. Reverses F2.
+  def step(%__MODULE__{phase: :awaiting_nick} = s, {:nick_error, code}) when code in [433, 437] do
+    {:cont, %{s | phase: :awaiting_verb_settle}, []}
+  end
+
+  def step(%__MODULE__{phase: :awaiting_nick} = s, :timeout) do
+    # leg (a): the re-NICK never landed within the deadline.
+    {:stop, %{s | phase: :failed, reason: :nick_unavailable}, []}
+  end
+
   def step(%__MODULE__{phase: :awaiting_final_r} = s, :r_observed) do
     {:stop, %{s | phase: :succeeded}, []}
   end
 
-  # F2 (vjt 2026-07-31): the post-verb NICK gets ONE shot. A refusal is
-  # TERMINAL — no retry line, no loop. An empty retry never wins the nick.
-  def step(%__MODULE__{phase: :awaiting_final_r} = s, {:nick_error, _}) do
-    {:stop, %{s | phase: :failed, reason: :nick_unavailable}, []}
-  end
-
   def step(%__MODULE__{phase: :awaiting_final_r} = s, :timeout) do
-    {:stop, %{s | phase: :failed, reason: :nick_unavailable}, []}
+    # leg (b): the nick WAS reclaimed and the sameNick IDENTIFY went out,
+    # but `+r` never confirmed. NOT `:wrong_password` — RECOVER already
+    # proved the password correct.
+    {:stop, %{s | phase: :failed, reason: :identify_unconfirmed}, []}
   end
 
   def step(state, _), do: {:cont, state, []}
 
-  # NICK to the credential nick + IDENTIFY for it, in ONE flush. Order
-  # matters: NICK first so the IDENTIFY that follows is `sameNick` and
-  # thus commits `+r` (mirrors `GhostRecovery`'s `:succeeded` emit). If
-  # the NICK fails, the IDENTIFY is a harmless foreign-nick identify (no
-  # `+r`) and the sequence reclaims off the 433/437.
-  @spec take_and_identify(t()) :: [String.t()]
-  defp take_and_identify(%__MODULE__{cred_nick: nick, secret: secret}) do
-    ["NICK #{nick}\r\n", "PRIVMSG NickServ :IDENTIFY #{nick} #{secret}\r\n"]
-  end
+  # NICK to the credential nick. RAW case (key/display/wire split).
+  @spec take(t()) :: [String.t()]
+  defp take(%__MODULE__{cred_nick: nick}), do: ["NICK #{nick}\r\n"]
+
+  # IDENTIFY for the credential nick. RAW case. Only ever sameNick — the
+  # initial leg (NICK just sent, free nick) or after `:nick_observed`.
+  @spec identify(t()) :: [String.t()]
+  defp identify(%__MODULE__{cred_nick: nick, secret: secret}),
+    do: ["PRIVMSG NickServ :IDENTIFY #{nick} #{secret}\r\n"]
 end

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -4030,6 +4030,10 @@ defmodule Grappa.Session.Server do
         %{state | recover_identity: nil, recover_timer: nil, recover_settle_timer: nil}
 
       :awaiting_verb_settle ->
+        # #623 — the reclaim RETRY re-enters this phase (a 433/437 on the
+        # re-NICK). Drain any spent/pending settle timer before re-arming so a
+        # retry never double-arms a stale :recover_settle.
+        :ok = cancel_and_drain(state.recover_settle_timer, :recover_settle)
         settle = Process.send_after(self(), :recover_settle, @recover_settle_ms)
         %{state | recover_identity: next, recover_settle_timer: settle}
 
@@ -4085,26 +4089,60 @@ defmodule Grappa.Session.Server do
   defp recover_progress_steps(:awaiting_r, %{phase: :awaiting_verb_settle, verb: verb}),
     do: [{:nick, :failed, nil}, {verb, :running, nil}]
 
-  defp recover_progress_steps(:awaiting_verb_settle, %{phase: :awaiting_final_r, verb: verb}),
-    do: [{verb, :ok, nil}, {:nick, :running, nil}, {:identify, :running, nil}]
+  # #623 — the verb settled; the re-NICK goes out ALONE. Only the nick step
+  # runs now — the identify step waits for `:nick_observed` (the sequencing
+  # barrier), so the modal never shows identify running before the nick lands.
+  defp recover_progress_steps(:awaiting_verb_settle, %{phase: :awaiting_nick, verb: verb}),
+    do: [{verb, :ok, nil}, {:nick, :running, nil}]
+
+  # #623 — the re-NICK was observed on-nick; the sameNick IDENTIFY goes out now.
+  defp recover_progress_steps(:awaiting_nick, %{phase: :awaiting_final_r}),
+    do: [{:nick, :ok, nil}, {:identify, :running, nil}]
 
   defp recover_progress_steps(_, %{phase: :succeeded}),
     do: [{:nick, :ok, nil}, {:identify, :ok, nil}, {:register, :ok, nil}]
 
+  # #623 pt3 — RECONCILE every in-flight step on terminal :failed (not just one)
+  # so the modal never strands a step at :running (the trace "hang"), keyed on
+  # the phase we failed OUT of.
   defp recover_progress_steps(old, %{phase: :failed, reason: reason, verb: verb}),
-    do: [{recover_failed_step(old, verb), :failed, reason}]
+    do: recover_terminal_steps(old, verb, reason)
 
+  # #623 — the retry (`:awaiting_nick` → `:awaiting_verb_settle`) and every
+  # other transition are SILENT: no visible retry churn.
   defp recover_progress_steps(_, _), do: []
 
-  # The step that FAILED, keyed on the phase we failed OUT of: a clean
-  # NICK with no `+r` is an IDENTIFY (wrong password) failure; an
-  # unanswered verb is the verb; a reclaimed NICK that still can't land is
-  # the NICK.
-  @spec recover_failed_step(RecoverIdentity.phase(), RecoverIdentity.verb()) :: SessionWire.recover_step()
-  defp recover_failed_step(:awaiting_r, _), do: :identify
-  defp recover_failed_step(:awaiting_verb_settle, verb) when verb in [:recover, :release], do: verb
-  defp recover_failed_step(:awaiting_final_r, _), do: :nick
-  defp recover_failed_step(_, _), do: :nick
+  # #623 pt3 — the reconciled terminal step list, keyed on the phase we failed
+  # OUT of. Every step still :running at that phase is flipped to its terminal
+  # status, and the two reclaim legs stay DISTINCT + trace-diagnosable:
+  #   * `:awaiting_r` — a clean NICK but `+r` never came → the IDENTIFY failed
+  #     (`:wrong_password`); the nick itself landed clean (`:ok`).
+  #   * `:awaiting_verb_settle` — the reclaim verb went unanswered → the verb
+  #     failed (`:services_declined`).
+  #   * `:awaiting_nick` — leg (a): the re-NICK never landed → the nick failed
+  #     (`:nick_unavailable`); the identify step never started.
+  #   * `:awaiting_final_r` — leg (b): the re-NICK landed but `+r` never
+  #     confirmed → the identify failed (`:identify_unconfirmed`); the nick is
+  #     already `:ok`.
+  @spec recover_terminal_steps(
+          RecoverIdentity.phase(),
+          RecoverIdentity.verb(),
+          RecoverIdentity.reason()
+        ) :: [{SessionWire.recover_step(), SessionWire.recover_status(), SessionWire.recover_reason() | nil}]
+  defp recover_terminal_steps(:awaiting_r, _verb, reason),
+    do: [{:nick, :ok, nil}, {:identify, :failed, reason}]
+
+  defp recover_terminal_steps(:awaiting_verb_settle, verb, reason) when verb in [:recover, :release],
+    do: [{verb, :failed, reason}]
+
+  defp recover_terminal_steps(:awaiting_nick, _verb, reason),
+    do: [{:nick, :failed, reason}]
+
+  defp recover_terminal_steps(:awaiting_final_r, _verb, reason),
+    do: [{:nick, :ok, nil}, {:identify, :failed, reason}]
+
+  defp recover_terminal_steps(_old, _verb, reason),
+    do: [{:nick, :failed, reason}]
 
   # Build the IRC.Client opts map from the pre-resolved primitive
   # plan. Nick-fallback + Cloak password decryption already happened
@@ -4301,6 +4339,10 @@ defmodule Grappa.Session.Server do
     next_state = effects |> apply_effects(derived_state) |> prune_seeded_channels()
     maybe_broadcast_channels_changed(state, next_state)
     maybe_broadcast_own_nick_changed(state, next_state)
+    # #623 — a self-NICK arrives as a :nick command → this delegate path (never
+    # the numeric path). Feed the recover FSM `:nick_observed` when our nick
+    # just landed on the credential nick the reclaim leg is chasing.
+    next_state = maybe_advance_recover_on_nick(state, next_state)
     {:noreply, next_state}
   end
 
@@ -4426,6 +4468,30 @@ defmodule Grappa.Session.Server do
   end
 
   defp maybe_broadcast_own_nick_changed(_, _), do: :ok
+
+  # #623 — feed the recover FSM `:nick_observed` when our OWN nick just changed
+  # to the credential nick the reclaim leg is chasing. This is the sequencing
+  # barrier: the FSM withholds the reclaim IDENTIFY until the NICK is provably
+  # landed, so a services-side ordering lag can never leave the IDENTIFY under
+  # the old (Guest) nick, where sameNick fails and `+r` never arrives. Only
+  # fires in `:awaiting_nick`; every other phase — and a non-recover nick change
+  # — is a no-op. `Map.get` for #229 hot-reload safety (a proc predating the
+  # `:recover_identity` field has no such key). The compare folds both sides
+  # (nick KEYs fold, GH #121/#537).
+  @spec maybe_advance_recover_on_nick(t(), t()) :: t()
+  defp maybe_advance_recover_on_nick(%{nick: prev}, %{nick: next} = state) when prev != next do
+    case Map.get(state, :recover_identity) do
+      %RecoverIdentity{phase: :awaiting_nick, cred_nick: cred} ->
+        if fold_key(state, next) == fold_key(state, cred),
+          do: advance_recover(state, :nick_observed),
+          else: state
+
+      _ ->
+        state
+    end
+  end
+
+  defp maybe_advance_recover_on_nick(_prev, state), do: state
 
   # #498 — mirror `state.nick` into this session's own SessionRegistry entry
   # value. The ONE writer of the cheap live-nick copy: it always writes

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -4129,19 +4129,19 @@ defmodule Grappa.Session.Server do
           RecoverIdentity.verb(),
           RecoverIdentity.reason()
         ) :: [{SessionWire.recover_step(), SessionWire.recover_status(), SessionWire.recover_reason() | nil}]
-  defp recover_terminal_steps(:awaiting_r, _verb, reason),
+  defp recover_terminal_steps(:awaiting_r, _, reason),
     do: [{:nick, :ok, nil}, {:identify, :failed, reason}]
 
   defp recover_terminal_steps(:awaiting_verb_settle, verb, reason) when verb in [:recover, :release],
     do: [{verb, :failed, reason}]
 
-  defp recover_terminal_steps(:awaiting_nick, _verb, reason),
+  defp recover_terminal_steps(:awaiting_nick, _, reason),
     do: [{:nick, :failed, reason}]
 
-  defp recover_terminal_steps(:awaiting_final_r, _verb, reason),
+  defp recover_terminal_steps(:awaiting_final_r, _, reason),
     do: [{:nick, :ok, nil}, {:identify, :failed, reason}]
 
-  defp recover_terminal_steps(_old, _verb, reason),
+  defp recover_terminal_steps(_, _, reason),
     do: [{:nick, :failed, reason}]
 
   # Build the IRC.Client opts map from the pre-resolved primitive
@@ -4342,8 +4342,7 @@ defmodule Grappa.Session.Server do
     # #623 — a self-NICK arrives as a :nick command → this delegate path (never
     # the numeric path). Feed the recover FSM `:nick_observed` when our nick
     # just landed on the credential nick the reclaim leg is chasing.
-    next_state = maybe_advance_recover_on_nick(state, next_state)
-    {:noreply, next_state}
+    {:noreply, maybe_advance_recover_on_nick(state, next_state)}
   end
 
   # CP24 bucket E web/S8: keep `seeded_channels` consistent with
@@ -4491,7 +4490,7 @@ defmodule Grappa.Session.Server do
     end
   end
 
-  defp maybe_advance_recover_on_nick(_prev, state), do: state
+  defp maybe_advance_recover_on_nick(_, state), do: state
 
   # #498 — mirror `state.nick` into this session's own SessionRegistry entry
   # value. The ONE writer of the cheap live-nick copy: it always writes

--- a/lib/grappa/session/wire.ex
+++ b/lib/grappa/session/wire.ex
@@ -737,7 +737,14 @@ defmodule Grappa.Session.Wire do
 
   @type recover_status :: :running | :ok | :failed
 
-  @type recover_reason :: :wrong_password | :nick_unavailable | :services_declined
+  # #623 — `:identify_unconfirmed` (leg b): the nick WAS reclaimed and the
+  # sameNick IDENTIFY went out, but `+r` never confirmed by the deadline.
+  # DISTINCT from `:nick_unavailable` (leg a: the nick never landed) and from
+  # `:wrong_password` (RECOVER already proved the password correct). Additive
+  # per the wire contract — cic falls back to generic failure copy for an
+  # unrecognised token.
+  @type recover_reason ::
+          :wrong_password | :nick_unavailable | :services_declined | :identify_unconfirmed
 
   @type recover_progress_payload :: %{
           kind: :recover_progress,
@@ -1536,7 +1543,8 @@ defmodule Grappa.Session.Wire do
       when is_binary(network_slug) and
              step in [:identify, :register, :nick, :recover, :release] and
              status in [:running, :ok, :failed] and
-             (is_nil(reason) or reason in [:wrong_password, :nick_unavailable, :services_declined]) do
+             (is_nil(reason) or
+                reason in [:wrong_password, :nick_unavailable, :services_declined, :identify_unconfirmed]) do
     %{kind: :recover_progress, network: network_slug, step: step, status: status, reason: reason}
   end
 
@@ -1549,7 +1557,8 @@ defmodule Grappa.Session.Wire do
           recover_result_payload()
   def recover_result(network_slug, outcome, reason)
       when is_binary(network_slug) and outcome in [:succeeded, :failed] and
-             (is_nil(reason) or reason in [:wrong_password, :nick_unavailable, :services_declined]) do
+             (is_nil(reason) or
+                reason in [:wrong_password, :nick_unavailable, :services_declined, :identify_unconfirmed]) do
     %{kind: :recover_result, network: network_slug, outcome: outcome, reason: reason}
   end
 end

--- a/test/grappa/session/recover_identity_test.exs
+++ b/test/grappa/session/recover_identity_test.exs
@@ -4,9 +4,19 @@ defmodule Grappa.Session.RecoverIdentityTest do
   alias Grappa.Session.RecoverIdentity
 
   # Source-verified ordering (GH #581): `+r` is per-nick and only lands
-  # when you IDENTIFY while ON the registered nick (sameNick). So the
-  # sequence sends NICK + IDENTIFY together and waits for `+r` as success;
-  # a 433/437 drives a RECOVER/RELEASE detour, then one retry.
+  # when you IDENTIFY while ON the registered nick (sameNick).
+  #
+  # #623 — the RECLAIM leg is now SEQUENCED, not raced. After a 433/437
+  # the FSM sends RECOVER/RELEASE, then on the settle tick sends the
+  # re-NICK ALONE and waits for the nick change to be OBSERVED
+  # (`:nick_observed`) before the IDENTIFY — a services-side ordering lag
+  # can no longer land the IDENTIFY under the OLD (Guest) nick, which
+  # never yields `+r`. A 433/437 on the re-NICK is a bounded RETRY (the
+  # hold has not cleared yet), NOT a one-shot failure (reverses F2), all
+  # inside the host's untouched 15s overall deadline. The two terminal
+  # legs are now DISTINCT + trace-diagnosable: nick-never-reclaimed →
+  # :nick_unavailable (leg a, `:awaiting_nick`), reclaimed-but-+r-never-
+  # confirmed → :identify_unconfirmed (leg b, `:awaiting_final_r`).
 
   describe "init/2" do
     test "starts in :idle with cred_nick + secret populated, no verb/reason" do
@@ -28,6 +38,10 @@ defmodule Grappa.Session.RecoverIdentityTest do
 
       assert next.phase == :awaiting_r
       # NICK MUST precede IDENTIFY so the identify is sameNick and commits +r.
+      # The INITIAL leg keeps NICK+IDENTIFY together: when the nick is free the
+      # NICK lands with no hold to propagate, so the trailing IDENTIFY is
+      # sameNick. (The RECLAIM leg — after RECOVER forced off a live holder —
+      # is the racy one #623 sequences.)
       assert lines == ["NICK vjt\r\n", "PRIVMSG NickServ :IDENTIFY vjt s3cret\r\n"]
     end
 
@@ -50,7 +64,7 @@ defmodule Grappa.Session.RecoverIdentityTest do
     end
   end
 
-  describe "step/2 — nick held → verb → settle → one retry" do
+  describe "step/2 — nick held → verb → settle" do
     test ":awaiting_r + {:nick_error, 433} → :awaiting_verb_settle verb :recover + RECOVER" do
       state = %RecoverIdentity{phase: :awaiting_r, cred_nick: "vjt", secret: "s3cret"}
 
@@ -71,7 +85,7 @@ defmodule Grappa.Session.RecoverIdentityTest do
       assert lines == ["PRIVMSG NickServ :RELEASE vjt s3cret\r\n"]
     end
 
-    test ":awaiting_verb_settle + :settle → :awaiting_final_r + NICK then IDENTIFY" do
+    test ":awaiting_verb_settle + :settle → :awaiting_nick + NICK ALONE (no IDENTIFY yet)" do
       state = %RecoverIdentity{
         phase: :awaiting_verb_settle,
         cred_nick: "vjt",
@@ -81,8 +95,37 @@ defmodule Grappa.Session.RecoverIdentityTest do
 
       assert {:cont, next, lines} = RecoverIdentity.step(state, :settle)
 
+      # #623: NICK ALONE. The IDENTIFY waits for :nick_observed so it can never
+      # land under the old (Guest) nick and silently fail to grant +r.
+      assert next.phase == :awaiting_nick
+      assert next.verb == :recover
+      assert lines == ["NICK vjt\r\n"]
+    end
+
+    test ":awaiting_verb_settle + :timeout → :failed :services_declined" do
+      state = %RecoverIdentity{phase: :awaiting_verb_settle, cred_nick: "vjt", verb: :recover}
+
+      assert {:stop, next, []} = RecoverIdentity.step(state, :timeout)
+      assert next.phase == :failed
+      assert next.reason == :services_declined
+    end
+  end
+
+  describe "step/2 — #623 reclaim leg: IDENTIFY only after the nick change is OBSERVED" do
+    test ":awaiting_nick + :nick_observed → :awaiting_final_r + IDENTIFY ALONE" do
+      state = %RecoverIdentity{
+        phase: :awaiting_nick,
+        cred_nick: "vjt",
+        secret: "s3cret",
+        verb: :recover
+      }
+
+      assert {:cont, next, lines} = RecoverIdentity.step(state, :nick_observed)
+
       assert next.phase == :awaiting_final_r
-      assert lines == ["NICK vjt\r\n", "PRIVMSG NickServ :IDENTIFY vjt s3cret\r\n"]
+      # We are now provably ON the credential nick, so this IDENTIFY is sameNick
+      # and commits +r.
+      assert lines == ["PRIVMSG NickServ :IDENTIFY vjt s3cret\r\n"]
     end
 
     test ":awaiting_final_r + :r_observed → :succeeded" do
@@ -96,55 +139,96 @@ defmodule Grappa.Session.RecoverIdentityTest do
       assert {:stop, next, []} = RecoverIdentity.step(state, :r_observed)
       assert next.phase == :succeeded
     end
-
-    test ":awaiting_verb_settle + :timeout → :failed :services_declined" do
-      state = %RecoverIdentity{phase: :awaiting_verb_settle, cred_nick: "vjt", verb: :recover}
-
-      assert {:stop, next, []} = RecoverIdentity.step(state, :timeout)
-      assert next.phase == :failed
-      assert next.reason == :services_declined
-    end
   end
 
-  describe "step/2 — F2: a refused NICK after the verb is TERMINAL, never retried" do
-    # F2 (vjt 2026-07-31): a refused NICK after the verb has done its job is
-    # a FAILURE, not a retry. RECOVER was chosen precisely because an empty
-    # retry never wins the nick. The retry gets ONE shot; refusal = failed,
-    # and CRUCIALLY the FSM emits NO further NICK line — no loop.
-    test ":awaiting_final_r + {:nick_error, 433} → :failed :nick_unavailable, NO retry line" do
+  describe "step/2 — #623 bounded retry: a 433/437 on the re-NICK is a RETRY, not a one-shot fail" do
+    # #623 reverses F2. A refused re-NICK means the hold has not cleared YET —
+    # services freed it asynchronously and are lagging. Retrying the NICK as
+    # the hold clears is exactly what absorbs the jitter; it is NOT an "empty
+    # retry" (RECOVER already ran, so we do NOT re-issue it). The retry emits
+    # NO line — it returns to :awaiting_verb_settle so the host re-arms the
+    # settle beat, which re-sends the NICK. The loop is bounded by the host's
+    # untouched 15s overall deadline.
+    test ":awaiting_nick + {:nick_error, 433} → :awaiting_verb_settle (retry), verb kept, NO line" do
       state = %RecoverIdentity{
-        phase: :awaiting_final_r,
+        phase: :awaiting_nick,
         cred_nick: "vjt",
         secret: "s3cret",
         verb: :recover
       }
 
-      assert {:stop, next, lines} = RecoverIdentity.step(state, {:nick_error, 433})
-      assert next.phase == :failed
-      assert next.reason == :nick_unavailable
+      assert {:cont, next, lines} = RecoverIdentity.step(state, {:nick_error, 433})
+      assert next.phase == :awaiting_verb_settle
+      assert next.verb == :recover
+      # No RECOVER re-issue, no NICK here — the settle tick re-sends the NICK.
       assert lines == []
     end
 
-    test ":awaiting_final_r + {:nick_error, 437} → :failed :nick_unavailable, NO retry line" do
+    test ":awaiting_nick + {:nick_error, 437} → :awaiting_verb_settle (retry), verb kept, NO line" do
       state = %RecoverIdentity{
-        phase: :awaiting_final_r,
+        phase: :awaiting_nick,
         cred_nick: "vjt",
         secret: "s3cret",
         verb: :release
       }
 
-      assert {:stop, next, lines} = RecoverIdentity.step(state, {:nick_error, 437})
-      assert next.phase == :failed
-      assert next.reason == :nick_unavailable
+      assert {:cont, next, lines} = RecoverIdentity.step(state, {:nick_error, 437})
+      assert next.phase == :awaiting_verb_settle
+      assert next.verb == :release
       assert lines == []
     end
 
-    test ":awaiting_final_r + :timeout → :failed :nick_unavailable" do
-      state = %RecoverIdentity{phase: :awaiting_final_r, cred_nick: "vjt", verb: :recover}
+    test "full reclaim loop: verb → settle → 433 (retry) → settle → nick_observed → +r → succeeded" do
+      state = RecoverIdentity.init("vjt", "s3cret")
+
+      assert {:cont, s1, _} = RecoverIdentity.step(state, :start)
+
+      assert {:cont, s2, ["PRIVMSG NickServ :RECOVER vjt s3cret\r\n"]} =
+               RecoverIdentity.step(s1, {:nick_error, 433})
+
+      assert s2.phase == :awaiting_verb_settle
+
+      # First settle → NICK; the hold has NOT cleared yet → 433 → retry.
+      assert {:cont, s3, ["NICK vjt\r\n"]} = RecoverIdentity.step(s2, :settle)
+      assert s3.phase == :awaiting_nick
+      assert {:cont, s4, []} = RecoverIdentity.step(s3, {:nick_error, 433})
+      assert s4.phase == :awaiting_verb_settle
+
+      # Second settle → NICK; this time it lands and is OBSERVED → IDENTIFY.
+      assert {:cont, s5, ["NICK vjt\r\n"]} = RecoverIdentity.step(s4, :settle)
+      assert s5.phase == :awaiting_nick
+
+      assert {:cont, s6, ["PRIVMSG NickServ :IDENTIFY vjt s3cret\r\n"]} =
+               RecoverIdentity.step(s5, :nick_observed)
+
+      assert s6.phase == :awaiting_final_r
+
+      assert {:stop, s7, []} = RecoverIdentity.step(s6, :r_observed)
+      assert s7.phase == :succeeded
+    end
+  end
+
+  describe "step/2 — #623 distinct terminal legs (trace-diagnosable)" do
+    # leg (a): the re-NICK never lands within the deadline (the hold never
+    # cleared, or services kept renaming us) → :nick_unavailable.
+    test ":awaiting_nick + :timeout → :failed :nick_unavailable (leg a)" do
+      state = %RecoverIdentity{phase: :awaiting_nick, cred_nick: "vjt", verb: :recover}
 
       assert {:stop, next, []} = RecoverIdentity.step(state, :timeout)
       assert next.phase == :failed
       assert next.reason == :nick_unavailable
+    end
+
+    # leg (b): the re-NICK landed (we are ON the nick) and the sameNick
+    # IDENTIFY went out, but +r never confirmed by the deadline → a DISTINCT
+    # reason from leg (a). Password is proven correct (RECOVER ran), so this
+    # is NOT :wrong_password.
+    test ":awaiting_final_r + :timeout → :failed :identify_unconfirmed (leg b)" do
+      state = %RecoverIdentity{phase: :awaiting_final_r, cred_nick: "vjt", verb: :recover}
+
+      assert {:stop, next, []} = RecoverIdentity.step(state, :timeout)
+      assert next.phase == :failed
+      assert next.reason == :identify_unconfirmed
     end
   end
 
@@ -156,16 +240,24 @@ defmodule Grappa.Session.RecoverIdentityTest do
       assert {:cont, r1, l1} = RecoverIdentity.step(state, :start)
       assert l1 == ["NICK Vjt\r\n", "PRIVMSG NickServ :IDENTIFY Vjt s3cret\r\n"]
 
-      assert {:cont, _, l2} = RecoverIdentity.step(r1, {:nick_error, 433})
+      assert {:cont, r2, l2} = RecoverIdentity.step(r1, {:nick_error, 433})
       assert l2 == ["PRIVMSG NickServ :RECOVER Vjt s3cret\r\n"]
+
+      # The reclaim leg keeps the raw case too — NICK alone, then IDENTIFY alone.
+      assert {:cont, r3, ["NICK Vjt\r\n"]} = RecoverIdentity.step(r2, :settle)
+
+      assert {:cont, _, ["PRIVMSG NickServ :IDENTIFY Vjt s3cret\r\n"]} =
+               RecoverIdentity.step(r3, :nick_observed)
     end
   end
 
   describe "step/2 — no-ops (off-phase inputs and terminal passthrough)" do
     test "off-phase input is a no-op {:cont, state, []}" do
       state = %RecoverIdentity{phase: :awaiting_r, cred_nick: "vjt", secret: "s3cret"}
-      # :settle is only valid in :awaiting_verb_settle
+      # :settle is only valid in :awaiting_verb_settle; :nick_observed only in
+      # :awaiting_nick.
       assert {:cont, ^state, []} = RecoverIdentity.step(state, :settle)
+      assert {:cont, ^state, []} = RecoverIdentity.step(state, :nick_observed)
     end
 
     test "a :start on an already-started FSM is a no-op" do
@@ -180,6 +272,7 @@ defmodule Grappa.Session.RecoverIdentityTest do
         assert {:cont, ^state, []} = RecoverIdentity.step(state, :r_observed)
         assert {:cont, ^state, []} = RecoverIdentity.step(state, {:nick_error, 433})
         assert {:cont, ^state, []} = RecoverIdentity.step(state, :settle)
+        assert {:cont, ^state, []} = RecoverIdentity.step(state, :nick_observed)
         assert {:cont, ^state, []} = RecoverIdentity.step(state, :timeout)
       end
     end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -33,7 +33,7 @@ defmodule Grappa.Session.ServerTest do
   alias Grappa.IRC.Message
   alias Grappa.{IRCServer, PubSub.Topic, QueryWindows, Repo, Scrollback, Session, WSPresence}
   alias Grappa.Networks.{Credentials, SessionPlan}
-  alias Grappa.Session.{AwayState, Backoff, GhostRecovery, ISupport, Server, WindowState}
+  alias Grappa.Session.{AwayState, Backoff, GhostRecovery, ISupport, RecoverIdentity, Server, WindowState}
   alias Grappa.SessionStateHelpers
   alias Grappa.WindowCounts.PushSource
 
@@ -10460,11 +10460,14 @@ defmodule Grappa.Session.ServerTest do
                      1_000
     end
 
-    test "nick held (433) → RECOVER; then settle → +r → succeeded" do
+    test "nick held (433) → RECOVER → settle → re-NICK observed → +r → succeeded" do
       %{server: server, pid: pid, subject: subject, network: network, label: label} =
         start_recover_visitor("s3cret")
 
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(label))
+      # Parked-on-Guest: force a Guest nick so the reclaim NICK to the
+      # credential nick is a genuine, observable transition (#623 sequencing).
+      _ = :sys.replace_state(pid, fn state -> %{state | nick: "guestx"} end)
 
       assert :ok = Session.recover_identity(subject, network.id)
 
@@ -10478,9 +10481,18 @@ defmodule Grappa.Session.ServerTest do
                  1_000
                )
 
-      # Drive the post-verb settle tick deterministically (no 800ms sleep) →
-      # the ONE final NICK+IDENTIFY; then +r closes it succeeded.
+      # #623 — the settle tick sends the re-NICK ALONE; the IDENTIFY waits for
+      # the nick change to be OBSERVED. Drive the settle deterministically (no
+      # 800ms sleep); the :sys.get_state read is a FIFO barrier ensuring the
+      # settle landed (FSM at :awaiting_nick) BEFORE the self-NICK echo. Then
+      # the self-NICK + the +r ride the socket FIFO in order → IDENTIFY
+      # (sameNick) → +r → success.
       send(pid, :recover_settle)
+
+      assert SessionStateHelpers.recover_identity(SessionStateHelpers.fetch(pid)).phase ==
+               :awaiting_nick
+
+      IRCServer.feed(server, ":guestx!u@h NICK :#{@recover_nick}\r\n")
       IRCServer.feed(server, ":irc.test.org MODE #{@recover_nick} :+r\r\n")
 
       assert_receive %Phoenix.Socket.Broadcast{
@@ -10566,6 +10578,152 @@ defmodule Grappa.Session.ServerTest do
                      1_000
 
       assert Process.alive?(pid)
+    end
+
+    # #623 — a 433 on the re-NICK is a BOUNDED RETRY (the hold has not cleared
+    # yet), NOT a one-shot terminal failure (reverses F2). Distinguishing
+    # observable: after the 433 the recover FSM is STILL ARMED (pre-#623 it was
+    # cleared to nil at a terminal :failed). PING/PONG is a FIFO barrier proving
+    # the socket-fed 433 was processed before we read state.
+    test "reclaim leg: a 433 on the re-NICK RETRIES (FSM stays armed), not a one-shot fail" do
+      %{server: server, pid: pid, subject: subject, network: network} =
+        start_recover_visitor("s3cret")
+
+      _ = :sys.replace_state(pid, fn state -> %{state | nick: "guestx"} end)
+
+      assert :ok = Session.recover_identity(subject, network.id)
+
+      IRCServer.feed(server, ":irc.test.org 433 * #{@recover_nick} :Nickname is already in use\r\n")
+
+      assert {:ok, _} =
+               IRCServer.wait_for_line(
+                 server,
+                 &(&1 == "PRIVMSG NickServ :RECOVER #{@recover_nick} s3cret\r\n"),
+                 1_000
+               )
+
+      send(pid, :recover_settle)
+
+      assert SessionStateHelpers.recover_identity(SessionStateHelpers.fetch(pid)).phase ==
+               :awaiting_nick
+
+      # The re-NICK still 433s — the hold is not clear yet. Barrier a PONG
+      # AFTER it (FIFO) so the 433 is provably processed before we read state.
+      IRCServer.feed(server, ":irc.test.org 433 * #{@recover_nick} :Nickname is already in use\r\n")
+      IRCServer.feed(server, "PING :b623\r\n")
+
+      assert {:ok, _} =
+               IRCServer.wait_for_line(server, &String.contains?(&1, "b623"), 1_000)
+
+      # STILL ARMED — a retry, not a terminal fail — back at the settle phase
+      # so the host's re-armed settle beat re-sends the NICK.
+      fsm = SessionStateHelpers.recover_identity(SessionStateHelpers.fetch(pid))
+      assert %RecoverIdentity{phase: :awaiting_verb_settle} = fsm
+    end
+
+    # #623 pt3 — leg (b): the nick WAS reclaimed and the sameNick IDENTIFY went
+    # out, but +r never confirmed by the deadline. The terminal broadcast must
+    # RECONCILE the still-running identify step to :failed (pre-#623 it was left
+    # :running forever — the "hang" in the trace) with the DISTINCT reason
+    # :identify_unconfirmed. The full sequencing INTO :awaiting_final_r (settle →
+    # NICK → self-NICK observed → IDENTIFY) is proven end-to-end by the "nick
+    # held (433) → RECOVER → settle → re-NICK observed → +r → succeeded" test
+    # above; here we INJECT the FSM parked at :awaiting_final_r so the terminal
+    # reconciliation is isolated from the socket sequencing (the :timeout path
+    # flushes no lines, so it never touches the client).
+    test "terminal from :awaiting_final_r reconciles identify=failed + :identify_unconfirmed (leg b)" do
+      %{pid: pid, label: label} = start_recover_visitor("s3cret")
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(label))
+
+      # Parked ON-nick, IDENTIFY sent, awaiting +r.
+      _ =
+        :sys.replace_state(pid, fn state ->
+          %{
+            state
+            | recover_identity: %RecoverIdentity{
+                phase: :awaiting_final_r,
+                cred_nick: @recover_nick,
+                secret: "s3cret",
+                verb: :recover
+              }
+          }
+        end)
+
+      # Deadline fires with no +r.
+      send(pid, :recover_timeout)
+
+      # The identify step is reconciled to :failed (NOT left running).
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{
+                         kind: :recover_progress,
+                         step: :identify,
+                         status: :failed,
+                         reason: :identify_unconfirmed
+                       }
+                     },
+                     1_000
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{
+                         kind: :recover_result,
+                         outcome: :failed,
+                         reason: :identify_unconfirmed
+                       }
+                     },
+                     1_000
+    end
+
+    # #623 pt3 — leg (a): the re-NICK never landed (the hold never cleared). The
+    # terminal broadcast marks the nick step :failed with :nick_unavailable —
+    # DISTINCT from leg (b) in BOTH the failed step and the reason.
+    test "terminal from :awaiting_nick marks nick=failed + :nick_unavailable (leg a)" do
+      %{server: server, pid: pid, subject: subject, network: network, label: label} =
+        start_recover_visitor("s3cret")
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(label))
+      _ = :sys.replace_state(pid, fn state -> %{state | nick: "guestx"} end)
+
+      assert :ok = Session.recover_identity(subject, network.id)
+      IRCServer.feed(server, ":irc.test.org 433 * #{@recover_nick} :Nickname is already in use\r\n")
+
+      assert {:ok, _} =
+               IRCServer.wait_for_line(
+                 server,
+                 &(&1 == "PRIVMSG NickServ :RECOVER #{@recover_nick} s3cret\r\n"),
+                 1_000
+               )
+
+      # Settle → NICK alone; no self-NICK ever observed → stuck at :awaiting_nick.
+      send(pid, :recover_settle)
+
+      assert SessionStateHelpers.recover_identity(SessionStateHelpers.fetch(pid)).phase ==
+               :awaiting_nick
+
+      send(pid, :recover_timeout)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{
+                         kind: :recover_progress,
+                         step: :nick,
+                         status: :failed,
+                         reason: :nick_unavailable
+                       }
+                     },
+                     1_000
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{
+                         kind: :recover_result,
+                         outcome: :failed,
+                         reason: :nick_unavailable
+                       }
+                     },
+                     1_000
     end
   end
 end

--- a/test/support/session_state_helpers.ex
+++ b/test/support/session_state_helpers.ex
@@ -139,6 +139,12 @@ defmodule Grappa.SessionStateHelpers do
   @spec ghost_timer(snapshot()) :: term()
   def ghost_timer(state), do: state.ghost_timer
 
+  # --- recover identity (#581/#623) --------------------------------------
+
+  @doc "Recover-identity driver state (`Grappa.Session.RecoverIdentity`), or `nil`."
+  @spec recover_identity(snapshot()) :: term()
+  def recover_identity(state), do: state.recover_identity
+
   # --- away --------------------------------------------------------------
 
   @doc "Away state machine value (`Grappa.Session.AwayState`)."


### PR DESCRIPTION
## What this is

`recover-identity-real.spec.ts:268` reddened four times in CI on unrelated
branches, always the same shape: modal `outcome=failed`, `nick=failed`,
`recover=ok`, `identify=running`. This branch was written on 2026-08-01 from
FSM reasoning; it has now been **wire-traced against the real testnet**, and
the trace corrected the rationale — the code survives, the story changes.

## What the wire says (measured 2026-08-03, `--repeat-each 3`)

* The initial leg's `NICK` + `IDENTIFY` ship together, the NICK earns a 433,
  so the IDENTIFY is evaluated under the Guest nick: services answers
  `Password accepted for <nick>` **addressed to the Guest**. No `+r` (sameNick
  rule) — but the account IS authenticated.
* `RECOVER` does not kill the holder; services force-renames it
  (`NICK :Guest56004`) and completes on its own clock, 3–7s later.
* When the rename lands, **services volunteers `+r` itself** — 1ms after the
  NICK echo, ~9ms BEFORE any IDENTIFY we could send. So `+r` was never ours,
  in either design, and sequencing cannot shorten the leg.

## What actually fails, and the cure

The re-NICK can be refused with a **433 five seconds after the send** (1 run in
3 on one stack). The F2 one-shot rule made that terminal — which is exactly the
CI signature. A 433/437 in `:awaiting_nick` now re-arms the settle beat and
re-sends the NICK, bounded by the untouched 15s deadline. **That retry is the
cure**; the reproduction was a retry-absorbed red. Sequencing stays as the
backstop (it stops firing an IDENTIFY that provably cannot commit `+r`).

Terminal legs are now distinct — `:nick_unavailable` (never landed) vs new
`:identify_unconfirmed` (reclaimed, `+r` unconfirmed) — and the terminal
broadcast reconciles every in-flight step, so the modal stops stranding
`identify` at `running`. Four reds said nothing; the fifth will name its leg.

Both timing constants untouched: the happy path costs 3–7s of services clock
against 15s, which is thinner than it reads — a FINDING for a real failing
trace, not a knob to turn while the suite is green.

## Also here

**The spec is re-runnable.** The recover nick + email are stamped per run. A
NickServ registration is once-per-nick-per-container, so the fixed nick made
`--repeat-each` — the iso-rerun discipline `docs/TESTING.md` mandates —
unusable on the one spec that needed it. Stamping it is what surfaced the 433.

## Note for the reviewer: a gate that CI never runs

Worth its own issue: the drift gate (`mix grappa.gen_wire_types --check`) runs
**only in `scripts/check.sh`** — no workflow invokes it, which is exactly why CI
stayed green over a stale mirror for a whole merge.

## Gates

* `scripts/check.sh` — **exit 0** (compile, credo strict, dialyzer, sobelow,
  audits, wire-types drift, 257 bats).
* `scripts/integration.sh` — **590 passed (25.1m)**, full suite both projects,
  including `recover-identity-real` at 9.5s.
* A/B on the fix, 3 iterations on one stack: `+r` at rename+4–12ms every time,
  including one run that took the 433-retry path and still landed green.

Those two runs predate the rebase onto `main` (they were taken with the
`:passkey_required` mirror + copy held as local edits, since #700 had not landed
yet). Both fixes now arrive from `main` — b209b91d + 7ead6ade — the local copies
were dropped rather than merged, and nothing in the branch depended on them.
Re-run after the rebase: `bun run check` (biome + `tsc --noEmit`) and
`bun run build`, both exit 0; the Elixir + integration gates are CI's now.

Refs #623
