### PR TITLE
accounts(#636): let a revoke degrade instead of crashing the request

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -29112,3 +29112,52 @@ arrive to a freed buffer", and `main` ends with a long comment about the model
 thread that was neither stopped nor joined while shutdown freed the mutex and
 SSL context underneath it. The helper's own teardown was the one place that had
 drifted from the rule the rest of the tree follows.
+## 2026-08-05 — #636: a revoke either owns a retry budget or its caller does
+
+`Accounts.revoke_session/1` was a bare `Repo.update_all` with no busy-retry,
+and every caller bound it with `:ok = ...`. Under SQLite write contention the
+UPDATE raises `SQLITE_BUSY`, the match blows up, and the request dies with a
+500 — at precisely the peak-write moments (a flood, a reconnect burst, a
+migration) when a revoke matters most. #630 had already fixed its own path by
+adding `revoke_session_resilient/1` beside it, which left two spellings of the
+same verb where one is a trap.
+
+**The pair collapsed rather than being propagated.** `revoke_session/1` now IS
+the resilient one and `revoke_session_resilient/1` is gone. The suffix was
+never a distinction worth keeping: `revoke_sessions_for_visitor/1` (#523/#518)
+has been busy-resilient with no suffix since it shipped, so the codebase
+already said resilient-is-the-default. Leaving a second, fail-hard spelling in
+place is how the next caller picks the wrong one.
+
+**The class is not "wrap every revoke".** Half the family — the two `reset_*`
+transactions, TOTP enrolment/disable, the passkey mode change — calls the
+revoke from INSIDE a `Repo.BusyRetry.run(fn -> Repo.transaction(…) end)`. There
+a nested retry is actively wrong: it would sleep holding the open
+transaction's connection, extending the contention it is waiting on, and would
+convert a raise the transaction needs into a return value. The correct unit of
+retry is the whole transaction, and the enclosing engine already retries it.
+So the rule is per-ROLE, not per-function: **every revoke either owns a
+`BusyRetry` budget and returns `{:error, :db_unavailable}`, or it raises and
+says so in its name.** The in-transaction members are now
+`revoke_other_sessions_for_user!/2` and the private
+`revoke_sessions_for_user!/1`; the bang is the contract, and the family
+contract is written out on `revoke_session/1`.
+
+**What a degraded revoke does is a per-caller judgement, and it splits.** The
+`Plugs.Authn` co-terminus cleanup logs and CONTINUES: the plug has already
+decided to reject, denial is the safe direction, and the visitor is still
+expired so the next request re-attempts the revoke. `DELETE /auth/logout` and
+`PUT /admin/users/:id/password` do the opposite and surface a typed 503 —
+there the success answer is a claim (you are logged out / the compromised
+account is evicted) that the degrade did not make true. This is the same axis
+as #815 but resolved differently at each door: the question is never "crash or
+swallow", it is "does the caller's success response become a lie". The one
+thing none of them may do is what they all did before, which is raise.
+
+**The asymmetry is deliberate and #590 is the precedent.** `purge_if_anon/1`
+absorbs a sustained busy to `:ok` + a log because the reaper will collect the
+row anyway — best-effort cleanup with no client waiting on it. That absorption
+lives in the CALLER's judgement, not in the context function: `revoke_session/1`
+always returns the typed error, and the plug decides to continue. Absorbing
+inside the context would have taken the choice away from logout, which needs
+it.

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -468,34 +468,46 @@ defmodule Grappa.Accounts do
 
   @doc """
   Marks the session row's `revoked_at` to now. Idempotent and safe to
-  call with an unknown id — both paths return `:ok` (no-op for the
-  unknown id) so callers don't need to branch on existence. The
-  affected-row count is logged so a typo'd revoke (zero matches)
-  remains greppable in operator logs without changing the API
-  contract.
-  """
-  @spec revoke_session(Ecto.UUID.t()) :: :ok
-  def revoke_session(id) when is_binary(id) do
-    {affected, _} = Repo.update_all(session_by_id_query(id), set: [revoked_at: DateTime.utc_now()])
-    Logger.info("session revoked", session_ref: session_handle(id), affected: affected)
-    :ok
-  end
+  call with an unknown id — both land on `:ok` (no-op for the unknown id)
+  so callers don't need to branch on existence. The affected-row count is
+  logged so a typo'd revoke (zero matches) remains greppable in operator
+  logs without changing the API contract.
 
-  @doc """
-  As `revoke_session/1`, but rides out a transient SQLITE_BUSY via
-  `Repo.BusyRetry` and degrades to `{:error, :db_unavailable}` on sustained
-  saturation instead of the MatchError-crash a bare `:ok = <update_all>`
-  would raise. The #630 web-session SEVER path
-  (`GrappaWeb.RequestBudget.sever/3`) calls this: it fires at PEAK DB write
-  contention (a flood IS the load) and, because the flood ladder severs
-  exactly ONCE at the crossing, a crash here would both skip the socket
-  close AND permanently defeat enforcement for the window. Sibling of
-  `revoke_sessions_for_visitor/1` (#523/#518), whose login door had the same
-  "must degrade, not crash" need. A single idempotent UPDATE, so a retried
-  statement is safe.
+  Rides out a transient SQLITE_BUSY via `Repo.BusyRetry` and degrades to
+  `{:error, :db_unavailable}` on sustained saturation instead of the
+  MatchError-crash a bare `:ok = <update_all>` raises. Every door that
+  revokes a single session hits the DB at exactly the wrong moment: the
+  #630 SEVER path (`GrappaWeb.RequestBudget.sever/3`) fires at PEAK write
+  contention (a flood IS the load) and severs exactly ONCE at the
+  crossing, so a crash there both skips the socket close AND permanently
+  defeats enforcement for the window; `DELETE /auth/logout` and the
+  `Plugs.Authn` co-terminus visitor cleanup are the same shape. A single
+  idempotent UPDATE, so a retried statement is safe.
+
+  ## The family contract (#636)
+
+  Every revoke in this module is in exactly one of two roles, and the
+  spelling says which:
+
+    * **caller-facing** — `revoke_session/1`, `revoke_sessions_for_user/1`,
+      `revoke_sessions_for_visitor/1`. Reached from a plug, a controller,
+      or an operator verb with no enclosing retry, so each owns its own
+      `Repo.BusyRetry` budget and returns `{:error, :db_unavailable}`.
+    * **in-transaction** — the `!` variants
+      (`revoke_other_sessions_for_user!/2` and the private
+      `revoke_sessions_for_user!/1`). Reached only from inside a
+      `Repo.BusyRetry.run(fn -> Repo.transaction(…) end)`, where the
+      enclosing engine retries the WHOLE transaction. They deliberately do
+      NOT retry: a nested retry would sleep while holding the open
+      transaction's connection, extending the very contention it waits on,
+      and would convert a raise the transaction needs into a return value.
+      The bang is the contract — it raises, and its caller owns the budget.
+
+  #636 collapsed the former `revoke_session_resilient/1` into this
+  function. There is no fail-hard spelling left to copy by mistake.
   """
-  @spec revoke_session_resilient(Ecto.UUID.t()) :: :ok | {:error, :db_unavailable}
-  def revoke_session_resilient(id) when is_binary(id) do
+  @spec revoke_session(Ecto.UUID.t()) :: :ok | {:error, :db_unavailable}
+  def revoke_session(id) when is_binary(id) do
     case Repo.BusyRetry.run(fn ->
            {:ok, Repo.update_all(session_by_id_query(id), set: [revoked_at: DateTime.utc_now()])}
          end) do
@@ -563,9 +575,26 @@ defmodule Grappa.Accounts do
   zero. The affected count rides the audit log so a user with zero prior
   sessions stays distinguishable from one whose sessions were all already
   revoked. Sibling of `revoke_sessions_for_visitor/1`.
+
+  Caller-facing, so it owns its `Repo.BusyRetry` budget and degrades to
+  `{:error, :db_unavailable}` — see the family contract on
+  `revoke_session/1`. The in-transaction users of the same UPDATE call
+  `revoke_sessions_for_user!/1` instead.
   """
-  @spec revoke_sessions_for_user(User.t()) :: :ok
-  def revoke_sessions_for_user(%User{id: user_id}) do
+  @spec revoke_sessions_for_user(User.t()) :: :ok | {:error, :db_unavailable}
+  def revoke_sessions_for_user(%User{} = user) do
+    case Repo.BusyRetry.run(fn -> {:ok, revoke_sessions_for_user!(user)} end) do
+      {:ok, :ok} -> :ok
+      {:error, :db_unavailable} = err -> err
+    end
+  end
+
+  # In-transaction twin of `revoke_sessions_for_user/1`: no retry of its
+  # own, RAISES on SQLITE_BUSY so the raise aborts the enclosing
+  # transaction and reaches the outer `Repo.BusyRetry`, which re-runs the
+  # whole unit. See the family contract on `revoke_session/1`.
+  @spec revoke_sessions_for_user!(User.t()) :: :ok
+  defp revoke_sessions_for_user!(%User{id: user_id}) do
     query = from(s in Session, where: s.user_id == ^user_id and is_nil(s.revoked_at))
 
     {affected, _} = Repo.update_all(query, set: [revoked_at: DateTime.utc_now()])
@@ -579,9 +608,19 @@ defmodule Grappa.Accounts do
     :ok
   end
 
-  @doc "Revokes every live bearer for `user` except the current session."
-  @spec revoke_other_sessions_for_user(User.t(), Ecto.UUID.t()) :: :ok
-  def revoke_other_sessions_for_user(%User{id: user_id}, current_session_id)
+  @doc """
+  Revokes every live bearer for `user` except the current session.
+
+  In-transaction only — every caller (TOTP enrolment/disable, the passkey
+  mode transaction) already runs inside a
+  `Repo.BusyRetry.run(fn -> Repo.transaction(…) end)`, so this RAISES on
+  SQLITE_BUSY rather than retrying: the raise is what aborts the
+  transaction and hands the retry to the enclosing engine. See the family
+  contract on `revoke_session/1`. A caller with no such enclosure wants a
+  caller-facing revoke, not this one.
+  """
+  @spec revoke_other_sessions_for_user!(User.t(), Ecto.UUID.t()) :: :ok
+  def revoke_other_sessions_for_user!(%User{id: user_id}, current_session_id)
       when is_binary(current_session_id) do
     query =
       from(s in Session,
@@ -707,7 +746,7 @@ defmodule Grappa.Accounts do
       )
 
     :ok = RecoveryCodes.drop_if_orphaned(user.id)
-    :ok = revoke_sessions_for_user(user)
+    :ok = revoke_sessions_for_user!(user)
     Repo.get!(User, user.id)
   end
 
@@ -726,14 +765,14 @@ defmodule Grappa.Accounts do
     Passkey |> where([p], p.user_id == ^user.id) |> Repo.delete_all()
     user |> User.passkey_mode_changeset(%{passkey_mode: :disabled}) |> Repo.update!()
     :ok = RecoveryCodes.drop_if_orphaned(user.id)
-    :ok = revoke_sessions_for_user(user)
+    :ok = revoke_sessions_for_user!(user)
     Repo.get!(User, user.id)
   end
 
   defp confirm_totp_transaction(user, current_session_id, secret, code, unix_seconds) do
     case TOTP.confirm_enrollment(user, secret, code, unix_seconds) do
       {:ok, recovery_codes} ->
-        :ok = revoke_other_sessions_for_user(user, current_session_id)
+        :ok = revoke_other_sessions_for_user!(user, current_session_id)
         recovery_codes
 
       {:error, reason} ->
@@ -764,7 +803,7 @@ defmodule Grappa.Accounts do
 
     recovery_query = from(r in TOTPRecoveryCode, where: r.user_id == ^user.id)
     Repo.delete_all(recovery_query)
-    :ok = revoke_other_sessions_for_user(user, current_session_id)
+    :ok = revoke_other_sessions_for_user!(user, current_session_id)
     Repo.get!(User, user.id)
   end
 

--- a/lib/grappa/accounts/webauthn.ex
+++ b/lib/grappa/accounts/webauthn.ex
@@ -393,7 +393,7 @@ defmodule Grappa.Accounts.WebAuthn do
     # TOTP user's codes and left the second_factor exits unconsidered.
     :ok = RecoveryCodes.drop_if_orphaned(user.id)
 
-    :ok = Grappa.Accounts.revoke_other_sessions_for_user(user, current_session_id)
+    :ok = Grappa.Accounts.revoke_other_sessions_for_user!(user, current_session_id)
     mode
   end
 end

--- a/lib/grappa/networks/credentials.ex
+++ b/lib/grappa/networks/credentials.ex
@@ -1009,7 +1009,7 @@ defmodule Grappa.Networks.Credentials do
   /connect), never the `:connected`-with-no-session wedge. A NON-transient
   fault (syntax / corruption) still re-raises — `Repo.BusyRetry`'s contract,
   CLAUDE.md "no silent-swallow". Sibling of
-  `Accounts.revoke_session_resilient/1` (#630), which had the same "must
+  `Accounts.revoke_session/1` (#630, #636), which had the same "must
   degrade, not crash under peak write load" need. The delete is idempotent, so
   a retried statement is safe.
   """

--- a/lib/grappa_web/controllers/admin/users_controller.ex
+++ b/lib/grappa_web/controllers/admin/users_controller.ex
@@ -132,14 +132,24 @@ defmodule GrappaWeb.Admin.UsersController do
   forced reset. Only the TARGET's sessions are revoked; an admin
   rotating another account's password keeps their own session (an admin
   self-rotating is forced to re-login, the secure default).
+
+  #636: the revoke IS the eviction, so it may not degrade quietly. Under a
+  saturated DB `Accounts.revoke_sessions_for_user/1` returns
+  `{:error, :db_unavailable}` and this action surfaces the typed 503 —
+  answering 200 would tell the operator the compromised account was
+  evicted while every attacker bearer is still live. The rotation itself
+  has already committed; the operator retries and the second pass is
+  idempotent. (Before #636 the same saturation raised a MatchError 500 —
+  same half-applied state, indistinguishable from a real bug.)
   """
   @spec update_password(Plug.Conn.t(), map()) ::
-          Plug.Conn.t() | {:error, :not_found | :bad_request | Ecto.Changeset.t()}
+          Plug.Conn.t()
+          | {:error, :not_found | :bad_request | :db_unavailable | Ecto.Changeset.t()}
   def update_password(conn, %{"id" => id} = params) when is_binary(id) do
     with {:ok, attrs} <- password_attrs(params),
          %Grappa.Accounts.User{} = user <- Accounts.get_user(id),
-         {:ok, updated} <- Accounts.update_password(user, attrs) do
-      :ok = Accounts.revoke_sessions_for_user(updated)
+         {:ok, updated} <- Accounts.update_password(user, attrs),
+         :ok <- Accounts.revoke_sessions_for_user(updated) do
       :ok = UserSocket.disconnect_subject({:user, updated})
       :ok = emit_user_password_changed(updated, conn)
       counts = LiveIntrospection.count_sessions_by_user()

--- a/lib/grappa_web/controllers/auth_controller.ex
+++ b/lib/grappa_web/controllers/auth_controller.ex
@@ -252,14 +252,30 @@ defmodule GrappaWeb.AuthController do
   `c:Phoenix.Endpoint.broadcast/3` (PubSub server unreachable) is logged
   and swallowed since the session row is already revoked, so the WS
   will be rejected on its next message anyway.
+
+  #636: the revoke is the one step here that may not be degraded quietly.
+  A 204 is a promise that the bearer is dead; answering it while the
+  revoke never landed would leave the browser believing it is logged out
+  with a token that still authenticates. So a `{:error, :db_unavailable}`
+  from `Accounts.revoke_session/1` propagates to `FallbackController` as a
+  typed 503 + `retry-after` and the client retries. (Before #636 the same
+  saturation was a MatchError 500 — same half-applied state, no way for
+  the client to tell it apart from a real bug.) The anon teardown ordering
+  above is NOT flipped to revoke-first to shrink that window: draining the
+  `Session.Server` before the row goes is what keeps an in-flight
+  scrollback persist off the `messages.visitor_id` FK, and the surviving
+  bearer self-heals — its next request finds the visitor purged and takes
+  the `Plugs.Authn` cleanup branch.
   """
-  @spec logout(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  @spec logout(Plug.Conn.t(), map()) :: Plug.Conn.t() | {:error, :db_unavailable}
   def logout(conn, _) do
     subject = conn.assigns[:current_subject]
     :ok = maybe_terminate_sessions(subject)
-    :ok = Accounts.revoke_session(conn.assigns.current_session_id)
-    :ok = maybe_disconnect_socket(subject)
-    send_resp(conn, :no_content, "")
+
+    with :ok <- Accounts.revoke_session(conn.assigns.current_session_id) do
+      :ok = maybe_disconnect_socket(subject)
+      send_resp(conn, :no_content, "")
+    end
   end
 
   # #126 — detach is the ABSENCE of teardown. `DELETE /auth/logout` for a

--- a/lib/grappa_web/plugs/authn.ex
+++ b/lib/grappa_web/plugs/authn.ex
@@ -102,7 +102,7 @@ defmodule GrappaWeb.Plugs.Authn do
         # tombstone while waiting for the Reaper's 60s tick. Registered
         # visitors keep their row (purge_if_anon is a no-op) but the
         # session still revokes.
-        :ok = Accounts.revoke_session(session_id)
+        :ok = revoke_stale_session(session_id, :expired_visitor)
         :ok = Visitors.purge_if_anon(visitor_id)
         {:error, :expired_visitor}
 
@@ -113,8 +113,33 @@ defmodule GrappaWeb.Plugs.Authn do
         # if the visitor row disappeared mid-request we want the
         # operator log to flag it AND revoke the orphan session so the
         # bearer dies immediately.
-        :ok = Accounts.revoke_session(session_id)
+        :ok = revoke_stale_session(session_id, :visitor_missing)
         {:error, :visitor_missing}
+    end
+  end
+
+  # #636 — co-terminus cleanup on a request the plug has ALREADY decided to
+  # reject. Denial is the safe direction, so a revoke that degrades under
+  # SQLITE_BUSY must not change the verdict — and must not crash it either,
+  # which is what the former `:ok = Accounts.revoke_session(...)` binding did
+  # over an unretried `update_all`. It logs and the 401 proceeds. Self-healing:
+  # the visitor is expired or gone, so the very next request re-enters this
+  # branch and re-attempts the revoke. Deliberately the OPPOSITE call from
+  # `AuthController.logout/2`, which surfaces the same degrade as a 503 —
+  # there a 204 would promise a logout that did not happen; here the caller
+  # is being denied either way.
+  @spec revoke_stale_session(Ecto.UUID.t(), :expired_visitor | :visitor_missing) :: :ok
+  defp revoke_stale_session(session_id, reason) do
+    case Accounts.revoke_session(session_id) do
+      :ok ->
+        :ok
+
+      {:error, :db_unavailable} ->
+        Logger.warning(
+          "authn: stale visitor session revoke degraded (db unavailable) — " <>
+            "request still rejected, revoke retried on the next request",
+          authn_failure: reason
+        )
     end
   end
 

--- a/lib/grappa_web/request_budget.ex
+++ b/lib/grappa_web/request_budget.ex
@@ -75,7 +75,7 @@ defmodule GrappaWeb.RequestBudget do
     #    degrades to :db_unavailable — logged, then the teardown CONTINUES so
     #    the live socket still closes (the stale bearer is throttled on its
     #    next request). Never crash the guard.
-    case Accounts.revoke_session_resilient(session_id) do
+    case Accounts.revoke_session(session_id) do
       :ok ->
         :ok
 

--- a/test/grappa/accounts_test.exs
+++ b/test/grappa/accounts_test.exs
@@ -3,6 +3,7 @@ defmodule Grappa.AccountsTest do
 
   alias Grappa.Accounts
   alias Grappa.Accounts.User
+  alias Grappa.Repo.BusyRetry
 
   @password "correct horse battery staple"
 
@@ -416,7 +417,11 @@ defmodule Grappa.AccountsTest do
   # {:error, :db_unavailable} rather than the MatchError-crash a bare
   # `:ok = <bare update_all>` raises. Sibling of
   # `revoke_sessions_for_visitor/1` (#523/#518).
-  describe "revoke_session_resilient/1" do
+  #
+  # #636 — this WAS `revoke_session_resilient/1`, a second spelling living
+  # beside a fail-hard `revoke_session/1`. The pair collapsed: there is one
+  # caller-facing single-session revoke and it is this one.
+  describe "revoke_session/1" do
     setup do
       {:ok, user} = Accounts.create_user(%{name: "sever-revoke", password: @password})
       {:ok, session} = Accounts.create_session({:user, user.id}, "127.0.0.1", "ua", [])
@@ -424,29 +429,89 @@ defmodule Grappa.AccountsTest do
     end
 
     test "revokes the session with no contention", %{session: session} do
-      assert :ok = Accounts.revoke_session_resilient(session.id)
+      assert :ok = Accounts.revoke_session(session.id)
       assert {:error, :revoked} = Accounts.authenticate(session.id)
     end
 
     test "rides out a transient busy within the retry budget, then revokes", %{session: session} do
       # 3 injected faults clear well inside the 1500ms budget → the revoke
       # still lands (proves the BusyRetry wiring, not just the degrade arm).
-      Grappa.Repo.BusyRetry.inject_transient_faults(3)
+      BusyRetry.inject_transient_faults(3)
 
-      assert :ok = Accounts.revoke_session_resilient(session.id)
+      assert :ok = Accounts.revoke_session(session.id)
       assert {:error, :revoked} = Accounts.authenticate(session.id)
     end
 
     test "degrades to :db_unavailable under sustained busy, never raising, bearer left intact", %{
       session: session
     } do
-      Grappa.Repo.BusyRetry.inject_transient_faults(10_000)
+      BusyRetry.inject_transient_faults(10_000)
 
-      assert {:error, :db_unavailable} = Accounts.revoke_session_resilient(session.id)
+      assert {:error, :db_unavailable} = Accounts.revoke_session(session.id)
 
       # The revoke never landed, so the bearer is untouched — the caller's
       # retry starts from the same state, no half-applied session churn.
       assert {:ok, _} = Accounts.authenticate(session.id)
+    end
+  end
+
+  # #636 — the bulk user revoke is the same class as the single-session one:
+  # `PUT /admin/users/:id/password` calls it OUTSIDE any transaction, so it
+  # owns its own retry budget and degrades rather than raising a MatchError
+  # into the operator's request.
+  describe "revoke_sessions_for_user/1" do
+    setup do
+      {:ok, user} = Accounts.create_user(%{name: "bulk-revoke", password: @password})
+      {:ok, first} = Accounts.create_session({:user, user.id}, "127.0.0.1", "ua", [])
+      {:ok, second} = Accounts.create_session({:user, user.id}, "127.0.0.1", "ua", [])
+      %{user: user, first: first, second: second}
+    end
+
+    test "revokes every live bearer with no contention", ctx do
+      assert :ok = Accounts.revoke_sessions_for_user(ctx.user)
+      assert {:error, :revoked} = Accounts.authenticate(ctx.first.id)
+      assert {:error, :revoked} = Accounts.authenticate(ctx.second.id)
+    end
+
+    test "rides out a transient busy within the retry budget, then revokes", ctx do
+      BusyRetry.inject_transient_faults(3)
+
+      assert :ok = Accounts.revoke_sessions_for_user(ctx.user)
+      assert {:error, :revoked} = Accounts.authenticate(ctx.first.id)
+    end
+
+    test "degrades to :db_unavailable under sustained busy, never raising", ctx do
+      BusyRetry.inject_transient_faults(10_000)
+
+      assert {:error, :db_unavailable} = Accounts.revoke_sessions_for_user(ctx.user)
+
+      # Nothing was revoked, so the retry starts from the same state.
+      assert {:ok, _} = Accounts.authenticate(ctx.first.id)
+      assert {:ok, _} = Accounts.authenticate(ctx.second.id)
+    end
+
+    # The in-transaction members of the family (`reset_totp/1`,
+    # `reset_passkeys/1`, the TOTP/passkey mode transactions) must NOT own a
+    # retry of their own: they already run inside
+    # `BusyRetry.run(Repo.transaction(…))`, where the enclosing engine retries
+    # the WHOLE transaction. #636 therefore hands them a `!` primitive that
+    # RAISES, so the raise can abort the transaction and reach that outer
+    # engine. These two pin both halves of that contract from the caller's
+    # side: the revoke still lands, and the degrade is still the outer
+    # engine's typed tuple rather than a MatchError on a `:ok =` binding.
+    test "reset_totp/1 still revokes the user's bearers via the in-transaction revoke", ctx do
+      assert {:ok, _} = Accounts.reset_totp(ctx.user.name)
+
+      assert {:error, :revoked} = Accounts.authenticate(ctx.first.id)
+      assert {:error, :revoked} = Accounts.authenticate(ctx.second.id)
+    end
+
+    test "reset_totp/1 degrades to :db_unavailable — the OUTER engine owns the retry", ctx do
+      BusyRetry.inject_transient_faults(10_000)
+
+      assert {:error, :db_unavailable} = Accounts.reset_totp(ctx.user.name)
+
+      assert {:ok, _} = Accounts.authenticate(ctx.first.id)
     end
   end
 

--- a/test/grappa_web/controllers/admin/users_controller_test.exs
+++ b/test/grappa_web/controllers/admin/users_controller_test.exs
@@ -338,6 +338,34 @@ defmodule GrappaWeb.Admin.UsersControllerTest do
       assert {:error, :revoked} = Accounts.authenticate(target_session.id)
     end
 
+    # #636 — the S8 revoke was a bare `:ok = Accounts.revoke_sessions_for_user/1`
+    # over an unretried `update_all`, so a SQLITE_BUSY crashed the operator's
+    # request with a MatchError 500. Degrading quietly would be worse than the
+    # crash: a 200 would tell the operator the compromised account was evicted
+    # when every attacker bearer is still live. Typed 503, retry.
+    test "PUT /password returns 503 when the session revoke degrades under a busy DB",
+         %{conn: conn} do
+      {target, target_session} = user_and_session()
+      admin_sess = admin_session()
+
+      Grappa.Repo.BusyRetry.inject_transient_faults(10_000)
+
+      conn =
+        conn
+        |> put_bearer(admin_sess.id)
+        |> put_req_header("content-type", "application/json")
+        |> put(
+          "/admin/users/#{target.id}/password",
+          Jason.encode!(%{password: "rotated horse staple"})
+        )
+
+      assert json_response(conn, 503) == %{"error" => "db_unavailable"}
+
+      # The 503 is honest about the half-applied state: the password DID
+      # rotate, and the bearers the rotation was meant to evict did NOT.
+      assert {:ok, _} = Accounts.authenticate(target_session.id)
+    end
+
     test "PUT /password closes the target's live WebSocket (S8)", %{conn: conn} do
       target = user_fixture(name: "wspw-#{System.unique_integer([:positive])}")
       topic = "user_socket:" <> target.name

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -914,6 +914,28 @@ defmodule GrappaWeb.AuthControllerTest do
       assert json_response(conn, 401) == %{"error" => "unauthorized"}
     end
 
+    # #636 — logout used to bind the revoke with `:ok = ...` over an
+    # unretried `update_all`, so a SQLITE_BUSY became a MatchError 500. It is
+    # ALSO the one caller in the family that must not degrade quietly: a 204
+    # here tells the browser it is logged out while the bearer still
+    # authenticates. So it surfaces the typed 503 and the client retries.
+    test "returns 503 db_unavailable when the revoke degrades, leaving the bearer live",
+         %{conn: conn} do
+      {_, session} = user_and_session()
+      Grappa.Repo.BusyRetry.inject_transient_faults(10_000)
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> delete("/auth/logout")
+
+      assert json_response(conn, 503) == %{"error" => "db_unavailable"}
+      assert Enum.member?(Plug.Conn.get_resp_header(conn, "retry-after"), "1")
+
+      # No lie: the session really is still usable, and the response said so.
+      assert {:ok, _} = Accounts.authenticate(session.id)
+    end
+
     test "with revoked Bearer returns 401", %{conn: conn} do
       {_, session} = user_and_session()
       :ok = Accounts.revoke_session(session.id)

--- a/test/grappa_web/plugs/authn_test.exs
+++ b/test/grappa_web/plugs/authn_test.exs
@@ -196,6 +196,35 @@ defmodule GrappaWeb.Plugs.AuthnTest do
       assert reloaded_session == nil or reloaded_session.revoked_at != nil
     end
 
+    # #636 — the co-terminus revoke above used to be a bare
+    # `:ok = Accounts.revoke_session(session_id)` over an unretried
+    # `update_all`: a SQLITE_BUSY raised a MatchError and the whole request
+    # died with a 500. The plug has ALREADY decided to reject at this point,
+    # and denial is the safe direction, so a degraded revoke must not change
+    # the verdict — it logs and lets the 401 through. Self-healing, too: the
+    # visitor is still expired, so the next request retries the revoke.
+    test "expired ANON visitor still 401s when the revoke degrades under a busy DB",
+         %{conn: conn, session: session} do
+      past = DateTime.add(DateTime.utc_now(), -1, :hour)
+      query = from(v in Visitor, where: v.id == ^session.visitor_id)
+      {1, _} = Repo.update_all(query, set: [expires_at: past])
+
+      Grappa.Repo.BusyRetry.inject_transient_faults(10_000)
+
+      result =
+        conn
+        |> put_req_header("authorization", "Bearer #{session.id}")
+        |> Authn.call(Authn.init([]))
+
+      assert result.halted
+      assert result.status == 401
+      assert result.resp_body =~ "unauthorized"
+
+      # The degrade is honest: nothing was revoked. The bearer is dead anyway
+      # (the visitor is expired), so the next request re-attempts the cleanup.
+      assert %Session{revoked_at: nil} = Repo.get(Session, session.id)
+    end
+
     # #211 phase 7 — the "expired REGISTERED visitor → 401 + row STAYS"
     # test was DELETED: registration is DERIVED from the credentials now
     # (`Credentials.visitor_registered?/1`), and `Visitors.touch/1`


### PR DESCRIPTION
Refs #636.

## Still real?

All four cited call sites were still fail-hard on current `origin/main`, and
there is a **fifth the issue does not name**: `PUT /admin/users/:id/password`
(`admin/users_controller.ex:142`) binds `revoke_sessions_for_user/1` with
`:ok =` too. Nothing had been fixed in the meantime.

One cited item needed re-reading, though. `revoke_sessions_for_user/1`'s two
in-module callers (`totp_reset_transaction`, `reset_passkeys_transaction`) are
already inside a `BusyRetry.run(Repo.transaction(…))`, so a busy there is
*already* ridden out by the enclosing engine — their `:ok =` is a legitimate
assertion, not the defect. The unguarded caller of that function is the admin
endpoint the issue missed.

## The class fix

**The pair collapsed.** `revoke_session/1` IS the resilient one now;
`revoke_session_resilient/1` is deleted. Two spellings where one is a trap is
how the next person picks wrong, and the suffix never was a distinction —
`revoke_sessions_for_visitor/1` (#523/#518) has been busy-resilient with no
suffix since it shipped, so the codebase already said resilient-is-the-default.

**But the class is not "wrap every revoke".** Half the family runs inside
`BusyRetry.run(Repo.transaction(…))`, where a nested retry is actively wrong:
it would sleep holding the open transaction's connection — extending the very
contention it waits on — and would convert the raise the transaction needs
into a return value. The correct retry unit there is the whole transaction,
and the outer engine already owns it. So the rule is per-ROLE:

* **caller-facing** — `revoke_session/1`, `revoke_sessions_for_user/1`,
  `revoke_sessions_for_visitor/1`: own a `BusyRetry` budget, return
  `{:error, :db_unavailable}`.
* **in-transaction** — `revoke_other_sessions_for_user!/2` and the private
  `revoke_sessions_for_user!/1`: raise, and the bang says so. Their caller
  owns the budget.

The contract is written out on `revoke_session/1` so the next member of the
family lands in the right half.

## What each caller does under a busy DB

| caller | before | now |
|---|---|---|
| `Plugs.Authn` expired visitor | MatchError 500 | warns, **401 still returned** |
| `Plugs.Authn` visitor missing | MatchError 500 | warns, **401 still returned** |
| `DELETE /auth/logout` | MatchError 500 | **503 `db_unavailable`** + `retry-after` |
| `PUT /admin/users/:id/password` | MatchError 500 | **503 `db_unavailable`** |
| `RequestBudget.sever/3` | already resilient | unchanged (renamed callee) |
| the in-transaction four | already covered by the outer retry | unchanged (bang callee) |

The split is deliberate, and it is the #815 question asked at each door
separately: *does this caller's success answer become a lie?* The plug has
already decided to reject and denial is the safe direction, so it logs and
continues — self-healing, since the visitor is still expired and the next
request re-attempts the revoke. Logout and the admin rotation cannot degrade
quietly: a 204 promises the bearer is dead and a 200 promises the compromised
account is evicted, and neither happened. What none of them may do is what
they all did before, which is raise.

`purge_if_anon/1` (#590) is the precedent for the quiet half, and note where
the absorption lives: in the *caller's* judgement, not in the context
function. `revoke_session/1` always returns the typed error — absorbing inside
`Accounts` would have taken the choice away from logout, which needs it.

## Tests

Failing first, and each asserts the CALLER's observable behaviour under an
injected sustained busy, not merely a return shape:

* `AccountsTest` — `revoke_session/1` and `revoke_sessions_for_user/1` ride
  out a transient busy, degrade under a sustained one, and leave the bearers
  intact when they degrade.
* `AuthnTest` — an expired anon visitor still 401s when the revoke degrades,
  and `revoked_at` really is still `nil` (the degrade is honest).
* `AuthControllerTest` — logout 503s with `retry-after: 1`, and the bearer
  still authenticates afterwards.
* `Admin.UsersControllerTest` — the rotation 503s and the target's bearer is
  still live.
* Two `reset_totp/1` tests pin the in-transaction half from the caller's side:
  the revoke still lands, and the degrade is still the outer engine's typed
  tuple rather than a MatchError.

The five reds were read before any of them went green.

## Gate

`scripts/check.sh` → RC=0 (8 doctests, 50 properties, 5129 tests, 0 failures;
dialyzer `done (passed successfully)`; sobelow/doctor/credo/format clean; bats
278 ok). Working tree byte-identical before and after the run.

No `integration.sh` — server-only change, no wire tokens, no cic surface. Say
the word if you want the STACK lane spent on it anyway.