### PR TITLE
infra(#441): derive the shellcheck set, and give infra/linux its first tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,28 +101,39 @@ jobs:
         # arg wiring the bare runner doesn't need.
         run: vendor/bats-core/bin/bats test/bin/ test/infra/ test/scripts/
 
-      - name: Shellcheck + POSIX-lint deploy scripts (#503 anti-drift)
-        # The shared deploy lib (infra/lib/deploy_common.sh) MUST stay
-        # strict POSIX sh so dash can run it on the FreeBSD jail (/bin/sh).
-        # Lint the lib as sh, the three consumers with -x (they source the
-        # lib), and dash -n parse the POSIX pieces so a reintroduced
-        # bashism in the shared algorithm fails CI instead of silently
-        # breaking the jail deploy — the exact copy-paste-drift class #503
-        # exists to kill.
+      - name: Shellcheck every shell script under bin/ infra/ scripts/ (#441)
+        # DERIVED, not listed. The list this replaces named eleven paths by
+        # hand and had been correct exactly once: `infra/linux/install.sh` —
+        # the file whose defects filed #441 — was never on it, `bin/` was not
+        # linted at all, and the next script added would have been uncovered
+        # for the same reason. scripts/shellcheck.sh enumerates instead
+        # (`--list` prints the set), so coverage is a property of being a
+        # shell script rather than of someone remembering.
+        #
+        # The linter is a digest-pinned container, not the runner's
+        # preinstalled shellcheck: findings change between minors, so a
+        # laptop and whatever ubuntu-latest ships that month must not
+        # disagree about what "clean" means.
+        run: scripts/shellcheck.sh
+
+      - name: POSIX-parse the shared deploy lib + its sh consumers (#503)
+        # A DIFFERENT property from the lint above, with a different tool:
+        # the shared deploy lib (infra/lib/deploy_common.sh) must stay strict
+        # POSIX sh so dash can run it as the FreeBSD jail's /bin/sh. dash -n
+        # parses; shellcheck lints. A reintroduced bashism in the shared
+        # algorithm fails here instead of silently breaking the jail deploy —
+        # the copy-paste-drift class #503 exists to kill.
+        #
+        # Still a hand-written list, deliberately: #441 derived the SHELLCHECK
+        # set, and this one is not the same question — "which files must parse
+        # under dash" is a claim about where they run, and the honest
+        # derivation for it is a separate piece of work.
         run: |
-          shellcheck -s sh infra/lib/deploy_common.sh infra/docker/assert-abi-lockstep.sh infra/docker/release-entrypoint.sh infra/docker/get.sh
-          shellcheck -x infra/freebsd/deploy.sh infra/linux/deploy.sh scripts/deploy.sh infra/docker/deploy.sh
-          # The ONE secret generator (#862): three consumers now (postinstall,
-          # the release image's entrypoint, infra/docker/deploy.sh), so a
-          # bashism-free-but-broken edit must fail here, not on someone's box.
-          shellcheck -x infra/packaging/gen-secrets.sh
           dash -n infra/lib/deploy_common.sh
           dash -n infra/freebsd/deploy.sh
           dash -n infra/docker/assert-abi-lockstep.sh
           dash -n infra/docker/release-entrypoint.sh
           dash -n infra/docker/get.sh
-          # #665 cloud bootstrap + drift-guard (bash, not the POSIX-sh lib).
-          shellcheck -x infra/cloud/first-boot.sh infra/cloud/check-drift.sh
 
       - name: Cloud provider-door drift-guard (#665)
         # Prove every provider door (infra/aws today, infra/terraform later)

--- a/bin/grappa
+++ b/bin/grappa
@@ -38,6 +38,7 @@
 
 set -euo pipefail
 
+# shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/../scripts/_lib.sh"
 
 # Test seam: bats overrides SCRIPTS_DIR to point at a tmpdir with
@@ -139,6 +140,7 @@ rpc_eval() {
 
 die_unknown_verb() {
     printf 'bin/grappa: unknown verb %q\n' "$1" >&2
+    # shellcheck disable=SC2016  # backticks are literal prose in the message
     printf 'Run `bin/grappa help` for the full verb table.\n' >&2
     exit 64
 }
@@ -192,6 +194,7 @@ verb_remote_shell() {
         --batch)
             shift
             if [ "${1:-}" != "-e" ] || [ -z "${2:-}" ]; then
+                # shellcheck disable=SC2016  # backticks are literal prose
                 printf 'remote-shell --batch requires `-e <expr>`.\n' >&2
                 printf 'Usage: bin/grappa remote-shell --batch -e <expr>\n' >&2
                 exit 64

--- a/bin/grappa
+++ b/bin/grappa
@@ -345,7 +345,7 @@ help_top() {
     printf '    bin/grappa <verb> [args...]\n'
     printf '    bin/grappa help [verb]\n\n'
 
-    local group verb kind target g desc
+    local group verb g desc
     for group in "${GROUP_ORDER[@]}"; do
         printf '%s\n' "${GROUP_HEADERS[$group]}"
         # Iterate in insertion order via the GROUP_ORDER+VERBS pairing.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -29545,3 +29545,59 @@ than a parameter worth adding. And the guard remains a per-verb habit, not a
 whole-module property: a new `await` that captures the token and skips the
 check reopens the defect for its own call path — one owner makes the rule
 greppable, it does not make it automatic.
+## 2026-08-05 — #441: the shellcheck set is derived, and the first gate found two real defects
+
+`infra/linux` had no automated gate at all: `integration.yml` is path-filtered
+to `lib/ cicchetto/ config/ priv/ mix.*`, and `ci.yml`'s shellcheck step named
+**eleven paths by hand**. #503 later added `test/infra/` to the bats discovery
+set and `infra/linux/deploy.sh` to that list — but a hand list is a snapshot,
+not a gate. `infra/linux/install.sh`, the file whose defects filed this issue,
+was never on it. `bin/` was not linted at all.
+
+**Derived, not listed.** `scripts/shellcheck.sh` enumerates every regular file
+under `bin/`, `infra/`, `scripts/` that ends in `.sh` or opens with a shell
+shebang — 71 files against the old eleven. The shebang half is load-bearing:
+it picks up `bin/grappa`, `grappa-source-alias`, and the two `rc.d` services,
+which a `*.sh` glob cannot see. There is deliberately **no dialect table**:
+every script already declares its shell (shebang, or a `# shellcheck shell=`
+directive on the two sourced libs), and a table here would be a second place
+for that to drift — the removed defect, reintroduced one level down.
+
+**The linter is a digest-pinned container**, not the runner's preinstalled
+binary. shellcheck's findings change between minors, so a laptop and whatever
+`ubuntu-latest` ships that month otherwise disagree about what "clean" means,
+and the laptop's green is the one a contributor trusts before pushing. Same
+posture as the #103 base-image pins.
+
+**What the first run found.** 22 of 70 files failed, and only ONE was a
+defect. Fifteen were missing the `# shellcheck source=scripts/_lib.sh`
+directive that `scripts/deploy.sh` had carried all along; unfollowed,
+shellcheck also cannot see the lib's `set -euo pipefail`, so it reported every
+`cd "$REPO_ROOT"` as unguarded — one directive cleared both codes. Six were
+deliberate idioms, annotated at the site with the reason rather than dropped
+from the set: the `su -c '...'` bodies whose single quotes ARE the point,
+literal backticks in a printf'd help message, `CDPATH= cd`, and — file-wide on
+the two rc.d services — the four codes that ARE the rc.subr contract. The
+defect was two dead `local`s in `bin/grappa`'s `help_top`.
+
+**The more valuable finding came from the bats, not the linter.**
+`install.sh`'s comments say the 2026-07-22 incident was closed with "fail loud
+... rather than let a blank secret slip into the env file". It fails loud and
+writes the blank: `set_env_if_blank KEY "$(gen ...)"` puts the failure in
+ARGUMENT position, where `gen_raw`'s `exit 1` exits only the subshell and the
+enclosing command's status is `set_env_if_blank`'s — so neither `set -e` nor
+`pipefail` ever sees it, and the redundant second `| tail -n1` made even the
+substitution's status 0. Measured: with every generator failing, three secrets
+land blank; with ONLY `gen_encryption_key` failing, the script **exits 0**,
+starts the unit, passes its healthcheck and prints "grappa is up and healthy"
+with the Cloak vault keyed on the empty string. The single reason the first
+case aborted at all is VAPID's empty-check — the one empty-test in the file
+that sits outside a substitution. Fixed by capture-CHECK-write at all five
+generator sites, which is the shape the VAPID branch already used.
+
+**Left standing, deliberately.** The `dash -n` POSIX-parse list stays
+hand-written in its own step. "Which files must parse under dash" is a claim
+about where a file RUNS, not about what it is; deriving it honestly means
+deciding whether every `#!/bin/sh` script in the tree is jail-bound, and that
+is separate work. It is now labelled as such in the workflow rather than
+sitting there looking like the same list.

--- a/infra/freebsd/jail_cic_build.sh
+++ b/infra/freebsd/jail_cic_build.sh
@@ -18,6 +18,8 @@
 
 set -eu
 
+# shellcheck disable=SC2016  # the single quotes are the point: this body
+# is a script for the CHILD shell, where $PATH / $@ / $line resolve.
 exec su -l grappa -c '
 set -eu
 cd /home/grappa/grappa/cicchetto

--- a/infra/freebsd/jail_mix.sh
+++ b/infra/freebsd/jail_mix.sh
@@ -29,6 +29,8 @@ case "$0" in
 esac
 printf '%s\n' "$@" > "${ARGS_FILE}"
 
+# shellcheck disable=SC2016  # the single quotes are the point: this body
+# is a script for the CHILD shell, where $PATH / $@ / $line resolve.
 exec su -l grappa -c '
 set -eu
 export PATH=/usr/local/lib/erlang28/bin:$PATH

--- a/infra/freebsd/jail_release.sh
+++ b/infra/freebsd/jail_release.sh
@@ -36,6 +36,8 @@ case "$0" in
 esac
 printf '%s\n' "$@" > "${ARGS_FILE}"
 
+# shellcheck disable=SC2016  # the single quotes are the point: this body
+# is a script for the CHILD shell, where $PATH / $@ / $line resolve.
 exec su -l grappa -c '
 set -eu
 set -a

--- a/infra/freebsd/rc.d/grappa
+++ b/infra/freebsd/rc.d/grappa
@@ -1,5 +1,18 @@
 #!/bin/sh
 #
+# shellcheck disable=SC1091,SC2034,SC2223,SC3043
+# File-wide, and each code is the rc.subr CONTRACT rather than a defect:
+#   SC1091 — /etc/rc.subr exists on the FreeBSD host, never on the linter's.
+#   SC2034 — rcvar/pidfile/command/extra_commands/*_cmd are READ BY rc.subr
+#            after we set them; "unused here" is how the interface works.
+#   SC2223 — `: ${var:="default"}` is THE rc.d default-assignment idiom, used
+#            by every script under /usr/local/etc/rc.d.
+#   SC3043 — `local` is undefined in POSIX sh but real in FreeBSD's /bin/sh
+#            (ash), which is the only shell that ever runs this file, and
+#            rc.subr itself uses it.
+# Everything else stays linted: this mutes four known-idiomatic codes, not
+# the file (#441).
+#
 # PROVIDE: grappa
 # REQUIRE: NETWORKING SERVERS
 # KEYWORD: shutdown

--- a/infra/freebsd/rc.d/grappa_ndp_keepalive
+++ b/infra/freebsd/rc.d/grappa_ndp_keepalive
@@ -1,5 +1,15 @@
 #!/bin/sh
 #
+# shellcheck disable=SC1091,SC2034,SC2223
+# File-wide, and each code is the rc.subr CONTRACT rather than a defect:
+#   SC1091 — /etc/rc.subr exists on the FreeBSD host, never on the linter's.
+#   SC2034 — rcvar/pidfile/command/extra_commands/*_cmd are READ BY rc.subr
+#            after we set them; "unused here" is how the interface works.
+#   SC2223 — `: ${var:="default"}` is THE rc.d default-assignment idiom, used
+#            by every script under /usr/local/etc/rc.d.
+# Everything else stays linted: this mutes three known-idiomatic codes, not
+# the file (#441).
+#
 # PROVIDE: grappa_ndp_keepalive
 # REQUIRE: NETWORKING
 # KEYWORD: shutdown

--- a/infra/linux/install.sh
+++ b/infra/linux/install.sh
@@ -48,6 +48,7 @@ run_as_grappa() {
 
 # $HOME resolves to grappa's own home once run_as_grappa's `sudo -u
 # ... -H` has switched user — no need to look it up here.
+# shellcheck disable=SC2016  # deferred expansion is the point (see above)
 asdf_path_export='export PATH="$HOME/.local/bin:$HOME/.asdf/shims:$PATH"'
 
 say "1/11 install_prereqs.sh"
@@ -179,14 +180,44 @@ gen() {
 	gen_raw "$1" | tail -n1
 }
 
+# Capture, CHECK, then write — never `set_env_if_blank KEY "$(gen ...)"`.
+#
+# In argument position a command substitution's failure cannot stop this
+# script: `gen_raw`'s `exit 1` exits the SUBSHELL, and the enclosing command's
+# status is `set_env_if_blank`'s, so neither `set -e` nor `pipefail` ever sees
+# it. So the loud ERROR the comment above promises got printed and the blank
+# was written anyway. Worse than the noise: if the failing generator was not
+# the VAPID one (whose explicit empty-check below is OUTSIDE a substitution,
+# and is the only reason any of this ever aborted), the run continued to
+# `systemctl start` and exited 0 announcing a healthy host — with
+# GRAPPA_ENCRYPTION_KEY set to the empty string, i.e. a Cloak vault keyed on
+# nothing. Measured, #441.
+#
+# Assigning first makes the failure real (`set -euo pipefail` fires on the
+# assignment), and the emptiness check additionally catches a generator that
+# exits 0 with nothing to say — the shape that killed VAPID in 2026-07-24.
+require_nonempty() {
+	local key="$1" what="$2" value="$3"
+	if [ -z "${value}" ]; then
+		echo "[install] ERROR: '${what}' produced an empty ${key} — refusing to write a blank secret" >&2
+		exit 1
+	fi
+}
+
 if ! grep -qE "^SECRET_KEY_BASE=.+$" "${ENV_FILE}" || grep -qE "^SECRET_KEY_BASE=REPLACE_ME$" "${ENV_FILE}"; then
-	set_env_if_blank SECRET_KEY_BASE "$(gen 'mix phx.gen.secret' | tail -n1)"
+	secret_key_base="$(gen 'mix phx.gen.secret')"
+	require_nonempty SECRET_KEY_BASE 'mix phx.gen.secret' "${secret_key_base}"
+	set_env_if_blank SECRET_KEY_BASE "${secret_key_base}"
 fi
 if ! grep -qE "^SECRET_SIGNING_SALT=.+$" "${ENV_FILE}" || grep -qE "^SECRET_SIGNING_SALT=REPLACE_ME$" "${ENV_FILE}"; then
-	set_env_if_blank SECRET_SIGNING_SALT "$(gen 'mix phx.gen.secret 32' | tail -n1)"
+	signing_salt="$(gen 'mix phx.gen.secret 32')"
+	require_nonempty SECRET_SIGNING_SALT 'mix phx.gen.secret 32' "${signing_salt}"
+	set_env_if_blank SECRET_SIGNING_SALT "${signing_salt}"
 fi
 if ! grep -qE "^GRAPPA_ENCRYPTION_KEY=.+$" "${ENV_FILE}" || grep -qE "^GRAPPA_ENCRYPTION_KEY=REPLACE_ME$" "${ENV_FILE}"; then
-	set_env_if_blank GRAPPA_ENCRYPTION_KEY "$(gen 'mix grappa.gen_encryption_key' | tail -n1)"
+	encryption_key="$(gen 'mix grappa.gen_encryption_key')"
+	require_nonempty GRAPPA_ENCRYPTION_KEY 'mix grappa.gen_encryption_key' "${encryption_key}"
+	set_env_if_blank GRAPPA_ENCRYPTION_KEY "${encryption_key}"
 fi
 # Regeneration trigger checks BOTH keys, not just the public one — a
 # guard on VAPID_PUBLIC_KEY alone would leave a
@@ -220,7 +251,11 @@ if vapid_key_needs_gen VAPID_PUBLIC_KEY || vapid_key_needs_gen VAPID_PRIVATE_KEY
 	force_set_env VAPID_PRIVATE_KEY "${vapid_private}"
 fi
 if ! grep -qE "^RELEASE_COOKIE=.+$" "${ENV_FILE}" || grep -qE "^RELEASE_COOKIE=REPLACE_ME$" "${ENV_FILE}"; then
-	set_env_if_blank RELEASE_COOKIE "$(openssl rand -hex 32)"
+	# Same capture-check-write shape as the mix generators above: openssl in
+	# argument position could fail into a blank cookie just as silently.
+	release_cookie="$(openssl rand -hex 32)"
+	require_nonempty RELEASE_COOKIE 'openssl rand -hex 32' "${release_cookie}"
+	set_env_if_blank RELEASE_COOKIE "${release_cookie}"
 fi
 force_set_env DATABASE_PATH "${REPO_ROOT}/runtime/grappa_prod.db"
 force_set_env UPLOADS_STORAGE_ROOT "${REPO_ROOT}/runtime/uploads"

--- a/infra/packaging/version.sh
+++ b/infra/packaging/version.sh
@@ -25,7 +25,14 @@ set -eu
 
 # No `dirname --` / `cd --`: BSD dirname (the FreeBSD jail) doesn't accept the
 # end-of-options `--`, and $0 is always an invoked path (never starts with -).
+#
+# `CDPATH= cd` is an env-prefixed command (clear CDPATH for this cd only), not
+# a botched assignment — shellcheck's SC1007 heuristic cannot tell the two
+# apart, and the prefix form is the portable way to keep a user's CDPATH from
+# teleporting `cd` somewhere else and silently mis-rooting the repo.
+# shellcheck disable=SC1007
 SCRIPT_DIR="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1007
 REPO_ROOT="$(CDPATH= cd "${SCRIPT_DIR}/../.." && pwd)"
 
 # `head -1` + `tr -d` strips any trailing newline / CR the file carries so the

--- a/scripts/bun.sh
+++ b/scripts/bun.sh
@@ -34,6 +34,7 @@
 # /tmp is a tmpfs so bun's tempdir writes succeed under the dropped
 # UID (the image's default /tmp is root-owned).
 
+# shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
 
 # oven/bun image, digest-pinned (#103 supply-chain: `oven/bun:1` is a

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -33,6 +33,7 @@
 #
 # Canonical "which test runner do I use?" docs: docs/TESTING.md.
 
+# shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
 
 cd "$REPO_ROOT"

--- a/scripts/credo.sh
+++ b/scripts/credo.sh
@@ -10,6 +10,7 @@
 # Pins MIX_ENV=dev via scripts/mix.sh because credo is `only: [:dev, :test]`
 # and unavailable under MIX_ENV=prod (the typical live-container env).
 
+# shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
 
 cd "$REPO_ROOT"

--- a/scripts/db.sh
+++ b/scripts/db.sh
@@ -9,6 +9,7 @@
 # Defaults to dev when not set. Prod DBs open read-only via WAL-safe
 # attach.
 
+# shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
 
 cd "$REPO_ROOT"

--- a/scripts/deploy-cic.sh
+++ b/scripts/deploy-cic.sh
@@ -27,6 +27,7 @@
 
 set -euo pipefail
 
+# shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
 
 # #364 docker S10: assert main-checkout + main-branch BEFORE the dist

--- a/scripts/dialyzer.sh
+++ b/scripts/dialyzer.sh
@@ -13,6 +13,7 @@
 # Pins MIX_ENV=dev via scripts/mix.sh because dialyxir is
 # `only: [:dev, :test]` and unavailable under MIX_ENV=prod.
 
+# shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
 
 cd "$REPO_ROOT"

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -9,6 +9,7 @@
 # dev-tooling family — `.formatter.exs` may pull dev-only formatter
 # plugins in the future.
 
+# shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
 
 cd "$REPO_ROOT"

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -8,6 +8,7 @@
 # this probes grappa directly. The probe runs from INSIDE the container, so
 # it's independent of host port binding.
 
+# shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
 
 cd "$REPO_ROOT"

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -29,6 +29,7 @@
 
 set -euo pipefail
 
+# shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
 
 E2E_DIR="$SRC_ROOT/cicchetto/e2e"

--- a/scripts/mix.sh
+++ b/scripts/mix.sh
@@ -17,6 +17,7 @@
 # anywhere else it's passed through verbatim to mix (which will likely
 # reject it). Predictable parse path > flexible parse path.
 
+# shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
 
 cd "$REPO_ROOT"

--- a/scripts/monitor.sh
+++ b/scripts/monitor.sh
@@ -6,6 +6,7 @@
 #   scripts/monitor.sh -n 200         # custom line count
 #   scripts/monitor.sh --since 10m    # logs from 10 minutes ago
 
+# shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
 
 cd "$REPO_ROOT"

--- a/scripts/observer.sh
+++ b/scripts/observer.sh
@@ -30,6 +30,7 @@
 # Requires the dev image (MIX_ENV=dev): observer_cli is `only: [:dev]`, so
 # this does not work against a prod-profile container.
 
+# shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
 
 cd "$REPO_ROOT"

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -7,6 +7,7 @@
 # Use for ad-hoc debugging. Don't add it to any docs flow — IEx is the
 # normal entry point (scripts/iex.sh).
 
+# shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
 
 cd "$REPO_ROOT"

--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# scripts/shellcheck.sh — the shell lint gate, over a DERIVED file set.
+#
+# Usage:
+#   scripts/shellcheck.sh          # lint everything, exit non-zero on a finding
+#   scripts/shellcheck.sh --list   # print the derived set and exit
+#
+# #441 — the gate this replaces was a HAND-WRITTEN list of eleven paths in
+# ci.yml. A hand list is not a gate, it is a snapshot: `infra/linux/install.sh`
+# — the file whose defects filed this issue — was never on it, and `bin/` was
+# not linted at all. The next script added would have been uncovered for the
+# same reason the last one was. So the set is DERIVED: every shell script under
+# the roots below is linted because it IS one, not because someone remembered.
+#
+# Membership rule, deliberately mechanical: a regular file under `bin/`,
+# `infra/`, or `scripts/` that either ends in `.sh` or opens with a shell
+# shebang. That picks up the four extensionless scripts a `*.sh` glob misses
+# (`bin/grappa`, `infra/freebsd/bin/grappa-source-alias`, the two
+# `infra/freebsd/rc.d/` services) and skips the non-shell files that live
+# alongside them (nginx.conf, the perl keepalive, PKGBUILD, the pacman
+# scriptlet — no shebang, sourced by pacman, not a shell program we ship).
+#
+# No per-file dialect table: every script already declares its own dialect,
+# via its shebang or (for the two sourced libs, which have none) a
+# `# shellcheck shell=` directive on line 1. shellcheck reads both. A table
+# here would be a second place for that to drift.
+#
+# `-x` (follow `source`) is on for everything: the repo's scripts are thin
+# consumers of `scripts/_lib.sh` and `infra/lib/deploy_common.sh`, and without
+# following them shellcheck cannot see `set -euo pipefail` and reports the
+# whole codebase's `cd "$REPO_ROOT"` as unguarded. Following needs a
+# `# shellcheck source=<repo-relative path>` directive at each `.` line whose
+# argument is computed (`. "$(dirname "$0")/_lib.sh"`) — those are part of the
+# gate, not decoration.
+#
+# The linter is a digest-pinned container, NOT the host binary, for the same
+# reason the base images are pinned (#103): shellcheck's findings change
+# between minors, so a laptop on 0.9 and a runner on whatever ubuntu-latest
+# ships that month disagree about what "clean" means — and the laptop's green
+# is the one you trust before pushing. One image, one verdict, both sides.
+#
+# Exit 0 = every derived script is clean. Exit 1 = a finding (or docker
+# missing — a gate that silently skips itself is worse than no gate).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# koalaman/shellcheck, digest-pinned (#103 supply-chain posture; the tag stays
+# for human readability). Refresh on an intentional bump:
+#   docker buildx imagetools inspect koalaman/shellcheck:vX.Y \
+#     --format '{{.Manifest.Digest}}'
+readonly SHELLCHECK_IMAGE="koalaman/shellcheck:v0.10.0@sha256:2097951f02e735b613f4a34de20c40f937a6c8f18ecb170612c88c34517221fb"
+
+readonly LINT_ROOTS=(bin infra scripts)
+
+# A shell script by extension, or by shebang for the extensionless ones.
+is_shell_script() {
+	local path="$1" first_line
+	case "$path" in
+	*.sh) return 0 ;;
+	esac
+	# A binary or empty file simply has no shell shebang to read.
+	IFS= read -r first_line < "$path" 2>/dev/null || return 1
+	[[ $first_line =~ ^#!.*[[:space:]/](sh|bash|dash|ksh)([[:space:]]|$) ]]
+}
+
+derive_set() {
+	local path
+	while IFS= read -r path; do
+		if is_shell_script "$path"; then printf '%s\n' "$path"; fi
+	done < <(find "${LINT_ROOTS[@]}" -type f | sort)
+}
+
+mapfile -t SCRIPTS < <(derive_set)
+
+if [ "${#SCRIPTS[@]}" -eq 0 ]; then
+	echo "shellcheck.sh: derived an EMPTY file set — the roots moved, or find failed" >&2
+	exit 1
+fi
+
+if [ "${1:-}" = "--list" ]; then
+	printf '%s\n' "${SCRIPTS[@]}"
+	exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+	echo "shellcheck.sh: docker is required (the linter is a pinned container)" >&2
+	exit 1
+fi
+
+echo "shellcheck.sh: linting ${#SCRIPTS[@]} derived shell scripts under ${LINT_ROOTS[*]}"
+docker run --rm -v "$REPO_ROOT:/mnt" -w /mnt "$SHELLCHECK_IMAGE" -x "${SCRIPTS[@]}"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -13,6 +13,7 @@
 #
 # Canonical "which test runner do I use?" docs: docs/TESTING.md.
 
+# shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
 
 cd "$REPO_ROOT"

--- a/test/bats_helpers.bash
+++ b/test/bats_helpers.bash
@@ -61,3 +61,27 @@ refute() {
 
     return 0
 }
+
+# Numeric permission bits of a file ("640"), on both userlands.
+#
+# NOT `stat -f '%Lp' f || stat -c '%a' f`. `-f` is the FORMAT flag on BSD
+# stat and `--file-system` on GNU stat, so on Linux that spelling asks for
+# filesystem status, treats the format string as a second file operand, and
+# exits non-zero — AFTER printing six lines of filesystem status to stdout.
+# `||` then appends the fallback's "640" to them, and the caller compares a
+# seven-line blob against "640". Measured on ubuntu:24.04 (GNU coreutils
+# 9.4): the assertion could not pass on a Linux runner, and was green on
+# the maintainer's darwin box only because BSD stat reads `-f` the other way.
+#
+# So: probe GNU FIRST (the failing spelling there is `-c`, which BSD rejects
+# as an illegal option without writing to stdout), and CAPTURE rather than
+# chain — a fallback must replace the first attempt's output, never be
+# concatenated onto it.
+file_mode() {
+    local mode
+    if mode="$(stat -c '%a' "$1" 2>/dev/null)"; then
+        printf '%s\n' "$mode"
+        return 0
+    fi
+    stat -f '%Lp' "$1"
+}

--- a/test/infra/cloud_first_boot_test.bats
+++ b/test/infra/cloud_first_boot_test.bats
@@ -139,10 +139,6 @@ EOF
     export PATH="$FAKE_DIR:$PATH"
 }
 
-mode_of() {  # GNU-first, BSD fallback (macOS runner) — matches the packaging probe.
-    stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
-}
-
 # ───────────────────────────── required knobs ────────────────────────────────
 
 @test "hard-fails when GRAPPA_DOMAIN is unset" {
@@ -274,7 +270,7 @@ mode_of() {  # GNU-first, BSD fallback (macOS runner) — matches the packaging 
 @test "relocks the env file to 0640 after rewriting it" {
     run "$FBSH"
     [ "$status" -eq 0 ]
-    [ "$(mode_of "$GRAPPA_ENV_FILE")" = "640" ]
+    [ "$(file_mode "$GRAPPA_ENV_FILE")" = "640" ]
 }
 
 # ───────────────────────────── nginx site ────────────────────────────────────

--- a/test/infra/deploy_docker_release_image_test.bats
+++ b/test/infra/deploy_docker_release_image_test.bats
@@ -90,7 +90,7 @@ EOF
     [ "$status" -eq 0 ]
 
     [ -f "$ENV_FILE" ]
-    [ "$(stat -c '%a' "$ENV_FILE" 2>/dev/null || stat -f '%Lp' "$ENV_FILE")" = "600" ]
+    [ "$(file_mode "$ENV_FILE")" = "600" ]
     grep -qE '^PHX_HOST=grappa\.example\.org$' "$ENV_FILE"
     grep -qE '^SECRET_KEY_BASE=.+' "$ENV_FILE"
     grep -qE '^SECRET_SIGNING_SALT=.+' "$ENV_FILE"

--- a/test/infra/install_linux_test.bats
+++ b/test/infra/install_linux_test.bats
@@ -1,0 +1,308 @@
+#!/usr/bin/env bats
+#
+# infra/linux/install.sh — the first-install orchestrator for the native
+# systemd substrate. #441: this file had NO automated gate of any kind. It is
+# also the file whose defects filed the issue, and its own comments record
+# three that reached a live host:
+#
+#   * 2026-07-22 — PHX_HOST stayed at the template's `grappa.example.org`
+#     forever, because the seed-if-blank writer saw the example value as
+#     "already set". Fixed by splitting force_set_env out; nothing pinned it.
+#   * 2026-07-24 — `mix grappa.gen_vapid` prints FOUR lines, and routing it
+#     through the single-line `gen` helper's `tail -n1` kept the last COMMENT
+#     and discarded both keys. The app then booted "fine" with Web Push
+#     silently dead, because an env var set to "" is not nil.
+#   * the tmp+mv rewrite in both env writers births a fresh inode under
+#     root's umask (0644 root:root), dropping the 0640 root:grappa the
+#     secrets need. Re-locked in both writers — twice, because the first fix
+#     missed force_set_env, which runs LAST.
+#
+# So the subject here is the ENV FILE, and every assertion is about its
+# CONTENTS or its MODE — the outcome an operator gets — never about which
+# helper was called in what order.
+#
+# Scope: the pure shell-side logic. Everything that needs a real host is
+# stubbed on PATH (sudo, mix, openssl, systemctl, curl) or replaced with a
+# recorder (the five sibling scripts install.sh delegates to by absolute
+# SCRIPT_DIR path), mirroring test/infra/deploy_linux_test.bats. `chown` is a
+# no-op because the suite does not run as root; `chmod` is deliberately NOT
+# stubbed, so the final mode assertion is a real stat of a real file.
+
+load ../bats_helpers
+
+setup() {
+    SRC_DIR="$BATS_TEST_DIRNAME/../../infra/linux"
+
+    FAKE_DIR="$BATS_TEST_TMPDIR/fake"
+    mkdir -p "$FAKE_DIR"
+
+    # Empty HOME: install.sh's run_as_grappa body prepends
+    # $HOME/.local/bin:$HOME/.asdf/shims to PATH, and a real asdf on the dev
+    # host would shadow the `mix` stub with a real toolchain.
+    export HOME="$BATS_TEST_TMPDIR/home"
+    mkdir -p "$HOME"
+
+    # ---- a checkout that already exists, so the clone branch is skipped ---
+    export REPO_ROOT="$BATS_TEST_TMPDIR/repo"
+    mkdir -p "$REPO_ROOT/.git" "$REPO_ROOT/infra/linux"
+    cp "$SRC_DIR/grappa.env.example" "$REPO_ROOT/infra/linux/grappa.env.example"
+
+    # ---- install.sh + recorders for the five delegates -------------------
+    INSTALL_DIR="$BATS_TEST_TMPDIR/installer"
+    mkdir -p "$INSTALL_DIR"
+    cp "$SRC_DIR/install.sh" "$INSTALL_DIR/install.sh"
+    chmod +x "$INSTALL_DIR/install.sh"
+    for stub in install_prereqs.sh install_toolchain.sh cic_build.sh \
+        install_systemd.sh install_nginx.sh; do
+        printf '#!/bin/sh\nexit 0\n' > "$INSTALL_DIR/$stub"
+        chmod +x "$INSTALL_DIR/$stub"
+    done
+
+    export ENV_FILE="$BATS_TEST_TMPDIR/grappa.env"
+    export GRAPPA_USER=grappa
+    export PHX_HOST=irc.test.example
+    export PORT=4444
+
+    # `mix` failure injection for the fail-loud case.
+    export MIX_GEN_RC=0
+    export MIX_GEN_RC_FILE="$BATS_TEST_TMPDIR/mix-gen-rc"
+
+    # ---- PATH stubs ------------------------------------------------------
+    # sudo -u grappa -H bash -c '<cmd>' → run <cmd> in-process, dropping the
+    # privilege flags. The stubs the body reaches read only ambient env.
+    cat > "$FAKE_DIR/sudo" <<'EOF'
+#!/bin/sh
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -u) shift 2 ;;
+        -H|-E|-n|-i|-s) shift ;;
+        --) shift; break ;;
+        -*) shift ;;
+        *) break ;;
+    esac
+done
+exec "$@"
+EOF
+
+    # mix: deterministic generators, in the REAL output shapes. gen_vapid
+    # prints four lines (two keys, two comments) — the 2026-07-24 shape that
+    # a tail -n1 silently reduced to a comment. A leading `warning:` line
+    # exercises the filter gen_raw applies.
+    cat > "$FAKE_DIR/mix" <<'EOF'
+#!/bin/sh
+# Failure injection is scoped to the GENERATORS. Failing every mix verb
+# would abort back at the build step and prove nothing about the
+# secrets bootstrap, which is what this models.
+case "$*" in
+    phx.gen.secret*|grappa.gen_*)
+        if [ -f "$MIX_GEN_RC_FILE" ]; then
+            echo "mix: the generator blew up" >&2
+            exit 1
+        fi
+        ;;
+esac
+case "$*" in
+    "phx.gen.secret 32")
+        echo "warning: the VM is running with native name encoding"
+        echo "SALT-thirty-two-chars-deterministic"
+        ;;
+    "phx.gen.secret")
+        echo "BASE-secret-key-deterministic"
+        ;;
+    "grappa.gen_encryption_key")
+        echo "CLOAK-key-deterministic"
+        ;;
+    "grappa.gen_vapid")
+        echo "VAPID_PUBLIC_KEY=PUB-deterministic"
+        echo "VAPID_PRIVATE_KEY=PRIV-deterministic"
+        echo "# paste both into your env file"
+        echo "# back the private key up"
+        ;;
+esac
+exit 0
+EOF
+
+    printf '#!/bin/sh\necho COOKIE-deterministic\n' > "$FAKE_DIR/openssl"
+
+    # chown: the suite is not root. chmod is NOT stubbed — the mode is the
+    # property under test.
+    printf '#!/bin/sh\nexit 0\n' > "$FAKE_DIR/chown"
+
+    # install(1): the -o/-g ownership needs root, the -m mode does not. Keep
+    # the mode, drop the ownership, so the created file's mode is real.
+    cat > "$FAKE_DIR/install" <<'EOF'
+#!/bin/sh
+mode=""
+dirmode=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -d) dirmode=1; shift ;;
+        -m) mode="$2"; shift 2 ;;
+        -o|-g) shift 2 ;;
+        --) shift; break ;;
+        -*) shift ;;
+        *) break ;;
+    esac
+done
+if [ "$dirmode" -eq 1 ]; then
+    mkdir -p "$@"
+    [ -n "$mode" ] && chmod "$mode" "$@"
+    exit 0
+fi
+src="$1"; dst="$2"
+cp "$src" "$dst"
+[ -n "$mode" ] && chmod "$mode" "$dst"
+exit 0
+EOF
+
+    printf '#!/bin/sh\nexit 0\n' > "$FAKE_DIR/systemctl"
+    printf '#!/bin/sh\nexit 0\n' > "$FAKE_DIR/curl"
+    printf '#!/bin/sh\nexit 0\n' > "$FAKE_DIR/git"
+
+    chmod +x "$FAKE_DIR"/*
+    export PATH="$FAKE_DIR:$PATH"
+}
+
+# All lines in the env file for KEY — plural on purpose: a writer that
+# appends without removing the old line leaves TWO, and the last one wins at
+# systemd load time while `grep -m1` would happily report the first.
+env_lines() {
+    grep -c "^$1=" "$ENV_FILE" || true
+}
+
+env_value() {
+    sed -n "s/^$1=//p" "$ENV_FILE" | tail -n1
+}
+
+file_mode() {
+    # BSD stat (macOS dev host) vs GNU stat (Linux CI).
+    stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1"
+}
+
+@test "a missing PHX_HOST aborts before anything is written (#441)" {
+    unset PHX_HOST
+
+    run "$BATS_TEST_TMPDIR/installer/install.sh"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"PHX_HOST is required"* ]]
+    refute test -f "$ENV_FILE"
+}
+
+@test "the operator's PHX_HOST and PORT replace the template's example values (#441)" {
+    # The 2026-07-22 live defect: grappa.env.example ships a NON-blank,
+    # non-REPLACE_ME `PHX_HOST=grappa.example.org`, so a seed-if-blank writer
+    # treats it as already configured and the host never changes.
+    run "$BATS_TEST_TMPDIR/installer/install.sh"
+    [ "$status" -eq 0 ]
+
+    [ "$(env_value PHX_HOST)" = "irc.test.example" ]
+    [ "$(env_value PORT)" = "4444" ]
+    # And exactly once each: the rewrite must REPLACE, not append beside the
+    # template line.
+    [ "$(env_lines PHX_HOST)" -eq 1 ]
+    [ "$(env_lines PORT)" -eq 1 ]
+}
+
+@test "every REPLACE_ME secret is filled in from its generator (#441)" {
+    run "$BATS_TEST_TMPDIR/installer/install.sh"
+    [ "$status" -eq 0 ]
+
+    [ "$(env_value SECRET_KEY_BASE)" = "BASE-secret-key-deterministic" ]
+    [ "$(env_value SECRET_SIGNING_SALT)" = "SALT-thirty-two-chars-deterministic" ]
+    [ "$(env_value GRAPPA_ENCRYPTION_KEY)" = "CLOAK-key-deterministic" ]
+    [ "$(env_value RELEASE_COOKIE)" = "COOKIE-deterministic" ]
+    refute grep -q 'REPLACE_ME' "$ENV_FILE"
+}
+
+@test "the VAPID pair lands whole, from a four-line generator (#441)" {
+    # The 2026-07-24 live defect: `mix grappa.gen_vapid` prints two keys and
+    # two comment lines, and the single-line `gen` helper's tail -n1 kept the
+    # last COMMENT. Both keys ended up empty, and `System.get_env || raise`
+    # never fired because "" is not nil — Web Push was silently dead.
+    run "$BATS_TEST_TMPDIR/installer/install.sh"
+    [ "$status" -eq 0 ]
+
+    [ "$(env_value VAPID_PUBLIC_KEY)" = "PUB-deterministic" ]
+    [ "$(env_value VAPID_PRIVATE_KEY)" = "PRIV-deterministic" ]
+    [ "$(env_lines VAPID_PUBLIC_KEY)" -eq 1 ]
+    [ "$(env_lines VAPID_PRIVATE_KEY)" -eq 1 ]
+    refute grep -qE '^VAPID_(PUBLIC|PRIVATE)_KEY=(#|$)' "$ENV_FILE"
+}
+
+@test "the finished env file is 0640, not the tmp+mv default (#441)" {
+    # Both writers rewrite via `grep -v > tmp && mv`, which births a fresh
+    # inode under root's umask and drops the mode the secrets need.
+    # force_set_env runs LAST (the config values), so the re-lock has to be
+    # in that one too — it was missing once.
+    run "$BATS_TEST_TMPDIR/installer/install.sh"
+    [ "$status" -eq 0 ]
+
+    [ "$(file_mode "$ENV_FILE")" = "640" ]
+}
+
+@test "a re-run keeps the secrets and still re-applies the config values (#441)" {
+    # Idempotency is the whole reason the two writers are separate: secrets
+    # are seed-once (regenerating them invalidates every stored credential),
+    # config is this-invocation-wins.
+    run "$BATS_TEST_TMPDIR/installer/install.sh"
+    [ "$status" -eq 0 ]
+    first_secret="$(env_value SECRET_KEY_BASE)"
+    first_vapid="$(env_value VAPID_PRIVATE_KEY)"
+
+    PHX_HOST=second.test.example PORT=5555 run "$BATS_TEST_TMPDIR/installer/install.sh"
+    [ "$status" -eq 0 ]
+
+    [ "$(env_value SECRET_KEY_BASE)" = "$first_secret" ]
+    [ "$(env_value VAPID_PRIVATE_KEY)" = "$first_vapid" ]
+    [ "$(env_value PHX_HOST)" = "second.test.example" ]
+    [ "$(env_value PORT)" = "5555" ]
+    [ "$(env_lines PHX_HOST)" -eq 1 ]
+}
+
+@test "ONE failing generator is enough to abort — no exit-0 with a blank key (#441)" {
+    # The severe half, measured on the pre-#441 script: with only
+    # gen_encryption_key failing, the VAPID belt-and-braces check (the one
+    # empty-test that sits OUTSIDE a command substitution) never fires, so
+    # nothing stopped the run. It printed its loud ERROR, wrote
+    # `GRAPPA_ENCRYPTION_KEY=`, started the unit, passed the healthcheck and
+    # exited 0 announcing a healthy host — with the Cloak vault keyed on the
+    # empty string. Loud and fail-OPEN is not fail-closed.
+    cat > "$FAKE_DIR/mix" <<'EOF'
+#!/bin/sh
+case "$*" in
+    grappa.gen_encryption_key) echo "mix: the generator blew up" >&2; exit 1 ;;
+    "phx.gen.secret 32") echo "SALT-thirty-two-chars-deterministic" ;;
+    "phx.gen.secret") echo "BASE-secret-key-deterministic" ;;
+    grappa.gen_vapid)
+        echo "VAPID_PUBLIC_KEY=PUB-deterministic"
+        echo "VAPID_PRIVATE_KEY=PRIV-deterministic"
+        ;;
+esac
+exit 0
+EOF
+    chmod +x "$FAKE_DIR/mix"
+
+    run "$BATS_TEST_TMPDIR/installer/install.sh"
+
+    [ "$status" -ne 0 ]
+    refute grep -qE '^GRAPPA_ENCRYPTION_KEY=$' "$ENV_FILE"
+}
+
+@test "a failing generator aborts loudly instead of writing a blank secret (#441)" {
+    # The third 2026-07-22 defect: the generator's stderr was discarded, so
+    # `set -e` aborted the script SILENTLY and three secrets had already been
+    # written as empty strings.
+    touch "$MIX_GEN_RC_FILE"
+
+    run "$BATS_TEST_TMPDIR/installer/install.sh"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"failed"* ]]
+    [[ "$output" == *"the generator blew up"* ]]
+    # Whatever it managed to write, it must not have left a blank secret
+    # behind for the operator to boot on.
+    if [ -f "$ENV_FILE" ]; then
+        refute grep -qE '^(SECRET_KEY_BASE|SECRET_SIGNING_SALT|GRAPPA_ENCRYPTION_KEY|VAPID_[A-Z]+_KEY)=$' "$ENV_FILE"
+    fi
+}

--- a/test/infra/install_linux_test.bats
+++ b/test/infra/install_linux_test.bats
@@ -174,11 +174,6 @@ env_value() {
     sed -n "s/^$1=//p" "$ENV_FILE" | tail -n1
 }
 
-file_mode() {
-    # BSD stat (macOS dev host) vs GNU stat (Linux CI).
-    stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1"
-}
-
 @test "a missing PHX_HOST aborts before anything is written (#441)" {
     unset PHX_HOST
 

--- a/test/infra/shellcheck_gate_test.bats
+++ b/test/infra/shellcheck_gate_test.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+#
+# scripts/shellcheck.sh — the DERIVED shell-lint gate (#441).
+#
+# The thing under test is the derivation, not shellcheck. A hand-written list
+# of eleven paths is what #441 is about: it silently omitted
+# `infra/linux/install.sh` (the file whose defects filed the issue) and all of
+# `bin/`, and would have omitted the next script added for the same reason. So
+# these cases pin two properties:
+#
+#   1. the RULE — membership follows from being a shell script, exercised in a
+#      sandbox tree so a new file can actually be added and observed;
+#   2. the REAL set — the specific files the old list forgot are in it now.
+#
+# Plus the anti-regression that matters most: ci.yml must invoke the script,
+# and must not go back to naming paths. A hand list re-added beside the
+# derived one would re-open the gap while looking like extra rigour.
+#
+# `--list` is used throughout rather than a real lint run: this suite is about
+# WHICH files the gate covers. Whether they are clean is the gate's own job,
+# and it needs docker, which bats here does not.
+
+load ../bats_helpers
+
+setup() {
+    GATE="$BATS_TEST_DIRNAME/../../scripts/shellcheck.sh"
+    CI_YML="$BATS_TEST_DIRNAME/../../.github/workflows/ci.yml"
+
+    # A sandbox repo with the same three roots, and the gate copied in: the
+    # script derives its own root from BASH_SOURCE, so the copy enumerates
+    # the sandbox and a case can add a file and see what happens.
+    SANDBOX="$BATS_TEST_TMPDIR/sandbox"
+    mkdir -p "$SANDBOX/bin" "$SANDBOX/infra/linux" "$SANDBOX/scripts"
+    cp "$GATE" "$SANDBOX/scripts/shellcheck.sh"
+    chmod +x "$SANDBOX/scripts/shellcheck.sh"
+    SANDBOX_GATE="$SANDBOX/scripts/shellcheck.sh"
+}
+
+@test "a NEW extensionless script with a shell shebang joins the set (#441)" {
+    # The whole point of deriving: nobody edits a list for this to be covered.
+    printf '#!/usr/bin/env bash\ntrue\n' > "$SANDBOX/infra/linux/newverb"
+    printf '#!/bin/sh\ntrue\n' > "$SANDBOX/bin/another"
+
+    run "$SANDBOX_GATE" --list
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"infra/linux/newverb"* ]]
+    [[ "$output" == *"bin/another"* ]]
+}
+
+@test "a NEW .sh joins the set even with no shebang at all (#441)" {
+    # The sourced libs (scripts/_lib.sh, infra/lib/deploy_common.sh) have no
+    # shebang — they declare their dialect with a `# shellcheck shell=`
+    # directive instead. The extension has to be enough on its own.
+    printf '# shellcheck shell=bash\ntrue\n' > "$SANDBOX/infra/linux/_helpers.sh"
+
+    run "$SANDBOX_GATE" --list
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"infra/linux/_helpers.sh"* ]]
+}
+
+@test "non-shell files under the same roots stay OUT (#441)" {
+    # These really do live beside the scripts: nginx.conf, the perl NDP
+    # keepalive, PKGBUILD. Sweeping them in would make the gate fail on files
+    # shellcheck cannot parse, and the pressure would be to shrink the set.
+    printf '# grappa — nginx config\nserver { }\n' > "$SANDBOX/infra/linux/nginx.conf"
+    printf '#!/usr/local/bin/perl\nprint "hi";\n' > "$SANDBOX/infra/linux/keepalive.pl"
+    printf '# Maintainer: someone\npkgname=grappa\n' > "$SANDBOX/infra/linux/PKGBUILD"
+
+    run "$SANDBOX_GATE" --list
+
+    [ "$status" -eq 0 ]
+    refute grep -q 'nginx.conf' <<<"$output"
+    refute grep -q 'keepalive.pl' <<<"$output"
+    refute grep -q 'PKGBUILD' <<<"$output"
+}
+
+@test "an empty derived set fails loud instead of passing vacuously (#441)" {
+    # A gate that lints nothing and exits 0 is the failure mode that hides a
+    # moved directory or a broken find.
+    rm -rf "${SANDBOX:?}/bin" "${SANDBOX:?}/infra"
+    mkdir -p "$SANDBOX/bin" "$SANDBOX/infra"
+    rm -f "$SANDBOX/scripts"/*.sh.bak
+    # Only the gate itself is left under scripts/, so remove it from view by
+    # running a copy from outside the enumerated roots.
+    mkdir -p "$SANDBOX/tools"
+    cp "$GATE" "$SANDBOX/tools/gate.sh"
+    chmod +x "$SANDBOX/tools/gate.sh"
+    rm -f "$SANDBOX/scripts/shellcheck.sh"
+
+    run "$SANDBOX/tools/gate.sh" --list
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"EMPTY file set"* ]]
+}
+
+@test "the real set covers what the hand-written list forgot (#441)" {
+    # The eleven-path list in ci.yml before #441 named neither of these.
+    # infra/linux/install.sh is the file the issue was filed about; bin/ was
+    # not linted at all; the rc.d services have no .sh extension.
+    run "$GATE" --list
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"infra/linux/install.sh"* ]]
+    [[ "$output" == *"infra/linux/install_systemd.sh"* ]]
+    [[ "$output" == *"bin/grappa"* ]]
+    [[ "$output" == *"infra/freebsd/rc.d/grappa"* ]]
+    # And it still covers everything the old list did name.
+    [[ "$output" == *"infra/lib/deploy_common.sh"* ]]
+    [[ "$output" == *"infra/cloud/first-boot.sh"* ]]
+    [[ "$output" == *"infra/packaging/gen-secrets.sh"* ]]
+}
+
+@test "the gate lints ITSELF (#441)" {
+    # A linter exempt from its own rule is the first file to rot.
+    run "$GATE" --list
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"scripts/shellcheck.sh"* ]]
+}
+
+@test "ci.yml runs the derived gate and names no shellcheck paths (#441)" {
+    # The regression this guards is not "shellcheck disappeared" — it is
+    # someone re-adding `shellcheck <some new file>` beside the derived run.
+    # That reads like extra care and quietly restores the two-sources-of-truth
+    # state the issue exists to end.
+    grep -q 'scripts/shellcheck.sh' "$CI_YML"
+
+    # Every shellcheck mention in the workflow must be the script, never a
+    # bare invocation with operands.
+    refute grep -nE '^[[:space:]]+shellcheck[[:space:]]' "$CI_YML"
+}


### PR DESCRIPTION
Closes the gap in #441: `infra/linux` had no automated gate at all, and what gate existed elsewhere was a hand-written list.

## Coverage, in counted files

| | before | after |
|---|---|---|
| shellcheck | **11** paths named by hand in `ci.yml` | **71** derived |
| `bin/` | not linted at all | 2 files |
| `infra/linux/install.sh` | never on the list | linted **and** 8 bats cases |
| bats | 301 | 316 |

The 60 newly-linted files include every `infra/linux/install_*.sh`, all 15 `infra/freebsd/jail_*.sh`, the whole of `infra/packaging/`, and the four extensionless scripts a `*.sh` glob cannot see (`bin/grappa`, `grappa-source-alias`, the two `rc.d` services).

## Derived, not listed

`scripts/shellcheck.sh` enumerates: a regular file under `bin/`, `infra/`, `scripts/` that ends in `.sh` **or** opens with a shell shebang. `--list` prints the set, so the coverage claim above is inspectable rather than asserted.

No dialect table — every script already declares its shell (shebang, or `# shellcheck shell=` on the two sourced libs). A table here would be a second place for that to drift, i.e. the removed defect one level down.

**The `dash -n` list stays hand-written**, in its own step, labelled as such. "Which files must parse under dash" is a claim about where a file *runs*, not about what it is; deriving it honestly is separate work and I did not smuggle it in.

## Old defects the gate found — both real, both in their own commit

**1. `bin/grappa` (`8d213db`)** — two dead `local`s in `help_top`. The only genuine lint defect of the 22 initial failures.

**2. `infra/linux/install.sh` (`8d26b08`) — the serious one, and it came from the bats, not the linter.** The file's comments say the 2026-07-22 incident was closed with *"fail loud … rather than let a blank secret slip into the env file."* It fails loud **and writes the blank**:

- every generator failing → `SECRET_KEY_BASE=`, `SECRET_SIGNING_SALT=`, `GRAPPA_ENCRYPTION_KEY=` all blank;
- **only `gen_encryption_key` failing → exit 0.** Unit started, healthcheck passed, `grappa is up and healthy` printed, Cloak vault keyed on the empty string.

Mechanism: `set_env_if_blank KEY "$(gen ...)"` puts the failure in *argument* position — `gen_raw`'s `exit 1` exits the subshell, the enclosing command's status is `set_env_if_blank`'s, so neither `set -e` nor `pipefail` sees it; the redundant second `| tail -n1` made even the substitution's status 0. The sole reason the first case aborted is VAPID's empty-check, the one empty-test outside a substitution. Fixed with capture-CHECK-write at all five generator sites — the shape the VAPID branch already used.

## What the other 21 failures were (none silently excluded)

- **15** missing the `# shellcheck source=scripts/_lib.sh` directive `scripts/deploy.sh` already carried. Unfollowed, shellcheck also cannot see the lib's `set -euo pipefail`, so it flagged every `cd "$REPO_ROOT"` (SC2164) — one directive cleared both.
- **6** deliberate idioms, annotated **at the site with the reason**, never dropped from the set: the `su -c '...'` bodies whose single quotes are the point; literal backticks in a printf'd help string; `CDPATH= cd`; and — file-wide on the two `rc.d` services — the four codes that *are* the rc.subr contract (`/etc/rc.subr` absent on a linter host, `*_cmd`/`rcvar` read by rc.subr, `: ${var:="x"}`, `local` in ash). Scoped to those codes; everything else in those files stays linted.

Happy to convert any of the rc.d mutes into per-line annotations or a fix if you'd rather — that block is the only judgement call here.

## Shellcheck version

Measured under **shellcheck 0.10.0**, digest-pinned (`koalaman/shellcheck:v0.10.0@sha256:2097951f…`) and used by CI too, so the runner's preinstalled binary no longer decides what "clean" means. Same posture as the #103 base-image pins; refresh recipe in the script header.

## Tests

`test/infra/install_linux_test.bats` (8) — every assertion is about the env file's **contents or mode**, never call order. Six characterize behaviour already correct (PHX_HOST required; the operator's host overwriting the template's `grappa.example.org`, the 2026-07-22 defect; the four-line VAPID generator landing whole, the 2026-07-24 one; the final **0640** after the `tmp+mv` rewrite that regressed twice; re-run keeps secrets, re-applies config). Two pin the fix — **red against the pre-fix script, green after**.

`test/infra/shellcheck_gate_test.bats` (7) — the derivation rule in a sandbox tree (a new extensionless shebang script joins; a `.sh` with no shebang joins; `nginx.conf`/`.pl`/`PKGBUILD` stay out; an empty set fails loud; the gate lints itself), plus the anti-regression: `ci.yml` must invoke the script and name no shellcheck paths. Proved non-vacuous by re-adding such a line — the case goes red.

## What I will not claim

- **`install.sh` was never executed end-to-end against a real host.** Every delegate, `sudo`, `mix`, `openssl`, `systemctl` and `curl` is stubbed. What only a real Debian install exercises — the toolchain build, systemd `Type=exec`, nginx — is still covered by nothing but a human.
- **`chown` is stubbed** (the suite is not root), so the *ownership* half of `root:grappa` is unverified. `chmod` is deliberately real, so the **mode** assertion is a genuine `stat`.
- **CI's shellcheck version was not measured, it was replaced.** I never established which version `ubuntu-latest` shipped; pinning makes the question moot rather than answering it.
- **The 60 newly-covered files are lint-clean, not correct.** shellcheck found one real defect in them; it is not a proof of anything else.
- **The rc.d mutes are a judgement call**, not a measurement. I read the four codes as rc.subr contract and wrote the reason down; I did not run those services.

## Test plan

- [x] `scripts/shellcheck.sh` — exit 0 over 71 derived files (shellcheck 0.10.0, pinned)
- [x] `scripts/bats.sh` (full set) — exit 0, **316 ok / 0 not ok** (was 301)
- [x] Mutation: 2 install.sh cases red against the pre-fix script, green after
- [x] Mutation: the `ci.yml` anti-regression case red when a bare `shellcheck <path>` line is re-added
- [ ] No Elixir gate run — no `lib/` change, and `scripts/check.sh` would take the COMPILE lane