### PR TITLE
shottino(#757): refuse an over-long query instead of cutting it, and strip the fragment on both branches

### DIFF
--- a/frontends/shottino/call/whip.c
+++ b/frontends/shottino/call/whip.c
@@ -77,11 +77,16 @@ bool whip_url_parse(const char *url, struct whip_url *out) {
      * malformed, so this is normalised here rather than at every use. */
     if (*p != '/') {
         if (*p && *p != '?' && *p != '#') return false;
-        snprintf(out->path, sizeof(out->path), "/%s", *p == '?' ? p : "");
-        return true;
+        /* Refused rather than cut to length, like the branch below: a
+         * truncated query is a DIFFERENT request — another session id,
+         * a token that is no longer the token — and it would go out
+         * looking like the one that was asked for. */
+        if (strlen(p) + 2 > sizeof(out->path)) return false;
+        snprintf(out->path, sizeof(out->path), "/%s", p);
+    } else {
+        if (strlen(p) + 1 > sizeof(out->path)) return false;
+        snprintf(out->path, sizeof(out->path), "%s", p);
     }
-    if (strlen(p) + 1 > sizeof(out->path)) return false;
-    snprintf(out->path, sizeof(out->path), "%s", p);
     /* A fragment is a client-side concept and is never sent. */
     char *hash = strchr(out->path, '#');
     if (hash) *hash = 0;

--- a/frontends/shottino/tests/test_whip.c
+++ b/frontends/shottino/tests/test_whip.c
@@ -44,9 +44,41 @@ TEST(a_url_is_split_or_refused) {
     CHECK_STR(u.host, "2001:db8::1");
     CHECK_LONG(u.port, 9000);
 
-    /* A fragment is a client-side concept and is never sent. */
+    /* A fragment is a client-side concept and is never sent. Asserted
+     * on both branches: a URL with a path, and one with only a query. */
     CHECK(whip_url_parse("https://sfu.example/whip#frag", &u));
     CHECK_STR(u.path, "/whip");
+
+    CHECK(whip_url_parse("http://sfu.example?a=1#frag", &u));
+    CHECK_STR(u.path, "/?a=1");
+
+    CHECK(whip_url_parse("http://sfu.example#frag", &u));
+    CHECK_STR(u.path, "/");
+
+    CHECK(whip_url_parse("http://sfu.example?a=1", &u));
+    CHECK_STR(u.path, "/?a=1");
+
+    /* A query that does not fit is REFUSED, never cut to length: a
+     * truncated query is a DIFFERENT request — a different session id,
+     * a token that is now the wrong token — and it would go out looking
+     * like the one that was asked for. */
+    char query[WHIP_MAX_URL + 64];
+    memset(query, 'a', sizeof(query) - 1);
+    query[sizeof(query) - 1] = 0;
+    memcpy(query, "http://sfu.example?", 19);
+    CHECK(!whip_url_parse(query, &u));
+
+    /* The largest query that DOES fit still parses, so the refusal
+     * above is a bound and not a blanket. `path` holds the leading '/'
+     * plus the query plus the NUL. */
+    char fitting[WHIP_MAX_URL + 64];
+    memset(fitting, 'a', sizeof(fitting) - 1);
+    memcpy(fitting, "http://sfu.example?", 19);
+    fitting[19 + (WHIP_MAX_URL - 2)] = 0; /* query is '?' + WHIP_MAX_URL-2 bytes... */
+    CHECK(!whip_url_parse(fitting, &u));  /* ...one too many */
+    fitting[19 + (WHIP_MAX_URL - 3)] = 0;
+    CHECK(whip_url_parse(fitting, &u));
+    CHECK_LONG((long)strlen(u.path), WHIP_MAX_URL - 1);
 
     /* Every other scheme is refused rather than guessed: this URL
      * arrived in a message somebody else wrote. */


### PR DESCRIPTION
`whip_url_parse` splits into a branch for a URL that carries a path and
one for a URL that carries only a query, and the two disagreed twice:

- the path branch length-checked and returned `false`; the query branch
  handed the bytes to `snprintf` and let it cut at `WHIP_MAX_URL`
- the path branch stripped at `#`; the query branch returned *before*
  reaching the strip, so `http://h?a#frag` sent the fragment upstream —
  contradicting the comment three lines below the write

Verified live on current `main` before touching anything. #755 changed
this file but not this function: the room-segment encoder and the
`whip_request` control-character gate sit elsewhere, so both halves of
this finding were still exactly as reported.

## Why refuse beats truncate

A cut query is not a shorter version of the request — it is a
**different** request. Another session id, or a token that is no longer
the token, sent out looking like the one that was asked for, and
`whip_resolve` then resolves a relative `Location` against a base that
never existed. That is the shape of #756: a value the parser silently
invents while reporting success. Refusing hands the caller the one true
statement available — this URL does not fit — instead of a plausible
wrong one.

The branches now differ only in whether they prepend the `/`, and the
single fragment strip runs after both, so neither can drift from the
other again by being edited alone.

## Tests

Added to `a_url_is_split_or_refused`, asserting the resulting path
**byte for byte** rather than the bool — a bool-only test survives
deleting the strip, since the parse still succeeds either way:

- `http://h?a=1#frag` → `/?a=1`, `http://h#frag` → `/`, `http://h?a=1` → `/?a=1`
- a query past `WHIP_MAX_URL` is refused
- the bound is pinned from both sides: the largest query that fits still
  parses (path length `WHIP_MAX_URL - 1`), one byte more is refused, so
  an off-by-one cannot pass itself off as a refusal

Measured, not assumed — each mutation kills checks:

| mutation | checks killed |
|---|---|
| drop the query-branch length gate | 2 |
| drop the fragment strip | 3 |
| off-by-one (`+2` → `+1`) | 1 |
| restore the pre-fix early return verbatim | 3 |

## Class sweep

No other branch pair in this parser disagrees the same way.
`whip_url_format`, both `whip_resolve` branches, `header_value` and the
`head` buffer in `whip_request` all refuse on overflow; `hostport` is
sized so the parser's own bounds make truncation unreachable; the
`media.c` SDP builders all return `w > 0 && w < out_sz`. The one
remaining truncation, `split_source`, is fed by a local `/set` value,
not by a stranger, and both of its callers treat it identically — no
disagreement to reconcile.

## Gate

`make check` locally: 15 of 16 suites, 11004 checks green. `test_keys`
needs `<pty.h>` and cannot build on darwin; CI runs all 16 on Ubuntu.