### PR TITLE
auth(#766): the recovery set decides the door, not the factor that is armed

### DIFF
--- a/cicchetto/src/__tests__/auth.test.ts
+++ b/cicchetto/src/__tests__/auth.test.ts
@@ -167,6 +167,32 @@ describe("auth signal store", () => {
       expect(auth.token()).toBeNull();
     });
 
+    // #766 — the token and `totp_available` are no longer the same fact. The
+    // server hands out a challenge whenever the account can spend SOMETHING
+    // at that door, and for an account whose only remaining fallback is its
+    // recovery set that means a token with `totp_available: false`. The
+    // degrade must key on the token, because keying on `totp_available`
+    // rethrows and leaves an account with a valid code no way to type it.
+    it("degrades on a recovery-only challenge, where TOTP is unavailable", async () => {
+      const api = await import("../lib/api");
+      const { getPasskey } = await import("../lib/passkeys");
+      vi.mocked(api.login).mockResolvedValue({
+        two_factor_required: true as const,
+        passkey_options: { challenge_id: "pk-1", public_key: { challenge: "AQID" } },
+        totp_available: false,
+        challenge_token: "challenge-123",
+      });
+      vi.mocked(getPasskey).mockRejectedValue(new Error("Passkey authentication cancelled"));
+      const auth = await import("../lib/auth");
+
+      await expect(auth.login("alice", "secret")).resolves.toEqual({
+        kind: "totp",
+        challengeToken: "challenge-123",
+        passkeyError: new Error("Passkey authentication cancelled"),
+      });
+      expect(auth.token()).toBeNull();
+    });
+
     it("degrades to the TOTP challenge when the server rejects the assertion", async () => {
       // A rejected assertion (replayed challenge, expired ceremony) is a
       // ceremony failure like any other: the account still has a second

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -29545,3 +29545,80 @@ than a parameter worth adding. And the guard remains a per-verb habit, not a
 whole-module property: a new `await` that captures the token and skips the
 check reopens the defect for its own call path — one owner makes the rule
 greppable, it does not make it automatic.
+## 2026-08-05 — #766: the recovery set decides the door, not the factor that happens to be armed
+
+An account in passkey `second_factor` with TOTP disarmed held ten valid,
+armed recovery codes that no door would read. Both doors refused for their
+own reason: `PasskeyController.recover/2` matches only
+`%User{passkey_mode: :passwordless}` and everything else falls to the
+catch-all that records a throttle failure and answers `:invalid_two_factor`;
+the post-password door was offered only when `TOTP.enabled?/1`, and
+`TOTP.verify/3` rolls the whole exchange back with `:two_factor_not_enabled`
+when `totp_enabled_at` is nil. So the settings UI advertised a fallback that
+nothing on the server would honour.
+
+**The state is reachable through the supported UI path**, which is what
+makes it a defect rather than a curiosity: a passwordless account is the
+only mode that mints codes without TOTP, and switching it to second factor
+keeps them — `RecoveryCodes.drop_if_orphaned/1` deliberately counts
+`second_factor` as an armed factor. `Accounts.reset_totp/1` (the operator
+undo) reaches the same state from the other side.
+
+**Both halves of the fix ask about the SET, not about the factor.** The set
+is ONE flat account-level credential shared by every factor, so a door that
+keys on `passkey_mode` or on `TOTP.enabled?/1` is asking a question that was
+never about it. `Accounts.recovery_codes_armed?/1` now gates the
+post-password challenge alongside `TOTP.enabled?/1`, and
+`Accounts.verify_second_factor/3` spends a recovery code when TOTP is
+disarmed. The second branches on `TOTP.verify/3`'s own not-enabled answer
+rather than a `TOTP.enabled?/1` pre-check: one read decides, so a disarm
+racing the redemption cannot land between the question and the answer.
+
+**What was deliberately NOT widened, and why the issue's own text was not
+followed to the letter.** #766 proposed widening
+`PasskeyController.recover/2` to `second_factor`. That door mints a session
+from a recovery code ALONE. For a passwordless account this is the right
+trade — one factor in, one factor out, since password login is refused for
+the mode. For a `second_factor` account the password IS the first factor, so
+the same widening would have closed the lockout by demoting a two-credential
+account to a one-credential one, and it would have done so on an
+unauthenticated endpoint. The redemption a `second_factor` account gets is
+therefore the one a TOTP account already had: password first, code second,
+inside the existing `:totp_login` failure window. This also settles the
+"single passkey_mode-blind redemption path" the ruling preferred: the doors
+differ because the FACTOR COUNT differs, and collapsing them would be a
+downgrade dressed as a simplification.
+
+That refusal is pinned by a test rather than by this paragraph —
+`recovery_code_doors_test.exs` asserts that `/auth/passkeys/recover` still
+answers `invalid_two_factor` to a `second_factor` account, so a later
+"obvious" fix for the same issue fails the suite instead of quietly landing.
+
+**The guard is the class, not the instance.** The same file enumerates every
+state whose login demands a second factor — passwordless, second factor with
+and without TOTP, TOTP alone — and asserts each can spend an armed code and
+that the code is consumed by doing so. #766 was one row of that matrix; the
+matrix is the rule, so the next mode or factor added has a place that already
+fails if it strands its codes.
+
+**Throttle parity was measured, not asserted.** The widened branch shares
+`:totp_login` with the TOTP door: eleven attempts are refused even when the
+eleventh code is genuine, and the same code then opens the door once the
+counter is cleared — the second half is what stops the 429 from being
+satisfied by a code that was simply unredeemable. Both production halves
+were mutation-checked individually; each one reverted alone turns the suite
+red.
+
+**Nothing was destroyed and no teardown rule moved.** The first ruling on
+this issue was to clear the unusable codes; it was superseded once the
+lockout consequence was put in front of vjt — *"se sono ancora
+potenzialmente utilizzabili non vanno cancellati"*. The conservative line in
+`RecoveryCodes.drop_if_orphaned/1` stands unchanged and stops being a
+contradiction: the codes are preserved AND they can now be spent.
+
+**Adjacent, left standing, reported not fixed.**
+`Accounts.disable_totp/3` deletes the whole recovery set unconditionally
+rather than going through `drop_if_orphaned/1`, so a user who disables TOTP
+while passkey `second_factor` is armed loses the fallback that rule says to
+keep — the mirror image of this issue, and a teardown change, which this
+issue explicitly froze.

--- a/lib/grappa/accounts.ex
+++ b/lib/grappa/accounts.ex
@@ -682,6 +682,45 @@ defmodule Grappa.Accounts do
     end
   end
 
+  @doc """
+  Spends one post-password second factor: the TOTP code when TOTP is armed,
+  a recovery code otherwise.
+
+  The recovery set is ONE account-level credential shared by every factor,
+  so the door that spends it cannot be owned by TOTP. `TOTP.verify/3` speaks
+  for the account only while `totp_enabled_at` is set and otherwise refuses
+  the whole exchange — which stranded an account in passkey `second_factor`
+  with TOTP disarmed, holding codes no door would read (#766). Its
+  not-enabled answer is the branch condition here rather than a
+  `TOTP.enabled?/1` pre-check: one read decides, so a disarm racing the
+  redemption cannot land between the question and the answer.
+
+  The oracle stays as opaque as `TOTP.verify/3`'s own: a wrong recovery code
+  is `:invalid_two_factor`, indistinguishable from a wrong TOTP code.
+  """
+  @spec verify_second_factor(User.t(), String.t(), integer()) ::
+          {:ok, :totp | :recovery}
+          | {:error, :invalid_two_factor | :two_factor_replayed | :db_unavailable}
+  def verify_second_factor(%User{} = user, code, unix_seconds)
+      when is_binary(code) and is_integer(unix_seconds) do
+    case TOTP.verify(user, code, unix_seconds) do
+      {:error, :two_factor_not_enabled} -> spend_recovery_code(user, code)
+      result -> result
+    end
+  end
+
+  defp spend_recovery_code(user, code) do
+    case consume_recovery_code(user, code) do
+      :ok -> {:ok, :recovery}
+      {:error, :invalid_recovery_code} -> {:error, :invalid_two_factor}
+      {:error, :db_unavailable} = error -> error
+    end
+  end
+
+  @doc "Whether the account still holds an unspent recovery code."
+  @spec recovery_codes_armed?(User.t()) :: boolean()
+  def recovery_codes_armed?(%User{id: user_id}), do: RecoveryCodes.armed?(user_id)
+
   @doc "Generates an unarmed recovery set for passwordless activation."
   @spec prepare_recovery_codes() :: [String.t()]
   def prepare_recovery_codes, do: RecoveryCodes.generate()

--- a/lib/grappa/accounts/recovery_codes.ex
+++ b/lib/grappa/accounts/recovery_codes.ex
@@ -44,6 +44,17 @@ defmodule Grappa.Accounts.RecoveryCodes do
     :ok
   end
 
+  @doc """
+  Whether the account still holds an unspent recovery code.
+
+  The question a door asks before offering itself (#766): the set is armed
+  independently of which factor is, so "is TOTP on" is not the same
+  question and answering with it strands the codes.
+  """
+  @spec armed?(Ecto.UUID.t()) :: boolean()
+  def armed?(user_id) when is_binary(user_id),
+    do: TOTPRecoveryCode |> where([r], r.user_id == ^user_id) |> Repo.exists?()
+
   @doc "Rotates all recovery codes and returns their plaintext values once."
   @spec rotate(Ecto.UUID.t()) :: [String.t()]
   def rotate(user_id) when is_binary(user_id) do

--- a/lib/grappa_web/controllers/auth_controller.ex
+++ b/lib/grappa_web/controllers/auth_controller.ex
@@ -403,16 +403,9 @@ defmodule GrappaWeb.AuthController do
           passkey_second_factor(conn, user)
 
         TOTP.enabled?(user) ->
-          challenge =
-            Phoenix.Token.sign(
-              GrappaWeb.Endpoint,
-              @totp_challenge_salt,
-              {user.id, format_ip(conn), conn.assigns[:current_client_id]}
-            )
-
           conn
           |> put_status(:accepted)
-          |> json(%{two_factor_required: true, challenge_token: challenge})
+          |> json(%{two_factor_required: true, challenge_token: sign_challenge(user, conn)})
 
         true ->
           mint_user_session(conn, user)
@@ -446,14 +439,31 @@ defmodule GrappaWeb.AuthController do
     end
   end
 
-  defp optional_totp_challenge(user, conn) do
-    if TOTP.enabled?(user) do
-      Phoenix.Token.sign(
-        GrappaWeb.Endpoint,
-        @totp_challenge_salt,
-        {user.id, format_ip(conn), conn.assigns[:current_client_id]}
-      )
+  # #766 — the post-password code door is offered whenever it can redeem
+  # something, and the recovery set is one of those things. Gating the
+  # challenge on `TOTP.enabled?/1` alone left an account in passkey
+  # `second_factor` with TOTP disarmed holding ten valid codes and no door
+  # that would look at them: the passwordless door refuses the mode, and
+  # this one handed out no token to knock with. The set is account-level
+  # and shared (`Grappa.Accounts.RecoveryCodes`), so what decides the door
+  # is whether the account HAS a second factor to spend — not which one.
+  #
+  # `challenge_token` is not repurposed by this: `/auth/totp/verify` has
+  # always spent a recovery code as readily as a TOTP one, and cic's form
+  # has always been labelled "Authenticator or recovery code". Only the
+  # condition under which the token is minted widens.
+  defp second_factor_challenge(user, conn) do
+    if TOTP.enabled?(user) or Accounts.recovery_codes_armed?(user) do
+      sign_challenge(user, conn)
     end
+  end
+
+  defp sign_challenge(user, conn) do
+    Phoenix.Token.sign(
+      GrappaWeb.Endpoint,
+      @totp_challenge_salt,
+      {user.id, format_ip(conn), conn.assigns[:current_client_id]}
+    )
   end
 
   defp passkey_second_factor(conn, user) do
@@ -467,7 +477,7 @@ defmodule GrappaWeb.AuthController do
         two_factor_required: true,
         passkey_options: options,
         totp_available: TOTP.enabled?(user),
-        challenge_token: optional_totp_challenge(user, conn)
+        challenge_token: second_factor_challenge(user, conn)
       })
     end
   end
@@ -480,10 +490,18 @@ defmodule GrappaWeb.AuthController do
   end
 
   defp verify_second_factor(user, code, conn) do
-    case TOTP.verify(user, code, System.system_time(:second)) do
+    case Accounts.verify_second_factor(user, code, System.system_time(:second)) do
       {:ok, _} = ok ->
         :ok = FailureWindow.clear(:totp_login, {format_ip(conn), user.id})
         ok
+
+      # #815's rule, one door over: a saturated writer is not a bad
+      # credential. Recovery-code redemption commits through
+      # `Repo.BusyRetry`, so sustained saturation reaches here — and the
+      # catch-all below would charge the user's throttle for the server's
+      # problem, then tell them to re-type a code that was never wrong.
+      {:error, :db_unavailable} = error ->
+        error
 
       {:error, _} ->
         _ =

--- a/test/grappa_web/recovery_code_doors_test.exs
+++ b/test/grappa_web/recovery_code_doors_test.exs
@@ -22,10 +22,9 @@ defmodule GrappaWeb.RecoveryCodeDoorsTest do
   import Ecto.Query
   import Grappa.AuthFixtures
 
-  alias Grappa.Accounts
+  alias Grappa.{Accounts, Repo}
   alias Grappa.Accounts.{Passkey, Session, TOTP, TOTPRecoveryCode, User, WebAuthn}
   alias Grappa.RateLimit.FailureWindow
-  alias Grappa.Repo
 
   @states [
     :passwordless,
@@ -141,11 +140,11 @@ defmodule GrappaWeb.RecoveryCodeDoorsTest do
     {:ok, :passwordless} = WebAuthn.set_mode(user, :passwordless, session.id, codes)
     {:ok, :second_factor} = WebAuthn.set_mode(reload(user), :second_factor, session.id, [])
 
-    user = reload(user)
-    refute TOTP.enabled?(user)
-    assert codes_left(user) == 10
+    stranded = reload(user)
+    refute TOTP.enabled?(stranded)
+    assert codes_left(stranded) == 10
 
-    %{user: user, password: password, code: hd(codes), door: :post_password}
+    %{user: stranded, password: password, code: hd(codes), door: :post_password}
   end
 
   defp arm(:totp_only) do
@@ -155,7 +154,7 @@ defmodule GrappaWeb.RecoveryCodeDoorsTest do
     %{user: reload(user), password: password, code: hd(codes), door: :post_password}
   end
 
-  defp redeem(conn, :passwordless_recovery, user, _password, code) do
+  defp redeem(conn, :passwordless_recovery, user, _, code) do
     conn
     |> post("/auth/passkeys/recover", %{"identifier" => user.name, "recovery_code" => code})
     |> json_response(200)
@@ -203,9 +202,15 @@ defmodule GrappaWeb.RecoveryCodeDoorsTest do
 
   defp reload(user), do: Repo.get!(User, user.id)
 
-  defp codes_left(user),
-    do: Repo.aggregate(from(r in TOTPRecoveryCode, where: r.user_id == ^user.id), :count)
+  defp codes_left(user) do
+    TOTPRecoveryCode
+    |> where([r], r.user_id == ^user.id)
+    |> Repo.aggregate(:count)
+  end
 
-  defp session_count(user),
-    do: Repo.aggregate(from(s in Session, where: s.user_id == ^user.id and is_nil(s.revoked_at)), :count)
+  defp session_count(user) do
+    Session
+    |> where([s], s.user_id == ^user.id and is_nil(s.revoked_at))
+    |> Repo.aggregate(:count)
+  end
 end

--- a/test/grappa_web/recovery_code_doors_test.exs
+++ b/test/grappa_web/recovery_code_doors_test.exs
@@ -1,0 +1,211 @@
+defmodule GrappaWeb.RecoveryCodeDoorsTest do
+  @moduledoc """
+  The class guard for #766: an armed recovery set always has a door.
+
+  Recovery codes are ONE flat account-level credential shared by TOTP and
+  passkey login (`Grappa.Accounts.RecoveryCodes`), and `drop_if_orphaned/1`
+  deliberately preserves the set while ANY factor is armed. So every state
+  that arms the set — and demands a second factor at login — owes it a
+  redemption path. #766 is one instance of that rule being broken
+  (`passkey_mode: :second_factor` with TOTP disarmed, reachable by switching
+  a passwordless account to second factor); the matrix below is the rule.
+
+  The door is not the same everywhere, and deliberately so: a passwordless
+  account redeems the code ALONE (the code stands in for the passkey, its
+  only factor), while every other state redeems it BEHIND the password (the
+  code stands in for the second factor, not for both). Collapsing the two
+  into one passkey_mode-blind door would turn a 2FA account into a
+  one-credential account.
+  """
+  use GrappaWeb.ConnCase, async: false
+
+  import Ecto.Query
+  import Grappa.AuthFixtures
+
+  alias Grappa.Accounts
+  alias Grappa.Accounts.{Passkey, Session, TOTP, TOTPRecoveryCode, User, WebAuthn}
+  alias Grappa.RateLimit.FailureWindow
+  alias Grappa.Repo
+
+  @states [
+    :passwordless,
+    :second_factor_with_totp,
+    :second_factor_without_totp,
+    :totp_only
+  ]
+
+  for state <- @states do
+    test "#{state}: the armed recovery set is spendable", %{conn: conn} do
+      %{user: user, password: password, code: code, door: door} = arm(unquote(state))
+
+      body = redeem(conn, door, user, password, code)
+
+      assert is_binary(body["token"])
+      assert body["subject"]["id"] == user.id
+      # Spent, not waved through: a door that minted a session without
+      # consuming the code would satisfy the assertion above.
+      assert codes_left(user) == 9
+    end
+  end
+
+  # The widened branch must not be the cheap one. It shares the post-password
+  # `:totp_login` window with the TOTP door, so the eleventh attempt is
+  # refused even when the code handed over is genuine.
+  test "the second_factor-without-TOTP door is inside the same failure window", %{conn: conn} do
+    %{user: user, password: password, code: code} = arm(:second_factor_without_totp)
+    on_exit(fn -> FailureWindow.clear(:totp_login, {"127.0.0.1", user.id}) end)
+
+    live = session_count(user)
+    challenge = challenge_token(conn, user, password)
+
+    for _ <- 1..10 do
+      assert conn
+             |> post("/auth/totp/verify", %{
+               "challenge_token" => challenge,
+               "code" => "wrongwrongwrongwrongwrongw"
+             })
+             |> json_response(401) == %{"error" => "invalid_two_factor"}
+    end
+
+    assert conn
+           |> post("/auth/totp/verify", %{"challenge_token" => challenge, "code" => code})
+           |> json_response(429) == %{"error" => "too_many_attempts"}
+
+    assert session_count(user) == live
+    assert codes_left(user) == 10
+
+    # The window was the only thing refusing it: the very same code opens
+    # the door once the counter is cleared. Without this the 429 above
+    # would also be satisfied by a code no door can ever redeem, which is
+    # precisely the bug under test.
+    :ok = FailureWindow.clear(:totp_login, {"127.0.0.1", user.id})
+
+    assert conn
+           |> post("/auth/totp/verify", %{"challenge_token" => challenge, "code" => code})
+           |> json_response(200)
+           |> Map.fetch!("subject")
+           |> Map.fetch!("id") == user.id
+
+    assert codes_left(user) == 9
+  end
+
+  # The pin for the door NOT widened. `/auth/passkeys/recover` mints a
+  # session from a recovery code alone, which is the right trade for a
+  # passwordless account (one factor in, one factor out) and the wrong one
+  # for a second_factor account, whose password is the first factor. Widening
+  # this door instead of the post-password one would close #766 by demoting
+  # a 2FA account to a single credential.
+  test "the passwordless door still refuses a second_factor account", %{conn: conn} do
+    %{user: user, code: code} = arm(:second_factor_without_totp)
+    live = session_count(user)
+
+    on_exit(fn ->
+      FailureWindow.clear(:passkey_recovery, "127.0.0.1")
+      FailureWindow.clear(:passkey_recovery, {"127.0.0.1", user.id})
+    end)
+
+    assert conn
+           |> post("/auth/passkeys/recover", %{"identifier" => user.name, "recovery_code" => code})
+           |> json_response(401) == %{"error" => "invalid_two_factor"}
+
+    assert session_count(user) == live
+    assert codes_left(user) == 10
+  end
+
+  defp arm(:passwordless) do
+    {user, password} = user_fixture_with_password()
+    register_passkey(user)
+    codes = Accounts.prepare_recovery_codes()
+    {:ok, :passwordless} = WebAuthn.set_mode(user, :passwordless, session_fixture(user).id, codes)
+
+    %{user: reload(user), password: password, code: hd(codes), door: :passwordless_recovery}
+  end
+
+  defp arm(:second_factor_with_totp) do
+    {user, password} = user_fixture_with_password()
+    register_passkey(user)
+    codes = arm_totp(user)
+    {:ok, :second_factor} = WebAuthn.set_mode(user, :second_factor, session_fixture(user).id, [])
+
+    %{user: reload(user), password: password, code: hd(codes), door: :post_password}
+  end
+
+  # The reachable path into #766's state: a passwordless account (the only
+  # mode that mints codes without TOTP) switched to second factor. The set
+  # survives because `drop_if_orphaned/1` counts second_factor as armed.
+  defp arm(:second_factor_without_totp) do
+    {user, password} = user_fixture_with_password()
+    register_passkey(user)
+    codes = Accounts.prepare_recovery_codes()
+    session = session_fixture(user)
+    {:ok, :passwordless} = WebAuthn.set_mode(user, :passwordless, session.id, codes)
+    {:ok, :second_factor} = WebAuthn.set_mode(reload(user), :second_factor, session.id, [])
+
+    user = reload(user)
+    refute TOTP.enabled?(user)
+    assert codes_left(user) == 10
+
+    %{user: user, password: password, code: hd(codes), door: :post_password}
+  end
+
+  defp arm(:totp_only) do
+    {user, password} = user_fixture_with_password()
+    codes = arm_totp(user)
+
+    %{user: reload(user), password: password, code: hd(codes), door: :post_password}
+  end
+
+  defp redeem(conn, :passwordless_recovery, user, _password, code) do
+    conn
+    |> post("/auth/passkeys/recover", %{"identifier" => user.name, "recovery_code" => code})
+    |> json_response(200)
+  end
+
+  defp redeem(conn, :post_password, user, password, code) do
+    conn
+    |> post("/auth/totp/verify", %{
+      "challenge_token" => challenge_token(conn, user, password),
+      "code" => code
+    })
+    |> json_response(200)
+  end
+
+  defp challenge_token(conn, user, password) do
+    pending =
+      conn
+      |> post("/auth/login", %{"identifier" => user.name, "password" => password})
+      |> json_response(202)
+
+    assert pending["two_factor_required"] == true
+    token = pending["challenge_token"]
+    assert is_binary(token), "no post-password door: the login handed out no challenge token"
+    token
+  end
+
+  defp arm_totp(user) do
+    enrollment = TOTP.new_enrollment(user, "Grappa test")
+    at = System.system_time(:second)
+    {:ok, code} = TOTP.code_at(enrollment.secret, at)
+    {:ok, codes} = TOTP.confirm_enrollment(user, enrollment.secret, code, at)
+    codes
+  end
+
+  defp register_passkey(user) do
+    Repo.insert!(
+      Passkey.changeset(%Passkey{}, %{
+        user_id: user.id,
+        credential_id: :crypto.strong_rand_bytes(16),
+        public_key: CBOR.encode(%{1 => 2, 3 => -7}),
+        name: "phone"
+      })
+    )
+  end
+
+  defp reload(user), do: Repo.get!(User, user.id)
+
+  defp codes_left(user),
+    do: Repo.aggregate(from(r in TOTPRecoveryCode, where: r.user_id == ^user.id), :count)
+
+  defp session_count(user),
+    do: Repo.aggregate(from(s in Session, where: s.user_id == ^user.id and is_nil(s.revoked_at)), :count)
+end


### PR DESCRIPTION
Refs #766.

## What was broken

An account in passkey `second_factor` with TOTP disarmed held ten valid,
armed recovery codes that **no door would read**:

- `PasskeyController.recover/2` matches only `%User{passkey_mode: :passwordless}`;
  everything else falls to the catch-all that records a throttle failure and
  answers `:invalid_two_factor`.
- The post-password door was offered only when `TOTP.enabled?/1`, and
  `TOTP.verify/3` rolls the exchange back with `:two_factor_not_enabled` when
  `totp_enabled_at` is nil.

The state is reachable through the supported UI path, which is what makes it a
defect: a passwordless account is the only mode that mints codes without TOTP,
and switching it to second factor **keeps** them, because
`RecoveryCodes.drop_if_orphaned/1` deliberately counts `second_factor` as
armed. `Accounts.reset_totp/1` reaches the same state from the other side.

## The fix asks about the SET, not about the factor

The recovery set is ONE flat account-level credential shared by every factor, so
a door keyed on `passkey_mode` or on `TOTP.enabled?/1` is asking a question that
was never about it.

- `Accounts.recovery_codes_armed?/1` gates the post-password challenge alongside
  `TOTP.enabled?/1` — the door exists whenever there is something to spend at it.
- `Accounts.verify_second_factor/3` spends a recovery code when TOTP is disarmed.
  It branches on `TOTP.verify/3`'s **own** not-enabled answer rather than a
  `TOTP.enabled?/1` pre-check, so a disarm racing the redemption cannot land
  between the question and the answer.

`challenge_token` is not repurposed: `/auth/totp/verify` has always spent a
recovery code as readily as a TOTP one, and cic's form is already labelled
"Authenticator or recovery code". Only the condition under which the token is
minted widens — no client change is required, and one cic test pins the degrade
on the token rather than on `totp_available` (the two have stopped being the
same fact).

## What was deliberately NOT widened

The issue proposed widening `PasskeyController.recover/2` to `second_factor`.
That door mints a session from a recovery code **alone** — the right trade for a
passwordless account (one factor in, one factor out, since password login is
refused for the mode) and the wrong one for a `second_factor` account, whose
password IS the first factor. Widening it would have closed a lockout by
demoting a two-credential account to a one-credential one, on an unauthenticated
endpoint. A test pins the refusal so a later "obvious" fix fails the suite
instead of quietly landing.

This is also the honest answer to the preferred "single `passkey_mode`-blind
redemption path": the doors differ because the FACTOR COUNT differs.

Nothing is destroyed and no teardown rule moves.

## Evidence

- **RED first, on the right rows.** The matrix failed on exactly the two
  `second_factor_without_totp` rows; the other three states were green before
  the fix.
- **Both production halves mutation-checked individually.** Reverting the
  challenge predicate alone → 2 red. Reverting the redemption branch alone → 2
  red.
- **Throttle parity measured, not asserted.** The widened branch shares the
  `:totp_login` window: the eleventh attempt is 429 *even with a genuine code*,
  and the same code then opens the door once the counter is cleared — the second
  half is what stops the 429 from being satisfied by a code that was simply
  unredeemable.
- **The guard is the class.** `recovery_code_doors_test.exs` enumerates every
  state whose login demands a second factor (passwordless, second factor with
  and without TOTP, TOTP alone) and asserts each can spend an armed code and
  that the code is consumed by doing so.
- `scripts/check.sh` exit 0 — `8 doctests, 50 properties, 5140 tests, 0
  failures`, dialyzer `Total errors: 0`, bats `done (passed successfully)`.
  cic: 4259 tests green, `tsc --noEmit` clean, biome clean.

## Reported, not fixed

`Accounts.disable_totp/3` deletes the whole recovery set unconditionally instead
of going through `drop_if_orphaned/1`, so a user who disables TOTP while passkey
`second_factor` is armed loses the fallback that rule says to keep — the mirror
image of this issue. It is a teardown change, which this issue explicitly froze,
so it is written down in DESIGN_NOTES rather than touched here.