### PR TITLE
cic(#793): put the invite link back on `?go=`, plus the DCC non-goal

### DIFF
--- a/NON-GOALS.md
+++ b/NON-GOALS.md
@@ -19,6 +19,13 @@ belongs elsewhere — in a bot on the network, or behind a plain link.
 - **No inline image display** — #315. Image URLs stay URLs; the client renders
   text. Uploading and sharing a link is fine — embedding and rendering media in
   the scrollback is not.
+- **No DCC** — #167. No IRC-native peer-to-peer file transfer or chat (DCC
+  SEND, DCC CHAT). Sharing a file means uploading it to grappa and posting the
+  link, which is already how images, video and documents work; DCC instead
+  needs a direct connection between two clients, and the always-on bouncer
+  sitting between them is the wrong thing to broker it. This has been in
+  `README.md`'s out-of-scope list since `3c7a0357` — it is written here so the
+  answer is in one place.
 
 ## Why keep a list of things we won't build
 

--- a/cicchetto/e2e/tests/issue793-invite-link.spec.ts
+++ b/cicchetto/e2e/tests/issue793-invite-link.spec.ts
@@ -1,22 +1,25 @@
-// #793 — a shareable invite link, `irc.sindro.me/<network>/<channel>`, is a
-// URL you can paste to a normal person: they click it, they are ASKED, and
+// #793 — a shareable invite link, `irc.sindro.me/?go=<network>/<channel>`, is
+// a URL you can paste to a normal person: they click it, they are ASKED, and
 // they land in the channel.
 //
 // What is proven here is the user-visible chain, end to end against the live
 // bahamut-test leaf, not the existence of a parser:
-//   1. Opening the app AT the invite path pops the shared ConfirmModal naming
+//   1. Opening the app AT the invite URL pops the shared ConfirmModal naming
 //      the channel; confirming JOINs it and switches to the window. The
-//      address bar is left clean, so a refresh does not re-fire the invite.
+//      address bar is left clean once the invite is spent, so a refresh does
+//      not re-fire it.
 //   2. An invite to a channel we are already in switches straight there with
 //      NO modal (#648's rule: asking to join an open window is noise).
 //   3. An invite naming a network this account has not bound joins nothing
 //      and says so — the branch #793 leaves open (cross-user network
 //      identity) must be a visible dead end, never a silent one.
 //
-// Before #793 the SPA had no route for a two-segment path at all: the server
-// served index.html (#399) and the router matched nothing, so the link
-// rendered a blank page. That is what test 1 fails on if the boot reader
-// stops rewriting the URL.
+// `?go=` is a query param on `/`, deliberately: vjt asked for it in those
+// words so an invite could never collide with a client route. The first
+// shipment used `/<network>/<channel>` instead and had to keep a denylist of
+// reserved first segments to stay out of `/share/:token`'s way. Nothing here
+// depends on the path any more, which is the property that made the denylist
+// unnecessary.
 
 import type { Page } from "@playwright/test";
 import { expect, test } from "../fixtures/test";
@@ -36,18 +39,20 @@ import { getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
 
 // Lowercase throughout: raw == ASCII-folded, so the sidebar window key (the
 // folded key IS the display) equals the spelling asserted on. The raw-vs-
-// folded split of the invite path itself is pinned by the inviteLink unit
+// folded split of the invite value itself is pinned by the inviteLink unit
 // test (`#BoFH`), which is the cheaper place for a casing matrix.
 const freshChannel = (label: string) => `#i793${label}-${crypto.randomUUID().slice(0, 6)}`;
 
-// The link carries the channel WITHOUT its `#`: a literal `#` in a URL is the
-// fragment delimiter and would never reach the server. The bare spelling is
-// the one a human pastes, and the parser implies the sigil.
-const invitePath = (networkSlug: string, channel: string) =>
-  `/${networkSlug}/${channel.replace(/^#/, "")}`;
+// Links are written by hand — there is no generator in the product, by vjt's
+// ruling — so this helper IS the canonical spelling, and it is the shape the
+// docs quote. The channel travels WITHOUT its `#` (a literal `#` starts the
+// fragment and the value would truncate; the parser implies the sigil), and
+// each component is encoded on its own so the `/` separator survives.
+const inviteUrl = (networkSlug: string, channel: string) =>
+  `/?go=${encodeURIComponent(networkSlug)}/${encodeURIComponent(channel.replace(/^#/, ""))}`;
 
 // Auth is pre-seeded the way `loginAs` does it, but the navigation target is
-// the invite path rather than `/` — `loginAs` always gotos the root.
+// the invite URL rather than `/` — `loginAs` always gotos the bare root.
 async function openInvite(page: Page, vjt: SeededUser, path: string): Promise<void> {
   await page.addInitScript(
     ([token, subjectJson]) => {
@@ -64,7 +69,7 @@ test("an invite link asks, then joins and switches (#793)", async ({ page }) => 
   const vjt = getSeededVjt();
   const target = freshChannel("join");
 
-  await openInvite(page, vjt, invitePath(NETWORK_SLUG, target));
+  await openInvite(page, vjt, inviteUrl(NETWORK_SLUG, target));
 
   // Discriminating probe: the invite reader sets this only after it has
   // ROUTED a parsed target, so the assertions below cannot pass off the back
@@ -79,7 +84,9 @@ test("an invite link asks, then joins and switches (#793)", async ({ page }) => 
 
   // Address bar already clean — the invite is spent, a refresh re-fires
   // nothing. Asserted BEFORE the confirm so it is the reader being tested,
-  // not some later navigation.
+  // not some later navigation. The `?go=` is dropped by the SAME step that
+  // routes the target, so waiting on the applied flag is what makes this
+  // deterministic rather than a poll against a boot-time rewrite.
   expect(new URL(page.url()).pathname).toBe("/");
   expect(new URL(page.url()).search).toBe("");
 
@@ -112,7 +119,7 @@ test("an invite to a channel we are already in switches with NO modal (#793)", a
     .toContain(already);
 
   try {
-    await openInvite(page, vjt, invitePath(NETWORK_SLUG, already));
+    await openInvite(page, vjt, inviteUrl(NETWORK_SLUG, already));
     await page.waitForFunction(() => window.__cicInviteLinkApplied === true, null, {
       timeout: 15_000,
     });
@@ -129,7 +136,7 @@ test("an invite to a channel we are already in switches with NO modal (#793)", a
 test("an invite for an unbound network joins nothing and says so (#793)", async ({ page }) => {
   const vjt = getSeededVjt();
 
-  await openInvite(page, vjt, invitePath("nowhere-bound", "somechannel"));
+  await openInvite(page, vjt, inviteUrl("nowhere-bound", "somechannel"));
   await page.waitForFunction(() => window.__cicInviteLinkApplied === true, null, {
     timeout: 15_000,
   });

--- a/cicchetto/src/__tests__/inviteLink.test.ts
+++ b/cicchetto/src/__tests__/inviteLink.test.ts
@@ -3,17 +3,22 @@ import { confirmJoinChannel, switchToChannelWindow } from "../lib/channelJoin";
 import {
   dismissInviteToast,
   inviteToasts,
-  parseInviteLinkPath,
+  parseInviteLinkUrl,
   routeInviteTarget,
 } from "../lib/inviteLink";
 
-// #793 — shareable channel invite links: `irc.sindro.me/<network>/<channel>`.
+// #793 — shareable channel invite links: `irc.sindro.me/?go=azzurra/sniffo`.
 //
-// Two halves, both here: the PATH parser (the new reader — `pushTarget.ts`
-// only ever read `location.search`) and the ROUTE (what the parsed target
-// does). The route delegates to the #648 join verb rather than reimplementing
-// confirm-then-join, so these assertions are about DELEGATION, not about the
-// modal's internals (ConfirmModal has its own tests).
+// Two halves, both here: the QUERY parser and the ROUTE (what the parsed
+// target does). The route delegates to the #648 join verb rather than
+// reimplementing confirm-then-join, so these assertions are about DELEGATION,
+// not about the modal's internals (ConfirmModal has its own tests).
+//
+// Half of the parse block is about what the BROWSER does to the value before
+// this code ever sees it. `?go=` puts the channel inside a query param, where
+// `#`, `&` and `+` each have a meaning of their own — those cases are pinned
+// against measured behaviour (node's WHATWG URL), not against what the
+// characters "should" do.
 
 vi.mock("../lib/channelJoin", () => ({
   confirmJoinChannel: vi.fn(),
@@ -27,71 +32,125 @@ vi.mock("../lib/networks", () => ({
   channelsBySlug: vi.fn(() => ({ azzurra: [{ id: 10, name: "#bofh" }] })),
 }));
 
-describe("parseInviteLinkPath", () => {
-  it("reads a bare two-segment path and implies the # sigil", () => {
-    expect(parseInviteLinkPath("/azzurra/sniffo")).toEqual({
+describe("parseInviteLinkUrl", () => {
+  it("reads ?go=<network>/<channel> and implies the # sigil", () => {
+    expect(parseInviteLinkUrl("/?go=azzurra/sniffo")).toEqual({
       networkSlug: "azzurra",
       channelName: "#sniffo",
       kind: "channel",
     });
   });
 
-  it("keeps a percent-encoded # sigil instead of doubling it", () => {
-    // `#` cannot travel literally in a path — a browser would read it as the
-    // fragment and the server would never see the segment at all (#755: the
-    // room segment was the one URL component never encoded).
-    expect(parseInviteLinkPath("/azzurra/%23sniffo")?.channelName).toBe("#sniffo");
+  it("reads an absolute URL the same as a relative one", () => {
+    // `location.href` is what the boot reader passes, and it is absolute.
+    expect(parseInviteLinkUrl("https://irc.sindro.me/?go=azzurra/sniffo")?.channelName).toBe(
+      "#sniffo",
+    );
   });
 
-  it("passes the non-# chantypes sigils through untouched", () => {
-    expect(parseInviteLinkPath("/azzurra/&local")?.channelName).toBe("&local");
-    expect(parseInviteLinkPath("/azzurra/+modeless")?.channelName).toBe("+modeless");
-    expect(parseInviteLinkPath("/azzurra/!ABCDEsecret")?.channelName).toBe("!ABCDEsecret");
+  it("ignores the path — a two-segment path is no longer an invite", () => {
+    // The retired form. `?go=` exists precisely so an invite cannot collide
+    // with a client route, so the path must carry no meaning at all here.
+    expect(parseInviteLinkUrl("/azzurra/sniffo")).toBeNull();
+    expect(parseInviteLinkUrl("/share/abc123")).toBeNull();
+  });
+
+  it("takes a percent-encoded # sigil instead of doubling it", () => {
+    expect(parseInviteLinkUrl("/?go=azzurra/%23sniffo")?.channelName).toBe("#sniffo");
+  });
+
+  it("gets nothing from a LITERAL # — the browser eats it as the fragment", () => {
+    // Measured: `new URL("/?go=azzurra/#sniffo")` has search `?go=azzurra/`
+    // and hash `#sniffo`. The channel never reaches the app, so the value is
+    // one segment and the whole invite is refused rather than half-read.
+    // This is #755's lesson in a query param: the room segment is the one URL
+    // component people forget to encode.
+    expect(parseInviteLinkUrl("/?go=azzurra/#sniffo")).toBeNull();
+  });
+
+  it("gets nothing from a LITERAL & — the browser reads it as the next param", () => {
+    // Same shape as the `#` case, different delimiter: `&local` starts a
+    // second query param and `go` truncates to `azzurra/`.
+    expect(parseInviteLinkUrl("/?go=azzurra/&local")).toBeNull();
+  });
+
+  it("reads a literal + as a SPACE, and a space is refused", () => {
+    // `application/x-www-form-urlencoded` decoding turns `+` into a space —
+    // the one delimiter that does NOT truncate the value but silently
+    // rewrites it. A space cannot appear in a channel name, so the forbidden
+    // -byte scan catches it. Encoded (`%2B`), the sigil arrives intact.
+    expect(parseInviteLinkUrl("/?go=azzurra/+modeless")).toBeNull();
+    expect(parseInviteLinkUrl("/?go=azzurra/%2Bmodeless")?.channelName).toBe("+modeless");
+  });
+
+  it("takes the non-# chantypes sigils when they are encoded", () => {
+    expect(parseInviteLinkUrl("/?go=azzurra/%26local")?.channelName).toBe("&local");
+    expect(parseInviteLinkUrl("/?go=azzurra/!ABCDEsecret")?.channelName).toBe("!ABCDEsecret");
+  });
+
+  it("reads a wholly-encoded value, separator slash included", () => {
+    // `encodeURIComponent("azzurra/#sniffo")` escapes the separator too. The
+    // decode restores it, so the over-careful writer gets the same target as
+    // the minimal one.
+    expect(parseInviteLinkUrl(`/?go=${encodeURIComponent("azzurra/#sniffo")}`)).toEqual({
+      networkSlug: "azzurra",
+      channelName: "#sniffo",
+      kind: "channel",
+    });
   });
 
   it("percent-decodes a non-ASCII channel name", () => {
-    expect(parseInviteLinkPath("/azzurra/caff%C3%A8")?.channelName).toBe("#caffè");
+    expect(parseInviteLinkUrl("/?go=azzurra/caff%C3%A8")?.channelName).toBe("#caffè");
   });
 
   it("preserves the raw casing (the display spelling goes on the wire)", () => {
-    expect(parseInviteLinkPath("/azzurra/Sniffo")?.channelName).toBe("#Sniffo");
+    expect(parseInviteLinkUrl("/?go=azzurra/Sniffo")?.channelName).toBe("#Sniffo");
   });
 
   it("tolerates a trailing slash", () => {
-    expect(parseInviteLinkPath("/azzurra/sniffo/")?.channelName).toBe("#sniffo");
+    expect(parseInviteLinkUrl("/?go=azzurra/sniffo/")?.channelName).toBe("#sniffo");
   });
 
-  it("rejects a path that is not exactly two segments", () => {
-    expect(parseInviteLinkPath("/")).toBeNull();
-    expect(parseInviteLinkPath("/azzurra")).toBeNull();
-    expect(parseInviteLinkPath("/azzurra/sniffo/extra")).toBeNull();
+  it("rejects a value that is not exactly two segments", () => {
+    expect(parseInviteLinkUrl("/?go=azzurra")).toBeNull();
+    expect(parseInviteLinkUrl("/?go=azzurra/sniffo/extra")).toBeNull();
   });
 
-  it("rejects the reserved /share/:token client route", () => {
-    // A real two-segment route already exists — without this, a visitor
-    // share link would be read as an invite to network `share`.
-    expect(parseInviteLinkPath("/share/abc123")).toBeNull();
+  it("returns null when there is no go param at all", () => {
+    expect(parseInviteLinkUrl("/")).toBeNull();
+    expect(parseInviteLinkUrl("/?network=azzurra&channel=%23sniffo")).toBeNull();
+    expect(parseInviteLinkUrl("/?go=")).toBeNull();
+  });
+
+  it("returns null on an unparseable URL instead of throwing", () => {
+    expect(parseInviteLinkUrl("http://[")).toBeNull();
   });
 
   it("rejects a channel segment carrying a comma", () => {
     // JOIN takes a comma-separated LIST: an unfiltered comma turns one
     // invite into a multi-channel join the sender never wrote.
-    expect(parseInviteLinkPath("/azzurra/sniffo,bofh")).toBeNull();
-    expect(parseInviteLinkPath("/azzurra/sniffo%2Cbofh")).toBeNull();
+    expect(parseInviteLinkUrl("/?go=azzurra/sniffo,bofh")).toBeNull();
+    expect(parseInviteLinkUrl("/?go=azzurra/sniffo%2Cbofh")).toBeNull();
   });
 
   it("rejects a channel segment carrying whitespace or control bytes", () => {
-    expect(parseInviteLinkPath("/azzurra/sniffo%20bofh")).toBeNull();
-    expect(parseInviteLinkPath("/azzurra/sniffo%0D%0AQUIT")).toBeNull();
-    expect(parseInviteLinkPath("/azzurra/sniffo%07")).toBeNull();
+    expect(parseInviteLinkUrl("/?go=azzurra/sniffo%20bofh")).toBeNull();
+    expect(parseInviteLinkUrl("/?go=azzurra/sniffo%0D%0AQUIT")).toBeNull();
+    expect(parseInviteLinkUrl("/?go=azzurra/sniffo%07")).toBeNull();
   });
 
-  it("rejects a malformed percent-escape instead of throwing", () => {
-    expect(parseInviteLinkPath("/azzurra/%ZZ")).toBeNull();
+  it("keeps a malformed percent-escape verbatim rather than throwing", () => {
+    // Measured, and a DELIBERATE change from the path reader, which decoded
+    // by hand and got a URIError for `%ZZ`. `URLSearchParams` follows WHATWG
+    // and leaves an undecodable sequence as its own bytes, so a typo names a
+    // legal-if-silly channel instead of being refused. Safe because the
+    // consent modal prints the channel it is about to join: the human reads
+    // `#%ZZ` and says no.
+    expect(parseInviteLinkUrl("/?go=azzurra/%ZZ")?.channelName).toBe("#%ZZ");
   });
 
   it("rejects a bare sigil with no name", () => {
-    expect(parseInviteLinkPath("/azzurra/%23")).toBeNull();
+    expect(parseInviteLinkUrl("/?go=azzurra/%23")).toBeNull();
   });
 });
 

--- a/cicchetto/src/lib/inviteLink.ts
+++ b/cicchetto/src/lib/inviteLink.ts
@@ -4,19 +4,32 @@ import { channelsBySlug, networkBySlug } from "./networks";
 import type { PushTarget } from "./pushPayload";
 import { createToastQueue } from "./toasts";
 
-// #793 — shareable channel invite links: paste `https://irc.sindro.me/azzurra/sniffo`
+// #793 — shareable channel invite links: paste `https://irc.sindro.me/?go=azzurra/sniffo`
 // anywhere, the recipient clicks, gets a confirm, and lands in the channel.
 //
-// This is the READ side (decision 5 of the issue): consuming a link. The
-// "copy invite link" affordance in the channel UI is a separate shipment.
+// This is the READ side (decision 5 of the issue): consuming a link. Links are
+// written BY HAND — vjt ruled out a generation UI, a token and an expiry — so
+// there is no builder here. The canonical spelling is therefore written down
+// rather than generated: this comment, the parse tests, `inviteUrl` in the
+// #793 e2e spec, and the DESIGN_NOTES entry. Nothing in the product composes
+// one, and nothing should until the write side (decision 5) is asked for.
+//
+// **`?go=` is the canonical form, and it is a query param on purpose.** vjt's
+// words: *"a query param, deliberately, to avoid the fronting problem (no
+// path-prefix collision with the SPA routes)"*. The first shipment read
+// `/<network>/<channel>` from `location.pathname` instead, which put every
+// invite in the same namespace as every present and future client route —
+// `/login`, `/share/:token`, and whatever comes next — and needed a
+// reserved-segment denylist to keep them apart. A query param has no such
+// namespace to share, so the denylist is gone with it.
 //
 // It is a second ENTRY POINT into the deep-link machinery, not a second
 // subsystem. `pushTarget.ts` already reads `?network=&channel=` at boot,
-// normalises it into a `PushTarget`, and defers routing until `networks()`
-// seeds; the invite path normalises into the SAME `PushTarget` and reuses the
-// SAME reader and the SAME defer (see `applyDeepLinkFromUrl`). Only two things
-// are genuinely new: parsing the PATH (the old reader looked at
-// `location.search` only), and routing to a JOIN instead of a selection.
+// normalises it into a `PushTarget`, and defers routing until its store seeds;
+// the invite normalises into the SAME `PushTarget` and reuses the SAME reader
+// and the SAME defer (see `applyDeepLinkFromUrl`). Only two things are
+// genuinely new: a second param spelling, and routing to a JOIN instead of a
+// selection.
 //
 // The join itself is the #648 verb — `confirmJoinChannel` — untouched: it
 // already owns confirm -> `postJoin` -> switch, and already switches with no
@@ -24,28 +37,25 @@ import { createToastQueue } from "./toasts";
 // implementation, no parallel window state.
 
 // RFC 2812 chantypes. A segment that already starts with one is taken
-// verbatim; a bare segment gets `#` (vjt's `irc.sindro.me/azzurra/sniffo`
-// example — the overwhelming case, and the only spelling a normal person
-// will ever type).
+// verbatim; a bare segment gets `#` (vjt's `?go=azzurra/sniffo` example —
+// "the `#` is implied", the overwhelming case, and the only spelling a normal
+// person will ever type).
 //
-// A literal `#` cannot travel in a path: the browser reads it as the start of
-// the fragment and the server never sees the segment at all. #755 is the
-// precedent for getting this wrong — the room segment there was the one URL
-// component never encoded. So `#` MUST arrive percent-encoded (`%23`), which
-// is also why the bare form exists: `/azzurra/sniffo` is what people paste.
+// Inside a query param the three delimiters bite differently, and all three
+// are pinned by measurement in `inviteLink.test.ts` rather than by reasoning:
+// a literal `#` starts the FRAGMENT (the value truncates and the channel never
+// reaches the app), a literal `&` starts the NEXT PARAM (same truncation), and
+// a literal `+` decodes to a SPACE (the value survives but says something
+// else). Truncation costs a segment, so those two refuse the whole invite;
+// the space is caught by the forbidden-byte scan below. Encoded — `%23`,
+// `%26`, `%2B` — each arrives intact. #755 is the precedent for getting this
+// wrong: the room segment was the one URL component never encoded.
 const CHANTYPES = "#&+!";
-
-// Two-segment client routes that are NOT invites. `/share/:token` (the visitor
-// session-sharing landing) is the only one today; `/login` and `/` are single
-// segment and cannot collide. Everything else two-segment reaching the SPA is
-// an invite — real API/asset paths are answered by the server before the
-// `GET /*path` SPA fallback (#399) ever runs.
-const RESERVED_FIRST_SEGMENT = new Set(["share"]);
 
 // Bytes RFC 2812 forbids inside a channel name, rejected rather than escaped.
 // The comma is the one that matters: JOIN takes a comma-separated LIST, so an
-// unfiltered `/azzurra/sniffo,bofh` would turn one invite into a multi-channel
-// join the sender never wrote. Everything at or below 0x20 covers
+// unfiltered `?go=azzurra/sniffo,bofh` would turn one invite into a
+// multi-channel join the sender never wrote. Everything at or below 0x20 covers
 // NUL/BEL/CR/LF/space, which cannot appear in a real channel and are the shape
 // a frame-injection attempt takes. Deliberately NOT rejecting `:` — also
 // illegal per the RFC, but harmless in a JSON body, and a false reject breaks
@@ -66,31 +76,46 @@ function hasForbiddenChannelByte(name: string): boolean {
 }
 
 /**
- * Parses `/<network>/<channel>` into the same `PushTarget` the push deep-link
- * reader produces. Returns null for anything that is not an invite — a
- * reserved route, a wrong segment count, an undecodable escape, or a channel
- * name carrying bytes IRC forbids.
+ * Parses `?go=<network>/<channel>` into the same `PushTarget` the push
+ * deep-link reader produces. Returns null for anything that is not an invite —
+ * no `go` param, a wrong segment count, or a channel name carrying bytes IRC
+ * forbids.
+ *
+ * Takes a whole URL rather than a query string, absolute or relative, so the
+ * boot reader can hand it `location.href` exactly as it hands the same value
+ * to `parsePushTargetUrl`. The PATH is read for nothing, and that is the whole
+ * point of the shape: a parser that still glanced at the path would keep the
+ * route collision `?go=` was chosen to remove.
+ *
+ * Decoding is `URLSearchParams`', not `decodeURIComponent`'s, and the
+ * difference is deliberate: the WHATWG rules leave an undecodable escape as
+ * its own bytes instead of throwing, so `%ZZ` names a silly channel rather
+ * than being refused. The consent modal prints the channel before anyone
+ * joins it, which is where a typo gets caught by the only reader that can
+ * judge it.
+ *
+ * A value split on `/` also tolerates further components LATER (vjt: "further
+ * path components may be added later") — today anything past the second is
+ * refused rather than ignored, because a silently-dropped component is a lie
+ * about what the link asked for.
  *
  * `kind` is always `"channel"`: unlike `parsePushTargetUrl` there is no
  * sigil-sniffing for a DM target, because a DM invite link is meaningless —
  * the whole point is joining a room.
  */
-export function parseInviteLinkPath(pathname: string): PushTarget | null {
-  const [rawNetwork, rawChannel, ...rest] = pathname.split("/").filter((s) => s.length > 0);
-  if (rawNetwork === undefined || rawChannel === undefined || rest.length > 0) return null;
-  if (RESERVED_FIRST_SEGMENT.has(rawNetwork)) return null;
-
-  let networkSlug: string;
-  let channel: string;
+export function parseInviteLinkUrl(rawUrl: string): PushTarget | null {
+  let url: URL;
   try {
-    networkSlug = decodeURIComponent(rawNetwork);
-    channel = decodeURIComponent(rawChannel);
+    url = new URL(rawUrl, "https://placeholder.invalid");
   } catch {
-    // Malformed percent-escape — `decodeURIComponent` throws URIError.
     return null;
   }
 
-  if (networkSlug.length === 0 || channel.length === 0) return null;
+  const value = url.searchParams.get("go");
+  if (value === null) return null;
+
+  const [networkSlug, channel, ...rest] = value.split("/").filter((s) => s.length > 0);
+  if (networkSlug === undefined || channel === undefined || rest.length > 0) return null;
   if (hasForbiddenChannelByte(channel)) return null;
 
   const channelName = CHANTYPES.includes(channel.charAt(0)) ? channel : `#${channel}`;
@@ -102,8 +127,8 @@ export function parseInviteLinkPath(pathname: string): PushTarget | null {
 
 // Open decision 1 of #793, deliberately NOT settled here: `networkBySlug`
 // resolves against THIS user's bound networks, but an invite is cross-user by
-// definition, so the recipient may have no `azzurra` at all. Whether the path
-// segment becomes a globally-resolvable network identifier or the flow grows
+// definition, so the recipient may have no `azzurra` at all. Whether the
+// network segment becomes a globally-resolvable identifier or the flow grows
 // an "add this network, then join" step is a product decision that has not
 // been taken. What this branch must not do is fail silently: somebody clicked
 // a link and is owed an answer, so it says what it observed and stops.

--- a/cicchetto/src/lib/pushTarget.ts
+++ b/cicchetto/src/lib/pushTarget.ts
@@ -24,7 +24,7 @@
 // selection doesn't fire on a still-loading store.
 
 import { createEffect, untrack } from "solid-js";
-import { parseInviteLinkPath, routeInviteTarget } from "./inviteLink";
+import { parseInviteLinkUrl, routeInviteTarget } from "./inviteLink";
 import { moduleRoot } from "./moduleRoot";
 import { channelsBySlug, networkBySlug, networks } from "./networks";
 import { type PushTarget, parsePushTargetUrl } from "./pushPayload";
@@ -157,13 +157,14 @@ export function installPushTargetListener(): void {
  * short-circuit means a re-fire would no-op anyway, but cleaning
  * the URL removes the question entirely.
  *
- * Invite link (#793): the second shape, `/<network>/<channel>`, read
- * from `location.pathname` by `lib/inviteLink.ts` into the SAME
- * `PushTarget` and deferred by the SAME mechanism. What differs is
- * only what the target DOES on arrival — a confirm-then-join instead
- * of a selection — and when the URL is cleaned. The two shapes cannot
- * co-occur meaningfully; a push payload wins, since it carries an
- * explicit notification the operator just tapped.
+ * Invite link (#793): the second shape, `?go=<network>/<channel>`,
+ * read by `lib/inviteLink.ts` into the SAME `PushTarget` and deferred
+ * by the SAME mechanism. Both shapes are now query params on the same
+ * URL, which is what makes "one reader, two shapes" literally true
+ * rather than a figure of speech. What differs is only what the target
+ * DOES on arrival — a confirm-then-join instead of a selection. The two
+ * cannot co-occur meaningfully; a push payload wins, since it carries
+ * an explicit notification the operator just tapped.
  */
 export function applyDeepLinkFromUrl(): void {
   if (typeof window === "undefined" || !window.location) return;
@@ -184,15 +185,17 @@ export function applyDeepLinkFromUrl(): void {
     return;
   }
 
-  // #793 — the same reader, second URL shape: `/<network>/<channel>`.
-  const invite = parseInviteLinkPath(window.location.pathname);
+  // #793 — the same reader, second URL shape: `?go=<network>/<channel>`.
+  //
+  // No early URL clean, unlike the path form this replaced. That clean existed
+  // because a two-segment path matched no route, so leaving it in the address
+  // bar across `render()` mounted the app on nothing; `?go=` sits on `/`, a
+  // real route, so the router is content and `deferUntilReady`'s own
+  // post-routing clean is the only one needed. One cleaning site, and the
+  // invite stays legible in the address bar for as long as it is still
+  // pending.
+  const invite = parseInviteLinkUrl(window.location.href);
   if (invite === null) return;
-  // Cleaned HERE rather than after the routing (the push path's timing),
-  // because this call happens BEFORE `render()` and the router has no route
-  // for a two-segment path: left in place, the address bar would mount the
-  // app on nothing at all. It also satisfies the same requirement the push
-  // path cleans for — a refresh must not re-fire the invite.
-  if (window.history) window.history.replaceState({}, "", "/");
   deferUntilReady({
     target: invite,
     route: routeInviteTarget,

--- a/cicchetto/src/main.tsx
+++ b/cicchetto/src/main.tsx
@@ -188,10 +188,11 @@ bootstrapAuth();
 // reloaded the SPA at `/` and dropped the deep-link entirely.
 //
 // #793 — the same boot reader also consumes an invite link
-// (`/<network>/<channel>`), which is why it is no longer named after
-// push alone. It MUST stay above `render()`: the invite path is not a
-// route, so the reader rewrites the address bar to `/` before the
-// router ever looks at it.
+// (`?go=<network>/<channel>`), which is why it is no longer named after
+// push alone. Both shapes are query params on `/`, so neither one needs
+// the router's cooperation; the reader captures the target before
+// `render()` and holds it until the store it depends on resolves, which
+// is what lets an invite survive the login round-trip.
 installPushTargetListener();
 applyDeepLinkFromUrl();
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -31618,3 +31618,57 @@ a cold open whose gap probe *failed* — `loadInitialScrollback` then keeps the
 anchored resume and loads one page of an unknown gap. There is no honest number
 to show there, because the failure of the probe is exactly the absence of the
 measurement. Left alone rather than guessed at.
+## 2026-08-06 — #793: the invite link moves to `?go=`, which was the order all along
+
+The read side shipped `/<network>/<channel>` (union #942). vjt's enqueue
+comment on the issue had specified something else, in these words: **"URL
+shape: `?go=azzurra/sniffo` — a query param, deliberately, to avoid the
+fronting problem (no path-prefix collision with the SPA routes)"**. The
+shipment reversed that silently, and the reversal is what this entry corrects.
+It is not a style preference: the query param is load-bearing for the reason
+vjt gave, and the previous entry above documents a design that argued its way
+around the instruction instead of following it.
+
+**Where the collision was.** A path-shaped invite lives in the same namespace
+as every present and future client route, so the parser needed a denylist of
+reserved first segments (`share`, for `/share/:token`) and a standing
+obligation on whoever adds the next route to remember to extend it. `?go=` has
+no namespace to share. The denylist is deleted, not moved.
+
+**The early URL clean goes with it.** The path reader rewrote the address bar
+to `/` before `render()`, because a two-segment path matched no route and the
+app would otherwise mount on nothing. `?go=` sits on `/`, a real route, so
+`deferUntilReady`'s post-routing clean is the only one left — one cleaning
+site, and a pending invite stays legible in the address bar until it is spent.
+The auth round-trip is unchanged: the target is captured in memory before
+`render()`, and cic's redirect to `/login` drops the query string either way,
+so the hard-refresh-on-`/login` corner is still lost and still accepted.
+
+**The delimiters bite differently in a query param, and were measured.** In a
+path the hazard was one character; here there are three, and each fails its own
+way. A literal `#` starts the FRAGMENT, so `?go=azzurra/#sniffo` arrives as
+`azzurra/` — truncated to one segment, and the whole invite is refused rather
+than half-read. A literal `&` starts the NEXT PARAM: same truncation, same
+refusal. A literal `+` is the nasty one, because it does not truncate — form
+decoding turns it into a SPACE, so the value survives while saying something
+else, and it is the existing forbidden-byte scan (anything ≤ 0x20) that catches
+it. Encoded (`%23`, `%26`, `%2B`) all three arrive intact, and
+`encodeURIComponent` over the whole value works too, separator slash included.
+These are pinned by test against node's WHATWG URL, not derived from the specs.
+
+**One behaviour deliberately changed.** The path reader called
+`decodeURIComponent` by hand and returned null when it threw, so `%ZZ` was
+refused. `URLSearchParams` follows WHATWG and leaves an undecodable escape as
+its own bytes, so the same typo now names the legal-if-silly channel `#%ZZ`.
+Left as it is rather than re-adding a validity check: the safety property that
+rejection was protecting is "do not throw", which the new decoder gives for
+free, and the consent modal prints the channel name before anyone joins it —
+the human reading `Join #%ZZ?` is a better judge of a typo than a parser.
+
+**The old path form is NOT accepted in reading.** It shipped at 17:27 today, is
+in no tag (v0.12.0 predates it), and every link is written by hand — vjt ruled
+out a generator, a token and an expiry — so there is no plausible population of
+path-shaped links in the wild to protect. Keeping it as a second accepted form
+would have preserved precisely the route-namespace collision that `?go=` exists
+to remove, in exchange for compatibility with a spelling that existed for one
+evening.


### PR DESCRIPTION
## Perché

vjt's enqueue comment on #793 specified the URL shape in these words:

> **URL shape: `?go=azzurra/sniffo`** — a query param, deliberately, **to avoid the fronting problem** (no path-prefix collision with the SPA routes).

The read side shipped `/<network>/<channel>` instead (PR #939, union #942). Nobody argued the instruction down — it was reversed in silence. This restores it.

The query param is load-bearing for exactly the reason given. A path-shaped invite shares a namespace with every present and future client route, which is why the parser carried a denylist of reserved first segments (`share`, for `/share/:token`) plus an unwritten obligation on whoever adds the next route to extend it. `?go=` has no namespace to share: the denylist is **deleted**, not moved, and the parser reads no path at all.

## Cosa cambia

- `parseInviteLinkPath(pathname)` → `parseInviteLinkUrl(rawUrl)`, reading `?go=` off the whole URL — the same value `parsePushTargetUrl` already gets. One boot reader, two query shapes, now literally rather than as a figure of speech.
- `RESERVED_FIRST_SEGMENT` deleted.
- The early `replaceState` deleted. It only existed because a two-segment path matched no route and would mount the app on nothing across `render()`. `?go=` sits on `/`, so `deferUntilReady`'s post-routing clean is the only one left. The login round-trip is unchanged: the target is captured in memory before `render()` either way.
- **La vecchia forma path NON è accettata in lettura.** It shipped at 17:27 today, is in no tag (v0.12.0 predates it), and every link is hand-written (vjt ruled out a generator, token and expiry) — there is no population of path-shaped links to protect. Accepting both would preserve precisely the collision `?go=` exists to remove, in exchange for compatibility with a spelling that lived one evening.

## Encoding — misurato, non assunto

A path had one hostile character; a query has three, each failing its own way. Pinned against node's WHATWG `URL`:

| written | `go` arrives as | outcome |
|---|---|---|
| `?go=azzurra/#sniffo` | `azzurra/` | fragment ate it → 1 segment → **refused** |
| `?go=azzurra/&local` | `azzurra/` | next param → same truncation → **refused** |
| `?go=azzurra/+modeless` | `azzurra/ modeless` | `+` → **SPACE** → forbidden-byte scan → **refused** |
| `?go=azzurra/%23sniffo` | `azzurra/#sniffo` | ✅ |
| `?go=azzurra/%26local` · `%2Bmodeless` | intact | ✅ |
| `?go=azzurra%2F%23sniffo` | `azzurra/#sniffo` | whole-value encode works, separator included ✅ |

The `+` is the nasty one: it does not truncate, so the value survives while meaning something else.

**Un comportamento cambia di proposito.** The path reader hand-decoded and returned null when `decodeURIComponent` threw, so `%ZZ` was refused. `URLSearchParams` follows WHATWG and leaves an undecodable escape as its own bytes, so the same typo now names `#%ZZ`. Left alone rather than re-validated: the property the rejection protected was "do not throw", which the new decoder gives for free, and the consent modal prints the channel before anyone joins — a human reading `Join #%ZZ?` judges a typo better than a parser.

## Secondo commit — #167

`README.md` has declared DCC out of scope since `3c7a0357`, one clause deep in the Scope paragraph. `NON-GOALS.md`, whose stated job is that the answer is written down once, did not list it. One entry added.

## Gate

Cic-only, nessuna lane. Rc letti da file:

- `scripts/bun.sh install` → **rc=0**
- `WRITABLE_CIC=1 scripts/bun.sh run check` → **rc=0** (biome 498 file + `tsc --noEmit` standalone rc=0)
- `scripts/bun.sh run test` → **rc=0**, `243 passed (243)` / `4510 passed (4510)`
- TDD: rosso letto prima — `19 failed | 4 passed (23)` sul solo `inviteLink.test.ts`, poi `23 passed`.
- `tsc -p e2e/tsconfig.json --noEmit`: 26 errori, **3 nella spec #793 e tutti e 3 pre-esistenti** — sono le stesse tre righe `window.__cicInviteLinkApplied` che `origin/main` ha alle righe 72/116/133 (`declare global` vive in `src/`, che quel tsconfig non include). Zero `.js` emessi.

## Cosa NON affermo

- **Le e2e sono scritte, non girate.** La lane STACK è di un altro worker stasera. La spec compila e non introduce errori di tipo; che passi contro il leaf bahamut-test non è provato qui.
- **Non affermo che nessuno abbia mai aperto un link path-shaped.** Affermo che non è in nessun tag e che ha vissuto poche ore; la popolazione è plausibilmente zero, non provatamente zero.
- **Non ho toccato la decisione 1** (identità di rete cross-user): rete non bound → nessun join, un toast che la nomina. Vicolo cieco visibile, come prima.
- **Non ho aggiunto un generatore di link.** vjt li ha esclusi. La forma canonica è scritta nei commenti, nei test, in `inviteUrl` della spec e in DESIGN_NOTES — **ma in nessun doc rivolto a un umano**: chi deve scrivere un invito a mano oggi deve leggere il sorgente. È un buco che aveva anche la spedizione precedente, non introdotto qui, e non l'ho chiuso perché sarebbe stata una terza voce non ordinata. Segnalato.
- **#167 non ha la label `never`** che il preambolo di `NON-GOALS.md` dichiara come tracciamento (è chiusa not-planned con enhancement/cicchetto/roadmap/grappa). Non ho rietichettato l'issue di qualcun altro.