### PR TITLE
cic(#402): give a non-joined mobile window exactly one surface

### DIFF
--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -481,6 +481,29 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// GET /networks/:slug/archive — the server-side archive list (mirrors
+// `cicchetto/src/lib/api.ts`'s `listArchive`). Returns the archived
+// TARGET names only; callers assert membership.
+//
+// #402 uses it as the PRECONDITION of a client-side disappearance: cic
+// filters this list through `visibleArchiveForNetwork`, so "the row is
+// nowhere in the UI" only indicts the client once the server is on
+// record as offering it. Without this probe a spec asserting absence
+// stays green when the row stops being archive-eligible at all — passing
+// for the wrong reason.
+export async function listArchiveTargets(
+  token: string,
+  networkSlug: string,
+): Promise<string[]> {
+  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(networkSlug)}/archive`;
+  const res = await fetch(url, { headers: { authorization: `Bearer ${token}` } });
+  if (!res.ok) {
+    throw new Error(`listArchiveTargets: unexpected status ${res.status}`);
+  }
+  const body = (await res.json()) as { archive: Array<{ target: string }> };
+  return body.archive.map((entry) => entry.target);
+}
+
 // PART a channel via REST DELETE (mirrors `cicchetto/src/lib/api.ts`'s
 // `postPart`, but framed for the runner's GRAPPA_BASE_URL). Used by
 // test cleanup hooks to undo `/join`'s autojoin-persistence side-effect

--- a/cicchetto/e2e/tests/issue402-mobile-window-surfaces.spec.ts
+++ b/cicchetto/e2e/tests/issue402-mobile-window-surfaces.spec.ts
@@ -1,0 +1,128 @@
+// @webkit — #402. A non-joined window with scrollback must be reachable
+// from EXACTLY ONE mobile surface. Today it is reachable from none.
+//
+// UX-5 bucket BK states the rule as "one window, one surface": the
+// archive filter (`lib/archive.ts` → `visibleArchiveForNetwork`)
+// subtracts EVERY row of the shared pseudo-row projection
+// (`lib/pseudoChannels.ts`), on the premise that the nav renders it.
+// That premise holds on desktop, where the Sidebar renders every
+// non-joined state. On mobile it does not:
+//
+//   * `Shell.tsx` renders the mobile layout as a full JSX branch with NO
+//     `.shell-sidebar` at all — the desktop pseudo-rows have no host;
+//   * `BottomBar.tsx` narrows the same projection to `:invited`
+//     (#71 INC-3, vjt ruling — the bar is space-scarce and the other
+//     states are "history best confined to the sidebar").
+//
+// The sidebar that ruling defers to does not exist on this form factor,
+// and the archive filter subtracts the states anyway. So a `:pending` /
+// `:failed` / `:kicked` / `:parked` window is subtracted by a surface
+// that does not draw it: one window, ZERO surfaces. That is the reported
+// defect — a channel that was in Archive vanishes from it the moment
+// `/cs invite` puts the window back into a non-joined state, and comes
+// back only on reload (which drops the client's window-state map).
+//
+// This spec drives the `:failed` arm because it is the one an e2e can
+// materialize deterministically (`+i` → 473), and it is on the reported
+// path: the ChanServ invite auto-JOINs (`{:rejoin_invited, _}` →
+// `record_in_flight_join/2` → `:pending`) and lands `:failed` when the
+// invite does not actually let the operator in. Both states are hidden
+// by the same subtraction; the jsdom sibling
+// (`src/__tests__/mobileWindowSurfaces.test.tsx`) covers all four.
+//
+// The assertion is the USER OUTCOME — the channel is reachable from
+// exactly one surface — NOT a particular mechanism, so it holds for
+// either resolution of the open design fork (bar renders the state, or
+// the archive stops subtracting what the bar does not render).
+//
+// Companion contract, already green: `issue71-inc3-bottombar-invite.spec.ts`
+// asserts the bar's narrowing on this same viewport (invited IN, failed
+// OUT). That spec pins one surface; this one pins the union.
+//
+// BottomBar is mobile-only (Shell renders it only in the isMobile()
+// branch), so this runs on the webkit-iphone-15 project alone — the
+// @webkit tag; the chromium project grepInverts it.
+
+import { expect, test } from "../fixtures/test";
+import {
+  closeArchive,
+  composeSend,
+  expandArchiveGroup,
+  loginAs,
+  openArchive,
+  selectChannel,
+  sidebarWindow,
+} from "../fixtures/cicchettoPage";
+import { listArchiveTargets, partChannel } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+// Per-run-unique: bahamut holds channel state for a window after
+// disconnect, so a literal collides on rapid reruns (--repeat-each).
+const GATED_CHANNEL = `#i402-gated-${crypto.randomUUID().slice(0, 8)}`;
+
+let peer: IrcPeer | null = null;
+
+test.afterEach(async () => {
+  if (peer) {
+    await peer.disconnect("i402 cleanup").catch(() => {});
+    peer = null;
+  }
+  const vjt = getSeededVjt();
+  await partChannel(vjt.token, NETWORK_SLUG, GATED_CHANNEL).catch(() => {});
+});
+
+test("@webkit #402 — a failed-JOIN window with scrollback stays reachable from exactly one mobile surface", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
+
+  peer = await IrcPeer.connect({ nick: `i402peer-${crypto.randomUUID().slice(0, 6)}` });
+
+  // The peer founds a `+i` channel; the operator's /join is rejected with
+  // 473 → the window flips `:failed` and the failure notice persists as
+  // scrollback, which is what makes the channel archive-eligible.
+  await peer.join(GATED_CHANNEL);
+  await peer.mode(GATED_CHANNEL, "+i");
+  await composeSend(page, `/join ${GATED_CHANNEL}`);
+  // `.compose-box-greyed` is the "state machine actually reached :failed"
+  // sentinel (same one #71 INC-3 uses): without it a later absence assert
+  // could be racing a state that never materialized.
+  await expect(page.locator(".compose-box")).toHaveClass(/compose-box-greyed/, { timeout: 10_000 });
+
+  // PRECONDITION — the server offers the row. Everything below is about
+  // what cic does with it; if this were absent, a zero-surface union
+  // would indict the server (or the failure-row persistence), not the
+  // client-side filter, and the test would pass for the wrong reason.
+  await expect
+    .poll(() => listArchiveTargets(vjt.token, NETWORK_SLUG), { timeout: 10_000 })
+    .toContain(GATED_CHANNEL);
+
+  // Focus back on a JOINED window before reaching for the rail. On mobile
+  // a not-joined channel window has NO door to the rail drawer at all —
+  // the TopicBar hamburger is `<Show when={windowIsJoined}>`-gated
+  // (TopicBar.tsx) and the ShellChrome rail opener renders only for
+  // `kind !== "channel"` (Shell.tsx) — so archive/settings/rooms are
+  // unreachable while the failed channel holds focus. That is an adjacent
+  // gap, not this defect; navigating away is also what the operator does.
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
+
+  // The two mobile surfaces. The BottomBar stays in the DOM behind the
+  // archive modal's backdrop, so both are countable at once — no tapping
+  // through the scrim, only counting.
+  await openArchive(page);
+  const group = await expandArchiveGroup(page, NETWORK_SLUG);
+  const archiveRow = group.locator(".archive-modal-row", { hasText: GATED_CHANNEL });
+  const barTab = sidebarWindow(page, NETWORK_SLUG, GATED_CHANNEL);
+
+  await expect
+    .poll(async () => (await barTab.count()) + (await archiveRow.count()), {
+      timeout: 15_000,
+      message: `#402: ${GATED_CHANNEL} must be reachable from exactly one mobile surface (bottom bar OR archive)`,
+    })
+    .toBe(1);
+
+  await closeArchive(page);
+});

--- a/cicchetto/src/BottomBar.tsx
+++ b/cicchetto/src/BottomBar.tsx
@@ -3,7 +3,7 @@ import CloseButton from "./CloseButton";
 import { channelKey } from "./lib/channelKey";
 import { mentionCounts } from "./lib/mentions";
 import { channelsBySlug, networks } from "./lib/networks";
-import { pseudoChannelsForNetwork } from "./lib/pseudoChannels";
+import { navPseudoChannelsForNetwork } from "./lib/pseudoChannels";
 import { queryWindowsByNetwork } from "./lib/queryWindows";
 import { requestScrollToBottom } from "./lib/scrollToBottomCommand";
 import {
@@ -230,23 +230,22 @@ const BottomBar: Component<Props> = (props) => {
 
               {/* #71 INC-3 — the /invite-opened `:invited` virtual channel.
                   The mobile BottomBar surfaces ONLY the `:invited` slice of
-                  the shared pseudo-row projection (lib/pseudoChannels.ts).
-                  The desktop Sidebar renders EVERY non-joined state
-                  (pending/failed/kicked/parked) as a greyed row; the bottom
-                  bar is space-scarce, so failed/kicked/parked history stays
-                  confined to the sidebar — an INTENTIONAL narrowing, not a
-                  second projection (DESIGN_NOTES 2026-07-26 #71 INC-3). The
+                  the shared pseudo-row projection; the desktop Sidebar
+                  renders EVERY non-joined state (pending/failed/kicked/
+                  parked) as a greyed row, because the bottom bar is
+                  space-scarce (DESIGN_NOTES 2026-07-26 #71 INC-3). #402 moved
+                  that narrowing OUT of this call site and into
+                  `navPseudoChannelsForNetwork` (lib/pseudoChannels.ts), where
+                  the archive filter reads it too: an open-coded filter here
+                  is what let the archive subtract rows this bar never drew,
+                  leaving a non-joined window with zero mobile surfaces. The
                   tab is greyed + tappable (opens the invite notice + JOIN
                   button in scrollback, kind "channel"); the × routes through
                   the shared `dismissPseudoWindow` verb (windowClose.ts) — the
                   SAME verb the desktop Sidebar's pseudo-row × uses, so a
                   dismiss lands focus identically on both surfaces ($server;
                   see DESIGN_NOTES 2026-07-26). */}
-              <For
-                each={pseudoChannelsForNetwork(network.slug, network.id).filter(
-                  (row) => row.state === "invited",
-                )}
-              >
+              <For each={navPseudoChannelsForNetwork(network.slug, network.id)}>
                 {(row) => (
                   <>
                     <button

--- a/cicchetto/src/Sidebar.tsx
+++ b/cicchetto/src/Sidebar.tsx
@@ -6,7 +6,7 @@ import { channelKey } from "./lib/channelKey";
 import { mentionCounts } from "./lib/mentions";
 import { mentionsBundleBySlug } from "./lib/mentionsWindow";
 import { channelsBySlug, isAdmin, networkBySlug, networks, user } from "./lib/networks";
-import { pseudoChannelsForNetwork } from "./lib/pseudoChannels";
+import { navPseudoChannelsForNetwork } from "./lib/pseudoChannels";
 import { queryWindowsByNetwork } from "./lib/queryWindows";
 import { reconnectingByNetwork } from "./lib/reconnectingStatus";
 import { requestScrollToBottom } from "./lib/scrollToBottomCommand";
@@ -512,8 +512,14 @@ const Sidebar: Component<Props> = () => {
                   comment. PHASE 1.1's joined-arm produced ghost rows on
                   PART (no cross-topic ordering between channels_changed
                   and per-channel PART broadcasts). Reverted; cp15-b5
-                  gates on per-channel join-line wire-truth instead. */}
-                <For each={pseudoChannelsForNetwork(network.slug, network.id)}>
+                  gates on per-channel join-line wire-truth instead.
+
+                  #402 — via `navPseudoChannelsForNetwork`, the form-factor
+                  view of that projection, which is also what the archive
+                  filter subtracts. Shell mounts this Sidebar in the desktop
+                  branch only, so here it yields every non-joined state, as
+                  before. */}
+                <For each={navPseudoChannelsForNetwork(network.slug, network.id)}>
                   {(row) => (
                     <li
                       classList={{ selected: isSelected(network.slug, row.name) }}

--- a/cicchetto/src/__tests__/BottomBar.test.tsx
+++ b/cicchetto/src/__tests__/BottomBar.test.tsx
@@ -14,8 +14,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // rationale; mobile mirrors the desktop wiring exactly).
 const isActiveSelectionMock = vi.hoisted(() => vi.fn<(next: unknown) => boolean>());
 
-// #71 INC-3 — controllable shared pseudo-row projection. Default [] so the
-// existing tests see no invited tabs; the invited tests override per network.
+// #71 INC-3 — controllable shared pseudo-row projection, in its #402
+// form-factor shape (`navPseudoChannelsForNetwork`): the narrowing to
+// `:invited` is the projection's job now, not this component's.
+// Default [] so the existing tests see no invited tabs; the invited tests
+// override per network.
 const pseudoRowsMock = vi.hoisted(() =>
   vi.fn<(slug: string, id: number) => Array<{ name: string; state: string }>>(),
 );
@@ -80,7 +83,7 @@ vi.mock("../lib/windowClose", () => ({
 
 // #71 INC-3 — the shared pseudo-row projection.
 vi.mock("../lib/pseudoChannels", () => ({
-  pseudoChannelsForNetwork: (slug: string, id: number) => pseudoRowsMock(slug, id),
+  navPseudoChannelsForNetwork: (slug: string, id: number) => pseudoRowsMock(slug, id),
 }));
 
 vi.mock("../lib/archive", () => ({
@@ -760,9 +763,16 @@ describe("BottomBar", () => {
   // `:invited` slice of the shared pseudo-row projection — an INTENTIONAL
   // narrowing vs the desktop Sidebar (which shows every non-joined state),
   // because the bottom bar is space-scarce and failed/kicked/parked are
-  // history best confined to the sidebar. The e2e asserts BOTH sides
-  // (invited appears; failed does not); these unit tests lock the filter +
-  // the tab affordances.
+  // history best confined to the sidebar.
+  //
+  // #402 moved that narrowing INTO the projection
+  // (`navPseudoChannelsForNetwork`, unit-tested in
+  // `lib/__tests__/pseudoChannels.test.ts`) because the archive filter has
+  // to subtract the same set; a filter open-coded here was invisible to it.
+  // So these tests lock the tab affordances and the fact that this bar
+  // applies NO policy of its own. The e2e still asserts both ends on a real
+  // mobile viewport (`issue71-inc3-bottombar-invite.spec.ts`: invited
+  // appears, failed does not).
   describe("#71 INC-3 — :invited virtual channel", () => {
     it("renders an :invited pseudo-channel as a tab carrying data-window-state='invited'", () => {
       pseudoRowsMock.mockImplementation((slug) =>
@@ -775,20 +785,24 @@ describe("BottomBar", () => {
       expect(tab?.textContent).toContain("#invited");
     });
 
-    it("renders ONLY :invited — a :failed or :kicked pseudo-channel does NOT appear (narrowing)", () => {
+    // #402 — the bar draws every row the nav projection hands it and applies
+    // no state filter of its own. A second filter here is precisely what
+    // desynced the bar from the archive: the archive subtracted rows the bar
+    // had silently dropped, and the window ended up on no surface at all.
+    // The narrowing itself is asserted where it now lives, on
+    // `navPseudoChannelsForNetwork`.
+    it("applies no narrowing of its own — it draws every row the nav projection yields", () => {
       pseudoRowsMock.mockImplementation((slug) =>
         slug === "freenode"
           ? [
               { name: "#invited", state: "invited" },
               { name: "#failed", state: "failed" },
-              { name: "#kicked", state: "kicked" },
             ]
           : [],
       );
       render(() => <BottomBar />);
       expect(screen.getByText("#invited")).toBeInTheDocument();
-      expect(screen.queryByText("#failed")).toBeNull();
-      expect(screen.queryByText("#kicked")).toBeNull();
+      expect(screen.getByText("#failed")).toBeInTheDocument();
     });
 
     it("tapping the invited tab selects it with kind 'channel'", () => {

--- a/cicchetto/src/__tests__/mobileWindowSurfaces.test.tsx
+++ b/cicchetto/src/__tests__/mobileWindowSurfaces.test.tsx
@@ -1,0 +1,154 @@
+import { render } from "@solidjs/testing-library";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { warmGraph } from "./helpers/warmGraph";
+
+// #402 — the mobile surface UNION for a non-joined window.
+//
+// UX-5 bucket BK states the rule as "one window, one surface": the archive
+// filter (`visibleArchiveForNetwork`) subtracts EVERY row the shared
+// pseudo-row projection yields, on the premise that the nav renders it.
+// That premise holds on desktop (Sidebar renders every non-joined state)
+// and NOT on mobile: the Sidebar is a whole absent JSX branch there
+// (`Shell.tsx` mobile layout) and `BottomBar` narrows the same projection
+// to `state === "invited"` (#71 INC-3, a deliberate space-scarcity
+// choice). So on mobile a `pending` / `failed` / `kicked` / `parked`
+// window is subtracted from the archive by a surface that does not render
+// it: one window, ZERO surfaces.
+//
+// These tests assert the USER OUTCOME on the mobile form factor — the
+// channel is reachable from exactly one of the two mobile surfaces — not
+// that any particular function was called.
+//
+// Boundary mocks: the reactive data sources only. The projection under
+// test (`lib/pseudoChannels`), the archive filter (`lib/archive`), the
+// channel-key codec and `BottomBar` itself are all REAL.
+
+// THE form factor under test. `isMobile()` is the signal Shell branches its
+// layout on and the one `navPseudoChannelsForNetwork` reads; jsdom has no
+// matchMedia, so without this the whole file would silently measure desktop.
+vi.mock("../lib/theme", () => ({
+  isMobile: () => true,
+  prefersDark: () => false,
+  applyTheme: vi.fn(),
+}));
+
+vi.mock("../lib/api", () => ({
+  listArchive: vi.fn(),
+  setOn401Handler: vi.fn(),
+  isContentKind: (k: string) => k === "privmsg" || k === "notice" || k === "action",
+  isPresenceKind: (k: string) => !(k === "privmsg" || k === "notice" || k === "action"),
+}));
+
+vi.mock("../lib/selection", () => ({
+  selectedChannel: () => null,
+  setSelectedChannel: vi.fn(),
+  isActiveSelection: () => false,
+  unreadCounts: () => ({}),
+  messagesUnread: () => ({}),
+  eventsUnread: () => ({}),
+  applySeedEnvelope: vi.fn(),
+}));
+
+vi.mock("../lib/mentions", () => ({
+  mentionCounts: () => ({}),
+  setServerMention: vi.fn(),
+}));
+
+vi.mock("../lib/scrollToBottomCommand", () => ({
+  requestScrollToBottom: vi.fn(),
+  scrollToBottomRequest: () => 0,
+}));
+
+vi.mock("../lib/windowClose", () => ({
+  closeQueryWindow: vi.fn(),
+  confirmLeaveChannel: vi.fn(),
+  confirmDisconnectNetwork: vi.fn(),
+  dismissPseudoWindow: vi.fn(),
+}));
+
+vi.mock("../lib/queryWindows", () => ({
+  queryWindowsByNetwork: () => ({}),
+}));
+
+beforeAll(() =>
+  warmGraph(
+    () => import("../lib/archive"),
+    () => import("../BottomBar"),
+  ),
+);
+
+beforeEach(() => {
+  vi.resetModules();
+  localStorage.clear();
+  vi.clearAllMocks();
+});
+
+// The scenario of the report, step by step:
+//   1. the session reconnects, the rejoin of a +i channel fails → the
+//      window carries scrollback and shows up in Archive;
+//   2. `/cs invite` lands, the server auto-JOINs and broadcasts
+//      `window_pending` on the user topic → cic stores `pending`;
+//   3. the archive filter releases nothing and the bottom bar renders
+//      nothing → the window is gone from the UI.
+async function mobileSurfacesFor(state: string): Promise<{
+  bottomBarTabs: string[];
+  archiveTargets: string[];
+}> {
+  vi.doMock("../lib/networks", () => ({
+    networks: () => [{ id: 1, slug: "azzurra", inserted_at: "", updated_at: "" }],
+    // No live channel: the JOIN never resolved.
+    channelsBySlug: () => ({ azzurra: [] }),
+  }));
+  vi.doMock("../lib/windowState", () => ({
+    windowStateByChannel: () => ({ "azzurra #gated": state }),
+  }));
+
+  localStorage.setItem("grappa-token", "tok");
+  const api = await import("../lib/api");
+  vi.mocked(api.listArchive).mockResolvedValue([
+    { target: "#gated", kind: "channel", last_activity: 300, row_count: 42 },
+  ]);
+
+  const archive = await import("../lib/archive");
+  await archive.loadArchive("azzurra");
+
+  const { default: BottomBar } = await import("../BottomBar");
+  const { container } = render(() => <BottomBar />);
+  const bottomBarTabs = Array.from(
+    container.querySelectorAll<HTMLElement>("[data-window-name]"),
+  ).map((el) => el.dataset.windowName ?? "");
+
+  return {
+    bottomBarTabs,
+    archiveTargets: archive.visibleArchiveForNetwork("azzurra", 1).map((e) => e.target),
+  };
+}
+
+describe("#402 — mobile surfaces for a non-joined window with scrollback", () => {
+  // `pending` is the state the ChanServ self-invite path lands
+  // (`{:rejoin_invited, _}` → `record_in_flight_join/2`), i.e. the exact
+  // sequence in the report.
+  it.each(["pending", "failed", "kicked", "parked"])(
+    "keeps a %s window reachable from exactly one mobile surface",
+    async (state) => {
+      const { bottomBarTabs, archiveTargets } = await mobileSurfacesFor(state);
+
+      const surfaces = [
+        bottomBarTabs.includes("#gated") ? "bottom-bar" : null,
+        archiveTargets.includes("#gated") ? "archive" : null,
+      ].filter((s) => s !== null);
+
+      expect(surfaces).toHaveLength(1);
+    },
+  );
+
+  // The counter-case that keeps the fix honest: `invited` IS rendered by
+  // the bottom bar, so the archive MUST stay suppressed — one surface,
+  // not two.
+  it("keeps an invited window on the bottom bar and out of the archive", async () => {
+    const { bottomBarTabs, archiveTargets } = await mobileSurfacesFor("invited");
+
+    expect(bottomBarTabs).toContain("#gated");
+    expect(archiveTargets).not.toContain("#gated");
+  });
+});

--- a/cicchetto/src/lib/__tests__/pseudoChannels.test.ts
+++ b/cicchetto/src/lib/__tests__/pseudoChannels.test.ts
@@ -14,19 +14,24 @@ const state = vi.hoisted(() => ({
   ws: {} as Record<string, string>,
   cbs: undefined as Record<string, { name: string; joined: boolean }[]> | undefined,
   qw: {} as Record<number, { targetNick: string }[]>,
+  mobile: false,
 }));
 
 vi.mock("../windowState", () => ({ windowStateByChannel: () => state.ws }));
 vi.mock("../networks", () => ({ channelsBySlug: () => state.cbs }));
 vi.mock("../queryWindows", () => ({ queryWindowsByNetwork: () => state.qw }));
+// The form factor is an environment boundary (matchMedia); mocking the
+// signal is what lets one jsdom run exercise both navs.
+vi.mock("../theme", () => ({ isMobile: () => state.mobile }));
 
 import { channelKey } from "../channelKey";
-import { pseudoChannelsForNetwork } from "../pseudoChannels";
+import { navPseudoChannelsForNetwork, pseudoChannelsForNetwork } from "../pseudoChannels";
 
 beforeEach(() => {
   state.ws = {};
   state.cbs = {};
   state.qw = {};
+  state.mobile = false;
 });
 
 describe("pseudoChannelsForNetwork", () => {
@@ -90,5 +95,45 @@ describe("pseudoChannelsForNetwork", () => {
     expect(pseudoChannelsForNetwork("freenode", 1)).toEqual([
       { name: "#invited", state: "invited" },
     ]);
+  });
+});
+
+// #402 — the form-factor view. This is the set the navs render AND the set
+// the archive filter subtracts, so the two cannot disagree about which
+// window has a surface. The narrowing used to be open-coded in BottomBar,
+// where the archive could not see it.
+describe("navPseudoChannelsForNetwork", () => {
+  const everyNonJoinedState = () => {
+    state.ws = {
+      [channelKey("freenode", "#pending")]: "pending",
+      [channelKey("freenode", "#invited")]: "invited",
+      [channelKey("freenode", "#failed")]: "failed",
+      [channelKey("freenode", "#kicked")]: "kicked",
+      [channelKey("freenode", "#parked")]: "parked",
+    };
+  };
+
+  it("draws every non-joined state on desktop (the Sidebar renders them all)", () => {
+    everyNonJoinedState();
+    state.mobile = false;
+    expect(navPseudoChannelsForNetwork("freenode", 1)).toEqual(
+      pseudoChannelsForNetwork("freenode", 1),
+    );
+    expect(navPseudoChannelsForNetwork("freenode", 1)).toHaveLength(5);
+  });
+
+  it("draws ONLY :invited on mobile (#71 INC-3 — the BottomBar is the only nav)", () => {
+    everyNonJoinedState();
+    state.mobile = true;
+    expect(navPseudoChannelsForNetwork("freenode", 1)).toEqual([
+      { name: "#invited", state: "invited" },
+    ]);
+  });
+
+  it("inherits the base projection's exclusions on mobile (a live :invited dedups away)", () => {
+    state.ws = { [channelKey("freenode", "#dup")]: "invited" };
+    state.cbs = { freenode: [{ name: "#dup", joined: true }] };
+    state.mobile = true;
+    expect(navPseudoChannelsForNetwork("freenode", 1)).toEqual([]);
   });
 });

--- a/cicchetto/src/lib/archive.ts
+++ b/cicchetto/src/lib/archive.ts
@@ -4,7 +4,7 @@ import { token } from "./auth";
 import { identityScopedStore } from "./identityScopedStore";
 import { channelsBySlug } from "./networks";
 import { normalizeNick } from "./nickEquals";
-import { pseudoChannelsForNetwork } from "./pseudoChannels";
+import { navPseudoChannelsForNetwork } from "./pseudoChannels";
 import { queryWindowsByNetwork } from "./queryWindows";
 
 // Per-network archive store. Source-of-truth for cic's per-network
@@ -159,8 +159,14 @@ export function visibleArchiveForNetwork(slug: string, networkId: number): Archi
   // Reuse the ONE shared pseudo-row projection — folding its names
   // (ASCII, #372/#525) for the archive's own compare. See the block comment
   // above for why this MUST NOT re-derive from raw windowState.
+  //
+  // #402: subtract what the nav of THIS form factor actually draws, not the
+  // whole projection. On mobile there is no Sidebar and the BottomBar draws
+  // only `:invited`, so subtracting `pending`/`failed`/`kicked`/`parked`
+  // there left the window with no surface at all. `navPseudoChannelsForNetwork`
+  // owns that narrowing for the navs too, so the two cannot drift.
   const pseudoNames = new Set(
-    pseudoChannelsForNetwork(slug, networkId).map((row) => normalizeNick(row.name)),
+    navPseudoChannelsForNetwork(slug, networkId).map((row) => normalizeNick(row.name)),
   );
   return entries.filter((entry) => {
     const folded = normalizeNick(entry.target);

--- a/cicchetto/src/lib/pseudoChannels.ts
+++ b/cicchetto/src/lib/pseudoChannels.ts
@@ -1,6 +1,7 @@
 import { type ChannelKey, decodeChannelKey } from "./channelKey";
 import { channelsBySlug } from "./networks";
 import { queryWindowsByNetwork } from "./queryWindows";
+import { isMobile } from "./theme";
 import { windowStateByChannel } from "./windowState";
 
 // Synthetic window rows: keys with windowState != "joined" whose
@@ -44,11 +45,9 @@ import { windowStateByChannel } from "./windowState";
 // #71 INC-3 — this is the ONE shared projection (the single code path)
 // behind BOTH the desktop Sidebar pseudo-rows AND the mobile BottomBar
 // `:invited` tab. Extracted from Sidebar so the two navs derive from
-// the same source rather than two parallel projections. A consumer MAY
-// narrow the returned set by state as a presentation choice — BottomBar
-// renders only `invited` (see DESIGN_NOTES 2026-07-26 #71 INC-3) — but
-// that filter is a different rendering of one source, NOT a second
-// projection.
+// the same source rather than two parallel projections. What each form
+// factor actually DRAWS out of it is `navPseudoChannelsForNetwork`
+// below — never a filter open-coded at a call site.
 
 export type PseudoRow = {
   name: string;
@@ -75,4 +74,29 @@ export function pseudoChannelsForNetwork(slug: string, networkId: number): Pseud
     out.push({ name, state: state as PseudoRow["state"] });
   }
   return out;
+}
+
+// #402 — what the nav of the CURRENT form factor actually DRAWS, which is
+// NOT the same set as the projection above.
+//
+// UX-5 bucket BK reads "one window, one surface", and the archive filter
+// (`archive.ts` → `visibleArchiveForNetwork`) implements it by subtracting
+// the pseudo-rows — on the premise that a nav renders what it subtracts.
+// Desktop honours that premise: `Shell.tsx` mounts the Sidebar, which draws
+// every non-joined state. Mobile does not: the mobile branch has no Sidebar
+// at all (an absent JSX branch, not `display:none`) and the BottomBar is
+// space-scarce, so it draws only the `:invited` slice (#71 INC-3, DESIGN_NOTES
+// 2026-07-26). `pending` / `failed` / `kicked` / `parked` were therefore
+// subtracted by a surface that never drew them: one window, ZERO surfaces —
+// a window that vanished from the UI until a reload.
+//
+// So the form-factor narrowing lives HERE, in the same module the archive
+// subtracts from, and every nav consumes it: the filter can no longer drift
+// from what is on screen. `isMobile()` is the SAME signal `Shell.tsx` branches
+// its layout on, so "which nav exists" and "which rows it draws" cannot
+// disagree.
+export function navPseudoChannelsForNetwork(slug: string, networkId: number): PseudoRow[] {
+  const rows = pseudoChannelsForNetwork(slug, networkId);
+  if (!isMobile()) return rows;
+  return rows.filter((row) => row.state === "invited");
 }

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -30148,3 +30148,64 @@ pref outlives the session that motivated it.
 not built at all rather than composed with a `dynamic(false)` tautology. The
 overwhelmingly common subject — no pins, no oversized channels — gets
 exactly the pre-#505 statement.
+
+## 2026-08-05 — #402: the archive subtracts what a nav DRAWS, not what a projection yields
+
+UX-5 bucket BK reads "one window, one surface", and `visibleArchiveForNetwork`
+implemented it by subtracting every row of the shared pseudo-row projection
+(`lib/pseudoChannels.ts`). That subtraction rests on a premise: some nav
+renders what the archive gives up. Desktop honours it — `Shell.tsx` mounts the
+Sidebar, which draws every non-joined state. Mobile never did. The mobile
+layout is a separate JSX branch with no Sidebar at all (an absent branch, not
+`display:none`), and the BottomBar draws the `:invited` slice alone (#71 INC-3,
+space scarcity). So on mobile the archive was subtracting rows on behalf of a
+surface that did not exist.
+
+**It is a class, and the class was measured, not argued.** The jsdom sibling of
+the repro counts the union of the two mobile surfaces per state: `pending`,
+`failed`, `kicked`, `parked` → **0**; `invited` → **1**. The report arrived as
+"`/cs invite` makes the channel vanish from Archive", and the ChanServ
+self-invite path (`{:rejoin_invited, _}` → `record_in_flight_join/2`) lands
+`:pending` — but `:pending` is one member of the set, not the defect. Fixing the
+invite arm would have left three states equally invisible.
+
+**The fix is (B): narrow the subtraction, not widen the bar.** The alternative
+(A) — have the BottomBar draw every non-joined state — was declined: it reverses
+the 2026-07-26 #71 INC-3 ruling on a bar that is space-scarce by construction,
+and `issue71-inc3-bottombar-invite.spec.ts` pins that ruling on the same
+viewport. So `navPseudoChannelsForNetwork/2` now answers "what does the nav of
+THIS form factor actually draw", and all three consumers read it: Sidebar,
+BottomBar, and the archive filter. The narrowing moved OUT of BottomBar's `<For>`
+and into the projection module.
+
+**That relocation is the actual repair.** A filter open-coded at a nav call site
+is invisible to the module that subtracts, which is precisely how the two came
+to disagree; one function makes the disagreement unrepresentable. The form-factor
+test is `isMobile()` — the SAME signal `Shell.tsx` branches its layout on — so
+"which nav is mounted" and "which rows it draws" cannot answer differently. In
+jsdom, absent `matchMedia`, it resolves desktop, which is the pre-existing
+behaviour; the mobile tests state the form factor explicitly rather than inherit
+it.
+
+**Declined: moving this to the server.** The tempting server-side arm is to stop
+offering the row — have `list_archive` exclude channels with a live non-joined
+window. It would have removed the only recovery that exists today.
+`Session.list_channels/2` is `Map.keys(state.members)` (server.ex), so a
+non-joined channel is never "live" and stays archive-eligible; the client's
+windowState map is memory-only, so a reload empties it and the archive row comes
+back. Hiding it server-side would make the disappearance permanent — worse
+mobile behaviour than the bug being fixed.
+
+**Kept honest by the counter-case.** The `invited` row must stay OUT of the
+archive, because the bar does draw it. Both the jsdom sibling and the e2e assert
+the union is exactly one, not at-least-one, so "stop subtracting" cannot pass:
+it would show `invited` on two surfaces and redden the same assertion the zeroes
+redden.
+
+**Adjacent and deliberately not crossed (#881).** On mobile a non-joined window
+hides every door to the rail — the TopicBar hamburger is `windowIsJoined`-gated
+and the ShellChrome opener renders only for `kind !== "channel"` — so Archive
+itself is unreachable while the failed channel holds focus. The e2e navigates
+back to a joined window before reaching for the archive, and says so. #402 gives
+the window a surface; #881 is what makes that surface reachable from where the
+operator is standing.


### PR DESCRIPTION
Issue: #402.

## What was wrong

`visibleArchiveForNetwork` enforces UX-5 bucket BK ("one window, one
surface") by subtracting every row of the shared pseudo-row projection —
on the premise that a nav renders what the archive gives up. Desktop
honours it (`Shell.tsx` mounts the Sidebar, which draws every non-joined
state). Mobile does not: the mobile layout is a separate JSX branch with
no Sidebar at all, and the BottomBar draws only the `:invited` slice
(#71 INC-3, space scarcity).

So on mobile the archive subtracted rows on behalf of a surface that did
not exist. The window ended up on **no** surface, until a reload emptied
the client-side window-state map and let the archive row back.

## It is a class, and it was measured

The jsdom repro (commit 2, red on purpose) counts the union of the two
mobile surfaces per state, against the tree before the fix:

| state | mobile surfaces |
|---|---|
| `pending` | 0 |
| `failed` | 0 |
| `kicked` | 0 |
| `parked` | 0 |
| `invited` | 1 |

The report arrived via `/cs invite`, whose auto-JOIN lands `:pending` —
one member of the set, not the defect.

## The change

`navPseudoChannelsForNetwork/2` (in `lib/pseudoChannels.ts`) answers what
the nav of the CURRENT form factor actually draws. Sidebar, BottomBar and
the archive filter all read it. The `:invited` narrowing moved out of
BottomBar's `<For>` and into the projection: a filter open-coded at a nav
call site is invisible to the module that subtracts, which is how the two
came to disagree. The form-factor test is `isMobile()` — the same signal
`Shell.tsx` branches its layout on.

Declined, deliberately:

* **Widening the bar** to draw every non-joined state — reverses the
  2026-07-26 #71 INC-3 ruling and would redden
  `issue71-inc3-bottombar-invite.spec.ts` on this same viewport. That spec
  is untouched and still passes: the bar draws invited alone; only the
  archive's idea of the bar changed.
* **Hiding the row server-side** (`list_archive` excluding live non-joined
  windows) — `Session.list_channels/2` is `Map.keys(state.members)`, so the
  row staying archive-eligible IS the only recovery there is today. Hiding
  it would make the disappearance permanent.

## Verification

* Red first, both levels: the e2e (commit 1) and the jsdom sibling
  (commit 2) were each recorded failing on this tree before the fix.
* jsdom repro after the fix: the four zeroes become 1, `invited` stays 1.
  The assertion is *exactly* one, so "just stop subtracting" cannot pass —
  it would put `invited` on two surfaces.
* Full cic unit suite: 238 files / 4326 tests green. `biome check` + `tsc
  --noEmit` clean.
* The `@webkit` e2e has not been run locally in this session — it is on CI.

## Adjacent, not crossed

#881: on mobile a non-joined window hides every door to the rail
(`windowIsJoined`-gated hamburger; opener only for `kind !== "channel"`),
so Archive is unreachable while the failed channel holds focus. The e2e
navigates back to a joined window first and says why. This PR gives the
window a surface; #881 is what makes that surface reachable from where the
operator is standing.