### PR TITLE
auth(#815): say the DB failed, not the credential

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -28954,3 +28954,83 @@ not add another.
 assertions fell. The entropy-came-from-the-source half stayed green under that
 mutation, which is the honest reading: it pins the derivation, and the refusal
 assertions pin the check.
+
+## 2026-08-05 — #815: wrapping a compare-and-set, once the hazard was measured
+
+`consume_sign_count/2` → `commit_counter/3` was the last passkey write still
+raising a 500 on transient SQLite contention. #768 wrapped the other three and
+deliberately skipped this one, because the wrap alone is not obviously safe and
+is arguably worse: the write is a **compare-and-set** (`where sign_count ==
+^expected`), so it is not idempotent under retry. An attempt that COMMITTED and
+then reported an error would be retried, match zero rows against the counter it
+had itself advanced, and fall into `refuse_clone/2` — a legitimate login refused
+and a false clone alarm, naming a user and a credential, written into the
+operator's log by the very mechanism meant to improve availability.
+
+**That premise was an inference about the code, so it was measured before
+anything was built.** 142 forced mid-flight connection kills across four shapes
+(lock contention; a long `UPDATE` interrupted mid-VDBE; the deadline swept
+across the commit boundary from both sides; the single-row CAS blocked on a lock
+released under a swept deadline), each attempt writing a unique marker read back
+through a **different pooled connection** so "did it land" is answered by the
+database and never by the return value. Result: **zero** cases of "caller sees a
+transient error *and* the row moved", including 63 where the pool had already
+destroyed the connection under the caller.
+
+The mechanism, not the luck: before the commit, `Exqlite.Connection.disconnect/2`
+calls `Sqlite3.cancel/1`, which wakes the busy handler (`SQLITE_BUSY` →
+`"Database busy"`, transient) or interrupts the VDBE (`"interrupted"`,
+non-transient → `BusyRetry` re-raises); either way SQLite rolls back and there is
+nothing to double-apply. After the commit, `DBConnection.Holder.holder_apply/4`
+fails its `:ets.update_element` on the deleted holder and `augment_disconnect/1`
+rewrites **only** `{:disconnect, …}` tuples — an `{:ok, …}` falls through
+unchanged, so a committed write is still reported as committed. Every retry
+therefore re-runs an attempt that left the row untouched, and the CAS still
+matches.
+
+**The wrap is half the change; the caller was the actual defect.**
+`authenticate/3` closed on `_ -> {:error, :invalid_passkey}`, so shipping the
+wrap alone would have relabelled a saturated writer as a forged credential — the
+exact lie #768 removed from `set_mode/2` and `register/2`, reintroduced one layer
+down, and a worse answer than the 500 it replaced because the user believes it
+and re-enrols a credential that was never wrong. A 503 on this path can only be
+observed by someone who already produced a valid assertion for a credential we
+hold, so it discloses nothing they did not supply. **One atom widens, not the
+else:** `:cloned_authenticator` stays collapsed, because the wire must never
+confirm to an attacker that their clone was spotted. The same clause was owed at
+the wire in `login_verify/2` and `second_factor_verify/2` — two separate `case`s,
+so fixing one leaves the other lying, and they are pinned separately.
+
+**The sketched retry-safe CAS is declined, and this is the reason.** #815
+proposed treating "0 rows matched *and* the stored counter already equals the
+value we tried to write" as success, "costing nothing". It does not cost nothing:
+two assertions racing on one credential both read `expected` and both present the
+same `new_count`, so the loser finds exactly that condition and would be
+**accepted** — which is precisely the captured-assertion-replayed-alongside-the-
+genuine-one that the CAS exists to refuse. It trades a measured-nonexistent
+hazard for a real hole in clone detection. Distinguishing "my own committed
+attempt" from "a concurrent genuine one" needs a per-attempt token in the row,
+which is heavier than the problem.
+
+**What is bounded by construction, and what is not.** The degrade path returns
+`{:error, :db_unavailable}` on its own branch and never reaches `refuse_clone/2`,
+so a saturated writer cannot produce a clone alarm no matter what the pool does.
+The residual exposure is only the committed-then-error sequence above, whose
+worst outcome is one spurious clone warning and one refused login on an already
+saturated database — not an auth bypass.
+
+**Re-measure when this moves.** The commit-survives-the-kill half rests on
+`holder_apply/4` + `augment_disconnect/1` in **db_connection 2.10.2**, and the
+rollback half on `Sqlite3.cancel/1` in **exqlite 0.38.0** (via ecto_sqlite3
+0.24.1) — internals, not documented contracts, so a bump can change them without
+a changelog line loud enough to notice. A bump of either in `mix.lock` is the
+trigger; the observable to re-run to zero is "caller raised **and** the row
+moved", read back through a second pooled connection under the prod pool posture
+(`pool_size: 3`, `busy_timeout: 30_000`, WAL) — never the `pool_size: 1` Sandbox,
+which cannot produce real contention. Two things were **not** measured and stay
+open: the FreeBSD jail (the logic is platform-independent, the timing is not),
+and multi-statement `Repo.transaction` boundaries, where a deadline can land
+after `COMMIT` but before the transaction returns. The latter is #768's
+`run_mode_transaction/4`, not this write — and it is safe for a different
+reason: replaying that transaction re-applies the same mode, the same recovery
+set and the same revocations, so unlike a CAS it is idempotent.

--- a/lib/grappa/accounts/webauthn.ex
+++ b/lib/grappa/accounts/webauthn.ex
@@ -98,7 +98,8 @@ defmodule Grappa.Accounts.WebAuthn do
   end
 
   @doc "Consumes and verifies a passkey assertion once."
-  @spec authenticate(map(), atom(), binding()) :: {:ok, User.t(), map()} | {:error, term()}
+  @spec authenticate(map(), atom(), binding()) ::
+          {:ok, User.t(), map()} | {:error, :invalid_passkey | :db_unavailable}
   def authenticate(params, purpose, binding) do
     with {:ok, challenge, %{user_id: user_id, binding: ^binding} = metadata} <-
            WebAuthnChallengeStore.take(params["challenge_id"], purpose),
@@ -109,6 +110,21 @@ defmodule Grappa.Accounts.WebAuthn do
          %User{} = user <- Repo.get(User, user_id) do
       {:ok, user, metadata}
     else
+      # #815 — the LAST clause reached here decides what a saturated writer
+      # looks like, and the catch-all below answers "your credential is bad".
+      # Since #815 wrapped the counter commit in `Repo.BusyRetry`, that answer
+      # would be a statement about a credential this function verified and
+      # accepted: everything ahead of the write passed, and only the write
+      # failed. It is the same lie #768 removed from `set_mode/2` and
+      # `register/2`, one layer down — and worse than the 500 the wrap replaced,
+      # because the user believes it and re-enrols a credential that was fine.
+      #
+      # ONE atom widens, not the else. `:cloned_authenticator` in particular
+      # stays collapsed below: the wire must never confirm to an attacker that
+      # their clone was spotted (see `refuse_clone/2`). A 503 here can only be
+      # read by someone who already produced a valid assertion for a credential
+      # we hold, so it tells them nothing they did not supply themselves.
+      {:error, :db_unavailable} = err -> err
       _ -> {:error, :invalid_passkey}
     end
   end
@@ -297,7 +313,8 @@ defmodule Grappa.Accounts.WebAuthn do
   The write is a compare-and-set on the stored counter, so two assertions
   racing on one credential cannot both win.
   """
-  @spec consume_sign_count(Passkey.t(), non_neg_integer()) :: :ok | {:error, :cloned_authenticator}
+  @spec consume_sign_count(Passkey.t(), non_neg_integer()) ::
+          :ok | {:error, :cloned_authenticator | :db_unavailable}
   def consume_sign_count(%Passkey{sign_count: 0} = passkey, 0), do: commit_counter(passkey, 0, 0)
 
   def consume_sign_count(%Passkey{sign_count: old_count} = passkey, new_count)
@@ -309,12 +326,34 @@ defmodule Grappa.Accounts.WebAuthn do
   # Compare-and-set against the counter we read. A concurrent assertion that
   # already moved the row wins and this one is refused, so a captured
   # assertion cannot be replayed alongside the genuine one.
+  #
+  # #815 — the last unwrapped passkey write, deliberately left out of #768
+  # because a CAS is not idempotent: an attempt that COMMITTED and then
+  # reported an error would be retried, match zero rows against the counter it
+  # had itself advanced, and be refused as a clone — a legitimate login denied
+  # and a false clone alarm in the operator's log. That sequence was measured
+  # rather than reasoned about (142 forced mid-flight connection kills, zero
+  # occurrences) and it cannot happen through this pool; the whole argument,
+  # its limits, and what must be re-measured if `db_connection`'s internals
+  # change are in DESIGN_NOTES 2026-08-05. Every retry therefore re-runs an
+  # attempt that left the row untouched, so the CAS still matches.
+  #
+  # `refuse_clone/2` stays on the `{:ok, 0}` branch only: a degrade is not a
+  # refusal, and routing it through the clone rule would write exactly the
+  # alarm this wrap was accused of manufacturing.
   defp commit_counter(%Passkey{id: id} = passkey, new_count, expected) do
     query = from(p in Passkey, where: p.id == ^id and p.sign_count == ^expected)
 
-    case Repo.update_all(query, set: [sign_count: new_count, last_used_at: DateTime.utc_now()]) do
-      {1, _} -> :ok
-      {0, _} -> refuse_clone(passkey, new_count)
+    result =
+      Repo.BusyRetry.run(fn ->
+        {count, _} = Repo.update_all(query, set: [sign_count: new_count, last_used_at: DateTime.utc_now()])
+        {:ok, count}
+      end)
+
+    case result do
+      {:ok, 1} -> :ok
+      {:ok, 0} -> refuse_clone(passkey, new_count)
+      {:error, :db_unavailable} = err -> err
     end
   end
 

--- a/lib/grappa_web/controllers/passkey_controller.ex
+++ b/lib/grappa_web/controllers/passkey_controller.ex
@@ -221,6 +221,10 @@ defmodule GrappaWeb.PasskeyController do
   def login_verify(conn, params) do
     case WebAuthn.authenticate(params, :passwordless, client_binding(conn)) do
       {:ok, %User{passkey_mode: :passwordless} = user, _} -> mint_session(conn, user)
+      # #815 — `authenticate/3` writes the sign counter, so a saturated writer
+      # is a legitimate outcome of a VERIFIED assertion. The catch-all below is
+      # the login oracle and stays opaque; a 503 is not part of it.
+      {:error, :db_unavailable} = err -> err
       _ -> {:error, :invalid_two_factor}
     end
   end
@@ -230,6 +234,9 @@ defmodule GrappaWeb.PasskeyController do
   def second_factor_verify(conn, params) do
     case WebAuthn.authenticate(params, :second_factor, client_binding(conn)) do
       {:ok, %User{passkey_mode: :second_factor} = user, _} -> mint_session(conn, user)
+      # #815 — as `login_verify/2`. Two actions, two `case`s: fixing one and
+      # not the other leaves the second door telling the same lie.
+      {:error, :db_unavailable} = err -> err
       _ -> {:error, :invalid_two_factor}
     end
   end

--- a/test/grappa/accounts/passkey_test.exs
+++ b/test/grappa/accounts/passkey_test.exs
@@ -223,6 +223,27 @@ defmodule Grappa.Accounts.PasskeyTest do
       assert log =~ ctx.passkey.id
       assert log =~ ctx.user.id
     end
+
+    # #815 — the counter commit is the last unwrapped passkey write, so a
+    # transient SQLITE_BUSY under WAL with pool_size > 1 raised straight out of
+    # `Repo.update_all/2` and reached the caller as a 500. The reason #768 left
+    # it alone was the CAS: a write that lands and THEN reports an error would
+    # be retried, match zero rows against a counter that already moved, and be
+    # refused as a clone. That was measured and does not happen (see
+    # DESIGN_NOTES 2026-08-05), so the wrap goes in — and BOTH halves of the
+    # feared outcome are pinned here: the caller must see the DB fault, and the
+    # operator's log must NOT gain a clone alarm for a write that was never
+    # refused. A degrade routed through `refuse_clone/2` would pass the first
+    # assertion and fail the second.
+    test "a counter commit held off by a saturated writer degrades, it does not cry clone", ctx do
+      Repo.BusyRetry.inject_transient_faults(10_000)
+      {result, log} = with_log(fn -> WebAuthn.consume_sign_count(ctx.passkey, 6) end)
+      Repo.BusyRetry.inject_transient_faults(0)
+
+      assert result == {:error, :db_unavailable}
+      refute log =~ "sign counter did not advance"
+      assert Repo.get!(Passkey, ctx.passkey.id).sign_count == 5
+    end
   end
 
   test "passwordless activation persists the pre-shown recovery set only at commit" do

--- a/test/grappa/accounts/webauthn_verification_test.exs
+++ b/test/grappa/accounts/webauthn_verification_test.exs
@@ -174,6 +174,37 @@ defmodule Grappa.Accounts.WebAuthnVerificationTest do
 
       assert Repo.get!(Passkey, ctx.passkey.id).sign_count == 5
     end
+
+    # #815 — the whole defect. `authenticate/3` closes on `_ -> {:error,
+    # :invalid_passkey}`, so wrapping the counter commit in `Repo.BusyRetry`
+    # WITHOUT this would hand every caller a saturated writer relabelled as a
+    # forged credential — the exact lie #768 removed one layer up, and a worse
+    # answer than the 500 the wrap replaced, because the user believes it and
+    # goes to re-enrol a credential that was never wrong.
+    #
+    # This assertion is signed and valid: everything ahead of the write passed,
+    # and the ONLY thing that failed is the write. So `:invalid_passkey` here
+    # would be a statement about the credential that the code never tested.
+    test "a saturated writer surfaces as a DB fault, not as a bad credential", ctx do
+      params = assert_params(ctx, 1)
+
+      Repo.BusyRetry.inject_transient_faults(10_000)
+      result = WebAuthn.authenticate(params, :second_factor, @binding)
+      Repo.BusyRetry.inject_transient_faults(0)
+
+      assert result == {:error, :db_unavailable}
+      assert Repo.get!(Passkey, ctx.passkey.id).sign_count == 0
+    end
+
+    # The oracle stays shut for everything else. `:cloned_authenticator` is the
+    # one fault the wire must never confirm — surfacing the DB fault must not
+    # widen the else into a diagnostic surface for the clone rule too.
+    test "the clone refusal stays collapsed into the opaque answer", ctx do
+      assert {:ok, _, _} = WebAuthn.authenticate(assert_params(ctx, 5), :second_factor, @binding)
+
+      assert {:error, :invalid_passkey} =
+               WebAuthn.authenticate(assert_params(ctx, 3), :second_factor, @binding)
+    end
   end
 
   defp begin_registration(ctx) do

--- a/test/grappa_web/controllers/passkey_controller_test.exs
+++ b/test/grappa_web/controllers/passkey_controller_test.exs
@@ -194,8 +194,16 @@ defmodule GrappaWeb.PasskeyControllerTest do
       assert Repo.aggregate(Passkey, :count, :id) == 0
     end
 
+    # The fault is aimed PAST the assertion, and that is the whole point of the
+    # test. #815 wrapped the sign-counter commit inside `authenticate/3`, which
+    # made it the FIRST retried write this route performs — so an
+    # arm-everything fault degrades there and the request never reaches
+    # `set_mode/4` at all. The test would stay green and quietly stop proving
+    # the clause it was written for. `fire_on: 2` rides out the counter commit
+    # and fires on the mode transaction; the advanced counter is what proves it
+    # landed there, since a degrade at check 1 leaves the counter at zero.
     test "POST /me/passkeys/mode behind a saturated writer is a 503, not a refused assertion", ctx do
-      register_credential(ctx)
+      passkey = register_credential(ctx)
 
       options =
         json_response(
@@ -208,12 +216,67 @@ defmodule GrappaWeb.PasskeyControllerTest do
 
       params = assertion_params(ctx, options, 1)
 
-      BusyRetry.inject_transient_faults(10_000)
+      # Bound to a variable, never `self()` inside the closure: `on_exit` runs
+      # in its OWN process, so the closure would disarm the wrong pid and leave
+      # this one armed for whoever inherits it.
+      test_pid = self()
+      BusyRetry.arm_faults(test_pid, 10_000, fire_on: 2)
+      on_exit(fn -> BusyRetry.disarm_faults(test_pid) end)
       conn = post(authed(ctx.session), "/me/passkeys/mode", params)
-      BusyRetry.inject_transient_faults(0)
+      BusyRetry.disarm_faults(test_pid)
 
       assert json_response(conn, 503) == %{"error" => "db_unavailable"}
       assert Repo.get!(User, ctx.user.id).passkey_mode == :disabled
+      assert Repo.get!(Passkey, passkey.id).sign_count == 1
+    end
+
+    # #815 — the assertion routes reach a write of their own: the sign-counter
+    # commit inside `authenticate/3`. Wrapped, it degrades, and both actions
+    # closed on `_ -> {:error, :invalid_two_factor}` — a 401 telling the holder
+    # of a perfectly good passkey that their authenticator was rejected. These
+    # two pin the honest answer at the wire, and pin it SEPARATELY because
+    # `login_verify/2` and `second_factor_verify/2` are two `case`s: fixing one
+    # leaves the other lying.
+    test "POST /auth/passkeys/verify behind a saturated writer is a 503, not a refused assertion", ctx do
+      passkey = register_credential(ctx)
+      arm_mode(ctx, :passwordless)
+
+      options =
+        build_conn()
+        |> post("/auth/passkeys/options", %{"identifier" => ctx.user.name})
+        |> json_response(200)
+
+      params = assertion_params(ctx, options, 1)
+
+      BusyRetry.inject_transient_faults(10_000)
+      conn = post(build_conn(), "/auth/passkeys/verify", params)
+      BusyRetry.inject_transient_faults(0)
+
+      assert json_response(conn, 503) == %{"error" => "db_unavailable"}
+      assert Repo.get!(Passkey, passkey.id).sign_count == 0
+    end
+
+    test "POST /auth/passkeys/second-factor behind a saturated writer is a 503, not a refused assertion", ctx do
+      passkey = register_credential(ctx)
+      arm_mode(ctx, :second_factor)
+
+      {:ok, options} =
+        WebAuthn.begin_authentication(
+          Repo.get!(User, ctx.user.id),
+          :second_factor,
+          %{ip: "127.0.0.1", client_id: nil},
+          @ceremony_origin,
+          %{}
+        )
+
+      params = assertion_params(ctx, stringify(options), 1)
+
+      BusyRetry.inject_transient_faults(10_000)
+      conn = post(build_conn(), "/auth/passkeys/second-factor", params)
+      BusyRetry.inject_transient_faults(0)
+
+      assert json_response(conn, 503) == %{"error" => "db_unavailable"}
+      assert Repo.get!(Passkey, passkey.id).sign_count == 0
     end
 
     defp authed(session),


### PR DESCRIPTION
Builds on the measurement posted to #815, which answered the question that issue was blocked on: **no**, Exqlite cannot report an error for a write that has already committed on this path (142 forced mid-flight connection kills, 0 occurrences). The issue's own text then applies verbatim — *"If it cannot — the retry can never observe a committed-then-failed attempt, and a plain wrap is safe."*

## The two halves

**(a) The wrap.** `commit_counter/3` — the passkey sign-counter compare-and-set, and the last passkey write still raising a 500 on transient SQLite contention — now rides out contention through `Repo.BusyRetry`, like the three writes #768 wrapped. `refuse_clone/2` stays on the `{:ok, 0}` branch only: a degrade is not a refusal, so the wrap structurally cannot produce the false clone alarm it was accused of manufacturing.

**(b) The caller, which is the actual defect.** `authenticate/3` closed on `_ -> {:error, :invalid_passkey}`. Shipping (a) alone would have relabelled a saturated writer as a **forged credential** — the exact lie #768 removed from `set_mode/2` and `register/2`, reintroduced one layer down, and a worse answer than the 500 it replaces, because the user believes it and goes to re-enrol a credential that was never wrong. The fault now surfaces distinctly, at three doors: `authenticate/3`, and the two wire actions `login_verify/2` and `second_factor_verify/2` (separate `case`s — fixing one leaves the other lying).

**The oracle does not widen.** One atom, not the else. `:cloned_authenticator` stays collapsed, because the wire must never confirm to an attacker that their clone was spotted. A 503 here is only reachable by someone who already produced a valid assertion for a credential we hold, so it discloses nothing they did not supply.

## Tests, and the red each one was read at

TDD, and the red was read before every green — the first one was **not** what I predicted, which changed the plan:

- The fault seam lives *inside* `BusyRetry.run/1`, so on an unwrapped write the injected faults are inert and the ceremony simply succeeds. So (a)'s red is "there is no retry at all", not a raise.
- (b)'s red only exists once (a) is in. So (a) was implemented **alone** and the suite re-run: `authenticate/3` returned `{:error, :invalid_passkey}` while the log line read `db write unavailable: SQLite pool saturated`. That is the defect, captured.
- The two wire tests were then **mutation-measured**: with only the two controller clauses removed, both routes answer `401 invalid_two_factor` beside the same saturation warning. Each test pins its own action.

New coverage:

| test | asserts |
|---|---|
| `consume_sign_count/2` degrade | caller gets `:db_unavailable`, counter unmoved, **and no clone alarm in the log** — a degrade routed through `refuse_clone/2` passes the first and fails the last |
| `authenticate/3` under saturation (real signed ceremony) | `{:error, :db_unavailable}`, **not** `:invalid_passkey` |
| clone refusal still collapsed | `:cloned_authenticator` stays `:invalid_passkey` at the boundary |
| `POST /auth/passkeys/verify` / `/second-factor` | 503 `db_unavailable`, not 401 |

**One existing test is re-aimed, not left alone.** (a) makes the counter commit the FIRST retried write the mode-change route performs, so #831's arm-everything fault now degrades there and never reaches `set_mode/4` — the test would stay green while quietly ceasing to prove the clause it was written for. It now arms `fire_on: 2`, and asserts the counter **advanced to 1**: that is the evidence the degrade landed on the mode transaction rather than ahead of it. The `fire_on` value was determined empirically, as that seam's contract requires.

## Declining #815's own sketch, with reasons

The issue proposed a retry-safe CAS — treat *"0 rows matched **and** the stored counter already equals the value we tried to write"* as success — and judged it to "cost nothing". It does not. Two assertions racing on one credential both read `expected` and both present the same `new_count`; the loser finds exactly that condition and would be **accepted**. That is precisely the captured-assertion-replayed-alongside-the-genuine-one the CAS exists to refuse. It trades a measured-nonexistent hazard for a real hole in clone detection, so it is declined and the reasoning is recorded rather than left to be rediscovered.

## Limits, carried into the decision log

The measurement's declared limits are load-bearing and are in the DESIGN_NOTES entry, not just in a comment:

- The commit-survives-the-kill half rests on `holder_apply/4` + `augment_disconnect/1` in **db_connection 2.10.2**, the rollback half on `Sqlite3.cancel/1` in **exqlite 0.38.0** — internals, **not** documented contracts.
- **Trigger to re-measure:** a bump of either in `mix.lock`. The observable to re-run to zero is "caller raised *and* the row moved", read back through a *second* pooled connection under the prod pool posture — never the `pool_size: 1` Sandbox, which cannot produce real contention.
- Measured on the Linux dev container, **not** the FreeBSD jail (the logic is platform-independent; the timing is not).
- Multi-statement transaction boundaries were not probed. That is #768's `run_mode_transaction/4`, not this write, and it is safe for a different reason: replaying it re-applies the same mode, recovery set and revocations, so unlike a CAS it is idempotent.
- Blast radius if an internal does change: one spurious clone warning and one refused login on an already-saturated DB. Not an auth bypass.

## Also

The item owed from #768 — its two `:db_unavailable` clauses becoming reachable once the #742 ceremony fixture landed — is **already covered on main** by #831/#833, so nothing was added for it here beyond keeping the mode test honest (above).

## Gates

`scripts/check.sh` exit **0**: `8 doctests, 50 properties, 5126 tests, 0 failures`; Dialyzer `done (passed successfully)`; Sobelow `Total errors: 0`; doctor passed (100% spec coverage); bats green.