### PR TITLE
shottino(#763): a guard that cannot fail loudly, and a suite that cannot fail at all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,11 +164,18 @@ jobs:
       # package that ships ncursesw.pc — shottino links the WIDE build
       # (it is UTF-8 end to end), and the old libncursesw5-dev name no
       # longer exists on current Debian/Ubuntu.
+      #
+      # ffmpeg is a TEST dependency, and it is here because it was not:
+      # the runner has no ffmpeg, so every green run of this job printed
+      # "test_layout: no ffmpeg — skipping decode checks" and the one test
+      # that asks the real decoder what it produced asserted nothing. It
+      # now fails instead of skipping (#763), so the binary has to be here
+      # for the check to mean what its name says.
       - name: Install build dependencies
         run: |
           sudo apt-get update -q
           sudo apt-get install -y -q --no-install-recommends \
-            pkg-config libncurses-dev libssl-dev
+            pkg-config libncurses-dev libssl-dev ffmpeg
 
       - name: Configure
         run: ./configure

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -29275,3 +29275,52 @@ a PATH holding only the scratch directory) could not find `sleep` and died
 instantly, closing the write end and handing the parent a clean EOF by
 accident. A positive control that admits a corpse is not a control: it now
 sets its own PATH and asserts the child is RUNNING, not merely forked.
+
+## 2026-08-05 — #763: a guard that cannot fail loudly, and a suite that cannot fail at all
+
+Three defects with one shape: a test that reads its own environment, decides
+quietly that it cannot do its job, and reports exactly what a passing test
+reports.
+
+**The HOME guard was conditional, so its failure restored the incident it
+prevented.** `894c3ec8` stopped `test_windows` rewriting the developer's
+`~/.local/share/shottino/shottino.conf` with
+`if (mkdtemp(test_home)) setenv("HOME", test_home, 1);` — which, when mkdtemp
+fails, runs the whole suite against the real `$HOME` again with nothing
+reported. Measured both ways by pointing the template at a directory that does
+not exist: the old line runs 1302 checks, prints "1302 checks passed", exits
+0, and leaves a rewritten `shottino.conf` and `llm.conf` in the home it was
+given; the replacement prints the errno and exits 1 before the first test.
+
+**And it guarded one suite of six.** Every suite that `#include`s
+`../shottino.c` inherits that file's reach into `$HOME`: anything calling
+`shottino_state_dir()` mkdirs there. The finding called this latent. It is
+not — `test_layout` reaches it TODAY through
+`a_modal_over_the_settings_panel_is_drawn`, so `make check` has been creating
+`~/.local/share/shottino` on every developer machine and every CI runner, as a
+container run of `origin/main` confirms. The setup moved to `test.h` and all
+six suites call it.
+
+**The class needed a mechanical check, not a resolution.** The guard was added
+to `test_windows.c` after the incident and `test_call.c` was then written
+beside it with none: the class re-opened once already, unnoticed, before
+anyone filed it. `make check-home-guard` compares two sets — "includes
+shottino.c" and "calls `test_use_temp_home()`" — and names the suite that
+forgot. The seventh suite is the one this is for.
+
+**A skip is requested, never inferred.** `test_layout` returned 0 for the
+WHOLE suite where `/dev/null` or a terminfo entry was missing, and its decode
+test returns having asserted nothing wherever ffmpeg is absent — which is
+every CI run to date: the last green run on main prints `test_layout: no
+ffmpeg — skipping decode checks`, so the one test that asks the real decoder
+what it produced has never executed there. Both now fail, `SHOTTINO_TEST_ALLOW_SKIP=1`
+is the way to say a host genuinely cannot, and CI installs ffmpeg rather than
+setting it. The two tests that need no screen run before `newterm`, so the
+opt-out still checks what does not depend on a terminal.
+
+**The opt-out is read strictly, and the mutation is why.** `SHOTTINO_TEST_ALLOW_SKIP=`
+— set, empty — enabled the skip under the first implementation, which meant
+the run intended to exercise the failure path was exercising the opt-out
+instead. Only `"1"` skips now; unset, empty, `0` and `yes` are all red. A
+reading of an opt-out must err towards red, or it becomes the silent
+degradation it was written to remove.

--- a/frontends/shottino/Makefile
+++ b/frontends/shottino/Makefile
@@ -51,7 +51,7 @@ TESTS := tests/test_llm tests/test_ws tests/test_json tests/test_wire tests/test
 SANITIZE ?= -fsanitize=address,undefined -fno-omit-frame-pointer
 TEST_CFLAGS := -std=c11 -Wall -Wextra -Wpedantic -O1 -g $(SANITIZE)
 
-.PHONY: all install clean check
+.PHONY: all install clean check check-home-guard
 
 all: $(BIN)
 
@@ -160,8 +160,31 @@ tests/test_call: tests/test_call.c tests/test.h shottino.c call/media.c call/med
 tests/test_keys: tests/test_keys.c tests/test.h shottino.c json.c wire.c alias.c mirc.c termcolor.c http.c media.c ircd.c ws.c llm.c
 	$(CC) $(CPPFLAGS) $(TEST_CFLAGS) $(CFLAGS_DEPS) -o $@ tests/test_keys.c json.c wire.c alias.c mirc.c termcolor.c http.c media.c ircd.c ws.c llm.c $(LDLIBS) -lutil
 
+# Compiling shottino.c means inheriting its reach into $HOME: anything
+# that calls shottino_state_dir() mkdirs there, and prefs_save writes the
+# developer's own config. test.h's test_use_temp_home() is the answer, and
+# THIS is what stops the next suite from being written without it — the
+# guard was added to test_windows.c after the incident, and test_call.c
+# was then added beside it with no guard at all. A grep is enough: the two
+# sets are "includes shottino.c" and "takes a temp HOME", and they must be
+# the same set.
+check-home-guard:
+	@suites=$$(grep -l '#include "\.\./shottino\.c"' tests/*.c); \
+	if [ -z "$$suites" ]; then \
+		echo "check-home-guard: no suite includes shottino.c — wrong directory?" >&2; \
+		exit 2; \
+	fi; \
+	missing=$$(grep -L 'test_use_temp_home()' $$suites); \
+	if [ -n "$$missing" ]; then \
+		echo "check-home-guard: these suites compile shottino.c and run against the REAL \$$HOME:" >&2; \
+		for m in $$missing; do echo "  $$m" >&2; done; \
+		echo "add test_use_temp_home(); as the first statement of main (see tests/test.h)" >&2; \
+		exit 1; \
+	fi; \
+	echo "check-home-guard: $$(echo $$suites | wc -w | tr -d ' ') suites compile shottino.c, all take a temp HOME"
+
 # `make check` is the gate: build every suite, run every suite, fail loud.
-check: $(TESTS)
+check: check-home-guard $(TESTS)
 	@rc=0; for t in $(TESTS); do \
 		printf '== %s\n' "$$t"; \
 		./$$t || rc=1; \

--- a/frontends/shottino/tests/test.h
+++ b/frontends/shottino/tests/test.h
@@ -9,12 +9,20 @@
  * Usage:
  *   TEST(name) { ... CHECK(cond); CHECK_STR(a, b); }
  *   int main(void) { RUN(name); return test_report(); }
+ *
+ * A suite that #includes ../shottino.c calls test_use_temp_home() as the
+ * first statement of main — see below, and `make check-home-guard`.
  */
 #ifndef SHOTTINO_TEST_H
 #define SHOTTINO_TEST_H
 
+#include <errno.h>
+#include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+/* mkdtemp lives in stdlib.h on glibc and in unistd.h on macOS. */
+#include <unistd.h>
 
 static int test_failures;
 static int test_checks;
@@ -35,6 +43,15 @@ static const char *test_current;
             test_failures++;                                                                       \
             fprintf(stderr, "FAIL %s:%d [%s] %s\n", __FILE__, __LINE__, test_current, #cond);      \
         }                                                                                          \
+    } while (0)
+
+/* An unconditional failure, for the case a CHECK cannot express: a
+ * dependency the test needs is missing, so nothing below it can run. */
+#define FAIL(msg)                                                                                  \
+    do {                                                                                           \
+        test_checks++;                                                                             \
+        test_failures++;                                                                           \
+        fprintf(stderr, "FAIL %s:%d [%s] %s\n", __FILE__, __LINE__, test_current, msg);            \
     } while (0)
 
 /* String equality with both values printed on failure — a bare CHECK on
@@ -62,6 +79,66 @@ static const char *test_current;
                     test_current, e_, a_);                                                         \
         }                                                                                          \
     } while (0)
+
+/* A skip is REQUESTED, never inferred.
+ *
+ * A suite that reads its own environment and quietly decides not to
+ * assert anything reports exactly what a passing suite reports. Two here
+ * did: test_layout returned 0 for the WHOLE suite where terminfo was
+ * missing, and its decode test returns having asserted nothing wherever
+ * ffmpeg is absent — which is every CI run to date. So a missing test
+ * dependency FAILS, and an operator who knows their host cannot have it
+ * says so with SHOTTINO_TEST_ALLOW_SKIP=1. */
+static inline bool test_skip_allowed(void) { return getenv("SHOTTINO_TEST_ALLOW_SKIP") != NULL; }
+
+/* A HOME OF OUR OWN, before a single test runs.
+ *
+ * Anything that reaches shottino_state_dir() mkdirs under $HOME and may
+ * then write there: prefs_save resolves prefs_path at call time, so a
+ * suite that saves settings rewrites the DEVELOPER'S OWN
+ * ~/.local/share/shottino/shottino.conf with whatever defaults a test app
+ * happens to hold. That is not hypothetical: vjt lost
+ * `voice.source = alsa:hw:2` to `pulse:default` on every `make check`,
+ * and blamed the reinstall that always happened alongside it.
+ *
+ * So every suite that compiles shottino.c takes a temporary HOME here,
+ * whether or not it currently reaches that code — the reach is one new
+ * test away and nothing warns when it appears. `make check-home-guard`
+ * is what keeps the next suite from forgetting.
+ *
+ * FATAL rather than conditional on purpose. The guard this replaces read
+ *     if (mkdtemp(test_home)) setenv("HOME", test_home, 1);
+ * which runs the whole suite against the real $HOME when mkdtemp fails,
+ * silently, with no failure reported — the original incident, restored by
+ * the one line that was supposed to prevent it. A guard whose failure is
+ * invisible is not a guard. */
+static char test_temp_home[64];
+
+static inline void test_temp_home_remove(void) {
+    if (!test_temp_home[0]) return;
+    /* Recursive because the suite left a state directory in there, and
+     * `make check` leaked one /tmp/shottino-test-home-* per run before
+     * this. The path is mkdtemp's own output, never input. */
+    char cmd[sizeof(test_temp_home) + 16];
+    snprintf(cmd, sizeof(cmd), "rm -rf '%s'", test_temp_home);
+    if (system(cmd) != 0) fprintf(stderr, "warning: %s not removed\n", test_temp_home);
+    test_temp_home[0] = 0;
+}
+
+static inline void test_use_temp_home(void) {
+    snprintf(test_temp_home, sizeof(test_temp_home), "/tmp/shottino-test-home-XXXXXX");
+    if (!mkdtemp(test_temp_home)) {
+        fprintf(stderr, "FATAL %s: mkdtemp: %s — refusing to run against the real $HOME\n",
+                __FILE__, strerror(errno));
+        exit(1);
+    }
+    if (setenv("HOME", test_temp_home, 1) != 0) {
+        fprintf(stderr, "FATAL %s: setenv(HOME): %s\n", __FILE__, strerror(errno));
+        test_temp_home_remove();
+        exit(1);
+    }
+    atexit(test_temp_home_remove);
+}
 
 static int test_report(void) {
     if (test_failures) {

--- a/frontends/shottino/tests/test.h
+++ b/frontends/shottino/tests/test.h
@@ -88,8 +88,16 @@ static const char *test_current;
  * missing, and its decode test returns having asserted nothing wherever
  * ffmpeg is absent — which is every CI run to date. So a missing test
  * dependency FAILS, and an operator who knows their host cannot have it
- * says so with SHOTTINO_TEST_ALLOW_SKIP=1. */
-static inline bool test_skip_allowed(void) { return getenv("SHOTTINO_TEST_ALLOW_SKIP") != NULL; }
+ * says so with SHOTTINO_TEST_ALLOW_SKIP=1.
+ *
+ * Exactly "1", not merely set: an empty SHOTTINO_TEST_ALLOW_SKIP= in a CI
+ * env block would otherwise disable the gate while looking like it turns
+ * nothing on, and a typo'd value should fail loudly rather than skip
+ * quietly. Whichever way this reading errs, it must err towards red. */
+static inline bool test_skip_allowed(void) {
+    const char *v = getenv("SHOTTINO_TEST_ALLOW_SKIP");
+    return v && strcmp(v, "1") == 0;
+}
 
 /* A HOME OF OUR OWN, before a single test runs.
  *

--- a/frontends/shottino/tests/test_call.c
+++ b/frontends/shottino/tests/test_call.c
@@ -405,6 +405,8 @@ TEST(a_configured_helper_is_used_or_refused_never_quietly_replaced) {
 }
 
 int main(void) {
+    test_use_temp_home();
+
     RUN(a_nick_folds_to_one_path_and_two_people_never_fold_to_one);
     RUN(a_nick_that_does_not_fit_is_cut_between_escapes_and_never_past_the_end);
     RUN(the_nick_in_me_is_the_same_byte_string_as_the_nick_in_peers);

--- a/frontends/shottino/tests/test_commands.c
+++ b/frontends/shottino/tests/test_commands.c
@@ -217,6 +217,8 @@ TEST(nothing_spells_its_own_version) {
 }
 
 int main(void) {
+    test_use_temp_home();
+
     source = read_source();
     if (!source) {
         fprintf(stderr, "test_commands: cannot read shottino.c (run from frontends/shottino)\n");

--- a/frontends/shottino/tests/test_ircd.c
+++ b/frontends/shottino/tests/test_ircd.c
@@ -946,6 +946,8 @@ TEST(archive_mode_asks_grappa_only_when_the_ring_falls_short) {
 }
 
 int main(void) {
+    test_use_temp_home();
+
     RUN(bind_spec_reads_ports_addresses_and_both_families);
     RUN(loopback_is_the_whole_127_block_and_the_v6_one);
     RUN(client_lines_parse_into_command_and_params);

--- a/frontends/shottino/tests/test_keys.c
+++ b/frontends/shottino/tests/test_keys.c
@@ -312,6 +312,8 @@ TEST(a_key_interrupting_an_escape_sequence_is_not_swallowed) {
 }
 
 int main(void) {
+    test_use_temp_home();
+
     RUN(the_input_line_has_a_cursor_you_can_move);
     RUN(modified_keys_decode_where_terminfo_describes_them);
     RUN(modified_keys_decode_where_terminfo_describes_nothing);

--- a/frontends/shottino/tests/test_layout.c
+++ b/frontends/shottino/tests/test_layout.c
@@ -1040,11 +1040,19 @@ static int decode_frames(struct app *app, const char *path, media_protocol proto
 
 TEST(the_decoder_says_what_animates_not_the_url) {
     if (!have_ffmpeg()) {
-        fprintf(stderr, "test_layout: no ffmpeg — skipping decode checks\n");
+        /* Not a skip by default. This test is the only thing in the tree
+         * that asks the real decoder what it produced, and every CI run
+         * so far printed "no ffmpeg — skipping" and reported green. */
+        if (!test_skip_allowed())
+            FAIL("ffmpeg is not on PATH: install it, or set SHOTTINO_TEST_ALLOW_SKIP=1");
+        else
+            fprintf(stderr, "test_layout: no ffmpeg — decode checks skipped on request\n");
         return;
     }
     char dir[] = "/tmp/shottino-test-XXXXXX";
-    if (!mkdtemp(dir)) return;
+    bool have_dir = mkdtemp(dir) != NULL;
+    CHECK(have_dir);
+    if (!have_dir) return;
     char gif[PATH_MAX], png[PATH_MAX], cmd[PATH_MAX * 2];
     snprintf(gif, sizeof(gif), "%s/a.bin", dir);  /* no extension to hint with */
     snprintf(png, sizeof(png), "%s/s.bin", dir);
@@ -1056,6 +1064,12 @@ TEST(the_decoder_says_what_animates_not_the_url) {
              "ffmpeg -y -loglevel error -f lavfi -i testsrc=size=32x24:duration=1 -frames:v 1 "
              "-f image2 -c:v png %s >/dev/null 2>&1", png);
     bool made_png = system(cmd) == 0;
+    /* An ffmpeg build without the gif or png encoder guarded away every
+     * assertion below and still passed. There IS an ffmpeg here — that it
+     * cannot produce these two files is a finding, not a reason to
+     * report nothing. */
+    CHECK(made_gif);
+    CHECK(made_png);
 
     struct app *app = test_app();
     CHECK(app != NULL);
@@ -1439,24 +1453,45 @@ TEST(the_sampling_draw_fills_its_box_rather_than_clipping) {
     free(m.rgb);
 }
 
+/* No screen: everything below the offscreen terminal is unrunnable, and
+ * saying so is the whole job. Returning 0 here reported a green suite
+ * that had asserted nothing at all on any host without a terminal
+ * database — see test_skip_allowed in test.h. */
+static int no_screen(const char *why) {
+    if (test_skip_allowed()) {
+        fprintf(stderr, "test_layout: %s — drawing tests skipped on request\n", why);
+        return test_report();
+    }
+    fprintf(stderr,
+            "test_layout: %s — the drawing tests cannot run. Install a terminal\n"
+            "database (ncurses-base), or set SHOTTINO_TEST_ALLOW_SKIP=1 to accept\n"
+            "a run that asserts only what needs no screen.\n",
+            why);
+    return 1;
+}
+
 int main(void) {
+    test_use_temp_home();
+
     /* Same as the real program does before it touches ncurses. Without
      * it ncursesw has no multibyte encoding to work with and writes a
      * SPACE where a half block was asked for — which makes every
      * assertion about drawn picture cells quietly vacuous. */
     setlocale(LC_ALL, "");
+
+    /* These two need no screen — one is arithmetic on a string, the
+     * other asks ffmpeg what it decoded. They run BEFORE the offscreen
+     * terminal so that a host that cannot provide one still checks them
+     * rather than reporting on nothing. */
+    RUN(the_topic_breaks_on_a_word);
+    RUN(the_decoder_says_what_animates_not_the_url);
+
     FILE *sink = fopen("/dev/null", "w");
-    if (!sink) {
-        fprintf(stderr, "test_layout: cannot open /dev/null — skipping\n");
-        return 0;
-    }
-    /* An offscreen screen: no TTY, no terminfo beyond the entry named
-     * here. A build host without terminfo skips rather than fails — the
-     * suite asserts shottino's layout, not the host's terminal database. */
+    if (!sink) return no_screen("cannot open /dev/null");
+    /* An offscreen screen: no TTY, no terminfo beyond the entry named here. */
     if (!newterm("xterm", sink, stdin)) {
-        fprintf(stderr, "test_layout: no usable terminfo entry — skipping\n");
         fclose(sink);
-        return 0;
+        return no_screen("no usable terminfo entry");
     }
     RUN(audio_is_clickable_but_not_drawn);
     RUN(the_sidebar_records_a_row_for_every_window);
@@ -1489,8 +1524,6 @@ int main(void) {
     RUN(roster_pane_draws_from_the_offset);
     RUN(the_topic_band_is_at_most_two_lines);
     RUN(a_short_channel_name_leaves_the_topic_the_width);
-    RUN(the_topic_breaks_on_a_word);
-    RUN(the_decoder_says_what_animates_not_the_url);
     RUN(an_action_is_drawn_louder_than_system_noise);
     RUN(a_source_rectangle_is_clamped_into_the_picture);
     RUN(a_cell_samples_across_the_whole_rectangle);

--- a/frontends/shottino/tests/test_windows.c
+++ b/frontends/shottino/tests/test_windows.c
@@ -4125,20 +4125,8 @@ TEST(the_settings_panel_lists_every_setting) {
 }
 
 int main(void) {
-    /* A HOME OF OUR OWN, before a single test runs.
-     *
-     * This suite calls the real prefs_save/prefs_load, and prefs_path
-     * resolves $HOME at call time — so without this it writes the
-     * developer's OWN ~/.local/share/shottino/shottino.conf, with
-     * whatever defaults a test app happens to hold. That is exactly
-     * what it did: vjt lost `voice.source = alsa:hw:2` to
-     * `pulse:default` on every `make check`, and blamed the reinstall
-     * that always happened alongside it.
-     *
-     * Set once here rather than per test, because the next test to call
-     * prefs_save is the one nobody remembers to guard. */
-    char test_home[] = "/tmp/shottino-test-home-XXXXXX";
-    if (mkdtemp(test_home)) setenv("HOME", test_home, 1);
+    /* This suite calls the real prefs_save/prefs_load. See test.h. */
+    test_use_temp_home();
 
     RUN(names_are_compared_under_the_ircds_casemapping);
     RUN(a_channel_opened_twice_in_two_spellings_is_one_window);


### PR DESCRIPTION
Fixes the class behind #763, not the example. Three defects with one shape: a
test reads its own environment, decides quietly it cannot do its job, and
reports exactly what a passing test reports.

## What the finding said, and what the file actually says now

Re-read against `c172043f`, not the `388f883b` the review was written at:

- **Items 1–3 stand.** The conditional guard, the single-suite scope and the
  leaked temp directory are all still there.
- **Item 2's "latent, not active" is STALE.** `test_layout` reaches
  `shottino_state_dir()` TODAY, through `a_modal_over_the_settings_panel_is_drawn`
  — found by instrumenting `RUN` and the function, not by reading. So
  `make check` has been creating `~/.local/share/shottino` on every developer
  machine and every CI runner. A container run of `origin/main` leaves
  `/root/.local/share/shottino` behind; the same run of this branch leaves
  nothing.
- **Item 4's "including the three new call-frame tests" is STALE.** Those live
  in `tests/test_call.c` now and were never behind test_layout's skip. The
  defect it describes is real anyway, for the other 37.
- **Item 5's suggested fix does not work.** Committing a gif fixture removes
  only the *encode* step; `media_decode_job` execs ffmpeg itself, so the test
  still needs the binary. Taken the other branch of the issue's own "or":
  fail unless the skip is requested, and give CI the binary.

## Measured

- **The old guard, displaced.** Point the template at a directory that does not
  exist. Old line: 1302 checks run, `1302 checks passed`, exit 0, and a
  rewritten `shottino.conf` + `llm.conf` in the home it was handed. New:
  `FATAL tests/test.h: mkdtemp: No such file or directory`, exit 1, no test
  runs, nothing written.
- **CI has never run the decode test.** The last green run of the shottino job
  on main (`30966743036`) prints `test_layout: no ffmpeg — skipping decode
  checks`. This is why the job now installs ffmpeg.
- **ffmpeg present, on Linux, the test really passes.** `ubuntu:24.04` +
  `ffmpeg 6.1.1`, `origin/main` vs this branch: identical failure set (three
  container-only ones: `media_tool_available` under root, and the two
  `count_blocks` already known from #758), check count 2941 → 2944 — the three
  new assertions all pass against a real decoder.
- **Drift guard, mutated.** Delete the call from `test_call.c`:
  `check-home-guard` names that file and exits non-zero. Restored: green.
- **No screen, mutated.** `newterm` with a terminal name that does not exist:
  unset / empty / `0` / `yes` → exit 1 with the reason; `1` → exit 0 having
  still run the 4 checks that need no screen.
- **No leak.** 34 stale `/tmp/shottino-test-home-*` existed on this machine
  before; five suite runs later, still 34. (Now zero.)
- Local gate: 16 suites green, zero warnings, clean tree before and after.
  `test_keys` cannot build on darwin (`pty.h`) — it builds and passes in the
  container.

## The mutation found a defect in the fix

`SHOTTINO_TEST_ALLOW_SKIP=` (set, empty) enabled the skip, so the run meant to
exercise the failure path was exercising the opt-out. Only `"1"` skips now.
Where a reading of an opt-out can err, it must err towards red.

## What I did not do

- Did not touch #762's unconstrained assertions in `test_windows.c`, though
  they are in the file I edited. My change there is the four lines of `main`.
- Did not claim the class is closed by hoisting alone. The guard was added to
  `test_windows.c` after the incident and `test_call.c` was written beside it
  with none — the class re-opened once already, unnoticed. `make check-home-guard`
  compares "includes shottino.c" against "calls test_use_temp_home()" and names
  the suite that forgot.