### PR TITLE
cic(#904): a one-deep send queue for the composer

### DIFF
--- a/cicchetto/e2e/tests/issue904-one-deep-send-queue.spec.ts
+++ b/cicchetto/e2e/tests/issue904-one-deep-send-queue.spec.ts
@@ -1,0 +1,110 @@
+// #904 — the composer's one-deep send queue, in a real browser.
+//
+// The defect: on a slow link a SINGLE in-flight send shared one buffer with
+// the operator. The textarea stayed writable, Enter was a no-op (ComposeBox's
+// own `sending()` early-returned), and when the 201 finally landed the
+// end-of-submit clear wiped the follow-up the operator had typed meanwhile —
+// silently, and without it ever reaching history.
+//
+// The fix moved the in-flight truth into the store, keyed on the window: the
+// message leaves the composer AT DISPATCH, a second Enter parks its line in a
+// slot exactly one deep, the pump sends it on the ack, and a third is refused
+// visibly (readOnly) instead of being eaten.
+//
+// Why an e2e and not only jsdom: three of the four properties below are
+// browser-rendered state on the real send path — the textarea emptying at
+// dispatch, the readOnly refusal, and the queued line actually reaching the
+// server in order once the first ack lands (`feedback_cicchetto_browser_smoke`
+// — jsdom can observe none of that against a live grappa + leaf).
+//
+// The slow link is synthesized with `page.route`: the FIRST send POST is held
+// open until the spec releases it, which is exactly the ~5s mobile ack the
+// issue was reported on, made deterministic. Everything else — the queueing,
+// the dispatch, the ordering — is the real client and the real server.
+//
+// Subject-/platform-agnostic (store state + one `readOnly` binding), so one
+// desktop chromium run with the registered seed is sufficient.
+
+import { composeTextarea, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// POST /networks/{slug}/channels/{channel}/messages (no query string); the GET
+// pagination variant carries `?before=`/`?after=` and is let through untouched.
+const SEND_POST_RE = /\/channels\/[^/]+\/messages(\?|$)/;
+
+test.setTimeout(60_000);
+
+test("#904 — a slow send frees the composer, queues ONE more, refuses the third, and delivers both in order", async ({
+  page,
+}) => {
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  const tag = crypto.randomUUID().slice(0, 8);
+  const first = `q904 ${tag} first`;
+  const second = `q904 ${tag} second`;
+  const third = `q904 ${tag} third`;
+
+  // The slow link: hold the FIRST send POST open until this spec releases it.
+  // Every later send goes through untouched — the queue drains at full speed
+  // once the ack that was blocking it lands.
+  let releaseFirst: () => void = () => {};
+  const firstHeld = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  const sentBodies: string[] = [];
+  await page.route(SEND_POST_RE, async (route) => {
+    const request = route.request();
+    if (request.method() !== "POST") {
+      await route.continue();
+      return;
+    }
+    const body = JSON.parse(request.postData() ?? "{}") as { body?: string };
+    sentBodies.push(body.body ?? "");
+    if (sentBodies.length === 1) await firstHeld;
+    await route.continue();
+  });
+
+  const ta = composeTextarea(page);
+
+  // 1. The first message leaves the composer at DISPATCH, while its POST is
+  //    still hanging. Pre-fix the draft sat here until the 201.
+  await ta.fill(first);
+  await ta.press("Enter");
+  await expect(ta).toHaveValue("", { timeout: 5_000 });
+  await expect.poll(() => sentBodies.length).toBe(1);
+
+  // 2. The operator writes the next one while the first is still in flight and
+  //    hits Enter. Pre-fix that Enter did nothing at all and this text was
+  //    destroyed by the first send's end-of-submit clear.
+  await ta.fill(second);
+  await ta.press("Enter");
+  await expect(ta).toHaveValue("", { timeout: 5_000 });
+  // Queued, NOT sent: the link is still blocked on the first message.
+  expect(sentBodies).toEqual([first]);
+
+  // 3. Queue full (one in flight + one queued) → the refusal is VISIBLE: the
+  //    textarea goes read-only rather than accepting a third message it would
+  //    then have to eat. readOnly, never disabled — disabled blurs the box and
+  //    collapses the on-screen keyboard (#59).
+  await expect(ta).toHaveJSProperty("readOnly", true);
+  await expect(ta).toHaveJSProperty("disabled", false);
+
+  // 4. The ack lands. The queued line goes out — after the first, never before
+  //    it — and both render in the channel.
+  releaseFirst();
+  await expect.poll(() => sentBodies, { timeout: 15_000 }).toEqual([first, second]);
+  await expect(scrollbackLine(page, "privmsg", first)).toBeVisible({ timeout: 10_000 });
+  await expect(scrollbackLine(page, "privmsg", second)).toBeVisible({ timeout: 10_000 });
+
+  // The composer is the operator's again, and it works.
+  await expect(ta).toHaveJSProperty("readOnly", false);
+  await ta.fill(third);
+  await ta.press("Enter");
+  await expect(scrollbackLine(page, "privmsg", third)).toBeVisible({ timeout: 10_000 });
+});

--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -4,6 +4,8 @@ import { channelKey } from "./lib/channelKey";
 import {
   getDraft,
   isDraining,
+  isQueueFull,
+  isSending,
   recallNext,
   recallPrev,
   setDraft,
@@ -109,7 +111,6 @@ type Feedback = { text: string; severity: "error" | "notice" };
 const ComposeBox: Component<Props> = (props) => {
   const key = () => channelKey(props.networkSlug, props.channelName);
   const [feedback, setFeedback] = createSignal<Feedback | null>(null);
-  const [sending, setSending] = createSignal(false);
   // Auto-dismiss handle for a shown NOTICE. Held so a new input / new submit /
   // unmount can cancel a pending fire — otherwise a stale timer would clear a
   // freshly-shown notice (or fire after the ComposeBox is gone).
@@ -404,24 +405,23 @@ const ComposeBox: Component<Props> = (props) => {
 
   // ---- Submit ------------------------------------------------------
 
+  // #904 — no component-local in-flight gate any more. The store owns the
+  // one-deep queue keyed on the WINDOW, and it is the only thing that can
+  // tell a second Enter (queue it) from a third (refuse it) — a `sending()`
+  // here answered "no" to both after any unmount, and answered "yes" to the
+  // second one, which is how the operator's next message got eaten.
   const doSubmit = async (): Promise<void> => {
-    if (sending()) return;
-    setSending(true);
     clearFeedback();
-    try {
-      const result = await submit(key(), props.networkSlug, props.channelName);
-      // #356 — three outcomes:
-      //   {error}          → sticky red alert (except the "empty" no-op marker).
-      //   {ok: string}     → green auto-dismissing notice (the /notify + /hilight
-      //                      confirmation output, previously computed + discarded).
-      //   {ok: true}       → silent success (draft cleared upstream, no seam).
-      if ("error" in result) {
-        if (result.error !== "empty") setFeedback({ text: result.error, severity: "error" });
-      } else if (typeof result.ok === "string") {
-        showNotice(result.ok);
-      }
-    } finally {
-      setSending(false);
+    const result = await submit(key(), props.networkSlug, props.channelName);
+    // #356 — three outcomes:
+    //   {error}          → sticky red alert (except the "empty" no-op marker).
+    //   {ok: string}     → green auto-dismissing notice (the /notify + /hilight
+    //                      confirmation output, previously computed + discarded).
+    //   {ok: true}       → silent success (draft cleared upstream, no seam).
+    if ("error" in result) {
+      if (result.error !== "empty") setFeedback({ text: result.error, severity: "error" });
+    } else if (typeof result.ok === "string") {
+      showNotice(result.ok);
     }
   };
 
@@ -515,8 +515,14 @@ const ComposeBox: Component<Props> = (props) => {
           // prevent. Keyed on the WINDOW, not the component-local sending():
           // that one would follow the operator to whatever window they switch
           // to mid-drain and freeze the wrong composer.
-          readOnly={isDraining(key())}
-          aria-busy={isDraining(key())}
+          //
+          // #904 — the second refusal, same shape: one send in flight plus one
+          // queued behind it is the whole depth, and the third message is
+          // refused HERE, visibly, instead of being accepted and then eaten.
+          // A single in-flight send does NOT lock the box — composing the next
+          // one while this one goes out is the feature.
+          readOnly={isDraining(key()) || isQueueFull(key())}
+          aria-busy={isDraining(key()) || isQueueFull(key())}
           placeholder={composePlaceholder(props.networkSlug, props.channelName)}
           rows={1}
           aria-label="compose message"
@@ -538,8 +544,8 @@ const ComposeBox: Component<Props> = (props) => {
           // itself is decorative (aria-hidden), so aria-busy is the a11y twin
           // of the visual swap. Screen readers announce the busy state instead
           // of only the disabled state.
-          aria-busy={sending()}
-          disabled={sending() || getDraft(key()).trim() === ""}
+          aria-busy={isSending(key())}
+          disabled={getDraft(key()).trim() === ""}
           // #59: keep the textarea focused when sending via the button.
           // Tapping a <button> moves focus off the textarea, which collapses
           // the native on-screen keyboard (Android especially). preventDefault
@@ -547,8 +553,9 @@ const ComposeBox: Component<Props> = (props) => {
           // submits. Same trick as the image-picker button.
           onPointerDown={(e) => e.preventDefault()}
         >
-          {/* #241 — in-flight feedback. While a send is in flight
-              (`sending()` true — POST-scoped: cleared on the send's 201
+          {/* #241 — in-flight feedback. While a send is in flight for THIS
+              window (#904 moved that truth into the store, where it survives
+              the unmount a window switch causes; it clears on the send's 201
               ack, the server persisting+broadcasting atomically) the
               paper-plane arrow is swapped for a CSS spinner; it reverts
               to the arrow on resolution. Non-optimistic: the spinner
@@ -557,7 +564,7 @@ const ComposeBox: Component<Props> = (props) => {
               (`aria-hidden`) ring like the arrow it replaces — the
               button's `aria-label` carries the a11y name in both states. */}
           <Show
-            when={sending()}
+            when={isSending(key())}
             fallback={
               <svg
                 width="16"

--- a/cicchetto/src/__tests__/ComposeBox.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBox.test.tsx
@@ -1,5 +1,13 @@
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// #904 — the send queue lives in the store, keyed on the window, and
+// ComposeBox is a VIEW over it: the spinner, the readOnly refusal and the
+// Enter path all read these. Real signals (not plain mock returns) so a flip
+// re-renders exactly as the store's own signal does in production.
+const [mockSending, setMockSending] = createSignal(false);
+const [mockQueueFull, setMockQueueFull] = createSignal(false);
 
 vi.mock("../lib/compose", () => ({
   getDraft: vi.fn(() => ""),
@@ -11,6 +19,9 @@ vi.mock("../lib/compose", () => ({
   // #737 — the per-window paced-drain lock the textarea's readOnly is keyed
   // on. Default false: every pre-existing case is a window nobody is draining.
   isDraining: vi.fn(() => false),
+  // #904 — per-window in-flight state + the one-deep queue's full signal.
+  isSending: () => mockSending(),
+  isQueueFull: () => mockQueueFull(),
 }));
 
 vi.mock("../lib/channelKey", () => ({
@@ -87,6 +98,8 @@ beforeEach(() => {
   // Reset the module-singleton confirm-dialog store so a prior test's
   // pending request never leaks into the next one.
   dismissConfirm();
+  setMockSending(false);
+  setMockQueueFull(false);
 });
 
 describe("ComposeBox", () => {
@@ -122,14 +135,20 @@ describe("ComposeBox", () => {
   it("#241 — send button swaps arrow→spinner while a send is in flight, reverts on resolve", async () => {
     const compose = await import("../lib/compose");
     vi.mocked(compose.getDraft).mockReturnValue("hello");
-    // Deferred submit: holds `sending()` true across the in-flight
-    // assertions; resolving it drives the revert-to-arrow.
+    // Deferred submit standing in for the store: #904 moved the in-flight
+    // truth OUT of this component (a local `sending()` dies on unmount and
+    // follows the operator to the wrong window), so the mock raises and
+    // lowers the per-window flag exactly where the store does.
     let resolveSubmit: (r: { ok: true }) => void = () => {};
-    vi.mocked(compose.submit).mockReturnValue(
-      new Promise<{ ok: true }>((res) => {
-        resolveSubmit = res;
-      }),
-    );
+    vi.mocked(compose.submit).mockImplementation(() => {
+      setMockSending(true);
+      return new Promise<{ ok: true }>((res) => {
+        resolveSubmit = (r) => {
+          setMockSending(false);
+          res(r);
+        };
+      });
+    });
     try {
       render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
       const btn = screen.getByRole("button", { name: /send message/i });
@@ -456,6 +475,55 @@ describe("ComposeBox", () => {
     render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
     const ta = screen.getByPlaceholderText(/message #a/i) as HTMLTextAreaElement;
     expect(ta.readOnly).toBe(false);
+  });
+
+  // #904 — one in flight plus one queued is the whole depth. The THIRD
+  // message is refused where the operator can see it: the textarea goes
+  // read-only, the same visible refusal #737 uses, rather than accepting
+  // keystrokes that Enter would then silently eat.
+  it("#904 — textarea goes readOnly when the one-deep queue is full", () => {
+    setMockQueueFull(true);
+    render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+    const ta = screen.getByPlaceholderText(/message #a/i) as HTMLTextAreaElement;
+    expect(ta.readOnly).toBe(true);
+    expect(ta.getAttribute("aria-busy")).toBe("true");
+    // Never `disabled`: that blurs the textarea and collapses the on-screen
+    // keyboard (#59).
+    expect(ta.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("#904 — textarea stays writable while ONE send is in flight", () => {
+    setMockSending(true);
+    render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+    const ta = screen.getByPlaceholderText(/message #a/i) as HTMLTextAreaElement;
+    // The whole point of the queue: compose the next one while this one flies.
+    expect(ta.readOnly).toBe(false);
+  });
+
+  // #904 — the guard that used to swallow this Enter was ComposeBox's own
+  // `sending()`. A second Enter during a slow send did nothing at all; the
+  // typed line then died in the end-of-submit clear. It must reach the store,
+  // which is the only thing that knows whether the queue has room.
+  it("#904 — a second Enter during an in-flight send reaches the store", async () => {
+    const compose = await import("../lib/compose");
+    vi.mocked(compose.getDraft).mockReturnValue("hello");
+    let pending = 0;
+    vi.mocked(compose.submit).mockImplementation(() => {
+      pending += 1;
+      setMockSending(true);
+      return new Promise<{ ok: true }>(() => {});
+    });
+    try {
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      const ta = screen.getByPlaceholderText(/message #a/i);
+      fireEvent.keyDown(ta, { key: "Enter" });
+      await waitFor(() => expect(pending).toBe(1));
+      fireEvent.keyDown(ta, { key: "Enter" });
+      await waitFor(() => expect(pending).toBe(2));
+    } finally {
+      vi.mocked(compose.getDraft).mockReturnValue("");
+      vi.mocked(compose.submit).mockReset();
+    }
   });
 
   // #177 removed the custom on-screen IRC keyboard. The compose textarea no

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -225,6 +225,10 @@ vi.mock("../lib/compose", () => ({
   tabComplete: vi.fn(),
   // #737 — ComposeBox reads the per-window paced-drain lock for its readOnly.
   isDraining: () => false,
+  // #904 — …and the one-deep send queue's in-flight + full signals, for the
+  // send-button spinner and the queue-full refusal.
+  isSending: () => false,
+  isQueueFull: () => false,
 }));
 
 vi.mock("../lib/theme", () => ({

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -1915,6 +1915,31 @@ describe("#904 — one-deep send queue", () => {
     expect(compose.getDraft(k)).toBe("b\nc");
   });
 
+  // #904 — the pump took the text OUT of the composer, so it owes it back on
+  // every exit, including the one nobody plans for. `dispatchDraft` catches
+  // around its dispatch switch, but the parse ahead of it is outside that net:
+  // a throw there used to leave the draft untouched and now would evaporate it,
+  // which is the exact destruction this issue is about. It must come back, and
+  // the throw must still surface — swallowing it would hide the next bug.
+  it("#904 — a throw out of dispatch hands the text back instead of eating it", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    vi.doMock("../lib/slashCommands", () => ({
+      parseSlash: () => {
+        throw new Error("parser exploded");
+      },
+    }));
+    try {
+      const compose = await import("../lib/compose");
+      compose.setDraft(k, "precious text");
+      await expect(compose.submit(k, "freenode", "#a")).rejects.toThrow("parser exploded");
+      expect(compose.getDraft(k)).toBe("precious text");
+      expect(compose.isSending(k)).toBe(false);
+    } finally {
+      vi.doUnmock("../lib/slashCommands");
+      vi.resetModules();
+    }
+  });
+
   it("#904 — a queued line is recallable from history the moment it leaves the composer", async () => {
     localStorage.setItem("grappa-token", "tok");
     const acks = await deferredSend();

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -1716,6 +1716,227 @@ describe("compose submit — slash command dispatch", () => {
   });
 });
 
+// #904 — the composer buffer and the send machinery used to share one slot for
+// a SINGLE send too: the draft stayed put for the whole in-flight window and
+// the end-of-submit clear wiped whatever the operator had typed meanwhile.
+// #737 only closed the multi-line drain half of that class. The fix is a send
+// queue exactly ONE message deep, owned by the store and keyed on the WINDOW:
+// the submission leaves the composer at DISPATCH, the operator types the next
+// one, a second Enter queues it, and the third is refused where they can see
+// it. Nothing is ever silently eaten.
+describe("#904 — one-deep send queue", () => {
+  const k = channelKey("freenode", "#a");
+
+  // A send whose ack the test controls: the resolver is handed back so the
+  // in-flight window is a real, observable state rather than a timing guess.
+  const deferredSend = async () => {
+    const sb = await import("../lib/scrollback");
+    const acks: Array<{ body: string; resolve: () => void; reject: (e: unknown) => void }> = [];
+    vi.mocked(sb.sendMessage).mockImplementation(
+      (_slug: string, _target: string, body: string) =>
+        new Promise<void>((resolve, reject) => {
+          acks.push({ body, resolve, reject });
+        }),
+    );
+    return acks;
+  };
+
+  it("#904 — the message leaves the composer at dispatch, not at the ack", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const acks = await deferredSend();
+    const compose = await import("../lib/compose");
+
+    compose.setDraft(k, "first");
+    const done = compose.submit(k, "freenode", "#a");
+    await Promise.resolve();
+
+    // In flight: the composer is EMPTY and belongs to the operator again.
+    expect(compose.isSending(k)).toBe(true);
+    expect(compose.getDraft(k)).toBe("");
+    expect(compose.isQueueFull(k)).toBe(false);
+
+    acks[0]?.resolve();
+    expect(await done).toEqual({ ok: true });
+    expect(compose.isSending(k)).toBe(false);
+  });
+
+  it("#904 — what the operator types during a slow send survives the ack", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const acks = await deferredSend();
+    const compose = await import("../lib/compose");
+
+    compose.setDraft(k, "first");
+    const done = compose.submit(k, "freenode", "#a");
+    await Promise.resolve();
+
+    // The defect: this used to be destroyed by the end-of-submit clear.
+    compose.setDraft(k, "ok also bring the charger");
+    acks[0]?.resolve();
+    await done;
+
+    expect(compose.getDraft(k)).toBe("ok also bring the charger");
+  });
+
+  it("#904 — a second Enter queues the next message and it goes out on the ack", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const acks = await deferredSend();
+    const sb = await import("../lib/scrollback");
+    const compose = await import("../lib/compose");
+
+    compose.setDraft(k, "first");
+    const done = compose.submit(k, "freenode", "#a");
+    await Promise.resolve();
+
+    compose.setDraft(k, "second");
+    expect(await compose.submit(k, "freenode", "#a")).toEqual({ ok: true });
+    // Queued, so it left the composer too — and nothing went out yet.
+    expect(compose.getDraft(k)).toBe("");
+    expect(compose.isQueueFull(k)).toBe(true);
+    expect(vi.mocked(sb.sendMessage).mock.calls.length).toBe(1);
+
+    acks[0]?.resolve();
+    // The queued line is dispatched by the pump on the ack — wait for the
+    // send it makes, don't guess a microtask count.
+    await vi.waitFor(() => expect(acks.length).toBe(2));
+    acks[1]?.resolve();
+    await done;
+
+    expect(vi.mocked(sb.sendMessage).mock.calls.map((c) => c[2])).toEqual(["first", "second"]);
+    expect(compose.isSending(k)).toBe(false);
+    expect(compose.isQueueFull(k)).toBe(false);
+  });
+
+  it("#904 — a THIRD submission is refused visibly, not eaten", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const acks = await deferredSend();
+    const sb = await import("../lib/scrollback");
+    const compose = await import("../lib/compose");
+
+    compose.setDraft(k, "first");
+    const done = compose.submit(k, "freenode", "#a");
+    await Promise.resolve();
+    compose.setDraft(k, "second");
+    await compose.submit(k, "freenode", "#a");
+
+    compose.setDraft(k, "third");
+    const refused = await compose.submit(k, "freenode", "#a");
+
+    expect(refused).toHaveProperty("error");
+    // Refused means REFUSED: the text stays in the composer, unsent.
+    expect(compose.getDraft(k)).toBe("third");
+    expect(vi.mocked(sb.sendMessage).mock.calls.length).toBe(1);
+
+    acks[0]?.resolve();
+    await vi.waitFor(() => expect(acks.length).toBe(2));
+    acks[1]?.resolve();
+    await done;
+    expect(vi.mocked(sb.sendMessage).mock.calls.map((c) => c[2])).toEqual(["first", "second"]);
+  });
+
+  it("#904 — a failed send hands the line back IN FRONT of what was typed meanwhile", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const acks = await deferredSend();
+    const api = await import("../lib/api");
+    const compose = await import("../lib/compose");
+
+    compose.setDraft(k, "first");
+    const done = compose.submit(k, "freenode", "#a");
+    await Promise.resolve();
+    compose.setDraft(k, "typed later");
+
+    acks[0]?.reject(new api.ApiError(400, "invalid_line"));
+    expect(await done).toHaveProperty("error");
+
+    // Both survive, in the order they were written.
+    expect(compose.getDraft(k)).toBe("first\ntyped later");
+  });
+
+  it("#904 — a failed send hands the QUEUED line back too and never fires it", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const acks = await deferredSend();
+    const sb = await import("../lib/scrollback");
+    const api = await import("../lib/api");
+    const compose = await import("../lib/compose");
+
+    compose.setDraft(k, "first");
+    const done = compose.submit(k, "freenode", "#a");
+    await Promise.resolve();
+    compose.setDraft(k, "second");
+    await compose.submit(k, "freenode", "#a");
+
+    acks[0]?.reject(new api.ApiError(400, "invalid_line"));
+    expect(await done).toHaveProperty("error");
+
+    // A dead link fires nothing further; both lines come back, in order.
+    expect(vi.mocked(sb.sendMessage).mock.calls.length).toBe(1);
+    expect(compose.getDraft(k)).toBe("first\nsecond");
+    expect(compose.isQueueFull(k)).toBe(false);
+    expect(compose.isSending(k)).toBe(false);
+  });
+
+  it("#904 — the queue is per WINDOW: a sibling composer is untouched", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const acks = await deferredSend();
+    const compose = await import("../lib/compose");
+    const other = channelKey("freenode", "#b");
+
+    compose.setDraft(k, "first");
+    const done = compose.submit(k, "freenode", "#a");
+    await Promise.resolve();
+
+    expect(compose.isSending(other)).toBe(false);
+    compose.setDraft(other, "elsewhere");
+    expect(compose.getDraft(other)).toBe("elsewhere");
+
+    acks[0]?.resolve();
+    await done;
+    expect(compose.getDraft(other)).toBe("elsewhere");
+  });
+
+  // #904 × #666/#737 — the multi-line drain is the ONE submission that keeps
+  // the buffer: it claims the window (readOnly) and mirrors its own, finer-
+  // grained residue there. The pump must not hand the whole paste back on top
+  // of that remainder.
+  it("#904 — a failed multi-line drain leaves ONLY its residue, not the whole paste", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    const api = await import("../lib/api");
+    const compose = await import("../lib/compose");
+
+    let n = 0;
+    vi.mocked(sb.sendMessage).mockImplementation(async () => {
+      n += 1;
+      if (n === 2) throw new api.ApiError(400, "invalid_line");
+      return undefined as never;
+    });
+
+    compose.setDraft(k, "a\nb\nc");
+    expect(await compose.submit(k, "freenode", "#a")).toHaveProperty("error");
+    expect(compose.getDraft(k)).toBe("b\nc");
+  });
+
+  it("#904 — a queued line is recallable from history the moment it leaves the composer", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const acks = await deferredSend();
+    const compose = await import("../lib/compose");
+
+    compose.setDraft(k, "first");
+    const done = compose.submit(k, "freenode", "#a");
+    await Promise.resolve();
+
+    // The composer is empty (the line left at dispatch) — so a recall that
+    // returns the line proves history holds it BEFORE any ack. Pre-fix the
+    // push happened on the 201 and this walked into an empty history.
+    expect(compose.getDraft(k)).toBe("");
+    compose.recallPrev(k);
+    expect(compose.getDraft(k)).toBe("first");
+
+    compose.setDraft(k, "");
+    acks[0]?.resolve();
+    await done;
+  });
+});
+
 describe("compose tabComplete (members-only, irssi-exact)", () => {
   const k = channelKey("freenode", "#a");
 

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -113,6 +113,19 @@ type ComposeState = {
 // error: string = failure, displayed inline; draft preserved.
 type SubmitResult = { ok: true | string } | { error: string };
 
+// #904 — `submit` (the pump) OWNS the composer buffer: it takes the text out
+// at dispatch and hands it back if the submission fails, so every failure
+// path preserves the draft without each of the ~40 arms knowing about it.
+// The multi-line #666 drain is the ONE exception — it claims the buffer
+// (#737) and mirrors its own, finer-grained residue into it, so it says
+// `keptBuffer` and the pump keeps its hands off instead of dropping the whole
+// paste back on top of the remainder.
+type DispatchOutcome = SubmitResult | { error: string; keptBuffer: true };
+
+// #904 — one window's send queue: an entry exists while a submission from it
+// is in flight, and `queued` holds the at-most-one message sent behind it.
+type Outbox = { queued: string | null };
+
 const empty = (): ComposeState => ({
   draft: "",
   history: [],
@@ -313,6 +326,71 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     });
   };
 
+  // #904 — the send queue, exactly ONE message deep, per WINDOW. An entry
+  // exists for as long as a submission from that window is in flight; its
+  // `queued` slot holds the at-most-one message the operator sent behind it.
+  //
+  // One deep, not unbounded: a backlog over a dead link fires stale lines into
+  // the channel minutes later. One line cannot go that stale, and if the link
+  // is down there is exactly one line to hand back. Full → the composer is
+  // refused VISIBLY (ComposeBox turns the textarea readOnly), which is the
+  // whole point — the defect this replaces ate the third message in silence.
+  //
+  // Keyed on the window, like the #737 drain lock and for the same reason: a
+  // ComposeBox-local `sending()` dies on unmount (home / mentions / $list, the
+  // desktop↔mobile swap) and follows the operator to the wrong composer.
+  const [outboxByKey, setOutboxByKey] = createSignal<Record<ChannelKey, Outbox>>({});
+
+  // Same lifetime hazard as the drain lock: a send that never settles never
+  // runs its release, and a stale entry would leave the composer refusing
+  // writes across a logout/login.
+  onIdentityChange(() => setOutboxByKey({}));
+
+  const isSending = (key: ChannelKey): boolean => outboxByKey()[key] !== undefined;
+
+  const isQueueFull = (key: ChannelKey): boolean => outboxByKey()[key]?.queued != null;
+
+  const setOutbox = (key: ChannelKey, box: Outbox | null): void => {
+    setOutboxByKey((prev) => {
+      const next = { ...prev };
+      if (box === null) delete next[key];
+      else next[key] = box;
+      return next;
+    });
+  };
+
+  // Take the queued message out of the slot, freeing it for the next Enter.
+  const takeQueued = (key: ChannelKey): string | null => {
+    const queued = outboxByKey()[key]?.queued ?? null;
+    if (queued !== null) setOutbox(key, { queued: null });
+    return queued;
+  };
+
+  // #904 — the submission LEAVES the composer here: history first (so a line
+  // that is queued, or dies on a dead link, is recallable the moment it is
+  // out of the box — pre-fix an eaten message never reached history at all),
+  // then the buffer is emptied for the next message.
+  const takeDraft = (key: ChannelKey): string => {
+    const text = getState(key).draft;
+    if (text.trim() !== "") pushHistory(key, text);
+    writeState(key, (s) => ({ ...s, draft: "", historyCursor: null }));
+    tabCycle = null;
+    return text;
+  };
+
+  // …and comes back here when it could not be sent. IN FRONT of whatever the
+  // composer holds now: the operator typed that AFTER the failed line, so it
+  // belongs after it. Never a clobber — that is the destruction #904 is about.
+  const handBack = (key: ChannelKey, owed: string[]): void => {
+    const text = owed.filter((t) => t !== "").join("\n");
+    if (text === "") return;
+    writeState(key, (s) => ({
+      ...s,
+      draft: s.draft === "" ? text : `${text}\n${s.draft}`,
+      historyCursor: null,
+    }));
+  };
+
   const setDraft = (key: ChannelKey, value: string): void => {
     if (isDraining(key)) return;
     // Any explicit edit (typing, paste, clear) breaks the tab-cycle
@@ -404,10 +482,12 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   //     so an unconditional write silently ate it. When it is non-empty the
   //     redirect is refused and `source` keeps the remainder (re-addressed by
   //     its own prefix, so it still resends to the intended peer).
-  //   * Whoever does NOT own the residue is emptied. Redirecting used to leave
-  //     the WHOLE `/msg bob …` command in `source` — the error arm returns
-  //     before the shared clear — so the remainder existed twice and hitting
-  //     Enter back in the source window re-delivered every line.
+  //   * Whoever does NOT own the residue is emptied — so the remainder never
+  //     exists twice and Enter back in the source window cannot re-deliver
+  //     every line. #904 moved that emptying UPSTREAM: the pump takes the
+  //     source draft out at dispatch, before this runs at all. Re-clearing it
+  //     here would be a clobber now, not a tidy-up — `/msg` awaits its query
+  //     topic join first, and the operator can type into `source` during it.
   //
   // Resolved ONCE, before the first line: per-tick resolution would flip after
   // the first residue write makes `preferred` non-empty, hopping windows
@@ -420,29 +500,39 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     target: string,
     body: string,
     action: boolean,
-  ): Promise<SubmitResult> => {
+  ): Promise<DispatchOutcome> => {
     const home =
       preferred.key === source.key || getDraft(preferred.key) === "" ? preferred : source;
-    if (home.key !== source.key) {
-      writeState(source.key, (s) => ({ ...s, draft: "", historyCursor: null }));
-    }
     let sentCount = 0;
     let totalCount = 0;
-    // #737 — the drain owns this draft until it stops, however long the
-    // pacing takes. Released in `finally` so a fatal mid-fan-out unlocks the
-    // window too: a lock that outlives its drain leaves the composer dead
-    // until reload, which is worse than the overwrite it prevents.
+    // #904 — the two buffer regimes of a free-text send, told apart by the ONE
+    // property that decides who needs the composer:
+    //
+    //   * MULTI-LINE — a #666 paced drain. It owns the buffer for as long as
+    //     the pacing lasts (a 429 ladder can hold it a minute), mirroring the
+    //     shrinking remainder into it, so it CLAIMS the window (#737) and the
+    //     operator is refused rather than overwritten.
+    //   * SINGLE LINE — the #904 domain. There is no partial state to mirror:
+    //     it either acked (residue "") or none of it went out. So the buffer
+    //     goes straight back to the operator, who is typing the next message
+    //     into it while this one flies; a residue write here would clobber
+    //     exactly the text this issue exists to stop losing.
+    const multi = splitMessageLines(body).length > 1;
     // #737 × #723 — lock BOTH ends of the drain: the residue home, whose draft
     // the pacing callback rewrites on every acked line, and the window the
     // operator submitted from, so a second Enter there cannot start a rival
     // drain that fans the same remainder out twice. They collapse to one key
-    // whenever the residue stays in the window it was typed in.
-    const locked = [...new Set([source.key, home.key])];
+    // whenever the residue stays in the window it was typed in. Released in
+    // `finally` so a fatal mid-fan-out unlocks the window too: a lock that
+    // outlives its drain leaves the composer dead until reload, which is worse
+    // than the overwrite it prevents.
+    const locked = multi ? [...new Set([source.key, home.key])] : [];
     claimDrafts(locked);
     try {
       await sendBodyLines(slug, target, body, action, (sent, total, residue) => {
         sentCount = sent;
         totalCount = total;
+        if (!multi) return;
         // Residue-only draft, reset to the live bottom (historyCursor null):
         // we're typing the remainder, not walking history. A drained send
         // leaves "" — never a bare prefix the operator would have to erase.
@@ -463,39 +553,38 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       // whether or not the body was multi-line.
       const reason = friendlyError(e);
       const sentOf = totalCount > 1 ? ` — sent ${sentCount} of ${totalCount} lines` : "";
-      if (home.key !== preferred.key) {
+      // #904 — a single line has no residue to relocate: the pump hands the
+      // ORIGINAL text back to the window it was typed in, which needs no
+      // re-addressing because it still carries its own `/me ` / `/msg <peer> `.
+      // So the "your eyes are elsewhere" test is the FOCUS switch (`/msg`
+      // moved them to the query window), not which window won the residue.
+      const relocated = multi ? home.key !== preferred.key : preferred.key !== source.key;
+      if (relocated) {
         // "The rest" presumes something went out; on a single-line body
         // nothing did, so name the whole message instead.
         const what = totalCount > 1 ? "the rest are" : "your message is";
-        return { error: `${reason}${sentOf}; ${what} in the window you sent from` };
+        const error = `${reason}${sentOf}; ${what} in the window you sent from`;
+        return multi ? { error, keptBuffer: true } : { error };
       }
-      return totalCount > 1
-        ? { error: `${reason}${sentOf}; the rest are in the box` }
-        : { error: reason };
+      if (!multi) return { error: reason };
+      return { error: `${reason}${sentOf}; the rest are in the box`, keptBuffer: true };
     } finally {
       releaseDrafts(locked);
     }
   };
 
-  const submit = async (
+  // #904 — dispatch ONE submission. It never reads or writes the composer
+  // buffer: the pump (`submit`, below) hands it the text and owns the
+  // put-back, which is what lets every failure arm here just `return {error}`.
+  const dispatchDraft = async (
     key: ChannelKey,
     networkSlug: string,
     channelName: string,
-  ): Promise<SubmitResult> => {
-    // #737 — a drain already owns this window's draft, and that draft holds
-    // the residue it has NOT sent yet. Re-submitting would fan the same
-    // remainder out a second time (the #666 duplicate this whole mechanism
-    // exists to prevent) and hand two drains one lock, so the first to finish
-    // would unlock a window the other is still rewriting. The guard lives
-    // here, not in ComposeBox: that component's `sending()` dies with it, and
-    // it unmounts whenever the operator visits home / mentions / $list or the
-    // desktop↔mobile layouts swap — after which Enter (keydown still fires on
-    // a readOnly textarea) started a fresh drain.
-    if (isDraining(key)) return { error: "still sending the previous paste" };
-    const state = getState(key);
+    text: string,
+  ): Promise<DispatchOutcome> => {
     // #385 — expand user-defined aliases (from the aliasList store) before
     // dispatch; the parser stays pure and takes the map as an argument.
-    const cmd = parseSlash(state.draft, aliases());
+    const cmd = parseSlash(text, aliases());
     // Empty short-circuits before the token check — an empty submit is
     // a no-op regardless of session state, and the consumer (ComposeBox)
     // wants the same outcome whether or not a token is in play.
@@ -1516,8 +1605,8 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         }
       }
     } catch (e) {
-      // REST/PubSub failure surfaces here. Preserve the draft (no
-      // history push, no draft clear) so the user can retry without
+      // REST/PubSub failure surfaces here. The pump hands the text back to
+      // the composer on this {error}, so the user can retry without
       // re-typing; the {error} arm fires the ComposeBox alert banner.
       //
       // U-3 (UD3): typed ApiErrors get the shared `friendlyApiError`
@@ -1535,11 +1624,6 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       return { error: friendlyError(e) };
     }
 
-    // Success: push the original draft (NOT the parsed cmd) onto history,
-    // clear the draft, reset cursor.
-    if (state.draft.trim() !== "") pushHistory(key, state.draft);
-    writeState(key, (s) => ({ ...s, draft: "", historyCursor: null }));
-    tabCycle = null;
     // #356: a string `result.ok` (the /notify + /hilight confirmation /
     // list output) IS now surfaced — ComposeBox routes it through the
     // severity-tagged feedback signal as a green, auto-dismissing
@@ -1548,6 +1632,74 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     // removed the numericInline row that used to render it and never
     // rewired a consumer — the gap #356 closed.)
     return result;
+  };
+
+  // #904 — the pump. Submitting is now two distinct jobs, and this owns the
+  // one `dispatchDraft` must not: the composer buffer.
+  //
+  //   * IDLE — take the text out (it leaves the composer AT DISPATCH, not on
+  //     the 201: that clear-at-ack is what wiped the operator's next message),
+  //     dispatch it, then keep dispatching whatever the operator queued behind
+  //     it until the slot is empty.
+  //   * IN FLIGHT — this Enter is the operator's SECOND message. Park it in
+  //     the one-deep slot; the in-flight pump picks it up on the ack. Enter
+  //     means something again during a slow send, which is half the defect.
+  //   * QUEUE FULL — refuse, and leave the text in the composer where the
+  //     operator can see it (ComposeBox turns the textarea readOnly at the
+  //     same moment, so this is the belt to that pair of braces: Enter still
+  //     fires on a readOnly textarea, and on a remounted ComposeBox).
+  //
+  // The whole chain settles on the FIRST Enter's promise, so a queued line
+  // that dies still surfaces its error to a caller that is watching.
+  const submit = async (
+    key: ChannelKey,
+    networkSlug: string,
+    channelName: string,
+  ): Promise<SubmitResult> => {
+    // #737 — a drain already owns this window's draft, and that draft holds
+    // the residue it has NOT sent yet. Re-submitting would fan the same
+    // remainder out a second time (the #666 duplicate this whole mechanism
+    // exists to prevent) and hand two drains one lock, so the first to finish
+    // would unlock a window the other is still rewriting. The guard lives
+    // here, not in ComposeBox: that component's `sending()` dies with it, and
+    // it unmounts whenever the operator visits home / mentions / $list or the
+    // desktop↔mobile layouts swap — after which Enter (keydown still fires on
+    // a readOnly textarea) started a fresh drain.
+    if (isDraining(key)) return { error: "still sending the previous paste" };
+
+    if (isSending(key)) {
+      if (isQueueFull(key)) {
+        return { error: "one message is already waiting — hold on until it goes out" };
+      }
+      // A blank Enter is the same no-op it is anywhere else; it must not
+      // burn the slot and lock the composer for nothing.
+      if (getDraft(key).trim() === "") return { error: "empty" };
+      setOutbox(key, { queued: takeDraft(key) });
+      return { ok: true };
+    }
+
+    setOutbox(key, { queued: null });
+    try {
+      let text = takeDraft(key);
+      for (;;) {
+        const outcome = await dispatchDraft(key, networkSlug, channelName, text);
+        if ("error" in outcome) {
+          // A dead link fires nothing further: the queued line is handed back
+          // unsent rather than delivered minutes late, and it comes back
+          // AFTER the line that failed — the order they were typed in.
+          const owed = "keptBuffer" in outcome ? [] : [text];
+          const queued = takeQueued(key);
+          if (queued !== null) owed.push(queued);
+          handBack(key, owed);
+          return outcome;
+        }
+        const queued = takeQueued(key);
+        if (queued === null) return outcome;
+        text = queued;
+      }
+    } finally {
+      setOutbox(key, null);
+    }
   };
 
   // #30 — the channel candidate set: every channel JOINED on the same
@@ -1685,6 +1837,8 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     submit,
     tabComplete,
     isDraining,
+    isSending,
+    isQueueFull,
   };
 });
 
@@ -1696,3 +1850,5 @@ export const recallNext = exports_.recallNext;
 export const submit = exports_.submit;
 export const tabComplete = exports_.tabComplete;
 export const isDraining = exports_.isDraining;
+export const isSending = exports_.isSending;
+export const isQueueFull = exports_.isQueueFull;

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -1679,25 +1679,33 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     }
 
     setOutbox(key, { queued: null });
+    // Whatever the pump is holding when it leaves. A dead link fires nothing
+    // further: the queued line is handed back unsent rather than delivered
+    // minutes late, and it comes back AFTER the line that failed — the order
+    // they were typed in.
+    let inHand: string | null = null;
     try {
       let text = takeDraft(key);
       for (;;) {
+        inHand = text;
         const outcome = await dispatchDraft(key, networkSlug, channelName, text);
-        if ("error" in outcome) {
-          // A dead link fires nothing further: the queued line is handed back
-          // unsent rather than delivered minutes late, and it comes back
-          // AFTER the line that failed — the order they were typed in.
-          const owed = "keptBuffer" in outcome ? [] : [text];
-          const queued = takeQueued(key);
-          if (queued !== null) owed.push(queued);
-          handBack(key, owed);
-          return outcome;
-        }
+        // A drain that kept the buffer already put its own residue there.
+        inHand = "error" in outcome && !("keptBuffer" in outcome) ? text : null;
+        if ("error" in outcome) return outcome;
         const queued = takeQueued(key);
         if (queued === null) return outcome;
         text = queued;
       }
     } finally {
+      // …including the exit nobody plans for. `dispatchDraft` catches around
+      // its dispatch switch, but the parse ahead of it is outside that net,
+      // and the pump owes the composer its text back on EVERY path — a throw
+      // that evaporated it would be this issue's own defect, wearing a stack
+      // trace. The throw still propagates; only the text is rescued.
+      const owed = inHand === null ? [] : [inHand];
+      const queued = takeQueued(key);
+      if (queued !== null) owed.push(queued);
+      handBack(key, owed);
       setOutbox(key, null);
     }
   };

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -30396,3 +30396,71 @@ reason is that it defends an impossible state. `windowStateByChannel` mirrors
 `Session.Server`'s `window_states`, which is channel-keyed by construction; a
 DM lives in `queryWindows`. The measurement is recorded in the code comment so
 the next reader does not re-add it.
+
+## 2026-08-06 — #904: the composer buffer gets one owner, and a queue exactly one deep
+
+peluche, on a phone over a bad link: send a line, type the follow-up while the
+first is still going out, press Enter — nothing happens, and when the first
+ack lands the composer empties and the follow-up is gone. vjt: "happens
+absolutely always."
+
+**#737 fixed this class and only half its instances.** That guard is keyed on
+`isDraining`, which ONLY the #666 paced multi-line drain raises. A single slow
+send never raised it, so the textarea stayed writable, `setDraft` accepted the
+typing, Enter early-returned on ComposeBox's own `sending()`, and the shared
+end-of-submit clear then wiped a message that was typed, un-sendable, and
+never even reached history. The lesson generalises: a guard keyed on ONE
+mechanism's flag protects that mechanism, not the invariant behind it. The
+invariant is *the composer buffer has exactly one owner at a time*.
+
+**While a send is in flight that owner is the OPERATOR.** So the message must
+leave the composer at DISPATCH, not on the 201 — which is also what makes the
+end-of-submit clear disappear rather than get a condition bolted onto it.
+`submit` becomes a pump around a `dispatchDraft` that never touches the
+buffer: the pump takes the text out, dispatches it, and hands it back on any
+failure. That is why ~40 dispatch arms can keep returning a bare `{error}` and
+still preserve the draft; each one no longer has to remember to.
+
+**One deep, and the third is refused where you can see it.** The general send
+queue was rejected in the same conversation: a backlog over a dead link fires
+stale lines into the channel minutes later. One line cannot go that stale, and
+if the link is down there is exactly one line to hand back. Full → the
+textarea goes readOnly (the #737 refusal shape; never `disabled`, which blurs
+and collapses the on-screen keyboard, #59). A visible refusal is the point —
+the defect being replaced was a silent eat.
+
+**Hand-back is a prepend, never a clobber.** The failed line comes back in
+FRONT of whatever is in the box, because the operator typed that afterwards;
+a queued line that never flew comes back after it. Order beats delivery: a
+failed first send does NOT fire the queued second. And the pump hands back
+from a `finally`, so even a throw out of the parse (which sits outside
+`dispatchDraft`'s catch) returns the text instead of evaporating it — that
+exit would otherwise be this issue's own defect wearing a stack trace.
+
+**The multi-line drain keeps its buffer, and says so.** It claims the window
+(#737) and mirrors its own finer-grained residue (#666/#723), so it returns
+`keptBuffer` and the pump does not drop the whole paste on top of the
+remainder. A single line has no partial state to mirror — it either acked or
+none of it went out — so it writes nothing and lets the operator keep typing.
+That split retired two writes that were clobbers the moment the operator
+regained the buffer: the source-emptying write (`/msg` awaits its query-topic
+join first, so there IS a window to type in) and the successful single-line
+send's residue write of `""`. It also simplified the #723 re-addressing for
+single lines away: the ORIGINAL text still carries its own `/me ` / `/msg
+<peer> `, so handing the raw submission back needs no prefix reconstruction —
+only the copy branch changed, from "which window won the residue" to "did the
+focus move away from where the text lands".
+
+**Deliberately NOT built: pending rows and a correlation token.** The issue
+notes a token is only needed if pending rows interleave into confirmed order.
+No pending rows were built at all — cic never originates state, and the
+server echo stays the sole render path (the #254 / #251 rule). The cost is
+real and accepted: between dispatch and echo the queued line is visible
+nowhere except history (ArrowUp), with the send-button spinner as the only
+in-flight affordance.
+
+**In-flight state moved into the store, keyed on the window.** Same reason as
+the drain lock: a ComposeBox-local flag dies on unmount (home / mentions /
+$list, the desktop↔mobile swap) and follows the operator to the wrong
+composer. The #241 send spinner is keyed on it too now, so it stops lying
+after a window switch.


### PR DESCRIPTION
Fixes the half of #737's class it never covered: a **single** slow send.

## The defect

`#737`'s guard is keyed on `isDraining`, raised ONLY by the #666 paced
multi-line drain. A lone message on a bad link never raised it, so the
composer and the send machinery shared one buffer: the textarea stayed
writable, Enter was a no-op (ComposeBox's own `sending()` early-returned),
and the end-of-submit clear then wiped the follow-up. Typed, un-sendable,
silently destroyed — and it never even reached history.

## The shape

The composer buffer has exactly one owner at a time, and while a send is in
flight that owner is the OPERATOR.

* `submit` becomes a **pump** around a `dispatchDraft` that never touches the
  buffer. The pump takes the text out **at dispatch** (not on the 201) and
  hands it back on any failure — which is why ~40 dispatch arms can keep
  returning a bare `{error}` and still preserve the draft.
* A second Enter parks its line in a slot **exactly one deep**; the pump
  sends it on the ack. Enter means something again during a slow send.
* A third is **refused visibly**: the textarea goes `readOnly` (never
  `disabled` — that blurs and collapses the on-screen keyboard, #59).
* Hand-back is a **prepend, never a clobber**, and a failed first send does
  NOT fire the queued second — order beats delivery. The pump hands back from
  a `finally`, so even a throw out of the parse returns the text.
* The multi-line drain keeps the buffer it claimed (#737) and its own residue
  mirroring (#666/#723); it returns `keptBuffer` so the pump does not drop the
  whole paste on top of the remainder.
* In-flight state lives in the **store, keyed on the window** — a
  component-local flag dies on unmount and follows the operator to the wrong
  composer. The #241 spinner is keyed on it now too.

## Deliberately not built

No pending rows, no correlation token. cic never originates state and the
server echo stays the sole render path (#254/#251). Stated cost: between
dispatch and echo the queued line is visible only in history (ArrowUp), with
the send-button spinner as the in-flight affordance.

## Test plan

- [x] `scripts/bun.sh run test` — 4388 passing (10 new store tests, 3 new
      ComposeBox tests)
- [x] mutation-tested, 6 mutations, 6 killed: never-queue (2 red),
      clear-at-ack (5 red), clobbering hand-back (1 red), fire-queued-after-
      failure (1 red), reinstated component-local gate (1 red), readOnly
      without queue-full (1 red)
- [x] biome + `tsc --noEmit` clean
- [ ] `e2e/tests/issue904-one-deep-send-queue.spec.ts` — holds the first send
      POST open via `page.route` and pins all four properties end to end.
      **Not yet run: needs the STACK lane.**