### PR TITLE
cic(#914): a toggle to hide the »N jump-to-next-active button

### DIFF
--- a/cicchetto/e2e/tests/issue914-hide-next-active.spec.ts
+++ b/cicchetto/e2e/tests/issue914-hide-next-active.spec.ts
@@ -1,0 +1,118 @@
+// GH #914 — a Settings toggle that hides the #235 "jump to next active
+// window" (»N) button. Off by default; ONE preference governing BOTH
+// placements (desktop sidebar + mobile overlay).
+//
+// The preference is PRESENTATIONAL. `jumpToNextActiveWindow()` is shared with
+// the Alt+A keybinding and Ctrl+N — #235 keeps exactly one code path — so
+// hiding the button must not disable the verb. THAT is what the desktop test
+// exists to catch: after the button is gone, Alt+A must still jump. An
+// assertion that merely proves the button is absent would pass against a
+// broken build that also killed the keybinding.
+//
+// The mobile test cannot make that claim: there is no physical Alt+A chord on
+// a phone, so hiding the overlay deliberately leaves NO jump affordance —
+// which is precisely what the reporter asked for. It earns its place for a
+// different reason: the mobile button is a SEPARATE mount site (a viewport-
+// fixed overlay / ScrollbackPane float stack, #280), so it proves the one
+// preference reaches the other placement, not just the sidebar one.
+//
+// Seeding mirrors issue235-next-active-window.spec.ts: clear the autojoin
+// channel's baseline unread by focusing it, park focus on the neutral $server
+// window (outside the channel/query cycle), then have a peer DM the operator
+// so exactly ONE window — a tier-0 query — is unread. Waiting on the count
+// "1" also removes the seed race.
+
+import {
+  closeSettings,
+  loginAs,
+  openSettingsSection,
+  selectChannel,
+  sidebarWindow,
+  waitForDmListenerReady,
+} from "../fixtures/cicchettoPage";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+const DM_LINE = "914 direct message";
+
+const NEXT_ACTIVE_BTN = '[data-testid="next-active-btn"]';
+const NEXT_ACTIVE_COUNT = '[data-testid="next-active-btn"] .next-active-count';
+
+test.setTimeout(90_000);
+
+// Produce exactly one unread window (a tier-0 DM) with focus parked on
+// $server. Returns the connected peer so the caller can disconnect it.
+async function seedOneUnreadDm(
+  page: Parameters<typeof loginAs>[0],
+  peerNick: string,
+): Promise<IrcPeer> {
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+  await selectChannel(page, NETWORK_SLUG, NETWORK_SLUG, { awaitWsReady: false });
+  // The own-nick DM topic must be subscribed before the peer DMs, or the
+  // inbound broadcast fastlanes to zero subscribers (harness gotcha).
+  await waitForDmListenerReady(page, NETWORK_SLUG);
+
+  const peer = await IrcPeer.connect({ nick: peerNick });
+  peer.privmsg(NETWORK_NICK, DM_LINE);
+  await expect(sidebarWindow(page, NETWORK_SLUG, peerNick)).toBeVisible({ timeout: 10_000 });
+  return peer;
+}
+
+test("desktop: the toggle hides the button and Alt+A STILL jumps", async ({ page }) => {
+  const vjt = getSeededVjt();
+  const peerNick = "act914-d";
+  await loginAs(page, vjt);
+
+  const peer = await seedOneUnreadDm(page, peerNick);
+  try {
+    // Default (no stored preference) → the affordance renders, reporting the
+    // one unread window.
+    await expect(page.locator(NEXT_ACTIVE_COUNT)).toHaveText("1", { timeout: 10_000 });
+
+    // Off by default in the drawer too, then flip it ON.
+    await openSettingsSection(page, "display");
+    await expect(page.getByTestId("hide-next-active-toggle")).not.toBeChecked();
+    await page.getByTestId("hide-next-active-toggle").check();
+    await closeSettings(page);
+
+    // The button is gone while the window is STILL unread — i.e. hidden by the
+    // preference, not by #235's auto-hide.
+    await expect(page.locator(NEXT_ACTIVE_BTN)).toHaveCount(0, { timeout: 10_000 });
+    await expect(sidebarWindow(page, NETWORK_SLUG, peerNick)).not.toHaveClass(/selected/);
+
+    // THE assertion. The button is hidden; the verb must be untouched, so the
+    // keybinding still jumps to the unread DM window.
+    await page.keyboard.press("Alt+a");
+    await expect(sidebarWindow(page, NETWORK_SLUG, peerNick)).toHaveClass(/selected/, {
+      timeout: 10_000,
+    });
+  } finally {
+    await peer.disconnect("914 desktop done");
+  }
+});
+
+test("@webkit mobile: the same toggle hides the overlay placement", async ({ page }) => {
+  const vjt = getSeededVjt();
+  const peerNick = "act914-m";
+  await loginAs(page, vjt);
+
+  const peer = await seedOneUnreadDm(page, peerNick);
+  try {
+    await expect(page.locator(NEXT_ACTIVE_COUNT)).toHaveText("1", { timeout: 10_000 });
+
+    await openSettingsSection(page, "display");
+    await expect(page.getByTestId("hide-next-active-toggle")).not.toBeChecked();
+    await page.getByTestId("hide-next-active-toggle").check();
+    await closeSettings(page);
+
+    // Same single preference, other mount site: the overlay is gone while the
+    // DM window is still unread.
+    await expect(page.locator(NEXT_ACTIVE_BTN)).toHaveCount(0, { timeout: 10_000 });
+    await expect(sidebarWindow(page, NETWORK_SLUG, peerNick)).not.toHaveClass(/selected/);
+  } finally {
+    await peer.disconnect("914 mobile done");
+  }
+});

--- a/cicchetto/src/NextActiveButton.tsx
+++ b/cicchetto/src/NextActiveButton.tsx
@@ -5,6 +5,7 @@ import {
   jumpToNextActiveWindow,
   nextActiveKind,
 } from "./lib/activeWindows";
+import { getHideNextActive } from "./lib/hideNextActive";
 
 // GH #235 — the on-screen "jump to next active window" affordance
 // (irssi Alt+A). ONE component, placements selected by `variant`: the
@@ -21,6 +22,12 @@ import {
 // #280 — badge COLOR reflects the next target's tier via `nextActiveKind`:
 // RED (priority) for a mention/DM, BLUE (normal) for an ordinary channel.
 // Same single source as the count/auto-hide, so it can never diverge.
+//
+// #914 — `getHideNextActive()` ANDs into the same gate. It is PRESENTATIONAL:
+// it removes this button (both variants, one preference) and nothing else, so
+// Alt+A and Ctrl+N keep jumping through the untouched `jumpToNextActiveWindow`
+// verb. On mobile that leaves no jump affordance, which is the point of the
+// request. The pref is per-DEVICE and client-local — see lib/hideNextActive.
 
 export type Props = {
   variant: "desktop" | "mobile";
@@ -28,7 +35,7 @@ export type Props = {
 
 const NextActiveButton: Component<Props> = (props) => {
   return (
-    <Show when={hasActiveWindows()}>
+    <Show when={hasActiveWindows() && !getHideNextActive()}>
       <button
         type="button"
         class={`next-active-btn next-active-btn-${props.variant}`}

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -20,6 +20,7 @@ import { getColoredNicklist } from "./lib/colorNicklist";
 import { syncedSetColoredNicklist, syncedSetTimeFormat } from "./lib/displayPrefs";
 import { type FontSizeKey, getFontSize, setFontSize } from "./lib/fontSize";
 import { friendlyApiError } from "./lib/friendlyApiError";
+import { getHideNextActive, setHideNextActive } from "./lib/hideNextActive";
 import { detach, quit, updateIdentity } from "./lib/lifecycle";
 import { isAdmin, networks, user } from "./lib/networks";
 import { mirrorNotificationPrefs } from "./lib/notificationPrefs";
@@ -199,6 +200,13 @@ const SettingsDrawer: Component<Props> = (props) => {
     const on = (e.currentTarget as HTMLInputElement).checked;
     setColoredNicklistSig(on); // local signal for optimistic drawer UI
     syncedSetColoredNicklist(on); // #449 — local apply + server PUT
+  };
+
+  // #914 — no drawer-local mirror signal (unlike the nicklist row above):
+  // `getHideNextActive()` is already the module signal, so the checkbox binds
+  // straight to it and there is no second copy to keep in sync.
+  const onHideNextActiveChange = (e: Event) => {
+    setHideNextActive((e.currentTarget as HTMLInputElement).checked);
   };
 
   // #126 — detach: leave cic, KEEP the bouncer up. Persistent identities
@@ -1312,6 +1320,25 @@ const SettingsDrawer: Component<Props> = (props) => {
                     data-testid="colored-nicklist-toggle"
                   />
                   show colored nicklist
+                </label>
+              </fieldset>
+
+              {/* #914 — hide the #235 "jump to next active window" (»N)
+                button. Off by default. PRESENTATIONAL: it removes the button
+                in BOTH placements (desktop sidebar + mobile overlay) and
+                nothing else — Alt+A and Ctrl+N keep jumping. Client-local and
+                per-DEVICE, unlike the two synced rows above; the complaint is
+                the viewport-fixed mobile overlay. */}
+              <fieldset class="hide-next-active-fieldset">
+                <legend>jump button</legend>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={getHideNextActive()}
+                    onChange={onHideNextActiveChange}
+                    data-testid="hide-next-active-toggle"
+                  />
+                  hide the jump-to-next-active button
                 </label>
               </fieldset>
             </section>

--- a/cicchetto/src/__tests__/SettingsDrawer.test.tsx
+++ b/cicchetto/src/__tests__/SettingsDrawer.test.tsx
@@ -21,6 +21,11 @@ vi.mock("../lib/colorNicklist", () => ({
   setColoredNicklist: vi.fn(),
 }));
 
+vi.mock("../lib/hideNextActive", () => ({
+  getHideNextActive: vi.fn(() => false),
+  setHideNextActive: vi.fn(),
+}));
+
 const subjectHolder = vi.hoisted(() => ({
   current: null as
     | { kind: "user"; id: string; name: string }
@@ -375,6 +380,32 @@ describe("SettingsDrawer display options section (#443)", () => {
     openSub("display-settings-entry");
     fireEvent.click(screen.getByTestId("colored-nicklist-toggle"));
     expect(colorNicklist.setColoredNicklist).toHaveBeenCalledWith(true);
+  });
+
+  // #914 — the fourth fieldset. It is an append to the SAME display-options
+  // section, so it must land inside that block like its three siblings.
+  it("renders the hide-jump-button toggle inside the display-options section", () => {
+    wrap(true);
+    openSub("display-settings-entry");
+    const section = screen.getByTestId("settings-section-display");
+    expect(section.querySelector('[data-testid="hide-next-active-toggle"]')).not.toBeNull();
+  });
+
+  it("renders the hide-jump-button toggle unchecked by default", () => {
+    wrap(true);
+    openSub("display-settings-entry");
+    const toggle = screen.getByTestId("hide-next-active-toggle") as HTMLInputElement;
+    // getHideNextActive mock returns false → the #235 button keeps rendering
+    // for anyone who never touches this row (off by default).
+    expect(toggle.checked).toBe(false);
+  });
+
+  it("toggling the hide-jump-button checkbox fires setHideNextActive(true)", async () => {
+    const hideNextActive = await import("../lib/hideNextActive");
+    wrap(true);
+    openSub("display-settings-entry");
+    fireEvent.click(screen.getByTestId("hide-next-active-toggle"));
+    expect(hideNextActive.setHideNextActive).toHaveBeenCalledWith(true);
   });
 });
 

--- a/cicchetto/src/__tests__/hideNextActive.test.ts
+++ b/cicchetto/src/__tests__/hideNextActive.test.ts
@@ -1,0 +1,80 @@
+import { createEffect, createRoot } from "solid-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// #914 — "hide the jump-to-next-active button" display preference. Boolean,
+// OFF by default (current behaviour unchanged for anyone who does nothing).
+//
+// LOCAL, not server-backed: this is a per-DEVICE pref, the same class as
+// fontSize.ts, which `Grappa.UserSettings`'s display_prefs typedoc excludes
+// from the #449 sync on exactly that ground. The complaint behind #914 is the
+// viewport-fixed MOBILE overlay; syncing would blank the desktop sidebar
+// control on a device the user never complained about.
+//
+// It takes colorNicklist.ts's SHAPE (module-singleton signal + localStorage
+// write-through), not fontSize.ts's, because the flag is consumed at RENDER
+// time by NextActiveButton's <Show> gate — a bare localStorage read there
+// would not re-run on toggle.
+
+describe("hideNextActive module", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    localStorage.clear();
+  });
+
+  describe("getHideNextActive()", () => {
+    it("defaults to false when localStorage is empty", async () => {
+      const { getHideNextActive } = await import("../lib/hideNextActive");
+      expect(getHideNextActive()).toBe(false);
+    });
+
+    it("returns true when localStorage holds 'true'", async () => {
+      localStorage.setItem("cicchetto.hideNextActive", "true");
+      const { getHideNextActive } = await import("../lib/hideNextActive");
+      expect(getHideNextActive()).toBe(true);
+    });
+
+    it("returns false when localStorage holds 'false'", async () => {
+      localStorage.setItem("cicchetto.hideNextActive", "false");
+      const { getHideNextActive } = await import("../lib/hideNextActive");
+      expect(getHideNextActive()).toBe(false);
+    });
+
+    it("falls back to false when localStorage holds a non-boolean value", async () => {
+      localStorage.setItem("cicchetto.hideNextActive", "1");
+      const { getHideNextActive } = await import("../lib/hideNextActive");
+      expect(getHideNextActive()).toBe(false);
+    });
+  });
+
+  describe("setHideNextActive()", () => {
+    it("persists 'true' to localStorage when enabled", async () => {
+      const { setHideNextActive } = await import("../lib/hideNextActive");
+      setHideNextActive(true);
+      expect(localStorage.getItem("cicchetto.hideNextActive")).toBe("true");
+    });
+
+    it("persists 'false' to localStorage when disabled", async () => {
+      const { setHideNextActive } = await import("../lib/hideNextActive");
+      setHideNextActive(false);
+      expect(localStorage.getItem("cicchetto.hideNextActive")).toBe("false");
+    });
+
+    // The assertion that actually constrains the SHAPE. A plain
+    // `localStorage.getItem` getter passes every test above — including a
+    // set-then-get round-trip — while leaving the mounted <Show> gate stale
+    // forever. Only a TRACKED read proves the signal: the effect must re-run.
+    it("re-runs a tracked read, so the mounted gate re-renders on toggle", async () => {
+      const { getHideNextActive, setHideNextActive } = await import("../lib/hideNextActive");
+      const seen: boolean[] = [];
+      createRoot(() => {
+        createEffect(() => seen.push(getHideNextActive()));
+      });
+      await Promise.resolve();
+      expect(seen).toEqual([false]);
+
+      setHideNextActive(true);
+      await Promise.resolve();
+      expect(seen).toEqual([false, true]);
+    });
+  });
+});

--- a/cicchetto/src/lib/hideNextActive.ts
+++ b/cicchetto/src/lib/hideNextActive.ts
@@ -1,0 +1,62 @@
+import { createSignal } from "solid-js";
+import { moduleRoot } from "./moduleRoot";
+
+// #914 — "hide the jump-to-next-active button" display preference. Boolean,
+// OFF by default, so the #235 affordance keeps rendering for everyone who
+// never opens Settings.
+//
+// ## PRESENTATIONAL ONLY
+//
+// This flag gates the BUTTON, never the verb. `jumpToNextActiveWindow()` is
+// shared with the Alt+A keybinding and Ctrl+N (#235 keeps one code path), and
+// both must still jump while the button is hidden. On mobile that deliberately
+// leaves no jump affordance — that IS the request. Nothing here touches
+// `activeWindowCount()` / `nextActiveKind()`, so unread accounting is
+// unchanged and the count can never disagree with the auto-hide condition.
+//
+// ## LOCAL, not one of the #449 server-backed display prefs
+//
+// This diverges from the issue's suggested home (`lib/displayPrefs`). The
+// split already documented on `Grappa.UserSettings`'s `display_prefs` typedoc
+// is per-DEVICE stays client-local (fontSize.ts) vs device-neutral converges
+// across devices (time format, colored nicklist, presence filter). The
+// complaint behind #914 is the viewport-fixed MOBILE overlay; the desktop
+// sidebar control is not what anyone objected to. Syncing one preference
+// across both variants would blank the desktop button on a device the user
+// never complained about — a bigger, silent behaviour change than the one
+// asked for. Local → synced stays additive if that call is ever reversed;
+// synced → local would be a migration.
+//
+// ## colorNicklist.ts's SHAPE, not fontSize.ts's
+//
+// fontSize applies itself as a boot-time CSS-var write, so a plain
+// localStorage read suffices there. This flag is read at RENDER time inside
+// NextActiveButton's `<Show>` gate, so it needs a module-singleton Solid
+// signal: a bare `localStorage.getItem` in the render path would not re-run
+// when the setting changes and the mounted button would stay stale until a
+// reload.
+
+const STORAGE_KEY = "cicchetto.hideNextActive";
+const DEFAULT_HIDDEN = false;
+
+function readStored(): boolean {
+  const v = localStorage.getItem(STORAGE_KEY);
+  return v === null ? DEFAULT_HIDDEN : v === "true";
+}
+
+// Module-singleton signal seeded from storage. createRoot anchors it for the
+// app lifetime (same shape as colorNicklist.ts) — the preference is
+// identity-agnostic, so no token-rotation reset arm is needed.
+const { current, setCurrent } = moduleRoot(() => {
+  const [current, setCurrent] = createSignal<boolean>(readStored());
+  return { current, setCurrent };
+});
+
+export function getHideNextActive(): boolean {
+  return current();
+}
+
+export function setHideNextActive(on: boolean): void {
+  localStorage.setItem(STORAGE_KEY, on ? "true" : "false");
+  setCurrent(on);
+}

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -30764,3 +30764,69 @@ asserted 321/322/323 take the default path, became the alibi that hid #910 for
 months. #458's line about the equality being held by "both moduledocs
 cross-reference" was also corrected: that WAS the mechanism, and this entry is
 where it stopped being.
+
+## 2026-08-06 — #914: the jump button is per-DEVICE, so its pref stays out of the synced set
+
+#914 asked for a toggle hiding the #235 `»N` jump-to-next-active button, and
+proposed `lib/displayPrefs` as "the natural home". **It landed somewhere else,
+on purpose:** `cicchetto/src/lib/hideNextActive.ts`, client-local, localStorage
+plus a module signal. A future reader will find it sitting outside the synced
+set and reasonably suspect an oversight. It is not one.
+
+**The split already existed and this pref falls on the other side of it.**
+`Grappa.UserSettings`'s `display_prefs` typedoc records it: font size is
+"deliberately excluded — it is per-DEVICE (vjt, #449) and stays client-local".
+The three prefs that ARE synced (time format, colored nicklist, presence
+filter) have no device axis; #449 was filed because a desktop toggle stayed
+invisible on the iOS PWA, which is a convergence complaint about a
+device-NEUTRAL setting. #914 is the mirror image: the reporter is a phone user,
+and the thing complained about is the viewport-fixed MOBILE overlay. Nobody
+objected to the desktop sidebar control. One synced preference governing both
+variants would therefore blank the desktop button on a device the user never
+mentioned — a larger behaviour change than the one requested, applied
+silently. Device-shaped pref, device-local storage, same rule as `fontSize`.
+
+**The asymmetry decided the tie.** Local → synced is additive whenever someone
+wants convergence: add the key, seed up, done. Synced → local is a migration
+with a persisted blob to unwind. When the argument is close, take the branch
+that stays cheap to reverse. It is reversible in one review comment, which is
+why the divergence is stated in the PR body rather than buried.
+
+**Two consequences fell out in the same direction, and neither was the
+argument.** A fourth key needs an Elixir leg, and
+`validate_and_normalize_display_prefs/2` builds an explicit three-key whitelist
+— an unknown key is DROPPED, not rejected — so a cic shipped ahead of its
+server (they deploy separately, `deploy-m42.sh --cic`) would PUT the pref, get
+a 200, and have the reconcile's server-wins apply quietly reset it. That is the
+`wireNarrow` additive-field trap wearing the other hat, and it is guardable,
+but only if you remember to guard it. This was REASONED from the whitelist, not
+observed against an old server; it is recorded as a consequence of the choice,
+not evidence for it.
+
+**PRESENTATIONAL is the invariant, not the feature.** The pref ANDs into the
+existing `<Show>` gate and stops there. `jumpToNextActiveWindow()` is shared
+with Alt+A and Ctrl+N and #235 keeps exactly one code path, so hiding the
+button must never disarm the verb; `activeWindowCount()` / `nextActiveKind()`
+keep feeding the same single source, so unread accounting is untouched. On
+mobile the hidden button deliberately leaves no jump affordance — that IS the
+request, not a gap. A future change that gates the verb on this flag breaks the
+contract. The e2e asserts it directly and by name: button hidden, Alt+A still
+jumps to the unread DM. "The button is absent" would have passed against a
+build that also killed the keybinding.
+
+**Shape: `colorNicklist.ts`, not `fontSize.ts`.** Font size gets away with a
+plain localStorage read because it applies itself as a boot-time CSS-var write.
+This flag is read at RENDER time inside the gate, so it needs the
+module-singleton signal or a mounted button stays stale until reload. That
+distinction was MEASURED, not assumed: the module was first written the wrong
+way on purpose, and six of the seven unit assertions passed against it —
+including the set-then-get round-trip. Only the tracked-read assertion failed.
+
+**Which indicts a sibling test, left standing deliberately.**
+`colorNicklist.test.ts:54`, named "updates the reactive getter so subsequent
+reads reflect the change", is that same set-then-get round-trip: it does not
+constrain `colorNicklist`'s signal shape either. That module's reactivity is
+currently pinned only by `issue443-colored-nicklist.spec.ts` in a real browser.
+Recorded here rather than fixed in #914's diff — the finding is worth more than
+the two-line edit, and widening an unrelated PR to bury it is how findings get
+lost.


### PR DESCRIPTION
Issue #914. Adds an off-by-default display preference that hides the #235
`»N` jump-to-next-active button, in BOTH placements, without touching the
verb behind it.

## What changed

- `cicchetto/src/lib/hideNextActive.ts` — new boolean pref, module-singleton
  Solid signal + localStorage write-through.
- `NextActiveButton.tsx` — the pref ANDs into the existing gate:
  `<Show when={hasActiveWindows() && !getHideNextActive()}>`.
- `SettingsDrawer.tsx` — a fourth fieldset in the existing display-options
  section.
- Unit tests (7 + 3) and an e2e spec (desktop + `@webkit` mobile).

`jumpToNextActiveWindow()`, `activeWindowCount()` and `nextActiveKind()` are
untouched: the preference is presentational and unread accounting does not
change. Alt+A and Ctrl+N keep jumping with the button hidden. On mobile that
deliberately leaves no jump affordance — that is the request.

## Deliberate divergence from the issue: the pref is LOCAL, not synced

The issue proposes `lib/displayPrefs` (the #449 server-backed mechanism). **I
did not do that**, and this is the one decision worth a review comment.

`Grappa.UserSettings`'s `display_prefs` typedoc already draws the line, and
attributes it: per-DEVICE prefs stay client-local (`fontSize.ts` is excluded
from the sync on exactly that ground), device-neutral prefs converge
(timestamp format, colored nicklist, presence filter).

This one has a device dimension. The report is about the viewport-fixed
**mobile overlay**; nobody objected to the desktop sidebar control. #449 was
filed for the opposite complaint — a desktop toggle that stayed invisible on
the iOS PWA, i.e. a convergence gap on a pref with no device axis. Syncing one
preference across both variants here would blank the desktop button on a
device the user never complained about: a bigger behaviour change than the one
requested, made silently.

Reversal is cheap in one direction only, which is part of why it went this
way: local → synced is additive later, synced → local is a migration. Flip it
in one review comment if you disagree.

Two secondary consequences, both in favour: no Elixir leg (the server's
`validate_and_normalize_display_prefs/2` builds an explicit 3-key whitelist, so
a fourth key would need the server deployed *first* — a cic ships independently
via `--cic`, and an undeployed server silently drops the unknown key), and the
e2e toggles synchronously instead of racing a fire-and-forget PUT.

## Shape notes

- `colorNicklist.ts`'s shape, not `fontSize.ts`'s: the flag is read at RENDER
  time inside the gate, so a bare `localStorage.getItem` would leave a mounted
  button stale until reload.
- The Settings checkbox binds straight to the module signal. The nicklist row
  above it keeps a drawer-local mirror signal; that is a second copy of state
  that has to be kept in sync, so the new row does not copy it.
- No CSS: the three sibling fieldset classes carry no rules either, they are
  semantic hooks.

## Placement

No rearrangement. The display sub-page is one `settings-section-display` block
with three fieldsets; this is a uniform fourth append. The four-flat-controls
rearrangement mentioned in triage is the **push** sub-page — a different page.
Worth noting that the section already mixes local (`text size`) and synced
(`timestamp`, `nicklist`) prefs and the user cannot tell them apart.

## Test plan

- [x] `bun run test` — 242 files / 4431 tests, exit 0 (baseline 241 / 4421).
- [x] `tsc --noEmit` on `src` — exit 0.
- [x] `biome check src` — exit 0.
- [ ] e2e `issue914-hide-next-active.spec.ts` — **not executed**, see the
      comment below. Needs the exclusive stack lane.