### PR TITLE
cic: the security panes — a QR nobody can scan (#734) and buttons nobody can tap (#735)

### DIFF
--- a/cicchetto/src/InlineConfirmButton.tsx
+++ b/cicchetto/src/InlineConfirmButton.tsx
@@ -20,6 +20,10 @@ import type { Component } from "solid-js";
 // IS the load-bearing UX signal. No `::before` sigils or wrapping
 // spans — the visible label is the inner text directly.
 
+// `disabled` is optional like `extraClass`: the admin tables that first used
+// this button have no in-flight state to gate on, and requiring the prop
+// there would mean nine `disabled={false}` call sites saying nothing. #735's
+// passkey rows DO have one — the removal they confirm is a request in flight.
 export type Props = {
   idleLabel: string;
   confirmLabel: string;
@@ -28,6 +32,7 @@ export type Props = {
   onConfirm: () => void | Promise<void>;
   testId: string;
   extraClass?: string;
+  disabled?: boolean;
 };
 
 const InlineConfirmButton: Component<Props> = (props) => {
@@ -37,6 +42,7 @@ const InlineConfirmButton: Component<Props> = (props) => {
       class={`inline-confirm-btn ${props.extraClass ?? ""}`.trim()}
       classList={{ confirming: props.armed }}
       data-testid={props.testId}
+      disabled={props.disabled ?? false}
       onClick={() => {
         if (props.armed) {
           void props.onConfirm();

--- a/cicchetto/src/PasskeySettings.tsx
+++ b/cicchetto/src/PasskeySettings.tsx
@@ -1,4 +1,5 @@
 import { type Component, createSignal, For, onMount, Show } from "solid-js";
+import InlineConfirmButton from "./InlineConfirmButton";
 import {
   deletePasskey,
   finishPasskeyModeChange,
@@ -21,6 +22,11 @@ const PasskeySettings: Component = () => {
   const [recoveryToken, setRecoveryToken] = createSignal<string | null>(null);
   const [error, setError] = createSignal<string | null>(null);
   const [busy, setBusy] = createSignal(false);
+  // #735 — deleting a passkey is irreversible and, in passwordless mode, can
+  // lock the account out entirely, so removal goes through the drawer's
+  // existing two-tap InlineConfirmButton rather than firing on first tap.
+  // One armed id across the whole list: arming a row disarms its siblings.
+  const [armedRemoval, setArmedRemoval] = createSignal<string | null>(null);
 
   const currentToken = (): string => {
     const value = token();
@@ -127,6 +133,7 @@ const PasskeySettings: Component = () => {
       setError(value instanceof Error ? value.message : String(value));
     } finally {
       setBusy(false);
+      setArmedRemoval(null);
     }
   };
 
@@ -143,9 +150,15 @@ const PasskeySettings: Component = () => {
                 {(passkey) => (
                   <li>
                     {passkey.name}{" "}
-                    <button type="button" disabled={busy()} onClick={() => void remove(passkey.id)}>
-                      remove
-                    </button>
+                    <InlineConfirmButton
+                      idleLabel={`remove ${passkey.name}`}
+                      confirmLabel={`confirm removing ${passkey.name}`}
+                      testId={`passkey-remove-${passkey.id}`}
+                      disabled={busy()}
+                      armed={armedRemoval() === passkey.id}
+                      onArm={() => setArmedRemoval(passkey.id)}
+                      onConfirm={() => void remove(passkey.id)}
+                    />
                   </li>
                 )}
               </For>

--- a/cicchetto/src/ShareSessionModal.tsx
+++ b/cicchetto/src/ShareSessionModal.tsx
@@ -205,7 +205,7 @@ const ShareSessionModal: Component = () => {
             <p class="share-modal-qr-heading">
               scan this code on another device to access your session
             </p>
-            <div class="share-modal-qr" data-testid="share-qr" innerHTML={qrMarkup()} />
+            <div class="qr-frame" data-testid="share-qr" innerHTML={qrMarkup()} />
 
             <p class="share-modal-alt muted">alternatively, send yourself a link</p>
             <Show when={canNativeShare()}>

--- a/cicchetto/src/TotpSettings.tsx
+++ b/cicchetto/src/TotpSettings.tsx
@@ -121,7 +121,7 @@ const TotpSettings: Component<Props> = (props) => {
             <form onSubmit={confirmEnrollment} data-testid="totp-enrollment-form">
               <p>Scan this QR code, or enter the key manually. Then confirm one code.</p>
               <div
-                class="share-qr"
+                class="qr-frame"
                 innerHTML={qrSvgWithLabel(pending.provisioning_uri, "TOTP enrollment QR code")}
               />
               <label for="totp-manual-key">Manual key</label>

--- a/cicchetto/src/__tests__/ShareSessionModal.test.tsx
+++ b/cicchetto/src/__tests__/ShareSessionModal.test.tsx
@@ -44,9 +44,13 @@ describe("ShareSessionModal (#392)", () => {
     await waitFor(() => expect(screen.getByTestId("share-modal")).toBeInTheDocument());
     expect(mintShareToken).toHaveBeenCalledWith("session-token");
 
-    // QR container carries an inline <svg> built from the share URL.
+    // QR container carries an inline <svg> built from the share URL, inside
+    // the shared sized frame. #734 — the testid and the class are different
+    // names on purpose; reaching for the testid as a class is what left the
+    // TOTP pane's QR unsized, so both call sites are pinned to `.qr-frame`.
     const qr = await screen.findByTestId("share-qr");
     expect(qr.querySelector("svg")).not.toBeNull();
+    expect(qr.className).toContain("qr-frame");
 
     // The link the user sends to themselves.
     const url = (await screen.findByTestId("share-url")) as HTMLInputElement;

--- a/cicchetto/src/__tests__/helpers/themeCss.ts
+++ b/cicchetto/src/__tests__/helpers/themeCss.ts
@@ -1,0 +1,29 @@
+/// <reference types="node" />
+import { readFileSync } from "node:fs";
+
+// Shared source-level reader for the stylesheet, lifted out of
+// ipadSafeArea.test.ts when #734/#735 needed the same "does this rule
+// exist, and what does it declare?" guard (CLAUDE.md "implement once,
+// reuse everywhere"). vitest stubs `.css?raw` imports to empty, so the
+// stylesheet has to be read off disk; relative paths resolve against cwd
+// (= cicchetto/, the vite root). cicchetto's tsconfig deliberately omits
+// @types/node, hence the file-scoped reference above.
+export const themeCss = readFileSync("src/themes/default.css", "utf8");
+
+/**
+ * Extract a single top-level CSS rule body by its selector. Matches
+ * `selector { ... }` at column 0 (top-level rules, outside any @media
+ * block, start at the left margin). Returns the text BETWEEN the braces
+ * with CSS comments stripped, so prose that mentions a property cannot
+ * satisfy or trip a declaration assertion. Throws when the rule is absent
+ * so a rename can't silently pass the test — the #734 failure mode was a
+ * class name with NO rule behind it at all.
+ */
+export function ruleBody(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`^${escaped}\\s*\\{([^}]*)\\}`, "m");
+  const match = themeCss.match(re);
+  const captured = match?.[1];
+  if (captured === undefined) throw new Error(`CSS rule not found: ${selector}`);
+  return captured.replace(/\/\*[\s\S]*?\*\//g, "");
+}

--- a/cicchetto/src/__tests__/ipadSafeArea.test.ts
+++ b/cicchetto/src/__tests__/ipadSafeArea.test.ts
@@ -1,6 +1,7 @@
 /// <reference types="node" />
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import { ruleBody, themeCss } from "./helpers/themeCss";
 
 // #205 — cicchetto as an installed PWA on iPadOS rendered its top chrome
 // (settings cog included) UNDER the iOS status bar, clipped and
@@ -26,25 +27,11 @@ import { describe, expect, it } from "vitest";
 // the `/// <reference types="node" />` above scopes the Node types to this
 // file alone rather than widening ambient types for the whole `src` tree.
 // vitest runs on Node so readFileSync exists at runtime; relative paths
-// resolve against cwd (= cicchetto/, the vite root).
-const css = readFileSync("src/themes/default.css", "utf8");
+// resolve against cwd (= cicchetto/, the vite root). The stylesheet read +
+// `ruleBody` extractor moved to helpers/themeCss.ts when #734/#735 needed
+// the same guard.
+const css = themeCss;
 const indexHtml = readFileSync("index.html", "utf8");
-
-// Extract a single top-level CSS rule body by its selector. Matches
-// `selector {  ... }` at column 0 (the desktop `.shell` rule lives
-// outside any @media block, so it starts at the left margin). Returns the
-// text BETWEEN the braces, with CSS comments stripped so prose that
-// mentions a property (e.g. a comment describing the old `height: 100vh`)
-// can't satisfy or trip a declaration assertion. Throws if the rule is
-// absent so a rename can't silently pass the test.
-function ruleBody(selector: string): string {
-  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const re = new RegExp(`^${escaped}\\s*\\{([^}]*)\\}`, "m");
-  const match = css.match(re);
-  const captured = match?.[1];
-  if (captured === undefined) throw new Error(`CSS rule not found: ${selector}`);
-  return captured.replace(/\/\*[\s\S]*?\*\//g, "");
-}
 
 describe("#205 iPad standalone-PWA safe area", () => {
   it("index.html viewport meta opts into viewport-fit=cover", () => {

--- a/cicchetto/src/__tests__/securityPaneControls.test.tsx
+++ b/cicchetto/src/__tests__/securityPaneControls.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
+import { ruleBody } from "./helpers/themeCss";
+
+// #734 — the TOTP enrolment QR rendered into a class with NO rule behind it.
+//
+// Two guard flavours here, deliberately:
+//   * A SOURCE-LEVEL CSS guard. jsdom applies no stylesheet, so the QR's real
+//     appearance is NOT observable in this suite — only the presence of the
+//     rule that sizes and lightens it. Scannability still needs a real camera.
+//   * A DOM guard for what jsdom CAN see: which class the container asks for.
+
+const api = vi.hoisted(() => ({
+  getPasskeyStatus: vi.fn(),
+  getTotpStatus: vi.fn(),
+  startTotpEnrollment: vi.fn(),
+}));
+
+vi.mock("../lib/api", () => ({
+  ApiError: class ApiError extends Error {},
+  confirmTotpEnrollment: vi.fn(),
+  deletePasskey: vi.fn(),
+  disableTotp: vi.fn(),
+  finishPasskeyModeChange: vi.fn(),
+  finishPasskeyRegistration: vi.fn(),
+  getPasskeyStatus: api.getPasskeyStatus,
+  getTotpStatus: api.getTotpStatus,
+  preparePasswordless: vi.fn(),
+  startPasskeyModeChange: vi.fn(),
+  startPasskeyRegistration: vi.fn(),
+  startPasswordlessActivation: vi.fn(),
+  startTotpEnrollment: api.startTotpEnrollment,
+}));
+
+vi.mock("../lib/auth", () => ({ token: () => "test-token" }));
+
+vi.mock("../lib/passkeys", () => ({
+  createPasskey: vi.fn(),
+  getPasskey: vi.fn(),
+}));
+
+import TotpSettings from "../TotpSettings";
+
+describe("#734 TOTP enrolment QR sits in a sized, light-framed box", () => {
+  it("the QR frame rule supplies a fixed box and a white background", () => {
+    // The #734 defect exactly: `.share-qr` was a data-testid, not a class,
+    // so the container had no rule — ruleBody throws when the rule is gone.
+    const body = ruleBody(".qr-frame");
+    expect(body).toMatch(/width:\s*12rem/);
+    expect(body).toMatch(/height:\s*12rem/);
+    expect(body).toMatch(/background:\s*#fff/);
+  });
+
+  it("the QR frame sizes the injected svg to fill it", () => {
+    // lib/qr.ts emits a viewBox-scaled svg with no intrinsic px size, so
+    // without this rule the code renders at the UA's replaced-element default.
+    const body = ruleBody(".qr-frame svg");
+    expect(body).toMatch(/width:\s*100%/);
+    expect(body).toMatch(/height:\s*100%/);
+  });
+
+  it("the enrolment QR container asks for the sized frame class", async () => {
+    api.getTotpStatus.mockResolvedValue({ enabled: false });
+    api.getPasskeyStatus.mockResolvedValue({ mode: "disabled", passkeys: [] });
+    api.startTotpEnrollment.mockResolvedValue({
+      enrollment_token: "enrol-token",
+      provisioning_uri: "otpauth://totp/grappa:vjt?secret=ABCD",
+      secret: "ABCD",
+    });
+
+    render(() => <TotpSettings onBack={() => {}} />);
+    await fireEvent.click(await screen.findByRole("button", { name: "enable TOTP" }));
+
+    const form = await screen.findByTestId("totp-enrollment-form");
+    expect(form.querySelector(".qr-frame")).not.toBeNull();
+  });
+});

--- a/cicchetto/src/__tests__/securityPaneControls.test.tsx
+++ b/cicchetto/src/__tests__/securityPaneControls.test.tsx
@@ -1,16 +1,21 @@
 import { fireEvent, render, screen } from "@solidjs/testing-library";
-import { describe, expect, it, vi } from "vitest";
-import { ruleBody } from "./helpers/themeCss";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ruleBody, themeCss } from "./helpers/themeCss";
 
-// #734 — the TOTP enrolment QR rendered into a class with NO rule behind it.
+// #734 / #735 — the two security panes (TOTP + passkeys) shipped with a QR
+// container whose class had NO rule behind it, and with buttons that carried
+// no class at all under a drawer that had no base <button> treatment.
 //
 // Two guard flavours here, deliberately:
-//   * A SOURCE-LEVEL CSS guard. jsdom applies no stylesheet, so the QR's real
-//     appearance is NOT observable in this suite — only the presence of the
-//     rule that sizes and lightens it. Scannability still needs a real camera.
-//   * A DOM guard for what jsdom CAN see: which class the container asks for.
+//   * SOURCE-LEVEL CSS guards. jsdom applies no stylesheet, so the rendered
+//     44px height and the QR's real appearance are NOT observable in this
+//     suite — only the presence of the rules that produce them. The on-device
+//     tap target and the scannability of the code still need a real iPhone.
+//   * DOM guards for what jsdom CAN see: which class the QR container asks
+//     for, and each remove button's accessible name + confirm step.
 
 const api = vi.hoisted(() => ({
+  deletePasskey: vi.fn(),
   getPasskeyStatus: vi.fn(),
   getTotpStatus: vi.fn(),
   startTotpEnrollment: vi.fn(),
@@ -19,7 +24,7 @@ const api = vi.hoisted(() => ({
 vi.mock("../lib/api", () => ({
   ApiError: class ApiError extends Error {},
   confirmTotpEnrollment: vi.fn(),
-  deletePasskey: vi.fn(),
+  deletePasskey: api.deletePasskey,
   disableTotp: vi.fn(),
   finishPasskeyModeChange: vi.fn(),
   finishPasskeyRegistration: vi.fn(),
@@ -39,6 +44,7 @@ vi.mock("../lib/passkeys", () => ({
   getPasskey: vi.fn(),
 }));
 
+import PasskeySettings from "../PasskeySettings";
 import TotpSettings from "../TotpSettings";
 
 describe("#734 TOTP enrolment QR sits in a sized, light-framed box", () => {
@@ -73,5 +79,95 @@ describe("#734 TOTP enrolment QR sits in a sized, light-framed box", () => {
 
     const form = await screen.findByTestId("totp-enrollment-form");
     expect(form.querySelector(".qr-frame")).not.toBeNull();
+  });
+});
+
+describe("#735 the settings drawer gives every button a tap floor", () => {
+  it("the base drawer button rule floors the height at the HIG minimum", () => {
+    // Absolute px, via --tap-min: the html root font-size is 14px, so a rem
+    // tap target under-shoots 44px (feedback_cic_tap_target_rem_pitfall).
+    const body = ruleBody(":where(.settings-drawer) button");
+    expect(body).toMatch(/min-height:\s*var\(--tap-min\)/);
+    expect(themeCss).toMatch(/--tap-min:\s*44px/);
+  });
+
+  it("dresses the button in the drawer's own font, not the UA's", () => {
+    const body = ruleBody(":where(.settings-drawer) button");
+    expect(body).toMatch(/font-family:\s*var\(--font-mono\)/);
+    expect(body).toMatch(/font-size:\s*var\(--font-size\)/);
+    // Paired with the floor: under content-box, min-height 44px would mean
+    // 44px PLUS padding and border on every button in the drawer.
+    expect(body).toMatch(/box-sizing:\s*border-box/);
+  });
+
+  it("stays at element-only specificity — a floor, never an override", () => {
+    // The load-bearing half of the rule is the `:where()`. Written bare, the
+    // selector would weigh (0,1,1) and repaint .settings-back, .logout,
+    // .watchlists-remove and the theme cards instead of yielding to them.
+    expect(themeCss).toContain(":where(.settings-drawer) button {");
+    expect(themeCss).not.toMatch(/^\.settings-drawer button \{/m);
+  });
+
+  it("declares no border-radius — the drawer is square by intent", () => {
+    // No drawer button class declares a radius (the irssi sharp-corner
+    // aesthetic the .settings-section comment states), so a radius on the
+    // base rule would round every one of them at once.
+    expect(ruleBody(":where(.settings-drawer) button")).not.toMatch(/border-radius/);
+  });
+
+  it("a disabled drawer button reads as disabled under the base look", () => {
+    // Both panes gate their controls on busy(); custom colours would
+    // otherwise drop the UA's own greying-out with nothing in its place.
+    // Pinned to the value: `/opacity/` alone passes against `opacity: 1`.
+    const body = ruleBody(":where(.settings-drawer) button:disabled");
+    expect(body).toMatch(/opacity:\s*0\.5/);
+    expect(body).toMatch(/cursor:\s*default/);
+  });
+});
+
+describe("#735 each passkey remove button names its own passkey", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getPasskeyStatus.mockResolvedValue({
+      mode: "second_factor",
+      passkeys: [
+        { id: "passkey-1", name: "phone", inserted_at: "2026-08-03T00:00:00Z", last_used_at: null },
+        {
+          id: "passkey-2",
+          name: "laptop",
+          inserted_at: "2026-08-03T00:00:00Z",
+          last_used_at: null,
+        },
+      ],
+    });
+  });
+
+  it("gives every remove button a distinct accessible name", async () => {
+    render(() => <PasskeySettings />);
+
+    await screen.findByRole("button", { name: "remove phone" });
+    screen.getByRole("button", { name: "remove laptop" });
+  });
+
+  it("arms before deleting, so one mis-tap cannot destroy a credential", async () => {
+    render(() => <PasskeySettings />);
+
+    await fireEvent.click(await screen.findByRole("button", { name: "remove phone" }));
+    expect(api.deletePasskey).not.toHaveBeenCalled();
+
+    // The armed label names the passkey too — a screen reader hears WHICH
+    // credential the confirmation destroys, not a bare "confirm".
+    await fireEvent.click(screen.getByRole("button", { name: "confirm removing phone" }));
+    expect(api.deletePasskey).toHaveBeenCalledWith("test-token", "passkey-1", "");
+  });
+
+  it("arming one row disarms the other", async () => {
+    render(() => <PasskeySettings />);
+
+    await fireEvent.click(await screen.findByRole("button", { name: "remove phone" }));
+    await fireEvent.click(screen.getByRole("button", { name: "remove laptop" }));
+
+    expect(screen.getByRole("button", { name: "remove phone" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "confirm removing laptop" })).toBeTruthy();
   });
 });

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -9776,8 +9776,16 @@ audio.media-viewer-media {
 
 /* Black-on-white QR framed in its own light card so it stays scannable
    regardless of the cic theme (a light-on-dark QR is rejected by many
-   scanners). The inner <svg> is viewBox-scaled → it fills this box. */
-.share-modal-qr {
+   scanners). The inner <svg> is viewBox-scaled → it fills this box.
+
+   #734 — named `.qr-frame`, NOT `.share-modal-qr`: this IS the sized
+   container `lib/qr.ts` contracts for ("the caller injects it into a sized
+   container — no fixed px width/height"), and it has two call sites now
+   (the share modal and the TOTP enrolment pane). The modal-scoped old name
+   is what caused #734 — the security pane reached for `share-qr`, which is
+   the modal's data-testid, and landed on a class with no rule at all. One
+   QR frame primitive, both call sites; no second sized-box rule. */
+.qr-frame {
   width: 12rem;
   height: 12rem;
   max-width: 70vw;
@@ -9788,7 +9796,7 @@ audio.media-viewer-media {
   box-sizing: border-box;
 }
 
-.share-modal-qr svg {
+.qr-frame svg {
   display: block;
   width: 100%;
   height: 100%;

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -3512,6 +3512,63 @@ html.resize-dragging * {
   color: var(--accent);
 }
 
+/* #735 — base <button> treatment for the whole settings drawer, the twin of
+   the #497/#508 global input rule above. The drawer had NO base button rule:
+   every pane that forgot a class (the TOTP + passkey security panes, the
+   watchlists/aliases/perform "add" buttons, whose `.watchlists-add-btn` has
+   never had a rule behind it) rendered a UA-default control — UA font, UA
+   grey, and roughly 20px tall — inside a themed dark drawer. Five more
+   per-class rules would have been five more places to forget; this is the
+   one treatment every drawer button gets for free.
+
+   `:where()` keeps the selector at element-only specificity (0,0,1), so a
+   per-class rule at (0,1,0) always wins the properties it DECLARES:
+   .settings-back, .logout, .watchlists-remove, .inline-confirm-btn and the
+   theme cards keep their own paint. The look IS .settings-back's (transparent
+   + accent + border) — the drawer's existing idiom promoted to the base
+   rather than a new one invented beside it.
+
+   A base rule is only a floor for what the class DIDN'T declare, so keep the
+   declaration list to what a styled button can safely inherit. Two effects
+   are deliberate and DO reach shipped controls:
+     * the 44px floor lands on the borderless micro-buttons too
+       (.watchlists-remove ×, .aliases-edit), so watch-list / keyword / alias
+       rows grow from ~20px to 44px. That is the SAME sub-HIG target #735
+       reports, in panes that never reported it — fixing the class, not the
+       instance. Revert path if the density is unwanted: exempt those two
+       classes with an explicit min-height of their own.
+     * .logout / .admin-console-entry / .delete-account-entry declare
+       font-family but no font-size, so they move off the UA's 13.3px onto
+       the drawer's --font-size — the same unification #497 made for inputs.
+   NO border-radius here: the drawer is square by documented intent (see the
+   .settings-section comment, "sharp corners, irssi aesthetic"), and NO drawer
+   button class declares one, so a radius on the base would round all of them.
+   box-sizing is load-bearing, not tidiness: with content-box the 44px floor
+   would be 44px PLUS padding and border on every button.
+
+   min-height in ABSOLUTE px via --tap-min (44px): the html root font-size is
+   14px, so a rem-based tap target under-shoots the Apple-HIG floor. The
+   :disabled pair is not decoration — both security panes gate their controls
+   on busy(), and custom colours drop the UA's own greying-out. That one sits
+   at (0,1,1) on purpose (a pseudo-class carries class weight): a disabled
+   control must read as disabled whatever its own class paints. */
+:where(.settings-drawer) button {
+  box-sizing: border-box;
+  min-height: var(--tap-min);
+  padding: 0.4rem 0.7rem;
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: var(--font-size);
+  cursor: pointer;
+}
+
+:where(.settings-drawer) button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 .settings-drawer h2 {
   font-size: 1rem;
   font-weight: normal;


### PR DESCRIPTION
Issues #734 and #735, one branch: they overlap in `TotpSettings.tsx` and both add CSS to `themes/default.css`, so split into two branches they would conflict with each other. Two commits, one per issue.

## #734 — the enrolment QR had no box

`TotpSettings.tsx` rendered the QR into `class="share-qr"`, which is not a class at all: it is the share modal's `data-testid`. The real sized box next to it is `.share-modal-qr`. So the enrolment code came out at the UA's default replaced-element size on a dark card, with no white frame and no quiet zone — and `lib/qr.ts` contracts for a *sized* container precisely because a light-on-dark QR is what camera scanners reject. A user who cannot scan cannot enrol a second factor.

I did not point the pane at `.share-modal-qr`. **That name is the bug's cause**: a modal-scoped label on what is really the shared "sized, theme-independent QR box" every `qr.ts` caller must supply, sitting next to a differently-named testid — and the second call site copied the wrong token. Renamed to `.qr-frame`, both call sites now use it. One frame primitive, two users, no second sized-box rule beside the first.

## #735 — one base rule, not a sixth per-class exception

None of the buttons on either pane carried a class and the drawer had **no base `button` rule**, so they rendered UA-default — UA font, UA grey, ~20px tall — inside a themed dark drawer.

A `.security-pane button` rule would have been the sixth exception, and would have left the identical defect in the panes that already have it: **`.watchlists-add-btn`, worn by the add buttons in watchlists, aliases and perform, has never had a rule behind it either.** So this is the rule the drawer should have had — the twin of the `input:where(...)` treatment from #497/#508, `:where()` and all. Element-only specificity (0,0,1) means every per-class rule at (0,1,0) wins the properties it declares; the look is `.settings-back`'s own, promoted to the base rather than invented beside it. `--tap-min` is 44px in absolute px already — the root font-size is 14px, so a rem target would under-shoot.

The remove button's two defects are one fix: it now renders the drawer's existing two-tap `InlineConfirmButton`, with the passkey's name in the **visible** label in both states (`remove phone` → `confirm removing phone`). Visible name over `aria-label` per WCAG label-in-name, and because it stays truthful when the button arms — a static `aria-label` would not.

## Three effects that reach shipped panes — deliberate, and worth your eye

A base rule is a floor only for what a class did *not* declare, so the declaration list is short. What still lands outside the security panes:

1. **The 44px floor reaches the borderless micro-buttons** (`.watchlists-remove` ×, `.aliases-edit`), so watch-list, keyword and alias rows grow from ~20px to 44px. This is the same sub-HIG target #735 reports, in three panes that never reported it. Revert path if you dislike the density: one `min-height` on those two classes, noted in the CSS.
2. **`.logout` / `.admin-console-entry` / `.delete-account-entry`** declare a font-family but no font-size, so they move off the UA's 13.3px onto the drawer's `--font-size` — the same unification #497 made for inputs.
3. An earlier draft carried `border-radius: 3px`. **No drawer button class declares a radius**, so it rounded every button in the drawer at once, against the stated irssi sharp-corner aesthetic. Caught in review, dropped, and pinned by a test.

## Verification, and what it cannot cover

`bun run check` (biome + tsc) rc=0 · full vitest **4021 passed / 224 files** rc=0 · `bun run build` rc=0. No lane used; nothing on docker or e2e.

⚠️ **jsdom applies no stylesheet.** The suite proves the rules exist and what they declare, plus what the DOM says (which class the QR container asks for, each remove button's accessible name, the arm-before-delete step). It cannot show you a 44px target or a scannable QR. Both want a real iPhone, and the three effects above want your eye on staging.

The CSS guards use `ruleBody()`, which throws when a selector has no rule — exactly #734's defect class. Lifted it out of `ipadSafeArea.test.ts` into `__tests__/helpers/themeCss.ts` on its second use.

## Reviewed

One synchronous review agent over the full diff. It confirmed the border-radius regression (fixed), two mirror tests that would have passed against a broken implementation (`/opacity/` passes against `opacity: 1`; the "specificity" test asserted fonts) — both rewritten with teeth — and that nothing pinned the share-modal side of the rename (now pinned). It verified as clean: the `:disabled` override, the `disabled?` prop against all nine `InlineConfirmButton` call sites, the rename's completeness including the Playwright specs (they key the untouched `share-qr` testid), and the helper lift's faithfulness.