### PR TITLE
#915: raise the denoise auto-activation cutoff from 50 to 200

### DIFF
--- a/cicchetto/e2e/tests/issue222-presence-filter.spec.ts
+++ b/cicchetto/e2e/tests/issue222-presence-filter.spec.ts
@@ -5,13 +5,14 @@
 //
 // This e2e is the interactive witness for the per-channel toggle + the
 // render-layer filter + localStorage persistence. It exercises REAL presence
-// events (a peer joins + parts #bofh) — NOT 50 spawned peers: 50 nicks from
-// one IP risks bahamut flood/autokill (feedback_e2e_multinet_live_needs_
-// distinct_nicks), and there is no window-exposed member-count seam in the e2e
-// harness to inflate membership. The size-default MATH (49 shown / 50 hidden +
-// the precedence truth table) is proven authoritatively in the vitest boundary
-// test (src/__tests__/presenceFilter.test.ts); this spec owns the interactive
-// toggle/persistence path.
+// events (a peer joins + parts #bofh) — NOT LARGE_CHANNEL_THRESHOLD spawned
+// peers: that many nicks from one IP risks bahamut flood/autokill
+// (feedback_e2e_multinet_live_needs_distinct_nicks), and there is no
+// window-exposed member-count seam in the e2e harness to inflate membership.
+// So the size-default MATH (the boundary pair + the precedence truth table) is
+// UNREACHABLE from here at any threshold value and is proven authoritatively
+// in the vitest boundary test (src/__tests__/presenceFilter.test.ts); this
+// spec owns the interactive toggle/persistence path.
 //
 // Assertions (all VISIBLE outcomes, CLAUDE.md "assert outcomes not calls"):
 //   1. small channel, default shown → a peer join + part row IS visible
@@ -65,7 +66,8 @@ test("#222 — per-channel toggle hides join/part rows, persists across reload, 
       .locator('[data-testid="scrollback-line"][data-kind="privmsg"]')
       .filter({ hasText: privmsgBody });
 
-    // 1. small channel (< 50 members), pref unset → presence shown by default.
+    // 1. small channel (a handful of members, far below
+    //    LARGE_CHANNEL_THRESHOLD), pref unset → presence shown by default.
     await expect(joinRow).toHaveCount(1, { timeout: 10_000 });
     await expect(partRow).toHaveCount(1, { timeout: 10_000 });
     await expect(privmsgRow).toHaveCount(1, { timeout: 10_000 });

--- a/cicchetto/e2e/tests/issue239-hidden-msg-unread.spec.ts
+++ b/cicchetto/e2e/tests/issue239-hidden-msg-unread.spec.ts
@@ -69,9 +69,10 @@ test("#239 — hidden control message does NOT bump the unread badge; reading cl
   // for the auto-joined self-JOIN line, proving REST + WS both landed.
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
 
-  // Pin #bofh to HIDE presence via the production toggle (no need to seed 50
-  // members — the size-default math is unit-tested; this is the interactive
-  // hide path). #500 folded the denoise toggle behind the rail launcher menu;
+  // Pin #bofh to HIDE presence via the production toggle (no need to seed
+  // LARGE_CHANNEL_THRESHOLD members — the size-default math is unit-tested;
+  // this is the interactive hide path). #500 folded the denoise toggle behind
+  // the rail launcher menu;
   // open it (desktop: taps the launcher) to reach the toggle.
   await openRailMenu(page);
   const toggle = page.locator('.rail-actions-menu [data-testid="presence-toggle"]');

--- a/cicchetto/src/__tests__/presenceFilter.test.ts
+++ b/cicchetto/src/__tests__/presenceFilter.test.ts
@@ -13,8 +13,12 @@ import { channelKey } from "../lib/channelKey";
 // The "tough" part the issue flagged: an automatic size-based default and a
 // manual per-channel override need a clear precedence — explicit choice WINS
 // over the size default. That precedence is the pure `resolvePresenceVisible`
-// truth table tested here (the size-default math the e2e deliberately does NOT
-// exercise with 50 real peers — flood/autokill risk).
+// truth table tested here — and ONLY here: the size default is not reachable
+// from the e2e at any threshold value (spawning LARGE_CHANNEL_THRESHOLD real
+// peers trips the bahamut same-host autokill, and the harness exposes no
+// member-count seam), so these cases are the sole gate on the cutoff. Every
+// count is derived from the constant, never a literal: a literal keeps passing
+// on the OPPOSITE branch after a tune (#915 raised 50 → 200).
 
 describe("presenceFilter module", () => {
   beforeEach(() => {
@@ -26,18 +30,22 @@ describe("presenceFilter module", () => {
 
   describe("resolvePresenceVisible() — pure precedence truth table", () => {
     it("unset pref: visible below the LARGE_CHANNEL_THRESHOLD", async () => {
-      const { resolvePresenceVisible } = await import("../lib/presenceFilter");
-      expect(resolvePresenceVisible(undefined, 49)).toBe(true);
+      const { resolvePresenceVisible, LARGE_CHANNEL_THRESHOLD } = await import(
+        "../lib/presenceFilter"
+      );
+      // Well below the cutoff, not the boundary (that pair has its own case).
+      expect(resolvePresenceVisible(undefined, Math.floor(LARGE_CHANNEL_THRESHOLD / 2))).toBe(true);
     });
 
     it("unset pref: hidden at-or-above the LARGE_CHANNEL_THRESHOLD", async () => {
-      const { resolvePresenceVisible } = await import("../lib/presenceFilter");
-      // 50 is the boundary: >= threshold hides.
-      expect(resolvePresenceVisible(undefined, 50)).toBe(false);
-      expect(resolvePresenceVisible(undefined, 500)).toBe(false);
+      const { resolvePresenceVisible, LARGE_CHANNEL_THRESHOLD } = await import(
+        "../lib/presenceFilter"
+      );
+      expect(resolvePresenceVisible(undefined, LARGE_CHANNEL_THRESHOLD)).toBe(false);
+      expect(resolvePresenceVisible(undefined, LARGE_CHANNEL_THRESHOLD * 10)).toBe(false);
     });
 
-    it("boundary is exactly LARGE_CHANNEL_THRESHOLD (49 shown, 50 hidden)", async () => {
+    it("boundary is exactly LARGE_CHANNEL_THRESHOLD: one below shown, at it hidden", async () => {
       const { resolvePresenceVisible, LARGE_CHANNEL_THRESHOLD } = await import(
         "../lib/presenceFilter"
       );
@@ -46,9 +54,13 @@ describe("presenceFilter module", () => {
     });
 
     it("explicit 'show' overrides the size default even on a huge channel", async () => {
-      const { resolvePresenceVisible } = await import("../lib/presenceFilter");
-      expect(resolvePresenceVisible("show", 100)).toBe(true);
-      expect(resolvePresenceVisible("show", 5000)).toBe(true);
+      const { resolvePresenceVisible, LARGE_CHANNEL_THRESHOLD } = await import(
+        "../lib/presenceFilter"
+      );
+      // Counts must sit ABOVE the threshold or the case degenerates: an unset
+      // pref would return true too and the override would go unconstrained.
+      expect(resolvePresenceVisible("show", LARGE_CHANNEL_THRESHOLD)).toBe(true);
+      expect(resolvePresenceVisible("show", LARGE_CHANNEL_THRESHOLD * 25)).toBe(true);
     });
 
     it("explicit 'hide' overrides the size default even on a tiny channel", async () => {
@@ -142,19 +154,22 @@ describe("presenceFilter module", () => {
 
   describe("channelPresenceVisible() — reactive wrapper reading the signal", () => {
     it("follows the size default when the pref is unset", async () => {
-      const { channelPresenceVisible } = await import("../lib/presenceFilter");
-      expect(channelPresenceVisible(key(), 10)).toBe(true);
-      expect(channelPresenceVisible(key(), 80)).toBe(false);
+      const { channelPresenceVisible, LARGE_CHANNEL_THRESHOLD } = await import(
+        "../lib/presenceFilter"
+      );
+      expect(channelPresenceVisible(key(), LARGE_CHANNEL_THRESHOLD - 1)).toBe(true);
+      expect(channelPresenceVisible(key(), LARGE_CHANNEL_THRESHOLD)).toBe(false);
     });
 
     it("reflects an explicit pin regardless of member count", async () => {
-      const { channelPresenceVisible, setChannelPresencePref } = await import(
-        "../lib/presenceFilter"
-      );
+      const { channelPresenceVisible, setChannelPresencePref, LARGE_CHANNEL_THRESHOLD } =
+        await import("../lib/presenceFilter");
+      // Both counts are chosen so the SIZE DEFAULT would answer the opposite —
+      // otherwise the pin would be indistinguishable from the default.
       setChannelPresencePref(key(), "hide");
       expect(channelPresenceVisible(key(), 3)).toBe(false);
       setChannelPresencePref(key(), "show");
-      expect(channelPresenceVisible(key(), 999)).toBe(true);
+      expect(channelPresenceVisible(key(), LARGE_CHANNEL_THRESHOLD)).toBe(true);
     });
   });
 
@@ -182,19 +197,23 @@ describe("presenceFilter module", () => {
     });
 
     it("suppressed kinds hidden when the channel hides presence, visible otherwise", async () => {
-      const { presenceRowVisible, setChannelPresencePref, clearChannelPresencePref } = await import(
-        "../lib/presenceFilter"
-      );
+      const {
+        presenceRowVisible,
+        setChannelPresencePref,
+        clearChannelPresencePref,
+        LARGE_CHANNEL_THRESHOLD,
+      } = await import("../lib/presenceFilter");
       // Small channel, pref unset → follow-size default → visible.
       expect(presenceRowVisible(key(), 3, "join")).toBe(true);
       // Large channel, pref unset → hidden by the size default.
-      expect(presenceRowVisible(key(), 80, "join")).toBe(false);
-      // Explicit hide on a tiny channel → hidden.
+      expect(presenceRowVisible(key(), LARGE_CHANNEL_THRESHOLD, "join")).toBe(false);
+      // Explicit hide on a tiny channel → hidden (unset would SHOW here, so
+      // the override is what the assertion pins).
       setChannelPresencePref(key(), "hide");
       expect(presenceRowVisible(key(), 3, "part")).toBe(false);
-      // Explicit show on a huge channel → visible.
+      // Explicit show on a huge channel → visible (unset would HIDE here).
       setChannelPresencePref(key(), "show");
-      expect(presenceRowVisible(key(), 999, "quit")).toBe(true);
+      expect(presenceRowVisible(key(), LARGE_CHANNEL_THRESHOLD, "quit")).toBe(true);
       clearChannelPresencePref(key());
     });
   });

--- a/cicchetto/src/__tests__/selection.test.ts
+++ b/cicchetto/src/__tests__/selection.test.ts
@@ -465,8 +465,8 @@ describe("selection store", () => {
   // settle event advances the cursor over them). The count and the pane MUST
   // reconcile to the ONE shared presence predicate (presenceRowVisible):
   // count over VISIBLE rows only. Explicit "hide" pin stands in for a large
-  // channel so we don't seed 50 members (flood/autokill risk in the e2e; the
-  // size-default math lives in presenceFilter.test.ts).
+  // channel so we don't seed LARGE_CHANNEL_THRESHOLD members (flood/autokill
+  // risk in the e2e; the size-default math lives in presenceFilter.test.ts).
   describe("presence-filter-hidden rows excluded from the badge (#239)", () => {
     it("hidden join/part do NOT count toward eventsUnread when the channel hides presence", async () => {
       localStorage.setItem("grappa-token", "tok");

--- a/cicchetto/src/lib/presenceFilter.ts
+++ b/cicchetto/src/lib/presenceFilter.ts
@@ -57,10 +57,17 @@ import { moduleRoot } from "./moduleRoot";
 // keeping this client-only — that was a mis-application: that memory is about
 // i18n, not display-pref persistence.)
 
-// "large" cutoff. Named constant, one-line tune. 50+ member channels drown
+// "large" cutoff. Named constant, one-line tune. 200+ member channels drown
 // in J/P/Q; smaller channels keep them visible. A channel whose live member
-// count crosses this while the pref is unset auto-flips.
-export const LARGE_CHANNEL_THRESHOLD = 50;
+// count crosses this while the pref is unset auto-flips. Raised from 50 to
+// 200 in #915: a 50-member channel does not drown, and auto-denoising it hid
+// traffic the operator wanted. MUST equal the server twin
+// `Grappa.PresenceFilter`'s `@large_channel_threshold` (lib/grappa/
+// presence_filter.ex) — the server applies the SAME size default to the REST
+// history fetch (#458), so a divergence makes page-up disagree with the live
+// tail on any channel sized between the two values. No gate pins them; the
+// two moduledocs cross-reference and that is the whole guard.
+export const LARGE_CHANNEL_THRESHOLD = 200;
 
 // The NARROW noise set — join/part/quit/nick_change ONLY. Deliberately NOT
 // ScrollbackPane's `PRESENCE_KINDS` (which also holds mode/topic/kick/

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -10627,8 +10627,11 @@ toggle re-shows; the choice persists. grappa STILL delivers the events —
 cic decides whether to RENDER. Client-only, no wire/server change (#217
 precedent + `feedback_no_localized_strings_server_side`).
 
-**Four defaults:** (1) "large" = `LARGE_CHANNEL_THRESHOLD = 50` members —
-ONE named constant in `lib/presenceFilter.ts`, one-line tune. (2) Toggle
+**Four defaults:** (1) "large" = `LARGE_CHANNEL_THRESHOLD` members — ONE
+named constant in `lib/presenceFilter.ts`, one-line tune. Set to 50 HERE;
+**raised to 200 by #915 (2026-08-06), which also found the constant had
+grown a server twin — read that entry for the value in force.** The
+constant is the SSOT; this number is the choice made on 2026-07-13. (2) Toggle
 scope = per-channel CLIENT preference, localStorage — NOT a server/shared
 setting. (3) NICK changes ARE in the suppression set. (4) Persistence
 keyed by `channelKey` — case-folds, so `#Chan`/`#chan` share one pref
@@ -10667,8 +10670,8 @@ onClick trips biome `noStaticElementInteractions` (#220 lesson) and loses
 keyboard access.
 
 **Tests.** `presenceFilter.test.ts` owns the size-default + precedence
-truth table. The size-default MATH is NOT e2e'd — 50 real peers from one
-IP risks bahamut flood/autokill
+truth table. The size-default MATH is NOT e2e'd — `LARGE_CHANNEL_THRESHOLD`
+real peers from one IP risks bahamut flood/autokill
 (`feedback_e2e_multinet_live_needs_distinct_nicks`) and there is no
 member-count seam in the harness; `issue222-presence-filter.spec.ts` owns
 the interactive path.
@@ -21466,8 +21469,12 @@ decision, server-owned, so every device converges.
 
 **SSOT + the mirrored threshold.** `Grappa.PresenceFilter.hidden?/2` is the
 inverted twin of cic's `resolvePresenceVisible` (show=visible ⇔ hidden=false);
-`@large_channel_threshold 50` mirrors cic's `LARGE_CHANNEL_THRESHOLD` and MUST
-stay equal (both moduledocs cross-reference). The suppressed set is a NARROW
+`@large_channel_threshold` mirrors cic's `LARGE_CHANNEL_THRESHOLD` and MUST
+stay equal. Set to 50 HERE, **raised to 200 by #915 (2026-08-06)** — read that
+entry for the value in force. At the time of this entry the equality was held by
+prose alone (both moduledocs cross-reference); #915 measured that nothing failed
+on drift and replaced the prose with an executable guard in
+`presence_filter_test.exs`. The suppressed set is a NARROW
 SSOT — `Message.suppressed_presence_kinds/0` = `[:join, :part, :quit,
 :nick_change]`, sitting beside `content_kinds`/`notify_kinds` — deliberately NOT
 the wider render-layer `PRESENCE_KINDS` (mode/topic/kick/server_event stay
@@ -21491,9 +21498,10 @@ render filter drops rows already in the store, for free. No import cycle
 table), `message_test.exs` (the narrow set), `scrollback_test.exs` (each fetch
 arity excludes the suppressed kinds under `hide_presence: true`),
 `messages_controller_test.exs` (hide / show / unset-no-session / channel
-canonicalization) + an outbound test proving unset + ≥50 members → hide (break-
-verified that it bites). cic: `displayPrefs.test.ts` asserts SHOW
-purges-then-reloads (with the order guard) and HIDE does neither. e2e
+canonicalization) + an outbound test proving unset + at-or-above
+`large_channel_threshold/0` members → hide (break-verified that it bites).
+cic: `displayPrefs.test.ts` asserts SHOW purges-then-reloads (with the order
+guard) and HIDE does neither. e2e
 (`issue458-presence-page-yield.spec.ts`) proves the visible-yield: a channel
 with many presence rows + few content rows, pref=hide, page-up renders a full
 screen of content instead of an empty page.
@@ -30734,3 +30742,25 @@ seed poll ATTEMPTS or pad MESSAGES, never members — none change meaning. The
 only member-count sources in the whole stack are `membersByChannel` (unit-
 mocked) and a live NAMES burst (`session_with_members`), and both already
 derive from the constant.
+
+**200 is a judgement call, not a measurement — and the guard is built for
+that.** Nobody produced a member-count distribution from prod or a J/P/Q-rate-
+versus-channel-size curve; vjt picked the number from operating the thing, the
+same way 50 was picked in #222. So the honest posture is that the VALUE is
+soft and the INVARIANT is hard: the drift guard pins the two languages EQUAL
+and deliberately does NOT pin 200, which means it survives him changing his
+mind again — the next tune stays two lines and one test that fails if you only
+do one of them. No gate in the repo asserts the cutoff is 200, and that is the
+design, not a hole.
+
+**The two entries above were corrected at the source, not annotated around.**
+#222 (2026-07-13) said `LARGE_CHANNEL_THRESHOLD = 50` and #458 (2026-07-28)
+said `@large_channel_threshold 50`; both now name the constant, record the
+value chosen THEN as the decision it was, and point here for the value in
+force. A decision log is a coherent record, not a caveat-wall: an old entry
+asserting a stale value as live is a false statement about the system that the
+next reader will cite — precisely how `numeric_router.ex`'s moduledoc, which
+asserted 321/322/323 take the default path, became the alibi that hid #910 for
+months. #458's line about the equality being held by "both moduledocs
+cross-reference" was also corrected: that WAS the mechanism, and this entry is
+where it stopped being.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -30679,3 +30679,58 @@ The banner is derived straight off the same map, so it restores the barrier
 in kind; `BannerSlot` exposes `data-banner-id` (the per-entry identity), which
 names the exact (network, channel) and is therefore a strictly tighter
 observation than the old `data-window-state="invited"`.
+
+---
+
+## 2026-08-06 — #915: the denoise cutoff is one number in two languages, and nothing was watching it
+
+> *"denoise va attivato in automatico dai chan con 200 persone in su. non 50 son
+> troppo pochi."* — vjt
+
+`LARGE_CHANNEL_THRESHOLD` moves 50 → 200. A 50-member channel does not drown in
+join/part/quit; auto-denoising it hid traffic the operator wanted. The decision
+is vjt's and the tune is one line — the work was everything the tune exposed.
+
+**It was never a cic-only change.** #458 gave the rule a server twin:
+`Grappa.PresenceFilter.@large_channel_threshold` (`lib/grappa/
+presence_filter.ex`) applies the SAME size default to the REST history fetch so
+`limit` counts VISIBLE rows, while cic keeps the render-layer filter for the
+live WS tail. Both moduledocs say the two MUST stay equal — and **nothing in
+the repo fails if they don't**. There is no drift guard: no test reads the
+`.ts` from Elixir, no codegen, no shared manifest. Two prose cross-references
+are the entire mechanism. Had this landed cic-only, every channel sized 50–199
+would have shown J/P/Q on the live tail and lost it on page-up, silently, with
+a green suite. Both constants move here.
+
+**The literals that would have passed on the opposite branch.** The issue
+claimed every reference already read the exported constant. Measured, it did
+not: `presenceFilter.test.ts` carried `49`, `50`, `80`, `100`. Two of those go
+RED at 200 and would have forced the edit anyway; the interesting one is
+`resolvePresenceVisible("show", 100)` under the name *"explicit 'show'
+overrides the size default even on a huge channel"* — at 200 that count is
+**small**, so an unset pref returns `true` as well and the assertion stops
+distinguishing the override from the default. Green, named for a property it no
+longer tests. Every count in that file now derives from the constant, and each
+"explicit pin" case is placed where the size default answers the OPPOSITE, so
+the pin is what the assertion pins. The Elixir side was already written this
+way throughout (`PresenceFilter.large_channel_threshold()`), which is why it
+needed no test edits at all.
+
+**The size default is unreachable from the e2e — before and after.** #222's own
+moduledoc records why: spawning that many nicks from one IP trips the bahamut
+same-host autokill, and the harness exposes no member-count seam to inflate
+membership. So the boundary was already gated by vitest alone at 50, and 200
+neither improves nor degrades that — the e2e owns the interactive toggle and
+persistence path, not the cutoff. The stale prose that said "50 members" in
+four places (`issue222`, `issue239`, `selection.test.ts`, and the
+`presenceFilter.test.ts` header) now names the constant instead: a comment
+carrying a number the code no longer holds is the alibi that stops the next
+reader from checking, which is exactly how #910's moduledoc bug survived.
+
+**Swept and settled, not skipped.** The four e2e loops flagged as suspicious
+(`issue211-phase6-matrix:95`, `issue211-phase7-multinet-reconnect:176,197`,
+`issue260-sticky-network-tab:162`, `marker-target-window-regression:132`) all
+seed poll ATTEMPTS or pad MESSAGES, never members — none change meaning. The
+only member-count sources in the whole stack are `membersByChannel` (unit-
+mocked) and a live NAMES burst (`session_with_members`), and both already
+derive from the constant.

--- a/lib/grappa/presence_filter.ex
+++ b/lib/grappa/presence_filter.ex
@@ -39,19 +39,23 @@ defmodule Grappa.PresenceFilter do
 
   use Boundary, top_level?: true, deps: [], exports: []
 
-  # MUST equal cic's `LARGE_CHANNEL_THRESHOLD` (presenceFilter.ts): 50+ member
+  # MUST equal cic's `LARGE_CHANNEL_THRESHOLD` (presenceFilter.ts): 200+ member
   # channels drown in join/part/quit, so an unset channel that has grown this
-  # large hides presence by the size default.
-  @large_channel_threshold 50
+  # large hides presence by the size default. Raised from 50 to 200 in #915 —
+  # a 50-member channel does not drown, and auto-denoising it hid traffic the
+  # operator wanted. Nothing FAILS if this drifts from cic's constant: the
+  # server would omit presence from the REST history page while cic renders it
+  # on the live tail, for every channel sized between the two values.
+  @large_channel_threshold 200
 
   @doc """
   The member-count cutoff for the unset size default. Exposed so callers and
-  tests reference the constant instead of hard-coding `50` (which would drift
-  from cic's `LARGE_CHANNEL_THRESHOLD` silently).
+  tests reference the constant instead of hard-coding its value (which would
+  drift from cic's `LARGE_CHANNEL_THRESHOLD` silently).
   """
-  # Constant accessor — Dialyzer narrows the success typing to the literal `50`,
+  # Constant accessor — Dialyzer narrows the success typing to the literal,
   # so the honest `pos_integer()` spec reads as a supertype. Keep the general
-  # spec (the value is a tunable, not a contract on `50`) and silence the noise.
+  # spec (the value is a tunable, not a contract on it) and silence the noise.
   @dialyzer {:nowarn_function, large_channel_threshold: 0}
   @spec large_channel_threshold() :: pos_integer()
   def large_channel_threshold, do: @large_channel_threshold

--- a/test/grappa/presence_filter_test.exs
+++ b/test/grappa/presence_filter_test.exs
@@ -37,4 +37,40 @@ defmodule Grappa.PresenceFilterTest do
       refute PresenceFilter.hidden?(nil, nil)
     end
   end
+
+  # #915 — the cutoff exists TWICE, once per language, and until now the ONLY
+  # thing holding the two equal was a sentence in each moduledoc. Every test on
+  # both sides derives from its own constant, so raising one alone leaves both
+  # suites fully green while the server omits presence from the REST history
+  # page and cic renders it on the live tail — for every channel sized between
+  # the two values, silently. Same executable-drift-guard shape as
+  # `GrappaWeb.RouterSwDenylistTest` (which parses `service-worker.ts`) and the
+  # `should_notify_parity_test.exs` shared truth table: the rule is expressed
+  # once per language, so the EQUALITY has to be expressed as code.
+  describe "cross-language threshold parity (#915)" do
+    @cic_path "cicchetto/src/lib/presenceFilter.ts"
+
+    test "@large_channel_threshold equals cic's LARGE_CHANNEL_THRESHOLD" do
+      source = File.read!(@cic_path)
+
+      cic_value =
+        case Regex.run(~r/export\s+const\s+LARGE_CHANNEL_THRESHOLD\s*=\s*(\d+)\s*;/, source) do
+          [_, digits] -> String.to_integer(digits)
+          _ -> flunk("Could not locate `export const LARGE_CHANNEL_THRESHOLD = <n>;` in #{@cic_path}")
+        end
+
+      assert cic_value == PresenceFilter.large_channel_threshold(),
+             """
+             The denoise size-default cutoff has drifted between the two languages.
+
+               #{@cic_path}: #{cic_value}
+               Grappa.PresenceFilter:            #{PresenceFilter.large_channel_threshold()}
+
+             They MUST be equal (#458 gave the render-layer rule a server twin for
+             the REST history fetch). While they differ, every channel whose member
+             count falls between the two values shows join/part/quit on the live WS
+             tail and loses it on page-up. Move BOTH or neither.
+             """
+    end
+  end
 end


### PR DESCRIPTION
## The decision

vjt: *"denoise va attivato in automatico dai chan con 200 persone in su. non 50 son troppo pochi."*
`LARGE_CHANNEL_THRESHOLD` 50 → 200. A 50-member channel does not drown in
join/part/quit; auto-denoising it hid traffic the operator wanted.

**200 is a judgement call, not a measurement.** I have no evidence that 200 is the right
number and did not look for any: no member-count distribution from prod, no J/P/Q-rate-
versus-channel-size curve. vjt picked it from operating the thing, the same way 50 was
picked in #222. Nothing in this PR should be read as implying the threshold was derived.
That is precisely why the drift guard below pins EQUALITY and not the value — it survives
him changing his mind again.

## It was not a cic-only change

The cutoff exists **twice**. #458 gave the render-layer rule a server twin —
`Grappa.PresenceFilter.@large_channel_threshold` (`lib/grappa/presence_filter.ex`)
applies the same size default to the REST history fetch so `limit` counts VISIBLE
rows, while cic keeps its filter for the live WS tail. Both moduledocs say the two
MUST stay equal, and **nothing in the repo failed if they didn't**.

Landing this cic-only would have made every channel sized 50–199 show J/P/Q on the
live tail and lose it on page-up, silently, with a fully green suite. Both constants
move here.

## Finding: an assertion that stopped distinguishing the override from the default

The issue states every reference already read the exported constant. Measured, it did
not — `presenceFilter.test.ts` carried `49`, `50`, `80`, `100`. Two go red at 200 and
would have forced the edit anyway. The dangerous one is the one that stays green:

```ts
it("explicit 'show' overrides the size default even on a huge channel", ...)
  expect(resolvePresenceVisible("show", 100)).toBe(true);
```

At 200 that count is **small**, so an unset pref returns `true` as well: the assertion
no longer distinguishes the OVERRIDE from the DEFAULT. Green, under a name for a
property it has stopped testing — the same class as #912.

Every count now derives from the constant, and each explicit-pin case is placed where
the size default answers the OPPOSITE, so the pin is what the assertion pins. The
Elixir side was already written this way throughout
(`PresenceFilter.large_channel_threshold()`) and needed no test edits.

## Finding: the suites constrain the RULE, not the VALUE

With everything derived, I put cic's constant back to 50 and re-ran the cic suite:
**4395 tests passed, 241 files, zero reds.** Nothing in either language would have
caught a wrong threshold. That measurement is the entire reason the drift guard exists.

So the equality is now code, in the shape the repo already uses for once-per-language
rules (`RouterSwDenylistTest` parses `service-worker.ts`;
`should_notify_parity_test.exs` shares a JSON truth table). It pins EQUALITY, not the
number, so no gate in this repo asserts the cutoff is 200 — that is the design, not a
hole.

Verified by displacement, not by its own green: with cic at 50 and the server at 200 the
guard fails alone, `6 tests, 1 failure`, printing `cicchetto/src/lib/presenceFilter.ts:
50` vs `Grappa.PresenceFilter: 200`.

## The sweep

The four flagged e2e loops (`issue211-phase6-matrix:95`,
`issue211-phase7-multinet-reconnect:176,197`, `issue260-sticky-network-tab:162`,
`marker-target-window-regression:132`) seed poll ATTEMPTS or pad MESSAGES, never
members — none change meaning. The only member-count sources in the stack are
`membersByChannel` (unit-mocked) and a live NAMES burst (`session_with_members`), both
already derived. Stale prose naming "50" in four places now names the constant.

**The size default is unreachable from the e2e, before and after.** #222's own moduledoc
records why: that many nicks from one IP trips the bahamut same-host autokill and the
harness exposes no member-count seam. The boundary was gated by vitest alone at 50 and
still is at 200 — no coverage lost, none gained.

## The decision log was corrected at the source

#222 (~10630) said `LARGE_CHANNEL_THRESHOLD = 50` and #458 (~21472) said
`@large_channel_threshold 50` / "≥50 members → hide". I had left both, reasoning that a
chronological log is superseded by its newest entry. Wrong: an old entry asserting a
stale value as live is a false statement the next reader cites instead of checking —
how `numeric_router.ex`'s moduledoc hid #910 for months. Both now name the constant,
keep the value chosen THEN as the decision it was, and point at the #915 entry for the
value in force. #458's "held equal because both moduledocs cross-reference" is corrected
too: that WAS the mechanism, until this PR measured that nothing failed on drift.

## Gates — rc files on the worker host, check them yourself

| gate | rc file | rc | log |
|---|---|---|---|
| `scripts/check.sh` (COMPILE lane) | `/tmp/w2-check.rc` | **0** | `/tmp/w2-check.log` |
| mutation: cic 50 / server 200 | `/tmp/w2-mut2.rc` | **2** (expected red) | `/tmp/w2-mut2.log` |
| restore + 3 threshold files | `/tmp/w2-restore.rc` | **0** | `/tmp/w2-restore.log` |
| `mix docs` (DESIGN_NOTES is an ExDoc extra) | `/tmp/w2-docs.rc` | **0** | `/tmp/w2-docs.log` |

`check.sh` detail: `8 doctests, 54 properties, 5273 tests, 0 failures`; Dialyzer
`Total errors: 0`; credo strict, sobelow, doctor, deps.audit, wire-types check clean;
bats `1..328`. Working tree porcelain-clean before AND after. Run detached with an
explicit `cd` into the worktree — the log's first line is `CWD=` for that reason.

cic gates: `bun run check` exit 0, `tsc --noEmit` standalone exit 0 clean,
`bun run test` 241 files / 4395 tests green.