### PR TITLE
cic(#837): one identityMoved predicate, and the two guards nobody was holding

### DIFF
--- a/cicchetto/src/__tests__/customTheme.test.ts
+++ b/cicchetto/src/__tests__/customTheme.test.ts
@@ -1,13 +1,18 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { createRoot } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setToken } from "../lib/auth";
 import {
+  activePair,
   applyCustomTheme,
   COLOR_KEYS,
   getAppliedThemePayload,
+  mountCustomThemeSync,
   setThemePreviewMode,
   tokenToCssVars,
 } from "../lib/customTheme";
 import { EDITOR_BASE_KEYS, EDITOR_MODE_KEYS, EDITOR_NICK_KEYS } from "../lib/themeEditor";
 import type { TokenColors, TokenPayload } from "../lib/themesApi";
+import type { ThemesWireT } from "../lib/wireTypes";
 
 // #75 producer path — apply-engine seams the editor depends on.
 //
@@ -171,5 +176,122 @@ describe("editor color vocabulary vs the canonical key set", () => {
       ...EDITOR_NICK_KEYS,
     ]);
     expect(editorKeys).toEqual(new Set<string>(COLOR_KEYS));
+  });
+});
+
+// #837 — the mid-flight identity guard in `mountCustomThemeSync`, which had no
+// test at all: the effect captured `token()` at entry, awaited GET /me/theme,
+// and re-checked before applying. Removing that re-check broke nothing, so the
+// rule was free to be dropped by anyone tidying the module.
+//
+// What it holds: `applyResolvedPair` is not a read — it paints documentElement
+// AND writes the boot cache. A response that lands after a rotation therefore
+// puts subject A's theme on subject B's screen and persists it as B's
+// FOUC-free boot theme, so it survives the reload that would otherwise correct
+// it. Identity-transition cleanup cannot reach this: A→B never runs the
+// logout-clear branch, and nothing cancels a request already on the wire.
+describe("mountCustomThemeSync — a response that outlives its identity (#837)", () => {
+  const A_TOKEN = "tok-a";
+  const B_TOKEN = "tok-b";
+  const A_BG = "#aa0000";
+  const B_BG = "#00bb00";
+
+  const themed = (bg: string): TokenPayload => {
+    const base = payload();
+    return { ...base, colors: { ...base.colors, bg } as TokenColors };
+  };
+
+  const themeRow = (id: number, bg: string): ThemesWireT => ({
+    id,
+    name: `theme-${id}`,
+    author: "tester",
+    built_in: false,
+    published: true,
+    apply_count: 0,
+    in_use: 0,
+    mine: true,
+    payload: themed(bg) as unknown as Record<string, unknown>,
+    inserted_at: "2026-01-01T00:00:00Z",
+  });
+
+  const bearerOf = (init?: RequestInit): string | null =>
+    new Headers(init?.headers).get("authorization");
+
+  const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+  // Hold A's GET open; answer any other bearer with B's theme immediately, so
+  // the only route by which A's theme can reach the DOM or the cache is the
+  // held continuation under test.
+  function stubWithHeldGetForA(): { release: (pair: unknown) => void } {
+    let release!: (r: Response) => void;
+    const held = new Promise<Response>((r) => {
+      release = r;
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation((_url, init?: RequestInit) => {
+      if (bearerOf(init) === `Bearer ${A_TOKEN}`) return held;
+      return Promise.resolve(
+        new Response(JSON.stringify({ light: themeRow(2, B_BG), dark: null }), { status: 200 }),
+      );
+    });
+    return {
+      release: (pair: unknown) => release(new Response(JSON.stringify(pair), { status: 200 })),
+    };
+  }
+
+  // Disposal in afterEach, not at the end of each case: the effect under test
+  // writes module-singleton state, so a case that fails an assertion and skips
+  // its own dispose() would leave a live sync running against the NEXT case's
+  // fetch stub — the failure would then cascade into a neighbour that is fine.
+  let dispose: (() => void) | null = null;
+
+  function mountFor(t: string): void {
+    setToken(t);
+    createRoot((d) => {
+      dispose = d;
+      mountCustomThemeSync();
+    });
+  }
+
+  beforeEach(() => {
+    setToken(null);
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    dispose?.();
+    dispose = null;
+  });
+
+  it("does not paint or cache the previous subject's theme when its GET lands after a rotation", async () => {
+    const a = stubWithHeldGetForA();
+    mountFor(A_TOKEN);
+    await flush(); // A's GET is on the wire, held
+
+    setToken(B_TOKEN); // rotation lands INSIDE A's await; B's own theme applies
+    await flush();
+
+    a.release({ light: themeRow(1, A_BG), dark: null });
+    await flush();
+
+    expect(activePair()).toEqual({ light: 2, dark: null });
+    expect(getAppliedThemePayload()?.colors.bg).toBe(B_BG);
+    expect(document.documentElement.style.getPropertyValue("--bg")).toBe(B_BG);
+  });
+
+  // The control. Same harness, same held response, no rotation: without it a
+  // gate that never delivered A's pair would make the case above pass while
+  // asserting nothing.
+  it("does apply that same response when the identity holds", async () => {
+    const a = stubWithHeldGetForA();
+    mountFor(A_TOKEN);
+    await flush();
+
+    a.release({ light: themeRow(1, A_BG), dark: null });
+    await flush();
+
+    expect(activePair()).toEqual({ light: 1, dark: null });
+    expect(getAppliedThemePayload()?.colors.bg).toBe(A_BG);
+    expect(document.documentElement.style.getPropertyValue("--bg")).toBe(A_BG);
   });
 });

--- a/cicchetto/src/__tests__/displayPrefs.test.ts
+++ b/cicchetto/src/__tests__/displayPrefs.test.ts
@@ -526,3 +526,125 @@ describe("syncedSetChannelPresencePref — refetch on reveal (#458)", () => {
     expect(asMock(loadInitialScrollback)).not.toHaveBeenCalled();
   });
 });
+
+// #837 — the mid-flight identity guard, the OTHER door into the cross-account
+// bleed the clear-on-logout block above closes. That block covers the identity
+// TRANSITION (logout clears, so B never inherits A's residue). This one covers
+// what the transition cannot reach: a GET already in flight when the rotation
+// happens. The effect captured A's token at entry and nothing cancels its
+// request, so the continuation resumes holding a bearer the server has already
+// retired — and it acts on the response.
+//
+// Two distinct harms, one per case below:
+//   * server-wins applies A's prefs over B's freshly-loaded ones;
+//   * a never-persisted A response fires a seed-up PUT under A's retired
+//     bearer — a 401/404 on the host's fail2ban-watched surface (#281's class).
+//
+// The rotation must land strictly INSIDE the await: A's GET is held open until
+// setToken has already re-run the effect for B and B's own answer has applied.
+describe("mountDisplayPrefsSync — a response that outlives its identity (#837)", () => {
+  const OTHER = "B-bearer";
+
+  const A_PREFS: DisplayPrefs = {
+    time_format: "hm",
+    colored_nicklist: true,
+    presence_filter: { [KEY_A]: "hide" },
+  };
+  // Distinct from A on all three axes, so "B's state survived" is an assertion
+  // about B's values rather than about the module defaults.
+  const B_PREFS: DisplayPrefs = {
+    time_format: "hms",
+    colored_nicklist: false,
+    presence_filter: { [KEY_B]: "hide" },
+  };
+
+  const bearerOf = (init?: RequestInit): string | null =>
+    new Headers(init?.headers).get("authorization");
+
+  const methodOf = (init?: RequestInit): string => (init?.method ?? "GET").toUpperCase();
+
+  const jsonResponse = (body: unknown): Response =>
+    new Response(JSON.stringify(body), { status: 200 });
+
+  // Hold A's GET open; answer everything else immediately. B's GET carries
+  // B_PREFS persisted, so the only route by which A's values can reach the
+  // local state is the held continuation under test.
+  function stubWithHeldGetForA(): { release: (body: unknown) => void } {
+    let release!: (r: Response) => void;
+    const held = new Promise<Response>((r) => {
+      release = r;
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation((_url, init?: RequestInit) => {
+      if (methodOf(init) === "GET" && bearerOf(init) === `Bearer ${TOKEN}`) return held;
+      return Promise.resolve(jsonResponse({ display_prefs: B_PREFS, persisted: true }));
+    });
+    return { release: (body: unknown) => release(jsonResponse(body)) };
+  }
+
+  const putBearers = (): (string | null)[] =>
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls
+      .filter((c) => methodOf(c[1] as RequestInit | undefined) === "PUT")
+      .map((c) => bearerOf(c[1] as RequestInit | undefined));
+
+  // Disposal in afterEach, not at the end of each case: the effect under test
+  // writes module-singleton state, so a case that fails an assertion and skips
+  // its own dispose() would leave a live sync running against the NEXT case's
+  // fetch stub — the failure would then cascade into a neighbour that is fine.
+  let dispose: (() => void) | null = null;
+
+  function mountFor(t: string): void {
+    setToken(t);
+    createRoot((d) => {
+      dispose = d;
+      mountDisplayPrefsSync();
+    });
+  }
+
+  afterEach(() => {
+    dispose?.();
+    dispose = null;
+  });
+
+  // Drive A-login → mount → rotate to B → release A's held GET with `body`.
+  async function rotateUnderAHeldGet(body: unknown): Promise<void> {
+    const a = stubWithHeldGetForA();
+    mountFor(TOKEN);
+    await flush(); // A's GET is on the wire, held
+    setToken(OTHER); // rotation lands INSIDE A's await; B's own GET answers
+    await flush();
+    a.release(body);
+    await flush();
+  }
+
+  it("does not apply the previous subject's prefs when its GET lands after a rotation", async () => {
+    await rotateUnderAHeldGet({ display_prefs: A_PREFS, persisted: true });
+
+    expect(getTimeFormat()).toBe(B_PREFS.time_format);
+    expect(getColoredNicklist()).toBe(B_PREFS.colored_nicklist);
+    expect(getAllPresencePrefs()).toEqual(B_PREFS.presence_filter);
+  });
+
+  // The control for the case above. Same harness, same held GET, no rotation:
+  // if A's response stopped reaching the apply path at all (a broken gate, a
+  // changed wire shape), the case above would pass while testing nothing.
+  it("does apply that same response when the identity holds", async () => {
+    const a = stubWithHeldGetForA();
+    mountFor(TOKEN);
+    await flush();
+    a.release({ display_prefs: A_PREFS, persisted: true });
+    await flush();
+
+    expect(getTimeFormat()).toBe(A_PREFS.time_format);
+    expect(getColoredNicklist()).toBe(A_PREFS.colored_nicklist);
+    expect(getAllPresencePrefs()).toEqual(A_PREFS.presence_filter);
+  });
+
+  it("does not seed up under a bearer the rotation already retired", async () => {
+    // persisted:false is the seed-up branch — the one that PUTs. Under A's
+    // retired bearer that write is both a wrong-identity request and, if the
+    // server honoured it, A's local map landing on B's account.
+    await rotateUnderAHeldGet({ display_prefs: A_PREFS, persisted: false });
+
+    expect(putBearers()).not.toContain(`Bearer ${TOKEN}`);
+  });
+});

--- a/cicchetto/src/lib/customTheme.ts
+++ b/cicchetto/src/lib/customTheme.ts
@@ -1,5 +1,6 @@
 import { createEffect, createSignal } from "solid-js";
 import { token } from "./auth";
+import { identityMoved } from "./identityMoved";
 import { moduleRoot } from "./moduleRoot";
 import { prefersDark } from "./theme";
 import type { ActiveThemePair, TokenPayload } from "./themesApi";
@@ -285,8 +286,9 @@ export function mountCustomThemeSync(): void {
     }
     void getActiveThemePair(t)
       .then((pair) => {
-        // Token rotated mid-flight — a later effect run owns the DOM now.
-        if (token() !== t) return;
+        // Token rotated mid-flight — a later effect run owns the DOM and the
+        // boot cache now (#837).
+        if (identityMoved(t)) return;
         applyResolvedPair(pair);
       })
       .catch((e) => {

--- a/cicchetto/src/lib/displayPrefs.ts
+++ b/cicchetto/src/lib/displayPrefs.ts
@@ -2,6 +2,7 @@ import { createEffect } from "solid-js";
 import { token } from "./auth";
 import { type ChannelKey, decodeChannelKey } from "./channelKey";
 import { getColoredNicklist, setColoredNicklist } from "./colorNicklist";
+import { identityMoved } from "./identityMoved";
 import {
   getAllPresencePrefs,
   type PresencePref,
@@ -127,8 +128,9 @@ export function mountDisplayPrefsSync(): void {
     }
     void getDisplayPrefs(t)
       .then((resp) => {
-        // Token rotated mid-flight — a later effect run owns the state now.
-        if (token() !== t) return;
+        // Token rotated mid-flight — a later effect run owns the state now,
+        // and the seed-up PUT below would carry a retired bearer (#837).
+        if (identityMoved(t)) return;
         // PUSH the LOCAL state up (never let the server clobber it) when either:
         //   * an earlier `syncedSet*` write is still UNCONFIRMED (its PUT never
         //     ACKed — e.g. a reload raced the fire-and-forget PUT). Without this

--- a/cicchetto/src/lib/identityMoved.ts
+++ b/cicchetto/src/lib/identityMoved.ts
@@ -1,0 +1,43 @@
+import { token } from "./auth";
+
+// THE identity predicate: the identity that started this continuation is not
+// the identity that will receive its result.
+//
+// `t` is the bearer a verb captured at entry — its identity, not merely its
+// credential. Any `await` can span an identity transition, and nothing cancels
+// a request already on the wire, so a continuation that outlived its identity
+// must do NOTHING further: not one request, not one write. Re-read `token()`
+// after the await and compare.
+//
+// Both halves of "nothing further" are load-bearing, which is why the check
+// belongs AFTER the await rather than in front of the request:
+//
+//   * the WIRE half — a request carrying a retired bearer 401s at best; aimed
+//     at a resource the NEW identity cannot see it 404s, and the host's
+//     `http-404` fail2ban jail bans the client IP at the firewall. A routine
+//     account switch self-bans the operator (#281's harm class).
+//   * the STORE half — the same continuation without touching the network: the
+//     result it already fetched lands in state the rotation just purged, so the
+//     new identity renders (or persists, or paints) the old one's data.
+//
+// Deliberately NOT part of `identityScopedStore`: that factory owns the
+// identity TRANSITION (fire the resets), while this owns a verb's OWN captured
+// identity, which the factory never sees. The two are complements — the resets
+// clear state, this refuses the write that arrives after the clear.
+//
+// Deliberately NOT in `auth.ts` either, though that module owns `token`: a
+// stub of `../auth` in a test would then stub the guard away with it, and the
+// rule under test would silently stop existing. Importing `token` from here
+// keeps the predicate real while still resolving through any token mock.
+//
+// #837 collapsed four inlined copies into this one. Adopters:
+//   * `scrollback.ts`   (#788) — eleven awaits, refusing a stale REQUEST;
+//   * `networks.ts`     (#818) — the `/me` hydrate side-effects;
+//   * `displayPrefs.ts`         — the login-reconcile apply + seed-up PUT;
+//   * `customTheme.ts`          — the active-theme paint + boot-cache write.
+// A fifth await site that captures the token adopts it unchanged; a site that
+// needs a VARIANT of the comparison has found a domain boundary, and that is
+// worth saying out loud rather than parameterising this.
+export function identityMoved(t: string): boolean {
+  return token() !== t;
+}

--- a/cicchetto/src/lib/networks.ts
+++ b/cicchetto/src/lib/networks.ts
@@ -11,6 +11,7 @@ import {
 } from "./api";
 import { token } from "./auth";
 import { setBadge } from "./badge";
+import { identityMoved } from "./identityMoved";
 import { identityScopedStore } from "./identityScopedStore";
 import { applyMeEnvelope } from "./readCursor";
 
@@ -81,13 +82,12 @@ const exports = identityScopedStore((onIdentityChange) => {
     //
     // The identity-TRANSITION is already handled (readCursor's own `on(token)`
     // arm and the `onIdentityChange` purge below both fire on rotation); what
-    // was missing is refusing a write that arrives AFTER the purge. Same rule
-    // and same predicate as #788's `identityMoved` in `scrollback.ts`: check
-    // after the await, not in front of the request. Kept in the caller rather
-    // than inside `applyMeEnvelope` because the check guards the whole block —
-    // `setBadge` shares this await and this bug — and because `readCursor`
-    // cannot know which identity produced an envelope handed to it.
-    if (token() !== t) return m;
+    // was missing is refusing a write that arrives AFTER the purge — the rule
+    // `identityMoved` owns. Kept in the caller rather than inside
+    // `applyMeEnvelope` because the check guards the whole block (`setBadge`
+    // shares this await and this bug) and because `readCursor` cannot know
+    // which identity produced an envelope handed to it.
+    if (identityMoved(t)) return m;
     // CP29 R-4: hydrate the readCursor signal map from the bulk envelope
     // BEFORE downstream consumers (subscribe.ts join effects, etc.)
     // observe `user()` and start joining channel topics. The join-reply

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -8,6 +8,7 @@ import {
 } from "./api";
 import { token } from "./auth";
 import { type ChannelKey, channelKey, decodeChannelKey } from "./channelKey";
+import { identityMoved } from "./identityMoved";
 import { identityScopedStore } from "./identityScopedStore";
 import { getReadCursor, setReadCursor } from "./readCursor";
 import { getResumeCursor, recordSeen } from "./reconnectBackfill";
@@ -150,27 +151,14 @@ const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): Scrollba
   return dropCount > 0 ? rows.slice(dropCount) : rows;
 };
 
-// #788 — THE rule for every async verb in this module: an `await` can span an
-// identity transition, and a continuation that outlived its identity must do
-// NOTHING further. Not one request on the wire, not one write into the store.
+// #788 — how THE identity rule applies to this module. The predicate itself,
+// and why a continuation that outlived its identity must do nothing further
+// (the wire half and the store half), live in `identityMoved.ts`; below is
+// only what is specific to these verbs.
 //
-// `t` is the bearer the verb captured at entry — its identity, not merely its
-// credential. Re-read `token()` after the await and compare: if it moved, the
-// verb belongs to an identity that no longer exists here.
-//
-// Both halves of "nothing further" are load-bearing, which is why the check
-// sits after the await rather than in front of each REST call:
-//
-//   * the WIRE half is #788 proper. A request carrying a revoked bearer 401s
-//     at best; for a channel the NEW identity is not attached to it 404s, and
-//     the host's `http-404` fail2ban jail bans the client IP at the firewall.
-//     A routine account switch self-bans the operator — the #281 harm class,
-//     reached through a different door.
-//   * the STORE half is the same continuation without touching the network:
-//     the page it already fetched merges into a map the rotation just purged,
-//     so the new identity renders the old one's scrollback. A guard wrapped
-//     around the REST calls alone would not catch it — the poisoning happens
-//     between the resolved fetch and the next request.
+// The store half is why the check sits after the await rather than in front of
+// each REST call: a guard wrapped around the requests alone would not catch it
+// — the poisoning happens between the resolved fetch and the next request.
 //
 // So: eleven of this module's fifteen awaits are followed by this check, and
 // the bail is whatever "did nothing" means for that verb's return type. Two
@@ -197,12 +185,9 @@ const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): Scrollba
 //     running. Same for the `refreshScrollback` completion stamp, which would
 //     tell a spec that ITS backfill had landed.
 //
-// Not hoisted into `identityScopedStore`: that factory owns the identity
-// TRANSITION (fire the resets), while this owns a verb's own captured
-// identity, which the factory never sees. Sibling modules inline the same
-// comparison (`displayPrefs`, `customTheme`) to drop a stale RESPONSE; this is
-// the same predicate used one step earlier, to refuse a stale REQUEST.
-const identityMoved = (t: string): boolean => token() !== t;
+// The sibling adopters (`networks`, `displayPrefs`, `customTheme`) use the
+// same predicate to drop a stale RESPONSE; this module uses it one step
+// earlier, to refuse a stale REQUEST.
 
 const exports = identityScopedStore((onIdentityChange) => {
   const loadedChannels = new Set<ChannelKey>();

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -29493,3 +29493,55 @@ substrate side (`jail_db_write.sh`, re-run the installer, then the UI), and
 that is now written down in `docs/OPERATIONS.md` rather than fixed here.
 `infra/linux/` has no source-alias wrapper at all, so it has no equivalent
 gap to close.
+
+## 2026-08-05 — #837: one identity predicate, and the two guards nobody was holding
+
+`identityMoved` — "the identity that started this continuation is not the
+identity that will receive its result" — was written inline in four modules:
+`scrollback.ts` (#788), `networks.ts` (#818), `displayPrefs.ts`, and
+`customTheme.ts`. Consolidating them was filed as a timing decision, not a
+merit one, and this is the pickup.
+
+**The refactor was the smaller half.** #788 and #818 each shipped a test for
+their own guard; the other two had none. Deleting `if (token() !== t) return;`
+from `displayPrefs.ts` left all 4258 cases green, and the same deletion in
+`customTheme.ts` left them green too. Extracting one predicate over two
+unpinned call sites would have moved untested code from four places to one and
+bought nothing — the shared owner would have been just as free to be dropped,
+now in one edit instead of four. So the tests came first, and they are the
+deliverable the issue predicted they would be.
+
+**What those two guards actually hold**, which is more than the 401 on the
+wire. `displayPrefs`: subject A's prefs applied over B's freshly-loaded ones,
+and — on the `persisted: false` seed-up branch — a PUT under A's retired
+bearer, which is #281's fail2ban harm class. `customTheme`: `applyResolvedPair`
+paints `documentElement` AND writes the FOUC boot cache, so A's theme lands on
+B's screen and then survives the reload that would otherwise correct it.
+Neither is reachable by identity-TRANSITION cleanup — an A→B rotation never
+runs the logout-clear branch that the existing cross-account-bleed tests cover,
+and nothing cancels a request already on the wire. Each new case has a
+no-rotation control releasing the SAME held response, so a gate that stopped
+delivering it fails loudly instead of passing vacuously.
+
+**Placement: its own module, not `auth.ts`.** `auth.ts` owns `token`, so it
+looked like the owner. But 38 test files stub `../auth`, and a partial stub
+would then replace the guard with `undefined` — the rule under test would stop
+existing wherever a suite meant to control only the token. A separate module
+that imports `token` keeps the predicate real while still resolving through
+those mocks. Confirmed, not assumed: under the mutation below the #788 suite,
+which mocks `../auth` with its own Solid signal, goes red like the rest.
+Not folded into `identityScopedStore` either — that factory owns the identity
+TRANSITION (fire the resets), while this owns a verb's OWN captured identity,
+which the factory never sees. Complements, not duplicates.
+
+**Measured.** Neutering the shared predicate turns 9 cases red across exactly
+the four adopters and nothing else: scrollback 5, networks 1, displayPrefs 2,
+customTheme 1. Restored: 235 files / 4263 tests green.
+
+**Left standing.** The four sites adopted the predicate unchanged, so no
+variant surfaced and none was invented; a fifth await site that needs a
+DIFFERENT comparison has found a domain boundary worth saying out loud rather
+than a parameter worth adding. And the guard remains a per-verb habit, not a
+whole-module property: a new `await` that captures the token and skips the
+check reopens the defect for its own call path — one owner makes the rule
+greppable, it does not make it automatic.


### PR DESCRIPTION
Picks up #837. The refactor is the smaller half; the missing tests are the deliverable the issue predicted.

## What was actually missing

#788 (`scrollback.ts`) and #818 (`networks.ts`) each shipped a test for their own mid-flight guard. The other two copies — `mountDisplayPrefsSync` and `mountCustomThemeSync` — had **none**. Deleting `if (token() !== t) return;` from either module left the entire cic suite green.

So consolidating first would have moved untested code from four places to one and protected nothing: the single owner would have been just as free to be dropped, now in one edit instead of four. Tests first, then the extraction.

## Commits

1. **`a0d93f4` — pin the two unheld guards.** New rotation cases for `displayPrefs` and `customTheme`, each with a no-rotation control that releases the SAME held response (a gate that stopped delivering it fails loudly instead of passing vacuously).
2. **`c6d50d7` — give the predicate one owner.** New `cicchetto/src/lib/identityMoved.ts`; all four sites adopt it **unchanged**.
3. **`02bc316` — DESIGN_NOTES.**

## Mutation numbers

Per-site, before the extraction:

| site | red | green | pre-existing cases moved |
|---|---|---|---|
| `displayPrefs` guard removed | 2 | 18 | **0 of 17** |
| `customTheme` guard removed | 1 | 36 | **0** |

Shared predicate neutered after the extraction — 9 red across exactly the four adopters and nothing else:

| suite | red |
|---|---|
| `scrollbackIdentityRotation` (#788) | 5 |
| `networks` (#818) | 1 |
| `displayPrefs` (new) | 2 |
| `customTheme` (new) | 1 |

Restored: **235 files / 4263 tests green**, `bun run check` exit 0.

## Two design points

**Own module, not `auth.ts`.** `auth.ts` owns `token`, so it looked like the owner — but 38 test files stub `../auth`, and a partial stub would replace the guard with `undefined`: the rule under test would stop existing wherever a suite meant to control only the token. A separate module importing `token` keeps the predicate real while still resolving through those mocks. Confirmed empirically — under the mutation the #788 suite, which mocks `../auth` with its own Solid signal, goes red like the rest.

**Not folded into `identityScopedStore`.** That factory owns the identity TRANSITION (fire the resets); this owns a verb's OWN captured identity, which the factory never sees. Complements, not duplicates.

## What the two new guards hold, beyond the 401

- `displayPrefs` — A's prefs applied over B's, and on the `persisted: false` seed-up branch a PUT under A's retired bearer (#281's fail2ban harm class).
- `customTheme` — `applyResolvedPair` paints `documentElement` **and** writes the FOUC boot cache, so A's theme lands on B's screen and survives the reload that would otherwise correct it.

Neither is reachable by identity-transition cleanup: an A→B rotation never runs the logout-clear branch the existing cross-account-bleed tests cover, and nothing cancels a request already on the wire.

## What I will not claim

- **No behaviour change is asserted beyond what the suite measures.** The four adopters are byte-equivalent in logic (`token() !== t`); no browser or e2e run was done, because nothing user-visible changes and nothing outside vitest was touched.
- **The guard is still a per-verb habit, not a whole-module property.** A new `await` that captures the token and skips the check reopens the defect for its own call path. One owner makes the rule greppable, not automatic.
- **Only the four sites named in the issue were audited.** I did not sweep the codebase for other capture-then-await patterns that ought to adopt it.

## Test plan

- [x] `bun run test` — 235 files / 4263 tests green (baseline 4258 + 5 new)
- [x] `bun run check` — exit 0 (biome + tsc)
- [x] `bun run build` — tsc --noEmit + vite build clean
- [x] Mutation, per site and shared — numbers above
- [ ] cic-only change: no lane, no server suite, no e2e