### PR TITLE
fix(#863): a blank-looking line no longer aborts a multi-line paste

### DIFF
--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { channelKey } from "../lib/channelKey";
 import { LIST_WINDOW_NAME } from "../lib/windowKinds";
+import { BLANK_BODY_ERROR, serverAcceptsBody } from "./serverBodyPredicate";
 
 vi.mock("../lib/api", () => {
   class ApiError extends Error {
@@ -380,6 +381,53 @@ describe("compose submit — slash command dispatch", () => {
     // History records the WHOLE original paste (one recall entry), not per-line.
     compose.recallPrev(k);
     expect(compose.getDraft(k)).toBe("one\ntwo\nthree");
+  });
+
+  // #863 — a whitespace-only line must never abort the REST of a paste.
+  //
+  // This is the constraint that holds whichever way the fix goes, so it is the
+  // one worth pinning before the direction is chosen. If cic starts dropping
+  // whitespace-only lines, the line never reaches the door and the others go
+  // out. If the server starts accepting them, the line is delivered and the
+  // others go out. Only today's disagreement — cic sends it, the server calls
+  // it blank — stops the paste dead and mirrors the remainder back into the
+  // draft, which is what two users reported as a "scrambled" paste.
+  //
+  // The door here rejects exactly what the real server rejects
+  // (`serverBodyPredicate.ts`, which carries the derivation), with the real
+  // 422 envelope: `friendlyApiError` turns it into `Please fix: body: can't be
+  // blank.` — the string in the report.
+  //
+  // Deliberately NOT asserted: whether " " itself is sent. That is the product
+  // decision (#863's open question) and this test must survive either answer,
+  // so it asserts only that the CONTENT lines all got out and the composer was
+  // left empty.
+  it("#863 — a whitespace-only line does not abort the rest of the paste", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    const api = await import("../lib/api");
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+
+    vi.mocked(sb.sendMessage).mockImplementation(async (_slug, _target, body) => {
+      if (!serverAcceptsBody(body)) {
+        throw new api.ApiError(
+          BLANK_BODY_ERROR.status,
+          BLANK_BODY_ERROR.code,
+          BLANK_BODY_ERROR.info,
+        );
+      }
+      return undefined as never;
+    });
+
+    // A code paste with an indented blank line in the middle — the reported shape.
+    compose.setDraft(k, "def f():\n \n    return 1");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    const sent = vi.mocked(sb.sendMessage).mock.calls.map((c) => c[2]);
+    expect(sent.filter((line) => line.trim() !== "")).toEqual(["def f():", "    return 1"]);
+    expect(compose.getDraft(k)).toBe("");
+    expect(result).toEqual({ ok: true });
   });
 
   // #666 — the CORE bug. A fatal mid-paste error must leave ONLY the unsent

--- a/cicchetto/src/__tests__/messageLines.test.ts
+++ b/cicchetto/src/__tests__/messageLines.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { splitMessageLines } from "../lib/messageLines";
+import { serverAcceptsBody } from "./serverBodyPredicate";
 
 // IRC frames are newline-delimited, so a PRIVMSG body cannot carry an
 // embedded LF — `splitMessageLines` turns a multiline compose into one
@@ -42,4 +43,36 @@ describe("splitMessageLines", () => {
   it("preserves a whitespace-only line (it is content on the wire, not empty)", () => {
     expect(splitMessageLines("a\n \nb")).toEqual(["a", " ", "b"]);
   });
+});
+
+// #863 — the two halves of "what is an empty line" must agree.
+//
+// The splitter decides what cic PUTS ON THE WIRE; the server decides what it
+// will accept. Nothing connects the two, so they drifted: the splitter keeps a
+// whitespace-only line on purpose ("content on the wire, not empty", the test
+// directly above), and the server refuses it as blank. The disagreement is
+// invisible until someone pastes a block with an indented blank line in it,
+// which is the ordinary shape of pasted code, logs and quoted text.
+//
+// This pin does NOT say which side is right — that is a product decision. It
+// says only that a line cic chooses to send must be one the server takes. It
+// holds either way: if the splitter starts dropping whitespace-only lines it
+// never emits one; if the server starts accepting them the model in
+// `serverBodyPredicate.ts` moves with it. What it forbids is fixing one half
+// and leaving the other to disagree in silence again.
+describe("#863 — splitMessageLines agrees with the server on what is empty", () => {
+  const pastes = [
+    "a\n \nb", // the reported shape: a space between two content lines
+    "a\n\t\nb", // same, tab-indented — a code paste
+    "first\n   \nsecond\n\nthird", // mixed: indented blank, truly empty
+    "  leading\ntrailing  ", // content with edge whitespace stays content
+    "plain", // the single-line common path
+  ];
+
+  for (const paste of pastes) {
+    it(`every line emitted for ${JSON.stringify(paste)} is a body the server accepts`, () => {
+      const emitted = splitMessageLines(paste);
+      expect(emitted.filter((line) => !serverAcceptsBody(line))).toEqual([]);
+    });
+  }
 });

--- a/cicchetto/src/__tests__/messageLines.test.ts
+++ b/cicchetto/src/__tests__/messageLines.test.ts
@@ -40,8 +40,22 @@ describe("splitMessageLines", () => {
     expect(splitMessageLines("only\n")).toEqual(["only"]);
   });
 
-  it("preserves a whitespace-only line (it is content on the wire, not empty)", () => {
-    expect(splitMessageLines("a\n \nb")).toEqual(["a", " ", "b"]);
+  // #863 — this case used to assert the OPPOSITE: that a whitespace-only line
+  // is preserved because it is "content on the wire, not empty". It is
+  // inverted rather than deleted, because the reversal is the decision worth
+  // keeping visible. The server never accepted such a line — Ecto trims before
+  // its empty-value test — so cic was sending something guaranteed to be
+  // refused, and one indented blank line in a paste aborted the rest of it.
+  it("drops a whitespace-only line — the server counts it as blank, so it is not content", () => {
+    expect(splitMessageLines("a\n \nb")).toEqual(["a", "b"]);
+  });
+
+  it("drops a tab-only line too — the shape a code paste actually produces", () => {
+    expect(splitMessageLines("a\n\t\nb")).toEqual(["a", "b"]);
+  });
+
+  it("keeps a line whose whitespace surrounds real content (indentation is content)", () => {
+    expect(splitMessageLines("def f():\n    return 1")).toEqual(["def f():", "    return 1"]);
   });
 });
 
@@ -54,12 +68,13 @@ describe("splitMessageLines", () => {
 // invisible until someone pastes a block with an indented blank line in it,
 // which is the ordinary shape of pasted code, logs and quoted text.
 //
-// This pin does NOT say which side is right — that is a product decision. It
-// says only that a line cic chooses to send must be one the server takes. It
-// holds either way: if the splitter starts dropping whitespace-only lines it
-// never emits one; if the server starts accepting them the model in
-// `serverBodyPredicate.ts` moves with it. What it forbids is fixing one half
-// and leaving the other to disagree in silence again.
+// This pin does not encode WHICH answer was chosen — the client moving onto
+// the server's notion was a product decision, and pinning the decision would
+// only restate the splitter's own code. It pins the AGREEMENT: a line cic
+// chooses to send must be one the server takes. It survives the server
+// changing its mind too (the model in `serverBodyPredicate.ts` moves, and the
+// splitter must follow or this fails). What it forbids is the state #863 was
+// filed from — one half moving and the other left to disagree in silence.
 describe("#863 — splitMessageLines agrees with the server on what is empty", () => {
   const pastes = [
     "a\n \nb", // the reported shape: a space between two content lines

--- a/cicchetto/src/__tests__/serverBodyPredicate.ts
+++ b/cicchetto/src/__tests__/serverBodyPredicate.ts
@@ -2,12 +2,14 @@
 // the client-side suites can be held against it.
 //
 // THIS IS THE HALF THAT MUST BE UPDATED IF THE SERVER CHANGES. The
-// disagreement #863 reports is silent precisely because the two predicates
-// live in two languages with nothing tying them together: the client's is
-// `splitMessageLines`' `!== ""` filter (`src/lib/messageLines.ts`), the
-// server's is an emergent property of Ecto rather than a written rule.
-// Whichever way the fix goes, both halves move together — and the suites
-// that import this file fail until they do.
+// disagreement #863 reported was silent precisely because the two predicates
+// live in two languages with nothing tying them together: the client's, in
+// `splitMessageLines` (`src/lib/messageLines.ts`), and the server's, an
+// emergent property of Ecto rather than a written rule. #863 closed the gap
+// by moving the CLIENT onto the server's notion — it now drops a line that
+// trims to nothing. This file is what keeps them from drifting apart again:
+// if the server's half moves, this model moves with it, and the suites that
+// import it fail until the splitter follows.
 //
 // Where the server's behaviour comes from (read on origin/main, measured on
 // prod by the #863 reporter — NOT executed from this suite):

--- a/cicchetto/src/__tests__/serverBodyPredicate.ts
+++ b/cicchetto/src/__tests__/serverBodyPredicate.ts
@@ -1,0 +1,44 @@
+// #863 — the server's notion of "an empty message body", modelled here so
+// the client-side suites can be held against it.
+//
+// THIS IS THE HALF THAT MUST BE UPDATED IF THE SERVER CHANGES. The
+// disagreement #863 reports is silent precisely because the two predicates
+// live in two languages with nothing tying them together: the client's is
+// `splitMessageLines`' `!== ""` filter (`src/lib/messageLines.ts`), the
+// server's is an emergent property of Ecto rather than a written rule.
+// Whichever way the fix goes, both halves move together — and the suites
+// that import this file fail until they do.
+//
+// Where the server's behaviour comes from (read on origin/main, measured on
+// prod by the #863 reporter — NOT executed from this suite):
+//
+//   * `GrappaWeb.MessagesController.create/2` guards on `body != ""`, so a
+//     whitespace-only body passes the controller.
+//   * `Grappa.Session.send_privmsg/4` only rejects CRLF/NUL, so it passes
+//     there too.
+//   * `Grappa.Session.Server.persist_and_send_fragments/5` persists BEFORE
+//     it relays, and `Grappa.Scrollback.Message.changeset/2` runs
+//     `validate_required([:body])`. Ecto's `cast/4` trims string params
+//     before its empty-value test (`Ecto.Type.trim/2` against
+//     `@empty_values [""]`), so `" "` is treated as an ABSENT param: the
+//     change is never applied, `:body` stays nil, and validate_required
+//     adds "can't be blank".
+//
+// So the server accepts a body iff it is non-empty AFTER trimming — an
+// accident of `cast/4`, not a decision anyone wrote down. That is the point.
+//
+// LIMIT, stated rather than papered over: this uses JavaScript's `trim()`,
+// which is not byte-identical to Elixir's `String.trim/1` on exotic
+// whitespace (U+FEFF is stripped by JS and not by Elixir). Callers must
+// keep their samples to ASCII spaces and tabs, where the two agree. This
+// model is a stand-in for the real server, and only inside that range.
+export const serverAcceptsBody = (body: string): boolean => body.trim() !== "";
+
+// The 422 the server returns when `serverAcceptsBody` is false, in the exact
+// shape `readError` builds — `friendlyApiError` renders this as
+// `Please fix: body: can't be blank.`, the string the user reported.
+export const BLANK_BODY_ERROR = {
+  status: 422,
+  code: "validation_failed",
+  info: { field_errors: { body: ["can't be blank"] } },
+} as const;

--- a/cicchetto/src/lib/messageLines.ts
+++ b/cicchetto/src/lib/messageLines.ts
@@ -17,11 +17,26 @@
 // guard is `not String.contains?(s, ["\r", "\n", "\x00"])`). Splitting
 // on LF alone would leave an embedded or CR-only `\r` in the body and
 // the server would bounce that frame: the splitter must satisfy the
-// guard for all three forms, not just trailing-CR-from-CRLF. Drops lines
-// that are empty after the split — an empty PRIVMSG is itself invalid,
-// and a blank line between paragraphs is not worth a wire frame. A
-// whitespace-only line is kept: it is content on the wire, not empty. A
-// single-line body returns `[body]` unchanged, so the common path is a
+// guard for all three forms, not just trailing-CR-from-CRLF.
+//
+// Drops every line that is blank after trimming — an empty PRIVMSG is
+// itself invalid, and a blank line between paragraphs is not worth a
+// wire frame. The trim matters, and #863 is why: this filter used to be
+// a strict `!== ""` on the reasoning that a whitespace-only line is
+// "content on the wire, not empty". The server disagreed, silently. It
+// accepts a body only if it is non-empty AFTER trimming (Ecto's `cast/4`
+// trims before its empty-value test, so `" "` arrives as an absent param
+// and `validate_required` fires), so cic sent a line the door would
+// always refuse — and because `sendBodyLines` treats a non-429 as fatal,
+// one indented blank line inside a pasted block killed the paste and
+// pushed the remainder back into the draft. Two users reported it.
+//
+// The predicates are now the same one, and `serverBodyPredicate.ts` (the
+// test-side model of the server's half) is what holds them together: if
+// the server's notion of blank ever moves, that file and this filter
+// move together or the suites fail.
+//
+// A single-line body returns `[body]` unchanged, so the common path is a
 // one-element list and callers loop once.
 export const splitMessageLines = (body: string): string[] =>
-  body.split(/\r\n|\r|\n/).filter((line) => line !== "");
+  body.split(/\r\n|\r|\n/).filter((line) => line.trim() !== "");


### PR DESCRIPTION
Refs #863. cic-only — the server is not touched.

## The bug

Two users pasted a block with an indented blank line in it and watched the
paste stop halfway, with the unsent remainder shoved back into the draft and
`Please fix: body: can't be blank.` on screen.

Client and server did not agree on what "empty" means, and nothing connected
the two predicates:

- `splitMessageLines` filtered on a strict `!== ""`, keeping a whitespace-only
  line on the reasoning — stated in the module comment — that it is "content on
  the wire, not empty".
- The server accepts a body only if it is non-empty **after trimming**: Ecto's
  `cast/4` trims before its empty-value test, so `" "` arrives as an absent
  param, `:body` stays nil and `validate_required` fires.

So cic was sending a line the door would always refuse. `sendBodyLines` treats
a non-429 as fatal, so the refusal killed the rest of the paste.

## The fix

The client half moves onto the server's notion: the splitter drops a line that
trims to nothing. Whitespace that *surrounds* content is untouched —
indentation is content, and a pasted code block keeps its shape.

The direction was vjt's call between two viable ones (client drops vs server
accepts). The cost of this one was measured before it was chosen: it forces the
existing `preserves a whitespace-only line` case to be reversed.

## Two commits, on purpose

1. **The red tests, before any cure.** They assert only the constraint that
   holds whichever direction wins — a whitespace-only line must never abort the
   lines after it — plus a cross-stack pin that the two predicates agree.
2. **The cure.**

## What changed in the existing test, and why not delete it

`preserves a whitespace-only line` asserted the old intent. It is **inverted,
not removed**: it now reads `drops a whitespace-only line — the server counts
it as blank, so it is not content`, and carries a comment saying it used to
assert the opposite and why that was reversed. Deleting it would erase the fact
that the intent was reversed; a reader six months from now needs to find the
reversal, not its absence.

Two cases join it: a tab-only line (what a code paste actually produces) and an
indented line with content, which pins that the trim decides *emptiness* rather
than stripping content — a guard against the over-fix, not against the bug.

The cross-stack pin is left as written. It does not encode which answer won; it
asserts the two predicates AGREE, so it keeps holding if the server's half ever
moves. `serverBodyPredicate.ts` stays the declared place to update when it does.

## Evidence

- Before the cure: `4 failed | 167 passed (171)` on the two suites. The test
  that counts failed with
  `expected [ 'def f():' ] to deeply equal [ 'def f():', '    return 1' ]` —
  the second line never attempted.
- After: `173 passed (173)` on those suites; full vitest run **235 files, 4266
  tests, all green**; `tsc --noEmit` clean; biome clean on the touched files.
- **Mutation measured, not assumed.** Committing first, then restoring the old
  `!== ""` filter, turns **6 tests red** — the original 4 plus the 2 new ones.
  The indented-line case stays green under that mutation, correctly: it guards
  the over-fix, not the bug. Working tree restored and re-verified green.
- Both directions were probed while the tests were still red, to confirm they
  were not written to only one outcome: modelling the server as accepting
  whitespace made them pass too.

## Not measured

**No ExUnit was run — no COMPILE lane on this worker.** The server's behaviour
is MODELLED in `cicchetto/src/__tests__/serverBodyPredicate.ts`, from the
measurement in the issue and from reading the code; the file states each step
it was derived from. If that model is wrong, this fix is aligned to the wrong
thing.

One honest limit, written in the file rather than hidden: production now trims
with JavaScript's `trim()` while the server trims with Elixir's `String.trim/1`.
They agree across ASCII spaces and tabs — the samples stay in that range — but
not on exotic whitespace (U+FEFF is stripped by one and not the other). That
residual disagreement is narrower than the one this closes, and it is now
documented instead of silent.