### PR TITLE
cic(#816): make a multi-line body arrive only by explicit consent

### DIFF
--- a/cicchetto/e2e/tests/issue80-paste-flood-guard.spec.ts
+++ b/cicchetto/e2e/tests/issue80-paste-flood-guard.spec.ts
@@ -29,6 +29,7 @@ import {
   confirmModalBody,
   confirmModalCancel,
   confirmModalYes,
+  scrollbackLine,
   loginAs,
   selectChannel,
 } from "../fixtures/cicchettoPage";
@@ -116,4 +117,73 @@ test("#816 — a one-message paste is frictionless; two messages already guard",
   // 2, where #80 had it at 4.
   await pasteText(page, "riga uno\nriga due");
   await expect(confirmModal(page)).toBeVisible();
+});
+
+// #816 — the hard cap and its second door.
+//
+// Above the ceiling the block never enters the composer at all. Refusing
+// outright was rejected: the operator gets upload-as-file (the text becomes a
+// text/plain File on the existing upload path, and the URL is posted as one
+// 📄 PRIVMSG instead of N) or cancel.
+//
+// The end of that chain — multipart POST, auto-send, IRC echo — is exactly
+// what jsdom cannot follow (ComposeBox.test.tsx can only assert that
+// `triggerUploads` was called with the right File), so this is the gate that
+// proves the reuse actually reuses: a text paste really does traverse the
+// image-upload plumbing and come back as a link in the channel.
+test("#816 — a paste over the hard cap uploads as a file instead of flooding", async ({
+  page,
+  browserName,
+}) => {
+  test.skip(
+    browserName !== "chromium",
+    "shares the upload plumbing gated to chromium by the uploads specs; the paste half is browser-agnostic and covered above",
+  );
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  // Pre-ack the embedded-host privacy modal so the upload runs unattended
+  // (that flow is covered by ux-6-b-embedded-upload).
+  await page.evaluate(() =>
+    localStorage.setItem("image-upload-privacy-acknowledged:embedded", "1"),
+  );
+
+  const ta = composeTextarea(page);
+  await expect(ta).toBeVisible();
+  await expect(ta).toHaveValue("");
+
+  // Six messages — one past the ceiling of five.
+  const tag = crypto.randomUUID().slice(0, 8);
+  const block = Array.from({ length: 6 }, (_, i) => `over ${tag} riga ${i}`).join("\n");
+
+  await pasteText(page, block);
+  await expect(confirmModal(page)).toBeVisible();
+  // Both numbers, so the operator knows what would fit.
+  await expect(confirmModalBody(page)).toContainText("6");
+  await expect(confirmModalBody(page)).toContainText("5");
+
+  // Cancel first: the safe default drops the paste with no upload and no
+  // text in the box. Asserted before the affirmative so a handler that
+  // uploaded unconditionally could not pass this spec.
+  await confirmModalCancel(page);
+  await expect(confirmModal(page)).toHaveCount(0);
+  await expect(ta).toHaveValue("");
+
+  // The second door. The block must NOT land in the composer — it goes out
+  // as one 📄-prefixed link instead of six frames.
+  await pasteText(page, block);
+  await expect(confirmModal(page)).toBeVisible();
+  await confirmModalYes(page);
+  await expect(confirmModal(page)).toHaveCount(0);
+  await expect(ta).toHaveValue("");
+
+  const rows = scrollbackLine(page, "privmsg", "📄");
+  await expect.poll(async () => await rows.count(), { timeout: 20_000 }).toBeGreaterThanOrEqual(1);
+
+  // And the burst never happened: none of the pasted lines went to the
+  // channel as its own message. Without this, an implementation that
+  // uploaded AND pasted would still be green above.
+  await expect(scrollbackLine(page, "privmsg", `over ${tag} riga 0`)).toHaveCount(0);
 });

--- a/cicchetto/e2e/tests/issue80-paste-flood-guard.spec.ts
+++ b/cicchetto/e2e/tests/issue80-paste-flood-guard.spec.ts
@@ -1,11 +1,15 @@
 // #80 — multi-line paste flood guard.
 //
 // A multi-line paste into the compose box becomes one PRIVMSG per line on
-// submit (compose.ts → messageLines.ts), so a big pasted block can flood a
-// channel. Above a small line threshold (>3 lines) the paste is intercepted
-// and an explicit confirm dialog opens BEFORE the text lands; Cancel drops it
-// (the safe default), the "Paste" button inserts it + refocuses the textarea.
-// At/below the threshold the paste stays frictionless (no dialog).
+// submit (compose.ts → messageLines.ts), so a pasted block can flood a
+// channel. Any paste that becomes MORE THAN ONE MESSAGE is intercepted and an
+// explicit confirm dialog opens BEFORE the text lands, stating how many
+// messages it will become; Cancel drops it (the safe default), the "Paste"
+// button inserts it + refocuses the textarea. A one-message paste stays
+// frictionless (no dialog).
+//
+// #816 replaced #80's >3-line carve-out with that rule, and moved the quoted
+// number from lines to messages — see lib/pasteFlood.
 //
 // The guard reuses the store-driven confirm dialog (ConfirmModal.tsx /
 // lib/confirmDialog) — no new modal — so it inherits the overlay scroll-lock,
@@ -62,10 +66,10 @@ test("#80 — multi-line paste: dialog opens, Cancel drops it, Paste inserts it"
   await expect(ta).toBeVisible();
   await expect(ta).toHaveValue("");
 
-  // 4 lines > threshold (3) → guarded.
+  // 4 messages → guarded.
   const block = "riga uno\nriga due\nriga tre\nriga quattro";
 
-  // Paste → confirm dialog with the interpolated line count + channel name.
+  // Paste → confirm dialog with the interpolated message count + channel name.
   // The text has NOT landed yet — the guard holds it back.
   await pasteText(page, block);
   await expect(confirmModal(page)).toBeVisible();
@@ -89,7 +93,7 @@ test("#80 — multi-line paste: dialog opens, Cancel drops it, Paste inserts it"
   await expect(ta).toBeFocused();
 });
 
-test("#80 — a short (≤3-line) paste is frictionless; a longer one still guards", async ({
+test("#816 — a one-message paste is frictionless; two messages already guard", async ({
   page,
 }) => {
   if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
@@ -100,13 +104,16 @@ test("#80 — a short (≤3-line) paste is frictionless; a longer one still guar
   const ta = composeTextarea(page);
   await expect(ta).toBeVisible();
 
-  // 3 lines == threshold → NO dialog (frictionless).
-  await pasteText(page, "riga uno\nriga due\nriga tre");
+  // One message, with the trailing newline a copy leaves behind → NO dialog.
+  // That artifact is why the guard counts messages and not lines: as lines
+  // this is two, and it would have cost a dialog for nothing.
+  await pasteText(page, "riga unica\n");
   await expect(confirmModal(page)).toHaveCount(0);
 
-  // Positive control: a 4-line paste DOES open the dialog. Proves the guard
-  // is live in this browser, so the 3-line no-op above is a real frictionless
-  // pass — not a dead handler that never fires.
-  await pasteText(page, "a\nb\nc\nd");
+  // Positive control: TWO messages already open the dialog. Proves the guard
+  // is live in this browser, so the no-op above is a real frictionless pass
+  // and not a dead handler that never fires — and pins the #816 boundary at
+  // 2, where #80 had it at 4.
+  await pasteText(page, "riga uno\nriga due");
   await expect(confirmModal(page)).toBeVisible();
 });

--- a/cicchetto/e2e/tests/multiline-compose-fanout.spec.ts
+++ b/cicchetto/e2e/tests/multiline-compose-fanout.spec.ts
@@ -1,5 +1,6 @@
-// Multiline compose fan-out — a body with embedded newlines (Shift+Enter
-// in ComposeBox, or a pasted block) must send one PRIVMSG per line.
+// Multiline compose fan-out — a body with embedded newlines (a pasted block;
+// #816 made Shift+Enter a no-op, so paste is the only route) must send one
+// PRIVMSG per line.
 //
 // Pre-fix the whole multiline draft went as a single PRIVMSG and the
 // server bounced it as `:invalid_line` (CRLF is the IRC frame delimiter)

--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -441,9 +441,17 @@ const ComposeBox: Component<Props> = (props) => {
   };
 
   const onKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key === "Enter") {
+      // #816 — Shift+Enter is a NO-OP: preventDefault with no send, so the
+      // textarea inserts no line break and the composer stays single-line. A
+      // newline cannot travel inside a PRIVMSG (CRLF terminates the frame),
+      // so honouring one means splitting into N messages — a flood the
+      // operator never asked for by holding a modifier, and one no client
+      // sets the precedent for (mIRC's editbox is single-line, hexchat
+      // splits paste). Paste is left as the ONE route a multi-line body can
+      // take into the box, and paste is guarded (lib/pasteFlood).
       e.preventDefault();
-      void doSubmit();
+      if (!e.shiftKey) void doSubmit();
       return;
     }
     if (e.key === "ArrowUp") {

--- a/cicchetto/src/__tests__/ComposeBox.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBox.test.tsx
@@ -324,12 +324,29 @@ describe("ComposeBox", () => {
     expect(compose.submit).toHaveBeenCalledWith(expect.anything(), "freenode", "#a");
   });
 
-  it("Shift+Enter inserts a newline (does NOT submit)", async () => {
+  // #816 — Shift+Enter is a NO-OP: it neither submits nor inserts a line
+  // break. The composer stays single-line, because a newline cannot travel
+  // inside a PRIVMSG and the only way to honour one is to split into N
+  // messages — a flood hazard the operator never asked for by pressing a
+  // modifier. No client sets the precedent either (mIRC's editbox is
+  // single-line; hexchat splits paste). Paste remains the ONE way a
+  // multi-line body reaches the box, and paste is guarded.
+  it("#816 — Shift+Enter is a no-op: no submit and no line break", async () => {
     const compose = await import("../lib/compose");
     render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
     const ta = screen.getByPlaceholderText(/message #a/i);
-    fireEvent.keyDown(ta, { key: "Enter", shiftKey: true });
+    const ev = new KeyboardEvent("keydown", {
+      key: "Enter",
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    ta.dispatchEvent(ev);
     expect(compose.submit).not.toHaveBeenCalled();
+    // preventDefault is what stops the textarea's own newline insertion —
+    // asserting "no submit" alone passed against the old behaviour too.
+    expect(ev.defaultPrevented).toBe(true);
+    expect(compose.setDraft).not.toHaveBeenCalled();
   });
 
   it("Up arrow on first-line cursor calls recallPrev", async () => {
@@ -1180,6 +1197,23 @@ describe("ComposeBox", () => {
       expect(req?.confirmLabel).toBe("Paste");
     });
 
+    // #816 — the dialog must declare how many MESSAGES the paste becomes, not
+    // how many lines it occupies. The two differ whenever a blank line is in
+    // play, and only the message count is a promise the send path keeps.
+    it("#816 — the count quoted is MESSAGES, so blank interior lines are not counted", async () => {
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      const ta = screen.getByPlaceholderText(/message #a/i) as HTMLTextAreaElement;
+      // Four lines as typed, two of them blank → two messages on the wire.
+      ta.dispatchEvent(makeTextPaste("uno\n\n   \ndue"));
+
+      const req = confirmRequest();
+      expect(req).not.toBeNull();
+      expect(req?.title).toContain("2");
+      expect(req?.body).toContain("2");
+      expect(req?.title).not.toContain("4");
+      expect(req?.body).toMatch(/messages/i);
+    });
+
     it("confirming (Paste) inserts the pasted text into the compose draft", async () => {
       const compose = await import("../lib/compose");
       render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
@@ -1228,11 +1262,26 @@ describe("ComposeBox", () => {
       expect(confirmRequest()).toBeNull();
     });
 
-    it("a 3-line paste (at the threshold) does NOT open the dialog — native paste proceeds", async () => {
+    // #816 — the pre-existing 3-line carve-out is GONE. Any paste that
+    // becomes more than one message confirms, because every one of them is a
+    // burst the operator did not explicitly compose.
+    it("#816 — a 2-line paste opens the dialog (the old 3-line carve-out is gone)", async () => {
       render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
       const ta = screen.getByPlaceholderText(/message #a/i) as HTMLTextAreaElement;
 
-      const paste = makeTextPaste("uno\ndue\ntre");
+      const paste = makeTextPaste("uno\ndue");
+      ta.dispatchEvent(paste);
+
+      expect(paste.defaultPrevented).toBe(true);
+      expect(confirmRequest()?.title).toContain("2");
+    });
+
+    it("#816 — a one-message paste with a trailing newline stays frictionless", async () => {
+      // The commonest copy artifact must not start costing a dialog.
+      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+      const ta = screen.getByPlaceholderText(/message #a/i) as HTMLTextAreaElement;
+
+      const paste = makeTextPaste("just one pasted line\n");
       ta.dispatchEvent(paste);
 
       expect(paste.defaultPrevented).toBe(false);

--- a/cicchetto/src/__tests__/ComposeBox.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBox.test.tsx
@@ -1276,6 +1276,67 @@ describe("ComposeBox", () => {
       expect(confirmRequest()?.title).toContain("2");
     });
 
+    // #816 — above the hard cap the paste does not land in the box at all.
+    // The operator gets two doors instead: upload the block as a file and
+    // post the link (the same shape as the 📸 image path — `text/plain` is
+    // already an accepted `document` MIME, so this reuses the upload verb
+    // rather than inventing a service), or cancel. Never a bare refusal.
+    describe("#816 — over the hard cap", () => {
+      const OVER_CAP = Array.from({ length: 6 }, (_, i) => `riga ${i}`).join("\n");
+
+      it("offers 'Upload as file' instead of the paste affirmative", async () => {
+        render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+        const ta = screen.getByPlaceholderText(/message #a/i) as HTMLTextAreaElement;
+        const paste = makeTextPaste(OVER_CAP);
+        ta.dispatchEvent(paste);
+
+        expect(paste.defaultPrevented).toBe(true);
+        const req = confirmRequest();
+        expect(req).not.toBeNull();
+        expect(req?.confirmLabel).toBe("Upload as file");
+        // The copy has to carry BOTH numbers: what they pasted and where the
+        // ceiling is. "Too many" without the limit leaves them guessing.
+        expect(req?.body).toContain("6");
+        expect(req?.body).toContain("5");
+      });
+
+      it("confirming uploads the block as a text file and never touches the draft", async () => {
+        const compose = await import("../lib/compose");
+        const orch = await import("../lib/uploadOrchestrator");
+        render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+        const ta = screen.getByPlaceholderText(/message #a/i) as HTMLTextAreaElement;
+        ta.dispatchEvent(makeTextPaste(OVER_CAP));
+
+        acceptConfirm();
+
+        expect(orch.triggerUploads).toHaveBeenCalledTimes(1);
+        const files = vi.mocked(orch.triggerUploads).mock.calls[0]?.[3] as File[];
+        expect(files).toHaveLength(1);
+        expect(files[0]?.type).toBe("text/plain");
+        // The bytes are the paste itself — an upload that dropped or mangled
+        // the text would still satisfy "a file was uploaded".
+        await expect(files[0]?.text()).resolves.toBe(OVER_CAP);
+        // The whole point of this arm: the burst never enters the composer.
+        expect(compose.setDraft).not.toHaveBeenCalled();
+      });
+
+      it("cancelling neither uploads nor pastes", async () => {
+        const compose = await import("../lib/compose");
+        const orch = await import("../lib/uploadOrchestrator");
+        render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+        const ta = screen.getByPlaceholderText(/message #a/i) as HTMLTextAreaElement;
+        ta.dispatchEvent(makeTextPaste(OVER_CAP));
+        // Pin WHICH dialog was dismissed — without this the case passes
+        // against a build that never grew the over-cap arm at all.
+        expect(confirmRequest()?.confirmLabel).toBe("Upload as file");
+
+        dismissConfirm();
+
+        expect(orch.triggerUploads).not.toHaveBeenCalled();
+        expect(compose.setDraft).not.toHaveBeenCalled();
+      });
+    });
+
     it("#816 — a one-message paste with a trailing newline stays frictionless", async () => {
       // The commonest copy artifact must not start costing a dialog.
       render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);

--- a/cicchetto/src/lib/__tests__/pasteFlood.test.ts
+++ b/cicchetto/src/lib/__tests__/pasteFlood.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { splitMessageLines } from "../messageLines";
-import { pastedMessageCount, shouldGuardPaste } from "../pasteFlood";
+import { classifyPaste, PASTE_HARD_MESSAGE_LIMIT, pastedMessageCount } from "../pasteFlood";
+
+const block = (n: number): string => Array.from({ length: n }, (_, i) => `l${i}`).join("\n");
 
 // #80/#816 — paste flood guard. A multi-line paste becomes one PRIVMSG per
 // line on submit, so the guard confirms BEFORE the text lands and declares
@@ -59,27 +61,48 @@ describe("pasteFlood — pastedMessageCount", () => {
   });
 });
 
-describe("pasteFlood — shouldGuardPaste", () => {
-  it("leaves a single-line paste frictionless", () => {
-    expect(shouldGuardPaste("just one line")).toBe(false);
+describe("pasteFlood — classifyPaste", () => {
+  it("lets a single-line paste through frictionless", () => {
+    expect(classifyPaste("just one line")).toBe("insert");
   });
 
-  it("guards from the second message onwards (#816 — any newline confirms)", () => {
-    // Pre-#816 this tripped only above three lines, so two- and three-line
-    // pastes went straight in. The ruling removed that carve-out.
-    expect(shouldGuardPaste("a\nb")).toBe(true);
-    expect(shouldGuardPaste("a\nb\nc")).toBe(true);
-    expect(shouldGuardPaste("a\nb\nc\nd")).toBe(true);
+  it("lets an empty paste through", () => {
+    expect(classifyPaste("")).toBe("insert");
   });
 
-  it("does not guard a paste whose newlines carry no message", () => {
+  it("passes a paste whose newlines carry no message", () => {
     // One real line plus a trailing newline, or padding whitespace, is still
     // ONE message — there is no burst to warn about.
-    expect(shouldGuardPaste("hello\n")).toBe(false);
-    expect(shouldGuardPaste("hello\n   \n")).toBe(false);
+    expect(classifyPaste("hello\n")).toBe("insert");
+    expect(classifyPaste("hello\n   \n")).toBe("insert");
   });
 
-  it("does not guard an empty paste", () => {
-    expect(shouldGuardPaste("")).toBe(false);
+  it("confirms from the second message onwards (#816 — any newline confirms)", () => {
+    // Pre-#816 this tripped only above three lines, so two- and three-line
+    // pastes went straight in. The ruling removed that carve-out.
+    expect(classifyPaste("a\nb")).toBe("confirm");
+    expect(classifyPaste("a\nb\nc")).toBe("confirm");
+    expect(classifyPaste("a\nb\nc\nd")).toBe("confirm");
+  });
+
+  it("confirms up to and including the hard limit, and refuses past it", () => {
+    // The boundary, driven off the production constant so the test cannot
+    // silently drift from it.
+    expect(classifyPaste(block(PASTE_HARD_MESSAGE_LIMIT))).toBe("confirm");
+    expect(classifyPaste(block(PASTE_HARD_MESSAGE_LIMIT + 1))).toBe("over-limit");
+  });
+
+  it("pins the hard limit at the ruled constant", () => {
+    // vjt, 2026-08-06: a constant, not derived from anything the server says.
+    // Networks differ and usermode-exempt users exist, so there is no value
+    // to derive — this is a deliberate flat ceiling.
+    expect(PASTE_HARD_MESSAGE_LIMIT).toBe(5);
+  });
+
+  it("weighs the cap in messages, so blank lines cannot push a paste over it", () => {
+    // Five real lines with blanks between them is five wire frames. Counting
+    // what the box would SHOW (nine lines) would refuse a paste that is
+    // exactly at the limit.
+    expect(classifyPaste("a\n\nb\n\nc\n\nd\n\ne")).toBe("confirm");
   });
 });

--- a/cicchetto/src/lib/__tests__/pasteFlood.test.ts
+++ b/cicchetto/src/lib/__tests__/pasteFlood.test.ts
@@ -1,77 +1,82 @@
 import { describe, expect, it } from "vitest";
-import { PASTE_FLOOD_LINE_THRESHOLD, pastedLineCount, shouldGuardPaste } from "../pasteFlood";
+import { splitMessageLines } from "../messageLines";
+import { pastedMessageCount, shouldGuardPaste } from "../pasteFlood";
 
-// #80 — paste flood guard. A multi-line paste into the compose box becomes
-// one PRIVMSG per line on submit (compose.ts → messageLines.ts), so a big
-// pasted block can flood a channel. `pastedLineCount` is the pure line
-// counter the guard trips on; `shouldGuardPaste` applies the threshold.
-// This is the boundary proof the confirm-before-paste wiring rests on.
+// #80/#816 — paste flood guard. A multi-line paste becomes one PRIVMSG per
+// line on submit, so the guard confirms BEFORE the text lands and declares
+// what the paste will become.
+//
+// #816 moved the unit of both halves from LINES to MESSAGES. The old guard
+// counted what the operator would SEE in the box (blank interior lines
+// included) and tripped only above three; the ruling is that any paste which
+// becomes more than one message confirms, and that the dialog states the
+// message count. "How big is the burst" and "what do we promise" are the same
+// question, so there is now ONE counter and it is `splitMessageLines` — the
+// function the send path itself uses.
 
-describe("pasteFlood — pastedLineCount", () => {
-  it("counts a single line as 1", () => {
-    expect(pastedLineCount("hello")).toBe(1);
+describe("pasteFlood — pastedMessageCount", () => {
+  it("counts a single line as one message", () => {
+    expect(pastedMessageCount("hello")).toBe(1);
   });
 
-  it("counts an empty string as 0", () => {
-    expect(pastedLineCount("")).toBe(0);
+  it("counts empty text as zero messages", () => {
+    expect(pastedMessageCount("")).toBe(0);
   });
 
-  it("counts N lines by newline count + 1", () => {
-    expect(pastedLineCount("a\nb")).toBe(2);
-    expect(pastedLineCount("a\nb\nc")).toBe(3);
-    expect(pastedLineCount("a\nb\nc\nd")).toBe(4);
+  it("counts each line of a multi-line block", () => {
+    expect(pastedMessageCount("a\nb")).toBe(2);
+    expect(pastedMessageCount("a\nb\nc")).toBe(3);
+    expect(pastedMessageCount("a\nb\nc\nd")).toBe(4);
   });
 
-  it("does NOT inflate the count for a single trailing newline", () => {
-    // A trailing newline is a common copy artifact — it must not read as
-    // an extra empty line (else a 3-line copy-with-trailing-\n would trip
-    // the guard as 4).
-    expect(pastedLineCount("a\nb\nc\n")).toBe(3);
-    expect(pastedLineCount("a\nb\nc\nd\n")).toBe(4);
+  it("is delimiter-agnostic across CRLF, lone CR and LF", () => {
+    expect(pastedMessageCount("a\r\nb\r\nc\r\nd")).toBe(4);
+    expect(pastedMessageCount("a\rb\rc\rd")).toBe(4);
   });
 
-  it("normalizes CRLF line endings", () => {
-    expect(pastedLineCount("a\r\nb\r\nc\r\nd")).toBe(4);
-    expect(pastedLineCount("a\r\nb\r\nc\r\n")).toBe(3);
+  it("does not count a trailing newline as an extra message", () => {
+    // The commonest copy artifact. It produces no wire frame, so it must not
+    // inflate the number the dialog quotes.
+    expect(pastedMessageCount("a\nb\nc\n")).toBe(3);
+    expect(pastedMessageCount("hello\n")).toBe(1);
   });
 
-  it("normalizes lone CR (old-Mac) line endings", () => {
-    expect(pastedLineCount("a\rb\rc\rd")).toBe(4);
+  it("does not count blank or whitespace-only interior lines", () => {
+    // #863 — the send path drops them (the server refuses a body that is
+    // empty after trimming), so quoting them would over-state the burst the
+    // operator is being asked to authorise.
+    expect(pastedMessageCount("a\n\nb")).toBe(2);
+    expect(pastedMessageCount("a\n   \nb")).toBe(2);
   });
 
-  it("counts blank interior lines (they are lines being pasted)", () => {
-    // Distinct from splitMessageLines (send-time fan-out) which DROPS
-    // blanks — the guard counts what the operator SEES land in the box.
-    expect(pastedLineCount("a\n\nb")).toBe(3);
+  it("agrees with the send path exactly", () => {
+    // The guard's number IS a promise about what send will do. If the two
+    // predicates ever diverge, the dialog starts lying — so pin them
+    // together rather than restating the rule.
+    for (const text of ["hello", "a\nb", "a\n\nb", "a\r\nb\r\n", "  \n \n", "x\ny\nz\n"]) {
+      expect(pastedMessageCount(text)).toBe(splitMessageLines(text).length);
+    }
   });
 });
 
 describe("pasteFlood — shouldGuardPaste", () => {
-  it("does not guard a single-line paste", () => {
+  it("leaves a single-line paste frictionless", () => {
     expect(shouldGuardPaste("just one line")).toBe(false);
   });
 
-  it("does not guard at or below the threshold", () => {
-    expect(shouldGuardPaste("a\nb")).toBe(false); // 2 lines
-    expect(shouldGuardPaste("a\nb\nc")).toBe(false); // 3 lines == threshold
+  it("guards from the second message onwards (#816 — any newline confirms)", () => {
+    // Pre-#816 this tripped only above three lines, so two- and three-line
+    // pastes went straight in. The ruling removed that carve-out.
+    expect(shouldGuardPaste("a\nb")).toBe(true);
+    expect(shouldGuardPaste("a\nb\nc")).toBe(true);
+    expect(shouldGuardPaste("a\nb\nc\nd")).toBe(true);
   });
 
-  it("guards above the threshold", () => {
-    expect(shouldGuardPaste("a\nb\nc\nd")).toBe(true); // 4 lines > 3
-  });
-
-  it("guards exactly one line past the threshold and not one before it", () => {
-    // Boundary proof, driven off the production threshold constant so it
-    // can't silently drift from the implementation.
-    const atThreshold = Array.from({ length: PASTE_FLOOD_LINE_THRESHOLD }, (_, i) => `l${i}`).join(
-      "\n",
-    );
-    const overThreshold = Array.from(
-      { length: PASTE_FLOOD_LINE_THRESHOLD + 1 },
-      (_, i) => `l${i}`,
-    ).join("\n");
-    expect(shouldGuardPaste(atThreshold)).toBe(false);
-    expect(shouldGuardPaste(overThreshold)).toBe(true);
+  it("does not guard a paste whose newlines carry no message", () => {
+    // One real line plus a trailing newline, or padding whitespace, is still
+    // ONE message — there is no burst to warn about.
+    expect(shouldGuardPaste("hello\n")).toBe(false);
+    expect(shouldGuardPaste("hello\n   \n")).toBe(false);
   });
 
   it("does not guard an empty paste", () => {

--- a/cicchetto/src/lib/messageLines.ts
+++ b/cicchetto/src/lib/messageLines.ts
@@ -1,9 +1,12 @@
 // IRC frames are newline-delimited: a PRIVMSG body cannot carry an
 // embedded LF/CR (the server rejects it as `:invalid_line` —
 // `Session.send_privmsg`'s CRLF/NUL guard, the wire delimiter). A
-// multiline compose — Shift+Enter in ComposeBox, or a pasted block — is
-// the operator asking for one message PER line, so cic splits at this
-// user-intent boundary and sends each line as its own PRIVMSG.
+// multiline body — a pasted block, since #816 made Shift+Enter a no-op and
+// left paste the only route to one — is the operator asking for one message
+// PER line, so cic splits at this user-intent boundary and sends each line
+// as its own PRIVMSG. `pasteFlood` calls this function to tell the operator
+// how many messages a paste becomes BEFORE it lands: the guard's number and
+// the fan-out are the same computation, deliberately.
 //
 // This is the client's half of message framing; the server still owns
 // 512-byte length splitting for any single long line

--- a/cicchetto/src/lib/pasteFlood.ts
+++ b/cicchetto/src/lib/pasteFlood.ts
@@ -1,36 +1,33 @@
-// #80 — paste flood guard. A multi-line paste into the compose box becomes
-// one PRIVMSG per line on submit (compose.ts → messageLines.ts), so a large
+// #80/#816 — paste flood guard. A multi-line paste into the compose box
+// becomes one PRIVMSG per line on submit (compose.ts → messageLines.ts), so a
 // pasted block can flood a channel. The guard trips a confirm dialog BEFORE
-// the text lands in the textarea, above a small line threshold; single- and
-// few-line pastes stay frictionless.
+// the text lands in the textarea. This module is the pure counting +
+// threshold half — no DOM, no store — so the boundary is proven in isolation;
+// `pasteRoute` owns the dialog call and ComposeBox the event wiring.
 //
-// This module is the pure counting + threshold half — no DOM, no store — so
-// the boundary (3 lines = frictionless, 4 lines = guarded) is proven in
-// isolation. ComposeBox owns the event wiring + the confirm-dialog call.
-
-// Guard when a pasted block exceeds THIS many lines. `> 3` (i.e. 4+ lines)
-// keeps 1–3-line pastes — the overwhelming common case (a URL, a short
-// snippet, an address) — frictionless while catching the flood-shaped block.
-// Spec #80 suggested "e.g. >2-3 lines"; 3 is the upper bound of that range,
-// biasing toward fewer interruptions. Provisional — a single knob to retune.
-export const PASTE_FLOOD_LINE_THRESHOLD = 3;
-
-// Count the lines in a pasted block for the flood guard. Normalizes every
-// line-ending convention (CRLF, lone CR, LF) so the count is delimiter-
-// agnostic, and strips ONE trailing newline so a paste that merely ends in a
-// newline (a common copy artifact) isn't counted as an extra empty line.
+// #816 moved both halves off LINES and onto MESSAGES.
 //
-// Blank INTERIOR lines ARE counted: this is the count of lines the operator
-// is about to drop into the compose box (what they SEE), which is distinct
-// from the send-time fan-out — splitMessageLines drops blanks because an
-// empty PRIVMSG is invalid on the wire, a different concern from "how big is
-// this paste".
-export const pastedLineCount = (text: string): number => {
-  const normalized = text.replace(/\r\n|\r/g, "\n").replace(/\n$/, "");
-  if (normalized === "") return 0;
-  return normalized.split("\n").length;
-};
+// The threshold: any paste that becomes more than ONE message confirms. #80
+// carved out 1–3 lines as frictionless on the reasoning that short pastes are
+// the common case; the ruling withdrew that carve-out, because every
+// multi-message paste is a burst the operator did not compose by hand and the
+// dialog is where they find out. A single line — with or without the trailing
+// newline every copy leaves behind — still goes straight in.
+//
+// The unit: `splitMessageLines`, the SAME function the send path uses. #80
+// deliberately used a different counter (lines as SEEN in the box, blank
+// interior lines included), which was defensible while the dialog only asked
+// "how big is this paste". It stopped being defensible once the dialog has to
+// declare how many MESSAGES the paste becomes: that number is a promise about
+// what send will do, so the code that does it must be the code that counts.
+// `pasteFlood.test.ts` pins the two together.
 
-// True when a paste is large enough to flood-guard (confirm before it lands).
-export const shouldGuardPaste = (text: string): boolean =>
-  pastedLineCount(text) > PASTE_FLOOD_LINE_THRESHOLD;
+import { splitMessageLines } from "./messageLines";
+
+// How many PRIVMSGs this pasted block would become. Blank and whitespace-only
+// lines yield none (#863 — the server refuses a body that is empty after
+// trimming), and neither does a trailing newline.
+export const pastedMessageCount = (text: string): number => splitMessageLines(text).length;
+
+// True when a paste is large enough to guard (confirm before it lands).
+export const shouldGuardPaste = (text: string): boolean => pastedMessageCount(text) > 1;

--- a/cicchetto/src/lib/pasteFlood.ts
+++ b/cicchetto/src/lib/pasteFlood.ts
@@ -29,5 +29,26 @@ import { splitMessageLines } from "./messageLines";
 // trimming), and neither does a trailing newline.
 export const pastedMessageCount = (text: string): number => splitMessageLines(text).length;
 
-// True when a paste is large enough to guard (confirm before it lands).
-export const shouldGuardPaste = (text: string): boolean => pastedMessageCount(text) > 1;
+// The hard ceiling on how many messages a paste may become. A flat CONSTANT,
+// deliberately not derived from anything the server tells us (vjt,
+// 2026-08-06): flood limits differ per network and usermode-exempt users
+// exist, so there is no honest value to derive — a ceiling we picked and can
+// retune beats one we pretend to have computed.
+export const PASTE_HARD_MESSAGE_LIMIT = 5;
+
+// What to do with a pasted block. A closed set rather than two booleans, so
+// the router switches once and a new arm is a compile error at every call
+// site instead of a silently-unhandled case.
+//
+//   "insert"     — one message (or none): let it land, no friction.
+//   "confirm"    — 2..LIMIT messages: confirm, stating the count.
+//   "over-limit" — past the ceiling: the block never enters the composer;
+//                  the operator gets upload-as-file or cancel.
+export type PasteVerdict = "insert" | "confirm" | "over-limit";
+
+export function classifyPaste(text: string): PasteVerdict {
+  const messages = pastedMessageCount(text);
+  if (messages <= 1) return "insert";
+  if (messages <= PASTE_HARD_MESSAGE_LIMIT) return "confirm";
+  return "over-limit";
+}

--- a/cicchetto/src/lib/pasteRoute.ts
+++ b/cicchetto/src/lib/pasteRoute.ts
@@ -2,7 +2,7 @@ import { channelKey } from "./channelKey";
 import { getDraft, isDraining, setDraft } from "./compose";
 import { requestConfirm } from "./confirmDialog";
 import { dropUpload } from "./dropUpload";
-import { pastedLineCount, shouldGuardPaste } from "./pasteFlood";
+import { pastedMessageCount, shouldGuardPaste } from "./pasteFlood";
 import { categoryOf } from "./uploadCategory";
 
 // Shared clipboard-paste routing — the file/text branching lifted out of
@@ -96,25 +96,28 @@ export function routeClipboardPaste(
     e.preventDefault();
     return;
   }
-  // #80 — plain-text multi-line paste flood guard. A pasted block is sent
-  // as one PRIVMSG per line on submit (compose.ts → messageLines.ts), so a
-  // large block can flood the channel. Above the line threshold, intercept
-  // the native paste and confirm BEFORE the text lands; below it, fall
-  // through to native textarea paste so 1–3-line pastes stay frictionless.
-  // Reuses the store-driven confirm dialog (lib/confirmDialog) — Cancel is
-  // the safe default (drop the paste), the affirmative button pastes.
+  // #80/#816 — plain-text multi-line paste guard. A pasted block is sent as
+  // one PRIVMSG per line on submit (compose.ts → messageLines.ts), so any
+  // paste that becomes more than one message is a burst the operator did not
+  // compose by hand. Intercept the native paste and confirm BEFORE the text
+  // lands; a one-message paste falls through to the native textarea insert
+  // and stays frictionless. Reuses the store-driven confirm dialog
+  // (lib/confirmDialog) — Cancel is the safe default (drop the paste), the
+  // affirmative button pastes.
   const text = data.getData("text");
   if (shouldGuardPaste(text)) {
     e.preventDefault();
-    const lines = pastedLineCount(text);
+    // #816 — quote MESSAGES, not lines. The operator is authorising a number
+    // of wire frames, and that is the number the send path will produce; a
+    // line count would over-state it for any block containing a blank line.
+    // Always ≥ 2 here (that is what tripped the guard), so the plural is
+    // unconditional and needs no branch.
+    const messages = pastedMessageCount(text);
     requestConfirm({
-      title: `Paste ${lines} lines?`,
+      title: `Paste as ${messages} messages?`,
       // Target-neutral copy: `channelName` is a nick on a query (DM) window,
-      // so "flood the channel" would misdescribe a DM. "a burst of messages"
-      // is honest without over-claiming one-message-per-line (blank lines are
-      // dropped at send — splitMessageLines), and reads right for both a
-      // channel and a DM.
-      body: `You're about to paste ${lines} lines into ${channelName}. Sending can flood it with a burst of messages.`,
+      // so "flood the channel" would misdescribe a DM. "it" carries both.
+      body: `This paste will be sent to ${channelName} as ${messages} separate messages. Sending can flood it with a burst.`,
       confirmLabel: "Paste",
       onConfirm: () => insertPastedText(ta, networkSlug, channelName, text),
     });

--- a/cicchetto/src/lib/pasteRoute.ts
+++ b/cicchetto/src/lib/pasteRoute.ts
@@ -2,7 +2,7 @@ import { channelKey } from "./channelKey";
 import { getDraft, isDraining, setDraft } from "./compose";
 import { requestConfirm } from "./confirmDialog";
 import { dropUpload } from "./dropUpload";
-import { pastedMessageCount, shouldGuardPaste } from "./pasteFlood";
+import { classifyPaste, PASTE_HARD_MESSAGE_LIMIT, pastedMessageCount } from "./pasteFlood";
 import { categoryOf } from "./uploadCategory";
 
 // Shared clipboard-paste routing — the file/text branching lifted out of
@@ -46,6 +46,22 @@ export function insertPastedText(
     ta.focus();
     ta.setSelectionRange(caret, caret);
   });
+}
+
+// #816 — the second door above the hard cap. A block too big to send as a
+// burst becomes a `text/plain` File and rides the EXISTING upload path: the
+// orchestrator posts the resulting URL as a 📄-prefixed PRIVMSG, one frame
+// instead of N, and the recipient clicks through. No new category, no new
+// server surface — `text/plain` is already an accepted `document` MIME
+// (uploadCategory.ts, a 1:1 mirror of the server's @mime_categories), so this
+// reuses the upload VERB rather than inventing a paste service. Same shape as
+// the 📸 image path CLAUDE.md names as the model for "media is a link, and
+// IRC stays text".
+export const PASTE_UPLOAD_FILENAME = "paste.txt";
+
+export function uploadPastedText(text: string, networkSlug: string, channelName: string): void {
+  const file = new File([text], PASTE_UPLOAD_FILENAME, { type: "text/plain" });
+  dropUpload([file], networkSlug, channelName);
 }
 
 // Route a clipboard `paste` event to the upload path or the text path for the
@@ -99,33 +115,45 @@ export function routeClipboardPaste(
   // #80/#816 — plain-text multi-line paste guard. A pasted block is sent as
   // one PRIVMSG per line on submit (compose.ts → messageLines.ts), so any
   // paste that becomes more than one message is a burst the operator did not
-  // compose by hand. Intercept the native paste and confirm BEFORE the text
-  // lands; a one-message paste falls through to the native textarea insert
-  // and stays frictionless. Reuses the store-driven confirm dialog
-  // (lib/confirmDialog) — Cancel is the safe default (drop the paste), the
-  // affirmative button pastes.
+  // compose by hand. `classifyPaste` owns the three-way decision; this switch
+  // owns what each one looks like. Both dialogs reuse the store-driven
+  // confirm (lib/confirmDialog) — Cancel is the safe default in both.
   const text = data.getData("text");
-  if (shouldGuardPaste(text)) {
-    e.preventDefault();
-    // #816 — quote MESSAGES, not lines. The operator is authorising a number
-    // of wire frames, and that is the number the send path will produce; a
-    // line count would over-state it for any block containing a blank line.
-    // Always ≥ 2 here (that is what tripped the guard), so the plural is
-    // unconditional and needs no branch.
-    const messages = pastedMessageCount(text);
-    requestConfirm({
-      title: `Paste as ${messages} messages?`,
-      // Target-neutral copy: `channelName` is a nick on a query (DM) window,
-      // so "flood the channel" would misdescribe a DM. "it" carries both.
-      body: `This paste will be sent to ${channelName} as ${messages} separate messages. Sending can flood it with a burst.`,
-      confirmLabel: "Paste",
-      onConfirm: () => insertPastedText(ta, networkSlug, channelName, text),
-    });
-    return;
+  // Always the real count in both guarded arms, and ≥ 2 by construction, so
+  // the plural is unconditional and needs no branch.
+  const messages = pastedMessageCount(text);
+  switch (classifyPaste(text)) {
+    case "confirm":
+      e.preventDefault();
+      requestConfirm({
+        // #816 — quote MESSAGES, not lines. The operator is authorising wire
+        // frames, and that is what the send path will produce; a line count
+        // would over-state it for any block containing a blank line.
+        title: `Paste as ${messages} messages?`,
+        // Target-neutral copy: `channelName` is a nick on a query (DM)
+        // window, so "flood the channel" would misdescribe a DM. "it" carries
+        // both.
+        body: `This paste will be sent to ${channelName} as ${messages} separate messages. Sending can flood it with a burst.`,
+        confirmLabel: "Paste",
+        onConfirm: () => insertPastedText(ta, networkSlug, channelName, text),
+      });
+      return;
+    case "over-limit":
+      e.preventDefault();
+      requestConfirm({
+        title: `Too many messages to send`,
+        // Both numbers: what they pasted and where the ceiling is. "Too many"
+        // without the limit leaves the operator guessing what would fit.
+        body: `This paste would be ${messages} separate messages to ${channelName} — more than the ${PASTE_HARD_MESSAGE_LIMIT} a burst may be. Upload it as a text file instead and post the link.`,
+        confirmLabel: "Upload as file",
+        onConfirm: () => uploadPastedText(text, networkSlug, channelName),
+      });
+      return;
+    case "insert":
+      if (nativeInsertAvailable) return; // focused textarea → the browser inserts it
+      if (text === "") return; // global path with no readable text → focus-only (iOS)
+      e.preventDefault();
+      insertPastedText(ta, networkSlug, channelName, text);
+      return;
   }
-  // Below the flood threshold.
-  if (nativeInsertAvailable) return; // focused textarea → the browser inserts it
-  if (text === "") return; // global path with no readable text → focus-only (iOS)
-  e.preventDefault();
-  insertPastedText(ta, networkSlug, channelName, text);
 }

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -31195,3 +31195,59 @@ tags. And the dry-run paragraph keeps its mechanism — validating the shipping
 job pre-merge is still right — it just loses the false premise that the job is
 unproven; the reason to run it is now "you changed the Dockerfile or the job",
 not "it has never run".
+## 2026-08-06 — #816: a multi-line body is a burst, and a burst needs consent
+
+**The hazard.** A newline cannot travel inside a `PRIVMSG` — CRLF terminates
+the frame — so honouring one means splitting into N messages. N messages at
+once is precisely what upstream flood protection closes the connection for,
+the limits differ per network, and users with the right usermode are exempt,
+so there is no safe value to assume. The composer had two routes onto that and
+neither asked the operator anything.
+
+**Shift+Enter is a no-op, not a line break.** `preventDefault` with no send:
+the composer stays single-line. It used to insert a newline, which is a burst
+requested by holding a modifier, and there is no precedent to match — mIRC's
+editbox is single-line and pops a "paste N lines?" dialog, hexchat splits
+paste line by line. Closing this door is what makes the remaining one
+sufficient: paste is now the ONLY way a multi-line body reaches the box, and
+paste is guarded. `composeSend` in the e2e fixtures fills the textarea
+programmatically, so the fan-out spec still exercises the split — the
+behaviour is untouched, only the keyboard route to it is gone.
+
+**The guard trips on the second message, not the fourth line.** #80 carved out
+1–3 lines as frictionless, reasoning that short pastes (a URL, an address) are
+the overwhelming common case and should not cost a dialog. The ruling withdrew
+the carve-out: every multi-message paste is a burst the operator did not
+compose by hand, and the dialog is where they learn what it will become.
+
+**It counts MESSAGES, and that is a reversal worth recording.** #80's counter
+was deliberately *not* `splitMessageLines`: it counted lines as SEEN in the
+box, blank interior lines included, and its comment defended the difference —
+"how big is this paste" was held to be a different question from the send-time
+fan-out. That was right while the dialog only warned about size. It stopped
+being right the moment the dialog has to state how many *messages* the paste
+becomes, because that number is a promise about what the send path will do. So
+the guard now calls `splitMessageLines` itself and `pasteFlood.test.ts` pins
+the two together with an equality assertion rather than restating the rule —
+if the send-side notion of "blank" moves again (#863 moved it once, from
+`!== ""` to a trim), the dialog cannot silently start lying. Visible effects: a
+lone trailing newline, the commonest copy artifact, no longer costs a dialog;
+and a block with a blank line between paragraphs quotes the real frame count
+instead of an inflated one.
+
+**What this deliberately does NOT ship.** The ruling also sets a hard constant
+cap (5 lines) above which the operator gets a paste service *or* cancel. The
+cap cannot be built without its doors, and the service's mechanism was
+unspecified — so it is proposed rather than guessed at. The proposal, and the
+reason it is cheap: `text/plain` is ALREADY an accepted upload MIME in the
+`document` category (`uploadCategory.ts`, mirroring the server's
+`@mime_categories`), so a paste service needs no new category, no new server
+surface and no new taxonomy — it is the pasted text wrapped in a `File` and
+handed to the existing `dropUpload`, which posts the URL as a clickable link
+in the body, the same shape as the 📸 image-upload pattern CLAUDE.md names as
+the model. Recorded here so the next reader does not re-derive the survey.
+
+**Known gap, flagged not closed.** The cap, when it lands, is per-paste. Two
+consecutive within-limit pastes still accumulate in the draft, so a paste-time
+cap is not a send-time guarantee. Whether the limit belongs at submit instead
+of (or as well as) at paste is a design question, not an oversight.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -31251,3 +31251,49 @@ the model. Recorded here so the next reader does not re-derive the survey.
 consecutive within-limit pastes still accumulate in the draft, so a paste-time
 cap is not a send-time guarantee. Whether the limit belongs at submit instead
 of (or as well as) at paste is a design question, not an oversight.
+
+## 2026-08-06 — #816 cap: the second door is the upload verb, not a new service
+
+**The cap is a constant, deliberately.** `PASTE_HARD_MESSAGE_LIMIT = 5`, not
+derived from anything the server says (vjt's ruling). The issue's open question
+asked whether to derive it; the answer is that there is nothing honest to
+derive from — flood limits differ per network and usermode-exempt users are
+exempt from them entirely, so a "computed" ceiling would be a guess wearing a
+formula. A flat number we picked and can retune is the truthful shape.
+
+**Refusing outright was rejected.** Above the ceiling the operator gets two
+doors — upload the block as a file and post the link, or cancel — never a bare
+"no". A dead end teaches the operator nothing except to paste it in two halves,
+which is the same burst with extra steps.
+
+**The service is the upload verb, and that is the whole point.** `text/plain`
+is ALREADY an accepted upload MIME in the `document` category
+(`uploadCategory.ts`, a 1:1 mirror of the server's `@mime_categories`, 10 MiB
+on the default host). So the second door needs no new category, no new server
+surface and no new taxonomy: the pasted text is wrapped in a `File` and handed
+to the existing `dropUpload`, and the orchestrator posts the resulting URL as
+one 📄-prefixed PRIVMSG. That is the same shape as the 📸 image path CLAUDE.md
+names as the model — media is a link, IRC stays text — and it is CLAUDE.md's
+"reuse the verbs, not the nouns" applied literally. The 20% that did not fit
+would have been the domain boundary; there wasn't any.
+
+**Shape: a three-way verdict, not two booleans.** `classifyPaste/1` returns
+`"insert" | "confirm" | "over-limit"` and `pasteRoute` switches on it once.
+Two predicates (`shouldGuard` + `exceedsLimit`) would have let a call site
+answer one and forget the other; the closed set makes a future fourth arm a
+compile error at every switch instead of a silent fall-through.
+
+**The e2e is the gate that proves the reuse reuses.** jsdom can only assert
+that `triggerUploads` was called with the right `File`; the multipart POST →
+auto-send → IRC echo is what shows a *text* paste really does traverse the
+*image* plumbing. That spec was verified by mutation, not by its green: with
+the upload MIME changed to an unaccepted one, `dropUpload` filters the file out
+and the spec fails at the 📄 assertion after its full 20s poll. It also asserts
+the burst did NOT also happen (none of the pasted lines appear as their own
+message), so an implementation that uploaded AND pasted cannot pass.
+
+**Still open, and deliberately not closed here.** The cap is per-paste. Two
+consecutive within-limit pastes accumulate in the draft, so a paste-time cap is
+not a send-time guarantee. Whether the ceiling belongs at submit as well is a
+product question, referred to vjt rather than settled by whoever happened to be
+writing the guard.


### PR DESCRIPTION
## What ships

A newline cannot travel inside a `PRIVMSG` (CRLF terminates the frame), so honouring one means splitting into N messages — and N at once is exactly what upstream flood protection closes the connection for. The composer had two routes onto that and neither asked.

**1. Shift+Enter is a no-op.** `preventDefault`, no send, no line break. It used to insert a newline. No client sets the precedent (mIRC's editbox is single-line and pops a "paste N lines?" dialog; hexchat splits paste), only the hazard exists. Closing this door is what makes the remaining one sufficient: **paste is now the only way a multi-line body reaches the box, and paste is guarded.**

**2. Any paste that becomes more than one message confirms**, and the dialog quotes **messages**, not lines — `Paste as N messages?` — with N computed by `splitMessageLines`, the function the send path itself uses.

**3. A hard cap of five messages, with two doors above it.** `PASTE_HARD_MESSAGE_LIMIT = 5`, a flat constant. Above it the block never enters the composer: the operator gets **"Upload as file"** or **cancel**. Never a bare refusal — a dead end only teaches them to paste it in two halves, which is the same burst with extra steps.

`classifyPaste/1` returns a closed `"insert" | "confirm" | "over-limit"` and the router switches on it once, so a future fourth arm is a compile error at every call site rather than a silent fall-through.

## The second door is the upload verb, not a new service

`text/plain` is **already** an accepted upload MIME in the `document` category (`uploadCategory.ts`, a 1:1 mirror of the server's `@mime_categories`, 10 MiB on the default host). So the overflow path needs **no new category, no new server surface, no new taxonomy**: the pasted text is wrapped in a `File` and handed to the existing `dropUpload`, and the orchestrator posts the resulting URL as one 📄-prefixed PRIVMSG. Same shape as the 📸 image path CLAUDE.md names as the model — media is a link, IRC stays text. CLAUDE.md's "reuse the verbs, not the nouns", applied literally; the 20% that didn't fit would have been the domain boundary, and there wasn't any.

The cap is a constant on purpose. The issue asked whether to derive it; there is nothing honest to derive from — flood limits differ per network and usermode-exempt users escape them entirely, so a "computed" ceiling would be a guess wearing a formula.

## The reversal, called out

#80's counter was deliberately **not** `splitMessageLines`, with a comment defending the difference: it counted lines as SEEN in the box (blank interior lines included), because "how big is this paste" was held to be a different question from the send-time fan-out. That was right while the dialog only warned about size. It stops being right once the dialog must state how many *messages* the paste becomes, because that number is a promise about what send will do. The two are now one computation, pinned by an equality assertion rather than a restated rule — so if the send-side notion of "blank" moves again (#863 moved it once), the dialog cannot silently start lying.

Visible effects: a lone trailing newline (the commonest copy artifact) no longer costs a dialog; a block with blank lines between paragraphs quotes the real frame count, and cannot be pushed over the cap by lines that produce no frame.

## Still open, deliberately

**The cap is per-paste.** Two consecutive within-limit pastes still accumulate in the draft, so a paste-time cap is not a send-time guarantee. Whether the ceiling also belongs at submit is a product question — referred to vjt, not settled by whoever happened to be writing the guard.

## Gates

- `bun run test` — **4451/4451 green** (242 files).
- `bun run check` (biome + `tsc --noEmit`) exit 0; `tsc --noEmit` standalone exit 0. (biome ignores `e2e/`, so the specs have no static gate — run, not linted.)
- Scoped e2e, chromium: `paste|multiline compose` → **6/6 green**, including the new over-cap spec and the rewritten #80 boundary arm. **A spot-check, not the ship gate** — the full `scripts/integration.sh` on this PR's CI is.

**The over-cap e2e was verified by mutation, not trusted for being green.** It passed in 1.2s, which is fast for a multipart POST → auto-send → IRC echo, so the upload MIME was temporarily changed to one `dropUpload` filters out: the spec then failed at the 📄 assertion after its full 20s poll. It is load-bearing. It also asserts the burst did NOT also happen — none of the pasted lines appear as their own message — so an implementation that uploaded *and* pasted could not pass it.

Three e2e specs had comments/assertions updated because they encoded the old rule: `issue80-paste-flood-guard` (the 3-line frictionless arm asserted behaviour the ruling removed; plus the new over-cap test), and `multiline-compose-fanout` (its header cited Shift+Enter as a multiline source).

Refs #816.