### PR TITLE
cic(#947): let the divider count the conversation, not the page

### DIFF
--- a/cicchetto/e2e/tests/issue947-unread-divider-count.spec.ts
+++ b/cicchetto/e2e/tests/issue947-unread-divider-count.spec.ts
@@ -1,0 +1,167 @@
+// #947 — the in-pane unread divider labels itself with the page size.
+//
+// This is the notch AFTER #693. That change suppressed the divider for a pane
+// sitting far behind, because a count taken from the loaded rows would have
+// described the tail page rather than the abandoned region — "a confident
+// wrong number in the one place the operator reads to decide where they left
+// off" — and handed the true, server-measured count to the pinned
+// "N unread — jump back" bar instead (see `issue161-forward-paging.spec.ts`,
+// which pins that state).
+//
+// Taking the jump was the case nobody followed through on. `jumpToUnread`
+// refetches `after(resumeFrom, PAGE_LIMIT)` — ONE page out of a gap that is
+// > 200 by the very definition of far-behind — REPLACES the pane with it, and
+// clears the far-behind flag. Clearing the flag un-suppresses the divider,
+// whose count is recomputed from the rows now loaded: exactly 200, every
+// time, for every window in this state. The operator taps a bar reading
+// "239 unread" and lands two hundred milliseconds later on
+// "── 200 unread messages ──". The fetch cap, surfacing as a fact about the
+// conversation.
+//
+// The fix keeps loaded-row math for the divider's PLACEMENT (it must sit
+// between the last read row and the first unread row actually in the pane —
+// no server count knows where that is) and takes the LABEL from the
+// measurement the jump already had in hand: the same `missed` number the bar
+// advertised, stamped with the cursor it was measured after so it expires by
+// itself once the frozen divider re-latches somewhere else.
+//
+// The discriminating assertion is therefore NOT "the divider is present" but
+// "the number you tapped is the number you land on". Against the unfixed
+// client the divider reads exactly `MAX_HTTP_LIMIT`; the bar's count and the
+// divider's count disagree, and the spec is RED on both halves.
+//
+// Seeding mirrors the #693 spec: the shared seeder plants 200 rows in #bofh
+// and this needs unread > 200, so it re-seeds via the admin
+// `resetSubject(baselineSeed)` surface. The wrapped `test` fixture's afterEach
+// truncates #bofh back to the baseline, so no manual row cleanup is needed;
+// `restoreReadCursorToTail` in afterAll undoes the early cursor (BUGHUNT-3
+// cascade rule — a spec that leaves a mid-list cursor behind makes every
+// downstream spec open its pane at a divider instead of at the tail).
+
+import { expect, test } from "../fixtures/test";
+import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import {
+  fetchAllMessagesAsc,
+  resetSubject,
+  restoreReadCursorToTail,
+  setReadCursorToId,
+} from "../fixtures/grappaApi";
+import {
+  AUTOJOIN_CHANNELS,
+  getSeededAdmin,
+  getSeededVjt,
+  NETWORK_SLUG,
+  VJT_USER,
+} from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Larger than the 200-row server cap, so a cursor planted early leaves a gap
+// the resume cannot drain in one page — the far-behind precondition.
+const LARGE_SEED_COUNT = 260;
+const SEED_SENDER = "seed-bot";
+
+// The server's `@max_http_limit` and the client's `PAGE_LIMIT`. The number the
+// unfixed divider reports, and therefore the number this spec must see the
+// divider NOT report.
+const MAX_HTTP_LIMIT = 200;
+
+// Rows left after the planted cursor. Above the cap (so the pane goes far
+// behind and the jump's after-page comes back FULL), and close enough to it
+// that a saturated label and an honest one are plainly different numbers.
+const UNREAD_TARGET = 240;
+
+const countIn = (label: string, what: string): number => {
+  const match = label.match(/(\d+)/);
+  if (!match?.[1]) {
+    throw new Error(`#947 spec: ${what} carries no count: ${JSON.stringify(label)}`);
+  }
+  return Number(match[1]);
+};
+
+test.describe("#947 — the unread divider counts the conversation, not the page", () => {
+  test.use({ viewport: { width: 800, height: 300 } });
+
+  test.afterAll(async () => {
+    if (!CHANNEL) return;
+    const vjt = getSeededVjt();
+    await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
+  });
+
+  test("jumping back into the unread region keeps the count the affordance advertised", async ({
+    page,
+  }) => {
+    if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+    const vjt = getSeededVjt();
+    const admin = getSeededAdmin();
+
+    await resetSubject(
+      admin.token,
+      VJT_USER,
+      { [NETWORK_SLUG]: AUTOJOIN_CHANNELS },
+      { [NETWORK_SLUG]: [{ name: CHANNEL, seedCount: LARGE_SEED_COUNT, seedSender: SEED_SENDER }] },
+    );
+
+    const rows = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, CHANNEL);
+    expect(rows.length).toBeGreaterThan(UNREAD_TARGET);
+
+    const lastReadRow = rows[rows.length - UNREAD_TARGET];
+    if (!lastReadRow) throw new Error("#947 spec: seeded #bofh rows missing cursor index");
+    const rowsAfterCursor = rows.filter((r) => r.id > lastReadRow.id).length;
+    // Guard the precondition: below this the pane never goes far behind and
+    // the spec would pass by testing nothing.
+    expect(rowsAfterCursor).toBeGreaterThan(MAX_HTTP_LIMIT);
+
+    // Plant the cursor BEFORE login so the channel hydrates with it and takes
+    // the cursor-present fetch arm.
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, lastReadRow.id);
+
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, CHANNEL);
+
+    // The bar renders only once the resume has probed the count and decided
+    // the gap is undrainable — the readiness signal for the far-behind arm.
+    const jumpButton = page.locator('[data-testid="far-behind-jump"]');
+    await expect(jumpButton).toBeAttached({ timeout: 10_000 });
+
+    // The number the operator is about to tap. Uncapped (#693), so strictly
+    // above the page limit — otherwise the two numbers could agree by
+    // coincidence and the assertion below would prove nothing.
+    const advertised = countIn(await jumpButton.innerText(), "the jump-back bar");
+    expect(advertised).toBeGreaterThan(MAX_HTTP_LIMIT);
+    expect(advertised).toBeLessThanOrEqual(rowsAfterCursor);
+
+    await jumpButton.click();
+
+    // The swap landed: the bar is gone and the divider is back, now that the
+    // pane is anchored at the read position again.
+    await expect(page.locator('[data-testid="far-behind-bar"]')).toHaveCount(0);
+    const marker = page.locator('[data-testid="unread-marker"]');
+    await expect(marker).toBeVisible({ timeout: 10_000 });
+
+    // THE assertion. The unfixed client reads exactly MAX_HTTP_LIMIT here,
+    // because it recounted the one page the jump could carry.
+    const shown = countIn(await marker.innerText(), "the unread divider");
+    expect(shown).toBe(advertised);
+    expect(shown).toBeGreaterThan(MAX_HTTP_LIMIT);
+
+    // Placement is still loaded-row math, and must not have moved: the last
+    // read row sits ABOVE the divider, the first unread row BELOW it. A label
+    // fix that relocated the divider would be a worse bug than the label.
+    // Day separators are not in this selector, so adjacency here is exactly
+    // "the row before / after the divider" in the message flow.
+    const flow = await page
+      .locator('[data-testid="unread-marker"], [data-testid="scrollback-line"]')
+      .evaluateAll((nodes) =>
+        nodes.map((n) =>
+          n.getAttribute("data-testid") === "unread-marker" ? "MARKER" : n.getAttribute("data-msg-id"),
+        ),
+      );
+    const markerAt = flow.indexOf("MARKER");
+    expect(markerAt).toBeGreaterThan(0); // read context above it
+    expect(flow[markerAt - 1]).toBe(String(lastReadRow.id));
+    const firstUnread = rows.find((r) => r.id > lastReadRow.id);
+    if (!firstUnread) throw new Error("#947 spec: no row after the planted cursor");
+    expect(flow[markerAt + 1]).toBe(String(firstUnread.id));
+  });
+});

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -46,6 +46,7 @@ import {
   lastOwnSend,
   loadMore as loadMoreScrollback,
   loadNewer as loadNewerScrollback,
+  measuredUnreadByChannel,
   ownSendSubmitted,
   refreshScrollback,
   scrollbackByChannel,
@@ -1383,6 +1384,22 @@ const ScrollbackPane: Component<Props> = (props) => {
               !isOwnPresenceEvent(m, ownNick),
           ).length
         : 0;
+    // #947 — the LABEL, which is not always the count above. `unreadCount`
+    // can only see rows the pane holds, and a pane resumed by a #693 jump
+    // holds one page out of a gap that was >200 by definition — so it would
+    // read exactly the page size, the fetch cap surfacing as a fact about the
+    // conversation. When the fetch that filled this pane measured the region
+    // server-side, that measurement is the label. Its `at` stamp is what
+    // makes spending it safe: it answers "how many rows follow THIS cursor",
+    // so it applies only while the divider is still frozen against that same
+    // cursor and expires by itself the moment the freeze re-latches.
+    //
+    // PLACEMENT stays with `unreadCount` and the loop below: the divider has
+    // to sit between the last read row and the first unread row actually in
+    // the pane, and no server count knows where that is.
+    const measured = measuredUnreadByChannel()[key()];
+    const unreadLabel =
+      measured !== undefined && measured.at === cursor ? measured.count : unreadCount;
     // Only inject the marker if there are unread messages AND some read messages
     // to show as context above it. When all messages are unread, put the marker
     // at the very top (before index 0). When none are unread, skip the marker.
@@ -1420,7 +1437,7 @@ const ScrollbackPane: Component<Props> = (props) => {
         !isOperatorActionEcho(msg) &&
         !isOwnPresenceEvent(msg, ownNick)
       ) {
-        result.push({ type: "unread-marker", count: unreadCount, id: "unread-marker" });
+        result.push({ type: "unread-marker", count: unreadLabel, id: "unread-marker" });
         markerInjected = true;
         // Day-separator logic: if the previous message (last read) and this first
         // unread message are on different days, the day-separator goes AFTER the

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -89,6 +89,13 @@ const pushOwnSendSubmitted = (key: string) => setOwnSubmitted(key);
 const [farBehind, setFarBehind] = createSignal<
   Record<string, { missed: number; resumeFrom: number }>
 >({});
+// #947 — the server-measured unread count for a pane whose loaded unread
+// region is truncated (set by a jump that could only carry one page back).
+// Stamped with the cursor it was measured `at`, so the pane spends it only
+// while its frozen divider is still anchored to that same cursor.
+const [measuredUnread, setMeasuredUnread] = createSignal<
+  Record<string, { at: number; count: number }>
+>({});
 // Resolves TRUE by default (the swap happened) — the pane chains off the
 // result to stand the marker latch back down on a failed jump.
 const jumpToUnreadSpy = vi.fn((_slug: string, _name: string) => Promise.resolve(true));
@@ -119,6 +126,9 @@ vi.mock("../lib/scrollback", () => ({
   // fires. Signal-backed so a spec can flip a window into the far-behind
   // state after mount, the same way `setScrollback` drives the row list.
   farBehindByChannel: () => farBehind(),
+  // #947 — signal-backed for the same reason as `farBehindByChannel`: a spec
+  // drives the post-jump state (rows swapped, flag cleared, count carried).
+  measuredUnreadByChannel: () => measuredUnread(),
   // Wrapped, not passed by reference: `vi.mock` is hoisted above the spy
   // declarations, so the factory may only DEFER to them.
   jumpToUnread: (slug: string, name: string) => jumpToUnreadSpy(slug, name),
@@ -2111,6 +2121,71 @@ describe("ScrollbackPane", () => {
         ));
         const bar = screen.getByTestId("far-behind-bar");
         expect(screen.getByTestId("scrollback").contains(bar)).toBe(false);
+      });
+    });
+
+    // #947 — the notch after #693. The operator took the jump, so the flag is
+    // gone and the divider is back; but the jump could only carry ONE page of
+    // the gap, so counting the loaded rows reports the page size. The number
+    // they tapped ("3000 unread — jump back") and the number they land on must
+    // be the same number.
+    describe("truncated unread region (#947)", () => {
+      afterEach(() => setMeasuredUnread({}));
+
+      it("labels the divider with the server's count, not the loaded rows", () => {
+        seedReadCursor("freenode", "#grappa", 1);
+        setScrollback({ "freenode #grappa": fixture });
+        setMeasuredUnread({ "freenode #grappa": { at: 1, count: 3000 } });
+        render(() => (
+          <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+        ));
+        expect(screen.getByTestId("unread-marker")).toHaveTextContent("3000 unread messages");
+      });
+
+      it("still PLACES the divider by the loaded rows", () => {
+        // Only the label is carried. Placement stays loaded-row math — the
+        // divider has to sit between the last read row and the first unread
+        // row that is actually in the pane, and no server count can say where
+        // that is.
+        seedReadCursor("freenode", "#grappa", 1);
+        setScrollback({ "freenode #grappa": fixture });
+        setMeasuredUnread({ "freenode #grappa": { at: 1, count: 3000 } });
+        render(() => (
+          <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+        ));
+        const flow = Array.from(
+          screen
+            .getByTestId("scrollback")
+            .querySelectorAll('[data-testid="unread-marker"], .scrollback-line[data-msg-id]'),
+        );
+        const markerAt = flow.findIndex((n) => n.getAttribute("data-testid") === "unread-marker");
+        expect(markerAt).toBeGreaterThan(0); // read context above it
+        expect(flow[markerAt - 1]?.getAttribute("data-msg-id")).toBe(String(fixture[0]?.id));
+        expect(flow[markerAt + 1]?.getAttribute("data-msg-id")).toBe(String(fixture[1]?.id));
+      });
+
+      it("ignores a measurement taken at a DIFFERENT cursor", () => {
+        // Self-invalidating by construction: the count answers "how many rows
+        // are after id 1", so it is meaningless once the divider re-freezes
+        // somewhere else. Falling back to the loaded rows understates; reusing
+        // a stale 3000 would be a confident wrong number that never expires.
+        seedReadCursor("freenode", "#grappa", 1);
+        setScrollback({ "freenode #grappa": fixture });
+        setMeasuredUnread({ "freenode #grappa": { at: 999, count: 3000 } });
+        render(() => (
+          <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+        ));
+        expect(screen.getByTestId("unread-marker")).toHaveTextContent("2 unread messages");
+      });
+
+      it("does not leak another window's measurement into this pane", () => {
+        seedReadCursor("freenode", "#grappa", 1);
+        setScrollback({ "freenode #grappa": fixture });
+        setMeasuredUnread({ "freenode #other": { at: 1, count: 3000 } });
+        render(() => (
+          <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+        ));
+        expect(screen.getByTestId("unread-marker")).toHaveTextContent("2 unread messages");
       });
     });
 

--- a/cicchetto/src/__tests__/selection.test.ts
+++ b/cicchetto/src/__tests__/selection.test.ts
@@ -274,6 +274,38 @@ describe("selection store", () => {
       expect(selection.unreadCounts()[seedKey]).toBe(9);
     });
 
+    // #947 — the seed is NOT an unbounded authority once the pane hydrates.
+    // Filed under the belief that `messagesUnread()` stays server-true while
+    // only the in-pane divider saturates at the fetch cap, so the divider
+    // could simply read the badge. It cannot: the local-rows branch below
+    // OVERRIDES the seed for any key holding rows (local truth wins — the
+    // seed is a sync-time snapshot), so a pane holding a capped page reports
+    // the capped number on BOTH surfaces. Pinned because it is the reason the
+    // divider's honest count has to be carried from the fetch that measured
+    // it rather than read off the badge.
+    it("local rows override a LARGER seed once the key is hydrated", async () => {
+      localStorage.setItem("grappa-token", "tok");
+      const selection = await import("../lib/selection");
+      const scrollback = await import("../lib/scrollback");
+      const key = channelKey("freenode", "#capped");
+      selection.setServerSeedCount(key, { messages: 5000, events: 0 });
+
+      for (let id = 1; id <= 200; id++) {
+        scrollback.appendToScrollback(key, {
+          id,
+          network: "freenode",
+          channel: "#capped",
+          server_time: id,
+          kind: "privmsg",
+          sender: "bob",
+          body: "x",
+          meta: {},
+        });
+      }
+
+      expect(selection.messagesUnread()[key]).toBe(200);
+    });
+
     it("memo splits scrollback rows by content vs presence kind", async () => {
       localStorage.setItem("grappa-token", "tok");
       const selection = await import("../lib/selection");

--- a/cicchetto/src/lib/__tests__/loadInitialScrollback.test.ts
+++ b/cicchetto/src/lib/__tests__/loadInitialScrollback.test.ts
@@ -276,6 +276,59 @@ describe("#693 far-behind resume", () => {
     expect(farBehindByChannel()[key]).toBeUndefined();
   });
 
+  // #947 — the jump refetches ONE page out of a gap that is >200 by the very
+  // definition of far-behind, then clears the flag, which un-suppresses the
+  // #693 divider. Its count is recomputed from the loaded rows, so it reads
+  // exactly the page size — the operator taps "3000 unread — jump back" and
+  // lands on "── 200 unread messages ──". The fetch cap leaking into a
+  // user-visible number, one notch earlier than the case #693 suppressed.
+  //
+  // The honest number is already in hand at that moment (`far.missed`,
+  // measured server-side at `far.resumeFrom`), so keep it instead of dropping
+  // it. Stamped WITH the cursor it was measured at so it self-invalidates: it
+  // applies only while the divider is still frozen against that same cursor.
+  it("a truncated jump keeps the server's count for the divider to label with", async () => {
+    const { loadInitialScrollback, jumpToUnread, measuredUnreadByChannel } = await import(
+      "../scrollback"
+    );
+    const { applyJoinReply } = await import("../readCursor");
+    const { channelKey } = await import("../channelKey");
+    const key = channelKey("net", "#truncated");
+    applyJoinReply("net", "#truncated", 100);
+    countMessagesAfterSpy.mockResolvedValue(3000);
+    listMessagesSpy.mockResolvedValue([row(3100)]);
+    await loadInitialScrollback("net", "#truncated");
+
+    // The jump can only carry ONE page of the 3000 back into the pane.
+    listMessagesAfterSpy.mockResolvedValue(Array.from({ length: 200 }, (_, i) => row(101 + i)));
+    listMessagesSpy.mockResolvedValue([row(100)]);
+    await jumpToUnread("net", "#truncated");
+
+    expect(measuredUnreadByChannel()[key]).toEqual({ at: 100, count: 3000 });
+  });
+
+  it("a jump that drained the whole region records nothing — the rows ARE the count", async () => {
+    // A short page means the pane now holds every unread row, so the
+    // loaded-row count is the truth and a carried number could only go stale
+    // against it. Recording one unconditionally is how a cache starts lying.
+    const { loadInitialScrollback, jumpToUnread, measuredUnreadByChannel } = await import(
+      "../scrollback"
+    );
+    const { applyJoinReply } = await import("../readCursor");
+    const { channelKey } = await import("../channelKey");
+    const key = channelKey("net", "#drained");
+    applyJoinReply("net", "#drained", 100);
+    countMessagesAfterSpy.mockResolvedValue(3000);
+    listMessagesSpy.mockResolvedValue([row(3100)]);
+    await loadInitialScrollback("net", "#drained");
+
+    listMessagesAfterSpy.mockResolvedValue([row(101), row(102)]);
+    listMessagesSpy.mockResolvedValue([row(100)]);
+    await jumpToUnread("net", "#drained");
+
+    expect(measuredUnreadByChannel()[key]).toBeUndefined();
+  });
+
   it("reconnect: a full backfill page with more than a page still missing lands at the tail", async () => {
     const { refreshScrollback, scrollbackByChannel, farBehindByChannel } = await import(
       "../scrollback"

--- a/cicchetto/src/lib/scrollback.ts
+++ b/cicchetto/src/lib/scrollback.ts
@@ -252,6 +252,37 @@ const exports = identityScopedStore((onIdentityChange) => {
     Record<ChannelKey, { missed: number; resumeFrom: number }>
   >({});
 
+  // #947 — "the pane's unread region is TRUNCATED, and here is what the server
+  // said it really holds." Set by a jump that could only carry one page back
+  // out of a gap that is >200 by the definition of far-behind: the flag comes
+  // off, the #693 divider suppression lifts, and a count recomputed from the
+  // loaded rows would read exactly the page size. The operator taps
+  // "3000 unread — jump back" and lands on "── 200 unread messages ──" — the
+  // fetch cap leaking into a user-visible number, one notch after the case
+  // #693 suppressed.
+  //
+  //   * `count` — the same server measurement the jump affordance advertised
+  //     (`far.missed`). Deliberately the SAME number and not a second one:
+  //     it counts rows the divider's predicate would exclude (own-presence,
+  //     operator echoes), so it can run slightly high, and the alternative is
+  //     showing the operator a third figure for one question.
+  //   * `at` — the cursor it was measured after. The record is spent only
+  //     while the frozen divider is still anchored there, which is what makes
+  //     it self-invalidating rather than a cache somebody has to remember to
+  //     sweep: once the freeze re-latches, the answer stops applying on its
+  //     own and the pane falls back to counting rows.
+  const [measuredUnreadByChannel, setMeasuredUnreadByChannel] = createSignal<
+    Record<ChannelKey, { at: number; count: number }>
+  >({});
+
+  const clearMeasuredUnread = (key: ChannelKey): void => {
+    setMeasuredUnreadByChannel((prev) => {
+      if (!(key in prev)) return prev;
+      const { [key]: _drop, ...rest } = prev;
+      return rest;
+    });
+  };
+
   // Send-relatch (2026-06-09): the channel-key of THIS device's most
   // recent own send. `sendMessage` writes it; ScrollbackPane reads it to
   // hide the frozen unread-marker on a focused send ("marker showing +
@@ -286,12 +317,13 @@ const exports = identityScopedStore((onIdentityChange) => {
   });
 
   // Identity-transition cleanup, and the SSOT for what an identity transition
-  // clears. Eleven registered resets fired by the factory's
+  // clears. Twelve registered resets fired by the factory's
   // createEffect(on(token, ...)) — seven Set.clear() (loadedChannels +
   // loadMore{InFlight,Exhausted} + loadNewer{InFlight,Exhausted}, #161 +
-  // refreshInFlight + jumpInFlight, #788) + four signal flushes
+  // refreshInFlight + jumpInFlight, #788) + five signal flushes
   // (scrollbackByChannel + lastOwnSend + ownSendSubmitted, #580 +
-  // farBehindByChannel, #693). Order matches the pre-A3 inline shape.
+  // farBehindByChannel, #693 + measuredUnreadByChannel, #947). Order matches
+  // the pre-A3 inline shape.
   //
   // #788 — the last two are registered here, away from their declarations
   // beside the verbs that own them, precisely BECAUSE that distance is how
@@ -320,6 +352,7 @@ const exports = identityScopedStore((onIdentityChange) => {
   onIdentityChange(() => setLastOwnSend(null));
   onIdentityChange(() => setOwnSendSubmitted(null));
   onIdentityChange(() => setFarBehindByChannel({}));
+  onIdentityChange(() => setMeasuredUnreadByChannel({}));
 
   // Insert an incoming message into the per-channel ascending list at its
   // (server_time, id) position, deduping by id. REST + WS can overlap: the
@@ -405,6 +438,16 @@ const exports = identityScopedStore((onIdentityChange) => {
     // with the loaded rows while thousands are missing, which is the wrong
     // number the suppression exists to prevent.
     setFarBehindByChannel((prev) => {
+      if (!(oldKey in prev)) return prev;
+      const { [oldKey]: moved, ...rest } = prev;
+      return moved === undefined ? rest : { ...rest, [newKey]: moved };
+    });
+    // #947 — same argument, same migration set (CLAUDE.md #373: a new
+    // nick-keyed store that skips this strands its old-nick rows). The count
+    // is about a conversation, not about a spelling of the peer's nick;
+    // stranded, the relabeled pane falls back to counting its truncated rows
+    // and shows the page size — the number this record exists to replace.
+    setMeasuredUnreadByChannel((prev) => {
       if (!(oldKey in prev)) return prev;
       const { [oldKey]: moved, ...rest } = prev;
       return moved === undefined ? rest : { ...rest, [newKey]: moved };
@@ -576,6 +619,19 @@ const exports = identityScopedStore((onIdentityChange) => {
       // the new oldest row — both latches are stale.
       loadNewerExhausted.delete(key);
       loadMoreExhausted.delete(key);
+      // #947 — a FULL page says the unread region did not fit, so the divider
+      // about to be un-suppressed cannot count it. Hand it the number we
+      // already measured rather than dropping it here and letting the pane
+      // report the page size. A SHORT page drained the whole region: the rows
+      // ARE the count, and a carried number could only go stale against them.
+      if (afterPage.length === PAGE_LIMIT) {
+        setMeasuredUnreadByChannel((prev) => ({
+          ...prev,
+          [key]: { at: far.resumeFrom, count: far.missed },
+        }));
+      } else {
+        clearMeasuredUnread(key);
+      }
       clearFarBehind(key);
       return true;
     } catch (err) {
@@ -1108,6 +1164,8 @@ const exports = identityScopedStore((onIdentityChange) => {
     // #693 — the rows the far-behind record points back to were just deleted
     // server-side; offering to jump into them would 404 the affordance.
     clearFarBehind(key);
+    // #947 — and the count of those rows is now a count of nothing.
+    clearMeasuredUnread(key);
     if (hasSignal) {
       setScrollbackByChannel((prev) => {
         const { [key]: _drop, ...rest } = prev;
@@ -1138,6 +1196,7 @@ const exports = identityScopedStore((onIdentityChange) => {
     loadInitialScrollback,
     loadMore,
     loadNewer,
+    measuredUnreadByChannel,
     purgeScrollback,
     renameScrollbackKey,
     refreshScrollback,
@@ -1156,6 +1215,7 @@ export const jumpToUnread = exports.jumpToUnread;
 export const loadInitialScrollback = exports.loadInitialScrollback;
 export const loadMore = exports.loadMore;
 export const loadNewer = exports.loadNewer;
+export const measuredUnreadByChannel = exports.measuredUnreadByChannel;
 export const purgeScrollback = exports.purgeScrollback;
 export const renameScrollbackKey = exports.renameScrollbackKey;
 export const refreshScrollback = exports.refreshScrollback;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -31460,3 +31460,62 @@ which the deploy preflight reads as COLD — for packages that are not in the
 prod release, so the COLD buys no production security. Worth folding into the
 next COLD-forcing change rather than shipping alone. `mix deps.audit` remains
 the hard CVE gate throughout and is untouched.
+
+## 2026-08-06 — #947: the divider counts the conversation, the pane counts its rows
+
+The in-pane `── N unread messages ──` divider reported exactly **200** for any
+window resumed by a #693 jump-back. Not a random number: 200 is the server's
+`@max_http_limit` and the client's `PAGE_LIMIT`, and the divider was recounting
+the rows the pane happened to hold.
+
+**#693 already solved this one notch earlier and stopped there.** While a pane
+is far behind, the divider is suppressed precisely because a loaded-row count
+would be "a confident wrong number in the one place the operator reads to
+decide where they left off", and the true server-measured count goes to the
+pinned "N unread — jump back" bar instead. Taking the jump was the case nobody
+followed through on: `jumpToUnread` refetches `after(resumeFrom, PAGE_LIMIT)` —
+one page out of a gap that is >200 *by the definition of far-behind* — replaces
+the pane, and clears the flag. Clearing the flag un-suppresses the divider, and
+`far.missed` is dropped on the floor at the exact moment the label needs it. The
+operator taps a bar reading "239 unread" and lands on "── 200 unread messages
+──". Two numbers for one question, the second one wrong, decided by a fetch cap.
+
+**The issue's suggested fix was a no-op, and that is worth recording.** #947
+proposed taking the label from `selection.ts`'s `messagesUnread()`, described as
+the authoritative unbounded seed. It is not, once the pane hydrates:
+`perChannelUnread`'s local-rows branch *overrides* the seed for any key holding
+rows (local truth wins — the seed is a sync-time snapshot). Measured, not
+argued: with a 5000 seed and 200 loaded rows past the cursor, `messagesUnread()`
+returns **200**. The badge and the divider saturate identically, so reading one
+off the other would have replaced 200 with 200. The premise that "the two
+disagree" only holds while far-behind is SET — and there the divider is
+suppressed, so there is no second number to disagree with. Pinned by
+`selection.test.ts` "local rows override a LARGER seed once the key is
+hydrated", so the next reader does not re-derive it.
+
+**What shipped.** `scrollback.ts` gains `measuredUnreadByChannel`:
+`{at, count}` per key, written by `jumpToUnread` only when the after-page came
+back at the cap (a short page drained the region, so the rows ARE the count and
+a carried number could only go stale against them). `count` is deliberately the
+SAME `far.missed` the bar advertised rather than a second measurement — it
+counts rows the divider's predicate excludes (own-presence, operator echoes) and
+so can run slightly high, but showing the operator a third figure for one
+question is worse than showing a consistent one.
+
+**`at` is the whole design.** It stamps the cursor the count was measured after,
+and the pane spends the record only while its frozen divider is still anchored
+there. That makes the store self-invalidating instead of a cache somebody has to
+remember to sweep: once the freeze re-latches, the answer stops applying on its
+own. It still joins the two registers that exist for this class of state — the
+identity-transition reset list and the #373 `renameScrollbackKey` migration set
+(a count is about a conversation, not about a spelling of the peer's nick).
+
+**Placement stays loaded-row math.** The divider has to sit between the last
+read row and the first unread row actually in the pane; no server count knows
+where that is. Only the label moved.
+
+**Out of scope, deliberately.** The other path that shows a saturated divider is
+a cold open whose gap probe *failed* — `loadInitialScrollback` then keeps the
+anchored resume and loads one page of an unknown gap. There is no honest number
+to show there, because the failure of the probe is exactly the absence of the
+measurement. Left alone rather than guessed at.


### PR DESCRIPTION
Refs #947.

## The defect

The in-pane `── N unread messages ──` divider reads exactly **200** for any window resumed by a #693 jump-back. 200 is the server's `@max_http_limit` and the client's `PAGE_LIMIT` — the divider was recounting the rows the pane happened to hold, so the fetch cap surfaced as a fact about the conversation.

#693 solved this one notch earlier and stopped there. While a pane is far behind the divider is *suppressed*, precisely because a loaded-row count would be "a confident wrong number in the one place the operator reads to decide where they left off", and the server-measured count goes to the pinned `N unread — jump back` bar instead.

Taking the jump was the case nobody followed through on. `jumpToUnread` refetches `after(resumeFrom, PAGE_LIMIT)` — one page out of a gap that is >200 *by the definition of far-behind* — replaces the pane, and clears the flag. Clearing the flag un-suppresses the divider, and `far.missed` is dropped on the floor at the exact moment the label needs it. You tap a bar reading "239 unread" and land on "── 200 unread messages ──".

## The issue's suggested fix is a no-op — measured, not argued

#947 proposes taking the label from `selection.ts`'s `messagesUnread()`, described as the authoritative unbounded seed. **It is not, once the pane hydrates.** `perChannelUnread`'s local-rows branch *overrides* the seed for any key holding rows.

Measured: with a **5000** seed and **200** loaded rows past the cursor, `messagesUnread()` returns **200**. Badge and divider saturate identically — reading one off the other would have replaced 200 with 200.

The issue's paired symptom ("the badge shows the real larger number, so the two disagree") only holds while far-behind is SET, and there the divider is *suppressed*, so there is no second number to disagree with. Pinned in `selection.test.ts` so the next reader does not re-derive it.

## What shipped

- `scrollback.ts` — `measuredUnreadByChannel`: `{at, count}` per key, written by `jumpToUnread` **only** when the after-page came back at the cap. A short page drained the region, so the rows ARE the count and a carried number could only go stale against them.
- `count` is deliberately the **same** `far.missed` the bar advertised, not a second measurement. It counts rows the divider's predicate excludes (own-presence, operator echoes) so it can run slightly high — but a third figure for one question is worse than a consistent one.
- **`at` is the whole design.** It stamps the cursor the count was measured after; the pane spends the record only while its frozen divider is still anchored there. Self-invalidating, not a cache somebody has to remember to sweep. It still joins the identity-transition reset list and the #373 `renameScrollbackKey` migration set (a count is about a conversation, not a spelling of the peer's nick).
- **Placement stays loaded-row math.** The divider must sit between the last read row and the first unread row actually in the pane; no server count knows where that is. Only the label moved.

## Deliberately out of scope

A cold open whose gap probe **failed** also shows a saturated divider — `loadInitialScrollback` then keeps the anchored resume and loads one page of an unknown gap. There is no honest number to show there: the failure of the probe is exactly the absence of the measurement. Left alone rather than guessed at.

## Test plan

- [x] RED observed before the fix: `Expected "3000 unread messages" / Received "2 unread messages"`.
- [x] **Mutation-measured**: neutering the `afterPage.length === PAGE_LIMIT` arm turns the carrier test red, so the test binds to the change rather than passing alongside it.
- [x] `scripts/bun.sh install` — rc 0
- [x] `WRITABLE_CIC=1 scripts/bun.sh run check` — rc 0; `tsc --noEmit` also run standalone (rc 0), since `check` short-circuits it on a biome failure
- [x] `scripts/bun.sh run test` — rc 0, **243 files / 4481 tests passed**
- [x] e2e spec `issue947-unread-divider-count.spec.ts` contributes **0** of the 26 pre-existing `tsc -p e2e` errors
- [ ] e2e **written, not run** — the STACK lane belongs to another worker; CI runs it. Asserts the user-visible contract: the number you tap is the number you land on, and the divider has not moved.