### PR TITLE
infra(#746): make the cloud drift-guard check the executable surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,9 +122,12 @@ jobs:
 
       - name: Cloud provider-door drift-guard (#665)
         # Prove every provider door (infra/aws today, infra/terraform later)
-        # references the shared infra/cloud/first-boot.sh AND exposes the same
-        # knob names from infra/cloud/params.contract. A hand-written second
-        # door that drifts from the contract fails here instead of silently.
+        # INVOKES the shared infra/cloud/first-boot.sh from its UserData/
+        # user_data block, binds every knob marker from infra/cloud/params.contract
+        # to a real parameter, and exports exactly the env the bootstrap
+        # requires. All three read the executable surface — a prose mention or
+        # an orphaned marker satisfies none of them (#746). A hand-written
+        # second door that drifts from the contract fails here, not silently.
         run: infra/cloud/check-drift.sh
 
       - name: Upload coverage

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -28776,3 +28776,50 @@ gate rather than a delay — the send POST is held until the pane has tail-follo
 the echo, then released — which is deterministic without waiting on wall-clock:
 10/10 red before the fix, 10/10 green after, where case 1 stayed green through
 all six of those pre-fix runs.
+## 2026-08-04 — #746: the cloud drift-guard now checks the executable surface
+
+`infra/cloud/check-drift.sh` (#665) exists so the CloudFormation door and the
+shared `first-boot.sh` cannot drift apart. Every check it performed was
+satisfiable by a comment, so it defended nothing a launched stack depends on.
+All three defects were MEASURED against the shipped template before anything
+was written: delete the real `UserData` `curl`+`bash` and the four prose
+mentions of `first-boot.sh` (Description, two knob comments, one block comment)
+kept the whole-file grep happy — guard OK; delete the `SshCidr:` parameter and
+leave its `# grappa-knob: ssh_cidr` marker — guard OK; rename `GRAPPA_DOMAIN`
+on the template side alone — guard OK, bats green, and every launched stack
+dies in `UserData`.
+
+**The guard reads only what runs.** It extracts each door's bootstrap block —
+CFN `UserData:` / Terraform `user_data`, delimited by indentation — drops
+comment lines, and requires the invocation to live THERE. Knob markers must be
+BOUND: the first non-comment line after the marker (before the next marker) is
+the declaration it annotates, so an orphan reads as a missing knob rather than
+a passing one. And the env handshake, which did not exist at all, is now
+set-equality between the `GRAPPA_*` a door exports and what the bootstrap
+requires. Equality in BOTH directions on purpose: the missing side catches a
+door that never passes a required knob, the extra side catches the rename,
+which is otherwise invisible because each file stays individually valid.
+
+**Required-env is derived from code, never from a marker.** A knob is required
+iff `first-boot.sh` reads it with an EMPTY default (`GRAPPA_X="${GRAPPA_X:-}"`);
+a non-empty default is a production config default or a test seam no door
+passes. A `# grappa-env:` marker was the obvious alternative and is exactly the
+disease being cured — the orphaned `grappa-knob:` marker is what a detached
+comment decays into. The cost is that the assignment shape is now load-bearing;
+it is stated at both ends, and a parse that yields nothing exits 2 (misuse)
+rather than passing vacuously.
+
+**The RED cases mutate the shipped template, one defect at a time.** The old
+negative case wrote a synthetic door naming the bootstrap on exactly one line
+and removed every trace of it — a mutation the real template cannot undergo, so
+it proved the guard fails against a shape we do not ship. Each case now filters
+a COPY of the real file and asserts the mutated door STILL names `first-boot.sh`
+in prose; that assertion is what makes it a test of the fix rather than of the
+fixture. The Terraform fixture carries the same prose for the same reason: with
+it absent, the case passed under the OLD whole-file grep too and proved nothing.
+Each new check was then reverted in isolation and only its own cases fell.
+
+**`sed -E` with a backreference is a GNU extension.** The first required-env
+parse used `s/^(GRAPPA_[A-Z0-9_]+)="\$\{\1:-\}".*/\1/p` and matched NOTHING on
+BSD sed. It surfaced as exit 2 rather than as a silently empty required set only
+because the empty-parse guard was written first — the same reason it stays.

--- a/infra/cloud/check-drift.sh
+++ b/infra/cloud/check-drift.sh
@@ -4,21 +4,37 @@
 # The design deliberately does NOT generate the provider templates from one
 # source (that would be CDK/cdktf — a Node toolchain + synthesized artifacts
 # committed anyway, to save ~30 lines of resource graph). Instead the two
-# doors are hand-written and a CHECK keeps them honest: every provider wrapper
-# must (1) reference the shared bootstrap `first-boot.sh` and (2) expose the
-# SAME knob names from infra/cloud/params.contract, marked `grappa-knob: <name>`.
+# doors are hand-written and a CHECK keeps them honest. Every provider wrapper
+# must:
+#
+#   (1) INVOKE the shared bootstrap `first-boot.sh` from its bootstrap block
+#       (CFN `UserData:` / Terraform `user_data`), not merely mention it;
+#   (2) expose the SAME knob names from infra/cloud/params.contract, each
+#       `grappa-knob: <name>` marker BOUND to the parameter it annotates;
+#   (3) export exactly the env vars first-boot.sh requires.
+#
+# All three checks read the EXECUTABLE surface, because that is the surface
+# that breaks a launched stack. The first two used to be satisfied by a
+# comment: the whole-file grep for `first-boot.sh` was satisfied by the four
+# prose mentions that survive deleting the real UserData bootstrap, and a knob
+# marker left behind by a deleted parameter passed as a detached comment. (3)
+# did not exist at all, and it is the drift that actually happens — rename
+# GRAPPA_DOMAIN on one side and every launched stack dies in UserData while
+# both files stay individually valid. See #746.
 #
 # This is a guard, NOT a generator: it never edits a template, it only fails
 # loud when the doors drift. It runs against whatever doors exist today
 # (infra/aws/) and starts covering infra/terraform/ the day that lands — an
 # absent provider directory is not drift, so it is tolerated silently.
 #
-# Exit 0 = every present door references first-boot.sh and exposes all knobs.
-# Exit 1 = drift (a door missing the reference or a knob marker).
-# Exit 2 = misuse / missing contract.
+# Exit 0 = every present door invokes first-boot.sh, binds every knob, and
+#          hands over exactly the required env.
+# Exit 1 = drift.
+# Exit 2 = misuse / missing contract / missing bootstrap.
 #
-# Pure filesystem + grep, no network, no cloud CLI — so it lives under bats
-# (test/infra/cloud_drift_guard_test.bats), which proves it goes RED on drift.
+# Pure filesystem + grep/awk, no network, no cloud CLI — so it lives under bats
+# (test/infra/cloud_drift_guard_test.bats), which proves it goes RED on drift
+# by mutating the REAL shipped template, one defect at a time.
 # bash, `set -euo pipefail`, shellcheck-clean.
 
 set -euo pipefail
@@ -28,8 +44,9 @@ SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="${GRAPPA_REPO_ROOT:-$(cd "$SELF_DIR/../.." && pwd)}"
 CONTRACT="${GRAPPA_PARAMS_CONTRACT:-$REPO_ROOT/infra/cloud/params.contract}"
 
-# The bootstrap filename every door must reference (curl-at-ref + exec).
+# The bootstrap every door must curl-at-ref + exec.
 BOOTSTRAP_NAME='first-boot.sh'
+BOOTSTRAP="$REPO_ROOT/infra/cloud/$BOOTSTRAP_NAME"
 
 # The provider doors. A glob that matches nothing (e.g. infra/terraform absent)
 # contributes zero files — tolerated, not an error.
@@ -44,6 +61,11 @@ fail() { printf '[check-drift] DRIFT: %s\n' "$*" >&2; drift=1; }
 	exit 2
 }
 
+[ -f "$BOOTSTRAP" ] || {
+	printf '[check-drift] missing shared bootstrap: %s\n' "$BOOTSTRAP" >&2
+	exit 2
+}
+
 # Parse the canonical knob names from the KNOBS block (between the BEGIN/END
 # markers), skipping blanks + comments.
 read_knobs() {
@@ -52,6 +74,23 @@ read_knobs() {
 		/^# END KNOBS$/   { inb = 0 }
 		inb && $0 !~ /^#/ && NF { print $1 }
 	' "$CONTRACT"
+}
+
+# The env handshake, read off the bootstrap's own code: a knob it reads with an
+# EMPTY default (`GRAPPA_X="${GRAPPA_X:-}"`) is REQUIRED from the door, while a
+# non-empty default is a production config default / test seam that no door
+# passes. Derived from the assignment itself, never from a comment — a comment
+# is the thing this guard exists to stop trusting.
+# awk with a whole-line string compare, not a sed backreference: `sed -E` only
+# honours \1 inside the pattern as a GNU extension, and silently matched
+# nothing on BSD sed.
+read_required_env() {
+	awk '
+		index($0, "=") {
+			name = substr($0, 1, index($0, "=") - 1)
+			if (name ~ /^GRAPPA_[A-Z0-9_]+$/ && $0 == name "=\"${" name ":-}\"") { print name }
+		}
+	' "$BOOTSTRAP" | sort -u
 }
 
 # Collect present door files across every provider glob (nullglob so an absent
@@ -66,9 +105,72 @@ door_files() {
 	[ "${#doors[@]}" -gt 0 ] && printf '%s\n' "${doors[@]}"
 }
 
+# The body of a door's bootstrap block — CFN `UserData:` or Terraform
+# `user_data = <<-EOT` — delimited by indentation: everything indented DEEPER
+# than the key, up to the first line that is not. This is the door's executable
+# surface; prose elsewhere in the file is not part of it.
+door_bootstrap_block() {
+	awk '
+		{
+			match($0, /^[ \t]*/)
+			ind = RLENGTH
+			if (inb) {
+				if ($0 ~ /^[ \t]*$/) next
+				if (ind > base) { print; next }
+				inb = 0
+			}
+			if ($0 ~ /^[ \t]*(UserData:|user_data[ \t]*=)/) { base = ind; inb = 1 }
+		}
+	' "$1"
+}
+
+# Its executable lines only — a comment inside UserData is still prose.
+door_bootstrap_code() {
+	door_bootstrap_block "$1" | grep -vE '^[ \t]*#' || true
+}
+
+# The env vars a door hands the bootstrap: the GRAPPA_* names it assigns inside
+# its bootstrap block.
+door_exported_env() {
+	door_bootstrap_code "$1" \
+		| sed -E -n 's/^[ \t]*(export[ \t]+)?(GRAPPA_[A-Z0-9_]+)=.*/\2/p' \
+		| sort -u
+}
+
+# The knob names whose marker is BOUND to a declaration: the first non-blank,
+# non-comment line after the marker — before the next marker — is the parameter
+# the marker annotates. A marker whose parameter was deleted is left dangling
+# and is NOT reported, so the caller sees it as a missing knob. A marker written
+# as a trailing comment on the declaration itself counts as bound.
+door_bound_knobs() {
+	awk '
+		/grappa-knob:/ {
+			match($0, /grappa-knob:[ \t]*[A-Za-z0-9_]+/)
+			knob = substr($0, RSTART, RLENGTH)
+			sub(/grappa-knob:[ \t]*/, "", knob)
+			# Anything other than the comment opener before the marker means the
+			# declaration IS this line.
+			if (substr($0, 1, RSTART - 1) ~ /[^ \t#\/]/) { print knob; pending = ""; next }
+			pending = knob
+			next
+		}
+		pending != "" && $0 !~ /^[ \t]*$/ && $0 !~ /^[ \t]*#/ {
+			print pending
+			pending = ""
+		}
+	' "$1"
+}
+
 mapfile -t KNOBS < <(read_knobs)
 [ "${#KNOBS[@]}" -gt 0 ] || {
 	printf '[check-drift] no knobs parsed from %s (empty KNOBS block?)\n' "$CONTRACT" >&2
+	exit 2
+}
+
+mapfile -t REQUIRED_ENV < <(read_required_env)
+[ "${#REQUIRED_ENV[@]}" -gt 0 ] || {
+	# shellcheck disable=SC2016  # the un-expanded ${...} IS the shape being asked for
+	printf '[check-drift] no required env parsed from %s (expected GRAPPA_X="${GRAPPA_X:-}")\n' "$BOOTSTRAP" >&2
 	exit 2
 }
 
@@ -79,19 +181,40 @@ if [ "${#DOORS[@]}" -eq 0 ]; then
 	exit 0
 fi
 
+required_list="$(printf '%s\n' "${REQUIRED_ENV[@]}")"
+
 drift=0
 for door in "${DOORS[@]}"; do
 	say "checking $door"
 
-	# (1) references the shared bootstrap.
-	grep -q "$BOOTSTRAP_NAME" "$door" \
-		|| fail "$door does not reference $BOOTSTRAP_NAME (must curl+exec the shared bootstrap, not inline it)"
+	# (1) the door INVOKES the shared bootstrap from its bootstrap block.
+	block="$(door_bootstrap_code "$door")"
+	if [ -z "$block" ]; then
+		fail "$door has no UserData:/user_data bootstrap block (it must curl+exec $BOOTSTRAP_NAME, not inline it)"
+	elif ! printf '%s\n' "$block" | grep -q "$BOOTSTRAP_NAME"; then
+		fail "$door does not invoke $BOOTSTRAP_NAME from its bootstrap block (a prose mention elsewhere in the file is not a bootstrap)"
+	fi
 
-	# (2) exposes every knob via its grappa-knob marker.
+	# (2) every knob marker is present AND bound to the parameter it annotates.
+	bound="$(door_bound_knobs "$door")"
 	for knob in "${KNOBS[@]}"; do
-		grep -qE "grappa-knob:[[:space:]]*${knob}([[:space:]]|$)" "$door" \
-			|| fail "$door is missing knob marker 'grappa-knob: ${knob}'"
+		if ! grep -qE "grappa-knob:[[:space:]]*${knob}([[:space:]]|$)" "$door"; then
+			fail "$door is missing knob marker 'grappa-knob: ${knob}'"
+		elif ! printf '%s\n' "$bound" | grep -qx "$knob"; then
+			fail "$door has a dangling 'grappa-knob: ${knob}' marker — no parameter follows it (deleted parameter, orphaned comment)"
+		fi
 	done
+
+	# (3) the env handshake: the door exports exactly what the bootstrap requires.
+	exported="$(door_exported_env "$door")"
+	while read -r missing; do
+		[ -n "$missing" ] || continue
+		fail "$door never exports ${missing}, which $BOOTSTRAP_NAME requires — every stack launched from this door dies in its bootstrap"
+	done < <(comm -23 <(printf '%s\n' "$required_list") <(printf '%s\n' "$exported"))
+	while read -r extra; do
+		[ -n "$extra" ] || continue
+		fail "$door exports ${extra}, which $BOOTSTRAP_NAME does not require — a renamed or stale knob the bootstrap will ignore"
+	done < <(comm -13 <(printf '%s\n' "$required_list") <(printf '%s\n' "$exported"))
 done
 
 if [ "$drift" -ne 0 ]; then
@@ -99,5 +222,5 @@ if [ "$drift" -ne 0 ]; then
 	exit 1
 fi
 
-say "OK — all ${#DOORS[@]} door(s) reference $BOOTSTRAP_NAME and expose all ${#KNOBS[@]} knobs"
+say "OK — all ${#DOORS[@]} door(s) invoke $BOOTSTRAP_NAME, bind all ${#KNOBS[@]} knobs and export all ${#REQUIRED_ENV[@]} required env vars"
 exit 0

--- a/infra/cloud/first-boot.sh
+++ b/infra/cloud/first-boot.sh
@@ -13,7 +13,8 @@
 # THIS script + the parameter names in infra/cloud/params.contract, and
 # nothing else; the resource graph (CFN YAML vs Terraform HCL) stays two
 # hand-written files. The CI drift-guard (infra/cloud/check-drift.sh) proves
-# both doors reference this script and expose the same knob names.
+# both doors INVOKE this script from their bootstrap block, bind every knob
+# marker to a real parameter, and export exactly the env this script requires.
 #
 # UNLIKE infra/linux/ (which sits BEHIND an upstream TLS box and runs a dumb
 # HTTP reverse proxy), a cloud box is the whole world: it terminates TLS
@@ -51,6 +52,12 @@
 set -euo pipefail
 
 # ── Required operator knobs ─────────────────────────────────────────────────
+# The SHAPE below is load-bearing, not style: check-drift.sh reads the
+# required-env set off these assignments — `GRAPPA_X="${GRAPPA_X:-}"`, an empty
+# default, means every provider door must export it, while the non-empty
+# defaults further down are config/test seams no door passes. It then fails CI
+# unless each door exports exactly this set. A new required knob written any
+# other way silently drops out of the handshake the guard defends (#746).
 GRAPPA_DOMAIN="${GRAPPA_DOMAIN:-}"
 GRAPPA_ADMIN_EMAIL="${GRAPPA_ADMIN_EMAIL:-}"
 

--- a/infra/cloud/params.contract
+++ b/infra/cloud/params.contract
@@ -3,17 +3,26 @@
 # One canonical knob per line inside the KNOBS block below. This is the
 # provider-agnostic contract: whichever door an operator comes through (the
 # CloudFormation template today, a Terraform module later), the SAME answers
-# must produce the SAME machine. Two things keep the doors honest, both
-# enforced by infra/cloud/check-drift.sh (wired into CI):
+# must produce the SAME machine. Three things keep the doors honest, all
+# enforced by infra/cloud/check-drift.sh (wired into CI) and all read off each
+# door's EXECUTABLE surface — a comment satisfies none of them (#746):
 #
 #   1. Every provider wrapper (infra/aws/*.yaml today, infra/terraform/*.tf
-#      later) MUST reference the shared bootstrap by name: `first-boot.sh`.
+#      later) MUST INVOKE the shared bootstrap from its bootstrap block (CFN
+#      `UserData:`, Terraform `user_data`): `first-boot.sh`. Naming it in
+#      prose elsewhere in the file is not a bootstrap.
 #   2. Every wrapper MUST annotate the parameter that implements each knob
 #      with a machine-readable marker:  grappa-knob: <name>
-#      (a YAML comment in the CFN template, an HCL comment in Terraform). The
-#      guard greps for `grappa-knob: <name>` per door, so it is agnostic to
-#      each tool's own naming convention — CFN's `Domain` and Terraform's
-#      `domain` both satisfy the `domain` knob by carrying the same marker.
+#      (a YAML comment in the CFN template, an HCL comment in Terraform), and
+#      the marker must be BOUND to that parameter — the next non-comment line
+#      is the declaration it annotates, so a marker left behind by a deleted
+#      parameter reads as a missing knob. The guard is agnostic to each tool's
+#      own naming convention — CFN's `Domain` and Terraform's `domain` both
+#      satisfy the `domain` knob by carrying the same marker.
+#   3. Every wrapper MUST export EXACTLY the env vars first-boot.sh requires,
+#      from inside that same bootstrap block. This is the handshake that
+#      actually breaks: rename GRAPPA_DOMAIN on one side and both files stay
+#      individually valid while every launched stack dies in its bootstrap.
 #
 # What each knob means (the semantic contract, not tool syntax):
 #   domain         public hostname → PHX_HOST, nginx server_name, TLS SAN.

--- a/test/infra/cloud_drift_guard_test.bats
+++ b/test/infra/cloud_drift_guard_test.bats
@@ -3,14 +3,14 @@
 # Bats suite for infra/cloud/check-drift.sh — the #665 shared-ground guard.
 #
 # The guard proves both provider doors (infra/aws/*.yaml today, infra/terraform/
-# *.tf later) reference the shared first-boot.sh AND expose the same knob names
-# from infra/cloud/params.contract. These tests prove it goes GREEN on a
-# faithful door and RED the moment a door drifts (a knob marker or the bootstrap
-# reference goes missing) — the whole point of a guard is that it fails on drift.
+# *.tf later) hand the shared first-boot.sh the SAME machine: they invoke it
+# from their bootstrap block, they expose every knob in infra/cloud/params.contract,
+# and they export exactly the env vars the bootstrap requires.
 #
-# The REAL params.contract is copied into a sandbox REPO_ROOT (production knob
-# list, not a re-typed one), and synthetic door files are written to exercise
-# each drift shape.
+# EVERY drift case below is a mutation of the REAL, SHIPPED template (copied
+# into a sandbox REPO_ROOT alongside the real params.contract and the real
+# first-boot.sh). A synthetic door proves the guard rejects a shape we do not
+# ship; only the real one proves it rejects the shape we do (#746).
 
 setup() {
     REPO_SRC="$BATS_TEST_DIRNAME/../.."
@@ -18,85 +18,173 @@ setup() {
 
     export GRAPPA_REPO_ROOT="$BATS_TEST_TMPDIR/repo"
     mkdir -p "$GRAPPA_REPO_ROOT/infra/cloud" "$GRAPPA_REPO_ROOT/infra/aws"
-    # Use the real contract so the knob set under test is production truth.
+    # The contract, the bootstrap and the door are all PRODUCTION copies, so
+    # the knob set, the required-env set and the door shape under test are
+    # truth rather than a re-typed approximation.
     cp "$REPO_SRC/infra/cloud/params.contract" "$GRAPPA_REPO_ROOT/infra/cloud/params.contract"
+    cp "$REPO_SRC/infra/cloud/first-boot.sh" "$GRAPPA_REPO_ROOT/infra/cloud/first-boot.sh"
 
-    AWS_DOOR="$GRAPPA_REPO_ROOT/infra/aws/grappa.yaml"
+    BOOTSTRAP="$GRAPPA_REPO_ROOT/infra/cloud/first-boot.sh"
+    AWS_DOOR="$GRAPPA_REPO_ROOT/infra/aws/grappa-cloudformation.yaml"
+    REAL_AWS_DOOR="$REPO_SRC/infra/aws/grappa-cloudformation.yaml"
 }
 
-# A faithful door: references first-boot.sh + carries every knob marker.
-write_good_aws_door() {
-    cat > "$AWS_DOOR" <<'EOF'
+# The shipped CloudFormation door, verbatim.
+write_real_aws_door() {
+    cp "$REAL_AWS_DOOR" "$AWS_DOOR"
+}
+
+# Rewrite the sandbox door through a filter — every RED case is a one-mutation
+# delta from the shipped template.
+mutate_aws_door() {
+    "$@" < "$AWS_DOOR" > "$AWS_DOOR.tmp"
+    mv "$AWS_DOOR.tmp" "$AWS_DOOR"
+}
+
+write_real_tf_door() {
+    mkdir -p "$GRAPPA_REPO_ROOT/infra/terraform"
+    TF_DOOR="$GRAPPA_REPO_ROOT/infra/terraform/main.tf"
+    cat > "$TF_DOOR" <<'EOF'
 # grappa-knob: domain
+variable "domain" { type = string }
+
 # grappa-knob: admin_email
+variable "admin_email" { type = string }
+
 # grappa-knob: instance_type
+variable "instance_type" { type = string }
+
 # grappa-knob: ssh_cidr
+variable "ssh_cidr" { type = string }
+
 # grappa-knob: disk_size_gb
-UserData: curl .../infra/cloud/first-boot.sh | bash
+variable "disk_size_gb" { type = number }
+
+resource "aws_instance" "grappa" {
+  instance_type = var.instance_type
+  user_data = <<-EOT
+    #!/bin/bash
+    set -euo pipefail
+    export GRAPPA_DOMAIN='${var.domain}'
+    export GRAPPA_ADMIN_EMAIL='${var.admin_email}'
+    curl -fsSL https://raw.githubusercontent.com/vjt/grappa-irc/main/infra/cloud/first-boot.sh -o /root/grappa-first-boot.sh
+    bash /root/grappa-first-boot.sh
+  EOT
+}
 EOF
 }
 
-@test "GREEN: a faithful AWS door passes" {
-    write_good_aws_door
+@test "GREEN: the shipped AWS door passes" {
+    write_real_aws_door
     run "$GUARD"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"expose all"* ]]
+    [[ "$output" == *"bind all"* ]]
+    [[ "$output" == *"export all"* ]]
+}
+
+@test "RED: deleting the bootstrap invocation fails even though prose still names it" {
+    write_real_aws_door
+    # Delete ONLY the executable bootstrap lines. The template still names
+    # first-boot.sh in its Description and in three comments — the four prose
+    # mentions that used to satisfy a whole-file grep (#746).
+    mutate_aws_door grep -vE '^[[:space:]]*(curl|bash) .*first-boot'
+    grep -q "first-boot.sh" "$AWS_DOOR" # the mutation is NOT "remove every trace"
+
+    run "$GUARD"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"does not invoke first-boot.sh"* ]]
+}
+
+@test "RED: a knob marker orphaned by a deleted parameter fails" {
+    write_real_aws_door
+    # Delete the SshCidr parameter, leave its `# grappa-knob: ssh_cidr` marker.
+    mutate_aws_door awk '/^[ ]*SshCidr:/ { skip = 1 } /grappa-knob:/ { skip = 0 } !skip'
+    grep -q "grappa-knob: ssh_cidr" "$AWS_DOOR" # marker survives, parameter does not
+
+    run "$GUARD"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ssh_cidr"* ]]
 }
 
 @test "RED: a missing knob marker fails with exit 1" {
-    write_good_aws_door
-    # Drop the ssh_cidr marker.
-    grep -v "grappa-knob: ssh_cidr" "$AWS_DOOR" > "$AWS_DOOR.tmp"
-    mv "$AWS_DOOR.tmp" "$AWS_DOOR"
+    write_real_aws_door
+    mutate_aws_door grep -v "grappa-knob: ssh_cidr"
     run "$GUARD"
     [ "$status" -eq 1 ]
     [[ "$output" == *"grappa-knob: ssh_cidr"* ]]
 }
 
-@test "RED: a door that does not reference first-boot.sh fails with exit 1" {
-    write_good_aws_door
-    grep -v "first-boot.sh" "$AWS_DOOR" > "$AWS_DOOR.tmp"
-    mv "$AWS_DOOR.tmp" "$AWS_DOOR"
+@test "RED: renaming an exported env var on the door side fails" {
+    write_real_aws_door
+    # The handshake break that kills every launched stack in UserData while
+    # both files stay individually valid (#746).
+    mutate_aws_door sed 's/GRAPPA_DOMAIN/GRAPPA_HOSTNAME/g'
     run "$GUARD"
     [ "$status" -eq 1 ]
-    [[ "$output" == *"first-boot.sh"* ]]
+    [[ "$output" == *"GRAPPA_DOMAIN"* ]]
+}
+
+@test "RED: a new required env in first-boot.sh that no door exports fails" {
+    write_real_aws_door
+    # The same break from the other side: the bootstrap starts requiring a knob
+    # the door never learned to pass.
+    printf '%s\n' 'GRAPPA_REGION="${GRAPPA_REGION:-}"' >> "$BOOTSTRAP"
+    run "$GUARD"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"GRAPPA_REGION"* ]]
+}
+
+@test "RED: a door exporting an env var the bootstrap does not require fails" {
+    write_real_aws_door
+    mutate_aws_door awk '
+        { print }
+        /export GRAPPA_ADMIN_EMAIL=/ { print "          export GRAPPA_RAW_BASE=x" }
+    '
+    run "$GUARD"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"GRAPPA_RAW_BASE"* ]]
 }
 
 @test "tolerant: absent infra/terraform is NOT drift" {
-    write_good_aws_door
+    write_real_aws_door
     # No infra/terraform/ dir exists in the sandbox.
     run "$GUARD"
     [ "$status" -eq 0 ]
 }
 
 @test "GREEN: a faithful Terraform door is also checked once present" {
-    write_good_aws_door
-    mkdir -p "$GRAPPA_REPO_ROOT/infra/terraform"
-    cat > "$GRAPPA_REPO_ROOT/infra/terraform/main.tf" <<'EOF'
-# grappa-knob: domain
-# grappa-knob: admin_email
-# grappa-knob: instance_type
-# grappa-knob: ssh_cidr
-# grappa-knob: disk_size_gb
-# user_data runs infra/cloud/first-boot.sh
-EOF
+    write_real_aws_door
+    write_real_tf_door
     run "$GUARD"
     [ "$status" -eq 0 ]
 }
 
 @test "RED: a Terraform door missing a knob fails once present" {
-    write_good_aws_door
-    mkdir -p "$GRAPPA_REPO_ROOT/infra/terraform"
-    cat > "$GRAPPA_REPO_ROOT/infra/terraform/main.tf" <<'EOF'
-# grappa-knob: domain
-# grappa-knob: admin_email
-# grappa-knob: instance_type
-# grappa-knob: ssh_cidr
-# user_data runs infra/cloud/first-boot.sh
-EOF
+    write_real_aws_door
+    write_real_tf_door
+    grep -v "grappa-knob: disk_size_gb" "$TF_DOOR" > "$TF_DOOR.tmp"
+    mv "$TF_DOOR.tmp" "$TF_DOOR"
     run "$GUARD"
     [ "$status" -eq 1 ]
     [[ "$output" == *"disk_size_gb"* ]]
+}
+
+@test "RED: a Terraform door whose user_data does not run the bootstrap fails" {
+    write_real_aws_door
+    write_real_tf_door
+    grep -vE '^[[:space:]]*(curl|bash) .*first-boot' "$TF_DOOR" > "$TF_DOOR.tmp"
+    mv "$TF_DOOR.tmp" "$TF_DOOR"
+    run "$GUARD"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"does not invoke first-boot.sh"* ]]
+}
+
+@test "RED: a door with no bootstrap block at all fails" {
+    write_real_aws_door
+    mutate_aws_door grep -v "UserData:"
+    run "$GUARD"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no UserData:/user_data bootstrap block"* ]]
 }
 
 @test "no doors at all is not a failure (exit 0)" {
@@ -107,8 +195,15 @@ EOF
 }
 
 @test "missing contract fails with exit 2 (misuse)" {
-    write_good_aws_door
+    write_real_aws_door
     rm "$GRAPPA_REPO_ROOT/infra/cloud/params.contract"
+    run "$GUARD"
+    [ "$status" -eq 2 ]
+}
+
+@test "missing first-boot.sh fails with exit 2 (misuse)" {
+    write_real_aws_door
+    rm "$BOOTSTRAP"
     run "$GUARD"
     [ "$status" -eq 2 ]
 }

--- a/test/infra/cloud_drift_guard_test.bats
+++ b/test/infra/cloud_drift_guard_test.bats
@@ -45,6 +45,12 @@ write_real_tf_door() {
     mkdir -p "$GRAPPA_REPO_ROOT/infra/terraform"
     TF_DOOR="$GRAPPA_REPO_ROOT/infra/terraform/main.tf"
     cat > "$TF_DOOR" <<'EOF'
+# grappa terraform door (#665). user_data curls the shared
+# infra/cloud/first-boot.sh at a git ref and execs it — it is NOT inlined
+# here, so this door and the CloudFormation one run the same bootstrap.
+# (This prose mirrors the shipped CFN template's: it must NOT be enough to
+# satisfy the guard on its own.)
+
 # grappa-knob: domain
 variable "domain" { type = string }
 
@@ -174,6 +180,8 @@ EOF
     write_real_tf_door
     grep -vE '^[[:space:]]*(curl|bash) .*first-boot' "$TF_DOOR" > "$TF_DOOR.tmp"
     mv "$TF_DOOR.tmp" "$TF_DOOR"
+    grep -q "first-boot.sh" "$TF_DOOR" # prose survives here too
+
     run "$GUARD"
     [ "$status" -eq 1 ]
     [[ "$output" == *"does not invoke first-boot.sh"* ]]


### PR DESCRIPTION
Refs #746.

`infra/cloud/check-drift.sh` exists so the CloudFormation door (#665 — the new
install door shipping in this release) and the shared `first-boot.sh` cannot
drift apart. Every check it performed was satisfiable by a comment.

## The defects, measured on the shipped template before anything was written

| mutation of `infra/aws/grappa-cloudformation.yaml` | guard before |
|---|---|
| delete the real `UserData` `curl`+`bash` (`:146-147`) | **OK** — the four prose mentions of `first-boot.sh` keep the whole-file grep happy |
| delete the `SshCidr:` parameter, keep `# grappa-knob: ssh_cidr` | **OK** |
| rename `GRAPPA_DOMAIN` on the template side only | **OK**, and bats green — every launched stack then dies in `UserData` |

The guard's own RED fixture could not have exposed the first: it wrote a
synthetic door naming the bootstrap on exactly one line and mutated it with
`grep -v "first-boot.sh"`, removing every trace. That mutation is impossible on
the real template, so the negative case proved the guard fails against a door
shape we do not ship.

## What the guard checks now

All three read the **executable surface** only:

1. **Invocation, anchored.** The door's bootstrap block (CFN `UserData:` /
   Terraform `user_data`, delimited by indentation) is extracted, comment lines
   dropped, and the invocation must live there. Prose elsewhere is not a
   bootstrap.
2. **Bound knob markers.** The first non-comment line after a `grappa-knob:`
   marker (before the next marker) is the declaration it annotates, so a marker
   orphaned by a deleted parameter reads as a missing knob. A marker written as
   a trailing comment on the declaration counts as bound.
3. **The env handshake**, which did not exist. Set-equality between the
   `GRAPPA_*` a door exports and the env `first-boot.sh` requires — in BOTH
   directions: the missing side catches a door that never passes a required
   knob, the extra side catches the rename, which is otherwise invisible
   because each file stays individually valid.

Required-env is derived from the bootstrap's own code — a knob is required iff
it is read with an empty default (`GRAPPA_X="${GRAPPA_X:-}"`) — never from a
`# grappa-env:` marker, which is the detached-comment disease this PR removes.
The cost is that the assignment shape is load-bearing; it is stated at both
ends, and a parse yielding nothing exits 2 rather than passing vacuously.

## Tests

Every RED case mutates a **copy of the real shipped template**, one defect at a
time, and asserts the mutated door **still names `first-boot.sh`** — that
assertion is what makes it a test of the fix rather than of the fixture. The
Terraform fixture grows the same prose for the same reason: without it, the
"user_data does not run the bootstrap" case passed under the old whole-file
grep too, so it asserted a message rather than a behaviour.

## Verification

- Each of the three defects reproduced on the real template first (table above).
- Each new check then **reverted in isolation**; only its own cases fell:
  - block anchoring → cases 2, 11, 12
  - bound markers → case 3
  - missing-env direction → cases 5, 6
  - extra-env direction → case 7
- `test/infra/cloud_drift_guard_test.bats`: 16/16.
- Full bats set (`test/bin/ test/infra/ test/scripts/`): **278/278, rc=0**.
- `shellcheck -x infra/cloud/first-boot.sh infra/cloud/check-drift.sh`: clean.
- Working tree verified clean before and after the gates.

Shell/bats/docs only — no Elixir, no `config/`, no `lib/`.

### One incidental find
The first required-env parse used `sed -E` with a backreference
(`s/^(GRAPPA_[A-Z0-9_]+)="\$\{\1:-\}".*/\1/p`) and matched **nothing** on BSD
sed — `\1` inside the pattern is a GNU extension. It surfaced as a loud exit 2
rather than a silently empty required set only because the empty-parse guard
was written first; it is now awk with a whole-line compare.