### PR TITLE
shottino(#760): keep the grid a refused tiles line was meant to keep

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -29161,3 +29161,69 @@ lives in the CALLER's judgement, not in the context function: `revoke_session/1`
 always returns the typed error, and the plug decides to continue. Absorbing
 inside the context would have taken the choice away from logout, which needs
 it.
+
+## 2026-08-05 — #760: a refusal and an empty answer are not the same zero
+
+`call_tiles_parse` decides which rectangle of the composited call frame
+belongs to which person, and it is deliberately all-or-nothing: a line that
+does not parse cleanly is refused whole, because a half-applied grid draws
+faces under the wrong names. That contract is stated three times — in the
+function's own comment, in the comment three lines above the `memcpy` that
+consumed it, and in `frontends/shottino/docs/CALLS.md`. The single call site
+did the opposite of all three: it adopted the refusal, count `0` and frame
+`0x0`, so one malformed line — a truncated pipe write, a re-grid racing a peer
+leaving — blanked the video grid mid-call and left it blank until the next good
+line arrived.
+
+**The fix the issue proposed would have introduced a second bug.** `if (n > 0)`
+reads as the obvious guard, and it is wrong, because `0` already had a second
+meaning: the helper publishes `{"event":"tiles","value":""}` when it stops the
+decoder because nobody is sending a picture (`call/main.c` `video_retile`), and
+that is an INSTRUCTION, not a failure. A count-only guard would hold the last
+two faces labelled over a frame stream that has stopped. The root cause is not
+the missing guard — it is that a lossy return value made the guard unwriteable:
+the caller could not distinguish "there is nothing to draw" from "I could not
+read this". So the parser now answers three ways (`< 0` refused, `0` an empty
+grid, `> 0` the tile count) and the caller does the opposite thing in each.
+
+**A bare frame size stays a refusal.** `"640x480"` with nothing after it is a
+line cut mid-write, and the helper never emits one: when `media_grid_layout`
+refuses, `media_start_video_mix` returns false on `tile_count <= 0` and the
+helper reports an `error` event instead of a tile-less grid. The empty grid has
+exactly two spellings, `""` and `"<w>x<h>;"`, and both are pinned.
+
+**The refusal is now said out loud.** One line into the call window, on a path
+that already narrates every other thing the helper reports. Unreported, a grid
+that silently stops following the call reaches us as "the video broke", which
+is unactionable — the same failure mode as #758's error strings that no branch
+could reach and #756's over-read that no one could observe. Not rate-limited
+and not latched: a `tiles` event is emitted when the grid CHANGES, not per
+frame, so the flood this would guard against does not exist, and a latch is a
+per-call field that needs resetting and will drift.
+
+**Second defect, same path: uninitialised stack into shared state.** The
+`tiles` local was uninitialised and the parser writes nothing to it on its
+early exits, so the `memcpy` under `app->lock` carried whatever the stack held
+— and still would past the tile count on a GOOD line, since the whole array is
+copied either way. Zeroed at declaration. It was harmless only because every
+reader gates on `tile_count`, which is a coincidence rather than a design.
+
+**The class was swept.** One structural twin: `admin_verb_run` copies an
+uninitialised `struct admin_field fields[ADMIN_FORM_MAX]` whole into
+`app->overlay.form` — but it is guarded by `if (nf)` and every reader is
+bounded by `form_count`, so it is latent, not live. The producer-side
+`video_retile` assigns `media_grid_layout`'s count straight into
+`c->vmix.tile_count` and leaves `tiles` stale on a refusal, which is safe for
+the same reason: the count gates every reader. No other all-or-nothing parser
+in `frontends/shottino` has a call site that adopts partial output.
+
+**Testability was the reason this site had none.** The per-line handling lived
+inside the reader thread, and a thread blocked in `fgets` on a pipe cannot be
+asserted about; it now lives in `call_event_apply`, driven from the test with
+the helper's real JSON. The RED was measured against five mutations rather than
+assumed: dropping the guard (9 checks), collapsing the parser back to one `0`
+(17), dropping the zero-init (35 — the assertions come back `0xAAAAAAAA`,
+because the test dirties the stack first on purpose, since a quiet stack is
+often already zero and would have made that check a green that proves nothing),
+writing the guard the way the issue words it (17, of which three are the
+camera-off regression), and keeping the guard while saying nothing (2).

--- a/frontends/shottino/docs/CALLS.md
+++ b/frontends/shottino/docs/CALLS.md
@@ -587,7 +587,22 @@ visible on the next frame drawn.
 The tile map is adopted **all or nothing**. A cell that does not fit the
 frame it claims to belong to would sample somebody else's pixels, so a
 line that fails validation leaves the previous grid in place: a stale
-picture beats a mislabelled one.
+picture beats a mislabelled one. The refusal is reported in the call
+window — a grid that quietly stops following the call is indistinguishable
+from the video breaking.
+
+An **empty value** is not a refusal. It is how the helper says nobody is
+sending a picture any more, published when it stops the decoder, and the
+grid really does go away:
+
+```
+{"event":"tiles","value":""}
+```
+
+Those two outcomes are opposite instructions to the reader, so
+`call_tiles_parse` answers three ways — negative for refused, zero for an
+empty grid, positive for the tile count. They used to share `0`, and that
+is what let one malformed line blank a working picture.
 
 The filter graph (`media_mix_filter`) and the grid are both pure
 functions and unit-tested; the graph was additionally verified by

--- a/frontends/shottino/shottino.c
+++ b/frontends/shottino/shottino.c
@@ -3542,29 +3542,48 @@ static bool call_ring_parse(const char *word, enum call_ring_policy *out) {
  * kind of bug that gets believed.
  *
  * All or nothing: a line that does not parse cleanly leaves the caller
- * with the grid it already had rather than a half-updated one. Returns
- * the tile count, or 0. */
+ * with the grid it already had rather than a half-updated one.
+ *
+ * THREE outcomes, not two, because "refused" and "nobody is sending a
+ * picture" are opposite instructions to the caller and both used to
+ * come back as 0:
+ *
+ *   < 0  refused — keep the grid you have, this line means nothing
+ *   = 0  a grid with no cells: everybody's camera is off. The helper
+ *        says this with an empty value when it stops the decoder, and
+ *        it is a real update — the caller CLEARS
+ *   > 0  the tile count, and only then are *frame_w / *frame_h written
+ *
+ * Collapsing those two into 0 is what let a malformed line blank the
+ * picture: the caller could not tell "there is nothing to draw" from
+ * "I could not read this". */
 static int call_tiles_parse(const char *value, int *frame_w, int *frame_h, struct call_tile *out,
                             int max) {
-    if (!value || !frame_w || !frame_h || !out || max <= 0) return 0;
+    if (!value || !frame_w || !frame_h || !out || max <= 0) return -1;
+    /* An empty value is how the helper reports that it stopped the
+     * decoder because nobody is publishing (call/main.c video_retile).
+     * Not a truncation — an instruction. */
+    if (!value[0]) return 0;
     int fw = 0, fh = 0, used = 0;
-    if (sscanf(value, "%dx%d%n", &fw, &fh, &used) != 2 || fw <= 0 || fh <= 0) return 0;
+    if (sscanf(value, "%dx%d%n", &fw, &fh, &used) != 2 || fw <= 0 || fh <= 0) return -1;
     const char *p = value + used;
+    /* The same empty grid, spelled with the frame it would have had. */
+    if (strcmp(p, ";") == 0) return 0;
     int n = 0;
     while (*p == ';' && n < max) {
         struct call_tile t;
         int adv = 0;
-        if (sscanf(p, ";%d,%d,%d,%d,%d%n", &t.slot, &t.x, &t.y, &t.w, &t.h, &adv) != 5) return 0;
+        if (sscanf(p, ";%d,%d,%d,%d,%d%n", &t.slot, &t.x, &t.y, &t.w, &t.h, &adv) != 5) return -1;
         /* A cell outside the frame it claims to be part of would sample
          * somebody else's pixels, or none. Refuse the whole line. */
-        if (t.slot < 0 || t.slot >= CALL_MAX_PEERS) return 0;
+        if (t.slot < 0 || t.slot >= CALL_MAX_PEERS) return -1;
         if (t.w <= 0 || t.h <= 0 || t.x < 0 || t.y < 0 || t.x + t.w > fw || t.y + t.h > fh)
-            return 0;
+            return -1;
         out[n++] = t;
         p += adv;
     }
-    if (*p) return 0; /* trailing junk: the line was not what we think */
-    if (n == 0) return 0;
+    if (*p) return -1; /* trailing junk: the line was not what we think */
+    if (n == 0) return -1; /* a frame size and nothing after it: truncated */
     *frame_w = fw;
     *frame_h = fh;
     return n;
@@ -14650,6 +14669,63 @@ static void *call_frame_main(void *arg) {
     return NULL;
 }
 
+/* One line of the helper's event stream, applied.
+ *
+ * Split out of the reader thread so the thing that DECIDES — which
+ * grid is adopted, which one is refused — can be driven from a test
+ * with the helper's real output. A thread reading a pipe cannot be
+ * asserted about; this can. */
+static void call_event_apply(struct app *app, const char *line) {
+    if (!line[0] || line[0] == '#') return; /* a --verbose note */
+    char event[64] = "", value[512] = "";
+    json_top_string(line, strlen(line), "event", event, sizeof(event));
+    if (!json_top_string(line, strlen(line), "value", value, sizeof(value)))
+        json_top_string(line, strlen(line), "message", value, sizeof(value));
+    if (strcmp(event, "error") == 0) log_line(app, "call: %s", value);
+    else if (strcmp(event, "state") == 0) log_line(app, "call: %s", value);
+    else if (strcmp(event, "media") == 0) log_line(app, "call: carrying %s", value);
+    else if (strcmp(event, "closed") == 0) log_line(app, "call: ended");
+    else if (strcmp(event, "tiles") == 0) {
+        /* The grid changed: somebody started or stopped sending a
+         * picture. Adopted wholesale or not at all — a half-applied
+         * grid draws faces under the wrong names.
+         *
+         * Zeroed at declaration, not merely filled by the parser: the
+         * whole array is copied below, so the cells PAST the tile count
+         * are copied too, and on a refusal the parser writes none of
+         * them. Every reader gates on `tile_count` today, which makes
+         * uninitialised stack in there harmless by coincidence rather
+         * than by design. */
+        struct call_tile tiles[CALL_MAX_PEERS] = {0};
+        int fw = 0, fh = 0;
+        int n = call_tiles_parse(value, &fw, &fh, tiles, CALL_MAX_PEERS);
+        /* REFUSED. The contract is the caller keeps what it had, and
+         * blanking the grid is not keeping it — a truncated pipe write
+         * mid-call would black out a working picture. Said out loud
+         * because a grid that silently stops following the call is the
+         * kind of thing nobody reports: they just say the video broke. */
+        if (n < 0) {
+            log_line(app, "call: refused a malformed tile grid — keeping the last one");
+            return;
+        }
+        pthread_mutex_lock(&app->lock);
+        memcpy(app->call_live.tiles, tiles, sizeof(tiles));
+        app->call_live.tile_count = n;
+        app->call_live.frame_w = fw;
+        app->call_live.frame_h = fh;
+        /* Keep looking at the same PERSON across a re-grid where we
+         * can: the cell they occupy moves when the set changes, and
+         * following the index instead would silently swap who you
+         * were watching. */
+        int keep = 0;
+        for (int i = 0; i < n; i++)
+            if (tiles[i].slot == app->call_live.focus_slot) keep = i;
+        app->call_live.focus = keep;
+        app->call_live.focus_slot = n > 0 ? tiles[keep].slot : -1;
+        pthread_mutex_unlock(&app->lock);
+    }
+}
+
 /* Drain the helper's event stream into the window it belongs to.
  *
  * The helper reports state and failures as JSON lines on stderr; without
@@ -14663,38 +14739,7 @@ static void *call_reader_main(void *arg) {
     char line[1024];
     while (fgets(line, sizeof(line), f)) {
         line[strcspn(line, "\r\n")] = 0;
-        if (!line[0] || line[0] == '#') continue; /* a --verbose note */
-        char event[64] = "", value[512] = "";
-        json_top_string(line, strlen(line), "event", event, sizeof(event));
-        if (!json_top_string(line, strlen(line), "value", value, sizeof(value)))
-            json_top_string(line, strlen(line), "message", value, sizeof(value));
-        if (strcmp(event, "error") == 0) log_line(app, "call: %s", value);
-        else if (strcmp(event, "state") == 0) log_line(app, "call: %s", value);
-        else if (strcmp(event, "media") == 0) log_line(app, "call: carrying %s", value);
-        else if (strcmp(event, "closed") == 0) log_line(app, "call: ended");
-        else if (strcmp(event, "tiles") == 0) {
-            /* The grid changed: somebody started or stopped sending a
-             * picture. Adopted wholesale or not at all — a half-applied
-             * grid draws faces under the wrong names. */
-            struct call_tile tiles[CALL_MAX_PEERS];
-            int fw = 0, fh = 0;
-            int n = call_tiles_parse(value, &fw, &fh, tiles, CALL_MAX_PEERS);
-            pthread_mutex_lock(&app->lock);
-            memcpy(app->call_live.tiles, tiles, sizeof(tiles));
-            app->call_live.tile_count = n;
-            app->call_live.frame_w = fw;
-            app->call_live.frame_h = fh;
-            /* Keep looking at the same PERSON across a re-grid where we
-             * can: the cell they occupy moves when the set changes, and
-             * following the index instead would silently swap who you
-             * were watching. */
-            int keep = 0;
-            for (int i = 0; i < n; i++)
-                if (tiles[i].slot == app->call_live.focus_slot) keep = i;
-            app->call_live.focus = keep;
-            app->call_live.focus_slot = n > 0 ? tiles[keep].slot : -1;
-            pthread_mutex_unlock(&app->lock);
-        }
+        call_event_apply(app, line);
     }
     fclose(f); /* owns err_fd */
     pthread_mutex_lock(&app->lock);

--- a/frontends/shottino/tests/test_windows.c
+++ b/frontends/shottino/tests/test_windows.c
@@ -2168,34 +2168,128 @@ TEST(the_call_tile_map_is_parsed_or_rejected_whole) {
     /* ALL OR NOTHING. A cell that does not fit the frame it claims to
      * belong to would sample somebody else's pixels, so the whole line
      * is refused and the caller keeps the grid it already had — better
-     * a stale picture than a mislabelled one. */
-    CHECK(call_tiles_parse("160x120;0,0,0,80,60;1,100,0,80,60", &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse("160x120;0,0,0,80,200", &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse("160x120;0,-1,0,80,60", &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse("160x120;0,0,0,0,60", &fw, &fh, t, CALL_MAX_PEERS) == 0);
+     * a stale picture than a mislabelled one.
+     *
+     * A refusal is NEGATIVE, not zero. Zero is a real grid with nobody
+     * in it, and the caller must be able to tell the two apart: one
+     * says keep drawing what you had, the other says stop. */
+    CHECK(call_tiles_parse("160x120;0,0,0,80,60;1,100,0,80,60", &fw, &fh, t, CALL_MAX_PEERS) < 0);
+    CHECK(call_tiles_parse("160x120;0,0,0,80,200", &fw, &fh, t, CALL_MAX_PEERS) < 0);
+    CHECK(call_tiles_parse("160x120;0,-1,0,80,60", &fw, &fh, t, CALL_MAX_PEERS) < 0);
+    CHECK(call_tiles_parse("160x120;0,0,0,0,60", &fw, &fh, t, CALL_MAX_PEERS) < 0);
     /* A slot outside the cap would index the nick table past its end. */
-    CHECK(call_tiles_parse("160x120;99,0,0,80,60", &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse("160x120;-1,0,0,80,60", &fw, &fh, t, CALL_MAX_PEERS) == 0);
+    CHECK(call_tiles_parse("160x120;99,0,0,80,60", &fw, &fh, t, CALL_MAX_PEERS) < 0);
+    CHECK(call_tiles_parse("160x120;-1,0,0,80,60", &fw, &fh, t, CALL_MAX_PEERS) < 0);
 
-    /* Malformed in the ways a truncated or reordered line actually is. */
-    CHECK(call_tiles_parse("", &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse("160x120", &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse("160x120;0,0,0,80", &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse("160x120;0,0,0,80,60;junk", &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse("160x120;0,0,0,80,60trailing", &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse("0x0;0,0,0,80,60", &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse(NULL, &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse("160x120;0,0,0,80,60", &fw, &fh, NULL, CALL_MAX_PEERS) == 0);
+    /* Malformed in the ways a truncated or reordered line actually is.
+     * A frame size with nothing after it is a line cut mid-write, not
+     * an empty grid — the helper spells THAT differently, below. */
+    CHECK(call_tiles_parse("160x120", &fw, &fh, t, CALL_MAX_PEERS) < 0);
+    CHECK(call_tiles_parse("160x120;0,0,0,80", &fw, &fh, t, CALL_MAX_PEERS) < 0);
+    CHECK(call_tiles_parse("160x120;0,0,0,80,60;junk", &fw, &fh, t, CALL_MAX_PEERS) < 0);
+    CHECK(call_tiles_parse("160x120;0,0,0,80,60trailing", &fw, &fh, t, CALL_MAX_PEERS) < 0);
+    CHECK(call_tiles_parse("0x0;0,0,0,80,60", &fw, &fh, t, CALL_MAX_PEERS) < 0);
+    CHECK(call_tiles_parse(NULL, &fw, &fh, t, CALL_MAX_PEERS) < 0);
+    CHECK(call_tiles_parse("160x120;0,0,0,80,60", &fw, &fh, NULL, CALL_MAX_PEERS) < 0);
 
     /* An empty grid — everybody turned their camera off — is reported
-     * as none rather than as a parse failure the caller would ignore. */
+     * as none rather than as a parse failure the caller would ignore.
+     * The empty VALUE is the spelling the helper actually emits when it
+     * stops the decoder (call/main.c video_retile); the frame-size-then
+     * -separator form is the same statement with the size still on it. */
+    CHECK(call_tiles_parse("", &fw, &fh, t, CALL_MAX_PEERS) == 0);
     CHECK(call_tiles_parse("160x120;", &fw, &fh, t, CALL_MAX_PEERS) == 0);
 
     /* The frame size is only adopted when the line as a whole was
      * good: a rejected line must not leave half of it applied. */
     fw = fh = 0;
-    CHECK(call_tiles_parse("640x480;0,0,0,999,999", &fw, &fh, t, CALL_MAX_PEERS) == 0);
+    CHECK(call_tiles_parse("640x480;0,0,0,999,999", &fw, &fh, t, CALL_MAX_PEERS) < 0);
     CHECK(fw == 0 && fh == 0);
+}
+
+/* Leave the stack where the tile array is about to live full of
+ * non-zero bytes.
+ *
+ * Only a test needs this: it is the difference between "the array
+ * happened to be zero" and "the array was zeroed". Without it the
+ * uninitialised-tiles check below passes on whatever the previous call
+ * left behind, which on a quiet stack is often zeros — a green that
+ * proves nothing. Sized past the tile array and marked noinline so the
+ * frame is really written and really reused. */
+__attribute__((noinline)) static void dirty_the_stack(void) {
+    volatile unsigned char scratch[sizeof(struct call_tile) * CALL_MAX_PEERS * 4];
+    for (size_t i = 0; i < sizeof(scratch); i++) scratch[i] = 0xAA;
+}
+
+/* The grid the helper publishes is applied WHOLE, or not at all — and
+ * "not at all" means the previous one stays up.
+ *
+ * The parser was written all-or-nothing and says so twice; its only
+ * caller adopted the refusal anyway, so one malformed line — a
+ * truncated pipe write, a re-grid racing a peer leaving — blanked the
+ * video grid mid-call and left it blank until the next good line. The
+ * caller is where the contract is kept or broken, so the caller is what
+ * this drives, through the same JSON the helper writes. */
+TEST(a_refused_grid_leaves_the_last_one_up) {
+    struct app *app = window_app();
+    CHECK(app != NULL);
+    app->call_live.focus_slot = -1;
+
+    /* Two people on camera. */
+    call_event_apply(app, "{\"event\":\"tiles\",\"value\":\"160x120;0,0,0,80,60;2,80,0,80,60\"}");
+    CHECK_LONG(app->call_live.tile_count, 2);
+    CHECK_LONG(app->call_live.frame_w, 160);
+    CHECK_LONG(app->call_live.tiles[1].slot, 2);
+    /* Nobody was being watched, so the first cell takes the focus. */
+    CHECK_LONG(app->call_live.focus_slot, 0);
+
+    /* A cell that does not fit the frame it claims to belong to. The
+     * whole line is refused — and refused means the picture that was
+     * being drawn a moment ago is still being drawn. */
+    size_t before = app->log_count;
+    call_event_apply(app, "{\"event\":\"tiles\",\"value\":\"160x120;0,0,0,80,60;1,100,0,80,60\"}");
+    CHECK_LONG(app->call_live.tile_count, 2);
+    CHECK_LONG(app->call_live.frame_w, 160);
+    CHECK_LONG(app->call_live.frame_h, 120);
+    CHECK_LONG(app->call_live.tiles[1].slot, 2);
+    CHECK_LONG(app->call_live.focus_slot, 0);
+    /* And it is SAID. A grid that quietly stops following the call is
+     * reported as "the video broke", which is unactionable. */
+    CHECK_LONG(app->log_count, before + 1);
+    CHECK(log_has(app, "refused a malformed tile grid"));
+
+    /* Truncated mid-write — the other shape a bad line arrives in. */
+    call_event_apply(app, "{\"event\":\"tiles\",\"value\":\"160x120;0,0,0,80\"}");
+    CHECK_LONG(app->call_live.tile_count, 2);
+    CHECK_LONG(app->call_live.tiles[1].slot, 2);
+
+    /* NOT a refusal: the helper stops the decoder and publishes an
+     * empty value when nobody is sending a picture. That one is an
+     * instruction and the grid really does go away — a guard that
+     * merely kept every zero-tile result would leave two faces labelled
+     * on a frame stream that has stopped. */
+    before = app->log_count;
+    call_event_apply(app, "{\"event\":\"tiles\",\"value\":\"\"}");
+    CHECK_LONG(app->call_live.tile_count, 0);
+    CHECK_LONG(app->call_live.focus_slot, -1);
+    CHECK_LONG(app->log_count, before);
+
+    /* Nothing beyond the tile count is carried in from the stack. Every
+     * reader gates on the count today, so this is not a live bug — it
+     * is uninitialised memory crossing into shared state under a mutex,
+     * which stops being harmless the first time a reader forgets. */
+    dirty_the_stack();
+    call_event_apply(app, "{\"event\":\"tiles\",\"value\":\"160x120;3,0,0,80,60\"}");
+    CHECK_LONG(app->call_live.tile_count, 1);
+    for (int i = 1; i < CALL_MAX_PEERS; i++) {
+        CHECK_LONG(app->call_live.tiles[i].slot, 0);
+        CHECK_LONG(app->call_live.tiles[i].x, 0);
+        CHECK_LONG(app->call_live.tiles[i].y, 0);
+        CHECK_LONG(app->call_live.tiles[i].w, 0);
+        CHECK_LONG(app->call_live.tiles[i].h, 0);
+    }
+
+    free_app(app);
 }
 
 /* A client-local window is never asked about over REST.
@@ -4114,6 +4208,7 @@ int main(void) {
     RUN(notifications_parse_refuse_and_persist);
     RUN(a_configured_setting_survives_save_and_load);
     RUN(the_call_tile_map_is_parsed_or_rejected_whole);
+    RUN(a_refused_grid_leaves_the_last_one_up);
     RUN(a_client_local_window_is_never_fetched_from_the_server);
     RUN(a_conversation_is_remembered_and_rolls_to_fit);
     RUN(the_context_budget_leaves_room_for_the_fixed_parts);


### PR DESCRIPTION
Fixes the contract violation in #760 — and does **not** fix it the way the issue words it, for a reason worth reading before the diff.

## What was verified against the current file

`call_tiles_parse` (`shottino.c:3547`) and its only call site (now `call_event_apply`, formerly inline in `call_reader_main` around `shottino.c:14681`). Both defects were still real:

- No guard on the parse result. A refused line was adopted as count `0`, frame `0x0` — the grid blanked, which is the exact outcome the parser's own comment, the comment three lines above the `memcpy`, and `docs/CALLS.md` all exist to prevent.
- `tiles` was an uninitialised local, and the parser writes nothing to it on its early exits, so the `memcpy` under `app->lock` carried uninitialised stack into `app->call_live.tiles`.

## Why `if (n > 0)` is the wrong fix

The helper publishes `{"event":"tiles","value":""}` when it stops the decoder because nobody is sending a picture — `call/main.c` `video_retile`, the `n == 0` branch. That arrives as the same `0` a malformed line does. A count-only guard would therefore hold the last grid up over a frame stream that has *stopped*: two faces still labelled, nobody on camera.

The root cause is not the missing guard, it is that `0` already meant two opposite things, so no correct guard could be written at the call site. The parser now answers three ways:

- `< 0` — refused. Keep the grid you have.
- `0` — a grid with no cells. Everybody's camera is off; clear.
- `> 0` — the tile count, and only then are `*frame_w` / `*frame_h` written.

A bare frame size (`"640x480"`, nothing after it) stays a **refusal**: it is a line cut mid-write, and the helper never emits one — when `media_grid_layout` refuses, `media_start_video_mix` returns false on `tile_count <= 0` and the helper reports an `error` event instead of a tile-less grid. The empty grid has exactly two spellings, `""` and `"<w>x<h>;"`, both pinned.

## Should a refused line be reported?

**Yes, and it now is** — one line into the call window. Unreported, a grid that silently stops following the call reaches us as "the video broke", which nobody can act on. That is the same failure mode as #758's error strings no branch could reach and #756's over-read no one could observe.

Neither latched nor rate-limited, deliberately: a `tiles` event is emitted when the grid *changes*, not per frame, so the flood a latch would guard against does not exist — and a latch is a per-call field that needs resetting and will drift. The line does **not** echo the payload; the three sibling branches in the same loop already echo helper-controlled text verbatim, and this one had nothing to add by widening that surface.

## The RED was measured, not assumed

The per-line handling moved out of the reader thread into `call_event_apply` so the decision can be driven with the helper's real JSON — a thread blocked in `fgets` on a pipe cannot be asserted about, which is why this call site had no test at all. Five mutations, each applied to the committed tree and run:

| mutation | checks failed |
|---|---|
| drop the refusal guard (the #760 defect, restored) | 9 |
| collapse the parser back to one `0` | 17 |
| drop the `= {0}` on the tiles local | 35 |
| write the guard the way the issue words it (`n <= 0`, old parser) | 17 — three of them the camera-off regression |
| keep the guard, say nothing | 2 |

The zero-init check is the one that could have been a zombie: on a quiet stack an uninitialised array is often already zero, so the test dirties the stack first through a `noinline` frame sized past the tile array. With `= {0}` reverted the assertions come back `0xAAAAAAAA`, so the check is reading real garbage rather than an accidental clean slate.

## Class sweep

One structural twin, latent not live: `admin_verb_run` (`shottino.c:5396`) `memcpy`s an uninitialised `struct admin_field fields[ADMIN_FORM_MAX]` whole into `app->overlay.form`, but it is guarded by `if (nf)` and every reader is bounded by `form_count`. Producer side, `video_retile` (`call/main.c:342`) assigns `media_grid_layout`'s count straight into `c->vmix.tile_count` and leaves `tiles` stale on a refusal — safe for the same reason. No other all-or-nothing parser in `frontends/shottino` has a call site that adopts partial output; ~30 candidates were checked and ruled out (every `wire_*` narrower is guarded, `llm_config_parse` is incremental by design, the rest pre-initialise their out-parameters).

## Gate

`make check` over 15 of the 16 suites locally (`tests/test_keys` needs `<pty.h>`, Linux-only — CI runs all 16): exit 0, 15 suites, `1302 checks passed` in `test_windows`, no new warnings.