### PR TITLE
#505: teach both unread-seed doors the presence filter

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -21918,6 +21918,20 @@ one real wiring witness.
 `live_nick_index/1` (or `current_nick/2` directly) — never re-introduce a
 configured-nick shortcut "for the hot path"; the hot path is now cheap.
 
+**Scope correction (added 2026-08-05, #505).** Read the rejection of option
+(c) as being about the NICK, not as a blanket "no `GenServer.call` at
+cold-load". The trick that dissolved it — mirroring the value into the
+SessionRegistry entry — works precisely because a nick changes at ONE
+chokepoint and is a copy, never a parallel computation. #505 needed a live
+MEMBER COUNT for the presence size default, which changes on every
+JOIN/PART/QUIT/KICK; mirroring that would be a maintained parallel copy of
+`state.members`, i.e. the drifting duplicate state CLAUDE.md rule 1
+forbids. So #505 deliberately re-adds ONE call per live network per
+cold-load — bounded per network (not per window), skipped entirely when the
+network has no unset window, and never periodic. See DESIGN_NOTES
+2026-08-05 (#505) for the full argument. The rule above stands unchanged
+for own-nick-keyed counts.
+
 ## 2026-07-28 — #513: LINKS carries the requested mask, and a second in-flight /links is refused (not clobbered)
 
 Two distinct defects in the same place, both papered over by `SHOW_NETWORK_MAP = false` (#496 hid the 🗺 Map button "until /links is fixed"). #513 fixes both and flips the flag back on.
@@ -30038,3 +30052,99 @@ loses the negotiated codec rather than raising a use-after-free.
 YAML. State which files are compiled, which are linked into a sanitized binary,
 and which are neither — those are three different guarantees, and the middle one
 is the only one that catches lifetime and bounds defects.
+## 2026-08-05 — #505: the unread seed learns the presence filter, and buys it back with one call per network
+
+**Symptom.** On a channel hiding join/part/quit/nick_change, the faint
+`events` badge was seeded high by the server and visibly DROPPED when cic
+hydrated the channel. Two counts, two answers: the seed counted every row
+past the cursor, while cic's `perChannelUnread` routes the same rows through
+`presenceRowVisible` and skips the suppressed kinds. A badge the operator
+cannot clear by reading, until the act of opening the channel corrects it.
+
+**The issue's evidence named one door; there are two.** #505 was filed
+pointing at `WindowCounts.snapshot` → `Scrollback.count_after_split`, for
+both the `join_reply` seed and the `/me` cold-load. That was true when the
+observation was made and stale by the time it was fixed: #396 had already
+moved the cold-load onto `WindowCounts.bulk_snapshot` →
+`ReadCursor.bulk_unread_split`, a single `FROM read_cursors` statement that
+does not touch `count_after_split` at all. Since the FIRST symptom the issue
+describes ("never-opened-this-session") is served by exactly that door,
+teaching only the per-window path would have left the reported case
+untouched while looking fixed. Both doors now take the filter; the
+correction is recorded on the issue itself.
+
+**The rule is not forked.** #458 introduced
+`Grappa.PresenceFilter.hidden?/2` — the pure tri-state (`"hide"` wins,
+`"show"` wins, unset follows the live member count against the 50-member
+threshold, unknowable count SHOWS). #505 adds no second copy of it. What it
+adds is the I/O around it, lifted out of `GrappaWeb.MessagesController`
+(where #458 left it as three private helpers) into
+`Grappa.PresenceFilter.Resolver`.
+
+**Why the resolver needed its own top-level boundary.** No existing module
+had the deps. `Grappa.WindowCounts` is the natural-looking home, but
+`Grappa.Session` deps `Grappa.WindowCounts`, so `WindowCounts → Session`
+closes a cycle. `Grappa.PresenceFilter` is deliberately `deps: []` — giving
+the pure rule a Repo and a GenServer call would end its testability as a
+rule. `GrappaWeb` has the deps but is the web boundary, and
+`Grappa.WindowCounts.Pusher` (one of the four consumers) cannot depend on
+it. So the resolver sits ABOVE its callers in a boundary of its own —
+structurally identical to `Pusher`, which is there for the same reason.
+
+**The #498 tradeoff, partially bought back — deliberately, and bounded.**
+#498 (2026-07-28, above) converged the badge/unread doors onto the LIVE nick
+and explicitly rejected its option (c), "resolve through `Grappa.Session` at
+count time", because of the per-network `GenServer.call` it would add to the
+settle/cold-load path — citing #482, where ONE such call on a snapshot path
+reddened two timing specs. #498 dissolved that tradeoff by making the nick
+readable from the SessionRegistry entry value, a plain ETS read.
+
+The member count cannot follow the nick onto that trick. A nick changes at
+one chokepoint; a member count changes on every JOIN, PART, QUIT and KICK.
+Mirroring it into the registry value means maintaining a parallel copy of
+`state.members` with its own housekeeping — duplicated state that drifts,
+which CLAUDE.md's design-discipline rule 1 exists to prevent, and a worse
+trade than the call it saves. So #505 puts the call back, with three bounds
+that keep it a different order of magnitude from what #498 removed:
+
+- **Per network, not per window.** `Session.list_member_counts/2` is a new
+  bulk verb returning `%{channel => count}` in one call. The old shape
+  (`list_members/3` per channel) would have been ~50 calls at a 50-window
+  logon — the exact fan-out #396 collapsed.
+- **Only when a window is unset.** The resolver takes the caller's window
+  universe (`/me` threads its cursor envelope) so "does this network still
+  have an unset window?" is decidable without asking. A network whose every
+  window carries an explicit pin is never asked. Measured at the session
+  mailbox via `:erlang.trace`, not asserted: the skip is invisible in the
+  result, so a result-level test would have proved nothing.
+- **Cold-load only, never periodic.** The count is read once per `/me`, not
+  on a timer and not per message.
+
+The property #396 actually defends — a CONSTANT number of DB queries
+regardless of window count — is untouched: the exclusion rides the existing
+`join_on` dynamic, per slug, in the same two statements.
+
+**Seeded, not zero.** `list_member_counts/2` carries `list_members/3`'s
+seeded discrimination and OMITS a channel that has not yet observed its 366
+RPL_ENDOFNAMES. A pre-NAMES channel's count is UNKNOWABLE, not zero, and
+reporting `0` would read as "small channel, show presence" for a channel
+about to turn out to have 900 members. Absent → unset → decision D → SHOW.
+
+**Narrow, not "zero the events bucket".** The exclusion is
+`Message.suppressed_presence_kinds/0` only. `:mode`, `:topic`, `:kick` and
+`:server_event` still count under `events` when hiding, because the pane
+still renders them. Every test of the hiding path asserts one of those
+survives — without that assertion, "apply the narrow filter" and "zero the
+bucket" pass identically.
+
+**The hidden set is keyed by SLUG, not network id.** The pin itself is
+(`"<slug> <channel>"`), and `bulk_unread_split/3` already joins `networks`
+for the slug. It also matters for correctness: a network with no live
+session is absent from `own_nicks` (which comes from
+`live_nick_windows/1`), so an id-keyed set could not carry its pins — and a
+pref outlives the session that motivated it.
+
+**Empty set, byte-identical SQL.** When nothing hides, the exclusion term is
+not built at all rather than composed with a `dynamic(false)` tautology. The
+overwhelmingly common subject — no pins, no oversized channels — gets
+exactly the pre-#505 statement.

--- a/lib/grappa/presence_filter/resolver.ex
+++ b/lib/grappa/presence_filter/resolver.ex
@@ -1,0 +1,240 @@
+defmodule Grappa.PresenceFilter.Resolver do
+  @moduledoc """
+  The I/O half of the presence decision: fetch the two inputs
+  `Grappa.PresenceFilter.hidden?/2` needs — the server-owned tri-state pref
+  (#449) and the LIVE member count — and apply the rule.
+
+  ## Why this is a module and not three private helpers
+
+  #458 introduced the resolution as private helpers inside
+  `GrappaWeb.MessagesController`, where the only consumer was the history
+  fetch. #505 gives it three more consumers on two different sides of the
+  app — the `join_reply` seed, the per-message `window_counts` push
+  (`Grappa.WindowCounts.Pusher`, NOT a web module), and the `/me` cold-load
+  — and the issue's own instruction is to reuse the resolver rather than
+  fork the precedence rule. Four copies of "read the pref, maybe count the
+  members, apply the rule" is exactly how a tri-state quietly becomes four
+  slightly different tri-states.
+
+  ## Why its OWN top-level boundary
+
+  It cannot live anywhere that already has these deps:
+
+    * `Grappa.WindowCounts` is the natural-looking home, but `Grappa.Session`
+      deps `Grappa.WindowCounts` — so `WindowCounts → Session` would close a
+      Boundary cycle.
+    * `Grappa.PresenceFilter` is deliberately dep-free ("owns only the
+      threshold + precedence rule"). Giving the pure rule module a Repo and
+      a GenServer call would make it untestable as a rule.
+    * `GrappaWeb` has the deps, but it is the web boundary and `Pusher` —
+      which needs this — cannot depend on it.
+
+  So it sits in its own `top_level?: true` boundary ABOVE its callers. Same
+  inversion, for the same reason, as `Grappa.WindowCounts.Pusher`.
+
+  ## One rule, two shapes
+
+  `hidden?/4` answers for ONE window; `hidden_channels/3` answers for the
+  whole subject at once (the `/me` cold-load, which must stay at a constant
+  number of queries — #396). Both bottom out in the SAME
+  `PresenceFilter.hidden?/2` call, so the tri-state precedence and the size
+  threshold are evaluated in exactly one place:
+
+    * an explicit `"hide"` / `"show"` pin wins, count irrelevant;
+    * unset follows the live member count against the threshold;
+    * unset with an unknowable count (no live session, or the channel has
+      not yet observed its NAMES burst) SHOWS — decision D of #458, never
+      hide history on a guess.
+
+  ## The pin key is not folded on read
+
+  A pin is stored under cic's composite `ChannelKey`
+  (`"<slug> <folded channel>"`, `cicchetto/src/lib/channelKey.ts`), and
+  `channel_key/2` folds the channel being LOOKED UP so any casing resolves
+  to the same pin. The stored key itself is taken verbatim in the bulk path.
+  That is deliberate: re-folding stored keys there would make the bulk path
+  honour a legacy raw-cased pin that `hidden?/4` misses, and one rule with
+  two behaviours is the thing this module exists to prevent.
+  """
+
+  use Boundary,
+    top_level?: true,
+    deps: [
+      Grappa.IRC,
+      Grappa.PresenceFilter,
+      Grappa.Session,
+      Grappa.Subject,
+      Grappa.UserSettings
+    ]
+
+  alias Grappa.IRC.Identifier
+  alias Grappa.{PresenceFilter, Session, Subject, UserSettings}
+
+  @doc """
+  Whether the history reads + unread seed should HIDE presence rows for one
+  `(subject, network, channel)` window.
+
+  `Session.list_members/3` is called ONLY when the pref is unset — an
+  explicit pin needs no count, so the common case skips the GenServer
+  round-trip entirely.
+  """
+  @spec hidden?(Subject.t(), String.t(), integer(), String.t()) :: boolean()
+  def hidden?(subject, network_slug, network_id, channel)
+      when is_binary(network_slug) and is_integer(network_id) and is_binary(channel) do
+    pins = UserSettings.get_display_prefs(subject).presence_filter
+    pref = Map.get(pins, channel_key(network_slug, channel))
+
+    PresenceFilter.hidden?(pref, member_count_for_unset(pref, subject, network_id, channel))
+  end
+
+  @doc """
+  The hiding channels for the WHOLE subject, as
+  `%{network_slug => MapSet.of(channel)}` — the shape
+  `Grappa.ReadCursor.bulk_unread_split/3` excludes on.
+
+  Keyed by slug, not network id, because the pin itself is
+  (`"<slug> <channel>"`). That matters for a network whose session is not
+  live: it is absent from `own_nicks` (which comes from
+  `Grappa.Push.BadgeCount.live_nick_windows/1`), so an id-keyed set could
+  not carry its pins — and a pref outlives the session that motivated it.
+
+  A slug with no hiding channel is absent from the result rather than
+  mapping to an empty set.
+
+  ## `windows` — why the window universe is a parameter
+
+  `windows` is the caller's `%{slug => %{channel => _}}` envelope (`/me`
+  passes its cursor envelope verbatim; only the KEYS are read). It is not a
+  convenience: without it the answer to "does this network still have an
+  UNSET channel?" is undecidable here, because the pins alone cannot bound
+  the set of channels that EXIST. With it, two things follow:
+
+    * the member-count call is SKIPPED for a network whose every window
+      carries an explicit pin — the count is then irrelevant to every
+      decision, so asking for it is pure waste;
+    * the resulting MapSets contain only real windows, so the `IN` list
+      pushed into the bulk statement is bounded by the subject's window
+      count instead of by everything the session happens to be joined to.
+
+  Channels outside `windows` are correctly ignored: `bulk_unread_split/3`
+  is driven `FROM read_cursors`, so a channel with no cursor contributes no
+  row to filter.
+
+  ## This re-adds a per-network GenServer call at cold-load — deliberately
+
+  #498 removed the per-network `GenServer.call` from the `/me` path by
+  moving the own-nick lookup onto a cheap `Registry` read, and explicitly
+  REJECTED resolving through `Grappa.Session` at count time for that reason
+  (DESIGN_NOTES 2026-07-28, option (c)). The size default cannot follow the
+  nick onto the Registry: a member count changes on every JOIN/PART, so
+  mirroring it into the registry value means maintaining a parallel copy
+  that drifts (CLAUDE.md design discipline, rule 1) — worse than the call
+  it saves. #505 therefore puts ONE call per live network back, and only
+  when that network has at least one unset window.
+
+  The bound is per NETWORK per cold-load — not per window, not periodic —
+  so the #396 property that actually matters (a CONSTANT number of DB
+  queries regardless of window count) is untouched. Recorded in
+  DESIGN_NOTES 2026-08-05.
+  """
+  @spec hidden_channels(
+          Subject.t(),
+          %{String.t() => {integer(), String.t()}},
+          %{String.t() => map()}
+        ) :: %{String.t() => MapSet.t(String.t())}
+  def hidden_channels(subject, own_nicks, windows)
+      when is_map(own_nicks) and is_map(windows) do
+    pins = parse_pins(UserSettings.get_display_prefs(subject).presence_filter)
+
+    Enum.reduce(windows, %{}, fn {slug, slug_windows}, acc ->
+      slug_pins = Map.get(pins, slug, %{})
+      channels = Map.keys(slug_windows)
+      slug_counts = counts_for_unset(subject, own_nicks, slug, channels, slug_pins)
+
+      hiding =
+        Enum.filter(channels, fn channel ->
+          PresenceFilter.hidden?(Map.get(slug_pins, channel), Map.get(slug_counts, channel))
+        end)
+
+      case hiding do
+        [] -> acc
+        hiding -> Map.put(acc, slug, MapSet.new(hiding))
+      end
+    end)
+  end
+
+  @doc """
+  cic's composite `ChannelKey` for a `(network, channel)` pair —
+  `"<slug> <folded channel>"`. The channel is folded through the identifier
+  SSOT so a request in any casing resolves to the one stored pin.
+  """
+  @spec channel_key(String.t(), String.t()) :: String.t()
+  def channel_key(network_slug, channel),
+    do: "#{network_slug} #{Identifier.canonical_target(channel)}"
+
+  # ---------------------------------------------------------------------------
+  # Private
+  # ---------------------------------------------------------------------------
+
+  # An explicit pin makes the count irrelevant — skip the GenServer call.
+  @spec member_count_for_unset(String.t() | nil, Subject.t(), integer(), String.t()) ::
+          non_neg_integer() | nil
+  defp member_count_for_unset(nil, subject, network_id, channel) do
+    case Session.list_members(subject, network_id, channel) do
+      {:ok, members} when is_list(members) -> length(members)
+      # :uninitialized (NAMES not yet seeded) or :no_session — the count is
+      # unknowable, and `PresenceFilter.hidden?/2` reads nil as SHOW.
+      _ -> nil
+    end
+  end
+
+  defp member_count_for_unset(_, _, _, _), do: nil
+
+  # `%{"<slug> <channel>" => pref}` → `%{slug => %{channel => pref}}`. The
+  # separator is a space, which neither a slug nor an IRC channel name may
+  # contain (RFC 2812 chanstring excludes 0x20), so splitting on the first
+  # one is unambiguous. A key without a separator is not a ChannelKey and is
+  # dropped rather than guessed at.
+  @spec parse_pins(%{String.t() => String.t()}) :: %{String.t() => %{String.t() => String.t()}}
+  defp parse_pins(presence_filter) do
+    Enum.reduce(presence_filter, %{}, fn {key, pref}, acc ->
+      case String.split(key, " ", parts: 2) do
+        [slug, channel] when slug != "" and channel != "" ->
+          Map.update(acc, slug, %{channel => pref}, &Map.put(&1, channel, pref))
+
+        _ ->
+          acc
+      end
+    end)
+  end
+
+  # `%{channel => count}` for ONE network's windows — or `%{}` without
+  # asking, whenever the count cannot change any decision. Both skips are
+  # exact, not heuristic:
+  #
+  #   * every window of this slug carries an explicit pin, so
+  #     `PresenceFilter.hidden?/2` short-circuits on the pin for every one
+  #     of them and the count is dead weight;
+  #   * the network has no live session, so it is absent from `own_nicks`
+  #     and there is nothing to ask.
+  #
+  # An empty result lands the unset channels on decision D (SHOW) — the
+  # same answer `hidden?/4` gives for `{:error, :no_session}`. Never hide
+  # history on a guess.
+  @spec counts_for_unset(
+          Subject.t(),
+          %{String.t() => {integer(), String.t()}},
+          String.t(),
+          [String.t()],
+          %{String.t() => String.t()}
+        ) :: %{String.t() => non_neg_integer()}
+  defp counts_for_unset(subject, own_nicks, slug, channels, slug_pins) do
+    with true <- Enum.any?(channels, &(not Map.has_key?(slug_pins, &1))),
+         {:ok, {network_id, _}} <- Map.fetch(own_nicks, slug),
+         {:ok, counts} <- Session.list_member_counts(subject, network_id) do
+      counts
+    else
+      _ -> %{}
+    end
+  end
+end

--- a/lib/grappa/push/badge_count.ex
+++ b/lib/grappa/push/badge_count.ex
@@ -16,7 +16,7 @@ defmodule Grappa.Push.BadgeCount do
 
   The notify predicate gates on `Grappa.Scrollback.Message.notify_kinds/0`
   (`:privmsg`, `:action`) — the notify-worthy SUBSET of the unread-content
-  kinds `Grappa.WindowCounts.snapshot/6` counts. Both derive from ONE
+  kinds `Grappa.WindowCounts.snapshot/7` counts. Both derive from ONE
   projection declaration (#395), so this badge total is a subset of the
   per-window unread message counts BY CONSTRUCTION: a `:notice` counts as
   unread but never reaches this badge.
@@ -27,8 +27,8 @@ defmodule Grappa.Push.BadgeCount do
   early-bails at `@badge_cap` (99) and each window folds at most
   `@per_channel_cap` (100) rows, so a subject with thousands of unread
   notify-worthy messages reports `99`, not the true total. The per-window
-  unread MESSAGE count (`Grappa.WindowCounts.snapshot/6`'s `messages`
-  field, off `Scrollback.count_after_split/5`) is by contrast EXACT and
+  unread MESSAGE count (`Grappa.WindowCounts.snapshot/7`'s `messages`
+  field, off `Scrollback.count_after_split/6`) is by contrast EXACT and
   unbounded. This asymmetry is intentional, not an oversight: the badge
   answers "roughly how many notify-worthy — capped, because the UI renders
   `99+`", the window count answers "exactly how many new". Past the cap the

--- a/lib/grappa/read_cursor.ex
+++ b/lib/grappa/read_cursor.ex
@@ -218,7 +218,7 @@ defmodule Grappa.ReadCursor do
   Bulk unread-split envelope (#396): nested
   `%{network_slug => %{channel => %{messages: n, events: n}}}`. Same nesting
   as `bulk_envelope/0`; the value is the content-vs-presence split
-  `Scrollback.count_after_split/5` returns per window.
+  `Scrollback.count_after_split/6` returns per window.
   """
   @type bulk_split_envelope ::
           %{String.t() => %{String.t() => %{messages: non_neg_integer(), events: non_neg_integer()}}}
@@ -226,7 +226,7 @@ defmodule Grappa.ReadCursor do
   @doc """
   #396 — the ENTIRE subject's per-window unread `%{messages, events}` split
   in ONE query, driven by the read cursors (replaces the cold-load's
-  N × `Scrollback.count_after_split/5` fan-out — ~2 queries per window at
+  N × `Scrollback.count_after_split/6` fan-out — ~2 queries per window at
   logon).
 
   Drives `FROM read_cursors` LEFT JOIN `messages` on the SINGLE unified
@@ -240,7 +240,7 @@ defmodule Grappa.ReadCursor do
   (#364) and nicks raw (#372), so the fold is required on each side for a
   differently-cased DM peer to resolve to one window.
 
-  Semantics vs `count_after_split/5`: IDENTICAL for channel + DM-peer
+  Semantics vs `count_after_split/6`: IDENTICAL for channel + DM-peer
   windows. The own-nick SELF window (cursor channel == own nick) differs by
   design (#396): the single predicate folds `COALESCE` and so counts self
   rows the old `channel == own AND dm_with == own` narrowing missed —
@@ -271,15 +271,37 @@ defmodule Grappa.ReadCursor do
   "unread" to them, and a parted channel (or every `/nick`) used to strand
   a permanent "1" behind it. The fold is PER-NETWORK because a subject may
   hold a different nick on each.
-  This is the #396 cold-load twin of `Scrollback.count_after_split/5`'s
+  This is the #396 cold-load twin of `Scrollback.count_after_split/6`'s
   identical exclusion — one rule, both count doors. Content is untouched;
   legitimate unread that arrived before the leave survives (and #532 B
   surfaces it). A slug absent from `own_nicks` (or a `nil` nick) applies no
   exclusion for that network — its presence rows count as before.
+
+  ## #505 — `hidden_channels` excludes suppressed presence per window
+
+  `%{network_slug => MapSet.of(channel)}`, resolved once by the caller via
+  `Grappa.PresenceFilter.Resolver.hidden_channels/3`. For a window in that
+  set, the NARROW presence-noise kinds
+  (`Message.suppressed_presence_kinds/0`) do not join, so they never land in
+  its `events` bucket — the cold-load twin of `count_after_split/6`'s
+  `hide_presence`, and the door the #505 badge jump is actually reported
+  through.
+
+  Keyed by SLUG because the pref is (`"<slug> <channel>"`), and because a
+  network with no live session is absent from `own_nicks` yet must still
+  honour its pins. The term is built per-slug as a disjunction and folded
+  into the SAME join condition as the own-authored exclusion — one
+  statement, no extra query, and nothing is added to the SQL at all when
+  the map is empty (the overwhelmingly common case: no pins, no oversized
+  channels).
   """
-  @spec bulk_unread_split(subject(), %{String.t() => {integer(), String.t()}}) ::
-          bulk_split_envelope()
-  def bulk_unread_split(subject, own_nicks) when is_map(own_nicks) do
+  @spec bulk_unread_split(
+          subject(),
+          %{String.t() => {integer(), String.t()}},
+          %{String.t() => MapSet.t(String.t())}
+        ) :: bulk_split_envelope()
+  def bulk_unread_split(subject, own_nicks, hidden_channels)
+      when is_map(own_nicks) and is_map(hidden_channels) do
     content = Message.content_kinds()
     {sub_field, sub_id} = subject_pair(subject)
     own_authored = own_authored_dynamic(own_nicks, content)
@@ -303,12 +325,14 @@ defmodule Grappa.ReadCursor do
           not (^own_authored)
       )
 
+    full_join_on = exclude_hidden_presence(join_on, hidden_channels)
+
     query =
       from(rc in Cursor,
         join: n in Network,
         on: n.id == rc.network_id,
         left_join: m in Message,
-        on: ^join_on,
+        on: ^full_join_on,
         where: not is_nil(rc.last_read_message_id),
         group_by: [n.slug, rc.channel, fragment("CASE WHEN ? THEN 1 ELSE 0 END", m.kind in ^content)],
         select: {
@@ -346,7 +370,7 @@ defmodule Grappa.ReadCursor do
   — the two fields `WindowCounts` folds through `Mentions.mentioned?/3`.
 
   Same unified `nick_fold(COALESCE(...))` window predicate as
-  `bulk_unread_split/2`, restricted to content kinds. An INNER JOIN (a
+  `bulk_unread_split/3`, restricted to content kinds. An INNER JOIN (a
   window with no unread content contributes no rows → zero mentions,
   supplied by the caller's default). The per-window `cap` is enforced with a
   `ROW_NUMBER() OVER (PARTITION BY window ORDER BY id)` window function
@@ -383,7 +407,7 @@ defmodule Grappa.ReadCursor do
 
     # Scope the DRIVING `read_cursors` to the subject via the shared
     # `subject_filter/2` (binding 0 == `rc`), identical to
-    # `bulk_unread_split/2` + `bulk_for_subject/1` — one way to express
+    # `bulk_unread_split/3` + `bulk_for_subject/1` — one way to express
     # "these cursors are mine". `subject_pair/1` is still needed for the
     # `on:`-clause match on `messages` (a join-side filter belongs in `on:`,
     # not `where`, so the JOIN keeps its driving row).
@@ -473,6 +497,38 @@ defmodule Grappa.ReadCursor do
       _, acc ->
         acc
     end)
+  end
+
+  # #505 — folds the per-window presence exclusion into the join condition.
+  # Built as a per-slug disjunction, the same shape `own_authored_dynamic/2`
+  # uses per network, so a subject hiding 50 channels across 3 networks still
+  # produces ONE statement.
+  #
+  # The empty case returns `join_on` untouched rather than composing with a
+  # `dynamic(false)`: a subject with no pins and no oversized channels is the
+  # overwhelmingly common case, and it deserves the exact pre-#505 SQL rather
+  # than a tautology the planner has to see through.
+  @spec exclude_hidden_presence(Ecto.Query.dynamic_expr(), %{
+          String.t() => MapSet.t(String.t())
+        }) :: Ecto.Query.dynamic_expr()
+  defp exclude_hidden_presence(join_on, hidden_channels) do
+    hiding = Enum.reject(hidden_channels, fn {_, channels} -> Enum.empty?(channels) end)
+
+    case hiding do
+      [] ->
+        join_on
+
+      slugs ->
+        suppressed = Message.suppressed_presence_kinds()
+
+        hidden =
+          Enum.reduce(slugs, dynamic(false), fn {slug, channels}, acc ->
+            list = MapSet.to_list(channels)
+            dynamic([rc, n, _], ^acc or (n.slug == ^slug and rc.channel in ^list))
+          end)
+
+        dynamic([_, _, m], ^join_on and not (m.kind in ^suppressed and ^hidden))
+    end
   end
 
   @doc """

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -93,7 +93,7 @@ defmodule Grappa.Scrollback do
 
   # Content-bearing kinds: the ones that carry a notification meaning.
   # S17 — derived from the schema SSOT (`Message.content_kinds/0`);
-  # feeds `count_after_split/5`'s `:messages` bucket, the content-row
+  # feeds `count_after_split/6`'s `:messages` bucket, the content-row
   # fetch, and the `dm_peer/4` guard here. Presence/control kinds
   # never notify.
   @content_kinds Message.content_kinds()
@@ -104,7 +104,7 @@ defmodule Grappa.Scrollback do
   # `maybe_exclude_presence/2`. A module attribute (compile-time list) so the
   # `not in ^...` interpolation renders `kind NOT IN (?, ?, ?)` with the atoms
   # dumped to their Ecto.Enum string values — same mechanism as
-  # `count_after_split/5`'s `^@content_kinds`.
+  # `count_after_split/6`'s `^@content_kinds`.
   @suppressed_presence_kinds Message.suppressed_presence_kinds()
 
   @doc """
@@ -522,9 +522,11 @@ defmodule Grappa.Scrollback do
   decision needs the TRUE size: a full page proves only "≥ limit", which
   cannot tell a 201-row gap from a 3000-row one.
 
-  (The unread badge does NOT come through here — the join reply +
-  `/me` cold-load seed it from `count_after_split/5` via
-  `Grappa.WindowCounts`, which splits content from presence.)
+  (The unread badge does NOT come through here. The join reply + the
+  per-message push seed it from `count_after_split/6` via
+  `Grappa.WindowCounts.snapshot/7`, which splits content from presence;
+  the `/me` cold-load does not touch this module at all since #396 —
+  it goes through `ReadCursor.bulk_unread_split/3`.)
 
   Same predicates as `fetch_after/7` so the count exactly matches what a
   `fetch_after(..., :infinity)` would return — modulo the `@max_limit`
@@ -573,9 +575,9 @@ defmodule Grappa.Scrollback do
   end
 
   @doc """
-  Same predicate as `count_after/6` — minus its `hide_presence` filter,
-  which would be self-defeating here — but returns the count split into a
-  `{content, presence}` pair as `%{messages: integer, events: integer}`.
+  Same predicate as `count_after/6`, including its `hide_presence` filter,
+  but returns the count split into a `{content, presence}` pair as
+  `%{messages: integer, events: integer}`.
 
   Sole consumer: the `/me` `unread_counts` envelope (bucket C, 2026-06-01)
   — cic's per-channel sidebar badge renders messages (bold) and events
@@ -599,12 +601,36 @@ defmodule Grappa.Scrollback do
   `fetch/6`): a defaulting wrapper silently re-opens the CP14-B3
   own-nick DM over-count for any caller that forgets to thread it
   (S2, 2026-07-08 review — the `/me` cold-load did exactly that).
+
+  ## `hide_presence` (#505)
+
+  Also a REQUIRED positional, same contract as `count_after/6`'s. It was
+  absent here until #505 on the reasoning that filtering a SPLIT count
+  would be self-defeating; the opposite turned out to be true. On a channel
+  that hides presence the pane never renders join/part/quit/nick_change, so
+  an `events` count that includes them is a badge the operator cannot clear
+  by reading — and because cic's hydrated count already excludes them
+  (`presenceRowVisible`, `cicchetto/src/lib/selection.ts`), the seed
+  visibly DROPS the moment the channel hydrates. That jump is the reported
+  bug.
+
+  The filter is NARROW: `Message.suppressed_presence_kinds/0` only. `:mode`,
+  `:topic`, `:kick` and `:server_event` still count under `events` when
+  hiding, because the pane still renders them. The content bucket is
+  unaffected either way — every suppressed kind is disjoint from
+  `@content_kinds`, so the exclusion can only ever shrink `events`.
   """
-  @spec count_after_split(subject(), integer(), String.t(), integer(), String.t() | nil) ::
-          %{messages: non_neg_integer(), events: non_neg_integer()}
-  def count_after_split(subject, network_id, channel, after_id, own_nick)
+  @spec count_after_split(
+          subject(),
+          integer(),
+          String.t(),
+          integer(),
+          String.t() | nil,
+          boolean()
+        ) :: %{messages: non_neg_integer(), events: non_neg_integer()}
+  def count_after_split(subject, network_id, channel, after_id, own_nick, hide_presence)
       when is_integer(network_id) and is_integer(after_id) and
-             (is_binary(own_nick) or is_nil(own_nick)) do
+             (is_binary(own_nick) or is_nil(own_nick)) and is_boolean(hide_presence) do
     # #576 — the own-nick SELF window (channel keyed to your own nick) is the
     # ONE window where own content is legitimate payload (notes-to-self, #396),
     # so own content is NOT excluded there — only in peer / channel windows.
@@ -617,6 +643,7 @@ defmodule Grappa.Scrollback do
       |> subject_where(subject)
       |> where([m], m.network_id == ^network_id)
       |> channel_or_dm_where(channel, own_nick)
+      |> maybe_exclude_presence(hide_presence)
       |> where([m], m.id > ^after_id)
       |> exclude_own_authored(own_nick, self_window?)
       # S17: the content bucket derives from `@content_kinds` (schema
@@ -670,7 +697,7 @@ defmodule Grappa.Scrollback do
   #
   # Derive-don't-duplicate: no cursor is moved, so any legitimate unread PEER
   # row that arrived before the own row survives, and it is timing-
-  # independent. Same rule applied in `ReadCursor.bulk_unread_split/2` (the
+  # independent. Same rule applied in `ReadCursor.bulk_unread_split/3` (the
   # #396 cold-load twin — the self-window test there is per-row on
   # `rc.channel`). Boundary: an INTERMEDIATE row of a multi-hop rename
   # (`alice→bob→vjt`) still counts and self-heals on the next view — a rare,
@@ -718,7 +745,7 @@ defmodule Grappa.Scrollback do
   `(subject, network_id, channel)` window, oldest-first.
 
   "Content" = `:privmsg | :notice | :action` — the same kind set
-  `count_after_split/5` buckets as `:messages` and the push-trigger
+  `count_after_split/6` buckets as `:messages` and the push-trigger
   predicate (`Grappa.Push.Triggers.should_notify?/4`) can act on.
   Presence/control kinds (`:join`, `:mode`, …) never carry a
   notification meaning, so they are excluded at the SQL layer rather
@@ -1091,7 +1118,7 @@ defmodule Grappa.Scrollback do
   # `list_archive/3`'s GROUP BY already uses (in-house precedent). Because
   # the match lives ONLY here, every consumer of the shared predicate
   # (`fetch/6`, `fetch_after/6`, `fetch_around/6`, `unread_content_tail/6`,
-  # `count_after/6`, `count_after_split/5` via `channel_or_dm_where/3`, and
+  # `count_after/6`, `count_after_split/6` via `channel_or_dm_where/3`, and
   # `delete_for_dm/3` directly) becomes sargable in one shot.
   @spec where_dm_peer(Ecto.Query.t(), String.t()) :: Ecto.Query.t()
   defp where_dm_peer(query, folded_peer) when is_binary(folded_peer) do
@@ -1129,7 +1156,7 @@ defmodule Grappa.Scrollback do
   # #458 — when hiding, exclude the narrow presence-noise kinds
   # (@suppressed_presence_kinds) in SQL so `limit` counts VISIBLE rows. The
   # `not in ^...` renders `kind NOT IN (?, ?, ?)` with the atoms dumped to
-  # their Ecto.Enum string values (same mechanism as count_after_split/5).
+  # their Ecto.Enum string values (same mechanism as count_after_split/6).
   # There is no index on `messages.kind` (#458 note): the predicate rides the
   # existing composite after the index scan — fine at current volumes.
   defp maybe_exclude_presence(query, false), do: query

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -1240,6 +1240,32 @@ defmodule Grappa.Session do
   end
 
   @doc """
+  Returns `%{channel => member_count}` for every channel in this session
+  whose NAMES burst has landed — the bulk twin of `list_members/3`.
+
+  #505: the `/me` cold-load resolves the presence-hiding size default for
+  EVERY window at once. Doing that through `list_members/3` would be one
+  GenServer call per channel at logon, which is precisely the per-window
+  fan-out #396 collapsed. One call returns the whole map.
+
+  Carries the SAME seeded discrimination as `list_members/3`, because the
+  distinction is load-bearing for the caller: a channel that has not yet
+  observed its 366 RPL_ENDOFNAMES has an UNKNOWABLE count, not a count of
+  zero, so it is OMITTED from the map rather than reported as `0`. A
+  consumer reading `0` would conclude "small channel, show presence" for a
+  channel that is about to turn out to have 900 members.
+
+  Channel keys are the members-map keys, i.e. already network-folded at
+  ingress (#537) — the same keys `read_cursors.channel` carries.
+  """
+  @spec list_member_counts(subject(), integer()) ::
+          {:ok, %{String.t() => non_neg_integer()}} | {:error, :no_session}
+  def list_member_counts(subject, network_id)
+      when is_subject(subject) and is_integer(network_id) do
+    call_session(subject, network_id, :list_member_counts)
+  end
+
+  @doc """
   Returns the cached topic for `channel` in the given session.
 
   Serves from the in-memory topic cache — no upstream TOPIC query is

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -2341,6 +2341,26 @@ defmodule Grappa.Session.Server do
     end
   end
 
+  # Returns `%{channel => member_count}` for every SEEDED channel. Public via
+  # `Grappa.Session.list_member_counts/2`.
+  #
+  # #505 — the bulk twin of `{:list_members, channel}`, for the `/me`
+  # cold-load's per-window presence-hiding decision. Filters on
+  # `seeded_channels` for the same reason `list_members/3` returns
+  # `:uninitialized`: a pre-NAMES channel's count is unknowable, and
+  # reporting it as `0` would read as "small channel" to the caller. A
+  # channel the operator has PARTed is gone from `state.members` and so is
+  # absent here too — it has no live count either.
+  def handle_call(:list_member_counts, _, state) do
+    counts =
+      for {channel, members} <- state.members,
+          MapSet.member?(state.seeded_channels, channel),
+          into: %{},
+          do: {channel, map_size(members)}
+
+    {:reply, {:ok, counts}, state}
+  end
+
   # Returns a snapshot of the topic cache for `channel`. Serves from cache —
   # no upstream query. Public via `Grappa.Session.get_topic/3`.
   def handle_call({:get_topic, channel}, _, state) when is_binary(channel) do

--- a/lib/grappa/window_counts.ex
+++ b/lib/grappa/window_counts.ex
@@ -4,7 +4,7 @@ defmodule Grappa.WindowCounts do
 
   ## Derive, don't duplicate
 
-  `snapshot/6` computes `%{messages, mentions, events, severity}` for a
+  `snapshot/7` computes `%{messages, mentions, events, severity}` for a
   `(subject, network, channel)` window PURELY from the read cursor
   (`Grappa.ReadCursor`) + the `messages` table. There is NO persisted
   counter and NO per-channel state in `Session.Server` — the count is
@@ -16,7 +16,7 @@ defmodule Grappa.WindowCounts do
   ## The three counts
 
     * `messages` — unread CONTENT rows (`:privmsg | :notice | :action`),
-      the same set `Scrollback.count_after_split/5` buckets as
+      the same set `Scrollback.count_after_split/6` buckets as
       `:messages`. Unbounded (exact) — a channel with 10k unread must
       surface 10k, matching `count_after/6`.
     * `events` — unread PRESENCE/CONTROL rows (`:join | :part | :quit |
@@ -41,7 +41,7 @@ defmodule Grappa.WindowCounts do
 
   ## Reuse, explicit own_nick
 
-  `snapshot/6` takes `own_nick` + `patterns` as explicit args — it does
+  `snapshot/7` takes `own_nick` + `patterns` as explicit args — it does
   NOT reach into `Session.Server`. Callers resolve them the same way the
   existing count doors do: the LIVE nick (`Push.BadgeCount.live_nick_windows/1`,
   a cheap `Registry` lookup) for `/me`, the live `state.nick` for the
@@ -103,14 +103,24 @@ defmodule Grappa.WindowCounts do
   `(subject, network_id, channel)` window relative to `cursor`
   (`last_read_message_id`; `nil` counts from the beginning).
 
-  `own_nick` and `patterns` are REQUIRED positionals — no defaulting
-  wrapper (same rule as `Scrollback.count_after/6`): a default silently
-  re-opens the CP14-B3 own-nick DM over-count and the mention-fold
+  `own_nick`, `patterns` and `hide_presence` are REQUIRED positionals — no
+  defaulting wrapper (same rule as `Scrollback.count_after/6`): a default
+  silently re-opens the CP14-B3 own-nick DM over-count and the mention-fold
   hazard. `own_nick` MAY be `nil` for the unbound-but-retained network
   case (`/me` seed for a network the subject holds no credential on) —
   there is then no nick to match, so `mentions` is `0` and messages/events
-  fall back to `count_after_split/5`'s channel-shape narrowing. Live
+  fall back to `count_after_split/6`'s channel-shape narrowing. Live
   doors (`join_reply`, per-message push) always pass a real nick.
+
+  ## `hide_presence` (#505)
+
+  Resolved by the caller through `Grappa.PresenceFilter.Resolver.hidden?/4`
+  — this module deliberately does not reach for prefs or a live member
+  count, the same way it does not reach into `Session.Server` for the nick.
+  When true, `events` drops the narrow suppressed presence kinds, which can
+  take `severity` off the ladder entirely: a window whose only unread is
+  hidden churn is `:none`, not `:event`. That is the point — a faint badge
+  the operator cannot clear by reading is worse than no badge.
   """
   @spec snapshot(
           Subject.t(),
@@ -118,15 +128,24 @@ defmodule Grappa.WindowCounts do
           String.t(),
           integer() | nil,
           String.t() | nil,
-          [String.t()]
+          [String.t()],
+          boolean()
         ) :: t()
-  def snapshot(subject, network_id, channel, cursor, own_nick, patterns)
+  def snapshot(subject, network_id, channel, cursor, own_nick, patterns, hide_presence)
       when is_integer(network_id) and (is_integer(cursor) or is_nil(cursor)) and
-             (is_binary(own_nick) or is_nil(own_nick)) and is_list(patterns) do
+             (is_binary(own_nick) or is_nil(own_nick)) and is_list(patterns) and
+             is_boolean(hide_presence) do
     after_id = cursor || 0
 
     %{messages: messages, events: events} =
-      Scrollback.count_after_split(subject, network_id, channel, after_id, own_nick)
+      Scrollback.count_after_split(
+        subject,
+        network_id,
+        channel,
+        after_id,
+        own_nick,
+        hide_presence
+      )
 
     mentions = count_mentions(subject, network_id, channel, after_id, own_nick, patterns)
 
@@ -141,13 +160,13 @@ defmodule Grappa.WindowCounts do
   @doc """
   #396 — the WHOLE subject's per-window snapshot map in a CONSTANT number of
   queries (2), independent of window count. Replaces the cold-load
-  (`MeController.build_unread_counts/2`) N × `snapshot/6` fan-out (~2 queries
+  (`MeController.build_unread_counts/2`) N × `snapshot/7` fan-out (~2 queries
   per window, ~100 round trips at a ~50-window logon).
 
   Returns the SAME nested shape the per-window loop built —
   `%{network_slug => %{channel => t()}}` — so `/me`'s `unread_counts`
   envelope is byte-identical for channel + DM-peer windows (the own-nick
-  SELF window count changes by design; see `ReadCursor.bulk_unread_split/2`
+  SELF window count changes by design; see `ReadCursor.bulk_unread_split/3`
   and DESIGN_NOTES 2026-07-25). The subject's own presence rows are excluded
   from `events` (#532 A) — the `own_nicks` threaded below drives that.
 
@@ -155,7 +174,7 @@ defmodule Grappa.WindowCounts do
   `nick_fold(COALESCE(dm_with, channel))` predicate unifies channel + DM
   windows into one join condition, served by the live prod indexes):
 
-    1. `ReadCursor.bulk_unread_split/2` — every window's `%{messages,
+    1. `ReadCursor.bulk_unread_split/3` — every window's `%{messages,
        events}` in one grouped statement (zero-unread windows included,
        nil-cursor windows skipped; own presence rows excluded from `events`
        via `own_nicks`, #532 A);
@@ -171,13 +190,30 @@ defmodule Grappa.WindowCounts do
   converged this onto the live nick (cheap `Registry` lookup) so the
   mention fold follows a `/nick`. A slug with no resolvable nick
   (`nil` own_nick, unbound-but-retained network) folds to `mentions: 0`,
-  the messages/events still counting — mirrors `snapshot/6`'s nil own_nick.
+  the messages/events still counting — mirrors `snapshot/7`'s nil own_nick.
+
+  ## `hidden_channels` (#505)
+
+  `%{network_slug => MapSet.of(channel)}`, resolved ONCE by the caller via
+  `Grappa.PresenceFilter.Resolver.hidden_channels/3` and pushed down into
+  the single split statement — the per-window `events` exclusion rides the
+  existing join condition, so a subject with 50 hiding windows still costs
+  the same two queries. This is the door the #505 symptom is actually
+  reported through: a channel never opened this session is seeded here, not
+  by `snapshot/7`.
+
+  An empty map means "nothing hides", and the exclusion term is then not
+  built at all — the statement is byte-identical to the pre-#505 one.
   """
-  @spec bulk_snapshot(Subject.t(), %{String.t() => {integer(), String.t()}}, [String.t()]) ::
-          %{String.t() => %{String.t() => t()}}
-  def bulk_snapshot(subject, own_nicks, patterns)
-      when is_map(own_nicks) and is_list(patterns) do
-    counts = ReadCursor.bulk_unread_split(subject, own_nicks)
+  @spec bulk_snapshot(
+          Subject.t(),
+          %{String.t() => {integer(), String.t()}},
+          [String.t()],
+          %{String.t() => MapSet.t(String.t())}
+        ) :: %{String.t() => %{String.t() => t()}}
+  def bulk_snapshot(subject, own_nicks, patterns, hidden_channels)
+      when is_map(own_nicks) and is_list(patterns) and is_map(hidden_channels) do
+    counts = ReadCursor.bulk_unread_split(subject, own_nicks, hidden_channels)
     tails = ReadCursor.bulk_unread_content_tails(subject, @mention_scan_cap)
 
     Map.new(counts, fn {slug, per_channel} ->

--- a/lib/grappa/window_counts/push_source.ex
+++ b/lib/grappa/window_counts/push_source.ex
@@ -6,7 +6,7 @@ defmodule Grappa.WindowCounts.PushSource do
   ## Why a behaviour + config injection
 
   `Grappa.Session.Server`'s `apply_effects/2` `:persist` arm wants to
-  push the fresh `WindowCounts.snapshot/6` for a `(subject, network,
+  push the fresh `WindowCounts.snapshot/7` for a `(subject, network,
   channel)` window right after a row lands, so a connected cic renders
   the new count without deriving it. But the snapshot needs the read
   cursor (`Grappa.ReadCursor`), which deps `Networks`, which deps

--- a/lib/grappa/window_counts/pusher.ex
+++ b/lib/grappa/window_counts/pusher.ex
@@ -19,7 +19,7 @@ defmodule Grappa.WindowCounts.Pusher do
   disconnected subject costs nothing. When connected, it spawns an
   unlinked `Task` (like `Push.Triggers`) so the Session hot path never
   blocks on the snapshot's DB work, then `emit/1` computes the fresh
-  `WindowCounts.snapshot/6` (cursor from `ReadCursor`, highlight patterns
+  `WindowCounts.snapshot/7` (cursor from `ReadCursor`, highlight patterns
   from `UserSettings`) and broadcasts the `window_counts` event on the
   per-channel topic. cic replaces its stored snapshot verbatim.
   """
@@ -29,6 +29,7 @@ defmodule Grappa.WindowCounts.Pusher do
   use Boundary,
     top_level?: true,
     deps: [
+      Grappa.PresenceFilter.Resolver,
       Grappa.PubSub,
       Grappa.ReadCursor,
       Grappa.Subject,
@@ -37,6 +38,7 @@ defmodule Grappa.WindowCounts.Pusher do
       Grappa.WSPresence
     ]
 
+  alias Grappa.PresenceFilter.Resolver
   alias Grappa.PubSub.Topic
   alias Grappa.{ReadCursor, UserSettings, WindowCounts, WSPresence}
   alias Grappa.WindowCounts.{PushSource, Wire}
@@ -80,7 +82,23 @@ defmodule Grappa.WindowCounts.Pusher do
         _ -> nil
       end
 
-    counts = WindowCounts.snapshot(subject, network_id, channel, cursor, own_nick, patterns)
+    # #505 — same presence decision the seed doors use, so a live push can
+    # never contradict the `join_reply` / `/me` snapshot it replaces
+    # verbatim in cic's store. Safe from here: `push/1` runs `emit/1` in a
+    # spawned Task, so the `Session.list_members/3` call inside the resolver
+    # is a call INTO the Session from another process, not a self-call.
+    hide_presence = Resolver.hidden?(subject, network_slug, network_id, channel)
+
+    counts =
+      WindowCounts.snapshot(
+        subject,
+        network_id,
+        channel,
+        cursor,
+        own_nick,
+        patterns,
+        hide_presence
+      )
 
     _ =
       Grappa.PubSub.broadcast_event(

--- a/lib/grappa_web.ex
+++ b/lib/grappa_web.ex
@@ -34,7 +34,11 @@ defmodule GrappaWeb do
         Grappa.Notify,
         Grappa.Operator,
         Grappa.OutboundV6Pool,
-        Grappa.PresenceFilter,
+        # #505 — the web edge now reaches the presence decision only through
+        # the resolver (pref + live member count + the rule); the pure rule
+        # module `Grappa.PresenceFilter` sits behind it and is no longer
+        # called from here.
+        Grappa.PresenceFilter.Resolver,
         Grappa.Protocol,
         Grappa.PubSub,
         Grappa.Push,

--- a/lib/grappa_web/channels/grappa_channel.ex
+++ b/lib/grappa_web/channels/grappa_channel.ex
@@ -182,6 +182,7 @@ defmodule GrappaWeb.GrappaChannel do
   alias Grappa.Cic.Wire, as: CicWire
   alias Grappa.IRC.Identifier
   alias Grappa.Networks.Network
+  alias Grappa.PresenceFilter.Resolver
   alias Grappa.PubSub.Topic
   alias Grappa.Scrollback.Wire, as: ScrollbackWire
   alias Grappa.ServerSettings
@@ -293,7 +294,7 @@ defmodule GrappaWeb.GrappaChannel do
   # (no per-channel cursor concept; bulk fetch lives at `/me`).
   #
   # #267 (server-authoritative counters): the reply ALSO carries
-  # `:window_counts` — the full `Grappa.WindowCounts.snapshot/6`
+  # `:window_counts` — the full `Grappa.WindowCounts.snapshot/7`
   # (`%{messages, mentions, events, severity}`) for the window relative to
   # the cursor. This REPLACED the former scalar `:unread_count`: cic now
   # renders the message / mention / event counts + severity colour
@@ -333,13 +334,29 @@ defmodule GrappaWeb.GrappaChannel do
         end
 
       # #267 — the per-channel WS seed is the full server-authoritative
-      # `WindowCounts.snapshot/6` (messages/mentions/events + severity),
+      # `WindowCounts.snapshot/7` (messages/mentions/events + severity),
       # NOT the former scalar unread_count. cic renders these directly and
       # stops deriving counts client-side. cursor == nil → snapshot counts
       # from row 0 (all unread); cic treats `:read_cursor = nil` as "no
       # cursor yet". Highlight patterns feed the mention count (SSOT).
       patterns = UserSettings.get_highlight_patterns(subject)
-      counts = WindowCounts.snapshot(subject, network.id, channel, cursor, own_nick, patterns)
+
+      # #505 — the seed must apply the channel's presence filter, or the
+      # faint `events` count includes rows the pane never renders and drops
+      # the moment cic hydrates. Same resolver the history fetch uses
+      # (#458), so the seed and the page agree on which rows exist.
+      hide_presence = Resolver.hidden?(subject, network.slug, network.id, channel)
+
+      counts =
+        WindowCounts.snapshot(
+          subject,
+          network.id,
+          channel,
+          cursor,
+          own_nick,
+          patterns,
+          hide_presence
+        )
 
       %{read_cursor: cursor, window_counts: counts}
     else

--- a/lib/grappa_web/controllers/me_controller.ex
+++ b/lib/grappa_web/controllers/me_controller.ex
@@ -26,6 +26,7 @@ defmodule GrappaWeb.MeController do
 
   alias Grappa.{AccountDeletion, Networks, ReadCursor, UserSettings, WindowCounts}
   alias Grappa.Networks.Credentials
+  alias Grappa.PresenceFilter.Resolver
   alias Grappa.Push.BadgeCount
   alias GrappaWeb.UserSocket
 
@@ -64,9 +65,9 @@ defmodule GrappaWeb.MeController do
   are absent — cic falls back to the per-channel join-reply seed (bucket
   B1) for those.
 
-  #396 — built via `Grappa.WindowCounts.bulk_snapshot/3` in a CONSTANT
+  #396 — built via `Grappa.WindowCounts.bulk_snapshot/4` in a CONSTANT
   number of queries (2), NOT 2 per window. The old path issued
-  `count_after_split/5` + `unread_content_tail/6` per cursor (~2N ≈ 100
+  `count_after_split/6` + `unread_content_tail/6` per cursor (~2N ≈ 100
   round trips at a ~50-window logon); #393's single
   `nick_fold(COALESCE(dm_with, channel))` predicate unified channel + DM
   windows into ONE `read_cursors ⋈ messages` join (served by the live prod
@@ -195,7 +196,7 @@ defmodule GrappaWeb.MeController do
   end
 
   # Walks the cursor envelope and resolves each (slug, channel, cursor)
-  # to a `count_after_split/5` per-channel pair. Returns the nested
+  # to a `count_after_split/6` per-channel pair. Returns the nested
   # `%{slug => %{channel => %{messages, events}}}` shape that mirrors
   # the cursor envelope; missing slugs (stale cursor referencing a
   # network that's since been deleted) are dropped.
@@ -209,7 +210,7 @@ defmodule GrappaWeb.MeController do
   # from unread_counts"` — is "channels without a cursor are absent;
   # cic falls back to the per-channel join_reply seed (bucket B1)".
   # A nil cursor IS "no cursor", so skipping matches the contract.
-  # Without this guard, `count_after_split/5`'s `is_integer(after_id)`
+  # Without this guard, `count_after_split/6`'s `is_integer(after_id)`
   # head clause throws FunctionClauseError and the entire /me response
   # 500s — cic then has no `user()` value and the Shell renders the
   # cold "select a channel below" placeholder with no admin console.
@@ -221,9 +222,9 @@ defmodule GrappaWeb.MeController do
   defp build_unread_counts(_, cursor_envelope) when map_size(cursor_envelope) == 0,
     do: %{}
 
-  defp build_unread_counts(subject, _) do
+  defp build_unread_counts(subject, cursor_envelope) do
     # #396 — the ENTIRE cold-load unread envelope in a CONSTANT number of
-    # queries (2), not 2 per window. `WindowCounts.bulk_snapshot/3` drives
+    # queries (2), not 2 per window. `WindowCounts.bulk_snapshot/4` drives
     # both the count split and the mention tails from the read cursors via
     # #393's single `nick_fold(COALESCE(dm_with, channel))` predicate (one
     # join condition for channel + DM windows, served by the live prod
@@ -241,6 +242,21 @@ defmodule GrappaWeb.MeController do
     own_nicks = BadgeCount.live_nick_windows(subject)
     patterns = UserSettings.get_highlight_patterns(subject)
 
-    WindowCounts.bulk_snapshot(subject, own_nicks, patterns)
+    # #505 — the presence-hiding decision for EVERY window, resolved once
+    # and pushed into the same split statement. Without it this door seeds
+    # the faint `events` badge with join/part/quit rows the pane will never
+    # render, and the count visibly drops as soon as cic hydrates the
+    # channel and recomputes through `presenceRowVisible`. This is the door
+    # the #505 report describes first: a channel never opened this session
+    # is seeded HERE, not by `snapshot/7`.
+    #
+    # The cursor envelope is threaded in as the window universe — it is what
+    # lets the resolver skip the member-count call for a network whose every
+    # window is explicitly pinned, and it bounds the exclusion list to
+    # windows that can actually produce a row (the split is driven FROM
+    # read_cursors).
+    hidden = Resolver.hidden_channels(subject, own_nicks, cursor_envelope)
+
+    WindowCounts.bulk_snapshot(subject, own_nicks, patterns, hidden)
   end
 end

--- a/lib/grappa_web/controllers/me_json.ex
+++ b/lib/grappa_web/controllers/me_json.ex
@@ -37,7 +37,7 @@ defmodule GrappaWeb.MeJSON do
   Nested map: `%{network_slug => %{channel => %{messages, mentions,
   events, severity}}}`. Same nesting as `read_cursors`; same
   nested-by-network grouping. Built inline by `MeController.show/2` from
-  `Grappa.WindowCounts.snapshot/6` per cursor (#267; slug→id index
+  `Grappa.WindowCounts.snapshot/7` per cursor (#267; slug→id index
   resolved controller-side to keep the count context free of a `Networks`
   dep edge). Channels without a cursor row are absent — cic falls
   back to the per-channel join reply seed (bucket B1) for those. Cic
@@ -76,7 +76,7 @@ defmodule GrappaWeb.MeJSON do
   @typedoc """
   Unread-count envelope: nested `%{slug => %{channel => %{messages,
   mentions, events, severity}}}`. #267 — the per-channel value is the
-  `Grappa.WindowCounts.snapshot/6` result (server-authoritative), so cic
+  `Grappa.WindowCounts.snapshot/7` result (server-authoritative), so cic
   renders the message / mention / event counts + severity colour without
   any client-side count derivation. Mirrors cic `selection.ts`'s
   `ServerWindowCounts` type byte-for-byte.

--- a/lib/grappa_web/controllers/messages_controller.ex
+++ b/lib/grappa_web/controllers/messages_controller.ex
@@ -57,8 +57,9 @@ defmodule GrappaWeb.MessagesController do
   import GrappaWeb.Validation, only: [validate_target_name: 1, validate_post_target_name: 1]
 
   alias Grappa.IRC.Identifier
-  alias Grappa.{PresenceFilter, Scrollback, Session, UserSettings}
+  alias Grappa.PresenceFilter.Resolver
   alias Grappa.RateLimit.TokenBucket
+  alias Grappa.{Scrollback, Session}
   alias GrappaWeb.{BodyLimit, Subject}
 
   @default_limit 50
@@ -327,38 +328,18 @@ defmodule GrappaWeb.MessagesController do
     |> json(%{ok: true})
   end
 
-  # #458 — resolve "should the history reads omit presence for this channel?"
-  # from the server-owned tri-state pref (#449) + live member count. The
-  # server evaluates the tri-state itself (issue paletto: never a client
-  # boolean) so every device converges on one decision. `Session.list_members/3`
-  # is called ONLY when the pref is unset — an explicit show/hide needs no
-  # count, so the common case skips the GenServer round-trip.
-  defp resolve_hide_presence(subject, network, channel) do
-    prefs = UserSettings.get_display_prefs(subject)
-    pref = Map.get(prefs.presence_filter, presence_channel_key(network, channel))
-    PresenceFilter.hidden?(pref, member_count_for_unset(pref, subject, network.id, channel))
-  end
-
-  # Rebuild cic's opaque ChannelKey (`cicchetto/src/lib/channelKey.ts`):
-  # "<slug> <canonical_channel>" — so a request in any casing resolves to the
-  # same stored pin. #537 — `index/2` already network-folded `channel` to the
-  # CASEMAPPING at the ingress, so on rfc1459 this matches cic's ChannelKey
-  # (built from the server's folded key); the fold here is the idempotent
-  # ASCII backstop (bahamut/ascii: byte-identical, prod unchanged).
-  defp presence_channel_key(network, channel),
-    do: "#{network.slug} #{Identifier.canonical_target(channel)}"
-
-  defp member_count_for_unset(nil, subject, network_id, channel) do
-    case Session.list_members(subject, network_id, channel) do
-      {:ok, members} when is_list(members) -> length(members)
-      # :uninitialized (names not yet seeded) or :no_session — count unknowable
-      # → decision D: PresenceFilter.hidden?/2 treats nil as SHOW.
-      _ -> nil
-    end
-  end
-
-  # Explicit show/hide: the count is irrelevant, skip the Session call.
-  defp member_count_for_unset(_, _, _, _), do: nil
+  # #458 — "should the history reads omit presence for this channel?",
+  # resolved from the server-owned tri-state pref (#449) + live member count.
+  # The server evaluates the tri-state itself (issue paletto: never a client
+  # boolean) so every device converges on one decision.
+  #
+  # #505 lifted the resolution out of this controller into
+  # `Grappa.PresenceFilter.Resolver`: the unread seed needs the identical
+  # answer from three more doors (`join_reply`, the per-message push, the
+  # `/me` cold-load), and two of them are not web modules. Four copies of
+  # the same tri-state is how a tri-state becomes four tri-states.
+  defp resolve_hide_presence(subject, network, channel),
+    do: Resolver.hidden?(subject, network.slug, network.id, channel)
 
   # Cursor mutex: at most one of `before` / `after` / `around`. Two or
   # more present together silently picking one would mask client bugs;

--- a/test/grappa/presence_filter/resolver_test.exs
+++ b/test/grappa/presence_filter/resolver_test.exs
@@ -1,0 +1,223 @@
+defmodule Grappa.PresenceFilter.ResolverTest do
+  @moduledoc """
+  #505 — the I/O half of the presence decision: read the server-owned
+  tri-state pref (#449) and the LIVE member count, then apply
+  `Grappa.PresenceFilter.hidden?/2` (the pure rule, #458).
+
+  `PresenceFilter` itself stays dep-free and is unit-tested in
+  `presence_filter_test.exs`; this file covers only what the resolver adds
+  — the pref key derivation, the "count only when unset" call gate, and the
+  bulk `%{slug => MapSet}` fan-out the `/me` cold-load needs.
+
+  `async: false`: the live-count branches need a real `Session.Server`, and
+  Session uses singleton supervisors + Registry (same rationale as
+  `Grappa.Session.ServerTest`).
+  """
+  use Grappa.DataCase, async: false
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.{IRCServer, PresenceFilter, UserSettings}
+  alias Grappa.PresenceFilter.Resolver
+
+  defp welcome_handler do
+    fn state, line ->
+      if String.starts_with?(line, "USER ") do
+        {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
+      else
+        {:reply, nil, state}
+      end
+    end
+  end
+
+  defp start_server do
+    {:ok, server} = IRCServer.start_link(welcome_handler())
+    {server, IRCServer.port(server)}
+  end
+
+  # A live session joined to `channel` with exactly `n` members seeded via a
+  # 353/366 NAMES burst. Returns `{network, pid, server}`.
+  defp session_with_members(user, channel, n) do
+    {server, port} = start_server()
+    slug = "az-#{System.unique_integer([:positive])}"
+    {network, _} = network_with_server(port: port, slug: slug)
+
+    _ =
+      credential_fixture(user, network, %{nick: "grappa-test", autojoin_channels: [channel]})
+
+    pid = start_session_for(user, network)
+
+    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "USER"), 1_000)
+    {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
+
+    IRCServer.feed(server, ":grappa-test!u@h JOIN :#{channel}\r\n")
+
+    # The self-JOIN already seeds `grappa-test`, so the burst supplies the
+    # remaining n-1 nicks and the count lands exactly on `n`.
+    nicks = Enum.map_join(1..(n - 1), " ", &"peer#{&1}")
+    IRCServer.feed(server, ":irc 353 grappa-test = #{channel} :grappa-test #{nicks}\r\n")
+    IRCServer.feed(server, ":irc 366 grappa-test #{channel} :End\r\n")
+    IRCServer.feed(server, "PING :flush\r\n")
+    {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "PONG :flush\r\n"), 1_000)
+
+    {network, pid}
+  end
+
+  defp pin(subject, key, value) do
+    prefs = UserSettings.get_display_prefs(subject)
+
+    {:ok, _} =
+      UserSettings.put_display_prefs(
+        subject,
+        %{prefs | presence_filter: Map.put(prefs.presence_filter, key, value)}
+      )
+
+    :ok
+  end
+
+  # The composite pref key, pinned LITERALLY here on purpose. It is a
+  # cross-stack contract with cic's `channelKey(slug, name)`
+  # (`cicchetto/src/lib/channelKey.ts`: `${slug} ${canonicalChannel(name)}`),
+  # so deriving it from the production helper would make this test agree with
+  # whatever the server does — including a drift that silently orphans every
+  # pin an operator has already saved.
+  defp key(slug, channel), do: "#{slug} #{channel}"
+
+  describe "hidden?/4 — single window" do
+    test ~s(an explicit "hide" pin hides, with no session and no member count) do
+      user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
+      subject = {:user, user.id}
+      {network, _} = network_with_server(port: 6667, slug: "az-#{System.unique_integer([:positive])}")
+
+      :ok = pin(subject, key(network.slug, "#chan"), "hide")
+
+      assert Resolver.hidden?(subject, network.slug, network.id, "#chan")
+    end
+
+    test "an unset channel with no live session SHOWS (decision D, #458)" do
+      user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
+      subject = {:user, user.id}
+      {network, _} = network_with_server(port: 6667, slug: "az-#{System.unique_integer([:positive])}")
+
+      refute Resolver.hidden?(subject, network.slug, network.id, "#chan")
+    end
+
+    test "the pin is looked up under the FOLDED channel, whatever casing is asked" do
+      user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
+      subject = {:user, user.id}
+      {network, _} = network_with_server(port: 6667, slug: "az-#{System.unique_integer([:positive])}")
+
+      :ok = pin(subject, key(network.slug, "#chan"), "hide")
+
+      assert Resolver.hidden?(subject, network.slug, network.id, "#CHAN")
+    end
+
+    test "a pin on ANOTHER network's same-named channel does not apply" do
+      user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
+      subject = {:user, user.id}
+      {net_a, _} = network_with_server(port: 6667, slug: "az-#{System.unique_integer([:positive])}")
+      {net_b, _} = network_with_server(port: 6667, slug: "az-#{System.unique_integer([:positive])}")
+
+      :ok = pin(subject, key(net_a.slug, "#chan"), "hide")
+
+      assert Resolver.hidden?(subject, net_a.slug, net_a.id, "#chan")
+      refute Resolver.hidden?(subject, net_b.slug, net_b.id, "#chan")
+    end
+
+    test "an unset channel at or above the threshold hides by the size default" do
+      user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
+      subject = {:user, user.id}
+      big = PresenceFilter.large_channel_threshold()
+      {network, pid} = session_with_members(user, "#big", big)
+
+      assert Resolver.hidden?(subject, network.slug, network.id, "#big")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "an unset channel below the threshold shows" do
+      user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
+      subject = {:user, user.id}
+      small = PresenceFilter.large_channel_threshold() - 1
+      {network, pid} = session_with_members(user, "#small", small)
+
+      refute Resolver.hidden?(subject, network.slug, network.id, "#small")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # The whole point of the tri-state: an explicit choice beats the size
+    # default in BOTH directions. Without a live oversized channel this
+    # assertion is vacuous, which is why it needs the session.
+    test ~s(an explicit "show" pin beats the size default on an oversized channel) do
+      user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
+      subject = {:user, user.id}
+      big = PresenceFilter.large_channel_threshold()
+      {network, pid} = session_with_members(user, "#big", big)
+
+      :ok = pin(subject, key(network.slug, "#big"), "show")
+
+      refute Resolver.hidden?(subject, network.slug, network.id, "#big")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+
+  describe "hidden_channels/2 — the /me cold-load fan-out" do
+    test "is the union of explicit hides and oversized unset channels, by slug" do
+      user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
+      subject = {:user, user.id}
+      big = PresenceFilter.large_channel_threshold()
+      {network, pid} = session_with_members(user, "#big", big)
+
+      # A small channel on the same live session: joined, seeded, under the
+      # threshold — must stay OUT of the set.
+      :ok = pin(subject, key(network.slug, "#pinned"), "hide")
+
+      hidden = Resolver.hidden_channels(subject, %{network.slug => {network.id, "grappa-test"}})
+
+      assert MapSet.member?(hidden[network.slug], "#big")
+      assert MapSet.member?(hidden[network.slug], "#pinned")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test ~s(an explicit "show" on an oversized channel is EXCLUDED from the set) do
+      user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
+      subject = {:user, user.id}
+      big = PresenceFilter.large_channel_threshold()
+      {network, pid} = session_with_members(user, "#big", big)
+
+      :ok = pin(subject, key(network.slug, "#big"), "show")
+
+      hidden = Resolver.hidden_channels(subject, %{network.slug => {network.id, "grappa-test"}})
+
+      refute MapSet.member?(Map.get(hidden, network.slug, MapSet.new()), "#big")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "with no live session, only the explicit hides survive" do
+      user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
+      subject = {:user, user.id}
+      {network, _} = network_with_server(port: 6667, slug: "az-#{System.unique_integer([:positive])}")
+
+      :ok = pin(subject, key(network.slug, "#pinned"), "hide")
+      :ok = pin(subject, key(network.slug, "#shown"), "show")
+
+      # `own_nicks` carries only LIVE networks (`BadgeCount.live_nick_windows/1`),
+      # so this network is absent from it — the pin must still be honoured,
+      # because a pref outlives the session that motivated it.
+      hidden = Resolver.hidden_channels(subject, %{})
+
+      assert MapSet.member?(hidden[network.slug], "#pinned")
+      refute MapSet.member?(hidden[network.slug], "#shown")
+    end
+
+    test "a subject with no pins and no sessions yields an empty map" do
+      user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
+
+      assert Resolver.hidden_channels({:user, user.id}, %{}) == %{}
+    end
+  end
+end

--- a/test/grappa/presence_filter/resolver_test.exs
+++ b/test/grappa/presence_filter/resolver_test.exs
@@ -163,21 +163,28 @@ defmodule Grappa.PresenceFilter.ResolverTest do
     end
   end
 
-  describe "hidden_channels/2 — the /me cold-load fan-out" do
+  describe "hidden_channels/3 — the /me cold-load fan-out" do
     test "is the union of explicit hides and oversized unset channels, by slug" do
       user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
       subject = {:user, user.id}
       big = PresenceFilter.large_channel_threshold()
       {network, pid} = session_with_members(user, "#big", big)
 
-      # A small channel on the same live session: joined, seeded, under the
-      # threshold — must stay OUT of the set.
       :ok = pin(subject, key(network.slug, "#pinned"), "hide")
 
-      hidden = Resolver.hidden_channels(subject, %{network.slug => {network.id, "grappa-test"}})
+      hidden =
+        Resolver.hidden_channels(
+          subject,
+          %{network.slug => {network.id, "grappa-test"}},
+          %{network.slug => %{"#big" => 1, "#pinned" => 2, "#quiet" => 3}}
+        )
 
+      # `#big` hides by the size default (unset, oversized), `#pinned` by the
+      # explicit pin — two different routes into the same set.
       assert MapSet.member?(hidden[network.slug], "#big")
       assert MapSet.member?(hidden[network.slug], "#pinned")
+      # `#quiet` is unset with no live count (never joined) → decision D.
+      refute MapSet.member?(hidden[network.slug], "#quiet")
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
@@ -190,7 +197,12 @@ defmodule Grappa.PresenceFilter.ResolverTest do
 
       :ok = pin(subject, key(network.slug, "#big"), "show")
 
-      hidden = Resolver.hidden_channels(subject, %{network.slug => {network.id, "grappa-test"}})
+      hidden =
+        Resolver.hidden_channels(
+          subject,
+          %{network.slug => {network.id, "grappa-test"}},
+          %{network.slug => %{"#big" => 1}}
+        )
 
       refute MapSet.member?(Map.get(hidden, network.slug, MapSet.new()), "#big")
 
@@ -200,7 +212,9 @@ defmodule Grappa.PresenceFilter.ResolverTest do
     test "with no live session, only the explicit hides survive" do
       user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
       subject = {:user, user.id}
-      {network, _} = network_with_server(port: 6667, slug: "az-#{System.unique_integer([:positive])}")
+
+      {network, _} =
+        network_with_server(port: 6667, slug: "az-#{System.unique_integer([:positive])}")
 
       :ok = pin(subject, key(network.slug, "#pinned"), "hide")
       :ok = pin(subject, key(network.slug, "#shown"), "show")
@@ -208,16 +222,89 @@ defmodule Grappa.PresenceFilter.ResolverTest do
       # `own_nicks` carries only LIVE networks (`BadgeCount.live_nick_windows/1`),
       # so this network is absent from it — the pin must still be honoured,
       # because a pref outlives the session that motivated it.
-      hidden = Resolver.hidden_channels(subject, %{})
+      hidden =
+        Resolver.hidden_channels(
+          subject,
+          %{},
+          %{network.slug => %{"#pinned" => 1, "#shown" => 2}}
+        )
 
       assert MapSet.member?(hidden[network.slug], "#pinned")
       refute MapSet.member?(hidden[network.slug], "#shown")
     end
 
-    test "a subject with no pins and no sessions yields an empty map" do
+    test "a channel with a pin but NO window is not in the set" do
+      user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
+      subject = {:user, user.id}
+
+      {network, _} =
+        network_with_server(port: 6667, slug: "az-#{System.unique_integer([:positive])}")
+
+      :ok = pin(subject, key(network.slug, "#pinned"), "hide")
+
+      # The bulk split is driven FROM read_cursors, so a channel with no
+      # cursor produces no row to exclude. Carrying it would only inflate
+      # the SQL `IN` list.
+      assert Resolver.hidden_channels(subject, %{}, %{}) == %{}
+    end
+
+    test "a subject with no pins and no windows yields an empty map" do
       user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
 
-      assert Resolver.hidden_channels({:user, user.id}, %{}) == %{}
+      assert Resolver.hidden_channels({:user, user.id}, %{}, %{}) == %{}
+    end
+  end
+
+  # The member count is only ever consulted for an UNSET window. When a
+  # network has none, asking for it is pure waste — and "we skip the call"
+  # is invisible in the RESULT (a fully pinned network decides identically
+  # either way), so it has to be measured at the mailbox or not claimed.
+  #
+  # These two tests are the same setup with ONE variable moved: whether the
+  # second window carries a pin. If the guard were absent, both would see
+  # the call; if the guard were over-eager, neither would.
+  describe "hidden_channels/3 — the member-count call is skipped when useless" do
+    setup do
+      user = user_fixture(name: "vjt-#{System.unique_integer([:positive])}")
+      subject = {:user, user.id}
+      {network, pid} = session_with_members(user, "#big", PresenceFilter.large_channel_threshold())
+      # No teardown: the trace flag lives ON the traced process, so it dies
+      # with the session the test body stops. Untracing in `on_exit` would
+      # run AFTER that and raise on a dead pid.
+      :erlang.trace(pid, true, [:receive])
+
+      %{subject: subject, network: network, pid: pid}
+    end
+
+    test "asks the session when at least one window is unset", ctx do
+      :ok = pin(ctx.subject, key(ctx.network.slug, "#big"), "hide")
+
+      _ =
+        Resolver.hidden_channels(
+          ctx.subject,
+          %{ctx.network.slug => {ctx.network.id, "grappa-test"}},
+          %{ctx.network.slug => %{"#big" => 1, "#unpinned" => 2}}
+        )
+
+      assert_receive {:trace, _, :receive, {:"$gen_call", _, :list_member_counts}}, 500
+
+      :ok = GenServer.stop(ctx.pid, :normal, 1_000)
+    end
+
+    test "does NOT ask the session when every window is pinned", ctx do
+      :ok = pin(ctx.subject, key(ctx.network.slug, "#big"), "hide")
+      :ok = pin(ctx.subject, key(ctx.network.slug, "#unpinned"), "show")
+
+      _ =
+        Resolver.hidden_channels(
+          ctx.subject,
+          %{ctx.network.slug => {ctx.network.id, "grappa-test"}},
+          %{ctx.network.slug => %{"#big" => 1, "#unpinned" => 2}}
+        )
+
+      refute_receive {:trace, _, :receive, {:"$gen_call", _, :list_member_counts}}, 300
+
+      :ok = GenServer.stop(ctx.pid, :normal, 1_000)
     end
   end
 end

--- a/test/grappa/read_cursor_test.exs
+++ b/test/grappa/read_cursor_test.exs
@@ -55,7 +55,7 @@ defmodule Grappa.ReadCursorTest do
 
   # Generic unread-content inserter: `sender: "peer"` so a row stands for
   # someone ELSE's message. #576 excludes the subject's OWN content from the
-  # unread count, and every `bulk_unread_split/2` test here threads
+  # unread count, and every `bulk_unread_split/3` test here threads
   # `own_nicks` as "vjt" — a "vjt" sender would fold to own and drop out,
   # silently zeroing the very counts these tests assert. Own-authored rows
   # are inserted explicitly (see the #532 A / #576 tests).
@@ -940,7 +940,7 @@ defmodule Grappa.ReadCursorTest do
       # outbound line + a peer reply. The reported bug is a DM badge whose
       # count is only the operator's own lines — content is read BY
       # DEFINITION, so the #396 cold-load twin must strip it exactly as
-      # count_after_split/5 does (one rule, both count doors).
+      # count_after_split/6 does (one rule, both count doors).
       a = dm_row(attrs, net.id, "vjt", "peer", 1, "anchor")
       {:ok, _} = ReadCursor.set(subject, net.id, "peer", a.id)
 

--- a/test/grappa/read_cursor_test.exs
+++ b/test/grappa/read_cursor_test.exs
@@ -812,7 +812,7 @@ defmodule Grappa.ReadCursorTest do
       {:ok, _} = ReadCursor.set(subject, net_b.id, "#ops", b.id)
 
       own_nicks = %{net_a.slug => {net_a.id, "vjt"}, net_b.slug => {net_b.id, "vjt"}}
-      split = ReadCursor.bulk_unread_split(subject, own_nicks)
+      split = ReadCursor.bulk_unread_split(subject, own_nicks, %{})
 
       assert split[net_a.slug]["#chan"] == %{messages: 2, events: 1}
       assert split[net_a.slug]["peer"] == %{messages: 1, events: 0}
@@ -829,13 +829,13 @@ defmodule Grappa.ReadCursorTest do
 
       own_nicks = %{net.slug => {net.id, "vjt"}}
 
-      assert ReadCursor.bulk_unread_split(subject, own_nicks)[net.slug]["#chan"] ==
+      assert ReadCursor.bulk_unread_split(subject, own_nicks, %{})[net.slug]["#chan"] ==
                %{messages: 0, events: 0}
     end
 
     test "returns an empty envelope for a subject with no cursors" do
       user = user_fixture()
-      assert ReadCursor.bulk_unread_split({:user, user.id}, %{}) == %{}
+      assert ReadCursor.bulk_unread_split({:user, user.id}, %{}, %{}) == %{}
     end
 
     test "excludes the subject's OWN presence rows from events (#532 A)" do
@@ -877,7 +877,7 @@ defmodule Grappa.ReadCursorTest do
 
       own_nicks = %{net.slug => {net.id, "vjt"}}
 
-      assert ReadCursor.bulk_unread_split(subject, own_nicks)[net.slug]["#chan"] ==
+      assert ReadCursor.bulk_unread_split(subject, own_nicks, %{})[net.slug]["#chan"] ==
                %{messages: 0, events: 1}
     end
 
@@ -926,7 +926,7 @@ defmodule Grappa.ReadCursorTest do
 
       own_nicks = %{net.slug => {net.id, "vjt"}}
 
-      assert ReadCursor.bulk_unread_split(subject, own_nicks)[net.slug]["#chan"] ==
+      assert ReadCursor.bulk_unread_split(subject, own_nicks, %{})[net.slug]["#chan"] ==
                %{messages: 0, events: 1}
     end
 
@@ -963,7 +963,7 @@ defmodule Grappa.ReadCursorTest do
 
       own_nicks = %{net.slug => {net.id, "vjt"}}
 
-      assert ReadCursor.bulk_unread_split(subject, own_nicks)[net.slug]["peer"] ==
+      assert ReadCursor.bulk_unread_split(subject, own_nicks, %{})[net.slug]["peer"] ==
                %{messages: 1, events: 0}
     end
 
@@ -996,7 +996,7 @@ defmodule Grappa.ReadCursorTest do
 
       own_nicks = %{net.slug => {net.id, "vjt"}}
 
-      assert ReadCursor.bulk_unread_split(subject, own_nicks)[net.slug]["#chan"] ==
+      assert ReadCursor.bulk_unread_split(subject, own_nicks, %{})[net.slug]["#chan"] ==
                %{messages: 1, events: 0}
     end
 
@@ -1041,7 +1041,7 @@ defmodule Grappa.ReadCursorTest do
 
       own_nicks = %{net.slug => {net.id, "vjt"}}
 
-      assert ReadCursor.bulk_unread_split(subject, own_nicks)[net.slug]["vjt"] ==
+      assert ReadCursor.bulk_unread_split(subject, own_nicks, %{})[net.slug]["vjt"] ==
                %{messages: 1, events: 0}
     end
   end

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -49,17 +49,20 @@ defmodule Grappa.ScrollbackTest do
   # rather than restated: a kind moving between `@content_kinds` /
   # `@suppressed_presence_kinds` must break the count assertions by CHANGING
   # THE NUMBERS, not silently agree with a hand-copied list.
+  # Every row carries a body, including the presence kinds that would
+  # normally persist `body: nil`. `Message.@body_required_kinds` is
+  # `content_kinds ∪ [:topic]`, and restating that here would be a second
+  # copy of a production list — while the changeset ACCEPTS a body on every
+  # kind, and these tests bucket rows by KIND and never read a body. So the
+  # uniform body is the choice that keeps the helper from forking an SSOT.
   defp seed_one_row_per_kind(user, net) do
     Message.kinds()
     |> Enum.with_index()
     |> Enum.each(fn {kind, i} ->
-      body = if kind in Message.content_kinds(), do: "msg #{i}", else: nil
       meta = if kind == :nick_change, do: %{new_nick: "bob#{i}"}, else: %{}
 
       {:ok, _} =
-        ScrollbackHelpers.insert(
-          sample(user, net, i, %{kind: kind, sender: "bob", body: body, meta: meta})
-        )
+        ScrollbackHelpers.insert(sample(user, net, i, %{kind: kind, sender: "bob", body: "row #{i}", meta: meta}))
     end)
   end
 
@@ -113,7 +116,7 @@ defmodule Grappa.ScrollbackTest do
   # (subject, network, <target>, id > cursor) grouped by content-vs-event
   # kind. Target-agnostic — `channel_or_dm_where/3` dispatches to the
   # `m.channel == ?` (channel) OR the folded-COALESCE `where_dm_peer/2` (DM)
-  # branch, so this proves BOTH count_after_split/5 paths are covered by the
+  # branch, so this proves BOTH count_after_split/6 paths are covered by the
   # respective `..._id_kind` index (kind at the tail = no per-row table
   # fetch). `kind` is read by the GROUP BY, so a covering plan requires it in
   # the index — this is the regression guard for the kind-at-tail claim.
@@ -1033,7 +1036,7 @@ defmodule Grappa.ScrollbackTest do
   end
 
   # The gap probe behind #693 (was the 2026-06-01 unread-badge primitive;
-  # the badge moved to `count_after_split/5` via `WindowCounts`). Mirrors
+  # the badge moved to `count_after_split/6` via `WindowCounts`). Mirrors
   # `fetch_after/7`'s predicate — presence filter included — so the count
   # is exactly what an uncapped fetch would hand the same caller.
   describe "count_after/6" do
@@ -1200,11 +1203,11 @@ defmodule Grappa.ScrollbackTest do
     end
   end
 
-  # Bucket C (2026-06-01) — `count_after_split/5` returns the count
+  # Bucket C (2026-06-01) — `count_after_split/6` returns the count
   # split into `%{messages, events}` via a single CASE-WHEN GROUP BY.
   # cic's `serverSeedCounts` consumes this shape (each badge renders
   # messages bold + events faint separately).
-  describe "count_after_split/5" do
+  describe "count_after_split/6" do
     test "zero cursor splits all rows by content vs presence kind",
          %{user: user, network: net} do
       {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 0, %{kind: :privmsg}))
@@ -1214,13 +1217,13 @@ defmodule Grappa.ScrollbackTest do
       {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 4, %{kind: :part, body: nil}))
       {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 5, %{kind: :quit, body: nil}))
 
-      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 0, nil) ==
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 0, nil, false) ==
                %{messages: 3, events: 3}
     end
 
     test "returns %{messages: 0, events: 0} for empty partition",
          %{user: user, network: net} do
-      assert Scrollback.count_after_split({:user, user.id}, net.id, "#empty", 0, nil) ==
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "#empty", 0, nil, false) ==
                %{messages: 0, events: 0}
     end
 
@@ -1228,7 +1231,7 @@ defmodule Grappa.ScrollbackTest do
          %{user: user, network: net} do
       for i <- 0..2, do: {:ok, _} = ScrollbackHelpers.insert(sample(user, net, i))
 
-      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 999_999_999, nil) ==
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 999_999_999, nil, false) ==
                %{messages: 0, events: 0}
     end
 
@@ -1238,7 +1241,7 @@ defmodule Grappa.ScrollbackTest do
       {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 1, %{kind: :join, body: nil}))
       {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 2, %{kind: :privmsg}))
 
-      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", m0.id, nil) ==
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", m0.id, nil, false) ==
                %{messages: 1, events: 1}
     end
 
@@ -1247,7 +1250,7 @@ defmodule Grappa.ScrollbackTest do
       {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 0, %{kind: :privmsg}))
       {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 1, %{kind: :notice}))
 
-      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 0, nil) ==
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 0, nil, false) ==
                %{messages: 2, events: 0}
     end
 
@@ -1256,7 +1259,7 @@ defmodule Grappa.ScrollbackTest do
       {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 0, %{kind: :join, body: nil}))
       {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 1, %{kind: :mode, body: nil}))
 
-      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 0, nil) ==
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 0, nil, false) ==
                %{messages: 0, events: 2}
     end
 
@@ -1321,7 +1324,7 @@ defmodule Grappa.ScrollbackTest do
       # live own_nick would let #576's own-content exclusion drop the
       # outbound row and confound the arm-count — that exclusion has its own
       # tests below.
-      assert Scrollback.count_after_split({:user, user.id}, net.id, "peer", 0, nil) ==
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "peer", 0, nil, false) ==
                %{messages: 3, events: 1}
     end
 
@@ -1345,7 +1348,7 @@ defmodule Grappa.ScrollbackTest do
       {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 2, %{kind: :privmsg, sender: "peer"}))
 
       # own_nick threaded → only the peer content row counts.
-      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 0, "vjt-grappa") ==
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 0, "vjt-grappa", false) ==
                %{messages: 1, events: 0}
     end
 
@@ -1358,7 +1361,7 @@ defmodule Grappa.ScrollbackTest do
 
       {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 1, %{kind: :privmsg, sender: "peer"}))
 
-      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 0, "vjt-grappa") ==
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 0, "vjt-grappa", false) ==
                %{messages: 1, events: 0}
     end
 
@@ -1370,7 +1373,7 @@ defmodule Grappa.ScrollbackTest do
       {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 1, %{kind: :privmsg, sender: "peer"}))
 
       # Unbound network / no live session → nothing to fold → both count.
-      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 0, nil) ==
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 0, nil, false) ==
                %{messages: 2, events: 0}
     end
 
@@ -1394,7 +1397,7 @@ defmodule Grappa.ScrollbackTest do
           dm_with: "vjt-grappa"
         })
 
-      assert Scrollback.count_after_split({:user, user.id}, net.id, "vjt-grappa", 0, "vjt-grappa") ==
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "vjt-grappa", 0, "vjt-grappa", false) ==
                %{messages: 1, events: 0}
     end
   end
@@ -1442,9 +1445,7 @@ defmodule Grappa.ScrollbackTest do
         meta = if kind == :nick_change, do: %{new_nick: "bob#{i}"}, else: %{}
 
         {:ok, _} =
-          ScrollbackHelpers.insert(
-            sample(user, net, i, %{kind: kind, sender: "bob", body: nil, meta: meta})
-          )
+          ScrollbackHelpers.insert(sample(user, net, i, %{kind: kind, sender: "bob", body: nil, meta: meta}))
       end
 
       assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 0, nil, true) ==
@@ -1459,7 +1460,10 @@ defmodule Grappa.ScrollbackTest do
       {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 0, %{kind: :join, body: nil}))
       {:ok, m1} = ScrollbackHelpers.insert(sample(user, net, 1, %{kind: :privmsg}))
       {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 2, %{kind: :part, body: nil}))
-      {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 3, %{kind: :topic, body: nil}))
+      # `:topic` is body-required (`Message.@body_required_kinds`) — it is a
+      # CONTROL row that carries text, which is exactly why it must survive
+      # the hide: the pane renders it.
+      {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 3, %{kind: :topic, body: "new topic"}))
 
       assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", m1.id, nil, false) ==
                %{messages: 0, events: 2}
@@ -2132,11 +2136,11 @@ defmodule Grappa.ScrollbackTest do
 
   # #393 A — channel unread-count covering index (kind at the tail).
   #
-  # `count_after_split/5` for a CHANNEL window is a GROUP BY aggregate with
+  # `count_after_split/6` for a CHANNEL window is a GROUP BY aggregate with
   # NO LIMIT over `(subject, network_id, channel, id > cursor)` reading
   # `kind` per row. Appending `kind` to the `(subject, network, channel, id)`
   # composite makes it COVERING (prod 2026-07-25: 80ms → 6ms, ~15x, via
-  # WindowCounts.snapshot/6 ← MeController.build_unread_counts/2). The new
+  # WindowCounts.snapshot/7 ← MeController.build_unread_counts/2). The new
   # index shares the old one's prefix, so the redundant `..._channel_id_index`
   # composites are dropped. Both covering indexes were applied LIVE on prod
   # 07:52 UTC under the EXACT names asserted here; the migration reconciles
@@ -3031,7 +3035,7 @@ defmodule Grappa.ScrollbackTest do
   # #379 (P0, 2026-07-22) — CP29 R-2 index regression. R-2 switched the
   # scrollback since-cursor key from `server_time` to monotonic `id`, so
   # every incremental read path — `fetch_after/6`, `count_after/6`,
-  # `count_after_split/5`, `unread_content_tail/6` — now filters
+  # `count_after_split/6`, `unread_content_tail/6` — now filters
   # `id > cursor ORDER BY id`. But the `messages` composites all still
   # END in `server_time`, so `id > ?` was NOT index-eligible: SQLite fell
   # back to scanning the busiest network's post-cursor rows (via

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -45,6 +45,24 @@ defmodule Grappa.ScrollbackTest do
     )
   end
 
+  # #505 — one row per kind in `Message.kinds/0`, read from the schema SSOT
+  # rather than restated: a kind moving between `@content_kinds` /
+  # `@suppressed_presence_kinds` must break the count assertions by CHANGING
+  # THE NUMBERS, not silently agree with a hand-copied list.
+  defp seed_one_row_per_kind(user, net) do
+    Message.kinds()
+    |> Enum.with_index()
+    |> Enum.each(fn {kind, i} ->
+      body = if kind in Message.content_kinds(), do: "msg #{i}", else: nil
+      meta = if kind == :nick_change, do: %{new_nick: "bob#{i}"}, else: %{}
+
+      {:ok, _} =
+        ScrollbackHelpers.insert(
+          sample(user, net, i, %{kind: kind, sender: "bob", body: body, meta: meta})
+        )
+    end)
+  end
+
   # #393 — EXPLAIN QUERY PLAN text for an Ecto query, rendered from the
   # PRODUCTION SQL (`Repo.to_sql`) so the plan reflects exactly what runs.
   defp explain_plan(query) do
@@ -1378,6 +1396,76 @@ defmodule Grappa.ScrollbackTest do
 
       assert Scrollback.count_after_split({:user, user.id}, net.id, "vjt-grappa", 0, "vjt-grappa") ==
                %{messages: 1, events: 0}
+    end
+  end
+
+  # #505 — the unread SEED must apply the same presence filter the fetch
+  # applies (#458), or a hiding channel's faint `events` badge counts rows the
+  # pane will never render and visibly DROPS the moment the channel hydrates.
+  # `hide_presence` here is the exact twin of `count_after/6`'s: same narrow
+  # kind set (`Message.suppressed_presence_kinds/0`), same required-positional
+  # rule (no defaulting wrapper).
+  describe "count_after_split/6 — hide_presence (#505)" do
+    test "hiding drops ONLY the narrow suppressed kinds from events",
+         %{user: user, network: net} do
+      seed_one_row_per_kind(user, net)
+
+      content = length(Message.content_kinds())
+      suppressed = length(Message.suppressed_presence_kinds())
+      all_events = length(Message.kinds()) - content
+
+      # The set is non-trivial in BOTH directions, else the two asserts below
+      # cannot tell "narrow filter" from "events bucket zeroed".
+      assert suppressed > 0
+      assert all_events > suppressed
+
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 0, nil, false) ==
+               %{messages: content, events: all_events}
+
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 0, nil, true) ==
+               %{messages: content, events: all_events - suppressed}
+    end
+
+    test "hiding never touches the content bucket", %{user: user, network: net} do
+      {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 0, %{kind: :privmsg}))
+      {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 1, %{kind: :notice}))
+      {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 2, %{kind: :action}))
+      {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 3, %{kind: :join, body: nil}))
+
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 0, nil, true) ==
+               %{messages: 3, events: 0}
+    end
+
+    test "a channel whose only unread is hidden presence seeds events: 0",
+         %{user: user, network: net} do
+      for {kind, i} <- Enum.with_index(Message.suppressed_presence_kinds()) do
+        meta = if kind == :nick_change, do: %{new_nick: "bob#{i}"}, else: %{}
+
+        {:ok, _} =
+          ScrollbackHelpers.insert(
+            sample(user, net, i, %{kind: kind, sender: "bob", body: nil, meta: meta})
+          )
+      end
+
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", 0, nil, true) ==
+               %{messages: 0, events: 0}
+    end
+
+    # The filter must ride the SAME cursor predicate, not replace it: a
+    # suppressed row BELOW the cursor was already excluded, so hiding must not
+    # change the answer for the read region.
+    test "hide_presence composes with the after_id predicate",
+         %{user: user, network: net} do
+      {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 0, %{kind: :join, body: nil}))
+      {:ok, m1} = ScrollbackHelpers.insert(sample(user, net, 1, %{kind: :privmsg}))
+      {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 2, %{kind: :part, body: nil}))
+      {:ok, _} = ScrollbackHelpers.insert(sample(user, net, 3, %{kind: :topic, body: nil}))
+
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", m1.id, nil, false) ==
+               %{messages: 0, events: 2}
+
+      assert Scrollback.count_after_split({:user, user.id}, net.id, "#sniffo", m1.id, nil, true) ==
+               %{messages: 0, events: 1}
     end
   end
 

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -5430,8 +5430,21 @@ defmodule Grappa.Session.ServerTest do
   # `list_members/3` would be one GenServer call per channel at logon, which
   # is exactly the per-window fan-out #396 collapsed. One call, whole map.
   describe "list_member_counts/2" do
+    # The file's default `start_server/0` is a PASSTHROUGH: it never answers
+    # 001, so registration never completes and no JOIN is ever sent. These
+    # tests need the session to actually reach the channels.
+    defp counts_welcome_handler do
+      fn state, line ->
+        if String.starts_with?(line, "USER ") do
+          {:reply, ":irc 001 grappa-test :Welcome\r\n", state}
+        else
+          {:reply, nil, state}
+        end
+      end
+    end
+
     test "returns the count per SEEDED channel in one call" do
-      {server, port} = start_server()
+      {server, port} = start_server(counts_welcome_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#one", "#two"]})
@@ -5461,7 +5474,7 @@ defmodule Grappa.Session.ServerTest do
     # twin must OMIT the key, or the caller reads 0 members and shows presence
     # on a channel that is about to turn out to have 900.
     test "omits a channel that has not yet observed 366 (pre-NAMES)" do
-      {server, port} = start_server()
+      {server, port} = start_server(counts_welcome_handler())
 
       {user, network, _} =
         setup_user_and_network(port, %{autojoin_channels: ["#seeded", "#pending"]})

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -5425,6 +5425,78 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  # #505 — the /me cold-load needs the member count for EVERY window at once
+  # to resolve the presence-hiding size default. Doing it with
+  # `list_members/3` would be one GenServer call per channel at logon, which
+  # is exactly the per-window fan-out #396 collapsed. One call, whole map.
+  describe "list_member_counts/2" do
+    test "returns the count per SEEDED channel in one call" do
+      {server, port} = start_server()
+
+      {user, network, _} =
+        setup_user_and_network(port, %{autojoin_channels: ["#one", "#two"]})
+
+      pid = start_session_for(user, network)
+
+      :ok = await_handshake(server)
+      {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
+
+      IRCServer.feed(server, ":grappa-test!u@h JOIN :#one\r\n")
+      IRCServer.feed(server, ":irc 353 grappa-test = #one :grappa-test alice bob\r\n")
+      IRCServer.feed(server, ":irc 366 grappa-test #one :End\r\n")
+      IRCServer.feed(server, ":grappa-test!u@h JOIN :#two\r\n")
+      IRCServer.feed(server, ":irc 353 grappa-test = #two :grappa-test carol\r\n")
+      IRCServer.feed(server, ":irc 366 grappa-test #two :End\r\n")
+      IRCServer.feed(server, "PING :flush\r\n")
+      {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "PONG :flush\r\n"), 1_000)
+
+      assert {:ok, %{"#one" => 3, "#two" => 2}} =
+               Session.list_member_counts({:user, user.id}, network.id)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # A channel joined but pre-NAMES has an UNKNOWABLE count, not a count of
+    # zero. `list_members/3` discriminates that as `:uninitialized`; the bulk
+    # twin must OMIT the key, or the caller reads 0 members and shows presence
+    # on a channel that is about to turn out to have 900.
+    test "omits a channel that has not yet observed 366 (pre-NAMES)" do
+      {server, port} = start_server()
+
+      {user, network, _} =
+        setup_user_and_network(port, %{autojoin_channels: ["#seeded", "#pending"]})
+
+      pid = start_session_for(user, network)
+
+      :ok = await_handshake(server)
+      {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
+
+      IRCServer.feed(server, ":grappa-test!u@h JOIN :#seeded\r\n")
+      IRCServer.feed(server, ":irc 353 grappa-test = #seeded :grappa-test alice\r\n")
+      IRCServer.feed(server, ":irc 366 grappa-test #seeded :End\r\n")
+      # #pending: joined, 353 delivered, but NO 366 — still uninitialized.
+      IRCServer.feed(server, ":grappa-test!u@h JOIN :#pending\r\n")
+      IRCServer.feed(server, ":irc 353 grappa-test = #pending :grappa-test bob carol\r\n")
+      IRCServer.feed(server, "PING :flush\r\n")
+      {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "PONG :flush\r\n"), 1_000)
+
+      assert {:ok, counts} = Session.list_member_counts({:user, user.id}, network.id)
+      assert counts == %{"#seeded" => 2}
+
+      # The discrimination this test rests on: the same channel reads
+      # :uninitialized through the per-channel door.
+      assert {:ok, :uninitialized} =
+               Session.list_members({:user, user.id}, network.id, "#pending")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "no session for (user, network) returns {:error, :no_session}" do
+      assert {:error, :no_session} =
+               Session.list_member_counts({:user, Ecto.UUID.generate()}, 999_999_999)
+    end
+  end
+
   describe "list_channels via GenServer.call" do
     test "returns Map.keys(SessionStateHelpers.members(state)) sorted alphabetically" do
       {_, port} = start_server()

--- a/test/grappa/window_counts_test.exs
+++ b/test/grappa/window_counts_test.exs
@@ -1,7 +1,7 @@
 defmodule Grappa.WindowCountsTest do
   @moduledoc """
   Server-authoritative per-window unread/mention/severity snapshot
-  (#267). `snapshot/6` derives `%{messages, mentions, events,
+  (#267). `snapshot/7` derives `%{messages, mentions, events,
   severity}` for a `(subject, network, channel)` window from the read
   cursor + the messages table — no persisted counter, no client
   compute.
@@ -13,7 +13,7 @@ defmodule Grappa.WindowCountsTest do
   nil-cursor (count from 0), past-tail (all zero), and the mention
   scan cap.
 
-  `async: true` — every test mints fresh rows; `snapshot/6` is a pure
+  `async: true` — every test mints fresh rows; `snapshot/7` is a pure
   read over sandboxed Repo state.
   """
   use Grappa.DataCase, async: true
@@ -369,18 +369,18 @@ defmodule Grappa.WindowCountsTest do
     insert(c, "#chan", st: 2, sender: "bob", body: "vjt ping")
     insert(c, "#chan", st: 3, sender: "carol", kind: :join, body: nil)
 
-    result = WindowCounts.snapshot(c.subject, c.network.id, "#chan", anchor.id, nil, [])
+    result = WindowCounts.snapshot(c.subject, c.network.id, "#chan", anchor.id, nil, [], false)
     assert result == %{messages: 1, mentions: 0, events: 1, severity: :message}
   end
 
   # ---------------------------------------------------------------------------
-  # #396 — bulk_snapshot/3: the WHOLE subject's envelope in a CONSTANT number
-  # of queries. Identical to the per-window snapshot/6 loop for channel + DM
+  # #396 — bulk_snapshot/4: the WHOLE subject's envelope in a CONSTANT number
+  # of queries. Identical to the per-window snapshot/7 loop for channel + DM
   # windows; the own-nick SELF window count changes BY DESIGN (single COALESCE
   # predicate — see the two self-DM tests below + DESIGN_NOTES 2026-07-25).
   # ---------------------------------------------------------------------------
-  describe "bulk_snapshot/3 (#396 constant-query cold-load)" do
-    test "matches per-window snapshot/6 for channel + DM windows across networks" do
+  describe "bulk_snapshot/4 (#396 constant-query cold-load)" do
+    test "matches per-window snapshot/7 for channel + DM windows across networks" do
       user = AuthFixtures.user_fixture()
       subject = {:user, user.id}
       net_a = AuthFixtures.network_fixture()
@@ -408,13 +408,13 @@ defmodule Grappa.WindowCountsTest do
       bulk = WindowCounts.bulk_snapshot(subject, own_nicks, [], %{})
 
       assert bulk[net_a.slug]["#chan"] ==
-               WindowCounts.snapshot(subject, net_a.id, "#chan", a.id, own, [])
+               WindowCounts.snapshot(subject, net_a.id, "#chan", a.id, own, [], false)
 
       assert bulk[net_a.slug]["peer"] ==
-               WindowCounts.snapshot(subject, net_a.id, "peer", di.id, own, [])
+               WindowCounts.snapshot(subject, net_a.id, "peer", di.id, own, [], false)
 
       assert bulk[net_b.slug]["#ops"] ==
-               WindowCounts.snapshot(subject, net_b.id, "#ops", b.id, own, [])
+               WindowCounts.snapshot(subject, net_b.id, "#ops", b.id, own, [], false)
     end
 
     test "highlight patterns fold through the bulk mention path too" do
@@ -431,7 +431,7 @@ defmodule Grappa.WindowCountsTest do
       bulk = WindowCounts.bulk_snapshot(subject, %{net.slug => {net.id, own}}, ["grappa"], %{})
 
       assert bulk[net.slug]["#chan"] ==
-               WindowCounts.snapshot(subject, net.id, "#chan", a.id, own, ["grappa"])
+               WindowCounts.snapshot(subject, net.id, "#chan", a.id, own, ["grappa"], false)
 
       assert bulk[net.slug]["#chan"].mentions == 1
     end
@@ -462,7 +462,7 @@ defmodule Grappa.WindowCountsTest do
 
       # Explicit behaviour delta: the OLD per-window narrowing
       # (`channel == own AND dm_with == own`) MISSES the dm_with-NULL row.
-      assert WindowCounts.snapshot(subject, net.id, own, anchor.id, own, []).messages == 1
+      assert WindowCounts.snapshot(subject, net.id, own, anchor.id, own, [], false).messages == 1
     end
 
     test "own-nick self window: mixed-case self-msg COUNTS via fold (#396)" do
@@ -485,10 +485,10 @@ defmodule Grappa.WindowCountsTest do
       # #537/#372 reversed assert (was `== 0`): the own-nick self-window
       # narrowing in `Scrollback.channel_or_dm_where/3` now folds `dm_with`
       # via `nick_fold/1` (dm_with is stored RAW for display, so the MATCH
-      # must fold — the #121/#372 nick invariant), so `snapshot/6` counts the
-      # cased self-msg exactly like `bulk_snapshot/3` does. The pre-fold RAW
+      # must fold — the #121/#372 nick invariant), so `snapshot/7` counts the
+      # cased self-msg exactly like `bulk_snapshot/4` does. The pre-fold RAW
       # compare (`"VJT" != "vjt"` → 0) was the bug this line of work closes.
-      assert WindowCounts.snapshot(subject, net.id, own, anchor.id, own, []).messages == 1
+      assert WindowCounts.snapshot(subject, net.id, own, anchor.id, own, [], false).messages == 1
     end
 
     test "nil own_nick (unbound network) yields mentions 0 but counts messages/events" do
@@ -550,7 +550,7 @@ defmodule Grappa.WindowCountsTest do
 
   # #505 — the COLD-LOAD door. This is the one the issue's first symptom
   # ("never-opened-this-session: the badge comes from the server seed")
-  # actually goes through: #396 moved `/me` off `snapshot/6` onto
+  # actually goes through: #396 moved `/me` off `snapshot/7` onto
   # `bulk_snapshot`, so a fix that only taught `count_after_split/6` the
   # filter would leave the reported case untouched.
   describe "bulk_snapshot/4 — presence-hiding windows (#505)" do
@@ -593,7 +593,10 @@ defmodule Grappa.WindowCountsTest do
       anchor = ins(subject, net.id, "#chan", st: 1, body: "anchor")
       ins(subject, net.id, "#chan", st: 2, sender: "alice", body: "hi vjt")
       ins(subject, net.id, "#chan", st: 3, sender: "bob", kind: :part, body: nil)
-      ins(subject, net.id, "#chan", st: 4, sender: "bob", kind: :topic, body: nil)
+      # `:topic` is body-required, and is the CONTROL row that must survive
+      # the hide — without it this test cannot tell the narrow filter from a
+      # zeroed events bucket.
+      ins(subject, net.id, "#chan", st: 4, sender: "bob", kind: :topic, body: "new topic")
       cursor(subject, net.id, "#chan", anchor.id)
 
       hidden = %{net.slug => MapSet.new(["#chan"])}

--- a/test/grappa/window_counts_test.exs
+++ b/test/grappa/window_counts_test.exs
@@ -74,9 +74,17 @@ defmodule Grappa.WindowCountsTest do
 
   defp reject_nil(map), do: :maps.filter(fn _, v -> v != nil end, map)
 
-  # snapshot with no highlight patterns unless overridden.
+  # snapshot with no highlight patterns unless overridden. `hide_presence:
+  # false` is the SHOWING channel — every pre-#505 test is that case, so it
+  # stays the shape of this helper; the hiding case has its own helper below
+  # so a reader can see at a glance which tests exercise the filter.
   defp snap(ctx, channel, cursor, own_nick, patterns \\ []) do
-    WindowCounts.snapshot(ctx.subject, ctx.network.id, channel, cursor, own_nick, patterns)
+    WindowCounts.snapshot(ctx.subject, ctx.network.id, channel, cursor, own_nick, patterns, false)
+  end
+
+  # #505 — the same window seen by a channel that is HIDING presence.
+  defp snap_hiding(ctx, channel, cursor, own_nick, patterns \\ []) do
+    WindowCounts.snapshot(ctx.subject, ctx.network.id, channel, cursor, own_nick, patterns, true)
   end
 
   # ---------------------------------------------------------------------------
@@ -194,6 +202,60 @@ defmodule Grappa.WindowCountsTest do
     result = snap(c, "#chan", anchor.id, "vjt")
     assert result.messages == 0
     assert result.severity == :event
+  end
+
+  # ---------------------------------------------------------------------------
+  # #505 — hide_presence: the seed applies the channel's presence filter
+  #
+  # The reported bug is a VISIBLE JUMP: on a hiding channel the faint `events`
+  # badge is seeded high by the server and drops when cic hydrates and
+  # recomputes locally through `presenceRowVisible`. These tests pin the seed
+  # to the hydrated answer.
+  # ---------------------------------------------------------------------------
+
+  test "hiding excludes the narrow suppressed kinds from events (#505)" do
+    c = ctx()
+    anchor = insert(c, "#chan", st: 1, body: "anchor")
+    insert(c, "#chan", st: 2, sender: "bob", kind: :join, body: nil)
+    insert(c, "#chan", st: 3, sender: "bob", kind: :part, body: nil)
+    insert(c, "#chan", st: 4, sender: "bob", kind: :mode, body: nil)
+
+    # Showing: all three. This is the pre-#505 answer and must not move.
+    assert snap(c, "#chan", anchor.id, "vjt") ==
+             %{messages: 0, mentions: 0, events: 3, severity: :event}
+
+    # Hiding: join + part go, :mode STAYS. If the filter were "zero the events
+    # bucket" instead of "apply the narrow kind set", this would read 0.
+    assert snap_hiding(c, "#chan", anchor.id, "vjt") ==
+             %{messages: 0, mentions: 0, events: 1, severity: :event}
+  end
+
+  # The payload of the whole issue: a channel whose only unread is hidden
+  # churn must seed a badge the operator actually sees as empty — severity
+  # falls off the ladder entirely, it does not merely shrink.
+  test "a hiding channel with only suppressed churn seeds severity :none (#505)" do
+    c = ctx()
+    anchor = insert(c, "#chan", st: 1, body: "anchor")
+    for i <- 2..10, do: insert(c, "#chan", st: i, sender: "bob", kind: :join, body: nil)
+    insert(c, "#chan", st: 11, sender: "bob", kind: :part, body: nil)
+    insert(c, "#chan", st: 12, sender: "old", kind: :nick_change, body: nil, meta: %{new_nick: "new"})
+    insert(c, "#chan", st: 13, sender: "bob", kind: :quit, body: nil)
+
+    assert snap(c, "#chan", anchor.id, "vjt").severity == :event
+
+    assert snap_hiding(c, "#chan", anchor.id, "vjt") ==
+             %{messages: 0, mentions: 0, events: 0, severity: :none}
+  end
+
+  test "hiding leaves messages, mentions and severity :mention untouched (#505)" do
+    c = ctx()
+    anchor = insert(c, "#chan", st: 1, body: "anchor")
+    insert(c, "#chan", st: 2, sender: "alice", body: "hey vjt")
+    insert(c, "#chan", st: 3, sender: "bob", body: "plain")
+    insert(c, "#chan", st: 4, sender: "bob", kind: :join, body: nil)
+
+    assert snap_hiding(c, "#chan", anchor.id, "vjt") ==
+             %{messages: 2, mentions: 1, events: 0, severity: :mention}
   end
 
   # ---------------------------------------------------------------------------
@@ -343,7 +405,7 @@ defmodule Grappa.WindowCountsTest do
       cursor(subject, net_b.id, "#ops", b.id)
 
       own_nicks = %{net_a.slug => {net_a.id, own}, net_b.slug => {net_b.id, own}}
-      bulk = WindowCounts.bulk_snapshot(subject, own_nicks, [])
+      bulk = WindowCounts.bulk_snapshot(subject, own_nicks, [], %{})
 
       assert bulk[net_a.slug]["#chan"] ==
                WindowCounts.snapshot(subject, net_a.id, "#chan", a.id, own, [])
@@ -366,7 +428,7 @@ defmodule Grappa.WindowCountsTest do
       ins(subject, net.id, "#chan", st: 3, sender: "bob", body: "unrelated")
       cursor(subject, net.id, "#chan", a.id)
 
-      bulk = WindowCounts.bulk_snapshot(subject, %{net.slug => {net.id, own}}, ["grappa"])
+      bulk = WindowCounts.bulk_snapshot(subject, %{net.slug => {net.id, own}}, ["grappa"], %{})
 
       assert bulk[net.slug]["#chan"] ==
                WindowCounts.snapshot(subject, net.id, "#chan", a.id, own, ["grappa"])
@@ -393,7 +455,7 @@ defmodule Grappa.WindowCountsTest do
       # A genuine self-message.
       ins(subject, net.id, own, st: 3, sender: own, body: "to self", dm_with: own)
 
-      bulk = WindowCounts.bulk_snapshot(subject, %{net.slug => {net.id, own}}, [])
+      bulk = WindowCounts.bulk_snapshot(subject, %{net.slug => {net.id, own}}, [], %{})
 
       # #396: COALESCE(dm_with, channel) folds the NULL row's channel=own in.
       assert bulk[net.slug][own].messages == 2
@@ -415,7 +477,7 @@ defmodule Grappa.WindowCountsTest do
       # casing — display-preserved, so the fold is required to match.
       ins(subject, net.id, own, st: 2, sender: own, body: "cased self", dm_with: "VJT")
 
-      bulk = WindowCounts.bulk_snapshot(subject, %{net.slug => {net.id, own}}, [])
+      bulk = WindowCounts.bulk_snapshot(subject, %{net.slug => {net.id, own}}, [], %{})
 
       # #396: both sides fold → "VJT" resolves to the own window.
       assert bulk[net.slug][own].messages == 1
@@ -441,7 +503,7 @@ defmodule Grappa.WindowCountsTest do
       ins(subject, net.id, "#chan", st: 3, sender: "bob", kind: :join, body: nil)
 
       # own_nicks WITHOUT this slug → own_nick_for_slug resolves nil.
-      bulk = WindowCounts.bulk_snapshot(subject, %{}, [])
+      bulk = WindowCounts.bulk_snapshot(subject, %{}, [], %{})
 
       assert bulk[net.slug]["#chan"] ==
                %{messages: 1, mentions: 0, events: 1, severity: :message}
@@ -456,7 +518,7 @@ defmodule Grappa.WindowCountsTest do
       m = ins(subject, net.id, "#chan", st: 1, body: "only")
       cursor(subject, net.id, "#chan", m.id)
 
-      bulk = WindowCounts.bulk_snapshot(subject, %{net.slug => {net.id, own}}, [])
+      bulk = WindowCounts.bulk_snapshot(subject, %{net.slug => {net.id, own}}, [], %{})
 
       assert bulk[net.slug]["#chan"] ==
                %{messages: 0, mentions: 0, events: 0, severity: :none}
@@ -466,7 +528,7 @@ defmodule Grappa.WindowCountsTest do
       user = AuthFixtures.user_fixture()
       subject = {:user, user.id}
 
-      assert WindowCounts.bulk_snapshot(subject, %{}, []) == %{}
+      assert WindowCounts.bulk_snapshot(subject, %{}, [], %{}) == %{}
     end
 
     test "issues a CONSTANT number of queries (2) regardless of window count" do
@@ -476,13 +538,124 @@ defmodule Grappa.WindowCountsTest do
       subject_3 = seed_windows(3)
       subject_30 = seed_windows(30)
 
-      q3 = count_repo_queries(fn -> WindowCounts.bulk_snapshot(subject_3, %{}, []) end)
-      q30 = count_repo_queries(fn -> WindowCounts.bulk_snapshot(subject_30, %{}, []) end)
+      q3 = count_repo_queries(fn -> WindowCounts.bulk_snapshot(subject_3, %{}, [], %{}) end)
+      q30 = count_repo_queries(fn -> WindowCounts.bulk_snapshot(subject_30, %{}, [], %{}) end)
 
       assert q3 == 2, "expected exactly 2 queries for 3 windows, got #{q3}"
       assert q30 == 2, "expected exactly 2 queries for 30 windows, got #{q30}"
       # Sanity: the 30-window subject really has 30 windows in the envelope.
-      assert map_size(hd(Map.values(WindowCounts.bulk_snapshot(subject_30, %{}, [])))) == 30
+      assert map_size(hd(Map.values(WindowCounts.bulk_snapshot(subject_30, %{}, [], %{})))) == 30
+    end
+  end
+
+  # #505 — the COLD-LOAD door. This is the one the issue's first symptom
+  # ("never-opened-this-session: the badge comes from the server seed")
+  # actually goes through: #396 moved `/me` off `snapshot/6` onto
+  # `bulk_snapshot`, so a fix that only taught `count_after_split/6` the
+  # filter would leave the reported case untouched.
+  describe "bulk_snapshot/4 — presence-hiding windows (#505)" do
+    test "hides suppressed churn for the hidden window ONLY, in one call" do
+      user = AuthFixtures.user_fixture()
+      subject = {:user, user.id}
+      net = AuthFixtures.network_fixture()
+      own = "vjt"
+
+      # Two channels on ONE network, identical row shapes. Only #big hides.
+      for chan <- ["#big", "#small"] do
+        anchor = ins(subject, net.id, chan, st: 1, body: "anchor")
+        ins(subject, net.id, chan, st: 2, sender: "alice", body: "hello")
+        ins(subject, net.id, chan, st: 3, sender: "bob", kind: :join, body: nil)
+        ins(subject, net.id, chan, st: 4, sender: "bob", kind: :quit, body: nil)
+        ins(subject, net.id, chan, st: 5, sender: "bob", kind: :mode, body: nil)
+        cursor(subject, net.id, chan, anchor.id)
+      end
+
+      own_nicks = %{net.slug => {net.id, own}}
+      hidden = %{net.slug => MapSet.new(["#big"])}
+
+      bulk = WindowCounts.bulk_snapshot(subject, own_nicks, [], hidden)
+
+      # #big: join + quit dropped, :mode survives.
+      assert bulk[net.slug]["#big"] ==
+               %{messages: 1, mentions: 0, events: 1, severity: :message}
+
+      # #small: untouched — the exclusion is PER WINDOW, not a global switch.
+      assert bulk[net.slug]["#small"] ==
+               %{messages: 1, mentions: 0, events: 3, severity: :message}
+    end
+
+    test "agrees with snapshot/7 for the same window" do
+      user = AuthFixtures.user_fixture()
+      subject = {:user, user.id}
+      net = AuthFixtures.network_fixture()
+      own = "vjt"
+
+      anchor = ins(subject, net.id, "#chan", st: 1, body: "anchor")
+      ins(subject, net.id, "#chan", st: 2, sender: "alice", body: "hi vjt")
+      ins(subject, net.id, "#chan", st: 3, sender: "bob", kind: :part, body: nil)
+      ins(subject, net.id, "#chan", st: 4, sender: "bob", kind: :topic, body: nil)
+      cursor(subject, net.id, "#chan", anchor.id)
+
+      hidden = %{net.slug => MapSet.new(["#chan"])}
+      bulk = WindowCounts.bulk_snapshot(subject, %{net.slug => {net.id, own}}, [], hidden)
+
+      assert bulk[net.slug]["#chan"] ==
+               WindowCounts.snapshot(subject, net.id, "#chan", anchor.id, own, [], true)
+    end
+
+    # The hidden set is keyed by SLUG because the pref itself is
+    # (`"<slug> <channel>"`). Same channel name on two networks, hidden on
+    # one: a set that leaked across networks would zero both.
+    test "the hidden set does not leak across networks" do
+      user = AuthFixtures.user_fixture()
+      subject = {:user, user.id}
+      net_a = AuthFixtures.network_fixture()
+      net_b = AuthFixtures.network_fixture()
+      own = "vjt"
+
+      for net <- [net_a, net_b] do
+        anchor = ins(subject, net.id, "#chan", st: 1, body: "anchor")
+        ins(subject, net.id, "#chan", st: 2, sender: "bob", kind: :join, body: nil)
+        cursor(subject, net.id, "#chan", anchor.id)
+      end
+
+      own_nicks = %{net_a.slug => {net_a.id, own}, net_b.slug => {net_b.id, own}}
+      hidden = %{net_a.slug => MapSet.new(["#chan"])}
+
+      bulk = WindowCounts.bulk_snapshot(subject, own_nicks, [], hidden)
+
+      assert bulk[net_a.slug]["#chan"].events == 0
+      assert bulk[net_b.slug]["#chan"].events == 1
+    end
+
+    # A hidden window whose churn is ALL suppressed must vanish from the
+    # badge, not shrink — the cold-load twin of the `snapshot/7` :none test.
+    test "an all-churn hidden window seeds severity :none" do
+      user = AuthFixtures.user_fixture()
+      subject = {:user, user.id}
+      net = AuthFixtures.network_fixture()
+
+      anchor = ins(subject, net.id, "#chan", st: 1, body: "anchor")
+      for i <- 2..6, do: ins(subject, net.id, "#chan", st: i, sender: "bob", kind: :join, body: nil)
+      cursor(subject, net.id, "#chan", anchor.id)
+
+      hidden = %{net.slug => MapSet.new(["#chan"])}
+      bulk = WindowCounts.bulk_snapshot(subject, %{net.slug => {net.id, "vjt"}}, [], hidden)
+
+      assert bulk[net.slug]["#chan"] ==
+               %{messages: 0, mentions: 0, events: 0, severity: :none}
+    end
+
+    # #396's whole point must survive #505: the exclusion rides the SAME two
+    # statements, it does not add a query per hidden window.
+    test "stays at a CONSTANT 2 queries with a non-empty hidden set" do
+      subject = seed_windows(30)
+      [slug] = Map.keys(WindowCounts.bulk_snapshot(subject, %{}, [], %{}))
+      hidden = %{slug => MapSet.new(for i <- 1..30, do: "#c#{i}")}
+
+      q = count_repo_queries(fn -> WindowCounts.bulk_snapshot(subject, %{}, [], hidden) end)
+
+      assert q == 2, "expected exactly 2 queries with 30 hidden windows, got #{q}"
     end
   end
 

--- a/test/grappa_web/controllers/me_controller_test.exs
+++ b/test/grappa_web/controllers/me_controller_test.exs
@@ -348,7 +348,7 @@ defmodule GrappaWeb.MeControllerTest do
     # `c.last_read_message_id` as-is; the column is nullable so a row
     # with explicit-no-cursor or legacy-null state surfaces as a nil
     # in the envelope. Pre-fix `build_unread_counts/2` passed the nil
-    # straight to `Scrollback.count_after_split/5` whose head guard is
+    # straight to `Scrollback.count_after_split/6` whose head guard is
     # `is_integer(after_id)` → FunctionClauseError → 500 on the whole
     # /me response → cic's `user()` signal stays unresolved → Shell
     # renders the cold "select a channel below" placeholder with no


### PR DESCRIPTION
## What

On a channel that hides `join`/`part`/`quit`/`nick_change`, the sidebar's faint `events` badge was seeded by counting rows the pane never renders, then visibly **dropped** as soon as cic hydrated the channel and recomputed through `presenceRowVisible`. Two counts, two answers — and the one shown first was the one the operator could not clear by reading.

The seed now applies the same presence filter the history fetch got in #458.

## The evidence in #505 pointed at one door; the symptom comes through the other

#505 attributed both the `join_reply` seed and the `/me` cold-load to `WindowCounts.snapshot` → `Scrollback.count_after_split`. That was true when the observation was made and stale by the time it was fixed: **#396 had already moved the cold-load** onto `WindowCounts.bulk_snapshot` → `ReadCursor.bulk_unread_split`, a single `FROM read_cursors` statement that never touches `count_after_split`.

Since "cold-load / never-opened-this-session" — the first symptom the issue lists — is served by exactly that door, teaching only the per-window path would have looked like a repair while leaving the reported case untouched. Both doors take the filter here. Correction recorded on the issue: https://github.com/vjt/grappa-irc/issues/505#issuecomment-5194285052

| | door | path | callers |
|---|---|---|---|
| A | per-window | `snapshot/7` → `count_after_split/6` | `join_reply`, per-message push |
| B | bulk | `bulk_snapshot/4` → `bulk_unread_split/3` | `/me` cold-load |

## The precedence rule is not forked

#458's `PresenceFilter.hidden?/2` remains the only place the tri-state and the 50-member threshold are evaluated. What moved is the **I/O around it** — out of `MessagesController`'s private helpers into `Grappa.PresenceFilter.Resolver`, now shared by four callers.

The resolver needed its own top-level boundary because no existing module has the deps: `WindowCounts` cannot reach `Session` (`Session` deps `WindowCounts`, so the cycle closes), `PresenceFilter` is deliberately dep-free, and `GrappaWeb` is unreachable from `WindowCounts.Pusher`. Same inversion, for the same reason, as `Pusher` itself.

## The #498 tradeoff, partially bought back — on purpose, and bounded

#498 removed the per-network `GenServer.call` from `/me` and explicitly rejected "resolve through `Session` at count time". The member count **cannot** follow the nick onto the SessionRegistry value: a nick changes at one chokepoint and is a copy; a member count changes on every JOIN/PART/QUIT/KICK, so mirroring it means maintaining a parallel copy of `state.members` that drifts.

So the call comes back, with three bounds:

- **per network, not per window** — `Session.list_member_counts/2` is a new bulk verb returning `%{channel => count}` in one call (the `list_members/3` shape would have been ~50 calls at a 50-window logon, the exact fan-out #396 collapsed);
- **skipped when useless** — a network whose every window carries an explicit pin is never asked. This required threading the caller's window universe (`/me` passes its cursor envelope), because "does this network still have an unset window?" is *undecidable* from the pins alone; the same parameter also bounds the SQL `IN` list to real windows;
- **cold-load only** — never periodic, never per message.

#498's decision-log entry is amended **at the source** so its rule reads as "about the nick" rather than as a blanket ban, and DESIGN_NOTES carries the full #505 argument.

## Narrow, not "zero the events bucket"

The exclusion is `Message.suppressed_presence_kinds/0` only. `:mode`, `:topic`, `:kick` and `:server_event` still count under `events`, because the pane still renders them. Every hiding test asserts one of them **survives** — without that assertion, "apply the narrow filter" and "zero the bucket" pass identically.

## How I know the tests constrain anything

The suite is green, which proves nothing on its own, so each mechanism was removed and the damage measured:

| mutation | result |
|---|---|
| drop `maybe_exclude_presence` from `count_after_split/6` | 8 tests fail |
| neuter the bulk exclusion in `bulk_unread_split/3` | 4 tests fail |
| remove the "skip the call" guard | exactly 1 fails — the `refute_receive`; the positive control still passes |
| drop the `seeded_channels` filter | pre-NAMES test fails, reporting `#pending => 3` for an unknowable count |

The skip guard is measured at the session mailbox with `:erlang.trace`, not asserted: a fully pinned network decides *identically* whether or not the call happens, so a result-level test would have been green with the guard deleted.

## Test plan

- [x] `scripts/check.sh` — rc=0, 5199 tests / 8 doctests / 52 properties, 0 failures; working tree clean before AND after
- [x] format, credo --strict, dialyzer (0 errors) individually green
- [x] four mutations, each turning the intended tests red
- [x] touched suites re-run green after rebase (839 tests)
- [ ] CI is the authority for the post-rebase tree

## What I am NOT claiming

The full `scripts/check.sh` green was measured on the tree **before** the final rebase onto `origin/main` (which moved 30 commits during this work). After the rebase I re-ran only the touched suites; CI covers the rest.

No cic change: the client already filters its hydrated count correctly — that is precisely why the seed disagreed with it. There is no browser-level verification here because there is nothing new for the browser to do.

While reading #498 I found that it justifies its rejection with *"#482 added ONE such call to a snapshot path and reddened two timing specs the same week"*. `Resolver.hidden?/4` in `join_reply` is that shape. That path already makes one call (`Session.casemapping/2`), so this takes it from one to two rather than breaking a call-free path — but if channel timing specs go red in CI, **that is the first thing to look at, not a flake**.
