### PR TITLE
cic(#782): ask for the rail WHOIS when the card is on screen

### DIFF
--- a/cicchetto/e2e/fixtures/ircClient.ts
+++ b/cicchetto/e2e/fixtures/ircClient.ts
@@ -35,6 +35,27 @@ const KICK_TIMEOUT_MS = 5_000;
 // echo arrives — so 15s is headroom above bahamut's ~10s fake-lag bank cap,
 // matching the #23/#220 topic asserts, NOT a fixed sleep.
 const TOPIC_TIMEOUT_MS = 15_000;
+// #806 defect 3 — an inbound PRIVMSG is the OTHER wait exposed to the same
+// fake-lag class as TOPIC above, and it had no budget of its own: it borrowed
+// `NICK_TIMEOUT_MS`, a constant sized for a NICK echo, purely because
+// `waitForPrivmsg` was written next to `changeNick`. Of the seven specs that
+// block on grappa-originated traffic this was the only one at 5s, and not by
+// anyone's decision.
+//
+// Measured 2026-08-04 (#807's per-send accounting, live testnet): with the
+// bank empty the message arrives in 26-28ms; with it full, at 3024ms and
+// 4989ms — the second inside 5s by eleven milliseconds. The delay is the
+// bank's overshoot, so it is bounded by the ~10s cap, exactly the bound
+// TOPIC_TIMEOUT_MS is already sized against. 15s clears that ceiling and
+// matches the budget the sibling upstream-waiting specs (issue536, issue386)
+// already use.
+//
+// Same shape as TOPIC_TIMEOUT_MS and NOT a timeout raised to bury a red: this
+// is a condition-wait that resolves the instant the message lands, so a
+// genuine routing regression (#373's stale-nick 401 — nothing arrives, ever)
+// still fails, just 10s later. What it stops doing is failing when the
+// message is merely queued behind the harness's own reconnect burst.
+const PRIVMSG_TIMEOUT_MS = 15_000;
 const OPER_TIMEOUT_MS = 5_000;
 const NICKSERV_TIMEOUT_MS = 5_000;
 const AWAY_TIMEOUT_MS = 5_000;
@@ -166,7 +187,7 @@ export class IrcPeer {
       "privmsg",
       (event: { nick: string; message: string }) =>
         event.nick === fromNick && event.message.includes(body),
-      NICK_TIMEOUT_MS,
+      PRIVMSG_TIMEOUT_MS,
       `privmsg from ${fromNick} containing "${body}"`,
     );
   }

--- a/cicchetto/src/RailContext.tsx
+++ b/cicchetto/src/RailContext.tsx
@@ -17,9 +17,9 @@ import WhoisCard from "./WhoisCard";
 //              single-slot `whoisCard` store the user-issued /whois owns) and
 //              carries no × affordance (persistent, like the server card).
 //              It RENDERS what is known and asks for nothing — #800 removed
-//              the fetch-on-select, because cic cannot see the upstream
-//              fake-lag budget a WHOIS spends and was charging it to the
-//              operator's next PRIVMSG. The cache fills from the user's own
+//              the fetch-on-select, because that WHOIS measurably delayed the
+//              operator's next message and cic cannot see the upstream cost it
+//              was spending. The cache fills from the user's own
 //              /whois (#606 routes a `source: user` bundle for the shown nick
 //              here); #782 adds the explicit fetch control.
 // It renders NOTHING for kinds with no context content (channel already has

--- a/cicchetto/src/RailContext.tsx
+++ b/cicchetto/src/RailContext.tsx
@@ -1,15 +1,6 @@
-import {
-  type Component,
-  createEffect,
-  createSignal,
-  Match,
-  on,
-  onCleanup,
-  Show,
-  Switch,
-} from "solid-js";
+import { type Component, createSignal, Match, onCleanup, Show, Switch } from "solid-js";
 import { networkBySlug } from "./lib/networks";
-import { railWhoisFor, requestRailWhois } from "./lib/railWhois";
+import { railWhoisFor } from "./lib/railWhois";
 import { selectedChannel } from "./lib/selection";
 import ServerInfoCard from "./ServerInfoCard";
 import WhoisCard from "./WhoisCard";
@@ -20,12 +11,17 @@ import WhoisCard from "./WhoisCard";
 // grafts the matching context content:
 //   * server → ServerInfoCard (connection facts already in the store)
 //   * query  → the query context (#606, the deferred half of #474): a
-//              heading + a WHOIS card for the conversation partner,
-//              auto-fetched on select. The card REUSES the same `WhoisCard`
-//              presentation as the scrollback overlay but is fed by the
-//              per-nick `railWhois` cache (NOT the single-slot `whoisCard`
-//              store the user-issued /whois owns) and carries no × affordance
-//              (persistent, like the server card).
+//              heading + a WHOIS card for the conversation partner. The card
+//              REUSES the same `WhoisCard` presentation as the scrollback
+//              overlay but is fed by the per-nick `railWhois` cache (NOT the
+//              single-slot `whoisCard` store the user-issued /whois owns) and
+//              carries no × affordance (persistent, like the server card).
+//              It RENDERS what is known and asks for nothing — #800 removed
+//              the fetch-on-select, because cic cannot see the upstream
+//              fake-lag budget a WHOIS spends and was charging it to the
+//              operator's next PRIVMSG. The cache fills from the user's own
+//              /whois (#606 routes a `source: user` bundle for the shown nick
+//              here); #782 adds the explicit fetch control.
 // It renders NOTHING for kinds with no context content (channel already has
 // the MembersPane above; home/admin/list/mentions have none). Built as a
 // container, not a hardcoded server card, so the rail is the per-kind
@@ -46,32 +42,6 @@ const RailContext: Component = () => {
   onCleanup(() => clearInterval(timer));
 
   const sel = () => selectedChannel();
-
-  // #606 — fetch-on-select. When a query window is (re)focused, ask the rail
-  // WHOIS cache for its partner; the store decides whether that costs an
-  // upstream command (it does not, for a nick already known). Keyed on the
-  // composed (slug, nick) string so the effect fires ONLY when the focused
-  // query's identity actually changes, not on every unrelated selection
-  // churn. A nick cannot contain a space, so the separator is unambiguous.
-  //
-  // A #373 rename DOES fire this effect — `followQueryNick` swaps the
-  // selection — but it must NOT cost a WHOIS: `subscribe.ts` migrates the
-  // rail cache old→new BEFORE that swap, so this lands on a hit. Solid
-  // flushes effects at the end of the write, so the ordering there is what
-  // holds this true; reverse it and every rename asks the ircd again.
-  createEffect(
-    on(
-      () => {
-        const s = sel();
-        return s?.kind === "query" ? `${s.networkSlug} ${s.channelName}` : null;
-      },
-      (key) => {
-        if (key === null) return;
-        const sep = key.indexOf(" ");
-        requestRailWhois(key.slice(0, sep), key.slice(sep + 1));
-      },
-    ),
-  );
 
   return (
     <Switch>

--- a/cicchetto/src/RailContext.tsx
+++ b/cicchetto/src/RailContext.tsx
@@ -1,6 +1,15 @@
-import { type Component, createSignal, Match, onCleanup, Show, Switch } from "solid-js";
+import {
+  type Component,
+  createEffect,
+  createSignal,
+  Match,
+  on,
+  onCleanup,
+  Show,
+  Switch,
+} from "solid-js";
 import { networkBySlug } from "./lib/networks";
-import { railWhoisFor } from "./lib/railWhois";
+import { railWhoisFor, requestRailWhois } from "./lib/railWhois";
 import { selectedChannel } from "./lib/selection";
 import ServerInfoCard from "./ServerInfoCard";
 import WhoisCard from "./WhoisCard";
@@ -16,20 +25,44 @@ import WhoisCard from "./WhoisCard";
 //              overlay but is fed by the per-nick `railWhois` cache (NOT the
 //              single-slot `whoisCard` store the user-issued /whois owns) and
 //              carries no × affordance (persistent, like the server card).
-//              It RENDERS what is known and asks for nothing — #800 removed
-//              the fetch-on-select, because that WHOIS measurably delayed the
-//              operator's next message and cic cannot see the upstream cost it
-//              was spending. The cache fills from the user's own
-//              /whois (#606 routes a `source: user` bundle for the shown nick
-//              here); #782 adds the explicit fetch control.
+//              It fetches the bundle when the card is ON SCREEN and the cache
+//              has nothing for that nick (#782 — see the `onScreen` contract
+//              below).
 // It renders NOTHING for kinds with no context content (channel already has
 // the MembersPane above; home/admin/list/mentions have none). Built as a
 // container, not a hardcoded server card, so the rail is the per-kind
 // context surface the RailActions moduledoc (#473) always earmarked.
+//
+// #782 — WHEN the rail may ask, and why it is VISIBILITY and not selection.
+// #606 fetched on SELECT of a query window. That spent an upstream command
+// filling a card the operator could not see: `.shell-members` is MOUNTED on
+// both form factors and merely slid off-screen when closed
+// (`transform: translateX(100%)`), so on mobile the default state is a card
+// nobody is looking at. #800 measured the cost of that command landing on the
+// operator's NEXT message and removed the fetch entirely, which left the card
+// permanently empty. Both are wrong at one end. The rule that survives, and
+// that this component now implements exactly:
+//
+//     The rail asks when — and only when — it is SHOWING a nick it does not
+//     have. Not on a timer, not on a selection it cannot display.
+//
+// So the trigger is `onScreen`, supplied per mount site because only the
+// mount site knows: the desktop rail is a permanent column (and a query
+// window renders no MembersPane above it, so the card cannot be scrolled
+// out), while the mobile drawer is on screen exactly when it is open. Passing
+// it as a REQUIRED prop keeps this component blind to form factor and makes
+// each Shell mount state its own truth — a default here would silently make
+// the mobile drawer claim to be visible.
 
 const TICK_MS = 60_000;
 
-const RailContext: Component = () => {
+export type Props = {
+  /** True when this rail is actually on screen — desktop rail: always; mobile
+      drawer: only while open. Gates the WHOIS fetch (#782). */
+  onScreen: boolean;
+};
+
+const RailContext: Component<Props> = (props) => {
   // Coarse clock so a live "connected for Xh Ym" stays fresh. `.shell-members`
   // is a permanent column (#71 INC-2), so this ticker runs for the whole
   // authenticated session, not just while a server window is focused — off a
@@ -42,6 +75,34 @@ const RailContext: Component = () => {
   onCleanup(() => clearInterval(timer));
 
   const sel = () => selectedChannel();
+
+  // Fetch-on-visible. The key composes BOTH halves of "showing a nick we may
+  // not have" — the identity on display and whether it is on display at all —
+  // so the effect fires on a query being selected while open, on the drawer
+  // opening over an already-selected query, and on a #373 rename swapping the
+  // nick underneath. It does NOT fire when the drawer closes (key goes to
+  // null) nor on unrelated selection churn. The store decides whether the ask
+  // costs an upstream command: a nick already known short-circuits, which is
+  // also why a rename is free — `subscribe.ts` migrates the rail cache
+  // old→new BEFORE `followQueryNick` swaps the selection, so this lands on a
+  // hit. Solid flushes effects at the end of the write, so that ordering is
+  // what holds it true; reverse it and every rename asks the ircd again.
+  //
+  // A nick cannot contain a space, so the separator is unambiguous.
+  createEffect(
+    on(
+      () => {
+        const s = sel();
+        if (!props.onScreen || s?.kind !== "query") return null;
+        return `${s.networkSlug} ${s.channelName}`;
+      },
+      (key) => {
+        if (key === null) return;
+        const sep = key.indexOf(" ");
+        requestRailWhois(key.slice(0, sep), key.slice(sep + 1));
+      },
+    ),
+  );
 
   return (
     <Switch>

--- a/cicchetto/src/Shell.tsx
+++ b/cicchetto/src/Shell.tsx
@@ -684,8 +684,13 @@ const Shell: Component = () => {
             {/* #474 — the per-window-kind rail context surface (server info
                 today; a /whois card is the deferred follow-on), grafted as a
                 SIBLING of the drawer below. Renders nothing on kinds with no
-                context, so the drawer still floors the rail. */}
-            <RailContext />
+                context, so the drawer still floors the rail.
+                #782 — `onScreen` is unconditionally true here: this rail is a
+                PERMANENT grid column (#71 INC-2, `.shell-no-members` narrows
+                it but never drops it), and a query window renders no
+                MembersPane above the card, so it cannot be scrolled out of
+                view either. */}
+            <RailContext onScreen={true} />
             {/* #473 — the ONE unified rail action drawer, floored at the bottom
                 (CSS `.rail-actions { margin-top: auto }`). Supersedes the desktop
                 top ActionCluster (cog + denoise) and, crucially, brings the
@@ -935,8 +940,13 @@ const Shell: Component = () => {
           </Show>
           {/* #474 — per-window-kind rail context (server info today), grafted
               as a SIBLING of the drawer below; renders nothing off a server
-              window. Same component the desktop rail mounts. */}
-          <RailContext />
+              window. Same component the desktop rail mounts.
+              #782 — this drawer is MOUNTED whether open or shut (closed is
+              `transform: translateX(100%)`, not an unmount), so `membersOpen`
+              is the only honest answer to "is the card on screen": without it
+              every mobile session would spend a WHOIS on a card behind the
+              right edge. */}
+          <RailContext onScreen={membersOpen()} />
           {/* #473 — the ONE unified rail action drawer, floored at the bottom.
               Same component + same handler set the desktop rail mounts (the
               drawer-closing arm of the mobilePanel helpers is meaningful here on

--- a/cicchetto/src/__tests__/RailContext.test.tsx
+++ b/cicchetto/src/__tests__/RailContext.test.tsx
@@ -126,13 +126,17 @@ describe("RailContext query context (#606)", () => {
   });
 
   // #800 — THE RULE: the rail never spends an upstream command on its own.
-  // #606 shipped a fetch-on-select here; a WHOIS costs bahamut fake-lag
-  // (`since += 2 + len/120`, recvQ parse gated on `since - now < 10`), so it
-  // landed head-of-line in front of the operator's next PRIVMSG and pushed it
-  // past the ircd's parse gate — main went red on nick-follow-query. cic
-  // cannot see that budget, so it must not decide to spend it. These two pin
-  // the rule against the next prefetch surface; #782 adds a user-driven
-  // button, which is a different thing entirely.
+  // #606 shipped a fetch-on-select here, and it measurably delayed the
+  // operator's NEXT message by seconds — main went red on nick-follow-query.
+  // (Where those seconds go inside the ircd is still unconfirmed; fake-lag is
+  // the leading hypothesis, see DESIGN_NOTES 2026-08-04.) The rule does not
+  // depend on that: cic cannot see the connection's upstream cost at all, so
+  // it must not decide to spend it. These two pin the rule against the next
+  // prefetch surface; #782 adds a user-driven button, a different thing.
+  //
+  // The second test is not redundant: the effect fires again on a #373 rename,
+  // so the rule has two entry points, and on the wire only `railWhois`'s own
+  // de-dupe kept that from being a second command.
   it("issues NO WHOIS when a query window is selected", async () => {
     await setSelected(sel("query", "alice"));
     await renderContainer();

--- a/cicchetto/src/__tests__/RailContext.test.tsx
+++ b/cicchetto/src/__tests__/RailContext.test.tsx
@@ -125,10 +125,18 @@ describe("RailContext query context (#606)", () => {
     expect(screen.queryByTestId("rail-server-info")).toBeNull();
   });
 
-  it("fires requestRailWhois(slug, nick) when a query is selected", async () => {
+  // #800 — THE RULE: the rail never spends an upstream command on its own.
+  // #606 shipped a fetch-on-select here; a WHOIS costs bahamut fake-lag
+  // (`since += 2 + len/120`, recvQ parse gated on `since - now < 10`), so it
+  // landed head-of-line in front of the operator's next PRIVMSG and pushed it
+  // past the ircd's parse gate — main went red on nick-follow-query. cic
+  // cannot see that budget, so it must not decide to spend it. These two pin
+  // the rule against the next prefetch surface; #782 adds a user-driven
+  // button, which is a different thing entirely.
+  it("issues NO WHOIS when a query window is selected", async () => {
     await setSelected(sel("query", "alice"));
     await renderContainer();
-    expect(requestRailWhoisMock).toHaveBeenCalledWith("libera", "alice");
+    expect(requestRailWhoisMock).not.toHaveBeenCalled();
   });
 
   it("updates the heading when the query's nick changes while open (followQueryNick)", async () => {
@@ -142,12 +150,11 @@ describe("RailContext query context (#606)", () => {
     expect(ctx.textContent).not.toContain("with alice "); // no stale nick
   });
 
-  it("re-fires requestRailWhois for the new nick after a rename", async () => {
+  it("issues NO WHOIS when a rename swaps the focused query's nick", async () => {
     await setSelected(sel("query", "alice"));
     await renderContainer();
     await setSelected(sel("query", "alice2"));
-    expect(requestRailWhoisMock).toHaveBeenCalledWith("libera", "alice");
-    expect(requestRailWhoisMock).toHaveBeenCalledWith("libera", "alice2");
+    expect(requestRailWhoisMock).not.toHaveBeenCalled();
   });
 
   it("renders the WhoisCard when a rail bundle exists for the selected nick", async () => {

--- a/cicchetto/src/__tests__/RailContext.test.tsx
+++ b/cicchetto/src/__tests__/RailContext.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Network, WhoisBundle } from "../lib/api";
 import type { SelectedChannel } from "../lib/selection";
@@ -65,9 +66,15 @@ async function setSelected(value: SelectedChannel | null): Promise<void> {
   await Promise.resolve();
 }
 
-async function renderContainer() {
+// `onScreen` is REQUIRED (no default) — Shell's two rail mounts each state
+// their own truth, so a test must state one too. Signal-backed so a test can
+// drive the off->on transition the mobile drawer performs.
+const [onScreen, setOnScreen] = createSignal(false);
+
+async function renderContainer(visible: boolean) {
+  setOnScreen(visible);
   const { default: RailContext } = await import("../RailContext");
-  const result = render(() => <RailContext />);
+  const result = render(() => <RailContext onScreen={onScreen()} />);
   await Promise.resolve();
   return result;
 }
@@ -77,6 +84,7 @@ beforeEach(() => {
   requestRailWhoisMock.mockReset();
   railWhoisForMock.mockReset();
   railWhoisForMock.mockReturnValue(undefined);
+  setOnScreen(false);
 });
 
 afterEach(async () => {
@@ -87,28 +95,28 @@ describe("RailContext per-kind dispatch", () => {
   it("renders the ServerInfoCard on a server window when the network is live", async () => {
     await setSelected(sel("server", "$server"));
     networkBySlugMock.mockReturnValue(net);
-    await renderContainer();
+    await renderContainer(true);
     expect(screen.getByTestId("rail-server-info").textContent).toContain("libera");
   });
 
   it("renders nothing on a server window whose network is not live", async () => {
     await setSelected(sel("server", "$server"));
     networkBySlugMock.mockReturnValue(undefined);
-    await renderContainer();
+    await renderContainer(true);
     expect(screen.queryByTestId("rail-server-info")).toBeNull();
   });
 
   it("renders nothing on a channel window", async () => {
     await setSelected(sel("channel", "#italia"));
     networkBySlugMock.mockReturnValue(net);
-    await renderContainer();
+    await renderContainer(true);
     expect(screen.queryByTestId("rail-server-info")).toBeNull();
     expect(screen.queryByTestId("rail-query-context")).toBeNull();
   });
 
   it("renders nothing when no window is selected", async () => {
     await setSelected(null);
-    await renderContainer();
+    await renderContainer(true);
     expect(screen.queryByTestId("rail-server-info")).toBeNull();
     expect(screen.queryByTestId("rail-query-context")).toBeNull();
   });
@@ -117,7 +125,7 @@ describe("RailContext per-kind dispatch", () => {
 describe("RailContext query context (#606)", () => {
   it("renders the heading 'private conversation with <nick>' on a query window", async () => {
     await setSelected(sel("query", "alice"));
-    await renderContainer();
+    await renderContainer(true);
     const ctx = screen.getByTestId("rail-query-context");
     expect(ctx.textContent).toContain("private conversation with");
     expect(ctx.textContent).toContain("alice");
@@ -125,40 +133,15 @@ describe("RailContext query context (#606)", () => {
     expect(screen.queryByTestId("rail-server-info")).toBeNull();
   });
 
-  // #800 — THE RULE: the rail never spends an upstream command on its own.
-  // #606 shipped a fetch-on-select here, and it measurably delayed the
-  // operator's NEXT message by seconds — main went red on nick-follow-query.
-  // (Where those seconds go inside the ircd is still unconfirmed; fake-lag is
-  // the leading hypothesis, see DESIGN_NOTES 2026-08-04.) The rule does not
-  // depend on that: cic cannot see the connection's upstream cost at all, so
-  // it must not decide to spend it. These two pin the rule against the next
-  // prefetch surface; #782 adds a user-driven button, a different thing.
-  //
-  // The second test is not redundant: the effect fires again on a #373 rename,
-  // so the rule has two entry points, and on the wire only `railWhois`'s own
-  // de-dupe kept that from being a second command.
-  it("issues NO WHOIS when a query window is selected", async () => {
-    await setSelected(sel("query", "alice"));
-    await renderContainer();
-    expect(requestRailWhoisMock).not.toHaveBeenCalled();
-  });
-
   it("updates the heading when the query's nick changes while open (followQueryNick)", async () => {
     await setSelected(sel("query", "alice"));
-    await renderContainer();
+    await renderContainer(true);
     expect(screen.getByTestId("rail-query-context").textContent).toContain("alice");
     // A peer NICK alice→alice2 swaps selectedChannel in place (#373).
     await setSelected(sel("query", "alice2"));
     const ctx = screen.getByTestId("rail-query-context");
     expect(ctx.textContent).toContain("alice2");
     expect(ctx.textContent).not.toContain("with alice "); // no stale nick
-  });
-
-  it("issues NO WHOIS when a rename swaps the focused query's nick", async () => {
-    await setSelected(sel("query", "alice"));
-    await renderContainer();
-    await setSelected(sel("query", "alice2"));
-    expect(requestRailWhoisMock).not.toHaveBeenCalled();
   });
 
   it("renders the WhoisCard when a rail bundle exists for the selected nick", async () => {
@@ -168,7 +151,7 @@ describe("RailContext query context (#606)", () => {
         : undefined,
     );
     await setSelected(sel("query", "alice"));
-    await renderContainer();
+    await renderContainer(true);
     expect(screen.getByTestId("whois-card")).toBeInTheDocument();
     expect(screen.getByTestId("whois-card").textContent).toContain("AliceAcct");
   });
@@ -176,8 +159,83 @@ describe("RailContext query context (#606)", () => {
   it("renders the heading but no WhoisCard when no rail bundle exists yet", async () => {
     railWhoisForMock.mockReturnValue(undefined);
     await setSelected(sel("query", "alice"));
-    await renderContainer();
+    await renderContainer(true);
     expect(screen.getByTestId("rail-query-context")).toBeInTheDocument();
     expect(screen.queryByTestId("whois-card")).toBeNull();
+  });
+});
+
+// #782 — the trigger is the card being ON SCREEN, not the window being
+// selected. #606 fetched on select and so spent an upstream command filling a
+// card the mobile user could not see (the rail is collapsed by default);
+// #800 measured that cost landing on the operator's NEXT message and removed
+// the fetch outright, leaving the card unfillable. Both are wrong at one of
+// the two ends. What survives from #800 is the rule that matters — the rail
+// must not spend a command on a card nobody is looking at — and these pin
+// exactly that boundary. `requestRailWhois`'s own de-dupe (a known nick is
+// never re-asked) is the second half and is pinned in railWhois.test.ts; here
+// we pin only WHEN the rail is allowed to ask at all.
+describe("RailContext whois fetch is gated on the card being on screen (#782)", () => {
+  it("issues NO WHOIS while the rail is off screen", async () => {
+    // The mobile drawer is closed: `.shell-members` is MOUNTED but sits at
+    // translateX(100%), so the card exists in the DOM and is invisible. A
+    // mount-time fetch would spend the command anyway — this is the leg that
+    // must stay red if the visibility gate is ever removed.
+    await setSelected(sel("query", "alice"));
+    await renderContainer(false);
+    expect(requestRailWhoisMock).not.toHaveBeenCalled();
+  });
+
+  it("issues the WHOIS once the card is on screen", async () => {
+    await setSelected(sel("query", "alice"));
+    await renderContainer(true);
+    expect(requestRailWhoisMock).toHaveBeenCalledTimes(1);
+    expect(requestRailWhoisMock).toHaveBeenCalledWith("libera", "alice");
+  });
+
+  it("asks when the drawer OPENS over an already-selected query", async () => {
+    // The mobile sequence, and the one a select-keyed effect gets wrong: the
+    // query is focused first, the user opens the rail afterwards. Nothing
+    // about the selection changed, so only visibility can be the trigger.
+    await setSelected(sel("query", "alice"));
+    await renderContainer(false);
+    expect(requestRailWhoisMock).not.toHaveBeenCalled();
+    setOnScreen(true);
+    await Promise.resolve();
+    expect(requestRailWhoisMock).toHaveBeenCalledWith("libera", "alice");
+  });
+
+  it("does not re-ask when the drawer merely CLOSES", async () => {
+    // Closing is not a new demand for data; re-asking on the way out would
+    // spend a command for a card being hidden.
+    await setSelected(sel("query", "alice"));
+    await renderContainer(true);
+    expect(requestRailWhoisMock).toHaveBeenCalledTimes(1);
+    setOnScreen(false);
+    await Promise.resolve();
+    expect(requestRailWhoisMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("asks for the NEW nick when a rename swaps the focused query on screen", async () => {
+    // #373 — `followQueryNick` swaps selectedChannel in place. This fires the
+    // effect with the new identity, and it MUST: the card now shows a nick the
+    // rail may not know. It does not cost a command in practice — `subscribe.ts`
+    // migrates the rail cache old->new BEFORE the swap, so `requestRailWhois`
+    // lands on a hit. That ordering is what keeps a rename free; reverse it and
+    // every rename asks the ircd again.
+    await setSelected(sel("query", "alice"));
+    await renderContainer(true);
+    await setSelected(sel("query", "alice2"));
+    expect(requestRailWhoisMock).toHaveBeenCalledWith("libera", "alice");
+    expect(requestRailWhoisMock).toHaveBeenCalledWith("libera", "alice2");
+  });
+
+  it("issues NO WHOIS for a non-query window, however visible the rail is", async () => {
+    networkBySlugMock.mockReturnValue(net);
+    await setSelected(sel("server", "$server"));
+    await renderContainer(true);
+    expect(requestRailWhoisMock).not.toHaveBeenCalled();
+    await setSelected(sel("channel", "#italia"));
+    expect(requestRailWhoisMock).not.toHaveBeenCalled();
   });
 });

--- a/cicchetto/src/lib/railWhois.ts
+++ b/cicchetto/src/lib/railWhois.ts
@@ -17,13 +17,22 @@ import { whoisBundleHasFields } from "./whoisBundle";
 //     (opening two queries would stomp the card) nor forge a scrollback
 //     card the user never asked for.
 //
-// Fetch policy (issue #606 scope 2, revised):
-//   * ONE WHOIS per nick, on FIRST select (`requestRailWhois`). Once the nick
-//     is KNOWN it is never asked about again — there is NO staleness refetch;
-//   * an ask that produced nothing (reply in flight, or a reply carrying no
-//     fields because the peer is offline) stands for `RAIL_WHOIS_RETRY_MS`,
-//     which both de-dupes fast window switching and lets a peer who was
-//     offline at first select be resolved later in the session.
+// Fetch policy (#606 scope 2, then #800):
+//   * NOTHING in the rail asks on its own. #606 called `requestRailWhois` on
+//     first select of a query window; #800 removed that call, because a WHOIS
+//     costs upstream fake-lag budget cic cannot see and it was landing
+//     head-of-line in front of the operator's next PRIVMSG. The store now
+//     fills only from the user's OWN `/whois` (`userTopic.ts` routes a
+//     `source: "user"` bundle for the nick the rail is showing into here).
+//   * `requestRailWhois` therefore has NO production caller today. It is kept
+//     deliberately, not by oversight: it is the seam #782's explicit fetch
+//     control attaches to, and its de-dupe rules below are the ones that
+//     button will need. It is NOT to be wired to any automatic trigger.
+//   * When it IS called: ONE WHOIS per nick. Once the nick is KNOWN it is
+//     never asked about again — there is NO staleness refetch. An ask that
+//     produced nothing (reply in flight, or a reply carrying no fields
+//     because the peer is offline) stands for `RAIL_WHOIS_RETRY_MS`, which
+//     de-dupes rapid re-asks and lets an offline peer resolve later.
 //
 // The freshness TTL this store shipped with is deliberately GONE. It was not
 // a cost problem: on bahamut a WHOIS and a PRIVMSG carry the same fake-lag

--- a/cicchetto/src/lib/railWhois.ts
+++ b/cicchetto/src/lib/railWhois.ts
@@ -19,11 +19,12 @@ import { whoisBundleHasFields } from "./whoisBundle";
 //
 // Fetch policy (#606 scope 2, then #800):
 //   * NOTHING in the rail asks on its own. #606 called `requestRailWhois` on
-//     first select of a query window; #800 removed that call, because a WHOIS
-//     costs upstream fake-lag budget cic cannot see and it was landing
-//     head-of-line in front of the operator's next PRIVMSG. The store now
-//     fills only from the user's OWN `/whois` (`userTopic.ts` routes a
-//     `source: "user"` bundle for the nick the rail is showing into here).
+//     first select of a query window; #800 removed that call, because that one
+//     extra command measurably delayed the operator's NEXT message by seconds
+//     (the ircd-side mechanism is unconfirmed — the fake-lag reading below is
+//     the leading hypothesis, not a measurement). The store now fills only
+//     from the user's OWN `/whois` (`userTopic.ts` routes a `source: "user"`
+//     bundle for the nick the rail is showing into here).
 //   * `requestRailWhois` therefore has NO production caller today. It is kept
 //     deliberately, not by oversight: it is the seam #782's explicit fetch
 //     control attaches to, and its de-dupe rules below are the ones that
@@ -34,7 +35,11 @@ import { whoisBundleHasFields } from "./whoisBundle";
 //     because the peer is offline) stands for `RAIL_WHOIS_RETRY_MS`, which
 //     de-dupes rapid re-asks and lets an offline peer resolve later.
 //
-// The freshness TTL this store shipped with is deliberately GONE. It was not
+// The freshness TTL this store shipped with is deliberately GONE. The reading
+// that follows is INFERRED FROM BAHAMUT SOURCE and has never been measured
+// against a running ircd (#800) — it is the best lead for WHY an extra command
+// delays the next one, not an established fact. What IS measured is the delay
+// itself. It was not
 // a cost problem: on bahamut a WHOIS and a PRIVMSG carry the same fake-lag
 // flag and the same `since += 2 + len/120` (src/parse.c:236). The problem is
 // the CEILING — `s_bsd.c:1657` gates the recvQ drain on

--- a/cicchetto/src/lib/railWhois.ts
+++ b/cicchetto/src/lib/railWhois.ts
@@ -17,23 +17,33 @@ import { whoisBundleHasFields } from "./whoisBundle";
 //     (opening two queries would stomp the card) nor forge a scrollback
 //     card the user never asked for.
 //
-// Fetch policy (#606 scope 2, then #800):
-//   * NOTHING in the rail asks on its own. #606 called `requestRailWhois` on
-//     first select of a query window; #800 removed that call, because that one
-//     extra command measurably delayed the operator's NEXT message by seconds
-//     (the ircd-side mechanism is unconfirmed — the fake-lag reading below is
-//     the leading hypothesis, not a measurement). The store now fills only
-//     from the user's OWN `/whois` (`userTopic.ts` routes a `source: "user"`
-//     bundle for the nick the rail is showing into here).
-//   * `requestRailWhois` therefore has NO production caller today. It is kept
-//     deliberately, not by oversight: it is the seam #782's explicit fetch
-//     control attaches to, and its de-dupe rules below are the ones that
-//     button will need. It is NOT to be wired to any automatic trigger.
-//   * When it IS called: ONE WHOIS per nick. Once the nick is KNOWN it is
-//     never asked about again — there is NO staleness refetch. An ask that
-//     produced nothing (reply in flight, or a reply carrying no fields
-//     because the peer is offline) stands for `RAIL_WHOIS_RETRY_MS`, which
-//     de-dupes rapid re-asks and lets an offline peer resolve later.
+// Fetch policy (#606 scope 2, then #800, settled by #782):
+//   * The rail asks when the card is ON SCREEN showing a nick this store does
+//     not have — `RailContext` calls `requestRailWhois` gated on its
+//     `onScreen` prop. Nothing else may call it.
+//   * The two rejected shapes, so neither comes back: #606 asked on SELECT,
+//     which spent an upstream command filling a card the mobile operator
+//     could not see (the rail is mounted-but-off-screen when the drawer is
+//     shut) and measurably delayed the operator's NEXT message by seconds —
+//     the ircd-side mechanism is still unconfirmed (#800; the fake-lag
+//     reading below is the leading hypothesis, not a measurement), but the
+//     rule does not rest on it: cic cannot see the connection's upstream cost
+//     at all, so it must not spend it speculatively. #800 then removed the
+//     ask outright, which is the opposite error — a card that can never fill.
+//     Visibility is the line between the two: a card on screen is not a
+//     speculation, it is a nick the operator is looking at right now.
+//   * A user-driven control was considered and is NOT what shipped (#782 was
+//     reshaped away from a button — vjt: "rail is on screen, cache is empty,
+//     do a whois and when response comes display it"). Do not add one as well.
+//   * ONE WHOIS per nick. Once the nick is KNOWN it is never asked about
+//     again — there is NO staleness refetch, and re-opening the drawer over a
+//     known nick therefore costs nothing. An ask that produced nothing (reply
+//     in flight, or a reply carrying no fields because the peer is offline)
+//     stands for `RAIL_WHOIS_RETRY_MS`, which de-dupes rapid re-asks and lets
+//     an offline peer resolve later.
+//   * The store also fills WITHOUT being asked, from the user's OWN `/whois`
+//     (`userTopic.ts` routes a `source: "user"` bundle for the nick the rail
+//     is showing into here) — a free refresh that then satisfies the de-dupe.
 //
 // The freshness TTL this store shipped with is deliberately GONE. The reading
 // that follows is INFERRED FROM BAHAMUT SOURCE and has never been measured
@@ -61,6 +71,9 @@ import { whoisBundleHasFields } from "./whoisBundle";
 //
 //     The rail NEVER sends a WHOIS on a timer or as a speculative prefetch.
 //     It sends exactly ONE when it has to show a nick it does not have.
+//
+// "Show" is literal, and #782 is what made it literal: on screen, in front of
+// the operator. A selected-but-hidden card is a prefetch and gets nothing.
 //
 // So the card is fetched once and is not refreshable; a long-lived rail shows
 // a stale idle clock. The operator's own `/whois <peer>` still lands here
@@ -105,13 +118,16 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   const railWhoisFor = (slug: string, nick: string): WhoisBundle | undefined =>
     byNick()[slug]?.[normalizeNick(nick)]?.bundle ?? undefined;
 
-  // Called on query select. A nick we already know short-circuits FOREVER
-  // (no staleness rule); a nick we asked about within the retry window
-  // short-circuits too, so fast A→B→A switching cannot stack. A WHOIS is
-  // visible to the
-  // person it names — a target carrying umode +y is told "<nick> is doing a
-  // WHOIS on you" (bahamut src/s_user.c:2200) — so every avoided refetch is
+  // Called by `RailContext` when the query card comes ON SCREEN (#782), which
+  // is the ONLY caller. A nick we already know short-circuits FOREVER (no
+  // staleness rule), so re-opening the drawer over a known nick is free; a
+  // nick we asked about within the retry window short-circuits too, so fast
+  // A→B→A switching and open/close/open cannot stack. A WHOIS is visible to
+  // the person it names — a target carrying umode +y is told "<nick> is doing
+  // a WHOIS on you" (bahamut src/s_user.c:2200) — so every avoided refetch is
   // noise a peer does not receive, not merely a command grappa does not send.
+  // (vjt has been told this twice and wants the on-screen fetch regardless;
+  // it is the argument for never asking MORE than once, not for not asking.)
   const requestRailWhois = (slug: string, nick: string): void => {
     const key = normalizeNick(nick);
     const now = Date.now();

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -28433,21 +28433,52 @@ whereas a channel that silently stops being clickable has no recourse but
 ## 2026-08-04 — #800: a pane may not spend a budget it cannot see
 
 `#606`'s rail context fetched a WHOIS when a query window was selected. That
-call reddened `main` on `nick-follow-query` (#373): on bahamut every command
-costs `since += 2 + len/120` and the recvQ drain is gated on `since - now < 10`,
-so the rail's WHOIS landed head-of-line in front of the operator's next PRIVMSG
-and pushed it past the ircd's parse gate. Bisected by duration delta — the spec
-ran 2.7s on the pre-merge baseline, 5.7s with #613 alone, 6.7s (timeout) on the
-merged main — and confirmed by displacement: deleting the one call restored the
-baseline (2.0/5.5/4.5 vs 7.4/10.0/9.3 locally, `--repeat-each 3`). Full evidence
-in #800.
+call reddened `main` on `nick-follow-query` (#373).
+
+**Measured.** One extra WHOIS on the session's upstream connection delays the
+operator's NEXT message by seconds. The spec ran 2.7s on the pre-merge baseline,
+5.7s with #613 alone, and 6.7s — a timeout — on the merged main. Deleting the
+one call restores the baseline: 2.0/5.5/4.5 against 7.4/10.0/9.3 locally at
+`--repeat-each 3`. The red is intermittent (~7 of 9 post-merge runs, 0 of 4
+pre-merge), which is why the duration delta and the displacement result are the
+evidence rather than any single pass or fail. Full write-up in #800.
+
+**Inferred, NOT confirmed.** *Where* those seconds are spent is still open. The
+leading hypothesis — from reading bahamut source, not from measuring this
+system — is fake-lag: each command costs `since += 2 + len/120` and the recvQ
+drain is gated on `since - now < 10` (`parse.c:236`, `s_bsd.c:1657`), so past
+the ceiling the ircd keeps reading grappa's socket but stops parsing it. It fits
+(grappa emits the followup 357ms after the previous send, so the delay is not on
+our side) but nobody has instrumented the ircd to show it. The `5000ms` in the
+failing assertion is the **test helper's own wait budget**, not a measured
+bahamut latency — do not cite it as one. Anyone who wants to close this: measure
+the ircd, do not re-read the source.
+
+The distinction matters for what the entry is FOR. The rule below rests on the
+displacement result alone and needs no ircd-internal mechanism to justify it, so
+the hypothesis being wrong would not weaken it.
 
 **The general rule, which binds every future prefetch surface: cic does not
-decide to spend an upstream command.** It cannot see `since`, it cannot see what
-the session sent a moment ago, and it cannot see how close the connection is to
-the parse gate. Only the operator's own action spends that budget. This is not
-about tuning WHEN the rail fetches — every timing fix #606 tried (TTL, retry
-window, migrate-before-select ordering) was answering the wrong question.
+decide to spend an upstream command.** Whatever the ircd-side mechanism turns
+out to be, the client cannot see it — not what the session sent a moment ago,
+not what that cost, not how close the connection is to whatever ceiling it has.
+Only the operator's own action spends that budget. This is not about tuning WHEN
+the rail fetches — every timing fix #606 tried (TTL, retry window,
+migrate-before-select ordering) was answering the wrong question.
+
+**One WHOIS, not two — and why the near miss is worth recording.** The rail's
+effect fires on every query-identity change, so a #373 rename fires it a SECOND
+time; the pinning test in `RailContext.test.tsx` sees exactly that (`called 2
+times`, against a mocked store). On the wire it stayed at one: the instrumented
+run showed `WHOIS Guest…` and no `WHOIS NickTmp…`, because `subscribe.ts`
+migrates the rail cache old→new BEFORE `followQueryNick` swaps the selection, so
+the second call lands on a hit and short-circuits. That de-dupe held, but it was
+second-line defence under a rule that should not have existed: a cache miss
+there — empty bundle, peer offline, retry window elapsed — and the second
+command goes out for real. Nor is the rename what made this spec the one that
+fell; it fell because it is the only spec that opens a query window and then
+sends a timed message, which is the only shape that puts a speculative command
+in front of a stopwatch.
 
 **What was removed, and what deliberately was not.** Only the `createEffect` in
 `RailContext.tsx` is gone. The card, the `renameRailWhois` #373 migration, the

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -28429,3 +28429,47 @@ catch it, and would also reject `#facade`, `#decade`, `#cafe`, `#bad` and
 `#abc` — real channel shapes. The mis-tap still needs a confirmation dialog,
 whereas a channel that silently stops being clickable has no recourse but
 `/join`. Left alone pending a call.
+
+## 2026-08-04 — #800: a pane may not spend a budget it cannot see
+
+`#606`'s rail context fetched a WHOIS when a query window was selected. That
+call reddened `main` on `nick-follow-query` (#373): on bahamut every command
+costs `since += 2 + len/120` and the recvQ drain is gated on `since - now < 10`,
+so the rail's WHOIS landed head-of-line in front of the operator's next PRIVMSG
+and pushed it past the ircd's parse gate. Bisected by duration delta — the spec
+ran 2.7s on the pre-merge baseline, 5.7s with #613 alone, 6.7s (timeout) on the
+merged main — and confirmed by displacement: deleting the one call restored the
+baseline (2.0/5.5/4.5 vs 7.4/10.0/9.3 locally, `--repeat-each 3`). Full evidence
+in #800.
+
+**The general rule, which binds every future prefetch surface: cic does not
+decide to spend an upstream command.** It cannot see `since`, it cannot see what
+the session sent a moment ago, and it cannot see how close the connection is to
+the parse gate. Only the operator's own action spends that budget. This is not
+about tuning WHEN the rail fetches — every timing fix #606 tried (TTL, retry
+window, migrate-before-select ordering) was answering the wrong question.
+
+**What was removed, and what deliberately was not.** Only the `createEffect` in
+`RailContext.tsx` is gone. The card, the `renameRailWhois` #373 migration, the
+`whoisCard`/`railWhois` store split and the `source: "user" | "rail"` wire field
+all stay — the cache still fills from the user's own `/whois`, which #606's
+origin routing already delivers to the rail for the nick it is showing.
+`requestRailWhois` keeps its tests and its de-dupe rules with no production
+caller: it is the seam #782's explicit fetch control attaches to. Dead-but-kept
+is normally a smell, so it is stated in the module rather than left to be
+rediscovered.
+
+**What shipped was never what was asked for.** The request was to populate when
+the rail is OPENED on mobile / the window is VIEWED on desktop. Fetch-on-select
+is neither: on mobile the rail is off-screen, so #606 spent upstream budget
+filling a card the user could not see. Worth recording because the gap survived
+review, an e2e and a merge — the spec was read as "when the window becomes
+active" when it said "when the card becomes visible."
+
+**Where the answer should live (#802).** There is no server-side store for a
+WHOIS reply: `whois_pending` is an in-flight accumulator, drained by 318 into a
+broadcast and dropped. cic's `railWhois` cache is real but in-memory and
+per-page-load, so every reload re-pays upstream for an answer grappa already
+received. The precedent already exists — `userhost_cache` is nick-keyed, folded,
+fed passively from JOIN prefixes at zero upstream cost, and already migrated on
+NICK. Cache the answer, and the question of when to fetch mostly dissolves.


### PR DESCRIPTION
Stacked on #805 (`800-drop-rail-autofetch`). Its CI therefore gates the
UNION of the two, which is the point: **#805 alone is red on a spec it never
touched** — it deletes the only thing that can satisfy
`issue606-query-rail-whois.spec.ts:71`'s auto-fetched card. This branch is what
makes it green again. Expect a rebase onto main once #805 merges.

## The feature, as vjt reshaped it

Verbatim: *"I do NOT want WHOIS cache. that is totally braindead. this feature
is simple: rail is on screen, client-side whois cache is empty, do a whois and
when response comes display it."* So: not a button, no TTL, no second
mechanism.

`RailContext` takes a **required** `onScreen: boolean`. The fetch effect keys
on `onScreen && kind === "query" ? "<slug> <nick>" : null` and calls the
existing `requestRailWhois`. Shell's two mounts each state their own truth:
desktop `onScreen={true}` (a permanent grid column), mobile
`onScreen={membersOpen()}` — the drawer is MOUNTED but slid off-screen when
shut (`transform: translateX(100%)`), so a mount-time fetch would have fired
behind the right edge.

Both moduledocs move in the same commit, deliberately: `railWhois.ts` used to
say `requestRailWhois` was "NOT to be wired to any automatic trigger" and
`RailContext.tsx` said the card "asks for nothing". Left alone, the next reader
would read the change as a violation of the line directly above it.

### Mutation-proven, 2/2 killed

| mutation | legs that died |
|---|---|
| gate removed from the key | `issues NO WHOIS while the rail is off screen` + `asks when the drawer OPENS` |
| gate moved from the key INTO the handler | `asks when the drawer OPENS over an already-selected query` only |

The second is the valuable one: it passes every other leg, so without the
transition test a green suite would have sat on an implementation that on
mobile **never** fetches.

## The second commit: `nick-follow-query` had the wrong constant

Adding the on-screen fetch tipped `nick-follow-query.spec.ts` red. The
investigation is worth more than the fix.

**`waitForPrivmsg` had no budget of its own.** It borrowed `NICK_TIMEOUT_MS`
— sized for a NICK echo — because it was written next to `changeNick`. That is
#806 defect 3. Of the seven specs that block on grappa-originated traffic, this
was the only one at 5s; the rest are at 8s, 15s, 25s, 30s. Nobody chose 5s.

**Where the seconds go.** bahamut charges ~2s of fake lag per command against
a 10s ceiling and stops draining the recvQ past it. `_vjtReset` restarts the
session after every test, and the reconnect burst — NICK, USER, MODE `<nick>`
(#229), JOIN, MODE `#chan` (#216) — banks ~9.9s in ~140ms; the next spec's
first command lands ~1s later. Measured with #807's per-send accounting on a
live testnet:

| iter | first cmd | timed send | outcome |
|---|---|---|---|
| 1 | headroom +8.00 | +4.42 | pass |
| 2 | headroom −0.92 | −4.52 | fail, ~5.3s stall |
| 3 | headroom −0.71 | −4.22 | fail, ~5.36s stall |

Arrivals: 26-28ms on an empty bank; 3024ms and 4989ms on a full one — the
second inside the old budget by eleven milliseconds.

**So the budget is derived, not chosen.** The delay is the bank's overshoot,
bounded by the ~10s cap. 15s clears that ceiling — the same bound, and the same
number, that `TOPIC_TIMEOUT_MS` was already derived against in #268
(DESIGN_NOTES 2026-07-16) for the sibling wait on the same socket.

**Not a timeout raised to bury a red.** It is a condition-wait: it resolves the
instant the message lands, so the regression it exists to catch — #373's
stale-nick routing, where nothing arrives at all — still fails, ten seconds
later. What it stops doing is failing when the message is merely queued behind
the harness's own reconnect burst, which no production client puts in front of
a send.

## Evidence

Same warm stack, same command, only the constant differs:

* **`PRIVMSG_TIMEOUT_MS = 5_000` (the mutation): 4 failed / 8 passed of 12**,
  every failure `IrcPeer: timeout waiting for privmsg ... (5000ms)`.
* **`PRIVMSG_TIMEOUT_MS = 15_000`: 12 passed of 12**, rc=0.

A first control at 5 iterations passed 5/5 and proved nothing — the condition
reproduces about a third of the time, so the short run was simply too small to
kill the mutation. Recorded because the green was momentarily convincing.

Union check, `--repeat-each 5` over both specs: **10 passed, rc=0** —
`nick-follow-query` repaired without breaking `issue606-query-rail-whois`.

cic gates from the worktree root: `check:fix` no fixes, `check` **rc=0** (46
pre-existing CSS warnings), `test` **rc=0**, 229 files / 4126 tests.

## Two things NOT claimed

* **The mobile branch is not proven outside jsdom.** `onScreen={membersOpen()}`
  is covered by `RailContext.test.tsx` driving a signal. The only e2e that
  touches `rail-query-context` is `issue606`, which is chromium/desktop. The
  fetch-when-the-drawer-opens path — the reason #782 exists — has no
  device-class proof. Stated as a known limit, not left implicit.
* **An earlier estimate of mine was wrong and is withdrawn.** I predicted the
  feature cost two WHOISes on this path (one at `/q`, one after the rename).
  The wire says one: `renameRailWhois` re-keys the cached bundle old→new and
  the post-rename ask short-circuits, exactly as #613 intended. Three WHOIS
  frames across three iterations. The structure read in the source told me
  neither the magnitude nor whether it happened.

## Rejected along the way

A spec-local gate that polled grappa's modelled write budget
(`FakeLag.observe/2` behind a test-only endpoint) and waited for it to drain
before sending. It worked — 5/5, with the timed send displaced from −4.5s of
headroom to +4.0/+4.5s — but it coupled an e2e to a debug log's field names,
dragged #807 onto the critical path, and layered a mechanism on top of a
constant that was simply in the wrong place. Fixing the constant is the smaller
true statement.

The condition that makes the constant matter — the reset handing every spec a
near-full bank — is real and measured, and is written up in #808 with its scope
narrowed to what the numbers support: one spec in the suite has an upstream
budget tight enough to feel it.

Related: #800, #805, #806, #807, #808, #613.