### PR TITLE
shottino: union gate for #760, #764 and #758

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -29227,3 +29227,51 @@ because the test dirties the stack first on purpose, since a quiet stack is
 often already zero and would have made that check a green that proves nothing),
 writing the guard the way the issue words it (17, of which three are the
 camera-off regression), and keeping the guard while saying nothing (2).
+## 2026-08-05 — #758: a primitive that cannot fail makes its callers' error handling dead code
+
+`spawn_ffmpeg` in the call helper returned a pid whenever `fork()` succeeded.
+`execvp` failing set the CHILD's exit status to 127 and nothing ever inspected
+it — the only `waitpid`s in the helper are the blocking reaps on the teardown
+path — so all three start functions reported success unconditionally. On a
+machine with no ffmpeg the call connected, the tile map published, the UI drew
+a call window, and the user got silence and a black rectangle with no
+diagnostic anywhere. ffmpeg is an OPT-IN dependency of an opt-in feature, so
+this is the ordinary case rather than an exotic one.
+
+**The callers were already right; the primitive underneath them lied.**
+`media_start_send` closes its socket and returns false on -1, and both mixes
+`return mix->pid > 0`. Three error messages were written for that false branch
+and none of them could be reached. That is the general shape worth naming: a
+function that cannot report failure does not merely lose an error, it converts
+every caller's error handling into unreachable code that reads, in review, as
+though the case were handled.
+
+**The exec gets a channel of its own: an `FD_CLOEXEC` pipe.** A successful
+exec closes the write end, so the parent reads EOF; a failed one leaves the
+child alive to write its errno first, so a non-empty read means the exec
+failed and nothing else does. Chosen over polling `waitpid(WNOHANG)` on the
+supervisor tick for three reasons: it answers at the start, where the callers
+already test a bool (a tick poll has no bool and would need new messages,
+leaving the existing ones dead — i.e. not fixing the defect); it cannot
+confuse "ffmpeg is not installed" with "ffmpeg died at second thirty"; and it
+is testable without a call, because PATH decides the outcome, whereas the tick
+lives in `call/main.c`, which no test links.
+
+**The boundary is stated, not implied.** An ffmpeg that starts and then dies —
+a device that will not open, a filter graph it refuses — is still invisible.
+The header used to claim "a failure shows as the process dying, which the
+caller sees" over code where nobody looked; the replacement says what is
+detected and what is not, because a comment promising a guarantee nobody
+implements is the bug, not the documentation of one (the same lesson as #754's
+job comment promising `-Werror` over a file it never compiled).
+
+**Two mutations, two different lessons.** Deleting the reap left every check
+green — and an unreaped failure is one zombie per supervisor tick for the
+length of the call, since the tick rebuilds both mixes, so the suite now
+asserts `waitpid(-1, WNOHANG) == ECHILD` after a failed start. And dropping
+`FD_CLOEXEC` from the write end should have hung the parent's read forever;
+the suite passed in one second, because the fake ffmpeg (`exec sleep 30` under
+a PATH holding only the scratch directory) could not find `sleep` and died
+instantly, closing the write end and handing the parent a clean EOF by
+accident. A positive control that admits a corpse is not a control: it now
+sets its own PATH and asserts the child is RUNNING, not merely forked.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -29161,3 +29161,69 @@ lives in the CALLER's judgement, not in the context function: `revoke_session/1`
 always returns the typed error, and the plug decides to continue. Absorbing
 inside the context would have taken the choice away from logout, which needs
 it.
+
+## 2026-08-05 — #760: a refusal and an empty answer are not the same zero
+
+`call_tiles_parse` decides which rectangle of the composited call frame
+belongs to which person, and it is deliberately all-or-nothing: a line that
+does not parse cleanly is refused whole, because a half-applied grid draws
+faces under the wrong names. That contract is stated three times — in the
+function's own comment, in the comment three lines above the `memcpy` that
+consumed it, and in `frontends/shottino/docs/CALLS.md`. The single call site
+did the opposite of all three: it adopted the refusal, count `0` and frame
+`0x0`, so one malformed line — a truncated pipe write, a re-grid racing a peer
+leaving — blanked the video grid mid-call and left it blank until the next good
+line arrived.
+
+**The fix the issue proposed would have introduced a second bug.** `if (n > 0)`
+reads as the obvious guard, and it is wrong, because `0` already had a second
+meaning: the helper publishes `{"event":"tiles","value":""}` when it stops the
+decoder because nobody is sending a picture (`call/main.c` `video_retile`), and
+that is an INSTRUCTION, not a failure. A count-only guard would hold the last
+two faces labelled over a frame stream that has stopped. The root cause is not
+the missing guard — it is that a lossy return value made the guard unwriteable:
+the caller could not distinguish "there is nothing to draw" from "I could not
+read this". So the parser now answers three ways (`< 0` refused, `0` an empty
+grid, `> 0` the tile count) and the caller does the opposite thing in each.
+
+**A bare frame size stays a refusal.** `"640x480"` with nothing after it is a
+line cut mid-write, and the helper never emits one: when `media_grid_layout`
+refuses, `media_start_video_mix` returns false on `tile_count <= 0` and the
+helper reports an `error` event instead of a tile-less grid. The empty grid has
+exactly two spellings, `""` and `"<w>x<h>;"`, and both are pinned.
+
+**The refusal is now said out loud.** One line into the call window, on a path
+that already narrates every other thing the helper reports. Unreported, a grid
+that silently stops following the call reaches us as "the video broke", which
+is unactionable — the same failure mode as #758's error strings that no branch
+could reach and #756's over-read that no one could observe. Not rate-limited
+and not latched: a `tiles` event is emitted when the grid CHANGES, not per
+frame, so the flood this would guard against does not exist, and a latch is a
+per-call field that needs resetting and will drift.
+
+**Second defect, same path: uninitialised stack into shared state.** The
+`tiles` local was uninitialised and the parser writes nothing to it on its
+early exits, so the `memcpy` under `app->lock` carried whatever the stack held
+— and still would past the tile count on a GOOD line, since the whole array is
+copied either way. Zeroed at declaration. It was harmless only because every
+reader gates on `tile_count`, which is a coincidence rather than a design.
+
+**The class was swept.** One structural twin: `admin_verb_run` copies an
+uninitialised `struct admin_field fields[ADMIN_FORM_MAX]` whole into
+`app->overlay.form` — but it is guarded by `if (nf)` and every reader is
+bounded by `form_count`, so it is latent, not live. The producer-side
+`video_retile` assigns `media_grid_layout`'s count straight into
+`c->vmix.tile_count` and leaves `tiles` stale on a refusal, which is safe for
+the same reason: the count gates every reader. No other all-or-nothing parser
+in `frontends/shottino` has a call site that adopts partial output.
+
+**Testability was the reason this site had none.** The per-line handling lived
+inside the reader thread, and a thread blocked in `fgets` on a pipe cannot be
+asserted about; it now lives in `call_event_apply`, driven from the test with
+the helper's real JSON. The RED was measured against five mutations rather than
+assumed: dropping the guard (9 checks), collapsing the parser back to one `0`
+(17), dropping the zero-init (35 — the assertions come back `0xAAAAAAAA`,
+because the test dirties the stack first on purpose, since a quiet stack is
+often already zero and would have made that check a green that proves nothing),
+writing the guard the way the issue words it (17, of which three are the
+camera-off regression), and keeping the guard while saying nothing (2).

--- a/frontends/shottino/Makefile
+++ b/frontends/shottino/Makefile
@@ -47,7 +47,7 @@ OBJS := shottino.o json.o wire.o alias.o mirc.o termcolor.o http.o media.o ircd.
 # reaches, which is the drawing primitives and nothing else. Do not trust
 # this net for changes elsewhere in that file; add a test or reason about
 # the path by hand.
-TESTS := tests/test_llm tests/test_ws tests/test_json tests/test_wire tests/test_alias tests/test_mirc tests/test_termcolor tests/test_http tests/test_media tests/test_whip tests/test_callmedia tests/test_callnote tests/test_layout tests/test_keys tests/test_ircd tests/test_commands tests/test_windows
+TESTS := tests/test_llm tests/test_ws tests/test_json tests/test_wire tests/test_alias tests/test_mirc tests/test_termcolor tests/test_http tests/test_media tests/test_whip tests/test_callmedia tests/test_callnote tests/test_layout tests/test_keys tests/test_ircd tests/test_commands tests/test_windows tests/test_call
 SANITIZE ?= -fsanitize=address,undefined -fno-omit-frame-pointer
 TEST_CFLAGS := -std=c11 -Wall -Wextra -Wpedantic -O1 -g $(SANITIZE)
 
@@ -148,6 +148,14 @@ tests/test_commands: tests/test_commands.c tests/test.h shottino.c json.c wire.c
 # question every other bug in the sidebar has turned out to be.
 tests/test_windows: tests/test_windows.c tests/test.h shottino.c json.c wire.c alias.c mirc.c termcolor.c http.c media.c ircd.c ws.c llm.c
 	$(CC) $(CPPFLAGS) $(TEST_CFLAGS) $(CFLAGS_DEPS) -o $@ tests/test_windows.c json.c wire.c alias.c mirc.c termcolor.c http.c media.c ircd.c ws.c llm.c $(LDLIBS)
+
+# test_call is the only suite linked against BOTH binaries: it compiles
+# shottino.c for the call helpers and links call/media.c so the codec
+# word shottino puts in the helper's argv can be handed to the helper's
+# own parser. Asserting that word against a literal here would only say
+# what this side already believes.
+tests/test_call: tests/test_call.c tests/test.h shottino.c call/media.c call/media.h json.c wire.c alias.c mirc.c termcolor.c http.c media.c ircd.c ws.c llm.c
+	$(CC) $(CPPFLAGS) $(TEST_CFLAGS) $(CFLAGS_DEPS) -o $@ tests/test_call.c call/media.c json.c wire.c alias.c mirc.c termcolor.c http.c media.c ircd.c ws.c llm.c $(LDLIBS)
 
 tests/test_keys: tests/test_keys.c tests/test.h shottino.c json.c wire.c alias.c mirc.c termcolor.c http.c media.c ircd.c ws.c llm.c
 	$(CC) $(CPPFLAGS) $(TEST_CFLAGS) $(CFLAGS_DEPS) -o $@ tests/test_keys.c json.c wire.c alias.c mirc.c termcolor.c http.c media.c ircd.c ws.c llm.c $(LDLIBS) -lutil

--- a/frontends/shottino/call/media.c
+++ b/frontends/shottino/call/media.c
@@ -74,16 +74,47 @@ static void split_source(const char *source, const char **fmt, const char **inpu
 }
 
 /* fork+exec ffmpeg with stdout wired to `stdout_fd` (or /dev/null) and
- * stderr discarded.
+ * stderr discarded. Returns -1 if the child could not be started AT ALL,
+ * having reaped it.
  *
  * ffmpeg's own diagnostics are dropped rather than merged into stderr:
  * stderr here is the JSON event stream shottino parses, and ffmpeg's
- * progress lines would be garbage in it. A failure shows as the process
- * dying, which the caller sees. */
+ * progress lines would be garbage in it. Which leaves the exec itself
+ * with nowhere to report from — so it gets a channel of its own.
+ *
+ * THE CLOEXEC PIPE IS THE DETECTOR. A successful exec closes the write
+ * end, so the parent reads EOF and knows only that the program started;
+ * a failed one leaves the child alive to write its errno first, so a
+ * non-empty read means the exec failed and nothing else does. The read
+ * blocks for exactly as long as the exec takes.
+ *
+ * This is not decoration. Without it fork() succeeding IS the answer,
+ * `execvp` failing sets an exit status of 127 that nobody in this
+ * program ever waits for, and every caller's "cannot start …" message
+ * hangs off a branch that cannot be reached — a machine with no ffmpeg
+ * gets a call window, silence, a black rectangle and no diagnostic
+ * anywhere. shottino already holds this line elsewhere: call_helper_path
+ * says "not installed" BEFORE forking, because a child that exits 127
+ * into a pipe tells nobody anything.
+ *
+ * What it does NOT cover: an ffmpeg that starts and then dies — a device
+ * that will not open, a filter graph it refuses. That is a different
+ * failure with a different lifetime (it can happen at any moment, not
+ * just at the start) and it is not detected here or anywhere else. */
 static pid_t spawn_ffmpeg(char *const argv[], int stdout_fd) {
+    int err_fds[2];
+    if (pipe(err_fds) != 0) return -1;
+    fcntl(err_fds[0], F_SETFD, FD_CLOEXEC);
+    fcntl(err_fds[1], F_SETFD, FD_CLOEXEC);
+
     pid_t pid = fork();
-    if (pid < 0) return -1;
+    if (pid < 0) {
+        close(err_fds[0]);
+        close(err_fds[1]);
+        return -1;
+    }
     if (pid == 0) {
+        close(err_fds[0]);
         int devnull = open("/dev/null", O_RDWR);
         if (devnull >= 0) {
             dup2(devnull, STDIN_FILENO);
@@ -92,9 +123,25 @@ static pid_t spawn_ffmpeg(char *const argv[], int stdout_fd) {
             if (devnull > STDERR_FILENO) close(devnull);
         }
         execvp("ffmpeg", argv);
+        int failed = errno;
+        (void)!write(err_fds[1], &failed, sizeof(failed));
         _exit(127);
     }
-    return pid;
+    close(err_fds[1]);
+
+    int child_errno = 0;
+    ssize_t got;
+    do {
+        got = read(err_fds[0], &child_errno, sizeof(child_errno));
+    } while (got < 0 && errno == EINTR);
+    close(err_fds[0]);
+    if (got <= 0) return pid;
+
+    /* Reaped here rather than left to the teardown: the caller is about
+     * to be told this leg does not exist, and a leg that does not exist
+     * has nobody to wait for it. */
+    while (waitpid(pid, NULL, 0) < 0 && errno == EINTR) {}
+    return -1;
 }
 
 bool media_start_send(struct media_leg *leg, const struct media_config *cfg, bool video) {

--- a/frontends/shottino/call/media.h
+++ b/frontends/shottino/call/media.h
@@ -253,7 +253,15 @@ int media_bind_loopback(int *port_out);
 
 /* Start capturing and packetising. The caller pumps `leg->fd` and hands
  * each datagram to the track. Returns false and leaves the leg stopped
- * if ffmpeg cannot be started. */
+ * if ffmpeg cannot be started.
+ *
+ * WHICH INCLUDES AN FFMPEG THAT IS NOT INSTALLED, and that is the whole
+ * value of the bool: a fork that succeeds says nothing about the exec
+ * that follows it, so this used to return true on a machine with no
+ * ffmpeg and the caller's error message was unreachable code. Every
+ * start function here answers the same question the same way — see
+ * spawn_ffmpeg for how the exec reports back, and for the failure it
+ * still does not cover (a child that starts and dies later). */
 bool media_start_send(struct media_leg *leg, const struct media_config *cfg, bool video);
 
 /* Forward one RTP packet a track delivered to the decoder. */

--- a/frontends/shottino/docs/CALLS.md
+++ b/frontends/shottino/docs/CALLS.md
@@ -226,7 +226,7 @@ unmuting take as long as a device open.
 transport libdatachannel owns: **118 RTP packets captured and forwarded →
 117 frames of rgb24 decoded**, and the audio leg producing Opus RTP.
 
-Five bugs that cost real time and are worth not repeating:
+Six bugs that cost real time and are worth not repeating:
 
 - **`-framerate` / `-video_size` are demuxer-specific.** v4l2 takes them;
   lavfi refuses them outright and the capture dies with its stderr
@@ -247,6 +247,18 @@ Five bugs that cost real time and are worth not repeating:
   blank window.
 - **The receive SDP cannot be unlinked right after the spawn.** The child
   may not have exec'd, and the decoder then reads nothing, silently.
+- **A fork that succeeds says nothing about the exec.** `spawn_ffmpeg`
+  returned a pid whenever `fork()` did, so a host with no ffmpeg opened a
+  call window, published a tile map, and produced silence and a black
+  rectangle: `execvp` failing only set the CHILD's exit status to 127,
+  and the only `waitpid`s in the helper are on the teardown path. Every
+  *"cannot start …"* message here hangs off the false branch those start
+  functions were not returning — the diagnostics existed and were
+  unreachable code. The exec now reports back over an `FD_CLOEXEC` pipe:
+  a successful one closes the write end and the parent reads EOF, a
+  failed one writes its errno first. What that does NOT catch — an
+  ffmpeg that starts and then dies, a device that will not open — is
+  still invisible, and is documented as such rather than implied away.
 
 The offer it generates, captured against a stub endpoint:
 

--- a/frontends/shottino/docs/CALLS.md
+++ b/frontends/shottino/docs/CALLS.md
@@ -587,7 +587,22 @@ visible on the next frame drawn.
 The tile map is adopted **all or nothing**. A cell that does not fit the
 frame it claims to belong to would sample somebody else's pixels, so a
 line that fails validation leaves the previous grid in place: a stale
-picture beats a mislabelled one.
+picture beats a mislabelled one. The refusal is reported in the call
+window — a grid that quietly stops following the call is indistinguishable
+from the video breaking.
+
+An **empty value** is not a refusal. It is how the helper says nobody is
+sending a picture any more, published when it stops the decoder, and the
+grid really does go away:
+
+```
+{"event":"tiles","value":""}
+```
+
+Those two outcomes are opposite instructions to the reader, so
+`call_tiles_parse` answers three ways — negative for refused, zero for an
+empty grid, positive for the tile count. They used to share `0`, and that
+is what let one malformed line blank a working picture.
 
 The filter graph (`media_mix_filter`) and the grid are both pure
 functions and unit-tested; the graph was additionally verified by

--- a/frontends/shottino/shottino.c
+++ b/frontends/shottino/shottino.c
@@ -3542,29 +3542,48 @@ static bool call_ring_parse(const char *word, enum call_ring_policy *out) {
  * kind of bug that gets believed.
  *
  * All or nothing: a line that does not parse cleanly leaves the caller
- * with the grid it already had rather than a half-updated one. Returns
- * the tile count, or 0. */
+ * with the grid it already had rather than a half-updated one.
+ *
+ * THREE outcomes, not two, because "refused" and "nobody is sending a
+ * picture" are opposite instructions to the caller and both used to
+ * come back as 0:
+ *
+ *   < 0  refused — keep the grid you have, this line means nothing
+ *   = 0  a grid with no cells: everybody's camera is off. The helper
+ *        says this with an empty value when it stops the decoder, and
+ *        it is a real update — the caller CLEARS
+ *   > 0  the tile count, and only then are *frame_w / *frame_h written
+ *
+ * Collapsing those two into 0 is what let a malformed line blank the
+ * picture: the caller could not tell "there is nothing to draw" from
+ * "I could not read this". */
 static int call_tiles_parse(const char *value, int *frame_w, int *frame_h, struct call_tile *out,
                             int max) {
-    if (!value || !frame_w || !frame_h || !out || max <= 0) return 0;
+    if (!value || !frame_w || !frame_h || !out || max <= 0) return -1;
+    /* An empty value is how the helper reports that it stopped the
+     * decoder because nobody is publishing (call/main.c video_retile).
+     * Not a truncation — an instruction. */
+    if (!value[0]) return 0;
     int fw = 0, fh = 0, used = 0;
-    if (sscanf(value, "%dx%d%n", &fw, &fh, &used) != 2 || fw <= 0 || fh <= 0) return 0;
+    if (sscanf(value, "%dx%d%n", &fw, &fh, &used) != 2 || fw <= 0 || fh <= 0) return -1;
     const char *p = value + used;
+    /* The same empty grid, spelled with the frame it would have had. */
+    if (strcmp(p, ";") == 0) return 0;
     int n = 0;
     while (*p == ';' && n < max) {
         struct call_tile t;
         int adv = 0;
-        if (sscanf(p, ";%d,%d,%d,%d,%d%n", &t.slot, &t.x, &t.y, &t.w, &t.h, &adv) != 5) return 0;
+        if (sscanf(p, ";%d,%d,%d,%d,%d%n", &t.slot, &t.x, &t.y, &t.w, &t.h, &adv) != 5) return -1;
         /* A cell outside the frame it claims to be part of would sample
          * somebody else's pixels, or none. Refuse the whole line. */
-        if (t.slot < 0 || t.slot >= CALL_MAX_PEERS) return 0;
+        if (t.slot < 0 || t.slot >= CALL_MAX_PEERS) return -1;
         if (t.w <= 0 || t.h <= 0 || t.x < 0 || t.y < 0 || t.x + t.w > fw || t.y + t.h > fh)
-            return 0;
+            return -1;
         out[n++] = t;
         p += adv;
     }
-    if (*p) return 0; /* trailing junk: the line was not what we think */
-    if (n == 0) return 0;
+    if (*p) return -1; /* trailing junk: the line was not what we think */
+    if (n == 0) return -1; /* a frame size and nothing after it: truncated */
     *frame_w = fw;
     *frame_h = fh;
     return n;
@@ -14706,6 +14725,63 @@ static void *call_frame_main(void *arg) {
     return NULL;
 }
 
+/* One line of the helper's event stream, applied.
+ *
+ * Split out of the reader thread so the thing that DECIDES — which
+ * grid is adopted, which one is refused — can be driven from a test
+ * with the helper's real output. A thread reading a pipe cannot be
+ * asserted about; this can. */
+static void call_event_apply(struct app *app, const char *line) {
+    if (!line[0] || line[0] == '#') return; /* a --verbose note */
+    char event[64] = "", value[512] = "";
+    json_top_string(line, strlen(line), "event", event, sizeof(event));
+    if (!json_top_string(line, strlen(line), "value", value, sizeof(value)))
+        json_top_string(line, strlen(line), "message", value, sizeof(value));
+    if (strcmp(event, "error") == 0) log_line(app, "call: %s", value);
+    else if (strcmp(event, "state") == 0) log_line(app, "call: %s", value);
+    else if (strcmp(event, "media") == 0) log_line(app, "call: carrying %s", value);
+    else if (strcmp(event, "closed") == 0) log_line(app, "call: ended");
+    else if (strcmp(event, "tiles") == 0) {
+        /* The grid changed: somebody started or stopped sending a
+         * picture. Adopted wholesale or not at all — a half-applied
+         * grid draws faces under the wrong names.
+         *
+         * Zeroed at declaration, not merely filled by the parser: the
+         * whole array is copied below, so the cells PAST the tile count
+         * are copied too, and on a refusal the parser writes none of
+         * them. Every reader gates on `tile_count` today, which makes
+         * uninitialised stack in there harmless by coincidence rather
+         * than by design. */
+        struct call_tile tiles[CALL_MAX_PEERS] = {0};
+        int fw = 0, fh = 0;
+        int n = call_tiles_parse(value, &fw, &fh, tiles, CALL_MAX_PEERS);
+        /* REFUSED. The contract is the caller keeps what it had, and
+         * blanking the grid is not keeping it — a truncated pipe write
+         * mid-call would black out a working picture. Said out loud
+         * because a grid that silently stops following the call is the
+         * kind of thing nobody reports: they just say the video broke. */
+        if (n < 0) {
+            log_line(app, "call: refused a malformed tile grid — keeping the last one");
+            return;
+        }
+        pthread_mutex_lock(&app->lock);
+        memcpy(app->call_live.tiles, tiles, sizeof(tiles));
+        app->call_live.tile_count = n;
+        app->call_live.frame_w = fw;
+        app->call_live.frame_h = fh;
+        /* Keep looking at the same PERSON across a re-grid where we
+         * can: the cell they occupy moves when the set changes, and
+         * following the index instead would silently swap who you
+         * were watching. */
+        int keep = 0;
+        for (int i = 0; i < n; i++)
+            if (tiles[i].slot == app->call_live.focus_slot) keep = i;
+        app->call_live.focus = keep;
+        app->call_live.focus_slot = n > 0 ? tiles[keep].slot : -1;
+        pthread_mutex_unlock(&app->lock);
+    }
+}
+
 /* Drain the helper's event stream into the window it belongs to.
  *
  * The helper reports state and failures as JSON lines on stderr; without
@@ -14719,38 +14795,7 @@ static void *call_reader_main(void *arg) {
     char line[1024];
     while (fgets(line, sizeof(line), f)) {
         line[strcspn(line, "\r\n")] = 0;
-        if (!line[0] || line[0] == '#') continue; /* a --verbose note */
-        char event[64] = "", value[512] = "";
-        json_top_string(line, strlen(line), "event", event, sizeof(event));
-        if (!json_top_string(line, strlen(line), "value", value, sizeof(value)))
-            json_top_string(line, strlen(line), "message", value, sizeof(value));
-        if (strcmp(event, "error") == 0) log_line(app, "call: %s", value);
-        else if (strcmp(event, "state") == 0) log_line(app, "call: %s", value);
-        else if (strcmp(event, "media") == 0) log_line(app, "call: carrying %s", value);
-        else if (strcmp(event, "closed") == 0) log_line(app, "call: ended");
-        else if (strcmp(event, "tiles") == 0) {
-            /* The grid changed: somebody started or stopped sending a
-             * picture. Adopted wholesale or not at all — a half-applied
-             * grid draws faces under the wrong names. */
-            struct call_tile tiles[CALL_MAX_PEERS];
-            int fw = 0, fh = 0;
-            int n = call_tiles_parse(value, &fw, &fh, tiles, CALL_MAX_PEERS);
-            pthread_mutex_lock(&app->lock);
-            memcpy(app->call_live.tiles, tiles, sizeof(tiles));
-            app->call_live.tile_count = n;
-            app->call_live.frame_w = fw;
-            app->call_live.frame_h = fh;
-            /* Keep looking at the same PERSON across a re-grid where we
-             * can: the cell they occupy moves when the set changes, and
-             * following the index instead would silently swap who you
-             * were watching. */
-            int keep = 0;
-            for (int i = 0; i < n; i++)
-                if (tiles[i].slot == app->call_live.focus_slot) keep = i;
-            app->call_live.focus = keep;
-            app->call_live.focus_slot = n > 0 ? tiles[keep].slot : -1;
-            pthread_mutex_unlock(&app->lock);
-        }
+        call_event_apply(app, line);
     }
     fclose(f); /* owns err_fd */
     pthread_mutex_lock(&app->lock);

--- a/frontends/shottino/tests/test_call.c
+++ b/frontends/shottino/tests/test_call.c
@@ -1,0 +1,415 @@
+/* test_call — the helpers that decide WHO is in a call.
+ *
+ * Everything here is on the path from "two people typed /call" to "two
+ * processes publish to the same URL". The failure mode they share is
+ * silence: nothing errors, both ends connect, and each hears nobody —
+ * because the two ends derived different paths, or worse, because two
+ * different people derived the SAME one and landed in one room.
+ *
+ * `call_path_nick` is the sharp one. Its own comment says ESCAPE, do not
+ * squash, and that is not style: mapping `[ ] \ ` ^ { | }` to `_` would
+ * make `foo[1]` and `foo{1}` one room. It is the same invariant the rest
+ * of this tree spells `canonical_target` — only KEYs fold, the fold is
+ * ASCII `A-Z` and nothing else, and a fold one byte too wide merges two
+ * identities without saying so.
+ *
+ * The call helpers already covered by test_windows (invite build/split,
+ * the peer list, the ring policy) stay there; this suite is the
+ * identity-and-exec family that had no test at all.
+ *
+ * Like test_layout, test_commands and test_windows, it compiles
+ * shottino.c itself — these are static functions in the app binary. It
+ * also links call/media.c, which is the OTHER binary: the codec word
+ * shottino puts in the helper's argv is only correct if the helper's own
+ * parser accepts it, and no assertion on shottino alone can say that. */
+#define main shottino_main_unused
+#include "../shottino.c"
+#undef main
+
+#include "../call/media.h"
+#include "test.h"
+
+#include <sys/stat.h>
+
+static struct app *call_app(const char *nick) {
+    struct app *app = calloc(1, sizeof(*app));
+    if (!app) return NULL;
+    pthread_mutex_init(&app->lock, NULL);
+    snprintf(app->subject, sizeof(app->subject), "user:%s", nick);
+    struct network *n = &app->networks[app->network_count++];
+    snprintf(n->slug, sizeof(n->slug), "azzurra");
+    snprintf(n->nick, sizeof(n->nick), "%s", nick);
+    n->id = 1;
+    return app;
+}
+
+static void call_app_free(struct app *app) {
+    pthread_mutex_destroy(&app->lock);
+    free(app);
+}
+
+/* ── the path segment ──────────────────────────────────────────────── */
+
+TEST(a_nick_folds_to_one_path_and_two_people_never_fold_to_one) {
+    char out[128];
+
+    /* FOLD, because IRC says `Alice` and `alice` are one person and two
+     * paths would be two halves of one conversation. */
+    call_path_nick("Alice", out, sizeof(out));
+    CHECK_STR(out, "alice");
+    call_path_nick("VJT", out, sizeof(out));
+    CHECK_STR(out, "vjt");
+
+    /* ESCAPE, do not squash. Every character IRC lets into a nick and a
+     * URL does not, spelled out: a `_` for each of these would be
+     * simpler and would put all of them in one room. */
+    static const struct {
+        const char *nick;
+        const char *path;
+    } specials[] = {
+        { "foo[1]", "foo%5b1%5d" }, { "foo{1}", "foo%7b1%7d" }, { "a\\b", "a%5cb" },
+        { "a`b", "a%60b" },         { "a^b", "a%5eb" },         { "a|b", "a%7cb" },
+        { "a-b_c.d~e", "a-b_c.d~e" },
+    };
+    for (size_t i = 0; i < sizeof(specials) / sizeof(specials[0]); i++) {
+        call_path_nick(specials[i].nick, out, sizeof(out));
+        CHECK_STR(out, specials[i].path);
+    }
+
+    /* The pair the comment names, stated as the thing that must not
+     * happen rather than as two encodings that happen to differ. On
+     * CASEMAPPING=ascii these are two people (#525), and the ircd will
+     * happily seat both in the channel the call was started from. */
+    char bracket[64], brace[64];
+    call_path_nick("foo[1]", bracket, sizeof(bracket));
+    call_path_nick("foo{1}", brace, sizeof(brace));
+    CHECK(strcmp(bracket, brace) != 0);
+
+    /* Non-ASCII is bytes, and the fold is `A-Z` — not tolower(), whose
+     * answer for a byte above 127 is the locale's business. Two nicks
+     * that differ only in a non-ASCII case pair stay two nicks, and a
+     * fold wide enough to merge them here would merge them in a room. */
+    char lower[64], upper[64];
+    call_path_nick("caf\xc3\xa9", lower, sizeof(lower)); /* café */
+    call_path_nick("CAF\xc3\x89", upper, sizeof(upper)); /* CAFÉ */
+    CHECK_STR(lower, "caf%c3%a9");
+    CHECK_STR(upper, "caf%c3%89");
+    CHECK(strcmp(lower, upper) != 0);
+
+    /* A nick we never had is an empty segment, not a crash: the call
+     * site passes `query ? channel : ""` for the far end of a channel
+     * call. */
+    call_path_nick("", out, sizeof(out));
+    CHECK_STR(out, "");
+    call_path_nick(NULL, out, sizeof(out));
+    CHECK_STR(out, "");
+}
+
+/* Every `%XX` in `s` is complete. A segment cut mid-escape is not a
+ * shorter name, it is a name the far end cannot have derived. */
+static bool escapes_are_whole(const char *s) {
+    for (const char *p = s; *p; p++) {
+        if (*p != '%') continue;
+        if (!isxdigit((unsigned char)p[1]) || !isxdigit((unsigned char)p[2])) return false;
+        p += 2;
+    }
+    return true;
+}
+
+TEST(a_nick_that_does_not_fit_is_cut_between_escapes_and_never_past_the_end) {
+    /* Held against the whole encoding: a short buffer must yield a
+     * PREFIX of it. Dropping the byte that did not fit and carrying on
+     * with the next one would also produce a shorter string — and would
+     * map `a[b` and `ab` to the same path. */
+    const char *nick = "a[b]c\xc3\xa9";
+    char full[64];
+    call_path_nick(nick, full, sizeof(full));
+    CHECK_STR(full, "a%5bb%5dc%c3%a9");
+
+    /* Exactly-sized heap buffers, so ASan is the bounds assertion: an
+     * off-by-one in either `n + 2 > out_sz` or `n + 4 > out_sz` writes
+     * the terminator one past the end, and this loop is where it lands. */
+    for (size_t sz = 1; sz <= strlen(full) + 2; sz++) {
+        char *out = malloc(sz);
+        CHECK(out != NULL);
+        if (!out) break;
+        call_path_nick(nick, out, sz);
+        CHECK(strlen(out) < sz);
+        CHECK(escapes_are_whole(out));
+        CHECK(strncmp(out, full, strlen(out)) == 0);
+        free(out);
+    }
+
+    /* A zero-length buffer is not written to at all — the caller may
+     * have handed us the tail of a full one. */
+    char *none = malloc(1);
+    CHECK(none != NULL);
+    if (none) {
+        none[0] = 'Z';
+        call_path_nick("abc", none, 0);
+        CHECK_LONG(none[0], 'Z');
+        free(none);
+    }
+
+    /* The headroom the call sites rely on. Every one of them encodes
+     * into a `char pn[128]`, and the encoder can triple its input, so
+     * the longest nick that certainly survives is 42 bytes. That is
+     * comfortably past NICKLEN on the ircds this talks to — bahamut and
+     * solanum both cap well under it, and both keep nicks ASCII — and
+     * this is the assertion that notices if either number moves. */
+    char worst[43];
+    memset(worst, '[', sizeof(worst) - 1);
+    worst[sizeof(worst) - 1] = 0;
+    char pn[128];
+    call_path_nick(worst, pn, sizeof(pn));
+    CHECK_LONG(strlen(pn), (sizeof(worst) - 1) * 3);
+}
+
+TEST(the_nick_in_me_is_the_same_byte_string_as_the_nick_in_peers) {
+    /* A nick with a bracket in it, because that is the one that tells
+     * two encoders apart. With a plain ASCII nick both a raw copy and a
+     * percent-encoder produce the same answer and the test proves
+     * nothing. */
+    struct app *app = call_app("vjt[m]");
+    CHECK(app != NULL);
+    if (!app) return;
+
+    char invite[512];
+    call_invite_build(CALL_AUDIO, "https://h/call", "shottino-1", invite, sizeof(invite));
+    char posted[512];
+    snprintf(posted, sizeof(posted), "%s", strchr(invite, ' ') + 1);
+    call_invite_peers(app, "azzurra", "sarabean", posted, sizeof(posted));
+    CHECK_STR(posted, "https://h/call/#r=shottino-1&peers=vjt%5bm%5d,sarabean");
+
+    /* What the SAME client appends when IT opens the link: the page
+     * prefills the nick from `me`, and the far end subscribes to the
+     * path built from `peers`. One byte of difference between the two
+     * and the browser publishes where nobody is listening. */
+    char mine[512];
+    call_url_for_me(app, "azzurra", posted, mine, sizeof(mine));
+    CHECK(strstr(mine, "&me=vjt%5bm%5d") != NULL);
+    const char *me = strstr(mine, "&me=");
+    const char *peers = strstr(mine, "&peers=");
+    CHECK(me != NULL && peers != NULL);
+    if (me && peers) {
+        me += 4;
+        peers += 7;
+        size_t n = strcspn(peers, ",&");
+        CHECK_LONG(strlen(me), n);
+        CHECK(strncmp(me, peers, n) == 0);
+    }
+
+    /* A URL that is not an invite is opened UNCHANGED. This runs on
+     * every link clicked in scrollback, and appending `&me=` to
+     * somebody's news article is both wrong and visible. */
+    char plain[512];
+    call_url_for_me(app, "azzurra", "https://example.com/article?a=1", plain, sizeof(plain));
+    CHECK_STR(plain, "https://example.com/article?a=1");
+
+    call_app_free(app);
+}
+
+/* ── the codec word ────────────────────────────────────────────────── */
+
+TEST(the_codec_word_is_one_the_helper_itself_accepts) {
+    static const enum call_vcodec all[] = { CALL_VCODEC_VP8, CALL_VCODEC_H264 };
+
+    for (size_t i = 0; i < sizeof(all) / sizeof(all[0]); i++) {
+        /* The word /set shows, the word the config file holds and the
+         * word /set accepts are one pair of functions. */
+        enum call_vcodec back;
+        CHECK(call_vcodec_parse(call_vcodec_word(all[i]), &back));
+        CHECK_LONG(back, all[i]);
+
+        /* And the word handed to the helper's `--video-codec` is one the
+         * HELPER parses — which the loop above cannot say, because this
+         * side accepts strictly more spellings than the other side does.
+         * `h.264` round-trips here and is refused by call/media.c, so a
+         * word() that emitted it would satisfy every assertion above and
+         * still put the call on the default codec while the user asked
+         * for the other one. */
+        enum media_video_codec helper;
+        CHECK(media_video_codec_parse(call_vcodec_word(all[i]), &helper));
+        CHECK_LONG(helper, all[i] == CALL_VCODEC_H264 ? MEDIA_VIDEO_H264 : MEDIA_VIDEO_VP8);
+    }
+
+    /* The spellings a person types. `h.264` is here because that is how
+     * the codec is written everywhere except a command-line flag. */
+    enum call_vcodec c;
+    CHECK(call_vcodec_parse("H264", &c));
+    CHECK_LONG(c, CALL_VCODEC_H264);
+    CHECK(call_vcodec_parse("h.264", &c));
+    CHECK_LONG(c, CALL_VCODEC_H264);
+    CHECK(call_vcodec_parse("VP8", &c));
+    CHECK_LONG(c, CALL_VCODEC_VP8);
+
+    /* Refused, not defaulted: asking for one codec and silently getting
+     * the other is the failure the enum exists to prevent. */
+    CHECK(!call_vcodec_parse("h265", &c));
+    CHECK(!call_vcodec_parse("vp9", &c));
+    CHECK(!call_vcodec_parse("", &c));
+    CHECK(!call_vcodec_parse(NULL, &c));
+}
+
+/* ── the frame the helper is told to decode to ─────────────────────── */
+
+TEST(the_frame_box_is_never_empty_and_never_unbounded) {
+    int cols = 0, rows = 0;
+
+    /* The chrome the call window does not get to draw in: two columns of
+     * border, four rows of border and status. */
+    call_frame_box(80, 24, &cols, &rows);
+    CHECK_LONG(cols, 78);
+    CHECK_LONG(rows, 20);
+
+    /* Capped, because this ends up as ASCII: past the cap the extra
+     * pixels are decoded, sampled and thrown away, every frame. */
+    call_frame_box(400, 200, &cols, &rows);
+    CHECK_LONG(cols, 160);
+    CHECK_LONG(rows, 60);
+
+    /* Floored. The size is handed to the helper at exec and the reader
+     * thread turns it into `cols * rows * 2 * 3` bytes per frame — a box
+     * that reached zero would make that a malloc(0) the reads then fill
+     * from a pipe, and a negative one an allocation of nearly SIZE_MAX. */
+    call_frame_box(4, 3, &cols, &rows);
+    CHECK_LONG(cols, 16);
+    CHECK_LONG(rows, 6);
+
+    for (int c = -4; c <= 400; c += 7) {
+        for (int r = -4; r <= 200; r += 11) {
+            call_frame_box(c, r, &cols, &rows);
+            CHECK(cols >= 16 && cols <= 160);
+            CHECK(rows >= 6 && rows <= 60);
+        }
+    }
+}
+
+/* ── finding the helper binary ─────────────────────────────────────── */
+
+static bool write_exec(const char *path, mode_t mode) {
+    FILE *f = fopen(path, "w");
+    if (!f) return false;
+    fputs("#!/bin/sh\nexit 0\n", f);
+    fclose(f);
+    return chmod(path, mode) == 0;
+}
+
+TEST(a_configured_helper_is_used_or_refused_never_quietly_replaced) {
+    char dir[] = "/tmp/shottino-helper-XXXXXX";
+    CHECK(mkdtemp(dir) != NULL);
+    char good[PATH_MAX], plain[PATH_MAX];
+    snprintf(good, sizeof(good), "%s/shottino-call", dir);
+    snprintf(plain, sizeof(plain), "%s/not-executable", dir);
+    CHECK(write_exec(good, 0755));
+    CHECK(write_exec(plain, 0644));
+
+    char out[PATH_MAX];
+
+    /* An executable that fits is taken. */
+    out[0] = 0;
+    CHECK(call_helper_accept(good, out, sizeof(out)));
+    CHECK_STR(out, good);
+
+    /* One that is not executable is not. */
+    snprintf(out, sizeof(out), "%s", "untouched");
+    CHECK(!call_helper_accept(plain, out, sizeof(out)));
+    CHECK_STR(out, "untouched");
+
+    /* One that does not FIT is refused rather than shortened: a
+     * truncated path names a different file, and a shorter one is quite
+     * likely a directory, which passes access(X_OK). */
+    snprintf(out, sizeof(out), "%s", "untouched");
+    CHECK(!call_helper_accept(good, out, strlen(good)));
+    CHECK_STR(out, "untouched");
+    CHECK(call_helper_accept(good, out, strlen(good) + 1));
+
+    /* Now the search. HOME and PATH both hold a usable helper, so the
+     * only thing these assertions can be reading is the ORDER. */
+    const char *home_saved = getenv("HOME");
+    const char *path_saved = getenv("PATH");
+    char home_keep[PATH_MAX], path_keep[4096];
+    snprintf(home_keep, sizeof(home_keep), "%s", home_saved ? home_saved : "");
+    snprintf(path_keep, sizeof(path_keep), "%s", path_saved ? path_saved : "");
+
+    char home[] = "/tmp/shottino-home-XXXXXX";
+    CHECK(mkdtemp(home) != NULL);
+    char sub[PATH_MAX], in_home[PATH_MAX];
+    snprintf(sub, sizeof(sub), "%s/.local", home);
+    CHECK_LONG(mkdir(sub, 0755), 0);
+    snprintf(sub, sizeof(sub), "%s/.local/share", home);
+    CHECK_LONG(mkdir(sub, 0755), 0);
+    snprintf(sub, sizeof(sub), "%s/.local/share/shottino", home);
+    CHECK_LONG(mkdir(sub, 0755), 0);
+    snprintf(sub, sizeof(sub), "%s/.local/share/shottino/bin", home);
+    CHECK_LONG(mkdir(sub, 0755), 0);
+    snprintf(in_home, sizeof(in_home), "%s/shottino-call", sub);
+    CHECK(write_exec(in_home, 0755));
+
+    struct app *app = call_app("vjt");
+    CHECK(app != NULL);
+    if (!app) return;
+
+    setenv("PATH", dir, 1);
+    setenv("HOME", home, 1);
+    out[0] = 0;
+    CHECK(call_helper_path(app, out, sizeof(out)));
+    CHECK_STR(out, in_home);
+
+    /* Nothing in HOME: PATH answers, which is the case where the helper
+     * arrived in a package rather than a download. */
+    setenv("HOME", "/nonexistent-shottino", 1);
+    out[0] = 0;
+    CHECK(call_helper_path(app, out, sizeof(out)));
+    CHECK_STR(out, good);
+
+    /* Nowhere at all is FALSE, so the caller falls back to the browser
+     * instead of forking something that exits 127 into a pipe. */
+    setenv("PATH", "/nonexistent-shottino", 1);
+    CHECK(!call_helper_path(app, out, sizeof(out)));
+
+    /* THE one that matters: `/set call.helper` names a path that is not
+     * usable, and there IS a perfectly good helper on PATH. The setting
+     * wins anyway — by failing. Falling through to the other binary
+     * would run something the user did not ask for and would hide the
+     * typo in their setting forever. */
+    setenv("PATH", dir, 1);
+    snprintf(app->call_helper, sizeof(app->call_helper), "%s/typo", dir);
+    CHECK(!call_helper_path(app, out, sizeof(out)));
+    snprintf(app->call_helper, sizeof(app->call_helper), "%s", plain);
+    CHECK(!call_helper_path(app, out, sizeof(out)));
+
+    /* And a configured one that IS usable is taken as given, ahead of
+     * the one PATH would have found. */
+    snprintf(app->call_helper, sizeof(app->call_helper), "%s", in_home);
+    out[0] = 0;
+    CHECK(call_helper_path(app, out, sizeof(out)));
+    CHECK_STR(out, in_home);
+
+    setenv("HOME", home_keep, 1);
+    setenv("PATH", path_keep, 1);
+    call_app_free(app);
+    unlink(good);
+    unlink(plain);
+    unlink(in_home);
+    snprintf(sub, sizeof(sub), "%s/.local/share/shottino/bin", home);
+    rmdir(sub);
+    snprintf(sub, sizeof(sub), "%s/.local/share/shottino", home);
+    rmdir(sub);
+    snprintf(sub, sizeof(sub), "%s/.local/share", home);
+    rmdir(sub);
+    snprintf(sub, sizeof(sub), "%s/.local", home);
+    rmdir(sub);
+    rmdir(home);
+    rmdir(dir);
+}
+
+int main(void) {
+    RUN(a_nick_folds_to_one_path_and_two_people_never_fold_to_one);
+    RUN(a_nick_that_does_not_fit_is_cut_between_escapes_and_never_past_the_end);
+    RUN(the_nick_in_me_is_the_same_byte_string_as_the_nick_in_peers);
+    RUN(the_codec_word_is_one_the_helper_itself_accepts);
+    RUN(the_frame_box_is_never_empty_and_never_unbounded);
+    RUN(a_configured_helper_is_used_or_refused_never_quietly_replaced);
+    return test_report();
+}

--- a/frontends/shottino/tests/test_callmedia.c
+++ b/frontends/shottino/tests/test_callmedia.c
@@ -1,18 +1,24 @@
-/* test_callmedia — the one pure thing in the media legs.
+/* test_callmedia — the pure parts of the media legs, and the one
+ * question about the impure part that can be asked without a call: does
+ * a spawn that fails SAY so.
  *
- * Everything else in media.c is fork+exec and sockets, verified by
- * running it (see docs/CALLS.md). The SDP is the exception and the one
- * that most deserves a test: a wrong payload type or rtpmap here is a
- * decoder that sits SILENT with no error at all, which is the least
- * debuggable failure this design has.
+ * The rest of media.c is sockets and codec behaviour, verified by
+ * running it (see docs/CALLS.md). The SDP is the part that most deserves
+ * a test: a wrong payload type or rtpmap there is a decoder that sits
+ * SILENT with no error at all, which is the least debuggable failure
+ * this design has — and a spawn reported as started when it was not is
+ * the same failure one layer down.
  *
  * Links media.c only — no libdatachannel — so the default gate never
  * depends on the opt-in submodule having been built.
  */
 #include "../call/media.h"
 
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "test.h"
@@ -402,6 +408,145 @@ TEST(loopback_ports_are_distinct_and_reported) {
     if (fd_b >= 0) close(fd_b);
 }
 
+/* A PATH containing exactly what `fake_ffmpeg` says — a script named
+ * `ffmpeg`, or nothing at all. The directory name is written back so the
+ * caller can take it down again.
+ *
+ * PATH rather than a real ffmpeg either way: the suite must decide the
+ * outcome itself, and "is ffmpeg installed on the machine running the
+ * tests" is exactly the question that must not affect it. */
+static bool path_holding_ffmpeg(const char *fake_ffmpeg, char *dir, size_t dir_sz) {
+    snprintf(dir, dir_sz, "/tmp/shottino-callmedia-XXXXXX");
+    if (!mkdtemp(dir)) return false;
+    if (fake_ffmpeg) {
+        char path[128];
+        snprintf(path, sizeof(path), "%s/ffmpeg", dir);
+        FILE *f = fopen(path, "w");
+        if (!f) return false;
+        fputs(fake_ffmpeg, f);
+        fclose(f);
+        if (chmod(path, 0755) != 0) return false;
+    }
+    return setenv("PATH", dir, 1) == 0;
+}
+
+static void path_restore(const char *dir, const char *saved) {
+    char path[128];
+    snprintf(path, sizeof(path), "%s/ffmpeg", dir);
+    unlink(path);
+    rmdir(dir);
+    setenv("PATH", saved, 1);
+}
+
+/* Exactly how main.c prepares a mix before starting it. A memset-zeroed
+ * one is NOT the same thing: its legs would own fd 0. */
+static void mix_init(struct media_mix *mix) {
+    memset(mix, 0, sizeof(*mix));
+    mix->pid = -1;
+    for (int i = 0; i < MEDIA_MAX_PEERS; i++) {
+        mix->legs[i].fd = -1;
+        mix->legs[i].pid = -1;
+    }
+}
+
+static struct media_config spawn_test_config(void) {
+    struct media_config cfg = { .audio_source = "pulse:default",
+                                .video_source = "v4l2:/dev/video0",
+                                .audio_sink = "pulse:default",
+                                .audio_payload_type = 111,
+                                .video_payload_type = 96,
+                                .audio_ssrc = 1,
+                                .video_ssrc = 2,
+                                .frame_w = 320,
+                                .frame_h = 240,
+                                .fps = 10,
+                                .capture_w = 640,
+                                .capture_h = 480,
+                                .capture_fps = 20,
+                                .video_kbps = 800,
+                                .video_codec = MEDIA_VIDEO_VP8,
+                                .want_video = true };
+    return cfg;
+}
+
+/* AN FFMPEG THAT CANNOT BE EXEC'D IS A START THAT FAILED.
+ *
+ * The helper is opt-in and its README does not make ffmpeg a hard
+ * dependency, so "not installed" is the ordinary case, not an exotic
+ * one. A fork that succeeds and an exec that does not is a child that
+ * exits 127 with its stderr discarded, and every caller's error message
+ * hangs off the false branch these functions were not returning: the
+ * call window opens, the tiles publish, and the user gets silence and a
+ * black rectangle with no diagnostic anywhere.
+ *
+ * All three start functions, because all three spawn and all three have
+ * their own message on the far side of the bool. */
+TEST(a_start_reports_an_ffmpeg_that_cannot_be_exec_d) {
+    char saved[4096];
+    snprintf(saved, sizeof(saved), "%s", getenv("PATH") ? getenv("PATH") : "");
+    char dir[64];
+    CHECK(path_holding_ffmpeg(NULL, dir, sizeof(dir)));
+
+    struct media_config cfg = spawn_test_config();
+    int slots[1] = { 0 };
+
+    struct media_leg leg;
+    CHECK(!media_start_send(&leg, &cfg, false));
+    /* And stopped, not half-started: the socket the capture would have
+     * been read from is closed, so nothing polls a leg that has no
+     * writer. */
+    CHECK(leg.pid == -1);
+    CHECK(leg.fd == -1);
+
+    struct media_mix amix;
+    mix_init(&amix);
+    CHECK(!media_start_audio_mix(&amix, slots, 1, &cfg));
+    CHECK(amix.pid == -1);
+    media_mix_free(&amix);
+
+    struct media_mix vmix;
+    mix_init(&vmix);
+    vmix.tile_count = media_grid_layout(slots, 1, cfg.frame_w, cfg.frame_h, vmix.tiles,
+                                        MEDIA_MAX_PEERS);
+    CHECK(vmix.tile_count == 1);
+    CHECK(!media_start_video_mix(&vmix, &cfg, -1));
+    CHECK(vmix.pid == -1);
+    media_mix_free(&vmix);
+
+    path_restore(dir, saved);
+}
+
+/* The other half of the same question, and the reason the one above
+ * means anything: a start that CAN exec still succeeds.
+ *
+ * Without this, "returns false" is satisfied just as well by a function
+ * that refuses everything. */
+TEST(a_start_succeeds_when_ffmpeg_is_on_the_path) {
+    char saved[4096];
+    snprintf(saved, sizeof(saved), "%s", getenv("PATH") ? getenv("PATH") : "");
+    char dir[64];
+    /* Anything that execs and stays up: this is the spawn contract under
+     * test, not ffmpeg's own behaviour. */
+    CHECK(path_holding_ffmpeg("#!/bin/sh\nexec sleep 30\n", dir, sizeof(dir)));
+
+    struct media_config cfg = spawn_test_config();
+    int slots[1] = { 0 };
+
+    struct media_leg leg;
+    CHECK(media_start_send(&leg, &cfg, false));
+    CHECK(leg.pid > 0);
+    media_stop(&leg);
+    CHECK(leg.pid == -1);
+
+    struct media_mix amix;
+    mix_init(&amix);
+    CHECK(media_start_audio_mix(&amix, slots, 1, &cfg));
+    CHECK(amix.pid > 0);
+    media_mix_free(&amix);
+
+    path_restore(dir, saved);
+}
+
 int main(void) {
     RUN(the_receive_sdp_describes_what_was_negotiated);
     RUN(the_receive_sdp_follows_the_negotiated_video_codec);
@@ -412,5 +557,7 @@ int main(void) {
     RUN(the_mix_filter_chains_every_tile_into_one_output);
     RUN(the_published_grid_is_complete_or_refused);
     RUN(loopback_ports_are_distinct_and_reported);
+    RUN(a_start_reports_an_ffmpeg_that_cannot_be_exec_d);
+    RUN(a_start_succeeds_when_ffmpeg_is_on_the_path);
     return test_report();
 }

--- a/frontends/shottino/tests/test_callmedia.c
+++ b/frontends/shottino/tests/test_callmedia.c
@@ -14,6 +14,7 @@
  */
 #include "../call/media.h"
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -513,6 +514,13 @@ TEST(a_start_reports_an_ffmpeg_that_cannot_be_exec_d) {
     CHECK(!media_start_video_mix(&vmix, &cfg, -1));
     CHECK(vmix.pid == -1);
     media_mix_free(&vmix);
+
+    /* AND NOT A CORPSE LEFT ANYWHERE. Nothing waits for a leg the caller
+     * was told does not exist, and the supervisor rebuilds both mixes on
+     * every tick — so on the machine this whole issue is about, a start
+     * that does not reap its own failed child leaks a zombie per tick
+     * for the length of the call. */
+    CHECK(waitpid(-1, NULL, WNOHANG) == -1 && errno == ECHILD);
 
     path_restore(dir, saved);
 }

--- a/frontends/shottino/tests/test_callmedia.c
+++ b/frontends/shottino/tests/test_callmedia.c
@@ -19,6 +19,7 @@
 #include <string.h>
 
 #include <sys/stat.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include "test.h"
@@ -525,9 +526,15 @@ TEST(a_start_succeeds_when_ffmpeg_is_on_the_path) {
     char saved[4096];
     snprintf(saved, sizeof(saved), "%s", getenv("PATH") ? getenv("PATH") : "");
     char dir[64];
-    /* Anything that execs and stays up: this is the spawn contract under
-     * test, not ffmpeg's own behaviour. */
-    CHECK(path_holding_ffmpeg("#!/bin/sh\nexec sleep 30\n", dir, sizeof(dir)));
+    /* Anything that execs and STAYS UP: this is the spawn contract under
+     * test, not ffmpeg's own behaviour.
+     *
+     * The inner PATH is not decoration. This one runs with PATH pointing
+     * at the scratch directory and nothing else, so a bare `sleep` is
+     * not found — the script then exits immediately, the check below
+     * still passes on a pid that is already a zombie, and the control
+     * proves nothing. Measured, not assumed. */
+    CHECK(path_holding_ffmpeg("#!/bin/sh\nPATH=/usr/bin:/bin\nexec sleep 30\n", dir, sizeof(dir)));
 
     struct media_config cfg = spawn_test_config();
     int slots[1] = { 0 };
@@ -535,6 +542,11 @@ TEST(a_start_succeeds_when_ffmpeg_is_on_the_path) {
     struct media_leg leg;
     CHECK(media_start_send(&leg, &cfg, false));
     CHECK(leg.pid > 0);
+    /* RUNNING, not merely forked. A child that exited the instant it
+     * started satisfies pid > 0 exactly as well — which is what made the
+     * bug this suite is about survive in the first place. */
+    int status = 0;
+    CHECK(waitpid(leg.pid, &status, WNOHANG) == 0);
     media_stop(&leg);
     CHECK(leg.pid == -1);
 
@@ -542,6 +554,7 @@ TEST(a_start_succeeds_when_ffmpeg_is_on_the_path) {
     mix_init(&amix);
     CHECK(media_start_audio_mix(&amix, slots, 1, &cfg));
     CHECK(amix.pid > 0);
+    CHECK(waitpid(amix.pid, &status, WNOHANG) == 0);
     media_mix_free(&amix);
 
     path_restore(dir, saved);

--- a/frontends/shottino/tests/test_windows.c
+++ b/frontends/shottino/tests/test_windows.c
@@ -2168,34 +2168,128 @@ TEST(the_call_tile_map_is_parsed_or_rejected_whole) {
     /* ALL OR NOTHING. A cell that does not fit the frame it claims to
      * belong to would sample somebody else's pixels, so the whole line
      * is refused and the caller keeps the grid it already had — better
-     * a stale picture than a mislabelled one. */
-    CHECK(call_tiles_parse("160x120;0,0,0,80,60;1,100,0,80,60", &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse("160x120;0,0,0,80,200", &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse("160x120;0,-1,0,80,60", &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse("160x120;0,0,0,0,60", &fw, &fh, t, CALL_MAX_PEERS) == 0);
+     * a stale picture than a mislabelled one.
+     *
+     * A refusal is NEGATIVE, not zero. Zero is a real grid with nobody
+     * in it, and the caller must be able to tell the two apart: one
+     * says keep drawing what you had, the other says stop. */
+    CHECK(call_tiles_parse("160x120;0,0,0,80,60;1,100,0,80,60", &fw, &fh, t, CALL_MAX_PEERS) < 0);
+    CHECK(call_tiles_parse("160x120;0,0,0,80,200", &fw, &fh, t, CALL_MAX_PEERS) < 0);
+    CHECK(call_tiles_parse("160x120;0,-1,0,80,60", &fw, &fh, t, CALL_MAX_PEERS) < 0);
+    CHECK(call_tiles_parse("160x120;0,0,0,0,60", &fw, &fh, t, CALL_MAX_PEERS) < 0);
     /* A slot outside the cap would index the nick table past its end. */
-    CHECK(call_tiles_parse("160x120;99,0,0,80,60", &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse("160x120;-1,0,0,80,60", &fw, &fh, t, CALL_MAX_PEERS) == 0);
+    CHECK(call_tiles_parse("160x120;99,0,0,80,60", &fw, &fh, t, CALL_MAX_PEERS) < 0);
+    CHECK(call_tiles_parse("160x120;-1,0,0,80,60", &fw, &fh, t, CALL_MAX_PEERS) < 0);
 
-    /* Malformed in the ways a truncated or reordered line actually is. */
-    CHECK(call_tiles_parse("", &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse("160x120", &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse("160x120;0,0,0,80", &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse("160x120;0,0,0,80,60;junk", &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse("160x120;0,0,0,80,60trailing", &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse("0x0;0,0,0,80,60", &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse(NULL, &fw, &fh, t, CALL_MAX_PEERS) == 0);
-    CHECK(call_tiles_parse("160x120;0,0,0,80,60", &fw, &fh, NULL, CALL_MAX_PEERS) == 0);
+    /* Malformed in the ways a truncated or reordered line actually is.
+     * A frame size with nothing after it is a line cut mid-write, not
+     * an empty grid — the helper spells THAT differently, below. */
+    CHECK(call_tiles_parse("160x120", &fw, &fh, t, CALL_MAX_PEERS) < 0);
+    CHECK(call_tiles_parse("160x120;0,0,0,80", &fw, &fh, t, CALL_MAX_PEERS) < 0);
+    CHECK(call_tiles_parse("160x120;0,0,0,80,60;junk", &fw, &fh, t, CALL_MAX_PEERS) < 0);
+    CHECK(call_tiles_parse("160x120;0,0,0,80,60trailing", &fw, &fh, t, CALL_MAX_PEERS) < 0);
+    CHECK(call_tiles_parse("0x0;0,0,0,80,60", &fw, &fh, t, CALL_MAX_PEERS) < 0);
+    CHECK(call_tiles_parse(NULL, &fw, &fh, t, CALL_MAX_PEERS) < 0);
+    CHECK(call_tiles_parse("160x120;0,0,0,80,60", &fw, &fh, NULL, CALL_MAX_PEERS) < 0);
 
     /* An empty grid — everybody turned their camera off — is reported
-     * as none rather than as a parse failure the caller would ignore. */
+     * as none rather than as a parse failure the caller would ignore.
+     * The empty VALUE is the spelling the helper actually emits when it
+     * stops the decoder (call/main.c video_retile); the frame-size-then
+     * -separator form is the same statement with the size still on it. */
+    CHECK(call_tiles_parse("", &fw, &fh, t, CALL_MAX_PEERS) == 0);
     CHECK(call_tiles_parse("160x120;", &fw, &fh, t, CALL_MAX_PEERS) == 0);
 
     /* The frame size is only adopted when the line as a whole was
      * good: a rejected line must not leave half of it applied. */
     fw = fh = 0;
-    CHECK(call_tiles_parse("640x480;0,0,0,999,999", &fw, &fh, t, CALL_MAX_PEERS) == 0);
+    CHECK(call_tiles_parse("640x480;0,0,0,999,999", &fw, &fh, t, CALL_MAX_PEERS) < 0);
     CHECK(fw == 0 && fh == 0);
+}
+
+/* Leave the stack where the tile array is about to live full of
+ * non-zero bytes.
+ *
+ * Only a test needs this: it is the difference between "the array
+ * happened to be zero" and "the array was zeroed". Without it the
+ * uninitialised-tiles check below passes on whatever the previous call
+ * left behind, which on a quiet stack is often zeros — a green that
+ * proves nothing. Sized past the tile array and marked noinline so the
+ * frame is really written and really reused. */
+__attribute__((noinline)) static void dirty_the_stack(void) {
+    volatile unsigned char scratch[sizeof(struct call_tile) * CALL_MAX_PEERS * 4];
+    for (size_t i = 0; i < sizeof(scratch); i++) scratch[i] = 0xAA;
+}
+
+/* The grid the helper publishes is applied WHOLE, or not at all — and
+ * "not at all" means the previous one stays up.
+ *
+ * The parser was written all-or-nothing and says so twice; its only
+ * caller adopted the refusal anyway, so one malformed line — a
+ * truncated pipe write, a re-grid racing a peer leaving — blanked the
+ * video grid mid-call and left it blank until the next good line. The
+ * caller is where the contract is kept or broken, so the caller is what
+ * this drives, through the same JSON the helper writes. */
+TEST(a_refused_grid_leaves_the_last_one_up) {
+    struct app *app = window_app();
+    CHECK(app != NULL);
+    app->call_live.focus_slot = -1;
+
+    /* Two people on camera. */
+    call_event_apply(app, "{\"event\":\"tiles\",\"value\":\"160x120;0,0,0,80,60;2,80,0,80,60\"}");
+    CHECK_LONG(app->call_live.tile_count, 2);
+    CHECK_LONG(app->call_live.frame_w, 160);
+    CHECK_LONG(app->call_live.tiles[1].slot, 2);
+    /* Nobody was being watched, so the first cell takes the focus. */
+    CHECK_LONG(app->call_live.focus_slot, 0);
+
+    /* A cell that does not fit the frame it claims to belong to. The
+     * whole line is refused — and refused means the picture that was
+     * being drawn a moment ago is still being drawn. */
+    size_t before = app->log_count;
+    call_event_apply(app, "{\"event\":\"tiles\",\"value\":\"160x120;0,0,0,80,60;1,100,0,80,60\"}");
+    CHECK_LONG(app->call_live.tile_count, 2);
+    CHECK_LONG(app->call_live.frame_w, 160);
+    CHECK_LONG(app->call_live.frame_h, 120);
+    CHECK_LONG(app->call_live.tiles[1].slot, 2);
+    CHECK_LONG(app->call_live.focus_slot, 0);
+    /* And it is SAID. A grid that quietly stops following the call is
+     * reported as "the video broke", which is unactionable. */
+    CHECK_LONG(app->log_count, before + 1);
+    CHECK(log_has(app, "refused a malformed tile grid"));
+
+    /* Truncated mid-write — the other shape a bad line arrives in. */
+    call_event_apply(app, "{\"event\":\"tiles\",\"value\":\"160x120;0,0,0,80\"}");
+    CHECK_LONG(app->call_live.tile_count, 2);
+    CHECK_LONG(app->call_live.tiles[1].slot, 2);
+
+    /* NOT a refusal: the helper stops the decoder and publishes an
+     * empty value when nobody is sending a picture. That one is an
+     * instruction and the grid really does go away — a guard that
+     * merely kept every zero-tile result would leave two faces labelled
+     * on a frame stream that has stopped. */
+    before = app->log_count;
+    call_event_apply(app, "{\"event\":\"tiles\",\"value\":\"\"}");
+    CHECK_LONG(app->call_live.tile_count, 0);
+    CHECK_LONG(app->call_live.focus_slot, -1);
+    CHECK_LONG(app->log_count, before);
+
+    /* Nothing beyond the tile count is carried in from the stack. Every
+     * reader gates on the count today, so this is not a live bug — it
+     * is uninitialised memory crossing into shared state under a mutex,
+     * which stops being harmless the first time a reader forgets. */
+    dirty_the_stack();
+    call_event_apply(app, "{\"event\":\"tiles\",\"value\":\"160x120;3,0,0,80,60\"}");
+    CHECK_LONG(app->call_live.tile_count, 1);
+    for (int i = 1; i < CALL_MAX_PEERS; i++) {
+        CHECK_LONG(app->call_live.tiles[i].slot, 0);
+        CHECK_LONG(app->call_live.tiles[i].x, 0);
+        CHECK_LONG(app->call_live.tiles[i].y, 0);
+        CHECK_LONG(app->call_live.tiles[i].w, 0);
+        CHECK_LONG(app->call_live.tiles[i].h, 0);
+    }
+
+    free_app(app);
 }
 
 /* A client-local window is never asked about over REST.
@@ -4114,6 +4208,7 @@ int main(void) {
     RUN(notifications_parse_refuse_and_persist);
     RUN(a_configured_setting_survives_save_and_load);
     RUN(the_call_tile_map_is_parsed_or_rejected_whole);
+    RUN(a_refused_grid_leaves_the_last_one_up);
     RUN(a_client_local_window_is_never_fetched_from_the_server);
     RUN(a_conversation_is_remembered_and_rolls_to_fit);
     RUN(the_context_budget_leaves_room_for_the_fixed_parts);


### PR DESCRIPTION
**Union of three already-green shottino PRs, re-based together onto current `main` (`4df09a79`).**

Supersedes the gates on #848 (#760), #849 (#764) and #847 (#758). Those three were each green against a base that has since moved — and **a PR's green attests to `branch + base`, never to `branch + the other branches about to land`.** Merging them one at a time would have asked that question three times against three different mains, while `main` itself keeps receiving shottino commits (`4df09a79` landed mid-queue and touches `shottino.c`, the same file #760 modifies).

Contents, in order:

- **#760** (from #848) — `call_tiles_parse`: a refused tiles line was being adopted as count `0`, frame `0x0`, blanking the grid the parser's own comment says it exists to keep.
- **#764** (from #849) — new `tests/test_call.c` covering the call helpers that decide who is in the room (`call_path_nick`, `call_url_for_me`, `call_invite_peers`, `call_helper_path`/`_accept`, `call_frame_box`, `call_vcodec_parse`/`_word`). Deliberately a **new file** rather than an edit to `test_windows.c`, which #762/#763 are queued against.
- **#758** (from #847) — a failed `exec` now reaches the error message written for it, the failed child is reaped rather than merely reported, and the positive control actually controls something.

**Why these three specifically belong in one gate:** #760 rewrites call code and #764 is *new tests over the call helpers*, so gating them together is the only way to ask "do the new call tests still pass after the tiles rewrite?" Three separate merges would each have been green and none would have asked it.

All three cherry-picked cleanly onto `4df09a79`. No `Closes` keywords: the issues are closed at the release, naming it.