### PR TITLE
cic(#739): three defects in the auth client — token wipe, forked type, dead mode

### DIFF
--- a/cicchetto/src/__tests__/api.test.ts
+++ b/cicchetto/src/__tests__/api.test.ts
@@ -62,19 +62,20 @@ describe("api 401 handler", () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
-  it("login 401 (invalid_credentials) also fires the handler — benign no-op when no token is set", async () => {
-    // Login is unauthenticated, so a 401 there means "wrong password,"
-    // not "expired token." The handler still fires; the auth-side
-    // setToken(null) is a no-op against an already-null token. Test
-    // pins the by-design behavior so future-Claude doesn't add a
-    // path-specific exception.
+  it("login 401 (invalid_credentials) does NOT fire the handler", async () => {
+    // #739 — this case used to assert the opposite, on the reasoning that
+    // "login is unauthenticated, so setToken(null) is a no-op against an
+    // already-null token". The premise is right and the conclusion wrong:
+    // localStorage is shared across tabs, so the token is NOT null when a
+    // second tab holds a live session. The test pinned the defect in place.
+    // See the #739 block at the bottom of this file for the whole class.
     const handler = vi.fn();
     api.setOn401Handler(handler);
     stubFetch(401, { error: "invalid_credentials" });
     await expect(api.login({ identifier: "x", password: "wrong" })).rejects.toBeInstanceOf(
       api.ApiError,
     );
-    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).not.toHaveBeenCalled();
   });
 
   it("ApiError still carries the server-side error code on 401", async () => {
@@ -833,5 +834,92 @@ describe("#395 — unread kind projection (CONTENT_KINDS / NOTIFY_KINDS)", () =>
   it("notice counts as unread content but is NOT notify-worthy", () => {
     expect(api.CONTENT_KINDS.has("notice")).toBe(true);
     expect(api.NOTIFY_KINDS.has("notice")).toBe(false);
+  });
+});
+
+describe("#739 — an UNAUTHENTICATED endpoint's 401 must not wipe the shared bearer", () => {
+  // These three send NO Authorization header (`buildHeaders()` with no
+  // token), so their 401 answers "these credentials are wrong", never "the
+  // stored bearer is dead" — the two questions the dead-token handler
+  // conflates. localStorage is shared across tabs, so a live session in tab
+  // A is logged out by a mistyped code in tab B.
+  //
+  // The failure is invisible in the single-tab case the old `readError`
+  // comment reasoned about ("the pre-login token is null, so setToken(null)
+  // is a no-op") — which is exactly why it survived review: the assumption
+  // holds right up until a second tab exists.
+
+  it("verifyTotpLogin: a wrong TOTP code does not fire the dead-token handler", async () => {
+    const handler = vi.fn();
+    api.setOn401Handler(handler);
+    stubFetch(401, { error: "invalid_code" });
+    await expect(api.verifyTotpLogin("challenge", "000000")).rejects.toBeInstanceOf(api.ApiError);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("login: wrong credentials do not fire the dead-token handler", async () => {
+    const handler = vi.fn();
+    api.setOn401Handler(handler);
+    stubFetch(401, { error: "invalid_credentials" });
+    await expect(api.login({ identifier: "alice", password: "wrong" })).rejects.toBeInstanceOf(
+      api.ApiError,
+    );
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("consumeShareToken: a dead share link does not fire the dead-token handler", async () => {
+    const handler = vi.fn();
+    api.setOn401Handler(handler);
+    stubFetch(401, { error: "invalid_token" });
+    await expect(api.consumeShareToken("expired")).rejects.toBeInstanceOf(api.ApiError);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("still decodes the error body it did not fire the handler for", async () => {
+    api.setOn401Handler(vi.fn());
+    stubFetch(401, { error: "invalid_code", attempts_left: 2 });
+    await expect(api.verifyTotpLogin("challenge", "000000")).rejects.toMatchObject({
+      status: 401,
+      code: "invalid_code",
+      info: { attempts_left: 2 },
+    });
+  });
+
+  it("an AUTHENTICATED endpoint's 401 still fires it — the control", async () => {
+    const handler = vi.fn();
+    api.setOn401Handler(handler);
+    stubFetch(401, { error: "unauthorized" });
+    await expect(api.me("dead-token")).rejects.toBeInstanceOf(api.ApiError);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("#739 — startPasskeyModeChange only offers modes the server accepts", () => {
+  // A compile-time regression, not a runtime one: the defect is that the
+  // TYPE admitted a value the server always rejects, so the guard has to be
+  // `tsc`. `@ts-expect-error` is the assertion — it FAILS the typecheck as
+  // "unused" if the parameter ever widens back to accept "passwordless".
+  //
+  // The server truth is `PasskeyController.settings_mode/1`: it admits
+  // `:second_factor` and `:disabled`, and bad_requests everything else.
+  // Passwordless is armed through preparePasswordless →
+  // startPasswordlessActivation, whose recovery token proves the codes were
+  // shown first.
+
+  it("rejects `passwordless` at compile time", () => {
+    const call = () =>
+      // @ts-expect-error — "passwordless" is not a settable mode on this route
+      api.startPasskeyModeChange("token", "password", "passwordless");
+    expect(call).toBeTypeOf("function");
+  });
+
+  it("still accepts the two modes PasskeySettings actually sends", () => {
+    // Both are live callers (PasskeySettings.tsx enable + disable), so
+    // narrowing to the literal "second_factor" would have broken disable.
+    const modes: Array<Parameters<typeof api.startPasskeyModeChange>[2]> = [
+      "second_factor",
+      "disabled",
+    ];
+    expect(modes).toHaveLength(2);
   });
 });

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -1362,10 +1362,14 @@ export function channelPushError(raw: unknown): ChannelPushError {
 // is fire-and-forget; api never awaits it. Cleared back to null in
 // tests via `setOn401Handler(null)` between cases.
 //
-// Login's own 401 ("invalid_credentials") triggers this too — but the
-// pre-login token is null, so setToken(null) is a no-op. Logout's
-// 401 already gets caught by `auth.logout`'s try/catch; the handler
-// firing first just clears the same state twice. Both benign.
+// Logout's 401 already gets caught by `auth.logout`'s try/catch; the
+// handler firing first just clears the same state twice. Benign.
+//
+// #739 — the LOGIN 401s used to reach here too, on the reasoning that
+// "the pre-login token is null, so setToken(null) is a no-op". That
+// holds for exactly one tab. localStorage is shared, so a live session
+// in another tab makes the token non-null while /login is open, and one
+// mistyped code logged it out. They now pass `false`; see the rule below.
 let on401Handler: (() => void) | null = null;
 
 export function setOn401Handler(fn: (() => void) | null): void {
@@ -1385,10 +1389,19 @@ export function setOn401Handler(fn: (() => void) | null): void {
 // and the #502 active-theme refresh (`getActiveThemePair`). Their transient 401
 // must NEVER clear a valid session's token — they still throw the decoded
 // `ApiError` so the caller keeps its boot cache, but they do not log the user
-// out. Everything else keeps the default: session-validating GETs (`/me`) and
-// on-demand user-action verbs, where a 401 genuinely means the token is dead.
-// A NEW boot cosmetic fetch MUST pass `false`, or a flaky-connection 401 at
-// boot will spuriously log the user out.
+// out.
+//
+// THE SECOND RULE (#739): pass `false` for every UNAUTHENTICATED endpoint —
+// the ones that send no `authorization` header at all (`buildHeaders()` with
+// no token). Their 401 answers "these credentials are wrong", never "the
+// stored bearer is dead", and the handler cannot tell the two apart. Today
+// that is `login`, `verifyTotpLogin` and `consumeShareToken`; the passkey
+// helpers get it from `passkeyRequest`.
+//
+// Everything else keeps the default: session-validating GETs (`/me`) and
+// on-demand user-action verbs that DO send the bearer, where a 401 genuinely
+// means the token is dead. A NEW boot cosmetic fetch or a NEW unauthenticated
+// endpoint MUST pass `false`, or someone else's live session gets logged out.
 export async function readError(res: Response, fireDeadTokenHandler = true): Promise<ApiError> {
   if (res.status === 401 && fireDeadTokenHandler && on401Handler !== null) on401Handler();
   let body: Record<string, unknown> = {};
@@ -1431,7 +1444,7 @@ export async function login(req: LoginRequest): Promise<LoginResponse> {
     headers: buildHeaders(),
     body: JSON.stringify(req),
   });
-  if (!res.ok) throw await readError(res);
+  if (!res.ok) throw await readError(res, false);
   return (await res.json()) as LoginResponse;
 }
 
@@ -1444,7 +1457,7 @@ export async function verifyTotpLogin(
     headers: buildHeaders(),
     body: JSON.stringify({ challenge_token: challengeToken, code }),
   });
-  if (!res.ok) throw await readError(res);
+  if (!res.ok) throw await readError(res, false);
   return (await res.json()) as AuthenticatedLoginResponse;
 }
 
@@ -1540,10 +1553,16 @@ export const finishPasskeyRegistration = (
   credential: unknown,
 ): Promise<PasskeySummary> =>
   passkeyRequest<PasskeySummary>("/me/passkeys/registration", credential, token);
+// #739 — `passwordless` is deliberately NOT reachable through this door and
+// never was: the server's `settings_mode/1` admits `:second_factor | :disabled`
+// and bad_requests everything else, because arming passwordless must go the
+// two-step route (`preparePasswordless` → `startPasswordlessActivation`) that
+// proves the recovery codes were shown BEFORE they became the only fallback.
+// Typing it here invited a caller to earn a bare 400 with no hint why.
 export const startPasskeyModeChange = (
   token: string,
   password: string,
-  mode: "disabled" | "second_factor" | "passwordless",
+  mode: "disabled" | "second_factor",
 ): Promise<PasskeyOptions> =>
   passkeyRequest<PasskeyOptions>("/me/passkeys/mode/options", { password, mode }, token);
 export const preparePasswordless = (
@@ -2891,6 +2910,6 @@ export async function consumeShareToken(shareToken: string): Promise<ShareTokenC
     headers: buildHeaders(),
     body: JSON.stringify({ token: shareToken }),
   });
-  if (!res.ok) throw await readError(res);
+  if (!res.ok) throw await readError(res, false);
   return (await res.json()) as ShareTokenConsumeResponse;
 }

--- a/cicchetto/src/lib/passkeys.ts
+++ b/cicchetto/src/lib/passkeys.ts
@@ -1,7 +1,9 @@
-export type PasskeyOptions = {
-  challenge_id: string;
-  public_key: Record<string, unknown>;
-};
+// #739 — IMPORTED, not re-declared. This is a wire shape, so api.ts owns it.
+// A second identical declaration here typechecked only by structural
+// coincidence, and would have gone stale silently the day the server renamed
+// a field: `tsc` stays green while the unchanged subset still matches, and
+// the mismatch surfaces as a WebAuthn failure on device.
+import type { PasskeyOptions } from "./api";
 
 // The wire is snake_case without exception, but `navigator.credentials`
 // wants the camelCase WebAuthn shape. Both ceremonies already have to


### PR DESCRIPTION
Code-review finding #739. Three defects, one file's worth of surface, two commits.

Every line was re-verified against `main` @ `9251ca84` before being touched — the finding was written against `388f883b` and **two of the three had drifted**. Details below.

## 1. A wrong TOTP code wiped the shared bearer — widened to the class

The finding named `verifyTotpLogin`. It is **one of three**.

`readError` fires the dead-token handler on any 401 unless told otherwise, and that handler clears the bearer from `localStorage` — which is shared across tabs. `login`, `verifyTotpLogin` and `consumeShareToken` all send **no** `authorization` header (`buildHeaders()` with no token), so their 401 answers *"these credentials are wrong"*, never *"the stored bearer is dead"*. All three now pass `false`.

That is the actual boundary, and it is now written next to `fireDeadTokenHandler` alongside the existing #449/#502 rule, because the next unauthenticated endpoint will be added by someone who has not read this PR.

**All three regression tests failed before the fix** — `login` and `consumeShareToken` are live instances, not speculation:

```
× verifyTotpLogin: a wrong TOTP code does not fire the dead-token handler
× login: wrong credentials do not fire the dead-token handler
× consumeShareToken: a dead share link does not fire the dead-token handler
   Tests  3 failed | 45 passed (48)
```

### A test was asserting the defect

`login`'s case was not an oversight. A comment argued it was benign — *"the pre-login token is null, so setToken(null) is a no-op"* — and a test pinned it:

> `it("login 401 (invalid_credentials) also fires the handler — benign no-op when no token is set")`
> *"Test pins the by-design behavior so future-Claude doesn't add a path-specific exception."*

Both were correct about one tab and wrong about two. The test is rewritten to assert the fixed behaviour, not worked around. Kept: a positive control asserting an **authenticated** 401 (`me`) still fires the handler, and a case asserting the error body is still decoded on the path that no longer fires it.

## 2. `PasskeyOptions` declared twice

Byte-identical declarations in `api.ts` and `passkeys.ts`, added in the same commit. `api.ts` keeps it — it is a wire shape. `passkeys.ts` imports the type; no re-export, since nothing outside those two files ever referenced it. No import cycle: `api.ts` does not import `passkeys.ts`.

**No runtime regression test is possible here, and I did not write a mirror one.** The defect is that the two declarations are compatible *today*; nothing observable fails until the server renames a field. The fix removes the possibility rather than detecting it, and `tsc` is the only guard there was.

## 3. `startPasskeyModeChange` — the finding's premise and its prescribed fix were both stale

The finding says the server *"has a single clause guarded `when mode == \"second_factor\"`"* and to **narrow the parameter to the literal `\"second_factor\"`**.

🔴 **That would have broken the disable flow.** At current `main`, `PasskeyController.settings_mode/1` admits `:second_factor` **and** `:disabled`, and `PasskeySettings.tsx:75` sends `"disabled"` to shut passkeys off. Narrowing as instructed fails `tsc` on a live caller.

The defect underneath is real and survives: `"passwordless"` is in the client type and the server always rejects it — deliberately, because arming passwordless must go through `preparePasswordless` → `startPasswordlessActivation`, whose recovery token proves the codes were shown *before* they became the only fallback. So the parameter is narrowed to `"disabled" | "second_factor"` — dropping only the dead value.

Guarded by a compile-time regression, since a type defect cannot be caught at runtime: a `@ts-expect-error` that fails the typecheck as *unused* the moment the parameter widens back. **Verified by mutation** — widening it to include `"passwordless"` again turns `tsc` red:

```
MUTATED_tsc_RC=1
src/__tests__/api.test.ts(911,7): error TS2578: Unused '@ts-expect-error' directive.
```

## Gates

From the worktree root, in order: `check:fix` no fixes · `check` **rc=0** · `tsc --noEmit` standalone **rc=0** (biome-red short-circuits the `&&`, so the typecheck is run separately to prove it ran) · `test` **rc=0, 232 files / 4188 tests**.

Server-side untouched — this is cic-only. No stack or compile lane used.