### PR TITLE
cic: let the paced drain own the draft it is draining (#737)

### DIFF
--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -1,7 +1,15 @@
 import { type Component, createSignal, onCleanup, Show } from "solid-js";
 import { isDiagEnabled } from "./DiagFloat";
 import { channelKey } from "./lib/channelKey";
-import { getDraft, recallNext, recallPrev, setDraft, submit, tabComplete } from "./lib/compose";
+import {
+  getDraft,
+  isDraining,
+  recallNext,
+  recallPrev,
+  setDraft,
+  submit,
+  tabComplete,
+} from "./lib/compose";
 import { composePlaceholder } from "./lib/composePlaceholder";
 import { diagPush } from "./lib/diagLog";
 import { networkBySlug } from "./lib/networks";
@@ -497,6 +505,18 @@ const ComposeBox: Component<Props> = (props) => {
           onInput={onInput}
           onKeyDown={onKeyDown}
           onPaste={onPaste}
+          // #737 — a paced drain rewrites this draft every acked line for as
+          // long as the pacing lasts. The store refuses operator writes while
+          // it does (that is the real guard, and it covers the global paste
+          // listener too); readOnly makes the refusal VISIBLE instead of
+          // swallowing keystrokes, and the submit button's spinner says why.
+          // readOnly, not disabled: disabled blurs the textarea, which
+          // collapses the on-screen keyboard — the focus steal #59 exists to
+          // prevent. Keyed on the WINDOW, not the component-local sending():
+          // that one would follow the operator to whatever window they switch
+          // to mid-drain and freeze the wrong composer.
+          readOnly={isDraining(key())}
+          aria-busy={isDraining(key())}
           placeholder={composePlaceholder(props.networkSlug, props.channelName)}
           rows={1}
           aria-label="compose message"

--- a/cicchetto/src/__tests__/BootErrorBoundary.test.tsx
+++ b/cicchetto/src/__tests__/BootErrorBoundary.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
 import { Show } from "solid-js";
-import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { warmGraph } from "./helpers/warmGraph";
 
 // #717 — the recoverability half, tested through the REAL resource cascade.
 //
@@ -63,6 +64,11 @@ const HEALTHY_ME = {
   read_cursors: {},
   badge_count: 0,
 };
+
+// #781 — see helpers/warmGraph.ts. The component pulls api, bundleHash,
+// connectivity and networks, so warming it covers every graph these tests
+// re-import.
+beforeAll(() => warmGraph(() => import("../BootErrorBoundary")));
 
 beforeEach(() => {
   vi.resetModules();

--- a/cicchetto/src/__tests__/ComposeBox.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBox.test.tsx
@@ -8,6 +8,9 @@ vi.mock("../lib/compose", () => ({
   recallPrev: vi.fn(),
   recallNext: vi.fn(),
   tabComplete: vi.fn(),
+  // #737 — the per-window paced-drain lock the textarea's readOnly is keyed
+  // on. Default false: every pre-existing case is a window nobody is draining.
+  isDraining: vi.fn(() => false),
 }));
 
 vi.mock("../lib/channelKey", () => ({
@@ -429,6 +432,30 @@ describe("ComposeBox", () => {
     render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
     const ta = screen.getByPlaceholderText(/message #a/i) as HTMLTextAreaElement;
     expect(ta.hasAttribute("disabled")).toBe(false);
+  });
+
+  // #737 — while a paced drain owns this window's draft the textarea goes
+  // read-only, so the operator SEES the refusal instead of watching their
+  // keystrokes get overwritten on the next acked line.
+  it("#737 — textarea is readOnly (never disabled) while the window is draining", async () => {
+    const compose = await import("../lib/compose");
+    vi.mocked(compose.isDraining).mockReturnValue(true);
+    try {
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      const ta = screen.getByPlaceholderText(/message #a/i) as HTMLTextAreaElement;
+      expect(ta.readOnly).toBe(true);
+      // `disabled` would blur it and collapse the on-screen keyboard — the
+      // focus steal #59 exists to prevent. readOnly keeps focus and caret.
+      expect(ta.hasAttribute("disabled")).toBe(false);
+    } finally {
+      vi.mocked(compose.isDraining).mockReturnValue(false);
+    }
+  });
+
+  it("#737 — textarea is writable when no drain owns the window", () => {
+    render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+    const ta = screen.getByPlaceholderText(/message #a/i) as HTMLTextAreaElement;
+    expect(ta.readOnly).toBe(false);
   });
 
   // #177 removed the custom on-screen IRC keyboard. The compose textarea no

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -214,6 +214,8 @@ vi.mock("../lib/compose", () => ({
   recallPrev: vi.fn(),
   recallNext: vi.fn(),
   tabComplete: vi.fn(),
+  // #737 — ComposeBox reads the per-window paced-drain lock for its readOnly.
+  isDraining: () => false,
 }));
 
 vi.mock("../lib/theme", () => ({

--- a/cicchetto/src/__tests__/archive.test.ts
+++ b/cicchetto/src/__tests__/archive.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ArchiveEntry } from "../lib/api";
+import { warmGraph } from "./helpers/warmGraph";
 
 vi.mock("../lib/api", () => ({
   listArchive: vi.fn(),
@@ -27,6 +28,10 @@ vi.mock("../lib/queryWindows", () => ({
 vi.mock("../lib/windowState", () => ({
   windowStateByChannel: () => ({}),
 }));
+
+// #781 — see helpers/warmGraph.ts. `lib/api` is NOT warmed: the factory at
+// the top of this file fully replaces it, so the real module never loads.
+beforeAll(() => warmGraph(() => import("../lib/archive")));
 
 beforeEach(() => {
   vi.resetModules();

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -597,11 +597,68 @@ describe("compose submit — slash command dispatch", () => {
       expect(compose.getDraft(k)).toBe("b\nc");
       compose.recallNext(k);
       expect(compose.getDraft(k)).toBe("b\nc");
-      expect(compose.tabComplete(k, "b\nc", 3, true)).toBeNull();
+
+      // Members MUST be seeded here, or tabComplete returns null on its own
+      // empty-members guard and this assertion proves nothing.
+      const members = await import("../lib/members");
+      vi.mocked(members.membersByChannel).mockReturnValue({
+        [k]: [{ nick: "bruno", modes: [] }],
+      });
+      expect(compose.tabComplete(k, "b", 1, true)).toBeNull();
       expect(compose.getDraft(k)).toBe("b\nc");
+      vi.mocked(members.membersByChannel).mockReturnValue({});
 
       await vi.advanceTimersByTimeAsync(2_000);
       await done;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // #737 — the re-entrancy hole the store lock has to close. ComposeBox
+  // unmounts when the operator visits home / mentions / $list and on the
+  // desktop↔mobile swap, which resets its local `sending()`. Enter still fires
+  // on a readOnly textarea, so a second submit would fan the SAME residue out
+  // again — the #666 duplicate — and hand two drains one lock, so the first to
+  // finish would unlock a window the other is still rewriting.
+  it("#737 — a second submit on a draining window is refused, not fanned out again", async () => {
+    vi.useFakeTimers();
+    try {
+      localStorage.setItem("grappa-token", "tok");
+      const sb = await import("../lib/scrollback");
+      const api = await import("../lib/api");
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+
+      let n = 0;
+      let refused = false;
+      vi.mocked(sb.sendMessage).mockImplementation(async () => {
+        n += 1;
+        if (n === 2 && !refused) {
+          refused = true;
+          throw new api.ApiError(429, "rate_limited", { retry_after: 2 });
+        }
+        return undefined as never;
+      });
+
+      compose.setDraft(k, "a\nb\nc");
+      const done = compose.submit(k, "freenode", "#a");
+      await vi.advanceTimersByTimeAsync(0);
+      expect(compose.isDraining(k)).toBe(true);
+
+      // The operator comes back to a remounted composer and hits Enter.
+      const sentBefore = vi.mocked(sb.sendMessage).mock.calls.length;
+      const second = await compose.submit(k, "freenode", "#a");
+      expect(second).toHaveProperty("error");
+      expect(vi.mocked(sb.sendMessage).mock.calls.length).toBe(sentBefore);
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(await done).toEqual({ ok: true });
+
+      // One drain, one delivery of each line — "b" twice on the CALL log is
+      // the 429 refusal plus its retry, never two fan-outs.
+      expect(vi.mocked(sb.sendMessage).mock.calls.map((c) => c[2])).toEqual(["a", "b", "b", "c"]);
+      expect(compose.isDraining(k)).toBe(false);
     } finally {
       vi.useRealTimers();
     }

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -510,6 +510,224 @@ describe("compose submit — slash command dispatch", () => {
     }
   });
 
+  // #737 — a paced drain OWNS the draft it is mirroring the residue into: it
+  // rewrites that buffer every acked line, for as long as the drain runs (a
+  // 429 ladder can hold it for a minute). The operator cannot share that
+  // buffer — anything they type is overwritten on the next tick and wiped by
+  // the end-of-submit clear. The store refuses the write instead of losing it,
+  // and refuses it at EVERY door, since typing, history recall, swipe recall,
+  // tab-complete and both paste routes all land on the same draft.
+  it("#737 — typing into a draining window is refused, residue intact, and unlocks after", async () => {
+    vi.useFakeTimers();
+    try {
+      localStorage.setItem("grappa-token", "tok");
+      const sb = await import("../lib/scrollback");
+      const api = await import("../lib/api");
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+
+      // "a" acks; "b" is refused ONCE with a 2s retry-after, then everything
+      // succeeds — a drain that is genuinely paused while the operator types.
+      let n = 0;
+      let refused = false;
+      vi.mocked(sb.sendMessage).mockImplementation(async () => {
+        n += 1;
+        if (n === 2 && !refused) {
+          refused = true;
+          throw new api.ApiError(429, "rate_limited", { retry_after: 2 });
+        }
+        return undefined as never;
+      });
+
+      compose.setDraft(k, "a\nb\nc");
+      const done = compose.submit(k, "freenode", "#a");
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(compose.isDraining(k)).toBe(true);
+      expect(compose.getDraft(k)).toBe("b\nc");
+
+      // The operator types a reply mid-pause. Pre-fix this landed in the
+      // draft and the next acked line silently replaced it.
+      compose.setDraft(k, "wait what happened");
+      expect(compose.getDraft(k)).toBe("b\nc");
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(await done).toEqual({ ok: true });
+
+      // Drain over: the window is the operator's again.
+      expect(compose.isDraining(k)).toBe(false);
+      compose.setDraft(k, "now it takes");
+      expect(compose.getDraft(k)).toBe("now it takes");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("#737 — history recall and tab-complete are refused mid-drain too", async () => {
+    vi.useFakeTimers();
+    try {
+      localStorage.setItem("grappa-token", "tok");
+      const sb = await import("../lib/scrollback");
+      const api = await import("../lib/api");
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+
+      // Seed one history entry so recallPrev has somewhere to walk.
+      vi.mocked(sb.sendMessage).mockResolvedValue();
+      compose.setDraft(k, "earlier line");
+      await compose.submit(k, "freenode", "#a");
+
+      let n = 0;
+      let refused = false;
+      vi.mocked(sb.sendMessage).mockImplementation(async () => {
+        n += 1;
+        if (n === 2 && !refused) {
+          refused = true;
+          throw new api.ApiError(429, "rate_limited", { retry_after: 2 });
+        }
+        return undefined as never;
+      });
+
+      compose.setDraft(k, "a\nb\nc");
+      const done = compose.submit(k, "freenode", "#a");
+      await vi.advanceTimersByTimeAsync(0);
+      expect(compose.getDraft(k)).toBe("b\nc");
+
+      compose.recallPrev(k);
+      expect(compose.getDraft(k)).toBe("b\nc");
+      compose.recallNext(k);
+      expect(compose.getDraft(k)).toBe("b\nc");
+      expect(compose.tabComplete(k, "b\nc", 3, true)).toBeNull();
+      expect(compose.getDraft(k)).toBe("b\nc");
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      await done;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // #737 — the lock is per WINDOW, not per component. A ComposeBox-local
+  // `sending()` flag would freeze whatever window the operator switched to
+  // while leaving the actually-draining one writable.
+  it("#737 — the lock is per key: a sibling window stays writable during a drain", async () => {
+    vi.useFakeTimers();
+    try {
+      localStorage.setItem("grappa-token", "tok");
+      const sb = await import("../lib/scrollback");
+      const api = await import("../lib/api");
+      const compose = await import("../lib/compose");
+      const draining = channelKey("freenode", "#a");
+      const other = channelKey("freenode", "#b");
+
+      let n = 0;
+      let refused = false;
+      vi.mocked(sb.sendMessage).mockImplementation(async () => {
+        n += 1;
+        if (n === 2 && !refused) {
+          refused = true;
+          throw new api.ApiError(429, "rate_limited", { retry_after: 2 });
+        }
+        return undefined as never;
+      });
+
+      compose.setDraft(draining, "a\nb\nc");
+      const done = compose.submit(draining, "freenode", "#a");
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(compose.isDraining(draining)).toBe(true);
+      expect(compose.isDraining(other)).toBe(false);
+      compose.setDraft(other, "typed elsewhere");
+      expect(compose.getDraft(other)).toBe("typed elsewhere");
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      await done;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // #737 — a lock that outlives its drain is worse than no lock: the window
+  // would be dead until reload. The fatal path must release it too.
+  it("#737 — a fatally failed drain releases the lock it was holding", async () => {
+    vi.useFakeTimers();
+    try {
+      localStorage.setItem("grappa-token", "tok");
+      const sb = await import("../lib/scrollback");
+      const api = await import("../lib/api");
+      const compose = await import("../lib/compose");
+      const k = channelKey("freenode", "#a");
+
+      // "a" acks, "b" is paced once (so the lock is observably HELD), and the
+      // retry of "b" dies fatally — the path that must still unlock.
+      let n = 0;
+      vi.mocked(sb.sendMessage).mockImplementation(async () => {
+        n += 1;
+        if (n === 2) throw new api.ApiError(429, "rate_limited", { retry_after: 2 });
+        if (n === 3) throw new api.ApiError(400, "invalid_line");
+        return undefined as never;
+      });
+
+      compose.setDraft(k, "a\nb\nc");
+      const done = compose.submit(k, "freenode", "#a");
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Held during the pace…
+      expect(compose.isDraining(k)).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(await done).toHaveProperty("error");
+
+      // …and released by the fatal exit, not just by the happy one.
+      expect(compose.isDraining(k)).toBe(false);
+      compose.setDraft(k, "b\nc fixed");
+      expect(compose.getDraft(k)).toBe("b\nc fixed");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // #737 — the lock follows the RESIDUE, not the window the operator typed in:
+  // /msg mirrors the remainder into the query window it just focused, which is
+  // the window that must stop accepting input.
+  it("#737 — a /msg drain locks the query window that receives the residue", async () => {
+    vi.useFakeTimers();
+    try {
+      localStorage.setItem("grappa-token", "tok");
+      const sb = await import("../lib/scrollback");
+      const api = await import("../lib/api");
+      const compose = await import("../lib/compose");
+      const source = channelKey("freenode", "#a");
+      const query = channelKey("freenode", "bob");
+
+      let n = 0;
+      let refused = false;
+      vi.mocked(sb.sendMessage).mockImplementation(async () => {
+        n += 1;
+        if (n === 2 && !refused) {
+          refused = true;
+          throw new api.ApiError(429, "rate_limited", { retry_after: 2 });
+        }
+        return undefined as never;
+      });
+
+      compose.setDraft(source, "/msg bob a\nb\nc");
+      const done = compose.submit(source, "freenode", "#a");
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(compose.isDraining(query)).toBe(true);
+      expect(compose.getDraft(query)).toBe("b\nc");
+      compose.setDraft(query, "typed at the peer");
+      expect(compose.getDraft(query)).toBe("b\nc");
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      await done;
+      expect(compose.isDraining(query)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("/me action sends as ACTION via scrollback.sendMessage with CTCP framing", async () => {
     localStorage.setItem("grappa-token", "tok");
     const sb = await import("../lib/scrollback");

--- a/cicchetto/src/__tests__/focus-rule.test.ts
+++ b/cicchetto/src/__tests__/focus-rule.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { warmGraph } from "./helpers/warmGraph";
 
 // C4.2 — Cluster-wide focus-only-on-user-action invariant.
 //
@@ -103,6 +104,10 @@ vi.mock("../lib/queryWindows", () => ({
   queryWindowsByNetwork: vi.fn(() => ({})),
   setQueryWindowsByNetwork: vi.fn(),
 }));
+
+// #781 — see helpers/warmGraph.ts. `lib/subscribe` pulls `lib/selection`;
+// `lib/api` is fully replaced by the factory above, so it never loads.
+beforeAll(() => warmGraph(() => import("../lib/subscribe")));
 
 beforeEach(() => {
   vi.resetModules();

--- a/cicchetto/src/__tests__/helpers/warmGraph.ts
+++ b/cicchetto/src/__tests__/helpers/warmGraph.ts
@@ -1,0 +1,42 @@
+// #781 — warm a heavy module graph before the tests that re-import it.
+//
+// A test file that pairs `vi.resetModules()` with a per-test
+// `await import("../lib/X")` pays vite's transform for that graph on the
+// FIRST import only: `resetModules` clears the module registry, not the
+// transform cache, so every later import in the same file costs single-digit
+// ms. Measured on the four files that use this: ~0.33-0.6s isolated, 1.5-3s
+// under 16-way worker contention — against a 5000ms `testTimeout`.
+//
+// Left inside a test, that first import can overrun the budget, and vitest's
+// timeout RACES the promise rather than cancelling it: the test is failed
+// while the import is still in flight, and the orphaned module evaluation
+// completes during the NEXT test, after its `vi.clearAllMocks()` has zeroed
+// the counters. That is the #781 "double join" — an assertion failure two
+// tests away from its cause.
+//
+// Calling this from `beforeAll` does not abolish the budget, it moves the
+// cost onto `hookTimeout` (10000ms default, unset in vitest.config.ts) — a
+// 3-6x margin over the measured worst case instead of a 2-3x one. The bigger
+// win is the failure SHAPE: a hook that overruns fails its whole file loudly
+// with `Hook timed out`, instead of surfacing as a phantom logic bug in an
+// unrelated test.
+//
+// PRECONDITION — the warmed graph MUST be inert at module scope. This hook
+// runs before the first `beforeEach`, so `setupTests.ts`'s global stubs
+// (localStorage / WebSocket / IntersectionObserver) are NOT installed yet,
+// and mocked modules are shared across `vi.resetModules()`. In practice:
+// no bearer in localStorage (every store keys its resources on `token`, so
+// they never fetch) and no unmocked `lib/socket` in the graph (or the warm
+// instance opens a real ws against jsdom). Break either and the warm
+// instance corrupts spies shared with the tests — silently, which is the
+// very failure class this fixes.
+//
+// Pass the module the tests import; transitive deps come for free, so
+// warming a module its graph already pulls in is dead weight. A
+// full-replacement `vi.mock(path, () => ({...}))` factory means the real
+// file is never transformed at all — warming THAT path warms nothing.
+export async function warmGraph(...loaders: Array<() => Promise<unknown>>): Promise<void> {
+  for (const load of loaders) {
+    await load();
+  }
+}

--- a/cicchetto/src/__tests__/pasteRoute.test.ts
+++ b/cicchetto/src/__tests__/pasteRoute.test.ts
@@ -14,6 +14,9 @@ vi.mock("../lib/channelKey", () => ({
 vi.mock("../lib/compose", () => ({
   getDraft: vi.fn(() => ""),
   setDraft: vi.fn(),
+  // #737 — the router drops a text paste aimed at a window a paced drain is
+  // still rewriting. Default false: every pre-existing case is idle.
+  isDraining: vi.fn(() => false),
 }));
 
 vi.mock("../lib/confirmDialog", () => ({
@@ -87,6 +90,40 @@ describe("pasteRoute — routeClipboardPaste", () => {
     expect(setDraft).toHaveBeenCalledWith("freenode #a", "one line");
     expect(preventDefault).toHaveBeenCalled();
     expect(requestConfirm).not.toHaveBeenCalled();
+  });
+
+  // #737 — a paced drain owns the target window's draft, so the text path has
+  // nowhere to put a paste. Drop it here instead of asking "Paste N lines?"
+  // and then discarding the answer when the store refuses the write.
+  it("#737 — text paste into a DRAINING window is dropped: no confirm, no insert", async () => {
+    const compose = await import("../lib/compose");
+    vi.mocked(compose.isDraining).mockReturnValue(true);
+    try {
+      for (const text of ["one line", "a\nb\nc\nd"]) {
+        const { e, preventDefault } = pasteEvent({ text });
+        routeClipboardPaste(e, textarea(), "freenode", "#a", false);
+        expect(requestConfirm).not.toHaveBeenCalled();
+        expect(setDraft).not.toHaveBeenCalled();
+        expect(preventDefault).toHaveBeenCalled();
+      }
+    } finally {
+      vi.mocked(compose.isDraining).mockReturnValue(false);
+    }
+  });
+
+  // …but an UPLOAD is a separate pipeline that never touches the draft, so a
+  // drain must not block it.
+  it("#737 — a FILE paste still uploads while the window is draining", async () => {
+    const compose = await import("../lib/compose");
+    vi.mocked(compose.isDraining).mockReturnValue(true);
+    try {
+      const file = pngFile();
+      const { e } = pasteEvent({ file });
+      routeClipboardPaste(e, textarea(), "freenode", "#a", true);
+      expect(dropUpload).toHaveBeenCalledWith([file], "freenode", "#a");
+    } finally {
+      vi.mocked(compose.isDraining).mockReturnValue(false);
+    }
   });
 
   it("empty text, native insert UNAVAILABLE → focus-only no-op (no insert, no preventDefault)", () => {

--- a/cicchetto/src/__tests__/userTopic-rotation.test.ts
+++ b/cicchetto/src/__tests__/userTopic-rotation.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { warmGraph } from "./helpers/warmGraph";
 
 // #364 cicchetto S1 — user-topic re-join across the token lifecycle.
 //
@@ -85,6 +86,11 @@ vi.mock("../lib/api", () => ({
     };
   },
 }));
+
+// #781 — this file IS the double join: an orphaned first import, still in
+// flight when its test was failed for overrunning, joined the user topic a
+// second time from inside the NEXT test. See helpers/warmGraph.ts.
+beforeAll(() => warmGraph(() => import("../lib/userTopic")));
 
 beforeEach(() => {
   vi.resetModules();

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -252,6 +252,11 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   onIdentityChange(() => {
     tabCycle = null;
   });
+  // #737 — the drain lock is identity-scoped like the drafts it guards. A
+  // send that never settles (a backgrounded tab whose fetch never resolves)
+  // never runs its release `finally`, and the lock would otherwise outlive a
+  // logout/login and leave the composer dead until reload.
+  onIdentityChange(() => setDrainingKeys({}));
 
   const getState = (key: ChannelKey): ComposeState => composeByChannel()[key] ?? empty();
 
@@ -460,6 +465,16 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     networkSlug: string,
     channelName: string,
   ): Promise<SubmitResult> => {
+    // #737 — a drain already owns this window's draft, and that draft holds
+    // the residue it has NOT sent yet. Re-submitting would fan the same
+    // remainder out a second time (the #666 duplicate this whole mechanism
+    // exists to prevent) and hand two drains one lock, so the first to finish
+    // would unlock a window the other is still rewriting. The guard lives
+    // here, not in ComposeBox: that component's `sending()` dies with it, and
+    // it unmounts whenever the operator visits home / mentions / $list or the
+    // desktop↔mobile layouts swap — after which Enter (keydown still fires on
+    // a readOnly textarea) started a fresh drain.
+    if (isDraining(key)) return { error: "still sending the previous paste" };
     const state = getState(key);
     // #385 — expand user-defined aliases (from the aliasList store) before
     // dispatch; the parser stays pure and takes the map as an argument.

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -264,7 +264,41 @@ const exports_ = identityScopedStore((onIdentityChange) => {
 
   const getDraft = (key: ChannelKey): string => getState(key).draft;
 
+  // #737 — a #666 paced drain OWNS the draft it mirrors the residue into, and
+  // it can own it for a minute (per line: a 429, the server's retry-after, up
+  // to 5 retries clamped at 60s each). The operator cannot share that buffer:
+  // whatever they type is overwritten on the next acked line and then wiped by
+  // the end-of-submit clear. Refuse the write instead of losing it.
+  //
+  // The claim is per WINDOW, not per component: a ComposeBox-local `sending()`
+  // would follow the operator to whatever window they switch to, freezing that
+  // one while leaving the actually-draining window writable. It is also
+  // checked HERE rather than at the doors, because every door lands on this
+  // store — typing, both paste routes (`pasteRoute` → setDraft), arrow-key and
+  // swipe history recall, and tab-complete. Gating one door means the next
+  // door added is a fresh instance of this bug.
+  const [drainingKeys, setDrainingKeys] = createSignal<Record<ChannelKey, true>>({});
+
+  const isDraining = (key: ChannelKey): boolean => drainingKeys()[key] === true;
+
+  const claimDrafts = (keys: ChannelKey[]): void => {
+    setDrainingKeys((prev) => {
+      const next = { ...prev };
+      for (const k of keys) next[k] = true;
+      return next;
+    });
+  };
+
+  const releaseDrafts = (keys: ChannelKey[]): void => {
+    setDrainingKeys((prev) => {
+      const next = { ...prev };
+      for (const k of keys) delete next[k];
+      return next;
+    });
+  };
+
   const setDraft = (key: ChannelKey, value: string): void => {
+    if (isDraining(key)) return;
     // Any explicit edit (typing, paste, clear) breaks the tab-cycle
     // and resets the history cursor to null (we're back to live draft).
     tabCycle = null;
@@ -272,6 +306,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   };
 
   const recallPrev = (key: ChannelKey): void => {
+    if (isDraining(key)) return;
     writeState(key, (s) => {
       if (s.history.length === 0) return s;
       // Leaving the bottom: park the live draft so recallNext can restore it.
@@ -285,6 +320,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   };
 
   const recallNext = (key: ChannelKey): void => {
+    if (isDraining(key)) return;
     writeState(key, (s) => {
       if (s.historyCursor === null) return s;
       const next = s.historyCursor + 1;
@@ -376,6 +412,11 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     }
     let sentCount = 0;
     let totalCount = 0;
+    // #737 — the drain owns this draft until it stops, however long the
+    // pacing takes. Released in `finally` so a fatal mid-fan-out unlocks the
+    // window too: a lock that outlives its drain leaves the composer dead
+    // until reload, which is worse than the overwrite it prevents.
+    claimDrafts([key]);
     try {
       await sendBodyLines(slug, target, body, action, (sent, total, residue) => {
         sentCount = sent;
@@ -409,6 +450,8 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       return totalCount > 1
         ? { error: `${reason}${sentOf}; the rest are in the box` }
         : { error: reason };
+    } finally {
+      releaseDrafts([key]);
     }
   };
 
@@ -1488,6 +1531,9 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     cursor: number,
     forward: boolean,
   ): { newInput: string; newCursor: number } | null => {
+    // #737 — tab-complete writes the draft directly (see writeState below),
+    // so it needs the same refusal as setDraft / the history walk.
+    if (isDraining(key)) return null;
     const all = membersByChannel()[key] ?? [];
     if (all.length === 0) return null;
 
@@ -1568,6 +1614,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     recallNext,
     submit,
     tabComplete,
+    isDraining,
   };
 });
 
@@ -1578,3 +1625,4 @@ export const recallPrev = exports_.recallPrev;
 export const recallNext = exports_.recallNext;
 export const submit = exports_.submit;
 export const tabComplete = exports_.tabComplete;
+export const isDraining = exports_.isDraining;

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -421,7 +421,13 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     // pacing takes. Released in `finally` so a fatal mid-fan-out unlocks the
     // window too: a lock that outlives its drain leaves the composer dead
     // until reload, which is worse than the overwrite it prevents.
-    claimDrafts([key]);
+    // #737 × #723 — lock BOTH ends of the drain: the residue home, whose draft
+    // the pacing callback rewrites on every acked line, and the window the
+    // operator submitted from, so a second Enter there cannot start a rival
+    // drain that fans the same remainder out twice. They collapse to one key
+    // whenever the residue stays in the window it was typed in.
+    const locked = [...new Set([source.key, home.key])];
+    claimDrafts(locked);
     try {
       await sendBodyLines(slug, target, body, action, (sent, total, residue) => {
         sentCount = sent;
@@ -456,7 +462,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         ? { error: `${reason}${sentOf}; the rest are in the box` }
         : { error: reason };
     } finally {
-      releaseDrafts([key]);
+      releaseDrafts(locked);
     }
   };
 

--- a/cicchetto/src/lib/pasteRoute.ts
+++ b/cicchetto/src/lib/pasteRoute.ts
@@ -1,5 +1,5 @@
 import { channelKey } from "./channelKey";
-import { getDraft, setDraft } from "./compose";
+import { getDraft, isDraining, setDraft } from "./compose";
 import { requestConfirm } from "./confirmDialog";
 import { dropUpload } from "./dropUpload";
 import { pastedLineCount, shouldGuardPaste } from "./pasteFlood";
@@ -83,6 +83,17 @@ export function routeClipboardPaste(
   if (files.length > 0) {
     e.preventDefault();
     dropUpload(files, networkSlug, channelName);
+    return;
+  }
+  // #737 — a paced drain owns this window's draft, so the text path has
+  // nowhere to put a paste: the store refuses the write. Drop it HERE rather
+  // than letting the flood modal ask "Paste 30 lines?" and then discard the
+  // answer. preventDefault covers the global-listener path, whose target
+  // textarea may not be the focused element and so is not protected by its own
+  // readOnly. The file branch above is untouched — an upload never touches the
+  // draft.
+  if (isDraining(channelKey(networkSlug, channelName))) {
+    e.preventDefault();
     return;
   }
   // #80 — plain-text multi-line paste flood guard. A pasted block is sent

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -27727,3 +27727,47 @@ with only a console line.
 This change adds no competing layer — the failure screen is a terminal state
 that replaces the Shell subtree, deliberately bare, and must not become the
 place staged-progress copy accretes.
+
+### 2026-08-03 — #737 — a paced drain OWNS the draft it is draining (cic)
+
+Follow-on defect from #666, found by the 2026-08 codebase review. A multi-line
+paste mirrors the unsent remainder into a window's draft after every acked
+line, and the #666 pacing can hold that for a minute (per line: a 429, the
+server's retry-after, up to 5 retries clamped at 60s each). Only the submit
+BUTTON was disabled for that window. The textarea stayed editable over the
+same buffer, so an operator typing a reply mid-drain watched it vanish on the
+next acked line, every couple of seconds, and then get wiped by the
+end-of-submit clear. Enter did nothing the whole time.
+
+**The drain and operator input cannot share one buffer.** The residue has to
+stay IN the draft — that is what makes a resend deliver only the remainder
+(#666, and #723's re-addressing rests on it) — so the operator's writes are
+what must yield. The store refuses them while a drain holds the window, rather
+than accepting and losing them.
+
+**The lock lives in the store, not in ComposeBox.** Two reasons. It is
+per-WINDOW: `sending()` is a ComposeBox-local signal, and the component's
+`key()` follows the operator, so a `readOnly={sending()}` would freeze whatever
+window they switched to mid-drain while leaving the actually-draining one
+writable. And every door lands on the same store — typing, `pasteRoute`
+(shared by the textarea paste AND the #352 global paste listener), arrow-key
+history recall, swipe recall, tab-complete. Gating one door means the next door
+added is a fresh instance of this bug; gating `setDraft` / `recallPrev` /
+`recallNext` / `tabComplete` closes the class.
+
+**`readOnly`, never `disabled`.** `disabled` blurs the textarea, which
+collapses the on-screen keyboard — the focus steal #59 exists to prevent, and
+which `ComposeBox.test.tsx` already guards. `readOnly` keeps focus, caret and
+selection, and makes the refusal visible instead of silently swallowing
+keystrokes; the submit button's existing spinner carries the "why".
+
+**Released in `finally`.** A lock that outlives its drain leaves the composer
+dead until reload — worse than the overwrite it prevents. The fatal path
+unlocks too, and the test pins that the lock was actually HELD before the
+release, so it cannot pass by never locking at all.
+
+**Deliberately not built.** A richer "sending 7 of 30 — composer locked"
+progress affordance. The spinner plus a read-only box is proportionate; a
+progress surface is a UX change, not this defect. And the composer is locked
+for the RESIDUE window only — a `/msg` whose source window keeps a draft is
+#723's territory, not this one.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -27766,6 +27766,24 @@ dead until reload — worse than the overwrite it prevents. The fatal path
 unlocks too, and the test pins that the lock was actually HELD before the
 release, so it cannot pass by never locking at all.
 
+**The lock closes the SEND door too, found in review.** Refusing writes is not
+enough: `doSubmit`'s only re-entrancy guard was ComposeBox's local `sending()`,
+and that component unmounts when the operator visits home / mentions / $list or
+the desktop↔mobile layouts swap. Coming back gives a fresh `sending() === false`
+over a residue-filled draft, and `keydown` fires on a readOnly textarea — so
+Enter started a SECOND drain over the same residue. That is a duplicate
+delivery (the #666 bug) plus two drains sharing one lock, where the first to
+finish unlocks a window the other is still rewriting. `submit` now refuses a
+draining key outright, in the store, for the same reason the write gate lives
+there.
+
+**Two more doors closed in the same pass.** `routeClipboardPaste` drops a text
+paste aimed at a draining window instead of raising the flood modal and then
+discarding the confirmed answer (the file branch is untouched — an upload never
+touches the draft). And `drainingKeys` resets on identity change like every
+other piece of state in this store: a send that never settles never runs its
+release `finally`, and the lock would otherwise survive a logout/login.
+
 **Deliberately not built.** A richer "sending 7 of 30 — composer locked"
 progress affordance. The spinner plus a read-only box is proportionate; a
 progress surface is a UX change, not this defect. And the composer is locked


### PR DESCRIPTION
Fixes #737 from the 2026-08 review campaign, plus three doors found in review.

## The reported bug

#666's fan-out mirrors the unsent remainder into a window's draft after every acked line, and the pacing can hold that for a minute (per line: a 429, the server's retry-after, up to 5 retries clamped at 60s each). Only the submit **button** was disabled. The textarea stayed editable over the same buffer, so a reply typed mid-drain was overwritten on the next acked line — repeatedly — and then wiped by the end-of-submit clear, while Enter did nothing.

The residue has to stay in the draft (that is what makes a resend deliver only the remainder), so the operator's writes are what yield: the store **refuses** them rather than losing them.

## Why the lock is in the store, not in ComposeBox

The issue suggests `readOnly` on `sending()`. That has the wrong scope and leaves doors open:

- **Wrong scope.** `sending()` is component-local and `key()` follows the operator, so `readOnly={sending()}` freezes whichever window they switch to mid-drain and leaves the actually-draining one writable.
- **Doors.** Typing, `pasteRoute` (the textarea paste *and* the #352 global listener), arrow-key recall, swipe recall and tab-complete all land on the same store. Gating one door relocates the bug.

So `setDraft` / `recallPrev` / `recallNext` / `tabComplete` refuse a draining key, and `ComposeBox` binds `readOnly={isDraining(key())}` so the refusal is visible. **`readOnly`, never `disabled`** — `disabled` blurs the textarea and collapses the on-screen keyboard, the focus steal #59 exists to prevent and which `ComposeBox.test.tsx` already guards.

## Three more doors, found in review

- **The send door.** `doSubmit`'s only re-entrancy guard was `sending()`, and ComposeBox unmounts on a visit to home / mentions / $list and on the desktop↔mobile swap. Coming back gives a fresh `sending() === false` over a residue-filled draft, and `keydown` fires on a readOnly textarea — so Enter started a **second drain over the same residue**: a duplicate delivery, plus two drains sharing one lock where the first to finish unlocks a window the other is still rewriting. `submit` now refuses a draining key.
- **The paste door.** `routeClipboardPaste` dropped into "Paste 30 lines?" and then discarded the confirmed answer. It now drops the text paste up front; the file branch is untouched, since an upload never touches the draft.
- **Identity.** `drainingKeys` now resets on identity change like every other piece of state in this store — a send that never settles never runs its release `finally`, and the lock would otherwise outlive a logout/login and leave the composer dead until reload.

## Test plan

- [x] 9 new tests (6 in `compose.test.ts`, 2 in `pasteRoute.test.ts`, 2 in `ComposeBox.test.tsx`); verified red by disabling `claimDrafts`, and the fatal-release test asserts the lock was HELD mid-pace so it cannot pass by never locking
- [x] `scripts/bun.sh run check` — rc 0
- [x] `scripts/bun.sh run test` — 3975 passed (218 files)
- [x] `scripts/bun.sh run build` — clean

cic-only; no wire change, no server change. Touches `sendPacedBody`, so it will conflict textually with #777 (#723) — both edit that function; the resolution is mechanical.