### PR TITLE
#740: record the passkey design, and give the cloned button shapes one declaration each

### DIFF
--- a/cicchetto/src/Login.tsx
+++ b/cicchetto/src/Login.tsx
@@ -449,7 +449,7 @@ const Login: Component = () => {
                   <div class="login-alt-auth-row">
                     <button
                       type="button"
-                      class="login-advanced-toggle"
+                      class="login-quiet-button login-advanced-toggle"
                       aria-expanded={advanced() ? "true" : "false"}
                       aria-controls="login-advanced"
                       onClick={() => setAdvanced((v) => !v)}
@@ -458,14 +458,14 @@ const Login: Component = () => {
                     </button>
                     <button
                       type="button"
-                      class="login-alt-auth"
+                      class="login-quiet-button login-alt-auth"
                       onClick={() => void onPasskeyLogin()}
                     >
                       Passkey
                     </button>
                     <button
                       type="button"
-                      class="login-alt-auth"
+                      class="login-quiet-button login-alt-auth"
                       onClick={() => setRecoveryMode((value) => !value)}
                     >
                       Recovery code
@@ -591,7 +591,7 @@ const Login: Component = () => {
                   </button>
                   <button
                     type="button"
-                    class="login-advanced-toggle"
+                    class="login-quiet-button login-advanced-toggle"
                     onClick={() => {
                       setTotpChallenge(null);
                       setTotpCode("");

--- a/cicchetto/src/MircText.tsx
+++ b/cicchetto/src/MircText.tsx
@@ -99,7 +99,11 @@ const renderChannel = (
 ): JSX.Element => {
   if (!onChannelClick) return channel;
   return (
-    <button type="button" class="channel-clickable" onClick={() => onChannelClick(channel)}>
+    <button
+      type="button"
+      class="scrollback-inline-button channel-clickable"
+      onClick={() => onChannelClick(channel)}
+    >
       {channel}
     </button>
   );

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -560,7 +560,7 @@ const renderRawEvent = (
             *** {senderSpan(sender)} invited you to {invitedChannel}{" "}
             <button
               type="button"
-              class="scrollback-invite-join"
+              class="scrollback-inline-button scrollback-invite-join"
               onClick={() => handlers.onJoinChannel(invitedChannel)}
             >
               [Join]
@@ -660,7 +660,7 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
   const senderSpan = (bracketLeft: string, bracketRight: string, nick: string): JSX.Element => (
     <button
       type="button"
-      class="scrollback-sender nick-clickable"
+      class="scrollback-sender scrollback-inline-button nick-clickable"
       onClick={() => handlers.onNickClick(nick)}
       onContextMenu={(e: MouseEvent) => handlers.onNickContextMenu(nick, e)}
     >
@@ -677,7 +677,7 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
   const bareSenderSpan = (nick: string): JSX.Element => (
     <button
       type="button"
-      class="scrollback-sender nick-clickable"
+      class="scrollback-sender scrollback-inline-button nick-clickable"
       onClick={() => handlers.onNickClick(nick)}
       onContextMenu={(e: MouseEvent) => handlers.onNickContextMenu(nick, e)}
     >

--- a/cicchetto/src/__tests__/Login.test.tsx
+++ b/cicchetto/src/__tests__/Login.test.tsx
@@ -522,3 +522,31 @@ describe("Login — captcha flow (carried forward)", () => {
     expect(mountCaptchaWidget).not.toHaveBeenCalled();
   });
 });
+
+// #740 — the CSS half of this pair is pinned in sharedButtonRules.test.ts.
+// This is the other half: a shared rule that nothing wears is the #734
+// failure mode inverted, and the two buttons this rule unifies sit in one
+// flex row under align-items: center, so a class missing from one of them
+// is a visible height mismatch rather than a cosmetic nit.
+describe("Login — #740 the quiet text-buttons wear the shared class", () => {
+  it("puts .login-quiet-button on the Advanced toggle and on both alt-auth buttons", () => {
+    renderLogin();
+    const quiet = [
+      screen.getByRole("button", { name: /Advanced/ }),
+      passkeyBtn(),
+      screen.getByRole("button", { name: "Recovery code" }),
+    ];
+    for (const button of quiet) {
+      expect(button.classList.contains("login-quiet-button")).toBe(true);
+    }
+  });
+
+  it("keeps the per-instance classes the e2e clicks as strict single matches", () => {
+    // issue281: `.login-advanced-toggle` must stay ONE element per rendered
+    // branch and `.login-alt-auth` exactly two. Composing a second class
+    // must not disturb either count.
+    renderLogin();
+    expect(document.querySelectorAll(".login-advanced-toggle")).toHaveLength(1);
+    expect(document.querySelectorAll(".login-alt-auth")).toHaveLength(2);
+  });
+});

--- a/cicchetto/src/__tests__/MircText.test.tsx
+++ b/cicchetto/src/__tests__/MircText.test.tsx
@@ -209,6 +209,8 @@ describe("MircText channel affordance (#648)", () => {
       <MircBody body="join #Sniffo now" emphasis onChannelClick={spy} />
     ));
     const btn = container.querySelector(".channel-clickable") as HTMLButtonElement;
+    // #740 — wears the shared inline-button reset beside its own class.
+    expect(btn.classList.contains("scrollback-inline-button")).toBe(true);
     expect(btn).not.toBeNull();
     // display-cased, raw (keys fold downstream; the affordance shows what
     // the sender typed).

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -1978,6 +1978,10 @@ describe("ScrollbackPane", () => {
       render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
       const sender = document.querySelector(".scrollback-sender");
       expect(sender?.classList.contains("nick-clickable")).toBe(true);
+      // #740 — and the shared inline-button reset it now takes its shape
+      // from. The CSS half is pinned in sharedButtonRules.test.ts; a rule
+      // nothing wears is the #734 failure mode inverted.
+      expect(sender?.classList.contains("scrollback-inline-button")).toBe(true);
     });
   });
 
@@ -3092,6 +3096,8 @@ describe("ScrollbackPane", () => {
       const btn = line.querySelector(".scrollback-invite-join") as HTMLButtonElement;
       expect(btn).not.toBeNull();
       expect(btn.textContent).toContain("Join");
+      // #740 — wears the shared inline-button reset beside its own class.
+      expect(btn.classList.contains("scrollback-inline-button")).toBe(true);
     });
 
     it("INVITE [Join] click invokes postJoin + setSelectedChannel", async () => {

--- a/cicchetto/src/__tests__/sharedButtonRules.test.ts
+++ b/cicchetto/src/__tests__/sharedButtonRules.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import { ruleBody, themeCss } from "./helpers/themeCss";
+
+// #740 — two sets of buttons had been styled by copying a rule instead of
+// sharing one. The guard is not "a shared rule exists" (that would pass with
+// the clones still in place beside it) but "the per-instance rules no longer
+// DECLARE the shared properties" — the clone is what drifts, so the clone is
+// what the test has to see gone.
+//
+// jsdom applies no stylesheet, so this reads the source. It proves what the
+// cascade is asked to do, never what a browser paints.
+
+function declares(body: string, property: string): boolean {
+  return new RegExp(`(^|;)\\s*${property}\\s*:`, "m").test(body);
+}
+
+// `ruleBody` throws on an absent rule — the #734 guard against a class name
+// with nothing behind it. Here the absence is the POINT: a per-instance class
+// that has no delta left carries no rule of its own and takes its paint from
+// the shared class it is worn beside. "No rule" and "a rule declaring no
+// shared property" are the same pass.
+function deltaBody(selector: string): string {
+  try {
+    return ruleBody(selector);
+  } catch {
+    return "";
+  }
+}
+
+describe("#740 — the login card's quiet text-buttons share ONE rule", () => {
+  // .login-advanced-toggle and .login-alt-auth were byte-identical: nine
+  // declarations each. They sit in the same flex row under
+  // align-items: center, so a padding or min-height tweak landing on one and
+  // not the other is visible as a height mismatch.
+  const SHARED = [
+    "background",
+    "color",
+    "border",
+    "text-align",
+    "padding",
+    "min-height",
+    "font-family",
+    "font-size",
+    "cursor",
+  ];
+
+  it("declares the quiet text-button shape once", () => {
+    const shared = ruleBody(".login-quiet-button");
+    for (const property of SHARED) {
+      expect(declares(shared, property), `.login-quiet-button declares ${property}`).toBe(true);
+    }
+  });
+
+  it("keeps the 44px tap floor on the shared rule, not on a copy", () => {
+    expect(ruleBody(".login-quiet-button")).toMatch(/min-height:\s*var\(--tap-min\)/);
+  });
+
+  it("hovers to --fg once, for both instances", () => {
+    expect(ruleBody(".login-quiet-button:hover")).toMatch(/color:\s*var\(--fg\)/);
+  });
+
+  it.each([".login-advanced-toggle", ".login-alt-auth"])(
+    "%s no longer re-declares any shared property",
+    (selector) => {
+      const body = deltaBody(selector);
+      for (const property of SHARED) {
+        expect(declares(body, property), `${selector} must not re-declare ${property}`).toBe(false);
+      }
+    },
+  );
+});
+
+describe("#740 — the scrollback's inline buttons share ONE reset", () => {
+  // .nick-clickable / .channel-clickable / .scrollback-invite-join are three
+  // copies of the same "render a <button> as inline text" reset. Their real
+  // deltas stay local: colour, padding, font-weight, and the #250
+  // user-select: text that the [Join] CTA deliberately does not carry.
+  const SHARED = ["cursor", "background", "border", "font", "display"];
+
+  it("declares the inline-button reset once", () => {
+    const shared = ruleBody(".scrollback-inline-button");
+    for (const property of SHARED) {
+      expect(declares(shared, property), `.scrollback-inline-button declares ${property}`).toBe(
+        true,
+      );
+    }
+  });
+
+  it("underlines on hover once, for all three", () => {
+    expect(ruleBody(".scrollback-inline-button:hover")).toMatch(/text-decoration:\s*underline/);
+  });
+
+  it.each([".nick-clickable", ".channel-clickable", ".scrollback-invite-join"])(
+    "%s no longer re-declares any shared property",
+    (selector) => {
+      const body = deltaBody(selector);
+      for (const property of SHARED) {
+        expect(declares(body, property), `${selector} must not re-declare ${property}`).toBe(false);
+      }
+    },
+  );
+
+  it("leaves the genuine per-instance deltas local", () => {
+    // Each of these differs from its siblings, so sharing them would be the
+    // opposite defect — one rule flattening three intended looks.
+    expect(ruleBody(".channel-clickable")).toMatch(/color:\s*var\(--accent\)/);
+    expect(ruleBody(".scrollback-invite-join")).toMatch(/font-weight:\s*bold/);
+    expect(ruleBody(".scrollback-invite-join")).toMatch(/padding:\s*0 0\.25em/);
+  });
+
+  it("keeps user-select: text off the [Join] CTA and on the two text tokens", () => {
+    // #250 — the nick and the #channel must stay inside a drag selection on
+    // Android; the [Join] CTA is deliberately not copyable (keepKeyboard.ts).
+    // If the shared reset ever absorbs user-select, this is what catches it.
+    expect(ruleBody(".nick-clickable")).toMatch(/user-select:\s*text/);
+    expect(ruleBody(".channel-clickable")).toMatch(/user-select:\s*text/);
+    expect(ruleBody(".scrollback-invite-join")).not.toMatch(/user-select/);
+    expect(ruleBody(".scrollback-inline-button")).not.toMatch(/user-select/);
+  });
+});
+
+describe("#740 — the shared rules are worn, not merely declared", () => {
+  // The #734 failure mode, inverted: a rule with no element behind it. The
+  // markup assertions live with their components (Login.test.tsx,
+  // ScrollbackPane.test.tsx); this one guards the CSS side of the pair —
+  // that nothing re-introduces a fourth copy of either shape.
+  it("no rule outside the shared one carries the quiet-button signature", () => {
+    // Keyed on the SHAPE, not on the 44px tap-target convention: an earlier
+    // draft matched padding+min-height alone and flagged
+    // `.archive-modal-group-summary`, which is a bold accent flex row that
+    // merely honours the same HIG floor. The signature that identifies a
+    // clone is transparent background + the mono face + that padding.
+    const clones = [...themeCss.matchAll(/^(\.[a-z0-9-]+)\s*\{([^}]*)\}/gm)].filter(
+      ([, , body]) =>
+        body !== undefined &&
+        /background:\s*transparent/.test(body) &&
+        /font-family:\s*var\(--font-mono\)/.test(body) &&
+        /padding:\s*0\.6rem 0\.25rem/.test(body),
+    );
+    expect(clones.map(([, selector]) => selector)).toEqual([".login-quiet-button"]);
+  });
+});

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -832,10 +832,19 @@ html.overlay-open #root > div {
   cursor: not-allowed;
 }
 
-/* #204 — Advanced disclosure toggle. Quiet text-button between the nick
-   input and Connect (vjt layout fix). Full-width comfortable tap target,
-   left-aligned so the ▸/▾ affordance reads as a disclosure, not a CTA. */
-.login-advanced-toggle {
+/* #740 — the quiet text-button of the login card, declared ONCE. It was
+   two byte-identical rules (#204's Advanced disclosure and #442's alt-auth
+   pair): nine declarations copied, in the same flex row under
+   align-items: center, so a padding or min-height tweak landing on one and
+   not the other shows up as a height mismatch between buttons that sit
+   side by side.
+
+   Worn ALONGSIDE the per-instance class, never instead of it: both
+   `.login-advanced-toggle` and `.login-alt-auth` are selector contracts the
+   e2e clicks as strict single matches (issue281), so they keep their names
+   and their own rules — which now hold only what genuinely differs. Today
+   that is nothing; the rules stay as the documented place for a delta. */
+.login-quiet-button {
   background: transparent;
   color: var(--muted);
   border: none;
@@ -847,9 +856,16 @@ html.overlay-open #root > div {
   cursor: pointer;
 }
 
-.login-advanced-toggle:hover {
+.login-quiet-button:hover {
   color: var(--fg);
 }
+
+/* #204's Advanced disclosure toggle and #442's alt-auth pair keep their
+   class names — both are selector contracts the e2e clicks as strict single
+   matches (issue281) — but no longer carry a rule of their own: they wear
+   .login-quiet-button beside it for the shape, and have no delta to declare.
+   A future per-instance tweak goes in a rule reintroduced here, not by
+   re-copying the block above. */
 
 /* #442 — the alt-auth entry points ride the Advanced toggle's row so they
    add NO height to the card. On 1024x900 with Advanced open the form is
@@ -866,26 +882,6 @@ html.overlay-open #root > div {
    the leading edge it has on main. */
 .login-alt-auth-row .login-advanced-toggle {
   margin-right: auto;
-}
-
-/* #442 — alternate auth entry points (passkey / recovery code). Same quiet
-   text-button look as the disclosure toggle, but a class of its own: the e2e
-   clicks .login-advanced-toggle as a strict single match, so that selector
-   must stay one element per rendered branch. */
-.login-alt-auth {
-  background: transparent;
-  color: var(--muted);
-  border: none;
-  text-align: left;
-  padding: 0.6rem 0.25rem;
-  min-height: var(--tap-min);
-  font-family: var(--font-mono);
-  font-size: 0.9rem;
-  cursor: pointer;
-}
-
-.login-alt-auth:hover {
-  color: var(--fg);
 }
 
 .login-advanced {
@@ -2404,15 +2400,34 @@ html.resize-dragging * {
   color: var(--accent);
 }
 
-/* C7.6: clickable nick — pointer cursor + subtle hover underline.
-   Applied to <button> elements in scrollback so they render inline. */
-.nick-clickable {
+/* #740 — "render a <button> as inline text", declared ONCE. It was three
+   copies (.nick-clickable, .channel-clickable, .scrollback-invite-join),
+   each carrying the same five-declaration reset plus the same hover
+   underline. Worn ALONGSIDE the per-instance class, which keeps only what
+   genuinely differs — colour, padding, font-weight, and the #250
+   user-select the [Join] CTA deliberately does not take.
+
+   Deliberately NOT a `.scrollback :where(button)` floor in the #735 shape:
+   the scrollback also holds buttons that are not inline text (the
+   scroll-to-bottom badge, the far-behind jump/dismiss pair), and
+   `display: inline` would break them. The shape belongs to these three
+   controls, not to their container. */
+.scrollback-inline-button {
   cursor: pointer;
   background: none;
   border: none;
-  padding: 0;
   font: inherit;
   display: inline;
+}
+
+.scrollback-inline-button:hover {
+  text-decoration: underline;
+}
+
+/* C7.6: clickable nick — the inline-text button reset above, with no padding
+   and the #250 selection carve-out. */
+.nick-clickable {
+  padding: 0;
   /* #250 (2026-07-15): keep the nick INSIDE a drag text-selection on
      EVERY platform — unconditional, NOT gated behind `html.is-ios`. The
      nick is an interactive inline <button>; Android's native touch-
@@ -2435,50 +2450,27 @@ html.resize-dragging * {
   user-select: text;
 }
 
-.nick-clickable:hover {
-  text-decoration: underline;
-}
-
-/* #648: clickable #channel in scrollback — an inline <button> (same
-   transparent-inline shape as .nick-clickable) tinted with the accent so a
+/* #648: clickable #channel in scrollback — tinted with the accent so a
    channel token reads as a link-like join affordance, distinct from a plain
    nick. user-select: text mirrors .nick-clickable (#250): the token stays
    inside a drag text-selection on every platform while the tap-to-join
    handler stays intact; keyboard/focus policy is owned separately by
    keepKeyboard.ts's SELECTABLE_TEXT_EXCLUDE (#354, #648). */
 .channel-clickable {
-  cursor: pointer;
-  background: none;
-  border: none;
   padding: 0;
-  font: inherit;
-  display: inline;
   color: var(--accent);
   -webkit-user-select: text;
   user-select: text;
 }
 
-.channel-clickable:hover {
-  text-decoration: underline;
-}
-
 /* No-silent-drops bucket 2: [Join] CTA inline button on INVITE rows.
-   Same shape as .nick-clickable (transparent button rendered inline)
-   but with explicit accent color + bracketed visual weight so the
-   click affordance is loud against the muted notice row. */
+   Explicit accent color + bracketed visual weight so the click affordance is
+   loud against the muted notice row. No user-select: unlike the two text
+   tokens this is a control, not copyable text (keepKeyboard.ts). */
 .scrollback-invite-join {
-  cursor: pointer;
-  background: none;
-  border: none;
   padding: 0 0.25em;
-  font: inherit;
-  display: inline;
   color: var(--accent);
   font-weight: bold;
-}
-
-.scrollback-invite-join:hover {
-  text-decoration: underline;
 }
 
 /* No-silent-drops bucket 4: clickable URLs in scrollback bodies.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -26546,7 +26546,11 @@ Enabling or disabling TOTP revokes every other web session. Disabling requires
 the account password. TOTP failures share one public error and are limited to
 ten failures per IP/account over fifteen minutes.
 
-Passkeys, recovery-code regeneration, and email recovery remain out of scope.
+Recovery-code regeneration and email recovery remain out of scope. Passkeys did
+too when this was written — they shipped two days later, and the entry below
+(2026-08-04 — #442/#736) is the record. Amended in place rather than left
+standing with a correction bolted on: a decision log is a coherent account, not
+a wall of caveats, and the next session reads the sentence, not the thread.
 
 ### 2026-08-02 — #666 — multi-line paste is resumable + self-pacing; the send-door 429 carries a retry-after (P0, cross-stack)
 
@@ -28504,3 +28508,86 @@ per-page-load, so every reload re-pays upstream for an answer grappa already
 received. The precedent already exists — `userhost_cache` is nick-keyed, folded,
 fed passively from JOIN prefixes at zero upstream cost, and already migrated on
 NICK. Cache the answer, and the question of when to fetch mostly dissolves.
+
+---
+
+### 2026-08-04 — #442 / #736 — passkeys: the mode ladder, and why passwordless costs two steps
+
+Written retroactively (#740). The passkey surface shipped across #442 and #736
+while the only entry that mentioned passkeys said they were out of scope, so a
+session reading the log in good faith would have concluded passwordless login
+does not exist — and then re-litigated or re-implemented it. The #442 entry is
+amended above; this is the record it points at. Everything below is stated as
+BEHAVIOUR, verified against `main` @ `942f642b`.
+
+**One account, three modes.** `users.passkey_mode` is
+`:disabled | :second_factor | :passwordless`, default `:disabled`, and it is
+the account's whole passkey posture — not a per-credential property. What a
+password login does depends only on it:
+
+* `:disabled` — password authenticates; TOTP still applies if armed (#442).
+* `:second_factor` — password authenticates, then a passkey assertion
+  completes. It sits AHEAD of TOTP in the ladder: an account with both armed
+  is asked for the passkey, not the code.
+* `:passwordless` — a password login is **refused**, and refused with the same
+  `:invalid_credentials` answer a wrong password gets. The uniform oracle is
+  the point: which credential half is wrong, and whether an account is
+  passwordless at all, are both things the login door declines to say.
+
+**Registration always costs the password**, in every mode. A passkey is a
+credential being minted, so minting one is a re-authentication, not a
+setting toggle.
+
+**Passwordless is armed in two steps, and cannot be armed in one.** The
+mode-change door (`POST /me/passkeys/mode/options`) admits `:second_factor` and
+`:disabled` only; handing it `passwordless` is a `bad_request`, deliberately and
+permanently. Arming passwordless goes:
+
+1. `POST /me/passkeys/passwordless/recovery` — password re-checked, ten
+   recovery codes generated and **shown once**, returned with a recovery token.
+2. `POST /me/passkeys/passwordless/options` — the token is redeemed for the
+   ceremony challenge; the assertion then flips the mode and stores the code
+   hashes in the same transaction.
+
+The token IS the proof that step 1 happened. Without it the ladder could be
+climbed to a state where the password no longer works and the only fallback
+has never been displayed — an account locked out by a successful operation.
+It expires in ten minutes, and it is **encrypted rather than signed**: it
+carries the plaintext codes, and a signed token is tamper-proof but perfectly
+readable by anything it passes through. The invariant is enforced at the
+context boundary too, not just by route shape: `set_mode/4` accepts
+`:passwordless` only with exactly ten codes and the other two modes only with
+none, so a caller that skips the handshake fails loudly instead of arriving at
+a half-armed account.
+
+**A passkey belongs to THIS deployment's origin.** WebAuthn binds a credential
+to the origin that registered it, and it will refuse to answer for any other.
+So the origin grappa asserts is a durable property of the deployment, not of
+the request in flight: operators fronting the bouncer with a public origin
+Phoenix would not derive set `GRAPPA_PASSKEY_ORIGIN`, and everyone else gets
+the Endpoint's public URL. The relying-party id is that origin's host. Two
+consequences worth stating before someone rediscovers them the hard way:
+**changing the public origin of a live deployment invalidates every passkey
+already registered against it**, and an account in `:passwordless` mode whose
+origin moved has no password to fall back on — only its recovery codes. This is
+also why the value is resolved in one place rather than derived per controller:
+two derivations are two chances to disagree, and the disagreement would surface
+as an unexplained authenticator refusal on a user's device.
+
+Ceremonies are single-use and short-lived — challenges are held server-side for
+five minutes and swept, user verification is `required` (the authenticator must
+prove a human, not merely possession).
+
+**The recovery codes are ONE account-level set, shared with TOTP.** Not a
+passkey-specific pool that happens to look similar — the same ten codes, the
+same table, the same one-shot semantics as #442. So arming passwordless
+**replaces** whatever recovery codes a TOTP user was already holding, and the
+old printout stops working. That is deliberate (one fallback credential per
+account beats two that can disagree about which is current) and it is the
+sharpest edge on this surface: it is the one step that silently invalidates
+something the user was told to keep safe. The codes shown in step 1 above are
+the account's codes from that moment on.
+
+**Still out of scope**, and unchanged by any of this: recovery-code
+regeneration as its own verb — the set is replaced as a side effect of arming
+TOTP or passwordless, never on demand — and email recovery.


### PR DESCRIPTION
Code-review finding #740. Two defects of the same shape — a second copy that will drift from the first — in two commits.

Every cited line was re-verified against `main` @ `942f642b` before being touched. Both defects are alive; neither had drifted.

## 1. The decision log denied that passkeys exist

`docs/DESIGN_NOTES.md`'s only passkey mention was #442's closing *"Passkeys, recovery-code regeneration, and email recovery remain out of scope"* — while #442 and #736 shipped registration, both modes, recovery codes and the mode-change ceremony.

That sentence is **amended in place**, not left standing with a correction further down. A decision log is a coherent account, not a wall of caveats: the next session reads the sentence, not the thread. It now points forward to the new entry.

The new entry states **behaviour, not the config-reading mechanism** — #750 is moving `passkey_origin` onto a `:persistent_term` seam in parallel, and an entry describing today's plumbing would be wrong by the time anyone reads it. Where it does touch mechanism it was verified on `main` at the time of writing.

Covered: the three-mode ladder and where `:second_factor` sits relative to TOTP; the uniform `invalid_credentials` oracle a passwordless account answers a password with, and why that uniformity is the point; why arming passwordless costs two steps and cannot be folded into one — including why the recovery token is *encrypted* rather than signed, and why `set_mode/4` re-checks at the context boundary an invariant the route shape already implies; the origin binding, with the two consequences worth knowing before rediscovering them the hard way — **moving a live deployment's public origin invalidates every passkey already registered**, and a `:passwordless` account whose origin moved has no password to fall back on.

🔴 **One thing the finding did not ask for, added because it is the sharpest edge on this surface:** the recovery codes are **one account-level set shared with TOTP** (`Accounts.RecoveryCodes` — *"shared by TOTP and passkeys"*, and `replace/2` deletes all rows before inserting). So arming passwordless **replaces the codes a TOTP user was already holding**, and their old printout silently stops working. It is the one step here that invalidates something the user was told to keep safe, and it was written nowhere.

## 2. Two cloned button shapes

`.login-alt-auth` was nine declarations byte-identical to `.login-advanced-toggle`; the two sit in the same flex row under `align-items: center`, so a padding or `min-height` tweak landing on one and not the other is a visible height mismatch. `.nick-clickable` / `.channel-clickable` / `.scrollback-invite-join` were three copies of the same "render a `<button>` as inline text" reset.

Each becomes one rule — `.login-quiet-button` and `.scrollback-inline-button` — worn **alongside** the per-instance class. The class names are load-bearing beyond paint: `.login-advanced-toggle` and `.login-alt-auth` are selector contracts the e2e clicks as strict single matches (issue281), and `keepKeyboard.ts` keys its `SELECTABLE_TEXT_EXCLUDE` off the scrollback trio. Composing a second class disturbs neither; the counts are pinned by a test.

Only genuine deltas stay local: colour, padding, `font-weight`, and the #250 `user-select: text` the two text tokens carry and the [Join] CTA deliberately does not. Where a class had no delta left, its rule is **deleted** rather than left empty, with a comment saying where a future delta goes.

**Not done as a `.scrollback :where(button)` floor in #735's shape**, which was the tempting precedent from this morning: the scrollback also holds the scroll-to-bottom badge and the far-behind jump/dismiss pair, and `display: inline` would break them. The shape belongs to these three controls, not to their container.

### The guard is the clone's absence, not the shared rule's presence

Asserting "a shared rule exists" passes with the clones still sitting beside it. So the tests assert the per-instance rules **no longer declare** the shared properties, plus a signature scan for a fourth copy — and the markup assertions check the shared class is actually **worn**, which is the #734 failure mode inverted (a rule with no element behind it).

- **13 CSS assertions, 12 failed before the fix** (the 13th pins the deltas that must stay local, and correctly passed throughout).
- **The scan found a real false positive of its own**: an earlier draft keyed on `padding` + `min-height` and flagged `.archive-modal-group-summary`, which is a bold accent flex row merely honouring the same 44px HIG floor. It now keys on the shape (transparent background + mono face + that padding).
- **Markup assertions verified by mutation** — stripping the shared classes from all four call sites turns 4 tests red across `Login`, `ScrollbackPane` and `MircText`; restored after.

jsdom applies no stylesheet, so all of this proves what the cascade is *asked* to do, never what a browser paints.

## Gates

From the worktree root: `check:fix` (fixed 1 file, committed) · `check` **rc=0** · `tsc --noEmit` standalone **rc=0** · `test` **rc=0, 233 files / 4203 tests**.

Server-side code untouched; the only non-cic file is `docs/DESIGN_NOTES.md`. No stack or compile lane used.