### PR TITLE
test(#781): warm the module graph before the tests that re-import it

### DIFF
--- a/cicchetto/src/__tests__/BootErrorBoundary.test.tsx
+++ b/cicchetto/src/__tests__/BootErrorBoundary.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
 import { Show } from "solid-js";
-import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { warmGraph } from "./helpers/warmGraph";
 
 // #717 — the recoverability half, tested through the REAL resource cascade.
 //
@@ -63,6 +64,11 @@ const HEALTHY_ME = {
   read_cursors: {},
   badge_count: 0,
 };
+
+// #781 — see helpers/warmGraph.ts. The component pulls api, bundleHash,
+// connectivity and networks, so warming it covers every graph these tests
+// re-import.
+beforeAll(() => warmGraph(() => import("../BootErrorBoundary")));
 
 beforeEach(() => {
   vi.resetModules();

--- a/cicchetto/src/__tests__/archive.test.ts
+++ b/cicchetto/src/__tests__/archive.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ArchiveEntry } from "../lib/api";
+import { warmGraph } from "./helpers/warmGraph";
 
 vi.mock("../lib/api", () => ({
   listArchive: vi.fn(),
@@ -27,6 +28,10 @@ vi.mock("../lib/queryWindows", () => ({
 vi.mock("../lib/windowState", () => ({
   windowStateByChannel: () => ({}),
 }));
+
+// #781 — see helpers/warmGraph.ts. `lib/api` is NOT warmed: the factory at
+// the top of this file fully replaces it, so the real module never loads.
+beforeAll(() => warmGraph(() => import("../lib/archive")));
 
 beforeEach(() => {
   vi.resetModules();

--- a/cicchetto/src/__tests__/focus-rule.test.ts
+++ b/cicchetto/src/__tests__/focus-rule.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { warmGraph } from "./helpers/warmGraph";
 
 // C4.2 — Cluster-wide focus-only-on-user-action invariant.
 //
@@ -103,6 +104,10 @@ vi.mock("../lib/queryWindows", () => ({
   queryWindowsByNetwork: vi.fn(() => ({})),
   setQueryWindowsByNetwork: vi.fn(),
 }));
+
+// #781 — see helpers/warmGraph.ts. `lib/subscribe` pulls `lib/selection`;
+// `lib/api` is fully replaced by the factory above, so it never loads.
+beforeAll(() => warmGraph(() => import("../lib/subscribe")));
 
 beforeEach(() => {
   vi.resetModules();

--- a/cicchetto/src/__tests__/helpers/warmGraph.ts
+++ b/cicchetto/src/__tests__/helpers/warmGraph.ts
@@ -1,0 +1,42 @@
+// #781 — warm a heavy module graph before the tests that re-import it.
+//
+// A test file that pairs `vi.resetModules()` with a per-test
+// `await import("../lib/X")` pays vite's transform for that graph on the
+// FIRST import only: `resetModules` clears the module registry, not the
+// transform cache, so every later import in the same file costs single-digit
+// ms. Measured on the four files that use this: ~0.33-0.6s isolated, 1.5-3s
+// under 16-way worker contention — against a 5000ms `testTimeout`.
+//
+// Left inside a test, that first import can overrun the budget, and vitest's
+// timeout RACES the promise rather than cancelling it: the test is failed
+// while the import is still in flight, and the orphaned module evaluation
+// completes during the NEXT test, after its `vi.clearAllMocks()` has zeroed
+// the counters. That is the #781 "double join" — an assertion failure two
+// tests away from its cause.
+//
+// Calling this from `beforeAll` does not abolish the budget, it moves the
+// cost onto `hookTimeout` (10000ms default, unset in vitest.config.ts) — a
+// 3-6x margin over the measured worst case instead of a 2-3x one. The bigger
+// win is the failure SHAPE: a hook that overruns fails its whole file loudly
+// with `Hook timed out`, instead of surfacing as a phantom logic bug in an
+// unrelated test.
+//
+// PRECONDITION — the warmed graph MUST be inert at module scope. This hook
+// runs before the first `beforeEach`, so `setupTests.ts`'s global stubs
+// (localStorage / WebSocket / IntersectionObserver) are NOT installed yet,
+// and mocked modules are shared across `vi.resetModules()`. In practice:
+// no bearer in localStorage (every store keys its resources on `token`, so
+// they never fetch) and no unmocked `lib/socket` in the graph (or the warm
+// instance opens a real ws against jsdom). Break either and the warm
+// instance corrupts spies shared with the tests — silently, which is the
+// very failure class this fixes.
+//
+// Pass the module the tests import; transitive deps come for free, so
+// warming a module its graph already pulls in is dead weight. A
+// full-replacement `vi.mock(path, () => ({...}))` factory means the real
+// file is never transformed at all — warming THAT path warms nothing.
+export async function warmGraph(...loaders: Array<() => Promise<unknown>>): Promise<void> {
+  for (const load of loaders) {
+    await load();
+  }
+}

--- a/cicchetto/src/__tests__/userTopic-rotation.test.ts
+++ b/cicchetto/src/__tests__/userTopic-rotation.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { warmGraph } from "./helpers/warmGraph";
 
 // #364 cicchetto S1 — user-topic re-join across the token lifecycle.
 //
@@ -85,6 +86,11 @@ vi.mock("../lib/api", () => ({
     };
   },
 }));
+
+// #781 — this file IS the double join: an orphaned first import, still in
+// flight when its test was failed for overrunning, joined the user topic a
+// second time from inside the NEXT test. See helpers/warmGraph.ts.
+beforeAll(() => warmGraph(() => import("../lib/userTopic")));
 
 beforeEach(() => {
   vi.resetModules();


### PR DESCRIPTION
## Summary

Fixes the cic vitest suite's order/load sensitivity for the four files that actually pay for it. Test-only; no production code touched.

Both of #781's failure modes turned out to be one root cause, established by instrumentation rather than deduction (full write-up: https://github.com/vjt/grappa-irc/issues/781#issuecomment-5169273502).

`vi.resetModules()` clears the module registry but not vite's transform cache, so only the **first** import of a graph is slow — measured 0.33-0.6s isolated, 1.5-3s under 16-way worker contention, against a 5s budget. Each affected file pays it in its own first test; later tests in the same file run in single-digit ms. Vitest's timeout **races** the promise rather than cancelling it, so an overrun fails the test with the import still in flight, and the orphaned evaluation completes inside the **next** test — joining the user topic a second time after `clearAllMocks()` zeroed the counter.

A probe (globalThis instance counter, logged at the `joinUser` call site) caught it:

```
stdout | ... > re-joins the user topic on token ROTATION      ← TEST 2's window
[probe] userTopic module instance created 1                   ← TEST 1's instance
[probe] userTopic JOIN 1 name alice token tokA                ← TEST 1's join, inside TEST 2
[probe] userTopic module instance created 2
[probe] userTopic JOIN 2 name alice token tokA
```

**The double join is harness-only, not browser-reachable**, so it is dead as a lead for #281/#769: `joinUser` has one production caller, the effect has one reactive dependency (`token()`; `socketUserName()` is a non-reactive localStorage read), and the call site is guarded by `if (channel !== null) return` with a synchronous assignment. Two live instances require `resetModules`; a browser evaluates the module once.

## What this does NOT claim

`beforeAll` is not "outside the clock" — it moves the cost from `testTimeout` (5s) to `hookTimeout` (10s, unset in `vitest.config.ts`). Margin over the measured worst case goes from 2-3x to 3-6x. The bigger win is the **failure shape**: a hook that overruns fails its whole file loudly with `Hook timed out`, where a test that overruns surfaces as a phantom logic bug two tests later. Raising `testTimeout` was the alternative, rejected because it hides an infrastructure cost inside a number meant to bound test logic and makes every genuine hang slower to report.

## Scope

The four files measured to overrun. **35** files share the `resetModules` + dynamic-import shape — the criterion is a heavy first import, not the shape alone. The precondition (the warmed graph must be inert at module scope, because this hook runs before the first `beforeEach` and so before `setupTests`' global stubs) lives once in `helpers/warmGraph.ts` rather than in four copies that would drift.

Two warm lines the first cut had were dead and are gone: a full-replacement `vi.mock` factory means the real module is never transformed, so warming `lib/api` in `archive` / `focus-rule` warmed nothing.

## Test plan

- [x] `scripts/bun.sh run test` — 222 files / 3994 tests green
- [x] `scripts/bun.sh run test -- --testTimeout=2000` green — the amplifier under which the unfixed tree lights up exactly this family (`focus-rule`, `archive`, `userTopic-rotation`, `BootErrorBoundary`)
- [x] `scripts/bun.sh run test -- --hookTimeout=3000` green — squeezes the path this change adds, not just the one it removes
- [x] Falsified: with the warm-up in place, reverting `identityScopedStore` to a bare `createRoot` still turns 6 of 7 `BootErrorBoundary` cases red — warming that graph has not blunted the #717 regression test
- [x] `tsc --noEmit` clean, biome clean
- [x] Code review round applied: retracted the "outside the clock" claim, removed the dead warm lines, corrected the file count (~20 → 35), collapsed four copied comment blocks into one helper

cic-only, no lane used.

Refs #781