### PR TITLE
irc(#800): S7 — instrument the fake-lag bank inside grappa, per send

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -526,7 +526,20 @@ config :logger, :console,
     # allowlist beyond `Meta.known_keys/0` (the sync test is a subset
     # check: known_keys ⊆ metadata). `:new_nick` pre-exists above.
     :old_nick,
-    :rows_migrated
+    :rows_migrated,
+    # #800 S7 — `Grappa.IRC.Client`'s per-frame outbound-cost line, at
+    # DEBUG (silent in production, which runs at :info). `:sent_bytes` and
+    # `:commands_10s` are MEASURED — what this process put on the wire and
+    # how much of it is still inside the ten-second horizon. `:penalty_10s_s`,
+    # `:bank_model_s` and `:headroom_s` are MODELLED by `Grappa.IRC.FakeLag`
+    # from bahamut's published `2 + len/120` arithmetic and must never be
+    # quoted as a reading off an ircd. `:command` (the verb, pre-existing)
+    # rides the same line; the parameters deliberately do not.
+    :sent_bytes,
+    :commands_10s,
+    :penalty_10s_s,
+    :bank_model_s,
+    :headroom_s
   ]
 
 import_config "#{config_env()}.exs"

--- a/lib/grappa/irc/client.ex
+++ b/lib/grappa/irc/client.ex
@@ -100,7 +100,7 @@ defmodule Grappa.IRC.Client do
   """
   use GenServer
 
-  alias Grappa.IRC.{AuthFSM, Identifier, Message, Parser}
+  alias Grappa.IRC.{AuthFSM, FakeLag, Identifier, Message, Parser}
 
   require Logger
 
@@ -164,7 +164,11 @@ defmodule Grappa.IRC.Client do
           liveness_idle_ms: pos_integer(),
           liveness_timeout_ms: pos_integer(),
           idle_timer: reference() | nil,
-          ping_timer: reference() | nil
+          ping_timer: reference() | nil,
+          # #800 S7 — what this connection's own outbound traffic would
+          # cost it under bahamut's flood throttle. Diagnostic only:
+          # nothing reads it to make a decision.
+          fake_lag: FakeLag.t()
         }
 
   # `:socket` is intentionally NOT enforced — pre-connect (between `init/1`
@@ -176,7 +180,17 @@ defmodule Grappa.IRC.Client do
   # #100: `liveness_idle_ms` / `liveness_timeout_ms` ARE enforced — they are
   # always resolved in `init/1` and a `nil` would crash `Process.send_after/3`
   # at arm time. Timer refs (`idle_timer` / `ping_timer`) start nil.
-  @enforce_keys [:transport, :dispatch_to, :fsm, :liveness_idle_ms, :liveness_timeout_ms]
+  #
+  # #800 S7: `fake_lag` is enforced for the same reason — `init/1` always
+  # seeds it and a `nil` would crash the accounting on the first frame.
+  @enforce_keys [
+    :transport,
+    :dispatch_to,
+    :fsm,
+    :liveness_idle_ms,
+    :liveness_timeout_ms,
+    :fake_lag
+  ]
   defstruct [
     :socket,
     :transport,
@@ -185,7 +199,8 @@ defmodule Grappa.IRC.Client do
     :liveness_idle_ms,
     :liveness_timeout_ms,
     :idle_timer,
-    :ping_timer
+    :ping_timer,
+    :fake_lag
   ]
 
   # Cluster visitor-auth hotfix: pre-crash throttle when do_connect/5
@@ -995,7 +1010,8 @@ defmodule Grappa.IRC.Client do
           liveness_idle_ms: Map.get(opts, :liveness_idle_ms, @liveness_idle_ms),
           liveness_timeout_ms: Map.get(opts, :liveness_timeout_ms, @liveness_timeout_ms),
           idle_timer: nil,
-          ping_timer: nil
+          ping_timer: nil,
+          fake_lag: FakeLag.new()
         }
 
         {:ok, state, {:continue, {:connect, opts}}}
@@ -1039,10 +1055,10 @@ defmodule Grappa.IRC.Client do
         # would cascade through Session.Server's narrow exit-catch
         # list at session/server.ex:660-677 (U-cluster cleanup
         # 2026-05-17 root cause).
-        Enum.each(sends, &(_ = transport_send(connected, &1)))
+        sent = send_frames(connected, sends)
         # #100 — arm the liveness idle timer now that the socket is up. Every
         # inbound line resets it (arm_idle/1); if it ever elapses we self-PING.
-        {:noreply, arm_idle(%{connected | fsm: fsm})}
+        {:noreply, arm_idle(%{sent | fsm: fsm})}
 
       {:error, reason} ->
         Process.send_after(self(), {:connect_failed_giveup, reason}, @connect_failure_sleep_ms)
@@ -1070,9 +1086,9 @@ defmodule Grappa.IRC.Client do
   # the ping_timer will fire the stop anyway (or a `:tcp_closed` beats it);
   # either way the reconnect chain engages.
   def handle_info(:liveness_idle, state) do
-    _ = transport_send(state, "PING :grappa-liveness\r\n")
+    {_, probed} = send_frame(state, "PING :grappa-liveness\r\n")
     timer = Process.send_after(self(), :liveness_timeout, state.liveness_timeout_ms)
-    {:noreply, %{state | idle_timer: nil, ping_timer: timer}}
+    {:noreply, %{probed | idle_timer: nil, ping_timer: timer}}
   end
 
   # #100 — liveness phase 2: the self-PING went unanswered for the full
@@ -1115,7 +1131,8 @@ defmodule Grappa.IRC.Client do
     # siblings (run 25975442301, 2026-05-17). Returning the honest
     # tuple lets the caller decide (Session.Server.terminate/2
     # discards the result; an interactive caller can retry).
-    {:reply, transport_send(state, ensure_crlf(line)), state}
+    {result, sent} = send_frame(state, ensure_crlf(line))
+    {:reply, result, sent}
   end
 
   # IRC framing requires every line to end with CRLF. The high-level
@@ -1528,16 +1545,16 @@ defmodule Grappa.IRC.Client do
         # because it's a local opt change (no I/O) — it cannot fail
         # for a transport-level reason short of the socket already
         # being gone, in which case the next info-message will stop us.
-        Enum.each(sends, &(_ = transport_send(state, &1)))
+        sent = send_frames(state, sends)
         :ok = transport_setopts(state, active: :once)
-        {:noreply, %{state | fsm: fsm}}
+        {:noreply, %{sent | fsm: fsm}}
 
       {:stop, reason, fsm, sends} ->
         # Same discard rationale; the FSM has already decided to stop
         # so an outbound write failure changes nothing.
-        Enum.each(sends, &(_ = transport_send(state, &1)))
+        sent = send_frames(state, sends)
         log_stop_reason(reason, fsm)
-        {:stop, reason, %{state | fsm: fsm}}
+        {:stop, reason, %{sent | fsm: fsm}}
     end
   end
 
@@ -1599,6 +1616,93 @@ defmodule Grappa.IRC.Client do
 
   defp log_stop_reason({:nick_rejected, code, nick}, _) do
     Logger.error("upstream rejected nick", numeric: code, nick: nick)
+  end
+
+  # #800 S7 — the instrumented outbound choke point. EVERY frame this
+  # process writes goes through here: the registration burst, the
+  # liveness self-PING, the FSM's handshake replies, and the session's
+  # own commands. Accounting only the last of those would under-count the
+  # connection's cost, and an under-count is exactly what would retire
+  # the fake-lag hypothesis for the wrong reason.
+  #
+  # Behaviour is unchanged from the bare `transport_send/2` it wraps:
+  # same bytes, same order, same honest tagged-tuple return. The only
+  # addition is that the caller now threads the updated state back.
+  @spec send_frame(t(), iodata()) :: {send_result(), t()}
+  defp send_frame(state, data) do
+    # A binary in, a binary out — `IO.iodata_to_binary/1` hands a binary
+    # straight back, so this costs nothing on the common path while still
+    # letting an iolist caller be measured by what actually goes on the
+    # wire.
+    frame = IO.iodata_to_binary(data)
+    result = transport_send(state, frame)
+
+    {fake_lag, sample} =
+      FakeLag.record(state.fake_lag, byte_size(frame), System.monotonic_time(:millisecond))
+
+    log_outbound_cost(frame, sample)
+
+    {result, %{state | fake_lag: fake_lag}}
+  end
+
+  # #800 S7 — one line per frame, at DEBUG.
+  #
+  # Level, deliberately: production runs at `:info` (`config/prod.exs`,
+  # `LOG_LEVEL`), so this is silent there and costs only the fold above —
+  # the `Logger.debug/2` macro never evaluates its arguments when the
+  # level is off. The dev/compose stack (which the integration testnet
+  # runs) has no level override and so defaults to `:debug`, which is
+  # where the measurement is taken. A live node can also read the current
+  # bank straight off `:sys.get_state/1` without any log at all.
+  #
+  # `command` is the VERB ONLY. The parameters are the message body on a
+  # PRIVMSG and the base64 credential on an AUTHENTICATE; CLAUDE.md
+  # Security is explicit that what reaches stdout outlives the process.
+  # The byte count is what the model charges for, so it is the number
+  # worth having — not the content.
+  @spec log_outbound_cost(binary(), FakeLag.sample()) :: :ok
+  defp log_outbound_cost(frame, sample) do
+    Logger.debug("upstream send",
+      command: verb(frame),
+      sent_bytes: byte_size(frame),
+      commands_10s: sample.commands_10s,
+      penalty_10s_s: sample.penalty_10s_s,
+      bank_model_s: sample.bank_model_s,
+      headroom_s: sample.headroom_s
+    )
+  end
+
+  @doc false
+  # Test-only seam for the log-line verb extraction. Mirrors
+  # `__tls_connect_opts_for_test__/1` — greppable, absent from public
+  # docs. The emitted line is asserted end-to-end in
+  # `Grappa.IRC.ClientOutboundCostTest`; this lets the async client suite
+  # pin the never-log-the-params rule without touching the global level.
+  @spec __verb_for_test__(binary()) :: binary()
+  def __verb_for_test__(frame), do: verb(frame)
+
+  # Leading token, stripped of its terminator and bounded: a frame is
+  # attacker-influenced only via our own builders, but an unbounded slice
+  # of a 512-byte line in a log field is a needless hostage.
+  @spec verb(binary()) :: binary()
+  defp verb(frame) do
+    frame
+    |> :binary.split([" ", "\r", "\n"])
+    |> hd()
+    |> binary_slice(0, 32)
+  end
+
+  # Fold a batch of frames through the choke point. The write result is
+  # discarded for the same reason the pre-#800 `Enum.each` discarded it:
+  # a peer RST mid-handshake is benign and the recv-loop's `:tcp_closed`
+  # follows; an FSM that has already decided to stop cannot be helped by
+  # a failed write either.
+  @spec send_frames(t(), [iodata()]) :: t()
+  defp send_frames(state, frames) do
+    Enum.reduce(frames, state, fn frame, acc ->
+      {_, acc} = send_frame(acc, frame)
+      acc
+    end)
   end
 
   # Nil-socket guard: connect_failed before socket assignment, or

--- a/lib/grappa/irc/fake_lag.ex
+++ b/lib/grappa/irc/fake_lag.ex
@@ -80,6 +80,30 @@ defmodule Grappa.IRC.FakeLag do
   find convenient would under-count, and an under-count is precisely what
   would kill the hypothesis for the wrong reason.
 
+  ## Why the accounting is UNGATED, and where the gate actually is
+
+  `record/3` runs on **every** outbound frame regardless of log level.
+  That is deliberate, not an oversight — do not "optimise" it behind a
+  flag. Keeping it always-on is what makes the bank readable on a live
+  node with `:sys.get_state/1`, with nothing switched on and nothing
+  restarted; a bank you must first enable is a bank you do not have when
+  the incident is happening. The cost bought with that is a filter over a
+  ten-second window plus a length and a sum, per frame.
+
+  The gate is the **Logger level**, and there is deliberately no second
+  one. Production runs at `:info`, where `Logger.debug/2` never even
+  evaluates its arguments, so the line costs nothing there. An operator
+  who sets `LOG_LEVEL=debug` has already accepted the firehose — Ecto's
+  per-query lines included — and one line per outbound frame is
+  consistent with what they asked for. A dedicated switch would duplicate
+  a gate that already exists, and a mechanism heavier than its problem is
+  the problem.
+
+  Volume, so that decision can be made with a number: one outbound frame
+  is one user message, one PONG roughly every 90 seconds per connection,
+  and the registration burst on each (re)connect. Modest per session;
+  multiply by sessions before enabling debug on a busy node.
+
   Diagnostic instrumentation: it changes nothing about what is sent or
   when. Pure — the caller supplies the clock reading.
   """

--- a/lib/grappa/irc/fake_lag.ex
+++ b/lib/grappa/irc/fake_lag.ex
@@ -119,6 +119,12 @@ defmodule Grappa.IRC.FakeLag do
 
   @doc "A connection that has sent nothing yet."
   @spec new() :: t()
+  # Dialyzer flags the t() supertype (success typing infers the singleton
+  # `since_ms: nil, window: []`). Keep t(): the result is stored in a
+  # `Grappa.IRC.Client` state field typed as t(), and narrowing here would
+  # propagate a narrower-than-useful type upstream. Same call as
+  # `Grappa.Session.AwayState.new/0`.
+  @dialyzer {:nowarn_function, new: 0}
   def new, do: %__MODULE__{}
 
   @doc """
@@ -156,7 +162,9 @@ defmodule Grappa.IRC.FakeLag do
   @spec prune([{integer(), pos_integer()}], integer()) :: [{integer(), pos_integer()}]
   defp prune(window, now_ms), do: Enum.filter(window, fn {at, _} -> now_ms - at <= @window_ms end)
 
-  @spec sample([{integer(), pos_integer()}], integer(), integer()) :: sample()
+  # Non-empty by construction: the frame being recorded is prepended
+  # before the sample is taken, so there is always at least one entry.
+  @spec sample([{integer(), pos_integer()}, ...], integer(), integer()) :: sample()
   defp sample(window, since_ms, now_ms) do
     penalty_ms = Enum.reduce(window, 0, fn {_, cost}, acc -> acc + cost end)
     bank_s = to_s(since_ms - now_ms)

--- a/lib/grappa/irc/fake_lag.ex
+++ b/lib/grappa/irc/fake_lag.ex
@@ -1,0 +1,178 @@
+defmodule Grappa.IRC.FakeLag do
+  @moduledoc """
+  #800 S7 — what our own outbound traffic would cost us under an ircd's
+  flood throttle, computed from the frames we actually send.
+
+  ## Why this exists
+
+  #800 measured that one extra command on the upstream connection delays
+  the operator's *next* message by seconds (`nick-follow-query`: 2.7s
+  baseline → 6.7s and a timeout once the rail issued a speculative
+  WHOIS). #805 removed that command, and the rule it established — a pane
+  may not spend a budget it cannot see — rests on that displacement result
+  alone.
+
+  What stayed open is WHERE those seconds are spent. The leading
+  hypothesis is bahamut's fake lag: every command advances a per-client
+  `since` clock by `2 + len/120` seconds, and the server stops draining
+  that client's recvQ while `since - now >= 10`
+  (`parse.c:236`, `s_bsd.c:1657`). **That hypothesis comes from reading
+  bahamut's source. Nobody has instrumented a running ircd.** Re-reading
+  the source cannot close it.
+
+  This module closes the half of it that lives on OUR side of the socket:
+  it makes the bank a number grappa observes about itself, per frame, on a
+  live connection. If the modelled bank sits near zero at the moment a
+  send is measurably delayed, fake lag is dead as an explanation without
+  anyone having to touch the ircd.
+
+  ## Measured vs modelled — read the fields accordingly
+
+    * **Measured** — `commands_10s` and the per-frame byte count: what
+      grappa put on the wire, and when. Facts about this process.
+    * **Modelled** — `penalty_10s_s`, `bank_model_s` and `headroom_s`:
+      what bahamut's published arithmetic WOULD charge for those frames,
+      and how far that leaves us from the drain gate. A model of a remote
+      server, evaluated locally. It is not a reading off the ircd and must
+      never be quoted as one.
+
+  Two numbers are reported, not one, because they answer two different
+  questions. `bank_model_s` says how much debt this connection carries;
+  `headroom_s` (`10 − bank`) says how close that debt is to the point
+  where the server stops reading us. A large bank with ample headroom is
+  not the same finding as a bank pressed against the gate, and #800's
+  claim — that the cost only bites on a connection already near the
+  ceiling after hundreds of preceding specs — is a claim about the SECOND
+  number. It has never been measured. Note that `since` is compared
+  against wall-clock `now`, so the bank drains in real time and cannot
+  accumulate across a 25-minute run; whether that is what actually
+  happens is what these numbers report.
+
+  Because `Grappa.IRC.Client` logs every frame's verb and byte count
+  alongside the aggregate, a reader who thinks the model charges the
+  wrong thing (bahamut may exempt `PONG`; opers are exempt outright) can
+  re-derive the bank from the raw lines rather than trust this arithmetic.
+
+  ## The arithmetic
+
+  `cost = 2 + div(bytes, 120)` seconds — **integer** division, mirroring
+  the C. A 64-byte PRIVMSG and a 119-byte one cost the same flat 2s; the
+  step to 3s lands at 120 bytes. `bytes` is the frame as written to the
+  socket, CRLF included, which can only differ from what bahamut counts
+  within two bytes of a 120-byte boundary.
+
+  The bank advances `since = max(since, now) + cost`, so idling drains it
+  and it never goes negative: a connection quiet for longer than its debt
+  starts the next command from the flat floor.
+
+  **Known divergence, above the gate.** This model advances the bank when
+  *we write*; bahamut advances it when *it parses*, and past the gate it
+  stops parsing, so the real bank saturates near the ceiling while ours
+  keeps climbing. A modelled bank far above ten therefore reads as "we
+  wrote considerably more than the server could drain" — a strong signal,
+  but not a literal server-side figure. Below the gate the two track.
+
+  ## Scope
+
+  Per-connection, in-process, driven by `Grappa.IRC.Client`'s outbound
+  choke point — so the registration burst, liveness PINGs and PONGs count
+  too, not just session-issued commands. A model fed only the commands we
+  find convenient would under-count, and an under-count is precisely what
+  would kill the hypothesis for the wrong reason.
+
+  Diagnostic instrumentation: it changes nothing about what is sent or
+  when. Pure — the caller supplies the clock reading.
+  """
+
+  # The recvQ-drain gate bahamut applies is `since - now < 10` seconds, so
+  # ten seconds is the horizon over which past commands can still be
+  # holding the connection back. Anything older cannot be part of the
+  # explanation for a send that is slow right now.
+  @window_ms 10_000
+
+  # The same ten seconds seen as a ceiling: at or past it, bahamut stops
+  # draining our recvQ, which is the moment a queued command starts
+  # waiting on the clock instead of on the server.
+  @ceiling_s 10.0
+
+  # `2 + len/120` from parse.c, in the C's own integer arithmetic.
+  @flat_cost_s 2
+  @bytes_per_second 120
+
+  @type sample :: %{
+          commands_10s: non_neg_integer(),
+          penalty_10s_s: float(),
+          bank_model_s: float(),
+          headroom_s: float(),
+          ceiling_s: float()
+        }
+
+  @typedoc """
+  `since_ms` is the modelled bank clock — `nil` until the first frame, so
+  a fresh connection cannot inherit a phantom debt. `window` holds
+  `{sent_at_ms, cost_ms}` newest-first, pruned to `@window_ms` on every
+  record, which is what bounds it on a long-lived connection.
+  """
+  @type t :: %__MODULE__{since_ms: integer() | nil, window: [{integer(), pos_integer()}]}
+
+  defstruct since_ms: nil, window: []
+
+  @doc "A connection that has sent nothing yet."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc """
+  Account for one outbound frame of `bytes` sent at `now_ms`, and return
+  the updated state plus the sample to report.
+
+  `now_ms` is a monotonic-clock reading in milliseconds — it may be
+  negative, and only differences between readings are meaningful.
+
+  Accepts a zero-byte frame rather than guarding it out: this runs on the
+  session's only outbound path, and instrumentation that can raise there
+  would take a live IRC connection down over a diagnostic.
+  """
+  @spec record(t(), non_neg_integer(), integer()) :: {t(), sample()}
+  def record(%__MODULE__{} = state, bytes, now_ms)
+      when is_integer(bytes) and bytes >= 0 and is_integer(now_ms) do
+    cost_ms = cost_ms(bytes)
+    since_ms = bank_base(state.since_ms, now_ms) + cost_ms
+    window = [{now_ms, cost_ms} | prune(state.window, now_ms)]
+
+    {%__MODULE__{since_ms: since_ms, window: window}, sample(window, since_ms, now_ms)}
+  end
+
+  # Two clauses rather than `max(since_ms || now_ms, now_ms)`: in Erlang's
+  # term order every integer sorts BELOW `nil`, so a `max/2` over a nil
+  # bank would quietly return `nil` and poison the arithmetic downstream
+  # (the `feedback_monotonic_guard_nil_term_order_footgun` trap).
+  @spec bank_base(integer() | nil, integer()) :: integer()
+  defp bank_base(nil, now_ms), do: now_ms
+  defp bank_base(since_ms, now_ms) when is_integer(since_ms), do: max(since_ms, now_ms)
+
+  @spec cost_ms(pos_integer()) :: pos_integer()
+  defp cost_ms(bytes), do: (@flat_cost_s + div(bytes, @bytes_per_second)) * 1_000
+
+  @spec prune([{integer(), pos_integer()}], integer()) :: [{integer(), pos_integer()}]
+  defp prune(window, now_ms), do: Enum.filter(window, fn {at, _} -> now_ms - at <= @window_ms end)
+
+  @spec sample([{integer(), pos_integer()}], integer(), integer()) :: sample()
+  defp sample(window, since_ms, now_ms) do
+    penalty_ms = Enum.reduce(window, 0, fn {_, cost}, acc -> acc + cost end)
+    bank_s = to_s(since_ms - now_ms)
+
+    %{
+      commands_10s: length(window),
+      penalty_10s_s: to_s(penalty_ms),
+      bank_model_s: bank_s,
+      # Goes NEGATIVE past the gate rather than clamping at zero: the
+      # command that crosses it is still parsed, and "how far over" is
+      # the interesting number once we are over.
+      headroom_s: @ceiling_s - bank_s,
+      ceiling_s: @ceiling_s
+    }
+  end
+
+  @spec to_s(integer()) :: float()
+  defp to_s(ms), do: ms / 1_000
+end

--- a/test/grappa/irc/client_outbound_cost_test.exs
+++ b/test/grappa/irc/client_outbound_cost_test.exs
@@ -49,6 +49,22 @@ defmodule Grappa.IRC.ClientOutboundCostTest do
     {server, client}
   end
 
+  # The oracle (the fake server received the frame) fires BEFORE the log
+  # line exists: `send_frame/2` writes to the socket first and accounts
+  # afterwards, so the server can be woken while the client is still
+  # between the two. Waiting on the server alone reads the log a moment
+  # too early — the same shape of bug as the one being instrumented here.
+  #
+  # Two real barriers, no sleep and no retry:
+  #   * `:sys.get_state/2` is a GenServer call, so it can only be answered
+  #     once the callback that wrote the frame has RETURNED — by which
+  #     time that callback's `Logger.debug` has run.
+  #   * `Logger.flush/0` then drains the handler queue into the capture.
+  defp settle(client) do
+    _ = :sys.get_state(client, 1_000)
+    Logger.flush()
+  end
+
   test "reports the modelled bank AND the distance from the drain gate" do
     # Two numbers, not one. #800 claims the cost bites only on a
     # connection already near the ceiling — that is a claim about the
@@ -59,6 +75,7 @@ defmodule Grappa.IRC.ClientOutboundCostTest do
       capture_log(fn ->
         :ok = Client.send_line(client, "PING :probe\r\n")
         {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "PING :probe\r\n"), 1_000)
+        settle(client)
       end)
 
     assert log =~ "upstream send"
@@ -77,8 +94,9 @@ defmodule Grappa.IRC.ClientOutboundCostTest do
     # fake-lag hypothesis for the wrong reason.
     log =
       capture_log(fn ->
-        {server, _} = start_pair()
+        {server, client} = start_pair()
         {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER "), 1_000)
+        settle(client)
       end)
 
     assert log =~ "command=NICK"
@@ -92,6 +110,7 @@ defmodule Grappa.IRC.ClientOutboundCostTest do
       capture_log(fn ->
         :ok = Client.send_line(client, "PRIVMSG #chan :sensitive body\r\n")
         {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "PRIVMSG"), 1_000)
+        settle(client)
       end)
 
     assert log =~ "command=PRIVMSG"

--- a/test/grappa/irc/client_outbound_cost_test.exs
+++ b/test/grappa/irc/client_outbound_cost_test.exs
@@ -1,0 +1,101 @@
+defmodule Grappa.IRC.ClientOutboundCostTest do
+  @moduledoc """
+  #800 S7 — the per-frame outbound-cost line `Grappa.IRC.Client` emits.
+
+  This is the diagnostic's only user-visible surface: the measurement is
+  taken by reading these lines off a running stack, so a missing field is
+  the whole instrument failing silently. It notably pins the
+  `config/config.exs` `:metadata` allowlist — a key that is not listed is
+  dropped at FORMAT time, which means the code looks right, the test
+  looks right, and the operator gets a blank line.
+
+  `async: false` because it lowers the global Logger level to observe a
+  :debug line (the test env runs at :warning) — same rationale as
+  `Grappa.Accounts.SessionLogHygieneTest`. It lives apart from
+  `Grappa.IRC.ClientTest` for exactly that reason: that suite is
+  `async: true` and must stay that way.
+  """
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Grappa.IRC.Client
+  alias Grappa.IRCServer
+
+  setup do
+    original = Logger.level()
+    Logger.configure(level: :debug)
+    on_exit(fn -> Logger.configure(level: original) end)
+    :ok
+  end
+
+  defp start_pair do
+    {:ok, server} = IRCServer.start_link(fn state, _ -> {:reply, nil, state} end)
+
+    {:ok, client} =
+      Client.start_link(%{
+        host: "127.0.0.1",
+        port: IRCServer.port(server),
+        tls: false,
+        dispatch_to: self(),
+        logger_metadata: [],
+        nick: "grappa-test",
+        ident: "grappa-test",
+        realname: "grappa-test",
+        sasl_user: "grappa-test",
+        auth_method: :none
+      })
+
+    {server, client}
+  end
+
+  test "reports the modelled bank AND the distance from the drain gate" do
+    # Two numbers, not one. #800 claims the cost bites only on a
+    # connection already near the ceiling — that is a claim about the
+    # HEADROOM, and a bank printed on its own cannot settle it either way.
+    {server, client} = start_pair()
+
+    log =
+      capture_log(fn ->
+        :ok = Client.send_line(client, "PING :probe\r\n")
+        {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "PING :probe\r\n"), 1_000)
+      end)
+
+    assert log =~ "upstream send"
+    assert log =~ "command=PING"
+    assert log =~ "sent_bytes=13"
+    assert log =~ "commands_10s="
+    assert log =~ "penalty_10s_s="
+    assert log =~ "bank_model_s="
+    assert log =~ "headroom_s="
+  end
+
+  test "counts the handshake frames too, so the bank is not read off a fresh slate" do
+    # The registration burst is on the same connection and costs the same
+    # bank. A model that starts counting at the session's first command
+    # would under-report, and an under-report is what would retire the
+    # fake-lag hypothesis for the wrong reason.
+    log =
+      capture_log(fn ->
+        {server, _} = start_pair()
+        {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER "), 1_000)
+      end)
+
+    assert log =~ "command=NICK"
+    assert log =~ "command=USER"
+  end
+
+  test "never puts the parameters of a frame on the log line" do
+    {server, client} = start_pair()
+
+    log =
+      capture_log(fn ->
+        :ok = Client.send_line(client, "PRIVMSG #chan :sensitive body\r\n")
+        {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "PRIVMSG"), 1_000)
+      end)
+
+    assert log =~ "command=PRIVMSG"
+    refute log =~ "sensitive body"
+    refute log =~ "#chan"
+  end
+end

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -20,7 +20,7 @@ defmodule Grappa.IRC.ClientTest do
 
   import ExUnit.CaptureLog
 
-  alias Grappa.IRC.{Client, Message}
+  alias Grappa.IRC.{Client, FakeLag, Message}
   alias Grappa.IRCServer
 
   # Default handler: ignore everything; tests that need scripted replies
@@ -2171,6 +2171,40 @@ defmodule Grappa.IRC.ClientTest do
 
       # Every leaf in the set was attempted before give-up.
       assert :counters.get(attempts, 1) == length(@azzurra_aaaa)
+    end
+  end
+
+  describe "outbound cost accounting (#800 S7)" do
+    test "accounts every frame the server receives, registration burst included" do
+      # A bank fed only by session-issued commands would under-count, and
+      # an under-count is what would kill the fake-lag hypothesis for the
+      # wrong reason. The fake server's own tally is the oracle: whatever
+      # it received is what the model must have charged for.
+      {server, port} = start_server(rfc_handler())
+      client = start_client(port)
+      :ok = await_handshake(server)
+
+      :ok = Client.send_line(client, "PING :probe\r\n")
+      {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "PING :probe\r\n"), 1_000)
+
+      %Client{fake_lag: %FakeLag{window: window}} = :sys.get_state(client, 1_000)
+
+      assert length(window) == length(IRCServer.sent_lines(server))
+      # Guard against the oracle and the model agreeing on nothing: the
+      # handshake alone puts several frames on the wire before the probe.
+      assert length(window) > 1
+    end
+
+    test "reports the verb alone, so a PRIVMSG body never reaches the log" do
+      # The line carries a byte count and a verb by design: a PRIVMSG's
+      # params are the message body and an AUTHENTICATE's are a base64
+      # credential, and CLAUDE.md Security is explicit that what reaches
+      # stdout outlives the process. The emitted line itself is covered by
+      # `Grappa.IRC.ClientOutboundCostTest` (async: false — it lowers the
+      # global log level); this pins the extraction that feeds it.
+      assert Client.__verb_for_test__("PRIVMSG #chan :sensitive body\r\n") == "PRIVMSG"
+      assert Client.__verb_for_test__("QUIT\r\n") == "QUIT"
+      assert Client.__verb_for_test__("AUTHENTICATE dXNlcgBwYXNz\r\n") == "AUTHENTICATE"
     end
   end
 end

--- a/test/grappa/irc/fake_lag_test.exs
+++ b/test/grappa/irc/fake_lag_test.exs
@@ -32,25 +32,22 @@ defmodule Grappa.IRC.FakeLagTest do
     end
 
     test "back-to-back commands stack, so a burst is what runs the bank up" do
-      state = FakeLag.new()
-      {state, _} = FakeLag.record(state, 64, @t0)
-      {_, sample} = FakeLag.record(state, 64, @t0)
+      {after_first, _} = FakeLag.record(FakeLag.new(), 64, @t0)
+      {_, sample} = FakeLag.record(after_first, 64, @t0)
 
       assert sample.bank_model_s == 4.0
     end
 
     test "wall-clock time between commands drains the bank" do
-      state = FakeLag.new()
-      {state, _} = FakeLag.record(state, 64, @t0)
-      {_, sample} = FakeLag.record(state, 64, @t0 + 1_500)
+      {after_first, _} = FakeLag.record(FakeLag.new(), 64, @t0)
+      {_, sample} = FakeLag.record(after_first, 64, @t0 + 1_500)
 
       assert sample.bank_model_s == 2.5
     end
 
     test "an idle gap longer than the bank clears it — no debt carries over" do
-      state = FakeLag.new()
-      {state, _} = FakeLag.record(state, 64, @t0)
-      {_, sample} = FakeLag.record(state, 64, @t0 + 9_000)
+      {after_first, _} = FakeLag.record(FakeLag.new(), 64, @t0)
+      {_, sample} = FakeLag.record(after_first, 64, @t0 + 9_000)
 
       assert sample.bank_model_s == 2.0
     end
@@ -122,18 +119,16 @@ defmodule Grappa.IRC.FakeLagTest do
     end
 
     test "keeps a command that is exactly ten seconds old" do
-      state = FakeLag.new()
-      {state, _} = FakeLag.record(state, 64, @t0)
-      {_, sample} = FakeLag.record(state, 64, @t0 + 10_000)
+      {after_first, _} = FakeLag.record(FakeLag.new(), 64, @t0)
+      {_, sample} = FakeLag.record(after_first, 64, @t0 + 10_000)
 
       assert sample.commands_10s == 2
       assert sample.penalty_10s_s == 4.0
     end
 
     test "drops a command that has aged out of the window" do
-      state = FakeLag.new()
-      {state, _} = FakeLag.record(state, 64, @t0)
-      {_, sample} = FakeLag.record(state, 64, @t0 + 10_001)
+      {after_first, _} = FakeLag.record(FakeLag.new(), 64, @t0)
+      {_, sample} = FakeLag.record(after_first, 64, @t0 + 10_001)
 
       assert sample.commands_10s == 1
       assert sample.penalty_10s_s == 2.0

--- a/test/grappa/irc/fake_lag_test.exs
+++ b/test/grappa/irc/fake_lag_test.exs
@@ -1,0 +1,154 @@
+defmodule Grappa.IRC.FakeLagTest do
+  @moduledoc """
+  #800 S7 — unit tests for the outbound-cost model.
+
+  These pin the ARITHMETIC of the model, not the ircd. Whether bahamut
+  actually charges what `FakeLag` models is exactly the open question the
+  instrumentation exists to answer; see the module's own boundary note.
+  """
+  use ExUnit.Case, async: true
+
+  alias Grappa.IRC.FakeLag
+
+  # A monotonic-clock reading is an arbitrary integer that may be negative
+  # (`System.monotonic_time/1` starts wherever the VM says). Anchoring the
+  # tests at a negative origin keeps a `nil`/zero sentinel from ever
+  # passing by accident.
+  @t0 -1_000_000
+
+  describe "record/3 — the modelled bank" do
+    test "one short command banks bahamut's flat two-second floor" do
+      {_, sample} = FakeLag.record(FakeLag.new(), 64, @t0)
+
+      assert sample.bank_model_s == 2.0
+    end
+
+    test "cost grows a second per WHOLE 120 bytes — integer division, as in C" do
+      {_, at_239} = FakeLag.record(FakeLag.new(), 239, @t0)
+      {_, at_240} = FakeLag.record(FakeLag.new(), 240, @t0)
+
+      assert at_239.bank_model_s == 3.0
+      assert at_240.bank_model_s == 4.0
+    end
+
+    test "back-to-back commands stack, so a burst is what runs the bank up" do
+      state = FakeLag.new()
+      {state, _} = FakeLag.record(state, 64, @t0)
+      {_, sample} = FakeLag.record(state, 64, @t0)
+
+      assert sample.bank_model_s == 4.0
+    end
+
+    test "wall-clock time between commands drains the bank" do
+      state = FakeLag.new()
+      {state, _} = FakeLag.record(state, 64, @t0)
+      {_, sample} = FakeLag.record(state, 64, @t0 + 1_500)
+
+      assert sample.bank_model_s == 2.5
+    end
+
+    test "an idle gap longer than the bank clears it — no debt carries over" do
+      state = FakeLag.new()
+      {state, _} = FakeLag.record(state, 64, @t0)
+      {_, sample} = FakeLag.record(state, 64, @t0 + 9_000)
+
+      assert sample.bank_model_s == 2.0
+    end
+  end
+
+  describe "record/3 — distance from the drain gate" do
+    test "reports headroom against the ceiling, not just the bank" do
+      {_, sample} = FakeLag.record(FakeLag.new(), 64, @t0)
+
+      assert sample.ceiling_s == 10.0
+      assert sample.headroom_s == 8.0
+    end
+
+    test "headroom goes negative past the gate rather than clamping" do
+      state =
+        Enum.reduce(1..6, FakeLag.new(), fn _, acc ->
+          {acc, _} = FakeLag.record(acc, 64, @t0)
+          acc
+        end)
+
+      {_, sample} = FakeLag.record(state, 64, @t0)
+
+      assert sample.bank_model_s == 14.0
+      assert sample.headroom_s == -4.0
+    end
+
+    test "traffic paced slower than its own cost never builds a bank" do
+      # The #800 text claims the cost bites only on a connection that has
+      # accumulated debt over hundreds of preceding specs. `since` is
+      # compared against wall-clock `now`, so it drains in real time: 25
+      # minutes of one-command-per-three-seconds leaves the floor, not a
+      # ceiling. Pinned here because it is arithmetic, not a measurement —
+      # what a real run does is what the instrumentation reports.
+      state =
+        Enum.reduce(0..499, FakeLag.new(), fn i, acc ->
+          {acc, _} = FakeLag.record(acc, 64, @t0 + i * 3_000)
+          acc
+        end)
+
+      {_, sample} = FakeLag.record(state, 64, @t0 + 500 * 3_000)
+
+      assert sample.bank_model_s == 2.0
+    end
+
+    test "a sustained burst runs the MODEL past the gate — a known divergence" do
+      # The model advances the bank when WE write; bahamut advances it
+      # when IT parses, and past the gate it stops parsing, so the real
+      # bank saturates near the ceiling while ours keeps climbing. A
+      # modelled bank far above 10 therefore reads as "we wrote much more
+      # than the server could drain", NOT as a literal server-side figure.
+      state =
+        Enum.reduce(0..99, FakeLag.new(), fn i, acc ->
+          {acc, _} = FakeLag.record(acc, 64, @t0 + i * 100)
+          acc
+        end)
+
+      {_, sample} = FakeLag.record(state, 64, @t0 + 10_000)
+
+      assert sample.bank_model_s > 100.0
+    end
+  end
+
+  describe "record/3 — the observed 10s window" do
+    test "counts the command being recorded" do
+      {_, sample} = FakeLag.record(FakeLag.new(), 64, @t0)
+
+      assert sample.commands_10s == 1
+      assert sample.penalty_10s_s == 2.0
+    end
+
+    test "keeps a command that is exactly ten seconds old" do
+      state = FakeLag.new()
+      {state, _} = FakeLag.record(state, 64, @t0)
+      {_, sample} = FakeLag.record(state, 64, @t0 + 10_000)
+
+      assert sample.commands_10s == 2
+      assert sample.penalty_10s_s == 4.0
+    end
+
+    test "drops a command that has aged out of the window" do
+      state = FakeLag.new()
+      {state, _} = FakeLag.record(state, 64, @t0)
+      {_, sample} = FakeLag.record(state, 64, @t0 + 10_001)
+
+      assert sample.commands_10s == 1
+      assert sample.penalty_10s_s == 2.0
+    end
+
+    test "the window does not grow without bound as an idle connection ticks" do
+      state =
+        Enum.reduce(0..200, FakeLag.new(), fn i, acc ->
+          {acc, _} = FakeLag.record(acc, 64, @t0 + i * 1_000)
+          acc
+        end)
+
+      {_, sample} = FakeLag.record(state, 64, @t0 + 201_000)
+
+      assert sample.commands_10s == 11
+    end
+  end
+end


### PR DESCRIPTION
S7 of the #800 plan. **Instrumentation, not a fix.** Nothing about what
grappa sends, or when, changes.

## The point

#805's rule stands on the displacement result and needs no ircd-internal
mechanism. What is still open is WHERE the seconds go, and the leading
answer — bahamut's fake lag, `since += 2 + len/120`, recvQ drain gated on
`since - now < 10` (`parse.c:236`, `s_bsd.c:1657`) — has only ever been
**read in C**. Twice this cycle an inference from that source was stated
as fact and had to be retracted. A third reading cannot close it.

This closes the half that lives on our side of the socket: the bank
becomes a number grappa observes about itself, per frame, on a live
connection.

## What it emits

One `[debug]` line per outbound frame:

```
command=NICK sent_bytes=18 commands_10s=1 penalty_10s_s=2.0 bank_model_s=2.0 headroom_s=8.0 [debug] upstream send
command=USER sent_bytes=35 commands_10s=2 penalty_10s_s=4.0 bank_model_s=4.0 headroom_s=6.0 [debug] upstream send
command=PING sent_bytes=13 commands_10s=3 penalty_10s_s=6.0 bank_model_s=6.0 headroom_s=4.0 [debug] upstream send
```

**Per send, not aggregated** — the bank at the moment of *that* frame, so
a slow iteration and a fast one can be compared line by line on the same
run without any post-processing.

**Two numbers, not one.** #800 claims the cost bites only on a connection
already near the ceiling; that is a claim about `headroom_s`, and a bank
printed alone cannot settle it either way.

## Measured vs modelled — the boundary is in the field names

| field | kind |
|---|---|
| `sent_bytes`, `commands_10s` | **MEASURED** — what this process put on the wire, and how much of it is still inside the ten-second horizon |
| `penalty_10s_s`, `bank_model_s`, `headroom_s` | **MODELLED** — bahamut's published arithmetic evaluated locally |

The modelled fields are **not** a reading off an ircd and must never be
quoted as one. Because every line also carries the raw verb and byte
count, a reader who thinks the model charges the wrong thing (bahamut may
well exempt `PONG`; opers are exempt outright) can re-derive the bank
from the raw lines instead of trusting the arithmetic.

## Two limits, written down rather than discovered later

* **Above the gate the model diverges.** It advances the bank when *we
  write*; bahamut advances it when *it parses*, and past the gate it
  stops parsing — so the real bank saturates near the ceiling while ours
  keeps climbing. A modelled bank far above 10 reads as "we wrote much
  more than the server could drain", not as a server-side figure. Below
  the gate the two track. Pinned by a test.
* **The parameters of a frame are never logged.** A PRIVMSG's params are
  the message body and an AUTHENTICATE's are a base64 credential. The
  verb and the byte count are what the model needs; the content is not.
  Pinned by two tests.

## Where the accounting hooks in

At the transport choke point, so the registration burst, the liveness
self-PING and the FSM's handshake replies count too — not only
session-issued commands. A bank fed just the commands convenient to count
would under-report, and **an under-report is exactly what would retire
the hypothesis for the wrong reason**. The brief scoped this to
`handle_call({:send, _})`; widening it is deliberate and is the one place
this PR exceeds the brief.

The fake IRC server's own tally is the oracle: a test asserts the model
charged for exactly the frames the server received.

## Cost, and where you read it

`Logger.debug/2` never evaluates its arguments when the level is off, and
production runs at `:info` — so prod is silent and pays only the fold.
The dev/compose stack the integration testnet runs has no level override
and defaults to `:debug`, which is where the measurement gets taken.
`LOG_LEVEL=debug` turns it on anywhere else. A live node can also read
the current bank straight off `:sys.get_state/1` with no log at all.

## Pre-registered verdicts (agreed before any number existed)

* **Bank near the ceiling when the spec fails** ⇒ fake lag confirmed as
  the mechanism; the fix is scheduling in `IRC.Client` (user-originated
  ahead of speculative — the `source: "rail" | "user"` tag from #606
  already exists, so no new wire field is needed).
* **Bank far from the ceiling** ⇒ the accumulation story falls, and #800
  needs correcting: it contains an assertion nobody has measured. This is
  the more valuable outcome of the two.
* **Same bank across a fast and a slow iteration of the same run** ⇒ fake
  lag is exonerated outright and the cause is elsewhere. The shape
  already argues for this — 28ms / 3024ms / 4989ms with the WHOIS present
  in all three, and arrivals clustering at 3031 / 6066 (≈2×3033) / 5002 /
  5010 ms, look like thresholds, not a bucket draining.

### The two outcomes do NOT weigh the same

Written down here **before** any number exists, because it is exactly the
kind of thing that gets forgotten once a table is on the screen. It
follows from the measured/modelled split above: the bank is bahamut's
arithmetic **re-evaluated by us, locally**. It is not the ircd's bank.

* **Bank far from the ceiling ⇒ STRONG falsification.** Even bahamut's
  own formula, borrowed and evaluated against the real frames, fails to
  predict a throttle. The hypothesis dies on its own terms. This verdict
  is solid and needs nothing further.
* **Bank near the ceiling ⇒ WEAK confirmation.** It shows that *our
  model* predicts a throttle, not that the ircd applied one. That is
  still a reading of the source — merely executed instead of read.

So the near-the-ceiling case closes nothing by itself. Settling it means
asking the ircd rather than our copy of its maths: **S8** — send a PING
immediately after the PRIVMSG and time the PONG on grappa's own socket.
Not built here; recorded so whoever reads these numbers in a month finds
how much they weigh sitting next to them.

## Tests

`test/grappa/irc/fake_lag_test.exs` (13, pure) — the cost floor, integer
division at the 120-byte step, stacking, real-time drain, the 10s window
boundary at 9999/10000/10001 ms, bounded growth, headroom, and the
above-the-gate divergence. Includes the arithmetic half of w1's
objection: 500 commands paced at 3s apart leave the bank at the floor, so
`since` cannot accumulate across a 25-minute run.

`test/grappa/irc/client_outbound_cost_test.exs` (3, `async: false` —
lowers the global log level, per the `SessionLogHygieneTest` precedent).

`client_test.exs` — the oracle test plus the verb-extraction seam.

**Mutation-proven, 2/2 killed:**
* dropping `:headroom_s` from the `config/config.exs` allowlist → the log
  test fails. That allowlist is a real silent-failure mode: an unlisted
  key is discarded at FORMAT time, so the code looks right and the
  operator gets a blank field.
* reverting the choke point to account only session sends → the oracle
  test fails 1 vs 3, and the handshake test fails.

## Gates

`scripts/check.sh` — **rc=0**. 8 doctests, 50 properties, **5081 tests, 0
failures**; 262 bats ok, none failing. Format, Credo strict, Dialyzer
(`:underspecs`), Sobelow, deps.audit all clean.

Integration/e2e **not run** — the STACK lane is not mine. The measurement
itself is the next step and needs that lane.

Related: #800 (evidence), #805 (the rule), #782 (the button), #802 (the
cache).
