### PR TITLE
cic(#793): shareable channel invite links — path → confirm → join

### DIFF
--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -602,6 +602,25 @@ export async function joinChannel(
   }
 }
 
+// GET /networks/:slug/channels — the channel list cic itself reads at boot
+// (`networks.ts` `channelsBySlug`). A spec whose PRECONDITION is "already in
+// this channel" must wait on THIS list rather than on `joinChannel` returning:
+// the POST only asks, and the row lands once the upstream JOIN completes. A
+// spec that races it is testing the boot ordering, not the behaviour it names
+// (#793, where the invite's already-in branch was scored against a channel the
+// server had not listed yet).
+export async function listChannelNames(token: string, networkSlug: string): Promise<string[]> {
+  const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(networkSlug)}/channels`;
+  const res = await fetch(url, { headers: { authorization: `Bearer ${token}` } });
+  if (!res.ok) {
+    throw new Error(`listChannelNames: unexpected status ${res.status}`);
+  }
+  // The response IS the array (no named wrapper) — same shape cic's
+  // `api.ts` `listChannels` reads.
+  const body = (await res.json()) as Array<{ name: string }>;
+  return body.map((c) => c.name);
+}
+
 // PATCH /networks/:slug — T32 connection_state transition. Mirrors
 // `cicchetto/src/lib/api.ts`'s `patchNetwork`. Used by the parked-
 // flow e2e: setting `connection_state: "parked"` triggers

--- a/cicchetto/e2e/tests/issue793-invite-link.spec.ts
+++ b/cicchetto/e2e/tests/issue793-invite-link.spec.ts
@@ -1,0 +1,142 @@
+// #793 — a shareable invite link, `irc.sindro.me/<network>/<channel>`, is a
+// URL you can paste to a normal person: they click it, they are ASKED, and
+// they land in the channel.
+//
+// What is proven here is the user-visible chain, end to end against the live
+// bahamut-test leaf, not the existence of a parser:
+//   1. Opening the app AT the invite path pops the shared ConfirmModal naming
+//      the channel; confirming JOINs it and switches to the window. The
+//      address bar is left clean, so a refresh does not re-fire the invite.
+//   2. An invite to a channel we are already in switches straight there with
+//      NO modal (#648's rule: asking to join an open window is noise).
+//   3. An invite naming a network this account has not bound joins nothing
+//      and says so — the branch #793 leaves open (cross-user network
+//      identity) must be a visible dead end, never a silent one.
+//
+// Before #793 the SPA had no route for a two-segment path at all: the server
+// served index.html (#399) and the router matched nothing, so the link
+// rendered a blank page. That is what test 1 fails on if the boot reader
+// stops rewriting the URL.
+
+import type { Page } from "@playwright/test";
+import { expect, test } from "../fixtures/test";
+import {
+  confirmModal,
+  confirmModalBody,
+  confirmModalYes,
+  sidebarWindow,
+} from "../fixtures/cicchettoPage";
+import {
+  joinChannel,
+  listChannelNames,
+  partChannel,
+  type SeededUser,
+} from "../fixtures/grappaApi";
+import { getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
+
+// Lowercase throughout: raw == ASCII-folded, so the sidebar window key (the
+// folded key IS the display) equals the spelling asserted on. The raw-vs-
+// folded split of the invite path itself is pinned by the inviteLink unit
+// test (`#BoFH`), which is the cheaper place for a casing matrix.
+const freshChannel = (label: string) => `#i793${label}-${crypto.randomUUID().slice(0, 6)}`;
+
+// The link carries the channel WITHOUT its `#`: a literal `#` in a URL is the
+// fragment delimiter and would never reach the server. The bare spelling is
+// the one a human pastes, and the parser implies the sigil.
+const invitePath = (networkSlug: string, channel: string) =>
+  `/${networkSlug}/${channel.replace(/^#/, "")}`;
+
+// Auth is pre-seeded the way `loginAs` does it, but the navigation target is
+// the invite path rather than `/` — `loginAs` always gotos the root.
+async function openInvite(page: Page, vjt: SeededUser, path: string): Promise<void> {
+  await page.addInitScript(
+    ([token, subjectJson]) => {
+      localStorage.setItem("grappa-token", token);
+      localStorage.setItem("grappa-subject", subjectJson);
+      localStorage.setItem("cic.installChoice", "browser");
+    },
+    [vjt.token, vjt.subjectJson] as const,
+  );
+  await page.goto(path);
+}
+
+test("an invite link asks, then joins and switches (#793)", async ({ page }) => {
+  const vjt = getSeededVjt();
+  const target = freshChannel("join");
+
+  await openInvite(page, vjt, invitePath(NETWORK_SLUG, target));
+
+  // Discriminating probe: the invite reader sets this only after it has
+  // ROUTED a parsed target, so the assertions below cannot pass off the back
+  // of an unrelated session-restore selection.
+  await page.waitForFunction(() => window.__cicInviteLinkApplied === true, null, {
+    timeout: 15_000,
+  });
+
+  // The consent gate. A URL must never join anybody silently.
+  await expect(confirmModal(page)).toBeVisible({ timeout: 10_000 });
+  await expect(confirmModalBody(page)).toHaveText(`Join ${target}?`);
+
+  // Address bar already clean — the invite is spent, a refresh re-fires
+  // nothing. Asserted BEFORE the confirm so it is the reader being tested,
+  // not some later navigation.
+  expect(new URL(page.url()).pathname).toBe("/");
+  expect(new URL(page.url()).search).toBe("");
+
+  await confirmModalYes(page);
+
+  try {
+    await expect(sidebarWindow(page, NETWORK_SLUG, target)).toHaveClass(/selected/, {
+      timeout: 15_000,
+    });
+    // Count-0, not not-visible: an absent node satisfies toBeVisible's
+    // negation for the wrong reason.
+    await expect(confirmModal(page)).toHaveCount(0);
+  } finally {
+    await partChannel(vjt.token, NETWORK_SLUG, target);
+  }
+});
+
+test("an invite to a channel we are already in switches with NO modal (#793)", async ({ page }) => {
+  const vjt = getSeededVjt();
+  const already = freshChannel("have");
+
+  // The PRECONDITION is "already in the channel", so it has to be true before
+  // the link is opened — not merely requested. `joinChannel` returns when the
+  // POST is accepted; the channel appears in the list cic reads at boot once
+  // the upstream JOIN lands. Waiting on the list makes this a test of the
+  // invite's already-in branch instead of a race against the join.
+  await joinChannel(vjt.token, NETWORK_SLUG, already);
+  await expect
+    .poll(() => listChannelNames(vjt.token, NETWORK_SLUG), { timeout: 20_000 })
+    .toContain(already);
+
+  try {
+    await openInvite(page, vjt, invitePath(NETWORK_SLUG, already));
+    await page.waitForFunction(() => window.__cicInviteLinkApplied === true, null, {
+      timeout: 15_000,
+    });
+
+    await expect(sidebarWindow(page, NETWORK_SLUG, already)).toHaveClass(/selected/, {
+      timeout: 15_000,
+    });
+    await expect(confirmModal(page)).toHaveCount(0);
+  } finally {
+    await partChannel(vjt.token, NETWORK_SLUG, already);
+  }
+});
+
+test("an invite for an unbound network joins nothing and says so (#793)", async ({ page }) => {
+  const vjt = getSeededVjt();
+
+  await openInvite(page, vjt, invitePath("nowhere-bound", "somechannel"));
+  await page.waitForFunction(() => window.__cicInviteLinkApplied === true, null, {
+    timeout: 15_000,
+  });
+
+  await expect(page.locator(".toast-stack .toast")).toContainText("nowhere-bound", {
+    timeout: 10_000,
+  });
+  // No consent was asked for, because there is nothing to consent to.
+  await expect(confirmModal(page)).toHaveCount(0);
+});

--- a/cicchetto/src/Toasts.tsx
+++ b/cicchetto/src/Toasts.tsx
@@ -5,6 +5,7 @@ import {
   bundleRefreshToasts,
   dismissBundleRefreshToast,
 } from "./lib/bundleRefreshNotice";
+import { dismissInviteToast, inviteToasts } from "./lib/inviteLink";
 import { dismissPresenceToast, presenceToasts } from "./lib/notifyWatch";
 import NickText from "./NickText";
 
@@ -94,6 +95,19 @@ const Toasts: Component = () => {
         {(toast) => (
           <ToastRow tone="update" icon="↻" onDismiss={() => dismissBundleRefreshToast(toast.id)}>
             <span class="toast-text">{toast.text}</span>
+          </ToastRow>
+        )}
+      </For>
+      {/* #793 — an invite link for a network this account has not bound.
+          Whether that case should offer to add the network is an open product
+          decision; until it is taken, the recipient at least learns why the
+          link they clicked did nothing. */}
+      <For each={inviteToasts()}>
+        {(toast) => (
+          <ToastRow tone="error" icon="!" onDismiss={() => dismissInviteToast(toast.id)}>
+            <span class="toast-text">
+              Invite for {toast.networkSlug} — you are not connected to that network.
+            </span>
           </ToastRow>
         )}
       </For>

--- a/cicchetto/src/__tests__/inviteLink.test.ts
+++ b/cicchetto/src/__tests__/inviteLink.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { confirmJoinChannel, switchToChannelWindow } from "../lib/channelJoin";
+import {
+  dismissInviteToast,
+  inviteToasts,
+  parseInviteLinkPath,
+  routeInviteTarget,
+} from "../lib/inviteLink";
+
+// #793 — shareable channel invite links: `irc.sindro.me/<network>/<channel>`.
+//
+// Two halves, both here: the PATH parser (the new reader — `pushTarget.ts`
+// only ever read `location.search`) and the ROUTE (what the parsed target
+// does). The route delegates to the #648 join verb rather than reimplementing
+// confirm-then-join, so these assertions are about DELEGATION, not about the
+// modal's internals (ConfirmModal has its own tests).
+
+vi.mock("../lib/channelJoin", () => ({
+  confirmJoinChannel: vi.fn(),
+  switchToChannelWindow: vi.fn(),
+}));
+
+vi.mock("../lib/networks", () => ({
+  networkBySlug: vi.fn((slug: string) =>
+    slug === "azzurra" ? { id: 1, slug: "azzurra", kind: "user" } : undefined,
+  ),
+  channelsBySlug: vi.fn(() => ({ azzurra: [{ id: 10, name: "#bofh" }] })),
+}));
+
+describe("parseInviteLinkPath", () => {
+  it("reads a bare two-segment path and implies the # sigil", () => {
+    expect(parseInviteLinkPath("/azzurra/sniffo")).toEqual({
+      networkSlug: "azzurra",
+      channelName: "#sniffo",
+      kind: "channel",
+    });
+  });
+
+  it("keeps a percent-encoded # sigil instead of doubling it", () => {
+    // `#` cannot travel literally in a path — a browser would read it as the
+    // fragment and the server would never see the segment at all (#755: the
+    // room segment was the one URL component never encoded).
+    expect(parseInviteLinkPath("/azzurra/%23sniffo")?.channelName).toBe("#sniffo");
+  });
+
+  it("passes the non-# chantypes sigils through untouched", () => {
+    expect(parseInviteLinkPath("/azzurra/&local")?.channelName).toBe("&local");
+    expect(parseInviteLinkPath("/azzurra/+modeless")?.channelName).toBe("+modeless");
+    expect(parseInviteLinkPath("/azzurra/!ABCDEsecret")?.channelName).toBe("!ABCDEsecret");
+  });
+
+  it("percent-decodes a non-ASCII channel name", () => {
+    expect(parseInviteLinkPath("/azzurra/caff%C3%A8")?.channelName).toBe("#caffè");
+  });
+
+  it("preserves the raw casing (the display spelling goes on the wire)", () => {
+    expect(parseInviteLinkPath("/azzurra/Sniffo")?.channelName).toBe("#Sniffo");
+  });
+
+  it("tolerates a trailing slash", () => {
+    expect(parseInviteLinkPath("/azzurra/sniffo/")?.channelName).toBe("#sniffo");
+  });
+
+  it("rejects a path that is not exactly two segments", () => {
+    expect(parseInviteLinkPath("/")).toBeNull();
+    expect(parseInviteLinkPath("/azzurra")).toBeNull();
+    expect(parseInviteLinkPath("/azzurra/sniffo/extra")).toBeNull();
+  });
+
+  it("rejects the reserved /share/:token client route", () => {
+    // A real two-segment route already exists — without this, a visitor
+    // share link would be read as an invite to network `share`.
+    expect(parseInviteLinkPath("/share/abc123")).toBeNull();
+  });
+
+  it("rejects a channel segment carrying a comma", () => {
+    // JOIN takes a comma-separated LIST: an unfiltered comma turns one
+    // invite into a multi-channel join the sender never wrote.
+    expect(parseInviteLinkPath("/azzurra/sniffo,bofh")).toBeNull();
+    expect(parseInviteLinkPath("/azzurra/sniffo%2Cbofh")).toBeNull();
+  });
+
+  it("rejects a channel segment carrying whitespace or control bytes", () => {
+    expect(parseInviteLinkPath("/azzurra/sniffo%20bofh")).toBeNull();
+    expect(parseInviteLinkPath("/azzurra/sniffo%0D%0AQUIT")).toBeNull();
+    expect(parseInviteLinkPath("/azzurra/sniffo%07")).toBeNull();
+  });
+
+  it("rejects a malformed percent-escape instead of throwing", () => {
+    expect(parseInviteLinkPath("/azzurra/%ZZ")).toBeNull();
+  });
+
+  it("rejects a bare sigil with no name", () => {
+    expect(parseInviteLinkPath("/azzurra/%23")).toBeNull();
+  });
+});
+
+describe("routeInviteTarget", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const t of inviteToasts()) dismissInviteToast(t.id);
+  });
+
+  it("delegates an unjoined channel to the #648 confirm-then-join verb", () => {
+    routeInviteTarget({ networkSlug: "azzurra", channelName: "#sniffo", kind: "channel" });
+    expect(confirmJoinChannel).toHaveBeenCalledWith("azzurra", "#sniffo");
+    expect(switchToChannelWindow).not.toHaveBeenCalled();
+  });
+
+  it("switches with NO modal when the channel is already in the server's list", () => {
+    routeInviteTarget({ networkSlug: "azzurra", channelName: "#bofh", kind: "channel" });
+    expect(switchToChannelWindow).toHaveBeenCalledWith("azzurra", "#bofh");
+    expect(confirmJoinChannel).not.toHaveBeenCalled();
+  });
+
+  it("folds the already-in comparison (a link is spelled by a human)", () => {
+    routeInviteTarget({ networkSlug: "azzurra", channelName: "#BoFH", kind: "channel" });
+    expect(switchToChannelWindow).toHaveBeenCalledWith("azzurra", "#BoFH");
+    expect(confirmJoinChannel).not.toHaveBeenCalled();
+  });
+
+  it("says so, visibly, when the network is not bound for this recipient", () => {
+    // Open decision 1 of #793 — cross-user network identity is unresolved, so
+    // this branch deliberately does NOT join anything. What it must not do is
+    // fail silently: the recipient clicked a link and is owed an answer.
+    routeInviteTarget({ networkSlug: "libera", channelName: "#sniffo", kind: "channel" });
+    expect(confirmJoinChannel).not.toHaveBeenCalled();
+    expect(switchToChannelWindow).not.toHaveBeenCalled();
+    const toasts = inviteToasts();
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0]?.networkSlug).toBe("libera");
+  });
+});

--- a/cicchetto/src/lib/channelJoin.ts
+++ b/cicchetto/src/lib/channelJoin.ts
@@ -31,7 +31,10 @@ import { windowStateByChannel } from "./windowState";
 // `channelKey`, which folds internally), because window_states + selection are
 // keyed folded — a mixed-case focus target opens a phantom window.
 
-function switchTo(networkSlug: string, rawChannel: string): void {
+// Exported for #793's invite-link route, which reaches the already-in-the-
+// channel outcome from a URL instead of a tap and must not grow a second
+// spelling of "focus this channel window".
+export function switchToChannelWindow(networkSlug: string, rawChannel: string): void {
   setSelectedChannel({
     networkSlug,
     channelName: canonicalChannel(rawChannel),
@@ -47,7 +50,7 @@ async function performJoin(networkSlug: string, rawChannel: string): Promise<voi
     await postJoin(t, networkSlug, rawChannel, null);
     // Focus originates HERE (the tap), AFTER the awaited join — a rejected
     // join (+i / +k / +b) never foregrounds a phantom window (#244).
-    switchTo(networkSlug, rawChannel);
+    switchToChannelWindow(networkSlug, rawChannel);
   } catch (err) {
     // Fire-and-forget UI action with no dedicated error surface (unlike the
     // DirectoryPane row's inline error signal). Log, don't throw — the same
@@ -85,7 +88,7 @@ export function acceptInvite(networkSlug: string, rawChannel: string): void {
 export function confirmJoinChannel(networkSlug: string, rawChannel: string): void {
   const joined = windowStateByChannel()[channelKey(networkSlug, rawChannel)] === "joined";
   if (joined) {
-    switchTo(networkSlug, rawChannel);
+    switchToChannelWindow(networkSlug, rawChannel);
     return;
   }
   requestConfirm({

--- a/cicchetto/src/lib/inviteLink.ts
+++ b/cicchetto/src/lib/inviteLink.ts
@@ -1,0 +1,147 @@
+import { confirmJoinChannel, switchToChannelWindow } from "./channelJoin";
+import { canonicalChannel } from "./channelKey";
+import { channelsBySlug, networkBySlug } from "./networks";
+import type { PushTarget } from "./pushPayload";
+import { createToastQueue } from "./toasts";
+
+// #793 — shareable channel invite links: paste `https://irc.sindro.me/azzurra/sniffo`
+// anywhere, the recipient clicks, gets a confirm, and lands in the channel.
+//
+// This is the READ side (decision 5 of the issue): consuming a link. The
+// "copy invite link" affordance in the channel UI is a separate shipment.
+//
+// It is a second ENTRY POINT into the deep-link machinery, not a second
+// subsystem. `pushTarget.ts` already reads `?network=&channel=` at boot,
+// normalises it into a `PushTarget`, and defers routing until `networks()`
+// seeds; the invite path normalises into the SAME `PushTarget` and reuses the
+// SAME reader and the SAME defer (see `applyDeepLinkFromUrl`). Only two things
+// are genuinely new: parsing the PATH (the old reader looked at
+// `location.search` only), and routing to a JOIN instead of a selection.
+//
+// The join itself is the #648 verb — `confirmJoinChannel` — untouched: it
+// already owns confirm -> `postJoin` -> switch, and already switches with no
+// modal when we are in the channel. No new socket call, no second confirm
+// implementation, no parallel window state.
+
+// RFC 2812 chantypes. A segment that already starts with one is taken
+// verbatim; a bare segment gets `#` (vjt's `irc.sindro.me/azzurra/sniffo`
+// example — the overwhelming case, and the only spelling a normal person
+// will ever type).
+//
+// A literal `#` cannot travel in a path: the browser reads it as the start of
+// the fragment and the server never sees the segment at all. #755 is the
+// precedent for getting this wrong — the room segment there was the one URL
+// component never encoded. So `#` MUST arrive percent-encoded (`%23`), which
+// is also why the bare form exists: `/azzurra/sniffo` is what people paste.
+const CHANTYPES = "#&+!";
+
+// Two-segment client routes that are NOT invites. `/share/:token` (the visitor
+// session-sharing landing) is the only one today; `/login` and `/` are single
+// segment and cannot collide. Everything else two-segment reaching the SPA is
+// an invite — real API/asset paths are answered by the server before the
+// `GET /*path` SPA fallback (#399) ever runs.
+const RESERVED_FIRST_SEGMENT = new Set(["share"]);
+
+// Bytes RFC 2812 forbids inside a channel name, rejected rather than escaped.
+// The comma is the one that matters: JOIN takes a comma-separated LIST, so an
+// unfiltered `/azzurra/sniffo,bofh` would turn one invite into a multi-channel
+// join the sender never wrote. Everything at or below 0x20 covers
+// NUL/BEL/CR/LF/space, which cannot appear in a real channel and are the shape
+// a frame-injection attempt takes. Deliberately NOT rejecting `:` — also
+// illegal per the RFC, but harmless in a JSON body, and a false reject breaks
+// a link for no gain.
+//
+// A codepoint scan rather than a regex character class: the bytes in question
+// are invisible in source, and a class that silently loses one of them is
+// exactly the kind of edit nobody spots in review.
+const COMMA = 0x2c;
+const DEL = 0x7f;
+function hasForbiddenChannelByte(name: string): boolean {
+  for (const ch of name) {
+    const code = ch.codePointAt(0);
+    if (code === undefined) continue;
+    if (code <= 0x20 || code === COMMA || code === DEL) return true;
+  }
+  return false;
+}
+
+/**
+ * Parses `/<network>/<channel>` into the same `PushTarget` the push deep-link
+ * reader produces. Returns null for anything that is not an invite — a
+ * reserved route, a wrong segment count, an undecodable escape, or a channel
+ * name carrying bytes IRC forbids.
+ *
+ * `kind` is always `"channel"`: unlike `parsePushTargetUrl` there is no
+ * sigil-sniffing for a DM target, because a DM invite link is meaningless —
+ * the whole point is joining a room.
+ */
+export function parseInviteLinkPath(pathname: string): PushTarget | null {
+  const [rawNetwork, rawChannel, ...rest] = pathname.split("/").filter((s) => s.length > 0);
+  if (rawNetwork === undefined || rawChannel === undefined || rest.length > 0) return null;
+  if (RESERVED_FIRST_SEGMENT.has(rawNetwork)) return null;
+
+  let networkSlug: string;
+  let channel: string;
+  try {
+    networkSlug = decodeURIComponent(rawNetwork);
+    channel = decodeURIComponent(rawChannel);
+  } catch {
+    // Malformed percent-escape — `decodeURIComponent` throws URIError.
+    return null;
+  }
+
+  if (networkSlug.length === 0 || channel.length === 0) return null;
+  if (hasForbiddenChannelByte(channel)) return null;
+
+  const channelName = CHANTYPES.includes(channel.charAt(0)) ? channel : `#${channel}`;
+  // A bare sigil names nothing.
+  if (channelName.length < 2) return null;
+
+  return { networkSlug, channelName, kind: "channel" };
+}
+
+// Open decision 1 of #793, deliberately NOT settled here: `networkBySlug`
+// resolves against THIS user's bound networks, but an invite is cross-user by
+// definition, so the recipient may have no `azzurra` at all. Whether the path
+// segment becomes a globally-resolvable network identifier or the flow grows
+// an "add this network, then join" step is a product decision that has not
+// been taken. What this branch must not do is fail silently: somebody clicked
+// a link and is owed an answer, so it says what it observed and stops.
+type InviteToast = { networkSlug: string };
+
+const queue = createToastQueue<InviteToast>();
+
+export const inviteToasts = queue.toasts;
+export const dismissInviteToast = queue.dismiss;
+
+/**
+ * Applies a parsed invite: confirm-then-join on a bound network, a plain
+ * switch when we are already in the channel, a visible notice when the
+ * network is not bound for this recipient.
+ */
+export function routeInviteTarget(target: PushTarget): void {
+  if (networkBySlug(target.networkSlug) === undefined) {
+    queue.queue({ networkSlug: target.networkSlug });
+    return;
+  }
+  if (alreadyInChannel(target.networkSlug, target.channelName)) {
+    switchToChannelWindow(target.networkSlug, target.channelName);
+    return;
+  }
+  confirmJoinChannel(target.networkSlug, target.channelName);
+}
+
+// "Already in that channel -> just switch, no modal" (#648's rule, restated by
+// #793). The source is the SERVER's channel list rather than
+// `windowStateByChannel`, which is what `confirmJoinChannel` consults on its
+// own: an invite fires at BOOT, and the window states arrive later, per
+// channel, off the per-channel WS join replies that `channelsBySlug` itself
+// drives. Reading the live projection here would race it and pop a modal for
+// a channel we are sitting in. Same fact, the source that is ready at the
+// moment this question gets asked.
+function alreadyInChannel(networkSlug: string, rawChannel: string): boolean {
+  const list = channelsBySlug()?.[networkSlug];
+  if (list === undefined) return false;
+  const key = canonicalChannel(rawChannel);
+  return list.some((c) => canonicalChannel(c.name) === key);
+}

--- a/cicchetto/src/lib/pushTarget.ts
+++ b/cicchetto/src/lib/pushTarget.ts
@@ -23,9 +23,10 @@
 // applies the same routing. Deferred until networks() seed so the
 // selection doesn't fire on a still-loading store.
 
-import { createEffect, on } from "solid-js";
+import { createEffect, untrack } from "solid-js";
+import { parseInviteLinkPath, routeInviteTarget } from "./inviteLink";
 import { moduleRoot } from "./moduleRoot";
-import { networkBySlug, networks } from "./networks";
+import { channelsBySlug, networkBySlug, networks } from "./networks";
 import { type PushTarget, parsePushTargetUrl } from "./pushPayload";
 import { canonicalQueryNick, openQueryWindowState } from "./queryWindows";
 import { setSelectedChannel } from "./selection";
@@ -128,7 +129,9 @@ export function installPushTargetListener(): void {
 }
 
 /**
- * Cold-path reader: when the SW opens a fresh window via
+ * THE boot-time deep-link reader — one reader, two URL shapes.
+ *
+ * Cold-path push (UX-6-J): when the SW opens a fresh window via
  * `openWindow(url)`, the URL ships the deep-link params but there's
  * no message-to-listener handshake (the page hasn't installed the
  * listener yet at openWindow time). Read `location.href` at boot,
@@ -153,36 +156,98 @@ export function installPushTargetListener(): void {
  * ergonomics. The selection store's UX-5 BU tuple-equality
  * short-circuit means a re-fire would no-op anyway, but cleaning
  * the URL removes the question entirely.
+ *
+ * Invite link (#793): the second shape, `/<network>/<channel>`, read
+ * from `location.pathname` by `lib/inviteLink.ts` into the SAME
+ * `PushTarget` and deferred by the SAME mechanism. What differs is
+ * only what the target DOES on arrival — a confirm-then-join instead
+ * of a selection — and when the URL is cleaned. The two shapes cannot
+ * co-occur meaningfully; a push payload wins, since it carries an
+ * explicit notification the operator just tapped.
  */
-export function applyPushTargetFromUrl(): void {
+export function applyDeepLinkFromUrl(): void {
   if (typeof window === "undefined" || !window.location) return;
-  const target = parsePushTargetUrl(window.location.href);
-  if (target === null) return;
-  deferUntilNetworksSeed(target);
+
+  const push = parsePushTargetUrl(window.location.href);
+  if (push !== null) {
+    deferUntilReady({
+      target: push,
+      route: routePushTarget,
+      // A push target names a channel the operator is already in, so the
+      // routing needs the live list — an empty store cannot resolve it.
+      ready: () => {
+        const nets = networks();
+        return nets !== undefined && nets.length > 0;
+      },
+      flag: "__cicPushTargetApplied",
+    });
+    return;
+  }
+
+  // #793 — the same reader, second URL shape: `/<network>/<channel>`.
+  const invite = parseInviteLinkPath(window.location.pathname);
+  if (invite === null) return;
+  // Cleaned HERE rather than after the routing (the push path's timing),
+  // because this call happens BEFORE `render()` and the router has no route
+  // for a two-segment path: left in place, the address bar would mount the
+  // app on nothing at all. It also satisfies the same requirement the push
+  // path cleans for — a refresh must not re-fire the invite.
+  if (window.history) window.history.replaceState({}, "", "/");
+  deferUntilReady({
+    target: invite,
+    route: routeInviteTarget,
+    // Waits on the CHANNEL LIST, not on `networks()`, because that is the
+    // source the invite route actually reads to decide whether we are
+    // already in the channel. `channelsBySlug` is keyed on `networks`, so it
+    // resolves strictly LATER — firing on the earlier signal read an
+    // unresolved list, concluded "not in it", and asked for consent to join
+    // a channel the operator was already sitting in (caught by the #793 e2e,
+    // which is why that spec exists).
+    //
+    // RESOLVED, not non-empty: a recipient with nothing bound still gets an
+    // answer (the not-bound notice) instead of silence. Unauthenticated, the
+    // resource never resolves at all, so the invite simply waits out the
+    // login round-trip and applies once the session is up.
+    ready: () => channelsBySlug() !== undefined,
+    flag: "__cicInviteLinkApplied",
+  });
 }
 
 declare global {
   interface Window {
     __cicPushTargetApplied?: boolean;
+    __cicInviteLinkApplied?: boolean;
   }
 }
 
-function deferUntilNetworksSeed(target: PushTarget): void {
+type DeepLink = {
+  target: PushTarget;
+  route: (target: PushTarget) => void;
+  // Reads whatever store the route depends on; the effect tracks it, so each
+  // deep-link shape declares its OWN readiness rather than sharing one that
+  // happens to fit the older caller.
+  ready: () => boolean;
+  flag: "__cicPushTargetApplied" | "__cicInviteLinkApplied";
+};
+
+function deferUntilReady(link: DeepLink): void {
   let applied = false;
   moduleRoot(() => {
-    createEffect(
-      on(networks, (nets) => {
-        if (applied) return;
-        if (!nets || nets.length === 0) return;
-        applied = true;
-        routePushTarget(target);
-        if (typeof window !== "undefined") {
-          window.__cicPushTargetApplied = true;
-          if (window.history && window.location) {
-            window.history.replaceState({}, "", "/");
-          }
+    createEffect(() => {
+      if (applied) return;
+      if (!link.ready()) return;
+      applied = true;
+      // `untrack`: the routing reads several stores, and none of them should
+      // become a dependency of the gate — the one-shot `applied` flag makes a
+      // re-run harmless, but a gate that re-fires on unrelated traffic is a
+      // gate nobody can reason about.
+      untrack(() => link.route(link.target));
+      if (typeof window !== "undefined") {
+        window[link.flag] = true;
+        if (window.history && window.location) {
+          window.history.replaceState({}, "", "/");
         }
-      }),
-    );
+      }
+    });
   });
 }

--- a/cicchetto/src/main.tsx
+++ b/cicchetto/src/main.tsx
@@ -29,7 +29,7 @@ import { installGlobalPaste } from "./lib/globalPaste";
 import { installKeyboardPreserve } from "./lib/keepKeyboard";
 import { applyIosClass, isStandalonePwa } from "./lib/platform";
 import { installPushResubscribe } from "./lib/pushResubscribe";
-import { applyPushTargetFromUrl, installPushTargetListener } from "./lib/pushTarget";
+import { applyDeepLinkFromUrl, installPushTargetListener } from "./lib/pushTarget";
 import { browserProbePerformance, installResumeProbe } from "./lib/resumeProbe";
 import { applySidebarWidthsFromStorage } from "./lib/sidebarWidths";
 import { notifyClientClosing, reportVisibility } from "./lib/socket";
@@ -183,11 +183,17 @@ bootstrapAuth();
 // from its `notificationclick` handler; this listener parses the URL
 // and routes `setSelectedChannel`. Cold-path: when SW opens a fresh
 // window via `openWindow(url)`, the URL carries the deep-link params;
-// `applyPushTargetFromUrl` reads them at boot and defers selection
+// `applyDeepLinkFromUrl` reads them at boot and defers selection
 // until `networks()` seeds. Pre-J, the SW's `existing.navigate(url)`
 // reloaded the SPA at `/` and dropped the deep-link entirely.
+//
+// #793 — the same boot reader also consumes an invite link
+// (`/<network>/<channel>`), which is why it is no longer named after
+// push alone. It MUST stay above `render()`: the invite path is not a
+// route, so the reader rewrites the address bar to `/` before the
+// router ever looks at it.
 installPushTargetListener();
-applyPushTargetFromUrl();
+applyDeepLinkFromUrl();
 
 // #181 — auto-renew a dropped push subscription on the SW-update /
 // app-resume seams. iOS silently drops `pushManager.getSubscription()`

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -31195,3 +31195,70 @@ tags. And the dry-run paragraph keeps its mechanism — validating the shipping
 job pre-merge is still right — it just loses the false premise that the job is
 unproven; the reason to run it is now "you changed the Dockerfile or the job",
 not "it has never run".
+## 2026-08-06 — #793: an invite link is a second door into the deep-link reader
+
+`irc.sindro.me/azzurra/sniffo` — paste it to a normal person, they click, they
+are asked, they land in the channel. The machinery for that already existed
+twice over, so the shipment is mostly about NOT building it a third time.
+
+**Two of the issue's five open decisions were already answered by the code.**
+Decision 4 (an index.html fallback so the SPA can be served on a two-segment
+path) has been true since #399: `SpaController`'s `GET /*path` catch-all serves
+the shell for any browser navigation that matched no static file and no API
+route, and since #485 every nginx substrate is a dumb `location / → BEAM`
+proxy, so there is no allowlist to extend either. Nothing server-side was
+written for this feature. And the issue's pointer to the join path —
+`slashCommands.ts` `{kind:"join"}` via `compose.ts` — was aimed one verb short:
+`channelJoin.ts`'s `confirmJoinChannel` (#648) already IS confirm → `postJoin`
+→ switch, including the already-in-the-channel case that switches with no
+modal. The invite route delegates to it and adds nothing.
+
+**What was genuinely new is the reader.** `pushTarget.ts` read
+`location.search` only. It now reads both shapes and dispatches:
+`?network=&channel=` routes a selection as before, `/<network>/<channel>`
+normalises into the SAME `PushTarget` and routes a join. One boot reader, one
+defer-until-`networks()`-seeds, two routes — hence the rename to
+`applyDeepLinkFromUrl`. The two gates differ on purpose: a push target must
+resolve against a non-empty list, while an invite fires as soon as the resource
+RESOLVES, so a recipient with nothing bound gets an answer instead of silence.
+
+**The URL is cleaned before `render()`, not after routing.** The push path
+cleans once the selection lands; the invite cannot wait that long, because the
+router has no route for a two-segment path and would mount the app on nothing
+at all. Cleaning early also satisfies the requirement the push path cleans for
+— a refresh must not re-fire the invite — and it is why no new `<Route>` was
+added. The pending invite then survives the login round-trip in memory: cic's
+login is a client-side navigate, and `networks()` cannot resolve before the
+session is up, so the existing defer IS the auth round-trip handling. A hard
+refresh while sitting on `/login` does lose it; that corner was accepted rather
+than given a sessionStorage store of its own.
+
+**Encoding (decision 2) is where the bytes matter.** A literal `#` is a
+fragment delimiter and never reaches the server, so the shareable spelling is
+bare (`/azzurra/sniffo`) and the parser implies the sigil; `%23` is accepted
+and not doubled; `& + !` pass through. The segment is percent-decoded once,
+and a channel name carrying anything at or below 0x20, a comma, or DEL is
+REJECTED rather than escaped. The comma is the load-bearing one: JOIN takes a
+comma-separated LIST, so an unfiltered `/azzurra/a,b` would turn one invite
+into a two-channel join nobody wrote. `/share/:token` is reserved — it is the
+only other two-segment client route, and without the exclusion a visitor share
+link would parse as an invite to a network called `share`.
+
+**Keyed channels (decision 3) stay out of scope**, as the issue defaults: a key
+in a path lands in history, logs and referrers.
+
+**Decision 1 was NOT settled here.** `networkBySlug` resolves against this
+user's bound networks and an invite is cross-user by definition, so the
+recipient may not have `azzurra` at all. Whether the segment becomes a globally
+resolvable identifier or the flow grows an "add this network, then join" step
+is a product call that has not been taken. The branch therefore joins nothing
+and says so, in one toast naming the network — a visible dead end, because the
+silent one is indistinguishable from a broken link.
+
+**The already-in check reads the channel LIST, not the window states.** That is
+the one place the invite deliberately diverges from `confirmJoinChannel`'s own
+source: an invite fires at BOOT, and `windowStateByChannel` is filled later,
+per channel, off the per-channel WS join replies that `channelsBySlug` itself
+drives. Asking the live projection at boot would race it and pop a modal for a
+channel the operator is already sitting in. Same fact, read from the source
+that is ready at the moment the question is asked.


### PR DESCRIPTION
Read side of #793: `irc.sindro.me/azzurra/sniffo` opens the app, asks, and joins.

## What it is

A second URL shape for the deep-link reader that already existed, not a second
subsystem. `pushTarget.ts` normalised `?network=&channel=` into a `PushTarget`
and deferred routing until the store it reads resolves; the invite path
normalises into the SAME `PushTarget`, uses the SAME reader and defer, and
hands the target to `channelJoin.ts`'s #648 verb `confirmJoinChannel` — which
already owns confirm → `postJoin` → switch, and already switches with no modal
when we are in the channel. No new socket call, no second confirm, no parallel
window state. `applyPushTargetFromUrl` is renamed `applyDeepLinkFromUrl`
because it is no longer about push alone.

## Two of the issue's premises were stale

- **Decision 4 (server-side routing) needed no work.** The SPA fallback for a
  two-segment path has existed since #399 (`SpaController`'s `GET /*path`), and
  since #485 every nginx substrate is a dumb `location / → BEAM` proxy with no
  allowlist to extend. Nothing server-side is touched in this PR.
- **The join path the issue points at is one verb short.** It names
  `slashCommands.ts` `{kind:"join"}` via `compose.ts`; the verb that actually
  matches — confirm, join, switch, and the already-in exception — is
  `confirmJoinChannel`.

## Decisions taken (2, 3) and not taken (1, 5)

- **Encoding.** A literal `#` is a fragment delimiter and never reaches the
  server, so the shareable spelling is bare and the parser implies the sigil;
  `%23` is accepted and not doubled, `& + !` pass through. A channel segment
  carrying a comma is REJECTED rather than escaped — JOIN takes a
  comma-separated list, so `/azzurra/a,b` would otherwise turn one invite into
  a two-channel join nobody wrote. Same for anything at or below 0x20 and DEL.
  `/share` is reserved: it is the only other two-segment client route.
- **Keyed channels stay out of scope**, as the issue defaults.
- **Decision 1 (cross-user network identity) is NOT settled here.** An invite
  naming a network this account has not bound joins nothing and says so in one
  toast — a visible dead end, because a silent one is indistinguishable from a
  broken link. Whether the segment becomes a globally resolvable identifier, or
  the flow grows "add this network, then join", is still open.
- **Decision 5:** read side only. No "copy invite link" affordance here.

## Two things worth review attention

- **The URL is cleaned BEFORE `render()`**, not after the routing lands (the
  push path's timing). The router has no route for a two-segment path, so
  leaving it in place mounts the app on nothing at all. Cleaning early still
  satisfies what the push path cleans for: a refresh must not re-fire the
  invite. The pending target survives the login round-trip on its own, since
  cic's login is a client-side navigate and the channel list cannot resolve
  before the session is up.
- **The invite waits on the CHANNEL LIST, not on `networks()`.** That is the
  source its already-in check reads, and `channelsBySlug` is keyed on
  `networks`, so it resolves strictly later. Gating on the earlier signal read
  an unresolved list, concluded "not in it", and asked for consent to join a
  channel the operator was already sitting in.

## Verification

- vitest: 4467/4467 on the rebased tree (16 new in `inviteLink.test.ts`).
- `bun run check` (biome + `tsc --noEmit`): rc=0.
- e2e chromium `--grep "#793"`: 3/3 — link → confirm → in the channel with the
  address bar clean; already-in → switch with no modal; unbound network → the
  notice, and no modal.
- The already-in gate is proven by MUTATION, not asserted: reverting it to the
  `networks()` gate (build kept compiling) turns that spec red, and restoring
  it turns it green.

## What is NOT claimed

- The unauthenticated → login → invite-applies round trip is covered by the
  deferral logic and unit tests, not by an e2e: a spec that fires a real login
  mints a live session on the shared testnet and cascade-poisons downstream
  specs.
- A hard refresh while sitting on `/login` with a pending invite loses it — the
  target lives in memory, and that corner was accepted rather than given a
  sessionStorage store of its own.
- Only chromium was run locally; the full integration suite is CI's call.