### PR TITLE
docs(#713): the TTL granularity floor, and why it is not a runtime guard

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -31029,8 +31029,12 @@ every other case reads freshness through a window wide enough to survive either
 precision, so a migration to `:utc_datetime_usec` would have made three
 statements silently false. `"captured_at is stored at second precision"` now
 fails if the precision changes. Verified by mutation rather than assumed —
-switching the schema field to `:utc_datetime_usec` and dropping both truncates
-turns it red while the rest of the module stays green.
+switching the schema field to `:utc_datetime_usec` and dropping `finalize/2`'s
+truncate turns exactly that one case red (1 failure in 9 tests + 1 property)
+while the rest of the module stays green. `ingest/3`'s truncate was left in
+place for the measurement on purpose: `inserted_at`/`updated_at` are still
+`:utc_datetime`, so dropping it makes Ecto refuse the dump and every case in
+the module dies for an unrelated reason — which would have measured nothing.
 
 **Not done, and deliberately.** `total_directory_rows/1` having to invent a TTL
 to ask for a row count is a smell — a `count/2` would let it stop lying. That

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -30994,3 +30994,44 @@ those three had rolled a bad tick yet. The pin
 `Supervisor.which_children/1` rather than a hand-written list, so a fourth
 reaper is covered on the day it is added, and asserts set-equality against the
 known three so the filter cannot silently match nothing.
+## 2026-08-06 — #713: a granularity floor is a documented fact, not a guard
+
+#718 fixed the flake itself (`ChannelDirectoryTest` asserted `:fresh` with
+`ttl_ms: 1_000` against a second-precision `captured_at`, so the whole budget
+could be spent before `list/3` was called). It left one question open: should
+`list/3` REJECT a `ttl_ms` below the column's granularity, so the next caller
+cannot ask an unanswerable question? Decided here: **no** — and the reasons are
+measurements, not taste.
+
+**It would not have caught the case that prompted it.** The value that went red
+was `ttl_ms: 1_000` — exactly the granularity, not below it. A `ttl_ms < 1_000`
+guard passes that call through untouched. The hazard is not "sub-second
+window"; it is "window comparable to the anchor's uncertainty", and the guard
+cannot see the difference because it cannot know how old the caller expects the
+snapshot to be.
+
+**It would reject two legitimate callers.** `Session.Server.total_directory_rows/1`
+passes `ttl_ms: 0` and reads `.total` only — it never looks at `status`, so the
+zero is a "don't care", not a question. And `@expired_ttl_ms -1` in
+`ChannelDirectoryTest` forces `:stale` deterministically; `0` is NOT equivalent
+there, because the comparison is `age_ms <= ttl_ms` and a stamp and a read
+landing in the same millisecond would score `:fresh`. A sub-granularity guard
+breaks a production path and the very constant that closed the flake.
+
+**So the floor goes where a caller reads it**, on `list/3`'s `:ttl_ms` option:
+the anchor is second-precision, the derived age overstates by up to 999 ms and
+never understates, and a window near that granularity answers by the clock.
+Production is clear by five orders of magnitude (48h).
+
+**One pin was missing.** Everything above — the doc, the test constants, this
+entry — rests on `captured_at` being `:utc_datetime`. Nothing asserted it:
+every other case reads freshness through a window wide enough to survive either
+precision, so a migration to `:utc_datetime_usec` would have made three
+statements silently false. `"captured_at is stored at second precision"` now
+fails if the precision changes. Verified by mutation rather than assumed —
+switching the schema field to `:utc_datetime_usec` and dropping both truncates
+turns it red while the rest of the module stays green.
+
+**Not done, and deliberately.** `total_directory_rows/1` having to invent a TTL
+to ask for a row count is a smell — a `count/2` would let it stop lying. That
+is an API change with no defect behind it, out of scope for a decision entry.

--- a/lib/grappa/channel_directory.ex
+++ b/lib/grappa/channel_directory.ex
@@ -134,6 +134,18 @@ defmodule Grappa.ChannelDirectory do
 
     * `:ttl_ms` (required) — freshness window in milliseconds; used to derive
       `status` (`:fresh` if `captured_at` is within TTL, `:stale` otherwise).
+      **The anchor is second-precision** (`Entry`'s `captured_at` is
+      `:utc_datetime`, so `finalize/2` truncates), so the derived age
+      OVERSTATES the true age by up to 999 ms and never understates it: a
+      snapshot is born up to a second old. A window comparable to that
+      granularity therefore answers by the clock rather than by the data —
+      `ttl_ms: 1_000` read immediately after `finalize/2` yields `:fresh` or
+      `:stale` depending on where in the wall-clock second the stamp landed
+      (#713). Production is clear of it by five orders of magnitude
+      (`ttl_ms/0` is 48h). This is a documented floor and NOT a runtime
+      rejection, deliberately — see #713 in `docs/DESIGN_NOTES.md` for why a
+      sub-granularity guard would have rejected two legitimate callers and
+      still not have caught the case that prompted the question.
     * `:sort` — `:users` (default, descending user count then ascending name) or
       `:name` (ascending name).
     * `:q` — case-insensitive substring filter applied to both `name` and `topic`.

--- a/test/grappa/channel_directory_test.exs
+++ b/test/grappa/channel_directory_test.exs
@@ -66,6 +66,20 @@ defmodule Grappa.ChannelDirectoryTest do
     assert Enum.map(entries, & &1.name) == ["#c3", "#c2", "#c1"]
   end
 
+  # #713 — the premise the TTL constants above and `list/3`'s documented
+  # granularity floor both rest on. Migrating `captured_at` to
+  # `:utc_datetime_usec` would retire the born-up-to-999ms-old problem and
+  # make all three statements false, and nothing else in the suite would
+  # notice: every other case reads freshness through a window wide enough to
+  # survive either precision.
+  test "captured_at is stored at second precision", %{subject: s, network_id: nid} do
+    :ok = Dir.replace_start(s, nid)
+    :ok = Dir.ingest(s, nid, rows(1))
+    :ok = Dir.finalize(s, nid)
+
+    assert %{captured_at: %DateTime{microsecond: {0, 0}}} = Dir.list(s, nid, ttl_ms: @ample_ttl_ms)
+  end
+
   test "replace_start clears a prior snapshot", %{subject: s, network_id: nid} do
     :ok = Dir.replace_start(s, nid)
     :ok = Dir.ingest(s, nid, rows(2))


### PR DESCRIPTION
## This is NOT the #713 test fix — that already shipped

`1820d6ec test(#713): stop asking a second-precision column a sub-second
question (#718)` landed the flake fix on `main`. Verified rather than
assumed: `channel_directory_test.exs` already carries `@ample_ttl_ms
60_000` / `@expired_ttl_ms -1`, `session/directory_test.exs:190` already
reads `ttl_ms: 60_000`, and `git grep "ttl_ms: 1_000"` over `test/` and
`lib/` returns nothing (the one `1_000` left at `directory_test.exs:137`
is an `assert_receive` timeout, not a TTL). The issue stayed open through
drift, not through unfinished work.

What is left is the issue's **second** question, and one pin nobody had
written.

## The open question, answered: no runtime rejection

> Worth deciding whether `list/3` should reject a `ttl_ms` below the
> column's granularity outright.

**No** — three measurements, not a preference:

1. **It would not have caught the case that prompted it.** The value that
   went red was `ttl_ms: 1_000` — exactly the granularity, not below it. A
   `ttl_ms < 1_000` guard passes that call through untouched. The hazard is
   not "sub-second window", it is "window comparable to the anchor's
   uncertainty", and a guard cannot tell those apart because it cannot know
   how old the caller expects the snapshot to be.
2. **It would reject a live production caller.**
   `Session.Server.total_directory_rows/1` (`server.ex:5978`) passes
   `ttl_ms: 0` and reads `.total` only — it never looks at `status`, so the
   zero is a "don't care", not a question.
3. **It would break the constant that closed the flake.** `@expired_ttl_ms
   -1` forces `:stale` deterministically, and `0` is not equivalent: the
   comparison is `age_ms <= ttl_ms`.

So the floor goes where a caller actually reads it — `list/3`'s `:ttl_ms`
doc — plus a decision entry in `DESIGN_NOTES`. The anchor is
second-precision, the derived age overstates by up to 999 ms and never
understates, and a window near that granularity answers by the clock
rather than by the data. Production is clear by five orders of magnitude
(48h).

## The pin that was missing

The doc, the test constants and the decision all rest on `captured_at`
being `:utc_datetime` — and nothing asserted it. Every other case in the
module reads freshness through a window wide enough to survive either
precision, so a migration to `:utc_datetime_usec` would have made all
three silently false with the suite still green.

`"captured_at is stored at second precision"` closes that.
**Verified by mutation, not assumed**: switching the schema field to
`:utc_datetime_usec` and dropping `finalize/2`'s truncate turns exactly
that one case red (1 failure in 9 tests + 1 property) while the rest of
the module stays green. `ingest/3`'s truncate was deliberately left in
place for the measurement — `inserted_at`/`updated_at` are still
`:utc_datetime`, so dropping it makes Ecto refuse the dump and the whole
module dies for an unrelated reason, which would have measured nothing.

## Not done, deliberately

`total_directory_rows/1` having to invent a TTL to ask for a row count is
a smell; a `count/2` would let it stop lying. That is an API change with
no defect behind it, and it is not what this PR is about.

## Gates

`scripts/check.sh` exit 0, read from a file rather than a pipe. Every
stage ran: compile `--warnings-as-errors`, `format --check-formatted`,
`credo --strict` (5120 mods/funs, no issues), `deps.audit` (no
vulnerabilities), `hex.audit` (advisory-only by design — #149), sobelow,
doctor in both envs, `8 doctests, 54 properties, 5290 tests, 0 failures`,
dialyzer, docs, wire-types drift check, and bats (328 ok / 0 not ok).
Working tree clean before and after.