### PR TITLE
irc(#908): TRACE's reply TYPE is not a routing destination

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -30464,3 +30464,48 @@ the drain lock: a ComposeBox-local flag dies on unmount (home / mentions /
 $list, the desktop↔mobile swap) and follows the operator to the wrong
 composer. The #241 send spinner is keyed on it too now, so it stops lying
 after a window switch.
+
+## 2026-08-06 — #908: TRACE is a report family, and the deny list is a patch on the wrong question
+
+`/trace nightwish.azzurra.chat` against Azzurra opened three query windows
+named `Operator`, `Server` and `Class`. `NumericRouter.scan_params/2` walks a
+numeric's middle params and takes the first nick-shaped, dotless, non-own
+token as a destination; every TRACE reply puts its **reply TYPE** in
+`params[1]` (`Link`, `Attempt`, `Operator`, `Server`, `Class`, `File`, …), so
+the scan routed the reply KIND. 200–210 + 261–262 join `@active_numerics`.
+
+**262 is covered even though it already worked.** Its `params[1]` is the
+traced server's name and `query_candidate?/2` excludes tokens containing a
+`.` — so the correct outcome rested on that server happening to be spelled
+with a dot. A family-wide rule cannot depend on a naming accident; the
+dotless spelling is pinned by test. 207/210 are `NULL` in bahamut and fix
+nothing today, but every reading of those slots (RPL_TRACESERVICE,
+RPL_TRACERECONNECT, ircu's RPL_STATSHELP) is server-directed, so the
+contiguous range costs nothing and leaves no hole for a network that emits
+them.
+
+**The moduledoc was lying about the failure mode, and that was the real
+finding.** It claimed the scan is a safe default — "at worst a row lands on
+`$server` instead of a more specific window". True of the channel branch;
+false of the query branch, whose failure mode is a row landing in the wrong
+CONVERSATION, and — before #640's `resolve_numeric_query_window/2` — MINTING
+a ghost window that then leaked into Archive via `list_archive`'s
+`COALESCE(dm_with, channel)`. #640 is a backstop, not a correct decision: a
+`/trace` issued while a query window named `Operator` is open still misroutes
+today.
+
+**Why a third patch instead of the root-cause fix.** The scan asks a
+syntactic question ("could this token be a nick?") of a semantic slot.
+Whether `params[1]` is a destination is a per-numeric FACT with no syntactic
+discriminant — a target for the error class, a channel for the channel class,
+DATA for every report class. So the table can only be keyed by the CODE,
+which both lists already are: a deny list and an allow list differ ONLY in
+which side the unknown falls on, and today the unknown falls on the guessing
+side. Three families have now been patched in (#184 STATS, UX-4 bucket I
+connect-storm, #908 TRACE) and the deny list stands at 43 codes against the
+two or three the query branch genuinely serves (401, plus the legacy 2-param
+shape). That ratio is the argument for inverting the default. Not done here:
+it changes behaviour for every numeric in neither list, and #221's WHOIS-leg
+guard is defined as "a `:scan`-class numeric" and would have to be re-sited
+first. Deny-list entries stay the right size of cut for one reported family;
+they are not a substitute for the inversion.

--- a/lib/grappa/session/numeric_router.ex
+++ b/lib/grappa/session/numeric_router.ex
@@ -23,13 +23,15 @@ defmodule Grappa.Session.NumericRouter do
      the recorded `origin_window` wins over the param scan and active-deny —
      perfect-correlation path (but NOT over delegation, per #276 above).
 
-  3. **Active deny list** (`@active_numerics`): a small set of numerics
-     whose params look nick-shaped but the "nick" is not a routing
-     destination — it's the rejected nick (433/432), the unknown command
-     name (421), the offending command's argument list (461), or an
-     ack (437). These ALWAYS go to `{:server, nil}`. Without this
-     deny list, the param-scan below would happily route 433's
-     "BLEH-as-nick" to a query window.
+  3. **Active deny list** (`@active_numerics`): numerics whose params look
+     nick-shaped but the "nick" is not a routing destination — it's the
+     rejected nick (433/432), the unknown command name (421), the
+     offending command's argument list (461), an ack (437), or a whole
+     server-directed REPORT family whose middles are data and type labels
+     (`@stats_numerics` #184, `@trace_numerics` #908, the connect-storm
+     tokens). These ALWAYS go to `{:server, nil}`. Without this deny
+     list, the param-scan below would happily route 433's "BLEH-as-nick"
+     to a query window.
 
   4. **Param scan** (the general case): walk `params`, skipping
      `params[0]` (own-nick echo) and the last element (trailing
@@ -45,8 +47,33 @@ defmodule Grappa.Session.NumericRouter do
   * The deny list is closed-set on purpose — adding a numeric to it is a
     deliberate "this looks routable but isn't" call. Unknown numerics fall
     through the param scan; if they have a channel-shaped param they go
-    there, otherwise `$server`. This is the safe default — at worst a row
-    lands on `$server` instead of a more specific window. No silent loss.
+    there, otherwise `$server`. Nothing is ever lost: every decision ends
+    at a real window.
+
+  * **The default is inverted, and this module knows it (#908).** An
+    earlier revision of this note claimed the scan's failure mode was
+    benign — "at worst a row lands on `$server` instead of a more specific
+    window". That is true of the channel branch and FALSE of the query
+    branch, whose failure mode is a row landing in the wrong CONVERSATION
+    (and, before #640's `resolve_numeric_query_window/2`, MINTING a ghost
+    window for it). The scan asks a syntactic question — "could this token
+    be a nick?" — of a semantic slot; whether `params[1]` is a destination
+    is a per-numeric FACT with no syntactic discriminant (a target for the
+    error class, a channel for the channel class, DATA for every report
+    class). So the routing table can only be keyed by the CODE, which is
+    what both lists already do — the deny list and an allow list differ
+    only in which side the UNKNOWN falls on, and we currently put it on
+    the guessing side. Three families have now been patched in
+    (#184 STATS, UX-4 bucket I connect-storm, #908 TRACE) and the deny
+    list stands at 43 codes against the two or three the scan's query
+    branch genuinely serves (401 and the legacy 2-param shape) — that
+    ratio IS the argument. The root-cause fix is to invert: enumerate the
+    target-bearing numerics and default the rest to `$server`. It is not
+    done here because it changes behaviour for every numeric in neither
+    list, and because #221's WHOIS-leg guard is defined as "a `:scan`-class
+    numeric" and would have to be re-sited first. Deny-list entries remain
+    the right size of cut for a single reported family; they are not a
+    substitute for that change.
   * `last_command_window` resolution is gone from this module. It survives
     in `Server.ex` only for labeled-response correlation bookkeeping.
     Pre-CP13 the router used it as the `:active` fallback target, but the
@@ -143,6 +170,36 @@ defmodule Grappa.Session.NumericRouter do
   # here if a bound network emits them.
   @stats_numerics Enum.to_list(211..219) ++ Enum.to_list(240..250)
 
+  # #908 — TRACE reply family (200–210, 261–262). The THIRD instance of the
+  # @stats_numerics disease (#184's stats letter; UX-4 bucket I's
+  # connect-storm metadata): a middle param that is a TYPE LABEL, whose
+  # syntax happens to satisfy `Identifier.valid_nick?/1`. For TRACE the
+  # label sits in `params[1]` on every member of the family — "Link",
+  # "Attempt", "Handshaking", "????", "Operator", "User", "Server",
+  # "<newtype>", "Class", "File" — so the param scan takes the reply KIND
+  # for a destination. Measured against Azzurra/bahamut on 2026-08-05: one
+  # `/trace <server>` opened three query windows named "Operator", "Server"
+  # and "Class". TRACE is server-directed by definition; the whole family
+  # belongs on `$server`.
+  #
+  # 262 RPL_ENDOFTRACE is covered even though `query_candidate?/2`'s
+  # `.`-exclusion already saves the observed reply: there the token is the
+  # traced SERVER's name, and the save depends on that name carrying a dot.
+  # A family-wide rule must not rest on how a server happens to be spelled.
+  #
+  # 207 and 210 are NULL in bahamut's table, so nothing is being fixed
+  # there today; they are covered because every reading of those slots is
+  # still server-directed (RFC 2812 RPL_TRACESERVICE / RPL_TRACERECONNECT;
+  # ircu reuses 210 as RPL_STATSHELP). A contiguous range costs nothing and
+  # leaves no hole for a bound network that does emit them.
+  #
+  # NB these bahamut replies carry NO trailing param, so
+  # `List.last(msg.params)` picks a data field and the persisted body is a
+  # bare "0" / "31" / "94086917687820". That is a DISPLAY concern, already
+  # covered by #424's `meta.raw_params` (rendered by #569) — the routing
+  # fix here neither causes nor repairs it.
+  @trace_numerics Enum.to_list(200..210) ++ [261, 262]
+
   # #785 — the RFC error range (4xx command failures, 5xx server errors).
   # Distinct from `severity/1`'s `>= 400` cut, which also lands the 6xx
   # vendor replies on `:error`; absorption keys off the RANGE instead, so a
@@ -158,6 +215,7 @@ defmodule Grappa.Session.NumericRouter do
   # ack. Always go to `{:server, nil}`. Closed set; expand deliberately.
   @active_numerics MapSet.new(
                      @stats_numerics ++
+                       @trace_numerics ++
                        [
                          # UX-4 bucket I (2026-05-19): connect-storm numerics
                          # whose middle params are server metadata (own ID,

--- a/test/grappa/session/numeric_router_test.exs
+++ b/test/grappa/session/numeric_router_test.exs
@@ -167,7 +167,8 @@ defmodule Grappa.Session.NumericRouterTest do
   # the reply TYPE token ("Operator", "Server", "Class", …), the third
   # instance of the #184 stats-letter disease.
   @active_numerics [4, 42, 263, 421, 432, 433, 437, 461, 512, 734] ++
-                     Enum.to_list(211..219) ++ Enum.to_list(240..250) ++
+                     Enum.to_list(211..219) ++
+                     Enum.to_list(240..250) ++
                      Enum.to_list(200..210) ++ [261, 262]
 
   describe "@active_numerics deny list → {:server, nil}" do

--- a/test/grappa/session/numeric_router_test.exs
+++ b/test/grappa/session/numeric_router_test.exs
@@ -163,8 +163,12 @@ defmodule Grappa.Session.NumericRouterTest do
   # token (watched nick / rejected MONITOR target) that is metadata, not a
   # query destination. The EventRouter toast is transient; the raw numeric
   # must land on $server (durable "list full" record).
+  # #908 — TRACE reply family (200–210, 261–262) folded in: `params[1]` is
+  # the reply TYPE token ("Operator", "Server", "Class", …), the third
+  # instance of the #184 stats-letter disease.
   @active_numerics [4, 42, 263, 421, 432, 433, 437, 461, 512, 734] ++
-                     Enum.to_list(211..219) ++ Enum.to_list(240..250)
+                     Enum.to_list(211..219) ++ Enum.to_list(240..250) ++
+                     Enum.to_list(200..210) ++ [261, 262]
 
   describe "@active_numerics deny list → {:server, nil}" do
     property "all @active_numerics route to {:server, nil} regardless of params" do
@@ -264,6 +268,62 @@ defmodule Grappa.Session.NumericRouterTest do
 
     test "242 RPL_STATSUPTIME: trailing-only STATS reply stays on $server" do
       m = msg(242, ["vjt", "Server Up 12 days, 03:45:12"])
+      assert {:server, nil} = NumericRouter.route(m, state())
+    end
+
+    # #908 — TRACE reply family. `params[1]` is the reply TYPE token, never
+    # a destination: the third instance of the same disease as #184's stats
+    # letter and bucket I's connect-storm metadata. The params below are
+    # VERBATIM `meta.raw_params` from a single `/trace nightwish.azzurra.chat`
+    # against Azzurra/bahamut on 2026-08-05 — which minted three query
+    # windows named "Operator", "Server" and "Class".
+    test "204 RPL_TRACEOPERATOR: reply type is NOT a query destination (#908 headline)" do
+      m = msg(204, ["vjt", "Operator", "1", "vjt[~user@host]", "0"])
+      assert {:server, nil} = NumericRouter.route(m, state())
+    end
+
+    test "206 RPL_TRACESERVER: reply type wins over later dotted params" do
+      # Eight params, and the FIRST nick-shaped candidate is the type token
+      # — the later `raptor.azzurra.chat[...]` / `*!*@...` fields are already
+      # rejected by the `.`-exclusion and the `!`/`@` charset.
+      m =
+        msg(206, [
+          "vjt",
+          "Server",
+          "0",
+          "8S",
+          "172C",
+          "raptor.azzurra.chat[unknown@0::0]",
+          "*!*@nightwish.azzurra.chat",
+          "94086917687820"
+        ])
+
+      assert {:server, nil} = NumericRouter.route(m, state())
+    end
+
+    test "209 RPL_TRACECLASS: reply type is NOT a query destination" do
+      # No trailing param in bahamut's format, so the persisted body is the
+      # bare class size ("2"). Display is #424/#569's problem; routing is ours.
+      m = msg(209, ["vjt", "Class", "0", "2"])
+      assert {:server, nil} = NumericRouter.route(m, state())
+    end
+
+    test "261 RPL_TRACELOG: the 'File' type token is NOT a query destination" do
+      m = msg(261, ["vjt", "File", "/var/log/ircd.log", "3"])
+      assert {:server, nil} = NumericRouter.route(m, state())
+    end
+
+    test "200 RPL_TRACELINK: the 'Link' type token is NOT a query destination" do
+      m = msg(200, ["vjt", "Link", "bahamut-2.2.1", "nightwish.azzurra.chat"])
+      assert {:server, nil} = NumericRouter.route(m, state())
+    end
+
+    # 262 already reached $server before #908, but only by the accident of a
+    # DOTTED server name hitting `query_candidate?/2`'s `.`-exclusion. Pin the
+    # dotless spelling too: the family is server-directed as a whole, so the
+    # decision must not depend on how the traced server happens to be named.
+    test "262 RPL_ENDOFTRACE: stays on $server even for a DOTLESS server name" do
+      m = msg(262, ["vjt", "services", "End of TRACE"])
       assert {:server, nil} = NumericRouter.route(m, state())
     end
   end


### PR DESCRIPTION
Fixes the misrouting reported in #908. Refs #184, #640, #424.

## What was wrong

One `/trace nightwish.azzurra.chat` against Azzurra opened three query
windows named `Operator`, `Server` and `Class`. Every TRACE reply carries
its reply KIND in `params[1]` — `Link`, `Attempt`, `Handshaking`, `????`,
`Operator`, `User`, `Server`, `<newtype>`, `Class`, `File` — and
`scan_params/2` takes the first nick-shaped, dotless, non-own middle param
as a routing destination. It routed the kind.

TRACE is server-directed by definition, so 200–210 + 261–262 join
`@active_numerics`: the third family after #184's STATS letter and UX-4
bucket I's connect-storm metadata.

## Decisions worth arguing with

**262 is covered even though it already worked.** Its `params[1]` is the
traced server's name, saved only by the `.`-exclusion in
`query_candidate?/2` — the correct outcome rested on that server happening
to be spelled with a dot. The test pins the DOTLESS spelling instead, so
the decision no longer depends on a naming accident.

**207/210 fix nothing today** — `NULL` in bahamut's table. Covered because
every reading of those slots is still server-directed (RPL_TRACESERVICE,
RPL_TRACERECONNECT, ircu's RPL_STATSHELP), and a contiguous range leaves no
hole for a network that does emit them.

**Not delegated.** TRACE has no cic UI, and delegating without an
EventRouter handler is the phantom-delegation silent drop already paid for
once with LIST (no-silent-drops B6.1 HIGH-3). `$server` notice + #424's
`meta.raw_params` is the whole display story. The bahamut replies carry no
trailing param, so the persisted body is a bare `0` / `31` /
`94086917687820` — a display concern #424/#569 already own, neither caused
nor repaired here.

**A moduledoc claim was false and is corrected.** It said the param scan is
safe by default — "at worst a row lands on `$server` instead of a more
specific window". That holds for the channel branch. The query branch's
failure mode is a row landing in the wrong CONVERSATION, and before #640 it
MINTED a ghost window that leaked into Archive via `list_archive`'s
`COALESCE(dm_with, channel)`. #640 is a backstop, not a correct decision: a
`/trace` issued while a window named `Operator` is open still misroutes.

## Why this is a third patch and not the root-cause fix

Recorded in the moduledoc and DESIGN_NOTES. The scan asks a syntactic
question ("could this token be a nick?") of a semantic slot, and there is no
syntactic discriminant: `params[1]` is a target for the error class, a
channel for the channel class, and DATA for every report class. The table
can only be keyed by the CODE — which both lists already are. A deny list
and an allow list differ ONLY in which side the unknown falls on, and today
it falls on the guessing side. The deny list now stands at 43 codes against
the two or three the query branch genuinely serves (401, plus the legacy
2-param shape); that ratio is the argument for inverting the default.

Left undone deliberately: inverting changes behaviour for every numeric in
neither list, and #221's WHOIS-leg guard is *defined* as "a `:scan`-class
numeric" and would have to be re-sited first. That is a design change, not a
bug fix.

## Verification

Red observed before green, with the fix reverted and the tests in place:
7 failures, each for the right reason — `{:query, "Operator"}`,
`{:query, "Server"}`, `{:query, "Class"}`, `{:query, "Link"}`,
`{:query, "File"}`, `{:query, "services"}`, plus the deny-list property.

`scripts/check.sh` rc=0 on the full tree: Credo `5119 mods/funs, found no
issues`; `8 doctests, 54 properties, 5272 tests, 0 failures`; Dialyzer
`Total errors: 0` / `done (passed successfully)`; Sobelow, doctor, bats all
green.

The six named tests use the `meta.raw_params` measured on prod verbatim.