### PR TITLE
fix(#785): a WHOIS in flight absorbs one 401, not every error the operator earns

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -27807,36 +27807,49 @@ premise that it must be a WHOIS leg grappa has no typed handler for yet.
 318, so for the whole in-flight window EVERY 401 for that nick was folded into
 the bundle's `extra_lines` instead of being routed to `{:query, nick}` and
 persisted. bahamut emits one 401 **per failing command** (`src/s_user.c`:
-`m_whois` sends 401 then 318; `m_privmsg` sends its own), so a `/msg` plus a
+`m_whois` sends 401 then 318; `m_message` sends its own), so a `/msg` plus a
 WHOIS to the same dead nick make two 401s and the guard ate both.
 
-**Why #221's premise is only half true.** WHOIS legs are all RPL_* — that is
-what makes "delegate anything arriving during a WHOIS" a safe default for
-numerics invented next year. Error numerics are not legs: they answer whatever
-command provoked them. A 407 ERR_TOOMANYTARGETS or a 531 answering the
-operator's PRIVMSG was being swallowed by an unrelated WHOIS bundle and never
-shown — a silent swallow at a boundary, which CLAUDE.md forbids. So the guard
-now carves out the RFC error range (400..599) wholesale. This is the general
-rule; 401 was the instance that got reported.
+**Why #221's premise is only half true.** Every WHOIS leg except 401 is RPL_* —
+that is what makes "delegate anything arriving during a WHOIS" a safe default
+for numerics invented next year. Error numerics are not legs: they answer
+whatever command provoked them. A 407 ERR_TOOMANYTARGETS answering the
+operator's PRIVMSG (`src/s_user.c:2087`) was being swallowed by an unrelated
+WHOIS bundle and never shown — a silent swallow at a boundary, which CLAUDE.md
+forbids. So the guard now carves out the RFC error range (400..599) wholesale.
+401 was the instance that got reported; the range is the rule.
+
+**The range is the RFC block, not "every error numeric", and that is a
+deliberate stop.** solanum puts some PRIVMSG-time errors above the block — 707
+ERR_TARGCHANGE, 716 ERR_TARGUMODEG, 723 ERR_NOPRIVS — and those remain
+absorbable, so on Libera a `/msg` to a `+g` nick during a WHOIS for that nick is
+still folded into the card. Widening to 7xx would buy that case at the cost of
+#221's actual promise (a vendor numeric invented next year folds with zero code
+change here), for a reply Azzurra never emits. Reconsider if grappa ever binds a
+solanum network in anger.
 
 **401 is the one genuinely ambiguous code, and it is unresolvable.** bahamut
-emits it both as the WHOIS's own leg and once per failing PRIVMSG/CTCP/INVITE.
+emits it both as the WHOIS's own leg and once per failing PRIVMSG/CTCP/INVITE
+(`m_message`, reached via `m_private` — there is no `m_privmsg` in bahamut).
 The two are byte-identical on the wire and IRC numerics carry no request
 identity, so no amount of care distinguishes them. The rule adopted: a pending
 WHOIS absorbs the **first** 401 for its target; every later one falls through to
 the param scan and lands in the target's query window (or `$server` when none is
 open, per #640). The first 401 may be attributed to the wrong command. That is
 accepted deliberately, because the user-visible outcome is right for every
-combination bahamut can emit: **N failing commands plus one WHOIS produce
-exactly N visible error rows**, whichever order they arrive in. That ordering
+combination bahamut can emit: **N failing commands plus ONE in-flight WHOIS
+produce exactly N visible error rows**, whichever order they arrive in. That ordering
 independence is the point — the bug was load-dependent precisely because the
 outcome used to depend on whether the WHOIS was primed before the PRIVMSG's 401
 came back.
 
 **The alternative — never absorb a 401 — was rejected.** It is simpler and
-purer, but #606 auto-fetches a WHOIS whenever a query window is focused, so it
-would turn every focus of a window with a departed peer into a fresh red row in
-that window's scrollback. Absorbing one keeps the WHOIS's own 401 in the card
+purer (the fold gate collapses to the range test, and two public functions plus
+the fourth `router_state` field disappear), but #606 WILL auto-fetch a WHOIS
+whenever a query window is focused — that is the open PR #613, not main today —
+so it would turn every focus of a window with a departed peer into a fresh red
+row in that window's scrollback. If #613 slips indefinitely, the simpler shape
+is the one to revert to. Absorbing one keeps the WHOIS's own 401 in the card
 where it belongs.
 
 **Absorption had to be ONE rule read from two places.** The first cut put the
@@ -27848,16 +27861,36 @@ so EventRouter can update state") and the generic pass-through folds
 the absorption: `NumericRouter.absorbable_whois_leg?/2` is the single predicate,
 `whois_extra_line_fold/4` gates on it, and
 `EventRouter.whois_nosuchnick_absorbed/1` derives the already-absorbed target
-set from the folded `extra_lines` rather than tracking a parallel flag. Nothing
-to keep in sync, so nothing can drift.
+set from the folded `extra_lines` rather than tracking a parallel flag. The two
+halves cannot drift because there is only one record.
+
+**There is a third writer, and the review found it.** `prime_pending/3`
+REPLACES the accumulator, so a second WHOIS for a target that already has one in
+flight wipes `extra_lines` and with it the absorption record. The predicted
+consequence was that the operator sees nothing again; measured, it is not — each
+WHOIS brings its own 401, so a reset that costs one absorption arrives together
+with the numeric that needs it, and the reported case still produces its row.
+`server_test.exs` pins that interleaving rather than arguing it. The real
+boundary is older than #785: `whois_pending` is keyed by NICK, so two concurrent
+WHOISes for one target are one entry and the first 318 drains it for both. With
+a duplicate in flight the bundle is approximate by construction (P-0a), and the
+"exactly N" claim above is scoped to one.
 
 **Known edge, left open on purpose.** An ircd that emits 401 with no trailing
 text folds nothing (`whois_trailing/1` returns nil), so absorption is never
-recorded and a repeat is absorbed again. bahamut and solanum both always send
-the trailing. The trailing-less shape is a pre-existing silent-drop hole in the
-generic pass-through — a delegated numeric with no trailing is dropped by
-EventRouter and never persisted by Server — and #785 neither widens nor closes
-it.
+recorded and EVERY 401 in the window is delegated and dropped — for that wire
+shape #785 is a no-op, not a partial fix. bahamut and solanum both always send
+the trailing, and `candidate_params/1` already documents the 2-param shape as a
+legacy-ircd thing, so this is bounded rather than hypothetical. The underlying
+hole — a delegated numeric with no trailing is dropped by EventRouter and never
+persisted by Server — is older than #785, which neither widens nor closes it.
+
+Same derivation, related fragility: if anyone later gives 401 a typed
+`do_route` clause, `whois_extra_line_fold/4` stops being reached, the absorbed
+set is permanently empty, and the router silently reverts to eating every 401
+with no test failing. A router-side record taken at the delegation decision
+would remove both problems at the cost of the parallel state this deliberately
+avoids; the trade is worth revisiting if 401 ever earns a typed handler.
 
 **Ordering.** This landed on main before #613 (#606 query-rail context) merges.
 #606 turns the race from "the seconds after a typed `/whois`" into a routine one

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -27789,3 +27789,79 @@ progress affordance. The spinner plus a read-only box is proportionate; a
 progress surface is a UX change, not this defect. And the composer is locked
 for the RESIDUE window only — a `/msg` whose source window keeps a draft is
 #723's territory, not this one.
+---
+
+## 2026-08-03 — #785: a WHOIS in flight absorbs ONE 401, not every error the operator earns
+
+**Symptom.** `/msg <nonexistent-nick> hi` gave the operator no feedback at all —
+no "No such nick" row anywhere — whenever a WHOIS for that same nick was in
+flight. Pinned by `cp13-s5-msg-ghost-401.spec.ts`, which failed with `Received:
+0` error notices.
+
+**The mechanism, read from the source rather than inferred.** 401
+ERR_NOSUCHNICK has no typed handler, so it reaches `NumericRouter`'s `:scan`
+class, and there the #221 generic WHOIS-leg guard fires: any scan-class numeric
+whose `params[1]` is an in-flight WHOIS target is returned `:delegated`, on the
+premise that it must be a WHOIS leg grappa has no typed handler for yet.
+`whois_targets` is derived from `state.whois_pending` and is only drained on
+318, so for the whole in-flight window EVERY 401 for that nick was folded into
+the bundle's `extra_lines` instead of being routed to `{:query, nick}` and
+persisted. bahamut emits one 401 **per failing command** (`src/s_user.c`:
+`m_whois` sends 401 then 318; `m_privmsg` sends its own), so a `/msg` plus a
+WHOIS to the same dead nick make two 401s and the guard ate both.
+
+**Why #221's premise is only half true.** WHOIS legs are all RPL_* — that is
+what makes "delegate anything arriving during a WHOIS" a safe default for
+numerics invented next year. Error numerics are not legs: they answer whatever
+command provoked them. A 407 ERR_TOOMANYTARGETS or a 531 answering the
+operator's PRIVMSG was being swallowed by an unrelated WHOIS bundle and never
+shown — a silent swallow at a boundary, which CLAUDE.md forbids. So the guard
+now carves out the RFC error range (400..599) wholesale. This is the general
+rule; 401 was the instance that got reported.
+
+**401 is the one genuinely ambiguous code, and it is unresolvable.** bahamut
+emits it both as the WHOIS's own leg and once per failing PRIVMSG/CTCP/INVITE.
+The two are byte-identical on the wire and IRC numerics carry no request
+identity, so no amount of care distinguishes them. The rule adopted: a pending
+WHOIS absorbs the **first** 401 for its target; every later one falls through to
+the param scan and lands in the target's query window (or `$server` when none is
+open, per #640). The first 401 may be attributed to the wrong command. That is
+accepted deliberately, because the user-visible outcome is right for every
+combination bahamut can emit: **N failing commands plus one WHOIS produce
+exactly N visible error rows**, whichever order they arrive in. That ordering
+independence is the point — the bug was load-dependent precisely because the
+outcome used to depend on whether the WHOIS was primed before the PRIVMSG's 401
+came back.
+
+**The alternative — never absorb a 401 — was rejected.** It is simpler and
+purer, but #606 auto-fetches a WHOIS whenever a query window is focused, so it
+would turn every focus of a window with a departed peer into a fresh red row in
+that window's scrollback. Absorbing one keeps the WHOIS's own 401 in the card
+where it belongs.
+
+**Absorption had to be ONE rule read from two places.** The first cut put the
+carve-out only in `NumericRouter.route/2`. That routed the second 401 correctly
+and still duplicated it into the WHOIS card, because `Session.Server` calls
+`EventRouter.route/2` on the non-delegated branch too (server.ex, "Also delegate
+so EventRouter can update state") and the generic pass-through folds
+`extra_lines` regardless of what the router decided. The fix is that the fold IS
+the absorption: `NumericRouter.absorbable_whois_leg?/2` is the single predicate,
+`whois_extra_line_fold/4` gates on it, and
+`EventRouter.whois_nosuchnick_absorbed/1` derives the already-absorbed target
+set from the folded `extra_lines` rather than tracking a parallel flag. Nothing
+to keep in sync, so nothing can drift.
+
+**Known edge, left open on purpose.** An ircd that emits 401 with no trailing
+text folds nothing (`whois_trailing/1` returns nil), so absorption is never
+recorded and a repeat is absorbed again. bahamut and solanum both always send
+the trailing. The trailing-less shape is a pre-existing silent-drop hole in the
+generic pass-through — a delegated numeric with no trailing is dropped by
+EventRouter and never persisted by Server — and #785 neither widens nor closes
+it.
+
+**Ordering.** This landed on main before #613 (#606 query-rail context) merges.
+#606 turns the race from "the seconds after a typed `/whois`" into a routine one
+by auto-fetching a WHOIS on window focus, which is exactly what `/msg <ghost>`
+does; on the #613 branch cp13-s5 failed 2/2 in full local suites and passed in
+CI on the same commit. The window has always existed on main — #606 only makes
+it hit every time.

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -90,7 +90,7 @@ defmodule Grappa.Session.EventRouter do
 
   alias Grappa.IRC.{CTCP, Identifier, Message}
   alias Grappa.{Scrollback, Session}
-  alias Grappa.Session.{ISupport, Presence}
+  alias Grappa.Session.{ISupport, NumericRouter, Presence}
 
   @typedoc """
   The Session.Server state subset this module reads + mutates. The
@@ -3325,10 +3325,53 @@ defmodule Grappa.Session.EventRouter do
         state
 
       {:ok, accum} ->
-        existing = Map.get(accum, :extra_lines, [])
-        merged = Map.put(accum, :extra_lines, [%{numeric: code, text: text} | existing])
-        %{state | whois_pending: Map.put(pending, nick_key, merged)}
+        # #785 — the fold is the ABSORPTION. It has to honour the same
+        # carve-out `NumericRouter.route/2` used to decide whether this
+        # numeric was a WHOIS leg at all: the routed-elsewhere copy (a
+        # second 401, any other 4xx/5xx) is already persisted in its own
+        # window by Server, so folding it here would double it into the
+        # card as well.
+        if NumericRouter.absorbable_whois_leg?(code, nosuchnick_absorbed?(accum)) do
+          existing = Map.get(accum, :extra_lines, [])
+          merged = Map.put(accum, :extra_lines, [%{numeric: code, text: text} | existing])
+          %{state | whois_pending: Map.put(pending, nick_key, merged)}
+        else
+          state
+        end
     end
+  end
+
+  @doc """
+  The in-flight WHOIS targets whose bundle has already absorbed a 401
+  ERR_NOSUCHNICK (#785).
+
+  DERIVED from the `extra_lines` fold that absorbed it rather than tracked in
+  a parallel flag — the fold IS the absorption, so the two cannot drift.
+  `Session.Server` feeds this into `NumericRouter.new_router_state/4` so the
+  operator's NEXT 401 for the same nick routes to its query window instead of
+  being eaten by the bundle too.
+
+  Known edge: an ircd that emits 401 with no trailing text folds nothing
+  (`whois_trailing/1` returns nil), so absorption is never recorded and a
+  repeat is absorbed again. bahamut and solanum both always send the
+  trailing; the trailing-less shape is a separate silent-drop hole in the
+  generic pass-through, not one #785 widens.
+  """
+  @spec whois_nosuchnick_absorbed(state()) :: MapSet.t(String.t())
+  def whois_nosuchnick_absorbed(state) do
+    for {key, accum} <- Map.get(state, :whois_pending, %{}),
+        nosuchnick_absorbed?(accum),
+        into: MapSet.new(),
+        do: key
+  end
+
+  @spec nosuchnick_absorbed?(map()) :: boolean()
+  defp nosuchnick_absorbed?(accum) when is_map(accum) do
+    nosuchnick = NumericRouter.nosuchnick_numeric()
+
+    accum
+    |> Map.get(:extra_lines, [])
+    |> Enum.any?(&(Map.get(&1, :numeric) == nosuchnick))
   end
 
   # P-0d — fold one or more LUSERS fields into `state.lusers_pending`.

--- a/lib/grappa/session/numeric_router.ex
+++ b/lib/grappa/session/numeric_router.ex
@@ -109,11 +109,15 @@ defmodule Grappa.Session.NumericRouter do
       `:delegated` so EventRouter's generic pass-through folds it into the
       bundle's `extra_lines`. This is the ROOT-cause fix: a numeric emitted
       next year needs zero code change to route correctly.
+    * `whois_nosuchnick_absorbed` — the subset of `whois_targets` whose
+      pending WHOIS has ALREADY absorbed a 401 ERR_NOSUCHNICK (#785). See
+      the error-class carve-out on `absorbable_whois_leg?/2`.
   """
   @type router_state :: %{
           required(:own_nick) => String.t() | nil,
           required(:labels_pending) => %{String.t() => window_ref()},
-          required(:whois_targets) => MapSet.t(String.t())
+          required(:whois_targets) => MapSet.t(String.t()),
+          required(:whois_nosuchnick_absorbed) => MapSet.t(String.t())
         }
 
   # ---------------------------------------------------------------------------
@@ -138,6 +142,15 @@ defmodule Grappa.Session.NumericRouter do
   # coverage: other ircds define STATS numerics in 220–239 too; add them
   # here if a bound network emits them.
   @stats_numerics Enum.to_list(211..219) ++ Enum.to_list(240..250)
+
+  # #785 — the RFC error range (4xx command failures, 5xx server errors).
+  # Distinct from `severity/1`'s `>= 400` cut, which deliberately paints
+  # the 6xx vendor replies red too; absorption keys off the RANGE, so a
+  # 671 RPL_WHOISSECURE stays a foldable WHOIS leg. 401 ERR_NOSUCHNICK is
+  # the one error a WHOIS emits about itself. Both are read by
+  # `absorbable_whois_leg?/2`.
+  @error_numerics 400..599
+  @nosuchnick_numeric 401
 
   # Active deny list: numerics whose params look nick-shaped but the
   # token is NOT a routing destination — it's the rejected/offending
@@ -510,15 +523,69 @@ defmodule Grappa.Session.NumericRouter do
   return spec, avoiding `call_without_opaque` false-positives at the
   `route/2` call site.
   """
-  @spec new_router_state(String.t() | nil, %{String.t() => window_ref()}, MapSet.t(String.t())) ::
-          router_state()
-  def new_router_state(own_nick, labels_pending, whois_targets) do
+  @spec new_router_state(
+          String.t() | nil,
+          %{String.t() => window_ref()},
+          MapSet.t(String.t()),
+          MapSet.t(String.t())
+        ) :: router_state()
+  def new_router_state(own_nick, labels_pending, whois_targets, whois_nosuchnick_absorbed) do
     %{
       own_nick: own_nick,
       labels_pending: labels_pending,
-      whois_targets: whois_targets
+      whois_targets: whois_targets,
+      whois_nosuchnick_absorbed: whois_nosuchnick_absorbed
     }
   end
+
+  @doc """
+  The one error numeric a WHOIS emits for itself: 401 ERR_NOSUCHNICK.
+
+  Public so `Session.EventRouter` can recognise the absorbed leg inside a
+  `whois_pending` accumulator against the SAME constant the routing rule
+  keys off — the two halves of the #785 carve-out cannot drift apart.
+  """
+  @spec nosuchnick_numeric() :: 401
+  def nosuchnick_numeric, do: @nosuchnick_numeric
+
+  @doc """
+  Whether an in-flight WHOIS may still absorb `code` as one of its legs.
+
+  #785 — the error-class carve-out on the #221 guard.
+
+  #221's guard captures ANY scan-class numeric whose `params[1]` is an
+  in-flight WHOIS target, on the premise that it must be an unhandled WHOIS
+  leg. That premise holds for WHOIS legs, which are all RPL_* — it does NOT
+  hold for the error numerics, which answer whatever command provoked them.
+  A 407 ERR_TOOMANYTARGETS or a 531 answering the operator's PRIVMSG was
+  being folded into an unrelated WHOIS bundle and never shown (the
+  "no silent-swallow at boundaries" rule, violated).
+
+  401 ERR_NOSUCHNICK is the single ambiguous code: bahamut emits it BOTH as
+  the WHOIS's own leg (`s_user.c` `m_whois`: 401 then 318) AND once per
+  failing PRIVMSG/CTCP/INVITE — identical on the wire, with no request
+  identity to correlate on. So a pending WHOIS absorbs the FIRST 401 for its
+  target and every later one falls through to the param scan, landing in the
+  target's query window (or `$server` when none is open, per #640). The
+  first 401 may be attributed to the wrong command, but the user-visible
+  outcome is right for every combination bahamut can emit: N failing
+  commands plus one WHOIS produce exactly N visible error rows.
+
+  Non-error codes stay unconditional — a WHOIS legitimately emits several
+  320 lines, and a 6xx numeric added to solanum next year must still fold
+  with zero code change here (#221's whole point).
+
+  Both halves of the carve-out read this one predicate: `route/2` decides
+  whether to delegate, `EventRouter`'s generic pass-through decides whether
+  to fold into `extra_lines`. They must agree, or a routed numeric is ALSO
+  duplicated into the WHOIS card.
+  """
+  @spec absorbable_whois_leg?(1..999, boolean()) :: boolean()
+  def absorbable_whois_leg?(@nosuchnick_numeric, nosuchnick_absorbed?),
+    do: not nosuchnick_absorbed?
+
+  def absorbable_whois_leg?(code, _) when code in @error_numerics, do: false
+  def absorbable_whois_leg?(_, _), do: true
 
   @doc """
   Routes one numeric `%Message{}` to a `routing_decision()`.
@@ -639,8 +706,8 @@ defmodule Grappa.Session.NumericRouter do
   # change here. Only the `:scan` class reaches this arm — delegated/active
   # numerics already resolved above, so a channel-state or STATS numeric is
   # never captured even if a WHOIS happens to be in flight.
-  defp route_for_class(:scan, %Message{params: params} = msg, state) do
-    if whois_leg?(params, state.whois_targets) do
+  defp route_for_class(:scan, %Message{command: {:numeric, code}, params: params} = msg, state) do
+    if whois_leg?(code, params, state) do
       :delegated
     else
       scan_params(msg.params, state)
@@ -648,13 +715,18 @@ defmodule Grappa.Session.NumericRouter do
   end
 
   # True iff `params[1]` (the numeric's target slot) is the canonical nick
-  # of a WHOIS in flight. Any other param shape (empty, own-nick-only,
-  # channel-shaped) yields false → normal param scan.
-  @spec whois_leg?([term()], MapSet.t(String.t())) :: boolean()
-  defp whois_leg?([_, target | _], whois_targets) when is_binary(target),
-    do: MapSet.member?(whois_targets, Identifier.canonical_target(target))
+  # of a WHOIS in flight AND the code is one this WHOIS may still absorb.
+  # Any other param shape (empty, own-nick-only, channel-shaped) yields
+  # false → normal param scan.
+  @spec whois_leg?(1..999, [term()], router_state()) :: boolean()
+  defp whois_leg?(code, [_, target | _], state) when is_binary(target) do
+    key = Identifier.canonical_target(target)
 
-  defp whois_leg?(_, _), do: false
+    MapSet.member?(state.whois_targets, key) and
+      absorbable_whois_leg?(code, MapSet.member?(state.whois_nosuchnick_absorbed, key))
+  end
+
+  defp whois_leg?(_, _, _), do: false
 
   # Walk the params skipping params[0] (own-nick echo) and the last element
   # (trailing human-readable text). The first channel-prefix param wins; if

--- a/lib/grappa/session/numeric_router.ex
+++ b/lib/grappa/session/numeric_router.ex
@@ -144,8 +144,8 @@ defmodule Grappa.Session.NumericRouter do
   @stats_numerics Enum.to_list(211..219) ++ Enum.to_list(240..250)
 
   # #785 — the RFC error range (4xx command failures, 5xx server errors).
-  # Distinct from `severity/1`'s `>= 400` cut, which deliberately paints
-  # the 6xx vendor replies red too; absorption keys off the RANGE, so a
+  # Distinct from `severity/1`'s `>= 400` cut, which also lands the 6xx
+  # vendor replies on `:error`; absorption keys off the RANGE instead, so a
   # 671 RPL_WHOISSECURE stays a foldable WHOIS leg. 401 ERR_NOSUCHNICK is
   # the one error a WHOIS emits about itself. Both are read by
   # `absorbable_whois_leg?/2`.
@@ -555,25 +555,34 @@ defmodule Grappa.Session.NumericRouter do
 
   #221's guard captures ANY scan-class numeric whose `params[1]` is an
   in-flight WHOIS target, on the premise that it must be an unhandled WHOIS
-  leg. That premise holds for WHOIS legs, which are all RPL_* — it does NOT
-  hold for the error numerics, which answer whatever command provoked them.
-  A 407 ERR_TOOMANYTARGETS or a 531 answering the operator's PRIVMSG was
-  being folded into an unrelated WHOIS bundle and never shown (the
-  "no silent-swallow at boundaries" rule, violated).
+  leg. That premise holds for every WHOIS leg EXCEPT 401 — the rest are all
+  RPL_* — and it does NOT hold for the error numerics, which answer whatever
+  command provoked them. A 407 ERR_TOOMANYTARGETS answering the operator's
+  PRIVMSG (bahamut `s_user.c:2087`) was being folded into an unrelated WHOIS
+  bundle and never shown (the "no silent-swallow at boundaries" rule,
+  violated).
 
   401 ERR_NOSUCHNICK is the single ambiguous code: bahamut emits it BOTH as
   the WHOIS's own leg (`s_user.c` `m_whois`: 401 then 318) AND once per
-  failing PRIVMSG/CTCP/INVITE — identical on the wire, with no request
+  failing PRIVMSG/CTCP/INVITE (`m_message`, reached via `m_private`) —
+  identical on the wire, with no request
   identity to correlate on. So a pending WHOIS absorbs the FIRST 401 for its
   target and every later one falls through to the param scan, landing in the
   target's query window (or `$server` when none is open, per #640). The
   first 401 may be attributed to the wrong command, but the user-visible
   outcome is right for every combination bahamut can emit: N failing
-  commands plus one WHOIS produce exactly N visible error rows.
+  commands plus ONE in-flight WHOIS produce exactly N visible error rows.
 
   Non-error codes stay unconditional — a WHOIS legitimately emits several
   320 lines, and a 6xx numeric added to solanum next year must still fold
   with zero code change here (#221's whole point).
+
+  The carve-out is deliberately the RFC error BLOCK, not every error numeric
+  in existence. solanum puts some PRIVMSG-time errors above it (707
+  ERR_TARGCHANGE, 716 ERR_TARGUMODEG, 723 ERR_NOPRIVS) and those stay
+  absorbable: widening to 7xx would cost #221's actual promise — a vendor
+  numeric invented next year folding into the card with zero code change —
+  to cover a reply Azzurra never emits.
 
   Both halves of the carve-out read this one predicate: `route/2` decides
   whether to delegate, `EventRouter`'s generic pass-through decides whether

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -4314,7 +4314,10 @@ defmodule Grappa.Session.Server do
       # (keys are already canonical nicks). Lets NumericRouter delegate an
       # unhandled WHOIS-leg numeric to EventRouter's generic pass-through
       # instead of misrouting it to a bogus query window.
-      MapSet.new(Map.keys(Map.get(state, :whois_pending, %{})))
+      MapSet.new(Map.keys(Map.get(state, :whois_pending, %{}))),
+      # #785 — of those, the ones whose bundle already absorbed a 401. The
+      # accumulator shape is EventRouter's, so the derivation lives there.
+      EventRouter.whois_nosuchnick_absorbed(state)
     )
   end
 

--- a/test/grappa/session/numeric_router_test.exs
+++ b/test/grappa/session/numeric_router_test.exs
@@ -522,7 +522,10 @@ defmodule Grappa.Session.NumericRouterTest do
       assert {:query, "ghost"} = NumericRouter.route(m, st)
     end
 
-    test "a 5xx error numeric is NEVER absorbed by an in-flight whois" do
+    test "an unassigned 5xx code is NEVER absorbed — the carve-out is the RANGE, not a list" do
+      # 531 is `NULL` in bahamut's err_str table (src/s_err.c) and unknown to
+      # solanum; it is here precisely BECAUSE no bound ircd emits it. The
+      # carve-out must hold for a code nobody enumerated.
       m = msg(531, ["vjt", "ghost", "You are not permitted to send private messages"])
       st = state(whois_targets: MapSet.new(["ghost"]))
       assert {:query, "ghost"} = NumericRouter.route(m, st)

--- a/test/grappa/session/numeric_router_test.exs
+++ b/test/grappa/session/numeric_router_test.exs
@@ -31,7 +31,8 @@ defmodule Grappa.Session.NumericRouterTest do
     %{
       own_nick: Keyword.get(opts, :own_nick, "vjt"),
       labels_pending: Keyword.get(opts, :labels_pending, %{}),
-      whois_targets: Keyword.get(opts, :whois_targets, MapSet.new())
+      whois_targets: Keyword.get(opts, :whois_targets, MapSet.new()),
+      whois_nosuchnick_absorbed: Keyword.get(opts, :whois_nosuchnick_absorbed, MapSet.new())
     }
   end
 
@@ -461,6 +462,89 @@ defmodule Grappa.Session.NumericRouterTest do
       # exactly as before (pre-#221 behaviour preserved for the non-whois case).
       m = msg(617, ["vjt", "alice", "some line"])
       assert {:query, "alice"} = NumericRouter.route(m, state(whois_targets: MapSet.new()))
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #785 — the error-class carve-out in the #221 guard
+  # ---------------------------------------------------------------------------
+
+  describe "whois-leg guard — error-class numerics (#785)" do
+    test "the FIRST 401 for an in-flight whois target is absorbed as the whois leg" do
+      m = msg(401, ["vjt", "ghost", "No such nick/channel"])
+      st = state(whois_targets: MapSet.new(["ghost"]))
+      assert :delegated = NumericRouter.route(m, st)
+    end
+
+    test "a SECOND 401 for the same in-flight whois target routes to the query window" do
+      m = msg(401, ["vjt", "ghost", "No such nick/channel"])
+
+      st =
+        state(
+          whois_targets: MapSet.new(["ghost"]),
+          whois_nosuchnick_absorbed: MapSet.new(["ghost"])
+        )
+
+      assert {:query, "ghost"} = NumericRouter.route(m, st)
+    end
+
+    test "the absorbed set folds the target case-insensitively (ASCII)" do
+      m = msg(401, ["vjt", "GHOST", "No such nick/channel"])
+
+      st =
+        state(
+          whois_targets: MapSet.new(["ghost"]),
+          whois_nosuchnick_absorbed: MapSet.new(["ghost"])
+        )
+
+      assert {:query, "GHOST"} = NumericRouter.route(m, st)
+    end
+
+    test "an absorbed 401 for ANOTHER target still absorbs for this one" do
+      m = msg(401, ["vjt", "ghost", "No such nick/channel"])
+
+      st =
+        state(
+          whois_targets: MapSet.new(["ghost", "alice"]),
+          whois_nosuchnick_absorbed: MapSet.new(["alice"])
+        )
+
+      assert :delegated = NumericRouter.route(m, st)
+    end
+
+    test "a non-401 error numeric is NEVER absorbed by an in-flight whois" do
+      # 407 ERR_TOOMANYTARGETS answers a PRIVMSG, never a WHOIS. Pre-#785 the
+      # generic guard swallowed it whole whenever a WHOIS for the same nick
+      # happened to be in flight — one command's failure eaten by another
+      # command's bundle.
+      m = msg(407, ["vjt", "ghost", "Too many recipients"])
+      st = state(whois_targets: MapSet.new(["ghost"]))
+      assert {:query, "ghost"} = NumericRouter.route(m, st)
+    end
+
+    test "a 5xx error numeric is NEVER absorbed by an in-flight whois" do
+      m = msg(531, ["vjt", "ghost", "You are not permitted to send private messages"])
+      st = state(whois_targets: MapSet.new(["ghost"]))
+      assert {:query, "ghost"} = NumericRouter.route(m, st)
+    end
+
+    test "an unknown 6xx numeric is still absorbed unconditionally (#221 intact)" do
+      # The absorbed set is 401-only bookkeeping: a non-error leg folds as
+      # many times as it arrives (a whois can emit several 320 lines).
+      m = msg(617, ["vjt", "ghost", "some new WHOIS line"])
+
+      st =
+        state(
+          whois_targets: MapSet.new(["ghost"]),
+          whois_nosuchnick_absorbed: MapSet.new(["ghost"])
+        )
+
+      assert :delegated = NumericRouter.route(m, st)
+    end
+
+    test "a 401 with NO whois in flight routes to the query window (pre-#221 behaviour)" do
+      m = msg(401, ["vjt", "ghost", "No such nick/channel"])
+      assert {:query, "ghost"} = NumericRouter.route(m, state())
     end
   end
 

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -9275,6 +9275,61 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    test "#785 — a pending WHOIS absorbs ONE 401; the next lands in the query window", %{
+      server: server,
+      user: user,
+      network: network,
+      pid: pid
+    } do
+      # Server twin of the cp13-s5-msg-ghost-401 e2e. `/msg ghost hi` opens the
+      # query window and (#606) focusing it fires a WHOIS, so bahamut answers
+      # with TWO 401s for the same nick — s_user.c emits one per failing
+      # command — plus the WHOIS's own 318. Pre-#785 the in-flight WHOIS
+      # swallowed BOTH via the #221 guard and the operator got no feedback at
+      # all that the nick does not exist.
+      assert {:ok, _} = Session.send_privmsg({:user, user.id}, network.id, "ghost", "hi")
+      assert QueryWindows.open?({:user, user.id}, network.id, "ghost")
+
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil)
+      _ = IRCServer.wait_for_line(server, &(&1 == "WHOIS ghost\r\n"), 1_000)
+
+      # Subscribe AFTER the outbound send so the mailbox holds only the 401s.
+      :ok =
+        Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.channel(user.name, network.slug, "ghost"))
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      IRCServer.feed(server, ":irc.test.org 401 grappa-test ghost :No such nick/channel\r\n")
+      IRCServer.feed(server, ":irc.test.org 401 grappa-test ghost :No such nick/channel\r\n")
+      IRCServer.feed(server, ":irc.test.org 318 grappa-test ghost :End of /WHOIS list\r\n")
+
+      # The second 401 is the operator's visible feedback, in the window they
+      # /msg'd — not $server, not swallowed.
+      assert_message_event(
+        kind: :notice,
+        channel: "ghost",
+        network: network.slug,
+        meta: %{
+          numeric: 401,
+          severity: :error,
+          raw_params: ["grappa-test", "ghost", "No such nick/channel"]
+        }
+      )
+
+      # ...and EXACTLY one: the first 401 went into the WHOIS card instead.
+      refute_receive %Phoenix.Socket.Broadcast{payload: %{kind: :message}}, 200
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :whois_bundle} = bundle
+                     },
+                     1_500
+
+      assert [%{numeric: 401, text: "No such nick/channel"}] = bundle.extra_lines
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
     test "318 case-insensitive against typed target (server may echo different case)", %{
       server: server,
       user: user,

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -9330,6 +9330,106 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    test "#785 — a non-401 error numeric is neither absorbed NOR folded into the card", %{
+      server: server,
+      user: user,
+      network: network,
+      pid: pid
+    } do
+      # The fold-side half of the carve-out. Routing the 407 to the query
+      # window is not enough: Server calls EventRouter on the non-delegated
+      # branch too, so without the same gate on `whois_extra_line_fold/4` the
+      # row would ALSO be duplicated into the WHOIS card's extra_lines.
+      assert {:ok, _} = Session.send_privmsg({:user, user.id}, network.id, "ghost", "hi")
+
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil)
+      _ = IRCServer.wait_for_line(server, &(&1 == "WHOIS ghost\r\n"), 1_000)
+
+      :ok =
+        Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.channel(user.name, network.slug, "ghost"))
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      IRCServer.feed(server, ":irc.test.org 407 grappa-test ghost :Too many recipients\r\n")
+      IRCServer.feed(server, ":irc.test.org 318 grappa-test ghost :End of /WHOIS list\r\n")
+
+      assert_message_event(
+        kind: :notice,
+        channel: "ghost",
+        network: network.slug,
+        meta: %{
+          numeric: 407,
+          severity: :error,
+          raw_params: ["grappa-test", "ghost", "Too many recipients"]
+        }
+      )
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :whois_bundle} = bundle
+                     },
+                     1_500
+
+      assert bundle.extra_lines == nil
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "#785 — a re-issued WHOIS resets the bundle, and the row accounting survives it", %{
+      server: server,
+      user: user,
+      network: network,
+      pid: pid
+    } do
+      # `prime_pending/3` REPLACES the accumulator, so a second WHOIS for a
+      # target that already has one in flight wipes `extra_lines` — and with
+      # it the absorption record this fix derives from. That is a third writer
+      # to the field, so the accounting is pinned here rather than argued:
+      # each WHOIS brings its own 401, so a reset that costs one absorption
+      # arrives together with the numeric that needs it.
+      #
+      # Boundary of the model, NOT introduced by #785: `whois_pending` is
+      # keyed by NICK, so two concurrent WHOISes for the same target are one
+      # entry and the first 318 drains it for both. The count below is exact
+      # for the reported case (one WHOIS); with a duplicate in flight the
+      # bundle is approximate by construction (P-0a).
+      assert {:ok, _} = Session.send_privmsg({:user, user.id}, network.id, "ghost", "hi")
+
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil)
+      _ = IRCServer.wait_for_line(server, &(&1 == "WHOIS ghost\r\n"), 1_000)
+
+      :ok =
+        Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.channel(user.name, network.slug, "ghost"))
+
+      # The /msg's 401 is absorbed by the first WHOIS.
+      IRCServer.feed(server, ":irc.test.org 401 grappa-test ghost :No such nick/channel\r\n")
+      refute_receive %Phoenix.Socket.Broadcast{payload: %{kind: :message}}, 300
+
+      # Re-prime BETWEEN the absorption and the first WHOIS's own reply — the
+      # interleaving that actually destroys the record.
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil)
+
+      IRCServer.feed(server, ":irc.test.org 401 grappa-test ghost :No such nick/channel\r\n")
+      IRCServer.feed(server, ":irc.test.org 318 grappa-test ghost :End of /WHOIS list\r\n")
+      IRCServer.feed(server, ":irc.test.org 401 grappa-test ghost :No such nick/channel\r\n")
+      IRCServer.feed(server, ":irc.test.org 318 grappa-test ghost :End of /WHOIS list\r\n")
+
+      # The operator still gets feedback — the failure is never fully silent,
+      # which is the #785 regression this pins against.
+      assert_message_event(
+        kind: :notice,
+        channel: "ghost",
+        network: network.slug,
+        meta: %{
+          numeric: 401,
+          severity: :error,
+          raw_params: ["grappa-test", "ghost", "No such nick/channel"]
+        }
+      )
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
     test "318 case-insensitive against typed target (server may echo different case)", %{
       server: server,
       user: user,


### PR DESCRIPTION
## The bug

`/msg <nonexistent-nick> hi` gives the operator **no feedback at all** — no "no such nick" row anywhere — whenever a WHOIS for that same nick is in flight. Pinned by `cicchetto/e2e/tests/cp13-s5-msg-ghost-401.spec.ts`, which fails with `Received: 0` error notices.

## Mechanism, read from source

401 ERR_NOSUCHNICK has no typed handler, so it reaches `NumericRouter`'s `:scan` class, where the pre-existing #221 generic WHOIS-leg guard returns `:delegated` for **any** scan-class numeric whose `params[1]` is an in-flight WHOIS target. `whois_targets` derives from `state.whois_pending` and only drains on 318, so for the whole window every 401 for that nick was folded into the bundle's `extra_lines` instead of being persisted in the query window.

bahamut emits one 401 **per failing command** (`src/s_user.c`: `m_whois` sends 401 then 318 at `:2196`; the PRIVMSG path sends its own via `m_message`), so a `/msg` plus a WHOIS to the same dead nick make two 401s and the guard ate both.

## The fix

- **Carve the RFC error range (400..599) out of the #221 guard.** Those numerics answer whatever command provoked them; they are not WHOIS legs. A 407 answering the operator's PRIVMSG was being swallowed by an unrelated bundle — a silent swallow at a boundary, which CLAUDE.md forbids. 401 was the reported instance; the range is the rule. Deliberately the RFC block only: solanum's 707/716/723 stay absorbable rather than cost #221's zero-code-change promise.
- **401 is the one ambiguous code.** It is byte-identical whether it answers the WHOIS or the PRIVMSG, and numerics carry no request identity. A pending WHOIS absorbs the **first** 401 for its target; later ones fall through to the scan. The first may be attributed to the wrong command — accepted deliberately, because the visible outcome is then right for **every order** bahamut can emit. That ordering independence is the point: the bug was load-dependent precisely because the outcome used to depend on whether the WHOIS was primed before the PRIVMSG's 401 came back.
- **One predicate, read from two places.** Routing it correctly was not enough — `Session.Server` calls `EventRouter.route/2` on the non-delegated branch too, and the generic pass-through folds `extra_lines` regardless of the routing decision, so the first cut routed the second 401 correctly and still duplicated it into the card. The fold **is** the absorption now: `whois_extra_line_fold/4` gates on `NumericRouter.absorbable_whois_leg?/2`, and the absorbed set is derived from the folded `extra_lines` rather than a parallel flag.

Rejected: never absorbing a 401. Simpler and purer, but #606 will auto-fetch a WHOIS on window focus, so it would paint a fresh red row on every focus of a departed peer's window.

## Ordering constraint

**This must land on main before #613 (#606 query-rail context) merges.** #606 turns the race from "the seconds after a typed `/whois`" into a routine one, because focusing a query window auto-WHOISes and `/msg <ghost>` focuses one. On the #613 branch cp13-s5 failed 2/2 in two separate full local suites and passed in CI on the same commit — timing luck. The window has always existed on main; #606 only makes it hit every time.

## Review round

Code review checked my bahamut citations and killed two of them; `ec56af52` retracts them in the record rather than quietly editing:

- there is no `m_privmsg` in bahamut (it is `m_message` via `m_private`);
- 531 is `NULL` in `src/s_err.c` — no bound ircd emits it, so it was never being swallowed. It stays as a test fixture, relabelled to say what it actually proves: the carve-out is a **range**, so it must hold for a code nobody enumerated.

It also found a third writer to the field the absorbed-set derives from: `prime_pending/3` **replaces** the accumulator, so a re-issued WHOIS wipes `extra_lines`. The predicted consequence was "the operator sees nothing again"; measured, it is not — each WHOIS brings its own 401, so the reset arrives together with the numeric that needs it. There is now a test pinning that interleaving instead of a paragraph arguing it. And a real coverage gap: nothing asserted that a non-401 error routed to the query window is **not** also folded into the card, so deleting the second clause of `absorbable_whois_leg?/2` left the suite green. Closed.

## Test plan

- [x] `scripts/check.sh` rc=0 on the final tree — `8 doctests, 50 properties, 5023 tests, 0 failures`, credo `4908 mods/funs, found no issues`, format/dialyzer/sobelow/audits/bats all green.
- [x] Failing test written first: 4 reds in `numeric_router_test.exs` before the fix, exactly the four new behaviours.
- [x] Server-level wiring proof in `server_test.exs` — two 401s plus a 318 for one pending WHOIS yield exactly one notice in the query window and exactly one `extra_lines` entry in the card.
- [x] Fold-gate coverage: a 407 with a pending WHOIS routes to the query window and leaves `extra_lines` nil.
- [x] Re-prime interleaving pinned: the operator still gets a row when a second WHOIS clobbers the accumulator mid-flight.
- [ ] **e2e not run — I do not hold the STACK lane.** `cp13-s5-msg-ghost-401` is the end-to-end proof and should be green before #613 merges.