### PR TITLE
cic(#687): make the CRT splash say which boot stage it is waiting on

### DIFF
--- a/cicchetto/e2e/tests/issue687-crt-boot-stages.spec.ts
+++ b/cicchetto/e2e/tests/issue687-crt-boot-stages.spec.ts
@@ -1,0 +1,122 @@
+// issue687-crt-boot-stages — the CRT splash must say WHICH boot stage it
+// is waiting on. Before #687 it showed the same five static lines during
+// a healthy 200 ms boot and during a stall, three of them asserting
+// subsystems were "OK" while the boot sat on a fetch. The user could not
+// tell "still loading" from "dead"; a self-hoster's installed PWA hung on
+// that screen every first launch.
+//
+// WHAT THIS PINS, and why it is not satisfiable by a component that
+// merely exists: every assertion reads the RENDERED TEXT of a stage line
+// and pairs it with the resource state that produced it. Two directions,
+// because only both together are a real proof —
+//
+//   * a register hard-coded to "done" passes an "is it visible?" check
+//     and fails `assertPending` here;
+//   * a register hard-coded to pending passes `assertPending` and fails
+//     `assertDone` in the second test.
+//
+// FROZEN BOOT, not a natural one: the splash is the Shell main-pane
+// `<Switch fallback>`, alive only until the boot resources settle. We
+// hold a stage open with a never-resolving `page.route`, the technique
+// crt-splash-font.spec.ts (#180) already uses. PENDING, not aborted: an
+// aborted resource ERRORS and Solid re-throws it on read, which trips
+// BootErrorBoundary and replaces the splash.
+//
+// BUDGET: #717's `bootFetch` bounds each boot GET at 8 s and retries
+// twice (500 ms + 2 s backoff), so a hung route yields ~26.5 s of splash
+// before the boundary takes over. Every assertion below must land inside
+// the FIRST attempt's 8 s — hence the explicit short timeouts. If a
+// future change to BOOT_FETCH_TIMEOUT_MS shortens that, this spec goes
+// red rather than silently asserting against the failure screen.
+
+import { type Locator, type Page, expect, test } from "@playwright/test";
+
+const ME_USER = {
+  kind: "user",
+  id: "e2e-687",
+  name: "e2e-687",
+  is_admin: false,
+  inserted_at: "2026-01-01T00:00:00Z",
+};
+
+function stage(page: Page, id: string): Locator {
+  return page.locator(`[data-stage="${id}"]`);
+}
+
+async function assertPending(line: Locator, label: string): Promise<void> {
+  await expect(line).toBeVisible({ timeout: 7_000 });
+  await expect(line).toHaveText(`${label}...`);
+  await expect(line).toHaveAttribute("data-done", "false");
+}
+
+async function assertDone(line: Locator, label: string): Promise<void> {
+  await expect(line).toBeVisible({ timeout: 7_000 });
+  await expect(line).toHaveText(`${label}... done`);
+  await expect(line).toHaveAttribute("data-done", "true");
+}
+
+// Seed a bearer + subject so RequireAuth mounts Shell without a real
+// login (auth.ts `isAuthenticated` gates on token PRESENCE), suppress the
+// install splash, and stub the boot theme GET so a fake bearer never
+// makes a real round-trip. Mirrors crt-splash-font.spec.ts.
+async function seedFrozenBoot(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    localStorage.setItem("grappa-token", "e2e-687-boot-stages");
+    localStorage.setItem(
+      "grappa-subject",
+      JSON.stringify({ kind: "user", id: "e2e-687", name: "e2e-687" }),
+    );
+    localStorage.setItem("cic.installChoice", "browser");
+  });
+
+  await page.route("**/me/theme", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "null" }),
+  );
+}
+
+test("a stalled /me names the stage it is stuck on, and claims no others (#687)", async ({
+  page,
+}) => {
+  await seedFrozenBoot(page);
+  await page.route("**/me", () => new Promise(() => {}));
+
+  await page.goto("/");
+
+  await expect(page.getByTestId("crt-splash")).toBeVisible({ timeout: 7_000 });
+
+  // The stall is at the first stage, so all three lines must read as
+  // unfinished. A splash that printed "done" on a fetch that never
+  // answered would be the old lie in a new font.
+  await assertPending(stage(page, "me"), "fetching my info");
+  await assertPending(stage(page, "networks"), "fetching networks");
+  await assertPending(stage(page, "channels"), "fetching channels");
+});
+
+test("a stalled /networks shows my info DONE and the stall one line down (#687)", async ({
+  page,
+}) => {
+  await seedFrozenBoot(page);
+
+  // /me answers; the networks fetch it unblocks never does. `**/networks`
+  // does not match `/networks/<slug>/channels`, which is a different
+  // path — but that fetch is keyed on this one and so never fires.
+  await page.route("**/me", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(ME_USER),
+    }),
+  );
+  await page.route("**/networks", () => new Promise(() => {}));
+
+  await page.goto("/");
+
+  await expect(page.getByTestId("crt-splash")).toBeVisible({ timeout: 7_000 });
+
+  // THE differential: the same screen, one stage further on. This is the
+  // assertion a static register cannot satisfy at the same time as the
+  // first test's.
+  await assertDone(stage(page, "me"), "fetching my info");
+  await assertPending(stage(page, "networks"), "fetching networks");
+  await assertPending(stage(page, "channels"), "fetching channels");
+});

--- a/cicchetto/src/CrtSplash.tsx
+++ b/cicchetto/src/CrtSplash.tsx
@@ -1,5 +1,5 @@
-import { type Component, Show } from "solid-js";
-import { channelsBySlug, user } from "./lib/networks";
+import { type Component, For, Show } from "solid-js";
+import { channelsBySlug, networks, user } from "./lib/networks";
 
 // #134 — retro CRT splash / loading screen.
 //
@@ -25,14 +25,41 @@ import { channelsBySlug, user } from "./lib/networks";
 // scrollback invariant is unaffected: this is app chrome, not inline
 // scrollback media.
 
-// Fake POST / boot lines for nerd flavour. Static text (no typing
-// animation) keeps it cheap to render and free of timing flake.
-const BOOT_LINES: readonly string[] = [
+// Retro banner. Flavour only, and now ONLY flavour: the three lines that
+// used to sit here claiming "scrollback subsystem ... OK" / "phoenix
+// channels link ... OK" / "connecting to bouncer ..." were static text
+// that said OK whatever the app was doing. During the stall #687 was
+// filed for, the splash was not merely silent — it asserted that
+// subsystems were up while the boot sat waiting on a fetch.
+const BANNER_LINES: readonly string[] = [
   "GRAPPA TERMINAL  ·  phosphor edition",
   "POST ............................ OK",
-  "scrollback subsystem ............ OK",
-  "phoenix channels link ........... OK",
-  "connecting to bouncer ...",
+];
+
+// #687 — the boot register. One line per stage, marked `done` as it
+// resolves, so a stall says WHERE it is stuck instead of looking exactly
+// like a healthy 200 ms boot.
+//
+// THREE stages, not the two the issue names: the boot chain is three
+// fetches deep and each is keyed on the one before it —
+// `channelsBySlug` ← `networks` ← `user` (lib/networks.ts), the same
+// chain `bootFetch`'s moduledoc enumerates. A register that named only
+// `me` and `channels` would label a stall in `GET /networks` as a
+// channels stall, which is the diagnosis this screen exists to give.
+//
+// Each `done` reads the SAME resource the `loading` predicate below
+// reads. No parallel "boot progress" state to drift out of sync: if the
+// register says all three are done, the gate has already handed off.
+type BootStage = {
+  readonly id: string;
+  readonly label: string;
+  readonly done: () => boolean;
+};
+
+const STAGES: readonly BootStage[] = [
+  { id: "me", label: "fetching my info", done: () => !!user() },
+  { id: "networks", label: "fetching networks", done: () => networks() !== undefined },
+  { id: "channels", label: "fetching channels", done: () => channelsBySlug() !== undefined },
 ];
 
 const CrtSplash: Component = () => {
@@ -52,8 +79,28 @@ const CrtSplash: Component = () => {
               vignette overlays so the phosphor glow reads through. */}
           <div class="crt-splash-content">
             <pre class="crt-splash-boot" aria-hidden="true">
-              {BOOT_LINES.join("\n")}
+              {BANNER_LINES.join("\n")}
             </pre>
+            {/* Not aria-hidden, unlike the banner above: this is the
+                only part of the screen carrying information, and the
+                container is already `role="status" aria-live="polite"`,
+                so each stage is announced as it completes. */}
+            <ul class="crt-splash-stages" data-testid="crt-boot-stages">
+              <For each={STAGES}>
+                {(stage) => (
+                  <li
+                    class="crt-splash-stage"
+                    data-stage={stage.id}
+                    data-done={stage.done() ? "true" : "false"}
+                  >
+                    {stage.label}...
+                    <Show when={stage.done()}>
+                      <span class="crt-splash-stage-done">{" done"}</span>
+                    </Show>
+                  </li>
+                )}
+              </For>
+            </ul>
             <p class="crt-splash-status">
               <span class="crt-splash-loading-text">LOADING</span>
               <span class="crt-splash-cursor" aria-hidden="true">

--- a/cicchetto/src/__tests__/CrtSplash.test.tsx
+++ b/cicchetto/src/__tests__/CrtSplash.test.tsx
@@ -19,16 +19,27 @@ import CrtSplash from "../CrtSplash";
 // Mocks: networks.ts (user + channelsBySlug signals).
 
 const userMock = vi.fn<() => unknown>(() => null);
+const networksMock = vi.fn<() => unknown>(() => undefined);
 const channelsBySlugMock = vi.fn<() => unknown>(() => undefined);
 
 vi.mock("../lib/networks", () => ({
   user: () => userMock(),
+  networks: () => networksMock(),
   channelsBySlug: () => channelsBySlugMock(),
 }));
+
+const USER = { kind: "visitor", id: "v1", nick: "guest", network_slug: "azzurra" };
+
+function stageLine(id: string): HTMLElement {
+  const el = document.querySelector(`[data-stage="${id}"]`);
+  if (el === null) throw new Error(`no boot-register line for stage "${id}"`);
+  return el as HTMLElement;
+}
 
 describe("CrtSplash (#134 — retro CRT loading splash)", () => {
   beforeEach(() => {
     userMock.mockReturnValue(null);
+    networksMock.mockReturnValue(undefined);
     channelsBySlugMock.mockReturnValue(undefined);
   });
 
@@ -48,15 +59,63 @@ describe("CrtSplash (#134 — retro CRT loading splash)", () => {
   });
 
   it("still renders while the channels resource is loading (user resolved, channels undefined)", () => {
-    userMock.mockReturnValue({ kind: "visitor", id: "v1", nick: "guest", network_slug: "azzurra" });
+    userMock.mockReturnValue(USER);
+    networksMock.mockReturnValue([]);
     channelsBySlugMock.mockReturnValue(undefined);
     render(() => <CrtSplash />);
 
     expect(screen.getByTestId("crt-splash")).toBeInTheDocument();
   });
 
+  // #687 — the register must say WHERE the boot is, not merely exist. A
+  // test that asserts the three lines are present would pass against a
+  // register hard-coded to "done", so every case below pins the done
+  // FLAG against a resource state, in both directions.
+  it("prints one un-done line per stage while nothing has resolved", () => {
+    render(() => <CrtSplash />);
+
+    expect(screen.getByTestId("crt-boot-stages").children).toHaveLength(3);
+
+    for (const id of ["me", "networks", "channels"]) {
+      expect(stageLine(id).dataset.done).toBe("false");
+      expect(stageLine(id).textContent).not.toMatch(/done/);
+    }
+
+    expect(stageLine("me").textContent).toBe("fetching my info...");
+  });
+
+  it("marks a stage done the moment its resource resolves, and only that stage", () => {
+    // /me answered; the networks fetch it unblocks is still in flight.
+    userMock.mockReturnValue(USER);
+    networksMock.mockReturnValue(undefined);
+    channelsBySlugMock.mockReturnValue(undefined);
+    render(() => <CrtSplash />);
+
+    expect(stageLine("me").dataset.done).toBe("true");
+    expect(stageLine("me").textContent).toBe("fetching my info... done");
+
+    // The stall is now named: this is the line the user is waiting on.
+    expect(stageLine("networks").dataset.done).toBe("false");
+    expect(stageLine("networks").textContent).toBe("fetching networks...");
+    expect(stageLine("channels").dataset.done).toBe("false");
+  });
+
+  it("marks the networks stage done on a resolved EMPTY list, not just a populated one", () => {
+    // `[]` is a resolved resource — a subject with no networks has
+    // finished that stage. Reading it as "still fetching" would leave
+    // the register stuck on a boot that is in fact past it.
+    userMock.mockReturnValue(USER);
+    networksMock.mockReturnValue([]);
+    channelsBySlugMock.mockReturnValue(undefined);
+    render(() => <CrtSplash />);
+
+    expect(stageLine("networks").dataset.done).toBe("true");
+    expect(stageLine("channels").dataset.done).toBe("false");
+  });
+
   it("hands off — renders nothing once both /me and channels have loaded", () => {
-    userMock.mockReturnValue({ kind: "visitor", id: "v1", nick: "guest", network_slug: "azzurra" });
+    userMock.mockReturnValue(USER);
+    networksMock.mockReturnValue([]);
     // A resolved empty object is truthy: load is DONE, there just are no
     // channels yet. The splash must hand off (render null), not linger.
     channelsBySlugMock.mockReturnValue({});

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -8452,6 +8452,23 @@ html.resize-dragging * {
   color: var(--crt-phosphor-dim);
 }
 
+/* #687 — the boot register. Same phosphor-dim body as the banner above
+   so it reads as one continuous CRT print-out; a completed stage steps
+   up to full phosphor, which is the only visual difference between
+   "waiting here" and "past this". */
+.crt-splash-stages {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 1.04rem;
+  line-height: 1.5;
+  color: var(--crt-phosphor-dim);
+}
+
+.crt-splash-stage-done {
+  color: var(--crt-phosphor);
+}
+
 .crt-splash-status {
   margin: 0;
   display: flex;


### PR DESCRIPTION
## The splash was worse than mute

The issue says a stalled boot shows "exactly the same thing it shows
during a healthy 200 ms boot: nothing". Measured, it showed **five static
lines**, three of them claims:

```
scrollback subsystem ............ OK
phoenix channels link ........... OK
connecting to bouncer ...
```

That text was hard-coded. During the stall it asserted subsystems were up
while the boot sat on a fetch — not silence, a false status report.

Those three are replaced by a register derived from the resources the
`loading` gate already reads: one line per stage, gaining `done` as it
resolves. Nothing else — no progress bar, no parallel boot-progress state
that could drift from the gate. The retro banner stays.

**Three stages, not the two the issue names.** The chain is three fetches
deep, each keyed on the one before (`channelsBySlug` ← `networks` ←
`user`) — the same chain `bootFetch`'s own moduledoc enumerates. A
register naming only me and channels would report a stall in `GET
/networks` as a channels stall, which is the diagnosis this screen exists
to give.

The register is not `aria-hidden`, unlike the banner. The container is
already `role="status" aria-live="polite"`, so a stage is announced as it
completes; a screen reader was getting the same nothing the eye was.

## Two of the issue's claims are stale — measured

> Neither boot fetch carries an `AbortSignal`, a timeout, or a retry.
> [...] If one hangs, the splash stays up forever.
> Verified against `origin/main` @ `043a71e2`.

Both were true at `043a71e2` and are false now. `git log
043a71e2..origin/main` lands **#717** in between:
`ffce283b` (bound the three boot GETs with a timeout and retry),
`74fe3243` (visible failure state and a way out),
`b7898df3`, `c0c6d295`, and `#779`'s `abaf5a25`. Today `bootFetch` gives
each boot GET an 8 s `AbortSignal.timeout` and two retries, and
`BootErrorBoundary` renders a failure message plus a **Retry** button
when the budget is spent — so a hang resolves to a visible dead end in
~26.5 s, not never.

Which means the issue's "after N seconds the stuck line should say so and
offer a retry" **already shipped**. What was still missing is the part
this PR does: saying *which stage* during those 26.5 s.

## Proof, not coverage

**Unit** — the three new cases pin the `done` flag against a resource
state in both directions, including the `[]` case (a resolved empty
network list is a FINISHED stage, not a pending one). Verified by
mutation: hard-coding all three stages to `done: () => true` turns
exactly those three red while the **three pre-existing cases stay green**
— which is itself the measurement that the old test file would have
accepted a register that lies.

**e2e** (`issue687-crt-boot-stages.spec.ts`) — two specs freeze the boot
at different stages and read rendered text: with `/me` hung all three
lines must read unfinished; with `/me` answered and `/networks` hung,
line one must read `fetching my info... done` and the stall must have
moved one line down. No single hard-coded register satisfies both. Frozen
with a never-resolving `page.route`, the technique
`crt-splash-font.spec.ts` (#180) already uses.

## What has NOT been run

The e2e spec is **authored but never executed** — the stack lane is held
by another branch. It also gets no static gate: `bun run check` is
`biome check src && tsc --noEmit`, neither of which covers `e2e/`, and
`tsc -p e2e/tsconfig.json` cannot resolve `@playwright/test` types in
this container. So its first execution will be the integration job unless
the lane frees up first. Flagging rather than implying a green.

**Run and green:** `bun run check` (biome + tsc) exit 0; `bun run test`
242 files / 4435 tests / 0 failures.

## Deliberately not done

Timeout, abort, retry and a failure state on the boot fetches — already
shipped by #717, as measured above. The PWA-relaunch trigger is tracked
separately. One thing I would propose separately rather than smuggle in
here: once all three stages resolve, `loading()` goes false and the
splash renders `null` while the Shell `<Switch>` fallback is still the
splash — so if auto-select never lands the user gets a **blank** pane,
which is the #193 dead end through a third door. Fixing it means changing
the splash's gate, which is a behaviour change beyond a boot log.