### PR TITLE
cic: make two test names earn what they claim (#921, #912)

### DIFF
--- a/cicchetto/src/__tests__/colorNicklist.test.ts
+++ b/cicchetto/src/__tests__/colorNicklist.test.ts
@@ -1,3 +1,4 @@
+import { createEffect, createRoot } from "solid-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // #443 — "show colored nicklist" display preference. Boolean, OFF by
@@ -56,6 +57,27 @@ describe("colorNicklist module", () => {
       expect(getColoredNicklist()).toBe(false);
       setColoredNicklist(true);
       expect(getColoredNicklist()).toBe(true);
+    });
+
+    // #921 — the assertion that actually constrains the SHAPE. Everything
+    // above, the set-then-get round-trip included, passes against a getter
+    // that is a plain `localStorage.getItem` — measured in #914, where the
+    // module was first written that way on purpose and 6 of 7 assertions
+    // stayed green. A non-reactive getter leaves the MOUNTED members pane
+    // monochrome until reload, which is the whole bug. Only a TRACKED read
+    // proves the signal: the effect has to re-run.
+    it("re-runs a tracked read, so a mounted nicklist re-renders on toggle", async () => {
+      const { getColoredNicklist, setColoredNicklist } = await import("../lib/colorNicklist");
+      const seen: boolean[] = [];
+      createRoot(() => {
+        createEffect(() => seen.push(getColoredNicklist()));
+      });
+      await Promise.resolve();
+      expect(seen).toEqual([false]);
+
+      setColoredNicklist(true);
+      await Promise.resolve();
+      expect(seen).toEqual([false, true]);
     });
   });
 });

--- a/cicchetto/src/__tests__/windowClose.test.ts
+++ b/cicchetto/src/__tests__/windowClose.test.ts
@@ -229,7 +229,21 @@ describe("dismissPseudoWindow — drops a pseudo-row, redirects if it was focuse
   // from EVERY window-state map (invited/failed/kicked alike), so the
   // backfill stops re-asserting it. The dismissal now mutates server
   // state — the invariant #511 restores.
-  it("PARTs the invited channel so the dismissal reaches the server and survives a reload (#511)", async () => {
+  //
+  // #912 — the name stops at what this test WITNESSES. It used to end in
+  // "and survives a reload", and it reloads nothing: durability is the client
+  // half COMPOSED with the server half (`PartCleanup.cleanup_local` →
+  // `WindowState.set_parted` → the cold-subscribe snapshot omits the key), and
+  // with `api` mocked no unit test can see past the call. What the call DOES
+  // pin is real — delete `postPart` from `partAndForget` and this reddens, so
+  // the client-only-dismiss regression dies here. The composition is witnessed
+  // only end-to-end, by `e2e/tests/issue511-failed-autojoin-dismiss-durable.spec.ts`
+  // (the `:failed` autojoin shape, through this same `partAndForget` DELETE —
+  // that file's header explains why the pseudo-row shape is vacuous there, and
+  // note #902 has since made `:invited` deliberately NON-durable). A unit name
+  // answering "yes" to "is #511's durability covered?" is how its previous e2e
+  // witness got deleted with nobody noticing.
+  it("calls postPart, so the dismissal reaches the server and not just the client (#511)", async () => {
     selectedChannelMock.mockReturnValue(null);
     const api = await import("../lib/api");
     const auth = await import("../lib/auth");


### PR DESCRIPTION
Two commits, one per issue. Same defect class: a test whose NAME promises a
property its assertions do not constrain. Test-only — production code is
byte-identical to `origin/main`.

## #921 — colorNicklist's unit suite passes a non-reactive rewrite

`"updates the reactive getter"` is a set-then-get round-trip, which does not
constrain the getter's shape. The measurement already existed: in #914,
`hideNextActive.ts` was written the wrong way on purpose and **6 of 7
assertions passed anyway**; only the tracked read died.

Reproduced here rather than argued. Rewriting `colorNicklist.ts` to a plain
`readStored()` getter with no module-singleton signal:

```
✓ defaults to false when localStorage is empty
✓ returns true when localStorage holds 'true'
✓ returns false when localStorage holds 'false'
✓ falls back to false when localStorage holds a non-boolean value
✓ persists 'true' to localStorage when enabled
✓ persists 'false' to localStorage when disabled
✓ updates the reactive getter so subsequent reads reflect the change
× re-runs a tracked read, so a mounted nicklist re-renders on toggle
Tests  1 failed | 7 passed (8)
```

7/8 green against a build that would leave a mounted members pane monochrome
until reload. The new assertion is the only one that dies. Module restored,
suite green.

## #912 — "survives a reload (#511)" reloads nothing

Renamed to `calls postPart, so the dismissal reaches the server and not just
the client (#511)`, with a comment pointing at the real composition witness,
`e2e/tests/issue511-failed-autojoin-dismiss-durable.spec.ts`.

Rename rather than deletion because the assertion underneath is load-bearing —
also measured, not assumed. Dropping `void postPart(...)` from `partAndForget`:

```
× PARTs the channel AND clears its windowState entry (475-failed +k autojoin)
× calls postPart, so the dismissal reaches the server and not just the client (#511)
Tests  2 failed | 8 passed (10)
```

The new name also drops the "invited" framing: #902 made `:invited` a banner
with a deliberately NON-durable ×, so naming this case after it would have
been a second false claim.

## Gates

- `scripts/bun.sh run check` — rc 0
- `tsc --noEmit` standalone — rc 0 (biome exits 0 on warnings here, but run
  separately so the `&&` cannot mask it)
- `scripts/bun.sh run test` — rc 0, **242 files / 4432 tests passed**

cic-only; no lane taken.

## No DESIGN_NOTES entry

Deliberate. The rationale is already recorded in the 2026-08-06 #914 entry
(#921 cites it); the per-test WHY belongs next to the assertion, and a second
copy in the decision log would be the duplicate that goes stale.

Refs #921, #912, #914, #902, #511.