### PR TITLE
shottino: make the call tests fail when the implementation is broken (#762)

### DIFF
--- a/frontends/shottino/tests/test_callmedia.c
+++ b/frontends/shottino/tests/test_callmedia.c
@@ -19,6 +19,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -36,6 +39,13 @@ TEST(the_receive_sdp_describes_what_was_negotiated) {
                                 .frame_w = 320,
                                 .frame_h = 240,
                                 .fps = 10,
+                                /* SPELLED OUT, though zero already means
+                                 * VP8: a designated initialiser that
+                                 * leaves it out puts the assertions below
+                                 * on whichever codec happens to sit at 0,
+                                 * so the enum's ORDER decides what this
+                                 * test is about. */
+                                .video_codec = MEDIA_VIDEO_VP8,
                                 .want_video = true };
     char sdp[512];
 
@@ -396,7 +406,8 @@ TEST(the_published_grid_is_complete_or_refused) {
 }
 
 /* Two legs must never be handed the same port, and the port has to be
- * one the caller can actually tell ffmpeg about. */
+ * one the caller can actually tell ffmpeg about — on the interface this
+ * function's name promises. */
 TEST(loopback_ports_are_distinct_and_reported) {
     int a = 0, b = 0;
     int fd_a = media_bind_loopback(&a);
@@ -405,7 +416,35 @@ TEST(loopback_ports_are_distinct_and_reported) {
     CHECK(fd_b >= 0);
     CHECK(a > 0);
     CHECK(b > 0);
+    /* Kept, but it is the KERNEL's promise and not this function's: two
+     * ephemeral sockets open at the same moment cannot be handed one
+     * port however badly the bind is written, so on its own this line
+     * would pass over an implementation that binds nothing at all. */
     CHECK(a != b);
+
+    /* So ask the socket. Both halves of what the caller is told:
+     *
+     * THE ADDRESS, because `INADDR_ANY` binds just as successfully and
+     * reports a port just as plausibly, and puts unauthenticated RTP on
+     * every interface the machine has — a silent, remote change of
+     * exposure that nothing else in the tree would notice.
+     *
+     * THE PORT, because the number is handed to ffmpeg as where to send;
+     * one that is not the bound port is a leg that receives nothing and
+     * says nothing about why. */
+    const int fds[2] = { fd_a, fd_b };
+    const int ports[2] = { a, b };
+    for (int i = 0; i < 2; i++) {
+        if (fds[i] < 0) continue;
+        struct sockaddr_in sa;
+        memset(&sa, 0, sizeof(sa));
+        socklen_t len = sizeof(sa);
+        CHECK(getsockname(fds[i], (struct sockaddr *)&sa, &len) == 0);
+        CHECK(sa.sin_family == AF_INET);
+        CHECK(sa.sin_addr.s_addr == htonl(INADDR_LOOPBACK));
+        CHECK_LONG(ntohs(sa.sin_port), ports[i]);
+    }
+
     if (fd_a >= 0) close(fd_a);
     if (fd_b >= 0) close(fd_b);
 }

--- a/frontends/shottino/tests/test_layout.c
+++ b/frontends/shottino/tests/test_layout.c
@@ -1415,10 +1415,53 @@ static int count_blocks(int y0, int x0, int rows, int cols) {
     return n;
 }
 
-/* And the draw itself: it FILLS the box it was given. The colour of
- * each cell is unreadable here, but whether a cell was written at all
- * is not — and fill-versus-clip is the property that matters. */
-TEST(the_sampling_draw_fills_its_box_rather_than_clipping) {
+/* The (fg, bg) a drawn cell actually carries.
+ *
+ * The glyph is a half block in every cell of every picture, so the
+ * colours are the ONLY thing a sampled draw varies — read them back, or
+ * the draw is unobserved past "something was written here". */
+static bool cell_colors(int y, int x, short *fg, short *bg) {
+    cchar_t cc;
+    wchar_t wch[CCHARW_MAX];
+    attr_t attrs = 0;
+    short pair = 0;
+    if (mvin_wch(y, x, &cc) != OK) return false;
+    if (getcchar(&cc, wch, &attrs, &pair, NULL) != OK) return false;
+    return pair_content(pair, fg, bg) == OK;
+}
+
+/* Upper half block: the TOP source pixel is the foreground, the BOTTOM
+ * one the background. Quantised by the production quantiser rather than
+ * a second copy of it — this asserts which PIXEL was read, not how a
+ * colour is approximated. */
+#define CHECK_CELL_RGB(y, x, top_rgb, bot_rgb)                                                     \
+    do {                                                                                           \
+        short fg_ = -2, bg_ = -2;                                                                  \
+        CHECK(cell_colors((y), (x), &fg_, &bg_));                                                  \
+        CHECK_LONG(fg_, mirc_terminal_color(top_rgb));                                             \
+        CHECK_LONG(bg_, mirc_terminal_color(bot_rgb));                                             \
+    } while (0)
+
+/* And the draw itself: it FILLS the box it was given, out of the pixels
+ * the SAMPLER names.
+ *
+ * Fill-versus-clip needs only the glyphs, and an all-black picture
+ * answers it. Sampled-versus-not does not: a draw that ignored the
+ * source rectangle and painted the top-left corner of the picture over
+ * and over fills the box exactly as completely, and against a black
+ * buffer draws exactly the same screen. So the picture carries its own
+ * position in its colour — one saturated colour per quadrant — and the
+ * corners of the box say which quadrant they came from. */
+TEST(the_sampling_draw_fills_its_box_from_the_pixels_it_sampled) {
+    /* What the program does before it draws anything. Without it the
+     * offscreen screen has no colour pairs to allocate, every cell falls
+     * back to CP_MAIN, and the checks below compare a picture against
+     * itself. */
+    init_theme();
+    mirc_colors_init();
+    CHECK(has_colors());
+    CHECK(COLORS >= 8);
+
     struct inline_media m;
     memset(&m, 0, sizeof(m));
     m.state = IM_READY;
@@ -1426,12 +1469,33 @@ TEST(the_sampling_draw_fills_its_box_rather_than_clipping) {
     m.rows = 20; /* 40 x 40 pixels */
     m.frame_count = 1;
     m.rgb = calloc((size_t)40 * 40 * 3, 1);
+    CHECK(m.rgb != NULL);
+    if (!m.rgb) return;
+
+    /* Four quadrants, four colours far enough apart to survive an
+     * 8-colour terminal. */
+    const long tl = 0xff0000, tr = 0x00ff00, bl = 0x0000ff, br = 0xffffff;
+    for (int y = 0; y < 40; y++)
+        for (int x = 0; x < 40; x++) {
+            long rgb = y < 20 ? (x < 20 ? tl : tr) : (x < 20 ? bl : br);
+            unsigned char *p = m.rgb + (((size_t)y * 40) + x) * 3;
+            p[0] = (unsigned char)(rgb >> 16);
+            p[1] = (unsigned char)(rgb >> 8);
+            p[2] = (unsigned char)rgb;
+        }
 
     /* A box SMALLER than the picture in cells. The ordinary draw clips
      * to the picture's own cell size; this one must cover all 5x10. */
     erase();
     draw_media_region_locked(&m, 2, 3, 0, 0, 0, 0, 5, 10);
     CHECK(count_blocks(2, 3, 5, 10) == 50);
+    /* Its four corners hold the picture's four corners: the box is a
+     * tenth the picture's cell area, so a draw that walked the source
+     * one pixel per cell would put the top-left quadrant in all four. */
+    CHECK_CELL_RGB(2, 3, tl, tl);
+    CHECK_CELL_RGB(2, 3 + 9, tr, tr);
+    CHECK_CELL_RGB(2 + 4, 3, bl, bl);
+    CHECK_CELL_RGB(2 + 4, 3 + 9, br, br);
 
     /* A box BIGGER than the picture in cells: 20x60 from a 40x20-cell
      * picture, every one written (and it fits this 24x80 screen — a box
@@ -1441,6 +1505,11 @@ TEST(the_sampling_draw_fills_its_box_rather_than_clipping) {
     erase();
     draw_media_region_locked(&m, 0, 0, 0, 0, 0, 0, 20, 60);
     CHECK(count_blocks(0, 0, 20, 60) == 1200);
+    /* Stretched the other way, and still reading the whole picture. */
+    CHECK_CELL_RGB(0, 0, tl, tl);
+    CHECK_CELL_RGB(0, 59, tr, tr);
+    CHECK_CELL_RGB(19, 0, bl, bl);
+    CHECK_CELL_RGB(19, 59, br, br);
 
     /* Refusals draw nothing at all rather than a partial box. */
     erase();
@@ -1527,7 +1596,7 @@ int main(void) {
     RUN(an_action_is_drawn_louder_than_system_noise);
     RUN(a_source_rectangle_is_clamped_into_the_picture);
     RUN(a_cell_samples_across_the_whole_rectangle);
-    RUN(the_sampling_draw_fills_its_box_rather_than_clipping);
+    RUN(the_sampling_draw_fills_its_box_from_the_pixels_it_sampled);
     endwin();
     fclose(sink);
     return test_report();

--- a/frontends/shottino/tests/test_windows.c
+++ b/frontends/shottino/tests/test_windows.c
@@ -3006,19 +3006,25 @@ TEST(the_call_picture_is_a_share_of_the_width) {
      * whole client; 24 on a 200-column one is a stamp. */
     call_video_box(80, &c, &r);
     CHECK_LONG(c, 20);
+    CHECK_LONG(r, 7);
     call_video_box(200, &c, &r);
     CHECK_LONG(c, 40); /* capped */
+    CHECK_LONG(r, 15);
     call_video_box(40, &c, &r);
     CHECK_LONG(c, 16); /* floored */
+    CHECK_LONG(r, 6);
 
-    /* 4:3 in PIXELS, where the pixel height is rows*2. */
+    /* 4:3 in PIXELS at every width, where the pixel height is rows*2.
+     * The rows are pinned to that ratio, not merely bounded by it: an
+     * inequality is no test here, because `r = w / 4` — every face
+     * stretched, at every width — satisfies "at least six rows and never
+     * taller than wide" exactly as well as the right answer does. The
+     * one-cell slack is the halving's rounding, and nothing more. */
     for (int total = 40; total <= 240; total += 8) {
         call_video_box(total, &c, &r);
         CHECK(c >= 16 && c <= 40);
-        CHECK(r >= 6);
-        /* Never taller than it is wide, in pixels — that would be a
-         * portrait box for a landscape camera. */
-        CHECK(r * 2 <= c);
+        CHECK(r * 2 <= (c * 3) / 4);
+        CHECK(r * 2 >= (c * 3) / 4 - 1);
     }
 }
 


### PR DESCRIPTION
Four assertions from the `frontends/shottino` review slice that do not
constrain what their test names claim. Every replacement below was
measured: the mutation was applied to production, the OLD test run
against it, then the NEW one.

## 1. The 4:3 rows were unconstrained — FIXED, measured

`tests/test_windows.c`, `the_call_picture_is_a_share_of_the_width`. The
width was pinned exactly; the height only by `r >= 6 && r * 2 <= c`.

**Mutation:** `shottino.c`, `int r = (w * 3) / 8` → `int r = w / 4` —
every face stretched, at every terminal width.

| | result |
|---|---|
| old test | `rc=0`, 0 failures |
| new test | `rc=1`, **23** failures |

The three widths already named now assert their exact rows (80→7,
200→15, 40→6), and the sweep asserts the ratio itself — `r*2` within one
cell of `(c*3)/4` — rather than a bound the wrong answer also clears.
The one-cell slack is the halving's rounding and nothing more; it is not
a range widened to make something pass.

Worth knowing for whoever reads the diff: at `c = 40` the mutation is
masked by the `if (r < 6) r = 6` floor, which is why that width alone
still yields 6. Under the correct formula that floor is unreachable —
`w >= 16` already forces `(w*3)/8 >= 6` — so 40→6 is the floor's value
and the formula's agreeing by coincidence.

## 2. The loopback bind never checked loopback — FIXED, measured

`tests/test_callmedia.c`, `loopback_ports_are_distinct_and_reported`.
`CHECK(a != b)` is a kernel guarantee for two simultaneously-open
ephemeral sockets; it would pass over an implementation that binds
nothing. It is kept, with a comment saying so, and `getsockname` now
asserts both halves of what the caller is actually told.

| mutation (`call/media.c`) | old test | new test |
|---|---|---|
| `INADDR_LOOPBACK` → `INADDR_ANY` | `rc=0`, 0 failures | `rc=1`, 2 failures |
| reported port `+ 1` | `rc=0`, 0 failures | `rc=1`, 2 failures |

The first is the one that matters: it puts unauthenticated RTP on every
interface the machine has, and nothing else in the tree would have
noticed.

## 3. The codec under test was an accident — FIXED, but I am NOT claiming a new constraint

`.video_codec` is now spelled out in
`the_receive_sdp_describes_what_was_negotiated`, so the enum's ordering
no longer decides what the test is about.

**This is a says-what-it-means fix, not a constraint.** The issue says
reordering the enum makes the assertion "silently change meaning". I
measured it, and that is not what happens:

| mutation (`call/media.h`) | old test | new test |
|---|---|---|
| reorder so `MEDIA_VIDEO_H264 = 0` | `rc=1`, **2 failures** | `rc=0` |
| insert a new `MEDIA_VIDEO_AV1 = 0` | `rc=0` | `rc=0` |

The reorder already turned the old test red — for the wrong reason (it
was asserting VP8 against a config that had silently become H.264). The
fix makes that mutation correctly a non-event. The genuinely silent
mutation is the second one, and **the new test does not catch it
either**, because `media_video_codec_name()` returns `\"VP8\"` for any
value that is not `MEDIA_VIDEO_H264`. That silent default is the real
hazard here, in production and not in the test — the same failure the
enum's own comment says it exists to prevent. I have not touched it: it
is a production change and this issue is test quality. Flagging it
rather than papering over it with a test that asserts the current
behaviour.

## 4. The sampling draw was validated against an all-black buffer — FIXED, measured

`tests/test_layout.c`. The picture now carries its position in its
colour (one saturated colour per quadrant) and the corners of two
differently-scaled boxes are read back, compared against the production
quantiser. Renamed to
`the_sampling_draw_fills_its_box_from_the_pixels_it_sampled`, since it
now asserts that too.

| mutation (`shottino.c`) | old test | new test |
|---|---|---|
| draw ignores the source rect, walks one source pixel per cell | `rc=0`, 0 failures | `rc=1`, 5 failures |
| sampler transposes x and y | `rc=1` | `rc=1` |

The first is the exact bug the old test's own comment named. The second
is listed for honesty, not as evidence: the sibling sampler test already
catches transposition, so it does not discriminate.

### Why this one needed a comment about colour

`shottino.c` says the offscreen test terminal \"reports no colours at
all, so a drawn cell cannot be told from its neighbour by reading the
screen back\". Measured: `has_colors()` is 1, but `COLORS` and
`COLOR_PAIRS` are both **0** — because nothing had called
`start_color()`. With `init_theme()` + `mirc_colors_init()`, the
program's own setup, the offscreen screen reports 8 colours and the
four corners come back as four distinct pairs. The claim was true only
as a consequence of the setup, not of the screen.

Those two calls live inside the test rather than in `main()`, to keep
the blast radius to the one test that needs them. If colours are ever
unavailable the test goes red rather than quiet: the corner checks would
compare a real colour against `CP_MAIN`'s.

## Class sweep

Checked the sibling call suites for the same shape. One near miss:
`test_call.c`, `the_frame_box_is_never_empty_and_never_unbounded` bounds
its sweep with `cols >= 16 && cols <= 160`. That is left alone —
unlike the 4:3 case the bound IS what the name claims, the three exact
cases above it already pin the formula, and narrowing it was refused for
the same reason on #764. `test_callnote.c`'s `strlen(got) >=
sizeof(big)` is an anti-truncation property, not an under-assertion.

## Gate

`make check` clean-built and green on darwin, 17 of 18 suites — 13,513
checks, exit 0, zero warnings. Two exclusions, both environmental and
both pre-existing:

- `test_keys` includes `<pty.h>`, which is Linux-only. CI runs it.
- `test_layout`'s decode check needs ffmpeg, which is not installed on
  this host, so it ran under the explicit `SHOTTINO_TEST_ALLOW_SKIP=1`
  opt-in from #763. Nothing this PR touches is behind that skip. CI
  installs ffmpeg and runs it.