### PR TITLE
chore(#149): the hex.audit derogation now describes the four advisories it covers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,13 +81,21 @@ jobs:
         run: mix sobelow --config --exit Medium
 
       - name: Hex audit (CVE check)
-        # Advisory-only (non-blocking): cowlib has two UNFIXABLE cow_cookie
-        # advisories (CVE-2026-43969 LOW + CVE-2026-43966 MED, fixed=None,
-        # no patched release) that are N/A to grappa (we only consume Cookie
-        # headers via Plug, never compose request cookies via cow_cookie).
-        # hex.audit has no per-advisory ignore, so it can't express that.
-        # `mix deps.audit` below remains the HARD, blocking CVE gate.
-        # Restore this to blocking when cowlib ships a patch — see #149.
+        # Advisory-only (non-blocking). FOUR advisories sit under this
+        # derogation today, not the two it was written for: cowlib 2.18.0
+        # carries CVE-2026-43966 (response splitting in
+        # cow_http_struct_hd:escape_string/2) and CVE-2026-43969
+        # (cow_cookie:cookie/1 injection), neither of which has a fixed
+        # release at ANY version, plus CVE-2026-59248 (HPACK/QPACK
+        # memory-exhaustion DoS, AV:N VA:H, fixed in 2.19.0); cowboy 2.17.0
+        # carries CVE-2026-65624 (max_headers bypass, fixed in 2.18.0).
+        # It holds because cowboy/cowlib enter ONLY via `bypass`
+        # (`only: :test`) — prod serves on Bandit and ships neither — NOT
+        # because of the severities, and NOT because of the cookie-composition
+        # argument, which never covered 43966. hex.audit has no per-advisory
+        # ignore, so it cannot express that. `mix deps.audit` below remains the
+        # HARD, blocking CVE gate. Full reasoning + what makes this fall: the
+        # `ci.check` alias in mix.exs, and #149.
         continue-on-error: true
         run: mix hex.audit
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -707,8 +707,14 @@ is due. Don't just look at todo.md.
   `docs/OPERATIONS.md`.
 - **Sobelow is a CI gate** — Medium-or-above findings fail the build.
   Every Phoenix app gets it.
-- **`mix deps.audit` + `mix hex.audit` are CI gates.** CVE-flagged
-  deps fail the build immediately.
+- **`mix deps.audit` is the hard CI gate.** CVE-flagged deps fail the
+  build immediately. **`mix hex.audit` is advisory-only** since #147 and
+  must not be read as a gate: cowboy/cowlib carry advisories with no
+  fixed release at any version, and hex.audit has no per-advisory ignore
+  to express that they are unreachable (both enter ONLY via `bypass`,
+  `only: :test`; prod serves on Bandit and ships neither). The full
+  advisory list, the reachability argument, and what would restore the
+  gate live on the `ci.check` alias in `mix.exs` — see #149.
 
 ## Docs map
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -31195,3 +31195,48 @@ tags. And the dry-run paragraph keeps its mechanism — validating the shipping
 job pre-merge is still right — it just loses the false premise that the job is
 unproven; the reason to run it is now "you changed the Dockerfile or the job",
 not "it has never run".
+## 2026-08-06 — #149: the derogation grew from two advisories to four, unread
+
+`mix hex.audit` was demoted to advisory-only in #147 for two cowlib advisories
+that no version fixes. Two more have landed under it since — one of them a
+network-reachable availability-HIGH — and nobody re-read the note. The measured
+state, from OSV rather than from the note:
+
+- **cowlib 2.18.0** carries THREE. `CVE-2026-43966` (response splitting in
+  `cow_http_struct_hd:escape_string/2`) and `CVE-2026-43969`
+  (`cow_cookie:cookie/1` injection) have **no fixed release at any version** —
+  2.19.0 is explicitly enumerated as affected. `CVE-2026-59248` (unbounded
+  HPACK/QPACK integer decode → memory exhaustion, AV:N VA:H) **is fixed in
+  2.19.0**.
+- **cowboy 2.17.0** carries `CVE-2026-65624` (max_headers bypass via duplicate
+  header names), **fixed in 2.18.0**.
+
+**So the issue's question has a number: no bump closes all four.** A bump to
+cowlib 2.19.0 + cowboy 2.18.0 closes exactly two, and the two survivors are the
+ones that keep hex.audit red. The hard gate cannot be restored, and #149 stays
+open. That is why this change is a comment and not a lock file.
+
+**The justification was also wrong, not just stale.** #147 recorded both
+unfixable advisories as `cow_cookie:cookie/1` request-cookie *composition*
+issues, N/A because grappa only consumes Cookie headers via Plug. 43966 is a
+response-header path in `cow_http_struct_hd`, so that argument never covered
+it. The honest one is narrower and stronger: **cowboy and cowlib enter the tree
+ONLY through `bypass` (`only: :test`, via plug_cowboy)**, prod serves on Bandit,
+and the release is built at `MIX_ENV=prod` — so none of the four is present in
+a deployed grappa at all. Reachability, not severity, is what holds the
+derogation up, and that is what makes it falsifiable: it dies the moment
+cowboy/cowlib become a runtime dep or grappa moves off Bandit, independently of
+whether anything gets patched.
+
+**One list, three readers.** The derogation was described in three places —
+the `ci.check` alias, the ci.yml step, and CLAUDE.md's security section, which
+still called `mix hex.audit` a blocking gate two months after it stopped being
+one. The full advisory list now lives ONCE, on the alias in `mix.exs`; the other
+two state the posture and point at it. Three copies of a list is how this drifted
+in the first place.
+
+**Declined, and why:** taking the two available fixes is a `mix.lock` change,
+which the deploy preflight reads as COLD — for packages that are not in the
+prod release, so the COLD buys no production security. Worth folding into the
+next COLD-forcing change rather than shipping alone. `mix deps.audit` remains
+the hard CVE gate throughout and is untouched.

--- a/mix.exs
+++ b/mix.exs
@@ -298,11 +298,41 @@ defmodule Grappa.MixProject do
         "cmd mix format --check-formatted",
         "cmd mix credo --strict",
         "cmd mix deps.audit",
-        # hex.audit is advisory-only (non-fatal): cowlib has two UNFIXABLE
-        # cow_cookie advisories (CVE-2026-43969 LOW + CVE-2026-43966 MED,
-        # fixed=None) that are N/A to grappa and that hex.audit can't ignore
-        # per-advisory. deps.audit above stays the hard CVE gate. Mirrors the
-        # `continue-on-error` on the CI step. Restore to fatal on cowlib patch — #149.
+        # hex.audit is advisory-only (non-fatal). FOUR advisories sit under
+        # this derogation today (OSV, 2026-08-06), not the two it was written
+        # for — it was never re-read as new ones landed:
+        #
+        #   cowlib 2.18.0
+        #     CVE-2026-43966  response splitting via non-VCHAR bytes in
+        #                     cow_http_struct_hd:escape_string/2 (CWE-113,
+        #                     SI:L) — NO fixed release
+        #     CVE-2026-43969  request-cookie injection in cow_cookie:cookie/1
+        #                     (CWE-93, AV:L) — NO fixed release
+        #     CVE-2026-59248  unbounded HPACK/QPACK prefixed-integer decode,
+        #                     memory-exhaustion DoS (CWE-770, AV:N VA:H)
+        #                     — FIXED in cowlib 2.19.0, not taken (#149)
+        #   cowboy 2.17.0
+        #     CVE-2026-65624  max_headers bypass via duplicate header names,
+        #                     memory exhaustion (CWE-770, AV:N VA:L)
+        #                     — FIXED in cowboy 2.18.0, not taken (#149)
+        #
+        # WHY THE DEROGATION HOLDS, and it is not the severities: cowboy and
+        # cowlib enter the tree ONLY through `bypass` (`only: :test`, via
+        # plug_cowboy). Production serves on Bandit, and a prod release built
+        # at MIX_ENV=prod contains neither — so none of the four is reachable
+        # by a deployed grappa. The pre-existing note claimed both unfixable
+        # advisories were cow_cookie COMPOSITION issues; 43966 is a response-
+        # header path, so "we never compose request cookies" never covered it.
+        # Reachability does.
+        #
+        # WHAT MAKES IT FALL: (a) cowlib shipping a release that fixes 43966 +
+        # 43969 — every version >= 2.9.0 is affected today, 2.19.0 included,
+        # so no bump can close them and hex.audit has no per-advisory ignore
+        # to express the N/A; (b) cowboy/cowlib becoming reachable at runtime
+        # (a non-test dep, or a move off Bandit), which voids the whole
+        # argument regardless of what is fixed. Either one, and the `|| true`
+        # goes — that is #149. deps.audit above stays the hard CVE gate, and
+        # this mirrors `continue-on-error` on the CI step.
         "cmd sh -c 'mix hex.audit || true'",
         "cmd mix sobelow --config --exit Medium",
         "cmd mix doctor",


### PR DESCRIPTION
#149 asks to restore `mix hex.audit` as a blocking gate "when cowlib ships a
patch". This measures whether that is possible yet. It is not — and while
measuring, the derogation turned out to be covering twice what it says.

## The question, answered with numbers (OSV, 2026-08-06)

| advisory | package | what it is | fixed in |
|---|---|---|---|
| CVE-2026-43966 | cowlib 2.18.0 | response splitting via non-VCHAR bytes in `cow_http_struct_hd:escape_string/2` (CWE-113, SI:L) | **nothing** — 2.19.0 enumerated as affected |
| CVE-2026-43969 | cowlib 2.18.0 | request-cookie injection in `cow_cookie:cookie/1` (CWE-93, AV:L) | **nothing** — 2.19.0 enumerated as affected |
| CVE-2026-59248 | cowlib 2.18.0 | unbounded HPACK/QPACK prefixed-integer decode → memory exhaustion (CWE-770, **AV:N VA:H**) | cowlib 2.19.0 |
| CVE-2026-65624 | cowboy 2.17.0 | `max_headers` bypass via duplicate header names → memory exhaustion (CWE-770, AV:N VA:L) | cowboy 2.18.0 |

**No bump closes all four.** cowlib 2.19.0 + cowboy 2.18.0 (both released)
would close the bottom two; the top two have no fixed release at any version,
so `hex.audit` stays red and the hard gate cannot be restored. **#149 stays
open** — this is a comment change, not a lock file.

## What was wrong, beyond being out of date

- **Count.** The note describes TWO advisories. Four are live under the
  derogation; the two newest arrived after it was written and nobody re-read it.
- **Identity.** It records both unfixable ones as `cow_cookie:cookie/1`
  request-cookie *composition* issues, N/A because grappa only consumes Cookie
  headers. **43966 is a response-header path** in `cow_http_struct_hd` — that
  argument never covered it.
- **Where it lives.** The derogation was stated in three places, and CLAUDE.md's
  security section still called `mix hex.audit` a blocking gate, two months
  after #147 demoted it.

## What this changes

The justification moves from "N/A by argument" to **unreachable by build env**:
cowboy and cowlib enter the tree ONLY through `bypass` (`only: :test`, via
plug_cowboy), production serves on Bandit, and the release is built at
`MIX_ENV=prod` — so none of the four is present in a deployed grappa. That is
narrower, verifiable, and *falsifiable*: it dies if either package becomes a
runtime dep or grappa moves off Bandit, whatever gets patched. The comment says
so explicitly.

The full list now lives ONCE, on the `ci.check` alias in `mix.exs`; the ci.yml
step and CLAUDE.md state the posture and point at it.

`mix deps.audit` remains the hard, blocking CVE gate — untouched.

## Decision surfaced, not taken: the two available fixes

Bumping cowlib → 2.19.0 and cowboy → 2.18.0 closes 59248 + 65624. It is a
`mix.lock` change, which the deploy preflight reads as **COLD** — for packages
that are not in the prod release, so the COLD buys no production security.
Recommendation: fold it into the next COLD-forcing change rather than ship it
alone. Say the word and it becomes a second commit here.

## What is NOT claimed

- **No gate was run.** This branch touches `mix.exs`, and the COMPILE lane is
  held by another worker, so `mix format --check-formatted`, `mix hex.audit`
  and `mix deps.audit` were NOT executed against it. The change is comment-only
  (consistent 8-space indentation inside the existing alias list) plus YAML and
  Markdown comments, but CI is the first thing that will actually compile it.
- The advisory set comes from OSV, not from `mix hex.audit` stdout — I could not
  run the tool. The two sources agreeing on FOUR is a reported observation, not
  something I verified myself.
- `api.osv.dev`'s by-version query returns zero vulns for cowlib 2.19.0, which
  contradicts the advisories' own `affected.versions` lists (2.19.0 is in both).
  I trusted the advisory records, not the query endpoint — worth knowing before
  anyone re-measures with a one-line curl.
- `docs/TESTING.md` documents a local `mix deps.audit --ignore-advisory-ids
  GHSA-g2wm-735q-3f56` while CI runs `deps.audit` bare and is green. I did not
  reconcile that; it needs a run.