### PR TITLE
test(#751): assert what the passkey/TOTP migrations REFUSE

### DIFF
--- a/test/grappa/migrations/add_user_passkeys_test.exs
+++ b/test/grappa/migrations/add_user_passkeys_test.exs
@@ -10,6 +10,12 @@ defmodule Grappa.Migrations.AddUserPasskeysTest do
   @totp_version 20_260_802_190_000
   @passkey_version 20_260_803_090_000
 
+  @timestamp "2026-01-01T00:00:00Z"
+  @user_a "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+  @user_b "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+  @key_1 "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
+  @key_2 "ffffffff-ffff-4fff-8fff-ffffffffffff"
+
   setup do
     path = Path.join(System.tmp_dir!(), "grappa-passkey-migration-#{System.unique_integer([:positive])}.db")
     Application.put_env(:grappa, SmokeRepo, database: path, pool_size: 1, foreign_keys: :on)
@@ -51,6 +57,134 @@ defmodule Grappa.Migrations.AddUserPasskeysTest do
     assert %{rows: [["disabled"]]} = query!("SELECT passkey_mode FROM users WHERE id = ?", [user_id])
     assert %{rows: [[^code_id, ^user_id]]} = query!("SELECT id,user_id FROM user_recovery_codes")
     assert %{rows: [[0]]} = query!("SELECT COUNT(*) FROM user_passkeys")
+  end
+
+  # Columns existing is not the claim worth making — the constraints are.
+  # These assert what the database REFUSES, in the shape of the incident
+  # each constraint exists to prevent, rather than reading the declaration
+  # back out of the catalogue. The smoke repo runs with `foreign_keys: :on`
+  # (see setup), so the FK is actually enforced here and not merely
+  # recorded.
+  describe "constraints the migration creates" do
+    setup %{migrations: migrations} do
+      assert [@passkey_version] =
+               Ecto.Migrator.run(SmokeRepo, migrations, :up, to: @passkey_version, log: false)
+
+      :ok
+    end
+
+    test "one credential id belongs to at most one account, across accounts" do
+      insert_user!(@user_a, "alice")
+      insert_user!(@user_b, "bob")
+      insert_passkey!(@key_1, @user_a, <<1, 2, 3>>)
+
+      # The incident: without `unique_index(:user_passkeys, [:credential_id])`
+      # two accounts hold the same credential id and
+      # `Repo.get_by(Passkey, credential_id: ..., user_id: ...)` starts
+      # resolving ambiguously. A unique index over [credential_id, user_id]
+      # would allow exactly this, so the second row must be someone ELSE's.
+      assert_raise Exqlite.Error, ~r/UNIQUE constraint failed: user_passkeys\.credential_id/, fn ->
+        insert_passkey!(@key_2, @user_b, <<1, 2, 3>>)
+      end
+    end
+
+    test "deleting an account takes its passkeys with it" do
+      insert_user!(@user_a, "alice")
+      insert_user!(@user_b, "bob")
+      insert_passkey!(@key_1, @user_a, <<1, 2, 3>>)
+      insert_passkey!(@key_2, @user_b, <<4, 5, 6>>)
+
+      query!("DELETE FROM users WHERE id = ?", [@user_a])
+
+      # Without `on_delete: :delete_all` this row outlives the account it
+      # authenticated — a live credential belonging to nobody.
+      assert %{rows: [[@key_2]]} = query!("SELECT id FROM user_passkeys")
+    end
+
+    test "every passkey column but the optional one is NOT NULL" do
+      # Asserted as a whole set, so a column losing `null: false` and a
+      # column gaining it are both loud. `id` is absent on purpose: SQLite
+      # does not imply NOT NULL for a non-INTEGER PRIMARY KEY, so the
+      # binary_id key reads as nullable here — a quirk of the engine, not
+      # a defect of this migration, and pinning it keeps the next reader
+      # from "fixing" it.
+      assert not_null_columns("user_passkeys") ==
+               MapSet.new(~w[
+                 user_id credential_id public_key sign_count name transports inserted_at updated_at
+               ])
+    end
+  end
+
+  # `change` is only as reversible as its least reversible step, and this
+  # migration's middle step is a table RENAME — the one most likely to
+  # strand a database halfway. Rolling back and forward proves the down
+  # path exists AND that the constraints come back with the second up:
+  # re-running the refusal is the assertion, because a table restored
+  # without its unique index would satisfy any column-shaped check.
+  test "down reverses the rename, the table and the column; up restores the constraint", %{
+    migrations: migrations
+  } do
+    insert_user!(@user_a, "alice")
+    assert [@passkey_version] = Ecto.Migrator.run(SmokeRepo, migrations, :up, to: @passkey_version, log: false)
+    insert_passkey!(@key_1, @user_a, <<1, 2, 3>>)
+
+    assert [@passkey_version] = Ecto.Migrator.run(SmokeRepo, migrations, :down, step: 1, log: false)
+
+    refute "user_passkeys" in tables()
+    refute "user_recovery_codes" in tables()
+    assert "user_totp_recovery_codes" in tables()
+    refute "passkey_mode" in columns("users")
+    assert %{rows: [["alice"]]} = query!("SELECT name FROM users WHERE id = ?", [@user_a])
+
+    assert [@passkey_version] = Ecto.Migrator.run(SmokeRepo, migrations, :up, to: @passkey_version, log: false)
+
+    assert "user_recovery_codes" in tables()
+    assert %{rows: [["disabled"]]} = query!("SELECT passkey_mode FROM users WHERE id = ?", [@user_a])
+
+    insert_user!(@user_b, "bob")
+    insert_passkey!(@key_1, @user_a, <<1, 2, 3>>)
+
+    assert_raise Exqlite.Error, ~r/UNIQUE constraint failed: user_passkeys\.credential_id/, fn ->
+      insert_passkey!(@key_2, @user_b, <<1, 2, 3>>)
+    end
+  end
+
+  defp insert_user!(id, name) do
+    query!("INSERT INTO users (id,name,password_hash,is_admin,inserted_at,updated_at) VALUES (?,?,?,?,?,?)", [
+      id,
+      name,
+      "hash",
+      0,
+      @timestamp,
+      @timestamp
+    ])
+  end
+
+  defp insert_passkey!(id, user_id, credential_id) do
+    query!(
+      """
+      INSERT INTO user_passkeys
+        (id,user_id,credential_id,public_key,sign_count,name,transports,inserted_at,updated_at)
+      VALUES (?,?,?,?,?,?,?,?,?)
+      """,
+      [id, user_id, credential_id, <<9, 9, 9>>, 0, "key", "{}", @timestamp, @timestamp]
+    )
+  end
+
+  defp not_null_columns(table) do
+    ~s|SELECT name FROM pragma_table_info(?) WHERE "notnull" = 1|
+    |> query!([table])
+    |> Map.fetch!(:rows)
+    |> List.flatten()
+    |> MapSet.new()
+  end
+
+  defp columns(table) do
+    "SELECT name FROM pragma_table_info(?)" |> query!([table]) |> Map.fetch!(:rows) |> List.flatten()
+  end
+
+  defp tables do
+    "SELECT name FROM sqlite_master WHERE type = 'table'" |> query!() |> Map.fetch!(:rows) |> List.flatten()
   end
 
   defp query!(sql, params \\ []), do: Ecto.Adapters.SQL.query!(SmokeRepo, sql, params)

--- a/test/grappa/migrations/add_user_totp_test.exs
+++ b/test/grappa/migrations/add_user_totp_test.exs
@@ -7,11 +7,20 @@ end
 defmodule Grappa.Migrations.AddUserTotpTest do
   use ExUnit.Case, async: false
 
+  alias Ecto.Adapters.SQL
   alias Grappa.TotpMigrationSmokeRepo, as: SmokeRepo
 
   @previous_version 20_260_729_130_000
   @totp_version 20_260_802_190_000
   @row_count 5_000
+
+  @timestamp "2026-01-01T00:00:00.000000Z"
+  @user_a "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+  @user_b "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+  @code_1 "e0000000-0000-4000-8000-000000000001"
+  @code_2 "e0000000-0000-4000-8000-000000000002"
+  @code_3 "e0000000-0000-4000-8000-000000000003"
+  @code_4 "e0000000-0000-4000-8000-000000000004"
 
   setup do
     path = Path.join(System.tmp_dir!(), "grappa-totp-migration-#{System.unique_integer([:positive])}.db")
@@ -79,6 +88,124 @@ defmodule Grappa.Migrations.AddUserTotpTest do
              query!("SELECT name, password_hash FROM users WHERE name = 'legacy-04200'").rows
   end
 
+  # The row-preservation test above proves the migration does not lose
+  # data. These prove the other half: that what it creates actually
+  # refuses. Stated as the incident each constraint prevents rather than
+  # as a reading of the catalogue — the smoke repo runs `foreign_keys: :on`
+  # (see setup), so the FK is enforced here and not merely declared.
+  describe "constraints the migration creates" do
+    setup %{migrations_path: migrations_path} do
+      assert [@totp_version] =
+               Ecto.Migrator.run(SmokeRepo, migrations_path, :up, to: @totp_version, log: false)
+
+      insert_user!(@user_a, "alice")
+      insert_user!(@user_b, "bob")
+
+      :ok
+    end
+
+    test "a recovery code is unique per account, not globally and not per account alone" do
+      insert_recovery_code!(@code_1, @user_a, <<1, 2, 3>>)
+
+      # Same account, different hash: an account holds ten of these, so a
+      # unique index on [user_id] alone would break enrollment outright.
+      insert_recovery_code!(@code_2, @user_a, <<4, 5, 6>>)
+
+      # Different account, same hash: two people may draw the same code
+      # and neither may lock the other out, so the index cannot be on
+      # [code_hash] alone either.
+      insert_recovery_code!(@code_3, @user_b, <<1, 2, 3>>)
+
+      # Same account, same hash: the one combination that must not exist,
+      # or a code already spent still opens the door.
+      assert_raise Exqlite.Error, ~r/UNIQUE constraint failed/, fn ->
+        insert_recovery_code!(@code_4, @user_a, <<1, 2, 3>>)
+      end
+    end
+
+    test "deleting an account takes its recovery codes with it" do
+      insert_recovery_code!(@code_1, @user_a, <<1, 2, 3>>)
+      insert_recovery_code!(@code_2, @user_b, <<4, 5, 6>>)
+
+      SQL.query!(SmokeRepo, "DELETE FROM users WHERE id = ?", [@user_a])
+
+      assert query!("SELECT id FROM user_totp_recovery_codes").rows == [[@code_2]]
+    end
+
+    test "every recovery-code column is NOT NULL" do
+      # Whole set, so a column losing `null: false` and a column gaining
+      # it are equally loud. `id` is absent on purpose: SQLite does not
+      # imply NOT NULL for a non-INTEGER PRIMARY KEY, so a binary_id key
+      # reads as nullable — an engine quirk, not a defect here.
+      assert not_null_columns("user_totp_recovery_codes") ==
+               MapSet.new(~w[user_id code_hash inserted_at])
+    end
+
+    test "down drops the table and the user columns; up restores the constraint", %{
+      migrations_path: migrations_path
+    } do
+      insert_recovery_code!(@code_1, @user_a, <<1, 2, 3>>)
+
+      assert [@totp_version] =
+               Ecto.Migrator.run(SmokeRepo, migrations_path, :down, step: 1, log: false)
+
+      refute "user_totp_recovery_codes" in tables()
+      refute "totp_secret_encrypted" in user_columns()
+      refute "totp_enabled_at" in user_columns()
+      refute "totp_last_used_step" in user_columns()
+      # The accounts outlive the rollback; only what this migration added
+      # goes away. Counted by id rather than in total, because the
+      # migration graph seeds a `system` user of its own.
+      assert [["alice"], ["bob"]] ==
+               SQL.query!(
+                 SmokeRepo,
+                 "SELECT name FROM users WHERE id IN (?,?) ORDER BY name",
+                 [@user_a, @user_b]
+               ).rows
+
+      assert [@totp_version] =
+               Ecto.Migrator.run(SmokeRepo, migrations_path, :up, to: @totp_version, log: false)
+
+      assert "totp_secret_encrypted" in user_columns()
+      insert_recovery_code!(@code_1, @user_a, <<1, 2, 3>>)
+
+      # The table came back — but a table restored without its unique
+      # index would satisfy any column-shaped check, so the refusal is
+      # the assertion.
+      assert_raise Exqlite.Error, ~r/UNIQUE constraint failed/, fn ->
+        insert_recovery_code!(@code_2, @user_a, <<1, 2, 3>>)
+      end
+    end
+  end
+
+  defp insert_user!(id, name) do
+    SQL.query!(
+      SmokeRepo,
+      "INSERT INTO users (id, name, password_hash, is_admin, inserted_at, updated_at) VALUES (?,?,?,?,?,?)",
+      [id, name, "hash", 0, @timestamp, @timestamp]
+    )
+  end
+
+  defp insert_recovery_code!(id, user_id, code_hash) do
+    SQL.query!(
+      SmokeRepo,
+      "INSERT INTO user_totp_recovery_codes (id, user_id, code_hash, inserted_at) VALUES (?,?,?,?)",
+      [id, user_id, code_hash, @timestamp]
+    )
+  end
+
+  defp not_null_columns(table) do
+    SmokeRepo
+    |> SQL.query!(~s|SELECT name FROM pragma_table_info(?) WHERE "notnull" = 1|, [table])
+    |> Map.fetch!(:rows)
+    |> List.flatten()
+    |> MapSet.new()
+  end
+
+  defp tables do
+    "SELECT name FROM sqlite_master WHERE type = 'table'" |> query!() |> Map.fetch!(:rows) |> List.flatten()
+  end
+
   defp seed_legacy_rows do
     query!("""
     WITH RECURSIVE n(value) AS (
@@ -123,5 +250,5 @@ defmodule Grappa.Migrations.AddUserTotpTest do
     value
   end
 
-  defp query!(sql), do: Ecto.Adapters.SQL.query!(SmokeRepo, sql, [])
+  defp query!(sql), do: SQL.query!(SmokeRepo, sql, [])
 end


### PR DESCRIPTION
Issue #751. Both cited sites verified against current main (`fa519aa7`)
before writing: the tests really do stop at tables-and-columns, no
constraint is asserted anywhere, and neither file runs `:down` or a
second `:up`. Nothing here was already dead.

## Shape of the assertions

Behavioural, not catalogue reads. A `PRAGMA index_list` assertion only
confirms the declaration was written; what matters is that SQLite
**refuses**. So each test performs the incident the constraint exists to
prevent and demands the error — the shape `check_constraints_test.exs`
already established in this repo. Both smoke repos run
`foreign_keys: :on`, so the FK is genuinely enforced here rather than
merely recorded.

- `unique_index(:user_passkeys, [:credential_id])` — a second account
  claiming the same credential id must be refused. That is exactly the
  issue's scenario, and it also rules out a unique over
  `[credential_id, user_id]`, which would permit it.
- the `on_delete: :delete_all` FK — deleting an account must take its
  passkeys with it, with a second account's key left standing as the
  control.
- `unique_index(:user_totp_recovery_codes, [:user_id, :code_hash])` —
  **three inserts, not one.** A duplicate rejection alone is also
  satisfied by a unique on `[user_id]` (which would break enrollment,
  since an account holds ten codes) and by one on `[code_hash]` (which
  would let one account lock another out). Same account/different hash
  and different account/same hash must both be ACCEPTED for the
  composite to be pinned. Both narrowings are in the matrix below.
- `null: false` — the one PRAGMA read. Seven inserts to prove seven
  columns would be noise; asserted as a whole set so a column losing the
  constraint and a column gaining it are equally loud.

## Reversibility: verified before tested, not assumed

The brief was right to flag this. Both migrations are `change`, and the
passkey one's middle step is a table RENAME
(`user_totp_recovery_codes` → `user_recovery_codes`) — the step most
likely to strand a database halfway. I probed it first: it reverses
cleanly, `:down, step: 1` restores the old name, drops `user_passkeys`
and removes `passkey_mode`, and a second `:up` replays. So both files now
round-trip **up → down → up**, and the second up re-runs the *refusal*
rather than re-checking columns — a table restored without its unique
index would satisfy any column-shaped check.

The 5000-row survival check in `add_user_totp_test.exs` is untouched;
everything here sits beside it.

## Mutation matrix

Each applied to the migration, run, reverted. 10 tests across both files.

| mutation | red |
| --- | --- |
| drop `unique_index(:user_passkeys, [:credential_id])` | "one credential id belongs to at most one account" + the passkey round trip |
| passkey FK `on_delete: :delete_all` → `:nothing` | "deleting an account takes its passkeys with it" |
| drop `null: false` from `user_passkeys.credential_id` | "every passkey column but the optional one is NOT NULL" |
| drop `unique_index(:user_totp_recovery_codes, [:user_id, :code_hash])` | "a recovery code is unique per account…" + the TOTP round trip |
| narrow that index to `[:user_id]` | "a recovery code is unique per account…" |
| narrow that index to `[:code_hash]` | "a recovery code is unique per account…" |
| recovery FK `on_delete: :delete_all` → `:nothing` | "deleting an account takes its recovery codes with it" |

No collateral reds. The two round-trip tests going red alongside their
constraint test is intended: they re-assert the same refusal after the
replay, which is the point of the second `:up`.

## Two facts worth recording

- **The rename does not rename the index.** After
  `user_totp_recovery_codes` → `user_recovery_codes`, the unique index is
  still called `user_totp_recovery_codes_user_id_code_hash_index`. That
  is why nothing here asserts index *names*.
- **SQLite does not imply NOT NULL for a non-INTEGER PRIMARY KEY**, so
  the `binary_id` `id` column reads as nullable in `pragma_table_info`.
  An engine quirk, not a defect of these migrations — pinned by omission
  from the expected set, with a comment, so the next reader does not
  "fix" it.

## Gate

`scripts/check.sh` rc=0 from the worktree root: credo `found no issues`,
dialyzer `Total errors: 0` / `done (passed successfully)`, doctor passed,
sobelow clean, ExUnit `8 doctests, 50 properties, 5112 tests, 0 failures`,
bats 0 not-ok. Both migration files also run green 3× in isolation.

Test-only change; no production code and no migration is modified.