### PR TITLE
test(#903): pin tap 2's resting geometry and give it the margin it assumed

### DIFF
--- a/cicchetto/e2e/tests/issue360-scroll-to-bottom-mention-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue360-scroll-to-bottom-mention-badge.spec.ts
@@ -37,9 +37,12 @@ const BADGE = '[data-testid="scroll-to-bottom-badge"]';
 
 // Desktop (width > 768px, the mobile breakpoint; height > 500px, above the
 // #319 landscape-compact tier) but narrow — the sidebar + members pane leave a
-// ~420px scroll pane, so a 380-char filler wraps to a ~250px-tall block. A
-// couple of those overflow the ~380px fold, keeping the peer message count
-// tiny (fewer sends = no flood; see PACE_MS).
+// scroll pane a few hundred px wide, so one filler wraps to a block tall enough
+// that a couple of them overflow the fold, keeping the peer message count tiny
+// (fewer sends = no flood; see PACE_MS). Deliberately no px figure for that
+// block: it depends on the runner's font metrics, this comment used to guess
+// ~250px while the buffer comment below guessed ~140px, and #903 was the bill
+// for reasoning about margins in numbers nobody had measured.
 test.use({ viewport: { width: 900, height: 560 } });
 
 // ~270-char body → wraps to a tall (~7-line) block at this pane width, WITHOUT
@@ -54,16 +57,33 @@ const MENTION_2 = `${NETWORK_NICK}: second ping i360 mention two`;
 
 // Buffer, oldest → newest. LEADING pushes MENTION_1 below the fold at
 // scroll-top; MIDDLE separates the two mentions by more than half the pane so
-// centering the first leaves the second below the fold; TRAILING keeps
-// MENTION_2 off the exact tail so the pane is still not-at-bottom after the
-// second jump (button stays up) and there is travel for the final snap. Each
-// filler is ~140px on a ~380px pane; counts chosen with generous margin over
-// every threshold so a small render-height variance can't flip an assertion
-// while keeping the send count (and thus the fake-lag pacing time) low — this
-// spec runs inside the 25-minute integration CI ceiling.
+// centering the first leaves the second below the fold; TRAILING keeps the pane
+// off the tail after the second jump (button stays up) and leaves travel for
+// the final snap.
+//
+// #903 — TRAILING is NOT a round number, it is the one constant this spec's
+// premise rests on, and it was wrong. The jump anchors on the message AFTER the
+// mention (#360 iOS, b208eebd), so what separates the resting centre from the
+// tail is TRAILING-1 fillers, not TRAILING — and that commit never revisited
+// this block. Measured from the failing run's trace (31046232909): after tap 2
+// the pane rested at scrollTop 941 against a tail of 945. FOUR pixels, against
+// a 50px threshold — so the button unmounted because the pane really was at the
+// bottom, and the "button remains" assertion below was asserting something
+// false. Not a race, and nothing to tolerate.
+//
+// Each added filler pushes the resting position a further ~1 filler off the
+// tail (the anchor does not move; only the tail does), so TRAILING 2 → 4 buys
+// roughly two filler-heights of margin over the threshold instead of 4px. The
+// filler's rendered height is the thing that varies per runner — this file used
+// to estimate it at ~250px in one comment and ~140px in another, which is
+// exactly the uncertainty that made the old margin a coin toss — so the margin
+// is sized in FILLERS, a unit that scales with whatever that height turns out
+// to be, rather than in pixels. Cost is 2 more paced sends (~4.4s) inside the
+// 25-minute integration CI ceiling. `expectSettledNotAtBottom` asserts the
+// premise outright, so if this ever drifts again the red says so with a number.
 const LEADING = 4;
 const MIDDLE = 2;
-const TRAILING = 2;
+const TRAILING = 4;
 const LAST_FILLER_IDX = LEADING + MIDDLE + TRAILING - 1;
 // Short unique prefix of the last filler — a 380-char `hasText` is brittle
 // under Playwright whitespace normalisation; this token pins the tail line.

--- a/cicchetto/e2e/tests/issue360-scroll-to-bottom-mention-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue360-scroll-to-bottom-mention-badge.spec.ts
@@ -99,6 +99,45 @@ async function scrollToTop(page: Page): Promise<void> {
   });
 }
 
+// #903 — the pane's RESTING geometry, then the button. The button renders
+// under `<Show when={!atBottomNow()}>` and `atBottomNow` is DERIVED from
+// `scrollHeight - scrollTop - clientHeight` read in onScroll, so "the button is
+// there" is really a claim about where the pane came to rest. Checking the
+// premise separately makes a red name which half broke: the distance assertion
+// failing means the pane genuinely landed within the threshold (the buffer's
+// margin below the jump target is too thin — a fixture problem), while it
+// passing with the button still absent means the signal disagrees with the
+// settled geometry (a product problem — onScroll clears `atBottomNow` only when
+// scrollTop DECREASES, so a true reading taken mid-jump is never revised on the
+// way down). A bare "element(s) not found" distinguishes neither.
+//
+// The idle wait is a CONDITION, not a delay: two consecutive reads with an
+// identical scrollTop mean the smooth jump has stopped moving. It cannot be
+// spelled `expect.poll(distance).toBeGreaterThan(...)` — that succeeds on the
+// FIRST satisfying read, which during a downward jump is the first one taken,
+// constraining nothing about the resting position it is supposed to pin.
+async function expectSettledNotAtBottom(page: Page): Promise<void> {
+  let prev: number | null = null;
+  await expect
+    .poll(
+      async () => {
+        const top = await page.evaluate(() => {
+          const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+          return el === null ? null : Math.round(el.scrollTop);
+        });
+        const settled = top !== null && top === prev;
+        prev = top;
+        return settled;
+      },
+      { timeout: 10_000 },
+    )
+    .toBe(true);
+  expect(
+    (await distFromBottom(page)) ?? 0,
+    "the pane must come to rest above the at-bottom threshold, or the button is right to be gone",
+  ).toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
+}
+
 // True when the scrollback line whose body contains `needle` is fully within
 // the scroll container's visible box (the jump target landed in view). Read
 // against the CONTAINER rect (not the browser viewport) so an off-fold line
@@ -218,9 +257,7 @@ test.describe("#360 — mention-aware scroll-to-bottom badge", () => {
 
       // Precondition: scrolled up, the floating button shows, and the badge
       // counts BOTH mentions below the fold.
-      await expect
-        .poll(async () => (await distFromBottom(page)) ?? 0, { timeout: 5_000 })
-        .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
+      await expectSettledNotAtBottom(page);
       await expect(page.locator(SCROLL_TO_BOTTOM)).toBeVisible({ timeout: 5_000 });
       await expect(page.locator(BADGE)).toHaveText("2", { timeout: 10_000 });
 
@@ -232,6 +269,7 @@ test.describe("#360 — mention-aware scroll-to-bottom badge", () => {
         .toBe(true);
       await expect(page.locator(BADGE)).toHaveText("1", { timeout: 10_000 });
       // Still not at bottom → the button stays up for the next jump.
+      await expectSettledNotAtBottom(page);
       await expect(page.locator(SCROLL_TO_BOTTOM)).toBeVisible();
 
       // Tap 2 → jump to MENTION_2; no mentions remain below → badge gone.
@@ -241,7 +279,10 @@ test.describe("#360 — mention-aware scroll-to-bottom badge", () => {
         .toBe(true);
       await expect(page.locator(BADGE)).toHaveCount(0, { timeout: 10_000 });
       // Trailing content is still below → the button remains (now a plain
-      // snap-to-bottom affordance).
+      // snap-to-bottom affordance). The thinnest margin in the spec: the jump
+      // anchors on the message AFTER the mention (#360 iOS, b208eebd), so only
+      // TRAILING-1 fillers separate the resting centre from the tail.
+      await expectSettledNotAtBottom(page);
       await expect(page.locator(SCROLL_TO_BOTTOM)).toBeVisible();
 
       // Tap 3 (empty badge) → classic snap-to-bottom: newest line, button hides.


### PR DESCRIPTION
Refs #903.

## What the trace says (the screenshot was the wrong window)

`test-failed-1.png` shows `seed line #200` + `has joined #bofh`. That is **not** this
spec's channel: `SEED_COUNT = 200` is seeded into `AUTOJOIN_CHANNELS = ["#bofh"]`
(`e2e/fixtures/test.ts:39,131`), while the spec runs on a fresh `#i360m-<ts>` that
contains no `seed line #N` at all. `screenshot: "only-on-failure"` is captured in page-
fixture teardown, i.e. after the test body's `finally` has already `partChannel`-ed the
spec's window — so that PNG is the post-cleanup fallback view, not the failing moment.

The trace artifact does show the failing moment, and agrees with the conclusion anyway:

| evidence (run 31046232909) | value |
|---|---|
| selected window at `after@call@11903` (the failing assert) | `#i360m-73890` |
| `scrollTop` at rest after tap 2 (`before@call@11903`) | **941** |
| tail `scrollTop`, full buffer rendered (`after@call@11871`) | **945** |
| distance from bottom vs the 50px threshold | **4px** |

So `<Show when={!atBottomNow()}>` unmounted correctly: the pane genuinely was at the
bottom. Line 245's *"trailing content is still below → the button remains"* was false in
that run. **No product defect, no timing race, nothing to tolerate.**

## Why the premise was false

`b208eebd` (#360 iOS) moved the jump anchor to the message **after** the mention and never
revisited the buffer constants. What separates the resting centre from the tail is
`TRAILING-1` fillers — and `TRAILING` was 2, so the entire cushion was one filler. Whether
it cleared 50px came down to the runner's font metrics, which is exactly why the same
commits passed locally and failed on CI.

## The change

1. **`expectSettledNotAtBottom`** — wait for scroll IDLE (two consecutive equal `scrollTop`
   reads: a condition, not a delay and not a timeout bump), assert the distance, then the
   button. A future drift now reds with a number instead of `element(s) not found`.
   Applied to all three sites asserting the button's presence.
2. **`TRAILING` 2 → 4** — sized in *fillers*, not pixels. An added filler moves the tail
   without moving the anchor, so each buys a filler-height of margin whatever that height
   is on a given runner. The two contradictory pixel guesses in the file (~250px in one
   comment, ~140px in another — a spread that straddles the threshold) are deleted rather
   than corrected: neither was ever measured. Cost is 2 paced sends, ~4.4s.

## Class check

Every other `SCROLL_TO_BOTTOM` visibility assertion in the suite (#243, #280, #289, #253,
contamination) follows an explicit `scrollTop = 0` or a park with the distance already
asserted, where the premise cannot be in doubt. The exposed class is exactly the two
assertions in this spec that follow a mention jump, and both are covered.

## Not claimed

- **Not claimed green.** The only gate that executes this file is the integration lane,
  which I do not hold. `TRAILING = 4` is derived from the trace's 4px and the fact that a
  filler is worth far more than 46px — it is reasoned, not observed.
- `tsc -p e2e/tsconfig.json --noEmit` reports 23 errors, the same 23 as `origin/main`;
  none from this change. The one in this file (`msg.type() === "warn"`) is pre-existing and
  untouched.

## Two defects found alongside, deliberately left out of scope

- `cicchetto/e2e/tsconfig.json` has no `"noEmit"`, so the invocation that
  `cicchetto/e2e/.gitignore` documents emits a `.js` beside all 350 e2e sources.
- `e2e/` has no static gate at all: `biome.json` `includes` omits it (and `biome check` on
  an ignored path exits **0** while reporting "Checked 0 files"), and CI's `bun run check`
  typechecks `include: ["src"]` only — hence 23 unnoticed type errors.