### PR TITLE
cic(#731): fold the /LIST casing before focusing a directory row

### DIFF
--- a/cicchetto/src/DirectoryPane.tsx
+++ b/cicchetto/src/DirectoryPane.tsx
@@ -13,7 +13,7 @@ import {
   setSort,
   triggerRefresh,
 } from "./lib/channelDirectory";
-import { channelKey } from "./lib/channelKey";
+import { canonicalChannel, channelKey } from "./lib/channelKey";
 import { friendlyApiError } from "./lib/friendlyApiError";
 import { closeToPreviousWindow, setSelectedChannel } from "./lib/selection";
 import { windowStateByChannel } from "./lib/windowState";
@@ -107,9 +107,16 @@ const DirectoryRow: Component<DirectoryRowProps> = (props) => {
       // device broadcast, pending→joined transition) can't steal focus. The
       // tap is the ONLY new focus origin. After the awaited postJoin so a
       // failed join (e.g. +i) never foregrounds a phantom window.
+      //
+      // #731 — the FOLDED name, like channelJoin.switchTo and compose.ts
+      // `/join`. `entry.name` is the raw `/LIST` spelling (the directory is
+      // the documented verbatim-casing exception) while selection and
+      // window_states are keyed folded, so a raw target focuses a window the
+      // sidebar can't match. Only the KEY folds: postJoin above and the
+      // rendered label below keep the display casing.
       setSelectedChannel({
         networkSlug: props.networkSlug,
-        channelName: props.entry.name,
+        channelName: canonicalChannel(props.entry.name),
         kind: "channel",
       });
     } catch (err) {
@@ -124,9 +131,12 @@ const DirectoryRow: Component<DirectoryRowProps> = (props) => {
   // channel you asked for. Automatic re-joins still never steal focus.
   const onActivate = () => {
     if (isJoined()) {
+      // #731 — folded, for the same reason as onJoin: `isJoined()` above
+      // already folds through `channelKey`, so focusing the raw name targets
+      // a different key than the one that just answered "joined".
       setSelectedChannel({
         networkSlug: props.networkSlug,
-        channelName: props.entry.name,
+        channelName: canonicalChannel(props.entry.name),
         kind: "channel",
       });
       return;

--- a/cicchetto/src/__tests__/DirectoryPane.test.tsx
+++ b/cicchetto/src/__tests__/DirectoryPane.test.tsx
@@ -360,6 +360,69 @@ describe("DirectoryPane", () => {
     });
   });
 
+  // #731 — `channel_directory.name` is the documented verbatim-casing
+  // exception: it stores the `/LIST` spelling, and bahamut preserves the
+  // creation casing (`#Sniffo`). Selection + window_states are keyed FOLDED,
+  // so a raw focus target opens a phantom window the sidebar can't match.
+  // Same split every sibling uses (channelJoin.switchTo, compose.ts /join):
+  // the KEY folds, the wire argument and the visible label stay RAW.
+  //
+  // The folded expectation is a LITERAL, not `canonicalChannel(...)`: routing
+  // both sides through the same helper would keep this green if the helper
+  // itself regressed. `#Sniffo` → `#sniffo` is the whole contract, spelled out.
+  describe("focus folds the /LIST casing (#731)", () => {
+    const MIXED_PAGE: DirectoryPage = {
+      ...FRESH_PAGE,
+      entries: [{ name: "#Sniffo", topic: null, user_count: 5, featured: false }],
+      total: 1,
+    };
+
+    it("join-then-foreground focuses the FOLDED name while postJoin gets the RAW one", async () => {
+      directoryPageMock.mockReturnValue(MIXED_PAGE);
+      windowStateByChannelMock.mockReturnValue({});
+      render(() => <DirectoryPane networkSlug={SLUG} />);
+
+      fireEvent.click(screen.getByRole("button", { name: /join #Sniffo/i }));
+
+      await waitFor(() => {
+        expect(setSelectedChannelMock).toHaveBeenCalledWith({
+          networkSlug: SLUG,
+          channelName: "#sniffo",
+          kind: "channel",
+        });
+      });
+      // The wire keeps the display spelling — the server does its own casemapping.
+      expect(postJoinMock).toHaveBeenCalledWith("test-token", SLUG, "#Sniffo", null);
+    });
+
+    it("tapping an already-joined mixed-case row focuses the FOLDED name", async () => {
+      directoryPageMock.mockReturnValue(MIXED_PAGE);
+      // channelKey folds internally, so this is the same entry window_states
+      // holds for the joined `#sniffo`.
+      windowStateByChannelMock.mockReturnValue({
+        [channelKey(SLUG, "#Sniffo")]: "joined",
+      });
+      render(() => <DirectoryPane networkSlug={SLUG} />);
+
+      fireEvent.click(screen.getByRole("button", { name: /open #Sniffo/i }));
+
+      await waitFor(() => {
+        expect(setSelectedChannelMock).toHaveBeenCalledWith({
+          networkSlug: SLUG,
+          channelName: "#sniffo",
+          kind: "channel",
+        });
+      });
+      expect(postJoinMock).not.toHaveBeenCalled();
+    });
+
+    it("renders the RAW /LIST casing as the row label", () => {
+      directoryPageMock.mockReturnValue(MIXED_PAGE);
+      render(() => <DirectoryPane networkSlug={SLUG} />);
+      expect(screen.getByText("#Sniffo")).toBeInTheDocument();
+    });
+  });
+
   describe("close button (#125)", () => {
     it("renders a close button that returns to the previous window", async () => {
       directoryPageMock.mockReturnValue(FRESH_PAGE);


### PR DESCRIPTION
Issue #731.

## The defect

`channel_directory.name` is the documented verbatim-casing exception — it stores the `/LIST` spelling, and bahamut preserves the casing a channel was created with. Both focus sites in `DirectoryRow` handed that raw name straight to `setSelectedChannel`, while the row's OWN `isJoined()` folded through `channelKey`.

So tapping `#Sniffo` joined fine, but the selection became `#Sniffo` while `channelsBySlug` and `window_states` held `#sniffo`. The sidebar showed no active row, and tapping the `#sniffo` sidebar row afterwards read as a switch to a DIFFERENT window instead of a re-tap of the current one.

## The fix

Route both `setSelectedChannel` calls through `canonicalChannel` — the same helper `channelJoin.switchTo` uses, and the one `compose.ts` folds `/join`'s first element with (added for #510, filed for this exact phantom-window shape). Two call sites, one import.

This is the CLAUDE.md fold invariant, not a new rule: **only the KEY folds**. The `postJoin` wire argument and the rendered label keep the raw spelling — the server does its own casemapping, and a channel's casing is presentation.

## Tests

Three new cases under `focus folds the /LIST casing (#731)`, driven by a `#Sniffo` entry:

- join-then-foreground focuses `#sniffo` while `postJoin` still receives `#Sniffo`
- tapping an already-joined mixed-case row focuses `#sniffo`
- the row label still renders `#Sniffo`

The folded expectation is a **literal**, not `canonicalChannel(...)`: routing both sides through the same helper would keep the test green if the helper itself regressed.

**Mutation-proven, one leg at a time** — a shared "both legs broken" red would not have shown that each assert is individually load-bearing:

| mutation | result |
|---|---|
| both legs raw (pre-fix) | 2 failed / 43 passed |
| `onJoin` raw only | 1 failed — the join test, and only it |
| `onActivate` raw only | 1 failed — the already-joined test, and only it |
| fix in place | 45 passed |

## Gates

Run sequentially from the worktree root, output to file, rc read from file:

- `bun run check` (biome + tsc) — **rc=0**
- `bun run test` — **rc=0**, `Test Files 229 passed (229) / Tests 4125 passed (4125)`
- `bun run build` — **rc=0**, `precache 21 entries`

cic-only change; no server, e2e, or docker surface touched.

## Notes

- Branched off `origin/main` at `4f92701d`. `main`'s `integration` job is currently red on `tests/nick-follow-query.spec.ts` out of the five-PR merge — inherited, unrelated to this diff, which touches no server or e2e code.
- Expect a rebase: PR #797 (#738) also touches `DirectoryPane.tsx`, in different hunks (the pane-level search box; this one is inside the `DirectoryRow` sub-component).