### PR TITLE
union: #749 + #751 + #818 gated together

### DIFF
--- a/cicchetto/src/__tests__/networks.test.ts
+++ b/cicchetto/src/__tests__/networks.test.ts
@@ -529,5 +529,60 @@ describe("networks resources", () => {
         expect(networks.channelsBySlug()).toEqual({});
       });
     });
+
+    // #818 — the identity TRANSITION was already purged (the arm above, plus
+    // readCursor's own `on(token)`); what leaked is a write arriving AFTER it.
+    // `createResource` drops the stale VALUE but cannot cancel the await, so
+    // the fetcher's side-effects still run when account A's `/me` settles
+    // post-rotation — seeding B's cursor map (and badge) with A's numbers.
+    it("a /me still in flight from the OLD identity hydrates neither cursors nor badge", async () => {
+      localStorage.setItem("grappa-token", "tok-a");
+      await seedStubs();
+      const api = await import("../lib/api");
+      const auth = await import("../lib/auth");
+      const networks = await import("../lib/networks");
+      const readCursor = await import("../lib/readCursor");
+      const badge = await import("../lib/badge");
+
+      let releaseA: ((m: MeResponse) => void) | undefined;
+      const meA = new Promise<MeResponse>((resolve) => {
+        releaseA = resolve;
+      });
+      vi.mocked(api.me).mockImplementation((t: string) =>
+        t === "tok-a"
+          ? meA
+          : Promise.resolve({
+              kind: "user",
+              id: "u2",
+              name: "bob",
+              is_admin: false,
+              inserted_at: "x",
+              read_cursors: {},
+              badge_count: 0,
+            } as MeResponse),
+      );
+      networks.refetchUser();
+
+      auth.setToken("tok-b");
+      await vi.waitFor(() => {
+        expect(networks.user()?.id).toBe("u2");
+      });
+
+      releaseA?.({
+        kind: "user",
+        id: "u1",
+        name: "alice",
+        is_admin: false,
+        inserted_at: "x",
+        read_cursors: { freenode: { "#grappa": 5000 } },
+        badge_count: 42,
+      } as MeResponse);
+      await meA;
+      await Promise.resolve();
+
+      expect(readCursor.getReadCursor("freenode", "#grappa")).toBeNull();
+      // Same await, same leak: the badge seed is guarded by the same check.
+      expect(badge.badgeCount()).toBe(0);
+    });
   });
 });

--- a/cicchetto/src/__tests__/readCursor.test.ts
+++ b/cicchetto/src/__tests__/readCursor.test.ts
@@ -243,6 +243,56 @@ describe("readCursor", () => {
     expect(getReadCursor("freenode", "#cicchetto")).toBeNull();
   });
 
+  // #818 — the `on(token)` arm at the foot of the module, which the file
+  // header has claimed as covered (point 7) since C7.3 without a case behind
+  // it: deleting the arm outright left all 25 cases green, and the whole
+  // 4217-test suite too. Read state is server-owned per (subject, network,
+  // channel), so this map is a per-subject CACHE; nothing but this arm tells
+  // it the subject changed. Without it A's cursors are applied to B's windows
+  // — B's unread backlog renders as already read, and A's lower cursor on B's
+  // window can drive a spurious MARKREAD upstream.
+  describe("#818 — identity-transition arm", () => {
+    it("wipes the map on a token ROTATION (A → B)", async () => {
+      const { setToken } = await import("../lib/auth");
+      const { applyMeEnvelope, getReadCursor } = await import("../lib/readCursor");
+      setToken("tok-a");
+      applyMeEnvelope({ freenode: { "#grappa": 5000 } });
+      expect(getReadCursor("freenode", "#grappa")).toBe(5000);
+
+      setToken("tok-b");
+
+      expect(getReadCursor("freenode", "#grappa")).toBeNull();
+    });
+
+    it("wipes the map on LOGOUT (A → null)", async () => {
+      const { setToken } = await import("../lib/auth");
+      const { applyMeEnvelope, getReadCursor } = await import("../lib/readCursor");
+      setToken("tok-a");
+      applyMeEnvelope({ freenode: { "#grappa": 5000 } });
+
+      setToken(null);
+
+      expect(getReadCursor("freenode", "#grappa")).toBeNull();
+    });
+
+    it("KEEPS the map on the cold-start login (null → A)", async () => {
+      // The `prev != null` half of the filter. A cold login must not wipe what
+      // the /me hydration seeded moments earlier in the same flush — the
+      // envelope lands before the token settles on some boot paths.
+      const { setToken } = await import("../lib/auth");
+      const { applyMeEnvelope, getReadCursor, clearReadCursors } = await import(
+        "../lib/readCursor"
+      );
+      setToken(null);
+      clearReadCursors();
+      applyMeEnvelope({ freenode: { "#grappa": 5000 } });
+
+      setToken("tok-a");
+
+      expect(getReadCursor("freenode", "#grappa")).toBe(5000);
+    });
+  });
+
   describe("Solid reactivity (unread-marker bug fix)", () => {
     it("getReadCursor is tracked: applyReadCursorSet invalidates a Solid effect", async () => {
       // Repro for the unread-marker pinning bug. ScrollbackPane's `rows`

--- a/cicchetto/src/lib/networks.ts
+++ b/cicchetto/src/lib/networks.ts
@@ -67,6 +67,27 @@ const exports = identityScopedStore((onIdentityChange) => {
   >(token, async (t) => {
     if (!t) return null;
     const m = await me(t);
+    // #818 — refuse to hydrate for an identity that is no longer current.
+    // `createResource` discards the stale VALUE (a rotation refetches and only
+    // the latest promise feeds `user()`), but it cannot cancel an await: the
+    // two SIDE-EFFECTS below run whenever this promise settles, even seconds
+    // after the token rotated. Both write module-global caches keyed by
+    // nothing but (slug, channel), so account A's `/me` landing after the
+    // switch seeds B's cursors and B's badge with A's numbers. The cursor half
+    // is the worse one: a channel B has never read gets a `read_cursor: null`
+    // join reply, which `applyJoinReply` deliberately no-ops on, so A's value
+    // is never corrected — B's backlog renders as already seen, and the
+    // inverse (A's lower cursor on B's window) can drive a spurious MARKREAD.
+    //
+    // The identity-TRANSITION is already handled (readCursor's own `on(token)`
+    // arm and the `onIdentityChange` purge below both fire on rotation); what
+    // was missing is refusing a write that arrives AFTER the purge. Same rule
+    // and same predicate as #788's `identityMoved` in `scrollback.ts`: check
+    // after the await, not in front of the request. Kept in the caller rather
+    // than inside `applyMeEnvelope` because the check guards the whole block —
+    // `setBadge` shares this await and this bug — and because `readCursor`
+    // cannot know which identity produced an envelope handed to it.
+    if (token() !== t) return m;
     // CP29 R-4: hydrate the readCursor signal map from the bulk envelope
     // BEFORE downstream consumers (subscribe.ts join effects, etc.)
     // observe `user()` and start joining channel topics. The join-reply

--- a/test/grappa/accounts/totp_test.exs
+++ b/test/grappa/accounts/totp_test.exs
@@ -115,13 +115,34 @@ defmodule Grappa.Accounts.TOTPTest do
     assert %DateTime{} = Repo.get!(Session, other.id).revoked_at
   end
 
-  test "new enrollment URI contains issuer, account, and secret" do
+  # The label is what an authenticator app puts under the user's thumb, so
+  # it has to name the ACCOUNT, not merely be present: built from `user.id`
+  # instead of `user.name` the URI still parses, still carries the issuer,
+  # still round-trips the secret, and every enrolled account shows up as a
+  # UUID. The parameters are pinned for the same reason — RFC 6238 leaves
+  # SHA1/6/30 as defaults, but `code_at/2` is not written against defaults,
+  # so a URI that omits or contradicts them enrolls an app that computes
+  # codes this server will refuse.
+  test "new enrollment URI labels the account and pins the RFC 6238 parameters" do
     user = user_fixture(name: "alice")
     enrollment = TOTP.new_enrollment(user, "Grappa (irc.example)")
 
-    assert String.starts_with?(enrollment.provisioning_uri, "otpauth://totp/")
-    assert enrollment.provisioning_uri =~ "issuer=Grappa+%28irc.example%29"
-    assert enrollment.provisioning_uri =~ "secret=#{enrollment.secret}"
+    assert %URI{scheme: "otpauth", host: "totp", path: path, query: query} =
+             URI.parse(enrollment.provisioning_uri)
+
+    assert URI.decode(path) == "/Grappa (irc.example):alice"
+
+    params = URI.decode_query(query)
+    assert params["issuer"] == "Grappa (irc.example)"
+    assert params["algorithm"] == "SHA1"
+    assert params["digits"] == "6"
+    assert params["period"] == "30"
+
+    # Not just an echo of the struct: the URI has to carry a secret the
+    # authenticator can actually key on — 20 raw bytes, Base32, unpadded.
+    assert params["secret"] == enrollment.secret
+    assert {:ok, key} = Base.decode32(params["secret"], padding: false)
+    assert byte_size(key) == 20
   end
 
   # The recovery set is shared, so disarming TOTP must not destroy a

--- a/test/grappa/migrations/add_user_passkeys_test.exs
+++ b/test/grappa/migrations/add_user_passkeys_test.exs
@@ -10,6 +10,12 @@ defmodule Grappa.Migrations.AddUserPasskeysTest do
   @totp_version 20_260_802_190_000
   @passkey_version 20_260_803_090_000
 
+  @timestamp "2026-01-01T00:00:00Z"
+  @user_a "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+  @user_b "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+  @key_1 "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
+  @key_2 "ffffffff-ffff-4fff-8fff-ffffffffffff"
+
   setup do
     path = Path.join(System.tmp_dir!(), "grappa-passkey-migration-#{System.unique_integer([:positive])}.db")
     Application.put_env(:grappa, SmokeRepo, database: path, pool_size: 1, foreign_keys: :on)
@@ -51,6 +57,134 @@ defmodule Grappa.Migrations.AddUserPasskeysTest do
     assert %{rows: [["disabled"]]} = query!("SELECT passkey_mode FROM users WHERE id = ?", [user_id])
     assert %{rows: [[^code_id, ^user_id]]} = query!("SELECT id,user_id FROM user_recovery_codes")
     assert %{rows: [[0]]} = query!("SELECT COUNT(*) FROM user_passkeys")
+  end
+
+  # Columns existing is not the claim worth making — the constraints are.
+  # These assert what the database REFUSES, in the shape of the incident
+  # each constraint exists to prevent, rather than reading the declaration
+  # back out of the catalogue. The smoke repo runs with `foreign_keys: :on`
+  # (see setup), so the FK is actually enforced here and not merely
+  # recorded.
+  describe "constraints the migration creates" do
+    setup %{migrations: migrations} do
+      assert [@passkey_version] =
+               Ecto.Migrator.run(SmokeRepo, migrations, :up, to: @passkey_version, log: false)
+
+      :ok
+    end
+
+    test "one credential id belongs to at most one account, across accounts" do
+      insert_user!(@user_a, "alice")
+      insert_user!(@user_b, "bob")
+      insert_passkey!(@key_1, @user_a, <<1, 2, 3>>)
+
+      # The incident: without `unique_index(:user_passkeys, [:credential_id])`
+      # two accounts hold the same credential id and
+      # `Repo.get_by(Passkey, credential_id: ..., user_id: ...)` starts
+      # resolving ambiguously. A unique index over [credential_id, user_id]
+      # would allow exactly this, so the second row must be someone ELSE's.
+      assert_raise Exqlite.Error, ~r/UNIQUE constraint failed: user_passkeys\.credential_id/, fn ->
+        insert_passkey!(@key_2, @user_b, <<1, 2, 3>>)
+      end
+    end
+
+    test "deleting an account takes its passkeys with it" do
+      insert_user!(@user_a, "alice")
+      insert_user!(@user_b, "bob")
+      insert_passkey!(@key_1, @user_a, <<1, 2, 3>>)
+      insert_passkey!(@key_2, @user_b, <<4, 5, 6>>)
+
+      query!("DELETE FROM users WHERE id = ?", [@user_a])
+
+      # Without `on_delete: :delete_all` this row outlives the account it
+      # authenticated — a live credential belonging to nobody.
+      assert %{rows: [[@key_2]]} = query!("SELECT id FROM user_passkeys")
+    end
+
+    test "every passkey column but the optional one is NOT NULL" do
+      # Asserted as a whole set, so a column losing `null: false` and a
+      # column gaining it are both loud. `id` is absent on purpose: SQLite
+      # does not imply NOT NULL for a non-INTEGER PRIMARY KEY, so the
+      # binary_id key reads as nullable here — a quirk of the engine, not
+      # a defect of this migration, and pinning it keeps the next reader
+      # from "fixing" it.
+      assert not_null_columns("user_passkeys") ==
+               MapSet.new(~w[
+                 user_id credential_id public_key sign_count name transports inserted_at updated_at
+               ])
+    end
+  end
+
+  # `change` is only as reversible as its least reversible step, and this
+  # migration's middle step is a table RENAME — the one most likely to
+  # strand a database halfway. Rolling back and forward proves the down
+  # path exists AND that the constraints come back with the second up:
+  # re-running the refusal is the assertion, because a table restored
+  # without its unique index would satisfy any column-shaped check.
+  test "down reverses the rename, the table and the column; up restores the constraint", %{
+    migrations: migrations
+  } do
+    insert_user!(@user_a, "alice")
+    assert [@passkey_version] = Ecto.Migrator.run(SmokeRepo, migrations, :up, to: @passkey_version, log: false)
+    insert_passkey!(@key_1, @user_a, <<1, 2, 3>>)
+
+    assert [@passkey_version] = Ecto.Migrator.run(SmokeRepo, migrations, :down, step: 1, log: false)
+
+    refute "user_passkeys" in tables()
+    refute "user_recovery_codes" in tables()
+    assert "user_totp_recovery_codes" in tables()
+    refute "passkey_mode" in columns("users")
+    assert %{rows: [["alice"]]} = query!("SELECT name FROM users WHERE id = ?", [@user_a])
+
+    assert [@passkey_version] = Ecto.Migrator.run(SmokeRepo, migrations, :up, to: @passkey_version, log: false)
+
+    assert "user_recovery_codes" in tables()
+    assert %{rows: [["disabled"]]} = query!("SELECT passkey_mode FROM users WHERE id = ?", [@user_a])
+
+    insert_user!(@user_b, "bob")
+    insert_passkey!(@key_1, @user_a, <<1, 2, 3>>)
+
+    assert_raise Exqlite.Error, ~r/UNIQUE constraint failed: user_passkeys\.credential_id/, fn ->
+      insert_passkey!(@key_2, @user_b, <<1, 2, 3>>)
+    end
+  end
+
+  defp insert_user!(id, name) do
+    query!("INSERT INTO users (id,name,password_hash,is_admin,inserted_at,updated_at) VALUES (?,?,?,?,?,?)", [
+      id,
+      name,
+      "hash",
+      0,
+      @timestamp,
+      @timestamp
+    ])
+  end
+
+  defp insert_passkey!(id, user_id, credential_id) do
+    query!(
+      """
+      INSERT INTO user_passkeys
+        (id,user_id,credential_id,public_key,sign_count,name,transports,inserted_at,updated_at)
+      VALUES (?,?,?,?,?,?,?,?,?)
+      """,
+      [id, user_id, credential_id, <<9, 9, 9>>, 0, "key", "{}", @timestamp, @timestamp]
+    )
+  end
+
+  defp not_null_columns(table) do
+    ~s|SELECT name FROM pragma_table_info(?) WHERE "notnull" = 1|
+    |> query!([table])
+    |> Map.fetch!(:rows)
+    |> List.flatten()
+    |> MapSet.new()
+  end
+
+  defp columns(table) do
+    "SELECT name FROM pragma_table_info(?)" |> query!([table]) |> Map.fetch!(:rows) |> List.flatten()
+  end
+
+  defp tables do
+    "SELECT name FROM sqlite_master WHERE type = 'table'" |> query!() |> Map.fetch!(:rows) |> List.flatten()
   end
 
   defp query!(sql, params \\ []), do: Ecto.Adapters.SQL.query!(SmokeRepo, sql, params)

--- a/test/grappa/migrations/add_user_totp_test.exs
+++ b/test/grappa/migrations/add_user_totp_test.exs
@@ -7,11 +7,20 @@ end
 defmodule Grappa.Migrations.AddUserTotpTest do
   use ExUnit.Case, async: false
 
+  alias Ecto.Adapters.SQL
   alias Grappa.TotpMigrationSmokeRepo, as: SmokeRepo
 
   @previous_version 20_260_729_130_000
   @totp_version 20_260_802_190_000
   @row_count 5_000
+
+  @timestamp "2026-01-01T00:00:00.000000Z"
+  @user_a "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+  @user_b "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+  @code_1 "e0000000-0000-4000-8000-000000000001"
+  @code_2 "e0000000-0000-4000-8000-000000000002"
+  @code_3 "e0000000-0000-4000-8000-000000000003"
+  @code_4 "e0000000-0000-4000-8000-000000000004"
 
   setup do
     path = Path.join(System.tmp_dir!(), "grappa-totp-migration-#{System.unique_integer([:positive])}.db")
@@ -79,6 +88,124 @@ defmodule Grappa.Migrations.AddUserTotpTest do
              query!("SELECT name, password_hash FROM users WHERE name = 'legacy-04200'").rows
   end
 
+  # The row-preservation test above proves the migration does not lose
+  # data. These prove the other half: that what it creates actually
+  # refuses. Stated as the incident each constraint prevents rather than
+  # as a reading of the catalogue — the smoke repo runs `foreign_keys: :on`
+  # (see setup), so the FK is enforced here and not merely declared.
+  describe "constraints the migration creates" do
+    setup %{migrations_path: migrations_path} do
+      assert [@totp_version] =
+               Ecto.Migrator.run(SmokeRepo, migrations_path, :up, to: @totp_version, log: false)
+
+      insert_user!(@user_a, "alice")
+      insert_user!(@user_b, "bob")
+
+      :ok
+    end
+
+    test "a recovery code is unique per account, not globally and not per account alone" do
+      insert_recovery_code!(@code_1, @user_a, <<1, 2, 3>>)
+
+      # Same account, different hash: an account holds ten of these, so a
+      # unique index on [user_id] alone would break enrollment outright.
+      insert_recovery_code!(@code_2, @user_a, <<4, 5, 6>>)
+
+      # Different account, same hash: two people may draw the same code
+      # and neither may lock the other out, so the index cannot be on
+      # [code_hash] alone either.
+      insert_recovery_code!(@code_3, @user_b, <<1, 2, 3>>)
+
+      # Same account, same hash: the one combination that must not exist,
+      # or a code already spent still opens the door.
+      assert_raise Exqlite.Error, ~r/UNIQUE constraint failed/, fn ->
+        insert_recovery_code!(@code_4, @user_a, <<1, 2, 3>>)
+      end
+    end
+
+    test "deleting an account takes its recovery codes with it" do
+      insert_recovery_code!(@code_1, @user_a, <<1, 2, 3>>)
+      insert_recovery_code!(@code_2, @user_b, <<4, 5, 6>>)
+
+      SQL.query!(SmokeRepo, "DELETE FROM users WHERE id = ?", [@user_a])
+
+      assert query!("SELECT id FROM user_totp_recovery_codes").rows == [[@code_2]]
+    end
+
+    test "every recovery-code column is NOT NULL" do
+      # Whole set, so a column losing `null: false` and a column gaining
+      # it are equally loud. `id` is absent on purpose: SQLite does not
+      # imply NOT NULL for a non-INTEGER PRIMARY KEY, so a binary_id key
+      # reads as nullable — an engine quirk, not a defect here.
+      assert not_null_columns("user_totp_recovery_codes") ==
+               MapSet.new(~w[user_id code_hash inserted_at])
+    end
+
+    test "down drops the table and the user columns; up restores the constraint", %{
+      migrations_path: migrations_path
+    } do
+      insert_recovery_code!(@code_1, @user_a, <<1, 2, 3>>)
+
+      assert [@totp_version] =
+               Ecto.Migrator.run(SmokeRepo, migrations_path, :down, step: 1, log: false)
+
+      refute "user_totp_recovery_codes" in tables()
+      refute "totp_secret_encrypted" in user_columns()
+      refute "totp_enabled_at" in user_columns()
+      refute "totp_last_used_step" in user_columns()
+      # The accounts outlive the rollback; only what this migration added
+      # goes away. Counted by id rather than in total, because the
+      # migration graph seeds a `system` user of its own.
+      assert [["alice"], ["bob"]] ==
+               SQL.query!(
+                 SmokeRepo,
+                 "SELECT name FROM users WHERE id IN (?,?) ORDER BY name",
+                 [@user_a, @user_b]
+               ).rows
+
+      assert [@totp_version] =
+               Ecto.Migrator.run(SmokeRepo, migrations_path, :up, to: @totp_version, log: false)
+
+      assert "totp_secret_encrypted" in user_columns()
+      insert_recovery_code!(@code_1, @user_a, <<1, 2, 3>>)
+
+      # The table came back — but a table restored without its unique
+      # index would satisfy any column-shaped check, so the refusal is
+      # the assertion.
+      assert_raise Exqlite.Error, ~r/UNIQUE constraint failed/, fn ->
+        insert_recovery_code!(@code_2, @user_a, <<1, 2, 3>>)
+      end
+    end
+  end
+
+  defp insert_user!(id, name) do
+    SQL.query!(
+      SmokeRepo,
+      "INSERT INTO users (id, name, password_hash, is_admin, inserted_at, updated_at) VALUES (?,?,?,?,?,?)",
+      [id, name, "hash", 0, @timestamp, @timestamp]
+    )
+  end
+
+  defp insert_recovery_code!(id, user_id, code_hash) do
+    SQL.query!(
+      SmokeRepo,
+      "INSERT INTO user_totp_recovery_codes (id, user_id, code_hash, inserted_at) VALUES (?,?,?,?)",
+      [id, user_id, code_hash, @timestamp]
+    )
+  end
+
+  defp not_null_columns(table) do
+    SmokeRepo
+    |> SQL.query!(~s|SELECT name FROM pragma_table_info(?) WHERE "notnull" = 1|, [table])
+    |> Map.fetch!(:rows)
+    |> List.flatten()
+    |> MapSet.new()
+  end
+
+  defp tables do
+    "SELECT name FROM sqlite_master WHERE type = 'table'" |> query!() |> Map.fetch!(:rows) |> List.flatten()
+  end
+
   defp seed_legacy_rows do
     query!("""
     WITH RECURSIVE n(value) AS (
@@ -123,5 +250,5 @@ defmodule Grappa.Migrations.AddUserTotpTest do
     value
   end
 
-  defp query!(sql), do: Ecto.Adapters.SQL.query!(SmokeRepo, sql, [])
+  defp query!(sql), do: SQL.query!(SmokeRepo, sql, [])
 end

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -335,6 +335,164 @@ defmodule GrappaWeb.AuthControllerTest do
     end
   end
 
+  # The second factor's own brute-force bound. The sibling mode-1 describe
+  # proves it for the PASSWORD door; this is the same claim for the TOTP
+  # door, which guards a 10^6 space and so needs it more, not less.
+  #
+  # Note what the loop below relies on: ONE challenge token answers all
+  # eleven requests. The challenge is a `Phoenix.Token`, so it is REUSABLE
+  # for its whole 300s window — only the TOTP code is one-shot (see
+  # "replayed TOTP is rejected" above). That is the intended UX (a typo
+  # must not cost the password round trip) and it is exactly why the
+  # window needs a counter: without one, a single post-password token is
+  # an unlimited oracle.
+  describe "POST /auth/totp/verify throttle (:totp_login)" do
+    test "the 11th attempt is 429 too_many_attempts even with the correct code", %{conn: conn} do
+      {user, password} = user_fixture_with_password()
+      secret = arm_totp(user)
+      wrong = wrong_totp_code(secret, System.system_time(:second))
+
+      pending =
+        conn
+        |> post("/auth/login", %{"identifier" => user.name, "password" => password})
+        |> json_response(202)
+
+      for _ <- 1..10 do
+        assert conn
+               |> post("/auth/totp/verify", %{
+                 "challenge_token" => pending["challenge_token"],
+                 "code" => wrong
+               })
+               |> json_response(401) == %{"error" => "invalid_two_factor"}
+      end
+
+      {:ok, code} = TOTP.code_at(secret, System.system_time(:second))
+
+      assert conn
+             |> post("/auth/totp/verify", %{
+               "challenge_token" => pending["challenge_token"],
+               "code" => code
+             })
+             |> json_response(429) == %{"error" => "too_many_attempts"}
+
+      assert session_count() == 0
+    end
+
+    test "a fresh account is unaffected by another's exhausted window", %{conn: conn} do
+      {spent, spent_password} = user_fixture_with_password()
+      spent_secret = arm_totp(spent)
+      wrong = wrong_totp_code(spent_secret, System.system_time(:second))
+
+      spent_pending =
+        conn
+        |> post("/auth/login", %{"identifier" => spent.name, "password" => spent_password})
+        |> json_response(202)
+
+      for _ <- 1..10 do
+        post(conn, "/auth/totp/verify", %{
+          "challenge_token" => spent_pending["challenge_token"],
+          "code" => wrong
+        })
+      end
+
+      {user, password} = user_fixture_with_password()
+      secret = arm_totp(user)
+
+      pending =
+        conn
+        |> post("/auth/login", %{"identifier" => user.name, "password" => password})
+        |> json_response(202)
+
+      {:ok, code} = TOTP.code_at(secret, System.system_time(:second))
+
+      assert conn
+             |> post("/auth/totp/verify", %{
+               "challenge_token" => pending["challenge_token"],
+               "code" => code
+             })
+             |> json_response(200)
+    end
+  end
+
+  # The post-password challenge is deliberately short-lived: it is handed
+  # out BEFORE the second factor is proven, so anything that leaks one — a
+  # proxy log, a crash report, a shared screen — hands over half a login.
+  # 300s is the whole bound, and nothing but `max_age:` enforces it.
+  #
+  # These mint the token directly because the age is the subject and a
+  # token obtained from `/auth/login` is always fresh. That duplicates the
+  # controller's private salt here, so the second test is not decoration:
+  # it runs the SAME helper with a current timestamp and demands a bearer.
+  # Drift the salt, the payload shape, or the binding and the control goes
+  # red — a wrong salt reads as `invalid_two_factor`, never as an accepted
+  # login, so this pair cannot quietly test nothing.
+  describe "POST /auth/totp/verify challenge lifetime" do
+    @totp_challenge_salt "account-totp-login-v1"
+    @totp_challenge_max_age_seconds 300
+
+    test "a challenge older than its window is refused as expired", %{conn: conn} do
+      {user, _} = user_fixture_with_password()
+      secret = arm_totp(user)
+      {:ok, code} = TOTP.code_at(secret, System.system_time(:second))
+      stale = System.system_time(:second) - @totp_challenge_max_age_seconds - 1
+
+      refused =
+        post(conn, "/auth/totp/verify", %{
+          "challenge_token" => totp_challenge_token(user, conn, stale),
+          "code" => code
+        })
+
+      assert json_response(refused, 401) == %{"error" => "two_factor_challenge_expired"}
+      assert session_count() == 0
+    end
+
+    test "a challenge inside its window still mints the bearer", %{conn: conn} do
+      {user, _} = user_fixture_with_password()
+      secret = arm_totp(user)
+      {:ok, code} = TOTP.code_at(secret, System.system_time(:second))
+      fresh = System.system_time(:second) - @totp_challenge_max_age_seconds + 30
+
+      body =
+        conn
+        |> post("/auth/totp/verify", %{
+          "challenge_token" => totp_challenge_token(user, conn, fresh),
+          "code" => code
+        })
+        |> json_response(200)
+
+      assert body["subject"]["id"] == user.id
+      assert session_count() == 1
+    end
+  end
+
+  defp totp_challenge_token(user, conn, signed_at) do
+    Phoenix.Token.sign(
+      GrappaWeb.Endpoint,
+      @totp_challenge_salt,
+      {user.id, GrappaWeb.RemoteIP.format(conn), conn.assigns[:current_client_id]},
+      signed_at: signed_at
+    )
+  end
+
+  # A code that no step in `matching_step/3`'s ±1 window accepts, and one
+  # step further out on each side so a 30s boundary crossed mid-test can't
+  # turn it valid. Derived from the production generator rather than
+  # hardcoded: "000000" is a real code once every 10^6 enrollments.
+  defp wrong_totp_code(secret, now) do
+    accepted =
+      for step_offset <- -2..2 do
+        {:ok, code} = TOTP.code_at(secret, now + step_offset * 30)
+        code
+      end
+
+    # Pigeonhole: five codes are accepted, so one of the first six
+    # numbers is not among them.
+    Enum.find_value(0..length(accepted), fn n ->
+      candidate = n |> Integer.to_string() |> String.pad_leading(6, "0")
+      if candidate not in accepted, do: candidate
+    end)
+  end
+
   # #404 — an account holder who types their BARE account name (no `@`)
   # must get an ACCOUNT session, not a silently-provisioned guest. Pre-fix
   # the dispatch keyed SOLELY on `@` presence, so a bare account name


### PR DESCRIPTION
Union gate for three finding PRs that were each green against a base that has since moved. **Opened instead of merging them singly.**

Replaces, by content:
- **#826** — `test(#749)`: put the TOTP door's three unasserted claims under test
- **#829** — `test(#751)`: assert what the migrations REFUSE, not what they declare
- **#830** — `cic(#818)`: refuse a `/me` hydration that outlived its identity

Cherry-picked onto `0331cf4c` in that order, no conflicts. 7 files: 4 Elixir test files, `cicchetto/src/lib/networks.ts` + 2 cic test files.

## Why a union and not three merges

Each of the three was green against `fa519aa7`, and **a PR's green attests to `branch + base`, never to `branch + the other branches about to land`**. Merging them singly would also cost three sequential re-gates (the cic change pulls `integration`, ~25 min) for work already written and already individually green.

This is the same reasoning that broke `main` for twelve hours on 2026-08-03, when five separately-green PRs were merged on their individual greens. Textual non-overlap is not semantic independence — the union is both the faster gate and the correct one.

## Closing note

The three source PRs must be **closed by content**, not by GitHub: cherry-picking rewrote the SHAs, so GitHub will not mark them merged on its own.