### PR TITLE
shottino(#759): stop the writers before releasing what they write

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -28954,3 +28954,81 @@ not add another.
 assertions fell. The entropy-came-from-the-source half stayed green under that
 mutation, which is the honest reading: it pins the derivation, and the refusal
 assertions pin the check.
+## 2026-08-05 — #759: teardown is an order, and a trylock is not a lifetime barrier
+
+`shottino-call`'s hangup released the media legs before it stopped the threads
+that write them. `media_stop` closed each leg's socket while the peer
+connections were still alive two lines below, so RTP arriving mid-hangup ran on
+libdatachannel's thread against a leg being dismantled — `media_feed` tests
+`fd < 0` and then `sendto`s it as two steps, `media_stop` closes and blanks the
+fd as two more, and `session_release` opens a socket for its DELETE right
+after, so the descriptor number comes straight back and the write lands
+somewhere unrelated.
+
+**The `vlock` reads like the protection against this and is not.** The RTP
+callbacks take it with TRYLOCK on purpose: it is BACKPRESSURE, meaning "a
+re-tile is forking ffmpeg, drop this datagram rather than park a media thread".
+Teardown never took it, so the trylock always succeeded exactly when it
+mattered. A lock whose fast path is allowed to skip it cannot be a lifetime
+primitive, whatever the call sites look like.
+
+**Ordering over locking.** Both fixes were on the table. Wrapping the media
+block in `vlock` shuts the window; releasing the sessions and calling
+`rtcCleanup()` FIRST deletes it. The second is preferred because it removes the
+concurrency rather than synchronising it — no future callback has to remember
+the lock, and there is no interval in which live peer connections point at legs
+that have already been freed. The invariant is now one sentence: stop
+everything that can touch a resource before releasing the resource. The pump
+thread is joined, the callback threads are gone with `rtcCleanup()`, and only
+then do the fds close. The cost accepted is that the decoders outlive the
+hangup DELETEs by however long the SFU takes to answer them — ffmpeg processes
+reading loopback sockets that have gone quiet, killed a moment later.
+
+**No honest test, said plainly.** The failure needs a live SFU, a peer sending
+RTP, and a hangup inside a window of a few instructions. The only unit test
+available would assert the ORDER of the calls, which mirrors the implementation
+instead of checking it. The two siblings fixed alongside it DID admit honest
+tests, and both were written failing first against the old logic transcribed
+verbatim.
+
+**Sibling 1 — measure, do not reserve.** The published tile grid accumulated
+`snprintf`'s return, which is the length it WOULD have written, under a loop
+guard reserving a flat 40 bytes per record against a worst case of 55. The
+guard can pass on a record that does not fit, and `shown[at] = 0` then writes
+past the buffer: unreachable at `CALL_TILE_MAX 3`, an out-of-bounds stack write
+the day the cap is raised. The guard is now the return value itself. The
+builder moved to `media.c` beside the other pure builder over the same tiles,
+which is what let the suite reach it without the libdatachannel link — the
+transcribed-verbatim version fails three checks and trips ASan on precisely
+that terminator. It is also now COMPLETE OR REFUSED, because the reader adopts
+a grid wholesale: one record short says three people are in the call when four
+are, and draws faces under the wrong names.
+
+**Sibling 2 — the comment prefix is per LINE, because the reader is.** `note()`
+wrote `"# "` once and handed the rest to `vfprintf`, so a multi-line note
+commented its first line and emitted the rest bare — while `call_reader_main`
+skips a line only when `line[0] == '#'` and parses every other non-empty line
+as a JSON event. A note carrying a whole SDP answer therefore hands the event
+stream one server-controlled line per line the SFU sent, and an answer line
+shaped like `{"event":"closed"}` is a remote peer driving shottino's call
+window. Latent only because `call_helper_start` never passes `--verbose`.
+
+**The output contract got an owner.** `emit`/`note`/`emit_event` moved to
+`call/note.c`, which links without libdatachannel and is therefore testable.
+Both ways this stream can break are byte-level and silent at runtime — a line
+that is neither comment nor JSON, and a value that escapes its own string — so
+both are now pinned. Worth recording separately: **no CI job compiles the call
+helper.** `make` builds `shottino`, `make check` builds the suites, and `make
+call` is opt-in behind cmake and the vendored submodule, so `call/main.c` is
+compiled by nobody in CI. That is how two `-Wformat-nonliteral` warnings sat in
+it unseen (the extraction gives the varargs helpers the format attribute the
+rest of the tree carries, and they are gone). It is also why the changes here
+were syntax-checked by hand against a stub `rtc/rtc.h`.
+
+**The class, swept.** shottino.c already applies this rule and says so:
+`call_helper_stop` joins the reader before closing the pipe it reads, closes
+the frame pipe only after the helper is gone "so a frame in flight cannot
+arrive to a freed buffer", and `main` ends with a long comment about the model
+thread that was neither stopped nor joined while shutdown freed the mutex and
+SSL context underneath it. The helper's own teardown was the one place that had
+drifted from the rule the rest of the tree follows.

--- a/frontends/shottino/Makefile
+++ b/frontends/shottino/Makefile
@@ -47,7 +47,7 @@ OBJS := shottino.o json.o wire.o alias.o mirc.o termcolor.o http.o media.o ircd.
 # reaches, which is the drawing primitives and nothing else. Do not trust
 # this net for changes elsewhere in that file; add a test or reason about
 # the path by hand.
-TESTS := tests/test_llm tests/test_ws tests/test_json tests/test_wire tests/test_alias tests/test_mirc tests/test_termcolor tests/test_http tests/test_media tests/test_whip tests/test_callmedia tests/test_layout tests/test_keys tests/test_ircd tests/test_commands tests/test_windows
+TESTS := tests/test_llm tests/test_ws tests/test_json tests/test_wire tests/test_alias tests/test_mirc tests/test_termcolor tests/test_http tests/test_media tests/test_whip tests/test_callmedia tests/test_callnote tests/test_layout tests/test_keys tests/test_ircd tests/test_commands tests/test_windows
 SANITIZE ?= -fsanitize=address,undefined -fno-omit-frame-pointer
 TEST_CFLAGS := -std=c11 -Wall -Wextra -Wpedantic -O1 -g $(SANITIZE)
 
@@ -102,6 +102,12 @@ tests/test_whip: tests/test_whip.c tests/test.h call/whip.c call/whip.h http.c h
 # of the opt-in submodule.
 tests/test_callmedia: tests/test_callmedia.c tests/test.h call/media.c call/media.h
 	$(CC) $(CPPFLAGS) $(TEST_CFLAGS) -o $@ tests/test_callmedia.c call/media.c
+
+# The helper's stderr is a PARSED stream with a reader at the other end,
+# so what it is allowed to write is a contract and not formatting. Links
+# note.c only, for the same reason test_callmedia links media.c only.
+tests/test_callnote: tests/test_callnote.c tests/test.h call/note.c call/note.h
+	$(CC) $(CPPFLAGS) $(TEST_CFLAGS) -o $@ tests/test_callnote.c call/note.c
 
 tests/test_mirc: tests/test_mirc.c tests/test.h mirc.c mirc.h
 	$(CC) $(CPPFLAGS) $(TEST_CFLAGS) -o $@ tests/test_mirc.c mirc.c
@@ -179,7 +185,7 @@ LDC_LIBS := $(LDC_BUILD)/libdatachannel.a \
             $(LDC_BUILD)/deps/libsrtp/libsrtp2.a \
             $(LDC_BUILD)/deps/usrsctp/usrsctplib/libusrsctp.a
 CALL_BIN := shottino-call
-CALL_SRC := call/main.c call/whip.c call/media.c http.c
+CALL_SRC := call/main.c call/whip.c call/media.c call/note.c http.c
 CALL_CFLAGS := $(CPPFLAGS) $(CFLAGS) -I$(LDC_DIR)/include
 
 .PHONY: call
@@ -202,11 +208,12 @@ $(LDC_LIBS): $(LDC_DIR)/CMakeLists.txt
 	  -DNO_WEBSOCKET=ON -DNO_EXAMPLES=ON -DNO_TESTS=ON
 	cmake --build $(LDC_BUILD) -j
 
-$(CALL_BIN): $(CALL_SRC) call/whip.h call/media.h http.h $(LDC_LIBS)
+$(CALL_BIN): $(CALL_SRC) call/whip.h call/media.h call/note.h http.h $(LDC_LIBS)
 	$(CC) $(CALL_CFLAGS) -c -o call/main.o call/main.c
 	$(CC) $(CALL_CFLAGS) -c -o call/whip.o call/whip.c
 	$(CC) $(CALL_CFLAGS) -c -o call/media.o call/media.c
-	$(CXX) -o $@ call/main.o call/whip.o call/media.o http.o $(LDC_LIBS) \
+	$(CC) $(CALL_CFLAGS) -c -o call/note.o call/note.c
+	$(CXX) -o $@ call/main.o call/whip.o call/media.o call/note.o http.o $(LDC_LIBS) \
 	  -static-libstdc++ -static-libgcc -lssl -lcrypto -lpthread -lm
 
 # The helper rides along WHEN IT HAS BEEN BUILT, and is not a
@@ -228,4 +235,4 @@ install: $(BIN)
 # libdatachannel from scratch is minutes, it is not what `clean` is for,
 # and it is already untracked. `rm -rf vendor/build` is the deliberate act.
 clean:
-	rm -f $(BIN) $(OBJS) $(OBJS:.o=.d) $(TESTS) $(CALL_BIN) call/main.o call/whip.o call/media.o
+	rm -f $(BIN) $(OBJS) $(OBJS:.o=.d) $(TESTS) $(CALL_BIN) call/main.o call/whip.o call/media.o call/note.o

--- a/frontends/shottino/call/main.c
+++ b/frontends/shottino/call/main.c
@@ -342,34 +342,24 @@ static void video_retile(struct call *c) {
         media_grid_layout(slots, n, c->cfg->frame_w, c->cfg->frame_h, c->vmix.tiles,
                           CALL_TILE_MAX);
     bool ok = media_start_video_mix(&c->vmix, c->cfg, c->frame_fd);
-    /* THE GRID, PUBLISHED. Not a status line — a contract.
-     *
-     * The composited frame is one picture on a byte pipe, so without
-     * these rectangles the other end cannot tell whose face is where.
-     * With them it can sample any cell into any box, which is what
-     * makes focus a drawing decision there instead of a decoder restart
-     * here.
-     *
-     *     <frame_w>x<frame_h>;slot,x,y,w,h;slot,x,y,w,h...
-     *
-     * shottino knows which nick each slot is — it built the subscribe
-     * list — so the slot number is enough to label a cell. Fewer tiles
-     * here than peers in the call is also how the cap is REPORTED
-     * rather than silently applied. */
+    /* `drawn` can be fewer than the peers who are sending: the cap is
+     * REPORTED — the note at the end of this function — rather than
+     * silently applied. */
     char shown[64 + CALL_MAX_PEERS * 32];
-    size_t at = 0;
     int drawn = c->vmix.tile_count;
-    at += (size_t)snprintf(shown + at, sizeof(shown) - at, "%dx%d", c->cfg->frame_w,
-                           c->cfg->frame_h);
-    for (int i = 0; i < drawn && at + 40 < sizeof(shown); i++)
-        at += (size_t)snprintf(shown + at, sizeof(shown) - at, ";%d,%d,%d,%d,%d",
-                               c->vmix.tiles[i].slot, c->vmix.tiles[i].x, c->vmix.tiles[i].y,
-                               c->vmix.tiles[i].w, c->vmix.tiles[i].h);
-    shown[at] = 0;
+    bool described = media_tiles_describe(c->vmix.tiles, drawn, c->cfg->frame_w, c->cfg->frame_h,
+                                          shown, sizeof(shown));
     pthread_mutex_unlock(&c->vlock);
 
     if (!ok) {
         emit_event("error", "message", "cannot start video decoding");
+        return;
+    }
+    if (!described) {
+        /* The grid is all-or-nothing at the other end, so a grid that
+         * did not fit is reported as a failure rather than published
+         * short: half a grid draws faces under the wrong names. */
+        emit_event("error", "message", "the tile grid could not be published");
         return;
     }
     emit_event("tiles", "value", shown);

--- a/frontends/shottino/call/main.c
+++ b/frontends/shottino/call/main.c
@@ -24,13 +24,14 @@
  *                        no microphone are opened: "it produced no
  *                        error" is not good enough for a device light.
  *
- * Output contract:
+ * Output contract, owned and enforced by note.c:
  *   stdout — the raw rgb24 frame stream. NOTHING else writes here.
  *   stderr — one JSON object per line: {"event":…}. With --verbose,
  *            human notes are interleaved as `#` comment lines, which a
  *            parser skips on the first character.
  */
 #include "media.h"
+#include "note.h"
 #include "whip.h"
 
 #include <errno.h>
@@ -38,7 +39,6 @@
 #include <poll.h>
 #include <pthread.h>
 #include <signal.h>
-#include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -101,55 +101,6 @@
 #define CALL_TILE_MAX 3
 
 static volatile sig_atomic_t stop_requested;
-
-static bool verbose;
-static pthread_mutex_t out_lock = PTHREAD_MUTEX_INITIALIZER;
-
-/* Every line out of this process goes through one of these two, so the
- * "stdout is frames only" rule cannot be broken by a stray printf. */
-static void emit(const char *fmt, ...) {
-    va_list ap;
-    va_start(ap, fmt);
-    pthread_mutex_lock(&out_lock);
-    vfprintf(stderr, fmt, ap);
-    fputc('\n', stderr);
-    fflush(stderr);
-    pthread_mutex_unlock(&out_lock);
-    va_end(ap);
-}
-
-static void note(const char *fmt, ...) {
-    if (!verbose) return;
-    va_list ap;
-    va_start(ap, fmt);
-    pthread_mutex_lock(&out_lock);
-    fputs("# ", stderr);
-    vfprintf(stderr, fmt, ap);
-    fputc('\n', stderr);
-    fflush(stderr);
-    pthread_mutex_unlock(&out_lock);
-    va_end(ap);
-}
-
-/* JSON string escaping for the few fields that can carry server text. */
-static void emit_event(const char *event, const char *key, const char *value) {
-    char esc[512];
-    size_t n = 0;
-    for (const unsigned char *p = (const unsigned char *)(value ? value : "");
-         *p && n + 7 < sizeof(esc); p++) {
-        if (*p == '"' || *p == '\\') {
-            esc[n++] = '\\';
-            esc[n++] = (char)*p;
-        } else if (*p < 0x20) {
-            n += (size_t)snprintf(esc + n, sizeof(esc) - n, "\\u%04x", *p);
-        } else {
-            esc[n++] = (char)*p;
-        }
-    }
-    esc[n] = 0;
-    if (key) emit("{\"event\":\"%s\",\"%s\":\"%s\"}", event, key, esc);
-    else emit("{\"event\":\"%s\"}", event);
-}
 
 static void on_signal(int sig) {
     (void)sig;
@@ -909,7 +860,7 @@ int main(int argc, char **argv) {
             }
             break;
         case OPT_FPS: mcfg.fps = atoi(optarg); break;
-        case 'v': verbose = true; break;
+        case 'v': note_set_verbose(true); break;
         case 'p': printf("%d\n", CALL_PROTOCOL); return 0;
         case 'h': usage(stdout); return 0;
         default: usage(stderr); return 2;
@@ -930,7 +881,7 @@ int main(int argc, char **argv) {
     signal(SIGINT, on_signal);
     signal(SIGTERM, on_signal);
 
-    rtcInitLogger(verbose ? RTC_LOG_WARNING : RTC_LOG_NONE, on_rtc_log);
+    rtcInitLogger(note_verbose() ? RTC_LOG_WARNING : RTC_LOG_NONE, on_rtc_log);
 
     struct call call;
     memset(&call, 0, sizeof(call));

--- a/frontends/shottino/call/main.c
+++ b/frontends/shottino/call/main.c
@@ -1200,15 +1200,49 @@ int main(int argc, char **argv) {
         if (!still) break;
     }
 
+    /* TEARDOWN IS AN ORDER, and the order is: stop everything that can
+     * TOUCH a resource before releasing the resource.
+     *
+     * Every one of the three writers here reaches the media legs, and
+     * each is silenced in turn:
+     *
+     *   - the pump thread, joined;
+     *   - the RTP callbacks, which run on libdatachannel's threads and
+     *     stop only when the peer connections are gone and rtcCleanup()
+     *     has joined the pool;
+     *   - this thread, which then closes the sockets with nobody left
+     *     to race.
+     *
+     * The legs USED to go first, while the peer connections were still
+     * alive two lines below. media_stop() closes a leg's fd and blanks
+     * it as two separate stores, and media_feed()'s `fd < 0` guard is
+     * read before the sendto — so an RTP packet arriving during hangup
+     * could pass the guard, have the fd closed under it, and then write
+     * to a descriptor number session_release() had already recycled for
+     * its hangup socket. The callbacks take `vlock` with TRYLOCK, which
+     * is a BACKPRESSURE primitive (a re-tile is in progress, drop the
+     * packet) and not a lifetime barrier: teardown never held it, so it
+     * always succeeded, and the guard read as protection it was not
+     * giving.
+     *
+     * Wrapping the media teardown in `vlock` would also have closed the
+     * window, and is what the report suggested. Ordering is preferred
+     * because it deletes the concurrency instead of synchronising it:
+     * there is no window left to reason about, no future callback that
+     * has to remember the lock, and no interval during which live peer
+     * connections point at legs that have already been freed. The cost
+     * is that the decoders now outlive the hangup DELETEs by however
+     * long the SFU takes to answer them — ffmpeg processes reading
+     * loopback sockets that have gone quiet, killed a moment later. */
     stop_requested = 1; /* ends the pump */
     if (pumping) pthread_join(pump, NULL);
+    session_release(&call.pub);
+    for (int i = 0; i < CALL_MAX_PEERS; i++) session_release(&call.sub[i]);
+    rtcCleanup();
     media_stop(&call.send_audio);
     media_stop(&call.send_video);
     media_mix_free(&call.amix);
     media_mix_free(&call.vmix);
-    session_release(&call.pub);
-    for (int i = 0; i < CALL_MAX_PEERS; i++) session_release(&call.sub[i]);
-    rtcCleanup();
     emit_event("closed", NULL, NULL);
     return connected ? 0 : 1;
 }

--- a/frontends/shottino/call/media.c
+++ b/frontends/shottino/call/media.c
@@ -493,6 +493,34 @@ bool media_mix_filter(const struct media_tile *tiles, int n, int fps, int frame_
     return true;
 }
 
+bool media_tiles_describe(const struct media_tile *tiles, int n, int frame_w, int frame_h,
+                          char *out, size_t out_sz) {
+    if (!out || out_sz == 0) return false;
+    out[0] = 0;
+    if (!tiles || n < 0) return false;
+    /* Measured on what snprintf WOULD have written, every record, rather
+     * than on a constant reserved per record. A constant is a guess at a
+     * record's worst case, and the day it guesses low the cursor walks
+     * past the end of the buffer and the terminator is written there. */
+    size_t at = 0;
+    int w = snprintf(out, out_sz, "%dx%d", frame_w, frame_h);
+    if (w < 0 || (size_t)w >= out_sz) {
+        out[0] = 0;
+        return false;
+    }
+    at = (size_t)w;
+    for (int i = 0; i < n; i++) {
+        w = snprintf(out + at, out_sz - at, ";%d,%d,%d,%d,%d", tiles[i].slot, tiles[i].x,
+                     tiles[i].y, tiles[i].w, tiles[i].h);
+        if (w < 0 || (size_t)w >= out_sz - at) {
+            out[0] = 0;
+            return false;
+        }
+        at += (size_t)w;
+    }
+    return true;
+}
+
 /* Give a leg a loopback port and an SDP, without starting anything.
  * The port SURVIVES a re-tile: the RTP callback keeps writing to it
  * while the decoder behind it is being replaced, so a focus change

--- a/frontends/shottino/call/media.h
+++ b/frontends/shottino/call/media.h
@@ -214,6 +214,24 @@ int media_grid_layout(const int *slots, int n, int frame_w, int frame_h, struct 
 bool media_mix_filter(const struct media_tile *tiles, int n, int fps, int frame_w, int frame_h,
                       char *out, size_t out_sz);
 
+/* THE GRID, PUBLISHED. Not a status line — a contract.
+ *
+ *     <frame_w>x<frame_h>;slot,x,y,w,h;slot,x,y,w,h...
+ *
+ * The composited frame is one picture on a byte pipe, so without these
+ * rectangles the other end cannot tell whose face is where. With them it
+ * can sample any cell into any box, which is what makes focus a drawing
+ * decision there instead of a decoder restart here. The slot number is
+ * enough to label a cell: shottino built the subscribe list, so it knows
+ * which nick each slot is.
+ *
+ * COMPLETE OR REFUSED — returns false and leaves `out` EMPTY when the
+ * whole grid does not fit. The other end adopts a grid wholesale or not
+ * at all, because a short one draws faces under the wrong names, which
+ * is worse than drawing none. Pure, and therefore tested. */
+bool media_tiles_describe(const struct media_tile *tiles, int n, int frame_w, int frame_h,
+                          char *out, size_t out_sz);
+
 /* Start (or restart) the composited video decoder. Ports already bound
  * in `mix->legs` are KEPT, so RTP arriving during a re-tile lands
  * somewhere valid rather than on a closed socket. Caller fills

--- a/frontends/shottino/call/note.c
+++ b/frontends/shottino/call/note.c
@@ -1,0 +1,91 @@
+#include "note.h"
+
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static bool verbose;
+static pthread_mutex_t out_lock = PTHREAD_MUTEX_INITIALIZER;
+
+void note_set_verbose(bool on) { verbose = on; }
+
+bool note_verbose(void) { return verbose; }
+
+/* Every line out of this process goes through this or note(), so the
+ * "stdout is frames only" rule cannot be broken by a stray printf. */
+static void emit(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+
+static void emit(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    pthread_mutex_lock(&out_lock);
+    vfprintf(stderr, fmt, ap);
+    fputc('\n', stderr);
+    fflush(stderr);
+    pthread_mutex_unlock(&out_lock);
+    va_end(ap);
+}
+
+void note(const char *fmt, ...) {
+    if (!verbose) return;
+    /* FORMATTED FIRST, then written a line at a time. Writing "# " and
+     * then handing the format string to vfprintf comments the first line
+     * and no other, and the notes that matter are the multi-line ones:
+     * a whole SDP answer goes through here, the body is the SFU's, and
+     * the reader at the other end decides line by line. An answer with a
+     * line shaped like an event is then an event — a remote peer driving
+     * shottino's call window. */
+    char stack[1024];
+    char *buf = stack;
+    va_list ap;
+    va_start(ap, fmt);
+    int n = vsnprintf(stack, sizeof(stack), fmt, ap);
+    va_end(ap);
+    if (n < 0) return;
+    if ((size_t)n >= sizeof(stack)) {
+        /* A real answer with a dozen candidates clears a kilobyte, and
+         * truncating loses exactly the part that was worth printing. */
+        char *big = malloc((size_t)n + 1);
+        if (big) {
+            va_start(ap, fmt);
+            vsnprintf(big, (size_t)n + 1, fmt, ap);
+            va_end(ap);
+            buf = big;
+        }
+    }
+    pthread_mutex_lock(&out_lock);
+    const char *p = buf;
+    do {
+        const char *nl = strchr(p, '\n');
+        size_t len = nl ? (size_t)(nl - p) : strlen(p);
+        fputs("# ", stderr);
+        fwrite(p, 1, len, stderr);
+        fputc('\n', stderr);
+        p = nl ? nl + 1 : p + len;
+    } while (*p);
+    fflush(stderr);
+    pthread_mutex_unlock(&out_lock);
+    if (buf != stack) free(buf);
+}
+
+/* JSON string escaping for the few fields that can carry server text. */
+void emit_event(const char *event, const char *key, const char *value) {
+    char esc[512];
+    size_t n = 0;
+    for (const unsigned char *p = (const unsigned char *)(value ? value : "");
+         *p && n + 7 < sizeof(esc); p++) {
+        if (*p == '"' || *p == '\\') {
+            esc[n++] = '\\';
+            esc[n++] = (char)*p;
+        } else if (*p < 0x20) {
+            n += (size_t)snprintf(esc + n, sizeof(esc) - n, "\\u%04x", *p);
+        } else {
+            esc[n++] = (char)*p;
+        }
+    }
+    esc[n] = 0;
+    if (key) emit("{\"event\":\"%s\",\"%s\":\"%s\"}", event, key, esc);
+    else emit("{\"event\":\"%s\"}", event);
+}

--- a/frontends/shottino/call/note.h
+++ b/frontends/shottino/call/note.h
@@ -1,0 +1,36 @@
+/* note.h — everything this process says to shottino.
+ *
+ * ONE owner for the stderr contract, because it IS a contract and it has
+ * a reader at the other end (`call_reader_main` in shottino.c):
+ *
+ *   stdout — the raw rgb24 frame stream. NOTHING else writes here.
+ *   stderr — one JSON object per line: {"event":…}. With --verbose,
+ *            human notes are interleaved as `#` comment lines, which the
+ *            reader skips on the first character.
+ *
+ * Split out of main.c so the contract can be TESTED without the media
+ * helper's libdatachannel link: the two ways it can be broken — a line
+ * that is not a `#` comment and is not JSON either, and an event value
+ * that escapes its own string — are both silent at runtime and both
+ * decided entirely by the bytes these functions write.
+ */
+#ifndef SHOTTINO_CALL_NOTE_H
+#define SHOTTINO_CALL_NOTE_H
+
+#include <stdbool.h>
+
+/* --verbose. Off, notes are not written at all; events always are. */
+void note_set_verbose(bool on);
+bool note_verbose(void);
+
+/* One JSON object on one line. `value` is escaped; `key` is ours. */
+void emit_event(const char *event, const char *key, const char *value);
+
+/* A human note, EVERY line of it prefixed with "# ".
+ *
+ * Every line, not just the first: the reader skips a line only when its
+ * first character is '#', so a note carrying a whole SDP body hands the
+ * event stream one attacker-shaped line per line the server sent. */
+void note(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+
+#endif /* SHOTTINO_CALL_NOTE_H */

--- a/frontends/shottino/docs/CALLS.md
+++ b/frontends/shottino/docs/CALLS.md
@@ -191,7 +191,8 @@ usage: shottino-call [--whip <url>] [--whep <url>] [options]
 **stdout is reserved for the raw frame stream and nothing else writes
 there**; events are one JSON object per line on **stderr**, and
 `--verbose` notes are `#` comment lines a parser skips on the first
-character. `--protocol` exists so shottino can refuse a helper left
+character — **every** line of a note, not just its first, because the
+reader decides line by line and a note can carry a whole SDP body. `--protocol` exists so shottino can refuse a helper left
 behind by an older install rather than misbehaving with it.
 
 It does the full signalling round trip — gather ICE, build the offer,

--- a/frontends/shottino/tests/test_callmedia.c
+++ b/frontends/shottino/tests/test_callmedia.c
@@ -332,6 +332,61 @@ TEST(the_mix_filter_chains_every_tile_into_one_output) {
     CHECK(!media_mix_filter(NULL, 2, 10, 640, 480, f, sizeof(f)));
 }
 
+/* The grid, as shottino is told about it. The other end adopts it
+ * WHOLESALE or not at all, so the only two honest outcomes here are a
+ * complete grid and no grid — a short one draws faces under the wrong
+ * names, which is worse than drawing none. */
+TEST(the_published_grid_is_complete_or_refused) {
+    struct media_tile t[MEDIA_MAX_PEERS];
+    const int slots[4] = { 0, 2, 5, 7 };
+    char g[320];
+
+    CHECK(media_grid_layout(slots, 1, 640, 480, t, MEDIA_MAX_PEERS) == 1);
+    CHECK(media_tiles_describe(t, 1, 640, 480, g, sizeof(g)));
+    CHECK_STR(g, "640x480;0,0,0,640,480");
+
+    CHECK(media_grid_layout(slots, 4, 640, 480, t, MEDIA_MAX_PEERS) == 4);
+    CHECK(media_tiles_describe(t, 4, 640, 480, g, sizeof(g)));
+    CHECK_STR(g, "640x480;0,0,0,320,240;2,320,0,320,240;5,0,240,320,240;7,320,240,320,240");
+
+    /* A layout that fitted nobody — media_grid_layout refuses a frame
+     * with no room for even one usable cell — still publishes the frame
+     * size. The other end needs it to know what it is not drawing. */
+    CHECK(media_tiles_describe(t, 0, 640, 480, g, sizeof(g)));
+    CHECK_STR(g, "640x480");
+
+    /* REFUSED, not shortened. The buffer holds the header and the first
+     * record and nothing more; a builder that stops when it runs out
+     * hands over a grid that says one peer is in the call when four
+     * are. Reachable the day CALL_TILE_MAX is raised. */
+    char small[32];
+    CHECK(media_grid_layout(slots, 4, 640, 480, t, MEDIA_MAX_PEERS) == 4);
+    CHECK(!media_tiles_describe(t, 4, 640, 480, g, 32));
+    CHECK(!media_tiles_describe(t, 4, 640, 480, small, sizeof(small)));
+    /* Emptied on refusal, so a caller that ignores the answer publishes
+     * nothing rather than the half it happened to fit. */
+    CHECK_STR(small, "");
+
+    /* Not even the header fits: still refused, still empty, still no
+     * write past the end — the one that ASan is here for. */
+    char nano[4];
+    CHECK(!media_tiles_describe(t, 1, 640, 480, nano, sizeof(nano)));
+    CHECK_STR(nano, "");
+
+    /* A record wider than any slack the old length guard reserved. The
+     * builder must measure what snprintf WOULD have written, not assume
+     * a record's worst case: the guard was a constant, and a constant
+     * that is smaller than the truth is an out-of-bounds terminator. */
+    struct media_tile wide[1] = { { 2147483647, 2147483647, 2147483647, 2147483647, 2147483647 } };
+    char sixty[64];
+    CHECK(!media_tiles_describe(wide, 1, 2147483647, 2147483647, sixty, sizeof(sixty)));
+    CHECK_STR(sixty, "");
+
+    CHECK(!media_tiles_describe(NULL, 2, 640, 480, g, sizeof(g)));
+    CHECK(!media_tiles_describe(t, 1, 640, 480, NULL, sizeof(g)));
+    CHECK(!media_tiles_describe(t, 1, 640, 480, g, 0));
+}
+
 /* Two legs must never be handed the same port, and the port has to be
  * one the caller can actually tell ffmpeg about. */
 TEST(loopback_ports_are_distinct_and_reported) {
@@ -355,6 +410,7 @@ int main(void) {
     RUN(the_answer_says_which_codec_this_peer_publishes);
     RUN(the_grid_is_even_and_independent_of_focus);
     RUN(the_mix_filter_chains_every_tile_into_one_output);
+    RUN(the_published_grid_is_complete_or_refused);
     RUN(loopback_ports_are_distinct_and_reported);
     return test_report();
 }

--- a/frontends/shottino/tests/test_callnote.c
+++ b/frontends/shottino/tests/test_callnote.c
@@ -1,0 +1,157 @@
+/* test_callnote — what the media helper is allowed to put on stderr.
+ *
+ * stderr is a PARSED stream: shottino's call_reader_main treats every
+ * line that is not empty and does not begin with '#' as one JSON event.
+ * So the whole safety of the channel rests on two byte-level properties
+ * that nothing at runtime will ever complain about — a note that fails
+ * to comment ALL of its lines, and an event value that escapes its own
+ * string. Both are decided here, and only here.
+ *
+ * Links call/note.c only — no libdatachannel — so the default gate never
+ * depends on the opt-in submodule having been built.
+ */
+#include "../call/note.h"
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "test.h"
+
+/* stderr is what is under test AND what test.h reports failures on, so
+ * it is captured to a file and put back BEFORE anything is asserted. */
+static int cap_saved = -1;
+static char cap_path[64];
+
+static void cap_start(void) {
+    snprintf(cap_path, sizeof(cap_path), "/tmp/shottino-note-XXXXXX");
+    int fd = mkstemp(cap_path);
+    if (fd < 0) abort();
+    fflush(stderr);
+    cap_saved = dup(STDERR_FILENO);
+    dup2(fd, STDERR_FILENO);
+    close(fd);
+}
+
+static void cap_end(char *out, size_t out_sz) {
+    fflush(stderr);
+    dup2(cap_saved, STDERR_FILENO);
+    close(cap_saved);
+    cap_saved = -1;
+    FILE *f = fopen(cap_path, "r");
+    size_t n = f ? fread(out, 1, out_sz - 1, f) : 0;
+    out[n] = 0;
+    if (f) fclose(f);
+    unlink(cap_path);
+}
+
+/* True when every non-empty line the helper wrote is one the reader
+ * will skip — i.e. nothing here can be mistaken for an event. */
+static bool every_line_is_a_comment(const char *s) {
+    for (const char *p = s; *p;) {
+        const char *nl = strchr(p, '\n');
+        size_t len = nl ? (size_t)(nl - p) : strlen(p);
+        if (len > 0 && p[0] != '#') return false;
+        p = nl ? nl + 1 : p + len;
+    }
+    return true;
+}
+
+TEST(a_note_comments_every_line_it_writes) {
+    char got[8192];
+    note_set_verbose(true);
+
+    cap_start();
+    note("subscribe 0: joined late");
+    cap_end(got, sizeof(got));
+    CHECK_STR(got, "# subscribe 0: joined late\n");
+
+    /* A MULTI-LINE note. The helper writes one for every answer it gets
+     * at --verbose, and the reader comments out lines, not messages. */
+    cap_start();
+    note("%s: answer\n%s", "publish", "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\n");
+    cap_end(got, sizeof(got));
+    CHECK(every_line_is_a_comment(got));
+    CHECK(strstr(got, "# v=0") != NULL);
+    CHECK(strstr(got, "# o=- 0 0 IN IP4 127.0.0.1") != NULL);
+
+    /* THE INJECTION. The answer body is the SFU's, not ours, and an SDP
+     * is a list of lines. One shaped like an event reaches the reader as
+     * an event unless every line of the note is commented — which is a
+     * remote peer closing the call window, or worse. */
+    cap_start();
+    note("%s: answer\n%s", "subscribe 0",
+         "v=0\r\na=x:{\"event\":\"closed\"}\r\n{\"event\":\"error\",\"message\":\"pwned\"}\r\n");
+    cap_end(got, sizeof(got));
+    CHECK(every_line_is_a_comment(got));
+    CHECK(strstr(got, "\n{\"event\"") == NULL);
+
+    /* Longer than any buffer a formatter would put on the stack: a real
+     * answer with a dozen candidates clears 1 KB easily, and a note that
+     * silently truncates loses the very body it was asked to show. */
+    char big[4096];
+    memset(big, 'a', sizeof(big) - 1);
+    big[sizeof(big) - 1] = 0;
+    big[1000] = '\n';
+    big[2000] = '\n';
+    cap_start();
+    note("answer\n%s", big);
+    cap_end(got, sizeof(got));
+    CHECK(every_line_is_a_comment(got));
+    CHECK(strlen(got) >= sizeof(big));
+    CHECK(got[strlen(got) - 1] == '\n');
+
+    /* Off means silent — the notes are the only thing --verbose adds. */
+    note_set_verbose(false);
+    cap_start();
+    note("%s", "not written");
+    cap_end(got, sizeof(got));
+    CHECK_STR(got, "");
+    note_set_verbose(true);
+}
+
+/* The other half of the same surface: a value that escapes its string
+ * is a line the reader parses as some other event entirely. */
+TEST(an_event_value_cannot_escape_its_own_string) {
+    char got[8192];
+
+    cap_start();
+    emit_event("state", "value", "publish connected");
+    cap_end(got, sizeof(got));
+    CHECK_STR(got, "{\"event\":\"state\",\"value\":\"publish connected\"}\n");
+
+    cap_start();
+    emit_event("closed", NULL, NULL);
+    cap_end(got, sizeof(got));
+    CHECK_STR(got, "{\"event\":\"closed\"}\n");
+
+    /* Server text: quotes, backslashes and control bytes all come back
+     * as one line with the braces still ours. */
+    cap_start();
+    emit_event("error", "message", "he said \"no\" \\ then\nleft");
+    cap_end(got, sizeof(got));
+    CHECK_STR(got,
+              "{\"event\":\"error\",\"message\":\"he said \\\"no\\\" \\\\ then\\u000aleft\"}\n");
+    /* ONE line out, whatever went in. */
+    CHECK(strchr(got, '\n') == got + strlen(got) - 1);
+
+    /* Over-long server text is cut, not spilled: still one line, still
+     * closed, still parseable. */
+    char loud[2048];
+    memset(loud, '"', sizeof(loud) - 1);
+    loud[sizeof(loud) - 1] = 0;
+    cap_start();
+    emit_event("error", "message", loud);
+    cap_end(got, sizeof(got));
+    CHECK(strchr(got, '\n') == got + strlen(got) - 1);
+    CHECK(strncmp(got, "{\"event\":\"error\",\"message\":\"", 27) == 0);
+    CHECK(strstr(got, "\"}\n") == got + strlen(got) - 3);
+}
+
+int main(void) {
+    RUN(a_note_comments_every_line_it_writes);
+    RUN(an_event_value_cannot_escape_its_own_string);
+    return test_report();
+}


### PR DESCRIPTION
Fixes the teardown race reported in #759, plus the two latent siblings the
issue asked to be fixed while in here.

## The race

`shottino-call`'s hangup released the media legs before it stopped the threads
that write them. `media_stop` closed each leg's socket while the peer
connections were still alive two lines below, so RTP arriving mid-hangup ran on
libdatachannel's thread against a leg being dismantled — `media_feed` tests
`fd < 0` and then `sendto`s it as two steps, `media_stop` closes and blanks the
fd as two more, and `session_release` opens a socket for its DELETE right
after, so the descriptor number comes back and the write lands on an unrelated
fd.

**Which shape, and why.** The issue offered `vlock` around the media block, or
moving `session_release` + `rtcCleanup()` above it. I took the ordering.

The `vlock` reads like the protection against this and is not: the callbacks
take it with TRYLOCK because it is *backpressure* — a re-tile is forking
ffmpeg, drop the datagram rather than park a media thread — and teardown never
took it, so the trylock always succeeded exactly when it mattered. A lock whose
fast path is allowed to skip it cannot be a lifetime primitive.

Locking would have shut the window. Ordering deletes it: after `rtcCleanup()`
no callback thread exists, so nothing races the close. What locking would have
cost is the part that decided it — the concurrency stays and only gets
synchronised, so every future callback has to remember the lock, and there is
still an interval in which live peer connections point at legs already freed.
The invariant is now one sentence in the code: stop everything that can touch a
resource before releasing the resource.

Accepted cost: the decoders outlive the hangup DELETEs by however long the SFU
takes to answer them — ffmpeg processes reading loopback sockets that have gone
quiet, killed a moment later.

## Sibling 1 — the grid terminator

`shown[at] = 0` where `at` accumulated `snprintf`'s would-be length, under a
guard reserving a flat 40 bytes against a 55-byte worst case. The guard is now
the return value. The builder moves to `media.c` beside the other pure builder
over the same tiles, which is what makes it testable without the libdatachannel
link, and it is now complete-or-refused: the reader adopts a grid wholesale, so
one record short says three people are in the call when four are.

## Sibling 2 — the `#` prefix

`note()` prefixed the first line and handed the rest to `vfprintf`, while the
reader skips a line only on `line[0] == '#'` and parses every other non-empty
line as an event. A note carrying an SDP answer therefore hands the event
stream one server-controlled line per line the SFU sent. Now formatted first,
written a line at a time. `emit`/`note`/`emit_event` move to `call/note.c` so
the contract has an owner that links without libdatachannel and can be tested.

## Tests

Both siblings have tests written **failing first** against the old logic
transcribed verbatim: the grid one fails three checks plus an ASan
stack-buffer-overflow on exactly that terminator write; the note one fails six,
including the injected `{"event":...}` line arriving unprefixed.

The race itself has **no test, deliberately**. It needs a live SFU, a peer
sending RTP, and a hangup inside a window of a few instructions; the only unit
test available would assert the call *order*, which mirrors the implementation
rather than checking it. Saying so rather than shipping a test a broken
implementation would still satisfy.

## Worth knowing

**No CI job compiles the call helper.** `make` builds `shottino`, `make check`
builds the suites, `make call` is opt-in behind cmake and the vendored
submodule — so `call/main.c` is compiled by nobody in CI. That is how two
`-Wformat-nonliteral` warnings sat in it unseen (the extraction gives the
varargs helpers the format attribute the rest of the tree carries; they are
gone). The changes here were syntax-checked by hand against a stub `rtc/rtc.h`
under the shipped warning set.

## The class, swept

`shottino.c` already applies this rule and documents it: `call_helper_stop`
joins the reader before closing the pipe it reads, closes the frame pipe only
after the helper is gone "so a frame in flight cannot arrive to a freed
buffer", and `main` carries a long comment about the model thread that was
neither stopped nor joined while shutdown freed the mutex and SSL context
underneath it. The helper's own teardown was the one place that had drifted.

## Verification

16/16 local suites green from a clean rebuild (`test_keys` is Linux-only and
runs in CI). Two new suites: `tests/test_callnote`, and the grid case in
`tests/test_callmedia`.