### PR TITLE
cic(#925): send on the event iOS actually delivers

### DIFF
--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -108,8 +108,23 @@ const NOTICE_DISMISS_MS = 3_000;
 //                strings built in compose.ts, previously computed + discarded).
 type Feedback = { text: string; severity: "error" | "notice" };
 
+// #925 — did the pointer come up inside the box it went down on? The one
+// piece of geometry in the send button's pointer-driven activation, kept
+// pure so the abort-by-sliding-off case is decidable without touch physics.
+// Inclusive on all four edges: a release exactly on the boundary is a
+// release on the control.
+function releasedInside(rect: DOMRect, x: number, y: number): boolean {
+  return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+}
+
 const ComposeBox: Component<Props> = (props) => {
   const key = () => channelKey(props.networkSlug, props.channelName);
+
+  // #925 — send-button press bookkeeping. Plain `let`s, not signals: nothing
+  // renders off them, they only carry state from one event to the next within
+  // a single press.
+  let pressedPointerId: number | null = null;
+  let sentFromPointer = false;
   const [feedback, setFeedback] = createSignal<Feedback | null>(null);
   // Auto-dismiss handle for a shown NOTICE. Held so a new input / new submit /
   // unmount can cancel a pending fire — otherwise a stale timer would clear a
@@ -548,10 +563,46 @@ const ComposeBox: Component<Props> = (props) => {
           disabled={getDraft(key()).trim() === ""}
           // #59: keep the textarea focused when sending via the button.
           // Tapping a <button> moves focus off the textarea, which collapses
-          // the native on-screen keyboard (Android especially). preventDefault
-          // on pointerdown stops the focus steal — the click still fires +
-          // submits. Same trick as the image-picker button.
-          onPointerDown={(e) => e.preventDefault()}
+          // the native on-screen keyboard (Android especially). The cancel
+          // lands on `mousedown` — the legacy focus-shift carrier — and NEVER
+          // on `pointerdown`, which is also iOS's gesture-start signal
+          // (lib/keepKeyboard.ts states the rule and the bug that wrote it).
+          // The document-level keepKeyboard listener already does this on
+          // iOS; this one is what covers Android, where that listener is
+          // isIos()-gated and so does nothing at all.
+          onMouseDown={(e) => e.preventDefault()}
+          // #925 — activation rides the POINTER, not the click. A `type=
+          // "submit"` button sends only when a `click` reaches the form, and
+          // on real iOS a press the OS routes into a long-press gesture
+          // synthesizes no mouse events at all (vjt measured exactly that for
+          // #366, 2026-07-21): `:active` lights up, no click ever arrives, the
+          // text stays in the field. `pointerup` fires either way.
+          onPointerDown={(e) => {
+            pressedPointerId = e.pointerId;
+            // Re-arm: the previous press may have sent without ever producing
+            // a click to consume the swallow flag.
+            sentFromPointer = false;
+          }}
+          onPointerUp={(e) => {
+            if (pressedPointerId !== e.pointerId) return;
+            pressedPointerId = null;
+            // Touch pointers are implicitly captured by the element the press
+            // landed on, so a release anywhere still targets this button.
+            // Sliding off to abort is the platform's cancel affordance and it
+            // must keep working for an irreversible action — hit-test it.
+            if (!releasedInside(e.currentTarget.getBoundingClientRect(), e.clientX, e.clientY)) {
+              return;
+            }
+            sentFromPointer = true;
+            void doSubmit();
+          }}
+          // The synthetic click that follows a normal tap would submit the
+          // form a second time. Swallow it — but only a pointer-generated
+          // click (`detail > 0`): a keyboard activation reports detail 0 and
+          // must always reach the form, since no pointerup carried its send.
+          onClick={(e) => {
+            if (sentFromPointer && e.detail > 0) e.preventDefault();
+          }}
         >
           {/* #241 — in-flight feedback. While a send is in flight for THIS
               window (#904 moved that truth into the store, where it survives

--- a/cicchetto/src/__tests__/ComposeBox.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBox.test.tsx
@@ -84,6 +84,10 @@ vi.mock("../lib/networks", () => ({
 }));
 
 import ComposeBox from "../ComposeBox";
+// Static handle on the mocked module (vi.mock is hoisted, so this IS the
+// mock). The older cases reach for it via `await import` case-by-case; the
+// #925 block asserts on `submit` in every one of its tests.
+import * as compose_ from "../lib/compose";
 // #80 — the paste flood guard reuses the REAL confirm-dialog store (not a
 // mock): ComposeBox calls requestConfirm, and these tests assert on the
 // store signal + drive accept/dismiss exactly as ConfirmModal.test.tsx does.
@@ -178,22 +182,128 @@ describe("ComposeBox", () => {
     }
   });
 
-  // #59 — tapping the send button must NOT steal focus from the textarea
-  // (that collapses the on-screen keyboard). The handler preventDefaults
-  // the pointerdown; the click still submits. Needs a non-empty draft —
-  // the button is disabled (un-tappable) while the draft is empty.
-  it("#59 — send button preventDefaults pointerdown (no focus steal)", async () => {
-    const compose = await import("../lib/compose");
-    vi.mocked(compose.getDraft).mockReturnValue("hi");
-    try {
+  // #925 — the send button's activation path. Two independent contracts:
+  //
+  //   focus retention (#59) rides `mousedown`, never `pointerdown` — the
+  //   invariant lib/keepKeyboard.ts was written to enforce;
+  //
+  //   activation rides `pointerup`, so a press that iOS declines to
+  //   synthesize mouse events for still sends. The synthetic click that
+  //   follows a normal tap must NOT send a second time.
+  //
+  // Needs a non-empty draft throughout — the button is disabled (and so
+  // fires no pointer events at all) while the draft is empty.
+  describe("#925 — send button activation", () => {
+    // jsdom's getBoundingClientRect returns an all-zero rect, which the
+    // release-inside guard reads as "the pointer came up off the button".
+    // Give the button a real box so the geometry under test is the one the
+    // production predicate sees, not a degenerate one.
+    const BUTTON_RECT = { left: 300, right: 344, top: 500, bottom: 544 };
+
+    function renderWithDraft(): HTMLElement {
       render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
       const btn = screen.getByRole("button", { name: /send message/i });
-      const ev = new Event("pointerdown", { bubbles: true, cancelable: true });
-      btn.dispatchEvent(ev);
-      expect(ev.defaultPrevented).toBe(true);
-    } finally {
-      vi.mocked(compose.getDraft).mockReturnValue("");
+      Object.defineProperty(btn, "getBoundingClientRect", {
+        configurable: true,
+        value: () => ({
+          ...BUTTON_RECT,
+          width: BUTTON_RECT.right - BUTTON_RECT.left,
+          height: BUTTON_RECT.bottom - BUTTON_RECT.top,
+          x: BUTTON_RECT.left,
+          y: BUTTON_RECT.top,
+          toJSON() {},
+        }),
+      });
+      return btn;
     }
+
+    // jsdom's PointerEvent constructor is unreliable (same workaround as
+    // ResizeHandle.test.tsx): a MouseEvent carries every field the handlers
+    // read — clientX/clientY, pointerId, preventDefault.
+    function pointer(type: string, x: number, y: number): Event {
+      const e = new MouseEvent(type, { bubbles: true, cancelable: true, clientX: x, clientY: y });
+      Object.defineProperty(e, "pointerId", { value: 1 });
+      return e;
+    }
+
+    const CENTRE: [number, number] = [322, 522];
+
+    beforeEach(() => {
+      vi.mocked(compose_.getDraft).mockReturnValue("hi");
+      vi.mocked(compose_.submit).mockResolvedValue({ ok: true });
+    });
+
+    it("does NOT cancel pointerdown — that is the gesture-start signal", () => {
+      const btn = renderWithDraft();
+      const e = pointer("pointerdown", ...CENTRE);
+      btn.dispatchEvent(e);
+      expect(e.defaultPrevented).toBe(false);
+    });
+
+    it("#59 — cancels mousedown instead, so focus never leaves the textarea", () => {
+      const btn = renderWithDraft();
+      const e = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
+      btn.dispatchEvent(e);
+      expect(e.defaultPrevented).toBe(true);
+    });
+
+    it("sends on pointerup, without waiting for a click", () => {
+      const btn = renderWithDraft();
+      btn.dispatchEvent(pointer("pointerdown", ...CENTRE));
+      btn.dispatchEvent(pointer("pointerup", ...CENTRE));
+      expect(compose_.submit).toHaveBeenCalledTimes(1);
+    });
+
+    it("swallows the synthetic click that follows, so a tap sends ONCE", () => {
+      const btn = renderWithDraft();
+      btn.dispatchEvent(pointer("pointerdown", ...CENTRE));
+      btn.dispatchEvent(pointer("pointerup", ...CENTRE));
+      // detail=1 is what a pointer-generated click reports.
+      const click = new MouseEvent("click", { bubbles: true, cancelable: true, detail: 1 });
+      btn.dispatchEvent(click);
+      expect(compose_.submit).toHaveBeenCalledTimes(1);
+      expect(click.defaultPrevented).toBe(true);
+    });
+
+    it("lets a keyboard activation through even while the swallow is armed", () => {
+      // A keyboard click reports detail 0 and carries no pointerup to have
+      // sent for it, so swallowing it would drop the send outright. Armed
+      // first, deliberately: this is the state a click-less pointer send
+      // leaves behind, and the one an Enter must survive.
+      const btn = renderWithDraft();
+      btn.dispatchEvent(pointer("pointerdown", ...CENTRE));
+      btn.dispatchEvent(pointer("pointerup", ...CENTRE));
+      const click = new MouseEvent("click", { bubbles: true, cancelable: true, detail: 0 });
+      btn.dispatchEvent(click);
+      expect(click.defaultPrevented).toBe(false);
+      // The form's own onSubmit carries the send for this path; the button
+      // must simply keep out of the way of its default activation behaviour.
+    });
+
+    it("does not send when the finger slides off the button before release", () => {
+      const btn = renderWithDraft();
+      btn.dispatchEvent(pointer("pointerdown", ...CENTRE));
+      btn.dispatchEvent(pointer("pointerup", BUTTON_RECT.left - 60, BUTTON_RECT.top - 60));
+      expect(compose_.submit).not.toHaveBeenCalled();
+    });
+
+    it("re-arms after a press that produced no click, so the next tap still sends", () => {
+      const btn = renderWithDraft();
+      // First press: sends on pointerup, and iOS synthesizes no click for it.
+      btn.dispatchEvent(pointer("pointerdown", ...CENTRE));
+      btn.dispatchEvent(pointer("pointerup", ...CENTRE));
+      // Second press: the swallow flag must not still be armed from the first,
+      // or this tap's own click would be eaten as a duplicate.
+      btn.dispatchEvent(pointer("pointerdown", ...CENTRE));
+      btn.dispatchEvent(pointer("pointerup", ...CENTRE));
+      expect(compose_.submit).toHaveBeenCalledTimes(2);
+    });
+
+    it("ignores a pointerup whose pointerdown never landed on the button", () => {
+      const btn = renderWithDraft();
+      btn.dispatchEvent(pointer("pointerup", ...CENTRE));
+      expect(compose_.submit).not.toHaveBeenCalled();
+    });
   });
 
   it("typing fires compose.setDraft", async () => {

--- a/cicchetto/src/main.tsx
+++ b/cicchetto/src/main.tsx
@@ -144,7 +144,9 @@ installSmartScrollPin();
 // UX-3 preserve-keyboard — single document-level capture listener.
 // When compose <input> has focus and the user taps anywhere that
 // isn't another input/textarea, suppress the implicit focus shift
-// (preventDefault on pointerdown) so iOS doesn't dismiss the
+// (preventDefault on MOUSEDOWN — never pointerdown, which is also
+// iOS's gesture-start signal; the module header carries the rule and
+// the bugs that wrote it) so iOS doesn't dismiss the
 // keyboard. Replaces per-button onPointerDown wiring (UX-3 NON +
 // BIS-DEC) — every new tappable surface inherits the behavior
 // automatically.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -30830,3 +30830,63 @@ currently pinned only by `issue443-colored-nicklist.spec.ts` in a real browser.
 Recorded here rather than fixed in #914's diff — the finding is worth more than
 the two-line edit, and widening an unrelated PR to bury it is how findings get
 lost.
+
+## 2026-08-06 — #925: the send button waits for a click that iOS does not always send
+
+**The report.** On iPhone (installed PWA, keyboard up) a tap on the compose
+send button sometimes did nothing: `:active` lit up, the message did not go,
+and the text stayed in the field. That last detail is the discriminator — the
+draft is cleared by the send path, so a still-full field means the send never
+ran, not that the render lied.
+
+**The suspicion vjt filed, and what reading the code actually established.**
+`ComposeBox.tsx` wired the button with `onPointerDown={(e) =>
+e.preventDefault()}` — the one place in the app doing what `lib/keepKeyboard.ts`
+was written to forbid, since `pointerdown` is also iOS's gesture-start signal
+(that same mistake cost the un-scrollable archive modal, 2026-05-18). Reading
+the code proves the path EXISTS. It does not prove it fires. It was left
+labelled as a suspicion, and it is not what this change is justified on.
+
+**What the code already knew.** The mechanism that predicts this symptom
+exactly was measured on a real device eleven days earlier, for #366, and is
+written down in `keepKeyboard.ts`: on real iOS Safari a press the OS routes
+into a long-press gesture *synthesizes no mouse events at all* — only taps do.
+A `type="submit"` button sends only when a `click` reaches the form. No mouse
+events means no click means no submit, while `:active` (driven by touch, not
+by mouse) still lights up. The field report and the repro log both feature
+presses in the 650–980 ms band. So the send button's activation was resting on
+an event iOS is documented — in this repo, from this project's own dogfood —
+to withhold.
+
+**The fix: activation rides `pointerup`, focus retention rides `mousedown`.**
+`pointerup` fires whether or not the OS decides to synthesize mouse events;
+the repro log shows it on all six long presses. The synthetic click that
+follows a normal tap is swallowed so a tap cannot send twice — gated on
+`detail > 0`, because a keyboard activation reports `detail 0` and has no
+pointerup to have sent for it, so swallowing that one would drop the send
+outright. Release is hit-tested against the button's box (`releasedInside`):
+touch pointers are implicitly captured by the element the press landed on, so
+without the test, pressing send and sliding away to abort would still fire —
+and a message to a channel is not undoable.
+
+**Why the button keeps a focus-retention handler at all, on `mousedown`.**
+The issue proposed simply deleting the per-button wiring and letting the
+global `keepKeyboard` listener do its job. It cannot: that listener is
+`isIos()`-gated, and #59 was reported on Android ("Android especially"). On
+iOS the button's `mousedown` cancel is redundant with the global one and
+harmless; on Android it is the only thing there is.
+
+**Stated plainly: not reproduced.** Playwright webkit does not reproduce iOS
+touch physics, so the failing arm was not observed here — only field-reported,
+plus a device log of the *proposed* wiring succeeding 6/6. What is NOT
+established is that the old `pointerdown` cancel was the thing losing the send;
+a control run with the old wiring on the same device is what would close that.
+The fix is justified on the click's absence being the failure mode the repo had
+already measured, not on the suspicion the issue opened with.
+
+**Two comments were lying, and comments are what write this class of bug.**
+`main.tsx` described the global preserve listener as "preventDefault on
+pointerdown" (it hooks `mousedown`), and the send button's own comment claimed
+"same trick as the image-picker button" (that button has carried a plain
+`onClick` for some time). Both were fixed here. A comment that misnames the
+event is how the next person re-adds a `pointerdown` cancel.


### PR DESCRIPTION
## What

The compose **send** button is a `type="submit"`, so it sends only when a `click` reaches the form. `lib/keepKeyboard.ts` already records — from a real-device measurement taken for #366 on 2026-07-21 — that iOS Safari synthesizes **no mouse events at all** for a press the OS routes into a long-press gesture; only taps get them. No mouse events → no click → no submit, while `:active` still lights up from the touch and the draft stays in the field. That is the reported symptom, and the mechanism was already written down in this repo.

Activation therefore moves to `pointerup`, which fires either way (the issue's device log shows it on all six long presses, 648–982 ms).

## The wiring

- `pointerup` submits, guarded by the `pointerId` that went down on the button.
- The synthetic `click` that follows a normal tap is swallowed so a tap cannot send twice — gated on `detail > 0`, because a keyboard activation reports `detail 0` and carries no pointerup to have sent for it; swallowing that one would drop the send outright.
- The release is hit-tested against the button's box (`releasedInside`): touch pointers are implicitly captured by the press target, so without the test, pressing send and sliding away to abort would still fire — and a message to a channel is not undoable.
- Focus retention (#59) stays, moved onto `mousedown` (the legacy focus-shift carrier) and off `pointerdown` (also iOS's gesture-start signal — the rule `keepKeyboard.ts` exists to enforce).

## One correction to the issue's proposal

Option 1 was "drop the per-button wiring, let the global `keepKeyboard` `mousedown` listener do its job". It cannot: that listener is `isIos()`-gated, and #59 was an Android report ("Android especially"). On iOS the button's own `mousedown` cancel is redundant with the global one and harmless; on Android it is the only thing there is. So the handler stays, on the right event.

## Scope of the evidence, stated plainly

**Not reproduced.** Playwright webkit does not carry iOS touch physics. The failing arm is field-reported (Scatolone_Fabbricone); the passing arm is Hypnotize's device log of *this* wiring, 6/6. What is **not** established is that the old `pointerdown` cancel was the thing losing the send — a control run with the old wiring on the same device is what would close that loop. This change is justified on the click's absence being a failure mode this repo had already measured, not on the suspicion the issue opened with. **vjt device-verifies on the phone.**

## Also

Two comments named the wrong event and were fixed: `main.tsx` described the global preserve listener as "preventDefault on pointerdown" (it hooks `mousedown`), and the send button claimed "same trick as the image-picker button" (that button carries a plain `onClick`). A comment that misnames the event is how this class of bug gets written again.

## Gates

- `bun run test` — 4439/4439 green (242 files), incl. 8 new `#925` cases: pointerdown not cancelled, mousedown cancelled, pointerup sends, synthetic click swallowed once, keyboard activation survives the armed swallow, slide-off aborts, re-arm across presses, orphan pointerup ignored.
- `bun run check` (biome + `tsc --noEmit`) — exit 0; `tsc --noEmit` standalone also exit 0.
- e2e not yet run (needs a lane) — six existing specs drive the send button in a real browser and are the meaningful regression gate for this change.

Refs #925.