### PR TITLE
cic(#907): claim the composer, THEN await the query-topic join

### DIFF
--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -833,6 +833,112 @@ describe("compose submit — slash command dispatch", () => {
     }
   });
 
+  // #907 — the claim must happen BEFORE the arm awaits. Every other paced-send
+  // arm is safe by the SHAPE of `sendPacedBody`: it claims synchronously, so
+  // there is no moment between the composer emptying (#904 takes the text out
+  // at dispatch) and the lock. `/msg` awaited the #254 query-topic join first,
+  // and that await was a gap the operator could type into — destroyed by the
+  // first residue write in the one configuration where the source window is
+  // also the residue home: a query window that is already busy (#723).
+  //
+  // The join is held open by the test, so nothing here depends on how long a
+  // real join ACK takes — the operator types while the promise is unresolved
+  // by construction, not by timing.
+  it("#907 — /msg claims the composer BEFORE it awaits the query-topic join", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    const api = await import("../lib/api");
+    const qtj = await import("../lib/queryTopicJoin");
+    const compose = await import("../lib/compose");
+    const source = channelKey("freenode", "#a");
+    const query = channelKey("freenode", "bob");
+
+    let ackJoin!: () => void;
+    let joinAwaited = false;
+    qtj.setEnsureQueryTopicJoined(() => {
+      joinAwaited = true;
+      return new Promise<void>((resolve) => {
+        ackJoin = resolve;
+      });
+    });
+
+    let n = 0;
+    vi.mocked(sb.sendMessage).mockImplementation(async () => {
+      n += 1;
+      if (n === 2) throw new api.ApiError(400, "invalid_line");
+      return undefined as never;
+    });
+
+    // Busy query window → the residue is refused the redirect and comes back
+    // to the SOURCE, which is the window still reachable during the join.
+    compose.setDraft(query, "half typed reply");
+    compose.setDraft(source, "/msg bob l1\nl2\nl3");
+    const done = compose.submit(source, "freenode", "#a");
+    expect(joinAwaited).toBe(true);
+
+    // Parked on the join ACK. The buffer is already out of the composer, and
+    // the drain that will rewrite it has not started: pre-fix this typing
+    // landed, and the first residue write ate it without a trace.
+    expect(compose.isDraining(source)).toBe(true);
+    compose.setDraft(source, "and one more thing");
+    expect(compose.getDraft(source)).toBe("");
+
+    ackJoin();
+    const result = await done;
+
+    expect(result).toHaveProperty("error");
+    expect(compose.getDraft(source)).toBe("/msg bob l2\nl3");
+    expect(compose.getDraft(query)).toBe("half typed reply");
+    expect(compose.isDraining(source)).toBe(false);
+  });
+
+  // #907, the counterweight — claiming both candidate homes across the join is
+  // what makes the home choice honest, but only ONE of them ends up holding
+  // the residue. The loser is handed back to the operator the moment the
+  // choice is made: freezing a window the drain will never write to would be a
+  // dead composer for the length of a 429 ladder, in the very window `/msg`
+  // just moved the operator's eyes to.
+  it("#907 — the window that loses the residue is writable again for the drain", async () => {
+    vi.useFakeTimers();
+    try {
+      localStorage.setItem("grappa-token", "tok");
+      const sb = await import("../lib/scrollback");
+      const api = await import("../lib/api");
+      const compose = await import("../lib/compose");
+      const source = channelKey("freenode", "#a");
+      const query = channelKey("freenode", "bob");
+
+      let n = 0;
+      let refused = false;
+      vi.mocked(sb.sendMessage).mockImplementation(async () => {
+        n += 1;
+        if (n === 2 && !refused) {
+          refused = true;
+          throw new api.ApiError(429, "rate_limited", { retry_after: 2 });
+        }
+        return undefined as never;
+      });
+
+      compose.setDraft(query, "half typed reply");
+      compose.setDraft(source, "/msg bob l1\nl2\nl3");
+      const done = compose.submit(source, "freenode", "#a");
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Mid-drain: the source owns the residue and is locked; the query window
+      // owns nothing but the operator's own text and stays theirs.
+      expect(compose.isDraining(source)).toBe(true);
+      expect(compose.isDraining(query)).toBe(false);
+      compose.setDraft(query, "half typed reply, now finished");
+      expect(compose.getDraft(query)).toBe("half typed reply, now finished");
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(await done).toEqual({ ok: true });
+      expect(compose.isDraining(source)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("/me action sends as ACTION via scrollback.sendMessage with CTCP framing", async () => {
     localStorage.setItem("grappa-token", "tok");
     const sb = await import("../lib/scrollback");

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -493,6 +493,15 @@ const exports_ = identityScopedStore((onIdentityChange) => {
   // the first residue write makes `preferred` non-empty, hopping windows
   // mid-drain. Known hole: text typed into `preferred` AFTER that resolution
   // (possible during a long 429-paced drain) is still overwritten.
+  //
+  // #907 — `prepare` is whatever the arm must arrange before the first line can
+  // go out (`/msg` awaits its #254 query-topic join). It runs INSIDE the claim,
+  // and that is the whole reason it is a parameter here rather than a statement
+  // in the arm: between the composer emptying at dispatch (#904) and the first
+  // residue write there must be no moment the operator can type into, or that
+  // keystroke is overwritten by the write. Required, never optional, so the
+  // next arm that grows an await has to answer the question instead of silently
+  // re-opening the gap.
   const sendPacedBody = async (
     source: ResidueHome,
     preferred: ResidueHome,
@@ -500,9 +509,8 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     target: string,
     body: string,
     action: boolean,
+    prepare: () => Promise<void>,
   ): Promise<DispatchOutcome> => {
-    const home =
-      preferred.key === source.key || getDraft(preferred.key) === "" ? preferred : source;
     let sentCount = 0;
     let totalCount = 0;
     // #904 — the two buffer regimes of a free-text send, told apart by the ONE
@@ -526,52 +534,73 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     // `finally` so a fatal mid-fan-out unlocks the window too: a lock that
     // outlives its drain leaves the composer dead until reload, which is worse
     // than the overwrite it prevents.
-    const locked = multi ? [...new Set([source.key, home.key])] : [];
-    claimDrafts(locked);
+    //
+    // #907 — claimed BEFORE `prepare`, which means before the home is known,
+    // so BOTH candidates are taken: the choice below reads `preferred`'s draft,
+    // and a draft that stayed writable across an await would be stale ground to
+    // decide on. The loser is handed back the moment the choice is made.
+    const claimed = multi ? [...new Set([source.key, preferred.key])] : [];
+    claimDrafts(claimed);
     try {
-      await sendBodyLines(slug, target, body, action, (sent, total, residue) => {
-        sentCount = sent;
-        totalCount = total;
-        if (!multi) return;
-        // Residue-only draft, reset to the live bottom (historyCursor null):
-        // we're typing the remainder, not walking history. A drained send
-        // leaves "" — never a bare prefix the operator would have to erase.
-        writeState(home.key, (s) => ({
-          ...s,
-          draft: residueDraft(home, residue),
-          historyCursor: null,
-        }));
-      });
-      return { ok: true };
-    } catch (e) {
-      // Fatal mid-fan-out (WS down, invalid_line, severed 401). The residue
-      // draft is already set to the unsent remainder; surface the reason and,
-      // for a genuine multi-line paste, how many lines went out so the operator
-      // knows the send partially landed. "In the box" means the composer they
-      // are looking at — a lie when a busy `preferred` sent the remainder back
-      // to the window they submitted from, so that case says where it went
-      // whether or not the body was multi-line.
-      const reason = friendlyError(e);
-      const sentOf = totalCount > 1 ? ` — sent ${sentCount} of ${totalCount} lines` : "";
-      // #904 — a single line has no residue to relocate: the pump hands the
-      // ORIGINAL text back to the window it was typed in, which needs no
-      // re-addressing because it still carries its own `/me ` / `/msg <peer> `.
-      // So the "your eyes are elsewhere" test is the FOCUS switch (`/msg`
-      // moved them to the query window), not which window won the residue.
-      const relocated = multi ? home.key !== preferred.key : preferred.key !== source.key;
-      if (relocated) {
-        // "The rest" presumes something went out; on a single-line body
-        // nothing did, so name the whole message instead.
-        const what = totalCount > 1 ? "the rest are" : "your message is";
-        const error = `${reason}${sentOf}; ${what} in the window you sent from`;
-        return multi ? { error, keptBuffer: true } : { error };
+      await prepare();
+      const home =
+        preferred.key === source.key || getDraft(preferred.key) === "" ? preferred : source;
+      // Holding a composer hostage for a drain that will never write to it is
+      // its own defect — and `/msg` has just moved the operator's eyes into
+      // exactly that window.
+      releaseDrafts(claimed.filter((k) => k !== source.key && k !== home.key));
+      try {
+        await sendBodyLines(slug, target, body, action, (sent, total, residue) => {
+          sentCount = sent;
+          totalCount = total;
+          if (!multi) return;
+          // Residue-only draft, reset to the live bottom (historyCursor null):
+          // we're typing the remainder, not walking history. A drained send
+          // leaves "" — never a bare prefix the operator would have to erase.
+          writeState(home.key, (s) => ({
+            ...s,
+            draft: residueDraft(home, residue),
+            historyCursor: null,
+          }));
+        });
+        return { ok: true };
+      } catch (e) {
+        // Fatal mid-fan-out (WS down, invalid_line, severed 401). The residue
+        // draft is already set to the unsent remainder; surface the reason and,
+        // for a genuine multi-line paste, how many lines went out so the
+        // operator knows the send partially landed. "In the box" means the
+        // composer they are looking at — a lie when a busy `preferred` sent the
+        // remainder back to the window they submitted from, so that case says
+        // where it went whether or not the body was multi-line.
+        const reason = friendlyError(e);
+        const sentOf = totalCount > 1 ? ` — sent ${sentCount} of ${totalCount} lines` : "";
+        // #904 — a single line has no residue to relocate: the pump hands the
+        // ORIGINAL text back to the window it was typed in, which needs no
+        // re-addressing because it still carries its own `/me ` / `/msg <peer> `.
+        // So the "your eyes are elsewhere" test is the FOCUS switch (`/msg`
+        // moved them to the query window), not which window won the residue.
+        const relocated = multi ? home.key !== preferred.key : preferred.key !== source.key;
+        if (relocated) {
+          // "The rest" presumes something went out; on a single-line body
+          // nothing did, so name the whole message instead.
+          const what = totalCount > 1 ? "the rest are" : "your message is";
+          const error = `${reason}${sentOf}; ${what} in the window you sent from`;
+          return multi ? { error, keptBuffer: true } : { error };
+        }
+        if (!multi) return { error: reason };
+        return { error: `${reason}${sentOf}; the rest are in the box`, keptBuffer: true };
       }
-      if (!multi) return { error: reason };
-      return { error: `${reason}${sentOf}; the rest are in the box`, keptBuffer: true };
     } finally {
-      releaseDrafts(locked);
+      // Everything ever claimed, including the case `prepare` itself threw:
+      // `releaseDrafts` deletes keys, so releasing the loser twice is a no-op.
+      releaseDrafts(claimed);
     }
   };
+
+  // The paced-send arms that address a window which already exists have nothing
+  // to arrange before their first line (#907: `prepare` is required precisely
+  // so that answer is written down rather than assumed).
+  const nothingToPrepare = (): Promise<void> => Promise.resolve();
 
   // #904 — dispatch ONE submission. It never reads or writes the composer
   // buffer: the pump (`submit`, below) hands it the text and owns the
@@ -660,7 +689,15 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           // #723 — the residue stays in THIS window and this window IS the
           // target, so the bare remainder resends correctly: no prefix.
           const home = { key, resubmitPrefix: "" };
-          const r = await sendPacedBody(home, home, networkSlug, channelName, cmd.body, false);
+          const r = await sendPacedBody(
+            home,
+            home,
+            networkSlug,
+            channelName,
+            cmd.body,
+            false,
+            nothingToPrepare,
+          );
           if ("error" in r) return r;
           result = r;
           break;
@@ -672,7 +709,15 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           // #723 — the remainder must resend as an ACTION, not as plain text:
           // the residue carries the `/me ` back with it.
           const home = { key, resubmitPrefix: "/me " };
-          const r = await sendPacedBody(home, home, networkSlug, channelName, cmd.body, true);
+          const r = await sendPacedBody(
+            home,
+            home,
+            networkSlug,
+            channelName,
+            cmd.body,
+            true,
+            nothingToPrepare,
+          );
           if ("error" in r) return r;
           result = r;
           break;
@@ -865,7 +910,15 @@ const exports_ = identityScopedStore((onIdentityChange) => {
             // sent `/msg nickserv IDENTIFY <pass>` ends up resent to the
             // channel the operator typed it in.
             const home = { key, resubmitPrefix: `/msg ${cmd.target} ` };
-            const svc = await sendPacedBody(home, home, networkSlug, cmd.target, cmd.body, false);
+            const svc = await sendPacedBody(
+              home,
+              home,
+              networkSlug,
+              cmd.target,
+              cmd.body,
+              false,
+              nothingToPrepare,
+            );
             if ("error" in svc) return svc;
             result = svc;
             break;
@@ -873,15 +926,6 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           const canonical = canonicalQueryNick(networkId, cmd.target);
           openQueryWindowState(networkId, canonical, new Date().toISOString());
           setSelectedChannel({ networkSlug, channelName: canonical, kind: "query" });
-          // #254 — subscribe-before-send: make the (slug,target) query topic's
-          // WS subscription READY (await the join ACK) BEFORE the first PRIVMSG
-          // POST, so the server's own-echo broadcast has a live listener and
-          // renders live. Pre-fix the join raced the POST (it's gated on the
-          // open_query_window → query_windows_list round-trip) and the echo
-          // fastlaned to nobody — the row then only reappeared on reload. The
-          // echo stays the sole render path (no optimistic local render — cf.
-          // the #251 source_address abolition).
-          await ensureQueryTopicJoined(networkSlug, canonical);
           // #666 — resumable + paced. The residue PREFERS the QUERY window we
           // just focused (`canonical`) over the source window: /msg already
           // switched focus here, so a partial-send remainder + its error banner
@@ -894,6 +938,20 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           // window ends up holding it — and in the source window it keeps its
           // `/msg <peer> `, so resending from a channel cannot spill a private
           // message into that channel.
+          //
+          // #254 — subscribe-before-send: make the (slug,target) query topic's
+          // WS subscription READY (await the join ACK) BEFORE the first PRIVMSG
+          // POST, so the server's own-echo broadcast has a live listener and
+          // renders live. Pre-fix the join raced the POST (it's gated on the
+          // open_query_window → query_windows_list round-trip) and the echo
+          // fastlaned to nobody — the row then only reappeared on reload. The
+          // echo stays the sole render path (no optimistic local render — cf.
+          // the #251 source_address abolition).
+          //
+          // #907 — it is handed over as the `prepare` step rather than awaited
+          // here, so the composer is already claimed while it runs: awaited in
+          // the arm, it was a gap between the #904 take-at-dispatch and the
+          // first residue write, and a keystroke landing in it was destroyed.
           const r = await sendPacedBody(
             { key, resubmitPrefix: `/msg ${canonical} ` },
             { key: channelKey(networkSlug, canonical), resubmitPrefix: "" },
@@ -901,6 +959,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
             canonical,
             cmd.body,
             false,
+            () => ensureQueryTopicJoined(networkSlug, canonical),
           );
           if ("error" in r) return r;
           result = r;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -30830,3 +30830,60 @@ currently pinned only by `issue443-colored-nicklist.spec.ts` in a real browser.
 Recorded here rather than fixed in #914's diff — the finding is worth more than
 the two-line edit, and widening an unrelated PR to bury it is how findings get
 lost.
+
+## 2026-08-06 — #907: claim the buffer, THEN await — the rule becomes a parameter
+
+`/msg` awaited `ensureQueryTopicJoined` (the #254 subscribe-before-send join
+ACK) in the dispatch arm, and only then called `sendPacedBody`, which claims
+the #737 drain lock. Between those two lines the composer was empty (#904 takes
+the text out AT DISPATCH) and unclaimed: a keystroke landing there was
+overwritten by the first residue write of the paced drain. Every other
+paced-send arm is safe by SHAPE rather than by care — `sendPacedBody` resolves
+the residue home and claims in one synchronous block, so no gap exists to type
+into. Nothing protected that shape.
+
+**The fix is the shape, not the arm.** `sendPacedBody` grew a required
+`prepare: () => Promise<void>` and runs it INSIDE the claim; `/msg` hands it
+`() => ensureQueryTopicJoined(slug, canonical)` and the other three call sites
+pass `nothingToPrepare`. Required, not optional: an arm that grows an await
+before its first line now has one place to put it, and the ceremony of passing
+a no-op is the question being asked out loud. Patching only the `/msg` arm —
+claim, await, release, then let `sendPacedBody` re-claim — also closes the hole
+(there is no await between that release and the re-claim, so no keystroke can
+interleave), but it duplicates the `multi` rule and the key set in the arm, and
+"safe because no yield point sits between these two statements" is precisely
+the reasoning that was already load-bearing and already unprotected.
+
+**Both candidate homes are claimed across `prepare`, and the loser is released
+the moment the choice is made.** The home choice reads `preferred`'s draft
+(#723: a busy query window refuses the redirect), and reading it after an await
+it stayed writable during would be deciding on stale ground. Post-`prepare` the
+locked set is byte-identical to the pre-fix one, so the drain's own posture is
+unchanged — the query window that ends up owning nothing goes straight back to
+the operator, whose eyes `/msg` just moved into it. Freezing a window the drain
+will never write to would be its own defect.
+
+**What is NOT measured.** Nobody has timed a join ACK, and no repro was run
+against production. The issue is a code-structure reading and stays one: the
+window's WIDTH and how often it bites are unknown, and no claim here rests on
+them. What IS measured is that the path exists — the test below fails on the
+pre-fix code at the exact assertion that says so.
+
+**One trigger from the issue is falsified.** #907 lists a QUEUED submission
+(#904's one-deep slot) among the conditions. It is not required: #904 empties
+the composer on the FIRST Enter too, so the gap opens on a plain single
+submission. The test queues nothing and still reds.
+
+**The oracle is mid-await, and that is not a shortcut.** Post-fix and pre-fix
+the FINAL draft is identical — the residue write lands on an empty box either
+way, because the operator's text was destroyed rather than merged. So a
+before/after assertion on the settled state passes against the bug. The test
+holds the join promise open under its own control (`setEnsureQueryTopicJoined`,
+the #254 seam, is an injection point), types into the source window while it is
+unresolved, and asserts the write was REFUSED — the #737 posture, refuse rather
+than lose. No timing is guessed anywhere: the promise is resolved by the test,
+not by a clock.
+
+**No e2e, deliberately.** The observable is a textarea that is readOnly for the
+length of one WS round trip. A browser spec racing that window would pass by
+luck, which is worse than not having one.


### PR DESCRIPTION
Ref #907.

## The gap

The `/msg` arm awaited `ensureQueryTopicJoined` (the #254 subscribe-before-send
join ACK) and only then called `sendPacedBody`, which claims the #737 drain
lock. Across that await the composer is already empty — #904 takes the text out
AT DISPATCH — and unclaimed, so a keystroke landing there is overwritten by the
first residue write of the paced drain.

Every other paced-send arm is safe by the SHAPE of `sendPacedBody`: it resolves
the residue home and claims in one synchronous block, so there is no moment to
type into. Nothing protected that shape.

## The fix is the shape, not the arm

`sendPacedBody` takes a required `prepare: () => Promise<void>` and runs it
INSIDE the claim. `/msg` hands over its join; the other three call sites pass
`nothingToPrepare`. Required rather than optional is the point: the next arm
that grows an await has exactly one place to put it, and passing a no-op is the
question asked out loud.

Patching only the arm (claim → await → release → let `sendPacedBody` re-claim)
also closes the hole — there is no yield point between that release and the
re-claim — but it duplicates the `multi` rule and the key set in the arm, and
"safe because nothing can interleave between these two statements" is precisely
the reasoning that was already load-bearing and already unprotected.

Both candidate homes are claimed across `prepare`: the home choice reads
`preferred`'s draft (#723 — a busy query window refuses the redirect), and
reading it after an await it stayed writable during is deciding on stale
ground. The loser is released the instant the choice is made, so post-`prepare`
the locked set is byte-identical to the pre-fix one and a window the drain will
never write to is not held hostage — least of all the query window `/msg` just
moved the operator's eyes into.

## What I refuse to claim

- **The width of the window and how often it bites.** Nobody has timed a join
  ACK; no production repro was run. This stays what the issue said it was — a
  code-structure reading. Nothing in the fix or the test rests on a duration.
- **That the issue's trigger list is right.** It is not, and this is measured:
  #907 lists a QUEUED submission (#904's one-deep slot) among the conditions.
  Not required — #904 empties the composer on the FIRST Enter too. The new test
  queues nothing and still reds on the pre-fix code.

## The test, and why its oracle is mid-await

`#907 — /msg claims the composer BEFORE it awaits the query-topic join` fails
on the pre-fix code at `expect(isDraining(source)).toBe(true)` and passes after.

The oracle is deliberately the state DURING the await, not the settled state:
post-fix and pre-fix the final draft is IDENTICAL, because the operator's text
is destroyed rather than merged. A before/after assertion on the end state
would have passed against the bug. The test holds the join promise open itself
(`setEnsureQueryTopicJoined`, the #254 seam, is an injection point), types while
it is unresolved, and asserts the write was REFUSED — the #737 posture, refuse
rather than lose. No timing is guessed: the test resolves the promise.

A second test pins the counterweight — the window that loses the residue is
writable again for the length of the drain — so the fix cannot degrade into
"freeze everything". That one is green both before and after; it guards this
change's collateral, not the defect.

**No e2e, deliberately.** The observable is a textarea readOnly for the length
of one WS round trip. A browser spec racing that window would pass by luck,
which is worse than not having one.

## Gates

- `scripts/bun.sh run test` — 4433 passed / 242 files, green.
- `scripts/bun.sh run check` — exit 0 (biome + tsc); `tsc --noEmit` standalone
  exit 0.
- Server side untouched (cic-only diff plus a DESIGN_NOTES entry).