### PR TITLE
test(#831): cover #768's two `:db_unavailable` clauses, now that a ceremony can be signed

### DIFF
--- a/test/grappa_web/controllers/passkey_controller_test.exs
+++ b/test/grappa_web/controllers/passkey_controller_test.exs
@@ -165,6 +165,56 @@ defmodule GrappaWeb.PasskeyControllerTest do
       assert Repo.get!(User, ctx.user.id).passkey_mode == :disabled
     end
 
+    # #831 — #768 wrapped both ceremony writes in `Repo.BusyRetry` and put a
+    # `:db_unavailable` clause ahead of each catch-all, but could only pin the
+    # DELETE at the wire: reaching these two needs a ceremony, and nothing in
+    # the suite could sign one. `WebAuthnCeremony` can (#742), so the contract
+    # is provable now. Without the clause the degrade falls into the
+    # `:invalid_two_factor` catch-all and a saturated writer is reported as a
+    # bad authenticator — a lie the user answers by retrying a ceremony that
+    # cannot succeed.
+    test "POST /me/passkeys/registration behind a saturated writer is a 503, not a refused credential", ctx do
+      options =
+        json_response(
+          post(authed(ctx.session), "/me/passkeys/registration/options", %{
+            "password" => ctx.password,
+            "name" => "phone"
+          }),
+          200
+        )
+
+      params = registration_params(ctx, options, @ceremony_origin)
+
+      Grappa.Repo.BusyRetry.inject_transient_faults(10_000)
+      conn = post(authed(ctx.session), "/me/passkeys/registration", params)
+      Grappa.Repo.BusyRetry.inject_transient_faults(0)
+
+      assert json_response(conn, 503) == %{"error" => "db_unavailable"}
+      assert Repo.aggregate(Passkey, :count, :id) == 0
+    end
+
+    test "POST /me/passkeys/mode behind a saturated writer is a 503, not a refused assertion", ctx do
+      register_credential(ctx)
+
+      options =
+        json_response(
+          post(authed(ctx.session), "/me/passkeys/mode/options", %{
+            "password" => ctx.password,
+            "mode" => "second_factor"
+          }),
+          200
+        )
+
+      params = assertion_params(ctx, options, 1)
+
+      Grappa.Repo.BusyRetry.inject_transient_faults(10_000)
+      conn = post(authed(ctx.session), "/me/passkeys/mode", params)
+      Grappa.Repo.BusyRetry.inject_transient_faults(0)
+
+      assert json_response(conn, 503) == %{"error" => "db_unavailable"}
+      assert Repo.get!(User, ctx.user.id).passkey_mode == :disabled
+    end
+
     defp authed(session),
       do: put_req_header(build_conn(), "authorization", "Bearer #{session.id}")
 

--- a/test/grappa_web/controllers/passkey_controller_test.exs
+++ b/test/grappa_web/controllers/passkey_controller_test.exs
@@ -7,6 +7,7 @@ defmodule GrappaWeb.PasskeyControllerTest do
   alias Grappa.Accounts.{Passkey, Session, TOTP, TOTPRecoveryCode, User, WebAuthn}
   alias Grappa.RateLimit.FailureWindow
   alias Grappa.{Repo, WebAuthnCeremony}
+  alias Grappa.Repo.BusyRetry
   alias GrappaWeb.PasskeyOrigin
 
   defp passwordless_user do
@@ -185,9 +186,9 @@ defmodule GrappaWeb.PasskeyControllerTest do
 
       params = registration_params(ctx, options, @ceremony_origin)
 
-      Grappa.Repo.BusyRetry.inject_transient_faults(10_000)
+      BusyRetry.inject_transient_faults(10_000)
       conn = post(authed(ctx.session), "/me/passkeys/registration", params)
-      Grappa.Repo.BusyRetry.inject_transient_faults(0)
+      BusyRetry.inject_transient_faults(0)
 
       assert json_response(conn, 503) == %{"error" => "db_unavailable"}
       assert Repo.aggregate(Passkey, :count, :id) == 0
@@ -207,9 +208,9 @@ defmodule GrappaWeb.PasskeyControllerTest do
 
       params = assertion_params(ctx, options, 1)
 
-      Grappa.Repo.BusyRetry.inject_transient_faults(10_000)
+      BusyRetry.inject_transient_faults(10_000)
       conn = post(authed(ctx.session), "/me/passkeys/mode", params)
-      Grappa.Repo.BusyRetry.inject_transient_faults(0)
+      BusyRetry.inject_transient_faults(0)
 
       assert json_response(conn, 503) == %{"error" => "db_unavailable"}
       assert Repo.get!(User, ctx.user.id).passkey_mode == :disabled
@@ -498,7 +499,7 @@ defmodule GrappaWeb.PasskeyControllerTest do
         })
       )
 
-    Grappa.Repo.BusyRetry.inject_transient_faults(10_000)
+    BusyRetry.inject_transient_faults(10_000)
 
     conn =
       conn
@@ -507,7 +508,7 @@ defmodule GrappaWeb.PasskeyControllerTest do
 
     assert json_response(conn, 503) == %{"error" => "db_unavailable"}
 
-    Grappa.Repo.BusyRetry.inject_transient_faults(0)
+    BusyRetry.inject_transient_faults(0)
     assert Repo.aggregate(Passkey, :count, :id) == 1
   end
 


### PR DESCRIPTION
Follow-up #831. **Tests only** — no production code changed, so this is inside the freeze.

## The two clauses are still there, and still uncovered

Checked against the real file at `fa519aa7`, not against the line numbers in the issue:

- `passkey_controller.ex:58` — `register/2`, `{:error, :db_unavailable} = err -> err` ahead of `_ -> {:error, :invalid_two_factor}`
- `passkey_controller.ex:158` — `set_mode/2`, same clause ahead of the same catch-all

Both present, both unreached by the suite. Nothing had already covered them and nothing had removed them.

## Why they could not be covered before, and can be now

#768 wrapped `complete_registration/3`'s insert and `set_mode/4`'s transaction in `Repo.BusyRetry`, and put a `:db_unavailable` clause ahead of each controller catch-all. Only the DELETE could be pinned at the wire: the other two sit behind a real `Wax.register` / `Wax.authenticate`, and the suite could not sign one. #768 said so rather than arming a fault at a test that never reached the clause — a test that passes without being able to fail is worse than no test.

#742 built `WebAuthnCeremony`, and #743/#749 drove it through these exact routes. So the debt is payable.

## What the tests assert

Both sign a genuine ceremony, then arm `inject_transient_faults/1` **after** the options call — no `BusyRetry.run/1` op runs between the arming and the target write, so the fault can only land where the test claims (the `Accounts.authenticate/1` bearer lookup and `verify_password/2` are raw `Repo` / pure Argon2, and the fault seam only fires at a `BusyRetry.run` attempt).

The point is not the status number but the lie under it: without the clause the degrade falls into `:invalid_two_factor`, telling the user their authenticator was rejected and sending them back to retry a ceremony that cannot succeed. So each test also asserts the write did **not** land — no credential row, mode still `:disabled`.

## Mutation matrix

Each clause deleted on its own, full module re-run:

| mutation | result |
| --- | --- |
| drop `register/2`'s clause | **1 failure** — the registration test only. `got: 401, "invalid_two_factor"`, with `db write unavailable: … returning :db_unavailable` in the captured log, so the degrade did reach the controller. |
| drop `set_mode/2`'s clause | **1 failure** — the mode test only. Same 401, same log line. |
| neither | 19 tests, 0 failures |

No collateral reds in either direction: the mutation reddens the test written for it and nothing else.

## Second commit

Credo strict allows a nested module inline at most twice. The #768 delete test sat exactly on that threshold; four more calls push the file over and it flags all six. Aliased `Grappa.Repo.BusyRetry` and moved the pre-existing call sites onto it too, so the file has one spelling rather than two.

## Not in scope

`consume_sign_count/2` and its CAS retry-safety are #815, deliberately blocked on an observation nobody has made yet (whether Exqlite can raise a transient error *after* the write landed). Untouched.

## Gates

`scripts/check.sh` — **rc=0**. `8 doctests, 50 properties, 5106 tests, 0 failures`; Dialyzer `Total errors: 0, Skipped: 0, Unnecessary Skips: 0`; format, Credo strict, Sobelow, deps.audit, bats all clean. Working tree clean before and after.

One run hit the known `could not lookup Ecto repo Grappa.Repo because it was not started` infra flake (807 failures in one block, no test content); the re-run above is the clean one.

Integration/e2e not run — nothing here reaches that lane.