### PR TITLE
cic(#788): a continuation that outlived its identity does nothing further

### DIFF
--- a/cicchetto/src/lib/__tests__/scrollbackIdentityRotation.test.ts
+++ b/cicchetto/src/lib/__tests__/scrollbackIdentityRotation.test.ts
@@ -2,7 +2,7 @@
 // further: no request on the wire, no write into the store.
 //
 // Every async verb in `scrollback.ts` captures `token()` at entry and then
-// awaits. The nine `onIdentityChange` resets clear STATE; they cancel nothing
+// awaits. The `onIdentityChange` resets clear STATE; they cancel nothing
 // in flight. So a rotation or a detach landing inside one of those awaits
 // leaves the continuation holding a bearer the server has already revoked —
 // and it sends it. Reproduced in a browser on the real bundle (see the issue):
@@ -81,19 +81,33 @@ const row = (id: number): ScrollbackMessage => ({
   meta: {},
 });
 
-// A full `PAGE_LIMIT` page — the shape that makes `refreshScrollback` probe
-// for the remainder, which is the measured #788 site.
-const fullPage = (): ScrollbackMessage[] => Array.from({ length: 200 }, (_, i) => row(i + 1));
+// A full page — the shape that makes `refreshScrollback` probe for the
+// remainder, which is the measured #788 site. The size is read back from the
+// limit the module ASKED for rather than hardcoded to today's `PAGE_LIMIT`:
+// a hardcoded 200 that drifts out of step would stop entering the probe
+// branch at all, and the case would pass because it tested nothing. The
+// "identity holds" control below fails loudly if that ever happens anyway.
+const fullPageFor = (spy: { mock: { calls: unknown[][] } }): ScrollbackMessage[] => {
+  const limit = spy.mock.calls[0]?.[4];
+  if (typeof limit !== "number") throw new Error("no page limit observed on the wire");
+  return Array.from({ length: limit }, (_, i) => row(i + 1));
+};
 
 // Hold a REST call open so the rotation can land strictly inside its await,
 // which is the whole point: the continuation resumes under a bearer the
 // server has already revoked.
-const gate = <T>(): { promise: Promise<T>; release: (value: T) => void } => {
+const gate = <T>(): {
+  promise: Promise<T>;
+  release: (value: T) => void;
+  fail: (err: Error) => void;
+} => {
   let release!: (value: T) => void;
-  const promise = new Promise<T>((resolve) => {
+  let fail!: (err: Error) => void;
+  const promise = new Promise<T>((resolve, reject) => {
     release = resolve;
+    fail = reject;
   });
-  return { promise, release };
+  return { promise, release, fail };
 };
 
 // Rotate and let Solid's effect queue run the identity resets before the
@@ -127,10 +141,25 @@ describe("#788 identity rotation mid-flight", () => {
 
     const pending = refreshScrollback("net", "#probe-stale");
     await rotateTo("tok-b");
-    page.release(fullPage());
+    page.release(fullPageFor(listMessagesAfterSpy));
     await pending;
 
     expect(bearersSeenBy(countMessagesAfterSpy)).not.toContain("tok-a");
+  });
+
+  // The control for the case above: same harness, same full page, no rotation.
+  // Without it, a full page that stopped being full would silently turn the
+  // stale-probe case into an assertion about a branch nobody entered.
+  it("does probe for the remainder when the identity holds", async () => {
+    const { refreshScrollback } = await import("../scrollback");
+    const page = gate<ScrollbackMessage[]>();
+    listMessagesAfterSpy.mockReturnValue(page.promise);
+
+    const pending = refreshScrollback("net", "#probe-live");
+    page.release(fullPageFor(listMessagesAfterSpy));
+    await pending;
+
+    expect(bearersSeenBy(countMessagesAfterSpy)).toContain("tok-a");
   });
 
   it("does not land a page fetched by the old identity in the purged store", async () => {
@@ -159,6 +188,55 @@ describe("#788 identity rotation mid-flight", () => {
     await Promise.all([pendingA, pendingB]);
 
     expect(bearersSeenBy(listMessagesAfterSpy)).toContain("tok-b");
+  });
+
+  // The other half of the lock question. Clearing the Set on rotation is only
+  // safe if the old continuation then keeps its hands off it: its `finally`
+  // would otherwise delete a key the NEW identity re-added, unlocking a fetch
+  // that is still running — and stamp that key as backfilled while it is not.
+  it("does not release or stamp the new identity's in-flight refresh", async () => {
+    const { refreshScrollback } = await import("../scrollback");
+    const { channelKey } = await import("../channelKey");
+    const stale = gate<ScrollbackMessage[]>();
+    const live = gate<ScrollbackMessage[]>();
+    listMessagesAfterSpy.mockReturnValueOnce(stale.promise);
+    listMessagesAfterSpy.mockReturnValueOnce(live.promise);
+
+    const pendingA = refreshScrollback("net", "#held");
+    await rotateTo("tok-b");
+    const pendingB = refreshScrollback("net", "#held");
+    // A's continuation resumes and unwinds while B is still on the wire.
+    stale.release([]);
+    await pendingA;
+
+    // B still holds the key, so a re-entrant call is still a no-op...
+    await refreshScrollback("net", "#held");
+    expect(bearersSeenBy(listMessagesAfterSpy).filter((b) => b === "tok-b")).toHaveLength(1);
+    // ...and nothing has told a spec that B's backfill landed.
+    const stamped = (window as Window & { __cic_scrollbackRefreshed?: Set<string> })
+      .__cic_scrollbackRefreshed;
+    expect(stamped?.has(channelKey("net", "#held"))).not.toBe(true);
+
+    live.release([]);
+    await pendingB;
+  });
+
+  // The reject path, which is the LIKELIER arrival: a bearer revoked while the
+  // request was in flight comes back as `api.ts`'s 401 throw, not as a clean
+  // resolve. `loadInitialScrollback`'s catch releases the load-once gate — the
+  // new identity's gate, past a rotation.
+  it("does not release the new identity's load-once gate when the old fetch 401s", async () => {
+    const { loadInitialScrollback, wasLoaded } = await import("../scrollback");
+    const stale = gate<ScrollbackMessage[]>();
+    listMessagesSpy.mockReturnValueOnce(stale.promise);
+
+    const pendingA = loadInitialScrollback("net", "#gate");
+    await rotateTo("tok-b");
+    const pendingB = loadInitialScrollback("net", "#gate");
+    stale.fail(new Error("401 Unauthorized"));
+    await Promise.all([pendingA, pendingB]);
+
+    expect(wasLoaded("net", "#gate")).toBe(true);
   });
 
   it("does not baseline the cold-open read cursor with a revoked bearer", async () => {

--- a/cicchetto/src/lib/__tests__/scrollbackIdentityRotation.test.ts
+++ b/cicchetto/src/lib/__tests__/scrollbackIdentityRotation.test.ts
@@ -1,0 +1,176 @@
+// #788 — an async scrollback verb that outlives its identity must do NOTHING
+// further: no request on the wire, no write into the store.
+//
+// Every async verb in `scrollback.ts` captures `token()` at entry and then
+// awaits. The nine `onIdentityChange` resets clear STATE; they cancel nothing
+// in flight. So a rotation or a detach landing inside one of those awaits
+// leaves the continuation holding a bearer the server has already revoked —
+// and it sends it. Reproduced in a browser on the real bundle (see the issue):
+// a `/messages/count` went out 10ms AFTER its own bearer was revoked.
+//
+// The harm is not just the 401. It is the #281 harm class: a request for the
+// OLD identity's channel 404s when the new identity is not attached to that
+// network, and the host's `http-404` fail2ban jail bans the client IP at the
+// firewall — a routine account switch self-bans the user.
+//
+// The sibling harm the same continuation causes without touching the wire: the
+// page it already fetched lands in a store the rotation just purged, so the
+// new identity renders the old one's scrollback.
+//
+// The mock of `../auth` here is a REAL Solid signal, not the flat
+// `token: () => value` stub the sibling suites use. That stub is not reactive,
+// so `identityScopedStore`'s `createEffect(on(token))` never fires and no
+// purge ever happens — the rotation these cases turn on would not exist.
+
+import { createSignal } from "solid-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ScrollbackMessage } from "../api";
+
+// Mirrors loadInitialScrollback.test.ts: keep importing scrollback's
+// transitive graph from opening a real WebSocket against jsdom's
+// about:blank base URL.
+vi.mock("../socket", () => ({
+  joinUser: vi.fn(() => ({ on: vi.fn(), push: vi.fn().mockReturnValue({ receive: vi.fn() }) })),
+  joinChannel: vi.fn(() => ({
+    join: vi.fn(() => ({ receive: vi.fn().mockReturnValue({ receive: vi.fn() }) })),
+    on: vi.fn(),
+  })),
+  pushCloseQueryWindow: vi.fn(),
+  pushOpenQueryWindow: vi.fn(),
+  notifyClientClosing: vi.fn(),
+  pushAwaySet: vi.fn(),
+  pushAwayUnset: vi.fn(),
+}));
+
+const [mockToken, setMockToken] = createSignal<string | null>(null);
+vi.mock("../auth", () => ({
+  token: () => mockToken(),
+  setToken: (v: string | null) => setMockToken(v),
+}));
+
+const listMessagesSpy = vi.fn<(...a: unknown[]) => Promise<ScrollbackMessage[]>>();
+const listMessagesAfterSpy = vi.fn<(...a: unknown[]) => Promise<ScrollbackMessage[]>>();
+const countMessagesAfterSpy = vi.fn<(...a: unknown[]) => Promise<number>>();
+vi.mock("../api", async () => {
+  const actual = await vi.importActual<typeof import("../api")>("../api");
+  return {
+    ...actual,
+    listMessages: (...args: unknown[]) => listMessagesSpy(...args),
+    listMessagesAfter: (...args: unknown[]) => listMessagesAfterSpy(...args),
+    countMessagesAfter: (...args: unknown[]) => countMessagesAfterSpy(...args),
+  };
+});
+
+const setReadCursorSpy = vi.fn().mockResolvedValue(undefined);
+vi.mock("../readCursor", async () => {
+  const actual = await vi.importActual<typeof import("../readCursor")>("../readCursor");
+  return {
+    ...actual,
+    setReadCursor: (...args: Parameters<typeof actual.setReadCursor>) => setReadCursorSpy(...args),
+  };
+});
+
+const row = (id: number): ScrollbackMessage => ({
+  id,
+  network: "net",
+  channel: "#bofh",
+  server_time: 1_700_000_000 + id,
+  kind: "privmsg",
+  sender: "peer",
+  body: `line ${id}`,
+  meta: {},
+});
+
+// A full `PAGE_LIMIT` page — the shape that makes `refreshScrollback` probe
+// for the remainder, which is the measured #788 site.
+const fullPage = (): ScrollbackMessage[] => Array.from({ length: 200 }, (_, i) => row(i + 1));
+
+// Hold a REST call open so the rotation can land strictly inside its await,
+// which is the whole point: the continuation resumes under a bearer the
+// server has already revoked.
+const gate = <T>(): { promise: Promise<T>; release: (value: T) => void } => {
+  let release!: (value: T) => void;
+  const promise = new Promise<T>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release };
+};
+
+// Rotate and let Solid's effect queue run the identity resets before the
+// held call is released.
+const rotateTo = async (next: string | null): Promise<void> => {
+  setMockToken(next);
+  await Promise.resolve();
+};
+
+const bearersSeenBy = (spy: { mock: { calls: unknown[][] } }): unknown[] =>
+  spy.mock.calls.map((c) => c[0]);
+
+describe("#788 identity rotation mid-flight", () => {
+  beforeEach(() => {
+    listMessagesSpy.mockReset();
+    listMessagesSpy.mockResolvedValue([]);
+    listMessagesAfterSpy.mockReset();
+    listMessagesAfterSpy.mockResolvedValue([]);
+    countMessagesAfterSpy.mockReset();
+    countMessagesAfterSpy.mockResolvedValue(0);
+    setReadCursorSpy.mockClear();
+    // Each test starts from a clean identity. Setting the token IS a
+    // rotation, so this also fires the store purge between cases.
+    setMockToken("tok-a");
+  });
+
+  it("does not probe with a bearer revoked while the backfill page was in flight", async () => {
+    const { refreshScrollback } = await import("../scrollback");
+    const page = gate<ScrollbackMessage[]>();
+    listMessagesAfterSpy.mockReturnValue(page.promise);
+
+    const pending = refreshScrollback("net", "#probe-stale");
+    await rotateTo("tok-b");
+    page.release(fullPage());
+    await pending;
+
+    expect(bearersSeenBy(countMessagesAfterSpy)).not.toContain("tok-a");
+  });
+
+  it("does not land a page fetched by the old identity in the purged store", async () => {
+    const { refreshScrollback, scrollbackByChannel } = await import("../scrollback");
+    const { channelKey } = await import("../channelKey");
+    const page = gate<ScrollbackMessage[]>();
+    listMessagesAfterSpy.mockReturnValue(page.promise);
+
+    const pending = refreshScrollback("net", "#store-stale");
+    await rotateTo("tok-b");
+    page.release([row(1), row(2)]);
+    await pending;
+
+    expect(scrollbackByChannel()[channelKey("net", "#store-stale")]).toBeUndefined();
+  });
+
+  it("releases the per-key refresh lock on rotation so the new identity can backfill", async () => {
+    const { refreshScrollback } = await import("../scrollback");
+    const stale = gate<ScrollbackMessage[]>();
+    listMessagesAfterSpy.mockReturnValueOnce(stale.promise);
+
+    const pendingA = refreshScrollback("net", "#lock");
+    await rotateTo("tok-b");
+    const pendingB = refreshScrollback("net", "#lock");
+    stale.release([]);
+    await Promise.all([pendingA, pendingB]);
+
+    expect(bearersSeenBy(listMessagesAfterSpy)).toContain("tok-b");
+  });
+
+  it("does not baseline the cold-open read cursor with a revoked bearer", async () => {
+    const { loadInitialScrollback } = await import("../scrollback");
+    const page = gate<ScrollbackMessage[]>();
+    listMessagesSpy.mockReturnValue(page.promise);
+
+    const pending = loadInitialScrollback("net", "#cursor-stale");
+    await rotateTo("tok-b");
+    page.release([row(203), row(202), row(201)]);
+    await pending;
+
+    expect(bearersSeenBy(setReadCursorSpy)).not.toContain("tok-a");
+  });
+});

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -33,7 +33,7 @@ import { getResumeCursor, recordSeen } from "./reconnectBackfill";
 // overlap in a small race window — the same row would otherwise
 // appear twice. `id` is monotonic per the schema's auto-increment column.
 //
-// Identity-scoped state via identityScopedStore (dup-A3 close): nine resets
+// Identity-scoped state via identityScopedStore (dup-A3 close): eleven resets
 // registered (see the registration block below). The factory preserves the A1
 // invariant — registration runs before any verb fires, so no rotation can be
 // missed for want of a registered reset.
@@ -182,6 +182,21 @@ const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): Scrollba
 // one survived: it was never a whole-module property, just an unwritten habit
 // that the three verbs with a single await happened to keep.
 //
+// An await has THREE exits and all three are the verb's own conduct, so the
+// check belongs at each one that touches state:
+//
+//   * resolve — the eleven above.
+//   * reject — `api.ts` throws on any non-ok response, so a bearer revoked
+//     WHILE the request was in flight comes back as a 401 throw, which is the
+//     likelier arrival than a clean resolve. Only one catch in this module
+//     writes state (`loadInitialScrollback` releasing its load-once gate); the
+//     rest log and return, so only that one carries the check.
+//   * finally — the per-key in-flight locks. Past a rotation the reset has
+//     already cleared the Set, so an entry under this key belongs to the
+//     identity that replaced us: deleting it unlocks a fetch that is still
+//     running. Same for the `refreshScrollback` completion stamp, which would
+//     tell a spec that ITS backfill had landed.
+//
 // Not hoisted into `identityScopedStore`: that factory owns the identity
 // TRANSITION (fire the resets), while this owns a verb's own captured
 // identity, which the factory never sees. Sibling modules inline the same
@@ -302,12 +317,13 @@ const exports = identityScopedStore((onIdentityChange) => {
   // reaches the `finally`, and B's `refreshScrollback` for the same key
   // short-circuits in the meantime, so B's window silently never backfills.
   //
-  // Clearing them mid-flight lets A's `finally` delete a key B has since
-  // re-added, which can let a third call for B fetch the same page twice.
-  // Benign and deliberate: `appendToScrollback` dedupes by id, so the cost is
-  // one redundant GET, against a window that otherwise stays empty. A
-  // conditional delete keyed on the captured identity would buy nothing the
-  // dedupe does not already cover.
+  // Clearing a Set mid-flight would otherwise let A's `finally` delete a key B
+  // has since re-added, unlocking a fetch that is still running. Every one of
+  // the four in-flight `finally` blocks therefore releases its key only while
+  // the identity still holds — past a rotation the reset owns the Set and the
+  // continuation owns nothing. (An id-dedupe argument covers only the two
+  // merge paths; `jumpToUnread` REPLACES the key's rows, so a second concurrent
+  // jump would discard whatever landed between the two writes.)
   onIdentityChange(() => loadedChannels.clear());
   onIdentityChange(() => loadMoreInFlight.clear());
   onIdentityChange(() => loadMoreExhausted.clear());
@@ -581,7 +597,7 @@ const exports = identityScopedStore((onIdentityChange) => {
       console.error("[scrollback] jumpToUnread failed", slug, name, err);
       return false;
     } finally {
-      jumpInFlight.delete(key);
+      if (!identityMoved(t)) jumpInFlight.delete(key);
     }
   };
 
@@ -735,6 +751,14 @@ const exports = identityScopedStore((onIdentityChange) => {
     } catch {
       // First-load failure leaves the empty seed in place; the pane
       // shows "no messages yet". A retry mechanism is Phase 5+.
+      //
+      // #788 — the reject path is the likelier arrival for a bearer revoked
+      // in flight (`api.ts` throws the 401), and this gate is identity-scoped
+      // state. Releasing it past a rotation releases the NEW identity's gate:
+      // its next re-select reads `wasLoaded` false, takes the fresh-open arm
+      // that deliberately does NOT fire `refreshScrollback` (#159), and so
+      // skips one live-delivery catch-up while re-paying for a cold load.
+      if (identityMoved(t)) return;
       loadedChannels.delete(key);
     }
   };
@@ -777,7 +801,7 @@ const exports = identityScopedStore((onIdentityChange) => {
       // retry by scrolling again; the in-flight guard releases via
       // the finally clause below.
     } finally {
-      loadMoreInFlight.delete(key);
+      if (!identityMoved(t)) loadMoreInFlight.delete(key);
     }
   };
 
@@ -832,7 +856,7 @@ const exports = identityScopedStore((onIdentityChange) => {
       // Transient error — do NOT latch. The user can retry by scrolling;
       // the in-flight guard releases via the `finally` below.
     } finally {
-      loadNewerInFlight.delete(key);
+      if (!identityMoved(t)) loadNewerInFlight.delete(key);
     }
   };
 
@@ -1048,10 +1072,12 @@ const exports = identityScopedStore((onIdentityChange) => {
       // telemetry hook will replace this.
       console.error("[scrollback] refreshScrollback failed", slug, name, err);
     } finally {
-      refreshInFlight.delete(key);
-      // #552 — mark this backfill DONE (success or error): no more in-flight
-      // DOM recreation for this key, so a spec awaiting it can safely proceed.
-      stampScrollbackRefreshed(key);
+      if (!identityMoved(t)) {
+        refreshInFlight.delete(key);
+        // #552 — mark this backfill DONE (success or error): no more in-flight
+        // DOM recreation for this key, so a spec awaiting it can safely proceed.
+        stampScrollbackRefreshed(key);
+      }
     }
   };
 

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -38,20 +38,20 @@ import { getResumeCursor, recordSeen } from "./reconnectBackfill";
 // invariant — registration runs before any verb fires, so no rotation can be
 // missed for want of a registered reset.
 //
-// #769 — what that does NOT buy, and what this comment used to claim it
+// #788 — what the resets do NOT buy, and what this comment used to claim they
 // did ("a logout/rotation between `loadInitialScrollback` start and finish
-// always wins the race"): the resets clear STATE, they do not cancel a
-// verb already in flight. Every ASYNC verb here captures `token()` at entry
-// and then awaits, and nothing re-checks it afterwards — so a continuation
-// resuming past a rotation still holds the bearer it captured, and the
-// per-key in-flight guards that are NOT in the reset list (`refreshInFlight`,
-// `jumpInFlight`) still hold their keys. Ordering-with-cancellation was
-// never implemented; the wording promised it anyway.
+// always wins the race"): they clear STATE, they do not cancel a verb already
+// in flight. Every ASYNC verb here captures `token()` at entry and then
+// awaits, and nothing used to re-check it afterwards — so a continuation
+// resuming past a rotation still held the bearer it captured, and the per-key
+// in-flight guards that were NOT in the reset list (`refreshInFlight`,
+// `jumpInFlight`) still held their keys. Ordering-with-cancellation was never
+// implemented; the wording promised it anyway.
 //
-// That is not theoretical: delaying the reconnect backfill 400ms in a browser
+// That was not theoretical: delaying the reconnect backfill 400ms in a browser
 // put a `/messages/count` on the wire 10ms AFTER the detach, carrying the
-// revoked bearer. Tracked as its own defect (see #788) — #769 turned out to be
-// a spec race and is NOT that bug.
+// revoked bearer. (#769, which surfaced it, turned out to be a spec race and
+// is NOT that bug.) See `identityMoved` for the rule that closes it.
 //
 // ---------------------------------------------------------------------------
 // CP14 B3 — DM history is now bidirectional server-side.
@@ -150,6 +150,45 @@ const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): Scrollba
   return dropCount > 0 ? rows.slice(dropCount) : rows;
 };
 
+// #788 — THE rule for every async verb in this module: an `await` can span an
+// identity transition, and a continuation that outlived its identity must do
+// NOTHING further. Not one request on the wire, not one write into the store.
+//
+// `t` is the bearer the verb captured at entry — its identity, not merely its
+// credential. Re-read `token()` after the await and compare: if it moved, the
+// verb belongs to an identity that no longer exists here.
+//
+// Both halves of "nothing further" are load-bearing, which is why the check
+// sits after the await rather than in front of each REST call:
+//
+//   * the WIRE half is #788 proper. A request carrying a revoked bearer 401s
+//     at best; for a channel the NEW identity is not attached to it 404s, and
+//     the host's `http-404` fail2ban jail bans the client IP at the firewall.
+//     A routine account switch self-bans the operator — the #281 harm class,
+//     reached through a different door.
+//   * the STORE half is the same continuation without touching the network:
+//     the page it already fetched merges into a map the rotation just purged,
+//     so the new identity renders the old one's scrollback. A guard wrapped
+//     around the REST calls alone would not catch it — the poisoning happens
+//     between the resolved fetch and the next request.
+//
+// So: eleven of this module's fifteen awaits are followed by this check, and
+// the bail is whatever "did nothing" means for that verb's return type. Two
+// classes of await are exempt, four sites in all — the ones whose await is
+// their last act (`probeGap`, and the two tail calls into `anchorAtTail`), and
+// `resolveJumpTarget`, whose only successor is a pure value returned to a
+// caller that checks immediately. A new verb that awaits and skips the check
+// reopens the defect for its own call path only — which is exactly how this
+// one survived: it was never a whole-module property, just an unwritten habit
+// that the three verbs with a single await happened to keep.
+//
+// Not hoisted into `identityScopedStore`: that factory owns the identity
+// TRANSITION (fire the resets), while this owns a verb's own captured
+// identity, which the factory never sees. Sibling modules inline the same
+// comparison (`displayPrefs`, `customTheme`) to drop a stale RESPONSE; this is
+// the same predicate used one step earlier, to refuse a stale REQUEST.
+const identityMoved = (t: string): boolean => token() !== t;
+
 const exports = identityScopedStore((onIdentityChange) => {
   const loadedChannels = new Set<ChannelKey>();
   // CP14 B2: per-key in-flight Set guards against scroll-burst fan-out
@@ -246,16 +285,36 @@ const exports = identityScopedStore((onIdentityChange) => {
     equals: false,
   });
 
-  // Identity-transition cleanup. Nine registered resets fired by the
-  // factory's createEffect(on(token, ...)) — five Set.clear() (loadedChannels
-  // + loadMore{InFlight,Exhausted} + loadNewer{InFlight,Exhausted}, #161) +
-  // four signal flushes (scrollbackByChannel + lastOwnSend + ownSendSubmitted,
-  // #580 + farBehindByChannel, #693). Order matches the pre-A3 inline shape.
+  // Identity-transition cleanup, and the SSOT for what an identity transition
+  // clears. Eleven registered resets fired by the factory's
+  // createEffect(on(token, ...)) — seven Set.clear() (loadedChannels +
+  // loadMore{InFlight,Exhausted} + loadNewer{InFlight,Exhausted}, #161 +
+  // refreshInFlight + jumpInFlight, #788) + four signal flushes
+  // (scrollbackByChannel + lastOwnSend + ownSendSubmitted, #580 +
+  // farBehindByChannel, #693). Order matches the pre-A3 inline shape.
+  //
+  // #788 — the last two are registered here, away from their declarations
+  // beside the verbs that own them, precisely BECAUSE that distance is how
+  // they came to be missed: this list is the thing to read when asking "what
+  // survives a rotation", so a lock that is not on it is a lock nobody will
+  // remember. Left held, they were a real defect and not merely untidy — an
+  // in-flight refresh for identity A keeps A's key until its continuation
+  // reaches the `finally`, and B's `refreshScrollback` for the same key
+  // short-circuits in the meantime, so B's window silently never backfills.
+  //
+  // Clearing them mid-flight lets A's `finally` delete a key B has since
+  // re-added, which can let a third call for B fetch the same page twice.
+  // Benign and deliberate: `appendToScrollback` dedupes by id, so the cost is
+  // one redundant GET, against a window that otherwise stays empty. A
+  // conditional delete keyed on the captured identity would buy nothing the
+  // dedupe does not already cover.
   onIdentityChange(() => loadedChannels.clear());
   onIdentityChange(() => loadMoreInFlight.clear());
   onIdentityChange(() => loadMoreExhausted.clear());
   onIdentityChange(() => loadNewerInFlight.clear());
   onIdentityChange(() => loadNewerExhausted.clear());
+  onIdentityChange(() => refreshInFlight.clear());
+  onIdentityChange(() => jumpInFlight.clear());
   onIdentityChange(() => setScrollbackByChannel({}));
   onIdentityChange(() => setLastOwnSend(null));
   onIdentityChange(() => setOwnSendSubmitted(null));
@@ -371,11 +430,13 @@ const exports = identityScopedStore((onIdentityChange) => {
   //
   // Three callers reach this verb and they are indistinguishable on the wire —
   // same URL shape, and two of the three anchor at the read cursor. They are
-  // also NOT symmetric with respect to identity, which is what #788 turns on:
+  // also NOT symmetric with respect to identity, which is what #788 turned on:
   // the cold-open call below runs with NO await between its `token()` capture
   // and this request (`getReadCursor` is a synchronous signal read), so it
   // cannot reach the wire under anything but the current bearer, while the two
-  // reconnect callers await first and can carry a revoked one.
+  // reconnect callers await first and could carry a revoked one. Each of those
+  // two now checks `identityMoved` before it gets here; this verb takes no
+  // check of its own because its await is its last act.
   const probeGap = async (
     t: string,
     slug: string,
@@ -420,6 +481,7 @@ const exports = identityScopedStore((onIdentityChange) => {
   ): Promise<void> => {
     const key = channelKey(slug, name);
     const page = await listMessages(t, slug, name);
+    if (identityMoved(t)) return;
     const rows = [...page].sort(byServerTimeThenId);
     const newest = rows[rows.length - 1]?.id ?? 0;
     setScrollbackByChannel((prev) => {
@@ -445,6 +507,11 @@ const exports = identityScopedStore((onIdentityChange) => {
   // it differs. One extra small GET, only on the reconnect path, only when
   // already far behind. A failed re-probe keeps the anchor: a slightly
   // conservative jump target beats no affordance at all.
+  //
+  // #788 exemption: no `identityMoved` check after the await here. This verb
+  // has no successor of its own — it returns two numbers, and the caller
+  // checks before spending them. Adding one would mean inventing a bail value
+  // for a function that cannot do harm.
   const resolveJumpTarget = async (
     t: string,
     slug: string,
@@ -498,6 +565,7 @@ const exports = identityScopedStore((onIdentityChange) => {
         listMessagesAfter(t, slug, name, far.resumeFrom, PAGE_LIMIT),
         listMessages(t, slug, name, far.resumeFrom + 1),
       ]);
+      if (identityMoved(t)) return false;
       // Disjoint by construction — `after(cursor)` is `id > cursor`,
       // `before(cursor + 1)` is `id <= cursor` — so concat + sort needs no
       // dedupe pass.
@@ -569,6 +637,7 @@ const exports = identityScopedStore((onIdentityChange) => {
         // a brand-new window auto-scrolls to the tail, so the newest
         // rows are exactly what's wanted and there's no divider to anchor.
         const page = await listMessages(t, slug, name);
+        if (identityMoved(t)) return;
         mergeIntoScrollback(key, page);
         // RC2 (decouple-unread-badge) — baseline the read cursor to this
         // backlog's tail. Opening a fresh channel auto-scrolls to the
@@ -642,6 +711,7 @@ const exports = identityScopedStore((onIdentityChange) => {
         // behind the load-once gate, on a human click; the pane is empty here
         // so `anchorAtTail` has nothing to discard.
         const gap = await probeGap(t, slug, name, cursor);
+        if (identityMoved(t)) return;
         if (gap !== null && isFarBehind(gap)) {
           await anchorAtTail(t, slug, name, gap, cursor);
         } else {
@@ -649,6 +719,7 @@ const exports = identityScopedStore((onIdentityChange) => {
             listMessagesAfter(t, slug, name, cursor, PAGE_LIMIT),
             listMessages(t, slug, name, cursor + 1),
           ]);
+          if (identityMoved(t)) return;
           // A rejoin's `refreshScrollback` can have re-anchored this key at
           // the tail while these two pages were in flight (nothing serialises
           // the cold-load and the reconnect path for one key). Splicing the
@@ -692,6 +763,7 @@ const exports = identityScopedStore((onIdentityChange) => {
       // a `messages.id` value, eliminating same-ms ties that straddled
       // page boundaries pre-flip.
       const page = await listMessages(t, slug, name, oldest.id);
+      if (identityMoved(t)) return;
       // CP14 B2: empty page from the server means there's no older
       // history to load. Latch the channel so subsequent scroll-to-
       // top events don't re-fetch.
@@ -747,6 +819,7 @@ const exports = identityScopedStore((onIdentityChange) => {
     loadNewerInFlight.add(key);
     try {
       const page = await listMessagesAfter(t, slug, name, newest.id, PAGE_LIMIT);
+      if (identityMoved(t)) return;
       // Empty forward page = the local tail IS the live server tail. Latch
       // so subsequent scroll-to-bottom events (including the auto-follow
       // scroll that fires when a live row appends at the tail) are no-ops.
@@ -815,6 +888,11 @@ const exports = identityScopedStore((onIdentityChange) => {
     // is cheaper than hoisting `setCursorIfAdvances` to a leaf module
     // for a single second caller.
     const row = await apiSendMessage(t, slug, name, body, ctcpTarget);
+    // #788 — the cursor POST below was already unreachable past a rotation, but
+    // only by accident: the store purge empties the pane, `hasRenderedRow`
+    // goes false, and the anti-poison gate declines. That is a guarantee owed
+    // to an unrelated invariant, one refactor away from evaporating. State it.
+    if (identityMoved(t)) return;
     // Anti-poison gate (issue #50 / m6, 2026-06-09): only advance the
     // cursor when the local pane already holds a rendered row. Advancing
     // PAST an unrendered row poisons `refreshScrollback`'s resume cursor —
@@ -925,6 +1003,7 @@ const exports = identityScopedStore((onIdentityChange) => {
       // dynamic per-channel cap) doesn't have to thread through the
       // api.ts helper signature.
       const page = await listMessagesAfter(t, slug, name, cursor, PAGE_LIMIT);
+      if (identityMoved(t)) return;
       for (const msg of page) {
         appendToScrollback(key, msg);
         // Roll the high-water mark forward as we ingest so a second
@@ -956,8 +1035,10 @@ const exports = identityScopedStore((onIdentityChange) => {
         const last = page[page.length - 1];
         const anchor = last ? last.id : cursor;
         const gap = await probeGap(t, slug, name, anchor);
+        if (identityMoved(t)) return;
         if (gap !== null && isFarBehind(gap)) {
           const target = await resolveJumpTarget(t, slug, name, anchor, gap);
+          if (identityMoved(t)) return;
           await anchorAtTail(t, slug, name, target.missed, target.resumeFrom);
         }
       }

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -28504,3 +28504,62 @@ per-page-load, so every reload re-pays upstream for an answer grappa already
 received. The precedent already exists — `userhost_cache` is nick-keyed, folded,
 fed passively from JOIN prefixes at zero upstream cost, and already migrated on
 NICK. Cache the answer, and the question of when to fetch mostly dissolves.
+
+---
+
+## 2026-08-04 — #788: a continuation that outlived its identity does nothing further
+
+`cicchetto/src/lib/scrollback.ts` scopes its state to the identity through
+`identityScopedStore`: nine resets fire on the `on(token)` transition and clear
+the pane, the load-once gate and the paging latches. The moduledoc used to read
+that as a race the store always wins. It never was. **The resets clear STATE;
+they cancel nothing in flight.** Every async verb captures `token()` at entry
+and then awaits, so a rotation or a detach landing inside one of those awaits
+leaves the continuation running under an identity that no longer exists.
+
+Measured, not argued: with the join-ok backfill held 400ms in a browser on the
+real bundle, a `/messages/count` went out **10ms after its own bearer was
+revoked**, through entirely production code paths.
+
+**Why a 401 is the least of it.** This is the #281 harm class reached through a
+different door. A request for the OLD identity's channel 404s when the new
+identity is not attached to that network, and the host's `http-404` fail2ban
+jail bans the client IP at the firewall. A routine account switch self-bans the
+operator.
+
+**The rule: check after the await, not in front of the request.** The stale
+continuation causes two harms, and only one of them is on the wire. The other
+needs no network at all — the page it already fetched merges into a map the
+rotation just purged, and the new identity renders the old one's scrollback.
+That harm happens *between* the resolved fetch and the next request, so the
+tidier-looking fix (one guarded wrapper around the module's REST calls, which
+the issue floated as the "reuse the verb" answer) cannot see it. Placing the
+check immediately after each await catches both, because everything downstream
+is unreachable. One shared predicate, `identityMoved(t)`, at eleven of the
+module's fifteen awaits; the four exempt are the ones with nothing after them,
+plus `resolveJumpTarget`, whose only successor is a pure value its caller checks
+before spending.
+
+Not hoisted into `identityScopedStore`: that factory owns the identity
+TRANSITION, while this owns a verb's own captured identity, which the factory
+never sees. `displayPrefs` and `customTheme` already inline the same comparison
+to drop a stale RESPONSE — this is the same predicate one step earlier, to
+refuse a stale REQUEST.
+
+**`refreshInFlight` and `jumpInFlight` join the reset list.** Both were declared
+beside the verbs that own them rather than beside the other five Sets, and both
+were consequently missing from the cleanup — a real defect, not untidiness: an
+in-flight refresh for identity A holds A's key until its continuation reaches
+the `finally`, and B's refresh for the same key short-circuits meanwhile, so B's
+window silently never backfills. Clearing mid-flight lets A's `finally` delete a
+key B has re-added, which can cost one redundant GET; `appendToScrollback`
+dedupes by id, so that is the cheaper side of the trade.
+
+**Two honest notes.** `sendMessage`'s post-await cursor POST was already
+unreachable past a rotation — but by accident, via the store purge emptying the
+pane so the #50 anti-poison gate declines. A guarantee owed to an unrelated
+invariant is one refactor from evaporating, so it is now stated. And the
+regression test mocks `../auth` with a REAL Solid signal: the flat
+`token: () => value` stub the sibling suites use is not reactive, so
+`createEffect(on(token))` never fires and the rotation the cases turn on would
+not exist.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -28546,14 +28546,34 @@ never sees. `displayPrefs` and `customTheme` already inline the same comparison
 to drop a stale RESPONSE — this is the same predicate one step earlier, to
 refuse a stale REQUEST.
 
+**An await has three exits, and the first census walked one of them.** Review
+caught it: the resolve path is not even the likely arrival. `api.ts` throws on
+any non-ok response, so a bearer revoked *while the request was in flight*
+comes back as a 401 throw — straight past every guard, into the `catch`. Most
+catches here only log, but `loadInitialScrollback`'s releases the load-once
+gate, which is identity-scoped state: past a rotation it releases the NEW
+identity's gate, and that window's next re-select reads `wasLoaded` false,
+takes the fresh-open arm that deliberately does not fire `refreshScrollback`
+(#159), and so skips one live-delivery catch-up while re-paying for a cold
+load. The `finally` blocks are the third exit and the same story: they release
+per-key locks that, after the reset has cleared the Set, belong to whoever
+replaced us. All four now release only while the identity still holds, and the
+`refreshScrollback` completion stamp with them — stamping tells an e2e that
+ITS backfill landed. The rule is not "check after the await"; it is "every exit
+from the await that touches state".
+
 **`refreshInFlight` and `jumpInFlight` join the reset list.** Both were declared
 beside the verbs that own them rather than beside the other five Sets, and both
 were consequently missing from the cleanup — a real defect, not untidiness: an
 in-flight refresh for identity A holds A's key until its continuation reaches
 the `finally`, and B's refresh for the same key short-circuits meanwhile, so B's
-window silently never backfills. Clearing mid-flight lets A's `finally` delete a
-key B has re-added, which can cost one redundant GET; `appendToScrollback`
-dedupes by id, so that is the cheaper side of the trade.
+window silently never backfills. The first pass justified the unconditional
+`finally` delete with "`appendToScrollback` dedupes by id, so the worst case is
+one redundant GET" — true of the merge paths and false of `jumpToUnread`, which
+REPLACES the key's rows and would discard whatever landed between two
+concurrent writes. A rationale that does not cover the Set it is written beside
+is not a rationale, so the conditional release above replaced it and the trade
+disappeared.
 
 **Two honest notes.** `sendMessage`'s post-await cursor POST was already
 unreachable past a rotation — but by accident, via the store purge emptying the
@@ -28562,4 +28582,8 @@ invariant is one refactor from evaporating, so it is now stated. And the
 regression test mocks `../auth` with a REAL Solid signal: the flat
 `token: () => value` stub the sibling suites use is not reactive, so
 `createEffect(on(token))` never fires and the rotation the cases turn on would
-not exist.
+not exist. Seven cases in all, each verified RED by removing exactly the guard
+it covers and watching only it fall — including a control case that fails
+loudly if the "full page" the stale-probe case releases ever stops being full,
+which would otherwise turn that assertion into one about a branch nobody
+entered.


### PR DESCRIPTION
Refs #788.

## The defect

`identityScopedStore`'s resets clear scrollback STATE on an identity
transition; they cancel nothing in flight. Every async verb in
`cicchetto/src/lib/scrollback.ts` captured `token()` at entry and then awaited
without re-checking, so a rotation or detach landing inside one of those awaits
left the continuation running under an identity that no longer existed — and it
sent. Measured in a browser on the real bundle: with the join-ok backfill held
400ms, a `/messages/count` went out 10ms after its own bearer was revoked.

The harm is not the 401. It is the #281 class through another door: a request
for the old identity's channel 404s when the new identity is not attached to
that network, and the host's `http-404` fail2ban jail bans the client IP at the
firewall. A routine account switch self-bans the operator.

## The census

15 awaits, 9 async verbs. 11 now carry the check; 4 are exempt and say so in
place — three whose await is their last act (`probeGap`, the two tail calls
into `anchorAtTail`), and `resolveJumpTarget`, which returns a pure value its
caller checks before spending. Every `setReadCursor` is either pre-await or
post-guard.

The issue named `probeGap`-after-`listMessagesAfter`. The class is wider in two
directions the issue did not name:

* **the store, not just the wire.** The same continuation poisons without
  touching the network: the page it already fetched merges into a map the
  rotation just purged, so the new identity renders the old one's scrollback.
  That happens *between* the resolved fetch and the next request — which is why
  the guard sits after each await and not in front of each REST call. The
  wrapper shape the issue floated as the "reuse the verb" answer cannot see it.
* **three exits, not one.** `api.ts` throws on any non-ok response, so a bearer
  revoked mid-flight arrives as a 401 throw rather than a clean resolve — the
  likelier path. `loadInitialScrollback`'s catch releases the load-once gate:
  past a rotation it releases the NEW identity's gate, whose next re-select
  reads `wasLoaded` false, takes the fresh-open arm that deliberately does not
  fire `refreshScrollback` (#159), and skips one live-delivery catch-up. The
  four `finally` blocks release per-key locks that, after the reset cleared the
  Set, belong to whoever replaced us.

## The mechanism

One shared predicate, `identityMoved(t) => token() !== t`, at every exit from
an await that touches state. Not hoisted into `identityScopedStore`: that
factory owns the identity TRANSITION, this owns a verb's own captured identity,
which the factory never sees. `displayPrefs` and `customTheme` already inline
the same comparison to drop a stale RESPONSE — this is the same predicate one
step earlier, to refuse a stale REQUEST.

## The two locks

`refreshInFlight` and `jumpInFlight` join the reset list. Declared beside their
verbs rather than beside the other five Sets, they were missed — and left held
they are a real defect: an in-flight refresh for A keeps A's key until its
`finally`, and B's refresh for that key short-circuits meanwhile, so B's window
silently never backfills.

An earlier draft justified the unconditional `finally` delete with
"`appendToScrollback` dedupes by id, worst case one redundant GET". True of the
merge paths, false of `jumpToUnread`, which REPLACES the key's rows. The
conditional release retired the trade instead of documenting it wrongly.

## Tests

Seven cases in `scrollbackIdentityRotation.test.ts`, each verified RED by
removing exactly the guard it covers and watching only it fall: the stale
probe, the stale page landing in the purged store, the surviving lock, the
cold-open cursor baseline, the released-and-stamped in-flight refresh, the
released load-once gate on a 401, plus a control case that fails loudly if the
"full page" the stale-probe case releases ever stops being full — which would
otherwise turn that assertion into one about a branch nobody entered.

They mock `../auth` with a REAL Solid signal. The flat `token: () => value`
stub the sibling suites use is not reactive, so `createEffect(on(token))` never
fires and the rotation these cases turn on would not exist.

## Honest notes

* `sendMessage`'s post-await cursor POST was already unreachable past a
  rotation — but only via the store purge emptying the pane so the #50
  anti-poison gate declines. A guarantee owed to an unrelated invariant is one
  refactor from evaporating, so it is now stated rather than inherited.
* Out of scope, noticed while reading: `readCursor.ts` is NOT identity-scoped,
  so its cursor map survives a rotation. May well be deliberate (join-reply
  hydration re-seeds it), but nothing says so.

## Gates

cic-only. `bun run check` 0, `tsc --noEmit` 0, `bun run test` 0 — 233 files,
4195 tests.