### PR TITLE
cic(#96): sidebar a11y — named groups, spoken state, focus rings (tree role withheld)

### DIFF
--- a/cicchetto/src/Sidebar.tsx
+++ b/cicchetto/src/Sidebar.tsx
@@ -86,6 +86,17 @@ import NickText from "./NickText";
 const NOT_JOINED_STATES = new Set(["invited", "failed", "kicked", "parked"]);
 const NETWORK_GREYED_STATES = new Set(["parked", "failed"]);
 
+// #96 — a row's state, spoken. Every non-live sidebar row is rendered muted +
+// italic and NOTHING else: a screen reader gets no signal at all, and the
+// greyed (parked / failed / invited / kicked) and parted treatments are
+// pixel-identical, so a sighted operator can't tell them apart either. This
+// folds the word into the button's accessible name ("#italia (parked)")
+// without touching a single pixel. Renders nothing when there's no state to
+// report, so a live row's name is unchanged.
+const RowState: Component<{ state: string | null }> = (props) => (
+  <Show when={props.state}>{(state) => <span class="sr-only"> ({state()})</span>}</Show>
+);
+
 export type Props = Record<string, never>;
 
 const Sidebar: Component<Props> = () => {
@@ -94,24 +105,49 @@ const Sidebar: Component<Props> = () => {
     return s !== null && s.networkSlug === slug && s.channelName === name;
   };
 
+  // #96 — the row a keyboard/screen-reader operator is ON. Selection was
+  // conveyed by the `.selected` class alone (background + accent colour), so
+  // an assistive tech had no way to tell which of N rows is the open window.
+  // `aria-current` is the annotation for "the one in a set that is current";
+  // it goes on the <button> (the focusable node the AT lands on), not the
+  // <li> that carries the class.
+  const ariaCurrent = (slug: string, name: string): "true" | undefined =>
+    isSelected(slug, name) ? "true" : undefined;
+
   // CP19 T32: network-level greyed when the credential is parked or
   // failed. Drives both the network header `.sidebar-network-greyed`
   // class AND the cascading per-channel/per-query overlay in
-  // `isGreyed/2` below.
+  // `greyedState/2` below.
   //
   // Bucket F H4: only UserNetwork carries connection_state. Narrow on
   // network.kind first; visitor networks are never greyed at the
   // network level (visitors have no credential row to park / fail).
-  const isNetworkGreyed = (slug: string): boolean => {
+  //
+  // #96 — returns the STATE WORD, not a boolean: the greyed treatment is
+  // muted + italic, which is (a) invisible to a screen reader and (b)
+  // pixel-identical to the `.parted` treatment, so not even a sighted
+  // operator can tell "network parked" from "you left this channel". One
+  // derivation feeds both consumers — the class (colour) and the sr-only
+  // word (announced) — so the two can never disagree.
+  const networkGreyedState = (slug: string): string | null => {
     const net = networkBySlug(slug);
-    return net?.kind === "user" && NETWORK_GREYED_STATES.has(net.connection_state);
+    if (net?.kind !== "user") return null;
+    return NETWORK_GREYED_STATES.has(net.connection_state) ? net.connection_state : null;
   };
 
-  const isGreyed = (slug: string, name: string): boolean => {
-    if (isNetworkGreyed(slug)) return true;
-    const s = windowStateByChannel()[channelKey(slug, name)];
-    return s !== undefined && NOT_JOINED_STATES.has(s);
+  const isNetworkGreyed = (slug: string): boolean => networkGreyedState(slug) !== null;
+
+  // Network cascade wins over the per-window state deliberately: when the
+  // credential is parked, EVERY row under it is unreachable regardless of
+  // what its own window state last said. Same precedence the boolean had.
+  const greyedState = (slug: string, name: string): string | null => {
+    const cascade = networkGreyedState(slug);
+    if (cascade !== null) return cascade;
+    const own = windowStateByChannel()[channelKey(slug, name)];
+    return own !== undefined && NOT_JOINED_STATES.has(own) ? own : null;
   };
+
+  const isGreyed = (slug: string, name: string): boolean => greyedState(slug, name) !== null;
 
   const networkReason = (slug: string): string | undefined => {
     const net = networkBySlug(slug);
@@ -187,6 +223,7 @@ const Sidebar: Component<Props> = () => {
           <button
             type="button"
             class="sidebar-window-btn sidebar-home-btn"
+            aria-current={ariaCurrent(HOME_WINDOW_SLUG, HOME_WINDOW_NAME)}
             onClick={() => handleClick(HOME_WINDOW_SLUG, HOME_WINDOW_NAME, "home")}
           >
             <span class="sidebar-home-emoji" aria-hidden="true">
@@ -210,6 +247,7 @@ const Sidebar: Component<Props> = () => {
             <button
               type="button"
               class="sidebar-window-btn sidebar-admin-btn"
+              aria-current={ariaCurrent(ADMIN_WINDOW_SLUG, ADMIN_WINDOW_NAME)}
               data-testid="sidebar-admin-row"
               onClick={() => handleClick(ADMIN_WINDOW_SLUG, ADMIN_WINDOW_NAME, "admin")}
             >
@@ -229,8 +267,18 @@ const Sidebar: Component<Props> = () => {
         <For each={networks()}>
           {(network) => (
             <>
+              {/* #96 — the per-network <ul> is the grouping the sidebar draws
+                  with a rail and a tinted header row; unnamed, a screen
+                  reader announced it as a bare "list, 6 items" and the
+                  network→window hierarchy was carried by pixels only. Naming
+                  the list is the whole of that hierarchy expressible without
+                  restructuring the DOM (see the tree-role note in the #96 PR
+                  body). The home + admin <ul>s stay unnamed on purpose: they
+                  are identity-scoped SINGLE rows, not groups — a name there
+                  would just repeat the row's own label. */}
               <ul
                 class={`sidebar-network-section${isNetworkGreyed(network.slug) ? " sidebar-network-greyed" : ""}`}
+                aria-label={`${network.slug} windows`}
               >
                 {/* UX-4 bucket C — network header + server window collapsed
                   into a single row. The old per-network `<h3>` is gone; this
@@ -248,6 +296,7 @@ const Sidebar: Component<Props> = () => {
                     type="button"
                     onClick={() => handleClick(network.slug, SERVER_WINDOW_NAME, "server")}
                     class="sidebar-window-btn"
+                    aria-current={ariaCurrent(network.slug, SERVER_WINDOW_NAME)}
                   >
                     {/* #71 INC-1 — the leading ⚙️ network-emoji is REMOVED.
                       It made the server line read reverse-indented against the
@@ -265,6 +314,10 @@ const Sidebar: Component<Props> = () => {
                     >
                       {network.slug}
                     </span>
+                    {/* #96 — the greyed network header's only cue is
+                        muted+italic (`.sidebar-network-greyed`) plus a `title`
+                        tooltip, and a tooltip is mouse-only. Speak the state. */}
+                    <RowState state={networkGreyedState(network.slug)} />
                     {/* C8.3 — away visual indicator. Surfaces on the
                       collapsed network-header row when the user is in away
                       state on this network. Driven by `away_confirmed`
@@ -358,6 +411,7 @@ const Sidebar: Component<Props> = () => {
                     type="button"
                     onClick={() => handleClick(network.slug, LIST_WINDOW_NAME, "list")}
                     class="sidebar-window-btn"
+                    aria-current={ariaCurrent(network.slug, LIST_WINDOW_NAME)}
                   >
                     <span class="sidebar-network-emoji" aria-hidden="true">
                       📇
@@ -385,6 +439,7 @@ const Sidebar: Component<Props> = () => {
                       type="button"
                       onClick={() => handleClick(network.slug, "", "mentions")}
                       class="sidebar-window-btn"
+                      aria-current={ariaCurrent(network.slug, "")}
                     >
                       <span class="sidebar-network-emoji" aria-hidden="true">
                         @
@@ -407,6 +462,7 @@ const Sidebar: Component<Props> = () => {
                           type="button"
                           onClick={() => handleClick(network.slug, channel.name, "channel")}
                           class={`sidebar-window-btn${isGreyed(network.slug, channel.name) ? " sidebar-window-greyed" : ""}`}
+                          aria-current={ariaCurrent(network.slug, channel.name)}
                         >
                           <span
                             class="sidebar-channel-name"
@@ -414,6 +470,14 @@ const Sidebar: Component<Props> = () => {
                           >
                             {channel.name}
                           </span>
+                          {/* #96 — two independent colour-only states on this
+                              one row: `.parted` (we left, window kept open) and
+                              the greyed overlay (network parked/failed, or the
+                              window's own not-joined state). They render
+                              IDENTICALLY (muted + italic), so speaking them is
+                              the only way either is distinguishable at all. */}
+                          <RowState state={channel.joined ? null : "parted"} />
+                          <RowState state={greyedState(network.slug, channel.name)} />
                           <Show when={(messagesUnread()[key] ?? 0) > 0}>
                             <span class="sidebar-msg-unread">{messagesUnread()[key]}</span>
                           </Show>
@@ -473,6 +537,7 @@ const Sidebar: Component<Props> = () => {
                             ? "sidebar-window-btn sidebar-window-pending"
                             : "sidebar-window-btn sidebar-window-greyed"
                         }
+                        aria-current={ariaCurrent(network.slug, row.name)}
                       >
                         <span
                           class="sidebar-channel-name"
@@ -480,6 +545,12 @@ const Sidebar: Component<Props> = () => {
                         >
                           {row.name}
                         </span>
+                        {/* #96 — the pseudo row IS its state (pending /
+                            invited / failed / kicked / parked) and carries it
+                            in `data-window-state` for e2e, but rendered it to
+                            the operator as opacity + italic only. Speak the
+                            same word the test seam already exposes. */}
+                        <RowState state={row.state} />
                       </button>
                       {/* UX-5 bucket BK (2026-05-19): × on every pseudo-row.
                         Pre-BK pseudo-rows were uncloseable — a failed JOIN
@@ -520,8 +591,10 @@ const Sidebar: Component<Props> = () => {
                           type="button"
                           onClick={() => handleClick(network.slug, qw.targetNick, "query")}
                           class={`sidebar-window-btn${isGreyed(network.slug, qw.targetNick) ? " sidebar-window-greyed" : ""}`}
+                          aria-current={ariaCurrent(network.slug, qw.targetNick)}
                         >
                           <NickText nick={qw.targetNick} extraClass="sidebar-channel-name" />
+                          <RowState state={greyedState(network.slug, qw.targetNick)} />
                           <Show when={(messagesUnread()[key] ?? 0) > 0}>
                             <span class="sidebar-msg-unread">{messagesUnread()[key]}</span>
                           </Show>

--- a/cicchetto/src/__tests__/Sidebar.test.tsx
+++ b/cicchetto/src/__tests__/Sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { fireEvent, render, screen, within } from "@solidjs/testing-library";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 let mockNetworkConnectionState: Record<string, string | undefined> = {};
@@ -75,8 +75,15 @@ vi.mock("../lib/networks", () => ({
   user: () => mockUser,
 }));
 
+// #96 — aria-current marks the OPEN window row. The pre-#96 mock pinned
+// `selectedChannel` to null forever, so nothing in this file could ever drive
+// the selected branch; make it a holder like the other mutable mocks (reset
+// to null in beforeEach, so every pre-#96 test keeps its "nothing selected"
+// world unchanged).
+let mockSelectedChannel: { networkSlug: string; channelName: string; kind: string } | null = null;
+
 vi.mock("../lib/selection", () => ({
-  selectedChannel: () => null,
+  selectedChannel: () => mockSelectedChannel,
   setSelectedChannel: vi.fn(),
   isActiveSelection: (next: unknown) => isActiveSelectionMock(next),
   unreadCounts: () => ({ "freenode #bnc": 3 }),
@@ -202,16 +209,32 @@ import * as qwMod from "../lib/queryWindows";
 import * as scrollCmd from "../lib/scrollToBottomCommand";
 import * as selMod from "../lib/selection";
 // windowKinds is NOT mocked — import constants from the real module.
-import { LIST_WINDOW_NAME } from "../lib/windowKinds";
+import {
+  HOME_WINDOW_NAME,
+  HOME_WINDOW_SLUG,
+  LIST_WINDOW_NAME,
+  SERVER_WINDOW_NAME,
+} from "../lib/windowKinds";
 import Sidebar from "../Sidebar";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // #96 — `clearAllMocks` clears CALL HISTORY but keeps a spy's
+  // implementation, so the two `vi.spyOn(selMod, "selectedChannel")
+  // .mockReturnValue(...)` in the pseudo-row × block leaked their return
+  // value into every test that ran after them: from that point on the
+  // sidebar believed `#italia` was the open window. Nothing noticed while
+  // selection had no observable output beyond a CSS class no later test
+  // asserted — the #96 `aria-current` tests are its first readers, and they
+  // failed in-suite while passing in isolation. Restore the real binding
+  // between tests.
+  vi.restoreAllMocks();
   mockWindowState = {};
   mockNetworkConnectionState = {};
   mockNetworkConnectionReason = {};
   mockAwayByNetwork = {};
   mockMentionsBundles = {};
+  mockSelectedChannel = null;
   adminHolder.value = false;
   // #71 INC-1 — default logged-in user so the own-nick footer renders; the
   // logged-out test flips this to null.
@@ -1043,6 +1066,117 @@ describe("Sidebar", () => {
       const { container } = render(() => <Sidebar />);
       const footer = container.querySelector('[data-testid="sidebar-own-nick-freenode"]');
       expect(footer?.querySelector(".sidebar-window-btn")).toBeNull();
+    });
+  });
+
+  // #96 — accessibility pass. Every assertion below queries by ROLE and by
+  // ACCESSIBLE NAME: that is the thing an assistive tech actually consumes.
+  // Asserting `getAttribute("aria-current")` or the presence of a `.sr-only`
+  // node would pass just as happily with the attribute on the wrong element,
+  // or on an element the name computation ignores — it would prove markup,
+  // not announceability.
+  describe("#96 — accessibility", () => {
+    it("each network's windows are a group a screen reader can enter BY NAME", () => {
+      render(() => <Sidebar />);
+      const group = screen.getByRole("list", { name: "freenode windows" });
+      // Named AND owning the rows — a label on an empty/wrong list would
+      // satisfy the name alone.
+      expect(within(group).getByRole("button", { name: /^#italia/ })).toBeInTheDocument();
+      expect(within(group).getByRole("button", { name: /^alice/ })).toBeInTheDocument();
+    });
+
+    it("the open window is the one row discoverable as current", () => {
+      mockSelectedChannel = { networkSlug: "freenode", channelName: "#bnc", kind: "channel" };
+      render(() => <Sidebar />);
+      const current = screen.getAllByRole("button", { current: true });
+      expect(current).toHaveLength(1);
+      expect(current[0]).toHaveTextContent("#bnc");
+    });
+
+    it("no row claims to be current when nothing is selected", () => {
+      render(() => <Sidebar />);
+      expect(screen.queryAllByRole("button", { current: true })).toHaveLength(0);
+    });
+
+    it("current-ness follows the selection onto a non-channel row (home)", () => {
+      mockSelectedChannel = {
+        networkSlug: HOME_WINDOW_SLUG,
+        channelName: HOME_WINDOW_NAME,
+        kind: "home",
+      };
+      render(() => <Sidebar />);
+      const current = screen.getAllByRole("button", { current: true });
+      expect(current).toHaveLength(1);
+      // The home row's LABEL is "Home" (the `$home` slug is the routing key,
+      // never shown) — assert what a screen reader would read out.
+      expect(current[0]).toHaveTextContent("Home");
+    });
+
+    it("current-ness follows the selection onto the network's server row", () => {
+      mockSelectedChannel = {
+        networkSlug: "freenode",
+        channelName: SERVER_WINDOW_NAME,
+        kind: "server",
+      };
+      render(() => <Sidebar />);
+      const current = screen.getAllByRole("button", { current: true });
+      expect(current).toHaveLength(1);
+      expect(current[0]).toHaveTextContent("freenode");
+    });
+
+    it("a live row's name carries no state suffix", () => {
+      render(() => <Sidebar />);
+      expect(screen.getByRole("button", { name: /^#italia/ })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /^#italia\s*\(/ })).toBeNull();
+    });
+
+    it("a parted channel SAYS parted — the muted+italic cue is silent", () => {
+      render(() => <Sidebar />);
+      // #azzurra is joined: false in the channelsBySlug mock.
+      expect(screen.getByRole("button", { name: /^#azzurra\s*\(parted\)/ })).toBeInTheDocument();
+    });
+
+    it("a greyed row stays in the list AND names its state (invited)", () => {
+      mockWindowState = { "freenode #italia": "invited" };
+      render(() => <Sidebar />);
+      // Still a reachable row — greying must never remove a window from the
+      // sidebar (its scrollback is the reason the row survives a failed JOIN).
+      expect(screen.getByRole("button", { name: /^#italia\s*\(invited\)/ })).toBeInTheDocument();
+    });
+
+    it("each not-joined state names ITSELF, not a generic 'unavailable'", () => {
+      for (const state of ["invited", "failed", "kicked", "parked"]) {
+        mockWindowState = { "freenode #bnc": state };
+        const { unmount } = render(() => <Sidebar />);
+        expect(
+          screen.getByRole("button", { name: new RegExp(`^#bnc\\s*\\(${state}\\)`) }),
+        ).toBeInTheDocument();
+        unmount();
+      }
+    });
+
+    it("a pending row names itself pending (it is not greyed, and not silent)", () => {
+      mockWindowState = { "freenode #new": "pending" };
+      render(() => <Sidebar />);
+      expect(screen.getByRole("button", { name: /^#new\s*\(pending\)/ })).toBeInTheDocument();
+    });
+
+    it("a parked NETWORK speaks the cascade on the header AND on every row under it", () => {
+      mockNetworkConnectionState = { freenode: "parked" };
+      render(() => <Sidebar />);
+      expect(screen.getByRole("button", { name: /^freenode\s*\(parked\)/ })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /^#italia\s*\(parked\)/ })).toBeInTheDocument();
+      // The DM row derives from the same cascade — a parked network takes the
+      // query windows down with it.
+      expect(screen.getByRole("button", { name: /^alice\s*\(parked\)/ })).toBeInTheDocument();
+    });
+
+    it("the network cascade OUTRANKS a row's own state (parked network, invited window)", () => {
+      mockNetworkConnectionState = { freenode: "failed" };
+      mockWindowState = { "freenode #italia": "invited" };
+      render(() => <Sidebar />);
+      expect(screen.getByRole("button", { name: /^#italia\s*\(failed\)/ })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /^#italia\s*\(invited\)/ })).toBeNull();
     });
   });
 });

--- a/cicchetto/src/__tests__/focusVisible.test.ts
+++ b/cicchetto/src/__tests__/focusVisible.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { focusRules } from "./helpers/themeCss";
+
+// #96 — keyboard focus visibility.
+//
+// WHAT THIS PROVES: the stylesheet never takes the focus indicator away
+// without putting one back, and the surfaces #96 names carry an authored
+// ring. Both are source-level invariants over `src/themes/default.css`.
+//
+// WHAT THIS DOES NOT PROVE — and no jsdom test can:
+//   * that a ring is actually PAINTED. jsdom has no layout and nwsapi does
+//     not match `:focus-visible`, so `getComputedStyle` after `.focus()`
+//     returns nothing useful. Only a real browser can answer that.
+//   * that the ring has sufficient CONTRAST. `--accent` is a per-theme token
+//     and operators author their own themes (lib/customTheme.ts), so the
+//     contrast ratio is not a property of this file at all.
+//   * that the ring is not CLIPPED by an ancestor's overflow. That is
+//     geometry; it needs a browser.
+// The ring geometry chosen here (inset on the edge-to-edge sidebar rows,
+// outset on the padded chrome buttons) is an argued choice, NOT a measured
+// one. See the #96 PR body.
+
+describe("#96 — focus indicators are never silently removed", () => {
+  // The defect this catches, in its original form: BOTH of the stylesheet's
+  // two `:focus-visible` rules read `{ color: var(--fg); outline: none }`.
+  // They suppressed the UA ring for keyboard users and left a colour shift
+  // as the only cue — an indicator with no area. A rule may still legally
+  // drop the outline, but only by supplying its own indicator (the text
+  // inputs do this: they swap the outline for an accent border).
+  const REPLACEMENTS = ["box-shadow", "border-color"];
+
+  it("no focus rule suppresses the outline without supplying an indicator", () => {
+    const offenders = focusRules()
+      .filter(({ body }) => /outline:\s*(none|0)\s*;/.test(body))
+      .filter(({ body }) => !/outline:\s*(?!none|0)/.test(body))
+      .filter(({ body }) => !REPLACEMENTS.some((decl) => body.includes(decl)))
+      .map(({ selectors }) => selectors);
+
+    expect(offenders).toEqual([]);
+  });
+
+  // #96's named surfaces. The sidebar is the app's primary keyboard
+  // navigation surface and shipped with NO authored focus style: whatever
+  // the UA happened to draw was the cue, on every theme.
+  const RINGED = [
+    ".sidebar-home-section li .sidebar-window-btn:focus-visible",
+    ".sidebar-admin-section li .sidebar-window-btn:focus-visible",
+    ".sidebar-network-section li .sidebar-window-btn:focus-visible",
+    ".sidebar-network-section li .sidebar-close:focus-visible",
+    ".sidebar-network-section li .sidebar-umode-indicator:focus-visible",
+    ".shell-chrome-btn:focus-visible",
+    ".settings-drawer-close:focus-visible",
+    ".service-modal-prompt-input:focus-visible",
+  ];
+
+  it.each(RINGED)("%s declares a visible outline", (selector) => {
+    const owning = focusRules().filter(({ selectors }) => selectors.includes(selector));
+    expect(owning.length).toBeGreaterThan(0);
+    const withRing = owning.filter(({ body }) => /outline:\s*\d/.test(body));
+    expect(withRing.length).toBeGreaterThan(0);
+  });
+});

--- a/cicchetto/src/__tests__/focusVisible.test.ts
+++ b/cicchetto/src/__tests__/focusVisible.test.ts
@@ -29,10 +29,28 @@ describe("#96 — focus indicators are never silently removed", () => {
   // inputs do this: they swap the outline for an accent border).
   const REPLACEMENTS = ["box-shadow", "border-color"];
 
+  // Declaration-level, not a regex over the block: a `/outline:\s*(?!none)/`
+  // "does it also set a real outline?" guard backtracks its own `\s*` to zero
+  // and matches `outline: none` itself, which made the first cut of this test
+  // unfalsifiable — the mutation that re-suppressed a ring left it green.
+  // Last write wins, as the cascade does inside one block.
+  const outlineValue = (body: string): string | null => {
+    let value: string | null = null;
+    for (const decl of body.split(";")) {
+      const colon = decl.indexOf(":");
+      if (colon < 0) continue;
+      if (decl.slice(0, colon).trim() !== "outline") continue;
+      value = decl.slice(colon + 1).trim();
+    }
+    return value;
+  };
+
   it("no focus rule suppresses the outline without supplying an indicator", () => {
     const offenders = focusRules()
-      .filter(({ body }) => /outline:\s*(none|0)\s*;/.test(body))
-      .filter(({ body }) => !/outline:\s*(?!none|0)/.test(body))
+      .filter(({ body }) => {
+        const outline = outlineValue(body);
+        return outline === "none" || outline === "0";
+      })
       .filter(({ body }) => !REPLACEMENTS.some((decl) => body.includes(decl)))
       .map(({ selectors }) => selectors);
 
@@ -56,7 +74,7 @@ describe("#96 — focus indicators are never silently removed", () => {
   it.each(RINGED)("%s declares a visible outline", (selector) => {
     const owning = focusRules().filter(({ selectors }) => selectors.includes(selector));
     expect(owning.length).toBeGreaterThan(0);
-    const withRing = owning.filter(({ body }) => /outline:\s*\d/.test(body));
+    const withRing = owning.filter(({ body }) => /^\d/.test(outlineValue(body) ?? ""));
     expect(withRing.length).toBeGreaterThan(0);
   });
 });

--- a/cicchetto/src/__tests__/helpers/themeCss.ts
+++ b/cicchetto/src/__tests__/helpers/themeCss.ts
@@ -19,6 +19,29 @@ export const themeCss = readFileSync("src/themes/default.css", "utf8");
  * so a rename can't silently pass the test — the #734 failure mode was a
  * class name with NO rule behind it at all.
  */
+/**
+ * Every rule whose selector list mentions a focus state (`:focus` or
+ * `:focus-visible`), as `{ selectors, body }` pairs with CSS comments
+ * stripped. Matches INNERMOST blocks only — the `[^{}]` classes can't span a
+ * brace, so an `@media` prelude is never captured as a selector, and a rule
+ * nested inside one still is.
+ *
+ * Grouped selector lists come back whole (`a:focus-visible,\n b:focus-visible`)
+ * rather than split, so a caller asking "is this surface covered?" must look
+ * inside the list — which is what `#96` needs: the sidebar's ring is one rule
+ * over five selectors on purpose.
+ */
+export function focusRules(): { selectors: string; body: string }[] {
+  const stripped = themeCss.replace(/\/\*[\s\S]*?\*\//g, "");
+  const out: { selectors: string; body: string }[] = [];
+  for (const match of stripped.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    const selectors = match[1] ?? "";
+    const body = match[2] ?? "";
+    if (selectors.includes(":focus")) out.push({ selectors: selectors.trim(), body });
+  }
+  return out;
+}
+
 export function ruleBody(selector: string): string {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const re = new RegExp(`^${escaped}\\s*\\{([^}]*)\\}`, "m");

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -1686,6 +1686,34 @@ html.resize-dragging * {
   padding-left: 0.75rem;
 }
 
+/* #96 — keyboard focus ring for every interactive sidebar surface. The
+   sidebar is the app's primary keyboard navigation surface and it shipped
+   with no authored focus style at all: whatever the UA drew was the cue, on
+   every theme, including operator-authored ones.
+
+   `:focus-visible`, NOT `:focus` — a ring on a mouse click is noise, and
+   these rows are clicked far more often than they are tabbed to.
+
+   `outline-offset: -2px` (INSET) because the window buttons are edge-to-edge
+   (`flex: 1 1 auto` inside a full-width `<li>`) inside a scrolling aside: an
+   outset ring gets clipped on the left and right by the container. The ×
+   and the umode chip are inset for the same reason — one ring geometry for
+   the whole surface, not two.
+
+   All three sections in ONE rule: home / admin / per-network rows are the
+   same affordance and must not drift into three focus treatments. The
+   section-qualified selectors keep specificity above the base
+   `.sidebar-*-section li .sidebar-window-btn` rules (biome
+   `noDescendingSpecificity`). */
+.sidebar-home-section li .sidebar-window-btn:focus-visible,
+.sidebar-admin-section li .sidebar-window-btn:focus-visible,
+.sidebar-network-section li .sidebar-window-btn:focus-visible,
+.sidebar-network-section li .sidebar-close:focus-visible,
+.sidebar-network-section li .sidebar-umode-indicator:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
 /* #71 INC-1 — own-nick footer (per network). The operator's IRC nick was
    shown nowhere; surface it as a quiet identity line at the bottom of each
    network group, below the grouping rail. Muted frame + 👤 so it reads as
@@ -2235,7 +2263,18 @@ html.resize-dragging * {
 .shell-chrome-btn:hover,
 .shell-chrome-btn:focus-visible {
   color: var(--fg);
-  outline: none;
+}
+
+/* #96 — keyboard focus ring. `:focus-visible`, NOT `:focus`: a ring that
+   appears on a mouse click is noise, and these buttons are clicked far more
+   than they are tabbed to. The rule this REPLACES paired the colour lift with
+   `outline: none`, i.e. it suppressed the UA ring for keyboard users and left
+   a --muted → --fg colour shift as the only cue — a colour-only indicator with
+   no area (WCAG 1.4.11). Ring is offset OUTSIDE: chrome buttons sit in a row
+   with spare padding around them. */
+.shell-chrome-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 /* Scrollback (existing rules — minor additions for mention highlight) */
@@ -3449,7 +3488,14 @@ html.resize-dragging * {
 .settings-drawer-close:hover,
 .settings-drawer-close:focus-visible {
   color: var(--fg);
-  outline: none;
+}
+
+/* #96 — same suppression as `.shell-chrome-btn` (see the comment there):
+   the drawer × had `outline: none` under `:focus-visible`, leaving a bare
+   colour shift as the keyboard cue. */
+.settings-drawer-close:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 /* UX-4 bucket L — bottom "done" button (mobile thumb-reach surface). */
@@ -6943,6 +6989,18 @@ html.resize-dragging * {
   border: none;
   outline: none;
   padding: 0.25rem 0;
+}
+
+/* #96 — this input is the one focus surface in the app with NO cue at all:
+   `border: none` + `outline: none` above, and (unlike every other text field,
+   which swaps the UA outline for an accent border) nothing put back. Inset
+   ring so it can't be clipped by the prompt row's own frame. `:focus-visible`
+   always matches a focused text field, mouse or keyboard — the mouse-noise
+   argument that governs the buttons doesn't apply here; the spelling is for
+   consistency, not behaviour. */
+.service-modal-prompt-input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 
 .service-modal-prompt-input::placeholder {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -29545,3 +29545,63 @@ than a parameter worth adding. And the guard remains a per-verb habit, not a
 whole-module property: a new `await` that captures the token and skips the
 check reopens the defect for its own call path — one owner makes the rule
 greppable, it does not make it automatic.
+
+## 2026-08-05 — #96: naming what the sidebar draws, and NOT declaring a tree
+
+Issue #96 asks for tree semantics on the channel sidebar, tap targets, and
+focus contrast. The tap targets landed earlier of their own accord (#204/#306/
+#459 put `--chrome-tap-min: 48px` / `--tap-min: 44px` on the sidebar rows).
+This entry is the other two thirds, and the one thing deliberately NOT done.
+
+**`role="tree"` is not shipped, on purpose, pending vjt.** A tree is the most
+keyboard-dependent role in ARIA: the APG pattern is a composite widget with a
+single tab stop, roving `tabindex`, and Up/Down/Home/End arrow navigation.
+Declaring the role without that contract tells an assistive tech "arrows work
+here" when they do not — the first rule of ARIA, no ARIA beats bad ARIA. And
+implementing the contract is not free here: roving tabindex takes every
+sidebar row's `×` OUT of the Tab sequence, which REMOVES a keyboard affordance
+operators have today. Every window row carries a `<CloseButton>` sibling
+inside its `<li>`; a tree makes those unreachable without inventing a second
+key binding for them.
+
+There is a second, smaller obstacle: the sidebar renders three or more
+sibling `<ul>`s (home, admin, one per network) inside an `<aside>` that also
+holds `NextActiveButton` and `ResizeHandle`, so a single `role="tree"` needs a
+new wrapper element — and `display: contents` on a role-bearing element has a
+history of dropping it out of the accessibility tree. A per-network tree with
+`aria-level` avoids that, but not the keyboard problem.
+
+**What shipped instead** carries the hierarchy that #96 actually complains
+about, with no DOM restructuring, no layout change, and no new affordance:
+each per-network `<ul>` is NAMED (`aria-label="<slug> windows"`), so it
+announces as "freenode windows, list, 6 items" instead of a bare list, and the
+network → window grouping stops being pure indentation. Home and admin stay
+unnamed: single identity-scoped rows, not groups.
+
+**Two more states were pixels-only and are now spoken.** `aria-current="true"`
+marks the open window (previously the `.selected` class alone), and the
+not-live state rides in the accessible name via an `sr-only` span. That second
+one is not just an AT gap: `.parted` and `.sidebar-window-greyed` are BOTH
+muted + italic, so "you left this channel" and "the network is parked" render
+identically for everyone. `isGreyed/2` became `greyedState/2` returning the
+word, with the boolean derived from it — one derivation behind both the class
+and the announcement, network-parked cascade keeping its precedence.
+
+**Focus.** The stylesheet had exactly two `:focus-visible` rules and both read
+`{ color: var(--fg); outline: none }` — suppressing the UA ring for keyboard
+users in favour of a colour shift with no area. The sidebar, the app's primary
+keyboard surface, had no authored focus style at all. Rings are
+`:focus-visible` (a ring on a mouse click is noise, presumably why the
+suppressions existed), inset on the edge-to-edge rows so the scrolling aside
+cannot clip them. The durable part is `focusRules()` +
+`focusVisible.test.ts`: no focus-state rule may drop the outline without
+supplying its own indicator — the text inputs legitimately swap it for an
+accent border and pass, and both original suppressions would have failed it.
+
+**Limits, stated rather than implied.** None of this proves a ring is painted,
+that it has contrast (`--accent` is per-theme and operators author themes), or
+that VoiceOver reads any of it. jsdom has no layout and nwsapi does not match
+`:focus-visible`; there is no browser on the authoring host. The ring geometry
+is argued, not measured, and everything here is a source-level invariant plus
+role/accessible-name queries — which is the layer an AT consumes, but not the
+layer a human with a screen reader experiences.


### PR DESCRIPTION
Issue #96 asks for three things on the channel sidebar: tree semantics, tap
targets, focus contrast. The tap targets already landed on their own via
#204/#306/#459 (`--chrome-tap-min: 48px` / `--tap-min: 44px`, applied to the
sidebar rows). This is the other two thirds — plus one thing I deliberately
did **not** do.

## The tree role is withheld, and it is your call

`role="tree"` is the most keyboard-dependent role in ARIA. The APG pattern is
a composite widget: one tab stop, roving `tabindex`, Up/Down/Home/End. Ship
the roles without that contract and the widget lies — an AT is told arrows
work when they don't (no ARIA beats bad ARIA). Ship the contract and roving
`tabindex` takes every row's `×` **out of the Tab sequence**: each window row
has a `<CloseButton>` sibling inside its `<li>`, so a tree removes a keyboard
affordance operators have today, unless a second key binding is invented for
it. That reads to me as a redesign, not an a11y annotation, so I stopped.

Smaller second obstacle: the sidebar renders 3+ sibling `<ul>`s (home, admin,
one per network) inside an `<aside>` that also holds `NextActiveButton` and
`ResizeHandle`, so one `role="tree"` needs a new wrapper — and
`display: contents` on a role-bearing element has a history of dropping it out
of the a11y tree. A per-network tree with `aria-level` dodges that but not the
keyboard problem.

Precedent worth knowing before you decide: `AdminPane` already ships
`role="tablist"` + 10 `role="tab"` with no roving tabindex and no arrow keys.
So the codebase has accepted roles-without-the-keyboard-model before. A
tablist degrades gracefully; a tree is the role that degrades worst.

Also worth flagging: #96's stated motivation is **iOS VoiceOver**. The desktop
`Sidebar` is never mounted on mobile — `BottomBar` is. Whatever we do here does
not reach an iPhone.

## What did ship

**Hierarchy, without touching the DOM.** Each per-network `<ul>` is named
(`aria-label="freenode windows"`), so it announces as a named group of 6
instead of a bare "list, 6 items", and the network → window grouping stops
being pure indentation. Home and admin stay unnamed on purpose: single
identity-scoped rows, not groups.

**Two states that were pixels and nothing else.**
* `aria-current="true"` on the open window's `<button>` — selection was the
  `.selected` class alone.
* The not-live state now rides in the accessible name (`"#italia (parked)"`)
  via an `sr-only` span. This one isn't only an AT gap: `.parted` and
  `.sidebar-window-greyed` are BOTH muted + italic, so "you left this channel"
  and "the network is parked" are indistinguishable **for everyone**.
  `isGreyed/2` became `greyedState/2` returning the word, with the boolean
  derived from it — one derivation behind the class and the announcement, so
  they cannot disagree; the network-parked cascade keeps its precedence over a
  row's own state.

**Focus.** The whole 9,979-line stylesheet had exactly two `:focus-visible`
rules and *both* read `{ color: var(--fg); outline: none }` — they suppressed
the UA ring for keyboard users and left a `--muted → --fg` colour shift as the
only cue, an indicator with no area. A third surface
(`.service-modal-prompt-input`) has `border: none` + `outline: none` and puts
nothing back at all. The sidebar itself had no authored focus style, so the cue
was whatever the UA drew, on every theme including operator-authored ones.
Rings are `:focus-visible`, never `:focus` (a ring on a mouse click is noise —
presumably why the suppressions were written); inset on the edge-to-edge rows
so the scrolling aside can't clip them, outset on the padded chrome buttons.

Note the premise correction: there is **no global `outline: none` reset**, so
keyboard focus was not invisible app-wide — the UA ring survives everywhere
nobody killed it. The defect is narrower and sharper than "largely invisible":
three surfaces that removed it, and a primary nav surface that never authored
one.

## How it's tested

Every sidebar assertion queries by **role and accessible name** — the thing an
AT actually consumes. `getAttribute("aria-current")` would pass with the
attribute on an element the name computation ignores.

Mutations, each reverted after measuring:

| mutation | red |
|---|---|
| drop `aria-current` on the channel row | 1 |
| drop the per-network group name | 1 |
| drop the greyed state word | 4 |
| re-suppress the ring on `.shell-chrome-btn:focus-visible` | 2 |
| delete the sidebar ring rule | 5 |
| re-scope that ring `:focus-visible` → `:focus` | 1 |
| add a BRAND NEW suppressing rule on an unlisted surface | 1 |

That last one matters: the stylesheet invariant generalises past the surfaces
I enumerated. It is the durable half of this PR — no focus-state rule may drop
the outline without supplying its own indicator (text inputs legitimately swap
it for an accent border and pass; both original suppressions would have
failed).

**The first cut of that invariant was unfalsifiable and the mutation caught
it.** `/outline:\s*(?!none|0)/` backtracks its `\s*` to zero width, lands the
lookahead on the space before `none`, and matches `outline: none` itself — so
every suppressor was filtered out as a non-suppressor and the offenders list
was structurally always empty. Re-suppressing a ring left it green. Rewritten
as a declaration-level read; now that mutation turns it red. Separate commit.

**Bug found on the way:** `vi.clearAllMocks()` clears call history but keeps a
spy's implementation, so two `vi.spyOn(selMod, "selectedChannel")` calls in the
pseudo-row `×` block leaked "`#italia` is the open window" into every test that
ran after them in `Sidebar.test.tsx`. Nothing had ever read selection's output,
so nothing noticed — these tests failed in-suite while passing in isolation.

## What I refuse to claim

* **That any of this is audible.** No screen reader was run. VoiceOver, NVDA
  and JAWS each differ on when they insert a separator between adjacent text
  nodes, which is exactly the seam the state word sits in — the tests match
  `\s*` before it precisely because `dom-accessibility-api` concatenates
  without one where browsers add one.
* **That a ring is painted, has contrast, or isn't clipped.** jsdom has no
  layout and nwsapi doesn't match `:focus-visible`; there is no browser on this
  host to measure with. `--accent` is a per-theme token and operators author
  their own themes, so contrast isn't a property of this stylesheet at all. The
  inset-vs-outset geometry is **argued, not measured**.
* **That the greyed rows behave correctly on a real network park.** The
  cascade is exercised against the mocked `connection_state`; the derivation is
  unchanged from what shipped, only its return type moved from `boolean` to the
  word.

If you want the ring geometry or the announcements verified for real, that
needs an e2e (STACK lane) or a device check — say the word and I'll ask for
the lane rather than pretend jsdom covered it.

## Gates

`bun run check` rc=0 · `bun run test` rc=0 — 237 files / 4317 tests
(baseline at the merge-base: 236 / 4296; +21 = 12 sidebar + 9 focus).
Working tree clean before and after both runs. cic-only, no lane consumed.