### PR TITLE
cic(#913): cap the rail actions menu against the SAFE top edge

### DIFF
--- a/cicchetto/e2e/tests/issue913-rail-menu-safe-area.spec.ts
+++ b/cicchetto/e2e/tests/issue913-rail-menu-safe-area.spec.ts
@@ -1,0 +1,107 @@
+// #913 — the rail actions menu must cap itself against the SAFE top edge, not
+// the physical one.
+//
+// Sibling of the #588 guard in issue500-rail-launcher-overflow.spec.ts. #588
+// proved the menu stops growing off the top of the screen; it asserts the
+// topmost row lands at y >= 0. #913 is the residue: under `viewport-fit=cover`
+// y = 0 is the PHYSICAL top of the display, behind the status bar, so a row at
+// y = 8 satisfied #588 while sitting under the clock — and the cap being one
+// inset too generous, the rows still fit, `overflow-y: auto` never engaged, and
+// the occluded row could not be scrolled to.
+//
+// THE MEASUREMENT PROBLEM. Playwright does not synthesize
+// `env(safe-area-inset-*)` on any engine we run: it resolves to 0, so the real
+// on-device geometry is NOT observable here and no assertion about a 59px
+// notch can be honest. What IS observable is the WIRING — whether the inset
+// reaches the cap at all, and at what rate. So this spec measures the SAME menu
+// twice, once with the inset at its Playwright value and once with a stubbed
+// non-zero one, and asserts the topmost row moved down by exactly that much.
+//
+// That differential is what makes it non-hollow. Against the pre-fix build the
+// cap ignores the variable entirely, so the delta is 0 and this fails. An
+// absolute `y >= inset` assertion would NOT fail there — it is already true at
+// inset 0, which is precisely how #588 passed while #913 was live.
+//
+// The stub goes through `--safe-area-inset-top` on `:root`, the indirection the
+// fix introduced (JS cannot reliably read `env()` back out of a custom
+// property, so the arithmetic lives in CSS). Being a variable is what makes it
+// stubbable at all; the felt behaviour on a notched device is still vjt's to
+// confirm, and this spec does not claim it.
+
+import { expect, test } from "../fixtures/test";
+import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0]; // #bofh — vjt's seeded autojoin channel
+
+// Short enough that the action rows cannot all fit above the bottom-pinned
+// launcher, so the menu is pinned to its cap rather than to its content height.
+// A tall viewport would let the menu fit, the cap would stop being the binding
+// constraint, and the delta below would be 0 on a FIXED build too — the #588
+// trap, restated. Mirrors the sibling spec's viewport for the same reason.
+const VIEWPORT = { width: 1280, height: 200 };
+
+// A plausible notch: iPhone 17 Pro reports ~59px. The exact number does not
+// matter to the assertion (it is a delta), only that it is non-zero and large
+// enough to dwarf sub-pixel layout noise.
+const STUB_INSET = 59;
+
+// No peers needed: menu overflow is a function of row count vs the space above
+// the launcher, independent of the member list (the #588 spec's own note).
+test.setTimeout(90_000);
+
+test("#913 — the safe-area inset shrinks the rail menu cap, pushing its top row clear", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  await page.setViewportSize(VIEWPORT);
+  await openRailMenu(page);
+
+  const menu = page.locator(".rail-actions-menu");
+  await expect(menu).toBeVisible();
+  const topRow = menu.locator("[data-testid='mobile-panel-home']");
+  await expect(topRow).toBeVisible();
+
+  // Precondition — the menu ACTUALLY overflows, so its box is the cap and not
+  // its content. Without this the whole measurement is of the wrong thing.
+  const overflowsBefore = await menu.evaluate((el) => el.scrollHeight > el.clientHeight + 1);
+  expect(overflowsBefore, "rail menu must overflow for the cap to be the binding constraint").toBe(
+    true,
+  );
+
+  const boxBefore = await topRow.boundingBox();
+  expect(boxBefore, "top menu row must have a layout box").not.toBeNull();
+
+  // Stub a non-zero inset. `:root:root` (0,2,0) rather than `:root` (0,1,0) so
+  // the override wins on specificity and does not depend on where the bundler
+  // injected the stylesheet relative to this tag. The menu is `max-height`-
+  // capped in CSS, so this reflows on its own — the JS-measured
+  // `--rail-menu-space-above` is unaffected (the launcher has not moved), which
+  // is exactly what isolates the inset as the only changed operand.
+  await page.addStyleTag({ content: `:root:root { --safe-area-inset-top: ${STUB_INSET}px; }` });
+
+  // The cap shrank, so the menu can only overflow harder — assert it, or a
+  // regression that collapses the menu entirely would sail past the delta.
+  const overflowsAfter = await menu.evaluate((el) => el.scrollHeight > el.clientHeight + 1);
+  expect(overflowsAfter, "a smaller cap must still leave the menu scrollable").toBe(true);
+
+  const boxAfter = await topRow.boundingBox();
+  expect(boxAfter, "top menu row must still have a layout box").not.toBeNull();
+
+  if (boxBefore && boxAfter) {
+    // THE DEFECT: pre-fix the cap ignores the inset, the box does not move, and
+    // this delta is 0. Post-fix the top edge descends by exactly one inset.
+    // Sub-pixel tolerance only — a partial subtraction is a bug, not a rounding.
+    expect(
+      boxAfter.y - boxBefore.y,
+      "the top row must descend by exactly the safe-area inset",
+    ).toBeGreaterThan(STUB_INSET - 1.5);
+    expect(
+      boxAfter.y - boxBefore.y,
+      "the top row must not descend by MORE than the inset (double-counted)",
+    ).toBeLessThan(STUB_INSET + 1.5);
+  }
+});

--- a/cicchetto/src/RailActions.tsx
+++ b/cicchetto/src/RailActions.tsx
@@ -89,9 +89,11 @@ export type Props = {
   setters: MobilePanelSetters;
 };
 
-// #588 — px kept clear at the viewport top when the menu is capped to the space
-// above the launcher, so the topmost row isn't flush against the screen edge
-// (notch / status bar breathing room). Fed to `spaceAbove`.
+// #588 — px kept clear above the menu so the topmost row isn't flush against
+// whatever is above it. Breathing room ONLY: #913 established that clearing the
+// notch / status bar is a separate, ~59px job that this constant was silently
+// being asked to do. The inset is subtracted in CSS (see below); this is what
+// remains on top of it. Fed to `spaceAbove`.
 const RAIL_MENU_TOP_GAP = 8;
 
 const RailActions: Component<Props> = (props) => {
@@ -145,17 +147,28 @@ const RailActions: Component<Props> = (props) => {
   // second, differently-buggy CSS-only guess. Re-measure on `resize` /
   // `visualViewport` resize: that is where the mobile-keyboard-up case lives
   // (the visual viewport shrinks, the launcher rides up, the space above
-  // changes). Null while closed → the menu isn't mounted anyway, and the JSX
-  // falls back to the CSS var.
-  const [menuMaxHeight, setMenuMaxHeight] = createSignal<number | null>(null);
+  // changes) — and where rotation lands too, which matters now that the cap's
+  // other operand (the safe-area inset) also changes with orientation. Null
+  // while closed → the menu isn't mounted anyway, and the CSS var() chain
+  // falls back to the viewport height.
+  //
+  // #913 — this measurement is only HALF the cap. `getBoundingClientRect()` is
+  // relative to the layout viewport, whose origin under `viewport-fit=cover` is
+  // the physical top of the display, behind the status bar. The stylesheet
+  // takes `var(--safe-area-inset-top)` off what we publish here; we do NOT read
+  // the inset in JS, because `getComputedStyle().getPropertyValue()` on an
+  // unregistered custom property is not guaranteed to resolve `env()` to a
+  // length — it can return the token stream, and the NaN that follows would
+  // fail silently as a no-op fix.
+  const [menuSpaceAbove, setMenuSpaceAbove] = createSignal<number | null>(null);
   createEffect(() => {
     if (!open()) {
-      setMenuMaxHeight(null);
+      setMenuSpaceAbove(null);
       return;
     }
     const measure = (): void => {
       if (!rootRef) return;
-      setMenuMaxHeight(spaceAbove(rootRef.getBoundingClientRect().top, RAIL_MENU_TOP_GAP));
+      setMenuSpaceAbove(spaceAbove(rootRef.getBoundingClientRect().top, RAIL_MENU_TOP_GAP));
     };
     measure();
     window.addEventListener("resize", measure);
@@ -178,10 +191,13 @@ const RailActions: Component<Props> = (props) => {
           class="rail-actions-menu"
           role="menu"
           style={
-            // #588 — cap to the space above the launcher (JS-measured); the CSS
-            // `max-height: var(--viewport-height)` stays as the pre-measure
-            // fallback. undefined → the CSS rule applies.
-            menuMaxHeight() !== null ? { "max-height": `${menuMaxHeight()}px` } : undefined
+            // #588/#913 — publish the JS-measured space above the launcher; the
+            // stylesheet's `max-height` subtracts the safe-area inset from it
+            // and clamps. undefined → the var() falls back to the viewport
+            // height (pre-measure only).
+            menuSpaceAbove() !== null
+              ? { "--rail-menu-space-above": `${menuSpaceAbove()}px` }
+              : undefined
           }
         >
           {/* #291 — home launcher. Always visible; leftmost/topmost. */}

--- a/cicchetto/src/__tests__/RailActions.test.tsx
+++ b/cicchetto/src/__tests__/RailActions.test.tsx
@@ -231,6 +231,62 @@ describe("RailActions (#473)", () => {
   });
 });
 
+// #588 → #913 — the upward-opening menu's max-height cap. #588 established
+// that the cap is the space ABOVE the launcher, measured in JS. #913 is the
+// residue: `getBoundingClientRect().top` is measured from the LAYOUT viewport
+// origin, which under `viewport-fit=cover` is the PHYSICAL top of the display
+// — behind the status bar. The inset itself is NOT resolvable from JS (an
+// unregistered custom property's `env()` is not guaranteed to compute through
+// `getComputedStyle`), so the split is: JS publishes the one number CSS cannot
+// know (the anchor's viewport offset, gap already applied) as
+// `--rail-menu-space-above`, and the stylesheet subtracts
+// `var(--safe-area-inset-top)` from it. These tests pin the JS half; the CSS
+// half is pinned in railMenuSafeArea.test.ts.
+describe("RailActions upward-menu cap (#588 → #913)", () => {
+  function stubAnchorTop(top: number): void {
+    const root = document.querySelector(".rail-actions");
+    if (!(root instanceof HTMLElement)) throw new Error(".rail-actions did not render");
+    root.getBoundingClientRect = (): DOMRect =>
+      ({ top, y: top, bottom: top, left: 0, x: 0, right: 0, width: 0, height: 0 }) as DOMRect;
+  }
+
+  function menuEl(): HTMLElement {
+    const menu = document.querySelector(".rail-actions-menu");
+    if (!(menu instanceof HTMLElement)) throw new Error(".rail-actions-menu did not render");
+    return menu;
+  }
+
+  it("publishes the space above the launcher, gap deducted, as a custom property", () => {
+    render(() => <RailActions setters={setters} />);
+    stubAnchorTop(500);
+    openMenu();
+    // 500 (anchor top) - 8 (RAIL_MENU_TOP_GAP) — the CSS then takes the
+    // safe-area inset off this, which is the whole #913 fix.
+    expect(menuEl().style.getPropertyValue("--rail-menu-space-above")).toBe("492px");
+  });
+
+  it("re-measures when the viewport changes (rotation / keyboard reflow)", () => {
+    render(() => <RailActions setters={setters} />);
+    stubAnchorTop(500);
+    openMenu();
+    expect(menuEl().style.getPropertyValue("--rail-menu-space-above")).toBe("492px");
+    // Rotation and `interactive-widget=resizes-content` both move the launcher;
+    // a cap measured once at open would go stale and re-open the #588 overflow.
+    stubAnchorTop(200);
+    window.dispatchEvent(new Event("resize"));
+    expect(menuEl().style.getPropertyValue("--rail-menu-space-above")).toBe("192px");
+  });
+
+  it("clamps at zero when the launcher sits above the gap", () => {
+    render(() => <RailActions setters={setters} />);
+    stubAnchorTop(4);
+    openMenu();
+    // A NEGATIVE length would be an invalid max-height → declaration dropped →
+    // the uncapped #588 overflow returns.
+    expect(menuEl().style.getPropertyValue("--rail-menu-space-above")).toBe("0px");
+  });
+});
+
 // #500 — the always-expanded button column became unreachable on a big channel
 // (desktop: it sat below the overflowing nick list; mobile: it ate the rail).
 // vjt's fix: collapse every action behind ONE launcher permanently pinned at

--- a/cicchetto/src/__tests__/railMenuSafeArea.test.ts
+++ b/cicchetto/src/__tests__/railMenuSafeArea.test.ts
@@ -61,14 +61,14 @@ describe("#913 rail actions menu safe-area cap", () => {
   it(".rail-actions-menu carries the overlay-scroller touch-action carve-out", () => {
     // The menu is an overlay scroller living inside the `touch-action: none`
     // blanket (`.shell-mobile`, and `html.overlay-open #root > div` while the
-    // rail lock is held). Every sibling scroller in this stylesheet —
-    // `.members-pane`, `.settings-drawer`, `.archive-modal` — re-asserts
-    // `pan-y` on the scroller AND on its descendants, because touch-action does
-    // not inherit and iOS elects the gesture consumer from the hit-test
-    // target's own value (UX-6 bucket A v2). The action rows ARE the hit-test
-    // targets here. Without the carve-out, shrinking the cap makes the menu
-    // overflow but the pan can still be refused — the same symptom, a second
-    // cause.
+    // rail lock is held). Scroller-level `pan-y` is what every sibling scroller
+    // carries (`.settings-drawer`, `.archive-modal`, `.home-pane` …); the
+    // DESCENDANT half has one precedent, `.members-pane *`, added by UX-6
+    // bucket A v2 after the scroller-only form had shipped and did not work —
+    // touch-action does not inherit, and iOS elects the gesture consumer from
+    // the hit-test target's own value. The action rows ARE the hit-test targets
+    // here. Without the carve-out, shrinking the cap makes the menu overflow
+    // but the pan can still be refused — the same symptom, a second cause.
     expect(ruleBody(".rail-actions-menu")).toMatch(/touch-action:\s*pan-y/);
     expect(themeCss).toMatch(/\.rail-actions-menu \*\s*\{[^}]*touch-action:\s*pan-y/);
   });

--- a/cicchetto/src/__tests__/railMenuSafeArea.test.ts
+++ b/cicchetto/src/__tests__/railMenuSafeArea.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { ruleBody, themeCss } from "./helpers/themeCss";
+
+// #913 — the rail actions menu opened INTO the iOS safe area: the topmost row
+// (home) rendered behind the status bar, and the menu did not scroll.
+//
+// Residue of #588, not a regression of it. #588 replaced a CSS cap of the WHOLE
+// viewport with a JS cap of the space above the launcher, which is correct in
+// principle but measures from the wrong origin: `getBoundingClientRect().top`
+// is relative to the LAYOUT viewport, and under `viewport-fit=cover` that
+// origin is the PHYSICAL top edge of the display, underneath the status bar.
+// The 8px `RAIL_MENU_TOP_GAP` is breathing room, not a ~59px status-bar
+// allowance.
+//
+// The inset is subtracted HERE, in CSS, and not in RailActions.tsx: `env()` is
+// substituted by the engine at computed-value time, but reading it back out of
+// an unregistered custom property with `getComputedStyle().getPropertyValue()`
+// is not guaranteed to yield a length — it can hand back the literal token
+// stream, which `parseFloat` turns into NaN and a `|| 0` fallback silently
+// swallows, leaving the bug in place while looking fixed. Every other inset in
+// this stylesheet is a plain CSS `env()` for the same reason; this one joins
+// them. JS supplies only what CSS cannot know — the anchor's viewport offset,
+// as `--rail-menu-space-above` (see RailActions.test.tsx for that half).
+//
+// SOURCE-LEVEL guards. Playwright does not synthesize `env(safe-area-inset-*)`
+// (they resolve to 0), and jsdom resolves neither `env()` nor `calc()`, so the
+// on-device geometry is not observable in any gate we run — the `:root`
+// indirection exists partly so a browser test CAN stub a non-zero inset. The
+// felt behaviour still needs a real notched device.
+
+describe("#913 rail actions menu safe-area cap", () => {
+  it(":root exposes the top inset as a custom property with a 0px fallback", () => {
+    // The indirection is what makes the inset overridable by a test and keeps
+    // `env()` resolution in the engine. The `0px` fallback matters on its own:
+    // a bare `env(safe-area-inset-top)` on an engine that does not know the
+    // variable makes the whole declaration invalid, which would drop the cap
+    // entirely and bring the #588 overflow back on non-iOS browsers.
+    expect(ruleBody(":root")).toMatch(/--safe-area-inset-top:\s*env\(safe-area-inset-top,\s*0px\)/);
+  });
+
+  it(".rail-actions-menu subtracts the inset from the JS-measured space above", () => {
+    const body = ruleBody(".rail-actions-menu");
+    expect(body).toMatch(/max-height:[^;]*var\(--rail-menu-space-above/);
+    expect(body).toMatch(/max-height:[^;]*var\(--safe-area-inset-top,\s*0px\)/);
+  });
+
+  it("the cap is clamped at zero and keeps its pre-measure fallback", () => {
+    const body = ruleBody(".rail-actions-menu");
+    // Subtracting the inset can drive the result negative on a short viewport.
+    // A negative max-height is out of range; clamp explicitly rather than lean
+    // on used-value clamping, per the #588 note that an ignored cap returns the
+    // overflow bug.
+    expect(body).toMatch(/max-height:\s*max\(\s*0px\s*,/);
+    // Until the effect measures (menu closed, or the frame before open), the
+    // custom property is unset and the cap falls back to the viewport height —
+    // the #588 pre-measure fallback, now nested in the same expression instead
+    // of a second declaration that could drift from it.
+    expect(body).toMatch(/var\(--rail-menu-space-above,\s*var\(--viewport-height,\s*80vh\)\)/);
+  });
+
+  it(".rail-actions-menu carries the overlay-scroller touch-action carve-out", () => {
+    // The menu is an overlay scroller living inside the `touch-action: none`
+    // blanket (`.shell-mobile`, and `html.overlay-open #root > div` while the
+    // rail lock is held). Every sibling scroller in this stylesheet —
+    // `.members-pane`, `.settings-drawer`, `.archive-modal` — re-asserts
+    // `pan-y` on the scroller AND on its descendants, because touch-action does
+    // not inherit and iOS elects the gesture consumer from the hit-test
+    // target's own value (UX-6 bucket A v2). The action rows ARE the hit-test
+    // targets here. Without the carve-out, shrinking the cap makes the menu
+    // overflow but the pan can still be refused — the same symptom, a second
+    // cause.
+    expect(ruleBody(".rail-actions-menu")).toMatch(/touch-action:\s*pan-y/);
+    expect(themeCss).toMatch(/\.rail-actions-menu \*\s*\{[^}]*touch-action:\s*pan-y/);
+  });
+});

--- a/cicchetto/src/lib/menuPosition.ts
+++ b/cicchetto/src/lib/menuPosition.ts
@@ -51,6 +51,13 @@ export function computeMenuPosition(m: MenuMeasurement): MenuPlacement {
 // y=0 must never produce a NEGATIVE max-height (invalid CSS → rule ignored →
 // the overflow bug returns). Sibling of `placeAxis`'s viewport-oversize
 // pin — both hand the CSS `overflow-y: auto` a valid, in-viewport box.
+//
+// #913 — the return value is no longer the final max-height: `anchorTop` is
+// measured from the layout viewport origin, which under `viewport-fit=cover`
+// is BEHIND the status bar, so the caller publishes this as
+// `--rail-menu-space-above` and the stylesheet subtracts
+// `var(--safe-area-inset-top)` before capping. `gap` is breathing room only —
+// it is NOT a notch allowance, and must not be grown into one.
 export function spaceAbove(anchorTop: number, gap: number): number {
   return Math.max(0, anchorTop - gap);
 }

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -1913,8 +1913,12 @@ html.resize-dragging * {
   touch-action: pan-y;
 }
 
-/* #913 — descendant gesture carve-out, mirroring `.members-pane *` (UX-6
-   bucket A v2) and the same pair on `.settings-drawer` / `.archive-modal`.
+/* #913 — descendant gesture carve-out. Scroller-level `pan-y` is the common
+   case here (`.settings-drawer`, `.archive-modal`, `.image-upload-modal`,
+   `.home-pane` … all carry it, most with a comment about the same trap), but
+   the DESCENDANT form has exactly ONE precedent: `.members-pane *`, added by
+   UX-6 bucket A v2 (2026-05-20) precisely because the scroller-only version
+   had shipped and did not work.
    touch-action does NOT inherit, so the action rows sit at the default `auto`
    while their ancestors are under the `touch-action: none` blanket
    (`.shell-mobile`, plus `html.overlay-open #root > div` — this menu holds the

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -194,6 +194,19 @@
      floor (feedback_cic_tap_target_rem_pitfall). Theme-independent, so it
      lives on base :root, NOT in the per-theme blocks. */
   --tap-min: 44px;
+  /* #913 — the iOS top safe-area inset, as a variable. Everything else in this
+     file writes `env(safe-area-inset-top)` inline, which is right for a
+     padding: the engine substitutes it and nobody has to read it back. The
+     rail actions menu is the one cap whose OTHER operand is measured in JS
+     (`--rail-menu-space-above`), and JS cannot reliably obtain the inset: an
+     unregistered custom property hands `getComputedStyle().getPropertyValue()`
+     its token stream, not a length, so `parseFloat` yields NaN and a `|| 0`
+     fallback hides it. Keeping the arithmetic in CSS keeps `env()` where the
+     engine resolves it. The `0px` fallback is load-bearing: without it an
+     engine that does not know the variable invalidates the whole declaration
+     and the cap disappears (the #588 overflow, back). Theme-independent, so it
+     lives on base :root. */
+  --safe-area-inset-top: env(safe-area-inset-top, 0px);
   /* grappa-irc#69: theme the scrollbars. `scrollbar-color` and
      `scrollbar-width` inherit, so declaring them on :root themes every
      scrollable descendant (.scrollback, members pane, admin tables…)
@@ -1858,13 +1871,23 @@ html.resize-dragging * {
    contain` stops the scroll chaining to the list behind. z-index sits at the
    context-menu layer so it clears the rail chrome; the fixed backdrop below is
    one step under it.
-   #588 — the `max-height: var(--viewport-height)` here is now only the
-   PRE-MEASURE FALLBACK. `var(--viewport-height)` is the WHOLE viewport, but a
-   menu opening upward only has the space ABOVE the launcher; capping at the
-   viewport let the overflowing rows grow off the top of the screen with no
-   scroll. RailActions.tsx measures the real space above on open (+ on resize /
-   visualViewport) and overrides `max-height` inline via `spaceAbove` — only
-   then does the `overflow-y: auto` below actually engage. */
+   #588 — `var(--viewport-height)` is the WHOLE viewport, but a menu opening
+   upward only has the space ABOVE the launcher; capping at the viewport let
+   the overflowing rows grow off the top of the screen with no scroll. So it
+   survives here only as the PRE-MEASURE FALLBACK, nested inside the var()
+   chain: RailActions.tsx measures the real space above on open (+ on resize /
+   visualViewport, via `spaceAbove`) and publishes it as
+   `--rail-menu-space-above`. Only then does the `overflow-y: auto` below
+   actually engage.
+   #913 — that measurement comes from `getBoundingClientRect().top`, which
+   under `viewport-fit=cover` is measured from the PHYSICAL top of the display,
+   so the cap ran a full status bar too tall: the topmost row rendered behind
+   the clock, and — being one inset roomier than the space it had — the rows
+   still fit, so `overflow-y: auto` never engaged and that row could not be
+   scrolled into reach. Subtract the inset HERE, where the engine resolves
+   `env()` (see the `--safe-area-inset-top` note on :root for why not in JS).
+   `max(0px, …)` because the subtraction can go negative on a short viewport,
+   and a negative max-height is an ignored declaration — i.e. no cap at all. */
 .rail-actions-menu {
   position: absolute;
   bottom: 100%;
@@ -1878,9 +1901,30 @@ html.resize-dragging * {
   background: var(--bg-alt);
   border: 1px solid var(--border);
   border-bottom: none;
-  max-height: var(--viewport-height, 80vh);
+  max-height: max(
+    0px,
+    calc(
+      var(--rail-menu-space-above, var(--viewport-height, 80vh)) -
+      var(--safe-area-inset-top, 0px)
+    )
+  );
   overflow-y: auto;
   overscroll-behavior: contain;
+  touch-action: pan-y;
+}
+
+/* #913 — descendant gesture carve-out, mirroring `.members-pane *` (UX-6
+   bucket A v2) and the same pair on `.settings-drawer` / `.archive-modal`.
+   touch-action does NOT inherit, so the action rows sit at the default `auto`
+   while their ancestors are under the `touch-action: none` blanket
+   (`.shell-mobile`, plus `html.overlay-open #root > div` — this menu holds the
+   overlay lock while open). iOS elects the gesture consumer from the hit-test
+   target's own value, and the rows ARE the hit-test target across nearly the
+   whole menu. Without this, capping the menu correctly makes it overflow but
+   the pan can still be refused — the second symptom, surviving the fix for the
+   first. */
+.rail-actions-menu * {
+  touch-action: pan-y;
 }
 
 /* #500 — the launcher carries the same `.rail-action` full-width row chrome

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -30552,12 +30552,17 @@ engine, handing back the uncapped #588 overflow.
 inset, straightforwardly. The no-scroll half is a CONSEQUENCE in the reported
 configuration — a cap one inset too generous means the rows fit, so
 `overflow-y: auto` never engages — but it has a second, independent blocker:
-`.rail-actions-menu` carried no `touch-action` carve-out. Every sibling overlay
-scroller in the stylesheet (`.members-pane`, `.settings-drawer`,
-`.archive-modal`) re-asserts `pan-y` on the scroller AND its descendants, each
-with a comment about the same trap, because touch-action does not inherit and
-iOS elects the gesture consumer from the hit-test target's own value (UX-6
-bucket A v2). The menu holds the overlay lock while open, so it sits under the
+`.rail-actions-menu` carried no `touch-action` carve-out. Scroller-level
+`pan-y` is near-universal in that stylesheet — `.settings-drawer`,
+`.archive-modal`, `.image-upload-modal`, `.admin-pane`, `.who-modal-body`,
+`.home-pane` all carry it, five of them under a comment naming the same trap.
+The DESCENDANT form has exactly ONE precedent, `.members-pane *`, and that is
+the instructive one: UX-6 bucket A v2 added it *after* the scroller-only
+version had shipped and failed, because touch-action does not inherit and iOS
+elects the gesture consumer from the hit-test target's own value. (An earlier
+draft of this entry claimed three surfaces carried the descendant form; that
+was wrong — grep says one.) The menu holds the overlay lock while open, so it
+sits under the
 `touch-action: none` blanket, and its action rows are the hit-test target
 across most of its area. Capping correctly makes it overflow; the carve-out
 makes the overflow pannable. Added here for that reason — pattern-derived, NOT

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -30509,3 +30509,76 @@ it changes behaviour for every numeric in neither list, and #221's WHOIS-leg
 guard is defined as "a `:scan`-class numeric" and would have to be re-sited
 first. Deny-list entries stay the right size of cut for one reported family;
 they are not a substitute for the inversion.
+
+## 2026-08-06 — #913: the inset is CSS's to resolve, and JS supplies only what CSS cannot measure
+
+The rail actions menu opened into the iOS safe area: the topmost row rendered
+behind the status bar, and the menu would not scroll to bring it into reach.
+Residue of #588, not a regression of it. #588 replaced a cap of the WHOLE
+viewport with a cap of the space above the launcher, which is the right cap
+taken from the wrong origin — `getBoundingClientRect().top` is relative to the
+layout viewport, and under `viewport-fit=cover` that origin is the PHYSICAL top
+of the display. `RAIL_MENU_TOP_GAP = 8` was silently being asked to clear a
+~59px notch.
+
+**The split of responsibility is the durable part.** The issue proposed reading
+the inset in JS: expose `--safe-area-inset-top: env(...)` on `:root` and pull
+it back with `getComputedStyle().getPropertyValue()`. That is not safe. An
+UNREGISTERED custom property's computed value is a token stream, not a length;
+`getPropertyValue` can hand back the literal `env(safe-area-inset-top)`, whose
+`parseFloat` is `NaN`, which the proposal's own `|| 0` fallback turns into a
+fix that looks applied and does nothing. So the arithmetic was split by who can
+know what: **JS publishes the one number CSS cannot measure** — the anchor's
+distance to the viewport top, gap already deducted, as
+`--rail-menu-space-above` — **and the stylesheet subtracts the one value JS
+cannot reliably resolve**, `var(--safe-area-inset-top)`, then clamps with
+`max(0px, …)`. The next JS-measured cap on this codebase should follow the same
+seam rather than reach for `getComputedStyle`.
+
+**A pure-CSS cap was considered and is not available.** No CSS construct yields
+an element's distance to the viewport top; the viewport-unit forms
+(`--viewport-height`, `100dvh`) are exactly the whole-viewport cap #588
+removed, and the anchor is not viewport-pinned on desktop, so a
+`calc(100dvh - …)` shape would be wrong there. JS measurement stays. It
+re-measures on `resize` + `visualViewport` resize, which is also where rotation
+lands — now load-bearing, because the inset itself changes with orientation.
+
+**The `0px` fallbacks are load-bearing, not defensive.** An `env()` whose
+variable the engine does not know invalidates the entire declaration. Without
+`env(safe-area-inset-top, 0px)` the `max-height` would simply vanish on such an
+engine, handing back the uncapped #588 overflow.
+
+**Two symptoms, and only ONE of them shares the cause.** The occlusion is the
+inset, straightforwardly. The no-scroll half is a CONSEQUENCE in the reported
+configuration — a cap one inset too generous means the rows fit, so
+`overflow-y: auto` never engages — but it has a second, independent blocker:
+`.rail-actions-menu` carried no `touch-action` carve-out. Every sibling overlay
+scroller in the stylesheet (`.members-pane`, `.settings-drawer`,
+`.archive-modal`) re-asserts `pan-y` on the scroller AND its descendants, each
+with a comment about the same trap, because touch-action does not inherit and
+iOS elects the gesture consumer from the hit-test target's own value (UX-6
+bucket A v2). The menu holds the overlay lock while open, so it sits under the
+`touch-action: none` blanket, and its action rows are the hit-test target
+across most of its area. Capping correctly makes it overflow; the carve-out
+makes the overflow pannable. Added here for that reason — pattern-derived, NOT
+device-measured.
+
+**Nothing we run can observe the whole fix.** Playwright resolves
+`env(safe-area-inset-*)` to 0 on every engine in the suite, and jsdom resolves
+neither `env()` nor `calc()`. So the guards pin the two halves separately: the
+JS half behaviourally (measured value, re-measure on resize, clamp at zero,
+with a stubbed anchor rect), the CSS arithmetic at source level in the
+`ipadSafeArea.test.ts` style, and the seam between them by an e2e that measures
+the same menu twice — once at Playwright's zero inset, once with a stubbed
+59px — and asserts the top row descended by exactly that much. The differential
+is what makes it non-hollow: an absolute `y >= inset` assertion is already true
+at inset 0, which is precisely how #588's guard stayed green while #913 was
+live. The felt behaviour on a notched device remains vjt's to confirm.
+
+**Out of scope, reported not fixed.** `placeAxis` / `computeMenuPosition`
+(`UserContextMenu`) clamps against `viewportHeight` from origin 0 with no inset
+awareness on EITHER edge, so a context menu opened near the top can land under
+the status bar, and one near the bottom under the home indicator, for the same
+reason. `spaceAbove` has exactly one consumer, so #913 is contained; the
+`placeAxis` blind spot is a second instance of the same origin bug and wants
+its own issue.


### PR DESCRIPTION
Fixes the rail actions menu opening into the iOS safe area (#913): the topmost
row rendered behind the status bar, and the menu would not scroll to bring it
into reach.

## What was wrong

Residue of #588, not a regression of it. #588 replaced a cap of the WHOLE
viewport with a cap of the space above the launcher — the right cap, taken
from the wrong origin. `getBoundingClientRect().top` is relative to the layout
viewport, whose origin under `viewport-fit=cover` is the PHYSICAL top of the
display. `RAIL_MENU_TOP_GAP = 8` was silently being asked to clear a ~59px
notch.

## The fix, and why it is not the one the issue proposed

The issue proposed reading the inset in JS via
`getComputedStyle().getPropertyValue("--safe-area-inset-top")`. I did not do
that. An unregistered custom property's computed value is a token stream, not
a length — `getPropertyValue` can return the literal `env(safe-area-inset-top)`,
whose `parseFloat` is `NaN`, which the proposal's own `|| 0` fallback would
turn into a fix that looks applied and does nothing.

Split by who can know what instead:

* **JS** publishes the one number CSS cannot measure — the anchor's distance to
  the viewport top, gap deducted — as `--rail-menu-space-above`.
* **CSS** subtracts the one value JS cannot reliably resolve,
  `var(--safe-area-inset-top)`, and clamps with `max(0px, …)`.

A pure-CSS cap was considered and is not available: no CSS construct yields an
element's distance to the viewport top, the viewport-unit forms are exactly the
whole-viewport cap #588 removed, and the anchor is not viewport-pinned on
desktop. The JS measurement re-runs on `resize` + `visualViewport` resize,
which is where rotation lands too — now load-bearing, since the inset itself
changes with orientation.

The `0px` fallbacks are load-bearing rather than defensive: an `env()` whose
variable the engine does not know invalidates the whole declaration, which
would drop the cap entirely and hand back the #588 overflow.

## Second symptom, second cause — and what is NOT measured about it

vjt reported TWO symptoms. The occlusion is the inset, straightforwardly. The
no-scroll half is a consequence in the reported configuration (a cap one inset
too generous means the rows fit, so `overflow-y: auto` never engages) — but it
has an independent blocker the issue does not mention: `.rail-actions-menu`
carried no `touch-action` carve-out, while it holds the overlay lock and
therefore sits under the `touch-action: none` blanket, and its action rows are
the hit-test target across most of its area. Capping correctly makes the menu
overflow; the carve-out makes the overflow pannable.

**Stated plainly: this half is pattern-derived, and its necessity is NOT
measured.** Scroller-level `pan-y` is near-universal in that stylesheet
(`.settings-drawer`, `.archive-modal`, `.image-upload-modal`, `.admin-pane`,
`.who-modal-body`, `.home-pane` — five of them under a comment naming this
exact trap). The DESCENDANT form, which is what I added, has exactly **one**
precedent: `.members-pane *`. That one is the instructive case — UX-6 bucket A
v2 added it *after* the scroller-only version had shipped and failed. An
earlier draft of this PR claimed three surfaces carried the descendant pair;
that was wrong, and the correcting commit says so. I cannot claim the carve-out
was necessary here, nor that it is sufficient. It ships because the symptom was
reported and a cap-only fix may leave it standing.

## Test plan

- [x] `scripts/bun.sh run test` — 4395 passed / 241 files
- [x] `scripts/bun.sh run check` — rc 0; standalone `tsc --noEmit` rc 0
- [x] 7-way mutation harness against the new guards — all 7 killed, none survived
- [ ] e2e — NOT run locally, by design: this PR's `integration` job runs the full
      suite, so `issue913-rail-menu-safe-area.spec.ts` and the #588 guard in
      `issue500-rail-launcher-overflow.spec.ts` both execute there. Expect the
      e2e count to be +1 and the new spec to appear by name.
- [ ] on-device verification on a notched iPhone — not reproducible in any gate
      we run; the felt behaviour remains vjt's to confirm