### PR TITLE
cic(#973): fold the read-cursor map key so a query badge can clear

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -462,18 +462,21 @@ export async function waitForQueryWindowReady(
 
 // Mirror of `cicchetto/src/lib/channelKey.ts:canonicalChannel` — the e2e
 // tree MIRRORS src, never imports it (separate build context; see
-// fixtures/push.ts). Channel names (RFC 2812 sigils `#&!+`) are
-// case-folded; other targets keep casing. MUST stay byte-identical to the
-// src twin, or the composite key this rebuilds won't match the one
-// subscribe.ts stamped into `__cic_channelReady`.
+// fixtures/push.ts). MUST stay byte-identical to the src twin, or the
+// composite key this rebuilds won't match the one subscribe.ts stamped
+// into `__cic_channelReady`.
+//
+// #973 — this mirror had drifted two ways and was silently rebuilding keys
+// nothing had stamped. It was still the PRE-#537 shape: sigil-gated (a nick
+// came back RAW) and folding with `toLowerCase`. The src twin folds EVERY
+// identifier — a nick as well as a channel — because bahamut folds them the
+// same way, and it folds with the byte-level `asciiFold` so non-ASCII stays
+// distinct (`#CAFÉ` ≠ `#café`, the #525 posture `toLowerCase` breaks). No
+// green spec caught it because none had yet passed a mixed-case nick through
+// these seams; the first one to try would have hung on a barrier that can
+// never fire and read as a product bug.
 function canonicalChannelName(name: string): string {
-  if (name.length === 0) return name;
-  const first = name.charCodeAt(0);
-  // 0x23 #, 0x26 &, 0x21 !, 0x2B +
-  if (first === 0x23 || first === 0x26 || first === 0x21 || first === 0x2b) {
-    return name.toLowerCase();
-  }
-  return name;
+  return name.replace(/[A-Z]/g, (c) => String.fromCharCode(c.charCodeAt(0) + 32));
 }
 
 // Wait until cic's channels-loop has subscribed to a real IRC channel's

--- a/cicchetto/e2e/tests/issue973-query-unread-badge-clears.spec.ts
+++ b/cicchetto/e2e/tests/issue973-query-unread-badge-clears.spec.ts
@@ -1,0 +1,132 @@
+// #973 — the unread badge on a QUERY window must clear when the operator
+// reads it, and STAY clear.
+//
+// Reported on 0.13.1: in a DM the badge only ever grew. Channels were fine.
+// The cursor map was written under the peer nick in the casing the window
+// wears (`query_windows.target_nick` is case-preserving server-side, and
+// `canonicalQueryNick` resolves a selection to that spelling — it is not a
+// fold) and read back under the ASCII-FOLDED name the badge memo decodes out
+// of a `ChannelKey`. Two keys, one map. The only writer that ever landed the
+// folded key was the `/me` cold load, so the count was right at page load and
+// wrong forever after. Fixed by folding inside `readCursor.ts`'s `cacheKey` —
+// the single door every cursor writer and reader already passes through.
+//
+// Why this spec exists on top of the vitest boundary tests
+// (src/__tests__/queryUnreadBadgeCasing.test.ts): those drive the store's
+// entry points directly and prove the KEYS agree. They cannot prove the pill
+// leaves the screen. The reported symptom is a number the operator can see, so
+// the witness has to be the rendered badge, reached through the real settle
+// path (open the window, read, leave) rather than a synthetic cursor write.
+// Per feedback_ux_e2e_mandatory: every cic UX-touching change ships one.
+//
+// RED proof (pre-fix): assertion 3 fails — after reading and leaving the query
+// the badge still reads "1", because the leave-settle cursor landed on
+// `azzurra I973Peer` while the memo kept asking `azzurra i973peer`. Assertion 5
+// then reads "2" instead of "1", which is the monotonic growth vjt reported.
+//
+// The peer nick is deliberately MIXED CASE — that is the whole bug. A
+// lowercase peer would fold to itself and the spec would pass on broken code.
+// bahamut preserves nick casing, and `IrcPeer` reconciles `peer.nick` from the
+// authoritative 001 (#604), so every locator below is derived from the nick
+// the server actually registered, never from the constant we asked for.
+
+import { expect, test } from "../fixtures/test";
+import {
+  loginAs,
+  selectChannel,
+  sidebarMessageBadge,
+  waitForDmListenerReady,
+} from "../fixtures/cicchettoPage";
+import { restoreReadCursorToTail } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+const SERVER_WINDOW = "Server";
+const PEER_NICK = "I973Peer";
+const FIRST_DM = "issue-973 first dm";
+const SECOND_DM = "issue-973 second dm";
+
+// The spec focuses #bofh (advancing its cursor on leave). Restore it to tail so
+// downstream specs inherit a clean at-tail cursor (BUGHUNT-3 cascade rule).
+test.afterEach(async () => {
+  const vjt = getSeededVjt();
+  await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL).catch(() => {});
+});
+
+test("#973 — a mixed-case query window's unread badge clears on read and stays clear", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+
+  // Channel-first focus so the boot chain is fully evaluated, then await the
+  // own-nick DM-listener subscribe: without it the peer's PRIVMSG below
+  // fan-outs to zero subscribers and the query window never auto-opens
+  // (FLAKE-D — same guard as CP14 B3).
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+  await waitForDmListenerReady(page, NETWORK_SLUG);
+
+  // Sit on the Server window: a query window's badge is only observable while
+  // it is not the selected one, and Server has no compose, so it cannot
+  // produce client chatter that races the assertions.
+  await selectChannel(page, NETWORK_SLUG, SERVER_WINDOW, { awaitWsReady: false });
+
+  const peer = await IrcPeer.connect({ nick: PEER_NICK });
+  const nick = peer.nick;
+  try {
+    // 1. Inbound DM auto-opens the query window and puts one on the badge.
+    peer.privmsg(NETWORK_NICK, FIRST_DM);
+    await expect(sidebarMessageBadge(page, NETWORK_SLUG, nick)).toHaveText("1", {
+      timeout: 10_000,
+    });
+
+    // 2. Read it. Waiting on the rendered line — not the tab click — is what
+    //    makes the following leave-settle meaningful: the cursor advances over
+    //    rows the pane actually showed.
+    await selectChannel(page, NETWORK_SLUG, nick);
+    await expect(
+      page
+        .locator('[data-testid="scrollback-line"][data-kind="privmsg"]')
+        .filter({ hasText: FIRST_DM }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Leave — the settle write advances the server-owned cursor over what was
+    // read. Back on Server the query's badge is observable again.
+    await selectChannel(page, NETWORK_SLUG, SERVER_WINDOW, { awaitWsReady: false });
+
+    // 3. THE #973 ASSERTION — reading cleared it. Pre-fix the settle landed on
+    //    the raw key, the memo kept reading the folded one, and this stayed "1".
+    await expect(sidebarMessageBadge(page, NETWORK_SLUG, nick)).toHaveCount(0, {
+      timeout: 10_000,
+    });
+
+    // 4. A second DM arrives while the operator is away. The badge counts it —
+    //    the fix must not have silenced the window, only unstuck the cursor.
+    peer.privmsg(NETWORK_NICK, SECOND_DM);
+
+    // 5. Exactly "1", not "2". This is the monotonic growth from the report:
+    //    with the cursor stuck, the first (already-read) DM was still being
+    //    counted, so the second arrival read "2". A spec that only checked
+    //    "badge is present" would pass on the broken code.
+    await expect(sidebarMessageBadge(page, NETWORK_SLUG, nick)).toHaveText("1", {
+      timeout: 10_000,
+    });
+
+    // 6. Reading again clears it again — the cursor keeps moving, it did not
+    //    just happen to be right once.
+    await selectChannel(page, NETWORK_SLUG, nick);
+    await expect(
+      page
+        .locator('[data-testid="scrollback-line"][data-kind="privmsg"]')
+        .filter({ hasText: SECOND_DM }),
+    ).toBeVisible({ timeout: 10_000 });
+    await selectChannel(page, NETWORK_SLUG, SERVER_WINDOW, { awaitWsReady: false });
+
+    await expect(sidebarMessageBadge(page, NETWORK_SLUG, nick)).toHaveCount(0, {
+      timeout: 10_000,
+    });
+  } finally {
+    await peer.disconnect("973 witness done");
+  }
+});

--- a/cicchetto/src/__tests__/queryUnreadBadgeCasing.test.ts
+++ b/cicchetto/src/__tests__/queryUnreadBadgeCasing.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { channelKey } from "../lib/channelKey";
+
+// #973 — the unread badge on a QUERY window never resets.
+//
+// The cursor map was written under the peer nick as the operator's window
+// carries it (`query_windows.target_nick` is case-preserving server-side, and
+// `canonicalQueryNick` deliberately returns that CASING, not a fold) while the
+// badge memo looks the cursor up under the FOLDED name it decodes out of a
+// `ChannelKey`. Two keys, one map: the write landed on `azzurra Mezmerize`,
+// the read asked for `azzurra mezmerize`, missed, and counted every row as
+// unread forever. Channels were spared only because a channel name arrives
+// already canonical, so raw === folded and the fork was invisible.
+//
+// This file runs the REAL cursor store — same reason unreadBadgeFocused.test.ts
+// does: the property under test is that the badge falls when the cursor moves,
+// so a stubbed store would assert nothing. The writers driven here are the
+// production entry points (`applyReadCursorSet` = the `read_cursor_set` WS
+// event, `applyJoinReply` = the Phoenix join reply, `applyMeEnvelope` = the
+// `/me` cold load), each handed the RAW mixed-case nick exactly as subscribe.ts
+// and ScrollbackPane hand it to them.
+
+vi.mock(import("../lib/api"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    listNetworks: vi.fn().mockResolvedValue([]),
+    listChannels: vi.fn().mockResolvedValue([]),
+    listMessages: vi.fn().mockResolvedValue([]),
+    sendMessage: vi.fn(),
+    me: vi.fn().mockResolvedValue({
+      kind: "user",
+      id: "u-test",
+      name: "alice",
+      is_admin: false,
+      inserted_at: "2026-01-01T00:00:00Z",
+      read_cursors: {},
+    }),
+    login: vi.fn(),
+    logout: vi.fn(),
+    setOn401Handler: vi.fn(),
+  };
+});
+
+const SLUG = "azzurra";
+// The casing the operator's window actually carries: `target_nick` preserves
+// first-opened input, and selection.ts resolves a query selection to
+// `match.targetNick` verbatim.
+const PEER_RAW = "Mezmerize";
+const PEER_FOLDED = "mezmerize";
+
+beforeEach(() => {
+  vi.resetModules();
+  localStorage.clear();
+  vi.clearAllMocks();
+  vi.spyOn(document, "hasFocus").mockReturnValue(true);
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => "visible",
+  });
+});
+
+const seedThreeDms = async (): Promise<ReturnType<typeof channelKey>> => {
+  const scrollback = await import("../lib/scrollback");
+  const key = channelKey(SLUG, PEER_RAW);
+  for (const id of [1, 2, 3]) {
+    scrollback.appendToScrollback(key, {
+      id,
+      network: SLUG,
+      channel: PEER_RAW,
+      server_time: id,
+      kind: "privmsg",
+      sender: PEER_RAW,
+      body: `dm ${id}`,
+      meta: {},
+    });
+  }
+  return key;
+};
+
+describe("#973 query-window unread badge across nick casing", () => {
+  it("clears when the WS cursor echo arrives under the raw peer nick", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const selection = await import("../lib/selection");
+    const readCursor = await import("../lib/readCursor");
+    const key = await seedThreeDms();
+
+    selection.setSelectedChannel({
+      networkSlug: SLUG,
+      channelName: PEER_RAW,
+      kind: "query",
+    });
+    expect(selection.messagesUnread()[key]).toBe(3);
+
+    // subscribe.ts's `read_cursor_set` arm passes the handler's `name`
+    // closure, which is the raw target the window was opened with.
+    readCursor.applyReadCursorSet(SLUG, PEER_RAW, 3);
+
+    expect(selection.messagesUnread()[key]).toBeUndefined();
+  });
+
+  it("keeps falling one row at a time — it does not merely snap to zero", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const selection = await import("../lib/selection");
+    const readCursor = await import("../lib/readCursor");
+    const key = await seedThreeDms();
+
+    selection.setSelectedChannel({
+      networkSlug: SLUG,
+      channelName: PEER_RAW,
+      kind: "query",
+    });
+
+    readCursor.applyReadCursorSet(SLUG, PEER_RAW, 1);
+    expect(selection.messagesUnread()[key]).toBe(2);
+    readCursor.applyReadCursorSet(SLUG, PEER_RAW, 2);
+    expect(selection.messagesUnread()[key]).toBe(1);
+    readCursor.applyReadCursorSet(SLUG, PEER_RAW, 3);
+    expect(selection.messagesUnread()[key]).toBeUndefined();
+  });
+
+  it("clears when the join reply carries the cursor under the raw peer nick", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const selection = await import("../lib/selection");
+    const readCursor = await import("../lib/readCursor");
+    const key = await seedThreeDms();
+
+    // subscribe.ts:790 — the per-channel join reply, on every rejoin.
+    readCursor.applyJoinReply(SLUG, PEER_RAW, 3);
+
+    expect(selection.messagesUnread()[key]).toBeUndefined();
+  });
+
+  it("does not resurrect the count when the /me cold load re-seeds the folded key", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const selection = await import("../lib/selection");
+    const readCursor = await import("../lib/readCursor");
+    const key = await seedThreeDms();
+
+    // The one writer that already landed the folded key. It is authoritative
+    // and REPLACES the map, so a later raw write must land on the same key or
+    // the two hydration sources fork — the exact shape of the report (right at
+    // page load, then monotonically wrong).
+    readCursor.applyMeEnvelope({ [SLUG]: { [PEER_FOLDED]: 2 } });
+    expect(selection.messagesUnread()[key]).toBe(1);
+
+    readCursor.applyReadCursorSet(SLUG, PEER_RAW, 3);
+    expect(selection.messagesUnread()[key]).toBeUndefined();
+  });
+});
+
+describe("#973 read-cursor store keys on the folded identifier", () => {
+  it("reads back a raw-nick write under the folded nick, and vice versa", async () => {
+    const { applyReadCursorSet, getReadCursor, clearReadCursors } = await import(
+      "../lib/readCursor"
+    );
+    clearReadCursors();
+
+    applyReadCursorSet(SLUG, PEER_RAW, 200);
+
+    expect(getReadCursor(SLUG, PEER_FOLDED)).toBe(200);
+    expect(getReadCursor(SLUG, PEER_RAW)).toBe(200);
+  });
+
+  it("folds idempotently — /me hands it keys the server already folded", async () => {
+    const { applyMeEnvelope, readCursors, getReadCursor, clearReadCursors } = await import(
+      "../lib/readCursor"
+    );
+    clearReadCursors();
+
+    applyMeEnvelope({ [SLUG]: { [PEER_FOLDED]: 100 } });
+
+    expect(Object.keys(readCursors())).toEqual([`${SLUG} ${PEER_FOLDED}`]);
+    expect(getReadCursor(SLUG, PEER_FOLDED)).toBe(100);
+  });
+
+  it("stores under the key the badge memo decodes out of a ChannelKey", async () => {
+    const { decodeChannelKey } = await import("../lib/channelKey");
+    const { applyReadCursorSet, readCursors, clearReadCursors } = await import("../lib/readCursor");
+    clearReadCursors();
+
+    applyReadCursorSet(SLUG, PEER_RAW, 7);
+
+    // selection.ts:414 builds its lookup key exactly this way.
+    const decoded = decodeChannelKey(channelKey(SLUG, PEER_RAW));
+    if (decoded === null) throw new Error("channelKey did not decode");
+    expect(readCursors()[`${decoded.slug} ${decoded.name}`]).toBe(7);
+  });
+
+  it("keeps the optimistic forward-only gate on the same key as the hydrated cursor", async () => {
+    const { applyReadCursorSet, getReadCursor, setReadCursor, clearReadCursors } = await import(
+      "../lib/readCursor"
+    );
+    clearReadCursors();
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    applyReadCursorSet(SLUG, PEER_RAW, 500);
+    // A stale settle for an OLDER row, posted with the raw nick. Under the
+    // forked keys this read `undefined` on the raw key and clobbered the map
+    // backwards; the gate has to see the 500.
+    await setReadCursor("tok", SLUG, PEER_RAW, 400);
+
+    expect(getReadCursor(SLUG, PEER_FOLDED)).toBe(500);
+    vi.unstubAllGlobals();
+  });
+
+  it("leaves the POST target raw — the server folds at ingress, the wire does not", async () => {
+    const { setReadCursor, clearReadCursors } = await import("../lib/readCursor");
+    clearReadCursors();
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await setReadCursor("tok", SLUG, PEER_RAW, 42);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain(`/channels/${PEER_RAW}/read-cursor`);
+    vi.unstubAllGlobals();
+  });
+
+  it("migrates the cursor on a #373 rename whichever casing each side arrives in", async () => {
+    const { applyReadCursorSet, getReadCursor, renameReadCursorChannel, clearReadCursors } =
+      await import("../lib/readCursor");
+    clearReadCursors();
+
+    applyReadCursorSet(SLUG, PEER_RAW, 900);
+    // The `nick_change` event carries whatever the ircd sent, on both sides.
+    renameReadCursorChannel(SLUG, PEER_FOLDED, "NewNick");
+
+    expect(getReadCursor(SLUG, PEER_FOLDED)).toBeNull();
+    expect(getReadCursor(SLUG, "newnick")).toBe(900);
+  });
+
+  it("is a no-op for a channel, whose name is already canonical", async () => {
+    const { applyReadCursorSet, readCursors, getReadCursor, clearReadCursors } = await import(
+      "../lib/readCursor"
+    );
+    clearReadCursors();
+
+    applyReadCursorSet(SLUG, "#sniffo", 300);
+
+    expect(Object.keys(readCursors())).toEqual([`${SLUG} #sniffo`]);
+    expect(getReadCursor(SLUG, "#sniffo")).toBe(300);
+  });
+});

--- a/cicchetto/src/lib/readCursor.ts
+++ b/cicchetto/src/lib/readCursor.ts
@@ -32,12 +32,41 @@
 
 import { createEffect, createSignal, on } from "solid-js";
 import { token } from "./auth";
+import { canonicalChannel } from "./channelKey";
 import { moduleRoot } from "./moduleRoot";
 import { isVirtualWindowName } from "./windowKinds";
 
 const LEGACY_KEY_PREFIX = "rc:";
 
-const cacheKey = (networkSlug: string, channel: string): string => `${networkSlug} ${channel}`;
+// #973 — the ONE fold on the cursor map's KEY boundary, same
+// `canonicalChannel` (`asciiFold`, mirror of the server's
+// `Grappa.IRC.Identifier.canonical_target/1`) that `channelKey/2` applies.
+//
+// Pre-fix this interpolated the caller's string verbatim, which forked the
+// map for QUERY windows: `query_windows.target_nick` is case-preserving
+// server-side and `canonicalQueryNick` deliberately resolves a selection to
+// that CASING (it answers "which spelling does this window wear", it is not a
+// fold), so every writer on the query path — the `read_cursor_set` WS arm and
+// join-reply in subscribe.ts, the settle/leave writes in ScrollbackPane —
+// handed us `Mezmerize`. The badge memo (selection.ts `perChannelUnread`)
+// reads the cursor under the name it decodes out of a `ChannelKey`, which IS
+// folded, so it asked for `mezmerize`, missed, and counted the whole window
+// unread. The only writer that landed the folded key was the `/me` cold load
+// (the server persists cursors canonicalised), which is why the badge was
+// right at page load and then grew monotonically forever.
+//
+// Folding HERE rather than at each call site is the single-door form the
+// key/display/wire split asks for: every entry point (`getReadCursor`,
+// `applyMeEnvelope`, `applyJoinReply`, `applyReadCursorSet`, `setReadCursor`'s
+// optimistic advance, `renameReadCursorChannel`) inherits it and no future
+// caller can get it wrong. It is idempotent, so the already-folded `/me` keys
+// are unaffected; it is invisible for channels, whose names arrive canonical
+// (raw === folded), which is why only queries ever broke. Display casing is
+// untouched — this feeds map KEYS only, never a label. So is the WIRE: the
+// POST below still targets the RAW channel, because the server folds at
+// ingress and the wire carries the operator's spelling.
+const cacheKey = (networkSlug: string, channel: string): string =>
+  `${networkSlug} ${canonicalChannel(channel)}`;
 
 const [cursors, setCursors] = moduleRoot(() => createSignal<Record<string, number>>({}));
 
@@ -66,7 +95,8 @@ export const readCursors = (): Record<string, number> => cursors();
 /**
  * Cursor map key shape — exported so the consumer memo can decode a
  * `${slug} ${chan}` map key back into its parts without re-deriving
- * the separator. Mirrors `cacheKey/2`.
+ * the separator. Mirrors `cacheKey/2`, so the `channel` it returns is the
+ * FOLDED identifier (#973), never a display spelling.
  */
 export const decodeCursorKey = (key: string): { slug: string; channel: string } | null => {
   const sep = key.indexOf(" ");
@@ -257,7 +287,12 @@ export const renameReadCursorChannel = (
   oldChannel: string,
   newChannel: string,
 ): void => {
-  if (oldChannel === newChannel) return;
+  // The `nick_change` event carries whatever casing the ircd sent on either
+  // side, so "same window, nothing to migrate" is a KEY question and folds
+  // (#973). A pure re-casing (`Foo` → `foo`) is one identity, not a rename:
+  // without the fold it fell through to a self-migration that rebuilt the map
+  // into an equal-but-new object and woke every cursor consumer for nothing.
+  if (cacheKey(networkSlug, oldChannel) === cacheKey(networkSlug, newChannel)) return;
   setCursors((prev) => {
     const oldKey = cacheKey(networkSlug, oldChannel);
     const oldVal = prev[oldKey];


### PR DESCRIPTION
Fixes the report on #973: in a DM window the unread badge only ever grew. Channels were fine.

## The defect

The cursor map was **written** under the peer nick in the casing the window wears and **read back** under the ASCII-folded one.

`query_windows.target_nick` is case-preserving server-side, and `canonicalQueryNick` deliberately resolves a selection to that spelling — it answers *"which spelling does this window wear"*, it is **not** a fold. So every writer on the query path handed `readCursor.cacheKey` a raw `Mezmerize`. The badge memo (`selection.ts` `perChannelUnread`) looks the cursor up under the name it decodes out of a `ChannelKey`, which **is** folded, so it asked for `mezmerize`, missed, and counted the whole window unread.

The only writer that landed the folded key was the `/me` cold load (the server persists cursors canonicalised). That is exactly why the count was right at page load and monotonically wrong after.

Channels were spared because a channel name arrives already canonical: raw `===` folded, so the fork was invisible.

## The fix

One fold, inside `readCursor.ts`'s `cacheKey` — the single door every cursor writer and reader already passes through. The single-door form CLAUDE.md's key/display/wire split asks for, so no future writer can get it wrong.

Idempotent (the `/me` keys are already folded), invisible for channels, and **display casing and the POST target stay RAW** — this feeds map KEYS only, and the server folds at ingress.

`renameReadCursorChannel`'s "nothing to migrate" guard folds too: a pure re-casing is one identity, and without the fold it fell through to a self-migration that rebuilt the map into an equal-but-new object and woke every cursor consumer for nothing.

## The issue's count of writers was low

The issue named four. The grep found more — `subscribe.ts:647` (the own-nick DM arm), `subscribe.ts:790`, `reconnectBackfill.ts:75`, `selection.ts:536/540`, and seven sites in `scrollback.ts`. All of them inherit the fold, which is the argument for fixing the door rather than the callers.

## Adjacent drift, fixed in its own commit

`cicchettoPage.ts` keeps a hand-copied mirror of `canonicalChannel` (the e2e tree cannot import src) whose own comment says it MUST stay byte-identical. It had drifted two ways and was still the PRE-#537 shape: sigil-gated (a nick came back raw) and folding with `toLowerCase` (the Unicode over-fold #525 removed). No green spec caught it because none had yet passed a mixed-case nick through those seams; the first to try would have hung on a barrier key nothing stamps and read as a product bug.

Separate commit so it is revertable alone.

## Evidence

| gate | result |
|---|---|
| `bun run test` at `origin/main` (1fc4e04b), before any edit | rc=0 — 243 files, 4518 tests |
| new vitest, **pre-fix** | rc=1 — **8 failed**, 3 passed |
| new vitest, post-fix | rc=0 — 11/11 |
| `bun run test` full, post-fix | rc=0 — 244 files, 4529 tests |
| `bun run check` (biome + tsc) | rc=0 |
| `tsc -p e2e/tsconfig.json --noEmit` | 26 pre-existing errors, **zero in the two files this PR touches**; `--listFiles` confirms both are in the program |

The three vitest cases that **pass pre-fix** are deliberate: they pin the invariants the fold must not disturb — idempotence over server-folded keys, the raw wire target, and channels unchanged. If the fold had been wrong they would have flipped red.

## What I refused to assert

- **The e2e is UNRUN.** No STACK lane was allocated, so `scripts/integration.sh` was not executed. I have not measured it red pre-fix either, so I am **not** claiming the spec is falsifiable — only that it is written to be. Its RED prediction (assertion 3 reads `"1"`, assertion 5 reads `"2"`) is reasoning from the diagnosis, not a measurement.
- **I did not prove the fixture-mirror change breaks nothing by running the suite.** The evidence is static: no e2e spec uses a non-ASCII channel name, and none passes a mixed-case nick through `waitForChannelReady` / `waitForScrollbackRefreshed` (a spec that did would already be hanging). That is a grep, not a green run.
- **I did not verify the server side.** This is client-only; the server already folds cursor keys at ingress and at rest. I did not re-read `ReadCursor` to confirm the `read_cursor_set` broadcast's channel spelling — it does not matter here, because `subscribe.ts` keys off its own raw `name` closure either way, but I am not asserting what the server sends.
- **`decodeCursorKey` has no production caller** — only two test mocks. I updated its doc to say the channel it returns is now folded, and changed nothing else. I am not claiming it is used.
- **The rfc1459 axis is untouched.** cic has no per-network casemapping normalisation; on `:ascii` (all of prod) that is a no-op, and this PR does not close the known national-char gap documented in CLAUDE.md.

## Notes

- DESIGN_NOTES entry is parked at `/tmp/w1-designnotes-973.md` and applies only on merge — a decision log describing code not in main is a lie in the register.
- Not merging or deploying; awaiting instruction.