### PR TITLE
shottino(#756): stop a header-less WHIP response from unbounding the header scan

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -28866,3 +28866,43 @@ reported symptom (a refusal for a free nick) is gone either way. Closing the
 remaining half means deciding whether a live rename may RELEASE a dead ANON
 row's claim, which is the reaper-retention question #828 already defers as a
 follow-up, and it is a design call rather than a bug fix.
+## 2026-08-05 — #756: an empty header block is empty, not endless
+
+`whip_response_parse` bounds the header scan by subtracting two pointers it
+derives INDEPENDENTLY: `hdr_end`, the start of the blank-line terminator found
+by scanning for `\n\n` / `\r\n\r\n`, and `hblock`, one past the status line's
+first `\n`. With at least one header line those two agree. With ZERO header
+lines they CROSS, because the terminator's first newline IS the status line's
+own: `"HTTP/1.1 200 OK\r\n\r\n"` puts `hdr_end` at index 15 and `hblock` at 17,
+and `(size_t)(15 - 17)` is `SIZE_MAX - 1`. The LF-only spelling gives `SIZE_MAX`
+the same way. `header_value` is bounded by nothing else, so it walked off the
+end of the 256 KB response buffer hunting for `\n` and `Location:` — and on a
+hit, `memcpy`'d up to 2047 bytes of adjacent heap into `out->location`, which
+becomes the session resource and is later sent to the server in the `DELETE`.
+The responding host is attacker-choosable: a WHIP endpoint is named in a call
+invite, and an invite is an `http(s)://` URL arriving in an IRC message.
+
+**Clamped to 0, not refused.** Both are memory-safe; the choice is about who
+owns the policy. A header-less `200` is well-formed HTTP that happens to be
+useless, and this parser already says elsewhere that an unusable response is a
+SUCCESSFUL parse reporting its status — the 404 case, where the caller decides
+what 4xx means. Refusing would move that judgement into the parser AND destroy
+the status on the way out: `call/main.c` reports "the endpoint answered %d",
+which would degrade to the generic "malformed HTTP response from %s". The
+caller already handles an absent Location (`resp.location[0]` gates
+`have_resource`), so the clamp costs nothing and keeps the diagnosis honest.
+
+**The class was swept, not just the example.** Every other unsigned subtraction
+in `whip.c` has its operands ordered by a preceding guard — `sp - raw` and
+`slash - base->path` come from a forward scan of the same buffer; `len -
+body_at` is covered by the `i + 1 < len` / `i + 3 < len` loop conditions that
+set `body_at`; `line_end - v` is covered by the `line_end - pos > name_len`
+test that admitted the line. `http.c` has no header parser at all — only the
+chunked decoder, which already carries its own `SIZE_MAX` overflow guard. This
+crossing was the one place two pointers were derived by separate scans.
+
+**Both spellings are load-bearing in the test.** The bytes are handed to the
+parser in a TIGHT heap allocation rather than the 256 KB buffer production
+uses, so the over-read is an ASan abort instead of a quiet stroll; with the
+clamp reverted, the CRLF case trips at 0 bytes past a 19-byte region and the
+LF-only case, run alone, trips at 0 bytes past a 17-byte one.

--- a/frontends/shottino/call/whip.c
+++ b/frontends/shottino/call/whip.c
@@ -221,7 +221,15 @@ bool whip_response_parse(const char *raw, size_t len, struct whip_response *out)
     const char *first_eol = memchr(raw, '\n', len);
     if (!first_eol) return false;
     const char *hblock = first_eol + 1;
-    size_t hlen = (size_t)(hdr_end - hblock);
+    /* With ZERO header lines the blank-line terminator IS the status
+     * line's own newline, so hblock lands PAST hdr_end and the two
+     * pointers have crossed: subtracting them into a size_t wraps to
+     * about SIZE_MAX and the header scan below walks off the end of the
+     * buffer. Such a response has an EMPTY header block, which is what
+     * the clamp says. It is not refused: a response nobody can use is
+     * still a response, and the caller reports its status — same
+     * reasoning as the 404 that parses fine and has no Location. */
+    size_t hlen = hblock < hdr_end ? (size_t)(hdr_end - hblock) : 0;
 
     header_value(hblock, hlen, "Location", out->location, sizeof(out->location));
 

--- a/frontends/shottino/tests/test_whip.c
+++ b/frontends/shottino/tests/test_whip.c
@@ -174,9 +174,44 @@ TEST(a_response_is_parsed_or_refused) {
     whip_response_free(&r);
 }
 
+/* Both spellings of a response carrying ZERO header lines. The blank-line
+ * terminator IS the status line's own newline, so the two pointers that
+ * bound the header block have CROSSED: subtracting them into a size_t
+ * wraps to about SIZE_MAX and the header scan then walks off the end of
+ * the response buffer, reading — and, on a "Location:" hit, COPYING into
+ * the session resource — whatever heap follows it.
+ *
+ * The bytes are handed over in a TIGHT heap allocation, so the over-read
+ * is a sanitizer abort here rather than the quiet stroll through the rest
+ * of a 256 KB buffer that it is in production. */
+static void a_response_with_no_headers(const char *bytes) {
+    size_t len = strlen(bytes);
+    char *tight = malloc(len);
+    CHECK(tight != NULL);
+    if (!tight) return;
+    memcpy(tight, bytes, len);
+
+    /* Well-formed, just useless: the status is reported and the caller
+     * decides what to do about the missing Location, exactly as it does
+     * for a 404. */
+    struct whip_response r;
+    CHECK(whip_response_parse(tight, len, &r));
+    CHECK_LONG(r.status, 200);
+    CHECK_STR(r.location, "");
+    CHECK_LONG((long)r.body_len, 0);
+    whip_response_free(&r);
+    free(tight);
+}
+
+TEST(a_header_block_can_be_empty_but_never_endless) {
+    a_response_with_no_headers("HTTP/1.1 200 OK\r\n\r\n");
+    a_response_with_no_headers("HTTP/1.1 200 OK\n\n");
+}
+
 int main(void) {
     RUN(a_url_is_split_or_refused);
     RUN(a_location_resolves_against_the_request);
     RUN(a_response_is_parsed_or_refused);
+    RUN(a_header_block_can_be_empty_but_never_endless);
     return test_report();
 }


### PR DESCRIPTION
Fixes the highest-severity finding of the `frontends/shottino` review slice (#756). Verified still live against current `main` before touching anything: `call/whip.c:221-224`, `:209`, `:163-165` are textually as cited.

## The defect

`whip_response_parse` bounds the header block by subtracting two pointers derived by SEPARATE scans:

- `hdr_end` — start of the blank-line terminator, from the `\n\n` / `\r\n\r\n` loop
- `hblock` — one past the status line's first `\n`

With at least one header line they agree. With ZERO header lines they **cross**, because the terminator's first newline IS the status line's own:

| input | `hdr_end` | `hblock` | `hlen` |
|---|---|---|---|
| `"HTTP/1.1 200 OK\r\n\r\n"` (19) | `raw+15` | `raw+17` | `SIZE_MAX - 1` |
| `"HTTP/1.1 200 OK\n\n"` (17) | `raw+15` | `raw+16` | `SIZE_MAX` |

`header_value` is bounded by nothing else, so it walks off the end of the 256 KB response buffer hunting for `\n` and `Location:` — and on a hit `memcpy`s up to 2047 bytes of adjacent heap into `out->location`, which becomes `s->resource` and is later sent to the server in the `DELETE`. The responding host is attacker-choosable (a WHIP endpoint is named in a call invite; an invite is an `http(s)://` URL from an IRC message), though joining is user-initiated, so not zero-click.

## The fix — clamped, not refused

```c
size_t hlen = hblock < hdr_end ? (size_t)(hdr_end - hblock) : 0;
```

Both clamp and `return false` are memory-safe; the choice is about who owns the policy. A header-less `200` is well-formed HTTP that happens to be useless, and this parser already says so elsewhere — `test_whip.c:142`: *"An error status is a SUCCESSFUL parse that reports the status — the caller decides what 4xx means, not the parser."* Refusing would move that judgement into the parser AND destroy the status on the way out: `call/main.c:701` reports "the endpoint answered %d", which would degrade to the generic "malformed HTTP response from %s". `call/main.c:715` already gates `have_resource` on `resp.location[0]`, so the clamp costs nothing and keeps the diagnosis honest.

## The class, not just the example

Swept every other unsigned subtraction in the file — each has its operands ordered by a preceding guard:

- `sp - raw` (`:192`), `slash - base->path` (`:146`) — forward scans of the same buffer
- `len - body_at` (`:228`) — covered by the `i + 1 < len` / `i + 3 < len` loop conditions that set `body_at`
- `line_end - v` (`:173`) — covered by the `line_end - pos > name_len` test that admitted the line

`http.c` has no header parser at all, only the chunked decoder, which already carries its own `SIZE_MAX` overflow guard. This crossing was the one place two pointers were derived by separate scans.

## Test

TDD: the regression test went in first and was watched fail for the right reason — ASan `heap-buffer-overflow READ` in `header_value`, called from `whip_response_parse`. The bytes are handed over in a **tight heap allocation** rather than the 256 KB buffer production uses, so the over-read is an abort instead of a quiet stroll.

Both spellings proven load-bearing by displacement — with the clamp reverted:
- CRLF: `0 bytes after 19-byte region`
- LF-only, run alone: `0 bytes after 17-byte region`

## Gate

`make -C frontends/shottino check` is the CI gate. Locally on macOS 10/16 suites build and are green (`test_whip` 78 checks); the other 6 (`test_callmedia`, `test_layout`, `test_keys`, `test_ircd`, `test_commands`, `test_windows`) fail to COMPILE on this toolchain with `INADDR_LOOPBACK` / `MSG_DONTWAIT` undeclared under `_POSIX_C_SOURCE` — **proven pre-existing**: the identical failing set appears at the merge-base with this change removed, and none of those targets compile `call/whip.c`. CI is Ubuntu, where they build.