### PR TITLE
test(cic): cover the passkey surface and unblock the Login mock (#736)

### DIFF
--- a/cicchetto/src/__tests__/Login.test.tsx
+++ b/cicchetto/src/__tests__/Login.test.tsx
@@ -8,9 +8,16 @@ import { ApiError } from "../lib/api";
 // raw HTTP layer so the form test stays focused on form behavior, not
 // transport. The auth-store ⇄ api wiring is covered separately in
 // auth.test.ts.
+// #736 — the factory MUST declare every auth function `Login.tsx` reaches.
+// It used to omit `loginWithPasskey`/`loginWithRecoveryCode` (the #442
+// alternate-auth row), so the first click on either button raised
+// `TypeError: … is not a function` instead of a meaningful assertion — the
+// whole passkey surface was untestable from here.
 vi.mock("../lib/auth", () => ({
   login: vi.fn(),
   verifyTotp: vi.fn(),
+  loginWithPasskey: vi.fn(),
+  loginWithRecoveryCode: vi.fn(),
   logout: vi.fn(),
   token: vi.fn(() => null),
   isAuthenticated: vi.fn(() => false),
@@ -292,6 +299,109 @@ describe("Login — TOTP", () => {
     await waitFor(() => {
       expect(auth.verifyTotp).toHaveBeenCalledWith("challenge-123", "123456");
     });
+  });
+});
+
+// #736 — the #442 alternate-auth row (Passkey / Recovery code) shipped
+// untested, and the mock above made testing it impossible. Both buttons
+// share `passkeyIdentifier()`, which classifies the SAME field the main
+// form submits — so the sanitization the Connect path is pinned for must
+// hold here too, and an empty field must stop before the ceremony rather
+// than firing a request for the identifier "".
+const passkeyBtn = () => screen.getByRole("button", { name: "Passkey" });
+
+describe("Login — #442 alternate auth (passkey / recovery code)", () => {
+  it("signs in with the SANITIZED identifier when Passkey is clicked", async () => {
+    vi.mocked(auth.loginWithPasskey).mockResolvedValue(undefined);
+    renderLogin();
+    fireEvent.input(nickField(), { target: { value: "my nick" } });
+    fireEvent.click(passkeyBtn());
+    await waitFor(() => {
+      expect(auth.loginWithPasskey).toHaveBeenCalledWith("my_nick");
+    });
+    // Same correction-is-visible contract as the Connect path.
+    expect((nickField() as HTMLInputElement).value).toBe("my_nick");
+  });
+
+  it("refuses to start the ceremony with an empty identifier", async () => {
+    renderLogin();
+    fireEvent.click(passkeyBtn());
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/account name or email first/i);
+    });
+    expect(auth.loginWithPasskey).not.toHaveBeenCalled();
+  });
+
+  it("shows the cancellation reason and keeps the form when the ceremony fails", async () => {
+    // A dismissed WebAuthn prompt rejects with a plain Error, not an
+    // ApiError — the non-ApiError arm of handleError must surface its
+    // message instead of the generic "login_failed".
+    vi.mocked(auth.loginWithPasskey).mockRejectedValue(
+      new Error("Passkey authentication cancelled"),
+    );
+    renderLogin();
+    fireEvent.input(nickField(), { target: { value: "alice" } });
+    fireEvent.click(passkeyBtn());
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/passkey authentication cancelled/i);
+    });
+    expect(nickField()).toBeInTheDocument();
+  });
+
+  it("renders friendly copy for an ApiError from the ceremony", async () => {
+    vi.mocked(auth.loginWithPasskey).mockRejectedValue(new ApiError(401, "invalid_credentials"));
+    renderLogin();
+    fireEvent.input(nickField(), { target: { value: "alice" } });
+    fireEvent.click(passkeyBtn());
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/invalid name or password/i);
+    });
+  });
+
+  it("keeps the recovery-code field collapsed until Recovery code is clicked", () => {
+    renderLogin();
+    expect(screen.queryByLabelText(/^recovery code$/i)).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Recovery code" }));
+    expect(screen.getByLabelText(/^recovery code$/i)).toBeInTheDocument();
+  });
+
+  it("submits the identifier and the recovery code together", async () => {
+    vi.mocked(auth.loginWithRecoveryCode).mockResolvedValue(undefined);
+    renderLogin();
+    fireEvent.input(nickField(), { target: { value: "alice" } });
+    fireEvent.click(screen.getByRole("button", { name: "Recovery code" }));
+    fireEvent.input(screen.getByLabelText(/^recovery code$/i), {
+      target: { value: "abcd-1234" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /recover account/i }));
+    await waitFor(() => {
+      expect(auth.loginWithRecoveryCode).toHaveBeenCalledWith("alice", "abcd-1234");
+    });
+  });
+
+  it("surfaces a spent or wrong recovery code as an error", async () => {
+    vi.mocked(auth.loginWithRecoveryCode).mockRejectedValue(
+      new ApiError(401, "invalid_credentials"),
+    );
+    renderLogin();
+    fireEvent.input(nickField(), { target: { value: "alice" } });
+    fireEvent.click(screen.getByRole("button", { name: "Recovery code" }));
+    fireEvent.input(screen.getByLabelText(/^recovery code$/i), { target: { value: "nope" } });
+    fireEvent.click(screen.getByRole("button", { name: /recover account/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/invalid name or password/i);
+    });
+  });
+
+  it("refuses to recover with an empty identifier", async () => {
+    renderLogin();
+    fireEvent.click(screen.getByRole("button", { name: "Recovery code" }));
+    fireEvent.input(screen.getByLabelText(/^recovery code$/i), { target: { value: "abcd-1234" } });
+    fireEvent.click(screen.getByRole("button", { name: /recover account/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/account name or email first/i);
+    });
+    expect(auth.loginWithRecoveryCode).not.toHaveBeenCalled();
   });
 });
 

--- a/cicchetto/src/__tests__/PasskeySettings.test.tsx
+++ b/cicchetto/src/__tests__/PasskeySettings.test.tsx
@@ -3,26 +3,33 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const api = vi.hoisted(() => ({
   finishPasskeyModeChange: vi.fn(),
+  finishPasskeyRegistration: vi.fn(),
   getPasskeyStatus: vi.fn(),
   startPasskeyModeChange: vi.fn(),
+  startPasskeyRegistration: vi.fn(),
 }));
 
 vi.mock("../lib/api", () => ({
   deletePasskey: vi.fn(),
   finishPasskeyModeChange: api.finishPasskeyModeChange,
-  finishPasskeyRegistration: vi.fn(),
+  finishPasskeyRegistration: api.finishPasskeyRegistration,
   getPasskeyStatus: api.getPasskeyStatus,
   preparePasswordless: vi.fn(),
   startPasskeyModeChange: api.startPasskeyModeChange,
-  startPasskeyRegistration: vi.fn(),
+  startPasskeyRegistration: api.startPasskeyRegistration,
   startPasswordlessActivation: vi.fn(),
 }));
 
 vi.mock("../lib/auth", () => ({ token: () => "test-token" }));
 
-vi.mock("../lib/passkeys", () => ({
+const passkeys = vi.hoisted(() => ({
   createPasskey: vi.fn(),
-  getPasskey: vi.fn().mockResolvedValue({ assertion: true }),
+  getPasskey: vi.fn(),
+}));
+
+vi.mock("../lib/passkeys", () => ({
+  createPasskey: passkeys.createPasskey,
+  getPasskey: passkeys.getPasskey,
 }));
 
 import PasskeySettings from "../PasskeySettings";
@@ -43,6 +50,56 @@ describe("PasskeySettings", () => {
     });
     api.startPasskeyModeChange.mockResolvedValue({ challenge_id: "challenge" });
     api.finishPasskeyModeChange.mockResolvedValue({ mode: "disabled" });
+    api.startPasskeyRegistration.mockResolvedValue({ challenge_id: "challenge", public_key: {} });
+    api.finishPasskeyRegistration.mockResolvedValue(undefined);
+    passkeys.createPasskey.mockResolvedValue({ attestation: true });
+    passkeys.getPasskey.mockResolvedValue({ assertion: true });
+  });
+
+  const addPasskey = async (): Promise<void> => {
+    await fireEvent.input(screen.getByLabelText("Passkey name"), { target: { value: "phone" } });
+    await fireEvent.input(screen.getByLabelText("Account password"), {
+      target: { value: "correct horse battery staple" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "add passkey" }));
+  };
+
+  it("registers a passkey with the name and password entered", async () => {
+    render(() => <PasskeySettings />);
+
+    await screen.findByText("Mode: passwordless");
+    await addPasskey();
+
+    await waitFor(() =>
+      expect(api.startPasskeyRegistration).toHaveBeenCalledWith(
+        "test-token",
+        "correct horse battery staple",
+        "phone",
+      ),
+    );
+    expect(api.finishPasskeyRegistration).toHaveBeenCalledWith("test-token", {
+      attestation: true,
+    });
+  });
+
+  // #736 — a dismissed WebAuthn prompt rejects mid-`register()`. The pane
+  // must NAME the reason and stay usable: `busy` is set before the ceremony
+  // and only the `finally` clears it, so a regression there leaves every
+  // button in the pane permanently disabled with no way back but a reload.
+  it("reports a cancelled ceremony and leaves the pane usable for a retry", async () => {
+    passkeys.createPasskey.mockRejectedValue(new Error("Passkey creation cancelled"));
+    render(() => <PasskeySettings />);
+
+    await screen.findByText("Mode: passwordless");
+    await addPasskey();
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent("Passkey creation cancelled"),
+    );
+    expect(api.finishPasskeyRegistration).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "add passkey" })).not.toBeDisabled();
+    // The typed name survives — the retry does not start from a blank form.
+    expect((screen.getByLabelText("Passkey name") as HTMLInputElement).value).toBe("phone");
   });
 
   it("returns a passwordless account to password login with password and passkey", async () => {

--- a/cicchetto/src/__tests__/TotpSettings.test.tsx
+++ b/cicchetto/src/__tests__/TotpSettings.test.tsx
@@ -1,0 +1,124 @@
+import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// #736 — the TOTP enrolment surface shipped with no component coverage: the
+// only tests over the security pane drove `auth.ts` (the store) or the
+// passkey pane. What was missing is the FAILURE half — a wrong or expired
+// code — which is the branch a real user hits, and the branch that decides
+// whether the pane stays usable or strands them.
+//
+// `lib/api` is spread from the real module so `ApiError` stays the genuine
+// class: `reportError` narrows on `instanceof ApiError` to pick friendly
+// copy over `String(value)`, and a hand-rolled stand-in silently takes the
+// wrong arm.
+
+const api = vi.hoisted(() => ({
+  confirmTotpEnrollment: vi.fn(),
+  disableTotp: vi.fn(),
+  getPasskeyStatus: vi.fn(),
+  getTotpStatus: vi.fn(),
+  startTotpEnrollment: vi.fn(),
+}));
+
+vi.mock("../lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/api")>();
+  return { ...actual, ...api };
+});
+
+vi.mock("../lib/auth", () => ({ token: () => "test-token" }));
+
+vi.mock("../lib/passkeys", () => ({
+  createPasskey: vi.fn(),
+  getPasskey: vi.fn(),
+}));
+
+import { ApiError } from "../lib/api";
+import TotpSettings from "../TotpSettings";
+
+const ENROLLMENT = {
+  enrollment_token: "enrol-1",
+  secret: "JBSWY3DPEHPK3PXP",
+  provisioning_uri: "otpauth://totp/grappa:alice?secret=JBSWY3DPEHPK3PXP&issuer=grappa",
+};
+
+const renderSettings = () => render(() => <TotpSettings onBack={() => undefined} />);
+
+const beginEnrollment = async (): Promise<void> => {
+  await fireEvent.click(await screen.findByRole("button", { name: "enable TOTP" }));
+  await screen.findByTestId("totp-enrollment-form");
+};
+
+const confirmCode = async (code: string): Promise<void> => {
+  await fireEvent.input(screen.getByLabelText("Authenticator code"), { target: { value: code } });
+  await fireEvent.click(screen.getByRole("button", { name: "confirm and enable" }));
+};
+
+describe("TotpSettings — enrolment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getTotpStatus.mockResolvedValue({ enabled: false });
+    api.getPasskeyStatus.mockResolvedValue({ mode: "disabled", passkeys: [] });
+    api.startTotpEnrollment.mockResolvedValue(ENROLLMENT);
+  });
+
+  it("shows the manual key so an unscannable QR is not a dead end", async () => {
+    renderSettings();
+    await beginEnrollment();
+
+    expect((screen.getByLabelText("Manual key") as HTMLInputElement).value).toBe(ENROLLMENT.secret);
+  });
+
+  it("enables TOTP and shows the recovery codes once the code is confirmed", async () => {
+    api.confirmTotpEnrollment.mockResolvedValue({ recovery_codes: ["aaa-111", "bbb-222"] });
+    renderSettings();
+    await beginEnrollment();
+    await confirmCode("123456");
+
+    await waitFor(() => expect(screen.getByTestId("totp-recovery-codes")).toBeInTheDocument());
+    expect(api.confirmTotpEnrollment).toHaveBeenCalledWith("test-token", "enrol-1", "123456");
+    expect(screen.getByText("aaa-111")).toBeInTheDocument();
+  });
+
+  // The cancel/failure path: a wrong or already-used code. The enrolment
+  // MUST survive it — dropping the pending enrolment here would send the
+  // user back to a fresh QR (and a fresh secret) after one typo, silently
+  // invalidating the one they already scanned into their authenticator.
+  it("keeps the enrolment alive and names the failure on a wrong code", async () => {
+    api.confirmTotpEnrollment.mockRejectedValue(new ApiError(401, "invalid_two_factor"));
+    renderSettings();
+    await beginEnrollment();
+    await confirmCode("000000");
+
+    await waitFor(() =>
+      expect(within(screen.getByTestId("totp-settings")).getByRole("alert")).toHaveTextContent(
+        "Invalid or already-used authenticator/recovery code.",
+      ),
+    );
+    expect(screen.getByTestId("totp-enrollment-form")).toBeInTheDocument();
+    expect((screen.getByLabelText("Manual key") as HTMLInputElement).value).toBe(ENROLLMENT.secret);
+    expect(screen.getByRole("button", { name: "confirm and enable" })).not.toBeDisabled();
+    expect(screen.queryByTestId("totp-recovery-codes")).toBeNull();
+  });
+
+  it("surfaces a rejected password when disabling instead of silently no-opping", async () => {
+    api.getTotpStatus.mockResolvedValue({ enabled: true });
+    api.disableTotp.mockRejectedValue(new ApiError(401, "invalid_credentials"));
+    renderSettings();
+
+    // Scoped: the passkey pane below renders its own "Account password"
+    // field, so an unscoped query matches two inputs.
+    const form = await screen.findByTestId("totp-disable-form");
+    await fireEvent.input(within(form).getByLabelText("Account password"), {
+      target: { value: "wrong" },
+    });
+    await fireEvent.click(within(form).getByRole("button", { name: "disable TOTP" }));
+
+    await waitFor(() =>
+      expect(within(screen.getByTestId("totp-settings")).getByRole("alert")).toHaveTextContent(
+        "Invalid name or password.",
+      ),
+    );
+    // Still enabled: the pane must not claim a disable that never happened.
+    expect(screen.getByTestId("totp-disable-form")).toBeInTheDocument();
+  });
+});

--- a/cicchetto/src/__tests__/auth.test.ts
+++ b/cicchetto/src/__tests__/auth.test.ts
@@ -6,9 +6,22 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // `vi.resetModules()` the second test would observe the first test's
 // signal value because the module instance is cached across imports.
 
+// #736 — `lib/passkeys` is the browser-ceremony boundary (it calls
+// `navigator.credentials`, which jsdom does not implement). Mock it here
+// and keep the auth-side branching real: the passkey → TOTP degrade in
+// `login()` is the most conditional logic on the auth surface and it
+// shipped with no coverage at all.
+vi.mock("../lib/passkeys", () => ({
+  getPasskey: vi.fn(),
+}));
+
 vi.mock("../lib/api", () => ({
   login: vi.fn(),
   verifyTotpLogin: vi.fn(),
+  getPasskeyLoginOptions: vi.fn(),
+  verifyPasskeyLogin: vi.fn(),
+  verifyPasskeySecondFactor: vi.fn(),
+  recoverPasskeyLogin: vi.fn(),
   me: vi.fn(),
   logout: vi.fn(),
   setOn401Handler: vi.fn(),
@@ -95,6 +108,151 @@ describe("auth signal store", () => {
     await auth.verifyTotp("challenge-123", "123456");
     expect(api.verifyTotpLogin).toHaveBeenCalledWith("challenge-123", "123456");
     expect(auth.token()).toBe("tok-2fa");
+  });
+
+  // #736 — a passkey-second-factor login has FOUR outcomes off one server
+  // response, and which one you get depends on a browser ceremony that can
+  // fail for reasons the server never sees (no authenticator, user dismissed
+  // the prompt, timeout). The degrade is silent by design — the whole point
+  // is that the user reaches the TOTP form instead of a dead end — which is
+  // exactly why it needs pinning: a regression here shows up as "passkey
+  // users can't log in", with no error anywhere.
+  describe("login() — passkey second factor", () => {
+    const passkeyChallenge = (challengeToken: string | null) => ({
+      two_factor_required: true as const,
+      passkey_options: { challenge_id: "pk-1", public_key: { challenge: "AQID" } },
+      totp_available: challengeToken !== null,
+      challenge_token: challengeToken,
+    });
+
+    it("runs the ceremony and installs the session on a good assertion", async () => {
+      const api = await import("../lib/api");
+      const { getPasskey } = await import("../lib/passkeys");
+      vi.mocked(api.login).mockResolvedValue(passkeyChallenge("challenge-123"));
+      vi.mocked(getPasskey).mockResolvedValue({ raw_id: "AQ" });
+      vi.mocked(api.verifyPasskeySecondFactor).mockResolvedValue({
+        token: "tok-passkey",
+        subject: { kind: "user", id: "u1", name: "alice" },
+      });
+      const auth = await import("../lib/auth");
+
+      await expect(auth.login("alice", "secret")).resolves.toEqual({ kind: "authenticated" });
+
+      expect(getPasskey).toHaveBeenCalledWith({
+        challenge_id: "pk-1",
+        public_key: { challenge: "AQID" },
+      });
+      expect(api.verifyPasskeySecondFactor).toHaveBeenCalledWith({ raw_id: "AQ" });
+      expect(auth.token()).toBe("tok-passkey");
+    });
+
+    it("degrades to the TOTP challenge when the ceremony fails and a code is available", async () => {
+      const api = await import("../lib/api");
+      const { getPasskey } = await import("../lib/passkeys");
+      vi.mocked(api.login).mockResolvedValue(passkeyChallenge("challenge-123"));
+      vi.mocked(getPasskey).mockRejectedValue(new Error("Passkey authentication cancelled"));
+      const auth = await import("../lib/auth");
+
+      await expect(auth.login("alice", "secret")).resolves.toEqual({
+        kind: "totp",
+        challengeToken: "challenge-123",
+      });
+
+      expect(api.verifyPasskeySecondFactor).not.toHaveBeenCalled();
+      expect(auth.token()).toBeNull();
+    });
+
+    it("degrades to the TOTP challenge when the server rejects the assertion", async () => {
+      // A rejected assertion (replayed challenge, expired ceremony) is a
+      // ceremony failure like any other: the account still has a second
+      // factor the user can reach, so the form must offer it.
+      const api = await import("../lib/api");
+      const { getPasskey } = await import("../lib/passkeys");
+      vi.mocked(api.login).mockResolvedValue(passkeyChallenge("challenge-123"));
+      vi.mocked(getPasskey).mockResolvedValue({ raw_id: "AQ" });
+      vi.mocked(api.verifyPasskeySecondFactor).mockRejectedValue(new Error("challenge_expired"));
+      const auth = await import("../lib/auth");
+
+      await expect(auth.login("alice", "secret")).resolves.toEqual({
+        kind: "totp",
+        challengeToken: "challenge-123",
+      });
+      expect(auth.token()).toBeNull();
+    });
+
+    it("rethrows the ceremony error when the account has no TOTP fallback", async () => {
+      // `challenge_token: null` means the server minted no TOTP challenge —
+      // passkey is the ONLY second factor. Swallowing the error here would
+      // resolve the login as authenticated with no token.
+      const api = await import("../lib/api");
+      const { getPasskey } = await import("../lib/passkeys");
+      vi.mocked(api.login).mockResolvedValue(passkeyChallenge(null));
+      vi.mocked(getPasskey).mockRejectedValue(new Error("Passkey authentication cancelled"));
+      const auth = await import("../lib/auth");
+
+      await expect(auth.login("alice", "secret")).rejects.toThrow(
+        "Passkey authentication cancelled",
+      );
+      expect(auth.token()).toBeNull();
+      expect(localStorage.getItem("grappa-token")).toBeNull();
+    });
+  });
+
+  describe("passkey login entry points", () => {
+    it("loginWithPasskey() fetches options, signs them, and installs the session", async () => {
+      const api = await import("../lib/api");
+      const { getPasskey } = await import("../lib/passkeys");
+      const options = { challenge_id: "pk-1", public_key: { challenge: "AQID" } };
+      vi.mocked(api.getPasskeyLoginOptions).mockResolvedValue(options);
+      vi.mocked(getPasskey).mockResolvedValue({ raw_id: "AQ" });
+      vi.mocked(api.verifyPasskeyLogin).mockResolvedValue({
+        token: "tok-passwordless",
+        subject: { kind: "user", id: "u1", name: "alice" },
+      });
+      const auth = await import("../lib/auth");
+
+      await auth.loginWithPasskey("alice");
+
+      expect(api.getPasskeyLoginOptions).toHaveBeenCalledWith("alice");
+      expect(getPasskey).toHaveBeenCalledWith(options);
+      expect(api.verifyPasskeyLogin).toHaveBeenCalledWith({ raw_id: "AQ" });
+      expect(auth.token()).toBe("tok-passwordless");
+      expect(localStorage.getItem("grappa-subject")).toBe(
+        JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+      );
+    });
+
+    it("loginWithPasskey() leaves no token behind when the ceremony is cancelled", async () => {
+      const api = await import("../lib/api");
+      const { getPasskey } = await import("../lib/passkeys");
+      vi.mocked(api.getPasskeyLoginOptions).mockResolvedValue({
+        challenge_id: "pk-1",
+        public_key: {},
+      });
+      vi.mocked(getPasskey).mockRejectedValue(new Error("Passkey authentication cancelled"));
+      const auth = await import("../lib/auth");
+
+      await expect(auth.loginWithPasskey("alice")).rejects.toThrow(
+        "Passkey authentication cancelled",
+      );
+
+      expect(api.verifyPasskeyLogin).not.toHaveBeenCalled();
+      expect(auth.token()).toBeNull();
+    });
+
+    it("loginWithRecoveryCode() installs the session for a good code", async () => {
+      const api = await import("../lib/api");
+      vi.mocked(api.recoverPasskeyLogin).mockResolvedValue({
+        token: "tok-recovered",
+        subject: { kind: "user", id: "u1", name: "alice" },
+      });
+      const auth = await import("../lib/auth");
+
+      await auth.loginWithRecoveryCode("alice", "code-1234");
+
+      expect(api.recoverPasskeyLogin).toHaveBeenCalledWith("alice", "code-1234");
+      expect(auth.token()).toBe("tok-recovered");
+    });
   });
 
   it("logout() calls api.logout with current token and clears state", async () => {

--- a/cicchetto/src/lib/__tests__/passkeys.test.ts
+++ b/cicchetto/src/lib/__tests__/passkeys.test.ts
@@ -1,0 +1,293 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPasskey, getPasskey } from "../passkeys";
+
+// #736 — `lib/passkeys.ts` shipped with no coverage. It is the ONE place
+// the snake_case wire meets the camelCase WebAuthn API, and the ONE place
+// base64url ⇄ ArrayBuffer conversion happens. Both are silent-corruption
+// candidates: a wrong alphabet swap or a dropped `=` pad yields a
+// well-formed buffer of the WRONG bytes, so the ceremony fails at the
+// authenticator (or, worse, verifies against a different challenge) with
+// nothing in the UI naming the cause.
+//
+// jsdom ships no `navigator.credentials`, so the ceremony is faked at that
+// exact boundary — everything above it (both conversions, both option
+// rebuilds, both cancel guards) is the real module.
+
+const credentials = { create: vi.fn(), get: vi.fn() };
+
+const creationOptionsFrom = (options: unknown): PublicKeyCredentialCreationOptions => {
+  const publicKey = (options as { publicKey?: PublicKeyCredentialCreationOptions }).publicKey;
+  if (publicKey === undefined) throw new Error("credentials.create called without publicKey");
+  return publicKey;
+};
+
+const requestOptionsFrom = (options: unknown): PublicKeyCredentialRequestOptions => {
+  const publicKey = (options as { publicKey?: PublicKeyCredentialRequestOptions }).publicKey;
+  if (publicKey === undefined) throw new Error("credentials.get called without publicKey");
+  return publicKey;
+};
+
+const bytesOf = (buffer: ArrayBuffer | ArrayBufferView): number[] =>
+  Array.from(
+    buffer instanceof ArrayBuffer
+      ? new Uint8Array(buffer)
+      : new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength),
+  );
+
+const requestOptions = (overrides: Record<string, unknown>) => ({
+  challenge_id: "challenge-1",
+  public_key: { challenge: "AQIDBA", rp_id: "grappa.example", ...overrides },
+});
+
+const creationOptions = (overrides: Record<string, unknown>) => ({
+  challenge_id: "challenge-1",
+  public_key: {
+    challenge: "AQIDBA",
+    rp: { id: "grappa.example", name: "Grappa" },
+    user: { id: "dXNlcg", name: "alice", display_name: "Alice L" },
+    pub_key_cred_params: [{ type: "public-key", alg: -7 }],
+    ...overrides,
+  },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(navigator, "credentials", { value: credentials, configurable: true });
+});
+
+afterEach(() => {
+  // Delete rather than set-undefined: jsdom's baseline is an ABSENT
+  // property, and #725's feature detection probes for exactly that.
+  Reflect.deleteProperty(navigator, "credentials");
+});
+
+describe("passkeys — base64url ⇄ ArrayBuffer", () => {
+  // Every sample exercises a different pad length (0/1/2 `=`) AND both
+  // URL-alphabet substitutions, so a lost pad or a `-`/`+` mix-up moves
+  // at least one of them.
+  const SAMPLES = ["-_-_", "abc", "-A", "AQIDBAUGBwgJCg"];
+
+  it.each(SAMPLES)("round-trips %s unchanged through decode → encode", async (sample) => {
+    // The challenge goes IN as base64url, is decoded to an ArrayBuffer for
+    // the authenticator, and comes back OUT re-encoded as `raw_id`. Echoing
+    // the decoded buffer back as the credential makes the pair an identity
+    // check using only production code — no local re-implementation of
+    // either half to drift against.
+    credentials.get.mockImplementation(async (options: unknown) => {
+      const challenge = requestOptionsFrom(options).challenge as ArrayBuffer;
+      return {
+        rawId: challenge,
+        response: {
+          authenticatorData: challenge,
+          clientDataJSON: challenge,
+          signature: challenge,
+          userHandle: null,
+        },
+      };
+    });
+
+    const result = await getPasskey(requestOptions({ challenge: sample }));
+
+    expect(result.raw_id).toBe(sample);
+  });
+
+  it("decodes the URL alphabet as `-`→`+` and `_`→`/`, not the reverse", async () => {
+    // "-_-_" is "+/+/" in standard base64 → 0xFB 0xFF 0xBF. Swapping the
+    // two substitutions yields a different byte triple, and dropping them
+    // makes `atob` throw — either way this pin moves.
+    credentials.get.mockResolvedValue({
+      rawId: new Uint8Array([1]).buffer,
+      response: {
+        authenticatorData: new Uint8Array([2]).buffer,
+        clientDataJSON: new Uint8Array([3]).buffer,
+        signature: new Uint8Array([4]).buffer,
+        userHandle: null,
+      },
+    });
+
+    await getPasskey(requestOptions({ challenge: "-_-_" }));
+
+    const publicKey = requestOptionsFrom(credentials.get.mock.calls[0]?.[0]);
+    expect(bytesOf(publicKey.challenge)).toEqual([0xfb, 0xff, 0xbf]);
+  });
+
+  it("strips the `=` padding off the encoded output", async () => {
+    // A 1-byte buffer is 4 base64 chars, 2 of them padding. `=` is not
+    // URL-safe and the server decodes strict base64url, so the pad MUST
+    // be gone on the way out.
+    credentials.get.mockResolvedValue({
+      rawId: new Uint8Array([0xf8]).buffer,
+      response: {
+        authenticatorData: new Uint8Array([0xf8]).buffer,
+        clientDataJSON: new Uint8Array([0xf8]).buffer,
+        signature: new Uint8Array([0xf8]).buffer,
+        userHandle: null,
+      },
+    });
+
+    const result = await getPasskey(requestOptions({}));
+
+    expect(result.raw_id).toBe("-A");
+  });
+});
+
+describe("passkeys — getPasskey (assertion ceremony)", () => {
+  const assertion = {
+    rawId: new Uint8Array([0x01]).buffer,
+    response: {
+      authenticatorData: new Uint8Array([0x02]).buffer,
+      clientDataJSON: new Uint8Array([0x03]).buffer,
+      signature: new Uint8Array([0x04]).buffer,
+      userHandle: new Uint8Array([0x05]).buffer,
+    },
+  };
+
+  it("rebuilds the wire options into the camelCase WebAuthn shape", async () => {
+    credentials.get.mockResolvedValue(assertion);
+
+    await getPasskey(
+      requestOptions({
+        timeout: 60_000,
+        user_verification: "required",
+        allow_credentials: [
+          { type: "public-key", id: "AQID", transports: ["internal"] },
+          { type: "public-key", id: "BAUG" },
+        ],
+      }),
+    );
+
+    const publicKey = requestOptionsFrom(credentials.get.mock.calls[0]?.[0]);
+    expect(publicKey.rpId).toBe("grappa.example");
+    expect(publicKey.timeout).toBe(60_000);
+    expect(publicKey.userVerification).toBe("required");
+    const allowed = publicKey.allowCredentials ?? [];
+    expect(allowed.map((item) => bytesOf(item.id))).toEqual([
+      [0x01, 0x02, 0x03],
+      [0x04, 0x05, 0x06],
+    ]);
+    // `transports` is OMITTED (not `undefined`) when the wire omits it —
+    // Safari rejects a descriptor carrying an explicit undefined.
+    expect(allowed[0]?.transports).toEqual(["internal"]);
+    expect(allowed[1] === undefined ? true : "transports" in allowed[1]).toBe(false);
+  });
+
+  it("sends an empty allowCredentials when the wire omits it", async () => {
+    credentials.get.mockResolvedValue(assertion);
+
+    await getPasskey(requestOptions({}));
+
+    expect(requestOptionsFrom(credentials.get.mock.calls[0]?.[0]).allowCredentials).toEqual([]);
+  });
+
+  it("returns the assertion with the challenge_id it was handed", async () => {
+    credentials.get.mockResolvedValue(assertion);
+
+    const result = await getPasskey(requestOptions({}));
+
+    expect(result).toEqual({
+      challenge_id: "challenge-1",
+      raw_id: "AQ",
+      authenticator_data: "Ag",
+      client_data_json: "Aw",
+      signature: "BA",
+      user_handle: "BQ",
+    });
+  });
+
+  it("keeps a null user_handle null instead of encoding it", async () => {
+    // A second-factor assertion carries no user handle. `encode(null)`
+    // would throw inside `String.fromCharCode`, so the null MUST survive
+    // as null all the way to the wire.
+    credentials.get.mockResolvedValue({
+      ...assertion,
+      response: { ...assertion.response, userHandle: null },
+    });
+
+    const result = await getPasskey(requestOptions({}));
+
+    expect(result.user_handle).toBeNull();
+  });
+
+  it("rejects with a cancelled message when the user dismisses the prompt", async () => {
+    // Chrome resolves `get()` with null on some dismiss paths instead of
+    // rejecting; without the guard the next line reads `.rawId` off null
+    // and the user sees a TypeError.
+    credentials.get.mockResolvedValue(null);
+
+    await expect(getPasskey(requestOptions({}))).rejects.toThrow(
+      "Passkey authentication cancelled",
+    );
+  });
+});
+
+describe("passkeys — createPasskey (registration ceremony)", () => {
+  const attestation = {
+    rawId: new Uint8Array([0x01]).buffer,
+    response: {
+      attestationObject: new Uint8Array([0x02]).buffer,
+      clientDataJSON: new Uint8Array([0x03]).buffer,
+      getTransports: () => ["usb", "nfc"],
+    },
+  };
+
+  it("rebuilds the wire options into the camelCase WebAuthn shape", async () => {
+    credentials.create.mockResolvedValue(attestation);
+
+    await createPasskey(
+      creationOptions({
+        attestation: "none",
+        authenticator_selection: { resident_key: "required", user_verification: "preferred" },
+        exclude_credentials: [{ type: "public-key", id: "AQID" }],
+      }),
+    );
+
+    const publicKey = creationOptionsFrom(credentials.create.mock.calls[0]?.[0]);
+    // `display_name` → `displayName` is the whole reason this rebuild
+    // exists; a passthrough would hand the authenticator an undefined.
+    expect(publicKey.user.displayName).toBe("Alice L");
+    expect(publicKey.user.name).toBe("alice");
+    expect(bytesOf(publicKey.user.id)).toEqual([0x75, 0x73, 0x65, 0x72]);
+    expect(publicKey.pubKeyCredParams).toEqual([{ type: "public-key", alg: -7 }]);
+    expect(publicKey.attestation).toBe("none");
+    expect(publicKey.authenticatorSelection).toEqual({
+      residentKey: "required",
+      userVerification: "preferred",
+    });
+    expect((publicKey.excludeCredentials ?? []).map((item) => bytesOf(item.id))).toEqual([
+      [0x01, 0x02, 0x03],
+    ]);
+  });
+
+  it("returns the attestation with the transports the authenticator reported", async () => {
+    credentials.create.mockResolvedValue(attestation);
+
+    const result = await createPasskey(creationOptions({}));
+
+    expect(result).toEqual({
+      challenge_id: "challenge-1",
+      raw_id: "AQ",
+      attestation_object: "Ag",
+      client_data_json: "Aw",
+      transports: ["usb", "nfc"],
+    });
+  });
+
+  it("sends an empty transports list when the authenticator has no getTransports", async () => {
+    // `getTransports` is not universal (older Safari/Firefox). The optional
+    // call MUST degrade to [] rather than blow up the registration.
+    credentials.create.mockResolvedValue({
+      ...attestation,
+      response: { ...attestation.response, getTransports: undefined },
+    });
+
+    const result = await createPasskey(creationOptions({}));
+
+    expect(result.transports).toEqual([]);
+  });
+
+  it("rejects with a cancelled message when the user dismisses the prompt", async () => {
+    credentials.create.mockResolvedValue(null);
+
+    await expect(createPasskey(creationOptions({}))).rejects.toThrow("Passkey creation cancelled");
+  });
+});


### PR DESCRIPTION
Addresses #736 (code-review campaign, `cicchetto/src` slice).

## The mock

`Login.test.tsx`'s `vi.mock("../lib/auth", …)` declared six functions;
`Login.tsx` calls eight. The two missing ones — `loginWithPasskey` and
`loginWithRecoveryCode` — are the whole #442 alternate-auth row, so the
first test to click either button got `TypeError: … is not a function`
instead of an assertion.

**Fixing the mock turned nothing red: 28/28 before, 36/36 after.** That is
the finding, not a relief — the omission was not hiding a failing
behaviour, it was *preventing the surface from being tested at all*. No
existing test leaned on the false factory.

## The coverage that was missing

| file | what it now pins |
|---|---|
| `lib/__tests__/passkeys.test.ts` (new, 15) | base64url ⇄ ArrayBuffer round-trip, URL-alphabet direction, stripped `=` pad, both option rebuilds (`display_name` → `displayName`), null `user_handle`, absent `getTransports`, both cancel guards |
| `__tests__/auth.test.ts` (+7) | all four outcomes of the `auth.login` passkey → TOTP degrade, plus `loginWithPasskey` / `loginWithRecoveryCode` |
| `__tests__/Login.test.tsx` (+8) | both alt-auth buttons: sanitization, empty-field refusal, ApiError vs plain cancel Error, recovery round trip |
| `__tests__/PasskeySettings.test.tsx` (+2) | registration happy path + a cancelled ceremony that leaves the pane usable |
| `__tests__/TotpSettings.test.tsx` (new, 4) | enrolment, wrong code, rejected disable password |

The round-trip test echoes the decoded challenge back out as `raw_id`, so
it is an identity check through the real encode/decode pair — neither half
is re-implemented in the test to drift against.

Both component tests assert the pane stays **usable** after the failure: a
`busy` flag stranded by a rejected ceremony disables every button until a
reload, and dropping the pending TOTP enrolment on one typo would
invalidate the QR the user already scanned into their authenticator.

## Proof the tests can fail

Nine defects injected into production code, one at a time, each reverted
after its run. Every one was killed by exactly the intended test(s):

| mutation | red |
|---|---|
| decode: swap `-`→`/`, `_`→`+` | 3 (both `-_` samples + the alphabet pin) |
| encode: keep the `=` padding | 6 |
| `getPasskey`: drop the null-credential guard | 1 (cancel) |
| `createPasskey`: `displayName: user.name` | 1 (creation rebuild) |
| `auth.login`: swallow a failed ceremony as authenticated | 1 (no-fallback rethrow) |
| `auth.login`: never degrade to TOTP | 2 (both degrade cases) |
| `Login`: skip identifier classification | 3 (sanitize + both empty refusals) |
| `PasskeySettings`: leave `busy` latched | 1 (retry) |
| `TotpSettings`: drop the enrolment on error | 1 (enrolment survives) |

No mutation survived; the tree was clean after every restore.

## Gates

* `scripts/bun.sh run test` — **225 files / 4046 tests passed, rc=0**
* `scripts/bun.sh run check` (biome + tsc) — rc=0

cic-only, no lane taken. No production code changed.

## Conflict boundaries respected

Does not touch `PasskeySettings.tsx`, `TotpSettings.tsx` or
`themes/default.css` (PR #794's files) — the pane tests drive them from
the outside and avoid #794's `.share-qr` → `.qr-frame` rename. Nothing
under `cicchetto/e2e/` (worker-2's #712).

No defects found worth filing: the surface behaved correctly under every
failure path exercised.