### PR TITLE
cic(#868): re-wire the live notify path through the shared predicate

### DIFF
--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -20,6 +20,7 @@ import { type FontSizeKey, getFontSize, setFontSize } from "./lib/fontSize";
 import { friendlyApiError } from "./lib/friendlyApiError";
 import { detach, quit, updateIdentity } from "./lib/lifecycle";
 import { isAdmin, networks, user } from "./lib/networks";
+import { mirrorNotificationPrefs } from "./lib/notificationPrefs";
 import { popOverlay, pushOverlay } from "./lib/overlayScrollLock";
 import {
   deletePushSubscription,
@@ -359,6 +360,10 @@ const SettingsDrawer: Component<Props> = (props) => {
     try {
       const loaded = await getNotificationPrefs(t);
       setPrefs(loaded);
+      // #868 — feed the live notify path the same authoritative map the form
+      // renders, so the beep obeys a pref the moment it is read, not on the
+      // next user-topic rejoin.
+      mirrorNotificationPrefs(loaded);
       setChannelsOnlyText(loaded.channel_messages_only.join(", "));
       setNicksOnlyText(loaded.private_messages_only.join(", "));
     } catch {
@@ -465,6 +470,9 @@ const SettingsDrawer: Component<Props> = (props) => {
     try {
       const saved = await putNotificationPrefs(t, next);
       setPrefs(saved);
+      // #868 — mirror the server's NORMALIZED echo (not `next`): the whitelists
+      // come back folded, which is the form the predicate compares against.
+      mirrorNotificationPrefs(saved);
     } catch (err) {
       const code = err instanceof Error ? err.message : "save_failed";
       setPrefsError(code);

--- a/cicchetto/src/__tests__/focus-rule.test.ts
+++ b/cicchetto/src/__tests__/focus-rule.test.ts
@@ -37,6 +37,11 @@ vi.mock("../lib/api", () => ({
   // transitively) needs the classifier in its api mock.
   isContentKind: (k: string) => k === "privmsg" || k === "notice" || k === "action",
   isPresenceKind: (k: string) => !(k === "privmsg" || k === "notice" || k === "action"),
+  // #868 — this file drives real messages through subscribe.ts, which now
+  // decides the beep via `pushTriggers.shouldNotify` and so reads the
+  // notify-worthy kind set from api.ts. Same mirror the classifiers above
+  // needed when selection.ts started importing them.
+  NOTIFY_KINDS: new Set(["privmsg", "action"]),
   displayNick: (me: { kind: "user" | "visitor"; name?: string; nick?: string }) =>
     me.kind === "user" ? (me.name ?? "") : (me.nick ?? ""),
   // Mirror of production `ownNickForNetwork` — see subscribe.test.ts

--- a/cicchetto/src/__tests__/notificationPrefs.test.ts
+++ b/cicchetto/src/__tests__/notificationPrefs.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setToken } from "../lib/auth";
+import {
+  mirrorNotificationPrefs,
+  notificationPrefs,
+  refreshNotificationPrefs,
+} from "../lib/notificationPrefs";
+import { DEFAULT_NOTIFICATION_PREFS, type NotificationPrefs } from "../lib/userSettings";
+
+// #868 — the notification-prefs store. `subscribe.ts` reads this signal on
+// every inbound message to decide the in-app beep and the optimistic
+// `document.title` bump, so three properties are load-bearing:
+//
+//   * the un-hydrated value is the SERVER's own default, not an empty map. A
+//     client that has not hydrated yet must behave like a subject who never
+//     configured anything — never like one who muted everything.
+//   * refreshNotificationPrefs hydrates from GET. That is the mechanism the
+//     user-topic-join hydration relies on, so a pref set on another device
+//     reaches this device's beep after a reload.
+//   * mirrorNotificationPrefs adopts a server response, so toggling a pref in
+//     the settings drawer changes the beep immediately rather than at the next
+//     rejoin.
+
+const TOKEN = "notif-prefs-tok";
+
+const MUTED_MENTIONS: NotificationPrefs = {
+  ...DEFAULT_NOTIFICATION_PREFS,
+  channel_mentions: false,
+  private_messages_all: false,
+};
+
+beforeEach(() => {
+  setToken(TOKEN);
+  mirrorNotificationPrefs(DEFAULT_NOTIFICATION_PREFS);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setToken(null);
+  mirrorNotificationPrefs(DEFAULT_NOTIFICATION_PREFS);
+});
+
+describe("notificationPrefs store — #868", () => {
+  it("starts at the server defaults, so an un-hydrated client is not silently muted", () => {
+    expect(notificationPrefs()).toEqual(DEFAULT_NOTIFICATION_PREFS);
+    // Pinned explicitly: these two are what make the un-hydrated state
+    // deliver rather than swallow.
+    expect(notificationPrefs().channel_mentions).toBe(true);
+    expect(notificationPrefs().private_messages_all).toBe(true);
+  });
+
+  it("refreshNotificationPrefs hydrates the signal from GET (the rejoin-hydration path)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ notification_prefs: MUTED_MENTIONS }), { status: 200 }),
+    );
+
+    const prefs = await refreshNotificationPrefs();
+
+    expect(prefs).toEqual(MUTED_MENTIONS);
+    expect(notificationPrefs()).toEqual(MUTED_MENTIONS);
+  });
+
+  it("refreshNotificationPrefs sends the bearer to the prefs endpoint", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ notification_prefs: DEFAULT_NOTIFICATION_PREFS }), {
+        status: 200,
+      }),
+    );
+
+    await refreshNotificationPrefs();
+
+    const [url, init] = spy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/me/settings/notification-prefs");
+    expect((init.headers as Record<string, string>).authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it("a failed GET leaves the last known prefs in place rather than blanking them", async () => {
+    mirrorNotificationPrefs(MUTED_MENTIONS);
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response("nope", { status: 500 }));
+
+    await expect(refreshNotificationPrefs()).rejects.toBeDefined();
+
+    // The user-topic hydrate swallows this rejection into a console.warn; the
+    // signal must not have been clobbered on the way out.
+    expect(notificationPrefs()).toEqual(MUTED_MENTIONS);
+  });
+
+  it("refreshNotificationPrefs without a session throws instead of fetching unauthenticated", async () => {
+    setToken(null);
+    const spy = vi.spyOn(globalThis, "fetch");
+
+    await expect(refreshNotificationPrefs()).rejects.toThrow("no session");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("mirrorNotificationPrefs adopts a server response so a settings toggle takes effect at once", () => {
+    mirrorNotificationPrefs(MUTED_MENTIONS);
+    expect(notificationPrefs()).toEqual(MUTED_MENTIONS);
+  });
+});

--- a/cicchetto/src/__tests__/notificationPrefs.test.ts
+++ b/cicchetto/src/__tests__/notificationPrefs.test.ts
@@ -41,12 +41,20 @@ afterEach(() => {
 });
 
 describe("notificationPrefs store — #868", () => {
-  it("starts at the server defaults, so an un-hydrated client is not silently muted", () => {
-    expect(notificationPrefs()).toEqual(DEFAULT_NOTIFICATION_PREFS);
+  it("starts at the server defaults, so an un-hydrated client is not silently muted", async () => {
+    // A FRESH module instance, not the file-scope one: `beforeEach` mirrors a
+    // known map into the shared signal, which would make this test assert the
+    // mirror rather than the initial value. Mutating the store's initial value
+    // reddened nothing until this was re-imported per-test — the assertion was
+    // covering the line without constraining it.
+    vi.resetModules();
+    const fresh = await import("../lib/notificationPrefs");
+
+    expect(fresh.notificationPrefs()).toEqual(DEFAULT_NOTIFICATION_PREFS);
     // Pinned explicitly: these two are what make the un-hydrated state
     // deliver rather than swallow.
-    expect(notificationPrefs().channel_mentions).toBe(true);
-    expect(notificationPrefs().private_messages_all).toBe(true);
+    expect(fresh.notificationPrefs().channel_mentions).toBe(true);
+    expect(fresh.notificationPrefs().private_messages_all).toBe(true);
   });
 
   it("refreshNotificationPrefs hydrates the signal from GET (the rejoin-hydration path)", async () => {

--- a/cicchetto/src/__tests__/subscribe.test.ts
+++ b/cicchetto/src/__tests__/subscribe.test.ts
@@ -1,6 +1,7 @@
 import { createEffect, createRoot, createSignal, on } from "solid-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { channelKey } from "../lib/channelKey";
+import { DEFAULT_NOTIFICATION_PREFS, type NotificationPrefs } from "../lib/userSettings";
 
 // Boundary: mock REST (`lib/api`) + the socket helpers (`lib/socket`).
 // `subscribe.ts` is a side-effect module — the createRoot installs
@@ -36,6 +37,11 @@ vi.mock("../lib/api", () => ({
   // routeMessage path); the mock needs to expose the classifier.
   isContentKind: (k: string) => k === "privmsg" || k === "notice" || k === "action",
   isPresenceKind: (k: string) => !(k === "privmsg" || k === "notice" || k === "action"),
+  // #868 — subscribe.ts now decides the beep through `pushTriggers.shouldNotify`,
+  // which reads the notify-worthy kind set from here. Same hand-mirrored
+  // convention as the two classifiers above: the notify subset is
+  // privmsg|action (NOTICE is unread but never notify-worthy).
+  NOTIFY_KINDS: new Set(["privmsg", "action"]),
   displayNick: (me: { kind: "user" | "visitor"; name?: string; nick?: string }) =>
     me.kind === "user" ? (me.name ?? "") : (me.nick ?? ""),
   // Mirror of production `ownNickForNetwork` — single source for
@@ -130,12 +136,33 @@ vi.mock("../lib/beep", () => ({
   playBeep: vi.fn(),
 }));
 
+// #868 — the optimistic `document.title` bump is the other half of the live
+// notify decision, so it is asserted alongside the beep. `setBadge` is stubbed
+// too: `networks.ts` seeds it from the `/me` envelope on every load here.
+vi.mock("../lib/badge", () => ({
+  incrementBadge: vi.fn(),
+  setBadge: vi.fn(),
+}));
+
 // #370 — the keyword-highlight list, signal-backed so a test can stage
 // custom /hilight patterns. Default empty so the own-nick beep tests are
 // unaffected. The live beep now matches own nick ∪ these patterns (one path).
 const [highlightPatternsSig, setHighlightPatternsForTest] = createSignal<string[]>([]);
 vi.mock("../lib/highlightList", () => ({
   highlightPatterns: () => highlightPatternsSig(),
+}));
+
+// #868 — the live notify path reads the subject's server notification prefs.
+// Signal-backed so a test can stage a pref and assert the beep obeys it. The
+// default is the PRODUCTION default (`channel_mentions: true`,
+// `private_messages_all: true`), so every pre-#868 beep test keeps its meaning.
+const [notificationPrefsSig, setNotificationPrefsForTest] = createSignal<NotificationPrefs>(
+  DEFAULT_NOTIFICATION_PREFS,
+);
+vi.mock("../lib/notificationPrefs", () => ({
+  notificationPrefs: () => notificationPrefsSig(),
+  refreshNotificationPrefs: vi.fn().mockResolvedValue(undefined),
+  mirrorNotificationPrefs: vi.fn(),
 }));
 
 vi.mock("../lib/queryWindows", () => ({
@@ -170,6 +197,7 @@ beforeEach(async () => {
   localStorage.clear();
   vi.clearAllMocks();
   setHighlightPatternsForTest([]);
+  setNotificationPrefsForTest(DEFAULT_NOTIFICATION_PREFS);
   // Reset H2 per-topic registry so cross-test handler counts don't
   // leak (each test that opts in via usePerTopicChannels gets a fresh
   // pool; tests that don't opt in fall back to the singleton mockChannel).
@@ -3218,8 +3246,15 @@ describe("subscribe - not-joined pre-subscribe loop (CP15 B5 fix + #78)", () => 
       // mirror the top-level vi.mock — selection.ts's badge memo now
       // imports `isContentKind` from api.ts; without it the doMock
       // bleeds a missing-export into UX-6-L beep tests downstream.
+      //
+      // #868 — the same bleed, second instance: this `doMock` outlives its
+      // own test (a `vi.doMock` registration survives `vi.resetModules`), so
+      // every api export any DOWNSTREAM test needs has to be mirrored here.
+      // `NOTIFY_KINDS` is now one of them, because subscribe.ts decides the
+      // beep through `pushTriggers.shouldNotify`.
       isContentKind: (k: string) => k === "privmsg" || k === "notice" || k === "action",
       isPresenceKind: (k: string) => !(k === "privmsg" || k === "notice" || k === "action"),
+      NOTIFY_KINDS: new Set(["privmsg", "action"]),
       displayNick: (me: { kind: string; name?: string }) => me.name ?? "",
       ownNickForNetwork: (
         net: { slug: string; nick?: string },
@@ -3630,6 +3665,239 @@ describe("subscribe — UX-6-L foreground beep wiring", () => {
         kind: "privmsg",
         sender: "alice",
         body: "talking to myself",
+        meta: {},
+      },
+    });
+
+    expect(beep.playBeep).not.toHaveBeenCalled();
+  });
+});
+
+// #868 — the live path decides through the SHARED predicate.
+//
+// Before this issue, `subscribe.ts` called `matchesWatchlist` directly and
+// read no preference at all, while the OS push was decided server-side by
+// `Grappa.Push.Triggers.should_notify?/4`. One preference, two answers. Each
+// test below pins a case where the two surfaces used to disagree.
+describe("subscribe — #868 the beep obeys the notification prefs", () => {
+  const asAlice = async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    const beep = await import("../lib/beep");
+    const badge = await import("../lib/badge");
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalled();
+    });
+    store.setSelectedChannel({
+      networkSlug: "freenode",
+      channelName: "#cicchetto",
+      kind: "channel",
+    });
+    return { beep, badge };
+  };
+
+  it("channel_mentions:false silences a mention that the server would not push", async () => {
+    setNotificationPrefsForTest({ ...DEFAULT_NOTIFICATION_PREFS, channel_mentions: false });
+    const { beep, badge } = await asAlice();
+
+    fireMessageEvent("#grappa", { id: 800, kind: "privmsg", body: "alice ping" });
+
+    expect(beep.playBeep).not.toHaveBeenCalled();
+    expect(badge.incrementBadge).not.toHaveBeenCalled();
+  });
+
+  it("channel_messages_all:true beeps on a message with no mention at all", async () => {
+    setNotificationPrefsForTest({ ...DEFAULT_NOTIFICATION_PREFS, channel_messages_all: true });
+    const { beep } = await asAlice();
+
+    fireMessageEvent("#grappa", { id: 801, kind: "privmsg", body: "no mention here" });
+
+    expect(beep.playBeep).toHaveBeenCalledTimes(1);
+  });
+
+  it("channel_messages_only listing the channel beeps without a mention", async () => {
+    setNotificationPrefsForTest({
+      ...DEFAULT_NOTIFICATION_PREFS,
+      channel_messages_only: ["#grappa"],
+    });
+    const { beep } = await asAlice();
+
+    fireMessageEvent("#grappa", { id: 802, kind: "privmsg", body: "no mention here" });
+
+    expect(beep.playBeep).toHaveBeenCalledTimes(1);
+  });
+
+  it("an ACTION mentioning own nick beeps — the server pushes it, so the title must move too", async () => {
+    const { beep, badge } = await asAlice();
+
+    fireMessageEvent("#grappa", { id: 803, kind: "action", body: "waves at alice" });
+
+    expect(beep.playBeep).toHaveBeenCalledTimes(1);
+    expect(badge.incrementBadge).toHaveBeenCalledTimes(1);
+  });
+
+  it("an inbound DM mentioning own nick beeps ONCE, not once per decision site", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    const beep = await import("../lib/beep");
+    const socket = await import("../lib/socket");
+    await loadStores();
+    await vi.waitFor(() => {
+      const topics = vi.mocked(socket.joinChannel).mock.calls.map((c) => `${c[1]}/${c[2]}`);
+      expect(topics).toContain("freenode/alice");
+    });
+
+    const joinCalls = vi.mocked(socket.joinChannel).mock.calls;
+    const dmJoinIdx = joinCalls.findIndex((c) => c[1] === "freenode" && c[2] === "alice");
+    const eventCalls = mockChannel.on.mock.calls.filter((c) => c[0] === "event");
+    const dmHandler = eventCalls[dmJoinIdx]?.[1] as (p: unknown) => void;
+    // The DM listener used to beep at its own call site AND again inside
+    // routeMessage's mention path, so a DM whose body happened to contain the
+    // operator's nick fired two oscillators back to back. The existing
+    // DM-beep test hid it by using a body with no mention ("hey").
+    dmHandler({
+      kind: "message",
+      message: {
+        id: 804,
+        network: "freenode",
+        channel: "alice",
+        server_time: 0,
+        kind: "privmsg",
+        sender: "bob",
+        body: "alice ping",
+        meta: {},
+      },
+    });
+
+    expect(beep.playBeep).toHaveBeenCalledTimes(1);
+  });
+
+  it("private_messages_all:false silences an inbound DM the server would not push", async () => {
+    setNotificationPrefsForTest({
+      ...DEFAULT_NOTIFICATION_PREFS,
+      private_messages_all: false,
+      channel_mentions: true,
+    });
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    const beep = await import("../lib/beep");
+    const socket = await import("../lib/socket");
+    await loadStores();
+    await vi.waitFor(() => {
+      const topics = vi.mocked(socket.joinChannel).mock.calls.map((c) => `${c[1]}/${c[2]}`);
+      expect(topics).toContain("freenode/alice");
+    });
+
+    const joinCalls = vi.mocked(socket.joinChannel).mock.calls;
+    const dmJoinIdx = joinCalls.findIndex((c) => c[1] === "freenode" && c[2] === "alice");
+    const eventCalls = mockChannel.on.mock.calls.filter((c) => c[0] === "event");
+    const dmHandler = eventCalls[dmJoinIdx]?.[1] as (p: unknown) => void;
+    // Body carries the own nick on purpose: the DM branch owns this row, so
+    // `channel_mentions` must NOT rescue it. That is the server's `dm?/2`
+    // routing, and the client now agrees.
+    dmHandler({
+      kind: "message",
+      message: {
+        id: 805,
+        network: "freenode",
+        channel: "alice",
+        server_time: 0,
+        kind: "privmsg",
+        sender: "bob",
+        body: "alice ping",
+        meta: {},
+      },
+    });
+
+    expect(beep.playBeep).not.toHaveBeenCalled();
+  });
+
+  it("private_messages_only listing the sender beeps when private_messages_all is off", async () => {
+    setNotificationPrefsForTest({
+      ...DEFAULT_NOTIFICATION_PREFS,
+      private_messages_all: false,
+      private_messages_only: ["bob"],
+    });
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    const beep = await import("../lib/beep");
+    const socket = await import("../lib/socket");
+    await loadStores();
+    await vi.waitFor(() => {
+      const topics = vi.mocked(socket.joinChannel).mock.calls.map((c) => `${c[1]}/${c[2]}`);
+      expect(topics).toContain("freenode/alice");
+    });
+
+    const joinCalls = vi.mocked(socket.joinChannel).mock.calls;
+    const dmJoinIdx = joinCalls.findIndex((c) => c[1] === "freenode" && c[2] === "alice");
+    const eventCalls = mockChannel.on.mock.calls.filter((c) => c[0] === "event");
+    const dmHandler = eventCalls[dmJoinIdx]?.[1] as (p: unknown) => void;
+    dmHandler({
+      kind: "message",
+      message: {
+        id: 806,
+        network: "freenode",
+        channel: "alice",
+        server_time: 0,
+        kind: "privmsg",
+        sender: "bob",
+        body: "no mention here",
+        meta: {},
+      },
+    });
+
+    expect(beep.playBeep).toHaveBeenCalledTimes(1);
+  });
+
+  it("a peer NOTICE does not beep — NOTICE is unread-worthy but never notify-worthy", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    const beep = await import("../lib/beep");
+    const socket = await import("../lib/socket");
+    await loadStores();
+    await vi.waitFor(() => {
+      const topics = vi.mocked(socket.joinChannel).mock.calls.map((c) => `${c[1]}/${c[2]}`);
+      expect(topics).toContain("freenode/alice");
+    });
+
+    const joinCalls = vi.mocked(socket.joinChannel).mock.calls;
+    const dmJoinIdx = joinCalls.findIndex((c) => c[1] === "freenode" && c[2] === "alice");
+    const eventCalls = mockChannel.on.mock.calls.filter((c) => c[0] === "event");
+    const dmHandler = eventCalls[dmJoinIdx]?.[1] as (p: unknown) => void;
+    // Deliberate, user-visible subtraction (UX-6-L used to beep here). The
+    // server never pushes a NOTICE, so beeping made the desktop and the phone
+    // disagree on the same row. The window still takes the unread.
+    dmHandler({
+      kind: "message",
+      message: {
+        id: 807,
+        network: "freenode",
+        channel: "alice",
+        server_time: 0,
+        kind: "notice",
+        sender: "bob",
+        body: "heads up",
         meta: {},
       },
     });

--- a/cicchetto/src/lib/notificationPrefs.ts
+++ b/cicchetto/src/lib/notificationPrefs.ts
@@ -1,0 +1,67 @@
+// #868 — cic-side mirror of the subject's server notification preferences.
+//
+// Why this exists. The live notify path (`subscribe.ts`: the in-app beep and
+// the optimistic `document.title` bump) used to decide on a bare
+// `matchesWatchlist` call, reading no preference at all — so `channel_mentions:
+// false` still beeped and `private_messages_all: false` still beeped, while the
+// OS push (decided server-side in `Grappa.Push.Triggers`) correctly stayed
+// silent. One preference, two answers. `pushTriggers.shouldNotify` was the
+// mirror of the server predicate but had NO live caller, which is exactly what
+// DESIGN_NOTES flagged on 2026-06-21: "cic has no global notification-prefs
+// signal to feed the full shouldNotify at message-arrival". This is that
+// signal.
+//
+// Same shape as `highlightList.ts` / `aliasList.ts`: the prefs live in server
+// user_settings with NO broadcast, so the signal only ever holds what the last
+// server round-trip returned and every writer feeds it the AUTHORITATIVE
+// response, never a locally-composed value (CLAUDE.md window-state invariant
+// family — cic never originates state).
+//
+// Identity-scoped: with no broadcast to self-heal it, a logout/account-switch
+// would otherwise leave the previous account's prefs deciding the new
+// account's beeps. The reset returns the signal to
+// `DEFAULT_NOTIFICATION_PREFS`, which is byte-identical to the server's
+// `UserSettings.default_notification_prefs/0` — so an un-hydrated client
+// behaves like a subject who never touched their settings, rather than like a
+// subject who muted everything.
+
+import { createSignal } from "solid-js";
+import { token } from "./auth";
+import { identityScopedStore } from "./identityScopedStore";
+import {
+  DEFAULT_NOTIFICATION_PREFS,
+  getNotificationPrefs,
+  type NotificationPrefs,
+} from "./userSettings";
+
+const exports_ = identityScopedStore((onIdentityChange) => {
+  const [notificationPrefs, setNotificationPrefs] = createSignal<NotificationPrefs>(
+    DEFAULT_NOTIFICATION_PREFS,
+  );
+
+  // Logout / account switch — back to the server's own defaults.
+  onIdentityChange(() => setNotificationPrefs(DEFAULT_NOTIFICATION_PREFS));
+
+  // Adopt a prefs map the SERVER returned (a GET body or a PUT's normalized
+  // echo). Not a setter for client-composed values: the settings drawer owns
+  // the form state and hands over only what came back over the wire.
+  const mirrorNotificationPrefs = (prefs: NotificationPrefs): void => {
+    setNotificationPrefs(prefs);
+  };
+
+  // Fetch the current prefs and mirror them. Called on every user-topic
+  // (re)join alongside the highlight-list and alias hydrates.
+  const refreshNotificationPrefs = async (): Promise<NotificationPrefs> => {
+    const t = token();
+    if (t === null) throw new Error("no session");
+    const prefs = await getNotificationPrefs(t);
+    setNotificationPrefs(prefs);
+    return prefs;
+  };
+
+  return { notificationPrefs, mirrorNotificationPrefs, refreshNotificationPrefs };
+});
+
+export const notificationPrefs = exports_.notificationPrefs;
+export const mirrorNotificationPrefs = exports_.mirrorNotificationPrefs;
+export const refreshNotificationPrefs = exports_.refreshNotificationPrefs;

--- a/cicchetto/src/lib/pushTriggers.ts
+++ b/cicchetto/src/lib/pushTriggers.ts
@@ -25,7 +25,7 @@
 import { type MessageKind, NOTIFY_KINDS } from "./api";
 import { canonicalChannel } from "./channelKey";
 import { matchesWatchlist } from "./mentionMatch";
-import { asciiFold } from "./nickEquals";
+import { asciiFold, nickEquals } from "./nickEquals";
 import type { NotificationPrefs } from "./userSettings";
 
 // Minimal structural shape the predicate needs — a subset of the wire
@@ -46,10 +46,11 @@ export type ShouldNotifyMessage = {
  *   1. kind gate — only the shared `NOTIFY_KINDS` SSOT (privmsg|action,
  *      the "notify" subset of api's CONTENT_KINDS, #395) → everything else
  *      false. NOTICE (services chatter) counts as unread but never notifies.
- *   2. DM (channel === ownNick): private_messages_all OR
+ *   2. own row (#532 C) — a row this operator authored never notifies.
+ *   3. DM (channel folds to ownNick): private_messages_all OR
  *      asciiFold(sender) in private_messages_only (mirrors the
- *      server's `canonical_nick(sender) in ...`).
- *   3. channel: channel_messages_all OR canonicalChannel(channel) in
+ *      server's `canonical_target(sender) in ...`).
+ *   4. channel: channel_messages_all OR canonicalChannel(channel) in
  *      channel_messages_only OR (channel_mentions AND mention).
  */
 export function shouldNotify(
@@ -64,7 +65,25 @@ export function shouldNotify(
   // convention as `wireNarrow.ts`.
   if (!NOTIFY_KINDS.has(message.kind as MessageKind)) return false;
 
-  if (message.channel === ownNick) {
+  // #532 C, #868 — "is this row mine?" decided by sender IDENTITY, and asked
+  // BEFORE the window-shape test below. An OUTBOUND DM is persisted with
+  // `channel = peer` (only an INBOUND one carries `channel = own_nick`), so
+  // the shape test misroutes it to the channel branch, where the operator's
+  // own highlight patterns run over the operator's own body — self-notifying
+  // on every outgoing message that happens to contain their nick. The server
+  // has had this step since #532 C (`triggers.ex` `own_row?/2`); this port
+  // did not, and the shared fixture had no row that could see the gap.
+  if (nickEquals(message.sender, ownNick)) return false;
+
+  // Fold BOTH sides, mirroring the server's `dm?/2`. The `channel` KEY is
+  // folded at the persist boundary (`Message.canonicalize_channel/1`, #537)
+  // while `ownNick` is the RAW live nick off `net.nick` — so a raw `===`
+  // silently fails for any operator whose nick carries an uppercase letter,
+  // routing their inbound DMs into the channel branch. `canonicalChannel` is
+  // the client mirror of `Identifier.canonical_target/1` and folds a
+  // nick-shaped identifier exactly as it folds a channel (a sigil sits
+  // outside `A-Z`), which is why the same function serves both sides here.
+  if (canonicalChannel(message.channel) === canonicalChannel(ownNick)) {
     return dmMatch(message, prefs);
   }
   return channelMatch(message, prefs, ownNick, patterns);
@@ -89,8 +108,9 @@ function channelMatch(
   patterns: string[],
 ): boolean {
   return (
-    // canonicalChannel (sigil-gated ASCII fold), NOT a bare toLowerCase,
-    // mirroring the server's `Identifier.canonical_channel(channel) in
+    // canonicalChannel (the plain ASCII fold — #537 retired the sigil gate
+    // on both ports), NOT a bare toLowerCase, mirroring the server's
+    // `Identifier.canonical_target(channel) in
     // channel_messages_only` — the whitelist is stored channel-folded
     // (CASEMAPPING=ascii, A-Z only; #525). bahamut folds `A-Z` ONLY, so
     // `#Chan`/`#chan` are ONE channel but `#chan[1]` and `#chan{1}` are

--- a/cicchetto/src/lib/shouldNotifyTruthTable.json
+++ b/cicchetto/src/lib/shouldNotifyTruthTable.json
@@ -290,5 +290,151 @@
     },
     "patterns": [],
     "expected": true
+  },
+  {
+    "name": "own row (#532 C): own channel message mentioning own nick never notifies",
+    "message": {
+      "kind": "privmsg",
+      "channel": "#sniffo",
+      "sender": "vjt",
+      "body": "vjt: note to self"
+    },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": true,
+      "private_messages_all": false,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
+    "name": "own row (#532 C): beats channel_messages_all — the identity gate runs FIRST",
+    "message": { "kind": "privmsg", "channel": "#sniffo", "sender": "vjt", "body": "hello all" },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": true,
+      "channel_messages_only": [],
+      "channel_mentions": false,
+      "private_messages_all": false,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
+    "name": "own row (#532 C): OUTBOUND DM is channel=peer, so only sender-identity catches it",
+    "message": {
+      "kind": "privmsg",
+      "channel": "alice",
+      "sender": "vjt",
+      "body": "vjt will be late"
+    },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": true,
+      "private_messages_all": false,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
+    "name": "own row (#532 C): self-msg (channel=own_nick, sender=own_nick) beats private_messages_all",
+    "message": { "kind": "privmsg", "channel": "vjt", "sender": "vjt", "body": "reminder" },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": false,
+      "private_messages_all": true,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
+    "name": "own row (#532 C): the sender-identity compare FOLDS case (VJT is still me)",
+    "message": {
+      "kind": "privmsg",
+      "channel": "#sniffo",
+      "sender": "VJT",
+      "body": "vjt: note to self"
+    },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": true,
+      "private_messages_all": false,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
+    "name": "own row (#532 C): a DIFFERENT sender is not me — the gate must not swallow real traffic",
+    "message": {
+      "kind": "privmsg",
+      "channel": "#sniffo",
+      "sender": "vjtx",
+      "body": "vjt: ping"
+    },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": true,
+      "private_messages_all": false,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": true
+  },
+  {
+    "name": "DM shape (#537): channel is stored FOLDED, so a mixed-case own_nick still routes to the DM branch",
+    "message": { "kind": "privmsg", "channel": "vjt", "sender": "alice", "body": "hello" },
+    "own_nick": "VJT",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": false,
+      "private_messages_all": true,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": true
+  },
+  {
+    "name": "DM shape (#537): a mis-routed DM would notify via channel_mentions the user never asked for",
+    "message": { "kind": "privmsg", "channel": "vjt", "sender": "alice", "body": "VJT: yo" },
+    "own_nick": "VJT",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": true,
+      "private_messages_all": false,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
+    "name": "DM shape (#537): a real channel is NOT a DM even when own_nick folds into its name",
+    "message": { "kind": "privmsg", "channel": "#vjt", "sender": "alice", "body": "hello" },
+    "own_nick": "VJT",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": false,
+      "private_messages_all": true,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": false
   }
 ]

--- a/cicchetto/src/lib/shouldNotifyTruthTable.json
+++ b/cicchetto/src/lib/shouldNotifyTruthTable.json
@@ -424,6 +424,34 @@
     "expected": false
   },
   {
+    "name": "channel fold is ASCII, not Unicode: #CAFÉ does not hit a #café whitelist entry (#525)",
+    "message": { "kind": "privmsg", "channel": "#CAFÉ", "sender": "alice", "body": "hello" },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": ["#café"],
+      "channel_mentions": false,
+      "private_messages_all": false,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
+    "name": "sender fold is ASCII, not Unicode: CAFÉ does not hit a café whitelist entry (#525)",
+    "message": { "kind": "privmsg", "channel": "vjt", "sender": "CAFÉ", "body": "hello" },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": false,
+      "private_messages_all": false,
+      "private_messages_only": ["café"]
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
     "name": "DM shape (#537): a real channel is NOT a DM even when own_nick folds into its name",
     "message": { "kind": "privmsg", "channel": "#vjt", "sender": "alice", "body": "hello" },
     "own_nick": "VJT",

--- a/cicchetto/src/lib/subscribe.ts
+++ b/cicchetto/src/lib/subscribe.ts
@@ -10,7 +10,6 @@ import { isDocumentVisible } from "./documentVisibility";
 import { highlightPatterns } from "./highlightList";
 import { seedIsupport } from "./isupport";
 import { applyPresenceEvent, seedMembers } from "./members";
-import { matchesWatchlist } from "./mentionMatch";
 import { setServerMention } from "./mentions";
 import { moduleRoot } from "./moduleRoot";
 import {
@@ -22,9 +21,11 @@ import {
   user,
 } from "./networks";
 import { nickEquals } from "./nickEquals";
+import { notificationPrefs } from "./notificationPrefs";
 import { isOperatorActionEcho } from "./operatorActionEcho";
 import { isOwnPresenceEvent } from "./ownPresenceEvent";
 import { resolvePing } from "./pingCorrelation";
+import { shouldNotify } from "./pushTriggers";
 import { setEnsureQueryTopicJoined } from "./queryTopicJoin";
 import { canonicalQueryNick, queryWindowsByNetwork } from "./queryWindows";
 import { renameRailWhois } from "./railWhois";
@@ -286,58 +287,48 @@ moduleRoot(() => {
     // sidebar badge gate and the in-pane unread-marker stay aligned.
     if (isOperatorActionEcho(message)) return;
 
-    // Live mention alert (beep + optimistic PWA badge) — PRIVMSGs whose body
-    // matches the operator's watchlist (own nick ∪ /hilight keywords), on a
-    // non-effectively-focused window, not from own nick.
+    // Live notify alert (beep + optimistic PWA badge), for every window shape
+    // this function routes — channels, query windows, and the DM listener.
     //
-    // #267 — the mention COUNT is no longer bumped here. It is
-    // server-authoritative (`mentions.ts`, seeded by /me + join_reply and
-    // pushed on every new message + cursor advance via the `window_counts`
-    // event), so the client-side count regex is gone — that regex never
-    // rebuilt on reconnect / across tabs, the bug #267 fixes. What stays
-    // is the LIVE alert: `matchesWatchlist` fires the in-app beep + the
-    // optimistic desktop-title badge bump the instant a match lands on an
-    // unfocused window, before the server's window_counts push round-trips.
-    // These are transient live cues, not the count of record.
+    // #267 — the mention COUNT is not bumped here. It is server-authoritative
+    // (`mentions.ts`, seeded by /me + join_reply and pushed on every new
+    // message + cursor advance via the `window_counts` event). What stays is
+    // the LIVE alert: the in-app beep + the optimistic desktop-title bump the
+    // instant a notify-worthy row lands on an unfocused window, before the
+    // server's window_counts push round-trips. Transient live cues, not the
+    // count of record.
     //
-    // #370 — the SAME `matchesWatchlist` predicate the in-message visual
-    // highlight uses (own nick = just another entry in the watchlist source,
-    // NOT a special case). One notify path: a custom keyword beeps + bumps
-    // exactly like an own-nick mention, matching the server SSOT
-    // `Grappa.Mentions.mentioned?/3` that already drives OS push + the count.
+    // #868 — the DECISION is `pushTriggers.shouldNotify`, the mirror of the
+    // server's `Grappa.Push.Triggers.should_notify?/4`, and no longer a bare
+    // `matchesWatchlist` call. It used to be: this path read NO preference at
+    // all, so `channel_mentions: false` still beeped, `private_messages_all:
+    // false` still beeped, an `action` the server DID push never moved the
+    // title, and `channel_messages_all: true` never beeped. The push and the
+    // title answered the same question differently. Routing both through one
+    // predicate is what makes a preference mean one thing.
+    //
+    // The own-echo and kind gates now live INSIDE the predicate (its `own_row`
+    // step and `NOTIFY_KINDS`), so they are not repeated here — repeating them
+    // is how the two ports drifted in the first place. `ownNick` is non-null
+    // on every handler that carries content (the sole `ownNick = null` handler
+    // is $server); the guard makes that explicit rather than relying on
+    // `nickEquals` returning false for a null side. `u` keeps a not-yet-loaded
+    // /me from deciding.
+    //
+    // Single decision site: the DM listener used to beep at its own call site
+    // as well, so a DM whose body contained the operator's nick fired twice.
     //
     // UX-6-L (2026-05-20): the beep complements the SW's
     // visibility-anywhere OS-notification suppression (`lib/pushDedup.ts`).
+    const u = untrack(user);
     if (
-      message.kind === "privmsg" &&
+      u &&
+      ownNick !== null &&
       !effectivelyFocused(slug, displayName) &&
-      !nickEquals(message.sender, ownNick)
+      shouldNotify(message, ownNick, notificationPrefs(), highlightPatterns())
     ) {
-      const u = untrack(user);
-      // #211 phase 7 — match on the PER-NETWORK own nick (`ownNick`, already
-      // threaded into this handler), NOT the retired identity-wide
-      // `displayNick(u)` (a visitor has no single nick now). Guard on `u`
-      // so a not-yet-loaded /me still skips.
-      //
-      // #370 — the own-echo suppression above (`!nickEquals(sender, ownNick)`)
-      // is only sound while `ownNick` is non-null here (nickEquals returns
-      // false on a null side). That holds on every path that reaches this
-      // PRIVMSG beep: channel/DM handlers install with `ownNick = net.nick`
-      // (a required non-null field) only once the user→networks→channels
-      // resource chain has resolved, and the sole `ownNick=null` handler
-      // ($server) carries no PRIVMSGs. If channels ever become joinable
-      // before /me resolves, or `net.nick` is relaxed to nullable, restore an
-      // explicit own-nick guard here.
-      if (u && matchesWatchlist(message.body, ownNick, highlightPatterns())) {
-        playBeep();
-        // Optimistic foreground badge bump so the desktop `document.title`
-        // moves the instant a mention lands on an unfocused window, before
-        // the server sync. The per-channel mention COUNT + the global badge
-        // are both server-authoritative (`window_counts` push +
-        // `read_cursor_set` badge_count); this only nudges the title early
-        // and self-heals on the next sync.
-        incrementBadge();
-      }
+      playBeep();
+      incrementBadge();
     }
   };
 
@@ -690,19 +681,16 @@ moduleRoot(() => {
             // this is the live-WS mirror of that single window key.
             const peer = canonicalQueryNick(networkId, message.sender);
             const senderKey = channelKey(slug, peer);
-            // UX-6-L (2026-05-20) — inbound DM is operator-targeted by
-            // definition; beep at the call site so routeMessage's
-            // signature stays narrow (DM-specific audio policy is a
-            // DM-listener concern, not a shared-routing concern).
-            // `effectivelyFocused` is the single-source focus predicate
-            // (see helper at top of createRoot); anchor on the peer's
-            // canonical window name.
-            //
-            // sender !== ownNick gate: own self-msg echoes ride this
-            // topic too; suppress the audible alert for own typing.
-            if (!nickEquals(message.sender, ownNick) && !effectivelyFocused(slug, peer)) {
-              playBeep();
-            }
+            // #868 — no beep at this call site any more. It used to live here
+            // "so routeMessage's signature stays narrow", but routeMessage
+            // already ran its own mention-path beep over the same row, so a DM
+            // mentioning the operator's nick beeped twice. Worse, this site
+            // decided "inbound DM is operator-targeted by definition" and so
+            // ignored `private_messages_all` / `private_messages_only`
+            // entirely, while the server's push obeyed them. routeMessage is
+            // now the single decision site and it asks the shared predicate,
+            // which routes this row into the DM branch by folded window shape
+            // exactly as `Grappa.Push.Triggers.dm?/2` does.
             routeMessage(slug, senderKey, peer, message, ownNick);
             return;
           }
@@ -733,11 +721,16 @@ moduleRoot(() => {
             // #372: canonical peer re-key — see the PRIVMSG/ACTION arm.
             const peer = canonicalQueryNick(networkId, message.sender);
             const senderKey = channelKey(slug, peer);
-            // UX-6-L (2026-05-20): peer NOTICEs are inbound DM-shaped
-            // traffic — same beep policy as the PRIVMSG/ACTION arm.
-            // The sender !== ownNick check above already gates this
-            // branch.
-            if (!effectivelyFocused(slug, peer)) playBeep();
+            // #868 — a peer NOTICE no longer beeps. UX-6-L gave it the same
+            // audio policy as a PRIVMSG on the grounds that it is inbound
+            // DM-shaped traffic, but NOTICE is deliberately outside
+            // `notify_kinds` on the server (services chatter is the dominant
+            // inbound NOTICE shape), so the phone stayed silent while the
+            // desktop beeped on the very same row. This is the one
+            // user-visible subtraction in #868: the window still takes the
+            // unread, only the tone is gone. If peer NOTICEs should be
+            // audible, that is a preference, not a hard-coded exception —
+            // which is #866's territory, not this refactor's.
             routeMessage(slug, senderKey, peer, message, ownNick);
             return;
           }

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -32,6 +32,7 @@ import { moduleRoot } from "./moduleRoot";
 import { setNamesReply } from "./namesModal";
 import { mutateNetworkNick, refetchChannels, refetchNetworks } from "./networks";
 import { nickEquals } from "./nickEquals";
+import { refreshNotificationPrefs } from "./notificationPrefs";
 import {
   applyPresenceChange,
   applyPresenceError,
@@ -1033,6 +1034,19 @@ moduleRoot(() => {
       // of a server-synced, cross-device alias layer.
       void refreshAliases().catch((err) =>
         console.warn("[userTopic] alias-list hydrate failed", err),
+      );
+      // #868 — hydrate the notification prefs on every user-topic (re)join,
+      // for the SAME reason as the two above: they live in server
+      // user_settings with NO broadcast, and the live notify path
+      // (`subscribe.ts` → `shouldNotify`) now reads them to decide the in-app
+      // beep and the optimistic `document.title` bump. Without this the store
+      // sits on `DEFAULT_NOTIFICATION_PREFS` for the whole session and a
+      // subject who muted channel mentions would keep hearing them until they
+      // opened the settings drawer. The signal defaults to the SERVER's own
+      // defaults, so a failed hydrate degrades to "behaves like a subject who
+      // never configured anything" — never to silence.
+      void refreshNotificationPrefs().catch((err) =>
+        console.warn("[userTopic] notification-prefs hydrate failed", err),
       );
     });
     channel.on("event", (raw: unknown) => {


### PR DESCRIPTION
Prerequisite refactor for #866, per vjt's ruling on that issue's Q6/Q7
("fixa ovviamente e va bene issue separata fatta PRIMA. prima refactor" /
"ricabla"). Refs #868.

## The root

The client's notification predicate was not the code that decided anything.

`pushTriggers.shouldNotify` — the mirror of `Grappa.Push.Triggers.should_notify?/4`,
pinned by a shared truth-table fixture and two suites — had **no production
caller**. What actually beeped and moved `document.title` was `subscribe.ts`,
calling `matchesWatchlist` directly and reading **no preference at all**.

## 1. The two ports were not mirrors, and the fixture could not see it

The server has a branch the client did not: `own_row?` (#532 C), the
sender-identity gate that runs *before* the window-shape test. The client also
compared `message.channel === ownNick` **raw**, while the server folds both
sides — and `channel` is folded at the persist boundary (#537), so every
operator with an uppercase letter in their nick had inbound DMs routed into the
channel branch.

The 18 existing rows exercised the kind gate, the DM branch and the channel
branch, and nothing else. **Nine rows added; seven failed on the client and
passed on the server** before the fix. That asymmetry is the measurement.
Two of the nine are negative controls (a near-miss sender `vjtx`, `#vjt` as a
real channel) so a too-broad fix cannot buy itself green.

## 2. The fold was unguarded — found by mutation, not by reading

Swapping `canonical_target/1` → `String.downcase/1` (server) and
`asciiFold` → `toLowerCase()` (client) reddened **zero** rows. Every identifier
in the table was plain ASCII, where the two folds agree. The 2026-07-20
architecture review named this hole on the bracket axis; brackets survive
`toLowerCase` untouched, so those rows could never have caught it either. Two
non-ASCII rows (`#CAFÉ` vs `#café`, `CAFÉ` vs `café`) close it.

## 3. The live path now decides with the predicate

Measured behaviour changes:

| case | before | after |
|---|---|---|
| `channel_mentions: false` + mention | beeped, no push | silent, no push |
| `private_messages_all: false` + DM | beeped, no push | silent, no push |
| `channel_messages_all: true` | silent, push fired | beeps, push fired |
| `channel_messages_only` hit | silent, push fired | beeps, push fired |
| `action` mentioning own nick | no title bump, push fired | title bumps, push fired |
| DM whose body mentions own nick | **beeped twice** | beeps once |
| peer NOTICE DM | beeped, no push | silent, no push |

The double beep was not inferred: the assertion read *"expected 1 call, got 2"*.
The DM listener decided at its own call site and `routeMessage` decided again
over the same row; the pre-existing DM-beep test could not see it because its
body carried no mention.

`notificationPrefs.ts` is the signal DESIGN_NOTES asked for on 2026-06-21
("cic has no global notification-prefs signal to feed the full shouldNotify at
message-arrival"). Same shape as `highlightList.ts` / `aliasList.ts`: no
broadcast exists for these, so it hydrates on every user-topic (re)join and the
settings drawer feeds it the server's normalized echo. It defaults to the
**server's own defaults**, so a failed hydrate degrades to "unconfigured",
never to silence.

## One deliberate subtraction — flag for review

**A peer NOTICE no longer beeps.** UX-6-L gave it PRIVMSG's audio policy as
inbound DM-shaped traffic, but NOTICE sits outside `notify_kinds` server-side,
so the desktop was beeping on a row the phone was silent about. The window
still takes the unread. Making it audible again is a *preference*, not a
hard-coded exception — which is #866's territory. One line to reverse.

## Mutation evidence

Every branch deleted in turn; the rows that went red recorded.

* **client port, 10/10 branches guarded** — own_row 5 red, DM fold 2, kind gate 2,
  `channel_messages_all` 1, channel whitelist 2, mentions 4, `private_messages_all` 2,
  private whitelist 3, channel fold 1, sender fold 1
* **server port, 10/10 branches guarded** — identical row counts, so the fixture
  is a two-way gate, not a one-way assertion
* **re-wire, 7/7 behaviours guarded** — prefs-read 3 red, kind gate 1,
  single-decision-site 4, store default 1, hydrate 1, mirror 2, no-session guard 1

Two harness findings worth naming: the store's "starts at the server defaults"
test reddened **nothing** at first (`beforeEach` mirrored a map into the shared
signal, so it asserted the mirror, not the default — fixed by re-importing the
module per test), and one "0 red" reading was my own parser bug, caught by
re-running that mutation by hand rather than filing it.

## Scope

Decides none of #866's Q1–Q5 — data shape, snooze, mute semantics and UI stay
there. No wire change: no new field, no `protocol_version` bump. Server
untouched; the client moved to it.

## Verification

* `scripts/check.sh` exit 0 — Credo `5007 mods/funs, found no issues`;
  ExUnit `8 doctests, 50 properties, 5145 tests, 0 failures`; Dialyzer
  `Total errors: 0`; bats 295 ok. Tree clean before and after.
* `scripts/bun.sh run test` — 236 files, 4283 tests, 0 failures (baseline 235 / 4258).
* `tsc --noEmit` exit 0, `biome check src` exit 0 (48 pre-existing warnings, unchanged).
* Re-verified after rebasing onto current `main`.

**Not verified:** no e2e ran (no STACK lane), and no real browser — the beep
and `document.title` claims are jsdom-level. `playBeep` is a mock here; that a
tone is actually audible, and that the OS/PWA badge follows, are unproven by
this PR.