### PR TITLE
cic(#943): append the rejected field to the admin users error banner

### DIFF
--- a/cicchetto/src/AdminUsersTab.tsx
+++ b/cicchetto/src/AdminUsersTab.tsx
@@ -10,6 +10,7 @@ import {
   adminUpdateUserPassword,
 } from "./lib/api";
 import { token } from "./lib/auth";
+import { operatorApiError } from "./lib/friendlyApiError";
 
 // Admin-panel bucket 5 — Users admin tab.
 //
@@ -40,6 +41,14 @@ import { token } from "./lib/auth";
 // Per CLAUDE.md "No localized strings server-side": error tokens come
 // from the server as snake_case strings ("last_admin",
 // "validation_failed"); cic owns human-readable rendering.
+//
+// #943 — the banner shows the RAW wire token, on purpose: operator-console
+// policy (AdminSettingsTab lines 33-35). The three verbs whose controller
+// `@spec` admits an `Ecto.Changeset.t()` (create / toggle admin / rotate
+// password) additionally append the 422's per-field detail via
+// `operatorApiError`, because the token alone never says which field is
+// wrong. `delete` and the list GET cannot produce a changeset, so they keep
+// the plain `err.code` narrowing.
 
 type CreateForm = {
   name: string;
@@ -101,8 +110,7 @@ const AdminUsersTab: Component = () => {
       setCreateForm({ ...EMPTY_CREATE });
       await refresh();
     } catch (err) {
-      const code = err instanceof ApiError ? err.code : "create_failed";
-      setError(`create: ${code}`);
+      setError(`create: ${operatorApiError(err, "create_failed")}`);
     } finally {
       setCreating(false);
     }
@@ -116,8 +124,7 @@ const AdminUsersTab: Component = () => {
       await adminUpdateUserAdmin(t, u.id, !u.is_admin);
       await refresh();
     } catch (err) {
-      const code = err instanceof ApiError ? err.code : "request_failed";
-      setError(`toggle admin (${u.name}): ${code}`);
+      setError(`toggle admin (${u.name}): ${operatorApiError(err, "request_failed")}`);
     }
   };
 
@@ -145,8 +152,7 @@ const AdminUsersTab: Component = () => {
       // change but the operator sees confirmation via row-state rerender.
       await refresh();
     } catch (err) {
-      const code = err instanceof ApiError ? err.code : "request_failed";
-      setError(`rotate password (${u.name}): ${code}`);
+      setError(`rotate password (${u.name}): ${operatorApiError(err, "request_failed")}`);
     }
   };
 

--- a/cicchetto/src/__tests__/AdminUsersTab.test.tsx
+++ b/cicchetto/src/__tests__/AdminUsersTab.test.tsx
@@ -236,3 +236,96 @@ describe("AdminUsersTab — delete flow", () => {
     expect(screen.getByTestId("admin-users-error").textContent).toContain("last_admin");
   });
 });
+
+// #943 — the three write verbs whose controller `@spec` admits an
+// `Ecto.Changeset.t()` (create / update / update_password) can answer 422
+// `validation_failed` with per-field detail in `field_errors`. The banner
+// rendered `err.code` alone, so "must start with a letter…" — the only text
+// that says WHAT to type instead — never reached the operator.
+//
+// The raw wire token STAYS: that is written operator-console policy
+// (AdminSettingsTab lines 33-35), not an oversight. The detail is APPENDED.
+// `delete` and the list GET are deliberately absent: neither can produce a
+// changeset (users_controller.ex:53 / :176), so a branch there is dead code.
+describe("AdminUsersTab — 422 field_errors detail (#943)", () => {
+  const NAME_MSG = "must start with a letter, then alphanumeric/_/-";
+
+  const validationError = async (info: Record<string, unknown>) => {
+    // Re-import to dodge the module mock: the component narrows on
+    // `instanceof ApiError`, so the rejection must be the real class.
+    const api = await vi.importActual<typeof import("../lib/api")>("../lib/api");
+    return new api.ApiError(422, "validation_failed", info);
+  };
+
+  const submitCreate = (name: string): void => {
+    fireEvent.input(screen.getByTestId("admin-users-create-name"), { target: { value: name } });
+    fireEvent.input(screen.getByTestId("admin-users-create-password"), {
+      target: { value: "secret-pass-1234" },
+    });
+    fireEvent.click(screen.getByTestId("admin-users-create-submit"));
+  };
+
+  it("create surfaces the wire token AND the offending field", async () => {
+    (adminCreateUser as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+      await validationError({ field_errors: { name: [NAME_MSG] } }),
+    );
+    render(() => <AdminUsersTab />);
+    await waitFor(() => expect(screen.queryByTestId("admin-users-table")).not.toBeNull());
+
+    submitCreate("9bad");
+
+    await waitFor(() => expect(screen.queryByTestId("admin-users-error")).not.toBeNull());
+    const banner = screen.getByTestId("admin-users-error").textContent ?? "";
+    expect(banner).toContain("create: validation_failed");
+    expect(banner).toContain(`name: ${NAME_MSG}`);
+  });
+
+  it("create with no field_errors renders exactly today's bare-token banner", async () => {
+    (adminCreateUser as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+      await validationError({}),
+    );
+    render(() => <AdminUsersTab />);
+    await waitFor(() => expect(screen.queryByTestId("admin-users-table")).not.toBeNull());
+
+    submitCreate("carol");
+
+    await waitFor(() => expect(screen.queryByTestId("admin-users-error")).not.toBeNull());
+    expect(screen.getByTestId("admin-users-error").textContent).toBe(
+      "failed: create: validation_failed — click ↻ refresh to retry",
+    );
+  });
+
+  it("admin toggle surfaces the wire token AND the offending field", async () => {
+    (adminUpdateUserAdmin as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+      await validationError({ field_errors: { is_admin: ["is invalid"] } }),
+    );
+    render(() => <AdminUsersTab />);
+    await waitFor(() => expect(screen.queryByTestId("admin-users-table")).not.toBeNull());
+
+    fireEvent.click(screen.getByTestId(`admin-user-toggle-admin-${ALICE.id}`));
+
+    await waitFor(() => expect(screen.queryByTestId("admin-users-error")).not.toBeNull());
+    const banner = screen.getByTestId("admin-users-error").textContent ?? "";
+    expect(banner).toContain("toggle admin (alice): validation_failed");
+    expect(banner).toContain("is_admin: is invalid");
+  });
+
+  it("password rotation surfaces the wire token AND the offending field", async () => {
+    (adminUpdateUserPassword as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+      await validationError({ field_errors: { password: ["should be at least 8 character(s)"] } }),
+    );
+    render(() => <AdminUsersTab />);
+    await waitFor(() => expect(screen.queryByTestId("admin-users-table")).not.toBeNull());
+
+    fireEvent.click(screen.getByTestId(`admin-user-rotate-password-${ALICE.id}`));
+    fireEvent.input(screen.getByTestId(`admin-user-rotate-input-${ALICE.id}`), {
+      target: { value: "short" },
+    });
+    fireEvent.click(screen.getByTestId(`admin-user-rotate-submit-${ALICE.id}`));
+
+    await waitFor(() => expect(screen.queryByTestId("admin-users-error")).not.toBeNull());
+    const banner = screen.getByTestId("admin-users-error").textContent ?? "";
+    expect(banner).toContain("rotate password (alice): validation_failed");
+    expect(banner).toContain("password: should be at least 8 character(s)");
+  });
+});

--- a/cicchetto/src/__tests__/friendlyApiError.test.ts
+++ b/cicchetto/src/__tests__/friendlyApiError.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { ApiError } from "../lib/api";
-import { friendlyApiError } from "../lib/friendlyApiError";
+import { friendlyApiError, operatorApiError } from "../lib/friendlyApiError";
 
 // U-3 (UD3) — exhaustive matrix over the typed-error wire tokens
 // the server emits via FallbackController. Adding a new arm to
@@ -181,5 +181,48 @@ describe("friendlyApiError", () => {
   it("network_unreachable without retry_after info uses generic copy", () => {
     const err = new ApiError(503, "network_unreachable", {});
     expect(friendlyApiError(err)).toBe("We can't reach the network right now.");
+  });
+});
+
+// #943 — the admin consoles render the raw wire token by policy, so they
+// take this door instead of `friendlyApiError`. Its whole contract is the
+// degradation ladder: detail when the 422 carries it, the bare token when it
+// doesn't, the caller's fallback when there is no wire token at all.
+describe("operatorApiError", () => {
+  it("appends the per-field detail to the wire token", () => {
+    const err = new ApiError(422, "validation_failed", {
+      field_errors: { name: ["must start with a letter"], password: ["is too short"] },
+    });
+    expect(operatorApiError(err, "unused")).toBe(
+      "validation_failed — name: must start with a letter; password: is too short",
+    );
+  });
+
+  it("joins multiple messages for one field", () => {
+    const err = new ApiError(422, "validation_failed", {
+      field_errors: { name: ["is too short", "has invalid format"] },
+    });
+    expect(operatorApiError(err, "unused")).toBe(
+      "validation_failed — name: is too short, has invalid format",
+    );
+  });
+
+  for (const [label, info] of [
+    ["absent", {}],
+    ["null", { field_errors: null }],
+    ["not an object", { field_errors: "name is bad" }],
+    ["empty", { field_errors: {} }],
+    ["all-empty arrays", { field_errors: { name: [] } }],
+  ] as Array<[string, Record<string, unknown>]>) {
+    it(`degrades to the bare token when field_errors is ${label}`, () => {
+      expect(operatorApiError(new ApiError(422, "validation_failed", info), "unused")).toBe(
+        "validation_failed",
+      );
+    });
+  }
+
+  it("returns the caller's fallback for a non-ApiError throw", () => {
+    expect(operatorApiError(new Error("net down"), "create_failed")).toBe("create_failed");
+    expect(operatorApiError("boom", "request_failed")).toBe("request_failed");
   });
 });

--- a/cicchetto/src/lib/friendlyApiError.ts
+++ b/cicchetto/src/lib/friendlyApiError.ts
@@ -76,6 +76,38 @@ export function errorMessage(value: unknown): string {
   return String(value);
 }
 
+// #943 — the per-field walk over the 422 envelope's `field_errors`, lifted
+// out of the `validation_failed` arm below so it has exactly one
+// implementation. Returns `"name: too short; password: is required"` or
+// `null` when the key is absent, not an object, or carries no usable message
+// — callers decide what a `null` degrades to.
+export function fieldErrorSummary(err: ApiError): string | null {
+  const fieldErrors = err.info.field_errors;
+  if (fieldErrors === null || typeof fieldErrors !== "object") return null;
+  const parts: string[] = [];
+  for (const [field, msgs] of Object.entries(fieldErrors as Record<string, unknown>)) {
+    if (Array.isArray(msgs) && msgs.length > 0) parts.push(`${field}: ${msgs.join(", ")}`);
+  }
+  return parts.length > 0 ? parts.join("; ") : null;
+}
+
+// #943 — the ADMIN-CONSOLE counterpart to `errorMessage`, and deliberately
+// its opposite policy: the admin tabs render the raw wire token, because
+// that is what an operator debugging a 422 wants to see (the written rule
+// lives at `AdminSettingsTab.tsx` lines 33-35, and all 8 tabs follow it).
+// The token alone, though, throws away the only text that says WHAT to type
+// instead — the changeset's per-field message. So: token first, detail
+// appended, and a payload without `field_errors` degrades to exactly the
+// bare token rendered before this existed.
+//
+// `fallback` is for the non-`ApiError` throw (network/parse failure), where
+// there is no wire token at all — each call site names its own verb.
+export function operatorApiError(value: unknown, fallback: string): string {
+  if (!(value instanceof ApiError)) return fallback;
+  const detail = fieldErrorSummary(value);
+  return detail === null ? value.code : `${value.code} — ${detail}`;
+}
+
 function friendlyKnown(err: ApiError, code: ErrorTokensRestErrorToken): string {
   switch (code) {
     case "invalid_credentials":
@@ -195,16 +227,8 @@ function friendlyKnown(err: ApiError, code: ErrorTokensRestErrorToken): string {
       // msg" summary so the user sees WHICH field is wrong and
       // WHY without parsing wire tokens; falls back to a generic
       // copy when the shape is degraded.
-      const fieldErrors = err.info.field_errors as Record<string, string[]> | undefined;
-      if (fieldErrors !== undefined && fieldErrors !== null && typeof fieldErrors === "object") {
-        const parts: string[] = [];
-        for (const [field, msgs] of Object.entries(fieldErrors)) {
-          if (Array.isArray(msgs) && msgs.length > 0) {
-            parts.push(`${field}: ${msgs.join(", ")}`);
-          }
-        }
-        if (parts.length > 0) return `Please fix: ${parts.join("; ")}.`;
-      }
+      const summary = fieldErrorSummary(err);
+      if (summary !== null) return `Please fix: ${summary}.`;
       return "The request was invalid. Please check your input.";
     }
     case "cannot_disconnect_self":

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -31460,3 +31460,44 @@ which the deploy preflight reads as COLD — for packages that are not in the
 prod release, so the COLD buys no production security. Worth folding into the
 next COLD-forcing change rather than shipping alone. `mix deps.audit` remains
 the hard CVE gate throughout and is untouched.
+
+## 2026-08-06 — #943: the operator wants the token AND the field, not one of them
+
+**The issue's premise was false and the symptom was real.** #943 asked to route
+five `AdminUsersTab` sites through `friendlyApiError`, on the grounds that the
+other admin tabs already do. They don't: `AdminSettingsTab.tsx` lines 33-35
+refuse it *in writing* ("operator console policy — operators want the wire
+token for debugging"), and a sweep found 39 raw-token sites across 8 admin tabs
+with zero calls into the friendly map. `AdminUsersTab` is the rule, not the
+exception, so "make it consistent" pointed the wrong way.
+
+Two of the five prescribed sites also cannot reach the error class the issue is
+about: `index` is a GET and `delete`'s `@spec` is
+`{:error, :not_found | :last_admin}` (`users_controller.ex:53`, `:176`). Adding
+a `field_errors` branch there would be dead code.
+
+**What was real:** `fallback_controller.ex` answers a bad changeset with
+`%{error: "validation_failed", field_errors: …}`, and `Accounts.User` writes the
+one sentence that says what to type instead — "must start with a letter, then
+alphanumeric/_/-". The banner rendered `err.code` alone, so that sentence never
+arrived. An operator saw `create: validation_failed` and had to guess.
+
+**Resolution — additive, not a swap.** The raw wire token stays (it is policy,
+not an oversight); the per-field detail is appended:
+`create: validation_failed — name: must start with a letter…`. Only the three
+verbs whose controller `@spec` admits an `Ecto.Changeset.t()` — create, toggle
+admin, rotate password — take the new door.
+
+The per-field walk was already written, inline in `friendlyApiError`'s
+`validation_failed` arm. It was lifted out as `fieldErrorSummary` and the arm
+now calls it, so the two surfaces cannot drift into two spellings of the same
+summary. `operatorApiError(value, fallback)` sits beside `errorMessage` as its
+deliberate opposite: same "an `unknown` from a catch block" contract, opposite
+policy — token-first for the operator console, human copy for everyone else.
+A payload without `field_errors` degrades to exactly the bare token rendered
+before this existed, which is what the non-regression test pins.
+
+**Declined:** widening to the other 36 raw-token sites. Every one of them would
+need its own answer to "can this endpoint even produce a changeset?", and
+getting that wrong ships dead branches. That is a separate issue, not a
+drive-by.


### PR DESCRIPTION
Ref #943.

## The issue's premise was false; the symptom was real

#943 asked to route five `AdminUsersTab` sites through `friendlyApiError`,
because "the other admin tabs already do". They don't — `AdminSettingsTab.tsx`
lines 33-35 refuse it *in writing* ("operator console policy — operators want
the wire token for debugging"), and a sweep finds **39 raw-token sites across 8
admin tabs with zero calls** into the friendly map. `AdminUsersTab` is the rule.

Two of the five prescribed sites also can't reach the error class in question:
`index` is a GET, and `delete`'s `@spec` is `{:error, :not_found | :last_admin}`
(`users_controller.ex:53`, `:176`). A `field_errors` branch there is dead code.

What *is* real: `fallback_controller.ex` answers a bad changeset with
`%{error: "validation_failed", field_errors: …}` and `Accounts.User` writes the
one sentence that says what to type instead — "must start with a letter, then
alphanumeric/_/-". The banner rendered `err.code` alone and dropped it.

## What this does — additive, per vjt's ruling

The raw wire token **stays** (policy, not oversight); the per-field detail is
appended: `create: validation_failed — name: must start with a letter…`.

Only the three verbs whose controller `@spec` admits an `Ecto.Changeset.t()`
take the new door: **create**, **toggle admin**, **rotate password**.

The per-field walk already existed, inline in `friendlyApiError`'s
`validation_failed` arm. It's lifted out as `fieldErrorSummary` and the arm now
calls it — one implementation, no drift. `operatorApiError(value, fallback)`
sits beside `errorMessage` as its deliberate opposite: same "an `unknown` out of
a catch" contract, token-first policy for the operator console.

Absent / null / non-object / all-empty `field_errors` degrades to the **bare
token rendered today** — not `""`, not `undefined`.

## Declined

Widening to the other 36 raw-token sites. Each needs its own answer to "can this
endpoint even produce a changeset?", and guessing ships dead branches. Separate
issue, not a drive-by.

## Test plan

- [x] TDD: 3 new component tests RED first (`create: validation_failed — click ↻ refresh to retry` observed, field missing), then green.
- [x] Non-regression test pins the 422-**without**-`field_errors` banner to the byte-identical string it renders today.
- [x] `operatorApiError` unit matrix: every rung of the degradation ladder + the non-`ApiError` fallback.
- [x] `WRITABLE_CIC=1 bun run check` (biome + tsc) — rc=0, tsc confirmed run, 0 `error TS`.
- [x] `bun run test` full suite — rc=0, **243 files / 4486 tests passed**.

cic-only: no lane needed.