### PR TITLE
test(#752, #753): two waits that could not fail the way they were meant to

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -819,7 +819,18 @@ export async function openRailMenu(page: Page): Promise<void> {
   const deadline = Date.now() + 15_000;
   for (;;) {
     try {
-      if ((await launcher.getAttribute("aria-expanded")) === "false") {
+      // #752 — the timeout is what makes the deadline reachable. `getAttribute`
+      // auto-waits for the element to ATTACH, and `playwright.config.ts` sets no
+      // `actionTimeout` (default 0 = no limit), so a launcher that never mounts
+      // leaves this call neither returning nor throwing: the `catch` below is
+      // never entered and the 15s deadline is never evaluated. The loop then
+      // hangs until the whole-test timeout — 60s to 150s in the specs that raise
+      // it — and reports `getAttribute` instead of "the rail menu never opened".
+      // Every other leg of this family is already bounded (see
+      // `openMembersDrawer`: `isVisible`/`count` do not wait, click and the
+      // visibility assert carry explicit 3s); this was the divergent one, and 86
+      // spec files come through this door.
+      if ((await launcher.getAttribute("aria-expanded", { timeout: 3_000 })) === "false") {
         await launcher.click({ timeout: 3_000 });
       }
       await expect(menu).toBeVisible({ timeout: 3_000 });

--- a/test/grappa/ws_presence_test.exs
+++ b/test/grappa/ws_presence_test.exs
@@ -35,6 +35,49 @@ defmodule Grappa.WSPresenceTest do
     end)
   end
 
+  # #753 — settle on the DOWN having been PROCESSED, never on the clock.
+  #
+  # `Process.exit/2` is asynchronous, so the monitor `:DOWN` races every call
+  # the test makes next. The old shape bet a fixed 50ms on winning that race
+  # and then asserted the post-death state; under load the mailbox has not
+  # drained in 50ms and the assertion reads the PRE-death value. That is the
+  # alone-green / gate-red class #653 spent four slices removing — and with the
+  # sleeps cut to 0 SIX of the nine cases in this file fail, which is the same
+  # race arriving early rather than a different bug.
+  #
+  # Two settles, in order of preference:
+  #
+  #   1. A settle MESSAGE, where one exists. `:ws_all_hidden` is emitted by the
+  #      very `handle_info` that processes the `:DOWN`, so receiving it IS the
+  #      barrier — assert it FIRST and the follow-up reads are guaranteed to see
+  #      the committed state (our call is queued behind that `handle_info`).
+  #   2. This helper, where no message is emitted (that being the point of the
+  #      case). The count is the observable the `:DOWN` moves; polling it is not
+  #      a longer wait but the SAME assertion, made once the state it describes
+  #      has arrived, and it still fails with the real value at the deadline.
+  @settle_timeout_ms 500
+  @settle_poll_ms 5
+
+  defp assert_ws_count(user_name, expected) do
+    assert_ws_count(user_name, expected, System.monotonic_time(:millisecond) + @settle_timeout_ms)
+  end
+
+  defp assert_ws_count(user_name, expected, deadline) do
+    actual = WSPresence.ws_count(user_name)
+
+    cond do
+      actual == expected ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        assert actual == expected
+
+      true ->
+        :timer.sleep(@settle_poll_ms)
+        assert_ws_count(user_name, expected, deadline)
+    end
+  end
+
   describe "register/2 and ws_count/1" do
     test "registering a socket pid bumps the count" do
       :ok = WSPresence.register("vjt", self())
@@ -198,9 +241,8 @@ defmodule Grappa.WSPresenceTest do
       assert WSPresence.ws_count("alice") == 2
 
       Process.exit(p1, :kill)
-      :timer.sleep(50)
 
-      assert WSPresence.ws_count("alice") == 1
+      assert_ws_count("alice", 1)
 
       send(p2, :stop)
     end
@@ -212,11 +254,12 @@ defmodule Grappa.WSPresenceTest do
       assert_receive {:ws_visible, "bob"}, 200
 
       Process.exit(p, :kill)
-      :timer.sleep(50)
 
+      # The message comes from the `handle_info` that processes the `:DOWN`, so
+      # it is the barrier — the reads below are then guaranteed post-commit.
+      assert_receive {:ws_all_hidden, "bob"}, 200
       assert WSPresence.ws_count("bob") == 0
       refute WSPresence.any_visible?("bob")
-      assert_receive {:ws_all_hidden, "bob"}, 200
     end
 
     test "a HIDDEN pid dying does NOT fire :ws_all_hidden (was never visible)" do
@@ -225,9 +268,10 @@ defmodule Grappa.WSPresenceTest do
       # p stays hidden (default)
 
       Process.exit(p, :kill)
-      :timer.sleep(50)
 
-      assert WSPresence.ws_count("bob") == 0
+      # No message to wait on — its absence is the point — so settle on the
+      # count, which is what makes the refute non-vacuous.
+      assert_ws_count("bob", 0)
       refute_receive {:ws_all_hidden, "bob"}, 100
     end
 
@@ -242,9 +286,8 @@ defmodule Grappa.WSPresenceTest do
       assert_receive {:ws_visible, "carol"}, 200
 
       Process.exit(p1, :kill)
-      :timer.sleep(50)
 
-      assert WSPresence.ws_count("carol") == 1
+      assert_ws_count("carol", 1)
       assert WSPresence.any_visible?("carol")
       refute_receive {:ws_all_hidden, "carol"}, 100
 
@@ -260,8 +303,12 @@ defmodule Grappa.WSPresenceTest do
       assert Map.has_key?(:sys.get_state(WSPresence).sockets, "visitor:mallory")
 
       Process.exit(p, :kill)
-      :timer.sleep(50)
 
+      # Settle on the count, then probe the map: the pid removal and the
+      # entry-drop decision happen in the same `handle_info`, so a count of 0
+      # means the choice between "dropped" and "left empty" has been made —
+      # which is the distinction this case exists to pin.
+      assert_ws_count("visitor:mallory", 0)
       refute Map.has_key?(:sys.get_state(WSPresence).sockets, "visitor:mallory")
     end
 
@@ -272,10 +319,9 @@ defmodule Grappa.WSPresenceTest do
       :ok = WSPresence.register("dave", p2)
 
       Process.exit(p1, :kill)
-      :timer.sleep(50)
 
+      assert_ws_count("dave", 1)
       assert Map.has_key?(:sys.get_state(WSPresence).sockets, "dave")
-      assert WSPresence.ws_count("dave") == 1
 
       send(p2, :stop)
     end
@@ -306,10 +352,12 @@ defmodule Grappa.WSPresenceTest do
 
       # ...but its DEATH is still the last reported-visible device leaving.
       Process.exit(p, :kill)
-      :timer.sleep(50)
 
-      assert WSPresence.ws_count("ivan") == 0
+      # Message first: it is emitted by the `handle_info` that handles the
+      # `:DOWN`, so it proves the transition ran. Asserting the count ahead of
+      # it read a state nothing had promised to have reached yet.
       assert_receive {:ws_all_hidden, "ivan"}, 200
+      assert WSPresence.ws_count("ivan") == 0
     end
 
     test "client_closing on a STALE :visible pid still fires :ws_all_hidden" do
@@ -355,7 +403,11 @@ defmodule Grappa.WSPresenceTest do
       :ok = WSPresence.mark_stale_for_test("lena", stale)
 
       Process.exit(fresh, :kill)
-      :timer.sleep(50)
+      # Settle on the fresh pid actually being GONE. The old sleep did not make
+      # this case flaky — the 100ms refute absorbed it — it made it VACUOUS:
+      # a refute that runs before the `:DOWN` is processed passes for the wrong
+      # reason. Now the death is a fact before the absence is asserted.
+      assert_ws_count("lena", 1)
       # `stale` is still raw-visible — the user has not gone all-hidden.
       refute_receive {:ws_all_hidden, "lena"}, 100
 
@@ -376,7 +428,7 @@ defmodule Grappa.WSPresenceTest do
 
       # Subsequent real DOWN is idempotent (already hidden → no re-fire)
       Process.exit(p, :kill)
-      :timer.sleep(50)
+      assert_ws_count("grace", 0)
       refute_receive {:ws_all_hidden, "grace"}, 100
     end
 


### PR DESCRIPTION
Both findings are the same family — **an await that cannot fail as
intended** — so they ship as one PR. Test-only, no production code.

## #752 — `openRailMenu`'s 15s deadline is unreachable on its `getAttribute` leg

`cicchetto/e2e/fixtures/cicchettoPage.ts`. The loop consults its deadline
only from the `catch`, and the first statement in the `try` is
`launcher.getAttribute("aria-expanded")`, which auto-waits for the element
to ATTACH. `playwright.config.ts` sets no `actionTimeout`, and Playwright's
own types spell out the consequence:

> Maximum time in milliseconds. Defaults to `0` - no timeout. The default
> value can be changed via `actionTimeout` option in the config…

So a launcher that never mounts leaves that call neither returning nor
throwing: the `catch` is never entered, the deadline is never evaluated,
and the loop hangs until the whole-test timeout — reporting `getAttribute`
rather than "the rail menu never opened". 68 specs raise that timeout to
60–150s; 86 spec files come through this door.

Fixed with `{ timeout: 3_000 }`, which is what the sibling primitive
already does on every leg (`openMembersDrawer`: `isVisible`/`count` do not
wait at all, click and visibility assert both carry an explicit 3s).
`openRailMenu` was the one divergent member of the family.

### The global `actionTimeout` — measured, and deliberately NOT in this PR

You asked me to decide and say why. **I am not adding it**, and this is the
measurement rather than caution:

- **425** bare `.click()` calls across `tests/` + `fixtures/`, against **6**
  that pass an explicit timeout. A global default would newly cap all 425.
- **68 specs already raise their own test timeout** — 32 × 60s, 27 × 90s,
  5 × 120s, 4 × 150s. Those are precisely the flows where one action
  legitimately sits for a long time under gate load, and they are the ones
  a global cap would convert into new reds.

Choosing a value needs a distribution of real action durations under full
gate load, and getting that means running the e2e suite — the exclusive
lane, which I do not have. Guessing 5s or 10s and finding out in CI is the
outcome you explicitly said you did not want. The punctual fix closes the
reported hole with zero blast radius; the global belongs in its own change,
gated on that measurement.

## #753 — `:timer.sleep(50)` holding up an ordering, in nine places

`test/grappa/ws_presence_test.exs`. `Process.exit(pid, :kill)` is
asynchronous, so the monitor `:DOWN` races every call the test makes next.
A fixed 50ms is a bet on winning that race; under load the mailbox has not
drained and the assertion reads the PRE-death value — the alone-green /
gate-red class #653 spent four slices removing.

**Proof the mechanism is real, not inferred.** With the sleeps cut to 0 on
the unmodified file, **six of the nine cases fail**:

```
1) count decrements when a tracked pid exits          left: 2  right: 1
2) a VISIBLE pid dying fires :ws_all_hidden           left: 1  right: 0
3) a HIDDEN pid dying does NOT fire :ws_all_hidden    left: 1  right: 0
4) one of two visible sockets dying does NOT fire     left: 2  right: 1
5) the user's entry is dropped when its last socket dies
6) a STALE :visible pid dying still fires (ivan)      left: 1  right: 0
29 tests, 6 failures
```

Zero is not a different bug from fifty — it is the same race arriving
early.

**Widened from two to nine.** The issue named `ivan` and `lena`; the other
seven are the identical shape in the same file. Per CLAUDE.md's "fix root
causes, not examples", leaving them half-migrated would just hand the next
author two patterns to copy from.

Two settles, in order of preference:

1. **A settle MESSAGE, where one exists.** `:ws_all_hidden` is emitted by
   the very `handle_info` that processes the `:DOWN`, so receiving it IS
   the barrier — the follow-up reads then queue behind that `handle_info`
   and are guaranteed post-commit. `bob`-visible and `ivan` asserted the
   count *before* that message; inverted, the sleep just disappears.
2. **`assert_ws_count/2`**, where no message is emitted — that absence
   being the point of those cases. The count is the observable the `:DOWN`
   moves. Polling it is not a longer wait: same assertion, made once the
   state it describes has arrived, still failing with the real value at its
   500ms deadline.

**One case is not a flake and is worth calling out.** `lena`'s sleep
preceded a `refute_receive`, whose own 100ms absorbed the delay — so it was
never red. It was **vacuous**: a refute that runs before the `:DOWN` is
processed passes for the wrong reason. Settling on the count first makes
the death a fact before the absence is asserted. Same for `grace`, `carol`
and the hidden-`bob` refutes.

## Gates

- `mix test test/grappa/ws_presence_test.exs` — **29 tests, 0 failures**
- `--repeat-until-failure 20` on that file — **21 consecutive green runs**
- **Full Elixir suite — 8 doctests, 50 properties, 5084 tests, 0 failures**
- `mix format` applied; `mix credo` on the file — no issues

**Not run, stated rather than implied:** the e2e fixture change has no
local gate. `biome.json` scopes to `src/**`, and `cicchetto/e2e` has its own
tsconfig with no lint or typecheck script, so `bun run check` does not see
it; the only real exercise is the Playwright suite itself, which needs the
exclusive lane. The signature is verified against
`playwright-core/types/types.d.ts:13580` (`getAttribute(name, options?: {
timeout?: number })`), and nothing under `cicchetto/src` changed.