### PR TITLE
auth review batch: passkey mode, re-auth, delete race, error surface

### DIFF
--- a/cicchetto/src/__tests__/friendlyApiError.test.ts
+++ b/cicchetto/src/__tests__/friendlyApiError.test.ts
@@ -156,6 +156,9 @@ const CASES: Array<{ code: string; matches: RegExp; info?: Record<string, unknow
   // still enabled (`PasskeyController.delete/2`). The copy has to name the
   // two ways out, because the refusal is otherwise a dead end for the user.
   { code: "passkey_required", matches: /only passkey/i },
+  // 409 asking for a ceremony with nothing registered to answer it — the
+  // mirror of the above, and the door that used to answer 500.
+  { code: "passkey_not_configured", matches: /don't have a passkey yet/i },
 ];
 
 describe("friendlyApiError", () => {

--- a/cicchetto/src/__tests__/passkeys.test.ts
+++ b/cicchetto/src/__tests__/passkeys.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createPasskey, getPasskey } from "../lib/passkeys";
+
+// The server speaks snake_case and `navigator.credentials` speaks the
+// camelCase WebAuthn shape; lib/passkeys.ts is the only place that
+// translates. Nothing else in the app would notice a mistranslation, so
+// these assert the exact object the browser API is handed.
+
+const b64 = (bytes: number[]): string =>
+  btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+
+const bytesOf = (buffer: BufferSource | undefined): number[] =>
+  Array.from(new Uint8Array(buffer as ArrayBuffer));
+
+const definedOr = <T>(value: T | undefined, what: string): T => {
+  if (value === undefined) throw new Error(`expected ${what}`);
+  return value;
+};
+
+const optionsGivenTo = <T>(spy: ReturnType<typeof vi.fn>): T => {
+  const call = definedOr(spy.mock.calls[0], "the browser credentials API to have been called");
+  return (call[0] as { publicKey: T }).publicKey;
+};
+
+const credentialStub = {
+  rawId: new Uint8Array([9, 9]).buffer,
+  response: {
+    attestationObject: new Uint8Array([1]).buffer,
+    clientDataJSON: new Uint8Array([2]).buffer,
+    authenticatorData: new Uint8Array([3]).buffer,
+    signature: new Uint8Array([4]).buffer,
+    userHandle: null,
+    getTransports: () => ["usb"],
+  },
+};
+
+let create: ReturnType<typeof vi.fn>;
+let get: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  create = vi.fn().mockResolvedValue(credentialStub);
+  get = vi.fn().mockResolvedValue(credentialStub);
+  vi.stubGlobal("navigator", { credentials: { create, get } });
+});
+
+describe("createPasskey", () => {
+  const options = {
+    challenge_id: "cid",
+    public_key: {
+      challenge: b64([1, 2, 3]),
+      rp: { id: "irc.example", name: "Grappa" },
+      user: { id: b64([4, 5]), name: "vjt", display_name: "vjt" },
+      pub_key_cred_params: [{ type: "public-key", alg: -7 }],
+      timeout: 300000,
+      attestation: "none",
+      authenticator_selection: { resident_key: "preferred", user_verification: "required" },
+    },
+  };
+
+  it("hands the browser the camelCase shape with decoded buffers", async () => {
+    await createPasskey(options);
+
+    const publicKey = optionsGivenTo<PublicKeyCredentialCreationOptions>(create);
+    expect(bytesOf(publicKey.challenge)).toEqual([1, 2, 3]);
+    expect(bytesOf(publicKey.user.id)).toEqual([4, 5]);
+    expect(publicKey.user.displayName).toBe("vjt");
+    expect(publicKey.pubKeyCredParams).toEqual([{ type: "public-key", alg: -7 }]);
+    expect(publicKey.authenticatorSelection).toEqual({
+      residentKey: "preferred",
+      userVerification: "required",
+    });
+  });
+
+  it("leaves no snake_case key behind for the browser to ignore", async () => {
+    await createPasskey(options);
+
+    const publicKey = optionsGivenTo<PublicKeyCredentialCreationOptions>(create);
+    expect(Object.keys(publicKey).filter((key) => key.includes("_"))).toEqual([]);
+  });
+});
+
+describe("getPasskey", () => {
+  it("decodes allow_credentials so a non-discoverable key can be offered", async () => {
+    await getPasskey({
+      challenge_id: "cid",
+      public_key: {
+        challenge: b64([7]),
+        rp_id: "irc.example",
+        timeout: 300000,
+        user_verification: "required",
+        allow_credentials: [{ type: "public-key", id: b64([1, 2, 3]), transports: ["usb"] }],
+      },
+    });
+
+    const publicKey = optionsGivenTo<PublicKeyCredentialRequestOptions>(get);
+    expect(publicKey.rpId).toBe("irc.example");
+    expect(publicKey.userVerification).toBe("required");
+
+    const descriptor = definedOr(publicKey.allowCredentials?.[0], "one offered credential");
+    expect(descriptor.type).toBe("public-key");
+    expect(descriptor.transports).toEqual(["usb"]);
+    expect(bytesOf(descriptor.id)).toEqual([1, 2, 3]);
+  });
+
+  it("omits transports when the server sent no hint", async () => {
+    await getPasskey({
+      challenge_id: "cid",
+      public_key: {
+        challenge: b64([7]),
+        rp_id: "irc.example",
+        allow_credentials: [{ type: "public-key", id: b64([1]) }],
+      },
+    });
+
+    const publicKey = optionsGivenTo<PublicKeyCredentialRequestOptions>(get);
+    const descriptor = definedOr(publicKey.allowCredentials?.[0], "one offered credential");
+    expect("transports" in descriptor).toBe(false);
+  });
+
+  it("sends an empty allow list when the passwordless door offered none", async () => {
+    await getPasskey({
+      challenge_id: "cid",
+      public_key: { challenge: b64([7]), rp_id: "irc.example", user_verification: "required" },
+    });
+
+    expect(optionsGivenTo<PublicKeyCredentialRequestOptions>(get).allowCredentials).toEqual([]);
+  });
+});

--- a/cicchetto/src/lib/friendlyApiError.ts
+++ b/cicchetto/src/lib/friendlyApiError.ts
@@ -68,6 +68,11 @@ function friendlyKnown(err: ApiError, code: ErrorTokensRestErrorToken): string {
       // lock the account out. Name both exits — a bare refusal reads as a
       // dead end.
       return "That's your only passkey. Add another, or turn off passkey sign-in first.";
+    case "passkey_not_configured":
+      // 409 — the mirror of `passkey_required`: a ceremony was asked for by
+      // an account holding no credential to answer it with. Name the exit;
+      // the account is one registration away from the thing it asked for.
+      return "You don't have a passkey yet. Add one before changing how you sign in.";
     case "too_many_sessions":
       // U-3 (UD3): ip_cap_exceeded — this source IP already holds
       // its allotted session(s) for this network (`max_per_ip`,

--- a/cicchetto/src/lib/passkeys.ts
+++ b/cicchetto/src/lib/passkeys.ts
@@ -3,18 +3,33 @@ export type PasskeyOptions = {
   public_key: Record<string, unknown>;
 };
 
-type CreationJSON = Omit<
-  PublicKeyCredentialCreationOptions,
-  "challenge" | "user" | "excludeCredentials"
-> & {
+// The wire is snake_case without exception, but `navigator.credentials`
+// wants the camelCase WebAuthn shape. Both ceremonies already have to
+// rebuild the options object to turn base64url strings into ArrayBuffers,
+// so that rebuild is the one place the two spellings meet.
+
+type DescriptorJSON = { type: "public-key"; id: string; transports?: AuthenticatorTransport[] };
+
+type CreationJSON = {
   challenge: string;
-  user: Omit<PublicKeyCredentialUserEntity, "id"> & { id: string };
-  excludeCredentials?: Array<Omit<PublicKeyCredentialDescriptor, "id"> & { id: string }>;
+  rp: PublicKeyCredentialRpEntity;
+  user: { id: string; name: string; display_name: string };
+  pub_key_cred_params: PublicKeyCredentialParameters[];
+  timeout?: number;
+  attestation?: AttestationConveyancePreference;
+  authenticator_selection?: {
+    resident_key?: ResidentKeyRequirement;
+    user_verification?: UserVerificationRequirement;
+  };
+  exclude_credentials?: DescriptorJSON[];
 };
 
-type RequestJSON = Omit<PublicKeyCredentialRequestOptions, "challenge" | "allowCredentials"> & {
+type RequestJSON = {
   challenge: string;
-  allowCredentials?: Array<Omit<PublicKeyCredentialDescriptor, "id"> & { id: string }>;
+  rp_id: string;
+  timeout?: number;
+  user_verification?: UserVerificationRequirement;
+  allow_credentials?: DescriptorJSON[];
 };
 
 const decode = (value: string): ArrayBuffer => {
@@ -31,17 +46,27 @@ const encode = (value: ArrayBuffer): string => {
   return btoa(raw).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 };
 
+const toDescriptor = (item: DescriptorJSON): PublicKeyCredentialDescriptor => ({
+  type: item.type,
+  id: decode(item.id),
+  ...(item.transports === undefined ? {} : { transports: item.transports }),
+});
+
 export async function createPasskey(options: PasskeyOptions): Promise<Record<string, unknown>> {
   const json = options.public_key as CreationJSON;
-  const publicKey = {
-    ...json,
+  const publicKey: PublicKeyCredentialCreationOptions = {
     challenge: decode(json.challenge),
-    user: { ...json.user, id: decode(json.user.id) },
-    excludeCredentials: (json.excludeCredentials ?? []).map((item) => ({
-      ...item,
-      id: decode(item.id),
-    })),
-  } as PublicKeyCredentialCreationOptions;
+    rp: json.rp,
+    user: { id: decode(json.user.id), name: json.user.name, displayName: json.user.display_name },
+    pubKeyCredParams: json.pub_key_cred_params,
+    timeout: json.timeout,
+    attestation: json.attestation,
+    authenticatorSelection: {
+      residentKey: json.authenticator_selection?.resident_key,
+      userVerification: json.authenticator_selection?.user_verification,
+    },
+    excludeCredentials: (json.exclude_credentials ?? []).map(toDescriptor),
+  };
   const credential = (await navigator.credentials.create({
     publicKey,
   })) as PublicKeyCredential | null;
@@ -59,12 +84,11 @@ export async function createPasskey(options: PasskeyOptions): Promise<Record<str
 export async function getPasskey(options: PasskeyOptions): Promise<Record<string, unknown>> {
   const json = options.public_key as RequestJSON;
   const publicKey: PublicKeyCredentialRequestOptions = {
-    ...json,
     challenge: decode(json.challenge),
-    allowCredentials: (json.allowCredentials ?? []).map((item) => ({
-      ...item,
-      id: decode(item.id),
-    })),
+    rpId: json.rp_id,
+    timeout: json.timeout,
+    userVerification: json.user_verification,
+    allowCredentials: (json.allow_credentials ?? []).map(toDescriptor),
   };
   const credential = (await navigator.credentials.get({ publicKey })) as PublicKeyCredential | null;
   if (credential === null) throw new Error("Passkey authentication cancelled");

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -1382,6 +1382,7 @@ export const ERROR_TOKENS_REST_ERROR_TOKEN = [
   "malformed_ident",
   "password_required",
   "passkey_required",
+  "passkey_not_configured",
   "password_mismatch",
   "network_not_visitor_enabled",
   "network_ambiguous",

--- a/config/config.exs
+++ b/config/config.exs
@@ -386,6 +386,15 @@ config :logger, :console,
     # audit line (admin password rotation, S8) — sibling of
     # `visitor_id` on `revoke_sessions_for_visitor/1`.
     :user_id,
+    # Passkey clone detection: an assertion whose signature counter did not
+    # advance is refused with the same opaque error every other passkey
+    # failure returns, so the wire tells an attacker nothing — which leaves
+    # this log line as the only place the operator can see it. It carries
+    # both counters so a genuine authenticator glitch can be told apart
+    # from a credential that is being replayed.
+    :passkey_id,
+    :stored_sign_count,
+    :presented_sign_count,
     # IRC client (Phase 2 sub-task 2f): SASL handshake numerics
     # (904 / 905 failures, etc.) ride this key so operator log search
     # can grep "sasl" + numeric in a single pass. `:sasl_user` is the

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -27972,3 +27972,37 @@ BEFORE the probe: a `/messages/count` on the wire 10ms after its own bearer was
 revoked, through production code paths in a real browser. That is #788 — the
 async verbs capture `token()` at entry and never re-check — and it is NOT what
 #769 turned out to be.
+---
+
+## 2026-08-03 — the auth wire joins the rest of the wire (snake_case)
+
+The WebAuthn ceremony options were the one place the client-facing wire spoke
+camelCase: `rpId`, `userVerification`, `pubKeyCredParams`,
+`authenticatorSelection`, `displayName`. The excuse was that
+`navigator.credentials` wants exactly those spellings, so passing the block
+through verbatim looked like it saved a translation.
+
+It did not save one. `cicchetto/src/lib/passkeys.ts` already had to rebuild the
+whole options object on both ceremonies, because `challenge`, `user.id` and
+every credential id arrive as base64url strings and the browser API wants
+`ArrayBuffer`s. The translation was always there; it was simply doing half a
+job, and the wire paid for the other half by breaking a rule CLAUDE.md states
+without exception.
+
+**vjt's call: snake_case now.** Passkeys are not in production and no client
+depends on the current spelling, so the cost is one commit today against a
+permanent exception in the contract. Grandfathering it would have made "the
+whole wire is snake_case" a claim a reader could no longer trust — and the next
+person adding an auth field would have had to guess which side of the line it
+fell on. The camelCase mapping now lives in the same step that decodes the
+buffers, which is the only place in cic that knows the WebAuthn shape at all.
+
+Not a `protocol_version` bump: the additive-only rule does not cover renaming
+fields, but there is no deployed client to break, so the version stays put.
+`wireTypes.ts` is untouched too — the options ride inside `public_key:
+Record<string, unknown>`, opaque to the generator.
+
+**Apply:** an exception to a wire rule is worth taking only while something
+actually depends on it. Before granting one, check whether the boundary code
+already does the work the exception was supposed to avoid — here it did, and
+the exception bought nothing but a footnote.

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -674,9 +674,12 @@ defmodule Grappa.Accounts do
         {:error, :not_found}
 
       user ->
-        Repo.BusyRetry.run(fn -> Repo.transaction(fn -> totp_reset_transaction(user) end) end)
+        run_totp_reset(user)
     end
   end
+
+  defp run_totp_reset(user),
+    do: Repo.BusyRetry.run(fn -> Repo.transaction(fn -> totp_reset_transaction(user) end) end)
 
   defp totp_reset_transaction(user) do
     user_query = from(u in User, where: u.id == ^user.id)

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -714,7 +714,7 @@ defmodule Grappa.Accounts do
 
   defp reset_passkeys_transaction(user) do
     Passkey |> where([p], p.user_id == ^user.id) |> Repo.delete_all()
-    {1, _} = User |> where([u], u.id == ^user.id) |> Repo.update_all(set: [passkey_mode: "disabled"])
+    user |> User.passkey_mode_changeset(%{passkey_mode: :disabled}) |> Repo.update!()
     :ok = RecoveryCodes.drop_if_orphaned(user.id)
     :ok = revoke_sessions_for_user(user)
     Repo.get!(User, user.id)

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -655,6 +655,47 @@ defmodule Grappa.Accounts do
     end
   end
 
+  @doc """
+  Operator recovery: disarms TOTP and revokes live sessions.
+
+  The undo for an enrolment the account owner did not make. `reset_passkeys/1`
+  deliberately does NOT cover this — it clears the passkey side and leaves
+  `totp_secret_encrypted` armed, so before this existed an operator with shell
+  access still could not restore password-only login.
+
+  Leaves the recovery-code set intact. That set is account-level and shared
+  with passkey passwordless mode, so disarming one factor is not entitled to
+  destroy the other factor's way back in.
+  """
+  @spec reset_totp(String.t()) :: {:ok, User.t()} | {:error, :not_found | :db_unavailable}
+  def reset_totp(name) when is_binary(name) do
+    case get_user_by_name(name) do
+      nil ->
+        {:error, :not_found}
+
+      user ->
+        Repo.BusyRetry.run(fn -> Repo.transaction(fn -> totp_reset_transaction(user) end) end)
+    end
+  end
+
+  defp totp_reset_transaction(user) do
+    user_query = from(u in User, where: u.id == ^user.id)
+
+    {1, _} =
+      Repo.update_all(
+        user_query,
+        set: [
+          totp_secret_encrypted: nil,
+          totp_enabled_at: nil,
+          totp_last_used_step: nil,
+          updated_at: DateTime.utc_now()
+        ]
+      )
+
+    :ok = revoke_sessions_for_user(user)
+    Repo.get!(User, user.id)
+  end
+
   defp consume_recovery_code_once(user_id, code) do
     case RecoveryCodes.consume(user_id, code) do
       :ok -> {:ok, :consumed}

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -647,7 +647,13 @@ defmodule Grappa.Accounts do
   @spec prepare_recovery_codes() :: [String.t()]
   def prepare_recovery_codes, do: RecoveryCodes.generate()
 
-  @doc "Operator recovery: removes passkeys, recovery codes, passwordless mode, and live sessions."
+  @doc """
+  Operator recovery: removes passkeys, passwordless mode, and live sessions.
+
+  The recovery set is account-level and shared, so it goes only if nothing
+  is left armed to redeem it — see `RecoveryCodes.drop_if_orphaned/1` and
+  the `reset_totp/1` sibling.
+  """
   @spec reset_passkeys(String.t()) :: {:ok, User.t()} | {:error, :not_found | :db_unavailable}
   def reset_passkeys(name) when is_binary(name) do
     case get_user_by_name(name) do

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -663,9 +663,10 @@ defmodule Grappa.Accounts do
   `totp_secret_encrypted` armed, so before this existed an operator with shell
   access still could not restore password-only login.
 
-  Leaves the recovery-code set intact. That set is account-level and shared
-  with passkey passwordless mode, so disarming one factor is not entitled to
-  destroy the other factor's way back in.
+  The recovery set is account-level and shared, so it survives exactly as
+  long as some factor can still redeem it: it stays when passkey login is
+  armed, and goes with the last factor standing. See
+  `Grappa.Accounts.RecoveryCodes.drop_if_orphaned/1`.
   """
   @spec reset_totp(String.t()) :: {:ok, User.t()} | {:error, :not_found | :db_unavailable}
   def reset_totp(name) when is_binary(name) do
@@ -695,6 +696,7 @@ defmodule Grappa.Accounts do
         ]
       )
 
+    :ok = RecoveryCodes.drop_if_orphaned(user.id)
     :ok = revoke_sessions_for_user(user)
     Repo.get!(User, user.id)
   end
@@ -712,8 +714,8 @@ defmodule Grappa.Accounts do
 
   defp reset_passkeys_transaction(user) do
     Passkey |> where([p], p.user_id == ^user.id) |> Repo.delete_all()
-    TOTPRecoveryCode |> where([r], r.user_id == ^user.id) |> Repo.delete_all()
     {1, _} = User |> where([u], u.id == ^user.id) |> Repo.update_all(set: [passkey_mode: "disabled"])
+    :ok = RecoveryCodes.drop_if_orphaned(user.id)
     :ok = revoke_sessions_for_user(user)
     Repo.get!(User, user.id)
   end

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -605,14 +605,27 @@ defmodule Grappa.Accounts do
     end)
   end
 
+  @doc """
+  Re-confirms an account password for a privileged mutation.
+
+  The single door for "prove it is still you" on an already-authenticated
+  request. A bearer alone must never be enough to change how the account
+  authenticates: an enrolment, a mode switch or a credential deletion each
+  outlives the token that requested it, so each re-asks for the password.
+  """
+  @spec verify_password(User.t(), String.t()) :: :ok | {:error, :invalid_credentials}
+  def verify_password(%User{} = user, password) when is_binary(password) do
+    if Argon2.verify_pass(password, user.password_hash),
+      do: :ok,
+      else: {:error, :invalid_credentials}
+  end
+
   @doc "Atomically disables TOTP and revokes every other bearer session."
   @spec disable_totp(User.t(), Ecto.UUID.t(), String.t()) ::
           {:ok, User.t()} | {:error, term()}
   def disable_totp(user, current_session_id, password) do
-    if Argon2.verify_pass(password, user.password_hash) do
+    with :ok <- verify_password(user, password) do
       run_disable_totp_transaction(user, current_session_id)
-    else
-      {:error, :invalid_credentials}
     end
   end
 

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -93,10 +93,8 @@ defmodule Grappa.Accounts do
   def get_user_by_credentials(name, password)
       when is_binary(name) and is_binary(password) do
     case Repo.get_by(User, name: name) do
-      %User{password_hash: hash} = user ->
-        if Argon2.verify_pass(password, hash),
-          do: {:ok, user},
-          else: {:error, :invalid_credentials}
+      %User{} = user ->
+        with :ok <- verify_password(user, password), do: {:ok, user}
 
       nil ->
         Argon2.no_user_verify()
@@ -606,12 +604,18 @@ defmodule Grappa.Accounts do
   end
 
   @doc """
-  Re-confirms an account password for a privileged mutation.
+  Checks a plaintext password against an account's stored hash.
 
-  The single door for "prove it is still you" on an already-authenticated
-  request. A bearer alone must never be enough to change how the account
-  authenticates: an enrolment, a mode switch or a credential deletion each
-  outlives the token that requested it, so each re-asks for the password.
+  The ONE place a password is compared. Two callers need it for different
+  reasons and both belong here: `get_user_by_credentials/2` at login, and
+  every privileged mutation that re-asks "prove it is still you" — a bearer
+  alone must never be enough to change how the account authenticates, since
+  an enrolment, a mode switch or a credential deletion each outlives the
+  token that requested it.
+
+  Takes a `%User{}`, so it says nothing about accounts that do not exist;
+  that timing oracle is `get_user_by_credentials/2`'s to close, with
+  `Argon2.no_user_verify/0`.
   """
   @spec verify_password(User.t(), String.t()) :: :ok | {:error, :invalid_credentials}
   def verify_password(%User{} = user, password) when is_binary(password) do

--- a/lib/grappa/accounts/recovery_codes.ex
+++ b/lib/grappa/accounts/recovery_codes.ex
@@ -34,7 +34,7 @@ defmodule Grappa.Accounts.RecoveryCodes do
   # 2026-08-03): the conservative line is that codes outlive any 2FA
   # factor still standing, not just the one that happened to mint them.
   @spec armed_factor?(User.t()) :: boolean()
-  defp armed_factor?(user), do: TOTP.enabled?(user) or user.passkey_mode != "disabled"
+  defp armed_factor?(user), do: TOTP.enabled?(user) or user.passkey_mode != :disabled
 
   @spec drop_unless_armed(boolean(), Ecto.UUID.t()) :: :ok
   defp drop_unless_armed(true, _), do: :ok

--- a/lib/grappa/accounts/recovery_codes.ex
+++ b/lib/grappa/accounts/recovery_codes.ex
@@ -2,10 +2,47 @@ defmodule Grappa.Accounts.RecoveryCodes do
   @moduledoc "Account-level one-shot recovery codes shared by TOTP and passkeys."
   import Ecto.Query
 
-  alias Grappa.Accounts.TOTPRecoveryCode
+  alias Grappa.Accounts.{TOTP, TOTPRecoveryCode, User}
   alias Grappa.Repo
 
   @count 10
+
+  @doc """
+  Drops the recovery set once the last factor that could redeem it is gone.
+
+  There is ONE flat account-level set, shared by TOTP and passkey login,
+  with no per-factor ownership recorded anywhere — so no single teardown
+  is entitled to assume the codes are its own to destroy. Every teardown
+  calls this AFTER its own mutation has landed, and the codes go only
+  when nothing is armed to use them.
+
+  The conservative half of that (keeping codes a surviving factor still
+  needs) is the half that had been getting this wrong: disabling passkey
+  login, or an operator resetting passkeys, wiped a TOTP user's codes
+  outright.
+  """
+  @spec drop_if_orphaned(Ecto.UUID.t()) :: :ok
+  def drop_if_orphaned(user_id) when is_binary(user_id) do
+    User
+    |> Repo.get!(user_id)
+    |> armed_factor?()
+    |> drop_unless_armed(user_id)
+  end
+
+  # "Armed" means the factor could still be the only thing between the
+  # account and a locked door. Passkey `second_factor` counts (vjt,
+  # 2026-08-03): the conservative line is that codes outlive any 2FA
+  # factor still standing, not just the one that happened to mint them.
+  @spec armed_factor?(User.t()) :: boolean()
+  defp armed_factor?(user), do: TOTP.enabled?(user) or user.passkey_mode != "disabled"
+
+  @spec drop_unless_armed(boolean(), Ecto.UUID.t()) :: :ok
+  defp drop_unless_armed(true, _), do: :ok
+
+  defp drop_unless_armed(false, user_id) do
+    TOTPRecoveryCode |> where([r], r.user_id == ^user_id) |> Repo.delete_all()
+    :ok
+  end
 
   @doc "Rotates all recovery codes and returns their plaintext values once."
   @spec rotate(Ecto.UUID.t()) :: [String.t()]

--- a/lib/grappa/accounts/totp.ex
+++ b/lib/grappa/accounts/totp.ex
@@ -10,7 +10,7 @@ defmodule Grappa.Accounts.TOTP do
   import Ecto.Query
   import Bitwise
 
-  alias Grappa.Accounts.{RecoveryCodes, TOTPRecoveryCode, User}
+  alias Grappa.Accounts.{RecoveryCodes, User}
   alias Grappa.Repo
 
   @digits 6
@@ -99,19 +99,19 @@ defmodule Grappa.Accounts.TOTP do
     end
   end
 
+  # `RecoveryCodes` owns the set — it mints them (`arm/4` above rotates
+  # through it) so it also spends them. This used to be a second, private
+  # copy of the same normalise-hash-delete, which only worked while the two
+  # agreed byte for byte; the day one grew a rule the other lacked, codes
+  # minted at one door would have stopped opening the other.
+  #
+  # The error is re-shaped, not re-decided: `verify/3` speaks one opaque
+  # `:invalid_two_factor` for a bad TOTP code and a bad recovery code
+  # alike, so a caller cannot learn which of the two it got wrong.
   defp consume_recovery_code(%User{id: user_id}, code) do
-    normalized = normalize_recovery_code(code)
-
-    if valid_recovery_code?(normalized) do
-      hash = recovery_code_hash(normalized)
-      query = from(r in TOTPRecoveryCode, where: r.user_id == ^user_id and r.code_hash == ^hash)
-
-      case Repo.delete_all(query) do
-        {1, _} -> :recovery
-        {0, _} -> Repo.rollback(:invalid_two_factor)
-      end
-    else
-      Repo.rollback(:invalid_two_factor)
+    case RecoveryCodes.consume(user_id, code) do
+      :ok -> :recovery
+      {:error, :invalid_recovery_code} -> Repo.rollback(:invalid_two_factor)
     end
   end
 
@@ -161,15 +161,4 @@ defmodule Grappa.Accounts.TOTP do
         Repo.rollback(:already_enabled)
     end
   end
-
-  defp normalize_recovery_code(code) do
-    code
-    |> String.trim()
-    |> String.downcase()
-    |> String.replace("-", "")
-    |> String.replace(" ", "")
-  end
-
-  defp valid_recovery_code?(code), do: Regex.match?(~r/^[a-z2-7]{26}$/, code)
-  defp recovery_code_hash(code), do: :crypto.hash(:sha256, normalize_recovery_code(code))
 end

--- a/lib/grappa/accounts/user.ex
+++ b/lib/grappa/accounts/user.ex
@@ -25,6 +25,8 @@ defmodule Grappa.Accounts.User do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type passkey_mode :: :disabled | :second_factor | :passwordless
+
   @type t :: %__MODULE__{
           id: Ecto.UUID.t() | nil,
           name: String.t() | nil,
@@ -33,7 +35,7 @@ defmodule Grappa.Accounts.User do
           totp_secret_encrypted: binary() | nil,
           totp_enabled_at: DateTime.t() | nil,
           totp_last_used_step: integer() | nil,
-          passkey_mode: String.t(),
+          passkey_mode: passkey_mode(),
           is_admin: boolean(),
           inserted_at: DateTime.t() | nil,
           updated_at: DateTime.t() | nil
@@ -47,7 +49,7 @@ defmodule Grappa.Accounts.User do
     field :totp_secret_encrypted, Grappa.EncryptedBinary, redact: true
     field :totp_enabled_at, :utc_datetime_usec
     field :totp_last_used_step, :integer
-    field :passkey_mode, :string, default: "disabled"
+    field :passkey_mode, Ecto.Enum, values: [:disabled, :second_factor, :passwordless], default: :disabled
     field :is_admin, :boolean, default: false
 
     timestamps(type: :utc_datetime_usec)
@@ -102,6 +104,24 @@ defmodule Grappa.Accounts.User do
     user
     |> cast(attrs, [:is_admin])
     |> validate_required([:is_admin])
+  end
+
+  @doc """
+  Narrow changeset for `:passkey_mode` transitions only.
+
+  The mode decides which login door the account gets, so it is the one
+  field where a value outside the set is an authentication bug rather than
+  a display bug. Both teardown paths used to write it through
+  `Repo.update_all/2`, which skips casting entirely — the set survived only
+  as pattern matches scattered across the callers. `Ecto.Enum` closes the
+  column and this changeset closes the write, so the two agree by
+  construction.
+  """
+  @spec passkey_mode_changeset(t(), %{required(:passkey_mode) => passkey_mode()}) :: Ecto.Changeset.t()
+  def passkey_mode_changeset(%__MODULE__{} = user, attrs) do
+    user
+    |> cast(attrs, [:passkey_mode])
+    |> validate_required([:passkey_mode])
   end
 
   @doc """

--- a/lib/grappa/accounts/webauthn.ex
+++ b/lib/grappa/accounts/webauthn.ex
@@ -23,7 +23,7 @@ defmodule Grappa.Accounts.WebAuthn do
   @spec begin_registration(User.t(), String.t(), String.t(), binding(), String.t()) ::
           {:ok, map()} | {:error, :invalid_credentials}
   def begin_registration(user, password, name, binding, origin) do
-    if Argon2.verify_pass(password, user.password_hash) do
+    with :ok <- Grappa.Accounts.verify_password(user, password) do
       challenge = Wax.new_registration_challenge(challenge_opts(origin))
 
       id =
@@ -34,8 +34,6 @@ defmodule Grappa.Accounts.WebAuthn do
         })
 
       {:ok, registration_options(id, challenge, user)}
-    else
-      {:error, :invalid_credentials}
     end
   end
 

--- a/lib/grappa/accounts/webauthn.ex
+++ b/lib/grappa/accounts/webauthn.ex
@@ -8,7 +8,7 @@ defmodule Grappa.Accounts.WebAuthn do
   require Logger
 
   @type binding :: %{ip: String.t() | nil, client_id: String.t() | nil}
-  @type mode :: String.t()
+  @type mode :: User.passkey_mode()
 
   @doc "Lists public passkey metadata for account settings."
   @spec list(User.t()) :: [Passkey.t()]
@@ -107,27 +107,45 @@ defmodule Grappa.Accounts.WebAuthn do
     end
   end
 
+  @doc """
+  Decodes a wire mode string into the closed set the schema stores.
+
+  The wire speaks the three mode spellings; the column stores them as the
+  atoms that make the set closed. This is the single door between the two,
+  and it reads the schema's own mapping rather than restating the list, so
+  a fourth mode cannot exist on one side only.
+  """
+  @spec decode_mode(term()) :: {:ok, mode()} | {:error, :invalid_mode}
+  def decode_mode(value) when is_binary(value) do
+    case Enum.find(Ecto.Enum.mappings(User, :passkey_mode), fn {_, wire} -> wire == value end) do
+      {mode, _} -> {:ok, mode}
+      nil -> {:error, :invalid_mode}
+    end
+  end
+
+  def decode_mode(_), do: {:error, :invalid_mode}
+
   @doc "Changes passkey mode after a verified assertion; passwordless rotates recovery codes."
   @spec set_mode(User.t(), mode(), Ecto.UUID.t(), [String.t()]) :: {:ok, mode()} | {:error, term()}
   def set_mode(user, mode, current_session_id, recovery_codes \\ [])
 
-  def set_mode(user, "passwordless" = mode, current_session_id, recovery_codes)
+  def set_mode(user, :passwordless = mode, current_session_id, recovery_codes)
       when length(recovery_codes) == 10 do
     run_mode_transaction(user, mode, current_session_id, recovery_codes)
   end
 
-  def set_mode(user, "second_factor" = mode, current_session_id, []) do
+  def set_mode(user, :second_factor = mode, current_session_id, []) do
     run_mode_transaction(user, mode, current_session_id, [])
   end
 
-  def set_mode(user, "disabled" = mode, current_session_id, []) do
+  def set_mode(user, :disabled = mode, current_session_id, []) do
     run_mode_transaction(user, mode, current_session_id, [])
   end
 
-  def set_mode(_, "passwordless", _, _),
+  def set_mode(_, :passwordless, _, _),
     do: {:error, :recovery_codes_required}
 
-  def set_mode(_, "second_factor", _, _),
+  def set_mode(_, :second_factor, _, _),
     do: {:error, :unexpected_recovery_codes}
 
   @doc "Deletes one credential owned by the account."
@@ -280,9 +298,9 @@ defmodule Grappa.Accounts.WebAuthn do
   end
 
   defp set_mode_transaction(user, mode, current_session_id, recovery_codes) do
-    if mode == "passwordless", do: :ok = RecoveryCodes.replace(user.id, recovery_codes)
+    if mode == :passwordless, do: :ok = RecoveryCodes.replace(user.id, recovery_codes)
 
-    {1, _} = User |> where([u], u.id == ^user.id) |> Repo.update_all(set: [passkey_mode: mode])
+    user |> User.passkey_mode_changeset(%{passkey_mode: mode}) |> Repo.update!()
 
     # AFTER the mode write, so the shared-set rule reads the mode we just
     # committed. It replaces a narrower guard that fired only on

--- a/lib/grappa/accounts/webauthn.ex
+++ b/lib/grappa/accounts/webauthn.ex
@@ -2,7 +2,7 @@ defmodule Grappa.Accounts.WebAuthn do
   @moduledoc "Passkey registration and assertion ceremonies for durable accounts."
   import Ecto.Query
 
-  alias Grappa.Accounts.{Passkey, RecoveryCodes, TOTPRecoveryCode, User, WebAuthnChallengeStore}
+  alias Grappa.Accounts.{Passkey, RecoveryCodes, User, WebAuthnChallengeStore}
   alias Grappa.Repo
 
   require Logger
@@ -282,10 +282,14 @@ defmodule Grappa.Accounts.WebAuthn do
   defp set_mode_transaction(user, mode, current_session_id, recovery_codes) do
     if mode == "passwordless", do: :ok = RecoveryCodes.replace(user.id, recovery_codes)
 
-    if mode == "disabled" and user.passkey_mode == "passwordless",
-      do: TOTPRecoveryCode |> where([r], r.user_id == ^user.id) |> Repo.delete_all()
-
     {1, _} = User |> where([u], u.id == ^user.id) |> Repo.update_all(set: [passkey_mode: mode])
+
+    # AFTER the mode write, so the shared-set rule reads the mode we just
+    # committed. It replaces a narrower guard that fired only on
+    # passwordless -> disabled and deleted unconditionally, which wiped a
+    # TOTP user's codes and left the second_factor exits unconsidered.
+    :ok = RecoveryCodes.drop_if_orphaned(user.id)
+
     :ok = Grappa.Accounts.revoke_other_sessions_for_user(user, current_session_id)
     mode
   end

--- a/lib/grappa/accounts/webauthn.ex
+++ b/lib/grappa/accounts/webauthn.ex
@@ -5,6 +5,8 @@ defmodule Grappa.Accounts.WebAuthn do
   alias Grappa.Accounts.{Passkey, RecoveryCodes, TOTPRecoveryCode, User, WebAuthnChallengeStore}
   alias Grappa.Repo
 
+  require Logger
+
   @type binding :: %{ip: String.t() | nil, client_id: String.t() | nil}
   @type mode :: String.t()
 
@@ -97,7 +99,7 @@ defmodule Grappa.Accounts.WebAuthn do
          {:ok, credential_id} <- decode(params["raw_id"]),
          %Passkey{} = passkey <- Repo.get_by(Passkey, credential_id: credential_id, user_id: user_id),
          {:ok, auth_data} <- verify_assertion(params, credential_id, challenge),
-         :ok <- accept_counter(passkey, auth_data.sign_count),
+         :ok <- consume_sign_count(passkey, auth_data.sign_count),
          %User{} = user <- Repo.get(User, user_id) do
       {:ok, user, metadata}
     else
@@ -214,22 +216,57 @@ defmodule Grappa.Accounts.WebAuthn do
     end
   end
 
-  defp accept_counter(%Passkey{id: id}, new_count) when new_count == 0 do
-    touch_query(from(p in Passkey, where: p.id == ^id), 0)
-  end
+  @doc """
+  Consumes the signature counter an assertion presented, refusing one that
+  did not advance.
 
-  defp accept_counter(%Passkey{id: id, sign_count: old_count}, new_count)
-       when new_count > old_count do
-    touch_query(from(p in Passkey, where: p.id == ^id and p.sign_count < ^new_count), new_count)
-  end
+  The assertion-time step of `authenticate/3`, exposed because it is the
+  clone-detection rule and deserves to be tested against real rows rather
+  than through a hand-forged WebAuthn ceremony.
 
-  defp accept_counter(_, _), do: {:error, :cloned_authenticator}
+  A zero counter means "this authenticator does not count" ONLY when the
+  credential has never counted either. Once a stored counter has moved, a
+  zero is the clone signal WebAuthn L3 7.2.21 describes — and the old
+  unguarded clause not only accepted it, it wrote the zero back, so the
+  clone erased the very evidence and every later assertion looked clean.
 
-  defp touch_query(query, count) do
-    case Repo.update_all(query, set: [sign_count: count, last_used_at: DateTime.utc_now()]) do
+  The write is a compare-and-set on the stored counter, so two assertions
+  racing on one credential cannot both win.
+  """
+  @spec consume_sign_count(Passkey.t(), non_neg_integer()) :: :ok | {:error, :cloned_authenticator}
+  def consume_sign_count(%Passkey{sign_count: 0} = passkey, 0), do: commit_counter(passkey, 0, 0)
+
+  def consume_sign_count(%Passkey{sign_count: old_count} = passkey, new_count)
+      when new_count > old_count,
+      do: commit_counter(passkey, new_count, old_count)
+
+  def consume_sign_count(passkey, new_count), do: refuse_clone(passkey, new_count)
+
+  # Compare-and-set against the counter we read. A concurrent assertion that
+  # already moved the row wins and this one is refused, so a captured
+  # assertion cannot be replayed alongside the genuine one.
+  defp commit_counter(%Passkey{id: id} = passkey, new_count, expected) do
+    query = from(p in Passkey, where: p.id == ^id and p.sign_count == ^expected)
+
+    case Repo.update_all(query, set: [sign_count: new_count, last_used_at: DateTime.utc_now()]) do
       {1, _} -> :ok
-      {0, _} -> {:error, :cloned_authenticator}
+      {0, _} -> refuse_clone(passkey, new_count)
     end
+  end
+
+  # `authenticate/3` collapses this into `:invalid_passkey` so the wire
+  # never confirms to an attacker that their clone was spotted. That makes
+  # the log the ONLY place the operator can learn it happened, so it has to
+  # carry enough to act on: which account, which credential, both counters.
+  defp refuse_clone(%Passkey{id: id, user_id: user_id, sign_count: stored}, presented) do
+    Logger.warning("passkey assertion refused: sign counter did not advance",
+      passkey_id: id,
+      user_id: user_id,
+      stored_sign_count: stored,
+      presented_sign_count: presented
+    )
+
+    {:error, :cloned_authenticator}
   end
 
   defp encode(binary), do: Base.url_encode64(binary, padding: false)

--- a/lib/grappa/accounts/webauthn.ex
+++ b/lib/grappa/accounts/webauthn.ex
@@ -66,7 +66,7 @@ defmodule Grappa.Accounts.WebAuthn do
 
   @doc "Begins a passkey assertion for login or a settings mode change."
   @spec begin_authentication(User.t(), atom(), binding(), String.t(), map()) :: {:ok, map()} | {:error, term()}
-  def begin_authentication(user, purpose, binding, origin, metadata \\ %{}) do
+  def begin_authentication(user, purpose, binding, origin, metadata) do
     credentials = credentials(user.id)
 
     if credentials == [] do
@@ -125,8 +125,6 @@ defmodule Grappa.Accounts.WebAuthn do
 
   @doc "Changes passkey mode after a verified assertion; passwordless rotates recovery codes."
   @spec set_mode(User.t(), mode(), Ecto.UUID.t(), [String.t()]) :: {:ok, mode()} | {:error, term()}
-  def set_mode(user, mode, current_session_id, recovery_codes \\ [])
-
   def set_mode(user, :passwordless = mode, current_session_id, recovery_codes)
       when length(recovery_codes) == 10 do
     run_mode_transaction(user, mode, current_session_id, recovery_codes)

--- a/lib/grappa/accounts/webauthn.ex
+++ b/lib/grappa/accounts/webauthn.ex
@@ -146,15 +146,43 @@ defmodule Grappa.Accounts.WebAuthn do
   def set_mode(_, :second_factor, _, _),
     do: {:error, :unexpected_recovery_codes}
 
-  @doc "Deletes one credential owned by the account."
-  @spec delete(User.t(), Ecto.UUID.t()) :: :ok | {:error, :not_found}
-  def delete(user, id) do
-    query = from(p in Passkey, where: p.id == ^id and p.user_id == ^user.id)
+  @doc """
+  Deletes one credential owned by the account, refusing the last one an
+  armed mode still needs.
 
+  The "is this the last one" test is part of the DELETE rather than a read
+  before it. Counting first and deleting second is two statements, and two
+  concurrent requests both saw two credentials and both went ahead — which
+  leaves a passwordless account with zero passkeys and no door at all. As
+  one statement the second request re-decides against the row the first
+  already removed, and loses.
+  """
+  @spec delete(User.t(), Ecto.UUID.t()) :: :ok | {:error, :not_found | :passkey_required}
+  def delete(%User{passkey_mode: :disabled} = user, id), do: run_delete(user, id, owned(user, id))
+
+  def delete(user, id) do
+    others = from(o in Passkey, where: o.user_id == ^user.id and o.id != ^id)
+
+    run_delete(user, id, from(p in owned(user, id), where: exists(others)))
+  end
+
+  defp owned(user, id), do: from(p in Passkey, where: p.id == ^id and p.user_id == ^user.id)
+
+  defp run_delete(user, id, query) do
     case Repo.delete_all(query) do
       {1, _} -> :ok
-      {0, _} -> {:error, :not_found}
+      {0, _} -> refuse_delete(user, id)
     end
+  end
+
+  # A zero-row delete is either "not yours, or not there" or "it is the last
+  # one an armed mode needs", and one statement cannot report which. Asking
+  # afterwards can only mis-label under a concurrent delete, where both
+  # answers were true of some instant.
+  defp refuse_delete(user, id) do
+    if Repo.exists?(owned(user, id)),
+      do: {:error, :passkey_required},
+      else: {:error, :not_found}
   end
 
   defp challenge_opts(origin) do

--- a/lib/grappa/accounts/webauthn.ex
+++ b/lib/grappa/accounts/webauthn.ex
@@ -85,7 +85,7 @@ defmodule Grappa.Accounts.WebAuthn do
           })
         )
 
-      {:ok, authentication_options(id, challenge)}
+      {:ok, authentication_options(id, challenge, exposed_credentials(purpose, credentials))}
     end
   end
 
@@ -165,16 +165,45 @@ defmodule Grappa.Accounts.WebAuthn do
     }
   end
 
-  defp authentication_options(id, challenge) do
+  # `residentKey: "preferred"` lets an authenticator hand back a
+  # NON-discoverable credential, and the browser cannot find one of those
+  # without being told the id. So every ceremony whose caller has already
+  # proven who they are gets the account's credential list; the
+  # passwordless login door does not, because it answers an anonymous
+  # caller and credential ids are a tracking handle we will not hand out.
+  defp exposed_credentials(purpose, credentials) when purpose in [:second_factor, :mode_change],
+    do: credentials
+
+  defp exposed_credentials(_, _), do: []
+
+  defp authentication_options(id, challenge, credentials) do
     %{
       challenge_id: id,
-      public_key: %{
-        challenge: encode(challenge.bytes),
-        rpId: challenge.rp_id,
-        timeout: 300_000,
-        userVerification: "required"
-      }
+      public_key:
+        maybe_allow_credentials(
+          %{
+            challenge: encode(challenge.bytes),
+            rpId: challenge.rp_id,
+            timeout: 300_000,
+            userVerification: "required"
+          },
+          credentials
+        )
     }
+  end
+
+  defp maybe_allow_credentials(options, []), do: options
+
+  defp maybe_allow_credentials(options, credentials),
+    do: Map.put(options, :allowCredentials, Enum.map(credentials, &allow_credential/1))
+
+  defp allow_credential(%Passkey{credential_id: credential_id, transports: transports}) do
+    descriptor = %{type: "public-key", id: encode(credential_id)}
+
+    case Map.get(transports, "values", []) do
+      [] -> descriptor
+      values -> Map.put(descriptor, :transports, values)
+    end
   end
 
   defp verify_assertion(params, credential_id, challenge) do

--- a/lib/grappa/accounts/webauthn.ex
+++ b/lib/grappa/accounts/webauthn.ex
@@ -158,11 +158,11 @@ defmodule Grappa.Accounts.WebAuthn do
       public_key: %{
         challenge: encode(challenge.bytes),
         rp: %{id: challenge.rp_id, name: "Grappa"},
-        user: %{id: encode(user.id), name: user.name, displayName: user.name},
-        pubKeyCredParams: [%{type: "public-key", alg: -7}, %{type: "public-key", alg: -257}],
+        user: %{id: encode(user.id), name: user.name, display_name: user.name},
+        pub_key_cred_params: [%{type: "public-key", alg: -7}, %{type: "public-key", alg: -257}],
         timeout: 300_000,
         attestation: "none",
-        authenticatorSelection: %{residentKey: "preferred", userVerification: "required"}
+        authenticator_selection: %{resident_key: "preferred", user_verification: "required"}
       }
     }
   end
@@ -185,9 +185,9 @@ defmodule Grappa.Accounts.WebAuthn do
         maybe_allow_credentials(
           %{
             challenge: encode(challenge.bytes),
-            rpId: challenge.rp_id,
+            rp_id: challenge.rp_id,
             timeout: 300_000,
-            userVerification: "required"
+            user_verification: "required"
           },
           credentials
         )
@@ -197,7 +197,7 @@ defmodule Grappa.Accounts.WebAuthn do
   defp maybe_allow_credentials(options, []), do: options
 
   defp maybe_allow_credentials(options, credentials),
-    do: Map.put(options, :allowCredentials, Enum.map(credentials, &allow_credential/1))
+    do: Map.put(options, :allow_credentials, Enum.map(credentials, &allow_credential/1))
 
   defp allow_credential(%Passkey{credential_id: credential_id, transports: transports}) do
     descriptor = %{type: "public-key", id: encode(credential_id)}

--- a/lib/grappa/accounts/webauthn_challenge_store.ex
+++ b/lib/grappa/accounts/webauthn_challenge_store.ex
@@ -64,7 +64,7 @@ defmodule Grappa.Accounts.WebAuthnChallengeStore do
   defp schedule_sweep, do: Process.send_after(self(), :sweep, @sweep_interval_ms)
 
   defp drop_expired(state, now) do
-    Map.reject(state, fn {_id, {_challenge, _purpose, _metadata, expires_at}} ->
+    Map.reject(state, fn {_, {_, _, _, expires_at}} ->
       expires_at <= now
     end)
   end

--- a/lib/grappa/accounts/webauthn_challenge_store.ex
+++ b/lib/grappa/accounts/webauthn_challenge_store.ex
@@ -1,8 +1,16 @@
 defmodule Grappa.Accounts.WebAuthnChallengeStore do
-  @moduledoc "One-shot, process-local WebAuthn ceremony challenge store."
+  @moduledoc """
+  One-shot, process-local WebAuthn ceremony challenge store.
+
+  A ceremony that is never completed is never `take/2`n, so the TTL check
+  on the read path alone retained abandoned entries for the life of the
+  node — and the endpoint that fills this store sits on the unauthenticated
+  login door. The periodic sweep is what bounds it.
+  """
   use GenServer
 
   @ttl_seconds 300
+  @sweep_interval_ms :timer.seconds(60)
 
   @type purpose :: :registration | :authentication | :mode_change | :passwordless | :second_factor
   @type metadata :: map()
@@ -27,7 +35,10 @@ defmodule Grappa.Accounts.WebAuthnChallengeStore do
   end
 
   @impl GenServer
-  def init(state), do: {:ok, state}
+  def init(state) do
+    schedule_sweep()
+    {:ok, state}
+  end
 
   @impl GenServer
   def handle_call({:put, id, challenge, purpose, metadata, expires_at}, _, state) do
@@ -42,5 +53,19 @@ defmodule Grappa.Accounts.WebAuthnChallengeStore do
       {_, next} ->
         {:reply, {:error, :invalid_challenge}, next}
     end
+  end
+
+  @impl GenServer
+  def handle_info(:sweep, state) do
+    schedule_sweep()
+    {:noreply, drop_expired(state, System.monotonic_time(:second))}
+  end
+
+  defp schedule_sweep, do: Process.send_after(self(), :sweep, @sweep_interval_ms)
+
+  defp drop_expired(state, now) do
+    Map.reject(state, fn {_id, {_challenge, _purpose, _metadata, expires_at}} ->
+      expires_at <= now
+    end)
   end
 end

--- a/lib/grappa/application.ex
+++ b/lib/grappa/application.ex
@@ -112,6 +112,14 @@ defmodule Grappa.Application do
     # CLAUDE.md-designated boundary (mirrors `Grappa.Uploads.boot/1`).
     :ok = Grappa.HttpHosts.boot(http_host_aliases())
 
+    # A passkey is bound to an origin at registration and refuses to answer
+    # for any other, so the RP origin is a deployment property, not a
+    # per-request one. Stash the operator's `GRAPPA_PASSKEY_ORIGIN` override
+    # (nil when unset — the Endpoint fallback resolves at call time, since
+    # the Endpoint is not up yet here). Boot-time read of
+    # `Application.get_env/2` is the CLAUDE.md-designated boundary.
+    :ok = GrappaWeb.PasskeyOrigin.boot()
+
     # #399: stash the built cicchetto SPA dist root in `:persistent_term`
     # so the endpoint's `Plug.Static` + SPA history-fallback and
     # `Grappa.Cic.Bundle`'s hash/version live-read resolve against ONE

--- a/lib/grappa/ws_presence.ex
+++ b/lib/grappa/ws_presence.ex
@@ -287,9 +287,10 @@ defmodule Grappa.WSPresence do
   registration so `cic-bundle-changed` reaches every connected tab.
 
   CP23 S4 B5 — used by the `cic-bundle-changed` admin endpoint to fan
-  out the new bundle hash on every connected user's user-topic. Empty
-  socket maps (a user previously connected, all sockets dropped) are
-  filtered out so callers don't broadcast to dead audiences.
+  out the new bundle hash on every connected user's user-topic. Every
+  key is a live audience: a user loses its entry the moment its last
+  socket dies (see `put_user_sockets/3`), so there is nothing dead to
+  filter out.
   """
   @spec list_user_names() :: [String.t()]
   def list_user_names do
@@ -326,7 +327,8 @@ defmodule Grappa.WSPresence do
   active `stale_ms`. Backs the `/admin/ws_presence` diagnostic (#318): a
   backgrounded-iOS-PWA run reads back whether the socket went
   stale/hidden or is (wrongly) still fresh-visible. Users with no live
-  socket are omitted.
+  socket cannot appear: they stop being tracked at all when their last
+  socket dies (see `put_user_sockets/3`).
   """
   @spec snapshot() :: snapshot()
   def snapshot do
@@ -488,21 +490,14 @@ defmodule Grappa.WSPresence do
   end
 
   def handle_call(:list_user_names, _, state) do
-    names =
-      state.sockets
-      |> Enum.filter(fn {_, m} -> map_size(m) > 0 end)
-      |> Enum.map(fn {name, _} -> name end)
-
-    {:reply, names, state}
+    {:reply, Map.keys(state.sockets), state}
   end
 
   def handle_call(:snapshot, _, state) do
     now = now_ms()
 
     users =
-      state.sockets
-      |> Enum.reject(fn {_, pids} -> map_size(pids) == 0 end)
-      |> Enum.map(fn {user_name, pids} ->
+      Enum.map(state.sockets, fn {user_name, pids} ->
         %{
           user_name: user_name,
           any_visible: any_visible_in?(state, user_name),
@@ -600,7 +595,17 @@ defmodule Grappa.WSPresence do
   # Private helpers
   # ---------------------------------------------------------------------------
 
+  # The ONE write door for `sockets`, and the place the "no empty maps"
+  # invariant is kept: a user whose last socket just went away is REMOVED,
+  # not left pointing at `%{}`. `user_name` is `"visitor:" <> id` for
+  # visitors, so the key space is unbounded and every visitor that ever
+  # connected would otherwise leave a permanent entry in a `:permanent`
+  # GenServer that is never restarted to clear them.
   @spec put_user_sockets(t(), String.t(), %{pid() => pid_state()}) :: t()
+  defp put_user_sockets(state, user_name, user_sockets) when map_size(user_sockets) == 0 do
+    %{state | sockets: Map.delete(state.sockets, user_name)}
+  end
+
   defp put_user_sockets(state, user_name, user_sockets) do
     %{state | sockets: Map.put(state.sockets, user_name, user_sockets)}
   end

--- a/lib/grappa_web.ex
+++ b/lib/grappa_web.ex
@@ -63,7 +63,11 @@ defmodule GrappaWeb do
         GrappaWeb.BodyLimit
       ] ++
         if(Mix.env() in [:dev, :test], do: [Grappa.TestSupport.SubjectReset], else: []),
-    exports: [Endpoint]
+    # `PasskeyOrigin` joins `Endpoint` on the export list for the same
+    # reason: `Grappa.Application.start/2` reaches in to boot it, the
+    # documented boot-time-config boundary. Nothing else outside
+    # `GrappaWeb` may call it.
+    exports: [Endpoint, PasskeyOrigin]
 
   @doc "Imports for `use GrappaWeb, :controller` — Phoenix.Controller + Plug.Conn + the JSON fallback."
   @spec controller() :: Macro.t()

--- a/lib/grappa_web/controllers/auth_controller.ex
+++ b/lib/grappa_web/controllers/auth_controller.ex
@@ -380,10 +380,10 @@ defmodule GrappaWeb.AuthController do
     with :ok <- check_mode1_throttle(ip),
          {:ok, user} <- authenticate_mode1(name, password, ip) do
       cond do
-        user.passkey_mode == "passwordless" ->
+        user.passkey_mode == :passwordless ->
           {:error, :invalid_credentials}
 
-        user.passkey_mode == "second_factor" ->
+        user.passkey_mode == :second_factor ->
           passkey_second_factor(conn, user)
 
         TOTP.enabled?(user) ->

--- a/lib/grappa_web/controllers/auth_controller.ex
+++ b/lib/grappa_web/controllers/auth_controller.ex
@@ -45,7 +45,7 @@ defmodule GrappaWeb.AuthController do
   alias Grappa.Auth.IdentifierClassifier
   alias Grappa.RateLimit.FailureWindow
   alias Grappa.Visitors.{Login, Visitor}
-  alias GrappaWeb.RemoteIP
+  alias GrappaWeb.{PasskeyOrigin, RemoteIP}
 
   require Logger
 
@@ -444,7 +444,7 @@ defmodule GrappaWeb.AuthController do
     binding = %{ip: format_ip(conn), client_id: conn.assigns[:current_client_id]}
 
     with {:ok, options} <-
-           WebAuthn.begin_authentication(user, :second_factor, binding, passkey_origin()) do
+           WebAuthn.begin_authentication(user, :second_factor, binding, PasskeyOrigin.origin()) do
       conn
       |> put_status(:accepted)
       |> json(%{
@@ -455,9 +455,6 @@ defmodule GrappaWeb.AuthController do
       })
     end
   end
-
-  defp passkey_origin,
-    do: Application.get_env(:grappa, :passkey_origin, GrappaWeb.Endpoint.url())
 
   defp check_totp_throttle(conn, user_id) do
     case FailureWindow.check(:totp_login, {format_ip(conn), user_id}, @totp_max_failures) do

--- a/lib/grappa_web/controllers/auth_controller.ex
+++ b/lib/grappa_web/controllers/auth_controller.ex
@@ -444,7 +444,7 @@ defmodule GrappaWeb.AuthController do
     binding = %{ip: format_ip(conn), client_id: conn.assigns[:current_client_id]}
 
     with {:ok, options} <-
-           WebAuthn.begin_authentication(user, :second_factor, binding, PasskeyOrigin.origin()) do
+           WebAuthn.begin_authentication(user, :second_factor, binding, PasskeyOrigin.origin(), %{}) do
       conn
       |> put_status(:accepted)
       |> json(%{

--- a/lib/grappa_web/controllers/fallback_controller.ex
+++ b/lib/grappa_web/controllers/fallback_controller.ex
@@ -54,6 +54,7 @@ defmodule GrappaWeb.FallbackController do
            | :malformed_ident
            | :password_required
            | :passkey_required
+           | :passkey_not_configured
            | :password_mismatch
            | :network_not_visitor_enabled
            | :network_ambiguous
@@ -408,6 +409,16 @@ defmodule GrappaWeb.FallbackController do
     conn
     |> put_status(:conflict)
     |> json(%{error: "passkey_required"})
+  end
+
+  # The mirror of `passkey_required`: a ceremony was asked for by an account
+  # that holds no credential to answer it with. Same 409 — the request
+  # conflicts with the account's state, and registering a passkey resolves
+  # it.
+  def call(conn, {:error, :passkey_not_configured}) do
+    conn
+    |> put_status(:conflict)
+    |> json(%{error: "passkey_not_configured"})
   end
 
   # T31 admission errors. Status-code split:

--- a/lib/grappa_web/controllers/passkey_controller.ex
+++ b/lib/grappa_web/controllers/passkey_controller.ex
@@ -62,22 +62,32 @@ defmodule GrappaWeb.PasskeyController do
   @spec mode_options(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:error, atom()}
   def mode_options(
         %{assigns: %{current_subject: {:user, user}}} = conn,
-        %{"password" => password, "mode" => mode}
-      )
-      when mode in ["second_factor", "disabled"] do
-    if Argon2.verify_pass(password, user.password_hash) do
-      with {:ok, options} <-
-             WebAuthn.begin_authentication(user, :mode_change, client_binding(conn), PasskeyOrigin.origin(), %{
-               mode: mode
-             }) do
-        json(conn, options)
-      end
+        %{"password" => password, "mode" => wire_mode}
+      ) do
+    with {:ok, mode} <- settings_mode(wire_mode),
+         true <- Argon2.verify_pass(password, user.password_hash),
+         {:ok, options} <- mode_change_options(conn, user, %{mode: mode}) do
+      json(conn, options)
     else
-      {:error, :invalid_credentials}
+      false -> {:error, :invalid_credentials}
+      {:error, _} = error -> error
     end
   end
 
   def mode_options(_, _), do: {:error, :bad_request}
+
+  # Passwordless is deliberately not settable here. It may only be reached
+  # through `passwordless_options/2`, whose recovery token proves the codes
+  # were shown BEFORE arming the mode that makes them the only fallback.
+  defp settings_mode(wire_mode) do
+    case WebAuthn.decode_mode(wire_mode) do
+      {:ok, mode} when mode in [:second_factor, :disabled] -> {:ok, mode}
+      _ -> {:error, :bad_request}
+    end
+  end
+
+  defp mode_change_options(conn, user, metadata),
+    do: WebAuthn.begin_authentication(user, :mode_change, client_binding(conn), PasskeyOrigin.origin(), metadata)
 
   @doc "Generates the mandatory recovery set before passwordless activation."
   @spec prepare_passwordless(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:error, atom()}
@@ -119,11 +129,7 @@ defmodule GrappaWeb.PasskeyController do
     with {:ok, %{user_id: user_id, session_id: ^session_id, binding: ^binding, codes: codes}} <-
            verify_recovery_token(token),
          true <- user_id == user.id,
-         {:ok, options} <-
-           WebAuthn.begin_authentication(user, :mode_change, client_binding(conn), PasskeyOrigin.origin(), %{
-             mode: "passwordless",
-             recovery_codes: codes
-           }) do
+         {:ok, options} <- mode_change_options(conn, user, %{mode: :passwordless, recovery_codes: codes}) do
       json(conn, options)
     else
       _ -> {:error, :invalid_two_factor}
@@ -160,7 +166,7 @@ defmodule GrappaWeb.PasskeyController do
       not Argon2.verify_pass(password, user.password_hash) ->
         {:error, :invalid_credentials}
 
-      user.passkey_mode != "disabled" and length(WebAuthn.list(user)) == 1 ->
+      user.passkey_mode != :disabled and length(WebAuthn.list(user)) == 1 ->
         {:error, :passkey_required}
 
       true ->
@@ -201,7 +207,7 @@ defmodule GrappaWeb.PasskeyController do
   def login_options(_, _), do: {:error, :bad_request}
 
   defp begin_passwordless(conn, identifier) do
-    with %User{passkey_mode: "passwordless"} = user <- find_user(identifier),
+    with %User{passkey_mode: :passwordless} = user <- find_user(identifier),
          {:ok, options} <-
            WebAuthn.begin_authentication(user, :passwordless, client_binding(conn), PasskeyOrigin.origin()) do
       json(conn, options)
@@ -214,7 +220,7 @@ defmodule GrappaWeb.PasskeyController do
   @spec login_verify(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:error, atom()}
   def login_verify(conn, params) do
     case WebAuthn.authenticate(params, :passwordless, client_binding(conn)) do
-      {:ok, %User{passkey_mode: "passwordless"} = user, _} -> mint_session(conn, user)
+      {:ok, %User{passkey_mode: :passwordless} = user, _} -> mint_session(conn, user)
       _ -> {:error, :invalid_two_factor}
     end
   end
@@ -223,7 +229,7 @@ defmodule GrappaWeb.PasskeyController do
   @spec second_factor_verify(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:error, atom()}
   def second_factor_verify(conn, params) do
     case WebAuthn.authenticate(params, :second_factor, client_binding(conn)) do
-      {:ok, %User{passkey_mode: "second_factor"} = user, _} -> mint_session(conn, user)
+      {:ok, %User{passkey_mode: :second_factor} = user, _} -> mint_session(conn, user)
       _ -> {:error, :invalid_two_factor}
     end
   end
@@ -246,7 +252,7 @@ defmodule GrappaWeb.PasskeyController do
   # `alice@b.bb` are one account — spelled as three distinct strings. Keying
   # the window on the string handed the attacker a fresh bucket per spelling
   # and the per-account limit never tripped.
-  defp recover_resolved(conn, ip, %User{passkey_mode: "passwordless"} = user, code) do
+  defp recover_resolved(conn, ip, %User{passkey_mode: :passwordless} = user, code) do
     key = {ip, user.id}
 
     with :ok <- FailureWindow.check(:passkey_recovery, key, @recovery_account_attempts),

--- a/lib/grappa_web/controllers/passkey_controller.ex
+++ b/lib/grappa_web/controllers/passkey_controller.ex
@@ -6,7 +6,7 @@ defmodule GrappaWeb.PasskeyController do
   alias Grappa.Accounts.{User, WebAuthn}
   alias Grappa.Auth.IdentifierClassifier
   alias Grappa.RateLimit.FailureWindow
-  alias GrappaWeb.RemoteIP
+  alias GrappaWeb.{PasskeyOrigin, RemoteIP}
 
   @recovery_salt "account-passwordless-recovery-v1"
   @recovery_max_age_seconds 600
@@ -40,7 +40,7 @@ defmodule GrappaWeb.PasskeyController do
         %{"password" => password, "name" => name}
       ) do
     with {:ok, options} <-
-           WebAuthn.begin_registration(user, password, name, client_binding(conn), origin()) do
+           WebAuthn.begin_registration(user, password, name, client_binding(conn), PasskeyOrigin.origin()) do
       json(conn, options)
     end
   end
@@ -67,7 +67,9 @@ defmodule GrappaWeb.PasskeyController do
       when mode in ["second_factor", "disabled"] do
     if Argon2.verify_pass(password, user.password_hash) do
       with {:ok, options} <-
-             WebAuthn.begin_authentication(user, :mode_change, client_binding(conn), origin(), %{mode: mode}) do
+             WebAuthn.begin_authentication(user, :mode_change, client_binding(conn), PasskeyOrigin.origin(), %{
+               mode: mode
+             }) do
         json(conn, options)
       end
     else
@@ -114,7 +116,7 @@ defmodule GrappaWeb.PasskeyController do
            verify_recovery_token(token),
          true <- user_id == user.id,
          {:ok, options} <-
-           WebAuthn.begin_authentication(user, :mode_change, client_binding(conn), origin(), %{
+           WebAuthn.begin_authentication(user, :mode_change, client_binding(conn), PasskeyOrigin.origin(), %{
              mode: "passwordless",
              recovery_codes: codes
            }) do
@@ -197,7 +199,7 @@ defmodule GrappaWeb.PasskeyController do
   defp begin_passwordless(conn, identifier) do
     with %User{passkey_mode: "passwordless"} = user <- find_user(identifier),
          {:ok, options} <-
-           WebAuthn.begin_authentication(user, :passwordless, client_binding(conn), origin()) do
+           WebAuthn.begin_authentication(user, :passwordless, client_binding(conn), PasskeyOrigin.origin()) do
       json(conn, options)
     else
       _ -> {:error, :invalid_credentials}
@@ -287,8 +289,6 @@ defmodule GrappaWeb.PasskeyController do
 
   defp client_binding(conn),
     do: %{ip: RemoteIP.format(conn), client_id: conn.assigns[:current_client_id]}
-
-  defp origin, do: Application.get_env(:grappa, :passkey_origin, GrappaWeb.Endpoint.url())
 
   defp verify_recovery_token(token) do
     Phoenix.Token.verify(GrappaWeb.Endpoint, @recovery_salt, token, max_age: @recovery_max_age_seconds)

--- a/lib/grappa_web/controllers/passkey_controller.ex
+++ b/lib/grappa_web/controllers/passkey_controller.ex
@@ -11,6 +11,19 @@ defmodule GrappaWeb.PasskeyController do
   @recovery_salt "account-passwordless-recovery-v1"
   @recovery_max_age_seconds 600
 
+  # Recovery is throttled on TWO buckets, because one is sidesteppable.
+  # The per-account bucket is the real control, but it can only be keyed
+  # once the identifier RESOLVES — and resolution is itself the work an
+  # attacker wants to amplify. So the IP bucket is checked first (cheap
+  # ETS, no DB) and bounds probing for accounts that do not exist; the
+  # account bucket then bounds guesses against one that does.
+  @recovery_window_ms :timer.minutes(15)
+  @recovery_ip_attempts 30
+  @recovery_account_attempts 10
+
+  # Ceremony allocation, not guessing: see `login_options/2`.
+  @login_options_attempts 30
+
   @doc "Lists passkeys and active login mode."
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:error, atom()}
   def index(%{assigns: %{current_subject: {:user, user}}} = conn, _) do
@@ -151,9 +164,35 @@ defmodule GrappaWeb.PasskeyController do
 
   def delete(_, _), do: {:error, :bad_request}
 
-  @doc "Starts passwordless login for an account identifier."
+  @doc """
+  Starts passwordless login for an account identifier.
+
+  IP-throttled: every call allocates a challenge in
+  `WebAuthnChallengeStore` that only a completed ceremony reclaims, so an
+  unauthenticated caller that never completes one must not be able to
+  allocate without bound. The store's own sweep is the second half of
+  that guarantee.
+  """
   @spec login_options(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:error, atom()}
-  def login_options(conn, %{"identifier" => identifier}) do
+  def login_options(conn, %{"identifier" => identifier}) when is_binary(identifier) do
+    ip = RemoteIP.format(conn)
+
+    case FailureWindow.check(:passkey_login_options, ip, @login_options_attempts) do
+      {:error, :limited} ->
+        {:error, :too_many_attempts}
+
+      :ok ->
+        # EVERY call is counted, not just the ones that fail. The abuse
+        # here is allocation, and the cheapest way to allocate is to keep
+        # succeeding: a loop against a known passwordless identifier gets
+        # a 200 each time, so a failures-only window would never trip on
+        # the exact traffic it needs to bound.
+        _ = FailureWindow.record_failure(:passkey_login_options, ip, @recovery_window_ms)
+        begin_passwordless(conn, identifier)
+    end
+  end
+
+  defp begin_passwordless(conn, identifier) do
     with %User{passkey_mode: "passwordless"} = user <- find_user(identifier),
          {:ok, options} <-
            WebAuthn.begin_authentication(user, :passwordless, client_binding(conn), origin()) do
@@ -186,10 +225,25 @@ defmodule GrappaWeb.PasskeyController do
   @doc "Consumes an account recovery code for passwordless fallback."
   @spec recover(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:error, atom()}
   def recover(conn, %{"identifier" => identifier, "recovery_code" => code}) do
-    key = {RemoteIP.format(conn), String.downcase(String.trim(identifier))}
+    ip = RemoteIP.format(conn)
 
-    with :ok <- FailureWindow.check(:passkey_recovery, key, 10),
-         %User{passkey_mode: "passwordless"} = user <- find_user(identifier),
+    case FailureWindow.check(:passkey_recovery, ip, @recovery_ip_attempts) do
+      {:error, :limited} -> {:error, :too_many_attempts}
+      :ok -> recover_resolved(conn, ip, find_user(identifier), code)
+    end
+  end
+
+  def recover(_, _), do: {:error, :bad_request}
+
+  # Keyed on the RESOLVED account, never on the wire identifier. `find_user/1`
+  # folds an email to its local part, so `alice`, `alice@a.aa` and
+  # `alice@b.bb` are one account — spelled as three distinct strings. Keying
+  # the window on the string handed the attacker a fresh bucket per spelling
+  # and the per-account limit never tripped.
+  defp recover_resolved(conn, ip, %User{passkey_mode: "passwordless"} = user, code) do
+    key = {ip, user.id}
+
+    with :ok <- FailureWindow.check(:passkey_recovery, key, @recovery_account_attempts),
          :ok <- Accounts.consume_recovery_code(user, code) do
       :ok = FailureWindow.clear(:passkey_recovery, key)
       mint_session(conn, user)
@@ -198,12 +252,16 @@ defmodule GrappaWeb.PasskeyController do
         {:error, :too_many_attempts}
 
       _ ->
-        _ = FailureWindow.record_failure(:passkey_recovery, key, :timer.minutes(15))
+        _ = FailureWindow.record_failure(:passkey_recovery, key, @recovery_window_ms)
+        _ = FailureWindow.record_failure(:passkey_recovery, ip, @recovery_window_ms)
         {:error, :invalid_two_factor}
     end
   end
 
-  def recover(_, _), do: {:error, :bad_request}
+  defp recover_resolved(_conn, ip, _unresolved, _code) do
+    _ = FailureWindow.record_failure(:passkey_recovery, ip, @recovery_window_ms)
+    {:error, :invalid_two_factor}
+  end
 
   defp mint_session(conn, user) do
     user_agent = conn |> get_req_header("user-agent") |> List.first()

--- a/lib/grappa_web/controllers/passkey_controller.ex
+++ b/lib/grappa_web/controllers/passkey_controller.ex
@@ -65,12 +65,9 @@ defmodule GrappaWeb.PasskeyController do
         %{"password" => password, "mode" => wire_mode}
       ) do
     with {:ok, mode} <- settings_mode(wire_mode),
-         true <- Argon2.verify_pass(password, user.password_hash),
+         :ok <- Accounts.verify_password(user, password),
          {:ok, options} <- mode_change_options(conn, user, %{mode: mode}) do
       json(conn, options)
-    else
-      false -> {:error, :invalid_credentials}
-      {:error, _} = error -> error
     end
   end
 
@@ -95,7 +92,7 @@ defmodule GrappaWeb.PasskeyController do
         %{assigns: %{current_subject: {:user, user}, current_session_id: session_id}} = conn,
         %{"password" => password}
       ) do
-    if Argon2.verify_pass(password, user.password_hash) do
+    with :ok <- Accounts.verify_password(user, password) do
       codes = Accounts.prepare_recovery_codes()
 
       # ENCRYPTED, not merely signed: this payload carries the plaintext
@@ -111,8 +108,6 @@ defmodule GrappaWeb.PasskeyController do
         })
 
       json(conn, %{recovery_codes: codes, recovery_token: token})
-    else
-      {:error, :invalid_credentials}
     end
   end
 
@@ -162,17 +157,17 @@ defmodule GrappaWeb.PasskeyController do
         %{assigns: %{current_subject: {:user, user}}} = conn,
         %{"id" => id, "password" => password}
       ) do
-    cond do
-      not Argon2.verify_pass(password, user.password_hash) ->
-        {:error, :invalid_credentials}
-
-      user.passkey_mode != :disabled and length(WebAuthn.list(user)) == 1 ->
-        {:error, :passkey_required}
-
-      true ->
-        with :ok <- WebAuthn.delete(user, id), do: send_resp(conn, :no_content, "")
+    with :ok <- Accounts.verify_password(user, password),
+         false <- last_passkey?(user),
+         :ok <- WebAuthn.delete(user, id) do
+      send_resp(conn, :no_content, "")
+    else
+      true -> {:error, :passkey_required}
+      {:error, _} = error -> error
     end
   end
+
+  defp last_passkey?(user), do: user.passkey_mode != :disabled and length(WebAuthn.list(user)) == 1
 
   def delete(_, _), do: {:error, :bad_request}
 

--- a/lib/grappa_web/controllers/passkey_controller.ex
+++ b/lib/grappa_web/controllers/passkey_controller.ex
@@ -88,8 +88,12 @@ defmodule GrappaWeb.PasskeyController do
     if Argon2.verify_pass(password, user.password_hash) do
       codes = Accounts.prepare_recovery_codes()
 
+      # ENCRYPTED, not merely signed: this payload carries the plaintext
+      # recovery codes, and a signed token is tamper-proof but perfectly
+      # readable — anything the token passes through on its way back to us
+      # could lift the account's whole fallback credential out of it.
       token =
-        Phoenix.Token.sign(GrappaWeb.Endpoint, @recovery_salt, %{
+        Phoenix.Token.encrypt(GrappaWeb.Endpoint, @recovery_salt, %{
           user_id: user.id,
           session_id: session_id,
           binding: client_binding(conn),
@@ -291,7 +295,7 @@ defmodule GrappaWeb.PasskeyController do
     do: %{ip: RemoteIP.format(conn), client_id: conn.assigns[:current_client_id]}
 
   defp verify_recovery_token(token) do
-    Phoenix.Token.verify(GrappaWeb.Endpoint, @recovery_salt, token, max_age: @recovery_max_age_seconds)
+    Phoenix.Token.decrypt(GrappaWeb.Endpoint, @recovery_salt, token, max_age: @recovery_max_age_seconds)
   end
 
   defp public_passkey(passkey) do

--- a/lib/grappa_web/controllers/passkey_controller.ex
+++ b/lib/grappa_web/controllers/passkey_controller.ex
@@ -158,16 +158,10 @@ defmodule GrappaWeb.PasskeyController do
         %{"id" => id, "password" => password}
       ) do
     with :ok <- Accounts.verify_password(user, password),
-         false <- last_passkey?(user),
          :ok <- WebAuthn.delete(user, id) do
       send_resp(conn, :no_content, "")
-    else
-      true -> {:error, :passkey_required}
-      {:error, _} = error -> error
     end
   end
-
-  defp last_passkey?(user), do: user.passkey_mode != :disabled and length(WebAuthn.list(user)) == 1
 
   def delete(_, _), do: {:error, :bad_request}
 

--- a/lib/grappa_web/controllers/passkey_controller.ex
+++ b/lib/grappa_web/controllers/passkey_controller.ex
@@ -198,7 +198,7 @@ defmodule GrappaWeb.PasskeyController do
   defp begin_passwordless(conn, identifier) do
     with %User{passkey_mode: :passwordless} = user <- find_user(identifier),
          {:ok, options} <-
-           WebAuthn.begin_authentication(user, :passwordless, client_binding(conn), PasskeyOrigin.origin()) do
+           WebAuthn.begin_authentication(user, :passwordless, client_binding(conn), PasskeyOrigin.origin(), %{}) do
       json(conn, options)
     else
       _ -> {:error, :invalid_credentials}

--- a/lib/grappa_web/controllers/passkey_controller.ex
+++ b/lib/grappa_web/controllers/passkey_controller.ex
@@ -192,6 +192,8 @@ defmodule GrappaWeb.PasskeyController do
     end
   end
 
+  def login_options(_, _), do: {:error, :bad_request}
+
   defp begin_passwordless(conn, identifier) do
     with %User{passkey_mode: "passwordless"} = user <- find_user(identifier),
          {:ok, options} <-
@@ -201,8 +203,6 @@ defmodule GrappaWeb.PasskeyController do
       _ -> {:error, :invalid_credentials}
     end
   end
-
-  def login_options(_, _), do: {:error, :bad_request}
 
   @doc "Verifies passwordless assertion and mints a bearer."
   @spec login_verify(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:error, atom()}
@@ -258,7 +258,7 @@ defmodule GrappaWeb.PasskeyController do
     end
   end
 
-  defp recover_resolved(_conn, ip, _unresolved, _code) do
+  defp recover_resolved(_, ip, _, _) do
     _ = FailureWindow.record_failure(:passkey_recovery, ip, @recovery_window_ms)
     {:error, :invalid_two_factor}
   end

--- a/lib/grappa_web/controllers/totp_controller.ex
+++ b/lib/grappa_web/controllers/totp_controller.ex
@@ -16,28 +16,43 @@ defmodule GrappaWeb.TotpController do
 
   def show(_, _), do: {:error, :forbidden}
 
-  @doc "Starts enrollment; returned secret remains unarmed until confirmation."
+  @doc """
+  Starts enrollment; returned secret remains unarmed until confirmation.
+
+  Password-gated like `delete/2`: confirming an enrolment revokes every
+  other bearer session and hands out the recovery codes, so a borrowed
+  token alone must not be able to arm a second factor the real owner
+  does not hold.
+  """
   @spec start_enrollment(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:error, atom()}
-  def start_enrollment(%{assigns: %{current_subject: {:user, user}}} = conn, _) do
-    if TOTP.enabled?(user) do
-      {:error, :already_enabled}
-    else
-      issuer = "Grappa (#{conn.host})"
-      enrollment = TOTP.new_enrollment(user, issuer)
+  def start_enrollment(
+        %{assigns: %{current_subject: {:user, user}}} = conn,
+        %{"password" => password}
+      )
+      when is_binary(password) do
+    with :ok <- Accounts.verify_password(user, password) do
+      if TOTP.enabled?(user) do
+        {:error, :already_enabled}
+      else
+        issuer = "Grappa (#{conn.host})"
+        enrollment = TOTP.new_enrollment(user, issuer)
 
-      token =
-        Phoenix.Token.sign(GrappaWeb.Endpoint, @enrollment_salt, %{
-          "user_id" => user.id,
-          "secret" => enrollment.secret
+        token =
+          Phoenix.Token.sign(GrappaWeb.Endpoint, @enrollment_salt, %{
+            "user_id" => user.id,
+            "secret" => enrollment.secret
+          })
+
+        json(conn, %{
+          enrollment_token: token,
+          secret: enrollment.secret,
+          provisioning_uri: enrollment.provisioning_uri
         })
-
-      json(conn, %{
-        enrollment_token: token,
-        secret: enrollment.secret,
-        provisioning_uri: enrollment.provisioning_uri
-      })
+      end
     end
   end
+
+  def start_enrollment(%{assigns: %{current_subject: {:user, _}}}, _), do: {:error, :bad_request}
 
   def start_enrollment(_, _), do: {:error, :forbidden}
 

--- a/lib/grappa_web/error_tokens.ex
+++ b/lib/grappa_web/error_tokens.ex
@@ -116,6 +116,7 @@ defmodule GrappaWeb.ErrorTokens do
           | :malformed_ident
           | :password_required
           | :passkey_required
+          | :passkey_not_configured
           | :password_mismatch
           | :network_not_visitor_enabled
           | :network_ambiguous

--- a/lib/grappa_web/passkey_origin.ex
+++ b/lib/grappa_web/passkey_origin.ex
@@ -1,0 +1,71 @@
+defmodule GrappaWeb.PasskeyOrigin do
+  @moduledoc """
+  The WebAuthn Relying Party origin this deployment asserts.
+
+  ## Why it is not just the Endpoint URL
+
+  A passkey is bound to an origin at registration and will refuse to
+  answer for any other, so this value is a durable property of the
+  deployment rather than of the request that happens to be in flight.
+  Operators who front the bouncer with something whose public origin
+  differs from what Phoenix would derive set `GRAPPA_PASSKEY_ORIGIN`
+  (`config/runtime.exs`); everyone else gets `Endpoint.url()`, which is
+  already rooted at the public origin for exactly the same reason
+  upload links are.
+
+  ## Boot-time read → `:persistent_term`
+
+  Per CLAUDE.md "`Application.{put,get}_env`: boot-time only, runtime
+  banned", `Grappa.Application.start/2` calls `boot/0` once before the
+  supervision tree comes up and the value lands in `:persistent_term`;
+  `origin/0` is then a lock-free read on the request path. Mirrors
+  `Grappa.HttpHosts.boot/1` and `Grappa.Push.BadgeSource.boot/0`.
+
+  The Endpoint fallback is resolved at CALL time, not at boot — the
+  Endpoint is not started yet when `boot/0` runs. It also means the two
+  passkey controllers no longer each carry their own copy of the
+  fallback, which is how they could have drifted apart.
+
+  Tests substitute via `put_test_origin/1`, not `Application.put_env`.
+
+  Inherits the `GrappaWeb` boundary (no explicit `use Boundary`) — same
+  pattern as `GrappaWeb.RemoteIP` and `GrappaWeb.Validation`. It reads
+  `GrappaWeb.Endpoint`, which lives in that boundary, so standing itself
+  up as a top-level one would only manufacture a cycle.
+  """
+
+  @key {__MODULE__, :origin}
+
+  @doc """
+  Stash the operator-configured passkey origin into `:persistent_term`.
+
+  Stores `nil` when `GRAPPA_PASSKEY_ORIGIN` is unset, which is the
+  signal for `origin/0` to fall back to the Endpoint.
+  """
+  @spec boot() :: :ok
+  def boot do
+    :persistent_term.put(@key, Application.get_env(:grappa, :passkey_origin))
+    :ok
+  end
+
+  @doc """
+  The origin every WebAuthn ceremony is bound to: the operator's
+  override when one is configured, otherwise the Endpoint's public URL.
+  """
+  @spec origin() :: String.t()
+  def origin do
+    case :persistent_term.get(@key, nil) do
+      configured when is_binary(configured) -> configured
+      nil -> GrappaWeb.Endpoint.url()
+    end
+  end
+
+  if Mix.env() == :test do
+    @doc false
+    @spec put_test_origin(String.t() | nil) :: :ok
+    def put_test_origin(origin) do
+      :persistent_term.put(@key, origin)
+      :ok
+    end
+  end
+end

--- a/lib/mix/tasks/grappa.reset_passkeys.ex
+++ b/lib/mix/tasks/grappa.reset_passkeys.ex
@@ -2,10 +2,15 @@ defmodule Mix.Tasks.Grappa.ResetPasskeys do
   @shortdoc "Resets passkeys for a locked-out account"
 
   @moduledoc """
-  Removes all passkeys and recovery codes, restores password login, and
-  revokes live sessions for one account.
+  Removes all passkeys, restores password login, and revokes live sessions
+  for one account.
 
       scripts/mix.sh grappa.reset_passkeys --user alice
+
+  Sibling of `grappa.reset_totp`, which covers the TOTP side. The account
+  recovery codes are shared between the two factors, so they go only if
+  this leaves nothing armed to redeem them — disarming one factor is not
+  entitled to destroy the other's way back in.
   """
   use Boundary, top_level?: true, deps: [Grappa.Accounts, Mix.Tasks.Grappa.Boot]
   use Mix.Task
@@ -15,7 +20,7 @@ defmodule Mix.Tasks.Grappa.ResetPasskeys do
   @impl Mix.Task
   def run(args) do
     {opts, _, _} = OptionParser.parse(args, strict: [user: :string])
-    name = Keyword.fetch!(opts, :user)
+    name = Keyword.get(opts, :user) || Mix.raise("--user is required")
     Boot.start_app_silent()
 
     case Grappa.Accounts.reset_passkeys(name) do

--- a/lib/mix/tasks/grappa.reset_totp.ex
+++ b/lib/mix/tasks/grappa.reset_totp.ex
@@ -1,0 +1,32 @@
+defmodule Mix.Tasks.Grappa.ResetTotp do
+  @shortdoc "Disarms TOTP for a locked-out account"
+
+  @moduledoc """
+  Clears the TOTP secret and revokes live sessions for one account,
+  restoring password-only login.
+
+      scripts/mix.sh grappa.reset_totp --user alice
+
+  Sibling of `grappa.reset_passkeys`, which covers the passkey side.
+  Neither touches the account recovery codes: that set is shared between
+  the two factors, so disarming one is not entitled to destroy the
+  other's way back in.
+  """
+  use Boundary, top_level?: true, deps: [Grappa.Accounts, Mix.Tasks.Grappa.Boot]
+  use Mix.Task
+
+  alias Mix.Tasks.Grappa.Boot
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _, _} = OptionParser.parse(args, strict: [user: :string])
+    name = Keyword.get(opts, :user) || Mix.raise("--user is required")
+    Boot.start_app_silent()
+
+    case Grappa.Accounts.reset_totp(name) do
+      {:ok, _} -> IO.puts("disarmed TOTP and revoked sessions for #{name}")
+      {:error, :not_found} -> Mix.raise("account not found: #{name}")
+      {:error, :db_unavailable} -> Mix.raise("database unavailable")
+    end
+  end
+end

--- a/lib/mix/tasks/grappa.reset_totp.ex
+++ b/lib/mix/tasks/grappa.reset_totp.ex
@@ -7,10 +7,10 @@ defmodule Mix.Tasks.Grappa.ResetTotp do
 
       scripts/mix.sh grappa.reset_totp --user alice
 
-  Sibling of `grappa.reset_passkeys`, which covers the passkey side.
-  Neither touches the account recovery codes: that set is shared between
-  the two factors, so disarming one is not entitled to destroy the
-  other's way back in.
+  Sibling of `grappa.reset_passkeys`, which covers the passkey side. The
+  account recovery codes are shared between the two factors, so they go
+  only if this leaves nothing armed to redeem them — disarming one factor
+  is not entitled to destroy the other's way back in.
   """
   use Boundary, top_level?: true, deps: [Grappa.Accounts, Mix.Tasks.Grappa.Boot]
   use Mix.Task

--- a/test/grappa/accounts/passkey_test.exs
+++ b/test/grappa/accounts/passkey_test.exs
@@ -172,15 +172,64 @@ defmodule Grappa.Accounts.PasskeyTest do
     assert %DateTime{} = Repo.get!(Accounts.Session, other.id).revoked_at
   end
 
-  test "disabling second-factor passkeys preserves TOTP recovery codes" do
-    user = user_fixture()
-    current = session_fixture(user)
-    codes = Accounts.prepare_recovery_codes()
-    :ok = Accounts.RecoveryCodes.replace(user.id, codes)
-    user |> Ecto.Changeset.change(passkey_mode: "second_factor") |> Repo.update!()
+  # The recovery set is ONE flat account-level set with no record of which
+  # factor minted it, so a teardown may only destroy it once nothing is
+  # left that could redeem it. Both directions are asserted here because
+  # the earlier guard got each one wrong in a different way: it wiped the
+  # codes a surviving TOTP still needed, and it kept codes no factor could
+  # ever spend.
+  describe "set_mode/4 recovery-set teardown" do
+    setup do
+      user = user_fixture()
+      %{user: user, session: session_fixture(user)}
+    end
 
-    second_factor_user = Repo.get!(Accounts.User, user.id)
-    assert {:ok, "disabled"} = WebAuthn.set_mode(second_factor_user, "disabled", current.id)
-    assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 10
+    test "disabling passwordless keeps the codes an armed TOTP still needs", ctx do
+      armed = arm_totp(ctx.user)
+      {:ok, "passwordless"} = WebAuthn.set_mode(armed, "passwordless", ctx.session.id, codes())
+
+      passwordless = Repo.get!(Accounts.User, armed.id)
+      assert {:ok, "disabled"} = WebAuthn.set_mode(passwordless, "disabled", ctx.session.id)
+      assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 10
+    end
+
+    test "disabling second-factor keeps the codes an armed TOTP still needs", ctx do
+      armed = arm_totp(ctx.user)
+      second_factor = set_passkey_mode(armed, "second_factor")
+
+      assert {:ok, "disabled"} = WebAuthn.set_mode(second_factor, "disabled", ctx.session.id)
+      assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 10
+    end
+
+    test "disabling second-factor with no other factor takes the codes with it", ctx do
+      :ok = Accounts.RecoveryCodes.replace(ctx.user.id, codes())
+      second_factor = set_passkey_mode(ctx.user, "second_factor")
+
+      assert {:ok, "disabled"} = WebAuthn.set_mode(second_factor, "disabled", ctx.session.id)
+      assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 0
+    end
+
+    test "moving passwordless to second-factor keeps the codes, still armed", ctx do
+      {:ok, "passwordless"} = WebAuthn.set_mode(ctx.user, "passwordless", ctx.session.id, codes())
+
+      passwordless = Repo.get!(Accounts.User, ctx.user.id)
+      assert {:ok, "second_factor"} = WebAuthn.set_mode(passwordless, "second_factor", ctx.session.id)
+      assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 10
+    end
+  end
+
+  defp codes, do: Accounts.prepare_recovery_codes()
+
+  defp set_passkey_mode(user, mode) do
+    user |> Ecto.Changeset.change(passkey_mode: mode) |> Repo.update!()
+    Repo.get!(Accounts.User, user.id)
+  end
+
+  defp arm_totp(user) do
+    secret = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
+    now = 1_700_000_000
+    {:ok, code} = Accounts.TOTP.code_at(secret, now)
+    {:ok, _} = Accounts.TOTP.confirm_enrollment(user, secret, code, now)
+    Repo.get!(Accounts.User, user.id)
   end
 end

--- a/test/grappa/accounts/passkey_test.exs
+++ b/test/grappa/accounts/passkey_test.exs
@@ -19,7 +19,7 @@ defmodule Grappa.Accounts.PasskeyTest do
     assert is_binary(id)
     assert options.rp.id == "irc.example"
     assert options.user.name == user.name
-    assert options.authenticatorSelection.userVerification == "required"
+    assert options.authenticator_selection.user_verification == "required"
   end
 
   describe "begin_authentication/5 credential exposure" do
@@ -54,8 +54,8 @@ defmodule Grappa.Accounts.PasskeyTest do
       assert {:ok, %{public_key: options}} =
                WebAuthn.begin_authentication(ctx.user, :passwordless, ctx.binding, "https://irc.example")
 
-      assert options.rpId == "irc.example"
-      refute Map.has_key?(options, :allowCredentials)
+      assert options.rp_id == "irc.example"
+      refute Map.has_key?(options, :allow_credentials)
     end
 
     for purpose <- [:second_factor, :mode_change] do
@@ -63,7 +63,7 @@ defmodule Grappa.Accounts.PasskeyTest do
         assert {:ok, %{public_key: options}} =
                  WebAuthn.begin_authentication(ctx.user, unquote(purpose), ctx.binding, "https://irc.example")
 
-        assert [%{type: "public-key", id: id, transports: ["usb"]}] = options.allowCredentials
+        assert [%{type: "public-key", id: id, transports: ["usb"]}] = options.allow_credentials
         assert Base.url_decode64!(id, padding: false) == <<1, 2, 3>>
       end
     end
@@ -74,7 +74,7 @@ defmodule Grappa.Accounts.PasskeyTest do
       assert {:ok, %{public_key: options}} =
                WebAuthn.begin_authentication(ctx.user, :second_factor, ctx.binding, "https://irc.example")
 
-      assert [credential] = options.allowCredentials
+      assert [credential] = options.allow_credentials
       refute Map.has_key?(credential, :transports)
     end
   end

--- a/test/grappa/accounts/passkey_test.exs
+++ b/test/grappa/accounts/passkey_test.exs
@@ -52,7 +52,7 @@ defmodule Grappa.Accounts.PasskeyTest do
 
     test "passwordless stays discoverable and hands no credential id to an anonymous caller", ctx do
       assert {:ok, %{public_key: options}} =
-               WebAuthn.begin_authentication(ctx.user, :passwordless, ctx.binding, "https://irc.example")
+               WebAuthn.begin_authentication(ctx.user, :passwordless, ctx.binding, "https://irc.example", %{})
 
       assert options.rp_id == "irc.example"
       refute Map.has_key?(options, :allow_credentials)
@@ -61,7 +61,7 @@ defmodule Grappa.Accounts.PasskeyTest do
     for purpose <- [:second_factor, :mode_change] do
       test "#{purpose} lists the account's own credentials so a non-discoverable key can answer", ctx do
         assert {:ok, %{public_key: options}} =
-                 WebAuthn.begin_authentication(ctx.user, unquote(purpose), ctx.binding, "https://irc.example")
+                 WebAuthn.begin_authentication(ctx.user, unquote(purpose), ctx.binding, "https://irc.example", %{})
 
         assert [%{type: "public-key", id: id, transports: ["usb"]}] = options.allow_credentials
         assert Base.url_decode64!(id, padding: false) == <<1, 2, 3>>
@@ -72,7 +72,7 @@ defmodule Grappa.Accounts.PasskeyTest do
       Repo.update_all(Passkey, set: [transports: %{}])
 
       assert {:ok, %{public_key: options}} =
-               WebAuthn.begin_authentication(ctx.user, :second_factor, ctx.binding, "https://irc.example")
+               WebAuthn.begin_authentication(ctx.user, :second_factor, ctx.binding, "https://irc.example", %{})
 
       assert [credential] = options.allow_credentials
       refute Map.has_key?(credential, :transports)
@@ -165,7 +165,7 @@ defmodule Grappa.Accounts.PasskeyTest do
 
     other = session_fixture(user)
     passwordless_user = Repo.get!(Accounts.User, user.id)
-    assert {:ok, :disabled} = WebAuthn.set_mode(passwordless_user, :disabled, current.id)
+    assert {:ok, :disabled} = WebAuthn.set_mode(passwordless_user, :disabled, current.id, [])
     assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 0
     assert Repo.get!(Accounts.User, passwordless_user.id).passkey_mode == :disabled
     assert is_nil(Repo.get!(Accounts.Session, current.id).revoked_at)
@@ -189,7 +189,7 @@ defmodule Grappa.Accounts.PasskeyTest do
       {:ok, :passwordless} = WebAuthn.set_mode(armed, :passwordless, ctx.session.id, codes())
 
       passwordless = Repo.get!(Accounts.User, armed.id)
-      assert {:ok, :disabled} = WebAuthn.set_mode(passwordless, :disabled, ctx.session.id)
+      assert {:ok, :disabled} = WebAuthn.set_mode(passwordless, :disabled, ctx.session.id, [])
       assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 10
     end
 
@@ -197,7 +197,7 @@ defmodule Grappa.Accounts.PasskeyTest do
       armed = arm_totp(ctx.user)
       second_factor = set_passkey_mode(armed, :second_factor)
 
-      assert {:ok, :disabled} = WebAuthn.set_mode(second_factor, :disabled, ctx.session.id)
+      assert {:ok, :disabled} = WebAuthn.set_mode(second_factor, :disabled, ctx.session.id, [])
       assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 10
     end
 
@@ -205,7 +205,7 @@ defmodule Grappa.Accounts.PasskeyTest do
       :ok = Accounts.RecoveryCodes.replace(ctx.user.id, codes())
       second_factor = set_passkey_mode(ctx.user, :second_factor)
 
-      assert {:ok, :disabled} = WebAuthn.set_mode(second_factor, :disabled, ctx.session.id)
+      assert {:ok, :disabled} = WebAuthn.set_mode(second_factor, :disabled, ctx.session.id, [])
       assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 0
     end
 
@@ -213,7 +213,7 @@ defmodule Grappa.Accounts.PasskeyTest do
       {:ok, :passwordless} = WebAuthn.set_mode(ctx.user, :passwordless, ctx.session.id, codes())
 
       passwordless = Repo.get!(Accounts.User, ctx.user.id)
-      assert {:ok, :second_factor} = WebAuthn.set_mode(passwordless, :second_factor, ctx.session.id)
+      assert {:ok, :second_factor} = WebAuthn.set_mode(passwordless, :second_factor, ctx.session.id, [])
       assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 10
     end
   end

--- a/test/grappa/accounts/passkey_test.exs
+++ b/test/grappa/accounts/passkey_test.exs
@@ -1,6 +1,7 @@
 defmodule Grappa.Accounts.PasskeyTest do
   use Grappa.DataCase, async: true
 
+  import ExUnit.CaptureLog
   import Grappa.AuthFixtures
 
   alias Grappa.{Accounts, Accounts.Passkey, Accounts.TOTPRecoveryCode, Accounts.WebAuthn, Repo}
@@ -75,6 +76,69 @@ defmodule Grappa.Accounts.PasskeyTest do
 
       assert [credential] = options.allowCredentials
       refute Map.has_key?(credential, :transports)
+    end
+  end
+
+  describe "consume_sign_count/2" do
+    setup do
+      user = user_fixture()
+
+      passkey =
+        Repo.insert!(
+          Passkey.changeset(%Passkey{}, %{
+            user_id: user.id,
+            credential_id: <<1, 2, 3>>,
+            public_key: CBOR.encode(%{1 => 2}),
+            name: "phone",
+            sign_count: 5
+          })
+        )
+
+      %{user: user, passkey: passkey}
+    end
+
+    test "an advancing counter is accepted and stored", ctx do
+      assert :ok = WebAuthn.consume_sign_count(ctx.passkey, 6)
+
+      reloaded = Repo.get!(Passkey, ctx.passkey.id)
+      assert reloaded.sign_count == 6
+      assert %DateTime{} = reloaded.last_used_at
+    end
+
+    test "an authenticator that never counted keeps its zero", ctx do
+      zeroed = Repo.update!(Ecto.Changeset.change(ctx.passkey, sign_count: 0))
+
+      assert :ok = WebAuthn.consume_sign_count(zeroed, 0)
+      assert Repo.get!(Passkey, zeroed.id).sign_count == 0
+    end
+
+    test "a zero from a credential that HAS counted is refused, and the counter survives", ctx do
+      assert {:error, :cloned_authenticator} = WebAuthn.consume_sign_count(ctx.passkey, 0)
+      assert Repo.get!(Passkey, ctx.passkey.id).sign_count == 5
+    end
+
+    for presented <- [4, 5] do
+      test "a counter that did not advance (#{presented} against 5) is refused", ctx do
+        assert {:error, :cloned_authenticator} =
+                 WebAuthn.consume_sign_count(ctx.passkey, unquote(presented))
+
+        assert Repo.get!(Passkey, ctx.passkey.id).sign_count == 5
+      end
+    end
+
+    test "an assertion whose counter was already consumed by another loses the race", ctx do
+      Repo.update_all(Passkey, set: [sign_count: 7])
+
+      assert {:error, :cloned_authenticator} = WebAuthn.consume_sign_count(ctx.passkey, 6)
+      assert Repo.get!(Passkey, ctx.passkey.id).sign_count == 7
+    end
+
+    test "the refusal is logged, because the wire deliberately says nothing", ctx do
+      log = capture_log(fn -> WebAuthn.consume_sign_count(ctx.passkey, 0) end)
+
+      assert log =~ "sign counter did not advance"
+      assert log =~ ctx.passkey.id
+      assert log =~ ctx.user.id
     end
   end
 

--- a/test/grappa/accounts/passkey_test.exs
+++ b/test/grappa/accounts/passkey_test.exs
@@ -21,39 +21,61 @@ defmodule Grappa.Accounts.PasskeyTest do
     assert options.authenticatorSelection.userVerification == "required"
   end
 
-  test "authentication keeps account credentials server-side and uses discoverable client options" do
-    user = user_fixture()
-    other = user_fixture()
-    key = %{1 => 2, 3 => -7, -1 => 1, -2 => <<0::256>>, -3 => <<0::256>>}
+  describe "begin_authentication/5 credential exposure" do
+    setup do
+      user = user_fixture()
+      other = user_fixture()
+      key = %{1 => 2, 3 => -7, -1 => 1, -2 => <<0::256>>, -3 => <<0::256>>}
 
-    Repo.insert!(
-      Passkey.changeset(%Passkey{}, %{
-        user_id: user.id,
-        credential_id: <<1, 2, 3>>,
-        public_key: CBOR.encode(key),
-        name: "phone"
-      })
-    )
+      Repo.insert!(
+        Passkey.changeset(%Passkey{}, %{
+          user_id: user.id,
+          credential_id: <<1, 2, 3>>,
+          public_key: CBOR.encode(key),
+          name: "phone",
+          transports: %{"values" => ["usb"]}
+        })
+      )
 
-    Repo.insert!(
-      Passkey.changeset(%Passkey{}, %{
-        user_id: other.id,
-        credential_id: <<4, 5, 6>>,
-        public_key: CBOR.encode(key),
-        name: "other"
-      })
-    )
+      Repo.insert!(
+        Passkey.changeset(%Passkey{}, %{
+          user_id: other.id,
+          credential_id: <<4, 5, 6>>,
+          public_key: CBOR.encode(key),
+          name: "other"
+        })
+      )
 
-    assert {:ok, %{public_key: options}} =
-             WebAuthn.begin_authentication(
-               user,
-               :passwordless,
-               %{ip: "192.0.2.1", client_id: nil},
-               "https://irc.example"
-             )
+      %{user: user, binding: %{ip: "192.0.2.1", client_id: nil}}
+    end
 
-    assert options.rpId == "irc.example"
-    refute Map.has_key?(options, :allowCredentials)
+    test "passwordless stays discoverable and hands no credential id to an anonymous caller", ctx do
+      assert {:ok, %{public_key: options}} =
+               WebAuthn.begin_authentication(ctx.user, :passwordless, ctx.binding, "https://irc.example")
+
+      assert options.rpId == "irc.example"
+      refute Map.has_key?(options, :allowCredentials)
+    end
+
+    for purpose <- [:second_factor, :mode_change] do
+      test "#{purpose} lists the account's own credentials so a non-discoverable key can answer", ctx do
+        assert {:ok, %{public_key: options}} =
+                 WebAuthn.begin_authentication(ctx.user, unquote(purpose), ctx.binding, "https://irc.example")
+
+        assert [%{type: "public-key", id: id, transports: ["usb"]}] = options.allowCredentials
+        assert Base.url_decode64!(id, padding: false) == <<1, 2, 3>>
+      end
+    end
+
+    test "an account with no transports hint omits the key rather than sending an empty list", ctx do
+      Repo.update_all(Passkey, set: [transports: %{}])
+
+      assert {:ok, %{public_key: options}} =
+               WebAuthn.begin_authentication(ctx.user, :second_factor, ctx.binding, "https://irc.example")
+
+      assert [credential] = options.allowCredentials
+      refute Map.has_key?(credential, :transports)
+    end
   end
 
   test "passwordless activation persists the pre-shown recovery set only at commit" do

--- a/test/grappa/accounts/passkey_test.exs
+++ b/test/grappa/accounts/passkey_test.exs
@@ -218,6 +218,68 @@ defmodule Grappa.Accounts.PasskeyTest do
     end
   end
 
+  # Counting the credentials and then deleting one is two statements, and
+  # two concurrent requests both saw two credentials and both went ahead —
+  # a passwordless account ends with zero passkeys and no door at all. The
+  # count belongs INSIDE the delete, which is what these assert: the second
+  # delete re-decides against the row the first one removed. A true
+  # concurrent race cannot be staged here (the sandbox serialises both
+  # processes onto one connection), so the sequential pair is what proves
+  # the guard moved into the statement rather than reading a stale count.
+  describe "delete/2 last-credential guard" do
+    setup do
+      user = user_fixture()
+      %{user: user, session: session_fixture(user)}
+    end
+
+    defp add_passkey(user, credential_id) do
+      Repo.insert!(
+        Passkey.changeset(%Passkey{}, %{
+          user_id: user.id,
+          credential_id: credential_id,
+          public_key: CBOR.encode(%{1 => 2}),
+          name: "key-#{byte_size(credential_id)}"
+        })
+      )
+    end
+
+    test "an armed account keeps the last credential it depends on", ctx do
+      passkey = add_passkey(ctx.user, <<1>>)
+      {:ok, :passwordless} = WebAuthn.set_mode(ctx.user, :passwordless, ctx.session.id, codes())
+      armed = Repo.get!(Accounts.User, ctx.user.id)
+
+      assert {:error, :passkey_required} = WebAuthn.delete(armed, passkey.id)
+      assert Repo.aggregate(Passkey, :count, :id) == 1
+    end
+
+    test "the delete itself re-decides, so the second of two cannot empty the account", ctx do
+      first = add_passkey(ctx.user, <<1>>)
+      second = add_passkey(ctx.user, <<2, 2>>)
+      {:ok, :passwordless} = WebAuthn.set_mode(ctx.user, :passwordless, ctx.session.id, codes())
+      armed = Repo.get!(Accounts.User, ctx.user.id)
+
+      assert :ok = WebAuthn.delete(armed, first.id)
+      assert {:error, :passkey_required} = WebAuthn.delete(armed, second.id)
+      assert Repo.aggregate(Passkey, :count, :id) == 1
+    end
+
+    test "an account back on password login may remove its last credential", ctx do
+      passkey = add_passkey(ctx.user, <<1>>)
+
+      assert :ok = WebAuthn.delete(ctx.user, passkey.id)
+      assert Repo.aggregate(Passkey, :count, :id) == 0
+    end
+
+    test "a credential owned by someone else is not found, armed or not", ctx do
+      other = add_passkey(user_fixture(), <<3>>)
+      {:ok, :passwordless} = WebAuthn.set_mode(ctx.user, :passwordless, ctx.session.id, codes())
+      armed = Repo.get!(Accounts.User, ctx.user.id)
+
+      assert {:error, :not_found} = WebAuthn.delete(armed, other.id)
+      assert Repo.aggregate(Passkey, :count, :id) == 1
+    end
+  end
+
   # The mode decides which login door an account gets, so a value outside
   # the set is not a cosmetic problem: `!= "disabled"` reads TRUE for it and
   # no door matches, which wedges the account with no error anywhere. The

--- a/test/grappa/accounts/passkey_test.exs
+++ b/test/grappa/accounts/passkey_test.exs
@@ -149,9 +149,9 @@ defmodule Grappa.Accounts.PasskeyTest do
     codes = Accounts.prepare_recovery_codes()
 
     assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 0
-    assert {:ok, "passwordless"} = WebAuthn.set_mode(user, "passwordless", current.id, codes)
+    assert {:ok, :passwordless} = WebAuthn.set_mode(user, :passwordless, current.id, codes)
     assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 10
-    assert Repo.get!(Accounts.User, user.id).passkey_mode == "passwordless"
+    assert Repo.get!(Accounts.User, user.id).passkey_mode == :passwordless
     assert is_nil(Repo.get!(Accounts.Session, current.id).revoked_at)
     assert %DateTime{} = Repo.get!(Accounts.Session, other.id).revoked_at
   end
@@ -161,13 +161,13 @@ defmodule Grappa.Accounts.PasskeyTest do
     current = session_fixture(user)
     codes = Accounts.prepare_recovery_codes()
 
-    assert {:ok, "passwordless"} = WebAuthn.set_mode(user, "passwordless", current.id, codes)
+    assert {:ok, :passwordless} = WebAuthn.set_mode(user, :passwordless, current.id, codes)
 
     other = session_fixture(user)
     passwordless_user = Repo.get!(Accounts.User, user.id)
-    assert {:ok, "disabled"} = WebAuthn.set_mode(passwordless_user, "disabled", current.id)
+    assert {:ok, :disabled} = WebAuthn.set_mode(passwordless_user, :disabled, current.id)
     assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 0
-    assert Repo.get!(Accounts.User, passwordless_user.id).passkey_mode == "disabled"
+    assert Repo.get!(Accounts.User, passwordless_user.id).passkey_mode == :disabled
     assert is_nil(Repo.get!(Accounts.Session, current.id).revoked_at)
     assert %DateTime{} = Repo.get!(Accounts.Session, other.id).revoked_at
   end
@@ -186,35 +186,59 @@ defmodule Grappa.Accounts.PasskeyTest do
 
     test "disabling passwordless keeps the codes an armed TOTP still needs", ctx do
       armed = arm_totp(ctx.user)
-      {:ok, "passwordless"} = WebAuthn.set_mode(armed, "passwordless", ctx.session.id, codes())
+      {:ok, :passwordless} = WebAuthn.set_mode(armed, :passwordless, ctx.session.id, codes())
 
       passwordless = Repo.get!(Accounts.User, armed.id)
-      assert {:ok, "disabled"} = WebAuthn.set_mode(passwordless, "disabled", ctx.session.id)
+      assert {:ok, :disabled} = WebAuthn.set_mode(passwordless, :disabled, ctx.session.id)
       assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 10
     end
 
     test "disabling second-factor keeps the codes an armed TOTP still needs", ctx do
       armed = arm_totp(ctx.user)
-      second_factor = set_passkey_mode(armed, "second_factor")
+      second_factor = set_passkey_mode(armed, :second_factor)
 
-      assert {:ok, "disabled"} = WebAuthn.set_mode(second_factor, "disabled", ctx.session.id)
+      assert {:ok, :disabled} = WebAuthn.set_mode(second_factor, :disabled, ctx.session.id)
       assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 10
     end
 
     test "disabling second-factor with no other factor takes the codes with it", ctx do
       :ok = Accounts.RecoveryCodes.replace(ctx.user.id, codes())
-      second_factor = set_passkey_mode(ctx.user, "second_factor")
+      second_factor = set_passkey_mode(ctx.user, :second_factor)
 
-      assert {:ok, "disabled"} = WebAuthn.set_mode(second_factor, "disabled", ctx.session.id)
+      assert {:ok, :disabled} = WebAuthn.set_mode(second_factor, :disabled, ctx.session.id)
       assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 0
     end
 
     test "moving passwordless to second-factor keeps the codes, still armed", ctx do
-      {:ok, "passwordless"} = WebAuthn.set_mode(ctx.user, "passwordless", ctx.session.id, codes())
+      {:ok, :passwordless} = WebAuthn.set_mode(ctx.user, :passwordless, ctx.session.id, codes())
 
       passwordless = Repo.get!(Accounts.User, ctx.user.id)
-      assert {:ok, "second_factor"} = WebAuthn.set_mode(passwordless, "second_factor", ctx.session.id)
+      assert {:ok, :second_factor} = WebAuthn.set_mode(passwordless, :second_factor, ctx.session.id)
       assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 10
+    end
+  end
+
+  # The mode decides which login door an account gets, so a value outside
+  # the set is not a cosmetic problem: `!= "disabled"` reads TRUE for it and
+  # no door matches, which wedges the account with no error anywhere. The
+  # column refuses to hold one at all, which is why this reaches for raw SQL
+  # — nothing above it can even express the write.
+  describe "passkey_mode closed set" do
+    test "a mode outside the set cannot be loaded back as an account" do
+      user = user_fixture()
+      Repo.query!("UPDATE users SET passkey_mode = 'bogus' WHERE name = ?", [user.name])
+
+      assert_raise ArgumentError, fn -> Repo.get!(Accounts.User, user.id) end
+    end
+
+    test "the wire spelling of every mode decodes, and nothing else does" do
+      assert {:ok, :disabled} = WebAuthn.decode_mode("disabled")
+      assert {:ok, :second_factor} = WebAuthn.decode_mode("second_factor")
+      assert {:ok, :passwordless} = WebAuthn.decode_mode("passwordless")
+
+      assert {:error, :invalid_mode} = WebAuthn.decode_mode("bogus")
+      assert {:error, :invalid_mode} = WebAuthn.decode_mode(:disabled)
+      assert {:error, :invalid_mode} = WebAuthn.decode_mode(nil)
     end
   end
 

--- a/test/grappa/accounts/totp_test.exs
+++ b/test/grappa/accounts/totp_test.exs
@@ -107,6 +107,25 @@ defmodule Grappa.Accounts.TOTPTest do
     assert enrollment.provisioning_uri =~ "secret=#{enrollment.secret}"
   end
 
+  test "reset_totp/1 disarms the factor and revokes sessions, keeping the recovery set" do
+    {user, codes} = armed_user_with_recovery_codes()
+    session = session_fixture(user)
+    assert TOTP.enabled?(user)
+
+    {:ok, reset} = Accounts.reset_totp(user.name)
+
+    refute TOTP.enabled?(reset)
+    assert %DateTime{} = Repo.get!(Session, session.id).revoked_at
+
+    # The recovery set is shared with passkey passwordless mode, so
+    # disarming TOTP must not destroy the other factor's way back in.
+    assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == length(codes)
+  end
+
+  test "reset_totp/1 reports an unknown account rather than succeeding silently" do
+    assert {:error, :not_found} = Accounts.reset_totp("no-such-account")
+  end
+
   defp armed_user do
     {user, _} = armed_user_with_recovery_codes()
     user

--- a/test/grappa/accounts/totp_test.exs
+++ b/test/grappa/accounts/totp_test.exs
@@ -107,8 +107,13 @@ defmodule Grappa.Accounts.TOTPTest do
     assert enrollment.provisioning_uri =~ "secret=#{enrollment.secret}"
   end
 
-  test "reset_totp/1 disarms the factor and revokes sessions, keeping the recovery set" do
+  # The recovery set is shared, so disarming TOTP must not destroy a
+  # surviving passkey factor's way back in — but once TOTP was the last
+  # factor standing, leaving the codes behind would strand a live
+  # credential on an account whose login is password-only again.
+  test "reset_totp/1 disarms the factor and revokes sessions, keeping a passkey's recovery set" do
     {user, codes} = armed_user_with_recovery_codes()
+    user |> Ecto.Changeset.change(passkey_mode: "passwordless") |> Repo.update!()
     session = session_fixture(user)
     assert TOTP.enabled?(user)
 
@@ -116,9 +121,24 @@ defmodule Grappa.Accounts.TOTPTest do
 
     refute TOTP.enabled?(reset)
     assert %DateTime{} = Repo.get!(Session, session.id).revoked_at
+    assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == length(codes)
+  end
 
-    # The recovery set is shared with passkey passwordless mode, so
-    # disarming TOTP must not destroy the other factor's way back in.
+  test "reset_totp/1 takes the recovery set with it when TOTP was the last factor" do
+    {user, _} = armed_user_with_recovery_codes()
+    assert Repo.get!(User, user.id).passkey_mode == "disabled"
+
+    {:ok, _} = Accounts.reset_totp(user.name)
+
+    assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 0
+  end
+
+  test "reset_passkeys/1 keeps the recovery set an armed TOTP still needs" do
+    {user, codes} = armed_user_with_recovery_codes()
+    user |> Ecto.Changeset.change(passkey_mode: "second_factor") |> Repo.update!()
+
+    {:ok, _} = Accounts.reset_passkeys(user.name)
+
     assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == length(codes)
   end
 

--- a/test/grappa/accounts/totp_test.exs
+++ b/test/grappa/accounts/totp_test.exs
@@ -130,7 +130,7 @@ defmodule Grappa.Accounts.TOTPTest do
   # credential on an account whose login is password-only again.
   test "reset_totp/1 disarms the factor and revokes sessions, keeping a passkey's recovery set" do
     {user, codes} = armed_user_with_recovery_codes()
-    user |> Ecto.Changeset.change(passkey_mode: "passwordless") |> Repo.update!()
+    user |> Ecto.Changeset.change(passkey_mode: :passwordless) |> Repo.update!()
     session = session_fixture(user)
     assert TOTP.enabled?(user)
 
@@ -143,7 +143,7 @@ defmodule Grappa.Accounts.TOTPTest do
 
   test "reset_totp/1 takes the recovery set with it when TOTP was the last factor" do
     {user, _} = armed_user_with_recovery_codes()
-    assert Repo.get!(User, user.id).passkey_mode == "disabled"
+    assert Repo.get!(User, user.id).passkey_mode == :disabled
 
     {:ok, _} = Accounts.reset_totp(user.name)
 
@@ -152,7 +152,7 @@ defmodule Grappa.Accounts.TOTPTest do
 
   test "reset_passkeys/1 keeps the recovery set an armed TOTP still needs" do
     {user, codes} = armed_user_with_recovery_codes()
-    user |> Ecto.Changeset.change(passkey_mode: "second_factor") |> Repo.update!()
+    user |> Ecto.Changeset.change(passkey_mode: :second_factor) |> Repo.update!()
 
     {:ok, _} = Accounts.reset_passkeys(user.name)
 

--- a/test/grappa/accounts/totp_test.exs
+++ b/test/grappa/accounts/totp_test.exs
@@ -55,6 +55,23 @@ defmodule Grappa.Accounts.TOTPTest do
     assert {:error, :invalid_two_factor} = TOTP.verify(user, recovery, 1_700_000_030)
   end
 
+  # One set, two doors. They must agree on normalisation and hashing or a
+  # code minted behind one is unspendable at the other — and the account
+  # holder has no way to tell which door their code belongs to.
+  test "a code minted by TOTP enrolment is spendable at the passkey recovery door" do
+    {user, [code | _]} = armed_user_with_recovery_codes()
+
+    assert :ok = Accounts.consume_recovery_code(user, code)
+    assert {:error, :invalid_recovery_code} = Accounts.consume_recovery_code(user, code)
+  end
+
+  test "a code spent at the passkey door is gone from the TOTP door too" do
+    {user, [code | _]} = armed_user_with_recovery_codes()
+
+    assert :ok = Accounts.consume_recovery_code(user, code)
+    assert {:error, :invalid_two_factor} = TOTP.verify(user, code, 1_700_000_030)
+  end
+
   test "disable requires password and removes secret plus recovery codes" do
     {user, password} = user_fixture_with_password()
     {armed, _} = arm(user)

--- a/test/grappa/accounts/webauthn_challenge_store_test.exs
+++ b/test/grappa/accounts/webauthn_challenge_store_test.exs
@@ -14,4 +14,20 @@ defmodule Grappa.Accounts.WebAuthnChallengeStoreTest do
     assert {:ok, ^challenge, %{user_id: "user-1"}} = WebAuthnChallengeStore.take(second, :registration)
     assert {:error, :invalid_challenge} = WebAuthnChallengeStore.take(second, :registration)
   end
+
+  test "the sweep drops an abandoned ceremony and keeps a live one" do
+    # An abandoned ceremony is never taken, so the read-path TTL check
+    # never sees it — driving the callback directly is what proves the
+    # sweep, and needs no control over the monotonic clock.
+    now = System.monotonic_time(:second)
+    challenge = Wax.new_registration_challenge(origin: "https://irc.example", rp_id: "irc.example")
+
+    state = %{
+      "abandoned" => {challenge, :registration, %{}, now - 1},
+      "live" => {challenge, :registration, %{}, now + 300}
+    }
+
+    assert {:noreply, swept} = WebAuthnChallengeStore.handle_info(:sweep, state)
+    assert Map.keys(swept) == ["live"]
+  end
 end

--- a/test/grappa/ws_presence_test.exs
+++ b/test/grappa/ws_presence_test.exs
@@ -250,6 +250,35 @@ defmodule Grappa.WSPresenceTest do
 
       send(p2, :stop)
     end
+
+    # Visitor names are `"visitor:" <> id`, so the key space is unbounded and
+    # every visitor that ever connected used to leave a permanent empty map
+    # behind in a `:permanent` GenServer that never restarts.
+    test "the user's entry is dropped when its last socket dies, not left empty" do
+      p = stub_pid()
+      :ok = WSPresence.register("visitor:mallory", p)
+      assert Map.has_key?(:sys.get_state(WSPresence).sockets, "visitor:mallory")
+
+      Process.exit(p, :kill)
+      :timer.sleep(50)
+
+      refute Map.has_key?(:sys.get_state(WSPresence).sockets, "visitor:mallory")
+    end
+
+    test "a user keeping one socket alive stays tracked" do
+      p1 = stub_pid()
+      p2 = stub_pid()
+      :ok = WSPresence.register("dave", p1)
+      :ok = WSPresence.register("dave", p2)
+
+      Process.exit(p1, :kill)
+      :timer.sleep(50)
+
+      assert Map.has_key?(:sys.get_state(WSPresence).sockets, "dave")
+      assert WSPresence.ws_count("dave") == 1
+
+      send(p2, :stop)
+    end
   end
 
   describe "#671 — a STALE :visible pid still arms auto-away (every door)" do

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -29,6 +29,7 @@ defmodule GrappaWeb.AuthControllerTest do
   alias Grappa.RateLimit.FailureWindow
   alias Grappa.Session.Server, as: SessionServer
   alias Grappa.Visitors.Visitor
+  alias GrappaWeb.PasskeyOrigin
 
   # NetworkCircuit is ETS-backed and survives Ecto sandbox resets.
   # Clear before each test so spawn failures from one test don't trip
@@ -78,14 +79,8 @@ defmodule GrappaWeb.AuthControllerTest do
 
   test "passkey second-factor options use the configured WebAuthn origin", %{conn: conn} do
     {user, password} = user_fixture_with_password()
-    previous_origin = Application.get_env(:grappa, :passkey_origin)
-    Application.put_env(:grappa, :passkey_origin, "https://login.example:8443")
-
-    on_exit(fn ->
-      if previous_origin,
-        do: Application.put_env(:grappa, :passkey_origin, previous_origin),
-        else: Application.delete_env(:grappa, :passkey_origin)
-    end)
+    :ok = PasskeyOrigin.put_test_origin("https://login.example:8443")
+    on_exit(fn -> PasskeyOrigin.put_test_origin(nil) end)
 
     key = %{1 => 2, 3 => -7, -1 => 1, -2 => <<0::256>>, -3 => <<0::256>>}
 

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -107,7 +107,7 @@ defmodule GrappaWeb.AuthControllerTest do
       |> post("/auth/login", %{"identifier" => user.name, "password" => password})
       |> json_response(202)
 
-    assert pending["passkey_options"]["public_key"]["rpId"] == "login.example"
+    assert pending["passkey_options"]["public_key"]["rp_id"] == "login.example"
   end
 
   describe "POST /auth/login (mode-1 admin via email)" do

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -94,7 +94,7 @@ defmodule GrappaWeb.AuthControllerTest do
     )
 
     user
-    |> Ecto.Changeset.change(passkey_mode: "second_factor")
+    |> Ecto.Changeset.change(passkey_mode: :second_factor)
     |> Repo.update!()
 
     pending =

--- a/test/grappa_web/controllers/passkey_controller_test.exs
+++ b/test/grappa_web/controllers/passkey_controller_test.exs
@@ -152,6 +152,24 @@ defmodule GrappaWeb.PasskeyControllerTest do
     decoded <> token
   end
 
+  # A mode change is proved with a passkey assertion, so an account holding
+  # no passkey cannot start one. That is a plain conflict with the account's
+  # state and the caller can act on it — but nothing mapped the error, so it
+  # fell out of the FallbackController as an unhandled clause and the door
+  # answered a 500. Reachable with two lines of client: create an account,
+  # ask for second_factor before registering anything.
+  test "asking for a ceremony with no passkey registered is a conflict, not a crash", %{conn: conn} do
+    {user, password} = user_fixture_with_password()
+    session = session_fixture(user)
+
+    response =
+      conn
+      |> put_req_header("authorization", "Bearer #{session.id}")
+      |> post("/me/passkeys/mode/options", %{"password" => password, "mode" => "second_factor"})
+
+    assert json_response(response, 409) == %{"error" => "passkey_not_configured"}
+  end
+
   # A bearer alone must never be enough to change HOW an account
   # authenticates, so every one of these doors re-asks for the password. The
   # check was open-coded four times over and not one of the four had a test

--- a/test/grappa_web/controllers/passkey_controller_test.exs
+++ b/test/grappa_web/controllers/passkey_controller_test.exs
@@ -113,6 +113,45 @@ defmodule GrappaWeb.PasskeyControllerTest do
     assert is_nil(Repo.get!(Session, session.id).revoked_at)
   end
 
+  # The checkpoint token carries the not-yet-armed recovery codes so the
+  # server need not store them before the ceremony commits. A SIGNED token
+  # is tamper-proof but not secret — its payload is plain base64 — so the
+  # codes would be readable by anything the token passes through.
+  test "the recovery checkpoint token does not carry the codes in the clear", %{conn: conn} do
+    {user, password} = user_fixture_with_password()
+    session = session_fixture(user)
+
+    prepared =
+      conn
+      |> put_req_header("authorization", "Bearer #{session.id}")
+      |> post("/me/passkeys/passwordless/recovery", %{"password" => password})
+      |> json_response(200)
+
+    readable = decoded_segments(prepared["recovery_token"])
+
+    for code <- prepared["recovery_codes"] do
+      refute readable =~ code
+    end
+  end
+
+  # Everything a bearer of the token can read without a key: the token
+  # itself plus each of its base64url segments decoded. A signed token
+  # yields its whole term-encoded payload here; an encrypted one yields
+  # ciphertext.
+  defp decoded_segments(token) do
+    decoded =
+      token
+      |> String.split(".")
+      |> Enum.map_join(" ", fn segment ->
+        case Base.url_decode64(segment, padding: false) do
+          {:ok, raw} -> raw
+          :error -> segment
+        end
+      end)
+
+    decoded <> token
+  end
+
   test "last passkey can be deleted after returning to password login", %{conn: conn} do
     {user, password} = user_fixture_with_password()
     session = session_fixture(user)

--- a/test/grappa_web/controllers/passkey_controller_test.exs
+++ b/test/grappa_web/controllers/passkey_controller_test.exs
@@ -257,7 +257,7 @@ defmodule GrappaWeb.PasskeyControllerTest do
     assert json_response(blocked, 409) == %{"error" => "passkey_required"}
 
     passwordless_user = Repo.get!(User, user.id)
-    assert {:ok, :disabled} = WebAuthn.set_mode(passwordless_user, :disabled, session.id)
+    assert {:ok, :disabled} = WebAuthn.set_mode(passwordless_user, :disabled, session.id, [])
 
     conn = put_req_header(recycle(conn), "authorization", "Bearer #{session.id}")
     assert response(delete(conn, "/me/passkeys/#{passkey.id}", %{"password" => password}), 204)

--- a/test/grappa_web/controllers/passkey_controller_test.exs
+++ b/test/grappa_web/controllers/passkey_controller_test.exs
@@ -5,7 +5,71 @@ defmodule GrappaWeb.PasskeyControllerTest do
   import Ecto.Query
 
   alias Grappa.Accounts.{Passkey, Session, TOTP, TOTPRecoveryCode, User, WebAuthn}
+  alias Grappa.RateLimit.FailureWindow
   alias Grappa.Repo
+
+  defp passwordless_user do
+    {user, password} = user_fixture_with_password()
+    session = session_fixture(user)
+
+    Repo.insert!(
+      Passkey.changeset(%Passkey{}, %{
+        user_id: user.id,
+        credential_id: :crypto.strong_rand_bytes(16),
+        public_key: CBOR.encode(%{1 => 2, 3 => -7}),
+        name: "phone"
+      })
+    )
+
+    {:ok, "passwordless"} =
+      WebAuthn.set_mode(user, "passwordless", session.id, Grappa.Accounts.prepare_recovery_codes())
+
+    {Repo.get!(User, user.id), password}
+  end
+
+  test "login_options is throttled even while it keeps succeeding", %{conn: conn} do
+    # The abuse is challenge ALLOCATION, and the cheapest way to allocate
+    # is to keep succeeding — so a failures-only window would never see
+    # this traffic. Every 200 has to count against the bucket too.
+    {user, _password} = passwordless_user()
+    on_exit(fn -> FailureWindow.clear(:passkey_login_options, "127.0.0.1") end)
+
+    for _ <- 1..30 do
+      assert conn |> post("/auth/passkeys/options", %{"identifier" => user.name}) |> Map.get(:status) == 200
+    end
+
+    assert conn
+           |> post("/auth/passkeys/options", %{"identifier" => user.name})
+           |> json_response(429) == %{"error" => "too_many_attempts"}
+  end
+
+  test "recovery throttling survives respelling the identifier", %{conn: conn} do
+    # find_user/1 folds an email to its local part, so these all resolve to
+    # ONE account. Keying the window on the wire string handed the attacker
+    # a fresh bucket per spelling.
+    {user, _password} = passwordless_user()
+
+    on_exit(fn ->
+      FailureWindow.clear(:passkey_recovery, "127.0.0.1")
+      FailureWindow.clear(:passkey_recovery, {"127.0.0.1", user.id})
+    end)
+
+    spellings = Stream.cycle([user.name, "#{user.name}@a.aa", "#{user.name}@b.bb"])
+
+    for identifier <- Enum.take(spellings, 10) do
+      post(conn, "/auth/passkeys/recover", %{
+        "identifier" => identifier,
+        "recovery_code" => "wrongwrongwrongwrongwrongw"
+      })
+    end
+
+    assert conn
+           |> post("/auth/passkeys/recover", %{
+             "identifier" => "#{user.name}@c.cc",
+             "recovery_code" => "wrongwrongwrongwrongwrongw"
+           })
+           |> json_response(429) == %{"error" => "too_many_attempts"}
+  end
 
   test "passwordless mode rejects password and accepts a one-shot recovery code", %{conn: conn} do
     {user, password} = user_fixture_with_password()

--- a/test/grappa_web/controllers/passkey_controller_test.exs
+++ b/test/grappa_web/controllers/passkey_controller_test.exs
@@ -31,7 +31,7 @@ defmodule GrappaWeb.PasskeyControllerTest do
     # The abuse is challenge ALLOCATION, and the cheapest way to allocate
     # is to keep succeeding — so a failures-only window would never see
     # this traffic. Every 200 has to count against the bucket too.
-    {user, _password} = passwordless_user()
+    {user, _} = passwordless_user()
     on_exit(fn -> FailureWindow.clear(:passkey_login_options, "127.0.0.1") end)
 
     for _ <- 1..30 do
@@ -47,7 +47,7 @@ defmodule GrappaWeb.PasskeyControllerTest do
     # find_user/1 folds an email to its local part, so these all resolve to
     # ONE account. Keying the window on the wire string handed the attacker
     # a fresh bucket per spelling.
-    {user, _password} = passwordless_user()
+    {user, _} = passwordless_user()
 
     on_exit(fn ->
       FailureWindow.clear(:passkey_recovery, "127.0.0.1")

--- a/test/grappa_web/controllers/passkey_controller_test.exs
+++ b/test/grappa_web/controllers/passkey_controller_test.exs
@@ -152,6 +152,64 @@ defmodule GrappaWeb.PasskeyControllerTest do
     decoded <> token
   end
 
+  # A bearer alone must never be enough to change HOW an account
+  # authenticates, so every one of these doors re-asks for the password. The
+  # check was open-coded four times over and not one of the four had a test
+  # behind it — this pins all of them at once, before they are folded into a
+  # single door.
+  describe "password re-authentication" do
+    setup %{conn: conn} do
+      {user, password} = user_fixture_with_password()
+      session = session_fixture(user)
+
+      passkey =
+        Repo.insert!(
+          Passkey.changeset(%Passkey{}, %{
+            user_id: user.id,
+            credential_id: <<9, 9, 9>>,
+            public_key: CBOR.encode(%{1 => 2, 3 => -7}),
+            name: "phone"
+          })
+        )
+
+      %{conn: conn, user: user, password: password, session: session, passkey: passkey}
+    end
+
+    test "every privileged passkey verb refuses the wrong password", ctx do
+      wrong = ctx.password <> "-nope"
+
+      requests = [
+        {:post, "/me/passkeys/registration/options", %{"password" => wrong, "name" => "phone"}},
+        {:post, "/me/passkeys/mode/options", %{"password" => wrong, "mode" => "second_factor"}},
+        {:post, "/me/passkeys/passwordless/recovery", %{"password" => wrong}},
+        {:delete, "/me/passkeys/#{ctx.passkey.id}", %{"password" => wrong}}
+      ]
+
+      for {verb, path, params} <- requests do
+        conn =
+          ctx.conn
+          |> recycle()
+          |> put_req_header("authorization", "Bearer #{ctx.session.id}")
+
+        response = dispatch(conn, GrappaWeb.Endpoint, verb, path, params)
+
+        assert json_response(response, 401) == %{"error" => "invalid_credentials"},
+               "#{verb} #{path} accepted a wrong password"
+      end
+
+      assert Repo.aggregate(Passkey, :count, :id) == 1
+    end
+
+    test "the right password gets past the door it guards", ctx do
+      response =
+        ctx.conn
+        |> put_req_header("authorization", "Bearer #{ctx.session.id}")
+        |> post("/me/passkeys/passwordless/recovery", %{"password" => ctx.password})
+
+      assert length(json_response(response, 200)["recovery_codes"]) == 10
+    end
+  end
+
   # The column stores the mode as one of a closed set of atoms; the wire has
   # always spelled it out in full, and `cicchetto/src/lib/api.ts` types the
   # three spellings literally. Nothing else pinned that, so the encoding was

--- a/test/grappa_web/controllers/passkey_controller_test.exs
+++ b/test/grappa_web/controllers/passkey_controller_test.exs
@@ -21,8 +21,8 @@ defmodule GrappaWeb.PasskeyControllerTest do
       })
     )
 
-    {:ok, "passwordless"} =
-      WebAuthn.set_mode(user, "passwordless", session.id, Grappa.Accounts.prepare_recovery_codes())
+    {:ok, :passwordless} =
+      WebAuthn.set_mode(user, :passwordless, session.id, Grappa.Accounts.prepare_recovery_codes())
 
     {Repo.get!(User, user.id), password}
   end
@@ -80,7 +80,7 @@ defmodule GrappaWeb.PasskeyControllerTest do
 
     User
     |> where([u], u.id == ^user.id)
-    |> Repo.update_all(set: [passkey_mode: "passwordless"])
+    |> Repo.update_all(set: [passkey_mode: :passwordless])
 
     rejected = post(conn, "/auth/login", %{"identifier" => user.name, "password" => password})
     assert json_response(rejected, 401) == %{"error" => "invalid_credentials"}
@@ -108,7 +108,7 @@ defmodule GrappaWeb.PasskeyControllerTest do
 
     assert length(prepared["recovery_codes"]) == 10
     assert is_binary(prepared["recovery_token"])
-    assert Repo.get!(User, user.id).passkey_mode == "disabled"
+    assert Repo.get!(User, user.id).passkey_mode == :disabled
     assert Repo.aggregate(TOTPRecoveryCode, :count, :id) == 0
     assert is_nil(Repo.get!(Session, session.id).revoked_at)
   end
@@ -152,6 +152,28 @@ defmodule GrappaWeb.PasskeyControllerTest do
     decoded <> token
   end
 
+  # The column stores the mode as one of a closed set of atoms; the wire has
+  # always spelled it out in full, and `cicchetto/src/lib/api.ts` types the
+  # three spellings literally. Nothing else pinned that, so the encoding was
+  # free to drift the moment the storage type changed.
+  test "every mode reaches the wire in the spelling the client types", %{conn: conn} do
+    {user, _} = user_fixture_with_password()
+    session = session_fixture(user)
+
+    for {mode, wire} <- [{:disabled, "disabled"}, {:second_factor, "second_factor"}, {:passwordless, "passwordless"}] do
+      user |> Ecto.Changeset.change(passkey_mode: mode) |> Repo.update!()
+
+      body =
+        conn
+        |> recycle()
+        |> put_req_header("authorization", "Bearer #{session.id}")
+        |> get("/me/passkeys")
+        |> json_response(200)
+
+      assert body["mode"] == wire
+    end
+  end
+
   test "last passkey can be deleted after returning to password login", %{conn: conn} do
     {user, password} = user_fixture_with_password()
     session = session_fixture(user)
@@ -166,8 +188,8 @@ defmodule GrappaWeb.PasskeyControllerTest do
         })
       )
 
-    assert {:ok, "passwordless"} =
-             WebAuthn.set_mode(user, "passwordless", session.id, Grappa.Accounts.prepare_recovery_codes())
+    assert {:ok, :passwordless} =
+             WebAuthn.set_mode(user, :passwordless, session.id, Grappa.Accounts.prepare_recovery_codes())
 
     blocked =
       conn
@@ -177,7 +199,7 @@ defmodule GrappaWeb.PasskeyControllerTest do
     assert json_response(blocked, 409) == %{"error" => "passkey_required"}
 
     passwordless_user = Repo.get!(User, user.id)
-    assert {:ok, "disabled"} = WebAuthn.set_mode(passwordless_user, "disabled", session.id)
+    assert {:ok, :disabled} = WebAuthn.set_mode(passwordless_user, :disabled, session.id)
 
     conn = put_req_header(recycle(conn), "authorization", "Bearer #{session.id}")
     assert response(delete(conn, "/me/passkeys/#{passkey.id}", %{"password" => password}), 204)

--- a/test/grappa_web/controllers/totp_controller_test.exs
+++ b/test/grappa_web/controllers/totp_controller_test.exs
@@ -6,7 +6,7 @@ defmodule GrappaWeb.TotpControllerTest do
   alias Grappa.{Accounts, Accounts.Session, Accounts.TOTP, Accounts.TOTPRecoveryCode, Repo}
 
   test "a bearer alone cannot start TOTP enrollment", %{conn: conn} do
-    {user, _password} = user_fixture_with_password()
+    {user, _} = user_fixture_with_password()
     session = session_fixture(user)
 
     assert conn
@@ -16,7 +16,7 @@ defmodule GrappaWeb.TotpControllerTest do
   end
 
   test "a wrong password cannot start TOTP enrollment", %{conn: conn} do
-    {user, _password} = user_fixture_with_password()
+    {user, _} = user_fixture_with_password()
     session = session_fixture(user)
 
     assert conn

--- a/test/grappa_web/controllers/totp_controller_test.exs
+++ b/test/grappa_web/controllers/totp_controller_test.exs
@@ -5,15 +5,35 @@ defmodule GrappaWeb.TotpControllerTest do
 
   alias Grappa.{Accounts, Accounts.Session, Accounts.TOTP, Accounts.TOTPRecoveryCode, Repo}
 
+  test "a bearer alone cannot start TOTP enrollment", %{conn: conn} do
+    {user, _password} = user_fixture_with_password()
+    session = session_fixture(user)
+
+    assert conn
+           |> put_bearer(session.id)
+           |> post("/me/totp/enrollment", %{})
+           |> json_response(400) == %{"error" => "bad_request"}
+  end
+
+  test "a wrong password cannot start TOTP enrollment", %{conn: conn} do
+    {user, _password} = user_fixture_with_password()
+    session = session_fixture(user)
+
+    assert conn
+           |> put_bearer(session.id)
+           |> post("/me/totp/enrollment", %{"password" => "not-the-password"})
+           |> json_response(401) == %{"error" => "invalid_credentials"}
+  end
+
   test "user enrolls TOTP, sees recovery codes once, and other sessions are revoked", %{conn: conn} do
-    {user, _} = user_fixture_with_password()
+    {user, password} = user_fixture_with_password()
     current = session_fixture(user)
     other = session_fixture(user)
 
     enrollment =
       conn
       |> put_bearer(current.id)
-      |> post("/me/totp/enrollment", %{})
+      |> post("/me/totp/enrollment", %{"password" => password})
       |> json_response(200)
 
     {:ok, code} = TOTP.code_at(enrollment["secret"], System.system_time(:second))
@@ -42,14 +62,14 @@ defmodule GrappaWeb.TotpControllerTest do
   end
 
   test "enrollment rolls back when other-session revocation fails", %{conn: conn} do
-    {user, _} = user_fixture_with_password()
+    {user, password} = user_fixture_with_password()
     current = session_fixture(user)
     other = session_fixture(user)
 
     enrollment =
       conn
       |> put_bearer(current.id)
-      |> post("/me/totp/enrollment", %{})
+      |> post("/me/totp/enrollment", %{"password" => password})
       |> json_response(200)
 
     {:ok, code} = TOTP.code_at(enrollment["secret"], System.system_time(:second))


### PR DESCRIPTION
The server-side findings from the #741 auth review. Six commits, one finding each, every one re-derived against the current head before it was touched — one of the original batch had already been fixed by #722 and is not re-fixed here.

## What each commit proves

**`auth: close the set of passkey modes at the column, not at the callers`**
`passkey_mode` decides which login door an account gets, and it was a plain `:string` whose three legal values survived only as pattern matches across five modules — with both writers reaching the column through `Repo.update_all/2`, which skips casting entirely. It is now an `Ecto.Enum`: no migration (the atoms dump to the strings already stored), and the wire is unchanged, with a new test pinning each spelling because `cicchetto/src/lib/api.ts` types the three literally. The gain over a string-union `@type` — which CLAUDE.md also permits — is enforcement in BOTH directions: a value outside the set can no longer be written *or read back*. A row holding one used to read TRUE for `!= "disabled"` while matching no door, wedging the account with no error anywhere; it now raises on load.

**`auth: pin the password re-auth every passkey verb performs`**
Characterisation only, green on the unrefactored code by construction. Four privileged doors re-ask for the account password and not one of the four had a test behind it.

**`auth: compare a password in one place instead of five`**
The fold those tests were written for. `Accounts.verify_password/2` was added as the single re-auth door and four callers kept their own `Argon2.verify_pass/2` anyway. Login's `get_user_by_credentials/2` folds in too — it looked different only because of the absent-account branch, which is the timing oracle, not the comparison. No module outside `Grappa.Accounts` calls `Argon2.verify_pass/2` now.

**`auth: decide the last-passkey question inside the delete`**
The controller counted credentials and then deleted one. Two statements, no transaction: two concurrent deletes both saw two credentials, both passed, and a passwordless account ended with zero passkeys and no way in. The condition is now part of the DELETE — it removes the row only when another credential for the account exists, so the second request re-decides against the row the first removed and loses. The rule also moves from the controller into the context that owns credentials.

**`auth: retire the optional arguments and the docs that outlived P3`**
Two banned default arguments (`set_mode(user, :passwordless, session_id)` compiled fine and quietly meant "no recovery codes"), a `KeyError`-with-stack-trace where the sibling task raised a sentence, and three docs still describing the recovery set as it behaved before the shared-set rule landed.

**`auth: answer a missing passkey with a conflict instead of a crash`**
`WebAuthn.begin_authentication/5` has always returned `{:error, :passkey_not_configured}` and nothing mapped it; `FallbackController` has no catch-all by design, so the door answered 500. Reachable in two lines of client — an account with no passkey asking to enable second-factor. Now 409, mirroring `passkey_required`, with the token moving in lockstep across `ErrorTokens`, the regenerated `wireTypes.ts`, and cic's `friendlyApiError` switch, whose `assertNever` would otherwise have failed `tsc`.

## Gates

Full `scripts/check.sh` **rc=0** on the rebased branch: 5044 tests / 0 failures, dialyzer `Total errors: 0`, credo strict / sobelow / doctor / format clean, `wireTypes.ts` in sync, 262/262 bats. cic lane (a new wire token crosses the stack): `bun run check` rc=0, `tsc --noEmit` standalone rc=0, suite 3936 passing — the two reds in the full cic run are `compose`/`subscribe`, which give 220/220 re-run in isolation and are untouched by this branch.

## Deliberately not in here

- **h14** (the `nick_fallback` advisory row emitted mid-ghost-recovery and never retracted) is still blocked on a design call and no code was written for it. Worth flagging: the premise that `advance_ghost/2` is the single terminal door is wrong — the 8s `:ghost_timeout` handler clears `ghost_recovery` on its own, so a fix that emits only on the FSM's `:failed` would go silent on the likeliest real failure.
- **The "route passkey verbs through `Grappa.Accounts`" half of the re-auth finding.** It is not a passkey divergence: `Accounts.TOTP`, `Accounts.Session` and `Accounts.User` are all reached the same way from the web layer and Boundary permits it. That is a codebase-wide convention call, not an auth fix.
- **#768**, filed from this work: the passkey door mishandles transient SQLite contention — three writes outside `Repo.BusyRetry`, and `set_mode/2`'s catch-all relabelling `:db_unavailable` as `invalid_two_factor`, telling the user their authenticator is bad when the database is merely busy.