### PR TITLE
cic(#779): moduleRoot guard checks the invariant; bootFetch's budget covers the body

### DIFF
--- a/cicchetto/src/__tests__/moduleRootGuard.test.ts
+++ b/cicchetto/src/__tests__/moduleRootGuard.test.ts
@@ -2,7 +2,8 @@ import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
-// #717 — a bare `createRoot` must not come back.
+// #717 — a module-lifetime reactive computation must not run without an error
+// context.
 //
 // The first cut of #717 gave the error context to `identityScopedStore` alone
 // and left every other module root bare. `activeWindows.ts` — a module-level
@@ -15,7 +16,7 @@ import { describe, expect, it } from "vitest";
 //
 // CLAUDE.md: "Half-migrated creates two patterns — Claude copies whichever is
 // closer." So the migration is total and this test is what keeps it total. A
-// new root goes through `moduleRoot`; nothing else may call `createRoot`.
+// new root goes through `moduleRoot`; nothing else may own one.
 //
 // Sibling of biomePin.test.ts / versionSource.test.ts — vitest runs from the
 // cicchetto dir, so `src` is at cwd.
@@ -25,17 +26,78 @@ import { describe, expect, it } from "vitest";
 // the error context (see its header — a swallowed reset is #281's bug).
 const FACTORIES = ["src/lib/moduleRoot.ts", "src/lib/identityScopedStore.ts"];
 
-// Test files are out of scope, and not as a convenience exclusion: the rule is
-// about module-LIFETIME roots — singletons that are never disposed, whose throw
-// therefore has nowhere to go. A test root is the opposite, and says so in its
-// own shape: every one of them takes the `dispose` callback and scopes ownership
-// to the case. `createRoot` is exactly the right primitive there.
+// Test files are out of scope. The reason is the ERROR CONTEXT, not the shape:
+// a test module's root dies with the worker, and a throw inside one surfaces as
+// a failing test — the runner IS the context this guard exists to supply. (The
+// shape argument this comment used to make — "every one of them takes the
+// `dispose` callback" — is not true: `home.test.ts`, `railWhois.test.ts`,
+// `whoisCard.test.ts` and `subscribe.test.ts` each open one that does not.
+// Those roots leak within their worker; that is a test-hygiene matter, not a
+// #717 one, and it is not what this guard is for.)
 const isTestFile = (rel: string): boolean =>
   rel.includes("__tests__") || /\.test\.tsx?$/.test(rel) || rel === "src/setupTests.ts";
 
 // Matches a call, not the word: comments and prose about `createRoot` are fine
 // and there are several that explain the history.
-const BARE_ROOT = /\bcreateRoot\s*\(/;
+const ROOT_CALL = /\bcreateRoot\s*\(/;
+
+// A root whose callback BINDS the dispose argument is scoped — the author holds
+// the handle and the root ends. A root that ignores it is module-LIFETIME: never
+// disposed, so a throw inside it has nowhere to go. That, not the spelling, is
+// what the door exists for. Covers `d => …`, `(dispose) => …` and the `async`
+// forms; anything else is treated as owning, which is the safe default.
+const DISPOSING_ROOT = /\bcreateRoot\s*\(\s*(?:async\s+)?(?:\(\s*[A-Za-z_$]|[A-Za-z_$][\w$]*\s*=>)/;
+
+// The reactive primitives whose throw aborts the update cycle. `createSignal`
+// is absent on purpose: a signal is a value cell, it runs no user code and
+// cannot throw into `runUpdates`.
+const COMPUTATION = /\bcreate(?:Effect|Memo|Resource|Computed|RenderEffect)\s*\(/;
+
+// Module scope, detected as "starts at column 0". biome owns the formatting, so
+// anything nested is indented — a heuristic, but a pinned one, and the failure
+// direction is a false POSITIVE the author fixes by moving the call into the
+// root where it already belonged.
+const isModuleScope = (line: string): boolean => !/^\s/.test(line);
+
+// A root opened on the same line owns what follows it there:
+// `moduleRoot(() => createSignal(0))` is one line and correctly scoped.
+const OPENS_ROOT = /\b(?:moduleRoot|createRoot)\s*\(/;
+
+// Prose lines carry the migration's history; several of them quote the very
+// calls this guard forbids.
+const isProse = (line: string): boolean => {
+  const trimmed = line.trim();
+  return trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*");
+};
+
+type Offence = { line: number; rule: "owning-root" | "unowned-computation" };
+
+/**
+ * Classify one module's source. Pure over text so the fixtures below can pin
+ * the predicate itself — a guard that only ever runs over a clean tree proves
+ * nothing about what it would catch.
+ *
+ * Two rules, one invariant ("every module-lifetime computation has an error
+ * context"): a root that never disposes must come from `moduleRoot`, and a
+ * computation at module scope must be inside a root at all. #779.1 — the
+ * second rule is the one the original spelling-based guard could not express,
+ * and a module-scope `createMemo` with `Owner === null` reproduces the #717
+ * freeze exactly.
+ */
+function offences(src: string): Offence[] {
+  const found: Offence[] = [];
+  src.split("\n").forEach((line, i) => {
+    if (isProse(line)) return;
+    if (ROOT_CALL.test(line) && !DISPOSING_ROOT.test(line)) {
+      found.push({ line: i + 1, rule: "owning-root" });
+      return;
+    }
+    if (COMPUTATION.test(line) && isModuleScope(line) && !OPENS_ROOT.test(line)) {
+      found.push({ line: i + 1, rule: "unowned-computation" });
+    }
+  });
+  return found;
+}
 
 function sourceFiles(dir: string): string[] {
   const out: string[] = [];
@@ -50,34 +112,77 @@ function sourceFiles(dir: string): string[] {
   return out;
 }
 
+describe("module roots (#717 — the predicate)", () => {
+  it("flags a root that ignores its dispose argument — that root is forever", () => {
+    expect(offences("const exports_ = createRoot(() => {")).toEqual([
+      { line: 1, rule: "owning-root" },
+    ]);
+  });
+
+  it("allows a root that BINDS dispose — scoped ownership is what createRoot is for", () => {
+    // #779.3 — a detached/portal render is normal Solid and correct in
+    // production code. Without this arm the next author needing one is pushed
+    // into `moduleRoot` (wrong: it never disposes, so they leak a root) or
+    // into an exclusion list, which CLAUDE.md forbids.
+    expect(offences("  const dispose = createRoot((dispose) => render(el));")).toEqual([]);
+    expect(offences("  createRoot(async (d) => {")).toEqual([]);
+    expect(offences("  createRoot((d) => {")).toEqual([]);
+  });
+
+  it("flags a module-scope computation with no root at all", () => {
+    // #779.1 — THE evasion the spelling-based guard cannot see. A module-scope
+    // `createEffect`/`createMemo`/`createResource` outside any root has
+    // `Owner === null`, so `handleError` finds no handler and rethrows out of
+    // `runUpdates`: the identical cycle abort, the identical frozen last frame,
+    // the identical #717 signature. Solid only emits a dev-mode console.warn.
+    expect(offences("export const live = createMemo(() => channels().length);")).toEqual([
+      { line: 1, rule: "unowned-computation" },
+    ]);
+    expect(offences("createEffect(() => syncBadge(count()));")).toEqual([
+      { line: 1, rule: "unowned-computation" },
+    ]);
+  });
+
+  it("allows a computation nested inside something — only module scope is unowned", () => {
+    expect(offences("  const live = createMemo(() => channels().length);")).toEqual([]);
+    expect(offences("const [c, setC] = moduleRoot(() => createSignal(0));")).toEqual([]);
+    // A one-line root: the computation is lexically inside its callback.
+    expect(offences("const live = moduleRoot(() => createMemo(() => 1));")).toEqual([]);
+  });
+
+  it("ignores prose — the migration left explanatory comments quoting both calls", () => {
+    expect(offences("//   const exports_ = createRoot(() => {")).toEqual([]);
+    expect(offences(" * compiles for `createResource(user, …)`")).toEqual([]);
+  });
+});
+
 describe("module roots (#717 — one door, and it stays one)", () => {
-  it("has no bare createRoot outside the root factories", () => {
+  it("has no owning root and no unowned computation outside the root factories", () => {
     const root = resolve(process.cwd(), "src");
-    const offenders: string[] = [];
+    const found: string[] = [];
 
     for (const file of sourceFiles(root)) {
       const rel = relative(process.cwd(), file);
       if (FACTORIES.includes(rel) || isTestFile(rel)) continue;
-      const src = readFileSync(file, "utf8");
-      src.split("\n").forEach((line, i) => {
-        // Skip comment lines — the migration left explanatory prose behind.
-        const trimmed = line.trim();
-        if (trimmed.startsWith("//") || trimmed.startsWith("*")) return;
-        if (BARE_ROOT.test(line)) offenders.push(`${rel}:${i + 1}`);
-      });
+      for (const o of offences(readFileSync(file, "utf8"))) {
+        found.push(`${rel}:${o.line} (${o.rule})`);
+      }
     }
 
     expect(
-      offenders,
-      `bare createRoot found — use moduleRoot() so the root gets an error context (#717):\n${offenders.join("\n")}`,
+      found,
+      `use moduleRoot() so the root gets an error context (#717):\n${found.join("\n")}`,
     ).toEqual([]);
   });
 
-  it("still guards something — the factories themselves do call createRoot", () => {
+  it("still guards something — the factories themselves open an owning root", () => {
     // Without this, deleting both factories (or renaming the call) would leave
-    // the test above vacuously green.
-    const called = FACTORIES.filter((f) =>
-      BARE_ROOT.test(readFileSync(resolve(process.cwd(), f), "utf8")),
+    // the test above vacuously green. #779.2 — it runs through `offences`, so a
+    // factory reduced to PROSE about `createRoot` no longer satisfies it: the
+    // literal `//   const exports_ = createRoot(() => {` in
+    // identityScopedStore's pattern-history comment used to.
+    const called = FACTORIES.filter(
+      (f) => offences(readFileSync(resolve(process.cwd(), f), "utf8")).length > 0,
     );
     expect(called).toEqual(FACTORIES);
   });

--- a/cicchetto/src/lib/bootFetch.test.ts
+++ b/cicchetto/src/lib/bootFetch.test.ts
@@ -129,6 +129,36 @@ describe("bootFetch (#717 — bounded, retrying boot transport)", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("retries an attempt whose BODY aborts, and hands back a body the caller can read", async () => {
+    // #779.4 — `fetch` resolves at the HEADERS and the signal stays live on the
+    // Response, but every caller (`me`, `listNetworks`, `listChannels`) reads
+    // the body AFTER bootFetch has returned. A body still streaming when the
+    // per-attempt budget expires aborted out there, where the retry loop could
+    // not see it: a boot that failed and never tried again. Plausible on a slow
+    // link with a large `/me` envelope (read_cursors + unread_counts).
+    const aborting = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"partial":'));
+          controller.error(new DOMException("The operation was aborted.", "AbortError"));
+        },
+      }),
+      { status: 200 },
+    );
+    const fetchMock = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValueOnce(aborting)
+      .mockResolvedValueOnce(new Response('{"ok":true}', { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const promise = bootFetch("/me", {});
+    await vi.advanceTimersByTimeAsync(totalBackoffMs);
+    const res = await promise;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+  });
+
   it("gives each attempt its own signal, so attempt 1's timeout cannot abort attempt 2", async () => {
     const fetchMock = vi
       .fn<() => Promise<Response>>()

--- a/cicchetto/src/lib/bootFetch.ts
+++ b/cicchetto/src/lib/bootFetch.ts
@@ -44,8 +44,9 @@ function sleep(ms: number): Promise<void> {
  * GET a boot-critical resource with a per-attempt timeout and bounded retry.
  *
  * Resolves with the `Response` for ANY completed request, including error
- * statuses — status handling stays with the caller. Rejects with the last
- * transport error once the attempts are exhausted.
+ * statuses — status handling stays with the caller. "Completed" means the body
+ * arrived too, not just the headers. Rejects with the last transport error once
+ * the attempts are exhausted.
  */
 export async function bootFetch(
   path: string,
@@ -68,7 +69,17 @@ export async function bootFetch(
     // abort attempt 2 the moment it started — a retry that can never win.
     const signal = AbortSignal.timeout(BOOT_FETCH_TIMEOUT_MS);
     try {
-      return await fetch(path, { ...init, signal });
+      const res = await fetch(path, { ...init, signal });
+      // The budget must cover the BODY too. `fetch` resolves at the headers
+      // while the signal stays live on the `Response`, and every caller reads
+      // the body (`res.json()`) after this function has returned — so a body
+      // still streaming at the deadline used to abort out there, where the
+      // retry loop could not see it: a boot that failed and never retried.
+      // Draining a clone pulls that read INSIDE the attempt, which both makes
+      // the abort retryable and leaves the returned `Response` fully buffered,
+      // so the caller's own read can no longer be cut by our signal.
+      await res.clone().arrayBuffer();
+      return res;
     } catch (error) {
       lastError = error;
       const backoff = BOOT_FETCH_BACKOFF_MS[attempt];

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -28504,3 +28504,60 @@ per-page-load, so every reload re-pays upstream for an answer grappa already
 received. The precedent already exists — `userhost_cache` is nick-keyed, folded,
 fed passively from JOIN prefixes at zero upstream cost, and already migrated on
 NICK. Cache the answer, and the question of when to fetch mostly dissolves.
+
+## 2026-08-04 — #779: a timeout that stops at the headers is not a budget
+
+Two hardening items out of #717's review round 3, neither a live defect.
+
+**`bootFetch`'s per-attempt budget now covers the body.** `AbortSignal.timeout`
+starts at dispatch and stays live on the `Response`, but `fetch` resolves at
+the HEADERS and every caller — `me`, `listNetworks`, `listChannels` — reads the
+body with `res.json()` after `bootFetch` has already returned. A body still
+streaming at the 8s deadline therefore aborted OUTSIDE the retry loop: an
+`AbortError` the loop never saw, so an attempt the policy calls retryable was
+silently not retried. The fix drains a `res.clone()` inside the attempt. That
+pulls the body read into the budget (the abort becomes an ordinary retryable
+transport failure) and leaves the returned `Response` fully buffered, so the
+caller's own read can no longer be cut by our signal. Identity is preserved —
+the original `Response` is what comes back, not a reconstruction — which keeps
+`res.ok` / `res.status` / `readError` untouched. Plausible on a slow mobile
+link with a large `/me` envelope (`read_cursors` + `unread_counts`); on a LAN it
+never fires. The docstring's "ANY completed request" is now true: completed
+means the body arrived, not just the headers.
+
+**The `moduleRoot` guard enforces the invariant, not a spelling.** The #717
+invariant is "every module-lifetime computation has an error context". The
+guard enforced "no bare `createRoot`", which a module-scope `createEffect` /
+`createMemo` / `createResource` with NO root at all evades completely: it has
+`Owner === null`, so the throw propagates out of `runUpdates`, the queued render
+effects are discarded and the last frame freezes — the #717 signature exactly,
+with the regex reporting the file clean. Zero instances today; the point is that
+it is the EASIER thing for the next author to write.
+
+The rewrite splits one text predicate in two — an *owning root* (a `createRoot`
+whose callback ignores `dispose`, i.e. one that is never disposed) and an
+*unowned computation* (a reactive primitive at column 0 with no root on the
+line) — and both run through the same prose filter. Three consequences:
+
+- **A disposable root is now legal in production code.** `createRoot(dispose =>
+  …)` for a detached or portal render is normal Solid; the old guard flagged it
+  and left the next author choosing between `moduleRoot` (wrong — it never
+  disposes, so they leak a root) and an exclusion list, which CLAUDE.md forbids.
+  Binding `dispose` IS the invariant: a root with a handle ends.
+- **The anti-vacuity case can no longer be satisfied by a comment.** It runs
+  through the same classifier, so the literal `//   const exports_ =
+  createRoot(() => {` in `identityScopedStore`'s pattern-history comment stops
+  counting.
+- **The predicate is unit-tested against fixtures**, not only walked over a
+  clean tree. A guard that has never seen an offender proves nothing about what
+  it would catch.
+
+Module scope is detected as "starts at column 0" — a heuristic, pinned by the
+fact that biome owns the formatting, and one whose failure direction is a false
+positive the author fixes by moving the call into the root it belonged in.
+
+The test-file exemption stays, with a corrected justification: it is the ERROR
+CONTEXT that makes test roots out of scope (a test module's root dies with the
+worker and a throw surfaces as a failing test — the runner IS the context),
+not the shape. The comment used to claim every test root takes `dispose`; four
+do not.


### PR DESCRIPTION
The four findings from #717 review round 3. Issue #779. Every line was
re-verified against the files as they stand on `main` (the findings were
written at `388f883b`) — all four premises still hold, with **one
correction** noted below.

Two commits: the transport fix, then the guard.

## 4 — `bootFetch`'s per-attempt timeout also bounded the body read, and that abort was never retried

The one with a real consequence. `AbortSignal.timeout(8_000)` starts at
dispatch and stays live on the `Response`, but `fetch` resolves at the
HEADERS and every caller (`me`, `listNetworks`, `listChannels`) does
`await res.json()` after `bootFetch` returned. A body still streaming at
the deadline aborted **outside** the retry loop — an `AbortError` the loop
never saw, so an attempt the policy explicitly calls retryable was
silently not retried.

Fixed by draining a `res.clone()` inside the `try`. That pulls the body
read into the attempt (the abort becomes an ordinary retryable transport
failure) and leaves the returned `Response` fully buffered, so the
caller's own read can no longer be cut by our signal.

**Cloning, not reconstructing** — `new Response(await res.arrayBuffer(),
…)` would have worked too but loses identity, `res.url`, and trips the
null-body statuses. The original `Response` comes back, so the existing
`resolves.toBe(ok)` assertions still hold and `readError` is untouched.

Test: a first attempt whose body stream errors mid-way, a good second one.
Before: one `fetch` call and a `Response` whose `json()` rejects. After:
two calls and a readable body.

## 1 — the guard enforced a spelling, not the invariant

A module-scope `createEffect` / `createMemo` / `createResource` with no
root at all has `Owner === null` — the throw leaves `runUpdates`, the
queued render effects are discarded, the last frame freezes. The #717
signature exactly, and `/\bcreateRoot\s*\(/` reports the file clean.

The predicate is now two rules: an **owning root** (a `createRoot` whose
callback ignores `dispose`) and an **unowned computation** (a reactive
primitive at column 0 with no root on the line). Module scope is detected
as "starts at column 0" — a heuristic, pinned by biome owning the
formatting, and its failure direction is a false positive the author fixes
by moving the call into the root it belonged in.

Zero offenders in the tree today, so the classifier is also **unit-tested
against fixtures**: a guard that has never seen an offender proves nothing
about what it would catch. Those fixtures are the RED — the disposable-root
case and the module-scope-memo case both failed against the old predicate
before the rewrite.

## 2 — the anti-vacuity case was satisfiable by a comment

It ran the raw regex over the whole file, so `identityScopedStore.ts:10`'s
`//   const exports_ = createRoot(() => {` would have kept it green on
prose alone. It now runs through the same classifier as the walk, which
applies the prose filter. Pinned by a fixture case.

## 3 — no escape hatch for a legitimately disposable root

`createRoot(dispose => …)` for a detached or portal render is normal Solid
and correct in production code. The old guard flagged it, leaving the next
author choosing between `moduleRoot` (wrong — it never disposes, so they
leak a root) and an exclusion list, which CLAUDE.md forbids. Binding
`dispose` IS the invariant now: a root with a handle ends, a root without
one is forever and must come through the door.

**Correction to the issue.** #779.3 says the test-file exemption's own
justification is the right predicate — "every one of them takes the
`dispose` callback". That claim is **false**: `home.test.ts:42`,
`railWhois.test.ts:186`, `whoisCard.test.ts:61` and `subscribe.test.ts:1186`
each open a root that does not. So the dispose predicate could not replace
the path exemption without either editing four unrelated test files or
opening the exclusion list the finding was written to avoid.

The exemption therefore stays, with its justification corrected to the true
one: it is the ERROR CONTEXT that puts test roots out of scope — a test
module's root dies with the worker and a throw surfaces as a failing test,
so the runner IS the context this guard exists to supply. The four leaking
roots are a test-hygiene matter, not a #717 one; flagged here rather than
filed, since the freeze is on review findings.

## Gates

- `bun run test` — 232 files / 4194 tests, rc=0
- `bun run check` (biome + tsc) — rc=0; `tsc --noEmit` standalone rc=0

cic-only; no server code touched. `docs/DESIGN_NOTES.md` carries the
durable rationale. Refs #717, PR #776.