### PR TITLE
Apply a deploy that landed while nobody was looking (#674)

### DIFF
--- a/cicchetto/src/__tests__/staleResume.test.ts
+++ b/cicchetto/src/__tests__/staleResume.test.ts
@@ -1,6 +1,9 @@
 import { createRoot, createSignal } from "solid-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  BUNDLE_REFRESH_MINUTES_KEY,
+  bundleRefreshDwellMs,
+  DEFAULT_BUNDLE_REFRESH_MINUTES,
   DEFAULT_STALE_RESUME_HOURS,
   installStaleResumeReload,
   isStaleResume,
@@ -8,6 +11,7 @@ import {
   readLastActive,
   STALE_RESUME_HOURS_KEY,
   STALE_RESUME_STAMP_KEY,
+  shouldAutoRefreshBundle,
   staleResumeThresholdMs,
 } from "../lib/staleResume";
 
@@ -20,6 +24,7 @@ import {
 // the threshold, the implementation would be measuring the wrong thing.
 
 const HOUR = 3_600_000;
+const MINUTE = 60_000;
 
 // setupTests.ts installs a fresh localStorage per test but leaves jsdom's
 // sessionStorage — where the stamp lives — untouched, so it would bleed the
@@ -39,6 +44,10 @@ interface Harness {
   // the #318 foreground heartbeat.
   heartbeatTick: () => void;
   setNow: (t: number) => void;
+  // #674 — the bundle-hash mismatch predicate (`shouldShowRefreshBanner` in
+  // production). Flipping it mid-test is how a case models the on-rejoin
+  // `bundle_hash` push landing AFTER the resume that observed the absence.
+  setMismatch: (v: boolean) => void;
   reload: ReturnType<typeof vi.fn>;
   dispose: () => void;
 }
@@ -47,6 +56,7 @@ function install(startNow: number): Harness {
   let now = startNow;
   const reload = vi.fn();
   const [isVisible, setVisible] = createSignal(true);
+  const [bundleMismatch, setBundleMismatch] = createSignal(false);
   const handlers: Array<() => void> = [];
   let dispose = (): void => {};
   let check = (): void => {};
@@ -54,6 +64,7 @@ function install(startNow: number): Harness {
     dispose = d;
     check = installStaleResumeReload({
       isVisible,
+      bundleMismatch,
       now: () => now,
       reload,
       win: {
@@ -72,6 +83,7 @@ function install(startNow: number): Harness {
     setNow: (t: number) => {
       now = t;
     },
+    setMismatch: setBundleMismatch,
     reload,
     dispose,
   };
@@ -277,6 +289,232 @@ describe("installStaleResumeReload", () => {
     await flush();
     h.setNow(t0 + 7 * HOUR);
     h.visible(true);
+    await flush();
+    expect(h.reload).toHaveBeenCalledTimes(1);
+    h.dispose();
+  });
+});
+
+describe("bundleRefreshDwellMs — the #674 knob", () => {
+  // A knob of its OWN. The server's auto-away debounce happens to start at the
+  // same 10 minutes, but the two answer different questions ("should your peers
+  // be told you are away" vs "may I throw this document away") and #348 may make
+  // the server one user-configurable. Never derive one from the other.
+  it("defaults to 10 minutes", () => {
+    expect(DEFAULT_BUNDLE_REFRESH_MINUTES).toBe(10);
+    expect(bundleRefreshDwellMs()).toBe(10 * MINUTE);
+  });
+
+  it("is independent of the 48h stale-resume threshold", () => {
+    localStorage.setItem(STALE_RESUME_HOURS_KEY, "6");
+    expect(bundleRefreshDwellMs()).toBe(DEFAULT_BUNDLE_REFRESH_MINUTES * MINUTE);
+  });
+
+  it("honours a stored override", () => {
+    localStorage.setItem(BUNDLE_REFRESH_MINUTES_KEY, "30");
+    expect(bundleRefreshDwellMs()).toBe(30 * MINUTE);
+  });
+
+  it("falls back to the default on a non-numeric or non-positive override", () => {
+    localStorage.setItem(BUNDLE_REFRESH_MINUTES_KEY, "soon");
+    expect(bundleRefreshDwellMs()).toBe(DEFAULT_BUNDLE_REFRESH_MINUTES * MINUTE);
+    localStorage.setItem(BUNDLE_REFRESH_MINUTES_KEY, "0");
+    expect(bundleRefreshDwellMs()).toBe(DEFAULT_BUNDLE_REFRESH_MINUTES * MINUTE);
+    localStorage.setItem(BUNDLE_REFRESH_MINUTES_KEY, "-5");
+    expect(bundleRefreshDwellMs()).toBe(DEFAULT_BUNDLE_REFRESH_MINUTES * MINUTE);
+  });
+});
+
+describe("shouldAutoRefreshBundle — the decision", () => {
+  const dwell = 10 * MINUTE;
+
+  it("is false with no mismatch, however long the gap", () => {
+    expect(shouldAutoRefreshBundle(48 * HOUR, dwell, false)).toBe(false);
+  });
+
+  it("is false under and exactly at the dwell", () => {
+    expect(shouldAutoRefreshBundle(9 * MINUTE, dwell, true)).toBe(false);
+    expect(shouldAutoRefreshBundle(dwell, dwell, true)).toBe(false);
+  });
+
+  it("is true over the dwell with a mismatch", () => {
+    expect(shouldAutoRefreshBundle(dwell + 1, dwell, true)).toBe(true);
+  });
+});
+
+describe("installStaleResumeReload — #674 bundle auto-refresh", () => {
+  const t0 = 1_700_000_000_000;
+
+  // THE regression this branch exists for. `bundle_hash` rides the user-topic
+  // JOIN, so on resume it lands a rejoin later than the visibility transition
+  // that observed the absence — by which time `check` has already refreshed the
+  // stamp and `now - lastActive` reads ~0. A verdict computed at hash-arrival
+  // time would therefore be false forever, and the feature would never fire for
+  // its single most common case: the operator deployed while you were away.
+  it("reloads on a mismatch that arrives AFTER the resume, judged on the gap at the resume", async () => {
+    const h = install(t0);
+    await flush();
+    h.visible(false);
+    await flush();
+    h.setNow(t0 + 20 * MINUTE);
+    h.visible(true);
+    await flush();
+    // The resume itself saw no mismatch — the socket has not rejoined yet.
+    expect(h.reload).not.toHaveBeenCalled();
+    // The stamp has already been refreshed, so a re-derived gap would be ~0.
+    expect(readLastActive()).toBe(t0 + 20 * MINUTE);
+    // Rejoin completes and the server advertises the new bundle.
+    h.setMismatch(true);
+    await flush();
+    expect(h.reload).toHaveBeenCalledTimes(1);
+    h.dispose();
+  });
+
+  it("does not reload when the mismatch arrives after a SHORT absence — the banner keeps that case", async () => {
+    const h = install(t0);
+    await flush();
+    h.visible(false);
+    await flush();
+    h.setNow(t0 + 30_000);
+    h.visible(true);
+    await flush();
+    h.setMismatch(true);
+    await flush();
+    expect(h.reload).not.toHaveBeenCalled();
+    h.dispose();
+  });
+
+  it("reloads when a long absence ends and the mismatch was already known", async () => {
+    const h = install(t0);
+    await flush();
+    h.setMismatch(true);
+    await flush();
+    expect(h.reload).not.toHaveBeenCalled();
+    h.visible(false);
+    await flush();
+    h.setNow(t0 + 20 * MINUTE);
+    h.visible(true);
+    await flush();
+    expect(h.reload).toHaveBeenCalledTimes(1);
+    h.dispose();
+  });
+
+  it("never reloads while genuinely foreground — the heartbeat keeps the gap short", async () => {
+    const h = install(t0);
+    await flush();
+    h.setMismatch(true);
+    await flush();
+    // Six hours of continuous foreground use, one #318 tick every 30s.
+    for (let i = 1; i <= 720; i++) {
+      h.setNow(t0 + i * 30_000);
+      h.heartbeatTick();
+    }
+    await flush();
+    expect(h.reload).not.toHaveBeenCalled();
+    h.dispose();
+  });
+
+  it("fires once per absence, not once per trigger", async () => {
+    const h = install(t0);
+    await flush();
+    h.visible(false);
+    await flush();
+    h.setNow(t0 + 20 * MINUTE);
+    h.visible(true);
+    h.setMismatch(true);
+    await flush();
+    expect(h.reload).toHaveBeenCalledTimes(1);
+    h.pageshow();
+    h.visible(false);
+    await flush();
+    h.visible(true);
+    await flush();
+    expect(h.reload).toHaveBeenCalledTimes(1);
+    h.dispose();
+  });
+
+  // Constraint: no boolean latch, and no loop. A reload that never lands leaves
+  // the document healthy — the next check overwrites the captured gap with a
+  // short one and the dwell simply stops being satisfied.
+  it("self-closes after a reload that never landed, without a latch", async () => {
+    const h = install(t0);
+    await flush();
+    h.visible(false);
+    await flush();
+    h.setNow(t0 + 20 * MINUTE);
+    h.visible(true);
+    h.setMismatch(true);
+    await flush();
+    expect(h.reload).toHaveBeenCalledTimes(1);
+    // Navigation was blocked; this document lives on in the foreground.
+    h.setNow(t0 + 21 * MINUTE);
+    h.heartbeatTick();
+    await flush();
+    expect(h.reload).toHaveBeenCalledTimes(1);
+    // And a LATER genuine absence still trips — the feature is not disabled.
+    h.visible(false);
+    await flush();
+    h.setNow(t0 + 45 * MINUTE);
+    h.visible(true);
+    await flush();
+    expect(h.reload).toHaveBeenCalledTimes(2);
+    h.dispose();
+  });
+
+  // Constraint: a broken network must not be able to loop. No rejoin means no
+  // `bundle_hash`, so the mismatch predicate stays false and nothing fires —
+  // while the stamp keeps advancing, so the 48h branch cannot accumulate either.
+  it("cannot loop on a broken network — no mismatch, no reload, stamp still advancing", async () => {
+    const h = install(t0);
+    await flush();
+    for (let i = 1; i <= 5; i++) {
+      h.visible(false);
+      await flush();
+      h.setNow(t0 + i * 20 * MINUTE);
+      h.visible(true);
+      await flush();
+    }
+    expect(h.reload).not.toHaveBeenCalled();
+    expect(readLastActive()).toBe(t0 + 5 * 20 * MINUTE);
+    h.dispose();
+  });
+
+  // Constraint: the stamp is written unconditionally, even when the
+  // discriminant is unavailable. Withholding it would starve the 48h branch.
+  it("stamps on every check even with the discriminant unavailable", async () => {
+    const h = install(t0);
+    await flush();
+    h.visible(false);
+    await flush();
+    h.setNow(t0 + 20 * MINUTE);
+    h.visible(true);
+    await flush();
+    expect(readLastActive()).toBe(t0 + 20 * MINUTE);
+    h.dispose();
+  });
+
+  // Constraint: the two branches stay independent.
+  it("the 48h branch fires without consulting the bundle mismatch", async () => {
+    const h = install(t0);
+    await flush();
+    h.visible(false);
+    await flush();
+    h.setNow(t0 + 50 * HOUR);
+    h.visible(true);
+    await flush();
+    expect(h.reload).toHaveBeenCalledTimes(1);
+    h.dispose();
+  });
+
+  it("the bundle branch fires without consulting the staleness threshold", async () => {
+    localStorage.setItem(STALE_RESUME_HOURS_KEY, "9000");
+    const h = install(t0);
+    await flush();
+    h.visible(false);
+    await flush();
+    h.setNow(t0 + 20 * MINUTE);
+    h.visible(true);
+    h.setMismatch(true);
     await flush();
     expect(h.reload).toHaveBeenCalledTimes(1);
     h.dispose();

--- a/cicchetto/src/lib/staleResume.ts
+++ b/cicchetto/src/lib/staleResume.ts
@@ -1,14 +1,26 @@
-import { type Accessor, createEffect } from "solid-js";
+import { type Accessor, createEffect, createSignal } from "solid-js";
 
-// #695 — reload the whole client on resume after a prolonged absence.
+// Resume-time reload decisions. TWO independent reasons to throw the document
+// away, sharing one resume check, one stamp and one reload verb.
 //
-// A long-lived PWA document degrades ("Safari goes mad after a while"), so a
-// document iOS suspended for two days is worth throwing away rather than
-// resuming. Deliberately independent of the bundle-hash refresh (#674): that
-// one fires on a deploy, this one on elapsed inactivity whether or not a new
-// bundle exists. Both reach the SAME reload verb — `bundleHash.performRefresh`
-// — because a second reload path beside it would be a second consumer of the
-// same SW/cache dance (the three-presses-to-update bug it exists to fix).
+// #695 — a prolonged ABSENCE. A long-lived PWA document degrades ("Safari goes
+// mad after a while"), so a document iOS suspended for two days is worth
+// throwing away rather than resuming. Fires on elapsed inactivity whether or
+// not a new bundle exists.
+//
+// #674 — a DEPLOY landed while nobody was looking. The service worker already
+// installs the new bundle silently, but the open page keeps executing the JS it
+// booted with, so a long-lived PWA session runs old code indefinitely. When the
+// operator has been away long enough that a reload cannot eat anything they
+// were mid-way through, apply it without asking; otherwise the #674 refresh
+// banner keeps the case and the operator owns the timing.
+//
+// The two branches are INDEPENDENT: the absence branch never consults the
+// bundle hash, and the deploy branch never consults the staleness threshold.
+// They share only the check, the stamp and `deps.reload` — which is
+// `bundleHash.performRefresh`, because a second reload path beside it would be
+// a second consumer of the same SW/cache dance (the three-presses-to-update bug
+// it exists to fix).
 //
 // The interval is measured from a PERSISTED stamp, never from in-memory state
 // or a timer. That is the whole point: the document may have been frozen for
@@ -35,17 +47,57 @@ import { type Accessor, createEffect } from "solid-js";
 // trigger, so the document that just reloaded cannot immediately reload on
 // the absence it was itself the answer to.
 //
-// Threshold: 48h by default (24h was considered and rejected as too eager),
-// overridable per device via `localStorage["cicchetto.staleResumeHours"]` so
-// the number can be tuned without a deploy-shaped argument. An absent,
-// non-numeric or non-positive override falls back to the default — a typo
-// must never turn into "reload on every resume".
+// THE #674 INVARIANT — the dwell verdict is judged on the gap AT THE RESUME.
+//
+// `bundle_hash` rides the user-topic JOIN, so on resume it lands a rejoin after
+// the visibility transition that observed the absence. By then `check` has
+// already refreshed the stamp and `now - lastActive` reads ~0, so a verdict
+// re-derived at hash-arrival time would be false forever and the branch would
+// never fire for its most common case — the operator deployed while you were
+// away. `check` therefore READS the gap before `markActive` destroys it and
+// carries it to the decision. The carry is not a parallel structure: the stamp
+// overwrites the gap by construction, so this is its only surviving copy, it
+// has exactly one writer, and every check overwrites it — which is also what
+// closes the window, with no boolean latch to wedge the document.
+//
+// Withholding the stamp until the discriminant arrives was considered and
+// REJECTED: it breaks #695's "every check stamps" rule (the absence branch
+// would re-fire on every trigger), it couples a branch to a value it does not
+// consume, and on a broken network — where `bundle_hash` never arrives at all —
+// the stamp would never advance and the absence branch would loop.
+//
+// Thresholds: 48h for the absence (24h was considered and rejected as too
+// eager), 10 minutes for the deploy dwell. TWO KNOBS, never derived from one
+// another and never from the server's `@auto_away_debounce_ms`, which happens
+// to start at the same 10 minutes but answers a different question ("should
+// your peers be told you are away" vs "may I throw this document away"); #348
+// may yet make the server one user-configurable. Both are overridable per
+// device via localStorage so a number can be tuned without a deploy-shaped
+// argument. An absent, non-numeric or non-positive override falls back to the
+// default — a typo must never turn into "reload on every resume".
 
 export const STALE_RESUME_STAMP_KEY = "cicchetto.lastActiveAt";
 export const STALE_RESUME_HOURS_KEY = "cicchetto.staleResumeHours";
 export const DEFAULT_STALE_RESUME_HOURS = 48;
 
+export const BUNDLE_REFRESH_MINUTES_KEY = "cicchetto.bundleRefreshMinutes";
+export const DEFAULT_BUNDLE_REFRESH_MINUTES = 10;
+
 const MS_PER_HOUR = 3_600_000;
+const MS_PER_MINUTE = 60_000;
+
+/**
+ * A stored positive-number override, else `fallback`.
+ *
+ * Shared by both knobs so the "absent / non-numeric / non-positive → default"
+ * posture cannot drift between them. It does NOT make one derive from the
+ * other: they keep distinct keys, defaults and units.
+ */
+function positiveOverride(key: string, fallback: number): number {
+  const raw = localStorage.getItem(key);
+  const parsed = raw === null ? Number.NaN : Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 // The `pageshow` seam. Narrow on purpose: `installStaleResumeReload` has no
 // uninstall path (a real listener outlives its test), so unit tests pass a
@@ -60,6 +112,11 @@ export interface StaleResumeDeps {
   // window focus/blur). Consumed as a signal rather than re-registering
   // parallel listeners.
   isVisible: Accessor<boolean>;
+  // #674 — does the running page differ from the deployed bundle?
+  // `bundleHash.shouldShowRefreshBanner` in production. Injected rather than
+  // imported so this module stays free of the bundle-hash singletons and
+  // testable against a plain signal.
+  bundleMismatch: Accessor<boolean>;
   now: () => number;
   reload: () => void;
   win: ResumeWindowLike;
@@ -67,10 +124,14 @@ export interface StaleResumeDeps {
 
 /** The effective inactivity threshold in ms — the stored override, else 48h. */
 export function staleResumeThresholdMs(): number {
-  const raw = localStorage.getItem(STALE_RESUME_HOURS_KEY);
-  const hours = raw === null ? Number.NaN : Number(raw);
-  const effective = Number.isFinite(hours) && hours > 0 ? hours : DEFAULT_STALE_RESUME_HOURS;
-  return effective * MS_PER_HOUR;
+  return positiveOverride(STALE_RESUME_HOURS_KEY, DEFAULT_STALE_RESUME_HOURS) * MS_PER_HOUR;
+}
+
+/** The effective deploy-refresh dwell in ms — the stored override, else 10min. */
+export function bundleRefreshDwellMs(): number {
+  return (
+    positiveOverride(BUNDLE_REFRESH_MINUTES_KEY, DEFAULT_BUNDLE_REFRESH_MINUTES) * MS_PER_MINUTE
+  );
 }
 
 /** Record that this document was alive at `now`. */
@@ -101,6 +162,26 @@ export function isStaleResume(
 }
 
 /**
+ * Is a deploy worth applying without asking?
+ *
+ * Takes the already-measured gap rather than `(now, lastActive)` like its
+ * sibling above — deliberately. This decision is reached when the mismatch
+ * becomes knowable, which is AFTER the stamp was refreshed, so there is no
+ * honest `now - lastActive` left to compute. See the #674 invariant in the
+ * module header.
+ *
+ * Strictly greater than the dwell, and false without a mismatch however long
+ * the absence.
+ */
+export function shouldAutoRefreshBundle(
+  resumeGapMs: number,
+  dwellMs: number,
+  mismatch: boolean,
+): boolean {
+  return mismatch && resumeGapMs > dwellMs;
+}
+
+/**
  * Arm the stale-resume reload and return the check verb.
  *
  * Checks on every resume trigger: the visibility signal (tab switch,
@@ -117,9 +198,19 @@ export function isStaleResume(
  * refreshed, exactly as #649 argues for its three viewport resume triggers.
  */
 export function installStaleResumeReload(deps: StaleResumeDeps): () => void {
+  // The gap this check observed, carried to the #674 decision because
+  // `markActive` below is about to destroy it. Overwritten by every check, so
+  // a foreground heartbeat tick closes the window on its own.
+  const [resumeGapMs, setResumeGapMs] = createSignal(0);
+
   const check = (): void => {
     const now = deps.now();
-    const stale = isStaleResume(now, readLastActive(), staleResumeThresholdMs());
+    const lastActive = readLastActive();
+    // READ before the stamp overwrites it — the #674 invariant. Clamped at 0
+    // so a backwards clock step cannot manufacture an absence, mirroring
+    // `isStaleResume`'s future-dated-stamp posture.
+    setResumeGapMs(lastActive === null ? 0 : Math.max(0, now - lastActive));
+    const stale = isStaleResume(now, lastActive, staleResumeThresholdMs());
     // Stamp FIRST, unconditionally: this is what makes the reload fire once
     // per absence rather than once per trigger.
     markActive(now);
@@ -136,6 +227,17 @@ export function installStaleResumeReload(deps: StaleResumeDeps): () => void {
     // baseline than the last heartbeat tick.
     deps.isVisible();
     check();
+  });
+
+  // #674 — re-decided whenever EITHER input moves: the mismatch becoming known
+  // after a long resume (the common case: deployed while you were away), or a
+  // fresh long gap arriving while a mismatch was already known (the banner was
+  // up, you left, you came back). Both are read unconditionally so Solid tracks
+  // both every run — a short-circuit here would silently drop the second case.
+  createEffect(() => {
+    const mismatch = deps.bundleMismatch();
+    const gap = resumeGapMs();
+    if (shouldAutoRefreshBundle(gap, bundleRefreshDwellMs(), mismatch)) deps.reload();
   });
 
   return check;

--- a/cicchetto/src/main.tsx
+++ b/cicchetto/src/main.tsx
@@ -16,7 +16,7 @@ import "./lib/subscribe";
 import "./lib/userTopic";
 import { isDiagEnabled } from "./DiagFloat";
 import { mountBadgeReconcile, mountBadgeSync } from "./lib/badge";
-import { performRefresh } from "./lib/bundleHash";
+import { performRefresh, shouldShowRefreshBanner } from "./lib/bundleHash";
 import { applyCachedCustomTheme, mountCustomThemeSync } from "./lib/customTheme";
 import { diagPush } from "./lib/diagLog";
 import { mountDisplayPrefsSync } from "./lib/displayPrefs";
@@ -245,9 +245,16 @@ window.addEventListener("beforeunload", notifyClientClosing);
 // frozen with the document and its first tick after the thaw is the only
 // trigger that can observe the absence at all. A tick that stamped without
 // checking would erase the evidence instead of acting on it.
+// #674 — the same check also applies a DEPLOY that landed while nobody was
+// looking, gated on a 10-minute dwell of its own. `shouldShowRefreshBanner` is
+// the discriminant; below the dwell the refresh banner keeps the case and the
+// operator owns the timing. Because that same heartbeat re-stamps every 30s
+// while genuinely foreground, "the stamp is old" IS "the document was not
+// visible" — the dwell needs no second visibility read.
 createRoot(() => {
   const checkStaleResume = installStaleResumeReload({
     isVisible: isDocumentVisible,
+    bundleMismatch: shouldShowRefreshBanner,
     now: () => Date.now(),
     reload: () => void performRefresh(),
     win: window,

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -27365,3 +27365,73 @@ success depended on services re-emitting `+r` after a foreign-nick IDENTIFY
 that the code believed was the thing committing it. Trace the wire before
 theorising about a flake, and when a spec cannot be re-run in place, fix that
 FIRST — the triage discipline is worthless against a spec that only runs once.
+
+## 2026-08-03 — #674: a deploy applies itself when the gap at the resume says nobody was there
+
+`registerType: "autoUpdate"` already installs a new bundle silently, but it
+never touches the page that is already open: a long-lived PWA session keeps
+executing the JS it booted with, indefinitely. Detection was live already
+(`bootBundleHash` vs the `serverBundleHash` pushed on user-topic join);
+application was the one deliberately manual step, because a blind
+`location.reload()` on deploy trades a minor annoyance for lost work at exactly
+the moment an operator is shipping.
+
+**The gate is local, not the away status.** Two earlier rulings on the issue —
+gate on IRC auto-away, and gate on compose focus + draft emptiness — were both
+withdrawn. Away and auto-refresh are two consequences of ONE cause ("the user
+is not at this client"), so the client-side concern reads the cause directly:
+`documentVisibility.ts`, already `visibilityState === "visible" &&
+document.hasFocus()` and already the SSOT for live-cursor gating. No wire
+change, no server round-trip, no dependency on #694 (closed as superseded) or
+the auto-away fixes behind it. It also covers the case the away gate was
+invented for — someone who typed `/away` by hand and is still sitting there —
+better than the away gate did, because window focus says so directly.
+
+**The dwell is derived from the #695 stamp, not stored again.** The #318
+heartbeat re-stamps every 30s while genuinely foreground and STOPS when the
+document goes hidden, so "the stamp is older than the dwell" already MEANS "the
+document was not visible for that long". No second timestamp, no extra
+listener, no visibility read inside the branch.
+
+**THE INVARIANT: the dwell verdict is judged on the gap AT THE RESUME.** This
+is the whole design and the naive shape gets it wrong. `bundle_hash` rides the
+user-topic JOIN, so on resume it lands a rejoin AFTER the visibility transition
+that observed the absence — by which time `check` has refreshed the stamp and
+`now - lastActive` reads ~0. A verdict computed when the hash arrives is
+therefore false forever, and the feature never fires for its single most common
+case: the operator deployed while you were away. So `check` READS the gap before
+`markActive` destroys it and carries it to the decision.
+
+The carry is not a parallel structure: the stamp overwrites the gap by
+construction, so the captured number is its only surviving copy, it has exactly
+one writer, and every check overwrites it. That overwrite is also what closes
+the window — a reload that never lands is followed 30s later by a heartbeat tick
+that resets the gap to ~30s, so the dwell simply stops being satisfied. No
+boolean latch, which #695 had already rejected for wedging the document.
+
+**Rejected: withhold the stamp until the discriminant is available.** Proposed
+as the way to avoid the carry, and it fails three ways. It breaks #695's "every
+check stamps" rule, so the 48h absence branch re-fires on every trigger. It
+couples that branch to a value it does not consume. And on a broken network,
+where `bundle_hash` never arrives at all, the stamp never advances, the measured
+gap grows without bound and the absence branch loops — the failure appears only
+once the network is already broken.
+
+**Two knobs, never one.** 48h for the absence, 10 minutes for the deploy dwell,
+sharing only the "absent / non-numeric / non-positive → default" validation. The
+server's `@auto_away_debounce_ms` happens to start at the same 10 minutes and is
+deliberately NOT read: it answers "should your peers be told you are away", not
+"may I throw this document away", and #348 may yet make it user-configurable — a
+user tuning their away grace must not silently retune when their client reloads.
+
+**Below the dwell the banner keeps the case, unchanged.** The operator is right
+there and owns the timing.
+
+**Still open, product call:** whether an applied auto-refresh should announce
+itself afterwards (a transient "updated to vX"), so the operator is not left
+wondering why the scrollback jumped. Not built.
+
+**Known, filed separately:** compose drafts live in `identityScopedStore`
+signals with no storage backing, so every reload already discards them — the
+manual banner click included. Auto-refresh makes that pre-existing loss easier
+to hit rather than introducing it.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -27427,9 +27427,31 @@ user tuning their away grace must not silently retune when their client reloads.
 **Below the dwell the banner keeps the case, unchanged.** The operator is right
 there and owns the timing.
 
-**Still open, product call:** whether an applied auto-refresh should announce
-itself afterwards (a transient "updated to vX"), so the operator is not left
-wondering why the scrollback jumped. Not built.
+**Decided, and the answer is nothing (owner, 2026-08-03).** The question was
+whether an applied auto-refresh should announce itself afterwards. A persistent
+banner is out — it would hand the operator something to close, which is the
+annoyance this feature exists to remove. A toast would have to be
+self-expiring, and only if that were cheap.
+
+It is not cheap, so nothing ships. The only self-expiring toast surface is
+#247's, and its queue lives inside `notifyWatch.ts` as
+`PresenceToast = transition | error`, each variant carrying `networkId` /
+`nick` / `presence` / `detail`, cleared on identity switch alongside the watch
+list. Adding a `bundle` variant is precisely the "shared data model with a type
+flag" this file forbids: the update notice would live in the /notify module,
+where nobody will look for it, and would vanish on an identity switch for
+reasons that have nothing to do with bundles. The clean route — extract a
+generic toast store and surface, then migrate #247 onto it, since leaving two
+toast systems is the half-migrated state — means reworking shipped, tested code
+to serve a nice-to-have.
+
+Independently of the surface, the notice would also need to survive the reload
+that triggers it: a marker written before `performRefresh` and read-and-cleared
+at boot, with its own way to strand (marker written, navigation declined, a
+stale toast fires later). Two moving parts for a courtesy message.
+
+If a generic toast surface ever lands for another reason, this becomes a
+two-line producer and is worth revisiting. Until then, the reload is silent.
 
 **Known, filed separately:** compose drafts live in `identityScopedStore`
 signals with no storage backing, so every reload already discards them — the

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -27427,31 +27427,41 @@ user tuning their away grace must not silently retune when their client reloads.
 **Below the dwell the banner keeps the case, unchanged.** The operator is right
 there and owns the timing.
 
-**Decided, and the answer is nothing (owner, 2026-08-03).** The question was
-whether an applied auto-refresh should announce itself afterwards. A persistent
-banner is out — it would hand the operator something to close, which is the
-annoyance this feature exists to remove. A toast would have to be
-self-expiring, and only if that were cheap.
+**Decided: this ships silent, the notice is deferred to #775 (owner,
+2026-08-03).** The question was whether an applied auto-refresh should announce
+itself afterwards. A persistent banner is out — it would hand the operator
+something to close, which is the annoyance this feature exists to remove.
+Whatever announces has to auto-dismiss.
 
-It is not cheap, so nothing ships. The only self-expiring toast surface is
-#247's, and its queue lives inside `notifyWatch.ts` as
-`PresenceToast = transition | error`, each variant carrying `networkId` /
-`nick` / `presence` / `detail`, cleared on identity switch alongside the watch
-list. Adding a `bundle` variant is precisely the "shared data model with a type
-flag" this file forbids: the update notice would live in the /notify module,
-where nobody will look for it, and would vanish on an identity switch for
-reasons that have nothing to do with bundles. The clean route — extract a
-generic toast store and surface, then migrate #247 onto it, since leaving two
-toast systems is the half-migrated state — means reworking shipped, tested code
-to serve a nice-to-have.
+**The toast surface is NOT the cost — it is already built and already
+mounted.** `notifyWatch.ts` holds a self-expiring, click-to-dismiss toast
+store; `PresenceToasts.tsx` renders it; `Shell.tsx` mounts it in BOTH layouts
+(`:512` desktop, `:761` mobile), with the expiry timer, the stacking, the
+`role="status"` / `aria-live="polite"` semantics and the CSS all done. Those
+are the expensive parts of a toast and none of them need building. An earlier
+reading of this entry priced them as unpaid; that was wrong.
 
-Independently of the surface, the notice would also need to survive the reload
-that triggers it: a marker written before `performRefresh` and read-and-cleared
-at boot, with its own way to strand (marker written, navigation declined, a
-stale toast fires later). Two moving parts for a courtesy message.
+What stands is the coupling, not the cost. That queue is typed on presence
+semantics — `PresenceToast = transition | error`, each variant carrying
+`networkId` / `nick` / `presence` / `detail`, cleared on identity switch
+alongside the watch list. Adding a `bundle` variant is precisely the "shared
+data model with a type flag" this file forbids: the update notice would live in
+the /notify module, where nobody will look for it, and would vanish on an
+identity switch for reasons that have nothing to do with bundles. So the route
+is the other one — **extract a generic toast store + surface, then migrate
+#247's presence toasts onto it** (reuse the verbs, not the nouns; leaving two
+toast systems is the half-migrated state this file also forbids). That
+extraction is approved.
 
-If a generic toast surface ever lands for another reason, this becomes a
-two-line producer and is worth revisiting. Until then, the reload is silent.
+The genuinely expensive half is the reload. The notice has to survive the
+refresh that causes it: a marker written before `performRefresh`,
+read-and-cleared at boot, with its own way to strand — marker written,
+navigation declined, a stale toast fires later out of context. That is the real
+design work here, and it is why the notice does not ride along with the refresh
+itself.
+
+**Filed as #775**, which owns the extraction, the #247 migration and the
+cross-reload marker. Until it lands, the reload is silent.
 
 **Known, filed separately:** compose drafts live in `identityScopedStore`
 signals with no storage backing, so every reload already discards them — the


### PR DESCRIPTION
## What

`registerType: "autoUpdate"` already installs a new bundle silently, but it
never touches the page that is already open: a long-lived PWA session keeps
executing the JS it booted with, indefinitely. Detection was already live
(`bootBundleHash` vs the `serverBundleHash` pushed on user-topic join);
applying it was the deliberately manual banner click.

This adds a second branch to `installStaleResumeReload` — the #695 resume check
— so a deploy applies itself once the operator has been away long enough that a
reload cannot eat anything they were mid-way through. Below the dwell the
refresh banner keeps the case exactly as it is today.

## The gate is local, not the away status

Two earlier rulings on the issue were withdrawn by the owner: gate on IRC
auto-away, and gate on compose focus + draft emptiness. Away and auto-refresh
are two consequences of ONE cause — the user is not at this client — so the
client-side concern reads the cause directly via `documentVisibility.ts`, which
is already `visibilityState === "visible" && document.hasFocus()` and already
the SSOT for live-cursor gating. No wire change, no server round-trip, no
dependency on #694 (closed as superseded) or the auto-away fixes behind it. It
also covers the manual-`/away`-but-still-sitting-there case better than the away
gate did, because window focus says so directly.

**The dwell is derived, not stored again.** The #318 heartbeat re-stamps every
30s while genuinely foreground and STOPS when the document hides, so "the stamp
is older than the dwell" already MEANS "the document was not visible that long".
No second timestamp, no extra listener, no visibility read inside the branch.

## The invariant: the verdict is judged on the gap AT THE RESUME

This is the whole design, and the naive shape gets it wrong.

`bundle_hash` rides the user-topic JOIN, so on resume it lands a rejoin AFTER
the visibility transition that observed the absence — by which time `check` has
refreshed the stamp and `now - lastActive` reads ~0. A verdict computed when the
hash arrives is therefore false **forever**, and the feature never fires for its
single most common case: the operator deployed while you were away.

So `check` READS the gap before `markActive` destroys it and carries it to the
decision. The carry is not a parallel structure — the stamp overwrites the gap
by construction, so the captured number is its only surviving copy, it has
exactly one writer, and every check overwrites it. That overwrite is also what
closes the window: a reload that never lands is followed 30s later by a
heartbeat tick resetting the gap, so the dwell stops being satisfied. No boolean
latch, which #695 had already rejected for wedging the document.

### Rejected: withhold the stamp until the discriminant is available

Proposed as the way to avoid the carry. It fails three ways, and all three are
pinned by tests:

1. It breaks #695's "every check stamps" rule, so the 48h absence branch
   re-fires on every trigger.
2. It couples that branch to a value it does not consume.
3. On a broken network, where `bundle_hash` never arrives at all, the stamp
   never advances, the measured gap grows without bound and the absence branch
   **loops** — a failure that only appears once the network is already broken.

## Two knobs, never one

48h for the absence, 10 minutes for the deploy dwell, sharing only the
"absent / non-numeric / non-positive → default" validation via
`positiveOverride` (shared execution framework, distinct data — distinct keys,
defaults and units). The server's `@auto_away_debounce_ms` happens to start at
the same 10 minutes and is deliberately NOT read: it answers "should your peers
be told you are away", not "may I throw this document away", and #348 may yet
make it user-configurable — a user tuning their away grace must not silently
retune when their client reloads.

## Test plan

- [x] `staleResume.test.ts` 40/40 (28 pre-existing #695 + 12 new). Written
      RED first: the 12 new cases fail against `main`.
- [x] The regression the branch exists for: mismatch arriving AFTER the resume
      still reloads, judged on the gap at the resume.
- [x] One case per constraint — stamp stays unconditional; the two branches
      stay independent in both directions; no boolean latch (a reload that never
      lands self-closes and a later absence still trips); a broken network
      cannot loop.
- [x] Knob resolution: default 10min, override, non-numeric and non-positive
      fall back, independent of the 48h threshold.
- [x] `tsc --noEmit` rc=0 (run standalone — `check` short-circuits on biome).
- [x] `bun run check` rc=0.
- [x] `bun run test` rc=0 — 217 files / 3949 tests.
- [ ] Device check, vjt's leg: deploy, leave the PWA backgrounded past 10
      minutes, return, confirm the client comes back on the new bundle without
      a banner press — and that a sub-dwell return still shows the banner.

## Notes

- **Open, product call, not built:** whether an applied auto-refresh should
  announce itself afterwards (a transient "updated to vX"), so the operator is
  not left wondering why the scrollback jumped.
- **Filed separately as #772:** compose drafts live in `identityScopedStore`
  signals with no storage backing, so every reload already discards them — the
  manual banner click included. Pre-existing; auto-refresh makes it easier to
  hit rather than introducing it.