### PR TITLE
cic: the auth/passkey slice — #724 #725 #726 #727 #728 #729

### DIFF
--- a/cicchetto/src/Login.tsx
+++ b/cicchetto/src/Login.tsx
@@ -338,13 +338,34 @@ const Login: Component = () => {
   const onRecoveryLogin = async (): Promise<void> => {
     const id = passkeyIdentifier();
     if (id === null) return;
+    // #724 — this validation used to be a `required` attribute on the input.
+    // That attribute enlisted the field in the CREDENTIAL form's constraint
+    // validation, so an abandoned recovery field blocked an ordinary login.
+    // The recovery flow validates its own input instead.
+    const code = recoveryCode();
+    if (code === "") {
+      setError("Enter your recovery code.");
+      return;
+    }
     setError(null);
     try {
-      await auth.loginWithRecoveryCode(id, recoveryCode());
+      await auth.loginWithRecoveryCode(id, code);
       navigate("/", { replace: true });
     } catch (err) {
       handleError(err);
     }
+  };
+
+  // #724 — the recovery field sits inside the credential form (that is where
+  // the toggle that reveals it lives, and moving it below Connect would put
+  // it after the Advanced disclosure). It must not, however, reach that
+  // form's submission: Enter here used to implicitly submit the enclosing
+  // form, running `onSubmit` — the PASSWORD login — and never sending the
+  // code. Swallow the implicit submission and run the flow the user asked for.
+  const onRecoveryKeyDown = (event: KeyboardEvent): void => {
+    if (event.key !== "Enter") return;
+    event.preventDefault();
+    void onRecoveryLogin();
   };
 
   let nickInput: HTMLInputElement | undefined;
@@ -480,7 +501,7 @@ const Login: Component = () => {
                         autocomplete="one-time-code"
                         value={recoveryCode()}
                         onInput={(event) => setRecoveryCode(event.currentTarget.value)}
-                        required
+                        onKeyDown={onRecoveryKeyDown}
                       />
                       <button
                         type="button"

--- a/cicchetto/src/Login.tsx
+++ b/cicchetto/src/Login.tsx
@@ -5,7 +5,7 @@ import * as auth from "./lib/auth";
 import { type CaptchaProvider, mountCaptchaWidget } from "./lib/captcha";
 import { CONNECTING_MESSAGES } from "./lib/connectingMessages";
 import { severedForFlood } from "./lib/floodSever";
-import { friendlyApiError } from "./lib/friendlyApiError";
+import { errorMessage, friendlyApiError } from "./lib/friendlyApiError";
 import { classifyLoginIdentifier } from "./lib/loginIdentifier";
 
 // Bare credential form. The walking-skeleton login surface is one card,
@@ -149,6 +149,10 @@ const Login: Component = () => {
   const [msgIndex, setMsgIndex] = createSignal(0);
   const [captcha, setCaptcha] = createSignal<CaptchaChallenge | null>(null);
   const [totpChallenge, setTotpChallenge] = createSignal<string | null>(null);
+  // #728 — why the passkey second factor didn't complete, carried over from
+  // `auth.login` so the TOTP form can explain itself. `null` = no passkey was
+  // attempted (an ordinary TOTP account).
+  const [passkeyFallback, setPasskeyFallback] = createSignal<string | null>(null);
   const [totpCode, setTotpCode] = createSignal("");
   const [recoveryMode, setRecoveryMode] = createSignal(false);
   const [recoveryCode, setRecoveryCode] = createSignal("");
@@ -254,6 +258,10 @@ const Login: Component = () => {
       const result = await auth.login(id, pwd, captchaToken, advancedFields);
       if (result.kind === "totp") {
         setTotpChallenge(result.challengeToken);
+        // #728 — a passkey second factor that failed hands its reason over
+        // with the challenge. Without it the prompt just vanishes and a bare
+        // 2FA form appears, which reads as "my passkey has stopped working".
+        setPasskeyFallback(result.passkeyError === null ? null : errorMessage(result.passkeyError));
         setPassword("");
         return false;
       }
@@ -592,6 +600,19 @@ const Login: Component = () => {
                 <form class="login-form" onSubmit={onTotpSubmit} data-testid="totp-login-form">
                   <Brand />
                   <h2>two-factor authentication</h2>
+                  {/* #728 — never let the passkey prompt vanish without a
+                      word. Every ceremony failure (cancel, wrong
+                      authenticator, a 401 on the assertion, a network error)
+                      lands the user here; without this line they cannot tell
+                      a dismissed sheet from a broken credential. */}
+                  <Show when={passkeyFallback()}>
+                    {(reason) => (
+                      <p class="login-advanced-hint" data-testid="totp-passkey-fallback">
+                        Passkey sign-in didn't complete. {reason()} Use your authenticator or a
+                        recovery code instead.
+                      </p>
+                    )}
+                  </Show>
                   <label for="login-totp-code">Authenticator or recovery code</label>
                   <input
                     id="login-totp-code"
@@ -614,6 +635,7 @@ const Login: Component = () => {
                       setTotpChallenge(null);
                       setTotpCode("");
                       setError(null);
+                      setPasskeyFallback(null);
                     }}
                   >
                     Back

--- a/cicchetto/src/Login.tsx
+++ b/cicchetto/src/Login.tsx
@@ -196,51 +196,40 @@ const Login: Component = () => {
     }
   };
 
-  // Shared tail for both the plain submit and the captcha-solve retry: run
-  // the one blocking login request under the connecting view, navigate on
-  // success, revert to the form (with a friendly error) on failure.
-  const attemptLogin = async (
-    id: string,
-    pwd: string | null,
-    captchaToken?: string,
-  ): Promise<void> => {
+  // #727 — ONE in-flight latch for EVERY login flow this card offers.
+  //
+  // `connecting()` is not merely a spinner: the `<Show>` below swaps the form
+  // out for the connecting view, which is what makes a second click
+  // impossible. The password submit had it; the passkey and recovery-code
+  // doors did not, and neither button was ever disabled, so on a slow link
+  // the user got zero feedback and clicked again — sending a SECOND
+  // `POST /auth/passkeys/recover` with the same one-shot code. One request
+  // consumes it and navigates; the other comes back `invalid_two_factor` and
+  // books a hit in the server's `passkey_recovery` throttle window. An
+  // impatient double-click cost a recovery code AND a slice of the lockout
+  // budget. On the passkey button, the second ceremony is rejected outright
+  // by the browser ("A request is already pending").
+  //
+  // `run` returns whether the flow is DONE (navigate) or has handed off to
+  // another view on this card (the TOTP challenge — revert the latch, stay).
+  // Written as one helper rather than a fourth copy of the same
+  // try/stopRotation/handleError tail: the two copies that existed were
+  // already drifting.
+  const underConnecting = async (run: () => Promise<boolean>): Promise<void> => {
     setError(null);
     setConnecting(true);
     startRotation();
     try {
-      // #152 — thread login-Advanced ident/realname through the same
-      // boundary. Blank fields are omitted downstream (auth.login), so a
-      // guest/plain login stays a minimal request. Named `advancedFields`
-      // (not `advanced`) so it doesn't shadow the `advanced()` toggle
-      // signal accessor in this scope.
-      const advancedFields = { ident: ident(), realname: realname(), incognito: incognito() };
-      // Preserve the auth.login(id, pwd, captcha?) boundary shape: forward
-      // the captcha token only when present, so the plain path stays a
-      // 2-arg call (the captcha retry is the only 3-arg caller).
-      if (captchaToken === undefined) {
-        const result = await auth.login(id, pwd, undefined, advancedFields);
-        if (result.kind === "totp") {
-          stopRotation();
-          setConnecting(false);
-          setTotpChallenge(result.challengeToken);
-          setPassword("");
-          return;
-        }
-      } else {
-        const result = await auth.login(id, pwd, captchaToken, advancedFields);
-        if (result.kind === "totp") {
-          stopRotation();
-          setConnecting(false);
-          setTotpChallenge(result.challengeToken);
-          setPassword("");
-          return;
-        }
-      }
+      const navigateAway = await run();
       // Stop the cosmetic rotation before we leave — navigation unmounts
       // Login (onCleanup would catch it too), but being explicit means a
       // future route guard that bounces back to /login without unmounting
       // can't leave the interval running.
       stopRotation();
+      if (!navigateAway) {
+        setConnecting(false);
+        return;
+      }
       navigate("/", { replace: true });
     } catch (err) {
       setConnecting(false);
@@ -248,6 +237,28 @@ const Login: Component = () => {
       handleError(err);
     }
   };
+
+  // Shared tail for both the plain submit and the captcha-solve retry.
+  const attemptLogin = async (
+    id: string,
+    pwd: string | null,
+    captchaToken?: string,
+  ): Promise<void> =>
+    underConnecting(async () => {
+      // #152 — thread login-Advanced ident/realname through the same
+      // boundary. Blank fields are omitted downstream (auth.login), so a
+      // guest/plain login stays a minimal request. Named `advancedFields`
+      // (not `advanced`) so it doesn't shadow the `advanced()` toggle
+      // signal accessor in this scope.
+      const advancedFields = { ident: ident(), realname: realname(), incognito: incognito() };
+      const result = await auth.login(id, pwd, captchaToken, advancedFields);
+      if (result.kind === "totp") {
+        setTotpChallenge(result.challengeToken);
+        setPassword("");
+        return false;
+      }
+      return true;
+    });
 
   const handleCaptchaSolve = async (token: string): Promise<void> => {
     // By the time the captcha is solved the identifier has already been
@@ -299,18 +310,10 @@ const Login: Component = () => {
     const challenge = totpChallenge();
     if (challenge === null) return;
 
-    setError(null);
-    setConnecting(true);
-    startRotation();
-    try {
+    await underConnecting(async () => {
       await auth.verifyTotp(challenge, totpCode());
-      stopRotation();
-      navigate("/", { replace: true });
-    } catch (err) {
-      setConnecting(false);
-      stopRotation();
-      handleError(err);
-    }
+      return true;
+    });
   };
 
   const passkeyIdentifier = (): string | null => {
@@ -326,13 +329,10 @@ const Login: Component = () => {
   const onPasskeyLogin = async (): Promise<void> => {
     const id = passkeyIdentifier();
     if (id === null) return;
-    setError(null);
-    try {
+    await underConnecting(async () => {
       await auth.loginWithPasskey(id);
-      navigate("/", { replace: true });
-    } catch (err) {
-      handleError(err);
-    }
+      return true;
+    });
   };
 
   const onRecoveryLogin = async (): Promise<void> => {
@@ -347,13 +347,10 @@ const Login: Component = () => {
       setError("Enter your recovery code.");
       return;
     }
-    setError(null);
-    try {
+    await underConnecting(async () => {
       await auth.loginWithRecoveryCode(id, code);
-      navigate("/", { replace: true });
-    } catch (err) {
-      handleError(err);
-    }
+      return true;
+    });
   };
 
   // #724 — the recovery field sits inside the credential form (that is where

--- a/cicchetto/src/PasskeySettings.tsx
+++ b/cicchetto/src/PasskeySettings.tsx
@@ -40,65 +40,73 @@ const PasskeySettings: Component = () => {
   };
   onMount(() => void reload().catch((value) => setError(errorMessage(value))));
 
+  // #729 — FIVE privileged actions consume the account password, and only one
+  // of them (add) used to sit inside the form that visually owned the field.
+  // The other four read the signal from elsewhere in the pane with no prompt
+  // of their own, so a user who never filled that form sent `""` and got a
+  // bare 401 back; and a password typed to ADD a passkey stayed live in the
+  // signal, silently re-usable to change how the account authenticates.
+  //
+  // One gate for all five: refuse locally when the field is empty (naming the
+  // blocker instead of spending a doomed request AND a slot in the server's
+  // login-throttle window), and clear the field in the `finally` — on success
+  // AND on failure, so neither a good password nor a wrong one lingers for
+  // the next click to reuse. Re-typing IS the per-action re-confirmation the
+  // pane owes for a change of this weight.
+  const withPassword = async (run: (accountPassword: string) => Promise<void>): Promise<void> => {
+    setError(null);
+    const accountPassword = password();
+    if (accountPassword === "") {
+      setError("Enter your account password to confirm this change.");
+      return;
+    }
+    setBusy(true);
+    try {
+      await run(accountPassword);
+    } catch (value) {
+      setError(errorMessage(value));
+    } finally {
+      setBusy(false);
+      setPassword("");
+    }
+  };
+
   const register = async (event: Event): Promise<void> => {
     event.preventDefault();
-    setBusy(true);
-    setError(null);
-    try {
-      const options = await startPasskeyRegistration(currentToken(), password(), name());
+    await withPassword(async (accountPassword) => {
+      const options = await startPasskeyRegistration(currentToken(), accountPassword, name());
       await finishPasskeyRegistration(currentToken(), await createPasskey(options));
       setName("");
       await reload();
-    } catch (value) {
-      setError(errorMessage(value));
-    } finally {
-      setBusy(false);
-    }
+    });
   };
 
-  const enableSecondFactor = async (): Promise<void> => {
-    setBusy(true);
-    setError(null);
-    try {
-      const options = await startPasskeyModeChange(currentToken(), password(), "second_factor");
+  const enableSecondFactor = async (): Promise<void> =>
+    withPassword(async (accountPassword) => {
+      const options = await startPasskeyModeChange(
+        currentToken(),
+        accountPassword,
+        "second_factor",
+      );
       await finishPasskeyModeChange(currentToken(), await getPasskey(options));
       await reload();
-    } catch (value) {
-      setError(errorMessage(value));
-    } finally {
-      setBusy(false);
-    }
-  };
+    });
 
-  const disablePasskeyLogin = async (): Promise<void> => {
-    setBusy(true);
-    setError(null);
-    try {
-      const options = await startPasskeyModeChange(currentToken(), password(), "disabled");
+  const disablePasskeyLogin = async (): Promise<void> =>
+    withPassword(async (accountPassword) => {
+      const options = await startPasskeyModeChange(currentToken(), accountPassword, "disabled");
       await finishPasskeyModeChange(currentToken(), await getPasskey(options));
       setCodes([]);
       setRecoveryToken(null);
       await reload();
-    } catch (value) {
-      setError(errorMessage(value));
-    } finally {
-      setBusy(false);
-    }
-  };
+    });
 
-  const preparePasswordlessMode = async (): Promise<void> => {
-    setBusy(true);
-    setError(null);
-    try {
-      const prepared = await preparePasswordless(currentToken(), password());
+  const preparePasswordlessMode = async (): Promise<void> =>
+    withPassword(async (accountPassword) => {
+      const prepared = await preparePasswordless(currentToken(), accountPassword);
       setCodes(prepared.recovery_codes);
       setRecoveryToken(prepared.recovery_token);
-    } catch (value) {
-      setError(errorMessage(value));
-    } finally {
-      setBusy(false);
-    }
-  };
+    });
 
   const activatePasswordless = async (): Promise<void> => {
     const pending = recoveryToken();
@@ -127,16 +135,11 @@ const PasskeySettings: Component = () => {
   };
 
   const remove = async (id: string): Promise<void> => {
-    setBusy(true);
-    try {
-      await deletePasskey(currentToken(), id, password());
+    await withPassword(async (accountPassword) => {
+      await deletePasskey(currentToken(), id, accountPassword);
       await reload();
-    } catch (value) {
-      setError(errorMessage(value));
-    } finally {
-      setBusy(false);
-      setArmedRemoval(null);
-    }
+    });
+    setArmedRemoval(null);
   };
 
   return (
@@ -147,6 +150,22 @@ const PasskeySettings: Component = () => {
         {(current) => (
           <>
             <p>Mode: {current.mode}</p>
+            {/* #729 — ONE explicitly-labelled re-auth field, above every
+                control that consumes it, instead of a field nested in the
+                add-passkey form that four sibling buttons read behind the
+                user's back. It is cleared after each action (see
+                `withPassword`), so each one re-confirms. */}
+            <label for="passkey-password">Account password</label>
+            <input
+              id="passkey-password"
+              type="password"
+              autocomplete="current-password"
+              value={password()}
+              onInput={(e) => setPassword(e.currentTarget.value)}
+            />
+            <p role="note">
+              Every change below needs your account password. It is cleared after each one.
+            </p>
             <ul>
               <For each={current.passkeys}>
                 {(passkey) => (
@@ -176,15 +195,6 @@ const PasskeySettings: Component = () => {
                 data-protonpass-ignore="true"
                 value={name()}
                 onInput={(e) => setName(e.currentTarget.value)}
-                required
-              />
-              <label for="passkey-password">Account password</label>
-              <input
-                id="passkey-password"
-                type="password"
-                autocomplete="current-password"
-                value={password()}
-                onInput={(e) => setPassword(e.currentTarget.value)}
                 required
               />
               <button type="submit" disabled={busy()}>

--- a/cicchetto/src/PasskeySettings.tsx
+++ b/cicchetto/src/PasskeySettings.tsx
@@ -12,6 +12,8 @@ import {
   startPasswordlessActivation,
 } from "./lib/api";
 import { token } from "./lib/auth";
+import { copyText } from "./lib/clipboard";
+import { errorMessage } from "./lib/friendlyApiError";
 import { createPasskey, getPasskey } from "./lib/passkeys";
 
 const PasskeySettings: Component = () => {
@@ -36,7 +38,7 @@ const PasskeySettings: Component = () => {
   const reload = async (): Promise<void> => {
     setStatus(await getPasskeyStatus(currentToken()));
   };
-  onMount(() => void reload().catch((value) => setError(String(value))));
+  onMount(() => void reload().catch((value) => setError(errorMessage(value))));
 
   const register = async (event: Event): Promise<void> => {
     event.preventDefault();
@@ -48,7 +50,7 @@ const PasskeySettings: Component = () => {
       setName("");
       await reload();
     } catch (value) {
-      setError(value instanceof Error ? value.message : String(value));
+      setError(errorMessage(value));
     } finally {
       setBusy(false);
     }
@@ -62,7 +64,7 @@ const PasskeySettings: Component = () => {
       await finishPasskeyModeChange(currentToken(), await getPasskey(options));
       await reload();
     } catch (value) {
-      setError(value instanceof Error ? value.message : String(value));
+      setError(errorMessage(value));
     } finally {
       setBusy(false);
     }
@@ -78,7 +80,7 @@ const PasskeySettings: Component = () => {
       setRecoveryToken(null);
       await reload();
     } catch (value) {
-      setError(value instanceof Error ? value.message : String(value));
+      setError(errorMessage(value));
     } finally {
       setBusy(false);
     }
@@ -92,7 +94,7 @@ const PasskeySettings: Component = () => {
       setCodes(prepared.recovery_codes);
       setRecoveryToken(prepared.recovery_token);
     } catch (value) {
-      setError(value instanceof Error ? value.message : String(value));
+      setError(errorMessage(value));
     } finally {
       setBusy(false);
     }
@@ -109,7 +111,7 @@ const PasskeySettings: Component = () => {
       setRecoveryToken(null);
       await reload();
     } catch (value) {
-      setError(value instanceof Error ? value.message : String(value));
+      setError(errorMessage(value));
     } finally {
       setBusy(false);
     }
@@ -118,9 +120,9 @@ const PasskeySettings: Component = () => {
   const copyRecoveryCodes = async (): Promise<void> => {
     setError(null);
     try {
-      await navigator.clipboard.writeText(codes().join("\n"));
+      await copyText(codes().join("\n"));
     } catch (value) {
-      setError(value instanceof Error ? value.message : String(value));
+      setError(errorMessage(value));
     }
   };
 
@@ -130,7 +132,7 @@ const PasskeySettings: Component = () => {
       await deletePasskey(currentToken(), id, password());
       await reload();
     } catch (value) {
-      setError(value instanceof Error ? value.message : String(value));
+      setError(errorMessage(value));
     } finally {
       setBusy(false);
       setArmedRemoval(null);

--- a/cicchetto/src/PasskeySettings.tsx
+++ b/cicchetto/src/PasskeySettings.tsx
@@ -14,7 +14,7 @@ import {
 import { token } from "./lib/auth";
 import { copyText } from "./lib/clipboard";
 import { errorMessage } from "./lib/friendlyApiError";
-import { createPasskey, getPasskey } from "./lib/passkeys";
+import { createPasskey, getPasskey, PASSKEYS_UNAVAILABLE, passkeysAvailable } from "./lib/passkeys";
 
 const PasskeySettings: Component = () => {
   const [status, setStatus] = createSignal<PasskeyStatus | null>(null);
@@ -29,6 +29,14 @@ const PasskeySettings: Component = () => {
   // existing two-tap InlineConfirmButton rather than firing on first tap.
   // One armed id across the whole list: arming a row disarms its siblings.
   const [armedRemoval, setArmedRemoval] = createSignal<string | null>(null);
+
+  // #725 — WebAuthn is either present for this whole page load or it is not
+  // (the browser withholds `navigator.credentials` off a secure context), so
+  // this is read ONCE at setup rather than made reactive. Every control that
+  // needs a ceremony hides behind it and a note names the reason; removal
+  // does NOT, because deleting a stored credential runs no ceremony and is
+  // the one useful thing left to do here on a plain-http instance.
+  const webauthn = passkeysAvailable();
 
   const currentToken = (): string => {
     const value = token();
@@ -166,6 +174,11 @@ const PasskeySettings: Component = () => {
             <p role="note">
               Every change below needs your account password. It is cleared after each one.
             </p>
+            <Show when={!webauthn}>
+              <p role="note" data-testid="passkeys-unavailable">
+                {PASSKEYS_UNAVAILABLE} You can still remove passkeys you already registered.
+              </p>
+            </Show>
             <ul>
               <For each={current.passkeys}>
                 {(passkey) => (
@@ -184,24 +197,26 @@ const PasskeySettings: Component = () => {
                 )}
               </For>
             </ul>
-            <form onSubmit={register}>
-              <label for="passkey-name">Passkey name</label>
-              <input
-                id="passkey-name"
-                autocomplete="off"
-                data-1p-ignore
-                data-bwignore="true"
-                data-lpignore="true"
-                data-protonpass-ignore="true"
-                value={name()}
-                onInput={(e) => setName(e.currentTarget.value)}
-                required
-              />
-              <button type="submit" disabled={busy()}>
-                add passkey
-              </button>
-            </form>
-            <Show when={current.passkeys.length > 0}>
+            <Show when={webauthn}>
+              <form onSubmit={register}>
+                <label for="passkey-name">Passkey name</label>
+                <input
+                  id="passkey-name"
+                  autocomplete="off"
+                  data-1p-ignore
+                  data-bwignore="true"
+                  data-lpignore="true"
+                  data-protonpass-ignore="true"
+                  value={name()}
+                  onInput={(e) => setName(e.currentTarget.value)}
+                  required
+                />
+                <button type="submit" disabled={busy()}>
+                  add passkey
+                </button>
+              </form>
+            </Show>
+            <Show when={webauthn && current.passkeys.length > 0}>
               <button type="button" disabled={busy()} onClick={() => void enableSecondFactor()}>
                 require password + passkey
               </button>
@@ -218,7 +233,7 @@ const PasskeySettings: Component = () => {
                 account. Shottino cannot log in.
               </p>
             </Show>
-            <Show when={current.mode !== "disabled"}>
+            <Show when={webauthn && current.mode !== "disabled"}>
               <button type="button" disabled={busy()} onClick={() => void disablePasskeyLogin()}>
                 return to password login
               </button>

--- a/cicchetto/src/TotpSettings.tsx
+++ b/cicchetto/src/TotpSettings.tsx
@@ -1,6 +1,5 @@
 import { type Component, createSignal, For, onMount, Show } from "solid-js";
 import {
-  ApiError,
   confirmTotpEnrollment,
   disableTotp,
   getTotpStatus,
@@ -8,7 +7,8 @@ import {
   type TotpEnrollment,
 } from "./lib/api";
 import { token } from "./lib/auth";
-import { friendlyApiError } from "./lib/friendlyApiError";
+import { copyText } from "./lib/clipboard";
+import { errorMessage } from "./lib/friendlyApiError";
 import { qrSvgWithLabel } from "./lib/qr";
 import PasskeySettings from "./PasskeySettings";
 
@@ -30,7 +30,7 @@ const TotpSettings: Component<Props> = (props) => {
   };
 
   const reportError = (value: unknown): void => {
-    setError(value instanceof ApiError ? friendlyApiError(value) : String(value));
+    setError(errorMessage(value));
   };
 
   onMount(() => {
@@ -89,7 +89,12 @@ const TotpSettings: Component<Props> = (props) => {
   };
 
   const copyRecoveryCodes = async (): Promise<void> => {
-    await navigator.clipboard.writeText(recoveryCodes().join("\n"));
+    setError(null);
+    try {
+      await copyText(recoveryCodes().join("\n"));
+    } catch (value) {
+      reportError(value);
+    }
   };
 
   return (

--- a/cicchetto/src/__tests__/Login.test.tsx
+++ b/cicchetto/src/__tests__/Login.test.tsx
@@ -319,8 +319,11 @@ describe("Login — #442 alternate auth (passkey / recovery code)", () => {
     await waitFor(() => {
       expect(auth.loginWithPasskey).toHaveBeenCalledWith("my_nick");
     });
-    // Same correction-is-visible contract as the Connect path.
-    expect((nickField() as HTMLInputElement).value).toBe("my_nick");
+    // #727 — a succeeding ceremony now holds the connecting view and leaves,
+    // exactly like Connect, so the form is gone by here. The
+    // correction-is-visible half of this contract is asserted on the FAILURE
+    // path below, which is where the user still has a form to read.
+    expect(screen.getByTestId("login-connecting")).toBeInTheDocument();
   });
 
   it("refuses to start the ceremony with an empty identifier", async () => {
@@ -340,12 +343,15 @@ describe("Login — #442 alternate auth (passkey / recovery code)", () => {
       new Error("Passkey authentication cancelled"),
     );
     renderLogin();
-    fireEvent.input(nickField(), { target: { value: "alice" } });
+    fireEvent.input(nickField(), { target: { value: "my nick" } });
     fireEvent.click(passkeyBtn());
     await waitFor(() => {
       expect(screen.getByRole("alert")).toHaveTextContent(/passkey authentication cancelled/i);
     });
     expect(nickField()).toBeInTheDocument();
+    // Same correction-is-visible contract as the Connect path: the field the
+    // user comes back to shows what was actually sent.
+    expect((nickField() as HTMLInputElement).value).toBe("my_nick");
   });
 
   it("renders friendly copy for an ApiError from the ceremony", async () => {
@@ -355,6 +361,84 @@ describe("Login — #442 alternate auth (passkey / recovery code)", () => {
     fireEvent.click(passkeyBtn());
     await waitFor(() => {
       expect(screen.getByRole("alert")).toHaveTextContent(/invalid name or password/i);
+    });
+  });
+
+  // #727 — `onSubmit` swaps in the connecting view while the password login
+  // is in flight; its two siblings did not, and neither button was ever
+  // disabled. Both are fired as `void`, so the user got zero feedback and a
+  // second click went straight through.
+  describe("#727 the alternative doors share the in-flight latch", () => {
+    const pending = <T,>(): Promise<T> => new Promise<T>(() => {});
+
+    it("a double click on Recover account spends the one-shot code once", async () => {
+      // Two `POST /auth/passkeys/recover` with the SAME code: one consumes
+      // it and navigates, the other returns `invalid_two_factor` AND books a
+      // hit in the server's `passkey_recovery` throttle window (10 failures /
+      // 15 min). One impatient double-click burns a recovery code and a slice
+      // of the lockout budget.
+      vi.mocked(auth.loginWithRecoveryCode).mockReturnValue(pending<void>());
+      renderLogin();
+      fireEvent.input(nickField(), { target: { value: "alice" } });
+      fireEvent.click(screen.getByRole("button", { name: "Recovery code" }));
+      fireEvent.input(screen.getByLabelText(/^recovery code$/i), {
+        target: { value: "abcd-1234" },
+      });
+
+      const recover = screen.getByRole("button", { name: /recover account/i });
+      fireEvent.click(recover);
+      fireEvent.click(recover);
+
+      expect(auth.loginWithRecoveryCode).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("login-connecting")).toBeInTheDocument();
+    });
+
+    it("a double click on Passkey starts one ceremony", async () => {
+      // A second ceremony while the first is pending is rejected outright by
+      // Chrome ("A request is already pending").
+      vi.mocked(auth.loginWithPasskey).mockReturnValue(pending<void>());
+      renderLogin();
+      fireEvent.input(nickField(), { target: { value: "alice" } });
+
+      const button = passkeyBtn();
+      fireEvent.click(button);
+      fireEvent.click(button);
+
+      expect(auth.loginWithPasskey).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("login-connecting")).toBeInTheDocument();
+    });
+
+    it("gives the recovery flow the same in-flight feedback the password login has", async () => {
+      vi.mocked(auth.loginWithRecoveryCode).mockReturnValue(pending<void>());
+      renderLogin();
+      fireEvent.input(nickField(), { target: { value: "alice" } });
+      fireEvent.click(screen.getByRole("button", { name: "Recovery code" }));
+      fireEvent.input(screen.getByLabelText(/^recovery code$/i), {
+        target: { value: "abcd-1234" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /recover account/i }));
+
+      await waitFor(() => expect(screen.getByTestId("login-connecting")).toBeInTheDocument());
+      expect(screen.queryByLabelText(/nick or email/i)).toBeNull();
+    });
+
+    it("hands the card back when the alternative door fails", async () => {
+      // The latch must not strand the user in the spinner: a refused code
+      // reverts to the form with the reason, exactly like Connect does.
+      vi.mocked(auth.loginWithRecoveryCode).mockRejectedValue(
+        new ApiError(401, "invalid_two_factor"),
+      );
+      renderLogin();
+      fireEvent.input(nickField(), { target: { value: "alice" } });
+      fireEvent.click(screen.getByRole("button", { name: "Recovery code" }));
+      fireEvent.input(screen.getByLabelText(/^recovery code$/i), { target: { value: "nope" } });
+      fireEvent.click(screen.getByRole("button", { name: /recover account/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toHaveTextContent(/invalid or already-used/i);
+      });
+      expect(screen.queryByTestId("login-connecting")).toBeNull();
+      expect(nickField()).toBeInTheDocument();
     });
   });
 

--- a/cicchetto/src/__tests__/Login.test.tsx
+++ b/cicchetto/src/__tests__/Login.test.tsx
@@ -284,6 +284,7 @@ describe("Login — TOTP", () => {
     vi.mocked(auth.login).mockResolvedValue({
       kind: "totp",
       challengeToken: "challenge-123",
+      passkeyError: null,
     });
     vi.mocked(auth.verifyTotp).mockResolvedValue(undefined);
     renderLogin();
@@ -553,6 +554,58 @@ describe("Login — #442 alternate auth (passkey / recovery code)", () => {
       expect(screen.getByRole("alert")).toHaveTextContent(/account name or email first/i);
     });
     expect(auth.loginWithRecoveryCode).not.toHaveBeenCalled();
+  });
+});
+
+// #728 — the passkey second factor used to degrade to this form with the
+// error discarded. Cancel, no authenticator, a 401 on the assertion, a
+// network blip: all four vanished the prompt and produced a bare 2FA form.
+// From the outside they were indistinguishable, and a user without their
+// phone to hand concludes the passkey itself is broken.
+describe("Login — #728 the TOTP fallback says why the passkey didn't run", () => {
+  const totpAfterPasskeyFailure = (passkeyError: unknown) => {
+    vi.mocked(auth.login).mockResolvedValue({
+      kind: "totp",
+      challengeToken: "challenge-123",
+      passkeyError,
+    });
+    renderLogin();
+    fireEvent.input(nickField(), { target: { value: "alice@example.com" } });
+    fireEvent.input(screen.getByLabelText(/password/i), { target: { value: "secret" } });
+    fireEvent.click(connectBtn());
+  };
+
+  it("names a dismissed prompt above the code field", async () => {
+    totpAfterPasskeyFailure(new Error("Passkey authentication cancelled"));
+
+    const note = await screen.findByTestId("totp-passkey-fallback");
+    expect(note).toHaveTextContent(/Passkey authentication cancelled/);
+    expect(note).toHaveTextContent(/authenticator or a recovery code/i);
+  });
+
+  it("renders a server refusal as friendly copy, not a wire token", async () => {
+    totpAfterPasskeyFailure(new ApiError(401, "invalid_credentials"));
+
+    const note = await screen.findByTestId("totp-passkey-fallback");
+    expect(note).toHaveTextContent("Invalid name or password.");
+    expect(screen.queryByText(/401 invalid_credentials/)).toBeNull();
+  });
+
+  it("says nothing when no passkey was attempted", async () => {
+    totpAfterPasskeyFailure(null);
+
+    await screen.findByTestId("totp-login-form");
+    expect(screen.queryByTestId("totp-passkey-fallback")).toBeNull();
+  });
+
+  it("drops the note when the user backs out to the credential form", async () => {
+    totpAfterPasskeyFailure(new Error("Passkey authentication cancelled"));
+    await screen.findByTestId("totp-passkey-fallback");
+
+    fireEvent.click(screen.getByRole("button", { name: /back/i }));
+
+    expect(screen.queryByTestId("totp-passkey-fallback")).toBeNull();
+    expect(nickField()).toBeInTheDocument();
   });
 });
 

--- a/cicchetto/src/__tests__/Login.test.tsx
+++ b/cicchetto/src/__tests__/Login.test.tsx
@@ -393,6 +393,73 @@ describe("Login — #442 alternate auth (passkey / recovery code)", () => {
     });
   });
 
+  // #724 — the recovery block used to render INSIDE the credential form. Its
+  // input carries `required` and its button is `type="button"`, so the form's
+  // implicit submission target stayed `onSubmit` (the PASSWORD login) while
+  // the recovery input still took part in the form's constraint validation.
+  // Two user-visible consequences, one per test.
+  const recoveryField = () => screen.getByLabelText(/^recovery code$/i) as HTMLInputElement;
+
+  it("Enter in the recovery field runs recovery, NOT the password login", async () => {
+    // The user types a code and presses Enter. Implicit submission used to
+    // fire the ENCLOSING form's onSubmit — the password login — with whatever
+    // was in the credential fields, and the recovery code was never sent at
+    // all. With a nick and an empty password that is the guest path: a fresh
+    // anonymous session instead of a recovered account.
+    //
+    // jsdom implements no implicit submission, so the wrong-flow half of that
+    // is not observable here; what IS pinned is the fix's contract — Enter in
+    // this field runs recovery, and never the password login.
+    vi.mocked(auth.loginWithRecoveryCode).mockResolvedValue(undefined);
+    renderLogin();
+    fireEvent.input(nickField(), { target: { value: "alice" } });
+    fireEvent.click(screen.getByRole("button", { name: "Recovery code" }));
+    fireEvent.input(recoveryField(), { target: { value: "abcd-1234" } });
+
+    fireEvent.keyDown(recoveryField(), { key: "Enter" });
+
+    await waitFor(() => {
+      expect(auth.loginWithRecoveryCode).toHaveBeenCalledWith("alice", "abcd-1234");
+    });
+    expect(auth.login).not.toHaveBeenCalled();
+  });
+
+  it("names an empty recovery code instead of posting it", async () => {
+    // `required` used to supply this, from inside the wrong form. Dropping it
+    // without replacement would silently POST an empty code.
+    renderLogin();
+    fireEvent.input(nickField(), { target: { value: "alice" } });
+    fireEvent.click(screen.getByRole("button", { name: "Recovery code" }));
+    fireEvent.click(screen.getByRole("button", { name: /recover account/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/recovery code/i);
+    });
+    expect(auth.loginWithRecoveryCode).not.toHaveBeenCalled();
+  });
+
+  it("an abandoned recovery field does not block an ordinary login", async () => {
+    // Toggle recovery on, think better of it, leave it empty, click Connect.
+    // `required` inside the credential form made native validation refuse the
+    // submit and point at a field unrelated to the credentials just typed.
+    vi.mocked(auth.login).mockResolvedValue({ kind: "authenticated" });
+    renderLogin();
+    fireEvent.input(nickField(), { target: { value: "alice" } });
+    fireEvent.input(screen.getByLabelText(/password/i), { target: { value: "secret" } });
+    fireEvent.click(screen.getByRole("button", { name: "Recovery code" }));
+    expect(recoveryField().value).toBe("");
+
+    fireEvent.click(connectBtn());
+
+    await waitFor(() => {
+      expect(auth.login).toHaveBeenCalledWith("alice", "secret", undefined, {
+        ident: "",
+        realname: "",
+        incognito: false,
+      });
+    });
+  });
+
   it("refuses to recover with an empty identifier", async () => {
     renderLogin();
     fireEvent.click(screen.getByRole("button", { name: "Recovery code" }));

--- a/cicchetto/src/__tests__/PasskeySettings.test.tsx
+++ b/cicchetto/src/__tests__/PasskeySettings.test.tsx
@@ -35,11 +35,14 @@ vi.mock("../lib/auth", () => ({ token: () => "test-token" }));
 const passkeys = vi.hoisted(() => ({
   createPasskey: vi.fn(),
   getPasskey: vi.fn(),
+  passkeysAvailable: vi.fn(() => true),
 }));
 
 vi.mock("../lib/passkeys", () => ({
   createPasskey: passkeys.createPasskey,
   getPasskey: passkeys.getPasskey,
+  PASSKEYS_UNAVAILABLE: "Passkeys need a secure (HTTPS) connection.",
+  passkeysAvailable: passkeys.passkeysAvailable,
 }));
 
 import { ApiError } from "../lib/api";
@@ -70,6 +73,7 @@ describe("PasskeySettings", () => {
     api.finishPasskeyRegistration.mockResolvedValue(undefined);
     passkeys.createPasskey.mockResolvedValue({ attestation: true });
     passkeys.getPasskey.mockResolvedValue({ assertion: true });
+    passkeys.passkeysAvailable.mockReturnValue(true);
   });
 
   const addPasskey = async (): Promise<void> => {
@@ -213,6 +217,25 @@ describe("PasskeySettings", () => {
       expect(screen.getByRole("alert")).toHaveTextContent("Invalid name or password."),
     );
     expect((screen.getByLabelText("Account password") as HTMLInputElement).value).toBe("");
+  });
+
+  // #725 — on a plain-http instance every ceremony in this pane is
+  // impossible. Offering the controls anyway meant a click ended in
+  // `TypeError: undefined is not an object (evaluating
+  // 'navigator.credentials.create')` on the card. Say why instead — and keep
+  // removal, which runs no ceremony and is the one thing still useful here.
+  it("replaces the ceremony controls with a reason when WebAuthn is unavailable", async () => {
+    passkeys.passkeysAvailable.mockReturnValue(false);
+    render(() => <PasskeySettings />);
+
+    await screen.findByText("Mode: passwordless");
+    expect(screen.getByTestId("passkeys-unavailable")).toHaveTextContent(/secure \(HTTPS\)/);
+    expect(screen.queryByRole("button", { name: "add passkey" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "require password + passkey" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "use passkey as primary login" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "return to password login" })).toBeNull();
+    // Deleting a stored credential needs no ceremony, so it stays offered.
+    expect(screen.getByTestId("passkey-remove-passkey-1")).toBeInTheDocument();
   });
 
   it("returns a passwordless account to password login with password and passkey", async () => {

--- a/cicchetto/src/__tests__/PasskeySettings.test.tsx
+++ b/cicchetto/src/__tests__/PasskeySettings.test.tsx
@@ -151,6 +151,70 @@ describe("PasskeySettings", () => {
     expect(screen.queryByText(/409 passkey_required/)).toBeNull();
   });
 
+  // #729 — the password field used to live INSIDE the add-passkey form while
+  // four other privileged actions read the same signal from outside it. A
+  // user who never filled that form and clicks "remove" sent `""` as their
+  // password and got a 401 back, with nothing on screen saying a password was
+  // expected. Refuse locally and name the blocker.
+  it("refuses a privileged action with no password instead of firing a doomed request", async () => {
+    render(() => <PasskeySettings />);
+
+    await screen.findByText("Mode: passwordless");
+    await fireEvent.click(screen.getByTestId("passkey-remove-passkey-1"));
+    await fireEvent.click(screen.getByTestId("passkey-remove-passkey-1"));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/account password/i));
+    expect(api.deletePasskey).not.toHaveBeenCalled();
+  });
+
+  it("refuses a mode change with no password", async () => {
+    render(() => <PasskeySettings />);
+
+    await screen.findByText("Mode: passwordless");
+    await fireEvent.click(screen.getByRole("button", { name: "require password + passkey" }));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/account password/i));
+    expect(api.startPasskeyModeChange).not.toHaveBeenCalled();
+  });
+
+  // The other half of #729: the password stayed live in the signal and in the
+  // DOM for the whole drawer session, so a password typed to ADD a passkey
+  // was silently reused to change HOW THE ACCOUNT AUTHENTICATES. Clearing it
+  // after every action that consumed it makes the second action re-confirm.
+  it("clears the password after an action so the next one must re-confirm", async () => {
+    render(() => <PasskeySettings />);
+
+    await screen.findByText("Mode: passwordless");
+    await addPasskey();
+    // The clear lands in the action's `finally`, one `reload()` after the
+    // registration call — wait for the field itself, not for the call.
+    await waitFor(() =>
+      expect((screen.getByLabelText("Account password") as HTMLInputElement).value).toBe(""),
+    );
+    expect(api.finishPasskeyRegistration).toHaveBeenCalled();
+
+    await fireEvent.click(screen.getByRole("button", { name: "use passkey as primary login" }));
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/account password/i));
+    expect(api.preparePasswordless).not.toHaveBeenCalled();
+  });
+
+  it("clears the password after a REFUSED action too", async () => {
+    // A wrong password must not linger for the next click to reuse.
+    api.startPasskeyModeChange.mockRejectedValue(new ApiError(401, "invalid_credentials"));
+    render(() => <PasskeySettings />);
+
+    await screen.findByText("Mode: passwordless");
+    await fireEvent.input(screen.getByLabelText("Account password"), {
+      target: { value: "wrong" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "require password + passkey" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent("Invalid name or password."),
+    );
+    expect((screen.getByLabelText("Account password") as HTMLInputElement).value).toBe("");
+  });
+
   it("returns a passwordless account to password login with password and passkey", async () => {
     render(() => <PasskeySettings />);
 

--- a/cicchetto/src/__tests__/PasskeySettings.test.tsx
+++ b/cicchetto/src/__tests__/PasskeySettings.test.tsx
@@ -2,23 +2,33 @@ import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const api = vi.hoisted(() => ({
+  deletePasskey: vi.fn(),
   finishPasskeyModeChange: vi.fn(),
   finishPasskeyRegistration: vi.fn(),
   getPasskeyStatus: vi.fn(),
+  preparePasswordless: vi.fn(),
   startPasskeyModeChange: vi.fn(),
   startPasskeyRegistration: vi.fn(),
 }));
 
-vi.mock("../lib/api", () => ({
-  deletePasskey: vi.fn(),
-  finishPasskeyModeChange: api.finishPasskeyModeChange,
-  finishPasskeyRegistration: api.finishPasskeyRegistration,
-  getPasskeyStatus: api.getPasskeyStatus,
-  preparePasswordless: vi.fn(),
-  startPasskeyModeChange: api.startPasskeyModeChange,
-  startPasskeyRegistration: api.startPasskeyRegistration,
-  startPasswordlessActivation: vi.fn(),
-}));
+// #726 — spread from the real module (mirroring TotpSettings.test.tsx) so
+// `ApiError` stays the genuine class. The pane's error reporting narrows on
+// `instanceof ApiError` to pick friendly copy over the raw `<status> <code>`
+// wire token, and a hand-rolled stand-in silently takes the wrong arm.
+vi.mock("../lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/api")>();
+  return {
+    ...actual,
+    deletePasskey: api.deletePasskey,
+    finishPasskeyModeChange: api.finishPasskeyModeChange,
+    finishPasskeyRegistration: api.finishPasskeyRegistration,
+    getPasskeyStatus: api.getPasskeyStatus,
+    preparePasswordless: api.preparePasswordless,
+    startPasskeyModeChange: api.startPasskeyModeChange,
+    startPasskeyRegistration: api.startPasskeyRegistration,
+    startPasswordlessActivation: vi.fn(),
+  };
+});
 
 vi.mock("../lib/auth", () => ({ token: () => "test-token" }));
 
@@ -32,11 +42,17 @@ vi.mock("../lib/passkeys", () => ({
   getPasskey: passkeys.getPasskey,
 }));
 
+import { ApiError } from "../lib/api";
 import PasskeySettings from "../PasskeySettings";
 
 describe("PasskeySettings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    api.deletePasskey.mockResolvedValue(undefined);
+    api.preparePasswordless.mockResolvedValue({
+      recovery_codes: ["aaa-111", "bbb-222"],
+      recovery_token: "recovery-1",
+    });
     api.getPasskeyStatus.mockResolvedValue({
       mode: "passwordless",
       passkeys: [
@@ -100,6 +116,39 @@ describe("PasskeySettings", () => {
     expect(screen.getByRole("button", { name: "add passkey" })).not.toBeDisabled();
     // The typed name survives — the retry does not start from a blank form.
     expect((screen.getByLabelText("Passkey name") as HTMLInputElement).value).toBe("phone");
+  });
+
+  // #726 — `ApiError.message` is the literal `${status} ${code}`, so a pane
+  // that reports `value.message` prints a wire token at the user. The sibling
+  // TOTP pane already routes through `friendlyApiError`; this one did not.
+  it("renders friendly copy for a server error instead of the raw wire token", async () => {
+    api.startPasskeyRegistration.mockRejectedValue(new ApiError(401, "invalid_credentials"));
+    render(() => <PasskeySettings />);
+
+    await screen.findByText("Mode: passwordless");
+    await addPasskey();
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent("Invalid name or password."),
+    );
+    expect(screen.queryByText(/401 invalid_credentials/)).toBeNull();
+  });
+
+  it("renders friendly copy when a removal is refused, not the raw wire token", async () => {
+    // #696's `passkey_required` 409 is the removal a user is most likely to
+    // trip — the last passkey while passkey sign-in is still on.
+    api.deletePasskey.mockRejectedValue(new ApiError(409, "passkey_required"));
+    render(() => <PasskeySettings />);
+
+    await screen.findByText("Mode: passwordless");
+    await fireEvent.input(screen.getByLabelText("Account password"), {
+      target: { value: "correct horse battery staple" },
+    });
+    await fireEvent.click(screen.getByTestId("passkey-remove-passkey-1"));
+    await fireEvent.click(screen.getByTestId("passkey-remove-passkey-1"));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/only passkey/i));
+    expect(screen.queryByText(/409 passkey_required/)).toBeNull();
   });
 
   it("returns a passwordless account to password login with password and passkey", async () => {

--- a/cicchetto/src/__tests__/TotpSettings.test.tsx
+++ b/cicchetto/src/__tests__/TotpSettings.test.tsx
@@ -30,6 +30,8 @@ vi.mock("../lib/auth", () => ({ token: () => "test-token" }));
 vi.mock("../lib/passkeys", () => ({
   createPasskey: vi.fn(),
   getPasskey: vi.fn(),
+  PASSKEYS_UNAVAILABLE: "unavailable",
+  passkeysAvailable: () => true,
 }));
 
 import { ApiError } from "../lib/api";

--- a/cicchetto/src/__tests__/TotpSettings.test.tsx
+++ b/cicchetto/src/__tests__/TotpSettings.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor, within } from "@solidjs/testing-library";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 
 // #736 — the TOTP enrolment surface shipped with no component coverage: the
 // only tests over the security pane drove `auth.ts` (the store) or the
@@ -98,6 +98,60 @@ describe("TotpSettings — enrolment", () => {
     expect((screen.getByLabelText("Manual key") as HTMLInputElement).value).toBe(ENROLLMENT.secret);
     expect(screen.getByRole("button", { name: "confirm and enable" })).not.toBeDisabled();
     expect(screen.queryByTestId("totp-recovery-codes")).toBeNull();
+  });
+
+  // #726 — the recovery codes are shown EXACTLY once. A copy that fails and
+  // says nothing sends the user away believing ten one-shot codes are on the
+  // clipboard; the codes are gone the moment the pane re-renders. Both arms
+  // are reachable on a plain-http instance, where `navigator.clipboard` is
+  // `undefined` (the API is [SecureContext]-only) — not a hypothetical.
+  const showRecoveryCodes = async (): Promise<void> => {
+    api.confirmTotpEnrollment.mockResolvedValue({ recovery_codes: ["aaa-111", "bbb-222"] });
+    renderSettings();
+    await beginEnrollment();
+    await confirmCode("123456");
+    await screen.findByTestId("totp-recovery-codes");
+  };
+
+  const withClipboard = (value: unknown): void => {
+    const original = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+    Object.defineProperty(navigator, "clipboard", { value, configurable: true });
+    onTestFinished(() => {
+      if (original === undefined) {
+        Reflect.deleteProperty(navigator, "clipboard");
+      } else {
+        Object.defineProperty(navigator, "clipboard", original);
+      }
+    });
+  };
+
+  it("names a rejected clipboard write instead of losing the codes silently", async () => {
+    withClipboard({ writeText: vi.fn().mockRejectedValue(new Error("Write permission denied.")) });
+    await showRecoveryCodes();
+
+    await fireEvent.click(screen.getByRole("button", { name: "copy recovery codes" }));
+
+    await waitFor(() =>
+      expect(within(screen.getByTestId("totp-settings")).getByRole("alert")).toHaveTextContent(
+        "Write permission denied.",
+      ),
+    );
+    // The codes stay on screen — the user's fallback is to copy them by hand.
+    expect(screen.getByText("aaa-111")).toBeInTheDocument();
+  });
+
+  it("names a missing clipboard API instead of throwing a raw TypeError", async () => {
+    withClipboard(undefined);
+    await showRecoveryCodes();
+
+    await fireEvent.click(screen.getByRole("button", { name: "copy recovery codes" }));
+
+    await waitFor(() =>
+      expect(within(screen.getByTestId("totp-settings")).getByRole("alert")).toHaveTextContent(
+        /secure/i,
+      ),
+    );
+    expect(screen.getByText("aaa-111")).toBeInTheDocument();
   });
 
   it("surfaces a rejected password when disabling instead of silently no-opping", async () => {

--- a/cicchetto/src/__tests__/auth.test.ts
+++ b/cicchetto/src/__tests__/auth.test.ts
@@ -93,6 +93,8 @@ describe("auth signal store", () => {
     await expect(auth.login("alice", "secret")).resolves.toEqual({
       kind: "totp",
       challengeToken: "challenge-123",
+      // #728 — no passkey was attempted, so there is nothing to explain.
+      passkeyError: null,
     });
     expect(auth.token()).toBeNull();
     expect(localStorage.getItem("grappa-token")).toBeNull();
@@ -156,6 +158,9 @@ describe("auth signal store", () => {
       await expect(auth.login("alice", "secret")).resolves.toEqual({
         kind: "totp",
         challengeToken: "challenge-123",
+        // #728 — the degrade is silent no longer: the reason rides along so
+        // the TOTP form can say why the passkey prompt vanished.
+        passkeyError: new Error("Passkey authentication cancelled"),
       });
 
       expect(api.verifyPasskeySecondFactor).not.toHaveBeenCalled();
@@ -176,6 +181,9 @@ describe("auth signal store", () => {
       await expect(auth.login("alice", "secret")).resolves.toEqual({
         kind: "totp",
         challengeToken: "challenge-123",
+        // A server-side rejection is as distinguishable as a user cancel —
+        // from the OUTSIDE they used to look identical.
+        passkeyError: new Error("challenge_expired"),
       });
       expect(auth.token()).toBeNull();
     });

--- a/cicchetto/src/__tests__/passkeys.test.ts
+++ b/cicchetto/src/__tests__/passkeys.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createPasskey, getPasskey } from "../lib/passkeys";
+import { createPasskey, getPasskey, passkeysAvailable } from "../lib/passkeys";
 
 // The server speaks snake_case and `navigator.credentials` speaks the
 // camelCase WebAuthn shape; lib/passkeys.ts is the only place that
@@ -47,7 +47,59 @@ beforeEach(() => {
   vi.stubGlobal("navigator", { credentials: { create, get } });
 });
 
+// #725 — `CredentialsContainer` is [SecureContext]-only, so on a plain-http
+// deployment (grappa is self-hosted; an operator on `http://192.168.1.10` is
+// a supported reality) `navigator.credentials` is `undefined` and both entry
+// points threw `TypeError: undefined is not an object (evaluating
+// 'navigator.credentials.get')` — a JavaScript internal printed verbatim on
+// the login card and in the settings pane.
+describe("an origin or browser without WebAuthn", () => {
+  const refusalFrom = async (run: () => Promise<unknown>): Promise<unknown> =>
+    run().then(
+      () => {
+        throw new Error("expected the ceremony to be refused");
+      },
+      (value: unknown) => value,
+    );
+
+  beforeEach(() => {
+    // Exactly what a browser hands you over plain http: no `credentials`.
+    vi.stubGlobal("navigator", {});
+  });
+
+  it("reports itself unavailable", () => {
+    expect(passkeysAvailable()).toBe(false);
+  });
+
+  it("refuses registration by name rather than throwing a raw TypeError", async () => {
+    const refusal = await refusalFrom(() =>
+      createPasskey({ challenge_id: "cid", public_key: { challenge: b64([1]) } }),
+    );
+
+    expect(refusal).toBeInstanceOf(Error);
+    expect(refusal).not.toBeInstanceOf(TypeError);
+    expect((refusal as Error).message).toMatch(/secure \(HTTPS\) connection/);
+  });
+
+  it("refuses authentication by name rather than throwing a raw TypeError", async () => {
+    const refusal = await refusalFrom(() =>
+      getPasskey({
+        challenge_id: "cid",
+        public_key: { challenge: b64([1]), rp_id: "irc.example" },
+      }),
+    );
+
+    expect(refusal).toBeInstanceOf(Error);
+    expect(refusal).not.toBeInstanceOf(TypeError);
+    expect((refusal as Error).message).toMatch(/secure \(HTTPS\) connection/);
+  });
+});
+
 describe("createPasskey", () => {
+  it("reports itself available when the browser implements the ceremony", () => {
+    expect(passkeysAvailable()).toBe(true);
+  });
+
   const options = {
     challenge_id: "cid",
     public_key: {

--- a/cicchetto/src/__tests__/securityPaneControls.test.tsx
+++ b/cicchetto/src/__tests__/securityPaneControls.test.tsx
@@ -152,13 +152,26 @@ describe("#735 each passkey remove button names its own passkey", () => {
   it("arms before deleting, so one mis-tap cannot destroy a credential", async () => {
     render(() => <PasskeySettings />);
 
-    await fireEvent.click(await screen.findByRole("button", { name: "remove phone" }));
+    // #729 — this used to confirm with an untouched password field and assert
+    // `deletePasskey(…, "")`, PINNING the defect: a removal fired with an
+    // empty password and came back 401. The arming contract under test here
+    // is unchanged; the password is now supplied because the pane refuses
+    // without one.
+    await fireEvent.input(await screen.findByLabelText("Account password"), {
+      target: { value: "correct horse battery staple" },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "remove phone" }));
     expect(api.deletePasskey).not.toHaveBeenCalled();
 
     // The armed label names the passkey too — a screen reader hears WHICH
     // credential the confirmation destroys, not a bare "confirm".
     await fireEvent.click(screen.getByRole("button", { name: "confirm removing phone" }));
-    expect(api.deletePasskey).toHaveBeenCalledWith("test-token", "passkey-1", "");
+    expect(api.deletePasskey).toHaveBeenCalledWith(
+      "test-token",
+      "passkey-1",
+      "correct horse battery staple",
+    );
   });
 
   it("arming one row disarms the other", async () => {

--- a/cicchetto/src/__tests__/securityPaneControls.test.tsx
+++ b/cicchetto/src/__tests__/securityPaneControls.test.tsx
@@ -42,6 +42,8 @@ vi.mock("../lib/auth", () => ({ token: () => "test-token" }));
 vi.mock("../lib/passkeys", () => ({
   createPasskey: vi.fn(),
   getPasskey: vi.fn(),
+  PASSKEYS_UNAVAILABLE: "unavailable",
+  passkeysAvailable: () => true,
 }));
 
 import PasskeySettings from "../PasskeySettings";

--- a/cicchetto/src/lib/auth.ts
+++ b/cicchetto/src/lib/auth.ts
@@ -82,6 +82,31 @@ export function isAuthenticated(): boolean {
   return tokenSignal() !== null;
 }
 
+// #728 — the passkey-second-factor branch used to wrap BOTH the browser
+// ceremony and `verifyPasskeySecondFactor` in one `try` and return a bare
+// TOTP challenge from the `catch`, discarding the error entirely. Every
+// distinct failure — user cancel, no authenticator present, a 401 on a
+// genuinely invalid assertion, a network error — collapsed into the same
+// silent outcome: the passkey prompt vanishes and a bare "two-factor
+// authentication" form appears with no explanation. A user whose phone isn't
+// at hand concludes their passkey has stopped working.
+//
+// The FALLBACK ITSELF is right and is kept for every failure, including a
+// server-side 401: the account still has a second factor the user can reach,
+// and throwing instead would strand them at the login card with no way in.
+// What was wrong is that the reason was thrown away. It rides along now, and
+// `Login.tsx` renders it above the TOTP form.
+//
+// The issue also suggested swallowing `NotAllowedError` (user cancel) and
+// surfacing only the rest. Declined: that is exactly the scenario the issue
+// itself describes — "they dismissed the OS sheet by accident" — and it is
+// the case that most needs the note. Chrome also reports a ceremony TIMEOUT
+// as NotAllowedError, so the special case would silence two very different
+// events. `null` means no passkey was attempted at all.
+export type LoginOutcome =
+  | { kind: "authenticated" }
+  | { kind: "totp"; challengeToken: string; passkeyError: unknown };
+
 export async function login(
   identifier: string,
   password: string | null,
@@ -92,7 +117,7 @@ export async function login(
   // #363 — `incognito` rides the same advanced bundle; only a literal true
   // is sent (absent → an ordinary persistent session).
   advanced?: { ident?: string | null; realname?: string | null; incognito?: boolean },
-): Promise<{ kind: "authenticated" } | { kind: "totp"; challengeToken: string }> {
+): Promise<LoginOutcome> {
   const req: api.LoginRequest =
     password !== null && password !== "" ? { identifier, password } : { identifier };
   if (captchaToken !== undefined) req.captcha_token = captchaToken;
@@ -114,12 +139,18 @@ export async function login(
         return { kind: "authenticated" };
       } catch (error) {
         if (response.challenge_token !== null) {
-          return { kind: "totp", challengeToken: response.challenge_token };
+          return {
+            kind: "totp",
+            challengeToken: response.challenge_token,
+            passkeyError: error,
+          };
         }
+        // No TOTP challenge was minted: passkey is the ONLY second factor,
+        // so there is nothing to degrade to and the error must surface.
         throw error;
       }
     }
-    return { kind: "totp", challengeToken: response.challenge_token };
+    return { kind: "totp", challengeToken: response.challenge_token, passkeyError: null };
   }
   installLogin(response);
   return { kind: "authenticated" };

--- a/cicchetto/src/lib/clipboard.ts
+++ b/cicchetto/src/lib/clipboard.ts
@@ -1,0 +1,27 @@
+// #726 — one clipboard write for the surfaces that show a secret exactly
+// once (TOTP recovery codes, passwordless recovery codes).
+//
+// `navigator.clipboard` is `[SecureContext]`-only, so on a plain-http
+// deployment — an operator serving grappa over `http://` on a LAN, which is
+// supported — the property is `undefined` and a bare `.writeText` throws a
+// raw `TypeError: undefined is not an object`. The write can also reject on a
+// denied permission or a non-user-gesture call.
+//
+// Neither failure may be silent HERE, whatever a caller elsewhere chooses:
+// recovery codes are displayed once and are unrecoverable afterwards, so a
+// user who believes the copy worked loses them. Throw with copy that names
+// the reason AND the way out (copy by hand), and let the caller render it.
+//
+// `ShareSessionModal` deliberately keeps its own silent catch and is NOT
+// routed through here: the artifact it copies is a URL still sitting in a
+// visible, selectable input, so the failure is self-correcting. Same call,
+// different stakes.
+export async function copyText(text: string): Promise<void> {
+  const clipboard: Clipboard | undefined = navigator.clipboard;
+  if (clipboard === undefined) {
+    throw new Error(
+      "This browser only allows copying over a secure (HTTPS) connection. Select the text and copy it by hand.",
+    );
+  }
+  await clipboard.writeText(text);
+}

--- a/cicchetto/src/lib/friendlyApiError.ts
+++ b/cicchetto/src/lib/friendlyApiError.ts
@@ -1,4 +1,4 @@
-import { type ApiError, assertNever } from "./api";
+import { ApiError, assertNever } from "./api";
 import { formatBytes } from "./formatBytes";
 import { ERROR_TOKENS_REST_ERROR_TOKEN, type ErrorTokensRestErrorToken } from "./wireTypes";
 
@@ -50,6 +50,30 @@ function isKnownCode(code: string): code is ErrorTokensRestErrorToken {
 export function friendlyApiError(err: ApiError): string {
   if (!isKnownCode(err.code)) return err.message;
   return friendlyKnown(err, err.code);
+}
+
+// #726 — a `catch` block holds an `unknown`, and every pane that renders one
+// answers the same question: what copy does the user get? The two account
+// -security panes answered it differently. `TotpSettings` narrowed on
+// `ApiError`; `PasskeySettings` printed `value.message`, which for an
+// `ApiError` is the literal `${status} ${code}` — the raw wire token this
+// module exists to keep off the screen. One definition, three arms:
+//
+//   ApiError → the localized copy above (never `.message`, never the token)
+//   Error    → its own message; a WebAuthn/DOMException rejection already
+//              carries browser-authored human text, and `String(err)` would
+//              prefix it with a useless "Error: "
+//   anything → `String(value)`, so a non-Error throw is still loud
+//
+// DELIBERATELY not folded into `friendlyError` (lib/friendlyError.ts): that
+// one is the SEND door's dispatcher — it overrides `rate_limited` with the
+// throttle copy and collapses every untyped throw to "send failed", both of
+// which would be wrong here (a cancelled passkey ceremony must keep its own
+// message). Same verb, different domain.
+export function errorMessage(value: unknown): string {
+  if (value instanceof ApiError) return friendlyApiError(value);
+  if (value instanceof Error) return value.message;
+  return String(value);
 }
 
 function friendlyKnown(err: ApiError, code: ErrorTokensRestErrorToken): string {

--- a/cicchetto/src/lib/passkeys.ts
+++ b/cicchetto/src/lib/passkeys.ts
@@ -48,6 +48,33 @@ const encode = (value: ArrayBuffer): string => {
   return btoa(raw).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 };
 
+// #725 — `CredentialsContainer` is `[SecureContext]`-only. grappa is
+// self-hosted and an operator serving it over `http://` on a LAN is a
+// supported deployment, so `navigator.credentials` being `undefined` is not a
+// hypothetical: both ceremonies used to run into it and throw
+// `TypeError: undefined is not an object (evaluating
+// 'navigator.credentials.get')`, which the login card and the settings pane
+// then printed verbatim at the user.
+//
+// The predicate tests the two functions this module actually CALLS rather
+// than `isSecureContext`. Same answer — the browser withholds the whole
+// container off a secure context, which is the cause — but it is the honest
+// question ("can the ceremony run?") and it also covers a browser that simply
+// has no WebAuthn. `PublicKeyCredential` is deliberately NOT in the test: it
+// appears in this file only in type positions, so requiring it at runtime
+// would assert something we never touch.
+export const PASSKEYS_UNAVAILABLE =
+  "Passkeys need a secure (HTTPS) connection and a browser that supports them.";
+
+export function passkeysAvailable(): boolean {
+  const credentials = navigator.credentials as CredentialsContainer | undefined;
+  return typeof credentials?.create === "function" && typeof credentials.get === "function";
+}
+
+const requireWebAuthn = (): void => {
+  if (!passkeysAvailable()) throw new Error(PASSKEYS_UNAVAILABLE);
+};
+
 const toDescriptor = (item: DescriptorJSON): PublicKeyCredentialDescriptor => ({
   type: item.type,
   id: decode(item.id),
@@ -55,6 +82,7 @@ const toDescriptor = (item: DescriptorJSON): PublicKeyCredentialDescriptor => ({
 });
 
 export async function createPasskey(options: PasskeyOptions): Promise<Record<string, unknown>> {
+  requireWebAuthn();
   const json = options.public_key as CreationJSON;
   const publicKey: PublicKeyCredentialCreationOptions = {
     challenge: decode(json.challenge),
@@ -84,6 +112,7 @@ export async function createPasskey(options: PasskeyOptions): Promise<Record<str
 }
 
 export async function getPasskey(options: PasskeyOptions): Promise<Record<string, unknown>> {
+  requireWebAuthn();
   const json = options.public_key as RequestJSON;
   const publicKey: PublicKeyCredentialRequestOptions = {
     challenge: decode(json.challenge),


### PR DESCRIPTION
Six review findings against the TOTP/passkey contribution, all in
`cicchetto/src`. They collide by file — `Login.tsx` twice,
`PasskeySettings.tsx` twice — so one branch, one commit per finding.

All six were re-read against the real files first: every one is still
alive on `main` (line numbers had drifted; #729 undercounted its own
blast radius). None arrived dead.

## What each commit does

**#726 — one answer to "what does this catch show the user".** The two
security panes were two independent answers. `PasskeySettings` printed
`value.message` in all *seven* of its catches, and `ApiError.message` IS
`${status} ${code}` — a wrong password when adding a passkey put
`401 invalid_credentials` on screen. The divergence ran the other way too:
`TotpSettings.copyRecoveryCodes` had no clipboard guard and was fired as
`void`, so on a plain-http instance ten one-shot recovery codes were
silently not copied. Lifted `errorMessage(unknown)` and `copyText(string)`
— one definition each, both strictly better than either pane had.

**#729 — attach the re-auth field to every action that spends it.** FIVE
privileged actions read `password()`; only one sat inside the form that
owned the input. A removal with an untouched field sent `""` and got a
bare 401. The password was never cleared, so one typed to ADD a passkey was
silently reused to change how the account authenticates. One gate for all
five: field hoisted above everything that consumes it, empty refused by
name, cleared in the `finally` on success and failure alike.

**#725 — name the missing WebAuthn.** `navigator.credentials` is
`[SecureContext]`-only; on http both ceremonies threw
`TypeError: undefined is not an object` straight onto the login card.
Guarded, with a predicate that tests the functions we actually call.

**#724 — stop the recovery field driving the password login.** Enter in
that field implicitly submitted the *credential* form (the password login,
never sending the code), and its `required` blocked an unrelated Connect.

**#727 — one in-flight latch for every door.** The passkey and
recovery-code buttons had no busy flag and were never disabled: a
double-click sent two `POST /auth/passkeys/recover` with the same one-shot
code, burning it plus a slot in the server's throttle window.

**#728 — carry the reason into the TOTP fallback.** Cancel, no
authenticator, a 401 on the assertion, a network blip — four events, one
silent degrade to a bare 2FA form. The reason now rides along and is
rendered above the code field.

## Where I departed from the issues, and why

Stated here rather than buried, since each is a deliberate refusal:

- **#725** asks to hide the login card's "Passkey" button. Declined: a
  passwordless account has two doors and on http one is shut — a vanished
  button explains nothing, while the button plus a named refusal points at
  the recovery-code door beside it. An inline note instead would eat the
  25px of viewport slack #442 measured. The raw TypeError is gone either way.
- **#724** asks for a sibling `<form>`. Declined: HTML forbids nesting, so
  the field would move below Connect and the Advanced disclosure — far from
  the toggle that reveals it — and two `margin: auto` flex cards would need
  new CSS against specs that measure this card. Took the issue's own
  alternative. The `form="…"` owner attribute is the structurally right
  tool but stakes the recovery flow on behaviour unverifiable outside a real
  iOS device.
- **#728** asks to swallow `NotAllowedError`. Declined: that is the very
  scenario the issue describes (an accidentally dismissed sheet) and the
  one that most needs the note; Chrome also reports a timeout under that
  name.
- **#726** suggests a shared "confirmation state" for the copy button.
  Not built — the defect is the SILENT failure, not the missing
  confirmation. `ShareSessionModal`'s silent clipboard catch is left alone
  on purpose: the URL it copies stays visible and selectable.
- **#727** suggests `disabled={connecting()}` on the two buttons. Not
  added: raising the latch unmounts them, so the attribute could never be
  observed. A dead guard reads like a live one.

## Tests

Every fix was driven from a red that reproduces the reported defect, and
the reds were read before greening:

- `401 invalid_credentials` / `409 passkey_required` rendered verbatim
- `expected TypeError: undefined is not an object … to not be an instance
  of TypeError`
- `expected "vi.fn()" to be called 1 times, but got 2 times`
- jsdom refusing the Connect submit because of the recovery field's
  `required`

#724's two halves were mutation-checked by displacement: reverting either
one reds exactly its own test and nothing else.

One pre-existing test was PINNING #729 — `securityPaneControls.test.tsx`
asserted `deletePasskey(…, "passkey-1", "")`. Its subject (#735's two-tap
arming) is untouched; it now supplies a password, because the pane refuses
without one. One #736 assertion moved rather than dropped: a succeeding
passkey ceremony now holds the connecting view, so the
sanitized-identifier-is-visible contract is asserted on the cancellation
path, where the user actually has a form to read.

## What is NOT claimed

- No e2e ran. Only `login-alt-auth-entry-points.spec.ts` touches this
  surface; I read it against every change (`#login-recovery-code`, the
  "Recover account" name, the `.login-alt-auth`/`.login-advanced-toggle`
  selector counts, the tab walk's `.login-form` boundary, and the 1024x900
  card-height assertion are all intact) but reading is not running.
- The iOS rendering of the two new notes and of the moved password field is
  unverified — jsdom is blind to layout and webkit-under-Playwright is not
  iOS.
- The two test files covering `lib/passkeys.ts` were deliberately NOT
  consolidated (recorded in #810).

## Gates

`bun run check` (biome + tsc) exit 0 · `bun run build` (the real type gate)
clean · `bun run test` 4247 passed / 234 files, from 4223 at the
merge-base.