### PR TITLE
irc(#910): route the LIST family by code, and stop the doc denying it

### DIFF
--- a/lib/grappa/session/numeric_router.ex
+++ b/lib/grappa/session/numeric_router.ex
@@ -27,9 +27,10 @@ defmodule Grappa.Session.NumericRouter do
      nick-shaped but the "nick" is not a routing destination — it's the
      rejected nick (433/432), the unknown command name (421), the
      offending command's argument list (461), an ack (437), or a whole
-     server-directed REPORT family whose middles are data and type labels
-     (`@stats_numerics` #184, `@trace_numerics` #908, the connect-storm
-     tokens). These ALWAYS go to `{:server, nil}`. Without this deny
+     server-directed REPORT family whose middles are data, type labels or
+     table headers (`@stats_numerics` #184, `@trace_numerics` #908,
+     `@list_numerics` #910, the connect-storm tokens). These ALWAYS go to
+     `{:server, nil}`. Without this deny
      list, the param-scan below would happily route 433's "BLEH-as-nick"
      to a query window.
 
@@ -63,11 +64,17 @@ defmodule Grappa.Session.NumericRouter do
     class). So the routing table can only be keyed by the CODE, which is
     what both lists already do — the deny list and an allow list differ
     only in which side the UNKNOWN falls on, and we currently put it on
-    the guessing side. Three families have now been patched in
-    (#184 STATS, UX-4 bucket I connect-storm, #908 TRACE) and the deny
-    list stands at 43 codes against the two or three the scan's query
-    branch genuinely serves (401 and the legacy 2-param shape) — that
-    ratio IS the argument. The root-cause fix is to invert: enumerate the
+    the guessing side. Four families have now been patched in
+    (#184 STATS, UX-4 bucket I connect-storm, #908 TRACE, #910 LIST) and
+    the deny list stands at 46 codes against the two or three the scan's
+    query branch genuinely serves (401 and the legacy 2-param shape) —
+    that ratio IS the argument, and #910 sharpened it: that family was
+    not found by a bug report but by a sweep, two years after this very
+    moduledoc asserted BY NUMBER that it already routed correctly. The
+    scan's default does not merely guess wrong, it guesses wrong
+    SILENTLY — so the families surface one accidental read at a time,
+    and the count above is a floor, not an inventory. The root-cause fix
+    is to invert: enumerate the
     target-bearing numerics and default the rest to `$server`. It is not
     done here because it changes behaviour for every numeric in neither
     list, and because #221's WHOIS-leg guard is defined as "a `:scan`-class
@@ -200,6 +207,40 @@ defmodule Grappa.Session.NumericRouter do
   # fix here neither causes nor repairs it.
   @trace_numerics Enum.to_list(200..210) ++ [261, 262]
 
+  # #910 — LIST reply family (321–323). The FOURTH instance of the
+  # @stats_numerics disease, and the one this module's own moduledoc used to
+  # deny: it asserted by NUMBER that 321/322/323 "route via the default
+  # `{:server, nil}` path". They did not.
+  #
+  # 321 RPL_LISTSTART — `[nick, "Channel", "Users  Name"]`. `params[1]` is
+  #     the literal COLUMN HEADER of the table that follows, and "Channel"
+  #     satisfies `Identifier.valid_nick?/1`, so the scan resolved it to
+  #     `{:query, "Channel"}`. LATENT rather than observed: #640's
+  #     `resolve_numeric_query_window/2` collapses a query decision back to
+  #     `$server` when no such window is open. It becomes real the moment a
+  #     peer nicked "Channel" has a DM window open.
+  # 322 RPL_LIST — `[nick, "#chan", "5", "topic"]`. The CHANNEL branch wins,
+  #     and unlike the query branch it passes #640's gate untouched: one
+  #     `:notice` row persisted into EVERY listed channel's scrollback,
+  #     including channels the user has never joined. This is the observable
+  #     defect of the three.
+  # 323 RPL_LISTEND — `[nick, "End of /LIST"]`. Already reached `$server`,
+  #     but only because the trailing carries SPACES and so fails
+  #     `valid_nick?/1` — the same accident that saved 262 RPL_ENDOFTRACE
+  #     above. Covered for the same reason: a family-wide rule must not rest
+  #     on how a server happens to spell its terminator. Unlike 262 (whose
+  #     dotless-server-name spelling is real, and made its test red), no
+  #     known ircd spells this trailing in a way that routes wrong today —
+  #     so 323's membership is pinned by the deny-list property test, not by
+  #     an assertion on its true wire shape.
+  #
+  # Reachable because these are normally consumed by `Session.Server`'s
+  # `%{directory_refresh: %{}}` clause, whose tracker the `#84` watchdog
+  # NILS on `:directory_refresh_timeout` — every late frame then falls
+  # through to the generic numeric path. `/quote LIST` never arms the
+  # tracker at all.
+  @list_numerics Enum.to_list(321..323)
+
   # #785 — the RFC error range (4xx command failures, 5xx server errors).
   # Distinct from `severity/1`'s `>= 400` cut, which also lands the 6xx
   # vendor replies on `:error`; absorption keys off the RANGE instead, so a
@@ -216,6 +257,7 @@ defmodule Grappa.Session.NumericRouter do
   @active_numerics MapSet.new(
                      @stats_numerics ++
                        @trace_numerics ++
+                       @list_numerics ++
                        [
                          # UX-4 bucket I (2026-05-19): connect-storm numerics
                          # whose middle params are server metadata (own ID,
@@ -343,14 +385,21 @@ defmodule Grappa.Session.NumericRouter do
                         # No-silent-drops B6.1 HIGH-3 (2026-05-14):
                         # LIST (321/322/323) numerics were previously
                         # listed as `:delegated` to a phantom EventRouter
-                        # handler. Removing them lets `param_derived_route/3`
-                        # fall through to `scan_params/2`, which routes them
-                        # via the default `{:server, nil}` path — Server's
-                        # numeric handler then persists them as plain
-                        # `:notice` rows on `$server` with
-                        # `meta.numeric/severity`. Visible, never silent.
-                        # (The cic /list directory UI consumes the REST
-                        # `directory` snapshot, not these numerics.)
+                        # handler, and removing them from this set was
+                        # right — the cic /list directory UI consumes the
+                        # REST `directory` snapshot, not these numerics.
+                        # What this note ASSERTED for the next two years was
+                        # not: it said the scan then routed them "via the
+                        # default `{:server, nil}` path". Only 323 did.
+                        # 321 scanned to `{:query, "Channel"}` and 322 to the
+                        # LISTED channel. #910 moved the family to
+                        # `@list_numerics` in the deny list, which is what
+                        # actually delivers the `$server` persist this note
+                        # claimed. The claim is kept here, corrected rather
+                        # than deleted, because a wrong doc about a family it
+                        # names by NUMBER is the alibi that stops the next
+                        # reader from checking — and it worked on three
+                        # later passes over this module.
                         #
                         # #238 — LINKS (364/365) took the OTHER branch of
                         # that contract: the cic /links topology UI wires a

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -3274,12 +3274,22 @@ defmodule Grappa.Session.Server do
   # `directory_complete`). The `%{directory_refresh: %{}}` head is
   # load-bearing: it matches ONLY when a refresh is in flight (the tracker
   # is a map). A `nil` tracker fails the map pattern, so the numerics fall
-  # through to the generic handler below and route to `$server` scrollback
-  # as before (manual /LIST) — same shape-match discrimination the C4
-  # watchdog uses (`%{directory_refresh: nil}` vs catch-all), sidestepping
-  # a `not is_nil/1` guard. While in-flight the dedicated handler CONSUMES
-  # them — they are NOT persisted (the snapshot is the durable record, the
-  # pings are the live signal).
+  # through to the generic handler below — same shape-match discrimination
+  # the C4 watchdog uses (`%{directory_refresh: nil}` vs catch-all),
+  # sidestepping a `not is_nil/1` guard. While in-flight the dedicated
+  # handler CONSUMES them — they are NOT persisted (the snapshot is the
+  # durable record, the pings are the live signal).
+  #
+  # #910 — this note used to finish that sentence with "and route to
+  # `$server` scrollback as before (manual /LIST)", the same false claim
+  # `NumericRouter`'s moduledoc made about the same three numbers. They did
+  # NOT all reach `$server`: 322 param-scanned to the LISTED channel and
+  # persisted a row into channels the user had never joined. This clause is
+  # precisely what made that reachable — the `:directory_refresh_timeout`
+  # watchdog below NILS the tracker, so every LATE frame of a stalled
+  # refresh falls out of here and into the scan. 321/322/323 are now in
+  # `NumericRouter`'s deny list, which is what makes the `$server` claim
+  # true; do not re-derive it from this clause's fall-through.
   def handle_info(
         {:irc, %Message{command: {:numeric, code}} = msg},
         %{directory_refresh: %{}} = state

--- a/test/grappa/session/directory_test.exs
+++ b/test/grappa/session/directory_test.exs
@@ -16,7 +16,7 @@ defmodule Grappa.Session.DirectoryTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.{ChannelDirectory, IRCServer, PubSub.Topic, Session}
+  alias Grappa.{ChannelDirectory, IRCServer, PubSub.Topic, Scrollback, Session}
   alias Grappa.Networks.{Credentials, SessionPlan}
 
   defp passthrough_handler, do: fn state, _ -> {:reply, nil, state} end
@@ -103,6 +103,54 @@ defmodule Grappa.Session.DirectoryTest do
     # `:sys.get_state` serializes AFTER the timeout handler returns, so the
     # in-flight tracker is guaranteed cleared by the time we read it.
     assert :sys.get_state(pid).directory_refresh == nil
+  end
+
+  # #910 — the timeout above is exactly what makes the LIST family's routing
+  # reachable, so the two belong in one file: once the watchdog nils the
+  # tracker, the `%{directory_refresh: %{}}` head in `Server.handle_info` no
+  # longer matches and every late frame falls into the generic numeric path.
+  # Pre-fix `NumericRouter`'s param scan took 322's LISTED channel for the
+  # reply's destination and persisted a `:notice` row into a channel the user
+  # has never joined. This test is the one that fails on the real wire; the
+  # `NumericRouterTest` cases pin the decision itself.
+  test "a 322 arriving after the watchdog fired lands on $server, not in the listed channel" do
+    {server, port} = start_server()
+    {user, network, _} = setup_user_and_network(port)
+
+    credential = Credentials.get_credential!(user, network)
+    {:ok, base_plan} = SessionPlan.resolve(credential)
+    plan = Map.put(base_plan, :directory_refresh_timeout_ms, 50)
+    {:ok, pid} = Session.start_session({:user, user.id}, network.id, plan)
+
+    on_exit(fn ->
+      _ = DynamicSupervisor.terminate_child(Grappa.SessionSupervisor, pid)
+    end)
+
+    :ok = await_handshake(server)
+    :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+    :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.channel(user.name, network.slug, "$server"))
+
+    assert :ok = Session.refresh_directory({:user, user.id}, network.id)
+
+    # Wait for the watchdog, not a sleep: the `directory_failed` ping is the
+    # instant the tracker went nil, which is the precondition under test.
+    assert_receive %Phoenix.Socket.Broadcast{
+                     event: "event",
+                     payload: %{kind: :directory_failed}
+                   },
+                   1_000
+
+    IRCServer.feed(server, ":irc.test 322 nick #elixir 1200 :The Elixir channel\r\n")
+
+    # The $server row arriving IS the barrier — the routing decision has been
+    # taken and persisted by the time this returns.
+    assert_receive %Phoenix.Socket.Broadcast{
+                     event: "event",
+                     payload: %{message: %{channel: "$server", body: "The Elixir channel"}}
+                   },
+                   1_000
+
+    assert Scrollback.fetch({:user, user.id}, network.id, "#elixir", nil, 10, nil, false) == []
   end
 
   test "a 322/323 burst fills and finalizes the snapshot" do

--- a/test/grappa/session/numeric_router_test.exs
+++ b/test/grappa/session/numeric_router_test.exs
@@ -166,10 +166,15 @@ defmodule Grappa.Session.NumericRouterTest do
   # #908 — TRACE reply family (200–210, 261–262) folded in: `params[1]` is
   # the reply TYPE token ("Operator", "Server", "Class", …), the third
   # instance of the #184 stats-letter disease.
+  # #910 — LIST reply family (321–323) folded in: 321's `params[1]` is the
+  # literal column header "Channel" and 322's is the LISTED channel, neither
+  # of which is a destination for the reply. This property is what pins the
+  # MEMBERSHIP of all three; the real-wire-shape tests below document what
+  # each one actually routed to pre-fix.
   @active_numerics [4, 42, 263, 421, 432, 433, 437, 461, 512, 734] ++
                      Enum.to_list(211..219) ++
                      Enum.to_list(240..250) ++
-                     Enum.to_list(200..210) ++ [261, 262]
+                     Enum.to_list(200..210) ++ [261, 262] ++ Enum.to_list(321..323)
 
   describe "@active_numerics deny list → {:server, nil}" do
     property "all @active_numerics route to {:server, nil} regardless of params" do
@@ -327,6 +332,47 @@ defmodule Grappa.Session.NumericRouterTest do
       m = msg(262, ["vjt", "services", "End of TRACE"])
       assert {:server, nil} = NumericRouter.route(m, state())
     end
+
+    # #910 — LIST reply family (321/322/323). Reachable whenever the
+    # `directory_refresh` tracker is nil: the watchdog nils it on
+    # `:directory_refresh_timeout` and every late frame then falls here, and
+    # `/quote LIST` never arms the tracker at all. The three shapes are
+    # DIFFERENT defects and only one of them was user-visible — see the
+    # per-test notes.
+    test "321 RPL_LISTSTART: the column header 'Channel' is NOT a query destination" do
+      # RFC 1459's header row, verbatim. `params[1]` is the literal string
+      # "Channel" — a column label — and it satisfies `valid_nick?/1`, so the
+      # scan resolved it to {:query, "Channel"}. LATENT, not observed: #640's
+      # `resolve_numeric_query_window/2` collapses the decision back to
+      # $server unless a query window with that nick is open. It stops being
+      # latent the moment the operator has a DM open with a peer nicked
+      # "Channel", who then receives the LIST header.
+      m = msg(321, ["vjt", "Channel", "Users  Name"])
+      assert {:server, nil} = NumericRouter.route(m, state())
+    end
+
+    test "322 RPL_LIST: a LISTED channel is not the reply's destination (#910 headline)" do
+      # The observable defect of the three. The channel branch outranks the
+      # query branch AND passes through #640's window-existence gate
+      # untouched, so a late/unsolicited LIST persisted one `:notice` row
+      # into EVERY listed channel's scrollback — including channels the user
+      # has never joined.
+      m = msg(322, ["vjt", "#chan", "42", "a channel topic"])
+      assert {:server, nil} = NumericRouter.route(m, state())
+    end
+
+    test "323 RPL_LISTEND: stays on $server, and no longer by accident" do
+      # Already reached $server pre-fix, but only because "End of /LIST"
+      # carries spaces and so fails `valid_nick?/1` — the same
+      # accident-of-spelling that 262 RPL_ENDOFTRACE was covered for above.
+      # Unlike 262 (where a dotless server name is a real wire shape that
+      # made the pre-fix test RED), every ircd checked spells this trailing
+      # with spaces, so THIS assertion passes before and after. The property
+      # above is what constrains 323's membership; this test documents the
+      # wire.
+      m = msg(323, ["vjt", "End of /LIST"])
+      assert {:server, nil} = NumericRouter.route(m, state())
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -477,14 +523,16 @@ defmodule Grappa.Session.NumericRouterTest do
     end
 
     # B6.1 HIGH-3 — LIST (321/322/323) used to be `:delegated` to a phantom
-    # EventRouter handler, dropping silently. Now it falls through to
-    # `scan_params` and routes to `$server` (or the channel-prefix param
-    # when present), so Server's numeric handler persists visible `:notice`
-    # rows. LINKS (364/365) took the OTHER branch — see the #238 delegation
-    # tests below.
-    test "322 RPL_LIST is no longer delegated; routes to channel param" do
+    # EventRouter handler, dropping silently. It is no longer delegated, and
+    # it is no longer param-scanned either: #910 moved the family to the
+    # active deny list, so the routing assertions live with the rest of that
+    # class above. This test USED to pin `{:channel, "#chan"}` for 322 and
+    # called that outcome the fix — it was the defect, written down as an
+    # expectation, which is how it outlived three later passes over this
+    # module. LINKS (364/365) took the OTHER branch — see the #238 tests.
+    test "322 RPL_LIST is not delegated (#910 routes it via the deny list)" do
       m = msg(322, ["vjt", "#chan", "42", "a channel topic"])
-      assert {:channel, "#chan"} = NumericRouter.route(m, state())
+      refute NumericRouter.route(m, state()) == :delegated
     end
 
     # #238 — LINKS (364/365) are delegated so EventRouter's links_bundle


### PR DESCRIPTION
## What

321/322/323 were `:scan`-class, so `scan_params/2` read their middle params as routing
destinations. They are now a fourth deny-list family, `@list_numerics` — same shape of cut
as #184 STATS and #908 TRACE.

The three are **three different defects**, and only one of them was user-visible. That
distinction is the substance of this PR, so it is spelled out rather than averaged:

| numeric | shape | pre-fix decision | actually observable? |
|---|---|---|---|
| 321 RPL_LISTSTART | `[nick, "Channel", "Users  Name"]` | `{:query, "Channel"}` | **No — latent.** |
| 322 RPL_LIST | `[nick, "#chan", "5", "topic"]` | `{:channel, "#chan"}` | **Yes.** |
| 323 RPL_LISTEND | `[nick, "End of /LIST"]` | `{:server, nil}` | Already correct. |

**322 is the real one.** The channel branch wins, and unlike the query branch it passes
#640's window-existence gate untouched, so an unsolicited LIST persisted one `:notice` row
into *every listed channel's* scrollback — including channels the user has never joined.

**321 is latent, and the issue I filed overstates it.** #910 says it opens "a query window
literally named `Channel`". It does not: `Server.resolve_numeric_query_window/2` (#640)
collapses a `{:query, _}` decision back to `$server` when no such window is open. The pure
classifier is still wrong and still worth fixing — the router is documented as a syntactic
classifier and #640 is a downstream net, not a licence — but the blast radius is "the
operator has a DM open with a peer nicked `Channel`", not "a ghost window on every /LIST".

**Reachability is the `directory_refresh` watchdog.** The family is normally consumed by
`Session.Server`'s `%{directory_refresh: %{}}` clause, but the #84 watchdog NILS that
tracker on `:directory_refresh_timeout`; every late frame of a stalled refresh then falls
into the scan. `/quote LIST` never arms the tracker at all. That timeout is injectable
(`directory_refresh_timeout_ms`), so this is covered by a real integration test, not only
by a unit test of the decision.

## The other half: the doc was wrong, and so was a test

`NumericRouter`'s moduledoc asserted **by number** that 321/322/323 "route via the default
`{:server, nil}` path".

Asked to check whether a doc wrong about a family it names by number was wrong only once —
it was not:

1. **`server.ex:3277` repeated the same claim in its own words**: with a nil tracker the
   numerics "route to `$server` scrollback as before (manual /LIST)". False for 321 and 322,
   and stated in the very clause whose fall-through creates the exposure. Corrected.
2. **A test asserted the defect.** `"322 RPL_LIST is no longer delegated; routes to channel
   param"` pinned `assert {:channel, "#chan"}` and framed that outcome as B6.1 HIGH-3's fix.
   That is why this survived: not just a doc nobody re-read, but a green assertion ratifying
   it. Inverted here.

Both docs are corrected **in place** rather than deleted — the wrong claim is kept as the
record of how the family hid.

The design note's count goes 43 → 46 and "three families" → four, because a stale number one
paragraph from where that exact disease is diagnosed is the disease.

## Audit findings — reported, NOT fixed (out of scope)

- **Moduledoc priority item 1 names 5 delegated families (~20 codes). The set holds 71.**
  Missing from the prose: LUSERS, WHOWAS, LINKS, BANLIST, INFO/VERSION, UMODEIS,
  channel-state, join-failures, presence/WATCH/MONITOR, and both WHOIS-leg blocks. It is
  not false line-by-line, but it reads as an enumeration and is not one.
- **Item 3 calls 437 ERR_UNAVAILRESOURCE "an ack".** It is an error numeric; the inline
  comment on the list itself says "nick temporarily unavailable".
- **Verified TRUE, since I was checking anyway:** "`labels_pending` is populated SOLELY by
  the away command" — all three `prepare_label/2` call sites are `set_explicit_away` /
  `unset_explicit_away`. #276's "delegation wins over the label override" argument still
  rests on solid ground. The pre-fix deny-list count of 43 also checks out (20 STATS + 13
  TRACE + 10 explicit).

## On the default, for @vjt — not decided here

The sharper framing is that deny-list and allow-list are the *same mechanism*: both are
code-keyed tables. Nothing about the deny list's shape is the smell; its **default** is. The
real question is which side an UNKNOWN numeric falls on.

#910 makes the case sharper in a specific way, and it is not the 43→46 ratio. It is that
**this family was not found by a bug report.** It was found by a sweep, two years after the
module's own doc said it was fine. The scan's default does not merely guess wrong — it
guesses wrong *silently*, so families surface one accidental read at a time and the count is
a floor, not an inventory. That is an argument about discoverability, which a ratio cannot
make. Your call, not taken in this PR.

## Verification

- **RED first:** `/tmp/w2-910-red.rc` = **2** — 4 failures: 322 real shape → `{:channel, "#chan"}`,
  321 real shape → `{:query, "Channel"}`, the deny-list property (sampled 321) →
  `{:query, "looks_like_a_nick"}`, and the integration test (no `$server` row).
- **GREEN after:** `/tmp/w2-910-green.rc` = **0** (3 properties, 72 tests).
- **Full gate:** `/tmp/w2-910-check.rc` = **0** — `8 doctests, 54 properties, 5289 tests, 0
  failures`; Dialyzer `Total errors: 0, Skipped: 0` / `done (passed successfully)`; doctor
  passed both envs; bats 328 ok. Tree porcelain-clean before and after.
- **Mutation measured, not assumed:** `/tmp/w2-910-mut323.rc` = **2** with 323 removed from
  `@list_numerics` — and only the membership property fails. See the comment below.