### PR TITLE
#866: per-conversation notification mute, keyed on the conversation

### DIFF
--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -525,6 +525,35 @@ export async function partChannel(
   }
 }
 
+// #866 — drop every per-conversation mute for `token`'s subject.
+//
+// notification_prefs live in `user_settings` and OUTLIVE the spec that wrote
+// them: the seeded vjt is shared by the whole suite, so a mute left behind
+// silences a channel for every later spec that expects a push or a beep. That
+// is the shared-stack poisoning class, and it is silent — the victim spec
+// fails on a missing notification with nothing pointing back here.
+//
+// Read-modify-write rather than PUT-the-defaults: the endpoint has no PATCH
+// semantics, so writing a fresh default map would also clobber whatever
+// whitelists / toggles another fixture had set.
+export async function clearMutedConversations(token: string): Promise<void> {
+  const url = `${GRAPPA_BASE_URL}/me/settings/notification-prefs`;
+  const headers = { authorization: `Bearer ${token}` };
+
+  const current = await fetch(url, { headers });
+  if (!current.ok) throw new Error(`clearMutedConversations: GET ${current.status}`);
+  const { notification_prefs: prefs } = (await current.json()) as {
+    notification_prefs: Record<string, unknown>;
+  };
+
+  const res = await fetch(url, {
+    method: "PUT",
+    headers: { ...headers, "content-type": "application/json" },
+    body: JSON.stringify({ ...prefs, muted_targets: {} }),
+  });
+  if (!res.ok) throw new Error(`clearMutedConversations: PUT ${res.status}`);
+}
+
 // JOIN a channel via REST POST (mirrors `cicchetto/src/lib/api.ts`'s
 // `postJoin`). Used by tests that PART a seeded channel and need to
 // restore it for subsequent specs (M9, in particular — without restore,

--- a/cicchetto/e2e/tests/push-866-conversation-mute.spec.ts
+++ b/cicchetto/e2e/tests/push-866-conversation-mute.spec.ts
@@ -1,0 +1,123 @@
+// push-866-conversation-mute — per-conversation notification mute (#866).
+//
+// Sibling of `push-prefs-whitelist.spec.ts`, and deliberately the MIRROR of
+// it: that spec proves the allow-list can let a channel through, this one
+// proves the deny-list can hold a channel back — including a channel the
+// operator is mentioned in, which nothing before #866 could silence without
+// turning mentions off everywhere.
+//
+// What it gates, and why an e2e is the right shape for it:
+//
+//   * the mute is created through the SettingsDrawer picker (`pref-mute-picker`),
+//     not by POSTing /me/settings/notification-prefs. So the folded key the
+//     picker emits, the server's normalization, and the key
+//     `Grappa.Push.Triggers` compares are all proven to be the SAME string. A
+//     unit test on either side cannot see a fold mismatch between them.
+//   * the assertion is on PUSH delivery, which is decided server-side. A
+//     client-only mute would silence the tab and still ring the phone —
+//     exactly the failure mode #866's own text calls out.
+//   * the negative arm carries a MENTION. That is vjt's Q2 ruling under test:
+//     the mute always wins, a highlight does not pierce it. Both truth-table
+//     ports assert this too; here it is asserted end to end, where a mention
+//     genuinely travels through `Mentions.mentioned?/3`.
+//
+// Removing the feature turns the negative arm red: with no mute, a mention in
+// #866-muted delivers a push (channel_mentions defaults ON).
+
+import { loginAs, openSettingsSection, selectChannel } from "../fixtures/cicchettoPage";
+import { clearMutedConversations, partChannel } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import {
+  assertNoPushDelivery,
+  awaitPushDelivery,
+  enablePushFromSettings,
+  pushCatcherEndpoint,
+  resetPushCatcher,
+  resetPushSubscriptions,
+  setPageVisibility,
+  stubPushManager,
+} from "../fixtures/push";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+const PEER_NICK = "i866-muter";
+const MUTED_CHANNEL = "#866-muted";
+const LOUD_CHANNEL = "#866-loud";
+const SUB_ID = "conversation-mute";
+
+test("a muted channel swallows even a direct mention, while its unmuted sibling still pushes", async ({
+  page,
+  context,
+}) => {
+  const vjt = getSeededVjt();
+  await resetPushCatcher();
+  await resetPushSubscriptions(vjt.token);
+  await stubPushManager(context, { endpoint: pushCatcherEndpoint(SUB_ID) });
+  await context.grantPermissions(["notifications"]);
+
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
+
+  await enablePushFromSettings(page, context, { id: SUB_ID, token: vjt.token });
+
+  const peer = await IrcPeer.connect({ nick: PEER_NICK });
+  try {
+    await peer.join(MUTED_CHANNEL);
+    await peer.join(LOUD_CHANNEL);
+
+    // Join operator-side FIRST: the mute picker offers the conversations the
+    // operator actually has, so both windows must exist before the drawer can
+    // list either of them. That ordering is the feature, not spec bookkeeping.
+    for (const channel of [MUTED_CHANNEL, LOUD_CHANNEL]) {
+      await page.locator(".compose-box textarea").fill(`/join ${channel}`);
+      await page.locator(".compose-box textarea").press("Enter");
+      await selectChannel(page, NETWORK_SLUG, channel, { ownNick: NETWORK_NICK });
+    }
+
+    await openSettingsSection(page, "push");
+
+    // Leave `channel_mentions` at its default (ON). The whole point is that a
+    // mention WOULD have pushed and the mute is what stops it — unchecking it
+    // here would make the negative arm pass for the wrong reason.
+    await expect(page.locator('[data-testid="pref-channel-mentions"]')).toBeChecked();
+
+    const picker = page.locator('[data-testid="pref-mute-picker"]');
+    await expect(picker.locator(`option[value="${MUTED_CHANNEL}"]`)).toHaveCount(1);
+    await picker.selectOption(MUTED_CHANNEL);
+
+    // The row is drawn from the server's echo, so its presence is proof the
+    // PUT landed and came back normalized — no sleep, no arbitrary timeout.
+    await expect(page.locator(`[data-testid="pref-muted-${MUTED_CHANNEL}"]`)).toBeVisible({
+      timeout: 10_000,
+    });
+    // ...and the loud channel is demonstrably NOT muted, so the two arms below
+    // differ in exactly one variable.
+    await expect(page.locator(`[data-testid="pref-muted-${LOUD_CHANNEL}"]`)).toHaveCount(0);
+
+    await page.locator('[data-testid="settings-drawer-backdrop"]').click({ force: true });
+
+    // Focus a third window so neither target is "being read", and background
+    // the device so #182's foreground-suppression is not what decides either
+    // arm.
+    await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
+    await setPageVisibility(page, false);
+
+    // Negative arm — a MENTION in the muted channel. Pre-#866 this pushed.
+    peer.privmsg(MUTED_CHANNEL, `${NETWORK_NICK}: you will not hear this`);
+    await assertNoPushDelivery(SUB_ID, 1_500);
+
+    // Positive arm — the same mention shape in the unmuted sibling. This is
+    // what keeps the negative arm from passing because push broke outright.
+    peer.privmsg(LOUD_CHANNEL, `${NETWORK_NICK}: but you will hear this`);
+    const deliveries = await awaitPushDelivery(SUB_ID);
+    expect(deliveries.length).toBeGreaterThanOrEqual(1);
+  } finally {
+    await peer.disconnect("#866 mute done");
+    // The mute is PERSISTED per subject and vjt is shared by the whole suite —
+    // leaving it behind silences #866-muted for every later spec, and the
+    // victim fails on a missing notification with nothing pointing back here.
+    await clearMutedConversations(vjt.token).catch(() => {});
+    await partChannel(vjt.token, NETWORK_SLUG, MUTED_CHANNEL).catch(() => {});
+    await partChannel(vjt.token, NETWORK_SLUG, LOUD_CHANNEL).catch(() => {});
+  }
+});

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -12,8 +12,10 @@ import {
 import AliasSettings from "./AliasSettings";
 import DeleteAccountModal from "./DeleteAccountModal";
 import InlineConfirmButton from "./InlineConfirmButton";
+import { windowCandidates } from "./lib/activeWindows";
 import { ApiError, displayNick, type Network, visitorNetworkNick } from "./lib/api";
 import { getSubject, isPersistentIdentity, token } from "./lib/auth";
+import { canonicalChannel } from "./lib/channelKey";
 import { getColoredNicklist } from "./lib/colorNicklist";
 import { syncedSetColoredNicklist, syncedSetTimeFormat } from "./lib/displayPrefs";
 import { type FontSizeKey, getFontSize, setFontSize } from "./lib/fontSize";
@@ -495,6 +497,51 @@ const SettingsDrawer: Component<Props> = (props) => {
   const commitNicksOnly = () => {
     const next = { ...prefs(), private_messages_only: splitCsv(nicksOnlyText()) };
     void savePrefs(next);
+  };
+
+  // #866 — the per-conversation mute list, sorted by the stored (folded) key
+  // so the rows do not reshuffle when one is added.
+  const mutedConversations = (): { key: string; until: number | null }[] =>
+    Object.entries(prefs().muted_targets ?? {})
+      .map(([key, target]) => ({ key, until: target.until }))
+      .sort((a, b) => a.key.localeCompare(b.key));
+
+  // What the picker offers: the conversations the SIDEBAR shows (joined and
+  // parted channels, open queries), never a free-text field over all of IRC —
+  // vjt's Q5. Deduped by the folded key because `muted_targets` is per-subject
+  // and carries no network: `#grappa` on two networks is ONE mute, and
+  // offering it twice would imply otherwise. Already-muted keys drop out, so
+  // the picker cannot re-add a row that is on screen right below it.
+  const muteCandidates = (): { key: string; label: string }[] => {
+    const muted = prefs().muted_targets ?? {};
+    const byKey = new Map<string, string>();
+    for (const candidate of windowCandidates()) {
+      const key = canonicalChannel(candidate.channelName);
+      if (Object.hasOwn(muted, key) || byKey.has(key)) continue;
+      byKey.set(key, candidate.channelName);
+    }
+    return [...byKey]
+      .map(([key, label]) => ({ key, label }))
+      .sort((a, b) => a.key.localeCompare(b.key));
+  };
+
+  // `until: null` — permanent. The shape carries the snooze field from day
+  // one (Q1) but this cut exposes no picker for it, so every mute the UI
+  // creates is permanent until removed.
+  const muteConversation = (key: string) => {
+    if (key === "") return;
+    const current = prefs();
+    void savePrefs({
+      ...current,
+      muted_targets: { ...(current.muted_targets ?? {}), [key]: { until: null } },
+    });
+  };
+
+  const unmuteConversation = (key: string) => {
+    const current = prefs();
+    const next = { ...(current.muted_targets ?? {}) };
+    delete next[key];
+    void savePrefs({ ...current, muted_targets: next });
   };
 
   const onMasterToggle = async (checked: boolean) => {
@@ -1310,6 +1357,14 @@ const SettingsDrawer: Component<Props> = (props) => {
 
               <hr />
 
+              {/* #866 — the section used to be one flat run of four controls
+                  in which "only in channels" sat between two checkboxes about
+                  different things and "channel mentions" trailed the whitelist
+                  it does not belong to. Grouped under headings so each
+                  question ("when do channels notify me?", "when do DMs?",
+                  "what never does?") is answered in one place, and so the mute
+                  list has a home rather than being bolted onto the end. */}
+              <h3>channels</h3>
               <label>
                 <input
                   type="checkbox"
@@ -1349,6 +1404,8 @@ const SettingsDrawer: Component<Props> = (props) => {
                 />
                 channel mentions
               </label>
+
+              <h3>private messages</h3>
               <label>
                 <input
                   type="checkbox"
@@ -1376,6 +1433,54 @@ const SettingsDrawer: Component<Props> = (props) => {
                   data-testid="pref-nicks-only"
                 />
               </label>
+
+              <h3>muted conversations</h3>
+              <p class="prefs-hint">
+                A muted conversation never notifies — not even when someone says your nick. The name
+                applies on every network.
+              </p>
+              <label class="prefs-list">
+                mute:
+                <select
+                  disabled={savingPrefs() || muteCandidates().length === 0}
+                  // Value resets to "" so the same conversation can be muted,
+                  // removed, and muted again without the select getting stuck
+                  // on a stale selection.
+                  value=""
+                  onChange={(e) => {
+                    const el = e.currentTarget as HTMLSelectElement;
+                    const picked = el.value;
+                    el.value = "";
+                    muteConversation(picked);
+                  }}
+                  data-testid="pref-mute-picker"
+                >
+                  <option value="">pick a conversation…</option>
+                  <For each={muteCandidates()}>
+                    {(candidate) => <option value={candidate.key}>{candidate.label}</option>}
+                  </For>
+                </select>
+              </label>
+              <Show when={mutedConversations().length > 0}>
+                <ul class="watchlists-list" data-testid="pref-muted-list">
+                  <For each={mutedConversations()}>
+                    {(muted) => (
+                      <li class="watchlists-item" data-testid={`pref-muted-${muted.key}`}>
+                        <span class="watchlists-keyword">{muted.key}</span>
+                        <button
+                          type="button"
+                          class="watchlists-remove"
+                          disabled={savingPrefs()}
+                          aria-label={`Unmute ${muted.key}`}
+                          onClick={() => unmuteConversation(muted.key)}
+                        >
+                          ×
+                        </button>
+                      </li>
+                    )}
+                  </For>
+                </ul>
+              </Show>
 
               <Show when={prefsError() !== null}>
                 <p class="prefs-error" role="alert" data-testid="prefs-error">

--- a/cicchetto/src/__tests__/SettingsDrawer.test.tsx
+++ b/cicchetto/src/__tests__/SettingsDrawer.test.tsx
@@ -163,6 +163,19 @@ vi.mock("../lib/selection", () => ({
   selectedChannel: () => selectedChannelHolder.current,
 }));
 
+// #866 — the mute picker offers exactly the sidebar's window universe, which
+// `activeWindows.windowCandidates` derives from networks × channels × query
+// windows. Mocked at THAT boundary rather than by stubbing its three upstream
+// stores: the drawer's contract is "whatever the shared projection returns
+// becomes an option", and a test that rebuilt the projection would be
+// asserting its own arithmetic.
+const windowCandidatesHolder = vi.hoisted(() => ({
+  current: [] as { networkSlug: string; channelName: string; kind: "channel" | "query" }[],
+}));
+vi.mock("../lib/activeWindows", () => ({
+  windowCandidates: () => windowCandidatesHolder.current,
+}));
+
 vi.mock("../lib/push", () => ({
   enablePush: vi.fn().mockResolvedValue({ status: "enabled", subscriptionId: "sub-1" }),
   disablePush: vi.fn().mockResolvedValue(true),
@@ -265,6 +278,7 @@ beforeEach(() => {
   uploadTtlHolder.current = null;
   subjectHolder.current = null;
   selectedChannelHolder.current = null;
+  windowCandidatesHolder.current = [];
 });
 
 describe("SettingsDrawer", () => {
@@ -453,6 +467,141 @@ describe("SettingsDrawer notifications section", () => {
     await waitFor(() => {
       expect(screen.getByTestId("push-banner")).toBeInTheDocument();
     });
+  });
+});
+
+// #866 — the mute surface. vjt's Q5 ruled OUT a free-text field ("a long
+// free-text line of channel names is bad UX") in favour of a picker over the
+// conversations you actually have, with each mute rendered as its own
+// removable row.
+describe("SettingsDrawer muted conversations — #866", () => {
+  const optionValues = (): string[] =>
+    [...(screen.getByTestId("pref-mute-picker") as HTMLSelectElement).options].map((o) => o.value);
+
+  const lastPutPrefs = async (): Promise<Record<string, unknown>> => {
+    const userSettings = await import("../lib/userSettings");
+    const calls = (userSettings.putNotificationPrefs as ReturnType<typeof vi.fn>).mock.calls;
+    const last = calls[calls.length - 1] as [string, Record<string, unknown>];
+    return last[1];
+  };
+
+  const openPush = async () => {
+    const userSettings = await import("../lib/userSettings");
+    wrap(true);
+    openSub("push-settings-entry");
+    await waitFor(() => {
+      expect(userSettings.getNotificationPrefs).toHaveBeenCalled();
+    });
+  };
+
+  beforeEach(() => {
+    windowCandidatesHolder.current = [
+      { networkSlug: "azzurra", channelName: "#Sbiffo", kind: "channel" },
+      { networkSlug: "azzurra", channelName: "alice", kind: "query" },
+    ];
+  });
+
+  it("offers the conversations you are in, keyed by the folded name", async () => {
+    await openPush();
+
+    // "#Sbiffo" is offered under its FOLDED key — that is what gets stored and
+    // what the predicate compares against — while the option still READS as
+    // the operator typed it.
+    expect(optionValues()).toEqual(["", "#sbiffo", "alice"]);
+    expect(screen.getByRole("option", { name: "#Sbiffo" })).toBeInTheDocument();
+  });
+
+  it("collapses the same conversation on two networks into one option", async () => {
+    windowCandidatesHolder.current = [
+      { networkSlug: "azzurra", channelName: "#grappa", kind: "channel" },
+      { networkSlug: "libera", channelName: "#Grappa", kind: "channel" },
+    ];
+
+    await openPush();
+
+    // muted_targets is per-subject and carries no network, so offering the
+    // name twice would promise a per-network mute the store cannot keep.
+    expect(optionValues()).toEqual(["", "#grappa"]);
+  });
+
+  it("picking a conversation persists a permanent mute and adopts the server echo", async () => {
+    await openPush();
+
+    fireEvent.change(screen.getByTestId("pref-mute-picker"), { target: { value: "#sbiffo" } });
+
+    await waitFor(async () => {
+      expect(await lastPutPrefs()).toMatchObject({
+        muted_targets: { "#sbiffo": { until: null } },
+      });
+    });
+    // The row appears because the PUT's echo came back, not because the click
+    // optimistically drew it: the mock echoes what it was sent, and the store
+    // rule is that cic adopts the server's normalized map.
+    await waitFor(() => {
+      expect(screen.getByTestId("pref-muted-#sbiffo")).toBeInTheDocument();
+    });
+  });
+
+  it("drops an already-muted conversation from the picker", async () => {
+    const userSettings = await import("../lib/userSettings");
+    (userSettings.getNotificationPrefs as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ...userSettings.DEFAULT_NOTIFICATION_PREFS,
+      muted_targets: { "#sbiffo": { until: null } },
+    });
+
+    await openPush();
+
+    await waitFor(() => {
+      expect(optionValues()).toEqual(["", "alice"]);
+    });
+  });
+
+  it("the × removes just that mute and leaves the others stored", async () => {
+    const userSettings = await import("../lib/userSettings");
+    (userSettings.getNotificationPrefs as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ...userSettings.DEFAULT_NOTIFICATION_PREFS,
+      muted_targets: { "#sbiffo": { until: null }, alice: { until: null } },
+    });
+
+    await openPush();
+    await waitFor(() => {
+      expect(screen.getByTestId("pref-muted-#sbiffo")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText("Unmute #sbiffo"));
+
+    await waitFor(async () => {
+      expect(await lastPutPrefs()).toMatchObject({ muted_targets: { alice: { until: null } } });
+    });
+    // The removed key is ABSENT, not present-with-a-falsy-value: the predicate
+    // decides on key presence alone.
+    expect((await lastPutPrefs()).muted_targets).not.toHaveProperty("#sbiffo");
+  });
+
+  it("disables the picker when every conversation is already muted", async () => {
+    const userSettings = await import("../lib/userSettings");
+    (userSettings.getNotificationPrefs as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ...userSettings.DEFAULT_NOTIFICATION_PREFS,
+      muted_targets: { "#sbiffo": { until: null }, alice: { until: null } },
+    });
+
+    await openPush();
+
+    await waitFor(() => {
+      expect((screen.getByTestId("pref-mute-picker") as HTMLSelectElement).disabled).toBe(true);
+    });
+  });
+
+  it("tolerates a server response with no muted_targets at all", async () => {
+    const userSettings = await import("../lib/userSettings");
+    const legacy = { ...userSettings.DEFAULT_NOTIFICATION_PREFS };
+    delete legacy.muted_targets;
+    (userSettings.getNotificationPrefs as ReturnType<typeof vi.fn>).mockResolvedValueOnce(legacy);
+
+    await openPush();
+
+    expect(optionValues()).toEqual(["", "#sbiffo", "alice"]);
+    expect(screen.queryByTestId("pref-muted-list")).toBeNull();
   });
 });
 

--- a/cicchetto/src/__tests__/SettingsDrawer.test.tsx
+++ b/cicchetto/src/__tests__/SettingsDrawer.test.tsx
@@ -522,6 +522,13 @@ describe("SettingsDrawer muted conversations — #866", () => {
     // muted_targets is per-subject and carries no network, so offering the
     // name twice would promise a per-network mute the store cannot keep.
     expect(optionValues()).toEqual(["", "#grappa"]);
+    // And the surviving LABEL is the first candidate's spelling, i.e. the one
+    // the sidebar is showing highest. Measured: without this assertion the
+    // dedupe guard was unconstrained — the Map collapses the key on its own,
+    // so dropping the guard only flipped which spelling won and nothing went
+    // red. The guard now has to earn its line.
+    expect(screen.getByRole("option", { name: "#grappa" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "#Grappa" })).toBeNull();
   });
 
   it("picking a conversation persists a permanent mute and adopts the server echo", async () => {

--- a/cicchetto/src/__tests__/notificationPrefs.test.ts
+++ b/cicchetto/src/__tests__/notificationPrefs.test.ts
@@ -106,3 +106,75 @@ describe("notificationPrefs store — #868", () => {
     expect(notificationPrefs()).toEqual(MUTED_MENTIONS);
   });
 });
+
+// #866 Q3 — snooze expiry belongs to the READER, on both ports. The server
+// drops elapsed entries inside `get_notification_prefs/1`; this signal is its
+// client twin. It matters here and not only there because the mirror is
+// refreshed on a user-topic (re)join and nothing else: a snooze set at 09:00
+// for one hour must stop silencing at 10:00 in a tab that has been open the
+// whole time, without a round-trip.
+describe("notificationPrefs muted_targets expiry — #866", () => {
+  const NOW_SECONDS = 1_800_000_000;
+
+  const withMutes = (muted: NotificationPrefs["muted_targets"]): NotificationPrefs => ({
+    ...DEFAULT_NOTIFICATION_PREFS,
+    muted_targets: muted,
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_SECONDS * 1000);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps a permanent mute (until: null)", () => {
+    mirrorNotificationPrefs(withMutes({ "#noisy": { until: null } }));
+
+    expect(notificationPrefs().muted_targets).toEqual({ "#noisy": { until: null } });
+  });
+
+  it("keeps a snooze whose until is still ahead", () => {
+    mirrorNotificationPrefs(withMutes({ "#noisy": { until: NOW_SECONDS + 60 } }));
+
+    expect(notificationPrefs().muted_targets).toEqual({ "#noisy": { until: NOW_SECONDS + 60 } });
+  });
+
+  it("drops a snooze whose until has elapsed, leaving the conversation audible again", () => {
+    mirrorNotificationPrefs(withMutes({ "#noisy": { until: NOW_SECONDS - 1 } }));
+
+    expect(notificationPrefs().muted_targets).toEqual({});
+  });
+
+  it("expires at the READ, not at the mirror — the same stored map answers differently as the clock moves", () => {
+    // The discriminating one. Nothing re-hydrates between the two reads, so a
+    // filter applied in `mirrorNotificationPrefs` (or in the settings drawer)
+    // would keep silencing `#noisy` forever and leave this red.
+    mirrorNotificationPrefs(withMutes({ "#noisy": { until: NOW_SECONDS + 60 } }));
+    expect(notificationPrefs().muted_targets).toEqual({ "#noisy": { until: NOW_SECONDS + 60 } });
+
+    vi.setSystemTime((NOW_SECONDS + 61) * 1000);
+
+    expect(notificationPrefs().muted_targets).toEqual({});
+  });
+
+  it("expires per entry — an elapsed snooze does not take a permanent mute with it", () => {
+    mirrorNotificationPrefs(
+      withMutes({ "#noisy": { until: NOW_SECONDS - 1 }, alice: { until: null } }),
+    );
+
+    expect(notificationPrefs().muted_targets).toEqual({ alice: { until: null } });
+  });
+
+  it("tolerates a server that sends no muted_targets at all (cic ships ahead of the BEAM)", () => {
+    const legacy = { ...DEFAULT_NOTIFICATION_PREFS };
+    delete legacy.muted_targets;
+
+    mirrorNotificationPrefs(legacy);
+
+    expect(notificationPrefs().muted_targets).toBeUndefined();
+    expect(notificationPrefs().channel_mentions).toBe(true);
+  });
+});

--- a/cicchetto/src/__tests__/userSettings.test.ts
+++ b/cicchetto/src/__tests__/userSettings.test.ts
@@ -45,6 +45,11 @@ describe("DEFAULT_NOTIFICATION_PREFS", () => {
       channel_mentions: true,
       private_messages_all: true,
       private_messages_only: [],
+      // #866 — nothing muted by default. This map must stay byte-identical to
+      // the server's `UserSettings.default_notification_prefs/0`: it is what
+      // an un-hydrated client decides beeps with, so a divergence here means
+      // the client is silently stricter (or looser) than the push it mirrors.
+      muted_targets: {},
     });
   });
 });

--- a/cicchetto/src/lib/activeWindows.ts
+++ b/cicchetto/src/lib/activeWindows.ts
@@ -134,7 +134,12 @@ export function classifyNextActive(
 // mentions windows are intentionally excluded — #235 cycles
 // "channel/query" windows only (server status buffers aren't activity
 // windows in the irssi sense).
-function buildCandidates(): ActiveWindow[] {
+//
+// Exported since #866: the per-conversation mute picker offers exactly the
+// conversations the sidebar shows, and the alternative was a second
+// walk over `networks()` × `channelsBySlug()` × `queryWindowsByNetwork()`
+// that would drift from this one the first time a window shape is added.
+export function windowCandidates(): ActiveWindow[] {
   const out: ActiveWindow[] = [];
   const cbs = channelsBySlug() ?? {};
   const qwbn = queryWindowsByNetwork();
@@ -169,7 +174,7 @@ function buildActivityIds(): Record<ChannelKey, number> {
 const root = moduleRoot(() => {
   const activeWindows = createMemo((): ActiveWindow[] =>
     orderUnreadWindows({
-      candidates: buildCandidates(),
+      candidates: windowCandidates(),
       unread: messagesUnread(),
       mentions: mentionCounts(),
       activityId: buildActivityIds(),

--- a/cicchetto/src/lib/notificationPrefs.ts
+++ b/cicchetto/src/lib/notificationPrefs.ts
@@ -34,10 +34,36 @@ import {
   type NotificationPrefs,
 } from "./userSettings";
 
+// #866 Q3 — expiry lives in the READ, on both ports. The server drops
+// elapsed mutes inside `UserSettings.get_notification_prefs/1`; this is its
+// client twin, because the mirrored signal is only refreshed on a user-topic
+// (re)join and a snooze can elapse with the tab open. Doing it here rather
+// than in `shouldNotify` is what keeps that predicate pure `/4` and the
+// shared truth-table free of a `now` column.
+//
+// A malformed `until` fails OPEN (the entry is dropped, so the conversation
+// notifies) rather than silently muting forever.
+//
+// `until` is unix SECONDS, so `Date.now()` is divided, not compared raw.
+const withLiveMutes = (prefs: NotificationPrefs): NotificationPrefs => {
+  const muted = prefs.muted_targets;
+  if (muted === undefined) return prefs;
+
+  const now = Math.floor(Date.now() / 1000);
+  const entries = Object.entries(muted);
+  const live = entries.filter(([, m]) => m.until === null || m.until > now);
+  // Same object back when nothing elapsed — the common case, and it keeps
+  // referential identity for anything memoising on the prefs.
+  if (live.length === entries.length) return prefs;
+  return { ...prefs, muted_targets: Object.fromEntries(live) };
+};
+
 const exports_ = identityScopedStore((onIdentityChange) => {
-  const [notificationPrefs, setNotificationPrefs] = createSignal<NotificationPrefs>(
+  const [storedPrefs, setNotificationPrefs] = createSignal<NotificationPrefs>(
     DEFAULT_NOTIFICATION_PREFS,
   );
+
+  const notificationPrefs = (): NotificationPrefs => withLiveMutes(storedPrefs());
 
   // Logout / account switch — back to the server's own defaults.
   onIdentityChange(() => setNotificationPrefs(DEFAULT_NOTIFICATION_PREFS));

--- a/cicchetto/src/lib/pushTriggers.ts
+++ b/cicchetto/src/lib/pushTriggers.ts
@@ -47,10 +47,13 @@ export type ShouldNotifyMessage = {
  *      the "notify" subset of api's CONTENT_KINDS, #395) → everything else
  *      false. NOTICE (services chatter) counts as unread but never notifies.
  *   2. own row (#532 C) — a row this operator authored never notifies.
- *   3. DM (channel folds to ownNick): private_messages_all OR
+ *   3. muted conversation (#866) — the folded channel, or the folded PEER
+ *      for a DM, present in `muted_targets`. Beats every reason below it,
+ *      mentions included.
+ *   4. DM (channel folds to ownNick): private_messages_all OR
  *      asciiFold(sender) in private_messages_only (mirrors the
  *      server's `canonical_target(sender) in ...`).
- *   4. channel: channel_messages_all OR canonicalChannel(channel) in
+ *   5. channel: channel_messages_all OR canonicalChannel(channel) in
  *      channel_messages_only OR (channel_mentions AND mention).
  */
 export function shouldNotify(
@@ -83,10 +86,43 @@ export function shouldNotify(
   // the client mirror of `Identifier.canonical_target/1` and folds a
   // nick-shaped identifier exactly as it folds a channel (a sigil sits
   // outside `A-Z`), which is why the same function serves both sides here.
-  if (canonicalChannel(message.channel) === canonicalChannel(ownNick)) {
+  const isDm = canonicalChannel(message.channel) === canonicalChannel(ownNick);
+
+  // #866 — the per-conversation mute, and it wins over EVERY reason below,
+  // including a direct mention (vjt's Q2: the mute always wins, because the
+  // polite default for "I silenced this room" is that it stays silent).
+  // That is why it sits here and not inside the two branches.
+  if (isMuted(prefs, conversationKey(message, isDm))) return false;
+
+  if (isDm) {
     return dmMatch(message, prefs);
   }
   return channelMatch(message, prefs, ownNick, patterns);
+}
+
+// The identity of the CONVERSATION the row belongs to — the thing an
+// operator points at when they say "mute this tab". For a channel that is
+// the channel; for a DM it is the PEER, never `message.channel`, which an
+// inbound DM sets to own_nick (so keying on it would collapse every DM
+// onto one mute). Same fold as the two whitelists: `canonicalChannel` is
+// the mirror of `Identifier.canonical_target/1` and folds a nick exactly
+// as it folds a channel.
+function conversationKey(message: ShouldNotifyMessage, isDm: boolean): string {
+  return canonicalChannel(isDm ? message.sender : message.channel);
+}
+
+// `until` is deliberately NOT read here. Expiry belongs to the READER
+// (`notificationPrefs()` client-side, `get_notification_prefs/1` on the
+// server) so this predicate stays pure and the shared truth-table needs no
+// `now` column — vjt's Q3. A stored-but-elapsed mute reaching this point
+// still silences; that only happens to a caller that bypassed the reader.
+//
+// `Object.hasOwn`, not `muted[key] !== undefined`: the map arrives from
+// `JSON.parse`, so it carries Object.prototype and a peer legitimately
+// nicked `constructor` or `toString` would otherwise read as muted.
+function isMuted(prefs: NotificationPrefs, key: string): boolean {
+  const muted = prefs.muted_targets;
+  return muted !== undefined && Object.hasOwn(muted, key);
 }
 
 function dmMatch(message: ShouldNotifyMessage, prefs: NotificationPrefs): boolean {

--- a/cicchetto/src/lib/shouldNotifyTruthTable.json
+++ b/cicchetto/src/lib/shouldNotifyTruthTable.json
@@ -464,5 +464,170 @@
     },
     "patterns": [],
     "expected": false
+  },
+  {
+    "name": "mute (#866): a muted channel beats channel_messages_all",
+    "message": { "kind": "privmsg", "channel": "#noisy", "sender": "alice", "body": "chatter" },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": true,
+      "channel_messages_only": [],
+      "channel_mentions": true,
+      "private_messages_all": true,
+      "private_messages_only": [],
+      "muted_targets": { "#noisy": { "until": null } }
+    },
+    "patterns": ["vjt"],
+    "expected": false
+  },
+  {
+    "name": "mute (#866 Q2): a muted channel beats a direct mention — the mute always wins",
+    "message": { "kind": "privmsg", "channel": "#noisy", "sender": "alice", "body": "vjt: ping" },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": true,
+      "private_messages_all": true,
+      "private_messages_only": [],
+      "muted_targets": { "#noisy": { "until": null } }
+    },
+    "patterns": ["vjt"],
+    "expected": false
+  },
+  {
+    "name": "mute (#866): a muted channel beats its own channel_messages_only entry",
+    "message": { "kind": "privmsg", "channel": "#noisy", "sender": "alice", "body": "chatter" },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": ["#noisy"],
+      "channel_mentions": false,
+      "private_messages_all": true,
+      "private_messages_only": [],
+      "muted_targets": { "#noisy": { "until": null } }
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
+    "name": "mute (#866): muting one channel leaves its unmuted sibling notifying",
+    "message": { "kind": "privmsg", "channel": "#quiet", "sender": "alice", "body": "vjt: ping" },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": true,
+      "private_messages_all": true,
+      "private_messages_only": [],
+      "muted_targets": { "#noisy": { "until": null } }
+    },
+    "patterns": ["vjt"],
+    "expected": true
+  },
+  {
+    "name": "mute (#866): a muted DM peer beats private_messages_all",
+    "message": { "kind": "privmsg", "channel": "vjt", "sender": "alice", "body": "ping" },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": false,
+      "private_messages_all": true,
+      "private_messages_only": [],
+      "muted_targets": { "alice": { "until": null } }
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
+    "name": "mute (#866): the DM mute keys on the PEER, so muting own_nick silences nothing",
+    "message": { "kind": "privmsg", "channel": "vjt", "sender": "alice", "body": "ping" },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": false,
+      "private_messages_all": true,
+      "private_messages_only": [],
+      "muted_targets": { "vjt": { "until": null } }
+    },
+    "patterns": [],
+    "expected": true
+  },
+  {
+    "name": "mute (#866): muting one DM peer leaves another peer's DM notifying",
+    "message": { "kind": "privmsg", "channel": "vjt", "sender": "bob", "body": "ping" },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": false,
+      "private_messages_all": true,
+      "private_messages_only": [],
+      "muted_targets": { "alice": { "until": null } }
+    },
+    "patterns": [],
+    "expected": true
+  },
+  {
+    "name": "mute (#866): the incoming side folds A-Z, so a muted #noisy silences #NoIsY",
+    "message": { "kind": "privmsg", "channel": "#NoIsY", "sender": "alice", "body": "chatter" },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": true,
+      "channel_messages_only": [],
+      "channel_mentions": false,
+      "private_messages_all": true,
+      "private_messages_only": [],
+      "muted_targets": { "#noisy": { "until": null } }
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
+    "name": "mute (#866): the DM peer folds A-Z too, so a muted alice silences ALICE",
+    "message": { "kind": "privmsg", "channel": "vjt", "sender": "ALICE", "body": "ping" },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": false,
+      "channel_messages_only": [],
+      "channel_mentions": false,
+      "private_messages_all": true,
+      "private_messages_only": [],
+      "muted_targets": { "alice": { "until": null } }
+    },
+    "patterns": [],
+    "expected": false
+  },
+  {
+    "name": "mute (#866 #525): the fold is ASCII, so a muted #café does not silence #CAFÉ",
+    "message": { "kind": "privmsg", "channel": "#CAFÉ", "sender": "alice", "body": "chatter" },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": true,
+      "channel_messages_only": [],
+      "channel_mentions": false,
+      "private_messages_all": true,
+      "private_messages_only": [],
+      "muted_targets": { "#café": { "until": null } }
+    },
+    "patterns": [],
+    "expected": true
+  },
+  {
+    "name": "mute (#866 Q3): until is opaque to the predicate — an elapsed one still silences, because expiry belongs to the reader",
+    "message": { "kind": "privmsg", "channel": "#noisy", "sender": "alice", "body": "chatter" },
+    "own_nick": "vjt",
+    "prefs": {
+      "channel_messages_all": true,
+      "channel_messages_only": [],
+      "channel_mentions": false,
+      "private_messages_all": true,
+      "private_messages_only": [],
+      "muted_targets": { "#noisy": { "until": 1000000000 } }
+    },
+    "patterns": [],
+    "expected": false
   }
 ]

--- a/cicchetto/src/lib/userSettings.ts
+++ b/cicchetto/src/lib/userSettings.ts
@@ -18,12 +18,32 @@ import { ApiError, readError } from "./api";
 import type { PresencePref } from "./presenceFilter";
 import type { TimeFormatKey } from "./timeFormat";
 
+// #866 — one muted conversation. `until` is a unix timestamp in SECONDS
+// (the `upload_ttl_seconds` unit, not JS milliseconds); `null` means the
+// mute is permanent. The field exists from day one even though this cut
+// exposes no snooze picker, so a later "mute for 8 hours" needs no second
+// structure beside this one — vjt's Q1 ruling.
+export type MutedTarget = {
+  until: number | null;
+};
+
+// Keyed by the FOLDED conversation: `canonicalChannel(channel)` for a
+// channel, `canonicalChannel(peer)` for a DM. NOT by the row's `channel`
+// field — an inbound DM carries `channel = own_nick`, so that key would
+// make "mute me" mean "mute every DM I ever receive".
+export type MutedTargets = Record<string, MutedTarget>;
+
 export type NotificationPrefs = {
   channel_messages_all: boolean;
   channel_messages_only: string[];
   channel_mentions: boolean;
   private_messages_all: boolean;
   private_messages_only: string[];
+  // Optional because cic ships independently of the server (#618): a bundle
+  // newer than the BEAM it talks to must tolerate the field being absent
+  // rather than crash the predicate on every arriving message. Present in
+  // DEFAULT_NOTIFICATION_PREFS, and every reader defaults it to `{}`.
+  muted_targets?: MutedTargets;
 };
 
 export type NotificationPrefsResponse = {
@@ -36,6 +56,7 @@ export const DEFAULT_NOTIFICATION_PREFS: NotificationPrefs = {
   channel_mentions: true,
   private_messages_all: true,
   private_messages_only: [],
+  muted_targets: {},
 };
 
 export async function getNotificationPrefs(token: string): Promise<NotificationPrefs> {

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -4388,14 +4388,25 @@ html.resize-dragging * {
   gap: 0.25rem;
 }
 
-.settings-drawer label.prefs-list input[type="text"] {
+.settings-drawer label.prefs-list input[type="text"],
+.settings-drawer label.prefs-list select {
   color: var(--text);
   padding: 0.25rem 0.4rem;
 }
 
-.settings-drawer label.prefs-list input[type="text"]:disabled {
+.settings-drawer label.prefs-list input[type="text"]:disabled,
+.settings-drawer label.prefs-list select:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* #866 — the one line of prose in this fieldset. It carries two facts the
+   controls cannot: that a mute outranks a mention, and that the key has no
+   network in it. */
+.settings-drawer .prefs-hint {
+  font-size: 0.75rem;
+  color: var(--muted);
+  margin: 0 0 0.25rem;
 }
 
 .settings-drawer h3 {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -30268,3 +30268,79 @@ nick — which is also why the expansion cannot inject a second wire command
 (and `Client.send_raw` CR/LF/NUL-guards the line regardless). The empty arm is
 kept and tested anyway, because the pure module must not be the place that
 assumes its caller validated.
+## 2026-08-05 — #866: the mute is keyed on the CONVERSATION, and it outranks the mention
+
+Per-conversation notification mute, the way Telegram does it. Every list in
+`notification_prefs` was an allow-list, so a noisy channel could not be
+silenced at all: even with `channel_messages_all: false` and the channel
+absent from `channel_messages_only`, the third disjunct still fired, because
+`channel_mentions` is a GLOBAL boolean. The only way to quieten one room was
+to turn mentions off in every room.
+
+**The key is the conversation, not `message.channel`.** This is the decision
+the whole feature turns on, and the obvious reading is the wrong one. An
+INBOUND DM is persisted with `channel = own_nick` (only an outbound one
+carries `channel = peer`), so a mute keyed on the `channel` field would have
+made a single "mute vjt" entry silence every DM the subject ever receives,
+while "mute alice" silenced nothing at all. So `Triggers.muted?/3` folds the
+CHANNEL for a channel row and the PEER for a DM — the same
+`canonical_target/1` the two whitelists already fold through, and the same
+one `UserSettings` applies at write, because a write that folded differently
+would store a key no message can match. Both ports carry a truth-table row
+that expects TRUE for a mute on own_nick: a port that keys on `channel`
+turns it red.
+
+**The mute always wins (vjt's Q2).** Telegram makes "notify me on a mention
+anyway" an option for muted groups; this does not. The mute sits in the
+`cond` ABOVE both branches rather than as one more conjunct inside
+`channel_match?/4`, so the next disjunct someone adds cannot forget to
+exclude it. His reasoning: it is the more polite default.
+
+**One map, not two deny-lists (Q1).** `%{folded_target => %{"until" =>
+unix_seconds | nil}}` — `nil` permanent, an integer a snooze. Two
+`string[]` deny-lists would have been the smaller change and would have
+needed a parallel structure the first time anyone wanted "for 8 hours". The
+field carries `until` from day one even though this cut ships no snooze
+picker; there is deliberately no network in the key, exactly like
+`channel_messages_only` beside it, because `user_settings` is per-SUBJECT.
+The drawer picker dedupes by folded key for that reason — offering `#grappa`
+once per network would promise a per-network mute the shape cannot keep.
+
+**Expiry is a read PROJECTION (Q3).** Elapsed entries are dropped in
+`get_notification_prefs/1` and nowhere else: no sweeper, no clock in the
+predicate, no `now` column in the shared truth-table, and `should_notify?/4`
+stays a pure `/4`. It is not a write, because `Push.BadgeCount` calls that
+reader per badge recount and pruning there would turn every badge refresh
+into a DB write; the elapsed row leaves storage on the next PUT, since the
+client writes back the map it read. cic mirrors the rule at ITS read —
+`notificationPrefs()` filters on every access, because the signal only
+re-hydrates on a user-topic (re)join and a one-hour snooze has to stop
+silencing an hour later in a tab nobody reloaded. A filter at
+`mirrorNotificationPrefs` would have looked equivalent and never expired.
+
+**The one departure from full-replace.** An ABSENT `muted_targets` on PUT
+means "unchanged"; every other key stays full-replace, which is still the
+documented contract for the five the endpoint shipped with. cic deploys
+independently of the BEAM and an installed PWA can run a cached bundle for
+weeks, so a client that has never heard of the field is saying nothing about
+the subject's mutes rather than asserting there are none — clearing them
+would be silent data loss the first time such a client ticked any other
+checkbox. An explicit `{}` still clears.
+
+**Both readers fail OPEN.** A stored entry with an uninterpretable `until`
+is dropped, not honoured. A mute nobody can expire must not be a mute; the
+failure direction is "you get notified", never "you are silenced forever by
+a value no one can read".
+
+**Out of scope, ruled explicitly (Q4).** `WindowCounts` mention counts and
+the sidebar severity dot are untouched — a muted conversation still COUNTS,
+it just does not push, beep, or move the icon badge. The badge follows
+because it is derived from this same predicate (`Push.BadgeCount`), not
+because it was wired separately.
+
+**Measured, not assumed.** The dedupe guard in the picker was written with a
+test that appeared to cover it; mutating the guard away left all 87 drawer
+tests green, because the `Map` collapses the key on its own and the test read
+option VALUES, which are folded and identical either way. The guard only
+decides which SPELLING survives. The assertion now pins that, and the
+mutation reddens one test.

--- a/lib/grappa/push/triggers.ex
+++ b/lib/grappa/push/triggers.ex
@@ -26,6 +26,20 @@ defmodule Grappa.Push.Triggers do
        their own message body. Excluding by sender-identity kills that for
        both self-authored shapes (outbound DM + own channel message).
 
+    0b. **Muted conversation** (#866) — the row's CONVERSATION (the folded
+       channel, or the folded PEER for a DM) is a key of
+       `prefs.muted_targets` — never notify. This beats every reason below,
+       INCLUDING a direct mention: vjt's Q2 ruling is that the mute always
+       wins, because "I silenced this room" staying silent is the polite
+       default. The mute is keyed on the conversation and NOT on
+       `message.channel` for the same reason step 0 exists — an inbound DM
+       carries `channel = own_nick`, so that key would collapse every DM
+       onto a single mute.
+
+       `until` is not read here. Expiry happens on READ, in
+       `UserSettings.get_notification_prefs/1`, so this predicate stays pure
+       and needs no clock.
+
   Otherwise returns `true` for one of three reasons:
 
     1. **DM** (`message.channel == own_nick`):
@@ -211,6 +225,12 @@ defmodule Grappa.Push.Triggers do
       # This is the ONE predicate `Push.BadgeCount` folds over the unread
       # tail, so the badge and the OS notification can never disagree.
       own_row?(message, own_nick) -> false
+      # #866 — the per-conversation mute, and it OUTRANKS every reason below,
+      # a direct mention included (vjt's Q2: the mute always wins). Placing it
+      # in the `cond` rather than inside the two branches is what makes that
+      # true structurally instead of by remembering to add `and not muted?` to
+      # each new disjunct.
+      muted?(message, prefs, own_nick) -> false
       dm?(message, own_nick) -> dm_match?(message, prefs)
       true -> channel_match?(message, prefs, own_nick, patterns)
     end
@@ -261,6 +281,26 @@ defmodule Grappa.Push.Triggers do
     do: Identifier.canonical_target(channel) == Identifier.canonical_target(own_nick)
 
   defp dm?(_, _), do: false
+
+  # #866 — is this row's CONVERSATION muted?
+  #
+  # The key is the conversation, NOT the row's `channel` field. An inbound DM
+  # is persisted with `channel = own_nick`, so keying on `channel` would make
+  # one "mute vjt" entry silence every DM the operator ever receives, while
+  # "mute alice" silenced nothing. So: the folded channel for a channel row,
+  # the folded PEER for a DM. Same `canonical_target/1` fold the two
+  # whitelists use, matching the fold `UserSettings` applies at write.
+  #
+  # `until` is deliberately not consulted. Expiry belongs to the READER
+  # (`UserSettings.get_notification_prefs/1`, Q3), which is what keeps this
+  # predicate pure and the shared truth-table free of a `now` column.
+  defp muted?(%Message{channel: channel, sender: sender} = message, prefs, own_nick)
+       when is_binary(channel) and is_binary(sender) do
+    key = if dm?(message, own_nick), do: sender, else: channel
+    Map.has_key?(Map.get(prefs, :muted_targets, %{}), Identifier.canonical_target(key))
+  end
+
+  defp muted?(_, _, _), do: false
 
   defp dm_match?(%Message{} = message, prefs) do
     Map.get(prefs, :private_messages_all, false) or

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -102,12 +102,38 @@ defmodule Grappa.UserSettings do
   `String.downcase` on incoming message fields so the comparison
   is case-insensitive end-to-end.
   """
+  @typedoc """
+  Per-conversation notification mutes (#866) — the one DENY-list in
+  `notification_prefs()`, where everything else is an allow-list.
+
+  Keyed by the FOLDED conversation (`Identifier.canonical_target/1`, the
+  channel pattern: fold at write, compare `==` at read): a channel by its
+  name, a DM by its PEER's nick. NOT by the row's `channel` field — an
+  inbound DM is persisted with `channel = own_nick`, so that key would make
+  a single entry silence every DM the subject receives.
+
+  There is deliberately no network in the key. `user_settings` is
+  per-SUBJECT, exactly like `channel_messages_only` beside it, so `#grappa`
+  is one mute across every network the subject is on.
+
+  The value is the closed shape `%{"until" => unix_seconds | nil}`, string
+  keys because that is what survives the `:map` JSON round-trip. `nil` is a
+  permanent mute; an integer is a snooze. The field carries `until` from day
+  one (vjt's Q1) even though no UI sets it yet, so adding a snooze picker
+  later needs no second structure and no migration.
+
+  Elapsed entries are dropped by the READER (`get_notification_prefs/1`),
+  never by a sweeper and never by the predicate — see that function.
+  """
+  @type muted_targets :: %{String.t() => %{String.t() => pos_integer() | nil}}
+
   @type notification_prefs :: %{
           channel_messages_all: boolean(),
           channel_messages_only: [String.t()],
           channel_mentions: boolean(),
           private_messages_all: boolean(),
-          private_messages_only: [String.t()]
+          private_messages_only: [String.t()],
+          muted_targets: muted_targets()
         }
 
   @typedoc """
@@ -180,6 +206,12 @@ defmodule Grappa.UserSettings do
   # needs a boundary (same rationale as @aliases_max_count / @upload_ttl_seconds_max).
   @presence_filter_max_count 2_000
   @channel_key_max_bytes 256
+
+  # #866 — same rationale as @presence_filter_max_count: `muted_targets` is a
+  # user-writable JSON blob, so it needs a ceiling or it is a storage vector.
+  # Generous against reality — the picker only offers conversations the
+  # subject actually has, and nobody is in 2000 of them.
+  @muted_targets_max_count 2_000
 
   # Upper bound for upload_ttl_seconds: one year. Image hosts (litterbox,
   # 0x0.st) cap at days; nobody legitimately wants a year-long TTL token
@@ -343,7 +375,8 @@ defmodule Grappa.UserSettings do
       channel_messages_only: [],
       channel_mentions: true,
       private_messages_all: true,
-      private_messages_only: []
+      private_messages_only: [],
+      muted_targets: %{}
     }
   end
 
@@ -359,6 +392,21 @@ defmodule Grappa.UserSettings do
   previous shape revision), missing keys are filled from defaults
   so the returned shape is ALWAYS a complete `notification_prefs()`.
   Reader is side-effect-free.
+
+  ## Snooze expiry happens HERE (#866, vjt's Q3)
+
+  A `muted_targets` entry whose `until` has elapsed is dropped from the
+  returned map. This is the ONLY place a mute expires — there is no
+  sweeper, and `Push.Triggers.should_notify?/4` never looks at the clock,
+  which is what keeps it a pure `/4` predicate and keeps the shared
+  cic/Elixir truth-table free of a `now` column.
+
+  Expiry is a READ-side projection, not a write: the stored row keeps the
+  elapsed entry. It disappears from storage on the next
+  `put_notification_prefs/2`, because the client PUTs back the map it read
+  from here. That costs nothing and keeps this reader side-effect-free —
+  pruning here would make a GET issue a write, and `Push.BadgeCount` calls
+  this per badge recount.
   """
   @spec get_notification_prefs(Subject.t()) :: notification_prefs()
   def get_notification_prefs({_, _} = subject) do
@@ -368,7 +416,7 @@ defmodule Grappa.UserSettings do
 
       %Settings{data: data} ->
         case data[@notification_prefs_key] do
-          %{} = stored -> merge_with_defaults(stored)
+          %{} = stored -> stored |> merge_with_defaults() |> drop_elapsed_mutes()
           _ -> default_notification_prefs()
         end
     end
@@ -395,6 +443,17 @@ defmodule Grappa.UserSettings do
       fallback at trigger-eval time. Storing means flipping `_all`
       off restores the subject's last list — better UX than
       discarding.
+    * `muted_targets` (#866) is the ONE key whose ABSENCE means "leave it
+      alone" rather than "set it to empty". Every other key is
+      full-replace, and that is still the contract for the five the
+      endpoint shipped with. The exception exists because cic deploys
+      independently of the BEAM and an installed PWA can run a cached
+      bundle for weeks: a client that has never heard of `muted_targets`
+      is saying nothing about the subject's mutes, not asserting they have
+      none, and reading its silence as "clear them" would delete an
+      operator's mutes the first time they tick any other checkbox. Keys
+      are folded (`Identifier.canonical_target/1`) and `until` must be
+      `null` or a positive unix timestamp in seconds.
 
   Returns `{:ok, %Settings{}}` on persistence; `{:error, changeset}`
   with descriptive errors on either validation failure path.
@@ -995,7 +1054,62 @@ defmodule Grappa.UserSettings do
         {key, read_list(stored, key, Map.fetch!(defaults, key))}
       end)
 
-    Map.merge(bools, lists)
+    bools
+    |> Map.merge(lists)
+    |> Map.put(:muted_targets, read_muted_targets(stored))
+  end
+
+  # #866 — defensive read of the mute map, the twin of `sanitize_aliases_read/1`.
+  # A row written by a future (or miscoded) writer must not reach the predicate
+  # half-shaped: an entry survives only with a non-empty binary key and a value
+  # that yields a usable `until`, and it is rebuilt into EXACTLY
+  # `%{"until" => v}` so no stray sibling key rides along. Keys are NOT re-folded
+  # — they were folded at write, which is the channel pattern.
+  @spec read_muted_targets(map()) :: muted_targets()
+  defp read_muted_targets(stored) do
+    case Map.get(stored, :muted_targets, Map.get(stored, "muted_targets")) do
+      map when is_map(map) -> sanitize_muted_read(map)
+      _ -> %{}
+    end
+  end
+
+  defp sanitize_muted_read(map) do
+    map
+    |> Enum.flat_map(fn {key, value} ->
+      case {is_binary(key) and key != "", read_until(value)} do
+        {true, {:ok, until}} -> [{key, %{"until" => until}}]
+        _ -> []
+      end
+    end)
+    |> Map.new()
+  end
+
+  # `nil`/absent is a PERMANENT mute, not a malformed one. Anything else that
+  # is not a positive integer is malformed and drops the whole entry —
+  # failing OPEN (the conversation notifies) rather than silencing forever on
+  # a value nobody can interpret.
+  defp read_until(value) when is_map(value) do
+    case Map.get(value, "until", Map.get(value, :until)) do
+      nil -> {:ok, nil}
+      n when is_integer(n) and n > 0 -> {:ok, n}
+      _ -> :error
+    end
+  end
+
+  defp read_until(_), do: :error
+
+  # #866 Q3 — the ONE place a snooze expires. Read-side only: see
+  # `get_notification_prefs/1`'s doc for why this is not a write and not a
+  # sweeper.
+  @spec drop_elapsed_mutes(notification_prefs()) :: notification_prefs()
+  defp drop_elapsed_mutes(prefs) do
+    now = System.os_time(:second)
+
+    Map.update!(prefs, :muted_targets, fn muted ->
+      # Every value is `%{"until" => nil | pos_integer}` by construction —
+      # `sanitize_muted_read/1` dropped anything else — so this match is total.
+      Map.filter(muted, fn {_key, %{"until" => until}} -> is_nil(until) or until > now end)
+    end)
   end
 
   defp read_bool(stored, key, default) do
@@ -1021,7 +1135,9 @@ defmodule Grappa.UserSettings do
   defp validate_and_normalize_prefs(prefs, subject) do
     with {:ok, bools} <- cast_bools(prefs, subject),
          {:ok, lists} <- cast_lists(prefs, subject),
-         normalized = Map.merge(bools, lists),
+         {:ok, muted} <- cast_muted_targets(prefs, subject),
+         normalized =
+           bools |> Map.merge(lists) |> Map.put(:muted_targets, resolve_muted(muted, subject)),
          :ok <- ensure_at_least_one_trigger(normalized, subject) do
       {:ok, normalized}
     end
@@ -1100,6 +1216,100 @@ defmodule Grappa.UserSettings do
   # for real channels and corrective for a nick-shaped key.
   defp list_fold(:private_messages_only), do: &Identifier.canonical_target/1
   defp list_fold(:channel_messages_only), do: &Identifier.canonical_target/1
+
+  # #866 — the one key whose ABSENCE means "unchanged" rather than "empty".
+  # See `put_notification_prefs/2`'s doc: a cic bundle older than this BEAM is
+  # not asserting the subject has no mutes, and clearing them on its first
+  # checkbox save would be silent data loss during any rollout window. An
+  # explicit `null` reads the same as absent — a client that means "clear
+  # them" sends `{}`, which is a map and takes the normalize path.
+  defp cast_muted_targets(prefs, subject) do
+    case Map.get(prefs, :muted_targets, Map.get(prefs, "muted_targets")) do
+      nil -> {:ok, :unchanged}
+      map when is_map(map) -> normalize_muted_targets(map, subject)
+      _ -> {:error, prefs_changeset_error("muted_targets must be a map", subject)}
+    end
+  end
+
+  # Resolving :unchanged costs one extra SELECT, and only on the absent path.
+  # It reads through `get_notification_prefs/1` ON PURPOSE rather than off the
+  # raw column: that reader is also where snoozes expire, so an old client's
+  # save prunes elapsed entries as a side effect instead of writing them back.
+  defp resolve_muted(:unchanged, subject),
+    do: Map.fetch!(get_notification_prefs(subject), :muted_targets)
+
+  defp resolve_muted(muted, _subject) when is_map(muted), do: muted
+
+  defp normalize_muted_targets(map, subject) when map_size(map) > @muted_targets_max_count do
+    {:error,
+     prefs_changeset_error(
+       "muted_targets must have at most #{@muted_targets_max_count} entries",
+       subject
+     )}
+  end
+
+  defp normalize_muted_targets(map, subject), do: collect_muted(Map.to_list(map), %{}, subject)
+
+  # Collect-or-bail traversal per CLAUDE.md: success extends the accumulator,
+  # the first error returns immediately. Two raw keys that fold to the same
+  # target collapse onto one entry, last one wins — the same collision the
+  # picker prevents client-side by deduping before it offers the option.
+  defp collect_muted([], acc, _subject), do: {:ok, acc}
+
+  defp collect_muted([{key, value} | rest], acc, subject) do
+    with {:ok, folded} <- cast_muted_key(key, subject),
+         {:ok, target} <- cast_muted_value(value, subject) do
+      collect_muted(rest, Map.put(acc, folded, target), subject)
+    end
+  end
+
+  # Folded through `canonical_target/1`, the same fold `normalize_list/2`
+  # applies to the two whitelists and the same one `Triggers.muted?/3` applies
+  # to the incoming row — a write that folded differently would store a key no
+  # message can ever match.
+  defp cast_muted_key(key, subject) when is_binary(key) do
+    folded = key |> String.trim() |> Identifier.canonical_target()
+
+    cond do
+      folded == "" ->
+        {:error, prefs_changeset_error("muted_targets keys must be non-empty strings", subject)}
+
+      byte_size(folded) > @channel_key_max_bytes ->
+        {:error,
+         prefs_changeset_error(
+           "muted_targets keys must be at most #{@channel_key_max_bytes} bytes",
+           subject
+         )}
+
+      true ->
+        {:ok, folded}
+    end
+  end
+
+  defp cast_muted_key(_key, subject),
+    do: {:error, prefs_changeset_error("muted_targets keys must be strings", subject)}
+
+  # Rebuilt into EXACTLY `%{"until" => v}` — a sibling key the writer invented
+  # is dropped here rather than persisted into a shape the readers don't model.
+  defp cast_muted_value(value, subject) when is_map(value) do
+    case Map.get(value, "until", Map.get(value, :until)) do
+      nil ->
+        {:ok, %{"until" => nil}}
+
+      n when is_integer(n) and n > 0 ->
+        {:ok, %{"until" => n}}
+
+      _ ->
+        {:error,
+         prefs_changeset_error(
+           "muted_targets until must be null or a positive unix timestamp in seconds",
+           subject
+         )}
+    end
+  end
+
+  defp cast_muted_value(_value, subject),
+    do: {:error, prefs_changeset_error("muted_targets values must be maps", subject)}
 
   defp ensure_at_least_one_trigger(prefs, subject) do
     if Enum.any?(@prefs_trigger_keys, &Map.fetch!(prefs, &1)) do

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -1112,7 +1112,7 @@ defmodule Grappa.UserSettings do
     Map.update!(prefs, :muted_targets, fn muted ->
       # Every value is `%{"until" => nil | pos_integer}` by construction —
       # `sanitize_muted_read/1` dropped anything else — so this match is total.
-      Map.filter(muted, fn {_key, %{"until" => until}} -> is_nil(until) or until > now end)
+      Map.filter(muted, fn {_, %{"until" => until}} -> is_nil(until) or until > now end)
     end)
   end
 
@@ -1242,7 +1242,7 @@ defmodule Grappa.UserSettings do
   defp resolve_muted(:unchanged, subject),
     do: Map.fetch!(get_notification_prefs(subject), :muted_targets)
 
-  defp resolve_muted(muted, _subject) when is_map(muted), do: muted
+  defp resolve_muted(muted, _) when is_map(muted), do: muted
 
   defp normalize_muted_targets(map, subject) when map_size(map) > @muted_targets_max_count do
     {:error,
@@ -1258,7 +1258,7 @@ defmodule Grappa.UserSettings do
   # the first error returns immediately. Two raw keys that fold to the same
   # target collapse onto one entry, last one wins — the same collision the
   # picker prevents client-side by deduping before it offers the option.
-  defp collect_muted([], acc, _subject), do: {:ok, acc}
+  defp collect_muted([], acc, _), do: {:ok, acc}
 
   defp collect_muted([{key, value} | rest], acc, subject) do
     with {:ok, folded} <- cast_muted_key(key, subject),
@@ -1290,7 +1290,7 @@ defmodule Grappa.UserSettings do
     end
   end
 
-  defp cast_muted_key(_key, subject),
+  defp cast_muted_key(_, subject),
     do: {:error, prefs_changeset_error("muted_targets keys must be strings", subject)}
 
   # Rebuilt into EXACTLY `%{"until" => v}` — a sibling key the writer invented
@@ -1312,7 +1312,7 @@ defmodule Grappa.UserSettings do
     end
   end
 
-  defp cast_muted_value(_value, subject),
+  defp cast_muted_value(_, subject),
     do: {:error, prefs_changeset_error("muted_targets values must be maps", subject)}
 
   defp ensure_at_least_one_trigger(prefs, subject) do

--- a/lib/grappa/user_settings.ex
+++ b/lib/grappa/user_settings.ex
@@ -89,20 +89,6 @@ defmodule Grappa.UserSettings do
   alias Grappa.{Accounts.User, IRC.Identifier, Repo, Subject, UserSettings.Settings, Visitors.Visitor}
 
   @typedoc """
-  Per-subject notification preferences — push-notifications cluster B3.
-
-  Five booleans + two string-list whitelists. Whitelist semantics:
-  IF `channel_messages_all` is true the `channel_messages_only` list
-  is ignored at trigger-eval time (UI greys it out, server still
-  stores the value so toggling `_all` off restores the prior list).
-  Same for `private_messages_all` / `private_messages_only`.
-
-  Channel names + nicks are stored lowercased + trimmed (set via
-  `put_notification_prefs/2`). Trigger eval (B4) uses
-  `String.downcase` on incoming message fields so the comparison
-  is case-insensitive end-to-end.
-  """
-  @typedoc """
   Per-conversation notification mutes (#866) — the one DENY-list in
   `notification_prefs()`, where everything else is an allow-list.
 
@@ -127,6 +113,24 @@ defmodule Grappa.UserSettings do
   """
   @type muted_targets :: %{String.t() => %{String.t() => pos_integer() | nil}}
 
+  @typedoc """
+  Per-subject notification preferences — push-notifications cluster B3.
+
+  Three booleans + two string-list whitelists + one mute map (#866).
+  Whitelist semantics: IF `channel_messages_all` is true the
+  `channel_messages_only` list is ignored at trigger-eval time (UI greys
+  it out, server still stores the value so toggling `_all` off restores
+  the prior list). Same for `private_messages_all` /
+  `private_messages_only`.
+
+  `muted_targets` is the only DENY side and it OUTRANKS all of the above,
+  a mention included (vjt's Q2) — see `t:muted_targets/0`.
+
+  Channel names + nicks are stored folded + trimmed (set via
+  `put_notification_prefs/2`) through `Identifier.canonical_target/1`,
+  and trigger eval folds the incoming message fields the same way, so the
+  comparison is case-insensitive end-to-end under CASEMAPPING=ascii.
+  """
   @type notification_prefs :: %{
           channel_messages_all: boolean(),
           channel_messages_only: [String.t()],

--- a/test/grappa/push/should_notify_parity_test.exs
+++ b/test/grappa/push/should_notify_parity_test.exs
@@ -42,8 +42,13 @@ defmodule Grappa.Push.ShouldNotifyParityTest do
     "channel_messages_only" => :channel_messages_only,
     "channel_mentions" => :channel_mentions,
     "private_messages_all" => :private_messages_all,
-    "private_messages_only" => :private_messages_only
+    "private_messages_only" => :private_messages_only,
+    "muted_targets" => :muted_targets
   }
+
+  # Only the TOP level is atomized. `muted_targets`' own keys + its `until`
+  # stay strings on purpose: that IS the post-JSON-roundtrip shape the
+  # predicate reads out of `user_settings.data` in production (#866).
 
   test "the shared fixture is non-empty (guards an accidental empty array)" do
     assert length(@truth_table) >= 10

--- a/test/grappa/user_settings_test.exs
+++ b/test/grappa/user_settings_test.exs
@@ -283,7 +283,12 @@ defmodule Grappa.UserSettingsTest do
                channel_messages_only: [],
                channel_mentions: true,
                private_messages_all: true,
-               private_messages_only: []
+               private_messages_only: [],
+               # #866 — nothing muted by default. This map is also mirrored
+               # byte-for-byte by cic's DEFAULT_NOTIFICATION_PREFS, so an
+               # un-hydrated client behaves like a subject who configured
+               # nothing rather than one who muted everything.
+               muted_targets: %{}
              }
     end
   end
@@ -368,7 +373,8 @@ defmodule Grappa.UserSettingsTest do
         channel_messages_only: ["#sbiffo"],
         channel_mentions: true,
         private_messages_all: false,
-        private_messages_only: ["alice"]
+        private_messages_only: ["alice"],
+        muted_targets: %{"#noisy" => %{"until" => nil}}
       }
 
       assert {:ok, %Settings{}} = UserSettings.put_notification_prefs({:user, user.id}, prefs)
@@ -524,6 +530,203 @@ defmodule Grappa.UserSettingsTest do
 
       assert {:ok, _} = UserSettings.put_notification_prefs({:user, user.id}, prefs)
       assert UserSettings.get_highlight_patterns({:user, user.id}) == ["foo", "bar"]
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # muted_targets — per-conversation mute (#866)
+  # ---------------------------------------------------------------------------
+
+  defp base_prefs(muted) do
+    %{
+      channel_messages_all: false,
+      channel_messages_only: [],
+      channel_mentions: true,
+      private_messages_all: true,
+      private_messages_only: [],
+      muted_targets: muted
+    }
+  end
+
+  defp put_muted(user, muted),
+    do: UserSettings.put_notification_prefs({:user, user.id}, base_prefs(muted))
+
+  defp read_muted(user),
+    do: UserSettings.get_notification_prefs({:user, user.id}).muted_targets
+
+  describe "notification_prefs muted_targets (#866)" do
+    test "folds keys with canonical_target/1, so the stored key is the one a row matches" do
+      user = user_fixture()
+
+      assert {:ok, _} =
+               put_muted(user, %{
+                 "  #SBiffo " => %{"until" => nil},
+                 "Alice" => %{"until" => nil}
+               })
+
+      # A-Z only, and trimmed. The same fold `Triggers.muted?/3` applies to the
+      # incoming channel/sender — a write that folded differently would store a
+      # key no message can ever match.
+      assert read_muted(user) == %{
+               "#sbiffo" => %{"until" => nil},
+               "alice" => %{"until" => nil}
+             }
+    end
+
+    test "does not over-fold non-ASCII, so #CAFÉ and #café stay two mutes (#525)" do
+      user = user_fixture()
+
+      assert {:ok, _} =
+               put_muted(user, %{
+                 "#CAFÉ" => %{"until" => nil},
+                 "#café" => %{"until" => nil}
+               })
+
+      assert map_size(read_muted(user)) == 2
+    end
+
+    test "keeps a snooze whose until is still ahead" do
+      user = user_fixture()
+      until = System.os_time(:second) + 3_600
+
+      assert {:ok, _} = put_muted(user, %{"#noisy" => %{"until" => until}})
+      assert read_muted(user) == %{"#noisy" => %{"until" => until}}
+    end
+
+    test "drops a snooze whose until has elapsed, on READ (Q3)" do
+      user = user_fixture()
+      elapsed = System.os_time(:second) - 1
+
+      assert {:ok, _} = put_muted(user, %{"#noisy" => %{"until" => elapsed}})
+
+      assert read_muted(user) == %{}
+    end
+
+    test "expiry is a read projection — the elapsed row is still in the column" do
+      user = user_fixture()
+      elapsed = System.os_time(:second) - 1
+
+      assert {:ok, _} = put_muted(user, %{"#noisy" => %{"until" => elapsed}})
+      assert read_muted(user) == %{}
+
+      # The point of Q3 being "on read": no sweeper, and the GET does not turn
+      # into a write. `Push.BadgeCount` calls the reader per recount, so a
+      # pruning read would issue a write per badge refresh.
+      settings = Repo.get_by!(Settings, user_id: user.id)
+      assert %{"muted_targets" => %{"#noisy" => %{"until" => ^elapsed}}} =
+               settings.data["notification_prefs"]
+    end
+
+    test "an elapsed entry disappears from storage on the next write, without a sweeper" do
+      user = user_fixture()
+      elapsed = System.os_time(:second) - 1
+
+      assert {:ok, _} = put_muted(user, %{"#noisy" => %{"until" => elapsed}})
+      # A client PUTs back what it read, and what it read had the entry gone.
+      assert {:ok, _} = put_muted(user, read_muted(user))
+
+      settings = Repo.get_by!(Settings, user_id: user.id)
+      assert settings.data["notification_prefs"]["muted_targets"] == %{}
+    end
+
+    test "an ABSENT muted_targets key leaves the stored mutes alone" do
+      user = user_fixture()
+      assert {:ok, _} = put_muted(user, %{"#noisy" => %{"until" => nil}})
+
+      # A cic bundle predating #866 saves an unrelated checkbox. It is saying
+      # nothing about mutes, not asserting there are none — clearing them here
+      # would be silent data loss for the whole rollout window.
+      legacy = Map.delete(base_prefs(%{}), :muted_targets)
+      assert {:ok, _} = UserSettings.put_notification_prefs({:user, user.id}, legacy)
+
+      assert read_muted(user) == %{"#noisy" => %{"until" => nil}}
+    end
+
+    test "an EXPLICIT empty map does clear them — that is how the client unmutes" do
+      user = user_fixture()
+      assert {:ok, _} = put_muted(user, %{"#noisy" => %{"until" => nil}})
+
+      assert {:ok, _} = put_muted(user, %{})
+
+      assert read_muted(user) == %{}
+    end
+
+    test "rejects a non-integer until rather than storing a mute nobody can expire" do
+      user = user_fixture()
+
+      assert {:error, %Ecto.Changeset{} = cs} =
+               put_muted(user, %{"#noisy" => %{"until" => "tomorrow"}})
+
+      assert errors_on(cs)[:notification_prefs] != nil
+    end
+
+    test "rejects a non-positive until" do
+      user = user_fixture()
+
+      assert {:error, %Ecto.Changeset{}} = put_muted(user, %{"#noisy" => %{"until" => 0}})
+    end
+
+    test "rejects a value that is not a map" do
+      user = user_fixture()
+
+      assert {:error, %Ecto.Changeset{}} = put_muted(user, %{"#noisy" => true})
+    end
+
+    test "rejects a muted_targets that is not a map" do
+      user = user_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               UserSettings.put_notification_prefs(
+                 {:user, user.id},
+                 %{base_prefs(%{}) | muted_targets: ["#noisy"]}
+               )
+    end
+
+    test "rejects a key that folds to empty" do
+      user = user_fixture()
+
+      assert {:error, %Ecto.Changeset{}} = put_muted(user, %{"   " => %{"until" => nil}})
+    end
+
+    test "bounds the entry count, because the column is a user-writable blob" do
+      user = user_fixture()
+
+      too_many =
+        Map.new(1..2_001, fn n -> {"#chan#{n}", %{"until" => nil}} end)
+
+      assert {:error, %Ecto.Changeset{}} = put_muted(user, too_many)
+    end
+
+    test "drops a sibling key the writer invented rather than persisting an unmodelled shape" do
+      user = user_fixture()
+
+      assert {:ok, _} = put_muted(user, %{"#noisy" => %{"until" => nil, "reason" => "loud"}})
+
+      assert read_muted(user) == %{"#noisy" => %{"until" => nil}}
+    end
+
+    test "the reader survives a malformed stored map, failing OPEN" do
+      user = user_fixture()
+      {:ok, settings} = UserSettings.get_or_init({:user, user.id})
+
+      # Hand-written column, the shape a future/miscoded writer could leave.
+      data = %{
+        "notification_prefs" => %{
+          "channel_mentions" => true,
+          "muted_targets" => %{
+            "#good" => %{"until" => nil},
+            "#bad-until" => %{"until" => "soon"},
+            "#not-a-map" => 42,
+            "" => %{"until" => nil}
+          }
+        }
+      }
+
+      {:ok, _} = settings |> Settings.changeset(%{data: data}) |> Repo.update()
+
+      # Only the intelligible entry survives. The unreadable ones NOTIFY rather
+      # than silence forever — a mute nobody can interpret must not be a mute.
+      assert read_muted(user) == %{"#good" => %{"until" => nil}}
     end
   end
 

--- a/test/grappa/user_settings_test.exs
+++ b/test/grappa/user_settings_test.exs
@@ -613,6 +613,7 @@ defmodule Grappa.UserSettingsTest do
       # into a write. `Push.BadgeCount` calls the reader per recount, so a
       # pruning read would issue a write per badge refresh.
       settings = Repo.get_by!(Settings, user_id: user.id)
+
       assert %{"muted_targets" => %{"#noisy" => %{"until" => ^elapsed}}} =
                settings.data["notification_prefs"]
     end

--- a/test/grappa_web/controllers/user_settings_controller_test.exs
+++ b/test/grappa_web/controllers/user_settings_controller_test.exs
@@ -31,7 +31,10 @@ defmodule GrappaWeb.UserSettingsControllerTest do
       "channel_messages_only" => [],
       "channel_mentions" => true,
       "private_messages_all" => true,
-      "private_messages_only" => []
+      "private_messages_only" => [],
+      # #866 — nothing muted by default; the wire carries the key so a client
+      # can tell "no mutes" from "a server that predates the field".
+      "muted_targets" => %{}
     }
   end
 
@@ -90,7 +93,8 @@ defmodule GrappaWeb.UserSettingsControllerTest do
                "channel_messages_only" => ["#sbiffo"],
                "channel_mentions" => true,
                "private_messages_all" => false,
-               "private_messages_only" => ["alice"]
+               "private_messages_only" => ["alice"],
+               "muted_targets" => %{}
              }
     end
   end
@@ -149,6 +153,21 @@ defmodule GrappaWeb.UserSettingsControllerTest do
 
       stored = UserSettings.get_notification_prefs({:user, user.id})
       assert stored.channel_messages_only == ["#sbiffo", "#italia"]
+    end
+
+    # #866 — the nested mute map has to survive the wire in BOTH directions.
+    # Everything else in this envelope is a flat boolean or a list of strings;
+    # this is the first key whose value is an object, so the atom-vs-string
+    # round-trip through the `:map` column has one more level to get wrong.
+    test "round-trips the nested muted_targets map, folded", %{conn: conn, user: user} do
+      body = valid_prefs_wire(%{"muted_targets" => %{"#NOISY" => %{"until" => nil}}})
+      conn = put(conn, "/me/settings/notification-prefs", body)
+
+      assert %{"notification_prefs" => returned} = json_response(conn, 200)
+      assert returned["muted_targets"] == %{"#noisy" => %{"until" => nil}}
+
+      stored = UserSettings.get_notification_prefs({:user, user.id})
+      assert stored.muted_targets == %{"#noisy" => %{"until" => nil}}
     end
   end
 


### PR DESCRIPTION
Per-conversation notification mute (#866), on top of the #868 refactor.

Every list in `notification_prefs` was an allow-list, so a noisy channel
could not be silenced at all: even with `channel_messages_all: false` and
the channel absent from `channel_messages_only`, the third disjunct still
fired, because `channel_mentions` is a GLOBAL boolean. The only way to
quieten one room was to turn mentions off in every room.

Implements vjt's Q1–Q7 rulings verbatim; no product decision was invented.

## The decision the feature turns on

**The mute is keyed on the CONVERSATION, not on the row's `channel`
field.** An inbound DM is persisted with `channel = own_nick`, so keying
on `channel` would have made a single "mute vjt" entry silence every DM
the subject ever receives, while "mute alice" silenced nothing. So: the
folded channel for a channel row, the folded PEER for a DM. A truth-table
row expects TRUE for a mute on own_nick — a port that keys on `channel`
turns it red.

## The rest

- **The mute always wins (Q2).** It sits in the `cond` above both
  branches, so a direct mention does not pierce it and the next disjunct
  someone adds cannot forget to exclude it.
- **One map, `until` from day one (Q1).** `%{folded_target => %{"until"
  => unix_seconds | nil}}`. No UI writes an integer yet; two deny-lists
  would have needed a parallel structure the first time anyone wanted
  "for 8 hours". No network in the key — `user_settings` is per-SUBJECT,
  like `channel_messages_only` beside it.
- **Expiry is a read projection (Q3).** `get_notification_prefs/1` drops
  elapsed entries; no sweeper, no clock in the predicate, no `now` column
  in the shared truth-table. cic mirrors the rule at its own read, because
  the signal only re-hydrates on a user-topic (re)join and a one-hour
  snooze must stop silencing in a tab nobody reloaded.
- **Push / beep / badge only (Q4).** `WindowCounts` mention counts and the
  sidebar dot are untouched — a muted conversation still COUNTS. The badge
  follows because it is derived from this same predicate.
- **UI (Q5).** A picker over the conversations you actually have, not a
  text input; each mute is its own row with an ×, reusing the
  `.watchlists-list` idiom. The notifications section is regrouped under
  three headings rather than having the control bolted onto the end.
- **One departure from full-replace:** an ABSENT `muted_targets` on PUT
  means "unchanged". cic ships independently of the BEAM and an installed
  PWA can run a cached bundle for weeks; reading its silence as "clear
  them" would delete mutes the first time such a client ticked any other
  checkbox. An explicit `{}` still clears.

## Measured, not assumed

- 11 new shared truth-table rows. **7 measured red** in vitest before the
  cic port; the other 4 expect TRUE on purpose, so `-> false` cannot
  satisfy the set. With the server port reverted the SAME fixture reddens
  **7 of 41** in ExUnit — the drift gate works in both directions.
- Mutation testing on the drawer: neutering the add reddens 1, dropping
  the already-muted filter reddens 2. A dedupe guard I had "covered"
  turned out to be **unconstrained** (the Map dedupes on its own); the
  assertion was fixed so removing it now reddens 1.
- `scripts/check.sh` rc=0 — 8 doctests, 54 properties, 5266 tests, 0
  failures; 328 bats ok. Tree clean before and after.
- `scripts/bun.sh run test` 4365/4365, `run check` rc=0.
- Full `scripts/integration.sh`: **603 passed, 1 failed**. The failure is
  `issue270-peer-away-overlap` (the away banner never rendered), which
  runs BEFORE this spec, has no mechanism connecting it to notification
  prefs, and is green on main in CI at this branch's merge-base. **I did
  not establish a local full-suite baseline at the merge-base**, so I am
  not claiming it is unrelated — only that I found no link.