### PR TITLE
cic: the unread badge on the window you are reading (#887) and the one that is frozen (#888)

### DIFF
--- a/cicchetto/e2e/tests/issue887-focused-unread-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue887-focused-unread-badge.spec.ts
@@ -1,0 +1,194 @@
+// #887 — the unread badge on the window you are LOOKING AT.
+//
+// The report (vjt, 2026-08-05, on a channel he had just been reading): focus
+// the window → the badge disappears; switch away → it comes back at 1832.
+// Nothing was wrong — the read cursor was where it should be — but the two
+// states "you are looking at this" and "you have read this" were drawn
+// identically (no badge), so the display lied by omission.
+//
+// The fix removes the suppression overwrite from `perChannelUnread` and pairs
+// it with a read-at-the-tail cursor advance in ScrollbackPane, so the number
+// answers one question everywhere: how much have you not read.
+//
+// Why this has to be a browser test, not jsdom: BOTH halves of the contract
+// are geometry. "Holds while scrolled up" and "drains at the tail" are the
+// same code path taking opposite branches on `atBottomNow`, and jsdom's
+// zero-geometry pane reads as at-the-tail unconditionally — a jsdom test
+// cannot tell the branches apart (measured: deleting the at-tail gate leaves
+// the entire 171-test ScrollbackPane suite green). This spec is where that
+// gate is actually pinned.
+//
+// Per `feedback_e2e_user_class_parity_matrix`: this pins the unread-badge
+// CONTRACT, not a verb across user classes — one seeded registered user is
+// the right shape.
+
+import type { Page } from "@playwright/test";
+import { expect, test } from "../fixtures/test";
+import { loginAs, selectChannel, sidebarMessageBadge } from "../fixtures/cicchettoPage";
+import {
+  fetchAllMessagesAsc,
+  restoreReadCursorToTail,
+  setReadCursorToId,
+} from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+const PEER_NICK = "badge887-buddy";
+const RUN_ID = crypto.randomUUID().slice(0, 8);
+
+// How far back to plant the cursor. Two hard bounds, and the window between
+// them is where this scenario exists at all:
+//   * FAR ENOUGH that the divider the pane activates on is off-screen, so the
+//     pane lands NOT at the tail — the state whose badge must hold.
+//   * UNDER 200, or `isFarBehind` (scrollback.ts, #693) trips, the cursor
+//     freezes by design and the badge could never drain. That is #888's
+//     subject, not this one.
+const UNREAD_DEPTH = 120;
+
+// Longer than the pane's read-at-the-tail debounce (500ms) plus generous
+// browser slop. Every "the badge must NOT have moved" assertion waits this
+// long first — a negative that does not outlive the mechanism it is denying
+// proves nothing.
+const PAST_READ_AT_TAIL_SETTLE_MS = 1_500;
+
+// Longer than INPUT_EVENT_RECENCY_MS (1500ms). Waiting it out CLOSES the
+// scroll-settle arm's input gate, so a cursor advance observed afterwards
+// cannot be attributed to the operator's last wheel — it can only be the
+// read-at-the-tail arm. Displacement, not coincidence.
+const PAST_INPUT_RECENCY_MS = 2_200;
+
+async function wheelOverPane(page: Page, deltaY: number): Promise<void> {
+  // A REAL WheelEvent: ScrollbackPane's onScroll settle arm is gated on a
+  // preceding operator input event, and a synthetic `dispatchEvent("scroll")`
+  // does not stamp one (BUGHUNT-2).
+  const box = await page.locator('[data-testid="scrollback"]').boundingBox();
+  if (!box) throw new Error("scrollback bounding box null");
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.wheel(0, deltaY);
+}
+
+async function badgeCount(page: Page): Promise<number> {
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  const badge = sidebarMessageBadge(page, NETWORK_SLUG, CHANNEL);
+  if ((await badge.count()) === 0) return 0;
+  const text = (await badge.textContent()) ?? "";
+  const n = Number.parseInt(text.trim(), 10);
+  return Number.isNaN(n) ? 0 : n;
+}
+
+test.describe("#887 focused-window unread badge", () => {
+  // BUGHUNT-3 cascade rule: this spec deliberately leaves the cursor
+  // mid-channel for most of its run. Restore to tail so downstream specs
+  // inherit a fully-read #bofh.
+  test.afterAll(async () => {
+    if (!CHANNEL) return;
+    const vjt = getSeededVjt();
+    await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
+  });
+
+  test("survives focus, holds while scrolled up, and falls as the operator reads", async ({
+    page,
+  }) => {
+    if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+    const vjt = getSeededVjt();
+
+    const rows = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, CHANNEL);
+    expect(rows.length).toBeGreaterThanOrEqual(UNREAD_DEPTH + 10);
+    const lastRead = rows[rows.length - UNREAD_DEPTH];
+    if (!lastRead) throw new Error("#887 spec: seeded #bofh rows missing expected index");
+
+    // Plant the cursor BEFORE login so the channel hydrates already behind.
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, lastRead.id);
+
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+    const badge = sidebarMessageBadge(page, NETWORK_SLUG, CHANNEL);
+
+    // ── THE HEADLINE (RED pre-#887) ─────────────────────────────────────
+    // Focusing the window used to zero this badge outright. It must be here,
+    // showing the real distance.
+    await expect(badge).toBeVisible({ timeout: 10_000 });
+    const onFocus = await badgeCount(page);
+    expect(onFocus).toBeGreaterThan(60);
+
+    // ── HOLDS WHILE SCROLLED UP ─────────────────────────────────────────
+    // The pane activated on the unread divider, ~120 rows above the tail, so
+    // the operator is NOT looking at the newest rows. Waiting out the
+    // read-at-the-tail debounce must change nothing: marking rows read
+    // because they exist below the fold is precisely the mistake the
+    // at-tail gate exists to refuse.
+    await page.waitForTimeout(PAST_READ_AT_TAIL_SETTLE_MS);
+    expect(await badgeCount(page)).toBe(onFocus);
+
+    // ── FALLS AS THEY READ ──────────────────────────────────────────────
+    // A real wheel down: rows scroll past, the scroll-settle arm advances the
+    // cursor to the new visible tail, and the badge must come DOWN — not
+    // vanish (that was the bug) and not hold.
+    await wheelOverPane(page, 1_200);
+    await expect
+      .poll(async () => await badgeCount(page), { timeout: 10_000 })
+      .toBeLessThan(onFocus);
+    const afterReading = await badgeCount(page);
+    // Still unread rows below: a partial read is a partial drop. Asserting
+    // the INTERMEDIATE value is the point — a badge that only ever went
+    // "N → gone" would satisfy a first-and-last check while being exactly
+    // the vanishing behaviour #887 removed.
+    expect(afterReading).toBeGreaterThan(0);
+
+    // ── REACHES ZERO AT THE TAIL ────────────────────────────────────────
+    await wheelOverPane(page, 20_000);
+    await expect(badge).toHaveCount(0, { timeout: 10_000 });
+  });
+
+  test("a message arriving while the operator watches the tail clears itself", async ({ page }) => {
+    if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+    const vjt = getSeededVjt();
+
+    // Caught up and parked at the tail — the state the old suppression used
+    // to paper over and the one no pre-existing writer can serve: leave /
+    // blur / unmount all need the operator to STOP looking, and scroll-settle
+    // needs an input event that never comes.
+    await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+    await expect(sidebarMessageBadge(page, NETWORK_SLUG, CHANNEL)).toHaveCount(0, {
+      timeout: 10_000,
+    });
+
+    // Close the scroll-settle arm's input gate before doing anything else:
+    // `selectChannel` may have produced input events, and inside the recency
+    // window a drain could be attributed to the settle arm rather than to the
+    // read-at-the-tail one. After this wait only the latter can fire.
+    await page.waitForTimeout(PAST_INPUT_RECENCY_MS);
+
+    const peer = await IrcPeer.connect({ nick: PEER_NICK });
+    try {
+      await peer.join(CHANNEL);
+      const body = `#887 watched arrival ${RUN_ID}`;
+      peer.privmsg(CHANNEL, body);
+
+      // The row lands and the pane tail-follows it into view.
+      await expect(
+        page.locator('[data-testid="scrollback-line"]', { hasText: body }),
+      ).toBeVisible({ timeout: 10_000 });
+
+      // …and settles back to no badge, with the operator having touched
+      // nothing. Without the read-at-the-tail arm this sticks at 1 forever:
+      // the row is past the cursor, the badge is no longer suppressed, and
+      // every other writer is waiting for the operator to leave.
+      //
+      // The wait is load-bearing and must come BEFORE the assertion, not as
+      // its timeout: `toHaveCount(0)` resolves on the FIRST poll that
+      // succeeds, and the badge is legitimately absent for the instant
+      // between the row landing and the count bumping — so a bare
+      // auto-retrying assertion here would pass against a broken arm. Settle
+      // past the debounce first, then read once.
+      await page.waitForTimeout(PAST_READ_AT_TAIL_SETTLE_MS);
+      expect(await badgeCount(page)).toBe(0);
+    } finally {
+      await peer.disconnect("#887 watched-arrival done");
+    }
+  });
+});

--- a/cicchetto/src/BottomBar.tsx
+++ b/cicchetto/src/BottomBar.tsx
@@ -1,18 +1,11 @@
-import { type Component, createEffect, For, on, Show } from "solid-js";
+import { type Component, createEffect, For, on } from "solid-js";
 import CloseButton from "./CloseButton";
 import { channelKey } from "./lib/channelKey";
-import { mentionCounts } from "./lib/mentions";
 import { channelsBySlug, networks } from "./lib/networks";
 import { pseudoChannelsForNetwork } from "./lib/pseudoChannels";
 import { queryWindowsByNetwork } from "./lib/queryWindows";
 import { requestScrollToBottom } from "./lib/scrollToBottomCommand";
-import {
-  eventsUnread,
-  isActiveSelection,
-  messagesUnread,
-  selectedChannel,
-  setSelectedChannel,
-} from "./lib/selection";
+import { isActiveSelection, selectedChannel, setSelectedChannel } from "./lib/selection";
 import {
   closeQueryWindow,
   confirmDisconnectNetwork,
@@ -22,6 +15,7 @@ import {
 import type { WindowKind } from "./lib/windowKinds";
 import { SERVER_WINDOW_NAME } from "./lib/windowKinds";
 import NickText from "./NickText";
+import WindowBadges from "./WindowBadges";
 
 // BottomBar: mobile-only window picker rendered UNDER ComposeBox.
 //
@@ -168,15 +162,7 @@ const BottomBar: Component<Props> = (props) => {
                   ⚙️
                 </span>
                 <span class="bottom-bar-network-name">{network.slug}</span>
-                <Show when={(messagesUnread()[headerKey] ?? 0) > 0}>
-                  <span class="bottom-bar-msg-unread">{messagesUnread()[headerKey]}</span>
-                </Show>
-                <Show when={(eventsUnread()[headerKey] ?? 0) > 0}>
-                  <span class="bottom-bar-events-unread">{eventsUnread()[headerKey]}</span>
-                </Show>
-                <Show when={(mentionCounts()[headerKey] ?? 0) > 0}>
-                  <span class="bottom-bar-mention">@{mentionCounts()[headerKey]}</span>
-                </Show>
+                <WindowBadges channelKey={headerKey} variant="bottom-bar" />
               </button>
               {/* Disconnect × — sibling of the header, same flat-flex
                   discipline as channel/query closes (post-UX-3-DEC).
@@ -208,15 +194,7 @@ const BottomBar: Component<Props> = (props) => {
                         onClick={() => handleClick(network.slug, channel.name, "channel")}
                       >
                         {channel.name}
-                        <Show when={(messagesUnread()[key] ?? 0) > 0}>
-                          <span class="bottom-bar-msg-unread">{messagesUnread()[key]}</span>
-                        </Show>
-                        <Show when={(eventsUnread()[key] ?? 0) > 0}>
-                          <span class="bottom-bar-events-unread">{eventsUnread()[key]}</span>
-                        </Show>
-                        <Show when={(mentionCounts()[key] ?? 0) > 0}>
-                          <span class="bottom-bar-mention">@{mentionCounts()[key]}</span>
-                        </Show>
+                        <WindowBadges channelKey={key} variant="bottom-bar" />
                       </button>
                       <CloseButton
                         class="bottom-bar-close"
@@ -284,15 +262,7 @@ const BottomBar: Component<Props> = (props) => {
                         onClick={() => handleClick(network.slug, qw.targetNick, "query")}
                       >
                         <NickText nick={qw.targetNick} extraClass="bottom-bar-tab-nick" />
-                        <Show when={(messagesUnread()[key] ?? 0) > 0}>
-                          <span class="bottom-bar-msg-unread">{messagesUnread()[key]}</span>
-                        </Show>
-                        <Show when={(eventsUnread()[key] ?? 0) > 0}>
-                          <span class="bottom-bar-events-unread">{eventsUnread()[key]}</span>
-                        </Show>
-                        <Show when={(mentionCounts()[key] ?? 0) > 0}>
-                          <span class="bottom-bar-mention">@{mentionCounts()[key]}</span>
-                        </Show>
+                        <WindowBadges channelKey={key} variant="bottom-bar" />
                       </button>
                       <CloseButton
                         class="bottom-bar-close"

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -156,9 +156,20 @@ const SCROLL_SETTLE_DEBOUNCE_MS = 500;
 // #239 — debounce for the trailing-hidden cursor advance (Facet B). Coalesces
 // join/part storms (netsplits on a large / presence-hidden channel) to a single
 // forward cursor POST once arrivals quiesce. Same magnitude as the scroll-settle
-// debounce; the badge is suppressed while focused so the operator never sees the
-// delay, and the DOM settle paths stay eager.
+// debounce; the DOM settle paths stay eager. #887 — the focused window's badge
+// is no longer suppressed, so this delay IS now visible as a badge that lingers
+// half a second over a hidden join burst before dropping. Deliberate: the
+// alternative is a POST per netsplit line.
 const PRESENCE_CURSOR_SETTLE_MS = 500;
+
+// #887 — debounce for the read-at-the-tail cursor advance. Coalesces a burst of
+// arrivals into one forward POST, and — the load-bearing part — outlasts the
+// activation routine's rAF-deferred geometry write: a cold open into an unread
+// window mounts with `atBottomNow` at its `createSignal(true)` default and only
+// learns it actually jumped to a far divider a frame or two later (~:2094).
+// Firing inside that window would mark the backlog read from under the
+// operator. 500ms is ~30 frames of margin; it is NOT a tuning knob.
+const READ_AT_TAIL_SETTLE_MS = 500;
 
 // BUGHUNT-2: input-event-recency window for the scroll-settle gate.
 // onScroll only arms the settle timer if a real operator input event
@@ -1000,6 +1011,21 @@ type Row = SeparatorRow | UnreadMarkerRow | MessageRow | InviteAckRow | TopicRow
 
 const ScrollbackPane: Component<Props> = (props) => {
   let listRef!: HTMLDivElement;
+  // Every settle writer in this component answers the SAME question — "what
+  // is the last row the operator can actually see?" — and hands the answer to
+  // the one forward-only door (`setCursorIfAdvances`, which owns the #233
+  // monotonic clamp and the #693 far-behind freeze). Unmount, channel-leave,
+  // browser-blur, scroll-settle, the scroll-to-bottom gesture and the #887
+  // read-at-the-tail arm all shared this three-line body verbatim; it lives
+  // here once so a future guard cannot land in four of the five.
+  const settleCursorToVisibleTail = (): void => {
+    // `listRef!` is a definite-assignment ref: typed non-null, but genuinely
+    // undefined until Solid assigns it at mount (and every caller guarded it).
+    if (!listRef) return;
+    const id = lastFullyVisibleRowId(listRef);
+    if (id === null) return;
+    setCursorIfAdvances(props.networkSlug, props.channelName, id);
+  };
   // UX-8 (b): scroll-settle debounce timer. Plain let — pure mutation,
   // no Solid reactivity. Cleared on the next scroll event; fires once
   // when scroll has been quiescent for SCROLL_SETTLE_DEBOUNCE_MS.
@@ -1618,12 +1644,7 @@ const ScrollbackPane: Component<Props> = (props) => {
   // CURRENT pane (props.networkSlug, props.channelName — captured in
   // the closure at component-init time, won't change before unmount
   // because the component IS this (slug, channel) instance).
-  onCleanup(() => {
-    if (!listRef) return;
-    const id = lastFullyVisibleRowId(listRef);
-    if (id === null) return;
-    setCursorIfAdvances(props.networkSlug, props.channelName, id);
-  });
+  onCleanup(settleCursorToVisibleTail);
 
   createEffect(
     on(
@@ -2399,10 +2420,12 @@ const ScrollbackPane: Component<Props> = (props) => {
   // and POSTs via setCursorIfAdvances. Mirror of the leave-arm in
   // A3's key-effect, but for the no-key-change case.
   //
-  // No false→true arm here — focus-regain does NOT write the live
-  // cursor. (The DISPLAY snapshot IS re-latched on focus-regain by the
-  // sibling activation effect above — freeze contract option (b) — but
-  // that re-reads the existing cursor, it doesn't advance it.)
+  // No false→true arm HERE — the hide edge is this effect's whole job. The
+  // return edge is owned by the #887 read-at-the-tail arm below, which reaches
+  // the same door under a geometry gate this one does not need. (The DISPLAY
+  // snapshot is re-latched on focus-regain by the sibling activation effect
+  // above — freeze contract option (b) — by re-reading the cursor, not
+  // advancing it; that stays true whichever arm advances it.)
   //
   // `prev === undefined` guards the initial-mount run (mirrors the
   // sibling effect's identical guard).
@@ -2410,12 +2433,60 @@ const ScrollbackPane: Component<Props> = (props) => {
     on(isDocumentVisible, (visible, prev) => {
       if (prev === undefined) return;
       if (prev !== true || visible !== false) return;
-      if (!listRef) return;
-      const id = lastFullyVisibleRowId(listRef);
-      if (id === null) return;
-      setCursorIfAdvances(props.networkSlug, props.channelName, id);
+      settleCursorToVisibleTail();
     }),
   );
+
+  // #887 — read-at-the-tail. THE arm that makes a visible badge honest.
+  //
+  // Removing the focused-window suppression (selection.ts) exposed a cadence
+  // the badge could not survive: the pre-existing writers all fire when the
+  // operator STOPS looking (leave, blur, unmount) or when they SCROLL
+  // (scroll-settle, gated on a real input event). An operator sitting at the
+  // tail of a quiet window generates neither — so a message arriving while
+  // they watch it land would bump the badge to 1 and leave it there until
+  // they walked away. Suppression used to hide that; without an arm here the
+  // change would just trade a vanishing badge for a stuck one, which is the
+  // same complaint in a different flavour (#887's own warning).
+  //
+  // The rule is the honest one: while the tab is visible AND the pane is at
+  // the tail, what is rendered is what the operator is reading, so mark it
+  // read. Both gates are load-bearing:
+  //   * `isDocumentVisible()` — a selected-but-BACKGROUNDED tab must keep
+  //     accruing (the property the old suppression's visibility gate had, and
+  //     the one thing about it worth keeping).
+  //   * `atBottomNow()` — the GEOMETRIC measurement, not the `followMode`
+  //     intent. A reader parked above the tail, and a cold activation that
+  //     jumped to a far `── N unread ──` divider (which sets both false, ~:2094),
+  //     are NOT reading the rows below the fold; their badge must stand.
+  // Everything dangerous past those gates is already refused downstream:
+  // `setCursorIfAdvances` freezes a far-behind window (#693 — the case #888
+  // then makes legible) and is forward-only (#233), so a scrolled-up snapshot
+  // can never rewind.
+  //
+  // Debounced, and the timer is cleared+re-armed on EVERY re-run BEFORE the
+  // guards, because the fire callback reads `props` at fire time — a schedule
+  // left over from the previous window must never write the switched-to one
+  // (same hazard, same shape, as the #239 presence arm below). `key()` is read
+  // for exactly that reason: a channel switch must re-arm, not inherit.
+  let readAtTailSettleTimer: number | undefined;
+  createEffect(() => {
+    key();
+    const rowCount = rows()?.length ?? 0;
+    const visible = isDocumentVisible();
+    const atTail = atBottomNow();
+    if (readAtTailSettleTimer !== undefined) {
+      window.clearTimeout(readAtTailSettleTimer);
+      readAtTailSettleTimer = undefined;
+    }
+    if (!visible || !atTail || rowCount === 0) return;
+    readAtTailSettleTimer = window.setTimeout(settleCursorToVisibleTail, READ_AT_TAIL_SETTLE_MS);
+  });
+  onCleanup(() => {
+    if (readAtTailSettleTimer !== undefined) {
+      window.clearTimeout(readAtTailSettleTimer);
+    }
+  });
 
   // #239 — advance the server read-cursor over the TRAILING run of hidden
   // control messages while this window is DISPLAYED. The #222 presence filter
@@ -3199,13 +3270,7 @@ const ScrollbackPane: Component<Props> = (props) => {
     if (scrollSettleTimer !== undefined) {
       window.clearTimeout(scrollSettleTimer);
     }
-    scrollSettleTimer = window.setTimeout(() => {
-      if (!listRef) return;
-      const id = lastFullyVisibleRowId(listRef);
-      if (id !== null) {
-        setCursorIfAdvances(props.networkSlug, props.channelName, id);
-      }
-    }, SCROLL_SETTLE_DEBOUNCE_MS);
+    scrollSettleTimer = window.setTimeout(settleCursorToVisibleTail, SCROLL_SETTLE_DEBOUNCE_MS);
   };
 
   // #310 — the scroll-to-bottom GESTURE, shared by the floating button's
@@ -3243,11 +3308,7 @@ const ScrollbackPane: Component<Props> = (props) => {
   const scrollToBottomGesture = () => {
     applyOperatorTail();
     setMarkerActivationPending(false);
-    if (!listRef) return;
-    const id = lastFullyVisibleRowId(listRef);
-    if (id !== null) {
-      setCursorIfAdvances(props.networkSlug, props.channelName, id);
-    }
+    settleCursorToVisibleTail();
   };
 
   // #360 — the floating button's tap handler (replaces the raw

--- a/cicchetto/src/Sidebar.tsx
+++ b/cicchetto/src/Sidebar.tsx
@@ -3,20 +3,13 @@ import CloseButton from "./CloseButton";
 import { ownNickForNetwork } from "./lib/api";
 import { awayByNetwork } from "./lib/awayStatus";
 import { channelKey } from "./lib/channelKey";
-import { mentionCounts } from "./lib/mentions";
 import { mentionsBundleBySlug } from "./lib/mentionsWindow";
 import { channelsBySlug, isAdmin, networkBySlug, networks, user } from "./lib/networks";
 import { pseudoChannelsForNetwork } from "./lib/pseudoChannels";
 import { queryWindowsByNetwork } from "./lib/queryWindows";
 import { reconnectingByNetwork } from "./lib/reconnectingStatus";
 import { requestScrollToBottom } from "./lib/scrollToBottomCommand";
-import {
-  eventsUnread,
-  isActiveSelection,
-  messagesUnread,
-  selectedChannel,
-  setSelectedChannel,
-} from "./lib/selection";
+import { isActiveSelection, selectedChannel, setSelectedChannel } from "./lib/selection";
 import { openUmodeModal } from "./lib/umodeModal";
 import { umodesForNetwork } from "./lib/umodes";
 import {
@@ -36,6 +29,7 @@ import {
 } from "./lib/windowKinds";
 import { windowStateByChannel } from "./lib/windowState";
 import NickText from "./NickText";
+import WindowBadges from "./WindowBadges";
 
 // Left-pane sidebar: network → window tree. Renders ordered windows:
 //   1. Server (always present, not closeable)
@@ -345,22 +339,10 @@ const Sidebar: Component<Props> = () => {
                     {/* CP13 — server-window receives :notice rows for server-routed
                       numerics + NickServ + MOTD + ChanServ-fallback. Same badge
                       treatment as channels so unread counts surface uniformly. */}
-                    {(() => {
-                      const key = channelKey(network.slug, SERVER_WINDOW_NAME);
-                      return (
-                        <>
-                          <Show when={(messagesUnread()[key] ?? 0) > 0}>
-                            <span class="sidebar-msg-unread">{messagesUnread()[key]}</span>
-                          </Show>
-                          <Show when={(eventsUnread()[key] ?? 0) > 0}>
-                            <span class="sidebar-events-unread">{eventsUnread()[key]}</span>
-                          </Show>
-                          <Show when={(mentionCounts()[key] ?? 0) > 0}>
-                            <span class="sidebar-mention">@{mentionCounts()[key]}</span>
-                          </Show>
-                        </>
-                      );
-                    })()}
+                    <WindowBadges
+                      channelKey={channelKey(network.slug, SERVER_WINDOW_NAME)}
+                      variant="sidebar"
+                    />
                   </button>
                   {/* #229 — umode indicator + tap target. Shows the
                     operator's own umodes compactly (e.g. "+iS") and opens
@@ -478,15 +460,7 @@ const Sidebar: Component<Props> = () => {
                               the only way either is distinguishable at all. */}
                           <RowState state={channel.joined ? null : "parted"} />
                           <RowState state={greyedState(network.slug, channel.name)} />
-                          <Show when={(messagesUnread()[key] ?? 0) > 0}>
-                            <span class="sidebar-msg-unread">{messagesUnread()[key]}</span>
-                          </Show>
-                          <Show when={(eventsUnread()[key] ?? 0) > 0}>
-                            <span class="sidebar-events-unread">{eventsUnread()[key]}</span>
-                          </Show>
-                          <Show when={(mentionCounts()[key] ?? 0) > 0}>
-                            <span class="sidebar-mention">@{mentionCounts()[key]}</span>
-                          </Show>
+                          <WindowBadges channelKey={key} variant="sidebar" />
                         </button>
                         <CloseButton
                           class="sidebar-close"
@@ -595,15 +569,7 @@ const Sidebar: Component<Props> = () => {
                         >
                           <NickText nick={qw.targetNick} extraClass="sidebar-channel-name" />
                           <RowState state={greyedState(network.slug, qw.targetNick)} />
-                          <Show when={(messagesUnread()[key] ?? 0) > 0}>
-                            <span class="sidebar-msg-unread">{messagesUnread()[key]}</span>
-                          </Show>
-                          <Show when={(eventsUnread()[key] ?? 0) > 0}>
-                            <span class="sidebar-events-unread">{eventsUnread()[key]}</span>
-                          </Show>
-                          <Show when={(mentionCounts()[key] ?? 0) > 0}>
-                            <span class="sidebar-mention">@{mentionCounts()[key]}</span>
-                          </Show>
+                          <WindowBadges channelKey={key} variant="sidebar" />
                         </button>
                         <CloseButton
                           class="sidebar-close"

--- a/cicchetto/src/WindowBadges.tsx
+++ b/cicchetto/src/WindowBadges.tsx
@@ -1,0 +1,116 @@
+import { type Component, Show } from "solid-js";
+import type { ChannelKey } from "./lib/channelKey";
+import { mentionCounts } from "./lib/mentions";
+import { farBehindByChannel } from "./lib/scrollback";
+import { eventsUnread, messagesUnread } from "./lib/selection";
+
+// The unread / events / mention badge triad that trails a window row.
+//
+// Six verbatim copies of it used to sit inline — three in `Sidebar.tsx`
+// (server header, channel list, query list) and three in `BottomBar.tsx`
+// (the same three windows, mobile). #888 needed ONE predicate added to all
+// six; pasting it six times is exactly the copy-paste-with-tweaks CLAUDE.md
+// forbids, and the seventh window surface would have inherited five of the
+// six behaviours. So the triad lives here once and the two surfaces differ
+// only in the class prefix they were already using.
+//
+// The prefix is a closed set resolved through this table rather than
+// interpolated, so a typo is a type error and every class name stays
+// greppable from the stylesheet.
+const BADGE_CLASSES = {
+  sidebar: {
+    messages: "sidebar-msg-unread",
+    events: "sidebar-events-unread",
+    mention: "sidebar-mention",
+  },
+  "bottom-bar": {
+    messages: "bottom-bar-msg-unread",
+    events: "bottom-bar-events-unread",
+    mention: "bottom-bar-mention",
+  },
+} as const;
+
+export type WindowBadgesVariant = keyof typeof BADGE_CLASSES;
+
+// #888 — the modifier that says "this number is a DISTANCE, not a counter".
+// Shared by both variants: the stylesheet qualifies it per badge class, but
+// the token itself is one string so the two surfaces cannot drift apart.
+export const FAR_BEHIND_CLASS = "far-behind";
+
+export type BadgeKind = "messages" | "events";
+
+// What the badge SAYS, as opposed to what it shows. A bare "1832" inside a
+// row button is announced as a number with no unit and no state, which is
+// how a frozen far-behind count (#693) became indistinguishable from a live
+// one — two people read it as a broken counter on IRC the day #888 was
+// filed. The far-behind wording names the state AND the way out, at the
+// place the number is seen. `kind` is explicit rather than defaulted: the
+// events badge is frozen for the same reason but is not counting messages,
+// and a silent default would have it lie.
+export const badgeLabel = (count: number, kind: BadgeKind, farBehind: boolean): string =>
+  farBehind
+    ? `${count} ${kind} behind — jump to the boundary to catch up`
+    : `${count} unread ${kind}`;
+
+type Props = {
+  channelKey: ChannelKey;
+  variant: WindowBadgesVariant;
+};
+
+const WindowBadges: Component<Props> = (props) => {
+  const classes = () => BADGE_CLASSES[props.variant];
+  // Read the signal, not a snapshot: `dismissFarBehind` / `jumpToUnread`
+  // clear the record and the modifier must clear with it (#888 acceptance).
+  const farBehind = () => farBehindByChannel()[props.channelKey] !== undefined;
+  const messages = () => messagesUnread()[props.channelKey] ?? 0;
+  const events = () => eventsUnread()[props.channelKey] ?? 0;
+  const mentions = () => mentionCounts()[props.channelKey] ?? 0;
+
+  // BOTH unread badges take the treatment, not just the message one: the
+  // far-behind branch of `perChannelUnread` skips local counting wholesale
+  // and serves the frozen server seed for BOTH kinds, so both are equally
+  // stuck. The mention badge is left alone — it is server-authoritative and
+  // counted a different way (#267), so the cursor freeze does not pin it.
+  //
+  // `role="img"` + `aria-label` on both unread badges, unconditionally. The
+  // label carries the whole meaning, so the far-behind state is spoken
+  // ("1832 messages behind…") instead of arriving as a number that sounds
+  // exactly like a live one. Unconditional because the role is what makes
+  // `aria-label` legal on a <span> at all (a generic element does not support
+  // it), and a role that appears only in one state is a role a linter cannot
+  // check and a reader cannot predict. Same shape as the away badge in
+  // `Sidebar.tsx`. `title` is the sighted-hover twin, and is added only in the
+  // far-behind state: a tooltip reading "5 unread messages" over a "5" is
+  // noise.
+  return (
+    <>
+      <Show when={messages() > 0}>
+        <span
+          class={classes().messages}
+          classList={{ [FAR_BEHIND_CLASS]: farBehind() }}
+          role="img"
+          title={farBehind() ? badgeLabel(messages(), "messages", true) : undefined}
+          aria-label={badgeLabel(messages(), "messages", farBehind())}
+        >
+          {messages()}
+        </span>
+      </Show>
+      <Show when={events() > 0}>
+        <span
+          class={classes().events}
+          classList={{ [FAR_BEHIND_CLASS]: farBehind() }}
+          role="img"
+          title={farBehind() ? badgeLabel(events(), "events", true) : undefined}
+          aria-label={badgeLabel(events(), "events", farBehind())}
+        >
+          {events()}
+        </span>
+      </Show>
+      <Show when={mentions() > 0}>
+        <span class={classes().mention}>@{mentions()}</span>
+      </Show>
+    </>
+  );
+};
+
+export default WindowBadges;

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -1891,7 +1891,11 @@ describe("ScrollbackPane", () => {
       });
 
       // A bare mount/activation is a PROGRAMMATIC scroll — it must NOT advance
-      // the cursor (that's the BUGHUNT-2 input-gate contract).
+      // the cursor (that's the BUGHUNT-2 input-gate contract). Read here and
+      // now: post-#887 the read-at-the-tail arm WILL advance it half a second
+      // later on this jsdom pane (zero geometry reads as at-the-tail), which
+      // is correct and unrelated — the claim being pinned is that the gesture
+      // below is what does it, not the mount.
       expect(mockSetCursorIfAdvances).not.toHaveBeenCalled();
 
       // THE GESTURE: the jump-to-bottom command the floating button + the #243
@@ -4126,6 +4130,17 @@ describe("ScrollbackPane", () => {
   // jsdom layout returns null for `lastFullyVisibleRowId` (no real
   // viewport) so a jsdom positive test would not exercise the POST
   // branch.
+  //
+  // #887 — the observation is now taken with the tab HIDDEN. Not a
+  // convenience: jsdom's zero geometry makes every pane read as "at the
+  // tail", so the read-at-the-tail arm fires on its own 500ms debounce and
+  // would land a cursor write inside this test's wait window — a write that
+  // has nothing to do with the input gate but is indistinguishable from one
+  // at the mock. Hiding the tab closes THAT arm (its `isDocumentVisible`
+  // gate) through production's own door and leaves the scroll-settle arm
+  // fully armed, so what the assertion sees is the gate under test and
+  // nothing else. The blur transition itself writes the cursor (the
+  // browser-blur arm), hence the explicit clear before the scroll.
   describe("BUGHUNT-2 input-event gate", () => {
     it("scroll without preceding pointerdown does NOT call setCursorIfAdvances", async () => {
       // Seed enough rows for the scroll-settle path to be considered.
@@ -4148,6 +4163,12 @@ describe("ScrollbackPane", () => {
       expect(list).not.toBeNull();
       if (!list) throw new Error("scrollback DOM not found");
 
+      // Close the #887 read-at-the-tail arm (visibility gate) and drop the
+      // cursor write the blur transition itself performs.
+      setDocVisible(false);
+      await new Promise((r) => setTimeout(r, 0));
+      mockSetCursorIfAdvances.mockClear();
+
       // Fire scroll without any prior pointerdown / wheel / touchmove /
       // keydown. The gate's `lastInputEventAtMs` stays null → settle
       // timer never arms.
@@ -4158,6 +4179,61 @@ describe("ScrollbackPane", () => {
       // suite doesn't enable fake timers).
       await new Promise((r) => setTimeout(r, 700));
 
+      expect(mockSetCursorIfAdvances).not.toHaveBeenCalled();
+    });
+  });
+
+  // #887 — read-at-the-tail. The arm that makes an UN-suppressed badge honest.
+  //
+  // Removing the focused-window suppression (selection.ts) left the badge with
+  // no way DOWN while the operator sits at the tail of a quiet window: every
+  // pre-existing writer fires when they stop looking (leave / blur / unmount)
+  // or when they scroll (settle, gated on a real input event). A message
+  // landing while they watch it land would have bumped the badge and left it
+  // there — a stuck number instead of a vanishing one, the same complaint
+  // wearing a different hat.
+  //
+  // So: tab visible + pane at the tail ⇒ what is rendered is being read.
+  // jsdom's zero geometry reads as at-the-tail via `lastFullyVisibleRowId`'s
+  // at-bottom short-circuit, which is exactly the state under test.
+  describe("#887 read-at-the-tail cursor advance", () => {
+    it("advances to the arriving row with NO operator input event", async () => {
+      seedReadCursor("freenode", "#grappa", 1);
+      setScrollback({ "freenode #grappa": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      await waitFor(() => {
+        expect(screen.getAllByTestId("scrollback-line")).toHaveLength(3);
+      });
+
+      // No pointerdown / wheel / touchmove / keydown, and no gesture: the
+      // scroll-settle arm can never fire here. The only thing that can move
+      // the cursor is the state "visible AND at the tail".
+      await waitFor(
+        () => {
+          expect(mockSetCursorIfAdvances).toHaveBeenCalledWith("freenode", "#grappa", 3);
+        },
+        { timeout: 2_000 },
+      );
+    });
+
+    it("stands down while the tab is hidden (a backgrounded tab is not being read)", async () => {
+      seedReadCursor("freenode", "#grappa", 1);
+      setScrollback({ "freenode #grappa": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      await waitFor(() => {
+        expect(screen.getAllByTestId("scrollback-line")).toHaveLength(3);
+      });
+
+      // Hide, and drop the write the blur arm itself performs — what is under
+      // test is whether the read-at-the-tail arm keeps firing afterwards.
+      setDocVisible(false);
+      await new Promise((r) => setTimeout(r, 0));
+      mockSetCursorIfAdvances.mockClear();
+
+      // Well past the debounce: a selected-but-backgrounded tab must keep
+      // accruing its badge (the one property of the old suppression's
+      // visibility gate worth keeping), so nothing may be marked read.
+      await new Promise((r) => setTimeout(r, 900));
       expect(mockSetCursorIfAdvances).not.toHaveBeenCalled();
     });
   });

--- a/cicchetto/src/__tests__/WindowBadges.test.tsx
+++ b/cicchetto/src/__tests__/WindowBadges.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// #888 — the far-behind unread badge.
+//
+// A far-behind window (#693) has its read cursor deliberately frozen, so its
+// count does not move while the operator reads. Drawn as the ordinary solid
+// pill it is indistinguishable from a live counter, and two people read it as
+// a broken one on IRC the day the issue was filed. These tests pin the
+// legibility contract: the badge takes a distinct treatment and says what the
+// number means, the treatment clears the moment the far-behind record does,
+// and it never leaks onto a window that is merely unread.
+//
+// The component is rendered directly rather than through `Sidebar` /
+// `BottomBar`: the whole point of extracting it was that the two surfaces
+// render the SAME triad, and testing it through one of them would leave the
+// other's behaviour asserted nowhere. Both variants are driven here.
+
+const mockFarBehind = vi.hoisted(() => ({
+  value: {} as Record<string, { missed: number; resumeFrom: number } | undefined>,
+}));
+const mockMessages = vi.hoisted(() => ({ value: {} as Record<string, number> }));
+const mockEvents = vi.hoisted(() => ({ value: {} as Record<string, number> }));
+const mockMentions = vi.hoisted(() => ({ value: {} as Record<string, number> }));
+
+vi.mock("../lib/scrollback", () => ({
+  farBehindByChannel: () => mockFarBehind.value,
+}));
+vi.mock("../lib/selection", () => ({
+  messagesUnread: () => mockMessages.value,
+  eventsUnread: () => mockEvents.value,
+}));
+vi.mock("../lib/mentions", () => ({
+  mentionCounts: () => mockMentions.value,
+}));
+
+import { channelKey } from "../lib/channelKey";
+import WindowBadges, { badgeLabel, FAR_BEHIND_CLASS } from "../WindowBadges";
+
+const BEHIND = channelKey("freenode", "#italia");
+const NORMAL = channelKey("freenode", "#bnc");
+
+beforeEach(() => {
+  mockFarBehind.value = {};
+  mockMessages.value = { [BEHIND]: 1832, [NORMAL]: 3 };
+  mockEvents.value = { [BEHIND]: 40, [NORMAL]: 2 };
+  mockMentions.value = {};
+});
+
+describe("#888 far-behind badge treatment", () => {
+  it("marks BOTH unread badges of a far-behind window", () => {
+    mockFarBehind.value = { [BEHIND]: { missed: 1832, resumeFrom: 10 } };
+    const { container } = render(() => <WindowBadges channelKey={BEHIND} variant="sidebar" />);
+
+    const msg = container.querySelector(".sidebar-msg-unread");
+    const events = container.querySelector(".sidebar-events-unread");
+    // Both counts come from the frozen server seed while far behind (the
+    // memo's far-behind branch skips local counting wholesale), so both are
+    // equally stuck and both must say so.
+    expect(msg?.classList.contains(FAR_BEHIND_CLASS)).toBe(true);
+    expect(events?.classList.contains(FAR_BEHIND_CLASS)).toBe(true);
+    // The number itself is untouched — this is a treatment, not a rewrite.
+    expect(msg?.textContent).toBe("1832");
+  });
+
+  it("says what the number means, on hover and to a screen reader", () => {
+    mockFarBehind.value = { [BEHIND]: { missed: 1832, resumeFrom: 10 } };
+    render(() => <WindowBadges channelKey={BEHIND} variant="sidebar" />);
+
+    // Production's own wording, called the way production calls it — a
+    // hardcoded string here would pass while the badge said something else.
+    const expected = badgeLabel(1832, "messages", true);
+    const badge = screen.getByTitle(expected);
+    expect(badge.getAttribute("aria-label")).toBe(expected);
+    // The label must name the distance AND the way out, not just repeat "1832".
+    expect(expected).toContain("behind");
+    expect(expected).toContain("jump");
+  });
+
+  it("leaves a merely-unread window alone", () => {
+    mockFarBehind.value = { [BEHIND]: { missed: 1832, resumeFrom: 10 } };
+    const { container } = render(() => <WindowBadges channelKey={NORMAL} variant="sidebar" />);
+
+    const msg = container.querySelector(".sidebar-msg-unread");
+    expect(msg?.textContent).toBe("3");
+    // The far-behind record belongs to a DIFFERENT key; nothing about it may
+    // reach this one (the leak `ScrollbackPane.test.tsx`'s sibling far-behind
+    // test guards for the pane, guarded here for the badge).
+    expect(msg?.classList.contains(FAR_BEHIND_CLASS)).toBe(false);
+    expect(msg?.getAttribute("title")).toBeNull();
+    expect(msg?.getAttribute("aria-label")).toBe(badgeLabel(3, "messages", false));
+  });
+
+  it("clears the treatment as soon as the far-behind record clears", () => {
+    mockFarBehind.value = { [BEHIND]: { missed: 1832, resumeFrom: 10 } };
+    const { container, unmount } = render(() => (
+      <WindowBadges channelKey={BEHIND} variant="sidebar" />
+    ));
+    expect(
+      container.querySelector(".sidebar-msg-unread")?.classList.contains(FAR_BEHIND_CLASS),
+    ).toBe(true);
+    unmount();
+
+    // `jumpToUnread` / `dismissFarBehind` delete the record; the badge is a
+    // plain unread pill again.
+    mockFarBehind.value = {};
+    const after = render(() => <WindowBadges channelKey={BEHIND} variant="sidebar" />);
+    const msg = after.container.querySelector(".sidebar-msg-unread");
+    expect(msg?.classList.contains(FAR_BEHIND_CLASS)).toBe(false);
+    expect(msg?.getAttribute("title")).toBeNull();
+  });
+
+  it("applies the same treatment on the mobile bottom-bar variant", () => {
+    mockFarBehind.value = { [BEHIND]: { missed: 1832, resumeFrom: 10 } };
+    const { container } = render(() => <WindowBadges channelKey={BEHIND} variant="bottom-bar" />);
+
+    const msg = container.querySelector(".bottom-bar-msg-unread");
+    const events = container.querySelector(".bottom-bar-events-unread");
+    expect(msg?.classList.contains(FAR_BEHIND_CLASS)).toBe(true);
+    expect(events?.classList.contains(FAR_BEHIND_CLASS)).toBe(true);
+    // Same modifier token on both surfaces — the stylesheet qualifies it per
+    // badge class, so a second token here would silently unstyle one of them.
+    expect(msg?.getAttribute("title")).toBe(badgeLabel(1832, "messages", true));
+  });
+
+  it("does not touch the mention badge (server-authoritative, not cursor-frozen)", () => {
+    mockFarBehind.value = { [BEHIND]: { missed: 1832, resumeFrom: 10 } };
+    mockMentions.value = { [BEHIND]: 4 };
+    const { container } = render(() => <WindowBadges channelKey={BEHIND} variant="sidebar" />);
+
+    const mention = container.querySelector(".sidebar-mention");
+    expect(mention?.textContent).toBe("@4");
+    expect(mention?.classList.contains(FAR_BEHIND_CLASS)).toBe(false);
+  });
+
+  it("renders nothing for a window with no counts at all", () => {
+    mockMessages.value = {};
+    mockEvents.value = {};
+    const { container } = render(() => <WindowBadges channelKey={NORMAL} variant="sidebar" />);
+    expect(container.querySelector("span")).toBeNull();
+  });
+});

--- a/cicchetto/src/__tests__/selection.test.ts
+++ b/cicchetto/src/__tests__/selection.test.ts
@@ -1493,17 +1493,23 @@ describe("selection store", () => {
     });
   });
 
-  // 2026-06-02 — decouple the sidebar badge from the read cursor. The
-  // badge means "have I opened this window?" and must clear on SELECT,
-  // independent of the cursor (which the in-pane marker still rides on,
-  // so the marker survives the select). selection.ts suppresses the
-  // focused-AND-visible window's message/event counts in perChannelUnread;
-  // the cursor is never written here (ScrollbackPane owns cursor writes).
-  // Spec: docs/superpowers/specs/2026-06-02-decouple-unread-badge-design.md
-  describe("focused-window badge suppression (2026-06-02)", () => {
+  // #887 — the focused window's badge is NOT special any more.
+  //
+  // It used to be zeroed by a final overwrite in `perChannelUnread` while the
+  // window was selected AND the tab visible (2026-06-02, decouple-unread-badge
+  // RC1). That drew "you are looking at this" and "you have read this"
+  // identically — as no badge — while deliberately leaving the cursor where it
+  // was, so the number vanished on select and came back whole on leave. These
+  // tests pin the reversal: the count answers "how much have you not read" in
+  // the selected window exactly as in every other one, and it moves only when
+  // the read cursor moves. (That the cursor DOES move while the operator reads
+  // is ScrollbackPane's read-at-the-tail arm, tested there; the falling badge
+  // itself is `unreadBadgeFocused.test.ts`, which drives the real cursor store
+  // this file mocks flat.)
+  describe("focused-window badge is not suppressed (#887)", () => {
     const seedRows = async (key: ReturnType<typeof channelKey>, kind: "privmsg" | "join") => {
       const scrollback = await import("../lib/scrollback");
-      const [, name] = key.split(" ");
+      const [, name] = key.split(" ");
       for (const id of [1, 2, 3]) {
         scrollback.appendToScrollback(key, {
           id,
@@ -1518,7 +1524,7 @@ describe("selection store", () => {
       }
     };
 
-    it("selecting a visible window zeros its own message badge", async () => {
+    it("keeps the message badge on the window the operator selects", async () => {
       localStorage.setItem("grappa-token", "tok");
       const api = await import("../lib/api");
       vi.mocked(api.listMessages).mockResolvedValue([]);
@@ -1533,11 +1539,34 @@ describe("selection store", () => {
         kind: "channel",
       });
 
-      expect(selection.messagesUnread()[key]).toBeUndefined();
-      expect(selection.unreadCounts()[key]).toBeUndefined();
+      expect(selection.messagesUnread()[key]).toBe(3);
+      expect(selection.unreadCounts()[key]).toBe(3);
     });
 
-    it("does NOT suppress when the document is hidden (selected ≠ looking)", async () => {
+    it("keeps the event badge on the selected window too (presence kinds)", async () => {
+      localStorage.setItem("grappa-token", "tok");
+      const api = await import("../lib/api");
+      vi.mocked(api.listMessages).mockResolvedValue([]);
+      const selection = await import("../lib/selection");
+      const key = channelKey("freenode", "#grappa");
+      await seedRows(key, "join");
+      expect(selection.eventsUnread()[key]).toBe(3);
+
+      selection.setSelectedChannel({
+        networkSlug: "freenode",
+        channelName: "#grappa",
+        kind: "channel",
+      });
+
+      expect(selection.eventsUnread()[key]).toBe(3);
+    });
+
+    // The old suppression was gated on `isDocumentVisible` so a
+    // selected-but-BACKGROUNDED tab kept accruing. With the suppression gone
+    // the count no longer consults visibility AT ALL — which is the honest
+    // shape, but it means a regression re-introducing any focus/visibility
+    // special case would have to break this test to land.
+    it("reads the same whether the tab is hidden or visible", async () => {
       localStorage.setItem("grappa-token", "tok");
       const api = await import("../lib/api");
       vi.mocked(api.listMessages).mockResolvedValue([]);
@@ -1556,28 +1585,10 @@ describe("selection store", () => {
 
       setVisibilityForTest(true);
       await Promise.resolve();
-      expect(selection.messagesUnread()[key]).toBeUndefined();
+      expect(selection.messagesUnread()[key]).toBe(3);
     });
 
-    it("suppresses the event badge too (presence kinds)", async () => {
-      localStorage.setItem("grappa-token", "tok");
-      const api = await import("../lib/api");
-      vi.mocked(api.listMessages).mockResolvedValue([]);
-      const selection = await import("../lib/selection");
-      const key = channelKey("freenode", "#grappa");
-      await seedRows(key, "join");
-      expect(selection.eventsUnread()[key]).toBe(3);
-
-      selection.setSelectedChannel({
-        networkSlug: "freenode",
-        channelName: "#grappa",
-        kind: "channel",
-      });
-
-      expect(selection.eventsUnread()[key]).toBeUndefined();
-    });
-
-    it("re-exposes the count when the operator leaves the window", async () => {
+    it("does not change when the operator leaves the window", async () => {
       localStorage.setItem("grappa-token", "tok");
       const api = await import("../lib/api");
       vi.mocked(api.listMessages).mockResolvedValue([]);
@@ -1589,8 +1600,11 @@ describe("selection store", () => {
         channelName: "#grappa",
         kind: "channel",
       });
-      expect(selection.messagesUnread()[key]).toBeUndefined();
+      expect(selection.messagesUnread()[key]).toBe(3);
 
+      // Pre-#887 this transition was the one that RE-EXPOSED the count (3
+      // arriving out of nowhere, the "badge came back at 1832" report). The
+      // cursor has not moved, so nothing about the number may move either.
       selection.setSelectedChannel({
         networkSlug: "freenode",
         channelName: "#other",
@@ -1600,7 +1614,7 @@ describe("selection store", () => {
       expect(selection.messagesUnread()[key]).toBe(3);
     });
 
-    it("does NOT suppress OTHER (non-selected) windows", async () => {
+    it("leaves OTHER (non-selected) windows alone", async () => {
       localStorage.setItem("grappa-token", "tok");
       const api = await import("../lib/api");
       vi.mocked(api.listMessages).mockResolvedValue([]);

--- a/cicchetto/src/__tests__/unreadBadgeFocused.test.ts
+++ b/cicchetto/src/__tests__/unreadBadgeFocused.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { channelKey } from "../lib/channelKey";
+
+// #887 — the badge on the FOCUSED window: visible, and falling as rows are
+// marked read.
+//
+// Its own file because `selection.test.ts` mocks `../lib/readCursor` flat (a
+// stub returning an empty map), which is the right boundary for the questions
+// that file asks and exactly the wrong one here: the whole property under test
+// is that the number tracks the cursor as the cursor MOVES. So this file runs
+// the real cursor store and drives it through `applyReadCursorSet` — the same
+// entry point the server's `read_cursor_set` WS event lands on, so what the
+// test moves is what production moves.
+//
+// The complaint this pins (vjt, 2026-08-05): focus a channel you have been
+// reading → the badge disappears; switch away → it comes back at 1832. Both
+// halves were the suppression overwrite in `perChannelUnread`. What must
+// replace them is a number that starts where it should and comes DOWN.
+
+vi.mock(import("../lib/api"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    listNetworks: vi.fn().mockResolvedValue([]),
+    listChannels: vi.fn().mockResolvedValue([]),
+    listMessages: vi.fn().mockResolvedValue([]),
+    sendMessage: vi.fn(),
+    me: vi.fn().mockResolvedValue({
+      kind: "user",
+      id: "u-test",
+      name: "alice",
+      is_admin: false,
+      inserted_at: "2026-01-01T00:00:00Z",
+      read_cursors: {},
+    }),
+    login: vi.fn(),
+    logout: vi.fn(),
+    setOn401Handler: vi.fn(),
+  };
+});
+
+const SLUG = "freenode";
+const CHANNEL = "#grappa";
+
+beforeEach(() => {
+  vi.resetModules();
+  localStorage.clear();
+  vi.clearAllMocks();
+  vi.spyOn(document, "hasFocus").mockReturnValue(true);
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => "visible",
+  });
+});
+
+const seedThreeMessages = async (): Promise<ReturnType<typeof channelKey>> => {
+  const scrollback = await import("../lib/scrollback");
+  const key = channelKey(SLUG, CHANNEL);
+  for (const id of [1, 2, 3]) {
+    scrollback.appendToScrollback(key, {
+      id,
+      network: SLUG,
+      channel: CHANNEL,
+      server_time: id,
+      kind: "privmsg",
+      sender: "bob",
+      body: `msg ${id}`,
+      meta: {},
+    });
+  }
+  return key;
+};
+
+describe("#887 focused-window unread badge", () => {
+  it("stays visible on select and falls one row at a time as the cursor advances", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const selection = await import("../lib/selection");
+    const readCursor = await import("../lib/readCursor");
+    const key = await seedThreeMessages();
+
+    selection.setSelectedChannel({
+      networkSlug: SLUG,
+      channelName: CHANNEL,
+      kind: "channel",
+    });
+
+    // Pre-#887 this read `undefined`: selecting the window hid the badge.
+    expect(selection.messagesUnread()[key]).toBe(3);
+
+    // Reading. Each cursor advance is one more row marked read, and the badge
+    // must answer with the remainder — not hold, not vanish. Asserting the
+    // INTERMEDIATE value is the point: a badge that only ever went 3 →
+    // undefined would also pass a first-and-last check while being exactly
+    // the vanishing behaviour #887 removed.
+    readCursor.applyReadCursorSet(SLUG, CHANNEL, 1);
+    expect(selection.messagesUnread()[key]).toBe(2);
+
+    readCursor.applyReadCursorSet(SLUG, CHANNEL, 2);
+    expect(selection.messagesUnread()[key]).toBe(1);
+
+    // Fully read: the key drops out of the map entirely, which is how the
+    // sidebar's `> 0` guard unmounts the pill.
+    readCursor.applyReadCursorSet(SLUG, CHANNEL, 3);
+    expect(selection.messagesUnread()[key]).toBeUndefined();
+  });
+
+  it("does not resurrect the count when the operator leaves a window they read", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const selection = await import("../lib/selection");
+    const readCursor = await import("../lib/readCursor");
+    const key = await seedThreeMessages();
+
+    selection.setSelectedChannel({
+      networkSlug: SLUG,
+      channelName: CHANNEL,
+      kind: "channel",
+    });
+    readCursor.applyReadCursorSet(SLUG, CHANNEL, 3);
+    expect(selection.messagesUnread()[key]).toBeUndefined();
+
+    // The other half of the report: leaving used to lift the suppression and
+    // republish the whole pre-select count. With the count cursor-derived
+    // everywhere, leaving is not an event the badge can even observe.
+    selection.setSelectedChannel({
+      networkSlug: SLUG,
+      channelName: "#other",
+      kind: "channel",
+    });
+
+    expect(selection.messagesUnread()[key]).toBeUndefined();
+  });
+
+  it("keeps counting rows that arrive in the focused window past the cursor", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const scrollback = await import("../lib/scrollback");
+    const selection = await import("../lib/selection");
+    const readCursor = await import("../lib/readCursor");
+    const key = await seedThreeMessages();
+
+    selection.setSelectedChannel({
+      networkSlug: SLUG,
+      channelName: CHANNEL,
+      kind: "channel",
+    });
+    readCursor.applyReadCursorSet(SLUG, CHANNEL, 3);
+    expect(selection.messagesUnread()[key]).toBeUndefined();
+
+    // A message lands while the operator is looking at the window. The badge
+    // shows it — the count is not silenced by focus. Bringing it back to zero
+    // is the read-at-the-tail cursor advance (ScrollbackPane), which needs a
+    // laid-out pane and is tested there; what belongs here is that the memo
+    // reports the row at all, because the suppression used to eat it.
+    scrollback.appendToScrollback(key, {
+      id: 4,
+      network: SLUG,
+      channel: CHANNEL,
+      server_time: 4,
+      kind: "privmsg",
+      sender: "bob",
+      body: "arrives while you watch",
+      meta: {},
+    });
+
+    expect(selection.messagesUnread()[key]).toBe(1);
+  });
+});

--- a/cicchetto/src/lib/selection.ts
+++ b/cicchetto/src/lib/selection.ts
@@ -2,7 +2,6 @@ import { createEffect, createMemo, createSignal, on, untrack } from "solid-js";
 import { isContentKind, ownNickForNetwork } from "./api";
 import { token } from "./auth";
 import { type ChannelKey, channelKey, decodeChannelKey } from "./channelKey";
-import { isDocumentVisible } from "./documentVisibility";
 import { identityScopedStore } from "./identityScopedStore";
 import { saveLastFocused } from "./lastFocusedChannel";
 import { membersByChannel } from "./members";
@@ -47,14 +46,11 @@ import { windowIsPresent } from "./windowState";
 //   * Selection-change effect: fires `scrollback.loadInitialScrollback`
 //     to backfill history (the load-once gate lives in scrollback.ts)
 //     + clears mention counts for the focused window. As the cursor
-//     advances (via scroll-settle, focus-leave, browser-blur, send, and
-//     fresh-channel load-baseline in scrollback.ts) the derived counts
-//     fall on their own. The ONE count the cursor can't drop on its own
-//     is the focused-AND-visible window's: its cursor only moves on the
-//     NEXT settle, so `perChannelUnread` zeros that window's
-//     `{messages, events}` as a final overwrite (RC1, decouple-unread-
-//     badge) keyed on `selectedChannel` + `isDocumentVisible` — a
-//     backgrounded-but-selected tab keeps accruing.
+//     advances (via read-at-the-tail, scroll-settle, focus-leave,
+//     browser-blur, send, and fresh-channel load-baseline in
+//     scrollback.ts) the derived counts fall on their own — in the
+//     FOCUSED window exactly as in every other one (#887; the old
+//     focused-window zeroing overwrite is gone, see `perChannelUnread`).
 //
 // 2026-06-01 (unread-badges-from-cursor cluster, bucket B2): the four
 // increment stores (`unreadCounts`, `messagesUnread`, `eventsUnread`,
@@ -457,25 +453,27 @@ const exports = identityScopedStore((onIdentityChange) => {
       result[key] = { messages: msgs, events: evts };
     }
 
-    // 2026-06-02 — focused-window badge suppression. The operator is
-    // looking at this window (and the browser tab is visible), so it has
-    // nothing unread TO THEM right now: zero its count. Derived from
-    // selectedChannel + isDocumentVisible — the read cursor is NOT
-    // advanced, so the in-pane `── N unread ──` marker survives the
-    // select and clears on its own settle events (scroll / defocus /
-    // send). Gating on isDocumentVisible keeps a selected-but-backgrounded
-    // tab accruing its badge so a returning operator sees activity.
-    // Final overwrite so it covers both the seed-only and hydrated
-    // branches above. Spec:
-    // docs/superpowers/specs/2026-06-02-decouple-unread-badge-design.md
-    const focused = selectedChannel();
-    if (focused !== null && isDocumentVisible()) {
-      result[channelKey(focused.networkSlug, focused.channelName)] = {
-        messages: 0,
-        events: 0,
-      };
-    }
-
+    // #887 — the focused-window badge suppression is GONE (it used to sit
+    // here as a final overwrite zeroing the selected-AND-visible window's
+    // `{messages, events}`; 2026-06-02, decouple-unread-badge RC1).
+    //
+    // It drew "you are looking at this" and "you have read this" the same
+    // way — as no badge — while deliberately NOT advancing the cursor. On a
+    // window the operator was actively reading the badge therefore vanished
+    // on select and came back WHOLE (1832) on leave, which reads as a broken
+    // counter. Nothing was wrong; the display was lying by omission.
+    //
+    // The count is now the same question in every window, focused or not:
+    // "how much have you not read". It falls where it should because the
+    // cursor now advances WHILE the operator reads — ScrollbackPane's
+    // read-at-the-tail arm marks what is on screen at the tail read, on top
+    // of the pre-existing settle writers (scroll-settle, leave, blur, send).
+    // The in-pane `── N unread ──` divider is unaffected: it reads the FROZEN
+    // `markerCursorId` snapshot, not the live cursor (freeze contract).
+    //
+    // The one window whose count still cannot fall is a far-behind one
+    // (#693 freezes its cursor on purpose). That is now SAID rather than
+    // hidden — #888 marks the badge as a distance, not a stuck counter.
     return result;
   });
 

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -1579,6 +1579,30 @@ html.resize-dragging * {
   font-weight: bold;
 }
 
+/* #888 — the FAR-BEHIND unread badge. The read cursor of a far-behind
+   window is frozen on purpose (#693), so its number does not move while
+   the operator reads; drawn as the normal solid pill it reads as a broken
+   counter. Outlined instead of filled: same size, same position, same
+   number, but it stops claiming to be a live count and reads as a
+   distance — paired with the pane's own far-behind bar + jump control,
+   which is what actually clears it. Padding compensates the 1px border so
+   the pill does not resize when the state flips (the sidebar row would
+   reflow under a stationary number, which is its own kind of lie).
+   Written as `.sidebar-msg-unread.far-behind`, not a bare `.far-behind`,
+   so the modifier can never bleed onto an unrelated element. */
+.sidebar-msg-unread.far-behind {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  padding: 0 calc(0.4rem - 1px);
+  font-weight: normal;
+}
+
+.sidebar-events-unread.far-behind {
+  border: 1px solid var(--muted);
+  padding: 0 calc(0.3rem - 1px);
+}
+
 /* CP15 B5 — greyed window-row treatment for failed/kicked/parked
    channels and DM targets. Italic + dim mirror `.sidebar-channel-name.parted`
    (the per-channel "you've parted" visual) but apply at the row button
@@ -4974,6 +4998,24 @@ html.resize-dragging * {
   font-size: 0.7rem;
   line-height: 1.4;
   font-weight: bold;
+}
+
+/* #888 — the mobile twin of the sidebar far-behind badge. Same reasoning,
+   same outlined treatment, the bottom bar's own metrics. The strip is
+   horizontally scrolled and space-scarce, so the border-compensated
+   padding matters more here than on the sidebar: a tab that changes width
+   when the state flips shifts every tab to its right. */
+.bottom-bar-msg-unread.far-behind {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  padding: 0 calc(0.3rem - 1px);
+  font-weight: normal;
+}
+
+.bottom-bar-events-unread.far-behind {
+  border: 1px solid var(--muted);
+  padding: 0 calc(0.2rem - 1px);
 }
 
 /* UX-3 DEC: dropped `.bottom-bar-tab-wrap` <span> — tab + close ×


### PR DESCRIPTION
Two distinct defects, one PR: they land on the same four badge call sites
(`Sidebar` server/channel/query, plus the `BottomBar` chips), so separate
branches were guaranteed to conflict line-for-line.

## #887 — the badge vanished on the window you were reading

Focusing a window zeroed its unread count outright: a final overwrite in
`perChannelUnread` keyed on `selectedChannel` + `isDocumentVisible`, which
deliberately did NOT advance the read cursor. "You are looking at this" and
"you have read this" were drawn identically — as no badge — so a channel you
had just been reading lost its badge on select and got it back whole (1832)
on leave.

Removing the overwrite alone trades a vanishing badge for a stuck one: every
pre-existing cursor writer fires when the operator STOPS looking (leave /
blur / unmount) or when they SCROLL (settle, gated on a real input event). An
operator parked at the tail of a quiet window generates neither. So the
removal ships with a **read-at-the-tail** arm in `ScrollbackPane`: while the
tab is visible AND the pane is at the tail, advance the cursor to the last
fully visible row.

Both gates are load-bearing — a backgrounded tab keeps accruing, and a reader
parked above the fold (or a cold activation that jumped to a far unread
divider) must not have the rows below marked read for them. Everything
dangerous past them is already refused downstream by the single door
`setCursorIfAdvances`: the #693 far-behind freeze and the #233 forward-only
clamp. The in-pane divider is untouched — it reads the frozen
`markerCursorId`, not the live cursor.

Five writers shared the same three-line body verbatim; they now share one
helper.

## #888 — a frozen badge did not say it was frozen

A far-behind window's cursor is pinned on purpose, so its count does not move
while you read. Drawn as the ordinary solid pill it is indistinguishable from
a live counter. Now: an outlined variant (same size, same position, same
number — it just stops claiming to be a live count), plus a title and an
accessible label naming the distance and the way out. Both unread badges take
it, because the count memo serves the frozen server seed for both kinds while
far behind; the mention badge does not, being server-authoritative and
counted a different way (#267).

The badge triad sat inline in six verbatim copies. Adding one predicate to
six pasted blocks is copy-paste-with-tweaks, so the triad moved into
`WindowBadges` with the class prefix resolved through a closed table.

## What I measured (not just "tests pass")

Each claim was checked by mutating production and watching the specs go red:

| mutation | result |
| --- | --- |
| restore the suppression overwrite | 6 red across `selection.test.ts` + `unreadBadgeFocused.test.ts` |
| disable the read-at-the-tail arm | `advances to the arriving row with NO operator input event` red |
| drop its `isDocumentVisible` gate | `stands down while the tab is hidden` red — **and** the reworked BUGHUNT-2 input-gate test red, so its new "hide the tab to displace the confound" setup is doing real work |
| `farBehind` predicate → `false` | 4 red in `WindowBadges.test.tsx` |
| **drop the `atBottomNow` gate** | **all 171 ScrollbackPane tests still GREEN** |

That last row is the honest one: jsdom's zero-geometry pane reads as
at-the-tail unconditionally, so no unit test can tell the at-tail branch from
its opposite. The e2e is where that gate is actually pinned — it plants a
cursor 120 rows back, asserts the badge holds while scrolled up past the
debounce, then watches it fall under a real wheel, then watches a message
that arrives while the operator watches the tail clear itself with no input
(waiting out `INPUT_EVENT_RECENCY_MS` first, so the drain cannot be
attributed to the scroll-settle arm).

## What I will not claim

- **The e2e has not been run.** It needs the STACK lane. Everything below is
  what was actually run: `bun run check` rc=0, `bun run test` 4330/4330
  green, `bun run build` green, all on a clean tree.
- The intermediate badge blip (1, then gone) in the watched-arrival e2e is
  **not** asserted — the window is ~500ms and polling for it would be flaky.
  Only the settled end state is, after an explicit wait past the debounce so
  the assertion cannot pass against a broken arm on its first poll.
- The far-behind treatment is asserted at the DOM/class level, not visually.
  Nobody has looked at the outlined pill in a browser.
- Adding `aria-label` to the unread badges changes every window row's
  computed accessible name ("#italia 5" → "#italia 5 unread messages"). It is
  forced — a generic `<span>` cannot carry `aria-label` — and I think it is
  an improvement, but it is a change #96 territory may want an opinion on.
- `mentionCounts` keeps its own focus-zero overlay (#267). #887 did not ask
  to touch it and I did not, but the two badges now behave differently on a
  focused window: the unread one persists, the mention one still disappears.
  Flagging rather than deciding.

Branched from `c57d4dab`; `origin/main` moved (to `ffde30f3`) mid-work, so
this wants a rebase before merge.