### PR TITLE
cic(#804): resolve the archive peer's casing like the other eight sites

### DIFF
--- a/cicchetto/src/ArchiveModal.tsx
+++ b/cicchetto/src/ArchiveModal.tsx
@@ -14,7 +14,7 @@ import { mentionCounts } from "./lib/mentions";
 import { networks } from "./lib/networks";
 import { normalizeNick } from "./lib/nickEquals";
 import { createOverlayLock } from "./lib/overlayScrollLock";
-import { openQueryWindowState } from "./lib/queryWindows";
+import { canonicalQueryNick, openQueryWindowState } from "./lib/queryWindows";
 import { eventsUnread, messagesUnread, setSelectedChannel } from "./lib/selection";
 import NickText from "./NickText";
 
@@ -116,13 +116,27 @@ const ArchiveModal: Component = () => {
     // server which persists the query_windows row and broadcasts
     // `query_window_opened`; cic's subscribe loop re-arms and joins
     // the per-channel topic. Idempotent — no-op if already open.
+    //
+    // #804 — resolve the peer casing FIRST, like the eight sibling
+    // call sites of openQueryWindowState. The archive row carries one
+    // arbitrary spelling out of the folded group (`dm_with` is stored
+    // RAW, #121/#372), so a window already open under another casing
+    // would otherwise take the selection to a ChannelKey no sidebar
+    // row knows — the #731 / #799 phantom-pane shape. Both legs get
+    // the resolved value, mirroring ScrollbackPane.handleNickClick.
+    // The `channel` kind needs none: `messages.channel` stores the
+    // folded channel, so there is no raw casing to carry.
+    let channelName = target;
     if (kind === "query") {
       const net = networks()?.find((n) => n.slug === slug);
-      if (net) openQueryWindowState(net.id, target, new Date().toISOString());
+      if (net) {
+        channelName = canonicalQueryNick(net.id, target);
+        openQueryWindowState(net.id, channelName, new Date().toISOString());
+      }
     }
     setSelectedChannel({
       networkSlug: slug,
-      channelName: target,
+      channelName,
       kind,
     });
     close();

--- a/cicchetto/src/__tests__/ArchiveModal.test.tsx
+++ b/cicchetto/src/__tests__/ArchiveModal.test.tsx
@@ -35,9 +35,19 @@ vi.mock("../lib/networks", () => ({
   ],
 }));
 
-vi.mock("../lib/queryWindows", () => ({
-  openQueryWindowState: vi.fn(),
-}));
+// #804 — `canonicalQueryNick` is NOT a stub here: an identity stub would
+// pass whatever the component hands it straight back and blind the test
+// to the casing it actually resolves. It mirrors the real resolver
+// (lib/queryWindows.ts) over `mockOpenQueryNicks()`, folding with the
+// production `nickEquals`.
+vi.mock("../lib/queryWindows", async () => {
+  const { nickEquals } = await import("../lib/nickEquals");
+  return {
+    openQueryWindowState: vi.fn(),
+    canonicalQueryNick: (_networkId: number, nick: string) =>
+      mockOpenQueryNicks().find((open) => nickEquals(open, nick)) ?? nick,
+  };
+});
 
 vi.mock("../lib/api", () => ({
   deleteArchiveEntry: vi.fn().mockResolvedValue(undefined),
@@ -62,6 +72,7 @@ const {
   mockMessagesUnread,
   mockEventsUnread,
   mockMentionCounts,
+  mockOpenQueryNicks,
 } = vi.hoisted(() => ({
   mockOpen: vi.fn<() => boolean>(() => false),
   mockEntries: vi.fn<
@@ -81,6 +92,7 @@ const {
   mockMessagesUnread: vi.fn<() => Record<string, number>>(() => ({})),
   mockEventsUnread: vi.fn<() => Record<string, number>>(() => ({})),
   mockMentionCounts: vi.fn<() => Record<string, number>>(() => ({})),
+  mockOpenQueryNicks: vi.fn<() => string[]>(() => []),
 }));
 
 vi.mock("../lib/archive", () => ({
@@ -104,6 +116,7 @@ beforeEach(() => {
   mockMessagesUnread.mockReturnValue({});
   mockEventsUnread.mockReturnValue({});
   mockMentionCounts.mockReturnValue({});
+  mockOpenQueryNicks.mockReturnValue([]);
 });
 
 describe("ArchiveModal (#473 grouped)", () => {
@@ -247,6 +260,29 @@ describe("ArchiveModal (#473 grouped)", () => {
     // per-channel topic, else server NOTICEs (e.g. 401) drop on the floor.
     expect(qwMod.openQueryWindowState).toHaveBeenCalledWith(2, "vjt-peer", expect.any(String));
     expect(setArchiveModalOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("resolves a query entry's casing to the open window's, for BOTH legs (#804)", () => {
+    mockOpen.mockReturnValue(true);
+    // `dm_with` is stored RAW (#121/#372) and `list_archive` groups on the
+    // fold but selects one arbitrary row's spelling, so the archive row's
+    // casing need not match the window the peer is already open under.
+    mockOpenQueryNicks.mockReturnValue(["VJT-Peer"]);
+    mockEntries.mockImplementation((slug) =>
+      slug === "libera"
+        ? [{ target: "vjt-peer", kind: "query", last_activity: 100, row_count: 4 }]
+        : [],
+    );
+    render(() => <ArchiveModal />);
+    fireEvent.click(screen.getByText("vjt-peer"));
+    // Selection must land on the EXISTING row's key, not fork a phantom
+    // pane under the archive spelling (#731 / #799 shape).
+    expect(selMod.setSelectedChannel).toHaveBeenCalledWith({
+      networkSlug: "libera",
+      channelName: "VJT-Peer",
+      kind: "query",
+    });
+    expect(qwMod.openQueryWindowState).toHaveBeenCalledWith(2, "VJT-Peer", expect.any(String));
   });
 
   it("renders the unread msg badge for an archived DM holding unread (#532 B)", () => {


### PR DESCRIPTION
Fixes the one `openQueryWindowState` call site out of nine that did not
resolve the peer casing first. Issue #804.

## What

`ArchiveModal.handleSelectEntry` passed the archive row's raw `target`
to both `openQueryWindowState` and `setSelectedChannel`. It now runs it
through `canonicalQueryNick` — like `ScrollbackPane.handleNickClick`,
`MembersPane`, `WhoModal`, `NamesModal`, `UserContextMenu`,
`lib/pushTarget.ts`, and both `lib/compose.ts` sites — and uses the
resolved value for BOTH legs.

## Why, given it is inert today

The inertness is real but borrowed: `list_archive/3` excludes any target
present in the active keyset via a **folded** compare, so an archive
entry by construction has no open window — the one state where the eight
siblings' resolver is a no-op too. A *server* module's invariant is
holding a *client* selection path upright, nothing states the coupling
and no test pins it.

`dm_with` is stored RAW (#121/#372) and the archive query groups on the
fold while selecting one arbitrary row's spelling, so the moment the
exclusion changes — or a window opens between the archive fetch and the
row tap — selection holds `VJT-Peer` while the sidebar row is
`vjt-peer`: the #731 / #799 phantom-pane shape.

The governing rule is CLAUDE.md's *total consistency or nothing*: one
site out of nine reaching a shared verb by another route is a pattern
fork, and the next person to touch this file copies whichever is
closest.

## Notes

- **Not a fold.** `canonicalQueryNick` resolves to the existing window's
  RAW `targetNick`; folding there would break `Sidebar.tsx`'s raw `===`
  match and the ChannelKey derivation.
- The `kind: "channel"` leg is untouched — `messages.channel` stores the
  folded channel, so there is no raw casing to carry.
- The test file's `queryWindows` mock previously exported only
  `openQueryWindowState`. It now also carries `canonicalQueryNick` as a
  faithful stand-in over the production `nickEquals`, **not** an
  identity stub: an identity stub returns whatever the component passes
  and would have been blind to exactly this defect (the #799 lesson).

## Test

New case in `ArchiveModal.test.tsx`: an archive entry spelled
`vjt-peer` while a window is open as `VJT-Peer` must land selection —
and the window-open push — on `VJT-Peer`. Fails on `main` (selection
receives `vjt-peer`), passes here.

## Gates

- `bun run test` — 232 files / 4189 tests, rc=0
- `bun run check` (biome + tsc) — rc=0; `tsc --noEmit` standalone rc=0

cic-only change; no server code touched.