### PR TITLE
irc(#878): one letter-class verdict for the channel MODE token

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -29885,3 +29885,78 @@ that VoiceOver reads any of it. jsdom has no layout and nwsapi does not match
 is argued, not measured, and everything here is a source-level invariant plus
 role/accessible-name queries — which is the layer an AT consumes, but not the
 layer a human with a screen reader experiences.
+
+## 2026-08-05 — #878: the channel mode token, and the second reader that made it different
+
+#279 closed the mode-letter class on the umode half. The channel half was
+measured at the same time and deliberately left standing: `MODE #chan "+n!$ "`
+emitted `{:channel_modes_changed, "#chan", %{modes: [" ", "$", "!", "n"]}}`,
+and `324 RPL_CHANNELMODEIS` did the same for a snapshot. This is that half.
+
+**The rule was not re-argued.** Same class (RFC-2812 signs + ALPHA, via
+`Identifier.valid_mode_letter?/1`), same refusal to promote the per-network
+letter set to a validator, same whole-token reject. Re-deriving it would have
+risked deriving it differently.
+
+**Where the channel domain is NOT symmetric: the number of readers.** A umode
+token has one walker. A channel MODE token has two — `walk_modes/5` folds the
+per-user modes into the member roster, `walk_channel_modes/5` folds the
+channel-level ones into the mode entry — over the SAME bytes. Validating
+inside each walker would have produced two independent verdicts, and the
+measurement shows what that costs: with only the entry walker gated, a
+rejected `+o!x alice` still handed `alice` the op sigil. So the verdict is
+taken ONCE, before either walk, and both are gated on it
+(`apply_channel_mode_token/4`). #279's "one token, two readers" lesson,
+arrived at from the other direction: there the second reader was a secret
+committer, here it is a roster.
+
+**Where it is NOT asymmetric, against first appearance: the parameters.** The
+obvious trap in this issue is that channel modes take arguments — `+k key`,
+`+l 42`, `+b mask`, `+o nick` — and that their arity comes from ISUPPORT
+`CHANMODES`. It does not follow that the class must consult CHANMODES. A
+parameter travels as its own wire param; it is never a byte inside the mode
+token. The letter class therefore neither sees nor validates any parameter,
+and CHANMODES keeps its single job — arg ARITY per letter, via
+`takes_param?/3`. The domains touch the same letters and answer different
+questions.
+
+**And where the umode precedent must NOT be extended: 005 CHANMODES itself.**
+It is tempting to treat `CHANMODES=beI,k,l,imnpst` as the channel twin of the
+004 usermodes token that #279 did tighten — it is upstream bytes, split into
+characters, and it does reach the wire (`isupport_changed`'s `chanmodes_a..d`).
+The asymmetry is in the consequence of a reject. The 004 token is published
+and nothing else; rejecting it costs a greyed-out modal. CHANMODES is ALSO the
+arg-arity classifier every subsequent MODE line is parsed with, so rejecting
+the whole token silently falls back to the bahamut defaults and misaligns the
+args of REAL modes on a network that is merely eccentric. A token that is a
+published assertion should be rejected atomically; a token that is a lookup
+table is better partially right than replaced by another network's. Left
+unchanged on purpose.
+
+**What the reject withholds.** Derived state only. The `:persist` row still
+carries the verbatim `%{modes: "+n!$ ", args: []}` echo — the operator sees
+what upstream actually sent; only the state the client would act on is
+withheld. The 324 arm keeps the last authoritative entry and emits nothing,
+and `""` is a rejection there too: it asserts nothing, so a truncated line
+must not read as "the channel lost every mode". A bare `+` remains a valid
+empty snapshot.
+
+**Measured, not assumed, and one of the two claims came back wrong.** The
+first draft of the property comments said the channel arm was seed-dependent
+the way the umode one had been. Removing the letter check from the producer
+reddens the shape property on 20/20 seeds, 3–34 examples in — `:mode` is one
+generated command in twelve and every target that is not the session's own
+nick lands in the channel branch, so the pre-existing `is_list/1` arm was
+certifying garbage continuously. What IS seed-starved is 324 (one numeric draw
+in 999), which the dedicated snapshot property covers. And the empty-token
+clause is pinned by unit tests alone: flipped back to accepting `""`, the
+whole property file stays green on 5/5 seeds while exactly two unit tests
+redden, because an empty token parses to an empty letter set and satisfies the
+class trivially.
+
+**Collateral, measured, out of scope.** The generator reaches the channel
+branch with `MODE "" " "` — the clause routes ANY target that is not the
+session's own nick down the channel path, including an empty string and
+another user's nick, caching modes under that key. With the class gate in
+place the effect is well-formed, so this is a window-keying question, not a
+mode-parsing one, and it predates both halves of this class.

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -710,27 +710,20 @@ defmodule Grappa.Session.EventRouter do
       {:cont, state, [self_server_persist | r_effects] ++ umode_effects ++ identity_effects}
     else
       sender = Message.sender_nick(msg)
-      isupport = Map.get(state, :isupport, ISupport.default())
-      members = apply_mode_string(state.members, target, modes, args, isupport)
 
       # S2.3: split the mode string — per-user modes (matching the ISUPPORT
-      # PREFIX table) update state.members (above); channel-level
-      # modes update channel_modes cache. Walk once, produce two effects:
-      # members delta (done above) + channel_modes delta (done here). One
-      # channel_modes_changed broadcast per MODE event if the cache changed.
-      chan_key = normalize_channel(target, casemapping(state))
-      existing_entry = Map.get(Map.get(state, :channel_modes, %{}), chan_key, empty_mode_entry())
-      new_entry = apply_channel_mode_string(existing_entry, modes, args, isupport)
-
-      channel_modes =
-        Map.put(Map.get(state, :channel_modes, %{}), chan_key, new_entry)
-
-      mode_effects =
-        if new_entry != existing_entry do
-          [{:channel_modes_changed, target, new_entry}]
-        else
-          []
-        end
+      # PREFIX table) update state.members; channel-level modes update the
+      # channel_modes cache. Walk once, produce two effects: members delta +
+      # channel_modes delta. One channel_modes_changed broadcast per MODE
+      # event if the cache changed.
+      #
+      # #878 — both walks read the SAME upstream bytes, so they share ONE
+      # validity verdict (`apply_channel_mode_token/4`): a token that is not
+      # signs + mode letters is a malformed LINE, and neither reader may draw
+      # a conclusion from it. The raw `:persist` row below is emitted either
+      # way — the reject withholds derived STATE, never the transcript.
+      {members, channel_modes, mode_effects} =
+        apply_channel_mode_token(state, target, modes, args)
 
       {state, eff} =
         build_persist(
@@ -1047,16 +1040,27 @@ defmodule Grappa.Session.EventRouter do
   # 324 RPL_CHANNELMODEIS: initial mode snapshot after JOIN. Replaces the
   # channel_modes entry entirely with the parsed +modes [params] shape.
   # Mode string starts with '+'; args follow as separate params.
+  #
+  # #878 — a malformed mode param (anything but signs + mode letters) is NOT
+  # a snapshot: keep the last authoritative entry and emit nothing, rather
+  # than REPLACING it with parsed garbage. `""` is rejected for the same
+  # reason 221 rejects it — it asserts nothing, and a truncated line must not
+  # read as "the channel lost every mode". A bare `"+"` IS a valid empty
+  # snapshot (a modeless channel).
   defp do_route(
          %Message{command: {:numeric, 324}, params: [_, channel, mode_str | mode_args]},
          state
        )
        when is_binary(channel) and is_binary(mode_str) do
-    chan_key = normalize_channel(channel, casemapping(state))
-    isupport = Map.get(state, :isupport, ISupport.default())
-    entry = parse_mode_snapshot(mode_str, mode_args, isupport)
-    channel_modes = Map.put(Map.get(state, :channel_modes, %{}), chan_key, entry)
-    {:cont, %{state | channel_modes: channel_modes}, [{:channel_modes_changed, channel, entry}]}
+    if valid_mode_token?(mode_str) do
+      chan_key = normalize_channel(channel, casemapping(state))
+      isupport = Map.get(state, :isupport, ISupport.default())
+      entry = parse_mode_snapshot(mode_str, mode_args, isupport)
+      channel_modes = Map.put(Map.get(state, :channel_modes, %{}), chan_key, entry)
+      {:cont, %{state | channel_modes: channel_modes}, [{:channel_modes_changed, channel, entry}]}
+    else
+      {:cont, state, []}
+    end
   end
 
   # 221 RPL_UMODEIS (#229): the reply to a bare `MODE <selfnick>` query —
@@ -3216,6 +3220,62 @@ defmodule Grappa.Session.EventRouter do
           channel_mode_entry()
   defp apply_channel_mode_string(entry, mode_string, args, isupport) do
     walk_channel_modes(entry, mode_string, args, :add, isupport)
+  end
+
+  # #878 — the channel half of the #279 mode-letter class. A channel MODE
+  # token has TWO readers of the same bytes (`walk_modes/5` for the roster,
+  # `walk_channel_modes/5` for the entry), so unlike the umode walker the
+  # verdict is taken ONCE, up front, and both walks are gated on it: two
+  # walkers reaching two verdicts is how a rejected token still grants an op
+  # sigil. Reject the WHOLE token, never per-byte — a mode string is one
+  # atomic statement about the channel, and a half-parse publishes a set the
+  # server never declared.
+  #
+  # The CLASS is the RFC-2812 §3.2.3 grammar (signs + ALPHA), NOT the
+  # per-network ISUPPORT `CHANMODES`/`PREFIX` letter set: a server that
+  # under-announces would silently drop a real mode, exactly the argument
+  # #279 made for umodes. CHANMODES stays what it already is — the arg-ARITY
+  # classifier the walkers consult per letter (`ISupport.takes_param?/3`).
+  # A channel mode's PARAMETER (`+k key`, `+l 42`, `+b mask`) is a separate
+  # wire param, never a byte inside this token, so the letter class says
+  # nothing about it and validates none of it.
+  @spec valid_mode_token?(String.t()) :: boolean()
+  defp valid_mode_token?(""), do: false
+  defp valid_mode_token?(token) when is_binary(token), do: mode_token_letters?(token)
+
+  defp mode_token_letters?(""), do: true
+  defp mode_token_letters?("+" <> rest), do: mode_token_letters?(rest)
+  defp mode_token_letters?("-" <> rest), do: mode_token_letters?(rest)
+
+  defp mode_token_letters?(<<letter::binary-size(1), rest::binary>>),
+    do: Identifier.valid_mode_letter?(letter) and mode_token_letters?(rest)
+
+  # The gated channel-MODE application: on a valid token both readers run and
+  # the cache delta is emitted; on a rejected one the roster, the cache and
+  # the effect list are all left exactly as they were.
+  @spec apply_channel_mode_token(state(), String.t(), String.t(), [String.t()]) ::
+          {members(), %{String.t() => channel_mode_entry()}, [effect()]}
+  defp apply_channel_mode_token(state, target, modes, args) do
+    channel_modes = Map.get(state, :channel_modes, %{})
+
+    if valid_mode_token?(modes) do
+      isupport = Map.get(state, :isupport, ISupport.default())
+      members = apply_mode_string(state.members, target, modes, args, isupport)
+      chan_key = normalize_channel(target, casemapping(state))
+      existing_entry = Map.get(channel_modes, chan_key, empty_mode_entry())
+      new_entry = apply_channel_mode_string(existing_entry, modes, args, isupport)
+
+      effects =
+        if new_entry != existing_entry do
+          [{:channel_modes_changed, target, new_entry}]
+        else
+          []
+        end
+
+      {members, Map.put(channel_modes, chan_key, new_entry), effects}
+    else
+      {state.members, channel_modes, []}
+    end
   end
 
   # walk_channel_modes: same sticky-sign recursive pattern as walk_modes/5,

--- a/test/grappa/session/event_router_property_test.exs
+++ b/test/grappa/session/event_router_property_test.exs
@@ -434,7 +434,7 @@ defmodule Grappa.Session.EventRouterPropertyTest do
 
       assert {:cont, new_state, effects} = EventRouter.route(m, state)
 
-      for {_chan, entry} <- new_state.channel_modes do
+      for {_, entry} <- new_state.channel_modes do
         assert mode_letters?(entry), "malformed cached entry from token #{inspect(mode_str)}"
       end
 
@@ -458,7 +458,7 @@ defmodule Grappa.Session.EventRouterPropertyTest do
 
       assert {:cont, new_state, effects} = EventRouter.route(m, min_state())
 
-      for {_chan, entry} <- new_state.channel_modes do
+      for {_, entry} <- new_state.channel_modes do
         assert mode_letters?(entry), "malformed cached snapshot from token #{inspect(mode_str)}"
       end
 

--- a/test/grappa/session/event_router_property_test.exs
+++ b/test/grappa/session/event_router_property_test.exs
@@ -120,6 +120,13 @@ defmodule Grappa.Session.EventRouterPropertyTest do
         # LETTERS, keyed by the same letters, so the arm asserts the class —
         # the same production predicate the handlers validate with, so a
         # future ircd letter can never be green here and red there.
+        #
+        # This arm is NOT seed-dependent, measured: with the letter check
+        # removed from the producer it reddens on 20/20 seeds, 3–34 examples
+        # in. `:mode` is one command in twelve and EVERY target that is not
+        # the session's own nick routes to the channel branch, so the
+        # generator reached this effect on every run — meaning the old
+        # `is_list/1` was certifying garbage continuously, not occasionally.
         {:channel_modes_changed, channel, entry} ->
           assert is_binary(channel)
           assert is_map(entry)
@@ -395,13 +402,17 @@ defmodule Grappa.Session.EventRouterPropertyTest do
     end
   end
 
-  # #878 — the shape property above reaches a channel MODE / a 324 only when
-  # the seed draws one (one numeric in 999; a `:mode` whose first generated
-  # param happens to be channel-shaped), which is WHY the malformed
-  # `{:channel_modes_changed, "#chan", %{modes: [" ", "$", "!", "n"]}}` sat on
-  # main behind an `is_list/1` that could never see it. These two hit the
-  # channel-mode boundary on EVERY generated example, so the class is pinned
-  # by the test set rather than by the seed.
+  # #878 — what the shape property above does NOT reach on its own is the
+  # SNAPSHOT: numeric 324 is one draw in 999, so the arm covers the delta
+  # path continuously and the 324 path essentially never. These two hit both
+  # boundaries on EVERY generated example, so neither is pinned by the seed.
+  #
+  # Neither pins the EMPTY token, and the mutation says so out loud: with
+  # `valid_mode_token?("")` flipped back to `true` the whole property file is
+  # green on 5/5 seeds while two unit tests redden. An empty token parses to
+  # an empty letter set, which satisfies the class trivially — the wipe it
+  # causes is a STATE claim, not a shape claim, so it belongs to the unit
+  # tests by construction.
   defp mode_letters?(entry) do
     Enum.all?(entry.modes, &Identifier.valid_mode_letter?/1) and
       Enum.all?(Map.keys(entry.params), &Identifier.valid_mode_letter?/1)

--- a/test/grappa/session/event_router_property_test.exs
+++ b/test/grappa/session/event_router_property_test.exs
@@ -114,11 +114,19 @@ defmodule Grappa.Session.EventRouterPropertyTest do
           assert Map.has_key?(entry, :set_by)
           assert Map.has_key?(entry, :set_at)
 
+        # #878 — `is_list/1` + `is_map/1` here certified only the CONTAINER:
+        # the measured pre-fix effect `%{modes: [" ", "$", "!", "n"]}` from a
+        # fuzzed `MODE #chan "+n!$ "` satisfied both. The entry carries mode
+        # LETTERS, keyed by the same letters, so the arm asserts the class —
+        # the same production predicate the handlers validate with, so a
+        # future ircd letter can never be green here and red there.
         {:channel_modes_changed, channel, entry} ->
           assert is_binary(channel)
           assert is_map(entry)
           assert is_list(entry.modes)
           assert is_map(entry.params)
+          assert Enum.all?(entry.modes, &Identifier.valid_mode_letter?/1)
+          assert Enum.all?(Map.keys(entry.params), &Identifier.valid_mode_letter?/1)
 
         {:away_confirmed, status} ->
           # Numerics 305 / 306 (RPL_UNAWAY / RPL_NOWAWAY) emit
@@ -384,6 +392,68 @@ defmodule Grappa.Session.EventRouterPropertyTest do
 
       assert attrs.channel == String.downcase(channel),
              "bare +channel #{channel} must not be stripped to #{body}, got #{attrs.channel}"
+    end
+  end
+
+  # #878 — the shape property above reaches a channel MODE / a 324 only when
+  # the seed draws one (one numeric in 999; a `:mode` whose first generated
+  # param happens to be channel-shaped), which is WHY the malformed
+  # `{:channel_modes_changed, "#chan", %{modes: [" ", "$", "!", "n"]}}` sat on
+  # main behind an `is_list/1` that could never see it. These two hit the
+  # channel-mode boundary on EVERY generated example, so the class is pinned
+  # by the test set rather than by the seed.
+  defp mode_letters?(entry) do
+    Enum.all?(entry.modes, &Identifier.valid_mode_letter?/1) and
+      Enum.all?(Map.keys(entry.params), &Identifier.valid_mode_letter?/1)
+  end
+
+  property "#878: no channel MODE token yields a non-letter channel mode" do
+    check all(
+            mode_str <- string(:ascii, min_length: 0, max_length: 32),
+            args <- list_of(string(:ascii, min_length: 0, max_length: 8), max_length: 3)
+          ) do
+      m = %Message{
+        command: :mode,
+        params: ["#chan" | [mode_str | args]],
+        prefix: {:nick, "op", "u", "h"},
+        tags: %{}
+      }
+
+      state = %{min_state() | members: %{"#chan" => %{"alice" => []}}}
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+
+      for {_chan, entry} <- new_state.channel_modes do
+        assert mode_letters?(entry), "malformed cached entry from token #{inspect(mode_str)}"
+      end
+
+      for {:channel_modes_changed, _, entry} <- effects do
+        assert mode_letters?(entry), "malformed effect from token #{inspect(mode_str)}"
+      end
+    end
+  end
+
+  property "#878: no 324 RPL_CHANNELMODEIS snapshot yields a non-letter channel mode" do
+    check all(
+            mode_str <- string(:ascii, min_length: 0, max_length: 32),
+            args <- list_of(string(:ascii, min_length: 0, max_length: 8), max_length: 3)
+          ) do
+      m = %Message{
+        command: {:numeric, 324},
+        params: ["self" | ["#chan" | [mode_str | args]]],
+        prefix: {:server, "irc.example.org"},
+        tags: %{}
+      }
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, min_state())
+
+      for {_chan, entry} <- new_state.channel_modes do
+        assert mode_letters?(entry), "malformed cached snapshot from token #{inspect(mode_str)}"
+      end
+
+      for {:channel_modes_changed, _, entry} <- effects do
+        assert mode_letters?(entry), "malformed snapshot effect from token #{inspect(mode_str)}"
+      end
     end
   end
 end

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -1952,6 +1952,74 @@ defmodule Grappa.Session.EventRouterTest do
       assert entry.params["k"] == "secret"
     end
 
+    # #878 — the CHANNEL half of the #279 mode-letter class. A channel MODE
+    # token is upstream-supplied bytes; the two readers of those same bytes
+    # (the member roster walk and the channel_modes walk) must share ONE
+    # verdict, and a token that is not signs + mode letters is a malformed
+    # LINE, not a partially usable delta.
+    test "#878 MODE with a non-letter mode token emits no :channel_modes_changed" do
+      state = base_state(%{members: %{"#chan" => %{"alice" => []}}})
+
+      # The measured shape on the pre-fix tree: `+n!$ ` folded into
+      # `%{modes: [" ", "$", "!", "n"]}` — punctuation and a SPACE published
+      # as channel modes the server never set.
+      m = msg(:mode, ["#chan", "+n!$ "], {:nick, "op", "u", "h"})
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+
+      refute Enum.any?(effects, &match?({:channel_modes_changed, _, _}, &1))
+      assert Map.get(new_state.channel_modes, "#chan") == nil
+    end
+
+    test "#878 a rejected channel MODE token still persists the raw echo row" do
+      # The row is the honest verbatim echo of what upstream sent — the
+      # reject withholds the derived STATE, never the transcript.
+      state = base_state(%{members: %{"#chan" => %{"alice" => []}}})
+      m = msg(:mode, ["#chan", "+n!$ "], {:nick, "op", "u", "h"})
+
+      assert {:cont, _, effects} = EventRouter.route(m, state)
+      assert {:persist, :mode, attrs} = Enum.find(effects, &match?({:persist, :mode, _}, &1))
+      assert attrs.meta == %{modes: "+n!$ ", args: []}
+    end
+
+    test "#878 one verdict, two readers: a rejected token leaves the member roster alone" do
+      # `walk_modes/5` (roster) and `walk_channel_modes/5` (channel entry)
+      # read the SAME bytes. Pre-fix the roster reader granted `alice` the
+      # op sigil off a token the channel reader would also have mangled.
+      state = base_state(%{members: %{"#chan" => %{"alice" => []}}})
+      m = msg(:mode, ["#chan", "+o!x", "alice"], {:nick, "op", "u", "h"})
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+
+      assert new_state.members["#chan"]["alice"] == []
+      refute Enum.any?(effects, &match?({:channel_modes_changed, _, _}, &1))
+    end
+
+    test "#878 an empty mode token asserts nothing and is rejected" do
+      state = base_state(%{members: %{"#chan" => %{}}})
+      m = msg(:mode, ["#chan", ""], {:nick, "op", "u", "h"})
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+      refute Enum.any?(effects, &match?({:channel_modes_changed, _, _}, &1))
+      assert Map.get(new_state.channel_modes, "#chan") == nil
+    end
+
+    test "#878 a well-formed token is untouched by the class gate" do
+      # The gate must be invisible to every real ircd line: signs, mixed
+      # case, per-user modes with their nick args, param modes with theirs.
+      state = base_state(%{members: %{"#chan" => %{"alice" => []}}})
+      m = msg(:mode, ["#chan", "-l+koZ", "secret", "alice"], {:nick, "op", "u", "h"})
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+
+      entry = new_state.channel_modes["#chan"]
+      assert "k" in entry.modes
+      assert "Z" in entry.modes
+      assert entry.params["k"] == "secret"
+      assert new_state.members["#chan"]["alice"] == ["@"]
+      assert Enum.any?(effects, &match?({:channel_modes_changed, "#chan", _}, &1))
+    end
+
     test "MODE on user's own nick persists a $server confirmation row (#154b)" do
       # IRC user-MODE: `:vjt MODE vjt +i` — first param is the nick,
       # not a channel name. The user-MODE-on-self clause (matching
@@ -2165,6 +2233,53 @@ defmodule Grappa.Session.EventRouterTest do
 
       assert {:cont, _, effects} = EventRouter.route(m, state)
       assert {:visitor_r_observed, "regpass"} in effects
+    end
+  end
+
+  describe "route/2 — 324 RPL_CHANNELMODEIS (#878 mode-letter class)" do
+    test "a well-formed snapshot replaces the entry and emits the effect" do
+      state = base_state(%{})
+      m = msg({:numeric, 324}, ["vjt", "#chan", "+ntk", "secret"], {:server, "irc.test"})
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+      entry = new_state.channel_modes["#chan"]
+      assert Enum.sort(entry.modes) == ["k", "n", "t"]
+      assert entry.params["k"] == "secret"
+      assert {:channel_modes_changed, "#chan", ^entry} = Enum.find(effects, &match?({:channel_modes_changed, _, _}, &1))
+    end
+
+    test "a bare + is a valid EMPTY snapshot — a modeless channel" do
+      state = base_state(%{channel_modes: %{"#chan" => %{modes: ["n"], params: %{}}}})
+      m = msg({:numeric, 324}, ["vjt", "#chan", "+"], {:server, "irc.test"})
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+      assert new_state.channel_modes["#chan"] == %{modes: [], params: %{}}
+      assert Enum.any?(effects, &match?({:channel_modes_changed, "#chan", _}, &1))
+    end
+
+    test "a non-letter snapshot keeps the last authoritative entry and emits nothing" do
+      # A snapshot REPLACES; letting a malformed one through would publish a
+      # mode set the server never declared AND destroy the good one.
+      prev = %{modes: ["n", "t"], params: %{}}
+      state = base_state(%{channel_modes: %{"#chan" => prev}})
+      m = msg({:numeric, 324}, ["vjt", "#chan", "+n!$ "], {:server, "irc.test"})
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+      assert new_state.channel_modes["#chan"] == prev
+      refute Enum.any?(effects, &match?({:channel_modes_changed, _, _}, &1))
+    end
+
+    test "an empty snapshot token cannot WIPE the entry" do
+      # `""` asserts nothing at all — distinct from `"+"`, which asserts an
+      # empty set. A truncated line must not read as "the channel lost every
+      # mode".
+      prev = %{modes: ["n", "t"], params: %{}}
+      state = base_state(%{channel_modes: %{"#chan" => prev}})
+      m = msg({:numeric, 324}, ["vjt", "#chan", ""], {:server, "irc.test"})
+
+      assert {:cont, new_state, effects} = EventRouter.route(m, state)
+      assert new_state.channel_modes["#chan"] == prev
+      refute Enum.any?(effects, &match?({:channel_modes_changed, _, _}, &1))
     end
   end
 


### PR DESCRIPTION
The channel half of the class #279 closed for umodes. The rule is #279's,
applied rather than re-argued; what this PR is actually about is the two
places where the channel domain is **not** symmetric.

## Measured, pre-fix

```
MODE #chan "+n!$ "  →  {:channel_modes_changed, "#chan", %{modes: [" ", "$", "!", "n"]}}
324 "#chan" "+n!$ " →  same entry, and it REPLACES the good snapshot
324 "#chan" ""      →  wipes the entry to %{modes: [], params: %{}}
MODE #chan "+o!x" alice → alice is granted "@" off a malformed token
```

## The asymmetry that mattered: two readers

A umode token has one walker. A channel MODE token has two over the same
bytes — `walk_modes/5` (member roster) and `walk_channel_modes/5` (mode
entry). Validating inside each would have produced two verdicts, and the
measurement shows the cost: with only the entry walker gated, a rejected
`+o!x alice` still hands `alice` the op sigil. The verdict is taken **once**,
before either walk, and both are gated on it (`apply_channel_mode_token/4`).

## The asymmetry that looked like one and isn't: parameters

Channel modes take arguments (`+k key`, `+l 42`, `+b mask`, `+o nick`) and
their arity comes from ISUPPORT `CHANMODES`. It does **not** follow that the
class must consult CHANMODES: a parameter travels as its own wire param and is
never a byte inside the mode token, so the letter class neither sees nor
validates it. CHANMODES keeps its single job — arg arity per letter, via
`takes_param?/3`.

## What I refuse to extend the rule to: 005 CHANMODES

`parse_chanmodes/1` splits an upstream channel-mode token into characters with
no validation, and it does reach the wire (`isupport_changed`'s
`chanmodes_a..d`) — so on shape it looks like the channel twin of the 004
usermodes token #279 tightened. It is not, because the consequence of a reject
differs: the 004 token is published and nothing else, while CHANMODES is also
the arg-arity classifier every later MODE line is parsed with. A whole-token
reject there falls back to the bahamut defaults and silently misaligns the
args of **real** modes on a merely eccentric network. A published assertion
should be rejected atomically; a lookup table is better partially right than
replaced by another network's. Left unchanged on purpose.

## Mutation proof

- Letter check removed from the producer → the two dedicated properties red
  (seed 0), and the pre-existing shape property red on **20/20 seeds**, 3–34
  examples in. That corrected my own first claim: the arm was not
  seed-dependent, so the old `is_list/1` was certifying garbage continuously,
  not occasionally. 3 of the 5 new unit tests red.
- `valid_mode_token?("")` flipped back to `true` → the whole property file
  **green on 5/5 seeds** while exactly the 2 empty-token unit tests redden. An
  empty token parses to an empty letter set, so it satisfies the class
  trivially; the wipe is a state claim, not a shape claim.

## Not claimed

- No production symptom: no ircd sends these lines. This is boundary
  robustness plus a property surface, as the issue says.
- No downstream consumer wanted the raw bytes — cic's only reader renders
  ``+${modes.join("")}`` (`channelTopic.ts`), and `narrowModesEntry` already
  drops non-strings.
- The `:persist` echo row is unchanged on a reject: the gate withholds derived
  state, never the transcript.
- Collateral, measured, untouched: the MODE clause routes **any** target that
  is not the session's own nick down the channel path — the generator reaches
  it with `MODE "" " "`, caching modes under the `""` key. Window keying, not
  mode parsing, and it predates both halves of this class.

## Merge note

`Identifier.valid_mode_letter?/1` does not exist on `main` yet — it arrives
with PR #877 (#279). This branch adds it **byte-identical, at the same
insertion point**, so the two merge as one edit rather than a conflict.
`docs/DESIGN_NOTES.md` appends at EOF in both, which is the ordinary
chronological-append resolution.

## Gate

`scripts/check.sh` exit 0 on the final tree — 8 doctests, 52 properties,
5158 tests, 0 failures; credo strict, dialyzer, sobelow, audits, bats all
green; working tree clean before and after.