### PR TITLE
e2e(#806): make the privmsg wait an instrument, not a shrug

### DIFF
--- a/cicchetto/e2e/fixtures/ircClient.ts
+++ b/cicchetto/e2e/fixtures/ircClient.ts
@@ -15,6 +15,7 @@
 // peer leaks out of the runner between tests.
 
 import { Client } from "irc-framework";
+import { awaitPrivmsg } from "./privmsgWait";
 
 const HOST = process.env.E2E_IRC_HOST ?? "bahamut-test";
 const PORT = Number(process.env.E2E_IRC_PORT ?? "6667");
@@ -55,6 +56,11 @@ const TOPIC_TIMEOUT_MS = 15_000;
 // genuine routing regression (#373's stale-nick 401 — nothing arrives, ever)
 // still fails, just 10s later. What it stops doing is failing when the
 // message is merely queued behind the harness's own reconnect burst.
+//
+// This is the DEFAULT, not the only option: `waitForPrivmsg` takes a
+// `timeoutMs` like its sibling `waitForLine` does, so a spec that needs a
+// different budget asks for one instead of retuning everyone's (#806
+// defect 2).
 const PRIVMSG_TIMEOUT_MS = 15_000;
 const OPER_TIMEOUT_MS = 5_000;
 const NICKSERV_TIMEOUT_MS = 5_000;
@@ -174,22 +180,27 @@ export class IrcPeer {
   }
 
   // Await an inbound PRIVMSG to this peer from `fromNick` whose message
-  // contains `body`. Attaches the listener synchronously, so callers set
-  // it up BEFORE triggering the send:
-  //   const got = peer.waitForPrivmsg(nick, body); await composeSend(...);
-  //   await got;
+  // contains `body`, having issued `trigger` (the send that is supposed
+  // to produce it):
+  //   await peer.waitForPrivmsg(nick, body, () => composeSend(page, body));
+  //
+  // The trigger is an ARGUMENT rather than something the caller runs
+  // between an arm and an await (#806 defect 1). That is what lets the
+  // listener be attached before the trigger — so a fast reply cannot race
+  // it — while the deadline is clocked from the trigger, instead of the
+  // caller's trigger silently eating the delivery budget. Everything the
+  // wait saw is reported on failure; see `privmsgWait.ts`.
+  //
   // #373 — proves grappa routed an operator's DM to the LIVE (renamed)
   // nick with NO 401: if routing had followed the stale old nick the peer
-  // never receives it and this times out.
-  waitForPrivmsg(fromNick: string, body: string): Promise<void> {
-    return onceMatching(
-      this.client,
-      "privmsg",
-      (event: { nick: string; message: string }) =>
-        event.nick === fromNick && event.message.includes(body),
-      PRIVMSG_TIMEOUT_MS,
-      `privmsg from ${fromNick} containing "${body}"`,
-    );
+  // never receives it and this fails with cause SILENCE.
+  waitForPrivmsg(
+    fromNick: string,
+    body: string,
+    trigger: () => void | Promise<void>,
+    timeoutMs = PRIVMSG_TIMEOUT_MS,
+  ): Promise<void> {
+    return awaitPrivmsg(this.client, { fromNick, body, timeoutMs, trigger });
   }
 
   // Send a raw NOTICE to a target. `target` may be a nick, a channel, or
@@ -518,10 +529,10 @@ export class IrcPeer {
   // it.
   waitForLine(pattern: RegExp, label: string, timeoutMs = 8_000): Promise<string> {
     return new Promise((resolve, reject) => {
-      const timer = setTimeout(
-        () => reject(new Error(`IrcPeer: timeout waiting for ${label} (${timeoutMs}ms)`)),
-        timeoutMs,
-      );
+      const timer = setTimeout(() => {
+        this.client.removeListener("raw", handler);
+        reject(new Error(`IrcPeer: timeout waiting for ${label} (${timeoutMs}ms)`));
+      }, timeoutMs);
       const handler = (event: { line: string; from_server: boolean }) => {
         if (!event.from_server || !pattern.test(event.line)) return;
         clearTimeout(timer);
@@ -540,6 +551,11 @@ export class IrcPeer {
   }
 }
 
+// #806 — every wait below detaches its handler on the TIMEOUT branch too,
+// not just on the match. Rejecting without detaching leaves the handler
+// attached for the life of the peer: harmless-looking, but `waitForLine`'s
+// runs a regex over every wire line thereafter, and the next helper written
+// in this shape inherits it.
 function once<T = unknown>(
   client: Client,
   event: string,
@@ -547,14 +563,16 @@ function once<T = unknown>(
   label: string,
 ): Promise<T> {
   return new Promise((resolve, reject) => {
-    const timer = setTimeout(
-      () => reject(new Error(`IrcPeer: timeout waiting for ${label} (${timeoutMs}ms)`)),
-      timeoutMs,
-    );
-    client.once(event, (payload: T) => {
+    const timer = setTimeout(() => {
+      client.removeListener(event, handler);
+      reject(new Error(`IrcPeer: timeout waiting for ${label} (${timeoutMs}ms)`));
+    }, timeoutMs);
+    const handler = (payload: T) => {
       clearTimeout(timer);
+      client.removeListener(event, handler);
       resolve(payload);
-    });
+    };
+    client.on(event, handler);
   });
 }
 
@@ -566,10 +584,10 @@ function onceMatching<T>(
   label: string,
 ): Promise<T> {
   return new Promise((resolve, reject) => {
-    const timer = setTimeout(
-      () => reject(new Error(`IrcPeer: timeout waiting for ${label} (${timeoutMs}ms)`)),
-      timeoutMs,
-    );
+    const timer = setTimeout(() => {
+      client.removeListener(event, handler);
+      reject(new Error(`IrcPeer: timeout waiting for ${label} (${timeoutMs}ms)`));
+    }, timeoutMs);
     const handler = (payload: T) => {
       if (!predicate(payload)) return;
       clearTimeout(timer);

--- a/cicchetto/e2e/fixtures/privmsgWait.test.ts
+++ b/cicchetto/e2e/fixtures/privmsgWait.test.ts
@@ -94,6 +94,29 @@ describe("awaitPrivmsg", () => {
     await expect(wait).resolves.toBeUndefined();
   });
 
+  it("reports arrival offsets from the trigger, not from the arm", async () => {
+    // Same reason the deadline is clocked from the trigger: an offset
+    // measured from the arm silently includes however long the caller's
+    // trigger took, which is exactly the confusion this instrument exists
+    // to remove. Trigger costs 300ms, the noise lands 100ms after it.
+    const source = fakeSource();
+    const settled = failureOf(
+      awaitPrivmsg(source, {
+        fromNick: "vjt-grappa",
+        body: "followup",
+        timeoutMs: 1_000,
+        trigger: () => sleep(300),
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(300);
+    await vi.advanceTimersByTimeAsync(100);
+    source.emit("someone-else", "noise");
+    await vi.advanceTimersByTimeAsync(5_000);
+    const failure = await settled;
+    expect(failure).toContain("+100ms");
+    expect(failure).not.toContain("+400ms");
+  });
+
   it("names the sender it actually saw when the message came from someone else", async () => {
     const source = fakeSource();
     const settled = failureOf(

--- a/cicchetto/e2e/fixtures/privmsgWait.test.ts
+++ b/cicchetto/e2e/fixtures/privmsgWait.test.ts
@@ -1,0 +1,212 @@
+// #806 — the peer's inbound-PRIVMSG wait is the instrument a routing
+// regression (#373) is judged by, so its failure message has to be
+// evidence, not a shrug. These run under the cic vitest project (see
+// vitest.config.ts) because the wait is deliberately free of the
+// e2e-only `irc-framework` dependency.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type PrivmsgEvent, awaitPrivmsg, type PrivmsgSource } from "./privmsgWait";
+
+type FakeSource = PrivmsgSource & {
+  emit: (nick: string, message: string) => void;
+  attached: () => number;
+};
+
+function fakeSource(): FakeSource {
+  const handlers = new Set<(event: PrivmsgEvent) => void>();
+  return {
+    on: (_event, handler) => {
+      handlers.add(handler);
+    },
+    removeListener: (_event, handler) => {
+      handlers.delete(handler);
+    },
+    emit: (nick, message) => {
+      for (const handler of [...handlers]) handler({ nick, message });
+    },
+    attached: () => handlers.size,
+  };
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+// Every rejection assertion goes through this: `.rejects` needs the
+// promise to already be rejected by the time we await it, and the
+// rejection is driven by fake timers.
+async function failureOf(wait: Promise<void>): Promise<string> {
+  try {
+    await wait;
+  } catch (err) {
+    return (err as Error).message;
+  }
+  throw new Error("expected the wait to reject, but it resolved");
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("awaitPrivmsg", () => {
+  it("resolves when the expected message arrives", async () => {
+    const source = fakeSource();
+    const wait = awaitPrivmsg(source, {
+      fromNick: "vjt-grappa",
+      body: "followup",
+      timeoutMs: 1_000,
+      trigger: () => {},
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    source.emit("vjt-grappa", "followup-abc123");
+    await expect(wait).resolves.toBeUndefined();
+  });
+
+  it("is already listening while the trigger runs, so a fast reply cannot race it", async () => {
+    const source = fakeSource();
+    const wait = awaitPrivmsg(source, {
+      fromNick: "vjt-grappa",
+      body: "followup",
+      timeoutMs: 1_000,
+      // The reply lands DURING the trigger — the listener must already
+      // be attached, which is why arming stays ahead of the trigger.
+      trigger: () => source.emit("vjt-grappa", "followup-abc123"),
+    });
+    await expect(wait).resolves.toBeUndefined();
+  });
+
+  it("clocks the timeout from the trigger, not from the arm", async () => {
+    const source = fakeSource();
+    // Trigger costs 900ms; delivery then costs 900ms. Clocked from the
+    // arm that is 1800ms against a 1000ms budget — a false red. Clocked
+    // from the trigger the delivery had 900 of its 1000ms.
+    const wait = awaitPrivmsg(source, {
+      fromNick: "vjt-grappa",
+      body: "followup",
+      timeoutMs: 1_000,
+      trigger: () => sleep(900),
+    });
+    await vi.advanceTimersByTimeAsync(900);
+    await vi.advanceTimersByTimeAsync(900);
+    source.emit("vjt-grappa", "followup-abc123");
+    await expect(wait).resolves.toBeUndefined();
+  });
+
+  it("names the sender it actually saw when the message came from someone else", async () => {
+    const source = fakeSource();
+    const settled = failureOf(
+      awaitPrivmsg(source, {
+        fromNick: "vjt-grappa",
+        body: "followup",
+        timeoutMs: 1_000,
+        trigger: () => {},
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(20);
+    source.emit("vjt-grappa_", "followup-abc123");
+    await vi.advanceTimersByTimeAsync(5_000);
+    const failure = await settled;
+    expect(failure).toContain("vjt-grappa_");
+    expect(failure).toMatch(/OTHER SENDERS/);
+    expect(failure).toContain("followup-abc123");
+  });
+
+  it("says WRONG BODY when the right sender said something else", async () => {
+    const source = fakeSource();
+    const settled = failureOf(
+      awaitPrivmsg(source, {
+        fromNick: "vjt-grappa",
+        body: "followup",
+        timeoutMs: 1_000,
+        trigger: () => {},
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(20);
+    source.emit("vjt-grappa", "some other line");
+    await vi.advanceTimersByTimeAsync(5_000);
+    const failure = await settled;
+    expect(failure).toMatch(/WRONG BODY/);
+    expect(failure).toContain("some other line");
+  });
+
+  it("says SILENCE when nothing at all reached the peer", async () => {
+    const source = fakeSource();
+    const settled = failureOf(
+      awaitPrivmsg(source, {
+        fromNick: "vjt-grappa",
+        body: "followup",
+        timeoutMs: 1_000,
+        trigger: () => {},
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(5_000);
+    const failure = await settled;
+    expect(failure).toMatch(/SILENCE/);
+  });
+
+  it("distinguishes a message that was merely late from one that never came", async () => {
+    const source = fakeSource();
+    const settled = failureOf(
+      awaitPrivmsg(source, {
+        fromNick: "vjt-grappa",
+        body: "followup",
+        timeoutMs: 1_000,
+        trigger: () => {},
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(1_008);
+    source.emit("vjt-grappa", "followup-abc123");
+    await vi.advanceTimersByTimeAsync(5_000);
+    const failure = await settled;
+    expect(failure).toMatch(/LATE/);
+    expect(failure).toContain("8ms");
+    expect(failure).not.toMatch(/SILENCE/);
+  });
+
+  it("detaches its listener when the wait succeeds", async () => {
+    const source = fakeSource();
+    const wait = awaitPrivmsg(source, {
+      fromNick: "vjt-grappa",
+      body: "followup",
+      timeoutMs: 1_000,
+      trigger: () => {},
+    });
+    await vi.advanceTimersByTimeAsync(10);
+    source.emit("vjt-grappa", "followup-abc123");
+    await wait;
+    expect(source.attached()).toBe(0);
+  });
+
+  it("detaches its listener when the wait times out", async () => {
+    const source = fakeSource();
+    const settled = failureOf(
+      awaitPrivmsg(source, {
+        fromNick: "vjt-grappa",
+        body: "followup",
+        timeoutMs: 1_000,
+        trigger: () => {},
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(5_000);
+    await settled;
+    expect(source.attached()).toBe(0);
+  });
+
+  it("propagates a failing trigger and detaches instead of waiting out the budget", async () => {
+    const source = fakeSource();
+    const boom = new Error("composeSend blew up");
+    const settled = failureOf(
+      awaitPrivmsg(source, {
+        fromNick: "vjt-grappa",
+        body: "followup",
+        timeoutMs: 1_000,
+        trigger: () => Promise.reject(boom),
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    expect(await settled).toBe("composeSend blew up");
+    expect(source.attached()).toBe(0);
+  });
+});

--- a/cicchetto/e2e/fixtures/privmsgWait.ts
+++ b/cicchetto/e2e/fixtures/privmsgWait.ts
@@ -1,0 +1,180 @@
+// #806 — the instrument behind `IrcPeer.waitForPrivmsg`.
+//
+// This wait is how a routing regression (#373: grappa answers a DM to a
+// renamed peer's STALE nick, upstream 401s, nothing is delivered) is
+// judged, so it owes the reader evidence rather than a shrug. Three
+// properties the plain `onceMatching` wait could not give:
+//
+//  1. The listener is attached BEFORE the trigger runs — a fast reply
+//     cannot race it — while the deadline is clocked FROM the trigger.
+//     The old shape welded the two to one instant, so whatever the
+//     caller spent issuing the trigger came out of the delivery budget,
+//     silently and unreported. Taking the trigger AS AN ARGUMENT is what
+//     separates them without asking every caller to sequence it by hand:
+//     the ordering is now structural, not a docstring the next spec
+//     author has to obey.
+//  2. Every privmsg seen during the wait is recorded — non-matching ones
+//     included — and dumped on rejection. Measured on the #806 red runs:
+//     the expected message arrived ~1ms and ~8ms PAST the deadline, and
+//     the shipped error reported that identically to a total
+//     non-delivery. A failure that cannot tell "the product is broken"
+//     from "eight milliseconds late" is how a real regression gets
+//     dismissed as a flake.
+//  3. The handler is detached on EVERY exit path, timeout included.
+//
+// Deliberately free of `irc-framework` imports: `PrivmsgSource` is the
+// two-method slice of its `Client` this needs, which keeps the one piece
+// of the peer fixture carrying real logic unit-testable from the cic
+// vitest project (which does not have the e2e-only dependency).
+
+export type PrivmsgEvent = { nick: string; message: string };
+
+export type PrivmsgSource = {
+  on(event: "privmsg", handler: (event: PrivmsgEvent) => void): void;
+  removeListener(event: "privmsg", handler: (event: PrivmsgEvent) => void): void;
+};
+
+export type PrivmsgWaitSpec = {
+  fromNick: string;
+  body: string;
+  timeoutMs: number;
+  // Issued once the listener is attached; the deadline starts when this
+  // settles. Sync (`() => peer.privmsg(...)`) or async (`() =>
+  // composeSend(page, body)`) — an async trigger is precisely the case
+  // the old shape charged to the delivery budget.
+  trigger: () => void | Promise<void>;
+};
+
+// Keep listening this long past the deadline before rejecting. It changes
+// no verdict — a wait that blew its budget still fails — it only buys the
+// message the ability to say LATE instead of SILENCE. That distinction is
+// the difference between "delivery is slow" and "routing is broken", and
+// on the runs that filed this issue it came down to one millisecond.
+const LATE_ARRIVAL_GRACE_MS = 500;
+
+const BODY_EXCERPT_CHARS = 120;
+
+type SeenPrivmsg = { nick: string; message: string; at: number };
+
+export async function awaitPrivmsg(source: PrivmsgSource, spec: PrivmsgWaitSpec): Promise<void> {
+  const { fromNick, body, timeoutMs, trigger } = spec;
+  const seen: SeenPrivmsg[] = [];
+  // Re-based to the trigger below; until then the arm IS the zero, so a
+  // reply that beats the trigger's return still gets a sane offset.
+  let triggeredAt = Date.now();
+  let expired = false;
+  let settled = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  let resolveWait!: () => void;
+  let rejectWait!: (error: Error) => void;
+  const wait = new Promise<void>((resolve, reject) => {
+    resolveWait = resolve;
+    rejectWait = reject;
+  });
+
+  const matches = (event: PrivmsgEvent) =>
+    event.nick === fromNick && event.message.includes(body);
+
+  const handler = (event: PrivmsgEvent) => {
+    const at = Date.now();
+    seen.push({ nick: event.nick, message: event.message, at });
+    if (!matches(event)) return;
+    // Past the deadline this is the LATE case: it still fails, but it
+    // fails saying the message WAS delivered.
+    finish(expired ? new Error(failureMessage(spec, seen, triggeredAt, at)) : undefined);
+  };
+
+  // Detach + disarm without settling. Split out from `finish` so the
+  // trigger-threw path can clean up and rethrow the caller's own error
+  // rather than leaving `wait` rejected with nobody awaiting it.
+  const cleanup = (): boolean => {
+    if (settled) return false;
+    settled = true;
+    if (timer !== undefined) clearTimeout(timer);
+    source.removeListener("privmsg", handler);
+    return true;
+  };
+
+  const finish = (error?: Error) => {
+    if (!cleanup()) return;
+    if (error) rejectWait(error);
+    else resolveWait();
+  };
+
+  source.on("privmsg", handler);
+
+  try {
+    await trigger();
+  } catch (triggerError) {
+    cleanup();
+    throw triggerError;
+  }
+
+  // The reply beat the trigger's return — nothing left to time.
+  if (settled) return wait;
+
+  triggeredAt = Date.now();
+  timer = setTimeout(() => {
+    expired = true;
+    timer = setTimeout(
+      () => finish(new Error(failureMessage(spec, seen, triggeredAt, undefined))),
+      LATE_ARRIVAL_GRACE_MS,
+    );
+  }, timeoutMs);
+
+  return wait;
+}
+
+function failureMessage(
+  spec: PrivmsgWaitSpec,
+  seen: SeenPrivmsg[],
+  triggeredAt: number,
+  lateArrivalAt: number | undefined,
+): string {
+  const { fromNick, body, timeoutMs } = spec;
+  const offset = (at: number) => {
+    const delta = at - triggeredAt;
+    return `${delta >= 0 ? "+" : ""}${delta}ms`;
+  };
+
+  const lines = [
+    `IrcPeer: no privmsg from "${fromNick}" containing "${body}" within ${timeoutMs}ms`,
+    `  cause: ${cause(spec, seen, triggeredAt, lateArrivalAt)}`,
+  ];
+  if (seen.length > 0) {
+    lines.push(`  seen (${seen.length} privmsg, offsets from the trigger):`);
+    for (const entry of seen) {
+      lines.push(`    ${offset(entry.at)} <${entry.nick}> "${excerpt(entry.message)}"`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function cause(
+  spec: PrivmsgWaitSpec,
+  seen: SeenPrivmsg[],
+  triggeredAt: number,
+  lateArrivalAt: number | undefined,
+): string {
+  const { fromNick, timeoutMs } = spec;
+  if (lateArrivalAt !== undefined) {
+    const late = lateArrivalAt - triggeredAt - timeoutMs;
+    return `LATE — the expected message DID arrive, ${late}ms past the deadline: delivered, not lost`;
+  }
+  if (seen.length === 0) {
+    return "SILENCE — no privmsg of any kind reached this peer during the wait";
+  }
+  const fromExpected = seen.filter((entry) => entry.nick === fromNick);
+  if (fromExpected.length > 0) {
+    return `WRONG BODY — ${fromExpected.length} privmsg from "${fromNick}", none containing the expected text`;
+  }
+  const senders = [...new Set(seen.map((entry) => entry.nick))];
+  return `OTHER SENDERS — ${seen.length} privmsg arrived, none from "${fromNick}" (saw: ${senders.join(", ")})`;
+}
+
+function excerpt(message: string): string {
+  return message.length <= BODY_EXCERPT_CHARS
+    ? message
+    : `${message.slice(0, BODY_EXCERPT_CHARS)}…`;
+}

--- a/cicchetto/e2e/tests/issue604-peer-nick-reconcile.spec.ts
+++ b/cicchetto/e2e/tests/issue604-peer-nick-reconcile.spec.ts
@@ -50,11 +50,10 @@ test("#604 — connect survives a 433 collision, reconciling peer.nick so a DM r
       // reaches THIS peer, not the holder and not a phantom. If reconcile were
       // missing, `peer.nick` would still be the held nick — the DM would land
       // on the holder (irc-framework doesn't echo own sends) and this would
-      // time out. Arm the listener BEFORE the send.
+      // time out. The send is the wait's trigger, so the listener is
+      // attached before it goes out (#806).
       const token = `dm604-${crypto.randomUUID().slice(0, 8)}`;
-      const received = peer.waitForPrivmsg(holder.nick, token);
-      holder.privmsg(peer.nick, token);
-      await received;
+      await peer.waitForPrivmsg(holder.nick, token, () => holder.privmsg(peer.nick, token));
     } finally {
       await peer.disconnect("bye #604");
     }

--- a/cicchetto/e2e/tests/nick-follow-query.spec.ts
+++ b/cicchetto/e2e/tests/nick-follow-query.spec.ts
@@ -120,13 +120,14 @@ test("query window follows a peer NICK change — relabels, keeps history, route
 
     // STEP 4 — the core fix: a send in the focused window REACHES THE RENAMED
     // PEER. Pre-fix it routed to the vanished old nick → 401 and never
-    // arrived. Attach the peer's receive-listener BEFORE the send.
+    // arrived. The peer's receive-listener is attached before the send —
+    // `waitForPrivmsg` takes the send as its trigger and sequences the two.
     //
     // Gate on the NEW query topic being subscribed first: after the rename
     // the query-windows loop re-joins `(slug, NEW_NICK)`, and the server
     // fastlanes the own echo ONLY to a subscribed socket (no PubSub replay,
     // #254). Without this gate the own-echo render (line below) races the
-    // re-subscribe — the send still ROUTES (asserted via `received`), but
+    // re-subscribe — the send still ROUTES (asserted by the wait), but
     // its scrollback echo can miss the live push until the next refresh.
     await waitForQueryWindowReady(page, NETWORK_SLUG, NEW_NICK);
     // The send is the wait's trigger (#806): the peer is listening before

--- a/cicchetto/e2e/tests/nick-follow-query.spec.ts
+++ b/cicchetto/e2e/tests/nick-follow-query.spec.ts
@@ -129,9 +129,12 @@ test("query window follows a peer NICK change — relabels, keeps history, route
     // re-subscribe — the send still ROUTES (asserted via `received`), but
     // its scrollback echo can miss the live push until the next refresh.
     await waitForQueryWindowReady(page, NETWORK_SLUG, NEW_NICK);
-    const received = peer.waitForPrivmsg(NETWORK_NICK, FOLLOWUP_BODY);
-    await composeSend(page, FOLLOWUP_BODY);
-    await received; // times out if grappa still routed to the stale nick
+    // The send is the wait's trigger (#806): the peer is listening before
+    // it fires, and the delivery budget starts once it has fired — the
+    // round trip inside `composeSend` is not charged to delivery.
+    await peer.waitForPrivmsg(NETWORK_NICK, FOLLOWUP_BODY, () =>
+      composeSend(page, FOLLOWUP_BODY),
+    ); // fails with cause SILENCE if grappa still routed to the stale nick
     await expect(
       page.locator('[data-testid="scrollback-line"]', { hasText: FOLLOWUP_BODY }),
     ).toBeVisible({ timeout: 5_000 });

--- a/cicchetto/vitest.config.ts
+++ b/cicchetto/vitest.config.ts
@@ -15,7 +15,13 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/setupTests.ts"],
-    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    // `e2e/fixtures/**/*.test.ts` — the e2e peer/page fixtures are their
+    // own package (e2e/package.json, playwright-only), but the pieces of
+    // them that carry LOGIC rather than driver calls are unit-testable and
+    // worth testing here (#806). Matched on `.test.ts` alone, never
+    // `.spec.ts`: `e2e/tests/*.spec.ts` are playwright specs and must not
+    // be picked up by vitest.
+    include: ["src/**/*.{test,spec}.{ts,tsx}", "e2e/fixtures/**/*.test.ts"],
   },
   resolve: {
     conditions: ["development", "browser"],


### PR DESCRIPTION
Test infrastructure only — no production code. Refs #806.

`IrcPeer.waitForPrivmsg` is what a DM-routing regression (#373) is judged
by, and it could not tell three outcomes apart. All four defects in the
issue are addressed, in the order that pays.

## Defect 4 — one message for three causes

The wait now records **every** privmsg it sees during the window,
non-matching ones included, and reports a named cause. What a cause-3
failure looks like now (real output):

```
IrcPeer: no privmsg from "vjt-grappa" containing "followup-9c1f" within 15000ms
  cause: OTHER SENDERS — 2 privmsg arrived, none from "vjt-grappa" (saw: vjt-grappa_, ChanServ)
  seen (2 privmsg, offsets from the trigger):
    +12ms <vjt-grappa_> "followup-9c1f"
    +53ms <ChanServ> "This nickname is registered and protected."
```

against cause 1:

```
  cause: SILENCE — no privmsg of any kind reached this peer during the wait
```

and cause 2:

```
  cause: LATE — the expected message DID arrive, 8ms past the deadline: delivered, not lost
  seen (1 privmsg, offsets from the trigger):
    +15008ms <vjt-grappa> "followup-9c1f"
```

LATE needs one thing the recorder alone cannot give: at the deadline
nothing has arrived yet, so "1ms late" and "never" are still identical.
The wait therefore keeps listening 500ms past the deadline before
rejecting. **That changes no verdict** — a blown budget still fails — it
only buys the message the right to say "delivered, late". This is the
measured case from the issue: ~1ms and ~8ms late, reported as total
non-delivery.

## Defect 3 — already done

`PRIVMSG_TIMEOUT_MS` was split out of `NICK_TIMEOUT_MS` by 035ce5ac (the
#782 branch). Nothing to do beyond documenting that the number is now a
default rather than the only choice.

## Defect 2 — `timeoutMs`

`waitForPrivmsg` takes one, like its sibling `waitForLine`.
`PRIVMSG_TIMEOUT_MS` stays as the default.

## Defect 1 — the shape, and nothing more

**This fixes a latent structural defect and explains nothing about #800.**
The measured magnitude of the overlap on the only exposed call site is
10-16ms of 5000ms.

Arming before the trigger is correct and stays. The defect was that
arming and timing were welded to the same instant. The trigger is now an
**argument**: the listener is attached, the trigger runs, then the clock
starts. The ordering is structural instead of a docstring the next spec
author has to obey — which matters because the old docstring
*recommended* the affected shape.

## The listener leak, fixed for the class

`onceMatching` is the one the issue names, but `once` and `waitForLine`
reject on timeout leaving their handler attached too. `waitForLine` is
the one that costs something — its handler runs a regex over every wire
line the peer receives thereafter. Fixing only the named one would leave
the same shape in two places to copy from.

## Test plan

- [x] `e2e/fixtures/privmsgWait.test.ts` — 11 unit tests, written first
      against a stub reproducing today's semantics: **7 red, 3 green**
      (the 3 being the properties already correct — attaches before the
      trigger, resolves, detaches on success).
- [x] **Mutation-checked**, five properties mutated one at a time:
      deadline armed before the trigger → 1 dies; handler never detached
      → 3 die; grace window removed → 1 dies; non-matching privmsgs not
      recorded → 2 die. A fifth (offset origin) **survived** — every case
      used an instant trigger — so it got its own assertion and now dies
      too.
- [x] Both touched specs, real stack: `#604` and `nick-follow-query` pass.
- [x] cic vitest: 235 files / 4234 tests green. `bun run check` rc=0.
- [x] Full `scripts/integration.sh`: **598 passed, 1 failed** —
      `issue253-kbd-resize-scroll-preserve` (webkit-iphone-15).
      Baseline at the merge-base `2287d48a`, same command: **597 passed,
      2 failed** — the *same* `#253` at the *same* position, plus a
      `#196` this branch did not hit. The spec touches no IRC fixture.
      Pre-existing, not caused here; not fixed here either.

vitest picks up `e2e/fixtures/**/*.test.ts` — `.test.ts` only, never the
`.spec.ts` playwright specs. The wait is kept free of `irc-framework`
imports so the cic project (which lacks that e2e-only dependency) can
test it.