### PR TITLE
cic(#738): make the directory search box follow the store's filter

### DIFF
--- a/cicchetto/src/DirectoryPane.tsx
+++ b/cicchetto/src/DirectoryPane.tsx
@@ -4,6 +4,7 @@ import { token } from "./lib/auth";
 import {
   directoryError,
   directoryPage,
+  directoryQuery,
   directorySort,
   isLoadingMore,
   loadDirectory,
@@ -35,17 +36,20 @@ import { MircBody } from "./MircText";
 // close button returns to the previously active window.
 //
 // Data layer: channelDirectory.ts (directoryPage / loadDirectory / loadMore /
-// resetDirectory / directorySort / isLoadingMore / setSort / setQuery /
-// triggerRefresh). DirectoryPane owns LOCAL signals for the search text and
-// active sort (to render the controls) but every control change routes
-// through the store verbs so subsequent ping-driven re-GETs use the correct
-// view.
+// resetDirectory / directoryQuery / directorySort / isLoadingMore / setSort /
+// setQuery / triggerRefresh). DirectoryPane owns LOCAL signals for the search
+// text and active sort (to render the controls) but every control change
+// routes through the store verbs so subsequent ping-driven re-GETs use the
+// correct view.
 //
 // Pagination (#677): the server keyset-paginates (100/page); the pane drives
 // load-more via a bottom sentinel + IntersectionObserver → loadMore, which
 // APPENDS the next page. Search text is cleared on window close
-// (resetDirectory in onCleanup) so a reopened directory is unfiltered with an
-// empty box; sort is a sticky preference and rehydrates from directorySort.
+// (resetDirectory in onCleanup) so a reopened directory is unfiltered; sort is
+// a sticky preference. Neither control holds an opinion of its own: the sort
+// toggle rehydrates from directorySort, and the box mirrors directoryQuery
+// (#738) so a filter set from outside the pane — `/list <pattern>` — is
+// visible and clearable.
 //
 // Failure + ordering (#732): the store never rejects — it parks per-slug
 // failure copy the pane renders as an alert with a Retry. The search box
@@ -180,14 +184,17 @@ const DirectoryRow: Component<DirectoryRowProps> = (props) => {
 };
 
 const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
-  const [searchText, setSearchText] = createSignal("");
-  // #677 — the search key is cleared on window close (see the onCleanup /
-  // slug-switch resets below), so searchText always mounts "" and the store
-  // agrees. Sort, by contrast, is a sticky PREFERENCE: rehydrate the toggle
-  // from the store so a reopened pane's label matches the sorted list the
-  // store re-fetches (the drop-page reset would otherwise re-fetch the
-  // stored sort while the toggle showed the local default — a sibling of the
-  // very desync #677 fixes for the filter).
+  // #738 — seed the box from the store, like the sort toggle below: a control
+  // must not lie about the view the store is applying. The filter is cleared
+  // on window close, but `/list <pattern>` (compose.ts) calls setQuery from
+  // OUTSIDE the pane with no close in between — so mounting hard-coded "" put
+  // a filtered list under an empty box.
+  const [searchText, setSearchText] = createSignal(directoryQuery(props.networkSlug));
+  // #677 — sort is a sticky PREFERENCE: rehydrate the toggle from the store so
+  // a reopened pane's label matches the sorted list the store re-fetches (the
+  // drop-page reset would otherwise re-fetch the stored sort while the toggle
+  // showed the local default — a sibling of the very desync #677 fixes for
+  // the filter).
   const [activeSort, setActiveSort] = createSignal<"users" | "name">(
     directorySort(props.networkSlug),
   );
@@ -238,6 +245,19 @@ const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
         prevEntryCount = directoryPage(s)?.entries.length ?? 0;
         if (directoryPage(s) === undefined) void loadDirectory(s);
       },
+    ),
+  );
+
+  // #738 — the box FOLLOWS the store's filter, it does not just sample it at
+  // mount: compose.ts's `/list <pattern>` selects the $list window FIRST and
+  // calls setQuery after, and a second `/list <pattern>` reaches a pane that
+  // is already mounted. Typing still LEADS — the debounced setQuery echoes
+  // the same text back ~250ms later, so the mirror write is a no-op — which
+  // is why the box keeps a local signal instead of binding to the store.
+  createEffect(
+    on(
+      () => directoryQuery(props.networkSlug),
+      (q) => setSearchText(q),
     ),
   );
 

--- a/cicchetto/src/DirectoryPane.tsx
+++ b/cicchetto/src/DirectoryPane.tsx
@@ -184,12 +184,11 @@ const DirectoryRow: Component<DirectoryRowProps> = (props) => {
 };
 
 const DirectoryPane: Component<{ networkSlug: string }> = (props) => {
-  // #738 — seed the box from the store, like the sort toggle below: a control
-  // must not lie about the view the store is applying. The filter is cleared
-  // on window close, but `/list <pattern>` (compose.ts) calls setQuery from
-  // OUTSIDE the pane with no close in between — so mounting hard-coded "" put
-  // a filtered list under an empty box.
-  const [searchText, setSearchText] = createSignal(directoryQuery(props.networkSlug));
+  // #738 — the box renders this; the store's filter SEEDS it and keeps
+  // seeding it, via the mirror effect below (which runs before the first
+  // paint, so this initial value is never seen). Not a second rehydration
+  // point: one mechanism, or the two drift.
+  const [searchText, setSearchText] = createSignal("");
   // #677 — sort is a sticky PREFERENCE: rehydrate the toggle from the store so
   // a reopened pane's label matches the sorted list the store re-fetches (the
   // drop-page reset would otherwise re-fetch the stored sort while the toggle

--- a/cicchetto/src/__tests__/DirectoryPane.test.tsx
+++ b/cicchetto/src/__tests__/DirectoryPane.test.tsx
@@ -497,6 +497,7 @@ describe("DirectoryPane", () => {
     // character and deleting it again.
     describe("filter set from outside the pane (#738)", () => {
       it("mounts showing the store's active filter", () => {
+        // Mirrored before the first paint: the effect flushes inside render().
         setDirectoryQuerySignal("rust");
         directoryPageMock.mockReturnValue(FRESH_PAGE);
         render(() => <DirectoryPane networkSlug={SLUG} />);
@@ -518,25 +519,6 @@ describe("DirectoryPane", () => {
         await waitFor(() => {
           expect(input).toHaveValue("rust");
         });
-      });
-
-      // The box LEADS the store by SEARCH_DEBOUNCE_MS (#732): binding the
-      // input straight to the store would undo that and make typing lag a
-      // quarter second behind the keyboard.
-      it("keeps the typed text while the debounced store filter still lags", () => {
-        vi.useFakeTimers();
-        try {
-          directoryPageMock.mockReturnValue(FRESH_PAGE);
-          render(() => <DirectoryPane networkSlug={SLUG} />);
-          const input = screen.getByPlaceholderText(/search channels/i);
-
-          fireEvent.input(input, { target: { value: "ru" } });
-
-          expect(setQueryMock).not.toHaveBeenCalled();
-          expect(input).toHaveValue("ru");
-        } finally {
-          vi.useRealTimers();
-        }
       });
     });
   });

--- a/cicchetto/src/__tests__/DirectoryPane.test.tsx
+++ b/cicchetto/src/__tests__/DirectoryPane.test.tsx
@@ -51,6 +51,11 @@ const windowStateByChannelMock = vi.fn<() => Record<string, string>>(() => ({}))
 // is the append verb the IntersectionObserver calls (observer is inert in
 // jsdom — see setupTests); resetDirectory is the on-close filter clear.
 const directorySortMock = vi.fn<(slug: string) => "users" | "name">(() => "users");
+// #738 — the store's active filter, SIGNAL-backed so a test can set it from
+// outside the pane (what compose.ts's `/list <pattern>` does) both before and
+// after mount, and the pane's rehydration has something reactive to follow.
+const [directoryQuerySignal, setDirectoryQuerySignal] = createSignal("");
+const directoryQueryMock = vi.fn<(slug: string) => string>(() => directoryQuerySignal());
 const isLoadingMoreMock = vi.fn<(slug: string) => boolean>(() => false);
 const loadMoreMock = vi.fn<(slug: string) => Promise<void>>(() => Promise.resolve());
 const resetDirectoryMock = vi.fn<(slug: string) => void>(() => {});
@@ -60,6 +65,7 @@ const directoryErrorMock = vi.fn<(slug: string) => string | null>(() => null);
 vi.mock("../lib/channelDirectory", () => ({
   directoryError: (slug: string) => directoryErrorMock(slug),
   directoryPage: (slug: string) => directoryPageMock(slug),
+  directoryQuery: (slug: string) => directoryQueryMock(slug),
   directorySort: (slug: string) => directorySortMock(slug),
   isLoadingMore: (slug: string) => isLoadingMoreMock(slug),
   loadDirectory: (slug: string) => loadDirectoryMock(slug),
@@ -157,6 +163,7 @@ describe("DirectoryPane", () => {
     setSelectedChannelMock.mockClear();
     closeToPreviousWindowMock.mockClear();
     directorySortMock.mockReturnValue("users");
+    setDirectoryQuerySignal("");
     directoryErrorMock.mockReturnValue(null);
     isLoadingMoreMock.mockReturnValue(false);
     loadMoreMock.mockClear();
@@ -480,6 +487,56 @@ describe("DirectoryPane", () => {
 
       await waitFor(() => {
         expect(setQueryMock).toHaveBeenCalledWith(SLUG, "grappa");
+      });
+    });
+
+    // #738 — `/list <pattern>` calls setQuery from compose.ts, so the store's
+    // filter is settable from OUTSIDE the pane with no window close in
+    // between. A box hard-initialised to "" then shows a short filtered list
+    // with no visible reason for it, and no way to clear it but typing a
+    // character and deleting it again.
+    describe("filter set from outside the pane (#738)", () => {
+      it("mounts showing the store's active filter", () => {
+        setDirectoryQuerySignal("rust");
+        directoryPageMock.mockReturnValue(FRESH_PAGE);
+        render(() => <DirectoryPane networkSlug={SLUG} />);
+
+        expect(screen.getByPlaceholderText(/search channels/i)).toHaveValue("rust");
+      });
+
+      // compose.ts selects the $list window FIRST and calls setQuery after,
+      // and a second `/list <pattern>` reaches an already-mounted pane — so a
+      // one-shot seed at mount is not enough. The box must FOLLOW the store.
+      it("follows a filter set after mount", async () => {
+        directoryPageMock.mockReturnValue(FRESH_PAGE);
+        render(() => <DirectoryPane networkSlug={SLUG} />);
+        const input = screen.getByPlaceholderText(/search channels/i);
+        expect(input).toHaveValue("");
+
+        setDirectoryQuerySignal("rust");
+
+        await waitFor(() => {
+          expect(input).toHaveValue("rust");
+        });
+      });
+
+      // The box LEADS the store by SEARCH_DEBOUNCE_MS (#732): binding the
+      // input straight to the store would undo that and make typing lag a
+      // quarter second behind the keyboard.
+      it("keeps the typed text while the debounced store filter still lags", () => {
+        vi.useFakeTimers();
+        try {
+          directoryPageMock.mockReturnValue(FRESH_PAGE);
+          render(() => <DirectoryPane networkSlug={SLUG} />);
+          const input = screen.getByPlaceholderText(/search channels/i);
+
+          fireEvent.input(input, { target: { value: "ru" } });
+
+          expect(setQueryMock).not.toHaveBeenCalled();
+          expect(input).toHaveValue("ru");
+        } finally {
+          vi.useRealTimers();
+        }
       });
     });
   });

--- a/cicchetto/src/lib/channelDirectory.test.ts
+++ b/cicchetto/src/lib/channelDirectory.test.ts
@@ -4,6 +4,7 @@ import { setToken } from "./auth";
 import {
   directoryError,
   directoryPage,
+  directoryQuery,
   directorySort,
   isLoadingMore,
   loadDirectory,
@@ -127,6 +128,18 @@ describe("channelDirectory store", () => {
     await setSort("freenode", "name");
     expect(spy).toHaveBeenCalledWith(TOKEN, "freenode", expect.objectContaining({ sort: "name" }));
     expect(directoryPage("freenode")?.total).toBe(12);
+  });
+
+  // #738 — the pane's search box renders this, so it must report the filter
+  // the store is actually applying, whoever set it (the box, or compose.ts's
+  // `/list <pattern>`).
+  test("directoryQuery reports the applied filter and defaults to empty", async () => {
+    expect(directoryQuery("dq1")).toBe("");
+    vi.spyOn(api, "listDirectory").mockResolvedValue(makePage({ total: 1 }));
+    await setQuery("dq1", "rust");
+    expect(directoryQuery("dq1")).toBe("rust");
+    resetDirectory("dq1");
+    expect(directoryQuery("dq1")).toBe("");
   });
 
   test("setQuery + subsequent loadDirectory uses the stored q", async () => {

--- a/cicchetto/src/lib/channelDirectory.ts
+++ b/cicchetto/src/lib/channelDirectory.ts
@@ -158,6 +158,13 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   // fetchInto produces on reopen. Defaults to "users".
   const directorySort = (slug: string): "users" | "name" => currentView(slug).sort;
 
+  // #738 — the filter the store is actually applying, for the pane's search
+  // box to render. The filter is NOT sticky (resetDirectory clears it on
+  // close), but it IS settable from outside the pane: compose.ts's
+  // `/list <pattern>` calls setQuery directly. Without this the box has no
+  // way to know, and shows an empty filter over a filtered list.
+  const directoryQuery = (slug: string): string => currentView(slug).q;
+
   // #677 — true while a loadMore for `slug` is in flight (sentinel spinner).
   const isLoadingMore = (slug: string): boolean => loadingMore()[slug] ?? false;
 
@@ -275,6 +282,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   return {
     directoryError,
     directoryPage,
+    directoryQuery,
     directorySort,
     isLoadingMore,
     loadDirectory,
@@ -291,6 +299,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
 
 export const directoryError = exports_.directoryError;
 export const directoryPage = exports_.directoryPage;
+export const directoryQuery = exports_.directoryQuery;
 export const directorySort = exports_.directorySort;
 export const isLoadingMore = exports_.isLoadingMore;
 export const loadDirectory = exports_.loadDirectory;


### PR DESCRIPTION
Issue #738. `/list <pattern>` calls `setQuery(networkSlug, cmd.pattern)` from
`compose.ts:1239`, so the directory's filter is settable from OUTSIDE the pane
with no window close in between. `searchText` was hard-initialised to `""` on
the premise that the filter is only ever cleared on close and therefore
"always mounts empty and the store agrees" — a premise that died when the
pattern arg was wired. The operator typed `/list rust`, got a short filtered
list under an empty box, and could only clear it by typing a character and
deleting it again.

## The fix

Follow the sibling control. #677 rehydrates the sort toggle from
`directorySort(slug)` precisely so a control cannot lie about the store's
view; the store had no query counterpart, so this adds `directoryQuery(slug)`.

**One place it departs from the sort pattern, deliberately.** Sort is only ever
set from inside the pane, so sampling it once at mount is sound. The filter is
not: `compose.ts` selects the `$list` window FIRST and calls `setQuery` after,
and a second `/list <pattern>` reaches a pane that is already mounted. A
one-shot seed would leave both cases broken. So the box FOLLOWS the store via
an effect. It keeps its local signal rather than binding to the store directly
because typing must LEAD the debounced GET (#732); the store echoes the same
text back ~250ms later, so the mirror write is a no-op.

The stale comment is gone rather than left to justify the next regression — an
assertion whose premise had quietly expired is what let this survive review.

## Mutation evidence

Every leg was broken and watched go red (`bun.sh run test`, iso):

| Mutation | Result |
|---|---|
| remove the mirror effect | **2 red** — mount + after-mount |
| `directoryQuery` returns `""` | **1 red** — the store test |
| revert to `createSignal(directoryQuery(slug))` seed **and** keep the effect | **0 red** → the seed was dead code, dropped (2nd commit) |
| bind the input straight to the store | **0 red** → that guard test could not fail, dropped (2nd commit) |

Two of those four killed the *test* rather than the code. jsdom keeps whatever
value `fireEvent.input` wrote to the DOM, so a test asserting "the typed text
survives" stays green even with the input bound to the store — it was a mirror,
and its honest content is already covered by the #732 debounce suite. Solid
flushes the mirror effect inside `render()`, before the first paint, which is
why the separate mount seed provably bought nothing.

## The sort-control check you asked for

`setSort` has exactly one caller — `DirectoryPane.tsx` itself. No compose verb,
no userTopic dispatch, nothing outside the pane. **No finding**: the sort
toggle's one-shot rehydration has no outside-set hole today. It would have the
identical bug the moment one is added, but there is nothing to fix now and I
have not touched it.

## Gates

* `scripts/bun.sh run check` → rc=0 (biome + tsc)
* `scripts/bun.sh run test` → rc=0, **229 files / 4125 tests**
* `scripts/bun.sh run build` → rc=0
* Working tree clean before and after.

cic-only; no server code, no lane taken, docker/e2e untouched.

## Inherited red

This branch's `integration` job will show the same
`tests/nick-follow-query.spec.ts` failure `origin/main` (`4f92701d`) currently
has. Not from this change — nothing here touches the server or e2e.