### PR TITLE
shottino(#755): encode the room segment, and gate the request line

### DIFF
--- a/frontends/shottino/call/whip.c
+++ b/frontends/shottino/call/whip.c
@@ -314,10 +314,33 @@ static int dial(const char *host, int port, int timeout_ms, char *err, size_t er
     return fd;
 }
 
+/* Anything that would end the request line early, i.e. every C0 byte,
+ * DEL, and the space that separates target from version. */
+static bool has_request_line_break(const char *s) {
+    for (const unsigned char *p = (const unsigned char *)s; *p; p++)
+        if (*p <= ' ' || *p == 0x7f) return true;
+    return false;
+}
+
 bool whip_request(const struct whip_url *url, const char *method, const char *content_type,
                   const char *body, int timeout_ms, struct whip_response *out, char *err,
                   size_t err_sz) {
     if (!url || !method || !out) return false;
+
+    /* BELT AND BRACES over the encoding done by whoever built this URL.
+     *
+     * A request line is ONE line: a CR in the path is not a strange path,
+     * it is a second request the server will answer, and a CR in the host
+     * is an extra header. Today every caller encodes its path segments
+     * and the URL arrived in an IRC message, which cannot carry either
+     * byte — this gate is what keeps that true the day the URL comes from
+     * a config value, a flag, a redirect Location or a transport that is
+     * not IRC. Refused rather than encoded: at this depth we can no
+     * longer tell a path apart from its delimiters. */
+    if (has_request_line_break(url->path) || has_request_line_break(url->host)) {
+        set_err(err, err_sz, "refusing a URL with a control character in it");
+        return false;
+    }
 
     int fd = dial(url->host, url->port, timeout_ms, err, err_sz);
     if (fd < 0) return false;

--- a/frontends/shottino/shottino.c
+++ b/frontends/shottino/shottino.c
@@ -3268,6 +3268,48 @@ static void call_room_name(char *out, size_t out_sz) {
         n += (size_t)snprintf(out + n, out_sz - n, "%02x", raw[i]);
 }
 
+/* ONE path-segment encoder, RFC-3986 unreserved allowlist.
+ *
+ * Everything shottino puts between two slashes of a WHIP/WHEP URL comes
+ * through here, which is the whole point: the invariant is "every
+ * segment is encoded", and an invariant with one exception is a hole
+ * somebody finds later.
+ *
+ * `fold` is the one axis on which the two callers differ, and it is a
+ * domain difference, not a taste:
+ *
+ *   - a NICK folds, because IRC says `Alice` and `alice` are one person
+ *     and two paths would be two halves of one conversation.
+ *   - a ROOM does not. It is a credential compared byte for byte by the
+ *     SFU, so folding somebody else's mixed-case room would make it
+ *     unjoinable — and would halve the guessing space of a name whose
+ *     unguessability is the only thing keeping the call private.
+ *
+ * ESCAPE, never squash. A nick may legally contain [ ] \ ` ^ { | } and a
+ * room may contain anything at all; mapping them to `_` would be simpler
+ * and would silently put `foo[1]` and `foo{1}` in the SAME room. */
+static void call_path_encode(const char *in, bool fold, char *out, size_t out_sz) {
+    static const char hex[] = "0123456789abcdef";
+    size_t n = 0;
+    if (!out || out_sz == 0) return;
+    for (const unsigned char *p = (const unsigned char *)(in ? in : ""); *p; p++) {
+        unsigned char c = *p;
+        if (fold && c >= 'A' && c <= 'Z') c = (unsigned char)(c - 'A' + 'a');
+        bool safe = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+                    c == '-' || c == '_' || c == '.' || c == '~';
+        if (safe) {
+            if (n + 2 > out_sz) break;
+            out[n++] = (char)c;
+        } else {
+            if (n + 4 > out_sz) break;
+            out[n++] = '%';
+            out[n++] = hex[c >> 4];
+            out[n++] = hex[c & 15];
+        }
+    }
+    out[n] = 0;
+}
+
 /* The line an invite IS. One `/` between base and room however the base
  * was spelled — a doubled slash is a different path on some services and
  * a 404 on others. */
@@ -3302,17 +3344,28 @@ static bool call_invite_split(const char *url, char *base, size_t base_sz, char 
     memcpy(base, url, blen);
     base[blen] = 0;
 
-    room[0] = 0;
+    /* The room is a PATH SEGMENT and gets encoded like every other one.
+     *
+     * It is the only component of <base>/rtc/<room>/<nick>/whip that used
+     * to reach the URL raw, and it is the one that arrives in a stranger's
+     * PRIVMSG. IRC framing keeps CR, LF and space out; it does not keep
+     * out `?`, `#`, `%` or `..`, each of which redirects the publish.
+     * Encoded rather than refused because both ends of a call run this
+     * same function over the same fragment, so a strange room name still
+     * names ONE room — its own. */
+    char raw[256]; /* room as posted; the encoded form can be 3x and is bounded by room_sz */
+    raw[0] = 0;
     for (const char *p = hash + 1; *p;) {
         if (p[0] == 'r' && p[1] == '=') {
             size_t n = 0;
-            for (p += 2; *p && *p != '&' && n + 1 < room_sz; p++) room[n++] = *p;
-            room[n] = 0;
+            for (p += 2; *p && *p != '&' && n + 1 < sizeof(raw); p++) raw[n++] = *p;
+            raw[n] = 0;
             break;
         }
         while (*p && *p != '&') p++;
         if (*p == '&') p++;
     }
+    call_path_encode(raw, false, room, room_sz);
     return room[0] != 0;
 }
 
@@ -14326,25 +14379,7 @@ static bool call_helper_path(struct app *app, char *out, size_t out_sz) {
  *   two different people in one call, silently. Percent-encoding keeps
  *   them distinct. */
 static void call_path_nick(const char *nick, char *out, size_t out_sz) {
-    static const char hex[] = "0123456789abcdef";
-    size_t n = 0;
-    if (!out || out_sz == 0) return;
-    for (const unsigned char *p = (const unsigned char *)(nick ? nick : ""); *p; p++) {
-        unsigned char c = *p;
-        if (c >= 'A' && c <= 'Z') c = (unsigned char)(c - 'A' + 'a');
-        bool safe = (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' || c == '_' ||
-                    c == '.' || c == '~';
-        if (safe) {
-            if (n + 2 > out_sz) break;
-            out[n++] = (char)c;
-        } else {
-            if (n + 4 > out_sz) break;
-            out[n++] = '%';
-            out[n++] = hex[c >> 4];
-            out[n++] = hex[c & 15];
-        }
-    }
-    out[n] = 0;
+    call_path_encode(nick, true, out, out_sz);
 }
 
 /* Append `&peers=…` — every folded nick that could be in this call,

--- a/frontends/shottino/tests/test_whip.c
+++ b/frontends/shottino/tests/test_whip.c
@@ -208,10 +208,47 @@ TEST(a_header_block_can_be_empty_but_never_endless) {
     a_response_with_no_headers("HTTP/1.1 200 OK\n\n");
 }
 
+/* A request line is one line. Everything that builds a URL for this
+ * module encodes its path segments, so the only way a CR gets here is a
+ * caller that does not — and in the request line a CR is not a strange
+ * path, it is a second request the server will answer.
+ *
+ * The refusal has to be legible in `err`: dialling a dead port also
+ * returns false, so a test that only asserted false would pass with the
+ * gate deleted. */
+static void a_request_refuses(const char *url) {
+    struct whip_url u;
+    CHECK(whip_url_parse(url, &u)); /* the URL parser is not the gate */
+    struct whip_response resp;
+    char err[256] = "";
+    CHECK(!whip_request(&u, "POST", "application/sdp", "v=0\r\n", 100, &resp, err, sizeof(err)));
+    CHECK(strstr(err, "control character") != NULL);
+}
+
+TEST(a_control_character_never_reaches_the_request_line) {
+    a_request_refuses("http://127.0.0.1:9/rtc/a\r\nX-Evil: 1/whip");
+    a_request_refuses("http://127.0.0.1:9/rtc/a\nb/whip");
+    /* A space ends the path in a request line as surely as a CR ends the
+     * line, so it belongs to the same gate. */
+    a_request_refuses("http://127.0.0.1:9/rtc/a b/whip");
+    /* The host is interpolated into `Host:` by the same builder, and the
+     * URL parser stops the host only at `:` `/` `?` `#`. */
+    a_request_refuses("http://a\r\nX:9/whip");
+
+    /* The gate refuses control bytes, not ordinary encoded paths. */
+    struct whip_url ok;
+    CHECK(whip_url_parse("http://127.0.0.1:9/rtc/a%3fx/me%5b1%5d/whip", &ok));
+    struct whip_response resp;
+    char err[256] = "";
+    CHECK(!whip_request(&ok, "POST", "application/sdp", "v=0\r\n", 100, &resp, err, sizeof(err)));
+    CHECK(strstr(err, "control character") == NULL); /* refused by the socket, not the gate */
+}
+
 int main(void) {
     RUN(a_url_is_split_or_refused);
     RUN(a_location_resolves_against_the_request);
     RUN(a_response_is_parsed_or_refused);
     RUN(a_header_block_can_be_empty_but_never_endless);
+    RUN(a_control_character_never_reaches_the_request_line);
     return test_report();
 }

--- a/frontends/shottino/tests/test_windows.c
+++ b/frontends/shottino/tests/test_windows.c
@@ -3098,6 +3098,62 @@ TEST(an_invite_carries_its_room_in_the_fragment) {
     CHECK_STR(room, "shottino-99");
 }
 
+/* The room is a PATH SEGMENT, and it is the only one that used to reach
+ * the URL raw — the nick and the peers have always gone through the
+ * encoder. The room arrives in somebody else's PRIVMSG, so IRC framing
+ * already keeps CR, LF and space out of it; what it does NOT keep out is
+ * `?`, `#`, `%` and `..`, each of which means something to a URL. A room
+ * of `a?x` publishes to `/rtc/a` with a query, and `..` walks out of the
+ * room entirely.
+ *
+ * Encoding, not rejecting: the split is deterministic, so both ends of a
+ * call encode the same room to the same path and a strange room name
+ * still reaches a room — just its own. */
+TEST(a_room_is_a_path_segment_and_is_encoded_like_one) {
+    char base[MAX_LINE], room[160];
+
+    CHECK(call_invite_split("https://h/call/#r=a?x", base, sizeof(base), room, sizeof(room)));
+    CHECK_STR(room, "a%3fx");
+
+    /* The fragment starts at the FIRST `#`, so a second one is room. */
+    CHECK(call_invite_split("https://h/call/#r=a#b", base, sizeof(base), room, sizeof(room)));
+    CHECK_STR(room, "a%23b");
+
+    /* A percent is data here, not an escape we re-interpret: decoding
+     * somebody else's `%2e%2e` would be how `..` comes back. */
+    CHECK(call_invite_split("https://h/call/#r=a%2fb", base, sizeof(base), room, sizeof(room)));
+    CHECK_STR(room, "a%252fb");
+
+    CHECK(call_invite_split("https://h/call/#r=../../evil", base, sizeof(base), room,
+                            sizeof(room)));
+    CHECK_STR(room, "..%2f..%2fevil");
+
+    /* CR/LF cannot arrive over IRC — this is the day the room comes from
+     * a config value, a flag or a future transport instead. */
+    CHECK(call_invite_split("https://h/call/#r=a\r\nX", base, sizeof(base), room, sizeof(room)));
+    CHECK_STR(room, "a%0d%0aX");
+
+    /* Unreserved bytes pass through, so every room shottino generates is
+     * its own encoding and no existing invite changes meaning. */
+    char generated[96];
+    call_room_name(generated, sizeof(generated));
+    char line[512];
+    call_invite_build(CALL_AUDIO, "https://h/call", generated, line, sizeof(line));
+    enum call_kind kind;
+    char url[MAX_LINE];
+    CHECK(call_invite_parse(line, &kind, url, sizeof(url)));
+    CHECK(call_invite_split(url, base, sizeof(base), room, sizeof(room)));
+    CHECK_STR(room, generated);
+
+    /* CASE IS KEPT, which is where a room parts company with a nick. A
+     * nick folds because IRC says foo and FOO are one person; a room is
+     * a credential and a path, and the SFU compares it byte for byte —
+     * folding it would make somebody else's mixed-case room unjoinable. */
+    CHECK(call_invite_split("https://h/call/#r=Shottino-AB", base, sizeof(base), room,
+                            sizeof(room)));
+    CHECK_STR(room, "Shottino-AB");
+}
+
 TEST(a_call_in_a_query_with_yourself_lists_one_person) {
     struct app *app = window_app();
     CHECK(app != NULL);
@@ -3970,6 +4026,7 @@ int main(void) {
     RUN(an_invite_round_trips_through_its_own_parser);
     RUN(a_call_already_running_here_is_the_call);
     RUN(an_invite_carries_its_room_in_the_fragment);
+    RUN(a_room_is_a_path_segment_and_is_encoded_like_one);
     RUN(a_call_in_a_query_with_yourself_lists_one_person);
     RUN(rejoining_a_running_call_rebuilds_the_link_rather_than_replaying_it);
     RUN(a_query_rings_and_a_channel_only_announces);


### PR DESCRIPTION
Refs #755.

Every WHIP/WHEP URL is `<base>/rtc/<room>/<nick>/{whip,whep}`. Three of
those four components were percent-encoded through `call_path_nick`; the
room was not — `call_invite_split` copied every byte except `&` and NUL
out of the invite fragment and into the URL.

Verified live against current `main` (`ac294eba`) before writing
anything: the raw copy loop, the `snprintf(rtc, …, "%s/rtc/%s", …)` that
consumes it, and the request line in `call/whip.c` are all still exactly
as the issue describes.

## Both gates, as the issue asks

**1. Encode at the point of parse.** The room now goes through the same
allowlist as the nick. The encoder is shared rather than copied, with
the fold as its one parameter, because the two callers differ on domain
and not on taste: a nick folds (IRC says `Alice` and `alice` are one
person and two paths would be two halves of one conversation), a room
does not (the SFU compares it byte for byte, so folding somebody else's
mixed-case room makes it unjoinable — and folding a name whose
unguessability IS the privacy of the call halves its space).

Encoded rather than refused: the split is deterministic, so both ends of
a call turn the same fragment into the same path and an odd room name
still names ONE room — its own.

**2. Refuse a broken request line in `whip_request`.** A control byte in
`url->path` is not a strange path, it is a second request; `url->host`
lands in `Host:` by the same builder and the URL parser stops the host
only at `:` `/` `?` `#`. Space is in the gate with the C0 bytes because
it ends the request target as surely as a CR ends the line — the class
is "bytes that break the framing". Refused rather than encoded: by this
depth we can no longer tell a path from its delimiters. This is the gate
that keeps the guarantee when the first one stops applying — a redirect
`Location`, a config value, a flag, a transport that is not IRC.

`call_invite_parse`'s scheme and whitespace gate is untouched.

## What the tests assert

Not "it did not crash" — the encoded output, byte for byte, for each
survivor the issue names.

* `test_windows`: `a?x → a%3fx`, `a#b → a%23b`, `a%2fb → a%252fb`,
  `../../evil → ..%2f..%2fevil`, `a\r\nX → a%0d%0aX`; a generated room
  round-trips unchanged through build → parse → split (so no existing
  invite changes meaning); and `Shottino-AB` keeps its case, which is the
  room-is-not-a-nick decision made falsifiable.
* `test_whip`: the refusal must be legible in `err`. Dialling a dead port
  also returns false, so a test asserting only the bool would pass with
  the gate deleted; it asserts the reason, and asserts that an ordinary
  percent-encoded path is *not* refused by the gate.

Both were RED before the fix (5 checks). Mutating the fold flag to
`true` kills 2 checks, so the case assertion is load-bearing rather than
decorative.

## Class sweep

Every other place a string is interpolated into a URL or a request line:

* `call_url_for_me`'s `&me=` and `call_invite_peers`' `&peers=` —
  already encoded; after this change every component composed into a
  WHIP/WHEP URL goes through the one encoder.
* the grappa REST paths (`/api/server-settings`, `/api/uploads`) — all
  literal, no dynamic segment.
* `http_fetch` — the path is a remote URL taken as given, not a segment
  we compose.
* the `/llm` and STT builders interpolate a configured base and a bearer
  token; both are local `/set` values, not remote input, and they use a
  different request builder. Left alone deliberately.

## Gate

15 of 16 suites locally under ASan+UBSan (`test_keys` needs `<pty.h>`,
Linux-only): all green. Main binary rebuilt with `-Werror -O2` as CI
does: clean.