### PR TITLE
cic(#816): make the refusal speak and the second door a choice

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -315,6 +315,14 @@ export async function confirmModalCancel(page: Page): Promise<void> {
   await page.locator('[data-testid="confirm-modal-cancel"]').click();
 }
 
+// #816 — the optional THIRD button: a different route to what the operator
+// wanted, offered beside Cancel and the affirmative (the paste guard's
+// "Upload as .txt"). A Locator, not a click helper, so a spec can also assert
+// its ABSENCE on a plain two-button dialog.
+export function confirmModalAlternative(page: Page): Locator {
+  return page.locator('[data-testid="confirm-modal-alternative"]');
+}
+
 // Click the window to focus it. Solid's reactive flush + the shell's
 // auto-close-sidebar effect happen synchronously; the channel becomes
 // selected before this resolves.

--- a/cicchetto/e2e/tests/issue80-paste-flood-guard.spec.ts
+++ b/cicchetto/e2e/tests/issue80-paste-flood-guard.spec.ts
@@ -26,6 +26,7 @@ import { expect, test } from "../fixtures/test";
 import {
   composeTextarea,
   confirmModal,
+  confirmModalAlternative,
   confirmModalBody,
   confirmModalCancel,
   confirmModalYes,
@@ -163,6 +164,9 @@ test("#816 — a paste over the hard cap uploads as a file instead of flooding",
   // Both numbers, so the operator knows what would fit.
   await expect(confirmModalBody(page)).toContainText("6");
   await expect(confirmModalBody(page)).toContainText("5");
+  // No third door up here: the paste door is exactly what the cap closed, so
+  // uploading IS the affirmative. Two buttons, not three.
+  await expect(confirmModalAlternative(page)).toHaveCount(0);
 
   // Cancel first: the safe default drops the paste with no upload and no
   // text in the box. Asserted before the affirmative so a handler that
@@ -186,4 +190,87 @@ test("#816 — a paste over the hard cap uploads as a file instead of flooding",
   // channel as its own message. Without this, an implementation that
   // uploaded AND pasted would still be green above.
   await expect(scrollbackLine(page, "privmsg", `over ${tag} riga 0`)).toHaveCount(0);
+});
+
+// #816, vjt's ruling (2026-08-06) — the .txt upload is a CHOICE, not a
+// punishment.
+//
+// Before the ruling this door existed only ABOVE the hard cap: the operator
+// had to be REFUSED before being told there was another way. The ruling makes
+// it an alternative offered on every guarded paste, so a block of four lines
+// — perfectly sendable as a burst — can still go out as one link if that is
+// what the operator prefers.
+//
+// jsdom (ComposeBox.test.tsx) can only assert that the request CARRIES an
+// alternative and that firing the store verb calls triggerUploads. This is
+// the gate that proves the button RENDERS as a third choice beside the other
+// two and that picking it drives the whole upload chain to a link in the
+// channel, with the paste door still there and still working.
+test("#816 — an under-cap paste offers the .txt upload beside Paste, and it works", async ({
+  page,
+  browserName,
+}) => {
+  test.skip(
+    browserName !== "chromium",
+    "shares the upload plumbing gated to chromium by the uploads specs",
+  );
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  // Pre-ack the embedded-host privacy modal so the upload runs unattended
+  // (that flow is covered by ux-6-b-embedded-upload).
+  await page.evaluate(() =>
+    localStorage.setItem("image-upload-privacy-acknowledged:embedded", "1"),
+  );
+
+  const ta = composeTextarea(page);
+  await expect(ta).toBeVisible();
+  await expect(ta).toHaveValue("");
+
+  // FOUR messages — well under the ceiling of five, i.e. a paste the guard
+  // would happily let through. That is the whole point: the door is open
+  // before any refusal.
+  const tag = crypto.randomUUID().slice(0, 8);
+  const block = Array.from({ length: 4 }, (_, i) => `under ${tag} riga ${i}`).join("\n");
+
+  await pasteText(page, block);
+  await expect(confirmModal(page)).toBeVisible();
+  await expect(confirmModalBody(page)).toContainText("4");
+  // Three doors, not two: the affirmative still pastes, and the alternative
+  // is a peer choice next to it. A build that kept the .txt door cap-only
+  // reds right here.
+  const alt = confirmModalAlternative(page);
+  await expect(alt).toBeVisible();
+  await expect(alt).toHaveText("Upload as .txt");
+
+  // Cancel first — the safe default still fires NEITHER door. Asserted before
+  // the alternative so a handler that uploaded unconditionally cannot pass.
+  await confirmModalCancel(page);
+  await expect(confirmModal(page)).toHaveCount(0);
+  await expect(ta).toHaveValue("");
+
+  // Now take the third door: the block leaves as one 📄-prefixed link and
+  // never enters the composer.
+  await pasteText(page, block);
+  await expect(confirmModal(page)).toBeVisible();
+  await confirmModalAlternative(page).click();
+  await expect(confirmModal(page)).toHaveCount(0);
+  await expect(ta).toHaveValue("");
+
+  const rows = scrollbackLine(page, "privmsg", "📄");
+  await expect.poll(async () => await rows.count(), { timeout: 20_000 }).toBeGreaterThanOrEqual(1);
+  // The burst never happened — an implementation that uploaded AND pasted
+  // would still be green above.
+  await expect(scrollbackLine(page, "privmsg", `under ${tag} riga 0`)).toHaveCount(0);
+
+  // …and the paste door is still a door: the same block, confirmed, lands in
+  // the composer verbatim. The alternative ADDED a choice, it did not replace
+  // the affirmative.
+  await pasteText(page, block);
+  await expect(confirmModal(page)).toBeVisible();
+  await confirmModalYes(page);
+  await expect(confirmModal(page)).toHaveCount(0);
+  await expect(ta).toHaveValue(block);
 });

--- a/cicchetto/e2e/tests/issue816-shift-enter-speaks.spec.ts
+++ b/cicchetto/e2e/tests/issue816-shift-enter-speaks.spec.ts
@@ -1,0 +1,66 @@
+// #816 — Shift+Enter SPEAKS.
+//
+// A newline cannot travel inside a PRIVMSG (CRLF terminates the frame), so
+// honouring Shift+Enter means splitting into N messages — a burst the
+// operator never asked for by holding a modifier. cic therefore inserts
+// nothing and sends nothing.
+//
+// vjt's ruling (2026-08-06) is that the refusal must not be SILENT. Every
+// other chat app the operator uses honours that combination; a composer that
+// simply does nothing reads as a broken key or a cic bug, and there is no way
+// to learn that the protocol is what refused. So the composer says
+// "IRC does not support multi-line messages" on the #356 feedback seam.
+//
+// The vitest half (ComposeBox.test.tsx) proves the handler sets the feedback
+// signal in jsdom. This spec is the real-browser proof that the line actually
+// RENDERS where the operator is looking — and that the refusal is still a
+// refusal: no newline in the box, no message on the wire.
+
+import { expect, test } from "../fixtures/test";
+import {
+  composeSend,
+  composeTextarea,
+  loginAs,
+  scrollbackLine,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// vjt's wording, verbatim — this literal IS the requirement, so the spec
+// spells it out rather than importing the production constant (which would
+// make any rewording silently self-approving).
+const REFUSAL = "IRC does not support multi-line messages";
+
+test("#816 — Shift+Enter inserts no newline, sends nothing, and explains why", async ({ page }) => {
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  const ta = composeTextarea(page);
+  await expect(ta).toBeVisible();
+
+  const tag = crypto.randomUUID().slice(0, 8);
+  const typed = `se ${tag} prima riga`;
+  await ta.fill(typed);
+
+  // Nothing is up yet — so the assertion below cannot pass on a stale line
+  // left over from some earlier interaction.
+  await expect(page.getByText(REFUSAL)).toHaveCount(0);
+
+  await ta.press("Shift+Enter");
+
+  // The composer explains itself.
+  await expect(page.getByText(REFUSAL)).toBeVisible();
+  // …and it is still a refusal: the draft is untouched (no line break got in)
+  // and nothing was sent.
+  await expect(ta).toHaveValue(typed);
+  await expect(scrollbackLine(page, "privmsg", typed)).toHaveCount(0);
+
+  // Positive control: a plain Enter DOES send the same draft. Without this a
+  // dead composer (or a wedged window) would satisfy everything above.
+  await composeSend(page, typed);
+  await expect(scrollbackLine(page, "privmsg", typed)).toBeVisible({ timeout: 5_000 });
+});

--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -100,6 +100,11 @@ const NETWORK_GREYED_STATES = new Set(["parked", "failed"]);
 // you have to read them.
 const NOTICE_DISMISS_MS = 3_000;
 
+// #816 — what Shift+Enter says instead of doing nothing. vjt's wording
+// (2026-08-06), verbatim: it names the PROTOCOL as the thing that refuses, so
+// the operator stops looking for a broken key or a cic setting to flip.
+const SHIFT_ENTER_REFUSAL = "IRC does not support multi-line messages";
+
 // #356 — the compose-box feedback line, discriminated by severity:
 //   * "error"  → red, role=alert, STICKY (survives until the next submit /
 //                input). The failure the operator must read.
@@ -442,16 +447,25 @@ const ComposeBox: Component<Props> = (props) => {
 
   const onKeyDown = (e: KeyboardEvent) => {
     if (e.key === "Enter") {
-      // #816 — Shift+Enter is a NO-OP: preventDefault with no send, so the
-      // textarea inserts no line break and the composer stays single-line. A
-      // newline cannot travel inside a PRIVMSG (CRLF terminates the frame),
-      // so honouring one means splitting into N messages — a flood the
-      // operator never asked for by holding a modifier, and one no client
-      // sets the precedent for (mIRC's editbox is single-line, hexchat
-      // splits paste). Paste is left as the ONE route a multi-line body can
-      // take into the box, and paste is guarded (lib/pasteFlood).
+      // #816 — Shift+Enter inserts NOTHING and sends nothing: preventDefault
+      // with no submit, so the textarea takes no line break and the composer
+      // stays single-line. A newline cannot travel inside a PRIVMSG (CRLF
+      // terminates the frame), so honouring one means splitting into N
+      // messages — a flood the operator never asked for by holding a
+      // modifier, and one no client sets the precedent for (mIRC's editbox is
+      // single-line, hexchat splits paste). Paste is left as the ONE route a
+      // multi-line body can take into the box, and paste is guarded
+      // (lib/pasteFlood).
+      //
+      // vjt's ruling (2026-08-06): the refusal must SPEAK. Silence is
+      // indistinguishable from a broken key — the operator presses the
+      // combination their other chat clients honour, sees nothing happen, and
+      // has no way to learn that the protocol is what refused. It rides the
+      // existing #356 feedback seam as a NOTICE (role=status, self-clearing):
+      // nothing failed, so an assertive red alert would overstate it.
       e.preventDefault();
-      if (!e.shiftKey) void doSubmit();
+      if (e.shiftKey) showNotice(SHIFT_ENTER_REFUSAL);
+      else void doSubmit();
       return;
     }
     if (e.key === "ArrowUp") {

--- a/cicchetto/src/ConfirmModal.tsx
+++ b/cicchetto/src/ConfirmModal.tsx
@@ -1,5 +1,10 @@
 import { type Component, createEffect, Show } from "solid-js";
-import { acceptConfirm, confirmRequest, dismissConfirm } from "./lib/confirmDialog";
+import {
+  acceptConfirm,
+  chooseAlternative,
+  confirmRequest,
+  dismissConfirm,
+} from "./lib/confirmDialog";
 import { createOverlayLock } from "./lib/overlayScrollLock";
 
 // #195 — explicit confirm modal for destructive window actions (leave
@@ -71,6 +76,22 @@ const ConfirmModal: Component = () => {
               >
                 Cancel
               </button>
+              {/* #816 — the optional third door, between Cancel and the
+                  affirmative: a DIFFERENT route to what the operator wanted,
+                  not a softer yes. Placed here so the affirmative keeps the
+                  last (default-reading) slot and Cancel keeps the first. */}
+              <Show when={req().alternative}>
+                {(alt) => (
+                  <button
+                    type="button"
+                    class="confirm-modal-alternative"
+                    data-testid="confirm-modal-alternative"
+                    onClick={chooseAlternative}
+                  >
+                    {alt().label}
+                  </button>
+                )}
+              </Show>
               <button
                 type="button"
                 class="confirm-modal-confirm"

--- a/cicchetto/src/ThemeGallery.tsx
+++ b/cicchetto/src/ThemeGallery.tsx
@@ -227,6 +227,7 @@ const ThemeGallery: Component<Props> = (props) => {
       body: `Delete "${theme.name}"? This can't be undone.`,
       confirmLabel: "Delete",
       onConfirm: () => void remove(theme),
+      alternative: null,
     });
 
   // #333 — split the merged list into "your themes" (owned copies/creates)

--- a/cicchetto/src/__tests__/ComposeBox.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBox.test.tsx
@@ -91,7 +91,12 @@ import * as compose_ from "../lib/compose";
 // #80 — the paste flood guard reuses the REAL confirm-dialog store (not a
 // mock): ComposeBox calls requestConfirm, and these tests assert on the
 // store signal + drive accept/dismiss exactly as ConfirmModal.test.tsx does.
-import { acceptConfirm, confirmRequest, dismissConfirm } from "../lib/confirmDialog";
+import {
+  acceptConfirm,
+  chooseAlternative,
+  confirmRequest,
+  dismissConfirm,
+} from "../lib/confirmDialog";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -324,14 +329,16 @@ describe("ComposeBox", () => {
     expect(compose.submit).toHaveBeenCalledWith(expect.anything(), "freenode", "#a");
   });
 
-  // #816 — Shift+Enter is a NO-OP: it neither submits nor inserts a line
-  // break. The composer stays single-line, because a newline cannot travel
-  // inside a PRIVMSG and the only way to honour one is to split into N
-  // messages — a flood hazard the operator never asked for by pressing a
-  // modifier. No client sets the precedent either (mIRC's editbox is
-  // single-line; hexchat splits paste). Paste remains the ONE way a
-  // multi-line body reaches the box, and paste is guarded.
-  it("#816 — Shift+Enter is a no-op: no submit and no line break", async () => {
+  // #816 — Shift+Enter inserts NOTHING and submits NOTHING, and now SAYS SO.
+  // The composer stays single-line, because a newline cannot travel inside a
+  // PRIVMSG and the only way to honour one is to split into N messages — a
+  // flood hazard the operator never asked for by pressing a modifier. No
+  // client sets the precedent either (mIRC's editbox is single-line; hexchat
+  // splits paste). What vjt's ruling (2026-08-06) changed is that the refusal
+  // is no longer SILENT: a key that does nothing reads as a broken key, so
+  // the composer explains itself on the existing feedback seam. Paste remains
+  // the ONE way a multi-line body reaches the box, and paste is guarded.
+  it("#816 — Shift+Enter submits nothing, inserts no line break, and says why", async () => {
     const compose = await import("../lib/compose");
     render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
     const ta = screen.getByPlaceholderText(/message #a/i);
@@ -347,6 +354,20 @@ describe("ComposeBox", () => {
     // asserting "no submit" alone passed against the old behaviour too.
     expect(ev.defaultPrevented).toBe(true);
     expect(compose.setDraft).not.toHaveBeenCalled();
+    // The ruling's copy, verbatim. This is the assertion the old test
+    // INVERTED (it pinned the silence), so it is what proves the change.
+    expect(screen.getByText("IRC does not support multi-line messages")).toBeInTheDocument();
+  });
+
+  // A plain Enter must not trip the multi-line explanation — otherwise the
+  // notice would fire on every ordinary send and mean nothing.
+  it("#816 — a plain Enter shows no multi-line explanation", async () => {
+    const compose = await import("../lib/compose");
+    vi.mocked(compose.submit).mockResolvedValue({ ok: true });
+    render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+    const ta = screen.getByPlaceholderText(/message #a/i);
+    fireEvent.keyDown(ta, { key: "Enter" });
+    expect(screen.queryByText("IRC does not support multi-line messages")).toBeNull();
   });
 
   it("Up arrow on first-line cursor calls recallPrev", async () => {
@@ -1276,6 +1297,60 @@ describe("ComposeBox", () => {
       expect(confirmRequest()?.title).toContain("2");
     });
 
+    // #816 (vjt's ruling, 2026-08-06) — the .txt upload is a CHOICE, not a
+    // punishment. Before the ruling it appeared only ABOVE the hard cap, i.e.
+    // only once the operator had already been refused; the ruling makes it an
+    // alternative offered on every guarded paste. An operator who sees "4
+    // separate messages" and thinks better of it can send one link instead,
+    // without first having to hit a ceiling.
+    describe("#816 — the .txt door under the cap", () => {
+      it("the under-cap confirm carries the .txt upload as an alternative", async () => {
+        render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+        const ta = screen.getByPlaceholderText(/message #a/i) as HTMLTextAreaElement;
+        ta.dispatchEvent(makeTextPaste(FOUR_LINES));
+
+        const req = confirmRequest();
+        expect(req).not.toBeNull();
+        // Both doors are open: paste the burst, or send it as a file.
+        expect(req?.confirmLabel).toBe("Paste");
+        expect(req?.alternative?.label).toBe("Upload as .txt");
+      });
+
+      it("choosing it uploads the paste as text/plain and never touches the draft", async () => {
+        const compose = await import("../lib/compose");
+        const orch = await import("../lib/uploadOrchestrator");
+        render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+        const ta = screen.getByPlaceholderText(/message #a/i) as HTMLTextAreaElement;
+        ta.dispatchEvent(makeTextPaste(FOUR_LINES));
+
+        chooseAlternative();
+
+        expect(orch.triggerUploads).toHaveBeenCalledTimes(1);
+        const files = vi.mocked(orch.triggerUploads).mock.calls[0]?.[3] as File[];
+        expect(files).toHaveLength(1);
+        expect(files[0]?.type).toBe("text/plain");
+        // The bytes are the paste itself — an upload that dropped or mangled
+        // the text would still satisfy "a file was uploaded".
+        await expect(files[0]?.text()).resolves.toBe(FOUR_LINES);
+        // Picking the file door means the burst never enters the composer.
+        expect(compose.setDraft).not.toHaveBeenCalled();
+        expect(confirmRequest()).toBeNull();
+      });
+
+      it("the affirmative still pastes — the alternative does not displace it", async () => {
+        const compose = await import("../lib/compose");
+        const orch = await import("../lib/uploadOrchestrator");
+        render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+        const ta = screen.getByPlaceholderText(/message #a/i) as HTMLTextAreaElement;
+        ta.dispatchEvent(makeTextPaste(FOUR_LINES));
+
+        acceptConfirm();
+
+        expect(compose.setDraft).toHaveBeenCalledWith(expect.any(String), FOUR_LINES);
+        expect(orch.triggerUploads).not.toHaveBeenCalled();
+      });
+    });
+
     // #816 — above the hard cap the paste does not land in the box at all.
     // The operator gets two doors instead: upload the block as a file and
     // post the link (the same shape as the 📸 image path — `text/plain` is
@@ -1284,7 +1359,7 @@ describe("ComposeBox", () => {
     describe("#816 — over the hard cap", () => {
       const OVER_CAP = Array.from({ length: 6 }, (_, i) => `riga ${i}`).join("\n");
 
-      it("offers 'Upload as file' instead of the paste affirmative", async () => {
+      it("offers the .txt upload as the affirmative — the paste door is gone", async () => {
         render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
         const ta = screen.getByPlaceholderText(/message #a/i) as HTMLTextAreaElement;
         const paste = makeTextPaste(OVER_CAP);
@@ -1293,7 +1368,12 @@ describe("ComposeBox", () => {
         expect(paste.defaultPrevented).toBe(true);
         const req = confirmRequest();
         expect(req).not.toBeNull();
-        expect(req?.confirmLabel).toBe("Upload as file");
+        // Same label as the under-cap alternative: it is the same door, and
+        // two spellings would read as two different actions.
+        expect(req?.confirmLabel).toBe("Upload as .txt");
+        // Above the cap the paste door is GONE — there is no alternative to
+        // offer beside it, because uploading IS the affirmative here.
+        expect(req?.alternative).toBeNull();
         // The copy has to carry BOTH numbers: what they pasted and where the
         // ceiling is. "Too many" without the limit leaves them guessing.
         expect(req?.body).toContain("6");
@@ -1328,7 +1408,7 @@ describe("ComposeBox", () => {
         ta.dispatchEvent(makeTextPaste(OVER_CAP));
         // Pin WHICH dialog was dismissed — without this the case passes
         // against a build that never grew the over-cap arm at all.
-        expect(confirmRequest()?.confirmLabel).toBe("Upload as file");
+        expect(confirmRequest()?.confirmLabel).toBe("Upload as .txt");
 
         dismissConfirm();
 

--- a/cicchetto/src/__tests__/ConfirmModal.test.tsx
+++ b/cicchetto/src/__tests__/ConfirmModal.test.tsx
@@ -31,6 +31,7 @@ describe("ConfirmModal (#195)", () => {
       body: "Do you want to leave #italia?",
       confirmLabel: "Yes",
       onConfirm: vi.fn(),
+      alternative: null,
     });
     expect(screen.getByTestId("confirm-modal")).toBeInTheDocument();
     expect(screen.getByTestId("confirm-modal-body").textContent).toBe(
@@ -43,7 +44,7 @@ describe("ConfirmModal (#195)", () => {
   it("the affirmative button fires the action and closes", () => {
     const onConfirm = vi.fn();
     render(() => <ConfirmModal />);
-    requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm });
+    requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm, alternative: null });
     fireEvent.click(screen.getByTestId("confirm-modal-confirm"));
     expect(onConfirm).toHaveBeenCalledTimes(1);
     expect(screen.queryByTestId("confirm-modal")).toBeNull();
@@ -52,7 +53,7 @@ describe("ConfirmModal (#195)", () => {
   it("Cancel dismisses WITHOUT firing the action", () => {
     const onConfirm = vi.fn();
     render(() => <ConfirmModal />);
-    requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm });
+    requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm, alternative: null });
     fireEvent.click(screen.getByTestId("confirm-modal-cancel"));
     expect(onConfirm).not.toHaveBeenCalled();
     expect(screen.queryByTestId("confirm-modal")).toBeNull();
@@ -61,7 +62,7 @@ describe("ConfirmModal (#195)", () => {
   it("backdrop click dismisses WITHOUT firing the action", () => {
     const onConfirm = vi.fn();
     render(() => <ConfirmModal />);
-    requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm });
+    requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm, alternative: null });
     fireEvent.click(screen.getByTestId("confirm-modal-backdrop"));
     expect(onConfirm).not.toHaveBeenCalled();
     expect(screen.queryByTestId("confirm-modal")).toBeNull();
@@ -73,10 +74,48 @@ describe("ConfirmModal (#195)", () => {
   it("Escape dismisses WITHOUT firing the action (shared overlay stack)", async () => {
     const onConfirm = vi.fn();
     render(() => <ConfirmModal />);
-    requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm });
+    requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm, alternative: null });
     await waitFor(() => expect(overlayEscapeDepth()).toBe(1));
     expect(runTopmostOverlayEscape()).toBe(true);
     await waitFor(() => expect(screen.queryByTestId("confirm-modal")).toBeNull());
     expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  // #816 — the optional THIRD button. A request may carry an alternative way
+  // to get what the operator wanted (the paste guard's "send it as a .txt
+  // upload"), offered ALONGSIDE Cancel and the affirmative. Two-button
+  // requests must be unchanged: the button appears only when the request
+  // carries one.
+  describe("#816 — the alternative button", () => {
+    it("is absent when the request carries no alternative", () => {
+      render(() => <ConfirmModal />);
+      requestConfirm({
+        title: "t",
+        body: "b",
+        confirmLabel: "Yes",
+        onConfirm: vi.fn(),
+        alternative: null,
+      });
+      expect(screen.queryByTestId("confirm-modal-alternative")).toBeNull();
+    });
+
+    it("renders the alternative's label and fires ONLY its action, then closes", () => {
+      const onConfirm = vi.fn();
+      const onSelect = vi.fn();
+      render(() => <ConfirmModal />);
+      requestConfirm({
+        title: "t",
+        body: "b",
+        confirmLabel: "Paste",
+        onConfirm,
+        alternative: { label: "Upload as .txt", onSelect },
+      });
+      const btn = screen.getByTestId("confirm-modal-alternative");
+      expect(btn.textContent).toBe("Upload as .txt");
+      fireEvent.click(btn);
+      expect(onSelect).toHaveBeenCalledTimes(1);
+      expect(onConfirm).not.toHaveBeenCalled();
+      expect(screen.queryByTestId("confirm-modal")).toBeNull();
+    });
   });
 });

--- a/cicchetto/src/lib/__tests__/confirmDialog.test.ts
+++ b/cicchetto/src/lib/__tests__/confirmDialog.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { acceptConfirm, confirmRequest, dismissConfirm, requestConfirm } from "../confirmDialog";
+import {
+  acceptConfirm,
+  chooseAlternative,
+  confirmRequest,
+  dismissConfirm,
+  requestConfirm,
+} from "../confirmDialog";
 
 // #195 — the generic confirm-dialog store that gates destructive window
 // closes (leave channel / disconnect network), replacing the removed #172
@@ -11,14 +17,14 @@ describe("confirmDialog store (#195)", () => {
 
   it("requestConfirm sets the pending request without firing the action", () => {
     const onConfirm = vi.fn();
-    requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm });
+    requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm, alternative: null });
     expect(confirmRequest()).toMatchObject({ title: "t", body: "b", confirmLabel: "Yes" });
     expect(onConfirm).not.toHaveBeenCalled();
   });
 
   it("acceptConfirm fires the action once and clears the request", () => {
     const onConfirm = vi.fn();
-    requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm });
+    requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm, alternative: null });
     acceptConfirm();
     expect(onConfirm).toHaveBeenCalledTimes(1);
     expect(confirmRequest()).toBeNull();
@@ -26,7 +32,7 @@ describe("confirmDialog store (#195)", () => {
 
   it("dismissConfirm clears the request WITHOUT firing the action (safe default)", () => {
     const onConfirm = vi.fn();
-    requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm });
+    requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm, alternative: null });
     dismissConfirm();
     expect(onConfirm).not.toHaveBeenCalled();
     expect(confirmRequest()).toBeNull();
@@ -40,11 +46,90 @@ describe("confirmDialog store (#195)", () => {
   it("a second requestConfirm replaces the first (one modal at a time)", () => {
     const first = vi.fn();
     const second = vi.fn();
-    requestConfirm({ title: "1", body: "1", confirmLabel: "Yes", onConfirm: first });
-    requestConfirm({ title: "2", body: "2", confirmLabel: "Yes", onConfirm: second });
+    requestConfirm({
+      title: "1",
+      body: "1",
+      confirmLabel: "Yes",
+      onConfirm: first,
+      alternative: null,
+    });
+    requestConfirm({
+      title: "2",
+      body: "2",
+      confirmLabel: "Yes",
+      onConfirm: second,
+      alternative: null,
+    });
     expect(confirmRequest()?.title).toBe("2");
     acceptConfirm();
     expect(first).not.toHaveBeenCalled();
     expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  // #816 (vjt's ruling, 2026-08-06) — a request may carry a THIRD door: an
+  // alternative way to accomplish what the operator wanted, offered beside
+  // Cancel and the affirmative rather than instead of them. The paste guard is
+  // the first caller (send it as a .txt upload instead of N messages), but the
+  // store stays domain-agnostic: it carries a second closure and fires ONLY
+  // the one the operator picked.
+  describe("#816 — the alternative door", () => {
+    const alt = (onSelect: () => void) => ({ label: "Upload as .txt", onSelect });
+
+    it("chooseAlternative fires the alternative, NOT the affirmative, and clears", () => {
+      const onConfirm = vi.fn();
+      const onSelect = vi.fn();
+      requestConfirm({
+        title: "t",
+        body: "b",
+        confirmLabel: "Yes",
+        onConfirm,
+        alternative: alt(onSelect),
+      });
+      chooseAlternative();
+      expect(onSelect).toHaveBeenCalledTimes(1);
+      // The two doors are exclusive — picking one must not fire the other.
+      expect(onConfirm).not.toHaveBeenCalled();
+      expect(confirmRequest()).toBeNull();
+    });
+
+    it("acceptConfirm still fires only the affirmative when an alternative is present", () => {
+      const onConfirm = vi.fn();
+      const onSelect = vi.fn();
+      requestConfirm({
+        title: "t",
+        body: "b",
+        confirmLabel: "Yes",
+        onConfirm,
+        alternative: alt(onSelect),
+      });
+      acceptConfirm();
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it("dismissConfirm fires neither door", () => {
+      const onConfirm = vi.fn();
+      const onSelect = vi.fn();
+      requestConfirm({
+        title: "t",
+        body: "b",
+        confirmLabel: "Yes",
+        onConfirm,
+        alternative: alt(onSelect),
+      });
+      dismissConfirm();
+      expect(onConfirm).not.toHaveBeenCalled();
+      expect(onSelect).not.toHaveBeenCalled();
+      expect(confirmRequest()).toBeNull();
+    });
+
+    it("chooseAlternative on a request that carries none is a safe no-op", () => {
+      const onConfirm = vi.fn();
+      requestConfirm({ title: "t", body: "b", confirmLabel: "Yes", onConfirm, alternative: null });
+      expect(() => chooseAlternative()).not.toThrow();
+      expect(onConfirm).not.toHaveBeenCalled();
+      // The request survives: nothing was chosen, so nothing was resolved.
+      expect(confirmRequest()).not.toBeNull();
+    });
   });
 });

--- a/cicchetto/src/lib/channelJoin.ts
+++ b/cicchetto/src/lib/channelJoin.ts
@@ -96,5 +96,6 @@ export function confirmJoinChannel(networkSlug: string, rawChannel: string): voi
     body: `Join ${rawChannel}?`,
     confirmLabel: "Join",
     onConfirm: () => void performJoin(networkSlug, rawChannel),
+    alternative: null,
   });
 }

--- a/cicchetto/src/lib/confirmDialog.ts
+++ b/cicchetto/src/lib/confirmDialog.ts
@@ -17,6 +17,21 @@ import { createSignal } from "solid-js";
 //
 // Cancel is the safe default: NO destructive default button. Backdrop click,
 // Esc, and the Cancel button all dismiss WITHOUT firing the action.
+//
+// #816 added an OPTIONAL third door: an alternative way to get what the
+// operator wanted, offered ALONGSIDE Cancel and the affirmative instead of
+// replacing either. The paste guard is its first caller — "send this block as
+// a .txt upload" is not a yes and not a no, it is a different route to the
+// same intent — and the store stays domain-agnostic by carrying a second
+// closure rather than learning about uploads.
+
+// The third door. `null` on a request means a plain two-button yes/no dialog.
+export type ConfirmAlternative = {
+  // Label of the alternative button (e.g. "Upload as .txt").
+  label: string;
+  // Fired ONLY when the operator picks this door — never on confirm/dismiss.
+  onSelect: () => void;
+};
 
 export type ConfirmRequest = {
   // Short dialog heading (e.g. "Leave channel").
@@ -28,6 +43,10 @@ export type ConfirmRequest = {
   confirmLabel: string;
   // Fired ONLY on affirmative confirm — never on cancel/dismiss.
   onConfirm: () => void;
+  // Explicit `null` rather than an optional field: every call site declares
+  // whether its dialog has a third door, so a reader never has to check the
+  // type to find out that a two-button modal was intended.
+  alternative: ConfirmAlternative | null;
 };
 
 const [confirmRequest, setConfirmRequest] = createSignal<ConfirmRequest | null>(null);
@@ -51,4 +70,15 @@ export function acceptConfirm(): void {
   if (req === null) return;
   setConfirmRequest(null);
   req.onConfirm();
+}
+
+// #816 — the alternative door. Same clear-then-fire order as acceptConfirm,
+// and exclusive with it: picking this one never runs onConfirm. A request
+// with no alternative resolves to NOTHING — the dialog stays open, because
+// nothing was chosen.
+export function chooseAlternative(): void {
+  const alt = confirmRequest()?.alternative;
+  if (alt === undefined || alt === null) return;
+  setConfirmRequest(null);
+  alt.onSelect();
 }

--- a/cicchetto/src/lib/pasteRoute.ts
+++ b/cicchetto/src/lib/pasteRoute.ts
@@ -48,16 +48,22 @@ export function insertPastedText(
   });
 }
 
-// #816 — the second door above the hard cap. A block too big to send as a
-// burst becomes a `text/plain` File and rides the EXISTING upload path: the
-// orchestrator posts the resulting URL as a 📄-prefixed PRIVMSG, one frame
-// instead of N, and the recipient clicks through. No new category, no new
-// server surface — `text/plain` is already an accepted `document` MIME
-// (uploadCategory.ts, a 1:1 mirror of the server's @mime_categories), so this
-// reuses the upload VERB rather than inventing a paste service. Same shape as
-// the 📸 image path CLAUDE.md names as the model for "media is a link, and
-// IRC stays text".
+// #816 — the second door. A pasted block becomes a `text/plain` File and
+// rides the EXISTING upload path: the orchestrator posts the resulting URL as
+// a 📄-prefixed PRIVMSG, one frame instead of N, and the recipient clicks
+// through. No new category, no new server surface — `text/plain` is already
+// an accepted `document` MIME (uploadCategory.ts, a 1:1 mirror of the
+// server's @mime_categories), so this reuses the upload VERB rather than
+// inventing a paste service. Same shape as the 📸 image path CLAUDE.md names
+// as the model for "media is a link, and IRC stays text".
+//
+// vjt's ruling (2026-08-06) made it a CHOICE, not a punishment: it is offered
+// on EVERY guarded paste (as the confirm dialog's alternative door), not only
+// once the operator has already been refused by the hard cap. Above the cap
+// it is the affirmative, because the paste door is gone — same verb, same
+// label, so the two arms read as one action and not two.
 export const PASTE_UPLOAD_FILENAME = "paste.txt";
+export const PASTE_UPLOAD_LABEL = "Upload as .txt";
 
 export function uploadPastedText(text: string, networkSlug: string, channelName: string): void {
   const file = new File([text], PASTE_UPLOAD_FILENAME, { type: "text/plain" });
@@ -133,9 +139,16 @@ export function routeClipboardPaste(
         // Target-neutral copy: `channelName` is a nick on a query (DM)
         // window, so "flood the channel" would misdescribe a DM. "it" carries
         // both.
-        body: `This paste will be sent to ${channelName} as ${messages} separate messages. Sending can flood it with a burst.`,
+        body: `This paste will be sent to ${channelName} as ${messages} separate messages. Sending can flood it with a burst — or send it as one text file instead.`,
         confirmLabel: "Paste",
         onConfirm: () => insertPastedText(ta, networkSlug, channelName, text),
+        // The third door, offered BEFORE any refusal: an operator who reads
+        // "4 separate messages" and thinks better of it can post one link
+        // instead, without having to hit the cap first to be told it exists.
+        alternative: {
+          label: PASTE_UPLOAD_LABEL,
+          onSelect: () => uploadPastedText(text, networkSlug, channelName),
+        },
       });
       return;
     case "over-limit":
@@ -145,8 +158,11 @@ export function routeClipboardPaste(
         // Both numbers: what they pasted and where the ceiling is. "Too many"
         // without the limit leaves the operator guessing what would fit.
         body: `This paste would be ${messages} separate messages to ${channelName} — more than the ${PASTE_HARD_MESSAGE_LIMIT} a burst may be. Upload it as a text file instead and post the link.`,
-        confirmLabel: "Upload as file",
+        confirmLabel: PASTE_UPLOAD_LABEL,
         onConfirm: () => uploadPastedText(text, networkSlug, channelName),
+        // No third door here: the paste door is what the cap closed, so
+        // uploading IS the affirmative and there is nothing else to offer.
+        alternative: null,
       });
       return;
     case "insert":

--- a/cicchetto/src/lib/windowClose.ts
+++ b/cicchetto/src/lib/windowClose.ts
@@ -164,6 +164,7 @@ export function confirmLeaveChannel(networkSlug: string, channelName: string): v
     body: `Do you want to leave ${channelName}?`,
     confirmLabel: "Yes",
     onConfirm: () => closeChannelWindow(networkSlug, channelName),
+    alternative: null,
   });
 }
 
@@ -176,5 +177,6 @@ export function confirmDisconnectNetwork(networkSlug: string): void {
     body: `Disconnect from ${networkSlug}?`,
     confirmLabel: "Yes",
     onConfirm: () => disconnectNetwork(networkSlug),
+    alternative: null,
   });
 }

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -3888,6 +3888,7 @@ html.resize-dragging * {
 
 .confirm-modal-actions {
   display: flex;
+  flex-wrap: wrap;
   justify-content: flex-end;
   gap: 0.5rem;
 }
@@ -3905,6 +3906,20 @@ html.resize-dragging * {
   background: #c00;
   color: #fff;
   border: 1px solid #c00;
+  padding: 0.5rem 1rem;
+  font-family: var(--font-mono);
+  cursor: pointer;
+}
+
+/* #816 — the optional third door (e.g. "Upload as .txt" on the paste guard).
+   Neither destructive nor a dismissal, so it takes neither the red of the
+   affirmative nor the bare outline of Cancel: an accent-bordered button that
+   reads as a peer choice. Actions wrap on narrow screens (three buttons do
+   not fit 24rem at large font sizes) — see .confirm-modal-actions. */
+.confirm-modal-alternative {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent);
   padding: 0.5rem 1rem;
   font-family: var(--font-mono);
   cursor: pointer;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -31460,3 +31460,63 @@ which the deploy preflight reads as COLD — for packages that are not in the
 prod release, so the COLD buys no production security. Worth folding into the
 next COLD-forcing change rather than shipping alone. `mix deps.audit` remains
 the hard CVE gate throughout and is untouched.
+
+## 2026-08-06 — #816 ruling: a refusal that speaks, and a door that is a choice
+
+vjt's acceptance comment on #816 (2026-08-06 10:12Z) posed two conditions that
+the shipped implementation did not meet. This is both of them.
+
+**Shift+Enter had to stop being silent.** It still inserts nothing and sends
+nothing — a newline cannot travel inside a PRIVMSG, so honouring the key means
+splitting into N messages, a burst nobody asked for by holding a modifier. But
+a key that does *nothing* is indistinguishable from a broken key: every other
+chat app the operator uses honours that combination, so silence sends them
+looking for a cic setting to flip. It now says **"IRC does not support
+multi-line messages"** — vjt's wording, verbatim, naming the PROTOCOL as the
+thing that refused. It rides the existing #356 feedback seam as a NOTICE
+(`role=status`, self-clearing), not an error: nothing failed, and an assertive
+red alert would overstate a key that was never going to work.
+
+The old vitest **pinned the silence** (`expect(setDraft).not.toHaveBeenCalled()`
+and nothing more, under a comment describing the no-op as the feature). That
+assertion was rewritten, not supplemented — leaving it standing beside a new
+one would have encoded two contradictory truths and let either be "the" spec.
+
+**The .txt upload became a choice instead of a punishment.** It shipped as the
+affirmative on the OVER-CAP dialog only, i.e. reachable exclusively after the
+operator had already been refused. The ruling wants it *offered*, so the
+under-cap confirm now carries it as a third door beside Cancel and Paste. An
+operator who reads "4 separate messages" and thinks better of it posts one link
+instead, without first having to trip a ceiling to learn the option exists.
+
+**The store grew the door, not the paste guard.** `ConfirmRequest` gained
+`alternative: {label, onSelect} | null` plus a `chooseAlternative()` verb
+exclusive with `acceptConfirm()`. It is a REQUIRED field, not an optional one:
+all five existing call sites now write `alternative: null` explicitly, so a
+reader sees "this dialog has two buttons" as a stated fact rather than an
+absence they have to infer from the type. The store stays domain-agnostic — it
+carries a second closure and still knows nothing about uploads.
+
+Both arms use ONE label, `PASTE_UPLOAD_LABEL = "Upload as .txt"` (the over-cap
+affirmative said "Upload as file" before). Two spellings of one action read as
+two actions.
+
+**On the hard cap — measured, not removed.** vjt called the limit MOOT under
+the ruling; it is still in the tree and this change did not touch it, because
+what it now does is narrow and real: above 5 messages the *Paste* door
+disappears, leaving upload-or-cancel. The measurement that matters is that
+**`PASTE_HARD_MESSAGE_LIMIT = 5` is numerically the server's own burst
+allowance** — `config :grappa, :send_throttle, capacity: 5, refill_per_sec:
+0.5`, read from bahamut's flood ladder. So the cap is exactly "how many
+messages leave without the composer dropping into a paced drip", and past it
+`sendBodyLines` (#666) paces on the server's 429 retry-after — roughly one line
+per 2s, never dropping. A 40-line paste was never a disconnect; it was 80
+seconds of drip.
+
+That makes the cap defensible and its *documentation* wrong: `pasteFlood.ts`
+calls the number "deliberately not derived from anything the server tells us",
+while it silently duplicates a server constant that no wire field publishes. If
+an operator retunes `:send_throttle`, the client ceiling diverges in silence.
+Whether to publish `capacity` on `GET /api/config` (additive, no protocol bump)
+and derive the ceiling, or to keep the literal and document the coupling, is
+vjt's call — a shipped guard is not something to delete on the way past.


### PR DESCRIPTION
Completes the two conditions vjt set on #816 in the acceptance comment
(2026-08-06 10:12Z). Both were unshipped: the audit that marked the issue
`soon` had measured their absence, not their presence.

## 1. Shift+Enter speaks

It still inserts nothing and sends nothing — a newline cannot travel inside a
PRIVMSG, so honouring the key means splitting into N messages. What changes is
that the refusal is no longer silent. A key that does nothing is
indistinguishable from a broken key, and every other chat app the operator uses
honours that combination.

It now shows **"IRC does not support multi-line messages"** — the ruling's
wording verbatim — on the existing #356 feedback seam, as a NOTICE
(`role=status`, self-clearing) rather than an error: nothing failed.

The old vitest **pinned the silence**. It was rewritten, not supplemented — a
second assertion beside the old one would have left two contradictory truths in
the file.

## 2. The .txt door is a choice, not a punishment

It shipped as the affirmative on the **over-cap** dialog only, i.e. reachable
exclusively after the operator had already been refused. The under-cap confirm
now carries it as a third door beside Cancel and Paste.

The door lives in the confirm **store**, not the paste guard: `ConfirmRequest`
gains `alternative: {label, onSelect} | null` and a `chooseAlternative()` verb
exclusive with `acceptConfirm()`. **Required**, not optional — all five existing
call sites write `alternative: null` explicitly, so a two-button dialog is a
stated fact rather than an inferred absence. No new category, no new server
surface: `text/plain` is already an accepted `document` MIME and the existing
`dropUpload` does the work, so the wire still carries text + a clickable link
(the 📸 model). Both arms now share one label, `"Upload as .txt"` — the over-cap
affirmative said `"Upload as file"`, and two spellings of one action read as two
actions.

## The hard cap: measured, not removed

`PASTE_HARD_MESSAGE_LIMIT = 5` is untouched, deliberately — deleting a shipped
guard is not a drive-by. **The measurement:** that 5 is numerically the server's
own burst allowance (`config :grappa, :send_throttle, capacity: 5,
refill_per_sec: 0.5`, read from bahamut's flood ladder). So the ceiling is
exactly "how many messages leave before the composer drops into a paced drip" —
past it `sendBodyLines` (#666) paces on the server's 429 retry-after, ~1 line
per 2s, never dropping. A 40-line paste was never a disconnect; it was ~80s of
drip.

That makes the guard defensible and its own comment wrong: `pasteFlood.ts` calls
the number "deliberately not derived from anything the server tells us" while
silently duplicating a server constant that no wire field publishes. Retune
`:send_throttle` and the client ceiling diverges in silence.

**Recommendation, for vjt to rule on:** keep the cap. Either publish `capacity`
on `GET /api/config` (additive, no protocol bump) and derive the ceiling, or
keep the literal and document the coupling. Not done here.

## Tests

vitest red first on both behaviours, then green:

- `ComposeBox.test.tsx` — Shift+Enter says why (plus a plain-Enter control that
  the notice does NOT fire on an ordinary send); the under-cap alternative
  exists, uploads `text/plain` with the paste's own bytes, never touches the
  draft, and does not displace the Paste affirmative.
- `confirmDialog.test.ts` — `chooseAlternative` fires only its own closure, is
  exclusive with `acceptConfirm`, and is a safe no-op with no alternative.
- `ConfirmModal.test.tsx` — the button is absent on a two-button request,
  renders its label and closes on click.

e2e (written here, run by CI — the STACK lane is held elsewhere):

- `issue816-shift-enter-speaks.spec.ts` — the line RENDERS in a real browser,
  the draft keeps no line break, nothing reaches the channel; positive control
  that a plain Enter does send the same draft.
- `issue80-paste-flood-guard.spec.ts` — the under-cap dialog shows three doors,
  Cancel fires neither, the alternative drives the whole upload chain to a 📄
  link with no burst, and the Paste door still pastes. The over-cap arm asserts
  there is NO third button up there.

Local gates on a clean tree: `WRITABLE_CIC=1 bun run check` rc=0, `bun run test`
rc=0 (243 files, 4484 tests).

## What I refuse to assert

- **That the e2e specs pass.** They were written, never executed — the STACK
  lane belongs to another worker. CI is their first run.
- **That `tsc -p e2e` is clean.** It cannot resolve `@playwright/test` in this
  worktree (e2e deps not installed); the failure is environmental, and the
  specs' types are unverified locally.
- **That three buttons lay out well at every width.** `.confirm-modal-actions`
  got `flex-wrap`, but no browser rendered it here — darwin has no local
  browser measurement. Geometry is CI's word, not mine.
- **That the cap should go.** The ruling called it moot; the measurement says it
  still removes the Paste door above the server's burst. That is vjt's call.