### PR TITLE
compose(#772): the draft is window state, so store it where windows live

### DIFF
--- a/cicchetto/e2e/tests/issue772-compose-draft-reload.spec.ts
+++ b/cicchetto/e2e/tests/issue772-compose-draft-reload.spec.ts
@@ -1,0 +1,97 @@
+// #772 — an unsent compose draft survives a reload.
+//
+// The draft lived in an in-memory `identityScopedStore` signal, so it died
+// with the document. Every reload path ate it: the #674 refresh banner, a
+// manual reload, the #695 stale resume. #674 made reloads automatic once the
+// operator has been away past a dwell, which means the draft most likely to
+// be discarded is the one they walked away from mid-sentence.
+//
+// vitest covers the store contract by re-importing the module, which is a
+// faithful model of a boot but is still a model: it cannot show that the text
+// comes BACK INTO THE TEXTAREA, because the textarea is not in it. That is the
+// whole of what the user sees here, so it is what this asserts — type, reload
+// for real, read the textarea. `page.reload()` is the same in-place navigation
+// `performRefresh` ends in, so it exercises the tier decision too:
+// sessionStorage survives exactly this and nothing wider.
+//
+// Two negatives ride along, both worse-than-the-bug regressions:
+//   * a SENT message must not come back — resurrecting text the operator
+//     already dispatched would be a new defect, not a fixed one;
+//   * the draft must not leak into a DIFFERENT channel's composer.
+//
+// Sibling coverage: `compose.test.ts` ("compose draft persistence across a
+// reload (#772)") pins the store rules, including that history does NOT cross.
+
+import { expect, test } from "@playwright/test";
+import { composeTextarea, loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+// The seeder autojoins exactly one channel; `?? ""` satisfies
+// noUncheckedIndexedAccess without inventing a fallback that could pass.
+const CHANNEL = AUTOJOIN_CHANNELS[0] ?? "";
+
+test.describe("#772 compose drafts survive a reload", () => {
+  test("an unsent draft is still in the textarea after a real reload", async ({ page }) => {
+    const vjt = getSeededVjt();
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+    // Marker so a stale buffer from another spec cannot green this.
+    const draft = `half-written thought ${Date.now()}`;
+    const composer = composeTextarea(page);
+    await composer.fill(draft);
+    await expect(composer).toHaveValue(draft);
+
+    // A real reload — same tab, same origin, exactly what the #674 refresh
+    // button and a manual F5 both do.
+    await page.reload();
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+    // The point of the issue: the operator gets their sentence back, with no
+    // "restored" affordance to dismiss — it just looks like nothing happened.
+    await expect(composeTextarea(page)).toHaveValue(draft, { timeout: 10_000 });
+  });
+
+  test("a SENT message does not come back on reload", async ({ page }) => {
+    const vjt = getSeededVjt();
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+    const composer = composeTextarea(page);
+    const body = `issue772 sent ${Date.now()}`;
+    await composer.fill(body);
+    await composer.press("Enter");
+    // The clear IS the success signal (compose.ts empties the draft on a
+    // successful submit), so waiting for it also waits for the dispatch.
+    await expect(composer).toHaveValue("");
+
+    await page.reload();
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+    // Persisting a snapshot of the live store means the clear travels too. If
+    // it did not, the operator would find a sent line staged to send again.
+    await expect(composeTextarea(page)).toHaveValue("", { timeout: 10_000 });
+  });
+
+  test("a draft stays in its own channel — the server window does not inherit it", async ({
+    page,
+  }) => {
+    const vjt = getSeededVjt();
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+    const draft = `channel-scoped ${Date.now()}`;
+    await composeTextarea(page).fill(draft);
+
+    await page.reload();
+
+    // Land on the SERVER window first: its composer must be empty, proving
+    // the restore is keyed per channel and not a single global buffer.
+    await selectChannel(page, NETWORK_SLUG, "Server", { awaitWsReady: false });
+    await expect(composeTextarea(page)).toHaveValue("");
+
+    // …and the channel that owns the draft still has it.
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+    await expect(composeTextarea(page)).toHaveValue(draft, { timeout: 10_000 });
+  });
+});

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -254,6 +254,9 @@ vi.mock("../lib/nickEquals", async (importOriginal) => ({
 beforeEach(() => {
   vi.resetModules();
   localStorage.clear();
+  // #772 — drafts persist in sessionStorage, so it needs the same per-test
+  // wipe localStorage gets or one test's draft seeds the next one's boot.
+  sessionStorage.clear();
   vi.clearAllMocks();
 });
 
@@ -272,6 +275,101 @@ describe("compose draft state", () => {
   it("getDraft returns empty string for an untouched channel", async () => {
     const compose = await import("../lib/compose");
     expect(compose.getDraft(channelKey("freenode", "#never"))).toBe("");
+  });
+});
+
+// #772 — an unsent draft used to die with the document. `vi.resetModules()` +
+// a fresh import re-executes the module exactly as a page load does, so it is
+// the reload these tests are about: whatever survives it is what the operator
+// gets back. sessionStorage is deliberately NOT cleared between the two
+// imports — clearing it would be clearing the browser, not reloading it.
+describe("compose draft persistence across a reload (#772)", () => {
+  it("restores an unsent draft on the next boot", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const k = channelKey("freenode", "#a");
+
+    const before = await import("../lib/compose");
+    before.setDraft(k, "half-written thought");
+
+    vi.resetModules();
+    const after = await import("../lib/compose");
+
+    expect(after.getDraft(k)).toBe("half-written thought");
+  });
+
+  it("keeps drafts apart per channel across the reload", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const k1 = channelKey("freenode", "#a");
+    const k2 = channelKey("libera", "#b");
+
+    const before = await import("../lib/compose");
+    before.setDraft(k1, "for #a");
+    before.setDraft(k2, "for #b");
+
+    vi.resetModules();
+    const after = await import("../lib/compose");
+
+    expect(after.getDraft(k1)).toBe("for #a");
+    expect(after.getDraft(k2)).toBe("for #b");
+  });
+
+  it("does NOT resurrect a message that was already sent", async () => {
+    // The failure mode worse than the bug: re-posting text the operator
+    // already dispatched. `submit` clears the draft on success, and the
+    // persisted copy mirrors the store, so the clear must travel too.
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+
+    const before = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    before.setDraft(k, "already said this");
+    await before.submit(k, "freenode", "#a");
+    expect(before.getDraft(k)).toBe("");
+
+    vi.resetModules();
+    const after = await import("../lib/compose");
+
+    expect(after.getDraft(k)).toBe("");
+  });
+
+  it("does NOT resurrect a draft the operator cleared by hand", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const k = channelKey("freenode", "#a");
+
+    const before = await import("../lib/compose");
+    before.setDraft(k, "typed then thought better of it");
+    before.setDraft(k, "");
+
+    vi.resetModules();
+    const after = await import("../lib/compose");
+
+    expect(after.getDraft(k)).toBe("");
+  });
+
+  it("carries the draft ONLY — send history does not cross the reload", async () => {
+    // Scope pin. History is a different feature with a different lifetime
+    // question (and a server-side answer if it ever wants one); #772 asked
+    // for the unsent buffer. Persisting it by accident would silently widen
+    // what a reload restores.
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+
+    const before = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    before.setDraft(k, "sent one");
+    await before.submit(k, "freenode", "#a");
+    before.setDraft(k, "still typing");
+
+    vi.resetModules();
+    const after = await import("../lib/compose");
+
+    expect(after.getDraft(k)).toBe("still typing");
+    // recallPrev on a boot with no history is a no-op — it must NOT hand
+    // back "sent one", and it must not eat the restored draft either.
+    after.recallPrev(k);
+    expect(after.getDraft(k)).toBe("still typing");
   });
 });
 

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -1,4 +1,4 @@
-import { createSignal } from "solid-js";
+import { createEffect, createSignal, on } from "solid-js";
 import { addAlias, aliases, delAlias } from "./aliasList";
 import {
   ApiError,
@@ -133,6 +133,64 @@ const empty = (): ComposeState => ({
   stashedDraft: "",
 });
 
+// #772 — an unsent draft used to die with the document, so every reload path
+// ate it: the #674 refresh banner, a manual reload, the #695 stale resume.
+// #674 made that automatic once the operator has been away past a dwell — and
+// the draft they walked away from mid-sentence is exactly the one it discards.
+//
+// sessionStorage, NOT localStorage. The issue left the tier open; the codebase
+// had already answered it for this exact question. `staleResume.ts` keeps its
+// "when was THIS document last alive" stamp in sessionStorage because that is
+// per-window-lifetime: it survives a reload and a suspension, and it does not
+// leak between tabs. A half-typed line is the same kind of fact — it belongs
+// to the window the operator is typing in. In localStorage two tabs on the
+// same channel would overwrite each other's buffer, which is a worse bug than
+// the one being fixed, and every reload path #772 names happens in-place
+// (`window.location.reload()`), so nothing needs to outlive the tab.
+//
+// The issue also asked how drafts get evicted. They don't, because this is not
+// an archive: it MIRRORS the live store, and the store clears a draft when it
+// is sent or erased. What is persisted is "which channels have unsent text
+// right now", which a human bounds on their own. Nothing accumulates, so
+// nothing needs sweeping — and a logout purges it for free, because the
+// identity reset empties the store and the mirror follows it down.
+//
+// Only `draft` crosses. History, the history cursor and the #666 stashed
+// draft are in-session mechanics, not the thing the operator would miss.
+const DRAFTS_KEY = "cicchetto.composeDrafts";
+
+// Boundary parse: these bytes can come from a different bundle version or a
+// hand-edited devtools session, and a throw here would abort the whole store
+// build and leave cic with no composer at all. Shape-check each entry and drop
+// what doesn't fit, rather than trusting the cast.
+const loadPersistedDrafts = (): Record<ChannelKey, ComposeState> => {
+  const raw = sessionStorage.getItem(DRAFTS_KEY);
+  if (raw === null) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {};
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return {};
+  const out: Record<ChannelKey, ComposeState> = {};
+  for (const [key, draft] of Object.entries(parsed)) {
+    if (typeof draft !== "string" || draft === "") continue;
+    out[key as ChannelKey] = { ...empty(), draft };
+  }
+  return out;
+};
+
+const persistDrafts = (states: Record<ChannelKey, ComposeState>): void => {
+  const drafts: Record<string, string> = {};
+  for (const [key, state] of Object.entries(states)) {
+    if (state.draft !== "") drafts[key] = state.draft;
+  }
+  const keys = Object.keys(drafts);
+  if (keys.length === 0) sessionStorage.removeItem(DRAFTS_KEY);
+  else sessionStorage.setItem(DRAFTS_KEY, JSON.stringify(drafts));
+};
+
 // #591 — the single CTCP frame builder: `\x01VERB\x01` (no args) or
 // `\x01VERB args\x01`. This is the ONE place that wraps a body in CTCP `\x01`
 // framing — shared by /me (verb ACTION, one frame per line) and /ctcp
@@ -250,9 +308,21 @@ export const sendBodyLines = async (
 };
 
 const exports_ = identityScopedStore((onIdentityChange) => {
+  // #772 — seeded from the previous document's unsent drafts. The textarea is
+  // `value={getDraft(key())}`, so restoring the store IS restoring the UI:
+  // nothing in ComposeBox changes, and a restored draft simply looks like the
+  // reload never happened (no "restored" badge — a textarea that kept its text
+  // is what every other text field on the web already does).
   const [composeByChannel, setComposeByChannel] = createSignal<Record<ChannelKey, ComposeState>>(
-    {},
+    loadPersistedDrafts(),
   );
+
+  // The mirror. `defer` so the boot read is not immediately written back, and
+  // `on` so this tracks the store and nothing else. It is write-only toward
+  // storage — it never puts anything INTO the composer after boot, which is
+  // what keeps #907's guarantee intact: the claim→prepare→first-write window
+  // gains no new writer, and no await is introduced anywhere near it.
+  createEffect(on(composeByChannel, persistDrafts, { defer: true }));
 
   // Tab-complete cycle anchor. Continuation is detected by RANGE, not by
   // word equality, so it survives the ": "/" " suffix that sits after the

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -31095,3 +31095,60 @@ site that turned the column into a duration is the one that was wrong.
 
 **What is not claimed.** Mezmerize's database was never read; the mechanism is a
 code reading whose symptom matches, not an observation of his row.
+## 2026-08-06 — #772: the draft is window state, so it lives where windows live
+
+An unsent compose draft died with the document. `composeByChannel` is an
+in-memory `identityScopedStore` signal and nothing in `compose.ts` or
+`identityScopedStore.ts` ever touched storage, so every reload path ate it: the
+#674 refresh banner, a manual reload, the #695 stale resume. Nothing here was a
+regression — what changed is that #674 now reloads on its own once the operator
+has been away past a dwell, and the draft they abandoned mid-sentence and
+walked away from is precisely the one that gets discarded.
+
+**The issue left three questions open. Picking the tier answered two of them.**
+
+*Tier: sessionStorage.* The codebase had already reasoned this out for the same
+shape of fact. `staleResume.ts` keeps its "when was THIS document last alive"
+stamp in sessionStorage because that is per-window-lifetime: it survives a
+reload and a suspension and does not leak between tabs. A half-typed line is
+the same kind of fact — it belongs to the window being typed in. localStorage
+would let two tabs on one channel overwrite each other's buffer, a worse bug
+than the one being fixed, and buys nothing: every reload path #772 names is
+in-place (`window.location.reload()`), so nothing needs to outlive the tab.
+
+*Eviction: none, because this is not an archive.* The persisted value MIRRORS
+the live store, and the store clears a draft when it is sent or erased. What is
+on disk is "which channels have unsent text right now" — a set a human bounds
+on their own. Nothing accumulates, so nothing needs sweeping.
+
+*Identity purge: also free.* `onIdentityChange` already empties the store, and
+the mirror follows it down to `{}`. No second reset, no key scoped by subject.
+
+*Restored-marker: no.* A textarea that kept its text is what every other text
+field on the web does; a badge would be an affordance to dismiss for an event
+the operator did not ask about.
+
+**Only `draft` crosses.** History, the history cursor and the #666 stashed
+draft stay in-session: #772 asked for the unsent buffer, and a reload that
+silently restored send history would be a wider promise than anyone made. A
+test pins it.
+
+**The UI needed no change at all.** ComposeBox renders
+`value={getDraft(key())}`, so seeding the store IS restoring the composer.
+
+**It does not touch #907.** The mirror is an `on(composeByChannel, …,
+{defer: true})` effect that only ever writes TOWARD storage; it never puts
+anything into the composer after boot and introduces no await. The
+claim→prepare→first-residue-write window gains no new writer.
+
+**One catch, deliberately.** The seed `JSON.parse` is wrapped, because those
+bytes are a boundary — a different bundle version or a devtools edit — and a
+throw there would abort the whole store build and leave cic with no composer.
+Each entry is shape-checked and dropped if it does not fit. The write is NOT
+wrapped: no other `setItem` in cic is, and inventing a second pattern for a
+quota ceiling nobody has hit would be speculation.
+
+**Not measured:** the mirror serialises on every store write, which includes
+every keystroke and every acked line of a #666 paced drain. For drafts of human
+size that is noise, and no debounce was added on a guess; a pathological paste
+was not benchmarked.


### PR DESCRIPTION
## Premises checked first — this one is NOT stale

Two of today's three issues had premises the code had already overtaken. #772
has not: `compose.ts` still keeps `draft` in an in-memory `identityScopedStore`
signal, and `grep -n "localStorage\|sessionStorage"` over `compose.ts` +
`identityScopedStore.ts` returns **nothing**. The draft dies with the document,
exactly as reported. It builds.

## The three open questions — picking the tier answered two of them

**Tier: `sessionStorage`.** The issue left this open; the codebase had already
reasoned it out for the same shape of fact. `staleResume.ts` keeps its "when was
THIS document last alive" stamp in sessionStorage *because* that is
per-window-lifetime: it survives a reload and a suspension, and it does not leak
between tabs. A half-typed line belongs to the window being typed in.
localStorage would let two tabs on one channel overwrite each other's buffer — a
worse bug than the one being fixed — and buys nothing, since every reload path
the issue names is in-place (`window.location.reload()`, confirmed in
`bundleHash.performRefresh`).

**Eviction: none, because this is not an archive.** The persisted value MIRRORS
the live store, and the store clears a draft when it is sent or erased. What is
on disk is "which channels have unsent text *right now*" — a set a human bounds
on their own. Nothing accumulates, so nothing needs sweeping.

**Identity purge: also free.** `onIdentityChange` already empties the store and
the mirror follows it down to `{}`. No second reset, no subject-scoped key.

**Restored-marker: no.** A textarea that kept its text is what every other text
field on the web already does; a badge is an affordance to dismiss for an event
the operator never asked about.

## Scope held

Only `draft` crosses. History, the history cursor and the #666 stashed draft
stay in-session — #772 asked for the unsent buffer, and a reload that silently
restored send history would be a wider promise than anyone made. **A test pins
it**, so it cannot widen by accident.

**The UI needed no change at all**: ComposeBox renders `value={getDraft(key())}`,
so seeding the store IS restoring the composer.

## #907 is untouched

You flagged the crossing. The mirror is an `on(composeByChannel, …,
{defer: true})` effect that only ever writes TOWARD storage: it never puts
anything into the composer after boot, and it introduces no await. The
claim→prepare→first-residue-write window gains no new writer, so the guarantee
that redded-then-greened stays exactly as #907 left it.

## One catch, deliberately

The seed `JSON.parse` is wrapped — those bytes are a boundary (a different
bundle version, a devtools edit), and a throw there would abort the whole store
build and leave cic with no composer at all. Each entry is shape-checked and
dropped if it does not fit. The write is **not** wrapped: no other `setItem` in
cic is, and inventing a second pattern for a quota ceiling nobody has hit would
be speculation.

## Gates

| gate | result |
|---|---|
| `bun run test` | rc=0 — 242 files / **4449** tests (was 4443; +6) |
| `bun run check` | rc=0 |
| `tsc --noEmit` standalone | rc=0 — run separately, since `check` is `biome && tsc` and a biome red would hide it |
| e2e | 🔴 **NOT RUN locally** — the PR's Playwright job is the gate |

No Elixir file is touched, so `check.sh` has nothing to say here.

### Red read BEFORE the green, this time

The five new store tests were run against unmodified `compose.ts` first:
**3 failed, 2 passed**, and the split is the interesting part. The three that
failed are the ones that need persistence. The two that passed are the
anti-resurrection guards — "a SENT message does not come back", "a cleared
draft does not come back" — which pass trivially today *because nothing
persists*, and whose job starts now. They are still green after the change,
which is the actual assertion.

`vi.resetModules()` + a fresh import re-executes the module exactly as a page
load does; sessionStorage is deliberately not cleared between the two imports,
because clearing it would be clearing the browser, not reloading it.

## What I am NOT claiming

- **The e2e has not been executed.** `issue772-compose-draft-reload.spec.ts`
  asserts what the user actually sees — type, real `page.reload()`, read the
  textarea — plus the two negatives (a sent message must not return; the draft
  must not leak into the server window). Per your note I am leaning on the PR's
  Playwright job rather than asking for the STACK lane. Note it has no static
  net either: biome scopes to `src/**` and `tsc -p e2e/` cannot resolve
  `@playwright/test` in the container.
- **The write cost is not measured.** The mirror serialises on every store
  write — every keystroke, and every acked line of a #666 paced drain. For
  drafts of human size that is noise. I did not benchmark a pathological paste,
  and I did not add a debounce on a guess.
- The identity-rotation purge has **no direct test in `compose.test.ts`**: that
  file mocks `auth.token` as a plain `vi.fn`, which is not reactive, so
  `on(token)` never fires there. It follows from the mirror invariant (which is
  tested) plus the pre-existing `onIdentityChange` reset — I did not add a
  test-only surface to assert it directly.