### PR TITLE
union(#863 #837 #868): gate the three cic branches together, not separately

### DIFF
--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -20,6 +20,7 @@ import { type FontSizeKey, getFontSize, setFontSize } from "./lib/fontSize";
 import { friendlyApiError } from "./lib/friendlyApiError";
 import { detach, quit, updateIdentity } from "./lib/lifecycle";
 import { isAdmin, networks, user } from "./lib/networks";
+import { mirrorNotificationPrefs } from "./lib/notificationPrefs";
 import { popOverlay, pushOverlay } from "./lib/overlayScrollLock";
 import {
   deletePushSubscription,
@@ -359,6 +360,10 @@ const SettingsDrawer: Component<Props> = (props) => {
     try {
       const loaded = await getNotificationPrefs(t);
       setPrefs(loaded);
+      // #868 — feed the live notify path the same authoritative map the form
+      // renders, so the beep obeys a pref the moment it is read, not on the
+      // next user-topic rejoin.
+      mirrorNotificationPrefs(loaded);
       setChannelsOnlyText(loaded.channel_messages_only.join(", "));
       setNicksOnlyText(loaded.private_messages_only.join(", "));
     } catch {
@@ -465,6 +470,9 @@ const SettingsDrawer: Component<Props> = (props) => {
     try {
       const saved = await putNotificationPrefs(t, next);
       setPrefs(saved);
+      // #868 — mirror the server's NORMALIZED echo (not `next`): the whitelists
+      // come back folded, which is the form the predicate compares against.
+      mirrorNotificationPrefs(saved);
     } catch (err) {
       const code = err instanceof Error ? err.message : "save_failed";
       setPrefsError(code);

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { channelKey } from "../lib/channelKey";
 import { LIST_WINDOW_NAME } from "../lib/windowKinds";
+import { BLANK_BODY_ERROR, serverAcceptsBody } from "./serverBodyPredicate";
 
 vi.mock("../lib/api", () => {
   class ApiError extends Error {
@@ -380,6 +381,53 @@ describe("compose submit — slash command dispatch", () => {
     // History records the WHOLE original paste (one recall entry), not per-line.
     compose.recallPrev(k);
     expect(compose.getDraft(k)).toBe("one\ntwo\nthree");
+  });
+
+  // #863 — a whitespace-only line must never abort the REST of a paste.
+  //
+  // This is the constraint that holds whichever way the fix goes, so it is the
+  // one worth pinning before the direction is chosen. If cic starts dropping
+  // whitespace-only lines, the line never reaches the door and the others go
+  // out. If the server starts accepting them, the line is delivered and the
+  // others go out. Only today's disagreement — cic sends it, the server calls
+  // it blank — stops the paste dead and mirrors the remainder back into the
+  // draft, which is what two users reported as a "scrambled" paste.
+  //
+  // The door here rejects exactly what the real server rejects
+  // (`serverBodyPredicate.ts`, which carries the derivation), with the real
+  // 422 envelope: `friendlyApiError` turns it into `Please fix: body: can't be
+  // blank.` — the string in the report.
+  //
+  // Deliberately NOT asserted: whether " " itself is sent. That is the product
+  // decision (#863's open question) and this test must survive either answer,
+  // so it asserts only that the CONTENT lines all got out and the composer was
+  // left empty.
+  it("#863 — a whitespace-only line does not abort the rest of the paste", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    const api = await import("../lib/api");
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+
+    vi.mocked(sb.sendMessage).mockImplementation(async (_slug, _target, body) => {
+      if (!serverAcceptsBody(body)) {
+        throw new api.ApiError(
+          BLANK_BODY_ERROR.status,
+          BLANK_BODY_ERROR.code,
+          BLANK_BODY_ERROR.info,
+        );
+      }
+      return undefined as never;
+    });
+
+    // A code paste with an indented blank line in the middle — the reported shape.
+    compose.setDraft(k, "def f():\n \n    return 1");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    const sent = vi.mocked(sb.sendMessage).mock.calls.map((c) => c[2]);
+    expect(sent.filter((line) => line.trim() !== "")).toEqual(["def f():", "    return 1"]);
+    expect(compose.getDraft(k)).toBe("");
+    expect(result).toEqual({ ok: true });
   });
 
   // #666 — the CORE bug. A fatal mid-paste error must leave ONLY the unsent

--- a/cicchetto/src/__tests__/customTheme.test.ts
+++ b/cicchetto/src/__tests__/customTheme.test.ts
@@ -1,13 +1,18 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { createRoot } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setToken } from "../lib/auth";
 import {
+  activePair,
   applyCustomTheme,
   COLOR_KEYS,
   getAppliedThemePayload,
+  mountCustomThemeSync,
   setThemePreviewMode,
   tokenToCssVars,
 } from "../lib/customTheme";
 import { EDITOR_BASE_KEYS, EDITOR_MODE_KEYS, EDITOR_NICK_KEYS } from "../lib/themeEditor";
 import type { TokenColors, TokenPayload } from "../lib/themesApi";
+import type { ThemesWireT } from "../lib/wireTypes";
 
 // #75 producer path — apply-engine seams the editor depends on.
 //
@@ -171,5 +176,122 @@ describe("editor color vocabulary vs the canonical key set", () => {
       ...EDITOR_NICK_KEYS,
     ]);
     expect(editorKeys).toEqual(new Set<string>(COLOR_KEYS));
+  });
+});
+
+// #837 — the mid-flight identity guard in `mountCustomThemeSync`, which had no
+// test at all: the effect captured `token()` at entry, awaited GET /me/theme,
+// and re-checked before applying. Removing that re-check broke nothing, so the
+// rule was free to be dropped by anyone tidying the module.
+//
+// What it holds: `applyResolvedPair` is not a read — it paints documentElement
+// AND writes the boot cache. A response that lands after a rotation therefore
+// puts subject A's theme on subject B's screen and persists it as B's
+// FOUC-free boot theme, so it survives the reload that would otherwise correct
+// it. Identity-transition cleanup cannot reach this: A→B never runs the
+// logout-clear branch, and nothing cancels a request already on the wire.
+describe("mountCustomThemeSync — a response that outlives its identity (#837)", () => {
+  const A_TOKEN = "tok-a";
+  const B_TOKEN = "tok-b";
+  const A_BG = "#aa0000";
+  const B_BG = "#00bb00";
+
+  const themed = (bg: string): TokenPayload => {
+    const base = payload();
+    return { ...base, colors: { ...base.colors, bg } as TokenColors };
+  };
+
+  const themeRow = (id: number, bg: string): ThemesWireT => ({
+    id,
+    name: `theme-${id}`,
+    author: "tester",
+    built_in: false,
+    published: true,
+    apply_count: 0,
+    in_use: 0,
+    mine: true,
+    payload: themed(bg) as unknown as Record<string, unknown>,
+    inserted_at: "2026-01-01T00:00:00Z",
+  });
+
+  const bearerOf = (init?: RequestInit): string | null =>
+    new Headers(init?.headers).get("authorization");
+
+  const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+  // Hold A's GET open; answer any other bearer with B's theme immediately, so
+  // the only route by which A's theme can reach the DOM or the cache is the
+  // held continuation under test.
+  function stubWithHeldGetForA(): { release: (pair: unknown) => void } {
+    let release!: (r: Response) => void;
+    const held = new Promise<Response>((r) => {
+      release = r;
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation((_url, init?: RequestInit) => {
+      if (bearerOf(init) === `Bearer ${A_TOKEN}`) return held;
+      return Promise.resolve(
+        new Response(JSON.stringify({ light: themeRow(2, B_BG), dark: null }), { status: 200 }),
+      );
+    });
+    return {
+      release: (pair: unknown) => release(new Response(JSON.stringify(pair), { status: 200 })),
+    };
+  }
+
+  // Disposal in afterEach, not at the end of each case: the effect under test
+  // writes module-singleton state, so a case that fails an assertion and skips
+  // its own dispose() would leave a live sync running against the NEXT case's
+  // fetch stub — the failure would then cascade into a neighbour that is fine.
+  let dispose: (() => void) | null = null;
+
+  function mountFor(t: string): void {
+    setToken(t);
+    createRoot((d) => {
+      dispose = d;
+      mountCustomThemeSync();
+    });
+  }
+
+  beforeEach(() => {
+    setToken(null);
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    dispose?.();
+    dispose = null;
+  });
+
+  it("does not paint or cache the previous subject's theme when its GET lands after a rotation", async () => {
+    const a = stubWithHeldGetForA();
+    mountFor(A_TOKEN);
+    await flush(); // A's GET is on the wire, held
+
+    setToken(B_TOKEN); // rotation lands INSIDE A's await; B's own theme applies
+    await flush();
+
+    a.release({ light: themeRow(1, A_BG), dark: null });
+    await flush();
+
+    expect(activePair()).toEqual({ light: 2, dark: null });
+    expect(getAppliedThemePayload()?.colors.bg).toBe(B_BG);
+    expect(document.documentElement.style.getPropertyValue("--bg")).toBe(B_BG);
+  });
+
+  // The control. Same harness, same held response, no rotation: without it a
+  // gate that never delivered A's pair would make the case above pass while
+  // asserting nothing.
+  it("does apply that same response when the identity holds", async () => {
+    const a = stubWithHeldGetForA();
+    mountFor(A_TOKEN);
+    await flush();
+
+    a.release({ light: themeRow(1, A_BG), dark: null });
+    await flush();
+
+    expect(activePair()).toEqual({ light: 1, dark: null });
+    expect(getAppliedThemePayload()?.colors.bg).toBe(A_BG);
+    expect(document.documentElement.style.getPropertyValue("--bg")).toBe(A_BG);
   });
 });

--- a/cicchetto/src/__tests__/displayPrefs.test.ts
+++ b/cicchetto/src/__tests__/displayPrefs.test.ts
@@ -526,3 +526,125 @@ describe("syncedSetChannelPresencePref — refetch on reveal (#458)", () => {
     expect(asMock(loadInitialScrollback)).not.toHaveBeenCalled();
   });
 });
+
+// #837 — the mid-flight identity guard, the OTHER door into the cross-account
+// bleed the clear-on-logout block above closes. That block covers the identity
+// TRANSITION (logout clears, so B never inherits A's residue). This one covers
+// what the transition cannot reach: a GET already in flight when the rotation
+// happens. The effect captured A's token at entry and nothing cancels its
+// request, so the continuation resumes holding a bearer the server has already
+// retired — and it acts on the response.
+//
+// Two distinct harms, one per case below:
+//   * server-wins applies A's prefs over B's freshly-loaded ones;
+//   * a never-persisted A response fires a seed-up PUT under A's retired
+//     bearer — a 401/404 on the host's fail2ban-watched surface (#281's class).
+//
+// The rotation must land strictly INSIDE the await: A's GET is held open until
+// setToken has already re-run the effect for B and B's own answer has applied.
+describe("mountDisplayPrefsSync — a response that outlives its identity (#837)", () => {
+  const OTHER = "B-bearer";
+
+  const A_PREFS: DisplayPrefs = {
+    time_format: "hm",
+    colored_nicklist: true,
+    presence_filter: { [KEY_A]: "hide" },
+  };
+  // Distinct from A on all three axes, so "B's state survived" is an assertion
+  // about B's values rather than about the module defaults.
+  const B_PREFS: DisplayPrefs = {
+    time_format: "hms",
+    colored_nicklist: false,
+    presence_filter: { [KEY_B]: "hide" },
+  };
+
+  const bearerOf = (init?: RequestInit): string | null =>
+    new Headers(init?.headers).get("authorization");
+
+  const methodOf = (init?: RequestInit): string => (init?.method ?? "GET").toUpperCase();
+
+  const jsonResponse = (body: unknown): Response =>
+    new Response(JSON.stringify(body), { status: 200 });
+
+  // Hold A's GET open; answer everything else immediately. B's GET carries
+  // B_PREFS persisted, so the only route by which A's values can reach the
+  // local state is the held continuation under test.
+  function stubWithHeldGetForA(): { release: (body: unknown) => void } {
+    let release!: (r: Response) => void;
+    const held = new Promise<Response>((r) => {
+      release = r;
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation((_url, init?: RequestInit) => {
+      if (methodOf(init) === "GET" && bearerOf(init) === `Bearer ${TOKEN}`) return held;
+      return Promise.resolve(jsonResponse({ display_prefs: B_PREFS, persisted: true }));
+    });
+    return { release: (body: unknown) => release(jsonResponse(body)) };
+  }
+
+  const putBearers = (): (string | null)[] =>
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls
+      .filter((c) => methodOf(c[1] as RequestInit | undefined) === "PUT")
+      .map((c) => bearerOf(c[1] as RequestInit | undefined));
+
+  // Disposal in afterEach, not at the end of each case: the effect under test
+  // writes module-singleton state, so a case that fails an assertion and skips
+  // its own dispose() would leave a live sync running against the NEXT case's
+  // fetch stub — the failure would then cascade into a neighbour that is fine.
+  let dispose: (() => void) | null = null;
+
+  function mountFor(t: string): void {
+    setToken(t);
+    createRoot((d) => {
+      dispose = d;
+      mountDisplayPrefsSync();
+    });
+  }
+
+  afterEach(() => {
+    dispose?.();
+    dispose = null;
+  });
+
+  // Drive A-login → mount → rotate to B → release A's held GET with `body`.
+  async function rotateUnderAHeldGet(body: unknown): Promise<void> {
+    const a = stubWithHeldGetForA();
+    mountFor(TOKEN);
+    await flush(); // A's GET is on the wire, held
+    setToken(OTHER); // rotation lands INSIDE A's await; B's own GET answers
+    await flush();
+    a.release(body);
+    await flush();
+  }
+
+  it("does not apply the previous subject's prefs when its GET lands after a rotation", async () => {
+    await rotateUnderAHeldGet({ display_prefs: A_PREFS, persisted: true });
+
+    expect(getTimeFormat()).toBe(B_PREFS.time_format);
+    expect(getColoredNicklist()).toBe(B_PREFS.colored_nicklist);
+    expect(getAllPresencePrefs()).toEqual(B_PREFS.presence_filter);
+  });
+
+  // The control for the case above. Same harness, same held GET, no rotation:
+  // if A's response stopped reaching the apply path at all (a broken gate, a
+  // changed wire shape), the case above would pass while testing nothing.
+  it("does apply that same response when the identity holds", async () => {
+    const a = stubWithHeldGetForA();
+    mountFor(TOKEN);
+    await flush();
+    a.release({ display_prefs: A_PREFS, persisted: true });
+    await flush();
+
+    expect(getTimeFormat()).toBe(A_PREFS.time_format);
+    expect(getColoredNicklist()).toBe(A_PREFS.colored_nicklist);
+    expect(getAllPresencePrefs()).toEqual(A_PREFS.presence_filter);
+  });
+
+  it("does not seed up under a bearer the rotation already retired", async () => {
+    // persisted:false is the seed-up branch — the one that PUTs. Under A's
+    // retired bearer that write is both a wrong-identity request and, if the
+    // server honoured it, A's local map landing on B's account.
+    await rotateUnderAHeldGet({ display_prefs: A_PREFS, persisted: false });
+
+    expect(putBearers()).not.toContain(`Bearer ${TOKEN}`);
+  });
+});

--- a/cicchetto/src/__tests__/focus-rule.test.ts
+++ b/cicchetto/src/__tests__/focus-rule.test.ts
@@ -37,6 +37,11 @@ vi.mock("../lib/api", () => ({
   // transitively) needs the classifier in its api mock.
   isContentKind: (k: string) => k === "privmsg" || k === "notice" || k === "action",
   isPresenceKind: (k: string) => !(k === "privmsg" || k === "notice" || k === "action"),
+  // #868 — this file drives real messages through subscribe.ts, which now
+  // decides the beep via `pushTriggers.shouldNotify` and so reads the
+  // notify-worthy kind set from api.ts. Same mirror the classifiers above
+  // needed when selection.ts started importing them.
+  NOTIFY_KINDS: new Set(["privmsg", "action"]),
   displayNick: (me: { kind: "user" | "visitor"; name?: string; nick?: string }) =>
     me.kind === "user" ? (me.name ?? "") : (me.nick ?? ""),
   // Mirror of production `ownNickForNetwork` — see subscribe.test.ts

--- a/cicchetto/src/__tests__/messageLines.test.ts
+++ b/cicchetto/src/__tests__/messageLines.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { splitMessageLines } from "../lib/messageLines";
+import { serverAcceptsBody } from "./serverBodyPredicate";
 
 // IRC frames are newline-delimited, so a PRIVMSG body cannot carry an
 // embedded LF — `splitMessageLines` turns a multiline compose into one
@@ -42,4 +43,36 @@ describe("splitMessageLines", () => {
   it("preserves a whitespace-only line (it is content on the wire, not empty)", () => {
     expect(splitMessageLines("a\n \nb")).toEqual(["a", " ", "b"]);
   });
+});
+
+// #863 — the two halves of "what is an empty line" must agree.
+//
+// The splitter decides what cic PUTS ON THE WIRE; the server decides what it
+// will accept. Nothing connects the two, so they drifted: the splitter keeps a
+// whitespace-only line on purpose ("content on the wire, not empty", the test
+// directly above), and the server refuses it as blank. The disagreement is
+// invisible until someone pastes a block with an indented blank line in it,
+// which is the ordinary shape of pasted code, logs and quoted text.
+//
+// This pin does NOT say which side is right — that is a product decision. It
+// says only that a line cic chooses to send must be one the server takes. It
+// holds either way: if the splitter starts dropping whitespace-only lines it
+// never emits one; if the server starts accepting them the model in
+// `serverBodyPredicate.ts` moves with it. What it forbids is fixing one half
+// and leaving the other to disagree in silence again.
+describe("#863 — splitMessageLines agrees with the server on what is empty", () => {
+  const pastes = [
+    "a\n \nb", // the reported shape: a space between two content lines
+    "a\n\t\nb", // same, tab-indented — a code paste
+    "first\n   \nsecond\n\nthird", // mixed: indented blank, truly empty
+    "  leading\ntrailing  ", // content with edge whitespace stays content
+    "plain", // the single-line common path
+  ];
+
+  for (const paste of pastes) {
+    it(`every line emitted for ${JSON.stringify(paste)} is a body the server accepts`, () => {
+      const emitted = splitMessageLines(paste);
+      expect(emitted.filter((line) => !serverAcceptsBody(line))).toEqual([]);
+    });
+  }
 });

--- a/cicchetto/src/__tests__/messageLines.test.ts
+++ b/cicchetto/src/__tests__/messageLines.test.ts
@@ -40,8 +40,22 @@ describe("splitMessageLines", () => {
     expect(splitMessageLines("only\n")).toEqual(["only"]);
   });
 
-  it("preserves a whitespace-only line (it is content on the wire, not empty)", () => {
-    expect(splitMessageLines("a\n \nb")).toEqual(["a", " ", "b"]);
+  // #863 — this case used to assert the OPPOSITE: that a whitespace-only line
+  // is preserved because it is "content on the wire, not empty". It is
+  // inverted rather than deleted, because the reversal is the decision worth
+  // keeping visible. The server never accepted such a line — Ecto trims before
+  // its empty-value test — so cic was sending something guaranteed to be
+  // refused, and one indented blank line in a paste aborted the rest of it.
+  it("drops a whitespace-only line — the server counts it as blank, so it is not content", () => {
+    expect(splitMessageLines("a\n \nb")).toEqual(["a", "b"]);
+  });
+
+  it("drops a tab-only line too — the shape a code paste actually produces", () => {
+    expect(splitMessageLines("a\n\t\nb")).toEqual(["a", "b"]);
+  });
+
+  it("keeps a line whose whitespace surrounds real content (indentation is content)", () => {
+    expect(splitMessageLines("def f():\n    return 1")).toEqual(["def f():", "    return 1"]);
   });
 });
 
@@ -54,12 +68,13 @@ describe("splitMessageLines", () => {
 // invisible until someone pastes a block with an indented blank line in it,
 // which is the ordinary shape of pasted code, logs and quoted text.
 //
-// This pin does NOT say which side is right — that is a product decision. It
-// says only that a line cic chooses to send must be one the server takes. It
-// holds either way: if the splitter starts dropping whitespace-only lines it
-// never emits one; if the server starts accepting them the model in
-// `serverBodyPredicate.ts` moves with it. What it forbids is fixing one half
-// and leaving the other to disagree in silence again.
+// This pin does not encode WHICH answer was chosen — the client moving onto
+// the server's notion was a product decision, and pinning the decision would
+// only restate the splitter's own code. It pins the AGREEMENT: a line cic
+// chooses to send must be one the server takes. It survives the server
+// changing its mind too (the model in `serverBodyPredicate.ts` moves, and the
+// splitter must follow or this fails). What it forbids is the state #863 was
+// filed from — one half moving and the other left to disagree in silence.
 describe("#863 — splitMessageLines agrees with the server on what is empty", () => {
   const pastes = [
     "a\n \nb", // the reported shape: a space between two content lines

--- a/cicchetto/src/__tests__/notificationPrefs.test.ts
+++ b/cicchetto/src/__tests__/notificationPrefs.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setToken } from "../lib/auth";
+import {
+  mirrorNotificationPrefs,
+  notificationPrefs,
+  refreshNotificationPrefs,
+} from "../lib/notificationPrefs";
+import { DEFAULT_NOTIFICATION_PREFS, type NotificationPrefs } from "../lib/userSettings";
+
+// #868 — the notification-prefs store. `subscribe.ts` reads this signal on
+// every inbound message to decide the in-app beep and the optimistic
+// `document.title` bump, so three properties are load-bearing:
+//
+//   * the un-hydrated value is the SERVER's own default, not an empty map. A
+//     client that has not hydrated yet must behave like a subject who never
+//     configured anything — never like one who muted everything.
+//   * refreshNotificationPrefs hydrates from GET. That is the mechanism the
+//     user-topic-join hydration relies on, so a pref set on another device
+//     reaches this device's beep after a reload.
+//   * mirrorNotificationPrefs adopts a server response, so toggling a pref in
+//     the settings drawer changes the beep immediately rather than at the next
+//     rejoin.
+
+const TOKEN = "notif-prefs-tok";
+
+const MUTED_MENTIONS: NotificationPrefs = {
+  ...DEFAULT_NOTIFICATION_PREFS,
+  channel_mentions: false,
+  private_messages_all: false,
+};
+
+beforeEach(() => {
+  setToken(TOKEN);
+  mirrorNotificationPrefs(DEFAULT_NOTIFICATION_PREFS);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setToken(null);
+  mirrorNotificationPrefs(DEFAULT_NOTIFICATION_PREFS);
+});
+
+describe("notificationPrefs store — #868", () => {
+  it("starts at the server defaults, so an un-hydrated client is not silently muted", () => {
+    expect(notificationPrefs()).toEqual(DEFAULT_NOTIFICATION_PREFS);
+    // Pinned explicitly: these two are what make the un-hydrated state
+    // deliver rather than swallow.
+    expect(notificationPrefs().channel_mentions).toBe(true);
+    expect(notificationPrefs().private_messages_all).toBe(true);
+  });
+
+  it("refreshNotificationPrefs hydrates the signal from GET (the rejoin-hydration path)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ notification_prefs: MUTED_MENTIONS }), { status: 200 }),
+    );
+
+    const prefs = await refreshNotificationPrefs();
+
+    expect(prefs).toEqual(MUTED_MENTIONS);
+    expect(notificationPrefs()).toEqual(MUTED_MENTIONS);
+  });
+
+  it("refreshNotificationPrefs sends the bearer to the prefs endpoint", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ notification_prefs: DEFAULT_NOTIFICATION_PREFS }), {
+        status: 200,
+      }),
+    );
+
+    await refreshNotificationPrefs();
+
+    const [url, init] = spy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/me/settings/notification-prefs");
+    expect((init.headers as Record<string, string>).authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it("a failed GET leaves the last known prefs in place rather than blanking them", async () => {
+    mirrorNotificationPrefs(MUTED_MENTIONS);
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response("nope", { status: 500 }));
+
+    await expect(refreshNotificationPrefs()).rejects.toBeDefined();
+
+    // The user-topic hydrate swallows this rejection into a console.warn; the
+    // signal must not have been clobbered on the way out.
+    expect(notificationPrefs()).toEqual(MUTED_MENTIONS);
+  });
+
+  it("refreshNotificationPrefs without a session throws instead of fetching unauthenticated", async () => {
+    setToken(null);
+    const spy = vi.spyOn(globalThis, "fetch");
+
+    await expect(refreshNotificationPrefs()).rejects.toThrow("no session");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("mirrorNotificationPrefs adopts a server response so a settings toggle takes effect at once", () => {
+    mirrorNotificationPrefs(MUTED_MENTIONS);
+    expect(notificationPrefs()).toEqual(MUTED_MENTIONS);
+  });
+});

--- a/cicchetto/src/__tests__/notificationPrefs.test.ts
+++ b/cicchetto/src/__tests__/notificationPrefs.test.ts
@@ -41,12 +41,20 @@ afterEach(() => {
 });
 
 describe("notificationPrefs store — #868", () => {
-  it("starts at the server defaults, so an un-hydrated client is not silently muted", () => {
-    expect(notificationPrefs()).toEqual(DEFAULT_NOTIFICATION_PREFS);
+  it("starts at the server defaults, so an un-hydrated client is not silently muted", async () => {
+    // A FRESH module instance, not the file-scope one: `beforeEach` mirrors a
+    // known map into the shared signal, which would make this test assert the
+    // mirror rather than the initial value. Mutating the store's initial value
+    // reddened nothing until this was re-imported per-test — the assertion was
+    // covering the line without constraining it.
+    vi.resetModules();
+    const fresh = await import("../lib/notificationPrefs");
+
+    expect(fresh.notificationPrefs()).toEqual(DEFAULT_NOTIFICATION_PREFS);
     // Pinned explicitly: these two are what make the un-hydrated state
     // deliver rather than swallow.
-    expect(notificationPrefs().channel_mentions).toBe(true);
-    expect(notificationPrefs().private_messages_all).toBe(true);
+    expect(fresh.notificationPrefs().channel_mentions).toBe(true);
+    expect(fresh.notificationPrefs().private_messages_all).toBe(true);
   });
 
   it("refreshNotificationPrefs hydrates the signal from GET (the rejoin-hydration path)", async () => {

--- a/cicchetto/src/__tests__/serverBodyPredicate.ts
+++ b/cicchetto/src/__tests__/serverBodyPredicate.ts
@@ -2,12 +2,14 @@
 // the client-side suites can be held against it.
 //
 // THIS IS THE HALF THAT MUST BE UPDATED IF THE SERVER CHANGES. The
-// disagreement #863 reports is silent precisely because the two predicates
-// live in two languages with nothing tying them together: the client's is
-// `splitMessageLines`' `!== ""` filter (`src/lib/messageLines.ts`), the
-// server's is an emergent property of Ecto rather than a written rule.
-// Whichever way the fix goes, both halves move together — and the suites
-// that import this file fail until they do.
+// disagreement #863 reported was silent precisely because the two predicates
+// live in two languages with nothing tying them together: the client's, in
+// `splitMessageLines` (`src/lib/messageLines.ts`), and the server's, an
+// emergent property of Ecto rather than a written rule. #863 closed the gap
+// by moving the CLIENT onto the server's notion — it now drops a line that
+// trims to nothing. This file is what keeps them from drifting apart again:
+// if the server's half moves, this model moves with it, and the suites that
+// import it fail until the splitter follows.
 //
 // Where the server's behaviour comes from (read on origin/main, measured on
 // prod by the #863 reporter — NOT executed from this suite):

--- a/cicchetto/src/__tests__/serverBodyPredicate.ts
+++ b/cicchetto/src/__tests__/serverBodyPredicate.ts
@@ -1,0 +1,44 @@
+// #863 — the server's notion of "an empty message body", modelled here so
+// the client-side suites can be held against it.
+//
+// THIS IS THE HALF THAT MUST BE UPDATED IF THE SERVER CHANGES. The
+// disagreement #863 reports is silent precisely because the two predicates
+// live in two languages with nothing tying them together: the client's is
+// `splitMessageLines`' `!== ""` filter (`src/lib/messageLines.ts`), the
+// server's is an emergent property of Ecto rather than a written rule.
+// Whichever way the fix goes, both halves move together — and the suites
+// that import this file fail until they do.
+//
+// Where the server's behaviour comes from (read on origin/main, measured on
+// prod by the #863 reporter — NOT executed from this suite):
+//
+//   * `GrappaWeb.MessagesController.create/2` guards on `body != ""`, so a
+//     whitespace-only body passes the controller.
+//   * `Grappa.Session.send_privmsg/4` only rejects CRLF/NUL, so it passes
+//     there too.
+//   * `Grappa.Session.Server.persist_and_send_fragments/5` persists BEFORE
+//     it relays, and `Grappa.Scrollback.Message.changeset/2` runs
+//     `validate_required([:body])`. Ecto's `cast/4` trims string params
+//     before its empty-value test (`Ecto.Type.trim/2` against
+//     `@empty_values [""]`), so `" "` is treated as an ABSENT param: the
+//     change is never applied, `:body` stays nil, and validate_required
+//     adds "can't be blank".
+//
+// So the server accepts a body iff it is non-empty AFTER trimming — an
+// accident of `cast/4`, not a decision anyone wrote down. That is the point.
+//
+// LIMIT, stated rather than papered over: this uses JavaScript's `trim()`,
+// which is not byte-identical to Elixir's `String.trim/1` on exotic
+// whitespace (U+FEFF is stripped by JS and not by Elixir). Callers must
+// keep their samples to ASCII spaces and tabs, where the two agree. This
+// model is a stand-in for the real server, and only inside that range.
+export const serverAcceptsBody = (body: string): boolean => body.trim() !== "";
+
+// The 422 the server returns when `serverAcceptsBody` is false, in the exact
+// shape `readError` builds — `friendlyApiError` renders this as
+// `Please fix: body: can't be blank.`, the string the user reported.
+export const BLANK_BODY_ERROR = {
+  status: 422,
+  code: "validation_failed",
+  info: { field_errors: { body: ["can't be blank"] } },
+} as const;

--- a/cicchetto/src/__tests__/subscribe.test.ts
+++ b/cicchetto/src/__tests__/subscribe.test.ts
@@ -1,6 +1,7 @@
 import { createEffect, createRoot, createSignal, on } from "solid-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { channelKey } from "../lib/channelKey";
+import { DEFAULT_NOTIFICATION_PREFS, type NotificationPrefs } from "../lib/userSettings";
 
 // Boundary: mock REST (`lib/api`) + the socket helpers (`lib/socket`).
 // `subscribe.ts` is a side-effect module — the createRoot installs
@@ -36,6 +37,11 @@ vi.mock("../lib/api", () => ({
   // routeMessage path); the mock needs to expose the classifier.
   isContentKind: (k: string) => k === "privmsg" || k === "notice" || k === "action",
   isPresenceKind: (k: string) => !(k === "privmsg" || k === "notice" || k === "action"),
+  // #868 — subscribe.ts now decides the beep through `pushTriggers.shouldNotify`,
+  // which reads the notify-worthy kind set from here. Same hand-mirrored
+  // convention as the two classifiers above: the notify subset is
+  // privmsg|action (NOTICE is unread but never notify-worthy).
+  NOTIFY_KINDS: new Set(["privmsg", "action"]),
   displayNick: (me: { kind: "user" | "visitor"; name?: string; nick?: string }) =>
     me.kind === "user" ? (me.name ?? "") : (me.nick ?? ""),
   // Mirror of production `ownNickForNetwork` — single source for
@@ -130,12 +136,33 @@ vi.mock("../lib/beep", () => ({
   playBeep: vi.fn(),
 }));
 
+// #868 — the optimistic `document.title` bump is the other half of the live
+// notify decision, so it is asserted alongside the beep. `setBadge` is stubbed
+// too: `networks.ts` seeds it from the `/me` envelope on every load here.
+vi.mock("../lib/badge", () => ({
+  incrementBadge: vi.fn(),
+  setBadge: vi.fn(),
+}));
+
 // #370 — the keyword-highlight list, signal-backed so a test can stage
 // custom /hilight patterns. Default empty so the own-nick beep tests are
 // unaffected. The live beep now matches own nick ∪ these patterns (one path).
 const [highlightPatternsSig, setHighlightPatternsForTest] = createSignal<string[]>([]);
 vi.mock("../lib/highlightList", () => ({
   highlightPatterns: () => highlightPatternsSig(),
+}));
+
+// #868 — the live notify path reads the subject's server notification prefs.
+// Signal-backed so a test can stage a pref and assert the beep obeys it. The
+// default is the PRODUCTION default (`channel_mentions: true`,
+// `private_messages_all: true`), so every pre-#868 beep test keeps its meaning.
+const [notificationPrefsSig, setNotificationPrefsForTest] = createSignal<NotificationPrefs>(
+  DEFAULT_NOTIFICATION_PREFS,
+);
+vi.mock("../lib/notificationPrefs", () => ({
+  notificationPrefs: () => notificationPrefsSig(),
+  refreshNotificationPrefs: vi.fn().mockResolvedValue(undefined),
+  mirrorNotificationPrefs: vi.fn(),
 }));
 
 vi.mock("../lib/queryWindows", () => ({
@@ -170,6 +197,7 @@ beforeEach(async () => {
   localStorage.clear();
   vi.clearAllMocks();
   setHighlightPatternsForTest([]);
+  setNotificationPrefsForTest(DEFAULT_NOTIFICATION_PREFS);
   // Reset H2 per-topic registry so cross-test handler counts don't
   // leak (each test that opts in via usePerTopicChannels gets a fresh
   // pool; tests that don't opt in fall back to the singleton mockChannel).
@@ -3218,8 +3246,15 @@ describe("subscribe - not-joined pre-subscribe loop (CP15 B5 fix + #78)", () => 
       // mirror the top-level vi.mock — selection.ts's badge memo now
       // imports `isContentKind` from api.ts; without it the doMock
       // bleeds a missing-export into UX-6-L beep tests downstream.
+      //
+      // #868 — the same bleed, second instance: this `doMock` outlives its
+      // own test (a `vi.doMock` registration survives `vi.resetModules`), so
+      // every api export any DOWNSTREAM test needs has to be mirrored here.
+      // `NOTIFY_KINDS` is now one of them, because subscribe.ts decides the
+      // beep through `pushTriggers.shouldNotify`.
       isContentKind: (k: string) => k === "privmsg" || k === "notice" || k === "action",
       isPresenceKind: (k: string) => !(k === "privmsg" || k === "notice" || k === "action"),
+      NOTIFY_KINDS: new Set(["privmsg", "action"]),
       displayNick: (me: { kind: string; name?: string }) => me.name ?? "",
       ownNickForNetwork: (
         net: { slug: string; nick?: string },
@@ -3630,6 +3665,239 @@ describe("subscribe — UX-6-L foreground beep wiring", () => {
         kind: "privmsg",
         sender: "alice",
         body: "talking to myself",
+        meta: {},
+      },
+    });
+
+    expect(beep.playBeep).not.toHaveBeenCalled();
+  });
+});
+
+// #868 — the live path decides through the SHARED predicate.
+//
+// Before this issue, `subscribe.ts` called `matchesWatchlist` directly and
+// read no preference at all, while the OS push was decided server-side by
+// `Grappa.Push.Triggers.should_notify?/4`. One preference, two answers. Each
+// test below pins a case where the two surfaces used to disagree.
+describe("subscribe — #868 the beep obeys the notification prefs", () => {
+  const asAlice = async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    const beep = await import("../lib/beep");
+    const badge = await import("../lib/badge");
+    const store = await loadStores();
+    await vi.waitFor(() => {
+      expect(mockChannel.on).toHaveBeenCalled();
+    });
+    store.setSelectedChannel({
+      networkSlug: "freenode",
+      channelName: "#cicchetto",
+      kind: "channel",
+    });
+    return { beep, badge };
+  };
+
+  it("channel_mentions:false silences a mention that the server would not push", async () => {
+    setNotificationPrefsForTest({ ...DEFAULT_NOTIFICATION_PREFS, channel_mentions: false });
+    const { beep, badge } = await asAlice();
+
+    fireMessageEvent("#grappa", { id: 800, kind: "privmsg", body: "alice ping" });
+
+    expect(beep.playBeep).not.toHaveBeenCalled();
+    expect(badge.incrementBadge).not.toHaveBeenCalled();
+  });
+
+  it("channel_messages_all:true beeps on a message with no mention at all", async () => {
+    setNotificationPrefsForTest({ ...DEFAULT_NOTIFICATION_PREFS, channel_messages_all: true });
+    const { beep } = await asAlice();
+
+    fireMessageEvent("#grappa", { id: 801, kind: "privmsg", body: "no mention here" });
+
+    expect(beep.playBeep).toHaveBeenCalledTimes(1);
+  });
+
+  it("channel_messages_only listing the channel beeps without a mention", async () => {
+    setNotificationPrefsForTest({
+      ...DEFAULT_NOTIFICATION_PREFS,
+      channel_messages_only: ["#grappa"],
+    });
+    const { beep } = await asAlice();
+
+    fireMessageEvent("#grappa", { id: 802, kind: "privmsg", body: "no mention here" });
+
+    expect(beep.playBeep).toHaveBeenCalledTimes(1);
+  });
+
+  it("an ACTION mentioning own nick beeps — the server pushes it, so the title must move too", async () => {
+    const { beep, badge } = await asAlice();
+
+    fireMessageEvent("#grappa", { id: 803, kind: "action", body: "waves at alice" });
+
+    expect(beep.playBeep).toHaveBeenCalledTimes(1);
+    expect(badge.incrementBadge).toHaveBeenCalledTimes(1);
+  });
+
+  it("an inbound DM mentioning own nick beeps ONCE, not once per decision site", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    const beep = await import("../lib/beep");
+    const socket = await import("../lib/socket");
+    await loadStores();
+    await vi.waitFor(() => {
+      const topics = vi.mocked(socket.joinChannel).mock.calls.map((c) => `${c[1]}/${c[2]}`);
+      expect(topics).toContain("freenode/alice");
+    });
+
+    const joinCalls = vi.mocked(socket.joinChannel).mock.calls;
+    const dmJoinIdx = joinCalls.findIndex((c) => c[1] === "freenode" && c[2] === "alice");
+    const eventCalls = mockChannel.on.mock.calls.filter((c) => c[0] === "event");
+    const dmHandler = eventCalls[dmJoinIdx]?.[1] as (p: unknown) => void;
+    // The DM listener used to beep at its own call site AND again inside
+    // routeMessage's mention path, so a DM whose body happened to contain the
+    // operator's nick fired two oscillators back to back. The existing
+    // DM-beep test hid it by using a body with no mention ("hey").
+    dmHandler({
+      kind: "message",
+      message: {
+        id: 804,
+        network: "freenode",
+        channel: "alice",
+        server_time: 0,
+        kind: "privmsg",
+        sender: "bob",
+        body: "alice ping",
+        meta: {},
+      },
+    });
+
+    expect(beep.playBeep).toHaveBeenCalledTimes(1);
+  });
+
+  it("private_messages_all:false silences an inbound DM the server would not push", async () => {
+    setNotificationPrefsForTest({
+      ...DEFAULT_NOTIFICATION_PREFS,
+      private_messages_all: false,
+      channel_mentions: true,
+    });
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    const beep = await import("../lib/beep");
+    const socket = await import("../lib/socket");
+    await loadStores();
+    await vi.waitFor(() => {
+      const topics = vi.mocked(socket.joinChannel).mock.calls.map((c) => `${c[1]}/${c[2]}`);
+      expect(topics).toContain("freenode/alice");
+    });
+
+    const joinCalls = vi.mocked(socket.joinChannel).mock.calls;
+    const dmJoinIdx = joinCalls.findIndex((c) => c[1] === "freenode" && c[2] === "alice");
+    const eventCalls = mockChannel.on.mock.calls.filter((c) => c[0] === "event");
+    const dmHandler = eventCalls[dmJoinIdx]?.[1] as (p: unknown) => void;
+    // Body carries the own nick on purpose: the DM branch owns this row, so
+    // `channel_mentions` must NOT rescue it. That is the server's `dm?/2`
+    // routing, and the client now agrees.
+    dmHandler({
+      kind: "message",
+      message: {
+        id: 805,
+        network: "freenode",
+        channel: "alice",
+        server_time: 0,
+        kind: "privmsg",
+        sender: "bob",
+        body: "alice ping",
+        meta: {},
+      },
+    });
+
+    expect(beep.playBeep).not.toHaveBeenCalled();
+  });
+
+  it("private_messages_only listing the sender beeps when private_messages_all is off", async () => {
+    setNotificationPrefsForTest({
+      ...DEFAULT_NOTIFICATION_PREFS,
+      private_messages_all: false,
+      private_messages_only: ["bob"],
+    });
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    const beep = await import("../lib/beep");
+    const socket = await import("../lib/socket");
+    await loadStores();
+    await vi.waitFor(() => {
+      const topics = vi.mocked(socket.joinChannel).mock.calls.map((c) => `${c[1]}/${c[2]}`);
+      expect(topics).toContain("freenode/alice");
+    });
+
+    const joinCalls = vi.mocked(socket.joinChannel).mock.calls;
+    const dmJoinIdx = joinCalls.findIndex((c) => c[1] === "freenode" && c[2] === "alice");
+    const eventCalls = mockChannel.on.mock.calls.filter((c) => c[0] === "event");
+    const dmHandler = eventCalls[dmJoinIdx]?.[1] as (p: unknown) => void;
+    dmHandler({
+      kind: "message",
+      message: {
+        id: 806,
+        network: "freenode",
+        channel: "alice",
+        server_time: 0,
+        kind: "privmsg",
+        sender: "bob",
+        body: "no mention here",
+        meta: {},
+      },
+    });
+
+    expect(beep.playBeep).toHaveBeenCalledTimes(1);
+  });
+
+  it("a peer NOTICE does not beep — NOTICE is unread-worthy but never notify-worthy", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+    );
+    await seedStubs();
+    const beep = await import("../lib/beep");
+    const socket = await import("../lib/socket");
+    await loadStores();
+    await vi.waitFor(() => {
+      const topics = vi.mocked(socket.joinChannel).mock.calls.map((c) => `${c[1]}/${c[2]}`);
+      expect(topics).toContain("freenode/alice");
+    });
+
+    const joinCalls = vi.mocked(socket.joinChannel).mock.calls;
+    const dmJoinIdx = joinCalls.findIndex((c) => c[1] === "freenode" && c[2] === "alice");
+    const eventCalls = mockChannel.on.mock.calls.filter((c) => c[0] === "event");
+    const dmHandler = eventCalls[dmJoinIdx]?.[1] as (p: unknown) => void;
+    // Deliberate, user-visible subtraction (UX-6-L used to beep here). The
+    // server never pushes a NOTICE, so beeping made the desktop and the phone
+    // disagree on the same row. The window still takes the unread.
+    dmHandler({
+      kind: "message",
+      message: {
+        id: 807,
+        network: "freenode",
+        channel: "alice",
+        server_time: 0,
+        kind: "notice",
+        sender: "bob",
+        body: "heads up",
         meta: {},
       },
     });

--- a/cicchetto/src/lib/customTheme.ts
+++ b/cicchetto/src/lib/customTheme.ts
@@ -1,5 +1,6 @@
 import { createEffect, createSignal } from "solid-js";
 import { token } from "./auth";
+import { identityMoved } from "./identityMoved";
 import { moduleRoot } from "./moduleRoot";
 import { prefersDark } from "./theme";
 import type { ActiveThemePair, TokenPayload } from "./themesApi";
@@ -285,8 +286,9 @@ export function mountCustomThemeSync(): void {
     }
     void getActiveThemePair(t)
       .then((pair) => {
-        // Token rotated mid-flight — a later effect run owns the DOM now.
-        if (token() !== t) return;
+        // Token rotated mid-flight — a later effect run owns the DOM and the
+        // boot cache now (#837).
+        if (identityMoved(t)) return;
         applyResolvedPair(pair);
       })
       .catch((e) => {

--- a/cicchetto/src/lib/displayPrefs.ts
+++ b/cicchetto/src/lib/displayPrefs.ts
@@ -2,6 +2,7 @@ import { createEffect } from "solid-js";
 import { token } from "./auth";
 import { type ChannelKey, decodeChannelKey } from "./channelKey";
 import { getColoredNicklist, setColoredNicklist } from "./colorNicklist";
+import { identityMoved } from "./identityMoved";
 import {
   getAllPresencePrefs,
   type PresencePref,
@@ -127,8 +128,9 @@ export function mountDisplayPrefsSync(): void {
     }
     void getDisplayPrefs(t)
       .then((resp) => {
-        // Token rotated mid-flight — a later effect run owns the state now.
-        if (token() !== t) return;
+        // Token rotated mid-flight — a later effect run owns the state now,
+        // and the seed-up PUT below would carry a retired bearer (#837).
+        if (identityMoved(t)) return;
         // PUSH the LOCAL state up (never let the server clobber it) when either:
         //   * an earlier `syncedSet*` write is still UNCONFIRMED (its PUT never
         //     ACKed — e.g. a reload raced the fire-and-forget PUT). Without this

--- a/cicchetto/src/lib/identityMoved.ts
+++ b/cicchetto/src/lib/identityMoved.ts
@@ -1,0 +1,43 @@
+import { token } from "./auth";
+
+// THE identity predicate: the identity that started this continuation is not
+// the identity that will receive its result.
+//
+// `t` is the bearer a verb captured at entry — its identity, not merely its
+// credential. Any `await` can span an identity transition, and nothing cancels
+// a request already on the wire, so a continuation that outlived its identity
+// must do NOTHING further: not one request, not one write. Re-read `token()`
+// after the await and compare.
+//
+// Both halves of "nothing further" are load-bearing, which is why the check
+// belongs AFTER the await rather than in front of the request:
+//
+//   * the WIRE half — a request carrying a retired bearer 401s at best; aimed
+//     at a resource the NEW identity cannot see it 404s, and the host's
+//     `http-404` fail2ban jail bans the client IP at the firewall. A routine
+//     account switch self-bans the operator (#281's harm class).
+//   * the STORE half — the same continuation without touching the network: the
+//     result it already fetched lands in state the rotation just purged, so the
+//     new identity renders (or persists, or paints) the old one's data.
+//
+// Deliberately NOT part of `identityScopedStore`: that factory owns the
+// identity TRANSITION (fire the resets), while this owns a verb's OWN captured
+// identity, which the factory never sees. The two are complements — the resets
+// clear state, this refuses the write that arrives after the clear.
+//
+// Deliberately NOT in `auth.ts` either, though that module owns `token`: a
+// stub of `../auth` in a test would then stub the guard away with it, and the
+// rule under test would silently stop existing. Importing `token` from here
+// keeps the predicate real while still resolving through any token mock.
+//
+// #837 collapsed four inlined copies into this one. Adopters:
+//   * `scrollback.ts`   (#788) — eleven awaits, refusing a stale REQUEST;
+//   * `networks.ts`     (#818) — the `/me` hydrate side-effects;
+//   * `displayPrefs.ts`         — the login-reconcile apply + seed-up PUT;
+//   * `customTheme.ts`          — the active-theme paint + boot-cache write.
+// A fifth await site that captures the token adopts it unchanged; a site that
+// needs a VARIANT of the comparison has found a domain boundary, and that is
+// worth saying out loud rather than parameterising this.
+export function identityMoved(t: string): boolean {
+  return token() !== t;
+}

--- a/cicchetto/src/lib/messageLines.ts
+++ b/cicchetto/src/lib/messageLines.ts
@@ -17,11 +17,26 @@
 // guard is `not String.contains?(s, ["\r", "\n", "\x00"])`). Splitting
 // on LF alone would leave an embedded or CR-only `\r` in the body and
 // the server would bounce that frame: the splitter must satisfy the
-// guard for all three forms, not just trailing-CR-from-CRLF. Drops lines
-// that are empty after the split — an empty PRIVMSG is itself invalid,
-// and a blank line between paragraphs is not worth a wire frame. A
-// whitespace-only line is kept: it is content on the wire, not empty. A
-// single-line body returns `[body]` unchanged, so the common path is a
+// guard for all three forms, not just trailing-CR-from-CRLF.
+//
+// Drops every line that is blank after trimming — an empty PRIVMSG is
+// itself invalid, and a blank line between paragraphs is not worth a
+// wire frame. The trim matters, and #863 is why: this filter used to be
+// a strict `!== ""` on the reasoning that a whitespace-only line is
+// "content on the wire, not empty". The server disagreed, silently. It
+// accepts a body only if it is non-empty AFTER trimming (Ecto's `cast/4`
+// trims before its empty-value test, so `" "` arrives as an absent param
+// and `validate_required` fires), so cic sent a line the door would
+// always refuse — and because `sendBodyLines` treats a non-429 as fatal,
+// one indented blank line inside a pasted block killed the paste and
+// pushed the remainder back into the draft. Two users reported it.
+//
+// The predicates are now the same one, and `serverBodyPredicate.ts` (the
+// test-side model of the server's half) is what holds them together: if
+// the server's notion of blank ever moves, that file and this filter
+// move together or the suites fail.
+//
+// A single-line body returns `[body]` unchanged, so the common path is a
 // one-element list and callers loop once.
 export const splitMessageLines = (body: string): string[] =>
-  body.split(/\r\n|\r|\n/).filter((line) => line !== "");
+  body.split(/\r\n|\r|\n/).filter((line) => line.trim() !== "");

--- a/cicchetto/src/lib/networks.ts
+++ b/cicchetto/src/lib/networks.ts
@@ -11,6 +11,7 @@ import {
 } from "./api";
 import { token } from "./auth";
 import { setBadge } from "./badge";
+import { identityMoved } from "./identityMoved";
 import { identityScopedStore } from "./identityScopedStore";
 import { applyMeEnvelope } from "./readCursor";
 
@@ -81,13 +82,12 @@ const exports = identityScopedStore((onIdentityChange) => {
     //
     // The identity-TRANSITION is already handled (readCursor's own `on(token)`
     // arm and the `onIdentityChange` purge below both fire on rotation); what
-    // was missing is refusing a write that arrives AFTER the purge. Same rule
-    // and same predicate as #788's `identityMoved` in `scrollback.ts`: check
-    // after the await, not in front of the request. Kept in the caller rather
-    // than inside `applyMeEnvelope` because the check guards the whole block —
-    // `setBadge` shares this await and this bug — and because `readCursor`
-    // cannot know which identity produced an envelope handed to it.
-    if (token() !== t) return m;
+    // was missing is refusing a write that arrives AFTER the purge — the rule
+    // `identityMoved` owns. Kept in the caller rather than inside
+    // `applyMeEnvelope` because the check guards the whole block (`setBadge`
+    // shares this await and this bug) and because `readCursor` cannot know
+    // which identity produced an envelope handed to it.
+    if (identityMoved(t)) return m;
     // CP29 R-4: hydrate the readCursor signal map from the bulk envelope
     // BEFORE downstream consumers (subscribe.ts join effects, etc.)
     // observe `user()` and start joining channel topics. The join-reply

--- a/cicchetto/src/lib/notificationPrefs.ts
+++ b/cicchetto/src/lib/notificationPrefs.ts
@@ -1,0 +1,67 @@
+// #868 — cic-side mirror of the subject's server notification preferences.
+//
+// Why this exists. The live notify path (`subscribe.ts`: the in-app beep and
+// the optimistic `document.title` bump) used to decide on a bare
+// `matchesWatchlist` call, reading no preference at all — so `channel_mentions:
+// false` still beeped and `private_messages_all: false` still beeped, while the
+// OS push (decided server-side in `Grappa.Push.Triggers`) correctly stayed
+// silent. One preference, two answers. `pushTriggers.shouldNotify` was the
+// mirror of the server predicate but had NO live caller, which is exactly what
+// DESIGN_NOTES flagged on 2026-06-21: "cic has no global notification-prefs
+// signal to feed the full shouldNotify at message-arrival". This is that
+// signal.
+//
+// Same shape as `highlightList.ts` / `aliasList.ts`: the prefs live in server
+// user_settings with NO broadcast, so the signal only ever holds what the last
+// server round-trip returned and every writer feeds it the AUTHORITATIVE
+// response, never a locally-composed value (CLAUDE.md window-state invariant
+// family — cic never originates state).
+//
+// Identity-scoped: with no broadcast to self-heal it, a logout/account-switch
+// would otherwise leave the previous account's prefs deciding the new
+// account's beeps. The reset returns the signal to
+// `DEFAULT_NOTIFICATION_PREFS`, which is byte-identical to the server's
+// `UserSettings.default_notification_prefs/0` — so an un-hydrated client
+// behaves like a subject who never touched their settings, rather than like a
+// subject who muted everything.
+
+import { createSignal } from "solid-js";
+import { token } from "./auth";
+import { identityScopedStore } from "./identityScopedStore";
+import {
+  DEFAULT_NOTIFICATION_PREFS,
+  getNotificationPrefs,
+  type NotificationPrefs,
+} from "./userSettings";
+
+const exports_ = identityScopedStore((onIdentityChange) => {
+  const [notificationPrefs, setNotificationPrefs] = createSignal<NotificationPrefs>(
+    DEFAULT_NOTIFICATION_PREFS,
+  );
+
+  // Logout / account switch — back to the server's own defaults.
+  onIdentityChange(() => setNotificationPrefs(DEFAULT_NOTIFICATION_PREFS));
+
+  // Adopt a prefs map the SERVER returned (a GET body or a PUT's normalized
+  // echo). Not a setter for client-composed values: the settings drawer owns
+  // the form state and hands over only what came back over the wire.
+  const mirrorNotificationPrefs = (prefs: NotificationPrefs): void => {
+    setNotificationPrefs(prefs);
+  };
+
+  // Fetch the current prefs and mirror them. Called on every user-topic
+  // (re)join alongside the highlight-list and alias hydrates.
+  const refreshNotificationPrefs = async (): Promise<NotificationPrefs> => {
+    const t = token();
+    if (t === null) throw new Error("no session");
+    const prefs = await getNotificationPrefs(t);
+    setNotificationPrefs(prefs);
+    return prefs;
+  };
+
+  return { notificationPrefs, mirrorNotificationPrefs, refreshNotificationPrefs };
+});
+
+export const notificationPrefs = exports_.notificationPrefs;
+export const mirrorNotificationPrefs = exports_.mirrorNotificationPrefs;
+export const refreshNotificationPrefs = exports_.refreshNotificationPrefs;

--- a/cicchetto/src/lib/pushTriggers.ts
+++ b/cicchetto/src/lib/pushTriggers.ts
@@ -25,7 +25,7 @@
 import { type MessageKind, NOTIFY_KINDS } from "./api";
 import { canonicalChannel } from "./channelKey";
 import { matchesWatchlist } from "./mentionMatch";
-import { asciiFold } from "./nickEquals";
+import { asciiFold, nickEquals } from "./nickEquals";
 import type { NotificationPrefs } from "./userSettings";
 
 // Minimal structural shape the predicate needs — a subset of the wire
@@ -46,10 +46,11 @@ export type ShouldNotifyMessage = {
  *   1. kind gate — only the shared `NOTIFY_KINDS` SSOT (privmsg|action,
  *      the "notify" subset of api's CONTENT_KINDS, #395) → everything else
  *      false. NOTICE (services chatter) counts as unread but never notifies.
- *   2. DM (channel === ownNick): private_messages_all OR
+ *   2. own row (#532 C) — a row this operator authored never notifies.
+ *   3. DM (channel folds to ownNick): private_messages_all OR
  *      asciiFold(sender) in private_messages_only (mirrors the
- *      server's `canonical_nick(sender) in ...`).
- *   3. channel: channel_messages_all OR canonicalChannel(channel) in
+ *      server's `canonical_target(sender) in ...`).
+ *   4. channel: channel_messages_all OR canonicalChannel(channel) in
  *      channel_messages_only OR (channel_mentions AND mention).
  */
 export function shouldNotify(
@@ -64,7 +65,25 @@ export function shouldNotify(
   // convention as `wireNarrow.ts`.
   if (!NOTIFY_KINDS.has(message.kind as MessageKind)) return false;
 
-  if (message.channel === ownNick) {
+  // #532 C, #868 — "is this row mine?" decided by sender IDENTITY, and asked
+  // BEFORE the window-shape test below. An OUTBOUND DM is persisted with
+  // `channel = peer` (only an INBOUND one carries `channel = own_nick`), so
+  // the shape test misroutes it to the channel branch, where the operator's
+  // own highlight patterns run over the operator's own body — self-notifying
+  // on every outgoing message that happens to contain their nick. The server
+  // has had this step since #532 C (`triggers.ex` `own_row?/2`); this port
+  // did not, and the shared fixture had no row that could see the gap.
+  if (nickEquals(message.sender, ownNick)) return false;
+
+  // Fold BOTH sides, mirroring the server's `dm?/2`. The `channel` KEY is
+  // folded at the persist boundary (`Message.canonicalize_channel/1`, #537)
+  // while `ownNick` is the RAW live nick off `net.nick` — so a raw `===`
+  // silently fails for any operator whose nick carries an uppercase letter,
+  // routing their inbound DMs into the channel branch. `canonicalChannel` is
+  // the client mirror of `Identifier.canonical_target/1` and folds a
+  // nick-shaped identifier exactly as it folds a channel (a sigil sits
+  // outside `A-Z`), which is why the same function serves both sides here.
+  if (canonicalChannel(message.channel) === canonicalChannel(ownNick)) {
     return dmMatch(message, prefs);
   }
   return channelMatch(message, prefs, ownNick, patterns);
@@ -89,8 +108,9 @@ function channelMatch(
   patterns: string[],
 ): boolean {
   return (
-    // canonicalChannel (sigil-gated ASCII fold), NOT a bare toLowerCase,
-    // mirroring the server's `Identifier.canonical_channel(channel) in
+    // canonicalChannel (the plain ASCII fold — #537 retired the sigil gate
+    // on both ports), NOT a bare toLowerCase, mirroring the server's
+    // `Identifier.canonical_target(channel) in
     // channel_messages_only` — the whitelist is stored channel-folded
     // (CASEMAPPING=ascii, A-Z only; #525). bahamut folds `A-Z` ONLY, so
     // `#Chan`/`#chan` are ONE channel but `#chan[1]` and `#chan{1}` are

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -8,6 +8,7 @@ import {
 } from "./api";
 import { token } from "./auth";
 import { type ChannelKey, channelKey, decodeChannelKey } from "./channelKey";
+import { identityMoved } from "./identityMoved";
 import { identityScopedStore } from "./identityScopedStore";
 import { getReadCursor, setReadCursor } from "./readCursor";
 import { getResumeCursor, recordSeen } from "./reconnectBackfill";
@@ -150,27 +151,14 @@ const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): Scrollba
   return dropCount > 0 ? rows.slice(dropCount) : rows;
 };
 
-// #788 — THE rule for every async verb in this module: an `await` can span an
-// identity transition, and a continuation that outlived its identity must do
-// NOTHING further. Not one request on the wire, not one write into the store.
+// #788 — how THE identity rule applies to this module. The predicate itself,
+// and why a continuation that outlived its identity must do nothing further
+// (the wire half and the store half), live in `identityMoved.ts`; below is
+// only what is specific to these verbs.
 //
-// `t` is the bearer the verb captured at entry — its identity, not merely its
-// credential. Re-read `token()` after the await and compare: if it moved, the
-// verb belongs to an identity that no longer exists here.
-//
-// Both halves of "nothing further" are load-bearing, which is why the check
-// sits after the await rather than in front of each REST call:
-//
-//   * the WIRE half is #788 proper. A request carrying a revoked bearer 401s
-//     at best; for a channel the NEW identity is not attached to it 404s, and
-//     the host's `http-404` fail2ban jail bans the client IP at the firewall.
-//     A routine account switch self-bans the operator — the #281 harm class,
-//     reached through a different door.
-//   * the STORE half is the same continuation without touching the network:
-//     the page it already fetched merges into a map the rotation just purged,
-//     so the new identity renders the old one's scrollback. A guard wrapped
-//     around the REST calls alone would not catch it — the poisoning happens
-//     between the resolved fetch and the next request.
+// The store half is why the check sits after the await rather than in front of
+// each REST call: a guard wrapped around the requests alone would not catch it
+// — the poisoning happens between the resolved fetch and the next request.
 //
 // So: eleven of this module's fifteen awaits are followed by this check, and
 // the bail is whatever "did nothing" means for that verb's return type. Two
@@ -197,12 +185,9 @@ const capScrollbackRing = (key: ChannelKey, rows: ScrollbackMessage[]): Scrollba
 //     running. Same for the `refreshScrollback` completion stamp, which would
 //     tell a spec that ITS backfill had landed.
 //
-// Not hoisted into `identityScopedStore`: that factory owns the identity
-// TRANSITION (fire the resets), while this owns a verb's own captured
-// identity, which the factory never sees. Sibling modules inline the same
-// comparison (`displayPrefs`, `customTheme`) to drop a stale RESPONSE; this is
-// the same predicate used one step earlier, to refuse a stale REQUEST.
-const identityMoved = (t: string): boolean => token() !== t;
+// The sibling adopters (`networks`, `displayPrefs`, `customTheme`) use the
+// same predicate to drop a stale RESPONSE; this module uses it one step
+// earlier, to refuse a stale REQUEST.
 
 const exports = identityScopedStore((onIdentityChange) => {
   const loadedChannels = new Set<ChannelKey>();

--- a/cicchetto/src/lib/shouldNotifyTruthTable.json
+++ b/cicchetto/src/lib/shouldNotifyTruthTable.json
@@ -290,5 +290,151 @@
     },
     "patterns": [],
     "expected": true
+  },
+  {
+    "name": "own row (#532 C): own channel message mentioning own nick never notifies",
+    "message": {
+      "kind": "privmsg",
+      "channel": "#sniffo",
+      "sender": "vjt",
+      "body": "vjt: note to self"
+    },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": true,
+      "private_messages_all": false,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
+    "name": "own row (#532 C): beats channel_messages_all — the identity gate runs FIRST",
+    "message": { "kind": "privmsg", "channel": "#sniffo", "sender": "vjt", "body": "hello all" },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": true,
+      "channel_messages_only": [],
+      "channel_mentions": false,
+      "private_messages_all": false,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
+    "name": "own row (#532 C): OUTBOUND DM is channel=peer, so only sender-identity catches it",
+    "message": {
+      "kind": "privmsg",
+      "channel": "alice",
+      "sender": "vjt",
+      "body": "vjt will be late"
+    },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": true,
+      "private_messages_all": false,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
+    "name": "own row (#532 C): self-msg (channel=own_nick, sender=own_nick) beats private_messages_all",
+    "message": { "kind": "privmsg", "channel": "vjt", "sender": "vjt", "body": "reminder" },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": false,
+      "private_messages_all": true,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
+    "name": "own row (#532 C): the sender-identity compare FOLDS case (VJT is still me)",
+    "message": {
+      "kind": "privmsg",
+      "channel": "#sniffo",
+      "sender": "VJT",
+      "body": "vjt: note to self"
+    },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": true,
+      "private_messages_all": false,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
+    "name": "own row (#532 C): a DIFFERENT sender is not me — the gate must not swallow real traffic",
+    "message": {
+      "kind": "privmsg",
+      "channel": "#sniffo",
+      "sender": "vjtx",
+      "body": "vjt: ping"
+    },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": true,
+      "private_messages_all": false,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": true
+  },
+  {
+    "name": "DM shape (#537): channel is stored FOLDED, so a mixed-case own_nick still routes to the DM branch",
+    "message": { "kind": "privmsg", "channel": "vjt", "sender": "alice", "body": "hello" },
+    "own_nick": "VJT",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": false,
+      "private_messages_all": true,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": true
+  },
+  {
+    "name": "DM shape (#537): a mis-routed DM would notify via channel_mentions the user never asked for",
+    "message": { "kind": "privmsg", "channel": "vjt", "sender": "alice", "body": "VJT: yo" },
+    "own_nick": "VJT",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": true,
+      "private_messages_all": false,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
+    "name": "DM shape (#537): a real channel is NOT a DM even when own_nick folds into its name",
+    "message": { "kind": "privmsg", "channel": "#vjt", "sender": "alice", "body": "hello" },
+    "own_nick": "VJT",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": false,
+      "private_messages_all": true,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": false
   }
 ]

--- a/cicchetto/src/lib/shouldNotifyTruthTable.json
+++ b/cicchetto/src/lib/shouldNotifyTruthTable.json
@@ -424,6 +424,34 @@
     "expected": false
   },
   {
+    "name": "channel fold is ASCII, not Unicode: #CAFÉ does not hit a #café whitelist entry (#525)",
+    "message": { "kind": "privmsg", "channel": "#CAFÉ", "sender": "alice", "body": "hello" },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": ["#café"],
+      "channel_mentions": false,
+      "private_messages_all": false,
+      "private_messages_only": []
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
+    "name": "sender fold is ASCII, not Unicode: CAFÉ does not hit a café whitelist entry (#525)",
+    "message": { "kind": "privmsg", "channel": "vjt", "sender": "CAFÉ", "body": "hello" },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": false,
+      "private_messages_all": false,
+      "private_messages_only": ["café"]
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
     "name": "DM shape (#537): a real channel is NOT a DM even when own_nick folds into its name",
     "message": { "kind": "privmsg", "channel": "#vjt", "sender": "alice", "body": "hello" },
     "own_nick": "VJT",

--- a/cicchetto/src/lib/subscribe.ts
+++ b/cicchetto/src/lib/subscribe.ts
@@ -10,7 +10,6 @@ import { isDocumentVisible } from "./documentVisibility";
 import { highlightPatterns } from "./highlightList";
 import { seedIsupport } from "./isupport";
 import { applyPresenceEvent, seedMembers } from "./members";
-import { matchesWatchlist } from "./mentionMatch";
 import { setServerMention } from "./mentions";
 import { moduleRoot } from "./moduleRoot";
 import {
@@ -22,9 +21,11 @@ import {
   user,
 } from "./networks";
 import { nickEquals } from "./nickEquals";
+import { notificationPrefs } from "./notificationPrefs";
 import { isOperatorActionEcho } from "./operatorActionEcho";
 import { isOwnPresenceEvent } from "./ownPresenceEvent";
 import { resolvePing } from "./pingCorrelation";
+import { shouldNotify } from "./pushTriggers";
 import { setEnsureQueryTopicJoined } from "./queryTopicJoin";
 import { canonicalQueryNick, queryWindowsByNetwork } from "./queryWindows";
 import { renameRailWhois } from "./railWhois";
@@ -286,58 +287,48 @@ moduleRoot(() => {
     // sidebar badge gate and the in-pane unread-marker stay aligned.
     if (isOperatorActionEcho(message)) return;
 
-    // Live mention alert (beep + optimistic PWA badge) — PRIVMSGs whose body
-    // matches the operator's watchlist (own nick ∪ /hilight keywords), on a
-    // non-effectively-focused window, not from own nick.
+    // Live notify alert (beep + optimistic PWA badge), for every window shape
+    // this function routes — channels, query windows, and the DM listener.
     //
-    // #267 — the mention COUNT is no longer bumped here. It is
-    // server-authoritative (`mentions.ts`, seeded by /me + join_reply and
-    // pushed on every new message + cursor advance via the `window_counts`
-    // event), so the client-side count regex is gone — that regex never
-    // rebuilt on reconnect / across tabs, the bug #267 fixes. What stays
-    // is the LIVE alert: `matchesWatchlist` fires the in-app beep + the
-    // optimistic desktop-title badge bump the instant a match lands on an
-    // unfocused window, before the server's window_counts push round-trips.
-    // These are transient live cues, not the count of record.
+    // #267 — the mention COUNT is not bumped here. It is server-authoritative
+    // (`mentions.ts`, seeded by /me + join_reply and pushed on every new
+    // message + cursor advance via the `window_counts` event). What stays is
+    // the LIVE alert: the in-app beep + the optimistic desktop-title bump the
+    // instant a notify-worthy row lands on an unfocused window, before the
+    // server's window_counts push round-trips. Transient live cues, not the
+    // count of record.
     //
-    // #370 — the SAME `matchesWatchlist` predicate the in-message visual
-    // highlight uses (own nick = just another entry in the watchlist source,
-    // NOT a special case). One notify path: a custom keyword beeps + bumps
-    // exactly like an own-nick mention, matching the server SSOT
-    // `Grappa.Mentions.mentioned?/3` that already drives OS push + the count.
+    // #868 — the DECISION is `pushTriggers.shouldNotify`, the mirror of the
+    // server's `Grappa.Push.Triggers.should_notify?/4`, and no longer a bare
+    // `matchesWatchlist` call. It used to be: this path read NO preference at
+    // all, so `channel_mentions: false` still beeped, `private_messages_all:
+    // false` still beeped, an `action` the server DID push never moved the
+    // title, and `channel_messages_all: true` never beeped. The push and the
+    // title answered the same question differently. Routing both through one
+    // predicate is what makes a preference mean one thing.
+    //
+    // The own-echo and kind gates now live INSIDE the predicate (its `own_row`
+    // step and `NOTIFY_KINDS`), so they are not repeated here — repeating them
+    // is how the two ports drifted in the first place. `ownNick` is non-null
+    // on every handler that carries content (the sole `ownNick = null` handler
+    // is $server); the guard makes that explicit rather than relying on
+    // `nickEquals` returning false for a null side. `u` keeps a not-yet-loaded
+    // /me from deciding.
+    //
+    // Single decision site: the DM listener used to beep at its own call site
+    // as well, so a DM whose body contained the operator's nick fired twice.
     //
     // UX-6-L (2026-05-20): the beep complements the SW's
     // visibility-anywhere OS-notification suppression (`lib/pushDedup.ts`).
+    const u = untrack(user);
     if (
-      message.kind === "privmsg" &&
+      u &&
+      ownNick !== null &&
       !effectivelyFocused(slug, displayName) &&
-      !nickEquals(message.sender, ownNick)
+      shouldNotify(message, ownNick, notificationPrefs(), highlightPatterns())
     ) {
-      const u = untrack(user);
-      // #211 phase 7 — match on the PER-NETWORK own nick (`ownNick`, already
-      // threaded into this handler), NOT the retired identity-wide
-      // `displayNick(u)` (a visitor has no single nick now). Guard on `u`
-      // so a not-yet-loaded /me still skips.
-      //
-      // #370 — the own-echo suppression above (`!nickEquals(sender, ownNick)`)
-      // is only sound while `ownNick` is non-null here (nickEquals returns
-      // false on a null side). That holds on every path that reaches this
-      // PRIVMSG beep: channel/DM handlers install with `ownNick = net.nick`
-      // (a required non-null field) only once the user→networks→channels
-      // resource chain has resolved, and the sole `ownNick=null` handler
-      // ($server) carries no PRIVMSGs. If channels ever become joinable
-      // before /me resolves, or `net.nick` is relaxed to nullable, restore an
-      // explicit own-nick guard here.
-      if (u && matchesWatchlist(message.body, ownNick, highlightPatterns())) {
-        playBeep();
-        // Optimistic foreground badge bump so the desktop `document.title`
-        // moves the instant a mention lands on an unfocused window, before
-        // the server sync. The per-channel mention COUNT + the global badge
-        // are both server-authoritative (`window_counts` push +
-        // `read_cursor_set` badge_count); this only nudges the title early
-        // and self-heals on the next sync.
-        incrementBadge();
-      }
+      playBeep();
+      incrementBadge();
     }
   };
 
@@ -690,19 +681,16 @@ moduleRoot(() => {
             // this is the live-WS mirror of that single window key.
             const peer = canonicalQueryNick(networkId, message.sender);
             const senderKey = channelKey(slug, peer);
-            // UX-6-L (2026-05-20) — inbound DM is operator-targeted by
-            // definition; beep at the call site so routeMessage's
-            // signature stays narrow (DM-specific audio policy is a
-            // DM-listener concern, not a shared-routing concern).
-            // `effectivelyFocused` is the single-source focus predicate
-            // (see helper at top of createRoot); anchor on the peer's
-            // canonical window name.
-            //
-            // sender !== ownNick gate: own self-msg echoes ride this
-            // topic too; suppress the audible alert for own typing.
-            if (!nickEquals(message.sender, ownNick) && !effectivelyFocused(slug, peer)) {
-              playBeep();
-            }
+            // #868 — no beep at this call site any more. It used to live here
+            // "so routeMessage's signature stays narrow", but routeMessage
+            // already ran its own mention-path beep over the same row, so a DM
+            // mentioning the operator's nick beeped twice. Worse, this site
+            // decided "inbound DM is operator-targeted by definition" and so
+            // ignored `private_messages_all` / `private_messages_only`
+            // entirely, while the server's push obeyed them. routeMessage is
+            // now the single decision site and it asks the shared predicate,
+            // which routes this row into the DM branch by folded window shape
+            // exactly as `Grappa.Push.Triggers.dm?/2` does.
             routeMessage(slug, senderKey, peer, message, ownNick);
             return;
           }
@@ -733,11 +721,16 @@ moduleRoot(() => {
             // #372: canonical peer re-key — see the PRIVMSG/ACTION arm.
             const peer = canonicalQueryNick(networkId, message.sender);
             const senderKey = channelKey(slug, peer);
-            // UX-6-L (2026-05-20): peer NOTICEs are inbound DM-shaped
-            // traffic — same beep policy as the PRIVMSG/ACTION arm.
-            // The sender !== ownNick check above already gates this
-            // branch.
-            if (!effectivelyFocused(slug, peer)) playBeep();
+            // #868 — a peer NOTICE no longer beeps. UX-6-L gave it the same
+            // audio policy as a PRIVMSG on the grounds that it is inbound
+            // DM-shaped traffic, but NOTICE is deliberately outside
+            // `notify_kinds` on the server (services chatter is the dominant
+            // inbound NOTICE shape), so the phone stayed silent while the
+            // desktop beeped on the very same row. This is the one
+            // user-visible subtraction in #868: the window still takes the
+            // unread, only the tone is gone. If peer NOTICEs should be
+            // audible, that is a preference, not a hard-coded exception —
+            // which is #866's territory, not this refactor's.
             routeMessage(slug, senderKey, peer, message, ownNick);
             return;
           }

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -32,6 +32,7 @@ import { moduleRoot } from "./moduleRoot";
 import { setNamesReply } from "./namesModal";
 import { mutateNetworkNick, refetchChannels, refetchNetworks } from "./networks";
 import { nickEquals } from "./nickEquals";
+import { refreshNotificationPrefs } from "./notificationPrefs";
 import {
   applyPresenceChange,
   applyPresenceError,
@@ -1033,6 +1034,19 @@ moduleRoot(() => {
       // of a server-synced, cross-device alias layer.
       void refreshAliases().catch((err) =>
         console.warn("[userTopic] alias-list hydrate failed", err),
+      );
+      // #868 — hydrate the notification prefs on every user-topic (re)join,
+      // for the SAME reason as the two above: they live in server
+      // user_settings with NO broadcast, and the live notify path
+      // (`subscribe.ts` → `shouldNotify`) now reads them to decide the in-app
+      // beep and the optimistic `document.title` bump. Without this the store
+      // sits on `DEFAULT_NOTIFICATION_PREFS` for the whole session and a
+      // subject who muted channel mentions would keep hearing them until they
+      // opened the settings drawer. The signal defaults to the SERVER's own
+      // defaults, so a failed hydrate degrades to "behaves like a subject who
+      // never configured anything" — never to silence.
+      void refreshNotificationPrefs().catch((err) =>
+        console.warn("[userTopic] notification-prefs hydrate failed", err),
       );
     });
     channel.on("event", (raw: unknown) => {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -29493,3 +29493,55 @@ substrate side (`jail_db_write.sh`, re-run the installer, then the UI), and
 that is now written down in `docs/OPERATIONS.md` rather than fixed here.
 `infra/linux/` has no source-alias wrapper at all, so it has no equivalent
 gap to close.
+
+## 2026-08-05 — #837: one identity predicate, and the two guards nobody was holding
+
+`identityMoved` — "the identity that started this continuation is not the
+identity that will receive its result" — was written inline in four modules:
+`scrollback.ts` (#788), `networks.ts` (#818), `displayPrefs.ts`, and
+`customTheme.ts`. Consolidating them was filed as a timing decision, not a
+merit one, and this is the pickup.
+
+**The refactor was the smaller half.** #788 and #818 each shipped a test for
+their own guard; the other two had none. Deleting `if (token() !== t) return;`
+from `displayPrefs.ts` left all 4258 cases green, and the same deletion in
+`customTheme.ts` left them green too. Extracting one predicate over two
+unpinned call sites would have moved untested code from four places to one and
+bought nothing — the shared owner would have been just as free to be dropped,
+now in one edit instead of four. So the tests came first, and they are the
+deliverable the issue predicted they would be.
+
+**What those two guards actually hold**, which is more than the 401 on the
+wire. `displayPrefs`: subject A's prefs applied over B's freshly-loaded ones,
+and — on the `persisted: false` seed-up branch — a PUT under A's retired
+bearer, which is #281's fail2ban harm class. `customTheme`: `applyResolvedPair`
+paints `documentElement` AND writes the FOUC boot cache, so A's theme lands on
+B's screen and then survives the reload that would otherwise correct it.
+Neither is reachable by identity-TRANSITION cleanup — an A→B rotation never
+runs the logout-clear branch that the existing cross-account-bleed tests cover,
+and nothing cancels a request already on the wire. Each new case has a
+no-rotation control releasing the SAME held response, so a gate that stopped
+delivering it fails loudly instead of passing vacuously.
+
+**Placement: its own module, not `auth.ts`.** `auth.ts` owns `token`, so it
+looked like the owner. But 38 test files stub `../auth`, and a partial stub
+would then replace the guard with `undefined` — the rule under test would stop
+existing wherever a suite meant to control only the token. A separate module
+that imports `token` keeps the predicate real while still resolving through
+those mocks. Confirmed, not assumed: under the mutation below the #788 suite,
+which mocks `../auth` with its own Solid signal, goes red like the rest.
+Not folded into `identityScopedStore` either — that factory owns the identity
+TRANSITION (fire the resets), while this owns a verb's OWN captured identity,
+which the factory never sees. Complements, not duplicates.
+
+**Measured.** Neutering the shared predicate turns 9 cases red across exactly
+the four adopters and nothing else: scrollback 5, networks 1, displayPrefs 2,
+customTheme 1. Restored: 235 files / 4263 tests green.
+
+**Left standing.** The four sites adopted the predicate unchanged, so no
+variant surfaced and none was invented; a fifth await site that needs a
+DIFFERENT comparison has found a domain boundary worth saying out loud rather
+than a parameter worth adding. And the guard remains a per-verb habit, not a
+whole-module property: a new `await` that captures the token and skips the
+check reopens the defect for its own call path — one owner makes the rule
+greppable, it does not make it automatic.


### PR DESCRIPTION
Union of **#869 (#863)**, **#870 (#837)** and **#871 (#868)** — all three green and `CLEAN`
individually, cherry-picked onto current `origin/main` (`87be37a9`) so the combination gets gated
once, as a combination.

**Why a union rather than three merges.** Each PR's green attests to `branch + base`, never to
`branch + the other two branches about to land`. The three diffs touch **zero files in common** —
but textual non-overlap is not semantic independence, and all three touch the same client's async
and message-handling surface: #871 rewires `subscribe.ts`'s inbound decisions, #870 changes the
identity guard adopted by `scrollback.ts`/`networks.ts`, #869 changes what leaves the composer.
Three separate merges would each have been green and none would have asked whether they hold together.

All nine commits applied clean, in PR order:

- `#863` — a whitespace-only line no longer aborts the rest of a multi-line paste; the client now
  drops what the server counts as blank. The pre-existing `preserves a whitespace-only line` test was
  **inverted and renamed**, not deleted, with a comment recording that the intent was reversed.
- `#837` — one `identityMoved` predicate replaces four inline copies, plus the tests for the two sites
  (`displayPrefs`, `customTheme`) that had **no test holding their guard at all** — 0 of 17 and 0 of 36
  respectively caught the guard's removal before this.
- `#868` — the live notification path decides with the shared predicate instead of a bare watchlist
  match, the two ports stop diverging, and the parity fixture grows rows that can actually see them
  disagree.

Superseded PRs are closed by content at merge — the cherry-pick rewrites the SHAs, so GitHub cannot
close them by itself.