### PR TITLE
Measure the resume symptom instead of guessing at it (#697)

### DIFF
--- a/cicchetto/src/__tests__/resumeProbe.test.ts
+++ b/cicchetto/src/__tests__/resumeProbe.test.ts
@@ -1,0 +1,248 @@
+import { createRoot, createSignal } from "solid-js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  entryTypeSupport,
+  formatResumeProbeLine,
+  installResumeProbe,
+  PROBE_WINDOW_MS,
+  type ProbePerformance,
+  summariseFrameGaps,
+} from "../lib/resumeProbe";
+
+// #697 — on-device instrument for "iOS resume leaves the UI unresponsive".
+//
+// The pure parts are exhaustively tested here; the arming is covered only for
+// the contract that matters operationally (off unless diag is on, one summary
+// line per resume, observers disconnected). Whether a real iOS PWA freezes is
+// NOT testable here by construction — that is the whole reason the instrument
+// exists.
+
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+/** The single line the probe emitted. */
+const emitted = (push: ReturnType<typeof vi.fn>): string => String(push.mock.calls[0]?.[0]);
+
+describe("summariseFrameGaps", () => {
+  // samples[0] is the ARM time, so the first gap is resume→first frame — the
+  // interval a frozen document stretches, and the one worth seeing.
+  it("reports frame count, max gap and span", () => {
+    expect(summariseFrameGaps([100, 116, 132, 148])).toEqual({
+      frames: 3,
+      maxGapMs: 16,
+      spanMs: 48,
+    });
+  });
+
+  it("counts the arm→first-frame interval as a gap", () => {
+    expect(summariseFrameGaps([0, 3820, 3836])).toEqual({
+      frames: 2,
+      maxGapMs: 3820,
+      spanMs: 3836,
+    });
+  });
+
+  it("rounds fractional timestamps", () => {
+    const s = summariseFrameGaps([0, 16.4, 33.1]);
+    expect(s.maxGapMs).toBe(17);
+    expect(s.spanMs).toBe(33);
+  });
+
+  it("is empty with no frames at all — a document frozen for the whole window", () => {
+    expect(summariseFrameGaps([1000])).toEqual({ frames: 0, maxGapMs: 0, spanMs: 0 });
+    expect(summariseFrameGaps([])).toEqual({ frames: 0, maxGapMs: 0, spanMs: 0 });
+  });
+});
+
+describe("entryTypeSupport", () => {
+  it("is ok when the engine lists the entry type", () => {
+    expect(entryTypeSupport(["longtask", "event"], "longtask")).toBe("ok");
+  });
+
+  it("is unsupported when the engine omits it", () => {
+    expect(entryTypeSupport(["event"], "longtask")).toBe("unsupported");
+  });
+
+  // WebKit is the target and its support for these is not something to assume.
+  it("is unsupported when the engine exposes no list at all", () => {
+    expect(entryTypeSupport(undefined, "longtask")).toBe("unsupported");
+  });
+});
+
+describe("formatResumeProbeLine", () => {
+  const summary = { frames: 41, maxGapMs: 3820, spanMs: 10000 };
+
+  // THE honesty rule: an absent API and a genuinely quiet observer must not
+  // render the same, or a missing measurement reads as a clean measurement.
+  it("distinguishes an unsupported observer from one that saw nothing", () => {
+    const unsupported = formatResumeProbeLine(
+      summary,
+      { support: "unsupported", count: 0, maxMs: 0 },
+      { support: "ok", count: 0, maxMs: 0 },
+    );
+    expect(unsupported).toContain("longtask:unsupported");
+    expect(unsupported).toContain("input:none");
+    expect(unsupported).not.toContain("longtask:none");
+  });
+
+  it("reports count and max when the observer saw entries", () => {
+    const line = formatResumeProbeLine(
+      summary,
+      { support: "ok", count: 2, maxMs: 3810 },
+      { support: "ok", count: 3, maxMs: 512 },
+    );
+    expect(line).toContain("longtask:2 max=3810ms");
+    expect(line).toContain("input:3 max=512ms");
+  });
+
+  it("leads with the frame summary so the blocked/not-blocked verdict reads first", () => {
+    const line = formatResumeProbeLine(
+      summary,
+      { support: "ok", count: 0, maxMs: 0 },
+      { support: "ok", count: 0, maxMs: 0 },
+    );
+    expect(line.startsWith("resume 10000ms frames=41 maxgap=3820ms")).toBe(true);
+  });
+});
+
+interface Harness {
+  visible: (v: boolean) => void;
+  pageshow: () => void;
+  runFrames: (times: number[]) => void;
+  push: ReturnType<typeof vi.fn>;
+  disconnects: number;
+  dispose: () => void;
+}
+
+function install(opts: { enabled: boolean; supported: readonly string[] | undefined }): Harness {
+  const push = vi.fn();
+  const [isVisible, setVisible] = createSignal(true);
+  const handlers: Array<() => void> = [];
+  let frameCb: ((t: number) => void) | null = null;
+  let now = 0;
+  const state = { disconnects: 0 };
+  const perf: ProbePerformance = {
+    supportedEntryTypes: () => opts.supported,
+    observe: (entryType) => {
+      if (!(opts.supported ?? []).includes(entryType)) return null;
+      return () => {
+        state.disconnects += 1;
+      };
+    },
+  };
+  let dispose = (): void => {};
+  createRoot((d) => {
+    dispose = d;
+    installResumeProbe({
+      isVisible,
+      enabled: () => opts.enabled,
+      push,
+      now: () => now,
+      raf: (cb) => {
+        frameCb = cb;
+      },
+      perf,
+      win: {
+        addEventListener: (_e: "pageshow", h: () => void) => {
+          handlers.push(h);
+        },
+      },
+    });
+  });
+  return {
+    visible: setVisible,
+    pageshow: () => {
+      for (const h of handlers) h();
+    },
+    runFrames: (times) => {
+      for (const t of times) {
+        now = t;
+        const cb = frameCb;
+        frameCb = null;
+        cb?.(t);
+      }
+    },
+    push,
+    get disconnects() {
+      return state.disconnects;
+    },
+    dispose,
+  };
+}
+
+describe("installResumeProbe", () => {
+  // The operational requirement: nothing runs for a user who has not turned
+  // diagnostics on.
+  it("does nothing at all with diagnostics off", async () => {
+    const h = install({ enabled: false, supported: ["longtask"] });
+    await flush();
+    h.visible(false);
+    await flush();
+    h.visible(true);
+    await flush();
+    h.runFrames([0, 16, PROBE_WINDOW_MS + 1]);
+    expect(h.push).not.toHaveBeenCalled();
+    h.dispose();
+  });
+
+  it("emits exactly ONE summary line per resume, not one per frame", async () => {
+    const h = install({ enabled: true, supported: ["longtask", "event"] });
+    await flush();
+    h.visible(false);
+    await flush();
+    h.visible(true);
+    await flush();
+    h.runFrames([0, 16, 32, PROBE_WINDOW_MS + 1]);
+    expect(h.push).toHaveBeenCalledTimes(1);
+    expect(emitted(h.push)).toContain("resume ");
+    h.dispose();
+  });
+
+  it("marks an unsupported observer rather than reporting a quiet one", async () => {
+    const h = install({ enabled: true, supported: [] });
+    await flush();
+    h.visible(false);
+    await flush();
+    h.visible(true);
+    await flush();
+    h.runFrames([0, PROBE_WINDOW_MS + 1]);
+    expect(emitted(h.push)).toContain("longtask:unsupported");
+    expect(emitted(h.push)).toContain("input:unsupported");
+    h.dispose();
+  });
+
+  it("disconnects its observers when the window closes", async () => {
+    const h = install({ enabled: true, supported: ["longtask", "event"] });
+    await flush();
+    h.visible(false);
+    await flush();
+    h.visible(true);
+    await flush();
+    expect(h.disconnects).toBe(0);
+    h.runFrames([0, PROBE_WINDOW_MS + 1]);
+    expect(h.disconnects).toBe(2);
+    h.dispose();
+  });
+
+  it("arms on pageshow too — the bfcache restore the visibility signal never sees", async () => {
+    const h = install({ enabled: true, supported: [] });
+    await flush();
+    h.pageshow();
+    h.runFrames([0, PROBE_WINDOW_MS + 1]);
+    expect(h.push).toHaveBeenCalledTimes(1);
+    h.dispose();
+  });
+
+  it("does not arm a second window while one is already running", async () => {
+    const h = install({ enabled: true, supported: [] });
+    await flush();
+    h.visible(false);
+    await flush();
+    h.visible(true);
+    await flush();
+    // A pageshow lands mid-window — overlapping triggers are expected on iOS.
+    h.pageshow();
+    h.runFrames([0, PROBE_WINDOW_MS + 1]);
+    expect(h.push).toHaveBeenCalledTimes(1);
+    h.dispose();
+  });
+});

--- a/cicchetto/src/lib/resumeProbe.ts
+++ b/cicchetto/src/lib/resumeProbe.ts
@@ -1,0 +1,230 @@
+import { type Accessor, createEffect, on } from "solid-js";
+
+// #697 — on-device instrument for "iOS resume leaves the UI unresponsive for
+// 3-4 seconds". NOT a fix: this exists to decide WHICH bug we have, because a
+// static read of the resume path could not.
+//
+// WHY THE SYMPTOM AND NOT THE TEN CONSUMERS. Ten things run on
+// visibility → visible (kickReconnect, refreshScrollback, the viewport
+// writer, push resubscribe, badge, presence report + heartbeat, two
+// ScrollbackPane effects, two cursor gates). Wrapping all ten would be
+// invasive, would perturb what it measures, and assumes the answer is in
+// there. One cheap measurement of the SYMPTOM eliminates half the hypothesis
+// space first:
+//
+//   * a large frame gap   → our JS blocks the main thread; only THEN is
+//                           per-consumer attribution worth adding;
+//   * no gap, taps dead   → not our main thread at all — platform behaviour
+//                           on PWA resume, and #697 gets reframed;
+//   * neither             → the freeze did not happen on that resume, and the
+//                           repro needs work before anything else does.
+//
+// THE PRIMARY SIGNAL IS ENGINE-AGNOSTIC ON PURPOSE. `requestAnimationFrame`
+// scheduling delay needs no API support and works on WebKit, which the
+// interesting observers may not. `samples[0]` is the ARM time, so the first
+// gap measured is resume → first frame: exactly the interval a frozen
+// document stretches.
+//
+// The observers are strictly secondary and strictly feature-detected. An
+// engine that does not implement an entry type reports `unsupported`, NEVER an
+// empty result — a missing measurement must not read as a clean one (CLAUDE.md
+// log honesty: state what you OBSERVED, not the absence of work).
+//
+// KNOWN LIMITATION, do not read an absent line as an absent freeze: the probe
+// arms on the visibility transition and on `pageshow`. iOS frequently thaws a
+// document with NEITHER, and `requestAnimationFrame` does not run while
+// hidden, so a resume that fires no transition is not measured at all. If a
+// freeze is reported with no line to match it, that is this gap, not evidence.
+
+export const PROBE_WINDOW_MS = 10_000;
+
+export interface FrameGapSummary {
+  frames: number;
+  maxGapMs: number;
+  spanMs: number;
+}
+
+export type EntrySupport = "ok" | "unsupported";
+
+export interface ObservedEntries {
+  support: EntrySupport;
+  count: number;
+  maxMs: number;
+}
+
+/**
+ * Frame count, worst inter-frame gap and total span across a sample run.
+ *
+ * `samples[0]` is the arm time, so the first interval is resume → first frame.
+ * Fewer than two samples means no frame ever ran — a document frozen for the
+ * whole window — and reports zeroes rather than inventing a gap.
+ */
+export function summariseFrameGaps(samples: readonly number[]): FrameGapSummary {
+  const [armedAt] = samples;
+  const last = samples.at(-1);
+  // The undefined arms are unreachable once length >= 2; they are here to
+  // narrow under `noUncheckedIndexedAccess`, not to defend against anything.
+  if (samples.length < 2 || armedAt === undefined || last === undefined) {
+    return { frames: 0, maxGapMs: 0, spanMs: 0 };
+  }
+  let maxGap = 0;
+  let prev = armedAt;
+  for (const t of samples.slice(1)) {
+    const gap = t - prev;
+    if (gap > maxGap) maxGap = gap;
+    prev = t;
+  }
+  return {
+    frames: samples.length - 1,
+    maxGapMs: Math.round(maxGap),
+    spanMs: Math.round(last - armedAt),
+  };
+}
+
+/** Does this engine implement `entryType`? An absent list is unsupported. */
+export function entryTypeSupport(
+  supported: readonly string[] | undefined,
+  entryType: string,
+): EntrySupport {
+  return supported !== undefined && supported.includes(entryType) ? "ok" : "unsupported";
+}
+
+function formatObserved(label: string, observed: ObservedEntries): string {
+  // `unsupported` and `none` are deliberately distinct renderings.
+  if (observed.support === "unsupported") return `${label}:unsupported`;
+  if (observed.count === 0) return `${label}:none`;
+  return `${label}:${observed.count} max=${observed.maxMs}ms`;
+}
+
+/** One line per resume, frame summary first — the verdict reads left to right. */
+export function formatResumeProbeLine(
+  summary: FrameGapSummary,
+  longTask: ObservedEntries,
+  input: ObservedEntries,
+): string {
+  return [
+    `resume ${summary.spanMs}ms frames=${summary.frames} maxgap=${summary.maxGapMs}ms`,
+    formatObserved("longtask", longTask),
+    formatObserved("input", input),
+  ].join(" | ");
+}
+
+export interface ProbePerformance {
+  supportedEntryTypes(): readonly string[] | undefined;
+  /** Start observing; returns a disconnect verb, or null when unsupported. */
+  observe(entryType: string, onValues: (values: readonly number[]) => void): (() => void) | null;
+}
+
+export interface ProbeWindowLike {
+  addEventListener(event: "pageshow", handler: () => void): void;
+}
+
+export interface ResumeProbeDeps {
+  isVisible: Accessor<boolean>;
+  /** `isDiagEnabled` in production — nothing runs when diagnostics are off. */
+  enabled: () => boolean;
+  push: (line: string) => void;
+  now: () => number;
+  raf: (cb: (t: number) => void) => void;
+  perf: ProbePerformance;
+  win: ProbeWindowLike;
+}
+
+const LONGTASK = "longtask";
+const EVENT = "event";
+
+/**
+ * Arm the resume probe. No-op while `enabled()` is false.
+ *
+ * On each resume it samples frame scheduling for `PROBE_WINDOW_MS`, then emits
+ * ONE summary line — one per frame would drain `diagLog`'s 40-entry ring in a
+ * single resume.
+ */
+export function installResumeProbe(deps: ResumeProbeDeps): void {
+  let running = false;
+
+  const arm = (): void => {
+    if (!deps.enabled()) return;
+    // Overlapping triggers are normal on iOS (a visibility transition AND a
+    // pageshow for one resume); the second must not start a rival window.
+    // Cleared when the window closes, so this is a re-entrancy guard, not a
+    // latch that can disable the probe for good.
+    if (running) return;
+    running = true;
+
+    const armedAt = deps.now();
+    const samples: number[] = [armedAt];
+    const longTaskValues: number[] = [];
+    const inputValues: number[] = [];
+
+    const supported = deps.perf.supportedEntryTypes();
+    const stopLongTask = deps.perf.observe(LONGTASK, (v) => longTaskValues.push(...v));
+    const stopInput = deps.perf.observe(EVENT, (v) => inputValues.push(...v));
+
+    const finish = (): void => {
+      stopLongTask?.();
+      stopInput?.();
+      const observed = (entryType: string, values: readonly number[]): ObservedEntries => ({
+        support: entryTypeSupport(supported, entryType),
+        count: values.length,
+        maxMs: values.length === 0 ? 0 : Math.round(Math.max(...values)),
+      });
+      deps.push(
+        formatResumeProbeLine(
+          summariseFrameGaps(samples),
+          observed(LONGTASK, longTaskValues),
+          observed(EVENT, inputValues),
+        ),
+      );
+      running = false;
+    };
+
+    const step = (t: number): void => {
+      samples.push(t);
+      if (t - armedAt >= PROBE_WINDOW_MS) finish();
+      else deps.raf(step);
+    };
+    deps.raf(step);
+  };
+
+  deps.win.addEventListener("pageshow", arm);
+  createEffect(
+    on(deps.isVisible, (visible, prev) => {
+      // `prev === undefined` is the initial mount, which is a page load, not a
+      // resume. Only false→true is one.
+      if (prev === false && visible === true) arm();
+    }),
+  );
+}
+
+/**
+ * The real `PerformanceObserver` seam.
+ *
+ * `longtask` reports its own `duration`; an `event` entry's interesting number
+ * is `processingStart - startTime` — the input delay, which IS the reported
+ * symptom ("taps do nothing"). Neither is assumed to exist.
+ */
+export function browserProbePerformance(): ProbePerformance {
+  return {
+    supportedEntryTypes: () =>
+      typeof PerformanceObserver === "undefined"
+        ? undefined
+        : PerformanceObserver.supportedEntryTypes,
+    observe: (entryType, onValues) => {
+      if (entryTypeSupport(PerformanceObserver?.supportedEntryTypes, entryType) === "unsupported") {
+        return null;
+      }
+      const observer = new PerformanceObserver((list) => {
+        onValues(
+          list.getEntries().map((entry) => {
+            if (entryType !== EVENT) return entry.duration;
+            const timing = entry as PerformanceEventTiming;
+            return timing.processingStart - timing.startTime;
+          }),
+        );
+      });
+      observer.observe({ type: entryType, buffered: true });
+      return () => observer.disconnect();
+    },
+  };
+}

--- a/cicchetto/src/main.tsx
+++ b/cicchetto/src/main.tsx
@@ -14,9 +14,11 @@ import ShareConsume from "./ShareConsume";
 // app entry has to wire the side-effect module explicitly.
 import "./lib/subscribe";
 import "./lib/userTopic";
+import { isDiagEnabled } from "./DiagFloat";
 import { mountBadgeReconcile, mountBadgeSync } from "./lib/badge";
 import { performRefresh } from "./lib/bundleHash";
 import { applyCachedCustomTheme, mountCustomThemeSync } from "./lib/customTheme";
+import { diagPush } from "./lib/diagLog";
 import { mountDisplayPrefsSync } from "./lib/displayPrefs";
 import { isDocumentVisible } from "./lib/documentVisibility";
 import { applyFontSizeFromStorage } from "./lib/fontSize";
@@ -25,6 +27,7 @@ import { installKeyboardPreserve } from "./lib/keepKeyboard";
 import { applyIosClass, isStandalonePwa } from "./lib/platform";
 import { installPushResubscribe } from "./lib/pushResubscribe";
 import { applyPushTargetFromUrl, installPushTargetListener } from "./lib/pushTarget";
+import { browserProbePerformance, installResumeProbe } from "./lib/resumeProbe";
 import { applySidebarWidthsFromStorage } from "./lib/sidebarWidths";
 import { notifyClientClosing, reportVisibility } from "./lib/socket";
 import { installStaleResumeReload } from "./lib/staleResume";
@@ -257,6 +260,21 @@ createRoot(() => {
     const visible = isDocumentVisible();
     reportVisibility();
     heartbeat.setVisible(visible);
+  });
+  // #697 — resume-path instrument. Measures the SYMPTOM (frame scheduling
+  // delay, plus feature-detected long-task and input-delay observers) rather
+  // than wrapping the ten consumers that run on this same transition, so one
+  // cheap reading can rule out "our JS blocks the main thread" before anything
+  // invasive is added. Gated on `isDiagEnabled` — nothing runs, and no line is
+  // recorded, unless the operator turned diagnostics on in Settings.
+  installResumeProbe({
+    isVisible: isDocumentVisible,
+    enabled: isDiagEnabled,
+    push: diagPush,
+    now: () => performance.now(),
+    raf: (cb) => void requestAnimationFrame(cb),
+    perf: browserProbePerformance(),
+    win: window,
   });
 });
 


### PR DESCRIPTION
## What this is — and is not

This is **not a fix for #697**. It is the instrument that decides *which* bug
#697 is. The [diagnosis verdict](https://github.com/vjt/grappa-irc/issues/697#issuecomment-5167515480)
established that a static read cannot settle it and that what remains is
device-side only, so the next honest step is to measure on the device rather
than ship a speculative fix.

## How to turn it on, on the phone

The probe is **inert unless diagnostics are enabled** — with the flag clear it
never arms and never records a line.

1. In cicchetto on the iPhone, open **Settings → Admin → Debug**.
2. Flip the **DiagFloat** toggle on. (It writes `cic_diag=1` to `localStorage`;
   `AdminDebugTab.tsx` owns the switch.)
3. A fixed overlay appears top-right and stays visible over the compose bar and
   the keyboard — that is deliberate, it was built for exactly this kind of
   on-device diagnosis.
4. Reproduce: switch away from cicchetto for a few seconds, come back, and try
   to scroll or tap while it is dead.
5. Read the newest line at the top of the overlay. Flip the toggle back off when
   done.

## Reading the output

One line per resume:

```
resume 10000ms frames=41 maxgap=3820ms | longtask:2 max=3810ms | input:3 max=512ms
```

| Reading | Meaning |
|---|---|
| `maxgap` in the thousands | our JS blocked the main thread — **then** per-consumer attribution is worth adding |
| `maxgap` small but taps were dead | not our main thread — platform behaviour on PWA resume, and #697 gets reframed |
| `frames=0` | no frame ran for the whole window — the document was frozen throughout |
| `longtask:unsupported` | WebKit does not implement that observer. **Not** the same as `longtask:none` |

`maxgap` includes the arm → first-frame interval, which is exactly the interval
a frozen document stretches.

## Why the symptom and not the ten consumers

Ten things run on visibility → visible: `kickReconnect`, `refreshScrollback`,
the viewport writer, push resubscribe, badge, presence report + heartbeat, two
`ScrollbackPane` effects and two cursor gates. Wrapping all ten would be
invasive, would perturb what it measures, and assumes the answer is in there.
One cheap reading of the symptom splits the hypothesis space first, and only a
positive result justifies the invasive follow-up.

`requestAnimationFrame` scheduling delay is the primary signal because it needs
no API support and works on WebKit, where the more precise observers may not
exist. `longtask` and Event Timing are strictly secondary and strictly
feature-detected — and an engine that lacks an entry type reports `unsupported`
rather than an empty result, so a missing measurement can never be misread as a
clean one.

## Two limitations, both deliberate and both documented in the code

1. **The rAF loop perturbs what it measures.** Standard technique, negligible
   against a multi-second block, but this is not a zero-impact measurement and a
   sub-frame reading should not be trusted to that precision.
2. **An absent line is not an absent freeze.** The probe arms on the visibility
   transition and on `pageshow`; iOS frequently thaws a document with neither,
   and `requestAnimationFrame` does not run while hidden. A reported freeze with
   no matching line is that gap, not evidence.

## Test plan

- [x] `resumeProbe.test.ts` 16/16, written RED first.
- [x] The honesty rule is pinned: `unsupported` and `none` must not render the
      same, asserted in both the formatter and the installed probe.
- [x] Off with diagnostics off — no line recorded at all.
- [x] Exactly one summary line per resume, not one per frame.
- [x] Observers disconnected when the window closes; overlapping triggers (a
      visibility transition AND a `pageshow` for one resume) do not start a
      rival window.
- [x] Frame summary: arm→first-frame counted as a gap, fractional timestamps
      rounded, zero frames reported as zero rather than an invented gap.
- [x] `tsc --noEmit` rc=0 (run standalone — `check` short-circuits on biome).
- [x] `bun run check` rc=0.
- [x] `bun run test` rc=0 — 218 files / 3948 tests.
- [ ] The actual reading, vjt's leg: enable the flag on the iPhone, reproduce
      the freeze, and post the line on #697.

No e2e. A Playwright webkit spec cannot reproduce a frozen iOS PWA, so one here
would assert nothing about the thing being measured.