### PR TITLE
auth(#768): ride out SQLite contention on the passkey writes

### DIFF
--- a/lib/grappa/accounts/webauthn.ex
+++ b/lib/grappa/accounts/webauthn.ex
@@ -48,16 +48,24 @@ defmodule Grappa.Accounts.WebAuthn do
          {:ok, {auth_data, _}} <- Wax.register(attestation, client_data, challenge) do
       credential = auth_data.attested_credential_data
 
-      %Passkey{}
-      |> Passkey.changeset(%{
-        user_id: user.id,
-        credential_id: credential.credential_id,
-        public_key: CBOR.encode(credential.credential_public_key),
-        sign_count: auth_data.sign_count,
-        name: name,
-        transports: %{"values" => List.wrap(params["transports"])}
-      })
-      |> Repo.insert()
+      changeset =
+        Passkey.changeset(%Passkey{}, %{
+          user_id: user.id,
+          credential_id: credential.credential_id,
+          public_key: CBOR.encode(credential.credential_public_key),
+          sign_count: auth_data.sign_count,
+          name: name,
+          transports: %{"values" => List.wrap(params["transports"])}
+        })
+
+      # #768 — ride out a transient SQLITE_BUSY on the credential insert rather
+      # than raising a 500 at the end of a ceremony the user cannot cheaply
+      # repeat. `Repo.insert/1` already returns the `{:ok, _} | {:error,
+      # changeset}` shape `BusyRetry.run/1` wants, so the wrap is the whole
+      # change; sustained saturation degrades to `{:error, :db_unavailable}`.
+      # This is the `with` BODY, not a `<-` clause, so it bypasses the
+      # `:invalid_passkey` else and reaches the caller intact.
+      Repo.BusyRetry.run(fn -> Repo.insert(changeset) end)
     else
       false -> {:error, :invalid_passkey}
       {:error, _} -> {:error, :invalid_passkey}
@@ -155,7 +163,8 @@ defmodule Grappa.Accounts.WebAuthn do
   one statement the second request re-decides against the row the first
   already removed, and loses.
   """
-  @spec delete(User.t(), Ecto.UUID.t()) :: :ok | {:error, :not_found | :passkey_required}
+  @spec delete(User.t(), Ecto.UUID.t()) ::
+          :ok | {:error, :not_found | :passkey_required | :db_unavailable}
   def delete(%User{passkey_mode: :disabled} = user, id), do: run_delete(user, id, owned(user, id))
 
   def delete(user, id) do
@@ -166,10 +175,23 @@ defmodule Grappa.Accounts.WebAuthn do
 
   defp owned(user, id), do: from(p in Passkey, where: p.id == ^id and p.user_id == ^user.id)
 
+  # #768 — ride out a transient SQLITE_BUSY on the credential delete; sustained
+  # saturation degrades to `{:error, :db_unavailable}` (a 503 at the REST
+  # caller) rather than raising a 500. Wrap the delete in an `{:ok, _}` so the
+  # op honours the `BusyRetry.run/1` contract, as `QueryWindows.close/3` does.
+  # `refuse_delete/2` stays OUTSIDE the retry: it is a read, and re-running it
+  # per attempt would re-decide a question the delete already answered.
   defp run_delete(user, id, query) do
-    case Repo.delete_all(query) do
-      {1, _} -> :ok
-      {0, _} -> refuse_delete(user, id)
+    result =
+      Repo.BusyRetry.run(fn ->
+        {count, _} = Repo.delete_all(query)
+        {:ok, count}
+      end)
+
+    case result do
+      {:ok, 1} -> :ok
+      {:ok, 0} -> refuse_delete(user, id)
+      {:error, :db_unavailable} = err -> err
     end
   end
 

--- a/lib/grappa_web/controllers/passkey_controller.ex
+++ b/lib/grappa_web/controllers/passkey_controller.ex
@@ -52,6 +52,10 @@ defmodule GrappaWeb.PasskeyController do
   def register(%{assigns: %{current_subject: {:user, user}}} = conn, params) do
     case WebAuthn.complete_registration(user, params, client_binding(conn)) do
       {:ok, passkey} -> conn |> put_status(:created) |> json(public_passkey(passkey))
+      # #768 — a saturated writer is not a bad authenticator. Without this the
+      # BusyRetry wrap around the insert would only downgrade the 500 into a
+      # LIE, telling the user their brand-new credential was rejected.
+      {:error, :db_unavailable} = err -> err
       _ -> {:error, :invalid_two_factor}
     end
   end
@@ -145,6 +149,13 @@ defmodule GrappaWeb.PasskeyController do
          {:ok, ^mode} <- WebAuthn.set_mode(user, mode, session_id, Map.get(metadata, :recovery_codes, [])) do
       json(conn, %{mode: mode})
     else
+      # #768 — `set_mode/4` rides out contention through `Repo.BusyRetry`, so
+      # `:db_unavailable` is a legitimate outcome here. Collapsing it into the
+      # oracle told the user their authenticator was wrong and sent them to
+      # retry a ceremony that could not succeed; the honest answer is the 503
+      # FallbackController already maps. Everything BELOW stays opaque on
+      # purpose — this is an authentication oracle, not a diagnostic surface.
+      {:error, :db_unavailable} = err -> err
       _ -> {:error, :invalid_two_factor}
     end
   end

--- a/test/grappa/accounts/passkey_test.exs
+++ b/test/grappa/accounts/passkey_test.exs
@@ -270,6 +270,24 @@ defmodule Grappa.Accounts.PasskeyTest do
       assert Repo.aggregate(Passkey, :count, :id) == 0
     end
 
+    # #768 — the delete is a WRITE, so a transient SQLITE_BUSY under WAL with
+    # pool_size > 1 used to raise straight out of `Repo.delete_all/1` and land
+    # on the caller as a 500. Wrapped in `Repo.BusyRetry`, sustained saturation
+    # degrades to `{:error, :db_unavailable}` — the token FallbackController
+    # already turns into a clean 503. The pool_size:1 Sandbox cannot produce a
+    # real busy, so the engine's :test-only per-process fault seam forces one
+    # (same lever as the #523 themes-copy repro); ExUnit gives each test its
+    # own process, so the injection cannot leak.
+    test "a delete held off by a saturated writer degrades, it does not raise", ctx do
+      passkey = add_passkey(ctx.user, <<1>>)
+      Repo.BusyRetry.inject_transient_faults(10_000)
+
+      assert {:error, :db_unavailable} = WebAuthn.delete(ctx.user, passkey.id)
+
+      Repo.BusyRetry.inject_transient_faults(0)
+      assert Repo.aggregate(Passkey, :count, :id) == 1
+    end
+
     test "a credential owned by someone else is not found, armed or not", ctx do
       other = add_passkey(user_fixture(), <<3>>)
       {:ok, :passwordless} = WebAuthn.set_mode(ctx.user, :passwordless, ctx.session.id, codes())

--- a/test/grappa_web/controllers/passkey_controller_test.exs
+++ b/test/grappa_web/controllers/passkey_controller_test.exs
@@ -250,6 +250,37 @@ defmodule GrappaWeb.PasskeyControllerTest do
     end
   end
 
+  # #768 — DELETE is the one passkey write a test can drive end-to-end without
+  # forging a WebAuthn ceremony, so it is where the 500-vs-503 contract gets
+  # pinned at the wire. `verify_password/2` ahead of it is pure Argon2 and
+  # touches no BusyRetry op, so the injected fault can only land on the delete.
+  test "deleting a passkey behind a saturated writer is a 503, not a 500", %{conn: conn} do
+    {user, password} = user_fixture_with_password()
+    session = session_fixture(user)
+
+    passkey =
+      Repo.insert!(
+        Passkey.changeset(%Passkey{}, %{
+          user_id: user.id,
+          credential_id: <<9, 9, 9>>,
+          public_key: CBOR.encode(%{1 => 2, 3 => -7}),
+          name: "phone"
+        })
+      )
+
+    Grappa.Repo.BusyRetry.inject_transient_faults(10_000)
+
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer #{session.id}")
+      |> delete("/me/passkeys/#{passkey.id}", %{"password" => password})
+
+    assert json_response(conn, 503) == %{"error" => "db_unavailable"}
+
+    Grappa.Repo.BusyRetry.inject_transient_faults(0)
+    assert Repo.aggregate(Passkey, :count, :id) == 1
+  end
+
   test "last passkey can be deleted after returning to password login", %{conn: conn} do
     {user, password} = user_fixture_with_password()
     session = session_fixture(user)


### PR DESCRIPTION
Review finding #768. Both halves, minus the one the finding itself flags
as a design call.

## Half 1 — two of the three writes now ride out contention

`Repo.BusyRetry` exists so EVERY write path can wrap its op the same way
(#523/#518). `complete_registration/3` ran a bare `Repo.insert/1` and
`delete/2` a bare `Repo.delete_all/1`, so under WAL with `pool_size > 1`
a transient busy raised straight through as a 500 — a credential
registration behind a slow writer crashed instead of riding out the
burst.

- The insert already returns the `{:ok, _} | {:error, changeset}` shape
  the contract wants, so the wrap is the whole change. It sits in the
  `with` **body**, not a `<-` clause, so it bypasses the
  `:invalid_passkey` else and reaches the caller intact.
- The delete borrows the `{:ok, count}` wrapper `QueryWindows.close/3`
  already uses for the same reason.
- `refuse_delete/2` deliberately stays OUTSIDE the retry: it is a read,
  and re-running it per attempt would re-decide a question the delete
  already answered.

## Half 2 — and the same lie the finding did not spot

`set_mode/2` gets its `:db_unavailable` clause ahead of the catch-all,
as prescribed.

**`register/2` had the identical defect** (`passkey_controller.ex:55`,
`_ -> {:error, :invalid_two_factor}`) and the finding does not mention
it. It is not optional here: without that clause, wrapping the insert
would not have fixed anything — it would only have changed the defect's
shape, turning a 500 into a *lie* that tells the user the credential
they just created was rejected. Both clauses landed.

The rest of both catch-alls stays opaque on purpose: this is an
authentication oracle, not a diagnostic surface.

## What is NOT here

`consume_sign_count/2` is left alone, per the finding's own reading: it
sits on the assertion hot path whose caller collapses every outcome into
a uniform `:invalid_passkey`, so surfacing a distinct fault there is a
design decision rather than a mechanical wrap. Its consequences are
written up for whoever takes that call; nothing was changed on spec.

## Tests, and the honest limit

The finding says the sandbox offers no way to provoke contention. That
is out of date — `Repo.BusyRetry.inject_transient_faults/1` is the
engine's `:test`-only per-process seam, already the lever behind the
#523 themes-copy repro and five other suites. Contention is fully
deterministic; no test here sleeps.

Covered:

- `WebAuthn.delete/2` degrades to `{:error, :db_unavailable}` and leaves
  the row in place.
- `DELETE /me/passkeys/:id` answers **503 `db_unavailable`**, not a 500.
  `verify_password/2` ahead of it is pure Argon2 and touches no
  BusyRetry op, so the injected fault can only land on the delete.

**Mutation-proven:** unwrapping `run_delete/3` reddens both.

**Not covered, and it cannot be faked:** `register/2` and `set_mode/2`
are only reachable through a real `Wax.register` / `Wax.authenticate`
ceremony, and the suite has no ceremony fixture (nor does e2e — #712
ruled the WebAuthn ceremony out of scope). Their `:db_unavailable`
clauses rest on inspection. A test that armed the fault and never
reached the clause would pass without being able to fail, which is worse
than no test, so none was written. Building a real ES256 ceremony
fixture would close this and unlock the rest of the passkey door — worth
its own issue, not smuggled in here.

## Gates

`scripts/check.sh` — **rc=0**, 8 doctests, 50 properties, **5083 tests,
0 failures**, Dialyzer `Total errors: 0`. Format, Credo strict, Sobelow,
deps.audit clean. Working tree clean before and after.

Integration/e2e not run — the STACK lane is not mine, and nothing here
reaches it.