### PR TITLE
cic(#964): device row shows last-used + a 'this device' marker

### DIFF
--- a/cicchetto/e2e/fixtures/push.ts
+++ b/cicchetto/e2e/fixtures/push.ts
@@ -255,6 +255,32 @@ export async function resetPushSubscriptions(token: string): Promise<void> {
   }
 }
 
+/**
+ * #964 — blocks until the server has stamped `last_used_at` on at least one
+ * of `token`'s push subscriptions.
+ *
+ * Push.Sender bumps the row AFTER the vendor's 200, so push-catcher recording
+ * a delivery does NOT mean the DB write has landed: a UI refetch fired off the
+ * catcher alone races it. This polls the same REST view the settings drawer
+ * reads, so when it returns, a reload is GUARANTEED to render the stamped
+ * value — a real barrier, not a sleep.
+ */
+export async function awaitDeviceLastUsed(token: string, timeoutMs = 5_000): Promise<void> {
+  const base = "http://grappa-test:4000";
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const res = await fetch(`${base}/push/subscriptions`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      const body = (await res.json()) as { subscriptions?: { last_used_at: string | null }[] };
+      if ((body.subscriptions ?? []).some((s) => s.last_used_at !== null)) return;
+    }
+    await sleep(100);
+  }
+  throw new Error(`awaitDeviceLastUsed: no subscription stamped within ${timeoutMs}ms`);
+}
+
 export type CaughtDelivery = {
   headers: Record<string, string>;
   body_b64: string;

--- a/cicchetto/e2e/tests/push-964-device-row.spec.ts
+++ b/cicchetto/e2e/tests/push-964-device-row.spec.ts
@@ -1,0 +1,104 @@
+// push-964 — the device row stops being byte-identical to its twin.
+//
+// `parseUserAgent` collapses the UA to `Browser on OS`, so two instances of
+// the same browser on the same OS render the SAME row; the only escape hatch
+// was the full UA in `title=`, which is hover-only and therefore absent on
+// touch — where the drawer mostly lives. #964 point 3 + its follow-up put two
+// always-visible disambiguators on the row, both from data already on the
+// wire:
+//
+//   * the activity instant — `last_used_at`, falling back to `created_at`
+//     while nothing has been pushed to the device yet;
+//   * a "this device" marker on the row THIS browser registered (matched by
+//     endpoint→id, the same proof `disablePush` uses to never delete a row it
+//     cannot prove ours).
+//
+// Both assertions are on rendered TEXT, so this spec is engine-independent —
+// no @webkit twin (that pairing belongs to UA-dependent defects like #963's
+// `fieldtext`, not to data rendering).
+//
+// Why an e2e and not only a unit test: the "last used" branch needs the
+// server to have stamped `last_used_at`, and the ONLY thing that stamps it is
+// a real delivery (peer DM → Push.Triggers → Push.Sender → push-catcher).
+//
+// Why a SECOND browser context for the last leg, instead of reloading the
+// first: on boot `installPushResubscribe` renews a dropped-but-wanted
+// subscription, and the push stub's "subscribed" flag is per-document — so a
+// reload would look like a drop, POST a fresh row with `supersedes`, and
+// replace the very row whose `last_used_at` we are asserting. A clean context
+// carries no opt-in intent, so it renews nothing and reads the same server
+// row. It also proves the other half of the marker contract: the marker is
+// per-BROWSER, not per-user, so the same account elsewhere sees no marker.
+
+import { expect, test } from "../fixtures/test";
+import { loginAs, openSettingsSection, selectChannel } from "../fixtures/cicchettoPage";
+import { IrcPeer } from "../fixtures/ircClient";
+import {
+  awaitDeviceLastUsed,
+  awaitPushDelivery,
+  enablePushFromSettings,
+  pushCatcherEndpoint,
+  resetPushCatcher,
+  resetPushSubscriptions,
+  setPageVisibility,
+  stubPushManager,
+} from "../fixtures/push";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const PEER_NICK = "n964-dmer";
+const SUB_ID = "964-device-row";
+
+test("device row shows the activity instant + marks the device you are on", async ({
+  page,
+  context,
+  browser,
+}) => {
+  const vjt = getSeededVjt();
+  await resetPushCatcher();
+  await resetPushSubscriptions(vjt.token);
+  await stubPushManager(context, { endpoint: pushCatcherEndpoint(SUB_ID) });
+  await context.grantPermissions(["notifications"]);
+
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
+
+  await enablePushFromSettings(page, context, { id: SUB_ID, token: vjt.token });
+
+  // ── Freshly registered: nothing has been pushed here yet, so the row reads
+  // the creation instant — and it is OUR row, so it carries the marker.
+  await openSettingsSection(page, "push");
+  const row = page.locator('[data-testid="devices-list"] li').first();
+  await expect(row.getByTestId("device-activity")).toHaveText(/^added \d+[smhd]/);
+  await expect(row.getByTestId("device-current")).toHaveText(/this device/);
+  // Exactly one row may claim it — a marker on a second device would be the
+  // "which of these two Firefoxes am I?" bug wearing a green dot.
+  await expect(page.getByTestId("device-current")).toHaveCount(1);
+
+  // ── A real delivery stamps `last_used_at` on the row.
+  const peer = await IrcPeer.connect({ nick: PEER_NICK });
+  try {
+    // Background the device: a VISIBLE one suppresses the push at source.
+    await setPageVisibility(page, false);
+    peer.privmsg(NETWORK_NICK, "hi from n964-dmer");
+    expect((await awaitPushDelivery(SUB_ID)).length).toBeGreaterThanOrEqual(1);
+    // Barrier: Sender bumps the row AFTER the vendor 200, so the catcher
+    // seeing a delivery does not yet mean the DB write has landed.
+    await awaitDeviceLastUsed(vjt.token);
+  } finally {
+    await peer.disconnect("964 done");
+  }
+
+  // ── Same account, a different browser: the row now reads the delivery
+  // instant, and NOTHING here claims to be "this device".
+  const observerCtx = await browser.newContext();
+  try {
+    const observer = await observerCtx.newPage();
+    await loginAs(observer, vjt);
+    await openSettingsSection(observer, "push");
+    const observed = observer.locator('[data-testid="devices-list"] li').first();
+    await expect(observed.getByTestId("device-activity")).toHaveText(/^last used \d+[smhd]/);
+    await expect(observer.getByTestId("device-current")).toHaveCount(0);
+  } finally {
+    await observerCtx.close();
+  }
+});

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -30,10 +30,12 @@ import {
   disablePush,
   type EnablePushResult,
   enablePush,
+  formatDeviceActivity,
   listPushDevices,
   type PushDeviceSummary,
   pushAvailable,
   type SubscriptionId,
+  subscriptionIdForEndpoint,
 } from "./lib/push";
 import { reconnectConnectedNetworks } from "./lib/reconnect";
 import { selectedChannel } from "./lib/selection";
@@ -102,6 +104,12 @@ const SettingsDrawer: Component<Props> = (props) => {
 
   const [prefs, setPrefs] = createSignal<NotificationPrefs>(DEFAULT_NOTIFICATION_PREFS);
   const [devices, setDevices] = createSignal<PushDeviceSummary[]>([]);
+  // #964 — the server row THIS browser registered, so its list entry can say
+  // so. Proven by endpoint match (`subscriptionIdForEndpoint`), never guessed
+  // from the UA: two same-browser rows are byte-identical, which is the whole
+  // reason this issue exists. `null` = we cannot prove any row is ours (never
+  // subscribed here / cleared site data) — then NO row gets the marker.
+  const [currentDeviceId, setCurrentDeviceId] = createSignal<SubscriptionId | null>(null);
   const [pushEnabled, setPushEnabled] = createSignal(false);
   const [pushBanner, setPushBanner] = createSignal<string | null>(null);
   const [savingPrefs, setSavingPrefs] = createSignal(false);
@@ -461,6 +469,7 @@ const SettingsDrawer: Component<Props> = (props) => {
       if (registration.pushManager === undefined) return;
       const sub = await registration.pushManager.getSubscription();
       setPushEnabled(sub !== null);
+      setCurrentDeviceId(sub === null ? null : subscriptionIdForEndpoint(sub.endpoint));
     } catch {
       /* swallowed — pushEnabled stays false */
     }
@@ -560,6 +569,9 @@ const SettingsDrawer: Component<Props> = (props) => {
       const result: EnablePushResult = await enablePush(t);
       if (result.status === "enabled") {
         setPushEnabled(true);
+        // #964 — the drawer does NOT remount after the toggle, so the mount-time
+        // probe never re-runs; take the id straight off the enable result.
+        setCurrentDeviceId(result.subscriptionId);
         await refreshDevices();
       } else if (result.status === "permission_denied") {
         setPushEnabled(false);
@@ -578,6 +590,7 @@ const SettingsDrawer: Component<Props> = (props) => {
     } else {
       await disablePush(t);
       setPushEnabled(false);
+      setCurrentDeviceId(null);
       await refreshDevices();
     }
   };
@@ -1526,14 +1539,36 @@ const SettingsDrawer: Component<Props> = (props) => {
                       // can still surface the original for debugging /
                       // device disambiguation across same-browser instances.
                       const parsed = parseUserAgent(d.user_agent);
+                      // #964 — hover is the ONLY disambiguator today and it does
+                      // not exist on touch, which is where the drawer lives. The
+                      // activity instant + the this-device marker are the two
+                      // always-visible ones. Stamped at render, not on a ticking
+                      // clock: the list is refetched on drawer mount, so a live
+                      // "3m ago → 4m ago" would out-freshen its own data.
+                      const activity = formatDeviceActivity(d, Date.now());
+                      const isCurrent = () => currentDeviceId() === d.id;
                       return (
                         <li>
                           <span class="device-ua" title={d.user_agent ?? "(unknown browser)"}>
                             <span class="device-ua-icon" aria-hidden="true">
                               {deviceClassIcon(parsed.deviceClass)}
                             </span>
-                            <span class="device-ua-name">
-                              {parsed.browser} on {parsed.os}
+                            <span class="device-ua-text">
+                              <span class="device-ua-title">
+                                <span class="device-ua-name">
+                                  {parsed.browser} on {parsed.os}
+                                </span>
+                                <Show when={isCurrent()}>
+                                  <span class="device-current" data-testid="device-current">
+                                    ● this device
+                                  </span>
+                                </Show>
+                              </span>
+                              <Show when={activity !== null}>
+                                <span class="device-activity" data-testid="device-activity">
+                                  {activity}
+                                </span>
+                              </Show>
                             </span>
                           </span>
                           <button

--- a/cicchetto/src/__tests__/push.test.ts
+++ b/cicchetto/src/__tests__/push.test.ts
@@ -4,11 +4,14 @@ import {
   deletePushSubscription,
   disablePush,
   ensurePushSubscription,
+  formatDeviceActivity,
   getVapidPublicKey,
   listPushDevices,
+  type PushDeviceSummary,
   postPushSubscription,
   pushAvailable,
   type SubscriptionId,
+  subscriptionIdForEndpoint,
   vapidKeyToUint8Array,
 } from "../lib/push";
 
@@ -420,5 +423,71 @@ describe("pushAvailable — synchronous capability gate (#459)", () => {
       standalone: true,
     });
     expect(pushAvailable()).toBe(true);
+  });
+});
+
+// ── #964 — the device row's disambiguating metadata ────────────────────
+// Two rows reading "Firefox on Linux" are byte-identical today. The
+// payload already carries `created_at` + `last_used_at`; these two
+// helpers turn them (and "which row am I?") into row-level strings.
+
+describe("formatDeviceActivity — #964: the row's activity line", () => {
+  const NOW = Date.parse("2026-08-07T12:00:00Z");
+
+  const device = (over: Partial<PushDeviceSummary>): PushDeviceSummary => ({
+    id: "sub-1" as SubscriptionId,
+    user_agent: "Mozilla/5.0 (X11; Linux x86_64) Firefox/128.0",
+    created_at: "2026-08-07T11:00:00Z",
+    last_used_at: null,
+    ...over,
+  });
+
+  it("renders last_used_at when the device has been pushed to", () => {
+    expect(formatDeviceActivity(device({ last_used_at: "2026-08-07T07:48:00Z" }), NOW)).toBe(
+      "last used 4h 12m ago",
+    );
+  });
+
+  it("falls back to created_at when the device has never been pushed to", () => {
+    expect(formatDeviceActivity(device({ created_at: "2026-08-07T11:57:00Z" }), NOW)).toBe(
+      "added 3m ago",
+    );
+  });
+
+  it("prefers last_used_at over created_at when both are present", () => {
+    expect(
+      formatDeviceActivity(
+        device({ created_at: "2026-08-01T12:00:00Z", last_used_at: "2026-08-07T11:59:15Z" }),
+        NOW,
+      ),
+    ).toBe("last used 45s ago");
+  });
+
+  it("clamps a future instant (clock skew) instead of going negative", () => {
+    expect(formatDeviceActivity(device({ last_used_at: "2026-08-07T12:30:00Z" }), NOW)).toBe(
+      "last used 0s ago",
+    );
+  });
+
+  it("returns null when neither instant parses (omit the line, never guess)", () => {
+    expect(formatDeviceActivity(device({ created_at: "not-a-date" }), NOW)).toBeNull();
+  });
+});
+
+describe("subscriptionIdForEndpoint — #964: which row is THIS device", () => {
+  it("returns the stashed id when the endpoint matches", () => {
+    localStorage.setItem(SUB_ID_KEY, "sub-42");
+    localStorage.setItem(SUB_ENDPOINT_KEY, "https://push.example/ep");
+    expect(subscriptionIdForEndpoint("https://push.example/ep")).toBe("sub-42");
+  });
+
+  it("returns null when the live endpoint is not the one we stashed", () => {
+    localStorage.setItem(SUB_ID_KEY, "sub-42");
+    localStorage.setItem(SUB_ENDPOINT_KEY, "https://push.example/old");
+    expect(subscriptionIdForEndpoint("https://push.example/new")).toBeNull();
+  });
+
+  it("returns null when nothing was ever stashed", () => {
+    expect(subscriptionIdForEndpoint("https://push.example/ep")).toBeNull();
   });
 });

--- a/cicchetto/src/lib/push.ts
+++ b/cicchetto/src/lib/push.ts
@@ -20,6 +20,7 @@
 // bytes; localStorage is the authoritative cache.
 
 import { ApiError, readError } from "./api";
+import { formatDurationSince } from "./duration";
 import { isIos, isStandalonePwa } from "./platform";
 
 const VAPID_PUBLIC_KEY_STORAGE_KEY = "cic.vapidPublicKey";
@@ -170,6 +171,30 @@ export type PushDeviceSummary = {
   last_used_at: string | null;
 };
 
+/**
+ * #964 — the device row's activity line.
+ *
+ * `parseUserAgent` collapses the UA to `Browser on OS`, so two instances of
+ * the same browser on the same OS render byte-identical rows. The payload
+ * already carries two disambiguating instants the row used to throw away;
+ * this turns them into the one string that actually separates the twins
+ * (two devices are almost never last used in the same minute).
+ *
+ * `last_used_at` is `nil` until B2's Sender has pushed to the row at least
+ * once, so a freshly-enabled device falls back to `created_at` — "added 3m
+ * ago" is the honest reading of a device nothing has been sent to yet, and
+ * it is equally disambiguating.
+ *
+ * Returns null when NEITHER instant parses: per the #474 facts-only rule,
+ * omit the line rather than render a confident-wrong value.
+ */
+export function formatDeviceActivity(device: PushDeviceSummary, nowMs: number): string | null {
+  const lastUsed = formatDurationSince(device.last_used_at, nowMs);
+  if (lastUsed !== null) return `last used ${lastUsed} ago`;
+  const added = formatDurationSince(device.created_at, nowMs);
+  return added === null ? null : `added ${added} ago`;
+}
+
 /** GET /push/subscriptions — powers the per-device list in B3 settings. */
 export async function listPushDevices(token: string): Promise<PushDeviceSummary[]> {
   const res = await fetch("/push/subscriptions", {
@@ -203,7 +228,17 @@ function rememberSubscription(id: SubscriptionId, endpoint: string): void {
   localStorage.setItem(SUBSCRIPTION_ENDPOINT_STORAGE_KEY, endpoint);
 }
 
-function recallSubscriptionId(endpoint: string): SubscriptionId | null {
+/**
+ * The server-side row id we stashed for `endpoint`, or null when the live
+ * endpoint is not the one we registered (cleared site data, cross-profile
+ * re-install, a silently-rotated subscription).
+ *
+ * The endpoint match is the whole point: it is what makes the answer PROOF
+ * that the row is ours rather than a guess. `disablePush` leans on it to
+ * never DELETE a row it can't prove ours; #964's "this device" marker leans
+ * on it for the same reason — a stale id would badge the WRONG row.
+ */
+export function subscriptionIdForEndpoint(endpoint: string): SubscriptionId | null {
   const storedEndpoint = localStorage.getItem(SUBSCRIPTION_ENDPOINT_STORAGE_KEY);
   if (storedEndpoint !== endpoint) return null;
   // localStorage hands back a bare string; brand it at this recall seam.
@@ -342,7 +377,7 @@ export async function disablePush(token: string): Promise<boolean> {
   const endpoint = subscription.endpoint;
   await subscription.unsubscribe();
 
-  const knownId = recallSubscriptionId(endpoint);
+  const knownId = subscriptionIdForEndpoint(endpoint);
   if (knownId !== null) {
     await deletePushSubscription(token, knownId).catch(() => {
       /* swallowed — a missing row is fine; B2 Sender will GC dead rows on next push */

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -4537,6 +4537,39 @@ html.resize-dragging * {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  /* #964 — flex item since the title row: without this the auto minimum
+     keeps the name at full width and pushes the marker out of the row. */
+  min-width: 0;
+}
+
+/* #964 — the row grows a second line. `Browser on OS` collapses two
+   same-browser devices into byte-identical rows, so the row carries the
+   activity instant below the name and, on the one row this browser
+   registered, a "this device" marker beside it. The name keeps the
+   ellipsis; the marker does NOT shrink (it is the disambiguator). */
+.settings-drawer .device-ua-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.settings-drawer .device-ua-title {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.settings-drawer .device-current {
+  flex-shrink: 0;
+  color: var(--mode-voiced);
+  white-space: nowrap;
+}
+
+.settings-drawer .device-activity {
+  color: var(--muted);
+  font-size: 0.75rem;
+  white-space: nowrap;
 }
 
 .settings-drawer .device-remove {


### PR DESCRIPTION
Slice A of #964 — the two pieces the issue itself calls independent of the
label work: **point 3** (render `last_used_at` in the row) and the
**follow-up** (mark the device you are looking at right now). Pure cic, hot,
no Elixir and no schema change.

## What changes

`parseUserAgent` collapses the UA to `Browser on OS`, so two instances of the
same browser on the same OS render byte-identical rows — Hypnotize's report.
The only escape hatch was the full UA in `title=`: hover-only, so it does not
exist on touch, which is where the drawer lives. Both fixes come from data the
row was already handed and threw away.

- **Activity line** — `formatDeviceActivity(device, nowMs)` renders
  `last used 4h 12m ago`, falling back to `added 3m ago` while `last_used_at`
  is still nil (it is nil until the Sender has pushed to the row once). It
  REUSES `duration.ts:formatDurationSince` — the WHOIS-idle / server-rail
  formatter — rather than growing a second relative-time shape, and returns
  null when neither instant parses, so the line is omitted instead of guessing.
- **`● this device` marker** — the row id is PROVEN by endpoint match
  (`subscriptionIdForEndpoint`, the recall seam `disablePush` already used to
  never delete a row it cannot prove ours). Deducing it from the UA would badge
  whichever twin came first, which is the bug. No stashed match ⇒ no row is
  marked.

Timestamps are stamped at render, not on a ticking clock: the list is only
refetched on drawer mount, so a live `3m → 4m` would be fresher than its data.

## Explicitly NOT in scope

**Points 1 and 2 stay out** — the renameable label and the ordinal-suffixed
default. They need a migration, a `name` column and `PATCH
/push/subscriptions/:id`, and the design fork on the ordinal (STORED vs
DERIVED) is still unresolved. Shipping half of that shape now would bake the
wrong answer into a migration. Nothing in this slice depends on them.

Deliberately no `Closes #964`: the issue is only half done.

## Tests

- vitest: 8 new cases over `formatDeviceActivity` (branch preference, skew
  clamp, unparseable → null) and `subscriptionIdForEndpoint` (endpoint match /
  mismatch / nothing stashed). Both were **mutation-measured**: preferring
  `created_at` and dropping the endpoint check turn exactly 4 of them red.
- e2e `push-964-device-row.spec.ts`: enables push, asserts the visible
  `added …` line + the marker (and that exactly ONE row claims it), then drives
  a REAL delivery (peer DM → Triggers → Sender → push-catcher) — the only thing
  that stamps `last_used_at` — and asserts the row switched to `last used …`.

  Two deliberate choices in that spec:
  - a REST barrier (`awaitDeviceLastUsed`) between the catcher delivery and the
    UI read: Sender bumps the row AFTER the vendor 200, so the catcher alone is
    not a barrier;
  - the last leg reads from a SECOND browser context, not a reload. On boot
    `installPushResubscribe` renews a "dropped" subscription, and the stub's
    `subscribed` flag is per-document — a reload would POST `supersedes` and
    replace the very row under assertion. The clean context has no opt-in
    intent, so it renews nothing, and it proves the other half of the contract:
    the marker is per-BROWSER, not per-user.

  No `@webkit` twin: this is data rendering, engine-independent. The twin
  pairing belongs to UA-dependent defects like #963's `fieldtext`.

## Gates run locally

| gate | rc |
|---|---|
| `bun.sh run check` (biome + tsc) | 0 |
| `bun.sh run test` (243 files / 4518 tests) | 0 |
| `tsc -p e2e --noEmit` | 26 errors — the pre-existing baseline, zero mine |

Integration/e2e deliberately NOT run locally — CI on this PR owns them.

## Residue

- The DESIGN_NOTES entry for this slice is written but held out of the branch
  to avoid colliding with sibling worktrees; it lands with the merge.