### PR TITLE
cic: give the query rail a scroll owner (#984) and un-stretch the delete-account dialog (#987)

### DIFF
--- a/cicchetto/e2e/tests/issue157-delete-account.spec.ts
+++ b/cicchetto/e2e/tests/issue157-delete-account.spec.ts
@@ -128,6 +128,89 @@ test.describe("issue #157 — delete account", () => {
     }
   });
 
+  // #987 — the dialog must sit ON the screen, not BE the screen. The backdrop
+  // was `align-items: stretch`, which forces a flex child to the full
+  // cross-axis extent, so the modal was viewport-tall whatever it held and its
+  // own `max-height` read like a cap that never bit. Asserted as GEOMETRY, not
+  // computed style: `getComputedStyle` under device emulation has already lied
+  // once (#963), and "is it stretched" is a box question anyway.
+  //
+  // Note which assertion carries the weight. Scrim-above/below is the RED one:
+  // pre-fix the box starts at y=0 and ends at the viewport bottom, so both
+  // legs fail. The centring check is a GUARD, not the proof — a
+  // full-height box is trivially "centred" and would satisfy it alone.
+  test("#987 — the delete-account dialog is centred and sized to its content", async ({ page }) => {
+    const admin = getSeededAdmin();
+    const name = `e2e987-${Date.now()}`;
+    const identifier = `${name}@grappa.test`;
+    let createdId: string | null = null;
+
+    try {
+      createdId = await createThrowawayUser(admin.token, name, PASSWORD);
+      const { token, subject } = await login(identifier, PASSWORD);
+      await page.addInitScript(
+        ([t, subjectJson]) => {
+          localStorage.setItem("grappa-token", t);
+          localStorage.setItem("grappa-subject", subjectJson);
+          localStorage.setItem("cic.installChoice", "browser");
+        },
+        [token, JSON.stringify(subject)] as const,
+      );
+      await page.goto("/");
+      await expectShellReady(page);
+
+      await openSettingsDrawer(page);
+      await page.getByTestId("delete-account-btn").click();
+      const modal = page.getByTestId("delete-account-modal");
+      await expect(modal).toBeVisible();
+
+      // Measure the dialog against its own SCRIM, not against
+      // `page.viewportSize()`. The backdrop is `position: fixed; inset: 0`, and
+      // a fixed box resolves against the nearest transformed ancestor rather
+      // than the viewport — the settings drawer is `transform: translateX(0)`
+      // when open, so pinning the maths to the viewport would be one refactor
+      // (moving the modal inside the drawer) away from measuring the wrong
+      // rectangle and reporting it confidently. The scrim is also what "scrim
+      // above and below" is literally about. A sanity leg below still ties the
+      // scrim to the screen.
+      const backdrop = page.getByTestId("delete-account-backdrop");
+      const scrim = await backdrop.boundingBox();
+      const box = await modal.boundingBox();
+      const viewport = page.viewportSize();
+      expect(scrim, "the backdrop must have a layout box").not.toBeNull();
+      expect(box, "the modal must have a layout box").not.toBeNull();
+      expect(viewport, "the test needs a known viewport").not.toBeNull();
+      if (!scrim || !box || !viewport) return;
+
+      // Sanity: the scrim really is the screen, so the assertions below are
+      // about what the operator sees and not about some inner box.
+      expect(Math.round(scrim.height)).toBe(viewport.height);
+
+      // THE DEFECT: scrim above and below. Pre-fix there is none of either —
+      // `align-items: stretch` pins the dialog to both edges.
+      expect(box.y, "scrim must be visible above the dialog").toBeGreaterThan(scrim.y);
+      expect(box.y + box.height, "scrim must be visible below the dialog").toBeLessThan(
+        scrim.y + scrim.height,
+      );
+
+      // Sized to content: this dialog holds a heading, a warning, one input and
+      // two buttons. Three quarters of the scrim is a generous ceiling that
+      // still fails hard on the stretched box (which is exactly 1.0).
+      expect(box.height, "a short dialog must not claim most of the screen").toBeLessThan(
+        scrim.height * 0.75,
+      );
+
+      // Guard: vertically centred, the `.confirm-modal` contract. Allow a
+      // couple of px for sub-pixel rounding.
+      expect(Math.abs(box.y - scrim.y - (scrim.height - box.height) / 2)).toBeLessThanOrEqual(2);
+
+      // The dialog is only inspected here — never confirmed — so the throwaway
+      // account still exists and the `finally` below reaps it.
+    } finally {
+      if (createdId !== null) await deleteUserBestEffort(admin.token, createdId);
+    }
+  });
+
   test("a minted (anon) visitor is NOT offered delete account — only quit", async ({ browser }) => {
     const visitor = await mintVisitor(`e2e157v-${Date.now()}`);
     const ctx = await browser.newContext();

--- a/cicchetto/e2e/tests/issue984-query-rail-scroll-owner.spec.ts
+++ b/cicchetto/e2e/tests/issue984-query-rail-scroll-owner.spec.ts
@@ -1,0 +1,164 @@
+// #984 — the QUERY branch of the rail had no scroll owner, so a tall WHOIS
+// bundle pushed the `.rail-actions` launcher below the fold. vjt hit it on
+// iPhone with the keyboard up (the drawer's height tracks `--viewport-height`,
+// so the keyboard IS the fold), but the mechanism is form-factor-independent:
+// `.shell-members` is `overflow-y: visible` by decision (#500 — the launcher's
+// absolute overlay menu must not be clipped), which means an inner child has to
+// own the scroll. `.members-pane` does; `.rail-query-context` was `flex: 0 0
+// auto`, i.e. never shrink, no internal scroll.
+//
+// This is the exact twin of `issue500-rail-launcher-overflow`, one window kind
+// over, and it is asserted the same way and for the same reason: boundingBox,
+// never a plain click. Playwright auto-scrolls an element into its scroll
+// container before clicking, so a click would MASK the defect. And never
+// `getComputedStyle` for the reachability question — a computed-style
+// assertion under device emulation has already lied once (#963). Geometry is
+// the outcome the operator actually experiences.
+//
+// The second test covers the half no desktop assertion can see. The fix has a
+// touch component: the mobile drawer sits under the `.shell-mobile {
+// touch-action: none }` blanket (UX-3 PENT), so a NEW scroller must re-assert
+// `pan-y` on itself AND on its subtree (touch-action does not inherit, CSS UI
+// L4 — UX-6 bucket A v2). Without it the card scrolls under a mouse and
+// refuses to scroll under a finger. There is no geometry for a gesture
+// contract; the computed-style assertion on the webkit-iPhone project is the
+// established shape for it (`ux-6-a-mobile-members-scroll.spec.ts`), and
+// touch-action is not the paint-adjacent property #963 caught lying.
+
+import {
+  composeSend,
+  loginAs,
+  openMembersDrawer,
+  selectChannel,
+  waitForQueryWindowReady,
+} from "../fixtures/cicchettoPage";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+// Unique suffix so retries / sibling specs never collide on a nick already in
+// use upstream (same rule as issue606-query-rail-whois).
+const RUN_ID = crypto.randomUUID().slice(0, 8);
+const PEER = `Q984${RUN_ID}`;
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// A long realname is what makes the card GENUINELY overflow rather than merely
+// fit-with-no-margin. The rail track is capped at `fit-content(14rem)` (#605)
+// and `.whois-card-fields dd` is `word-break: break-word`, so this wraps into
+// many rows inside a narrow card — the same shape as a real gecos, just longer.
+// A short bundle would false-pass against the BROKEN build (nothing overflows,
+// nothing is pushed anywhere), which is the trap #500's spec calls out.
+const LONG_GECOS =
+  "a deliberately long realname so the rail whois card overflows a short viewport";
+
+// Short enough that the stacked WHOIS card cannot fit — the fold has to bite.
+const SHORT_VIEWPORT = { width: 1280, height: 220 };
+
+// Peer connect + upstream WHOIS round-trip + a viewport-resize reflow.
+test.setTimeout(90_000);
+
+test("#984 — a tall query WHOIS card keeps the rail launcher reachable", async ({ page }) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  const peer = await IrcPeer.connect({ nick: PEER, gecos: LONG_GECOS });
+  try {
+    // Share a channel so the peer is WHOIS-able and the bundle carries a
+    // channels line (one more row of card height).
+    await peer.join(CHANNEL);
+
+    await composeSend(page, `/q ${PEER}`);
+    await waitForQueryWindowReady(page, NETWORK_SLUG, PEER);
+
+    // Wait for the card to actually render before shrinking — the fetch is a
+    // real upstream round-trip, and resizing against an empty card would
+    // measure nothing.
+    const rail = page.locator(".shell-members");
+    const ctx = rail.getByTestId("rail-query-context");
+    await expect(ctx).toBeVisible({ timeout: 5_000 });
+    const railCard = rail.getByTestId("whois-card");
+    await expect(railCard).toBeVisible({ timeout: 8_000 });
+    await expect(railCard.locator(".whois-card-target")).toHaveText(PEER);
+
+    await page.setViewportSize(SHORT_VIEWPORT);
+
+    // Precondition — the card CONTENT is genuinely taller than the rail column
+    // that has to hold it. Deliberately NOT `ctx.scrollHeight >
+    // ctx.clientHeight`: that phrasing is the fix's own symptom (pre-fix the
+    // context is not a scroll container at all, so its two heights are equal
+    // and the precondition would fail for the wrong reason, telling us nothing
+    // about whether the scenario was reproduced). Content-vs-column holds on
+    // both sides of the fix and is what "the launcher gets pushed out" means.
+    const overflows = await ctx.evaluate((el) => {
+      const aside = el.closest(".shell-members");
+      return aside !== null && el.scrollHeight > aside.clientHeight;
+    });
+    expect(overflows, "the whois card must overflow the rail for this test to mean anything").toBe(
+      true,
+    );
+
+    // THE DEFECT: the launcher must still be inside the viewport. boundingBox
+    // is viewport-relative and does NOT scroll, so a launcher pushed past the
+    // fold by a non-shrinking card reports a y beyond it here.
+    const launcher = page.getByTestId("rail-actions-launcher");
+    await expect(launcher).toBeVisible();
+    const box = await launcher.boundingBox();
+    expect(box, "launcher must have a layout box").not.toBeNull();
+    if (box) {
+      expect(box.y, "launcher must not be above the viewport top").toBeGreaterThanOrEqual(0);
+      expect(
+        box.y + box.height,
+        "launcher must not be pushed below the fold by the whois card",
+      ).toBeLessThanOrEqual(SHORT_VIEWPORT.height + 1);
+    }
+  } finally {
+    await peer.disconnect("#984 done");
+  }
+});
+
+test("@webkit #984 — the query rail scroller carries pan-y, and so does its subtree", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  const peer = await IrcPeer.connect({ nick: `M${PEER}`, gecos: LONG_GECOS });
+  try {
+    await peer.join(CHANNEL);
+    await composeSend(page, `/q M${PEER}`);
+    await waitForQueryWindowReady(page, NETWORK_SLUG, `M${PEER}`);
+
+    await openMembersDrawer(page);
+    const ctx = page.locator(".shell-mobile .shell-members .rail-query-context");
+    await expect(ctx).toBeVisible({ timeout: 5_000 });
+    await expect(ctx.getByTestId("whois-card")).toBeVisible({ timeout: 8_000 });
+
+    // The scroller itself: it owns the overflow, so it must own the gesture.
+    const scroller = await ctx.evaluate((el) => {
+      const cs = getComputedStyle(el);
+      return {
+        overflowY: cs.overflowY,
+        touchAction: cs.touchAction,
+        overscrollBehaviorY: cs.overscrollBehaviorY,
+      };
+    });
+    expect(scroller.overflowY).toBe("auto");
+    expect(scroller.touchAction).toBe("pan-y");
+    expect(scroller.overscrollBehaviorY).toBe("contain");
+
+    // And the subtree: `touch-action` does not inherit, so a drag whose
+    // hit-test target is a card row would otherwise be routed by that
+    // descendant's default `auto` to a non-root scroll ancestor — `<body>`
+    // with the keyboard up — and the scroller's own pan-y never fires. This is
+    // the UX-6 bucket A v2 finding, re-applied to the query branch.
+    const rowTouchAction = await ctx
+      .locator(".whois-card-fields dd")
+      .first()
+      .evaluate((el) => getComputedStyle(el).touchAction);
+    expect(rowTouchAction).toBe("pan-y");
+  } finally {
+    await peer.disconnect("#984 mobile done");
+  }
+});

--- a/cicchetto/src/__tests__/queryUnreadBadgeCasing.test.ts
+++ b/cicchetto/src/__tests__/queryUnreadBadgeCasing.test.ts
@@ -231,6 +231,24 @@ describe("#973 read-cursor store keys on the folded identifier", () => {
     expect(getReadCursor(SLUG, "newnick")).toBe(900);
   });
 
+  it("treats a pure re-casing as one identity, leaving the map object untouched", async () => {
+    const { applyReadCursorSet, readCursors, renameReadCursorChannel, clearReadCursors } =
+      await import("../lib/readCursor");
+    clearReadCursors();
+
+    applyReadCursorSet(SLUG, PEER_FOLDED, 900);
+    const before = readCursors();
+
+    // `Foo` → `foo` is not a rename, it is the same window spelled twice.
+    // The guard has to answer that as a KEY question: raw-compared it reads
+    // "different", falls into the body, and puts the entry back under the key
+    // it just removed — same contents, NEW object identity, which wakes every
+    // consumer of the cursor signal to recompute nothing.
+    renameReadCursorChannel(SLUG, PEER_FOLDED, PEER_RAW);
+
+    expect(readCursors()).toBe(before);
+  });
+
   it("is a no-op for a channel, whose name is already canonical", async () => {
     const { applyReadCursorSet, readCursors, getReadCursor, clearReadCursors } = await import(
       "../lib/readCursor"

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -3775,7 +3775,16 @@ html.resize-dragging * {
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   display: flex;
-  align-items: stretch;
+  /* #987 — `center`, not `stretch`. On a flex backdrop `stretch` forces the
+     child to the full cross-axis extent, so the modal was viewport-tall
+     whatever it held and its own `max-height: var(--viewport-height)` read
+     like a cap that never bit: the box was already at that height because the
+     backdrop had put it there. Centred, the box sizes to content, the
+     max-height becomes a real ceiling, and the `overflow-y: auto` +
+     `touch-action: pan-y` already on the modal start earning their keep in the
+     tall case (large text, keyboard up) instead of being dead weight in the
+     short one. `.confirm-modal-backdrop` (~:3878) has always had this. */
+  align-items: center;
   justify-content: center;
   z-index: 1000;
 }
@@ -3786,7 +3795,14 @@ html.resize-dragging * {
   border: 1px solid #c00;
   width: 100%;
   max-width: 32rem;
-  max-height: var(--viewport-height, 100dvh);
+  /* #987 — the cap has to leave room for the margin below, or a tall dialog
+     (large text size, keyboard up) is exactly 2rem too big for the scrim and
+     centring clips 1rem off each end. `.confirm-modal` (~:3888) never needed
+     this because it carries no max-height at all. */
+  max-height: calc(var(--viewport-height, 100dvh) - 2rem);
+  /* #987 — the scrim has to be visible AROUND the dialog, not just behind it;
+     `.confirm-modal` carries the same margin for the same reason. */
+  margin: 1rem;
   padding: max(0.75rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom));
   font-family: var(--font-mono);
   font-size: var(--font-size);

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -7810,8 +7810,49 @@ html.resize-dragging * {
    binds here too because `.whois-card-fields dd` AND this heading both wrap
    (`word-break`) — the coupling gotcha #605 flagged: a non-wrapping token
    would floor `fit-content` above the cap. */
+/* #984 — the query branch owns the rail's scroll, exactly as `.members-pane`
+   does for the channel branch (~:3335). `.shell-members` is `overflow-y:
+   visible` by DECISION (#500: the launcher's absolute overlay menu must not be
+   clipped), so SOME inner child has to be the scroller or nothing is. With the
+   pre-#984 `flex: 0 0 auto` this one refused to shrink, a tall WHOIS bundle
+   grew the column past its own height, and the `margin-top: auto`
+   `.rail-actions` launcher was pushed below the fold — under the keyboard on
+   mobile, where the column height tracks `--viewport-height`. Same class as
+   #500 and #962: a flex child with no shrink contract in a bounded column. */
 .rail-query-context {
-  flex: 0 0 auto;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+/* #984 — the gesture half. The mobile drawer's scroller needs the SAME
+   contract `.members-pane` gets at the members carve-out (~:4861), for the same
+   two reasons. The drawer is `position: fixed` under the `.shell-mobile {
+   touch-action: none }` blanket (UX-3 PENT ~:2144), so `pan-y` has to be
+   re-asserted on the element that actually scrolls (UX-6 bucket A); and
+   `touch-action` does NOT inherit (CSS UI L4), so the subtree needs it too
+   (UX-6 bucket A v2) — a drag whose hit-test target is a `<dd>` of the WHOIS
+   card would otherwise be routed by that descendant's default `auto` to a
+   non-root scroll ancestor (`<body>`, with the keyboard up) and the scroller's
+   own `pan-y` would never fire. Without this pair the card scrolls under a
+   mouse and refuses to scroll under a finger.
+
+   Placed HERE, in its own breakpoint block right after the base rule, rather
+   than alongside the members carve-out in the big mobile block (~:4656): that
+   block comes EARLIER in the file than this selector's base rule, so the
+   `(0,3,0)` override would precede the `(0,1,0)` it overrides and trip
+   `noDescendingSpecificity`. Same `(0,3,0)` specificity guard as the members
+   pair — a future horizontal-swipe gesture inside the card must be declared
+   MORE specific than `.shell-mobile .shell-members .rail-query-context *`. */
+@media (max-width: 768px) {
+  .shell-mobile .shell-members .rail-query-context,
+  .shell-mobile .shell-members .rail-query-context * {
+    touch-action: pan-y;
+  }
+
+  .shell-mobile .shell-members .rail-query-context {
+    overscroll-behavior: contain;
+  }
 }
 
 /* #857 — the rail mount STACKS the pairs; the scrollback overlay keeps the


### PR DESCRIPTION
Two independent CSS geometry fixes for the 0.13.3 cic cluster, plus one
unrelated test recovered from an already-merged worktree. Commits are
separate per issue.

## #984 — the query rail had no scroll owner

`.shell-members` is `overflow-y: visible` by decision (#500, so the
launcher's absolute overlay menu is not clipped), which means an inner
child must own the scroll. `.members-pane` does; `.rail-query-context`
was `flex: 0 0 auto` — never shrink, no internal scroll — so on a query
window a tall WHOIS bundle grew the column past its own height and
pushed the `margin-top: auto` `.rail-actions` launcher below the fold.
On iPhone the column height tracks `--viewport-height`, so the fold is
the keyboard and the launcher is unreachable. Same class as #500 and
#962.

The query branch now gets the members-pane contract verbatim, plus the
gesture half the issue text omitted: the drawer sits under the
`.shell-mobile { touch-action: none }` blanket, so a new scroller has to
re-assert `pan-y` on itself **and** on its subtree (touch-action does
not inherit, CSS UI L4). Without the subtree rule a drag starting over a
WHOIS card row is routed by that row's default `auto` to `<body>` and
the scroller's own pan-y never fires — the card would scroll under a
mouse and refuse to scroll under a finger. That is the UX-6 bucket A /
A v2 finding, re-applied one window kind over. Called out here because
it is a deliberate widening of what the issue asked for.

Not done: making `.shell-members` itself the scroller. It is
`overflow-y: visible` on purpose and reversing that re-clips the menu.

## #987 — the delete-account dialog was stretched to the viewport

`align-items: stretch` on the flex backdrop forced the modal to the full
cross-axis extent, so it was viewport-tall regardless of content and its
`max-height` never bit. Now `center` + `margin: 1rem`, the
`.confirm-modal` contract.

One deviation from the issue text, deliberate: the cap becomes
`calc(var(--viewport-height) - 2rem)`. Keeping it at the bare viewport
height while adding a 1rem margin leaves a tall dialog exactly 2rem too
big for the scrim, and centring clips 1rem off each end — the ceiling
would stay approximately true, which is the defect being fixed, one size
down.

delete-account stays in the settings drawer; the red border and the
type-your-name gate are untouched. Geometry only.

## Unrelated: a #973 test

`test(#973): pin a pure re-casing as a no-op` was left uncommitted in a
worktree that had already been merged. Recovered here as its own commit.

## What was measured

- `scripts/bun.sh run check` — exit 0 (biome + `tsc --noEmit`).
- `scripts/bun.sh run test` — 244 files / 4530 tests green, exit 0.
- The #973 test is not vacuous: unfolding the guard in
  `renameReadCursorChannel` turns it red, folded it is green.
- Both new e2e assertions are geometric (`boundingBox`), never
  `getComputedStyle`, which has already lied under device emulation
  (#963). The one computed-style assertion is the `@webkit` touch-action
  contract, where there is no geometry to measure and
  `ux-6-a-mobile-members-scroll.spec.ts` is the established precedent.

## What was NOT measured

The Playwright suite was not run locally — the stack lane was not
requested, and a cic-only change needs a rebuilt `runtime/e2e/cicchetto-dist`
to test anything at all. The three new e2e tests (2 in the #984 spec,
1 added to `issue157-delete-account.spec.ts`) are gated by this PR's CI,
which runs the full suite.