### PR TITLE
cic(#800): drop the rail's speculative WHOIS — the pane stops spending a budget it cannot see

### DIFF
--- a/cicchetto/src/RailContext.tsx
+++ b/cicchetto/src/RailContext.tsx
@@ -17,9 +17,9 @@ import WhoisCard from "./WhoisCard";
 //              single-slot `whoisCard` store the user-issued /whois owns) and
 //              carries no × affordance (persistent, like the server card).
 //              It RENDERS what is known and asks for nothing — #800 removed
-//              the fetch-on-select, because cic cannot see the upstream
-//              fake-lag budget a WHOIS spends and was charging it to the
-//              operator's next PRIVMSG. The cache fills from the user's own
+//              the fetch-on-select, because that WHOIS measurably delayed the
+//              operator's next message and cic cannot see the upstream cost it
+//              was spending. The cache fills from the user's own
 //              /whois (#606 routes a `source: user` bundle for the shown nick
 //              here); #782 adds the explicit fetch control.
 // It renders NOTHING for kinds with no context content (channel already has

--- a/cicchetto/src/RailContext.tsx
+++ b/cicchetto/src/RailContext.tsx
@@ -1,15 +1,6 @@
-import {
-  type Component,
-  createEffect,
-  createSignal,
-  Match,
-  on,
-  onCleanup,
-  Show,
-  Switch,
-} from "solid-js";
+import { type Component, createSignal, Match, onCleanup, Show, Switch } from "solid-js";
 import { networkBySlug } from "./lib/networks";
-import { railWhoisFor, requestRailWhois } from "./lib/railWhois";
+import { railWhoisFor } from "./lib/railWhois";
 import { selectedChannel } from "./lib/selection";
 import ServerInfoCard from "./ServerInfoCard";
 import WhoisCard from "./WhoisCard";
@@ -20,12 +11,17 @@ import WhoisCard from "./WhoisCard";
 // grafts the matching context content:
 //   * server → ServerInfoCard (connection facts already in the store)
 //   * query  → the query context (#606, the deferred half of #474): a
-//              heading + a WHOIS card for the conversation partner,
-//              auto-fetched on select. The card REUSES the same `WhoisCard`
-//              presentation as the scrollback overlay but is fed by the
-//              per-nick `railWhois` cache (NOT the single-slot `whoisCard`
-//              store the user-issued /whois owns) and carries no × affordance
-//              (persistent, like the server card).
+//              heading + a WHOIS card for the conversation partner. The card
+//              REUSES the same `WhoisCard` presentation as the scrollback
+//              overlay but is fed by the per-nick `railWhois` cache (NOT the
+//              single-slot `whoisCard` store the user-issued /whois owns) and
+//              carries no × affordance (persistent, like the server card).
+//              It RENDERS what is known and asks for nothing — #800 removed
+//              the fetch-on-select, because cic cannot see the upstream
+//              fake-lag budget a WHOIS spends and was charging it to the
+//              operator's next PRIVMSG. The cache fills from the user's own
+//              /whois (#606 routes a `source: user` bundle for the shown nick
+//              here); #782 adds the explicit fetch control.
 // It renders NOTHING for kinds with no context content (channel already has
 // the MembersPane above; home/admin/list/mentions have none). Built as a
 // container, not a hardcoded server card, so the rail is the per-kind
@@ -46,32 +42,6 @@ const RailContext: Component = () => {
   onCleanup(() => clearInterval(timer));
 
   const sel = () => selectedChannel();
-
-  // #606 — fetch-on-select. When a query window is (re)focused, ask the rail
-  // WHOIS cache for its partner; the store decides whether that costs an
-  // upstream command (it does not, for a nick already known). Keyed on the
-  // composed (slug, nick) string so the effect fires ONLY when the focused
-  // query's identity actually changes, not on every unrelated selection
-  // churn. A nick cannot contain a space, so the separator is unambiguous.
-  //
-  // A #373 rename DOES fire this effect — `followQueryNick` swaps the
-  // selection — but it must NOT cost a WHOIS: `subscribe.ts` migrates the
-  // rail cache old→new BEFORE that swap, so this lands on a hit. Solid
-  // flushes effects at the end of the write, so the ordering there is what
-  // holds this true; reverse it and every rename asks the ircd again.
-  createEffect(
-    on(
-      () => {
-        const s = sel();
-        return s?.kind === "query" ? `${s.networkSlug} ${s.channelName}` : null;
-      },
-      (key) => {
-        if (key === null) return;
-        const sep = key.indexOf(" ");
-        requestRailWhois(key.slice(0, sep), key.slice(sep + 1));
-      },
-    ),
-  );
 
   return (
     <Switch>

--- a/cicchetto/src/__tests__/RailContext.test.tsx
+++ b/cicchetto/src/__tests__/RailContext.test.tsx
@@ -126,13 +126,17 @@ describe("RailContext query context (#606)", () => {
   });
 
   // #800 — THE RULE: the rail never spends an upstream command on its own.
-  // #606 shipped a fetch-on-select here; a WHOIS costs bahamut fake-lag
-  // (`since += 2 + len/120`, recvQ parse gated on `since - now < 10`), so it
-  // landed head-of-line in front of the operator's next PRIVMSG and pushed it
-  // past the ircd's parse gate — main went red on nick-follow-query. cic
-  // cannot see that budget, so it must not decide to spend it. These two pin
-  // the rule against the next prefetch surface; #782 adds a user-driven
-  // button, which is a different thing entirely.
+  // #606 shipped a fetch-on-select here, and it measurably delayed the
+  // operator's NEXT message by seconds — main went red on nick-follow-query.
+  // (Where those seconds go inside the ircd is still unconfirmed; fake-lag is
+  // the leading hypothesis, see DESIGN_NOTES 2026-08-04.) The rule does not
+  // depend on that: cic cannot see the connection's upstream cost at all, so
+  // it must not decide to spend it. These two pin the rule against the next
+  // prefetch surface; #782 adds a user-driven button, a different thing.
+  //
+  // The second test is not redundant: the effect fires again on a #373 rename,
+  // so the rule has two entry points, and on the wire only `railWhois`'s own
+  // de-dupe kept that from being a second command.
   it("issues NO WHOIS when a query window is selected", async () => {
     await setSelected(sel("query", "alice"));
     await renderContainer();

--- a/cicchetto/src/__tests__/RailContext.test.tsx
+++ b/cicchetto/src/__tests__/RailContext.test.tsx
@@ -125,10 +125,18 @@ describe("RailContext query context (#606)", () => {
     expect(screen.queryByTestId("rail-server-info")).toBeNull();
   });
 
-  it("fires requestRailWhois(slug, nick) when a query is selected", async () => {
+  // #800 — THE RULE: the rail never spends an upstream command on its own.
+  // #606 shipped a fetch-on-select here; a WHOIS costs bahamut fake-lag
+  // (`since += 2 + len/120`, recvQ parse gated on `since - now < 10`), so it
+  // landed head-of-line in front of the operator's next PRIVMSG and pushed it
+  // past the ircd's parse gate — main went red on nick-follow-query. cic
+  // cannot see that budget, so it must not decide to spend it. These two pin
+  // the rule against the next prefetch surface; #782 adds a user-driven
+  // button, which is a different thing entirely.
+  it("issues NO WHOIS when a query window is selected", async () => {
     await setSelected(sel("query", "alice"));
     await renderContainer();
-    expect(requestRailWhoisMock).toHaveBeenCalledWith("libera", "alice");
+    expect(requestRailWhoisMock).not.toHaveBeenCalled();
   });
 
   it("updates the heading when the query's nick changes while open (followQueryNick)", async () => {
@@ -142,12 +150,11 @@ describe("RailContext query context (#606)", () => {
     expect(ctx.textContent).not.toContain("with alice "); // no stale nick
   });
 
-  it("re-fires requestRailWhois for the new nick after a rename", async () => {
+  it("issues NO WHOIS when a rename swaps the focused query's nick", async () => {
     await setSelected(sel("query", "alice"));
     await renderContainer();
     await setSelected(sel("query", "alice2"));
-    expect(requestRailWhoisMock).toHaveBeenCalledWith("libera", "alice");
-    expect(requestRailWhoisMock).toHaveBeenCalledWith("libera", "alice2");
+    expect(requestRailWhoisMock).not.toHaveBeenCalled();
   });
 
   it("renders the WhoisCard when a rail bundle exists for the selected nick", async () => {

--- a/cicchetto/src/lib/railWhois.ts
+++ b/cicchetto/src/lib/railWhois.ts
@@ -17,13 +17,22 @@ import { whoisBundleHasFields } from "./whoisBundle";
 //     (opening two queries would stomp the card) nor forge a scrollback
 //     card the user never asked for.
 //
-// Fetch policy (issue #606 scope 2, revised):
-//   * ONE WHOIS per nick, on FIRST select (`requestRailWhois`). Once the nick
-//     is KNOWN it is never asked about again — there is NO staleness refetch;
-//   * an ask that produced nothing (reply in flight, or a reply carrying no
-//     fields because the peer is offline) stands for `RAIL_WHOIS_RETRY_MS`,
-//     which both de-dupes fast window switching and lets a peer who was
-//     offline at first select be resolved later in the session.
+// Fetch policy (#606 scope 2, then #800):
+//   * NOTHING in the rail asks on its own. #606 called `requestRailWhois` on
+//     first select of a query window; #800 removed that call, because a WHOIS
+//     costs upstream fake-lag budget cic cannot see and it was landing
+//     head-of-line in front of the operator's next PRIVMSG. The store now
+//     fills only from the user's OWN `/whois` (`userTopic.ts` routes a
+//     `source: "user"` bundle for the nick the rail is showing into here).
+//   * `requestRailWhois` therefore has NO production caller today. It is kept
+//     deliberately, not by oversight: it is the seam #782's explicit fetch
+//     control attaches to, and its de-dupe rules below are the ones that
+//     button will need. It is NOT to be wired to any automatic trigger.
+//   * When it IS called: ONE WHOIS per nick. Once the nick is KNOWN it is
+//     never asked about again — there is NO staleness refetch. An ask that
+//     produced nothing (reply in flight, or a reply carrying no fields
+//     because the peer is offline) stands for `RAIL_WHOIS_RETRY_MS`, which
+//     de-dupes rapid re-asks and lets an offline peer resolve later.
 //
 // The freshness TTL this store shipped with is deliberately GONE. It was not
 // a cost problem: on bahamut a WHOIS and a PRIVMSG carry the same fake-lag

--- a/cicchetto/src/lib/railWhois.ts
+++ b/cicchetto/src/lib/railWhois.ts
@@ -19,11 +19,12 @@ import { whoisBundleHasFields } from "./whoisBundle";
 //
 // Fetch policy (#606 scope 2, then #800):
 //   * NOTHING in the rail asks on its own. #606 called `requestRailWhois` on
-//     first select of a query window; #800 removed that call, because a WHOIS
-//     costs upstream fake-lag budget cic cannot see and it was landing
-//     head-of-line in front of the operator's next PRIVMSG. The store now
-//     fills only from the user's OWN `/whois` (`userTopic.ts` routes a
-//     `source: "user"` bundle for the nick the rail is showing into here).
+//     first select of a query window; #800 removed that call, because that one
+//     extra command measurably delayed the operator's NEXT message by seconds
+//     (the ircd-side mechanism is unconfirmed — the fake-lag reading below is
+//     the leading hypothesis, not a measurement). The store now fills only
+//     from the user's OWN `/whois` (`userTopic.ts` routes a `source: "user"`
+//     bundle for the nick the rail is showing into here).
 //   * `requestRailWhois` therefore has NO production caller today. It is kept
 //     deliberately, not by oversight: it is the seam #782's explicit fetch
 //     control attaches to, and its de-dupe rules below are the ones that
@@ -34,7 +35,11 @@ import { whoisBundleHasFields } from "./whoisBundle";
 //     because the peer is offline) stands for `RAIL_WHOIS_RETRY_MS`, which
 //     de-dupes rapid re-asks and lets an offline peer resolve later.
 //
-// The freshness TTL this store shipped with is deliberately GONE. It was not
+// The freshness TTL this store shipped with is deliberately GONE. The reading
+// that follows is INFERRED FROM BAHAMUT SOURCE and has never been measured
+// against a running ircd (#800) — it is the best lead for WHY an extra command
+// delays the next one, not an established fact. What IS measured is the delay
+// itself. It was not
 // a cost problem: on bahamut a WHOIS and a PRIVMSG carry the same fake-lag
 // flag and the same `since += 2 + len/120` (src/parse.c:236). The problem is
 // the CEILING — `s_bsd.c:1657` gates the recvQ drain on

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -28433,21 +28433,52 @@ whereas a channel that silently stops being clickable has no recourse but
 ## 2026-08-04 — #800: a pane may not spend a budget it cannot see
 
 `#606`'s rail context fetched a WHOIS when a query window was selected. That
-call reddened `main` on `nick-follow-query` (#373): on bahamut every command
-costs `since += 2 + len/120` and the recvQ drain is gated on `since - now < 10`,
-so the rail's WHOIS landed head-of-line in front of the operator's next PRIVMSG
-and pushed it past the ircd's parse gate. Bisected by duration delta — the spec
-ran 2.7s on the pre-merge baseline, 5.7s with #613 alone, 6.7s (timeout) on the
-merged main — and confirmed by displacement: deleting the one call restored the
-baseline (2.0/5.5/4.5 vs 7.4/10.0/9.3 locally, `--repeat-each 3`). Full evidence
-in #800.
+call reddened `main` on `nick-follow-query` (#373).
+
+**Measured.** One extra WHOIS on the session's upstream connection delays the
+operator's NEXT message by seconds. The spec ran 2.7s on the pre-merge baseline,
+5.7s with #613 alone, and 6.7s — a timeout — on the merged main. Deleting the
+one call restores the baseline: 2.0/5.5/4.5 against 7.4/10.0/9.3 locally at
+`--repeat-each 3`. The red is intermittent (~7 of 9 post-merge runs, 0 of 4
+pre-merge), which is why the duration delta and the displacement result are the
+evidence rather than any single pass or fail. Full write-up in #800.
+
+**Inferred, NOT confirmed.** *Where* those seconds are spent is still open. The
+leading hypothesis — from reading bahamut source, not from measuring this
+system — is fake-lag: each command costs `since += 2 + len/120` and the recvQ
+drain is gated on `since - now < 10` (`parse.c:236`, `s_bsd.c:1657`), so past
+the ceiling the ircd keeps reading grappa's socket but stops parsing it. It fits
+(grappa emits the followup 357ms after the previous send, so the delay is not on
+our side) but nobody has instrumented the ircd to show it. The `5000ms` in the
+failing assertion is the **test helper's own wait budget**, not a measured
+bahamut latency — do not cite it as one. Anyone who wants to close this: measure
+the ircd, do not re-read the source.
+
+The distinction matters for what the entry is FOR. The rule below rests on the
+displacement result alone and needs no ircd-internal mechanism to justify it, so
+the hypothesis being wrong would not weaken it.
 
 **The general rule, which binds every future prefetch surface: cic does not
-decide to spend an upstream command.** It cannot see `since`, it cannot see what
-the session sent a moment ago, and it cannot see how close the connection is to
-the parse gate. Only the operator's own action spends that budget. This is not
-about tuning WHEN the rail fetches — every timing fix #606 tried (TTL, retry
-window, migrate-before-select ordering) was answering the wrong question.
+decide to spend an upstream command.** Whatever the ircd-side mechanism turns
+out to be, the client cannot see it — not what the session sent a moment ago,
+not what that cost, not how close the connection is to whatever ceiling it has.
+Only the operator's own action spends that budget. This is not about tuning WHEN
+the rail fetches — every timing fix #606 tried (TTL, retry window,
+migrate-before-select ordering) was answering the wrong question.
+
+**One WHOIS, not two — and why the near miss is worth recording.** The rail's
+effect fires on every query-identity change, so a #373 rename fires it a SECOND
+time; the pinning test in `RailContext.test.tsx` sees exactly that (`called 2
+times`, against a mocked store). On the wire it stayed at one: the instrumented
+run showed `WHOIS Guest…` and no `WHOIS NickTmp…`, because `subscribe.ts`
+migrates the rail cache old→new BEFORE `followQueryNick` swaps the selection, so
+the second call lands on a hit and short-circuits. That de-dupe held, but it was
+second-line defence under a rule that should not have existed: a cache miss
+there — empty bundle, peer offline, retry window elapsed — and the second
+command goes out for real. Nor is the rename what made this spec the one that
+fell; it fell because it is the only spec that opens a query window and then
+sends a timed message, which is the only shape that puts a speculative command
+in front of a stopwatch.
 
 **What was removed, and what deliberately was not.** Only the `createEffect` in
 `RailContext.tsx` is gone. The card, the `renameRailWhois` #373 migration, the

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -28429,3 +28429,47 @@ catch it, and would also reject `#facade`, `#decade`, `#cafe`, `#bad` and
 `#abc` — real channel shapes. The mis-tap still needs a confirmation dialog,
 whereas a channel that silently stops being clickable has no recourse but
 `/join`. Left alone pending a call.
+
+## 2026-08-04 — #800: a pane may not spend a budget it cannot see
+
+`#606`'s rail context fetched a WHOIS when a query window was selected. That
+call reddened `main` on `nick-follow-query` (#373): on bahamut every command
+costs `since += 2 + len/120` and the recvQ drain is gated on `since - now < 10`,
+so the rail's WHOIS landed head-of-line in front of the operator's next PRIVMSG
+and pushed it past the ircd's parse gate. Bisected by duration delta — the spec
+ran 2.7s on the pre-merge baseline, 5.7s with #613 alone, 6.7s (timeout) on the
+merged main — and confirmed by displacement: deleting the one call restored the
+baseline (2.0/5.5/4.5 vs 7.4/10.0/9.3 locally, `--repeat-each 3`). Full evidence
+in #800.
+
+**The general rule, which binds every future prefetch surface: cic does not
+decide to spend an upstream command.** It cannot see `since`, it cannot see what
+the session sent a moment ago, and it cannot see how close the connection is to
+the parse gate. Only the operator's own action spends that budget. This is not
+about tuning WHEN the rail fetches — every timing fix #606 tried (TTL, retry
+window, migrate-before-select ordering) was answering the wrong question.
+
+**What was removed, and what deliberately was not.** Only the `createEffect` in
+`RailContext.tsx` is gone. The card, the `renameRailWhois` #373 migration, the
+`whoisCard`/`railWhois` store split and the `source: "user" | "rail"` wire field
+all stay — the cache still fills from the user's own `/whois`, which #606's
+origin routing already delivers to the rail for the nick it is showing.
+`requestRailWhois` keeps its tests and its de-dupe rules with no production
+caller: it is the seam #782's explicit fetch control attaches to. Dead-but-kept
+is normally a smell, so it is stated in the module rather than left to be
+rediscovered.
+
+**What shipped was never what was asked for.** The request was to populate when
+the rail is OPENED on mobile / the window is VIEWED on desktop. Fetch-on-select
+is neither: on mobile the rail is off-screen, so #606 spent upstream budget
+filling a card the user could not see. Worth recording because the gap survived
+review, an e2e and a merge — the spec was read as "when the window becomes
+active" when it said "when the card becomes visible."
+
+**Where the answer should live (#802).** There is no server-side store for a
+WHOIS reply: `whois_pending` is an in-flight accumulator, drained by 318 into a
+broadcast and dropped. cic's `railWhois` cache is real but in-memory and
+per-page-load, so every reload re-pays upstream for an answer grappa already
+received. The precedent already exists — `userhost_cache` is nick-keyed, folded,
+fed passively from JOIN prefixes at zero upstream cost, and already migrated on
+NICK. Cache the answer, and the question of when to fetch mostly dissolves.


### PR DESCRIPTION
Fixes the red `main`. Approved by vjt: *"ok leva la chiamata speculativa"*.

> **Correction (2nd commit).** An earlier version of this PR — and of the
> DESIGN_NOTES entry it adds — stated the bahamut fake-lag mechanism as
> established fact. It is not: it comes from reading bahamut source, not from
> measuring a running ircd, and the `5000ms` in the failing assertion is the
> **test helper's own wait budget**, not a bahamut latency. Caught by Sonic and
> vjt. The measured evidence below is unchanged and still carries the argument.

## What this does

Deletes the `createEffect` in `RailContext.tsx` that called
`requestRailWhois` when a query window was selected. That is the whole
behavioural change.

**This is NOT a revert of #613.** The rail card, the `renameRailWhois` #373
migration, the `whoisCard` / `railWhois` store split and the
`source: "user" | "rail"` wire field all stay. The cache still fills from the
user's own `/whois` — #606's origin routing already delivers a `source: "user"`
bundle for the nick the rail is showing into that store.

## Why — what is MEASURED

One extra WHOIS on the session's upstream connection delays the operator's
**next message** by seconds.

| build | `nick-follow-query` |
|---|---|
| `123720d5` pre-merge baseline | 2.7s ✓ |
| `2ac821cc` #613 alone | 5.7s ✓ (by 0.7s) |
| `4f92701d` merged main | 6.7s ✘ |

Locally, `--repeat-each 3`, chromium: main **7.4 / 10.0 / 9.3**; main minus this
one call **2.0 / 5.5 / 4.5**; baseline **2.0 / 3.4 / 4.4**. The red is
intermittent — ~7 of 9 post-merge runs, 0 of 4 pre-merge — which is exactly why
the duration delta and the displacement result are the evidence, not any single
run.

## Why — what is INFERRED, and not confirmed

*Where* those seconds are spent inside the ircd is **open**. The leading
hypothesis, from reading bahamut source, is fake-lag: each command costs
`since += 2 + len/120` and the recvQ drain is gated on `since - now < 10`
(`parse.c:236`, `s_bsd.c:1657`). It fits — grappa emitted the followup 357ms
after the previous send, so the delay is not on our side — but nobody has
instrumented the ircd to show it. Closing it means measuring the ircd, not
re-reading the source.

**The rule does not depend on it.** It follows from the displacement result
alone: **cic cannot see the connection's upstream cost — not what the session
sent a moment ago, not what it cost, not how close it is to whatever ceiling
exists — so it does not get to decide to spend a command.** Every timing fix
#606 reached for (TTL, retry window, migrate-before-select ordering) was
answering the wrong question. If the fake-lag reading turns out wrong, the rule
does not move.

## Tests

Two tests in `RailContext.test.tsx` pin the rule at the surface that broke it:

* `issues NO WHOIS when a query window is selected`
* `issues NO WHOIS when a rename swaps the focused query's nick`

They replace the two that asserted the opposite. **Both were watched RED against
the shipped code before the call came out** — 2 failed / 8 passed. A test that
passes with the call restored would be worthless, so this is the evidence that
it does not.

**On the rename leg, precisely.** That test's `called 2 times` counts **effect
firings against a mocked store**, not commands. On the wire it stayed at one:
the instrumented run showed `WHOIS Guest…` and no `WHOIS NickTmp…`, because
`subscribe.ts` migrates the rail cache old→new *before* `followQueryNick` swaps
the selection, so the second call short-circuits on a hit. The second entry
point is still worth pinning — a cache miss there (empty bundle, peer offline,
retry window elapsed) makes that call a real command — but it was a near miss,
not a second WHOIS. And the rename is not why this spec is the one that fell:
it fell because it is the only spec that opens a query window and then sends a
timed message.

## Deliberately left alone

`requestRailWhois` keeps its tests and its de-dupe rules and now has **no
production caller.** That is a choice, not an oversight: it is the seam #782's
explicit fetch control attaches to. Stated in the module moduledoc rather than
left to be rediscovered.

## Also recorded (no code)

What shipped was never what was asked for. The request was to populate when the
rail is **opened** on mobile / the window is **viewed** on desktop.
Fetch-on-select is neither — on mobile the rail is off screen, so #606 spent
upstream budget filling a card the user could not see.

The button itself is **#782** and is not built here. The server-side cache that
would make the question mostly go away is **#802** and is not built here either.

## Gates

* `scripts/bun.sh run check` (biome + tsc) — **rc=0**
* `scripts/bun.sh run test` — **rc=0**, 229 files / 4122 tests passed
* Integration deliberately left to this PR's CI rather than the local stack.

⚠️ Given the intermittency, a green integration here is **consistent with** the
fix but does not on its own prove it. The duration deltas and the displacement
run are the evidence.

Related: #800 (evidence), #613 / #606 (the fetch), #782 (the button), #802 (the
cache).