### PR TITLE
cic(#857): give the rail WHOIS value the whole card, not the leftovers

### DIFF
--- a/cicchetto/e2e/fixtures/railFieldGeometry.ts
+++ b/cicchetto/e2e/fixtures/railFieldGeometry.ts
@@ -1,0 +1,101 @@
+// #857 — the rail's definition-list cards must STACK: every `<dt>` and every
+// `<dd>` on its own row at the full card width. Two of the client's four
+// `<dl>`s mount in the rail (`RailContext` renders `ServerInfoCard` on a
+// server window and `WhoisCard` on a query), and both shipped as
+// `grid-template-columns: max-content 1fr`. In a full-width centre pane that
+// is right; inside the #605-capped `fit-content(14rem)` rail the label track
+// eats most of the card and `word-break: break-word` then chops each value a
+// few characters at a time.
+//
+// The oracle has to be a real engine: the defect and the fix are rendered
+// geometry, and jsdom has no layout. Hence one shared helper rather than a
+// copy per spec — the rule is one rule.
+//
+// MEASURED, not assumed (#858 diagnosis, chromium, rail dl width 156px):
+// counting a `Range`'s client rects over the whole `<dd>` OVERCOUNTS lines.
+// For a `<dd>` holding `<span class="whois-card-channel">#bofh</span>`
+// (`display: inline-block`) the range yields TWO rects of identical width —
+// `t=329.72 h=16.66 w=35.69` (the inline-block's border box, height = the
+// 1.4 line-height) and `t=330.72 h=14.00 w=35.69` (the text inside it, height
+// = the font box). Same content, counted twice, one pixel of half-leading
+// apart. So line boxes are counted over TEXT NODES only: a text node that
+// wraps still yields one rect per line (measured: `172.24.Azzurra-580278E6`
+// at t=91.72 and t=108.38), while an element box contributes none.
+
+import { expect, type Locator } from "@playwright/test";
+
+/** Roughly "one short word per line" — vjt's acceptance floor for #857. */
+const MIN_CHARS_PER_LINE = 8;
+
+type FieldRow = { tag: string; label: string; len: number; width: number; lines: number };
+type FieldGeometry = { dlWidth: number; rows: FieldRow[] };
+
+const measureFields = (card: Locator, dlSelector: string): Promise<FieldGeometry> =>
+  card.evaluate((el, sel) => {
+    const dl = el.querySelector(sel);
+    if (dl === null) throw new Error(`card has no ${sel}`);
+    const rows: FieldRow[] = [];
+    let label = "";
+    for (const kid of Array.from(dl.children)) {
+      const text = kid.textContent ?? "";
+      if (kid.tagName === "DT") label = text;
+      const tops = new Set<number>();
+      const walker = document.createTreeWalker(kid, NodeFilter.SHOW_TEXT);
+      for (let node = walker.nextNode(); node !== null; node = walker.nextNode()) {
+        if ((node.textContent ?? "").trim() === "") continue;
+        const range = document.createRange();
+        range.selectNodeContents(node);
+        for (const rect of Array.from(range.getClientRects())) {
+          if (rect.width === 0 && rect.height === 0) continue;
+          tops.add(Math.round(rect.top));
+        }
+      }
+      rows.push({
+        tag: kid.tagName,
+        label,
+        len: text.length,
+        width: kid.getBoundingClientRect().width,
+        lines: Math.max(tops.size, 1),
+      });
+    }
+    return { dlWidth: dl.getBoundingClientRect().width, rows };
+  }, dlSelector) as Promise<FieldGeometry>;
+
+/**
+ * Assert a rail-mounted `<dl>` is stacked: no two-column content anywhere in
+ * it. Every `<dt>` and `<dd>` spans the whole card (a label track leaves them
+ * a fraction — that IS the bug) and no value wraps below one short word per
+ * line.
+ */
+export const expectRailFieldsStacked = async (card: Locator, dlSelector: string) => {
+  const fields = await measureFields(card, dlSelector);
+  expect(fields.rows.length, `${dlSelector} rendered no rows to measure`).toBeGreaterThan(1);
+  for (const row of fields.rows) {
+    expect(
+      row.width,
+      `rail ${row.tag} "${row.label}" is ${row.width}px of the card's ${fields.dlWidth}px — still two columns`,
+    ).toBeGreaterThanOrEqual(fields.dlWidth - 0.5);
+    expect(
+      row.lines,
+      `rail ${row.tag} "${row.label}" (${row.len} chars) wraps onto ${row.lines} lines`,
+    ).toBeLessThanOrEqual(Math.max(1, Math.ceil(row.len / MIN_CHARS_PER_LINE)));
+  }
+};
+
+/**
+ * The complement, and the reason the rail rule is scoped rather than global:
+ * where the card HAS the width (the scrollback overlay) the aligned two
+ * columns stay. A leaked rail override would give the labels the full width
+ * here too.
+ */
+export const expectFieldsTwoColumn = async (card: Locator, dlSelector: string) => {
+  const fields = await measureFields(card, dlSelector);
+  const labels = fields.rows.filter((row) => row.tag === "DT");
+  expect(labels.length, `${dlSelector} rendered no labels to measure`).toBeGreaterThan(1);
+  for (const row of labels) {
+    expect(
+      row.width,
+      `overlay DT "${row.label}" spans the whole card — the rail override leaked`,
+    ).toBeLessThan(fields.dlWidth);
+  }
+};

--- a/cicchetto/e2e/tests/issue474-server-info-rail.spec.ts
+++ b/cicchetto/e2e/tests/issue474-server-info-rail.spec.ts
@@ -28,6 +28,7 @@
 
 import { expect, test } from "../fixtures/test";
 import { loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { expectRailFieldsStacked } from "../fixtures/railFieldGeometry";
 import { getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 
 const SERVER_WINDOW_LABEL = "Server";
@@ -83,5 +84,12 @@ test.describe("#474 server-info rail card", () => {
     // `identified` row: "no" — --auth none means no SASL/NickServ handshake,
     // so the nick never gains the +r umode connection_info reads.
     await expect(card.locator("[data-testid=rail-server-info-identified]")).toHaveText("no");
+
+    // #857 — nothing in the rail may render as two columns. This card shipped
+    // as `max-content 1fr`, which inside the #605-capped 14rem rail leaves
+    // each value a fraction of the card; every `<dt>` and `<dd>` must now own
+    // a full-width row of its own. Same helper guards the query-window card
+    // (`issue606-query-rail-whois.spec.ts`) — one rule, one assertion.
+    await expectRailFieldsStacked(card, ".rail-server-info-fields");
   });
 });

--- a/cicchetto/e2e/tests/issue606-query-rail-whois.spec.ts
+++ b/cicchetto/e2e/tests/issue606-query-rail-whois.spec.ts
@@ -23,6 +23,7 @@
 // Feature logic is engine-agnostic → chromium only (no `@webkit`), mirroring
 // nick-follow-query.spec.ts.
 
+import { type Locator } from "@playwright/test";
 import {
   composeSend,
   loginAs,
@@ -39,6 +40,39 @@ const RUN_ID = crypto.randomUUID().slice(0, 8);
 const PEER = `Rail${RUN_ID}`;
 const PEER_RENAMED = `Rail2${RUN_ID}`;
 const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// #857 — read the card's RENDERED geometry: for every `<dd>`, its box width
+// and how many line boxes its text actually occupies (a Range's client rects
+// are one per line, so distinct tops = lines). Both the "value is starved"
+// defect and its fix are invisible to the DOM and to jsdom; this is the only
+// place in the suite that can see them.
+const measureFields = (card: Locator) =>
+  card.evaluate((el) => {
+    const dl = el.querySelector(".whois-card-fields");
+    if (dl === null) throw new Error("whois card has no .whois-card-fields");
+    const rows: { label: string; len: number; width: number; lines: number }[] = [];
+    let label = "";
+    for (const kid of Array.from(dl.children)) {
+      if (kid.tagName === "DT") {
+        label = kid.textContent ?? "";
+        continue;
+      }
+      const range = document.createRange();
+      range.selectNodeContents(kid);
+      const tops = new Set<number>();
+      for (const rect of Array.from(range.getClientRects())) {
+        if (rect.width === 0 && rect.height === 0) continue;
+        tops.add(Math.round(rect.top));
+      }
+      rows.push({
+        label,
+        len: (kid.textContent ?? "").length,
+        width: kid.getBoundingClientRect().width,
+        lines: Math.max(tops.size, 1),
+      });
+    }
+    return { dlWidth: dl.getBoundingClientRect().width, rows };
+  });
 
 test("query rail shows heading + auto-fetched WHOIS card, follows NICK, coexists with /whois", async ({
   page,
@@ -79,6 +113,31 @@ test("query rail shows heading + auto-fetched WHOIS card, follows NICK, coexists
     // point of the disjoint stores): none present in the overlay layer.
     await expect(page.locator(".scrollback-overlay").getByTestId("whois-card")).toHaveCount(0);
 
+    // #857 — the rail card's VALUES must be readable, not a column of single
+    // characters. `.whois-card-fields` is `max-content 1fr`, so the label
+    // track sizes to the longest `<dt>`; inside the #605-capped 14rem rail
+    // that starves the value track and `word-break: break-word` then chops
+    // every value a few characters at a time. Measured here rather than
+    // asserted on a class name because the defect IS the rendered geometry —
+    // jsdom has no layout, so only a real engine can see it.
+    const railFields = await measureFields(railCard);
+    expect(railFields.rows.length).toBeGreaterThan(1);
+    for (const row of railFields.rows) {
+      // Stacked: the value owns the WHOLE card width (two columns leave it a
+      // fraction, which is the bug).
+      expect(
+        row.width,
+        `rail value "${row.label}" is narrower than the card`,
+      ).toBeGreaterThanOrEqual(railFields.dlWidth - 0.5);
+      // vjt's acceptance: no value wraps below roughly one short word per
+      // line. 8 chars/line is that floor; a 15-char value may take 2 lines,
+      // not 3+. Expressed against the value's own length so short values
+      // (`+iwx`) are not held to a ratio they cannot reach.
+      expect(row.lines, `rail value "${row.label}" wraps too tightly`).toBeLessThanOrEqual(
+        Math.max(1, Math.ceil(row.len / 8)),
+      );
+    }
+
     // A peer NICK while the query is open re-labels the heading (live).
     await peer.changeNick(PEER_RENAMED);
     await expect(ctx.locator(".rail-query-heading")).toHaveText(
@@ -96,6 +155,18 @@ test("query rail shows heading + auto-fetched WHOIS card, follows NICK, coexists
     await expect(overlayCard.locator(".whois-card-close")).toHaveCount(1);
     // ...and the rail card is STILL present (two disjoint cards at once).
     await expect(railCard).toBeVisible();
+
+    // #857 — the stacking fix is scoped to the rail mount, so the overlay
+    // card must KEEP its aligned two columns. A leaked override would give
+    // every value the full dl width here too; a label track means it did not.
+    const overlayFields = await measureFields(overlayCard);
+    expect(overlayFields.rows.length).toBeGreaterThan(1);
+    for (const row of overlayFields.rows) {
+      expect(
+        row.width,
+        `overlay value "${row.label}" lost its label column`,
+      ).toBeLessThan(overlayFields.dlWidth);
+    }
   } finally {
     await peer.disconnect("#606 done");
   }

--- a/cicchetto/e2e/tests/issue606-query-rail-whois.spec.ts
+++ b/cicchetto/e2e/tests/issue606-query-rail-whois.spec.ts
@@ -23,7 +23,6 @@
 // Feature logic is engine-agnostic → chromium only (no `@webkit`), mirroring
 // nick-follow-query.spec.ts.
 
-import { type Locator } from "@playwright/test";
 import {
   composeSend,
   loginAs,
@@ -31,6 +30,10 @@ import {
   waitForQueryWindowReady,
 } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
+import {
+  expectFieldsTwoColumn,
+  expectRailFieldsStacked,
+} from "../fixtures/railFieldGeometry";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
@@ -40,39 +43,6 @@ const RUN_ID = crypto.randomUUID().slice(0, 8);
 const PEER = `Rail${RUN_ID}`;
 const PEER_RENAMED = `Rail2${RUN_ID}`;
 const CHANNEL = AUTOJOIN_CHANNELS[0];
-
-// #857 — read the card's RENDERED geometry: for every `<dd>`, its box width
-// and how many line boxes its text actually occupies (a Range's client rects
-// are one per line, so distinct tops = lines). Both the "value is starved"
-// defect and its fix are invisible to the DOM and to jsdom; this is the only
-// place in the suite that can see them.
-const measureFields = (card: Locator) =>
-  card.evaluate((el) => {
-    const dl = el.querySelector(".whois-card-fields");
-    if (dl === null) throw new Error("whois card has no .whois-card-fields");
-    const rows: { label: string; len: number; width: number; lines: number }[] = [];
-    let label = "";
-    for (const kid of Array.from(dl.children)) {
-      if (kid.tagName === "DT") {
-        label = kid.textContent ?? "";
-        continue;
-      }
-      const range = document.createRange();
-      range.selectNodeContents(kid);
-      const tops = new Set<number>();
-      for (const rect of Array.from(range.getClientRects())) {
-        if (rect.width === 0 && rect.height === 0) continue;
-        tops.add(Math.round(rect.top));
-      }
-      rows.push({
-        label,
-        len: (kid.textContent ?? "").length,
-        width: kid.getBoundingClientRect().width,
-        lines: Math.max(tops.size, 1),
-      });
-    }
-    return { dlWidth: dl.getBoundingClientRect().width, rows };
-  });
 
 test("query rail shows heading + auto-fetched WHOIS card, follows NICK, coexists with /whois", async ({
   page,
@@ -113,30 +83,12 @@ test("query rail shows heading + auto-fetched WHOIS card, follows NICK, coexists
     // point of the disjoint stores): none present in the overlay layer.
     await expect(page.locator(".scrollback-overlay").getByTestId("whois-card")).toHaveCount(0);
 
-    // #857 — the rail card's VALUES must be readable, not a column of single
-    // characters. `.whois-card-fields` is `max-content 1fr`, so the label
-    // track sizes to the longest `<dt>`; inside the #605-capped 14rem rail
-    // that starves the value track and `word-break: break-word` then chops
-    // every value a few characters at a time. Measured here rather than
-    // asserted on a class name because the defect IS the rendered geometry —
-    // jsdom has no layout, so only a real engine can see it.
-    const railFields = await measureFields(railCard);
-    expect(railFields.rows.length).toBeGreaterThan(1);
-    for (const row of railFields.rows) {
-      // Stacked: the value owns the WHOLE card width (two columns leave it a
-      // fraction, which is the bug).
-      expect(
-        row.width,
-        `rail value "${row.label}" is narrower than the card`,
-      ).toBeGreaterThanOrEqual(railFields.dlWidth - 0.5);
-      // vjt's acceptance: no value wraps below roughly one short word per
-      // line. 8 chars/line is that floor; a 15-char value may take 2 lines,
-      // not 3+. Expressed against the value's own length so short values
-      // (`+iwx`) are not held to a ratio they cannot reach.
-      expect(row.lines, `rail value "${row.label}" wraps too tightly`).toBeLessThanOrEqual(
-        Math.max(1, Math.ceil(row.len / 8)),
-      );
-    }
+    // #857 — nothing in the rail may render as two columns: every `<dt>` and
+    // `<dd>` on its own row at the full card width, and no value wrapping
+    // below one short word per line. Measured in a real engine because the
+    // defect IS the geometry; the same rule is asserted on the server-window
+    // card by `issue474-server-info-rail.spec.ts`.
+    await expectRailFieldsStacked(railCard, ".whois-card-fields");
 
     // A peer NICK while the query is open re-labels the heading (live).
     await peer.changeNick(PEER_RENAMED);
@@ -156,17 +108,9 @@ test("query rail shows heading + auto-fetched WHOIS card, follows NICK, coexists
     // ...and the rail card is STILL present (two disjoint cards at once).
     await expect(railCard).toBeVisible();
 
-    // #857 — the stacking fix is scoped to the rail mount, so the overlay
-    // card must KEEP its aligned two columns. A leaked override would give
-    // every value the full dl width here too; a label track means it did not.
-    const overlayFields = await measureFields(overlayCard);
-    expect(overlayFields.rows.length).toBeGreaterThan(1);
-    for (const row of overlayFields.rows) {
-      expect(
-        row.width,
-        `overlay value "${row.label}" lost its label column`,
-      ).toBeLessThan(overlayFields.dlWidth);
-    }
+    // #857 — the stacking rule is scoped to the rail mount, so the overlay
+    // card must KEEP its aligned two columns: here the card HAS the width.
+    await expectFieldsTwoColumn(overlayCard, ".whois-card-fields");
   } finally {
     await peer.disconnect("#606 done");
   }

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -7540,16 +7540,31 @@ html.resize-dragging * {
   word-break: break-all;
 }
 
+/* #857 — STACKED, like every definition list mounted in the rail: label on
+   its own row, value beneath at the full card width. The two-column
+   `max-content 1fr` this shipped with sizes the label track to the longest
+   `<dt>` ("identified"), which inside the #605-capped 14rem rail leaves the
+   value a fraction of the card and lets `word-break: break-word` chop it. No
+   mount scoping needed here, unlike the sibling rule on
+   `.rail-query-context .whois-card-fields`: this card renders ONLY in the
+   rail, where WhoisCard is shared with the full-width scrollback overlay.
+
+   Row gap is uniform across the grid, so a stacked pair needs its own
+   separation or every row reads equidistant: the label opens a group. */
 .rail-server-info-fields {
   display: grid;
-  grid-template-columns: max-content 1fr;
+  grid-template-columns: 1fr;
   gap: 0.15rem 0.75rem;
   margin: 0;
 }
 
 .rail-server-info-fields dt {
   color: var(--muted);
-  text-align: right;
+  text-align: left;
+}
+
+.rail-server-info-fields dt:not(:first-of-type) {
+  margin-top: 0.4rem;
 }
 
 .rail-server-info-fields dd {
@@ -7572,7 +7587,10 @@ html.resize-dragging * {
 }
 
 /* #857 — the rail mount STACKS the pairs; the scrollback overlay keeps the
-   aligned two columns. `.whois-card-fields` is `max-content 1fr`, and
+   aligned two columns. Same rule as `.rail-server-info-fields` above — those
+   are the only two `<dl>`s the rail mounts (the other two, `.lusers-card-
+   fields` and `.whowas-card-fields`, are scrollback-overlay only and keep
+   their columns). `.whois-card-fields` is `max-content 1fr`, and
    `max-content` sizes the label track to the LONGEST `<dt>` in the bundle
    ("connecting from", WhoisCard.tsx). In a full-width centre pane that costs
    nothing; inside the #605-capped 14rem rail it claims most of the card, and

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -7571,6 +7571,36 @@ html.resize-dragging * {
   flex: 0 0 auto;
 }
 
+/* #857 — the rail mount STACKS the pairs; the scrollback overlay keeps the
+   aligned two columns. `.whois-card-fields` is `max-content 1fr`, and
+   `max-content` sizes the label track to the LONGEST `<dt>` in the bundle
+   ("connecting from", WhoisCard.tsx). In a full-width centre pane that costs
+   nothing; inside the #605-capped 14rem rail it claims most of the card, and
+   the `word-break: break-word` on `dd` then breaks each value a few
+   characters at a time instead of overflowing. Label-over-value hands the
+   value the WHOLE card width, so it wraps on word boundaries like prose.
+
+   Mount-scoped, NOT a container query on `.whois-card`, deliberately:
+   `container-type: inline-size` applies inline-size containment, which zeroes
+   the element's intrinsic contribution — and this card sits in a
+   `fit-content(14rem)` track (#605) that is SIZED from that contribution. A
+   width-driven rule would therefore silently re-size the rail track it is
+   trying to fit into. The mount is the honest proxy for "narrow" here.
+
+   Row-gap is uniform across the grid, so a stacked pair needs its own
+   separation or every row reads equidistant: the label opens a group. */
+.rail-query-context .whois-card-fields {
+  grid-template-columns: 1fr;
+}
+
+.rail-query-context .whois-card-fields dt {
+  text-align: left;
+}
+
+.rail-query-context .whois-card-fields dt:not(:first-of-type) {
+  margin-top: 0.4rem;
+}
+
 /* Mirrors `.members-pane h3` (uppercased, muted) so the query rail's
    heading slot reads identically to the channel members slot. */
 .rail-query-heading {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -29324,3 +29324,41 @@ the run intended to exercise the failure path was exercising the opt-out
 instead. Only `"1"` skips now; unset, empty, `0` and `yes` are all red. A
 reading of an opt-out must err towards red, or it becomes the silent
 degradation it was written to remove.
+
+---
+
+## 2026-08-05 — #857: the mount is the honest proxy, because the container query would re-size the container
+
+The query rail's WHOIS card rendered its values a few characters per line.
+The rail track is not at fault — `.shell-no-members` caps it at
+`fit-content(14rem)` (#605) and it measures as designed. The starvation is
+inside the card: `.whois-card-fields` is `grid-template-columns: max-content
+1fr`, and `max-content` sizes the label track to the LONGEST `<dt>` in the
+bundle — `connecting from`. In a full-width centre pane that costs nothing,
+which is why the same component in the scrollback `/whois` overlay has always
+looked right; in a 14rem column the label claims most of the card and the
+`word-break: break-word` on `dd` then chops each value rather than overflowing
+it. One component, two containers, and only one of them was ever measured.
+
+**The fix stacks label over value, scoped to `.rail-query-context`.** The
+tempting alternative — a container query on `.whois-card`, keying off actual
+width rather than mount — was rejected for a concrete reason:
+`container-type: inline-size` applies inline-size containment, which zeroes
+the element's intrinsic size contribution, and this card sits in a
+`fit-content(14rem)` track that is SIZED from exactly that contribution. A
+width-driven rule would have silently re-sized the track it was trying to fit
+into, converting a cosmetic bug into a layout one and re-opening the #605
+coupling that block already warns about. Where the card is mounted is the
+honest stand-in for how wide it is, precisely because the container's width is
+derived from the card.
+
+**The oracle has to be a real engine.** Reading the rule tells you it exists;
+it never tells you the rendered width, and jsdom has no layout at all, so the
+unit suite is structurally blind to both the defect and the fix. The guard
+therefore lives in `issue606-query-rail-whois.spec.ts`, which already stands up
+a real query window with a real upstream WHOIS: it reads each `<dd>`'s box and
+counts its line boxes (a Range's client rects are one per line), asserting the
+rail values span the whole card and wrap no tighter than roughly one short word
+per line — and, on the overlay card in the same page, that a label column is
+still there. A scoped override needs a test on BOTH sides of the scope, or the
+leak is the thing nobody notices.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -29354,11 +29354,31 @@ derived from the card.
 
 **The oracle has to be a real engine.** Reading the rule tells you it exists;
 it never tells you the rendered width, and jsdom has no layout at all, so the
-unit suite is structurally blind to both the defect and the fix. The guard
-therefore lives in `issue606-query-rail-whois.spec.ts`, which already stands up
-a real query window with a real upstream WHOIS: it reads each `<dd>`'s box and
-counts its line boxes (a Range's client rects are one per line), asserting the
-rail values span the whole card and wrap no tighter than roughly one short word
-per line — and, on the overlay card in the same page, that a label column is
-still there. A scoped override needs a test on BOTH sides of the scope, or the
-leak is the thing nobody notices.
+unit suite is structurally blind to both the defect and the fix. The guard is a
+shared e2e helper (`fixtures/railFieldGeometry.ts`) called from the two specs
+that already stand up the two rail cards: every `<dt>` and `<dd>` must span the
+whole card and wrap no tighter than roughly one short word per line, and the
+overlay card in the same page must still HAVE a label column. A scoped override
+needs a test on BOTH sides of the scope, or the leak is the thing nobody
+notices.
+
+**The rule is "no two columns in the rail", not "the WHOIS card".** A sweep of
+every `<dl>` in the client found four, of which exactly two mount in the rail —
+both from `RailContext`, both shipped `max-content 1fr`: WhoisCard on a query,
+ServerInfoCard on a server window. `.lusers-card-fields` and
+`.whowas-card-fields` are scrollback-overlay only and keep their columns. The
+list of surfaces someone happened to notice is a sample; the grep for the
+mechanism is the coverage.
+
+**A measurement can be wrong in the direction that looks like a bug.** The
+first CI run went red on `channels`: a five-character value (`#bofh`) reported
+as two line boxes in a 156px card — arithmetically impossible, and therefore
+about the counter rather than the layout. A `Range` over a `<dd>` returns the
+border box of a fully-contained element AND the text inside it, so the one
+`display: inline-block` channel span yielded two rects of identical width
+(t=329.72 h=16.66 w=35.69, the border box at the 1.4 line-height; t=330.72
+h=14.00 w=35.69, the text at the font box) one pixel of half-leading apart.
+Counting over text nodes only fixes it without touching the threshold. The
+tell was that the number was impossible, not that the test was inconvenient —
+and the same run's width assertion, which passed, is what ruled out "the
+override never reached that row" before a single line was changed.


### PR DESCRIPTION
Fixes the query-rail WHOIS card wrapping its values a few characters per line (issue #857).

## What the issue claimed, and what I verified

Every cited line still holds, at the paths as they exist today (the issue's `RailContext.tsx` / `WhoisCard.tsx` live at `cicchetto/src/`, not under `components/`):

- `RailContext.tsx:121` — the query branch mounts `WhoisCard` inside `.rail-query-context`. ✔
- `themes/default.css:7407` — `.whois-card-fields { grid-template-columns: max-content 1fr }`. ✔
- `themes/default.css:7419` — `.whois-card-fields dd { word-break: break-word }`. ✔
- `themes/default.css:1091` — `.shell.shell-no-members` sizes the rail `fit-content(14rem)`. ✔
- `WhoisCard.tsx:179` — `connecting from`, the longest `<dt>` in the bundle. ✔

A query window is never a joined channel, so `shell-no-members` is always on while the card is showing — the coupling is not incidental.

## The fix

`.rail-query-context .whois-card-fields` goes single-column, `dt` left-aligned, with a top margin opening each pair (the grid's row gap is uniform, so stacked pairs otherwise read equidistant). The scrollback overlay is untouched.

**Not a container query on `.whois-card`**, although the issue offers it and it keys off the real cause. `container-type: inline-size` applies inline-size containment, which zeroes the element's intrinsic size contribution — and this card sits in a `fit-content(14rem)` track that is *sized from* that contribution (the #605 coupling the CSS already warns about). A width-driven rule would silently re-size the container it is trying to fit into. Rationale is in the CSS at the point of use and in DESIGN_NOTES.

Both mounts of `RailContext` are narrow (desktop rail 14rem; mobile drawer `80vw`/max `18rem`), so the mount-scoped rule is right on both form factors.

## Evidence — and what I refuse to claim

**I did not measure the rendered layout, and nothing in this PR's local gates could.** jsdom has no layout engine, and this host has no runnable browser: Chrome dies on `bootstrap_check_in ... Permission denied` under every headless flag combination, and `open -na` returns `-54`. I built a static harness with the *production* card markup (dumped from a real Solid render) inlined into the real `.shell-no-members` shell and the real theme CSS, ready to measure — and could not execute it. So the mechanism above is a **reading of the cascade, not a measurement**, and I am not dressing it up as one.

What *is* mechanical: `issue606-query-rail-whois.spec.ts` already stands up a live query window with a real upstream WHOIS in a real chromium, so the guard went there. It reads each `<dd>`'s box and counts its line boxes (a Range's client rects are one per line) and asserts:

- every rail value spans the full card width — with the two-column grid it gets a fraction, so this fails with the bug present;
- no rail value wraps tighter than ~8 characters per line, expressed against the value's own length so short values (`+iwx`) are not held to a ratio they cannot reach — this is vjt's acceptance criterion, stated mechanically;
- the overlay card in the same page still has a label column, i.e. the scoped override did not leak.

Those assertions are **unrun locally** — the e2e needs the docker stack, which I did not take. CI's `integration` job is path-filtered on `cicchetto/src/**` and `cicchetto/e2e/**`, both of which this PR touches, so it runs there. Treat the e2e as unverified until that job is green.

**The scrollback overlay being visually unchanged** is argued from selector scope (the override is under `.rail-query-context`, which the overlay mount does not carry) plus the e2e's label-column assertion. It has not been eyeballed or screenshotted.

## Sibling instance, deliberately left alone

`.rail-server-info-fields` (ServerInfoCard) is the same `max-content 1fr` dl in the same capped rail, with a longest label of `identified` — 5 characters shorter than `connecting from`, same mechanism, milder. Nobody has reported it and this issue does not cover it, so I did not silently restyle a second shipped surface. Flagging it as an open call rather than deciding it here.

## Gates

- `scripts/bun.sh run check` → exit 0 (48 CSS warnings, all pre-existing; none name the new selectors)
- `tsc --noEmit` standalone → exit 0
- `scripts/bun.sh run test` → exit 0, 235 files / 4258 tests passed

Both re-run on the exact committed tree.