### PR TITLE
#964: name a push device — stored label, derived ordinal

### DIFF
--- a/cicchetto/e2e/tests/push-964-device-label.spec.ts
+++ b/cicchetto/e2e/tests/push-964-device-label.spec.ts
@@ -1,0 +1,147 @@
+// push-964 — naming a device, and the ordinal that names the ones you have not.
+//
+// The sibling spec (`push-964-device-row.spec.ts`) covers the two
+// disambiguators derived from data the row already carried: the activity
+// instant and the "this device" marker. This one covers the two that needed a
+// schema change — the user's own label, and the ordinal that separates the
+// twins nobody has named yet.
+//
+// Four contracts, every one asserted on what a person would SEE:
+//
+//   1. Two devices that parse to the same `Browser on OS` render DIFFERENT
+//      names, numbered oldest-first.
+//   2. Renaming one from its row replaces that name, and demotes the parsed
+//      string to the secondary line instead of dropping it.
+//   3. Naming one twin drops the OTHER's ordinal. This is the assertion a
+//      STORED ordinal would fail: a column written while the pair collided
+//      keeps its `#2` forever, whereas the derived name re-reads the list and
+//      finds the survivor alone in its group.
+//   4. Clearing the label hands the row back to the derived default — the
+//      twins collide again and BOTH are numbered once more.
+//
+// ## Why the rows are POSTed rather than registered from two browsers
+//
+// The contract under test is about two rows whose `user_agent` parses to the
+// same string. The runner has one engine per project, so a second browser
+// would supply the same UA — but also a second push stub, a second SW
+// registration and a second opt-in dance for rows this spec only ever reads.
+// POSTing them is the same insert the server would have performed, and it lets
+// the spec pin the UA, so the expected names are literal (`Firefox on Linux
+// #1`) instead of "whatever this engine calls itself".
+//
+// ## Why there is no page.reload()
+//
+// On boot `installPushResubscribe` renews a subscription the per-document push
+// stub makes look dropped; the renewal POSTs `supersedes`, which DELETES the
+// old row and inserts a fresh one — losing the very label under assertion. The
+// persistence leg therefore reads from a second BrowserContext, which carries
+// no opt-in intent and so renews nothing. Same reasoning as the sibling spec.
+//
+// No @webkit twin: every assertion is on rendered text, so nothing here is
+// engine-dependent.
+
+import { expect, test } from "../fixtures/test";
+import { loginAs, openSettingsSection } from "../fixtures/cicchettoPage";
+import { resetPushSubscriptions } from "../fixtures/push";
+import { getSeededVjt } from "../fixtures/seedData";
+
+const GRAPPA = "http://grappa-test:4000";
+
+// One UA for both rows: `parseUserAgent` collapses it to "Firefox on Linux",
+// which is precisely the collision Hypnotize reported.
+const TWIN_UA = "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0";
+const TWIN_NAME = "Firefox on Linux";
+
+test("twins carry ordinals, a rename replaces one, and the survivor drops its number", async ({
+  page,
+  browser,
+}) => {
+  const vjt = getSeededVjt();
+  await resetPushSubscriptions(vjt.token);
+
+  // Oldest first — the ordinal is assigned by creation instant, so the order
+  // of these two POSTs is what makes `#1` deterministic.
+  await registerDevice(vjt.token, TWIN_UA, "https://push.example/964-label-older");
+  await registerDevice(vjt.token, TWIN_UA, "https://push.example/964-label-newer");
+
+  await loginAs(page, vjt);
+  await openSettingsSection(page, "push");
+
+  const rows = page.locator('[data-testid="devices-list"] li');
+  await expect(rows).toHaveCount(2);
+
+  // ── 1. Both numbered, and the two names differ.
+  const first = rows.filter({ hasText: `${TWIN_NAME} #1` });
+  const second = rows.filter({ hasText: `${TWIN_NAME} #2` });
+  await expect(first).toHaveCount(1);
+  await expect(second).toHaveCount(1);
+
+  // ── 2. Rename the second one from its row.
+  await second.getByTestId("device-rename").click();
+  const input = page.getByTestId("device-name-input");
+  await expect(input).toBeVisible();
+  await input.fill("il portatile");
+  await page.getByTestId("device-rename-save").click();
+
+  const renamed = rows.filter({ hasText: "il portatile" });
+  await expect(renamed.getByTestId("device-name")).toHaveText("il portatile");
+  // The parsed string is not lost — it demotes to the secondary line.
+  await expect(renamed.getByTestId("device-parsed")).toHaveText(TWIN_NAME);
+
+  // ── 3. The other twin is now alone among the unnamed, so its ordinal is
+  // gone. A stored ordinal would still read "#1" here.
+  const survivor = rows.filter({ hasNotText: "il portatile" });
+  await expect(survivor.getByTestId("device-name")).toHaveText(TWIN_NAME);
+
+  // ── The label lives on the SERVER: a browser that has never seen this
+  // session reads the same name back.
+  const observerCtx = await browser.newContext();
+  try {
+    const observer = await observerCtx.newPage();
+    await loginAs(observer, vjt);
+    await openSettingsSection(observer, "push");
+    await expect(
+      observer.locator('[data-testid="devices-list"] li').filter({ hasText: "il portatile" }),
+    ).toHaveCount(1);
+  } finally {
+    await observerCtx.close();
+  }
+
+  // ── 4. Clearing the label hands the row back to its derived default, and
+  // the twins collide again — both numbered once more.
+  await renamed.getByTestId("device-rename").click();
+  await page.getByTestId("device-name-input").fill("");
+  await page.getByTestId("device-rename-save").click();
+
+  await expect(rows.filter({ hasText: `${TWIN_NAME} #1` })).toHaveCount(1);
+  await expect(rows.filter({ hasText: `${TWIN_NAME} #2` })).toHaveCount(1);
+  await expect(page.getByTestId("device-parsed")).toHaveCount(0);
+});
+
+/**
+ * POSTs a push subscription for `token`'s subject with an explicit UA, so the
+ * spec controls what the row parses to. Keys are the fixture pair the push
+ * helpers use — the changeset's length caps apply to every insert, whoever
+ * makes it.
+ */
+async function registerDevice(token: string, userAgent: string, endpoint: string): Promise<void> {
+  const res = await fetch(`${GRAPPA}/push/subscriptions`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "user-agent": userAgent,
+    },
+    body: JSON.stringify({
+      endpoint,
+      keys: {
+        p256dh:
+          "BCfaYE5dGabdzef68MI0SN24b4Gsf1t_N3ftUlWaFGzkuudjHLor0CRjosM3c7SLZ7PfFufpsFUh8vsO1t8wCHs",
+        auth: "dGVzdC1hdXRoLXNlY3JldDE2Yg",
+      },
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`registerDevice: ${res.status} ${await res.text()}`);
+  }
+}

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -19,7 +19,7 @@ import { canonicalChannel } from "./lib/channelKey";
 import { getColoredNicklist } from "./lib/colorNicklist";
 import { syncedSetColoredNicklist, syncedSetTimeFormat } from "./lib/displayPrefs";
 import { type FontSizeKey, getFontSize, setFontSize } from "./lib/fontSize";
-import { friendlyApiError } from "./lib/friendlyApiError";
+import { errorMessage, friendlyApiError } from "./lib/friendlyApiError";
 import { getHideNextActive, setHideNextActive } from "./lib/hideNextActive";
 import { detach, quit, updateIdentity } from "./lib/lifecycle";
 import { isAdmin, networks, user } from "./lib/networks";
@@ -27,6 +27,7 @@ import { mirrorNotificationPrefs } from "./lib/notificationPrefs";
 import { popOverlay, pushOverlay } from "./lib/overlayScrollLock";
 import {
   deletePushSubscription,
+  deviceRows,
   disablePush,
   type EnablePushResult,
   enablePush,
@@ -34,6 +35,7 @@ import {
   listPushDevices,
   type PushDeviceSummary,
   pushAvailable,
+  renamePushDevice,
   type SubscriptionId,
   subscriptionIdForEndpoint,
 } from "./lib/push";
@@ -110,6 +112,12 @@ const SettingsDrawer: Component<Props> = (props) => {
   // reason this issue exists. `null` = we cannot prove any row is ours (never
   // subscribed here / cleared site data) — then NO row gets the marker.
   const [currentDeviceId, setCurrentDeviceId] = createSignal<SubscriptionId | null>(null);
+  // #964 — inline rename. `renamingId` is the row currently in edit mode
+  // (at most one); the draft lives here rather than in the input so a
+  // re-render from a background refreshDevices cannot discard the typing.
+  const [renamingId, setRenamingId] = createSignal<SubscriptionId | null>(null);
+  const [renameDraft, setRenameDraft] = createSignal("");
+  const [renameError, setRenameError] = createSignal<string | null>(null);
   const [pushEnabled, setPushEnabled] = createSignal(false);
   const [pushBanner, setPushBanner] = createSignal<string | null>(null);
   const [savingPrefs, setSavingPrefs] = createSignal(false);
@@ -592,6 +600,37 @@ const SettingsDrawer: Component<Props> = (props) => {
       setPushEnabled(false);
       setCurrentDeviceId(null);
       await refreshDevices();
+    }
+  };
+
+  // #964 — opens the row's editor. Seeded with the STORED label, never with
+  // the derived default: pre-filling "Firefox on Linux #2" and hitting save
+  // would freeze today's ordinal into a stored label, which is the stale
+  // number the derived design exists to avoid.
+  const startRename = (device: PushDeviceSummary) => {
+    setRenameError(null);
+    setRenameDraft(device.label ?? "");
+    setRenamingId(device.id);
+  };
+
+  const cancelRename = () => {
+    setRenamingId(null);
+    setRenameError(null);
+  };
+
+  // Unlike removeDevice, a failure here is NOT swallowed: a 422 past the
+  // length cap is the user's own input coming back, and silently dropping
+  // it would look like the rename simply did not take.
+  const commitRename = async (id: SubscriptionId) => {
+    const t = token();
+    if (t === null) return;
+    try {
+      await renamePushDevice(t, id, renameDraft());
+      setRenamingId(null);
+      setRenameError(null);
+      await refreshDevices();
+    } catch (err) {
+      setRenameError(errorMessage(err));
     }
   };
 
@@ -1531,8 +1570,9 @@ const SettingsDrawer: Component<Props> = (props) => {
               <Show when={devices().length > 0}>
                 <h3>devices</h3>
                 <ul class="devices-list" data-testid="devices-list">
-                  <For each={devices()}>
-                    {(d) => {
+                  <For each={deviceRows(devices())}>
+                    {(row) => {
+                      const d = row.device;
                       // UX-4 bucket L (2026-05-19) — replace the raw UA
                       // string with `{icon} {Browser} on {OS}`. Title
                       // attribute preserves the full UA so a hover (desktop)
@@ -1547,39 +1587,111 @@ const SettingsDrawer: Component<Props> = (props) => {
                       // "3m ago → 4m ago" would out-freshen its own data.
                       const activity = formatDeviceActivity(d, Date.now());
                       const isCurrent = () => currentDeviceId() === d.id;
+                      const editing = () => renamingId() === d.id;
                       return (
                         <li>
-                          <span class="device-ua" title={d.user_agent ?? "(unknown browser)"}>
-                            <span class="device-ua-icon" aria-hidden="true">
-                              {deviceClassIcon(parsed.deviceClass)}
-                            </span>
-                            <span class="device-ua-text">
-                              <span class="device-ua-title">
-                                <span class="device-ua-name">
-                                  {parsed.browser} on {parsed.os}
-                                </span>
-                                <Show when={isCurrent()}>
-                                  <span class="device-current" data-testid="device-current">
-                                    ● this device
+                          <Show
+                            when={editing()}
+                            fallback={
+                              <>
+                                <span class="device-ua" title={d.user_agent ?? "(unknown browser)"}>
+                                  <span class="device-ua-icon" aria-hidden="true">
+                                    {deviceClassIcon(parsed.deviceClass)}
                                   </span>
-                                </Show>
-                              </span>
-                              <Show when={activity !== null}>
-                                <span class="device-activity" data-testid="device-activity">
-                                  {activity}
+                                  <span class="device-ua-text">
+                                    <span class="device-ua-title">
+                                      <span class="device-ua-name" data-testid="device-name">
+                                        {row.displayName}
+                                      </span>
+                                      <Show when={isCurrent()}>
+                                        <span class="device-current" data-testid="device-current">
+                                          ● this device
+                                        </span>
+                                      </Show>
+                                    </span>
+                                    {/* #964 — the parsed name survives as the
+                                        secondary line ONLY once a label has
+                                        taken its place above; printing it
+                                        twice on an unnamed row says nothing. */}
+                                    <Show when={row.named}>
+                                      <span class="device-activity" data-testid="device-parsed">
+                                        {parsed.browser} on {parsed.os}
+                                      </span>
+                                    </Show>
+                                    <Show when={activity !== null}>
+                                      <span class="device-activity" data-testid="device-activity">
+                                        {activity}
+                                      </span>
+                                    </Show>
+                                  </span>
+                                </span>
+                                <button
+                                  type="button"
+                                  class="device-remove"
+                                  data-testid="device-rename"
+                                  onClick={() => startRename(d)}
+                                >
+                                  rename
+                                </button>
+                                <button
+                                  type="button"
+                                  class="device-remove"
+                                  onClick={() => {
+                                    void removeDevice(d.id);
+                                  }}
+                                >
+                                  remove
+                                </button>
+                              </>
+                            }
+                          >
+                            <span class="device-rename-form">
+                              <input
+                                type="text"
+                                class="device-rename-input"
+                                data-testid="device-name-input"
+                                aria-label="device name"
+                                // Empty draft = no label yet; the placeholder shows
+                                // what the row falls back to, so clearing the field
+                                // is a visible choice rather than a blank row.
+                                placeholder={row.displayName}
+                                value={renameDraft()}
+                                onInput={(e) => setRenameDraft(e.currentTarget.value)}
+                                onKeyDown={(e) => {
+                                  if (e.key === "Enter") {
+                                    e.preventDefault();
+                                    void commitRename(d.id);
+                                  } else if (e.key === "Escape") {
+                                    e.preventDefault();
+                                    cancelRename();
+                                  }
+                                }}
+                              />
+                              <Show when={renameError() !== null}>
+                                <span class="prefs-error" data-testid="device-rename-error">
+                                  {renameError()}
                                 </span>
                               </Show>
                             </span>
-                          </span>
-                          <button
-                            type="button"
-                            class="device-remove"
-                            onClick={() => {
-                              void removeDevice(d.id);
-                            }}
-                          >
-                            remove
-                          </button>
+                            <button
+                              type="button"
+                              class="device-remove"
+                              data-testid="device-rename-save"
+                              onClick={() => {
+                                void commitRename(d.id);
+                              }}
+                            >
+                              save
+                            </button>
+                            <button
+                              type="button"
+                              class="device-remove"
+                              data-testid="device-rename-cancel"
+                              onClick={cancelRename}
+                            >
+                              cancel
+                            </button>
+                          </Show>
                         </li>
                       );
                     }}

--- a/cicchetto/src/__tests__/push.test.ts
+++ b/cicchetto/src/__tests__/push.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearVapidPublicKeyCache,
   deletePushSubscription,
+  deviceRows,
   disablePush,
   ensurePushSubscription,
   formatDeviceActivity,
@@ -437,6 +438,7 @@ describe("formatDeviceActivity — #964: the row's activity line", () => {
   const device = (over: Partial<PushDeviceSummary>): PushDeviceSummary => ({
     id: "sub-1" as SubscriptionId,
     user_agent: "Mozilla/5.0 (X11; Linux x86_64) Firefox/128.0",
+    label: null,
     created_at: "2026-08-07T11:00:00Z",
     last_used_at: null,
     ...over,
@@ -489,5 +491,149 @@ describe("subscriptionIdForEndpoint — #964: which row is THIS device", () => {
 
   it("returns null when nothing was ever stashed", () => {
     expect(subscriptionIdForEndpoint("https://push.example/ep")).toBeNull();
+  });
+});
+
+// ── #964 — the row's NAME: user label first, derived ordinal otherwise ──
+// The label is the only stored piece; the ordinal is derived on every
+// render precisely so deleting a twin cannot strand a lone "#2".
+
+describe("deviceRows — #964: the name the device row prints", () => {
+  const FIREFOX_LINUX = "Mozilla/5.0 (X11; Linux x86_64) Firefox/128.0";
+  const CHROME_MAC =
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36";
+
+  const dev = (
+    over: Omit<Partial<PushDeviceSummary>, "id"> & { id: string },
+  ): PushDeviceSummary => ({
+    user_agent: FIREFOX_LINUX,
+    label: null,
+    created_at: "2026-08-07T11:00:00Z",
+    last_used_at: null,
+    ...over,
+    id: over.id as SubscriptionId,
+  });
+
+  const nameOf = (rows: ReturnType<typeof deviceRows>, id: string): string | undefined =>
+    rows.find((r) => r.device.id === (id as SubscriptionId))?.displayName;
+
+  it("prints the parsed name, with NO ordinal, for a device alone in its group", () => {
+    const rows = deviceRows([dev({ id: "a" })]);
+    expect(rows.map((r) => r.displayName)).toEqual(["Firefox on Linux"]);
+    expect(rows[0]?.named).toBe(false);
+  });
+
+  it("prints no ordinal when the two devices parse differently", () => {
+    const rows = deviceRows([dev({ id: "a" }), dev({ id: "b", user_agent: CHROME_MAC })]);
+    expect(rows.map((r) => r.displayName)).toEqual(["Firefox on Linux", "Chrome on macOS"]);
+  });
+
+  it("numbers twins oldest-first, regardless of the order the server sent them", () => {
+    // Server order is newest-first, so the NEWER row arrives at index 0 —
+    // if the ordinal followed list position instead of created_at, the
+    // older device would be #2 and the numbers would flip whenever the
+    // list is re-sorted.
+    const rows = deviceRows([
+      dev({ id: "new", created_at: "2026-08-07T11:00:00Z" }),
+      dev({ id: "old", created_at: "2026-08-01T09:00:00Z" }),
+    ]);
+    expect(nameOf(rows, "old")).toBe("Firefox on Linux #1");
+    expect(nameOf(rows, "new")).toBe("Firefox on Linux #2");
+  });
+
+  it("keeps existing ordinals stable when a newer twin appears", () => {
+    const older = dev({ id: "old", created_at: "2026-08-01T09:00:00Z" });
+    const newer = dev({ id: "new", created_at: "2026-08-07T11:00:00Z" });
+    const third = dev({ id: "third", created_at: "2026-08-09T09:00:00Z" });
+
+    const before = deviceRows([newer, older]);
+    const after = deviceRows([third, newer, older]);
+
+    expect(nameOf(before, "old")).toBe(nameOf(after, "old"));
+    expect(nameOf(before, "new")).toBe(nameOf(after, "new"));
+    expect(nameOf(after, "third")).toBe("Firefox on Linux #3");
+  });
+
+  it("re-derives after a deletion instead of stranding a lone #2", () => {
+    // THE reason the ordinal is not a column: delete #1 and a stored #2
+    // has nobody to be second to. Derived, the survivor is alone in its
+    // group and drops the suffix entirely.
+    const older = dev({ id: "old", created_at: "2026-08-01T09:00:00Z" });
+    const newer = dev({ id: "new", created_at: "2026-08-07T11:00:00Z" });
+
+    expect(nameOf(deviceRows([newer, older]), "new")).toBe("Firefox on Linux #2");
+    expect(nameOf(deviceRows([newer]), "new")).toBe("Firefox on Linux");
+  });
+
+  it("numbers each colliding group independently", () => {
+    const rows = deviceRows([
+      dev({ id: "f1", created_at: "2026-08-01T09:00:00Z" }),
+      dev({ id: "f2", created_at: "2026-08-02T09:00:00Z" }),
+      dev({ id: "c1", user_agent: CHROME_MAC, created_at: "2026-08-03T09:00:00Z" }),
+      dev({ id: "c2", user_agent: CHROME_MAC, created_at: "2026-08-04T09:00:00Z" }),
+    ]);
+    expect(nameOf(rows, "f1")).toBe("Firefox on Linux #1");
+    expect(nameOf(rows, "f2")).toBe("Firefox on Linux #2");
+    expect(nameOf(rows, "c1")).toBe("Chrome on macOS #1");
+    expect(nameOf(rows, "c2")).toBe("Chrome on macOS #2");
+  });
+
+  it("the user's label wins over the derived name", () => {
+    const rows = deviceRows([
+      dev({ id: "a", label: "MacBook del lavoro", created_at: "2026-08-01T09:00:00Z" }),
+      dev({ id: "b", created_at: "2026-08-02T09:00:00Z" }),
+    ]);
+    expect(nameOf(rows, "a")).toBe("MacBook del lavoro");
+    expect(rows.find((r) => r.device.id === ("a" as SubscriptionId))?.named).toBe(true);
+  });
+
+  it("naming one twin leaves the other WITHOUT an orphan ordinal", () => {
+    // The pair is no longer ambiguous on screen, so the survivor must not
+    // keep a "#2" that has nothing to contrast with.
+    const rows = deviceRows([
+      dev({ id: "named", label: "fisso", created_at: "2026-08-01T09:00:00Z" }),
+      dev({ id: "bare", created_at: "2026-08-02T09:00:00Z" }),
+    ]);
+    expect(nameOf(rows, "bare")).toBe("Firefox on Linux");
+  });
+
+  it("still numbers the two that remain unlabelled among three twins", () => {
+    const rows = deviceRows([
+      dev({ id: "named", label: "fisso", created_at: "2026-08-01T09:00:00Z" }),
+      dev({ id: "x", created_at: "2026-08-02T09:00:00Z" }),
+      dev({ id: "y", created_at: "2026-08-03T09:00:00Z" }),
+    ]);
+    expect(nameOf(rows, "x")).toBe("Firefox on Linux #1");
+    expect(nameOf(rows, "y")).toBe("Firefox on Linux #2");
+  });
+
+  it("preserves the server's row order (newest first)", () => {
+    const rows = deviceRows([
+      dev({ id: "new", created_at: "2026-08-07T11:00:00Z" }),
+      dev({ id: "old", created_at: "2026-08-01T09:00:00Z" }),
+    ]);
+    expect(rows.map((r) => r.device.id)).toEqual(["new", "old"]);
+  });
+
+  it("falls back to the id for a total order when created_at does not parse", () => {
+    const rows = deviceRows([
+      dev({ id: "b", created_at: "not-a-date" }),
+      dev({ id: "a", created_at: "not-a-date" }),
+    ]);
+    expect(nameOf(rows, "a")).toBe("Firefox on Linux #1");
+    expect(nameOf(rows, "b")).toBe("Firefox on Linux #2");
+  });
+
+  it("groups two unparseable user agents together rather than splitting them", () => {
+    const rows = deviceRows([
+      dev({ id: "a", user_agent: null, created_at: "2026-08-01T09:00:00Z" }),
+      dev({ id: "b", user_agent: "", created_at: "2026-08-02T09:00:00Z" }),
+    ]);
+    expect(nameOf(rows, "a")).toBe("Unknown browser on Unknown OS #1");
+    expect(nameOf(rows, "b")).toBe("Unknown browser on Unknown OS #2");
+  });
+
+  it("returns an empty list for an empty device list", () => {
+    expect(deviceRows([])).toEqual([]);
   });
 });

--- a/cicchetto/src/lib/push.ts
+++ b/cicchetto/src/lib/push.ts
@@ -22,6 +22,7 @@
 import { ApiError, readError } from "./api";
 import { formatDurationSince } from "./duration";
 import { isIos, isStandalonePwa } from "./platform";
+import { parseUserAgent } from "./userAgent";
 
 const VAPID_PUBLIC_KEY_STORAGE_KEY = "cic.vapidPublicKey";
 
@@ -167,9 +168,97 @@ export async function deletePushSubscription(token: string, id: SubscriptionId):
 export type PushDeviceSummary = {
   id: SubscriptionId;
   user_agent: string | null;
+  /** #964 — user-set device name. `null` until renamed; see `deviceRows`. */
+  label: string | null;
   created_at: string;
   last_used_at: string | null;
 };
+
+/** A device paired with the name the row should actually print. */
+export type DeviceRow = {
+  device: PushDeviceSummary;
+  /** The user's label when set, else the derived `Browser on OS [#n]`. */
+  displayName: string;
+  /** True when `displayName` is the user's own label rather than the default. */
+  named: boolean;
+};
+
+const parsedDeviceName = (device: PushDeviceSummary): string => {
+  const parsed = parseUserAgent(device.user_agent);
+  return `${parsed.browser} on ${parsed.os}`;
+};
+
+// Oldest first, id as the tiebreak so the ordering is TOTAL — two rows
+// created in the same microsecond (or with an unparseable instant) must
+// still get a stable order, or the ordinals would shuffle between renders.
+const byCreation = (a: PushDeviceSummary, b: PushDeviceSummary): number => {
+  const ta = Date.parse(a.created_at);
+  const tb = Date.parse(b.created_at);
+  const ka = Number.isNaN(ta) ? Number.POSITIVE_INFINITY : ta;
+  const kb = Number.isNaN(tb) ? Number.POSITIVE_INFINITY : tb;
+  if (ka !== kb) return ka < kb ? -1 : 1;
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+};
+
+/**
+ * #964 — pairs each device with the name its row prints, preserving the
+ * server's ordering (newest first).
+ *
+ * The user's `label` wins outright. Without one the row falls back to the
+ * parsed `Browser on OS`, which is exactly the string that collides — so
+ * when two or more UNLABELLED devices parse to the same name, each gets an
+ * ordinal (`Firefox on Linux #1`, `#2`) assigned oldest-first. A device
+ * alone in its group takes no suffix: a solitary `#1` is noise.
+ *
+ * Labelled rows are excluded from the grouping, not just from the suffix.
+ * Naming one of two twins already disambiguates the pair, and leaving the
+ * other as a lone `#2` would be the stale-ordinal bug reintroduced by hand.
+ *
+ * ## Why the ordinal is DERIVED here and not a column
+ *
+ * Two independent reasons, and either alone settles it:
+ *
+ *   1. An ordinal is a function of how many rows currently share a parsed
+ *      name. Stored, it goes stale the instant one of them is deleted —
+ *      a `#2` with no `#1` that nothing realigns. Derived, the list
+ *      self-heals on the next render. The LABEL is the stored thing here;
+ *      the ordinal is only the fallback.
+ *   2. The grouping key is the OUTPUT of `parseUserAgent`, which exists
+ *      only in this codebase. Deriving server-side would mean a second UA
+ *      parser in Elixir whose classification could disagree with this one,
+ *      and then the ordinal would number a grouping the user cannot see.
+ */
+export function deviceRows(devices: PushDeviceSummary[]): DeviceRow[] {
+  const unlabelled = devices.filter((d) => (d.label ?? null) === null);
+
+  return devices.map((device) => {
+    const label = device.label ?? null;
+    if (label !== null) return { device, displayName: label, named: true };
+
+    const name = parsedDeviceName(device);
+    const twins = unlabelled.filter((d) => parsedDeviceName(d) === name).sort(byCreation);
+    const displayName =
+      twins.length < 2 ? name : `${name} #${twins.findIndex((d) => d.id === device.id) + 1}`;
+    return { device, displayName, named: false };
+  });
+}
+
+/**
+ * PATCH /push/subscriptions/:id — the #964 inline rename. An empty string
+ * clears the label server-side, so the row falls back to its derived name.
+ */
+export async function renamePushDevice(
+  token: string,
+  id: SubscriptionId,
+  label: string,
+): Promise<void> {
+  const res = await fetch(`/push/subscriptions/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({ label }),
+  });
+  if (!res.ok) throw await readError(res);
+}
 
 /**
  * #964 — the device row's activity line.

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -4572,6 +4572,28 @@ html.resize-dragging * {
   white-space: nowrap;
 }
 
+/* #964 — the row's edit mode. Takes the same flex slot the name occupied
+   so the save/cancel buttons land exactly where remove was, and the list
+   does not reflow when a row is opened for renaming. */
+.settings-drawer .device-rename-form {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.settings-drawer .device-rename-input {
+  width: 100%;
+  min-width: 0;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  padding: 0.15rem 0.3rem;
+}
+
 .settings-drawer .device-remove {
   background: transparent;
   border: 1px solid var(--border);

--- a/lib/grappa/push.ex
+++ b/lib/grappa/push.ex
@@ -39,6 +39,7 @@ defmodule Grappa.Push do
       subject (sorted by `inserted_at`, most-recent first).
     * `get_for_subject/2` — fetch one by ID, scoped to subject (404
       if cross-subject).
+    * `update_label/2` — rename a device (#964); `nil`/blank clears.
     * `delete/1` — by struct.
     * `delete_dead/1` — by endpoint URL. Used by B2's `Push.Sender`
       when a vendor returns 404/410 for a stale subscription.
@@ -236,6 +237,26 @@ defmodule Grappa.Push do
   """
   @spec delete(Subscription.t()) :: {:ok, Subscription.t()} | {:error, Ecto.Changeset.t()}
   def delete(%Subscription{} = sub), do: Repo.delete(sub)
+
+  @doc """
+  Renames a subscription (#964). `nil` or a blank string clears the
+  label, and the client falls back to its derived default name.
+
+  Struct-in, for the same reason as `delete/1`: the caller must already
+  have loaded + scoped the row through `get_for_subject/2`, so a path
+  parameter cannot reach an UPDATE without passing the subject check.
+
+  Every normalisation (trim, blank → NULL, length cap) lives in
+  `Subscription.label_changeset/2` — this is user input and it does not
+  reach `Repo` without a changeset.
+  """
+  @spec update_label(Subscription.t(), String.t() | nil) ::
+          {:ok, Subscription.t()} | {:error, Ecto.Changeset.t()}
+  def update_label(%Subscription{} = sub, label) when is_binary(label) or is_nil(label) do
+    sub
+    |> Subscription.label_changeset(%{label: label})
+    |> Repo.update()
+  end
 
   @doc """
   Deletes any subscription matching the given endpoint URL,

--- a/lib/grappa/push/subscription.ex
+++ b/lib/grappa/push/subscription.ex
@@ -5,9 +5,17 @@ defmodule Grappa.Push.Subscription do
 
   Push notifications cluster B1 (2026-05-14). Stores the three opaque
   fields the W3C Push API hands out (`endpoint`, `p256dh_key`,
-  `auth_key`) plus per-device metadata (`user_agent`, `last_used_at`)
-  that drives the "see + revoke my devices" UX in the cic settings
-  drawer (B3).
+  `auth_key`) plus per-device metadata (`user_agent`, `last_used_at`,
+  `label`) that drives the "see + revoke my devices" UX in the cic
+  settings drawer (B3).
+
+  ## `label` — the only user-writable field (#964)
+
+  Nullable, set through `label_changeset/2` alone. NULL means "no
+  label" and the client falls back to a derived name. The ordinal that
+  disambiguates two same-browser devices is deliberately NOT a column:
+  it is a function of how many rows currently share a parsed name, so a
+  stored copy strands a lone `#2` the moment `#1` is deleted.
 
   ## Subject XOR
 
@@ -57,6 +65,7 @@ defmodule Grappa.Push.Subscription do
           p256dh_key: String.t() | nil,
           auth_key: String.t() | nil,
           user_agent: String.t() | nil,
+          label: String.t() | nil,
           last_used_at: DateTime.t() | nil,
           inserted_at: DateTime.t() | nil,
           updated_at: DateTime.t() | nil
@@ -72,6 +81,7 @@ defmodule Grappa.Push.Subscription do
     field :p256dh_key, :string
     field :auth_key, :string
     field :user_agent, :string
+    field :label, :string
     field :last_used_at, :utc_datetime_usec
 
     timestamps(type: :utc_datetime_usec)
@@ -87,8 +97,18 @@ defmodule Grappa.Push.Subscription do
   # `Ecto.Changeset.change/2` path after a successful B2 Sender
   # delivery). A caller cannot supply an arbitrary timestamp on
   # create. `user_agent` IS optional; B1 review (B1.r1, 2026-05-14).
+  # `label` is likewise absent from the allowlist: it is the ONE
+  # user-writable field, it is never known at registration time (the
+  # browser has nothing to name itself with — see #964 on why the machine
+  # hostname is not reachable from a page), and it travels on its own
+  # `label_changeset/2` so a POST body cannot widen the create surface.
   @optional ~w(user_agent)a
   @subject ~w(user_id visitor_id)a
+
+  # Graphemes, not bytes — the cap bounds what the drawer renders, and the
+  # drawer renders characters. Roomy enough for "MacBook del lavoro",
+  # tight enough that the row keeps its ellipsis instead of wrapping.
+  @label_max 64
 
   @doc """
   Insert / update changeset.
@@ -148,6 +168,49 @@ defmodule Grappa.Push.Subscription do
       message: "user_id and visitor_id are mutually exclusive"
     )
   end
+
+  @doc """
+  Rename changeset — the ONE user-writable field on a subscription (#964).
+
+  Separate from `changeset/2` on purpose: `label` is not knowable at
+  registration, so keeping it off the create allowlist means the POST
+  surface cannot grow a field by accident, and this changeset cannot be
+  talked into touching an endpoint or a key.
+
+  The stored contract, and who enforces each half:
+
+    * **blank → NULL**, so "cleared" has exactly ONE representation and
+      the read side tests `is_nil/1` and never also `== ""`. This is what
+      makes clearing the label fall back to the derived
+      `Browser on OS [#n]` default instead of rendering an empty name.
+      Enforced by `cast/3` itself: its default `:empty_values` already
+      folds `""` AND a whitespace-only string to `nil`. Measured, not
+      assumed — a hand-written blank arm here was proven dead by removing
+      it and watching the blank/whitespace tests stay green. The tests
+      pin the CONTRACT, so it survives whoever implements it.
+    * **trim** of a non-blank value — a label is a display string, and
+      invisible padding would make two labels compare unequal. This half
+      Ecto does NOT do, so it lives here.
+    * **cap at #{@label_max} graphemes**, applied AFTER the trim, so a
+      value that only exceeds the cap by padding is accepted rather than
+      rejected on characters the user cannot see.
+
+  A non-string value fails `cast/3` with `"is invalid"`; the controller
+  rejects that shape earlier with a 400 so the 422 envelope stays about
+  values, not types.
+  """
+  @spec label_changeset(t(), map()) :: Ecto.Changeset.t()
+  def label_changeset(%__MODULE__{} = sub, attrs) do
+    sub
+    |> cast(attrs, [:label])
+    |> update_change(:label, &normalize_label/1)
+    |> validate_length(:label, max: @label_max)
+  end
+
+  @spec normalize_label(String.t() | nil) :: String.t() | nil
+  defp normalize_label(nil), do: nil
+
+  defp normalize_label(label) when is_binary(label), do: String.trim(label)
 
   # Mirror of `Grappa.ReadCursor.Cursor.validate_subject_xor/1`.
   @spec validate_subject_xor(Ecto.Changeset.t()) :: Ecto.Changeset.t()

--- a/lib/grappa_web/controllers/push_subscription_controller.ex
+++ b/lib/grappa_web/controllers/push_subscription_controller.ex
@@ -3,7 +3,7 @@ defmodule GrappaWeb.PushSubscriptionController do
   REST surface for `Grappa.Push` subscriptions — push notifications
   cluster B1 (2026-05-14) + visitor-parity V3 (2026-05-15).
 
-  Three endpoints, all behind `[:api, :authn]`:
+  Four endpoints, all behind `[:api, :authn]`:
 
     * `POST /push/subscriptions` — body
       `{"endpoint": <url>, "keys": {"p256dh": <b64>, "auth": <b64>}}`,
@@ -24,9 +24,15 @@ defmodule GrappaWeb.PushSubscriptionController do
       protection — one subject cannot enumerate another's
       subscription IDs).
 
+    * `PATCH /push/subscriptions/:id` — body `{"label": <string|null>}`,
+      the #964 inline rename. 200 with the updated device summary;
+      400 on a missing / non-string `label`; 404 (uniform body) for
+      cross-subject or missing IDs; 422 past the length cap.
+
     * `GET /push/subscriptions` — 200 with
-      `%{subscriptions: [%{id, user_agent, created_at, last_used_at},
-      ...]}`. Powers the cic settings drawer's per-device list (B3).
+      `%{subscriptions: [%{id, user_agent, label, created_at,
+      last_used_at}, ...]}`. Powers the cic settings drawer's per-device
+      list (B3).
 
   ## Subject-scoped — V3 (2026-05-15)
 
@@ -116,6 +122,28 @@ defmodule GrappaWeb.PushSubscriptionController do
       send_resp(conn, :no_content, "")
     end
   end
+
+  @doc """
+  `PATCH /push/subscriptions/:id` — rename a device (#964). Body
+  `{"label": <string|null>}`; `null` or a blank string clears the label
+  and the row falls back to its derived name.
+
+  400 when `label` is absent or not a string/null — a type error is the
+  client's bug, not a value the 422 envelope should have to describe.
+  404 (uniform body) for cross-subject OR missing IDs, same probing
+  protection as `delete/2`. 422 when the value exceeds the length cap.
+  """
+  @spec update(Plug.Conn.t(), map()) ::
+          Plug.Conn.t() | {:error, :bad_request | :not_found | Ecto.Changeset.t()}
+  def update(conn, %{"id" => id, "label" => label})
+      when is_binary(id) and (is_binary(label) or is_nil(label)) do
+    with {:ok, sub} <- Push.get_for_subject(Subject.from_assigns(conn.assigns), id),
+         {:ok, renamed} <- Push.update_label(sub, label) do
+      render(conn, :device, subscription: renamed)
+    end
+  end
+
+  def update(_, _), do: {:error, :bad_request}
 
   @doc """
   `GET /push/subscriptions` — list the authenticated subject's

--- a/lib/grappa_web/controllers/push_subscription_json.ex
+++ b/lib/grappa_web/controllers/push_subscription_json.ex
@@ -15,10 +15,18 @@ defmodule GrappaWeb.PushSubscriptionJSON do
     * `:show` (POST 201 response) — `%{id, created_at}`. Endpoint and
       keys are NOT echoed back; cic already has them locally (it just
       sent them).
-    * `:index` (GET 200) — `%{subscriptions: [%{id, user_agent,
+    * `:index` (GET 200) — `%{subscriptions: [%{id, user_agent, label,
       created_at, last_used_at}, ...]}`. Powers cic settings drawer
       device list (B3). `last_used_at` is `nil` until B2's
-      `Push.Sender` writes the first delivery.
+      `Push.Sender` writes the first delivery; `label` is `nil` until
+      the user renames the device (#964), and cic derives a name from
+      `user_agent` while it is.
+    * `:device` (PATCH 200) — one `subscription_summary()`, the same
+      shape an `:index` row carries.
+
+  `label` is a NEW additive field on an existing shape, so per the
+  additive-only wire contract (#447) it costs no `protocol_version`
+  bump: a client that does not know it simply ignores it.
 
   ## Why no endpoint/keys in any list shape
 
@@ -35,6 +43,7 @@ defmodule GrappaWeb.PushSubscriptionJSON do
   @type subscription_summary :: %{
           id: Ecto.UUID.t(),
           user_agent: String.t() | nil,
+          label: String.t() | nil,
           created_at: DateTime.t(),
           last_used_at: DateTime.t() | nil
         }
@@ -54,11 +63,23 @@ defmodule GrappaWeb.PushSubscriptionJSON do
     %{subscriptions: Enum.map(subs, &summary/1)}
   end
 
+  @doc """
+  Renders the `:device` action — the PATCH 200 response shape (#964).
+
+  Deliberately the SAME summary the `:index` rows carry rather than a
+  bespoke `{id, label}` echo: the rename response is a row, so cic can
+  splice it back into the list without a refetch, and there is one place
+  to change when a device grows another field.
+  """
+  @spec device(%{subscription: Subscription.t()}) :: subscription_summary()
+  def device(%{subscription: %Subscription{} = sub}), do: summary(sub)
+
   @spec summary(Subscription.t()) :: subscription_summary()
   defp summary(%Subscription{} = sub) do
     %{
       id: sub.id,
       user_agent: sub.user_agent,
+      label: sub.label,
       created_at: sub.inserted_at,
       last_used_at: sub.last_used_at
     }

--- a/lib/grappa_web/router.ex
+++ b/lib/grappa_web/router.ex
@@ -377,6 +377,9 @@ defmodule GrappaWeb.Router do
     # POST here → server stores endpoint+keys for B2's Push.Sender.
     get "/push/subscriptions", PushSubscriptionController, :index
     post "/push/subscriptions", PushSubscriptionController, :create
+    # #964 — inline rename from the device row. The label is the only
+    # user-writable field on a subscription.
+    patch "/push/subscriptions/:id", PushSubscriptionController, :update
     delete "/push/subscriptions/:id", PushSubscriptionController, :delete
 
     # UX-6-B1 (2026-05-20): embedded image uploader — authenticated

--- a/priv/repo/migrations/20260807120000_add_label_to_push_subscriptions.exs
+++ b/priv/repo/migrations/20260807120000_add_label_to_push_subscriptions.exs
@@ -1,0 +1,34 @@
+defmodule Grappa.Repo.Migrations.AddLabelToPushSubscriptions do
+  @moduledoc """
+  #964 — the one thing about a device only its owner knows: what to call it.
+
+  `user_agent` collapses to `Browser on OS` in the settings drawer, so two
+  instances of the same browser on the same OS render byte-identical rows.
+  Every other disambiguator we can synthesise (the activity instant, an
+  ordinal suffix, the PTR of the peer address) is derived from data the
+  server already holds; the label is the only one that is genuinely NEW
+  information, so it is the only one that earns a column.
+
+  Nullable with no default: NULL means "no label", and the row falls back
+  to the derived `Browser on OS [#n]` default. A `""` never reaches storage
+  — `Subscription.label_changeset/2` folds blank to NULL so "cleared" has
+  exactly one representation.
+
+  Deliberately NOT stored: the ordinal. It is a function of how many
+  subscriptions currently share a parsed name, so a stored copy goes stale
+  the moment one of them is deleted — a lone `#2` with no `#1`.
+
+  ## Hot deploy
+
+  COLD. `Grappa.Deploy.Preflight` classifies every `priv/repo/migrations/*`
+  path as `:migration`, substrate-independent, no exceptions for additive
+  nullable columns.
+  """
+  use Ecto.Migration
+
+  def change do
+    alter table(:push_subscriptions) do
+      add :label, :string
+    end
+  end
+end

--- a/test/grappa/push_test.exs
+++ b/test/grappa/push_test.exs
@@ -268,6 +268,94 @@ defmodule Grappa.PushTest do
     end
   end
 
+  describe "update_label/2 (#964)" do
+    test "a fresh subscription carries no label" do
+      user = user_fixture()
+      assert {:ok, %Subscription{label: nil}} = Push.create({:user, user.id}, valid_attrs())
+    end
+
+    test "create cannot set the label — it is not on the create allowlist" do
+      user = user_fixture()
+      attrs = Map.put(valid_attrs(), :label, "smuggled in at registration")
+      assert {:ok, %Subscription{label: nil}} = Push.create({:user, user.id}, attrs)
+    end
+
+    test "stores the label and the list reads it back" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+
+      assert {:ok, %Subscription{label: "MacBook del lavoro"}} =
+               Push.update_label(sub, "MacBook del lavoro")
+
+      assert [%Subscription{label: "MacBook del lavoro"}] =
+               Push.list_for_subject({:user, user.id})
+    end
+
+    test "trims surrounding whitespace" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+      assert {:ok, %Subscription{label: "telefono"}} = Push.update_label(sub, "  telefono \t ")
+    end
+
+    test "a blank string clears the label to NULL, not to an empty string" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+      {:ok, named} = Push.update_label(sub, "telefono")
+      assert {:ok, %Subscription{label: nil}} = Push.update_label(named, "")
+    end
+
+    test "a whitespace-only string clears the label too" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+      {:ok, named} = Push.update_label(sub, "telefono")
+      assert {:ok, %Subscription{label: nil}} = Push.update_label(named, "   ")
+    end
+
+    test "nil clears the label" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+      {:ok, named} = Push.update_label(sub, "telefono")
+      assert {:ok, %Subscription{label: nil}} = Push.update_label(named, nil)
+    end
+
+    test "rejects a label past the 64-grapheme cap" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+
+      assert {:error, %Ecto.Changeset{errors: errors}} =
+               Push.update_label(sub, String.duplicate("a", 65))
+
+      assert {_, opts} = errors[:label]
+      assert opts[:count] == 64
+    end
+
+    test "counts graphemes, not bytes — 64 multi-byte characters fit" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+      label = String.duplicate("è", 64)
+      assert {:ok, %Subscription{label: ^label}} = Push.update_label(sub, label)
+    end
+
+    test "the cap applies to the trimmed value, not the padded one" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+      padded = "   " <> String.duplicate("a", 64) <> "   "
+      expected = String.duplicate("a", 64)
+      assert {:ok, %Subscription{label: ^expected}} = Push.update_label(sub, padded)
+    end
+
+    test "renaming touches nothing but the label" do
+      user = user_fixture()
+      {:ok, sub} = Push.create({:user, user.id}, valid_attrs())
+      {:ok, renamed} = Push.update_label(sub, "telefono")
+      assert renamed.endpoint == sub.endpoint
+      assert renamed.p256dh_key == sub.p256dh_key
+      assert renamed.auth_key == sub.auth_key
+      assert renamed.user_agent == sub.user_agent
+      assert renamed.user_id == sub.user_id
+    end
+  end
+
   describe "touch_last_used/1" do
     test "sets last_used_at to a fresh timestamp" do
       user = user_fixture()

--- a/test/grappa_web/controllers/push_subscription_controller_test.exs
+++ b/test/grappa_web/controllers/push_subscription_controller_test.exs
@@ -16,6 +16,10 @@ defmodule GrappaWeb.PushSubscriptionControllerTest do
     * DELETE cross-subject → 404 (probing protection).
     * DELETE unknown ID → 404.
     * user_agent header is captured + persisted on POST.
+    * PATCH (#964 rename): 200 + row summary, visitor parity, label
+      visible on the following GET, blank / null clears to NULL, 422
+      past the cap, 400 on a missing or non-string label, 404
+      cross-subject + unknown ID.
   """
   use GrappaWeb.ConnCase, async: true
 
@@ -49,6 +53,20 @@ defmodule GrappaWeb.PushSubscriptionControllerTest do
       nil -> base
       supersedes -> Map.put(base, "supersedes", supersedes)
     end
+  end
+
+  # #964 — a persisted subscription to rename. Carries a real UA so the
+  # renamed row can be checked to keep every field the PATCH must not touch.
+  defp subscription_for(subject, endpoint) do
+    {:ok, sub} =
+      Push.create(subject, %{
+        endpoint: endpoint,
+        p256dh_key: "k",
+        auth_key: "a",
+        user_agent: "Mozilla/5.0 (X11; Linux x86_64) Firefox/124.0"
+      })
+
+    sub
   end
 
   describe "POST /push/subscriptions — auth gating" do
@@ -357,6 +375,165 @@ defmodule GrappaWeb.PushSubscriptionControllerTest do
     test "404 on unknown UUID", %{conn: conn} do
       {_, session} = user_and_session()
       conn = conn |> put_bearer(session.id) |> delete("/push/subscriptions/#{Ecto.UUID.generate()}")
+      assert json_response(conn, 404) == %{"error" => "not_found"}
+    end
+  end
+
+  describe "PATCH /push/subscriptions/:id (#964 rename)" do
+    test "401 without bearer", %{conn: conn} do
+      conn = patch(conn, "/push/subscriptions/#{Ecto.UUID.generate()}", %{"label" => "x"})
+      assert json_response(conn, 401)
+    end
+
+    test "200 with the renamed row, and the list reads it back", %{conn: conn} do
+      {user, session} = user_and_session()
+      sub = subscription_for({:user, user.id}, "https://example.com/push/rename-#{uniq()}")
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> patch("/push/subscriptions/#{sub.id}", %{"label" => "MacBook del lavoro"})
+
+      body = json_response(conn, 200)
+      assert body["id"] == sub.id
+      assert body["label"] == "MacBook del lavoro"
+      # Same summary shape the list rows carry, so cic can splice it back in.
+      assert body["user_agent"] == sub.user_agent
+      assert Map.has_key?(body, "created_at")
+      assert Map.has_key?(body, "last_used_at")
+      # Credential-grade material stays out of every response shape.
+      refute Map.has_key?(body, "endpoint")
+      refute Map.has_key?(body, "p256dh_key")
+
+      assert [%{label: "MacBook del lavoro"}] = Push.list_for_subject({:user, user.id})
+    end
+
+    test "200 for a visitor subject — V3 parity", %{conn: conn} do
+      {visitor, session} = visitor_and_session()
+      sub = subscription_for({:visitor, visitor.id}, "https://example.com/push/v-rename-#{uniq()}")
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> patch("/push/subscriptions/#{sub.id}", %{"label" => "telefono"})
+
+      assert json_response(conn, 200)["label"] == "telefono"
+      assert [%{label: "telefono"}] = Push.list_for_subject({:visitor, visitor.id})
+    end
+
+    test "GET exposes the label after a rename", %{conn: conn} do
+      {user, session} = user_and_session()
+      sub = subscription_for({:user, user.id}, "https://example.com/push/label-index-#{uniq()}")
+
+      conn
+      |> put_bearer(session.id)
+      |> patch("/push/subscriptions/#{sub.id}", %{"label" => "fisso"})
+      |> json_response(200)
+
+      listed =
+        build_conn()
+        |> put_bearer(session.id)
+        |> get("/push/subscriptions")
+        |> json_response(200)
+
+      assert %{"subscriptions" => [only]} = listed
+      assert only["label"] == "fisso"
+    end
+
+    test "a blank label clears the row back to null", %{conn: conn} do
+      {user, session} = user_and_session()
+      sub = subscription_for({:user, user.id}, "https://example.com/push/clear-#{uniq()}")
+
+      conn
+      |> put_bearer(session.id)
+      |> patch("/push/subscriptions/#{sub.id}", %{"label" => "da cancellare"})
+      |> json_response(200)
+
+      cleared =
+        build_conn()
+        |> put_bearer(session.id)
+        |> patch("/push/subscriptions/#{sub.id}", %{"label" => "   "})
+        |> json_response(200)
+
+      assert cleared["label"] == nil
+    end
+
+    test "an explicit null clears the row too", %{conn: conn} do
+      {user, session} = user_and_session()
+      sub = subscription_for({:user, user.id}, "https://example.com/push/null-#{uniq()}")
+
+      conn
+      |> put_bearer(session.id)
+      |> patch("/push/subscriptions/#{sub.id}", %{"label" => "da cancellare"})
+      |> json_response(200)
+
+      cleared =
+        build_conn()
+        |> put_bearer(session.id)
+        |> patch("/push/subscriptions/#{sub.id}", %{"label" => nil})
+        |> json_response(200)
+
+      assert cleared["label"] == nil
+    end
+
+    test "422 past the length cap, and the stored label is untouched", %{conn: conn} do
+      {user, session} = user_and_session()
+      sub = subscription_for({:user, user.id}, "https://example.com/push/toolong-#{uniq()}")
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> patch("/push/subscriptions/#{sub.id}", %{"label" => String.duplicate("a", 65)})
+
+      assert %{"error" => "validation_failed", "field_errors" => errors} =
+               json_response(conn, 422)
+
+      assert Map.has_key?(errors, "label")
+      assert [%{label: nil}] = Push.list_for_subject({:user, user.id})
+    end
+
+    test "400 when label is absent from the body", %{conn: conn} do
+      {user, session} = user_and_session()
+      sub = subscription_for({:user, user.id}, "https://example.com/push/nolabel-#{uniq()}")
+
+      conn = conn |> put_bearer(session.id) |> patch("/push/subscriptions/#{sub.id}", %{})
+      assert json_response(conn, 400)
+    end
+
+    test "400 when label is not a string", %{conn: conn} do
+      {user, session} = user_and_session()
+      sub = subscription_for({:user, user.id}, "https://example.com/push/badtype-#{uniq()}")
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> patch("/push/subscriptions/#{sub.id}", %{"label" => %{"nested" => true}})
+
+      assert json_response(conn, 400)
+    end
+
+    test "404 on cross-user rename (probing protection)", %{conn: conn} do
+      {alice, _} = user_and_session()
+      {_, bob_session} = user_and_session()
+      alice_sub = subscription_for({:user, alice.id}, "https://example.com/push/xrename-#{uniq()}")
+
+      conn =
+        conn
+        |> put_bearer(bob_session.id)
+        |> patch("/push/subscriptions/#{alice_sub.id}", %{"label" => "mio adesso"})
+
+      assert json_response(conn, 404) == %{"error" => "not_found"}
+      assert [%{label: nil}] = Push.list_for_subject({:user, alice.id})
+    end
+
+    test "404 on unknown UUID", %{conn: conn} do
+      {_, session} = user_and_session()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> patch("/push/subscriptions/#{Ecto.UUID.generate()}", %{"label" => "x"})
+
       assert json_response(conn, 404) == %{"error" => "not_found"}
     end
   end


### PR DESCRIPTION
Closes the two points of #964 that slice A (`3aefadab`) deliberately left
open: the renameable label and the ordinal-suffixed default. The
stored-vs-derived question is settled — **the label is stored, the ordinal
is derived.**

## Deploy classification: COLD

Verified, not assumed: `Grappa.Deploy.Preflight` classifies every
`priv/repo/migrations/*` path as `:migration`, substrate-independent, with
no exemption for an additive nullable column.

## The three commits

| SHA | What |
|---|---|
| `f43421f0` | server — migration, `label` column, `label_changeset/2`, `Push.update_label/2`, `PATCH /push/subscriptions/:id`, `label` on the JSON summary |
| `b03cd413` | cic — `deviceRows` (label → parsed → parsed + ordinal), inline rename from the row, CSS |
| `a9280925` | e2e — the rename and the ordinal driven through the real drawer |

## Why the ordinal is derived, and derived in cic

Two independent reasons, either sufficient on its own:

1. An ordinal is a function of *how many rows currently share a parsed
   name*. Stored, it goes stale the instant one of them is deleted — a
   `#2` with no `#1`, which nothing realigns. Derived, the list self-heals
   on the next read. The stored thing here is the LABEL.
2. The grouping key is the OUTPUT of `parseUserAgent`, which exists only
   in cic — `grep -rn user_agent lib/ --include='*.ex'` shows no
   server-side UA parser. Deriving it server-side would mean a SECOND
   parser in Elixir, free to classify differently, numbering a grouping
   the user cannot see.

Consequences, each with a test: a device alone in its group takes no
suffix; labelled rows leave the GROUPING (not just the suffix), so naming
one twin drops the other's number; ordering is `created_at` ascending with
the id as tiebreak, so a new twin appends `#3` instead of renumbering the
two already on screen.

## Corrections to the brief this was written from

1. **Point 4 (the "this device" marker) was already shipped.** `3aefadab`
   is on `origin/main` (`git branch -r --contains`) and carries
   `subscriptionIdForEndpoint`, the badge and its e2e. Nothing rebuilt.
2. **The ordinal is derived in cic, not on the server** — the second-parser
   argument above.
3. **No `Grappa.Push.Wire`, and no wire-type regeneration.** The push REST
   shapes come from `GrappaWeb.PushSubscriptionJSON`; CLAUDE.md's `*.Wire`
   rule governs PubSub/Channel payloads. `wireTypes.ts` carries no push
   shapes, and `mix grappa.gen_wire_types --check` passes untouched.
4. **COLD confirmed from `Preflight`**, rather than from the rule of thumb.

`label` is additive on an existing shape, so per the #447 additive-only
contract it costs no `protocol_version` bump.

## What I measured, and what I am NOT claiming

**Measured.** `scripts/check.sh` exit 0 end-to-end: 5377 tests / 0
failures, Dialyzer `Total errors: 0`, credo --strict, sobelow, doctor,
`gen_wire_types --check`, bats. The 13 new vitest cases are
mutation-measured — four mutations (number lonely groups, let labelled rows
re-enter the grouping, drop the `created_at` ordering, ignore the label)
each killed 1–4 of them, green on restore. The server side likewise: four
mutations (drop the normalisation, widen the cap, add `label` to the create
allowlist, widen the controller guard) each killed 1–3 of the 69.

A hand-written blank→NULL arm in `normalize_label/1` was **proven dead** —
Ecto's `cast/3` already folds `""` and whitespace-only to nil via its
default `:empty_values` — so it was deleted and the blank/whitespace tests
stayed green. The tests pin the contract; the implementation is minimal.

**NOT claiming.** The new e2e spec `push-964-device-label.spec.ts` has
**never been executed**. The STACK lane was held by other work, so it was
written from the sibling spec's shape and reasoned through, not run. The CI
`integration` job is its first execution — treat a red there as expected
cost, not as a surprise.

Also unverified by measurement: that the two rename buttons fit the row on
a narrow mobile viewport. The CSS puts the editor in the flex slot the name
occupied so the list should not reflow, but I read that off the stylesheet
rather than off a screenshot.