### PR TITLE
rail(#897): the uptime anchor belongs to the link, not to the row

### DIFF
--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -344,6 +344,29 @@ export async function fetchAllMessagesAsc(
   return [...byId.values()].sort((a, b) => a.id - b.id);
 }
 
+// M-9a — force-stop a live Session.Server pid, leaving every DB row
+// untouched (`DELETE /admin/sessions/:id` → `Operator.terminate_session`).
+// The m9b spec drives the same verb through the admin UI; this is the
+// runner-side twin for specs that need the RESULTING STATE rather than the
+// button. That state is the only way to manufacture, over a real stack, the
+// divergence #897 is about: a credential row still reading `:connected` with
+// no live link behind it.
+//
+// `sessionId` is the composite `"<kind>:<subject_uuid>:<network_id>"` the
+// admin surface keys on. Idempotent (204 even when the pid is already gone).
+export async function terminateSession(adminToken: string, sessionId: string): Promise<void> {
+  const url = `${GRAPPA_BASE_URL}/admin/sessions/${encodeURIComponent(sessionId)}`;
+  const res = await fetch(url, {
+    method: "DELETE",
+    headers: { authorization: `Bearer ${adminToken}` },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `grappaApi.terminateSession: ${sessionId} → ${res.status} ${await res.text()}`,
+    );
+  }
+}
+
 // M-cluster M-8 — operator-side delete via admin bearer. Mirrors
 // `Grappa.Operator.delete_visitor/1`. Used by e2e tests that mint
 // a visitor and need teardown cleanup on early-assertion-failure

--- a/cicchetto/e2e/tests/issue897-link-uptime.spec.ts
+++ b/cicchetto/e2e/tests/issue897-link-uptime.spec.ts
@@ -1,0 +1,146 @@
+// #897 — the server-info card's "connected <duration>" must measure the LIVE
+// IRC link, and must say nothing when there is no live link to measure.
+//
+// Mezmerize reported `connected 10d 9h` on an instance he was power-cycling
+// daily for upgrades. The card read the credential's
+// `connection_state_changed_at`, which answers a different question: when the
+// ROW last changed state. `Networks.connect/1` returns without a DB write on
+// an already-`:connected` row, and a restart deliberately never parks the
+// credential, so that column sails through restarts the socket does not.
+//
+// The fix moves the anchor to `connection.connected_at` — `Session.Server`'s
+// per-process stamp, inside the live-only `connection` sub-object of
+// `GET /networks`. Two consequences, and this spec asserts BOTH over the real
+// stack because only the real stack can produce the divergence:
+//
+//   1. On a live link the duration renders — proving the new anchor actually
+//      travels Session.Server → wire → store → DOM, which jsdom cannot show.
+//   2. With the pid stopped and the DB row left at `:connected`, the card
+//      keeps reporting the DB-canonical state and reports NO duration. This
+//      is the discriminator: the OLD code renders a duration here, computed
+//      from a column the terminate did not touch. It is also the CLAUDE.md
+//      DB-vs-live rule made visible — divergence is shown, not smoothed over.
+//
+// Subject choice: a freshly minted VISITOR, not a seeded user. The spec has
+// to kill a session to create the divergence, and a throwaway visitor is the
+// one subject whose death poisons no downstream spec on the serial stack
+// (`feedback_e2e_real_login_poisons_shared_stack`); it is reaped in `finally`.
+//
+// Desktop viewport → the rail column is permanent (#71 INC-2), no drawer
+// dance. Sibling coverage: `issue474-server-info-rail.spec.ts` (the card's
+// other rows), `ServerInfoCard.test.tsx` (the pure rendering rule).
+
+import { expect, test } from "@playwright/test";
+import { selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import {
+  GRAPPA_BASE_URL,
+  mintVisitor,
+  reapVisitors,
+  terminateSession,
+} from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+
+const SERVER_WINDOW_LABEL = "Server";
+
+// The composite id the admin session verbs key on. Resolved from the
+// visitor's own `GET /networks` rather than assuming the seeder's
+// single-network id, so the spec states its input instead of guessing it.
+async function resolveNetworkId(token: string, slug: string): Promise<number> {
+  const res = await fetch(`${GRAPPA_BASE_URL}/networks`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    throw new Error(`issue897: GET /networks → ${res.status} ${await res.text()}`);
+  }
+  const rows = (await res.json()) as Array<{ id: number; slug: string }>;
+  const row = rows.find((r) => r.slug === slug);
+  if (!row) throw new Error(`issue897: visitor has no row for ${slug}`);
+  return row.id;
+}
+
+test.describe("#897 server-info uptime measures the live link", () => {
+  test("renders the link's uptime while up, and NO duration once the pid is gone", async ({
+    browser,
+  }) => {
+    const admin = getSeededAdmin();
+    const visitor = await mintVisitor(`e2e897-${Date.now()}`);
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+
+    try {
+      const networkId = await resolveNetworkId(visitor.token, visitor.network_slug);
+      const subjectJson = JSON.stringify({
+        kind: "visitor",
+        id: visitor.id,
+        nick: visitor.nick,
+        network_slug: visitor.network_slug,
+        registered: false,
+      });
+      await page.addInitScript(
+        ([token, subject]) => {
+          localStorage.setItem("grappa-token", token);
+          localStorage.setItem("grappa-subject", subject);
+          localStorage.setItem("cic.installChoice", "browser");
+        },
+        [visitor.token, subjectJson] as const,
+      );
+      await page.goto("/");
+
+      // ---- 1. LIVE LINK: the duration is present and is a real duration.
+      await expect(sidebarWindow(page, visitor.network_slug, SERVER_WINDOW_LABEL)).toHaveCount(1, {
+        timeout: 15_000,
+      });
+      await selectChannel(page, visitor.network_slug, SERVER_WINDOW_LABEL, {
+        awaitWsReady: false,
+      });
+
+      const card = page.locator("[data-testid=rail-server-info]");
+      await expect(card).toBeVisible({ timeout: 10_000 });
+      await expect(card).toContainText("connected");
+      // The `dt` "connected" labels the uptime row (the state word above it
+      // lives in the `status` row's `dd`), so this locator is specific to the
+      // duration. The visitor's link is seconds old — a fresh mint — so the
+      // value is a small unit, which is itself evidence the anchor is the
+      // LINK and not the long-lived seeded row.
+      await expect(card.locator('dt:text-is("connected") + dd')).toHaveText(/\d+\s*[smhd]/, {
+        timeout: 10_000,
+      });
+
+      // ---- 2. Kill the pid, leave the row alone.
+      // `DELETE /admin/sessions/:id` is documented "force-stop the pid
+      // without touching the DB row" — so the credential still reads
+      // `:connected` while nothing is connected. Exactly Mezmerize's shape,
+      // manufactured in one call instead of a restart.
+      await terminateSession(admin.token, `visitor:${visitor.id}:${networkId}`);
+
+      // Reload rather than waiting for a push: no state TRANSITION happened,
+      // so by design there is no `connection_state_changed` event to react to
+      // — which is the whole reason the stale column went unnoticed. A fresh
+      // `GET /networks` is how a user coming back to the tab sees it.
+      await page.reload();
+      await expect(sidebarWindow(page, visitor.network_slug, SERVER_WINDOW_LABEL)).toHaveCount(1, {
+        timeout: 15_000,
+      });
+      await selectChannel(page, visitor.network_slug, SERVER_WINDOW_LABEL, {
+        awaitWsReady: false,
+      });
+      await expect(card).toBeVisible({ timeout: 10_000 });
+
+      // The DB-canonical state is unchanged and still shown — the card does
+      // not invent a "disconnected" it was never told about.
+      await expect(card).toContainText("connected");
+
+      // The live rows are gone, because there is no live session to describe.
+      // `server` first: it is the pre-existing #474 B honesty signal, so its
+      // absence proves `connection` really is null here and the uptime check
+      // below is testing the intended condition rather than a mis-seeded one.
+      await expect(card.locator('dt:text-is("server")')).toHaveCount(0);
+      // THE point of #897: no duration. Pre-fix this row rendered, counting
+      // from a timestamp the terminate never touched.
+      await expect(card.locator('dt:text-is("connected")')).toHaveCount(0);
+    } finally {
+      await ctx.close();
+      await reapVisitors(admin.token, visitor.id);
+    }
+  });
+});

--- a/cicchetto/src/ServerInfoCard.tsx
+++ b/cicchetto/src/ServerInfoCard.tsx
@@ -13,8 +13,9 @@ import { MircBody } from "./MircText";
 // Facts-only, sourced from existing session/network state:
 //   * slug   — the network label (there is no separate human name)
 //   * status — DB-canonical connection_state glyph + word + reason
-//   * uptime — connected-since, ONLY while genuinely connected (honesty:
-//              a duration next to a parked/failed state would lie)
+//   * uptime — how long the LIVE link has been up (#897), read from the
+//              `connection` sub-object below, so it is absent exactly when
+//              there is no live socket to measure
 //   * nick   — own IRC nick on this network
 //   * services — which NickServ software (omitted when "unknown")
 //
@@ -24,6 +25,7 @@ import { MircBody } from "./MircText";
 //              peer IP, so a round-robin landing is visible (#550 capture)
 //   * tls    — a 🔒 lock when the transport is TLS
 //   * identified — yes/no, from the +r umode (the #561 identity signal)
+//   * connected_at — the instant this socket came up, the uptime anchor (#897)
 // `connection` is null whenever there is no live connected session, so
 // these rows appear ONLY on a real socket — honesty over a stale value.
 //
@@ -40,13 +42,18 @@ type Props = {
 
 const ServerInfoCard: Component<Props> = (props) => {
   const state = () => connectionStateEmoji(props.network.connection_state);
-  // Uptime ONLY while connected — connection_state_changed_at is "time of
-  // last state transition", which IS the connect instant for a live link,
-  // but next to a parked/failed state it would read as a lie.
+  // #897 — how long THIS link has been up, from the live `connection`
+  // sub-object. Never `connection_state_changed_at`: that is the credential
+  // ROW's last state transition, and a bouncer restart leaves the row at
+  // `connected` without writing it, so it kept counting across restarts
+  // (Mezmerize saw "connected 10d 9h" on a box he power-cycled daily).
+  // Sourcing it from `connection` also makes the honest silence automatic:
+  // no live pid ⇒ no `connection` ⇒ no duration, rather than a number
+  // computed from a DB column that outlived the socket.
+  // `?? null` because cic and the server deploy independently — a server
+  // that predates the field sends `connection` without it.
   const uptime = () =>
-    props.network.connection_state === "connected"
-      ? formatDurationSince(props.network.connection_state_changed_at, props.now)
-      : null;
+    formatDurationSince(props.network.connection?.connected_at ?? null, props.now);
   const services = () => {
     const flavor = props.network.services_flavor;
     return flavor && flavor !== "unknown" ? flavor : null;

--- a/cicchetto/src/__tests__/RailContext.test.tsx
+++ b/cicchetto/src/__tests__/RailContext.test.tsx
@@ -47,7 +47,13 @@ const net: Network = {
   connection_state: "connected",
   connection_state_reason: null,
   connection_state_changed_at: "2026-07-31T08:00:00.000Z",
-  connection: { server: "89.31.72.10", port: 6697, tls: true, registered: true },
+  connection: {
+    server: "89.31.72.10",
+    port: 6697,
+    tls: true,
+    registered: true,
+    connected_at: "2026-07-31T08:00:00.000Z",
+  },
   inserted_at: "2026-07-01T00:00:00.000Z",
   updated_at: "2026-07-01T00:00:00.000Z",
 };

--- a/cicchetto/src/__tests__/ServerInfoCard.test.tsx
+++ b/cicchetto/src/__tests__/ServerInfoCard.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@solidjs/testing-library";
 import { describe, expect, it } from "vitest";
-import type { Network } from "../lib/api";
+import type { ConnectionInfo, Network } from "../lib/api";
 import ServerInfoCard from "../ServerInfoCard";
 
 // #474 — the server-window rail card. Pure presentational: it takes the
@@ -14,6 +14,18 @@ import ServerInfoCard from "../ServerInfoCard";
 
 const now = Date.parse("2026-07-31T12:00:00.000Z");
 
+// #897 — the LIVE link facts. `connected_at` is the instant THIS socket came
+// up (Session.Server's per-process stamp), deliberately 4h12m ago while the
+// credential row below last TRANSITIONED 10 days ago: the two must not be
+// confused, and the card renders the former.
+const baseConn: ConnectionInfo = {
+  server: "89.31.72.10",
+  port: 6697,
+  tls: true,
+  registered: true,
+  connected_at: new Date(now - (4 * 3600 + 12 * 60) * 1000).toISOString(),
+};
+
 const baseNet: Network = {
   kind: "user",
   id: 7,
@@ -24,8 +36,8 @@ const baseNet: Network = {
   realname: "VJT",
   connection_state: "connected",
   connection_state_reason: null,
-  connection_state_changed_at: new Date(now - (4 * 3600 + 12 * 60) * 1000).toISOString(),
-  connection: { server: "89.31.72.10", port: 6697, tls: true, registered: true },
+  connection_state_changed_at: new Date(now - 10 * 86400 * 1000).toISOString(),
+  connection: baseConn,
   inserted_at: "2026-07-01T00:00:00.000Z",
   updated_at: "2026-07-01T00:00:00.000Z",
 };
@@ -77,12 +89,45 @@ describe("ServerInfoCard", () => {
     expect(card.textContent).toContain("SASL 904 authentication failed");
   });
 
-  it("omits the uptime row when connected but the timestamp is unknown (null)", () => {
+  it("omits the uptime row when connected but the connect instant is unknown (null)", () => {
     render(() => (
-      <ServerInfoCard network={{ ...baseNet, connection_state_changed_at: null }} now={now} />
+      <ServerInfoCard
+        network={{ ...baseNet, connection: { ...baseConn, connected_at: null } }}
+        now={now}
+      />
     ));
     const card = screen.getByTestId("rail-server-info");
     expect(card.textContent).toContain("connected");
+    expect(card.textContent).not.toContain("4h 12m");
+  });
+
+  // #897 — Mezmerize's report: the card read `connection_state_changed_at`,
+  // the credential's last state TRANSITION. A bouncer restart never moves the
+  // row out of `:connected` (Networks.connect/1 no-ops without a DB write), so
+  // that column outlives the link by however many restarts happened since. The
+  // card must measure the LIVE link, which is what `connection.connected_at`
+  // (Session.Server's per-process stamp) is.
+  it("measures the live link, not the last DB state transition (#897)", () => {
+    render(() => <ServerInfoCard network={baseNet} now={now} />);
+    const card = screen.getByTestId("rail-server-info");
+    // The fixture's link came up 4h12m ago; its row last transitioned 10d ago.
+    expect(card.textContent).toContain("4h 12m");
+    expect(card.textContent).not.toContain("10d");
+  });
+
+  it("shows NO uptime when the DB row says connected but no link is live (#897)", () => {
+    // DB state and live state are separate sources of truth and may diverge
+    // (CLAUDE.md). A `:connected` row with a dead/reconnecting session gets an
+    // honest silence, never a duration computed from the DB column.
+    render(() => (
+      <ServerInfoCard
+        network={{ ...baseNet, connection_state: "connected", connection: null }}
+        now={now}
+      />
+    ));
+    const card = screen.getByTestId("rail-server-info");
+    expect(card.textContent).toContain("connected");
+    expect(card.textContent).not.toContain("10d");
     expect(card.textContent).not.toContain("4h 12m");
   });
 
@@ -110,7 +155,13 @@ describe("ServerInfoCard", () => {
       <ServerInfoCard
         network={{
           ...baseNet,
-          connection: { server: "127.0.0.1", port: 6667, tls: false, registered: false },
+          connection: {
+            ...baseConn,
+            server: "127.0.0.1",
+            port: 6667,
+            tls: false,
+            registered: false,
+          },
         }}
         now={now}
       />

--- a/cicchetto/src/__tests__/api.test.ts
+++ b/cicchetto/src/__tests__/api.test.ts
@@ -626,7 +626,13 @@ describe("tagNetwork (bucket F H4)", () => {
   });
 
   it("#474 B — passes connection through; defaults a missing one to null", () => {
-    const conn = { server: "89.31.72.10", port: 6697, tls: true, registered: true };
+    const conn = {
+      server: "89.31.72.10",
+      port: 6697,
+      tls: true,
+      registered: true,
+      connected_at: "2026-07-31T08:00:00.000Z",
+    };
     expect(api.tagNetwork({ ...rawComplete, connection: conn })?.connection).toEqual(conn);
     // rawComplete omits it → null (session not live / pre-field server), the
     // honest "no live connection" the server-info rail renders as no card.

--- a/cicchetto/src/lib/duration.ts
+++ b/cicchetto/src/lib/duration.ts
@@ -23,7 +23,7 @@ export function formatDuration(seconds: number | null): string | null {
 
 /**
  * Format the span between a wire ISO-8601 instant and `nowMs` (epoch ms)
- * as a human duration — e.g. a network's `connection_state_changed_at`
+ * as a human duration — e.g. a network's `connection.connected_at`
  * rendered as "connected for 4h 12m".
  *
  * Returns null for a null or unparseable timestamp (prefer omitting the

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -586,6 +586,7 @@ export type NetworksWireConnectionInfo = {
   port: number;
   tls: boolean;
   registered: boolean;
+  connected_at: string | null;
 };
 
 export type NetworksWireNetworkWithNickJson = {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -31039,3 +31039,59 @@ the module dies for an unrelated reason — which would have measured nothing.
 **Not done, and deliberately.** `total_directory_rows/1` having to invent a TTL
 to ask for a row count is a smell — a `count/2` would let it stop lying. That
 is an API change with no defect behind it, out of scope for a decision entry.
+
+## 2026-08-06 — #897: the uptime anchor belongs to the link, not to the row
+
+Mezmerize's server-info card read `connected 10d 9h` on a box he was shutting
+down for an upgrade every day. The card sourced that duration from the
+credential's `connection_state_changed_at`, above a comment claiming the column
+"IS the connect instant for a live link".
+
+**The comment was the bug.** `Networks.connect/1` has an explicit
+already-`:connected` clause that returns without a DB write, and a restart is
+deliberately not a state change — a transient loss must not park the network,
+the session reconnects and re-asserts at 001. So `docker stop` + `docker up`
+leaves the row `:connected` from end to end, the connect no-ops on the way back
+in, and the column keeps the timestamp of the last time the ROW moved. That is a
+perfectly good answer to a question nobody was asking.
+
+**The honest anchor already existed:** `Session.Server.connected_at`, stamped at
+`:irc_connected`, per-process, therefore resetting with the socket. The card had
+never been able to see it.
+
+**Where it goes is the design decision.** `connected_at` joins the map returned
+by `Session.connection_info/2` — the live-only facts already embedded as
+`:connection` on both `GET /networks` twins — rather than sitting beside the
+credential's own timestamp. `connection` is already `null` whenever there is no
+live pid, so "no socket ⇒ no duration" falls out of the shape instead of needing
+a second honesty rule bolted onto the renderer. A DB row stuck at `:connected`
+behind a dead session now shows its state and says nothing about uptime: the
+CLAUDE.md DB-vs-live separation, rendered.
+
+**One path, both doors.** `connection` reaches cic only through `GET /networks`,
+through a single `connection_json/1` shared by the user and visitor twins, and
+cic already refetches on the `connection_progress` "connected" edge — so a
+runtime reconnect refreshes the anchor along with the peer IP and the +r flag.
+No push carries `connection` today and none was added: the only place a
+`connection_state_changed` broadcast is built is inside the DB transition path,
+which would have to `GenServer.call` the very session that sometimes triggers it.
+
+Two smaller calls. `connection_json/1` MATCHES `connected_at` instead of
+`Map.get`-defaulting it — the sole producer is `connection_info/2`, so an absent
+key means a new producer forgot, and a FunctionClauseError beats a row that
+quietly stops rendering. And its input spec becomes
+`Grappa.Session.connection_info()`: the domain map carries `%DateTime{}` where
+the wire carries ISO-8601, a split that was invisible only while the two shapes
+happened to coincide. Codegen reads `@type`, not `@spec`, so naming the domain
+type there costs `wireTypes.ts` nothing.
+
+**The class was checked, and it is a class of one.** The issue left "does any
+other reader carry the same assumption?" open. Grepping every caller of
+`formatDuration*` in cic answers it: `ServerInfoCard` and `WhoisCard`, and the
+latter formats a WHOIS `idle_seconds` that never touched the column. `AdminWire`
+and `HomePane` carry `connection_state_changed_at` but render it as a
+transition timestamp, which is what it is. So the fix has no siblings — the one
+site that turned the column into a duration is the one that was wrong.
+
+**What is not claimed.** Mezmerize's database was never read; the mechanism is a
+code reading whose symptom matches, not an observation of his row.

--- a/lib/grappa/networks/wire.ex
+++ b/lib/grappa/networks/wire.ex
@@ -55,12 +55,23 @@ defmodule Grappa.Networks.Wire do
   reconnecting), the honest "no live connection" signal — prefer omitting
   over a stale value. Sourced by the controller via
   `Grappa.Session.connection_info/2`.
+
+  #897 — `:connected_at` (ISO-8601) is the instant THIS link came up, and
+  it lives HERE rather than beside `:connection_state_changed_at` for one
+  reason: it is live state, so it must vanish with the rest of `:connection`
+  when there is no live pid. The credential column next to it answers a
+  DIFFERENT question — when the ROW last changed state — and a bouncer
+  restart never moves the row out of `:connected` (`Networks.connect/1`
+  no-ops without a DB write), so it outlives the link by however many
+  restarts happened since. `nil` on a session whose state predates the
+  field (#216 hot-reload contract): "unknown", never a fabricated instant.
   """
   @type connection_info :: %{
           server: String.t(),
           port: integer(),
           tls: boolean(),
-          registered: boolean()
+          registered: boolean(),
+          connected_at: String.t() | nil
         }
 
   @typedoc """
@@ -313,7 +324,7 @@ defmodule Grappa.Networks.Wire do
           Network.t(),
           String.t(),
           Credential.t(),
-          connection_info() | nil
+          Grappa.Session.connection_info() | nil
         ) :: network_with_nick_json()
   def network_with_nick_to_json(%Network{} = n, nick, %Credential{} = cred, connection)
       when is_binary(nick) and nick != "" and (is_map(connection) or is_nil(connection)) do
@@ -357,7 +368,7 @@ defmodule Grappa.Networks.Wire do
           Network.t(),
           String.t(),
           Credential.t(),
-          connection_info() | nil
+          Grappa.Session.connection_info() | nil
         ) :: visitor_network_with_nick_json()
   def visitor_network_to_json(%Network{} = n, nick, %Credential{} = cred, connection)
       when is_binary(nick) and nick != "" and (is_map(connection) or is_nil(connection)) do
@@ -486,10 +497,29 @@ defmodule Grappa.Networks.Wire do
   # the controller resolved, or nil when there is no live connected session)
   # onto the exact `:connection` wire shape. Rebuilt field-by-field rather
   # than passed through so this module stays the SSOT for the JSON shape.
-  @spec connection_json(connection_info() | nil) :: connection_info() | nil
+  # It is also where the domain/wire type split is paid: the session speaks
+  # `%DateTime{}`, the wire speaks ISO-8601 (#897).
+  #
+  # `connected_at` is matched, not `Map.get`-defaulted: every producer is
+  # `Grappa.Session.connection_info/2`, so a map without the key means a
+  # NEW producer forgot it — a loud FunctionClauseError beats a silently
+  # missing uptime row.
+  @spec connection_json(Grappa.Session.connection_info() | nil) :: connection_info() | nil
   defp connection_json(nil), do: nil
 
-  defp connection_json(%{server: server, port: port, tls: tls, registered: registered}) do
-    %{server: server, port: port, tls: tls, registered: registered}
+  defp connection_json(%{
+         server: server,
+         port: port,
+         tls: tls,
+         registered: registered,
+         connected_at: connected_at
+       }) do
+    %{
+      server: server,
+      port: port,
+      tls: tls,
+      registered: registered,
+      connected_at: WireTime.iso8601_or_nil(connected_at)
+    }
   end
 end

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -1069,23 +1069,31 @@ defmodule Grappa.Session do
   and whether the nick is identified to services (`registered`, from the
   +r umode). Present only while connected; the accessors below degrade to
   `{:error, :no_peer}` otherwise.
+
+  #897 — `connected_at` is the instant THIS link came up (stamped at
+  `:irc_connected`, per-process, so it resets with the socket). `nil` only
+  on a session whose state predates the field (#216 hot-reload contract).
   """
   @type connection_info :: %{
           server: String.t(),
           port: :inet.port_number(),
           tls: boolean(),
-          registered: boolean()
+          registered: boolean(),
+          connected_at: DateTime.t() | nil
         }
 
   @doc """
   Returns the live upstream connection facts for the session at
-  `(subject, network_id)` — `%{server, port, tls, registered}` (#474 B,
-  the server-window rail card).
+  `(subject, network_id)` — `%{server, port, tls, registered, connected_at}`
+  (#474 B, the server-window rail card).
 
   `server` is the peer IP as a string (`:inet.ntoa/1` of the v6/v4 tuple),
   captured once at connect and cached (immutable for the connection), so
   this is an instant state read; `registered` is derived from the live
-  umode set (the same +r identity signal #561 keys on).
+  umode set (the same +r identity signal #561 keys on); `connected_at` is
+  the connect instant of THIS link (#897 — the honest uptime anchor, since
+  the credential's `connection_state_changed_at` survives bouncer restarts
+  the link does not).
 
   Returns `{:error, :no_peer}` in every not-connected window (pre-connect,
   mid-reconnect, socket just closed) — the honest "unknown", never

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -2271,6 +2271,15 @@ defmodule Grappa.Session.Server do
   # projection over this same call (no second overlapping handler). `tls` +
   # `umodes` via `Map.get` for the #216 hot-reload-safety contract (a session
   # started before #474 has neither key in state).
+  #
+  # #897 — `connected_at` rides along: it is the instant THIS link came up
+  # (stamped at `:irc_connected`, so it resets with the socket), the only
+  # honest anchor for "how long has the connection been up". The credential's
+  # `connection_state_changed_at` cannot answer that — `Networks.connect/1`
+  # no-ops without a DB write on an already-`:connected` row and a bouncer
+  # restart leaves the row `:connected`, so the column outlives the link. It
+  # belongs HERE, inside the live-only facts, precisely so it disappears with
+  # them when there is no live socket. `Map.get` for the same #216 contract.
   def handle_call({:connection_info}, _, %{peer_address: nil} = state) do
     {:reply, {:error, :no_peer}, state}
   end
@@ -2280,7 +2289,8 @@ defmodule Grappa.Session.Server do
       server: state.peer_address,
       port: state.peer_port,
       tls: Map.get(state, :tls, false),
-      registered: "r" in Map.get(state, :umodes, [])
+      registered: "r" in Map.get(state, :umodes, []),
+      connected_at: Map.get(state, :connected_at)
     }
 
     {:reply, {:ok, info}, state}

--- a/lib/grappa_web/controllers/networks_json.ex
+++ b/lib/grappa_web/controllers/networks_json.ex
@@ -17,6 +17,7 @@ defmodule GrappaWeb.NetworksJSON do
     longer from the retired singular `me.network_slug`.
   """
   alias Grappa.Networks.{Credential, Network, Wire}
+  alias Grappa.Session
 
   @doc """
   Renders the `:index` action — flat JSON array of network maps.
@@ -30,8 +31,9 @@ defmodule GrappaWeb.NetworksJSON do
   """
   @spec index(%{
           networks:
-            {:user, [{Network.t(), String.t(), Credential.t(), Wire.connection_info() | nil}]}
-            | {:visitor, [{Network.t(), String.t(), Credential.t(), Wire.connection_info() | nil}]}
+            {:user, [{Network.t(), String.t(), Credential.t(), Session.connection_info() | nil}]}
+            | {:visitor,
+               [{Network.t(), String.t(), Credential.t(), Session.connection_info() | nil}]}
         }) :: [Wire.network_with_nick_json()] | [Wire.visitor_network_with_nick_json()]
   def index(%{networks: {:user, network_rows}}) do
     Enum.map(network_rows, fn {network, nick, cred, connection} ->

--- a/lib/grappa_web/controllers/networks_json.ex
+++ b/lib/grappa_web/controllers/networks_json.ex
@@ -32,8 +32,7 @@ defmodule GrappaWeb.NetworksJSON do
   @spec index(%{
           networks:
             {:user, [{Network.t(), String.t(), Credential.t(), Session.connection_info() | nil}]}
-            | {:visitor,
-               [{Network.t(), String.t(), Credential.t(), Session.connection_info() | nil}]}
+            | {:visitor, [{Network.t(), String.t(), Credential.t(), Session.connection_info() | nil}]}
         }) :: [Wire.network_with_nick_json()] | [Wire.visitor_network_with_nick_json()]
   def index(%{networks: {:user, network_rows}}) do
     Enum.map(network_rows, fn {network, nick, cred, connection} ->

--- a/test/grappa/networks/wire_test.exs
+++ b/test/grappa/networks/wire_test.exs
@@ -228,10 +228,17 @@ defmodule Grappa.Networks.WireTest do
         connection_state_changed_at: DateTime.truncate(DateTime.utc_now(), :second)
       }
 
-      conn = %{server: "89.31.72.10", port: 6697, tls: true, registered: true}
+      at = ~U[2026-08-06T10:00:00Z]
+      conn = %{server: "89.31.72.10", port: 6697, tls: true, registered: true, connected_at: at}
       json = Wire.network_with_nick_to_json(network, "vjt", cred, conn)
 
-      assert json.connection == %{server: "89.31.72.10", port: 6697, tls: true, registered: true}
+      assert json.connection == %{
+               server: "89.31.72.10",
+               port: 6697,
+               tls: true,
+               registered: true,
+               connected_at: "2026-08-06T10:00:00Z"
+             }
     end
 
     test "visitor_network_to_json/4 embeds the live connection facts",
@@ -243,9 +250,46 @@ defmodule Grappa.Networks.WireTest do
         connection_state_changed_at: DateTime.truncate(DateTime.utc_now(), :second)
       }
 
-      conn = %{server: "127.0.0.1", port: 6667, tls: false, registered: false}
+      conn = %{
+        server: "127.0.0.1",
+        port: 6667,
+        tls: false,
+        registered: false,
+        connected_at: ~U[2026-08-06T10:00:00Z]
+      }
 
-      assert Wire.visitor_network_to_json(network, "vjt", cred, conn).connection == conn
+      assert Wire.visitor_network_to_json(network, "vjt", cred, conn).connection == %{
+               server: "127.0.0.1",
+               port: 6667,
+               tls: false,
+               registered: false,
+               connected_at: "2026-08-06T10:00:00Z"
+             }
+    end
+
+    test "connected_at renders as an ISO-8601 string, and nil stays nil (#897)",
+         %{network: network} do
+      # #897 — the link's connect instant travels inside `:connection`, the
+      # live-only sub-object, so it is absent exactly when there is no live
+      # pid. `nil` is reachable on a session whose state predates the field
+      # (the #216 hot-reload contract): the wire says "unknown", never a
+      # fabricated instant, and cic omits the row.
+      cred = %Credential{
+        network: network,
+        nick: "vjt",
+        connection_state: :connected,
+        connection_state_changed_at: DateTime.truncate(DateTime.utc_now(), :second)
+      }
+
+      base = %{server: "127.0.0.1", port: 6667, tls: false, registered: false, connected_at: nil}
+
+      live = %{base | connected_at: ~U[2026-08-06T09:30:45Z]}
+
+      assert Wire.network_with_nick_to_json(network, "vjt", cred, live).connection.connected_at ==
+               "2026-08-06T09:30:45Z"
+
+      assert Wire.network_with_nick_to_json(network, "vjt", cred, base).connection.connected_at ==
+               nil
     end
 
     test "connection: nil when the session is not live (honest, no fabricated facts)",

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -322,6 +322,33 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    test "carries connected_at — the instant THIS link came up (#897)" do
+      # #897 — the rail card's "connected <duration>" must measure the LIVE
+      # link, and the only anchor that resets with the link is per-process
+      # (`state.connected_at`, stamped at `:irc_connected`). The credential's
+      # `connection_state_changed_at` cannot serve: `Networks.connect/1`
+      # no-ops without a DB write on an already-`:connected` row, and a
+      # bouncer restart leaves the row `:connected` throughout, so that
+      # column survives restarts that the link does not.
+      #
+      # No sleep needed for the ordering: `IRC.Client` sends `:irc_connected`
+      # BEFORE it writes the NICK/USER frames (client.ex handle_continue
+      # {:connect, _}), so a fake server that has SEEN the USER line proves
+      # the message is already in the Session's mailbox — the subsequent
+      # GenServer.call is serialised behind it.
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+      before = DateTime.utc_now()
+      _ = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      assert {:ok, %{connected_at: %DateTime{} = at}} =
+               Session.connection_info({:user, user.id}, network.id)
+
+      assert DateTime.compare(at, before) != :lt
+      assert DateTime.compare(at, DateTime.utc_now()) != :gt
+    end
+
     test "returns {:error, :no_session} when no session is registered" do
       assert {:error, :no_session} =
                Session.connection_info({:user, Ecto.UUID.generate()}, -1)


### PR DESCRIPTION
Mezmerize's server-info card read `connected 10d 9h` on an instance he was
shutting down for an upgrade every day.

## The comment was the bug

The card sourced the duration from the credential's
`connection_state_changed_at`, above a comment asserting that column "IS the
connect instant for a live link". It is not. `Networks.connect/1` has an
explicit already-`:connected` clause that returns **without a DB write**, and a
restart is deliberately not a state change — a transient loss must not park the
network. So `docker stop` + `docker up` leaves the row `:connected` end to end,
the connect no-ops on the way back in, and the column keeps the timestamp of the
last time the ROW moved. A perfectly good answer to a question nobody asked.

## The honest anchor already existed

`Session.Server.connected_at` — stamped at `:irc_connected`, per-process,
therefore resetting with the socket. The card had never been able to see it.

**Where it goes is the design decision.** It joins the map returned by
`Session.connection_info/2` — the live-only facts already embedded as
`:connection` on both `GET /networks` twins — rather than sitting beside the
credential's own timestamp. `connection` is already `null` whenever there is no
live pid, so "no socket ⇒ no duration" falls out of the shape instead of needing
a second honesty rule bolted onto the renderer. A DB row stuck at `:connected`
behind a dead session now shows its state and says nothing about uptime: the
CLAUDE.md DB-vs-live separation, rendered.

**One path, both doors.** `connection` reaches cic only through `GET /networks`,
through a single `connection_json/1` shared by the user and visitor twins, and
cic already refetches on the `connection_progress` "connected" edge — so a
runtime reconnect refreshes the anchor along with the peer IP and the +r flag.
No push carries `connection` today and none was added: the only place a
`connection_state_changed` broadcast is built is inside the DB transition path,
which would have to `GenServer.call` the very session that sometimes triggers it.

Two smaller calls: `connection_json/1` MATCHES `connected_at` rather than
`Map.get`-defaulting it (sole producer is `connection_info/2`, so an absent key
means a new producer forgot — a FunctionClauseError beats a row that quietly
stops rendering); and its input spec becomes `Grappa.Session.connection_info()`,
because the domain map carries `%DateTime{}` where the wire carries ISO-8601 — a
split invisible only while the two shapes happened to coincide. Codegen reads
`@type`, not `@spec`, so naming the domain type there costs `wireTypes.ts`
nothing.

The lying comment is gone.

## The question the issue left open, answered

"Whether any other reader of `connection_state_changed_at` carries the same
assumption is unchecked." Checked: grepping every `formatDuration*` caller in cic
returns `ServerInfoCard` and `WhoisCard`, and the latter formats a WHOIS
`idle_seconds` that never touched the column. `AdminWire` and `HomePane` carry
the timestamp and render it as the transition it is. **The fix has no siblings.**

## Gates

| gate | result |
|---|---|
| `scripts/check.sh` | **rc=0**, read from file. Every stage evidenced: credo `5125 mods/funs, found no issues`; sobelow; doctor dev (296) + test (312); ExUnit `8 doctests, 54 properties, 5303 tests, 0 failures`; dialyzer `Total errors: 0`; `wireTypes.ts is in sync`; bats `ok 1..331`, zero `not ok`. Clean tree before and after. |
| `bun run check` | rc=0 (and `tsc --noEmit` run standalone, rc=0 — `check` is `biome && tsc`, so a biome red would have hidden it) |
| `bun run test` | rc=0, 242 files / 4443 tests |
| e2e | 🔴 **NOT RUN** — see below |

### Measured, not assumed

I wrote the implementation before running the red, which burns the oracle, so I
recovered it by mutation after committing:

- revert the card to `connection_state_changed_at` → **3 of 10** card tests fail,
  and they are exactly the three that discriminate (the baseline uptime
  assertion + both new #897 cases). The other 7 stay green, as they should.
- drop `connected_at` from the `connection_info` map → the new server-accessor
  test fails on the `%DateTime{}` match.

### What I am NOT claiming

- **The e2e has not been executed.** `issue897-link-uptime.spec.ts` is written
  and reasoned but never run: the STACK lane was held elsewhere. There is no
  static net for it either — biome scopes to `src/**`, and `tsc -p e2e/` cannot
  resolve `@playwright/test` types in the container (`error TS2688`). It is
  called out here rather than folded into a green.
- Mezmerize's database was never read. The mechanism is a code reading whose
  symptom matches; that is not the same as observing his row.
- Unrelated and pre-existing on `main`, non-gating (check.sh still rc=0):
  `mix hex.audit` reports advisories on transitive `cowlib 2.18.0` (one HIGH,
  one MEDIUM, one LOW) and `cowboy 2.17.0` (MEDIUM). Not touched here.