### PR TITLE
test(#893): take the ambient reapers out of the suite's write path

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -95,6 +95,22 @@ config :grappa, :start_bootstrap, false
 # app-boot ServerSettings arm-read out of the test tree too.
 config :grappa, :start_source_alias_manager, false
 
+# #893 — the three ambient sweepers (Visitors / Uploads / Accounts
+# Reaper) are started by the application supervisor in EVERY env,
+# including test, and `Grappa.DataCase` puts the Sandbox in SHARED mode
+# for `async: false` tests. An ambient 60s tick therefore runs its
+# `delete_all` / soft-delete on the CURRENT test's connection: a
+# cross-test writer nobody armed, firing at wall-clock. It reaped the
+# row out from under `Uploads.ReaperTest`'s sustained-busy case (1 in
+# 5185 on CI) — that test's own sweep degraded exactly as designed while
+# the ambient reaper flipped `deleted_at` behind it. Push the cadence
+# past any suite runtime so NO ambient sweep fires during `mix test`;
+# the reapers still boot (Uploads.Reaper's `init/1` mkdir_p's the global
+# storage root) and every reaper unit test drives `sweep/2` directly or
+# starts its OWN instance with an explicit short interval. Not a
+# timeout bump: it REMOVES a nondeterministic writer from the suite.
+config :grappa, :reaper_interval_ms, :timer.hours(24)
+
 # UX-6-B1 (2026-05-20): embedded image uploader storage dir for
 # `mix test`. The Reaper child in the application supervisor mkdir_p's
 # this at boot; per-test isolation comes from `start_supervised`-ing

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -30830,3 +30830,52 @@ currently pinned only by `issue443-colored-nicklist.spec.ts` in a real browser.
 Recorded here rather than fixed in #914's diff — the finding is worth more than
 the two-line edit, and widening an unrelated PR to bury it is how findings get
 lost.
+
+## 2026-08-06 — #893: the flaky test was right; the suite had an unarmed writer
+
+`Uploads.ReaperTest`'s sustained-busy case failed once in 5185 tests on CI and
+was filed as a tracked flake with the two candidate causes left explicitly
+undecided: load-sensitive setup, or a genuine mishandling of sustained BUSY.
+
+**It was neither.** The CI log settles it. The failing assertion was
+`assert is_nil(reloaded.deleted_at)` — and BOTH degrade lines were logged in
+the same block (`db write unavailable … 300ms retry budget (31 attempts)` and
+`uploads reaper failure error=:db_unavailable`). So the resilience path did
+exactly what the test claims it does: the injected fault fired on all 31
+attempts, the budget expired, the flip degraded, the sweep returned `{:ok, 0}`.
+The row was nonetheless soft-deleted. `BusyRetry` injects its fault BEFORE the
+op, so the test process never ran that `UPDATE`. Something else did.
+
+**The three ambient reapers tick during `mix test`.** The application
+supervisor starts `Visitors.Reaper`, `Uploads.Reaper` and `Accounts.Reaper` in
+every env, each on a 60s timer, and `Grappa.DataCase` puts the Sandbox in
+SHARED mode for `async: false` tests. A shared-mode connection belongs to
+whichever test is live, so an ambient tick runs its `delete_all` /
+soft-delete on THAT test's connection and mutates rows it just created. The
+reaper does not even need the file: `File.rm` returns `:enoent` for a row whose
+bytes live under some other test's temp root, and the enoent arm soft-deletes
+anyway. Wall-clock 60s landing inside a ~300ms window is the 1-in-thousands.
+
+**Proven by displacement, not by re-rolling the dice.** A probe test created an
+expired upload, sent the app-supervised reaper a single `:tick`, and read the
+row back: `deleted_at` set, the exact CI signature, first try. Twenty green
+repeats of the original test would have proven nothing — the failure needs a
+timer coincidence, not a code path. What is NOT claimed: the original 1-in-5185
+timing was never reproduced, and no attempt was made to.
+
+**Fix: remove the writer, do not soften the reader.** The cadence moves to a
+`:reaper_interval_ms` knob read once at the application boot boundary, pushed
+past any suite runtime in `config/test.exs`. The reapers still boot — that
+matters, `Uploads.Reaper.init/1` mkdir_p's the global storage root, and every
+reaper unit test either calls `sweep/2` directly or starts its own instance
+with an explicit short interval. No assert was weakened and no timeout raised;
+a nondeterministic cross-test writer was taken out of the suite.
+
+**Widened past the one test that noticed.** All three reapers get the knob, not
+just Uploads: the exposure is any `async: false` test whose rows match an
+expired-visitor, expired-upload, or idle-session predicate, and only one of
+those three had rolled a bad tick yet. The pin
+(`application_ambient_reapers_test.exs`) derives its set from
+`Supervisor.which_children/1` rather than a hand-written list, so a fourth
+reaper is covered on the day it is added, and asserts set-equality against the
+known three so the filter cannot silently match nothing.

--- a/lib/grappa/application.ex
+++ b/lib/grappa/application.ex
@@ -350,11 +350,12 @@ defmodule Grappa.Application do
           # public surface is up — Reaper's sweep deletes rows that REST/WS
           # might reach for; ordering it after Endpoint keeps the
           # "everything visible to clients is also visible to Reaper"
-          # invariant honest). The default 60s interval is far longer
-          # than boot, so the first sweep waits anyway — ordering is
+          # invariant honest). The `reaper_interval_ms/0` cadence (60s in
+          # prod) is far longer than boot, so the first sweep waits
+          # anyway — ordering is
           # belt-and-braces. Reaper consumes Grappa.Visitors; the
           # Application boundary has it listed in deps for that reason.
-          Grappa.Visitors.Reaper,
+          {Grappa.Visitors.Reaper, interval_ms: reaper_interval_ms()},
 
           # UX-6-B1 (2026-05-20): embedded image uploader Reaper. Same
           # rationale as Visitors.Reaper for the ordering: after Repo
@@ -367,7 +368,7 @@ defmodule Grappa.Application do
           # the controller + Reaper read from `:persistent_term`
           # thereafter (CLAUDE.md "Application.{put,get}_env: boot-time
           # only").
-          {Grappa.Uploads.Reaper, storage_root: uploads_storage_root()},
+          {Grappa.Uploads.Reaper, storage_root: uploads_storage_root(), interval_ms: reaper_interval_ms()},
 
           # #223: auth-session housekeeping GC. Sibling of Visitors.Reaper
           # / Uploads.Reaper — a THIRD domain (Accounts) gets its OWN
@@ -378,9 +379,10 @@ defmodule Grappa.Application do
           # the sweep removes idle-expired rows). Bulk `delete_all` over
           # USER sessions past the 7-day idle window that `authenticate/1`
           # already rejects; visitor sessions are out of scope (they
-          # CASCADE from the visitor row via Visitors.Reaper). Default
-          # 60s interval >> boot, so the first sweep waits anyway.
-          Grappa.Accounts.Reaper
+          # CASCADE from the visitor row via Visitors.Reaper). The
+          # `reaper_interval_ms/0` cadence (60s in prod) >> boot, so the
+          # first sweep waits anyway.
+          {Grappa.Accounts.Reaper, interval_ms: reaper_interval_ms()}
 
           # Bootstrap is appended LAST below: it depends on Registry +
           # SessionSupervisor existing so it can spawn sessions. Conditional
@@ -460,6 +462,22 @@ defmodule Grappa.Application do
   # reads from `:persistent_term`.
   defp uploads_storage_root do
     Application.fetch_env!(:grappa, :uploads_storage_root)
+  end
+
+  # #893: the shared tick cadence of the three ambient sweepers
+  # (Visitors / Uploads / Accounts). 60s everywhere except `:test`,
+  # where it is pushed past any suite runtime so NO ambient sweep ever
+  # fires during `mix test`. The application supervisor starts these
+  # three in every env, and `Grappa.DataCase` puts the Sandbox in
+  # SHARED mode for `async: false` tests — so an ambient tick runs its
+  # `delete_all` / soft-delete on the CURRENT test's connection and can
+  # mutate rows that test just created. That is what reaped the row out
+  # from under `Uploads.ReaperTest`'s sustained-busy case on CI (1 in
+  # 5185): the test's own sweep degraded exactly as designed while the
+  # ambient reaper flipped `deleted_at` behind it. Read at THIS boot
+  # boundary only (CLAUDE.md "Application.get_env: boot-time only").
+  defp reaper_interval_ms do
+    Application.get_env(:grappa, :reaper_interval_ms, 60_000)
   end
 
   # #399: the built cicchetto SPA dist root. Configured via

--- a/test/grappa/application_ambient_reapers_test.exs
+++ b/test/grappa/application_ambient_reapers_test.exs
@@ -45,8 +45,8 @@ defmodule Grappa.ApplicationAmbientReapersTest do
   defp running_reapers do
     Grappa.Supervisor
     |> Supervisor.which_children()
-    |> Enum.filter(fn {id, pid, _type, _mods} -> reaper?(id) and is_pid(pid) end)
-    |> Enum.map(fn {id, pid, _type, _mods} -> {id, pid} end)
+    |> Enum.filter(fn {id, pid, _, _} -> reaper?(id) and is_pid(pid) end)
+    |> Enum.map(fn {id, pid, _, _} -> {id, pid} end)
   end
 
   defp reaper?(id) when is_atom(id), do: id |> Atom.to_string() |> String.ends_with?(".Reaper")

--- a/test/grappa/application_ambient_reapers_test.exs
+++ b/test/grappa/application_ambient_reapers_test.exs
@@ -1,0 +1,54 @@
+defmodule Grappa.ApplicationAmbientReapersTest do
+  # #893 — determinism pin for the ambient sweepers.
+  #
+  # The application supervisor starts three periodic reapers (Visitors /
+  # Uploads / Accounts) in EVERY env, test included, and
+  # `Grappa.DataCase` puts the Sandbox in SHARED mode for `async: false`
+  # tests. So an ambient tick issues its `delete_all` / soft-delete on
+  # the CURRENT test's connection — a cross-test writer nobody armed,
+  # firing at wall-clock rather than at anything the test did. On CI it
+  # reaped the row out from under `Uploads.ReaperTest`'s sustained-busy
+  # case (1 failure in 5185): that test's own sweep degraded exactly as
+  # designed, and the ambient reaper flipped `deleted_at` behind it.
+  #
+  # The cure is a deterministic SETUP, not a weakened assert: in test the
+  # cadence is pushed past any suite runtime (`:reaper_interval_ms` in
+  # `config/test.exs`), so no ambient sweep ever fires. This pins that —
+  # it is RED against the pre-#893 tree (60s in test) and covers a FOURTH
+  # reaper automatically, because the set is derived from the running
+  # supervisor rather than listed by hand.
+  use ExUnit.Case, async: true
+
+  # No `mix test` run comes near an hour; production stays at 60s.
+  @suite_ceiling_ms :timer.minutes(60)
+
+  @known [Grappa.Visitors.Reaper, Grappa.Uploads.Reaper, Grappa.Accounts.Reaper]
+
+  test "no application-supervised reaper is scheduled to tick during a suite run" do
+    reapers = running_reapers()
+
+    assert Enum.sort(Enum.map(reapers, &elem(&1, 0))) == Enum.sort(@known),
+           "the reaper set derived from the running supervisor drifted from the known set — " <>
+             "if a reaper was added or renamed, the pin below must still cover it"
+
+    for {mod, pid} <- reapers do
+      assert %{interval_ms: interval} = :sys.get_state(pid)
+
+      assert interval > @suite_ceiling_ms,
+             "#{inspect(mod)} ticks every #{interval}ms in the test env. An ambient sweep " <>
+               "during the suite runs on the shared Sandbox connection of whatever " <>
+               "`async: false` test is live and mutates its rows (#893). Raise " <>
+               "`:reaper_interval_ms` in config/test.exs instead of arming this one by hand."
+    end
+  end
+
+  defp running_reapers do
+    Grappa.Supervisor
+    |> Supervisor.which_children()
+    |> Enum.filter(fn {id, pid, _type, _mods} -> reaper?(id) and is_pid(pid) end)
+    |> Enum.map(fn {id, pid, _type, _mods} -> {id, pid} end)
+  end
+
+  defp reaper?(id) when is_atom(id), do: id |> Atom.to_string() |> String.ends_with?(".Reaper")
+  defp reaper?(_), do: false
+end


### PR DESCRIPTION
## What the CI log actually says

The issue left two candidates open — load-sensitive setup, or a real
mishandling of sustained BUSY. It is neither, and the log settles it
([run 31030931942, attempt 1](https://github.com/vjt/grappa-irc/actions/runs/31030931942)):

```
1) test sweep/2 — resilience sustained DB busy → best-effort drop …
   Expected truthy, got false
   code: assert is_nil(reloaded.deleted_at)

   17:43:35.333 fault=busy_locked [warning] db write unavailable: SQLite pool
     saturated for the full 300ms retry budget (31 attempts) — returning :db_unavailable
   17:43:35.333 error=:db_unavailable [error] uploads reaper failure
```

Both degrade lines are present. The injected fault fired on all 31
attempts, the budget expired, the flip degraded, `{:ok, 0}` came back —
the resilience path did exactly what the test claims. And `BusyRetry`
injects *before* the op, so the test process never ran that `UPDATE`.
Something else soft-deleted the row.

## The writer nobody armed

`Grappa.Application` starts three periodic reapers (Visitors / Uploads /
Accounts) in **every** env, test included, and `Grappa.DataCase` puts
the Sandbox in SHARED mode for `async: false` tests. So an ambient 60s
tick issues its sweep on whatever test is live and mutates rows that
test just created. It does not even need the file: `File.rm` against
another test's temp root returns `:enoent`, and the enoent arm
soft-deletes anyway.

**Proven by displacement, not by re-rolling the dice.** A probe sent the
app-supervised reaper one `:tick` and reproduced the exact CI signature
first try (`deleted_at` set, row read back in the same test). What is
**not** claimed: the 1-in-5185 timing was never reproduced and no attempt
was made to — twenty green repeats prove nothing about a timer
coincidence.

## Fix

Cure the setup, not the assert. The cadence becomes a
`:reaper_interval_ms` knob read once at the application boot boundary,
pushed past any suite runtime in `config/test.exs`. The reapers still
boot (`Uploads.Reaper.init/1` mkdir_p's the global storage root) and
every reaper unit test drives `sweep/2` directly or starts its own
instance with a short explicit interval. **No assert weakened, no timeout
raised** — a nondeterministic cross-test writer removed. Production is
untouched (60s default; dev/prod configs set nothing).

All three reapers get the knob, not just Uploads: the exposure is any
`async: false` test whose rows match an expired-visitor, expired-upload
or idle-session predicate. Only one of the three had rolled a bad tick
yet.

## Oracle

`test/grappa/application_ambient_reapers_test.exs` derives its set from
`Supervisor.which_children/1` (a fourth reaper is covered the day it
lands) and asserts set-equality against the known three so the filter
cannot silently match nothing. **Verified RED against the pre-fix tree**:
with the knob at `60_000` the pin fails, naming `Grappa.Accounts.Reaper`
and its 60000ms.

## Gates

`scripts/check.sh` green end to end: `8 doctests, 54 properties, 5290
tests, 0 failures`, exit 0, working tree clean before and after.