### PR TITLE
e2e(#951): wait for the send to land, not for the box to empty

### DIFF
--- a/cicchetto/e2e/tests/issue772-compose-draft-reload.spec.ts
+++ b/cicchetto/e2e/tests/issue772-compose-draft-reload.spec.ts
@@ -23,7 +23,7 @@
 // reload (#772)") pins the store rules, including that history does NOT cross.
 
 import { expect, test } from "@playwright/test";
-import { composeTextarea, loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { composeTextarea, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 
 // The seeder autojoins exactly one channel; `?? ""` satisfies
@@ -61,9 +61,18 @@ test.describe("#772 compose drafts survive a reload", () => {
     const body = `issue772 sent ${Date.now()}`;
     await composer.fill(body);
     await composer.press("Enter");
-    // The clear IS the success signal (compose.ts empties the draft on a
-    // successful submit), so waiting for it also waits for the dispatch.
+    // The clear is the DISPATCH signal, not the success signal: post-#904
+    // `takeDraft` empties the buffer synchronously as the pump takes the text,
+    // before the POST is even issued, and the pump's `finally` hands it BACK if
+    // that POST fails. So an empty textarea alone still leaves the send in
+    // flight — and `page.reload()` aborts it (`TypeError: Failed to fetch`),
+    // which IS a failure, so the body is handed back and mirrored to
+    // sessionStorage during teardown. Measured on a fast host: reload landed
+    // ~35ms after dispatch against an ~87ms POST, and the spec lost by ~50ms
+    // (#951). Wait for the row the send produces — that is what "SENT" means
+    // here, and it cannot be true while the request is still open.
     await expect(composer).toHaveValue("");
+    await expect(scrollbackLine(page, "privmsg", body)).toBeVisible();
 
     await page.reload();
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });


### PR DESCRIPTION
## Verdetto: è la spec (misura completa su #951)

`#772 › a SENT message does not come back on reload` era rosso 3/3 in locale e verde in CI. L'asse era l'**host**, e la causa è la spec, non il prodotto.

La spec si sincronizzava sullo svuotamento del composer, su una premessa che dichiarava per iscritto: *"the clear IS the success signal"*. Falsa dopo #904: `takeDraft` (`compose.ts:1817`) svuota il buffer **sincronamente al dispatch**, prima che il POST parta, su ogni submit; e il `finally` della pompa chiama `handBack` (`compose.ts:1837`) se quel POST fallisce.

Il `page.reload()` aborta il POST in volo → è un fallimento → la pompa restituisce il testo → il mirror #772 lo scrive in `sessionStorage` durante il teardown → il documento successivo lo ripristina.

Timeline strumentata su questo host:

```
+512ms drafts-del   (takeDraft: il clear arriva, puntuale)
+513ms send-start
+548ms pagehide     (reload, 35ms dopo il dispatch)
+549ms send-rejected  TypeError: Failed to fetch
+549ms drafts-set   (handBack ri-specchia il body)
```

POST ~87ms, reload a ~35ms dal dispatch: la spec perde di ~50ms. Un host più lento lascia chiudere il POST — ecco perché la CI era verde.

## Displacement, non correlazione

Stessa run, tre varianti che differiscono **solo per dove sta l'attesa**:

| variante | esito |
|---|---|
| nessuna attesa | 3/3 ROSSO |
| attesa che il send si posi (punto giusto) | 3/3 VERDE |
| attesa uguale spostata prima di digitare (punto irrilevante) | 3/3 ROSSO |

## Il fix

L'oracolo, non il timing: "SENT" significa che la riga prodotta dal send è a schermo, e non può esserlo mentre la richiesta è ancora aperta. **Nessun timeout alzato, nessun assert indebolito** — l'asserzione dopo il reload è invariata.

**9/9 verde** (tutto il describe, `--repeat-each 3`, chromium) sull'host che dava 3/3 rosso.

## Prodotto non toccato

Restituire il testo per un send che il client non ha potuto confermare è esattamente ciò che #904 ha costruito. Nessun draft perso.

Fuori scope, annotato su #951: il POST abortito **era comunque arrivato al server**, quindi quell'hand-back rimette in canna una riga già uscita — confine at-least-once, non questo difetto.

## Test plan

- [x] `scripts/integration.sh --project chromium --grep "#772 compose drafts survive a reload" --repeat-each 3` → 9 passed
- [ ] `integration` completa in CI