### PR TITLE
test(#749): put the TOTP door's three unasserted claims under test

### DIFF
--- a/test/grappa/accounts/totp_test.exs
+++ b/test/grappa/accounts/totp_test.exs
@@ -115,13 +115,34 @@ defmodule Grappa.Accounts.TOTPTest do
     assert %DateTime{} = Repo.get!(Session, other.id).revoked_at
   end
 
-  test "new enrollment URI contains issuer, account, and secret" do
+  # The label is what an authenticator app puts under the user's thumb, so
+  # it has to name the ACCOUNT, not merely be present: built from `user.id`
+  # instead of `user.name` the URI still parses, still carries the issuer,
+  # still round-trips the secret, and every enrolled account shows up as a
+  # UUID. The parameters are pinned for the same reason — RFC 6238 leaves
+  # SHA1/6/30 as defaults, but `code_at/2` is not written against defaults,
+  # so a URI that omits or contradicts them enrolls an app that computes
+  # codes this server will refuse.
+  test "new enrollment URI labels the account and pins the RFC 6238 parameters" do
     user = user_fixture(name: "alice")
     enrollment = TOTP.new_enrollment(user, "Grappa (irc.example)")
 
-    assert String.starts_with?(enrollment.provisioning_uri, "otpauth://totp/")
-    assert enrollment.provisioning_uri =~ "issuer=Grappa+%28irc.example%29"
-    assert enrollment.provisioning_uri =~ "secret=#{enrollment.secret}"
+    assert %URI{scheme: "otpauth", host: "totp", path: path, query: query} =
+             URI.parse(enrollment.provisioning_uri)
+
+    assert URI.decode(path) == "/Grappa (irc.example):alice"
+
+    params = URI.decode_query(query)
+    assert params["issuer"] == "Grappa (irc.example)"
+    assert params["algorithm"] == "SHA1"
+    assert params["digits"] == "6"
+    assert params["period"] == "30"
+
+    # Not just an echo of the struct: the URI has to carry a secret the
+    # authenticator can actually key on — 20 raw bytes, Base32, unpadded.
+    assert params["secret"] == enrollment.secret
+    assert {:ok, key} = Base.decode32(params["secret"], padding: false)
+    assert byte_size(key) == 20
   end
 
   # The recovery set is shared, so disarming TOTP must not destroy a

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -335,6 +335,164 @@ defmodule GrappaWeb.AuthControllerTest do
     end
   end
 
+  # The second factor's own brute-force bound. The sibling mode-1 describe
+  # proves it for the PASSWORD door; this is the same claim for the TOTP
+  # door, which guards a 10^6 space and so needs it more, not less.
+  #
+  # Note what the loop below relies on: ONE challenge token answers all
+  # eleven requests. The challenge is a `Phoenix.Token`, so it is REUSABLE
+  # for its whole 300s window — only the TOTP code is one-shot (see
+  # "replayed TOTP is rejected" above). That is the intended UX (a typo
+  # must not cost the password round trip) and it is exactly why the
+  # window needs a counter: without one, a single post-password token is
+  # an unlimited oracle.
+  describe "POST /auth/totp/verify throttle (:totp_login)" do
+    test "the 11th attempt is 429 too_many_attempts even with the correct code", %{conn: conn} do
+      {user, password} = user_fixture_with_password()
+      secret = arm_totp(user)
+      wrong = wrong_totp_code(secret, System.system_time(:second))
+
+      pending =
+        conn
+        |> post("/auth/login", %{"identifier" => user.name, "password" => password})
+        |> json_response(202)
+
+      for _ <- 1..10 do
+        assert conn
+               |> post("/auth/totp/verify", %{
+                 "challenge_token" => pending["challenge_token"],
+                 "code" => wrong
+               })
+               |> json_response(401) == %{"error" => "invalid_two_factor"}
+      end
+
+      {:ok, code} = TOTP.code_at(secret, System.system_time(:second))
+
+      assert conn
+             |> post("/auth/totp/verify", %{
+               "challenge_token" => pending["challenge_token"],
+               "code" => code
+             })
+             |> json_response(429) == %{"error" => "too_many_attempts"}
+
+      assert session_count() == 0
+    end
+
+    test "a fresh account is unaffected by another's exhausted window", %{conn: conn} do
+      {spent, spent_password} = user_fixture_with_password()
+      spent_secret = arm_totp(spent)
+      wrong = wrong_totp_code(spent_secret, System.system_time(:second))
+
+      spent_pending =
+        conn
+        |> post("/auth/login", %{"identifier" => spent.name, "password" => spent_password})
+        |> json_response(202)
+
+      for _ <- 1..10 do
+        post(conn, "/auth/totp/verify", %{
+          "challenge_token" => spent_pending["challenge_token"],
+          "code" => wrong
+        })
+      end
+
+      {user, password} = user_fixture_with_password()
+      secret = arm_totp(user)
+
+      pending =
+        conn
+        |> post("/auth/login", %{"identifier" => user.name, "password" => password})
+        |> json_response(202)
+
+      {:ok, code} = TOTP.code_at(secret, System.system_time(:second))
+
+      assert conn
+             |> post("/auth/totp/verify", %{
+               "challenge_token" => pending["challenge_token"],
+               "code" => code
+             })
+             |> json_response(200)
+    end
+  end
+
+  # The post-password challenge is deliberately short-lived: it is handed
+  # out BEFORE the second factor is proven, so anything that leaks one — a
+  # proxy log, a crash report, a shared screen — hands over half a login.
+  # 300s is the whole bound, and nothing but `max_age:` enforces it.
+  #
+  # These mint the token directly because the age is the subject and a
+  # token obtained from `/auth/login` is always fresh. That duplicates the
+  # controller's private salt here, so the second test is not decoration:
+  # it runs the SAME helper with a current timestamp and demands a bearer.
+  # Drift the salt, the payload shape, or the binding and the control goes
+  # red — a wrong salt reads as `invalid_two_factor`, never as an accepted
+  # login, so this pair cannot quietly test nothing.
+  describe "POST /auth/totp/verify challenge lifetime" do
+    @totp_challenge_salt "account-totp-login-v1"
+    @totp_challenge_max_age_seconds 300
+
+    test "a challenge older than its window is refused as expired", %{conn: conn} do
+      {user, _} = user_fixture_with_password()
+      secret = arm_totp(user)
+      {:ok, code} = TOTP.code_at(secret, System.system_time(:second))
+      stale = System.system_time(:second) - @totp_challenge_max_age_seconds - 1
+
+      refused =
+        post(conn, "/auth/totp/verify", %{
+          "challenge_token" => totp_challenge_token(user, conn, stale),
+          "code" => code
+        })
+
+      assert json_response(refused, 401) == %{"error" => "two_factor_challenge_expired"}
+      assert session_count() == 0
+    end
+
+    test "a challenge inside its window still mints the bearer", %{conn: conn} do
+      {user, _} = user_fixture_with_password()
+      secret = arm_totp(user)
+      {:ok, code} = TOTP.code_at(secret, System.system_time(:second))
+      fresh = System.system_time(:second) - @totp_challenge_max_age_seconds + 30
+
+      body =
+        conn
+        |> post("/auth/totp/verify", %{
+          "challenge_token" => totp_challenge_token(user, conn, fresh),
+          "code" => code
+        })
+        |> json_response(200)
+
+      assert body["subject"]["id"] == user.id
+      assert session_count() == 1
+    end
+  end
+
+  defp totp_challenge_token(user, conn, signed_at) do
+    Phoenix.Token.sign(
+      GrappaWeb.Endpoint,
+      @totp_challenge_salt,
+      {user.id, GrappaWeb.RemoteIP.format(conn), conn.assigns[:current_client_id]},
+      signed_at: signed_at
+    )
+  end
+
+  # A code that no step in `matching_step/3`'s ±1 window accepts, and one
+  # step further out on each side so a 30s boundary crossed mid-test can't
+  # turn it valid. Derived from the production generator rather than
+  # hardcoded: "000000" is a real code once every 10^6 enrollments.
+  defp wrong_totp_code(secret, now) do
+    accepted =
+      for step_offset <- -2..2 do
+        {:ok, code} = TOTP.code_at(secret, now + step_offset * 30)
+        code
+      end
+
+    # Pigeonhole: five codes are accepted, so one of the first six
+    # numbers is not among them.
+    Enum.find_value(0..length(accepted), fn n ->
+      candidate = n |> Integer.to_string() |> String.pad_leading(6, "0")
+      if candidate not in accepted, do: candidate
+    end)
+  end
+
   # #404 — an account holder who types their BARE account name (no `@`)
   # must get an ACCOUNT session, not a silently-provisioned guest. Pre-fix
   # the dispatch keyed SOLELY on `@` presence, so a bare account name


### PR DESCRIPTION
Issue #749. All three cited sites verified alive against current main
(`8ae917a6`) before writing anything — line numbers had drifted from
`388f883b` but every defect is real. One half of one premise had not:
see the bottom.

## What changed

**1 — the throttle's blocking arm.** `check_totp_throttle/2` sits
mid-`with` in `verify_totp/2` and its `{:error, :limited}` arm was
unreachable from the suite: the one `:totp_login` test seeded nine
failures into ETS and asserted the CLEAR path. New test drives ten wrong
codes through `POST /auth/totp/verify` and demands 429 on the eleventh
*even with the correct code* — the shape the mode-1 password describe
already uses. A second test proves the window is keyed per (ip, user):
one account's exhausted bucket must not refuse a fresh one.

Two details worth flagging:
- The eleven requests reuse ONE challenge token. The challenge is a
  `Phoenix.Token`, so it is **reusable for its whole 300s window** —
  only the TOTP code is one-shot. That is the intended UX (a typo must
  not cost the password round trip) and precisely why the window needs a
  counter. Documented on the describe.
- The wrong code is derived from the production generator, excluding
  `matching_step/3`'s ±1 window plus one step either side so a 30s
  boundary crossed mid-loop cannot turn it valid. `"000000"` is a real
  code once every 10^6 enrollments, and the loop rolls the dice ten
  times.

**2 — the challenge window.** `grep two_factor_challenge_expired test/`
was empty. Two tests: one token minted 301s ago is refused as expired,
one minted inside the window still mints the bearer. The second is not
decoration — age is the subject, so these mint directly and duplicate
the controller's private salt. Running the SAME helper with a current
timestamp and demanding a 200 means a drifted salt, payload shape, or
binding turns the control red, instead of the expiry test passing for
the wrong reason (a wrong salt reads as `invalid_two_factor`, never as
an accepted login).

**3 — the enrollment label.** The URI test asserted a prefix, the
issuer, and an echo of its own secret. It now parses the URI instead of
substring-matching it, asserts the whole label
(`Grappa (irc.example):alice`), and pins `algorithm=SHA1` / `digits=6` /
`period=30` — `code_at/2` is not written against RFC defaults, so a URI
that omits them enrolls an app whose codes this server refuses. The
secret must additionally decode as 20 raw Base32 bytes, so it is no
longer a same-struct echo.

## Mutation matrix

Every mutation applied to production code, run, and reverted. Re-verified
against the final version of the wrong-code helper.

| mutation | result |
| --- | --- |
| drop `check_totp_throttle/2` from the `with` | **red** — only "the 11th attempt is 429…" |
| `max_age:` → `:infinity` in `Phoenix.Token.verify/4` | **red** — only "a challenge older than its window…" |
| `new_enrollment(%User{id: name}, …)` (label from the id) | **red** — only "new enrollment URI labels the account…" |

## One premise did not survive measurement

The issue extends finding 1 with *"Same for `:passkey_recovery`
(`passkey_controller.ex:191`, limit 10)"*. That half is **already
covered**, twice over, so nothing was added for it:

| mutation | result |
| --- | --- |
| drop the `:passkey_recovery` account-bucket check (limit 10) | **red** — the existing "recovery throttling survives respelling the identifier" catches it |
| drop the check at the literal cited line 191 (which is `:passkey_login_options`, limit 30 — not `:passkey_recovery`) | **red** — the existing "login_options is throttled even while it keeps succeeding" catches it |

Both existing tests drive real attempts through the endpoint and assert
the 429, which is exactly the shape the issue asks for. Reporting rather
than inventing a substitute.

## Pre-existing flake found while measuring, NOT touched here

`POST /auth/login (visitor via nick) every nick candidate in use → 409
nick_in_use (#40)` fails intermittently — about 2 reds in ~14 runs of
this file, and it reproduces on the **unmodified `origin/main` version**
of the file (1 red in 5 runs, 49 tests), so it is not this branch's. It
is in the #676 433-fallback-ladder path. I did not capture the failure
text before it went quiet, so I am not guessing at the mechanism. Flagged
for a separate issue rather than widening this PR.

## Gate

`scripts/check.sh` rc=0 from the worktree root: credo `found no issues`,
dialyzer `Total errors: 0` / `done (passed successfully)`, doctor passed,
sobelow clean, ExUnit `8 doctests, 50 properties, 5105 tests, 0 failures`,
bats 271 ok / 0 not ok.

Test-only change; no production code is touched.