### PR TITLE
cic(#963): the closed <select> is ours — appearance:none + a theme-following caret, and color-scheme for what the UA still paints

### DIFF
--- a/cicchetto/e2e/tests/issue75-theme-editor.spec.ts
+++ b/cicchetto/e2e/tests/issue75-theme-editor.spec.ts
@@ -67,21 +67,73 @@ async function openThemesGalleryMobile(page: PWPage): Promise<void> {
   await expect(page.getByTestId("theme-gallery")).toBeVisible({ timeout: 5_000 });
 }
 
-// #963 — the font <select>'s computed colour, plus the computed colour of the
-// name <input> beside it as the ORACLE. Both are read from the LIVE cascade:
-// the name field is an <input>, so the global form-control rule already gives
-// it `color: var(--fg)`, and the select must resolve to the same value from
-// that same rule. Never a literal — a hardcoded expected colour would pass on
-// a theme whose `--fg` happened to be black, which is the exact confusion this
-// bug is made of.
-function readEditorControlColors(page: PWPage): Promise<{ select: string; input: string }> {
-  return page.evaluate(() => {
-    const read = (id: string) => {
-      const el = document.querySelector(`[data-testid="${id}"]`);
-      return el ? getComputedStyle(el).color : "";
+// #963 — the legibility of a control, measured in PIXELS.
+//
+// The first version of this asked `getComputedStyle`, and computed style is
+// the wrong instrument twice over for this defect. On WebKit the native
+// menulist chrome paints its own fill OVER `background`, so the cascade said
+// legible while the control was not; and under `devices["iPhone 15"]`
+// emulation, a page carrying a <select> with <option>s makes
+// `getComputedStyle` hand back DEFAULT values for a subset of nodes (a <body>
+// reporting black while its own <input> child reports `#e0e0e0` is a read
+// artefact, not a cascade any engine can produce). What the user sees is the
+// pixels, so the pixels are the oracle: screenshot the control, histogram its
+// interior, and take the WCAG contrast between what fills it and what is
+// written on it.
+//
+// No colour literal is involved — the fill and the ink are both whatever the
+// engine painted. The only constant is WCAG's 4.5:1 floor for text.
+const WCAG_TEXT_CONTRAST_FLOOR = 4.5;
+
+// Contrast of the painted control: dominant interior colour (the fill) vs the
+// most frequent colour far enough from it to be ink (glyphs, caret). Null when
+// nothing is written on the control — a control with no ink would otherwise
+// score infinite contrast and pass vacuously.
+async function paintedContrast(page: PWPage, testId: string): Promise<number | null> {
+  const shot = (await page.getByTestId(testId).screenshot()).toString("base64");
+  return page.evaluate(async (b64: string) => {
+    const img = new Image();
+    img.src = `data:image/png;base64,${b64}`;
+    await img.decode();
+    const canvas = document.createElement("canvas");
+    canvas.width = img.naturalWidth;
+    canvas.height = img.naturalHeight;
+    const ctx = canvas.getContext("2d");
+    if (ctx === null) return null;
+    ctx.drawImage(img, 0, 0);
+
+    // Inset past the border (1 CSS px, up to 3 device px at dsf 3) and the
+    // rounded corners, so only the control's own surface is sampled.
+    const inset = 7;
+    const w = canvas.width - 2 * inset;
+    const h = canvas.height - 2 * inset;
+    if (w <= 0 || h <= 0) return null;
+    const { data } = ctx.getImageData(inset, inset, w, h);
+
+    const counts = new Map<number, number>();
+    for (let i = 0; i < data.length; i += 4) {
+      const key = (data[i] << 16) | (data[i + 1] << 8) | data[i + 2];
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    const byFrequency = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+    const fill = byFrequency[0][0];
+    const rgb = (k: number) => [(k >> 16) & 255, (k >> 8) & 255, k & 255];
+    const far = (k: number) =>
+      Math.max(...rgb(k).map((c, i) => Math.abs(c - rgb(fill)[i]))) > 40;
+    const ink = byFrequency.find(([k]) => far(k));
+    if (ink === undefined) return null;
+
+    const luminance = (k: number) => {
+      const [r, g, b] = rgb(k).map((c) => {
+        const s = c / 255;
+        return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+      });
+      return 0.2126 * r + 0.7152 * g + 0.0722 * b;
     };
-    return { select: read("theme-editor-font"), input: read("theme-editor-name") };
-  });
+    const a = luminance(fill);
+    const b = luminance(ink[0]);
+    return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
+  }, shot);
 }
 
 test.describe("#75 — theme editor (producer path)", () => {
@@ -150,52 +202,73 @@ test.describe("#75 — theme editor (producer path)", () => {
     await expect.poll(() => readAccent(page), { timeout: 5_000 }).toBe(accentPreOpen);
   });
 
-  // #963 — a <select> does NOT inherit color: the UA paints it `fieldtext`
-  // (black), which on a dark theme is black-on-dark. jsdom is blind to this
-  // (no UA stylesheet, no computed cascade), so the assertion has to run in a
-  // real engine.
+  // #963 — the font <select> has to be READABLE, which is a fact about pixels,
+  // not about the cascade. jsdom has neither, so the assertion is e2e.
   //
   // It runs on BOTH engines, as a tagged/untagged PAIR, because the two
   // Playwright projects PARTITION the suite: chromium takes `grepInvert:
   // /@webkit/`, webkit-iphone-15 takes `grep: /@webkit/`, so a single test can
-  // only ever reach one of them. A defect whose whole mechanism is a UA
-  // default (`fieldtext`) has to be measured on the UA that matters most for
-  // cic — Safari on iOS — and not inferred from Chrome. Same shape as
-  // `issue962-settings-drawer-row-squash.spec.ts`.
-  test("font select takes its color from the control rule, like a sibling input", async ({
-    page,
-  }) => {
+  // only ever reach one of them. That partition is load-bearing here: the two
+  // engines painted this control DIFFERENTLY (Chromium honoured `background`
+  // on a menulist, WebKit covered it with native chrome), so a green on one
+  // says nothing about the other — and cic's engine that matters most is
+  // Safari. Same shape as `issue962-settings-drawer-row-squash.spec.ts`.
+  test("font select is legible — painted fill vs painted text clears WCAG", async ({ page }) => {
     await loginAs(page, specUser());
     await openThemesGalleryDesktop(page);
 
     await page.getByTestId("theme-new").click();
     await expect(page.getByTestId("theme-editor")).toBeVisible({ timeout: 5_000 });
 
-    const painted = await readEditorControlColors(page);
-
-    // Guard the oracle: an empty/absent input color would make the equality
-    // vacuous.
-    expect(painted.input).not.toBe("");
-    expect(painted.select).toBe(painted.input);
+    await expect
+      .poll(() => paintedContrast(page, "theme-editor-font"), { timeout: 5_000 })
+      .toBeGreaterThanOrEqual(WCAG_TEXT_CONTRAST_FLOOR);
 
     await page.getByTestId("theme-editor-cancel-btn").click();
   });
 
-  test("@webkit #963 — font select takes its color from the control rule (iPhone)", async ({
-    page,
-  }) => {
+  test("@webkit #963 — font select is legible on the iPhone leg too", async ({ page }) => {
     await loginAs(page, specUser());
     await openThemesGalleryMobile(page);
 
     await page.getByTestId("theme-new").tap();
     await expect(page.getByTestId("theme-editor")).toBeVisible({ timeout: 5_000 });
 
-    const painted = await readEditorControlColors(page);
-
-    expect(painted.input).not.toBe("");
-    expect(painted.select).toBe(painted.input);
+    await expect
+      .poll(() => paintedContrast(page, "theme-editor-font"), { timeout: 5_000 })
+      .toBeGreaterThanOrEqual(WCAG_TEXT_CONTRAST_FLOOR);
 
     await page.getByTestId("theme-editor-cancel-btn").tap();
+  });
+
+  // #963 part B — `color-scheme`. `appearance: none` makes the CLOSED select
+  // ours, but the OPEN list of <option>s stays the UA's to paint (that is the
+  // point of keeping a real <select>: the system picker). The UA only knows
+  // which way to paint it if told, and it cannot be told a literal: cic ships
+  // a light theme, a dark theme and an editor that overrides `--bg` live. So
+  // the declaration is DERIVED from the theme that is painting — which is
+  // exactly what this asserts, by driving the theme from one end of the range
+  // to the other through the editor's own live preview and watching the
+  // derivation follow. A mirror of the implementation would compute the
+  // expected value the same way the product does; white and black instead
+  // carry their own answer.
+  test("the UA's own surfaces follow the theme — color-scheme tracks --bg", async ({ page }) => {
+    await loginAs(page, specUser());
+    await openThemesGalleryDesktop(page);
+
+    await page.getByTestId("theme-new").click();
+    await expect(page.getByTestId("theme-editor")).toBeVisible({ timeout: 5_000 });
+
+    const scheme = () =>
+      page.evaluate(() => getComputedStyle(document.documentElement).colorScheme);
+
+    await setEditorColor(page, "bg", "#ffffff");
+    await expect.poll(scheme, { timeout: 5_000 }).toBe("light");
+
+    await setEditorColor(page, "bg", "#000000");
+    await expect.poll(scheme, { timeout: 5_000 }).toBe("dark");
+
+    await page.getByTestId("theme-editor-cancel-btn").click();
   });
 
   test("self-hosted font applies live from same-origin /fonts (no CDN)", async ({ page }) => {

--- a/cicchetto/e2e/tests/issue75-theme-editor.spec.ts
+++ b/cicchetto/e2e/tests/issue75-theme-editor.spec.ts
@@ -85,11 +85,24 @@ async function openThemesGalleryMobile(page: PWPage): Promise<void> {
 // engine painted. The only constant is WCAG's 4.5:1 floor for text.
 const WCAG_TEXT_CONTRAST_FLOOR = 4.5;
 
-// Contrast of the painted control: dominant interior colour (the fill) vs the
-// most frequent colour far enough from it to be ink (glyphs, caret). Null when
-// nothing is written on the control — a control with no ink would otherwise
-// score infinite contrast and pass vacuously.
-async function paintedContrast(page: PWPage, testId: string): Promise<number | null> {
+// Contrast of what is WRITTEN on a control against what FILLS it: dominant
+// colour of the sampled region is the fill, the most frequent colour far
+// enough from it is the ink.
+//
+// The sampled region is the interior MINUS the inline-end strip, which is
+// where a caret lives — ours after `appearance: none`, the user agent's own
+// arrow before it. That exclusion is load-bearing, not tidiness: measured on
+// Playwright's WebKit, sampling the whole interior elects the native arrow
+// (#2e3436, more pixels than the glyphs) as the ink and reports a comfortable
+// 11.5:1 for a control whose own text — `--fg` #e0e0e0 on the native
+// rgb(244,244,244) fill — is invisible at 1.20:1. An oracle that scores a
+// decoration cannot see the defect it exists for.
+//
+// No ink at all — nothing distinguishable from the fill — is contrast 1, not
+// an error: it is precisely the shape this defect takes (black glyphs on a
+// near-black fill on Chromium, `--fg` glyphs on a near-white native fill on
+// WebKit), and both were measured returning exactly this.
+async function paintedTextContrast(page: PWPage, testId: string): Promise<number> {
   const shot = (await page.getByTestId(testId).screenshot()).toString("base64");
   return page.evaluate(async (b64: string) => {
     const img = new Image();
@@ -99,15 +112,17 @@ async function paintedContrast(page: PWPage, testId: string): Promise<number | n
     canvas.width = img.naturalWidth;
     canvas.height = img.naturalHeight;
     const ctx = canvas.getContext("2d");
-    if (ctx === null) return null;
+    if (ctx === null) return 1;
     ctx.drawImage(img, 0, 0);
 
     // Inset past the border (1 CSS px, up to 3 device px at dsf 3) and the
-    // rounded corners, so only the control's own surface is sampled.
+    // rounded corners; the screenshot is in DEVICE pixels, so the caret strip
+    // is too.
     const inset = 7;
-    const w = canvas.width - 2 * inset;
+    const strip = 32 * window.devicePixelRatio;
+    const w = canvas.width - 2 * inset - strip;
     const h = canvas.height - 2 * inset;
-    if (w <= 0 || h <= 0) return null;
+    if (w <= 0 || h <= 0) return 1;
     const { data } = ctx.getImageData(inset, inset, w, h);
 
     const counts = new Map<number, number>();
@@ -118,10 +133,9 @@ async function paintedContrast(page: PWPage, testId: string): Promise<number | n
     const byFrequency = [...counts.entries()].sort((a, b) => b[1] - a[1]);
     const fill = byFrequency[0][0];
     const rgb = (k: number) => [(k >> 16) & 255, (k >> 8) & 255, k & 255];
-    const far = (k: number) =>
-      Math.max(...rgb(k).map((c, i) => Math.abs(c - rgb(fill)[i]))) > 40;
+    const far = (k: number) => Math.max(...rgb(k).map((c, i) => Math.abs(c - rgb(fill)[i]))) > 40;
     const ink = byFrequency.find(([k]) => far(k));
-    if (ink === undefined) return null;
+    if (ink === undefined) return 1;
 
     const luminance = (k: number) => {
       const [r, g, b] = rgb(k).map((c) => {
@@ -221,7 +235,7 @@ test.describe("#75 — theme editor (producer path)", () => {
     await expect(page.getByTestId("theme-editor")).toBeVisible({ timeout: 5_000 });
 
     await expect
-      .poll(() => paintedContrast(page, "theme-editor-font"), { timeout: 5_000 })
+      .poll(() => paintedTextContrast(page, "theme-editor-font"), { timeout: 5_000 })
       .toBeGreaterThanOrEqual(WCAG_TEXT_CONTRAST_FLOOR);
 
     await page.getByTestId("theme-editor-cancel-btn").click();
@@ -235,7 +249,7 @@ test.describe("#75 — theme editor (producer path)", () => {
     await expect(page.getByTestId("theme-editor")).toBeVisible({ timeout: 5_000 });
 
     await expect
-      .poll(() => paintedContrast(page, "theme-editor-font"), { timeout: 5_000 })
+      .poll(() => paintedTextContrast(page, "theme-editor-font"), { timeout: 5_000 })
       .toBeGreaterThanOrEqual(WCAG_TEXT_CONTRAST_FLOOR);
 
     await page.getByTestId("theme-editor-cancel-btn").tap();

--- a/cicchetto/e2e/tests/issue75-theme-editor.spec.ts
+++ b/cicchetto/e2e/tests/issue75-theme-editor.spec.ts
@@ -49,6 +49,41 @@ async function openThemesGalleryDesktop(page: PWPage): Promise<void> {
   await expect(page.getByTestId("theme-gallery")).toBeVisible({ timeout: 5_000 });
 }
 
+// Mobile route to the same gallery. The members-sidebar hamburger (which hosts
+// the settings cog, the path to themes since #299) is channel-scoped, so a
+// channel has to be selected first — mirror of the gallery consumer spec. #299
+// removed the footer 🎨 launcher; rail launcher menu (#500) → cog → themes nav
+// row is the path now.
+async function openThemesGalleryMobile(page: PWPage): Promise<void> {
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
+  await expect(sidebarWindow(page, NETWORK_SLUG, CHANNEL)).toBeVisible();
+
+  await page.getByLabel(/open members sidebar/i).tap();
+  await expect(page.locator(".shell-members.open")).toBeVisible({ timeout: 5_000 });
+  await openRailMenu(page);
+  await page.locator(".rail-actions-menu [data-testid='action-cluster-cog']").tap();
+  await expect(page.locator(".shell-members.open")).toHaveCount(0, { timeout: 5_000 });
+  await page.getByTestId("themes-settings-entry").tap();
+  await expect(page.getByTestId("theme-gallery")).toBeVisible({ timeout: 5_000 });
+}
+
+// #963 — the font <select>'s computed colour, plus the computed colour of the
+// name <input> beside it as the ORACLE. Both are read from the LIVE cascade:
+// the name field is an <input>, so the global form-control rule already gives
+// it `color: var(--fg)`, and the select must resolve to the same value from
+// that same rule. Never a literal — a hardcoded expected colour would pass on
+// a theme whose `--fg` happened to be black, which is the exact confusion this
+// bug is made of.
+function readEditorControlColors(page: PWPage): Promise<{ select: string; input: string }> {
+  return page.evaluate(() => {
+    const read = (id: string) => {
+      const el = document.querySelector(`[data-testid="${id}"]`);
+      return el ? getComputedStyle(el).color : "";
+    };
+    return { select: read("theme-editor-font"), input: read("theme-editor-name") };
+  });
+}
+
 test.describe("#75 — theme editor (producer path)", () => {
   test("new theme: live preview + save persists across reload via the server", async ({ page }) => {
     await loginAs(page, specUser());
@@ -101,23 +136,7 @@ test.describe("#75 — theme editor (producer path)", () => {
 
   test("@webkit editor opens + live-previews + cancels on mobile", async ({ page }) => {
     await loginAs(page, specUser());
-    // The mobile members-sidebar hamburger (which hosts the settings cog,
-    // the path to themes since #299) is channel-scoped — select a channel
-    // first (mirror the gallery consumer spec).
-    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: specNick() });
-    await expect(sidebarWindow(page, NETWORK_SLUG, CHANNEL)).toBeVisible();
-
-    // Mobile: reach the themes sub-page via the rail launcher menu (#500) → cog
-    // (settings) → themes nav row. (#299 removed the footer 🎨 launcher; the
-    // cog is the path now.)
-    await page.getByLabel(/open members sidebar/i).tap();
-    const drawer = page.locator(".shell-members.open");
-    await expect(drawer).toBeVisible({ timeout: 5_000 });
-    await openRailMenu(page);
-    await page.locator(".rail-actions-menu [data-testid='action-cluster-cog']").tap();
-    await expect(page.locator(".shell-members.open")).toHaveCount(0, { timeout: 5_000 });
-    await page.getByTestId("themes-settings-entry").tap();
-    await expect(page.getByTestId("theme-gallery")).toBeVisible({ timeout: 5_000 });
+    await openThemesGalleryMobile(page);
 
     const accentPreOpen = await readAccent(page);
     await page.getByTestId("theme-new").tap();
@@ -134,26 +153,25 @@ test.describe("#75 — theme editor (producer path)", () => {
   // #963 — a <select> does NOT inherit color: the UA paints it `fieldtext`
   // (black), which on a dark theme is black-on-dark. jsdom is blind to this
   // (no UA stylesheet, no computed cascade), so the assertion has to run in a
-  // real engine. BOTH sides are read from the LIVE cascade — never a literal:
-  // the name field is an <input>, so the global form-control rule already
-  // gives it `color: var(--fg)`; the select must resolve to that same
-  // computed color, from that same rule.
+  // real engine.
+  //
+  // It runs on BOTH engines, as a tagged/untagged PAIR, because the two
+  // Playwright projects PARTITION the suite: chromium takes `grepInvert:
+  // /@webkit/`, webkit-iphone-15 takes `grep: /@webkit/`, so a single test can
+  // only ever reach one of them. A defect whose whole mechanism is a UA
+  // default (`fieldtext`) has to be measured on the UA that matters most for
+  // cic — Safari on iOS — and not inferred from Chrome. Same shape as
+  // `issue962-settings-drawer-row-squash.spec.ts`.
   test("font select takes its color from the control rule, like a sibling input", async ({
     page,
   }) => {
-    await loginAs(page, getSeededVjt());
+    await loginAs(page, specUser());
     await openThemesGalleryDesktop(page);
 
     await page.getByTestId("theme-new").click();
     await expect(page.getByTestId("theme-editor")).toBeVisible({ timeout: 5_000 });
 
-    const painted = await page.evaluate(() => {
-      const read = (id: string) => {
-        const el = document.querySelector(`[data-testid="${id}"]`);
-        return el ? getComputedStyle(el).color : "";
-      };
-      return { select: read("theme-editor-font"), input: read("theme-editor-name") };
-    });
+    const painted = await readEditorControlColors(page);
 
     // Guard the oracle: an empty/absent input color would make the equality
     // vacuous.
@@ -161,6 +179,23 @@ test.describe("#75 — theme editor (producer path)", () => {
     expect(painted.select).toBe(painted.input);
 
     await page.getByTestId("theme-editor-cancel-btn").click();
+  });
+
+  test("@webkit #963 — font select takes its color from the control rule (iPhone)", async ({
+    page,
+  }) => {
+    await loginAs(page, specUser());
+    await openThemesGalleryMobile(page);
+
+    await page.getByTestId("theme-new").tap();
+    await expect(page.getByTestId("theme-editor")).toBeVisible({ timeout: 5_000 });
+
+    const painted = await readEditorControlColors(page);
+
+    expect(painted.input).not.toBe("");
+    expect(painted.select).toBe(painted.input);
+
+    await page.getByTestId("theme-editor-cancel-btn").tap();
   });
 
   test("self-hosted font applies live from same-origin /fonts (no CDN)", async ({ page }) => {

--- a/cicchetto/e2e/tests/issue75-theme-editor.spec.ts
+++ b/cicchetto/e2e/tests/issue75-theme-editor.spec.ts
@@ -131,6 +131,38 @@ test.describe("#75 — theme editor (producer path)", () => {
     await expect.poll(() => readAccent(page), { timeout: 5_000 }).toBe(accentPreOpen);
   });
 
+  // #963 — a <select> does NOT inherit color: the UA paints it `fieldtext`
+  // (black), which on a dark theme is black-on-dark. jsdom is blind to this
+  // (no UA stylesheet, no computed cascade), so the assertion has to run in a
+  // real engine. BOTH sides are read from the LIVE cascade — never a literal:
+  // the name field is an <input>, so the global form-control rule already
+  // gives it `color: var(--fg)`; the select must resolve to that same
+  // computed color, from that same rule.
+  test("font select takes its color from the control rule, like a sibling input", async ({
+    page,
+  }) => {
+    await loginAs(page, getSeededVjt());
+    await openThemesGalleryDesktop(page);
+
+    await page.getByTestId("theme-new").click();
+    await expect(page.getByTestId("theme-editor")).toBeVisible({ timeout: 5_000 });
+
+    const painted = await page.evaluate(() => {
+      const read = (id: string) => {
+        const el = document.querySelector(`[data-testid="${id}"]`);
+        return el ? getComputedStyle(el).color : "";
+      };
+      return { select: read("theme-editor-font"), input: read("theme-editor-name") };
+    });
+
+    // Guard the oracle: an empty/absent input color would make the equality
+    // vacuous.
+    expect(painted.input).not.toBe("");
+    expect(painted.select).toBe(painted.input);
+
+    await page.getByTestId("theme-editor-cancel-btn").click();
+  });
+
   test("self-hosted font applies live from same-origin /fonts (no CDN)", async ({ page }) => {
     const requests: string[] = [];
     page.on("request", (r) => requests.push(r.url()));

--- a/cicchetto/src/lib/__tests__/colorScheme.test.ts
+++ b/cicchetto/src/lib/__tests__/colorScheme.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { applyColorScheme, colorSchemeFor } from "../colorScheme";
+
+// #963 — the `color-scheme` derivation. The UA paints what our CSS cannot
+// reach (the open <option> list of a real <select>, scrollbars), and the only
+// way to tell it which way is `color-scheme`. It is derived from the theme's
+// background rather than from the day/night slot, so a light theme parked in
+// the night slot still gets a light option list.
+//
+// The threshold under test is not arbitrary: it is the luminance at which
+// black and white contrast EQUALLY against the colour, which is the same
+// question the UA is being asked. #757575 is the last grey where white wins.
+
+describe("colorSchemeFor", () => {
+  test("the two shipped palettes resolve to their own mode", () => {
+    // The literal --bg of :root[data-theme="irssi-dark"] / ["mirc-light"].
+    expect(colorSchemeFor("#0a0a0a")).toBe("dark");
+    expect(colorSchemeFor("#ffffff")).toBe("light");
+  });
+
+  test("the boundary is where white stops being the more legible text", () => {
+    expect(colorSchemeFor("#757575")).toBe("dark");
+    expect(colorSchemeFor("#767676")).toBe("light");
+  });
+
+  test("luminance is weighted per channel, not averaged", () => {
+    // Same mean channel value, opposite verdicts: green carries 0.7152 of the
+    // luminance, blue 0.0722. A naive (r+g+b)/3 would call both the same.
+    expect(colorSchemeFor("#00a000")).toBe("light");
+    expect(colorSchemeFor("#0000a0")).toBe("dark");
+  });
+
+  test("reads the shorthand hex and the rgb() forms an engine may hand back", () => {
+    expect(colorSchemeFor("#000")).toBe("dark");
+    expect(colorSchemeFor("#FFF")).toBe("light");
+    expect(colorSchemeFor("rgb(10, 10, 10)")).toBe("dark");
+    expect(colorSchemeFor("rgb(255 255 255)")).toBe("light");
+    // A computed custom property arrives as a token stream, spaces included.
+    expect(colorSchemeFor("  #0a0a0a ")).toBe("dark");
+  });
+
+  test("a value that is not a colour yields no verdict rather than a guess", () => {
+    expect(colorSchemeFor("")).toBeNull();
+    expect(colorSchemeFor("var(--nope)")).toBeNull();
+    expect(colorSchemeFor("linear-gradient(#000, #fff)")).toBeNull();
+    expect(colorSchemeFor("#12345")).toBeNull();
+  });
+});
+
+describe("applyColorScheme", () => {
+  afterEach(() => {
+    document.documentElement.style.removeProperty("--bg");
+    document.documentElement.style.removeProperty("color-scheme");
+  });
+
+  test("writes the mode the current --bg resolves to, and clears it when unreadable", () => {
+    const root = document.documentElement;
+
+    root.style.setProperty("--bg", "#0a0a0a");
+    applyColorScheme();
+    expect(root.style.getPropertyValue("color-scheme")).toBe("dark");
+
+    root.style.setProperty("--bg", "#ffffff");
+    applyColorScheme();
+    expect(root.style.getPropertyValue("color-scheme")).toBe("light");
+
+    root.style.removeProperty("--bg");
+    applyColorScheme();
+    expect(root.style.getPropertyValue("color-scheme")).toBe("");
+  });
+});

--- a/cicchetto/src/lib/colorScheme.ts
+++ b/cicchetto/src/lib/colorScheme.ts
@@ -1,0 +1,86 @@
+// #963 — `color-scheme` on <html>, derived from the theme that is actually
+// painting.
+//
+// `appearance: none` (themes/default.css) makes the CLOSED <select> ours, but
+// everything the user agent still paints by itself stays the UA's: the open
+// list of <option>s (native by design — the whole point of keeping a real
+// <select> is the system picker), the scrollbars on engines that ignore
+// `scrollbar-color`, any future date/number input. `color-scheme` is the only
+// declaration that tells the UA which way to paint those.
+//
+// It cannot be a literal in the stylesheet. cic ships a light theme, a dark
+// theme AND a user theme editor whose payload overrides `--bg` inline on
+// <html>, so the mode is not knowable at authoring time — a
+// `:root[data-theme="irssi-dark"] { color-scheme: dark }` would lie the moment
+// a user parks a light custom theme on top of the dark base. So it is driven
+// from where the theme tokens are applied (theme.ts's base write and
+// customTheme.ts's overlay write both call `applyColorScheme`), and it is
+// DERIVED from `--bg` rather than from a second mode flag nobody would keep in
+// sync: the mode of a theme IS the lightness of its background.
+//
+// The threshold is not a guess: it is the luminance at which black and white
+// contrast EQUALLY against the colour (WCAG's own ratio formula solved for
+// L, `sqrt(1.05 * 0.05) - 0.05`). Below it white text is the better fit, which
+// is exactly the question `color-scheme: dark` answers for the UA.
+
+export type ColorScheme = "dark" | "light";
+
+const EQUAL_CONTRAST_LUMINANCE = Math.sqrt(1.05 * 0.05) - 0.05;
+
+type Rgb = { r: number; g: number; b: number };
+
+// `#rgb`, `#rrggbb` and the `rgb()` forms an engine may hand back. Anything
+// else (a named colour, a gradient, an empty computed value) is not a colour
+// this can reason about and yields null rather than a guessed mode.
+function parseColor(value: string): Rgb | null {
+  const v = value.trim();
+
+  const hex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(v);
+  if (hex) {
+    const d = hex[1];
+    const wide = d.length === 6;
+    const at = (i: number) => (wide ? d.slice(i * 2, i * 2 + 2) : d[i].repeat(2));
+    return {
+      r: Number.parseInt(at(0), 16),
+      g: Number.parseInt(at(1), 16),
+      b: Number.parseInt(at(2), 16),
+    };
+  }
+
+  const rgb = /^rgba?\(\s*([\d.]+)[\s,]+([\d.]+)[\s,]+([\d.]+)/i.exec(v);
+  if (rgb) {
+    return { r: Number(rgb[1]), g: Number(rgb[2]), b: Number(rgb[3]) };
+  }
+
+  return null;
+}
+
+// WCAG 2.x relative luminance.
+function relativeLuminance({ r, g, b }: Rgb): number {
+  const channel = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+// The scheme a background colour asks the UA for, or null when the value is
+// not a colour we can read.
+export function colorSchemeFor(cssColor: string): ColorScheme | null {
+  const rgb = parseColor(cssColor);
+  if (rgb === null) return null;
+  return relativeLuminance(rgb) < EQUAL_CONTRAST_LUMINANCE ? "dark" : "light";
+}
+
+// Re-derive `color-scheme` from whatever `--bg` resolves to RIGHT NOW —
+// the base [data-theme] block, or a custom theme's inline override on top of
+// it, whichever is winning. Called from both token-application sites; reading
+// the computed value rather than the payload is what keeps it to ONE rule for
+// both. An unreadable `--bg` (no stylesheet yet, a non-colour) clears the
+// declaration instead of guessing a mode.
+export function applyColorScheme(): void {
+  const root = document.documentElement;
+  const scheme = colorSchemeFor(getComputedStyle(root).getPropertyValue("--bg"));
+  if (scheme === null) root.style.removeProperty("color-scheme");
+  else root.style.setProperty("color-scheme", scheme);
+}

--- a/cicchetto/src/lib/colorScheme.ts
+++ b/cicchetto/src/lib/colorScheme.ts
@@ -35,21 +35,17 @@ type Rgb = { r: number; g: number; b: number };
 function parseColor(value: string): Rgb | null {
   const v = value.trim();
 
-  const hex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(v);
-  if (hex) {
-    const d = hex[1];
-    const wide = d.length === 6;
-    const at = (i: number) => (wide ? d.slice(i * 2, i * 2 + 2) : d[i].repeat(2));
-    return {
-      r: Number.parseInt(at(0), 16),
-      g: Number.parseInt(at(1), 16),
-      b: Number.parseInt(at(2), 16),
-    };
+  const hex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(v)?.[1];
+  if (hex !== undefined) {
+    const wide = hex.length === 6 ? hex : hex.replace(/./g, (c) => c + c);
+    const packed = Number.parseInt(wide, 16);
+    return { r: (packed >> 16) & 255, g: (packed >> 8) & 255, b: packed & 255 };
   }
 
   const rgb = /^rgba?\(\s*([\d.]+)[\s,]+([\d.]+)[\s,]+([\d.]+)/i.exec(v);
-  if (rgb) {
-    return { r: Number(rgb[1]), g: Number(rgb[2]), b: Number(rgb[3]) };
+  if (rgb !== null) {
+    const [r, g, b] = [Number(rgb[1]), Number(rgb[2]), Number(rgb[3])];
+    if ([r, g, b].every((c) => Number.isFinite(c))) return { r, g, b };
   }
 
   return null;

--- a/cicchetto/src/lib/customTheme.ts
+++ b/cicchetto/src/lib/customTheme.ts
@@ -1,5 +1,6 @@
 import { createEffect, createSignal } from "solid-js";
 import { token } from "./auth";
+import { applyColorScheme } from "./colorScheme";
 import { identityMoved } from "./identityMoved";
 import { moduleRoot } from "./moduleRoot";
 import { prefersDark } from "./theme";
@@ -117,6 +118,9 @@ export function applyCustomTheme(payload: TokenPayload | null): void {
   if (payload === null) {
     for (const v of THEME_CSS_VARS) root.style.removeProperty(v);
     root.classList.remove("theme-has-bg");
+    // #963 — back to the base cascade's `--bg`, so the UA-painted surfaces
+    // (the open <option> list, scrollbars) follow it back.
+    applyColorScheme();
     return;
   }
   const vars = tokenToCssVars(payload);
@@ -134,6 +138,12 @@ export function applyCustomTheme(payload: TokenPayload | null): void {
     "theme-has-bg",
     Boolean(payload.background.image_id || payload.background.builtin),
   );
+  // #963 — this payload's `--bg` now wins over the base block, so the UA-
+  // painted surfaces have to be told which way to paint. Derived from the
+  // resolved `--bg`, not from which slot (day/night) was picked: a user is
+  // free to park a light theme in the night slot, and the option list has to
+  // follow the colours, not the slot.
+  applyColorScheme();
 }
 
 // #358 — the cached day/night payload pair. `light` is the day slot, `dark`

--- a/cicchetto/src/lib/theme.ts
+++ b/cicchetto/src/lib/theme.ts
@@ -1,4 +1,5 @@
 import { createEffect, createSignal } from "solid-js";
+import { applyColorScheme } from "./colorScheme";
 import { moduleRoot } from "./moduleRoot";
 
 // Boot-time base theme + reactive viewport-mode signal.
@@ -34,8 +35,14 @@ function resolveAuto(): ResolvedTheme {
   return window.matchMedia("(prefers-color-scheme: dark)").matches ? "irssi-dark" : "mirc-light";
 }
 
+// #963 — the base palette write is one of the two places a theme lands on
+// <html>, so it is one of the two that re-derive `color-scheme` for the UA-
+// painted surfaces (the open <option> list first of all). The other is
+// customTheme.ts's overlay apply; both go through the same derivation, which
+// reads whatever `--bg` resolves to after the write.
 function writeDataset(theme: ResolvedTheme): void {
   document.documentElement.dataset.theme = theme;
+  applyColorScheme();
 }
 
 // Boot-time entry. Applies the OS-resolved base theme to

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -483,8 +483,8 @@ body {
   overscroll-behavior: none;
 }
 
-/* #497 / #508 — global text-input treatment (DENYLIST). The app had NO base
-   <input>/<textarea> rule, so UNCLASSED fields (the identity editor's
+/* #497 / #508 / #963 — global form-control treatment (DENYLIST). The app had
+   NO base <input>/<textarea> rule, so UNCLASSED fields (the identity editor's
    nick/realname/ident) fell back to tiny UA defaults, and every modal re-styled
    its own input in 13+ near-identical `.<x>-input` rules. This is the single
    global treatment: a comfortable ≥44px tap-target, the app's `--font-size`
@@ -508,7 +508,14 @@ body {
    tradeoff). RESTORE PATH if a real iPhone DOES zoom on focus: re-add, after the
    :focus rule, `html.is-ios input:where(:not(<same denylist>)), html.is-ios
    textarea { font-size: max(16px, var(--font-size)) }` — #508 removed it pending
-   vjt's device check. */
+   vjt's device check.
+   #963 added `select`: a <select> does NOT inherit `color` (the UA paints it
+   `fieldtext`, i.e. black), so every bare select in the app rendered
+   black-on-dark — reported on the theme editor's font picker, but the defect
+   was the whole CLASS of element, not that one instance. Selects belong here
+   for the same reason inputs do: one source for the theme tokens and the tap
+   target. No `:where()` needed — the bare element selector is already (0,0,1),
+   matching `textarea`. */
 input:where(
   :not(
     [type="radio"],
@@ -522,6 +529,7 @@ input:where(
     [type="image"]
   )
 ),
+select,
 textarea {
   box-sizing: border-box;
   min-height: var(--tap-min);
@@ -551,6 +559,7 @@ input:where(
     [type="image"]
   )
 ):focus,
+select:focus,
 textarea:focus {
   outline: none;
   border-color: var(--accent);
@@ -6457,9 +6466,13 @@ html.resize-dragging * {
   gap: 0.25rem;
 }
 
+/* #963 — this used to also declare `color: var(--text)`, and `--text` is
+   defined NOWHERE. An unresolvable var() on an inherited property computes to
+   the inherited value, so these controls were picking up the parent's color by
+   accident, not the value this rule meant. The global form-control rule is the
+   one source of `color: var(--fg)` now; only the tighter padding stays. */
 .settings-drawer label.prefs-list input[type="text"],
 .settings-drawer label.prefs-list select {
-  color: var(--text);
   padding: 0.25rem 0.4rem;
 }
 

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -223,6 +223,15 @@
      `e2e/tests/issue1039-hamburger-corner.spec.ts`. */
   --pane-chrome-inset-block: 0.5rem;
   --pane-chrome-inset-inline: 1rem;
+  /* #963 — geometry of the caret the form-control rule draws on every
+     <select> (see the `appearance: none` block below). Two numbers, one
+     source: --select-caret-inset is the caret's distance from the control's
+     inline END edge, --select-caret-room the padding that keeps the value
+     text off it. A per-component rule that tightens a select's padding MUST
+     re-declare `padding-inline-end: var(--select-caret-room)` or its longest
+     option runs under the caret. Theme-independent, so base :root. */
+  --select-caret-inset: 0.6rem;
+  --select-caret-room: 1.75rem;
   /* #913 — the iOS top safe-area inset, as a variable. Everything else in this
      file writes `env(safe-area-inset-top)` inline, which is right for a
      padding: the engine substitutes it and nobody has to read it back. The
@@ -563,6 +572,51 @@ select:focus,
 textarea:focus {
   outline: none;
   border-color: var(--accent);
+}
+
+/* #963 — the closed <select> is OURS. The rule above gives it the tokens, the
+   tap target and the focus ring, but on WebKit none of the paint half of that
+   lands: the native menulist chrome draws its own fill OVER `background`,
+   while `color` still reaches the glyphs — measured on Playwright's WebKit,
+   `--fg` text on an Adwaita `rgb(244,244,244)` fill, 1.20:1. Chromium honours
+   both. `appearance: none` retires the native chrome on every engine, so the
+   fill and the text come from the same place the surrounding controls' do.
+   The element stays a real <select>, so tapping it still opens the NATIVE
+   option picker (the iOS wheel, the Android dialog, the desktop popup) — this
+   is not a custom dropdown widget. The popup list itself stays UA-painted;
+   `color-scheme` (lib/colorScheme.ts) is what tells the UA how to paint it.
+
+   The caret is ours to draw now. It is two 45° gradient wedges in
+   `currentColor`, so it follows `--fg` in every theme with no second asset
+   for the dark case — a `background-image` data URI would freeze its colour
+   and need one variant per theme, and a ::before/::after is not reliable on a
+   replaced element. Its inline position is the writing direction's END, which
+   is where a native menulist puts it in both directions, hence the `:dir(rtl)`
+   flip rather than a hardcoded `right`.
+
+   CONSTRAINT this rule imposes on every component rule below: style a select
+   with `background-color`, NEVER the `background` shorthand — the shorthand
+   resets `background-image` and silently erases the caret. Same for padding:
+   keep `padding-inline-end: var(--select-caret-room)`. Three rules already
+   pay this (.theme-editor-font-select, .banlist-modal-add-form, the
+   settings-drawer prefs-list select). */
+select {
+  appearance: none;
+  padding-inline-end: var(--select-caret-room);
+  background-image:
+    linear-gradient(45deg, transparent 50%, currentColor 50%),
+    linear-gradient(135deg, currentColor 50%, transparent 50%);
+  background-size: 5px 5px;
+  background-repeat: no-repeat;
+  background-position:
+    right calc(var(--select-caret-inset) + 5px) center,
+    right var(--select-caret-inset) center;
+}
+
+select:dir(rtl) {
+  background-position:
+    left var(--select-caret-inset) center,
+    left calc(var(--select-caret-inset) + 5px) center;
 }
 
 /* UX-6 D9 (2026-05-21) — iOS-only layout-viewport pin. This is the
@@ -6476,6 +6530,12 @@ html.resize-dragging * {
   padding: 0.25rem 0.4rem;
 }
 
+/* #963 — the tighter padding above would put the longest option under the
+   caret the global select rule draws. Give its room back. */
+.settings-drawer label.prefs-list select {
+  padding-inline-end: var(--select-caret-room);
+}
+
 .settings-drawer label.prefs-list input[type="text"]:disabled,
 .settings-drawer label.prefs-list select:disabled {
   opacity: 0.5;
@@ -8652,10 +8712,18 @@ html.resize-dragging * {
 }
 
 .theme-editor-name-input,
+/* #963 — `background-color`, not the `background` shorthand: on the select the
+   shorthand would reset `background-image` and erase the caret the global
+   form-control rule draws. The tighter padding stays, but the select has to
+   keep the caret's room back. */
 .theme-editor-font-select,
 .theme-editor-bg-url-input {
-  background: var(--bg-alt);
+  background-color: var(--bg-alt);
   padding: 0 0.5rem;
+}
+
+.theme-editor-font-select {
+  padding-inline-end: var(--select-caret-room);
 }
 
 .theme-editor-group {
@@ -10078,10 +10146,14 @@ html.resize-dragging * {
   border-color: var(--accent, var(--fg));
 }
 
+/* #963 — `background-color`, not the `background` shorthand, and the caret's
+   room back on top of the tighter padding: this is a <select>, and the
+   shorthand would erase the caret the global form-control rule draws. */
 .banlist-modal-add-form {
   flex: 0 0 auto;
   padding: 0.4rem 0.5rem;
-  background: var(--bg-alt);
+  padding-inline-end: var(--select-caret-room);
+  background-color: var(--bg-alt);
   color: var(--fg);
   border: 1px solid var(--border);
   font-family: var(--font-mono);


### PR DESCRIPTION
> [!NOTE]
> **DRAFT until CI is green.** Re-scoped onto vjt's ruling of 2026-08-07 09:47
> + the 09:48 correction: **direction A** (`appearance: none`, the closed
> control becomes ours) **and B** (`color-scheme` bound to the resolved theme),
> both in this PR. The regression the previous head measured is gone — numbers
> below, both engines, before and after.

## The defect, and why one rule inverted it

A `<select>` does not inherit `color`, so the UA paints it `fieldtext`
(black). The global form-control rule covered `input`/`textarea` but never
`select`, so every bare select in the app painted black text; it stayed
legible only while it also had the UA's light background. Adding `select` to
that rule (the previous head) repaired Chromium and **inverted WebKit**.

**Root cause of the inversion:** the rule sets `background` AND `color`, and on
WebKit only one of the two lands. The native menulist chrome paints its own
fill OVER the author `background`, while `color` does reach the glyphs. So the
rule split in half: light `--fg` text on the engine's own light fill.

**The evidence that proves it is the fill, not the text.** Same page, same
stylesheet, one engine honouring `background` and one not — the `<input>`
beside the select never moves in any cell, which rules out the cascade and the
theme as the variable:

| engine | revision | painted fill | painted ink |
|---|---|---|---|
| chromium | pre-#963 | `rgb(17,17,17)` (ours) | none distinguishable — the reported defect |
| webkit | pre-#963 | `rgb(244,244,244)` (**Adwaita's, not ours**) | `rgb(0,0,0)` |
| chromium | colour-only | `rgb(17,17,17)` (ours) | `rgb(224,224,224)` |
| webkit | colour-only | `rgb(244,244,244)` (**still Adwaita's**) | `#e0e0e0`, invisible on it |

The author `background` reaches the pixels on Chromium in every row and on
WebKit in none of them. That is the whole mechanism, and it is why the fix is
`appearance: none` rather than another colour.

## Measured, before and after

Playwright's `chromium-1217` and `webkit-2272` (WebKit base `482d54b2`,
GTK/WPE Adwaita port) over a **static** page carrying the REAL `default.css` of
three revisions — no app stack, no suite. Text-region contrast (the inline-end
caret strip excluded, see the oracle note below); `null` = nothing
distinguishable from the fill, i.e. contrast 1.

| engine | pre-#963 | colour-only (previous head) | **this PR** |
|---|---|---|---|
| chromium-desktop | **null** ✘ (the report) | 14.30 ✔ | **14.30 ✔** |
| webkit-desktop | 19.09 ✔ | **null** ✘ (the regression) | **14.30 ✔** |
| webkit-iPhone15 | 19.09 ✔ | **null** ✘ | **14.30 ✔** |

Same three columns for the **unclassed** admin select: 21.00 / 15.00 / 15.00 on
Chromium, 18.75 / null / **15.00** on WebKit, 19.09 / null / **15.00** on the
iPhone leg. Two selects, one classed and one bare, move together — the picture
is the class of element, as the issue argued.

WCAG's floor for text is 4.5:1. After this PR every measured cell is at or
above 14.30, and the fill is the theme's own (`rgb(17,17,17)` / `rgb(10,10,10)`
— what the sibling `<input>` has had all along) on **every** engine.

## A — the closed control is ours

`appearance: none` retires the native chrome, so `background` counts again on
WebKit. The element stays a real `<select>`: tapping it still opens the native
option picker, which is why this is one CSS change and not a custom dropdown
widget. (The existing `selectOption` test in this same file exercises that the
control still behaves as a select.)

**The caret: vjt's mechanism does not work, and here is the measure.**
`mask-image` + `background-color: currentColor` is the right trick for an
element that IS an icon. A mask **clips** an element's whole rendering — its
fill, its border and its glyphs — it does not paint; applied to the select it
would erase the control and leave an arrow-shaped hole. The *intent* (one
asset, follows `--fg` in every theme, no dark variant) is preserved by drawing
the caret as two 45° gradient wedges in `currentColor`. `background-image` with
a data URI was rejected for exactly the reason vjt gave; `::before`/`::after`
was never an option on a replaced element.

Measured painted, in the inline-end strip, on all three engine configs. And it
does follow the writing direction (`:dir(rtl)`) — ink pixels in the left/right
strips of an LTR select vs an RTL one, desktop, both engines:

| engine | dir | left strip | right strip |
|---|---|---|---|
| chromium | ltr | 78 (the text) | **24** (the caret — a 10×5 wedge is 25px) |
| chromium | rtl | **25** (the caret) | 79 (the text) |
| webkit | ltr | 76 | **25** |
| webkit | rtl | **26** | 78 |

**One constraint this imposes, and it is a real maintenance cost:** a component
rule must style a select with `background-color`, never the `background`
shorthand, which resets `background-image` and silently erases the caret; and
it must keep `padding-inline-end: var(--select-caret-room)` if it tightens
padding. Three rules already paid it and are fixed here
(`.theme-editor-font-select`, `.banlist-modal-add-form`, the settings-drawer
prefs-list select). The two numbers live once, on `:root`. The constraint is
written where the next author will hit it, in the rule's own comment.

## B — `color-scheme`, derived from the theme that is painting

The open `<option>` list stays UA-painted by design. `color-scheme` is the only
way to tell the UA which way, and per the 09:48 correction it ships here.

It is **not** hardcoded, and it is **not** read off the day/night slot either:
it is derived from whatever `--bg` resolves to after a theme lands on `<html>`,
in the two places a theme lands (the base `[data-theme]` write in `theme.ts`,
the token overlay in `customTheme.ts`). The mode of a theme IS the lightness of
its background, so there is no second flag to keep in sync — and a user who
parks a light theme in the night slot gets a light option list, which a
slot-derived answer would get wrong. Threshold: the luminance where black and
white contrast equally (WCAG's ratio solved for L), which is precisely the
question the UA is being asked.

**Correction to the expectation in the 09:48 note:** "scrollbars included" will
be much less visible than stated. cic already themes its scrollbars explicitly
— `scrollbar-color`/`scrollbar-width` on `:root` (grappa-irc#69) and a
`::-webkit-scrollbar` block for Blink/WebKit — so those surfaces are already
author-painted and `color-scheme` has little left to change there. The visible
app-wide change is the UA-painted **option lists**, plus any future
date/number input. Still document-level and still intended; just smaller than
advertised.

## The test gate

**The `@webkit` twin stays, and its oracle becomes the pixels.** Deleting it
was the alternative and it is the wrong call: the two engines demonstrably
painted this control differently (the table above), so a green on Chromium
carries no information about the engine cic cares most about — which is the
whole reason the projects partition the suite. What was wrong was never the
leg, it was the instrument.

`getComputedStyle` is the wrong instrument twice over here. On desktop WebKit
it **passed** while the control was illegible, because the cascade said
`color: --fg` while the chrome painted over the fill. On the iPhone leg it went
red for a reason with nothing to do with the product: under
`devices["iPhone 15"]`, once the page holds a `<select>` with `<option>`s,
`getComputedStyle` returns DEFAULT values for a subset of nodes (a `<body>`
reporting black with `--fg` empty while its own `<input>` child reports
`#e0e0e0` is a read artefact — no cascade produces that). Green for the wrong
reason on one leg, red for the wrong reason on the other. CI run
`31137202035` on the previous head was that red: 626 passed, 1 failed, the
twin, on `expect(painted.select).toBe(painted.input)`.

So both legs now screenshot the control, histogram it, and assert WCAG 4.5:1
between the fill and the ink. No colour literal is involved — both sides are
whatever the engine painted; the only constant is the standard's threshold.

**The oracle was itself wrong on the first attempt, and the measurement caught
it.** Sampling the whole interior elects the NATIVE arrow (`#2e3436`, more
pixels than the glyphs) as the ink and scores a comfortable **11.5:1** for a
control whose text sits at 1.20:1 — it would have passed the regression it
exists to catch. The sampled region now stops before the inline-end caret
strip, and re-measured, the two WebKit legs of the regression go from 11.5 to
no-ink-at-all. The `null` → `1` change is the same honesty: nothing
distinguishable from the fill IS contrast 1.

Part B gets its own test, and deliberately not a mirror of the implementation:
it drives `--bg` to white and then to black through the editor's live preview
and watches `color-scheme` follow. White and black carry their own answer.

## Gates

| gate | rc | measured |
|---|---|---|
| `scripts/bun.sh run check` (biome + tsc) | 0 | `Checked 504 files`, no `error TS` |
| `scripts/bun.sh run test` (vitest, cold `tsbuildinfo`) | 0 | `Test Files 247 passed`, `Tests 4611 passed` |
| `scripts/bun.sh run build` | 0 | `precache 21 entries`, dist emitted |
| `tsc --noEmit -p e2e/tsconfig.json` | 1 | 26 errors, **0 in this spec** — the pre-existing e2e static-gate debt, untouched |
| vitest mutation `<= 0.0` | 1 | 5 of 6 red, `expected 'light' to be 'dark'` |
| vitest mutation naive `0.5` threshold | 1 | 2 red: the boundary test and the per-channel weighting |
| e2e suite | — | **NOT RUN — no lane.** See below |

## What is NOT claimed

- **That any of this describes Safari on a real iPhone.** Everything measured
  is Playwright's Linux WebKit with the Adwaita theme; `rgb(244,244,244)` and
  `#2e3436` are Adwaita's colours, not iOS's. The *direction* (native chrome
  covers `background`; `appearance: none` gives it back) is measured on that
  engine. **The real check is vjt on a real iPhone** — in particular that the
  option picker still opens from the tap and that the caret looks right there.
- **That the e2e specs pass.** They were not run locally, by design: the
  oracle's algorithm was proven in vitro against all three revisions on all
  three engine configs (the tables above), which is where its red and its
  green come from, and the suite proof is this PR's own `integration` run.
  In vitro is not the same as the spec passing inside the stack — until that
  job is green, treat the two e2e legs as written-and-reasoned, not executed.
- **That all 11 selects were observed.** Two were, one classed and one bare.
  They agree, but that is an inference from two samples, not a census.
- **That the light theme (`mirc-light`) is affected or exempt.** Not measured;
  the harness ran `irssi-dark` only.
- **That `color-scheme` changes nothing else visible.** It is document-level by
  nature. The scrollbar half is argued from the stylesheet (cic already paints
  them), not from pixels.
