### PR TITLE
docs(#860): the routed-IPv6-block prerequisite for mode 2

### DIFF
--- a/docs/DERIVED_SOURCE_ADDRESSES.md
+++ b/docs/DERIVED_SOURCE_ADDRESSES.md
@@ -15,7 +15,7 @@ Both problems have the same root: the network cannot tell the bouncer's users ap
 
 ## The mechanism
 
-The instance is given a routed IPv6 block — a **`/80`** — and **derives one address inside it per client network**, deterministically, from that client's own real source address:
+The instance is given a **routed** IPv6 block and dedicates a **`/80`** inside it to derivation — **one address per client network**, deterministically, from that client's own real source address:
 
 ```
 derived = block_prefix (80 bits) || first 48 bits of SHA-256("grappa/source-mapping/v1" || client_key)
@@ -29,6 +29,8 @@ The hash is **not keyed**. There is no secret and no key management: the mapping
 The interface id is deliberately ignored because RFC 8981 rotates it (privacy extensions) roughly daily; hashing the full 128 bits would silently expire every ban you set.
 
 For a `/80` the host part is 48 bits, so by the birthday bound the first collision is expected around `2^24 ≈ 16.7M` distinct client prefixes. Real instances map thousands, not millions.
+
+**That `/80` is not the whole allocation, and "routed" is not a figure of speech.** An instance carves its block into several `/80`s by role: the derivation block is one of them, and the reserved named addresses described below — the ones that keep a PTR — live in a *different* one, which is why they can never collide with a derived address. The reference instance routes two `/80`s to the bouncer for exactly that split. The **routed** part is load-bearing: on an on-link block a derived address leaves the host fine and the reply is never delivered, so mode 2 fails per session with nothing locally to see. How an operator gets a block into that state, and how they tell which kind they have, is a deployment prerequisite — `docs/OPERATIONS.md` covers it.
 
 Two properties follow, and they are what the feature buys:
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -808,26 +808,147 @@ ssh root@m42 'jexec grappa cp /home/grappa/grappa/infra/freebsd/rc.d/grappa \
   /usr/local/etc/rc.d/grappa && jexec grappa service grappa restart'
 ```
 
-**Jail outbound source IPs.** The jail is shared-IP
-(`jail.conf ip6=new`, `interface=vtnet0`); pool + per-server
-`source_address` IPs are `/128` aliases in `jail.conf ip6.addr`. To add
-a new source the jail can bind: append `vtnet0|<ip>/<prefix>` to
-`ip6.addr` (persist) + `jail -m jid=6 ip6.addr="…,vtnet0|<ip>/<prefix>"`
-(apply live, no restart). **Validated 2026-06-04: a shared-IP jail can
-bind a host-owned address, and jail teardown does NOT strip an address
-the host already owned** (jail(8) only removes what it added) — so the
-host's primary `::42` (rDNS `m42.openssl.it`, owned by `/etc/rc.conf`)
-is safe to share into the jail. Match the host's prefixlen (`::42/64`,
-not `/128`, or you collide with the host's on-link route).
+**Jail outbound source IPs.** The jail runs **VNET** on `bridge0`
+(`/etc/rc.conf:108`, "trasloco 2026-08-01" — measured 2026-08-05),
+reached over a `/126` transfer net: `…:2d3:fffe::1` / `…:fffe::5` host
+side, `…:fffe::6` jail side. It has its own network stack, so it
+configures its own addresses — which is also what lets mode 2 alias on
+`lo0` at all (`A VNET jail is REQUIRED`, below).
+
+> **Stale procedure, deliberately not replaced.** Until the
+> 2026-08-01 move this jail was **shared-IP** (`jail.conf ip6=new`,
+> `interface=vtnet0`), and a new bindable source was added by appending
+> `vtnet0|<ip>/<prefix>` to `jail.conf ip6.addr` plus `jail -m jid=6
+> ip6.addr="…"` to apply it live. That procedure belongs to the old
+> topology and does not describe the VNET jail. The finding it recorded
+> still holds for anyone running shared-IP (validated 2026-06-04: a
+> shared-IP jail can bind a host-owned address, and jail teardown does
+> not strip an address the host already owned — jail(8) removes only
+> what it added, so the host's primary `::42`, rDNS `m42.openssl.it`,
+> was safe to share in; match the host's prefixlen or collide with its
+> on-link route). **The VNET-era replacement has not been written**: it
+> was not measured when this correction was made (#860), so nothing is
+> asserted in its place.
 
 **Static-mapping source aliases (#543 mode 2).** The
 `static_mapping_with_reservations` addressing mode derives ONE stable
-`::cb::/80` source per untrusted client `/64` and binds it for the
-session lifetime. This is OFF by default (`addressing_mode` in
+source per untrusted client `/64`, inside the configured derivation
+`/80` (`addressing.static_mapping_prefix`), and binds it for the
+session lifetime.
+
+> **Addresses in this section, and why they are not interchangeable.**
+> Anything shown as a **template you would adapt** uses the RFC 3849
+> documentation prefix `2001:db8::/32` — never routable, so a
+> copy-paste cannot silently become a plausible-looking prefix that
+> goes nowhere. Anything shown as a **measured reading of m42** is real
+> and carries the date it was read. On m42, the live derivation block
+> is `2a03:4000:20:2d3:cafe::/80` (`addressing.static_mapping_prefix`,
+> measured 2026-08-05). The examples here used to name a
+> `…:2d3:cb::/80` that **is not routed on the reference host** — the
+> exact shape of the #609 incident, sitting in the runbook as the thing
+> to copy (#860). This is OFF by default (`addressing_mode` in
 `server_settings` defaults to `pool_with_reservations`); it must be
 armed per substrate before an admin flips the mode, or every mode-2
 session is HELD (`:mode2_disarmed`, credential marked failed) rather
 than egressing from the shared kernel-default source.
+
+**PREREQUISITE — the block must be ROUTED to your host, not on-link
+(#860).** Everything below assumes the provider already delivers the
+whole prefix to the machine. If it does not, every step still succeeds,
+`arm_check` still passes, and mode 2 still fails — per session, at the
+far end, where nothing you can see locally says why. Settle this first.
+
+- **The distinction, and why mode 2 needs the routed kind.** An
+  **on-link** prefix lives on the upstream L2 segment: the router reaches
+  each address by NDP, so only the addresses your host actually answers
+  for exist. Mode 2 derives addresses across the whole block on demand —
+  the outbound packet leaves fine, and the return traffic is dropped by a
+  router that never got a neighbour advertisement for that address. A
+  **routed** prefix is handed to your host as a next-hop; every address
+  inside it reaches you with no NDP involved. Only the second kind works.
+- **How to tell which you have.** Ask the provider, in these words: *is
+  this prefix routed to my host, and if so, to which next-hop address?*
+  The answer, not an inspection, is authoritative — but two checks give
+  you the shape:
+
+  ```sh
+  # FreeBSD                             # Linux
+  ifconfig -a | grep inet6              ip -6 addr
+  netstat -rn6                          ip -6 route
+  ```
+
+  The prefix your host's own address sits in, with the default route
+  pointing at a router inside it (or at a `fe80::` on that link), is your
+  on-link segment. A routed block is a **different** prefix, one that
+  appears in no interface's on-link scope and only exists because the
+  provider says it points at you. If a prefix is only ever mentioned in
+  the provider's control panel and never appears on an interface, that is
+  the routed one — or a claim you have not tested yet.
+
+  The empirical test, when you want to be sure before arming: put an
+  **arbitrary** address from the block (not the one the panel names) on
+  the host, and see whether traffic sent to it from outside arrives.
+  Routed blocks answer for any address; on-link ones only for the address
+  the segment already knows. Pick something that is not silently filtered
+  in transit — a listening TCP port is a better probe than ICMP.
+- **A routed block usually needs a next-hop address you have to
+  configure, and it is not inside the block.** This is the step that is
+  easiest to miss, because nothing about the routed prefix hints at it:
+  the provider routes toward an address on your **on-link** segment, and
+  if your host does not hold that address the entire prefix is dark for
+  everyone. On the reference host (m42, netcup "failover subnet"), that
+  next-hop is a `/128` alias of the host's EUI-64 on the upstream
+  interface — measured 2026-08-05 in `/etc/rc.conf`:
+
+  ```sh
+  # the on-link /64 the host lives in
+  ifconfig_vtnet0_ipv6="inet6 2a03:4000:2:33c::42 prefixlen 64"
+  # next-hop for the routed 2a03:4000:20:2d3::/64 (netcup failover subnet)
+  ifconfig_vtnet0_alias0="inet6 2a03:4000:2:33c:5837:69ff:fe76:1f8e prefixlen 128"
+  ```
+
+  Note the two prefixes have nothing in common: `2a03:4000:2:33c::/64` is
+  the on-link segment, `2a03:4000:20:2d3::/64` is the routed block, and
+  the address that ties them together belongs to the **former**. Which
+  address your provider expects is their choice — EUI-64, the panel's
+  stated gateway peer, whatever they tell you — so this is a question to
+  ask, not a value to copy. What generalises is the shape: *a routed
+  block is reachable only while the host answers on the next-hop the
+  provider routes to.*
+- **Getting the block from the host to the process.** With the prefix
+  arriving, the substrate steps below (FreeBSD alias wrapper / Linux
+  AnyIP route) are what let grappa bind inside it. On m42 the jail sits
+  behind a point-to-point link and the host static-routes `/80`s into it
+  — same `/etc/rc.conf` reading:
+
+  ```sh
+  ifconfig_bridge0_ipv6="inet6 2a03:4000:20:2d3:fffe::1 prefixlen 126"
+  ifconfig_bridge0_alias0="inet6 2a03:4000:20:2d3:fffe::5 prefixlen 126"
+  ipv6_static_routes="gvhbabe gvhcafe"
+  ipv6_route_gvhbabe="2a03:4000:20:2d3:babe:: -prefixlen 80 2a03:4000:20:2d3:fffe::6"
+  ipv6_route_gvhcafe="2a03:4000:20:2d3:cafe:: -prefixlen 80 2a03:4000:20:2d3:fffe::6"
+  ```
+
+  `fffe::6` is the jail side of the `/126`; `fffe::1` / `fffe::5` are the
+  host side. A single-machine install (no jail, no container) skips this
+  entirely — the block terminates on the host and the AnyIP route or the
+  alias wrapper is the whole path.
+- **If your block is on-link, mode 2 does not work on it.** Said plainly
+  because the failure is invisible until sessions are held: do not arm it
+  and hope. What is actually available:
+  - **Ask the provider for a routed prefix.** Frequently a separate
+    product from the on-link `/64` that came with the machine, and the
+    only path that is not fragile. This is the recommendation.
+  - **Proxy NDP over the prefix**, if you must. Per-address `neigh proxy`
+    entries cannot cover a `/80` (2^48 addresses), so this means a daemon
+    answering for the whole prefix — `net/ndppd` on FreeBSD, packaged on
+    most Linux distributions. It puts a userland process in the path of
+    every neighbour solicitation for your egress addresses, and #628
+    retired grappa's own NDP-keepalive service precisely because the
+    routed setup made it unnecessary. Treat it as the fragile option.
+  - **Stay on mode 1** (`pool_with_reservations`, the default). Reserved
+    named addresses and the shared pool need only ordinary on-link
+    addresses. It gives up per-client derivation, not the bouncer.
 
 - **Substrate select.** Set `GRAPPA_SUBSTRATE` in the deploy env
   (`jail` / `linux` / `docker`; unset ⇒ `docker` ⇒ Disabled adapter ⇒
@@ -850,14 +971,15 @@ than egressing from the shared kernel-default source.
 
   ```
   # /usr/local/etc/grappa/source-alias.conf   root:wheel, 0444
-  PREFIX=2a03:4000:20:2d3:cb::/80
+  PREFIX=2001:db8:1:2:cafe::/80
   ```
 
   Render this file from `ServerSettings.static_mapping_prefix` as part of the
   SAME deploy step that installs the wrapper + sudoers line, so the DB prefix
   and the wrapper's scope cannot drift by hand — that drift is the #609 prod
-  incident (the wrapper still pinned `cb::/80` while the intended block was
-  `cafe::/80`, which was not even routed, so every acquire failed exit 65 and
+  incident (the wrapper still pinned `…:2d3:cb::/80` — a prefix the host does
+  not route, confirmed 2026-08-05 against `/etc/rc.conf` — while the intended
+  block was the routed `…:2d3:cafe::/80`, so every acquire failed exit 65 and
   sessions stayed held). A missing / unreadable / malformed file makes the
   wrapper exit 66 (fail closed), never a wildcard fallback.
 
@@ -892,7 +1014,7 @@ than egressing from the shared kernel-default source.
   an AnyIP local route makes the whole block bindable at once. Provision
   BOTH (persist in your netplan/rc): `sysctl -w
   net.ipv6.ip_nonlocal_bind=1` and `ip -6 route add local
-  2a03:4000:20:2d3:cb::/80 dev lo`. `arm_check` verifies both; a missing
+  2001:db8:1:2:cafe::/80 dev lo`. `arm_check` verifies both; a missing
   route disarms with `:anyip_route_missing`, a disabled sysctl with
   `:ip_nonlocal_bind_disabled`.
 - **Boot reconcile.** At startup (after the HTTP surface is up, before

--- a/lib/grappa/net/source_alias.ex
+++ b/lib/grappa/net/source_alias.ex
@@ -1,7 +1,7 @@
 defmodule Grappa.Net.SourceAlias do
   @moduledoc """
   Platform adapter behaviour for binding a derived outbound source address
-  (`::cb::/80`, #543 `static_mapping_with_reservations`) to the local host so
+  (the derivation `/80`, #543 `static_mapping_with_reservations`) to the host so
   the upstream socket can `bind()` to it.
 
   Each substrate provisions a source address differently:
@@ -32,7 +32,7 @@ defmodule Grappa.Net.SourceAlias do
 
   ## Prefix is threaded, never stored
 
-  Every callback that touches an address takes the configured `::cb::/80`
+  Every callback that touches an address takes the configured derivation
   prefix explicitly (there is ONE prefix — the DB `ServerSettings.static_mapping_prefix/0`
   the manager arms against; no env duplicate). `ensure_source/2` /
   `release_source/2` guard `IpLiteral.in_cidr6?/2` BEFORE shelling: refusing

--- a/lib/grappa/net/source_alias/free_bsd.ex
+++ b/lib/grappa/net/source_alias/free_bsd.ex
@@ -1,7 +1,7 @@
 defmodule Grappa.Net.SourceAlias.FreeBSD do
   @moduledoc """
-  FreeBSD-jail source-alias adapter (#543). Binds a derived `::cb::/80`
-  address as a `/128` alias on `lo0` through the sudoers-scoped wrapper
+  FreeBSD-jail source-alias adapter (#543). Binds an address derived inside
+  the configured `/80` as a `/128` alias on `lo0` through the sudoers wrapper
   `infra/freebsd/bin/grappa-source-alias`, invoked via the hardened command
   seam (`Grappa.Net.SourceAlias.Config.cmd/0`).
 
@@ -102,7 +102,7 @@ defmodule Grappa.Net.SourceAlias.FreeBSD do
   end
 
   # Extract the inet6 addresses from `ifconfig lo0` output that fall inside
-  # `prefix`. Lines look like `\tinet6 2a03:4000:20:2d3:cb::1 prefixlen 128`;
+  # `prefix`. Lines look like `\tinet6 2001:db8:1:2:cafe::1 prefixlen 128`;
   # a link-local carries a `%lo0` zone we strip before the membership test.
   #
   # Each address is CANONICALIZED (`IpLiteral.canonicalize/1`, i.e. the same

--- a/lib/grappa/net/source_alias_manager.ex
+++ b/lib/grappa/net/source_alias_manager.ex
@@ -260,7 +260,7 @@ defmodule Grappa.Net.SourceAliasManager do
   defp held_addresses(state), do: Map.keys(state.refcounts) ++ state.held_source_fn.()
 
   # #627 — with no prefix, mode 2 is unconfigured (the arm gate already
-  # disarmed it, see `compute_arm/2`): there is no `::cb::/80` block to
+  # disarmed it, see `compute_arm/2`): there is no derivation block to
   # reconcile against and nothing can be a managed alias, so the sweep is not
   # merely unnecessary — it has no business running. Doing it anyway shelled
   # `ifconfig lo0` and filtered `::1` through `in_cidr6?(_, nil)`, raising in

--- a/lib/grappa/server_settings.ex
+++ b/lib/grappa/server_settings.ex
@@ -245,8 +245,8 @@ defmodule Grappa.ServerSettings do
 
   @doc """
   Returns the configured static-mapping derived-source prefix as a
-  canonical IPv6 CIDR string, or `nil` when unset. This is the `::cb::/80`
-  untrusted block the source derivation maps client `/64`s into.
+  canonical IPv6 CIDR string, or `nil` when unset. This is the untrusted
+  `/80` the source derivation maps client `/64`s into.
   """
   @spec static_mapping_prefix() :: String.t() | nil
   def static_mapping_prefix, do: get_raw(@key_static_mapping_prefix)

--- a/lib/grappa/vhosts.ex
+++ b/lib/grappa/vhosts.ex
@@ -299,7 +299,7 @@ defmodule Grappa.Vhosts do
   Distinct from `granted_vhost_ids/1` (ids, for the self-service `granted`
   flag) and from `allowed_vhosts/2` (which in mode 1 also folds in `in_pool`
   + generally-available — both INERT in mode 2). Reserved grant addresses
-  live OUTSIDE the `::cb::/80` derivation block by operator convention, so
+  live OUTSIDE the derivation `/80` by operator convention, so
   a grant can never collide with a derived address.
   """
   @spec granted_vhost_addresses(Subject.t()) :: [String.t()]

--- a/lib/grappa/vhosts/source_mapping.ex
+++ b/lib/grappa/vhosts/source_mapping.ex
@@ -5,7 +5,7 @@ defmodule Grappa.Vhosts.SourceMapping do
   `static_mapping_with_reservations` addressing mode.
 
   Each untrusted subject egresses from ONE stable address inside the
-  configured `::cb::/80`, derived from the subject's OWN client `/64`
+  configured derivation `/80`, derived from the subject's OWN client `/64`
   (v6) or `/32` (v4). This replaces the random pool for mode 2: an
   address is `derive(client_key(client_ip), prefix)` — same client, same
   address, forever (until the operator renumbers the prefix).


### PR DESCRIPTION
Refs #860.

Documentation only, plus eight comment lines in `lib/` (moduledoc text, no code).

## The gap

The mode-2 runbook began where the provider already routes the prefix to the
host — the one state you cannot reach by following the runbook. When it is
missing, every step below it still succeeds: the wrapper installs, `arm_check`
passes, the mode flips. It then fails per session at the far end, with nothing
locally to see.

## What is now documented (`docs/OPERATIONS.md`, ahead of the arming steps)

- **Routed vs on-link, and why only routed works.** On-link prefixes are
  reached by NDP, so a derived address egresses fine and the reply is dropped
  by a router that never got an advertisement for it.
- **How to tell which you have** — the question to ask the provider verbatim,
  the two inspection commands per OS, what the shape looks like either way, and
  an empirical test (an arbitrary address from the block, probed on a listening
  TCP port rather than ICMP).
- **The next-hop alias, which is the actual trap.** The provider routes toward
  an address on your **on-link** segment; if the host does not hold it the
  whole prefix is dark. Nothing about the routed prefix hints that this is
  needed, and the two prefixes share no bits.
- **From the block to the process** — on m42, `/80`s static-routed into the
  jail over a `/126` transfer net. A single-machine install skips it.
- **The on-link case, named as unsupported.** Ask the provider for a routed
  prefix (recommended); or `ndppd` over the prefix, with its fragility stated
  and tied to #628 which retired grappa's own NDP keepalive; or stay on mode 1.

## Measured vs inferred

**Measured** (vjt, on m42, 2026-08-05 — I have no access to that host):
`/etc/rc.conf` — the on-link `/64`, the EUI-64 `/128` next-hop alias for the
routed block, the `bridge0` `/126` transfer net, the two static `/80` routes
into the jail; `addressing.static_mapping_prefix` from the prod DB; the rc.conf
comment recording the `/64` split by role; the "jail in VNET su bridge0
(trasloco 2026-08-01)" line. Quoted with dates.

**Domain knowledge, not measured:** the NDP mechanics, and the inspection /
empirical procedure. Written as procedure with its caveats, not as a guarantee.

**From the issue, not verified:** that a routed block is often a separate cheap
product, and `ndppd` as the scaling answer to per-address `neigh proxy`.

**Refused:** any claim about a provider other than netcup. One host was
measured. The only thing generalised is *a routed block is reachable while the
host answers on the next-hop the provider routes to* — which address that is,
and whether your provider wants one at all, is written as a question to ask
them, never a value to copy.

## Three corrections the measurements forced — not what the issue asked for

Flagging these explicitly since they widen the diff:

1. **The example prefix was not routed.** `…:2d3:cb::/80` appeared in three
   places in OPERATIONS and six in `lib/` moduledocs; the host does not route
   it. A plausible-looking dead prefix, in the runbook, as the thing to copy —
   the exact shape of #609. Templates now use the RFC 3849 documentation prefix
   (never routable, so it cannot rot into plausibility), measured readings stay
   real and dated, and the live derivation block is named once as a reading.
   The moduledocs stop naming a concrete value at all: the prefix is a DB
   setting, so a literal there is right only by accident. Bats fixtures keep
   their arbitrary addresses — test inputs, not documentation.
2. **`Jail outbound source IPs` described the shared-IP jail.** It has been
   VNET on `bridge0` since 2026-08-01, which the transfer `/126` confirms and
   which the mode-2 section's "a VNET jail is REQUIRED" already assumed — the
   two contradicted each other ten lines apart. The shared-IP procedure is kept
   as an explicitly historical note (its 2026-06-04 finding still holds on that
   topology). **The VNET-era replacement is deliberately not written**: it was
   not measured, so nothing is asserted in its place.
3. **`DERIVED_SOURCE_ADDRESSES.md` said the instance is given a `/80`.** The
   reference instance is routed two, split by role — derivation, and
   reserved-with-PTR. That split is why a grant can never collide with a
   derived address, which the doc already stated further down without
   connecting it. It keeps the routed block as a premise (as the issue asks)
   and points at OPERATIONS for how to get one.

## Note for the merge order

This touches the same OPERATIONS paragraph that #861 rewrites (the #609
render step). Whichever lands second will hit a one-hunk conflict there.

## Gates

Docs and comment text; no code path changes. I could not run `mix ci.check`
here (no COMPILE lane), so the `lib/` edits are verified by inspection only:
substitutions inside `@moduledoc` heredocs and `#` comments, every touched line
measured under Credo's 120-column limit, no test or doctest references the
changed strings.