### PR TITLE
cic(#778): re-pin the tail when the pane's own box shrinks

### DIFF
--- a/cicchetto/e2e/tests/issue580-send-snap-independent-of-post.spec.ts
+++ b/cicchetto/e2e/tests/issue580-send-snap-independent-of-post.spec.ts
@@ -32,13 +32,26 @@
 // off-screen. GREEN post-fix: `setOwnSendSubmitted` fired before the await, so
 // the pane snaps to the tail regardless of the POST outcome.
 //
+// ## Case 2 — #778: the failure banner must not push the row back under
+//
+// Case 1 was intermittently red (~2 in 60) with a shape no rate could explain:
+// the pane WAS at the bottom by the 50px threshold, yet the just-sent row was
+// clipped. Measured cause: the `.compose-box-error` "send failed" line mounts
+// BELOW the pane and shrinks the scroll container by its own 25px. When it
+// lands AFTER the tail-follow write, the pane is left short of the tail by the
+// shrink — under the 50px threshold, but more than a 21px row — so the newest
+// row falls under the fold. Case 1 only ever saw it when the banner happened to
+// lose the race; case 2 PINS the ordering (the send POST is held until the
+// pane has tail-followed the WS echo) so the geometry is deterministic, and
+// asserts on the state the operator actually ends up looking at.
+//
 // Harness mirrors issue168-scroll-authority (DB-seeded 200-row `#bofh`; tiny
 // 800×300 viewport so the REST page overflows and scroll geometry is
 // measurable; mid-page cursor so cold-mount lands on the marker, above the
 // fold).
 
 import { test, expect } from "../fixtures/test";
-import { type Page } from "@playwright/test";
+import { type Locator, type Page } from "@playwright/test";
 import {
   composeTextarea,
   loginAs,
@@ -89,6 +102,79 @@ async function seedCursor(channel: string, messageId: number): Promise<void> {
   await setReadCursorToId(vjt.token, NETWORK_SLUG, channel, messageId);
 }
 
+// Fetch-wrap: the send POST reaches the server (which persists + WS-broadcasts
+// the row) but the CLIENT sees a failure — the #580 "server accepted, client
+// POST dropped" shape. Only the send POST is intercepted; every other request
+// (login, REST GETs, read-cursor POST) passes through untouched.
+//
+// `hold` gates WHEN the client-side failure surfaces: false rejects as soon as
+// the forward returns (case 1), true parks the rejection until the test calls
+// `__grappa778ReleaseSend()` — so the "send failed" banner, and the container
+// shrink it causes, land AFTER the pane has tail-followed the WS echo (case 2,
+// #778). A released signal, not a delay: nothing here waits on wall-clock.
+async function installFailingSendPost(page: Page, hold: boolean): Promise<void> {
+  await page.addInitScript((holdUntilReleased: boolean) => {
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    window.__grappa778ReleaseSend = release;
+    const orig = window.fetch.bind(window);
+    window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      const method = (
+        init?.method ?? (input instanceof Request ? input.method : "GET")
+      ).toUpperCase();
+      if (method === "POST" && /\/channels\/[^/]+\/messages(\?|$)/.test(url)) {
+        try {
+          await orig(input, init);
+        } catch {
+          // even a genuinely failed forward still simulates the client
+          // failure — swallow and reject below.
+        }
+        if (holdUntilReleased) await gate;
+        throw new TypeError("#580 simulated send POST failure");
+      }
+      return orig(input, init);
+    };
+  }, hold);
+}
+
+// Land on the unread marker with a mid-page cursor → cold-mount parks the view
+// ABOVE the fold, so distance-to-tail starts above threshold (mirror of
+// issue168) and a later "we are at the bottom" assert means something.
+async function arriveParkedOnMarker(page: Page, channel: string): Promise<void> {
+  const vjt = getSeededVjt();
+  const page0 = await fetchScrollbackPage(vjt.token, channel);
+  expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
+  const cursorRow = page0[25];
+  if (!cursorRow) throw new Error("seeded page too short for cursor placement");
+  await seedCursor(channel, cursorRow.id);
+
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, channel, { ownNick: NETWORK_NICK });
+  await waitForScrollbackRefreshed(page, NETWORK_SLUG, channel);
+
+  await expect
+    .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
+    .toBeGreaterThanOrEqual(REST_PAGE_SIZE);
+  await expect(page.locator('[data-testid="unread-marker"]')).toHaveCount(1);
+  await expect
+    .poll(async () => await distanceToBottom(page))
+    .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
+}
+
+// Send manually — `composeSend` awaits a draft-clear that a failed POST never
+// produces. We assert on scroll geometry + the WS-echoed line, not the textarea.
+async function sendAndAwaitEcho(page: Page, marker: string): Promise<Locator> {
+  const ta = composeTextarea(page);
+  await ta.fill(marker);
+  await ta.press("Enter");
+  const sentLine = scrollbackLines(page).filter({ hasText: marker });
+  await expect(sentLine).toHaveCount(1, { timeout: 10_000 });
+  return sentLine;
+}
+
 test.describe("issue #580 — own send snaps to the bottom independent of the POST", () => {
   test.use({ viewport: { width: 800, height: 300 } });
 
@@ -102,70 +188,14 @@ test.describe("issue #580 — own send snaps to the bottom independent of the PO
   });
 
   test("send whose POST fails still snaps to the bottom (case 1)", async ({ page }) => {
-    const vjt = getSeededVjt();
     if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
 
-    // Fetch-wrap: the send POST reaches the server (which persists +
-    // WS-broadcasts the row) but the CLIENT sees a failure — the #580 case-1
-    // "server accepted, client POST dropped" shape. Only the send POST is
-    // intercepted; every other request (login, REST GETs, read-cursor POST)
-    // passes through untouched.
-    await page.addInitScript(() => {
-      const orig = window.fetch.bind(window);
-      window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-        const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-        const method = (
-          init?.method ?? (input instanceof Request ? input.method : "GET")
-        ).toUpperCase();
-        if (method === "POST" && /\/channels\/[^/]+\/messages(\?|$)/.test(url)) {
-          // Forward the real request so the server broadcasts the row over WS,
-          // THEN reject so apiSendMessage sees a failed POST.
-          try {
-            await orig(input, init);
-          } catch {
-            // even a genuinely failed forward still simulates the client
-            // failure — swallow and reject below.
-          }
-          throw new TypeError("#580 simulated send POST failure");
-        }
-        return orig(input, init);
-      };
-    });
-
-    // Mid-page cursor → cold-mount lands on the unread marker (above the fold),
-    // so distance-to-tail starts ABOVE threshold (mirror of issue168).
-    const page0 = await fetchScrollbackPage(vjt.token, CHANNEL);
-    expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
-    const cursorRow = page0[25];
-    if (!cursorRow) throw new Error("seeded page too short for cursor placement");
-    await seedCursor(CHANNEL, cursorRow.id);
-
-    await loginAs(page, vjt);
-    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
-    await waitForScrollbackRefreshed(page, NETWORK_SLUG, CHANNEL);
-
-    await expect
-      .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
-      .toBeGreaterThanOrEqual(REST_PAGE_SIZE);
-    await expect(page.locator('[data-testid="unread-marker"]')).toHaveCount(1);
-
-    // Reading history: cold-mount parked the view on the marker, above the fold.
-    await expect
-      .poll(async () => await distanceToBottom(page))
-      .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
+    await installFailingSendPost(page, false);
+    await arriveParkedOnMarker(page, CHANNEL);
 
     // SEND — the POST will fail client-side, but the server broadcasts the row
-    // over WS. Send manually (composeSend awaits a draft-clear that a failed
-    // POST never produces); we assert on scroll geometry + the WS-echoed line,
-    // not on the textarea.
-    const marker = `#580 snap-on-fail ${Date.now()}`;
-    const ta = composeTextarea(page);
-    await ta.fill(marker);
-    await ta.press("Enter");
-
-    // The WS echo renders the row despite the failed POST.
-    const sentLine = scrollbackLines(page).filter({ hasText: marker });
-    await expect(sentLine).toHaveCount(1, { timeout: 10_000 });
+    // over WS, so the echo renders it.
+    const sentLine = await sendAndAwaitEcho(page, `#580 snap-on-fail ${Date.now()}`);
 
     // The pane snapped to the BOTTOM at submit time — NOT hostage to the POST.
     // RED pre-fix: the snap sat after the throwing await, so the view stayed
@@ -175,4 +205,44 @@ test.describe("issue #580 — own send snaps to the bottom independent of the PO
     );
     await expect(sentLine).toBeInViewport();
   });
+
+  test("the send-failure banner does not push the sent row under the fold (case 2, #778)", async ({
+    page,
+  }) => {
+    if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+
+    await installFailingSendPost(page, true);
+    await arriveParkedOnMarker(page, CHANNEL);
+
+    const sentLine = await sendAndAwaitEcho(page, `#778 snap-under-banner ${Date.now()}`);
+
+    // The pane has tail-followed the echo; the failure is still parked.
+    await expect.poll(async () => await distanceToBottom(page)).toBeLessThanOrEqual(
+      SCROLL_BOTTOM_THRESHOLD_PX,
+    );
+    await expect(sentLine).toBeInViewport();
+
+    // NOW let the POST fail. The `.compose-box-error` line mounts below the pane
+    // and shrinks the scroll container by its own height — moving the fold up
+    // over the row we just proved visible.
+    await page.evaluate(() => window.__grappa778ReleaseSend?.());
+    await expect(page.locator(".compose-box-error")).toBeVisible();
+
+    // RED pre-#778: the tail re-anchor lived only on window/visualViewport
+    // `resize`, which a shell-internal box change never fires, so the pane
+    // stayed short of the tail by the banner's height and the row was clipped —
+    // while distance-to-tail still read "at the bottom" (the shrink is under the
+    // 50px threshold but taller than a row). GREEN: the container ResizeObserver
+    // re-pins a follower to the tail on any box change.
+    await expect(sentLine).toBeInViewport();
+    await expect.poll(async () => await distanceToBottom(page)).toBeLessThanOrEqual(
+      SCROLL_BOTTOM_THRESHOLD_PX,
+    );
+  });
 });
+
+declare global {
+  interface Window {
+    __grappa778ReleaseSend?: () => void;
+  }
+}

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -1793,12 +1793,37 @@ const ScrollbackPane: Component<Props> = (props) => {
     // fires → gate recomputes); (3) the post-mount settle timer below, an
     // event-independent re-measure for the no-box-change settle.
     let overflowObserver: ResizeObserver | undefined;
+    let lastContainerHeight: number | null = null;
     if (listRef && typeof ResizeObserver !== "undefined") {
+      lastContainerHeight = listRef.clientHeight;
       overflowObserver = new ResizeObserver(() => {
         measureOverflow();
         // #360 — a container box change (flex-chain propagation with no `resize`
         // event) also moves the fold; keep the mention badge in step here too.
         recomputeMentionsBelow();
+        // #778 — and a moved fold must RE-PIN a follower to the tail, exactly as
+        // the `onResize` arm above does. The window/visualViewport events fire
+        // only for VIEWPORT changes; chrome growing inside the shell shrinks THIS
+        // box with no event at all — measured on the #580 e2e, the 25px
+        // `.compose-box-error` line mounting after the tail write left the pane
+        // 32px short of the tail with the just-sent row clipped under the fold
+        // (an intermittent "own send does not scroll" in the field). Same gate
+        // (`followMode`, the follow INTENT: a reader parked above the tail is
+        // preserved), same verb, same precedence — the RO is simply the honest
+        // signal for the class the event arm cannot see.
+        //
+        // Height-CHANGE gated: RO also delivers a callback on observe() and on
+        // width-only changes, neither of which moves the fold, and tail-snapping
+        // there would fight the cold-mount marker activation.
+        //
+        // `withHide: false` (the resize arm passes true): this fires on every
+        // composer growth, and the #130 visibility hide would blink the whole
+        // pane on each wrapped line. The rAF×2 correction lands two frames later
+        // with no intervening reader-visible wrong-scroll state to hide.
+        const height = listRef?.clientHeight ?? null;
+        const moved = lastContainerHeight !== null && height !== lastContainerHeight;
+        lastContainerHeight = height;
+        if (moved && followMode()) applyActivation("tail-only", false);
       });
       overflowObserver.observe(listRef);
     }

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -4468,6 +4468,79 @@ describe("ScrollbackPane", () => {
     });
   });
 
+  // #778 — a container BOX change moves the fold, so a follower must be re-pinned
+  // to the tail. The window/visualViewport `resize` arm already does this, but
+  // chrome growing INSIDE the shell (the compose-box send-error line, a wrapping
+  // composer) shrinks this box with NO resize event: measured on the #580 e2e, a
+  // 25px `.compose-box-error` mounting after the tail write left the pane 32px
+  // short of the tail with the just-sent row clipped under it.
+  describe("#778 — a container box change re-pins a follower to the tail", () => {
+    const flushRaf = async (): Promise<void> => {
+      await new Promise((r) =>
+        requestAnimationFrame(() => requestAnimationFrame(() => r(undefined))),
+      );
+    };
+
+    const renderWithFakeRO = async (): Promise<{
+      pane: HTMLDivElement;
+      fire: () => void;
+      scrollIntoViewSpy: ReturnType<typeof vi.fn>;
+    }> => {
+      let roCallback: ResizeObserverCallback | undefined;
+      class FakeResizeObserver {
+        constructor(cb: ResizeObserverCallback) {
+          roCallback = cb;
+        }
+        observe(): void {}
+        unobserve(): void {}
+        disconnect(): void {}
+      }
+      vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+      const scrollIntoViewSpy = vi.fn();
+      // biome-ignore lint/suspicious/noExplicitAny: jsdom Element type compat
+      (Element.prototype as any).scrollIntoView = scrollIntoViewSpy;
+      setScrollback({ "freenode #grappa": fixture });
+      const { container } = render(() => (
+        <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+      ));
+      const pane = container.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+      if (!pane) throw new Error("scrollback DOM not found");
+      // No read cursor → no divider → the cold-mount activation tails and arms
+      // followMode from the (jsdom 0/0 ⇒ at-bottom) geometry.
+      await flushRaf();
+      scrollIntoViewSpy.mockClear();
+      return { pane, fire: () => roCallback?.([], {} as ResizeObserver), scrollIntoViewSpy };
+    };
+
+    it("re-pins the tail when the container SHRINKS under a follower", async () => {
+      try {
+        const { pane, fire, scrollIntoViewSpy } = await renderWithFakeRO();
+        // The shell chrome grew below the pane: same content, shorter box.
+        Object.defineProperty(pane, "scrollHeight", { value: 1650, configurable: true });
+        Object.defineProperty(pane, "clientHeight", { value: 187, configurable: true });
+        fire();
+        await flushRaf();
+        expect(scrollIntoViewSpy).toHaveBeenCalledWith({ block: "end" });
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    });
+
+    it("does NOT scroll when the box did not change (the observe() baseline callback)", async () => {
+      try {
+        const { fire, scrollIntoViewSpy } = await renderWithFakeRO();
+        // ResizeObserver delivers a callback on observe() with the CURRENT size;
+        // a width-only change fires one too. Neither moved the fold, and
+        // tail-snapping on them would fight the cold-mount marker activation.
+        fire();
+        await flushRaf();
+        expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    });
+  });
+
   // #230 (mobile) — the pure underfill-rescue DECISION seam. Both the desktop
   // wheel path and the mobile touch path funnel through this one function
   // (implement-once); it is the CORE proof because Playwright's webkit project

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -28727,3 +28727,52 @@ it covers and watching only it fall — including a control case that fails
 loudly if the "full page" the stale-probe case releases ever stops being full,
 which would otherwise turn that assertion into one about a branch nobody
 entered.
+
+## 2026-08-04 — #778: the fold moves when the pane's own box moves, not only when the viewport does
+
+The #580 case-1 e2e failed roughly 2 in 60 with a shape no flake rate explains.
+The pane reported itself AT the bottom — distance-to-tail 32px, inside the 50px
+threshold — while the row just sent sat clipped under the fold, resolved by the
+locator on every retry, a real node with a real `data-msg-id`. Not a missing
+message, and not a snap that never fired.
+
+Measured on a reproduction, both failures byte-identical: `scrollTop` 1431,
+`scrollHeight` 1650, `clientHeight` **187** where the same container measured
+212 while the rows were being committed. The `.compose-box-error` "send failed"
+line is 25px tall, mounts BELOW the pane, and shrinks the scroll container by
+its own height. It landed AFTER the tail-follow write, so the pane was left
+short of the tail by exactly the shrink: under the 50px "at the bottom"
+threshold, and taller than a 21px row. Both quantities are needed to produce the
+paradox — a threshold coarser than a row is what lets "at the bottom" and "the
+newest row is invisible" be true at once.
+
+**The re-anchor already existed, on the wrong signal.** The onMount
+`window`/`visualViewport` `resize` arm re-pins a follower whenever the fold
+moves (#253 / UX-6 D9). Those events fire only for VIEWPORT changes. Chrome
+growing INSIDE the shell — the send-error line, a composer wrapping to a second
+line — moves the fold with no event whatsoever. The #285 container
+ResizeObserver is the honest signal for that whole class, and it was already
+carrying the same reasoning twice: the touch-action gate rides it (#285) and the
+mention-below-fold badge rides it (#360), both because a box change moves the
+fold. The tail re-anchor was simply never added. So the fix widens an existing
+rule to the class it always belonged to — same gate (`followMode`, the follow
+INTENT, so a reader parked above the tail is still preserved), same verb, same
+precedence — rather than introducing a second anchoring authority.
+
+Two deliberate details. The write is height-CHANGE gated: ResizeObserver
+delivers a callback on `observe()` and on width-only changes, neither of which
+moves the fold, and tail-snapping on them would fight the cold-mount marker
+activation. And it passes `withHide: false`, unlike the resize arm: this trigger
+fires on every composer growth, so the #130 visibility hide would blink the
+whole pane once per wrapped line, while the correction it protects lands two
+frames later with nothing reader-visible in between.
+
+**On proving a race.** The natural rate (2/60) cannot tell a fix from luck, and
+the first displacement attempt failed instructively: delaying the POST rejection
+by 400ms made the test pass 10/10, because the banner then mounted AFTER the
+assertion had already succeeded. Displacing the EVENT is not enough when the
+observation window moves with it. The spec now pins the ordering with a released
+gate rather than a delay — the send POST is held until the pane has tail-followed
+the echo, then released — which is deterministic without waiting on wall-clock:
+10/10 red before the fix, 10/10 green after, where case 1 stayed green through
+all six of those pre-fix runs.


### PR DESCRIPTION
Refs #778.

## What it was

The #580 case-1 e2e failed ~2 in 60 with a shape no rate explains: the pane
reported itself AT the bottom (distance-to-tail 32px, inside the 50px
threshold) while the just-sent row sat clipped under the fold, resolved by the
locator on every retry. Not a missing message, not a snap that never fired.

Measured, both failures byte-identical: `scrollTop` 1431, `scrollHeight` 1650,
`clientHeight` **187** where the same container measured 212 while the rows
were committing. The `.compose-box-error` "send failed" line is 25px tall,
mounts BELOW the pane and shrinks the scroll container by its own height. It
landed AFTER the tail-follow write, so the pane was left short of the tail by
exactly the shrink — under the 50px "at the bottom" threshold, and taller than
a 21px row. Both quantities are needed for the paradox: a threshold coarser
than a row is what lets "at the bottom" and "the newest row is invisible" both
be true.

The standing hypothesis in the issue (a #700/#693 tail anchor re-anchoring
after the WS row lands) is **falsified by the timeline**: there was exactly ONE
scroll write, and it was short — nothing re-anchored late.

## The fix

The re-anchor already existed, on the wrong signal. The onMount
`window`/`visualViewport` `resize` arm re-pins a follower whenever the fold
moves; those events fire only for VIEWPORT changes. Chrome growing INSIDE the
shell moves the fold with no event at all. The #285 container ResizeObserver is
the honest signal for that class and already carries the same reasoning twice
(the touch-action gate, #285; the mention-below-fold badge, #360) — the tail
re-anchor was simply never added to it. Same gate (`followMode`, so a reader
parked above the tail is still preserved), same verb, same precedence: no
second anchoring authority.

Height-CHANGE gated (RO also fires on `observe()` and on width-only changes;
tail-snapping there would fight the cold-mount marker activation) and
`withHide: false` (this fires on every composer growth; the #130 hide would
blink the whole pane per wrapped line).

## Evidence

| run | code | result |
|---|---|---|
| case 1, unpinned ordering | pre-fix | 2 red / 60 |
| case 2, pinned ordering | pre-fix | **10 red / 10** |
| case 2, pinned ordering | post-fix | **10 green / 10** |
| case 2, pinned ordering | fix reverted in-tree | **3 red / 3** |
| cic vitest (full) | post-fix | 4219 / 4219 |

The first displacement attempt failed instructively and is recorded in
DESIGN_NOTES: delaying the POST rejection by 400ms made the test pass 10/10,
because the banner then mounted after the assertion had already succeeded.
Displacing the event is not enough when the observation window moves with it.
The spec now pins the ordering with a **released gate, not a delay** — the send
POST is held until the pane has tail-followed the echo, then released — so the
geometry is deterministic without waiting on wall-clock.

## Full-suite state (NOT green — read before merging)

Two back-to-back full runs on this branch, byte-identical code, both 2 failed /
597 passed, and the failing sets are **disjoint**:

* run 1 — `issue168-scroll-authority:169` (6.5s; #552's documented duration
  discriminant, green in 1.4s on run 2) + `m-z-admin-cluster-journey:89` (#512).
* run 2 — `issue580 case 1` + `issue253-kbd-resize-scroll-preserve:94 @webkit`
  (7.2s; no flake issue tracks it — context for #653).

On run 2's `issue580 case 1`: it failed at the **distance poll** (line 203,
Received 385), i.e. "the snap never fired" — the opposite failure mode from
#778, whose signature is at-bottom TRUE / in-viewport FALSE. By the same
discriminant that separates #778 from #552, that red is the load-sensitive
"snap never fired" population, not this bug. The #778 mode did not recur in
either full run, nor in 93 targeted iterations.

`issue168` and `issue253` were each green 10/10 in isolation on this branch.