### PR TITLE
visitors(#828): a stale ANON credential no longer owns a nick nobody holds

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -28823,3 +28823,46 @@ Each new check was then reverted in isolation and only its own cases fell.
 parse used `s/^(GRAPPA_[A-Z0-9_]+)="\$\{\1:-\}".*/\1/p` and matched NOTHING on
 BSD sed. It surfaced as exit 2 rather than as a silently empty required set only
 because the empty-parse guard was written first — the same reason it stays.
+
+## 2026-08-05 — #828: a row in the registry is not a client on the network
+
+A visitor on grappa tried `/nick Cyber` on Azzurra and got 409 `nick_in_use`
+for a nick that was free upstream — no such client in `/whois`, NickServ
+enforcer not connected, confirmed independently by a second oper. Production,
+2026-08-04 ~23:21 CEST.
+
+The visitor branch of `POST /networks/:id/nick` ran a pre-check the user branch
+never had: a query over `network_credentials` for the folded nick on the
+network (`Visitors.nick_in_use?/3` → `Credentials.fetch_visitor_credential_by_nick/2`).
+The name said "in use"; the query said "recorded". Those are different
+questions, and the gap between them is a visitor who connected once, left, and
+whose ANON credential the reaper has not collected. That dead row held the nick
+against everyone else for as long as it lived.
+
+The authority on whether a nick is available is the ircd, and it was already
+answering. `433` during registration is classified `:nick_in_use` by
+`Visitors.Login.classify_down/1`; post-registration it lands on `$server`
+through the `NumericRouter` deny list (the rejected nick is not a routing
+destination). So on the "taken upstream" case the pre-check duplicated an
+answer we already get, and on the "free upstream" case it invented a refusal.
+
+The pre-check is now narrowed to IDENTIFIED holders rather than deleted,
+because there the question genuinely is different: the nick of an identified
+credential is its LOGIN KEY, bound at the proven `+r` (#561, held against a
+services-forced Guest), so handing it to another visitor is an identity
+problem, not a wire-availability one. `nick_in_use?/3` was renamed
+`nick_held_by_identified?/3` in the same change: the misleading name is the
+shape of the bug, and leaving it in place after narrowing the behaviour invites
+the next caller to make the same reading. The 409 wire token is unchanged.
+
+**Known incompleteness, deliberately not fixed here.** The folded-nick partial
+UNIQUE (`network_credentials_visitor_folded_nick_network_id_index`) still
+guards the persist. Against a stale ANON row that is no longer a
+near-zero-probability race but the steady state: the rename now succeeds on the
+wire, while `Credentials.update_visitor_credential_nick/3` fails the changeset
+and `Session.Server` logs and drops it — so the live session carries the new
+nick and the credential keeps the old one until the row is collected. The user's
+reported symptom (a refusal for a free nick) is gone either way. Closing the
+remaining half means deciding whether a live rename may RELEASE a dead ANON
+row's claim, which is the reaper-retention question #828 already defers as a
+follow-up, and it is a design call rather than a bug fix.

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -5336,7 +5336,8 @@ defmodule Grappa.Session.Server do
   # a services-forced `GuestNNNNN`; the identified nick is bound at +r via
   # `commit_identity/4`. The `(nick, network_slug)` UNIQUE constraint catches the
   # near-zero-probability concurrent-rename race; controller-boundary
-  # `Visitors.nick_in_use?/3` is the fast-path 409. User sessions
+  # `Visitors.nick_held_by_identified?/3` is the fast-path 409 for an
+  # identified holder (#828 — an ANON holder does not refuse). User sessions
   # don't carry a persister — their nick lives in `Networks.Credential`,
   # which is operator-driven and rotated via the user-side path
   # documented in `nick_controller.ex`.

--- a/lib/grappa/visitors.ex
+++ b/lib/grappa/visitors.ex
@@ -970,22 +970,41 @@ defmodule Grappa.Visitors do
   end
 
   @doc """
-  Visitor-side NICK rename pre-check (V9). Returns `true` if a
-  DIFFERENT visitor identity already holds `target_nick` on `network_id`;
-  the caller surfaces that as 409 nick_in_use BEFORE sending NICK
-  upstream. False if the slot is free, or if the only occupant IS the
-  visitor itself (idempotent rename to current nick).
+  Visitor-side NICK rename pre-check (V9, narrowed by #828). Returns
+  `true` if a DIFFERENT visitor identity holds `target_nick` on
+  `network_id` under an IDENTIFIED credential; the caller surfaces that
+  as 409 nick_in_use BEFORE sending NICK upstream. False if the slot is
+  free, if the only occupant IS the visitor itself (idempotent rename to
+  current nick), or if the occupant is ANON.
+
+  #828 — the ANON exemption is the whole point. This is a query over the
+  local credential registry: it answers "is this nick recorded against
+  some visitor row", NOT "is this nick in use on the network right now".
+  A visitor who connected once and left keeps its ANON row until the
+  reaper collects it, and pre-#828 that dead row refused the nick to
+  everyone else forever — observed in production on Azzurra
+  (2026-08-04), a nick free upstream that grappa would not hand out. The
+  only authority on wire availability is the ircd, which already answers
+  with `433` (classified `:nick_in_use` in `Visitors.Login`, routed to
+  `$server` post-registration), so the ANON pre-check bought nothing on
+  the taken case and lied on the free one.
+
+  An IDENTIFIED credential is a different question and keeps its
+  refusal: there the nick is the LOGIN KEY (#561 — bound at the proven
+  `+r`, held against a services-forced Guest), so letting another
+  visitor take it is an identity problem, not a wire-availability one.
 
   #211 phase 7 — folded lookup on the `(fold(nick), network_id)`
   credential (the same reader login uses), NOT the retired
   `visitors.(nick, network_slug)` row index.
   """
-  @spec nick_in_use?(Ecto.UUID.t(), String.t(), pos_integer()) :: boolean()
-  def nick_in_use?(visitor_id, target_nick, network_id)
+  @spec nick_held_by_identified?(Ecto.UUID.t(), String.t(), pos_integer()) :: boolean()
+  def nick_held_by_identified?(visitor_id, target_nick, network_id)
       when is_binary(visitor_id) and is_binary(target_nick) and is_integer(network_id) do
     case Credentials.fetch_visitor_credential_by_nick(target_nick, network_id) do
       {:error, :not_found} -> false
       {:ok, %Credential{visitor_id: ^visitor_id}} -> false
+      {:ok, %Credential{auth_method: :none}} -> false
       {:ok, %Credential{}} -> true
     end
   end
@@ -1004,8 +1023,10 @@ defmodule Grappa.Visitors do
   this is network-explicit. The credential-side folded-nick UNIQUE index
   (phase 4b) catches concurrent collisions (two visitors racing for the
   same nick on the same network) — the controller-boundary
-  `nick_in_use?/3` pre-check is the fast path; this is the second line of
-  defense for the near-zero-probability race.
+  `nick_held_by_identified?/3` pre-check is the fast path for an
+  identified holder (#828 — an ANON holder no longer refuses, so this
+  constraint is what a collision with a stale ANON row hits); this is the
+  second line of defense.
 
   #561 — the echo persist is GATED downstream: it rotates the nick only
   while the credential is ANON (`auth_method: :none`). An IDENTIFIED

--- a/lib/grappa_web/controllers/nick_controller.ex
+++ b/lib/grappa_web/controllers/nick_controller.ex
@@ -13,11 +13,17 @@ defmodule GrappaWeb.NickController do
   per-subject infrastructure.
 
   Visitor branch carries one extra step: a `(target_nick, network_id)`
-  pre-check via `Visitors.nick_in_use?/3` BEFORE the upstream NICK
-  frame is sent. If another visitor already holds the target nick
-  on the same network, the controller returns 409 `nick_in_use` and
-  no NICK frame reaches upstream. The check is fast-path; the
-  credential-side folded-nick UNIQUE
+  pre-check via `Visitors.nick_held_by_identified?/3` BEFORE the
+  upstream NICK frame is sent. If another visitor's IDENTIFIED
+  credential holds the target nick on the same network, the controller
+  returns 409 `nick_in_use` and no NICK frame reaches upstream — there
+  the nick is that visitor's login key (#561). An ANON row does NOT
+  refuse (#828): the credential registry knows who was recorded here,
+  not who is on the network now, and a stale ANON row used to block a
+  nick that was free upstream. The ircd answers that question itself
+  with `433`, which post-registration lands on `$server` via the
+  NumericRouter deny list. The check is fast-path; the credential-side
+  folded-nick UNIQUE
   (`network_credentials_visitor_folded_nick_network_id_index`, keyed on
   `(fold(nick), network_id)`) is the second line of defense that catches
   the near-zero-probability concurrent-rename race at the EventRouter
@@ -54,8 +60,8 @@ defmodule GrappaWeb.NickController do
   `NICK <new>` upstream through the session and returns 202 + `{"ok": true}`.
   Empty / non-string nick → 400. `:no_session` / `:invalid_line` collapse
   through `FallbackController` to 404 / 400 respectively. Visitor branch
-  adds 409 `nick_in_use` (target collides with another visitor row on
-  the same network) + 400 `malformed_nick` (target rejected by
+  adds 409 `nick_in_use` (target is the login key of another visitor's
+  IDENTIFIED credential on the same network — #828) + 400 `malformed_nick` (target rejected by
   `IRC.Identifier.valid_nick?/1` at the boundary, since the visitor
   schema's `nick_changeset/2` would reject it later — the controller
   surfaces it now to keep the failure mode consistent with login).
@@ -88,13 +94,16 @@ defmodule GrappaWeb.NickController do
 
   def create(_, _), do: {:error, :bad_request}
 
-  # V9 boundary check — surface the syntactic + uniqueness rejections
+  # V9 boundary check — surface the syntactic + identity rejections
   # at the controller before the upstream NICK frame goes out. Mirrors
   # the visitor login boundary's `Identifier.valid_nick?/1` shape so
   # the failure modes a visitor sees on /nick match what they saw on
   # initial login. #211 phase 7 — the collision check is per-network on
-  # the credential (`nick_in_use?/3` keyed on network_id), not the retired
-  # `visitors.(nick, network_slug)` row index.
+  # the credential (`nick_held_by_identified?/3` keyed on network_id),
+  # not the retired `visitors.(nick, network_slug)` row index. #828 — it
+  # is an IDENTITY guard, not an availability guard: availability is the
+  # ircd's answer (433), and asking the local registry instead refused
+  # free nicks off rows nobody was using.
   @spec check_visitor_nick(Ecto.UUID.t(), pos_integer(), String.t()) ::
           :ok | {:error, :malformed_nick | :nick_in_use}
   defp check_visitor_nick(visitor_id, network_id, nick) do
@@ -102,7 +111,7 @@ defmodule GrappaWeb.NickController do
       not Grappa.IRC.Identifier.valid_nick?(nick) ->
         {:error, :malformed_nick}
 
-      Visitors.nick_in_use?(visitor_id, nick, network_id) ->
+      Visitors.nick_held_by_identified?(visitor_id, nick, network_id) ->
         {:error, :nick_in_use}
 
       true ->

--- a/test/grappa/visitors_test.exs
+++ b/test/grappa/visitors_test.exs
@@ -397,23 +397,37 @@ defmodule Grappa.VisitorsTest do
     end
   end
 
-  describe "nick_in_use?/3 (per-network credential folded lookup)" do
-    test "true when a DIFFERENT visitor holds the folded nick on the network", %{network: net} do
-      {:ok, _} = Visitors.find_or_provision_anon("Taken", @network, "1.2.3.4")
+  describe "nick_held_by_identified?/3 (per-network credential folded lookup)" do
+    test "true when a DIFFERENT visitor's IDENTIFIED credential holds the folded nick",
+         %{network: net} do
+      {:ok, holder} = Visitors.find_or_provision_anon("Taken", @network, "1.2.3.4")
+      {:ok, _} = Visitors.commit_password(holder.id, net.id, "s3cret")
       {:ok, other} = Visitors.find_or_provision_anon("other", @network, "5.6.7.8")
 
       # ASCII-folded: `taken` collides with `Taken`.
-      assert Visitors.nick_in_use?(other.id, "taken", net.id)
+      assert Visitors.nick_held_by_identified?(other.id, "taken", net.id)
     end
 
-    test "false when only the visitor itself holds the nick (idempotent rename)", %{network: net} do
+    # #828 — the ANON row answers "was recorded here once", not "is on the
+    # network now". Refusing off it stranded nicks that were free upstream.
+    test "false when the holder credential is ANON", %{network: net} do
+      {:ok, _} = Visitors.find_or_provision_anon("Taken", @network, "1.2.3.4")
+      {:ok, other} = Visitors.find_or_provision_anon("other", @network, "5.6.7.8")
+
+      refute Visitors.nick_held_by_identified?(other.id, "taken", net.id)
+    end
+
+    test "false when only the visitor itself holds the nick, even identified (idempotent rename)",
+         %{network: net} do
       {:ok, v} = Visitors.find_or_provision_anon("Self", @network, "1.2.3.4")
-      refute Visitors.nick_in_use?(v.id, "self", net.id)
+      {:ok, _} = Visitors.commit_password(v.id, net.id, "s3cret")
+
+      refute Visitors.nick_held_by_identified?(v.id, "self", net.id)
     end
 
     test "false when the slot is free", %{network: net} do
       {:ok, v} = Visitors.find_or_provision_anon("vjt-free", @network, "1.2.3.4")
-      refute Visitors.nick_in_use?(v.id, "nobody-here", net.id)
+      refute Visitors.nick_held_by_identified?(v.id, "nobody-here", net.id)
     end
   end
 

--- a/test/grappa_web/controllers/nick_controller_test.exs
+++ b/test/grappa_web/controllers/nick_controller_test.exs
@@ -4,9 +4,11 @@ defmodule GrappaWeb.NickControllerTest do
   happy path 202; iso boundary (cross-user 404); no-session 404;
   bad_request guards. V9 (visitor-parity cluster, 2026-05-15) lifts
   the visitor short-circuit — visitors now traverse the same path
-  as users, with a per-(nick, network_slug) UNIQUE pre-check that
-  surfaces as 409 nick_in_use when another visitor row already holds
-  the target nick on the same network.
+  as users, with a per-network credential pre-check that surfaces as
+  409 nick_in_use when another visitor's IDENTIFIED credential holds
+  the target nick. #828 narrowed that pre-check to identified holders
+  only: an ANON row answers "recorded here once", not "in use on the
+  network now", and the ircd's 433 is the authority on the latter.
 
   `async: false` because Session uses singleton supervisors + Registry;
   see `Grappa.Session.ServerTest` for the same rationale.
@@ -15,12 +17,27 @@ defmodule GrappaWeb.NickControllerTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.IRCServer
+  alias Grappa.{IRCServer, Scrollback}
 
   defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
 
-  defp start_server do
-    {:ok, server} = IRCServer.start_link(passthrough_handler())
+  # Completes registration (001) so the session is welcomed and inbound
+  # numerics traverse the post-registration path (NumericRouter) instead
+  # of AuthFSM's registration clauses.
+  defp welcoming_handler do
+    fn state, line ->
+      if String.starts_with?(line, "USER ") do
+        {:reply, ":irc.test.org 001 grappa-test :Welcome\r\n", state}
+      else
+        {:reply, nil, state}
+      end
+    end
+  end
+
+  defp start_server, do: start_server(passthrough_handler())
+
+  defp start_server(handler) do
+    {:ok, server} = IRCServer.start_link(handler)
     {server, IRCServer.port(server)}
   end
 
@@ -154,18 +171,103 @@ defmodule GrappaWeb.NickControllerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
-    test "visitor subject — 409 nick_in_use when another visitor row holds the target nick on the same network",
+    # #828 — a stale ANON credential is a registry artefact, not an
+    # authority on who holds the nick upstream. Pre-fix the boundary
+    # answered 409 off that row and the NICK frame never left the box,
+    # so a nick free on the network stayed unreachable forever (observed
+    # in production on Azzurra, 2026-08-04).
+    test "visitor subject — 202 + NICK upstream when only a stale ANON credential holds the target nick (#828)",
          %{conn: _conn} do
       {server, port} = start_server()
-      old_nick = "v9a-#{System.unique_integer([:positive])}"
+      old_nick = "v828a-#{System.unique_integer([:positive])}"
       {visitor, network} = visitor_with_network(port, nick: old_nick)
       session = visitor_session_fixture(visitor)
 
-      # Squat the target nick with ANOTHER visitor row on the same
-      # network. The pre-check at the controller boundary surfaces 409
-      # before the upstream NICK frame is sent.
-      target_nick = "v9b-#{System.unique_integer([:positive])}"
+      # A DIFFERENT visitor identity whose ANON credential still records
+      # the target nick — the shape the reaper has not collected yet.
+      target_nick = "v828b-#{System.unique_integer([:positive])}"
       _ = visitor_fixture(nick: target_nick, network_slug: network.slug)
+
+      pid = start_visitor_session_for(visitor, network)
+      :ok = await_handshake(server)
+
+      conn =
+        Phoenix.ConnTest.build_conn()
+        |> put_bearer(session.id)
+        |> put_req_header("content-type", "application/json")
+        |> post("/networks/#{network.slug}/nick", %{"nick" => target_nick})
+
+      assert json_response(conn, 202) == %{"ok" => true}
+
+      # The frame reaches the ircd — the only authority on the nick.
+      {:ok, line} = IRCServer.wait_for_line(server, &(&1 == "NICK #{target_nick}\r\n"), 1_000)
+      assert line == "NICK #{target_nick}\r\n"
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # #828 — the other half of the same contract: dropping the ANON
+    # pre-check does not lose the refusal, it relocates it to the party
+    # that actually knows. A nick genuinely taken upstream comes back as
+    # the ircd's own 433, routed to `$server` by the NumericRouter deny
+    # list (`{:server, nil}` — the rejected nick is not a destination).
+    test "visitor subject — a nick taken upstream is refused by the ircd's 433, not by the controller (#828)",
+         %{conn: _conn} do
+      {server, port} = start_server(welcoming_handler())
+      old_nick = "v828c-#{System.unique_integer([:positive])}"
+      {visitor, network} = visitor_with_network(port, nick: old_nick)
+      session = visitor_session_fixture(visitor)
+      pid = start_visitor_session_for(visitor, network)
+      :ok = await_handshake(server)
+
+      # Free in the registry — nothing squats it locally. Upstream is the
+      # one that says no.
+      target_nick = "v828d-#{System.unique_integer([:positive])}"
+
+      conn =
+        Phoenix.ConnTest.build_conn()
+        |> put_bearer(session.id)
+        |> put_req_header("content-type", "application/json")
+        |> post("/networks/#{network.slug}/nick", %{"nick" => target_nick})
+
+      assert json_response(conn, 202) == %{"ok" => true}
+
+      {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "NICK #{target_nick}\r\n"), 1_000)
+
+      :ok =
+        IRCServer.feed(
+          server,
+          ":irc.test.org 433 #{old_nick} #{target_nick} :Nickname is already in use\r\n"
+        )
+
+      assert_eventually(fn ->
+        {:visitor, visitor.id}
+        |> Scrollback.fetch(network.id, "$server", nil, 10, nil, false)
+        |> Enum.any?(&(&1.body == "Nickname is already in use"))
+      end)
+
+      # The rename did not happen: the credential still carries the old nick.
+      assert {:ok, %{nick: ^old_nick}} =
+               Grappa.Networks.Credentials.get_visitor_credential(visitor.id, network.id)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # #561/#828 — the pre-check SURVIVES for identified credentials: an
+    # identified visitor's nick is its login key, so handing it to another
+    # visitor is an identity problem, not a wire-availability question.
+    test "visitor subject — 409 nick_in_use when another visitor's IDENTIFIED credential holds the target nick",
+         %{conn: _conn} do
+      {server, port} = start_server()
+      old_nick = "v828e-#{System.unique_integer([:positive])}"
+      {visitor, network} = visitor_with_network(port, nick: old_nick)
+      session = visitor_session_fixture(visitor)
+
+      target_nick = "v828f-#{System.unique_integer([:positive])}"
+      holder = visitor_fixture(nick: target_nick, network_slug: network.slug)
+      # Promote the holder through the production verb — committing the
+      # NickServ secret is what flips the credential to :nickserv_identify.
+      {:ok, _} = Grappa.Visitors.commit_password(holder.id, network.id, "s3cret")
 
       pid = start_visitor_session_for(visitor, network)
       :ok = await_handshake(server)

--- a/test/grappa_web/controllers/nick_controller_test.exs
+++ b/test/grappa_web/controllers/nick_controller_test.exs
@@ -17,7 +17,8 @@ defmodule GrappaWeb.NickControllerTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.{IRCServer, Scrollback}
+  alias Grappa.{IRCServer, Scrollback, Visitors}
+  alias Grappa.Networks.Credentials
 
   defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
 
@@ -162,7 +163,7 @@ defmodule GrappaWeb.NickControllerTest do
       # handle_info reduction. Polling keeps the test honest under
       # mailbox latency.
       assert_eventually(fn ->
-        case Grappa.Networks.Credentials.get_visitor_credential(visitor.id, network.id) do
+        case Credentials.get_visitor_credential(visitor.id, network.id) do
           {:ok, %{nick: ^new_nick}} -> true
           _ -> false
         end
@@ -248,7 +249,7 @@ defmodule GrappaWeb.NickControllerTest do
 
       # The rename did not happen: the credential still carries the old nick.
       assert {:ok, %{nick: ^old_nick}} =
-               Grappa.Networks.Credentials.get_visitor_credential(visitor.id, network.id)
+               Credentials.get_visitor_credential(visitor.id, network.id)
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
@@ -267,7 +268,7 @@ defmodule GrappaWeb.NickControllerTest do
       holder = visitor_fixture(nick: target_nick, network_slug: network.slug)
       # Promote the holder through the production verb — committing the
       # NickServ secret is what flips the credential to :nickserv_identify.
-      {:ok, _} = Grappa.Visitors.commit_password(holder.id, network.id, "s3cret")
+      {:ok, _} = Visitors.commit_password(holder.id, network.id, "s3cret")
 
       pid = start_visitor_session_for(visitor, network)
       :ok = await_handshake(server)
@@ -292,7 +293,7 @@ defmodule GrappaWeb.NickControllerTest do
 
       # DB unchanged — the per-network credential nick stays the original.
       assert {:ok, %{nick: nick}} =
-               Grappa.Networks.Credentials.get_visitor_credential(visitor.id, network.id)
+               Credentials.get_visitor_credential(visitor.id, network.id)
 
       assert nick == old_nick
 


### PR DESCRIPTION
Refs #828.

## What was wrong

A visitor renaming to a nick that is free on the network got 409 `nick_in_use`.
Seen in production on Azzurra 2026-08-04 ~23:21 CEST: the nick was free
upstream (no client in `/whois`, NickServ enforcer absent, confirmed by a
second oper) and grappa refused it anyway.

The visitor branch of `POST /networks/:id/nick` ran a pre-check the user branch
never had — a query over `network_credentials` for the folded nick on the
network. It answers *"is this nick recorded against some visitor row"*, not
*"is this nick in use on the network right now"*. A visitor who connected once
and left keeps its ANON credential until the reaper collects it, and that dead
row refused the nick to everyone else indefinitely.

## What changed

- `Visitors.nick_in_use?/3` → `nick_held_by_identified?/3`, and it now returns
  `false` for an ANON holder. The rename is deliberate: the old name promised
  network truth and delivered registry truth, which is the shape of the bug.
- The pre-check survives for IDENTIFIED holders, where the nick is the login
  key bound at the proven `+r` (#561) and giving it away is an identity
  problem, not an availability one.
- The 409 wire token is unchanged; the folded-nick partial UNIQUE is untouched.
- Availability now comes back from the only authority that has it: the ircd's
  `433`, classified `:nick_in_use` at login and routed to `$server`
  post-registration.

## Tests — three regressions, each mutation-proved

Controller-driven, in `nick_controller_test.exs`, plus the unit twins in
`visitors_test.exs`:

1. stale ANON holder → 202 and the `NICK` frame reaches upstream
2. nick taken upstream → 202, then the ircd's 433 lands on `$server`, and the
   credential nick does not rotate
3. IDENTIFIED holder → 409 `nick_in_use`, no `NICK` frame on the wire

Mutations, one branch at a time (`_build` recompile confirmed each time):

| mutation | red |
|---|---|
| drop the `auth_method: :none -> false` clause | test 1 + its unit twin, nothing else |
| identified holder returns `false` | test 3 + its unit twin, nothing else |
| 433 added to `@delegated_numerics` (no `$server` persist) | test 2 only |

Note on test 2's oracle: removing 433 from the `@active_numerics` deny list
does **not** make it fail, because a query-routed error numeric with no open
window is redirected to `$server` anyway. Test 2 asserts the visitor sees the
refusal, not the routing mechanism — the delegation mutation is what displaces
it.

## Known incompleteness — flagged, not fixed here

With the ANON refusal gone, the persist-time UNIQUE stops being a
near-zero-probability race guard and becomes the steady state for exactly this
scenario: the rename succeeds on the wire, then
`Credentials.update_visitor_credential_nick/3` fails the changeset and
`Session.Server` logs and drops it — so the live session carries the new nick
while the credential keeps the old one until the stale row is collected. The
reported symptom is gone either way. Closing the other half means deciding
whether a live rename may RELEASE a dead ANON row's claim, which is the
reaper-retention follow-up #828 already defers, and a design call rather than a
bug fix. Written up in DESIGN_NOTES.

## Gates

`scripts/check.sh` green from the worktree root: `8 doctests, 50 properties,
5119 tests, 0 failures`; dialyzer `Total errors: 0`; doctor, credo, sobelow,
bats all pass; `rc=0`.