### PR TITLE
test-support(#934): make the reset say where its time went

### DIFF
--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -719,12 +719,22 @@ export interface BaselineSeedChannel {
   seedSender?: string;
 }
 
+/**
+ * What one reset actually cost, for #934. `attempts` is how many times
+ * the 433 retry below fired (1 = no retry); `phases` is the server's own
+ * `k=v;k=v` breakdown, forwarded on the 204 as `x-grappa-reset-phases`.
+ */
+export type ResetOutcome = {
+  attempts: number;
+  phases: string;
+};
+
 export async function resetSubject(
   adminToken: string,
   userName: string,
   baselineAutojoin?: Record<string, string[]>,
   baselineSeed?: Record<string, BaselineSeedChannel[]>,
-): Promise<void> {
+): Promise<ResetOutcome> {
   const body: Record<string, unknown> = { user_name: userName };
   if (baselineAutojoin) body.baseline_autojoin = baselineAutojoin;
   if (baselineSeed) {
@@ -762,18 +772,30 @@ export async function resetSubject(
       },
       body: JSON.stringify(body),
     });
-    if (res.status === 204) return;
+    if (res.status === 204) {
+      return {
+        attempts: attempt,
+        phases: res.headers.get("x-grappa-reset-phases") ?? "",
+      };
+    }
 
     const text = await res.text().catch(() => "<no body>");
     const nickStillTaken = res.status === 500 && text.includes("nick_rejected");
     if (!nickStillTaken || attempt === maxAttempts) {
       throw new Error(`resetSubject(${userName}) failed: ${res.status} ${text}`);
     }
+    // #934 — this retry used to be SILENT, and that silence cost a whole
+    // investigation: `nick_rejected` appeared zero times in a full suite
+    // log and the zero proved nothing, because nothing ever wrote one.
+    // A loop that can multiply a 500 ms call by eight has to say so.
+    process.stderr.write(`__RESETRETRY__\t${attempt}\t${userName}\tnick_rejected\n`);
     // Observed 433 → the ghosted nick isn't released yet. Back off (capped)
     // then re-register; each reset attempt also reconnects, which itself
     // gives bahamut time to reap the prior connection's ghost.
     await sleep(Math.min(500 * attempt, 2_000));
   }
+  // Unreachable: the loop either returns on 204 or throws at maxAttempts.
+  throw new Error(`resetSubject(${userName}): retry loop fell through`);
 }
 
 // Overwrite a user's `credential.autojoin_channels` via the admin

--- a/cicchetto/e2e/fixtures/test.ts
+++ b/cicchetto/e2e/fixtures/test.ts
@@ -117,11 +117,19 @@ export const test = base.extend<{
     },
     { auto: true },
   ],
+  // The per-test reset is the single most expensive thing the suite does
+  // (#934: ~10 min of a 32 min run, and 43% of that concentrated in a tail
+  // that no client-side total could attribute). One stderr line per test
+  // makes every run its own dataset: elapsed, how many attempts the 433
+  // retry burned, and the server's own phase breakdown. Unconditional on
+  // purpose — the last two times this was a throwaway local diff, the
+  // evidence was lost before the question got answered.
   _vjtReset: [
-    async ({}, use) => {
+    async ({}, use, testInfo) => {
       await use();
       const admin = getSeededAdmin();
-      await resetSubject(
+      const startedAt = performance.now();
+      const { attempts, phases } = await resetSubject(
         admin.token,
         VJT_USER,
         { [NETWORK_SLUG]: AUTOJOIN_CHANNELS },
@@ -132,6 +140,10 @@ export const test = base.extend<{
             seedSender: "seed-bot",
           })),
         },
+      );
+      const elapsed = Math.round(performance.now() - startedAt);
+      process.stderr.write(
+        `__RESETCOST__\t${elapsed}\t${attempts}\t${phases}\t${testInfo.titlePath.join(" | ")}\n`,
       );
     },
     { auto: true },

--- a/config/config.exs
+++ b/config/config.exs
@@ -539,7 +539,27 @@ config :logger, :console,
     :commands_10s,
     :penalty_10s_s,
     :bank_model_s,
-    :headroom_s
+    :headroom_s,
+    # #934 — `Grappa.TestSupport.SubjectReset`'s per-phase wall-clock. The
+    # e2e reset is the most expensive thing the suite does per test and it
+    # used to be one opaque number; these name every span it can spend time
+    # in, so total minus the parts is the unattributed remainder. `:outcome`
+    # rides both lines (`:ok` or the inspected error) — a failed attempt is
+    # the one that leaves no other trace, and on #934 that was a 433
+    # `nick_rejected`. Test-support only: the module is compile-gated to
+    # :dev/:test and does not exist in a release. Declared here because an
+    # UNDECLARED metadata key is silently dropped by the formatter — the
+    # instrument would compile, run, and print nothing.
+    :outcome,
+    :total_ms,
+    :drain_ms,
+    :baseline_ms,
+    :seed_ms,
+    :respawn_ms,
+    :stop_ms,
+    :spawn_ms,
+    :welcome_ms,
+    :autojoin_ms
   ]
 
 import_config "#{config_env()}.exs"

--- a/lib/grappa/test_support/subject_reset.ex
+++ b/lib/grappa/test_support/subject_reset.ex
@@ -102,6 +102,8 @@ if Mix.env() in [:dev, :test] do
       WSPresence
     }
 
+    require Logger
+
     @reset_timeout_ms 5_000
     @autojoin_timeout_ms 5_000
     @autojoin_poll_interval_ms 50
@@ -115,6 +117,22 @@ if Mix.env() in [:dev, :test] do
     @type reset_opts :: %{
             optional(:baseline_autojoin) => %{String.t() => [String.t()]},
             optional(:baseline_seed) => %{String.t() => [baseline_channel()]}
+          }
+
+    @typedoc """
+    Wall-clock of each span a reset can spend time in, in milliseconds
+    (#934). Exhaustive by construction: `total_ms` minus the four parts
+    is the unattributed remainder, so a slow reset always has somewhere
+    to land. Returned to the caller AND logged, because the two answer
+    different questions — the return value correlates with the client's
+    own total, the log line survives an attempt that never returns one.
+    """
+    @type phases :: %{
+            drain_ms: non_neg_integer(),
+            baseline_ms: non_neg_integer(),
+            seed_ms: non_neg_integer(),
+            respawn_ms: non_neg_integer(),
+            total_ms: non_neg_integer()
           }
 
     @type reset_error ::
@@ -143,7 +161,12 @@ if Mix.env() in [:dev, :test] do
     names rows land cleanly on top of the seed baseline (stable
     post-state: seed_count + ~5 cycle rows per spec).
 
-    Returns `:ok` on success. Returns `{:error, :user_not_found}` if
+    Returns `{:ok, phases}` on success, where `phases` is the
+    per-span wall-clock of this reset (see `t:phases/0`); the
+    controller forwards it on the 204 as `x-grappa-reset-phases` so a
+    Playwright fixture can attribute its own measured total without
+    pairing anything by ordinal — which retries make impossible.
+    Returns `{:error, :user_not_found}` if
     the user_name doesn't exist. Returns `{:error, {:reconnect_timeout,
     network_slug}}` if a `Session.Server` restart didn't reach
     `:session_ready` within #{@reset_timeout_ms}ms. Returns `{:error,
@@ -153,7 +176,7 @@ if Mix.env() in [:dev, :test] do
     `autojoin_channels` entry has not reached `:joined` state within
     #{@autojoin_timeout_ms}ms after `:session_ready`.
     """
-    @spec reset!(String.t(), reset_opts()) :: :ok | {:error, reset_error()}
+    @spec reset!(String.t(), reset_opts()) :: {:ok, phases()} | {:error, reset_error()}
     def reset!(user_name, opts) when is_binary(user_name) and is_map(opts) do
       case Repo.get_by(Accounts.User, name: user_name) do
         nil -> {:error, :user_not_found}
@@ -162,6 +185,46 @@ if Mix.env() in [:dev, :test] do
     end
 
     defp do_reset(user, opts) do
+      started_at = System.monotonic_time(:millisecond)
+      baseline_autojoin = Map.get(opts, :baseline_autojoin, %{})
+      baseline_seed = Map.get(opts, :baseline_seed, %{})
+
+      {drain_ms, :ok} = measure(fn -> drain_surfaces(user) end)
+
+      {baseline_ms, credentials} =
+        measure(fn ->
+          user
+          |> Networks.Credentials.list_credentials_for_user()
+          |> Enum.map(&restore_baseline_channels(&1, baseline_autojoin))
+        end)
+
+      {seed_ms, :ok} = measure(fn -> reset_scrollback(user, credentials, baseline_seed) end)
+      {respawn_ms, outcome} = measure(fn -> respawn_each(user, credentials) end)
+
+      phases = %{
+        drain_ms: drain_ms,
+        baseline_ms: baseline_ms,
+        seed_ms: seed_ms,
+        respawn_ms: respawn_ms,
+        total_ms: System.monotonic_time(:millisecond) - started_at
+      }
+
+      Logger.info(
+        "subject reset",
+        [user: user.name, outcome: outcome_tag(outcome)] ++ Enum.sort(Map.to_list(phases))
+      )
+
+      case outcome do
+        :ok -> {:ok, phases}
+        {:error, _} = err -> err
+      end
+    end
+
+    # Every mutable surface the seed user owns, drained as ONE span so the
+    # phase log can tell DB/ETS cost apart from the scrollback re-seed and
+    # the respawn — the three used to be indistinguishable inside a single
+    # client-observed total.
+    defp drain_surfaces(user) do
       :ok = ReadCursor.clear_all_for_user(user.id)
       :ok = QueryWindows.close_all_for_user(user.id)
       :ok = Push.subscription_clear_all_for_user(user.id)
@@ -175,19 +238,16 @@ if Mix.env() in [:dev, :test] do
       # wired (dead code until now).
       :ok = Notify.clear_all_for_user(user.id)
       :ok = WSPresence.reset_for_user(user.name)
-
-      baseline_autojoin = Map.get(opts, :baseline_autojoin, %{})
-      baseline_seed = Map.get(opts, :baseline_seed, %{})
-
-      credentials =
-        user
-        |> Networks.Credentials.list_credentials_for_user()
-        |> Enum.map(&restore_baseline_channels(&1, baseline_autojoin))
-
-      :ok = reset_scrollback(user, credentials, baseline_seed)
-
-      respawn_each(user, credentials)
     end
+
+    defp measure(fun) do
+      started_at = System.monotonic_time(:millisecond)
+      result = fun.()
+      {System.monotonic_time(:millisecond) - started_at, result}
+    end
+
+    defp outcome_tag(:ok), do: :ok
+    defp outcome_tag({:error, reason}), do: inspect(reason)
 
     # Rewrite cred.last_joined_channels + cred.autojoin_channels to
     # the seed baseline so the merged SessionPlan starts every spec
@@ -274,14 +334,7 @@ if Mix.env() in [:dev, :test] do
 
       case cred.connection_state do
         :connected ->
-          :ok = Session.stop_session({:user, user.id}, network_id)
-
-          with {:ok, autojoin} <- spawn_and_await(user, cred, slug),
-               :ok <- await_autojoin(user, cred, slug, autojoin) do
-            respawn_each(user, rest)
-          else
-            {:error, _} = err -> err
-          end
+          respawn_connected(user, cred, slug, network_id, rest)
 
         _ ->
           # Parked / failed / disconnected — no respawn. Backoff +
@@ -290,10 +343,40 @@ if Mix.env() in [:dev, :test] do
       end
     end
 
+    # The four spans the respawn is made of, timed individually and logged
+    # per credential — including on the failure path, which is the ONLY
+    # trace an attempt that never returns to the caller leaves behind (a
+    # 433 `nick_rejected` is exactly that attempt, and #934 spent a whole
+    # investigation inferring its existence from arithmetic).
+    defp respawn_connected(user, cred, slug, network_id, rest) do
+      {stop_ms, :ok} = measure(fn -> Session.stop_session({:user, user.id}, network_id) end)
+      {spawned, spawn_ms, welcome_ms} = spawn_and_await(user, cred, slug)
+
+      {autojoin_ms, outcome} =
+        case spawned do
+          {:ok, autojoin} -> measure(fn -> await_autojoin(user, cred, slug, autojoin) end)
+          {:error, _} = err -> {0, err}
+        end
+
+      Logger.info("subject reset respawn",
+        network: slug,
+        outcome: outcome_tag(outcome),
+        stop_ms: stop_ms,
+        spawn_ms: spawn_ms,
+        welcome_ms: welcome_ms,
+        autojoin_ms: autojoin_ms
+      )
+
+      case outcome do
+        :ok -> respawn_each(user, rest)
+        {:error, _} = err -> err
+      end
+    end
+
     defp spawn_and_await(user, cred, slug) do
       case Networks.SessionPlan.resolve(cred) do
         {:ok, plan} -> do_spawn_and_await(user, cred, slug, plan)
-        {:error, reason} -> {:error, {:reconnect_failed, slug, reason}}
+        {:error, reason} -> {{:error, {:reconnect_failed, slug, reason}}, 0, 0}
       end
     end
 
@@ -309,20 +392,27 @@ if Mix.env() in [:dev, :test] do
         requesting_subject: nil
       }
 
-      case Grappa.SpawnOrchestrator.spawn(
-             {:user, user.id},
-             cred.network_id,
-             plan_with_notify,
-             capacity_input
-           ) do
+      {spawn_ms, spawned} =
+        measure(fn ->
+          Grappa.SpawnOrchestrator.spawn(
+            {:user, user.id},
+            cred.network_id,
+            plan_with_notify,
+            capacity_input
+          )
+        end)
+
+      case spawned do
         {:ok, _, pid} ->
-          case await_ready(pid, ref, slug) do
-            :ok -> {:ok, Map.get(plan, :autojoin_channels, [])}
-            {:error, _} = err -> err
+          {welcome_ms, ready} = measure(fn -> await_ready(pid, ref, slug) end)
+
+          case ready do
+            :ok -> {{:ok, Map.get(plan, :autojoin_channels, [])}, spawn_ms, welcome_ms}
+            {:error, _} = err -> {err, spawn_ms, welcome_ms}
           end
 
         {:error, reason} ->
-          {:error, {:reconnect_failed, slug, reason}}
+          {{:error, {:reconnect_failed, slug, reason}}, spawn_ms, 0}
       end
     end
 

--- a/lib/grappa_web/controllers/admin/test_reset_subject_controller.ex
+++ b/lib/grappa_web/controllers/admin/test_reset_subject_controller.ex
@@ -43,8 +43,10 @@ if Mix.env() in [:dev, :test] do
       opts = build_opts(params)
 
       case SubjectReset.reset!(user_name, opts) do
-        :ok ->
-          send_resp(conn, 204, "")
+        {:ok, phases} ->
+          conn
+          |> put_resp_header("x-grappa-reset-phases", encode_phases(phases))
+          |> send_resp(204, "")
 
         {:error, :user_not_found} ->
           conn |> put_status(:not_found) |> json(%{error: "user_not_found"})
@@ -72,6 +74,18 @@ if Mix.env() in [:dev, :test] do
 
     def reset(conn, _) do
       conn |> put_status(:unprocessable_entity) |> json(%{error: "user_name_required"})
+    end
+
+    # #934 — the reset's per-phase wall-clock, ridden out on the 204 as a
+    # header rather than a body so the 204 stays a 204 and no fixture has
+    # to learn a new status code. `k=v;k=v`, keys sorted so a diff of two
+    # runs lines up. A header (not just the server log) because a retry
+    # makes ordinal pairing between client samples and server lines
+    # impossible, and the retry is the thing being measured.
+    defp encode_phases(phases) do
+      phases
+      |> Enum.sort()
+      |> Enum.map_join(";", fn {phase, ms} -> "#{phase}=#{ms}" end)
     end
 
     # Coerce the JSON `baseline_autojoin` map into the keyword-shaped

--- a/test/grappa/test_support/subject_reset_test.exs
+++ b/test/grappa/test_support/subject_reset_test.exs
@@ -58,7 +58,7 @@ defmodule Grappa.TestSupport.SubjectResetTest do
 
   describe "reset!/2" do
     test "drains all mutable DB surfaces for the user", %{user: user, network: network} do
-      assert :ok = SubjectReset.reset!(user.name, %{})
+      assert {:ok, _phases} = SubjectReset.reset!(user.name, %{})
 
       assert ReadCursor.get({:user, user.id}, network.id, "#bofh") == nil
       assert QueryWindows.list_for_subject({:user, user.id}) == %{}
@@ -78,7 +78,7 @@ defmodule Grappa.TestSupport.SubjectResetTest do
       {:ok, _} = UserSettings.set_highlight_patterns({:user, other.id}, ["keep-me"])
       {:ok, _} = Notify.add({:user, other.id}, network.id, ["other-watched"], other.name)
 
-      assert :ok = SubjectReset.reset!(user.name, %{})
+      assert {:ok, _phases} = SubjectReset.reset!(user.name, %{})
 
       other_cursor = ReadCursor.get({:user, other.id}, network.id, "#bofh")
       assert other_cursor != nil
@@ -86,6 +86,19 @@ defmodule Grappa.TestSupport.SubjectResetTest do
       assert UserSettings.get_highlight_patterns({:user, other.id}) == ["keep-me"]
       # #364 S1 — the drain is user-scoped: the other user's watch list stays.
       assert [%{nick: "other-watched"}] = Notify.list({:user, other.id}, network.id)
+    end
+
+    test "reports the wall-clock of every phase it can spend time in", %{user: user} do
+      assert {:ok, phases} = SubjectReset.reset!(user.name, %{})
+
+      # #934: the e2e tail is 43% of the reset budget and nothing could say
+      # WHERE it goes. The phase set must be exhaustive — a span missing
+      # here is a span a slow reset has nowhere to land in.
+      assert phases |> Map.keys() |> Enum.sort() ==
+               [:baseline_ms, :drain_ms, :respawn_ms, :seed_ms, :total_ms]
+
+      assert Enum.all?(Map.values(phases), &(is_integer(&1) and &1 >= 0))
+      assert phases.total_ms >= phases.drain_ms
     end
 
     test "returns {:error, :user_not_found} for unknown user_name" do

--- a/test/grappa/test_support/subject_reset_test.exs
+++ b/test/grappa/test_support/subject_reset_test.exs
@@ -58,7 +58,7 @@ defmodule Grappa.TestSupport.SubjectResetTest do
 
   describe "reset!/2" do
     test "drains all mutable DB surfaces for the user", %{user: user, network: network} do
-      assert {:ok, _phases} = SubjectReset.reset!(user.name, %{})
+      assert {:ok, _} = SubjectReset.reset!(user.name, %{})
 
       assert ReadCursor.get({:user, user.id}, network.id, "#bofh") == nil
       assert QueryWindows.list_for_subject({:user, user.id}) == %{}
@@ -78,7 +78,7 @@ defmodule Grappa.TestSupport.SubjectResetTest do
       {:ok, _} = UserSettings.set_highlight_patterns({:user, other.id}, ["keep-me"])
       {:ok, _} = Notify.add({:user, other.id}, network.id, ["other-watched"], other.name)
 
-      assert {:ok, _phases} = SubjectReset.reset!(user.name, %{})
+      assert {:ok, _} = SubjectReset.reset!(user.name, %{})
 
       other_cursor = ReadCursor.get({:user, other.id}, network.id, "#bofh")
       assert other_cursor != nil

--- a/test/grappa_web/controllers/admin/test_reset_subject_controller_test.exs
+++ b/test/grappa_web/controllers/admin/test_reset_subject_controller_test.exs
@@ -48,6 +48,19 @@ defmodule GrappaWeb.Admin.TestResetSubjectControllerTest do
         |> post("/admin/test/reset-subject", %{"user_name" => user.name})
 
       assert response(conn, 204) == ""
+
+      # #934 — the phase breakdown rides out on the 204 itself. The
+      # Playwright fixture logs this next to its own measured total, which
+      # is the only way to attribute a slow reset: a retry means one test
+      # produces several server-side resets, so pairing client samples to
+      # server log lines by ordinal cannot work.
+      assert [encoded] = get_resp_header(conn, "x-grappa-reset-phases")
+
+      assert encoded
+             |> String.split(";")
+             |> Enum.map(&(&1 |> String.split("=") |> hd()))
+             |> Enum.sort() ==
+               ["baseline_ms", "drain_ms", "respawn_ms", "seed_ms", "total_ms"]
     end
 
     test "returns 403 with non-admin token", %{conn: conn, user_token: tok, user: user} do


### PR DESCRIPTION
Instrumentation for #934, then the measurement run. **The headline is a negative: with the instrument in place, the tail did not happen at all.**

## What was built

Two channels, because they answer different questions.

**1. Server-side phase timer.** `SubjectReset.reset!/2` returns `{:ok, phases}` — `drain` / `baseline` / `seed` / `respawn` / `total`, so total-minus-the-parts is the unattributed remainder and a slow reset always has somewhere to land. The controller forwards it on the 204 as **`x-grappa-reset-phases`** — a header, so the 204 stays a 204 and no fixture learns a new status code. It has to reach the **client**, not just the log: a retry means one test produces several server-side resets, so pairing client samples against server log lines **by ordinal cannot work** — and the retry is the thing being measured. `respawn_connected` additionally logs its four spans per credential (**stop / spawn / WELCOME / autojoin**) *including on the failure path* — the only trace an attempt that never returns to the caller leaves, and a 433 `nick_rejected` is exactly that attempt.

**2. The silent retry is silent no longer.** `nick_rejected` appeared **zero** times in a full green suite log and that zero proved nothing, because nothing ever wrote one. It now emits a line per retry, and the fixture carries the **attempt count** out beside its own measured elapsed. The question becomes a count instead of an inference.

The per-test `__RESETCOST__` line is unconditional on purpose: twice this was a throwaway local diff, and twice the evidence was gone before the question was answered.

**Boundary respected:** no timeout moved, no backoff touched, no product code. The retry's shape is left exactly as it was — this measures it, it does not fix it.

One thing the gate caught that is worth keeping: an **undeclared Logger metadata key is silently dropped by the formatter**. Without the `config.exs` allowlist entry the instrument would compile, run, cost time and print a line with no numbers on it.

## The measurement — 549 samples, same suite, same host

| | w2's run (`7270a595`) | this run (`8ed4f2e0`+instr) |
|---|---|---|
| samples | 549 | **549** |
| median | 595 ms | 538 ms |
| mean | 1124 ms | **582 ms** |
| p95 | 2180 ms | 972 ms |
| p99 | 12612 ms | **1328 ms** |
| max | 17635 ms | **1457 ms** |
| samples ≥ 3 s | 26 | **0** |
| retries (attempts > 1) | unknown | **0** |
| total reset budget | 617 s | **319 s** |
| test phase | 32.1 min | 25.4 min |

**There was no tail to attribute.** The specs that cost 12–17 s in w2's run (`marker-target-window-regression`, the `media-link-*` family, `ux-5-bc2-nick-render`) cost **415–588 ms** here. So, honestly, against the three questions asked:

- *where the 15 samples with no compatible retry depth spend their time* — **cannot say: they did not occur.**
- *whether the 12 proven-by-ceiling really retried* — **cannot say: zero retries occurred.** The instrument now counts them, so the next occurrence answers this without an argument.
- *the burst edges, the 14 sub-ceiling samples, the singleton* — **did not occur, so unexplained.**

That negative is itself the result: **the tail is not a property of the suite or of a spec's position in the run.** Two runs of the same 549 resets, one with a 26-sample tail and one with none.

## What the run DOES establish — where a normal reset's time goes

549 samples, server-side, and it is not where #808 was looking:

| phase | median | share of total |
|---|---|---|
| **`seed_ms`** (scrollback truncate + 200-row re-seed) | 370 ms | **72%** |
| `respawn_ms` (stop + spawn + WELCOME + autojoin) | 119 ms | 22% |
| `drain_ms` (DB/ETS surfaces) | 14 ms | 5% |
| `baseline_ms` (channel baseline rewrite) | 1 ms | 1% |

Client-observed total minus server total: **median 2 ms** — the client number *is* the server number, no HTTP mystery in between.

This sharpens #808's decline rather than reopening it: the restart it declined to make conditional is **22%** of a reset measured across a whole suite, and the dominant cost is the **200-row re-seed** nobody proposed touching. Not proposing anything here — just recording where the lever actually is.

## 🔴 Unrelated, but `main` is red

The run had one failure: `issue772-compose-draft-reload.spec.ts` › *"a SENT message does not come back on reload"* — the sent text is still in the textarea after the reload.

Attribution measured, not argued: **3/3 red in isolation on this branch, and 3/3 red in isolation on clean `origin/main` `8ed4f2e0`** with the instrumentation absent from the tree. Deterministic and **pre-existing** — not this change, and not a flake. Reported here because it means main is currently red on e2e; it is not touched by this PR.

## What I refuse to claim

- **I did not reproduce the phenomenon**, so nothing here explains it. Everything above about the tail is a negative.
- **The cause of the difference between the two runs is NOT established.** Host contention is a candidate and only a candidate: `/tmp` artifacts show other workers' gates finishing at 14:09:23 and 14:22:37 while w2's bursts sit at ≈14:12–14:16 and ≈14:19–14:21 — they **bracket** the bursts without pinning a job inside either. An mtime is a completion time, not an occupancy record. No CPU, IO or load measurement was taken during either run.
- **bahamut was not measured.** The per-IP throttle remains a candidate; zero retries this run is consistent with it and proves nothing about it.
- The two runs are on **different commits** (`7270a595` vs `8ed4f2e0`+instr). Same 549 resets and same spec set, but I did not verify that nothing between those commits touches reset cost.
- The instrument itself is **unvalidated against a slow reset** — every sample it saw was fast. Its behaviour under a retry is exercised by unit tests, not by a real 433.

## Gates

`scripts/check.sh` **rc=0**, every stage read from the log: credo `found no issues` · sobelow `No vulnerabilities found` · ExUnit `8 doctests, 54 properties, 5305 tests, 0 failures` · dialyzer `Total errors: 0 … passed successfully` · `Doctor validation has passed!` ×2 · `wireTypes.ts is in sync` · bats **331 ok / 0 not-ok**. Full e2e suite run (615 passed, the one pre-existing red above). `tsc -p e2e --noEmit`: 23 errors, **all pre-existing in specs this PR does not touch** (the known "e2e has no static gate" hole) — **zero** in the two fixture files changed here.