### PR TITLE
cic(#881): a non-joined channel window keeps every rail door

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -726,16 +726,19 @@ export async function composeSend(
 //   * channel window → TopicBar hamburger (aria-label "open members sidebar")
 //   * non-channel window (home/server/mentions/admin) → ShellChrome rail
 //     opener (☰, testid `shell-chrome-rail-opener`)
-// Exactly one of the two is rendered per window, so probe for the TopicBar
-// hamburger first and fall back to the rail opener. `.click()` (DevTools
+// Exactly one of the two is rendered per window — the split is on window KIND
+// alone (#881 removed the extra `windowIsJoined` gate that used to hide the
+// hamburger, and with it every rail door, on a `:failed`/`:kicked`/`:parked`
+// channel) — so probe for the TopicBar hamburger first and fall back to the
+// rail opener. `.click()` (DevTools
 // synthetic) over `.tap()` for the same WebKit synthesis-race reason as
 // closeMembersDrawer below.
 export async function openMembersDrawer(page: Page): Promise<void> {
   const drawer = page.locator(".shell-members.open");
   // #653/#519 — re-resolve per attempt instead of a single probe-then-click.
   // The opener that renders depends on the focused window kind (channel →
-  // TopicBar hamburger `<Show when={windowIsJoined}>`; non-channel → rail
-  // opener), and under full-gate load a settling selection redirect (e.g. the
+  // TopicBar hamburger; non-channel → rail opener), and under full-gate load a
+  // settling selection redirect (e.g. the
   // post-PART close-watcher moving focus) can swap the focused window — and
   // re-render the topic bar — BETWEEN the count probe and the click. The
   // hamburger then detaches mid-click; Playwright's built-in detach-retry

--- a/cicchetto/e2e/tests/issue881-mobile-nonjoined-rail-doors.spec.ts
+++ b/cicchetto/e2e/tests/issue881-mobile-nonjoined-rail-doors.spec.ts
@@ -1,0 +1,117 @@
+// @webkit — #881. On mobile, a NON-joined channel window must keep every rail
+// door. Before the fix it had none.
+//
+// `.shell-members` stopped being a members panel at #71 INC-2 / #473: it is the
+// permanent right rail, and Archive, Settings, Rooms and Admin live inside it.
+// A mobile channel window has exactly ONE way in — TopicBar's ☰ — because
+// `Shell.tsx` mounts the `.shell-chrome` opener only for `kind !== "channel"`
+// (the channel branch gives those ~32px back to the scrollback). That ☰ sat
+// behind `<Show when={windowIsJoined}>`, written when it really was a members
+// toggle, so a `:failed` / `:kicked` / `:parked` window lost the whole
+// navigation, not a member list.
+//
+// It was found by accident: the first run of the #402 repro died inside
+// `openArchive`, unable to find a door. Which is why this spec deliberately
+// does NOT navigate away from the failed window before reaching for the rail —
+// staying put IS the test. A user whose rejoin failed lands on that window, and
+// Archive is exactly where they need to go to find the channel again.
+//
+// vjt's ruling (2026-08-05) has two halves and both are asserted here: a
+// non-joined window renders what a joined one renders MINUS the members list.
+// So the doors must be reachable AND `.members-pane` must stay absent — a fix
+// that opened the rail by also resurrecting a stale member list would satisfy
+// the issue title and violate the ruling.
+//
+// The `:failed` arm is the one an e2e can materialize deterministically (`+i`
+// → 473), and `.compose-box-greyed` certifies the state machine really got
+// there — without it every assertion below could pass against a window that
+// never left `:joined`.
+//
+// Admin: `mobile-panel-admin` is `isAdmin()`-gated, and the seeded `vjt` is a
+// non-admin user (`admin-vjt` is the admin). So this spec pins the DOOR plus
+// the capability-independent buttons behind it; the admin launcher's own gate
+// is covered by the UX-6-C / #473 specs. Nothing about #881 was ever
+// admin-specific — losing the rail lost every button on it at once.
+//
+// Mobile-only shape (the ShellChrome/TopicBar opener split exists only in the
+// isMobile() branch), so this runs on the webkit-iphone-15 project alone — the
+// @webkit tag; the chromium project grepInverts it.
+
+import { expect, test } from "../fixtures/test";
+import {
+  closeArchive,
+  composeSend,
+  loginAs,
+  openArchive,
+  openRailMenu,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
+import { partChannel } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+// Per-run-unique: bahamut holds channel state for a window after disconnect, so
+// a literal collides on rapid reruns (--repeat-each).
+const GATED_CHANNEL = `#i881-gated-${crypto.randomUUID().slice(0, 8)}`;
+
+let peer: IrcPeer | null = null;
+
+test.setTimeout(90_000);
+
+test.afterEach(async () => {
+  if (peer) {
+    await peer.disconnect("i881 cleanup").catch(() => {});
+    peer = null;
+  }
+  const vjt = getSeededVjt();
+  await partChannel(vjt.token, NETWORK_SLUG, GATED_CHANNEL).catch(() => {});
+});
+
+test("@webkit #881 — a non-joined channel window keeps every rail door, and still no members list", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
+
+  peer = await IrcPeer.connect({ nick: `i881peer-${crypto.randomUUID().slice(0, 6)}` });
+
+  // The peer founds a `+i` channel; the operator's /join is rejected with 473,
+  // which selects the new window and flips it `:failed`.
+  await peer.join(GATED_CHANNEL);
+  await peer.mode(GATED_CHANNEL, "+i");
+  await composeSend(page, `/join ${GATED_CHANNEL}`);
+  await expect(page.locator(".compose-box")).toHaveClass(/compose-box-greyed/, { timeout: 10_000 });
+
+  // PRECONDITION — focus really is ON the gated window (the greyed compose is
+  // the selected window's). Pinned explicitly so a selection redirect that
+  // moved us back to a joined channel could not let the rest pass for the
+  // wrong reason: on a JOINED window every assertion below was already green.
+  await expect(page.locator(".topic-bar .topic-bar-channel")).toHaveText(GATED_CHANNEL);
+
+  // The mechanism, asserted because on this form factor it IS the outcome:
+  // the channel branch mounts no `.shell-chrome`, so if the ☰ is not there,
+  // there is no second door to fall back to.
+  await expect(page.getByTestId("shell-chrome")).toHaveCount(0);
+  await expect(page.locator(".topic-bar-hamburger")).toBeVisible();
+
+  // The outcome. `openRailMenu` walks the real path a user walks — tap the ☰,
+  // wait out the drawer slide, tap the launcher — and it is the same helper
+  // every rail-reaching spec uses, so it cannot quietly find some other door.
+  await openRailMenu(page);
+  const menu = page.locator(".shell-members .rail-actions-menu");
+  await expect(menu.getByTestId("mobile-panel-archive")).toBeVisible();
+  await expect(menu.getByTestId("action-cluster-cog")).toBeVisible();
+  await expect(menu.getByTestId("mobile-panel-list")).toBeVisible();
+  await expect(menu.getByTestId("mobile-panel-home")).toBeVisible();
+
+  // The other half of the ruling: the members list is the ONE thing a
+  // non-joined window genuinely does not get.
+  await expect(page.locator(".shell-members .members-pane")).toHaveCount(0);
+
+  // And the door actually leads somewhere — this exact call is the one that
+  // died while building the #402 repro, which is how #881 was found.
+  const modal = await openArchive(page);
+  await expect(modal).toBeVisible();
+  await closeArchive(page);
+});

--- a/cicchetto/src/TopicBar.tsx
+++ b/cicchetto/src/TopicBar.tsx
@@ -354,20 +354,25 @@ const TopicBar: Component<Props> = (props) => {
       </div>
       {/* #71 INC-2 — the presence-filter toggle (👁/🙈) moved to the right-rail
           RailActions drawer (channel-gated). It is no longer rendered here. */}
-      {/* Members hamburger only when actively joined. Parked / failed
-          / kicked channels have stale or absent member lists; the
-          right pane is suppressed in Shell.tsx for the same reason —
-          this hides the toggle that would otherwise dangle. */}
-      <Show when={windowIsJoined(key())}>
-        <button
-          type="button"
-          class="topic-bar-hamburger shell-chrome-btn"
-          aria-label="open members sidebar"
-          onClick={props.onToggleMembers}
-        >
-          ☰
-        </button>
-      </Show>
+      {/* #881 — UNCONDITIONAL. This ☰ is not a members toggle, it is the
+          rail door: on mobile it opens `.shell-members`, which since #71
+          INC-2 / #473 is the permanent right rail hosting Archive, Settings,
+          Rooms and Admin — and it is the ONLY door a channel window has
+          (ShellChrome's opener renders for `kind !== "channel"`). It used to
+          sit behind `windowIsJoined`, on the premise that it toggled a member
+          list; the member list is gated in Shell.tsx and this gate took the
+          whole navigation with it, stranding a `:failed`/`:kicked`/`:parked`
+          window with no way out. vjt's ruling: a non-joined window is not a
+          different window shape — same surface as a joined one, MINUS the
+          members list. So joinedness gates the list, never the door. */}
+      <button
+        type="button"
+        class="topic-bar-hamburger shell-chrome-btn"
+        aria-label="open members sidebar"
+        onClick={props.onToggleMembers}
+      >
+        ☰
+      </button>
 
       {/* Topic modal (#263) — opens read-only for everyone on strip click;
           shows full topic, setter, timestamp. An op (canEditTopic) also sees a

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -943,6 +943,41 @@ describe("Shell — mobile layout (isMobile = true)", () => {
       expect(container.querySelector(".shell-members .mobile-panel-actions")).toBeNull();
     });
 
+    // #881 — the composition, both halves of vjt's ruling in one test. A
+    // NON-joined channel window is the case with no second door: `.shell-chrome`
+    // is suppressed for `kind === "channel"`, so the TopicBar ☰ is the only way
+    // into the rail, and the rail is where Archive / Settings / Rooms / Admin
+    // live. Gating that ☰ on joinedness therefore deleted the navigation, not a
+    // members toggle. Asserted here as the OUTCOME (the doors are reachable),
+    // together with the half that must NOT change: no members list.
+    it("#881 mobile NON-joined channel: the rail doors are reachable and the members list stays absent", async () => {
+      mobileState.value = true;
+      selectionState.setSelSig({ networkSlug: "freenode", channelName: "#a", kind: "channel" });
+      mockWindowIsJoined.mockReturnValue(false);
+      const { container } = render(() => <Shell />);
+      await waitFor(() => {
+        expect(container.querySelector(".topic-bar")).toBeInTheDocument();
+      });
+      // The channel branch mounts no `.shell-chrome`, so there is no fallback
+      // opener — if the hamburger is gone, the rail is unreachable, full stop.
+      expect(container.querySelector(".shell-chrome")).toBeNull();
+      const hamburger = container.querySelector(".topic-bar .topic-bar-hamburger");
+      expect(hamburger).not.toBeNull();
+
+      fireEvent.click(hamburger as HTMLElement);
+      expect(container.querySelector(".shell-members")?.classList.contains("open")).toBe(true);
+
+      openRailMenu();
+      const menu = container.querySelector(".shell-members .rail-actions-menu");
+      expect(menu?.querySelector("[data-testid='mobile-panel-archive']")).not.toBeNull();
+      expect(menu?.querySelector("[data-testid='action-cluster-cog']")).not.toBeNull();
+      expect(menu?.querySelector("[data-testid='mobile-panel-list']")).not.toBeNull();
+
+      // The other half of the ruling: only the members list is genuinely
+      // absent. This is what the joinedness predicate is FOR.
+      expect(container.querySelector(".shell-members .members-pane")).toBeNull();
+    });
+
     it("mobile home window: standalone .shell-chrome row STAYS (no TopicBar / drawer to absorb buttons)", async () => {
       mobileState.value = true;
       selectionState.setSelSig({ networkSlug: "$home", channelName: "$home", kind: "home" });

--- a/cicchetto/src/__tests__/TopicBar.test.tsx
+++ b/cicchetto/src/__tests__/TopicBar.test.tsx
@@ -5,10 +5,11 @@ vi.mock("../lib/channelKey", () => ({
   channelKey: (slug: string, name: string) => `${slug} ${name}`,
 }));
 
-// windowState mock — TopicBar gates the members hamburger AND (since #263) the
-// modal ✏️ edit toggle on `windowIsJoined(key)` (via canEditTopic). Default the
-// predicate to `true` so the joined-state UI (hamburger + editable topic) is
-// exercised; the not-joined branch is set explicitly where tested.
+// windowState mock — since #881 the ONLY thing TopicBar gates on
+// `windowIsJoined(key)` is the modal ✏️ edit toggle (via canEditTopic, #263):
+// a real IRC permission, not chrome. The ☰ rail door is unconditional.
+// Default the predicate to `true` so the editable-topic path is exercised;
+// the not-joined branch is set explicitly where tested.
 const mockWindowIsJoined = vi.fn((_key: string) => true);
 vi.mock("../lib/windowState", () => ({
   windowIsJoined: (key: string) => mockWindowIsJoined(key),
@@ -118,22 +119,38 @@ describe("TopicBar", () => {
   // into ShellChrome (covered in Shell.test.tsx). TopicBar no longer
   // renders ⚙ — the corresponding test moved to ShellChrome.test.tsx.
 
-  describe("members hamburger + nick count visibility (joined-only)", () => {
-    it("hides the right hamburger when the channel is not joined", () => {
+  // #881 — the hamburger is the ONLY rail door a mobile channel window has
+  // (ShellChrome's opener renders for `kind !== "channel"`), and the rail is
+  // where Archive / Settings / Rooms / Admin live. Gating it on joinedness
+  // took the whole nav away from a `:failed` / `:kicked` / `:parked` window.
+  // vjt's ruling: a non-joined window is not a different window shape — it
+  // shows what a joined one shows MINUS the members list. So the ONLY
+  // joinedness gate left in this component is `canEditTopic` (a real IRC
+  // permission), and the members list itself is gated in Shell.tsx.
+  describe("#881 — the rail door is not conditioned on joinedness", () => {
+    it("renders the right hamburger even when the channel is not joined", () => {
       mockWindowIsJoined.mockReturnValue(false);
       render(() => <TopicBar {...baseProps()} />);
-      expect(screen.queryByLabelText(/open members sidebar/i)).not.toBeInTheDocument();
+      expect(screen.getByLabelText(/open members sidebar/i)).toBeInTheDocument();
     });
 
-    // UX-5 bucket BT (2026-05-19) — "X nicks" strip was dropped. The
-    // joined-gated visibility test is now redundant; the strip is
-    // gone everywhere. Kept as negative guard for the not-joined
-    // path so a resurrection would surface.
-    it("UX-5 bucket BT — never renders nick count, joined or not", () => {
+    it("the not-joined hamburger still fires onToggleMembers", () => {
       mockWindowIsJoined.mockReturnValue(false);
-      render(() => <TopicBar {...baseProps()} />);
-      expect(screen.queryByText(/\d+ nicks/i)).not.toBeInTheDocument();
+      const props = baseProps();
+      render(() => <TopicBar {...props} />);
+      fireEvent.click(screen.getByLabelText(/open members sidebar/i));
+      expect(props.onToggleMembers).toHaveBeenCalled();
     });
+  });
+
+  // UX-5 bucket BT (2026-05-19) — "X nicks" strip was dropped. The
+  // joined-gated visibility test is now redundant; the strip is
+  // gone everywhere. Kept as negative guard for the not-joined
+  // path so a resurrection would surface.
+  it("UX-5 bucket BT — never renders nick count, joined or not", () => {
+    mockWindowIsJoined.mockReturnValue(false);
+    render(() => <TopicBar {...baseProps()} />);
+    expect(screen.queryByText(/\d+ nicks/i)).not.toBeInTheDocument();
   });
 
   it("shows topic text when topic is set", () => {

--- a/cicchetto/src/lib/windowState.ts
+++ b/cicchetto/src/lib/windowState.ts
@@ -167,23 +167,34 @@ export const setKicked = exports_.setKicked;
 export const setParted = exports_.setParted;
 export const forceParted = exports_.forceParted;
 
-// Render-time predicates for "show member-list-shaped UI?".
+// Render-time predicates for "show the member LIST?" — and nothing else.
 //
-// Member list UI (right pane + the right hamburger toggle in TopicBar)
-// only makes sense when the window is an actively-joined channel.
-// Servers, DMs, mentions/list pseudo-windows, and parked/failed/kicked
-// channels do NOT have a live member list — showing the pane there
-// either reserves grid space for nothing (desktop) or surfaces a stale
-// "not joined" stub through a hamburger that should never have been
-// offered in the first place.
+// A live member list only exists for an actively-joined channel. Servers,
+// DMs, mentions/list pseudo-windows, and parked/failed/kicked channels do
+// not have one, so `MembersPane` is `<Show>`-gated on these predicates in
+// both Shell.tsx branches; on desktop the same signal narrows the rail
+// column (`.shell-no-members`) rather than reserving grid space for
+// nothing.
+//
+// #881 — SCOPE, and it is load-bearing: joinedness gates the LIST, never
+// the CHROME AROUND IT. This comment used to name "the right hamburger
+// toggle in TopicBar" as member-list UI, and TopicBar believed it. That ☰
+// is the rail DOOR (`.shell-members` has been the permanent Archive /
+// Settings / Rooms / Admin rail since #71 INC-2 / #473, and it is a
+// channel window's ONLY door), so gating it here deleted the whole
+// navigation for a non-joined window. vjt's ruling: a non-joined window
+// renders what a joined one renders MINUS the members list. Before adding
+// a caller, ask whether the thing you are gating IS the list — if it only
+// sits near it, this is the wrong predicate.
 //
 // `windowIsJoined(key)` is the primitive over the state map; absence
 // (parted / never-joined / non-channel pseudo-window) is treated as
 // "not joined" — no member list. `isActiveChannelJoined()` composes
-// it with the active selection's `kind` to gate the render-time
-// branches in Shell.tsx + TopicBar.tsx — exposed as a derived signal
+// it with the active selection's `kind` — exposed as a derived signal
 // (no arg) so each consumer just reads it without rebuilding the
-// channelKey itself.
+// channelKey itself. TopicBar's remaining `windowIsJoined` call is
+// `canEditTopic`: a genuine IRC permission (you cannot TOPIC a channel
+// you are not on), not chrome.
 
 export const windowIsJoined = (key: ChannelKey): boolean =>
   windowStateByChannel()[key] === "joined";


### PR DESCRIPTION
On mobile, a non-joined channel window had **no way to open the rail at all** —
Archive, Settings, Rooms and Admin were unreachable until the operator selected
some other window. Issue #881.

## Why it was a removal, not new chrome

`.shell-members` stopped being a members panel at #71 INC-2 / #473: it is the
permanent right rail, and every one of those doors lives inside it. A mobile
channel window has exactly ONE way in — TopicBar's ☰ — because `Shell.tsx`
mounts the `.shell-chrome` opener only for `kind !== "channel"` (the channel
branch gives those ~32px back to the scrollback). That ☰ sat behind
`<Show when={windowIsJoined}>`, written back when it really was a members
toggle, so a `:failed` / `:kicked` / `:parked` window lost the navigation.

vjt's ruling (2026-08-05): a non-joined window renders what a joined one
renders **minus the members list**. Not a reduced-chrome window shape — the
same shape with one thing missing. So joinedness now gates the list (Shell.tsx,
unchanged) and nothing else in TopicBar but `canEditTopic`, which is a genuine
IRC permission.

## The gate came from prose

`windowState.ts` described itself as the predicate for "member-list-shaped UI"
and named the TopicBar hamburger as an instance. TopicBar believed it. That
comment is corrected with the scope rule spelled out — leaving it would invite
the gate back the next time someone reads the module before the call site. Same
correction applied to the e2e fixture comment that documented the gate.

## What I measured

- **The RED was read before any fix.** The jsdom oracle dumped a topic bar with
  no hamburger in it.
- **Mutation, jsdom:** re-adding `<Show when={windowIsJoined}>` turns exactly
  the 3 new tests red and leaves 92 others green — the tests constrain this
  change and only this change.
- **Mutation, e2e:** with the gate back, the new spec fails in 11.6s on
  `.topic-bar-hamburger` not found. It is not a spec that passes for free.
- **Green:** `#881` on `webkit-iphone-15`, `--repeat-each 3`, 3/3 (8.3s / 2.8s /
  2.4s). cic `check` (biome + tsc) exit 0.

## What I am NOT claiming

The e2e's mutation run dies on the door assert, which sits *before*
`openRailMenu` / `openArchive`. So the two calls that prove the door leads
somewhere were exercised green but never exercised red — I have not measured
that they would fail on their own. The ordering is deliberate (an 11s pointed
failure beats a 15s opaque timeout inside the fixture's retry loop), but the
limit is real.

I also did not touch the ☰'s `aria-label`, still `"open members sidebar"` on a
button that is now the rail door. It matches how the codebase already names
that surface (`.shell-members`), renaming it would churn every spec that
locates it, and it is not what the issue reported — but I am not claiming the
label is accurate.

Admin is `isAdmin()`-gated and the seeded `vjt` is not an admin, so the spec
pins the door plus the capability-independent buttons behind it, not the admin
launcher itself.

Related: #402 (same sequence reaches both; that one loses a window, this one
lost the escape hatch it needs). Its repro currently navigates away from the
non-joined window before opening Archive, and says so — with this merged that
detour can probably go, but I did not widen scope to it.