### PR TITLE
cic(#30): Tab completes channel names, not only nicks

### DIFF
--- a/cicchetto/e2e/tests/issue30-channel-tab-completion.spec.ts
+++ b/cicchetto/e2e/tests/issue30-channel-tab-completion.spec.ts
@@ -1,0 +1,131 @@
+// #30 — Tab completes CHANNEL names, not only nicks.
+//
+// Reported by Mezmerize on #it-opers: typing `#sni`<Tab> did nothing.
+// `tabComplete` read the member list unconditionally, so a sigil'd token
+// had no candidate set at all. The fix switches the candidate SET on the
+// token's leading sigil: a channel token draws from the channels JOINED on
+// this window's network (the server-owned `windowStateByChannel`
+// projection), a bare token still draws from the member list.
+//
+// Both halves are asserted in ONE flow, and the second half is what makes
+// this spec non-hollow: a spec that only proved "`#t30…`<Tab> completes"
+// would still pass against a candidate set built from "every channel ever
+// seen". An INVITED channel — known to the client, present in the very same
+// `windowStateByChannel` map, NOT joined — is the negative case: refusing it
+// is the `state === "joined"` FILTER, not mere absence of the key.
+//
+// WHY INVITED AND NOT PARTED (measured, #898). The first cut parted the
+// channel and re-Tabbed the same prefix, barriered on the sidebar row
+// vanishing. That barrier reads a DIFFERENT projection than the assert:
+// the row for a joined channel comes from `channelsBySlug` (Sidebar.tsx,
+// user topic `channels_changed`) while the candidate set reads
+// `windowStateByChannel` (compose.ts, the per-channel PART echo), and
+// Sidebar.tsx says outright there is no cross-topic ordering between the
+// two. A stale `joined` entry has NO DOM footprint at all — joined is
+// excluded from the pseudo-rows — so no barrier on the parted channel can
+// exist. Probing the same keystroke on a deadline measured the gap at
+// 60ms / 2180ms / 4929ms / 3981ms / 3972ms across five repeats: real, and
+// wide. The invited row IS `windowStateByChannel` rendered, so here the
+// barrier and the assert read ONE projection and the refusal is single-shot
+// truth rather than a race the fast machine happens to win.
+//
+// The trailing `" "` (never the nick path's `": "`) is asserted verbatim:
+// a channel is a topic of conversation, never an addressee.
+//
+// Live-stack only: the candidate set is fed by the server's window_state
+// broadcasts over the WS, and the invited half needs a real upstream INVITE
+// round-trip. jsdom/vitest can seed the store but cannot prove the store is
+// the thing the completion reads in a real browser on a real socket.
+
+import { IrcPeer } from "../fixtures/ircClient";
+import {
+  composeSend,
+  composeTextarea,
+  loginAs,
+  selectChannel,
+  sidebarWindow,
+} from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+test.setTimeout(90_000);
+
+test("#30 — Tab completes a JOINED channel, and refuses an INVITED one", async ({ page }) => {
+  const vjt = getSeededVjt();
+  // Per-run identity so a stale row from an earlier run can never satisfy
+  // either half, and so two `--repeat-each` workers entering this line in
+  // the same millisecond cannot collide — on a shared stack a duplicate
+  // peer nick is a 433 and a shared prefix would make the refusal
+  // ambiguous. The typed prefixes are the stable heads; the stamp is the
+  // part only this run can supply.
+  const stamp = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+  // DISTINCT heads: `j` and `i`. A shared head would let the joined channel
+  // satisfy the invited prefix, and the refusal would fail for a reason
+  // that has nothing to do with the joined-only rule.
+  const joinedPrefix = `#t30j-${stamp}`;
+  const joinedChannel = `${joinedPrefix}-sniffo`;
+  const invitedPrefix = `#t30i-${stamp}`;
+  const invitedChannel = `${invitedPrefix}-sniffo`;
+
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
+
+  const ta = composeTextarea(page);
+  await expect(ta).toBeVisible();
+
+  const peer = await IrcPeer.connect({ nick: `t30p${stamp}` });
+  try {
+    await composeSend(page, `/join ${joinedChannel}`);
+    // Fully JOINED (not the greyed :pending pseudo-row): selectChannel with
+    // ownNick requires the self-JOIN line + the WS-ready seam.
+    await selectChannel(page, NETWORK_SLUG, joinedChannel, { ownNick: NETWORK_NICK });
+
+    // Type in a DIFFERENT window: the candidate set is network-scoped, not
+    // "the channel you are looking at".
+    await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
+
+    await ta.click();
+    await ta.fill(joinedPrefix);
+    await ta.press("Tab");
+    // Completed to the full channel with a PLAIN trailing space. Pre-#30
+    // this stayed at the typed prefix.
+    await expect(ta).toHaveValue(`${joinedChannel} `, { timeout: 5_000 });
+    await expect(ta).toBeFocused();
+
+    // Now a channel the client KNOWS about but is not in. Bahamut requires
+    // the inviter to be in the channel (or be an oper), so the peer joins
+    // first or the INVITE relay comes back 442 ERR_NOTONCHANNEL.
+    await peer.join(invitedChannel);
+    peer.rawInvite(NETWORK_NICK, invitedChannel);
+
+    // THE BARRIER, on the store under test: this pseudo-row is
+    // `windowStateByChannel` rendered, and `data-window-state` pins it to
+    // the real `:invited` derivation rather than to the greyed class that
+    // every not-joined state shares. Once it reads "invited", the key is in
+    // the very map the completion filters — so the refusal below is a fact
+    // about the FILTER, with no cross-topic race left to lose.
+    const invitedTab = sidebarWindow(page, NETWORK_SLUG, invitedChannel);
+    await expect(invitedTab).toBeVisible({ timeout: 15_000 });
+    await expect(invitedTab).toHaveAttribute("data-window-state", "invited");
+
+    // Known, keyed, NOT joined: the draft is left exactly as typed.
+    await ta.click();
+    await ta.fill(invitedPrefix);
+    await ta.press("Tab");
+    await expect(ta).toHaveValue(invitedPrefix);
+
+    // POSITIVE CONTROL for the refusal above. "The value did not change" also
+    // describes a dead keybinding, an unmounted handler, or a page that never
+    // finished booting — so prove the completion engine was ALIVE at that
+    // moment by nick-completing in the same textarea on the next keystroke.
+    // Without this, the negative half could pass for the wrong reason. It
+    // doubles as the regression guard that #30 did not break nicks.
+    const nickPrefix = NETWORK_NICK.slice(0, NETWORK_NICK.length - 2);
+    await ta.fill(nickPrefix);
+    await ta.press("Tab");
+    await expect(ta).toHaveValue(`${NETWORK_NICK}: `, { timeout: 5_000 });
+  } finally {
+    await composeSend(page, `/part ${joinedChannel}`).catch(() => {});
+    await peer.disconnect("done").catch(() => {});
+  }
+});

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -1826,6 +1826,117 @@ describe("compose tabComplete (members-only, irssi-exact)", () => {
   });
 });
 
+// #30 — Tab on a token carrying a channel sigil draws from the channels
+// JOINED on this window's network instead of the member list. Same cycle,
+// same revert slot, same anchor; only the candidate set and the suffix
+// differ (a channel is never addressed, so never a `": "`).
+describe("compose tabComplete — channel names (#30)", () => {
+  const k = channelKey("freenode", "#a");
+
+  const setJoinedWindows = async (states: Record<string, string>) => {
+    const ws = await import("../lib/windowState");
+    vi.mocked(ws.windowStateByChannel).mockReturnValue(
+      states as unknown as ReturnType<typeof ws.windowStateByChannel>,
+    );
+  };
+
+  const setMembers = async (nicks: string[]) => {
+    const members = await import("../lib/members");
+    vi.mocked(members.membersByChannel).mockReturnValue({
+      [k]: nicks.map((nick) => ({ nick, modes: [] })),
+    });
+  };
+
+  it("completes a joined channel from its prefix", async () => {
+    await setJoinedWindows({
+      [channelKey("freenode", "#sniffo")]: "joined",
+      [channelKey("freenode", "#other")]: "joined",
+    });
+    const compose = await import("../lib/compose");
+    const r = compose.tabComplete(k, "#sni", 4, true);
+    expect(r?.newInput).toBe("#sniffo ");
+    expect(r?.newCursor).toBe(8);
+  });
+
+  it("never appends ': ' — a channel is not addressed like a nick", async () => {
+    await setJoinedWindows({ [channelKey("freenode", "#sniffo")]: "joined" });
+    const compose = await import("../lib/compose");
+    // Line start: the nick path would produce "…: " here.
+    expect(compose.tabComplete(k, "#sni", 4, true)?.newInput).toBe("#sniffo ");
+  });
+
+  it("offers only channels on THIS window's network", async () => {
+    await setJoinedWindows({
+      [channelKey("freenode", "#sniffo")]: "joined",
+      [channelKey("azzurra", "#sniffonauti")]: "joined",
+    });
+    const compose = await import("../lib/compose");
+    expect(compose.tabComplete(k, "#sni", 4, true)?.newInput).toBe("#sniffo ");
+    const draft = compose.getDraft(k);
+    // Only one candidate on freenode → next step is the revert slot, NOT
+    // the same-prefix channel that lives on the other network.
+    expect(compose.tabComplete(k, draft, draft.length, true)?.newInput).toBe("#sni");
+  });
+
+  it("offers only JOINED windows — not pending/parked/failed/kicked", async () => {
+    await setJoinedWindows({
+      [channelKey("freenode", "#sniffo")]: "pending",
+      [channelKey("freenode", "#sniper")]: "parked",
+      [channelKey("freenode", "#snitch")]: "failed",
+      [channelKey("freenode", "#snoop")]: "kicked",
+    });
+    const compose = await import("../lib/compose");
+    expect(compose.tabComplete(k, "#sni", 4, true)).toBeNull();
+  });
+
+  it("folds case on the match and inserts the folded key (the channel display)", async () => {
+    await setJoinedWindows({ [channelKey("freenode", "#Sniffo")]: "joined" });
+    const compose = await import("../lib/compose");
+    expect(compose.tabComplete(k, "#SNI", 4, true)?.newInput).toBe("#sniffo ");
+  });
+
+  it("cycles matches then reverts to the typed text, then wraps", async () => {
+    await setJoinedWindows({
+      [channelKey("freenode", "#sniffo")]: "joined",
+      [channelKey("freenode", "#snitch")]: "joined",
+    });
+    const compose = await import("../lib/compose");
+    expect(compose.tabComplete(k, "#sn", 3, true)?.newInput).toBe("#sniffo ");
+    let draft = compose.getDraft(k);
+    expect(compose.tabComplete(k, draft, draft.length, true)?.newInput).toBe("#snitch ");
+    draft = compose.getDraft(k);
+    expect(compose.tabComplete(k, draft, draft.length, true)?.newInput).toBe("#sn");
+    draft = compose.getDraft(k);
+    expect(compose.tabComplete(k, draft, draft.length, true)?.newInput).toBe("#sniffo ");
+  });
+
+  it("completes mid-sentence, leaving the rest of the line alone", async () => {
+    await setJoinedWindows({ [channelKey("freenode", "#sniffo")]: "joined" });
+    const compose = await import("../lib/compose");
+    expect(compose.tabComplete(k, "vieni su #sni", 13, true)?.newInput).toBe("vieni su #sniffo ");
+  });
+
+  it("returns null when no joined channel matches the token", async () => {
+    await setJoinedWindows({ [channelKey("freenode", "#other")]: "joined" });
+    const compose = await import("../lib/compose");
+    expect(compose.tabComplete(k, "#sni", 4, true)).toBeNull();
+  });
+
+  it("a sigil-less token still completes NICKS, not channels", async () => {
+    await setJoinedWindows({ [channelKey("freenode", "#sniffo")]: "joined" });
+    await setMembers(["sniper"]);
+    const compose = await import("../lib/compose");
+    expect(compose.tabComplete(k, "sni", 3, true)?.newInput).toBe("sniper: ");
+  });
+
+  it("works from a query window (channel candidates come from the network)", async () => {
+    await setJoinedWindows({ [channelKey("freenode", "#sniffo")]: "joined" });
+    const compose = await import("../lib/compose");
+    const q = channelKey("freenode", "mezmerize");
+    expect(compose.tabComplete(q, "#sni", 4, true)?.newInput).toBe("#sniffo ");
+  });
+});
+
 // #268 — /away lifecycle: GOING-away clears this network's mentions bundle
 // (moved off the reorder-prone away_confirmed:"away" echo); bare /away
 // (un-away) does NOT clear (the return path re-SETs the bundle).

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -1560,6 +1560,12 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   // separate cut. The decoded name is already ASCII-folded (channelKey
   // folds at construction) and for channels the folded key IS the display
   // (the #537/#525 channel invariant), so it is inserted verbatim.
+  //
+  // No sigil filter on the candidate name: this map mirrors the server's
+  // `Session.Server` `window_states`, which is channel-keyed by
+  // construction (a DM lives in `queryWindows`, not here), so a
+  // "joined" non-channel key cannot occur. A guard for it was written,
+  // measured against the suite at ZERO failing tests, and deleted.
   const joinedChannelsOnNetwork = (key: ChannelKey): string[] => {
     const here = decodeChannelKey(key);
     if (here === null) return [];
@@ -1569,7 +1575,6 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       if (state !== "joined") continue;
       const there = decodeChannelKey(candidate as ChannelKey);
       if (there === null || there.slug !== here.slug) continue;
-      if (!CHANNEL_SIGIL.test(there.name)) continue;
       out.push(there.name);
     }
     return out;

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -14,7 +14,7 @@ import { token } from "./auth";
 import { openBanlistModal } from "./banlistModal";
 import { buildBanMask } from "./banMask";
 import { setQuery } from "./channelDirectory";
-import { type ChannelKey, canonicalChannel, channelKey } from "./channelKey";
+import { type ChannelKey, canonicalChannel, channelKey, decodeChannelKey } from "./channelKey";
 import { friendlyError } from "./friendlyError";
 import { addHighlight, delHighlight } from "./highlightList";
 import { identityScopedStore } from "./identityScopedStore";
@@ -67,6 +67,17 @@ import {
 import { openUmodeModal } from "./umodeModal";
 import { closeQueryWindow } from "./windowClose";
 import { LIST_WINDOW_NAME, SERVER_WINDOW_NAME } from "./windowKinds";
+import { windowStateByChannel } from "./windowState";
+
+// RFC 2812 channel sigils. The CORRECT source is the server's ISUPPORT
+// `CHANTYPES`, but nothing in this stack parses it: `Grappa.Session.ISupport`
+// carries CHANMODES / PREFIX / STATUSMSG / CASEMAPPING only, and cic's
+// `isupport.ts` store mirrors just chanmodes + prefix. So this is the same
+// literal class already open-coded across cic (slashCommands, linkify,
+// pushPayload, ScrollbackPane) — hoisted here so this file has ONE copy.
+// TODO(#30): plumb CHANTYPES through `isupport_changed` and read it per
+// network instead of assuming the RFC set.
+const CHANNEL_SIGIL = /^[#&+!]/;
 
 // Per-channel compose state. Owns:
 //   * `composeByChannel` — { draft, history, historyCursor } per key.
@@ -510,7 +521,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       // Channel windows start with '#', '&', '+', or '!' per IRC spec.
       // Query windows use a nick (no # prefix). Server/list/mentions
       // pseudo-windows use synthetic keys that don't start with '#'.
-      if (!/^[#&+!]/.test(name)) return null;
+      if (!CHANNEL_SIGIL.test(name)) return null;
       return name;
     };
 
@@ -1539,13 +1550,43 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     return result;
   };
 
-  // Tab-complete: members-only. Cycles nick matches for the word at the
-  // cursor, irssi-style. Cycle space is [match0 … matchN-1, <typed>]: after
-  // the last match the next forward step restores the originally-typed text,
-  // then wraps to match0. Writes the completed draft itself via writeState
-  // (NOT setDraft, which nulls tabCycle and would kill the cycle) — callers
-  // only place the caret. Returns the new input + caret, or null when
-  // there's nothing to complete.
+  // #30 — the channel candidate set: every channel JOINED on the same
+  // network as the window being typed in. Derived from the server-owned
+  // `windowStateByChannel` projection (no parallel client-side list to
+  // drift); a pending / invited / parked / failed / kicked window is NOT
+  // offered, mirroring the nick rule that you complete who is actually
+  // here. Scope is deliberately narrower than the issue's "optionally
+  // channels seen via /list or mentioned in the buffer" — those are a
+  // separate cut. The decoded name is already ASCII-folded (channelKey
+  // folds at construction) and for channels the folded key IS the display
+  // (the #537/#525 channel invariant), so it is inserted verbatim.
+  const joinedChannelsOnNetwork = (key: ChannelKey): string[] => {
+    const here = decodeChannelKey(key);
+    if (here === null) return [];
+    const states = windowStateByChannel();
+    const out: string[] = [];
+    for (const [candidate, state] of Object.entries(states)) {
+      if (state !== "joined") continue;
+      const there = decodeChannelKey(candidate as ChannelKey);
+      if (there === null || there.slug !== here.slug) continue;
+      if (!CHANNEL_SIGIL.test(there.name)) continue;
+      out.push(there.name);
+    }
+    return out;
+  };
+
+  // Tab-complete. Cycles matches for the word at the cursor, irssi-style.
+  // Cycle space is [match0 … matchN-1, <typed>]: after the last match the
+  // next forward step restores the originally-typed text, then wraps to
+  // match0. Writes the completed draft itself via writeState (NOT setDraft,
+  // which nulls tabCycle and would kill the cycle) — callers only place the
+  // caret. Returns the new input + caret, or null when there's nothing to
+  // complete.
+  //
+  // #30 — the token's leading sigil picks the candidate SET (channels vs
+  // members) and the suffix; the cycle, the revert slot and the anchor are
+  // shared. There is ONE completion engine, deliberately: a parallel one
+  // would drift on the re-tap/anchor rules that took #737 to get right.
   const tabComplete = (
     key: ChannelKey,
     input: string,
@@ -1555,8 +1596,6 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     // #737 — tab-complete writes the draft directly (see writeState below),
     // so it needs the same refusal as setDraft / the history walk.
     if (isDraining(key)) return null;
-    const all = membersByChannel()[key] ?? [];
-    if (all.length === 0) return null;
 
     const continuing =
       tabCycle !== null &&
@@ -1591,14 +1630,19 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       // Unicode-over-folds non-ASCII (`CAFÉ`→`café`), not the brackets.
       // Mirror of `Grappa.IRC.Identifier.canonical_nick/1`.
       prefix = asciiFold(typedWord);
-      // ": " only when the word is the first token on the line.
-      suffix = input.slice(0, anchorStart).trim() === "" ? ": " : " ";
+      // ": " only when the word is the first token on the line — and only
+      // for a NICK. A channel is a topic of conversation, never an
+      // addressee, so `#chan: ` would be wrong at line start (#30).
+      suffix =
+        !CHANNEL_SIGIL.test(typedWord) && input.slice(0, anchorStart).trim() === "" ? ": " : " ";
       oldEnd = cursor;
     }
 
-    const matches = all
-      .filter((m) => asciiFold(m.nick).startsWith(prefix))
-      .map((m) => m.nick)
+    const candidates = CHANNEL_SIGIL.test(typedWord)
+      ? joinedChannelsOnNetwork(key)
+      : (membersByChannel()[key] ?? []).map((m) => m.nick);
+    const matches = candidates
+      .filter((c) => asciiFold(c).startsWith(prefix))
       .sort((a, b) => a.localeCompare(b));
     if (matches.length === 0) return null;
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -30344,3 +30344,55 @@ tests green, because the `Map` collapses the key on its own and the test read
 option VALUES, which are folded and identical either way. The guard only
 decides which SPELLING survives. The assertion now pins that, and the
 mutation reddens one test.
+
+## 2026-08-05 — #30: the completion trigger picks a candidate SET, not a second engine
+
+Tab completed nicks and did nothing on a `#…` token. `compose.tabComplete`
+read `membersByChannel()` unconditionally, so a sigil'd word simply had no
+candidate set. Mezmerize reported it on #it-opers.
+
+**One engine, two candidate sets.** The obvious shape — a second
+`channelComplete` beside the nick one — was rejected. The cycle space
+(`[match0 … matchN-1, <typed>]`), the revert slot, and the re-tap anchor
+detection (continuation is detected by RANGE, the thing #737 had to get
+right) are the hard part, and they are identical for both. The sigil on the
+typed token now selects the candidate array and the suffix; everything
+downstream is untouched. A parallel engine would have drifted on the anchor
+rules the first time either side changed.
+
+**Candidates are JOINED channels on this window's network.** They are derived
+from `windowStateByChannel`, the existing server-owned projection, rather than
+a new client-side "channels I have heard of" list that would need its own
+housekeeping and would drift. The issue floats "optionally channels seen via
+/list or mentioned in the buffer"; that is deliberately NOT in this cut. Least
+surprise is that Tab offers what you are actually in — exactly the rule the
+nick path already follows by offering who is actually here. Network scope
+comes from decoding the window's own `ChannelKey`, so completion works from a
+query or server window too: the candidate set belongs to the network, not to
+the window you are looking at.
+
+**The suffix is the one place the two paths genuinely differ.** A first-token
+nick gets `": "` because you are addressing someone. A channel is a topic of
+conversation, never an addressee, so it always gets a plain `" "`. That is the
+20% that did not fit the shared verb, and it is the only branch taken.
+
+**CHANTYPES is the right source and does not exist.** ISUPPORT `CHANTYPES`
+is what should define the prefix set, but nothing in this stack parses it:
+`Grappa.Session.ISupport` carries CHANMODES / PREFIX / STATUSMSG /
+CASEMAPPING only, and cic's `isupport.ts` store mirrors just chanmodes +
+prefix. Inventing that plumbing inside a completion fix would have been the
+wrong cut, so this reuses the RFC 2812 class `[#&+!]` that cic already
+open-codes in `slashCommands`, `linkify`, `pushPayload` and `ScrollbackPane`
+— hoisted to ONE constant in `compose.ts` (which held a copy of its own) with
+a named TODO. Worth knowing for whoever picks the TODO up: those existing
+copies are not even in agreement — `slashCommands.ts:564` omits `+`.
+
+**A guard was written, measured at zero, and deleted.** The candidate loop
+first filtered decoded names on the channel sigil. Mutation-testing the
+implementation one conjunct at a time (remove the channel branch: 7 red;
+apply the nick suffix rule to channels: 6 red; drop the network filter: 1
+red; accept any window state: 1 red) put that filter at ZERO red — and the
+reason is that it defends an impossible state. `windowStateByChannel` mirrors
+`Session.Server`'s `window_states`, which is channel-keyed by construction; a
+DM lives in `queryWindows`. The measurement is recorded in the code comment so
+the next reader does not re-add it.


### PR DESCRIPTION
Issue #30 — reported by Mezmerize on #it-opers. Tab completed nicks; on a
`#…` token it did nothing at all.

## What was wrong

`compose.tabComplete` read `membersByChannel()` unconditionally, so a
sigil'd word had no candidate set. Not a broken match — no set.

## What this does

The token's leading sigil now picks the **candidate set** and the suffix.
Everything else — the cycle space `[match0 … matchN-1, <typed>]`, the
revert slot, the re-tap anchor detection — stays shared.

**One engine, deliberately.** A second `channelComplete` beside the nick
one was rejected: the anchor/re-tap rules are the hard part (#737 had to
get them right) and they are identical for both. A parallel engine would
drift the first time either side changed.

**Candidates are the channels JOINED on this window's network**, derived
from `windowStateByChannel` — the projection the server already owns —
rather than a new client-side "channels I have heard of" list that would
need its own housekeeping. Network scope comes from decoding the window's
own `ChannelKey`, so completion works from a query or server window too:
the set belongs to the network, not to the window you are looking at.

**The suffix is the one genuine difference.** A first-token nick gets
`": "` because you are addressing someone. A channel is a topic of
conversation, never an addressee, so it always gets a plain `" "`.

## Scope, stated

The issue floats "optionally channels seen via /list or mentioned in the
buffer". **Not in this cut.** Least surprise is that Tab offers what you
are actually in — exactly the rule the nick path follows by offering who
is actually here. A pending / invited / parked / failed / kicked window is
not offered.

## CHANTYPES: the right source, and it does not exist

ISUPPORT `CHANTYPES` is what should define the prefix set. Nothing in this
stack parses it: `Grappa.Session.ISupport` carries CHANMODES / PREFIX /
STATUSMSG / CASEMAPPING only, and cic's `isupport.ts` store mirrors just
chanmodes + prefix. Building that plumbing inside a completion fix was the
wrong cut, so this reuses the RFC 2812 class `[#&+!]` cic **already**
open-codes in `slashCommands`, `linkify`, `pushPayload` and
`ScrollbackPane` — hoisted to ONE constant in `compose.ts` (which held a
copy of its own) with a named TODO.

Worth knowing for whoever picks that TODO up: those existing copies are
not even in agreement. `slashCommands.ts:564` omits the `+`.

## Measured, not asserted

Each conjunct mutated away, one at a time, against `compose.test.ts`:

| mutation | failing tests |
|---|---|
| remove the channel branch (pre-fix behaviour) | 7 |
| apply the nick `": "` suffix rule to channels | 6 |
| drop the network filter | 1 |
| accept any window state, not only `joined` | 1 |
| drop the sigil filter on the decoded candidate | **0** |

The zero was **deleted, not dressed in a test**: it guarded an impossible
state. `windowStateByChannel` mirrors `Session.Server`'s `window_states`,
which is channel-keyed by construction — a DM lives in `queryWindows`. The
measurement is recorded in the code comment so nobody re-adds it.

## Tests

- `compose.test.ts` 158 → **168** unit tests. Full cic suite: 240 files /
  4351 tests green. `check` rc=0, `tsc --noEmit` rc=0, `build` rc=0.
- New e2e `issue30-channel-tab-completion.spec.ts` (chromium only, not
  `@webkit`-tagged): joins a per-run channel, completes it **from another
  window**, then PARTs it and re-Taps the SAME prefix — no completion.
  That second half is what pins the candidate set to LIVE joinedness
  rather than to history; a spec asserting only "it completes" would pass
  against a set built from "every channel ever seen".
  The refusal is followed by a **positive control** (a nick completion on
  the next keystroke in the same textarea), because "the value did not
  change" also describes a dead keybinding or a page that never booted.

## What I refuse to claim

- **That the e2e passes.** I was not allocated the stack lane; it is
  written and reasoned, not run. CI is the first execution.
- **That the e2e typechecks.** `cicchetto/e2e/node_modules` is absent
  locally; I verified every import against the fixture exports by hand.
- That the 3 unit tests already green before the fix constrain anything —
  they are regression guards, not proof.
- That the network filter and the joined-only filter are solidly covered:
  **1 failing test each**. Constrained, not redundant.

## Open product question

Tab on a **bare `#`** currently cycles every joined channel. That is the
irssi behaviour and it looks right, but it was not in the brief. Say the
word and it becomes a one-line refusal.