### PR TITLE
fix(#854): stop_session/2 keeps its post-condition, or says it failed

### DIFF
--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -82,11 +82,24 @@ defmodule Grappa.Session do
   # `stop_session/2` synchronisation budgets. The `:DOWN` window is the
   # OTP `terminate_child` round-trip plus a `terminate/2` callback ceiling;
   # the Registry-unregister window is the BEAM scheduler swap to drain the
-  # Registry process's own `{:DOWN, ...}` mailbox entry. 5s × 100 × 5ms is
-  # generous; in practice the budgets are exhausted in <10ms total.
+  # Registry process's own `{:DOWN, ...}` mailbox entry — a CORPSE-only
+  # wait since #854. A key held by a *live* pid is not cleanup lag, it is
+  # a supervisor restart that refilled the key, and no amount of polling
+  # frees it; pre-#854 the poll could not tell the two apart, so it burned
+  # its full 500 ms against a restarted session and then returned `:ok`
+  # with its post-condition unmet (measured: 63 leaked sessions across a
+  # 15-run batch, plateau band tracking this constant).
   @stop_down_timeout_ms 5_000
   @registry_unregister_attempts 100
   @registry_unregister_poll_ms 5
+
+  # How many times a stop re-terminates a key that a restart refilled
+  # under it. One round covers the measured case (an abnormal exit
+  # restarts the child exactly once); the spares cover a restart that
+  # lands after `flush_pending_restarts/0`. Bounded on purpose: a session
+  # respawning faster than we can stop it must end in a loud log, not an
+  # unbounded chase.
+  @stop_chase_rounds 3
 
   @typedoc """
   Tagged identifier for a session owner — a registered user or a
@@ -327,6 +340,14 @@ defmodule Grappa.Session do
   if any. Idempotent: returns `:ok` whether or not a session was
   registered for the key.
 
+  The post-condition is about the KEY, not about one pid: on return no
+  session is registered for `(subject, network_id)` — including one a
+  `:transient` restart spawned while the stop was running (#854). When
+  even that cannot be achieved (something respawns the session faster
+  than `@stop_chase_rounds` terminate rounds can remove it) the return
+  stays `:ok` — every caller pattern-matches it and none can recover —
+  but the unmet post-condition is a `Logger.error`, never silence.
+
   Used by `Grappa.Networks.Credentials.unbind_credential/2` to tear
   down the GenServer BEFORE the credential row is deleted (S29 H5).
   Without this, an unbind would leave the GenServer running with
@@ -381,111 +402,169 @@ defmodule Grappa.Session do
   end
 
   defp do_stop_session(subject, network_id) do
-    case whereis(subject, network_id) do
-      nil ->
+    stop_registered(subject, network_id, @stop_chase_rounds)
+  end
+
+  # The post-condition is about the KEY ("no session is registered for
+  # `(subject, network_id)`"), not about the pid we happened to look up.
+  # `Session.Server` is `restart: :transient`, so an abnormal exit — the
+  # 433 ladder's `{:client_exit, {:nick_rejected, 433, _}}` is the
+  # measured one (#854) — makes `Grappa.SessionSupervisor` restart the
+  # child, and the restarted child re-registers the SAME key from inside
+  # `GenServer.start_link/3`. Terminating one pid therefore does not free
+  # the key: each round re-reads the key and terminates whoever holds it
+  # now, and the last round says so out loud if the key is still taken.
+  defp stop_registered(subject, network_id, rounds_left) do
+    flush_pending_restarts()
+
+    case {whereis(subject, network_id), rounds_left} do
+      {nil, _} ->
         :ok
 
-      pid ->
-        # Monitor BEFORE terminate so we never miss the DOWN — even if
-        # the child dies between `whereis` and the monitor, the receive
-        # below gets an immediate DOWN with reason `:noproc`.
-        ref = Process.monitor(pid)
+      {pid, 0} ->
+        # CLAUDE.md "No silent-swallow at boundaries", and the sibling
+        # `:DOWN`-timeout path below already does exactly this. Pre-#854
+        # this case returned a bare `:ok`: a session survived its own
+        # tear-down and nothing anywhere said so.
+        Logger.error(
+          "stop_session post-condition FAILED — a session is STILL registered after " <>
+            "#{@stop_chase_rounds} terminate rounds; something keeps respawning it " <>
+            "(subject=#{inspect(subject)} network_id=#{network_id})",
+          pid: inspect(pid)
+        )
 
-        # `terminate_child` returns `:ok | {:error, :not_found}` for a
-        # `DynamicSupervisor` (the `:simple_one_for_one` error tag is
-        # impossible here — only plain Supervisor in legacy strategy
-        # mode emits it). The `:not_found` branch covers the race where
-        # the child died between `whereis` and this call; treat both
-        # branches as success since the post-condition (no session for
-        # the key) is what we promise. Pattern-match explicitly so an
-        # unexpected return shape from a future OTP would crash.
-        case DynamicSupervisor.terminate_child(Grappa.SessionSupervisor, pid) do
-          :ok -> :ok
-          {:error, :not_found} -> :ok
-        end
+        :ok
+
+      {pid, rounds} ->
+        terminate_and_await_down(pid, subject, network_id)
+        wait_until_unregistered(subject, network_id, pid, @registry_unregister_attempts)
+        stop_registered(subject, network_id, rounds - 1)
+    end
+  end
+
+  # A `GenServer.call` into the supervisor is a MAILBOX BARRIER: the
+  # supervisor handles its mailbox in order, so any `{:EXIT, child, _}` it
+  # has already received — i.e. any `:transient` restart already triggered
+  # — is fully applied before this returns, and the restarted child is
+  # registered by then (`Session.Server.start_link/1` registers under its
+  # `via` name INSIDE `GenServer.start_link/3`, so the supervisor is not
+  # done restarting until the key is taken). Without the barrier,
+  # `whereis/2` answers `nil` for a key a restart is about to refill
+  # microseconds later and the stop returns `:ok` having freed nothing
+  # (#854). `count_children/1` is the cheapest such call — the result is
+  # deliberately unused, the round-trip IS the point.
+  defp flush_pending_restarts do
+    _ = DynamicSupervisor.count_children(Grappa.SessionSupervisor)
+    :ok
+  end
+
+  defp terminate_and_await_down(pid, subject, network_id) do
+    # Monitor BEFORE terminate so we never miss the DOWN — even if
+    # the child dies between `whereis` and the monitor, the receive
+    # below gets an immediate DOWN with reason `:noproc`.
+    ref = Process.monitor(pid)
+
+    # `terminate_child` returns `:ok | {:error, :not_found}` for a
+    # `DynamicSupervisor` (the `:simple_one_for_one` error tag is
+    # impossible here — only plain Supervisor in legacy strategy
+    # mode emits it). The `:not_found` branch covers the race where
+    # the child died between `whereis` and this call; treat both
+    # branches as success since the post-condition (no session for
+    # the key) is what we promise. Pattern-match explicitly so an
+    # unexpected return shape from a future OTP would crash.
+    case DynamicSupervisor.terminate_child(Grappa.SessionSupervisor, pid) do
+      :ok -> :ok
+      {:error, :not_found} -> :ok
+    end
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _} -> :ok
+    after
+      @stop_down_timeout_ms ->
+        # A Session that refuses to die within the budget is a
+        # genuine bug (stuck `terminate/2`, runaway loop, link
+        # cycle). Surface it via Logger.error — silent timeout
+        # would leave the next `start_session/3` racing a zombie
+        # `:already_started` against the Registry. CLAUDE.md "Use
+        # infrastructure, don't bypass it." `:subject` and
+        # `:network_id` are NOT in the Logger metadata allowlist
+        # (see `config/config.exs`'s memory-pinned constraint —
+        # canonical session context uses `:user` = subject_label
+        # and `:network` = network_slug, threaded by
+        # `Log.set_session_context/2`). Inline into message body
+        # so allowlist stays tight.
+        Logger.error(
+          "session refused to die within #{@stop_down_timeout_ms}ms stop budget — " <>
+            "escalating to Process.exit :kill " <>
+            "(subject=#{inspect(subject)} network_id=#{network_id})",
+          pid: inspect(pid)
+        )
+
+        # spec-audit cascade hunt (2026-05-26): pre-fix the function
+        # demonitored and returned :ok WITHOUT killing the pid.
+        # CI run 26445436191 traced the AdminEventsTest cascade
+        # back here — visitor login_test's stop_session returned
+        # :ok despite the Session.Server still alive in
+        # reconnect-backoff (Client GenServer.call inside
+        # terminate/2 hangs ~5s on a wedged socket). The zombie
+        # then poisoned the SessionRegistry that the next
+        # singleton-lane test (AdminEventsTest) drains in setup,
+        # cascading 10+ unrelated failures.
+        #
+        # Fix: escalate to Process.exit/2 :kill — bypasses
+        # terminate/2, guarantees the pid dies. Re-wait briefly
+        # for the :DOWN so the Registry's own monitor cleanup
+        # has a chance to fire before we return, then proceed to
+        # wait_until_unregistered/3 below (which polls anyway).
+        #
+        # Note: this changes the post-condition of stop_session/2
+        # from "process MAY still be alive (with Logger.error
+        # noise) after 5s timeout" to "process WILL be dead". No
+        # caller relied on the zombie-alive case as a feature —
+        # the prior shape was always a bug.
+        Process.exit(pid, :kill)
 
         receive do
           {:DOWN, ^ref, :process, ^pid, _} -> :ok
         after
-          @stop_down_timeout_ms ->
-            # A Session that refuses to die within the budget is a
-            # genuine bug (stuck `terminate/2`, runaway loop, link
-            # cycle). Surface it via Logger.error — silent timeout
-            # would leave the next `start_session/3` racing a zombie
-            # `:already_started` against the Registry. CLAUDE.md "Use
-            # infrastructure, don't bypass it." `:subject` and
-            # `:network_id` are NOT in the Logger metadata allowlist
-            # (see `config/config.exs`'s memory-pinned constraint —
-            # canonical session context uses `:user` = subject_label
-            # and `:network` = network_slug, threaded by
-            # `Log.set_session_context/2`). Inline into message body
-            # so allowlist stays tight.
-            Logger.error(
-              "session refused to die within #{@stop_down_timeout_ms}ms stop budget — " <>
-                "escalating to Process.exit :kill " <>
-                "(subject=#{inspect(subject)} network_id=#{network_id})",
-              pid: inspect(pid)
-            )
-
-            # spec-audit cascade hunt (2026-05-26): pre-fix the function
-            # demonitored and returned :ok WITHOUT killing the pid.
-            # CI run 26445436191 traced the AdminEventsTest cascade
-            # back here — visitor login_test's stop_session returned
-            # :ok despite the Session.Server still alive in
-            # reconnect-backoff (Client GenServer.call inside
-            # terminate/2 hangs ~5s on a wedged socket). The zombie
-            # then poisoned the SessionRegistry that the next
-            # singleton-lane test (AdminEventsTest) drains in setup,
-            # cascading 10+ unrelated failures.
-            #
-            # Fix: escalate to Process.exit/2 :kill — bypasses
-            # terminate/2, guarantees the pid dies. Re-wait briefly
-            # for the :DOWN so the Registry's own monitor cleanup
-            # has a chance to fire before we return, then proceed to
-            # wait_until_unregistered/3 below (which polls anyway).
-            #
-            # Note: this changes the post-condition of stop_session/2
-            # from "process MAY still be alive (with Logger.error
-            # noise) after 5s timeout" to "process WILL be dead". No
-            # caller relied on the zombie-alive case as a feature —
-            # the prior shape was always a bug.
-            Process.exit(pid, :kill)
-
-            receive do
-              {:DOWN, ^ref, :process, ^pid, _} -> :ok
-            after
-              1_000 ->
-                # :kill is unmaskable; if we somehow still don't get
-                # :DOWN, the monitor itself is wedged (BEAM bug
-                # territory). Demonitor + proceed; downstream
-                # wait_until_unregistered/3 will surface the leak.
-                Process.demonitor(ref, [:flush])
-                :ok
-            end
+          1_000 ->
+            # :kill is unmaskable; if we somehow still don't get
+            # :DOWN, the monitor itself is wedged (BEAM bug
+            # territory). Demonitor + proceed; downstream
+            # wait_until_unregistered/3 will surface the leak.
+            Process.demonitor(ref, [:flush])
+            :ok
         end
-
-        # `Process.monitor` DOWN guarantees the process is dead, but
-        # `Grappa.SessionRegistry`'s OWN monitor on `pid` runs in the
-        # Registry process — it may not have unregistered the dead pid
-        # yet. Spin a tiny `Registry.lookup`-poll until the entry is
-        # gone or the budget expires; without this, callers chaining
-        # `stop_session/2` → `start_session/3` race a transient
-        # `:already_started` shape backed by a dead pid.
-        wait_until_unregistered(subject, network_id, @registry_unregister_attempts)
-        :ok
     end
   end
 
-  defp wait_until_unregistered(_, _, 0), do: :ok
+  # `Process.monitor` DOWN guarantees `stopped_pid` is dead, but
+  # `Grappa.SessionRegistry`'s OWN monitor on it runs in the Registry
+  # process — it may not have unregistered the corpse yet. Spin a tiny
+  # `Registry.lookup`-poll until the entry is gone or the budget expires;
+  # without this, callers chaining `stop_session/2` → `start_session/3`
+  # race a transient `:already_started` shape backed by a dead pid.
+  #
+  # #854: a DIFFERENT pid on the key is NOT that cleanup lag — it is a
+  # `:transient` restart that refilled the key while we were stopping its
+  # predecessor. Polling can never outlast a live holder, so return at
+  # once and let `stop_registered/3` terminate the newcomer. Pre-fix this
+  # clause was `_ ->` and the two cases were indistinguishable: the stop
+  # slept out its whole budget against a session that was very much alive,
+  # then reported success.
+  defp wait_until_unregistered(_subject, _network_id, _stopped_pid, 0), do: :ok
 
-  defp wait_until_unregistered(subject, network_id, attempts) do
+  defp wait_until_unregistered(subject, network_id, stopped_pid, attempts) do
     case whereis(subject, network_id) do
       nil ->
         :ok
 
-      _ ->
+      ^stopped_pid ->
         Process.sleep(@registry_unregister_poll_ms)
-        wait_until_unregistered(subject, network_id, attempts - 1)
+        wait_until_unregistered(subject, network_id, stopped_pid, attempts - 1)
+
+      _refilled_by_a_restart ->
+        :ok
     end
   end
 

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -552,7 +552,7 @@ defmodule Grappa.Session do
   # clause was `_ ->` and the two cases were indistinguishable: the stop
   # slept out its whole budget against a session that was very much alive,
   # then reported success.
-  defp wait_until_unregistered(_subject, _network_id, _stopped_pid, 0), do: :ok
+  defp wait_until_unregistered(_, _, _, 0), do: :ok
 
   defp wait_until_unregistered(subject, network_id, stopped_pid, attempts) do
     case whereis(subject, network_id) do
@@ -563,7 +563,7 @@ defmodule Grappa.Session do
         Process.sleep(@registry_unregister_poll_ms)
         wait_until_unregistered(subject, network_id, stopped_pid, attempts - 1)
 
-      _refilled_by_a_restart ->
+      _ ->
         :ok
     end
   end

--- a/test/grappa/session_stop_session_test.exs
+++ b/test/grappa/session_stop_session_test.exs
@@ -29,6 +29,7 @@ defmodule Grappa.SessionStopSessionTest.Holder do
   @registration_retry_ms 1
   @handshake_ms 1_000
 
+  @spec child_spec(map()) :: Supervisor.child_spec()
   def child_spec(opts) do
     %{
       id: {__MODULE__, opts.subject, opts.network_id, opts.generation},
@@ -37,6 +38,7 @@ defmodule Grappa.SessionStopSessionTest.Holder do
     }
   end
 
+  @spec start_link(map()) :: GenServer.on_start()
   def start_link(opts) do
     send(opts.observer, {:starting, opts.generation})
     Process.sleep(opts.register_delay_ms)
@@ -46,7 +48,7 @@ defmodule Grappa.SessionStopSessionTest.Holder do
   # The predecessor's Registry entry is cleaned asynchronously by the
   # Registry process, so a restart can legitimately lose the first
   # attempt at its own key. Retry rather than fail the whole start.
-  defp register(_opts, 0), do: {:error, :key_never_freed}
+  defp register(_, 0), do: {:error, :key_never_freed}
 
   defp register(opts, attempts) do
     case GenServer.start_link(__MODULE__, opts, name: Server.via(opts.subject, opts.network_id)) do
@@ -74,7 +76,7 @@ defmodule Grappa.SessionStopSessionTest.Holder do
   # Hand the key to a live stranger BEFORE dying, so the stopper's first
   # lookup after the `:DOWN` cannot mistake the situation for cleanup lag.
   @impl GenServer
-  def terminate(_reason, %{handoff: squatter} = opts) when is_pid(squatter) do
+  def terminate(_, %{handoff: squatter} = opts) when is_pid(squatter) do
     Registry.unregister(Grappa.SessionRegistry, Server.registry_key(opts.subject, opts.network_id))
     send(squatter, {:grab, self()})
 
@@ -85,7 +87,7 @@ defmodule Grappa.SessionStopSessionTest.Holder do
     end
   end
 
-  def terminate(_reason, %{refiller: refiller} = opts) when is_pid(refiller) do
+  def terminate(_, %{refiller: refiller} = opts) when is_pid(refiller) do
     send(refiller, {:refill, opts.generation + 1, self()})
 
     receive do
@@ -95,7 +97,7 @@ defmodule Grappa.SessionStopSessionTest.Holder do
     end
   end
 
-  def terminate(_reason, _opts), do: :ok
+  def terminate(_, _), do: :ok
 end
 
 defmodule Grappa.SessionStopSessionTest.Squatter do
@@ -118,6 +120,7 @@ defmodule Grappa.SessionStopSessionTest.Squatter do
 
   alias Grappa.Session.Server
 
+  @spec child_spec(map()) :: Supervisor.child_spec()
   def child_spec(opts) do
     %{
       id: {__MODULE__, opts.subject, opts.network_id},
@@ -126,6 +129,7 @@ defmodule Grappa.SessionStopSessionTest.Squatter do
     }
   end
 
+  @spec start_link(map()) :: GenServer.on_start()
   def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
 
   @impl GenServer
@@ -166,8 +170,7 @@ defmodule Grappa.SessionStopSessionTest do
   import ExUnit.CaptureLog
 
   alias Grappa.Session
-  alias Grappa.SessionStopSessionTest.Holder
-  alias Grappa.SessionStopSessionTest.Squatter
+  alias Grappa.SessionStopSessionTest.{Holder, Squatter}
 
   setup do
     subject = {:visitor, Ecto.UUID.generate()}
@@ -329,7 +332,7 @@ defmodule Grappa.SessionStopSessionTest do
 
   # The refill chain outlives a failed stop by design, so the singleton
   # supervisor must be left clean for the next test.
-  defp drain_key(_subject, _network_id, 0), do: :ok
+  defp drain_key(_, _, 0), do: :ok
 
   defp drain_key(subject, network_id, attempts) do
     case Session.whereis(subject, network_id) do

--- a/test/grappa/session_stop_session_test.exs
+++ b/test/grappa/session_stop_session_test.exs
@@ -1,0 +1,250 @@
+defmodule Grappa.SessionStopSessionTest.Holder do
+  @moduledoc """
+  A stand-in for `Grappa.Session.Server` that occupies a real
+  `Grappa.SessionRegistry` session key under the real
+  `Grappa.SessionSupervisor`, with the real `restart: :transient`
+  policy — the two ingredients #854 is about.
+
+  Two knobs make the restart race DETERMINISTIC instead of scheduler
+  luck:
+
+    * `:register_delay_ms` — `start_link/1` runs **in the supervisor's
+      own process**, so announcing `{:starting, generation}` before
+      sleeping proves the supervisor is *inside* a restart and cannot
+      answer any other call (including a `terminate_child/2` or a
+      `count_children/1`) until the restarted child has registered.
+
+    * `:refiller` — a process that starts the NEXT generation as a
+      supervisor child. The handshake happens inside `terminate/2`, i.e.
+      strictly BEFORE this child dies, so the refill call is enqueued at
+      the supervisor ahead of anything the stopper sends after observing
+      the `:DOWN`. This models an endless restart chase.
+  """
+
+  use GenServer, restart: :transient
+
+  alias Grappa.Session.Server
+
+  @registration_attempts 200
+  @registration_retry_ms 1
+  @refill_handshake_ms 1_000
+
+  def child_spec(opts) do
+    %{
+      id: {__MODULE__, opts.subject, opts.network_id, opts.generation},
+      start: {__MODULE__, :start_link, [opts]},
+      restart: :transient
+    }
+  end
+
+  def start_link(opts) do
+    send(opts.observer, {:starting, opts.generation})
+    Process.sleep(opts.register_delay_ms)
+    register(opts, @registration_attempts)
+  end
+
+  # The predecessor's Registry entry is cleaned asynchronously by the
+  # Registry process, so a restart can legitimately lose the first
+  # attempt at its own key. Retry rather than fail the whole start.
+  defp register(_opts, 0), do: {:error, :key_never_freed}
+
+  defp register(opts, attempts) do
+    case GenServer.start_link(__MODULE__, opts, name: Server.via(opts.subject, opts.network_id)) do
+      {:error, {:already_started, _}} ->
+        Process.sleep(@registration_retry_ms)
+        register(opts, attempts - 1)
+
+      other ->
+        other
+    end
+  end
+
+  @impl GenServer
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+    send(opts.observer, {:ready, opts.generation, self()})
+    {:ok, opts}
+  end
+
+  # Abnormal exit reason — exactly what `{:client_exit, {:nick_rejected,
+  # 433, _}}` is to the supervisor: a `:transient` restart trigger.
+  @impl GenServer
+  def handle_info(:crash, opts), do: {:stop, :boom, opts}
+
+  @impl GenServer
+  def terminate(_reason, %{refiller: nil}), do: :ok
+
+  def terminate(_reason, opts) do
+    send(opts.refiller, {:refill, opts.generation + 1, self()})
+
+    receive do
+      {:refilling, _} -> :ok
+    after
+      @refill_handshake_ms -> :ok
+    end
+  end
+end
+
+defmodule Grappa.SessionStopSessionTest do
+  @moduledoc """
+  #854 — `stop_session/2` promises a POST-CONDITION ("no session is
+  registered for this `(subject, network_id)`"), not an action ("I
+  terminated the pid I happened to see").
+
+  `Session.Server` is `restart: :transient`, so any abnormal exit —
+  the 433 ladder ending in `{:client_exit, {:nick_rejected, 433, _}}`
+  is the measured one — makes `Grappa.SessionSupervisor` restart the
+  child, and the restarted child re-registers the SAME registry key
+  inside its `GenServer.start_link/3`. A tear-down that reads the
+  Registry alone cannot see that restart: it either finds the key
+  momentarily free, or finds it refilled by a pid it never terminated.
+  Either way the session survives its own stop.
+
+  These tests use the real supervisor and the real `:transient` policy;
+  only the child module is a stand-in.
+  """
+
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Grappa.Session
+  alias Grappa.SessionStopSessionTest.Holder
+
+  setup do
+    subject = {:visitor, Ecto.UUID.generate()}
+    network_id = System.unique_integer([:positive])
+
+    on_exit(fn -> drain_key(subject, network_id, 20) end)
+
+    %{subject: subject, network_id: network_id}
+  end
+
+  describe "stop_session/2 post-condition" do
+    test "the key is free and the process dead for a session nobody restarts", ctx do
+      {:ok, pid} = start_holder(ctx, generation: 0, register_delay_ms: 0, refiller: nil)
+      assert_receive {:ready, 0, ^pid}, 1_000
+
+      log = capture_log(fn -> assert :ok = Session.stop_session(ctx.subject, ctx.network_id) end)
+
+      refute Process.alive?(pid)
+      assert Session.whereis(ctx.subject, ctx.network_id) == nil
+      refute log =~ "post-condition"
+    end
+
+    # The measured #854 defect. The restart is IN FLIGHT when the stop
+    # runs: the supervisor is blocked inside the restarted child's
+    # `start_link/1`, so the Registry answers `nil` for a key that is
+    # about to be refilled. Pre-fix `stop_session/2` returns `:ok` on
+    # that `nil` (or burns its 500 ms poll against the refilled key) and
+    # the restarted session outlives the tear-down that promised to
+    # remove it.
+    test "a :transient restart in flight does not survive stop_session/2", ctx do
+      {:ok, gen0} = start_holder(ctx, generation: 0, register_delay_ms: 50, refiller: nil)
+      assert_receive {:starting, 0}, 1_000
+      assert_receive {:ready, 0, ^gen0}, 1_000
+
+      send(gen0, :crash)
+
+      # Proves the supervisor is inside the restart, not that "enough
+      # time has passed": `start_link/1` emits this from the
+      # supervisor's own process before it registers the new child.
+      assert_receive {:starting, 0}, 1_000
+
+      assert :ok = Session.stop_session(ctx.subject, ctx.network_id)
+
+      assert_receive {:ready, 0, restarted}, 1_000
+
+      refute Process.alive?(restarted),
+             "the :transient restart survived stop_session/2 — the session key is held by a " <>
+               "live process the stop never terminated (#854)"
+
+      assert Session.whereis(ctx.subject, ctx.network_id) == nil
+    end
+
+    # The backstop. When the key keeps being refilled faster than the
+    # stop can free it, the failed post-condition MUST be loud —
+    # CLAUDE.md "No silent-swallow at boundaries", and the sibling
+    # `:DOWN`-timeout path 40 lines up already does exactly this.
+    # Pre-fix this returns `:ok` after ~500 ms with no log line at all,
+    # which is what let the defect live for months.
+    test "an unwinnable refill chase logs an error instead of a silent :ok", ctx do
+      refiller = start_refiller(ctx, max_generation: 4)
+
+      {:ok, gen0} = start_holder(ctx, generation: 0, register_delay_ms: 0, refiller: refiller)
+      assert_receive {:ready, 0, ^gen0}, 1_000
+
+      log = capture_log(fn -> assert :ok = Session.stop_session(ctx.subject, ctx.network_id) end)
+
+      assert log =~ "[error]"
+      assert log =~ "post-condition"
+      assert log =~ inspect(ctx.subject)
+    end
+  end
+
+  defp start_holder(ctx, opts) do
+    DynamicSupervisor.start_child(Grappa.SessionSupervisor, Holder.child_spec(holder_opts(ctx, opts)))
+  end
+
+  defp holder_opts(ctx, opts) do
+    %{
+      subject: ctx.subject,
+      network_id: ctx.network_id,
+      observer: self(),
+      generation: Keyword.fetch!(opts, :generation),
+      register_delay_ms: Keyword.fetch!(opts, :register_delay_ms),
+      refiller: Keyword.fetch!(opts, :refiller)
+    }
+  end
+
+  defp start_refiller(ctx, max_generation: max) do
+    test_pid = self()
+
+    spawn_link(fn ->
+      refill_loop(
+        fn generation ->
+          %{
+            subject: ctx.subject,
+            network_id: ctx.network_id,
+            observer: test_pid,
+            generation: generation,
+            register_delay_ms: 0,
+            refiller: self()
+          }
+        end,
+        max
+      )
+    end)
+  end
+
+  defp refill_loop(opts_fun, max) do
+    receive do
+      {:refill, generation, from} ->
+        send(from, {:refilling, generation})
+
+        if generation <= max do
+          _ = DynamicSupervisor.start_child(Grappa.SessionSupervisor, Holder.child_spec(opts_fun.(generation)))
+        end
+
+        refill_loop(opts_fun, max)
+
+      :stop ->
+        refill_loop(opts_fun, -1)
+    end
+  end
+
+  # The refill chain outlives a failed stop by design, so the singleton
+  # supervisor must be left clean for the next test.
+  defp drain_key(_subject, _network_id, 0), do: :ok
+
+  defp drain_key(subject, network_id, attempts) do
+    case Session.whereis(subject, network_id) do
+      nil ->
+        :ok
+
+      pid ->
+        _ = DynamicSupervisor.terminate_child(Grappa.SessionSupervisor, pid)
+        drain_key(subject, network_id, attempts - 1)
+    end
+  end
+end

--- a/test/grappa/session_stop_session_test.exs
+++ b/test/grappa/session_stop_session_test.exs
@@ -27,7 +27,7 @@ defmodule Grappa.SessionStopSessionTest.Holder do
 
   @registration_attempts 200
   @registration_retry_ms 1
-  @refill_handshake_ms 1_000
+  @handshake_ms 1_000
 
   def child_spec(opts) do
     %{
@@ -71,17 +71,74 @@ defmodule Grappa.SessionStopSessionTest.Holder do
   @impl GenServer
   def handle_info(:crash, opts), do: {:stop, :boom, opts}
 
+  # Hand the key to a live stranger BEFORE dying, so the stopper's first
+  # lookup after the `:DOWN` cannot mistake the situation for cleanup lag.
   @impl GenServer
-  def terminate(_reason, %{refiller: nil}), do: :ok
+  def terminate(_reason, %{handoff: squatter} = opts) when is_pid(squatter) do
+    Registry.unregister(Grappa.SessionRegistry, Server.registry_key(opts.subject, opts.network_id))
+    send(squatter, {:grab, self()})
 
-  def terminate(_reason, opts) do
-    send(opts.refiller, {:refill, opts.generation + 1, self()})
+    receive do
+      {:grabbed, ^squatter} -> :ok
+    after
+      @handshake_ms -> :ok
+    end
+  end
+
+  def terminate(_reason, %{refiller: refiller} = opts) when is_pid(refiller) do
+    send(refiller, {:refill, opts.generation + 1, self()})
 
     receive do
       {:refilling, _} -> :ok
     after
-      @refill_handshake_ms -> :ok
+      @handshake_ms -> :ok
     end
+  end
+
+  def terminate(_reason, _opts), do: :ok
+end
+
+defmodule Grappa.SessionStopSessionTest.Squatter do
+  @moduledoc """
+  A supervised child that takes the session key over from a `Holder`
+  that is dying — the stand-in for a restart that lands INSIDE
+  `stop_session/2`'s unregister poll, which is the #653 plateau: the
+  poll finds a LIVE pid on the key and, pre-#854, could not tell that
+  from the Registry's cleanup lag on the corpse it had just buried.
+
+  The hand-off is a handshake driven from the holder's `terminate/2`,
+  not a race for the key: the holder unregisters itself, this process
+  registers, and only then does the holder die. So the stopper's very
+  first post-`:DOWN` lookup is GUARANTEED to see a live stranger on the
+  key — the observation the plateau is made of — instead of it being a
+  coin toss with the Registry's cleanup.
+  """
+
+  use GenServer, restart: :temporary
+
+  alias Grappa.Session.Server
+
+  def child_spec(opts) do
+    %{
+      id: {__MODULE__, opts.subject, opts.network_id},
+      start: {__MODULE__, :start_link, [opts]},
+      restart: :temporary
+    }
+  end
+
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+  @impl GenServer
+  def init(opts), do: {:ok, opts}
+
+  @impl GenServer
+  def handle_info({:grab, from}, opts) do
+    {:ok, _} =
+      Registry.register(Grappa.SessionRegistry, Server.registry_key(opts.subject, opts.network_id), nil)
+
+    send(from, {:grabbed, self()})
+    send(opts.observer, {:squatted, self()})
+    {:noreply, opts}
   end
 end
 
@@ -110,6 +167,7 @@ defmodule Grappa.SessionStopSessionTest do
 
   alias Grappa.Session
   alias Grappa.SessionStopSessionTest.Holder
+  alias Grappa.SessionStopSessionTest.Squatter
 
   setup do
     subject = {:visitor, Ecto.UUID.generate()}
@@ -122,7 +180,7 @@ defmodule Grappa.SessionStopSessionTest do
 
   describe "stop_session/2 post-condition" do
     test "the key is free and the process dead for a session nobody restarts", ctx do
-      {:ok, pid} = start_holder(ctx, generation: 0, register_delay_ms: 0, refiller: nil)
+      {:ok, pid} = start_holder(ctx, generation: 0, register_delay_ms: 0, refiller: nil, handoff: nil)
       assert_receive {:ready, 0, ^pid}, 1_000
 
       log = capture_log(fn -> assert :ok = Session.stop_session(ctx.subject, ctx.network_id) end)
@@ -140,7 +198,7 @@ defmodule Grappa.SessionStopSessionTest do
     # the restarted session outlives the tear-down that promised to
     # remove it.
     test "a :transient restart in flight does not survive stop_session/2", ctx do
-      {:ok, gen0} = start_holder(ctx, generation: 0, register_delay_ms: 50, refiller: nil)
+      {:ok, gen0} = start_holder(ctx, generation: 0, register_delay_ms: 50, refiller: nil, handoff: nil)
       assert_receive {:starting, 0}, 1_000
       assert_receive {:ready, 0, ^gen0}, 1_000
 
@@ -171,7 +229,7 @@ defmodule Grappa.SessionStopSessionTest do
     test "an unwinnable refill chase logs an error instead of a silent :ok", ctx do
       refiller = start_refiller(ctx, max_generation: 4)
 
-      {:ok, gen0} = start_holder(ctx, generation: 0, register_delay_ms: 0, refiller: refiller)
+      {:ok, gen0} = start_holder(ctx, generation: 0, register_delay_ms: 0, refiller: refiller, handoff: nil)
       assert_receive {:ready, 0, ^gen0}, 1_000
 
       log = capture_log(fn -> assert :ok = Session.stop_session(ctx.subject, ctx.network_id) end)
@@ -179,6 +237,40 @@ defmodule Grappa.SessionStopSessionTest do
       assert log =~ "[error]"
       assert log =~ "post-condition"
       assert log =~ inspect(ctx.subject)
+    end
+
+    # The #653 plateau, and the ONLY test that constrains the poll's
+    # corpse-vs-refill discriminator: the squatter holds the key for the
+    # whole stop, so a poll that cannot tell it from cleanup lag sleeps
+    # out its entire budget (100 × 5 ms) before the chase can act.
+    test "the unregister poll does not sleep out its budget against a refilled key", ctx do
+      {:ok, squatter} =
+        DynamicSupervisor.start_child(
+          Grappa.SessionSupervisor,
+          Squatter.child_spec(%{subject: ctx.subject, network_id: ctx.network_id, observer: self()})
+        )
+
+      {:ok, gen0} =
+        start_holder(ctx, generation: 0, register_delay_ms: 0, refiller: nil, handoff: squatter)
+
+      assert_receive {:ready, 0, ^gen0}, 1_000
+
+      {elapsed_us, :ok} =
+        :timer.tc(fn -> Session.stop_session(ctx.subject, ctx.network_id) end)
+
+      assert_receive {:squatted, ^squatter}, 1_000
+
+      refute Process.alive?(gen0)
+      refute Process.alive?(squatter)
+      assert Session.whereis(ctx.subject, ctx.network_id) == nil
+
+      # Half an unregister budget. Measured ~5 ms once the poll stops
+      # waiting on a live holder; ~505 ms when it cannot tell one from a
+      # corpse — so the bound is not a timing guess, it sits 2× away from
+      # both the behaviour it allows and the one it rules out.
+      assert div(elapsed_us, 1_000) < 250,
+             "stop_session burned #{div(elapsed_us, 1_000)}ms — the unregister poll cannot " <>
+               "tell a Registry corpse from a key a restart refilled (#854/#653)"
     end
   end
 
@@ -193,7 +285,8 @@ defmodule Grappa.SessionStopSessionTest do
       observer: self(),
       generation: Keyword.fetch!(opts, :generation),
       register_delay_ms: Keyword.fetch!(opts, :register_delay_ms),
-      refiller: Keyword.fetch!(opts, :refiller)
+      refiller: Keyword.fetch!(opts, :refiller),
+      handoff: Keyword.fetch!(opts, :handoff)
     }
   end
 
@@ -209,7 +302,8 @@ defmodule Grappa.SessionStopSessionTest do
             observer: test_pid,
             generation: generation,
             register_delay_ms: 0,
-            refiller: self()
+            refiller: self(),
+            handoff: nil
           }
         end,
         max


### PR DESCRIPTION
Issue #854. The defect was measured while investigating the #653 plateau; this is the fix, the tests that see it, and the mutations proving they do.

## The cause, one level above the poll

`stop_session/2` promises *"no session is registered for `(subject, network_id)`"*. It was implemented as *"terminate the pid I looked up"*. Those are different statements while `Session.Server` is `restart: :transient`.

An abnormal exit — the 433 ladder's `{:client_exit, {:nick_rejected, 433, _}}` is the measured one — has `SessionSupervisor` restart the child, and the restarted child re-registers the **same** key from inside `GenServer.start_link/3`. So the tear-down monitored and terminated the pid it saw *before* the restart, then polled a key the restart had already refilled. The poll could not tell *"free"* from *"refilled by someone else"*: it burned all 100 attempts and returned `:ok` with its post-condition unmet **and not one line of log**.

Two doors, not one — the issue documented the second; the first fell out of writing the test:

1. the poll observes the live refill and sleeps out its budget (the #653 plateau);
2. the stop runs *while the restart is still in flight*, so the Registry answers `nil` for a key that is taken microseconds later, and the stop returns `:ok` having freed nothing.

Both need the same answer: **the key is the contract, not the pid.**

## The fix

- **A supervisor mailbox barrier before each key read.** A `count_children/1` round-trip: the supervisor handles its mailbox in order, so any `{:EXIT, child, _}` it already received is fully applied by the time it answers, and the restarted child is registered by then. This is what closes door 2 — the Registry alone cannot see a restart that has not registered yet.
- **The poll now knows which pid it buried.** Same pid = Registry cleanup lag, keep waiting. Different pid = a restart refilled the key, and no amount of waiting outlasts a live holder — return, and let the round loop terminate the newcomer. This closes door 1 and removes the plateau.
- **A bounded chase, and a `Logger.error` when the budget is spent with the key still taken.** CLAUDE.md *"No silent-swallow at boundaries"*, mirroring the sibling `:DOWN`-timeout path 40 lines up. That silence is what let this survive for months.

Return stays `:ok`: all 13 call sites pattern-match it and none can recover from a leaked session. Loud beats a MatchError storm.

## The tests, and the mutations that prove they see the defect

Real supervisor, real `:transient` policy; only the child is a stand-in. The restart race is made deterministic rather than raced: the child announces from `start_link/1`, which runs in the **supervisor's own process**, so the test knows the supervisor is *inside* a restart and cannot answer anything else until the key is retaken.

| mutation | result |
|---|---|
| barrier neutered | `a :transient restart in flight does not survive stop_session/2` — *the restart survived*; plus the loud-failure test |
| poll discriminator reverted | `the unregister poll does not sleep out its budget` — **687-823 ms** burned vs **0.9 ms**, i.e. the #653 plateau band, reproduced |
| `Logger.error` removed | `an unwinnable refill chase logs an error instead of a silent :ok` — captured log empty |

The first three tests were all **green** when the discriminator was reverted: the barrier absorbed every refill before the poll could see one, so four lines were shipping unconstrained. The fourth test exists because of that, and its first shape (a squatter *racing* the Registry cleanup) was a coin toss — 1 detection cold, 0 in 5 warm. The key is now **handed over** instead: the dying holder unregisters, the squatter registers, only then does the holder die.

`scripts/check.sh` green end to end: 5138 tests, dialyzer 0 errors, doctor, credo --strict, sobelow, bats. 15 consecutive repeats of the new file, 0 failures.

## What this does NOT claim

- **The production defect is measured; the fix is verified against a model of it.** These are unit tests over the real supervisor with a stand-in child — they do not re-run the 15-run visitor-login batch that produced the 63 leaked sessions.
- **Not addressed on purpose:** whether a 433-rejected `:transient` session should be restarted *at all*. With this fix the doomed restart is spawned and then removed — correct, but still wasted work, and the failed visitor login is only the loudest instance of the class (every abnormal death during a login races the same tear-down). Changing that is a restart-strategy decision on a documented invariant, not a boundary fix.
- **The chase bound (3 rounds) is not constrained by any test** — only its existence and its loud failure are. One round covers the observed holder, one a restart landing after the barrier, one is spare.