### PR TITLE
irc: guard send_line/2 when the client is not a pid

### DIFF
--- a/lib/grappa/irc/client.ex
+++ b/lib/grappa/irc/client.ex
@@ -314,9 +314,23 @@ defmodule Grappa.IRC.Client do
   (connect_failed pre-assignment, peer RST in flight). Callers that
   don't care about delivery may `_ = `-discard the result;
   `Session.Server.terminate/2` does this for the best-effort QUIT.
+
+  A `nil` client — `Session.Server`'s honest "no upstream process
+  right now", held for the whole Backoff-deferred respawn window —
+  is the same "nothing to write to" condition and answers with the
+  same `{:error, :no_socket}` as `transport_send(%{socket: nil}, _)`
+  one layer down. It must NOT reach `GenServer.call/3`: that exits
+  `:noproc` with `line` embedded in the exit reason, and the reason
+  is echoed by the caller's crash report AND persisted by
+  `Session.Server.terminate/2` → `SessionLog.emit(:disconnected,
+  reason: inspect(reason))`. `line` is a verbatim IRC frame, so for
+  `OPER` it carries the operator password (#961). Deliberately no
+  Logger call here for the same reason — the rejection is reported
+  by returning it, never by writing the frame anywhere.
   """
-  @spec send_line(pid(), iodata()) :: send_result()
-  def send_line(client, line), do: GenServer.call(client, {:send, line})
+  @spec send_line(pid() | nil, iodata()) :: send_result()
+  def send_line(client, line) when is_pid(client), do: GenServer.call(client, {:send, line})
+  def send_line(_, _), do: {:error, :no_socket}
 
   @doc """
   Sends `PRIVMSG <target> :<body>\\r\\n`. Rejects CR/LF/NUL in either

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -1601,6 +1601,40 @@ defmodule Grappa.IRC.ClientTest do
     end
   end
 
+  describe "no upstream Client process (#961)" do
+    # Between an upstream drop and the deferred respawn, `Session.Server`
+    # holds `client: nil` — the Backoff ladder defers the Client spawn to
+    # `{:start_client_after_backoff, _}`, and the session serves calls for
+    # the whole delay (5s..5min in production). Every `send_*` funnels
+    # through `send_line/2`, which used to reach `GenServer.call(nil, ...)`
+    # and exit `:noproc` with the ENTIRE line inside the exit reason. That
+    # reason is echoed at a level production keeps — the session's crash
+    # report, and `terminate/2` → `SessionLog.emit(:disconnected, reason:
+    # inspect(reason))`, which also persists it to `session_log_events`.
+    test "send_line/2 with no client returns a transport error instead of exiting" do
+      assert {:error, :no_socket} = Client.send_line(nil, "PING :x\r\n")
+    end
+
+    # The OPER frame is the instance of that class which carries a secret,
+    # so it gets its own sentinel: whatever term the caller ends up
+    # holding (returned OR raised) must not contain the password.
+    test "send_oper/3 with no client keeps the password out of the caller's term" do
+      sentinel = "sentinel-oper-pw-961"
+
+      result =
+        try do
+          Client.send_oper(nil, "vjt", sentinel)
+        catch
+          :exit, reason -> {:exited, reason}
+        end
+
+      refute inspect(result) =~ sentinel,
+             "the OPER password must not ride inside the term the caller sees — that term becomes the crash report and the persisted session-log reason"
+
+      assert result == {:error, :no_socket}
+    end
+  end
+
   describe "init/1 non-blocking (C2)" do
     # C2 cluster — `init/1` must NOT call `:gen_tcp.connect`/`:ssl.connect`
     # synchronously. Connect + handshake live in `handle_continue(:connect, _)`

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -10238,6 +10238,52 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    # #961 — the leak this closes is NOT the log line above (that one has a
+    # static body and holds). It is the Backoff respawn window: after a drop
+    # the session serves calls for the whole deferred-spawn delay (5s..5min
+    # in production) with `client: nil`. The OPER used to reach
+    # `GenServer.call(nil, {:send, "OPER vjt <password>\r\n"})`, whose
+    # `:noproc` exit reason embeds the frame — and that reason is echoed by
+    # the session's crash report AND persisted verbatim by `terminate/2` →
+    # `SessionLog.emit(:disconnected, reason: inspect(reason))`. Both sinks
+    # sit at levels production keeps. The guard is in `Client.send_line/2`
+    # (one door for every verb); here we pin the end-to-end outcome: the
+    # secret reaches no sink and the session does not die for having been
+    # asked to oper while reconnecting.
+    test "an OPER submitted in the Backoff respawn window leaks nothing and does not kill the session" do
+      {_, port} = start_server()
+      {user, network, _} = setup_user_and_network(port)
+      subject = {:user, user.id}
+      sentinel = "sentinel-oper-pw-961"
+
+      # Ladder at the cap → `handle_continue({:start_client, _})` defers the
+      # Client spawn, so this session serves the call below with no upstream
+      # process. `{:error, :no_socket}` IS the precondition assertion: had
+      # the deferred spawn already won, the OPER would have gone on the wire
+      # and replied `:ok`.
+      :ok = Backoff.reset(subject, network.id)
+      Enum.each(1..10, fn _ -> :ok = Backoff.record_failure(subject, network.id) end)
+      on_exit(fn -> Backoff.reset(subject, network.id) end)
+
+      pid = start_session_for(user, network)
+
+      {result, log} =
+        with_log(fn ->
+          try do
+            Session.send_oper(subject, network.id, "vjt", sentinel)
+          catch
+            :exit, reason -> {:exited, reason}
+          end
+        end)
+
+      refute inspect(result) =~ sentinel,
+             "the OPER password rode back inside the caller's term — the same term the crash report and the persisted session-log reason are built from"
+
+      assert result == {:error, :no_socket}
+      refute log =~ sentinel
+      assert Process.alive?(pid), "a /oper during the reconnect window must not take the session down"
+    end
+
     test "rejects CRLF in name before whereis lookup" do
       assert {:error, :invalid_line} =
                Session.send_oper({:user, Ecto.UUID.generate()}, 999_999, "vjt\r\nKILL", "p")

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -10276,12 +10276,17 @@ defmodule Grappa.Session.ServerTest do
           end
         end)
 
-      refute inspect(result) =~ sentinel,
-             "the OPER password rode back inside the caller's term — the same term the crash report and the persisted session-log reason are built from"
+      # The SINK is the discriminator here, asserted first. The caller's own
+      # term is NOT: `Session.call_session/3` catches the callee's exit and
+      # maps it to `{:error, :no_session}`, so at this layer the frame never
+      # rides back to the caller either way — it rides into the crash report
+      # and into `SessionLog`'s persisted reason. (The caller-term assertion
+      # belongs one layer down, on `Client.send_oper/3`, where it bites.)
+      refute log =~ sentinel,
+             "the OPER frame reached a log sink — the same reason `terminate/2` persists to session_log_events"
 
-      assert result == {:error, :no_socket}
-      refute log =~ sentinel
       assert Process.alive?(pid), "a /oper during the reconnect window must not take the session down"
+      assert result == {:error, :no_socket}
     end
 
     test "rejects CRLF in name before whereis lookup" do


### PR DESCRIPTION
## What changes

`Grappa.IRC.Client.send_line/2` handed its `client` argument straight to
`GenServer.call/3`. There is a real window in which a live `Session.Server`
holds `client: nil`: `handle_continue({:start_client, _})` defers the Client
spawn on the Backoff scale (`Process.send_after`), and the session keeps
serving calls for the whole delay — 5s..5min in production.

A send issued inside that window exited instead of returning. Two consequences,
both fixed by the same guard:

- the session died for the sole reason that it was handed a send while
  re-attaching upstream;
- the exit term was built from the call arguments, so it carried request
  content into two sinks that are not filtered at production log level: the
  crash report and the `session_log_events` row written by `terminate/2`
  (`emit_disconnected/3` → `format_reason/1` does `inspect(reason)` — that one
  is persisted, not merely logged).

## The fix

An `is_pid` guard in `send_line/2`. A non-pid client answers
`{:error, :no_socket}` — the same atom `transport_send(%{socket: nil}, _)`
already returns one level down, already part of `send_result()` and already
mapped by `Session.send_transport_error()`. No contract, spec or mapping
change; no new atom. The guard branch writes no log line: the request is
reported by returning it, never by writing it.

This is a property of the door, not of any one verb — every sender
(`send_privmsg`, `send_raw`, `send_nick`, `send_quit`, …) funnels through
`send_line/2`.

## Tests

3 new tests:

- `client_test.exs` — the door itself returns `{:error, :no_socket}` for a
  non-pid client, and the returned term carries no request content;
- `server_test.exs` — end-to-end inside the real backoff window: the sink stays
  clean and the session is still alive afterwards.

The discriminating assertion is on the **sink** (`refute log =~ sentinel`),
with the caller-term assertion kept one level down at `Client`, where it
actually bites: `Session.call_session/3` catches the callee exit and maps it to
`{:error, :no_session}`, so at the facade that assertion is dead either way.
The persisted row is deliberately not asserted — `SessionLog` writes via
`handle_cast`, and a `refute` against an async write would pass for the wrong
reason.

Verified by mutation: with the guard removed, all 3 redden — the door test on
the returned term, the session test on the sink. Backoff-window test run
`--repeat-until-failure 20`: 21/21 green.

`scripts/check.sh`: rc=0 — `5315 tests, 0 failures`, dialyzer
`Total errors: 0`, `done (passed successfully)`, bats `ok 331`.