### PR TITLE
union-0.11.1-b: #740 + #804 + #779 + #788 gated together

### DIFF
--- a/cicchetto/src/ArchiveModal.tsx
+++ b/cicchetto/src/ArchiveModal.tsx
@@ -14,7 +14,7 @@ import { mentionCounts } from "./lib/mentions";
 import { networks } from "./lib/networks";
 import { normalizeNick } from "./lib/nickEquals";
 import { createOverlayLock } from "./lib/overlayScrollLock";
-import { openQueryWindowState } from "./lib/queryWindows";
+import { canonicalQueryNick, openQueryWindowState } from "./lib/queryWindows";
 import { eventsUnread, messagesUnread, setSelectedChannel } from "./lib/selection";
 import NickText from "./NickText";
 
@@ -116,13 +116,27 @@ const ArchiveModal: Component = () => {
     // server which persists the query_windows row and broadcasts
     // `query_window_opened`; cic's subscribe loop re-arms and joins
     // the per-channel topic. Idempotent — no-op if already open.
+    //
+    // #804 — resolve the peer casing FIRST, like the eight sibling
+    // call sites of openQueryWindowState. The archive row carries one
+    // arbitrary spelling out of the folded group (`dm_with` is stored
+    // RAW, #121/#372), so a window already open under another casing
+    // would otherwise take the selection to a ChannelKey no sidebar
+    // row knows — the #731 / #799 phantom-pane shape. Both legs get
+    // the resolved value, mirroring ScrollbackPane.handleNickClick.
+    // The `channel` kind needs none: `messages.channel` stores the
+    // folded channel, so there is no raw casing to carry.
+    let channelName = target;
     if (kind === "query") {
       const net = networks()?.find((n) => n.slug === slug);
-      if (net) openQueryWindowState(net.id, target, new Date().toISOString());
+      if (net) {
+        channelName = canonicalQueryNick(net.id, target);
+        openQueryWindowState(net.id, channelName, new Date().toISOString());
+      }
     }
     setSelectedChannel({
       networkSlug: slug,
-      channelName: target,
+      channelName,
       kind,
     });
     close();

--- a/cicchetto/src/Login.tsx
+++ b/cicchetto/src/Login.tsx
@@ -449,7 +449,7 @@ const Login: Component = () => {
                   <div class="login-alt-auth-row">
                     <button
                       type="button"
-                      class="login-advanced-toggle"
+                      class="login-quiet-button login-advanced-toggle"
                       aria-expanded={advanced() ? "true" : "false"}
                       aria-controls="login-advanced"
                       onClick={() => setAdvanced((v) => !v)}
@@ -458,14 +458,14 @@ const Login: Component = () => {
                     </button>
                     <button
                       type="button"
-                      class="login-alt-auth"
+                      class="login-quiet-button login-alt-auth"
                       onClick={() => void onPasskeyLogin()}
                     >
                       Passkey
                     </button>
                     <button
                       type="button"
-                      class="login-alt-auth"
+                      class="login-quiet-button login-alt-auth"
                       onClick={() => setRecoveryMode((value) => !value)}
                     >
                       Recovery code
@@ -591,7 +591,7 @@ const Login: Component = () => {
                   </button>
                   <button
                     type="button"
-                    class="login-advanced-toggle"
+                    class="login-quiet-button login-advanced-toggle"
                     onClick={() => {
                       setTotpChallenge(null);
                       setTotpCode("");

--- a/cicchetto/src/MircText.tsx
+++ b/cicchetto/src/MircText.tsx
@@ -99,7 +99,11 @@ const renderChannel = (
 ): JSX.Element => {
   if (!onChannelClick) return channel;
   return (
-    <button type="button" class="channel-clickable" onClick={() => onChannelClick(channel)}>
+    <button
+      type="button"
+      class="scrollback-inline-button channel-clickable"
+      onClick={() => onChannelClick(channel)}
+    >
       {channel}
     </button>
   );

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -560,7 +560,7 @@ const renderRawEvent = (
             *** {senderSpan(sender)} invited you to {invitedChannel}{" "}
             <button
               type="button"
-              class="scrollback-invite-join"
+              class="scrollback-inline-button scrollback-invite-join"
               onClick={() => handlers.onJoinChannel(invitedChannel)}
             >
               [Join]
@@ -660,7 +660,7 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
   const senderSpan = (bracketLeft: string, bracketRight: string, nick: string): JSX.Element => (
     <button
       type="button"
-      class="scrollback-sender nick-clickable"
+      class="scrollback-sender scrollback-inline-button nick-clickable"
       onClick={() => handlers.onNickClick(nick)}
       onContextMenu={(e: MouseEvent) => handlers.onNickContextMenu(nick, e)}
     >
@@ -677,7 +677,7 @@ const renderBody = (msg: ScrollbackMessage, handlers: NickHandlers): JSX.Element
   const bareSenderSpan = (nick: string): JSX.Element => (
     <button
       type="button"
-      class="scrollback-sender nick-clickable"
+      class="scrollback-sender scrollback-inline-button nick-clickable"
       onClick={() => handlers.onNickClick(nick)}
       onContextMenu={(e: MouseEvent) => handlers.onNickContextMenu(nick, e)}
     >

--- a/cicchetto/src/__tests__/ArchiveModal.test.tsx
+++ b/cicchetto/src/__tests__/ArchiveModal.test.tsx
@@ -35,9 +35,19 @@ vi.mock("../lib/networks", () => ({
   ],
 }));
 
-vi.mock("../lib/queryWindows", () => ({
-  openQueryWindowState: vi.fn(),
-}));
+// #804 — `canonicalQueryNick` is NOT a stub here: an identity stub would
+// pass whatever the component hands it straight back and blind the test
+// to the casing it actually resolves. It mirrors the real resolver
+// (lib/queryWindows.ts) over `mockOpenQueryNicks()`, folding with the
+// production `nickEquals`.
+vi.mock("../lib/queryWindows", async () => {
+  const { nickEquals } = await import("../lib/nickEquals");
+  return {
+    openQueryWindowState: vi.fn(),
+    canonicalQueryNick: (_networkId: number, nick: string) =>
+      mockOpenQueryNicks().find((open) => nickEquals(open, nick)) ?? nick,
+  };
+});
 
 vi.mock("../lib/api", () => ({
   deleteArchiveEntry: vi.fn().mockResolvedValue(undefined),
@@ -62,6 +72,7 @@ const {
   mockMessagesUnread,
   mockEventsUnread,
   mockMentionCounts,
+  mockOpenQueryNicks,
 } = vi.hoisted(() => ({
   mockOpen: vi.fn<() => boolean>(() => false),
   mockEntries: vi.fn<
@@ -81,6 +92,7 @@ const {
   mockMessagesUnread: vi.fn<() => Record<string, number>>(() => ({})),
   mockEventsUnread: vi.fn<() => Record<string, number>>(() => ({})),
   mockMentionCounts: vi.fn<() => Record<string, number>>(() => ({})),
+  mockOpenQueryNicks: vi.fn<() => string[]>(() => []),
 }));
 
 vi.mock("../lib/archive", () => ({
@@ -104,6 +116,7 @@ beforeEach(() => {
   mockMessagesUnread.mockReturnValue({});
   mockEventsUnread.mockReturnValue({});
   mockMentionCounts.mockReturnValue({});
+  mockOpenQueryNicks.mockReturnValue([]);
 });
 
 describe("ArchiveModal (#473 grouped)", () => {
@@ -247,6 +260,29 @@ describe("ArchiveModal (#473 grouped)", () => {
     // per-channel topic, else server NOTICEs (e.g. 401) drop on the floor.
     expect(qwMod.openQueryWindowState).toHaveBeenCalledWith(2, "vjt-peer", expect.any(String));
     expect(setArchiveModalOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("resolves a query entry's casing to the open window's, for BOTH legs (#804)", () => {
+    mockOpen.mockReturnValue(true);
+    // `dm_with` is stored RAW (#121/#372) and `list_archive` groups on the
+    // fold but selects one arbitrary row's spelling, so the archive row's
+    // casing need not match the window the peer is already open under.
+    mockOpenQueryNicks.mockReturnValue(["VJT-Peer"]);
+    mockEntries.mockImplementation((slug) =>
+      slug === "libera"
+        ? [{ target: "vjt-peer", kind: "query", last_activity: 100, row_count: 4 }]
+        : [],
+    );
+    render(() => <ArchiveModal />);
+    fireEvent.click(screen.getByText("vjt-peer"));
+    // Selection must land on the EXISTING row's key, not fork a phantom
+    // pane under the archive spelling (#731 / #799 shape).
+    expect(selMod.setSelectedChannel).toHaveBeenCalledWith({
+      networkSlug: "libera",
+      channelName: "VJT-Peer",
+      kind: "query",
+    });
+    expect(qwMod.openQueryWindowState).toHaveBeenCalledWith(2, "VJT-Peer", expect.any(String));
   });
 
   it("renders the unread msg badge for an archived DM holding unread (#532 B)", () => {

--- a/cicchetto/src/__tests__/Login.test.tsx
+++ b/cicchetto/src/__tests__/Login.test.tsx
@@ -522,3 +522,31 @@ describe("Login — captcha flow (carried forward)", () => {
     expect(mountCaptchaWidget).not.toHaveBeenCalled();
   });
 });
+
+// #740 — the CSS half of this pair is pinned in sharedButtonRules.test.ts.
+// This is the other half: a shared rule that nothing wears is the #734
+// failure mode inverted, and the two buttons this rule unifies sit in one
+// flex row under align-items: center, so a class missing from one of them
+// is a visible height mismatch rather than a cosmetic nit.
+describe("Login — #740 the quiet text-buttons wear the shared class", () => {
+  it("puts .login-quiet-button on the Advanced toggle and on both alt-auth buttons", () => {
+    renderLogin();
+    const quiet = [
+      screen.getByRole("button", { name: /Advanced/ }),
+      passkeyBtn(),
+      screen.getByRole("button", { name: "Recovery code" }),
+    ];
+    for (const button of quiet) {
+      expect(button.classList.contains("login-quiet-button")).toBe(true);
+    }
+  });
+
+  it("keeps the per-instance classes the e2e clicks as strict single matches", () => {
+    // issue281: `.login-advanced-toggle` must stay ONE element per rendered
+    // branch and `.login-alt-auth` exactly two. Composing a second class
+    // must not disturb either count.
+    renderLogin();
+    expect(document.querySelectorAll(".login-advanced-toggle")).toHaveLength(1);
+    expect(document.querySelectorAll(".login-alt-auth")).toHaveLength(2);
+  });
+});

--- a/cicchetto/src/__tests__/MircText.test.tsx
+++ b/cicchetto/src/__tests__/MircText.test.tsx
@@ -209,6 +209,8 @@ describe("MircText channel affordance (#648)", () => {
       <MircBody body="join #Sniffo now" emphasis onChannelClick={spy} />
     ));
     const btn = container.querySelector(".channel-clickable") as HTMLButtonElement;
+    // #740 — wears the shared inline-button reset beside its own class.
+    expect(btn.classList.contains("scrollback-inline-button")).toBe(true);
     expect(btn).not.toBeNull();
     // display-cased, raw (keys fold downstream; the affordance shows what
     // the sender typed).

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -1978,6 +1978,10 @@ describe("ScrollbackPane", () => {
       render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
       const sender = document.querySelector(".scrollback-sender");
       expect(sender?.classList.contains("nick-clickable")).toBe(true);
+      // #740 — and the shared inline-button reset it now takes its shape
+      // from. The CSS half is pinned in sharedButtonRules.test.ts; a rule
+      // nothing wears is the #734 failure mode inverted.
+      expect(sender?.classList.contains("scrollback-inline-button")).toBe(true);
     });
   });
 
@@ -3092,6 +3096,8 @@ describe("ScrollbackPane", () => {
       const btn = line.querySelector(".scrollback-invite-join") as HTMLButtonElement;
       expect(btn).not.toBeNull();
       expect(btn.textContent).toContain("Join");
+      // #740 — wears the shared inline-button reset beside its own class.
+      expect(btn.classList.contains("scrollback-inline-button")).toBe(true);
     });
 
     it("INVITE [Join] click invokes postJoin + setSelectedChannel", async () => {

--- a/cicchetto/src/__tests__/moduleRootGuard.test.ts
+++ b/cicchetto/src/__tests__/moduleRootGuard.test.ts
@@ -2,7 +2,8 @@ import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
-// #717 — a bare `createRoot` must not come back.
+// #717 — a module-lifetime reactive computation must not run without an error
+// context.
 //
 // The first cut of #717 gave the error context to `identityScopedStore` alone
 // and left every other module root bare. `activeWindows.ts` — a module-level
@@ -15,7 +16,7 @@ import { describe, expect, it } from "vitest";
 //
 // CLAUDE.md: "Half-migrated creates two patterns — Claude copies whichever is
 // closer." So the migration is total and this test is what keeps it total. A
-// new root goes through `moduleRoot`; nothing else may call `createRoot`.
+// new root goes through `moduleRoot`; nothing else may own one.
 //
 // Sibling of biomePin.test.ts / versionSource.test.ts — vitest runs from the
 // cicchetto dir, so `src` is at cwd.
@@ -25,17 +26,78 @@ import { describe, expect, it } from "vitest";
 // the error context (see its header — a swallowed reset is #281's bug).
 const FACTORIES = ["src/lib/moduleRoot.ts", "src/lib/identityScopedStore.ts"];
 
-// Test files are out of scope, and not as a convenience exclusion: the rule is
-// about module-LIFETIME roots — singletons that are never disposed, whose throw
-// therefore has nowhere to go. A test root is the opposite, and says so in its
-// own shape: every one of them takes the `dispose` callback and scopes ownership
-// to the case. `createRoot` is exactly the right primitive there.
+// Test files are out of scope. The reason is the ERROR CONTEXT, not the shape:
+// a test module's root dies with the worker, and a throw inside one surfaces as
+// a failing test — the runner IS the context this guard exists to supply. (The
+// shape argument this comment used to make — "every one of them takes the
+// `dispose` callback" — is not true: `home.test.ts`, `railWhois.test.ts`,
+// `whoisCard.test.ts` and `subscribe.test.ts` each open one that does not.
+// Those roots leak within their worker; that is a test-hygiene matter, not a
+// #717 one, and it is not what this guard is for.)
 const isTestFile = (rel: string): boolean =>
   rel.includes("__tests__") || /\.test\.tsx?$/.test(rel) || rel === "src/setupTests.ts";
 
 // Matches a call, not the word: comments and prose about `createRoot` are fine
 // and there are several that explain the history.
-const BARE_ROOT = /\bcreateRoot\s*\(/;
+const ROOT_CALL = /\bcreateRoot\s*\(/;
+
+// A root whose callback BINDS the dispose argument is scoped — the author holds
+// the handle and the root ends. A root that ignores it is module-LIFETIME: never
+// disposed, so a throw inside it has nowhere to go. That, not the spelling, is
+// what the door exists for. Covers `d => …`, `(dispose) => …` and the `async`
+// forms; anything else is treated as owning, which is the safe default.
+const DISPOSING_ROOT = /\bcreateRoot\s*\(\s*(?:async\s+)?(?:\(\s*[A-Za-z_$]|[A-Za-z_$][\w$]*\s*=>)/;
+
+// The reactive primitives whose throw aborts the update cycle. `createSignal`
+// is absent on purpose: a signal is a value cell, it runs no user code and
+// cannot throw into `runUpdates`.
+const COMPUTATION = /\bcreate(?:Effect|Memo|Resource|Computed|RenderEffect)\s*\(/;
+
+// Module scope, detected as "starts at column 0". biome owns the formatting, so
+// anything nested is indented — a heuristic, but a pinned one, and the failure
+// direction is a false POSITIVE the author fixes by moving the call into the
+// root where it already belonged.
+const isModuleScope = (line: string): boolean => !/^\s/.test(line);
+
+// A root opened on the same line owns what follows it there:
+// `moduleRoot(() => createSignal(0))` is one line and correctly scoped.
+const OPENS_ROOT = /\b(?:moduleRoot|createRoot)\s*\(/;
+
+// Prose lines carry the migration's history; several of them quote the very
+// calls this guard forbids.
+const isProse = (line: string): boolean => {
+  const trimmed = line.trim();
+  return trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*");
+};
+
+type Offence = { line: number; rule: "owning-root" | "unowned-computation" };
+
+/**
+ * Classify one module's source. Pure over text so the fixtures below can pin
+ * the predicate itself — a guard that only ever runs over a clean tree proves
+ * nothing about what it would catch.
+ *
+ * Two rules, one invariant ("every module-lifetime computation has an error
+ * context"): a root that never disposes must come from `moduleRoot`, and a
+ * computation at module scope must be inside a root at all. #779.1 — the
+ * second rule is the one the original spelling-based guard could not express,
+ * and a module-scope `createMemo` with `Owner === null` reproduces the #717
+ * freeze exactly.
+ */
+function offences(src: string): Offence[] {
+  const found: Offence[] = [];
+  src.split("\n").forEach((line, i) => {
+    if (isProse(line)) return;
+    if (ROOT_CALL.test(line) && !DISPOSING_ROOT.test(line)) {
+      found.push({ line: i + 1, rule: "owning-root" });
+      return;
+    }
+    if (COMPUTATION.test(line) && isModuleScope(line) && !OPENS_ROOT.test(line)) {
+      found.push({ line: i + 1, rule: "unowned-computation" });
+    }
+  });
+  return found;
+}
 
 function sourceFiles(dir: string): string[] {
   const out: string[] = [];
@@ -50,34 +112,77 @@ function sourceFiles(dir: string): string[] {
   return out;
 }
 
+describe("module roots (#717 — the predicate)", () => {
+  it("flags a root that ignores its dispose argument — that root is forever", () => {
+    expect(offences("const exports_ = createRoot(() => {")).toEqual([
+      { line: 1, rule: "owning-root" },
+    ]);
+  });
+
+  it("allows a root that BINDS dispose — scoped ownership is what createRoot is for", () => {
+    // #779.3 — a detached/portal render is normal Solid and correct in
+    // production code. Without this arm the next author needing one is pushed
+    // into `moduleRoot` (wrong: it never disposes, so they leak a root) or
+    // into an exclusion list, which CLAUDE.md forbids.
+    expect(offences("  const dispose = createRoot((dispose) => render(el));")).toEqual([]);
+    expect(offences("  createRoot(async (d) => {")).toEqual([]);
+    expect(offences("  createRoot((d) => {")).toEqual([]);
+  });
+
+  it("flags a module-scope computation with no root at all", () => {
+    // #779.1 — THE evasion the spelling-based guard cannot see. A module-scope
+    // `createEffect`/`createMemo`/`createResource` outside any root has
+    // `Owner === null`, so `handleError` finds no handler and rethrows out of
+    // `runUpdates`: the identical cycle abort, the identical frozen last frame,
+    // the identical #717 signature. Solid only emits a dev-mode console.warn.
+    expect(offences("export const live = createMemo(() => channels().length);")).toEqual([
+      { line: 1, rule: "unowned-computation" },
+    ]);
+    expect(offences("createEffect(() => syncBadge(count()));")).toEqual([
+      { line: 1, rule: "unowned-computation" },
+    ]);
+  });
+
+  it("allows a computation nested inside something — only module scope is unowned", () => {
+    expect(offences("  const live = createMemo(() => channels().length);")).toEqual([]);
+    expect(offences("const [c, setC] = moduleRoot(() => createSignal(0));")).toEqual([]);
+    // A one-line root: the computation is lexically inside its callback.
+    expect(offences("const live = moduleRoot(() => createMemo(() => 1));")).toEqual([]);
+  });
+
+  it("ignores prose — the migration left explanatory comments quoting both calls", () => {
+    expect(offences("//   const exports_ = createRoot(() => {")).toEqual([]);
+    expect(offences(" * compiles for `createResource(user, …)`")).toEqual([]);
+  });
+});
+
 describe("module roots (#717 — one door, and it stays one)", () => {
-  it("has no bare createRoot outside the root factories", () => {
+  it("has no owning root and no unowned computation outside the root factories", () => {
     const root = resolve(process.cwd(), "src");
-    const offenders: string[] = [];
+    const found: string[] = [];
 
     for (const file of sourceFiles(root)) {
       const rel = relative(process.cwd(), file);
       if (FACTORIES.includes(rel) || isTestFile(rel)) continue;
-      const src = readFileSync(file, "utf8");
-      src.split("\n").forEach((line, i) => {
-        // Skip comment lines — the migration left explanatory prose behind.
-        const trimmed = line.trim();
-        if (trimmed.startsWith("//") || trimmed.startsWith("*")) return;
-        if (BARE_ROOT.test(line)) offenders.push(`${rel}:${i + 1}`);
-      });
+      for (const o of offences(readFileSync(file, "utf8"))) {
+        found.push(`${rel}:${o.line} (${o.rule})`);
+      }
     }
 
     expect(
-      offenders,
-      `bare createRoot found — use moduleRoot() so the root gets an error context (#717):\n${offenders.join("\n")}`,
+      found,
+      `use moduleRoot() so the root gets an error context (#717):\n${found.join("\n")}`,
     ).toEqual([]);
   });
 
-  it("still guards something — the factories themselves do call createRoot", () => {
+  it("still guards something — the factories themselves open an owning root", () => {
     // Without this, deleting both factories (or renaming the call) would leave
-    // the test above vacuously green.
-    const called = FACTORIES.filter((f) =>
-      BARE_ROOT.test(readFileSync(resolve(process.cwd(), f), "utf8")),
+    // the test above vacuously green. #779.2 — it runs through `offences`, so a
+    // factory reduced to PROSE about `createRoot` no longer satisfies it: the
+    // literal `//   const exports_ = createRoot(() => {` in
+    // identityScopedStore's pattern-history comment used to.
+    const called = FACTORIES.filter(
+      (f) => offences(readFileSync(resolve(process.cwd(), f), "utf8")).length > 0,
     );
     expect(called).toEqual(FACTORIES);
   });

--- a/cicchetto/src/__tests__/sharedButtonRules.test.ts
+++ b/cicchetto/src/__tests__/sharedButtonRules.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import { ruleBody, themeCss } from "./helpers/themeCss";
+
+// #740 — two sets of buttons had been styled by copying a rule instead of
+// sharing one. The guard is not "a shared rule exists" (that would pass with
+// the clones still in place beside it) but "the per-instance rules no longer
+// DECLARE the shared properties" — the clone is what drifts, so the clone is
+// what the test has to see gone.
+//
+// jsdom applies no stylesheet, so this reads the source. It proves what the
+// cascade is asked to do, never what a browser paints.
+
+function declares(body: string, property: string): boolean {
+  return new RegExp(`(^|;)\\s*${property}\\s*:`, "m").test(body);
+}
+
+// `ruleBody` throws on an absent rule — the #734 guard against a class name
+// with nothing behind it. Here the absence is the POINT: a per-instance class
+// that has no delta left carries no rule of its own and takes its paint from
+// the shared class it is worn beside. "No rule" and "a rule declaring no
+// shared property" are the same pass.
+function deltaBody(selector: string): string {
+  try {
+    return ruleBody(selector);
+  } catch {
+    return "";
+  }
+}
+
+describe("#740 — the login card's quiet text-buttons share ONE rule", () => {
+  // .login-advanced-toggle and .login-alt-auth were byte-identical: nine
+  // declarations each. They sit in the same flex row under
+  // align-items: center, so a padding or min-height tweak landing on one and
+  // not the other is visible as a height mismatch.
+  const SHARED = [
+    "background",
+    "color",
+    "border",
+    "text-align",
+    "padding",
+    "min-height",
+    "font-family",
+    "font-size",
+    "cursor",
+  ];
+
+  it("declares the quiet text-button shape once", () => {
+    const shared = ruleBody(".login-quiet-button");
+    for (const property of SHARED) {
+      expect(declares(shared, property), `.login-quiet-button declares ${property}`).toBe(true);
+    }
+  });
+
+  it("keeps the 44px tap floor on the shared rule, not on a copy", () => {
+    expect(ruleBody(".login-quiet-button")).toMatch(/min-height:\s*var\(--tap-min\)/);
+  });
+
+  it("hovers to --fg once, for both instances", () => {
+    expect(ruleBody(".login-quiet-button:hover")).toMatch(/color:\s*var\(--fg\)/);
+  });
+
+  it.each([".login-advanced-toggle", ".login-alt-auth"])(
+    "%s no longer re-declares any shared property",
+    (selector) => {
+      const body = deltaBody(selector);
+      for (const property of SHARED) {
+        expect(declares(body, property), `${selector} must not re-declare ${property}`).toBe(false);
+      }
+    },
+  );
+});
+
+describe("#740 — the scrollback's inline buttons share ONE reset", () => {
+  // .nick-clickable / .channel-clickable / .scrollback-invite-join are three
+  // copies of the same "render a <button> as inline text" reset. Their real
+  // deltas stay local: colour, padding, font-weight, and the #250
+  // user-select: text that the [Join] CTA deliberately does not carry.
+  const SHARED = ["cursor", "background", "border", "font", "display"];
+
+  it("declares the inline-button reset once", () => {
+    const shared = ruleBody(".scrollback-inline-button");
+    for (const property of SHARED) {
+      expect(declares(shared, property), `.scrollback-inline-button declares ${property}`).toBe(
+        true,
+      );
+    }
+  });
+
+  it("underlines on hover once, for all three", () => {
+    expect(ruleBody(".scrollback-inline-button:hover")).toMatch(/text-decoration:\s*underline/);
+  });
+
+  it.each([".nick-clickable", ".channel-clickable", ".scrollback-invite-join"])(
+    "%s no longer re-declares any shared property",
+    (selector) => {
+      const body = deltaBody(selector);
+      for (const property of SHARED) {
+        expect(declares(body, property), `${selector} must not re-declare ${property}`).toBe(false);
+      }
+    },
+  );
+
+  it("leaves the genuine per-instance deltas local", () => {
+    // Each of these differs from its siblings, so sharing them would be the
+    // opposite defect — one rule flattening three intended looks.
+    expect(ruleBody(".channel-clickable")).toMatch(/color:\s*var\(--accent\)/);
+    expect(ruleBody(".scrollback-invite-join")).toMatch(/font-weight:\s*bold/);
+    expect(ruleBody(".scrollback-invite-join")).toMatch(/padding:\s*0 0\.25em/);
+  });
+
+  it("keeps user-select: text off the [Join] CTA and on the two text tokens", () => {
+    // #250 — the nick and the #channel must stay inside a drag selection on
+    // Android; the [Join] CTA is deliberately not copyable (keepKeyboard.ts).
+    // If the shared reset ever absorbs user-select, this is what catches it.
+    expect(ruleBody(".nick-clickable")).toMatch(/user-select:\s*text/);
+    expect(ruleBody(".channel-clickable")).toMatch(/user-select:\s*text/);
+    expect(ruleBody(".scrollback-invite-join")).not.toMatch(/user-select/);
+    expect(ruleBody(".scrollback-inline-button")).not.toMatch(/user-select/);
+  });
+});
+
+describe("#740 — the shared rules are worn, not merely declared", () => {
+  // The #734 failure mode, inverted: a rule with no element behind it. The
+  // markup assertions live with their components (Login.test.tsx,
+  // ScrollbackPane.test.tsx); this one guards the CSS side of the pair —
+  // that nothing re-introduces a fourth copy of either shape.
+  it("no rule outside the shared one carries the quiet-button signature", () => {
+    // Keyed on the SHAPE, not on the 44px tap-target convention: an earlier
+    // draft matched padding+min-height alone and flagged
+    // `.archive-modal-group-summary`, which is a bold accent flex row that
+    // merely honours the same HIG floor. The signature that identifies a
+    // clone is transparent background + the mono face + that padding.
+    const clones = [...themeCss.matchAll(/^(\.[a-z0-9-]+)\s*\{([^}]*)\}/gm)].filter(
+      ([, , body]) =>
+        body !== undefined &&
+        /background:\s*transparent/.test(body) &&
+        /font-family:\s*var\(--font-mono\)/.test(body) &&
+        /padding:\s*0\.6rem 0\.25rem/.test(body),
+    );
+    expect(clones.map(([, selector]) => selector)).toEqual([".login-quiet-button"]);
+  });
+});

--- a/cicchetto/src/lib/__tests__/scrollbackIdentityRotation.test.ts
+++ b/cicchetto/src/lib/__tests__/scrollbackIdentityRotation.test.ts
@@ -2,7 +2,7 @@
 // further: no request on the wire, no write into the store.
 //
 // Every async verb in `scrollback.ts` captures `token()` at entry and then
-// awaits. The nine `onIdentityChange` resets clear STATE; they cancel nothing
+// awaits. The `onIdentityChange` resets clear STATE; they cancel nothing
 // in flight. So a rotation or a detach landing inside one of those awaits
 // leaves the continuation holding a bearer the server has already revoked —
 // and it sends it. Reproduced in a browser on the real bundle (see the issue):
@@ -81,19 +81,33 @@ const row = (id: number): ScrollbackMessage => ({
   meta: {},
 });
 
-// A full `PAGE_LIMIT` page — the shape that makes `refreshScrollback` probe
-// for the remainder, which is the measured #788 site.
-const fullPage = (): ScrollbackMessage[] => Array.from({ length: 200 }, (_, i) => row(i + 1));
+// A full page — the shape that makes `refreshScrollback` probe for the
+// remainder, which is the measured #788 site. The size is read back from the
+// limit the module ASKED for rather than hardcoded to today's `PAGE_LIMIT`:
+// a hardcoded 200 that drifts out of step would stop entering the probe
+// branch at all, and the case would pass because it tested nothing. The
+// "identity holds" control below fails loudly if that ever happens anyway.
+const fullPageFor = (spy: { mock: { calls: unknown[][] } }): ScrollbackMessage[] => {
+  const limit = spy.mock.calls[0]?.[4];
+  if (typeof limit !== "number") throw new Error("no page limit observed on the wire");
+  return Array.from({ length: limit }, (_, i) => row(i + 1));
+};
 
 // Hold a REST call open so the rotation can land strictly inside its await,
 // which is the whole point: the continuation resumes under a bearer the
 // server has already revoked.
-const gate = <T>(): { promise: Promise<T>; release: (value: T) => void } => {
+const gate = <T>(): {
+  promise: Promise<T>;
+  release: (value: T) => void;
+  fail: (err: Error) => void;
+} => {
   let release!: (value: T) => void;
-  const promise = new Promise<T>((resolve) => {
+  let fail!: (err: Error) => void;
+  const promise = new Promise<T>((resolve, reject) => {
     release = resolve;
+    fail = reject;
   });
-  return { promise, release };
+  return { promise, release, fail };
 };
 
 // Rotate and let Solid's effect queue run the identity resets before the
@@ -127,10 +141,25 @@ describe("#788 identity rotation mid-flight", () => {
 
     const pending = refreshScrollback("net", "#probe-stale");
     await rotateTo("tok-b");
-    page.release(fullPage());
+    page.release(fullPageFor(listMessagesAfterSpy));
     await pending;
 
     expect(bearersSeenBy(countMessagesAfterSpy)).not.toContain("tok-a");
+  });
+
+  // The control for the case above: same harness, same full page, no rotation.
+  // Without it, a full page that stopped being full would silently turn the
+  // stale-probe case into an assertion about a branch nobody entered.
+  it("does probe for the remainder when the identity holds", async () => {
+    const { refreshScrollback } = await import("../scrollback");
+    const page = gate<ScrollbackMessage[]>();
+    listMessagesAfterSpy.mockReturnValue(page.promise);
+
+    const pending = refreshScrollback("net", "#probe-live");
+    page.release(fullPageFor(listMessagesAfterSpy));
+    await pending;
+
+    expect(bearersSeenBy(countMessagesAfterSpy)).toContain("tok-a");
   });
 
   it("does not land a page fetched by the old identity in the purged store", async () => {
@@ -159,6 +188,55 @@ describe("#788 identity rotation mid-flight", () => {
     await Promise.all([pendingA, pendingB]);
 
     expect(bearersSeenBy(listMessagesAfterSpy)).toContain("tok-b");
+  });
+
+  // The other half of the lock question. Clearing the Set on rotation is only
+  // safe if the old continuation then keeps its hands off it: its `finally`
+  // would otherwise delete a key the NEW identity re-added, unlocking a fetch
+  // that is still running — and stamp that key as backfilled while it is not.
+  it("does not release or stamp the new identity's in-flight refresh", async () => {
+    const { refreshScrollback } = await import("../scrollback");
+    const { channelKey } = await import("../channelKey");
+    const stale = gate<ScrollbackMessage[]>();
+    const live = gate<ScrollbackMessage[]>();
+    listMessagesAfterSpy.mockReturnValueOnce(stale.promise);
+    listMessagesAfterSpy.mockReturnValueOnce(live.promise);
+
+    const pendingA = refreshScrollback("net", "#held");
+    await rotateTo("tok-b");
+    const pendingB = refreshScrollback("net", "#held");
+    // A's continuation resumes and unwinds while B is still on the wire.
+    stale.release([]);
+    await pendingA;
+
+    // B still holds the key, so a re-entrant call is still a no-op...
+    await refreshScrollback("net", "#held");
+    expect(bearersSeenBy(listMessagesAfterSpy).filter((b) => b === "tok-b")).toHaveLength(1);
+    // ...and nothing has told a spec that B's backfill landed.
+    const stamped = (window as Window & { __cic_scrollbackRefreshed?: Set<string> })
+      .__cic_scrollbackRefreshed;
+    expect(stamped?.has(channelKey("net", "#held"))).not.toBe(true);
+
+    live.release([]);
+    await pendingB;
+  });
+
+  // The reject path, which is the LIKELIER arrival: a bearer revoked while the
+  // request was in flight comes back as `api.ts`'s 401 throw, not as a clean
+  // resolve. `loadInitialScrollback`'s catch releases the load-once gate — the
+  // new identity's gate, past a rotation.
+  it("does not release the new identity's load-once gate when the old fetch 401s", async () => {
+    const { loadInitialScrollback, wasLoaded } = await import("../scrollback");
+    const stale = gate<ScrollbackMessage[]>();
+    listMessagesSpy.mockReturnValueOnce(stale.promise);
+
+    const pendingA = loadInitialScrollback("net", "#gate");
+    await rotateTo("tok-b");
+    const pendingB = loadInitialScrollback("net", "#gate");
+    stale.fail(new Error("401 Unauthorized"));
+    await Promise.all([pendingA, pendingB]);
+
+    expect(wasLoaded("net", "#gate")).toBe(true);
   });
 
   it("does not baseline the cold-open read cursor with a revoked bearer", async () => {

--- a/cicchetto/src/lib/__tests__/scrollbackIdentityRotation.test.ts
+++ b/cicchetto/src/lib/__tests__/scrollbackIdentityRotation.test.ts
@@ -1,0 +1,176 @@
+// #788 — an async scrollback verb that outlives its identity must do NOTHING
+// further: no request on the wire, no write into the store.
+//
+// Every async verb in `scrollback.ts` captures `token()` at entry and then
+// awaits. The nine `onIdentityChange` resets clear STATE; they cancel nothing
+// in flight. So a rotation or a detach landing inside one of those awaits
+// leaves the continuation holding a bearer the server has already revoked —
+// and it sends it. Reproduced in a browser on the real bundle (see the issue):
+// a `/messages/count` went out 10ms AFTER its own bearer was revoked.
+//
+// The harm is not just the 401. It is the #281 harm class: a request for the
+// OLD identity's channel 404s when the new identity is not attached to that
+// network, and the host's `http-404` fail2ban jail bans the client IP at the
+// firewall — a routine account switch self-bans the user.
+//
+// The sibling harm the same continuation causes without touching the wire: the
+// page it already fetched lands in a store the rotation just purged, so the
+// new identity renders the old one's scrollback.
+//
+// The mock of `../auth` here is a REAL Solid signal, not the flat
+// `token: () => value` stub the sibling suites use. That stub is not reactive,
+// so `identityScopedStore`'s `createEffect(on(token))` never fires and no
+// purge ever happens — the rotation these cases turn on would not exist.
+
+import { createSignal } from "solid-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ScrollbackMessage } from "../api";
+
+// Mirrors loadInitialScrollback.test.ts: keep importing scrollback's
+// transitive graph from opening a real WebSocket against jsdom's
+// about:blank base URL.
+vi.mock("../socket", () => ({
+  joinUser: vi.fn(() => ({ on: vi.fn(), push: vi.fn().mockReturnValue({ receive: vi.fn() }) })),
+  joinChannel: vi.fn(() => ({
+    join: vi.fn(() => ({ receive: vi.fn().mockReturnValue({ receive: vi.fn() }) })),
+    on: vi.fn(),
+  })),
+  pushCloseQueryWindow: vi.fn(),
+  pushOpenQueryWindow: vi.fn(),
+  notifyClientClosing: vi.fn(),
+  pushAwaySet: vi.fn(),
+  pushAwayUnset: vi.fn(),
+}));
+
+const [mockToken, setMockToken] = createSignal<string | null>(null);
+vi.mock("../auth", () => ({
+  token: () => mockToken(),
+  setToken: (v: string | null) => setMockToken(v),
+}));
+
+const listMessagesSpy = vi.fn<(...a: unknown[]) => Promise<ScrollbackMessage[]>>();
+const listMessagesAfterSpy = vi.fn<(...a: unknown[]) => Promise<ScrollbackMessage[]>>();
+const countMessagesAfterSpy = vi.fn<(...a: unknown[]) => Promise<number>>();
+vi.mock("../api", async () => {
+  const actual = await vi.importActual<typeof import("../api")>("../api");
+  return {
+    ...actual,
+    listMessages: (...args: unknown[]) => listMessagesSpy(...args),
+    listMessagesAfter: (...args: unknown[]) => listMessagesAfterSpy(...args),
+    countMessagesAfter: (...args: unknown[]) => countMessagesAfterSpy(...args),
+  };
+});
+
+const setReadCursorSpy = vi.fn().mockResolvedValue(undefined);
+vi.mock("../readCursor", async () => {
+  const actual = await vi.importActual<typeof import("../readCursor")>("../readCursor");
+  return {
+    ...actual,
+    setReadCursor: (...args: Parameters<typeof actual.setReadCursor>) => setReadCursorSpy(...args),
+  };
+});
+
+const row = (id: number): ScrollbackMessage => ({
+  id,
+  network: "net",
+  channel: "#bofh",
+  server_time: 1_700_000_000 + id,
+  kind: "privmsg",
+  sender: "peer",
+  body: `line ${id}`,
+  meta: {},
+});
+
+// A full `PAGE_LIMIT` page — the shape that makes `refreshScrollback` probe
+// for the remainder, which is the measured #788 site.
+const fullPage = (): ScrollbackMessage[] => Array.from({ length: 200 }, (_, i) => row(i + 1));
+
+// Hold a REST call open so the rotation can land strictly inside its await,
+// which is the whole point: the continuation resumes under a bearer the
+// server has already revoked.
+const gate = <T>(): { promise: Promise<T>; release: (value: T) => void } => {
+  let release!: (value: T) => void;
+  const promise = new Promise<T>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release };
+};
+
+// Rotate and let Solid's effect queue run the identity resets before the
+// held call is released.
+const rotateTo = async (next: string | null): Promise<void> => {
+  setMockToken(next);
+  await Promise.resolve();
+};
+
+const bearersSeenBy = (spy: { mock: { calls: unknown[][] } }): unknown[] =>
+  spy.mock.calls.map((c) => c[0]);
+
+describe("#788 identity rotation mid-flight", () => {
+  beforeEach(() => {
+    listMessagesSpy.mockReset();
+    listMessagesSpy.mockResolvedValue([]);
+    listMessagesAfterSpy.mockReset();
+    listMessagesAfterSpy.mockResolvedValue([]);
+    countMessagesAfterSpy.mockReset();
+    countMessagesAfterSpy.mockResolvedValue(0);
+    setReadCursorSpy.mockClear();
+    // Each test starts from a clean identity. Setting the token IS a
+    // rotation, so this also fires the store purge between cases.
+    setMockToken("tok-a");
+  });
+
+  it("does not probe with a bearer revoked while the backfill page was in flight", async () => {
+    const { refreshScrollback } = await import("../scrollback");
+    const page = gate<ScrollbackMessage[]>();
+    listMessagesAfterSpy.mockReturnValue(page.promise);
+
+    const pending = refreshScrollback("net", "#probe-stale");
+    await rotateTo("tok-b");
+    page.release(fullPage());
+    await pending;
+
+    expect(bearersSeenBy(countMessagesAfterSpy)).not.toContain("tok-a");
+  });
+
+  it("does not land a page fetched by the old identity in the purged store", async () => {
+    const { refreshScrollback, scrollbackByChannel } = await import("../scrollback");
+    const { channelKey } = await import("../channelKey");
+    const page = gate<ScrollbackMessage[]>();
+    listMessagesAfterSpy.mockReturnValue(page.promise);
+
+    const pending = refreshScrollback("net", "#store-stale");
+    await rotateTo("tok-b");
+    page.release([row(1), row(2)]);
+    await pending;
+
+    expect(scrollbackByChannel()[channelKey("net", "#store-stale")]).toBeUndefined();
+  });
+
+  it("releases the per-key refresh lock on rotation so the new identity can backfill", async () => {
+    const { refreshScrollback } = await import("../scrollback");
+    const stale = gate<ScrollbackMessage[]>();
+    listMessagesAfterSpy.mockReturnValueOnce(stale.promise);
+
+    const pendingA = refreshScrollback("net", "#lock");
+    await rotateTo("tok-b");
+    const pendingB = refreshScrollback("net", "#lock");
+    stale.release([]);
+    await Promise.all([pendingA, pendingB]);
+
+    expect(bearersSeenBy(listMessagesAfterSpy)).toContain("tok-b");
+  });
+
+  it("does not baseline the cold-open read cursor with a revoked bearer", async () => {
+    const { loadInitialScrollback } = await import("../scrollback");
+    const page = gate<ScrollbackMessage[]>();
+    listMessagesSpy.mockReturnValue(page.promise);
+
+    const pending = loadInitialScrollback("net", "#cursor-stale");
+    await rotateTo("tok-b");
+    page.release([row(203), row(202), row(201)]);
+    await pending;
+
+    expect(bearersSeenBy(setReadCursorSpy)).not.toContain("tok-a");
+  });
+});

--- a/cicchetto/src/lib/bootFetch.test.ts
+++ b/cicchetto/src/lib/bootFetch.test.ts
@@ -129,6 +129,36 @@ describe("bootFetch (#717 — bounded, retrying boot transport)", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("retries an attempt whose BODY aborts, and hands back a body the caller can read", async () => {
+    // #779.4 — `fetch` resolves at the HEADERS and the signal stays live on the
+    // Response, but every caller (`me`, `listNetworks`, `listChannels`) reads
+    // the body AFTER bootFetch has returned. A body still streaming when the
+    // per-attempt budget expires aborted out there, where the retry loop could
+    // not see it: a boot that failed and never tried again. Plausible on a slow
+    // link with a large `/me` envelope (read_cursors + unread_counts).
+    const aborting = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"partial":'));
+          controller.error(new DOMException("The operation was aborted.", "AbortError"));
+        },
+      }),
+      { status: 200 },
+    );
+    const fetchMock = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValueOnce(aborting)
+      .mockResolvedValueOnce(new Response('{"ok":true}', { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const promise = bootFetch("/me", {});
+    await vi.advanceTimersByTimeAsync(totalBackoffMs);
+    const res = await promise;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+  });
+
   it("gives each attempt its own signal, so attempt 1's timeout cannot abort attempt 2", async () => {
     const fetchMock = vi
       .fn<() => Promise<Response>>()

--- a/cicchetto/src/lib/bootFetch.ts
+++ b/cicchetto/src/lib/bootFetch.ts
@@ -44,8 +44,9 @@ function sleep(ms: number): Promise<void> {
  * GET a boot-critical resource with a per-attempt timeout and bounded retry.
  *
  * Resolves with the `Response` for ANY completed request, including error
- * statuses — status handling stays with the caller. Rejects with the last
- * transport error once the attempts are exhausted.
+ * statuses — status handling stays with the caller. "Completed" means the body
+ * arrived too, not just the headers. Rejects with the last transport error once
+ * the attempts are exhausted.
  */
 export async function bootFetch(
   path: string,
@@ -68,7 +69,17 @@ export async function bootFetch(
     // abort attempt 2 the moment it started — a retry that can never win.
     const signal = AbortSignal.timeout(BOOT_FETCH_TIMEOUT_MS);
     try {
-      return await fetch(path, { ...init, signal });
+      const res = await fetch(path, { ...init, signal });
+      // The budget must cover the BODY too. `fetch` resolves at the headers
+      // while the signal stays live on the `Response`, and every caller reads
+      // the body (`res.json()`) after this function has returned — so a body
+      // still streaming at the deadline used to abort out there, where the
+      // retry loop could not see it: a boot that failed and never retried.
+      // Draining a clone pulls that read INSIDE the attempt, which both makes
+      // the abort retryable and leaves the returned `Response` fully buffered,
+      // so the caller's own read can no longer be cut by our signal.
+      await res.clone().arrayBuffer();
+      return res;
     } catch (error) {
       lastError = error;
       const backoff = BOOT_FETCH_BACKOFF_MS[attempt];

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -33,7 +33,7 @@ import { getResumeCursor, recordSeen } from "./reconnectBackfill";
 // overlap in a small race window — the same row would otherwise
 // appear twice. `id` is monotonic per the schema's auto-increment column.
 //
-// Identity-scoped state via identityScopedStore (dup-A3 close): nine resets
+// Identity-scoped state via identityScopedStore (dup-A3 close): eleven resets
 // registered (see the registration block below). The factory preserves the A1
 // invariant — registration runs before any verb fires, so no rotation can be
 // missed for want of a registered reset.
@@ -182,6 +182,21 @@ const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): Scrollba
 // one survived: it was never a whole-module property, just an unwritten habit
 // that the three verbs with a single await happened to keep.
 //
+// An await has THREE exits and all three are the verb's own conduct, so the
+// check belongs at each one that touches state:
+//
+//   * resolve — the eleven above.
+//   * reject — `api.ts` throws on any non-ok response, so a bearer revoked
+//     WHILE the request was in flight comes back as a 401 throw, which is the
+//     likelier arrival than a clean resolve. Only one catch in this module
+//     writes state (`loadInitialScrollback` releasing its load-once gate); the
+//     rest log and return, so only that one carries the check.
+//   * finally — the per-key in-flight locks. Past a rotation the reset has
+//     already cleared the Set, so an entry under this key belongs to the
+//     identity that replaced us: deleting it unlocks a fetch that is still
+//     running. Same for the `refreshScrollback` completion stamp, which would
+//     tell a spec that ITS backfill had landed.
+//
 // Not hoisted into `identityScopedStore`: that factory owns the identity
 // TRANSITION (fire the resets), while this owns a verb's own captured
 // identity, which the factory never sees. Sibling modules inline the same
@@ -302,12 +317,13 @@ const exports = identityScopedStore((onIdentityChange) => {
   // reaches the `finally`, and B's `refreshScrollback` for the same key
   // short-circuits in the meantime, so B's window silently never backfills.
   //
-  // Clearing them mid-flight lets A's `finally` delete a key B has since
-  // re-added, which can let a third call for B fetch the same page twice.
-  // Benign and deliberate: `appendToScrollback` dedupes by id, so the cost is
-  // one redundant GET, against a window that otherwise stays empty. A
-  // conditional delete keyed on the captured identity would buy nothing the
-  // dedupe does not already cover.
+  // Clearing a Set mid-flight would otherwise let A's `finally` delete a key B
+  // has since re-added, unlocking a fetch that is still running. Every one of
+  // the four in-flight `finally` blocks therefore releases its key only while
+  // the identity still holds — past a rotation the reset owns the Set and the
+  // continuation owns nothing. (An id-dedupe argument covers only the two
+  // merge paths; `jumpToUnread` REPLACES the key's rows, so a second concurrent
+  // jump would discard whatever landed between the two writes.)
   onIdentityChange(() => loadedChannels.clear());
   onIdentityChange(() => loadMoreInFlight.clear());
   onIdentityChange(() => loadMoreExhausted.clear());
@@ -581,7 +597,7 @@ const exports = identityScopedStore((onIdentityChange) => {
       console.error("[scrollback] jumpToUnread failed", slug, name, err);
       return false;
     } finally {
-      jumpInFlight.delete(key);
+      if (!identityMoved(t)) jumpInFlight.delete(key);
     }
   };
 
@@ -735,6 +751,14 @@ const exports = identityScopedStore((onIdentityChange) => {
     } catch {
       // First-load failure leaves the empty seed in place; the pane
       // shows "no messages yet". A retry mechanism is Phase 5+.
+      //
+      // #788 — the reject path is the likelier arrival for a bearer revoked
+      // in flight (`api.ts` throws the 401), and this gate is identity-scoped
+      // state. Releasing it past a rotation releases the NEW identity's gate:
+      // its next re-select reads `wasLoaded` false, takes the fresh-open arm
+      // that deliberately does NOT fire `refreshScrollback` (#159), and so
+      // skips one live-delivery catch-up while re-paying for a cold load.
+      if (identityMoved(t)) return;
       loadedChannels.delete(key);
     }
   };
@@ -777,7 +801,7 @@ const exports = identityScopedStore((onIdentityChange) => {
       // retry by scrolling again; the in-flight guard releases via
       // the finally clause below.
     } finally {
-      loadMoreInFlight.delete(key);
+      if (!identityMoved(t)) loadMoreInFlight.delete(key);
     }
   };
 
@@ -832,7 +856,7 @@ const exports = identityScopedStore((onIdentityChange) => {
       // Transient error — do NOT latch. The user can retry by scrolling;
       // the in-flight guard releases via the `finally` below.
     } finally {
-      loadNewerInFlight.delete(key);
+      if (!identityMoved(t)) loadNewerInFlight.delete(key);
     }
   };
 
@@ -1048,10 +1072,12 @@ const exports = identityScopedStore((onIdentityChange) => {
       // telemetry hook will replace this.
       console.error("[scrollback] refreshScrollback failed", slug, name, err);
     } finally {
-      refreshInFlight.delete(key);
-      // #552 — mark this backfill DONE (success or error): no more in-flight
-      // DOM recreation for this key, so a spec awaiting it can safely proceed.
-      stampScrollbackRefreshed(key);
+      if (!identityMoved(t)) {
+        refreshInFlight.delete(key);
+        // #552 — mark this backfill DONE (success or error): no more in-flight
+        // DOM recreation for this key, so a spec awaiting it can safely proceed.
+        stampScrollbackRefreshed(key);
+      }
     }
   };
 

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -38,20 +38,20 @@ import { getResumeCursor, recordSeen } from "./reconnectBackfill";
 // invariant — registration runs before any verb fires, so no rotation can be
 // missed for want of a registered reset.
 //
-// #769 — what that does NOT buy, and what this comment used to claim it
+// #788 — what the resets do NOT buy, and what this comment used to claim they
 // did ("a logout/rotation between `loadInitialScrollback` start and finish
-// always wins the race"): the resets clear STATE, they do not cancel a
-// verb already in flight. Every ASYNC verb here captures `token()` at entry
-// and then awaits, and nothing re-checks it afterwards — so a continuation
-// resuming past a rotation still holds the bearer it captured, and the
-// per-key in-flight guards that are NOT in the reset list (`refreshInFlight`,
-// `jumpInFlight`) still hold their keys. Ordering-with-cancellation was
-// never implemented; the wording promised it anyway.
+// always wins the race"): they clear STATE, they do not cancel a verb already
+// in flight. Every ASYNC verb here captures `token()` at entry and then
+// awaits, and nothing used to re-check it afterwards — so a continuation
+// resuming past a rotation still held the bearer it captured, and the per-key
+// in-flight guards that were NOT in the reset list (`refreshInFlight`,
+// `jumpInFlight`) still held their keys. Ordering-with-cancellation was never
+// implemented; the wording promised it anyway.
 //
-// That is not theoretical: delaying the reconnect backfill 400ms in a browser
+// That was not theoretical: delaying the reconnect backfill 400ms in a browser
 // put a `/messages/count` on the wire 10ms AFTER the detach, carrying the
-// revoked bearer. Tracked as its own defect (see #788) — #769 turned out to be
-// a spec race and is NOT that bug.
+// revoked bearer. (#769, which surfaced it, turned out to be a spec race and
+// is NOT that bug.) See `identityMoved` for the rule that closes it.
 //
 // ---------------------------------------------------------------------------
 // CP14 B3 — DM history is now bidirectional server-side.
@@ -150,6 +150,45 @@ const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): Scrollba
   return dropCount > 0 ? rows.slice(dropCount) : rows;
 };
 
+// #788 — THE rule for every async verb in this module: an `await` can span an
+// identity transition, and a continuation that outlived its identity must do
+// NOTHING further. Not one request on the wire, not one write into the store.
+//
+// `t` is the bearer the verb captured at entry — its identity, not merely its
+// credential. Re-read `token()` after the await and compare: if it moved, the
+// verb belongs to an identity that no longer exists here.
+//
+// Both halves of "nothing further" are load-bearing, which is why the check
+// sits after the await rather than in front of each REST call:
+//
+//   * the WIRE half is #788 proper. A request carrying a revoked bearer 401s
+//     at best; for a channel the NEW identity is not attached to it 404s, and
+//     the host's `http-404` fail2ban jail bans the client IP at the firewall.
+//     A routine account switch self-bans the operator — the #281 harm class,
+//     reached through a different door.
+//   * the STORE half is the same continuation without touching the network:
+//     the page it already fetched merges into a map the rotation just purged,
+//     so the new identity renders the old one's scrollback. A guard wrapped
+//     around the REST calls alone would not catch it — the poisoning happens
+//     between the resolved fetch and the next request.
+//
+// So: eleven of this module's fifteen awaits are followed by this check, and
+// the bail is whatever "did nothing" means for that verb's return type. Two
+// classes of await are exempt, four sites in all — the ones whose await is
+// their last act (`probeGap`, and the two tail calls into `anchorAtTail`), and
+// `resolveJumpTarget`, whose only successor is a pure value returned to a
+// caller that checks immediately. A new verb that awaits and skips the check
+// reopens the defect for its own call path only — which is exactly how this
+// one survived: it was never a whole-module property, just an unwritten habit
+// that the three verbs with a single await happened to keep.
+//
+// Not hoisted into `identityScopedStore`: that factory owns the identity
+// TRANSITION (fire the resets), while this owns a verb's own captured
+// identity, which the factory never sees. Sibling modules inline the same
+// comparison (`displayPrefs`, `customTheme`) to drop a stale RESPONSE; this is
+// the same predicate used one step earlier, to refuse a stale REQUEST.
+const identityMoved = (t: string): boolean => token() !== t;
+
 const exports = identityScopedStore((onIdentityChange) => {
   const loadedChannels = new Set<ChannelKey>();
   // CP14 B2: per-key in-flight Set guards against scroll-burst fan-out
@@ -246,16 +285,36 @@ const exports = identityScopedStore((onIdentityChange) => {
     equals: false,
   });
 
-  // Identity-transition cleanup. Nine registered resets fired by the
-  // factory's createEffect(on(token, ...)) — five Set.clear() (loadedChannels
-  // + loadMore{InFlight,Exhausted} + loadNewer{InFlight,Exhausted}, #161) +
-  // four signal flushes (scrollbackByChannel + lastOwnSend + ownSendSubmitted,
-  // #580 + farBehindByChannel, #693). Order matches the pre-A3 inline shape.
+  // Identity-transition cleanup, and the SSOT for what an identity transition
+  // clears. Eleven registered resets fired by the factory's
+  // createEffect(on(token, ...)) — seven Set.clear() (loadedChannels +
+  // loadMore{InFlight,Exhausted} + loadNewer{InFlight,Exhausted}, #161 +
+  // refreshInFlight + jumpInFlight, #788) + four signal flushes
+  // (scrollbackByChannel + lastOwnSend + ownSendSubmitted, #580 +
+  // farBehindByChannel, #693). Order matches the pre-A3 inline shape.
+  //
+  // #788 — the last two are registered here, away from their declarations
+  // beside the verbs that own them, precisely BECAUSE that distance is how
+  // they came to be missed: this list is the thing to read when asking "what
+  // survives a rotation", so a lock that is not on it is a lock nobody will
+  // remember. Left held, they were a real defect and not merely untidy — an
+  // in-flight refresh for identity A keeps A's key until its continuation
+  // reaches the `finally`, and B's `refreshScrollback` for the same key
+  // short-circuits in the meantime, so B's window silently never backfills.
+  //
+  // Clearing them mid-flight lets A's `finally` delete a key B has since
+  // re-added, which can let a third call for B fetch the same page twice.
+  // Benign and deliberate: `appendToScrollback` dedupes by id, so the cost is
+  // one redundant GET, against a window that otherwise stays empty. A
+  // conditional delete keyed on the captured identity would buy nothing the
+  // dedupe does not already cover.
   onIdentityChange(() => loadedChannels.clear());
   onIdentityChange(() => loadMoreInFlight.clear());
   onIdentityChange(() => loadMoreExhausted.clear());
   onIdentityChange(() => loadNewerInFlight.clear());
   onIdentityChange(() => loadNewerExhausted.clear());
+  onIdentityChange(() => refreshInFlight.clear());
+  onIdentityChange(() => jumpInFlight.clear());
   onIdentityChange(() => setScrollbackByChannel({}));
   onIdentityChange(() => setLastOwnSend(null));
   onIdentityChange(() => setOwnSendSubmitted(null));
@@ -371,11 +430,13 @@ const exports = identityScopedStore((onIdentityChange) => {
   //
   // Three callers reach this verb and they are indistinguishable on the wire —
   // same URL shape, and two of the three anchor at the read cursor. They are
-  // also NOT symmetric with respect to identity, which is what #788 turns on:
+  // also NOT symmetric with respect to identity, which is what #788 turned on:
   // the cold-open call below runs with NO await between its `token()` capture
   // and this request (`getReadCursor` is a synchronous signal read), so it
   // cannot reach the wire under anything but the current bearer, while the two
-  // reconnect callers await first and can carry a revoked one.
+  // reconnect callers await first and could carry a revoked one. Each of those
+  // two now checks `identityMoved` before it gets here; this verb takes no
+  // check of its own because its await is its last act.
   const probeGap = async (
     t: string,
     slug: string,
@@ -420,6 +481,7 @@ const exports = identityScopedStore((onIdentityChange) => {
   ): Promise<void> => {
     const key = channelKey(slug, name);
     const page = await listMessages(t, slug, name);
+    if (identityMoved(t)) return;
     const rows = [...page].sort(byServerTimeThenId);
     const newest = rows[rows.length - 1]?.id ?? 0;
     setScrollbackByChannel((prev) => {
@@ -445,6 +507,11 @@ const exports = identityScopedStore((onIdentityChange) => {
   // it differs. One extra small GET, only on the reconnect path, only when
   // already far behind. A failed re-probe keeps the anchor: a slightly
   // conservative jump target beats no affordance at all.
+  //
+  // #788 exemption: no `identityMoved` check after the await here. This verb
+  // has no successor of its own — it returns two numbers, and the caller
+  // checks before spending them. Adding one would mean inventing a bail value
+  // for a function that cannot do harm.
   const resolveJumpTarget = async (
     t: string,
     slug: string,
@@ -498,6 +565,7 @@ const exports = identityScopedStore((onIdentityChange) => {
         listMessagesAfter(t, slug, name, far.resumeFrom, PAGE_LIMIT),
         listMessages(t, slug, name, far.resumeFrom + 1),
       ]);
+      if (identityMoved(t)) return false;
       // Disjoint by construction — `after(cursor)` is `id > cursor`,
       // `before(cursor + 1)` is `id <= cursor` — so concat + sort needs no
       // dedupe pass.
@@ -569,6 +637,7 @@ const exports = identityScopedStore((onIdentityChange) => {
         // a brand-new window auto-scrolls to the tail, so the newest
         // rows are exactly what's wanted and there's no divider to anchor.
         const page = await listMessages(t, slug, name);
+        if (identityMoved(t)) return;
         mergeIntoScrollback(key, page);
         // RC2 (decouple-unread-badge) — baseline the read cursor to this
         // backlog's tail. Opening a fresh channel auto-scrolls to the
@@ -642,6 +711,7 @@ const exports = identityScopedStore((onIdentityChange) => {
         // behind the load-once gate, on a human click; the pane is empty here
         // so `anchorAtTail` has nothing to discard.
         const gap = await probeGap(t, slug, name, cursor);
+        if (identityMoved(t)) return;
         if (gap !== null && isFarBehind(gap)) {
           await anchorAtTail(t, slug, name, gap, cursor);
         } else {
@@ -649,6 +719,7 @@ const exports = identityScopedStore((onIdentityChange) => {
             listMessagesAfter(t, slug, name, cursor, PAGE_LIMIT),
             listMessages(t, slug, name, cursor + 1),
           ]);
+          if (identityMoved(t)) return;
           // A rejoin's `refreshScrollback` can have re-anchored this key at
           // the tail while these two pages were in flight (nothing serialises
           // the cold-load and the reconnect path for one key). Splicing the
@@ -692,6 +763,7 @@ const exports = identityScopedStore((onIdentityChange) => {
       // a `messages.id` value, eliminating same-ms ties that straddled
       // page boundaries pre-flip.
       const page = await listMessages(t, slug, name, oldest.id);
+      if (identityMoved(t)) return;
       // CP14 B2: empty page from the server means there's no older
       // history to load. Latch the channel so subsequent scroll-to-
       // top events don't re-fetch.
@@ -747,6 +819,7 @@ const exports = identityScopedStore((onIdentityChange) => {
     loadNewerInFlight.add(key);
     try {
       const page = await listMessagesAfter(t, slug, name, newest.id, PAGE_LIMIT);
+      if (identityMoved(t)) return;
       // Empty forward page = the local tail IS the live server tail. Latch
       // so subsequent scroll-to-bottom events (including the auto-follow
       // scroll that fires when a live row appends at the tail) are no-ops.
@@ -815,6 +888,11 @@ const exports = identityScopedStore((onIdentityChange) => {
     // is cheaper than hoisting `setCursorIfAdvances` to a leaf module
     // for a single second caller.
     const row = await apiSendMessage(t, slug, name, body, ctcpTarget);
+    // #788 — the cursor POST below was already unreachable past a rotation, but
+    // only by accident: the store purge empties the pane, `hasRenderedRow`
+    // goes false, and the anti-poison gate declines. That is a guarantee owed
+    // to an unrelated invariant, one refactor away from evaporating. State it.
+    if (identityMoved(t)) return;
     // Anti-poison gate (issue #50 / m6, 2026-06-09): only advance the
     // cursor when the local pane already holds a rendered row. Advancing
     // PAST an unrendered row poisons `refreshScrollback`'s resume cursor —
@@ -925,6 +1003,7 @@ const exports = identityScopedStore((onIdentityChange) => {
       // dynamic per-channel cap) doesn't have to thread through the
       // api.ts helper signature.
       const page = await listMessagesAfter(t, slug, name, cursor, PAGE_LIMIT);
+      if (identityMoved(t)) return;
       for (const msg of page) {
         appendToScrollback(key, msg);
         // Roll the high-water mark forward as we ingest so a second
@@ -956,8 +1035,10 @@ const exports = identityScopedStore((onIdentityChange) => {
         const last = page[page.length - 1];
         const anchor = last ? last.id : cursor;
         const gap = await probeGap(t, slug, name, anchor);
+        if (identityMoved(t)) return;
         if (gap !== null && isFarBehind(gap)) {
           const target = await resolveJumpTarget(t, slug, name, anchor, gap);
+          if (identityMoved(t)) return;
           await anchorAtTail(t, slug, name, target.missed, target.resumeFrom);
         }
       }

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -832,10 +832,19 @@ html.overlay-open #root > div {
   cursor: not-allowed;
 }
 
-/* #204 — Advanced disclosure toggle. Quiet text-button between the nick
-   input and Connect (vjt layout fix). Full-width comfortable tap target,
-   left-aligned so the ▸/▾ affordance reads as a disclosure, not a CTA. */
-.login-advanced-toggle {
+/* #740 — the quiet text-button of the login card, declared ONCE. It was
+   two byte-identical rules (#204's Advanced disclosure and #442's alt-auth
+   pair): nine declarations copied, in the same flex row under
+   align-items: center, so a padding or min-height tweak landing on one and
+   not the other shows up as a height mismatch between buttons that sit
+   side by side.
+
+   Worn ALONGSIDE the per-instance class, never instead of it: both
+   `.login-advanced-toggle` and `.login-alt-auth` are selector contracts the
+   e2e clicks as strict single matches (issue281), so they keep their names
+   and their own rules — which now hold only what genuinely differs. Today
+   that is nothing; the rules stay as the documented place for a delta. */
+.login-quiet-button {
   background: transparent;
   color: var(--muted);
   border: none;
@@ -847,9 +856,16 @@ html.overlay-open #root > div {
   cursor: pointer;
 }
 
-.login-advanced-toggle:hover {
+.login-quiet-button:hover {
   color: var(--fg);
 }
+
+/* #204's Advanced disclosure toggle and #442's alt-auth pair keep their
+   class names — both are selector contracts the e2e clicks as strict single
+   matches (issue281) — but no longer carry a rule of their own: they wear
+   .login-quiet-button beside it for the shape, and have no delta to declare.
+   A future per-instance tweak goes in a rule reintroduced here, not by
+   re-copying the block above. */
 
 /* #442 — the alt-auth entry points ride the Advanced toggle's row so they
    add NO height to the card. On 1024x900 with Advanced open the form is
@@ -866,26 +882,6 @@ html.overlay-open #root > div {
    the leading edge it has on main. */
 .login-alt-auth-row .login-advanced-toggle {
   margin-right: auto;
-}
-
-/* #442 — alternate auth entry points (passkey / recovery code). Same quiet
-   text-button look as the disclosure toggle, but a class of its own: the e2e
-   clicks .login-advanced-toggle as a strict single match, so that selector
-   must stay one element per rendered branch. */
-.login-alt-auth {
-  background: transparent;
-  color: var(--muted);
-  border: none;
-  text-align: left;
-  padding: 0.6rem 0.25rem;
-  min-height: var(--tap-min);
-  font-family: var(--font-mono);
-  font-size: 0.9rem;
-  cursor: pointer;
-}
-
-.login-alt-auth:hover {
-  color: var(--fg);
 }
 
 .login-advanced {
@@ -2404,15 +2400,34 @@ html.resize-dragging * {
   color: var(--accent);
 }
 
-/* C7.6: clickable nick — pointer cursor + subtle hover underline.
-   Applied to <button> elements in scrollback so they render inline. */
-.nick-clickable {
+/* #740 — "render a <button> as inline text", declared ONCE. It was three
+   copies (.nick-clickable, .channel-clickable, .scrollback-invite-join),
+   each carrying the same five-declaration reset plus the same hover
+   underline. Worn ALONGSIDE the per-instance class, which keeps only what
+   genuinely differs — colour, padding, font-weight, and the #250
+   user-select the [Join] CTA deliberately does not take.
+
+   Deliberately NOT a `.scrollback :where(button)` floor in the #735 shape:
+   the scrollback also holds buttons that are not inline text (the
+   scroll-to-bottom badge, the far-behind jump/dismiss pair), and
+   `display: inline` would break them. The shape belongs to these three
+   controls, not to their container. */
+.scrollback-inline-button {
   cursor: pointer;
   background: none;
   border: none;
-  padding: 0;
   font: inherit;
   display: inline;
+}
+
+.scrollback-inline-button:hover {
+  text-decoration: underline;
+}
+
+/* C7.6: clickable nick — the inline-text button reset above, with no padding
+   and the #250 selection carve-out. */
+.nick-clickable {
+  padding: 0;
   /* #250 (2026-07-15): keep the nick INSIDE a drag text-selection on
      EVERY platform — unconditional, NOT gated behind `html.is-ios`. The
      nick is an interactive inline <button>; Android's native touch-
@@ -2435,50 +2450,27 @@ html.resize-dragging * {
   user-select: text;
 }
 
-.nick-clickable:hover {
-  text-decoration: underline;
-}
-
-/* #648: clickable #channel in scrollback — an inline <button> (same
-   transparent-inline shape as .nick-clickable) tinted with the accent so a
+/* #648: clickable #channel in scrollback — tinted with the accent so a
    channel token reads as a link-like join affordance, distinct from a plain
    nick. user-select: text mirrors .nick-clickable (#250): the token stays
    inside a drag text-selection on every platform while the tap-to-join
    handler stays intact; keyboard/focus policy is owned separately by
    keepKeyboard.ts's SELECTABLE_TEXT_EXCLUDE (#354, #648). */
 .channel-clickable {
-  cursor: pointer;
-  background: none;
-  border: none;
   padding: 0;
-  font: inherit;
-  display: inline;
   color: var(--accent);
   -webkit-user-select: text;
   user-select: text;
 }
 
-.channel-clickable:hover {
-  text-decoration: underline;
-}
-
 /* No-silent-drops bucket 2: [Join] CTA inline button on INVITE rows.
-   Same shape as .nick-clickable (transparent button rendered inline)
-   but with explicit accent color + bracketed visual weight so the
-   click affordance is loud against the muted notice row. */
+   Explicit accent color + bracketed visual weight so the click affordance is
+   loud against the muted notice row. No user-select: unlike the two text
+   tokens this is a control, not copyable text (keepKeyboard.ts). */
 .scrollback-invite-join {
-  cursor: pointer;
-  background: none;
-  border: none;
   padding: 0 0.25em;
-  font: inherit;
-  display: inline;
   color: var(--accent);
   font-weight: bold;
-}
-
-.scrollback-invite-join:hover {
-  text-decoration: underline;
 }
 
 /* No-silent-drops bucket 4: clickable URLs in scrollback bodies.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -28686,14 +28686,34 @@ never sees. `displayPrefs` and `customTheme` already inline the same comparison
 to drop a stale RESPONSE — this is the same predicate one step earlier, to
 refuse a stale REQUEST.
 
+**An await has three exits, and the first census walked one of them.** Review
+caught it: the resolve path is not even the likely arrival. `api.ts` throws on
+any non-ok response, so a bearer revoked *while the request was in flight*
+comes back as a 401 throw — straight past every guard, into the `catch`. Most
+catches here only log, but `loadInitialScrollback`'s releases the load-once
+gate, which is identity-scoped state: past a rotation it releases the NEW
+identity's gate, and that window's next re-select reads `wasLoaded` false,
+takes the fresh-open arm that deliberately does not fire `refreshScrollback`
+(#159), and so skips one live-delivery catch-up while re-paying for a cold
+load. The `finally` blocks are the third exit and the same story: they release
+per-key locks that, after the reset has cleared the Set, belong to whoever
+replaced us. All four now release only while the identity still holds, and the
+`refreshScrollback` completion stamp with them — stamping tells an e2e that
+ITS backfill landed. The rule is not "check after the await"; it is "every exit
+from the await that touches state".
+
 **`refreshInFlight` and `jumpInFlight` join the reset list.** Both were declared
 beside the verbs that own them rather than beside the other five Sets, and both
 were consequently missing from the cleanup — a real defect, not untidiness: an
 in-flight refresh for identity A holds A's key until its continuation reaches
 the `finally`, and B's refresh for the same key short-circuits meanwhile, so B's
-window silently never backfills. Clearing mid-flight lets A's `finally` delete a
-key B has re-added, which can cost one redundant GET; `appendToScrollback`
-dedupes by id, so that is the cheaper side of the trade.
+window silently never backfills. The first pass justified the unconditional
+`finally` delete with "`appendToScrollback` dedupes by id, so the worst case is
+one redundant GET" — true of the merge paths and false of `jumpToUnread`, which
+REPLACES the key's rows and would discard whatever landed between two
+concurrent writes. A rationale that does not cover the Set it is written beside
+is not a rationale, so the conditional release above replaced it and the trade
+disappeared.
 
 **Two honest notes.** `sendMessage`'s post-await cursor POST was already
 unreachable past a rotation — but by accident, via the store purge emptying the
@@ -28702,4 +28722,8 @@ invariant is one refactor from evaporating, so it is now stated. And the
 regression test mocks `../auth` with a REAL Solid signal: the flat
 `token: () => value` stub the sibling suites use is not reactive, so
 `createEffect(on(token))` never fires and the rotation the cases turn on would
-not exist.
+not exist. Seven cases in all, each verified RED by removing exactly the guard
+it covers and watching only it fall — including a control case that fails
+loudly if the "full page" the stale-probe case releases ever stops being full,
+which would otherwise turn that assertion into one about a branch nobody
+entered.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -26546,7 +26546,11 @@ Enabling or disabling TOTP revokes every other web session. Disabling requires
 the account password. TOTP failures share one public error and are limited to
 ten failures per IP/account over fifteen minutes.
 
-Passkeys, recovery-code regeneration, and email recovery remain out of scope.
+Recovery-code regeneration and email recovery remain out of scope. Passkeys did
+too when this was written — they shipped two days later, and the entry below
+(2026-08-04 — #442/#736) is the record. Amended in place rather than left
+standing with a correction bolted on: a decision log is a coherent account, not
+a wall of caveats, and the next session reads the sentence, not the thread.
 
 ### 2026-08-02 — #666 — multi-line paste is resumable + self-pacing; the send-door 429 carries a retry-after (P0, cross-stack)
 
@@ -28504,3 +28508,86 @@ per-page-load, so every reload re-pays upstream for an answer grappa already
 received. The precedent already exists — `userhost_cache` is nick-keyed, folded,
 fed passively from JOIN prefixes at zero upstream cost, and already migrated on
 NICK. Cache the answer, and the question of when to fetch mostly dissolves.
+
+---
+
+### 2026-08-04 — #442 / #736 — passkeys: the mode ladder, and why passwordless costs two steps
+
+Written retroactively (#740). The passkey surface shipped across #442 and #736
+while the only entry that mentioned passkeys said they were out of scope, so a
+session reading the log in good faith would have concluded passwordless login
+does not exist — and then re-litigated or re-implemented it. The #442 entry is
+amended above; this is the record it points at. Everything below is stated as
+BEHAVIOUR, verified against `main` @ `942f642b`.
+
+**One account, three modes.** `users.passkey_mode` is
+`:disabled | :second_factor | :passwordless`, default `:disabled`, and it is
+the account's whole passkey posture — not a per-credential property. What a
+password login does depends only on it:
+
+* `:disabled` — password authenticates; TOTP still applies if armed (#442).
+* `:second_factor` — password authenticates, then a passkey assertion
+  completes. It sits AHEAD of TOTP in the ladder: an account with both armed
+  is asked for the passkey, not the code.
+* `:passwordless` — a password login is **refused**, and refused with the same
+  `:invalid_credentials` answer a wrong password gets. The uniform oracle is
+  the point: which credential half is wrong, and whether an account is
+  passwordless at all, are both things the login door declines to say.
+
+**Registration always costs the password**, in every mode. A passkey is a
+credential being minted, so minting one is a re-authentication, not a
+setting toggle.
+
+**Passwordless is armed in two steps, and cannot be armed in one.** The
+mode-change door (`POST /me/passkeys/mode/options`) admits `:second_factor` and
+`:disabled` only; handing it `passwordless` is a `bad_request`, deliberately and
+permanently. Arming passwordless goes:
+
+1. `POST /me/passkeys/passwordless/recovery` — password re-checked, ten
+   recovery codes generated and **shown once**, returned with a recovery token.
+2. `POST /me/passkeys/passwordless/options` — the token is redeemed for the
+   ceremony challenge; the assertion then flips the mode and stores the code
+   hashes in the same transaction.
+
+The token IS the proof that step 1 happened. Without it the ladder could be
+climbed to a state where the password no longer works and the only fallback
+has never been displayed — an account locked out by a successful operation.
+It expires in ten minutes, and it is **encrypted rather than signed**: it
+carries the plaintext codes, and a signed token is tamper-proof but perfectly
+readable by anything it passes through. The invariant is enforced at the
+context boundary too, not just by route shape: `set_mode/4` accepts
+`:passwordless` only with exactly ten codes and the other two modes only with
+none, so a caller that skips the handshake fails loudly instead of arriving at
+a half-armed account.
+
+**A passkey belongs to THIS deployment's origin.** WebAuthn binds a credential
+to the origin that registered it, and it will refuse to answer for any other.
+So the origin grappa asserts is a durable property of the deployment, not of
+the request in flight: operators fronting the bouncer with a public origin
+Phoenix would not derive set `GRAPPA_PASSKEY_ORIGIN`, and everyone else gets
+the Endpoint's public URL. The relying-party id is that origin's host. Two
+consequences worth stating before someone rediscovers them the hard way:
+**changing the public origin of a live deployment invalidates every passkey
+already registered against it**, and an account in `:passwordless` mode whose
+origin moved has no password to fall back on — only its recovery codes. This is
+also why the value is resolved in one place rather than derived per controller:
+two derivations are two chances to disagree, and the disagreement would surface
+as an unexplained authenticator refusal on a user's device.
+
+Ceremonies are single-use and short-lived — challenges are held server-side for
+five minutes and swept, user verification is `required` (the authenticator must
+prove a human, not merely possession).
+
+**The recovery codes are ONE account-level set, shared with TOTP.** Not a
+passkey-specific pool that happens to look similar — the same ten codes, the
+same table, the same one-shot semantics as #442. So arming passwordless
+**replaces** whatever recovery codes a TOTP user was already holding, and the
+old printout stops working. That is deliberate (one fallback credential per
+account beats two that can disagree about which is current) and it is the
+sharpest edge on this surface: it is the one step that silently invalidates
+something the user was told to keep safe. The codes shown in step 1 above are
+the account's codes from that moment on.
+
+**Still out of scope**, and unchanged by any of this: recovery-code
+regeneration as its own verb — the set is replaced as a side effect of arming
+TOTP or passwordless, never on demand — and email recovery.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -28647,3 +28647,59 @@ CONTEXT that makes test roots out of scope (a test module's root dies with the
 worker and a throw surfaces as a failing test — the runner IS the context),
 not the shape. The comment used to claim every test root takes `dispose`; four
 do not.
+## 2026-08-04 — #788: a continuation that outlived its identity does nothing further
+
+`cicchetto/src/lib/scrollback.ts` scopes its state to the identity through
+`identityScopedStore`: nine resets fire on the `on(token)` transition and clear
+the pane, the load-once gate and the paging latches. The moduledoc used to read
+that as a race the store always wins. It never was. **The resets clear STATE;
+they cancel nothing in flight.** Every async verb captures `token()` at entry
+and then awaits, so a rotation or a detach landing inside one of those awaits
+leaves the continuation running under an identity that no longer exists.
+
+Measured, not argued: with the join-ok backfill held 400ms in a browser on the
+real bundle, a `/messages/count` went out **10ms after its own bearer was
+revoked**, through entirely production code paths.
+
+**Why a 401 is the least of it.** This is the #281 harm class reached through a
+different door. A request for the OLD identity's channel 404s when the new
+identity is not attached to that network, and the host's `http-404` fail2ban
+jail bans the client IP at the firewall. A routine account switch self-bans the
+operator.
+
+**The rule: check after the await, not in front of the request.** The stale
+continuation causes two harms, and only one of them is on the wire. The other
+needs no network at all — the page it already fetched merges into a map the
+rotation just purged, and the new identity renders the old one's scrollback.
+That harm happens *between* the resolved fetch and the next request, so the
+tidier-looking fix (one guarded wrapper around the module's REST calls, which
+the issue floated as the "reuse the verb" answer) cannot see it. Placing the
+check immediately after each await catches both, because everything downstream
+is unreachable. One shared predicate, `identityMoved(t)`, at eleven of the
+module's fifteen awaits; the four exempt are the ones with nothing after them,
+plus `resolveJumpTarget`, whose only successor is a pure value its caller checks
+before spending.
+
+Not hoisted into `identityScopedStore`: that factory owns the identity
+TRANSITION, while this owns a verb's own captured identity, which the factory
+never sees. `displayPrefs` and `customTheme` already inline the same comparison
+to drop a stale RESPONSE — this is the same predicate one step earlier, to
+refuse a stale REQUEST.
+
+**`refreshInFlight` and `jumpInFlight` join the reset list.** Both were declared
+beside the verbs that own them rather than beside the other five Sets, and both
+were consequently missing from the cleanup — a real defect, not untidiness: an
+in-flight refresh for identity A holds A's key until its continuation reaches
+the `finally`, and B's refresh for the same key short-circuits meanwhile, so B's
+window silently never backfills. Clearing mid-flight lets A's `finally` delete a
+key B has re-added, which can cost one redundant GET; `appendToScrollback`
+dedupes by id, so that is the cheaper side of the trade.
+
+**Two honest notes.** `sendMessage`'s post-await cursor POST was already
+unreachable past a rotation — but by accident, via the store purge emptying the
+pane so the #50 anti-poison gate declines. A guarantee owed to an unrelated
+invariant is one refactor from evaporating, so it is now stated. And the
+regression test mocks `../auth` with a REAL Solid signal: the flat
+`token: () => value` stub the sibling suites use is not reactive, so
+`createEffect(on(token))` never fires and the rotation the cases turn on would
+not exist.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -28591,3 +28591,59 @@ the account's codes from that moment on.
 **Still out of scope**, and unchanged by any of this: recovery-code
 regeneration as its own verb — the set is replaced as a side effect of arming
 TOTP or passwordless, never on demand — and email recovery.
+## 2026-08-04 — #779: a timeout that stops at the headers is not a budget
+
+Two hardening items out of #717's review round 3, neither a live defect.
+
+**`bootFetch`'s per-attempt budget now covers the body.** `AbortSignal.timeout`
+starts at dispatch and stays live on the `Response`, but `fetch` resolves at
+the HEADERS and every caller — `me`, `listNetworks`, `listChannels` — reads the
+body with `res.json()` after `bootFetch` has already returned. A body still
+streaming at the 8s deadline therefore aborted OUTSIDE the retry loop: an
+`AbortError` the loop never saw, so an attempt the policy calls retryable was
+silently not retried. The fix drains a `res.clone()` inside the attempt. That
+pulls the body read into the budget (the abort becomes an ordinary retryable
+transport failure) and leaves the returned `Response` fully buffered, so the
+caller's own read can no longer be cut by our signal. Identity is preserved —
+the original `Response` is what comes back, not a reconstruction — which keeps
+`res.ok` / `res.status` / `readError` untouched. Plausible on a slow mobile
+link with a large `/me` envelope (`read_cursors` + `unread_counts`); on a LAN it
+never fires. The docstring's "ANY completed request" is now true: completed
+means the body arrived, not just the headers.
+
+**The `moduleRoot` guard enforces the invariant, not a spelling.** The #717
+invariant is "every module-lifetime computation has an error context". The
+guard enforced "no bare `createRoot`", which a module-scope `createEffect` /
+`createMemo` / `createResource` with NO root at all evades completely: it has
+`Owner === null`, so the throw propagates out of `runUpdates`, the queued render
+effects are discarded and the last frame freezes — the #717 signature exactly,
+with the regex reporting the file clean. Zero instances today; the point is that
+it is the EASIER thing for the next author to write.
+
+The rewrite splits one text predicate in two — an *owning root* (a `createRoot`
+whose callback ignores `dispose`, i.e. one that is never disposed) and an
+*unowned computation* (a reactive primitive at column 0 with no root on the
+line) — and both run through the same prose filter. Three consequences:
+
+- **A disposable root is now legal in production code.** `createRoot(dispose =>
+  …)` for a detached or portal render is normal Solid; the old guard flagged it
+  and left the next author choosing between `moduleRoot` (wrong — it never
+  disposes, so they leak a root) and an exclusion list, which CLAUDE.md forbids.
+  Binding `dispose` IS the invariant: a root with a handle ends.
+- **The anti-vacuity case can no longer be satisfied by a comment.** It runs
+  through the same classifier, so the literal `//   const exports_ =
+  createRoot(() => {` in `identityScopedStore`'s pattern-history comment stops
+  counting.
+- **The predicate is unit-tested against fixtures**, not only walked over a
+  clean tree. A guard that has never seen an offender proves nothing about what
+  it would catch.
+
+Module scope is detected as "starts at column 0" — a heuristic, pinned by the
+fact that biome owns the formatting, and one whose failure direction is a false
+positive the author fixes by moving the call into the root it belonged in.
+
+The test-file exemption stays, with a corrected justification: it is the ERROR
+CONTEXT that makes test roots out of scope (a test module's root dies with the
+worker and a throw surfaces as a failing test — the runner IS the context),
+not the shape. The comment used to claim every test root takes `dispose`; four
+do not.


### PR DESCRIPTION
Four green PRs, one gate. Base `a371fee1`.

## Why a union

Each of the four was green against a base that has since moved. Merging
them one at a time means four ~25-minute re-gate rounds for work already
written and already green. Merging them on their individual greens is the
other failure: **a green attests `branch + base`, never `branch + the other
three`** — which is exactly what kept `main` red for twelve hours on
3 August, where the diffs touched disjoint files and still collided through
a shared upstream connection budget. Textual non-overlap is not semantic
independence. So: one branch, one gate.

**#819 (#742) is deliberately excluded** — red in CI on a security assert,
under investigation.

## What is in it, in graft order

| Issue | Source PR | Commits grafted |
|---|---|---|
| #740 — DESIGN_NOTES + duplicated button CSS | #813 | `58e6bd61`, `419ab096` |
| #804 — ArchiveModal peer casing | #820 | `ad79386d` |
| #779 — moduleRoot guard + bootFetch body budget | #821 | `5380f047`, `bfffd099` |
| #788 — scrollback stale bearer | #817 | `c80d4e24`, `ae3f5366` |

**The SHAs are rewritten** — these are cherry-picks, not merges, so the
four issues need closing by CONTENT, not by a `Closes` keyword resolving
against the original commits.

#813's merge commit `5566a37a` (`Merge branch 'main'`) was skipped: its
diff against the first parent is only what `main` had added at the time
(the #744 commits, already in `a371fee1`), so it carried no conflict
resolution and nothing to graft.

Order was chosen so the deepest change lands last: #788 rewrites
`scrollback.ts` more than anything else here, and if something were going
to collide it should collide against a settled tree. Nothing did — all
seven cherry-picks applied clean, with `docs/DESIGN_NOTES.md` auto-merging
twice.

## Verification per graft, not just at the end

So that a graft breaking an earlier one surfaces immediately rather than
25 minutes later:

| After grafting | Targeted run | Result |
|---|---|---|
| #740 | `sharedButtonRules`, `Login`, `MircText`, `ScrollbackPane` | 4 files / 237 tests |
| #804 | `ArchiveModal`, `queryWindows` | 2 files / 32 tests |
| #779 | `bootFetch`, `moduleRootGuard`, `moduleRoot`, `BootErrorBoundary` | 4 files / 27 tests |
| #788 | `scrollbackIdentityRotation`, `scrollback`, `subscribe` | 3 files / 144 tests |

Worth noting the #779 guard walks the whole `src` tree, so its green after
graft 3 also covers the file #740 added two grafts earlier.

## Union gate

Run from the worktree root, working tree verified clean before and after:

- `bun run check` (biome + tsc) — rc=0, 483 files, 48 warnings / 0 errors
- `tsc --noEmit` standalone — rc=0 (run separately: a biome failure
  short-circuits the `&&` and would hide a type error)
- `bun run test` — **234 files / 4217 tests, rc=0**

## Scope

16 files, all under `cicchetto/` and `docs/`. **No Elixir touched**, so no
server lane is needed for this gate.