### PR TITLE
session: re-key own inbound DM rows on a self nick change

### DIFF
--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -1292,6 +1292,105 @@ defmodule Grappa.Scrollback do
   end
 
   @doc """
+  #514 — re-keys the subject's OWN inbound DM rows from `old_nick` to
+  `new_nick` in `(subject, network_id)` after a SELF nick change.
+
+  An inbound DM is persisted at `channel = <own nick at receipt>,
+  dm_with = peer` (`dm_peer/4`). That `channel` value is NOT a window key
+  — the peer window resolves off `dm_with` via `where_dm_peer/2`, so the
+  history reads fine either way — it is a TAG recording who the subject
+  was when the row arrived, and `Push.Triggers.dm?/2` reads it back
+  against the LIVE own nick (#498). Leave it stale and every pre-rename
+  inbound DM stops classifying as a DM, falls into the channel branch of
+  `should_notify?/4`, and silently loses its badge / notify credit.
+
+  ## Why this is NOT `rename_dm_peer/4` with different arguments
+
+  The two UPDATEs would look alike; the GUARD is what differs, and the
+  difference is semantic, not cosmetic. `rename_dm_peer/4` counts through
+  `where_dm_peer/2` (`COALESCE(dm_with, channel)`), which on an inbound
+  row yields `dm_with` — the PEER — never our own nick. Called with a
+  self-rename it counts `0` and skips both UPDATEs: a silent no-op.
+
+  Nor can that guard simply be widened to cover both. The same column
+  holds two different roles and a nick can move between them over time:
+  once we vacate `old`, a peer may take it. A widened peer rename
+  `old -> new` would then also rewrite OUR inbound tag, and this
+  migration must conversely leave the peer's rows alone — hence the
+  narrow predicate below rather than a shared one.
+
+  ## The predicate, and the corruption it exists to prevent
+
+  Migrated rows are exactly `fold(channel) == fold(old)` AND
+  `dm_with IS NOT NULL` AND `fold(dm_with) != fold(old)` — "inbound,
+  received while we were `old`". The two extra conjuncts are load-bearing:
+
+    * an OUTBOUND DM carries `channel == dm_with == peer`, so a bare
+      `fold(channel) == fold(old)` would capture a conversation with a
+      peer who merely bears our old nick. Concretely: we were `alice`,
+      we DM'd `carol`, `carol` vanished, we took `carol`, we now rename
+      `carol -> dave` — the bare predicate files our history with the
+      REAL carol under `dave`.
+    * an ORPHAN row (`dm_with IS NULL`, e.g. a 401 NOTICE persisted at
+      `channel = peer`) is the server talking ABOUT a nick, not a DM we
+      received. `is_nil` is checked explicitly rather than left to SQL's
+      `lower(NULL) != x → NULL → filtered`, so the domain rule ("must be
+      a DM row") survives a future rewrite of the fold expression.
+
+  Channel rows need no exclusion: a sigil never folds to a bare nick.
+
+  Sets the FOLDED new nick — `channel` is a KEY column and
+  `Repo.update_all` bypasses the changeset fold
+  (`Message.canonicalize_channel/1`), so a raw value here would re-fork
+  the tag against every freshly-persisted row (same trap #537 fixed in
+  `rename_dm_peer/4`).
+
+  Returns `{:ok, count}` of re-keyed rows; `{:ok, 0}` on a case-only
+  change (`fold(old) == fold(new)` — the tag already reads back equal) or
+  an empty match.
+
+  Sole production caller: `Grappa.Session.Server.apply_effects/2` on the
+  `{:own_nick_renamed, old, new}` effect.
+
+  ## Deliberately out of scope
+
+  Two things a self-rename does NOT recover, both by nature rather than
+  omission:
+
+    * a mention of the old nick in a message BODY — prose, not a key;
+      rewriting it would falsify history.
+    * the own-nick SELF window (`/msg <ownnick>`, `channel == dm_with ==
+      own`), whose row shape is indistinguishable from an outbound DM to
+      a peer bearing our old nick without also folding `sender`. That is
+      a window-key migration (the peer-rename set: window row + cursor),
+      a different defect from this stale tag, and it is tracked apart.
+  """
+  @spec rename_own_nick(subject(), integer(), String.t(), String.t()) ::
+          {:ok, non_neg_integer()}
+  def rename_own_nick(subject, network_id, old_nick, new_nick)
+      when is_integer(network_id) and is_binary(old_nick) and is_binary(new_nick) do
+    folded_old = Identifier.canonical_target(old_nick)
+    folded_new = Identifier.canonical_target(new_nick)
+
+    if folded_old == folded_new do
+      {:ok, 0}
+    else
+      {count, _} =
+        Message
+        |> subject_where(subject)
+        |> where([m], m.network_id == ^network_id)
+        |> where(
+          [m],
+          Identifier.nick_fold(m.channel) == ^folded_old and not is_nil(m.dm_with) and
+            Identifier.nick_fold(m.dm_with) != ^folded_old
+        )
+        |> Repo.update_all(set: [channel: folded_new])
+
+      {:ok, count}
+    end
+  end
+
+  @doc """
   UX-1 (2026-05-17) — deletes all scrollback rows for a channel in a
   `(subject, network_id)` pair. Case-insensitive on the channel name
   (IRC channels are case-insensitive per RFC 1459 §2.2).

--- a/lib/grappa/scrollback.ex
+++ b/lib/grappa/scrollback.ex
@@ -1322,8 +1322,8 @@ defmodule Grappa.Scrollback do
   ## The predicate, and the corruption it exists to prevent
 
   Migrated rows are exactly `fold(channel) == fold(old)` AND
-  `dm_with IS NOT NULL` AND `fold(dm_with) != fold(old)` — "inbound,
-  received while we were `old`". The two extra conjuncts are load-bearing:
+  `fold(dm_with) != fold(old)` — "inbound, received while we were
+  `old`". The second conjunct carries two exclusions at once:
 
     * an OUTBOUND DM carries `channel == dm_with == peer`, so a bare
       `fold(channel) == fold(old)` would capture a conversation with a
@@ -1333,9 +1333,14 @@ defmodule Grappa.Scrollback do
       REAL carol under `dave`.
     * an ORPHAN row (`dm_with IS NULL`, e.g. a 401 NOTICE persisted at
       `channel = peer`) is the server talking ABOUT a nick, not a DM we
-      received. `is_nil` is checked explicitly rather than left to SQL's
-      `lower(NULL) != x → NULL → filtered`, so the domain rule ("must be
-      a DM row") survives a future rewrite of the fold expression.
+      received. It drops out on SQL three-valued logic:
+      `lower(NULL) != 'x'` is NULL, not true, so `WHERE` rejects the
+      row. An explicit `not is_nil(m.dm_with)` was written here first
+      and then deleted: mutation testing showed it changed no outcome
+      in the whole suite, and unmeasured code is a liability. The
+      orphan exclusion is pinned by test instead, so a future rewrite
+      of the fold fragment (a `COALESCE` that turns NULL into a value)
+      breaks loudly rather than silently sweeping orphans in.
 
   Channel rows need no exclusion: a sigil never folds to a bare nick.
 
@@ -1381,7 +1386,7 @@ defmodule Grappa.Scrollback do
         |> where([m], m.network_id == ^network_id)
         |> where(
           [m],
-          Identifier.nick_fold(m.channel) == ^folded_old and not is_nil(m.dm_with) and
+          Identifier.nick_fold(m.channel) == ^folded_old and
             Identifier.nick_fold(m.dm_with) != ^folded_old
         )
         |> Repo.update_all(set: [channel: folded_new])

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -832,28 +832,7 @@ defmodule Grappa.Session.EventRouter do
         []
       end
 
-    # #514: OUR OWN rename is not the mirror image of a peer's. A peer nick
-    # is a WINDOW KEY, so the peer arm above moves three stores and then
-    # broadcasts the move. Our own nick keys nothing: an inbound DM's window
-    # is `dm_with` (the peer), which a self-rename never touches. What our
-    # nick DOES leave behind is a TAG — every inbound DM row is persisted at
-    # `channel = <own nick at receipt>`, and `Push.Triggers.dm?/2` reads that
-    # back against the LIVE nick (#498), so a stale tag drops those rows out
-    # of the notify set. Hence ONE store to re-key, no query window, no read
-    # cursor, and nothing to broadcast (no window changed identity).
-    #
-    # Genuine renames only (`old ≢ new` under the fold) — a case-only change
-    # reads back equal and needs no rewrite. And NO `channels != []` gate,
-    # unlike the peer arm: that gate encodes "IRC only delivers a peer's NICK
-    # through a shared channel", which says nothing about our own echo, and
-    # the rows at stake are DMs — a DM-only session with zero channels joined
-    # is precisely the case #514 was filed from.
-    own_rename_effects =
-      if nick_eq?(old_nick, state.nick) and not nick_eq?(old_nick, new_nick) do
-        [{:own_nick_renamed, old_nick, new_nick}]
-      else
-        []
-      end
+    own_rename_effects = own_nick_rename_effects(state, old_nick, new_nick)
 
     # #581 — mirror bahamut's SILENT +r-strip on our own genuine self-rename
     # (see strip_r_on_self_rename/4) so the per-session umode set stays truthful.
@@ -3396,6 +3375,31 @@ defmodule Grappa.Session.EventRouter do
   # RPL_WELCOME); callers always pass a binary first arg (parsed wire
   # nick), mirroring `Grappa.Session.NumericRouter.nick_eq?/2`.
   @spec nick_eq?(String.t(), String.t() | nil) :: boolean()
+  # #514: OUR OWN rename is not the mirror image of a peer's. A peer nick is
+  # a WINDOW KEY, which is why the `:peer_nick_renamed` arm moves three
+  # stores and then broadcasts the move. Our own nick keys nothing: an
+  # inbound DM's window is `dm_with` (the peer), which a self-rename never
+  # touches. What our nick DOES leave behind is a TAG — every inbound DM row
+  # is persisted at `channel = <own nick at receipt>`, and
+  # `Push.Triggers.dm?/2` reads that back against the LIVE nick (#498), so a
+  # stale tag drops those rows out of the notify set. Hence ONE store to
+  # re-key, no query window, no read cursor, nothing to broadcast.
+  #
+  # Genuine renames only (`old ≢ new` under the fold) — a case-only change
+  # reads back equal and needs no rewrite. And NO `channels != []` gate,
+  # unlike the peer arm: that gate encodes "IRC only delivers a peer's NICK
+  # through a shared channel", which says nothing about our own echo, and the
+  # rows at stake are DMs — a DM-only session with zero channels joined is
+  # precisely the case #514 was filed from.
+  @spec own_nick_rename_effects(state(), String.t(), String.t()) :: [effect()]
+  defp own_nick_rename_effects(state, old_nick, new_nick) do
+    if nick_eq?(old_nick, state.nick) and not nick_eq?(old_nick, new_nick) do
+      [{:own_nick_renamed, old_nick, new_nick}]
+    else
+      []
+    end
+  end
+
   defp nick_eq?(_, nil), do: false
 
   defp nick_eq?(a, b) when is_binary(a) and is_binary(b),

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -221,6 +221,7 @@ defmodule Grappa.Session.EventRouter do
           | {:presence_error, :list_full, detail :: String.t()}
           | {:presence_command_unknown, :monitor | :watch}
           | {:peer_nick_renamed, old_nick :: String.t(), new_nick :: String.t()}
+          | {:own_nick_renamed, old_nick :: String.t(), new_nick :: String.t()}
 
   @doc """
   Classifies one inbound `Grappa.IRC.Message` against the current
@@ -831,6 +832,29 @@ defmodule Grappa.Session.EventRouter do
         []
       end
 
+    # #514: OUR OWN rename is not the mirror image of a peer's. A peer nick
+    # is a WINDOW KEY, so the peer arm above moves three stores and then
+    # broadcasts the move. Our own nick keys nothing: an inbound DM's window
+    # is `dm_with` (the peer), which a self-rename never touches. What our
+    # nick DOES leave behind is a TAG — every inbound DM row is persisted at
+    # `channel = <own nick at receipt>`, and `Push.Triggers.dm?/2` reads that
+    # back against the LIVE nick (#498), so a stale tag drops those rows out
+    # of the notify set. Hence ONE store to re-key, no query window, no read
+    # cursor, and nothing to broadcast (no window changed identity).
+    #
+    # Genuine renames only (`old ≢ new` under the fold) — a case-only change
+    # reads back equal and needs no rewrite. And NO `channels != []` gate,
+    # unlike the peer arm: that gate encodes "IRC only delivers a peer's NICK
+    # through a shared channel", which says nothing about our own echo, and
+    # the rows at stake are DMs — a DM-only session with zero channels joined
+    # is precisely the case #514 was filed from.
+    own_rename_effects =
+      if nick_eq?(old_nick, state.nick) and not nick_eq?(old_nick, new_nick) do
+        [{:own_nick_renamed, old_nick, new_nick}]
+      else
+        []
+      end
+
     # #581 — mirror bahamut's SILENT +r-strip on our own genuine self-rename
     # (see strip_r_on_self_rename/4) so the per-session umode set stays truthful.
     {final_state, self_umode_effects} =
@@ -838,7 +862,8 @@ defmodule Grappa.Session.EventRouter do
 
     {:cont, final_state,
      persist_effects ++
-       self_server_effects ++ visitor_persist_effects ++ peer_rename_effects ++ self_umode_effects}
+       self_server_effects ++
+       visitor_persist_effects ++ peer_rename_effects ++ own_rename_effects ++ self_umode_effects}
   end
 
   # Unsolicited TOPIC: a channel operator changed the topic mid-session.

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -5489,6 +5489,39 @@ defmodule Grappa.Session.Server do
     apply_effects(rest, state)
   end
 
+  # #514: WE renamed. Deliberately NOT the peer arm above with the arguments
+  # swapped — our own nick is not a window key, so nothing moves: an inbound
+  # DM's window is `dm_with` (the peer) and its read cursor is keyed there
+  # too, both untouched by our rename. What goes stale is the own-nick TAG
+  # each inbound row carries in `channel`, which `Push.Triggers.dm?/2`
+  # compares to the LIVE nick (#498) when `Push.BadgeCount` folds the notify
+  # predicate back over history. One store, one UPDATE, and no
+  # `query_windows_list` broadcast — there is no window whose identity
+  # changed, so a barrier event would announce something that did not happen.
+  #
+  # `state` here is the POST-route state, so `state.nick` already reads the
+  # NEW nick. The arm never consults it — both nicks travel in the effect —
+  # which is why it cannot be bitten by which side of the rename it sees.
+  #
+  # Ordering against the per-channel `:persist` nick_change rows queued ahead
+  # of this effect is immaterial: those are `channel = #chan` / `$server`
+  # with `dm_with = nil`, and the migration predicate requires a non-nil
+  # `dm_with`, so they can never be swept up.
+  defp apply_effects([{:own_nick_renamed, old_nick, new_nick} | rest], state) do
+    {:ok, migrated} =
+      Scrollback.rename_own_nick(state.subject, state.network_id, old_nick, new_nick)
+
+    if migrated > 0 do
+      Logger.info("inbound DM rows re-keyed to our new nick",
+        old_nick: old_nick,
+        new_nick: new_nick,
+        rows_migrated: migrated
+      )
+    end
+
+    apply_effects(rest, state)
+  end
+
   # #349 — commit-on-+r for USER sessions, scoped to the REGISTER case. A
   # staged `pending_registration_secret` means this +r confirms a wizard-
   # driven REGISTER, so promote the credential (password + auth_method →

--- a/test/grappa/push/badge_count_live_nick_test.exs
+++ b/test/grappa/push/badge_count_live_nick_test.exs
@@ -25,7 +25,7 @@ defmodule Grappa.Push.BadgeCountLiveNickTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.{IRCServer, Networks, ReadCursor, ScrollbackHelpers, Session}
+  alias Grappa.{IRCServer, Networks, ReadCursor, Scrollback, ScrollbackHelpers, Session}
   alias Grappa.Push.BadgeCount
 
   # The configured (credential) nick and the post-rename LIVE nick. The
@@ -42,6 +42,15 @@ defmodule Grappa.Push.BadgeCountLiveNickTest do
   # cross-process NICK pipeline (TCP buffer → Client → Session mailbox)
   # so the rename is fully applied before the assertions run.
   defp start_renamed_session do
+    {subject, network, server} = start_session_at_configured_nick()
+    :ok = force_self_rename(server)
+    {subject, network}
+  end
+
+  # Split out of `start_renamed_session/0` so #514 can seed scrollback rows
+  # while the session still holds `@configured_nick` — the whole point there
+  # is history that predates the rename.
+  defp start_session_at_configured_nick do
     rfc_handler = fn state, line ->
       if String.starts_with?(line, "USER ") do
         {:reply, ":server 001 #{@configured_nick} :Welcome\r\n", state}
@@ -64,11 +73,18 @@ defmodule Grappa.Push.BadgeCountLiveNickTest do
     # proving the nick reconciliation landed before the self-NICK below.
     {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
 
+    {{:user, user.id}, network, server}
+  end
+
+  # Feeds the self-NICK and blocks until the session has fully applied it.
+  # The PING/PONG round-trip is the barrier: PONG only goes out after the
+  # session process has drained the NICK ahead of it in its mailbox, so any
+  # `apply_effects/2` migration the rename triggers has already run.
+  defp force_self_rename(server) do
     IRCServer.feed(server, ":#{@configured_nick}!u@h NICK :#{@live_nick}\r\n")
     IRCServer.feed(server, "PING :flush\r\n")
     {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "PONG :flush\r\n"), 1_000)
-
-    {{:user, user.id}, network}
+    :ok
   end
 
   defp insert(subject, network, channel, opts) do
@@ -80,7 +96,8 @@ defmodule Grappa.Push.BadgeCountLiveNickTest do
         server_time: opts[:st],
         kind: :privmsg,
         sender: opts[:sender],
-        body: opts[:body]
+        body: opts[:body],
+        dm_with: opts[:dm_with]
       })
 
     message
@@ -166,5 +183,90 @@ defmodule Grappa.Push.BadgeCountLiveNickTest do
     # → counts the old-nick mention → 1. After: the live nick is @live_nick,
     # so the old nick is no longer the operator's identity → 0.
     assert BadgeCount.count(subject) == 0
+  end
+
+  describe "#514 — a self-rename re-keys inbound DM rows received under the old nick" do
+    @peer "alice"
+
+    # Seeds a DM window with `@peer` holding one read anchor and one unread
+    # inbound message, BOTH received while the session still holds
+    # `@configured_nick` (so both carry `channel = @configured_nick`, the
+    # own-nick tag `Push.Triggers.dm?/2` reads back). Then renames.
+    defp seed_dm_then_rename do
+      {subject, network, server} = start_session_at_configured_nick()
+
+      anchor =
+        insert(subject, network, @configured_nick,
+          st: 1,
+          sender: @peer,
+          body: "ciao",
+          dm_with: @peer
+        )
+
+      insert(subject, network, @configured_nick,
+        st: 2,
+        sender: @peer,
+        body: "ci sei?",
+        dm_with: @peer
+      )
+
+      # The cursor lives on the PEER window — that is the window key of an
+      # inbound DM, and it is exactly what the self-rename does NOT move.
+      set_cursor(subject, network, @peer, anchor.id)
+
+      :ok = force_self_rename(server)
+
+      {subject, network}
+    end
+
+    test "the unread DM keeps its badge credit across the rename" do
+      {subject, _network} = seed_dm_then_rename()
+
+      # RED before #514: the row's `channel` still tags the OLD nick, so
+      # `dm?/2` compares it against the LIVE nick, misses, and routes the row
+      # into the channel branch — where `channel_messages_all: false` and no
+      # mention of the new nick in "ci sei?" mean it stops counting → 0.
+      # After: the tag follows the identity, the row classifies as a DM, and
+      # `private_messages_all: true` credits it → 1.
+      assert BadgeCount.count(subject) == 1
+    end
+
+    # #514 REFUTATION PIN (1/2). The issue flagged the DM-window fetch as
+    # "possibly also affected". It is not: an inbound row's window key is
+    # `dm_with` (the peer), which a self-rename never touches. Both rows read
+    # back under the peer window after the rename — asserted through the
+    # production read path with the LIVE nick, the way the controller does.
+    test "the peer DM window still returns the full pre-rename history" do
+      {subject, network} = seed_dm_then_rename()
+
+      bodies =
+        subject
+        |> Scrollback.fetch(network.id, @peer, nil, 100, @live_nick, false)
+        |> Enum.map(& &1.body)
+        |> Enum.sort()
+
+      assert bodies == ["ci sei?", "ciao"]
+    end
+
+    # #514 REFUTATION PIN (2/2). A channel mention of the OLD nick is NOT
+    # recoverable by any storage migration: the old nick lives in the message
+    # BODY, which is prose, not a key — rewriting it would falsify history.
+    # This is a documented boundary of #514, not a defect left unfixed, and
+    # it is pinned so nobody later reads the re-keying as "mentions follow a
+    # rename too". (The #498 twin above pins the same edge from the other
+    # side; this one pins that #514's migration does not move it.)
+    test "a channel mention of the OLD nick stays uncounted — bodies are not keys" do
+      {subject, network, server} = start_session_at_configured_nick()
+
+      anchor = insert(subject, network, "#chan", st: 1, sender: "bob", body: "morning all")
+
+      insert(subject, network, "#chan", st: 2, sender: "bob", body: "#{@configured_nick}: ping")
+
+      set_cursor(subject, network, "#chan", anchor.id)
+
+      :ok = force_self_rename(server)
+
+      assert BadgeCount.count(subject) == 0
+    end
   end
 end

--- a/test/grappa/push/badge_count_live_nick_test.exs
+++ b/test/grappa/push/badge_count_live_nick_test.exs
@@ -220,7 +220,7 @@ defmodule Grappa.Push.BadgeCountLiveNickTest do
     end
 
     test "the unread DM keeps its badge credit across the rename" do
-      {subject, _network} = seed_dm_then_rename()
+      {subject, _} = seed_dm_then_rename()
 
       # RED before #514: the row's `channel` still tags the OLD nick, so
       # `dm?/2` compares it against the LIVE nick, misses, and routes the row

--- a/test/grappa/scrollback_test.exs
+++ b/test/grappa/scrollback_test.exs
@@ -2840,6 +2840,156 @@ defmodule Grappa.ScrollbackTest do
     end
   end
 
+  describe "rename_own_nick/4 (#514 — inbound DM rows re-key on a SELF nick change)" do
+    # An INBOUND DM is persisted at `channel = <own nick at receipt>,
+    # dm_with = peer` (`Scrollback.dm_peer/4`). That `channel` value is not
+    # the window key of anything — the peer window resolves off `dm_with` —
+    # it is a TAG recording who the subject was when the row arrived, and
+    # `Push.Triggers.dm?/2` reads it back against the LIVE own_nick (#498).
+    # A self-rename makes every such tag stale, so the row stops classifying
+    # as a DM. This migration moves the tag; nothing else about the row (or
+    # the window it belongs to) moves.
+    test "an inbound DM received under the old nick re-keys to the new nick",
+         %{user: user, network: net} do
+      {:ok, inb} =
+        Scrollback.persist_event(sample(user, net, 100, %{channel: "oldme", sender: "alice", dm_with: "alice"}))
+
+      assert {:ok, 1} = Scrollback.rename_own_nick({:user, user.id}, net.id, "oldme", "NewMe")
+
+      row = Repo.get!(Message, inb.id)
+      # `channel` is the window KEY column → stored FOLDED, exactly like
+      # `rename_dm_peer/4`'s channel update (#537). `dm_with` is the PEER
+      # (a display column) and has nothing to do with our rename.
+      assert row.channel == "newme"
+      assert row.dm_with == "alice"
+    end
+
+    # THE corruption guard, and the reason the predicate is not the bare
+    # `fold(channel) == fold(old)`: I was `alice`, I DM'd `carol`, `carol`
+    # vanished, I took the nick `carol`, and now I rename `carol -> dave`.
+    # The bare predicate would file my history with the REAL carol under
+    # `dave`. An OUTBOUND row is recognised by `channel == dm_with` — the
+    # nick in `channel` is the PEER's there, not mine.
+    test "does NOT touch an outbound DM to a peer that bears the old nick",
+         %{user: user, network: net} do
+      {:ok, out} =
+        Scrollback.persist_event(sample(user, net, 100, %{channel: "carol", sender: "alice", dm_with: "carol"}))
+
+      assert {:ok, 0} = Scrollback.rename_own_nick({:user, user.id}, net.id, "carol", "dave")
+
+      row = Repo.get!(Message, out.id)
+      assert row.channel == "carol"
+      assert row.dm_with == "carol"
+    end
+
+    # Same guard, orphan shape: a 401 NOTICE for a nick that happens to
+    # equal our old one is the SERVER talking about a peer, not a DM we
+    # received. `dm_with IS NULL` excludes it.
+    test "does NOT touch an orphan row (dm_with IS NULL) keyed at the old nick",
+         %{user: user, network: net} do
+      {:ok, orphan} =
+        Scrollback.persist_event(
+          sample(user, net, 200, %{
+            channel: "oldme",
+            sender: "server.azzurra.chat",
+            kind: :notice,
+            body: "No such nick/channel",
+            dm_with: nil
+          })
+        )
+
+      assert {:ok, 0} = Scrollback.rename_own_nick({:user, user.id}, net.id, "oldme", "newme")
+
+      assert Repo.get!(Message, orphan.id).channel == "oldme"
+    end
+
+    test "leaves channel rows alone", %{user: user, network: net} do
+      {:ok, chan} =
+        Scrollback.persist_event(sample(user, net, 100, %{channel: "#sniffo", sender: "alice", dm_with: nil}))
+
+      assert {:ok, 0} = Scrollback.rename_own_nick({:user, user.id}, net.id, "#sniffo", "newme")
+
+      assert Repo.get!(Message, chan.id).channel == "#sniffo"
+    end
+
+    test "ASCII-folded match: rows tagged 'oldme' migrate when matched via 'OldMe' (#525)",
+         %{user: user, network: net} do
+      {:ok, inb} =
+        Scrollback.persist_event(sample(user, net, 100, %{channel: "oldme", sender: "alice", dm_with: "alice"}))
+
+      assert {:ok, 1} = Scrollback.rename_own_nick({:user, user.id}, net.id, "OldMe", "newme")
+
+      assert Repo.get!(Message, inb.id).channel == "newme"
+    end
+
+    test "case-only fold (old == new) is a noop, returns {:ok, 0}", %{user: user, network: net} do
+      {:ok, inb} =
+        Scrollback.persist_event(sample(user, net, 100, %{channel: "Foo", sender: "alice", dm_with: "alice"}))
+
+      assert {:ok, 0} = Scrollback.rename_own_nick({:user, user.id}, net.id, "Foo", "FOO")
+
+      assert Repo.get!(Message, inb.id).channel == "foo"
+    end
+
+    test "isolated by subject and network", %{user: user, network: net} do
+      {:ok, other_net} = Networks.find_or_create_network(%{slug: "other-#{uniq()}"})
+      {:ok, alice} = Accounts.create_user(%{name: "alice-#{uniq()}", password: "correct horse battery"})
+
+      {:ok, other_net_row} =
+        Scrollback.persist_event(sample(user, other_net, 100, %{channel: "oldme", sender: "bob", dm_with: "bob"}))
+
+      {:ok, alice_row} =
+        Scrollback.persist_event(sample(alice, net, 100, %{channel: "oldme", sender: "bob", dm_with: "bob"}))
+
+      assert {:ok, 0} = Scrollback.rename_own_nick({:user, user.id}, net.id, "oldme", "newme")
+
+      assert Repo.get!(Message, other_net_row.id).channel == "oldme"
+      assert Repo.get!(Message, alice_row.id).channel == "oldme"
+    end
+
+    test "idempotent — returns {:ok, 0} on empty matches", %{user: user, network: net} do
+      assert {:ok, 0} = Scrollback.rename_own_nick({:user, user.id}, net.id, "ghost", "phantom")
+    end
+
+    # #514 REFUTATION PIN. The issue flagged the DM-window FETCH as
+    # "possibly also affected". It is not, and this test is what makes that
+    # a measurement rather than an opinion: `channel_or_dm_where/3` resolves
+    # a peer window through `where_dm_peer/2`, which matches
+    # `COALESCE(dm_with, channel)` — on an inbound row that is `dm_with`,
+    # the PEER, which a self-rename never touches. The history reads
+    # identically on BOTH sides of the migration. If someone ever re-keys
+    # the DM read off the own-nick tag, this breaks and tells them why.
+    test "the peer DM window reads the same rows BEFORE and AFTER the migration",
+         %{user: user, network: net} do
+      {:ok, inb} =
+        Scrollback.persist_event(sample(user, net, 100, %{channel: "oldme", sender: "alice", dm_with: "alice"}))
+
+      before_ids = user |> read_dm(net, "alice", "oldme") |> Enum.map(& &1.id)
+      assert before_ids == [inb.id]
+
+      assert {:ok, 1} = Scrollback.rename_own_nick({:user, user.id}, net.id, "oldme", "newme")
+
+      # Read with the LIVE (new) own_nick, as production would post-rename.
+      after_ids = user |> read_dm(net, "alice", "newme") |> Enum.map(& &1.id)
+      assert after_ids == before_ids
+    end
+
+    # The migrated tag must not leak the peer's DMs into the subject's OWN
+    # self-window: `channel_or_dm_where/3`'s own-nick branch narrows to
+    # `dm_with == own_nick` precisely so inbound peer DMs (now tagged with
+    # the new nick) stay out. Pinned here because the migration is what
+    # makes those rows tagged with the live nick in the first place.
+    test "migrated rows do not leak into the own-nick self window",
+         %{user: user, network: net} do
+      {:ok, _} =
+        Scrollback.persist_event(sample(user, net, 100, %{channel: "oldme", sender: "alice", dm_with: "alice"}))
+
+      assert {:ok, 1} = Scrollback.rename_own_nick({:user, user.id}, net.id, "oldme", "newme")
+
+      assert read_dm(user, net, "newme", "newme") == []
+    end
+  end
+
   describe "delete_for_channel/3 (UX-1)" do
     test "drops all rows for (subject, network, channel) — channel-shaped", %{
       user: user,

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -1706,6 +1706,43 @@ defmodule Grappa.Session.EventRouterTest do
       refute Enum.any?(effects, &match?({:peer_nick_renamed, _, _}, &1))
     end
 
+    test "NICK-self emits {:own_nick_renamed} so inbound DM rows re-key (#514)" do
+      state = base_state(%{members: %{"#italia" => %{"vjt" => ["@"], "alice" => []}}})
+      m = msg(:nick, ["vjt_"], {:nick, "vjt", "u", "h"})
+
+      assert {:cont, _, effects} = EventRouter.route(m, state)
+      assert {:own_nick_renamed, "vjt", "vjt_"} in effects
+    end
+
+    # No `channels != []` gate, unlike the peer arm: a peer's NICK only ever
+    # reaches us through a shared channel, but OUR OWN rename is echoed
+    # regardless — and the rows it invalidates are DMs, which need no shared
+    # channel to exist. Gating on membership would strand exactly the
+    # channel-less DM-only session #514 is about.
+    test "NICK-self emits {:own_nick_renamed} with ZERO channels joined (#514)" do
+      state = base_state(%{members: %{}})
+      m = msg(:nick, ["vjt_"], {:nick, "vjt", "u", "h"})
+
+      assert {:cont, _, effects} = EventRouter.route(m, state)
+      assert {:own_nick_renamed, "vjt", "vjt_"} in effects
+    end
+
+    test "NICK-self that is a case-only change emits NO {:own_nick_renamed} (#514)" do
+      state = base_state(%{members: %{"#italia" => %{"vjt" => ["@"]}}})
+      m = msg(:nick, ["VJT"], {:nick, "vjt", "u", "h"})
+
+      assert {:cont, _, effects} = EventRouter.route(m, state)
+      refute Enum.any?(effects, &match?({:own_nick_renamed, _, _}, &1))
+    end
+
+    test "NICK-other does NOT emit {:own_nick_renamed} (#514)" do
+      state = base_state(%{members: %{"#italia" => %{"vjt" => [], "alice" => ["@"]}}})
+      m = msg(:nick, ["alice_"], {:nick, "alice", "u", "h"})
+
+      assert {:cont, _, effects} = EventRouter.route(m, state)
+      refute Enum.any?(effects, &match?({:own_nick_renamed, _, _}, &1))
+    end
+
     test "NICK-self updates state.nick + fans out per channel PLUS a $server row (#61)" do
       state =
         base_state(%{
@@ -1724,14 +1761,18 @@ defmodule Grappa.Session.EventRouterTest do
       # #61: the per-channel rename line PLUS an always-visible $server
       # confirmation so the operator sees their own rename even from a
       # channel they're not currently looking at.
+      # A self-rename also emits {:own_nick_renamed} (#514), so narrow to the
+      # persist effects this test is about rather than mapping the whole list.
+      persists = Enum.filter(effects, &match?({:persist, :nick_change, _}, &1))
+
       channels =
-        effects
+        persists
         |> Enum.map(fn {:persist, :nick_change, a} -> a.channel end)
         |> Enum.sort()
 
       assert channels == Enum.sort(["#italia", "$server"])
 
-      Enum.each(effects, fn {:persist, :nick_change, attrs} ->
+      Enum.each(persists, fn {:persist, :nick_change, attrs} ->
         assert attrs.sender == "vjt"
         assert attrs.meta == %{new_nick: "vjt_"}
       end)
@@ -1744,7 +1785,10 @@ defmodule Grappa.Session.EventRouterTest do
       # The bug: a self-rename with no shared channels produced no effects
       # at all — no visible confirmation anywhere. It must surface on the
       # synthetic "$server" window, which always exists.
-      assert {:cont, new_state, [{:persist, :nick_change, attrs}]} =
+      # The $server row comes FIRST; {:own_nick_renamed} (#514) rides behind
+      # it — the list stays exact so a third effect appearing here is a
+      # deliberate decision, not a silent one.
+      assert {:cont, new_state, [{:persist, :nick_change, attrs}, {:own_nick_renamed, "vjt", "vjt_"}]} =
                EventRouter.route(m, state)
 
       assert new_state.nick == "vjt_"


### PR DESCRIPTION
Issue #514 — a self `/nick` left the subject's own inbound DM storage behind, so unread DMs received under the old nick lost their badge and notify credit.

## The defect

An inbound DM is persisted at `channel = <own nick at receipt>, dm_with = peer` (`Scrollback.dm_peer/4`). That `channel` value is **not a window key** — the peer window resolves off `dm_with` — it is a **tag** recording who we were when the row arrived, and `Push.Triggers.dm?/2` reads it back against the **live** own nick (#498). Nothing moved that tag when *we* renamed, so every pre-rename inbound DM stopped classifying as a DM, fell into the channel branch of `should_notify?/4`, and quietly dropped out of the notify set that `Push.BadgeCount` folds over history.

## Why this is one store, not the #373 set

A **peer** nick is a window key: that is why `{:peer_nick_renamed, …}` migrates three stores (`query_windows` row, DM scrollback, read cursor) and then broadcasts the move as a "rename fully applied" barrier.

Our **own** nick keys nothing. The inbound row's window and its read cursor are both keyed on the peer and are untouched by our rename. So the self-rename path is **one store, one UPDATE, no query window, no cursor, and no broadcast** — announcing a window move that did not happen would be a lie. The asymmetry *is* the answer here, not an exception being hidden.

`rename_dm_peer/4` also cannot simply be reused, and the reason is measurable rather than stylistic: its `count > 0` guard runs through `where_dm_peer/2` (`COALESCE(dm_with, channel)`), which on an inbound row yields the **peer**, never our own nick. Called with a self-rename it counts `0` and skips both UPDATEs — a silent no-op. Widening that guard to serve both cases is worse than duplicating it: the same column holds two roles and a nick migrates between them over time (we vacate `old`, a peer takes it), so a widened peer rename would start rewriting our inbound tag too.

## The predicate, and the corruption it prevents

Migrated rows are exactly `fold(channel) == fold(old)` **and** `fold(dm_with) != fold(old)`. The second conjunct is load-bearing: an outbound DM carries `channel == dm_with == peer`, so the bare channel test would refile our history with a peer who merely bears our old nick — we were `alice`, we DM'd `carol`, `carol` vanished, we took `carol`, we rename to `dave`, and the real carol's history lands under `dave`. Orphan rows (`dm_with IS NULL`) drop out on SQL three-valued logic and are pinned by test.

No `channels != []` gate on the effect, unlike the peer arm: that gate encodes "IRC delivers a peer's NICK only through a shared channel", which says nothing about our own echo, and the rows at stake are DMs — a DM-only session with zero channels joined is the case this was filed from.

## Two claims from the issue that measurement refutes

Both are pinned by test rather than argued, so nobody has to take my word for it:

1. **"The DM-window fetch may not surface old inbound DM history"** — it does. `channel_or_dm_where/3` resolves a peer window through `where_dm_peer/2`, matching `COALESCE(dm_with, channel)`, which on an inbound row is `dm_with` — the peer, untouched by a self-rename. Two tests read the window through the production path on both sides of the migration and assert the row set is identical. The read never depended on the own-nick tag; if someone ever re-keys it to, this breaks and says why.

2. **Mentions of the old nick are NOT recoverable.** A mention lives in the message **body**. A body is prose, not a key — rewriting it would falsify history, and no storage migration can or should restore that credit. This is a boundary of the change, not a defect left unfixed, and it is pinned by a test so nobody later reads the re-keying as "mentions follow a rename too".

The own-nick **self** window (`/msg <ownnick>`) is likewise out of scope: its row shape is indistinguishable from an outbound DM to a peer bearing our old nick without also folding `sender`, and it is a window-key migration — a different defect from this stale tag. Documented in the function's moduledoc; worth its own issue.

## Verification

TDD: 13 red first (badge count `0` where `1` was expected), then green.

Mutation testing against the three affected test files:

| mutation | red |
|---|---|
| effect never emitted | 4 |
| predicate widened to the bare channel test | 3 |
| outbound `dm_with != old` conjunct dropped | 1 |
| raw new nick stored instead of the folded key | 1 |
| case-only fold guard removed | 1 |
| `not is_nil(dm_with)` conjunct dropped | **0** |

The last row is a finding, not a footnote: that conjunct was mine, and it constrained nothing. It has been deleted in a follow-up commit rather than kept as unmeasured code.

`scripts/check.sh` exits 0 — 8 doctests, 54 properties, 5231 tests, 0 failures; Dialyzer `Total errors: 0`; Credo, Sobelow, doctor and the bats set all clean.