### PR TITLE
shottino(#880): link call/main.c into a sanitized test binary

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -29098,12 +29098,15 @@ window. Latent only because `call_helper_start` never passes `--verbose`.
 Both ways this stream can break are byte-level and silent at runtime — a line
 that is neither comment nor JSON, and a value that escapes its own string — so
 both are now pinned. Worth recording separately: **no CI job compiles the call
-helper.** `make` builds `shottino`, `make check` builds the suites, and `make
-call` is opt-in behind cmake and the vendored submodule, so `call/main.c` is
-compiled by nobody in CI. That is how two `-Wformat-nonliteral` warnings sat in
-it unseen (the extraction gives the varargs helpers the format attribute the
-rest of the tree carries, and they are gone). It is also why the changes here
-were syntax-checked by hand against a stub `rtc/rtc.h`.
+helper** — true when this was written, and no longer; see the 2026-08-05 entry
+below for what is gated now, and for the distinction between COMPILED and
+LINKED that this sentence did not yet have to make. `make` builds `shottino`,
+`make check` builds the suites, and `make call` is opt-in behind cmake and the
+vendored submodule, so `call/main.c` was compiled by nobody in CI. That is how
+two `-Wformat-nonliteral` warnings sat in it unseen (the extraction gives the
+varargs helpers the format attribute the rest of the tree carries, and they are
+gone). It is also why the changes here were syntax-checked by hand against a
+stub `rtc/rtc.h`.
 
 **The class, swept.** shottino.c already applies this rule and says so:
 `call_helper_stop` joins the reader before closing the pipe it reads, closes
@@ -29960,3 +29963,78 @@ session's own nick down the channel path, including an empty string and
 another user's nick, caching modes under that key. With the class gate in
 place the effect is well-formed, so this is a window-keying question, not a
 mode-parsing one, and it predates both halves of this class.
+## 2026-08-05 — #880: compiled is not linked, and the gate must say which
+
+`call/main.c` is the media helper's whole main loop plus the entire
+libdatachannel integration. #754 gave it `make call-compile`, a `-Werror`
+compile of `CALL_SRC` in the `shottino` job, and that closed the half of the
+hole it was aimed at: the file no longer goes unbuilt, and a warning there
+fails CI like a warning anywhere else. What it does not do is LINK, and the
+distinction had already been lost — the note above still read "no CI job
+compiles the call helper" months after that stopped being true, which is the
+kind of drift that lets a compile gate be read as coverage.
+
+**A compile gate proves a file parses.** It says nothing about a use-after-free
+in `session_release` or an out-of-bounds in `video_retile`, and #759 was
+precisely that class — fds closed with callback threads still live, plus an
+out-of-bounds `shown[at]` — found by READING, because no sanitizer could reach
+the file. Seven functions were outside ASan/UBSan entirely: `session_negotiate`,
+`session_release`, `on_state`, `video_retile`, `audio_retile`, `liveness_step`,
+`pump_main`.
+
+**What is gated now, in three tiers, and the words matter.** `call/main.c`,
+`call/whip.c`, `call/media.c`, `call/note.c` and `http.c` are COMPILED under
+`-Werror` (`call-compile`). `call/media.c`, `call/note.c` and `call/whip.c` are
+LINKED INTO SANITIZED BINARIES on their own (`test_callmedia`, `test_callnote`,
+`test_whip`), and `call/main.c` now is too, via `tests/test_callmain`. Nothing
+LINKS THE REAL HELPER: the C++ link driver, `-static-libstdc++` and the four
+vendored archives are still proven only by someone typing `make call`. Three
+different claims, and a gate that promises the second while delivering the
+first is worse than no gate.
+
+**Reaching statics costs a rename, not a refactor.** All seven are `static`, so
+the suite compiles `main.c` into itself with `#define main call_main_unused` —
+the device `test_layout.c` already uses for `shottino.c`. Extracting them to a
+header would have changed the shape of the code under test to suit the test,
+which is the trade this project does not make.
+
+**libdatachannel is stubbed, and the stub cannot drift.** Linking the real
+library costs cmake, a C++ toolchain and minutes of build, so `make check` would
+have grown a dependency on the opt-in submodule — the line `test_whip`,
+`test_callmedia` and `test_callnote` all hold deliberately. So the C API is
+declared in `tests/stub/rtc/rtc.h` and implemented in `tests/rtc_stub.c`. A stub
+nobody verifies is a SECOND API and a suite built on one proves things about the
+second API, so the shape is pinned by a CHAIN of two compilations: `make check`
+builds `rtc_stub.c` against the stub header (definitions cannot leave the
+declarations), and `call-compile` builds the same file against the VENDORED
+header in the one job that has the submodule (definitions cannot leave
+upstream). Between them the stub header cannot leave upstream either. Both links
+were broken on purpose to check: a signature changed in the stub header alone
+fails the test build; changed in header and definition together it fails
+`call-compile`.
+
+**The stub MODELS two things, because a null implementation would gate nothing.**
+A peer connection is an allocation whose tracks die with it, and `rtcSendMessage`
+reads the bytes it is handed for the length it is TOLD. It refuses to follow an
+id it has already freed and counts the attempt instead — reporting the helper's
+mistake rather than crashing on it. `session_negotiate` is driven against a real
+HTTP endpoint on loopback, not a mock, so the WHIP answer is parsed while it is
+still allocated.
+
+**Proven by mutation, and the mechanisms were not the guessed ones.** Six
+defects, one at a time, each rebuilt from scratch: six reds, but only two are
+ASan (`liveness_step` walking one index past arrays that are SEPARATE
+allocations in the fixture; the pump reporting 64 bytes more than it read, which
+needs a datagram near the 2048-byte buffer edge to fire). Two are UBSan
+array-bounds, not ASan — an off-by-one on `c->vlive[8]` lands on the next member
+of the SAME allocation and touches no redzone, so what catches it is the
+declared type (`index 8 out of bounds for type 'bool[8]'`), a check that would
+not fire had the array been reached through a pointer. Two are ordinary
+assertions: dropping `s->pc = -1` in `session_release`, and freeing the WHIP
+answer before parsing it — `whip_response_free` NULLs the body, so that reorder
+loses the negotiated codec rather than raising a use-after-free.
+
+**The general rule.** A sanitizer job nobody has ever seen fail is a line of
+YAML. State which files are compiled, which are linked into a sanitized binary,
+and which are neither — those are three different guarantees, and the middle one
+is the only one that catches lifetime and bounds defects.

--- a/frontends/shottino/Makefile
+++ b/frontends/shottino/Makefile
@@ -296,11 +296,15 @@ $(LDC_DIR)/CMakeLists.txt:
 # THE SECOND HALF (#880) is the stub check. tests/test_callmain links
 # call/main.c against a hand-written <rtc/rtc.h> so `make check` can run
 # the helper's main loop under ASan without the vendored submodule. A stub
-# whose shape nobody verifies is a SECOND API, and a suite built on a
-# second API proves things about the second API — so the stub's definitions
-# are compiled against the REAL header here, in the one job that has it. A
-# signature that has drifted from upstream is a compile error, not a
-# discovery someone makes at `make call` time.
+# whose shape nobody verifies is a SECOND API, and a suite built on one
+# proves things about the second API — so the stub's DEFINITIONS are
+# compiled against the REAL header here, in the one job that has it.
+#
+# That is one link of two: `make check` already compiles the same file
+# against the stub header, which pins the definitions to the declarations.
+# Neither end alone would do — a signature changed in the stub header only
+# fails the test build, and changed in both header and definition it fails
+# HERE. Together they leave the stub header no room to drift from upstream.
 #
 # What none of this covers, deliberately: no link of the helper runs, so
 # the C++ link driver, -static-libstdc++ and the four archives are still

--- a/frontends/shottino/Makefile
+++ b/frontends/shottino/Makefile
@@ -52,7 +52,7 @@ OBJS := shottino.o json.o wire.o alias.o mirc.o termcolor.o http.o media.o ircd.
 # reaches, which is the drawing primitives and nothing else. Do not trust
 # this net for changes elsewhere in that file; add a test or reason about
 # the path by hand.
-TESTS := tests/test_llm tests/test_ws tests/test_json tests/test_wire tests/test_alias tests/test_mirc tests/test_termcolor tests/test_http tests/test_media tests/test_whip tests/test_callmedia tests/test_callnote tests/test_layout tests/test_keys tests/test_ircd tests/test_commands tests/test_windows tests/test_call
+TESTS := tests/test_llm tests/test_ws tests/test_json tests/test_wire tests/test_alias tests/test_mirc tests/test_termcolor tests/test_http tests/test_media tests/test_whip tests/test_callmedia tests/test_callnote tests/test_callmain tests/test_layout tests/test_keys tests/test_ircd tests/test_commands tests/test_windows tests/test_call
 SANITIZE ?= -fsanitize=address,undefined -fno-omit-frame-pointer
 TEST_CFLAGS := -std=c11 -Wall -Wextra -Wpedantic -O1 -g $(SANITIZE)
 
@@ -116,6 +116,29 @@ tests/test_callmedia: tests/test_callmedia.c tests/test.h call/media.c call/medi
 # note.c only, for the same reason test_callmedia links media.c only.
 tests/test_callnote: tests/test_callnote.c tests/test.h call/note.c call/note.h
 	$(CC) $(CPPFLAGS) $(TEST_CFLAGS) -o $@ tests/test_callnote.c call/note.c
+
+# call/main.c, LINKED — the helper's main loop inside the sanitizers.
+#
+# `call-compile` below proves that file parses under -Werror and nothing
+# more, which left seven functions (session_negotiate, session_release,
+# on_state, video_retile, audio_retile, liveness_step, pump_main) outside
+# ASan/UBSan entirely — and #759 was exactly that class of defect. The
+# suite compiles main.c into itself with `main` renamed, the way
+# test_layout does with shottino.c, because every one of those is static.
+#
+# -Itests/stub puts tests/stub/rtc/rtc.h in front of <rtc/rtc.h>, so this
+# links the fake libdatachannel in tests/rtc_stub.c instead of the vendored
+# archives: the default gate must not need the opt-in submodule, exactly as
+# test_whip and test_callmedia do not. The stub's declarations are held to
+# the real ones by call-compile.
+#
+# -lssl -lcrypto because whip.c is real here — session_negotiate is driven
+# against an HTTP endpoint on loopback, not a mocked one.
+tests/test_callmain: tests/test_callmain.c tests/test.h tests/rtc_stub.c tests/rtc_stub.h \
+                     tests/stub/rtc/rtc.h call/main.c call/media.c call/media.h call/note.c \
+                     call/note.h call/whip.c call/whip.h http.c http.h
+	$(CC) $(CPPFLAGS) $(TEST_CFLAGS) -Itests/stub -o $@ tests/test_callmain.c tests/rtc_stub.c \
+	  call/media.c call/note.c call/whip.c http.c -pthread -lssl -lcrypto
 
 tests/test_mirc: tests/test_mirc.c tests/test.h mirc.c mirc.h
 	$(CC) $(CPPFLAGS) $(TEST_CFLAGS) -o $@ tests/test_mirc.c mirc.c
@@ -270,14 +293,25 @@ $(LDC_DIR)/CMakeLists.txt:
 # are already on disk beside the sources, no archive has to exist, and a
 # warning that fails the client build fails here the same way.
 #
-# What it does NOT cover, deliberately: no link runs, so the C++ link
-# driver, -static-libstdc++ and the four archives are still only proven
-# by someone typing `make call`.
+# THE SECOND HALF (#880) is the stub check. tests/test_callmain links
+# call/main.c against a hand-written <rtc/rtc.h> so `make check` can run
+# the helper's main loop under ASan without the vendored submodule. A stub
+# whose shape nobody verifies is a SECOND API, and a suite built on a
+# second API proves things about the second API — so the stub's definitions
+# are compiled against the REAL header here, in the one job that has it. A
+# signature that has drifted from upstream is a compile error, not a
+# discovery someone makes at `make call` time.
+#
+# What none of this covers, deliberately: no link of the helper runs, so
+# the C++ link driver, -static-libstdc++ and the four archives are still
+# only proven by someone typing `make call`.
 call-compile: $(LDC_DIR)/CMakeLists.txt
 	@for src in $(CALL_SRC); do \
 		echo "  CC (compile-only) $$src"; \
 		$(CC) $(CALL_CFLAGS) -c -o /dev/null "$$src" || exit 1; \
 	done
+	@echo "  CC (stub vs the real rtc.h) tests/rtc_stub.c"
+	@$(CC) $(CALL_CFLAGS) -c -o /dev/null tests/rtc_stub.c
 
 # USE_GNUTLS=OFF takes the OpenSSL already linked; USE_NICE=OFF takes the
 # bundled libjuice rather than adding a system libnice; NO_WEBSOCKET

--- a/frontends/shottino/tests/rtc_stub.c
+++ b/frontends/shottino/tests/rtc_stub.c
@@ -1,0 +1,343 @@
+/* rtc_stub.c — the fake libdatachannel that tests/test_callmain.c links.
+ *
+ * See tests/stub/rtc/rtc.h for why a stub and not the real library, and
+ * tests/rtc_stub.h for the shape of what it records.
+ *
+ * The two modelled behaviours are deliberate, and they are the reason the
+ * sanitizers have anything to bite on:
+ *
+ *   - a peer connection is an ALLOCATION. rtcDeletePeerConnection frees it
+ *     and every track that belongs to it, exactly as the real library
+ *     invalidates them. Naming one afterwards is counted, never followed —
+ *     the stub must report the helper's mistake, not crash on it.
+ *   - rtcSendMessage READS `size` bytes from `data`. A helper that passes a
+ *     length its own buffer does not have is an ASan read past that buffer,
+ *     at the call, with the helper's frame on the report.
+ *
+ * Ids are two disjoint ranges so a peer-connection id used where a track id
+ * belongs lands in bad_calls instead of quietly addressing something.
+ */
+#include "rtc_stub.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define STUB_MAX_PCS 64
+#define STUB_MAX_TRACKS 256
+#define STUB_PC_BASE 1
+#define STUB_TRACK_BASE 10000
+
+struct stub_pc {
+    void *user_ptr;
+    rtcStateChangeCallbackFunc state_cb;
+    rtcGatheringStateCallbackFunc gathering_cb;
+    char *remote_sdp;
+};
+
+struct stub_track {
+    int pc;
+    void *user_ptr;
+    rtcMessageCallbackFunc message_cb;
+    struct rtc_stub_track info;
+    int sent_count;
+    char *last_sent;
+    int last_sent_size;
+};
+
+static struct stub_pc *pcs[STUB_MAX_PCS];
+static struct stub_track *tracks[STUB_MAX_TRACKS];
+
+static int pcs_created, pcs_deleted, tracks_added, cleanups, bad_calls;
+static bool fail_next_create;
+static int fail_track_at, track_attempts;
+static bool gathering_completes = true;
+static bool remote_description_ok = true;
+static char offer_sdp[4096] = "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\n";
+static rtcLogCallbackFunc log_cb;
+
+static struct stub_pc *pc_at(int id) {
+    if (id < STUB_PC_BASE || id >= STUB_PC_BASE + STUB_MAX_PCS) return NULL;
+    return pcs[id - STUB_PC_BASE];
+}
+
+static struct stub_track *track_at(int id) {
+    if (id < STUB_TRACK_BASE || id >= STUB_TRACK_BASE + STUB_MAX_TRACKS) return NULL;
+    return tracks[id - STUB_TRACK_BASE];
+}
+
+static void track_free(int index) {
+    struct stub_track *t = tracks[index];
+    if (!t) return;
+    free(t->last_sent);
+    free(t);
+    tracks[index] = NULL;
+}
+
+void rtc_stub_reset(void) {
+    for (int i = 0; i < STUB_MAX_TRACKS; i++) track_free(i);
+    for (int i = 0; i < STUB_MAX_PCS; i++) {
+        if (!pcs[i]) continue;
+        free(pcs[i]->remote_sdp);
+        free(pcs[i]);
+        pcs[i] = NULL;
+    }
+    pcs_created = pcs_deleted = tracks_added = cleanups = bad_calls = 0;
+    fail_next_create = false;
+    fail_track_at = track_attempts = 0;
+    gathering_completes = true;
+    remote_description_ok = true;
+    log_cb = NULL;
+    snprintf(offer_sdp, sizeof(offer_sdp), "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\n");
+}
+
+int rtc_stub_pcs_created(void) { return pcs_created; }
+int rtc_stub_pcs_deleted(void) { return pcs_deleted; }
+int rtc_stub_cleanups(void) { return cleanups; }
+int rtc_stub_bad_calls(void) { return bad_calls; }
+int rtc_stub_tracks_added(void) { return tracks_added; }
+
+bool rtc_stub_track(int track, struct rtc_stub_track *out) {
+    struct stub_track *t = track_at(track);
+    if (!t || !out) return false;
+    *out = t->info;
+    return true;
+}
+
+int rtc_stub_sent_count(int track) {
+    struct stub_track *t = track_at(track);
+    return t ? t->sent_count : -1;
+}
+
+const char *rtc_stub_last_sent(int track, int *size) {
+    struct stub_track *t = track_at(track);
+    if (!t) return NULL;
+    if (size) *size = t->last_sent_size;
+    return t->last_sent;
+}
+
+const char *rtc_stub_remote_description(int pc) {
+    struct stub_pc *p = pc_at(pc);
+    return p ? p->remote_sdp : NULL;
+}
+
+void rtc_stub_fail_next_create(void) { fail_next_create = true; }
+void rtc_stub_fail_track_at(int nth) {
+    fail_track_at = nth;
+    track_attempts = 0;
+}
+void rtc_stub_set_gathering_completes(bool on) { gathering_completes = on; }
+void rtc_stub_set_remote_description_ok(bool ok) { remote_description_ok = ok; }
+
+void rtc_stub_set_offer(const char *sdp) {
+    snprintf(offer_sdp, sizeof(offer_sdp), "%s", sdp ? sdp : "");
+}
+
+bool rtc_stub_fire_state(int pc, rtcState state) {
+    struct stub_pc *p = pc_at(pc);
+    if (!p || !p->state_cb) return false;
+    p->state_cb(pc, state, p->user_ptr);
+    return true;
+}
+
+bool rtc_stub_deliver(int track, const void *data, int size) {
+    struct stub_track *t = track_at(track);
+    if (!t || !t->message_cb) return false;
+    t->message_cb(track, (const char *)data, size, t->user_ptr);
+    return true;
+}
+
+bool rtc_stub_log(rtcLogLevel level, const char *message) {
+    if (!log_cb) return false;
+    log_cb(level, message);
+    return true;
+}
+
+/* ── The API itself ────────────────────────────────────────────────────── */
+
+void rtcInitLogger(rtcLogLevel level, rtcLogCallbackFunc cb) {
+    (void)level;
+    log_cb = cb;
+}
+
+void rtcSetUserPointer(int id, void *ptr) {
+    struct stub_pc *p = pc_at(id);
+    if (p) {
+        p->user_ptr = ptr;
+        return;
+    }
+    struct stub_track *t = track_at(id);
+    if (t) {
+        t->user_ptr = ptr;
+        return;
+    }
+    bad_calls++;
+}
+
+int rtcCreatePeerConnection(const rtcConfiguration *config) {
+    (void)config;
+    if (fail_next_create) {
+        fail_next_create = false;
+        return RTC_ERR_FAILURE;
+    }
+    for (int i = 0; i < STUB_MAX_PCS; i++) {
+        if (pcs[i]) continue;
+        pcs[i] = calloc(1, sizeof(*pcs[i]));
+        if (!pcs[i]) return RTC_ERR_FAILURE;
+        pcs_created++;
+        return STUB_PC_BASE + i;
+    }
+    return RTC_ERR_FAILURE;
+}
+
+int rtcDeletePeerConnection(int pc) {
+    struct stub_pc *p = pc_at(pc);
+    if (!p) {
+        bad_calls++;
+        return RTC_ERR_INVALID;
+    }
+    /* The real library invalidates a peer connection's tracks with it, so
+     * a helper that sends on one afterwards must not find a live object
+     * here either — that is the teardown-ordering bug this suite is for. */
+    for (int i = 0; i < STUB_MAX_TRACKS; i++)
+        if (tracks[i] && tracks[i]->pc == pc) track_free(i);
+    free(p->remote_sdp);
+    free(p);
+    pcs[pc - STUB_PC_BASE] = NULL;
+    pcs_deleted++;
+    return RTC_ERR_SUCCESS;
+}
+
+int rtcSetStateChangeCallback(int pc, rtcStateChangeCallbackFunc cb) {
+    struct stub_pc *p = pc_at(pc);
+    if (!p) {
+        bad_calls++;
+        return RTC_ERR_INVALID;
+    }
+    p->state_cb = cb;
+    return RTC_ERR_SUCCESS;
+}
+
+int rtcSetGatheringStateChangeCallback(int pc, rtcGatheringStateCallbackFunc cb) {
+    struct stub_pc *p = pc_at(pc);
+    if (!p) {
+        bad_calls++;
+        return RTC_ERR_INVALID;
+    }
+    p->gathering_cb = cb;
+    return RTC_ERR_SUCCESS;
+}
+
+int rtcSetLocalDescription(int pc, const char *type) {
+    (void)type;
+    struct stub_pc *p = pc_at(pc);
+    if (!p) {
+        bad_calls++;
+        return RTC_ERR_INVALID;
+    }
+    /* Vanilla ICE against a reachable network: gathering finishes, and it
+     * finishes on the caller's thread. Turned off, this is a peer that
+     * never gathers — which is a timeout the helper has to survive. */
+    if (gathering_completes && p->gathering_cb)
+        p->gathering_cb(pc, RTC_GATHERING_COMPLETE, p->user_ptr);
+    return RTC_ERR_SUCCESS;
+}
+
+int rtcSetRemoteDescription(int pc, const char *sdp, const char *type) {
+    (void)type;
+    struct stub_pc *p = pc_at(pc);
+    if (!p) {
+        bad_calls++;
+        return RTC_ERR_INVALID;
+    }
+    if (!remote_description_ok) return RTC_ERR_INVALID;
+    free(p->remote_sdp);
+    p->remote_sdp = sdp ? strdup(sdp) : NULL;
+    return RTC_ERR_SUCCESS;
+}
+
+int rtcGetLocalDescription(int pc, char *buffer, int size) {
+    struct stub_pc *p = pc_at(pc);
+    if (!p) {
+        bad_calls++;
+        return RTC_ERR_INVALID;
+    }
+    int len = (int)strlen(offer_sdp);
+    if (!buffer || size <= len) return RTC_ERR_TOO_SMALL;
+    memcpy(buffer, offer_sdp, (size_t)len + 1);
+    return len;
+}
+
+static int track_add(int pc, const struct rtc_stub_track *info) {
+    struct stub_pc *p = pc_at(pc);
+    if (!p) {
+        bad_calls++;
+        return RTC_ERR_INVALID;
+    }
+    if (fail_track_at > 0 && ++track_attempts == fail_track_at) return RTC_ERR_FAILURE;
+    for (int i = 0; i < STUB_MAX_TRACKS; i++) {
+        if (tracks[i]) continue;
+        tracks[i] = calloc(1, sizeof(*tracks[i]));
+        if (!tracks[i]) return RTC_ERR_FAILURE;
+        tracks[i]->pc = pc;
+        tracks[i]->info = *info;
+        tracks_added++;
+        return STUB_TRACK_BASE + i;
+    }
+    return RTC_ERR_FAILURE;
+}
+
+int rtcAddTrack(int pc, const char *mediaDescriptionSdp) {
+    struct rtc_stub_track info;
+    memset(&info, 0, sizeof(info));
+    info.pc = pc;
+    info.from_sdp = true;
+    snprintf(info.sdp, sizeof(info.sdp), "%s", mediaDescriptionSdp ? mediaDescriptionSdp : "");
+    return track_add(pc, &info);
+}
+
+int rtcAddTrackEx(int pc, const rtcTrackInit *init) {
+    if (!init) {
+        bad_calls++;
+        return RTC_ERR_INVALID;
+    }
+    struct rtc_stub_track info;
+    memset(&info, 0, sizeof(info));
+    info.pc = pc;
+    info.direction = init->direction;
+    info.codec = init->codec;
+    info.payload_type = init->payloadType;
+    snprintf(info.mid, sizeof(info.mid), "%s", init->mid ? init->mid : "");
+    snprintf(info.profile, sizeof(info.profile), "%s", init->profile ? init->profile : "");
+    return track_add(pc, &info);
+}
+
+int rtcSetMessageCallback(int id, rtcMessageCallbackFunc cb) {
+    struct stub_track *t = track_at(id);
+    if (!t) {
+        bad_calls++;
+        return RTC_ERR_INVALID;
+    }
+    t->message_cb = cb;
+    return RTC_ERR_SUCCESS;
+}
+
+int rtcSendMessage(int id, const char *data, int size) {
+    struct stub_track *t = track_at(id);
+    if (!t) {
+        bad_calls++;
+        return RTC_ERR_INVALID;
+    }
+    t->sent_count++;
+    free(t->last_sent);
+    t->last_sent = NULL;
+    t->last_sent_size = size;
+    if (!data || size <= 0) return RTC_ERR_SUCCESS;
+    /* The copy IS the check: `size` bytes are read from the caller's
+     * buffer, so a length the caller does not have is a read past it. */
+    t->last_sent = malloc((size_t)size);
+    if (t->last_sent) memcpy(t->last_sent, data, (size_t)size);
+    return size;
+}
+
+void rtcCleanup(void) { cleanups++; }

--- a/frontends/shottino/tests/rtc_stub.h
+++ b/frontends/shottino/tests/rtc_stub.h
@@ -1,0 +1,88 @@
+/* rtc_stub.h — what the fake libdatachannel saw, and how to drive it.
+ *
+ * The stub is not a null implementation. It MODELS the two things the
+ * helper's lifetime bugs live in: a peer connection is an allocation that
+ * rtcDeletePeerConnection frees along with its tracks, and rtcSendMessage
+ * READS the bytes it is handed for the length it is told. Both are true of
+ * the real library, and both are what turns a size or a lifetime mistake
+ * in call/main.c into an ASan report instead of a passing test.
+ *
+ * The callbacks are driven through the pointers the helper registered,
+ * never called directly, so the registration is under test too — a
+ * callback wired to the wrong track is a bug the direct call cannot see.
+ */
+#ifndef SHOTTINO_TEST_RTC_STUB_H
+#define SHOTTINO_TEST_RTC_STUB_H
+
+#include <rtc/rtc.h>
+
+#include <stdbool.h>
+#include <stddef.h>
+
+/* Back to a fresh library: every pc and track released, every counter and
+ * every injected failure cleared. Call it between tests, or the leak
+ * checker attributes one test's peer connections to the next. */
+void rtc_stub_reset(void);
+
+/* ── What the helper asked for ─────────────────────────────────────────── */
+
+int rtc_stub_pcs_created(void);
+int rtc_stub_pcs_deleted(void);
+int rtc_stub_cleanups(void);
+
+/* Calls naming an id that was never handed out, or one already deleted.
+ * A counter rather than an abort: the point is to assert it is ZERO in
+ * tests that tear a call down, which is where use-after-delete lives. */
+int rtc_stub_bad_calls(void);
+
+struct rtc_stub_track {
+    int pc;
+    bool from_sdp; /* rtcAddTrack (hand-built m-line) vs rtcAddTrackEx */
+    char sdp[1024];
+    rtcDirection direction;
+    rtcCodec codec;
+    int payload_type;
+    char mid[32];
+    char profile[128];
+};
+
+int rtc_stub_tracks_added(void);
+/* False when `track` is not a live track id. */
+bool rtc_stub_track(int track, struct rtc_stub_track *out);
+
+/* What the helper pushed onto a track. `rtc_stub_last_sent` returns a
+ * buffer of exactly the length that was passed to rtcSendMessage — so an
+ * over-long size is an ASan read past the caller's buffer at the moment
+ * of the send, not a mystery later. */
+int rtc_stub_sent_count(int track);
+const char *rtc_stub_last_sent(int track, int *size);
+
+/* The SDP the helper handed to rtcSetRemoteDescription, or NULL. */
+const char *rtc_stub_remote_description(int pc);
+
+/* ── Injection ─────────────────────────────────────────────────────────── */
+
+void rtc_stub_fail_next_create(void);
+/* Refuse the `nth` track added from now on, counting from 1 — which is
+ * how the audio track is told from the multi-codec video offer that
+ * follows it, and those two failures have entirely different consequences. */
+void rtc_stub_fail_track_at(int nth);
+/* Default true: rtcSetLocalDescription reports gathering COMPLETE at once,
+ * the way vanilla ICE resolves against a reachable STUN-less network. Off
+ * is a peer that never finishes gathering, which is a real timeout. */
+void rtc_stub_set_gathering_completes(bool on);
+void rtc_stub_set_remote_description_ok(bool ok);
+/* What rtcGetLocalDescription hands back. Defaults to a minimal offer. */
+void rtc_stub_set_offer(const char *sdp);
+
+/* ── Driving the helper's own callbacks ────────────────────────────────── */
+
+/* Fire the state-change callback the helper registered on `pc`, with the
+ * user pointer it registered. False when nothing is registered. */
+bool rtc_stub_fire_state(int pc, rtcState state);
+/* Deliver an RTP packet to the message callback registered on `track`. */
+bool rtc_stub_deliver(int track, const void *data, int size);
+/* Hand a line to the log callback the helper installed with rtcInitLogger. */
+bool rtc_stub_log(rtcLogLevel level, const char *message);
+
+#endif /* SHOTTINO_TEST_RTC_STUB_H */

--- a/frontends/shottino/tests/stub/rtc/rtc.h
+++ b/frontends/shottino/tests/stub/rtc/rtc.h
@@ -1,0 +1,159 @@
+/* rtc/rtc.h — a STAND-IN for libdatachannel's C API, for the test build.
+ *
+ * WHY THIS EXISTS. call/main.c is the helper's whole main loop and the
+ * entire libdatachannel integration, and until now nothing linked it: the
+ * `call-compile` gate (#754) proves it PARSES under -Werror and says
+ * nothing about a use-after-free in session_release or an out-of-bounds in
+ * video_retile. Linking it into a sanitized test binary needs the rtc
+ * symbols to come from somewhere, and the real ones cost cmake, a C++
+ * toolchain and a multi-minute libdatachannel build — which is exactly why
+ * `make call` is opt-in and why `make check` must not depend on the
+ * vendored submodule having been checked out, let alone built. Every other
+ * call/ suite (test_whip, test_callmedia, test_callnote) holds that line.
+ *
+ * So the API is declared here and implemented in tests/rtc_stub.c, and the
+ * seven functions that were outside the sanitizers come inside them.
+ *
+ * THE DECLARATIONS ARE THE REAL ONES, and that is checked rather than
+ * asserted: `make call-compile` compiles tests/rtc_stub.c against the
+ * VENDORED <rtc/rtc.h> as well, so a definition here that has drifted from
+ * upstream is a compile error in the job that already has the submodule.
+ * A stub whose shape nobody verifies is a second API, and a test binary
+ * built against a second API proves things about the second API.
+ *
+ * What it deliberately does NOT cover: the C++ link driver,
+ * -static-libstdc++ and the four vendored archives. Those are still proven
+ * only by someone typing `make call`.
+ */
+#ifndef RTC_C_API
+#define RTC_C_API
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* Upstream defines these per-platform; the test build is neither Windows
+ * nor a shared library, which is the branch upstream lands on here. */
+#define RTC_C_EXPORT
+#define RTC_API
+
+typedef enum {
+    RTC_NEW = 0,
+    RTC_CONNECTING = 1,
+    RTC_CONNECTED = 2,
+    RTC_DISCONNECTED = 3,
+    RTC_FAILED = 4,
+    RTC_CLOSED = 5
+} rtcState;
+
+typedef enum {
+    RTC_GATHERING_NEW = 0,
+    RTC_GATHERING_INPROGRESS = 1,
+    RTC_GATHERING_COMPLETE = 2
+} rtcGatheringState;
+
+typedef enum { /* Don't change, it must match plog severity */
+               RTC_LOG_NONE = 0,
+               RTC_LOG_FATAL = 1,
+               RTC_LOG_ERROR = 2,
+               RTC_LOG_WARNING = 3,
+               RTC_LOG_INFO = 4,
+               RTC_LOG_DEBUG = 5,
+               RTC_LOG_VERBOSE = 6
+} rtcLogLevel;
+
+typedef enum {
+    RTC_CERTIFICATE_DEFAULT = 0, /* ECDSA */
+    RTC_CERTIFICATE_ECDSA = 1,
+    RTC_CERTIFICATE_RSA = 2,
+} rtcCertificateType;
+
+typedef enum {
+    /* video */
+    RTC_CODEC_H264 = 0,
+    RTC_CODEC_VP8 = 1,
+    RTC_CODEC_VP9 = 2,
+    RTC_CODEC_H265 = 3,
+    RTC_CODEC_AV1 = 4,
+
+    /* audio */
+    RTC_CODEC_OPUS = 128,
+    RTC_CODEC_PCMU = 129,
+    RTC_CODEC_PCMA = 130,
+    RTC_CODEC_AAC = 131,
+    RTC_CODEC_G722 = 132,
+} rtcCodec;
+
+typedef enum {
+    RTC_DIRECTION_UNKNOWN = 0,
+    RTC_DIRECTION_SENDONLY = 1,
+    RTC_DIRECTION_RECVONLY = 2,
+    RTC_DIRECTION_SENDRECV = 3,
+    RTC_DIRECTION_INACTIVE = 4
+} rtcDirection;
+
+typedef enum { RTC_TRANSPORT_POLICY_ALL = 0, RTC_TRANSPORT_POLICY_RELAY = 1 } rtcTransportPolicy;
+
+#define RTC_ERR_SUCCESS 0
+#define RTC_ERR_INVALID -1   /* invalid argument */
+#define RTC_ERR_FAILURE -2   /* runtime error */
+#define RTC_ERR_NOT_AVAIL -3 /* element not available */
+#define RTC_ERR_TOO_SMALL -4 /* buffer too small */
+
+typedef void(RTC_API *rtcLogCallbackFunc)(rtcLogLevel level, const char *message);
+typedef void(RTC_API *rtcStateChangeCallbackFunc)(int pc, rtcState state, void *ptr);
+typedef void(RTC_API *rtcGatheringStateCallbackFunc)(int pc, rtcGatheringState state, void *ptr);
+typedef void(RTC_API *rtcMessageCallbackFunc)(int id, const char *message, int size, void *ptr);
+
+RTC_C_EXPORT void rtcInitLogger(rtcLogLevel level, rtcLogCallbackFunc cb);
+
+RTC_C_EXPORT void rtcSetUserPointer(int id, void *ptr);
+
+typedef struct {
+    const char **iceServers;
+    int iceServersCount;
+    const char *proxyServer; /* libnice only */
+    const char *bindAddress; /* libjuice only, NULL means any */
+    rtcCertificateType certificateType;
+    rtcTransportPolicy iceTransportPolicy;
+    bool enableIceTcp;
+    bool enableIceUdpMux; /* libjuice only */
+    bool disableAutoNegotiation;
+    bool forceMediaTransport;
+    uint16_t portRangeBegin; /* 0 means automatic */
+    uint16_t portRangeEnd;   /* 0 means automatic */
+    int mtu;                 /* <= 0 means automatic */
+    int maxMessageSize;      /* <= 0 means default */
+} rtcConfiguration;
+
+RTC_C_EXPORT int rtcCreatePeerConnection(const rtcConfiguration *config); /* returns pc id */
+RTC_C_EXPORT int rtcDeletePeerConnection(int pc);
+
+RTC_C_EXPORT int rtcSetStateChangeCallback(int pc, rtcStateChangeCallbackFunc cb);
+RTC_C_EXPORT int rtcSetGatheringStateChangeCallback(int pc, rtcGatheringStateCallbackFunc cb);
+
+RTC_C_EXPORT int rtcSetLocalDescription(int pc, const char *type); /* type may be NULL */
+RTC_C_EXPORT int rtcSetRemoteDescription(int pc, const char *sdp, const char *type);
+
+RTC_C_EXPORT int rtcGetLocalDescription(int pc, char *buffer, int size);
+
+typedef struct {
+    rtcDirection direction;
+    rtcCodec codec;
+    int payloadType;
+    uint32_t ssrc;
+    const char *mid;
+    const char *name;    /* optional */
+    const char *msid;    /* optional */
+    const char *trackId; /* optional, track ID used in MSID */
+    const char *profile; /* optional, codec profile */
+} rtcTrackInit;
+
+RTC_C_EXPORT int rtcAddTrack(int pc, const char *mediaDescriptionSdp); /* returns tr id */
+RTC_C_EXPORT int rtcAddTrackEx(int pc, const rtcTrackInit *init);      /* returns tr id */
+
+RTC_C_EXPORT int rtcSetMessageCallback(int id, rtcMessageCallbackFunc cb);
+RTC_C_EXPORT int rtcSendMessage(int id, const char *data, int size);
+
+RTC_C_EXPORT void rtcCleanup(void);
+
+#endif /* RTC_C_API */

--- a/frontends/shottino/tests/stub/rtc/rtc.h
+++ b/frontends/shottino/tests/stub/rtc/rtc.h
@@ -15,11 +15,20 @@
  * seven functions that were outside the sanitizers come inside them.
  *
  * THE DECLARATIONS ARE THE REAL ONES, and that is checked rather than
- * asserted: `make call-compile` compiles tests/rtc_stub.c against the
- * VENDORED <rtc/rtc.h> as well, so a definition here that has drifted from
- * upstream is a compile error in the job that already has the submodule.
- * A stub whose shape nobody verifies is a second API, and a test binary
- * built against a second API proves things about the second API.
+ * asserted — a stub whose shape nobody verifies is a second API, and a
+ * test binary built against a second API proves things about the second
+ * API. The check is a CHAIN of two compilations, because neither end is
+ * enough on its own:
+ *
+ *   - `make check` builds tests/rtc_stub.c against THIS header, so the
+ *     definitions cannot drift from these declarations;
+ *   - `make call-compile` builds the same file against the VENDORED
+ *     <rtc/rtc.h>, in the one job that has the submodule, so those same
+ *     definitions cannot drift from upstream's.
+ *
+ * Between them this header cannot drift from upstream either. Verified by
+ * breaking each link: a signature changed here alone fails the test build,
+ * and changed here AND in rtc_stub.c together fails call-compile.
  *
  * What it deliberately does NOT cover: the C++ link driver,
  * -static-libstdc++ and the four vendored archives. Those are still proven

--- a/frontends/shottino/tests/test.h
+++ b/frontends/shottino/tests/test.h
@@ -148,6 +148,36 @@ static inline void test_use_temp_home(void) {
     atexit(test_temp_home_remove);
 }
 
+/* CAPTURING STDERR, which two suites now need: it is the media helper's
+ * whole output contract (one JSON event per line, notes commented) and it
+ * is also where test.h reports failures. So it is put back BEFORE anything
+ * is asserted — a CHECK between start and end writes its own diagnosis
+ * into the buffer under test and then loses it. */
+static int test_capture_fd = -1;
+static char test_capture_path[64];
+
+static inline void test_capture_stderr_start(void) {
+    snprintf(test_capture_path, sizeof(test_capture_path), "/tmp/shottino-capture-XXXXXX");
+    int fd = mkstemp(test_capture_path);
+    if (fd < 0) abort();
+    fflush(stderr);
+    test_capture_fd = dup(STDERR_FILENO);
+    dup2(fd, STDERR_FILENO);
+    close(fd);
+}
+
+static inline void test_capture_stderr_end(char *out, size_t out_sz) {
+    fflush(stderr);
+    dup2(test_capture_fd, STDERR_FILENO);
+    close(test_capture_fd);
+    test_capture_fd = -1;
+    FILE *f = fopen(test_capture_path, "r");
+    size_t n = f ? fread(out, 1, out_sz - 1, f) : 0;
+    out[n] = 0;
+    if (f) fclose(f);
+    unlink(test_capture_path);
+}
+
 static int test_report(void) {
     if (test_failures) {
         fprintf(stderr, "\n%d/%d checks FAILED\n", test_failures, test_checks);

--- a/frontends/shottino/tests/test_callmain.c
+++ b/frontends/shottino/tests/test_callmain.c
@@ -18,25 +18,32 @@
  * test_callmedia and test_callnote do; the stub's declarations are checked
  * against the real header by `make call-compile`.
  *
- * WHAT MAKES THE SANITIZERS ABLE TO FAIL, which is the point of linking at
- * all — a test that calls a function and asserts nothing gives ASan a look
- * inside, but it is not evidence, and a sanitizer job nobody has ever seen
- * go red is a line of YAML:
+ * WHAT MAKES THIS ABLE TO FAIL, which is the point of linking at all — a
+ * test that calls a function and asserts nothing gives ASan a look inside,
+ * but it is not evidence, and a sanitizer job nobody has ever seen go red
+ * is a line of YAML. Six defects were introduced one at a time to find
+ * out, and the mechanism that caught each one is not the one that would be
+ * guessed:
  *
- *   - `struct call` is HEAP-allocated here, never a stack local, so every
- *     one of the per-peer arrays (vlive, vpkts, amisses, legs…) carries
- *     redzones and a stray index is a heap-buffer-overflow at the access;
+ *   - the four arrays liveness_step is handed are SEPARATE allocations
+ *     here, exactly CALL_MAX_PEERS long. One index too far is an ASan
+ *     heap-buffer-overflow. The per-peer arrays INSIDE `struct call` are
+ *     not: an off-by-one there lands on the next member of the same
+ *     allocation, so no redzone is touched — what catches those is UBSan's
+ *     array-bounds on the declared type (`index 8 out of bounds for type
+ *     'bool[8]'`), which is a different check with a different reach;
  *   - the rtc stub COPIES the bytes handed to rtcSendMessage for the
- *     length it is told, so a pump that reports more than it has is a read
- *     past its own buffer;
- *   - the stub FREES a peer connection and its tracks on delete, so a
- *     teardown that releases in the wrong order is a use-after-free;
- *   - session_negotiate runs against a real socket with a real answer
- *     body, so the parse of that body happens while it is still allocated
- *     — and stops happening the moment it is not.
- *
- * Proven by mutation rather than asserted: the defects introduced to turn
- * this suite red are recorded in the commit that adds it.
+ *     length it is TOLD, so a pump that reports more than it read is an
+ *     ASan global-buffer-overflow — but only if a packet gets near the
+ *     buffer's edge, which is why one 2048-byte datagram is sent;
+ *   - the rest is ordinary assertions, and deliberately so. The stub
+ *     refuses to follow a peer-connection id it has already freed and
+ *     COUNTS the attempt instead: it has to report the helper's mistake,
+ *     not crash on it, so a release that forgets `s->pc = -1` fails a
+ *     check rather than raising a use-after-free. Likewise freeing the
+ *     WHIP answer before parsing it: whip_response_free NULLs the body, so
+ *     that reordering loses the negotiated codec and fails a check with no
+ *     sanitizer involved at all.
  */
 #define main call_main_unused
 #include "../call/main.c"

--- a/frontends/shottino/tests/test_callmain.c
+++ b/frontends/shottino/tests/test_callmain.c
@@ -1,0 +1,1341 @@
+/* test_callmain — the helper's main loop, under the sanitizers at last.
+ *
+ * COMPILING IS NOT LINKING. `make call-compile` (#754) proves call/main.c
+ * parses under -Werror; it says nothing about a use-after-free in
+ * session_release or a bounds mistake in video_retile, and #759 was
+ * exactly that class — fds closed with callback threads still live, plus
+ * an out-of-bounds `shown[at]` — found by reading, because no sanitizer
+ * could reach the file. Seven functions sat outside ASan/UBSan entirely:
+ * session_negotiate, session_release, on_state, video_retile,
+ * audio_retile, liveness_step and pump_main. This suite links them.
+ *
+ * HOW IT REACHES THEM. They are all `static`, so the file is compiled INTO
+ * this one with `main` renamed away — the same device tests/test_layout.c
+ * uses for shottino.c, and the only one that reaches a static function
+ * without changing the shape of the code under test. libdatachannel is
+ * replaced by tests/stub/rtc/rtc.h + tests/rtc_stub.c, so the gate stays
+ * free of the opt-in vendored submodule exactly as test_whip,
+ * test_callmedia and test_callnote do; the stub's declarations are checked
+ * against the real header by `make call-compile`.
+ *
+ * WHAT MAKES THE SANITIZERS ABLE TO FAIL, which is the point of linking at
+ * all — a test that calls a function and asserts nothing gives ASan a look
+ * inside, but it is not evidence, and a sanitizer job nobody has ever seen
+ * go red is a line of YAML:
+ *
+ *   - `struct call` is HEAP-allocated here, never a stack local, so every
+ *     one of the per-peer arrays (vlive, vpkts, amisses, legs…) carries
+ *     redzones and a stray index is a heap-buffer-overflow at the access;
+ *   - the rtc stub COPIES the bytes handed to rtcSendMessage for the
+ *     length it is told, so a pump that reports more than it has is a read
+ *     past its own buffer;
+ *   - the stub FREES a peer connection and its tracks on delete, so a
+ *     teardown that releases in the wrong order is a use-after-free;
+ *   - session_negotiate runs against a real socket with a real answer
+ *     body, so the parse of that body happens while it is still allocated
+ *     — and stops happening the moment it is not.
+ *
+ * Proven by mutation rather than asserted: the defects introduced to turn
+ * this suite red are recorded in the commit that adds it.
+ */
+#define main call_main_unused
+#include "../call/main.c"
+#undef main
+
+#include "rtc_stub.h"
+#include "test.h"
+
+#include <ctype.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <pthread.h>
+#include <signal.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+
+/* ── A call, on the heap ───────────────────────────────────────────────── */
+
+/* The state each function under test is contracted to read, in the shape
+ * main() gives it. On the heap deliberately: see the header comment. */
+struct fixture {
+    struct call *c;
+    struct media_config cfg;
+    int devnull;
+};
+
+static void fixture_start(struct fixture *f, bool video) {
+    /* wait_until() and pump_main() both bail on it, and it is a file-scope
+     * static: one test that ends a call would end every later one. */
+    stop_requested = 0;
+    rtc_stub_reset();
+
+    memset(f, 0, sizeof(*f));
+    f->cfg = (struct media_config){ .audio_source = "lavfi:anullsrc",
+                                    .video_source = "lavfi:testsrc",
+                                    .audio_sink = "null:-",
+                                    .audio_payload_type = 111,
+                                    .video_payload_type = 96,
+                                    .audio_ssrc = 1,
+                                    .video_ssrc = 2,
+                                    .frame_w = 320,
+                                    .frame_h = 240,
+                                    .fps = 10,
+                                    .capture_w = 640,
+                                    .capture_h = 480,
+                                    .capture_fps = 20,
+                                    .video_kbps = 800,
+                                    .video_codec = MEDIA_VIDEO_VP8,
+                                    .want_video = video };
+
+    struct call *c = calloc(1, sizeof(*c));
+    if (!c) abort();
+    pthread_mutex_init(&c->lock, NULL);
+    pthread_cond_init(&c->cv, NULL);
+    pthread_mutex_init(&c->vlock, NULL);
+    c->pub.owner = c;
+    c->pub.label = "publish";
+    c->pub.pc = -1;
+    c->pub.audio_track = c->pub.video_track = -1;
+    c->pub.slot = -1;
+    for (int i = 0; i < CALL_MAX_PEERS; i++) {
+        c->sub[i].owner = c;
+        c->sub[i].label = "subscribe";
+        c->sub[i].pc = -1;
+        c->sub[i].audio_track = c->sub[i].video_track = -1;
+        c->sub[i].slot = i;
+    }
+    c->send_audio.fd = c->send_video.fd = -1;
+    c->send_audio.pid = c->send_video.pid = -1;
+    c->vmix.pid = c->amix.pid = -1;
+    for (int i = 0; i < MEDIA_MAX_PEERS; i++) {
+        c->amix.legs[i].fd = c->amix.legs[i].pid = -1;
+        c->vmix.legs[i].fd = c->vmix.legs[i].pid = -1;
+        c->vmix.legs[i].codec = f->cfg.video_codec;
+        c->vmix.legs[i].payload_type = f->cfg.video_payload_type;
+    }
+    c->want_video = video;
+    c->speaker = -1;
+    /* main() hands the decoder its own stdout. Here that is the test
+     * runner's, and a decoder writing rgb24 into it would be noise. */
+    f->devnull = open("/dev/null", O_WRONLY);
+    c->frame_fd = f->devnull;
+    c->cfg = &f->cfg;
+    f->c = c;
+}
+
+static void fixture_stop(struct fixture *f) {
+    stop_requested = 1;
+    media_mix_free(&f->c->amix);
+    media_mix_free(&f->c->vmix);
+    media_stop(&f->c->send_audio);
+    media_stop(&f->c->send_video);
+    for (int i = 0; i < CALL_MAX_PEERS; i++)
+        if (f->c->sub[i].pc >= 0) rtcDeletePeerConnection(f->c->sub[i].pc);
+    if (f->c->pub.pc >= 0) rtcDeletePeerConnection(f->c->pub.pc);
+    pthread_mutex_destroy(&f->c->lock);
+    pthread_mutex_destroy(&f->c->vlock);
+    pthread_cond_destroy(&f->c->cv);
+    if (f->devnull >= 0) close(f->devnull);
+    free(f->c);
+    f->c = NULL;
+    rtc_stub_reset();
+    stop_requested = 0;
+}
+
+/* ── A PATH holding exactly one ffmpeg, or none ────────────────────────── */
+
+/* The same device tests/test_callmedia.c uses, for the same reason: the
+ * suite decides the outcome, never the machine it happens to run on. Local
+ * to this file rather than shared with that one because the lifetime
+ * differs — every start here spawns a child, so the two directories are
+ * made once and reused instead of one mkdtemp per call. */
+static char path_with[64], path_without[64], path_saved[4096];
+
+static bool fake_ffmpeg_setup(void) {
+    snprintf(path_with, sizeof(path_with), "/tmp/shottino-callmain-yes-XXXXXX");
+    snprintf(path_without, sizeof(path_without), "/tmp/shottino-callmain-no-XXXXXX");
+    if (!mkdtemp(path_with) || !mkdtemp(path_without)) return false;
+    char script[128];
+    snprintf(script, sizeof(script), "%s/ffmpeg", path_with);
+    FILE *fh = fopen(script, "w");
+    if (!fh) return false;
+    /* Anything that execs and STAYS UP: the spawn contract is what is
+     * under test, not ffmpeg's behaviour. The inner PATH is not decoration
+     * — this runs with PATH pointing at this directory alone. */
+    fputs("#!/bin/sh\nPATH=/usr/bin:/bin\nexec sleep 30\n", fh);
+    fclose(fh);
+    if (chmod(script, 0755) != 0) return false;
+    snprintf(path_saved, sizeof(path_saved), "%s", getenv("PATH") ? getenv("PATH") : "");
+    return true;
+}
+
+static void fake_ffmpeg_teardown(void) {
+    char cmd[256];
+    setenv("PATH", path_saved, 1);
+    snprintf(cmd, sizeof(cmd), "rm -rf '%s' '%s'", path_with, path_without);
+    if (system(cmd) != 0) fprintf(stderr, "warning: fake ffmpeg dirs not removed\n");
+}
+
+static void ffmpeg_available(bool yes) { setenv("PATH", yes ? path_with : path_without, 1); }
+
+/* ── A WHIP endpoint on loopback ───────────────────────────────────────── */
+
+#define SFU_MAX_EXCHANGES 6
+
+struct sfu {
+    int listen_fd;
+    int port;
+    pthread_t thread;
+    bool started;
+    pthread_mutex_t lock;
+    bool stop;
+    char reply[SFU_MAX_EXCHANGES][2048];
+    int replies;
+    char request[SFU_MAX_EXCHANGES][8192];
+    int requests;
+};
+
+/* strcasestr is a GNU extension and this file compiles without the feature
+ * macros that would bring it in. The needle is one we own. */
+static const char *header_find(const char *hay, const char *needle) {
+    size_t n = strlen(needle);
+    for (const char *p = hay; *p; p++) {
+        size_t i = 0;
+        while (i < n && p[i] && tolower((unsigned char)p[i]) == tolower((unsigned char)needle[i]))
+            i++;
+        if (i == n) return p;
+    }
+    return NULL;
+}
+
+/* Read one whole HTTP request: headers, then Content-Length bytes of body.
+ * Bounded on every axis — this runs inside `make check`, and a server that
+ * can block forever is a suite that hangs instead of failing. */
+static void sfu_read_request(int fd, char *out, size_t out_sz) {
+    size_t at = 0, want = 0;
+    bool have_head = false;
+    for (int spin = 0; spin < 256 && at + 1 < out_sz; spin++) {
+        struct pollfd p = { .fd = fd, .events = POLLIN, .revents = 0 };
+        if (poll(&p, 1, 500) <= 0) break;
+        ssize_t got = recv(fd, out + at, out_sz - at - 1, 0);
+        if (got <= 0) break;
+        at += (size_t)got;
+        out[at] = 0;
+        if (!have_head) {
+            const char *end = strstr(out, "\r\n\r\n");
+            if (!end) continue;
+            have_head = true;
+            const char *cl = header_find(out, "content-length:");
+            want = (size_t)(end + 4 - out) + (cl ? (size_t)atol(cl + 15) : 0);
+        }
+        if (have_head && at >= want) break;
+    }
+}
+
+static void *sfu_main(void *arg) {
+    struct sfu *s = arg;
+    for (;;) {
+        pthread_mutex_lock(&s->lock);
+        bool stop = s->stop;
+        pthread_mutex_unlock(&s->lock);
+        if (stop) return NULL;
+
+        struct pollfd p = { .fd = s->listen_fd, .events = POLLIN, .revents = 0 };
+        if (poll(&p, 1, 50) <= 0) continue;
+        int fd = accept(s->listen_fd, NULL, NULL);
+        if (fd < 0) continue;
+
+        char req[8192];
+        req[0] = 0;
+        sfu_read_request(fd, req, sizeof(req));
+
+        pthread_mutex_lock(&s->lock);
+        int n = s->requests;
+        if (n < SFU_MAX_EXCHANGES) {
+            snprintf(s->request[n], sizeof(s->request[n]), "%s", req);
+            s->requests = n + 1;
+        }
+        /* The last scripted reply REPEATS: a test that scripts one answer
+         * should not have to know how many requests the client makes. */
+        int which = n < s->replies ? n : (s->replies > 0 ? s->replies - 1 : -1);
+        char reply[2048];
+        snprintf(reply, sizeof(reply), "%s", which >= 0 ? s->reply[which] : "");
+        pthread_mutex_unlock(&s->lock);
+
+        size_t len = strlen(reply), sent = 0;
+        while (sent < len) {
+            ssize_t w = send(fd, reply + sent, len - sent, 0);
+            if (w <= 0) break;
+            sent += (size_t)w;
+        }
+        shutdown(fd, SHUT_RDWR);
+        close(fd);
+    }
+}
+
+static bool sfu_start(struct sfu *s) {
+    memset(s, 0, sizeof(*s));
+    pthread_mutex_init(&s->lock, NULL);
+    s->listen_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (s->listen_fd < 0) return false;
+    int one = 1;
+    setsockopt(s->listen_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    if (bind(s->listen_fd, (struct sockaddr *)&addr, sizeof(addr)) != 0) return false;
+    socklen_t len = sizeof(addr);
+    if (getsockname(s->listen_fd, (struct sockaddr *)&addr, &len) != 0) return false;
+    s->port = ntohs(addr.sin_port);
+    if (listen(s->listen_fd, 4) != 0) return false;
+    s->started = pthread_create(&s->thread, NULL, sfu_main, s) == 0;
+    return s->started;
+}
+
+static void sfu_script(struct sfu *s, const char *reply) {
+    pthread_mutex_lock(&s->lock);
+    if (s->replies < SFU_MAX_EXCHANGES)
+        snprintf(s->reply[s->replies], sizeof(s->reply[s->replies]), "%s", reply);
+    s->replies++;
+    pthread_mutex_unlock(&s->lock);
+}
+
+static int sfu_requests(struct sfu *s) {
+    pthread_mutex_lock(&s->lock);
+    int n = s->requests;
+    pthread_mutex_unlock(&s->lock);
+    return n;
+}
+
+static void sfu_request(struct sfu *s, int i, char *out, size_t out_sz) {
+    pthread_mutex_lock(&s->lock);
+    snprintf(out, out_sz, "%s", i >= 0 && i < s->requests ? s->request[i] : "");
+    pthread_mutex_unlock(&s->lock);
+}
+
+static void sfu_stop(struct sfu *s) {
+    pthread_mutex_lock(&s->lock);
+    s->stop = true;
+    pthread_mutex_unlock(&s->lock);
+    if (s->started) pthread_join(s->thread, NULL);
+    close(s->listen_fd);
+    pthread_mutex_destroy(&s->lock);
+}
+
+/* An SDP answer naming one video codec, so the negotiated payload type has
+ * something real to be read out of. */
+#define SFU_ANSWER_VP8                                                                             \
+    "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\n"                                          \
+    "m=audio 9 UDP/TLS/RTP/SAVPF 111\r\na=rtpmap:111 opus/48000/2\r\n"                             \
+    "m=video 9 UDP/TLS/RTP/SAVPF 96\r\na=rtpmap:96 VP8/90000\r\n"
+
+static void sfu_script_created(struct sfu *s, const char *location, const char *answer) {
+    char reply[2048];
+    snprintf(reply, sizeof(reply),
+             "HTTP/1.1 201 Created\r\nLocation: %s\r\nContent-Type: application/sdp\r\n"
+             "Content-Length: %zu\r\nConnection: close\r\n\r\n%s",
+             location, strlen(answer), answer);
+    sfu_script(s, reply);
+}
+
+static void sfu_script_status(struct sfu *s, int status, const char *text) {
+    char reply[2048];
+    snprintf(reply, sizeof(reply),
+             "HTTP/1.1 %d %s\r\nContent-Length: 0\r\nConnection: close\r\n\r\n", status, text);
+    sfu_script(s, reply);
+}
+
+static void sfu_url(const struct sfu *s, const char *path, char *out, size_t out_sz) {
+    snprintf(out, out_sz, "http://127.0.0.1:%d%s", s->port, path);
+}
+
+/* ── Bounded waiting ───────────────────────────────────────────────────── */
+
+/* Poll a condition rather than sleep a guess: a fixed sleep is either a
+ * slow suite or a flaky one, and usually both. */
+static bool wait_for(bool (*done)(void *), void *ctx, int ms) {
+    for (int waited = 0; waited < ms; waited += 5) {
+        if (done(ctx)) return true;
+        struct timespec tick = { .tv_sec = 0, .tv_nsec = 5 * 1000 * 1000 };
+        nanosleep(&tick, NULL);
+    }
+    return done(ctx);
+}
+
+/* ── liveness_step ─────────────────────────────────────────────────────── */
+
+/* Membership is measured from arriving packets, and the asymmetry is the
+ * design: a peer is live on the FIRST packet and dead only after several
+ * quiet ticks, because a re-tile every jittery second is worse than a
+ * stale tile.
+ *
+ * The four arrays are exactly CALL_MAX_PEERS long and on the heap, so a
+ * loop that runs one index too far is a heap-buffer-overflow here rather
+ * than a silent write into whatever follows. */
+TEST(liveness_is_immediate_on_the_way_in_and_patient_on_the_way_out) {
+    _Atomic unsigned long *pkts = calloc(CALL_MAX_PEERS, sizeof(*pkts));
+    unsigned long *seen = calloc(CALL_MAX_PEERS, sizeof(*seen));
+    int *misses = calloc(CALL_MAX_PEERS, sizeof(*misses));
+    bool *live = calloc(CALL_MAX_PEERS, sizeof(*live));
+    if (!pkts || !seen || !misses || !live) abort();
+
+    /* Nothing has ever arrived: no change, and nobody is live. */
+    CHECK(!liveness_step(pkts, seen, misses, live));
+    for (int i = 0; i < CALL_MAX_PEERS; i++) CHECK(!live[i]);
+
+    /* One packet from one peer promotes THAT peer, on the first tick. */
+    pkts[2] = 1;
+    CHECK(liveness_step(pkts, seen, misses, live));
+    CHECK(live[2]);
+    CHECK(!live[1]);
+    CHECK(!live[3]);
+
+    /* Quiet ticks below the threshold do not demote and report nothing:
+     * an event per tick is the noise this counter exists to avoid. */
+    for (int t = 1; t < CALL_TILE_MISSES; t++) {
+        CHECK(!liveness_step(pkts, seen, misses, live));
+        CHECK(live[2]);
+    }
+    /* The threshold tick demotes, once. */
+    CHECK(liveness_step(pkts, seen, misses, live));
+    CHECK(!live[2]);
+    CHECK(!liveness_step(pkts, seen, misses, live));
+
+    /* Movement is a CHANGED counter, not a bigger one — the packet count
+     * is unsigned and wraps, and a peer whose counter wrapped is sending. */
+    pkts[2] = ULONG_MAX;
+    CHECK(liveness_step(pkts, seen, misses, live));
+    CHECK(live[2]);
+    pkts[2] = 0;                                        /* wrapped */
+    CHECK(!liveness_step(pkts, seen, misses, live));    /* still live, no event */
+    CHECK(live[2]);
+
+    /* The last peer counts, which is the index a loop bound gets wrong. */
+    pkts[CALL_MAX_PEERS - 1] = 7;
+    CHECK(liveness_step(pkts, seen, misses, live));
+    CHECK(live[CALL_MAX_PEERS - 1]);
+
+    free(pkts);
+    free(seen);
+    free(misses);
+    free(live);
+}
+
+/* ── on_state ──────────────────────────────────────────────────────────── */
+
+TEST(a_state_change_is_recorded_and_named_once_per_peer) {
+    struct fixture f;
+    fixture_start(&f, false);
+    char got[4096];
+
+    test_capture_stderr_start();
+    on_state(0, RTC_CONNECTED, &f.c->pub);
+    test_capture_stderr_end(got, sizeof(got));
+    CHECK_LONG(f.c->pub.state, RTC_CONNECTED);
+    CHECK_STR(got, "{\"event\":\"state\",\"value\":\"publish connected\"}\n");
+
+    test_capture_stderr_start();
+    on_state(0, RTC_FAILED, &f.c->sub[3]);
+    test_capture_stderr_end(got, sizeof(got));
+    CHECK_LONG(f.c->sub[3].state, RTC_FAILED);
+    CHECK_STR(got, "{\"event\":\"state\",\"value\":\"subscribe failed\"}\n");
+
+    /* A peer we already know is absent walks connecting -> closed on every
+     * retry. Saying so each time is how a working call looks like a
+     * failing one — so the state is still RECORDED and nothing is said. */
+    f.c->sub[3].absent = true;
+    test_capture_stderr_start();
+    on_state(0, RTC_CONNECTING, &f.c->sub[3]);
+    on_state(0, RTC_CLOSED, &f.c->sub[3]);
+    test_capture_stderr_end(got, sizeof(got));
+    CHECK_LONG(f.c->sub[3].state, RTC_CLOSED);
+    CHECK_STR(got, "");
+
+    /* A state outside the table names nothing. The name array is indexed
+     * by the value the library hands over, so that bound is the difference
+     * between an unknown state and a read off the end of the table. */
+    f.c->sub[3].absent = false;
+    test_capture_stderr_start();
+    on_state(0, (rtcState)99, &f.c->sub[3]);
+    test_capture_stderr_end(got, sizeof(got));
+    CHECK_LONG(f.c->sub[3].state, 99);
+    CHECK_STR(got, "");
+
+    fixture_stop(&f);
+}
+
+/* The library's own diagnostics belong on stderr as comments: given no
+ * callback libdatachannel logs to STDOUT, which here is the rgb24 frame
+ * stream, so one warning writes text into the middle of a picture. */
+TEST(the_library_log_is_routed_into_the_comment_stream) {
+    struct fixture f;
+    fixture_start(&f, false);
+    char got[4096];
+    note_set_verbose(true);
+    rtcInitLogger(RTC_LOG_WARNING, on_rtc_log);
+
+    test_capture_stderr_start();
+    bool routed = rtc_stub_log(RTC_LOG_WARNING, "Track is not open");
+    test_capture_stderr_end(got, sizeof(got));
+    CHECK(routed);
+    CHECK_STR(got, "# libdatachannel: Track is not open\n");
+
+    /* A NULL message is what the C API allows: printed as an empty note,
+     * never dereferenced. */
+    test_capture_stderr_start();
+    routed = rtc_stub_log(RTC_LOG_ERROR, NULL);
+    test_capture_stderr_end(got, sizeof(got));
+    CHECK(routed);
+    CHECK_STR(got, "# libdatachannel: \n");
+
+    note_set_verbose(false);
+    fixture_stop(&f);
+}
+
+/* ── video_retile / audio_retile ───────────────────────────────────────── */
+
+/* The composited picture is rebuilt from who is SENDING, and the grid it
+ * built is PUBLISHED — the other end samples cells out of one byte pipe,
+ * so without the rectangles it cannot tell whose face is where. */
+TEST(video_retile_publishes_the_grid_it_actually_composited) {
+    struct fixture f;
+    fixture_start(&f, true);
+    ffmpeg_available(true);
+    char got[8192];
+
+    f.c->vlive[1] = true;
+    f.c->vlive[4] = true;
+    test_capture_stderr_start();
+    video_retile(f.c);
+    test_capture_stderr_end(got, sizeof(got));
+
+    CHECK_LONG(f.c->vmix.tile_count, 2);
+    CHECK(f.c->vmix.pid > 0);
+    /* The legs of the peers being drawn were given ports, and the RTP
+     * callback writes to those — a tile with no leg is a black cell. */
+    CHECK(f.c->vmix.legs[1].peer_port > 0);
+    CHECK(f.c->vmix.legs[4].peer_port > 0);
+    CHECK_LONG(f.c->vmix.legs[7].peer_port, 0);
+
+    /* The published value IS the grid that was composited, taken from the
+     * helper's own formatter. The buffer is the size the helper uses, so a
+     * grid this test accepts is one the helper could have published. */
+    char expect[64 + CALL_MAX_PEERS * 32];
+    bool described = media_tiles_describe(f.c->vmix.tiles, f.c->vmix.tile_count, f.cfg.frame_w,
+                                          f.cfg.frame_h, expect, sizeof(expect));
+    CHECK(described);
+    char line[1024];
+    snprintf(line, sizeof(line), "{\"event\":\"tiles\",\"value\":\"%s\"}\n", expect);
+    CHECK_STR(got, line);
+    /* Both peers are named in it, so "the grid" is not an empty string
+     * that happens to round-trip. */
+    CHECK(strstr(expect, ";1,") != NULL);
+    CHECK(strstr(expect, ";4,") != NULL);
+
+    /* Nobody sending stops the decoder rather than leaving it running on
+     * inputs that produce nothing — that is what makes an audio-only
+     * participant cost nothing — and publishes an EMPTY grid. */
+    f.c->vlive[1] = f.c->vlive[4] = false;
+    test_capture_stderr_start();
+    video_retile(f.c);
+    test_capture_stderr_end(got, sizeof(got));
+    CHECK_LONG(f.c->vmix.tile_count, 0);
+    CHECK_LONG(f.c->vmix.pid, -1);
+    CHECK_STR(got, "{\"event\":\"tiles\",\"value\":\"\"}\n");
+
+    fixture_stop(&f);
+}
+
+/* The cap is REPORTED, not silently applied: a peer in the call and not on
+ * screen gets the same honest degradation as one with the camera off,
+ * rather than a grid that reads as "everyone is here". */
+TEST(video_retile_reports_the_pictures_it_had_no_room_for) {
+    struct fixture f;
+    fixture_start(&f, true);
+    ffmpeg_available(true);
+    note_set_verbose(true);
+    char got[8192];
+
+    for (int i = 0; i < CALL_TILE_MAX + 2; i++) f.c->vlive[i] = true;
+    test_capture_stderr_start();
+    video_retile(f.c);
+    test_capture_stderr_end(got, sizeof(got));
+
+    CHECK_LONG(f.c->vmix.tile_count, CALL_TILE_MAX);
+    char expect[128];
+    snprintf(expect, sizeof(expect), "# video: %d of %d pictures shown", CALL_TILE_MAX,
+             CALL_TILE_MAX + 2);
+    CHECK(strstr(got, expect) != NULL);
+
+    note_set_verbose(false);
+    fixture_stop(&f);
+}
+
+/* A decoder that will not start is an error the user can act on. It used
+ * to be unreachable code — a fork that succeeds says nothing about the
+ * exec that follows it. */
+TEST(video_retile_says_so_when_the_decoder_cannot_start) {
+    struct fixture f;
+    fixture_start(&f, true);
+    ffmpeg_available(false);
+    char got[8192];
+
+    f.c->vlive[0] = true;
+    test_capture_stderr_start();
+    video_retile(f.c);
+    test_capture_stderr_end(got, sizeof(got));
+    CHECK_LONG(f.c->vmix.pid, -1);
+    CHECK_STR(got, "{\"event\":\"error\",\"message\":\"cannot start video decoding\"}\n");
+    fixture_stop(&f);
+
+    /* An audio-only call composites nothing, whatever is live. */
+    fixture_start(&f, false);
+    ffmpeg_available(true);
+    f.c->vlive[0] = true;
+    test_capture_stderr_start();
+    video_retile(f.c);
+    test_capture_stderr_end(got, sizeof(got));
+    CHECK_LONG(f.c->vmix.pid, -1);
+    CHECK_STR(got, "");
+    fixture_stop(&f);
+}
+
+/* One decoder for every voice, rebuilt over whoever is actually there: an
+ * amix fixed at connect time leaves a late joiner audible to nobody. */
+TEST(audio_retile_mixes_whoever_is_there_and_stops_when_nobody_is) {
+    struct fixture f;
+    fixture_start(&f, false);
+    ffmpeg_available(true);
+    note_set_verbose(true);
+    char got[8192];
+
+    f.c->alive[0] = true;
+    f.c->alive[5] = true;
+    test_capture_stderr_start();
+    audio_retile(f.c);
+    test_capture_stderr_end(got, sizeof(got));
+    CHECK(f.c->amix.pid > 0);
+    CHECK(f.c->amix.legs[0].peer_port > 0);
+    CHECK(f.c->amix.legs[5].peer_port > 0);
+    CHECK(strstr(got, "# audio: mixing 2 voices\n") != NULL);
+
+    /* One voice is not "1 voices". */
+    f.c->alive[5] = false;
+    test_capture_stderr_start();
+    audio_retile(f.c);
+    test_capture_stderr_end(got, sizeof(got));
+    CHECK(strstr(got, "# audio: mixing 1 voice\n") != NULL);
+
+    /* Nobody left: the decoder stops and says nothing. */
+    f.c->alive[0] = false;
+    test_capture_stderr_start();
+    audio_retile(f.c);
+    test_capture_stderr_end(got, sizeof(got));
+    CHECK_LONG(f.c->amix.pid, -1);
+    CHECK_STR(got, "");
+
+    note_set_verbose(false);
+    fixture_stop(&f);
+}
+
+TEST(audio_retile_says_so_when_playback_cannot_start) {
+    struct fixture f;
+    fixture_start(&f, false);
+    ffmpeg_available(false);
+    char got[8192];
+
+    f.c->alive[2] = true;
+    test_capture_stderr_start();
+    audio_retile(f.c);
+    test_capture_stderr_end(got, sizeof(got));
+    CHECK_LONG(f.c->amix.pid, -1);
+    CHECK(strstr(got, "cannot start audio playback") != NULL);
+
+    fixture_stop(&f);
+}
+
+/* ── the RTP callbacks ─────────────────────────────────────────────────── */
+
+/* Driven through the callback the helper REGISTERED, not called directly:
+ * a callback wired to the wrong track is the bug a direct call cannot see.
+ * Every subscriber has its own legs — N people are N streams, and one
+ * decoder fed from several would be a blender. */
+TEST(an_arriving_packet_is_counted_against_the_peer_that_sent_it) {
+    struct fixture f;
+    fixture_start(&f, true);
+
+    int pc = rtcCreatePeerConnection(NULL);
+    CHECK(pc > 0);
+    f.c->sub[2].pc = pc;
+    rtcSetUserPointer(pc, &f.c->sub[2]);
+
+    rtcTrackInit init;
+    memset(&init, 0, sizeof(init));
+    init.direction = RTC_DIRECTION_RECVONLY;
+    int audio = rtcAddTrackEx(pc, &init);
+    int video = rtcAddTrackEx(pc, &init);
+    CHECK(audio > 0 && video > 0);
+    rtcSetUserPointer(audio, &f.c->sub[2]);
+    rtcSetUserPointer(video, &f.c->sub[2]);
+    CHECK_LONG(rtcSetMessageCallback(audio, on_audio_rtp), RTC_ERR_SUCCESS);
+    CHECK_LONG(rtcSetMessageCallback(video, on_video_rtp), RTC_ERR_SUCCESS);
+
+    char rtp[200];
+    memset(rtp, 0x5a, sizeof(rtp));
+    CHECK(rtc_stub_deliver(audio, rtp, (int)sizeof(rtp)));
+    CHECK(rtc_stub_deliver(video, rtp, (int)sizeof(rtp)));
+    CHECK(rtc_stub_deliver(video, rtp, 40));
+
+    CHECK_LONG(f.c->apkts[2], 1);
+    CHECK_LONG(f.c->abytes[2], sizeof(rtp));
+    CHECK_LONG(f.c->vpkts[2], 2);
+    /* Nobody else moved: the slot is what routes a packet. */
+    for (int i = 0; i < CALL_MAX_PEERS; i++) {
+        if (i == 2) continue;
+        CHECK_LONG(f.c->apkts[i], 0);
+        CHECK_LONG(f.c->vpkts[i], 0);
+    }
+
+    /* An empty or negative length counts for nothing — a size taken from
+     * a negative int is how a length check becomes a huge read. */
+    CHECK(rtc_stub_deliver(audio, rtp, 0));
+    CHECK(rtc_stub_deliver(audio, rtp, -1));
+    CHECK(rtc_stub_deliver(video, rtp, -1));
+    CHECK_LONG(f.c->apkts[2], 1);
+    CHECK_LONG(f.c->vpkts[2], 2);
+
+    fixture_stop(&f);
+}
+
+/* ── pump_main ─────────────────────────────────────────────────────────── */
+
+struct pump_ctx {
+    int track;
+    int want;
+};
+
+static bool pump_saw(void *ctx) {
+    struct pump_ctx *p = ctx;
+    return rtc_stub_sent_count(p->track) >= p->want;
+}
+
+/* Has the pump taken everything off both capture sockets? The kernel's own
+ * answer, which is the only one that does not involve guessing a duration. */
+static bool sockets_drained(void *ctx) {
+    const int *fds = ctx;
+    for (int i = 0; i < 2; i++) {
+        int pending = 0;
+        if (ioctl(fds[i], FIONREAD, &pending) != 0 || pending != 0) return false;
+    }
+    return true;
+}
+
+/* Whatever the capture ffmpeg packetised goes onto the publishing track,
+ * and the socket is DRAINED per wakeup rather than read once: ffmpeg emits
+ * a video frame as a burst, and one-per-poll delivers a fraction of each
+ * frame with no keyframe ever completing. */
+TEST(the_pump_forwards_the_capture_and_drops_what_is_muted) {
+    struct fixture f;
+    fixture_start(&f, true);
+
+    int pc = rtcCreatePeerConnection(NULL);
+    f.c->pub.pc = pc;
+    rtcSetUserPointer(pc, &f.c->pub);
+    rtcTrackInit init;
+    memset(&init, 0, sizeof(init));
+    init.direction = RTC_DIRECTION_SENDONLY;
+    f.c->pub.audio_track = rtcAddTrackEx(pc, &init);
+    f.c->pub.video_track = rtcAddTrackEx(pc, &init);
+    CHECK(f.c->pub.audio_track > 0 && f.c->pub.video_track > 0);
+
+    /* The loopback sockets the capture legs own, and a sender playing the
+     * part of ffmpeg. */
+    int aport = 0, vport = 0;
+    f.c->send_audio.fd = media_bind_loopback(&aport);
+    f.c->send_video.fd = media_bind_loopback(&vport);
+    CHECK(f.c->send_audio.fd >= 0 && f.c->send_video.fd >= 0);
+    int tx = socket(AF_INET, SOCK_DGRAM, 0);
+    CHECK(tx >= 0);
+    struct sockaddr_in to;
+    memset(&to, 0, sizeof(to));
+    to.sin_family = AF_INET;
+    to.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+    /* A self-view leg: the same encoded frame on its way out, handed to a
+     * decoder on loopback — one capture, one encode, two destinations. */
+    int self_port = 0;
+    int self_sink = media_bind_loopback(&self_port);
+    CHECK(self_sink >= 0);
+    f.c->vmix.legs[CALL_SELF_SLOT].fd = socket(AF_INET, SOCK_DGRAM, 0);
+    f.c->vmix.legs[CALL_SELF_SLOT].peer_port = self_port;
+
+    pthread_t pump;
+    CHECK_LONG(pthread_create(&pump, NULL, pump_main, f.c), 0);
+
+    char packet[1400];
+    memset(packet, 0x2b, sizeof(packet));
+    packet[0] = (char)0x80;
+    to.sin_port = htons((uint16_t)aport);
+    for (int i = 0; i < 3; i++)
+        CHECK(sendto(tx, packet, sizeof(packet), 0, (struct sockaddr *)&to, sizeof(to)) ==
+              (ssize_t)sizeof(packet));
+
+    struct pump_ctx ctx = { .track = f.c->pub.audio_track, .want = 3 };
+    CHECK(wait_for(pump_saw, &ctx, 5000));
+    int size = 0;
+    const char *sent = rtc_stub_last_sent(f.c->pub.audio_track, &size);
+    CHECK_LONG(size, sizeof(packet));
+    CHECK(sent && memcmp(sent, packet, sizeof(packet)) == 0);
+
+    /* A packet that fills the pump's buffer to the edge arrives WHOLE. The
+     * buffer is MTU-bounded on purpose and the length travels separately
+     * from it, so this is where a length that outruns the bytes shows. */
+    char big[2048];
+    memset(big, 0x11, sizeof(big));
+    CHECK(sendto(tx, big, sizeof(big), 0, (struct sockaddr *)&to, sizeof(to)) ==
+          (ssize_t)sizeof(big));
+    ctx.want = 4;
+    CHECK(wait_for(pump_saw, &ctx, 5000));
+    sent = rtc_stub_last_sent(f.c->pub.audio_track, &size);
+    CHECK_LONG(size, sizeof(big));
+    CHECK(sent && memcmp(sent, big, sizeof(big)) == 0);
+
+    /* Video goes to the video track AND to the self tile, which joins the
+     * grid through the same liveness path as everybody else. */
+    to.sin_port = htons((uint16_t)vport);
+    CHECK(sendto(tx, packet, 120, 0, (struct sockaddr *)&to, sizeof(to)) == 120);
+    ctx.track = f.c->pub.video_track;
+    ctx.want = 1;
+    CHECK(wait_for(pump_saw, &ctx, 5000));
+    rtc_stub_last_sent(f.c->pub.video_track, &size);
+    CHECK_LONG(size, 120);
+    CHECK_LONG(f.c->vpkts[CALL_SELF_SLOT], 1);
+    char echo[2048];
+    CHECK(recv(self_sink, echo, sizeof(echo), MSG_DONTWAIT) == 120);
+
+    /* Mute is LOCAL and instant: the socket is still DRAINED — a muted
+     * minute would otherwise burst on unmute — and nothing is sent.
+     *
+     * Both halves are observed rather than waited out. The drain is read
+     * off the socket itself (FIONREAD reaching zero means the pump has
+     * taken every muted datagram), which makes "nothing was forwarded" an
+     * assertion about a KNOWN state instead of about a sleep that was
+     * hopefully long enough. Unmuting only afterwards is what keeps the
+     * marker below from racing the batch. */
+    f.c->muted = true;
+    f.c->camera_off = true;
+    to.sin_port = htons((uint16_t)aport);
+    for (int i = 0; i < 4; i++)
+        CHECK(sendto(tx, packet, 64, 0, (struct sockaddr *)&to, sizeof(to)) == 64);
+    to.sin_port = htons((uint16_t)vport);
+    for (int i = 0; i < 4; i++)
+        CHECK(sendto(tx, packet, 64, 0, (struct sockaddr *)&to, sizeof(to)) == 64);
+
+    int capture_fds[2] = { f.c->send_audio.fd, f.c->send_video.fd };
+    CHECK(wait_for(sockets_drained, capture_fds, 5000));
+    CHECK_LONG(rtc_stub_sent_count(f.c->pub.audio_track), 4);
+    /* The camera is off too, so the far end and the self tile went dark
+     * together — which is the point of dropping at the track rather than
+     * at the capture. */
+    CHECK_LONG(rtc_stub_sent_count(f.c->pub.video_track), 1);
+    CHECK_LONG(f.c->vpkts[CALL_SELF_SLOT], 1);
+    CHECK(recv(self_sink, echo, sizeof(echo), MSG_DONTWAIT) < 0);
+
+    /* Unmuting is instant and does NOT replay the minute that was muted. */
+    f.c->muted = false;
+    to.sin_port = htons((uint16_t)aport);
+    CHECK(sendto(tx, packet, 32, 0, (struct sockaddr *)&to, sizeof(to)) == 32);
+    ctx.track = f.c->pub.audio_track;
+    ctx.want = 5;
+    CHECK(wait_for(pump_saw, &ctx, 5000));
+    CHECK_LONG(rtc_stub_sent_count(f.c->pub.audio_track), 5);
+    rtc_stub_last_sent(f.c->pub.audio_track, &size);
+    CHECK_LONG(size, 32);
+
+    stop_requested = 1;
+    pthread_join(pump, NULL);
+    close(tx);
+    close(self_sink);
+    fixture_stop(&f);
+}
+
+/* With no capture leg there is nothing to poll, and the thread must END
+ * rather than spin: it is joined on every teardown. */
+TEST(the_pump_returns_when_there_is_nothing_to_pump) {
+    struct fixture f;
+    fixture_start(&f, false);
+    pthread_t pump;
+    CHECK_LONG(pthread_create(&pump, NULL, pump_main, f.c), 0);
+    CHECK_LONG(pthread_join(pump, NULL), 0);
+    fixture_stop(&f);
+}
+
+/* ── session_negotiate ─────────────────────────────────────────────────── */
+
+TEST(a_publish_posts_its_offer_and_encodes_what_the_answer_chose) {
+    struct fixture f;
+    fixture_start(&f, true);
+    struct sfu s;
+    CHECK(sfu_start(&s));
+    sfu_script_created(&s, "/session/7", SFU_ANSWER_VP8);
+    rtc_stub_set_offer(
+        "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\na=candidate:1 1 udp 1 127.0.0.1 1 typ host\r\n");
+
+    char url[256];
+    sfu_url(&s, "/room/whip", url, sizeof(url));
+    CHECK(session_negotiate(&f.c->pub, url, RTC_DIRECTION_SENDONLY, true, &f.cfg, NULL, 2000));
+
+    /* The session is up and knows how to hang itself up. */
+    CHECK(f.c->pub.active);
+    CHECK(f.c->pub.pc > 0);
+    CHECK(f.c->pub.have_resource);
+    char expect_resource[256];
+    snprintf(expect_resource, sizeof(expect_resource), "http://127.0.0.1:%d/session/7", s.port);
+    CHECK_STR(f.c->pub.resource, expect_resource);
+
+    /* The request that actually went out, and the gathered offer in it:
+     * WHIP is one POST with one body, so a candidate that arrived late
+     * would have nowhere to go. */
+    CHECK_LONG(sfu_requests(&s), 1);
+    char req[8192];
+    sfu_request(&s, 0, req, sizeof(req));
+    CHECK(strncmp(req, "POST /room/whip HTTP/1.1\r\n", 26) == 0);
+    CHECK(strstr(req, "Content-Type: application/sdp\r\n") != NULL);
+    CHECK(strstr(req, "a=candidate:1 1 udp 1 127.0.0.1 1 typ host") != NULL);
+
+    /* The answer reached the peer connection whole. */
+    CHECK_STR(rtc_stub_remote_description(f.c->pub.pc), SFU_ANSWER_VP8);
+
+    /* A PUBLISHER must ENCODE what the far end chose. Offering both and
+     * then encoding the configured preference is a call that arrives
+     * one-way, with every subscriber seeing a tile that never paints and
+     * no error anywhere. */
+    CHECK(f.c->pub.negotiated);
+    CHECK_LONG(f.c->pub.neg_codec, MEDIA_VIDEO_VP8);
+    CHECK_LONG(f.c->pub.neg_pt, 96);
+
+    /* The tracks it offered, carrying the values declared once in the
+     * config — a second copy of "Opus is 111" is a second place for it to
+     * stop being true. */
+    struct rtc_stub_track t;
+    CHECK(rtc_stub_track(f.c->pub.audio_track, &t));
+    CHECK_LONG(t.direction, RTC_DIRECTION_SENDONLY);
+    CHECK_LONG(t.codec, RTC_CODEC_OPUS);
+    CHECK_LONG(t.payload_type, f.cfg.audio_payload_type);
+    CHECK_STR(t.mid, "audio");
+    /* SENDING is a choice, so the publisher offers ONE video codec. */
+    CHECK(rtc_stub_track(f.c->pub.video_track, &t));
+    CHECK(!t.from_sdp);
+    CHECK_LONG(t.direction, RTC_DIRECTION_SENDONLY);
+    CHECK_LONG(t.codec, RTC_CODEC_VP8);
+    CHECK_LONG(t.payload_type, f.cfg.video_payload_type);
+    CHECK_STR(t.mid, "video");
+
+    session_release(&f.c->pub);
+    sfu_stop(&s);
+    fixture_stop(&f);
+}
+
+/* H.264 is spelled out rather than left NULL: the C API turns a NULL
+ * profile into no fmtp line at all, and an H.264 m-line without
+ * packetization-mode is one a browser may decline or read as single-NAL. */
+TEST(an_h264_publish_names_its_profile) {
+    struct fixture f;
+    fixture_start(&f, true);
+    f.cfg.video_codec = MEDIA_VIDEO_H264;
+    struct sfu s;
+    CHECK(sfu_start(&s));
+    sfu_script_created(&s, "/session/8", SFU_ANSWER_VP8);
+
+    char url[256];
+    sfu_url(&s, "/room/whip", url, sizeof(url));
+    CHECK(session_negotiate(&f.c->pub, url, RTC_DIRECTION_SENDONLY, true, &f.cfg, NULL, 2000));
+
+    struct rtc_stub_track t;
+    CHECK(rtc_stub_track(f.c->pub.video_track, &t));
+    CHECK_LONG(t.codec, RTC_CODEC_H264);
+    CHECK(strstr(t.profile, "packetization-mode=1") != NULL);
+    CHECK(strstr(t.profile, "profile-level-id=42e01f") != NULL);
+
+    /* The answer named VP8, and a publisher encodes what was CHOSEN. */
+    CHECK(f.c->pub.negotiated);
+    CHECK_LONG(f.c->pub.neg_codec, MEDIA_VIDEO_VP8);
+
+    session_release(&f.c->pub);
+    sfu_stop(&s);
+    fixture_stop(&f);
+}
+
+/* RECEIVING offers every codec we can decode and lets the answer choose:
+ * an SFU does not transcode, so the codec is a property of the PUBLISHER,
+ * and a subscriber that offered only its own preference sees a black tile
+ * for half the room with no error anywhere. */
+TEST(a_subscribe_offers_every_codec_and_decodes_the_one_that_answered) {
+    struct fixture f;
+    fixture_start(&f, true);
+    f.c->sub_count = 4;
+    struct sfu s;
+    CHECK(sfu_start(&s));
+    sfu_script_created(&s, "/session/9", SFU_ANSWER_VP8);
+
+    /* The leg starts on something else, so the answer has to move it. */
+    f.c->vmix.legs[3].codec = MEDIA_VIDEO_H264;
+    f.c->vmix.legs[3].payload_type = 97;
+    f.c->sub[3].receives = true;
+
+    char url[256];
+    sfu_url(&s, "/room/whep/bob", url, sizeof(url));
+    CHECK(session_negotiate(&f.c->sub[3], url, RTC_DIRECTION_RECVONLY, true, &f.cfg, NULL, 2000));
+
+    struct rtc_stub_track t;
+    CHECK(rtc_stub_track(f.c->sub[3].video_track, &t));
+    CHECK(t.from_sdp); /* the hand-built multi-codec m-line, not rtcAddTrackEx */
+    CHECK(strstr(t.sdp, "VP8") != NULL);
+    CHECK(strstr(t.sdp, "H264") != NULL);
+
+    /* Per-peer, onto that peer's own leg: a global setting would decode
+     * one participant as another. */
+    CHECK_LONG(f.c->vmix.legs[3].codec, MEDIA_VIDEO_VP8);
+    CHECK_LONG(f.c->vmix.legs[3].payload_type, 96);
+    CHECK_LONG(f.c->vmix.legs[2].codec, MEDIA_VIDEO_VP8); /* untouched default */
+    CHECK_LONG(f.c->vmix.legs[2].payload_type, f.cfg.video_payload_type);
+
+    session_release(&f.c->sub[3]);
+    sfu_stop(&s);
+    fixture_stop(&f);
+}
+
+/* A refused multi-codec offer falls back to the single-codec track rather
+ * than losing video entirely — reported, never silent, because it means
+ * this peer is only watchable if they publish what we guessed. */
+TEST(a_refused_multi_codec_offer_falls_back_and_says_so) {
+    struct fixture f;
+    fixture_start(&f, true);
+    f.c->sub_count = 1;
+    struct sfu s;
+    CHECK(sfu_start(&s));
+    sfu_script_created(&s, "/session/2", SFU_ANSWER_VP8);
+    f.c->sub[0].receives = true;
+
+    char url[256], got[4096];
+    sfu_url(&s, "/room/whep/ann", url, sizeof(url));
+    rtc_stub_fail_track_at(2); /* audio is 1, the m-line offer is 2 */
+    note_set_verbose(true);
+    test_capture_stderr_start();
+    bool ok = session_negotiate(&f.c->sub[0], url, RTC_DIRECTION_RECVONLY, true, &f.cfg, NULL,
+                                2000);
+    test_capture_stderr_end(got, sizeof(got));
+    note_set_verbose(false);
+    CHECK(ok);
+    CHECK(strstr(got, "# subscribe: the multi-codec offer was refused") != NULL);
+
+    struct rtc_stub_track t;
+    CHECK(rtc_stub_track(f.c->sub[0].video_track, &t));
+    CHECK(!t.from_sdp); /* fell back to the single-codec track */
+    CHECK_LONG(t.direction, RTC_DIRECTION_RECVONLY);
+
+    /* An audio track that cannot be added is fatal to the session — there
+     * is no fallback for the medium a call is made of. */
+    session_release(&f.c->sub[0]);
+    session_reset(&f.c->sub[0]);
+    rtc_stub_fail_track_at(1);
+    test_capture_stderr_start();
+    ok = session_negotiate(&f.c->sub[0], url, RTC_DIRECTION_RECVONLY, true, &f.cfg, NULL, 2000);
+    test_capture_stderr_end(got, sizeof(got));
+    CHECK(!ok);
+    CHECK(strstr(got, "cannot add the audio track") != NULL);
+
+    session_release(&f.c->sub[0]);
+    sfu_stop(&s);
+    fixture_stop(&f);
+}
+
+/* A 404 on a SUBSCRIBE is "that person is not in the call", which for a
+ * channel is true of most members most of the time. Said ONCE, then the
+ * retries go quiet — three lines per peer per tick buries the events that
+ * matter. */
+TEST(a_peer_who_is_not_in_the_call_is_reported_once_and_then_quietly) {
+    struct fixture f;
+    fixture_start(&f, false);
+    f.c->sub_count = 2;
+    struct sfu s;
+    CHECK(sfu_start(&s));
+    sfu_script_status(&s, 404, "Not Found");
+    char url[256], got[4096];
+    sfu_url(&s, "/room/whep/nobody", url, sizeof(url));
+
+    test_capture_stderr_start();
+    bool ok = session_negotiate(&f.c->sub[1], url, RTC_DIRECTION_RECVONLY, false, &f.cfg, NULL,
+                                2000);
+    test_capture_stderr_end(got, sizeof(got));
+    CHECK(!ok);
+    CHECK(f.c->sub[1].absent);
+    CHECK_STR(got, "{\"event\":\"state\",\"value\":\"subscribe: not in the call — retrying "
+                   "quietly\"}\n");
+
+    /* The retry says nothing at all. */
+    session_release(&f.c->sub[1]);
+    session_reset(&f.c->sub[1]);
+    CHECK(f.c->sub[1].absent); /* survives the reset, which runs on every retry */
+    test_capture_stderr_start();
+    ok = session_negotiate(&f.c->sub[1], url, RTC_DIRECTION_RECVONLY, false, &f.cfg, NULL, 2000);
+    test_capture_stderr_end(got, sizeof(got));
+    CHECK(!ok);
+    CHECK_STR(got, "");
+
+    /* Arriving is loud again: routine chatter is informative once more. */
+    session_release(&f.c->sub[1]);
+    session_reset(&f.c->sub[1]);
+    sfu_script_created(&s, "/session/1", SFU_ANSWER_VP8);
+    CHECK(session_negotiate(&f.c->sub[1], url, RTC_DIRECTION_RECVONLY, false, &f.cfg, NULL, 2000));
+    CHECK(!f.c->sub[1].absent);
+
+    session_release(&f.c->sub[1]);
+    sfu_stop(&s);
+    fixture_stop(&f);
+}
+
+/* Every other status is a real error and carries its NUMBER: "it did not
+ * work" without the number is the message that wastes an afternoon. And a
+ * 404 on a PUBLISH is not "not in the call". */
+TEST(any_other_status_is_an_error_with_its_number_on_it) {
+    struct fixture f;
+    fixture_start(&f, false);
+    struct sfu s;
+    CHECK(sfu_start(&s));
+    sfu_script_status(&s, 503, "Service Unavailable");
+    char url[256], got[4096];
+    sfu_url(&s, "/room/whip", url, sizeof(url));
+
+    test_capture_stderr_start();
+    bool ok = session_negotiate(&f.c->pub, url, RTC_DIRECTION_SENDRECV, false, &f.cfg, NULL, 2000);
+    test_capture_stderr_end(got, sizeof(got));
+    CHECK(!ok);
+    CHECK_STR(got, "{\"event\":\"error\",\"message\":\"publish: the endpoint answered 503\"}\n");
+    CHECK(!f.c->pub.absent);
+
+    session_release(&f.c->pub);
+    session_reset(&f.c->pub);
+    sfu_script_status(&s, 404, "Not Found");
+    test_capture_stderr_start();
+    ok = session_negotiate(&f.c->pub, url, RTC_DIRECTION_SENDRECV, false, &f.cfg, NULL, 2000);
+    test_capture_stderr_end(got, sizeof(got));
+    CHECK(!ok);
+    CHECK_STR(got, "{\"event\":\"error\",\"message\":\"publish: the endpoint answered 404\"}\n");
+    CHECK(!f.c->pub.absent);
+
+    session_release(&f.c->pub);
+    sfu_stop(&s);
+    fixture_stop(&f);
+}
+
+/* Vanilla ICE: gather everything, THEN offer — WHIP is one POST with one
+ * body and there is nowhere to trickle a late candidate to. A peer that
+ * never finishes gathering must time out and say why. */
+TEST(a_gathering_that_never_finishes_times_out_and_says_so) {
+    struct fixture f;
+    fixture_start(&f, false);
+    struct sfu s;
+    CHECK(sfu_start(&s));
+    sfu_script_created(&s, "/session/1", SFU_ANSWER_VP8);
+    rtc_stub_set_gathering_completes(false);
+
+    char url[256], got[4096];
+    sfu_url(&s, "/room/whip", url, sizeof(url));
+    test_capture_stderr_start();
+    bool ok = session_negotiate(&f.c->pub, url, RTC_DIRECTION_SENDRECV, false, &f.cfg, NULL, 100);
+    test_capture_stderr_end(got, sizeof(got));
+    CHECK(!ok);
+    CHECK_STR(got, "{\"event\":\"error\",\"message\":\"ICE gathering did not finish in time\"}\n");
+    /* Nothing was posted: the offer never became complete. */
+    CHECK_LONG(sfu_requests(&s), 0);
+    /* The peer connection exists all the same, and is owed a release. */
+    CHECK(f.c->pub.active);
+    CHECK(f.c->pub.pc > 0);
+
+    session_release(&f.c->pub);
+    sfu_stop(&s);
+    fixture_stop(&f);
+}
+
+/* A refused answer is not a session that quietly half-exists. */
+TEST(a_rejected_answer_fails_the_session_and_still_owes_a_hangup) {
+    struct fixture f;
+    fixture_start(&f, false);
+    struct sfu s;
+    CHECK(sfu_start(&s));
+    sfu_script_created(&s, "/session/4", SFU_ANSWER_VP8);
+    rtc_stub_set_remote_description_ok(false);
+
+    char url[256], got[4096];
+    sfu_url(&s, "/room/whip", url, sizeof(url));
+    test_capture_stderr_start();
+    bool ok = session_negotiate(&f.c->pub, url, RTC_DIRECTION_SENDRECV, false, &f.cfg, NULL, 2000);
+    test_capture_stderr_end(got, sizeof(got));
+    CHECK(!ok);
+    CHECK(strstr(got, "the SDP answer was rejected") != NULL);
+    /* The resource was resolved BEFORE the answer was tried, so the hangup
+     * is still owed — an SFU that never hears it holds the slot. */
+    CHECK(f.c->pub.have_resource);
+
+    session_release(&f.c->pub);
+    CHECK_LONG(sfu_requests(&s), 2); /* the POST, then the DELETE */
+    sfu_stop(&s);
+    fixture_stop(&f);
+}
+
+/* ── session_release ───────────────────────────────────────────────────── */
+
+/* Hanging up is a DELETE, owed on EVERY path that got a resource. An SFU
+ * that never hears it holds the slot until its own timeout, which for a
+ * room somebody is trying to re-enter is the difference between "call
+ * again" and "wait five minutes". */
+TEST(a_release_hangs_up_deletes_the_connection_and_is_safe_twice) {
+    struct fixture f;
+    fixture_start(&f, false);
+    struct sfu s;
+    CHECK(sfu_start(&s));
+    sfu_script_created(&s, "/session/12", SFU_ANSWER_VP8);
+    sfu_script_status(&s, 200, "OK");
+
+    char url[256];
+    sfu_url(&s, "/room/whip", url, sizeof(url));
+    CHECK(session_negotiate(&f.c->pub, url, RTC_DIRECTION_SENDRECV, false, &f.cfg, NULL, 2000));
+    int audio_track = f.c->pub.audio_track;
+
+    session_release(&f.c->pub);
+    CHECK_LONG(sfu_requests(&s), 2);
+    char req[8192];
+    sfu_request(&s, 1, req, sizeof(req));
+    CHECK(strncmp(req, "DELETE /session/12 HTTP/1.1\r\n", 29) == 0);
+
+    CHECK(!f.c->pub.have_resource);
+    CHECK(!f.c->pub.active);
+    CHECK_LONG(f.c->pub.pc, -1);
+    CHECK_LONG(rtc_stub_pcs_deleted(), 1);
+    /* The tracks went with the connection, as the real library does it. */
+    struct rtc_stub_track t;
+    CHECK(!rtc_stub_track(audio_track, &t));
+
+    /* Twice is not two hangups and not two deletes: teardown calls this
+     * over every subscriber slot, most of which were never used. */
+    session_release(&f.c->pub);
+    CHECK_LONG(sfu_requests(&s), 2);
+    CHECK_LONG(rtc_stub_pcs_deleted(), 1);
+    CHECK_LONG(rtc_stub_bad_calls(), 0);
+
+    for (int i = 0; i < CALL_MAX_PEERS; i++) session_release(&f.c->sub[i]);
+    CHECK_LONG(rtc_stub_pcs_deleted(), 1);
+    CHECK_LONG(rtc_stub_bad_calls(), 0);
+
+    sfu_stop(&s);
+    fixture_stop(&f);
+}
+
+/* session_negotiate marks a session ACTIVE the moment it creates the peer
+ * connection, which is before the POST that can refuse it. Left active, a
+ * peer who is simply not in the call is a session that never settles, so
+ * the whole call is declared dead — with a message blaming the SFU. */
+TEST(a_session_that_never_got_a_resource_still_releases_its_connection) {
+    struct fixture f;
+    fixture_start(&f, false);
+    f.c->sub_count = 1;
+    struct sfu s;
+    CHECK(sfu_start(&s));
+    sfu_script_status(&s, 404, "Not Found");
+
+    char url[256], got[4096];
+    sfu_url(&s, "/room/whep/ghost", url, sizeof(url));
+    test_capture_stderr_start();
+    bool ok = session_negotiate(&f.c->sub[0], url, RTC_DIRECTION_RECVONLY, false, &f.cfg, NULL,
+                                2000);
+    test_capture_stderr_end(got, sizeof(got));
+    CHECK(!ok);
+    CHECK_STR(got, "{\"event\":\"state\",\"value\":\"subscribe: not in the call — retrying "
+                   "quietly\"}\n");
+    CHECK(f.c->sub[0].active);
+    CHECK(f.c->sub[0].pc > 0);
+    CHECK(!f.c->sub[0].have_resource);
+
+    session_release(&f.c->sub[0]);
+    CHECK(!f.c->sub[0].active);
+    CHECK_LONG(f.c->sub[0].pc, -1);
+    CHECK_LONG(rtc_stub_pcs_deleted(), 1);
+    CHECK_LONG(sfu_requests(&s), 1); /* the POST only: no resource, no DELETE */
+    CHECK_LONG(rtc_stub_bad_calls(), 0);
+
+    sfu_stop(&s);
+    fixture_stop(&f);
+}
+
+/* A hangup the endpoint refuses must not stop the teardown: this runs on
+ * the way out of main, with the rest of the release still to do. */
+TEST(a_hangup_the_endpoint_refuses_is_reported_and_not_fatal) {
+    struct fixture f;
+    fixture_start(&f, false);
+    struct sfu s;
+    CHECK(sfu_start(&s));
+    sfu_script_created(&s, "/session/5", SFU_ANSWER_VP8);
+
+    char url[256], got[4096];
+    sfu_url(&s, "/room/whip", url, sizeof(url));
+    CHECK(session_negotiate(&f.c->pub, url, RTC_DIRECTION_SENDRECV, false, &f.cfg, NULL, 2000));
+
+    /* The endpoint is gone by the time we hang up. */
+    sfu_stop(&s);
+    note_set_verbose(true);
+    test_capture_stderr_start();
+    session_release(&f.c->pub);
+    test_capture_stderr_end(got, sizeof(got));
+    note_set_verbose(false);
+
+    CHECK(strstr(got, "# publish: hangup failed:") != NULL);
+    CHECK(!f.c->pub.have_resource);
+    CHECK_LONG(f.c->pub.pc, -1);
+    CHECK_LONG(rtc_stub_pcs_deleted(), 1);
+
+    fixture_stop(&f);
+}
+
+int main(void) {
+    /* main() ignores SIGPIPE because shottino can close the frame pipe at
+     * any moment; here it is the fake endpoint closing a socket, and the
+     * default disposition would kill the suite rather than fail it. */
+    signal(SIGPIPE, SIG_IGN);
+    if (!fake_ffmpeg_setup()) {
+        fprintf(stderr, "FATAL %s: cannot make a fake ffmpeg\n", __FILE__);
+        return 1;
+    }
+
+    RUN(liveness_is_immediate_on_the_way_in_and_patient_on_the_way_out);
+    RUN(a_state_change_is_recorded_and_named_once_per_peer);
+    RUN(the_library_log_is_routed_into_the_comment_stream);
+    RUN(video_retile_publishes_the_grid_it_actually_composited);
+    RUN(video_retile_reports_the_pictures_it_had_no_room_for);
+    RUN(video_retile_says_so_when_the_decoder_cannot_start);
+    RUN(audio_retile_mixes_whoever_is_there_and_stops_when_nobody_is);
+    RUN(audio_retile_says_so_when_playback_cannot_start);
+    RUN(an_arriving_packet_is_counted_against_the_peer_that_sent_it);
+    RUN(the_pump_forwards_the_capture_and_drops_what_is_muted);
+    RUN(the_pump_returns_when_there_is_nothing_to_pump);
+    RUN(a_publish_posts_its_offer_and_encodes_what_the_answer_chose);
+    RUN(an_h264_publish_names_its_profile);
+    RUN(a_subscribe_offers_every_codec_and_decodes_the_one_that_answered);
+    RUN(a_refused_multi_codec_offer_falls_back_and_says_so);
+    RUN(a_peer_who_is_not_in_the_call_is_reported_once_and_then_quietly);
+    RUN(any_other_status_is_an_error_with_its_number_on_it);
+    RUN(a_gathering_that_never_finishes_times_out_and_says_so);
+    RUN(a_rejected_answer_fails_the_session_and_still_owes_a_hangup);
+    RUN(a_release_hangs_up_deletes_the_connection_and_is_safe_twice);
+    RUN(a_session_that_never_got_a_resource_still_releases_its_connection);
+    RUN(a_hangup_the_endpoint_refuses_is_reported_and_not_fatal);
+
+    fake_ffmpeg_teardown();
+    return test_report();
+}

--- a/frontends/shottino/tests/test_callnote.c
+++ b/frontends/shottino/tests/test_callnote.c
@@ -20,32 +20,9 @@
 
 #include "test.h"
 
-/* stderr is what is under test AND what test.h reports failures on, so
- * it is captured to a file and put back BEFORE anything is asserted. */
-static int cap_saved = -1;
-static char cap_path[64];
-
-static void cap_start(void) {
-    snprintf(cap_path, sizeof(cap_path), "/tmp/shottino-note-XXXXXX");
-    int fd = mkstemp(cap_path);
-    if (fd < 0) abort();
-    fflush(stderr);
-    cap_saved = dup(STDERR_FILENO);
-    dup2(fd, STDERR_FILENO);
-    close(fd);
-}
-
-static void cap_end(char *out, size_t out_sz) {
-    fflush(stderr);
-    dup2(cap_saved, STDERR_FILENO);
-    close(cap_saved);
-    cap_saved = -1;
-    FILE *f = fopen(cap_path, "r");
-    size_t n = f ? fread(out, 1, out_sz - 1, f) : 0;
-    out[n] = 0;
-    if (f) fclose(f);
-    unlink(cap_path);
-}
+/* stderr is what is under test AND what test.h reports failures on, so it
+ * is captured to a file and put back BEFORE anything is asserted. The
+ * capture itself lives in test.h now that test_callmain needs it too. */
 
 /* True when every non-empty line the helper wrote is one the reader
  * will skip — i.e. nothing here can be mistaken for an event. */
@@ -63,16 +40,16 @@ TEST(a_note_comments_every_line_it_writes) {
     char got[8192];
     note_set_verbose(true);
 
-    cap_start();
+    test_capture_stderr_start();
     note("subscribe 0: joined late");
-    cap_end(got, sizeof(got));
+    test_capture_stderr_end(got, sizeof(got));
     CHECK_STR(got, "# subscribe 0: joined late\n");
 
     /* A MULTI-LINE note. The helper writes one for every answer it gets
      * at --verbose, and the reader comments out lines, not messages. */
-    cap_start();
+    test_capture_stderr_start();
     note("%s: answer\n%s", "publish", "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\n");
-    cap_end(got, sizeof(got));
+    test_capture_stderr_end(got, sizeof(got));
     CHECK(every_line_is_a_comment(got));
     CHECK(strstr(got, "# v=0") != NULL);
     CHECK(strstr(got, "# o=- 0 0 IN IP4 127.0.0.1") != NULL);
@@ -81,10 +58,10 @@ TEST(a_note_comments_every_line_it_writes) {
      * is a list of lines. One shaped like an event reaches the reader as
      * an event unless every line of the note is commented — which is a
      * remote peer closing the call window, or worse. */
-    cap_start();
+    test_capture_stderr_start();
     note("%s: answer\n%s", "subscribe 0",
          "v=0\r\na=x:{\"event\":\"closed\"}\r\n{\"event\":\"error\",\"message\":\"pwned\"}\r\n");
-    cap_end(got, sizeof(got));
+    test_capture_stderr_end(got, sizeof(got));
     CHECK(every_line_is_a_comment(got));
     CHECK(strstr(got, "\n{\"event\"") == NULL);
 
@@ -96,18 +73,18 @@ TEST(a_note_comments_every_line_it_writes) {
     big[sizeof(big) - 1] = 0;
     big[1000] = '\n';
     big[2000] = '\n';
-    cap_start();
+    test_capture_stderr_start();
     note("answer\n%s", big);
-    cap_end(got, sizeof(got));
+    test_capture_stderr_end(got, sizeof(got));
     CHECK(every_line_is_a_comment(got));
     CHECK(strlen(got) >= sizeof(big));
     CHECK(got[strlen(got) - 1] == '\n');
 
     /* Off means silent — the notes are the only thing --verbose adds. */
     note_set_verbose(false);
-    cap_start();
+    test_capture_stderr_start();
     note("%s", "not written");
-    cap_end(got, sizeof(got));
+    test_capture_stderr_end(got, sizeof(got));
     CHECK_STR(got, "");
     note_set_verbose(true);
 }
@@ -117,21 +94,21 @@ TEST(a_note_comments_every_line_it_writes) {
 TEST(an_event_value_cannot_escape_its_own_string) {
     char got[8192];
 
-    cap_start();
+    test_capture_stderr_start();
     emit_event("state", "value", "publish connected");
-    cap_end(got, sizeof(got));
+    test_capture_stderr_end(got, sizeof(got));
     CHECK_STR(got, "{\"event\":\"state\",\"value\":\"publish connected\"}\n");
 
-    cap_start();
+    test_capture_stderr_start();
     emit_event("closed", NULL, NULL);
-    cap_end(got, sizeof(got));
+    test_capture_stderr_end(got, sizeof(got));
     CHECK_STR(got, "{\"event\":\"closed\"}\n");
 
     /* Server text: quotes, backslashes and control bytes all come back
      * as one line with the braces still ours. */
-    cap_start();
+    test_capture_stderr_start();
     emit_event("error", "message", "he said \"no\" \\ then\nleft");
-    cap_end(got, sizeof(got));
+    test_capture_stderr_end(got, sizeof(got));
     CHECK_STR(got,
               "{\"event\":\"error\",\"message\":\"he said \\\"no\\\" \\\\ then\\u000aleft\"}\n");
     /* ONE line out, whatever went in. */
@@ -142,9 +119,9 @@ TEST(an_event_value_cannot_escape_its_own_string) {
     char loud[2048];
     memset(loud, '"', sizeof(loud) - 1);
     loud[sizeof(loud) - 1] = 0;
-    cap_start();
+    test_capture_stderr_start();
     emit_event("error", "message", loud);
-    cap_end(got, sizeof(got));
+    test_capture_stderr_end(got, sizeof(got));
     CHECK(strchr(got, '\n') == got + strlen(got) - 1);
     CHECK(strncmp(got, "{\"event\":\"error\",\"message\":\"", 27) == 0);
     CHECK(strstr(got, "\"}\n") == got + strlen(got) - 3);


### PR DESCRIPTION
Issue #880. `call/main.c` was compiled by CI (#754) and linked by nothing, so
seven functions stayed outside ASan/UBSan: `session_negotiate`,
`session_release`, `on_state`, `video_retile`, `audio_retile`, `liveness_step`,
`pump_main`. This links them.

## What is gated now — three tiers, and the words matter

| | files |
|---|---|
| compiled under `-Werror` (`call-compile`) | `call/main.c`, `call/whip.c`, `call/media.c`, `call/note.c`, `http.c` |
| **linked into a sanitized binary** | `call/media.c`, `call/note.c`, `call/whip.c` (already) — and now `call/main.c`, via `tests/test_callmain` |
| linked for real | **nothing.** The C++ link driver, `-static-libstdc++` and the four vendored archives are still proven only by typing `make call` |

## How

All seven are `static`, so the suite compiles `main.c` into itself with
`#define main call_main_unused` — the device `test_layout.c` already uses for
`shottino.c`. Extracting them to a header would have reshaped the code under
test to suit the test.

libdatachannel is a stub (`tests/stub/rtc/rtc.h` + `tests/rtc_stub.c`): linking
the real one costs cmake, a C++ toolchain and minutes of build, and `make check`
must not grow a dependency on the opt-in submodule — the line `test_whip`,
`test_callmedia` and `test_callnote` all hold. **The stub cannot drift**, by a
chain of two compilations: `make check` builds `rtc_stub.c` against the stub
header, `call-compile` builds the same file against the VENDORED header in the
one job that has the submodule. Both links were broken on purpose — a signature
changed in the stub header alone fails the test build (`rc=2`, conflicting
types); changed in header and definition together it fails `call-compile`
(`rc=2`).

The stub is not a null implementation: a peer connection is an allocation whose
tracks die with it, `rtcSendMessage` reads the bytes for the length it is TOLD,
and callbacks are driven through the pointers the helper registered rather than
called directly. `session_negotiate` runs against a real HTTP endpoint on
loopback, so the WHIP answer is parsed while it is still allocated.

22 tests, 242 checks.

## Proven by mutation — 6 defects, 6 reds

Baseline `242 checks passed rc=0`; each mutation rebuilt from scratch (`rm -f`
the binary first, so `make` cannot measure the previous build); each restored,
tree clean afterwards.

| mutation | result |
|---|---|
| `liveness_step` loops `i <= CALL_MAX_PEERS` | `rc=-6` **ASan heap-buffer-overflow** |
| `video_retile` collects one slot too many | `rc=1` **UBSan** `index 8 out of bounds for type 'bool[8]'` |
| `on_state` loses the bound on the name table | `rc=1` **UBSan** `index 99 out of bounds` + failed check |
| the pump reports `got + 64` bytes | `rc=-6` **ASan global-buffer-overflow** |
| `session_negotiate` frees the answer before parsing it | `rc=1` failed check (`negotiated` false) |
| `session_release` drops `s->pc = -1` | `rc=1` failed check (`pc` left at 1) |

## What I refuse to claim

- **Two of my own four claims were wrong, and the measurement is what said so.**
  I wrote that heap-allocating `struct call` gives every per-peer array
  redzones. It does not: an off-by-one on `c->vlive[8]` lands on the next member
  of the same allocation and touches no redzone. What turns that red is UBSan's
  array-bounds on the *declared type*, a different check that would **not** fire
  had the array been reached through a pointer. The heap allocation earns its
  keep only where the arrays are separate allocations — `liveness_step`'s four.
  I also wrote that a wrong release order would be a use-after-free; it is a
  failed assertion, because the stub deliberately refuses to follow a freed id.
  Both corrections are in the tree (commit 3 of 4) and in DESIGN_NOTES.
- **This is not coverage of the shipped helper.** It is coverage of `main.c`
  compiled against a stub. The link, the archives and libdatachannel's real
  behaviour are untested here, and the Makefile says so in one place.
- **`main()` itself is still unexercised** — argument parsing, the control-verb
  loop, the resubscribe round-robin and the teardown ORDER that #759 was about.
  The fixture rebuilds the state `main()` sets rather than calling it, so a
  divergence between the two is a gap this suite cannot see. Closing it means
  extracting an init from `main()`, which is a production change with no bug
  behind it; I did not take it unasked.
- **Nothing was run on Linux.** Verified on darwin only (18 suites, ~13.6k
  checks, `rc=0`, `test_keys` excluded — it needs `<pty.h>`). The real gate is
  CI.

## Doc drift

`docs/DESIGN_NOTES.md` still said *"no CI job compiles the call helper"*, false
since #754. Corrected in place with a pointer forward (the log is chronological
and it was true when written) plus a new entry stating the three tiers, the stub
chain and the mutation numbers.

## Test plan

- [x] `make check` locally: 18 suites green, ~13.6k checks, `rc=0`
- [x] `tests/test_callmain` under ASan+UBSan: 242 checks, no findings
- [x] `make call-compile` green against the real vendored header
- [x] both drift links proven to fail
- [x] 6/6 mutations red, restored, `git diff` clean
- [ ] CI on Linux