### PR TITLE
hold the nick-fallback advisory until ghost recovery settles

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -359,6 +359,7 @@ config :logger, :console,
     # (never a query window for the target). In the allowlist to satisfy the
     # known_keys↔metadata sync test even though no Logger call carries it today.
     :ctcp_target,
+    :nick_fallback,
     # Auth context (Phase 2): bearer-token session lifecycle. `session_ref`
     # is a non-reversible SHA-256 handle of the session-id (S9: the raw id
     # IS the bearer token, so it must NEVER hit the log stream) — it rides

--- a/lib/grappa/scrollback/meta.ex
+++ b/lib/grappa/scrollback/meta.ex
@@ -167,10 +167,11 @@ defmodule Grappa.Scrollback.Meta do
             | :ctcp_verb
             | :ctcp_args
             | :ctcp_target
+            | :nick_fallback
           ) => term()
         }
 
-  @known_keys ~w[target new_nick modes args numeric severity who who_target names names_target raw_verb raw_sender raw_params sender_user sender_host sender_prefix ctcp_verb ctcp_args ctcp_target]a
+  @known_keys ~w[target new_nick modes args numeric severity who who_target names names_target raw_verb raw_sender raw_params sender_user sender_host sender_prefix ctcp_verb ctcp_args ctcp_target nick_fallback]a
 
   @doc """
   The atom-key allowlist. Exposed so the test suite can assert that
@@ -198,7 +199,8 @@ defmodule Grappa.Scrollback.Meta do
           | :sender_prefix
           | :ctcp_verb
           | :ctcp_args
-          | :ctcp_target,
+          | :ctcp_target
+          | :nick_fallback,
           ...
         ]
   def known_keys, do: @known_keys

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -1662,7 +1662,25 @@ defmodule Grappa.Session.EventRouter do
       {:cont, reconciled, []}
     else
       {reconciled, eff} = nick_fallback_row(reconciled, msg, state.nick, welcomed_nick)
-      {:cont, reconciled, [eff]}
+      announce_or_park(reconciled, eff)
+    end
+  end
+
+  # #676 h14 — while ghost recovery is in flight the underscore is a move we
+  # are already undoing, not a fact about who the user is. The row is an
+  # ADVISORY with no retraction, so announcing it here leaves it sitting
+  # there, false, for the life of the scrollback.
+  #
+  # What gets parked is the BUILT effect, not the facts to rebuild it later.
+  # The sender is the upstream server name and it exists only on this 001
+  # message; carrying it forward on session state or on the FSM would
+  # duplicate something the message already holds, and the FSM has no
+  # business knowing about scrollback rows. `Session.Server` releases it at
+  # either failure terminal and drops it when the nick comes back.
+  defp announce_or_park(state, eff) do
+    case Map.get(state, :ghost_recovery) do
+      nil -> {:cont, state, [eff]}
+      _ -> {:cont, Map.put(state, :parked_nick_fallback, eff), []}
     end
   end
 

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -1666,24 +1666,6 @@ defmodule Grappa.Session.EventRouter do
     end
   end
 
-  # #676 h14 — while ghost recovery is in flight the underscore is a move we
-  # are already undoing, not a fact about who the user is. The row is an
-  # ADVISORY with no retraction, so announcing it here leaves it sitting
-  # there, false, for the life of the scrollback.
-  #
-  # What gets parked is the BUILT effect, not the facts to rebuild it later.
-  # The sender is the upstream server name and it exists only on this 001
-  # message; carrying it forward on session state or on the FSM would
-  # duplicate something the message already holds, and the FSM has no
-  # business knowing about scrollback rows. `Session.Server` releases it at
-  # either failure terminal and drops it when the nick comes back.
-  defp announce_or_park(state, eff) do
-    case Map.get(state, :ghost_recovery) do
-      nil -> {:cont, state, [eff]}
-      _ -> {:cont, Map.put(state, :parked_nick_fallback, eff), []}
-    end
-  end
-
   # CP15 B2 — JOIN failure numerics. Six codes carry the same shape:
   #   :server <code> <own_nick_echo> <channel> :<reason>
   # When the channel matches an in-flight JOIN (case-insensitive RFC 2812
@@ -2972,6 +2954,24 @@ defmodule Grappa.Session.EventRouter do
 
   # #127 — flush the accumulator to wire-order lines.
   defp server_reply_drain(%{lines: lines}), do: Enum.reverse(lines)
+
+  # #676 h14 — while ghost recovery is in flight the underscore is a move we
+  # are already undoing, not a fact about who the user is. The row is an
+  # ADVISORY with no retraction, so announcing it here leaves it sitting
+  # there, false, for the life of the scrollback.
+  #
+  # What gets parked is the BUILT effect, not the facts to rebuild it later.
+  # The sender is the upstream server name and it exists only on this 001
+  # message; carrying it forward on session state or on the FSM would
+  # duplicate something the message already holds, and the FSM has no
+  # business knowing about scrollback rows. `Session.Server` releases it at
+  # either failure terminal and drops it when the nick comes back.
+  defp announce_or_park(state, eff) do
+    case Map.get(state, :ghost_recovery) do
+      nil -> {:cont, state, [eff]}
+      _ -> {:cont, Map.put(state, :parked_nick_fallback, eff), []}
+    end
+  end
 
   # #676 — the "you are not the nick you asked for" row.
   #

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -653,6 +653,11 @@ defmodule Grappa.Session.Server do
           query_window_open?: EventRouter.query_window_open?(),
           ghost_recovery: GhostRecovery.t() | nil,
           ghost_timer: reference() | nil,
+          # #676 h14 — the `nick_fallback` advisory built at 001 but held
+          # back while `ghost_recovery` is in flight, because the rename it
+          # describes may be about to be undone. Released at either failure
+          # terminal, dropped on success. Nil whenever no ghost is armed.
+          parked_nick_fallback: {:persist, atom(), map()} | nil,
           # #581 — the visitor "recover my identity" FSM + its two timers
           # (overall deadline + the post-verb settle tick). All nil unless
           # a recovery is in flight; the FSM is a sibling to
@@ -1169,6 +1174,7 @@ defmodule Grappa.Session.Server do
       query_window_open?: Map.get(opts, :query_window_open?, &QueryWindows.open?/3),
       ghost_recovery: nil,
       ghost_timer: nil,
+      parked_nick_fallback: nil,
       # #581 — recover-identity FSM + timers idle until /recover (or the
       # home button) fires `handle_call(:recover_identity, ...)`.
       recover_identity: nil,
@@ -2994,10 +3000,12 @@ defmodule Grappa.Session.Server do
     advance_ghost(state, msg)
   end
 
+  # The SECOND failure terminal — `GhostRecovery.step(gr, :timeout)` is
+  # `:failed` by definition, so the parked advisory is released here too.
   def handle_info(:ghost_timeout, %{ghost_recovery: %GhostRecovery{} = gr} = state) do
     {_, _, lines} = GhostRecovery.step(gr, :timeout)
-    state = flush_lines(state, lines)
-    {:noreply, %{state | ghost_recovery: nil, ghost_timer: nil}}
+    state = state |> flush_lines(lines) |> release_nick_fallback()
+    {:noreply, clear_ghost(state)}
   end
 
   def handle_info(:ghost_timeout, state), do: {:noreply, state}
@@ -3943,14 +3951,42 @@ defmodule Grappa.Session.Server do
     state = flush_lines(state, lines)
 
     case next.phase do
-      terminal when terminal in [:succeeded, :failed] ->
+      # The nick came back, so the fallback the 001 wanted to announce never
+      # became true. Drop the parked row rather than announce a rename we
+      # just undid.
+      :succeeded ->
         :ok = cancel_and_drain(state.ghost_timer, :ghost_timeout)
+        {:noreply, clear_ghost(state)}
 
-        {:noreply, %{state | ghost_recovery: nil, ghost_timer: nil}}
+      :failed ->
+        :ok = cancel_and_drain(state.ghost_timer, :ghost_timeout)
+        {:noreply, state |> release_nick_fallback() |> clear_ghost()}
 
       _ ->
         {:noreply, %{state | ghost_recovery: next}}
     end
+  end
+
+  defp clear_ghost(state),
+    do: %{state | ghost_recovery: nil, ghost_timer: nil, parked_nick_fallback: nil}
+
+  # #676 h14 — release the advisory EventRouter parked at 001.
+  #
+  # Called from BOTH failure terminals. `advance_ghost/2` is the obvious
+  # one; `handle_info(:ghost_timeout, ...)` clears the FSM on its own and is
+  # the likeliest failure in the field — NickServ simply never answers. A
+  # release wired to only one of them is silent exactly when the underscore
+  # is most likely to be permanent, which is the accident #676 exists to
+  # prevent.
+  defp release_nick_fallback(%{parked_nick_fallback: nil} = state), do: state
+
+  defp release_nick_fallback(%{parked_nick_fallback: {:persist, kind, attrs}} = state) do
+    # Stamped at the terminal, not at 001. The row records that the fallback
+    # is now PERMANENT, which is decided here; a connect-time stamp would
+    # also sort it above the recovery's own $server chatter on reload while
+    # a live client had appended it below.
+    fresh = Map.put(attrs, :server_time, System.system_time(:millisecond))
+    apply_effects([{:persist, kind, fresh}], %{state | parked_nick_fallback: nil})
   end
 
   # Lines emitted by GhostRecovery bypass `handle_call({:send_privmsg,

--- a/test/grappa/scrollback/meta_test.exs
+++ b/test/grappa/scrollback/meta_test.exs
@@ -29,6 +29,21 @@ defmodule Grappa.Scrollback.MetaTest do
       assert {:ok, %{sender_prefix: "+"}} = Meta.load(%{"sender_prefix" => "+"})
     end
 
+    # #676 point 3 shipped a `$server` row carrying `meta.nick_fallback` and
+    # never added the key here, so EVERY one of those rows was rejected at
+    # the cast and swallowed by the "scrollback insert failed — session
+    # continues" arm. The advisory the issue exists to deliver has never
+    # reached a single user. Nothing caught it because the router test
+    # asserts the emitted EFFECT and stops there.
+    test "the nick-fallback advisory survives the cast that used to reject it" do
+      fallback = %{requested: "vjt", registered: "vjt_"}
+
+      assert {:ok, %{nick_fallback: ^fallback}} = Meta.cast(%{nick_fallback: fallback})
+
+      assert {:ok, %{nick_fallback: %{"requested" => "vjt"}}} =
+               Meta.load(%{"nick_fallback" => %{"requested" => "vjt", "registered" => "vjt_"}})
+    end
+
     test "string-keyed map: known keys atomized" do
       assert {:ok, %{target: "alice"}} = Meta.cast(%{"target" => "alice"})
 

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -12,7 +12,7 @@ defmodule Grappa.Session.EventRouterTest do
   use ExUnit.Case, async: true
 
   alias Grappa.IRC.Message
-  alias Grappa.Session.{EventRouter, ISupport, Wire}
+  alias Grappa.Session.{EventRouter, GhostRecovery, ISupport, Wire}
 
   @user_id "00000000-0000-0000-0000-000000000001"
   @subject {:user, @user_id}
@@ -2767,6 +2767,27 @@ defmodule Grappa.Session.EventRouterTest do
       assert attrs.meta.nick_fallback == %{requested: "vjt", registered: "vjt_"}
       assert attrs.body =~ "vjt"
       assert attrs.body =~ "vjt_"
+    end
+
+    # While ghost recovery is in flight the underscore is a move we are
+    # already undoing, not a fact. The row is an ADVISORY with no retraction
+    # — emitted now, it outlives the collision and sits there false forever.
+    # Park it and let the recovery's outcome decide; Session.Server owns the
+    # release.
+    test "a live ghost recovery parks the row instead of announcing it" do
+      state = base_state(%{nick: "vjt", ghost_recovery: %GhostRecovery{phase: :awaiting_ghost_notice}})
+      m = msg({:numeric, 1}, ["vjt_", "Welcome to IRC"], {:server, "irc.test.org"})
+
+      assert {:cont, new_state, []} = EventRouter.route(m, state)
+      assert new_state.nick == "vjt_"
+
+      assert {:persist, :server_event, attrs} = new_state.parked_nick_fallback
+      assert attrs.channel == "$server"
+      assert attrs.meta.nick_fallback == %{requested: "vjt", registered: "vjt_"}
+
+      # The sender only exists on the 001 message, which is exactly why the
+      # BUILT effect is what gets parked rather than the facts to rebuild it.
+      assert attrs.sender == "irc.test.org"
     end
 
     # A pure case difference is the ircd normalising, not a collision — the

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -8077,6 +8077,113 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    # #676 h14 — the fallback advisory must wait for the recovery to settle.
+    # Announcing at 001 names an underscore the recovery is in the middle of
+    # undoing, and the row has no retraction: it stays, false, forever.
+    #
+    # Both failure terminals are asserted because they are genuinely two
+    # doors. `advance_ghost/2` is the obvious one; the 8s `:ghost_timeout`
+    # clears the FSM on its own and is the likeliest real failure — NickServ
+    # simply never answers. A release wired to one door goes silent on the
+    # other, which is the accident #676 exists to prevent.
+    defp ghosting_session(nick) do
+      {server, port} = start_server(ghost_handler(nick))
+      {anon_visitor, network} = visitor_with_network(port, nick: nick)
+      {:ok, _} = Grappa.Visitors.commit_password(anon_visitor.id, network.id, "s3cret")
+      visitor = Grappa.Repo.reload!(anon_visitor)
+
+      pid = start_visitor_session_for(visitor, network)
+      {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "NICK #{nick}_\r\n"), 1_000)
+
+      {:ok, _} =
+        IRCServer.wait_for_line(server, &(&1 == "PRIVMSG NickServ :GHOST #{nick} s3cret\r\n"), 1_000)
+
+      # The handler answers the underscore NICK with 001, and the parking
+      # happens on THAT message. Its arm ends in a `MODE <welcomed_nick>`
+      # umode query, so seeing that line on the wire is the barrier proving
+      # the 001 was processed — without it a test can race ahead and clear
+      # the ghost before there is anything parked to release.
+      {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "MODE #{nick}_\r\n"), 1_000)
+
+      %{server: server, pid: pid, visitor: visitor, network: network, nick: nick}
+    end
+
+    # `IRCServer.feed/2` is async: a PING round-trip is the barrier proving
+    # the Session drained the fed line before state is read.
+    defp flush(server, tag) do
+      IRCServer.feed(server, "PING :#{tag}\r\n")
+      {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "PONG :#{tag}\r\n"), 1_000)
+      :ok
+    end
+
+    defp nick_fallback_rows(ctx) do
+      {:visitor, ctx.visitor.id}
+      |> Scrollback.fetch(ctx.network.id, "$server", nil, 50, nil, false)
+      |> Enum.filter(&is_map_key(&1.meta || %{}, :nick_fallback))
+    end
+
+    test "ghost recovery that gets the nick back announces nothing" do
+      ctx = ghosting_session("v_t18p_#{System.unique_integer([:positive])}")
+      nick = ctx.nick
+
+      IRCServer.feed(
+        ctx.server,
+        ":NickServ!services@services.azzurra.org NOTICE #{nick}_ :#{nick} has been ghosted.\r\n"
+      )
+
+      {:ok, _} = IRCServer.wait_for_line(ctx.server, &(&1 == "WHOIS #{nick}\r\n"), 1_000)
+
+      IRCServer.feed(ctx.server, ":server 401 #{nick}_ #{nick} :No such nick\r\n")
+      {:ok, _} = IRCServer.wait_for_line(ctx.server, &(&1 == "NICK #{nick}\r\n"), 1_000)
+      :ok = flush(ctx.server, "succeeded")
+
+      state = SessionStateHelpers.fetch(ctx.pid)
+      assert is_nil(SessionStateHelpers.ghost_recovery(state))
+      assert nick_fallback_rows(ctx) == []
+
+      :ok = GenServer.stop(ctx.pid, :normal, 1_000)
+    end
+
+    test "ghost recovery that loses the nick announces the fallback it kept" do
+      ctx = ghosting_session("v_t18f_#{System.unique_integer([:positive])}")
+      nick = ctx.nick
+
+      IRCServer.feed(
+        ctx.server,
+        ":NickServ!services@services.azzurra.org NOTICE #{nick}_ :#{nick} has been ghosted.\r\n"
+      )
+
+      {:ok, _} = IRCServer.wait_for_line(ctx.server, &(&1 == "WHOIS #{nick}\r\n"), 1_000)
+
+      # 311: the original nick is STILL there, so the ghost did not take and
+      # the underscore is what the user is stuck with.
+      IRCServer.feed(ctx.server, ":server 311 #{nick}_ #{nick} u h * :real\r\n")
+      :ok = flush(ctx.server, "failed")
+
+      state = SessionStateHelpers.fetch(ctx.pid)
+      assert is_nil(SessionStateHelpers.ghost_recovery(state))
+
+      assert [row] = nick_fallback_rows(ctx)
+      assert row.meta[:nick_fallback] == %{"requested" => nick, "registered" => "#{nick}_"}
+
+      :ok = GenServer.stop(ctx.pid, :normal, 1_000)
+    end
+
+    test "ghost recovery that times out announces the fallback too" do
+      ctx = ghosting_session("v_t18x_#{System.unique_integer([:positive])}")
+      nick = ctx.nick
+
+      send(ctx.pid, :ghost_timeout)
+
+      state = SessionStateHelpers.fetch(ctx.pid)
+      assert is_nil(SessionStateHelpers.ghost_recovery(state))
+
+      assert [row] = nick_fallback_rows(ctx)
+      assert row.meta[:nick_fallback] == %{"requested" => nick, "registered" => "#{nick}_"}
+
+      :ok = GenServer.stop(ctx.pid, :normal, 1_000)
+    end
+
     test "non-NickServ NOTICE during :awaiting_ghost_notice does NOT advance the FSM" do
       nick = "v_t18n_#{System.unique_integer([:positive])}"
 


### PR DESCRIPTION
h14 from the #741 auth review, on its own branch because it is session hot path and has nothing to do with the auth surface in #770.

Two commits. The second is the finding; the first is a bug found while testing it, and without it the second would have been decoration.

## The advisory never reached the database

`meta.nick_fallback` was never added to `Scrollback.Meta`'s `@known_keys`. Every #676 advisory row failed the cast and landed in the `scrollback insert failed — session continues` arm, so the message the issue exists to deliver has been silently dropped since it shipped.

Nothing caught it because the only test asserts the effect `EventRouter` **emits** and stops there — the row's journey after that was untested, and the persist failure is deliberately non-fatal, so no session ever crashed over it. It surfaced only because the h14 test asserts against real scrollback instead of against the effect tuple. The new cast/load test goes through the type rather than past it.

## The advisory fires mid-undo and never retracts

A registered visitor whose nick is taken gets `NICK vjt_` and a GHOST in the same breath, so 001 arrives as `vjt_` while `state.nick` is still `vjt` and the row fires: *"nick vjt was taken — you are registered as vjt_"*. Ghost recovery then usually **wins**, takes the nick back, and the row stays behind asserting something that stopped being true seconds later. It is an advisory with no retraction, so it is wrong forever.

The effect built at 001 is now parked on session state while a ghost is in flight, and the outcome decides: dropped when the nick comes back, released when it does not.

**Parked as the built effect, not as the facts to rebuild it.** The `sender` is the upstream server name and it exists only on that 001 message. Putting it on session state, or on the FSM, duplicates something the message already holds — and `GhostRecovery` has no business knowing about scrollback rows.

**Released at BOTH failure terminals.** This is the part worth reviewing. `advance_ghost/2` is the obvious door; `handle_info(:ghost_timeout, ...)` clears the FSM on its own and is the likeliest failure in the field, since it is what fires when NickServ simply never answers. A release wired only to the FSM would have gone silent exactly when the underscore is most likely to be permanent — the accident #676 exists to prevent, reintroduced by the fix for it. Both doors have a test, plus one for the success path asserting no row at all.

The row is stamped at the terminal rather than at 001: it records that the fallback is now permanent, which is decided there, and a connect-time stamp would sort it above the recovery's own `$server` chatter on reload while a live client had appended it below.

## Gates

Full `scripts/check.sh` **rc=0** — 5012 tests / 0 failures, dialyzer `Total errors: 0`, credo strict / sobelow / doctor / format clean, `wireTypes.ts` in sync, 262/262 bats. No wire change, so no cic lane.