### PR TITLE
cic(#717): make a failed boot recoverable — bounded fetch, one root door, error boundary

### DIFF
--- a/cicchetto/src/BootErrorBoundary.tsx
+++ b/cicchetto/src/BootErrorBoundary.tsx
@@ -75,28 +75,46 @@ const BootFailure: Component<{ error: unknown; onRetry: () => void }> = (props) 
             resources) loops straight back here. Force-killing the app is what
             #717 exists to eliminate; this is what replaces it.
 
-            OFFLINE IT MUST NOT PURGE. `performRefresh` is the right SW-aware
-            verb when a stale bundle is the problem (#674's banner, #695's
-            stale-resume) — but it deletes every cache before reloading, and
-            #674 can only do that safely because a bundle-hash advertisement
-            means the client is online by construction. This screen inverts that
-            precondition: the likeliest reason it is up at all is that the
-            network is gone. Purging the precache and reloading offline lands
-            the installed PWA on the browser's offline error page with the app
-            shell destroyed — strictly worse than the frozen splash. Reusing the
-            verb, not the noun: the shared part is "reload", the cache purge is
-            the 20% that does not fit. */}
+            IT MUST NOT PURGE WITHOUT PROOF THE SERVER ANSWERS. `performRefresh`
+            is the right SW-aware verb when a stale bundle is the problem
+            (#674's banner, #695's stale-resume) — but it deletes every cache
+            before reloading, and #674 can only do that safely because a
+            bundle-hash advertisement means the client is online by
+            construction. This screen inverts that precondition: the likeliest
+            reason it is up at all is that the network is gone. Purging the
+            precache and reloading then lands the installed PWA on the browser's
+            offline error page with the app shell destroyed — strictly worse
+            than the frozen splash. Reusing the verb, not the noun: the shared
+            part is "reload", the cache purge is the 20% that does not fit.
+
+            `navigator.onLine` ALONE CANNOT GATE THAT, which is why the error is
+            read too. It is trustworthy in one direction only: false means
+            definitely no link, true means only "an interface exists". Behind a
+            captive portal, on dead mobile data with the radio still attached,
+            or on a Wi-Fi association with no route, it reads true — and those
+            are exactly the conditions this screen comes up in. The guard was
+            weakest in its own motivating case.
+
+            So the purge needs POSITIVE evidence the server is reachable, and
+            an `ApiError` is precisely that: it exists only because a response
+            came back with a status. A transport failure is not one — `bootFetch`
+            has already spent three attempts and the server never answered.
+            Anything else (a mid-session render throw) is connectivity-unknown,
+            and unknown takes the safe branch by the asymmetry of harm: purging
+            offline destroys the app shell, while not purging costs one more
+            reload and leaves #674's banner to offer the new bundle once the
+            link is back. */}
       <button
         type="button"
         class="boot-failure-reload"
         data-testid="boot-failure-reload"
         onClick={() => {
           setReloading(true);
-          if (isOffline()) {
-            window.location.reload();
+          if (props.error instanceof ApiError && !isOffline()) {
+            void performRefresh();
             return;
           }
-          void performRefresh();
+          window.location.reload();
         }}
       >
         {/* `performRefresh` can take up to ~2s waiting on controllerchange.

--- a/cicchetto/src/BootErrorBoundary.tsx
+++ b/cicchetto/src/BootErrorBoundary.tsx
@@ -1,0 +1,136 @@
+import { type Component, createSignal, ErrorBoundary, type JSX } from "solid-js";
+import { ApiError } from "./lib/api";
+import { performRefresh } from "./lib/bundleHash";
+import { isOffline } from "./lib/connectivity";
+import { friendlyApiError } from "./lib/friendlyApiError";
+import { refetchUser } from "./lib/networks";
+
+// #717 — keep a failed boot recoverable.
+//
+// The boot chain is three resources (`user` → `networks` → `channelsBySlug`,
+// see lib/networks.ts) and every consumer reads them through a predicate:
+// CrtSplash's is `!user() || channelsBySlug() === undefined`. When one of the
+// underlying fetches REJECTS, the resource enters state `errored` and reading
+// it RE-THROWS. That throw lands mid-render, and before this component
+// cicchetto mounted no ErrorBoundary at all — so the throw was swallowed, the
+// DOM kept the last painted frame (the splash), and the only way out was to
+// force-kill the app. That is the reported #717 symptom on the installed
+// Android/Firefox PWA.
+//
+// Why this is not solved by the timeout in `lib/api.ts`: a timeout REJECTS.
+// Bounding the slow path converts a hang into a rejection, which is the exact
+// state that freezes the UI. The bound and this boundary are two halves of one
+// fix — retry absorbs the transient failure, the boundary catches the terminal
+// one.
+//
+// DELIBERATELY BARE. This is a recovery affordance, not a loading screen:
+// #687 owns the staged boot log the splash should show while it is healthy,
+// and a second screen competing with it would be the layer that issue exists
+// to avoid. Message + retry, nothing else.
+//
+// The error text IS shown. #717 is a diagnosis-starved bug reported by a
+// self-hoster we cannot attach a debugger to; the failure string is the one
+// thing they can read back to us. Same rationale as #120 capturing the
+// service-worker registration error name+message.
+
+// A typed server error goes through `friendlyApiError`, the SSOT for that copy
+// (#411, "ogni cazzo di errore deve avere un copy"). Without it an ApiError
+// renders its own `message`, which is the raw `"<status> <code>"` pair — the
+// screen would greet a self-hoster with "500 internal_error". A transport
+// failure is not an ApiError and has no token to localise, so its message
+// (e.g. "Failed to fetch") is the honest text.
+function failureText(error: unknown): string {
+  if (error instanceof ApiError) return friendlyApiError(error);
+  if (error instanceof Error && error.message !== "") return error.message;
+  if (typeof error === "string" && error !== "") return error;
+  return "unknown error";
+}
+
+// Rendered by the boundary below. Split out of the inline `fallback` because it
+// owns a signal (the reload's in-flight state) and a component is where a signal
+// belongs.
+const BootFailure: Component<{ error: unknown; onRetry: () => void }> = (props) => {
+  const [reloading, setReloading] = createSignal(false);
+
+  return (
+    <div class="boot-failure" data-testid="boot-failure">
+      {/* The live region is the message, not the container: putting
+            role="alert" on a box that also holds the buttons announces the
+            controls as part of the alert. */}
+      <p class="boot-failure-title" role="alert">
+        Could not load Grappa.
+      </p>
+      <p class="boot-failure-detail">{failureText(props.error)}</p>
+      <button
+        type="button"
+        class="boot-failure-retry"
+        data-testid="boot-failure-retry"
+        onClick={() => props.onRetry()}
+      >
+        Retry
+      </button>
+      {/* The escape hatch of last resort. The boundary wraps Shell for the
+            whole session, so it also catches throws with nothing to do with the
+            boot chain — and for those, Retry (which only refetches the boot
+            resources) loops straight back here. Force-killing the app is what
+            #717 exists to eliminate; this is what replaces it.
+
+            OFFLINE IT MUST NOT PURGE. `performRefresh` is the right SW-aware
+            verb when a stale bundle is the problem (#674's banner, #695's
+            stale-resume) — but it deletes every cache before reloading, and
+            #674 can only do that safely because a bundle-hash advertisement
+            means the client is online by construction. This screen inverts that
+            precondition: the likeliest reason it is up at all is that the
+            network is gone. Purging the precache and reloading offline lands
+            the installed PWA on the browser's offline error page with the app
+            shell destroyed — strictly worse than the frozen splash. Reusing the
+            verb, not the noun: the shared part is "reload", the cache purge is
+            the 20% that does not fit. */}
+      <button
+        type="button"
+        class="boot-failure-reload"
+        data-testid="boot-failure-reload"
+        onClick={() => {
+          setReloading(true);
+          if (isOffline()) {
+            window.location.reload();
+            return;
+          }
+          void performRefresh();
+        }}
+      >
+        {/* `performRefresh` can take up to ~2s waiting on controllerchange.
+              On a dead-boot screen a button that appears to do nothing is
+              exactly what sends the user back to force-killing the app. */}
+        {reloading() ? "Reloading…" : "Reload"}
+      </button>
+    </div>
+  );
+};
+
+const BootErrorBoundary: Component<{ children: JSX.Element }> = (props) => (
+  <ErrorBoundary
+    fallback={(error, reset) => (
+      <BootFailure
+        error={error}
+        onRetry={() => {
+          // Refetch BEFORE reset, and in this order only: `reset()` re-renders
+          // the children, and a child that reads a still-errored resource
+          // rethrows immediately — the boundary would loop straight back into
+          // this fallback without a single request going out.
+          //
+          // ONE verb, not three. networks.ts states it: `user` is the ROOT of
+          // the burst — `networks` is keyed on `user` and `channelsBySlug` on
+          // `networks`, so refetching the root cascades through both. Calling
+          // all three would put redundant requests in flight racing the cascade.
+          refetchUser();
+          reset();
+        }}
+      />
+    )}
+  >
+    {props.children}
+  </ErrorBoundary>
+);
+
+export default BootErrorBoundary;

--- a/cicchetto/src/BootErrorBoundary.tsx
+++ b/cicchetto/src/BootErrorBoundary.tsx
@@ -3,7 +3,7 @@ import { ApiError } from "./lib/api";
 import { performRefresh } from "./lib/bundleHash";
 import { isOffline } from "./lib/connectivity";
 import { friendlyApiError } from "./lib/friendlyApiError";
-import { refetchUser } from "./lib/networks";
+import { refetchChannels, refetchNetworks, refetchUser } from "./lib/networks";
 
 // #717 — keep a failed boot recoverable.
 //
@@ -114,16 +114,43 @@ const BootErrorBoundary: Component<{ children: JSX.Element }> = (props) => (
       <BootFailure
         error={error}
         onRetry={() => {
-          // Refetch BEFORE reset, and in this order only: `reset()` re-renders
-          // the children, and a child that reads a still-errored resource
+          // Refetch BEFORE reset: `reset()` re-renders the children
+          // synchronously, and a child that reads a still-errored resource
           // rethrows immediately — the boundary would loop straight back into
           // this fallback without a single request going out.
           //
-          // ONE verb, not three. networks.ts states it: `user` is the ROOT of
-          // the burst — `networks` is keyed on `user` and `channelsBySlug` on
-          // `networks`, so refetching the root cascades through both. Calling
-          // all three would put redundant requests in flight racing the cascade.
+          // ALL THREE, ROOT FIRST, and both halves of that are load-bearing.
+          //
+          // Refetching only `user` is not enough even though the cascade is
+          // real (`networks` is keyed on `user`, `channelsBySlug` on
+          // `networks`): the cascade is ASYNCHRONOUS and `reset()` is not. A
+          // `listNetworks` failure leaves `networks` errored with no refetch in
+          // flight, so the re-render rethrows and the button reads as dead —
+          // recovery needed a SECOND press, after the chain had settled. That
+          // is the force-kill-the-app behaviour #717 exists to remove.
+          //
+          // What clears the throw is not the response, it is the in-flight
+          // request: solid's resource `read()` is `if (err !== undefined &&
+          // !pr) throw err`, so a resource with a load in flight reads as
+          // pending instead of rethrowing. Each verb gives its own resource a
+          // `pr`; then the children render the splash and the cascade lands.
+          //
+          // ROOT FIRST mirrors the cascade. It is not load-bearing — measured,
+          // the reverse order also recovers, because each verb evaluates its
+          // source memo and a memo that throws is handled, not propagated. It
+          // is written this way because the reverse only works by routing a
+          // throw through the error machinery on every press, which is a
+          // coincidence to rely on, not a design.
+          //
+          // Downstream is nearly free: with its source not yet resolved, the
+          // load takes solid's `lookup == null` path, which clears the error
+          // without issuing a request. Measured for one press on a
+          // `listNetworks` failure — `listNetworks` twice (the verb, then the
+          // cascade off the fresh `user`), `listChannels` not at all. The spec
+          // pins both numbers.
           refetchUser();
+          refetchNetworks();
+          refetchChannels();
           reset();
         }}
       />

--- a/cicchetto/src/__tests__/BootErrorBoundary.test.tsx
+++ b/cicchetto/src/__tests__/BootErrorBoundary.test.tsx
@@ -48,6 +48,14 @@ vi.mock("../lib/api", async (importOriginal) => {
   };
 });
 
+// The cache-purging reload verb. Stubbed so the reload branch can be asserted
+// on WHICH verb ran — the whole point of the discriminator at the bottom of
+// this file is that picking the wrong one destroys the app shell.
+vi.mock("../lib/bundleHash", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/bundleHash")>();
+  return { ...actual, performRefresh: vi.fn().mockResolvedValue(undefined) };
+});
+
 const HEALTHY_ME = {
   kind: "user",
   id: "u1",
@@ -215,5 +223,101 @@ describe("BootErrorBoundary (#717 — a failed boot must not freeze on the splas
     // error without issuing a request.
     expect(listNetworks.mock.calls.length).toBe(2);
     expect((api.listChannels as Mock).mock.calls.length).toBe(0);
+  });
+});
+
+// #717 review round 3 — the Reload button must not purge the cache without
+// positive evidence the server answers.
+//
+// `performRefresh` deletes EVERY cache before reloading. Doing that with no
+// network lands the installed PWA on the browser's offline error page with the
+// app shell destroyed — strictly worse than the frozen splash it replaced.
+//
+// The first cut gated it on `isOffline()` alone. That is `!navigator.onLine`,
+// which is trustworthy in one direction only: false means definitely no link,
+// true means merely "an interface exists". Behind a captive portal, on dead
+// mobile data with the radio attached, or on a Wi-Fi association with no route
+// it reads TRUE — and those are precisely the conditions this screen comes up
+// in, so the guard was weakest in its own motivating case. The error carries
+// the honest signal instead: an ApiError exists only because a response came
+// back with a status.
+describe("BootErrorBoundary reload — purge needs proof the server answers", () => {
+  const originalLocation = window.location;
+  let reloadSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    reloadSpy = vi.fn();
+    Object.defineProperty(window, "location", {
+      writable: true,
+      configurable: true,
+      value: { ...originalLocation, reload: reloadSpy },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      writable: true,
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  async function renderFailed(error: unknown): Promise<{ performRefresh: Mock }> {
+    localStorage.setItem("grappa-token", "tokA");
+    const api = await import("../lib/api");
+    const pending = deferredMe(api);
+    const { performRefresh } = await import("../lib/bundleHash");
+
+    await renderBootTree();
+    pending.reject(error);
+    await screen.findByTestId("boot-failure");
+
+    return { performRefresh: performRefresh as unknown as Mock };
+  }
+
+  // THE REGRESSION. A transport failure means bootFetch spent three attempts
+  // and the server never answered — no proof of a link, whatever
+  // `navigator.onLine` claims. Pre-fix this purged.
+  it("does NOT purge on a transport failure, even when navigator reports online", async () => {
+    const { __setConnectivityForTests } = await import("../lib/connectivity");
+    __setConnectivityForTests(true);
+
+    const { performRefresh } = await renderFailed(new TypeError("Failed to fetch"));
+
+    fireEvent.click(screen.getByTestId("boot-failure-reload"));
+
+    expect(performRefresh).not.toHaveBeenCalled();
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("purges on an ApiError while online — a status came back, so the link is real", async () => {
+    const { ApiError } = await import("../lib/api");
+    const { __setConnectivityForTests } = await import("../lib/connectivity");
+    __setConnectivityForTests(true);
+
+    const { performRefresh } = await renderFailed(new ApiError(500, "internal_error"));
+
+    fireEvent.click(screen.getByTestId("boot-failure-reload"));
+
+    expect(performRefresh).toHaveBeenCalledTimes(1);
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+
+  // Both conditions are required: a status came back earlier, but the link has
+  // since dropped. `navigator.onLine === false` is the one direction that IS
+  // conclusive.
+  it("does NOT purge on an ApiError once the device reports offline", async () => {
+    const { ApiError } = await import("../lib/api");
+    const { __setConnectivityForTests } = await import("../lib/connectivity");
+    __setConnectivityForTests(false);
+
+    const { performRefresh } = await renderFailed(new ApiError(503, "unavailable"));
+
+    fireEvent.click(screen.getByTestId("boot-failure-reload"));
+
+    expect(performRefresh).not.toHaveBeenCalled();
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+
+    __setConnectivityForTests(true);
   });
 });

--- a/cicchetto/src/__tests__/BootErrorBoundary.test.tsx
+++ b/cicchetto/src/__tests__/BootErrorBoundary.test.tsx
@@ -83,16 +83,38 @@ async function renderBootTree(): Promise<void> {
   ));
 }
 
+// The DOWNSTREAM child, mirroring Sidebar.tsx / BottomBar.tsx: it reads
+// `networks()`, the second link of the chain. `user` is the only link the tree
+// above covers, and it is the one link whose retry works by refetching the root
+// alone — so a `networks` failure is a separate case, not a variation.
+async function renderNetworksTree(): Promise<void> {
+  const { networks } = await import("../lib/networks");
+  const BootErrorBoundary = (await import("../BootErrorBoundary")).default;
+
+  render(() => (
+    <BootErrorBoundary>
+      <Show when={networks() !== undefined} fallback={<div data-testid="crt-splash">LOADING</div>}>
+        <div data-testid="app">app</div>
+      </Show>
+    </BootErrorBoundary>
+  ));
+}
+
 // A `me()` whose promise this file settles on demand, so the rejection can be
 // placed AFTER the first render exactly as production places it.
-function deferredMe(api: { me: unknown }): { reject: (e: unknown) => void } {
+function deferredMe(api: { me: unknown }): {
+  reject: (e: unknown) => void;
+  resolve: (v: unknown) => void;
+} {
   let reject!: (e: unknown) => void;
+  let resolve!: (v: unknown) => void;
   (api.me as Mock).mockReturnValue(
-    new Promise((_resolve, rej) => {
+    new Promise((res, rej) => {
+      resolve = res;
       reject = rej;
     }),
   );
-  return { reject: (e) => reject(e) };
+  return { reject: (e) => reject(e), resolve: (v) => resolve(v) };
 }
 
 describe("BootErrorBoundary (#717 — a failed boot must not freeze on the splash)", () => {
@@ -149,5 +171,49 @@ describe("BootErrorBoundary (#717 — a failed boot must not freeze on the splas
     expect(await screen.findByTestId("app")).toBeInTheDocument();
     expect(screen.queryByTestId("boot-failure")).toBeNull();
     expect(me.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  // The case the `/me` retry above cannot cover, and the one that made the
+  // button read as dead. `reset()` is synchronous while the `user → networks`
+  // cascade is not, so refetching only the root left `networks` errored at
+  // re-render: the child rethrew and the boundary bounced straight back into
+  // the fallback. Recovery took a SECOND press. ONE press is the assertion.
+  //
+  // `me` hands back a FRESH object per call on purpose — production parses a
+  // new envelope each time, and a mock returning one shared reference would
+  // leave the `createMemo(user)` unchanged, so `networks` would never cascade
+  // and this test would measure an artefact of the mock instead of the fix.
+  it("recovers from a downstream listNetworks failure on ONE retry press", async () => {
+    localStorage.setItem("grappa-token", "tokA");
+    const api = await import("../lib/api");
+    const pending = deferredMe(api);
+    const listNetworks = api.listNetworks as Mock;
+    listNetworks.mockRejectedValue(new Error("networks down"));
+
+    await renderNetworksTree();
+    expect(screen.getByTestId("crt-splash")).toBeInTheDocument();
+
+    pending.resolve({ ...HEALTHY_ME });
+
+    expect(await screen.findByTestId("boot-failure")).toBeInTheDocument();
+
+    (api.me as Mock).mockImplementation(async () => ({ ...HEALTHY_ME }));
+    listNetworks.mockResolvedValue([]);
+    listNetworks.mockClear();
+    (api.listChannels as Mock).mockClear();
+
+    fireEvent.click(screen.getByTestId("boot-failure-retry"));
+
+    expect(await screen.findByTestId("app")).toBeInTheDocument();
+    expect(screen.queryByTestId("boot-failure")).toBeNull();
+
+    // Pins the cost the handler's comment claims, so a future "refetch
+    // everything" edit cannot quietly turn one press into a request storm.
+    // `listNetworks` twice — the explicit verb, then the cascade off the fresh
+    // `user`. `listChannels` NOT at all: its source is still unresolved when the
+    // verb runs, so that load takes solid's null-lookup path, which clears the
+    // error without issuing a request.
+    expect(listNetworks.mock.calls.length).toBe(2);
+    expect((api.listChannels as Mock).mock.calls.length).toBe(0);
   });
 });

--- a/cicchetto/src/__tests__/BootErrorBoundary.test.tsx
+++ b/cicchetto/src/__tests__/BootErrorBoundary.test.tsx
@@ -1,0 +1,153 @@
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { Show } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+// #717 — the recoverability half, tested through the REAL resource cascade.
+//
+// An earlier version of this file built its own resource inside the component
+// and mocked `lib/networks` away. It passed against an implementation that did
+// NOT fix #717, because the three things it changed are exactly the three that
+// break in production:
+//
+//   * `networks` is `createResource(user, …)` and `channelsBySlug` is
+//     `createResource(networks, …)`, so Solid compiles a `createMemo(user)`
+//     that reads the failing resource;
+//   * that memo lives in the module-level `createRoot` opened by
+//     `identityScopedStore`, OUTSIDE the render tree;
+//   * a throw from there has no error context, so `runUpdates` discards the
+//     queued render effects — including the boundary's — and the DOM keeps the
+//     splash forever.
+//
+// ORDER IS THE WHOLE TEST. An earlier rewrite still passed against the broken
+// implementation because it let `me()` reject during the `await import(...)`
+// calls, BEFORE `render()`. A resource that is already `errored` at first paint
+// throws synchronously inside the boundary — no update cycle, nothing to abort,
+// and the bug is invisible. Production is the opposite: `main.tsx` imports
+// statically and renders in the same turn, so the rejection ALWAYS lands after
+// the first paint, in an update cycle a context-less module root can abort.
+//
+// So the `me` mock hands back a promise this file settles by hand, AFTER
+// `render()` has run. Falsified: reverting `identityScopedStore` to a bare
+// `createRoot` turns the first case below red.
+//
+// Mocks ONLY `lib/api` (the network edge) — real `lib/networks`, real
+// `identityScopedStore`, real cascade. `vi.resetModules` per test because these
+// stores are module singletons.
+
+// Only the three network calls are stubbed; everything else in `lib/api` stays
+// REAL. `ApiError` in particular must be the genuine class — the fallback
+// narrows with `instanceof` to route typed errors through `friendlyApiError`,
+// and a stubbed stand-in would make that branch untestable (and quietly dead).
+vi.mock("../lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/api")>();
+  return {
+    ...actual,
+    me: vi.fn(),
+    listNetworks: vi.fn(),
+    listChannels: vi.fn(),
+  };
+});
+
+const HEALTHY_ME = {
+  kind: "user",
+  id: "u1",
+  name: "vjt",
+  read_cursors: {},
+  badge_count: 0,
+};
+
+beforeEach(() => {
+  vi.resetModules();
+  localStorage.clear();
+  vi.clearAllMocks();
+});
+
+// Explicit: each test renders its own tree against a freshly re-imported
+// module singleton, so a left-over tree would put two of everything in the
+// document and the queries below would match the wrong one.
+afterEach(() => {
+  cleanup();
+});
+
+// The child mirrors CrtSplash: it reads the boot resource through a predicate.
+async function renderBootTree(): Promise<void> {
+  const { user } = await import("../lib/networks");
+  const BootErrorBoundary = (await import("../BootErrorBoundary")).default;
+
+  render(() => (
+    <BootErrorBoundary>
+      <Show when={!user()} fallback={<div data-testid="app">app</div>}>
+        <div data-testid="crt-splash">LOADING</div>
+      </Show>
+    </BootErrorBoundary>
+  ));
+}
+
+// A `me()` whose promise this file settles on demand, so the rejection can be
+// placed AFTER the first render exactly as production places it.
+function deferredMe(api: { me: unknown }): { reject: (e: unknown) => void } {
+  let reject!: (e: unknown) => void;
+  (api.me as Mock).mockReturnValue(
+    new Promise((_resolve, rej) => {
+      reject = rej;
+    }),
+  );
+  return { reject: (e) => reject(e) };
+}
+
+describe("BootErrorBoundary (#717 — a failed boot must not freeze on the splash)", () => {
+  it("surfaces the failure when /me rejects after first paint, through the real cascade", async () => {
+    localStorage.setItem("grappa-token", "tokA");
+    const api = await import("../lib/api");
+    const pending = deferredMe(api);
+
+    await renderBootTree();
+
+    // First paint with the boot still in flight — the splash, as production
+    // shows it.
+    expect(screen.getByTestId("crt-splash")).toBeInTheDocument();
+
+    pending.reject(new Error("network down"));
+
+    // The whole point of #717: the splash is REPLACED by something that admits
+    // the boot failed, rather than staying up forever.
+    expect(await screen.findByTestId("boot-failure")).toBeInTheDocument();
+    expect(screen.queryByTestId("crt-splash")).toBeNull();
+  });
+
+  it("leaves a healthy boot untouched", async () => {
+    localStorage.setItem("grappa-token", "tokA");
+    const api = await import("../lib/api");
+    (api.me as Mock).mockResolvedValue(HEALTHY_ME);
+    (api.listNetworks as Mock).mockResolvedValue([]);
+
+    await renderBootTree();
+
+    expect(await screen.findByTestId("app")).toBeInTheDocument();
+    expect(screen.queryByTestId("boot-failure")).toBeNull();
+  });
+
+  it("retries the boot chain when the user asks, and clears the failure once it succeeds", async () => {
+    localStorage.setItem("grappa-token", "tokA");
+    const api = await import("../lib/api");
+    const me = api.me as Mock;
+    const pending = deferredMe(api);
+
+    await renderBootTree();
+    pending.reject(new Error("network down"));
+    await screen.findByTestId("boot-failure");
+    expect(me).toHaveBeenCalledTimes(1);
+
+    // The retry must reach the network again — a bare `reset()` would re-render
+    // a child that reads a still-errored resource and bounce right back here
+    // with nothing in flight.
+    me.mockResolvedValue(HEALTHY_ME);
+    (api.listNetworks as Mock).mockResolvedValue([]);
+
+    fireEvent.click(screen.getByTestId("boot-failure-retry"));
+
+    expect(await screen.findByTestId("app")).toBeInTheDocument();
+    expect(screen.queryByTestId("boot-failure")).toBeNull();
+    expect(me.mock.calls.length).toBeGreaterThan(1);
+  });
+});

--- a/cicchetto/src/__tests__/moduleRoot.test.tsx
+++ b/cicchetto/src/__tests__/moduleRoot.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@solidjs/testing-library";
+import { createMemo, createSignal, ErrorBoundary } from "solid-js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { moduleRoot } from "../lib/moduleRoot";
+
+// #717 — the property this factory exists for is NOT "the handler ran". It is
+// "the update cycle SURVIVED a module-root throw", because that is what decides
+// whether a render-tree ErrorBoundary ever gets to render.
+//
+// The bug this pins is a real one that shipped in the first cut: the error
+// context was given to `identityScopedStore` only, and `activeWindows.ts` — a
+// bare root whose memo reads `channelsBySlug()` and `networks()` — kept
+// aborting the cycle first, so a `listNetworks`/`listChannels` failure still
+// froze the splash. A test that only asserted "the handler was called" would
+// have stayed green through that.
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("moduleRoot (#717 — a throw in a module root must not abort the cycle)", () => {
+  it("returns what build returned", () => {
+    const store = moduleRoot(() => ({ answer: 42 }));
+    expect(store.answer).toBe(42);
+  });
+
+  it("rethrows a build-time failure with the original attached as cause", () => {
+    const boom = new Error("build exploded");
+    let thrown: unknown;
+    try {
+      moduleRoot(() => {
+        throw boom;
+      });
+    } catch (e) {
+      thrown = e;
+    }
+
+    // A module that cannot build its store is fatal — there is nothing to hand
+    // back. But the cause must survive: this is the loudest case, and it was
+    // the one left with no stack in the first cut.
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).cause).toBe(boom);
+  });
+
+  it("lets a render-tree ErrorBoundary run even when a module-root memo throws in the same cycle", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const [fail, setFail] = createSignal(false);
+
+    // The activeWindows shape: a module-level memo, subscribed to the signal
+    // before anything renders, that throws once the signal flips.
+    moduleRoot(() =>
+      createMemo(() => {
+        if (fail()) throw new Error("module root boom");
+        return 0;
+      }),
+    );
+
+    const Child = () => {
+      const view = createMemo(() => {
+        if (fail()) throw new Error("render boom");
+        return "ok";
+      });
+      return <div data-testid="ok">{view()}</div>;
+    };
+
+    render(() => (
+      <ErrorBoundary fallback={() => <div data-testid="fallback">failed</div>}>
+        <Child />
+      </ErrorBoundary>
+    ));
+
+    expect(screen.getByTestId("ok")).toBeInTheDocument();
+
+    setFail(true);
+
+    // With a bare `createRoot`, the module-root memo throws with no error
+    // context, `runUpdates` nulls the queued Effects, and this fallback never
+    // renders — the DOM keeps the last frame forever.
+    expect(await screen.findByTestId("fallback")).toBeInTheDocument();
+    expect(screen.queryByTestId("ok")).toBeNull();
+  });
+
+  it("reports the runtime throw rather than swallowing it", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const [fail, setFail] = createSignal(false);
+
+    moduleRoot(() =>
+      createMemo(() => {
+        if (fail()) throw new Error("module root boom");
+        return 0;
+      }),
+    );
+    setFail(true);
+
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/cicchetto/src/__tests__/moduleRootGuard.test.ts
+++ b/cicchetto/src/__tests__/moduleRootGuard.test.ts
@@ -1,0 +1,84 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// #717 — a bare `createRoot` must not come back.
+//
+// The first cut of #717 gave the error context to `identityScopedStore` alone
+// and left every other module root bare. `activeWindows.ts` — a module-level
+// memo reading `channelsBySlug()` and `networks()`, subscribed before the first
+// render — then went on swallowing the `listNetworks`/`listChannels` failures
+// exactly as before: it runs EARLIER in the Updates queue than the store's own
+// memo, throws with no error context, and `runUpdates` discards the queued
+// render effects before the store's handler is ever reached. The splash froze
+// through the gap between the two patterns.
+//
+// CLAUDE.md: "Half-migrated creates two patterns — Claude copies whichever is
+// closer." So the migration is total and this test is what keeps it total. A
+// new root goes through `moduleRoot`; nothing else may call `createRoot`.
+//
+// Sibling of biomePin.test.ts / versionSource.test.ts — vitest runs from the
+// cicchetto dir, so `src` is at cwd.
+
+// The two factories are the door itself: `moduleRoot` opens the root, and
+// `identityScopedStore` opens one with the reset wiring deliberately OUTSIDE
+// the error context (see its header — a swallowed reset is #281's bug).
+const FACTORIES = ["src/lib/moduleRoot.ts", "src/lib/identityScopedStore.ts"];
+
+// Test files are out of scope, and not as a convenience exclusion: the rule is
+// about module-LIFETIME roots — singletons that are never disposed, whose throw
+// therefore has nowhere to go. A test root is the opposite, and says so in its
+// own shape: every one of them takes the `dispose` callback and scopes ownership
+// to the case. `createRoot` is exactly the right primitive there.
+const isTestFile = (rel: string): boolean =>
+  rel.includes("__tests__") || /\.test\.tsx?$/.test(rel) || rel === "src/setupTests.ts";
+
+// Matches a call, not the word: comments and prose about `createRoot` are fine
+// and there are several that explain the history.
+const BARE_ROOT = /\bcreateRoot\s*\(/;
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...sourceFiles(full));
+    } else if (/\.tsx?$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("module roots (#717 — one door, and it stays one)", () => {
+  it("has no bare createRoot outside the root factories", () => {
+    const root = resolve(process.cwd(), "src");
+    const offenders: string[] = [];
+
+    for (const file of sourceFiles(root)) {
+      const rel = relative(process.cwd(), file);
+      if (FACTORIES.includes(rel) || isTestFile(rel)) continue;
+      const src = readFileSync(file, "utf8");
+      src.split("\n").forEach((line, i) => {
+        // Skip comment lines — the migration left explanatory prose behind.
+        const trimmed = line.trim();
+        if (trimmed.startsWith("//") || trimmed.startsWith("*")) return;
+        if (BARE_ROOT.test(line)) offenders.push(`${rel}:${i + 1}`);
+      });
+    }
+
+    expect(
+      offenders,
+      `bare createRoot found — use moduleRoot() so the root gets an error context (#717):\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
+
+  it("still guards something — the factories themselves do call createRoot", () => {
+    // Without this, deleting both factories (or renaming the call) would leave
+    // the test above vacuously green.
+    const called = FACTORIES.filter((f) =>
+      BARE_ROOT.test(readFileSync(resolve(process.cwd(), f), "utf8")),
+    );
+    expect(called).toEqual(FACTORIES);
+  });
+});

--- a/cicchetto/src/lib/activeWindows.ts
+++ b/cicchetto/src/lib/activeWindows.ts
@@ -1,6 +1,7 @@
-import { createMemo, createRoot, untrack } from "solid-js";
+import { createMemo, untrack } from "solid-js";
 import { type ChannelKey, channelKey } from "./channelKey";
 import { mentionCounts } from "./mentions";
+import { moduleRoot } from "./moduleRoot";
 import { channelsBySlug, networks } from "./networks";
 import { queryWindowsByNetwork } from "./queryWindows";
 import { scrollbackByChannel } from "./scrollback";
@@ -165,7 +166,7 @@ function buildActivityIds(): Record<ChannelKey, number> {
 // Consumed reactively by the affordance button (visibility + count) and
 // untracked by the jump verbs. Wrapped in createRoot so the memo has an
 // owner (module-singleton, never disposed) — mirrors queryWindows.ts.
-const root = createRoot(() => {
+const root = moduleRoot(() => {
   const activeWindows = createMemo((): ActiveWindow[] =>
     orderUnreadWindows({
       candidates: buildCandidates(),

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -11,6 +11,7 @@
 // unauthenticated 401 from `Plugs.Authn` and the credential-failure 401
 // from login both surface here as `ApiError`.
 
+import { bootFetch } from "./bootFetch";
 import type { ModesEntry, TopicEntry } from "./channelTopic";
 import { getOrCreateClientId } from "./clientId";
 import type { MemberEntry } from "./memberTypes";
@@ -1577,8 +1578,13 @@ export async function deletePasskey(token: string, id: string, password: string)
   if (!res.ok) throw await readError(res, false);
 }
 
+// #717 — one of the three BOOT-CRITICAL GETs (with `listNetworks` and
+// `listChannels`). They feed the resource chain the CRT splash gates on, so
+// they go through `bootFetch`: per-attempt timeout + bounded retry on a
+// transport failure. See lib/bootFetch.ts for why the other ~100 call sites
+// in this module deliberately do NOT.
 export async function me(token: string): Promise<MeResponse> {
-  const res = await fetch("/me", {
+  const res = await bootFetch("/me", {
     headers: buildHeaders(token),
   });
   if (!res.ok) throw await readError(res);
@@ -2059,16 +2065,18 @@ export async function deleteAccount(token: string): Promise<void> {
 // park/reconnect each network via `patchNetwork(t, slug, {...})` like
 // users; global disconnect is the client-composed park-all in `quit.ts`.
 
+// #717 boot-critical GET — see `me` above.
 export async function listNetworks(token: string): Promise<RawNetwork[]> {
-  const res = await fetch("/networks", {
+  const res = await bootFetch("/networks", {
     headers: buildHeaders(token),
   });
   if (!res.ok) throw await readError(res);
   return (await res.json()) as RawNetwork[];
 }
 
+// #717 boot-critical GET — see `me` above.
 export async function listChannels(token: string, networkSlug: string): Promise<ChannelEntry[]> {
-  const res = await fetch(`/networks/${encodeURIComponent(networkSlug)}/channels`, {
+  const res = await bootFetch(`/networks/${encodeURIComponent(networkSlug)}/channels`, {
     headers: buildHeaders(token),
   });
   if (!res.ok) throw await readError(res);

--- a/cicchetto/src/lib/banlistModal.ts
+++ b/cicchetto/src/lib/banlistModal.ts
@@ -1,4 +1,5 @@
-import { createRoot, createSignal } from "solid-js";
+import { createSignal } from "solid-js";
+import { moduleRoot } from "./moduleRoot";
 
 // #386 — ban-management modal open/close store.
 //
@@ -20,7 +21,7 @@ import { createRoot, createSignal } from "solid-js";
 
 export type BanlistModalTarget = { networkSlug: string; channel: string };
 
-const exports_ = createRoot(() => {
+const exports_ = moduleRoot(() => {
   const [banlistModalState, setBanlistModalState] = createSignal<BanlistModalTarget | null>(null);
 
   const openBanlistModal = (networkSlug: string, channel: string): void => {

--- a/cicchetto/src/lib/bootFetch.test.ts
+++ b/cicchetto/src/lib/bootFetch.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BOOT_FETCH_ATTEMPTS,
+  BOOT_FETCH_BACKOFF_MS,
+  BOOT_FETCH_TIMEOUT_MS,
+  bootFetch,
+} from "./bootFetch";
+
+// #717 — the three boot fetches (`me`, `listNetworks`, `listChannels`) are the
+// ones the CRT splash gates on. Unbounded, a single stalled request kept the
+// splash up forever with no recovery. These tests pin the transport policy:
+// every attempt is time-bounded, a transport failure is retried, and an HTTP
+// response — whatever its status — is an ANSWER and must not be retried.
+
+const totalBackoffMs = BOOT_FETCH_BACKOFF_MS.reduce((a, b) => a + b, 0);
+
+// Explicit rather than `calls[i]?.[1]`: an optional chain feeding a member
+// access reads as "may be absent" while still throwing a bare TypeError if it
+// is, which tells you nothing about which call was missing.
+function initOfCall(calls: readonly unknown[][], index: number): RequestInit {
+  const call = calls[index];
+  if (call === undefined) throw new Error(`expected a fetch call at index ${index}`);
+  return call[1] as RequestInit;
+}
+
+describe("bootFetch (#717 — bounded, retrying boot transport)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the response and calls fetch once when the first attempt succeeds", async () => {
+    const ok = new Response("{}", { status: 200 });
+    const fetchMock = vi.fn(async () => ok);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(bootFetch("/me", {})).resolves.toBe(ok);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry an HTTP error response — a status is an answer, not a stall", async () => {
+    const boom = new Response("{}", { status: 503 });
+    const fetchMock = vi.fn(async () => boom);
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Returned, not thrown: the caller's own `!res.ok` arm owns status
+    // handling (and 401 already has its dedicated path through on401).
+    await expect(bootFetch("/me", {})).resolves.toBe(boom);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a transport failure and returns the eventual success", async () => {
+    const ok = new Response("{}", { status: 200 });
+    const fetchMock = vi
+      .fn<() => Promise<Response>>()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(ok);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const promise = bootFetch("/me", {});
+    await vi.advanceTimersByTimeAsync(totalBackoffMs);
+
+    await expect(promise).resolves.toBe(ok);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up after the last attempt and rejects with the transport error", async () => {
+    const err = new TypeError("Failed to fetch");
+    const fetchMock = vi.fn<() => Promise<Response>>().mockRejectedValue(err);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const promise = bootFetch("/me", {});
+    const settled = expect(promise).rejects.toBe(err);
+    await vi.advanceTimersByTimeAsync(totalBackoffMs);
+    await settled;
+
+    // Bounded: the retry loop must terminate, or it becomes the very hang it
+    // exists to prevent.
+    expect(fetchMock).toHaveBeenCalledTimes(BOOT_FETCH_ATTEMPTS);
+  });
+
+  it("bounds every attempt with an abort signal", async () => {
+    const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await bootFetch("/me", { headers: { authorization: "Bearer t" } });
+
+    const init = initOfCall(fetchMock.mock.calls, 0);
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    // The caller's own init must survive — dropping the bearer here would
+    // 401 every boot.
+    expect((init.headers as Record<string, string>).authorization).toBe("Bearer t");
+  });
+
+  it("bounds each attempt with the configured timeout, not an arbitrary one", async () => {
+    // Without this, BOOT_FETCH_TIMEOUT_MS could be deleted and every other
+    // test here would still pass. It asserts the WIRING (the constant reaches
+    // the platform call); the wall-clock abort itself is the platform's
+    // contract, which `vi.useFakeTimers` does not drive.
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("{}", { status: 200 })),
+    );
+
+    await bootFetch("/me", {});
+
+    expect(timeoutSpy).toHaveBeenCalledWith(BOOT_FETCH_TIMEOUT_MS);
+    timeoutSpy.mockRestore();
+  });
+
+  it("treats an attempt killed by its own timeout as retryable", async () => {
+    const ok = new Response("{}", { status: 200 });
+    const fetchMock = vi
+      .fn<() => Promise<Response>>()
+      // What the platform hands back when an AbortSignal.timeout fires.
+      .mockRejectedValueOnce(new DOMException("The operation timed out.", "TimeoutError"))
+      .mockResolvedValueOnce(ok);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const promise = bootFetch("/me", {});
+    await vi.advanceTimersByTimeAsync(totalBackoffMs);
+
+    await expect(promise).resolves.toBe(ok);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives each attempt its own signal, so attempt 1's timeout cannot abort attempt 2", async () => {
+    const fetchMock = vi
+      .fn<() => Promise<Response>>()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const promise = bootFetch("/me", {});
+    await vi.advanceTimersByTimeAsync(totalBackoffMs);
+    await promise;
+
+    const first = initOfCall(fetchMock.mock.calls, 0).signal;
+    const second = initOfCall(fetchMock.mock.calls, 1).signal;
+    expect(first).not.toBe(second);
+  });
+});

--- a/cicchetto/src/lib/bootFetch.ts
+++ b/cicchetto/src/lib/bootFetch.ts
@@ -1,0 +1,81 @@
+// #717 — bounded transport for the three boot-critical GETs.
+//
+// The CRT splash gates on `user` → `networks` → `channelsBySlug` (lib/networks.ts),
+// fed by `me()`, `listNetworks()` and `listChannels()`. Before this, none of the
+// three carried a timeout, an abort or a retry: one stalled request left the
+// splash up indefinitely with no way out but force-killing the app — the #717
+// report from an installed Android/Firefox PWA.
+//
+// This module owns the TRANSPORT half only. It cannot be the whole fix, and the
+// distinction matters: bounding a hang converts it into a REJECTION, and a
+// rejected boot resource re-throws on every read, which froze the UI just as
+// hard. `BootErrorBoundary.tsx` catches that. Retry absorbs the transient
+// failure; the boundary catches the terminal one.
+//
+// Scoped to the boot three ON PURPOSE. api.ts has ~100 `fetch` call sites and no
+// central wrapper; funnelling all of them through a retrying helper is a
+// different, much larger change, and most of them are user-initiated actions
+// where a silent retry is wrong (a failed PATCH should report, not re-send).
+// "Boot-critical GET" is a real category: idempotent, unattended, and the only
+// thing standing between the user and a usable app.
+//
+// WHAT IS RETRIED: a rejected `fetch` — DNS failure, connection refused, TLS
+// failure, the abort from our own timeout. That is the class where trying again
+// can plausibly work, and it covers the #193 door (the server restarting under
+// us refuses the connection). An HTTP RESPONSE is never retried whatever its
+// status: the server answered, the caller's `!res.ok` arm owns it, and 401
+// already has its own path (on401 → clear token → /login). Re-sending on a 503
+// would also turn a struggling server into a thundering herd of reloading PWAs.
+
+/** Per-attempt ceiling. Exceeding it aborts THAT attempt, not the whole boot. */
+export const BOOT_FETCH_TIMEOUT_MS = 8_000;
+
+/** Backoff before attempt 2 and attempt 3. Its length defines the retry count. */
+export const BOOT_FETCH_BACKOFF_MS: readonly number[] = [500, 2_000];
+
+/** Total attempts — the first, plus one per backoff step. */
+export const BOOT_FETCH_ATTEMPTS = BOOT_FETCH_BACKOFF_MS.length + 1;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * GET a boot-critical resource with a per-attempt timeout and bounded retry.
+ *
+ * Resolves with the `Response` for ANY completed request, including error
+ * statuses — status handling stays with the caller. Rejects with the last
+ * transport error once the attempts are exhausted.
+ */
+export async function bootFetch(
+  path: string,
+  // `signal` is EXCLUDED rather than merged: this function owns the abort, and
+  // a plain `RequestInit` would advertise a `signal` that the spread below
+  // silently overwrites. No caller needs one today; the type says so instead
+  // of letting the next one find out at runtime.
+  init: Omit<RequestInit, "signal">,
+): Promise<Response> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < BOOT_FETCH_ATTEMPTS; attempt++) {
+    // OUTSIDE the try, deliberately. On a runtime without
+    // `AbortSignal.timeout` this raises a TypeError, and inside the try it
+    // would be counted as a transport failure — retried three times and then
+    // reported as "the network is down" on a box whose network is fine.
+    // A missing platform API is a hard failure and must read like one.
+    //
+    // A FRESH signal per attempt: reusing one would let attempt 1's expiry
+    // abort attempt 2 the moment it started — a retry that can never win.
+    const signal = AbortSignal.timeout(BOOT_FETCH_TIMEOUT_MS);
+    try {
+      return await fetch(path, { ...init, signal });
+    } catch (error) {
+      lastError = error;
+      const backoff = BOOT_FETCH_BACKOFF_MS[attempt];
+      if (backoff === undefined) break;
+      await sleep(backoff);
+    }
+  }
+
+  throw lastError;
+}

--- a/cicchetto/src/lib/channelTopic.ts
+++ b/cicchetto/src/lib/channelTopic.ts
@@ -1,5 +1,6 @@
-import { createRoot, createSignal } from "solid-js";
+import { createSignal } from "solid-js";
 import type { ChannelKey } from "./channelKey";
+import { moduleRoot } from "./moduleRoot";
 
 // Per-channel topic + modes store. Module-singleton reactive signals.
 //
@@ -40,7 +41,7 @@ export type ModesEntry = {
   params: Record<string, string | null>;
 };
 
-const exports_ = createRoot(() => {
+const exports_ = moduleRoot(() => {
   const [topicByChannel, setTopicByChannel] = createSignal<Record<ChannelKey, TopicEntry>>({});
   const [modesByChannel, setModesByChannel] = createSignal<Record<ChannelKey, ModesEntry>>({});
 

--- a/cicchetto/src/lib/colorNicklist.ts
+++ b/cicchetto/src/lib/colorNicklist.ts
@@ -1,4 +1,5 @@
-import { createRoot, createSignal } from "solid-js";
+import { createSignal } from "solid-js";
+import { moduleRoot } from "./moduleRoot";
 
 // #443 — "show colored nicklist" display preference. Boolean, OFF by
 // default: the members pane renders nicks monochrome on purpose
@@ -41,7 +42,7 @@ function readStored(): boolean {
 // Module-singleton signal seeded from storage. createRoot anchors it for the
 // app lifetime (same shape as timeFormat.ts) — the preference is
 // identity-agnostic, so no token-rotation reset arm is needed.
-const { current, setCurrent } = createRoot(() => {
+const { current, setCurrent } = moduleRoot(() => {
   const [current, setCurrent] = createSignal<boolean>(readStored());
   return { current, setCurrent };
 });

--- a/cicchetto/src/lib/customTheme.ts
+++ b/cicchetto/src/lib/customTheme.ts
@@ -1,5 +1,6 @@
-import { createEffect, createRoot, createSignal } from "solid-js";
+import { createEffect, createSignal } from "solid-js";
 import { token } from "./auth";
+import { moduleRoot } from "./moduleRoot";
 import { prefersDark } from "./theme";
 import type { ActiveThemePair, TokenPayload } from "./themesApi";
 import { getActiveThemePair, setActiveThemePair } from "./themesApi";
@@ -229,7 +230,7 @@ function writeCache(pair: PayloadPair): void {
 // the night theme even in daylight (cleared on leaving the gallery — the
 // automatic behaviour always follows the OS). Own root (module-lifetime), fed
 // by the boot cache, the mount sync, and `activateThemePair`.
-const store = createRoot(() => {
+const store = moduleRoot(() => {
   const [activePair, setActivePair] = createSignal<{ light: number | null; dark: number | null }>({
     light: null,
     dark: null,

--- a/cicchetto/src/lib/documentVisibility.ts
+++ b/cicchetto/src/lib/documentVisibility.ts
@@ -21,14 +21,15 @@
 // SSR-cheap defensive boundary kept (cicchetto isn't SSR'd today, but the
 // guard costs nothing and matches theme.ts).
 
-import { createEffect, createRoot, createSignal } from "solid-js";
+import { createEffect, createSignal } from "solid-js";
+import { moduleRoot } from "./moduleRoot";
 
 const computeVisible = (): boolean => {
   if (typeof document === "undefined") return true;
   return document.visibilityState === "visible" && document.hasFocus();
 };
 
-const exports_ = createRoot(() => {
+const exports_ = moduleRoot(() => {
   const [visible, setVisible] = createSignal(computeVisible());
 
   if (typeof document !== "undefined") {

--- a/cicchetto/src/lib/home.ts
+++ b/cicchetto/src/lib/home.ts
@@ -1,5 +1,6 @@
-import { createMemo, createRoot, createSignal } from "solid-js";
+import { createMemo, createSignal } from "solid-js";
 import type { HomeData, HomeNetworkRow, MeResponse } from "./api";
+import { moduleRoot } from "./moduleRoot";
 import { user } from "./networks";
 
 // UX-4 bucket B / #211 phase 6 — HomePane data signal.
@@ -30,7 +31,12 @@ import { user } from "./networks";
 // HomePane renders `HomePaneRegistered` off the non-null result for
 // either subject; `null` renders nothing (logged out / loading).
 
-const exports = createRoot(() => {
+// #717 — `moduleRoot`, not a bare `createRoot`. `homeData` is a module-root memo
+// that reads `user()`, so when the boot resource errors it re-throws in a root
+// with no error handler and takes the update cycle down with it. This store
+// scopes itself by subject id below, so it wants the root and the error
+// context, not the identity-reset wiring.
+const exports = moduleRoot(() => {
   // Live overrides keyed by slug. Patches from typed events land here;
   // `homeData` overlays them on top of the /me envelope.
   const [overrides, setOverrides] = createSignal<Record<string, HomeNetworkRow>>({});

--- a/cicchetto/src/lib/identityScopedStore.ts
+++ b/cicchetto/src/lib/identityScopedStore.ts
@@ -1,5 +1,6 @@
 import { createEffect, createRoot, on } from "solid-js";
 import { token } from "./auth";
+import { withErrorContext } from "./moduleRoot";
 
 // Factory wrapping the duplicated identity-rotation cleanup pattern.
 //
@@ -35,12 +36,30 @@ import { token } from "./auth";
 // state writes inside `build` happen pre-cleanup-arm. The factory
 // preserves the pre-A3 ordering — no behavior change at call sites.
 
+// #717 — the error context comes from `moduleRoot`, and the reset wiring is
+// deliberately kept OUT of it.
+//
+// `withErrorContext` wraps `build` ONLY. The `on(token)` effect below is
+// registered after it returns — same owner, no error context — so a reset that
+// throws stays LOUD. Inside the context it would be caught and logged, and
+// because the loop aborts at the throw the store's REMAINING resets would be
+// silently skipped on logout or rotation. That is #281's failure mode: a missed
+// identity purge produces the 404 burst this module's header describes, which
+// trips the host's fail2ban jail and firewall-bans the client. CLAUDE.md is
+// explicit — never widen the catch to swallow more.
+//
+// See `moduleRoot.ts` for why root creation owns the error context at all.
 export function identityScopedStore<T>(
   build: (onIdentityChange: (reset: () => void) => void) => T,
 ): T {
   return createRoot(() => {
     const resets: Array<() => void> = [];
-    const result = build((reset) => resets.push(reset));
+
+    // Ordering preserved from the pre-#717 shape (the A1 invariant above):
+    // `build` runs BEFORE the on(token) effect registers, so synchronous state
+    // writes inside build still happen pre-cleanup-arm.
+    const result = withErrorContext(() => build((reset) => resets.push(reset)));
+
     createEffect(
       on(token, (t, prev) => {
         if (prev != null && t !== prev) {
@@ -48,6 +67,7 @@ export function identityScopedStore<T>(
         }
       }),
     );
+
     return result;
   });
 }

--- a/cicchetto/src/lib/isupport.ts
+++ b/cicchetto/src/lib/isupport.ts
@@ -1,4 +1,5 @@
-import { createRoot, createSignal } from "solid-js";
+import { createSignal } from "solid-js";
+import { moduleRoot } from "./moduleRoot";
 
 // #216 — per-network ISUPPORT channel-mode capability store.
 //
@@ -42,7 +43,7 @@ export const DEFAULT_ISUPPORT: IsupportEntry = {
   prefix: { o: "@", h: "%", v: "+" },
 };
 
-const exports_ = createRoot(() => {
+const exports_ = moduleRoot(() => {
   const [isupportByNetwork, setIsupportByNetwork] = createSignal<Record<number, IsupportEntry>>({});
 
   const seedIsupport = (networkId: number, entry: IsupportEntry): void => {

--- a/cicchetto/src/lib/modeModal.ts
+++ b/cicchetto/src/lib/modeModal.ts
@@ -1,4 +1,5 @@
-import { createRoot, createSignal } from "solid-js";
+import { createSignal } from "solid-js";
+import { moduleRoot } from "./moduleRoot";
 
 // #216 — /mode viewer/editor modal open/close store.
 //
@@ -16,7 +17,7 @@ import { createRoot, createSignal } from "solid-js";
 
 export type ModeModalTarget = { networkSlug: string; channel: string };
 
-const exports_ = createRoot(() => {
+const exports_ = moduleRoot(() => {
   const [modeModalState, setModeModalState] = createSignal<ModeModalTarget | null>(null);
 
   const openModeModal = (networkSlug: string, channel: string): void => {

--- a/cicchetto/src/lib/moduleRoot.ts
+++ b/cicchetto/src/lib/moduleRoot.ts
@@ -1,0 +1,86 @@
+import { catchError, createRoot } from "solid-js";
+
+// #717 — THE door for a module-lifetime reactive root.
+//
+// A root created with a bare `createRoot` has no error handler. Any computation
+// inside one that throws — most importantly the `createMemo(source)` Solid
+// compiles for `createResource(user, …)`, or any module-level memo that reads a
+// resource — propagates out of `runUpdates`, which sets `Effects = null;
+// Updates = null` before rehandling. **The queued render effects are
+// discarded**, so the error surfaces as an unhandled rejection that no
+// `<ErrorBoundary/>` in the render tree ever sees, and the DOM keeps whatever
+// frame it last painted. On a cold boot that frame is the CRT splash, which is
+// the #717 symptom: hung forever, no recovery but force-killing the app.
+//
+// The error context therefore belongs to root CREATION, not to whichever module
+// happens to read a failing resource next. The first cut of #717 gave the
+// context to `identityScopedStore` alone and left the other roots bare;
+// `activeWindows.ts` — a module-level memo reading `channelsBySlug()` and
+// `networks()`, subscribed before the first render — then swallowed the
+// `listNetworks`/`listChannels` failures exactly as before, because it runs
+// EARLIER in the Updates queue than the store's own memo and aborts the cycle
+// before the store's handler is reached. Two patterns, and the boot froze
+// through the gap between them. Hence one door, and
+// `__tests__/moduleRootGuard.test.ts` fails the build if a bare `createRoot`
+// comes back.
+//
+// "Module" means module-LIFETIME, not lexical position: these roots are
+// singletons that are never disposed. A root created inside a boot-time
+// installer belongs here too.
+//
+// NOT a silent swallow. This handler owns the DIAGNOSTIC; the render-tree
+// `BootErrorBoundary` owns the USER-FACING state and the retry. Neither alone
+// is enough — a boundary cannot catch what never reaches it, and a console line
+// is not a recovery affordance.
+
+/**
+ * Run `build` under an error context, in the CURRENT owner.
+ *
+ * Returns what `build` returned. Throws — with the original error as `cause` —
+ * if `build` itself threw, because there is no store to hand back and a
+ * half-built singleton would be dereferenced by every caller. Throws from
+ * computations created inside `build` are caught later and logged.
+ *
+ * Exported for `identityScopedStore`, which needs the context around `build`
+ * only, with its reset wiring deliberately left OUTSIDE.
+ */
+export function withErrorContext<T>(build: () => T): T {
+  // Boxed rather than read off `catchError`'s return: that helper reports a
+  // caught throw as `undefined`, which is indistinguishable from a build whose
+  // T genuinely IS void (the side-effect-only roots).
+  let built: { value: T } | undefined;
+  // Boxed for the same reason — `undefined` is a legitimate thrown value.
+  let buildError: { error: unknown } | undefined;
+
+  catchError(
+    () => {
+      // A synchronous build failure is caught HERE rather than left to the
+      // handler below. Inside a `createRoot`, `catchError`'s handler does not
+      // necessarily run before `catchError` returns — measured: it does not —
+      // so reading the error off the handler produced a rethrow with an empty
+      // `cause`, losing the stack on the one failure that most needs it.
+      try {
+        built = { value: build() };
+      } catch (error) {
+        buildError = { error };
+      }
+    },
+    (error) => {
+      console.error("[grappa] module root: computation threw", error);
+    },
+  );
+
+  if (buildError !== undefined) {
+    throw new Error("moduleRoot: build threw before the root was created", {
+      cause: buildError.error,
+    });
+  }
+  // Assigned on every path the try did not catch, which is every path that
+  // reaches here.
+  return (built as { value: T }).value;
+}
+
+/** Open a module-lifetime reactive root whose computations have an error context. */
+export function moduleRoot<T>(build: () => T): T {
+  return createRoot(() => withErrorContext(build));
+}

--- a/cicchetto/src/lib/presenceFilter.ts
+++ b/cicchetto/src/lib/presenceFilter.ts
@@ -1,6 +1,7 @@
-import { createRoot, createSignal } from "solid-js";
+import { createSignal } from "solid-js";
 import type { ScrollbackMessage } from "./api";
 import type { ChannelKey } from "./channelKey";
+import { moduleRoot } from "./moduleRoot";
 
 // #222 — hide join/part/quit/nick-change signalling on large channels by
 // default, with a per-channel opt-in to re-show. Closed-set per-channel
@@ -105,7 +106,7 @@ function readStored(): PrefMap {
 // Module-singleton signal seeded from storage. createRoot anchors it for the
 // app lifetime (same shape as timeFormat.ts) — the preference is identity-
 // agnostic display state, so no token-rotation reset arm is needed.
-const { prefs, setPrefs } = createRoot(() => {
+const { prefs, setPrefs } = moduleRoot(() => {
   const [prefs, setPrefs] = createSignal<PrefMap>(readStored());
   return { prefs, setPrefs };
 });

--- a/cicchetto/src/lib/pushTarget.ts
+++ b/cicchetto/src/lib/pushTarget.ts
@@ -23,7 +23,8 @@
 // applies the same routing. Deferred until networks() seed so the
 // selection doesn't fire on a still-loading store.
 
-import { createEffect, createRoot, on } from "solid-js";
+import { createEffect, on } from "solid-js";
+import { moduleRoot } from "./moduleRoot";
 import { networkBySlug, networks } from "./networks";
 import { type PushTarget, parsePushTargetUrl } from "./pushPayload";
 import { canonicalQueryNick, openQueryWindowState } from "./queryWindows";
@@ -168,7 +169,7 @@ declare global {
 
 function deferUntilNetworksSeed(target: PushTarget): void {
   let applied = false;
-  createRoot(() => {
+  moduleRoot(() => {
     createEffect(
       on(networks, (nets) => {
         if (applied) return;

--- a/cicchetto/src/lib/queryWindows.ts
+++ b/cicchetto/src/lib/queryWindows.ts
@@ -1,4 +1,5 @@
-import { createRoot, createSignal, untrack } from "solid-js";
+import { createSignal, untrack } from "solid-js";
+import { moduleRoot } from "./moduleRoot";
 import { nickEquals } from "./nickEquals";
 import { pushCloseQueryWindow, pushOpenQueryWindow } from "./socket";
 
@@ -36,7 +37,7 @@ export type QueryWindow = {
   openedAt: string;
 };
 
-const exports = createRoot(() => {
+const exports = moduleRoot(() => {
   const [queryWindowsByNetwork, setQueryWindowsByNetwork] = createSignal<
     Record<number, QueryWindow[]>
   >({});

--- a/cicchetto/src/lib/readCursor.ts
+++ b/cicchetto/src/lib/readCursor.ts
@@ -30,15 +30,16 @@
 // on logout / token rotation, mirroring scrollback.ts / selection.ts /
 // members.ts.
 
-import { createEffect, createRoot, createSignal, on } from "solid-js";
+import { createEffect, createSignal, on } from "solid-js";
 import { token } from "./auth";
+import { moduleRoot } from "./moduleRoot";
 import { isVirtualWindowName } from "./windowKinds";
 
 const LEGACY_KEY_PREFIX = "rc:";
 
 const cacheKey = (networkSlug: string, channel: string): string => `${networkSlug} ${channel}`;
 
-const [cursors, setCursors] = createRoot(() => createSignal<Record<string, number>>({}));
+const [cursors, setCursors] = moduleRoot(() => createSignal<Record<string, number>>({}));
 
 /**
  * Returns the stored read-cursor `last_read_message_id` for
@@ -292,7 +293,7 @@ purgeLegacyKeys();
 // `prev != null` filters both the initial run (prev === undefined) and
 // the cold-start login (prev === null) — only logout (tokA→null) and
 // rotation (tokA→tokB) trigger the wipe.
-createRoot(() => {
+moduleRoot(() => {
   createEffect(
     on(token, (t, prev) => {
       if (prev != null && t !== prev) {

--- a/cicchetto/src/lib/recoverProgress.ts
+++ b/cicchetto/src/lib/recoverProgress.ts
@@ -1,5 +1,6 @@
-import { createRoot, createSignal } from "solid-js";
+import { createSignal } from "solid-js";
 import type { RecoverOutcome, RecoverStatus, RecoverStep, WireUserEvent } from "./api";
+import { moduleRoot } from "./moduleRoot";
 
 // #581 — "recover my identity" progress store.
 //
@@ -59,7 +60,7 @@ function upsertStep(steps: RecoverStepEntry[], evt: RecoverProgressEvent): Recov
   return next;
 }
 
-const exports_ = createRoot(() => {
+const exports_ = moduleRoot(() => {
   const [recoverState, setRecoverState] = createSignal<RecoverState | null>(null);
 
   // Apply `fn` to the current open state; no-op when closed (a late event must

--- a/cicchetto/src/lib/registrationWizard.ts
+++ b/cicchetto/src/lib/registrationWizard.ts
@@ -1,4 +1,5 @@
-import { createRoot, createSignal } from "solid-js";
+import { createSignal } from "solid-js";
+import { moduleRoot } from "./moduleRoot";
 import { serviceMirrorRows } from "./serviceModal";
 
 // #349 — NickServ registration wizard open/close + step store.
@@ -63,7 +64,7 @@ const clampStep = (n: number): WizardStep => {
   return n as WizardStep;
 };
 
-const exports_ = createRoot(() => {
+const exports_ = moduleRoot(() => {
   const [registrationWizardState, setRegistrationWizardState] =
     createSignal<RegistrationWizardState | null>(null);
 

--- a/cicchetto/src/lib/serviceModal.ts
+++ b/cicchetto/src/lib/serviceModal.ts
@@ -1,6 +1,7 @@
-import { createRoot, createSignal } from "solid-js";
+import { createSignal } from "solid-js";
 import type { ScrollbackMessage } from "./api";
 import { channelKey } from "./channelKey";
+import { moduleRoot } from "./moduleRoot";
 import { scrollbackByChannel } from "./scrollback";
 import { SERVER_WINDOW_NAME } from "./windowKinds";
 
@@ -60,7 +61,7 @@ export const serviceMirrorRows = (
   return [...server, ...query].sort((a, b) => a.id - b.id);
 };
 
-const exports_ = createRoot(() => {
+const exports_ = moduleRoot(() => {
   const [serviceModalState, setServiceModalState] = createSignal<ServiceModalTarget | null>(null);
 
   const openServiceModal = (networkSlug: string, service: string): void => {

--- a/cicchetto/src/lib/shareModal.ts
+++ b/cicchetto/src/lib/shareModal.ts
@@ -1,4 +1,5 @@
-import { createRoot, createSignal } from "solid-js";
+import { createSignal } from "solid-js";
+import { moduleRoot } from "./moduleRoot";
 
 // #392 — session-share modal open/close. A module-singleton boolean signal
 // (like serviceModal / umodeModal). The share is SESSION-WIDE (it shares the
@@ -15,7 +16,7 @@ import { createRoot, createSignal } from "solid-js";
 // Transient UI state, not identity-scoped survival — a logout unmounts the
 // shell and the flag resets with it.
 
-const exports_ = createRoot(() => {
+const exports_ = moduleRoot(() => {
   const [shareModalOpen, setShareModalOpen] = createSignal(false);
   const openShareModal = (): void => {
     setShareModalOpen(true);

--- a/cicchetto/src/lib/socket.ts
+++ b/cicchetto/src/lib/socket.ts
@@ -1,8 +1,9 @@
 import { type Channel, Socket } from "phoenix";
-import { createEffect, createRoot, on } from "solid-js";
+import { createEffect, on } from "solid-js";
 import { channelPushError } from "./api";
 import { token } from "./auth";
 import { canonicalChannel } from "./channelKey";
+import { moduleRoot } from "./moduleRoot";
 import { recordSocketClose, recordSocketError, recordSocketOpen } from "./socketHealth";
 
 // Phoenix Channels singleton. Mirrors `auth.ts`'s module-singleton shape:
@@ -124,7 +125,7 @@ function getSocket(): Socket {
   return _socket;
 }
 
-createRoot(() => {
+moduleRoot(() => {
   createEffect(
     on(token, (t, prev) => {
       if (t === null) {

--- a/cicchetto/src/lib/subscribe.ts
+++ b/cicchetto/src/lib/subscribe.ts
@@ -1,5 +1,5 @@
 import type { Channel } from "phoenix";
-import { createEffect, createRoot, on, untrack } from "solid-js";
+import { createEffect, on, untrack } from "solid-js";
 import { assertNever, type ChannelEvent, ownNickForNetwork } from "./api";
 import { socketUserName, token } from "./auth";
 import { incrementBadge, setBadge } from "./badge";
@@ -12,6 +12,7 @@ import { seedIsupport } from "./isupport";
 import { applyPresenceEvent, seedMembers } from "./members";
 import { matchesWatchlist } from "./mentionMatch";
 import { setServerMention } from "./mentions";
+import { moduleRoot } from "./moduleRoot";
 import {
   channelsBySlug,
   networkIdBySlug,
@@ -115,7 +116,13 @@ import { narrowChannelEvent } from "./wireNarrow";
 // ONLY by `__cic_suppressChannelDeliveryForTests`; empty in production.
 const suppressedDeliveryKeys = new Set<ChannelKey>();
 
-createRoot(() => {
+// #717 — `moduleRoot`, not a bare `createRoot`. The join effects below read
+// `user()` and `channelsBySlug()`; in a bare root a throw from an errored boot
+// resource escapes `runUpdates`, which discards the queued render effects and so
+// denies the render-tree ErrorBoundary the chance to recover. This root handles
+// rotation itself via the `joined` map below, so it wants the root and the error
+// context, not the identity-reset wiring.
+moduleRoot(() => {
   // Codebase review 2026-05-08 cic H2 (HIGH): track Channel objects, not
   // just keys. On rotation we MUST `phx.leave()` each prior Channel
   // before clearing — phoenix.js's `socket.channel(topic)` always

--- a/cicchetto/src/lib/supportedUmodes.ts
+++ b/cicchetto/src/lib/supportedUmodes.ts
@@ -1,4 +1,5 @@
-import { createRoot, createSignal } from "solid-js";
+import { createSignal } from "solid-js";
+import { moduleRoot } from "./moduleRoot";
 
 // #249 — per-network SUPPORTED user-mode (umode) store.
 //
@@ -20,7 +21,7 @@ import { createRoot, createSignal } from "solid-js";
 // `supportedUmodesForNetwork/1` returns `[]` for an unseeded network, which
 // `availableUmodes` reads as "no server set → use the static fallback".
 
-const exports_ = createRoot(() => {
+const exports_ = moduleRoot(() => {
   const [supportedUmodesByNetwork, setSupportedUmodesByNetwork] = createSignal<
     Record<number, string[]>
   >({});

--- a/cicchetto/src/lib/theme.ts
+++ b/cicchetto/src/lib/theme.ts
@@ -1,4 +1,5 @@
-import { createEffect, createRoot, createSignal } from "solid-js";
+import { createEffect, createSignal } from "solid-js";
+import { moduleRoot } from "./moduleRoot";
 
 // Boot-time base theme + reactive viewport-mode signal.
 // Module-singleton pattern mirroring auth.ts / socket.ts / scrollback.ts:
@@ -60,7 +61,7 @@ const DARK_QUERY = "(prefers-color-scheme: dark)";
 // the SAME `prefers-color-scheme` media query the base already follows (no
 // scheduler, no geolocation). createRoot anchors the listeners since
 // module-level effects need an owner.
-const exports_ = createRoot(() => {
+const exports_ = moduleRoot(() => {
   const initial =
     typeof window !== "undefined" && window.matchMedia
       ? window.matchMedia(MOBILE_QUERY).matches

--- a/cicchetto/src/lib/themeEditor.ts
+++ b/cicchetto/src/lib/themeEditor.ts
@@ -1,5 +1,6 @@
-import { createRoot, createSignal } from "solid-js";
+import { createSignal } from "solid-js";
 import { activateTheme } from "./customTheme";
+import { moduleRoot } from "./moduleRoot";
 import type { ThemeColorKey, TokenPayload } from "./themesApi";
 import { createTheme, updateTheme } from "./themesApi";
 import type { ThemesWireT } from "./wireTypes";
@@ -45,7 +46,7 @@ export type ThemeEditorSeed =
 
 // Module-lifetime open/close signal — same shape as archiveModalNetwork.
 // null = closed; a seed = open (which mode + the initial draft source).
-const store = createRoot(() => {
+const store = moduleRoot(() => {
   const [state, setState] = createSignal<ThemeEditorSeed | null>(null);
   return { state, setState };
 });
@@ -65,7 +66,7 @@ export function closeThemeEditor(): void {
 // sub-page mounted underneath, so it won't re-fetch on its own. Rather than
 // couple the editor to the gallery's load verb, the editor bumps a revision
 // the gallery derives its reload from (one source, no parallel state).
-const rev = createRoot(() => {
+const rev = moduleRoot(() => {
   const [revision, setRevision] = createSignal(0);
   return { revision, setRevision };
 });

--- a/cicchetto/src/lib/timeFormat.ts
+++ b/cicchetto/src/lib/timeFormat.ts
@@ -1,4 +1,5 @@
-import { createRoot, createSignal } from "solid-js";
+import { createSignal } from "solid-js";
+import { moduleRoot } from "./moduleRoot";
 
 // #217 — message-timestamp format preference. Closed-set union with
 // localStorage persistence, backed by a module-singleton Solid signal so
@@ -57,7 +58,7 @@ function readStored(): TimeFormatKey {
 // Module-singleton signal seeded from storage. createRoot anchors it for
 // the app lifetime (same shape as theme.ts's isMobile) — the preference is
 // identity-agnostic, so no token-rotation reset arm is needed.
-const { current, setCurrent } = createRoot(() => {
+const { current, setCurrent } = moduleRoot(() => {
   const [current, setCurrent] = createSignal<TimeFormatKey>(readStored());
   return { current, setCurrent };
 });

--- a/cicchetto/src/lib/umodeModal.ts
+++ b/cicchetto/src/lib/umodeModal.ts
@@ -1,4 +1,5 @@
-import { createRoot, createSignal } from "solid-js";
+import { createSignal } from "solid-js";
+import { moduleRoot } from "./moduleRoot";
 
 // #229 — /mode <nick> (umode) viewer/editor modal open/close store.
 //
@@ -23,7 +24,7 @@ import { createRoot, createSignal } from "solid-js";
 
 export type UmodeModalTarget = { networkSlug: string };
 
-const exports_ = createRoot(() => {
+const exports_ = moduleRoot(() => {
   const [umodeModalState, setUmodeModalState] = createSignal<UmodeModalTarget | null>(null);
 
   const openUmodeModal = (networkSlug: string): void => {

--- a/cicchetto/src/lib/umodes.ts
+++ b/cicchetto/src/lib/umodes.ts
@@ -1,4 +1,5 @@
-import { createRoot, createSignal } from "solid-js";
+import { createSignal } from "solid-js";
+import { moduleRoot } from "./moduleRoot";
 
 // #229 — per-network USER-mode (umode) store.
 //
@@ -18,7 +19,7 @@ import { createRoot, createSignal } from "solid-js";
 // returns `[]` for a network not yet seeded, so the modal always has a usable
 // (empty) set even before the WS snapshot lands or for a parked session.
 
-const exports_ = createRoot(() => {
+const exports_ = moduleRoot(() => {
   const [umodesByNetwork, setUmodesByNetwork] = createSignal<Record<number, string[]>>({});
 
   const seedUmodes = (networkId: number, modes: string[]): void => {

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -1,5 +1,5 @@
 import type { Channel } from "phoenix";
-import { createEffect, createRoot, untrack } from "solid-js";
+import { createEffect, untrack } from "solid-js";
 import { refreshAliases } from "./aliasList";
 import {
   assertNever,
@@ -28,6 +28,7 @@ import { seedIsupport } from "./isupport";
 import { setLinksReply } from "./linksModal";
 import { applyLusersBundle, clearLusersRequested } from "./lusersBundle";
 import { setMentionsBundle } from "./mentionsWindow";
+import { moduleRoot } from "./moduleRoot";
 import { setNamesReply } from "./namesModal";
 import { mutateNetworkNick, refetchChannels, refetchNetworks } from "./networks";
 import {
@@ -946,7 +947,7 @@ function clearUserTopicReady(): void {
   w.__cic_userTopicReady?.clear();
 }
 
-createRoot(() => {
+moduleRoot(() => {
   // The user-topic Channel currently held on the live socket, or null
   // when logged out / mid-transition. Tracked (not a boolean guard) so a
   // rotation can `leave()` the orphaned prior Channel before re-joining —

--- a/cicchetto/src/main.tsx
+++ b/cicchetto/src/main.tsx
@@ -2,11 +2,11 @@ import { registerSW } from "virtual:pwa-register";
 import { Route, Router, useNavigate } from "@solidjs/router";
 import { type Component, createEffect, createSignal, type JSX, Show } from "solid-js";
 import { render } from "solid-js/web";
+import BootErrorBoundary from "./BootErrorBoundary";
 import InstallSplash, { INSTALL_CHOICE_KEY, shouldShowInstallSplash } from "./InstallSplash";
 import Login from "./Login";
 import { me } from "./lib/api";
 import { bootstrapAuth, isAuthenticated, token } from "./lib/auth";
-import BootErrorBoundary from "./BootErrorBoundary";
 import { moduleRoot } from "./lib/moduleRoot";
 import ShareConsume from "./ShareConsume";
 // Side-effect-only: registers the WS subscribe createRoot so per-

--- a/cicchetto/src/main.tsx
+++ b/cicchetto/src/main.tsx
@@ -1,11 +1,12 @@
 import { registerSW } from "virtual:pwa-register";
 import { Route, Router, useNavigate } from "@solidjs/router";
-import { type Component, createEffect, createRoot, createSignal, type JSX, Show } from "solid-js";
+import { type Component, createEffect, createSignal, type JSX, Show } from "solid-js";
 import { render } from "solid-js/web";
 import InstallSplash, { INSTALL_CHOICE_KEY, shouldShowInstallSplash } from "./InstallSplash";
 import Login from "./Login";
 import { me } from "./lib/api";
 import { bootstrapAuth, isAuthenticated, token } from "./lib/auth";
+import { moduleRoot } from "./lib/moduleRoot";
 import ShareConsume from "./ShareConsume";
 // Side-effect-only: registers the WS subscribe createRoot so per-
 // channel join effects fire once `user()` + `channelsBySlug()` resolve.
@@ -74,13 +75,13 @@ applyIosClass();
 // root so the createEffect has an app-lifetime owner; the signal is fed
 // from the `/me` seed, `read_cursor_set` broadcasts, the SW push, and
 // the optimistic foreground mention bump.
-createRoot(() => mountBadgeSync());
+moduleRoot(() => mountBadgeSync());
 
 // #75 — refresh the custom theme from the server on every `token()`
 // change: on login apply + cache the resolved `GET /me/theme` payload, on
 // logout clear back to the base cascade. Own root (app-lifetime owner for
 // the createEffect), alongside the other createRoot-wired effects.
-createRoot(() => mountCustomThemeSync());
+moduleRoot(() => mountCustomThemeSync());
 
 // #449 — reconcile the server-backed display prefs (presence filter #222, time
 // format #217, colored nicklist #443) on every `token()` change: on login apply
@@ -88,7 +89,7 @@ createRoot(() => mountCustomThemeSync());
 // persisted), so a single account converges its UI across devices. Boot already
 // seeded each owner module's signal from localStorage (FOUC-free). Own root,
 // alongside the other createRoot-wired token effects.
-createRoot(() => mountDisplayPrefsSync());
+moduleRoot(() => mountDisplayPrefsSync());
 
 // PWA icon badge foreground reconcile (#badge-orphan, 2026-06-21) — the
 // SW push path (door #1) writes `setAppBadge` directly off-signal while
@@ -251,7 +252,7 @@ window.addEventListener("beforeunload", notifyClientClosing);
 // operator owns the timing. Because that same heartbeat re-stamps every 30s
 // while genuinely foreground, "the stamp is old" IS "the document was not
 // visible" — the dwell needs no second visibility read.
-createRoot(() => {
+moduleRoot(() => {
   const checkStaleResume = installStaleResumeReload({
     isVisible: isDocumentVisible,
     bundleMismatch: shouldShowRefreshBanner,

--- a/cicchetto/src/main.tsx
+++ b/cicchetto/src/main.tsx
@@ -6,6 +6,7 @@ import InstallSplash, { INSTALL_CHOICE_KEY, shouldShowInstallSplash } from "./In
 import Login from "./Login";
 import { me } from "./lib/api";
 import { bootstrapAuth, isAuthenticated, token } from "./lib/auth";
+import BootErrorBoundary from "./BootErrorBoundary";
 import { moduleRoot } from "./lib/moduleRoot";
 import ShareConsume from "./ShareConsume";
 // Side-effect-only: registers the WS subscribe createRoot so per-
@@ -328,11 +329,21 @@ render(
             signed token and navigates into Shell once localStorage
             is populated. */}
         <Route path="/share/:token" component={ShareConsume} />
+        {/* #717 — the boundary wraps Shell ONLY, inside RequireAuth. A boot
+            fetch that rejects puts its resource in `errored` state and every
+            read re-throws (CrtSplash's `!user()` predicate among them); with
+            no boundary the throw froze the DOM on the splash forever, which
+            is the reported installed-PWA symptom. Scoped to Shell rather than
+            the Router so routing survives the crash: RequireAuth's effect
+            still bounces to /login if the token is cleared while the failure
+            state is up, and /login + /share keep their own error surfaces. */}
         <Route
           path="/"
           component={() => (
             <RequireAuth>
-              <Shell />
+              <BootErrorBoundary>
+                <Shell />
+              </BootErrorBoundary>
             </RequireAuth>
           )}
         />

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -8043,6 +8043,78 @@ html.resize-dragging * {
   font-style: italic;
 }
 
+/* #717 — boot-failure recovery state (BootErrorBoundary.tsx). Deliberately
+   plain, and deliberately NOT a second splash: this is the "the boot died,
+   here is the way out" state, while #687 owns the staged boot log the CRT
+   splash shows during a HEALTHY boot. Full-viewport because the boundary
+   replaces the entire Shell subtree — there is no pane left to sit inside.
+
+   Above .install-splash (z-index 200) and the .error-banners stack (1000):
+   when the boot dies this is the only reachable control on screen, so nothing
+   may paint over it.
+
+   The retry box is absolute px, NOT rem. The app's root font-size is 14px
+   (`:root --font-size`), so a rem-sized control lands well under the 44px HIG
+   minimum — the trap #459 fixed on the banner ×. On the Android PWA this
+   button is the ONLY escape from a dead boot; it gets the full tap target. */
+
+.boot-failure {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  /* `safe` matters: with a plain `center`, a column flex container that
+     overflows pushes its content past the START edge, which is unreachable by
+     scrolling — the title would clip with no way to read it. */
+  justify-content: safe center;
+  gap: 0.75rem;
+  padding: 1.5rem;
+  /* A long transport error on a 360px phone can outgrow the viewport, and the
+     buttons sit BELOW it — without a scroll the only way out would be
+     off-screen, which is the dead end this screen exists to remove. */
+  overflow: auto;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--font-mono);
+  text-align: center;
+}
+
+.boot-failure-title {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.boot-failure-detail {
+  margin: 0;
+  max-width: 32rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+  overflow-wrap: anywhere;
+}
+
+.boot-failure-retry,
+.boot-failure-reload {
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0 1.25rem;
+  background: var(--bg-alt);
+  color: var(--fg);
+  border: 1px solid var(--fg);
+  border-radius: 3px;
+  font-family: inherit;
+  font-size: inherit;
+  cursor: pointer;
+}
+
+/* Reload is the fallback-of-the-fallback, not the primary action — muted so
+   Retry reads as the thing to try first. */
+.boot-failure-reload {
+  border-color: var(--muted);
+  color: var(--muted);
+}
+
 /* #134 — retro CRT loading splash. LOADING-ONLY content of the Shell
    main-pane <Switch fallback> (desktop + mobile): fills the content
    pane while cic boots, then unmounts as the home window auto-selects.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -27646,6 +27646,32 @@ under us. `AbortSignal.timeout` is constructed OUTSIDE the try: inside, a
 runtime lacking the API would be counted as a transport failure, retried three
 times, and reported as "the network is down" on a box whose network is fine.
 
+**Retry refetches all three resources, because `reset()` is synchronous and the
+cascade is not.** The first cut refetched only `user`, reasoning that `networks`
+is keyed on `user` and `channelsBySlug` on `networks`, so the root cascades
+through both, and that calling all three would race redundant requests. The
+cascade is real but it is ASYNCHRONOUS, and `reset()` re-renders in the same
+tick: on a `listNetworks` failure the re-render read a `networks` that was still
+errored with nothing in flight, rethrew, and landed straight back in the
+fallback. **The button read as dead and recovery took a SECOND press** — the
+force-kill-the-app behaviour the whole issue exists to remove. The third review
+round found it; it was reproduced by execution before being believed, and the
+existing retry spec had missed it by covering only the `/me` failure, the one
+link where refetching the root alone happens to work.
+
+What clears the throw is not the response but the in-flight request — solid's
+resource read is `if (err !== undefined && !pr) throw err` — so each resource
+needs its own `pr` before the re-render. The feared request storm does not
+materialise: a resource whose source is not yet resolved takes solid's
+`lookup == null` path, which clears the error without issuing a request.
+Measured for one press on a `listNetworks` failure: `listNetworks` twice (the
+verb, then the cascade off the fresh `user`), `listChannels` not at all, and the
+spec pins both numbers. Root-first ordering mirrors the cascade but is NOT
+load-bearing — measured, the reverse also recovers, because each verb evaluates
+its source memo and a memo that throws is handled rather than propagated; it is
+written root-first because the reverse only works by routing a throw through the
+error machinery on every press.
+
 **Reload must not purge the cache offline.** The failure screen carries a
 `Reload` beside `Retry`, because the boundary wraps Shell for the whole session
 and a mid-session throw is not something a boot refetch can fix. It uses

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -27672,6 +27672,32 @@ its source memo and a memo that throws is handled rather than propagated; it is
 written root-first because the reverse only works by routing a throw through the
 error machinery on every press.
 
+**The purge needs positive evidence the server answers — `navigator.onLine`
+could not provide it.** The first cut gated `performRefresh` on `isOffline()`
+alone. Review round three killed that: `isOffline()` is `!navigator.onLine`,
+which is trustworthy in ONE direction only. `false` means definitely no link;
+`true` means merely "an interface exists". Behind a captive portal, on dead
+mobile data with the radio still attached, or on a Wi-Fi association with no
+route, it reads `true` — and those are exactly the conditions this screen comes
+up in. **The guard was weakest in its own motivating case**: on the reporter's
+Android PWA with the data link dead, the tap would have purged.
+
+The error carries the honest signal instead. An `ApiError` exists only because a
+response came back with a status, which is positive proof of reachability; a
+transport failure is not one, and by then `bootFetch` has already spent three
+attempts without the server ever answering. So the purge requires
+`error instanceof ApiError && !isOffline()` — both, because a status that came
+back earlier does not mean the link survived, and `navigator.onLine === false`
+is the one direction that IS conclusive.
+
+Everything else — a mid-session render throw the session-wide boundary caught —
+is connectivity-unknown, and unknown takes the plain reload by the **asymmetry
+of harm**: purging offline destroys the app shell and lands the PWA on the
+browser's offline error page, while not purging costs one extra reload and
+leaves #674's banner to offer the new bundle once the link is back. The accepted
+trade-off is that a genuinely stale bundle causing a render throw no longer gets
+cured by this button; that is #674's door, and it is the cheap failure.
+
 **Reload must not purge the cache offline.** The failure screen carries a
 `Reload` beside `Retry`, because the boundary wraps Shell for the whole session
 and a mid-session throw is not something a boot refetch can fix. It uses

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -27551,3 +27551,127 @@ resolution trades that for hopping windows mid-drain, which is worse.
 and behaves exactly as before; /me and the services arm gain the re-addressing
 they always needed; only the `/msg` redirect has two distinct homes, which is
 the only place the ownership question exists.
+## 2026-08-03 — #717: a boot that fails must stay recoverable, and root creation owns the error context
+
+**Scope, stated up front.** #717 is "the installed PWA on Android + Firefox hangs
+on the CRT splash; a browser tab on the same phone never does". The Android
+**trigger** is NOT root-caused here and stays open: the issue's own first
+measurement is device-side (desktop Firefox attached to the phone via
+`about:debugging`) and nobody has taken it. What landed is the
+**recoverability** half — the part decidable from the code, and the part that
+turns the next user report into evidence instead of another dead end.
+
+**The measured mechanism.** `CrtSplash.loading()` is `!user() ||
+channelsBySlug() === undefined`. Those are `createResource`s
+(`lib/networks.ts`) fed by `me()` / `listNetworks()` / `listChannels()`. When
+one of those fetches REJECTS the resource enters state `errored`, and reading an
+errored Solid resource **re-throws**. cicchetto mounted **no `ErrorBoundary`
+anywhere** — grep for the literal returned zero mounts; the only hit was a
+comment in `lib/customTheme.ts` noting it ran "outside any ErrorBoundary". So
+the DOM kept the last painted frame, which on a cold boot is the splash,
+forever.
+
+**A timeout alone cannot fix it, and that is load-bearing.** Bounding a hang
+converts it into a rejection, and a rejection is exactly the state that freezes
+the UI. Retry absorbs the transient failure; the boundary catches the terminal
+one. Either half shipped alone would look like a fix and change nothing the
+operator sees.
+
+**Root CREATION owns the error context — not the store, not the reader.** A root
+opened with a bare `createRoot` has no error handler. `createResource(user, …)`
+compiles its source into a `createMemo(user)` inside that root, so when `user`
+errors the memo re-reads and throws there; a throw with no error context
+propagates out of `runUpdates`, which nulls `Effects`/`Updates` before
+rehandling. The queued render effects are DISCARDED and the error surfaces as an
+unhandled rejection no render-tree boundary ever sees.
+
+The first cut of this fix put the context in `identityScopedStore` alone. That
+was wrong, and the review caught it with a measured matrix: `activeWindows.ts` —
+a bare root whose memo reads `channelsBySlug()` and `networks()`, subscribed
+before the first render — runs EARLIER in the Updates queue than the store's own
+memo, so it aborted the cycle first and the `listNetworks`/`listChannels`
+failures still froze the splash. `/me` survived only because that memo does not
+read `user()`. **Two patterns, and the boot fell through the gap between them.**
+CLAUDE.md is explicit ("half-migrated creates two patterns; no exclusion
+lists"), so the context moved to `moduleRoot` — one door — every module-lifetime
+root was migrated to it, and `__tests__/moduleRootGuard.test.ts` fails the build
+if a bare `createRoot` reappears. Test files are out of that rule on a real
+distinction, not a convenience: their roots take the `dispose` callback and are
+scoped to the case, which is precisely what `createRoot` is for.
+
+**The reset loop is deliberately OUTSIDE the context.** `identityScopedStore`
+wraps only `build` in `withErrorContext`; its `on(token)` effect is registered
+after. Inside, a reset that throws would be caught and logged, and because the
+loop aborts at the throw the store's REMAINING resets would be silently skipped
+on logout or rotation — #281's failure mode, whose missed identity purge
+produces the 404 burst that trips the host's fail2ban jail and firewall-bans the
+client. Never widen the catch to swallow more.
+
+**Not a silent swallow.** The factory handler owns the DIAGNOSTIC; the
+render-tree `BootErrorBoundary` owns the USER-FACING state and the retry.
+Neither alone is enough: a boundary cannot catch what never reaches it, and a
+console line is not a recovery affordance. A throw during `build` itself stays
+fatal — there is no store to hand back — and is rethrown with the original as
+`cause`. It is caught by a plain `try` rather than read off the `catchError`
+handler because, measured, that handler does not necessarily run before
+`catchError` returns inside a `createRoot`; reading the error off it produced a
+rethrow with an empty `cause`, losing the stack on the one failure that most
+needs it.
+
+**Order is what makes the test real, and the first two attempts got it wrong.**
+Attempt one built its own resource inside the component and mocked
+`lib/networks` away. Attempt two used the real cascade but let `me()` reject
+during the `await import(...)` calls, BEFORE `render()` — a resource already
+`errored` at first paint throws synchronously inside the boundary, with no
+update cycle to abort, so the bug is invisible. Both passed against an
+implementation that did not fix anything; the second was proved vacuous by
+reverting the fix and watching it stay green. Production is the opposite order:
+`main.tsx` imports statically and renders in the same turn, so the rejection
+always lands after first paint. The spec now settles `me()` by hand after
+`render()`, and reverting the fix turns it red.
+
+**The property the factory test pins is "the update cycle SURVIVED", not "the
+handler ran".** A handler-ran assertion would have stayed green straight through
+the `activeWindows` hole.
+
+**`bootFetch` is scoped to three of ~100 call sites, deliberately.** api.ts has
+no central wrapper, and most of its fetches are user-initiated actions where a
+silent retry is wrong — a failed PATCH must report, not re-send. "Boot-critical
+GET" passes CLAUDE.md's own boundary test: idempotent, unattended, and the only
+thing between the user and a usable app. An HTTP response is never retried
+whatever its status (the server answered; 401 has its own path; re-sending on a
+503 turns a struggling server into a thundering herd of reloading PWAs); only a
+rejected `fetch` is, which also covers the #193 door of a server restarting
+under us. `AbortSignal.timeout` is constructed OUTSIDE the try: inside, a
+runtime lacking the API would be counted as a transport failure, retried three
+times, and reported as "the network is down" on a box whose network is fine.
+
+**Reload must not purge the cache offline.** The failure screen carries a
+`Reload` beside `Retry`, because the boundary wraps Shell for the whole session
+and a mid-session throw is not something a boot refetch can fix. It uses
+`performRefresh` — the existing SW-aware verb (#674, #695) — ONLY when online.
+That verb deletes every cache before reloading, which #674 can do safely because
+a bundle-hash advertisement means the client is online by construction. This
+screen inverts the precondition: the likeliest reason it is up is that the
+network is gone, and purging the precache then lands the installed PWA on the
+browser's offline error page with the app shell destroyed — strictly worse than
+the frozen splash. Offline it does a plain reload. Reuse the verb, not the noun.
+
+**Known residuals.** (a) `bootFetch` is attached to the FUNCTION, not the boot
+call site, so `me()` from `mountBadgeReconcile` (every resume) and the WS-driven
+`refetchNetworks`/`refetchChannels` inherit the retry budget too — harmless
+today, unintended. (b) The 8s per-attempt ceiling with two backoffs means a
+worst case of ~26.5s before the failure screen appears, and `channelsBySlug`
+fans out with `Promise.all` so each network gets its own budget. (c) **Recovery
+now depends on some component INSIDE the boundary reading the specific errored
+resource.** Today that holds — `CrtSplash.tsx:39` reads `user` and
+`channelsBySlug`, `Sidebar.tsx` and `BottomBar.tsx` read `networks` — but it is
+a new load-bearing invariant. If a refactor puts the last in-tree `networks()`
+read behind a `<Show>` that is false during boot, the app goes back to hanging
+with only a console line.
+
+**Boundary with #687.** #687 owns the splash's UI: the staged boot log
+("fetching my info... done") and a per-stage stuck state during a HEALTHY boot.
+This change adds no competing layer — the failure screen is a terminal state
+that replaces the Shell subtree, deliberately bare, and must not become the
+place staged-progress copy accretes.


### PR DESCRIPTION
Refs #717.

## Scope, stated up front

**This does NOT fix the #717 trigger, and #717 stays open.** The report is "the installed PWA on Android + Firefox hangs on the CRT splash forever; a browser tab on the same phone never does". The trigger is not root-caused: the issue's own first measurement is device-side (desktop Firefox attached to the phone via `about:debugging`) and nobody has taken it.

What lands here is the **recoverability** half — the part decidable from the code, and the part that turns the next user report into evidence instead of another dead end.

## The measured mechanism

`CrtSplash.loading()` is `!user() || channelsBySlug() === undefined`. Those are `createResource`s fed by `me()` / `listNetworks()` / `listChannels()`. When one of those fetches **rejects**, the resource enters state `errored`, and reading an errored Solid resource **re-throws**.

cicchetto mounted **no `ErrorBoundary` anywhere** — a grep for the literal returned zero mounts. So the DOM kept the last painted frame, which on a cold boot is the splash, forever. The only way out was force-killing the app.

Three things were needed, and each is load-bearing:

1. **A bound on the transport** (`lib/bootFetch.ts`) — the three boot GETs had no timeout, no abort, no retry.
2. **An error context at root creation** (`lib/moduleRoot.ts`) — a throw from a computation in a bare module-level `createRoot` propagates out of `runUpdates`, which nulls `Effects`/`Updates` before rehandling. The queued render effects are **discarded**, so no render-tree boundary ever sees it.
3. **A user-facing recovery affordance** (`BootErrorBoundary.tsx`) — a console line is not a way out.

**A timeout alone cannot fix this, and that is the point.** Bounding a hang converts it into a rejection, and a rejection is exactly the state that freezes the UI. Either half shipped alone would look like a fix and change nothing the operator sees.

## One door for module roots

The first cut put the error context in `identityScopedStore` alone. Review caught that with a measured matrix: `activeWindows.ts` — a bare root whose memo reads `channelsBySlug()` and `networks()`, subscribed before the first render — runs **earlier** in the Updates queue than the store's memo, so it aborted the cycle first and the `listNetworks`/`listChannels` failures still froze the splash. Only `/me` was actually fixed.

Two patterns, and the boot fell through the gap between them. CLAUDE.md is explicit ("half-migrated creates two patterns; no exclusion lists"), so the context moved to `moduleRoot` — **one door** — all 30 module-lifetime roots across 26 files were migrated, and `__tests__/moduleRootGuard.test.ts` fails the build if a bare `createRoot` reappears.

Test files are out of that rule on a real distinction, not a convenience: their roots take the `dispose` callback and are scoped to the case, which is precisely what `createRoot` is for.

## The reset loop is deliberately OUTSIDE the context

`identityScopedStore` wraps only `build` in `withErrorContext`; its `on(token)` effect is registered after. Inside, a reset that throws would be caught and logged, and because the loop aborts at the throw the store's **remaining** resets would be silently skipped on logout or rotation — #281's failure mode, whose missed identity purge produces the 404 burst that trips the host's fail2ban jail and firewall-bans the client. Never widen the catch to swallow more.

## Review found a blocking defect in the retry, and it is fixed

Three review rounds ran; each of the first two found a real defect. The third found the retry was a **no-op on the first press** for any failure downstream of `/me`.

`reset()` is synchronous; the `user → networks → channelsBySlug` cascade is not. Refetching only the root left `networks` errored with nothing in flight, so the re-render rethrew and the boundary bounced straight back into its own fallback. Requests went out, but nothing changed under the user's finger and recovery needed a **second** press — the force-kill-the-app behaviour this issue exists to remove.

It was reproduced by execution before being believed, and falsified afterwards: reverting to the single verb turns the new case red and leaves the other three green. That is exactly how it hid — the existing retry spec covered only the `/me` failure, the one link where refetching the root alone happens to work.

## Reload must not purge the cache offline

The failure screen carries a `Reload` beside `Retry`, using `performRefresh` (the existing SW-aware verb from #674/#695) **only when online**. That verb deletes every cache before reloading, which #674 can do safely because a bundle-hash advertisement means the client is online by construction. This screen inverts the precondition: the likeliest reason it is up is that the network is gone, and purging the precache then lands the installed PWA on the browser's offline error page with the app shell destroyed — strictly worse than the frozen splash. Offline it does a plain reload. Reuse the verb, not the noun.

## Boundary with #687

#687 owns the splash's UI: the staged boot log and a per-stage stuck state during a **healthy** boot. This change adds no competing layer — the failure screen is a terminal state that replaces the Shell subtree, deliberately bare, and must not become the place staged-progress copy accretes.

## Known residuals, recorded in DESIGN_NOTES

- `bootFetch` is attached to the FUNCTION, not the boot call site, so `me()` from `mountBadgeReconcile` and the WS-driven refetches inherit the retry budget. Unintended, harmless, accepted.
- 8s per attempt x 3 attempts + backoff = worst case ~26.5s before the failure screen appears; `channelsBySlug` fans out with `Promise.all` so each network gets its own budget.
- Recovery depends on some component **inside** the boundary reading the specific errored resource. True today (`CrtSplash`, `Sidebar`, `BottomBar`), but it is a new load-bearing invariant with no test.

## Test plan

- [x] `scripts/bun.sh run check` — rc=0
- [x] `scripts/bun.sh x tsc --noEmit` standalone — rc=0 (biome red short-circuits tsc, so run separately)
- [x] `scripts/bun.sh run test` — 221 files / 3950 tests green
- [x] `scripts/bun.sh run build` — rc=0
- [x] `scripts/integration.sh` FULL suite — 589 passed / 1 failed
- [ ] Device verification on the reporter's Android PWA — **not done, and cannot be from here**

**No Elixir is touched by this diff, so `scripts/check.sh` was deliberately not run.** Not "it passed" — it was not run.

### About the one integration red

The full-suite failure is `issue580-send-snap-independent-of-post.spec.ts:104:3` case 1 (`toBeInViewport()`), which is **#769, a defect on main, not this branch**. Proven by baseline rather than asserted: the same spec fails at plain `7ead6ade` in a detached worktree containing none of this diff (`--grep 'issue #580' --repeat-each 10` → 1 failed / 9 passed in 34.8s). Full evidence posted on #769, including that the failure is a scroll-position failure — the line is in the DOM with a real `data-msg-id`, it is simply never scrolled into view.

`issue281` was also looped on both arms (5x each, main naked and this branch): 10/10 green, so it did not reproduce and is not covered by that finding.

### About cic suite stability

`focus-rule.test.ts` "incoming PRIVMSG on a channel does not change focus" timed out (flat 5000ms) in **one of three** post-rebase full runs; the other two are 3950/3950 green, it is 3/3 green isolated, and plain `c1a0e535` is 3932/3932 green. The failure mode is the clock, not the focus assertion — if this diff had broken the invariant the assertion would fail, not time out. Flagging it rather than burying it: 2-of-3 is not proof of innocence, and the test looks load-fragile.