### PR TITLE
cic(#818): refuse a /me hydration that outlived its identity

### DIFF
--- a/cicchetto/src/__tests__/networks.test.ts
+++ b/cicchetto/src/__tests__/networks.test.ts
@@ -529,5 +529,60 @@ describe("networks resources", () => {
         expect(networks.channelsBySlug()).toEqual({});
       });
     });
+
+    // #818 — the identity TRANSITION was already purged (the arm above, plus
+    // readCursor's own `on(token)`); what leaked is a write arriving AFTER it.
+    // `createResource` drops the stale VALUE but cannot cancel the await, so
+    // the fetcher's side-effects still run when account A's `/me` settles
+    // post-rotation — seeding B's cursor map (and badge) with A's numbers.
+    it("a /me still in flight from the OLD identity hydrates neither cursors nor badge", async () => {
+      localStorage.setItem("grappa-token", "tok-a");
+      await seedStubs();
+      const api = await import("../lib/api");
+      const auth = await import("../lib/auth");
+      const networks = await import("../lib/networks");
+      const readCursor = await import("../lib/readCursor");
+      const badge = await import("../lib/badge");
+
+      let releaseA: ((m: MeResponse) => void) | undefined;
+      const meA = new Promise<MeResponse>((resolve) => {
+        releaseA = resolve;
+      });
+      vi.mocked(api.me).mockImplementation((t: string) =>
+        t === "tok-a"
+          ? meA
+          : Promise.resolve({
+              kind: "user",
+              id: "u2",
+              name: "bob",
+              is_admin: false,
+              inserted_at: "x",
+              read_cursors: {},
+              badge_count: 0,
+            } as MeResponse),
+      );
+      networks.refetchUser();
+
+      auth.setToken("tok-b");
+      await vi.waitFor(() => {
+        expect(networks.user()?.id).toBe("u2");
+      });
+
+      releaseA?.({
+        kind: "user",
+        id: "u1",
+        name: "alice",
+        is_admin: false,
+        inserted_at: "x",
+        read_cursors: { freenode: { "#grappa": 5000 } },
+        badge_count: 42,
+      } as MeResponse);
+      await meA;
+      await Promise.resolve();
+
+      expect(readCursor.getReadCursor("freenode", "#grappa")).toBeNull();
+      // Same await, same leak: the badge seed is guarded by the same check.
+      expect(badge.badgeCount()).toBe(0);
+    });
   });
 });

--- a/cicchetto/src/__tests__/readCursor.test.ts
+++ b/cicchetto/src/__tests__/readCursor.test.ts
@@ -243,6 +243,56 @@ describe("readCursor", () => {
     expect(getReadCursor("freenode", "#cicchetto")).toBeNull();
   });
 
+  // #818 — the `on(token)` arm at the foot of the module, which the file
+  // header has claimed as covered (point 7) since C7.3 without a case behind
+  // it: deleting the arm outright left all 25 cases green, and the whole
+  // 4217-test suite too. Read state is server-owned per (subject, network,
+  // channel), so this map is a per-subject CACHE; nothing but this arm tells
+  // it the subject changed. Without it A's cursors are applied to B's windows
+  // — B's unread backlog renders as already read, and A's lower cursor on B's
+  // window can drive a spurious MARKREAD upstream.
+  describe("#818 — identity-transition arm", () => {
+    it("wipes the map on a token ROTATION (A → B)", async () => {
+      const { setToken } = await import("../lib/auth");
+      const { applyMeEnvelope, getReadCursor } = await import("../lib/readCursor");
+      setToken("tok-a");
+      applyMeEnvelope({ freenode: { "#grappa": 5000 } });
+      expect(getReadCursor("freenode", "#grappa")).toBe(5000);
+
+      setToken("tok-b");
+
+      expect(getReadCursor("freenode", "#grappa")).toBeNull();
+    });
+
+    it("wipes the map on LOGOUT (A → null)", async () => {
+      const { setToken } = await import("../lib/auth");
+      const { applyMeEnvelope, getReadCursor } = await import("../lib/readCursor");
+      setToken("tok-a");
+      applyMeEnvelope({ freenode: { "#grappa": 5000 } });
+
+      setToken(null);
+
+      expect(getReadCursor("freenode", "#grappa")).toBeNull();
+    });
+
+    it("KEEPS the map on the cold-start login (null → A)", async () => {
+      // The `prev != null` half of the filter. A cold login must not wipe what
+      // the /me hydration seeded moments earlier in the same flush — the
+      // envelope lands before the token settles on some boot paths.
+      const { setToken } = await import("../lib/auth");
+      const { applyMeEnvelope, getReadCursor, clearReadCursors } = await import(
+        "../lib/readCursor"
+      );
+      setToken(null);
+      clearReadCursors();
+      applyMeEnvelope({ freenode: { "#grappa": 5000 } });
+
+      setToken("tok-a");
+
+      expect(getReadCursor("freenode", "#grappa")).toBe(5000);
+    });
+  });
+
   describe("Solid reactivity (unread-marker bug fix)", () => {
     it("getReadCursor is tracked: applyReadCursorSet invalidates a Solid effect", async () => {
       // Repro for the unread-marker pinning bug. ScrollbackPane's `rows`

--- a/cicchetto/src/lib/networks.ts
+++ b/cicchetto/src/lib/networks.ts
@@ -67,6 +67,27 @@ const exports = identityScopedStore((onIdentityChange) => {
   >(token, async (t) => {
     if (!t) return null;
     const m = await me(t);
+    // #818 — refuse to hydrate for an identity that is no longer current.
+    // `createResource` discards the stale VALUE (a rotation refetches and only
+    // the latest promise feeds `user()`), but it cannot cancel an await: the
+    // two SIDE-EFFECTS below run whenever this promise settles, even seconds
+    // after the token rotated. Both write module-global caches keyed by
+    // nothing but (slug, channel), so account A's `/me` landing after the
+    // switch seeds B's cursors and B's badge with A's numbers. The cursor half
+    // is the worse one: a channel B has never read gets a `read_cursor: null`
+    // join reply, which `applyJoinReply` deliberately no-ops on, so A's value
+    // is never corrected — B's backlog renders as already seen, and the
+    // inverse (A's lower cursor on B's window) can drive a spurious MARKREAD.
+    //
+    // The identity-TRANSITION is already handled (readCursor's own `on(token)`
+    // arm and the `onIdentityChange` purge below both fire on rotation); what
+    // was missing is refusing a write that arrives AFTER the purge. Same rule
+    // and same predicate as #788's `identityMoved` in `scrollback.ts`: check
+    // after the await, not in front of the request. Kept in the caller rather
+    // than inside `applyMeEnvelope` because the check guards the whole block —
+    // `setBadge` shares this await and this bug — and because `readCursor`
+    // cannot know which identity produced an envelope handed to it.
+    if (token() !== t) return m;
     // CP29 R-4: hydrate the readCursor signal map from the bulk envelope
     // BEFORE downstream consumers (subscribe.ts join effects, etc.)
     // observe `user()` and start joining channel topics. The join-reply


### PR DESCRIPTION
Refs #818.

## The reported defect is not live — verified on the file, at `fa519aa7`

The issue says readCursor's map survives a rotation because the nine
`onIdentityChange` resets do not cover it. The premise is right (the module
does not use the factory) but the conclusion is not: `readCursor.ts` has
carried **its own** `on(token)` arm since C7.3, and its predicate is the
factory's, line for line —

```
if (prev != null && t !== prev) clearReadCursors();   // readCursor.ts
if (prev != null && t !== prev) for (const r of resets) r();   // identityScopedStore.ts
```

So neither offered option changes behaviour: **(a)** routing through the
factory and **(b)** an explicit purge both address the identity TRANSITION,
and the transition already purges. The open persistence question dissolves
too — the map is memory-only and the legacy `rc:` localStorage keys are
purged at module load, so "persist across a reload for the same identity" is
already answered *no* by construction. No product decision to make here; had
there been one I'd have stopped and asked.

## What IS live: the write that lands after the purge

`networks.ts`'s `/me` fetcher is keyed on `token`. `createResource` discards
a stale VALUE, but it cannot cancel an await — when account A's `/me` settles
past a rotation, the fetcher's side-effects still run.

Measured, not argued: hold A's `/me`, rotate to B, then release A, and
`getReadCursor("freenode", "#grappa")` is **5000 — A's cursor, under B**.
And it is never corrected: a channel B has never read answers the join reply
with `read_cursor: null`, which `applyJoinReply` deliberately no-ops on. The
same await carries `setBadge`, so B inherits A's badge count as well. That is
precisely the issue's failure scenario, reached through a door the issue did
not name: state **in flight**, not state at rest.

This is #788's shape, so it takes #788's rule — *check after the await, not
in front of the request*. The check sits in the caller rather than inside
`applyMeEnvelope` because (1) it guards the whole side-effect block, badge
included, and (2) `readCursor` cannot know which identity produced an
envelope handed to it. **The condition that would flip that choice:** a
second caller of `applyMeEnvelope`. Then the guard must move inside with the
captured token in its signature — the way `setReadCursor` already owns its
virtual-window and positive-int guards so every caller inherits them. Today
there is exactly one caller.

I did **not** extract `identityMoved` into a shared helper: it would be the
fourth inline site (`scrollback.ts`, `displayPrefs`, `customTheme`), and
"total consistency or nothing" means migrating all four in one pass — a
cross-module refactor outside this perimeter and poor timing during a freeze.
Worth doing as its own change.

## A second, quieter defect: the arm was never covered

`readCursor.test.ts`'s header has listed *"7. on(token) cleanup arm wipes on
logout/rotation"* since C7.3. There is no such case. Deleting the arm
outright leaves all 25 readCursor tests green — and the **entire 4217-test
suite** green. The one thing standing between the cache and the reported bug
had zero protection. Three cases now pin it: rotation, logout, and the
cold-start login that the `prev != null` half must NOT wipe.

## Mutation proof (one at a time, against the full suite)

| mutation | result |
|---|---|
| remove `on(token)` arm in `readCursor.ts` | **2 failed** — exactly the rotation + logout cases (4219 pass) |
| remove `if (token() !== t)` in `networks.ts` | **1 failed** — exactly the hydration case (4220 pass) |
| neither (shipped state) | 4221 / 4221 |

`bun run check` (biome + tsc) and `bun run build` both clean.