### PR TITLE
auth: bring two login doors onto the shared failure-window shape

### DIFF
--- a/cicchetto/src/AdminEventsTab.tsx
+++ b/cicchetto/src/AdminEventsTab.tsx
@@ -1,6 +1,10 @@
 import { type Component, For } from "solid-js";
 import { adminEvents } from "./lib/adminEvents";
 import { assertNever, type WireAdminEvent } from "./lib/api";
+import type {
+  AdminEventsWireLoginThrottleDoor,
+  AdminEventsWireLoginThrottleScope,
+} from "./lib/wireTypes";
 
 // M-11 — Admin events tab. Renders the in-memory ring buffer from
 // `adminEvents()` newest-first. Per `feedback_no_localized_strings_server_side`,
@@ -98,8 +102,13 @@ function renderEvent(ev: WireAdminEvent): string {
     case "credential_unbound":
       return `${ev.user_name} unbound from ${ev.network_slug}${actorSuffix(ev.actor_user_name)}`;
     case "login_throttled":
-      // S6 — admin-login brute-force gate tripped for this source IP.
-      return `login throttled: ${ev.source_ip ?? "(unknown ip)"} hit ${ev.failures} failures in ${Math.round(ev.window_ms / 60000)}m`;
+      // S6 — a credential door's brute-force gate tripped for this source
+      // IP. Seven windows across five doors share this event, so the door
+      // and the key that crossed are what make it actionable: the fine key
+      // says one account is being hammered from that address, the ceiling
+      // says the address is spraying across accounts. Both are additive —
+      // a row minted before they existed reads as the bare trip.
+      return `login throttled: ${ev.source_ip ?? "(unknown ip)"} hit ${ev.failures} failures in ${Math.round(ev.window_ms / 60000)}m${throttleAttribution(ev.door, ev.scope)}`;
     case "web_session_severed":
       // #630 — a subject's web session was severed for sustained inbound
       // flooding (socket closed + bearer revoked; IRC session untouched).
@@ -123,6 +132,21 @@ function capLabel(n: number | null): string {
 
 function actorSuffix(name: string | null): string {
   return name !== null ? ` by ${name}` : "";
+}
+
+// Names the FailureWindow row that shut. `undefined` is the honest
+// reading of a pre-upgrade event replayed from the persisted ring, so it
+// renders as nothing rather than as a guess. `ip_account` is spelled
+// "per-account" and the bare `ip` "per-address" because that difference
+// IS the operator's read: one account hammered from an address versus an
+// address spraying across accounts.
+function throttleAttribution(
+  door: AdminEventsWireLoginThrottleDoor | undefined,
+  scope: AdminEventsWireLoginThrottleScope | undefined,
+): string {
+  if (door === undefined) return "";
+  if (scope === undefined) return ` [${door}]`;
+  return ` [${door}, ${scope === "ip_account" ? "per-account" : "per-address"}]`;
 }
 
 export default AdminEventsTab;

--- a/cicchetto/src/lib/wireNarrow.ts
+++ b/cicchetto/src/lib/wireNarrow.ts
@@ -9,11 +9,23 @@ import type {
 } from "./api";
 import type { ModesEntry, TopicEntry } from "./channelTopic";
 import type { MemberEntry } from "./memberTypes";
-import type { SessionLogEvent, SessionLogWireT, WindowCountsSeverity } from "./wireTypes";
+import type {
+  AdminEventsWireLoginThrottleDoor,
+  AdminEventsWireLoginThrottleScope,
+  SessionLogEvent,
+  SessionLogWireT,
+  WindowCountsSeverity,
+} from "./wireTypes";
 // #410 — the runtime allowlists derive from the codegen-emitted `as const`
 // enum arrays, so each closed set has ONE source (the server typespec via
 // wireTypes.ts), not a hand copy that can silently drift.
-import { SCROLLBACK_MESSAGE_KIND, SESSION_LOG_EVENT, WINDOW_COUNTS_SEVERITY } from "./wireTypes";
+import {
+  ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_DOOR,
+  ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_SCOPE,
+  SCROLLBACK_MESSAGE_KIND,
+  SESSION_LOG_EVENT,
+  WINDOW_COUNTS_SEVERITY,
+} from "./wireTypes";
 
 // #267 — narrow the window_counts severity to the closed union, defaulting
 // to "none" for an unknown value (defensive: a stale server mid hot-reload
@@ -25,6 +37,18 @@ function narrowSeverity(raw: unknown): WindowCountsSeverity {
   return typeof raw === "string" && (WINDOW_COUNTS_SEVERITY as readonly string[]).includes(raw)
     ? (raw as WindowCountsSeverity)
     : "none";
+}
+
+// An ADDITIVE closed-set field: absent (an older server minted the event)
+// or unrecognised (a newer one added an arm) both narrow to `undefined`,
+// so the caller renders without it instead of dropping the event. Same
+// #410 discipline as `narrowSeverity` — the allowlist IS the
+// codegen-emitted const, never a hand copy.
+function narrowEnumMember<T extends string>(
+  raw: unknown,
+  allowed: readonly string[],
+): T | undefined {
+  return typeof raw === "string" && allowed.includes(raw) ? (raw as T) : undefined;
 }
 
 // Bucket G H4+U3 (codebase-review-2026-05-12): runtime narrowing for
@@ -853,8 +877,14 @@ export function narrowAdminEvent(raw: unknown): WireAdminEvent | null {
         actor_user_name: r.actor_user_name,
         at: r.at as string,
       };
-    // S6 (review 2026-07-19) — mode-1 login throttle trip. source_ip
-    // is nullable (server RemoteIP honesty for unresolvable peers).
+    // S6 (review 2026-07-19) — a credential door's throttle trip.
+    // source_ip is nullable (server RemoteIP honesty for unresolvable
+    // peers). door/scope are ADDITIVE and narrow to `undefined` rather
+    // than nulling the event: the admin ring is mirrored to disk and
+    // reloaded at boot, so the Events tab genuinely replays rows minted
+    // before the fields existed. The trip is the load-bearing part; the
+    // attribution is the detail, and a missing detail must not delete
+    // the alert.
     case "login_throttled":
       if (
         !isNullableString(r.source_ip) ||
@@ -868,6 +898,14 @@ export function narrowAdminEvent(raw: unknown): WireAdminEvent | null {
         failures: r.failures,
         window_ms: r.window_ms,
         at: r.at as string,
+        door: narrowEnumMember<AdminEventsWireLoginThrottleDoor>(
+          r.door,
+          ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_DOOR,
+        ),
+        scope: narrowEnumMember<AdminEventsWireLoginThrottleScope>(
+          r.scope,
+          ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_SCOPE,
+        ),
       };
     case "cap_counts_changed":
       // REV-H H5 (2026-05-22): network_slug is required non-null on

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -368,12 +368,28 @@ export type AdminEventsWireCredentialUnboundEvent = {
   at: string;
 };
 
+export const ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_DOOR = [
+  "mode1_login",
+  "visitor_login",
+  "totp_login",
+  "passkey_recovery",
+  "passkey_login_options",
+] as const;
+export type AdminEventsWireLoginThrottleDoor =
+  (typeof ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_DOOR)[number];
+
+export const ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_SCOPE = ["ip", "ip_account"] as const;
+export type AdminEventsWireLoginThrottleScope =
+  (typeof ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_SCOPE)[number];
+
 export type AdminEventsWireLoginThrottledEvent = {
   kind: "login_throttled";
   source_ip: string | null;
   failures: number;
   window_ms: number;
   at: string;
+  door?: AdminEventsWireLoginThrottleDoor;
+  scope?: AdminEventsWireLoginThrottleScope;
 };
 
 export type AdminEventsWireWebSessionSeveredEvent = {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -31856,3 +31856,60 @@ is only reachable after the password, and the challenge token is bound to
 proven a password. And no per-account deny is added here either: the ceiling
 is per source IP, so a caller can only spend their own address, never lock
 another account's owner out of theirs.
+
+## 2026-08-07 — every credential window speaks, and says which one it was
+
+Two windows had been added the same night the audit was written, and the audit
+was right about the half it saw and wrong about its size. `login_throttled`
+had one emitter when the audit was written and two by the time it was read —
+the visitor door above had added one. The real number is worse than either:
+the unit that shuts is not a door but a `FailureWindow` row, `(bucket, key)`,
+and `:totp_login` and `:passkey_recovery` carry two rows each. Seven windows
+guard a credential door. Two emitted. Five — one of them added that night —
+shut in total silence.
+
+**A window that denies without a signal is a brake nobody knows is on.** It
+does not fail loudly; it fails as an unexplained login problem, which is the
+one failure mode an operator cannot tell from a bug. So the fix is not another
+emitter at each site: `GrappaWeb.LoginThrottle.charge/4` records the failure
+AND raises the crossing signal in one verb, and every credential door now
+charges through it. The signal is no longer a step a caller can forget — a new
+door cannot be added mute, because there is no longer a way to record a
+failure without it. `FailureWindow.check/3` deliberately stays at each call
+site: only the caller knows what expensive work it gates and what refusing
+must return. This is visibility, not policy.
+
+**Attribution is not decoration.** Seven windows sharing one undifferentiated
+event would tell an operator that some address hit thirty failures and leave
+them to guess whether that was a TOTP ceiling, a recovery ceiling, or
+challenge-allocation abuse — three different incidents. So the event carries
+`door` (which IS the bucket, derived from the counter rather than tracked
+beside it) and `scope` (`:ip` or `:ip_account`, derived from the shape of the
+key). The pair matters on the two-row doors: the fine key crossing says one
+account is being hammered from that address; the ceiling crossing says that
+address is spraying across accounts.
+
+**What is deliberately NOT in the payload: the account id.** On the recovery
+door the identifier is attacker-supplied and resolved by `find_user/1`, so
+carrying the account would let a spray write names of its own choosing into
+the admin stream. The operator gets the address, which is the party that can
+actually be acted on.
+
+**Why the two fields are `optional` on the wire, and why that is honest rather
+than a hedge.** The admin ring is mirrored to disk and reloaded at boot (#215
+Option B, `load_recent/1`), and `snapshot/0` serves those reloaded rows to a
+joining admin socket. After this upgrade the Events tab genuinely replays
+`login_throttled` rows minted by a server that predates the fields. So absence
+is a real wire state, not a hypothetical old client, and cic narrows both to
+`undefined` rather than nulling the event: the trip is the load-bearing part,
+the attribution is the detail, and a missing detail must not delete the alert.
+Additive fields need no `protocol_version` bump.
+
+Naming both closed sets rather than inlining them was forced, and the forcing
+is worth recording: the door union is 102 characters as an inline map field,
+which `mix grappa.gen_wire_types` emits unwrapped but biome would wrap at 100
+— the codegen drift gate and the cic format gate would have disagreed forever.
+A named enum type is emitted as an `as const` array plus a derived type, both
+formatted by the generator's own biome-mimicking rules, so the two gates agree.
+The new fields sit LAST in the map typespec so source order and any
+required-before-optional canonicalisation produce the same generated output.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -31776,6 +31776,7 @@ on a flex child, ask whether the parent has a fixed height. If it does, you
 have not set a minimum — you have replaced one, and handed the algorithm
 permission to use yours as the target.
 
+
 ## 2026-08-07 — the visitor password gate gets a window, keyed on the source IP alone
 
 `Grappa.RateLimit.FailureWindow` now stands in front of the visitor login
@@ -31834,3 +31835,24 @@ spend a visitor's own door on the server's problems. The test that pins the
 `:password_required` half would pass vacuously against the pre-fix tree, so it
 was proven by mutation — recording on every error branch turns it red.
 
+## 2026-08-07 — `:totp_login` gets the aggregate ceiling its siblings already had
+
+The second-factor window was keyed on `{ip, user_id}` and nothing else. That
+key is STRICTER than per-IP, not looser, which is exactly why it left a gap:
+one address got ten guesses PER ACCOUNT, so a hundred accounts bought a
+thousand attempts and no single key ever reached its limit. The fine key
+bounds the pair; nothing bounded the address.
+
+`:passkey_recovery` already carries both dimensions — 10 per `{ip, account}`
+and 30 per `ip` — and that second number is the one doing the work. So
+`:totp_login` now checks both and records both, with `@totp_ip_max_failures`
+at the same 30. The success path still clears the fine key only: an account
+the caller CAN satisfy must not reset the ceiling for every other account
+they are guessing.
+
+Two things this does not change. The attenuation stands — the second factor
+is only reachable after the password, and the challenge token is bound to
+`{user_id, ip, client_id}`, so the address spending the aggregate has already
+proven a password. And no per-account deny is added here either: the ceiling
+is per source IP, so a caller can only spend their own address, never lock
+another account's owner out of theirs.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -31776,3 +31776,61 @@ on a flex child, ask whether the parent has a fixed height. If it does, you
 have not set a minimum — you have replaced one, and handed the algorithm
 permission to use yours as the target.
 
+## 2026-08-07 — the visitor password gate gets a window, keyed on the source IP alone
+
+`Grappa.RateLimit.FailureWindow` now stands in front of the visitor login
+door (`AuthController.visitor_login/7`), bucket `:visitor_login`, 10 failures
+per 15 minutes per source IP. Same infrastructure and same shape as the
+mode-1 account door has used since S6 — check before the work, record only on
+a mismatch, one `login_throttled` admin event on the crossing failure. A
+separate bucket on purpose: merging two credential policies because they
+share a counter is how one door's limit silently becomes the other's.
+
+**It lives at the HTTP edge because the Boundary compiler said so, and it was
+right.** The first cut put the check inside `Visitors.Login`, next to the
+compare, which is where the scoping is most precise. `Grappa.Visitors` does
+not depend on `Grappa.RateLimit` or `Grappa.AdminEvents`, and the build said
+so out loud. Widening a domain context's dependency surface to hold a
+request-edge policy keyed on the source IP is the wrong trade when all three
+sibling windows already live in controllers — so the window moved to the
+door instead, and the domain context is untouched by this change. The
+placement is also strictly earlier: the check now precedes the nick
+classification, the DB lookups, the Cloak decrypt and any spawn, rather than
+sitting one frame above the compare.
+
+**Only a credential-bearing attempt is gated.** With the check at the door it
+would otherwise cover the anon and fresh-provision branches too, so a spray
+against registered nicks would take anonymous logins from the same NAT down
+with it. `check_visitor_throttle/2` returns `:ok` immediately when no password
+was supplied; the branches that carry one — the registered gate and the
+fresh-provision NickServ path, which dials an upstream with that secret — are
+both bounded.
+
+**Why this door and not another.** It is the credential door with the least
+under it. The account door pays an Argon2 per guess; this one pays a Cloak
+decrypt and a `Plug.Crypto.secure_compare/2` — constant-time, so no timing
+oracle, but cheap. It is also the only credential door mounted on
+`pipe_through :api`, with no request budget in front, and the captcha gates
+the fresh-provision branch rather than this one (and its default provider is
+`Disabled`, so an unconfigured self-host has none anywhere). Every attenuation
+that makes the other doors tolerable is absent here at once.
+
+**The key is the source IP and nothing else, and that is the design, not an
+omission.** A per-account dimension that DENIES is a remote lockout on someone
+else's identity: visitor nicks are enumerable at zero cost, and the window
+renews, so a single wrong guess every 90 seconds would hold a nick shut
+forever. The attacker would pay with the victim's door instead of their own.
+The per-IP cost on shared NAT is the tradeoff this project already accepted
+three doors over (2026-07-03), so the fix adds no lockout vector that did not
+already exist. What it explicitly does NOT buy is the distributed case: N
+addresses still get N windows, here as everywhere else — none of the failure
+windows in the codebase sums across IPs. Bounding that is detection before it
+is prevention, and it is a separate decision.
+
+**Only a wrong password charges it.** `record_visitor_failure/2` matches
+`:password_mismatch` and nothing else: a capacity refusal, an unreachable
+upstream or a `:password_required` are not guesses, and charging them would
+spend a visitor's own door on the server's problems. The test that pins the
+`:password_required` half would pass vacuously against the pre-fix tree, so it
+was proven by mutation — recording on every error branch turns it red.
+

--- a/lib/grappa/admin_events/wire.ex
+++ b/lib/grappa/admin_events/wire.ex
@@ -340,18 +340,57 @@ defmodule Grappa.AdminEvents.Wire do
         }
 
   @typedoc """
-  S6 (review 2026-07-19) — a source IP crossed the mode-1 login
-  failure threshold and is now throttled for the rest of its window.
-  Emitted ONCE per (ip, window) — on the exact limit-crossing failure,
-  not on every subsequently rejected request — so a spray can't flood
-  the admin stream with its own rejections.
+  Which credential door's window shut. The atom IS the
+  `Grappa.RateLimit.FailureWindow` bucket, so the door is DERIVED from
+  the counter rather than tracked beside it.
+  """
+  @type login_throttle_door ::
+          :mode1_login
+          | :visitor_login
+          | :totp_login
+          | :passkey_recovery
+          | :passkey_login_options
+
+  @login_throttle_doors [
+    :mode1_login,
+    :visitor_login,
+    :totp_login,
+    :passkey_recovery,
+    :passkey_login_options
+  ]
+
+  @typedoc """
+  Which KEY of the door crossed. `:totp_login` and `:passkey_recovery`
+  each carry two rows — a fine `{ip, account}` limit and a coarse `ip`
+  ceiling — and the two mean different incidents: the fine key says one
+  account is being hammered from that address, the ceiling says the
+  address is spraying across accounts.
+  """
+  @type login_throttle_scope :: :ip | :ip_account
+
+  @typedoc """
+  S6 (review 2026-07-19) — a credential door's failure window shut for
+  the rest of its window. Emitted ONCE per (bucket, key, window) — on the
+  exact limit-crossing failure, not on every subsequently rejected
+  request — so a spray can't flood the admin stream with its own
+  rejections.
+
+  `door` + `scope` + `source_ip` together name the exact
+  `FailureWindow` row that crossed; without them seven windows would
+  render as one indistinguishable line. Both are `optional` and a client
+  MUST tolerate their absence: the ring is mirrored to disk and reloaded
+  at boot (#215 Option B), so after this upgrade the Events tab still
+  serves `login_throttled` rows minted by a server that predates the
+  fields.
   """
   @type login_throttled_event :: %{
-          kind: :login_throttled,
-          source_ip: String.t() | nil,
-          failures: pos_integer(),
-          window_ms: pos_integer(),
-          at: String.t()
+          required(:kind) => :login_throttled,
+          required(:source_ip) => String.t() | nil,
+          required(:failures) => pos_integer(),
+          required(:window_ms) => pos_integer(),
+          required(:at) => String.t(),
+          optional(:door) => login_throttle_door(),
+          optional(:scope) => login_throttle_scope()
         }
 
   @typedoc """
@@ -1107,13 +1146,21 @@ defmodule Grappa.AdminEvents.Wire do
   end
 
   @doc false
-  @spec login_throttled(String.t() | nil, pos_integer(), pos_integer()) ::
-          login_throttled_event()
-  def login_throttled(source_ip, failures, window_ms)
-      when (is_binary(source_ip) or is_nil(source_ip)) and is_integer(failures) and
+  @spec login_throttled(
+          login_throttle_door(),
+          login_throttle_scope(),
+          String.t() | nil,
+          pos_integer(),
+          pos_integer()
+        ) :: login_throttled_event()
+  def login_throttled(door, scope, source_ip, failures, window_ms)
+      when door in @login_throttle_doors and scope in [:ip, :ip_account] and
+             (is_binary(source_ip) or is_nil(source_ip)) and is_integer(failures) and
              failures > 0 and is_integer(window_ms) and window_ms > 0 do
     %{
       kind: :login_throttled,
+      door: door,
+      scope: scope,
       source_ip: source_ip,
       failures: failures,
       window_ms: window_ms,

--- a/lib/grappa_web/controllers/auth_controller.ex
+++ b/lib/grappa_web/controllers/auth_controller.ex
@@ -39,13 +39,12 @@ defmodule GrappaWeb.AuthController do
   """
   use GrappaWeb, :controller
 
-  alias Grappa.{Accounts, AdminEvents, Networks, Session, Visitors}
+  alias Grappa.{Accounts, Networks, Session, Visitors}
   alias Grappa.Accounts.{TOTP, WebAuthn}
-  alias Grappa.AdminEvents.Wire, as: AdminEventsWire
   alias Grappa.Auth.IdentifierClassifier
   alias Grappa.RateLimit.FailureWindow
   alias Grappa.Visitors.{Login, Visitor}
-  alias GrappaWeb.{PasskeyOrigin, RemoteIP}
+  alias GrappaWeb.{LoginThrottle, PasskeyOrigin, RemoteIP}
 
   require Logger
 
@@ -517,11 +516,11 @@ defmodule GrappaWeb.AuthController do
 
       {:error, _} ->
         ip = format_ip(conn)
-        _ = FailureWindow.record_failure(:totp_login, {ip, user.id}, @totp_window_ms)
+        _ = LoginThrottle.charge(:totp_login, {ip, user.id}, @totp_window_ms, @totp_max_failures)
         # The aggregate is charged too, and is deliberately NOT cleared on
         # success above: one account the attacker can satisfy must not
         # reset the ceiling for every other account they are guessing.
-        _ = FailureWindow.record_failure(:totp_login, ip, @totp_window_ms)
+        _ = LoginThrottle.charge(:totp_login, ip, @totp_window_ms, @totp_ip_max_failures)
 
         {:error, :invalid_two_factor}
     end
@@ -559,15 +558,7 @@ defmodule GrappaWeb.AuthController do
         ok
 
       {:error, _} = err ->
-        count = FailureWindow.record_failure(@mode1_bucket, ip, @mode1_window_ms)
-
-        # Exactly-once-per-window operator signal: emit on the crossing
-        # failure only, never on the (attacker-driven) rejected requests
-        # that follow — a spray can't flood the admin stream.
-        if count == @mode1_max_failures do
-          AdminEvents.record(AdminEventsWire.login_throttled(ip, count, @mode1_window_ms))
-        end
-
+        _ = LoginThrottle.charge(@mode1_bucket, ip, @mode1_window_ms, @mode1_max_failures)
         err
     end
   end
@@ -658,14 +649,13 @@ defmodule GrappaWeb.AuthController do
   # server's problems.
   @spec record_visitor_failure(String.t() | nil, Login.login_error()) :: :ok
   defp record_visitor_failure(ip, :password_mismatch) do
-    count = FailureWindow.record_failure(@visitor_login_bucket, ip, @visitor_login_window_ms)
-
-    # Exactly-once-per-window operator signal, on the crossing failure
-    # only — same discipline as the mode-1 emitter, so a spray cannot
-    # flood the admin stream with its own rejections.
-    if count == @visitor_login_max_failures do
-      AdminEvents.record(AdminEventsWire.login_throttled(ip, count, @visitor_login_window_ms))
-    end
+    _ =
+      LoginThrottle.charge(
+        @visitor_login_bucket,
+        ip,
+        @visitor_login_window_ms,
+        @visitor_login_max_failures
+      )
 
     :ok
   end

--- a/lib/grappa_web/controllers/auth_controller.ex
+++ b/lib/grappa_web/controllers/auth_controller.ex
@@ -69,6 +69,9 @@ defmodule GrappaWeb.AuthController do
   @totp_challenge_salt "account-totp-login-v1"
   @totp_challenge_max_age_seconds 300
   @totp_max_failures 10
+  # Aggregate ceiling per source IP across ALL accounts, mirroring
+  # `:passkey_recovery`'s 30 — three accounts' worth of fine limit.
+  @totp_ip_max_failures 30
   @totp_window_ms :timer.minutes(15)
 
   @doc """
@@ -482,9 +485,18 @@ defmodule GrappaWeb.AuthController do
     end
   end
 
+  # Two dimensions, the `:passkey_recovery` shape: `{ip, user_id}` is the
+  # fine limit, the bare `ip` is the aggregate ceiling. The fine key alone
+  # is STRICTER than per-IP, not looser — it hands one address ten guesses
+  # PER ACCOUNT, so a hundred accounts bought a thousand attempts and no
+  # key ever reached its limit. The ceiling is what bounds the address.
   defp check_totp_throttle(conn, user_id) do
-    case FailureWindow.check(:totp_login, {format_ip(conn), user_id}, @totp_max_failures) do
-      :ok -> :ok
+    ip = format_ip(conn)
+
+    with :ok <- FailureWindow.check(:totp_login, ip, @totp_ip_max_failures),
+         :ok <- FailureWindow.check(:totp_login, {ip, user_id}, @totp_max_failures) do
+      :ok
+    else
       {:error, :limited} -> {:error, :too_many_attempts}
     end
   end
@@ -504,12 +516,12 @@ defmodule GrappaWeb.AuthController do
         error
 
       {:error, _} ->
-        _ =
-          FailureWindow.record_failure(
-            :totp_login,
-            {format_ip(conn), user.id},
-            @totp_window_ms
-          )
+        ip = format_ip(conn)
+        _ = FailureWindow.record_failure(:totp_login, {ip, user.id}, @totp_window_ms)
+        # The aggregate is charged too, and is deliberately NOT cleared on
+        # success above: one account the attacker can satisfy must not
+        # reset the ceiling for every other account they are guessing.
+        _ = FailureWindow.record_failure(:totp_login, ip, @totp_window_ms)
 
         {:error, :invalid_two_factor}
     end

--- a/lib/grappa_web/controllers/auth_controller.ex
+++ b/lib/grappa_web/controllers/auth_controller.ex
@@ -568,12 +568,14 @@ defmodule GrappaWeb.AuthController do
   # plug only fires once on the `login/2` call, so the captcha boundary
   # and the upstream verify call must both consume the same value.
   defp visitor_login(conn, nick, password, captcha_token, identity, network, incognito) do
+    ip = format_ip(conn)
+
     input = %{
       nick: nick,
       password: password,
       ident: identity.ident,
       realname: identity.realname,
-      ip: format_ip(conn),
+      ip: ip,
       user_agent: user_agent(conn),
       token: extract_bearer(conn),
       captcha_token: captcha_token,
@@ -584,16 +586,79 @@ defmodule GrappaWeb.AuthController do
       incognito: incognito
     }
 
-    case Login.login(input, []) do
-      {:ok, %{visitor: %Visitor{} = v, token: token}} ->
-        conn
-        |> put_status(:ok)
-        |> render(:login, token: token, subject: {:visitor, v})
+    with :ok <- check_visitor_throttle(ip, password) do
+      case Login.login(input, []) do
+        {:ok, %{visitor: %Visitor{} = v, token: token}} ->
+          conn
+          |> put_status(:ok)
+          |> render(:login, token: token, subject: {:visitor, v})
 
-      {:error, reason} ->
-        visitor_error_response(conn, nick, network, reason)
+        {:error, reason} ->
+          :ok = record_visitor_failure(ip, reason)
+          visitor_error_response(conn, nick, network, reason)
+      end
     end
   end
+
+  # S6's window, one door over. The registered-visitor password gate is
+  # the credential door with the least standing under it: the account
+  # door above pays an Argon2 per guess, this one pays a Cloak decrypt
+  # and a `Plug.Crypto.secure_compare/2` — constant-time, so no timing
+  # oracle, but cheap. It is also the only credential door on
+  # `pipe_through :api`, with no request budget in front, and the captcha
+  # gates the fresh-provision branch rather than the password one (its
+  # default provider is `Disabled`, so an unconfigured self-host has none
+  # anywhere). Every attenuation that makes the sibling doors tolerable
+  # is absent here at once.
+  #
+  # Its own bucket: sharing a counter is how one door's limit silently
+  # becomes another's.
+  @visitor_login_bucket :visitor_login
+  @visitor_login_max_failures 10
+  @visitor_login_window_ms :timer.minutes(15)
+
+  # Keyed on the source IP and NOTHING else. A per-account dimension that
+  # denies would be a remote lockout on someone else's identity: visitor
+  # nicks are enumerable at zero cost and the window renews, so one wrong
+  # guess every 90 seconds would hold a nick shut forever, with the victim
+  # paying instead of the attacker. The per-IP cost on shared NAT is the
+  # tradeoff already accepted three doors over (DESIGN_NOTES 2026-07-03).
+  #
+  # Only a credential-bearing attempt is gated. A passwordless visitor
+  # login is the anon/fresh door — and it is also how cic discovers a gate
+  # exists at all (post, read `:password_required` back, then prompt) — so
+  # gating it would let a spray against registered nicks take anonymous
+  # logins down with it.
+  @spec check_visitor_throttle(String.t() | nil, String.t() | nil) ::
+          :ok | {:error, :too_many_attempts}
+  defp check_visitor_throttle(_, nil), do: :ok
+
+  defp check_visitor_throttle(ip, password) when is_binary(password) do
+    case FailureWindow.check(@visitor_login_bucket, ip, @visitor_login_max_failures) do
+      :ok -> :ok
+      {:error, :limited} -> {:error, :too_many_attempts}
+    end
+  end
+
+  # Charges the window on a wrong password and nothing else. A capacity
+  # refusal, an unreachable upstream or a `:password_required` are not
+  # guesses, and charging them would spend a visitor's own door on the
+  # server's problems.
+  @spec record_visitor_failure(String.t() | nil, Login.login_error()) :: :ok
+  defp record_visitor_failure(ip, :password_mismatch) do
+    count = FailureWindow.record_failure(@visitor_login_bucket, ip, @visitor_login_window_ms)
+
+    # Exactly-once-per-window operator signal, on the crossing failure
+    # only — same discipline as the mode-1 emitter, so a spray cannot
+    # flood the admin stream with its own rejections.
+    if count == @visitor_login_max_failures do
+      AdminEvents.record(AdminEventsWire.login_throttled(ip, count, @visitor_login_window_ms))
+    end
+
+    :ok
+  end
+
+  defp record_visitor_failure(_, _), do: :ok
 
   # L-web-1: every visitor-error atom now flows through
   # `GrappaWeb.FallbackController` (wired globally via `use GrappaWeb,

--- a/lib/grappa_web/controllers/passkey_controller.ex
+++ b/lib/grappa_web/controllers/passkey_controller.ex
@@ -6,7 +6,7 @@ defmodule GrappaWeb.PasskeyController do
   alias Grappa.Accounts.{User, WebAuthn}
   alias Grappa.Auth.IdentifierClassifier
   alias Grappa.RateLimit.FailureWindow
-  alias GrappaWeb.{PasskeyOrigin, RemoteIP}
+  alias GrappaWeb.{LoginThrottle, PasskeyOrigin, RemoteIP}
 
   @recovery_salt "account-passwordless-recovery-v1"
   @recovery_max_age_seconds 600
@@ -198,8 +198,17 @@ defmodule GrappaWeb.PasskeyController do
         # here is allocation, and the cheapest way to allocate is to keep
         # succeeding: a loop against a known passwordless identifier gets
         # a 200 each time, so a failures-only window would never trip on
-        # the exact traffic it needs to bound.
-        _ = FailureWindow.record_failure(:passkey_login_options, ip, @recovery_window_ms)
+        # the exact traffic it needs to bound. So the crossing charge —
+        # and the operator signal it raises — lands on a request that
+        # SUCCEEDS.
+        _ =
+          LoginThrottle.charge(
+            :passkey_login_options,
+            ip,
+            @recovery_window_ms,
+            @login_options_attempts
+          )
+
         begin_passwordless(conn, identifier)
     end
   end
@@ -271,14 +280,16 @@ defmodule GrappaWeb.PasskeyController do
         {:error, :too_many_attempts}
 
       _ ->
-        _ = FailureWindow.record_failure(:passkey_recovery, key, @recovery_window_ms)
-        _ = FailureWindow.record_failure(:passkey_recovery, ip, @recovery_window_ms)
+        _ = LoginThrottle.charge(:passkey_recovery, key, @recovery_window_ms, @recovery_account_attempts)
+        _ = LoginThrottle.charge(:passkey_recovery, ip, @recovery_window_ms, @recovery_ip_attempts)
         {:error, :invalid_two_factor}
     end
   end
 
+  # An identifier that resolves to no passwordless account charges the
+  # ceiling and nothing else — there is no account to key the fine row on.
   defp recover_resolved(_, ip, _, _) do
-    _ = FailureWindow.record_failure(:passkey_recovery, ip, @recovery_window_ms)
+    _ = LoginThrottle.charge(:passkey_recovery, ip, @recovery_window_ms, @recovery_ip_attempts)
     {:error, :invalid_two_factor}
   end
 

--- a/lib/grappa_web/login_throttle.ex
+++ b/lib/grappa_web/login_throttle.ex
@@ -74,6 +74,6 @@ defmodule GrappaWeb.LoginThrottle do
   end
 
   @spec attribute(key()) :: {Wire.login_throttle_scope(), String.t() | nil}
-  defp attribute({source_ip, _account}), do: {:ip_account, source_ip}
+  defp attribute({source_ip, _}), do: {:ip_account, source_ip}
   defp attribute(source_ip), do: {:ip, source_ip}
 end

--- a/lib/grappa_web/login_throttle.ex
+++ b/lib/grappa_web/login_throttle.ex
@@ -1,0 +1,79 @@
+defmodule GrappaWeb.LoginThrottle do
+  @moduledoc """
+  Charges a credential door's failure window and tells the operator when
+  the charge was the one that shut it.
+
+  ## Why a shared verb
+
+  Recording and signalling were separate concerns spread across two
+  controllers, and the split showed: of the seven
+  `Grappa.RateLimit.FailureWindow` rows guarding a credential door, only
+  two ever emitted an admin event. The other five shut in silence — an
+  operator watching the Events tab saw nothing while a window was doing
+  its job. Every `record_failure/3` on a credential door now goes through
+  `charge/4`, so a door cannot be added mute: the signal is not a step a
+  caller can forget, it is part of the charge.
+
+  ## What it does NOT do
+
+  No deny logic. `FailureWindow.check/3` stays at each call site, ahead of
+  the expensive work it gates, because only the caller knows what that
+  work is and what refusing it must return. This module is visibility.
+
+  ## Attribution
+
+  `door` IS the `FailureWindow` bucket, so it is derived from the counter
+  rather than tracked beside it, and `scope` is derived from the shape of
+  the key. `:totp_login` and `:passkey_recovery` each carry two rows — a
+  fine `{ip, account}` limit and a coarse `ip` ceiling — and the pair
+  `(door, scope, source_ip)` is what names the row that crossed. The
+  account id is deliberately NOT carried: on the recovery door the
+  identifier is attacker-supplied, and putting it in the payload would let
+  a spray write names of its own choosing into the admin stream.
+
+  Belongs to the `GrappaWeb` boundary (no explicit `use Boundary`) — same
+  pattern as `GrappaWeb.RemoteIP` and `GrappaWeb.Validation`. It lives in
+  the web layer because a window keyed on the source IP is a request-edge
+  policy: `Grappa.Visitors` depends on neither `Grappa.RateLimit` nor
+  `Grappa.AdminEvents`, and widening a domain context to hold one is the
+  wrong trade.
+  """
+
+  alias Grappa.AdminEvents
+  alias Grappa.AdminEvents.Wire
+  alias Grappa.RateLimit.FailureWindow
+
+  @typedoc """
+  A bare source IP for a per-address row, or `{source_ip, account_id}`
+  for a per-(address, account) row. `nil` is an unresolvable peer, which
+  `Grappa.RateLimit.FailureWindow` keys like any other value.
+  """
+  @type key :: (source_ip :: String.t() | nil) | {String.t() | nil, term()}
+
+  @doc """
+  Records one failure against `(door, key)` and returns the window's new
+  count.
+
+  Emits `Grappa.AdminEvents.Wire.login_throttled/5` when this charge is
+  the one that reached `limit` — ONCE per window, on the crossing charge
+  only. The rejected requests that follow are attacker-driven, so
+  re-emitting on each would let a spray flood the admin stream with its
+  own rejections.
+  """
+  @spec charge(Wire.login_throttle_door(), key(), pos_integer(), pos_integer()) :: pos_integer()
+  def charge(door, key, window_ms, limit)
+      when is_integer(window_ms) and window_ms > 0 and is_integer(limit) and limit > 0 do
+    count = FailureWindow.record_failure(door, key, window_ms)
+
+    if count == limit do
+      {scope, source_ip} = attribute(key)
+      AdminEvents.record(Wire.login_throttled(door, scope, source_ip, count, window_ms))
+    end
+
+    count
+  end
+
+  @spec attribute(key()) :: {Wire.login_throttle_scope(), String.t() | nil}
+  defp attribute({source_ip, _account}), do: {:ip_account, source_ip}
+  defp attribute(source_ip), do: {:ip, source_ip}
+end

--- a/test/grappa/admin_events/wire_test.exs
+++ b/test/grappa/admin_events/wire_test.exs
@@ -73,10 +73,12 @@ defmodule Grappa.AdminEvents.WireTest do
     end
   end
 
-  describe "login_throttled/3" do
+  describe "login_throttled/5" do
     test "renders the typed wire shape" do
-      event = Wire.login_throttled("203.0.113.7", 10, 900_000)
+      event = Wire.login_throttled(:mode1_login, :ip, "203.0.113.7", 10, 900_000)
       assert event.kind == :login_throttled
+      assert event.door == :mode1_login
+      assert event.scope == :ip
       assert event.source_ip == "203.0.113.7"
       assert event.failures == 10
       assert event.window_ms == 900_000
@@ -84,8 +86,31 @@ defmodule Grappa.AdminEvents.WireTest do
     end
 
     test "accepts nil source_ip (unresolvable peer honesty)" do
-      event = Wire.login_throttled(nil, 10, 900_000)
+      event = Wire.login_throttled(:visitor_login, :ip, nil, 10, 900_000)
       assert event.source_ip == nil
+    end
+
+    # Five windows share this event now. Without `door` the operator reads
+    # "an address hit 30 failures" and cannot tell a TOTP ceiling from a
+    # recovery ceiling from challenge-allocation abuse; without `scope` the
+    # two-key doors emit two arms that differ only by a count the reader
+    # would have to know the constants to decode.
+    test "carries the door and the key shape that crossed" do
+      event = Wire.login_throttled(:passkey_recovery, :ip_account, "203.0.113.7", 10, 900_000)
+      assert event.door == :passkey_recovery
+      assert event.scope == :ip_account
+    end
+
+    test "refuses a door outside the closed set" do
+      assert_raise FunctionClauseError, fn ->
+        Wire.login_throttled(:not_a_door, :ip, "203.0.113.7", 10, 900_000)
+      end
+    end
+
+    test "refuses a scope outside the closed set" do
+      assert_raise FunctionClauseError, fn ->
+        Wire.login_throttled(:mode1_login, :ip_client, "203.0.113.7", 10, 900_000)
+      end
     end
   end
 

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -1408,6 +1408,113 @@ defmodule GrappaWeb.AuthControllerTest do
     end
   end
 
+  # The registered-visitor password gate has its own window (see
+  # `Grappa.Visitors.LoginTest` for the orchestrator contract). This is the
+  # wire half: without an explicit `visitor_error_response/4` clause the
+  # atom falls through to the catch-all and the door answers 500 while
+  # claiming to throttle. No IRC handshake anywhere below — a wrong
+  # password never dials, and neither does a throttled one.
+  # `:totp_login` was keyed on `{ip, user_id}` and nothing else — a key
+  # STRICTER than per-IP, so one address got its ten guesses per account
+  # with no bound on the total. `:passkey_recovery` already carries both
+  # dimensions (fine per account, coarse per IP); this brings the second
+  # factor to the same shape.
+  describe "POST /auth/totp/verify per-IP aggregate cap (:totp_login)" do
+    setup do
+      :ets.delete_all_objects(FailureWindow.table_name())
+      :ok
+    end
+
+    test "a fresh account is refused once the ADDRESS has spent the aggregate", %{conn: conn} do
+      # Each account's own `{ip, user_id}` key tops out at 10, so three
+      # accounts spend 30 failures from one address without any single key
+      # tripping. The fourth account's FIRST attempt has a clean per-account
+      # key: only the aggregate can refuse it.
+      spend = fn ->
+        {user, password} = user_fixture_with_password()
+        secret = arm_totp(user)
+        wrong = wrong_totp_code(secret, System.system_time(:second))
+
+        pending =
+          conn
+          |> with_ip(9)
+          |> post("/auth/login", %{"identifier" => user.name, "password" => password})
+          |> json_response(202)
+
+        for _ <- 1..10 do
+          assert conn
+                 |> with_ip(9)
+                 |> post("/auth/totp/verify", %{
+                   "challenge_token" => pending["challenge_token"],
+                   "code" => wrong
+                 })
+                 |> json_response(401) == %{"error" => "invalid_two_factor"}
+        end
+      end
+
+      for _ <- 1..3, do: spend.()
+
+      {fresh, password} = user_fixture_with_password()
+      secret = arm_totp(fresh)
+
+      pending =
+        conn
+        |> with_ip(9)
+        |> post("/auth/login", %{"identifier" => fresh.name, "password" => password})
+        |> json_response(202)
+
+      {:ok, code} = TOTP.code_at(secret, System.system_time(:second))
+
+      assert conn
+             |> with_ip(9)
+             |> post("/auth/totp/verify", %{
+               "challenge_token" => pending["challenge_token"],
+               "code" => code
+             })
+             |> json_response(429) == %{"error" => "too_many_attempts"}
+    end
+
+    test "another address is untouched by a spent one", %{conn: conn} do
+      {user, password} = user_fixture_with_password()
+      secret = arm_totp(user)
+      wrong = wrong_totp_code(secret, System.system_time(:second))
+
+      pending_a =
+        conn
+        |> with_ip(11)
+        |> post("/auth/login", %{"identifier" => user.name, "password" => password})
+        |> json_response(202)
+
+      for _ <- 1..10 do
+        conn
+        |> with_ip(11)
+        |> post("/auth/totp/verify", %{
+          "challenge_token" => pending_a["challenge_token"],
+          "code" => wrong
+        })
+      end
+
+      # Same account, another address: the aggregate is the attacker's own
+      # address, never the account's — so the real owner still gets in.
+      pending_b =
+        conn
+        |> with_ip(12)
+        |> post("/auth/login", %{"identifier" => user.name, "password" => password})
+        |> json_response(202)
+
+      {:ok, code} = TOTP.code_at(secret, System.system_time(:second))
+
+      assert conn
+             |> with_ip(12)
+             |> post("/auth/totp/verify", %{
+               "challenge_token" => pending_b["challenge_token"],
+               "code" => code
+             })
+             |> json_response(200)
+             |> Map.fetch!("token")
+    end
+  end
+
   # The registered-visitor password gate is the credential door with the
   # least standing under it — no KDF, no request budget, no captcha on this
   # branch. These pin the per-IP window that bounds it. No IRC handshake

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -26,6 +26,7 @@ defmodule GrappaWeb.AuthControllerTest do
   alias Grappa.Accounts.{Passkey, TOTP}
   alias Grappa.AdmissionStateHelpers
   alias Grappa.Networks.Credential
+  alias Grappa.PubSub.Topic
   alias Grappa.RateLimit.FailureWindow
   alias Grappa.Session.Server, as: SessionServer
   alias Grappa.Visitors.Visitor
@@ -1391,7 +1392,7 @@ defmodule GrappaWeb.AuthControllerTest do
 
     test "crossing the limit emits :login_throttled exactly once", %{conn: conn} do
       {user, _} = user_fixture_with_password()
-      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Grappa.PubSub.Topic.admin_events())
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.admin_events())
 
       for _ <- 1..10, do: wrong_login(conn, user, 5)
 
@@ -1528,7 +1529,7 @@ defmodule GrappaWeb.AuthControllerTest do
       {user, password} = user_fixture_with_password()
       secret = arm_totp(user)
       wrong = wrong_totp_code(secret, System.system_time(:second))
-      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Grappa.PubSub.Topic.admin_events())
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.admin_events())
 
       pending =
         conn
@@ -1559,7 +1560,7 @@ defmodule GrappaWeb.AuthControllerTest do
     end
 
     test "the address ceiling names its own crossing", %{conn: conn} do
-      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Grappa.PubSub.Topic.admin_events())
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.admin_events())
 
       # Three accounts, ten each: no per-account key ever passes ten, so
       # only the ceiling can be the thing that crossed at thirty.
@@ -1656,7 +1657,7 @@ defmodule GrappaWeb.AuthControllerTest do
     end
 
     test "crossing the limit emits :login_throttled exactly once", %{conn: conn} do
-      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Grappa.PubSub.Topic.admin_events())
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.admin_events())
 
       for _ <- 1..10, do: wrong_visitor_login(conn, 16)
 

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -1407,4 +1407,83 @@ defmodule GrappaWeb.AuthControllerTest do
       refute_receive %Phoenix.Socket.Broadcast{payload: %{kind: :login_throttled}}, 200
     end
   end
+
+  # The registered-visitor password gate is the credential door with the
+  # least standing under it — no KDF, no request budget, no captcha on this
+  # branch. These pin the per-IP window that bounds it. No IRC handshake
+  # anywhere below: a wrong password never dials, and neither does a
+  # throttled one.
+  describe "POST /auth/login visitor password-gate throttle" do
+    setup do
+      :ets.delete_all_objects(FailureWindow.table_name())
+
+      {network, _} = setup_visitor_network(pick_unused_port())
+      {:ok, visitor} = Visitors.find_or_provision_anon("vjt", "azzurra", "1.2.3.4")
+      {:ok, _} = Visitors.commit_password(visitor.id, network.id, "s3cret")
+
+      {:ok, network: network, visitor: visitor}
+    end
+
+    test "the 11th attempt from one IP is refused even with the CORRECT password", %{conn: conn} do
+      for _ <- 1..10 do
+        assert json_response(wrong_visitor_login(conn, 7), 401)["error"] == "password_mismatch"
+      end
+
+      # The correct secret, and still refused: the check precedes the whole
+      # login flow, so a throttled address buys no compare and no spawn.
+      # Nothing feeds a 001 here — if this were let through it would dial.
+      refused =
+        conn
+        |> with_ip(7)
+        |> post("/auth/login", %{"identifier" => "vjt", "password" => "s3cret"})
+
+      assert json_response(refused, 429) == %{"error" => "too_many_attempts"}
+    end
+
+    test "a spent IP does not lock the visitor's OWN door from elsewhere", %{conn: conn} do
+      for _ <- 1..10, do: wrong_visitor_login(conn, 13)
+      assert json_response(wrong_visitor_login(conn, 13), 429)["error"] == "too_many_attempts"
+
+      # Same nick, another address: still the credential oracle, not the
+      # throttle. Nicks are enumerable, so a per-account deny would let one
+      # address hold someone else's identity shut; this one cannot.
+      assert json_response(wrong_visitor_login(conn, 14), 401)["error"] == "password_mismatch"
+    end
+
+    test "a passwordless login never advances the counter", %{conn: conn} do
+      # cic discovers the gate by posting without a password and reading
+      # `password_required` back; it is also the anon/fresh door. Charging
+      # it would let a spray against registered nicks take anonymous logins
+      # down with it.
+      for _ <- 1..15 do
+        assert conn
+               |> with_ip(15)
+               |> post("/auth/login", %{"identifier" => "vjt"})
+               |> json_response(401) == %{"error" => "password_required"}
+      end
+
+      assert json_response(wrong_visitor_login(conn, 15), 401)["error"] == "password_mismatch"
+    end
+
+    test "crossing the limit emits :login_throttled exactly once", %{conn: conn} do
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Grappa.PubSub.Topic.admin_events())
+
+      for _ <- 1..10, do: wrong_visitor_login(conn, 16)
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: "grappa:admin:events",
+                       payload: %{kind: :login_throttled, source_ip: "10.66.0.16", failures: 10}
+                     },
+                     500
+
+      _ = wrong_visitor_login(conn, 16)
+      refute_receive %Phoenix.Socket.Broadcast{payload: %{kind: :login_throttled}}, 200
+    end
+  end
+
+  defp wrong_visitor_login(conn, d) do
+    conn
+    |> with_ip(d)
+    |> post("/auth/login", %{"identifier" => "vjt", "password" => "WRONG-pw"})
+  end
 end

--- a/test/grappa_web/controllers/auth_controller_test.exs
+++ b/test/grappa_web/controllers/auth_controller_test.exs
@@ -1397,7 +1397,13 @@ defmodule GrappaWeb.AuthControllerTest do
 
       assert_receive %Phoenix.Socket.Broadcast{
                        topic: "grappa:admin:events",
-                       payload: %{kind: :login_throttled, source_ip: "10.66.0.5", failures: 10}
+                       payload: %{
+                         kind: :login_throttled,
+                         door: :mode1_login,
+                         scope: :ip,
+                         source_ip: "10.66.0.5",
+                         failures: 10
+                       }
                      },
                      500
 
@@ -1513,6 +1519,83 @@ defmodule GrappaWeb.AuthControllerTest do
              |> json_response(200)
              |> Map.fetch!("token")
     end
+
+    # Both of this door's keys were silent before: the window shut and the
+    # operator saw nothing. They emit the SAME event as the two doors that
+    # already spoke, told apart by `door` + `scope` rather than by a count
+    # the reader would have to decode against the constants.
+    test "the per-account key names its own crossing", %{conn: conn} do
+      {user, password} = user_fixture_with_password()
+      secret = arm_totp(user)
+      wrong = wrong_totp_code(secret, System.system_time(:second))
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Grappa.PubSub.Topic.admin_events())
+
+      pending =
+        conn
+        |> with_ip(13)
+        |> post("/auth/login", %{"identifier" => user.name, "password" => password})
+        |> json_response(202)
+
+      for _ <- 1..10 do
+        conn
+        |> with_ip(13)
+        |> post("/auth/totp/verify", %{
+          "challenge_token" => pending["challenge_token"],
+          "code" => wrong
+        })
+      end
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: "grappa:admin:events",
+                       payload: %{
+                         kind: :login_throttled,
+                         door: :totp_login,
+                         scope: :ip_account,
+                         source_ip: "10.66.0.13",
+                         failures: 10
+                       }
+                     },
+                     500
+    end
+
+    test "the address ceiling names its own crossing", %{conn: conn} do
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Grappa.PubSub.Topic.admin_events())
+
+      # Three accounts, ten each: no per-account key ever passes ten, so
+      # only the ceiling can be the thing that crossed at thirty.
+      for _ <- 1..3 do
+        {user, password} = user_fixture_with_password()
+        secret = arm_totp(user)
+        wrong = wrong_totp_code(secret, System.system_time(:second))
+
+        pending =
+          conn
+          |> with_ip(14)
+          |> post("/auth/login", %{"identifier" => user.name, "password" => password})
+          |> json_response(202)
+
+        for _ <- 1..10 do
+          conn
+          |> with_ip(14)
+          |> post("/auth/totp/verify", %{
+            "challenge_token" => pending["challenge_token"],
+            "code" => wrong
+          })
+        end
+      end
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: "grappa:admin:events",
+                       payload: %{
+                         kind: :login_throttled,
+                         door: :totp_login,
+                         scope: :ip,
+                         source_ip: "10.66.0.14",
+                         failures: 30
+                       }
+                     },
+                     1000
+    end
   end
 
   # The registered-visitor password gate is the credential door with the
@@ -1579,7 +1662,13 @@ defmodule GrappaWeb.AuthControllerTest do
 
       assert_receive %Phoenix.Socket.Broadcast{
                        topic: "grappa:admin:events",
-                       payload: %{kind: :login_throttled, source_ip: "10.66.0.16", failures: 10}
+                       payload: %{
+                         kind: :login_throttled,
+                         door: :visitor_login,
+                         scope: :ip,
+                         source_ip: "10.66.0.16",
+                         failures: 10
+                       }
                      },
                      500
 

--- a/test/grappa_web/controllers/passkey_controller_test.exs
+++ b/test/grappa_web/controllers/passkey_controller_test.exs
@@ -365,6 +365,108 @@ defmodule GrappaWeb.PasskeyControllerTest do
            |> json_response(429) == %{"error" => "too_many_attempts"}
   end
 
+  # All three windows in this controller shut in silence. They emit the
+  # event the mode-1 door has always emitted, told apart by `door` +
+  # `scope`. Each is driven to ONE attempt short of its limit through the
+  # production counter, so the crossing is the request under test and not
+  # the twenty-nine that set it up.
+  @window_ms :timer.minutes(15)
+  @wrong_code "wrongwrongwrongwrongwrongw"
+
+  defp seed_failures(bucket, key, n) do
+    for _ <- 1..n, do: FailureWindow.record_failure(bucket, key, @window_ms)
+    :ok
+  end
+
+  defp watch_admin_events do
+    :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Grappa.PubSub.Topic.admin_events())
+  end
+
+  test "the recovery per-account key names its own crossing", %{conn: conn} do
+    {user, _} = passwordless_user()
+
+    clear = fn ->
+      FailureWindow.clear(:passkey_recovery, "127.0.0.1")
+      FailureWindow.clear(:passkey_recovery, {"127.0.0.1", user.id})
+    end
+
+    clear.()
+    on_exit(clear)
+
+    seed_failures(:passkey_recovery, {"127.0.0.1", user.id}, 9)
+    watch_admin_events()
+
+    assert conn
+           |> post("/auth/passkeys/recover", %{"identifier" => user.name, "recovery_code" => @wrong_code})
+           |> json_response(401) == %{"error" => "invalid_two_factor"}
+
+    assert_receive %Phoenix.Socket.Broadcast{
+                     topic: "grappa:admin:events",
+                     payload: %{
+                       kind: :login_throttled,
+                       door: :passkey_recovery,
+                       scope: :ip_account,
+                       source_ip: "127.0.0.1",
+                       failures: 10
+                     }
+                   },
+                   500
+  end
+
+  test "the recovery address ceiling names its own crossing", %{conn: conn} do
+    clear = fn -> FailureWindow.clear(:passkey_recovery, "127.0.0.1") end
+    clear.()
+    on_exit(clear)
+
+    # An identifier that resolves to no account charges the ceiling and
+    # nothing else — the per-account key is never even formed, so only the
+    # ceiling can be what crossed.
+    seed_failures(:passkey_recovery, "127.0.0.1", 29)
+    watch_admin_events()
+
+    assert conn
+           |> post("/auth/passkeys/recover", %{"identifier" => "nobody-here", "recovery_code" => @wrong_code})
+           |> json_response(401) == %{"error" => "invalid_two_factor"}
+
+    assert_receive %Phoenix.Socket.Broadcast{
+                     topic: "grappa:admin:events",
+                     payload: %{
+                       kind: :login_throttled,
+                       door: :passkey_recovery,
+                       scope: :ip,
+                       source_ip: "127.0.0.1",
+                       failures: 30
+                     }
+                   },
+                   500
+  end
+
+  test "challenge-allocation abuse names its own crossing", %{conn: conn} do
+    {user, _} = passwordless_user()
+    clear = fn -> FailureWindow.clear(:passkey_login_options, "127.0.0.1") end
+    clear.()
+    on_exit(clear)
+
+    # This window counts every call, not every failure, so the crossing
+    # request is a 200. The signal has to fire on a door that is SUCCEEDING.
+    seed_failures(:passkey_login_options, "127.0.0.1", 29)
+    watch_admin_events()
+
+    assert conn |> post("/auth/passkeys/options", %{"identifier" => user.name}) |> Map.get(:status) == 200
+
+    assert_receive %Phoenix.Socket.Broadcast{
+                     topic: "grappa:admin:events",
+                     payload: %{
+                       kind: :login_throttled,
+                       door: :passkey_login_options,
+                       scope: :ip,
+                       source_ip: "127.0.0.1",
+                       failures: 30
+                     }
+                   },
+                   500
+  end
+
   test "passwordless mode rejects password and accepts a one-shot recovery code", %{conn: conn} do
     {user, password} = user_fixture_with_password()
     secret = TOTP.new_enrollment(user, "Grappa test").secret


### PR DESCRIPTION
Three slices on the credential doors, all on `RateLimit.FailureWindow`. The
first two bring two doors onto the shared shape; the third makes every door
say so out loud. No new infrastructure, no schema change, no
`protocol_version` bump.

## What changes

**Visitor login door** (`AuthController.visitor_login/7`) gains a per-source-IP
window, bucket `:visitor_login`, 10 per 15 minutes. Only a credential-bearing
attempt is gated; only a wrong password charges it. It sits at the HTTP edge
rather than beside the compare because `Grappa.Visitors` depends on neither
`Grappa.RateLimit` nor `Grappa.AdminEvents` — the Boundary compiler said so,
and widening a domain context to hold a request-edge policy is the wrong trade
when all three sibling windows already live in controllers.

**TOTP verify** (`:totp_login`) gains the aggregate per-IP ceiling its siblings
have. It was keyed on `{ip, user_id}` alone — a key stricter than per-IP, which
means the fine limit bounds the pair while nothing bounds the address.
`:passkey_recovery` already carries both dimensions; this brings the second
factor to the same shape, same 30. The success path still clears the fine key
only, so one satisfiable account cannot reset the ceiling.

**Every window now emits, and names itself.** `GrappaWeb.LoginThrottle.charge/4`
records the failure AND raises the crossing signal in one verb; all eight charge
sites go through it. A new door cannot be added mute, because there is no longer
a way to record a credential failure without signalling. `FailureWindow.check/3`
deliberately stays at each call site — only the caller knows what work it gates
and what refusing must return. No deny logic moved.

## The count was wrong, and the correction is the point

The brief said three of four doors were silent. The unit that shuts is not a
door but a `FailureWindow` row, `(bucket, key)`, and `:totp_login` and
`:passkey_recovery` carry two rows each. **Seven windows guard a credential
door; two emitted; five were silent — and one of the five was added by the
second commit in this very PR.** A window that denies without a signal does not
fail loudly, it fails as an unexplained login problem, which is the one failure
mode an operator cannot tell from a bug.

Attribution is not decoration either: seven windows sharing one undifferentiated
event would report that some address hit thirty failures and leave the reader
guessing between a TOTP ceiling, a recovery ceiling and challenge-allocation
abuse. So the event carries `door` (which IS the bucket — derived, not tracked
beside it) and `scope` (`:ip` / `:ip_account`, derived from the shape of the
key). On the two-row doors that distinction is the whole read: the fine key says
one account is hammered from that address, the ceiling says that address sprays
across accounts.

The account id is deliberately absent from the payload. On the recovery door the
identifier is attacker-supplied, so carrying it would let a spray write names of
its own choosing into the admin stream.

## The key choice, stated

Every window is keyed on the source IP (optionally paired with an account) and
never on an account alone. A per-account dimension that DENIES is a remote
lockout on someone else's identity — the window renews, so a slow trickle would
hold an account shut indefinitely with the victim paying rather than the caller.
Nothing here adds a lockout vector that per-IP admission did not already carry
(DESIGN_NOTES 2026-07-03). Nothing here bounds the distributed case: N addresses
still get N windows. That is detection before prevention, and stays out of scope.

## Why the two new fields are `optional` on the wire

Not a hedge. The admin ring is mirrored to disk and reloaded at boot (#215
Option B), and `snapshot/0` serves those rows to a joining admin socket — so
after this ships the Events tab genuinely replays `login_throttled` rows minted
by a server that predates the fields. Absence is a real wire state, so cic
narrows both to `undefined` rather than nulling the event: the trip is
load-bearing, the attribution is detail, and a missing detail must not delete
the alert. Additive fields, so no version bump.

## Verification

- `scripts/check.sh` green end to end, rc read from a file: **5329 tests /
  0 failures**, Dialyzer `Total errors: 0`, Credo `found no issues`, doctor
  passed (dev + test), `wireTypes.ts is in sync`, bats 331/331. Sobelow's only
  finding is a pre-existing Low in `cic/bundle.ex`; the gate is Medium-or-above.
  Working tree clean before AND after.
- cic: `bun run check` rc 0 (biome *and* tsc — biome short-circuits, so the rc
  is what proves tsc ran), build clean.
- `wireTypes.ts` is codegen output under a drift gate. It was transcribed by
  hand first, then regenerated: byte-identical.
- Every claim proven by mutation rather than by a green run. Disabling the
  emitter reddens exactly seven tests and nothing else. Hardcoding the
  attribution to `:mode1_login, :ip` reddens six — mode-1 stays green *by
  construction*, because that is precisely what that door emits.

## Known gap, stated rather than buried

One cic vitest run out of three came back with 2 failures; the two later runs
were green on identical code. The failing run's log was not captured, so the
tests are not even named, and **this is not attributed** — not to this branch
and not to the host. A cold start is plausible (that run followed a 483-package
install with ~1400s of environment time) but plausible is not measured.
