### PR TITLE
shottino(#761): refuse the room the CSPRNG could not make

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -28906,3 +28906,51 @@ parser in a TIGHT heap allocation rather than the 256 KB buffer production
 uses, so the over-read is an ASan abort instead of a quiet stroll; with the
 clamp reverted, the CRLF case trips at 0 bytes past a 19-byte region and the
 LF-only case, run alone, trips at 0 bytes past a 17-byte one.
+## 2026-08-05 — #761: a draw that can fail, at the one call that has nothing else
+
+`RAND_bytes` returns 1 on success and leaves the buffer UNTOUCHED otherwise.
+Five sites in `shottino.c` ignored the return, and the room name for `/call`
+is the one where that is a security defect rather than an untidy line: the
+room name IS the access control — the code says so — so on a host with no
+entropy source the invite posted to a channel carried 16 bytes of
+uninitialised stack, hex-encoded, plausibly repeatable across runs from the
+same code path.
+
+**Refuse, do not degrade.** A weak room is worse than no call, so
+`call_room_name` returns false and `/call` posts nothing and says why. That
+answer is stated where the user can read it, because a refusal nobody sees is
+the silent-degrade this was meant to remove. The same reasoning binds
+`multipart_boundary`: the comment above it argues that 16 random bytes make a
+boundary collision impossible, which is an argument entirely about entropy
+that nothing checked, and a predictable boundary is what lets a file whose
+BYTES contain it split its own request and smuggle form fields into grappa's
+upload endpoint — so `/upload` and `/stt` refuse rather than send. The
+websocket key and the frame mask are RFC 6455 security properties (an
+unpredictable mask is what stops a client being made to emit chosen bytes at
+an intermediary), so unmaskable means unsendable. Reconnect jitter is the one
+draw here that is not a secret, and therefore the only one allowed to fail
+quietly: it buys spread, not safety, and zero is simply no jitter.
+
+**One door, and it zeroes on the way out.** `fill_random` is the only place
+that draws. A failed draw returns false AND zeroes the buffer, because
+all-zero is visibly broken while stack residue is precisely the shape a caller
+cannot distinguish from a secret. There is deliberately NO fallback source: a
+`time(NULL)`-seeded `rand()` is the canonical way this class of bug survives
+its own fix.
+
+**The seam is half the fix, because the old test could not fail.** It asserted
+`strlen(room) == 9 + 32` and that two draws differ — and uninitialised stack
+has a length and differs too, so both assertions hold for garbage. That is how
+this shipped past a suite that looked like it covered it. The draw now goes
+through a function pointer, so the test substitutes the source and asserts the
+output CAME FROM IT: a counting stub must yield `shottino-000102…0f` exactly,
+and a failing stub must yield no room at all. Asserting the shape of a string
+is what #762 complains about generally; the fix for one instance of it must
+not add another.
+
+**The RED was measured, not assumed.** With the seam in place and only the
+`!= 1` check removed, the failing source still minted
+`shottino-00000000000000000000000000000000` and exactly the seven refusal
+assertions fell. The entropy-came-from-the-source half stayed green under that
+mutation, which is the honest reading: it pins the derivation, and the refusal
+assertions pin the check.

--- a/frontends/shottino/shottino.c
+++ b/frontends/shottino/shottino.c
@@ -1559,6 +1559,41 @@ static char *xasprintf(const char *fmt, ...) {
     return s;
 }
 
+/* ── Entropy ───────────────────────────────────────────────────────────
+ *
+ * Every random byte this client draws comes through one door, for two
+ * reasons.
+ *
+ * `RAND_bytes` returns 1 on success and leaves the buffer UNTOUCHED
+ * otherwise, and five call sites ignored that. On a host with no
+ * entropy source — a jail, a minimal container, an early-boot
+ * invocation — a call room name was 16 bytes of uninitialised stack
+ * hex-encoded, and that name is the only thing standing between a
+ * stranger and the call (#761). There is deliberately NO fallback
+ * source: a time-seeded rand() is how this bug survives its own fix.
+ * A caller that needs a secret and cannot have one must REFUSE, and
+ * must say so where the user can read it.
+ *
+ * And a test cannot tell entropy from stack residue by looking at the
+ * result — garbage is the right length too, and two draws of it also
+ * differ. Drawing through a pointer is what lets a test substitute the
+ * source and assert the output CAME FROM IT. */
+static int rand_bytes_openssl(unsigned char *buf, size_t len) {
+    return RAND_bytes(buf, (int)len);
+}
+
+static int (*rand_source)(unsigned char *, size_t) = rand_bytes_openssl;
+
+/* True only when `len` bytes of CSPRNG output are in `buf`. A failed
+ * draw ZEROES rather than leaving the buffer as it found it: all-zero
+ * is visibly broken, while stack residue is precisely the shape a
+ * caller cannot tell from a secret. */
+static bool fill_random(unsigned char *buf, size_t len) {
+    if (rand_source(buf, len) == 1) return true;
+    memset(buf, 0, len);
+    return false;
+}
+
 static void log_line(struct app *app, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 static void log_line_mention(struct app *app, bool mention, const char *fmt, ...) __attribute__((format(printf, 3, 4)));
 static size_t focused_window_locked(struct app *app);
@@ -3254,18 +3289,24 @@ static const char *call_kind_word(enum call_kind kind) {
 
 /* A room nobody can guess: 16 bytes of CSPRNG as hex.
  *
- * Truncation is a real failure here rather than a cosmetic one — half a
- * room name is a different room — so the loop stops on the buffer and
- * the caller sizes it for the whole thing. */
-static void call_room_name(char *out, size_t out_sz) {
-    if (!out || out_sz == 0) return;
+ * False means there is no room, and the caller must not invent one. A
+ * short name is that same answer: truncation is a real failure here
+ * rather than a cosmetic one — half a room name is a different room,
+ * and a shorter one is a weaker secret — so the loop stops on the
+ * buffer, the caller sizes it for the whole thing, and anything less
+ * than the whole thing comes back empty. */
+static bool call_room_name(char *out, size_t out_sz) {
+    if (!out || out_sz == 0) return false;
+    out[0] = 0;
     unsigned char raw[16];
-    RAND_bytes(raw, sizeof(raw));
+    if (!fill_random(raw, sizeof(raw))) return false;
     int w = snprintf(out, out_sz, "shottino-");
-    if (w < 0) { out[0] = 0; return; }
+    if (w < 0) { out[0] = 0; return false; }
     size_t n = (size_t)w;
     for (size_t i = 0; i < sizeof(raw) && n + 2 < out_sz; i++)
         n += (size_t)snprintf(out + n, out_sz - n, "%02x", raw[i]);
+    if (n != (size_t)w + 2 * sizeof(raw)) { out[0] = 0; return false; }
+    return true;
 }
 
 /* The line an invite IS. One `/` between base and room however the base
@@ -5974,8 +6015,14 @@ static char *base64url_encode(const unsigned char *buf, size_t len) {
 
 static bool ws_connect(struct app *app) {
     if (!conn_open(app, &app->ws)) return false;
+    /* RFC 6455 wants a key the server cannot have seen coming; a
+     * constant one is how a cache that never learned about websockets
+     * hands somebody else's upgrade back to us. */
     unsigned char nonce[16];
-    RAND_bytes(nonce, sizeof(nonce));
+    if (!fill_random(nonce, sizeof(nonce))) {
+        log_line(app, "websocket handshake: no entropy for Sec-WebSocket-Key — not connecting");
+        return false;
+    }
     char *key = base64_encode(nonce, sizeof(nonce));
 
     /* The bearer rides the Sec-WebSocket-Protocol SUBPROTOCOL, never the
@@ -6096,8 +6143,12 @@ static bool ws_send_frame_locked(struct app *app, int opcode, const char *body, 
         hdr[hlen++] = 0x80 | 127;
         for (int i = 7; i >= 0; i--) hdr[hlen++] = (unsigned char)(len >> (i * 8));
     }
+    /* The mask is a security property of the protocol, not decoration:
+     * RFC 6455 requires it to be unpredictable so a client cannot be
+     * made to emit chosen bytes at an intermediary that mistakes them
+     * for a request. Unmaskable means unsendable. */
     unsigned char mask[4];
-    RAND_bytes(mask, sizeof(mask));
+    if (!fill_random(mask, sizeof(mask))) return false;
     memcpy(hdr + hlen, mask, 4);
     hlen += 4;
     unsigned char *frame = malloc(hlen + len);
@@ -7361,9 +7412,13 @@ static void ws_schedule_retry(struct app *app) {
         if (app->ws_backoff > WS_BACKOFF_MAX) app->ws_backoff = WS_BACKOFF_MAX;
     }
     /* Up to 25% jitter, so a fleet of clients does not resynchronise on a
-     * server restart and thunder back together. */
+     * server restart and thunder back together.
+     *
+     * The one draw in this file that is not a secret, and so the only
+     * one allowed to fail quietly: jitter buys spread, not safety, and
+     * a zero here is simply no jitter. */
     unsigned char r = 0;
-    RAND_bytes(&r, 1);
+    (void)fill_random(&r, sizeof(r));
     int jitter = (int)((unsigned)app->ws_backoff * r / (255 * 4));
     app->ws_retry_at = time(NULL) + app->ws_backoff + jitter;
 }
@@ -14157,8 +14212,17 @@ static void call_command(struct app *app, enum call_kind kind) {
         return;
     }
 
+    /* No room rather than a guessable one. The name IS the access
+     * control here, so a draw the CSPRNG could not serve is the end of
+     * this call, said out loud — degrading quietly to a weak room would
+     * hand the conversation to whoever tries the obvious URL. */
     char room[96];
-    call_room_name(room, sizeof(room));
+    if (!call_room_name(room, sizeof(room))) {
+        log_line(app, "/call: no entropy from the system CSPRNG — refusing to mint a room. The "
+                      "room name is the only thing keeping strangers out, so a guessable one is "
+                      "worse than no call");
+        return;
+    }
     char message[sizeof(app->call_base_url) + sizeof(room) + 640];
     call_invite_build(kind, app->call_base_url, room, message, sizeof(message));
     /* WHO IS IN THE CALL, for whoever opens this in a BROWSER.
@@ -15917,12 +15981,22 @@ static const char *mime_for_path(const char *path) {
  * CRLF in it would close the header early. Anything but the safe set
  * becomes '_', because a name is a label here, not an identifier — the
  * server decides what the upload is really called. */
-static void multipart_boundary(char *out, size_t out_sz) {
+static bool multipart_boundary(char *out, size_t out_sz) {
+    if (!out || out_sz == 0) return false;
+    out[0] = 0;
     unsigned char raw[16];
-    RAND_bytes(raw, sizeof(raw));
-    size_t n = snprintf(out, out_sz, "----shottino");
+    /* False means no boundary, and no boundary means no request: the
+     * argument above is entirely about entropy, so an unchecked draw
+     * would leave the smuggling door open while the comment claimed it
+     * was shut. */
+    if (!fill_random(raw, sizeof(raw))) return false;
+    int w = snprintf(out, out_sz, "----shottino");
+    if (w < 0) { out[0] = 0; return false; }
+    size_t n = (size_t)w;
     for (size_t i = 0; i < sizeof(raw) && n + 2 < out_sz; i++)
         n += (size_t)snprintf(out + n, out_sz - n, "%02x", raw[i]);
+    if (n != (size_t)w + 2 * sizeof(raw)) { out[0] = 0; return false; }
+    return true;
 }
 
 static void multipart_filename(const char *in, char *out, size_t out_sz) {
@@ -15982,7 +16056,12 @@ static void upload_file_to(struct app *app, const char *path, const char *marker
     const char *base = strrchr(path, '/');
     base = base ? base + 1 : path;
     char boundary[64];
-    multipart_boundary(boundary, sizeof(boundary));
+    if (!multipart_boundary(boundary, sizeof(boundary))) {
+        free(data);
+        log_line(app, "/upload: no entropy for a multipart boundary — refusing to send a request "
+                      "the file could split");
+        return;
+    }
     char safe_name[256];
     multipart_filename(base, safe_name, sizeof(safe_name));
     char *head = xasprintf("--%s\r\n"
@@ -16145,7 +16224,13 @@ static char *stt_transcribe_remote(struct app *app, const char *path) {
     const char *base = strrchr(path, '/');
     base = base ? base + 1 : path;
     char boundary[64];
-    multipart_boundary(boundary, sizeof(boundary));
+    if (!multipart_boundary(boundary, sizeof(boundary))) {
+        free(audio);
+        conn_close(&conn);
+        log_line(app, "/stt: no entropy for a multipart boundary — refusing to send a request the "
+                      "recording could split");
+        return NULL;
+    }
     char safe_name[256];
     multipart_filename(base, safe_name, sizeof(safe_name));
     char *head = xasprintf("--%s\r\n"

--- a/frontends/shottino/tests/test_windows.c
+++ b/frontends/shottino/tests/test_windows.c
@@ -3011,14 +3011,14 @@ TEST(only_a_marked_invite_is_a_call) {
 /* What /call posts is what a receiving shottino reads back. */
 TEST(an_invite_round_trips_through_its_own_parser) {
     char room[96];
-    call_room_name(room, sizeof(room));
+    CHECK(call_room_name(room, sizeof(room)));
     CHECK(strncmp(room, "shottino-", 9) == 0);
     CHECK_LONG((long)strlen(room), 9 + 32); /* 128 bits, as hex */
 
     /* Two rooms are two rooms — the name is the only thing standing
      * between a stranger and the call. */
     char second[96];
-    call_room_name(second, sizeof(second));
+    CHECK(call_room_name(second, sizeof(second)));
     CHECK(strcmp(room, second) != 0);
 
     for (int v = 0; v < 2; v++) {
@@ -3040,6 +3040,88 @@ TEST(an_invite_round_trips_through_its_own_parser) {
     CHECK(strstr(line, "//#") == NULL);
     call_invite_build(CALL_AUDIO, "https://meet.example", "r", line, sizeof(line));
     CHECK(strstr(line, "https://meet.example/#r=r") != NULL);
+}
+
+/* #761. The assertions above this comment cannot tell entropy from
+ * uninitialised stack: a garbage buffer is also 16 bytes long, and two
+ * garbage buffers also differ. `RAND_bytes` leaves the buffer UNTOUCHED
+ * when it fails, so on a host with no entropy source — a jail, a
+ * minimal container, an early-boot invocation — the room name was
+ * whatever the stack held, and every assertion still passed.
+ *
+ * So these go through the SOURCE instead of through the string's shape:
+ * a stub that produces KNOWN bytes proves the output was derived from
+ * it, and a stub that FAILS proves the refusal. Neither is satisfiable
+ * by an implementation that hexes the stack. */
+static int rand_calls;
+
+static int rand_counts_up(unsigned char *buf, size_t len) {
+    rand_calls++;
+    for (size_t i = 0; i < len; i++) buf[i] = (unsigned char)i;
+    return 1;
+}
+
+static int rand_refuses(unsigned char *buf, size_t len) {
+    (void)buf;
+    (void)len;
+    rand_calls++;
+    return 0; /* what OpenSSL returns with no entropy source */
+}
+
+TEST(random_bytes_are_the_sources_or_the_caller_is_told) {
+    int (*saved)(unsigned char *, size_t) = rand_source;
+
+    /* The door itself: what the source wrote, and true. */
+    rand_source = rand_counts_up;
+    rand_calls = 0;
+    unsigned char buf[4] = {9, 9, 9, 9};
+    CHECK(fill_random(buf, sizeof(buf)));
+    CHECK_LONG(rand_calls, 1);
+    CHECK_LONG(buf[0], 0);
+    CHECK_LONG(buf[3], 3);
+
+    /* A failed draw reports false AND leaves nothing that looks usable.
+     * Zeroed rather than left alone, because "16 bytes of stack" is the
+     * shape a caller cannot distinguish from a secret. */
+    rand_source = rand_refuses;
+    unsigned char stale[4] = {9, 9, 9, 9};
+    CHECK(!fill_random(stale, sizeof(stale)));
+    CHECK_LONG(stale[0], 0);
+    CHECK_LONG(stale[3], 0);
+
+    /* A room name IS those bytes, hex-encoded — not merely a string of
+     * the right length. */
+    rand_source = rand_counts_up;
+    char room[96];
+    CHECK(call_room_name(room, sizeof(room)));
+    CHECK_STR(room, "shottino-000102030405060708090a0b0c0d0e0f");
+
+    /* No entropy, no room: a guessable room is worse than no call, and
+     * nothing half-minted escapes for a caller to post by accident. */
+    rand_source = rand_refuses;
+    char none[96];
+    memset(none, 'x', sizeof(none));
+    none[sizeof(none) - 1] = 0;
+    CHECK(!call_room_name(none, sizeof(none)));
+    CHECK_STR(none, "");
+
+    /* The multipart boundary is the same class: the comment above it
+     * argues that 16 random bytes make a collision impossible, which is
+     * an argument about entropy that was never checked. A predictable
+     * boundary lets a file whose BYTES contain it split its own request. */
+    rand_source = rand_counts_up;
+    char boundary[64];
+    CHECK(multipart_boundary(boundary, sizeof(boundary)));
+    CHECK_STR(boundary, "----shottino000102030405060708090a0b0c0d0e0f");
+
+    rand_source = rand_refuses;
+    char nob[64];
+    memset(nob, 'x', sizeof(nob));
+    nob[sizeof(nob) - 1] = 0;
+    CHECK(!multipart_boundary(nob, sizeof(nob)));
+    CHECK_STR(nob, "");
+
+    rand_source = saved;
 }
 
 /* The room rides in the FRAGMENT, and a fragment is never sent to a
@@ -3968,6 +4050,7 @@ int main(void) {
     RUN(a_question_is_written_where_its_answer_will_land);
     RUN(only_a_marked_invite_is_a_call);
     RUN(an_invite_round_trips_through_its_own_parser);
+    RUN(random_bytes_are_the_sources_or_the_caller_is_told);
     RUN(a_call_already_running_here_is_the_call);
     RUN(an_invite_carries_its_room_in_the_fragment);
     RUN(a_call_in_a_query_with_yourself_lists_one_person);


### PR DESCRIPTION
`RAND_bytes` returns 1 on success and leaves the buffer UNTOUCHED otherwise.
Five call sites in `shottino.c` ignored that. The worst one mints the `/call`
room name — 16 bytes of uninitialised stack, hex-encoded, posted to a channel
as an invite — and that name IS the access control. On a host with no entropy
source (a jail, a minimal container, an early-boot invocation) the URL that is
the only thing between a stranger and the call becomes whatever the stack
held.

## The refusal

A weak room is worse than no call, so `call_room_name` returns `false` and
`/call` posts **nothing**, saying why in the window — a refusal nobody sees is
the same silent degrade this removes.

The class, swept:

| site | draw | on failure |
|---|---|---|
| `call_room_name` | room name = the access control | refuse; `/call` posts nothing and says so |
| `multipart_boundary` | anti-smuggling boundary | refuse; `/upload` + `/stt` send nothing and say so |
| `ws_connect` | `Sec-WebSocket-Key` | refuse the connect, logged |
| `ws_send_frame_locked` | RFC 6455 frame mask | unmaskable means unsendable (`false`) |
| `ws_schedule_retry` | reconnect jitter | the one draw that is not a secret — zero, i.e. no jitter |

Truncation now gives the same answer as a failed draw in both name-builders:
half a room name is a different room, and a shorter one is a weaker secret.

Every draw goes through one door, `fill_random`, which reports failure and
**zeroes** what it could not fill — all-zero is visibly broken, stack residue
is exactly the shape a caller cannot tell from a secret. There is deliberately
no fallback source: a `time(NULL)`-seeded `rand()` is how this bug survives
its own fix.

## Why the test could not have caught it, and now can

The old assertions were `strlen(room) == 9 + 32` and "two draws differ".
Uninitialised stack satisfies both. The draw now goes through a function
pointer, so the test substitutes the source and asserts the output **came from
it**: a counting stub must produce `shottino-000102…0f` exactly, and a failing
stub must produce no room at all.

**The RED was measured.** With the seam in place and only the `!= 1` check
removed, the failing source still minted
`shottino-00000000000000000000000000000000` and exactly seven assertions fell:

```
FAIL tests/test_windows.c:3058 !fill_random(stale, sizeof(stale))
FAIL tests/test_windows.c:3059 expected 0, got 9
FAIL tests/test_windows.c:3060 expected 0, got 9
FAIL tests/test_windows.c:3075 !call_room_name(none, sizeof(none))
FAIL tests/test_windows.c:3076 expected "", got "shottino-00000000000000000000000000000000"
FAIL tests/test_windows.c:3091 !multipart_boundary(nob, sizeof(nob))
FAIL tests/test_windows.c:3092 expected "", got "----shottino00000000000000000000000000000000"

7/1214 checks FAILED
```

The derivation half stayed green under that mutation, which is the honest
reading: it pins where the bytes came from, the refusal assertions pin the
check.

## Class sweep beyond `RAND_bytes`

`grep` over `frontends/shottino` for entropy and crypto returns: `SSL_connect`
(checked, both here and in `call/whip.c`), `SSL_read`/`SSL_write` (returns
consumed by the `conn_*` wrappers), `SHA256()` (cannot fail). `RAND_bytes` was
the whole of the unchecked set, and there is now exactly one call to it in the
tree.

## Gates

Full shottino suite, 15 of 16 binaries green locally (10 546 checks):

```
test_llm 236 · test_ws 371 · test_json 121 · test_wire 368 · test_alias 162
test_mirc 98 · test_termcolor 4404 · test_http 20 · test_media 105
test_whip 68 · test_callmedia 133 · test_layout 2937 · test_ircd 230
test_commands 479 · test_windows 1214
```

`test_keys` is unbuildable on this host — it includes `<pty.h>`, which is
Linux-only. Two other pre-existing Darwin gaps (`SOCK_CLOEXEC`, and the
`-L` for a Homebrew OpenSSL in the `test_whip`/`test_callmedia` rules) were
shimmed on the command line only; **no build file was touched**. CI's
`make -C frontends/shottino check` on Linux is the gate that covers all 16.

The shipped binary builds clean: the only warning is the pre-existing
`-Wformat-nonliteral` in `ircd_vsend_locked`.