### PR TITLE
irc(#279): validate the mode-letter class at the umode ingress

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -29545,3 +29545,70 @@ than a parameter worth adding. And the guard remains a per-verb habit, not a
 whole-module property: a new `await` that captures the token and skips the
 check reopens the defect for its own call path — one owner makes the rule
 greppable, it does not make it automatic.
+
+## 2026-08-05 — #279: the mode-letter class, and the assertion that certified nothing
+
+A fuzzed `221 RPL_UMODEIS` param folded into the per-session umode set
+verbatim — `walk_umodes/3` did `MapSet.put` of ANY byte — so a garbage param
+produced `{:umode_changed, [" ", "!", "\"", …]}`. No ircd sends that, so it
+never fired in production; it fired in CI, on whichever seeds happened to draw
+numeric 221.
+
+**The production half was never fixed the first time.** `c45bf1b3` (a #373
+review commit) reddened on seed 671214 and answered it in the property test:
+it added a `{:umode_changed, modes}` arm asserting `is_list` +
+`Enum.all?(&is_binary/1)`. Half of that was legitimate — the arm did not exist
+at all, so before it EVERY `:umode_changed`, including `["i","w"]`, flunked as
+a malformed effect; the type union had genuinely outgrown the allowlist. The
+other half was the cerotto: `is_binary/1` is precisely what `" "` and `"!"`
+satisfy. So "restore the pre-widening allowlist" was not the fix either — that
+allowlist rejected the legitimate case. The narrowing that closes it is a
+STRICTER arm than either: assert the mode-letter class.
+
+**Where the class comes from.** The mode letter SET is per-ircd (bahamut
+`+iwxs`, solanum `+DQZagiow`, extension-registered letters) and grappa stays
+agnostic to it — `supported_umodes` was rejected as the validator for exactly
+that reason: an under-advertising 004 would then silently drop a real umode,
+and 221 can arrive before any 004. What IS closed is the GRAMMAR: an RFC-2812
+mode block is signs + ALPHA. That is the widest rule that still rejects the
+fuzz, so it is the boundary contract — `Identifier.valid_mode_letter?/1`, one
+predicate shared by the handlers and by the property that pins them, so a
+future ircd's new letter cannot be green in one and red in the other.
+
+**Reject the whole token, not the bad bytes.** A mode string is one atomic
+statement about the session; a half-parsed one publishes a set the server
+never claimed, which is worse than keeping the last authoritative one. Empty
+is a rejection for the same reason — it asserts nothing, and would let a
+truncated line WIPE the set. A bare `+` stays a valid empty snapshot: the
+server saying "you hold no umodes" is a claim, and it still takes effect.
+
+**One verdict, two readers.** In the self-MODE branch the same bytes are read
+twice: the umode fold and `set_r_mode?/1`, the `+r` detector that commits a
+staged registration secret as cryptographically confirmed. Gating only the
+fold would have left a malformed line able to confirm a secret. The verdict is
+computed once and both readers hang off it. The `$server` confirmation row
+still persists — rejecting the FOLD is not rejecting the LINE.
+
+**004 came along** because it is the same boundary one numeric over: param 3
+is upstream bytes, and un-validated it emitted the identical malformed effect
+as `:supported_umodes_changed`, which drives the #249 `/umode` modal's
+available toggles. No effect SHAPE changed anywhere, so the #249 coordination
+the issue asked for is a no-op: `{:umode_changed, [letters]}` is what it was.
+
+**Measured by displacement.** With production reverted and the restricted
+tests kept, `--seed 671214` reproduces the original counterexample exactly
+(numeric 221, after 80 successful runs) and the restricted arm catches it;
+same seed on the fixed handler is green, as are seeds 0/1/42/999999/123456.
+Two targeted properties hit the 221 and 004 params on EVERY generated example,
+so the class no longer depends on a seed drawing a 1-in-999 numeric.
+
+**Left standing, and measured too:** the CHANNEL-mode walker has the same
+hole. `MODE #chan "+n!$ "` yields
+`{:channel_modes_changed, "#chan", %{modes: [" ", "$", "!", "n"]}}`, and the
+property's arm for it (`is_list(entry.modes)`) cannot see it — the same
+certificate-of-nothing, one effect over. It is NOT fixed here: channel mode
+letters consume ARGS through the ISUPPORT CHANMODES/PREFIX tables, so a
+whole-token rejection has to be agreed by `walk_modes/5` (members) and
+`walk_channel_modes/5` (cache) and the 324 snapshot together, with the ban /
+key / limit arg-alignment as the risk surface. That is its own change with its
+own tests, not a rider on this one.

--- a/lib/grappa/irc/identifier.ex
+++ b/lib/grappa/irc/identifier.ex
@@ -453,6 +453,28 @@ defmodule Grappa.IRC.Identifier do
   def valid_network_slug?(_), do: false
 
   @doc """
+  True iff the input is exactly one IRC mode letter — a single ASCII
+  letter, either case.
+
+  The mode LETTER SET is per-ircd (bahamut's `+iwxs`, solanum's
+  `+DQZagiow`, extension-registered letters) and grappa deliberately
+  stays agnostic to it — but the mode letter CLASS is closed by the
+  RFC-2812 §3.1.5/§3.2.3 grammar: a mode block is a run of signs and
+  ALPHA, nothing else. That class is the boundary contract for every
+  upstream-supplied mode token (#279), and it is the widest rule that
+  still rejects the fuzzed `221 RPL_UMODEIS` param (spaces, punctuation,
+  control bytes) which used to fold into the per-session umode set
+  verbatim.
+
+  Digits and the signs themselves are NOT mode letters: `+`/`-` are the
+  sign alphabet the walkers consume separately, and no ircd registers a
+  numeric mode char.
+  """
+  @spec valid_mode_letter?(term()) :: boolean()
+  def valid_mode_letter?(<<c>>) when c in ?a..?z or c in ?A..?Z, do: true
+  def valid_mode_letter?(_), do: false
+
+  @doc """
   True iff the input is a non-empty hostname-or-IP-shaped string. DNS
   validity is not checked — the connect attempt is the canonical
   authority.

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -671,19 +671,11 @@ defmodule Grappa.Session.EventRouter do
       # The +r case is special: when NickServ-as-IDP confirms a visitor's
       # IDENTIFY (or register→auth-code) it sets +r on the nick. +r is the
       # cryptographic-proof signal that the captured secret was accepted;
-      # emit `:visitor_r_observed` carrying it so `Session.Server
-      # .apply_effects/2` can commit it atomically into the visitors row.
+      # `visitor_r_effects/3` emits `:visitor_r_observed` carrying it so
+      # `Session.Server.apply_effects/2` can commit it atomically into the
+      # visitors row. Orthogonal to the confirmation row above — both
+      # effects coexist.
       #
-      # ONE +r-observation primitive serves both capture slots (#90 / #129
-      # — do not build two detectors). Two slots feed it: the timed
-      # `pending_auth` (IDENTIFY-family) and the untimed
-      # `pending_registration_secret` (REGISTER). If BOTH are staged,
-      # REGISTER wins — it is correct-by-construction (a wrong register
-      # never gets +r), whereas a stale wrong identify could still be in its
-      # 10s window. Both are set on `Session.Server` state but are optional
-      # from the pure router's POV; pure unit tests on user sessions skip
-      # them (Map.get → nil). Orthogonal to the confirmation row above —
-      # both effects coexist.
       # #279 — ONE validity verdict for the token, shared by BOTH readers
       # below (the +r detector and the umode fold). A mode string that is
       # not signs + mode letters is a malformed LINE, not a partially
@@ -691,15 +683,7 @@ defmodule Grappa.Session.EventRouter do
       # once here because `set_r_mode?/1` walks the same bytes.
       prev_umodes = Map.get(state, :umodes, [])
       parsed_umodes = apply_umode_string(prev_umodes, modes)
-      well_formed_modes? = match?({:ok, _}, parsed_umodes)
-
-      r_effects =
-        case {well_formed_modes? and set_r_mode?(modes), Map.get(state, :pending_registration_secret),
-              Map.get(state, :pending_auth)} do
-          {true, reg, _} when is_binary(reg) -> [{:visitor_r_observed, reg}]
-          {true, _, {pwd, _}} -> [{:visitor_r_observed, pwd}]
-          _ -> []
-        end
+      r_effects = visitor_r_effects(state, parsed_umodes, modes)
 
       # #229: fold the delta into the queryable per-session umode set so the
       # /mode <nick> modal reflects mid-session changes (an explicit
@@ -710,12 +694,7 @@ defmodule Grappa.Session.EventRouter do
       # whose state predates the :umodes field self-heals rather than
       # KeyError-crashing (mirror of #216's :isupport hot-safety). Emit
       # `:umode_changed` only on an actual change to keep fan-out minimal.
-      next_umodes =
-        case parsed_umodes do
-          {:ok, parsed} -> parsed
-          :error -> prev_umodes
-        end
-
+      next_umodes = umodes_or_unchanged(parsed_umodes, prev_umodes)
       umode_effects = if next_umodes != prev_umodes, do: [{:umode_changed, next_umodes}], else: []
       state = Map.put(state, :umodes, next_umodes)
 
@@ -1100,13 +1079,7 @@ defmodule Grappa.Session.EventRouter do
        )
        when is_binary(mode_str) do
     prev_umodes = Map.get(state, :umodes, [])
-
-    next_umodes =
-      case apply_umode_string([], mode_str) do
-        {:ok, parsed} -> parsed
-        :error -> prev_umodes
-      end
-
+    next_umodes = umodes_or_unchanged(apply_umode_string([], mode_str), prev_umodes)
     effects = if next_umodes != prev_umodes, do: [{:umode_changed, next_umodes}], else: []
     {:cont, Map.put(state, :umodes, next_umodes), effects}
   end
@@ -1136,13 +1109,7 @@ defmodule Grappa.Session.EventRouter do
        )
        when is_binary(usermodes) do
     prev = Map.get(state, :supported_umodes, [])
-
-    next =
-      case parse_supported_umodes(usermodes) do
-        {:ok, parsed} -> parsed
-        :error -> prev
-      end
-
+    next = umodes_or_unchanged(parse_supported_umodes(usermodes), prev)
     effects = if next != prev, do: [{:supported_umodes_changed, next}], else: []
     {:cont, Map.put(state, :supported_umodes, next), effects}
   end
@@ -3177,6 +3144,30 @@ defmodule Grappa.Session.EventRouter do
 
   defp toggle_umode(set, letter, :add), do: MapSet.put(set, letter)
   defp toggle_umode(set, letter, :remove), do: MapSet.delete(set, letter)
+
+  # #279 — the two readers of a self-MODE token, each gated by the SAME
+  # parse verdict so a malformed line can never yield a conclusion.
+  #
+  # `visitor_r_effects/3` is the +r capture-confirmation slot (#90/#129):
+  # ONE +r-observation primitive serves both staged secrets. If BOTH are
+  # staged, REGISTER wins — it is correct-by-construction (a wrong register
+  # never gets +r), whereas a stale wrong identify could still be inside
+  # its 10s window. Both fields are optional from the pure router's POV
+  # (pure unit tests on user sessions skip them → `Map.get` nil).
+  @spec visitor_r_effects(state(), {:ok, [String.t()]} | :error, String.t()) :: [effect()]
+  defp visitor_r_effects(_, :error, _), do: []
+
+  defp visitor_r_effects(state, {:ok, _}, modes) do
+    case {set_r_mode?(modes), Map.get(state, :pending_registration_secret), Map.get(state, :pending_auth)} do
+      {true, reg, _} when is_binary(reg) -> [{:visitor_r_observed, reg}]
+      {true, _, {pwd, _}} -> [{:visitor_r_observed, pwd}]
+      _ -> []
+    end
+  end
+
+  @spec umodes_or_unchanged({:ok, [String.t()]} | :error, [String.t()]) :: [String.t()]
+  defp umodes_or_unchanged({:ok, parsed}, _), do: parsed
+  defp umodes_or_unchanged(:error, prev), do: prev
 
   # #249 — parse the 004 RPL_MYINFO supported-usermode token (a signless
   # concatenation of letters, e.g. "oiwgrsk") into a sorted, deduped

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -684,8 +684,18 @@ defmodule Grappa.Session.EventRouter do
       # from the pure router's POV; pure unit tests on user sessions skip
       # them (Map.get → nil). Orthogonal to the confirmation row above —
       # both effects coexist.
+      # #279 — ONE validity verdict for the token, shared by BOTH readers
+      # below (the +r detector and the umode fold). A mode string that is
+      # not signs + mode letters is a malformed LINE, not a partially
+      # usable delta: neither reader may draw a conclusion from it. Parsed
+      # once here because `set_r_mode?/1` walks the same bytes.
+      prev_umodes = Map.get(state, :umodes, [])
+      parsed_umodes = apply_umode_string(prev_umodes, modes)
+      well_formed_modes? = match?({:ok, _}, parsed_umodes)
+
       r_effects =
-        case {set_r_mode?(modes), Map.get(state, :pending_registration_secret), Map.get(state, :pending_auth)} do
+        case {well_formed_modes? and set_r_mode?(modes), Map.get(state, :pending_registration_secret),
+              Map.get(state, :pending_auth)} do
           {true, reg, _} when is_binary(reg) -> [{:visitor_r_observed, reg}]
           {true, _, {pwd, _}} -> [{:visitor_r_observed, pwd}]
           _ -> []
@@ -700,8 +710,12 @@ defmodule Grappa.Session.EventRouter do
       # whose state predates the :umodes field self-heals rather than
       # KeyError-crashing (mirror of #216's :isupport hot-safety). Emit
       # `:umode_changed` only on an actual change to keep fan-out minimal.
-      prev_umodes = Map.get(state, :umodes, [])
-      next_umodes = apply_umode_string(prev_umodes, modes)
+      next_umodes =
+        case parsed_umodes do
+          {:ok, parsed} -> parsed
+          :error -> prev_umodes
+        end
+
       umode_effects = if next_umodes != prev_umodes, do: [{:umode_changed, next_umodes}], else: []
       state = Map.put(state, :umodes, next_umodes)
 
@@ -1075,13 +1089,24 @@ defmodule Grappa.Session.EventRouter do
   # #216 hot-reload-safety contract. Emit `:umode_changed` only on a real
   # change to keep fan-out minimal. Umodes are per-session (no channel), so
   # `apply_umode_string/2` folds the +/- string into a sorted letter list.
+  #
+  # #279 — a malformed mode param (anything but signs + mode letters) is
+  # NOT a snapshot: keep the last authoritative set and emit nothing,
+  # rather than replacing it with parsed garbage. `Map.put` still runs on
+  # the reject path so a hot-reloaded proc predating the field self-heals.
   defp do_route(
          %Message{command: {:numeric, 221}, params: [_, mode_str | _]},
          state
        )
        when is_binary(mode_str) do
     prev_umodes = Map.get(state, :umodes, [])
-    next_umodes = apply_umode_string([], mode_str)
+
+    next_umodes =
+      case apply_umode_string([], mode_str) do
+        {:ok, parsed} -> parsed
+        :error -> prev_umodes
+      end
+
     effects = if next_umodes != prev_umodes, do: [{:umode_changed, next_umodes}], else: []
     {:cont, Map.put(state, :umodes, next_umodes), effects}
   end
@@ -1111,7 +1136,13 @@ defmodule Grappa.Session.EventRouter do
        )
        when is_binary(usermodes) do
     prev = Map.get(state, :supported_umodes, [])
-    next = parse_supported_umodes(usermodes)
+
+    next =
+      case parse_supported_umodes(usermodes) do
+        {:ok, parsed} -> parsed
+        :error -> prev
+      end
+
     effects = if next != prev, do: [{:supported_umodes_changed, next}], else: []
     {:cont, Map.put(state, :supported_umodes, next), effects}
   end
@@ -3112,23 +3143,40 @@ defmodule Grappa.Session.EventRouter do
   # empty base = replace) and the self-MODE echo (from the current set =
   # delta). A snapshot from an ircd starts with `+`; a mid-session echo
   # may mix signs (`-i+w`).
-  @spec apply_umode_string([String.t()], String.t()) :: [String.t()]
+  #
+  # #279 — the mode string is upstream-supplied bytes, so the walk
+  # VALIDATES: a token is signs + `Identifier.valid_mode_letter?/1`
+  # letters and nothing else. Anything else is `:error` — the WHOLE token
+  # is rejected, not per-byte filtered. Rationale: a mode string is one
+  # atomic statement about the session, so a half-parsed one would publish
+  # a umode set the server never claimed (worse than keeping the last
+  # authoritative one). An empty token is `:error` for the same reason —
+  # it asserts nothing, and letting it through would let a truncated line
+  # WIPE the set. A bare sign (`"+"`) IS a valid empty snapshot.
+  @spec apply_umode_string([String.t()], String.t()) :: {:ok, [String.t()]} | :error
+  defp apply_umode_string(modes, "") when is_list(modes), do: :error
+
   defp apply_umode_string(modes, mode_string) when is_list(modes) and is_binary(mode_string) do
-    modes
-    |> MapSet.new()
-    |> walk_umodes(mode_string, :add)
-    |> Enum.sort()
+    case walk_umodes(MapSet.new(modes), mode_string, :add) do
+      {:ok, set} -> {:ok, Enum.sort(set)}
+      :error -> :error
+    end
   end
 
-  defp walk_umodes(set, "", _), do: set
+  defp walk_umodes(set, "", _), do: {:ok, set}
   defp walk_umodes(set, "+" <> rest, _), do: walk_umodes(set, rest, :add)
   defp walk_umodes(set, "-" <> rest, _), do: walk_umodes(set, rest, :remove)
 
-  defp walk_umodes(set, <<letter::binary-size(1), rest::binary>>, :add),
-    do: walk_umodes(MapSet.put(set, letter), rest, :add)
+  defp walk_umodes(set, <<letter::binary-size(1), rest::binary>>, direction) do
+    if Identifier.valid_mode_letter?(letter) do
+      walk_umodes(toggle_umode(set, letter, direction), rest, direction)
+    else
+      :error
+    end
+  end
 
-  defp walk_umodes(set, <<letter::binary-size(1), rest::binary>>, :remove),
-    do: walk_umodes(MapSet.delete(set, letter), rest, :remove)
+  defp toggle_umode(set, letter, :add), do: MapSet.put(set, letter)
+  defp toggle_umode(set, letter, :remove), do: MapSet.delete(set, letter)
 
   # #249 — parse the 004 RPL_MYINFO supported-usermode token (a signless
   # concatenation of letters, e.g. "oiwgrsk") into a sorted, deduped
@@ -3137,13 +3185,24 @@ defmodule Grappa.Session.EventRouter do
   # applies, so it does NOT share that walker (same wire SHAPE, different
   # MEANING; CLAUDE.md design-discipline #6). Any stray sign char is dropped
   # defensively (the token is signless by spec).
-  @spec parse_supported_umodes(String.t()) :: [String.t()]
+  #
+  # #279 — what the two DO share is the mode-letter CLASS at the boundary
+  # (`Identifier.valid_mode_letter?/1`): 004 param 3 is upstream-supplied
+  # bytes exactly like the 221 param, and un-validated it fed
+  # `{:supported_umodes_changed, [" ", "!", …]}` — the same malformed
+  # effect #279 was filed for, one numeric over. Reject the WHOLE token on
+  # any non-letter byte (`:error`), for the same reason 221 does: the
+  # availability set is one atomic advertisement, and a half-parsed one
+  # would grey out real toggles in cic's #249 /umode modal.
+  @spec parse_supported_umodes(String.t()) :: {:ok, [String.t()]} | :error
   defp parse_supported_umodes(token) when is_binary(token) do
-    token
-    |> String.graphemes()
-    |> Enum.reject(&(&1 in ["+", "-"]))
-    |> Enum.uniq()
-    |> Enum.sort()
+    letters = token |> String.graphemes() |> Enum.reject(&(&1 in ["+", "-"]))
+
+    if letters != [] and Enum.all?(letters, &Identifier.valid_mode_letter?/1) do
+      {:ok, letters |> Enum.uniq() |> Enum.sort()}
+    else
+      :error
+    end
   end
 
   # Parse a full mode snapshot string (e.g. "+nt" or "+ntk") plus arg list

--- a/test/grappa/irc/identifier_test.exs
+++ b/test/grappa/irc/identifier_test.exs
@@ -672,6 +672,41 @@ defmodule Grappa.IRC.IdentifierTest do
     end
   end
 
+  describe "valid_mode_letter?/1 (#279 mode-token boundary class)" do
+    test "accepts every single ASCII letter, both cases" do
+      for c <- ?a..?z, do: assert(Identifier.valid_mode_letter?(<<c>>))
+      for c <- ?A..?Z, do: assert(Identifier.valid_mode_letter?(<<c>>))
+    end
+
+    test "rejects the punctuation/space/control bytes a fuzzed mode param carries" do
+      for s <- [" ", "!", "\"", "$", "'", "(", ")", ",", "~", "\x01", "\x7f"] do
+        refute Identifier.valid_mode_letter?(s), "expected #{inspect(s)} to be rejected"
+      end
+    end
+
+    test "rejects digits — no ircd registers a numeric mode char" do
+      for s <- ~w(0 1 9), do: refute(Identifier.valid_mode_letter?(s))
+    end
+
+    test "rejects the signs themselves (a sign is not a mode letter)" do
+      refute Identifier.valid_mode_letter?("+")
+      refute Identifier.valid_mode_letter?("-")
+    end
+
+    test "rejects multi-byte and non-ASCII input (one letter means one byte)" do
+      refute Identifier.valid_mode_letter?("iw")
+      refute Identifier.valid_mode_letter?("")
+      refute Identifier.valid_mode_letter?("à")
+      refute Identifier.valid_mode_letter?("é")
+    end
+
+    test "rejects non-binary input" do
+      refute Identifier.valid_mode_letter?(nil)
+      refute Identifier.valid_mode_letter?(:i)
+      refute Identifier.valid_mode_letter?(?i)
+    end
+  end
+
   describe "member_prefix/1 (#25 grade-snapshot helper)" do
     test "returns the highest-precedence sigil (@ > % > +)" do
       assert Identifier.member_prefix(["@"]) == "@"

--- a/test/grappa/session/event_router_property_test.exs
+++ b/test/grappa/session/event_router_property_test.exs
@@ -12,7 +12,7 @@ defmodule Grappa.Session.EventRouterPropertyTest do
   use ExUnit.Case, async: true
   use ExUnitProperties
 
-  alias Grappa.IRC.Message
+  alias Grappa.IRC.{Identifier, Message}
   alias Grappa.Session.EventRouter
 
   defp ascii_nick_gen do
@@ -207,13 +207,20 @@ defmodule Grappa.Session.EventRouterPropertyTest do
         {:invited, channel} ->
           assert is_binary(channel)
 
+        # #279 — `is_binary/1` here was a CERTIFICATE OF NOTHING: it is
+        # exactly what a fuzzed 221 param full of spaces and punctuation
+        # satisfies, and adding it is how the malformed-effect red got
+        # silenced without the handler changing. The effect carries mode
+        # LETTERS, so the arm asserts the letter class — the same
+        # production predicate the 221/004 handlers validate with, so a
+        # future ircd letter can never be green here and red there.
         {:umode_changed, modes} ->
           assert is_list(modes)
-          assert Enum.all?(modes, &is_binary/1)
+          assert Enum.all?(modes, &Identifier.valid_mode_letter?/1)
 
         {:supported_umodes_changed, modes} ->
           assert is_list(modes)
-          assert Enum.all?(modes, &is_binary/1)
+          assert Enum.all?(modes, &Identifier.valid_mode_letter?/1)
 
         {:session_identity_changed, transition} ->
           assert transition in [:acquired, :lost]
@@ -291,6 +298,52 @@ defmodule Grappa.Session.EventRouterPropertyTest do
       channel_modes: %{},
       userhost_cache: %{}
     }
+  end
+
+  # #279 — the property above reaches numeric 221 / 004 only when the seed
+  # draws them (one numeric in 999, a handful of numerics per run): that is
+  # WHY the malformed `{:umode_changed, [" ", "!", …]}` lived on main as an
+  # INTERMITTENT red instead of a deterministic one. These two hit the umode
+  # boundary on every generated example, so the class is pinned by the test
+  # set rather than by the seed.
+  defp umode_letters?(modes) do
+    is_list(modes) and Enum.all?(modes, &Identifier.valid_mode_letter?/1)
+  end
+
+  property "#279: no 221 RPL_UMODEIS param yields a non-letter umode" do
+    check all(mode_str <- string(:ascii, min_length: 0, max_length: 32)) do
+      m = %Message{
+        command: {:numeric, 221},
+        params: ["self", mode_str],
+        prefix: {:server, "irc.example.org"},
+        tags: %{}
+      }
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, min_state())
+      assert umode_letters?(Map.get(new_state, :umodes, []))
+
+      for {:umode_changed, modes} <- effects do
+        assert umode_letters?(modes), "malformed umode set from param #{inspect(mode_str)}"
+      end
+    end
+  end
+
+  property "#279: no 004 RPL_MYINFO usermodes token yields a non-letter umode" do
+    check all(token <- string(:ascii, min_length: 0, max_length: 32)) do
+      m = %Message{
+        command: {:numeric, 4},
+        params: ["self", "irc.example.org", "ircd-1", token, "beI,k,l,imnpst", "bklov"],
+        prefix: {:server, "irc.example.org"},
+        tags: %{}
+      }
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, min_state())
+      assert umode_letters?(Map.get(new_state, :supported_umodes, []))
+
+      for {:supported_umodes_changed, modes} <- effects do
+        assert umode_letters?(modes), "malformed supported set from token #{inspect(token)}"
+      end
+    end
   end
 
   property "#218: a STATUSMSG-prefixed NOTICE target routes to the underlying channel" do

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -2227,6 +2227,84 @@ defmodule Grappa.Session.EventRouterTest do
       # Result is a sorted set — advertised order does not change the outcome.
       assert new_state.umodes == ["D", "Q", "Z", "i"]
     end
+
+    # #279 — the mode param is upstream-controlled bytes. A mode token is
+    # signs + ASCII letters and nothing else; anything else is not a
+    # partially-usable snapshot, it is a malformed line. Reject the WHOLE
+    # token at the boundary: keep the last authoritative set rather than
+    # publishing a half-parsed one.
+    test "221 with a garbage mode param is rejected whole — no effect, set untouched" do
+      state = base_state(%{nick: "vjt", umodes: ["i", "w"]})
+      # The literal counterexample from the #279 CI failure (seed 671214).
+      m = msg({:numeric, 221}, ["vjt", "]{@O& L#j|vH9_E"], {:server, "irc.azzurra.chat"})
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+      assert new_state.umodes == ["i", "w"]
+      refute Enum.any?(effects, &match?({:umode_changed, _}, &1))
+    end
+
+    test "221 with one stray byte among the letters is rejected whole (no silent drop)" do
+      state = base_state(%{nick: "vjt", umodes: ["i"]})
+      m = msg({:numeric, 221}, ["vjt", "+iw!"], {:server, "irc.azzurra.chat"})
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+      assert new_state.umodes == ["i"]
+      refute Enum.any?(effects, &match?({:umode_changed, _}, &1))
+    end
+
+    test "221 with an empty mode param does not wipe the set" do
+      state = base_state(%{nick: "vjt", umodes: ["i", "w"]})
+      m = msg({:numeric, 221}, ["vjt", ""], {:server, "irc.azzurra.chat"})
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+      assert new_state.umodes == ["i", "w"]
+      refute Enum.any?(effects, &match?({:umode_changed, _}, &1))
+    end
+
+    test "221 carrying only a sign clears the set (a real empty snapshot)" do
+      # `+` alone is well-formed: the server says "you hold no umodes".
+      # Distinct from the garbage case above — this one MUST take effect.
+      state = base_state(%{nick: "vjt", umodes: ["i", "w"]})
+      m = msg({:numeric, 221}, ["vjt", "+"], {:server, "irc.azzurra.chat"})
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+      assert new_state.umodes == []
+      assert {:umode_changed, []} in effects
+    end
+  end
+
+  describe "route/2 — #279 malformed user-mode tokens at the ingress boundary" do
+    test "a self-MODE echo with a garbage mode string does not pollute the umode set" do
+      state = base_state(%{nick: "vjt", umodes: ["i"]})
+      m = msg(:mode, ["vjt", "+w#$%"], {:nick, "vjt", "u", "h"})
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+      assert new_state.umodes == ["i"]
+      refute Enum.any?(effects, &match?({:umode_changed, _}, &1))
+    end
+
+    test "a self-MODE echo still persists the confirmation row on a garbage string" do
+      # Rejecting the FOLD is not rejecting the LINE: the operator still
+      # sees what the server said on the $server window. The persist meta
+      # is display, not a parsed key.
+      state = base_state(%{nick: "vjt", umodes: ["i"]})
+      m = msg(:mode, ["vjt", "+w#$%"], {:nick, "vjt", "u", "h"})
+
+      assert {:cont, _, effects} = EventRouter.route(m, state)
+      assert Enum.any?(effects, &match?({:persist, :mode, %{channel: "$server"}}, &1))
+    end
+
+    test "a garbage self-MODE echo cannot flip the +r identity signal" do
+      # session_identity_effects keys off the +r bit; a malformed string
+      # that happens to contain an `r` must not synthesise an identity
+      # transition out of upstream garbage.
+      state = base_state(%{nick: "vjt", umodes: []})
+      m = msg(:mode, ["vjt", "+r ?"], {:nick, "vjt", "u", "h"})
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+      assert new_state.umodes == []
+      refute Enum.any?(effects, &match?({:session_identity_changed, _}, &1))
+    end
   end
 
   describe "route/2 — 004 RPL_MYINFO supported umodes (#249)" do
@@ -2302,6 +2380,38 @@ defmodule Grappa.Session.EventRouterTest do
 
       assert {:cont, new_state, _} = EventRouter.route(m, state)
       assert new_state.supported_umodes == ["D", "Q", "Z", "a", "g", "i", "o", "w"]
+    end
+
+    # #279 — 004 param 3 is upstream bytes like the 221 param. Un-validated
+    # it emitted the SAME malformed effect one numeric over.
+    test "004 with a garbage usermodes token is rejected whole — set untouched" do
+      state = base_state(%{nick: "vjt", supported_umodes: ["i", "o", "w"]})
+
+      m =
+        msg(
+          {:numeric, 4},
+          ["vjt", "irc.azzurra.chat", "bahamut-2", "x]{K(<Sh", "beI,k,l,imnpst", "bklov"],
+          {:server, "irc.azzurra.chat"}
+        )
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+      assert new_state.supported_umodes == ["i", "o", "w"]
+      refute Enum.any?(effects, &match?({:supported_umodes_changed, _}, &1))
+    end
+
+    test "004 with an empty usermodes token does not wipe the advertised set" do
+      state = base_state(%{nick: "vjt", supported_umodes: ["i", "o", "w"]})
+
+      m =
+        msg(
+          {:numeric, 4},
+          ["vjt", "irc.azzurra.chat", "bahamut-2", "", "beI,k,l,imnpst", "bklov"],
+          {:server, "irc.azzurra.chat"}
+        )
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+      assert new_state.supported_umodes == ["i", "o", "w"]
+      refute Enum.any?(effects, &match?({:supported_umodes_changed, _}, &1))
     end
 
     test "004 with too-few params does not match (no crash, no fold)" do


### PR DESCRIPTION
Fixes the #279 malformed-effect class at the boundary, and un-does the
half-cerotto that answered it the first time.

## The defect

`walk_umodes/3` did `MapSet.put` of ANY byte, so a fuzzed `221 RPL_UMODEIS`
param emitted `{:umode_changed, [" ", "!", "\"", …]}`. A real ircd only sends
`+iwx`, so it never fired in production — it fired in CI, on whichever seeds
drew numeric 221.

## What the boundary validates now, and on what source of truth

The mode letter **SET** is per-ircd (bahamut `+iwxs`, solanum `+DQZagiow`,
extension-registered letters) and grappa stays agnostic to it. I did **not**
validate against `supported_umodes` (004): an under-advertising server would
then silently drop a real umode, and a 221 can arrive before any 004.

What is closed is the **grammar**: an RFC-2812 mode block is signs + ALPHA.
That is the widest rule that still rejects the fuzz, so it is the contract —
`Identifier.valid_mode_letter?/1`, one predicate shared by the handlers *and*
by the property that pins them, so a future ircd letter cannot be green in one
and red in the other.

Posture: **reject the whole token**, not the bad bytes. A mode string is one
atomic statement about the session; a half-parsed one publishes a set the
server never claimed. Empty is a rejection too (it asserts nothing and would
let a truncated line WIPE the set); a bare `+` stays a valid empty snapshot.

Two extras that fell out:

* **One verdict, two readers.** The self-MODE branch reads the same bytes
  twice — the umode fold and `set_r_mode?/1`, the `+r` detector that commits a
  staged registration secret as confirmed. Gating only the fold would leave a
  malformed line able to confirm a secret. The `$server` row still persists:
  rejecting the FOLD is not rejecting the LINE.
* **004 RPL_MYINFO** is the same boundary one numeric over — un-validated it
  emitted the identical malformed effect as `:supported_umodes_changed`, which
  drives the #249 `/umode` modal's toggles.

**#249 coordination:** no effect SHAPE changed. `{:umode_changed, [letters]}`
is what it always was, so there is nothing to settle once — only the domain of
the letters got narrower.

## The property was the other half of the job

`c45bf1b3` (a #373 review commit) reddened on seed 671214 and answered it in
the test: it added a `{:umode_changed, modes}` arm asserting `is_list` +
`all is_binary`. **Half of that was legitimate** — the arm did not exist, so
before it *every* `:umode_changed` flunked, including `["i","w"]`. The other
half was the cerotto: `is_binary/1` is exactly what `" "` and `"!"` satisfy.

So "restore the pre-widening allowlist" was **not** the fix: that allowlist
rejected the legitimate case. The narrowing here is stricter than either — the
arm asserts the letter class, via the production predicate.

## Measured by displacement

With production reverted and the restricted tests kept:

* `--seed 671214` reproduces the original counterexample exactly — numeric
  221, *after 80 successful runs*, `[" ", "\"", "$", "'", ")", …]` — and the
  restricted arm catches it. 3 properties red.
* Same seed on the fixed handler: green. Also green on seeds 0/1/42/999999/123456.
* Two new targeted properties hit the 221 and 004 params on **every** generated
  example, so the class stops depending on a seed drawing a 1-in-999 numeric.
* Unit tests went red-first with the defect printed in the failure
  (`[" ", "#", "&", "9", …]`), then green.

`scripts/check.sh` exit 0: 8 doctests, 52 properties, 5164 tests, 0 failures;
dialyzer 0; sobelow/credo --strict/doctor clean; bats 0 `not ok`.

## What I refuse to claim

This does **not** close the malformed-effect class — only its umode half.
Measured, not assumed: `MODE #chan "+n!$ "` still yields
`{:channel_modes_changed, "#chan", %{modes: [" ", "$", "!", "n"]}}`, and the
property's arm for it (`is_list(entry.modes)`) is the same
certificate-of-nothing one effect over. Not fixed here because channel mode
letters consume ARGS through the ISUPPORT CHANMODES/PREFIX tables: a
whole-token rejection has to be agreed by `walk_modes/5`, `walk_channel_modes/5`
and the 324 snapshot together, with ban/key/limit arg-alignment as the risk
surface. Worth its own issue.

Nor does it claim any production symptom was fixed: no ircd sends these bytes.
The value delivered is an unvalidated ingress closed and an intermittent main
red made deterministic.