### PR TITLE
auth(#744): make the WebAuthn challenge TTL branch reachable from a test

### DIFF
--- a/lib/grappa/accounts/webauthn_challenge_store.ex
+++ b/lib/grappa/accounts/webauthn_challenge_store.ex
@@ -32,7 +32,10 @@ defmodule Grappa.Accounts.WebAuthnChallengeStore do
   How long a stored ceremony stays claimable, single-sourced so a test
   can position a clock relative to it instead of restating the number.
   """
-  @spec ttl_seconds() :: pos_integer()
+  # `unquote(@ttl_seconds)` pins the spec to the compile-time singleton,
+  # mirroring `ChannelDirectory.ttl_ms/0`. A bare `pos_integer()` is a
+  # `:underspecs` supertype of the success typing and fails the gate.
+  @spec ttl_seconds() :: unquote(@ttl_seconds)
   def ttl_seconds, do: @ttl_seconds
 
   @doc "Atomically consumes a live challenge with the expected purpose."

--- a/lib/grappa/accounts/webauthn_challenge_store.ex
+++ b/lib/grappa/accounts/webauthn_challenge_store.ex
@@ -28,10 +28,30 @@ defmodule Grappa.Accounts.WebAuthnChallengeStore do
     id
   end
 
+  @doc """
+  How long a stored ceremony stays claimable, single-sourced so a test
+  can position a clock relative to it instead of restating the number.
+  """
+  @spec ttl_seconds() :: pos_integer()
+  def ttl_seconds, do: @ttl_seconds
+
   @doc "Atomically consumes a live challenge with the expected purpose."
   @spec take(String.t(), purpose()) :: {:ok, Wax.Challenge.t(), metadata()} | {:error, :invalid_challenge}
   def take(id, purpose) when is_binary(id) do
-    GenServer.call(__MODULE__, {:take, id, purpose, System.monotonic_time(:second)})
+    take(id, purpose, System.monotonic_time(:second))
+  end
+
+  @doc """
+  Same as `take/2` with an explicit monotonic `now` — the test seam that
+  makes the TTL branch reachable without sleeping the real TTL. Sampling
+  the clock inside left the expiry guard the one rule here nothing could
+  cover, on the store that backs an unauthenticated login door. Mirrors
+  `Grappa.RateLimit.FailureWindow.check/4`.
+  """
+  @spec take(String.t(), purpose(), integer()) ::
+          {:ok, Wax.Challenge.t(), metadata()} | {:error, :invalid_challenge}
+  def take(id, purpose, now) when is_binary(id) and is_integer(now) do
+    GenServer.call(__MODULE__, {:take, id, purpose, now})
   end
 
   @impl GenServer

--- a/test/grappa/accounts/webauthn_challenge_store_test.exs
+++ b/test/grappa/accounts/webauthn_challenge_store_test.exs
@@ -15,6 +15,28 @@ defmodule Grappa.Accounts.WebAuthnChallengeStoreTest do
     assert {:error, :invalid_challenge} = WebAuthnChallengeStore.take(second, :registration)
   end
 
+  test "a challenge at or past its TTL is refused, and refusing it consumes it" do
+    challenge = Wax.new_registration_challenge(origin: "https://irc.example", rp_id: "irc.example")
+    id = WebAuthnChallengeStore.put(challenge, :registration, %{user_id: "user-1"})
+
+    # Sampled AFTER the put, so `now + ttl` is at or past the stored
+    # `expires_at` whichever side of a second tick the put landed on.
+    now = System.monotonic_time(:second)
+    ttl = WebAuthnChallengeStore.ttl_seconds()
+
+    assert {:ok, ^challenge, %{user_id: "user-1"}} =
+             WebAuthnChallengeStore.take(id, :registration, now)
+
+    expired = WebAuthnChallengeStore.put(challenge, :registration, %{user_id: "user-2"})
+
+    assert {:error, :invalid_challenge} =
+             WebAuthnChallengeStore.take(expired, :registration, now + ttl)
+
+    # A refusal must EVICT, not merely decline: an expired ceremony that
+    # stayed in the map would answer a later in-window take.
+    assert {:error, :invalid_challenge} = WebAuthnChallengeStore.take(expired, :registration)
+  end
+
   test "the sweep drops an abandoned ceremony and keeps a live one" do
     # An abandoned ceremony is never taken, so the read-path TTL check
     # never sees it — driving the callback directly is what proves the


### PR DESCRIPTION
Review finding #744. **Half of it was already dead** — the sweeper landed
in `0960a99b` (`handle_info(:sweep)` + `drop_expired/2`, with a test that
drives the callback directly). This PR closes the half that is still
live: the clock.

## The defect that remains

`take/2` sampled `System.monotonic_time(:second)` inside itself, so the
`when expires_at > now` guard — the rule that stops a captured challenge
being replayed after its TTL — was the one branch in this module no test
could reach without sleeping the real 300 seconds.

It sat uncovered on the store that backs an **unauthenticated login
door**. A refactor that dropped the guard would have shipped green.

## Fix

Split the clock out, exactly as `RateLimit.FailureWindow.check/3` →
`check/4` already does:

- `take/2` stays the production call and samples the clock.
- `take/3` is the documented seam.
- No caller changes — `Accounts.WebAuthn` keeps calling `take/2`.

`ttl_seconds/0` is exposed for the same reason `FailureWindow.table_name/0`
is: a test positioning a clock relative to the TTL must read the
production constant rather than restate it. Its spec pins
`unquote(@ttl_seconds)`, the house convention for a constant accessor
under `:underspecs` (`ChannelDirectory.ttl_ms/0`,
`Scrollback.max_page_size/0`, `BodyLimit.max_body_bytes/0`).

## The test

Sampling `now` **after** the put makes `now + ttl` land at or past the
stored `expires_at` on either side of a second tick, so the expiry
assertion is deterministic rather than racing the clock.

It also pins that a refusal **evicts**: `Map.pop` drops the entry on the
error path too, so an expired ceremony cannot answer a later in-window
take. That was already true and now cannot silently stop being.

**Mutation-proven 2/2:**

- delete the `when expires_at > now` guard → the expired take returns
  `{:ok, …}`, test red.
- relax it to `>=` → the at-expiry take is accepted, test red.

## Gates

`scripts/check.sh` — **rc=0**, 8 doctests, 50 properties, **5082 tests, 0
failures**, Dialyzer `Total errors: 0`. Format, Credo strict, Sobelow,
deps.audit clean. Working tree clean before and after.

An earlier run of the same gate on the same tree came back with one
unrelated red — `Grappa.Session.LifecycleLogIntegrationTest` "clean stop
emits :disconnected clean=true" (`md.clean` false). It is green 6/6 in
isolation and green on the re-run, has no path to this diff, and looks
like another member of the #653 load-stability family. Reported rather
than worked around; no assert was touched.

Integration/e2e not run — the STACK lane is not mine, and nothing here
reaches it.