### PR TITLE
irc(#911,#922): measure the numeric router's two class tables

### DIFF
--- a/lib/grappa/session/numeric_router.ex
+++ b/lib/grappa/session/numeric_router.ex
@@ -11,12 +11,27 @@ defmodule Grappa.Session.NumericRouter do
 
   Priority order (highest → lowest):
 
-  1. **Delegated**: away acks (305/306, #276), WHOIS (311–319),
-     WHO (352/315), NAMES (353/366), MOTD (375/372/376) — owned by
-     dedicated handlers in `EventRouter`. We return `:delegated`; the
-     caller skips the matrix. Delegation wins even over a matching label
-     (see `route/2` — `labels_pending` holds only away labels, so a
-     labeled away-ack must not resurrect the row #276 suppresses).
+  1. **Delegated**: numerics owned by dedicated handlers in
+     `EventRouter` (and, for a few terminal ones, `Session.Server`). We
+     return `:delegated`; the caller skips the matrix. Delegation wins
+     even over a matching label (see `route/2` — `labels_pending` holds
+     only away labels, so a labeled away-ack must not resurrect the row
+     #276 suppresses).
+
+     **The inventory is `@delegated_numerics` below, not this note
+     (#922).** An earlier revision named five families here — away acks,
+     WHOIS, WHO, NAMES, MOTD — reading as some twenty codes, against the
+     71 the attribute actually held. LUSERS, WHOWAS, LINKS, BANLIST,
+     INFO/VERSION, UMODEIS, INVITE-ack, channel-state, join-failure,
+     presence and BOTH WHOIS legs were all absent, and the "311–319"
+     range quietly swallowed 314 RPL_WHOWASUSER and 315 RPL_ENDOFWHO —
+     WHOWAS and WHO, not WHOIS. Under-describing the set is not merely
+     misleading: it invites the next reader to conclude a numeric is
+     unhandled and add a parallel path — the same alibi #910 found in
+     item 3 below, in this same moduledoc, about a family it named BY
+     NUMBER. So this note names no codes at all. The attribute's
+     per-family comment blocks are the authority; restating them is
+     precisely what drifted.
 
   2. **Label-based** (IRCv3 `labeled-response` cap): if the numeric carries
      a `label` message-tag AND the label is registered in `labels_pending`,

--- a/lib/grappa/session/numeric_router.ex
+++ b/lib/grappa/session/numeric_router.ex
@@ -43,8 +43,10 @@ defmodule Grappa.Session.NumericRouter do
      rejected nick (433/432), the unknown command name (421), the
      offending command's argument list (461), an ack (437), or a whole
      server-directed REPORT family whose middles are data, type labels or
-     table headers (`@stats_numerics` #184, `@trace_numerics` #908,
-     `@list_numerics` #910, the connect-storm tokens). These ALWAYS go to
+     table headers (`@stats_numerics` #184/#911, `@trace_numerics` #908,
+     `@list_numerics` #910, `@admin_numerics` / `@help_numerics` /
+     `@sasl_numerics` / `@monitor_list_numerics` #911, the connect-storm
+     tokens). These ALWAYS go to
      `{:server, nil}`. Without this deny
      list, the param-scan below would happily route 433's "BLEH-as-nick"
      to a query window.
@@ -79,16 +81,19 @@ defmodule Grappa.Session.NumericRouter do
     class). So the routing table can only be keyed by the CODE, which is
     what both lists already do — the deny list and an allow list differ
     only in which side the UNKNOWN falls on, and we currently put it on
-    the guessing side. Four families have now been patched in
-    (#184 STATS, UX-4 bucket I connect-storm, #908 TRACE, #910 LIST) and
-    the deny list stands at 46 codes against the two or three the scan's
-    query branch genuinely serves (401 and the legacy 2-param shape) —
-    that ratio IS the argument, and #910 sharpened it: that family was
-    not found by a bug report but by a sweep, two years after this very
-    moduledoc asserted BY NUMBER that it already routed correctly. The
+    the guessing side. The deny list has now outgrown the scan it
+    guards: it enumerates essentially every server-directed reply family
+    the two bound ircds define, against the two or three destinations
+    the query branch genuinely serves (401 and the legacy 2-param
+    shape). That ratio IS the argument, and #911 settled it. #910 was
+    already a sweep finding rather than a bug report; #911 stopped
+    sweeping one family at a time and read both ircds' numeric FORMAT
+    TABLES end to end, which turned up four more families at once —
+    including a STATS range this very note had named as a known gap and
+    then left alone for two years. The
     scan's default does not merely guess wrong, it guesses wrong
     SILENTLY — so the families surface one accidental read at a time,
-    and the count above is a floor, not an inventory. The root-cause fix
+    and no list assembled this way is ever an inventory. The root-cause fix
     is to invert: enumerate the
     target-bearing numerics and default the rest to `$server`. It is not
     done here because it changes behaviour for every numeric in neither
@@ -183,14 +188,30 @@ defmodule Grappa.Session.NumericRouter do
   # bogus DM named "o") that even leaked into Archive via list_archive's
   # `COALESCE(dm_with, channel)` — the exact disease as the 004/042
   # connect-storm ghost below. STATS is server-directed by definition →
-  # always `{:server, nil}`. We deny the full 211–219 / 240–250 range —
+  # always `{:server, nil}`. #184 denied the full 211–219 / 240–250 range —
   # the STATS reply set Azzurra's bahamut actually emits (characterized
   # across the STATS letters in #155) — not just the letter the report
   # named, so EVERY `/stats <x>` reply lands on `$server`, not only
   # `/stats o`. NB this is the observed range, not universal STATS
   # coverage: other ircds define STATS numerics in 220–239 too; add them
   # here if a bound network emits them.
-  @stats_numerics Enum.to_list(211..219) ++ Enum.to_list(240..250)
+  #
+  # #911 closed that hole by reading the table instead of guessing at it.
+  # A bound network DOES emit them: bahamut fills 222/223/224/225/227/229
+  # with `":%s NNN %s %c %s * %s %d %d"` — the SAME `%c` class letter #184
+  # was filed for — plus 226 `":%s 226 %s %s %l"` (a count label) and 228,
+  # whose candidate slot is the literal "S". Every one has a live emitter:
+  # 225 `s_serv.c:1727`, 226 `s_serv.c:1816`, 227 via the
+  # `report_conf_links` table at `s_serv.c:1474`, 228 `s_serv.c:1867`,
+  # 229 `s_serv.c:1936` (WEBIRC builds). solanum leads 220 and 225 with a
+  # `%c` too. So the range is now the contiguous 211–250.
+  #
+  # 221 RPL_UMODEIS is the one code in 211–250 that is not a STATS reply
+  # on either ircd — #229 delegates it — so it is subtracted here rather
+  # than left for `numeric_class/1`'s delegated-first order to mask. A
+  # code sitting in BOTH sets is a latent contradiction that reads as
+  # deliberate; the disjointness property in the test keeps it out.
+  @stats_numerics Enum.to_list(211..250) -- [221]
 
   # #908 — TRACE reply family (200–210, 261–262). The THIRD instance of the
   # @stats_numerics disease (#184's stats letter; UX-4 bucket I's
@@ -256,6 +277,112 @@ defmodule Grappa.Session.NumericRouter do
   # tracker at all.
   @list_numerics Enum.to_list(321..323)
 
+  # #911 — the four families below came out of an AUDIT, not a bug report.
+  # #184, #908 and #910 each started from one observed ghost window; this
+  # set came from reading the numeric FORMAT TABLES of both bound ircds
+  # end to end — azzurra/bahamut @ 3b6ccff `src/s_err.c` (Azzurra, all of
+  # prod) and solanum-ircd/solanum @ 115b1e2 `include/messages.h` (Libera,
+  # and the e2e testnet's second node). Each code is here because a table
+  # entry SAYS its candidate slot holds a label, a letter or a data blob,
+  # never because an RFC suggests it might. Rows the reading DISPROVED are
+  # recorded at the end of this block; a falsified row is the more useful
+  # half of an audit, because it is the evidence the rest were measured.
+
+  # ADMIN reply family (256–259). Server-directed by definition — it
+  # describes the SERVER's operator, and `m_admin` (bahamut
+  # `s_serv.c:2695`) answers with the A-line fields verbatim.
+  #
+  # 257/258/259 are `":%s 25N %s :%s"` on bahamut and `":%s"` on solanum:
+  # a TWO-param numeric whose only middle IS the trailing. That matters,
+  # because `candidate_params/1`'s 2-elem clause (B6.1 HIGH-4, added so a
+  # tail-less 401 still reaches its target's window) hands that trailing
+  # straight to the scan. So the routing destination of an ADMIN reply is
+  # whatever the operator typed into `admin { }`: a one-word dotless
+  # A-line — "Azzurra", "staff", a nick — resolves to `{:query, <that>}`.
+  # Nothing about the family says "conversation"; the exposure is purely
+  # that a config string happened to be nick-shaped.
+  #
+  # 256 RPL_ADMINME carries the server NAME and is saved today only by
+  # `query_candidate?/2`'s `.`-exclusion — the same accident that saved
+  # 262 RPL_ENDOFTRACE and 323 RPL_LISTEND. Covered for the same reason
+  # those two are: a family-wide rule must not rest on how a server
+  # happens to be spelled.
+  @admin_numerics Enum.to_list(256..259)
+
+  # HELP reply family (704–706, solanum; bahamut has no 7xx HELP). The
+  # topic token sits in `params[1]` on all three —
+  # `":%s 704 %s %s :%s"`, fed `topic` at `modules/m_help.c:116` and
+  # `:123` — so `/help join` on Libera scans "join" and resolves the
+  # reply to `{:query, "join"}`. Reachable by an ordinary user typing an
+  # ordinary command: no `/quote`, no watchdog race, no oper privilege.
+  # Of everything #911 measured this is the shortest path from a normal
+  # keystroke to a wrong-conversation row.
+  @help_numerics Enum.to_list(704..706)
+
+  # SASL reply family (900–908, solanum). Server-directed: these describe
+  # the CONNECTION's authentication, not a peer.
+  #
+  # 900 RPL_LOGGEDIN is `":%s 900 %s %s!%s@%s %s :You are now logged in
+  # as %s"` (`modules/m_services.c:158` passes the account twice). The
+  # first candidate `nick!user@host` fails `valid_nick?/1` on the `!`, so
+  # the scan falls to the second — the ACCOUNT NAME — and routes there
+  # whenever the account differs from the nick. #911 filed this row as
+  # "the reply itself never observed"; the shape is now read from source,
+  # and the account-vs-nick condition is the whole of its latency.
+  # 908 RPL_SASLMECHS puts the mech list in `params[1]`; a multi-mech list
+  # carries commas and fails `valid_nick?/1`, a single-mech server
+  # advertising a bare "PLAIN" does not.
+  #
+  # 901–907 are two-param with spacey trailings and route to `$server`
+  # today; they are covered so the family has no hole, the same call the
+  # contiguous TRACE range made for 207/210. 904 ERR_SASLFAIL never
+  # reaches this module at all — `Session.Server` intercepts it with a
+  # dedicated `handle_info` clause ahead of the generic numeric path — so
+  # its membership is inert by construction, not merely unobserved.
+  @sasl_numerics Enum.to_list(900..908)
+
+  # MONITOR list replies (732/733, solanum). Siblings of the #247
+  # presence family: 730/731 are delegated (typed presence effects) and
+  # 734 is already denied, which left the LIST pair as the only members
+  # still guessing. 732 RPL_MONLIST is `":%s 732 %s :%s"` — two-param
+  # again, trailing = the comma-separated monitored-target blob, so a
+  # single-entry list is a bare nick and routes into that peer's window.
+  # 733 carries a spacey terminator and is pinned by the deny-list
+  # property, not by an observed misroute — the 323 posture.
+  @monitor_list_numerics [732, 733]
+
+  # #911, the rows the reading DISPROVED — deliberately NOT denied. They
+  # are recorded because an audit that only lists its hits gives no way to
+  # tell measurement from confident guessing, and because a deny-list
+  # entry that cannot be made to fail is dead weight that reads as cover.
+  #
+  # 436 ERR_NICKCOLLISION was filed as "the twin of 432/433/437, which are
+  # already denied". It is not. Those three name a nick that is NOT you —
+  # the one you asked for and were refused. Every 436 emitter on both
+  # ircds passes the RECIPIENT's own name into `params[1]`
+  # (bahamut `m_nick.c:302/324/346/383`,
+  # `sendto_one(acptr, …, acptr->name, acptr->name)`; solanum
+  # `modules/core/m_nick.c:807` and `m_signon.c:326`,
+  # `sendto_one_numeric(target_p, …, target_p->name)`), so `nick_eq?/2`
+  # already collapses it to `$server`. Denying it would add an entry no
+  # test could ever redden.
+  #
+  # 303 RPL_ISON was filed as a `/quote`-reachable bare nick. Both ircds
+  # append a trailing SPACE after every name they add
+  # (bahamut `s_user.c:3437`, solanum `m_ison.c:101`
+  # `*current_insert_point++ = ' '`), `Parser.parse_params/2` keeps a
+  # trailing verbatim, and `valid_nick?/1` rejects the space — so even the
+  # single-hit reply that made the row plausible is `"nick "`, not `"nick"`.
+  #
+  # And the reachability half of the list shrank too: bahamut's table
+  # defines NO 900, 410, 704–706, 732 or 908. Every family added above
+  # except STATS and ADMIN is solanum-only, which is to say Libera-only —
+  # none of it can fire on Azzurra, where all of prod lives.
+  #
+  # STATS 220–239 went the other way: filed as "already flagged as a known
+  # gap in the moduledoc" and left uncounted, it turned out to be the one
+  # family the network we actually run emits today.
+
   # #785 — the RFC error range (4xx command failures, 5xx server errors).
   # Distinct from `severity/1`'s `>= 400` cut, which also lands the 6xx
   # vendor replies on `:error`; absorption keys off the RANGE instead, so a
@@ -273,6 +400,10 @@ defmodule Grappa.Session.NumericRouter do
                      @stats_numerics ++
                        @trace_numerics ++
                        @list_numerics ++
+                       @admin_numerics ++
+                       @help_numerics ++
+                       @sasl_numerics ++
+                       @monitor_list_numerics ++
                        [
                          # UX-4 bucket I (2026-05-19): connect-storm numerics
                          # whose middle params are server metadata (own ID,
@@ -314,6 +445,27 @@ defmodule Grappa.Session.NumericRouter do
                          # the delegated set below.
                          # 421 ERR_UNKNOWNCOMMAND — unknown IRC command issued
                          421,
+                         # #911 — 410 ERR_INVALIDCAPCMD (solanum,
+                         # `":%s 410 %s %s :Invalid CAP subcommand"`).
+                         # `params[1]` is the rejected CAP SUBCOMMAND
+                         # token — "FOO" for `/quote CAP FOO` — which is
+                         # exactly 421's relationship to a bad command
+                         # name, one layer down in the capability
+                         # negotiation. Denied for 421's reason, not a
+                         # new one.
+                         410,
+                         # #911 — 472 ERR_UNKNOWNMODE. `params[1]` is a
+                         # single mode CHARACTER
+                         # (`":%s 472 %s %c :is an unknown mode char to
+                         # me"`, both ircds), and `valid_nick?/1` accepts
+                         # a bare letter — the identical defect #184 was
+                         # filed for, with a mode letter in place of a
+                         # STATS letter. bahamut defines the entry but no
+                         # `src/` caller emits it; solanum emits it live
+                         # from `ircd/chmode.c:1380`, so `/mode #chan +Ω`
+                         # on Libera scans the offending letter and can
+                         # resolve to a one-character peer's window.
+                         472,
                          # 432 ERR_ERRONEUSNICKNAME — bad nick format in /nick
                          432,
                          # 433 ERR_NICKNAMEINUSE — nick taken in /nick

--- a/test/grappa/session/numeric_router_test.exs
+++ b/test/grappa/session/numeric_router_test.exs
@@ -171,10 +171,23 @@ defmodule Grappa.Session.NumericRouterTest do
   # of which is a destination for the reply. This property is what pins the
   # MEMBERSHIP of all three; the real-wire-shape tests below document what
   # each one actually routed to pre-fix.
-  @active_numerics [4, 42, 263, 421, 432, 433, 437, 461, 512, 734] ++
-                     Enum.to_list(211..219) ++
-                     Enum.to_list(240..250) ++
-                     Enum.to_list(200..210) ++ [261, 262] ++ Enum.to_list(321..323)
+  # #911 — the audit families. STATS grew to the contiguous 211–250 (less
+  # 221 RPL_UMODEIS, which is delegated), and ADMIN (256–259), HELP
+  # (704–706), SASL (900–908) and the MONITOR list pair (732/733) joined,
+  # alongside 410 ERR_INVALIDCAPCMD and 472 ERR_UNKNOWNMODE. Each was read
+  # out of a bound ircd's numeric FORMAT TABLE — azzurra/bahamut @ 3b6ccff
+  # `src/s_err.c` and solanum @ 115b1e2 `include/messages.h` — not out of
+  # an RFC. The per-family tests below carry the measured wire shape and
+  # the emitting file:line; this property pins the MEMBERSHIP.
+  @active_numerics [4, 42, 263, 410, 421, 432, 433, 437, 461, 472, 512, 734] ++
+                     (Enum.to_list(211..250) -- [221]) ++
+                     Enum.to_list(200..210) ++
+                     [261, 262] ++
+                     Enum.to_list(321..323) ++
+                     Enum.to_list(256..259) ++
+                     Enum.to_list(704..706) ++
+                     Enum.to_list(900..908) ++
+                     [732, 733]
 
   describe "@active_numerics deny list → {:server, nil}" do
     property "all @active_numerics route to {:server, nil} regardless of params" do
@@ -371,6 +384,126 @@ defmodule Grappa.Session.NumericRouterTest do
       # above is what constrains 323's membership; this test documents the
       # wire.
       m = msg(323, ["vjt", "End of /LIST"])
+      assert {:server, nil} = NumericRouter.route(m, state())
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #911 — the audit families. Every shape below is transcribed from the
+  # emitting ircd's own format table, and every one of these tests is RED
+  # without its deny-list entry: each family reaches the param scan on the
+  # unpatched module and resolves to {:query, <label>}. The two rows the
+  # audit DISPROVED (436 ERR_NICKCOLLISION, 303 RPL_ISON) get no test,
+  # precisely because they already reach $server — an assertion there would
+  # pass before and after, constraining nothing. See the "rows the reading
+  # DISPROVED" block in NumericRouter for why they evaporated.
+  # ---------------------------------------------------------------------------
+
+  describe "@active_numerics deny list — the #911 audit families" do
+    property "@active_numerics and @delegated_numerics are DISJOINT" do
+      # A code in both sets is masked by `numeric_class/1`'s
+      # delegated-first order, so it never misbehaves — it just reads as
+      # two deliberate and contradictory decisions. #911 made this real:
+      # extending STATS to the contiguous 211–250 swallows 221 RPL_UMODEIS,
+      # which #229 delegates. It is subtracted in production; this is what
+      # keeps it subtracted.
+      check all(numeric <- member_of(@active_numerics)) do
+        refute numeric in @delegated_numerics
+      end
+    end
+
+    test "225 RPL_STATSZLINE: the Z-line class letter is NOT a query destination" do
+      # bahamut `s_err.c:253` — `":%s 225 %s %c %s %s"` — emitted from
+      # `s_serv.c:1727`. The identical `%c` class letter #184 was filed
+      # for, sitting in the 220–239 hole #184's own note left open with
+      # "add them here if a bound network emits them". Azzurra does.
+      m = msg(225, ["vjt", "Z", "*@banned.example.org", "zapped"])
+      assert {:server, nil} = NumericRouter.route(m, state())
+    end
+
+    test "222 RPL_STATS*: the 220–239 hole closed as a RANGE, not per-letter" do
+      # bahamut `s_err.c:250` — `":%s 222 %s %c %s * %s %d %d"`. #184's
+      # lesson was that fixing only the letter that got reported leaves
+      # every sibling letter routing wrong; the same holds one range up.
+      m = msg(222, ["vjt", "B", "*", "host.example.org", "0", "0"])
+      assert {:server, nil} = NumericRouter.route(m, state())
+    end
+
+    test "221 RPL_UMODEIS is delegated — it is NOT swallowed by the STATS range" do
+      # The one code in 211–250 that is not a STATS reply on either ircd.
+      m = msg(221, ["vjt", "+iwS"])
+      assert :delegated = NumericRouter.route(m, state())
+    end
+
+    test "257 RPL_ADMINLOC1: a one-word A-line is NOT a query destination" do
+      # bahamut `s_err.c:295` — `":%s 257 %s :%s"` — fed `aconf->host`
+      # verbatim from `s_serv.c:2695`. TWO params, so
+      # `candidate_params/1`'s 2-elem clause (B6.1 HIGH-4) hands the
+      # trailing straight to the scan, and the reply's destination becomes
+      # whatever the operator typed into `admin { }`.
+      m = msg(257, ["vjt", "Azzurra"])
+      assert {:server, nil} = NumericRouter.route(m, state())
+    end
+
+    test "256 RPL_ADMINME: stays on $server even for a DOTLESS server name" do
+      # solanum shape — `"%s :Administrative info"`, so `params[1]` is the
+      # server name. Saved today only by `query_candidate?/2`'s
+      # `.`-exclusion, exactly like 262 RPL_ENDOFTRACE and 323 RPL_LISTEND.
+      m = msg(256, ["vjt", "services", "Administrative info"])
+      assert {:server, nil} = NumericRouter.route(m, state())
+    end
+
+    test "704 RPL_HELPSTART: the help TOPIC is NOT a query destination" do
+      # solanum `include/messages.h` — `":%s 704 %s %s :%s"` — with
+      # `topic` passed at `modules/m_help.c:116`. `/help join` on Libera:
+      # an ordinary command from an ordinary user, no `/quote`, no
+      # watchdog race, no oper bit. The shortest path #911 found from a
+      # normal keystroke to a wrong-conversation row.
+      m = msg(704, ["vjt", "join", "JOIN <channel> - join a channel"])
+      assert {:server, nil} = NumericRouter.route(m, state())
+    end
+
+    test "900 RPL_LOGGEDIN: the SASL ACCOUNT is NOT a query destination" do
+      # solanum — `":%s 900 %s %s!%s@%s %s :You are now logged in as %s"`,
+      # `modules/m_services.c:158`. `params[1]` is a nick!user@host mask
+      # and fails `valid_nick?/1` on the `!`, so the scan falls through to
+      # `params[2]` — the account name — and routes there whenever the
+      # account differs from the nick.
+      m = msg(900, ["vjt", "vjt!u@example.org", "marcello", "You are now logged in as marcello"])
+
+      assert {:server, nil} = NumericRouter.route(m, state())
+    end
+
+    test "908 RPL_SASLMECHS: a lone advertised mech is NOT a query destination" do
+      # `":%s 908 %s %s :are available SASL mechanisms"`. A multi-mech
+      # list carries commas and already fails `valid_nick?/1`; a server
+      # advertising a bare "PLAIN" does not.
+      m = msg(908, ["vjt", "PLAIN", "are available SASL mechanisms"])
+      assert {:server, nil} = NumericRouter.route(m, state())
+    end
+
+    test "732 RPL_MONLIST: a single monitored target is NOT the reply's destination" do
+      # `":%s 732 %s :%s"` — two params again, trailing = the
+      # comma-separated monitored-target blob, so a one-entry list IS a
+      # bare nick. The #640 gate does not save this one: you monitor the
+      # people you talk to, so that window is exactly the one that is open.
+      m = msg(732, ["vjt", "peer"])
+      assert {:server, nil} = NumericRouter.route(m, state())
+    end
+
+    test "410 ERR_INVALIDCAPCMD: the CAP subcommand is NOT a query destination" do
+      # `":%s 410 %s %s :Invalid CAP subcommand"` — 421's relationship to
+      # a bad command name, one layer down in capability negotiation.
+      m = msg(410, ["vjt", "FOO", "Invalid CAP subcommand"])
+      assert {:server, nil} = NumericRouter.route(m, state())
+    end
+
+    test "472 ERR_UNKNOWNMODE: the mode CHARACTER is NOT a query destination" do
+      # `":%s 472 %s %c :is an unknown mode char to me"` on both ircds;
+      # `valid_nick?/1` accepts a bare letter, so this is #184's stats
+      # letter with a mode letter in its place. bahamut defines the entry
+      # and never emits it; solanum emits it live from `ircd/chmode.c:1380`.
+      m = msg(472, ["vjt", "z", "is an unknown mode char to me"])
       assert {:server, nil} = NumericRouter.route(m, state())
     end
   end

--- a/test/grappa/session/numeric_router_test.exs
+++ b/test/grappa/session/numeric_router_test.exs
@@ -314,7 +314,6 @@ defmodule Grappa.Session.NumericRouterTest do
   # Active deny list: nick-shaped tokens that are NOT destinations
   # ---------------------------------------------------------------------------
 
-
   describe "@active_numerics deny list → {:server, nil}" do
     property "all @active_numerics route to {:server, nil} regardless of params" do
       check all(numeric <- member_of(@active_numerics)) do
@@ -649,7 +648,6 @@ defmodule Grappa.Session.NumericRouterTest do
   # ---------------------------------------------------------------------------
   # Delegated numerics → :delegated
   # ---------------------------------------------------------------------------
-
 
   describe "delegated numerics → :delegated" do
     property "all delegated numerics return :delegated" do

--- a/test/grappa/session/numeric_router_test.exs
+++ b/test/grappa/session/numeric_router_test.exs
@@ -526,17 +526,29 @@ defmodule Grappa.Session.NumericRouterTest do
   # ---------------------------------------------------------------------------
 
   describe "@active_numerics deny list — the #911 audit families" do
-    property "@active_numerics and @delegated_numerics are DISJOINT" do
-      # A code in both sets is masked by `numeric_class/1`'s
-      # delegated-first order, so it never misbehaves — it just reads as
-      # two deliberate and contradictory decisions. #911 made this real:
-      # extending STATS to the contiguous 211–250 swallows 221 RPL_UMODEIS,
-      # which #229 delegates. It is subtracted in production; this is what
-      # keeps it subtracted.
-      check all(numeric <- member_of(@active_numerics)) do
-        refute numeric in @delegated_numerics
-      end
-    end
+    # There is NO disjointness property here, and the absence is deliberate.
+    #
+    # #911 shipped one, on the reasoning that extending STATS to a
+    # contiguous 211–250 swallows delegated 221 RPL_UMODEIS and something
+    # ought to pin the subtraction. Mutation testing killed it: putting 221
+    # back into production's `@active_numerics` left the whole file GREEN.
+    # The property compared the two MIRRORS in this file against each other,
+    # so it could only ever restate an invariant the test file already
+    # satisfied by construction — a green that constrained nothing.
+    #
+    # It cannot be repaired behaviourally either, and that is the real
+    # finding. `numeric_class/1` checks delegated FIRST, so a code sitting
+    # in both sets is INDISTINGUISHABLE through `route/2` from a code
+    # sitting in delegated alone. Double-membership has no observable
+    # consequence; it is an intent defect, not a behaviour defect, and no
+    # test driven through the public API can see it.
+    #
+    # What IS pinned: the "221 RPL_UMODEIS is delegated" test below fails if
+    # 221 ever drops out of `@delegated_numerics` while the STATS range
+    # covers it, and the deny property above fails if a delegated code is
+    # added to the deny mirror in step with production. The subtraction
+    # itself rests on the comment in `NumericRouter`, and this note is here
+    # so the next reader does not re-add the same reassuring green.
 
     test "225 RPL_STATSZLINE: the Z-line class letter is NOT a query destination" do
       # bahamut `s_err.c:253` — `":%s 225 %s %c %s %s"` — emitted from

--- a/test/grappa/session/numeric_router_test.exs
+++ b/test/grappa/session/numeric_router_test.exs
@@ -379,6 +379,15 @@ defmodule Grappa.Session.NumericRouterTest do
   # Delegated numerics → :delegated
   # ---------------------------------------------------------------------------
 
+  # #922 — this mirror is EXHAUSTIVE, and that is load-bearing. It used to
+  # hold 44 of the router's 71 delegated codes, so the property below
+  # asserted delegation for barely three fifths of the set: UMODEIS,
+  # INVITE-ack, LUSERS, presence and the whole bahamut WHOIS-leg family
+  # could all have been dropped from production with every test still
+  # green. The same undercount #922 found in the moduledoc, one layer
+  # down — a mirror that mirrors PART of the thing is worse than none,
+  # because it reads as coverage. A code added to `@delegated_numerics`
+  # MUST be added here too.
   @delegated_numerics [
     # #276 — away acks. RPL_UNAWAY (305) / RPL_NOWAWAY (306) are owned by
     # EventRouter's away_confirmed handler (fires the typed away STATE
@@ -456,7 +465,46 @@ defmodule Grappa.Session.NumericRouterTest do
     # leaks the trailing set-timestamp as a bare `:notice` row — same
     # disease as 333.
     367,
-    368
+    368,
+    # ---- added by #922: the 27 codes this mirror had drifted away from ----
+    # #229 — 221 RPL_UMODEIS (EventRouter parses the umode string into
+    # the per-session set and emits {:umode_changed, modes}).
+    221,
+    # 341 RPL_INVITING — INVITE ack.
+    341,
+    # LUSERS bundle.
+    251,
+    252,
+    253,
+    254,
+    255,
+    265,
+    266,
+    # P-0a — the bahamut/Azzurra WHOIS legs EventRouter folds into
+    # whois_pending (275 SSL, 301 AWAY, 307 regnick, 308/309 admin,
+    # 310 helper, 316 chanop, 325 agent, 326 modes, 339 java,
+    # 378 actually).
+    275,
+    301,
+    307,
+    308,
+    309,
+    310,
+    316,
+    325,
+    326,
+    339,
+    378,
+    # #247 — /notify presence numerics (MONITOR 730/731, WATCH 600–605).
+    # The ERROR numerics 512/734 are NOT here: they stay on the deny list
+    # so their raw text persists on $server.
+    730,
+    731,
+    600,
+    601,
+    602,
+    604,
+    605
   ]
 
   describe "delegated numerics → :delegated" do

--- a/test/grappa/session/numeric_router_test.exs
+++ b/test/grappa/session/numeric_router_test.exs
@@ -37,6 +37,183 @@ defmodule Grappa.Session.NumericRouterTest do
   end
 
   # ---------------------------------------------------------------------------
+  # Mirrors of NumericRouter's two class tables.
+  #
+  # Hoisted above every describe (#911) because a THIRD hand-maintained copy
+  # of these sets had grown below — the channel-prefix property's "codes that
+  # short-circuit before the param scan" exclusion — and it drifted the way
+  # the other two did. It is derived from these now. Module attributes read
+  # in SOURCE ORDER, so the definitions have to come first for that to work.
+  # ---------------------------------------------------------------------------
+
+  # Mirror of NumericRouter's @active_numerics. #184 folded the STATS
+  # reply family (211–219 RPL_STATS* + RPL_ENDOFSTATS, 240–250) in — the
+  # stats letter (`/stats o` → 219 `[nick, "o", "End of /STATS report"]`)
+  # is a nick-shaped metadata token, NOT a query destination.
+  # #276 — 305/306 moved OUT of the active deny list into
+  # @delegated_numerics: RPL_UNAWAY / RPL_NOWAWAY are pure away-state
+  # acks owned by EventRouter's away_confirmed handler and must NEVER
+  # persist a scrollback row (the away STATE is the signal, the numeric
+  # is noise). See the delegated-numerics section below.
+  # #247 — 512/734 presence-watch list-full errors folded in: nick-shaped
+  # token (watched nick / rejected MONITOR target) that is metadata, not a
+  # query destination. The EventRouter toast is transient; the raw numeric
+  # must land on $server (durable "list full" record).
+  # #908 — TRACE reply family (200–210, 261–262) folded in: `params[1]` is
+  # the reply TYPE token ("Operator", "Server", "Class", …), the third
+  # instance of the #184 stats-letter disease.
+  # #910 — LIST reply family (321–323) folded in: 321's `params[1]` is the
+  # literal column header "Channel" and 322's is the LISTED channel, neither
+  # of which is a destination for the reply. This property is what pins the
+  # MEMBERSHIP of all three; the real-wire-shape tests below document what
+  # each one actually routed to pre-fix.
+  # #911 — the audit families. STATS grew to the contiguous 211–250 (less
+  # 221 RPL_UMODEIS, which is delegated), and ADMIN (256–259), HELP
+  # (704–706), SASL (900–908) and the MONITOR list pair (732/733) joined,
+  # alongside 410 ERR_INVALIDCAPCMD and 472 ERR_UNKNOWNMODE. Each was read
+  # out of a bound ircd's numeric FORMAT TABLE — azzurra/bahamut @ 3b6ccff
+  # `src/s_err.c` and solanum @ 115b1e2 `include/messages.h` — not out of
+  # an RFC. The per-family tests below carry the measured wire shape and
+  # the emitting file:line; this property pins the MEMBERSHIP.
+  @active_numerics [4, 42, 263, 410, 421, 432, 433, 437, 461, 472, 512, 734] ++
+                     (Enum.to_list(211..250) -- [221]) ++
+                     Enum.to_list(200..210) ++
+                     [261, 262] ++
+                     Enum.to_list(321..323) ++
+                     Enum.to_list(256..259) ++
+                     Enum.to_list(704..706) ++
+                     Enum.to_list(900..908) ++
+                     [732, 733]
+
+  # #922 — this mirror is EXHAUSTIVE, and that is load-bearing. It used to
+  # hold 44 of the router's 71 delegated codes, so the property below
+  # asserted delegation for barely three fifths of the set: UMODEIS,
+  # INVITE-ack, LUSERS, presence and the whole bahamut WHOIS-leg family
+  # could all have been dropped from production with every test still
+  # green. The same undercount #922 found in the moduledoc, one layer
+  # down — a mirror that mirrors PART of the thing is worse than none,
+  # because it reads as coverage. A code added to `@delegated_numerics`
+  # MUST be added here too.
+  @delegated_numerics [
+    # #276 — away acks. RPL_UNAWAY (305) / RPL_NOWAWAY (306) are owned by
+    # EventRouter's away_confirmed handler (fires the typed away STATE
+    # effect); the numeric itself is content-free noise that must NEVER
+    # persist as a scrollback row. Delegated so Server.handle_info routes
+    # them via `delegate/2` (EventRouter only, no notice persist).
+    305,
+    306,
+    # WHOIS / WHO / NAMES / MOTD (pre-CP15)
+    311,
+    312,
+    313,
+    317,
+    318,
+    319,
+    352,
+    315,
+    353,
+    366,
+    # No-silent-drops B6.1 HIGH-3 (2026-05-14): LIST (321/322/323)
+    # REMOVED from @delegated_numerics (no EventRouter handler; the cic
+    # directory UI consumes the REST snapshot). #238 — LINKS (364/365)
+    # took the OTHER branch: a dedicated EventRouter clause now folds them
+    # into a :links_bundle, so they ARE delegated (added below).
+    364,
+    365,
+    375,
+    372,
+    376,
+    # #127 — MOTD 422 ERR_NOMOTD + INFO (371/374) + VERSION (351) delegated
+    # so the EventRouter #127 clauses own them (drain a server_reply modal
+    # when the matching command primed the session; $server persist when not).
+    # #374 — 402 ERR_NOSUCHSERVER joins the MOTD family: the terminator for
+    # `/motd <target>` to an unknown server, drained by the same clause.
+    422,
+    402,
+    371,
+    374,
+    351,
+    # CP15 B2 — JOIN failure numerics (EventRouter handles them now)
+    471,
+    473,
+    474,
+    475,
+    403,
+    405,
+    # Channel-state numerics (EventRouter caches into state.topics /
+    # state.channel_modes / state.channels_created — must be delegated
+    # so Server.handle_info doesn't double-persist them as `:notice`
+    # rows with body=trailing-param (which for 333 leaks the unix_ts
+    # as user-visible noise).
+    324,
+    329,
+    331,
+    332,
+    333,
+    # P-0c — WHOWAS bundle (314, 369, 406). 312 already in the WHOIS
+    # leg above; the EventRouter conflict-gates between whois_pending
+    # and whowas_pending so 312 still routes correctly.
+    314,
+    369,
+    406,
+    # #221 — solanum (Libera.Chat) WHOIS-leg numerics. EventRouter folds
+    # them into the whois_pending accumulator (typed 330/338/671/276,
+    # free-form 320, bot 335). Source: solanum include/numeric.h @ a4998b5.
+    276,
+    320,
+    330,
+    335,
+    338,
+    671,
+    # #376 — BANLIST bundle (367 RPL_BANLIST, 368 RPL_ENDOFBANLIST).
+    # EventRouter accumulates {mask, setter, set_ts} per 367 and emits
+    # :banlist_bundle on 368. Without delegation the param-derived scan
+    # leaks the trailing set-timestamp as a bare `:notice` row — same
+    # disease as 333.
+    367,
+    368,
+    # ---- added by #922: the 27 codes this mirror had drifted away from ----
+    # #229 — 221 RPL_UMODEIS (EventRouter parses the umode string into
+    # the per-session set and emits {:umode_changed, modes}).
+    221,
+    # 341 RPL_INVITING — INVITE ack.
+    341,
+    # LUSERS bundle.
+    251,
+    252,
+    253,
+    254,
+    255,
+    265,
+    266,
+    # P-0a — the bahamut/Azzurra WHOIS legs EventRouter folds into
+    # whois_pending (275 SSL, 301 AWAY, 307 regnick, 308/309 admin,
+    # 310 helper, 316 chanop, 325 agent, 326 modes, 339 java,
+    # 378 actually).
+    275,
+    301,
+    307,
+    308,
+    309,
+    310,
+    316,
+    325,
+    326,
+    339,
+    378,
+    # #247 — /notify presence numerics (MONITOR 730/731, WATCH 600–605).
+    # The ERROR numerics 512/734 are NOT here: they stay on the deny list
+    # so their raw text persists on $server.
+    730,
+    731,
+    600,
+    601,
+    602,
+    604,
+    605
+  ]
+
+  # ---------------------------------------------------------------------------
   # Param scan: channel-prefix wins
   # ---------------------------------------------------------------------------
 
@@ -80,35 +257,22 @@ defmodule Grappa.Session.NumericRouterTest do
     property "any channel-prefix in any candidate position wins over later params" do
       check all(
               numeric <- integer(400..499),
-              # Pre-CP13 active/deny + CP15 B2 join-failure delegated codes
-              # + channel-state numerics (324/329/331/332/333 delegated post
-              # cluster `channel-created-notice`) + P-0c WHOWAS not-found
-              # (406 delegated post numeric-delegation-p0) + #127 MOTD
-              # 422 ERR_NOMOTD + #374 402 ERR_NOSUCHSERVER (both delegated to
-              # the server-reply modal clause) short-circuit before the param
-              # scan; exclude all classes so the property exercises the
-              # channel-prefix fallthrough only.
-              numeric not in [
-                421,
-                432,
-                433,
-                437,
-                461,
-                471,
-                473,
-                474,
-                475,
-                403,
-                405,
-                324,
-                329,
-                331,
-                332,
-                333,
-                406,
-                422,
-                402
-              ],
+              # Deny-listed and delegated codes short-circuit ahead of the
+              # param scan, so they are excluded and the property exercises
+              # the channel-prefix fallthrough only.
+              #
+              # #911 — DERIVED, not restated. This used to be a hand-written
+              # list of the nineteen 4xx codes that were short-circuiting at
+              # the time, and it was the third hand-maintained mirror of the
+              # class tables in this file. It went red the moment #911 added
+              # 410 and 472 — correctly red, and for a reason that had
+              # nothing to do with the channel branch this property is about.
+              # A list that has to be edited whenever an unrelated set grows
+              # is not a precondition, it is a liability: the failure it
+              # produces points at the wrong code. It reads the mirrors now,
+              # so it cannot drift out of step with them again.
+              numeric not in @active_numerics,
+              numeric not in @delegated_numerics,
               chan_body <- string(:alphanumeric, min_length: 1, max_length: 20)
             ) do
         chan = "#" <> chan_body
@@ -150,44 +314,6 @@ defmodule Grappa.Session.NumericRouterTest do
   # Active deny list: nick-shaped tokens that are NOT destinations
   # ---------------------------------------------------------------------------
 
-  # Mirror of NumericRouter's @active_numerics. #184 folded the STATS
-  # reply family (211–219 RPL_STATS* + RPL_ENDOFSTATS, 240–250) in — the
-  # stats letter (`/stats o` → 219 `[nick, "o", "End of /STATS report"]`)
-  # is a nick-shaped metadata token, NOT a query destination.
-  # #276 — 305/306 moved OUT of the active deny list into
-  # @delegated_numerics: RPL_UNAWAY / RPL_NOWAWAY are pure away-state
-  # acks owned by EventRouter's away_confirmed handler and must NEVER
-  # persist a scrollback row (the away STATE is the signal, the numeric
-  # is noise). See the delegated-numerics section below.
-  # #247 — 512/734 presence-watch list-full errors folded in: nick-shaped
-  # token (watched nick / rejected MONITOR target) that is metadata, not a
-  # query destination. The EventRouter toast is transient; the raw numeric
-  # must land on $server (durable "list full" record).
-  # #908 — TRACE reply family (200–210, 261–262) folded in: `params[1]` is
-  # the reply TYPE token ("Operator", "Server", "Class", …), the third
-  # instance of the #184 stats-letter disease.
-  # #910 — LIST reply family (321–323) folded in: 321's `params[1]` is the
-  # literal column header "Channel" and 322's is the LISTED channel, neither
-  # of which is a destination for the reply. This property is what pins the
-  # MEMBERSHIP of all three; the real-wire-shape tests below document what
-  # each one actually routed to pre-fix.
-  # #911 — the audit families. STATS grew to the contiguous 211–250 (less
-  # 221 RPL_UMODEIS, which is delegated), and ADMIN (256–259), HELP
-  # (704–706), SASL (900–908) and the MONITOR list pair (732/733) joined,
-  # alongside 410 ERR_INVALIDCAPCMD and 472 ERR_UNKNOWNMODE. Each was read
-  # out of a bound ircd's numeric FORMAT TABLE — azzurra/bahamut @ 3b6ccff
-  # `src/s_err.c` and solanum @ 115b1e2 `include/messages.h` — not out of
-  # an RFC. The per-family tests below carry the measured wire shape and
-  # the emitting file:line; this property pins the MEMBERSHIP.
-  @active_numerics [4, 42, 263, 410, 421, 432, 433, 437, 461, 472, 512, 734] ++
-                     (Enum.to_list(211..250) -- [221]) ++
-                     Enum.to_list(200..210) ++
-                     [261, 262] ++
-                     Enum.to_list(321..323) ++
-                     Enum.to_list(256..259) ++
-                     Enum.to_list(704..706) ++
-                     Enum.to_list(900..908) ++
-                     [732, 733]
 
   describe "@active_numerics deny list → {:server, nil}" do
     property "all @active_numerics route to {:server, nil} regardless of params" do
@@ -512,133 +638,6 @@ defmodule Grappa.Session.NumericRouterTest do
   # Delegated numerics → :delegated
   # ---------------------------------------------------------------------------
 
-  # #922 — this mirror is EXHAUSTIVE, and that is load-bearing. It used to
-  # hold 44 of the router's 71 delegated codes, so the property below
-  # asserted delegation for barely three fifths of the set: UMODEIS,
-  # INVITE-ack, LUSERS, presence and the whole bahamut WHOIS-leg family
-  # could all have been dropped from production with every test still
-  # green. The same undercount #922 found in the moduledoc, one layer
-  # down — a mirror that mirrors PART of the thing is worse than none,
-  # because it reads as coverage. A code added to `@delegated_numerics`
-  # MUST be added here too.
-  @delegated_numerics [
-    # #276 — away acks. RPL_UNAWAY (305) / RPL_NOWAWAY (306) are owned by
-    # EventRouter's away_confirmed handler (fires the typed away STATE
-    # effect); the numeric itself is content-free noise that must NEVER
-    # persist as a scrollback row. Delegated so Server.handle_info routes
-    # them via `delegate/2` (EventRouter only, no notice persist).
-    305,
-    306,
-    # WHOIS / WHO / NAMES / MOTD (pre-CP15)
-    311,
-    312,
-    313,
-    317,
-    318,
-    319,
-    352,
-    315,
-    353,
-    366,
-    # No-silent-drops B6.1 HIGH-3 (2026-05-14): LIST (321/322/323)
-    # REMOVED from @delegated_numerics (no EventRouter handler; the cic
-    # directory UI consumes the REST snapshot). #238 — LINKS (364/365)
-    # took the OTHER branch: a dedicated EventRouter clause now folds them
-    # into a :links_bundle, so they ARE delegated (added below).
-    364,
-    365,
-    375,
-    372,
-    376,
-    # #127 — MOTD 422 ERR_NOMOTD + INFO (371/374) + VERSION (351) delegated
-    # so the EventRouter #127 clauses own them (drain a server_reply modal
-    # when the matching command primed the session; $server persist when not).
-    # #374 — 402 ERR_NOSUCHSERVER joins the MOTD family: the terminator for
-    # `/motd <target>` to an unknown server, drained by the same clause.
-    422,
-    402,
-    371,
-    374,
-    351,
-    # CP15 B2 — JOIN failure numerics (EventRouter handles them now)
-    471,
-    473,
-    474,
-    475,
-    403,
-    405,
-    # Channel-state numerics (EventRouter caches into state.topics /
-    # state.channel_modes / state.channels_created — must be delegated
-    # so Server.handle_info doesn't double-persist them as `:notice`
-    # rows with body=trailing-param (which for 333 leaks the unix_ts
-    # as user-visible noise).
-    324,
-    329,
-    331,
-    332,
-    333,
-    # P-0c — WHOWAS bundle (314, 369, 406). 312 already in the WHOIS
-    # leg above; the EventRouter conflict-gates between whois_pending
-    # and whowas_pending so 312 still routes correctly.
-    314,
-    369,
-    406,
-    # #221 — solanum (Libera.Chat) WHOIS-leg numerics. EventRouter folds
-    # them into the whois_pending accumulator (typed 330/338/671/276,
-    # free-form 320, bot 335). Source: solanum include/numeric.h @ a4998b5.
-    276,
-    320,
-    330,
-    335,
-    338,
-    671,
-    # #376 — BANLIST bundle (367 RPL_BANLIST, 368 RPL_ENDOFBANLIST).
-    # EventRouter accumulates {mask, setter, set_ts} per 367 and emits
-    # :banlist_bundle on 368. Without delegation the param-derived scan
-    # leaks the trailing set-timestamp as a bare `:notice` row — same
-    # disease as 333.
-    367,
-    368,
-    # ---- added by #922: the 27 codes this mirror had drifted away from ----
-    # #229 — 221 RPL_UMODEIS (EventRouter parses the umode string into
-    # the per-session set and emits {:umode_changed, modes}).
-    221,
-    # 341 RPL_INVITING — INVITE ack.
-    341,
-    # LUSERS bundle.
-    251,
-    252,
-    253,
-    254,
-    255,
-    265,
-    266,
-    # P-0a — the bahamut/Azzurra WHOIS legs EventRouter folds into
-    # whois_pending (275 SSL, 301 AWAY, 307 regnick, 308/309 admin,
-    # 310 helper, 316 chanop, 325 agent, 326 modes, 339 java,
-    # 378 actually).
-    275,
-    301,
-    307,
-    308,
-    309,
-    310,
-    316,
-    325,
-    326,
-    339,
-    378,
-    # #247 — /notify presence numerics (MONITOR 730/731, WATCH 600–605).
-    # The ERROR numerics 512/734 are NOT here: they stay on the deny list
-    # so their raw text persists on $server.
-    730,
-    731,
-    600,
-    601,
-    602,
-    604,
-    605
-  ]
 
   describe "delegated numerics → :delegated" do
     property "all delegated numerics return :delegated" do


### PR DESCRIPTION
Refs #911, #922. Both live in `lib/grappa/session/numeric_router.ex`; one commit for #922, four for #911.

## #922 — the moduledoc undercounted the delegated set

Item 1 named five families (away acks, WHOIS, WHO, NAMES, MOTD), reading as some twenty codes. `@delegated_numerics` held 71. LUSERS, WHOWAS, LINKS, BANLIST, INFO/VERSION, UMODEIS, INVITE-ack, channel-state, join-failure, presence and both WHOIS legs were absent, and the "311–319 = WHOIS" range quietly swallowed 314 RPL_WHOWASUSER and 315 RPL_ENDOFWHO — WHOWAS and WHO.

The fix is not a longer list; a longer list drifts the same way. **The note now names no codes at all** and points at the attribute, whose per-family comments already carry the WHY. A doc that does not enumerate cannot undercount.

The test-side mirror had the identical defect one layer down: 44 of 71, so the "all delegated numerics return `:delegated`" property covered three fifths of the set. UMODEIS, INVITE-ack, LUSERS, presence and the whole bahamut WHOIS-leg family could have been deleted from production with every test green. It is exhaustive now.

## #911 — the audit, done by reading the ircds instead of the RFC

#911 was filed as nine low-confidence rows of "params[1] looks nick-shaped", explicitly RFC recall with no source read and no capture, and said the first step should be to measure. So the measurement is the change: both bound ircds publish their entire numeric FORMAT TABLE — [azzurra/bahamut @ 3b6ccff `src/s_err.c`](https://github.com/azzurra/bahamut) (Azzurra, all of prod) and [solanum @ 115b1e2 `include/messages.h`](https://github.com/solanum-ircd/solanum) (Libera, and the e2e testnet's second node). Reading them end to end answers the shape question per code, with the emitting `file:line` beside it.

**Denied on that evidence:** STATS 220–239 (the gap #184's own note asked for — Azzurra emits 222/223/224/225/227/229 with the same `%c` class letter #184 was filed for, all with live emitters; the range is now 211–250 less delegated 221), ADMIN 256–259, HELP 704–706, SASL 900–908, MONITOR list 732/733, plus 410 ERR_INVALIDCAPCMD and 472 ERR_UNKNOWNMODE.

The worst bite is not exotic. 704 puts the help TOPIC in `params[1]`, so `/help join` on Libera resolves the reply to `{:query, "join"}` — an ordinary command, no `/quote`, no privilege. 257 is two-param, so B6.1 HIGH-4's 2-elem clause hands the operator's A-line text to the scan and a one-word `admin { }` block becomes the destination.

**Disproved and deliberately left alone.** 436 ERR_NICKCOLLISION is not the twin of 432/433/437: those name a nick that is not you, while every 436 emitter on both ircds passes the RECIPIENT's own name, so `nick_eq?/2` already lands it on `$server`. 303 RPL_ISON appends a trailing space after every name and the parser keeps a trailing verbatim, so even the single-hit reply is `"nick "`. Denying either would add an entry no test could redden. Both are written into the module, because an audit that lists only its hits gives no way to tell measurement from confident guessing.

**Reachability cuts against this PR and is stated as such:** bahamut defines no 900, 410, 704–706, 732 or 908 at all. Everything except STATS and ADMIN is Libera-only and cannot fire on Azzurra, where prod lives. STATS 220–239 went the other way — filed as a known gap and left uncounted, it is the one family the network we actually run emits today.

## A green that constrained nothing, and its retraction

I shipped a disjointness property and called it "not decoration" in the commit message. Mutation testing killed it: putting 221 back into production's `@active_numerics` left the file green, because the property compared the two mirrors in the test file against each other. It is also unrepairable behaviourally — `numeric_class/1` resolves delegated first, so a code in both sets is indistinguishable through `route/2` from one in delegated alone. Intent defect, not behaviour defect. Deleted, with the reasoning left where it stood. The commits are not squashed so the retraction stays readable.

Adding 410 and 472 also reddened the channel-prefix property, whose precondition was a THIRD hand-maintained mirror of these tables. It is derived from the other two now, and both were hoisted above every describe so it can be.

## Gates

`scripts/check.sh` whole, exit 0: 5300 tests / 54 properties / 8 doctests, 0 failures; 0 `not ok` across bats; Credo strict clean over 590 files; Dialyzer 0 errors; Sobelow clean; doctor passed. Tree clean before and after.

Mutation-checked: 8 mutations, each removing one deny-list family. Seven redden the specific test for the family removed (222/225, 256/257, 704, 900/908, 732, 410, 472). The eighth is the one described above.

## Not done

This does not invert the scan's default. It sharpens the argument — the deny list now covers essentially every server-directed reply family the two ircds define, against the two or three destinations the query branch genuinely serves — but the inversion still needs #221's WHOIS-leg guard re-sited first, per the existing moduledoc note. The audit is also not exhaustive: runtime-`%s` slots on bahamut-only families (271 SILELIST, 606 WATCHLIST, 618/620 DCC, 728/729 RESTRICTLIST, 334, 340, 342, 362, 382, 391) are classified but not judged.