### PR TITLE
shottino(#758): let a failed ffmpeg exec reach the error message written for it

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -29112,3 +29112,51 @@ arrive to a freed buffer", and `main` ends with a long comment about the model
 thread that was neither stopped nor joined while shutdown freed the mutex and
 SSL context underneath it. The helper's own teardown was the one place that had
 drifted from the rule the rest of the tree follows.
+## 2026-08-05 — #758: a primitive that cannot fail makes its callers' error handling dead code
+
+`spawn_ffmpeg` in the call helper returned a pid whenever `fork()` succeeded.
+`execvp` failing set the CHILD's exit status to 127 and nothing ever inspected
+it — the only `waitpid`s in the helper are the blocking reaps on the teardown
+path — so all three start functions reported success unconditionally. On a
+machine with no ffmpeg the call connected, the tile map published, the UI drew
+a call window, and the user got silence and a black rectangle with no
+diagnostic anywhere. ffmpeg is an OPT-IN dependency of an opt-in feature, so
+this is the ordinary case rather than an exotic one.
+
+**The callers were already right; the primitive underneath them lied.**
+`media_start_send` closes its socket and returns false on -1, and both mixes
+`return mix->pid > 0`. Three error messages were written for that false branch
+and none of them could be reached. That is the general shape worth naming: a
+function that cannot report failure does not merely lose an error, it converts
+every caller's error handling into unreachable code that reads, in review, as
+though the case were handled.
+
+**The exec gets a channel of its own: an `FD_CLOEXEC` pipe.** A successful
+exec closes the write end, so the parent reads EOF; a failed one leaves the
+child alive to write its errno first, so a non-empty read means the exec
+failed and nothing else does. Chosen over polling `waitpid(WNOHANG)` on the
+supervisor tick for three reasons: it answers at the start, where the callers
+already test a bool (a tick poll has no bool and would need new messages,
+leaving the existing ones dead — i.e. not fixing the defect); it cannot
+confuse "ffmpeg is not installed" with "ffmpeg died at second thirty"; and it
+is testable without a call, because PATH decides the outcome, whereas the tick
+lives in `call/main.c`, which no test links.
+
+**The boundary is stated, not implied.** An ffmpeg that starts and then dies —
+a device that will not open, a filter graph it refuses — is still invisible.
+The header used to claim "a failure shows as the process dying, which the
+caller sees" over code where nobody looked; the replacement says what is
+detected and what is not, because a comment promising a guarantee nobody
+implements is the bug, not the documentation of one (the same lesson as #754's
+job comment promising `-Werror` over a file it never compiled).
+
+**Two mutations, two different lessons.** Deleting the reap left every check
+green — and an unreaped failure is one zombie per supervisor tick for the
+length of the call, since the tick rebuilds both mixes, so the suite now
+asserts `waitpid(-1, WNOHANG) == ECHILD` after a failed start. And dropping
+`FD_CLOEXEC` from the write end should have hung the parent's read forever;
+the suite passed in one second, because the fake ffmpeg (`exec sleep 30` under
+a PATH holding only the scratch directory) could not find `sleep` and died
+instantly, closing the write end and handing the parent a clean EOF by
+accident. A positive control that admits a corpse is not a control: it now
+sets its own PATH and asserts the child is RUNNING, not merely forked.

--- a/frontends/shottino/call/media.c
+++ b/frontends/shottino/call/media.c
@@ -74,16 +74,47 @@ static void split_source(const char *source, const char **fmt, const char **inpu
 }
 
 /* fork+exec ffmpeg with stdout wired to `stdout_fd` (or /dev/null) and
- * stderr discarded.
+ * stderr discarded. Returns -1 if the child could not be started AT ALL,
+ * having reaped it.
  *
  * ffmpeg's own diagnostics are dropped rather than merged into stderr:
  * stderr here is the JSON event stream shottino parses, and ffmpeg's
- * progress lines would be garbage in it. A failure shows as the process
- * dying, which the caller sees. */
+ * progress lines would be garbage in it. Which leaves the exec itself
+ * with nowhere to report from — so it gets a channel of its own.
+ *
+ * THE CLOEXEC PIPE IS THE DETECTOR. A successful exec closes the write
+ * end, so the parent reads EOF and knows only that the program started;
+ * a failed one leaves the child alive to write its errno first, so a
+ * non-empty read means the exec failed and nothing else does. The read
+ * blocks for exactly as long as the exec takes.
+ *
+ * This is not decoration. Without it fork() succeeding IS the answer,
+ * `execvp` failing sets an exit status of 127 that nobody in this
+ * program ever waits for, and every caller's "cannot start …" message
+ * hangs off a branch that cannot be reached — a machine with no ffmpeg
+ * gets a call window, silence, a black rectangle and no diagnostic
+ * anywhere. shottino already holds this line elsewhere: call_helper_path
+ * says "not installed" BEFORE forking, because a child that exits 127
+ * into a pipe tells nobody anything.
+ *
+ * What it does NOT cover: an ffmpeg that starts and then dies — a device
+ * that will not open, a filter graph it refuses. That is a different
+ * failure with a different lifetime (it can happen at any moment, not
+ * just at the start) and it is not detected here or anywhere else. */
 static pid_t spawn_ffmpeg(char *const argv[], int stdout_fd) {
+    int err_fds[2];
+    if (pipe(err_fds) != 0) return -1;
+    fcntl(err_fds[0], F_SETFD, FD_CLOEXEC);
+    fcntl(err_fds[1], F_SETFD, FD_CLOEXEC);
+
     pid_t pid = fork();
-    if (pid < 0) return -1;
+    if (pid < 0) {
+        close(err_fds[0]);
+        close(err_fds[1]);
+        return -1;
+    }
     if (pid == 0) {
+        close(err_fds[0]);
         int devnull = open("/dev/null", O_RDWR);
         if (devnull >= 0) {
             dup2(devnull, STDIN_FILENO);
@@ -92,9 +123,25 @@ static pid_t spawn_ffmpeg(char *const argv[], int stdout_fd) {
             if (devnull > STDERR_FILENO) close(devnull);
         }
         execvp("ffmpeg", argv);
+        int failed = errno;
+        (void)!write(err_fds[1], &failed, sizeof(failed));
         _exit(127);
     }
-    return pid;
+    close(err_fds[1]);
+
+    int child_errno = 0;
+    ssize_t got;
+    do {
+        got = read(err_fds[0], &child_errno, sizeof(child_errno));
+    } while (got < 0 && errno == EINTR);
+    close(err_fds[0]);
+    if (got <= 0) return pid;
+
+    /* Reaped here rather than left to the teardown: the caller is about
+     * to be told this leg does not exist, and a leg that does not exist
+     * has nobody to wait for it. */
+    while (waitpid(pid, NULL, 0) < 0 && errno == EINTR) {}
+    return -1;
 }
 
 bool media_start_send(struct media_leg *leg, const struct media_config *cfg, bool video) {

--- a/frontends/shottino/call/media.h
+++ b/frontends/shottino/call/media.h
@@ -253,7 +253,15 @@ int media_bind_loopback(int *port_out);
 
 /* Start capturing and packetising. The caller pumps `leg->fd` and hands
  * each datagram to the track. Returns false and leaves the leg stopped
- * if ffmpeg cannot be started. */
+ * if ffmpeg cannot be started.
+ *
+ * WHICH INCLUDES AN FFMPEG THAT IS NOT INSTALLED, and that is the whole
+ * value of the bool: a fork that succeeds says nothing about the exec
+ * that follows it, so this used to return true on a machine with no
+ * ffmpeg and the caller's error message was unreachable code. Every
+ * start function here answers the same question the same way — see
+ * spawn_ffmpeg for how the exec reports back, and for the failure it
+ * still does not cover (a child that starts and dies later). */
 bool media_start_send(struct media_leg *leg, const struct media_config *cfg, bool video);
 
 /* Forward one RTP packet a track delivered to the decoder. */

--- a/frontends/shottino/docs/CALLS.md
+++ b/frontends/shottino/docs/CALLS.md
@@ -226,7 +226,7 @@ unmuting take as long as a device open.
 transport libdatachannel owns: **118 RTP packets captured and forwarded →
 117 frames of rgb24 decoded**, and the audio leg producing Opus RTP.
 
-Five bugs that cost real time and are worth not repeating:
+Six bugs that cost real time and are worth not repeating:
 
 - **`-framerate` / `-video_size` are demuxer-specific.** v4l2 takes them;
   lavfi refuses them outright and the capture dies with its stderr
@@ -247,6 +247,18 @@ Five bugs that cost real time and are worth not repeating:
   blank window.
 - **The receive SDP cannot be unlinked right after the spawn.** The child
   may not have exec'd, and the decoder then reads nothing, silently.
+- **A fork that succeeds says nothing about the exec.** `spawn_ffmpeg`
+  returned a pid whenever `fork()` did, so a host with no ffmpeg opened a
+  call window, published a tile map, and produced silence and a black
+  rectangle: `execvp` failing only set the CHILD's exit status to 127,
+  and the only `waitpid`s in the helper are on the teardown path. Every
+  *"cannot start …"* message here hangs off the false branch those start
+  functions were not returning — the diagnostics existed and were
+  unreachable code. The exec now reports back over an `FD_CLOEXEC` pipe:
+  a successful one closes the write end and the parent reads EOF, a
+  failed one writes its errno first. What that does NOT catch — an
+  ffmpeg that starts and then dies, a device that will not open — is
+  still invisible, and is documented as such rather than implied away.
 
 The offer it generates, captured against a stub endpoint:
 

--- a/frontends/shottino/tests/test_callmedia.c
+++ b/frontends/shottino/tests/test_callmedia.c
@@ -1,18 +1,24 @@
-/* test_callmedia — the one pure thing in the media legs.
+/* test_callmedia — the pure parts of the media legs, and the one
+ * question about the impure part that can be asked without a call: does
+ * a spawn that fails SAY so.
  *
- * Everything else in media.c is fork+exec and sockets, verified by
- * running it (see docs/CALLS.md). The SDP is the exception and the one
- * that most deserves a test: a wrong payload type or rtpmap here is a
- * decoder that sits SILENT with no error at all, which is the least
- * debuggable failure this design has.
+ * The rest of media.c is sockets and codec behaviour, verified by
+ * running it (see docs/CALLS.md). The SDP is the part that most deserves
+ * a test: a wrong payload type or rtpmap there is a decoder that sits
+ * SILENT with no error at all, which is the least debuggable failure
+ * this design has — and a spawn reported as started when it was not is
+ * the same failure one layer down.
  *
  * Links media.c only — no libdatachannel — so the default gate never
  * depends on the opt-in submodule having been built.
  */
 #include "../call/media.h"
 
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "test.h"
@@ -402,6 +408,145 @@ TEST(loopback_ports_are_distinct_and_reported) {
     if (fd_b >= 0) close(fd_b);
 }
 
+/* A PATH containing exactly what `fake_ffmpeg` says — a script named
+ * `ffmpeg`, or nothing at all. The directory name is written back so the
+ * caller can take it down again.
+ *
+ * PATH rather than a real ffmpeg either way: the suite must decide the
+ * outcome itself, and "is ffmpeg installed on the machine running the
+ * tests" is exactly the question that must not affect it. */
+static bool path_holding_ffmpeg(const char *fake_ffmpeg, char *dir, size_t dir_sz) {
+    snprintf(dir, dir_sz, "/tmp/shottino-callmedia-XXXXXX");
+    if (!mkdtemp(dir)) return false;
+    if (fake_ffmpeg) {
+        char path[128];
+        snprintf(path, sizeof(path), "%s/ffmpeg", dir);
+        FILE *f = fopen(path, "w");
+        if (!f) return false;
+        fputs(fake_ffmpeg, f);
+        fclose(f);
+        if (chmod(path, 0755) != 0) return false;
+    }
+    return setenv("PATH", dir, 1) == 0;
+}
+
+static void path_restore(const char *dir, const char *saved) {
+    char path[128];
+    snprintf(path, sizeof(path), "%s/ffmpeg", dir);
+    unlink(path);
+    rmdir(dir);
+    setenv("PATH", saved, 1);
+}
+
+/* Exactly how main.c prepares a mix before starting it. A memset-zeroed
+ * one is NOT the same thing: its legs would own fd 0. */
+static void mix_init(struct media_mix *mix) {
+    memset(mix, 0, sizeof(*mix));
+    mix->pid = -1;
+    for (int i = 0; i < MEDIA_MAX_PEERS; i++) {
+        mix->legs[i].fd = -1;
+        mix->legs[i].pid = -1;
+    }
+}
+
+static struct media_config spawn_test_config(void) {
+    struct media_config cfg = { .audio_source = "pulse:default",
+                                .video_source = "v4l2:/dev/video0",
+                                .audio_sink = "pulse:default",
+                                .audio_payload_type = 111,
+                                .video_payload_type = 96,
+                                .audio_ssrc = 1,
+                                .video_ssrc = 2,
+                                .frame_w = 320,
+                                .frame_h = 240,
+                                .fps = 10,
+                                .capture_w = 640,
+                                .capture_h = 480,
+                                .capture_fps = 20,
+                                .video_kbps = 800,
+                                .video_codec = MEDIA_VIDEO_VP8,
+                                .want_video = true };
+    return cfg;
+}
+
+/* AN FFMPEG THAT CANNOT BE EXEC'D IS A START THAT FAILED.
+ *
+ * The helper is opt-in and its README does not make ffmpeg a hard
+ * dependency, so "not installed" is the ordinary case, not an exotic
+ * one. A fork that succeeds and an exec that does not is a child that
+ * exits 127 with its stderr discarded, and every caller's error message
+ * hangs off the false branch these functions were not returning: the
+ * call window opens, the tiles publish, and the user gets silence and a
+ * black rectangle with no diagnostic anywhere.
+ *
+ * All three start functions, because all three spawn and all three have
+ * their own message on the far side of the bool. */
+TEST(a_start_reports_an_ffmpeg_that_cannot_be_exec_d) {
+    char saved[4096];
+    snprintf(saved, sizeof(saved), "%s", getenv("PATH") ? getenv("PATH") : "");
+    char dir[64];
+    CHECK(path_holding_ffmpeg(NULL, dir, sizeof(dir)));
+
+    struct media_config cfg = spawn_test_config();
+    int slots[1] = { 0 };
+
+    struct media_leg leg;
+    CHECK(!media_start_send(&leg, &cfg, false));
+    /* And stopped, not half-started: the socket the capture would have
+     * been read from is closed, so nothing polls a leg that has no
+     * writer. */
+    CHECK(leg.pid == -1);
+    CHECK(leg.fd == -1);
+
+    struct media_mix amix;
+    mix_init(&amix);
+    CHECK(!media_start_audio_mix(&amix, slots, 1, &cfg));
+    CHECK(amix.pid == -1);
+    media_mix_free(&amix);
+
+    struct media_mix vmix;
+    mix_init(&vmix);
+    vmix.tile_count = media_grid_layout(slots, 1, cfg.frame_w, cfg.frame_h, vmix.tiles,
+                                        MEDIA_MAX_PEERS);
+    CHECK(vmix.tile_count == 1);
+    CHECK(!media_start_video_mix(&vmix, &cfg, -1));
+    CHECK(vmix.pid == -1);
+    media_mix_free(&vmix);
+
+    path_restore(dir, saved);
+}
+
+/* The other half of the same question, and the reason the one above
+ * means anything: a start that CAN exec still succeeds.
+ *
+ * Without this, "returns false" is satisfied just as well by a function
+ * that refuses everything. */
+TEST(a_start_succeeds_when_ffmpeg_is_on_the_path) {
+    char saved[4096];
+    snprintf(saved, sizeof(saved), "%s", getenv("PATH") ? getenv("PATH") : "");
+    char dir[64];
+    /* Anything that execs and stays up: this is the spawn contract under
+     * test, not ffmpeg's own behaviour. */
+    CHECK(path_holding_ffmpeg("#!/bin/sh\nexec sleep 30\n", dir, sizeof(dir)));
+
+    struct media_config cfg = spawn_test_config();
+    int slots[1] = { 0 };
+
+    struct media_leg leg;
+    CHECK(media_start_send(&leg, &cfg, false));
+    CHECK(leg.pid > 0);
+    media_stop(&leg);
+    CHECK(leg.pid == -1);
+
+    struct media_mix amix;
+    mix_init(&amix);
+    CHECK(media_start_audio_mix(&amix, slots, 1, &cfg));
+    CHECK(amix.pid > 0);
+    media_mix_free(&amix);
+
+    path_restore(dir, saved);
+}
+
 int main(void) {
     RUN(the_receive_sdp_describes_what_was_negotiated);
     RUN(the_receive_sdp_follows_the_negotiated_video_codec);
@@ -412,5 +557,7 @@ int main(void) {
     RUN(the_mix_filter_chains_every_tile_into_one_output);
     RUN(the_published_grid_is_complete_or_refused);
     RUN(loopback_ports_are_distinct_and_reported);
+    RUN(a_start_reports_an_ffmpeg_that_cannot_be_exec_d);
+    RUN(a_start_succeeds_when_ffmpeg_is_on_the_path);
     return test_report();
 }

--- a/frontends/shottino/tests/test_callmedia.c
+++ b/frontends/shottino/tests/test_callmedia.c
@@ -14,6 +14,7 @@
  */
 #include "../call/media.h"
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -513,6 +514,13 @@ TEST(a_start_reports_an_ffmpeg_that_cannot_be_exec_d) {
     CHECK(!media_start_video_mix(&vmix, &cfg, -1));
     CHECK(vmix.pid == -1);
     media_mix_free(&vmix);
+
+    /* AND NOT A CORPSE LEFT ANYWHERE. Nothing waits for a leg the caller
+     * was told does not exist, and the supervisor rebuilds both mixes on
+     * every tick — so on the machine this whole issue is about, a start
+     * that does not reap its own failed child leaks a zombie per tick
+     * for the length of the call. */
+    CHECK(waitpid(-1, NULL, WNOHANG) == -1 && errno == ECHILD);
 
     path_restore(dir, saved);
 }

--- a/frontends/shottino/tests/test_callmedia.c
+++ b/frontends/shottino/tests/test_callmedia.c
@@ -19,6 +19,7 @@
 #include <string.h>
 
 #include <sys/stat.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include "test.h"
@@ -525,9 +526,15 @@ TEST(a_start_succeeds_when_ffmpeg_is_on_the_path) {
     char saved[4096];
     snprintf(saved, sizeof(saved), "%s", getenv("PATH") ? getenv("PATH") : "");
     char dir[64];
-    /* Anything that execs and stays up: this is the spawn contract under
-     * test, not ffmpeg's own behaviour. */
-    CHECK(path_holding_ffmpeg("#!/bin/sh\nexec sleep 30\n", dir, sizeof(dir)));
+    /* Anything that execs and STAYS UP: this is the spawn contract under
+     * test, not ffmpeg's own behaviour.
+     *
+     * The inner PATH is not decoration. This one runs with PATH pointing
+     * at the scratch directory and nothing else, so a bare `sleep` is
+     * not found — the script then exits immediately, the check below
+     * still passes on a pid that is already a zombie, and the control
+     * proves nothing. Measured, not assumed. */
+    CHECK(path_holding_ffmpeg("#!/bin/sh\nPATH=/usr/bin:/bin\nexec sleep 30\n", dir, sizeof(dir)));
 
     struct media_config cfg = spawn_test_config();
     int slots[1] = { 0 };
@@ -535,6 +542,11 @@ TEST(a_start_succeeds_when_ffmpeg_is_on_the_path) {
     struct media_leg leg;
     CHECK(media_start_send(&leg, &cfg, false));
     CHECK(leg.pid > 0);
+    /* RUNNING, not merely forked. A child that exited the instant it
+     * started satisfies pid > 0 exactly as well — which is what made the
+     * bug this suite is about survive in the first place. */
+    int status = 0;
+    CHECK(waitpid(leg.pid, &status, WNOHANG) == 0);
     media_stop(&leg);
     CHECK(leg.pid == -1);
 
@@ -542,6 +554,7 @@ TEST(a_start_succeeds_when_ffmpeg_is_on_the_path) {
     mix_init(&amix);
     CHECK(media_start_audio_mix(&amix, slots, 1, &cfg));
     CHECK(amix.pid > 0);
+    CHECK(waitpid(amix.pid, &status, WNOHANG) == 0);
     media_mix_free(&amix);
 
     path_restore(dir, saved);


### PR DESCRIPTION
Fixes the #758 blind spot: `spawn_ffmpeg` returned a pid whenever `fork()`
succeeded, so a machine with no ffmpeg opened a call window, published a tile
map, and produced silence and a black rectangle with no diagnostic anywhere.

## Still real, verified against the current files

`call/media.c:83-98` — `execvp` failing only set the CHILD's exit status to
127; the only `waitpid`s in the helper are the blocking reaps in `media_stop`
and `media_mix_stop`, both on teardown. So `media_start_send` (`:240`) caught
only a fork failure, and both mixes `return mix->pid > 0` (`:581`, `:674`) over
a pid that was always valid. The three messages the issue calls unreachable —
`call/main.c:399`, `:1015`, `:1017` — were exactly that.

## Shape (a), the FD_CLOEXEC pipe, over shape (b), the WNOHANG tick

- **It makes the EXISTING messages reachable.** The callers were already
  written correctly; the primitive under them lied. A tick poll has no bool to
  answer, would need error messages of its own, and would leave the ones the
  issue names as dead code — i.e. not fix the defect.
- **It cannot conflate.** The write happens between `execvp` returning and
  `_exit`, so "ffmpeg is not installed" is never confused with "ffmpeg died at
  second thirty". A `WNOHANG` poll conflates the two by construction, and is
  late by up to a tick.
- **It is testable.** PATH decides the outcome, so the suite never asks whether
  the machine running it has ffmpeg. The tick lives in `call/main.c`, which no
  test links and (until #754) no job compiles.

Cost: one pipe per spawn on a path that already forks, and a read that blocks
for as long as the exec takes. shottino already holds this line elsewhere —
`call_helper_path` says "not installed" BEFORE forking, "because a child that
exits 127 into a pipe" tells nobody anything.

## The header now agrees with the code

`media.h` promised "a failure shows as the process dying, which the caller
sees" over code where nobody looked, and "returns false … if ffmpeg cannot be
started" over a function that could not return false. The first is replaced
with what is actually detected; the second is now true. What is still NOT
covered — an ffmpeg that starts and then dies, a device that will not open — is
stated in the header and in `docs/CALLS.md` rather than implied away. A comment
promising a guarantee nobody implements is the bug (cf. #754).

## Tests, and the mutation that found a bug in the test

Failing first: with the fix reverted, 7 checks fall across all three start
functions. Four mutations measured:

| mutation | caught |
|---|---|
| revert `spawn_ffmpeg` to `origin/main` | 7 FAIL |
| drop `FD_CLOEXEC` from the write end | parent hangs (CI timeout) |
| treat EOF as a failed exec (`got < 0`) | parent hangs |
| drop the reap of the failed child | **NOT caught** → fixed, see below |

The reap matters: the supervisor rebuilds both mixes on every tick, so on the
machine this issue is about an unreaped failure is one zombie per tick for the
length of the call. The suite now asserts `waitpid(-1, WNOHANG) == ECHILD`
after a failed start.

The no-CLOEXEC mutation found a defect in the TEST, not the fix: the fake
ffmpeg (`exec sleep 30`) ran under a PATH holding only the scratch directory,
could not find `sleep`, and died instantly — closing the write end and handing
the parent a clean EOF by accident, so `pid > 0` passed on a zombie. The
positive control now sets its own PATH and asserts the child is RUNNING.

## The class

Every other fork+exec in shottino already has a channel its failure reaches:
`run_cmd` returns the exit status; the recorder waits and reports ffmpeg's last
stderr line; the `claude` CLI's exec failure arrives as an empty reply and says
"is \`claude\` on PATH and logged in?". The double-forked `xdg-open` /
`notify-send` / `mpv` are fire-and-forget by design (the grandchild is an
orphan; nothing can wait for it). `call/media.c` was the only place where the
diagnostic existed and could not be reached.

## Gates

- 15/16 suites green locally (`test_keys` is Linux-only), and **16/16 in a
  Linux container running the byte-exact CI commands** — build with `-Werror`
  and `make check`.
- `test_layout` fails 2 of 2937 checks in that container — **identically on
  `origin/main`**, so pre-existing and not from this change.