### PR TITLE
test(#742): cover the WebAuthn verification path with signed ceremonies

### DIFF
--- a/test/grappa/accounts/webauthn_verification_test.exs
+++ b/test/grappa/accounts/webauthn_verification_test.exs
@@ -1,0 +1,202 @@
+defmodule Grappa.Accounts.WebAuthnVerificationTest do
+  @moduledoc """
+  The verification half of the passkey door: `Wax.register/3` and
+  `Wax.authenticate/5`, driven by a real signed ceremony (#742).
+
+  Before this, nothing in the suite reached either function. Every other
+  passkey test seeds a `Passkey` row directly or exercises a route that
+  never verifies an assertion, so deleting the signature check — or
+  reordering `authenticate/3` so a forged blob short-circuits — left the
+  whole suite green while any assertion logged anyone in.
+  """
+  use Grappa.DataCase, async: true
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.Accounts.{Passkey, WebAuthn}
+  alias Grappa.{Repo, WebAuthnCeremony}
+
+  @origin "https://irc.example"
+  @binding %{ip: "192.0.2.1", client_id: "client"}
+
+  setup do
+    {user, password} = user_fixture_with_password()
+    authenticator = WebAuthnCeremony.new_authenticator(<<7, 7, 7, 7>>)
+
+    %{user: user, password: password, authenticator: authenticator}
+  end
+
+  describe "registration verification" do
+    test "a ceremony this authenticator signed registers the credential", ctx do
+      params = register_params(ctx)
+
+      assert {:ok, %Passkey{} = passkey} =
+               WebAuthn.complete_registration(ctx.user, params, @binding)
+
+      assert passkey.credential_id == ctx.authenticator.credential_id
+      assert passkey.user_id == ctx.user.id
+
+      # The stored key must survive the CBOR round trip as the coordinates
+      # Wax handed over — an assertion later verifies against exactly this.
+      assert {:ok, stored, ""} = CBOR.decode(passkey.public_key)
+      assert stored[-2] == ctx.authenticator.x
+      assert stored[-3] == ctx.authenticator.y
+    end
+
+    # `attestation: "none"` carries no attestation signature, so the evil
+    # twin cannot be a mutated one — there is nothing to mutate. What the
+    # server still verifies is that the ceremony answers THIS challenge at
+    # THIS origin, so those are the ones worth forging.
+    test "a ceremony answering a different challenge is refused", ctx do
+      {challenge_id, _challenge} = begin_registration(ctx)
+      {_, other_challenge} = begin_registration(ctx)
+
+      params =
+        WebAuthnCeremony.registration_params(
+          ctx.authenticator,
+          challenge_id,
+          other_challenge,
+          @origin
+        )
+
+      assert {:error, :invalid_passkey} =
+               WebAuthn.complete_registration(ctx.user, params, @binding)
+
+      assert Repo.aggregate(Passkey, :count, :id) == 0
+    end
+
+    test "a ceremony signed for another origin is refused", ctx do
+      {challenge_id, challenge} = begin_registration(ctx)
+
+      params =
+        WebAuthnCeremony.registration_params(
+          ctx.authenticator,
+          challenge_id,
+          challenge,
+          "https://phish.example"
+        )
+
+      assert {:error, :invalid_passkey} =
+               WebAuthn.complete_registration(ctx.user, params, @binding)
+
+      assert Repo.aggregate(Passkey, :count, :id) == 0
+    end
+
+    test "a ceremony bound to someone else's account is refused", ctx do
+      params = register_params(ctx)
+      intruder = user_fixture()
+
+      assert {:error, :invalid_passkey} =
+               WebAuthn.complete_registration(intruder, params, @binding)
+
+      assert Repo.aggregate(Passkey, :count, :id) == 0
+    end
+  end
+
+  describe "assertion verification" do
+    setup ctx do
+      assert {:ok, passkey} =
+               WebAuthn.complete_registration(ctx.user, register_params(ctx), @binding)
+
+      Map.put(ctx, :passkey, passkey)
+    end
+
+    test "an assertion this authenticator signed authenticates the user", ctx do
+      params = assert_params(ctx, 1)
+
+      assert {:ok, authenticated, %{}} = WebAuthn.authenticate(params, :second_factor, @binding)
+      assert authenticated.id == ctx.user.id
+      assert Repo.get!(Passkey, ctx.passkey.id).sign_count == 1
+    end
+
+    # THE test this whole fixture exists for. One bit of the signature is
+    # flipped and nothing else changes, so the only rule that can refuse it
+    # is the signature check itself. If this goes green with the
+    # verification removed, the door is open to any blob.
+    test "an assertion with a mutated signature is refused", ctx do
+      params = WebAuthnCeremony.tamper_signature(assert_params(ctx, 1))
+
+      assert {:error, :invalid_passkey} = WebAuthn.authenticate(params, :second_factor, @binding)
+      assert Repo.get!(Passkey, ctx.passkey.id).sign_count == 0
+    end
+
+    test "an assertion signed by a different authenticator is refused", ctx do
+      impostor = WebAuthnCeremony.new_authenticator(ctx.authenticator.credential_id)
+      {challenge_id, challenge} = begin_authentication(ctx)
+
+      params =
+        WebAuthnCeremony.assertion_params(impostor, challenge_id, challenge, @origin, 1)
+
+      assert {:error, :invalid_passkey} = WebAuthn.authenticate(params, :second_factor, @binding)
+      assert Repo.get!(Passkey, ctx.passkey.id).sign_count == 0
+    end
+
+    test "an assertion signed for another origin is refused", ctx do
+      {challenge_id, challenge} = begin_authentication(ctx)
+
+      params =
+        WebAuthnCeremony.assertion_params(
+          ctx.authenticator,
+          challenge_id,
+          challenge,
+          "https://phish.example",
+          1
+        )
+
+      assert {:error, :invalid_passkey} = WebAuthn.authenticate(params, :second_factor, @binding)
+    end
+
+    # The challenge is one-shot, so a captured assertion cannot be sent
+    # twice even though its signature stays perfectly valid.
+    test "a valid assertion cannot be replayed", ctx do
+      params = assert_params(ctx, 1)
+
+      assert {:ok, _, _} = WebAuthn.authenticate(params, :second_factor, @binding)
+      assert {:error, :invalid_passkey} = WebAuthn.authenticate(params, :second_factor, @binding)
+    end
+
+    # A ceremony opened for one purpose must not be spendable on another:
+    # the purpose is what tells a mode change from a login.
+    test "an assertion opened for a mode change cannot be spent as a login", ctx do
+      {:ok, %{challenge_id: id, public_key: %{challenge: challenge}}} =
+        WebAuthn.begin_authentication(ctx.user, :mode_change, @binding, @origin, %{mode: :disabled})
+
+      params = WebAuthnCeremony.assertion_params(ctx.authenticator, id, challenge, @origin, 1)
+
+      assert {:error, :invalid_passkey} = WebAuthn.authenticate(params, :passwordless, @binding)
+    end
+
+    test "an assertion whose counter did not advance is refused as a clone", ctx do
+      assert {:ok, _, _} = WebAuthn.authenticate(assert_params(ctx, 5), :second_factor, @binding)
+
+      assert {:error, :invalid_passkey} =
+               WebAuthn.authenticate(assert_params(ctx, 5), :second_factor, @binding)
+
+      assert Repo.get!(Passkey, ctx.passkey.id).sign_count == 5
+    end
+  end
+
+  defp begin_registration(ctx) do
+    {:ok, %{challenge_id: id, public_key: %{challenge: challenge}}} =
+      WebAuthn.begin_registration(ctx.user, ctx.password, "phone", @binding, @origin)
+
+    {id, challenge}
+  end
+
+  defp begin_authentication(ctx) do
+    {:ok, %{challenge_id: id, public_key: %{challenge: challenge}}} =
+      WebAuthn.begin_authentication(ctx.user, :second_factor, @binding, @origin, %{})
+
+    {id, challenge}
+  end
+
+  defp register_params(ctx) do
+    {id, challenge} = begin_registration(ctx)
+    WebAuthnCeremony.registration_params(ctx.authenticator, id, challenge, @origin)
+  end
+
+  defp assert_params(ctx, sign_count) do
+    {id, challenge} = begin_authentication(ctx)
+    WebAuthnCeremony.assertion_params(ctx.authenticator, id, challenge, @origin, sign_count)
+  end
+end

--- a/test/grappa/accounts/webauthn_verification_test.exs
+++ b/test/grappa/accounts/webauthn_verification_test.exs
@@ -48,7 +48,7 @@ defmodule Grappa.Accounts.WebAuthnVerificationTest do
     # server still verifies is that the ceremony answers THIS challenge at
     # THIS origin, so those are the ones worth forging.
     test "a ceremony answering a different challenge is refused", ctx do
-      {challenge_id, _challenge} = begin_registration(ctx)
+      {challenge_id, _} = begin_registration(ctx)
       {_, other_challenge} = begin_registration(ctx)
 
       params =

--- a/test/grappa_web/controllers/passkey_controller_test.exs
+++ b/test/grappa_web/controllers/passkey_controller_test.exs
@@ -5,10 +5,9 @@ defmodule GrappaWeb.PasskeyControllerTest do
   import Ecto.Query
 
   alias Grappa.Accounts.{Passkey, Session, TOTP, TOTPRecoveryCode, User, WebAuthn}
-  alias Grappa.WebAuthnCeremony
-  alias GrappaWeb.PasskeyOrigin
   alias Grappa.RateLimit.FailureWindow
-  alias Grappa.Repo
+  alias Grappa.{Repo, WebAuthnCeremony}
+  alias GrappaWeb.PasskeyOrigin
 
   defp passwordless_user do
     {user, password} = user_fixture_with_password()
@@ -60,13 +59,17 @@ defmodule GrappaWeb.PasskeyControllerTest do
 
     test "POST /me/passkeys/registration stores the credential a ceremony signed", ctx do
       options =
-        authed(ctx.session)
-        |> post("/me/passkeys/registration/options", %{"password" => ctx.password, "name" => "phone"})
-        |> json_response(200)
+        json_response(
+          post(authed(ctx.session), "/me/passkeys/registration/options", %{
+            "password" => ctx.password,
+            "name" => "phone"
+          }),
+          200
+        )
 
       params = registration_params(ctx, options, @ceremony_origin)
 
-      body = authed(ctx.session) |> post("/me/passkeys/registration", params) |> json_response(201)
+      body = json_response(post(authed(ctx.session), "/me/passkeys/registration", params), 201)
 
       assert body["name"] == "phone"
       assert Repo.aggregate(Passkey, :count, :id) == 1
@@ -74,13 +77,17 @@ defmodule GrappaWeb.PasskeyControllerTest do
 
     test "POST /me/passkeys/registration refuses a ceremony signed for another origin", ctx do
       options =
-        authed(ctx.session)
-        |> post("/me/passkeys/registration/options", %{"password" => ctx.password, "name" => "phone"})
-        |> json_response(200)
+        json_response(
+          post(authed(ctx.session), "/me/passkeys/registration/options", %{
+            "password" => ctx.password,
+            "name" => "phone"
+          }),
+          200
+        )
 
       params = registration_params(ctx, options, "https://phish.example")
 
-      assert authed(ctx.session) |> post("/me/passkeys/registration", params) |> json_response(401) ==
+      assert json_response(post(authed(ctx.session), "/me/passkeys/registration", params), 401) ==
                %{"error" => "invalid_two_factor"}
 
       assert Repo.aggregate(Passkey, :count, :id) == 0
@@ -142,13 +149,17 @@ defmodule GrappaWeb.PasskeyControllerTest do
       register_credential(ctx)
 
       options =
-        authed(ctx.session)
-        |> post("/me/passkeys/mode/options", %{"password" => ctx.password, "mode" => "second_factor"})
-        |> json_response(200)
+        json_response(
+          post(authed(ctx.session), "/me/passkeys/mode/options", %{
+            "password" => ctx.password,
+            "mode" => "second_factor"
+          }),
+          200
+        )
 
       params = WebAuthnCeremony.tamper_signature(assertion_params(ctx, options, 1))
 
-      assert authed(ctx.session) |> post("/me/passkeys/mode", params) |> json_response(401) ==
+      assert json_response(post(authed(ctx.session), "/me/passkeys/mode", params), 401) ==
                %{"error" => "invalid_two_factor"}
 
       assert Repo.get!(User, ctx.user.id).passkey_mode == :disabled

--- a/test/grappa_web/controllers/passkey_controller_test.exs
+++ b/test/grappa_web/controllers/passkey_controller_test.exs
@@ -5,6 +5,8 @@ defmodule GrappaWeb.PasskeyControllerTest do
   import Ecto.Query
 
   alias Grappa.Accounts.{Passkey, Session, TOTP, TOTPRecoveryCode, User, WebAuthn}
+  alias Grappa.WebAuthnCeremony
+  alias GrappaWeb.PasskeyOrigin
   alias Grappa.RateLimit.FailureWindow
   alias Grappa.Repo
 
@@ -25,6 +27,173 @@ defmodule GrappaWeb.PasskeyControllerTest do
       WebAuthn.set_mode(user, :passwordless, session.id, Grappa.Accounts.prepare_recovery_codes())
 
     {Repo.get!(User, user.id), password}
+  end
+
+  # #742 — the four routes that actually verify a ceremony had no test at
+  # all, so a forged assertion reaching `mint_session/2` would have been
+  # invisible. `WebAuthnCeremony` signs for real; every route here is
+  # driven twice, once with the signature it was given and once with one
+  # bit of it flipped.
+  describe "ceremony verification over the wire" do
+    @ceremony_origin "https://irc.example"
+
+    setup do
+      # The ceremony signs for a fixed origin, so the RP origin the server
+      # asserts has to be that one and not whatever the Endpoint derives.
+      PasskeyOrigin.put_test_origin(@ceremony_origin)
+      on_exit(fn -> PasskeyOrigin.put_test_origin(nil) end)
+
+      # `/auth/passkeys/options` counts EVERY call against a per-IP window
+      # shared by the whole module, so a ceremony test that opens one must
+      # hand the bucket back or it eats the throttle test's budget.
+      on_exit(fn -> FailureWindow.clear(:passkey_login_options, "127.0.0.1") end)
+
+      {user, password} = user_fixture_with_password()
+
+      %{
+        user: user,
+        password: password,
+        session: session_fixture(user),
+        authenticator: WebAuthnCeremony.new_authenticator(:crypto.strong_rand_bytes(16))
+      }
+    end
+
+    test "POST /me/passkeys/registration stores the credential a ceremony signed", ctx do
+      options =
+        authed(ctx.session)
+        |> post("/me/passkeys/registration/options", %{"password" => ctx.password, "name" => "phone"})
+        |> json_response(200)
+
+      params = registration_params(ctx, options, @ceremony_origin)
+
+      body = authed(ctx.session) |> post("/me/passkeys/registration", params) |> json_response(201)
+
+      assert body["name"] == "phone"
+      assert Repo.aggregate(Passkey, :count, :id) == 1
+    end
+
+    test "POST /me/passkeys/registration refuses a ceremony signed for another origin", ctx do
+      options =
+        authed(ctx.session)
+        |> post("/me/passkeys/registration/options", %{"password" => ctx.password, "name" => "phone"})
+        |> json_response(200)
+
+      params = registration_params(ctx, options, "https://phish.example")
+
+      assert authed(ctx.session) |> post("/me/passkeys/registration", params) |> json_response(401) ==
+               %{"error" => "invalid_two_factor"}
+
+      assert Repo.aggregate(Passkey, :count, :id) == 0
+    end
+
+    test "POST /auth/passkeys/verify mints a bearer for a signed assertion", ctx do
+      register_credential(ctx)
+      arm_mode(ctx, :passwordless)
+
+      options =
+        build_conn()
+        |> post("/auth/passkeys/options", %{"identifier" => ctx.user.name})
+        |> json_response(200)
+
+      params = assertion_params(ctx, options, 1)
+      body = build_conn() |> post("/auth/passkeys/verify", params) |> json_response(200)
+
+      assert is_binary(body["token"])
+    end
+
+    test "POST /auth/passkeys/verify refuses an assertion with a mutated signature", ctx do
+      register_credential(ctx)
+      arm_mode(ctx, :passwordless)
+
+      options =
+        build_conn()
+        |> post("/auth/passkeys/options", %{"identifier" => ctx.user.name})
+        |> json_response(200)
+
+      params = WebAuthnCeremony.tamper_signature(assertion_params(ctx, options, 1))
+
+      assert build_conn() |> post("/auth/passkeys/verify", params) |> json_response(401) ==
+               %{"error" => "invalid_two_factor"}
+    end
+
+    test "POST /auth/passkeys/second-factor refuses an assertion with a mutated signature", ctx do
+      register_credential(ctx)
+      arm_mode(ctx, :second_factor)
+
+      {:ok, options} =
+        WebAuthn.begin_authentication(
+          Repo.get!(User, ctx.user.id),
+          :second_factor,
+          %{ip: "127.0.0.1", client_id: nil},
+          @ceremony_origin,
+          %{}
+        )
+
+      params = assertion_params(ctx, stringify(options), 1)
+
+      assert build_conn() |> post("/auth/passkeys/second-factor", params) |> json_response(200)
+
+      assert build_conn()
+             |> post("/auth/passkeys/second-factor", WebAuthnCeremony.tamper_signature(params))
+             |> json_response(401) == %{"error" => "invalid_two_factor"}
+    end
+
+    test "POST /me/passkeys/mode refuses a mode change whose signature was mutated", ctx do
+      register_credential(ctx)
+
+      options =
+        authed(ctx.session)
+        |> post("/me/passkeys/mode/options", %{"password" => ctx.password, "mode" => "second_factor"})
+        |> json_response(200)
+
+      params = WebAuthnCeremony.tamper_signature(assertion_params(ctx, options, 1))
+
+      assert authed(ctx.session) |> post("/me/passkeys/mode", params) |> json_response(401) ==
+               %{"error" => "invalid_two_factor"}
+
+      assert Repo.get!(User, ctx.user.id).passkey_mode == :disabled
+    end
+
+    defp authed(session),
+      do: put_req_header(build_conn(), "authorization", "Bearer #{session.id}")
+
+    defp stringify(%{challenge_id: id, public_key: %{challenge: challenge}}),
+      do: %{"challenge_id" => id, "public_key" => %{"challenge" => challenge}}
+
+    defp registration_params(ctx, options, origin) do
+      WebAuthnCeremony.registration_params(
+        ctx.authenticator,
+        options["challenge_id"],
+        options["public_key"]["challenge"],
+        origin
+      )
+    end
+
+    defp assertion_params(ctx, options, sign_count) do
+      WebAuthnCeremony.assertion_params(
+        ctx.authenticator,
+        options["challenge_id"],
+        options["public_key"]["challenge"],
+        @ceremony_origin,
+        sign_count
+      )
+    end
+
+    defp register_credential(ctx) do
+      Repo.insert!(
+        Passkey.changeset(%Passkey{}, %{
+          user_id: ctx.user.id,
+          credential_id: ctx.authenticator.credential_id,
+          public_key: CBOR.encode(WebAuthnCeremony.cose_key(ctx.authenticator)),
+          name: "phone"
+        })
+      )
+    end
+
+    defp arm_mode(ctx, mode) do
+      codes = if mode == :passwordless, do: Grappa.Accounts.prepare_recovery_codes(), else: []
+      {:ok, ^mode} = WebAuthn.set_mode(ctx.user, mode, ctx.session.id, codes)
+    end
   end
 
   test "login_options is throttled even while it keeps succeeding", %{conn: conn} do

--- a/test/support/webauthn_ceremony.ex
+++ b/test/support/webauthn_ceremony.ex
@@ -139,11 +139,21 @@ defmodule Grappa.WebAuthnCeremony do
 
   Everything else stays byte-identical, so an assertion that still passes
   proves the signature is not being checked.
+
+  The bit is flipped in the DECODED signature, never in the base64url
+  text. A DER ECDSA signature is most often 71 bytes, whose unpadded
+  base64 ends on a character carrying two padding bits — flip one of
+  those and the text differs while the bytes it decodes to do not. The
+  server then received the genuine assertion, verified it correctly and
+  minted a token, so the evil twin passed as itself roughly one run in
+  ten. Decoding first makes the mutation reach `s` every time.
   """
   @spec tamper_signature(map()) :: map()
   def tamper_signature(%{"signature" => signature} = params) do
-    <<head::binary-size(byte_size(signature) - 1), last>> = signature
-    Map.put(params, "signature", head <> <<bxor(last, 1)>>)
+    {:ok, raw} = Base.url_decode64(signature, padding: false)
+    <<head::binary-size(byte_size(raw) - 1), last>> = raw
+
+    Map.put(params, "signature", encode(head <> <<bxor(last, 1)>>))
   end
 
   defp authenticator_data(origin, flags, sign_count) do

--- a/test/support/webauthn_ceremony.ex
+++ b/test/support/webauthn_ceremony.ex
@@ -1,0 +1,170 @@
+defmodule Grappa.WebAuthnCeremony do
+  @moduledoc """
+  A software authenticator that produces WebAuthn ceremonies `Wax` accepts.
+
+  ## Why this is support infrastructure and not a helper in one test file
+
+  `Wax.register/3` and `Wax.authenticate/5` are the only things standing
+  between a POSTed blob and a logged-in session, and nothing could reach
+  them from a test: every passkey test either seeds a `Passkey` row
+  directly or drives a route that never verifies an assertion (#742). A
+  ceremony cannot be faked with a fixture blob either — the signature is
+  over bytes that include the challenge the server just minted, so it has
+  to be produced per test, from a real key.
+
+  So this signs for real. `new_authenticator/1` generates a P-256 key
+  pair the way an authenticator would; `registration_params/4` and
+  `assertion_params/5` assemble exactly the four fields
+  `Grappa.Accounts.WebAuthn` reads off the wire, base64url-encoded
+  without padding like the browser sends them.
+
+  ## Every ceremony owes an evil twin
+
+  A happy-path-only test here is the very hole #742 describes: it stays
+  green if the verification is deleted. `tamper_signature/1` returns the
+  same ceremony with one bit of the signature flipped — everything else
+  byte-identical — so the only thing that can make the assertion fail is
+  the signature check itself.
+
+  ## Faithful where it matters
+
+  The COSE key inside the attestation is CBOR-encoded as byte strings
+  (`%CBOR.Tag{tag: :bytes}`), which is what a real authenticator emits
+  and what `Wax.Utils.CBOR` unwraps. Flags carry UP and UV because
+  `challenge_opts/1` asks for `user_verification: "required"`, and AT on
+  registration because that is what carries the credential.
+  """
+
+  import Bitwise
+
+  @aaguid <<0::128>>
+
+  @up 0x01
+  @uv 0x04
+  @at 0x40
+
+  @type t :: %{
+          credential_id: binary(),
+          x: binary(),
+          y: binary(),
+          private_key: binary()
+        }
+
+  @doc """
+  Generates an authenticator holding one P-256 credential.
+
+  `credential_id` is the opaque handle the server stores and the client
+  echoes back as `raw_id`; tests pass their own so two authenticators in
+  one test stay tellable apart.
+  """
+  @spec new_authenticator(binary()) :: t()
+  def new_authenticator(credential_id) when is_binary(credential_id) do
+    {<<4, x::binary-size(32), y::binary-size(32)>>, private_key} =
+      :crypto.generate_key(:ecdh, :prime256v1)
+
+    %{credential_id: credential_id, x: x, y: y, private_key: private_key}
+  end
+
+  @doc """
+  The COSE key for this authenticator, in the shape
+  `Grappa.Accounts.Passkey` stores.
+
+  For tests that seed a credential row directly instead of registering
+  one through a ceremony.
+  """
+  @spec cose_key(t()) :: map()
+  def cose_key(%{x: x, y: y}), do: %{1 => 2, 3 => -7, -1 => 1, -2 => x, -3 => y}
+
+  @doc """
+  Registration ceremony for `challenge_b64` (the value
+  `begin_registration/5` published), as `complete_registration/3` reads it.
+  """
+  @spec registration_params(t(), String.t(), String.t(), String.t()) :: map()
+  def registration_params(authenticator, challenge_id, challenge_b64, origin) do
+    client_data = client_data_json("webauthn.create", challenge_b64, origin)
+
+    auth_data =
+      authenticator_data(origin, @up ||| @uv ||| @at, 0) <>
+        @aaguid <>
+        <<byte_size(authenticator.credential_id)::unsigned-big-integer-size(16)>> <>
+        authenticator.credential_id <>
+        cbor_cose_key(authenticator)
+
+    attestation =
+      CBOR.encode(%{
+        "fmt" => "none",
+        "attStmt" => %{},
+        "authData" => %CBOR.Tag{tag: :bytes, value: auth_data}
+      })
+
+    %{
+      "challenge_id" => challenge_id,
+      "attestation_object" => encode(attestation),
+      "client_data_json" => encode(client_data),
+      "transports" => ["internal"]
+    }
+  end
+
+  @doc """
+  Assertion ceremony for `challenge_b64` (the value `begin_authentication/5`
+  published), as `authenticate/3` reads it.
+
+  `sign_count` is what the authenticator claims, so a test can drive the
+  clone-detection rule as well as the signature check.
+  """
+  @spec assertion_params(t(), String.t(), String.t(), String.t(), non_neg_integer()) :: map()
+  def assertion_params(authenticator, challenge_id, challenge_b64, origin, sign_count) do
+    client_data = client_data_json("webauthn.get", challenge_b64, origin)
+    auth_data = authenticator_data(origin, @up ||| @uv, sign_count)
+
+    signature =
+      :crypto.sign(
+        :ecdsa,
+        :sha256,
+        auth_data <> :crypto.hash(:sha256, client_data),
+        [authenticator.private_key, :prime256v1]
+      )
+
+    %{
+      "challenge_id" => challenge_id,
+      "raw_id" => encode(authenticator.credential_id),
+      "authenticator_data" => encode(auth_data),
+      "signature" => encode(signature),
+      "client_data_json" => encode(client_data)
+    }
+  end
+
+  @doc """
+  The same ceremony with one bit of the signature flipped.
+
+  Everything else stays byte-identical, so an assertion that still passes
+  proves the signature is not being checked.
+  """
+  @spec tamper_signature(map()) :: map()
+  def tamper_signature(%{"signature" => signature} = params) do
+    <<head::binary-size(byte_size(signature) - 1), last>> = signature
+    Map.put(params, "signature", head <> <<bxor(last, 1)>>)
+  end
+
+  defp authenticator_data(origin, flags, sign_count) do
+    rp_id = URI.parse(origin).host
+
+    :crypto.hash(:sha256, rp_id) <> <<flags>> <> <<sign_count::unsigned-big-integer-size(32)>>
+  end
+
+  defp client_data_json(type, challenge_b64, origin) do
+    Jason.encode!(%{type: type, challenge: challenge_b64, origin: origin})
+  end
+
+  defp cbor_cose_key(%{x: x, y: y}) do
+    CBOR.encode(%{
+      1 => 2,
+      3 => -7,
+      -1 => 1,
+      -2 => %CBOR.Tag{tag: :bytes, value: x},
+      -3 => %CBOR.Tag{tag: :bytes, value: y}
+    })
+  end
+
+  defp encode(binary), do: Base.url_encode64(binary, padding: false)
+end


### PR DESCRIPTION
Review finding #742. `Wax.register/3` and `Wax.authenticate/5` are the
only things standing between a POSTed blob and a session, and nothing in
the suite reached either. Verified against main: the sole `Wax.` under
`test/` built a challenge and nothing more.

## The fixture — `Grappa.WebAuthnCeremony`, in `test/support/`

A ceremony cannot be a canned blob: the signature covers bytes that
include the challenge the server just minted, so it has to be produced
per test. `test/support/webauthn_ceremony.ex` is therefore a **software
authenticator** — it generates a P-256 key with `:crypto.generate_key/2`
and signs for real.

It lives in `test/support` on purpose: #743, #749 and #751 need the same
door opened, and so does the untested half of #768 (see below).

```elixir
authenticator = WebAuthnCeremony.new_authenticator(credential_id)
WebAuthnCeremony.registration_params(authenticator, challenge_id, challenge, origin)
WebAuthnCeremony.assertion_params(authenticator, challenge_id, challenge, origin, sign_count)
WebAuthnCeremony.tamper_signature(params)   # the evil twin
WebAuthnCeremony.cose_key(authenticator)    # for seeding a row directly
```

A note on the brief: the hex package does not ship its `test/`
directory, so Wax's own vectors are not available to borrow. Generating
a key is better anyway — a fresh one per test cannot be shared state.

## Every path, and its twin

`tamper_signature/1` flips ONE bit of the signature and leaves everything
else byte-identical, so nothing but the signature check can refuse it.

Context level (`webauthn_verification_test.exs`, 11 tests): registration
accepted; assertion accepted and the counter advances; mutated signature
refused; a different authenticator refused; another origin refused; a
replayed assertion refused; a mode-change ceremony refused when spent as
a login; a counter that did not advance refused as a clone.

Wire level (`passkey_controller_test.exs`, 5 tests) — the four routes the
finding names: `POST /me/passkeys/registration`, `POST
/auth/passkeys/verify`, `POST /auth/passkeys/second-factor`, `POST
/me/passkeys/mode`. Origin pinned via `PasskeyOrigin.put_test_origin/1`,
the seam #750 left behind.

### Registration's twin cannot be a mutated signature

Worth stating plainly, because a reader will otherwise assume more
coverage than exists: with `attestation: "none"` the `attStmt` is empty
and `Wax.AttestationStatementFormat.None.verify/4` returns `{:ok,
{:none, nil, nil}}` without inspecting anything. There is no attestation
signature to mutate. So registration's twins forge what the server DOES
still verify there — the challenge, the origin, and the account the
ceremony was opened for.

## Mutation-proven, both of the finding's scenarios

- `verify_assertion/3` returns `{:ok, %{sign_count: 0}}` without calling
  `Wax.authenticate` → **7 tests red**.
- the `with` chain in `authenticate/3` loses its verification clauses so
  a forged assertion short-circuits → **7 tests red**.

Both kill the context-level twin AND the wire-level ones.

## One pollution I introduced and fixed at the setup

`/auth/passkeys/options` counts EVERY call against a per-IP window shared
by the whole module, so the ceremony tests were eating the throttle
test's budget and it 429'd early. The setup hands the bucket back on
exit. The throttle assertion was not touched.

## Gates

`scripts/check.sh` — **rc=0**, 8 doctests, 50 properties, **5099 tests, 0
failures** (+16), Dialyzer `Total errors: 0`. Format, Credo strict,
Sobelow, deps.audit clean. Working tree clean before and after.

Integration/e2e not run — the STACK lane is not mine, and nothing here
reaches it.

## Follow-up this unblocks (not done here)

#768's two `:db_unavailable` controller clauses were coverable only by
inspection because `register/2` and `set_mode/2` needed a ceremony. They
are reachable now. #768 stays exactly as it is; the coverage belongs in a
later change.