### PR TITLE
test: make every bats negated assertion able to fail, and keep it that way

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -27238,7 +27238,7 @@ the unread badge were built on.
 
 ## 2026-08-03 — #745: an assertion that cannot fail is not an assertion
 
-The bats suites carried 79 negated assertions written `! grep -q …`.
+The bats suites carried 80 negated assertions written `! grep -q …`.
 Bash suppresses `errexit` for a command whose status is inverted with
 `!` — POSIX is explicit: the shell does not exit when the failing
 command's return status is being inverted. A bats body runs under
@@ -27248,7 +27248,7 @@ last line in the body, where the body's own exit status carries it.
 Measured, not reasoned about — the claim is exactly the kind that sounds
 plausible either way, so it went through the vendored bats 1.9.0 first: a
 mid-test `! true` reports `ok`, the identical line as the final statement
-reports `not ok`. 23 of the 79 were mid-test, i.e. dead. The other 56
+reports `not ok`. 23 of the 80 were mid-test, i.e. dead. The other 57
 were live only because nobody had yet appended a line after them.
 
 Both halves got converted, and that is the load-bearing decision. Fixing
@@ -27264,16 +27264,35 @@ whole fix is that it is a function. It also prints what unexpectedly
 succeeded, which the bare `!` never could.
 
 Converting proved nothing was hiding: the full suite stayed green with
-every assertion live for the first time (260 passed, up from 257 by the
-three new guard cases). The dead ones had all been asserting things that
+every assertion live for the first time (262 passed, up from 257 by the
+five new guard cases). The dead ones had all been asserting things that
 happen to be true. That is the honest result — the change bought back the
 ability to catch a regression, it did not catch one.
 
 Which is also why the guard matters more than the conversion.
 `test/scripts/bats_assertion_style_test.bats` fails the gate if a bare
-`!` reappears, if a suite calls `refute` without loading the helper (a
-missing function is "command not found" = non-zero = a refute that always
-passes), or if `refute` itself stops failing on success. Without it the
+`!` reappears anywhere a command can begin, if a suite calls `refute`
+without loading the helper (a missing function is "command not found" =
+non-zero = a refute that always passes), or if `refute` itself stops
+failing on success.
+
+Review hardened three things worth recording, all of them the same shape
+as the original bug. The guard's first pattern only matched a bang at the
+START of a line, so it missed `a && ! b`, `a; ! b`, `a || ! b` and
+`{ ! b; }` — and widening it immediately turned up an 80th site
+(`deploy_docker_release_image_test.bats:207`) that the narrow scan had
+walked straight past. The guard's greps swallowed their own exit status,
+so a renamed path would have made it pass while scanning nothing —
+fail-open, in the guard against silent failure. And `refute` originally
+treated ANY non-zero as a satisfied negation, including grep's 2, which
+means "I could not look": since most of these logs are created by a stub
+when it runs rather than by setup, an assertion against an absent file
+would have held vacuously. Each is the same lesson twice — the check that
+cannot fail is worse than no check, because it reads as coverage.
+
+The self-test earned its place immediately: the widened pattern lost its
+leading-whitespace branch in the rewrite, and the case that asserts the
+guard catches every dead spelling is what caught it, before the suite ran. Without it the
 class regrows one copy-paste at a time, because the bad spelling is the
 natural one to write and nothing about it looks broken.
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -27235,3 +27235,50 @@ display cannot hold two regions without lying about the space between them. Then
 check what else reads the state you just changed the meaning of: here a pane
 that renders rows it has NOT read broke the assumption every cursor writer and
 the unread badge were built on.
+
+## 2026-08-03 — #745: an assertion that cannot fail is not an assertion
+
+The bats suites carried 79 negated assertions written `! grep -q …`.
+Bash suppresses `errexit` for a command whose status is inverted with
+`!` — POSIX is explicit: the shell does not exit when the failing
+command's return status is being inverted. A bats body runs under
+`set -e`, so the only reason any of them ever failed a test was position:
+last line in the body, where the body's own exit status carries it.
+
+Measured, not reasoned about — the claim is exactly the kind that sounds
+plausible either way, so it went through the vendored bats 1.9.0 first: a
+mid-test `! true` reports `ok`, the identical line as the final statement
+reports `not ok`. 23 of the 79 were mid-test, i.e. dead. The other 56
+were live only because nobody had yet appended a line after them.
+
+Both halves got converted, and that is the load-bearing decision. Fixing
+the 23 would have read as fixing the bug; it would have left 56 traps
+armed, each disguised as a working assertion and each one appended line
+away from going quiet. The class is "a negation that depends on line
+order", not "these 23 lines".
+
+The cure is that a FUNCTION CALL is an ordinary command — its non-zero
+return is not an inverted status, so errexit fires wherever it sits.
+`refute` (`test/bats_helpers.bash`) is a four-line function, and the
+whole fix is that it is a function. It also prints what unexpectedly
+succeeded, which the bare `!` never could.
+
+Converting proved nothing was hiding: the full suite stayed green with
+every assertion live for the first time (260 passed, up from 257 by the
+three new guard cases). The dead ones had all been asserting things that
+happen to be true. That is the honest result — the change bought back the
+ability to catch a regression, it did not catch one.
+
+Which is also why the guard matters more than the conversion.
+`test/scripts/bats_assertion_style_test.bats` fails the gate if a bare
+`!` reappears, if a suite calls `refute` without loading the helper (a
+missing function is "command not found" = non-zero = a refute that always
+passes), or if `refute` itself stops failing on success. Without it the
+class regrows one copy-paste at a time, because the bad spelling is the
+natural one to write and nothing about it looks broken.
+
+The guard deliberately does not flag `if ! cmd`, `while ! cmd` or
+`[ ! -f x ]`. The first two are condition contexts where inverting is the
+point; in the third the `!` belongs to the `[` builtin, which returns
+non-zero itself, so errexit still fires. Flagging those would have taught
+people to work around the guard.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -49,7 +49,7 @@ scripts/mix.sh --env=dev hex.audit
 scripts/mix.sh --env=dev doctor
 
 # Bash dispatchers (bin/grappa)
-scripts/bats.sh                          # all bats specs under test/bin/
+scripts/bats.sh                          # all bats specs: test/bin/ test/infra/ test/scripts/
 scripts/bats.sh test/bin/grappa_test.bats
 
 # E2E (Playwright + real testnet)
@@ -323,9 +323,12 @@ unless it happens to be the last line of the test:
 ! grep -q "should not be here" "$LOG"     # DEAD mid-test — reports ok
 ```
 
+The same applies anywhere a command can begin, not just at the start of a
+line: `a && ! b`, `a; ! b`, `a || ! b` and `{ ! b; }` are equally dead.
+
 Measured on the vendored bats 1.9.0: a mid-test `! true` reports `ok`;
 the identical line written last reports `not ok`. It cost the suites 23
-assertions that could not fail and 56 more that were live only by the
+assertions that could not fail and 57 more that were live only by the
 accident of line order.
 
 Use `refute` (`test/bats_helpers.bash`, `load ../bats_helpers`). A
@@ -338,7 +341,7 @@ refute grep -q 'partial-release' <<<"$output"   # was a pipeline
 ```
 
 `test/scripts/bats_assertion_style_test.bats` fails the gate if a bare
-one reappears. `if ! cmd`, `while ! cmd` and `[ ! -f x ]` are all fine
+one reappears in any of those positions. `if ! cmd`, `while ! cmd` and `[ ! -f x ]` are all fine
 and are not flagged — the first two are condition contexts, and in the
 third the `!` belongs to the test builtin, whose own non-zero return
 still trips errexit.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -139,7 +139,7 @@ The authoritative source is the comment block at the top of each
 * **`scripts/test.sh`** → `scripts/mix.sh --env=test test --warnings-as-errors "$@"`. Forces `MIX_ENV=test` (auto-detect would use the live container's env, usually dev/prod, breaking sandbox).
 * **`scripts/check.sh`** → `scripts/mix.sh --env=dev ci.check` + `mix grappa.gen_wire_types --check` (wireTypes drift gate) + `scripts/bats.sh`. The `ci.check` alias (in `mix.exs`) chains: compile (warnings as errors), format check, credo, deps.audit, hex.audit, sobelow, doctor, `cmd env MIX_ENV=test mix test --warnings-as-errors`, dialyzer, docs. Mirrors CI exactly.
 * **`scripts/bun.sh`** → oneshot `oven/bun:1` against `cicchetto/`. `run test` = vitest. `run check` = biome + tsc. `install`, `add`, etc. forward to bun.
-* **`scripts/bats.sh`** → host-side bats v1.9.0 (submodule at `vendor/bats-core`) against `test/bin/`. NOT containerised — bats tests host-side bash dispatchers (`bin/grappa`).
+* **`scripts/bats.sh`** → host-side bats v1.9.0 (submodule at `vendor/bats-core`) against `test/bin/`, `test/infra/` and `test/scripts/`. NOT containerised — bats tests host-side bash (`bin/grappa`, the deploy scripts, the cloud installer).
 * **`scripts/integration.sh`** → `scripts/testnet.sh up` → `docker compose run --rm playwright-runner npx playwright test "$@"` → trap-on-exit `scripts/testnet.sh down`. `KEEP_STACK=1` opts out of tear-down.
 * **`scripts/testnet.sh`** → manages the stack standalone. `up` boots hub + leaves + services + grappa-test + nginx-test + seeder. `down` tears down + wipes `runtime/e2e/`. `probe` connects an oper-up client to leaf4 for `/links` + `/stats l`.
 
@@ -312,6 +312,36 @@ the hard way on 2026-07-27.
    rsync -a /Users/mbarnaba/code/grappa/cicchetto/e2e/infra/ \
      <worktree>/cicchetto/e2e/infra/
    ```
+
+## Writing a bats assertion: never a bare `!` (#745)
+
+Bash suppresses `errexit` for a command whose status is inverted with
+`!`, and a bats body runs under `set -e`. So this assertion is a no-op
+unless it happens to be the last line of the test:
+
+```bash
+! grep -q "should not be here" "$LOG"     # DEAD mid-test — reports ok
+```
+
+Measured on the vendored bats 1.9.0: a mid-test `! true` reports `ok`;
+the identical line written last reports `not ok`. It cost the suites 23
+assertions that could not fail and 56 more that were live only by the
+accident of line order.
+
+Use `refute` (`test/bats_helpers.bash`, `load ../bats_helpers`). A
+function call is an ordinary command, so errexit applies anywhere in the
+body, and it prints what unexpectedly succeeded:
+
+```bash
+refute grep -q "should not be here" "$LOG"
+refute grep -q 'partial-release' <<<"$output"   # was a pipeline
+```
+
+`test/scripts/bats_assertion_style_test.bats` fails the gate if a bare
+one reappears. `if ! cmd`, `while ! cmd` and `[ ! -f x ]` are all fine
+and are not flagged — the first two are condition contexts, and in the
+third the `!` belongs to the test builtin, whose own non-zero return
+still trips errexit.
 
 ## Test isolation: the global `max_cases: 1` lane
 

--- a/test/bats_helpers.bash
+++ b/test/bats_helpers.bash
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Shared assertions for the bats suites (test/bin, test/infra, test/scripts).
+#
+# WHY THIS FILE EXISTS — the `! cmd` trap (#745)
+#
+# Bash suppresses `errexit` for a command whose status is inverted with
+# `!` (POSIX: "the shell does not exit if the command that fails is ...
+# the command whose return status is being inverted with !"). Bats runs
+# a test body under `set -e`, so a bare
+#
+#     ! grep -q "should not be here" "$LOG"
+#
+# only fails the case when it is the LAST line of the test. Anywhere
+# else it is a no-op: the grep matches, the negation yields 1, errexit
+# stays quiet, the body runs on, and the test reports ok. Measured on
+# the vendored bats 1.9.0 — a mid-test `! true` reports `ok`, the same
+# line as the final statement reports `not ok`.
+#
+# That made 23 assertions across the suites unable to fail, and left the
+# other 56 live only by the accident of being written last — one
+# appended line would have killed any of them silently.
+#
+# `refute` closes it because a FUNCTION CALL is an ordinary command: its
+# non-zero return is not an inverted status, so errexit fires normally
+# wherever it appears in the body.
+
+# Fail the test when `cmd` SUCCEEDS. The inverse of running `cmd` bare.
+#
+#     refute grep -q "run --no-start" "$ARGV_LOG"
+#
+# For something that was a pipeline under the old spelling, feed the
+# subject in rather than piping into `refute`:
+#
+#     refute grep -q 'partial-release' <<<"$output"
+refute() {
+    if "$@"; then
+        printf 'refute: expected a non-zero exit, but this SUCCEEDED:\n    %s\n' "$*" >&2
+        return 1
+    fi
+    return 0
+}

--- a/test/bats_helpers.bash
+++ b/test/bats_helpers.bash
@@ -33,10 +33,31 @@
 # subject in rather than piping into `refute`:
 #
 #     refute grep -q 'partial-release' <<<"$output"
+#
+# `cmd` must be a COMMAND, not a shell keyword: `[[ ... ]]` and
+# `(( ... ))` are parsed by the shell, not looked up, so `refute [[ -f x ]]`
+# dies with "command not found". Use `refute test -f x` (or `refute [ -f x ]`).
+#
+# An exit status of 2-or-more is treated as a FAILURE of the assertion,
+# not as a satisfied negation. For the greps these assertions are built
+# on, 1 means "looked, found nothing" while 2 means "could not look" —
+# a missing log file, a bad pattern. Passing on 2 would let an assertion
+# hold vacuously against a file that never existed, which is the same
+# class of silent no-op this helper was written to remove.
 refute() {
-    if "$@"; then
+    local rc=0
+    "$@" || rc=$?
+
+    if [ "$rc" -eq 0 ]; then
         printf 'refute: expected a non-zero exit, but this SUCCEEDED:\n    %s\n' "$*" >&2
         return 1
     fi
+
+    if [ "$rc" -gt 1 ]; then
+        printf 'refute: command ERRORED (rc=%s) so the assertion proves nothing:\n    %s\n' \
+            "$rc" "$*" >&2
+        return 1
+    fi
+
     return 0
 }

--- a/test/bin/grappa_test.bats
+++ b/test/bin/grappa_test.bats
@@ -10,6 +10,8 @@
 # Out of scope: this is NOT an integration test. The actual docker
 # compose API surface drift is caught by scripts/integration.sh.
 
+load ../bats_helpers
+
 setup() {
     BIN_GRAPPA="$BATS_TEST_DIRNAME/../../bin/grappa"
 
@@ -141,7 +143,7 @@ EOF
     run "$BIN_GRAPPA" open-db
     [ "$status" -eq 0 ]
     grep -q 'sqlite3' "$ARGV_LOG"
-    ! grep -q -- '-readonly' "$ARGV_LOG"
+    refute grep -q -- '-readonly' "$ARGV_LOG"
 }
 
 # --- boot-time verb dispatch ---------------------------------------------
@@ -176,7 +178,7 @@ EOF
     grep -q 'abc-uuid-1234' "$ARGV_LOG"
     # --rpc-eval (NOT --remsh which would eval on client) — same shape
     # as remote-shell --batch per T-2.
-    ! grep -q -- '--remsh' "$ARGV_LOG"
+    refute grep -q -- '--remsh' "$ARGV_LOG"
 }
 
 @test "delete-visitor with no args exits 64 with usage" {
@@ -208,7 +210,7 @@ EOF
     grep -q -- '--remsh' "$ARGV_LOG"
     grep -q -- 'grappa@grappa' "$ARGV_LOG"
     # Interactive mode — NO -T flag in the docker exec.
-    ! grep -qE 'docker .*compose .*exec -T grappa sh' "$ARGV_LOG"
+    refute grep -qE 'docker .*compose .*exec -T grappa sh' "$ARGV_LOG"
 }
 
 @test "remote-shell --batch -e <expr> invokes docker exec -T with --rpc-eval" {
@@ -220,7 +222,7 @@ EOF
     grep -q -- 'grappa@grappa' "$ARGV_LOG"
     # Batch uses --rpc-eval (eval on REMOTE), NOT --remsh (which would
     # eval on the client node before attaching the shell).
-    ! grep -q -- '--remsh' "$ARGV_LOG"
+    refute grep -q -- '--remsh' "$ARGV_LOG"
 }
 
 @test "remote-shell --batch without -e exits 64 with usage" {

--- a/test/infra/cloud_first_boot_test.bats
+++ b/test/infra/cloud_first_boot_test.bats
@@ -15,6 +15,8 @@
 # fetched snippet, grappa-tls helper + boot oneshot, and the LE-quota-safe
 # TLS-deferred-until-DNS behaviour.
 
+load ../bats_helpers
+
 setup() {
     REPO_SRC="$BATS_TEST_DIRNAME/../.."
     FBSH="$REPO_SRC/infra/cloud/first-boot.sh"
@@ -168,7 +170,7 @@ mode_of() {  # GNU-first, BSD fallback (macOS runner) — matches the packaging 
     grep -qx "PHX_HOST=irc.example.org" "$GRAPPA_ENV_FILE"
     grep -qx "VAPID_SUBJECT=mailto:ops@example.org" "$GRAPPA_ENV_FILE"
     # The template's REPLACE_ME host is gone.
-    ! grep -q "^PHX_HOST=REPLACE_ME$" "$GRAPPA_ENV_FILE"
+    refute grep -q "^PHX_HOST=REPLACE_ME$" "$GRAPPA_ENV_FILE"
 }
 
 @test "relocks the env file to 0640 after rewriting it" {
@@ -212,7 +214,7 @@ mode_of() {  # GNU-first, BSD fallback (macOS runner) — matches the packaging 
     [ "$status" -eq 0 ]
     [[ "$output" == *"DEFERRED"* ]]
     # certbot must NOT have been invoked at first boot.
-    ! grep -q "^certbot " "$ARGV_LOG"
+    refute grep -q "^certbot " "$ARGV_LOG"
 }
 
 @test "issues TLS immediately when DNS already resolves" {

--- a/test/infra/deploy_docker_get_test.bats
+++ b/test/infra/deploy_docker_get_test.bats
@@ -15,6 +15,8 @@
 # this doubles as an integration check that the layout get.sh lays down is the
 # one deploy.sh resolves deploy_common.sh through.
 
+load ../bats_helpers
+
 setup() {
     REPO_SRC="$BATS_TEST_DIRNAME/../.."
     GETSH="$REPO_SRC/infra/docker/get.sh"
@@ -127,7 +129,7 @@ EOF
     [ "$status" -ne 0 ]
     [[ "$output" == *"download failed"* ]]
     [ ! -f "$GRAPPA_HOME/infra/docker/deploy.sh" ]
-    ! grep -q "inspect" "$ARGV_LOG"   # deploy.sh never ran
+    refute grep -q "inspect" "$ARGV_LOG"   # deploy.sh never ran
 }
 
 @test "missing curl fails loud" {

--- a/test/infra/deploy_docker_release_image_test.bats
+++ b/test/infra/deploy_docker_release_image_test.bats
@@ -15,6 +15,8 @@
 # the generated env file can be inspected (perms + contents). Secret VALUES
 # are asserted only for shape/idempotence, never trusted from the network.
 
+load ../bats_helpers
+
 setup() {
     REPO_SRC="$BATS_TEST_DIRNAME/../.."
     BOX="$BATS_TEST_TMPDIR/box"
@@ -194,7 +196,7 @@ EOF
     grep -q "pull ghcr.io/vjt/grappa:latest" "$ARGV_LOG"
     grep -q "eval Grappa.Release.migrate()" "$ARGV_LOG"
     grep -qE "run -d .*--name grappa" "$ARGV_LOG"
-    ! grep -q "reload" "$ARGV_LOG"
+    refute grep -q "reload" "$ARGV_LOG"
     [[ "$output" == *"cold"* ]]
 }
 
@@ -234,7 +236,7 @@ EOF
     run "$DEPLOY" stop
     [ "$status" -eq 0 ]
     [[ "$output" == *"nothing to stop"* ]]
-    ! grep -q "rm -f grappa" "$ARGV_LOG"
+    refute grep -q "rm -f grappa" "$ARGV_LOG"
 }
 
 @test "stop: --volumes drops the data volume" {

--- a/test/infra/deploy_docker_release_image_test.bats
+++ b/test/infra/deploy_docker_release_image_test.bats
@@ -204,7 +204,7 @@ EOF
     run "$DEPLOY" update
     [ "$status" -ne 0 ]
     [[ "$output" == *"never installed"* ]]
-    [ ! -s "$ARGV_LOG" ] || ! grep -q "run -d" "$ARGV_LOG"
+    [ ! -s "$ARGV_LOG" ] || refute grep -q "run -d" "$ARGV_LOG"
 }
 
 @test "update: --force-cold is accepted (redundant)" {

--- a/test/infra/deploy_docker_test.bats
+++ b/test/infra/deploy_docker_test.bats
@@ -21,6 +21,8 @@
 # marker) and the self-modifying-script re-exec guard (+ DEPLOY_PREV_SHA
 # carry) — all now landed, bringing this substrate to parity with the jail.
 
+load ../bats_helpers
+
 setup() {
     # Normalize the tmpdir to its PHYSICAL path. On macOS $TMPDIR is a
     # symlink (/var/folders -> /private/var/folders); _lib.sh derives
@@ -136,7 +138,7 @@ run_deploy() {
     run_deploy
     [ "$status" -ne 0 ]
     [[ "$output" == *"branch"* ]]
-    ! grep -q "docker" "$ARGV_LOG"          # aborted before any docker call
+    refute grep -q "docker" "$ARGV_LOG"          # aborted before any docker call
 }
 
 # --- mode parsing ------------------------------------------------------------
@@ -162,7 +164,7 @@ run_deploy() {
 @test "--force-hot skips preflight and reloads" {
     run_deploy --force-hot
     [ "$status" -eq 0 ]
-    ! grep -q "run --no-start" "$ARGV_LOG"
+    refute grep -q "run --no-start" "$ARGV_LOG"
     grep -q "exec -T grappa curl.*reload" "$ARGV_LOG"
 }
 
@@ -170,7 +172,7 @@ run_deploy() {
     make_env
     run_deploy --force-cold
     [ "$status" -eq 0 ]
-    ! grep -q "run --no-start" "$ARGV_LOG"
+    refute grep -q "run --no-start" "$ARGV_LOG"
     grep -q "up -d --force-recreate" "$ARGV_LOG"
 }
 
@@ -193,7 +195,7 @@ run_deploy() {
     [ "$status" -eq 0 ]
     grep -q "exec -T grappa curl.*reload" "$ARGV_LOG"
     grep -q "exec -T grappa curl.*healthz" "$ARGV_LOG"
-    ! grep -q "up -d" "$ARGV_LOG"           # hot path never recreates
+    refute grep -q "up -d" "$ARGV_LOG"           # hot path never recreates
 }
 
 @test "hot reload reporting per-module failures aborts non-zero" {
@@ -203,7 +205,7 @@ run_deploy() {
     run_deploy
     [ "$status" -ne 0 ]
     [[ "$output" == *"failures"* ]]
-    ! grep -q "up -d" "$ARGV_LOG"
+    refute grep -q "up -d" "$ARGV_LOG"
 }
 
 # --- cold path ---------------------------------------------------------------
@@ -273,7 +275,7 @@ run_deploy() {
     run_deploy
     [ "$status" -eq 0 ]
     grep -q "cli(\[\"$marker\", \"$new\", \"docker\"\])" "$ARGV_LOG"
-    ! grep -q "cli(\[\"$prev\"" "$ARGV_LOG"
+    refute grep -q "cli(\[\"$prev\"" "$ARGV_LOG"
 }
 
 @test "garbage marker aborts loudly before preflight runs" {
@@ -283,7 +285,7 @@ run_deploy() {
     run_deploy
     [ "$status" -ne 0 ]
     [[ "$output" == *"last-deployed-sha"* ]]
-    ! grep -q "run --no-start" "$ARGV_LOG"
+    refute grep -q "run --no-start" "$ARGV_LOG"
 }
 
 # --- #503 enrich: self-modifying-script re-exec guard (+ prev-sha carry) ------
@@ -308,7 +310,7 @@ run_deploy() {
     # collapse the range to new..new (the re-pulled run's own pre-pull HEAD
     # equals new). The carry keeps the ORIGINAL pre-pull HEAD.
     grep -q "cli(\[\"$prev\", \"$new\", \"docker\"\])" "$ARGV_LOG"
-    ! grep -q "cli(\[\"$new\", \"$new\"" "$ARGV_LOG"
+    refute grep -q "cli(\[\"$new\", \"$new\"" "$ARGV_LOG"
 }
 
 @test "lib change (deploy_common.sh) in THIS pull also re-execs" {

--- a/test/infra/deploy_docker_update_test.bats
+++ b/test/infra/deploy_docker_update_test.bats
@@ -14,6 +14,8 @@
 # everything else silent). install + stop verbs live in
 # deploy_docker_verbs_test.bats (a box-skeleton harness, no pull).
 
+load ../bats_helpers
+
 setup() {
     # macOS $TMPDIR symlink normalization — REPO_ROOT is git's physical
     # path, keep the base physical too so the two agree.
@@ -145,8 +147,8 @@ run_update() {
     run_update
     [ "$status" -ne 0 ]
     [[ "$output" == *"install"* ]]
-    ! grep -q "run --no-start" "$ARGV_LOG"
-    ! grep -q "force-recreate" "$ARGV_LOG"
+    refute grep -q "run --no-start" "$ARGV_LOG"
+    refute grep -q "force-recreate" "$ARGV_LOG"
 }
 
 @test "update: a dirty working tree is refused before anything is pulled or recreated" {
@@ -157,7 +159,7 @@ run_update() {
     [ "$status" -ne 0 ]
     [[ "$output" == *"uncommitted"* ]]
     [ "$(git -C "$REPO_ROOT" rev-parse HEAD)" != "$(git -C "$UPSTREAM" rev-parse HEAD)" ]
-    ! grep -q "force-recreate" "$ARGV_LOG"
+    refute grep -q "force-recreate" "$ARGV_LOG"
 }
 
 @test "update: a diverged branch fails loud instead of merging or recreating" {
@@ -167,7 +169,7 @@ run_update() {
 
     run_update
     [ "$status" -ne 0 ]
-    ! grep -q "force-recreate" "$ARGV_LOG"
+    refute grep -q "force-recreate" "$ARGV_LOG"
 }
 
 @test "update: a box owned by another checkout is refused, and the owner is named" {
@@ -178,7 +180,7 @@ run_update() {
     [ "$status" -ne 0 ]
     [[ "$output" == *"$FAKE_OWNER_DIR"* ]]
     [ "$(git -C "$REPO_ROOT" rev-parse HEAD)" != "$(git -C "$UPSTREAM" rev-parse HEAD)" ]
-    ! grep -q "force-recreate" "$ARGV_LOG"
+    refute grep -q "force-recreate" "$ARGV_LOG"
 }
 
 # ───────────────────── hot-vs-cold via preflight (#503) ──────────────────
@@ -192,7 +194,7 @@ run_update() {
     [ "$status" -eq 0 ]
     grep -q "cli(\[\"$prev\", \"$new\", \"docker\"\])" "$ARGV_LOG"
     grep -q "exec -T grappa curl.*reload" "$ARGV_LOG"
-    ! grep -q "up -d" "$ARGV_LOG"                 # hot never recreates
+    refute grep -q "up -d" "$ARGV_LOG"                 # hot never recreates
 }
 
 @test "update: box up + code change + COLD verdict recreates, never reloads" {
@@ -202,7 +204,7 @@ run_update() {
     run_update
     [ "$status" -eq 0 ]
     grep -q "up -d --force-recreate" "$ARGV_LOG"
-    ! grep -q "exec -T grappa curl.*reload" "$ARGV_LOG"
+    refute grep -q "exec -T grappa curl.*reload" "$ARGV_LOG"
 }
 
 @test "update: the cold cic rebuild carries GRAPPA_VERSION from the VERSION file (#692)" {
@@ -228,7 +230,7 @@ run_update() {
     # PREVIOUS number into <meta cicchetto-version>, which is the silent
     # staleness #652 exists to prevent. Pin both halves.
     grep -Fqx "env GRAPPA_VERSION=99.99.99" "$ARGV_LOG"
-    ! grep -Fqx "env GRAPPA_VERSION=$was_on" "$ARGV_LOG"
+    refute grep -Fqx "env GRAPPA_VERSION=$was_on" "$ARGV_LOG"
 }
 
 @test "update: preflight non-verdict exit aborts and propagates the code" {
@@ -247,7 +249,7 @@ run_update() {
     run_update
     [ "$status" -ne 0 ]
     [[ "$output" == *"failures"* ]]
-    ! grep -q "up -d" "$ARGV_LOG"
+    refute grep -q "up -d" "$ARGV_LOG"
 }
 
 # ─────────────────── down box + --no-pull → cold (start again) ───────────
@@ -259,7 +261,7 @@ run_update() {
 
     run_update
     [ "$status" -eq 0 ]
-    ! grep -q "run --no-start" "$ARGV_LOG"        # down box skips preflight (forced cold)
+    refute grep -q "run --no-start" "$ARGV_LOG"        # down box skips preflight (forced cold)
     grep -q "up -d --force-recreate" "$ARGV_LOG"
 }
 
@@ -271,7 +273,7 @@ run_update() {
     run_update --no-pull
     [ "$status" -eq 0 ]
     [ "$(git -C "$REPO_ROOT" rev-parse HEAD)" = "$before" ]   # no pull
-    ! grep -q "run --no-start" "$ARGV_LOG"                    # empty range not classified
+    refute grep -q "run --no-start" "$ARGV_LOG"                    # empty range not classified
     grep -q "up -d --force-recreate" "$ARGV_LOG"
 }
 
@@ -281,7 +283,7 @@ run_update() {
     commit_upstream lib/base.txt > /dev/null
     run_update --force-hot
     [ "$status" -eq 0 ]
-    ! grep -q "run --no-start" "$ARGV_LOG"
+    refute grep -q "run --no-start" "$ARGV_LOG"
     grep -q "exec -T grappa curl.*reload" "$ARGV_LOG"
 }
 
@@ -290,7 +292,7 @@ run_update() {
     commit_upstream lib/base.txt > /dev/null
     run_update --force-cold
     [ "$status" -eq 0 ]
-    ! grep -q "run --no-start" "$ARGV_LOG"
+    refute grep -q "run --no-start" "$ARGV_LOG"
     grep -q "up -d --force-recreate" "$ARGV_LOG"
 }
 
@@ -320,7 +322,7 @@ run_update() {
     run_update
     [ "$status" -eq 0 ]
     grep -q "cli(\[\"$marker\", \"$new\", \"docker\"\])" "$ARGV_LOG"
-    ! grep -q "cli(\[\"$prev\"" "$ARGV_LOG"
+    refute grep -q "cli(\[\"$prev\"" "$ARGV_LOG"
 }
 
 @test "update: deploy.sh touched in THIS pull re-execs (verb preserved) and completes" {
@@ -353,7 +355,7 @@ EOF
 
     run_update
     [ "$status" -eq 0 ]
-    ! grep -q '^NGINX_PUBLISH=' "$REPO_ROOT/.env"
+    refute grep -q '^NGINX_PUBLISH=' "$REPO_ROOT/.env"
     grep -qE '^GRAPPA_PUBLISH=127\.0\.0\.1:3100$' "$REPO_ROOT/.env"
     [[ "$output" == *"NGINX_PUBLISH is deprecated"* ]]
 }

--- a/test/infra/deploy_docker_verbs_test.bats
+++ b/test/infra/deploy_docker_verbs_test.bats
@@ -22,6 +22,8 @@
 # stubbed on PATH so no image is built and no container is touched — same
 # recording shape as the quickstart suites this replaces.
 
+load ../bats_helpers
+
 setup() {
     REPO_SRC="$BATS_TEST_DIRNAME/../.."
     BOX="$BATS_TEST_TMPDIR/box"
@@ -126,8 +128,8 @@ EOF
     [ "$status" -eq 0 ]
 
     grep -qE '^PHX_HOST=localhost$' "$BOX/.env"
-    ! grep -q 'grappa.create_user' "$ARGV_LOG"
-    ! grep -q 'grappa.bind_network' "$ARGV_LOG"
+    refute grep -q 'grappa.create_user' "$ARGV_LOG"
+    refute grep -q 'grappa.bind_network' "$ARGV_LOG"
 }
 
 @test "install: an explicitly passed PHX_HOST overwrites what a previous run left in .env" {
@@ -178,7 +180,7 @@ EOF
 
     conf="$BOX/runtime/nginx-frontend.conf"
     [ -f "$conf" ]
-    ! grep -q '<your-domain>' "$conf"
+    refute grep -q '<your-domain>' "$conf"
     [ "$(grep -c 'server_name staging.example.org;' "$conf")" -eq 2 ]
     grep -q 'server 127.0.0.1:3100;' "$conf"
     grep -q 'ssl_certificate     /tmp/cert.pem;' "$conf"
@@ -190,7 +192,7 @@ EOF
         run "$DEPLOY" install
     [ "$status" -eq 0 ]
     grep -q 'server 127.0.0.1:3000;' "$BOX/runtime/nginx-frontend.conf"
-    ! grep -q 'server 0.0.0.0:3000;' "$BOX/runtime/nginx-frontend.conf"
+    refute grep -q 'server 0.0.0.0:3000;' "$BOX/runtime/nginx-frontend.conf"
 }
 
 @test "install: SEED_USER creates the admin account and binds the network before the stack comes up" {
@@ -211,14 +213,14 @@ EOF
         run "$DEPLOY" install
     [ "$status" -eq 0 ]
     grep -q -- "grappa.create_user --name tester --password hunter2222" "$ARGV_LOG"
-    ! grep -q -- "grappa.create_user .* --admin" "$ARGV_LOG"
+    refute grep -q -- "grappa.create_user .* --admin" "$ARGV_LOG"
 }
 
 @test "install: built-in themes are seeded before the stack comes up, even with no account" {
     run "$DEPLOY" install
     [ "$status" -eq 0 ]
     grep -q 'grappa.seed_themes' "$ARGV_LOG"
-    ! grep -q 'grappa.create_user' "$ARGV_LOG"
+    refute grep -q 'grappa.create_user' "$ARGV_LOG"
 
     themes_line="$(grep -n 'grappa.seed_themes' "$ARGV_LOG" | head -n1 | cut -d: -f1)"
     up_line="$(grep -n 'up -d' "$ARGV_LOG" | head -n1 | cut -d: -f1)"
@@ -261,7 +263,7 @@ EOF
     [ "$status" -ne 0 ]
     [[ "$output" == *"$FAKE_OWNER_DIR"* ]]
     [ ! -f "$BOX/.env" ]
-    ! grep -qE 'compose .*(up|build|run)' "$ARGV_LOG"
+    refute grep -qE 'compose .*(up|build|run)' "$ARGV_LOG"
 }
 
 @test "install: a box owned by this checkout does not block a re-run" {
@@ -293,7 +295,7 @@ EOF
     run "$DEPLOY" stop
     [ "$status" -ne 0 ]
     [[ "$output" == *"/somewhere/else/grappa-irc-469"* ]]
-    ! grep -q ' down' "$ARGV_LOG"
+    refute grep -q ' down' "$ARGV_LOG"
 }
 
 @test "stop: source mode outside a grappa checkout refuses before touching docker" {
@@ -323,7 +325,7 @@ EOF
     : > "$ARGV_LOG"
     run "$DEPLOY" stop
     [ "$status" -eq 0 ]
-    ! grep -qE 'down .*(-v|--volumes)' "$ARGV_LOG"
+    refute grep -qE 'down .*(-v|--volumes)' "$ARGV_LOG"
 }
 
 @test "stop: an unknown flag is refused instead of being handed to compose" {

--- a/test/infra/deploy_jail_test.bats
+++ b/test/infra/deploy_jail_test.bats
@@ -12,6 +12,8 @@
 # deploy exercises (rc.subr, run_erl, the live BEAM) is out of scope —
 # see the manual verification plan in the shipping commit.
 
+load ../bats_helpers
+
 setup() {
     DEPLOY_SH="$BATS_TEST_DIRNAME/../../infra/freebsd/deploy.sh"
 
@@ -151,7 +153,7 @@ run_deploy() {
     run_deploy
     [ "$status" -eq 0 ]
     grep -q "cli(\[\"$marker\", \"$new\", \"jail\"\])" "$ARGV_LOG"
-    ! grep -q "cli(\[\"$prev\"" "$ARGV_LOG"
+    refute grep -q "cli(\[\"$prev\"" "$ARGV_LOG"
 }
 
 @test "garbage marker: deploy aborts loudly before preflight runs" {
@@ -161,7 +163,7 @@ run_deploy() {
     run_deploy
     [ "$status" -ne 0 ]
     [[ "$output" == *"last-deployed-sha"* ]]
-    ! grep -q "run --no-start" "$ARGV_LOG"
+    refute grep -q "run --no-start" "$ARGV_LOG"
 }
 
 @test "well-formed marker sha that is not a commit aborts loudly too" {
@@ -171,7 +173,7 @@ run_deploy() {
     run_deploy
     [ "$status" -ne 0 ]
     [[ "$output" == *"last-deployed-sha"* ]]
-    ! grep -q "run --no-start" "$ARGV_LOG"
+    refute grep -q "run --no-start" "$ARGV_LOG"
 }
 
 @test "hot deploy completes and writes the marker as final step" {
@@ -213,7 +215,7 @@ EOF
     [ "$status" -eq 0 ]
     # base must be the bare marker sha — not "Last login...<marker>".
     grep -q "cli(\[\"$marker\", \"$new\", \"jail\"\])" "$ARGV_LOG"
-    ! grep -q "cli(\[\"Last login" "$ARGV_LOG"
+    refute grep -q "cli(\[\"Last login" "$ARGV_LOG"
 }
 
 # --- #7 caveat (a): re-exec guard stays keyed on the PRE-PULL range ---------
@@ -249,8 +251,8 @@ EOF
     run_deploy
     [ "$status" -eq 0 ]
     [[ "$output" == *"marker"* ]]
-    ! grep -q "service" "$ARGV_LOG"
-    ! grep -q "mix deps.get" "$ARGV_LOG"
+    refute grep -q "service" "$ARGV_LOG"
+    refute grep -q "mix deps.get" "$ARGV_LOG"
 }
 
 @test "--force-cold overrides the nothing-to-do fast path" {
@@ -262,7 +264,7 @@ EOF
     [[ "$output" == *"force"* ]]
     grep -q "service grappa stop" "$ARGV_LOG"
     grep -q "service grappa start" "$ARGV_LOG"
-    ! grep -q "run --no-start" "$ARGV_LOG"   # forced mode skips preflight
+    refute grep -q "run --no-start" "$ARGV_LOG"   # forced mode skips preflight
 }
 
 @test "--force-hot overrides the nothing-to-do fast path" {
@@ -272,7 +274,7 @@ EOF
     run_deploy --force-hot
     [ "$status" -eq 0 ]
     grep -q "mix deps.get --only prod" "$ARGV_LOG"
-    ! grep -q "run --no-start" "$ARGV_LOG"
+    refute grep -q "run --no-start" "$ARGV_LOG"
 }
 
 # --- #9 (deploy.sh side): cold path synchronizes on BEAM stop ----------------
@@ -311,8 +313,8 @@ EOF
     grep -q "service grappa stop" "$ARGV_LOG"
     grep -q "jail_beam_wait.sh wait-stopped grappa" "$ARGV_LOG"
     grep -q "jail_install_rcd.sh" "$ARGV_LOG"
-    ! grep -q "service grappa start" "$ARGV_LOG"
-    ! grep -q "curl" "$ARGV_LOG"                                   # no healthcheck
+    refute grep -q "service grappa start" "$ARGV_LOG"
+    refute grep -q "curl" "$ARGV_LOG"                                   # no healthcheck
     [ ! -f "$REPO_ROOT/runtime/last-deployed-sha" ]               # marker NOT written
     [[ "$output" == *"--defer-restart"* ]]
     [[ "$output" == *"bastille-restart"* ]]
@@ -324,7 +326,7 @@ EOF
     run_deploy --defer-restart --force-cold
     [ "$status" -eq 0 ]
     grep -q "jail_install_rcd.sh" "$ARGV_LOG"
-    ! grep -q "service grappa start" "$ARGV_LOG"
+    refute grep -q "service grappa start" "$ARGV_LOG"
     [ ! -f "$REPO_ROOT/runtime/last-deployed-sha" ]
     [[ "$output" == *"--defer-restart"* ]]
 }
@@ -332,7 +334,7 @@ EOF
 @test "--force-hot --defer-restart is a usage error (defer needs a stop)" {
     run_deploy --force-hot --defer-restart
     [ "$status" -eq 64 ]
-    ! grep -q "service grappa stop" "$ARGV_LOG"
+    refute grep -q "service grappa stop" "$ARGV_LOG"
 }
 
 @test "auto preflight HOT + --defer-restart is a usage error" {
@@ -341,7 +343,7 @@ EOF
 
     run_deploy --defer-restart
     [ "$status" -eq 64 ]
-    ! grep -q "service grappa stop" "$ARGV_LOG"
+    refute grep -q "service grappa stop" "$ARGV_LOG"
 }
 
 @test "unknown flag alongside a valid one is still a usage error (64)" {

--- a/test/infra/deploy_linux_test.bats
+++ b/test/infra/deploy_linux_test.bats
@@ -20,6 +20,8 @@
 # DEPLOY_PREV_SHA carry across re-exec — all now landed, bringing this
 # substrate to parity with the jail.
 
+load ../bats_helpers
+
 setup() {
     DEPLOY_SH="$BATS_TEST_DIRNAME/../../infra/linux/deploy.sh"
 
@@ -181,7 +183,7 @@ run_deploy() {
     run_deploy
     [ "$status" -eq 0 ]
     grep -q "cli(\[\"$marker\", \"$new\", \"linux\"\])" "$ARGV_LOG"
-    ! grep -q "cli(\[\"$prev\"" "$ARGV_LOG"
+    refute grep -q "cli(\[\"$prev\"" "$ARGV_LOG"
 }
 
 @test "garbage marker: deploy aborts loudly before preflight runs" {
@@ -191,7 +193,7 @@ run_deploy() {
     run_deploy
     [ "$status" -ne 0 ]
     [[ "$output" == *"last-deployed-sha"* ]]
-    ! grep -q "run --no-start" "$ARGV_LOG"
+    refute grep -q "run --no-start" "$ARGV_LOG"
 }
 
 @test "well-formed marker sha that is not a commit aborts loudly too" {
@@ -201,7 +203,7 @@ run_deploy() {
     run_deploy
     [ "$status" -ne 0 ]
     [[ "$output" == *"last-deployed-sha"* ]]
-    ! grep -q "run --no-start" "$ARGV_LOG"
+    refute grep -q "run --no-start" "$ARGV_LOG"
 }
 
 # --- hot path ----------------------------------------------------------------
@@ -213,7 +215,7 @@ run_deploy() {
     [ "$status" -eq 0 ]
     grep -q "curl .*-X POST.*reload" "$ARGV_LOG"
     [ "$(cat "$REPO_ROOT/runtime/last-deployed-sha")" = "$new" ]
-    ! grep -q "systemctl" "$ARGV_LOG"   # hot path never restarts
+    refute grep -q "systemctl" "$ARGV_LOG"   # hot path never restarts
 }
 
 @test "hot reload reporting per-module failures aborts non-zero, no marker" {
@@ -272,9 +274,9 @@ run_deploy() {
 
     run_deploy --force-hot
     [ "$status" -eq 0 ]
-    ! grep -q "run --no-start" "$ARGV_LOG"          # forced mode skips preflight
+    refute grep -q "run --no-start" "$ARGV_LOG"          # forced mode skips preflight
     grep -q "curl .*-X POST.*reload" "$ARGV_LOG"
-    ! grep -q "systemctl" "$ARGV_LOG"               # hot path never restarts
+    refute grep -q "systemctl" "$ARGV_LOG"               # hot path never restarts
     [ "$(cat "$REPO_ROOT/runtime/last-deployed-sha")" = "$new" ]
 }
 
@@ -284,7 +286,7 @@ run_deploy() {
 
     run_deploy --force-cold
     [ "$status" -eq 0 ]
-    ! grep -q "run --no-start" "$ARGV_LOG"
+    refute grep -q "run --no-start" "$ARGV_LOG"
     grep -q "systemctl stop grappa" "$ARGV_LOG"
     grep -q "systemctl start grappa" "$ARGV_LOG"
     [ "$(cat "$REPO_ROOT/runtime/last-deployed-sha")" = "$new" ]
@@ -304,9 +306,9 @@ run_deploy() {
     run_deploy
     [ "$status" -eq 0 ]
     [[ "$output" == *"nothing to do"* ]]
-    ! grep -q "mix deps.get" "$ARGV_LOG"       # build never runs
-    ! grep -q "systemctl" "$ARGV_LOG"
-    ! grep -q "run --no-start" "$ARGV_LOG"      # never reaches preflight
+    refute grep -q "mix deps.get" "$ARGV_LOG"       # build never runs
+    refute grep -q "systemctl" "$ARGV_LOG"
+    refute grep -q "run --no-start" "$ARGV_LOG"      # never reaches preflight
 }
 
 @test "--force-cold overrides the nothing-to-do fast path" {
@@ -321,7 +323,7 @@ run_deploy() {
     [[ "$output" == *"marker match"* ]]
     [[ "$output" == *"overrides"* ]]
     grep -q "systemctl stop grappa" "$ARGV_LOG"
-    ! grep -q "run --no-start" "$ARGV_LOG"      # forced mode skips preflight
+    refute grep -q "run --no-start" "$ARGV_LOG"      # forced mode skips preflight
 }
 
 # --- #503 enrich: DEPLOY_PREV_SHA carry across re-exec ------------------------
@@ -338,7 +340,7 @@ run_deploy() {
     # new..new and the real change silently drops out; the carry keeps the
     # ORIGINAL pre-pull HEAD as the base.
     grep -q "cli(\[\"$prev\", \"$new\", \"linux\"\])" "$ARGV_LOG"
-    ! grep -q "cli(\[\"$new\", \"$new\"" "$ARGV_LOG"
+    refute grep -q "cli(\[\"$new\", \"$new\"" "$ARGV_LOG"
 }
 
 # --- #541: deps sync precedes the preflight oneshot (Co-authored abonforti) ---

--- a/test/infra/deploy_m42_test.bats
+++ b/test/infra/deploy_m42_test.bats
@@ -15,6 +15,8 @@
 # Scope: pure host-side sequencing. The real jail bounce (bastille, rc.d,
 # the live BEAM) is out of scope — bats proves the ssh call sequence only.
 
+load ../bats_helpers
+
 setup() {
     DEPLOY_M42="$BATS_TEST_DIRNAME/../../scripts/deploy-m42.sh"
 
@@ -86,7 +88,7 @@ run_m42() {
     grep -q "deploy.sh --force-cold --defer-restart" "$SSH_LOG"
     grep -q "bastille restart grappa" "$SSH_LOG"
     grep -q "healthz" "$SSH_LOG"
-    ! grep -q "last-deployed-sha" "$SSH_LOG"
+    refute grep -q "last-deployed-sha" "$SSH_LOG"
 }
 
 @test "--full-restart still refuses when local main is ahead of origin (push-guard)" {
@@ -123,8 +125,8 @@ EOF
     # --force-cold from --full-restart is the ABSENCE of a bastille bounce
     # and a marker write.
     grep -q "jail_install_nginx.sh" "$SSH_LOG"
-    ! grep -q "bastille restart" "$SSH_LOG"
-    ! grep -q "last-deployed-sha" "$SSH_LOG"
+    refute grep -q "bastille restart" "$SSH_LOG"
+    refute grep -q "last-deployed-sha" "$SSH_LOG"
     [ "$(grep -c '^ssh ' "$SSH_LOG")" -eq 2 ]   # app deploy + nginx refresh
 }
 

--- a/test/infra/grappa_source_alias_test.bats
+++ b/test/infra/grappa_source_alias_test.bats
@@ -18,6 +18,8 @@
 #     invocation (it is NEVER env_keep'd through sudoers);
 #   * unknown subcommands / bad argc are usage errors (64).
 
+load ../bats_helpers
+
 setup() {
 	WRAP="$BATS_TEST_DIRNAME/../../infra/freebsd/bin/grappa-source-alias"
 
@@ -74,7 +76,7 @@ EOF
 	[ "$status" -eq 69 ]
 	# the add was attempted; the delete must NOT run (nothing was added)
 	grep -q "ifconfig lo0 inet6 2a03:4000:20:2d3:cb::/128 alias" "$IFCONFIG_LOG"
-	! grep -q -- "-alias" "$IFCONFIG_LOG"
+	refute grep -q -- "-alias" "$IFCONFIG_LOG"
 }
 
 @test "probe REFUSES a canary outside the config-file prefix (drift, 65)" {

--- a/test/infra/jail_beam_wait_test.bats
+++ b/test/infra/jail_beam_wait_test.bats
@@ -11,6 +11,8 @@
 # pkill'ing epmd while a BEAM is alive makes the BEAM respawn it and
 # races the new node's name registration (live-repro 2026-05-31).
 
+load ../bats_helpers
+
 setup() {
     BEAM_WAIT="$BATS_TEST_DIRNAME/../../infra/freebsd/jail_beam_wait.sh"
 
@@ -82,7 +84,7 @@ name_registered() { printf 'name %s at port 39559\n' "$1" > "$STATE/epmd_names";
     run "$BEAM_WAIT" wait-stopped grappa 1
     [ "$status" -eq 0 ]
     grep -q "pkill epmd" "$KILL_LOG"
-    ! grep -q "beam.smp" "$KILL_LOG"
+    refute grep -q "beam.smp" "$KILL_LOG"
 }
 
 @test "wait-stopped: other node names do not block" {

--- a/test/infra/release_assets_test.bats
+++ b/test/infra/release_assets_test.bats
@@ -14,6 +14,8 @@
 # body marker — the bug-prone parts that must not live untested in YAML.
 # Pure filesystem + string logic; no docker, no network, no mix.
 
+load ../bats_helpers
+
 setup() {
     REPO_SRC="$BATS_TEST_DIRNAME/../.."
     SCRIPT="$REPO_SRC/infra/packaging/release_assets.sh"
@@ -143,7 +145,7 @@ seed_complete() {
     run bash -c "'$SCRIPT' apply-body '$ASSETS' < '$BATS_TEST_TMPDIR/body.md'"
     [ "$status" -eq 0 ]
     printf '%s\n' "$output" | grep -q 'a real changelog line'
-    ! printf '%s\n' "$output" | grep -q 'grappa:partial-release'
+    refute grep -q 'grappa:partial-release' <<<"$output"
 }
 
 @test "usage: an unknown subcommand fails loudly" {

--- a/test/scripts/bats_assertion_style_test.bats
+++ b/test/scripts/bats_assertion_style_test.bats
@@ -2,66 +2,138 @@
 #
 # A guard over the test suites themselves (#745).
 #
-# `! cmd` at the top level of a bats test body cannot fail the case
-# unless it happens to be the last line — bash suppresses errexit for an
-# inverted status. Every such assertion is therefore either dead or one
-# appended line away from becoming dead, silently.
+# A negated command at the top level of a bats test body cannot fail the
+# case unless it happens to be the last line — bash suppresses errexit
+# for an inverted status. Every such assertion is therefore either dead
+# or one appended line away from becoming dead, silently.
 #
 # `refute` (test/bats_helpers.bash) is the replacement: an ordinary
 # function call, so errexit applies wherever it sits in the body.
 #
 # This guard is the reason the class cannot come back. Fixing the 79
 # sites was the one-off; this is the part that keeps them fixed.
+#
+# Every check enumerates the suites with `find`, deliberately NOT a
+# hardcoded directory list: scripts/bats.sh names the three directories
+# it runs, and a guard carrying its own copy would silently stop
+# covering a fourth one the day somebody adds it.
+
+load ../bats_helpers
 
 setup() {
     REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd -P)"
+
+    # Wider than "the line starts with a bang": errexit is suppressed for
+    # an inverted status ANYWHERE a command can begin, so a bang after
+    # `;`, `&&`, `||`, `|`, `(` or `{` is just as dead.
+    PATTERN='(^[[:space:]]*|[;&|({][[:space:]]*)![[:space:]]'
+}
+
+# Every .bats file under test/, as an array (no xargs: it reports 123
+# when the command it runs exits 1, which would mask grep's own
+# "found nothing" and turn a clean scan into a guard failure).
+suite_files() {
+    local f
+    SUITES=()
+    while IFS= read -r f; do SUITES+=("$f"); done \
+        < <(find "$REPO_ROOT/test" -name '*.bats' -type f | sort)
 }
 
 @test "no bats body asserts with a bare inverted command (use refute)" {
-    cd "$REPO_ROOT"
+    suite_files
 
-    # First non-blank token on the line is `!`. Deliberately does NOT
-    # match the legitimate spellings, all of which keep errexit:
-    #   `if ! cmd; then`     — condition context, negation is the point
-    #   `[ ! -f "$path" ]`   — the `!` belongs to the test builtin, and
-    #                          `[` itself returns non-zero, so errexit fires
-    #   `while ! cmd; do`    — condition context
-    local offenders
-    offenders="$(grep -rnE '^[[:space:]]*![[:space:]]' \
-        test/bin test/infra test/scripts --include='*.bats' || true)"
+    # grep: 0 = matches, 1 = none, 2+ = it could not look. Only 1 is a
+    # clean bill of health — treating 2 as "no offenders" would make this
+    # guard fail OPEN, the very shape it exists to catch.
+    local offenders rc=0
+    offenders="$(grep -nE "$PATTERN" "${SUITES[@]}")" || rc=$?
+
+    if [ "$rc" -gt 1 ]; then
+        printf 'guard could not scan the suites (grep rc=%s)\n' "$rc" >&2
+        return 1
+    fi
 
     if [ -n "$offenders" ]; then
         printf 'Bare inverted assertions found — these cannot fail the test:\n%s\n' \
             "$offenders" >&2
-        printf '\nReplace `! cmd` with `refute cmd` (test/bats_helpers.bash).\n' >&2
+        printf '\nReplace with `refute cmd` (test/bats_helpers.bash).\n' >&2
         return 1
     fi
 }
 
-@test "every suite that calls refute has loaded the helper" {
-    cd "$REPO_ROOT"
+@test "the guard catches every position a bare negation can hide in" {
+    # The dead spellings are ASSEMBLED rather than written literally: a
+    # literal one would be found by the scan above, in this very file.
+    # Each of these reports ok as a mid-test line on bats 1.9.0.
+    local b='!'
+    local dead=(
+        "    $b grep -q x \$LOG"
+        "$(printf '\t')$b grep -q x \$LOG"
+        "    { $b true; }"
+        "    true && $b true"
+        "    true; $b true"
+        "    true || $b true"
+    )
 
-    local missing=""
-    for f in test/bin/*.bats test/infra/*.bats test/scripts/*.bats; do
+    local d
+    for d in "${dead[@]}"; do
+        grep -qE "$PATTERN" <<<"$d" \
+            || { printf 'guard would MISS this dead spelling: %s\n' "$d" >&2; return 1; }
+    done
+
+    # ...and narrow enough not to flag the spellings that DO keep errexit.
+    # The first three are condition contexts where inverting is the point;
+    # in the last two the bang belongs to the test builtin (or to `!=`),
+    # and `[` returns non-zero itself, so errexit still trips.
+    local live=(
+        '    if ! grep -q x "$LOG"; then'
+        '    while ! grep -q x "$LOG"; do'
+        '    until ! grep -q x "$LOG"; do'
+        '    [ ! -f "$path" ]'
+        '    [ "$a" != "$b" ]'
+    )
+
+    local l
+    for l in "${live[@]}"; do
+        refute grep -qE "$PATTERN" <<<"$l"
+    done
+}
+
+@test "every suite that calls refute has loaded the helper" {
+    suite_files
+
+    local missing="" f
+    for f in "${SUITES[@]}"; do
         grep -qE '^[[:space:]]*refute[[:space:]]' "$f" || continue
-        grep -qE '^load .*bats_helpers' "$f" || missing="$missing$f"$'\n'
+        grep -qE '^[[:space:]]*load[[:space:]].*bats_helpers' "$f" \
+            || missing="$missing$f"$'\n'
     done
 
     if [ -n "$missing" ]; then
+        # A missing function is "command not found" — non-zero — so an
+        # unloaded `refute` reads as a satisfied negation. Silent, again.
         printf 'These call refute without loading the helper:\n%s' "$missing" >&2
         return 1
     fi
 }
 
 @test "refute fails the case when the command succeeds" {
-    # The property the whole change rests on, pinned here so a future
-    # edit to the helper cannot quietly restore the old no-op behaviour.
-    load ../bats_helpers
-
+    # The property the whole change rests on, pinned so a future edit to
+    # the helper cannot quietly restore the old no-op behaviour.
     run refute true
     [ "$status" -ne 0 ]
     [[ "$output" == *"SUCCEEDED"* ]]
 
     run refute false
     [ "$status" -eq 0 ]
+}
+
+@test "refute refuses to pass on a command that could not look" {
+    # grep 2 = "could not look" (missing file, bad pattern). Passing on it
+    # would let an assertion hold vacuously against a log that never
+    # existed — and most of these logs are created by a stub when it runs,
+    # not by setup, so "the file is absent" is a reachable state.
+    run refute grep -q 'anything' "$BATS_TEST_TMPDIR/does-not-exist"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"ERRORED"* ]]
 }

--- a/test/scripts/bats_assertion_style_test.bats
+++ b/test/scripts/bats_assertion_style_test.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+#
+# A guard over the test suites themselves (#745).
+#
+# `! cmd` at the top level of a bats test body cannot fail the case
+# unless it happens to be the last line — bash suppresses errexit for an
+# inverted status. Every such assertion is therefore either dead or one
+# appended line away from becoming dead, silently.
+#
+# `refute` (test/bats_helpers.bash) is the replacement: an ordinary
+# function call, so errexit applies wherever it sits in the body.
+#
+# This guard is the reason the class cannot come back. Fixing the 79
+# sites was the one-off; this is the part that keeps them fixed.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd -P)"
+}
+
+@test "no bats body asserts with a bare inverted command (use refute)" {
+    cd "$REPO_ROOT"
+
+    # First non-blank token on the line is `!`. Deliberately does NOT
+    # match the legitimate spellings, all of which keep errexit:
+    #   `if ! cmd; then`     — condition context, negation is the point
+    #   `[ ! -f "$path" ]`   — the `!` belongs to the test builtin, and
+    #                          `[` itself returns non-zero, so errexit fires
+    #   `while ! cmd; do`    — condition context
+    local offenders
+    offenders="$(grep -rnE '^[[:space:]]*![[:space:]]' \
+        test/bin test/infra test/scripts --include='*.bats' || true)"
+
+    if [ -n "$offenders" ]; then
+        printf 'Bare inverted assertions found — these cannot fail the test:\n%s\n' \
+            "$offenders" >&2
+        printf '\nReplace `! cmd` with `refute cmd` (test/bats_helpers.bash).\n' >&2
+        return 1
+    fi
+}
+
+@test "every suite that calls refute has loaded the helper" {
+    cd "$REPO_ROOT"
+
+    local missing=""
+    for f in test/bin/*.bats test/infra/*.bats test/scripts/*.bats; do
+        grep -qE '^[[:space:]]*refute[[:space:]]' "$f" || continue
+        grep -qE '^load .*bats_helpers' "$f" || missing="$missing$f"$'\n'
+    done
+
+    if [ -n "$missing" ]; then
+        printf 'These call refute without loading the helper:\n%s' "$missing" >&2
+        return 1
+    fi
+}
+
+@test "refute fails the case when the command succeeds" {
+    # The property the whole change rests on, pinned here so a future
+    # edit to the helper cannot quietly restore the old no-op behaviour.
+    load ../bats_helpers
+
+    run refute true
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"SUCCEEDED"* ]]
+
+    run refute false
+    [ "$status" -eq 0 ]
+}

--- a/test/scripts/deploy_reload_verify_test.bats
+++ b/test/scripts/deploy_reload_verify_test.bats
@@ -19,6 +19,8 @@
 # (deploy.sh reloads via in_container curl, so curl runs "inside" the
 # stubbed container — no separate curl stub needed).
 
+load ../bats_helpers
+
 setup() {
     DEPLOY_SH="$BATS_TEST_DIRNAME/../../scripts/deploy.sh"
     LIB_SH="$BATS_TEST_DIRNAME/../../scripts/_lib.sh"
@@ -119,7 +121,7 @@ run_hot() {
     [[ "$output" != *"hot-deploy complete"* ]]
     [[ "$output" == *"failures"* ]]
     # Must bail BEFORE healthchecking a stale-code stack.
-    ! grep -q 'healthz' "$ARGV_LOG"
+    refute grep -q 'healthz' "$ARGV_LOG"
 }
 
 @test "reload ok but healthcheck never returns 200 FAILS the deploy" {

--- a/test/scripts/iex_observer_test.bats
+++ b/test/scripts/iex_observer_test.bats
@@ -19,6 +19,8 @@
 # live-stack verification in scripts/integration.sh + a manual dev-stack
 # run — this suite guards the invocation contract.
 
+load ../bats_helpers
+
 setup() {
     IEX_SH="$BATS_TEST_DIRNAME/../../scripts/iex.sh"
     OBSERVER_SH="$BATS_TEST_DIRNAME/../../scripts/observer.sh"
@@ -56,14 +58,14 @@ EOF
     grep -q 'RELEASE_COOKIE' "$ARGV_LOG"
     # The bug being fixed: `iex -S mix` boots a whole new Grappa.Application.
     # remsh attaches to the LIVE node instead — assert we never `-S mix`.
-    ! grep -q -- '-S mix' "$ARGV_LOG"
+    refute grep -q -- '-S mix' "$ARGV_LOG"
 }
 
 @test "iex.sh attaches interactively (no docker exec -T)" {
     run "$IEX_SH"
     [ "$status" -eq 0 ]
     # remsh needs an interactive TTY — the docker exec must NOT carry -T.
-    ! grep -qE 'docker .*compose .*exec -T grappa' "$ARGV_LOG"
+    refute grep -qE 'docker .*compose .*exec -T grappa' "$ARGV_LOG"
 }
 
 # --- observer.sh ---------------------------------------------------------
@@ -89,5 +91,5 @@ EOF
     [ "$status" -eq 0 ]
     # The observer_cli TUI needs a TTY — the pre-#364 `in_container` path
     # used `exec -T` (no TTY). Assert the fix drops -T.
-    ! grep -qE 'docker .*compose .*exec -T grappa' "$ARGV_LOG"
+    refute grep -qE 'docker .*compose .*exec -T grappa' "$ARGV_LOG"
 }

--- a/test/scripts/mix_env_db_test.bats
+++ b/test/scripts/mix_env_db_test.bats
@@ -18,6 +18,8 @@
 # Stubs `docker` on PATH so no real container is touched; `git` is NOT
 # stubbed — _lib.sh derives SRC_ROOT/REPO_ROOT from the real checkout.
 
+load ../bats_helpers
+
 setup() {
     MIX_SH="$BATS_TEST_DIRNAME/../../scripts/mix.sh"
 
@@ -46,7 +48,7 @@ EOF
     grep -q 'MIX_ENV=prod' "$ARGV_LOG"
     grep -q 'DATABASE_PATH=/app/runtime/grappa_prod.db' "$ARGV_LOG"
     # The exact S5 bug: prod env with the dev db file. Must never happen.
-    ! grep -q 'grappa_dev.db' "$ARGV_LOG"
+    refute grep -q 'grappa_dev.db' "$ARGV_LOG"
 }
 
 @test "mix.sh --env=dev does NOT inject DATABASE_PATH (dev config owns the path)" {
@@ -55,12 +57,12 @@ EOF
     grep -q 'MIX_ENV=dev' "$ARGV_LOG"
     # dev reads config/dev.exs, not DATABASE_PATH — injecting would be
     # inert. Assert we don't pretend otherwise.
-    ! grep -q 'DATABASE_PATH' "$ARGV_LOG"
+    refute grep -q 'DATABASE_PATH' "$ARGV_LOG"
 }
 
 @test "mix.sh --env=test does NOT inject DATABASE_PATH (test config owns the path)" {
     run "$MIX_SH" --env=test test
     [ "$status" -eq 0 ]
     grep -q 'MIX_ENV=test' "$ARGV_LOG"
-    ! grep -q 'DATABASE_PATH' "$ARGV_LOG"
+    refute grep -q 'DATABASE_PATH' "$ARGV_LOG"
 }


### PR DESCRIPTION
## What

Bash suppresses `errexit` for a command whose status is inverted with `!` — POSIX is explicit that the shell does not exit when the failing command's return status is being inverted. A bats body runs under `set -e`, so this assertion is a no-op unless it happens to be the LAST line of the test:

```bash
! grep -q "should not be here" "$LOG"
```

The grep matches, the negation yields 1, errexit stays quiet, the body runs on, the test reports ok.

**Measured, not reasoned about** — on the vendored bats 1.9.0:

```
ok 1 mid-test negated assertion should fail but does not
not ok 2 last-line negated assertion is live
```

Across `test/bin`, `test/infra` and `test/scripts` that was **80 assertions: 23 dead, 57 live only because nobody had appended a line after them yet**. Both halves are the same defect, so both are converted — leaving the 57 would leave 57 traps armed, each disguised as a working assertion.

## How

`refute` (`test/bats_helpers.bash`) is the whole fix, and the fix is that it is a *function*: a function call is an ordinary command, so its non-zero return is not an inverted status and errexit fires wherever it sits. It also prints what unexpectedly succeeded, which a bare `!` never did.

`test/scripts/bats_assertion_style_test.bats` is the part that matters more than the conversion — this class regrows one copy-paste at a time, because the bad spelling is the natural one to write and nothing about it looks broken. Five cases: no bare bang anywhere a command can begin; the guard's own pattern catches every dead spelling and none of the legitimate ones (`if ! cmd`, `while ! cmd`, `[ ! -f x ]`); every suite calling `refute` has loaded the helper; `refute` still fails on success; `refute` still refuses to pass on a command that could not look.

## What review changed

Three defects, all the same shape as the bug being fixed — a check that reads as coverage while being unable to fail:

* The guard matched only a bang at the START of a line. `a && ! b`, `a; ! b`, `a || ! b`, `{ ! b; }` are equally dead. Widening it **found an 80th site** the narrow scan had walked past (`deploy_docker_release_image_test.bats:207`).
* Both guard greps swallowed their own exit status, so a renamed path would have scanned nothing and passed. They now separate "found none" (rc 1) from "could not look" (rc 2+), and enumerate with `find` instead of carrying a second copy of the directory list that already lives in `scripts/bats.sh`.
* `refute` treated any non-zero as a satisfied negation, including grep's 2 = "I could not look". Most of these logs are created by a stub when it runs, not by setup, so an assertion against an absent file would have held vacuously.

The self-test earned its place immediately: the widened pattern lost its leading-whitespace branch in the rewrite, and the case asserting the guard catches every dead spelling is what caught it, before the suite ran.

## Gates

* `scripts/bats.sh`, full, from the worktree root — **262 passed, 0 failed, rc 0** (257 before, plus the five guard cases).
* Not run: `scripts/check.sh`. It needs a COMPILE lane this session does not hold, and the diff touches no Elixir — only `*.bats`, one new `.bash` helper, and docs. The bats portion of that gate is what ran above, in full.

**Converting broke nothing.** The suite is green with every assertion live for the first time, so the 23 dead ones had all been asserting things that happen to be true. This buys back the ability to catch a regression; it did not catch one. The corrected inventory is on the issue — the numbers in its description (19 of 63) were my own undercount.

## Docs

`docs/DESIGN_NOTES.md` gets the decision with how it was measured; `docs/TESTING.md` gets the rule to follow when writing a new bats assertion, next to the other gate traps that fake a green. One stale line corrected while there: bats has covered `test/infra` and `test/scripts` for some time, the runbook still said `test/bin` only.

Refs #745