### PR TITLE
docs(#503): retire two claims that a thing had never run

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -31152,3 +31152,46 @@ quota ceiling nobody has hit would be speculation.
 every keystroke and every acked line of a #666 paced drain. For drafts of human
 size that is noise, and no debounce was added on a guess; a pathological paste
 was not benchmarked.
+
+## 2026-08-06 — #503 scope 5: the doc outlived the fact it was documenting
+
+Scope item 5 of #503 (publish the self-contained release image to ghcr) was
+picked up as new work. It was not new: `Dockerfile.release`, the `docker` job in
+`release.yml`, the multi-arch ruling and the pull-path docs all landed
+2026-07-31, and the surrounding scope items landed either side of it. Nothing
+was built here. What WAS wrong was the record: two paragraphs in
+`docs/OPERATIONS.md` still asserted a world that had since ended.
+
+**The failure class is not "stale docs", it is a claim about the ABSENCE of
+evidence.** Both sentences were true the minute they were written and became
+false without anyone touching them: *"`release.yml` has had ZERO runs"* and
+*"the `docker` release job is tag-driven with zero prior real runs and ghcr
+carries no grappa image yet"*. A statement of the form "this has never run" has
+an expiry date baked in, and unlike a wrong API name nothing fails when it
+rots — no test, no compile, no gate. It just quietly redirects the next reader
+to validate something that has been validated four times. The general rule: when
+a doc records that a thing is UNVERIFIED, it must name what would change the
+verdict, because someone will eventually do it and will not think to come back.
+
+**Measured, not reasoned.** The `docker` job has run on four real tag pushes
+(`v0.9.0`, `v0.10.0`, `v0.11.0`, `v0.12.0`), green on each. `ghcr.io/vjt/grappa`
+answers an ANONYMOUS pull token, so the package is public; `:latest`,
+`:v0.12.0`, `:v0.11.0`, `:v0.10.0` all resolve, `:latest` serves the same
+manifest as `:v0.12.0`, and the manifest is a genuine multi-arch OCI index
+(`linux/amd64` + `linux/arm64`). Reading the config blob of the published arm64
+manifest: `org.opencontainers.image.revision` is exactly the `v0.12.0` commit
+and `version` is `0.12.0`. Then the two verbs the doc itself nominated, against
+the real tag rather than a local build —
+`GRAPPA_TEST_IMAGE=ghcr.io/vjt/grappa:v0.12.0 scripts/release-image.sh
+fresh-boot`, then `warm-boot` — both reached `/healthz` 200, and `/api/config`
+on the running container reported `"version":"0.12.0"`. That last one is the
+check with teeth: the image takes the #391 no-git bare-version path, so tag and
+running code agreeing is a property of the build, not a tautology.
+
+**Not measured, and the replacement text says so.** The host is arm64, so only
+the `linux/arm64` leg was ever booted; the QEMU-built `amd64` leg is proven to
+build and to publish, never to run. `update` was not driven across two published
+tags. And the dry-run paragraph keeps its mechanism — validating the shipping
+job pre-merge is still right — it just loses the false premise that the job is
+unproven; the reason to run it is now "you changed the Dockerfile or the job",
+not "it has never run".

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -602,9 +602,11 @@ D** — see **Running the published image** below.
 - **Version.** The image reports the BARE `X.Y.Z` (no `.git` in the build
   context → the `#391` no-git path, like the AUR tarball). `docker inspect`
   shows the image tag; the RUNNING app is the version source of truth.
-- **VALIDATE BEFORE A REAL TAG — the zero-publication dry-run.** `release.yml`
-  has had ZERO runs, so validate the `docker` job (the SAME job that ships, not a
-  copy) BEFORE trusting it on a real tag, via the `docker_validation` dispatch:
+- **VALIDATE BEFORE A REAL TAG — the zero-publication dry-run.** A tag push is
+  the only thing that publishes, so a broken `docker` job is discovered with the
+  tag already cut and `:latest` possibly moved. Validate the job (the SAME one
+  that ships, not a copy) BEFORE a real tag whenever `Dockerfile.release`, the
+  job, or the release toolchain changes — via the `docker_validation` dispatch:
 
   ```sh
   # runs from ANY branch, so it works BEFORE merge; publishes NOTHING
@@ -735,14 +737,25 @@ curl -fsSL https://raw.githubusercontent.com/vjt/grappa-irc/main/infra/docker/ge
   its own CSP + security headers (#485) — put your TLS front door in front as a
   dumb reverse proxy, exactly as the from-source path.
 
-> **Verification of the PUBLISHED image is pending the first `vX.Y.Z` tag.** The
-> `docker` release job is tag-driven with zero prior real runs and ghcr carries
-> no grappa image yet. The bare-run one-liner IS now measured end to end, but
-> against a **locally built** image: `scripts/release-image.sh build` then
-> `fresh-boot` / `warm-boot` (#867) — that is the reproduction, use it. What
-> remains unverified is the published artifact and the job that pushes it, so
-> run the same two verbs against the real tag once one has cut, with
-> `GRAPPA_TEST_IMAGE=ghcr.io/vjt/grappa:vX.Y.Z`.
+> **The PUBLISHED image is verified — measured 2026-08-06 against
+> `ghcr.io/vjt/grappa:v0.12.0`.** The `docker` job has now run on four real tag
+> pushes (`v0.9.0`, `v0.10.0`, `v0.11.0`, `v0.12.0`) and was green on every one.
+> `:latest`, `:v0.12.0`, `:v0.11.0` and `:v0.10.0` all resolve to an ANONYMOUS
+> pull (the package is public), `:latest` serves the same manifest as
+> `:v0.12.0`, and it is a real multi-arch OCI index — `linux/amd64` +
+> `linux/arm64`. On the published artifact the OCI `revision` label equals the
+> `v0.12.0` commit and `version` equals `0.12.0`. Reproduce with the same two
+> verbs the local build uses:
+> `GRAPPA_TEST_IMAGE=ghcr.io/vjt/grappa:v0.12.0 scripts/release-image.sh
+> fresh-boot`, then `warm-boot` — both answered `/healthz` 200, and the running
+> app reported `"version":"0.12.0"` on `/api/config`, so the tag and the code it
+> runs agree (the check that matters, since the image reports the bare no-git
+> version).
+>
+> **Still NOT measured**, so do not read the above as more than it says: the
+> boot ran on an arm64 host, so only the **`linux/arm64`** leg has been
+> executed — the QEMU-built `amd64` leg is proven to BUILD and to publish, never
+> to boot. And `update` has not been driven across two published tags.
 
 ### AWS one-click box (CloudFormation) — #665
 


### PR DESCRIPTION
## What this is, and what it is NOT

This was picked up as **#503 scope item 5** — publish the self-contained release image to ghcr. **There was nothing to build.** Item 5 landed on **2026-07-31** (`aef38f33`, `7cbefd25`, `492558e9`, `abe1c53d`, `c2ff4c68`) and every other scope item landed either side of it. The issue body describes `main` as it was on **2026-07-27**, three days before the work started; it was never refreshed.

So this PR carries **zero code**. It fixes the only thing that was actually wrong: the record.

## The defect

Two passages in `docs/OPERATIONS.md` still asserted a world that had ended:

- `release.yml` **"has had ZERO runs"** (line 606)
- *"the `docker` release job is tag-driven with zero prior real runs and **ghcr carries no grappa image yet**… verification of the PUBLISHED image is pending the first `vX.Y.Z` tag"* (the blockquote at 738)

Both were true the minute they were written. **The class of failure is a claim about the ABSENCE of evidence** — it has an expiry date baked in, and unlike a wrong function name nothing fails when it rots. No test, no compile, no gate. It quietly sends the next reader off to validate something already validated four times.

## Measured, not reasoned

- The `docker` job has run on **four real tag pushes** — `v0.9.0`, `v0.10.0`, `v0.11.0`, `v0.12.0` — **green on every one**.
- `ghcr.io/vjt/grappa` answers an **anonymous** pull token, so the package is public. `:latest`, `:v0.12.0`, `:v0.11.0`, `:v0.10.0` all resolve; `:latest` serves the **same manifest** as `:v0.12.0`; the manifest is a genuine multi-arch **OCI index (`linux/amd64` + `linux/arm64`)`.
- Read from the **published** arm64 config blob (not from the yml): `org.opencontainers.image.revision` = `c57d4dab…`, which is exactly `git rev-parse v0.12.0^{commit}`; `version` = `0.12.0`.
- Then the two verbs the doc itself nominated, against the **real tag** instead of a local build:
  `GRAPPA_TEST_IMAGE=ghcr.io/vjt/grappa:v0.12.0 scripts/release-image.sh fresh-boot`, then `warm-boot` — both reached **`/healthz` 200**, and `/api/config` on the running container reported `"version":"0.12.0"`.

That last one is the check with teeth: the image takes the #391 **no-git bare-version** path, so tag and running code agreeing is a property of the build, not a tautology.

## What I REFUSE to claim

- **The `linux/amd64` leg was never booted.** The measurement ran on an arm64 host. The QEMU-built amd64 leg is proven to *build* and to *publish* — never to *run*. The replacement text says so.
- **`update` was not driven across two published tags.**
- I did not verify the ghcr package's visibility *setting*; I observed that an anonymous token pulls it, which is the operator-visible consequence, not the setting.
- The `v0.10.0`/`v0.9.0` greens are read from the CI job conclusion, not from a boot of those tags.

## Scope items that remain on #503 — issue stays OPEN, no `Closes`

All seven scope items are on `main`. The genuine residue is **unit E — hot-on-image update**, consistently labelled as deferred (not rejected) across `infra/docker/deploy.sh`, `infra/docker/get.sh` and the docs: image updates are **always cold** today. The issue's "if the two consequences cost more than they buy, report it as a finding" clause therefore has **nothing owed against it** — hot-on-image was postponed, not declined, so there is no silent drift to report.

The dry-run paragraph **keeps its mechanism** — validating the shipping job pre-merge is still right. It only loses the false premise: the reason to run it is now *"you changed the `Dockerfile` or the job"*, not *"it has never run"*.

## Gates

`scripts/check.sh` **rc=0**, every stage verified from the log: credo `found no issues` · sobelow `No vulnerabilities found` · ExUnit `8 doctests, 54 properties, 5304 tests, 0 failures` · dialyzer `Total errors: 0 … passed successfully` · `Doctor validation has passed!` · `wireTypes.ts is in sync` · bats **331 ok / 0 not-ok**. Working tree clean before and after. No cic file touched; docs-only diff.