### PR TITLE
session(#977): capture the SECOND token of SET PASSWD, not the whole line

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -7249,7 +7249,10 @@ point) gains a third verb class `:set_passwd` matching
   untouched (unit-pinned).
 - The new password is **rest-of-line**, not a token — Azzurra parses
   `strtok(NULL,"")`, so it may contain spaces; never split on the first
-  space.
+  space. **FALSE — superseded 2026-08-07 (#977).** That `strtok` yields the
+  OLD password AND the new one; `do_set_password` splits it at the first
+  space, and Azzurra passwords cannot contain spaces at all. Reading this
+  bullet as gospel is what stored the two concatenated.
 
 cic needs zero changes: `/ns set passwd …` already emits a `PRIVMSG NickServ`
 body the server captures (one-parser invariant). A pre-validating cic
@@ -32059,3 +32062,65 @@ takes down the whole suite, not one spec), and it is curl-fetched at boot by
 `infra/cloud/first-boot.sh:195` behind the `check-drift.sh` CI gate. Three
 live readers, one of them the CI. The rule "if only a dead substrate reads
 it, delete it" is right; its antecedent was simply false here.
+
+## 2026-08-07 — SET PASSWD hands over the OLD password first (#977)
+
+Every in-session NickServ password rotation stored the old and the new
+password **concatenated**. Reported in the wild: a visitor rotated, ended up
+with "a password that was too long", went through `RECOVER` + `RESETPASS`,
+and grappa still auto-identified with the dead secret. The "too long"
+password was the concatenation. This is the #124 split-brain, manufactured by
+grappa itself rather than by an out-of-band change.
+
+**The false premise, and where it came from.** The #131 note above records
+that Azzurra parses the new password with `strtok(NULL, "")` and that it may
+therefore contain spaces. The `strtok` is real; the reading was wrong. In
+`azzurra/services@23473ed`, `do_set` (`src/nickserv.c:2090`) hands
+`do_set_password` everything after the verb, and `do_set_password` (`:2182`)
+then splits THAT at the first space: `newpass = strchr(param, ' ');
+*newpass++ = '\0';`. The head is the OLD password — the comment at `:2204`
+says it outright — checked with `str_equals(param, ni->pass)`. The form is
+`SET PASSWD <old> <new>` and the rotation is AUTHENTICATED. Azzurra passwords
+cannot contain spaces at all: the line right after the split earns
+`CSNS_ERROR_PASSWORD_WITH_SPACES`. So the capture is the SECOND token, and a
+one-token `SET PASSWD <new>` (the Atheme spelling) is not a capture at all —
+services answer a syntax error and change nothing, so neither may we.
+
+**Vetting belongs at the door that speaks Azzurra.** The commit is
+OPTIMISTIC on-send (#131, unchanged: no `+r` fires for a rotation, and
+NOTICE-scraping stays banned), and an optimistic write has no take-backs — so
+a value services would refuse must be refused BEFORE it is written, not
+regretted after. `NSInterceptor` therefore carries `do_set_password`'s own
+guard chain in its order (spaces → nick-or-under-5 → over-`PASSMAX` →
+control codes) and answers a new `{:reject, :set_passwd, reason}`, the reason
+being the services error constant. The line still goes out: services deliver
+their own error notice to the user, grappa's DB is untouched, and the two
+stay in sync — which is the whole point. `Session.Server` logs the refusal at
+debug (never the password) rather than dropping it silently.
+
+Two guards are deliberately NOT mirrored, both because mirroring them buys
+nothing: `str_equals` against the current password (a no-op rotation would
+store the value already stored) and the old-password check itself — grappa
+cannot vet a mistyped OLD password from the line alone, so that one case
+still commits optimistically and still falls to #124's re-auth backstop.
+That is now the ONLY residual divergence on this path, down from "every
+rotation".
+
+**`PASSMAX` = 32 is a constant here on purpose.** It is a compile-time
+`#define` (`azzurra/services inc/config.h:96`), not a services.conf
+directive: there is nothing to learn at runtime from the wire and nothing for
+an operator to tune. It lives in `NSInterceptor` next to its source
+reference. The under-5 floor and `string_has_ccodes` (`src/misc.c:1321` — any
+BYTE below 32, or the byte 160) are the same kind of fact; the ccodes check
+is byte-level on purpose, which is also why an accented password is refused
+(`à` is `C3 A0`, and `A0` is 160).
+
+**Where it does NOT go.** `Credential.password_changeset/2` keeps only the
+CR/LF/NUL wire-hygiene guard. Azzurra's rules are one network's services
+talking, and that changeset is network-agnostic — encoding a 32-byte ceiling
+there would reject passwords other networks accept, for a path they do not
+even reach. One authority per fact: the Azzurra-shaped parser owns the
+Azzurra-shaped rules.
+
+The #131 entry above stands as the record of that day's reasoning; its
+"rest-of-line, may contain spaces" bullet is superseded here.

--- a/lib/grappa/networks/credential.ex
+++ b/lib/grappa/networks/credential.ex
@@ -491,9 +491,12 @@ defmodule Grappa.Networks.Credential do
     # Same wire-hygiene guard the wide `changeset/2` applies to `:password`
     # (line ~220): the stored value is re-interpolated into PASS /
     # `PRIVMSG NickServ :IDENTIFY` on the next auto-identify, so a CR/LF/NUL
-    # byte would split or truncate the outbound frame. A SET PASSWD password
-    # is rest-of-line (spaces are legal — `safe_line_token?` only rejects
-    # CR/LF/NUL), so this rejects only genuinely wire-unsafe values.
+    # byte would split or truncate the outbound frame. Deliberately NOT the
+    # place for Azzurra's SET PASSWD rules (≤ 32 bytes, ≥ 5, no spaces, ≠ nick,
+    # no control codes): those are one network's services talking, and this
+    # changeset is network-agnostic. They live at the door that speaks Azzurra
+    # — `Grappa.Session.NSInterceptor`, which refuses the line before any
+    # commit (#977). Here, only the wire-hygiene floor every network shares.
     |> validate_change(:password, &Identity.safe_line_token/2)
     |> put_encrypted_password()
   end

--- a/lib/grappa/networks/credentials.ex
+++ b/lib/grappa/networks/credentials.ex
@@ -632,13 +632,18 @@ defmodule Grappa.Networks.Credentials do
   leaving the wire (optimistic commit-on-send — the change emits no `+r`
   rendezvous, and NOTICE-scraping is banned, so there is no positive
   confirmation signal; the user is already identified and it is their own
-  deliberate change). A rejected change (Azzurra `do_set_password` refuses
-  insecure / over-`PASSMAX` / same-as-current) stores a password that
-  didn't take — recovered by #124's re-auth-on-identify-failure prompt.
+  deliberate change). #977 moved Azzurra's own guard chain (spaces, under 5 /
+  over `PASSMAX` bytes, equal to the nick, control codes) INTO `NSInterceptor`,
+  so a value services would refuse never reaches this function. The one
+  rejection grappa still cannot foresee is a mistyped OLD password — that one
+  stores a password that didn't take, recovered by #124's
+  re-auth-on-identify-failure prompt.
 
   User-bound mirror of the visitor-side `Grappa.Visitors.commit_password/2`.
-  The `password` is the rest-of-line the interceptor lifted, so it may
-  contain spaces; it is stored verbatim. Goes through the narrow
+  The `password` is the SECOND token of `SET PASSWD <old> <new>` (#977 — the
+  first is the old password services authenticate the rotation against), and
+  `NSInterceptor` has already refused anything services would (spaces, under
+  5 / over 32 bytes, equal to the nick, control codes). Goes through the narrow
   `Credential.password_changeset/2` so only `password_encrypted` is
   touched — the operator binding is left intact.
   """

--- a/lib/grappa/session/ns_interceptor.ex
+++ b/lib/grappa/session/ns_interceptor.ex
@@ -21,8 +21,8 @@ defmodule Grappa.Session.NSInterceptor do
     * `NS|NICKSERV IDENTIFY|ID|SIDENTIFY|GHOST|REGISTER <args>`   (services command alias)
     * `IDENTIFY|ID|SIDENTIFY <args>`                    (ircd `m_identify`)
     * `PASS <args>`                                     (ircd `m_pass` -> `m_identify`, post-connect)
-    * `PRIVMSG NickServ[@host] :SET PASSWD <new>` / `NS|NICKSERV SET PASSWD <new>` /
-      bare `SET PASSWD <new>`                           (#131 — in-session password change)
+    * `PRIVMSG NickServ[@host] :SET PASSWD <old> <new>` / `NS|NICKSERV SET PASSWD <old> <new>` /
+      bare `SET PASSWD <old> <new>`                      (#131 — in-session password change)
 
   Every pattern is ANCHORED at line start (`^`) so a channel PRIVMSG body that
   merely CONTAINS "identify"/"pass"/"set passwd" is never captured — raw IRC
@@ -30,15 +30,50 @@ defmodule Grappa.Session.NSInterceptor do
 
   Password extraction: last whitespace token for IDENTIFY/ID/SIDENTIFY/GHOST/
   PASS (`IDENTIFY [account] <pass>`, `GHOST <nick> <pass>`, `PASS [nick] <pass>`);
-  FIRST token for REGISTER (`REGISTER <pass> <email>`); REST-OF-LINE for
-  SET PASSWD (Azzurra parses the new password with `strtok(NULL,"")`, so it
-  may contain spaces — never split on the first space). The Azzurra verb is
-  `SET PASSWD`, NOT `SET PASSWORD` (`do_set` only routes `PASSWD`; `PASSWORD`
-  errors), so the regex matches `PASSWD` exactly and lets `SET PASSWORD …`
-  fall through untouched.
+  FIRST token for REGISTER (`REGISTER <pass> <email>`); the SECOND token for
+  SET PASSWD (#977). The Azzurra verb is `SET PASSWD`, NOT `SET PASSWORD`
+  (`do_set` only routes `PASSWD`; `PASSWORD` errors), so the regex matches
+  `PASSWD` exactly and lets `SET PASSWORD …` fall through untouched.
+
+  ## SET PASSWD takes the OLD password first, and its new one has no spaces
+
+  Read off `azzurra/services@23473ed`, not inferred. `do_set`
+  (`src/nickserv.c:2090`) hands the handler `param = strtok(NULL, "")` —
+  everything after the verb — and `do_set_password` (`:2182`) then splits
+  THAT at the first space: `newpass = strchr(param, ' '); *newpass++ = 0;`.
+  The head is the OLD password (`:2204`: *"param holds the old password"*,
+  checked against the stored one), the tail is the new. The form is
+  `SET PASSWD <old> <new>` and the rotation is AUTHENTICATED.
+
+  Before #977 this module read that `strtok(NULL, "")` as "the new password,
+  which may therefore contain spaces" and captured rest-of-line — so every
+  in-session rotation stored `"<old> <new>"` concatenated and corrupted the
+  credential. Azzurra passwords cannot contain spaces AT ALL: right after the
+  split, `strchr(newpass, ' ')` earns `CSNS_ERROR_PASSWORD_WITH_SPACES`.
+
+  Since the capture is written to the credential OPTIMISTICALLY on-send, a
+  value services would refuse must never be captured — it would store a
+  secret that never took. So this module also carries `do_set_password`'s own
+  guard chain, in its order (spaces / nick-or-under-5 / over-`PASSMAX` /
+  control codes), and answers `{:reject, :set_passwd, reason}` with the
+  services error constant as the reason. The line still goes out: services
+  send the user their own error notice, and grappa's DB stays untouched.
+  `PASSMAX` = 32 is a compile-time `#define` (`inc/config.h:96`), NOT a
+  services.conf directive — there is nothing to learn at runtime and nothing
+  for an operator to tune, so it lives here as a constant with its source
+  reference.
+
+  Two `do_set_password` guards are deliberately NOT mirrored: `str_equals`
+  against the CURRENT password (rejecting a no-op rotation, which would store
+  the value already stored — no divergence either way) and the old-password
+  check itself (`str_equals(param, ni->pass)`; grappa cannot vet a wrong OLD
+  password from the line alone, so a mistyped one still commits optimistically
+  — the #124 re-auth backstop, unchanged by #977).
 
   Boundary: inherits the parent `Grappa.Session` boundary (no `use Boundary`).
   """
+
+  alias Grappa.IRC.Identifier
 
   @typedoc """
   The captured verb's class. `:identify` covers IDENTIFY/ID/SIDENTIFY/
@@ -55,7 +90,28 @@ defmodule Grappa.Session.NSInterceptor do
   """
   @type kind :: :identify | :register | :set_passwd
 
-  @type result :: :passthrough | {:capture, kind(), String.t()}
+  @typedoc """
+  Why a syntactically-matched SET PASSWD was NOT captured: the name of the
+  services error the line will earn (`do_set_password`, `src/nickserv.c`).
+  `:syntax_error` is the one-token `SET PASSWD <new>` form, which Azzurra
+  rejects outright — services change nothing, so neither may we.
+  """
+  @type reject_reason ::
+          :syntax_error
+          | :password_with_spaces
+          | :insecure_password
+          | :password_max_length
+          | :password_with_ccodes
+
+  @type result ::
+          :passthrough
+          | {:capture, kind(), String.t()}
+          | {:reject, :set_passwd, reject_reason()}
+
+  # `azzurra/services@23473ed inc/config.h:96` — `#define PASSMAX 32`, and
+  # `do_set_password` rejects under 5. Compile-time defines, not conf knobs.
+  @passmax 32
+  @passmin 5
 
   # PRIVMSG-to-NickServ / NS-NICKSERV command form. `(?:...)` groups are
   # non-capturing; capture groups are (verb, rest).
@@ -67,44 +123,101 @@ defmodule Grappa.Session.NSInterceptor do
   # PASS post-connect identify (m_pass -> m_identify).
   @pass_re ~r/^PASS\s+(\S.*?)\s*$/i
 
-  # #131 — in-session SET PASSWD. Same anchored PRIVMSG-NickServ / NS-NICKSERV
-  # prefix family as `@verb_re`, plus the bare form (raw `/quote SET PASSWD`),
-  # via an optional prefix group. The verb is the literal two-token `SET
-  # PASSWD` (Azzurra `do_set` only routes `PASSWD`; `PASSWORD` errors — the
-  # literal `PASSWD\s+` naturally rejects `PASSWORD …`). The single capture
-  # group is the new password: REST-OF-LINE, leading/trailing whitespace
-  # trimmed, internal spaces preserved (Azzurra parses it with
-  # `strtok(NULL,"")`).
-  @set_passwd_re ~r/^(?:PRIVMSG\s+NickServ(?:@\S+)?\s+:|(?:NS|NICKSERV)\s+)?SET\s+PASSWD\s+(\S.*?)\s*$/i
+  # #131 / #977 — in-session SET PASSWD. Same anchored PRIVMSG-NickServ /
+  # NS-NICKSERV prefix family as `@verb_re`, plus the bare form (raw `/quote
+  # SET PASSWD`), via an optional prefix group. The verb is the literal
+  # two-token `SET PASSWD` (Azzurra `do_set` only routes `PASSWD`; `PASSWORD`
+  # errors — the literal `PASSWD` followed by a space or EOL rejects
+  # `PASSWORD …`).
+  #
+  # The capture group is services' `param` — old AND new, VERBATIM, split
+  # here rather than by the regex. No trimming: services trim nothing, and a
+  # trailing space is precisely what makes them refuse the line. Separators
+  # from `SET` onward are LITERAL spaces, not `\s`, because services tokenise
+  # with `strtok(…, " ")` / `strchr(…, ' ')` — a TAB is not a delimiter there
+  # and must not be treated as one. The PRIVMSG prefix keeps `\s+`: that part
+  # is parsed by the ircd, not by services. The group is optional so a bare
+  # `SET PASSWD` reaches the same `:syntax_error` verdict as `SET PASSWD x`.
+  @set_passwd_re ~r/^(?:PRIVMSG\s+NickServ(?:@\S+)?\s+:|(?:NS|NICKSERV)\s+)?SET +PASSWD(?: (.*))?$/i
 
   @doc """
-  Inspects one outbound IRC wire line and returns either `:passthrough`
-  (no NickServ secret-bearing verb detected) or `{:capture, kind, password}`
-  with the cleartext password lifted out and the verb class (`:identify` /
-  `:register` / `:set_passwd`) for the host to act on.
+  Inspects one outbound IRC wire line and returns `:passthrough` (no NickServ
+  secret-bearing verb detected), `{:capture, kind, password}` with the
+  cleartext password lifted out and the verb class (`:identify` / `:register`
+  / `:set_passwd`) for the host to act on, or `{:reject, :set_passwd, reason}`
+  for a SET PASSWD services will refuse (#977).
+
+  `nick` is the sender's CURRENT nick — `callerUser->nick` on the services
+  side. `do_set_password` refuses a new password equal to it
+  (`str_equals_nocase`), and this module refuses the same, so the nick is an
+  input to the verdict rather than something the host re-checks afterwards.
 
   Pure: no side effects. The host (`Grappa.Session.Server`) decides whether
   to stage against `+r` MODE (`:identify`/`:register`), commit optimistically
   on-send (`:set_passwd`, #131), discard on the pending-auth timeout, or
   overwrite on a subsequent capture.
   """
-  @spec intercept(String.t()) :: result()
-  def intercept(line) when is_binary(line) do
+  @spec intercept(String.t(), String.t()) :: result()
+  def intercept(line, nick) when is_binary(line) and is_binary(nick) do
     case Regex.run(@verb_re, line, capture: :all_but_first) do
       [verb, rest] -> dispatch(String.upcase(verb), rest)
-      nil -> intercept_set_passwd(line)
+      nil -> intercept_set_passwd(line, nick)
     end
   end
 
-  # #131 — SET PASSWD. The whole captured group IS the new password
-  # (rest-of-line), so there's no token-splitting clause: spaces are
-  # legal. SET PASSWD shares no verb with the identify family, so this
-  # check is order-independent w.r.t. `@verb_re`/`@bare_re`/`@pass_re`.
-  defp intercept_set_passwd(line) do
+  # #131 / #977 — SET PASSWD. SET PASSWD shares no verb with the identify
+  # family, so this check is order-independent w.r.t.
+  # `@verb_re`/`@bare_re`/`@pass_re`.
+  defp intercept_set_passwd(line, nick) do
     case Regex.run(@set_passwd_re, line, capture: :all_but_first) do
-      [new_password] -> {:capture, :set_passwd, new_password}
+      # `:re` TRIMS an unset trailing group, so a bare `SET PASSWD` — verb and
+      # nothing else — arrives as `[]` rather than `[""]`.
+      [] -> {:reject, :set_passwd, :syntax_error}
+      [param] -> split_set_passwd(param, nick)
       nil -> intercept_bare(line)
     end
+  end
+
+  # `param` is services' `strtok(NULL, "")`: OLD password, then new. The
+  # split is at the FIRST space, exactly like `strchr(param, ' ')`; with no
+  # space at all `do_set_password` bails to NS_SET_PASSWD_SYNTAX_ERROR, so a
+  # one-token `SET PASSWD <new>` (the Atheme spelling) changes nothing
+  # upstream and must change nothing here either.
+  defp split_set_passwd(param, nick) do
+    case String.split(param, " ", parts: 2) do
+      # The head is the OLD password; grappa cannot vet it, services do.
+      [_, new_password] -> vet_new_password(new_password, nick)
+      [_] -> {:reject, :set_passwd, :syntax_error}
+    end
+  end
+
+  # `do_set_password`'s guard chain, in ITS order — same order so the reason
+  # we report is the notice the user actually receives.
+  defp vet_new_password(new_password, nick) do
+    cond do
+      String.contains?(new_password, " ") -> {:reject, :set_passwd, :password_with_spaces}
+      insecure?(new_password, nick) -> {:reject, :set_passwd, :insecure_password}
+      byte_size(new_password) > @passmax -> {:reject, :set_passwd, :password_max_length}
+      ccodes?(new_password) -> {:reject, :set_passwd, :password_with_ccodes}
+      true -> {:capture, :set_passwd, new_password}
+    end
+  end
+
+  # `str_equals_nocase(callerUser->nick, newpass) || (str_len(newpass) < 5)`.
+  # `str_len` is a BYTE count, and the case-insensitive compare is the plain
+  # ASCII one — `Identifier.canonical_target/1`, per the project-wide rule
+  # that no nick comparison uses a bare `String.downcase/1`.
+  defp insecure?(new_password, nick) do
+    byte_size(new_password) < @passmin or
+      Identifier.canonical_target(new_password) == Identifier.canonical_target(nick)
+  end
+
+  # `string_has_ccodes` (`src/misc.c:1321`): any BYTE below 32, or the byte
+  # 160. Byte-level on purpose — 160 is a UTF-8 continuation byte (`à` is
+  # `C3 A0`), so services refuse accented passwords too, and mirroring them
+  # per-byte is the only way to predict that.
+  defp ccodes?(password) do
+    password |> :binary.bin_to_list() |> Enum.any?(&(&1 < 32 or &1 == 160))
   end
 
   defp intercept_bare(line) do

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -3905,7 +3905,7 @@ defmodule Grappa.Session.Server do
   # rendezvous to stage against).
   @spec capture_outbound_ns_secret(t(), String.t()) :: t()
   defp capture_outbound_ns_secret(state, line) do
-    case NSInterceptor.intercept(line) do
+    case NSInterceptor.intercept(line, state.nick) do
       {:capture, :register, password} ->
         Logger.debug("staged pending NickServ registration secret (untimed, #129)",
           verb: :ns_capture
@@ -3922,6 +3922,18 @@ defmodule Grappa.Session.Server do
 
       {:capture, :set_passwd, new_password} ->
         commit_set_passwd(state, new_password)
+
+      # #977 — a SET PASSWD Azzurra will refuse. Nothing is committed
+      # BECAUSE nothing changes upstream either, so the two stay in sync and
+      # services deliver the error notice to the user themselves; the reason
+      # atom is the services error constant. Debug, not an alarm — same class
+      # as the unidentified-visitor skip below. NEVER log the password.
+      {:reject, :set_passwd, reason} ->
+        Logger.debug("SET PASSWD not committed — services would reject it (#{reason})",
+          verb: :ns_set_passwd
+        )
+
+        state
 
       :passthrough ->
         state

--- a/test/grappa/networks/commit_password_test.exs
+++ b/test/grappa/networks/commit_password_test.exs
@@ -101,7 +101,10 @@ defmodule Grappa.Networks.CommitPasswordTest do
 
       refute Credential.password_changeset(cred, "new\r\npass").valid?
       refute Credential.password_changeset(cred, "new\x00pass").valid?
-      # A space is legal (SET PASSWD password is rest-of-line).
+      # A space still passes HERE: this changeset is network-agnostic and only
+      # guards the wire. Azzurra's no-spaces rule is enforced one layer up, at
+      # the door that speaks Azzurra (`Session.NSInterceptor`, #977), so a
+      # spaced value never reaches this function on the SET PASSWD path.
       assert Credential.password_changeset(cred, "new pass").valid?
     end
   end

--- a/test/grappa/session/ns_interceptor_test.exs
+++ b/test/grappa/session/ns_interceptor_test.exs
@@ -3,176 +3,239 @@ defmodule Grappa.Session.NSInterceptorTest do
 
   alias Grappa.Session.NSInterceptor
 
-  describe "intercept/1" do
+  # The sender's current nick — `callerUser->nick` on the services side. Only
+  # SET PASSWD reads it (`do_set_password` refuses a new password equal to
+  # it), so every other case goes through this default rather than repeating
+  # an argument it does not use.
+  @nick "caller"
+  defp intercept(line), do: NSInterceptor.intercept(line, @nick)
+
+  describe "intercept/2" do
     test "PRIVMSG NickServ :IDENTIFY pwd → {:capture, :identify, pwd}" do
       assert {:capture, :identify, "s3cret"} =
-               NSInterceptor.intercept("PRIVMSG NickServ :IDENTIFY s3cret")
+               intercept("PRIVMSG NickServ :IDENTIFY s3cret")
     end
 
     test "PRIVMSG NickServ :IDENTIFY account pwd → {:capture, :identify, pwd}" do
       assert {:capture, :identify, "s3cret"} =
-               NSInterceptor.intercept("PRIVMSG NickServ :IDENTIFY vjt s3cret")
+               intercept("PRIVMSG NickServ :IDENTIFY vjt s3cret")
     end
 
     test "PRIVMSG NickServ :GHOST nick pwd → {:capture, :identify, pwd}" do
       assert {:capture, :identify, "s3cret"} =
-               NSInterceptor.intercept("PRIVMSG NickServ :GHOST vjt s3cret")
+               intercept("PRIVMSG NickServ :GHOST vjt s3cret")
     end
 
     test "PRIVMSG NickServ :REGISTER pwd email → {:capture, :register, pwd}" do
       assert {:capture, :register, "s3cret"} =
-               NSInterceptor.intercept("PRIVMSG NickServ :REGISTER s3cret vjt@bad.ass")
+               intercept("PRIVMSG NickServ :REGISTER s3cret vjt@bad.ass")
     end
 
     test "case-insensitive verb match" do
       assert {:capture, :identify, "s3cret"} =
-               NSInterceptor.intercept("privmsg nickserv :identify s3cret")
+               intercept("privmsg nickserv :identify s3cret")
     end
 
     test "unrelated PRIVMSG → :passthrough" do
-      assert :passthrough = NSInterceptor.intercept("PRIVMSG #italia :ciao")
+      assert :passthrough = intercept("PRIVMSG #italia :ciao")
     end
 
     test "PRIVMSG to non-NickServ → :passthrough" do
-      assert :passthrough = NSInterceptor.intercept("PRIVMSG vjt :hello")
+      assert :passthrough = intercept("PRIVMSG vjt :hello")
     end
 
     test "non-PRIVMSG → :passthrough" do
-      assert :passthrough = NSInterceptor.intercept("JOIN #italia")
-      assert :passthrough = NSInterceptor.intercept("PING :foo")
+      assert :passthrough = intercept("JOIN #italia")
+      assert :passthrough = intercept("PING :foo")
     end
 
     test "captures the ID alias (azzurra m_identify alias) — last token, :identify" do
-      assert {:capture, :identify, "secret"} = NSInterceptor.intercept("PRIVMSG NickServ :ID secret")
-      assert {:capture, :identify, "secret"} = NSInterceptor.intercept("PRIVMSG NickServ :id secret")
+      assert {:capture, :identify, "secret"} = intercept("PRIVMSG NickServ :ID secret")
+      assert {:capture, :identify, "secret"} = intercept("PRIVMSG NickServ :id secret")
     end
 
     test "captures SIDENTIFY (silent identify) — last token, :identify" do
       assert {:capture, :identify, "secret"} =
-               NSInterceptor.intercept("PRIVMSG NickServ :SIDENTIFY secret")
+               intercept("PRIVMSG NickServ :SIDENTIFY secret")
     end
 
     test "captures IDENTIFY/ID with an account argument — password is the last token" do
       assert {:capture, :identify, "secret"} =
-               NSInterceptor.intercept("PRIVMSG NickServ :IDENTIFY myacct secret")
+               intercept("PRIVMSG NickServ :IDENTIFY myacct secret")
 
       assert {:capture, :identify, "secret"} =
-               NSInterceptor.intercept("PRIVMSG NickServ :ID myacct secret")
+               intercept("PRIVMSG NickServ :ID myacct secret")
     end
 
     test "captures a fully-qualified NickServ@services target" do
       assert {:capture, :identify, "secret"} =
-               NSInterceptor.intercept("PRIVMSG NickServ@services.azzurra.chat :ID secret")
+               intercept("PRIVMSG NickServ@services.azzurra.chat :ID secret")
     end
 
     test "captures the NS / NICKSERV server-command form" do
-      assert {:capture, :identify, "secret"} = NSInterceptor.intercept("NS IDENTIFY secret")
-      assert {:capture, :identify, "secret"} = NSInterceptor.intercept("NS id secret")
-      assert {:capture, :identify, "secret"} = NSInterceptor.intercept("NICKSERV SIDENTIFY secret")
+      assert {:capture, :identify, "secret"} = intercept("NS IDENTIFY secret")
+      assert {:capture, :identify, "secret"} = intercept("NS id secret")
+      assert {:capture, :identify, "secret"} = intercept("NICKSERV SIDENTIFY secret")
     end
 
     test "captures bare IDENTIFY/ID/SIDENTIFY commands (m_identify, no PRIVMSG)" do
-      assert {:capture, :identify, "secret"} = NSInterceptor.intercept("IDENTIFY secret")
-      assert {:capture, :identify, "secret"} = NSInterceptor.intercept("ID secret")
-      assert {:capture, :identify, "secret"} = NSInterceptor.intercept("SIDENTIFY myacct secret")
+      assert {:capture, :identify, "secret"} = intercept("IDENTIFY secret")
+      assert {:capture, :identify, "secret"} = intercept("ID secret")
+      assert {:capture, :identify, "secret"} = intercept("SIDENTIFY myacct secret")
     end
 
     test "captures PASS post-connect identify (m_pass -> m_identify) — last token, :identify" do
-      assert {:capture, :identify, "secret"} = NSInterceptor.intercept("PASS secret")
-      assert {:capture, :identify, "secret"} = NSInterceptor.intercept("PASS mynick secret")
+      assert {:capture, :identify, "secret"} = intercept("PASS secret")
+      assert {:capture, :identify, "secret"} = intercept("PASS mynick secret")
     end
 
     test "GHOST is :identify (last token); REGISTER is :register (first token)" do
       assert {:capture, :identify, "secret"} =
-               NSInterceptor.intercept("PRIVMSG NickServ :GHOST oldnick secret")
+               intercept("PRIVMSG NickServ :GHOST oldnick secret")
 
       assert {:capture, :register, "secret"} =
-               NSInterceptor.intercept("PRIVMSG NickServ :REGISTER secret me@x.io")
+               intercept("PRIVMSG NickServ :REGISTER secret me@x.io")
     end
 
     test "NS GHOST is :identify (last token); NS REGISTER is :register (first token)" do
-      assert {:capture, :identify, "secret"} = NSInterceptor.intercept("NS GHOST oldnick secret")
-      assert {:capture, :register, "secret"} = NSInterceptor.intercept("NS REGISTER secret me@x.io")
+      assert {:capture, :identify, "secret"} = intercept("NS GHOST oldnick secret")
+      assert {:capture, :register, "secret"} = intercept("NS REGISTER secret me@x.io")
     end
 
     test "a verb-only identify line with no password is passthrough (no empty capture)" do
-      assert :passthrough = NSInterceptor.intercept("IDENTIFY   ")
-      assert :passthrough = NSInterceptor.intercept("PASS  ")
-      assert :passthrough = NSInterceptor.intercept("PRIVMSG NickServ :ID  ")
+      assert :passthrough = intercept("IDENTIFY   ")
+      assert :passthrough = intercept("PASS  ")
+      assert :passthrough = intercept("PRIVMSG NickServ :ID  ")
     end
 
     test "ANCHORING: a channel message that merely contains identify/pass is passthrough" do
-      assert :passthrough = NSInterceptor.intercept("PRIVMSG #chan :identify yourself please")
-      assert :passthrough = NSInterceptor.intercept("PRIVMSG #chan :the pass is great")
-      assert :passthrough = NSInterceptor.intercept("PRIVMSG NickServ :HELP IDENTIFY")
-      assert :passthrough = NSInterceptor.intercept("ISON somenick")
-      assert :passthrough = NSInterceptor.intercept("IDLE foo")
+      assert :passthrough = intercept("PRIVMSG #chan :identify yourself please")
+      assert :passthrough = intercept("PRIVMSG #chan :the pass is great")
+      assert :passthrough = intercept("PRIVMSG NickServ :HELP IDENTIFY")
+      assert :passthrough = intercept("ISON somenick")
+      assert :passthrough = intercept("IDLE foo")
     end
   end
 
-  # #131 — in-session NickServ SET PASSWD capture. Azzurra's `do_set` only
-  # routes the `PASSWD` subcommand (`PASSWORD` errors); the new password is
-  # the rest-of-line (Azzurra parses it with `strtok(NULL,"")`, so it may
-  # carry spaces). The capture is a distinct `:set_passwd` kind because the
-  # host commits it optimistically on-send — NOT on a `+r` rendezvous (a
-  # SET PASSWD from an already-identified session emits no `+r`).
-  describe "intercept/1 — SET PASSWD (#131)" do
-    test "PRIVMSG NickServ :SET PASSWD newpass → {:capture, :set_passwd, newpass}" do
+  # #131 / #977 — in-session NickServ SET PASSWD capture. Azzurra's `do_set`
+  # only routes the `PASSWD` subcommand (`PASSWORD` errors) and hands the
+  # handler everything after the verb; `do_set_password` splits THAT at the
+  # first space. The form is `SET PASSWD <old> <new>`, an AUTHENTICATED
+  # rotation, so the capture is the SECOND token — capturing rest-of-line
+  # stored `"<old> <new>"` concatenated and corrupted the credential (#977).
+  # A distinct `:set_passwd` kind because the host commits it optimistically
+  # on-send — NOT on a `+r` rendezvous (a SET PASSWD from an already-identified
+  # session emits no `+r`) — which is exactly why a value services would
+  # refuse must be rejected here rather than written and regretted.
+  describe "intercept/2 — SET PASSWD (#131, #977)" do
+    test "#977 — captures the NEW password (second token), never the concatenation" do
       assert {:capture, :set_passwd, "newpass"} =
-               NSInterceptor.intercept("PRIVMSG NickServ :SET PASSWD newpass")
+               intercept("PRIVMSG NickServ :SET PASSWD oldpass newpass")
     end
 
-    test "NS / NICKSERV SET PASSWD server-command form" do
-      assert {:capture, :set_passwd, "newpass"} =
-               NSInterceptor.intercept("NS SET PASSWD newpass")
+    test "#977 — NS / NICKSERV / bare / fully-qualified forms all take the second token" do
+      assert {:capture, :set_passwd, "newpass"} = intercept("NS SET PASSWD oldpass newpass")
 
       assert {:capture, :set_passwd, "newpass"} =
-               NSInterceptor.intercept("NICKSERV SET PASSWD newpass")
-    end
+               intercept("NICKSERV SET PASSWD oldpass newpass")
 
-    test "bare SET PASSWD form (raw /quote)" do
+      assert {:capture, :set_passwd, "newpass"} = intercept("SET PASSWD oldpass newpass")
+
       assert {:capture, :set_passwd, "newpass"} =
-               NSInterceptor.intercept("SET PASSWD newpass")
-    end
-
-    test "password is the rest-of-line and may contain spaces (strtok(NULL,\"\"))" do
-      assert {:capture, :set_passwd, "my new pass phrase"} =
-               NSInterceptor.intercept("PRIVMSG NickServ :SET PASSWD my new pass phrase")
-
-      assert {:capture, :set_passwd, "two words"} =
-               NSInterceptor.intercept("NS SET PASSWD two words")
+               intercept("PRIVMSG NickServ@services.azzurra.chat :SET PASSWD oldpass newpass")
     end
 
     test "case-insensitive (cic forwards /ns set passwd verbatim, lower-cased)" do
       assert {:capture, :set_passwd, "newpass"} =
-               NSInterceptor.intercept("privmsg nickserv :set passwd newpass")
+               intercept("privmsg nickserv :set passwd oldpass newpass")
     end
 
-    test "fully-qualified NickServ@services target" do
-      assert {:capture, :set_passwd, "newpass"} =
-               NSInterceptor.intercept("PRIVMSG NickServ@services.azzurra.chat :SET PASSWD newpass")
+    test "#977 — one-token SET PASSWD <new> is a services syntax error, not a capture" do
+      assert {:reject, :set_passwd, :syntax_error} =
+               intercept("PRIVMSG NickServ :SET PASSWD newpass")
+
+      assert {:reject, :set_passwd, :syntax_error} = intercept("NS SET PASSWD newpass")
+    end
+
+    test "#977 — a TAB is not a services delimiter, so old\\tnew is one token" do
+      assert {:reject, :set_passwd, :syntax_error} =
+               intercept("PRIVMSG NickServ :SET PASSWD oldpass\tnewpass")
+    end
+
+    test "verb-only SET PASSWD carries no password at all" do
+      assert {:reject, :set_passwd, :syntax_error} = intercept("PRIVMSG NickServ :SET PASSWD")
+      assert {:reject, :set_passwd, :syntax_error} = intercept("SET PASSWD")
+    end
+
+    test "#977 — a new password with a space is refused (CSNS_ERROR_PASSWORD_WITH_SPACES)" do
+      assert {:reject, :set_passwd, :password_with_spaces} =
+               intercept("PRIVMSG NickServ :SET PASSWD oldpass my new pass")
+
+      # Trailing space: services trim nothing, so `newpass` ends in one.
+      assert {:reject, :set_passwd, :password_with_spaces} =
+               intercept("PRIVMSG NickServ :SET PASSWD oldpass newpass ")
+
+      # A doubled space after the verb makes the OLD password empty and the
+      # new one "oldpass newpass" — services refuse that too.
+      assert {:reject, :set_passwd, :password_with_spaces} =
+               intercept("PRIVMSG NickServ :SET PASSWD  oldpass newpass")
+
+      assert {:reject, :set_passwd, :password_with_spaces} =
+               intercept("PRIVMSG NickServ :SET PASSWD   ")
+    end
+
+    test "#977 — under 5 bytes is refused; exactly 5 is accepted" do
+      assert {:reject, :set_passwd, :insecure_password} =
+               intercept("PRIVMSG NickServ :SET PASSWD oldpass abcd")
+
+      assert {:capture, :set_passwd, "abcde"} =
+               intercept("PRIVMSG NickServ :SET PASSWD oldpass abcde")
+    end
+
+    test "#977 — a new password equal to the caller's nick is refused, any case" do
+      assert {:reject, :set_passwd, :insecure_password} =
+               NSInterceptor.intercept("SET PASSWD oldpass CaLLer", "caller")
+
+      assert {:reject, :set_passwd, :insecure_password} =
+               NSInterceptor.intercept("SET PASSWD oldpass caller", "CALLER")
+
+      assert {:capture, :set_passwd, "caller1"} =
+               NSInterceptor.intercept("SET PASSWD oldpass caller1", "caller")
+    end
+
+    test "#977 — over PASSMAX (32 bytes) is refused; exactly 32 is accepted" do
+      max = String.duplicate("a", 32)
+
+      assert {:capture, :set_passwd, ^max} = intercept("SET PASSWD oldpass #{max}")
+
+      assert {:reject, :set_passwd, :password_max_length} =
+               intercept("SET PASSWD oldpass #{max <> "a"}")
+    end
+
+    test "#977 — control codes are refused, counted per BYTE like string_has_ccodes" do
+      assert {:reject, :set_passwd, :password_with_ccodes} =
+               intercept("SET PASSWD oldpass new\x02pass")
+
+      # `à` is C3 A0 in UTF-8 and 160 is a control code to services, so an
+      # accented password is refused upstream — and therefore here.
+      assert {:reject, :set_passwd, :password_with_ccodes} =
+               intercept("SET PASSWD oldpass pàssword")
     end
 
     test "SET PASSWORD is NOT matched — Azzurra verb is PASSWD, PASSWORD errors" do
-      assert :passthrough = NSInterceptor.intercept("PRIVMSG NickServ :SET PASSWORD newpass")
-      assert :passthrough = NSInterceptor.intercept("NS SET PASSWORD newpass")
-      assert :passthrough = NSInterceptor.intercept("SET PASSWORD newpass")
+      assert :passthrough = intercept("PRIVMSG NickServ :SET PASSWORD oldpass newpass")
+      assert :passthrough = intercept("NS SET PASSWORD oldpass newpass")
+      assert :passthrough = intercept("SET PASSWORD oldpass newpass")
     end
 
     test "other SET subcommands (EMAIL etc.) are passthrough — only PASSWD is captured" do
-      assert :passthrough = NSInterceptor.intercept("PRIVMSG NickServ :SET EMAIL me@x.io")
-      assert :passthrough = NSInterceptor.intercept("NS SET HIDE ON")
-    end
-
-    test "verb-only SET PASSWD with no new password is passthrough (no empty capture)" do
-      assert :passthrough = NSInterceptor.intercept("PRIVMSG NickServ :SET PASSWD")
-      assert :passthrough = NSInterceptor.intercept("PRIVMSG NickServ :SET PASSWD   ")
-      assert :passthrough = NSInterceptor.intercept("SET PASSWD")
+      assert :passthrough = intercept("PRIVMSG NickServ :SET EMAIL me@x.io")
+      assert :passthrough = intercept("NS SET HIDE ON")
     end
 
     test "ANCHORING: a channel message / HELP that merely contains SET PASSWD is passthrough" do
-      assert :passthrough = NSInterceptor.intercept("PRIVMSG #chan :SET PASSWD lol")
-      assert :passthrough = NSInterceptor.intercept("PRIVMSG NickServ :HELP SET PASSWD")
+      assert :passthrough = intercept("PRIVMSG #chan :SET PASSWD oldpass lol")
+      assert :passthrough = intercept("PRIVMSG NickServ :HELP SET PASSWD")
     end
   end
 end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -6921,8 +6921,10 @@ defmodule Grappa.Session.ServerTest do
   # password OPTIMISTICALLY the moment the well-formed line leaves the wire.
   # Both credential homes: the user-bound `Networks.Credential` (via the
   # injected `credential_committer`) and the anon `visitors` row (via the
-  # reused `visitor_committer`).
-  describe "in-session SET PASSWD → optimistic commit-on-send (#131)" do
+  # reused `visitor_committer`). The wire form is `SET PASSWD <old> <new>`
+  # and what gets committed is the SECOND token (#977) — and only when
+  # Azzurra would accept it, since an optimistic commit has no take-backs.
+  describe "in-session SET PASSWD → optimistic commit-on-send (#131, #977)" do
     test "user session: SET PASSWD rotates the bound credential password, no +r needed" do
       {server, port} = start_server()
 
@@ -6937,7 +6939,7 @@ defmodule Grappa.Session.ServerTest do
                  {:user, user.id},
                  network.id,
                  "NickServ",
-                 "SET PASSWD newpass"
+                 "SET PASSWD oldpass newpass"
                )
 
       # Commit is synchronous inside the send handler — no `+r` MODE was fed.
@@ -6952,7 +6954,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
-    test "user session: a rest-of-line password with spaces is committed verbatim" do
+    test "#977 user session: a spaced new password is NOT committed — services refuse it" do
       {server, port} = start_server()
 
       {user, network, _} =
@@ -6966,13 +6968,15 @@ defmodule Grappa.Session.ServerTest do
                  {:user, user.id},
                  network.id,
                  "NickServ",
-                 "SET PASSWD correct horse battery staple"
+                 "SET PASSWD oldpass correct horse battery staple"
                )
 
       _ = SessionStateHelpers.fetch(pid)
 
-      assert Credentials.get_credential!(user, network).password_encrypted ==
-               "correct horse battery staple"
+      # `do_set_password` answers CSNS_ERROR_PASSWORD_WITH_SPACES and changes
+      # nothing upstream, so the stored secret must stay the old one — before
+      # #977 this wrote the whole rest-of-line and desynced the credential.
+      assert Credentials.get_credential!(user, network).password_encrypted == "oldpass"
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
@@ -6991,7 +6995,7 @@ defmodule Grappa.Session.ServerTest do
                  {:visitor, visitor.id},
                  network.id,
                  "NickServ",
-                 "SET PASSWD newpass"
+                 "SET PASSWD oldpass newpass"
                )
 
       state = SessionStateHelpers.fetch(pid)
@@ -7019,7 +7023,7 @@ defmodule Grappa.Session.ServerTest do
                  {:visitor, visitor.id},
                  network.id,
                  "NickServ",
-                 "SET PASSWD newpass"
+                 "SET PASSWD oldpass newpass"
                )
 
       _ = SessionStateHelpers.fetch(pid)


### PR DESCRIPTION
Fixes the #977 corruption: `SET PASSWD` stored the old and the new password
concatenated, so every in-session rotation left a credential that can never
identify again.

## What was wrong

`@set_passwd_re` captured rest-of-line. On Azzurra the syntax is
`SET PASSWD <old> <new>`: `do_set` (`src/nickserv.c:2090`) hands the handler
`param = strtok(NULL, "")` and `do_set_password` (`:2182`) splits THAT at the
first space — head = OLD password (checked with `str_equals(param, ni->pass)`,
the comment at `:2204` says it outright), tail = the new one. Verified against
`azzurra/services@23473ed`, fetched and read, not inferred.

So the moduledoc's *"may contain spaces — never split on the first space"* was
false in both halves: that `strtok` is old+new, and Azzurra passwords cannot
contain spaces at all (`CSNS_ERROR_PASSWORD_WITH_SPACES`, the line right after
the split). The claim had also propagated into the #131 DESIGN_NOTES entry and
three doc comments — all corrected, the old entry marked superseded.

## What changed

- **Capture the second token.** A one-token `SET PASSWD <new>` (the Atheme
  spelling) is NOT a capture: services answer a syntax error and change
  nothing, so neither may we.
- **Vet before storing.** The commit is optimistic on-send (#131 — no `+r`
  fires for a rotation), and an optimistic write has no take-backs, so
  `NSInterceptor` now carries `do_set_password`'s own guard chain in its order
  (spaces → nick-or-under-5 → over-`PASSMAX` → control codes) and answers a new
  `{:reject, :set_passwd, reason}` — the reason being the services error
  constant. The line still goes out: services deliver their own error notice,
  grappa's DB is untouched, the two stay in sync. `Session.Server` logs the
  refusal at debug, never the password.
- **`PASSMAX` = 32 as a constant**, with its source reference: it is a
  compile-time `#define` (`inc/config.h:96`), not a services.conf directive —
  nothing to learn at runtime, nothing for an operator to tune.
- **`intercept/1` → `intercept/2`.** `do_set_password` compares the new
  password against `callerUser->nick`, so the nick is an input to the verdict;
  the single production call site passes `state.nick`.

## Rulings worth challenging

- **The rules live in `NSInterceptor`, not in `Credential.password_changeset/2`.**
  The issue points at that changeset validating only CR/LF/NUL. It stays that
  way: it is network-agnostic, and a 32-byte ceiling is one network's services
  talking. One authority per fact — the Azzurra-shaped parser owns the
  Azzurra-shaped rules; the changeset keeps the wire-hygiene floor every
  network shares. Comment added there so the next reader does not read the
  absence as an oversight.
- **Two `do_set_password` guards are NOT mirrored,** both because mirroring
  buys nothing: `str_equals` against the current password (a no-op rotation
  would store the value already stored) and the old-password check itself —
  grappa cannot vet a mistyped OLD password from the line alone. That case
  still commits optimistically and still falls to #124's re-auth backstop. It
  is now the ONLY residual divergence on this path, down from every rotation.

## Behaviour changes visible to a user

`SET PASSWD <new>` used to update the stored credential and change nothing
upstream. It now updates nothing, which matches what services do. `#124`'s
editable password field remains the cure for a credential already corrupted.

## Test evidence

TDD, red first, on the pre-fix code:

```
left:  {:capture, :set_passwd, "newpw"}
right: {:capture, :set_passwd, "oldpw newpw"}
```

`test/grappa/session/server_test.exs` had a test asserting the bug
(*"a rest-of-line password with spaces is committed verbatim"*); it now
asserts the inverse — a spaced password leaves the stored secret alone.
New interceptor cases cover the second-token capture in all four wire forms,
the one-token and TAB syntax errors, the three-token / trailing-space /
doubled-space space rejections, both length boundaries (exactly 5 and exactly
32 accepted), nick equality in either case, and control codes counted per
BYTE (`à` is `C3 A0`, and 160 is a control code to services).

`scripts/check.sh` green in the worktree: 8 doctests, 54 properties,
5355 tests, 0 failures, plus format / credo / dialyzer / sobelow / doctor and
the full bats set. **NOT run:** `scripts/integration.sh` — the STACK lane was
held by another worker; nothing in this change touches the e2e surface (no
wire token, no cic change, no `SET PASSWD` reference anywhere in `e2e/` or
`cicchetto/`), but the PR CI is the gate that proves it, not me.

## Deploy classification

**HOT.** Pure code: two `lib/` modules and their docs, no migration, no
dependency, no `mix.exs`, no infra file.