### PR TITLE
cic(#799): fold the INVITE-row channel before focusing it

### DIFF
--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -14,7 +14,7 @@ import LusersCard from "./LusersCard";
 import { isContentKind, ownNickForNetwork, postJoin, type ScrollbackMessage } from "./lib/api";
 import { token } from "./lib/auth";
 import { confirmJoinChannel } from "./lib/channelJoin";
-import { channelKey, decodeChannelKey } from "./lib/channelKey";
+import { canonicalChannel, channelKey, decodeChannelKey } from "./lib/channelKey";
 import { type TopicJoinLine, topicByChannel, topicJoinLine } from "./lib/channelTopic";
 import { isDocumentVisible } from "./lib/documentVisibility";
 import { highlightPatterns } from "./lib/highlightList";
@@ -1261,7 +1261,19 @@ const ScrollbackPane: Component<Props> = (props) => {
     // invite row; keyed-channel invites are rare and the operator can
     // still type `/join #chan key` in compose if needed).
     void postJoin(t, props.networkSlug, channel, null).then(() => {
-      setSelectedChannel({ networkSlug: props.networkSlug, channelName: channel, kind: "channel" });
+      // #799 — the FOLDED name, like channelJoin.switchTo, compose.ts `/join`
+      // and DirectoryPane. `channel` is `params[1]` off a stored INVITE row:
+      // ingress folds it today (EventRouter's `:invite` clause, the #537 fix),
+      // but per the #525 posture `refold_identifiers_ascii` does not rewrite
+      // stored values, so a pre-#537 row still carries mixed case. Selection
+      // and window_states are keyed folded — a raw target foregrounds a window
+      // the sidebar can't match. Only the KEY folds: the postJoin above and
+      // the rendered row label keep the invite's spelling.
+      setSelectedChannel({
+        networkSlug: props.networkSlug,
+        channelName: canonicalChannel(channel),
+        kind: "channel",
+      });
     });
   };
 

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -192,6 +192,10 @@ vi.mock("../lib/socket", () => ({
 }));
 
 vi.mock("../lib/channelKey", () => ({
+  // Deliberately NOT folding, unlike prod: the fixtures in this file key
+  // `setScrollback` / `seedReadCursor` with raw names (`freenode NickServ`),
+  // so a folding composite key would orphan every one of them. The identity
+  // is safe here because no test drives two spellings of the same window.
   channelKey: (slug: string, name: string) => `${slug} ${name}`,
   // Faithful to the `${slug} ${name}` mock shape: split on the first space.
   // Needed once a test drives a real channel switch (the key-change effects
@@ -201,7 +205,13 @@ vi.mock("../lib/channelKey", () => ({
     const i = key.indexOf(" ");
     return i < 0 ? null : { slug: key.slice(0, i), name: key.slice(i + 1) };
   },
-  canonicalChannel: (name: string) => name,
+  // #799 — this WAS the identity, which made the mock lie about the one thing
+  // the function exists to do, so no test could ever observe a missing fold.
+  // Spelled out inline rather than re-exporting the real `asciiFold`: a mock
+  // that delegates to the module it stands in for cannot catch that module
+  // regressing, and the `A-Z`-only fold table is one regex.
+  canonicalChannel: (name: string) =>
+    name.replace(/[A-Z]/g, (c) => String.fromCharCode(c.charCodeAt(0) + 32)),
 }));
 
 // C3.2: mock membersByChannel for JOIN-self banner tests
@@ -3099,6 +3109,54 @@ describe("ScrollbackPane", () => {
           kind: "channel",
         });
       });
+    });
+
+    // #799 — a pre-#537 INVITE row still carries a mixed-case `params[1]`:
+    // the ingress fold (EventRouter's `:invite` clause) IS the #537 fix, and
+    // per the #525 posture `refold_identifiers_ascii` does NOT rewrite stored
+    // values. Selection and `window_states` are keyed FOLDED, so focusing the
+    // raw name opens a phantom pane the sidebar can't match. Same split as
+    // every sibling (channelJoin.switchTo, compose.ts /join, DirectoryPane):
+    // the KEY folds, the wire argument stays RAW.
+    //
+    // The folded expectation is a LITERAL, not `canonicalChannel(...)` —
+    // routing both sides through the same helper would stay green if the
+    // helper itself regressed. `#Sbiffo` → `#sbiffo` is the whole contract.
+    const mixedCaseInviteRow: ScrollbackMessage = {
+      ...inviteRow,
+      id: 107,
+      server_time: 107,
+      body: "#Sbiffo",
+      meta: {
+        raw_verb: "INVITE",
+        raw_sender: "vjt",
+        raw_params: ["grappa", "#Sbiffo"],
+      },
+    };
+
+    it("INVITE [Join] focuses the FOLDED channel while postJoin gets the RAW one (#799)", async () => {
+      mockPostJoin.mockClear();
+      mockSetSelectedChannel.mockClear();
+      setScrollback({ "freenode $server": [mixedCaseInviteRow] });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="$server" kind="channel" />);
+      const btn = document.querySelector(".scrollback-invite-join") as HTMLButtonElement;
+      btn.click();
+      await waitFor(() => {
+        expect(mockSetSelectedChannel).toHaveBeenCalledWith({
+          networkSlug: "freenode",
+          channelName: "#sbiffo",
+          kind: "channel",
+        });
+      });
+      // The wire keeps the invite's spelling — the ircd does its own
+      // casemapping, and cic never rewrites an outbound target.
+      expect(mockPostJoin).toHaveBeenCalledWith("test-token", "freenode", "#Sbiffo", null);
+    });
+
+    it("INVITE row renders the RAW channel spelling as its label (#799)", () => {
+      setScrollback({ "freenode $server": [mixedCaseInviteRow] });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="$server" kind="channel" />);
+      expect(screen.getByTestId("scrollback-line").textContent).toContain("#Sbiffo");
     });
 
     it("INVITE with malformed channel param falls through to generic render (no [Join])", () => {


### PR DESCRIPTION
Issue #799. Branched from `origin/main` at `4f92701d`.

## The defect

`ScrollbackPane.handleJoinChannel` forwarded the INVITE row's `params[1]`
straight into `setSelectedChannel`. Selection and `window_states` are keyed
FOLDED, so a mixed-case param foregrounds a key the sidebar cannot match — no
active row, empty phantom pane. Same failure shape as #731 in `DirectoryPane`.

Narrow today because ingress folds it (`EventRouter`'s `:invite` clause). But
that fold IS the #537 fix, and per the #525 posture `refold_identifiers_ascii`
does not rewrite stored values, so a pre-#537 INVITE row still sits in prod
scrollback with its raw casing. More structurally: the three siblings
(`channelJoin.switchTo`, `compose.ts` `/join`, `DirectoryPane`) fold at the
SELECTION boundary regardless of ingress; this one relied on ingress — two
patterns for one problem, and a silent trap for any future path in.

## The fix

`canonicalChannel(channel)` for the `setSelectedChannel` argument **only**. The
`postJoin` argument and the rendered row label keep the invite's spelling —
the key/display/wire split.

## The lying mock

`vi.mock("../lib/channelKey")` in `ScrollbackPane.test.tsx` stubbed
`canonicalChannel` as the **identity**, so no test in this file could ever
observe a missing fold. It now folds `A-Z` like prod, spelled out inline rather
than re-exporting the real `asciiFold` — a mock that delegates to the module it
stands in for cannot catch that module regressing.

`channelKey` stays deliberately non-folding, and the comment now says why: the
fixtures here key raw (`freenode NickServ`), and making it fold orphans them
(tried it — it reddened the unrelated `DOES count peer notice rows` unread-marker
test). Out of scope; recorded rather than papered over.

## Mutation proof

Both legs, plus the mock itself. Each mutation applied alone against the
committed tree; the named test is the only failure in all three.

| Mutation | Result |
|---|---|
| Revert the fold (`channelName: channel`) | RED — 1 failed / 166 passed |
| Fold the wire too (`postJoin(..., canonicalChannel(channel), ...)`) | RED — 1 failed / 166 passed |
| Restore the identity `canonicalChannel` mock | RED — 1 failed / 166 passed |
| Unmutated | GREEN — 167 passed |

The third row is the one that matters for the mock change: per the #736 lesson,
a mock fix that turns nothing red is not a fix.

## Gates

cic-only, run from the worktree root. No lane taken, nothing touched on
docker / e2e / integration.

- `bun run check:fix` then `bun run check` — **exit 0** (biome clean, so `tsc
  --noEmit` actually ran rather than being short-circuited)
- `bun run test` — **exit 0**, 229 files / **4124 passed**
- `git status --porcelain` empty before and after

jsdom is blind to layout, but this defect is store-level (selection key vs
sidebar key), so unit tests are the right instrument. No e2e.

## Not done here

`ArchiveModal.tsx` passing `target` unfolded (the issue's "also seen, NOT
filed" section) is untouched, as instructed.