### PR TITLE
shottino: compile call/main.c in CI (#754)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,11 @@ jobs:
   # first surface in the release workflow, on a tag, when the packages
   # tried to build a client that no longer compiled.
   #
+  # What it covers, exactly: the client is built and its suites run, and
+  # the media helper's sources are COMPILED but never linked and never
+  # packaged — the shipped .deb/AUR carry the client alone and fall back
+  # to a browser for calls, so nothing here proves a helper binary works.
+  #
   # Deliberately its own job rather than a step on `test`: it shares no
   # toolchain with the BEAM jobs (no Elixir, no deps cache), it runs in
   # well under a minute, and a failure should read as "shottino broke"
@@ -177,6 +182,20 @@ jobs:
         run: |
           make -C frontends/shottino clean
           make -C frontends/shottino \
+            CFLAGS="-std=c11 -Wall -Wextra -Wpedantic -Werror -O2 $(sed -n 's/^CFLAGS_DEPS := //p' config.mk)"
+
+      # The media helper is a separate opt-in target (`make call`) because
+      # linking it wants cmake, a C++ toolchain and a multi-minute
+      # libdatachannel build. So `make` above never touched call/main.c —
+      # 1214 lines, the helper's main loop and the whole libdatachannel
+      # integration — and no other job did either (#754). Compiling it is
+      # what that guarantee costs here: the vendored headers arrived with
+      # the recursive checkout, nothing has to be built, and the flags are
+      # the ones above so the helper cannot warn where the client may not.
+      # The link stays unproven on purpose — see the Makefile comment.
+      - name: Compile the media helper (warnings are errors)
+        run: |
+          make -C frontends/shottino call-compile \
             CFLAGS="-std=c11 -Wall -Wextra -Wpedantic -Werror -O2 $(sed -n 's/^CFLAGS_DEPS := //p' config.mk)"
 
       # Suites build with ASan+UBSan (see the Makefile): this is C parsing

--- a/frontends/shottino/Makefile
+++ b/frontends/shottino/Makefile
@@ -182,7 +182,7 @@ CALL_BIN := shottino-call
 CALL_SRC := call/main.c call/whip.c call/media.c http.c
 CALL_CFLAGS := $(CPPFLAGS) $(CFLAGS) -I$(LDC_DIR)/include
 
-.PHONY: call
+.PHONY: call call-compile
 call: $(CALL_BIN)
 
 # A checked-out submodule is a precondition with a readable failure. The
@@ -192,6 +192,23 @@ $(LDC_DIR)/CMakeLists.txt:
 	@echo "  git submodule update --init --recursive \\" >&2
 	@echo "      frontends/shottino/vendor/libdatachannel" >&2
 	@exit 1
+
+# The share of `call` that a gate can afford (#754). Linking the helper
+# costs cmake, a C++ toolchain and minutes of libdatachannel build, so no
+# CI or packaging job runs `call` — which left call/main.c, the helper's
+# whole main loop and the entire libdatachannel integration, compiled by
+# nothing in the tree. Compiling it costs a second: the vendored headers
+# are already on disk beside the sources, no archive has to exist, and a
+# warning that fails the client build fails here the same way.
+#
+# What it does NOT cover, deliberately: no link runs, so the C++ link
+# driver, -static-libstdc++ and the four archives are still only proven
+# by someone typing `make call`.
+call-compile: $(LDC_DIR)/CMakeLists.txt
+	@for src in $(CALL_SRC); do \
+		echo "  CC (compile-only) $$src"; \
+		$(CC) $(CALL_CFLAGS) -c -o /dev/null "$$src" || exit 1; \
+	done
 
 # USE_GNUTLS=OFF takes the OpenSSL already linked; USE_NICE=OFF takes the
 # bundled libjuice rather than adding a system libnice; NO_WEBSOCKET


### PR DESCRIPTION
Issue #754: `call/main.c` — 1214 lines, the helper's main loop and the whole
libdatachannel integration — is compiled by no CI, release or packaging job.

Re-verified on current `main` before touching anything: `git grep -n "make
call\|shottino-call\|libdatachannel" -- .github/ infra/` still returns nothing,
`all: $(BIN)` still excludes `$(CALL_BIN)`, and `test_whip`/`test_callmedia`
still link `whip.c`/`media.c` deliberately without libdatachannel. So
`call/main.c` is the one helper source no gate touches. Still real.

## Which option, and why

The issue offers a `-fsyntax-only` check or a real `make call` with cmake and a
cached libdatachannel build, and is honest that they are not equivalent. This is
neither of the two exactly: it is a real **compile** (`-c -o /dev/null`) of every
helper translation unit, with the same `-Werror` flag set as the client build
step above it.

- `-fsyntax-only` was the cheap option, and it is cheap partly by dropping
  diagnostics that need codegen. A compile costs the same second and does not.
- The full `make call` is what the job's promise implies, and it costs cmake,
  g++, and a multi-minute libdatachannel + libjuice + libsrtp + usrsctp build to
  cache — on a job that currently finishes in **2 minutes** end to end. Because
  this edits `ci.yml`, merging it re-runs every open PR, so the cost is paid many
  times over immediately.
- The compile needs **nothing new**: the job already does `submodules:
  recursive`, and the run log for `main` shows `libdatachannel` and its five
  deps being checked out today. The headers are on disk before the first step.

What it catches is exactly the failure the issue names: the file stops
compiling, or grows a warning the rest of the tree fails on. What it does not
catch: the C++ link driver, `-static-libstdc++`, and the four archives. That
gap is stated in both comments rather than implied away.

## Comment and reality now agree

The job advertised a `-Werror` guarantee that stopped short of the largest file
in the feature. Two comments changed so the advertisement matches:

- the job header now says what it covers, exactly — client built and tested,
  helper **compiled but never linked and never packaged**;
- the new step and the Makefile target both name the link as the deliberate
  hole.

If a later change adds the real `make call` job, both comments are the thing to
update; they are written to be falsifiable, not reassuring.

## I saw the gate fail

`make -C frontends/shottino call-compile` with the CI flags, on the untouched
tree: `rc=0`. Then two mutations appended to `call/main.c`, one at a time:

| mutation | result |
|---|---|
| `rtcNoSuchFunction(1);` — a libdatachannel symbol that does not exist | `error: call to undeclared function` → `make: *** [call-compile] Error 1`, `rc=2` |
| `static int f(int a, int b) { (void)a; return 0; }` — a mere warning | `error: unused parameter 'b' [-Werror,-Wunused-parameter]` → `rc=2` |

Restored, `rc=0`, tree clean. The second one matters more than the first: it
proves the `-Werror` half of the promise, not just the compiles-at-all half.

Verified under **both** compilers, since the local one is not the CI one: clang
on darwin (with the usual `_DARWIN_C_SOURCE` / `SOCK_CLOEXEC` shims), and gcc
14.4 in a Linux container running the byte-exact CI command, including the
`sed`-extracted `CFLAGS_DEPS`. Green on both. `ci.yml` parses (pyyaml) and the
step lands between Build and Tests.

One thing found while measuring: the shipped Makefile's own `WARNINGS` carries
`-Wformat=2`, but the CI Build step's `CFLAGS` override drops it — and under
clang the helper's varargs forwarders do trip `-Wformat-nonliteral`. This gate
therefore uses the Build step's flag set verbatim rather than inventing a
stricter one in a CI-plumbing change. Worth a separate look at whether CI should
carry `-Wformat=2`; not this PR.

## The packaging second-order point

The issue reads the packaging gap as deliberate, and I agree, with one caveat
worth writing down. `nfpm.yaml` builds one binary whose runtime deps the bundled
ERTS already pulls in; asking the .deb and AUR builders for cmake and a C++
toolchain to produce a second binary that most users will never invoke is a real
cost for a feature that degrades to "open a browser". The opt-in is the right
default and `install` already announces the fallback in plain words.

The caveat is that the fallback is the *only* path anything we ship has ever
taken, so `call_helper_path`'s discovery, the `--protocol` handshake and the
version-refusal branch are exercised by no shipped artifact. That is a testing
gap, not a packaging one, and it is not fixed by building the helper into a
package. I do not think it is worth a finding on its own yet; if the native call
path is meant to be a supported feature rather than a build-it-yourself one,
that is the conversation to have, and it is a bigger one than #754.

Scope note: packaging untouched, no `.deb`/AUR change, no new job.