### PR TITLE
session(#978): capture RESETPASS, and only for our own account

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -32124,3 +32124,81 @@ Azzurra-shaped rules.
 
 The #131 entry above stands as the record of that day's reasoning; its
 "rest-of-line, may contain spaces" bullet is superseded here.
+## 2026-08-07 — RESETPASS is captured on-send, and it names the account it rotates
+
+`RESETPASS` was not in `NSInterceptor`'s verb set, so recovering a lost
+NickServ password from inside grappa left the credential holding the dead
+secret and every reconnect identified with it (#978). Hit in the wild: a
+visitor went `RECOVER` + `RESETPASS` and grappa kept the old password.
+
+**Third TOKEN, not rest-of-line.** `do_resetpass`
+(`azzurra/services@23473ed src/nickserv.c:3851`) pulls three
+`strtok(NULL, " ")` — nick, code, new password. So runs of spaces collapse,
+a fourth token is never read (services discard it), and the password cannot
+contain a space. That last part makes `do_resetpass`'s own
+`strchr(newpass, ' ')` guard (`:3917`) dead code upstream. This is the
+inverse of the #977 trap on the sibling verb, where the same instinct
+("`strtok` means rest-of-line") stored two concatenated tokens: both verbs
+were read off the source rather than pattern-matched against each other.
+
+**No bare form.** `IDENTIFY`/`ID`/`SIDENTIFY`/`PASS` are captured bare
+because the ircd implements them (`m_identify`, `m_pass`). `RESETPASS` is
+not in `azzurra/bahamut include/msg.h`'s message table at all — it exists
+only as a services command — so a bare `RESETPASS …` reaches nobody and the
+regex requires the `PRIVMSG NickServ` / `NS` / `NICKSERV` prefix.
+
+**On-send, and staging against `+r` is not merely awkward — it is
+impossible.** The obvious move is to copy the `:identify` family's `+r`
+rendezvous, and it is wrong here for a structural reason: `do_resetpass`
+ends with `user_remove_id(ni->nick, FALSE)` (`:3948`), so a SUCCESSFUL reset
+DE-identifies the caller instead of granting `+r`. A staged capture would
+wait for a confirmation that can never arrive, and
+`visitor_r_effects/3` would discard it on the 10s timeout. RESETPASS
+therefore joins `:set_passwd` on the optimistic commit-on-send path (#131).
+
+**The optimistic commit's divergence is accepted, again.** If services
+refuse the line for a reason we cannot see — nick not registered / frozen /
+no `NI_PASSRESET` / the code expired or wrong — we have already written.
+That is the same residue #977 declared for the old password, it is NOT
+closable by staging (see above), and #124's re-auth-on-identify-failure
+prompt remains the backstop. What IS mirrored is the password guard chain
+services apply before committing — and it is the SAME chain in both
+handlers, against the same constants (`:3917`-`:3934` vs `:2210`-`:2226`),
+so #978 folded #977's copy into one shared `vet_new_password/3`: spaces,
+nick-or-under-5, over-`PASSMAX`, control codes, answered as
+`{:reject, kind, reason}` with the line still shipped and the DB untouched.
+Only the nick differs — `callerUser->nick` for SET PASSWD, the nick being
+RESET for RESETPASS — so the caller supplies it. The spaces arm is simply
+unreachable on the RESETPASS path, exactly as it is upstream; shared and
+unreachable beats duplicated and free to drift the next time Azzurra adds
+a rule.
+
+The auth code is deliberately not vetted even for shape.
+`strtoul(codestr, &err, 10)` accepts a leading sign, so a partial mirror
+would reject lines services accept — and the two failure directions are not
+symmetric: a false reject silently reinstates the exact bug #978 closes,
+while a false accept only re-enters a divergence already accepted here.
+
+**The ownership check is new, and it is what keeps the fix from being a
+regression.** RESETPASS is the only captured verb that NAMES the account it
+rotates, and that account need not be ours: the code arrives by email, so a
+user holding two nicks can recover the other one from this session.
+Committing that would store a stranger's secret in this credential —
+strictly worse than the stale secret #978 exists to replace. So the capture
+carries both operands (`{:capture, :reset_passwd, target_nick, password}`,
+the one non-uniform result shape) and `Session.Server` — not the pure
+interceptor — decides ownership, because ownership is session policy and
+needs the casemapping-aware `fold_key/2`. The compare is against
+`configured_nick/1` (the credential's `nick` column, #885), never the live
+nick: after a 433 fallback the live nick is precisely the wrong one, and it
+is the credential we are about to write.
+
+**Its own kind, for the log line.** `:reset_passwd` writes the same secret
+to the same row as `:set_passwd` through the same committers (extracted to
+`rotate_stored_password/2` — one write, two callers), but the two verbs fail
+differently and the SET PASSWD log lines would lie about it. `SET PASSWD`
+from an unidentified visitor is logged "services would reject it", which is
+true there and FALSE here: services accept a RESETPASS from an unidentified
+user — that is what the verb is for. All grappa lacks in that case is a
+stored secret to rotate, and the follow-up IDENTIFY binds the new one
+through the ordinary `+r` rendezvous.

--- a/lib/grappa/session/ns_interceptor.ex
+++ b/lib/grappa/session/ns_interceptor.ex
@@ -23,15 +23,18 @@ defmodule Grappa.Session.NSInterceptor do
     * `PASS <args>`                                     (ircd `m_pass` -> `m_identify`, post-connect)
     * `PRIVMSG NickServ[@host] :SET PASSWD <old> <new>` / `NS|NICKSERV SET PASSWD <old> <new>` /
       bare `SET PASSWD <old> <new>`                      (#131 — in-session password change)
+    * `PRIVMSG NickServ[@host] :RESETPASS <nick> <code> <new>` /
+      `NS|NICKSERV RESETPASS <nick> <code> <new>`        (#978 — account recovery)
 
   Every pattern is ANCHORED at line start (`^`) so a channel PRIVMSG body that
-  merely CONTAINS "identify"/"pass"/"set passwd" is never captured — raw IRC
+  merely CONTAINS "identify"/"pass"/"set passwd"/"resetpass" is never captured — raw IRC
   frames start with the command verb, PRIVMSGs start with `PRIVMSG`.
 
   Password extraction: last whitespace token for IDENTIFY/ID/SIDENTIFY/GHOST/
   PASS (`IDENTIFY [account] <pass>`, `GHOST <nick> <pass>`, `PASS [nick] <pass>`);
   FIRST token for REGISTER (`REGISTER <pass> <email>`); the SECOND token for
-  SET PASSWD (#977). The Azzurra verb is `SET PASSWD`, NOT `SET PASSWORD`
+  SET PASSWD (#977); the THIRD for RESETPASS (#978). The Azzurra verb is
+  `SET PASSWD`, NOT `SET PASSWORD`
   (`do_set` only routes `PASSWD`; `PASSWORD` errors), so the regex matches
   `PASSWD` exactly and lets `SET PASSWORD …` fall through untouched.
 
@@ -70,6 +73,63 @@ defmodule Grappa.Session.NSInterceptor do
   password from the line alone, so a mistyped one still commits optimistically
   — the #124 re-auth backstop, unchanged by #977).
 
+  ## RESETPASS: the THIRD token, and it names the account (#978)
+
+  Read off `azzurra/services@23473ed`, `src/nickserv.c:3851` (`do_resetpass`),
+  not inferred. The handler pulls three `strtok(NULL, " ")` in order — nick,
+  code, new password — so the secret is the third TOKEN, a fourth is never
+  read (services DISCARD anything after it), and runs of spaces collapse the
+  way `strtok` skips its delimiters. There is no `RESETPASS` in the ircd's
+  message table (`azzurra/bahamut include/msg.h` carries `IDENTIFY` and
+  `PASS`, no `RESETPASS`), so — unlike IDENTIFY/SET PASSWD — a BARE
+  `RESETPASS …` reaches no service and must not be captured.
+
+  The capture carries the TARGET NICK alongside the password, because
+  RESETPASS is the one verb here that names the account it rotates: it can
+  recover a nick that is not this session's. Whether that account is the one
+  this session's credential holds is the host's call (`Session.Server`, which
+  owns `configured_nick/1` and the casemapping-aware fold), so this module
+  reports both operands and judges neither.
+
+  ### It commits on-send and CANNOT stage against `+r`
+
+  `do_resetpass` ends with `user_remove_id(ni->nick, FALSE)` (`:3948`): a
+  SUCCESSFUL reset drops every current identification instead of granting
+  one. No `+r` follows, ever — so the `:identify` family's rendezvous is not
+  merely inconvenient here, it is structurally unreachable, and a staged
+  capture would wait for a confirmation that cannot arrive. RESETPASS
+  therefore commits optimistically on-send, like `:set_passwd` (#131).
+
+  ### Which guards are mirrored, and which cannot be
+
+  Since the commit is optimistic, a value services would refuse must never be
+  captured. `do_resetpass` (`:3917`-`:3934`) applies the SAME four password
+  guards as `do_set_password`, against the same constants, so both verbs run
+  one shared `vet_new_password/3` — spaces / nick-or-under-5 /
+  over-`PASSMAX` / control codes — answered as
+  `{:reject, :reset_passwd, reason}` with the services error constant as the
+  reason. The line still goes out; services notify the user.
+
+  Only the nick differs: `do_set_password` compares the new password against
+  `callerUser->nick`, `do_resetpass` against `ni->nick` — the nick being
+  RESET, which the line itself carries. And the shared spaces arm is dead on
+  this path, exactly as `do_resetpass`'s own `strchr(newpass, ' ')` is dead
+  upstream: `strtok(" ")` already ended the token at the first space.
+
+  Everything `do_resetpass` checks BEFORE the password — nick registered, not
+  forbidden, not frozen, `NI_PASSRESET` set, the code within `ONE_WEEK` of the
+  SENDPASS, and the code matching `ni->auth` — is services-side state this
+  module cannot see, so a doomed RESETPASS still commits optimistically
+  (#124's re-auth prompt is the backstop). The code is deliberately not vetted
+  even for shape: `strtoul(codestr, &err, 10)` accepts a leading sign, so a
+  partial mirror would reject lines services accept — and a false reject
+  silently reinstates the very bug #978 closes, while a false accept only
+  re-enters a divergence that is already accepted here.
+
+  A reject reason is therefore the notice the user receives only when those
+  earlier checks passed; it is a log-line detail, never a claim about what
+  services did.
+
   Boundary: inherits the parent `Grappa.Session` boundary (no `use Boundary`).
   """
 
@@ -85,20 +145,40 @@ defmodule Grappa.Session.NSInterceptor do
   in-session password change (#131): an already-identified session
   rotates its NickServ password, which emits NO `+r` transition — so the
   host commits it OPTIMISTICALLY on-send rather than staging it against a
-  rendezvous. The host maps verb → action; the interceptor only reports
-  which verb it saw.
+  rendezvous. `:reset_passwd` (#978) is the account-recovery sibling: it
+  commits on-send for a STRONGER reason — a successful RESETPASS
+  de-identifies the user, so no `+r` can ever follow — and it is the only
+  kind whose capture carries a second operand, the nick it rotates. The
+  host maps verb → action; the interceptor only reports which verb it saw.
   """
-  @type kind :: :identify | :register | :set_passwd
+  @type kind :: :identify | :register | :set_passwd | :reset_passwd
 
   @typedoc """
-  Why a syntactically-matched SET PASSWD was NOT captured: the name of the
-  services error the line will earn (`do_set_password`, `src/nickserv.c`).
-  `:syntax_error` is the one-token `SET PASSWD <new>` form, which Azzurra
-  rejects outright — services change nothing, so neither may we.
+  The two verbs that ROTATE a stored secret rather than prove one. They are
+  the only kinds that can be REJECTED — an optimistic on-send commit has no
+  take-backs, so a value services would refuse must be caught here, while a
+  wrong IDENTIFY password simply never reaches the DB.
   """
-  @type reject_reason ::
-          :syntax_error
-          | :password_with_spaces
+  @type rotation_kind :: :set_passwd | :reset_passwd
+
+  @typedoc """
+  Why a syntactically-matched rotation verb was NOT captured: the name of the
+  services error the line will earn (`do_set_password` / `do_resetpass`,
+  `src/nickserv.c`) — for RESETPASS, if it gets that far. `:syntax_error` is
+  the one-token `SET PASSWD <new>` form and the under-three-tokens RESETPASS,
+  both refused outright — services change nothing, so neither may we. It is
+  raised while PARSING, which is why it is not a `vet_reject_reason/0`: the
+  shared guard chain only ever sees a line that already tokenised.
+  """
+  @type reject_reason :: :syntax_error | vet_reject_reason()
+
+  @typedoc """
+  The four guards `do_set_password` and `do_resetpass` share, verbatim.
+  `:password_with_spaces` cannot arise on the RESETPASS path: `strtok(" ")`
+  ends the token at the first space, so its third token can never hold one.
+  """
+  @type vet_reject_reason ::
+          :password_with_spaces
           | :insecure_password
           | :password_max_length
           | :password_with_ccodes
@@ -106,10 +186,11 @@ defmodule Grappa.Session.NSInterceptor do
   @type result ::
           :passthrough
           | {:capture, kind(), String.t()}
-          | {:reject, :set_passwd, reject_reason()}
+          | {:capture, :reset_passwd, String.t(), String.t()}
+          | {:reject, rotation_kind(), reject_reason()}
 
   # `azzurra/services@23473ed inc/config.h:96` — `#define PASSMAX 32`, and
-  # `do_set_password` rejects under 5. Compile-time defines, not conf knobs.
+  # both handlers reject under 5. Compile-time defines, not conf knobs.
   @passmax 32
   @passmin 5
 
@@ -140,28 +221,77 @@ defmodule Grappa.Session.NSInterceptor do
   # `SET PASSWD` reaches the same `:syntax_error` verdict as `SET PASSWD x`.
   @set_passwd_re ~r/^(?:PRIVMSG\s+NickServ(?:@\S+)?\s+:|(?:NS|NICKSERV)\s+)?SET +PASSWD(?: (.*))?$/i
 
+  # #978 — account-recovery RESETPASS. Same PRIVMSG-NickServ / NS-NICKSERV
+  # prefix family as `@verb_re`, but the prefix is NOT optional: RESETPASS is
+  # a services command with no ircd counterpart, so a bare line reaches
+  # nobody. The single group is services' argument string, VERBATIM and
+  # untrimmed — `split_resetpass/1` tokenises it the way `strtok(NULL, " ")`
+  # does, which is why the separator here is a LITERAL space rather than
+  # `\s`: a TAB is not a delimiter to services and must not become one here.
+  # The PRIVMSG prefix keeps `\s+` — that part is parsed by the ircd. The
+  # group is optional so a bare `RESETPASS` reaches the same `:syntax_error`
+  # verdict as `RESETPASS vjt`.
+  @resetpass_re ~r/^(?:PRIVMSG\s+NickServ(?:@\S+)?\s+:|(?:NS|NICKSERV)\s+)RESETPASS(?: (.*))?$/i
+
   @doc """
   Inspects one outbound IRC wire line and returns `:passthrough` (no NickServ
   secret-bearing verb detected), `{:capture, kind, password}` with the
   cleartext password lifted out and the verb class (`:identify` / `:register`
-  / `:set_passwd`) for the host to act on, or `{:reject, :set_passwd, reason}`
-  for a SET PASSWD services will refuse (#977).
+  / `:set_passwd`) for the host to act on,
+  `{:capture, :reset_passwd, target_nick, password}` for the one verb that
+  also names the account it rotates (#978), or `{:reject, kind, reason}` for
+  a rotation services will refuse (#977, #978).
 
   `nick` is the sender's CURRENT nick — `callerUser->nick` on the services
   side. `do_set_password` refuses a new password equal to it
   (`str_equals_nocase`), and this module refuses the same, so the nick is an
   input to the verdict rather than something the host re-checks afterwards.
+  It is NOT used on the RESETPASS path: `do_resetpass` compares against the
+  nick being RESET (`ni->nick`), which the line itself carries.
 
   Pure: no side effects. The host (`Grappa.Session.Server`) decides whether
   to stage against `+r` MODE (`:identify`/`:register`), commit optimistically
-  on-send (`:set_passwd`, #131), discard on the pending-auth timeout, or
-  overwrite on a subsequent capture.
+  on-send (`:set_passwd`, #131; `:reset_passwd`, #978 — and for the latter,
+  only when the target nick is this session's own account), discard on the
+  pending-auth timeout, or overwrite on a subsequent capture.
   """
   @spec intercept(String.t(), String.t()) :: result()
   def intercept(line, nick) when is_binary(line) and is_binary(nick) do
     case Regex.run(@verb_re, line, capture: :all_but_first) do
       [verb, rest] -> dispatch(String.upcase(verb), rest)
+      nil -> intercept_resetpass(line, nick)
+    end
+  end
+
+  # #978 — RESETPASS. Shares no verb with its siblings, so this check is
+  # order-independent w.r.t. `@verb_re`/`@set_passwd_re`/`@bare_re`/`@pass_re`.
+  defp intercept_resetpass(line, nick) do
+    case Regex.run(@resetpass_re, line, capture: :all_but_first) do
+      # `:re` TRIMS an unset trailing group, so a bare `RESETPASS` — verb and
+      # nothing else — arrives as `[]` rather than `[""]`.
+      [] -> {:reject, :reset_passwd, :syntax_error}
+      [args] -> split_resetpass(args)
       nil -> intercept_set_passwd(line, nick)
+    end
+  end
+
+  # Three `strtok(NULL, " ")` in a row: runs of spaces are skipped, empty
+  # tokens are never produced, and the third token ENDS at the next space —
+  # so a fourth is unread and the password cannot contain a space. Missing
+  # any of the three is NS_RESETPASS_SYNTAX_ERROR: services change nothing,
+  # so neither may we. The nick vetted against is the line's own first token
+  # (`ni->nick`), NOT the caller's — `do_resetpass` can reset another nick.
+  defp split_resetpass(args) do
+    # nick, code (services' to check), new password, then the discarded tail.
+    case String.split(args, " ", trim: true) do
+      [nick, _, new_password | _] ->
+        case vet_new_password(:reset_passwd, new_password, nick) do
+          :ok -> {:capture, :reset_passwd, nick, new_password}
+          reject -> reject
+        end
+
+      _ ->
+        {:reject, :reset_passwd, :syntax_error}
     end
   end
 
@@ -186,27 +316,48 @@ defmodule Grappa.Session.NSInterceptor do
   defp split_set_passwd(param, nick) do
     case String.split(param, " ", parts: 2) do
       # The head is the OLD password; grappa cannot vet it, services do.
-      [_, new_password] -> vet_new_password(new_password, nick)
-      [_] -> {:reject, :set_passwd, :syntax_error}
+      [_, new_password] ->
+        case vet_new_password(:set_passwd, new_password, nick) do
+          :ok -> {:capture, :set_passwd, new_password}
+          reject -> reject
+        end
+
+      [_] ->
+        {:reject, :set_passwd, :syntax_error}
     end
   end
 
-  # `do_set_password`'s guard chain, in ITS order — same order so the reason
-  # we report is the notice the user actually receives.
-  defp vet_new_password(new_password, nick) do
+  # The guard chain BOTH rotation handlers apply to a new password, in THEIR
+  # order — same order so the reason we report is the notice the user
+  # actually receives. `do_set_password` (`:2210`-`:2226`) and `do_resetpass`
+  # (`:3917`-`:3934`) run the identical four checks against the identical
+  # constants; only the nick they compare against differs, so the caller
+  # supplies it (`callerUser->nick` for SET PASSWD, the nick being RESET for
+  # RESETPASS). One chain, because a second copy would drift from the first
+  # the next time Azzurra adds a rule.
+  #
+  # The spaces arm cannot fire on the RESETPASS path: `strtok(" ")` ends the
+  # token at the first space, so its third token can never hold one — which
+  # is also why `do_resetpass`'s own `strchr(newpass, ' ')` (`:3917`) is dead
+  # code upstream. Shared and unreachable beats duplicated and divergent.
+  @spec vet_new_password(rotation_kind(), String.t(), String.t()) ::
+          :ok | {:reject, rotation_kind(), vet_reject_reason()}
+  defp vet_new_password(kind, new_password, nick) do
     cond do
-      String.contains?(new_password, " ") -> {:reject, :set_passwd, :password_with_spaces}
-      insecure?(new_password, nick) -> {:reject, :set_passwd, :insecure_password}
-      byte_size(new_password) > @passmax -> {:reject, :set_passwd, :password_max_length}
-      ccodes?(new_password) -> {:reject, :set_passwd, :password_with_ccodes}
-      true -> {:capture, :set_passwd, new_password}
+      String.contains?(new_password, " ") -> {:reject, kind, :password_with_spaces}
+      insecure?(new_password, nick) -> {:reject, kind, :insecure_password}
+      byte_size(new_password) > @passmax -> {:reject, kind, :password_max_length}
+      ccodes?(new_password) -> {:reject, kind, :password_with_ccodes}
+      true -> :ok
     end
   end
 
-  # `str_equals_nocase(callerUser->nick, newpass) || (str_len(newpass) < 5)`.
-  # `str_len` is a BYTE count, and the case-insensitive compare is the plain
-  # ASCII one — `Identifier.canonical_target/1`, per the project-wide rule
-  # that no nick comparison uses a bare `String.downcase/1`.
+  # `str_equals_nocase(<nick>, newpass) || (str_len(newpass) < 5)` — the nick
+  # being `callerUser->nick` in `do_set_password` and `ni->nick` (the reset
+  # target, up to case: `findnick` matches case-insensitively) in
+  # `do_resetpass`. `str_len` is a BYTE count, and the case-insensitive
+  # compare is the plain ASCII one — `Identifier.canonical_target/1`, per the
+  # project-wide rule that no nick comparison uses a bare `String.downcase/1`.
   defp insecure?(new_password, nick) do
     byte_size(new_password) < @passmin or
       Identifier.canonical_target(new_password) == Identifier.canonical_target(nick)

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -3935,6 +3935,21 @@ defmodule Grappa.Session.Server do
 
         state
 
+      # #978 — RESETPASS also commits on-send, and for a stronger reason:
+      # `do_resetpass` de-identifies the user, so the `+r` a staged capture
+      # would rendezvous with can never arrive.
+      {:capture, :reset_passwd, target_nick, new_password} ->
+        commit_reset_passwd(state, target_nick, new_password)
+
+      # #978 — the same posture as the SET PASSWD reject above, for the
+      # sibling verb's own guard chain.
+      {:reject, :reset_passwd, reason} ->
+        Logger.debug("RESETPASS not committed — services would reject it (#{reason})",
+          verb: :ns_reset_passwd
+        )
+
+        state
+
       :passthrough ->
         state
     end
@@ -3990,32 +4005,92 @@ defmodule Grappa.Session.Server do
   # (`Credentials.commit_password/3`). Returns `state` unchanged — the
   # commit is a side-effect (DB write), there's no capture slot to stage.
   @spec commit_set_passwd(t(), String.t()) :: t()
-  defp commit_set_passwd(%{subject: {:visitor, visitor_id}, visitor_password_rotator: rotator} = state, new_password)
-       when is_function(rotator, 2) do
-    log_set_passwd_commit(rotator.(visitor_id, new_password), visitor_id: visitor_id)
+  defp commit_set_passwd(state, new_password) do
+    {result, meta} = rotate_stored_password(state, new_password)
+    log_set_passwd_commit(result, meta)
     state
   end
 
-  defp commit_set_passwd(%{subject: {:user, user_id}, credential_committer: committer} = state, new_password)
-       when is_function(committer, 1) do
-    log_set_passwd_commit(committer.(new_password), user: user_id)
+  # Picks the committer for this subject and runs it, returning the result
+  # plus the Logger metadata naming the credential home. Shared by the two
+  # optimistic on-send rotations (SET PASSWD #131, RESETPASS #978) — they
+  # write the same secret to the same row and differ only in what they log,
+  # so the verb-specific part is the log helper, not the write.
+  #
+  # `{:error, :no_committer}` means no committer in the plan: a test fixture
+  # / Bootstrap path without injection, or a pre-#131 session HOT-reloaded
+  # before the `credential_committer` / `visitor_password_rotator` field
+  # existed (the struct-key patterns fail to match, so we land on the
+  # catch-all rather than crashing). The capture is observed but not
+  # persisted; the operator-visible signal is the caller's log line, and
+  # #124's re-auth recovers the now-stale stored password on the next
+  # identify. A cold restart re-inits with the committer wired.
+  @spec rotate_stored_password(t(), String.t()) :: {{:ok, term()} | {:error, term()}, keyword()}
+  defp rotate_stored_password(%{subject: {:visitor, visitor_id}, visitor_password_rotator: rotator}, new_password)
+       when is_function(rotator, 2),
+       do: {rotator.(visitor_id, new_password), [visitor_id: visitor_id]}
+
+  defp rotate_stored_password(%{subject: {:user, user_id}, credential_committer: committer}, new_password)
+       when is_function(committer, 1),
+       do: {committer.(new_password), [user: user_id]}
+
+  defp rotate_stored_password(_, _), do: {{:error, :no_committer}, []}
+
+  # #978 — RESETPASS names the account it rotates, and it need not be ours:
+  # the code is emailed, so a user holding two nicks can recover the other
+  # one from this session. Committing that would store a secret belonging to
+  # a different account in this credential — strictly worse than the stale
+  # secret #978 exists to replace. The compare is against
+  # `configured_nick/1` (the credential's `nick` column, #885), NOT the live
+  # nick: after a 433 fallback the live nick is precisely the wrong one, and
+  # it is the credential we are about to write.
+  @spec commit_reset_passwd(t(), String.t(), String.t()) :: t()
+  defp commit_reset_passwd(state, target_nick, new_password) do
+    if fold_key(state, target_nick) == fold_key(state, configured_nick(state)) do
+      {result, meta} = rotate_stored_password(state, new_password)
+      log_reset_passwd_commit(result, meta)
+    else
+      Logger.debug(
+        "RESETPASS targets another account (#{target_nick}) — this credential left alone",
+        verb: :ns_reset_passwd
+      )
+    end
+
     state
   end
 
-  # No committer in the plan: a test fixture / Bootstrap path without
-  # injection, or a pre-#131 session HOT-reloaded before the
-  # `credential_committer` / `visitor_password_rotator` field existed (the
-  # struct-key pattern above fails to match, so we land here rather than
-  # crashing). The capture is observed but not persisted; the
-  # operator-visible signal is this log line, and #124's re-auth recovers
-  # the now-stale stored password on the next identify. A cold restart
-  # re-inits with the committer wired.
-  defp commit_set_passwd(state, _) do
-    Logger.error("SET PASSWD captured but no committer in plan — not persisted",
-      verb: :ns_set_passwd
+  defp log_reset_passwd_commit({:ok, _}, meta) do
+    Logger.info(
+      "RESETPASS captured → stored credential updated (optimistic, #978)",
+      Keyword.put(meta, :verb, :ns_reset_passwd)
     )
+  end
 
-    state
+  # A visitor whose credential never held a password. NOT the SET PASSWD
+  # case: services accept a RESETPASS from an unidentified user — that is
+  # what the verb is FOR — so this is not "services would reject it". We
+  # simply have no stored secret to rotate, and `rotate_password/3` refuses
+  # to promote an anon row on an optimistic write. The follow-up IDENTIFY
+  # binds the new secret through the `+r` rendezvous instead.
+  defp log_reset_passwd_commit({:error, :not_identified}, meta) do
+    Logger.debug(
+      "RESETPASS from a visitor with no stored credential — nothing to rotate",
+      Keyword.put(meta, :verb, :ns_reset_passwd)
+    )
+  end
+
+  defp log_reset_passwd_commit({:error, :no_committer}, meta) do
+    Logger.error(
+      "RESETPASS captured but no committer in plan — not persisted",
+      Keyword.put(meta, :verb, :ns_reset_passwd)
+    )
+  end
+
+  defp log_reset_passwd_commit({:error, reason}, meta) do
+    Logger.error(
+      "RESETPASS captured but credential commit failed",
+      meta |> Keyword.put(:reason, inspect(reason)) |> Keyword.put(:verb, :ns_reset_passwd)
+    )
   end
 
   defp log_set_passwd_commit({:ok, _}, meta) do
@@ -4031,6 +4106,13 @@ defmodule Grappa.Session.Server do
   defp log_set_passwd_commit({:error, :not_identified}, meta) do
     Logger.debug(
       "SET PASSWD from unidentified visitor — not committed (services would reject)",
+      Keyword.put(meta, :verb, :ns_set_passwd)
+    )
+  end
+
+  defp log_set_passwd_commit({:error, :no_committer}, meta) do
+    Logger.error(
+      "SET PASSWD captured but no committer in plan — not persisted",
       Keyword.put(meta, :verb, :ns_set_passwd)
     )
   end

--- a/test/grappa/session/ns_interceptor_test.exs
+++ b/test/grappa/session/ns_interceptor_test.exs
@@ -238,4 +238,109 @@ defmodule Grappa.Session.NSInterceptorTest do
       assert :passthrough = intercept("PRIVMSG NickServ :HELP SET PASSWD")
     end
   end
+
+  # #978 — the account-recovery sibling. `do_resetpass` takes THREE
+  # `strtok(NULL, " ")` — nick, code, new password — so the secret is the
+  # third TOKEN, and everything after it is discarded by services. The
+  # capture carries the target nick too: RESETPASS names the account it
+  # rotates, and only the host knows whether that account is ours.
+  describe "intercept/2 — RESETPASS (#978)" do
+    test "PRIVMSG NickServ :RESETPASS nick code new → captures the THIRD token" do
+      assert {:capture, :reset_passwd, "vjt", "newpassword"} =
+               intercept("PRIVMSG NickServ :RESETPASS vjt 12345 newpassword")
+    end
+
+    test "NS / NICKSERV RESETPASS server-command form" do
+      assert {:capture, :reset_passwd, "vjt", "newpassword"} =
+               intercept("NS RESETPASS vjt 12345 newpassword")
+
+      assert {:capture, :reset_passwd, "vjt", "newpassword"} =
+               intercept("NICKSERV RESETPASS vjt 12345 newpassword")
+    end
+
+    test "fully-qualified NickServ@services target" do
+      assert {:capture, :reset_passwd, "vjt", "newpassword"} =
+               intercept("PRIVMSG NickServ@services.azzurra.chat :RESETPASS vjt 12345 newpassword")
+    end
+
+    test "case-insensitive verb match" do
+      assert {:capture, :reset_passwd, "vjt", "newpassword"} =
+               intercept("privmsg nickserv :resetpass vjt 12345 newpassword")
+    end
+
+    test "there is NO bare form — RESETPASS is not an ircd command" do
+      assert :passthrough = intercept("RESETPASS vjt 12345 newpassword")
+    end
+
+    test "a fourth token is DISCARDED — strtok stops at the third" do
+      assert {:capture, :reset_passwd, "vjt", "newpassword"} =
+               intercept("NS RESETPASS vjt 12345 newpassword and more")
+    end
+
+    test "runs of spaces collapse — strtok skips its delimiters" do
+      assert {:capture, :reset_passwd, "vjt", "newpassword"} =
+               intercept("NS RESETPASS  vjt   12345   newpassword  ")
+    end
+
+    test "fewer than three tokens is a syntax error upstream — never a capture" do
+      assert {:reject, :reset_passwd, :syntax_error} =
+               intercept("NS RESETPASS")
+
+      assert {:reject, :reset_passwd, :syntax_error} =
+               intercept("NS RESETPASS vjt")
+
+      assert {:reject, :reset_passwd, :syntax_error} =
+               intercept("PRIVMSG NickServ :RESETPASS vjt 12345")
+
+      # Trailing space: services' third `strtok` still returns NULL.
+      assert {:reject, :reset_passwd, :syntax_error} =
+               intercept("PRIVMSG NickServ :RESETPASS vjt 12345 ")
+    end
+
+    test "a password under 5 bytes is refused (CSNS_ERROR_INSECURE_PASSWORD)" do
+      assert {:reject, :reset_passwd, :insecure_password} =
+               intercept("NS RESETPASS vjt 12345 abcd")
+    end
+
+    test "a password equal to the TARGET nick is refused, case-insensitively" do
+      assert {:reject, :reset_passwd, :insecure_password} =
+               intercept("NS RESETPASS vjtvjt 12345 VJTVJT")
+    end
+
+    test "that compare is against the reset TARGET, not the caller's nick" do
+      # `do_resetpass` checks `ni->nick`, the nick being reset — unlike
+      # `do_set_password`, which checks `callerUser->nick` (`@nick` here).
+      assert {:capture, :reset_passwd, "othernick", @nick} =
+               intercept("NS RESETPASS othernick 12345 #{@nick}")
+
+      assert {:reject, :reset_passwd, :insecure_password} =
+               intercept("NS RESETPASS #{@nick} 12345 #{String.upcase(@nick)}")
+    end
+
+    test "a password over PASSMAX=32 bytes is refused" do
+      assert {:reject, :reset_passwd, :password_max_length} =
+               intercept("NS RESETPASS vjt 12345 #{String.duplicate("a", 33)}")
+
+      assert {:capture, :reset_passwd, "vjt", _} =
+               intercept("NS RESETPASS vjt 12345 #{String.duplicate("a", 32)}")
+    end
+
+    test "control codes are refused — including the byte 160 string_has_ccodes rejects" do
+      assert {:reject, :reset_passwd, :password_with_ccodes} =
+               intercept("NS RESETPASS vjt 12345 new\x02pass")
+
+      # A TAB is not a strtok(" ") delimiter, so it lands INSIDE the token —
+      # and services refuse it as a control code.
+      assert {:reject, :reset_passwd, :password_with_ccodes} =
+               intercept("NS RESETPASS vjt 12345 new\tpass")
+
+      assert {:reject, :reset_passwd, :password_with_ccodes} =
+               intercept("NS RESETPASS vjt 12345 new" <> <<160>> <> "pass")
+    end
+
+    test "ANCHORING: a channel message / HELP that merely contains RESETPASS is passthrough" do
+      assert :passthrough = intercept("PRIVMSG #chan :RESETPASS vjt 12345 lolwhat")
+      assert :passthrough = intercept("PRIVMSG NickServ :HELP RESETPASS")
+    end
+  end
 end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -7060,6 +7060,120 @@ defmodule Grappa.Session.ServerTest do
     end
   end
 
+  # #978 — account-recovery RESETPASS. The stored secret after a lost
+  # password is by definition the wrong one, so learning the new one is the
+  # whole point. It commits on-send for a reason SET PASSWD does not share:
+  # a successful `do_resetpass` calls `user_remove_id`, so the `+r` a staged
+  # capture would wait for can never arrive.
+  describe "RESETPASS → optimistic commit-on-send (#978)" do
+    test "user session: RESETPASS on our own nick stores the THIRD token" do
+      {server, port} = start_server()
+
+      {user, network, _} =
+        setup_user_and_network(port, %{auth_method: :nickserv_identify, password: "oldpass"})
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      assert {:ok, :no_persist} =
+               Session.send_privmsg(
+                 {:user, user.id},
+                 network.id,
+                 "NickServ",
+                 "RESETPASS grappa-test 12345 newpassword"
+               )
+
+      state = SessionStateHelpers.fetch(pid)
+
+      # Before #978 this line was passthrough: the credential kept the dead
+      # secret and every reconnect identified with it.
+      assert Credentials.get_credential!(user, network).password_encrypted == "newpassword"
+
+      # Committed, not staged — no `+r` was fed and none is coming.
+      assert is_nil(SessionStateHelpers.pending_auth(state))
+      assert is_nil(SessionStateHelpers.pending_auth_timer(state))
+      assert is_nil(SessionStateHelpers.pending_registration_secret(state))
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "user session: RESETPASS on ANOTHER nick leaves our credential alone" do
+      {server, port} = start_server()
+
+      {user, network, _} =
+        setup_user_and_network(port, %{auth_method: :nickserv_identify, password: "oldpass"})
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      assert {:ok, :no_persist} =
+               Session.send_privmsg(
+                 {:user, user.id},
+                 network.id,
+                 "NickServ",
+                 "RESETPASS someoneelse 12345 newpassword"
+               )
+
+      _ = SessionStateHelpers.fetch(pid)
+
+      # RESETPASS names the account it rotates, and that one is not ours:
+      # committing here would store a stranger's secret in our row.
+      assert Credentials.get_credential!(user, network).password_encrypted == "oldpass"
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "user session: a RESETPASS Azzurra would refuse is not committed" do
+      {server, port} = start_server()
+
+      {user, network, _} =
+        setup_user_and_network(port, %{auth_method: :nickserv_identify, password: "oldpass"})
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      # Under 5 bytes — CSNS_ERROR_INSECURE_PASSWORD. Services change
+      # nothing, so an optimistic commit would desync the credential.
+      assert {:ok, :no_persist} =
+               Session.send_privmsg(
+                 {:user, user.id},
+                 network.id,
+                 "NickServ",
+                 "RESETPASS grappa-test 12345 abcd"
+               )
+
+      _ = SessionStateHelpers.fetch(pid)
+      assert Credentials.get_credential!(user, network).password_encrypted == "oldpass"
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    test "visitor session: RESETPASS rotates the stored visitor secret" do
+      {server, port} = start_server()
+      {visitor, network} = visitor_with_network(port)
+      # The incident shape: grappa holds a secret that no longer works, and
+      # the visitor recovers the account from inside grappa.
+      {:ok, _} = Grappa.Visitors.commit_password(visitor.id, network.id, "oldpass")
+      pid = start_visitor_session_for(visitor, network)
+      :ok = await_handshake(server)
+
+      assert {:ok, :no_persist} =
+               Session.send_privmsg(
+                 {:visitor, visitor.id},
+                 network.id,
+                 "NickServ",
+                 "RESETPASS #{visitor_nick(visitor)} 12345 newpassword"
+               )
+
+      _ = SessionStateHelpers.fetch(pid)
+
+      assert visitor_password(visitor, network) == "newpassword"
+      assert Credentials.visitor_registered?(visitor.id)
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+  end
+
   describe "001 RPL_WELCOME stages pending_auth for :nickserv_identify visitors (Task 16)" do
     test "registered visitor: 001 stages pending_auth + clears one-shot field" do
       nick = "v_t16_#{System.unique_integer([:positive])}"


### PR DESCRIPTION
Fixes the #978 gap: `RESETPASS` was not in `NSInterceptor`'s verb set, so
recovering a lost NickServ password from inside grappa left the credential
holding the dead secret — and every reconnect identified with it. Hit in the
wild: a visitor went `RECOVER` + `RESETPASS` and grappa kept the old password.

**HOT** — pure code (`ns_interceptor.ex`, `server.ex`), no migration, no
`mix.exs`, no config, no cic.

## What the source says (verified, not inferred)

`do_resetpass` (`azzurra/services@23473ed src/nickserv.c:3851`) pulls three
`strtok(NULL, " ")` — nick, code, new password:

- the secret is the **third token**; runs of spaces collapse and a fourth
  token is never read (services discard it);
- it therefore **cannot contain a space**, which makes the handler's own
  `strchr(newpass, ' ')` guard (`:3917`) dead code upstream;
- there is **no bare form** to capture: `RESETPASS` is absent from
  `azzurra/bahamut include/msg.h`'s message table, so a bare line reaches
  nobody. I fetched both files at the pinned ref rather than trusting the
  issue text — the `nickserv.c` copy is byte-identical to upstream's blob.

## On-send, per the ruling — and staging is not merely awkward here

`do_resetpass` ends with `user_remove_id(ni->nick, FALSE)` (`:3948`): a
SUCCESSFUL reset **de-identifies** the caller instead of granting `+r`. So
the `+r` rendezvous is structurally unreachable, not just inconvenient — a
staged capture would wait for a confirmation that can never arrive and then
time out. It joins `:set_passwd` on the optimistic commit-on-send path.

## What I refused to claim

- **The optimistic commit still diverges, and I did not try to cure it.**
  If services refuse for state we cannot see — nick not registered / frozen /
  no `NI_PASSRESET` / code expired or wrong — we have already written. Same
  residue #977 declared; #124 is the backstop. Declared, not closed.
- **The auth code is deliberately not vetted, even for shape.**
  `strtoul(codestr, &err, 10)` accepts a leading sign, so a partial mirror
  would reject lines services accept. The two directions are not symmetric: a
  false reject silently reinstates the exact bug this PR closes, a false
  accept only re-enters the divergence already accepted above.
- **`:reject` reasons are a log-line detail, not a claim about services.**
  They are the notice the user receives only when the earlier server-state
  checks passed; the outcome (never write) is right either way.
- **The e2e/integration suite was not run** — `scripts/check.sh` only.

## The one thing I added beyond the brief

RESETPASS is the only captured verb that **names the account it rotates**,
and the emailed code means it need not be ours (a user holding two nicks can
recover the other from this session). A naive fix would store a stranger's
secret in our credential — strictly worse than the stale one #978 exists to
replace, i.e. the fix would create a new bug. So the capture carries both
operands and `Session.Server` decides ownership against `configured_nick/1`
(#885, the credential's `nick`) rather than the live nick, using the
casemapping-aware fold: ownership is session policy, not IRC parsing. Say
the word and I'll drop it, but I'd rather not ship the fix without it.

## Guards: shared with #977, not copied

#977 landed while this was in flight, so I rebased onto it and folded the two
guard chains into one `vet_new_password/3`. Both handlers run the identical
four checks against the identical constants (`PASSMAX` 32, under-5,
`string_has_ccodes` = byte `<32 || ==160`, verified in `inc/config.h:96` and
`src/misc.c:1321`); only the nick differs — `callerUser->nick` for SET
PASSWD, the nick being RESET for RESETPASS — so the caller supplies it. The
spaces arm is unreachable on the RESETPASS path, exactly as upstream. Keeping
them separate as the issue implied would have been the "same problem, two
solutions" shape the standards ban. Per the brief I kept the validations in
`NSInterceptor` rather than the network-agnostic changeset: that is the layer
that speaks Azzurra.

Its own `:reset_passwd` kind, though — the write is shared
(`rotate_stored_password/2`, one committer pick, two callers) but the verbs
fail differently, and the SET PASSWD log lines would lie: "services would
reject it" is true of a SET PASSWD from an unidentified visitor and **false**
of a RESETPASS, which is precisely the verb for someone who cannot identify.

## Tests

Red first: the 11 new interceptor cases all returned `:passthrough` before
the change. The server-side ownership guard was proven load-bearing by
mutation (forcing the condition true makes the "another nick" test store
`newpassword` instead of `oldpass` — exactly one failure).

- `ns_interceptor_test.exs`: third token, fourth-token discard, collapsed
  spaces, no bare form, the three syntax-error shapes, each guard, TAB as a
  non-delimiter that lands in the token and trips the ccodes rule, and a pin
  that the insecure-password compare uses the reset TARGET, not the caller.
- `server_test.exs`: user session rotates on our own nick; another nick
  leaves the credential alone; a refused password is not committed; visitor
  session rotates (the reported incident's shape).

`scripts/check.sh` green end to end: 8 doctests, 54 properties, 5373 tests,
0 failures; Dialyzer `Total errors: 0`; Credo clean over 594 files; Sobelow
clean; `deps.audit` "No vulnerabilities found"; 336 bats ok.