### PR TITLE
infra(#747,#748): make the cloud bootstrap suite exercise the script

### DIFF
--- a/infra/cloud/first-boot.sh
+++ b/infra/cloud/first-boot.sh
@@ -85,8 +85,12 @@ require_env() {
 		|| die "GRAPPA_ADMIN_EMAIL ('$GRAPPA_ADMIN_EMAIL') is not a valid email address."
 }
 
+# No test escape hatch here on purpose: an env var that skips the privilege
+# check ships to production, where anything able to set it walks straight past
+# the check — and because the suite set it unconditionally, the check itself
+# was never once exercised (#747). The suite stubs `id` on PATH like it stubs
+# apt-get and systemctl, so this runs verbatim under test.
 require_root() {
-	[ "${GRAPPA_SKIP_PRIVCHECK:-}" = 1 ] && return 0
 	[ "$(id -u)" -eq 0 ] || die "first-boot.sh must run as root (apt, systemctl, /etc/grappa all need it)."
 }
 
@@ -104,13 +108,19 @@ fetch() {
 # fully into a var FIRST (not piped) so no early-terminating stage can SIGPIPE
 # the download under `set -o pipefail`; `sed -n '1p'` reads all input, so it
 # picks the first match without closing the pipe early either.
+# Non-zero means "could not read the API"; empty stdout means "read it, no
+# such asset". Keeping those apart needs the trailing `|| true`: no match makes
+# grep exit 1, `set -o pipefail` promotes that to the pipeline's status, and in
+# the caller's command substitution `set -e` then killed the whole script — so
+# the die naming the problem was unreachable and a release without an amd64
+# asset aborted first boot with exit 1 and not one word of explanation (#748).
 latest_deb_url() {
 	local json
 	json="$(curl -fsSL "$GITHUB_API")" || return 1
 	printf '%s\n' "$json" \
 		| grep -o '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]*_amd64\.deb"' \
 		| sed 's/.*"\(https[^"]*_amd64\.deb\)".*/\1/' \
-		| sed -n '1p'
+		| sed -n '1p' || true
 }
 
 install_grappa_deb() {
@@ -123,7 +133,7 @@ install_grappa_deb() {
 	# but a minbase cloud image may lack curl before the .deb lands.
 	apt-get install -y -q nginx certbot python3-certbot-nginx ca-certificates curl
 
-	deb_url="$(latest_deb_url)"
+	deb_url="$(latest_deb_url)" || die "could not read the latest release from $GITHUB_API"
 	[ -n "$deb_url" ] || die "no grappa_*_amd64.deb asset in the latest release ($GITHUB_API)"
 	say "Latest .deb: $deb_url"
 

--- a/test/infra/cloud_first_boot_test.bats
+++ b/test/infra/cloud_first_boot_test.bats
@@ -29,8 +29,7 @@ setup() {
     export GRAPPA_TLS_HELPER="$BATS_TEST_TMPDIR/sbin/grappa-tls"
     export GRAPPA_TLS_UNIT="$BATS_TEST_TMPDIR/systemd/grappa-tls.service"
 
-    # ── Behaviour seams: never actually root, fast health loop ──────────────
-    export GRAPPA_SKIP_PRIVCHECK=1
+    # ── Behaviour seams: fast health loop ───────────────────────────────────
     export GRAPPA_HEALTH_RETRIES=3
     export GRAPPA_HEALTH_SLEEP=0
 
@@ -62,12 +61,18 @@ while [ $# -gt 0 ]; do
 done
 case "$url" in
   */releases/latest)
+    [ -n "${RELEASE_API_FAILS:-}" ] && exit 22
+    # RELEASE_HAS_NO_DEB=1 → a real release that shipped no amd64 asset.
+    [ -n "${RELEASE_HAS_NO_DEB:-}" ] \
+      && { printf '{"tag_name":"v9.9.9","assets":[{"browser_download_url":"https://github.com/vjt/grappa-irc/releases/download/v9.9.9/grappa_9.9.9_arm64.deb"}]}\n'; exit 0; }
     printf '{"tag_name":"v9.9.9","assets":[{"browser_download_url":"https://github.com/vjt/grappa-irc/releases/download/v9.9.9/grappa_9.9.9_amd64.deb"}]}\n' ;;
   *_amd64.deb)
+    [ -n "${DEB_FETCH_FAILS:-}" ] && exit 22
     [ -n "$dest" ] && printf 'FAKE DEB\n' > "$dest" ;;
   */infra/snippets/locations-api.conf)
     [ -n "$dest" ] && cp "$SRC_LOCATIONS" "$dest" ;;
   *healthz*)
+    [ -n "${HEALTH_NEVER_OK:-}" ] && exit 7
     exit 0 ;;
   *) printf 'fake curl: unexpected url: %s\n' "$url" >&2; exit 1 ;;
 esac
@@ -90,7 +95,29 @@ exit 0
 EOF
     chmod +x "$FAKE_DIR/apt-get"
 
-    for tool in systemctl nginx certbot; do
+    # id: root, like the box the script is written for. Stubbed on PATH
+    # rather than skipped through an env var, so require_root runs verbatim
+    # here and production carries no bypass (#747). A test that wants a
+    # non-root run overrides this stub.
+    cat > "$FAKE_DIR/id" <<'EOF'
+#!/usr/bin/env bash
+printf 'id %s\n' "$*" >> "$ARGV_LOG"
+printf '%s\n' "${FAKE_UID:-0}"
+EOF
+    chmod +x "$FAKE_DIR/id"
+
+    # certbot: separate from the log-only stubs because grappa-tls execs it,
+    # and CERTBOT_FAILS=1 is how a test drives the likeliest real failure —
+    # the Let's Encrypt rate limit.
+    cat > "$FAKE_DIR/certbot" <<'EOF'
+#!/usr/bin/env bash
+printf 'certbot %s\n' "$*" >> "$ARGV_LOG"
+[ -n "${CERTBOT_FAILS:-}" ] && exit 1
+exit 0
+EOF
+    chmod +x "$FAKE_DIR/certbot"
+
+    for tool in systemctl nginx; do
         cat > "$FAKE_DIR/$tool" <<EOF
 #!/usr/bin/env bash
 printf '$tool %s\n' "\$*" >> "$ARGV_LOG"
@@ -132,6 +159,25 @@ mode_of() {  # GNU-first, BSD fallback (macOS runner) — matches the packaging 
     [[ "$output" == *"GRAPPA_ADMIN_EMAIL is required"* ]]
 }
 
+# ───────────────────────────── privilege ─────────────────────────────────────
+
+# Until #747 this could not even be written: the suite exported
+# GRAPPA_SKIP_PRIVCHECK=1 in setup, so require_root returned before reading
+# the uid and no test could reach the refusal.
+@test "refuses to run as a non-root user" {
+    FAKE_UID=1000 run "$FBSH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"must run as root"* ]]
+    # It refuses BEFORE touching the box.
+    refute grep -q "^apt-get " "$ARGV_LOG"
+}
+
+@test "checks the uid rather than trusting an env var" {
+    GRAPPA_SKIP_PRIVCHECK=1 FAKE_UID=1000 run "$FBSH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"must run as root"* ]]
+}
+
 # ───────────────────────────── install path ──────────────────────────────────
 
 @test "installs the LATEST release .deb via apt (no pin)" {
@@ -159,7 +205,59 @@ mode_of() {  # GNU-first, BSD fallback (macOS runner) — matches the packaging 
 @test "fails loud if the env file is missing after install" {
     SKIP_ENV_SEED=1 run "$FBSH"
     [ "$status" -ne 0 ]
-    [[ "$output" == *"missing"* ]]
+    # Pin the PATH, not just the word: "missing" appears in more than one
+    # die, so the bare substring passed for a refusal it never saw.
+    [[ "$output" == *"$GRAPPA_ENV_FILE missing"* ]]
+}
+
+# ───────────────────────────── failure paths ─────────────────────────────────
+#
+# The happy path was covered and every way the bootstrap can FAIL was not, so
+# a box could report a successful first boot while serving nothing. Each of
+# these asserts the die AND that the run stopped there.
+
+# Both of these used to abort with a bare exit 1 and NO message: under
+# `set -o pipefail` a no-match grep failed the pipeline, and `set -e` killed
+# the script at the command substitution — before the die that names the
+# problem. An operator read a cloud-init that failed for no stated reason.
+@test "a release with no amd64 .deb asset says so instead of dying mute" {
+    RELEASE_HAS_NO_DEB=1 run "$FBSH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"no grappa_*_amd64.deb asset"* ]]
+    refute grep -qE "apt-get install .*grappa\.deb" "$ARGV_LOG"
+}
+
+@test "an unreachable release API is reported as such, not as a missing asset" {
+    RELEASE_API_FAILS=1 run "$FBSH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"could not read the latest release"* ]]
+    refute grep -qE "apt-get install .*grappa\.deb" "$ARGV_LOG"
+}
+
+@test "a failed .deb download aborts instead of installing a half-file" {
+    DEB_FETCH_FAILS=1 run "$FBSH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"download failed"* ]]
+    refute grep -qE "apt-get install .*grappa\.deb" "$ARGV_LOG"
+}
+
+@test "health that never comes up is a failed boot, not a quiet one" {
+    HEALTH_NEVER_OK=1 run "$FBSH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"did not become healthy"* ]]
+    # Exhausted the budget rather than giving up on the first miss.
+    [ "$(grep -c "curl .*healthz" "$ARGV_LOG")" -eq "$GRAPPA_HEALTH_RETRIES" ]
+    # And it stopped: TLS never got installed on a box that serves nothing.
+    [ ! -e "$GRAPPA_TLS_HELPER" ]
+}
+
+@test "a grappa-tls failure leaves the box up with a re-run instruction" {
+    # The likeliest real failure is the Let's Encrypt quota, and it must NOT
+    # fail the boot: grappa itself is already serving, only the cert is late.
+    GETENT_RESOLVES=1 CERTBOT_FAILS=1 run "$FBSH"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"grappa-tls failed"* ]]
+    [[ "$output" == *"sudo grappa-tls"* ]]
 }
 
 # ───────────────────────────── env force-set ─────────────────────────────────
@@ -189,6 +287,21 @@ mode_of() {  # GNU-first, BSD fallback (macOS runner) — matches the packaging 
     # The #485 SSOT snippet was fetched, not re-typed.
     grep -q "grappa_upstream" "$GRAPPA_NGINX_SNIPPETS/grappa-locations-api.conf"
     grep -q "curl .*/infra/snippets/locations-api.conf" "$ARGV_LOG"
+}
+
+# Writing sites-available and never linking it leaves nginx serving the stock
+# default: the site file reads perfect on disk, the box answers nothing, and
+# the ACME challenge goes to the wrong server_name.
+@test "enables the site and drops the stock default" {
+    mkdir -p "$GRAPPA_NGINX_SITES_ENABLED"
+    printf 'stock default\n' > "$GRAPPA_NGINX_SITES_ENABLED/default"
+
+    run "$FBSH"
+    [ "$status" -eq 0 ]
+
+    [ -L "$GRAPPA_NGINX_SITES_ENABLED/grappa" ]
+    [ "$(readlink "$GRAPPA_NGINX_SITES_ENABLED/grappa")" = "$GRAPPA_NGINX_SITES_AVAILABLE/grappa" ]
+    [ ! -e "$GRAPPA_NGINX_SITES_ENABLED/default" ]
 }
 
 # ───────────────────────────── TLS helper + defer ────────────────────────────

--- a/test/infra/deploy_docker_verbs_test.bats
+++ b/test/infra/deploy_docker_verbs_test.bats
@@ -66,8 +66,13 @@ printf '\n' >> "$ARGV_LOG"
 # \`GRAPPA_VERSION: \${GRAPPA_VERSION:-}\` through from this environment — the
 # prod profile pulls the cicchetto-build oneshot in via depends_on, so \`up -d\`
 # counts as a cic build launch just like an explicit run does (#692).
+#
+# The profile is part of the pattern, not decoration: a bare \`up -d\` does NOT
+# pull cicchetto-build in and builds no bundle. Matching it anyway let the
+# #692 regression check pass with \`--profile prod\` deleted from cmd_install
+# — measured, 25/25 green while no bundle would have been built at all.
 case "\$*" in
-    *cicchetto-build*|*"up -d"*)
+    *cicchetto-build*|*"--profile prod"*"up -d"*)
         printf 'env GRAPPA_VERSION=%s\n' "\${GRAPPA_VERSION:-}" >> "$ARGV_LOG" ;;
 esac
 if [ "\$1" = inspect ]; then
@@ -94,8 +99,13 @@ printf '\n' >> "$ARGV_LOG"
 # \`GRAPPA_VERSION: \${GRAPPA_VERSION:-}\` through from this environment — the
 # prod profile pulls the cicchetto-build oneshot in via depends_on, so \`up -d\`
 # counts as a cic build launch just like an explicit run does (#692).
+#
+# The profile is part of the pattern, not decoration: a bare \`up -d\` does NOT
+# pull cicchetto-build in and builds no bundle. Matching it anyway let the
+# #692 regression check pass with \`--profile prod\` deleted from cmd_install
+# — measured, 25/25 green while no bundle would have been built at all.
 case "\$*" in
-    *cicchetto-build*|*"up -d"*)
+    *cicchetto-build*|*"--profile prod"*"up -d"*)
         printf 'env GRAPPA_VERSION=%s\n' "\${GRAPPA_VERSION:-}" >> "$ARGV_LOG" ;;
 esac
 for a in "\$@"; do
@@ -225,6 +235,16 @@ EOF
     themes_line="$(grep -n 'grappa.seed_themes' "$ARGV_LOG" | head -n1 | cut -d: -f1)"
     up_line="$(grep -n 'up -d' "$ARGV_LOG" | head -n1 | cut -d: -f1)"
     [ -n "$themes_line" ] && [ -n "$up_line" ] && [ "$themes_line" -lt "$up_line" ]
+}
+
+# cicchetto-build lives in the prod profile, so a bare `up -d` starts the
+# bouncer and builds no bundle at all — the box serves a stale or absent SPA.
+# Nothing asserted the profile before: it could be deleted from cmd_install
+# and the whole file stayed green.
+@test "install: brings the stack up under the prod profile, or no bundle is built" {
+    run "$DEPLOY" install
+    [ "$status" -eq 0 ]
+    grep -q -- "--profile prod up -d" "$ARGV_LOG"
 }
 
 @test "install: the stack comes up carrying GRAPPA_VERSION from the VERSION file (#692)" {


### PR DESCRIPTION
Two code-review findings on `infra/cloud/first-boot.sh`, same file, same sitting.

## #747 — a production privilege bypass that existed only for the tests

`require_root` returned early on `GRAPPA_SKIP_PRIVCHECK=1`, and the bats setup
exported it unconditionally — so the check was never executed by any test, and
the escape hatch shipped to the box regardless.

Both halves are gone. `id` is stubbed on PATH exactly like `apt-get`,
`systemctl`, `nginx` and `getent` already are, so the script runs verbatim and
the refusal finally has a test. A second case exports the retired variable and
asserts it changes nothing.

**Oracle:** restore the bypass line → `checks the uid rather than trusting an
env var` goes red. Before this change the "must run as root" case was not
reachable at all.

## #748 — every failure path of the bootstrap was uncovered

Now covered: health that never comes up (and that the retry budget is *spent*,
not abandoned on the first miss), a release with no amd64 asset, an unreachable
release API, a failed `.deb` download, and a `grappa-tls` that exits non-zero —
the Let's Encrypt quota, the likeliest real failure, which must **not** fail the
boot. Plus the nginx symlink and the removal of the stock `default`, which
nothing asserted: write `sites-available` and never link it and the site reads
perfect on disk while the box answers nothing.

### A real defect the new tests found

`deb_url="$(latest_deb_url)"` runs under `set -euo pipefail`. A no-match grep
fails the pipeline, so the script died **at the assignment**, before the `die`
that names the problem: a release without an amd64 `.deb` aborted first boot
with exit 1 and no message at all. `latest_deb_url` now returns non-zero only
for "could not read the API" and empty for "no such asset", and the caller
reports the two apart.

### Two assertions that were passing without seeing anything

- The env-file-missing check matched the bare word `missing`, which more than
  one `die` contains — pinned to the path.
- The docker stub logged the #692 `GRAPPA_VERSION` line for any `up -d`, but
  only the prod profile pulls `cicchetto-build` in. **Measured:** deleting
  `--profile prod` from `cmd_install` left all 25 cases green while no bundle
  would have been built. The stub now requires the profile and `install`
  asserts it outright — with the profile removed, both cases go red.

## Gates

- `scripts/bats.sh` (full set): **271/271, rc=0** — baseline on `origin/main`
  was 262/262, so +9 and no regressions. Working tree clean before and after.
- `shellcheck -x infra/cloud/first-boot.sh`: clean.
- `infra/cloud/check-drift.sh`: OK, all doors reference the script.

Note: bats case 44 (`RED: a missing knob marker fails with exit 1`) was flagged
as a known pre-existing red — it is **green** here, on `origin/main` and after.