### PR TITLE
web: gate /admin on the transport peer, not the resolved client IP

### DIFF
--- a/lib/grappa_web/plugs/loopback_only.ex
+++ b/lib/grappa_web/plugs/loopback_only.ex
@@ -1,7 +1,7 @@
 defmodule GrappaWeb.Plugs.LoopbackOnly do
   @moduledoc """
-  Halts any request whose `remote_ip` isn't `127.0.0.1` (or `::1`) with
-  a uniform 403 JSON body.
+  Halts, with a uniform 403 JSON body, any request that did not reach the
+  BEAM directly from inside the container / jail.
 
   Used to gate the admin reload endpoint (`POST /admin/reload`) so it's
   only callable from inside the running container / jail — `docker exec
@@ -22,43 +22,51 @@ defmodule GrappaWeb.Plugs.LoopbackOnly do
   basic-auth or session-cookie), this plug stays as the inner gate;
   the auth layer is the outer one.
 
-  ## Interaction with `RemoteIpFromProxy`
+  ## Why NOT `conn.remote_ip`
 
-  `GrappaWeb.Endpoint`'s `RemoteIpFromProxy` plug runs FIRST and may
-  rewrite `conn.remote_ip` from `X-Forwarded-For` when the peer is
-  loopback AND XFF is present (the local-reverse-proxy shape — the
-  bastille jail, or any deployment fronted by an operator's own
-  same-host proxy; #485 dropped the in-stack docker nginx). That
-  means a loopback peer
-  who sets `X-Forwarded-For: 127.0.0.1` will reach this plug with
-  `conn.remote_ip = {127, 0, 0, 1}` and pass the gate. This is
-  **explicitly accepted**: anyone with shell access on the host
-  (`sudo bastille cmd grappa`, `docker exec grappa`) already has
-  root-equivalent access — they can kill the BEAM, drop sqlite,
-  rewrite the codebase. POST /admin/reload is the least interesting
-  thing they could do. The defense at this layer is the real-client-IP
-  check above (a remote request arrives through the dumb proxy with
-  `conn.remote_ip` rewritten to the actual client, which is not
-  loopback, so it 403s) plus the compose port-publish binding grappa to
-  `127.0.0.1` — NOT input validation against an attacker with the keys.
-  See `RemoteIpFromProxy` moduledoc for the full trust matrix.
+  `conn.remote_ip` is an *attribution*, not a capability. By the time
+  this plug runs, `GrappaWeb.Endpoint`'s `RemoteIpFromProxy` has already
+  replaced the transport peer with the best available guess at who the
+  client is — and that guess can be loopback for reasons that carry no
+  operator privilege whatsoever. A forwarded chain that names only
+  reserved addresses yields no client at all, and the resolver then
+  answers with the transport peer, which behind a same-host reverse
+  proxy (the bastille jail, `proxy_pass 127.0.0.1:4000`) IS loopback.
+  Gating on that value made the gate a function of a heuristic.
+
+  So the gate reads `RemoteIpFromProxy.direct_loopback_peer?/1` instead:
+  the transport peer was loopback AND the request carried no forwarded
+  header. That is a property of the TRANSPORT — nothing a caller can put
+  in a header produces it — and it is exactly the operator shape this
+  gate exists for (`sudo bastille cmd grappa curl
+  http://127.0.0.1:4000/admin/reload`, `docker exec grappa curl ...`).
+  Every deploy path that pokes these routes uses exactly that shape.
+  A request that came through any proxy this project ships carries a
+  forwarded header unconditionally, so it can never satisfy the
+  predicate.
+
+  It **fails closed**: a conn that never passed through
+  `RemoteIpFromProxy` answers `false` and gets the 403.
+
+  The residual (a fronting proxy that sets no forwarded header at all
+  while proxying over loopback) is named in the `RemoteIpFromProxy`
+  moduledoc, together with the full trust matrix.
   """
   @behaviour Plug
 
   import Plug.Conn
 
-  @loopback_v4 {127, 0, 0, 1}
-  @loopback_v6 {0, 0, 0, 0, 0, 0, 0, 1}
+  alias GrappaWeb.Plugs.RemoteIpFromProxy
 
   @impl Plug
   def init(opts), do: opts
 
   @impl Plug
   def call(conn, _) do
-    case conn.remote_ip do
-      @loopback_v4 -> conn
-      @loopback_v6 -> conn
-      _ -> conn |> send_resp(403, ~s({"error":"loopback_only"})) |> halt()
+    if RemoteIpFromProxy.direct_loopback_peer?(conn) do
+      conn
+    else
+      conn |> send_resp(403, ~s({"error":"loopback_only"})) |> halt()
     end
   end
 end

--- a/lib/grappa_web/plugs/remote_ip_from_proxy.ex
+++ b/lib/grappa_web/plugs/remote_ip_from_proxy.ex
@@ -37,23 +37,39 @@ defmodule GrappaWeb.Plugs.RemoteIpFromProxy do
   The first row covers the operator's healthcheck/admin-poke shape:
   `sudo bastille cmd grappa curl http://127.0.0.1:4000/admin/reload`
   (or `docker exec grappa curl ...`) — loopback peer, no proxy
-  headers, trust the peer. `Plugs.LoopbackOnly` gates on the result.
+  headers, trust the peer. This row is ALSO the shape
+  `Plugs.LoopbackOnly` gates on — but it gates on the predicate below,
+  never on this row's resolved value.
 
-  ## Shell-spoof: explicitly accepted residual risk
+  ## The resolved client IP is NOT an authorization signal
 
-  An attacker with shell access on the host CAN spoof
-  `X-Forwarded-For: 127.0.0.1` from a loopback peer; the wrapper
-  trusts XFF in that case and `Plugs.LoopbackOnly` would accept
-  the result. The earlier (cp51-era) version of this plug blocked
-  that spoof at the cost of breaking nginx-as-local-proxy. The
-  trade-off is intentional: anyone who can run `sudo bastille cmd
-  grappa <anything>` or `docker exec grappa <anything>` already
-  has root-equivalent access (kill the BEAM, drop the sqlite DB,
-  write the codebase). `POST /admin/reload` is the least
-  interesting thing they could do. The defense at this layer is
-  network reachability (nginx doesn't proxy `/admin/reload`,
-  grappa binds 127.0.0.1 only), NOT input validation against an
-  attacker who already has the keys.
+  `trusted_client_ip/3`'s answer is the best available *attribution* of
+  a request — it is not a capability. A resolved value of `127.0.0.1`
+  can mean "the operator's shell curled us directly" OR "a forwarded
+  chain resolved to nothing and the peer happened to be the local
+  reverse proxy". Those two are not equally privileged, and no consumer
+  can tell them apart from the resolved value alone.
+
+  So `Plugs.LoopbackOnly` does NOT read `conn.remote_ip`. It reads
+  `direct_loopback_peer?/1`, the row-1 predicate this plug stamps as an
+  assign: transport peer is loopback AND the request carries no
+  forwarded header at all. That is exactly the operator-shell shape and
+  it is a property of the TRANSPORT, so it cannot be produced by
+  anything a request body or header says. Every reverse proxy this
+  project ships sets a forwarded header unconditionally
+  (`infra/snippets/locations-api.conf`), so a request that arrived
+  through one can never satisfy the predicate.
+
+  **Residual, named:** the predicate's tightness rests on the fronting
+  proxy setting a forwarded header. An operator who fronts grappa with
+  their own proxy that sets none AND proxies over loopback presents
+  every request as the operator shell. That is unchanged from the
+  earlier behaviour rather than introduced here, and it is why
+  operators should keep grappa's port bound away from untrusted
+  networks regardless. Shell access on the host also remains
+  root-equivalent by construction (kill the BEAM, drop the sqlite DB,
+  rewrite the codebase), so this layer never claimed to defend against
+  it.
 
   ## Loopback shapes
 
@@ -84,6 +100,11 @@ defmodule GrappaWeb.Plugs.RemoteIpFromProxy do
   # doors can't drift onto different header sets.
   @default_headers ~w[x-forwarded-for x-real-ip]
 
+  # The assign carrying the row-1 predicate. Private on purpose: readers go
+  # through `direct_loopback_peer?/1` so exactly ONE module knows both the
+  # key and the fail-closed default.
+  @direct_peer_assign :direct_loopback_peer
+
   @typedoc "Packed plug options: the header allowlist + the `RemoteIp` keyword opts."
   @type opts :: {[binary()], keyword()}
 
@@ -100,7 +121,7 @@ defmodule GrappaWeb.Plugs.RemoteIpFromProxy do
 
   @impl Plug
   @spec call(Plug.Conn.t(), opts()) :: Plug.Conn.t()
-  def call(%Plug.Conn{remote_ip: peer, req_headers: req_headers} = conn, opts) do
+  def call(%Plug.Conn{remote_ip: peer, req_headers: req_headers} = conn, {headers, _} = opts) do
     ip = trusted_client_ip(peer, req_headers, opts)
     # Preserve `RemoteIp.call/2`'s side-effect: it stamped the `:remote_ip`
     # Logger metadata (config allowlists it — the HTTP log line carries the
@@ -108,7 +129,42 @@ defmodule GrappaWeb.Plugs.RemoteIpFromProxy do
     # here. This is an HTTP-request logging concern local to the plug, not
     # part of the shared trust decision.
     put_remote_ip_metadata(ip)
-    %{conn | remote_ip: ip}
+
+    # Stamp the row-1 predicate here — this is the only point in the pipeline
+    # that still sees the transport peer, which `remote_ip` is about to lose.
+    direct? = direct_loopback_peer?(peer, req_headers, headers)
+
+    Plug.Conn.assign(%{conn | remote_ip: ip}, @direct_peer_assign, direct?)
+  end
+
+  @doc """
+  Whether the request reached the BEAM DIRECTLY from inside the box: the
+  transport peer is loopback and no forwarded header is present.
+
+  This is the authorization-grade signal `Plugs.LoopbackOnly` gates on —
+  distinct from `conn.remote_ip`, which after `call/2` is an attribution
+  and can be loopback for reasons that carry no privilege. Reads the assign
+  `call/2` stamps and **fails closed**: a conn the plug never touched
+  answers `false`.
+  """
+  @spec direct_loopback_peer?(Plug.Conn.t()) :: boolean()
+  def direct_loopback_peer?(%Plug.Conn{assigns: assigns}),
+    do: Map.get(assigns, @direct_peer_assign, false)
+
+  @doc """
+  Row 1 of the trust matrix, as a predicate: loopback transport peer AND no
+  forwarded header among the `headers` allowlist.
+
+  Both a resolution input (row 1 returns the peer verbatim) and the
+  authorization signal `call/2` stamps for `Plugs.LoopbackOnly` — one
+  definition, so the gate can never drift onto a different header allowlist
+  than the resolver. Takes the allowlist itself, not the packed `opts()`:
+  the decision has no business reading `RemoteIp`'s keyword options.
+  """
+  @spec direct_loopback_peer?(:inet.ip_address(), [{binary(), binary()}], [binary()]) ::
+          boolean()
+  def direct_loopback_peer?(peer_ip, req_headers, headers) do
+    loopback?(peer_ip) and not has_forwarded_header?(req_headers, headers)
   end
 
   @doc """
@@ -136,14 +192,26 @@ defmodule GrappaWeb.Plugs.RemoteIpFromProxy do
   forwarded chain right-to-left and stops at the first non-reserved IP —
   so a trusted proxy's appended real client wins over any forged leftmost
   entry, and a header yielding no client falls back to the peer.
+
+  That last fallback is a known ATTRIBUTION limitation, still open: when
+  every entry in the chain is a reserved address the walk yields nothing,
+  and the answer collapses onto the transport peer — so such clients
+  share one identity for throttle keys, the `sessions.ip` audit column
+  and the #543 mode-2 source derivation. Do NOT read a return value of
+  this function as a privilege; `Plugs.LoopbackOnly` gates on
+  `direct_loopback_peer?/1` precisely so this limitation cannot become an
+  authorization decision.
   """
   @spec trusted_client_ip(:inet.ip_address(), [{binary(), binary()}], opts()) ::
           :inet.ip_address()
   def trusted_client_ip(peer_ip, req_headers, {headers, remote_ip_opts}) do
-    if loopback?(peer_ip) and not has_forwarded_header?(req_headers, headers) do
+    if direct_loopback_peer?(peer_ip, req_headers, headers) do
       peer_ip
     else
-      RemoteIp.from(req_headers, remote_ip_opts) || peer_ip
+      case RemoteIp.from(req_headers, remote_ip_opts) do
+        nil -> peer_ip
+        client -> client
+      end
     end
   end
 

--- a/lib/grappa_web/router.ex
+++ b/lib/grappa_web/router.ex
@@ -61,10 +61,12 @@ defmodule GrappaWeb.Router do
     plug GrappaWeb.Plugs.ResolveNetwork
   end
 
-  # Admin pipeline — loopback-only gate. Used by `POST /admin/reload`
-  # (CP23 cluster `code-reload` B3). Reachable from `docker exec grappa
-  # curl ...` inside the container; nginx doesn't proxy `/admin/*` and
-  # the compose service publishes loopback-only by default.
+  # Admin pipeline — direct-peer gate. Used by `POST /admin/reload`
+  # (CP23 cluster `code-reload` B3). Reachable ONLY from `docker exec
+  # grappa curl ...` / `bastille cmd grappa curl ...` inside the box:
+  # since #485 every nginx substrate forwards `/admin/*` unfiltered, so
+  # this plug is the gate — and it keys on the transport peer, not on the
+  # resolved client IP. See `GrappaWeb.Plugs.LoopbackOnly`.
   pipeline :admin do
     plug :accepts, ["json", "text"]
     plug GrappaWeb.Plugs.LoopbackOnly

--- a/test/grappa_web/controllers/admin_controller_test.exs
+++ b/test/grappa_web/controllers/admin_controller_test.exs
@@ -1,11 +1,14 @@
 defmodule GrappaWeb.AdminControllerTest do
   @moduledoc """
-  `POST /admin/reload` is loopback-gated (only `127.0.0.1` / `::1`)
-  and triggers `Phoenix.CodeReloader.reload/1` on success.
+  `POST /admin/reload` is gated on the request having reached the BEAM
+  directly from inside the box (loopback transport peer AND no forwarded
+  header) and triggers `Phoenix.CodeReloader.reload/1` on success.
 
-  The loopback gate is the load-bearing security check — the test
-  exercises both the allow path (default ConnCase remote_ip is
-  `127.0.0.1`) and the deny path (manually rewritten remote_ip).
+  That gate is the load-bearing security check — the tests exercise the
+  allow path (default ConnCase peer is `127.0.0.1`, bare) and every deny
+  path: a non-loopback peer, and a loopback peer carrying a forwarded
+  header (i.e. one that came through a proxy). The gate never reads the
+  RESOLVED client IP; see `GrappaWeb.Plugs.LoopbackOnly`.
 
   The reload itself is a no-op against committed code in the test
   sandbox (Mix is loaded, so reload! runs; nothing changed on disk).
@@ -70,47 +73,48 @@ defmodule GrappaWeb.AdminControllerTest do
       assert response(conn, 403) =~ "loopback_only"
     end
 
-    # SECURITY: end-to-end proof that the `RemoteIpFromProxy` wrapper
-    # protects the LoopbackOnly gate from container-shell spoofing.
-    # The attack: `docker exec grappa curl -H "X-Forwarded-For: <ip>"
-    # http://localhost:4000/admin/reload`. Bare `RemoteIp` would
-    # rewrite `conn.remote_ip` from the header and (when the spoofed
-    # value is loopback) silently grant access. The wrapper bypasses
-    # the rewrite when the TCP peer is loopback, so the gate sees the
-    # genuine loopback peer (allow) and the spoofed value is ignored.
+    # SECURITY: the presence of ANY forwarded header disqualifies a
+    # request from the gate, loopback transport peer or not. A forwarded
+    # header means some proxy handled this request, and the operator
+    # shape the gate exists for never goes through one.
     #
-    # Tested at controller level (not unit) because the integration
-    # of wrapper + LoopbackOnly + admin pipeline is the contract that
-    # actually defends the surface — a wrapper-only unit test would
-    # pass even if a future refactor removed the wrapper from the
-    # endpoint.
-    test "spoofed X-Forwarded-For from loopback peer is ignored, gate still passes (200)",
-         %{conn: conn} do
-      # Peer = 127.0.0.1 (ConnCase default), X-F-F spoofs a LAN IP.
-      # Without the wrapper: bare RemoteIp rewrites to {192,168,1,100},
-      # LoopbackOnly returns 403 (by coincidence the spoof self-DoSes).
-      # WITH the wrapper: peer is loopback → wrapper bypasses → gate
-      # sees {127,0,0,1} → 200.
+    # This case USED to return 200, and for the wrong reason: the header
+    # named only a reserved address, the resolver therefore found no
+    # client, fell back to the transport peer, and the gate — which read
+    # the resolved value — saw loopback. The 200 was the fallback
+    # showing through, not a deliberate allowance.
+    #
+    # Tested at controller level (not unit) because the integration of
+    # wrapper + LoopbackOnly + admin pipeline is the contract that
+    # actually defends the surface — a wrapper-only unit test would pass
+    # even if a future refactor removed the wrapper from the endpoint.
+    test "loopback peer carrying a forwarded header is denied (403)", %{conn: conn} do
       conn =
         conn
         |> Plug.Conn.put_req_header("x-forwarded-for", "192.168.1.100")
         |> post("/admin/reload")
 
-      body = json_response(conn, 200)
-      assert is_list(body["reloaded"])
+      assert response(conn, 403) =~ "loopback_only"
     end
 
-    test "spoofed X-Forwarded-For: 127.0.0.1 from non-loopback peer is denied (403)",
+    test "X-Real-IP also disqualifies a loopback peer (403)", %{conn: conn} do
+      # Both headers in the allowlist must disqualify, or the gate's
+      # tightness would depend on which one the fronting proxy sets —
+      # the shipped snippets set BOTH, an operator's own proxy may set
+      # either.
+      conn =
+        conn
+        |> Plug.Conn.put_req_header("x-real-ip", "192.168.1.100")
+        |> post("/admin/reload")
+
+      assert response(conn, 403) =~ "loopback_only"
+    end
+
+    test "forwarded header naming loopback, from a non-loopback peer, is denied (403)",
          %{conn: conn} do
-      # The malicious case the wrapper exists to prevent: peer is a
-      # LAN IP, attacker sets `X-Forwarded-For: 127.0.0.1` hoping to
-      # masquerade as loopback. Wrapper bypass applies only to
-      # loopback PEERS — a LAN peer still hits bare RemoteIp, which
-      # walks the X-F-F chain and finds {127,0,0,1} as a reserved-
-      # range hit. `RemoteIp` skips reserved entries during the walk,
-      # so the rewrite falls back to... nothing in the chain, leaving
-      # conn.remote_ip as the original peer {192,168,1,100}. The gate
-      # sees a LAN IP and returns 403. (The attacker can't elevate.)
+      # A caller on a LAN peer claiming to be loopback. Denied twice
+      # over: the peer is not loopback, and a forwarded header is
+      # present. The gate never consults what the header claims.
       conn =
         %{conn | remote_ip: {192, 168, 1, 100}}
         |> Plug.Conn.put_req_header("x-forwarded-for", "127.0.0.1")

--- a/test/grappa_web/plugs/remote_ip_from_proxy_test.exs
+++ b/test/grappa_web/plugs/remote_ip_from_proxy_test.exs
@@ -12,6 +12,13 @@ defmodule GrappaWeb.Plugs.RemoteIpFromProxyTest do
   The loopback+XFF row is the bastille-jail (and Docker) shape:
   nginx runs on the same host and proxies via loopback. Tests pin
   the matrix so a config-shape drift fails here before it ships.
+
+  The plug also stamps `direct_loopback_peer?/1` — row 1 as a boolean,
+  the authorization-grade signal `Plugs.LoopbackOnly` gates on. It is
+  deliberately NOT the resolved `conn.remote_ip`: that value is an
+  attribution and can be loopback for reasons carrying no privilege.
+  Its own describe block pins the predicate, the fail-closed default,
+  and the named residual.
   """
   use ExUnit.Case, async: true
 
@@ -182,6 +189,80 @@ defmodule GrappaWeb.Plugs.RemoteIpFromProxyTest do
                {203, 0, 113, 7},
                [{"x-forwarded-for", "10.0.0.5"}]
              ) == {203, 0, 113, 7}
+    end
+  end
+
+  # A caller whose own source address is in a reserved range, fronted by a
+  # same-host reverse proxy, arrives with a forwarded chain in which every
+  # entry is reserved. The resolver finds no client in such a chain and
+  # answers with the transport peer — which in that topology is loopback.
+  #
+  # No header is forged; the proxy builds the chain itself. The gate must
+  # deny anyway, and it does, because it reads the transport predicate and
+  # not the resolved value. This pins the GATE, which is the whole point of
+  # separating the two.
+  #
+  # The sibling property — that the RESOLVED value should not collapse onto
+  # the peer either — is an attribution concern, still open, and is NOT
+  # pinned here: it has no fix in this tree, and a permanently-red test
+  # buys nothing. See the `trusted_client_ip/3` moduledoc.
+  describe "reserved-only forwarded chain behind a loopback proxy" do
+    test "the loopback gate rejects a private-range caller fronted by a loopback proxy" do
+      conn =
+        :post
+        |> Plug.Test.conn("/admin/cic-bundle-changed")
+        |> Map.put(:remote_ip, {127, 0, 0, 1})
+        |> Plug.Conn.put_req_header("x-forwarded-for", "10.66.6.6")
+        |> RemoteIpFromProxy.call(RemoteIpFromProxy.init(@plug_opts))
+        |> GrappaWeb.Plugs.LoopbackOnly.call([])
+
+      assert conn.halted, "LoopbackOnly admitted a caller whose real source is 10.66.6.6"
+      assert conn.status == 403
+    end
+  end
+
+  # The authorization-grade signal `Plugs.LoopbackOnly` gates on. Distinct
+  # from the resolved `conn.remote_ip`, which is an attribution: it can be
+  # loopback for reasons that carry no operator privilege. This predicate is
+  # a property of the TRANSPORT, so no header can produce it.
+  describe "direct_loopback_peer? — the gate signal" do
+    test "fails closed on a conn the plug never touched" do
+      refute RemoteIpFromProxy.direct_loopback_peer?(%Plug.Conn{remote_ip: {127, 0, 0, 1}})
+    end
+
+    test "true for a loopback peer with no forwarded header (the operator shell)" do
+      assert RemoteIpFromProxy.direct_loopback_peer?(call({127, 0, 0, 1}, []))
+      assert RemoteIpFromProxy.direct_loopback_peer?(call({0, 0, 0, 0, 0, 0, 0, 1}, []))
+    end
+
+    test "false for a loopback peer carrying any allowlisted forwarded header" do
+      refute RemoteIpFromProxy.direct_loopback_peer?(call({127, 0, 0, 1}, [{"x-forwarded-for", "10.66.6.6"}]))
+
+      refute RemoteIpFromProxy.direct_loopback_peer?(call({127, 0, 0, 1}, [{"x-real-ip", "10.66.6.6"}]))
+    end
+
+    test "false for a non-loopback peer" do
+      refute RemoteIpFromProxy.direct_loopback_peer?(call({10, 66, 6, 6}, []))
+      refute RemoteIpFromProxy.direct_loopback_peer?(call({203, 0, 113, 42}, []))
+    end
+
+    # RESIDUAL, pinned so it is not mistaken for a closed hole: the
+    # predicate's tightness rests on the fronting proxy setting a forwarded
+    # header. Every proxy config this project ships sets both headers
+    # unconditionally, but an operator's own proxy that sets NEITHER while
+    # proxying over loopback is indistinguishable from the operator shell.
+    # This is unchanged from the prior behaviour rather than introduced by
+    # the gate change — it is a reason to keep the port off untrusted
+    # networks, not a reason to widen the gate.
+    test "a header-less loopback-fronting proxy is indistinguishable from the shell" do
+      assert RemoteIpFromProxy.direct_loopback_peer?(call({127, 0, 0, 1}, []))
+    end
+
+    # A header OUTSIDE the allowlist must not disqualify: the gate and the
+    # resolver read the SAME allowlist, so a random `forwarded:` header
+    # can't lock the operator out of their own reload endpoint.
+    test "a header outside the allowlist does not disqualify" do
+      assert RemoteIpFromProxy.direct_loopback_peer?(call({127, 0, 0, 1}, [{"forwarded", "for=10.66.6.6"}]))
     end
   end
 


### PR DESCRIPTION
## What

`Plugs.LoopbackOnly` gated `POST /admin/reload` + `POST /admin/cic-bundle-changed`
by reading `conn.remote_ip`. By the time the gate runs, that field is
`RemoteIpFromProxy`'s best guess at **who the client is** — an attribution, not a
capability. It can be loopback because the operator curled us from inside the box,
or because a forwarded chain resolved to nothing and the transport peer happened to
be a same-host reverse proxy. Nothing downstream can tell those apart from the value
alone, so an authorization decision was riding on a resolution heuristic.

The gate now reads `RemoteIpFromProxy.direct_loopback_peer?/1`: **transport peer was
loopback AND the request carried no forwarded header**. That is row 1 of the existing
trust matrix expressed as a predicate, stamped as an assign at the one point in the
pipeline that still sees the peer. It is a property of the transport, so no header
produces it, and it **fails closed** when the plug has not run.

## Operator cost: zero, measured

Every shipped caller of these two routes hits `127.0.0.1:4000` **directly**:
`scripts/deploy.sh`, `infra/docker/deploy.sh`, `infra/freebsd/deploy.sh`,
`infra/freebsd/jail_deploy_cic.sh`, `scripts/deploy-cic.sh`. Both shipped nginx
snippets set `X-Real-IP` + `X-Forwarded-For` unconditionally
(`infra/snippets/locations-api.conf`). Clean separation: through a proxy → never
passes; from inside the box → always passes.

## Still open — this closes the GATE and nothing else

Named explicitly so this does not read as done:

- **Attribution collapse.** The resolved value can still fall back to the transport
  peer for callers the forwarded chain cannot identify, so those callers share one
  identity across throttle keys, the `sessions.ip` audit column, and the #543 mode-2
  source derivation. Different fix, different risk profile — deliberately not here.
  `trusted_client_ip/3`'s moduledoc says so at the call site.
- **Chain-entry selection.** Which entry of a forwarded chain wins is still
  influenced by the chain's own contents. Untouched here; changing it needs its own
  threat test written first.

## One flipped test, and why it mattered

`admin_controller_test.exs` had a test pinning 200 for a loopback peer carrying a
forwarded header, with a comment claiming the wrapper bypassed the rewrite for
loopback peers. That is not the mechanism: a present header takes the header row,
the wrapper does not bypass, and the 200 came out of the resolver's
fall-back-to-peer. It was a **green pin on the defect**, explained by a mechanism
that was not in play. Now 403, with a comment describing what actually happens.

## Dialyzer note

Extracting the predicate produced one `missing_range: nil` on `trusted_client_ip/3`:
with the `if` condition behind an opaque call, Dialyzer stops eliminating the `nil`
in `RemoteIp.from/2`'s spec through `x || peer_ip`. Isolated by displacement (inline
green / extracted red; `||` red / explicit `case` green) rather than explained — I am
not claiming to know Dialyzer's pruning heuristic. The explicit `case` is the better
shape anyway: the "chain resolved to nothing, fall back to the peer" line is
load-bearing and now reads as a branch instead of a trailing `||`.

## Test plan

- [x] `scripts/check.sh` from the worktree root — **rc=0**: 5323 tests / 0 failures,
      Credo `found no issues`, Dialyzer `Total errors: 0`, Sobelow, `deps.audit`
      (`No vulnerabilities found`), doctor.
- [x] Rebased onto `origin/main` c58ec3eb; `git merge-base --is-ancestor` verified.
- [ ] CI (integration + e2e not run locally).