### PR TITLE
cic: give the paced-send residue one owner, in resendable form (#723)

### DIFF
--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -948,10 +948,12 @@ describe("compose submit — slash command dispatch", () => {
 
   // #723 — when the query window is BUSY the redirect is refused outright and
   // the source keeps ownership of the residue: the operator's text is never
-  // destroyed, and the remainder still has exactly one home. The error copy
-  // must say WHERE it went (log-honesty) — "in the box" is a lie when the
-  // operator is now looking at a different composer.
-  it("#723 — a partial /msg into a busy query window keeps the residue in the source", async () => {
+  // destroyed, and the remainder still has exactly one home. It comes back
+  // RE-ADDRESSED — a bare remainder in a CHANNEL composer would resend the
+  // private message to the channel. The error copy must say where it went
+  // (log-honesty) — "in the box" is a lie when the operator is now looking at
+  // a different composer.
+  it("#723 — a partial /msg into a busy query window keeps the residue in the source, re-addressed", async () => {
     localStorage.setItem("grappa-token", "tok");
     const sb = await import("../lib/scrollback");
     const api = await import("../lib/api");
@@ -971,10 +973,98 @@ describe("compose submit — slash command dispatch", () => {
     const result = await compose.submit(source, "freenode", "#a");
 
     expect(compose.getDraft(query)).toBe("half typed reply");
-    expect(compose.getDraft(source)).toBe("l2\nl3");
+    expect(compose.getDraft(source)).toBe("/msg bob l2\nl3");
     expect(result).toHaveProperty("error");
     expect((result as { error: string }).error).toContain("sent 1 of 3 lines");
     expect((result as { error: string }).error).not.toContain("in the box");
+
+    // The whole point of the prefix: resending from the CHANNEL still reaches
+    // bob. Bare "l2\nl3" here would have spilled a private message into #a.
+    vi.mocked(sb.sendMessage).mockReset();
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    await compose.submit(source, "freenode", "#a");
+    expect(vi.mocked(sb.sendMessage).mock.calls.map((c) => [c[1], c[2]])).toEqual([
+      ["bob", "l2"],
+      ["bob", "l3"],
+    ]);
+  });
+
+  // #723 — a relocated remainder is announced even for a single-line body.
+  // The "sent N of M lines" detail stays multi-line-only (#342's throttle copy
+  // for a lone send), but "your text moved to another window" is news at any
+  // length.
+  it("#723 — a single-line /msg into a busy query window says where the text went", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    const api = await import("../lib/api");
+    const compose = await import("../lib/compose");
+    const source = channelKey("freenode", "#a");
+    const query = channelKey("freenode", "bob");
+
+    vi.mocked(sb.sendMessage).mockRejectedValue(new api.ApiError(400, "invalid_line"));
+
+    compose.setDraft(query, "half typed reply");
+    compose.setDraft(source, "/msg bob hi");
+    const result = await compose.submit(source, "freenode", "#a");
+
+    expect(compose.getDraft(query)).toBe("half typed reply");
+    expect(compose.getDraft(source)).toBe("/msg bob hi");
+    expect((result as { error: string }).error).toContain("the window you sent from");
+    expect((result as { error: string }).error).not.toContain("lines");
+  });
+
+  // #723, same class — a services target opens NO query window, so the residue
+  // always stays in the channel the operator typed it in. Bare, it resends the
+  // credential to that channel. This is the leak that made the re-addressing
+  // rule general rather than a patch on the /msg fallback.
+  it("#723 — a partial /msg to a service keeps its /msg <service> (no channel spill)", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    const api = await import("../lib/api");
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+
+    vi.mocked(sb.sendMessage).mockRejectedValue(new api.ApiError(400, "invalid_line"));
+
+    compose.setDraft(k, "/msg nickserv IDENTIFY s3cret");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(result).toHaveProperty("error");
+    expect(compose.getDraft(k)).toBe("/msg nickserv IDENTIFY s3cret");
+
+    // Resending goes to the service, never to #a.
+    vi.mocked(sb.sendMessage).mockReset();
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    await compose.submit(k, "freenode", "#a");
+    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "nickserv", "IDENTIFY s3cret");
+  });
+
+  // #723, same class — an ACTION remainder left bare resends as plain text,
+  // silently downgrading the message kind.
+  it("#723 — a partial /me keeps its /me so the remainder resends as an ACTION", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    const api = await import("../lib/api");
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+
+    let n = 0;
+    vi.mocked(sb.sendMessage).mockImplementation(async () => {
+      n += 1;
+      if (n === 2) throw new api.ApiError(400, "invalid_line");
+      return undefined as never;
+    });
+
+    compose.setDraft(k, "/me waves\nthen bows");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(result).toHaveProperty("error");
+    expect(compose.getDraft(k)).toBe("/me then bows");
+
+    vi.mocked(sb.sendMessage).mockReset();
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    await compose.submit(k, "freenode", "#a");
+    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "\x01ACTION then bows\x01");
   });
 
   // UX-4 bucket G — `/msg <Xserv> <text>` sends the wire frame but

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -1039,6 +1039,75 @@ describe("compose submit — slash command dispatch", () => {
     expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "nickserv", "IDENTIFY s3cret");
   });
 
+  // #723, worst of the class — a residue that is plain text INSIDE a paste
+  // stops being plain text once it is alone in the box. "notes\n/quit" dying on
+  // line 2 used to leave a bare `/quit`, and Enter parked every network and
+  // logged the operator out. The `//` literal escape keeps it text.
+  it("#723 — a residue starting with / is escaped so resending sends text, not a command", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    const api = await import("../lib/api");
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+
+    let n = 0;
+    vi.mocked(sb.sendMessage).mockImplementation(async () => {
+      n += 1;
+      if (n === 2) throw new api.ApiError(400, "invalid_line");
+      return undefined as never;
+    });
+
+    compose.setDraft(k, "notes\n/quit");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(result).toHaveProperty("error");
+    expect(compose.getDraft(k)).toBe("//quit");
+
+    vi.mocked(sb.sendMessage).mockReset();
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    vi.mocked(api.patchNetwork).mockClear();
+    await compose.submit(k, "freenode", "#a");
+
+    // The line goes out as the literal text it was in the paste…
+    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "/quit");
+    // …and emphatically does NOT disconnect the operator: a dispatched /quit
+    // parks every network through this endpoint.
+    expect(api.patchNetwork).not.toHaveBeenCalled();
+  });
+
+  // #723 — the multi-line form of the same escape: only the FIRST character
+  // needs it, because parseSlash decides once for the whole draft and the
+  // per-line fan-out sends the rest verbatim.
+  it("#723 — the / escape covers only the first char; later slash lines stay verbatim", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    const api = await import("../lib/api");
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+
+    let n = 0;
+    vi.mocked(sb.sendMessage).mockImplementation(async () => {
+      n += 1;
+      if (n === 2) throw new api.ApiError(400, "invalid_line");
+      return undefined as never;
+    });
+
+    compose.setDraft(k, "notes\n/part #a\n/nick bob");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(result).toHaveProperty("error");
+    expect(compose.getDraft(k)).toBe("//part #a\n/nick bob");
+
+    vi.mocked(sb.sendMessage).mockReset();
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    await compose.submit(k, "freenode", "#a");
+
+    expect(vi.mocked(sb.sendMessage).mock.calls.map((c) => c[2])).toEqual([
+      "/part #a",
+      "/nick bob",
+    ]);
+  });
+
   // #723, same class — an ACTION remainder left bare resends as plain text,
   // silently downgrading the message kind.
   it("#723 — a partial /me keeps its /me so the remainder resends as an ACTION", async () => {

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -892,6 +892,91 @@ describe("compose submit — slash command dispatch", () => {
     expect(result).toEqual({ ok: true });
   });
 
+  // #723 — the residue has exactly ONE owner. `/msg` redirects the unsent
+  // remainder to the query window it just focused, so the SOURCE window must
+  // be emptied on the SAME path — pre-fix the `if ("error" in r) return r`
+  // early-return skipped the shared end-of-submit clear and left the WHOLE
+  // `/msg bob …` command sitting in the source composer, next to a residue
+  // copy in the query window. Hitting Enter there re-delivered every line.
+  it("#723 — a partial /msg leaves the residue ONLY in the query window; the source is emptied", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    const api = await import("../lib/api");
+    const compose = await import("../lib/compose");
+    const source = channelKey("freenode", "#a");
+    const query = channelKey("freenode", "bob");
+
+    // l1 delivered; l2 fails FATALLY (400 invalid_line) → l3 never attempted.
+    let n = 0;
+    vi.mocked(sb.sendMessage).mockImplementation(async () => {
+      n += 1;
+      if (n === 2) throw new api.ApiError(400, "invalid_line");
+      return undefined as never;
+    });
+
+    compose.setDraft(source, "/msg bob l1\nl2\nl3");
+    const result = await compose.submit(source, "freenode", "#a");
+
+    expect(result).toHaveProperty("error");
+    // The remainder lives with the operator's new focus…
+    expect(compose.getDraft(query)).toBe("l2\nl3");
+    // …and NOWHERE else. The full command must not survive for a resend.
+    expect(compose.getDraft(source)).toBe("");
+  });
+
+  // #723 second leg — the query window's composer belongs to the OPERATOR.
+  // `sendPacedBody` wrote the residue unconditionally, and the final residue
+  // of a SUCCESSFUL send is "" — so `/msg bob hi` from #a silently erased a
+  // half-typed message sitting in bob's box.
+  it("#723 — a successful /msg does NOT clobber a half-typed draft in the query window", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+    const compose = await import("../lib/compose");
+    const source = channelKey("freenode", "#a");
+    const query = channelKey("freenode", "bob");
+
+    compose.setDraft(query, "half typed reply");
+    compose.setDraft(source, "/msg bob hi");
+    const result = await compose.submit(source, "freenode", "#a");
+
+    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "bob", "hi");
+    expect(result).toEqual({ ok: true });
+    expect(compose.getDraft(query)).toBe("half typed reply");
+    expect(compose.getDraft(source)).toBe("");
+  });
+
+  // #723 — when the query window is BUSY the redirect is refused outright and
+  // the source keeps ownership of the residue: the operator's text is never
+  // destroyed, and the remainder still has exactly one home. The error copy
+  // must say WHERE it went (log-honesty) — "in the box" is a lie when the
+  // operator is now looking at a different composer.
+  it("#723 — a partial /msg into a busy query window keeps the residue in the source", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    const api = await import("../lib/api");
+    const compose = await import("../lib/compose");
+    const source = channelKey("freenode", "#a");
+    const query = channelKey("freenode", "bob");
+
+    let n = 0;
+    vi.mocked(sb.sendMessage).mockImplementation(async () => {
+      n += 1;
+      if (n === 2) throw new api.ApiError(400, "invalid_line");
+      return undefined as never;
+    });
+
+    compose.setDraft(query, "half typed reply");
+    compose.setDraft(source, "/msg bob l1\nl2\nl3");
+    const result = await compose.submit(source, "freenode", "#a");
+
+    expect(compose.getDraft(query)).toBe("half typed reply");
+    expect(compose.getDraft(source)).toBe("l2\nl3");
+    expect(result).toHaveProperty("error");
+    expect((result as { error: string }).error).toContain("sent 1 of 3 lines");
+    expect((result as { error: string }).error).not.toContain("in the box");
+  });
+
   // UX-4 bucket G — `/msg <Xserv> <text>` sends the wire frame but
   // does NOT open a query window or shift focus. Services responses
   // route to the `$server` window server-side (Identifier.services_sender?

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -326,6 +326,22 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   // the channel.
   type ResidueHome = { key: ChannelKey; resubmitPrefix: string };
 
+  // …with one correction for the empty prefix: a residue whose first line
+  // starts with `/` is no longer plain text once it is alone in the box —
+  // `parseSlash` would DISPATCH it. A paste of "notes\n/quit" that dies on
+  // line 2 leaves `/quit`, and Enter parks every network and logs the operator
+  // out; `/msg <someone-else>` re-addresses the remainder to a third party.
+  // `//` is the literal-privmsg escape the parser already ships, and it only
+  // ever needs to cover the FIRST character: parseSlash reads the whole draft,
+  // decides once, and hands the rest back for the per-line fan-out. A non-empty
+  // prefix needs no escape — the residue is already an argument by then, so
+  // `/me /quit` sends the literal text.
+  const residueDraft = (home: ResidueHome, residue: string): string => {
+    if (residue === "") return "";
+    if (home.resubmitPrefix !== "") return `${home.resubmitPrefix}${residue}`;
+    return residue.startsWith("/") ? `/${residue}` : residue;
+  };
+
   // `source` is the window the operator submitted from; `preferred` is where
   // the remainder should surface — the same window for privmsg / me, the
   // freshly focused query window for /msg, which moves the operator's eyes
@@ -367,8 +383,11 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         // Residue-only draft, reset to the live bottom (historyCursor null):
         // we're typing the remainder, not walking history. A drained send
         // leaves "" — never a bare prefix the operator would have to erase.
-        const draft = residue === "" ? "" : `${home.resubmitPrefix}${residue}`;
-        writeState(home.key, (s) => ({ ...s, draft, historyCursor: null }));
+        writeState(home.key, (s) => ({
+          ...s,
+          draft: residueDraft(home, residue),
+          historyCursor: null,
+        }));
       });
       return { ok: true };
     } catch (e) {
@@ -382,7 +401,10 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       const reason = friendlyError(e);
       const sentOf = totalCount > 1 ? ` — sent ${sentCount} of ${totalCount} lines` : "";
       if (home.key !== preferred.key) {
-        return { error: `${reason}${sentOf}; the rest are in the window you sent from` };
+        // "The rest" presumes something went out; on a single-line body
+        // nothing did, so name the whole message instead.
+        const what = totalCount > 1 ? "the rest are" : "your message is";
+        return { error: `${reason}${sentOf}; ${what} in the window you sent from` };
       }
       return totalCount > 1
         ? { error: `${reason}${sentOf}; the rest are in the box` }

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -316,15 +316,26 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   // history-push never runs (which would wipe the residue and record a
   // half-sent paste).
   //
-  // #723 — the residue has EXACTLY ONE owner. `source` is the window the
-  // operator submitted from; `preferred` is where the remainder should surface
-  // (the same window for privmsg / me, the freshly focused query window for
-  // /msg, which moves the operator's eyes there). Two rules resolve them:
+  // #723 — the residue has EXACTLY ONE owner, and it lands there in RESENDABLE
+  // form. A candidate home is a window plus the text that must precede the
+  // remainder for a plain resubmit FROM that window to reproduce the sends
+  // still owed. In the window that is itself the target, that prefix is empty
+  // and the bare remainder resends correctly — the #666 case. Anywhere else it
+  // is the command that re-addresses it (`/me `, `/msg <nick> `), because a
+  // bare remainder dropped in a CHANNEL composer resends a private message to
+  // the channel.
+  type ResidueHome = { key: ChannelKey; resubmitPrefix: string };
+
+  // `source` is the window the operator submitted from; `preferred` is where
+  // the remainder should surface — the same window for privmsg / me, the
+  // freshly focused query window for /msg, which moves the operator's eyes
+  // there. Two rules pick between them:
   //
   //   * A busy `preferred` outranks us. Its draft is the operator's own
   //     half-typed text, and the final residue of a SUCCESSFUL send is `""` —
   //     so an unconditional write silently ate it. When it is non-empty the
-  //     redirect is refused outright and `source` keeps the remainder.
+  //     redirect is refused and `source` keeps the remainder (re-addressed by
+  //     its own prefix, so it still resends to the intended peer).
   //   * Whoever does NOT own the residue is emptied. Redirecting used to leave
   //     the WHOLE `/msg bob …` command in `source` — the error arm returns
   //     before the shared clear — so the remainder existed twice and hitting
@@ -332,18 +343,20 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   //
   // Resolved ONCE, before the first line: per-tick resolution would flip after
   // the first residue write makes `preferred` non-empty, hopping windows
-  // mid-drain.
+  // mid-drain. Known hole: text typed into `preferred` AFTER that resolution
+  // (possible during a long 429-paced drain) is still overwritten.
   const sendPacedBody = async (
-    source: ChannelKey,
-    preferred: ChannelKey,
+    source: ResidueHome,
+    preferred: ResidueHome,
     slug: string,
     target: string,
     body: string,
     action: boolean,
   ): Promise<SubmitResult> => {
-    const residueKey = preferred === source || getDraft(preferred) === "" ? preferred : source;
-    if (residueKey !== source) {
-      writeState(source, (s) => ({ ...s, draft: "", historyCursor: null }));
+    const home =
+      preferred.key === source.key || getDraft(preferred.key) === "" ? preferred : source;
+    if (home.key !== source.key) {
+      writeState(source.key, (s) => ({ ...s, draft: "", historyCursor: null }));
     }
     let sentCount = 0;
     let totalCount = 0;
@@ -352,24 +365,27 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         sentCount = sent;
         totalCount = total;
         // Residue-only draft, reset to the live bottom (historyCursor null):
-        // we're typing the remainder, not walking history.
-        writeState(residueKey, (s) => ({ ...s, draft: residue, historyCursor: null }));
+        // we're typing the remainder, not walking history. A drained send
+        // leaves "" — never a bare prefix the operator would have to erase.
+        const draft = residue === "" ? "" : `${home.resubmitPrefix}${residue}`;
+        writeState(home.key, (s) => ({ ...s, draft, historyCursor: null }));
       });
       return { ok: true };
     } catch (e) {
       // Fatal mid-fan-out (WS down, invalid_line, severed 401). The residue
       // draft is already set to the unsent remainder; surface the reason and,
       // for a genuine multi-line paste, how many lines went out so the operator
-      // knows the send partially landed and where the rest is queued. "In the
-      // box" means the composer they are looking at — a lie when a busy
-      // `preferred` sent the remainder back to the window they submitted from.
+      // knows the send partially landed. "In the box" means the composer they
+      // are looking at — a lie when a busy `preferred` sent the remainder back
+      // to the window they submitted from, so that case says where it went
+      // whether or not the body was multi-line.
       const reason = friendlyError(e);
-      const where =
-        residueKey === preferred
-          ? "the rest are in the box"
-          : "the rest are in the window you sent from";
+      const sentOf = totalCount > 1 ? ` — sent ${sentCount} of ${totalCount} lines` : "";
+      if (home.key !== preferred.key) {
+        return { error: `${reason}${sentOf}; the rest are in the window you sent from` };
+      }
       return totalCount > 1
-        ? { error: `${reason} — sent ${sentCount} of ${totalCount} lines; ${where}` }
+        ? { error: `${reason}${sentOf}; the rest are in the box` }
         : { error: reason };
     }
   };
@@ -455,7 +471,10 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           // a send-door 429 drains the rest over time; a fatal error leaves ONLY
           // the unsent remainder in the draft (early-return so the end-of-submit
           // clear never wipes it).
-          const r = await sendPacedBody(key, key, networkSlug, channelName, cmd.body, false);
+          // #723 — the residue stays in THIS window and this window IS the
+          // target, so the bare remainder resends correctly: no prefix.
+          const home = { key, resubmitPrefix: "" };
+          const r = await sendPacedBody(home, home, networkSlug, channelName, cmd.body, false);
           if ("error" in r) return r;
           result = r;
           break;
@@ -463,7 +482,11 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         case "me": {
           // CTCP ACTION framing per line: \x01ACTION <text>\x01. Same #666
           // resumable + paced fan-out as privmsg.
-          const r = await sendPacedBody(key, key, networkSlug, channelName, cmd.body, true);
+          //
+          // #723 — the remainder must resend as an ACTION, not as plain text:
+          // the residue carries the `/me ` back with it.
+          const home = { key, resubmitPrefix: "/me " };
+          const r = await sendPacedBody(home, home, networkSlug, channelName, cmd.body, true);
           if ("error" in r) return r;
           result = r;
           break;
@@ -647,8 +670,16 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           const networkId = networkIdBySlug(networkSlug);
           if (networkId === undefined) return { error: "/msg: network not found" };
           if (isServicesSender(cmd.target)) {
-            // #666 — resumable + paced; residue keyed on the source window `key`.
-            const svc = await sendPacedBody(key, key, networkSlug, cmd.target, cmd.body, false);
+            // #666 — resumable + paced; residue keyed on the source window
+            // `key`, because a services target opens no query window to move
+            // it to.
+            //
+            // #723 — that window is NOT the target, so the remainder must keep
+            // its `/msg <service> `. A bare residue here is how a partially
+            // sent `/msg nickserv IDENTIFY <pass>` ends up resent to the
+            // channel the operator typed it in.
+            const home = { key, resubmitPrefix: `/msg ${cmd.target} ` };
+            const svc = await sendPacedBody(home, home, networkSlug, cmd.target, cmd.body, false);
             if ("error" in svc) return svc;
             result = svc;
             break;
@@ -674,10 +705,12 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           // #723 — a preference, not a seizure: a half-typed draft already in
           // that window belongs to the operator, so sendPacedBody refuses the
           // redirect and keeps the remainder in `key`. Either way exactly one
-          // window ends up holding it.
+          // window ends up holding it — and in the source window it keeps its
+          // `/msg <peer> `, so resending from a channel cannot spill a private
+          // message into that channel.
           const r = await sendPacedBody(
-            key,
-            channelKey(networkSlug, canonical),
+            { key, resubmitPrefix: `/msg ${canonical} ` },
+            { key: channelKey(networkSlug, canonical), resubmitPrefix: "" },
             networkSlug,
             canonical,
             cmd.body,

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -311,18 +311,40 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   // paces and drains the rest over time (the composer stays busy while it
   // does); a fatal error stops with the residue in the draft and surfaces how
   // many lines made it out. Used by the privmsg / me / msg arms — the free-text
-  // paths whose body can be a multi-line paste. `key` is the SOURCE window (the
-  // one the operator submitted from), so a partial send leaves the remainder
-  // where it was typed. On error returns `{error}` — the caller MUST early-
-  // return it so the shared end-of-submit draft-clear + history-push never
-  // runs (which would wipe the residue and record a half-sent paste).
+  // paths whose body can be a multi-line paste. On error returns `{error}` —
+  // the caller MUST early-return it so the shared end-of-submit draft-clear +
+  // history-push never runs (which would wipe the residue and record a
+  // half-sent paste).
+  //
+  // #723 — the residue has EXACTLY ONE owner. `source` is the window the
+  // operator submitted from; `preferred` is where the remainder should surface
+  // (the same window for privmsg / me, the freshly focused query window for
+  // /msg, which moves the operator's eyes there). Two rules resolve them:
+  //
+  //   * A busy `preferred` outranks us. Its draft is the operator's own
+  //     half-typed text, and the final residue of a SUCCESSFUL send is `""` —
+  //     so an unconditional write silently ate it. When it is non-empty the
+  //     redirect is refused outright and `source` keeps the remainder.
+  //   * Whoever does NOT own the residue is emptied. Redirecting used to leave
+  //     the WHOLE `/msg bob …` command in `source` — the error arm returns
+  //     before the shared clear — so the remainder existed twice and hitting
+  //     Enter back in the source window re-delivered every line.
+  //
+  // Resolved ONCE, before the first line: per-tick resolution would flip after
+  // the first residue write makes `preferred` non-empty, hopping windows
+  // mid-drain.
   const sendPacedBody = async (
-    key: ChannelKey,
+    source: ChannelKey,
+    preferred: ChannelKey,
     slug: string,
     target: string,
     body: string,
     action: boolean,
   ): Promise<SubmitResult> => {
+    const residueKey = preferred === source || getDraft(preferred) === "" ? preferred : source;
+    if (residueKey !== source) {
+      writeState(source, (s) => ({ ...s, draft: "", historyCursor: null }));
+    }
     let sentCount = 0;
     let totalCount = 0;
     try {
@@ -331,19 +353,23 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         totalCount = total;
         // Residue-only draft, reset to the live bottom (historyCursor null):
         // we're typing the remainder, not walking history.
-        writeState(key, (s) => ({ ...s, draft: residue, historyCursor: null }));
+        writeState(residueKey, (s) => ({ ...s, draft: residue, historyCursor: null }));
       });
       return { ok: true };
     } catch (e) {
       // Fatal mid-fan-out (WS down, invalid_line, severed 401). The residue
       // draft is already set to the unsent remainder; surface the reason and,
       // for a genuine multi-line paste, how many lines went out so the operator
-      // knows the send partially landed and the rest is queued in the box.
+      // knows the send partially landed and where the rest is queued. "In the
+      // box" means the composer they are looking at — a lie when a busy
+      // `preferred` sent the remainder back to the window they submitted from.
       const reason = friendlyError(e);
+      const where =
+        residueKey === preferred
+          ? "the rest are in the box"
+          : "the rest are in the window you sent from";
       return totalCount > 1
-        ? {
-            error: `${reason} — sent ${sentCount} of ${totalCount} lines; the rest are in the box`,
-          }
+        ? { error: `${reason} — sent ${sentCount} of ${totalCount} lines; ${where}` }
         : { error: reason };
     }
   };
@@ -429,7 +455,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           // a send-door 429 drains the rest over time; a fatal error leaves ONLY
           // the unsent remainder in the draft (early-return so the end-of-submit
           // clear never wipes it).
-          const r = await sendPacedBody(key, networkSlug, channelName, cmd.body, false);
+          const r = await sendPacedBody(key, key, networkSlug, channelName, cmd.body, false);
           if ("error" in r) return r;
           result = r;
           break;
@@ -437,7 +463,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         case "me": {
           // CTCP ACTION framing per line: \x01ACTION <text>\x01. Same #666
           // resumable + paced fan-out as privmsg.
-          const r = await sendPacedBody(key, networkSlug, channelName, cmd.body, true);
+          const r = await sendPacedBody(key, key, networkSlug, channelName, cmd.body, true);
           if ("error" in r) return r;
           result = r;
           break;
@@ -622,7 +648,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           if (networkId === undefined) return { error: "/msg: network not found" };
           if (isServicesSender(cmd.target)) {
             // #666 — resumable + paced; residue keyed on the source window `key`.
-            const svc = await sendPacedBody(key, networkSlug, cmd.target, cmd.body, false);
+            const svc = await sendPacedBody(key, key, networkSlug, cmd.target, cmd.body, false);
             if ("error" in svc) return svc;
             result = svc;
             break;
@@ -639,13 +665,18 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           // echo stays the sole render path (no optimistic local render — cf.
           // the #251 source_address abolition).
           await ensureQueryTopicJoined(networkSlug, canonical);
-          // #666 — resumable + paced. Residue keyed on the QUERY window we just
-          // focused (`canonical`), NOT the source window: /msg already switched
-          // focus here, so a partial-send remainder + its error banner must
-          // co-locate in the window the operator is now looking at — and a
+          // #666 — resumable + paced. The residue PREFERS the QUERY window we
+          // just focused (`canonical`) over the source window: /msg already
+          // switched focus here, so a partial-send remainder + its error banner
+          // must co-locate in the window the operator is now looking at — and a
           // resend of that plain-text residue from the query window goes to
           // `canonical` (the intended peer), not back to the source channel.
+          // #723 — a preference, not a seizure: a half-typed draft already in
+          // that window belongs to the operator, so sendPacedBody refuses the
+          // redirect and keeps the remainder in `key`. Either way exactly one
+          // window ends up holding it.
           const r = await sendPacedBody(
+            key,
             channelKey(networkSlug, canonical),
             networkSlug,
             canonical,

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -27467,3 +27467,48 @@ cross-reload marker. Until it lands, the reload is silent.
 signals with no storage backing, so every reload already discards them — the
 manual banner click included. Auto-refresh makes that pre-existing loss easier
 to hit rather than introducing it.
+### 2026-08-03 — #723 — the paced-send residue has exactly one owner (cic)
+
+Follow-on defect from #666, found by the 2026-08 codebase review. #666 made a
+partial multi-line send leave ONLY the unsent remainder in the composer, so a
+resend could never re-deliver the lines that already went out. The `/msg` arm
+broke that guarantee in both directions.
+
+**Leg one — the remainder existed twice.** Every `sendPacedBody` call site
+passed the SOURCE window key, the same key the shared end-of-submit clear
+writes, so residue and clear agreed on one owner. `/msg` was the exception: it
+passed the freshly focused QUERY window key, deliberately, so the remainder
+lands where the operator is now looking. But its failure arm early-returns —
+it must, or the shared clear would wipe the residue — and that return skipped
+the clear for the source window too. So a `/msg bob l1\nl2\nl3` that died on
+`l2` left `l2\nl3` in bob's box AND the whole original command in `#chan`'s.
+Coming back to `#chan` later and hitting Enter re-delivered all three lines:
+exactly the duplicate resend #666 exists to prevent, reintroduced by the
+redirect.
+
+**Leg two — the redirect target is not ours to clobber.** The progress
+callback wrote the residue unconditionally, and the final residue of a
+SUCCESSFUL send is `""`. A query window is not a window the send started from:
+if the operator had a half-typed reply sitting in bob's box, a plain
+`/msg bob hi` from another window silently erased it.
+
+**The rule: one owner, resolved once, and a busy window outranks us.**
+`sendPacedBody` now takes `source` (where it was submitted) and `preferred`
+(where the remainder should surface — the same key for privmsg / me, the query
+window for /msg). It resolves the residue key ONCE before the first line:
+`preferred` when that window's composer is empty, otherwise `source`. Whichever
+one does not own the residue is emptied up front, so the full command cannot
+survive a partial send. Resolving per-tick instead would flip after the first
+residue write makes `preferred` non-empty and hop windows mid-drain.
+
+**Refusing the redirect beats merging.** The alternative — write the residue
+into a busy window anyway, prepended or appended — invents a merge semantic for
+two texts the operator never asked to join. Falling back to `source` keeps both
+texts intact and still leaves the remainder in exactly one place. The cost is
+that the remainder is then NOT where the operator is looking, so the error copy
+stops saying "the rest are in the box" (a lie in that case) and names the
+window they sent from — the log-honesty rule applied to operator-facing copy.
+
+**Scope.** cic-only, no wire change. The privmsg / me / services arms pass
+`(key, key)` and behave exactly as before; only the `/msg` redirect has two
+distinct keys, which is the only place the ownership question exists.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -27526,12 +27526,26 @@ for a plain resubmit from that window to reproduce the sends still owed:
 action, `/msg <nick> ` anywhere the target is someone else. Empty residue still
 writes an empty draft — never a bare prefix the operator has to erase.
 
-**Known holes, deliberate.** (1) The owner is resolved ONCE, so text typed into
-the preferred window DURING a long 429-paced drain is still overwritten;
-per-tick resolution trades that for hopping windows mid-drain, which is worse.
-(2) A remainder whose first line begins with `/` resubmits as a slash command;
-that stumbles into an "unknown command" error rather than sending, so it is a
-nuisance, not a leak.
+**Leg four, found in the re-review: an empty prefix is not always the right
+answer either.** A line that is plain text INSIDE a paste stops being plain
+text once it is alone in the box. Paste `notes` + `/quit`, lose the second
+line, and the residue is a bare `/quit` — Enter parks every network and logs
+the operator out. `/msg <someone-else>` re-addresses the remainder to a third
+party; `/me` silently changes the message kind. An earlier draft of this entry
+called that a nuisance rather than a leak, which was wrong: every one of those
+verbs is in `DISPATCH`.
+
+The parser already ships the escape — `//foo` is a literal privmsg of `/foo` —
+and it only ever has to cover the FIRST character, because `parseSlash` reads
+the whole draft, decides once, and hands the body back for the per-line
+fan-out. A non-empty prefix needs no escape: by then the residue is an
+argument, so `/me /quit` sends the literal text. So `residueDraft` is the one
+place that renders a residue for its home, and the empty-prefix case doubles a
+leading slash.
+
+**Known hole, deliberate.** The owner is resolved ONCE, so text typed into the
+preferred window DURING a long 429-paced drain is still overwritten; per-tick
+resolution trades that for hopping windows mid-drain, which is worse.
 
 **Scope.** cic-only, no wire change. The privmsg arm carries an empty prefix
 and behaves exactly as before; /me and the services arm gain the re-addressing

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -27507,8 +27507,33 @@ two texts the operator never asked to join. Falling back to `source` keeps both
 texts intact and still leaves the remainder in exactly one place. The cost is
 that the remainder is then NOT where the operator is looking, so the error copy
 stops saying "the rest are in the box" (a lie in that case) and names the
-window they sent from — the log-honesty rule applied to operator-facing copy.
+window they sent from, at any body length — the log-honesty rule applied to
+operator-facing copy. The "sent N of M lines" detail stays multi-line-only, so
+#342's copy for a single throttled send is untouched.
 
-**Scope.** cic-only, no wire change. The privmsg / me / services arms pass
-`(key, key)` and behave exactly as before; only the `/msg` redirect has two
-distinct keys, which is the only place the ownership question exists.
+**Leg three, found in review: ownership is not enough — the residue must be
+RESENDABLE where it lands.** The first cut of the fallback wrote the bare
+remainder into the source window. That window is a CHANNEL, so hitting Enter
+would have PRIVMSG'd a private message to the channel: a worse bug than the
+duplicate it replaced. Chasing the general rule found the same shape already
+shipped in two other arms — `/msg nickserv IDENTIFY <pass>` failing mid-send
+left the bare credential in the channel composer, and a partial `/me` left the
+remainder as plain text, silently downgrading the ACTION.
+
+So the residue's home is a window PLUS the text that must precede the remainder
+for a plain resubmit from that window to reproduce the sends still owed:
+`""` where the window is itself the target (the #666 case), `/me ` for an
+action, `/msg <nick> ` anywhere the target is someone else. Empty residue still
+writes an empty draft — never a bare prefix the operator has to erase.
+
+**Known holes, deliberate.** (1) The owner is resolved ONCE, so text typed into
+the preferred window DURING a long 429-paced drain is still overwritten;
+per-tick resolution trades that for hopping windows mid-drain, which is worse.
+(2) A remainder whose first line begins with `/` resubmits as a slash command;
+that stumbles into an "unknown command" error rather than sending, so it is a
+nuisance, not a leak.
+
+**Scope.** cic-only, no wire change. The privmsg arm carries an empty prefix
+and behaves exactly as before; /me and the services arm gain the re-addressing
+they always needed; only the `/msg` redirect has two distinct homes, which is
+the only place the ownership question exists.


### PR DESCRIPTION
Fixes the #723 defect from the 2026-08 review campaign, plus two live instances of the same class found while chasing the general rule.

## The reported bug

#666 guarantees a partial multi-line send leaves ONLY the unsent remainder in a composer, so a resend can never re-deliver what already went out. The `/msg` arm broke it in both directions:

- It redirects the residue to the query window it just focused — correct, that is where the operator is now looking — but its failure path early-returns before the shared end-of-submit clear, so the SOURCE window kept the whole original `/msg bob …` command. The remainder existed twice; Enter back in the source window re-delivered every line.
- The residue write was unconditional, and the final residue of a *successful* send is `""` — so `/msg bob hi` from another window silently erased a half-typed reply already sitting in bob's box.

## The rule

A residue home is a window **plus the text that makes a plain resubmit from it reproduce the sends still owed**. `sendPacedBody` takes a `source` and a `preferred` home and resolves the owner ONCE, before the first line: `preferred` when its composer is empty, `source` otherwise. Whichever key does not own the residue is emptied. Resolving per-tick would flip after the first write makes `preferred` non-empty and hop windows mid-drain.

## Two more instances, found in review

Both were already shipped, and both are why the fix is a general rule rather than a patch on the `/msg` fallback:

- **Bare residue in a channel composer.** The first cut let the fallback write the remainder bare into the source window — a channel — so Enter would PRIVMSG a private message to the channel. The same shape was already live in the services arm: a `/msg nickserv IDENTIFY <pass>` dying mid-send left the bare credential in the channel box. A partial `/me` left plain text that resends without the ACTION framing.
- **A residue that starts with `/` re-parses as a command.** Paste `notes` + `/quit`, lose line 2, and the residue is a bare `/quit` — Enter parks every network and logs the operator out. `parseSlash` already ships the `//` literal escape, and it only has to cover the first character.

## Test plan

- [x] 8 new tests in `cicchetto/src/__tests__/compose.test.ts`, each red on its own half-revert
- [x] `scripts/bun.sh run check` — rc 0
- [x] `scripts/bun.sh run test` — 3940 passed (217 files)
- [x] `scripts/bun.sh run build` — clean

cic-only; no wire change, no server change.