### PR TITLE
cic(#986): lifecycle verbs move to the rail, behind a subject-true confirm

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -945,9 +945,10 @@ export async function openSettingsSection(
 
 // #500 — open the settings drawer ROOT (viewport-aware), returning the drawer
 // dialog locator. The sibling of openSettingsSection for specs that need the
-// drawer's main index itself — e.g. to reach the Admin Console entry
-// (admin-console-entry), which lives in the drawer, not in a #460 sub-section —
-// or to assert drawer chrome. The cog (aria-label "open settings" /
+// drawer's main index itself — to reach a main-page affordance (share session,
+// delete account) or to assert drawer chrome. (#986 — reaching the ADMIN
+// console is no longer one of those reasons: use openAdminConsole, which goes
+// through the rail.) The cog (aria-label "open settings" /
 // action-cluster-cog) now lives behind the RailActions launcher (#500):
 // openRailMenu reveals the menu (opening the rail drawer first on mobile), then
 // the cog is tapped. Idempotent — the open step is a no-op if the drawer is
@@ -963,40 +964,33 @@ export async function openSettingsDrawer(page: Page): Promise<Locator> {
   return page.getByRole("dialog", { name: /settings/i });
 }
 
-// Open the admin console — the SINGLE door for reaching AdminPane, the
-// sibling of openSettingsDrawer. The Admin Console entry lives INSIDE the
-// settings drawer, so this opens the drawer, clicks the entry (whose onClick
-// fires onClose() + onOpenAdmin()), then WAITS for the drawer to finish
-// closing before returning. That wait is load-bearing: `.settings-drawer`
-// slides out over a 200ms `transform` transition (themes/default.css) at
-// z-index 100 anchored right, so a caller that clicks a right-side admin tab
-// (e.g. the 9th tab, Settings) the instant `admin-pane` mounts can land the
-// click on the STILL-SLIDING drawer instead of the tab. The tab's onClick is
-// a pure synchronous signal, so a swallowed click simply never switches the
-// tab — no product defect, a delivery race. This race is pre-existing and
-// LATENT across the ~20 admin specs that hand-roll `admin-console-entry`
-// .click(); centralizing the wait here fixes the whole class in ONE place
-// (follow-up issue tracks migrating the remaining specs onto this primitive).
-// Surfaced as a ~9% flake once #508's iOS font floor perturbed the layout
-// timing. Returns the admin-pane locator so callers scope assertions to it.
+// Open the admin console — the SINGLE door for reaching AdminPane.
+//
+// #986 — that door is now the rail's 🔧 admin launcher, not the settings
+// drawer. The drawer's "admin console" entry was an exact duplicate of it
+// (same isAdmin() gate, same setSelectedChannel({kind:"admin"}) payload) and
+// was removed along with its `onOpenAdmin` prop; every spec that used to
+// hand-roll `admin-console-entry` .click() now comes through here.
+//
+// The route through the rail also RETIRES the flake this helper was written
+// to absorb. Reaching admin via the drawer meant clicking an entry that
+// closed the drawer, and `.settings-drawer` slides out over a 200ms
+// `transform` at z-index 100 anchored right — so a caller that clicked a
+// right-side admin tab (Settings is the 9th of 10) the instant `admin-pane`
+// mounted could land the click on the STILL-SLIDING drawer. That is why the
+// old body waited for `not.toBeInViewport()` before returning. The rail
+// launcher opens no drawer at all: `openAdminPanel` closes members +
+// settings + archive and sets selection, so there is nothing left mid-
+// transition over the tabs. (Surfaced as a ~9% flake once #508's iOS font
+// floor perturbed the layout timing; the pre-#986 mitigation is now
+// structural.)
+//
+// Returns the admin-pane locator so callers scope assertions to it.
 export async function openAdminConsole(page: Page): Promise<Locator> {
-  const drawer = await openSettingsDrawer(page);
-  await page.getByTestId("admin-console-entry").click();
-  // The entry closes the drawer AND opens admin. The drawer stays MOUNTED
-  // (SettingsDrawer keeps it in the DOM across open/close — a CSS `.open`
-  // toggle, not a <Show>): closing only strips `.open`, which STARTS a 200ms
-  // `translateX(100%)` slide-out (themes/default.css, z-index 100, anchored
-  // right). Waiting on `.settings-drawer.open` count→0 returned at the slide's
-  // START, with the drawer still on-screen covering the right-side admin tabs
-  // (Settings is the 9th of 10) → a caller's tab click landed on the sliding
-  // drawer and was swallowed. The closed drawer changes NO
-  // visibility/display/pointer-events (so toBeHidden never fires — an
-  // off-screen transform is still "visible" to Playwright); instead wait until
-  // it has fully slid OUT of the viewport (transition settled at
-  // translateX(100%)), the instant it can no longer intercept the next click.
-  await expect(drawer).not.toBeInViewport({ timeout: 5_000 });
+  await openRailMenu(page);
+  await page.getByTestId("mobile-panel-admin").click();
   const pane = page.getByTestId("admin-pane");
-  await expect(pane).toBeVisible({ timeout: 5_000 });
+  await expect(pane).toBeVisible({ timeout: 10_000 });
   return pane;
 }
 

--- a/cicchetto/e2e/tests/admin-credentials.spec.ts
+++ b/cicchetto/e2e/tests/admin-credentials.spec.ts
@@ -10,7 +10,7 @@
 // vjt/bahamut-test credential (it's load-bearing for other specs).
 
 import { expect, test } from "../fixtures/test";
-import { openSettingsDrawer, expectShellReady } from "../fixtures/cicchettoPage";
+import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 
@@ -31,10 +31,7 @@ async function adminLogin(
 }
 
 async function openCredentialsTab(page: import("@playwright/test").Page): Promise<void> {
-  await openSettingsDrawer(page);
-  await expect(page.getByRole("dialog", { name: /settings/i })).toBeVisible();
-  await page.getByTestId("admin-console-entry").click();
-  await expect(page.getByTestId("admin-pane")).toBeVisible();
+  await openAdminConsole(page);
   await page.getByTestId("admin-tab-credentials").click();
   await expect(page.getByTestId("admin-credentials-table")).toBeVisible({ timeout: 10_000 });
 }

--- a/cicchetto/e2e/tests/admin-network-crud.spec.ts
+++ b/cicchetto/e2e/tests/admin-network-crud.spec.ts
@@ -10,7 +10,7 @@
 // suffix) and best-effort delete in finally.
 
 import { expect, test } from "../fixtures/test";
-import { openSettingsDrawer, expectShellReady } from "../fixtures/cicchettoPage";
+import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 
@@ -36,10 +36,7 @@ async function adminLogin(
 }
 
 async function openNetworksTab(page: import("@playwright/test").Page): Promise<void> {
-  await openSettingsDrawer(page);
-  await expect(page.getByRole("dialog", { name: /settings/i })).toBeVisible();
-  await page.getByTestId("admin-console-entry").click();
-  await expect(page.getByTestId("admin-pane")).toBeVisible();
+  await openAdminConsole(page);
   await page.getByTestId("admin-tab-networks").click();
   await expect(page.getByTestId("admin-networks-table")).toBeVisible({ timeout: 10_000 });
 }

--- a/cicchetto/e2e/tests/admin-server-crud.spec.ts
+++ b/cicchetto/e2e/tests/admin-server-crud.spec.ts
@@ -9,7 +9,7 @@
 // pollute the seeded networks' server lists).
 
 import { expect, test } from "../fixtures/test";
-import { openSettingsDrawer, expectShellReady } from "../fixtures/cicchettoPage";
+import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 
@@ -30,10 +30,7 @@ async function adminLogin(
 }
 
 async function openNetworksTab(page: import("@playwright/test").Page): Promise<void> {
-  await openSettingsDrawer(page);
-  await expect(page.getByRole("dialog", { name: /settings/i })).toBeVisible();
-  await page.getByTestId("admin-console-entry").click();
-  await expect(page.getByTestId("admin-pane")).toBeVisible();
+  await openAdminConsole(page);
   await page.getByTestId("admin-tab-networks").click();
   await expect(page.getByTestId("admin-networks-table")).toBeVisible({ timeout: 10_000 });
 }

--- a/cicchetto/e2e/tests/admin-users.spec.ts
+++ b/cicchetto/e2e/tests/admin-users.spec.ts
@@ -14,7 +14,7 @@
 // best-effort delete via REST in finally to avoid leaking rows.
 
 import { expect, test } from "../fixtures/test";
-import { openSettingsDrawer, expectShellReady } from "../fixtures/cicchettoPage";
+import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 
@@ -35,10 +35,7 @@ async function adminLogin(
 }
 
 async function openUsersTab(page: import("@playwright/test").Page): Promise<void> {
-  await openSettingsDrawer(page);
-  await expect(page.getByRole("dialog", { name: /settings/i })).toBeVisible();
-  await page.getByTestId("admin-console-entry").click();
-  await expect(page.getByTestId("admin-pane")).toBeVisible();
+  await openAdminConsole(page);
   await page.getByTestId("admin-tab-users").click();
   await expect(page.getByTestId("admin-users-table")).toBeVisible({ timeout: 10_000 });
 }

--- a/cicchetto/e2e/tests/admin-visitors-layout.spec.ts
+++ b/cicchetto/e2e/tests/admin-visitors-layout.spec.ts
@@ -28,7 +28,7 @@
 // via REST, log in as the seeded admin, open AdminPane → Visitors tab).
 
 import { expect, test } from "../fixtures/test";
-import { openSettingsDrawer } from "../fixtures/cicchettoPage";
+import { openAdminConsole } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 
@@ -49,10 +49,7 @@ test("admin Visitors tab: per-network cell is separated + delete button stays in
       [admin.token, admin.subjectJson] as const,
     );
     await page.goto("/");
-    await openSettingsDrawer(page);
-    await expect(page.getByRole("dialog", { name: /settings/i })).toBeVisible();
-    await page.getByTestId("admin-console-entry").click();
-    await expect(page.getByTestId("admin-pane")).toBeVisible();
+    await openAdminConsole(page);
     await page.getByTestId("admin-tab-visitors").click();
     await expect(page.getByTestId("admin-visitors-table")).toBeVisible({ timeout: 10_000 });
 

--- a/cicchetto/e2e/tests/featured-channels.spec.ts
+++ b/cicchetto/e2e/tests/featured-channels.spec.ts
@@ -11,7 +11,7 @@
 // the seeded networks' featured lists.
 
 import { expect, test } from "../fixtures/test";
-import { openSettingsDrawer, expectShellReady } from "../fixtures/cicchettoPage";
+import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 
@@ -32,10 +32,7 @@ async function adminLogin(
 }
 
 async function openNetworksTab(page: import("@playwright/test").Page): Promise<void> {
-  await openSettingsDrawer(page);
-  await expect(page.getByRole("dialog", { name: /settings/i })).toBeVisible();
-  await page.getByTestId("admin-console-entry").click();
-  await expect(page.getByTestId("admin-pane")).toBeVisible();
+  await openAdminConsole(page);
   await page.getByTestId("admin-tab-networks").click();
   await expect(page.getByTestId("admin-networks-table")).toBeVisible({ timeout: 10_000 });
 }

--- a/cicchetto/e2e/tests/issue126-detach-lifecycle.spec.ts
+++ b/cicchetto/e2e/tests/issue126-detach-lifecycle.spec.ts
@@ -8,13 +8,17 @@
 // stable browser gate):
 //
 //   1. EPHEMERAL VISITOR GATING — a minted (anon, no NickServ identity)
-//      visitor's settings drawer offers ONLY "quit": no "detach", no
+//      visitor's rail actions menu offers ONLY "quit": no "detach", no
 //      "disconnect"/"reconnect", and the retired "log out" label is gone.
 //      RED before #126 (an ephemeral visitor saw a single "log out"
-//      button and no `quit-irc-btn`).
+//      button and no `quit-irc-btn`). #986 moved the surface from the
+//      settings drawer to the rail and put a confirm modal in front of the
+//      verb; the GATE is the same question, so this test follows it there —
+//      and now also pins the modal copy that gate earns, since an anon
+//      visitor is the one subject whose quit DESTROYS the session.
 //
 //   2. USER DETACH KEEPS THE BOUNCER (bug #1 + #2) — after a user detaches
-//      via the drawer, the web session ends (back to /login) but the
+//      via the rail, the web session ends (back to /login) but the
 //      server-side Session.Server + upstream IRC connection STAY UP: the
 //      autojoin channel is still `joined` server-side. RED before #126
 //      (logout called stop_all_user_sessions, tearing the upstream down →
@@ -27,7 +31,7 @@
 // RED run of this spec would tear the seeded session down).
 
 import { test, expect } from "../fixtures/test";
-import { openSettingsDrawer, loginAs } from "../fixtures/cicchettoPage";
+import { openRailMenu, loginAs } from "../fixtures/cicchettoPage";
 import {
   reapVisitors,
   GRAPPA_BASE_URL,
@@ -119,13 +123,11 @@ test.describe("issue #126 — detach lifecycle", () => {
         [visitor.token, subjectJson] as const,
       );
       await page.goto("/");
-      await openSettingsDrawer(page);
-      const drawer = page.getByRole("dialog", { name: /settings/i });
-      await expect(drawer).toHaveClass(/open/);
+      await openRailMenu(page);
 
       // The ONLY lifecycle verb an ephemeral visitor gets is quit.
       await expect(page.getByTestId("quit-irc-btn")).toBeVisible();
-      await expect(page.getByTestId("quit-irc-btn")).toHaveText(/^quit$/i);
+      await expect(page.getByTestId("quit-irc-btn")).toHaveText(/quit/i);
       // Persistent-identity verbs are withheld …
       await expect(page.getByTestId("detach-btn")).toHaveCount(0);
       await expect(page.getByTestId("disconnect-btn")).toHaveCount(0);
@@ -133,6 +135,20 @@ test.describe("issue #126 — detach lifecycle", () => {
       // … and the retired "log out" label is gone (positive twin so a
       // testid typo can't silently green this).
       await expect(page.getByText(/^log out$/i)).toHaveCount(0);
+
+      // #986 — and the copy in front of that verb must be the ANON one. This
+      // is the subject the issue was filed for: the server hard-deletes an
+      // unregistered visitor row on the way out (Visitors.purge_if_anon →
+      // destroy_visitor, CASCADE), so the modal has to say so BEFORE the tap.
+      // Asserted against a REAL minted anon visitor rather than a stubbed
+      // subject — the vitest can fake `registered: false`, only this can
+      // prove the shipped client classifies a real one that way. Cancel:
+      // this session is torn down by the finally block, not by the modal.
+      await page.getByTestId("quit-irc-btn").click();
+      await expect(page.getByTestId("confirm-modal-body")).toHaveText(/deletes it/i);
+      await expect(page.getByTestId("confirm-modal-body")).not.toHaveText(/survive/i);
+      await page.getByTestId("confirm-modal-cancel").click();
+      await expect(page.getByTestId("confirm-modal")).toHaveCount(0);
     } finally {
       await ctx.close();
       // Tear down the throwaway visitor's row + session (loud — see reapVisitors).
@@ -149,11 +165,13 @@ test.describe("issue #126 — detach lifecycle", () => {
 
     await loginAs(page, vjt);
 
-    // Detach via the drawer — the web session ends (back to /login) …
-    await openSettingsDrawer(page);
-    const drawer = page.getByRole("dialog", { name: /settings/i });
-    await expect(drawer).toHaveClass(/open/);
+    // Detach via the rail — #986 put a confirm modal in front of the verb,
+    // so the affirmative is what actually fires it. The web session then
+    // ends (back to /login) …
+    await openRailMenu(page);
     await page.getByTestId("detach-btn").click();
+    await expect(page.getByTestId("confirm-modal-body")).toHaveText(/keeps running/i);
+    await page.getByTestId("confirm-modal-confirm").click();
     await expect(page).toHaveURL(/\/login/, { timeout: 10_000 });
 
     // … but the bouncer STAYS UP: the upstream Session.Server survived, so

--- a/cicchetto/e2e/tests/issue157-delete-account.spec.ts
+++ b/cicchetto/e2e/tests/issue157-delete-account.spec.ts
@@ -27,7 +27,7 @@
 // DeleteAccountModal). Honest scope, mirroring issue126-detach-lifecycle.
 
 import { test, expect } from "../fixtures/test";
-import { openSettingsDrawer, expectShellReady } from "../fixtures/cicchettoPage";
+import { openSettingsDrawer, expectShellReady, openRailMenu, closeSettings } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL, login, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 
@@ -236,9 +236,16 @@ test.describe("issue #157 — delete account", () => {
       await openSettingsDrawer(page);
       await expect(page.getByRole("dialog", { name: /settings/i })).toHaveClass(/open/);
 
-      // The ephemeral visitor gets quit, never delete-account.
-      await expect(page.getByTestId("quit-irc-btn")).toBeVisible();
+      // The ephemeral visitor never gets delete-account. #986 moved the
+      // positive twin (quit) out of this drawer and into the rail, so the
+      // twin is asserted there — the drawer must show NEITHER, and the
+      // delete-account absence keeps a real positive control via the
+      // registered cases above.
       await expect(page.getByTestId("delete-account-btn")).toHaveCount(0);
+      await expect(page.getByTestId("quit-irc-btn")).toHaveCount(0);
+      await closeSettings(page);
+      await openRailMenu(page);
+      await expect(page.getByTestId("quit-irc-btn")).toBeVisible();
     } finally {
       await ctx.close();
       const admin = getSeededAdmin();

--- a/cicchetto/e2e/tests/issue215-session-log.spec.ts
+++ b/cicchetto/e2e/tests/issue215-session-log.spec.ts
@@ -15,7 +15,7 @@
 // `m11-admin-events-live.spec.ts`.
 
 import { expect, test } from "@playwright/test";
-import { openSettingsDrawer, expectShellReady } from "../fixtures/cicchettoPage";
+import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
 
 async function adminFriendlyLogin(
@@ -35,11 +35,7 @@ async function adminFriendlyLogin(
 }
 
 async function openAdminPane(page: import("@playwright/test").Page): Promise<void> {
-  await openSettingsDrawer(page);
-  const drawer = page.getByRole("dialog", { name: /settings/i });
-  await expect(drawer).toBeVisible();
-  await page.getByTestId("admin-console-entry").click();
-  await expect(page.getByTestId("admin-pane")).toBeVisible();
+  await openAdminConsole(page);
 }
 
 test("#215 Session Log tab renders the persisted session-lifecycle tail", async ({ page }) => {

--- a/cicchetto/e2e/tests/issue252-vhost-selector.spec.ts
+++ b/cicchetto/e2e/tests/issue252-vhost-selector.spec.ts
@@ -25,7 +25,7 @@
 // exercises the real CSS/DOM render path jsdom can't.
 
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
-import { openSettingsDrawer, expectShellReady } from "../fixtures/cicchettoPage";
+import { openSettingsDrawer, expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
 import { getSeededAdmin, getSeededVjt } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
@@ -45,10 +45,7 @@ async function loginAs(page: import("@playwright/test").Page, seed: Seed): Promi
 }
 
 async function openVhostsTab(page: import("@playwright/test").Page): Promise<void> {
-  await openSettingsDrawer(page);
-  await expect(page.getByRole("dialog", { name: /settings/i })).toBeVisible();
-  await page.getByTestId("admin-console-entry").click();
-  await expect(page.getByTestId("admin-pane")).toBeVisible();
+  await openAdminConsole(page);
   await page.getByTestId("admin-tab-vhosts").click();
   await expect(page.getByTestId("admin-vhosts-create-form")).toBeVisible({ timeout: 10_000 });
 }

--- a/cicchetto/e2e/tests/issue256-vhost-inpool-enforce.spec.ts
+++ b/cicchetto/e2e/tests/issue256-vhost-inpool-enforce.spec.ts
@@ -17,7 +17,7 @@
 // enforce-forward (tick → checked + disabled), not the read-side OR.
 
 import { expect, test } from "../fixtures/test";
-import { openSettingsDrawer, expectShellReady } from "../fixtures/cicchettoPage";
+import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 
@@ -38,10 +38,7 @@ async function adminLogin(
 }
 
 async function openVhostsTab(page: import("@playwright/test").Page): Promise<void> {
-  await openSettingsDrawer(page);
-  await expect(page.getByRole("dialog", { name: /settings/i })).toBeVisible();
-  await page.getByTestId("admin-console-entry").click();
-  await expect(page.getByTestId("admin-pane")).toBeVisible();
+  await openAdminConsole(page);
   await page.getByTestId("admin-tab-vhosts").click();
   await expect(page.getByTestId("admin-vhosts-table")).toBeVisible({ timeout: 10_000 });
 }

--- a/cicchetto/e2e/tests/issue257-vhost-subject-autocomplete.spec.ts
+++ b/cicchetto/e2e/tests/issue257-vhost-subject-autocomplete.spec.ts
@@ -16,7 +16,7 @@
 // typed nick — is the value proof.
 
 import { expect, test } from "../fixtures/test";
-import { openSettingsDrawer, expectShellReady } from "../fixtures/cicchettoPage";
+import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 
@@ -37,10 +37,7 @@ async function adminLogin(
 }
 
 async function openVhostsTab(page: import("@playwright/test").Page): Promise<void> {
-  await openSettingsDrawer(page);
-  await expect(page.getByRole("dialog", { name: /settings/i })).toBeVisible();
-  await page.getByTestId("admin-console-entry").click();
-  await expect(page.getByTestId("admin-pane")).toBeVisible();
+  await openAdminConsole(page);
   await page.getByTestId("admin-tab-vhosts").click();
   await expect(page.getByTestId("admin-vhosts-table")).toBeVisible({ timeout: 10_000 });
 }

--- a/cicchetto/e2e/tests/issue269-visitor-reconnect-toggle.spec.ts
+++ b/cicchetto/e2e/tests/issue269-visitor-reconnect-toggle.spec.ts
@@ -23,7 +23,7 @@
 // alone: the session genuinely goes down then up on the SPECIFIC network.
 
 import { expect, test } from "../fixtures/test";
-import { openSettingsDrawer } from "../fixtures/cicchettoPage";
+import { openAdminConsole } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 
@@ -40,10 +40,7 @@ async function adminOpenVisitorsTab(
     [seed.token, seed.subjectJson] as const,
   );
   await page.goto("/");
-  await openSettingsDrawer(page);
-  await expect(page.getByRole("dialog", { name: /settings/i })).toBeVisible();
-  await page.getByTestId("admin-console-entry").click();
-  await expect(page.getByTestId("admin-pane")).toBeVisible();
+  await openAdminConsole(page);
   await page.getByTestId("admin-tab-visitors").click();
   await expect(page.getByTestId("admin-visitors-table")).toBeVisible({ timeout: 10_000 });
 }

--- a/cicchetto/e2e/tests/issue281-account-switch-no-replay.spec.ts
+++ b/cicchetto/e2e/tests/issue281-account-switch-no-replay.spec.ts
@@ -59,11 +59,7 @@
 // genuine phantom, and (b) the real B login spawns NO upstream Session.Server,
 // so it can't dangle a session / cascade (feedback_e2e_real_login_poisons_shared_stack).
 
-import {
-  openSettingsDrawer,
-  waitForChannelReady,
-  waitForScrollbackRefreshed,
-} from "../fixtures/cicchettoPage";
+import { waitForChannelReady, waitForScrollbackRefreshed, openRailMenu } from "../fixtures/cicchettoPage";
 import { login } from "../fixtures/grappaApi";
 import {
   ADMIN_IDENTIFIER,
@@ -185,12 +181,13 @@ test.describe("issue #281 — account switch replay", () => {
     });
 
     // --- The account switch (the repro) ---
-    // Detach A via the settings drawer → back to /login. token → null,
+    // Detach A via the rail actions menu → back to /login. token → null,
     // in-context: pre-fix, A's Solid resources go STALE (not cleared).
-    await openSettingsDrawer(page);
-    const drawer = page.getByRole("dialog", { name: /settings/i });
-    await expect(drawer).toHaveClass(/open/);
+    // #986 — detach lives in the rail now and asks first; the affirmative is
+    // what fires it.
+    await openRailMenu(page);
     await page.getByTestId("detach-btn").click();
+    await page.getByTestId("confirm-modal-confirm").click();
     await expect(page).toHaveURL(/\/login/, { timeout: 10_000 });
 
     // Log back in as account B (admin-vjt — registered, password under the

--- a/cicchetto/e2e/tests/issue291-mobile-home-button.spec.ts
+++ b/cicchetto/e2e/tests/issue291-mobile-home-button.spec.ts
@@ -9,11 +9,9 @@
 // bottom of `.shell-members` — present on BOTH desktop and mobile and on
 // EVERY window kind. It supersedes the retired mobile-only
 // `.mobile-panel-actions` footer AND the post-#71 top ActionCluster: the
-// settings cog + denoise toggle now live in the rail too. So an admin on a
-// channel window sees SEVEN buttons — home, rooms (📇 $list), themes, archive,
-// settings (cog), admin, denoise — each keeping its testid (the $list launcher
-// is labelled "rooms" but keeps `mobile-panel-list`; the cog keeps
-// `action-cluster-cog`).
+// settings cog + denoise toggle now live in the rail too. Each keeps its
+// testid (the $list launcher is labelled "rooms" but keeps
+// `mobile-panel-list`; the cog keeps `action-cluster-cog`).
 //
 // This spec drives the real mobile layout (@webkit / iPhone 15): open the
 // drawer, assert the home launcher is present with its sibling launchers,
@@ -127,13 +125,16 @@ test.describe("#291 — home launcher in the rail actions drawer", () => {
     // channel window (it too folded into the rail).
     await expect(menu.locator("[data-testid='presence-toggle']")).toHaveCount(1);
 
-    // Every launcher is a proper mobile tap target (≥44px, #291). Seven buttons
-    // for an admin on a channel window: home, rooms, themes, archive, settings
-    // (cog), admin, denoise. #500 — scope the count to `.rail-actions-menu`: the
-    // pinned launcher ALSO carries `.shell-chrome-btn` but lives OUTSIDE the
-    // menu, so counting under the menu yields exactly the seven action buttons.
+    // Every launcher is a proper mobile tap target (≥44px, #291) — the actual
+    // #291 contract. This sweeps whatever the menu renders rather than pinning
+    // a total: the exhaustive "these buttons and no others" set is owned by
+    // issue473 ("rail hosts every labelled button"), and a total duplicated
+    // here reddened this spec the moment #986 added detach + quit, neither of
+    // which #291 has anything to say about. It cannot pass vacuously — the
+    // seven testids above are each asserted present in this same `menu`.
+    // #500 — scope to `.rail-actions-menu`: the pinned launcher ALSO carries
+    // `.shell-chrome-btn` but lives OUTSIDE the menu.
     const buttons = menu.locator(".shell-chrome-btn");
-    await expect(buttons).toHaveCount(7);
     const count = await buttons.count();
     for (let i = 0; i < count; i++) {
       const box = await buttons.nth(i).boundingBox();

--- a/cicchetto/e2e/tests/issue299-footer-admin-reachable.spec.ts
+++ b/cicchetto/e2e/tests/issue299-footer-admin-reachable.spec.ts
@@ -13,7 +13,7 @@
 //
 // The invariant this spec guards — "admin stays reachable" — is unchanged. It
 // drives the real mobile layout (@webkit / iPhone 15) and proves:
-//   (a) the rail hosts the full launcher set (themes PRESENT),
+//   (a) the themes launcher — the one that caused the clip — is PRESENT,
 //   (b) admin is present, ≥44px, and TAPPABLE (renders the AdminPane), and
 //   (c) themes is still reachable via the cog → themes nav row.
 // The themes launcher's own deep-link behaviour is owned by the issue332 spec;
@@ -107,15 +107,16 @@ test.describe("#299 — admin reachable from the rail actions drawer", () => {
     await openRailMenu(page);
     const railMenu = page.locator(".rail-actions-menu");
 
-    // #473/#500 — every launcher lives in the ONE `.rail-actions-menu`. An admin
-    // on a channel window sees SEVEN: home, rooms, themes, archive, settings
-    // (cog), admin, denoise. The themes launcher is PRESENT (its clip-vs-wrap
-    // history is moot now the rail is a flex column). The settings cog folded
-    // into the rail with the `action-cluster-cog` testid (no
-    // `mobile-panel-settings` button ever existed).
+    // #473/#500 — every launcher lives in the ONE `.rail-actions-menu`. The
+    // themes launcher is PRESENT (its clip-vs-wrap history is moot now the rail
+    // is a flex column) and it does NOT strand admin — the whole subject of
+    // this spec. The settings cog folded into the rail with the
+    // `action-cluster-cog` testid (no `mobile-panel-settings` button ever
+    // existed). The exhaustive "these and no others" total lives in issue473,
+    // which owns it: pinned here too it made THIS spec red for #986's detach +
+    // quit, an arrival that cannot strand anything.
     await expect(railMenu.locator("[data-testid='mobile-panel-themes']")).toHaveCount(1);
     await expect(railMenu.locator("[data-testid='action-cluster-cog']")).toHaveCount(1);
-    await expect(railMenu.locator(".shell-chrome-btn")).toHaveCount(7);
 
     // Admin is present AND a proper ≥44px tap target.
     const adminBtn = railMenu.locator("[data-testid='mobile-panel-admin']");

--- a/cicchetto/e2e/tests/issue43-split-logout.spec.ts
+++ b/cicchetto/e2e/tests/issue43-split-logout.spec.ts
@@ -2,76 +2,90 @@
 // the IRC session connected) and "quit" (park ALL networks + logout,
 // bouncer offline) for registered users.
 //
-// vitest (src/__tests__/SettingsDrawer.test.tsx) pins the WIRING with a
-// mocked quitAll — detach→logout, quit two-tap→quitAll, disarm-on-close,
-// visitor single button. This Playwright spec is the production-fidelity
-// confirmation per `feedback_ux_e2e_mandatory` + `_cicchetto_browser_smoke`:
-// it exercises the real CSS render + reactivity that jsdom cannot —
-//   * both buttons VISIBLE + clickable inside the open drawer overlay
-//     (the `_css_block_button_wraps_inline_prefix` clip class);
-//   * the destructive "quit" two-tap ARM guard in a real browser — one
-//     tap flips to the red `.confirming` confirm copy WITHOUT navigating;
-//   * the disarm-on-close effect firing through the real `.open` toggle.
+// #986 — both verbs moved OUT of the settings drawer and into the rail
+// actions menu, and the destructive gate changed shape with them: the
+// two-tap `InlineConfirmButton` arm is gone, replaced by the shared #195
+// confirm modal whose BODY states the per-subject consequence. The arm-guard
+// test below therefore became a modal-guard test. What the issue asserts is
+// unchanged: a registered user sees two distinct verbs, and the destructive
+// one cannot fire on a single tap.
 //
-// DELIBERATELY NOT EXERCISED HERE: the SECOND "quit" tap (fires quitAll →
-// parks vjt's network + logout) and a real "detach" click (DELETE
+// vitest (src/__tests__/RailActions.test.tsx) pins the WIRING with a mocked
+// quitAll — detach→logout, quit→quitAll, the three modal bodies, the gate.
+// This Playwright spec is the production-fidelity confirmation per
+// `feedback_ux_e2e_mandatory` + `_cicchetto_browser_smoke`: it exercises the
+// real CSS render + reactivity that jsdom cannot —
+//   * both entries VISIBLE + clickable inside the absolutely-positioned,
+//     max-height-capped RailActions menu (the
+//     `_css_block_button_wraps_inline_prefix` clip class);
+//   * the confirm modal painting OVER the rail (z-index 1000 vs the menu's
+//     301) carrying the real per-subject body text;
+//   * Cancel returning the operator to an untouched session.
+//
+// DELIBERATELY NOT EXERCISED HERE: the AFFIRMATIVE button (fires quitAll →
+// parks vjt's network + logout) and a confirmed "detach" (DELETE
 // /auth/logout revokes the bearer). vjt's seeded token + IRC session are
 // SHARED across the whole spec suite (see seedData.ts's cascade
 // warnings) — confirming quit would park the session and revoking the
 // bearer would 401 every downstream vjt spec. The quitAll park-all+logout
 // composite already has full-stack coverage in u-4-device-identity-change
-// + ux-4-z-cluster-journey; this spec owns the NEW render + arm-guard
+// + ux-4-z-cluster-journey; this spec owns the render + confirm-gate
 // surface only, not the (pre-covered) destructive composite. Every
 // interaction below is client-side state — zero server mutation.
 
-import { openSettingsDrawer, loginAs } from "../fixtures/cicchettoPage";
+import { openRailMenu, loginAs } from "../fixtures/cicchettoPage";
 import { getSeededVjt } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
-import { type Page } from "@playwright/test";
 
-async function openDrawer(page: Page) {
-  await openSettingsDrawer(page);
-  const drawer = page.getByRole("dialog", { name: /settings/i });
-  await expect(drawer).toHaveClass(/open/);
-  return drawer;
-}
-
-test("issue #43 — registered user sees detach + quit, not a bare 'log out'", async ({ page }) => {
+test("issue #43 — registered user sees detach + quit in the rail, not a bare 'log out'", async ({
+  page,
+}) => {
   await loginAs(page, getSeededVjt());
-  await openDrawer(page);
+  await openRailMenu(page);
 
   const detach = page.getByTestId("detach-btn");
   const quit = page.getByTestId("quit-irc-btn");
   await expect(detach).toBeVisible();
-  await expect(detach).toHaveText(/^detach$/i);
+  await expect(detach).toHaveText(/detach/i);
   await expect(quit).toBeVisible();
-  await expect(quit).toHaveText(/^quit$/i);
+  await expect(quit).toHaveText(/quit/i);
   // Positive twin for the negative assertion so a testid typo can't
   // silently green both paths (per the M-7 spec's polarity discipline).
   await expect(page.getByText(/^log out$/i)).toHaveCount(0);
 });
 
-test("issue #43 — quit arms on first tap (red confirm copy) and disarms on close", async ({
+test("issue #43/#986 — quit opens a confirm modal that explains, and Cancel changes nothing", async ({
   page,
 }) => {
   await loginAs(page, getSeededVjt());
-  const drawer = await openDrawer(page);
-  const quit = page.getByTestId("quit-irc-btn");
+  await openRailMenu(page);
 
-  // First tap arms — flips to the destructive confirm copy + the shared
-  // InlineConfirmButton `.confirming` red treatment. It must NOT navigate
-  // (arming alone never fires quitAll/logout).
-  await quit.click();
-  await expect(quit).toHaveText(/really quit IRC/i);
-  await expect(quit).toHaveClass(/confirming/);
+  // One tap must NOT tear anything down — it raises the modal.
+  await page.getByTestId("quit-irc-btn").click();
+  const modal = page.getByTestId("confirm-modal");
+  await expect(modal).toBeVisible();
+  // The body is the whole point of #986: a registered user is told the
+  // bouncer goes offline and the account SURVIVES — not the old six words
+  // ("really quit IRC?") that an anon visitor got for a different event.
+  await expect(page.getByTestId("confirm-modal-body")).toHaveText(/survive/i);
   await expect(page).not.toHaveURL(/\/login/);
 
-  // The drawer stays mounted across close (CSS .open toggle), so the
-  // createEffect disarm is the only thing standing between a stale armed
-  // button and a one-tap bouncer kill on reopen. Close → reopen → idle.
-  await page.getByTestId("settings-drawer-done").click();
-  await expect(drawer).not.toHaveClass(/open/);
-  await openSettingsDrawer(page);
-  await expect(drawer).toHaveClass(/open/);
-  await expect(quit).toHaveText(/^quit$/i);
+  // Cancel is the safe default (#195): it dismisses without firing.
+  await page.getByTestId("confirm-modal-cancel").click();
+  await expect(modal).toHaveCount(0);
+  await expect(page).not.toHaveURL(/\/login/);
+});
+
+test("issue #43/#986 — detach's modal promises the opposite of quit's", async ({ page }) => {
+  await loginAs(page, getSeededVjt());
+  await openRailMenu(page);
+
+  await page.getByTestId("detach-btn").click();
+  // detach keeps the bouncer up, quit takes it offline. One shared string
+  // would defeat the change, so assert the DISTINGUISHING claim rather than
+  // merely that a modal came up.
+  await expect(page.getByTestId("confirm-modal-body")).toHaveText(/keeps running/i);
+  await page.getByTestId("confirm-modal-cancel").click();
+  await expect(page.getByTestId("confirm-modal")).toHaveCount(0);
+  await expect(page).not.toHaveURL(/\/login/);
 });

--- a/cicchetto/e2e/tests/issue473-rail-actions-drawer.spec.ts
+++ b/cicchetto/e2e/tests/issue473-rail-actions-drawer.spec.ts
@@ -13,9 +13,10 @@
 // spec exists to guard:
 //   * Every rail button now carries a VISIBLE TEXT LABEL next to its glyph
 //     (`.rail-action-label`) — the whole point of #473 (the bare emoji had to
-//     be guessed / long-pressed). The siblings assert testid COUNTS
-//     (issue291 mobile full-7, ux-5-bm/bt relocation); none pins the desktop
-//     rail's labelled-button SET as a whole. Test (a) does.
+//     be guessed / long-pressed). The siblings assert individual testids for
+//     whatever THEY are about (issue291 the home launcher, issue299 admin
+//     reachability); none pins the rail's labelled-button SET as a whole, nor
+//     should they. Test (a) does, and owns it — see RAIL_BUTTONS.
 //   * The archive button is ALWAYS shown (like settings), NOT selection-gated,
 //     so the ONE archive surface is reachable from HOME — where there is no
 //     network context — not just from a channel/server window. Test (b) pins
@@ -24,13 +25,15 @@
 //   * The full PART → grouped-modal → lazy-expand → revive round trip on
 //     desktop (test c) and its mobile parity via the collapsed drawer (test d).
 //
-// Capability gating (RailActions.tsx): home / themes / archive / settings are
-// always shown; rooms needs a network context (channel/server window); denoise
-// is channel-gated; admin is isAdmin()-gated. vjt is a NON-admin, so on a
-// channel window it sees SIX labelled buttons and the admin button is ABSENT —
-// the isAdmin() gate's negative arm. The admin-present arm (the full seven) is
-// owned by issue291 / ux-6-c, which promote vjt via setAdminFlag; this spec
-// stays on the plain non-admin baseline to keep the shared stack untouched.
+// Capability gating (RailActions.tsx): home / themes / archive / settings /
+// quit are always shown; rooms needs a network context (channel/server window);
+// mentions needs a live bundle for that network; denoise is channel-gated;
+// detach is canDetach()-gated; admin is isAdmin()-gated. vjt is a persistent
+// NON-admin, so on a channel window it sees the EIGHT labelled buttons in
+// RAIL_BUTTONS, with admin ABSENT — the isAdmin() gate's negative arm. The
+// admin-present arm is exercised by issue291 / issue299 / ux-6-c, which promote
+// vjt via setAdminFlag; this spec stays on the plain non-admin baseline to keep
+// the shared stack untouched.
 //
 // Projects (playwright.config.ts): the plain-title tests run on chromium
 // (desktop 1280×720); the `@webkit` test runs on webkit-iphone-15 (393×852,
@@ -55,10 +58,18 @@ import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../
 const CHANNEL = AUTOJOIN_CHANNELS[0]; // #bofh — the seeded autojoin channel
 
 // The rail buttons a NON-admin (vjt) sees on a CHANNEL window, each paired with
-// the `.rail-action-label` text #473 gave it. Admin is excluded — it is
-// isAdmin()-gated and asserted ABSENT for vjt below. Order mirrors the render
-// order in RailActions.tsx (home · rooms · themes · archive · settings ·
-// denoise), but the assertions are per-button so order drift is not the signal.
+// the `.rail-action-label` text #473 gave it. Order mirrors the render order in
+// RailActions.tsx, but the assertions are per-button so order drift is not the
+// signal. TWO buttons are deliberately absent and so excluded: `admin`
+// (isAdmin()-gated, asserted ABSENT for vjt below) and `mentions` (needs a live
+// `mentions_bundle` push for the current network — none arrives here).
+//
+// This list is the SOLE owner of the exhaustive rail set: the tests below both
+// assert `toHaveCount(RAIL_BUTTONS.length)` inside the open menu, so "these and
+// no others" is one number derived from one array in one file. #986 is the
+// cautionary tale — the same total was ALSO pinned by issue291 and issue299,
+// and adding detach + quit reddened two specs that have nothing to do with the
+// rail's membership. A new rail entry belongs HERE, and only here.
 const RAIL_BUTTONS: ReadonlyArray<{ testid: string; label: string }> = [
   { testid: "mobile-panel-home", label: "home" },
   { testid: "mobile-panel-list", label: "rooms" },
@@ -66,6 +77,10 @@ const RAIL_BUTTONS: ReadonlyArray<{ testid: string; label: string }> = [
   { testid: "mobile-panel-archive", label: "archive" },
   { testid: "action-cluster-cog", label: "settings" },
   { testid: "presence-toggle", label: "denoise" },
+  // #986 — the lifecycle pair, moved out of the settings drawer. `detach` is
+  // canDetach()-gated: vjt is a persistent user, so it renders.
+  { testid: "detach-btn", label: "detach" },
+  { testid: "quit-irc-btn", label: "quit" },
 ];
 
 test.setTimeout(60_000);
@@ -94,8 +109,8 @@ test.describe("#473 — RailActions drawer + grouped ArchiveModal", () => {
 
     // #500 — the labelled buttons are collapsed behind ONE launcher; reveal the
     // menu first (openRailMenu is viewport-aware: on desktop it taps the
-    // launcher directly). The seven action buttons live inside
-    // `.rail-actions-menu` now, so re-scope every button query to it.
+    // launcher directly). The action buttons live inside `.rail-actions-menu`
+    // now, so re-scope every button query to it.
     await openRailMenu(page);
     const menu = page.locator(".shell-members .rail-actions-menu");
     await expect(menu).toBeVisible();
@@ -114,6 +129,12 @@ test.describe("#473 — RailActions drawer + grouped ArchiveModal", () => {
     // Assert absence INSIDE the open menu (alongside the present buttons above),
     // so the menu is proven expanded — a collapsed menu would hide admin too.
     await expect(menu.locator("[data-testid='mobile-panel-admin']")).toHaveCount(0);
+
+    // …and NOTHING else. The exhaustive clause the loop above cannot express:
+    // it proves every listed button is there, not that no unlisted one is. The
+    // launcher itself also carries `.shell-chrome-btn` but lives OUTSIDE the
+    // menu, so this counts exactly the action buttons.
+    await expect(menu.locator(".shell-chrome-btn")).toHaveCount(RAIL_BUTTONS.length);
   });
 
   test("desktop home — archive is always-on (no selection) and opens the grouped modal", async ({
@@ -188,7 +209,7 @@ test.describe("#473 — RailActions drawer + grouped ArchiveModal", () => {
     await expect(rail).toBeVisible();
     // #500 — the buttons are collapsed behind the launcher; reveal the menu
     // (openRailMenu sees the drawer is already open and just taps the launcher).
-    // The seven action buttons live inside `.rail-actions-menu` now.
+    // The action buttons live inside `.rail-actions-menu` now.
     await openRailMenu(page);
     const menu = page.locator(".shell-members.open .rail-actions-menu");
     await expect(menu).toBeVisible();
@@ -198,6 +219,11 @@ test.describe("#473 — RailActions drawer + grouped ArchiveModal", () => {
       await expect(button.locator(".rail-action-label")).toHaveText(label);
     }
     await expect(menu.locator("[data-testid='mobile-panel-admin']")).toHaveCount(0);
+    // Same exhaustive total as desktop — which is the point: gating in
+    // RailActions is capability-only, so the two form factors render the SAME
+    // set. Pinning it on both sides is what makes "no form-factor gates" a
+    // tested claim rather than a moduledoc sentence.
+    await expect(menu.locator(".shell-chrome-btn")).toHaveCount(RAIL_BUTTONS.length);
 
     // Close the launcher menu first — its full-viewport backdrop (fixed
     // inset:0) would otherwise intercept the drawer-backdrop click below. Escape

--- a/cicchetto/e2e/tests/issue477-quit-persistence.spec.ts
+++ b/cicchetto/e2e/tests/issue477-quit-persistence.spec.ts
@@ -1,4 +1,4 @@
-// Issue #477 — quit() + SettingsDrawer.showDetach route on PERSISTENCE,
+// Issue #477 — quit() + the detach affordance route on PERSISTENCE,
 // not subject class. Before #477 both hand-rolled the same predicate twice
 // (`kind === "user" || (visitor && registered === true)`); the collapse
 // routes both through the shared `isPersistentIdentity` (lib/auth.ts). This
@@ -39,24 +39,24 @@
 //
 // The registered-visitor case seeds `registered: true` into the persisted
 // subject — the SAME field the server sets for a real registered visitor and
-// the SOLE input showDetach reads (issue126 seeds `registered: false`
+// the SOLE input the detach gate reads (issue126 seeds `registered: false`
 // symmetrically for its ephemeral case).
 
-import { openSettingsDrawer, loginAs } from "../fixtures/cicchettoPage";
+import { openRailMenu, loginAs } from "../fixtures/cicchettoPage";
 import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin, getSeededVjt } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 import { type Browser, type Page } from "@playwright/test";
 
-async function openDrawer(page: Page) {
-  await openSettingsDrawer(page);
-  const drawer = page.getByRole("dialog", { name: /settings/i });
-  await expect(drawer).toHaveClass(/open/);
-  return drawer;
+// #986 — the lifecycle verbs left the settings drawer for the rail actions
+// menu. The persistence QUESTION this spec is about (`isPersistentIdentity`,
+// via `canDetach()`) did not change; only the surface it gates did.
+async function openLifecycleMenu(page: Page): Promise<void> {
+  await openRailMenu(page);
 }
 
 // Mint a throwaway visitor, seed it into a fresh isolated context carrying
-// the given `registered` flag (the field showDetach + quit() read), and
+// the given `registered` flag (the field canDetach() + quit() read), and
 // bootstrap cicchetto. Returns the page + a teardown that closes the context
 // and deletes the visitor row (idempotent — an ephemeral quit already purged
 // it server-side, so the delete 404s, swallowed).
@@ -94,40 +94,49 @@ async function bootVisitor(
 }
 
 test.describe("issue #477 — quit()/detach route on persistence, not class", () => {
-  test("registered USER (persistent) → drawer offers BOTH detach and quit", async ({ page }) => {
+  test("registered USER (persistent) → the rail offers BOTH detach and quit", async ({ page }) => {
     await loginAs(page, getSeededVjt());
-    await openDrawer(page);
+    await openLifecycleMenu(page);
 
-    // Persistent identity → isPersistentIdentity true → showDetach renders
+    // Persistent identity → isPersistentIdentity true → canDetach() renders
     // the detach affordance alongside the universal quit. Read-only: no
     // click mutates the shared vjt session.
     await expect(page.getByTestId("detach-btn")).toBeVisible();
     await expect(page.getByTestId("quit-irc-btn")).toBeVisible();
   });
 
-  test("registered VISITOR (persistent) → drawer offers BOTH detach and quit", async ({
+  test("registered VISITOR (persistent) → the rail offers BOTH detach and quit", async ({
     browser,
   }) => {
     const { page, teardown } = await bootVisitor(browser, true);
     try {
-      await openDrawer(page);
+      await openLifecycleMenu(page);
 
       // `registered === true` → persistent, exactly like a user: detach is
       // offered. This is the arm the #477 collapse must keep grouped with
-      // the user arm — no existing e2e covered a registered visitor's drawer.
+      // the user arm — no existing e2e covered a registered visitor here.
       await expect(page.getByTestId("detach-btn")).toBeVisible();
       await expect(page.getByTestId("quit-irc-btn")).toBeVisible();
+
+      // #986 — persistent, so the quit copy must PROMISE SURVIVAL. Against a
+      // real NickServ-flagged visitor, not a stubbed subject: this is the
+      // middle row of the three-way copy split, and the one a vitest fake
+      // cannot prove the shipped client reaches.
+      await page.getByTestId("quit-irc-btn").click();
+      await expect(page.getByTestId("confirm-modal-body")).toHaveText(/survive/i);
+      await page.getByTestId("confirm-modal-cancel").click();
+      await expect(page.getByTestId("confirm-modal")).toHaveCount(0);
     } finally {
       await teardown();
     }
   });
 
-  test("ephemeral VISITOR → drawer offers ONLY quit, and quit lands on /login", async ({
+  test("ephemeral VISITOR → the rail offers ONLY quit, and quit lands on /login", async ({
     browser,
   }) => {
     const { page, teardown } = await bootVisitor(browser, false);
     try {
-      await openDrawer(page);
+      await openLifecycleMenu(page);
 
       // Ephemeral (not persistent) → no detach; quit is the only lifecycle
       // verb (positive twin so a testid typo can't silently green the
@@ -135,14 +144,15 @@ test.describe("issue #477 — quit()/detach route on persistence, not class", ()
       await expect(page.getByTestId("quit-irc-btn")).toBeVisible();
       await expect(page.getByTestId("detach-btn")).toHaveCount(0);
 
-      // The quit ACTION end-state: the two-tap InlineConfirmButton arms on
-      // the first tap (red confirm copy, no navigation) then fires onQuit →
-      // quit() → logout (the ephemeral path) → RequireAuth bounces to
-      // /login. On a throwaway visitor, so it poisons no shared state.
-      const quit = page.getByTestId("quit-irc-btn");
-      await quit.click();
-      await expect(quit).toHaveText(/really quit IRC/i);
-      await quit.click();
+      // The quit ACTION end-state: #986 replaced the two-tap arm with the
+      // shared confirm modal, so the first tap RAISES it (no navigation) and
+      // the affirmative fires quit() → logout (the ephemeral path) →
+      // RequireAuth bounces to /login. On a throwaway visitor, so it poisons
+      // no shared state.
+      await page.getByTestId("quit-irc-btn").click();
+      await expect(page.getByTestId("confirm-modal-body")).toHaveText(/deletes it/i);
+      await expect(page).not.toHaveURL(/\/login/);
+      await page.getByTestId("confirm-modal-confirm").click();
       await expect(page).toHaveURL(/\/login/, { timeout: 10_000 });
     } finally {
       await teardown();

--- a/cicchetto/e2e/tests/m-z-admin-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/m-z-admin-cluster-journey.spec.ts
@@ -37,7 +37,7 @@
 // visitors against azzurra would 503 if the revert didn't run.
 
 import { expect, test } from "@playwright/test";
-import { openSettingsDrawer, expectShellReady } from "../fixtures/cicchettoPage";
+import { expectShellReady, openAdminConsole, openRailMenu } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { mintVisitor } from "../fixtures/grappaApi";
 
@@ -62,11 +62,7 @@ async function adminFriendlyLogin(
 }
 
 async function openAdminPane(page: import("@playwright/test").Page): Promise<void> {
-  await openSettingsDrawer(page);
-  const drawer = page.getByRole("dialog", { name: /settings/i });
-  await expect(drawer).toBeVisible();
-  await page.getByTestId("admin-console-entry").click();
-  await expect(page.getByTestId("admin-pane")).toBeVisible();
+  await openAdminConsole(page);
 }
 
 // PATCH /admin/networks/:slug — partial body shape per M-10. Only
@@ -92,19 +88,17 @@ test("M-Z admin operator journey: drawer → 4 tabs → cap-saturation event lan
   const admin = getSeededAdmin();
   await adminFriendlyLogin(page, admin);
 
-  // STEP 1 — Login as admin → drawer entry visible.
-  // adminFriendlyLogin already asserts the cog is visible; opening
-  // the drawer + asserting the Admin entry exercises the M-7 gate.
-  await openSettingsDrawer(page);
-  const drawer = page.getByRole("dialog", { name: /settings/i });
-  await expect(drawer).toBeVisible();
-  await expect(page.getByTestId("admin-console-entry")).toBeVisible();
+  // STEP 1 — Login as admin → the rail's 🔧 admin launcher is visible.
+  // #986 — the settings-drawer "admin console" entry this step used to
+  // exercise was a duplicate of that launcher and is gone; the M-7 gate it
+  // proved is the same gate, on the surviving door.
+  await openRailMenu(page);
+  await expect(page.getByTestId("mobile-panel-admin")).toBeVisible();
 
   // Mount the AdminPane → channel join + snapshot push happen here.
   // EVERY subsequent assertion depends on the pane being mounted, so
   // the channel subscription is live by the time we hit cap-saturate.
-  await page.getByTestId("admin-console-entry").click();
-  await expect(page.getByTestId("admin-pane")).toBeVisible();
+  await openAdminConsole(page);
 
   // STEP 2 — Visitors tab: list renders (table when populated, or
   // the explicit "no visitors" marker when empty — seeder doesn't

--- a/cicchetto/e2e/tests/m10-admin-networks-cap-editor.spec.ts
+++ b/cicchetto/e2e/tests/m10-admin-networks-cap-editor.spec.ts
@@ -18,7 +18,7 @@
 // by the time the spec runs.
 
 import { expect, test } from "@playwright/test";
-import { openSettingsDrawer, expectShellReady } from "../fixtures/cicchettoPage";
+import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
 
 async function adminFriendlyLogin(
@@ -38,11 +38,7 @@ async function adminFriendlyLogin(
 }
 
 async function openAdminNetworksTab(page: import("@playwright/test").Page): Promise<void> {
-  await openSettingsDrawer(page);
-  const drawer = page.getByRole("dialog", { name: /settings/i });
-  await expect(drawer).toBeVisible();
-  await page.getByTestId("admin-console-entry").click();
-  await expect(page.getByTestId("admin-pane")).toBeVisible();
+  await openAdminConsole(page);
   await page.getByTestId("admin-tab-networks").click();
   await expect(page.getByTestId("admin-networks-table")).toBeVisible({ timeout: 10_000 });
 }

--- a/cicchetto/e2e/tests/m11-admin-events-live.spec.ts
+++ b/cicchetto/e2e/tests/m11-admin-events-live.spec.ts
@@ -16,7 +16,7 @@
 // land in the Events tab within the expected fan-out window.
 
 import { expect, test } from "@playwright/test";
-import { openSettingsDrawer, expectShellReady } from "../fixtures/cicchettoPage";
+import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
 
 async function adminFriendlyLogin(
@@ -36,11 +36,7 @@ async function adminFriendlyLogin(
 }
 
 async function openAdminPane(page: import("@playwright/test").Page): Promise<void> {
-  await openSettingsDrawer(page);
-  const drawer = page.getByRole("dialog", { name: /settings/i });
-  await expect(drawer).toBeVisible();
-  await page.getByTestId("admin-console-entry").click();
-  await expect(page.getByTestId("admin-pane")).toBeVisible();
+  await openAdminConsole(page);
 }
 
 test("M-11 Events tab renders + receives reaper_swept after Force Reap", async ({ page }) => {

--- a/cicchetto/e2e/tests/m7-admin-gate-settings-drawer.spec.ts
+++ b/cicchetto/e2e/tests/m7-admin-gate-settings-drawer.spec.ts
@@ -1,27 +1,36 @@
-// M-cluster M-7 — admin-gated drawer entry + admin pane skeleton.
+// M-cluster M-7 — the admin-gated door + admin pane skeleton.
+//
+// #986 — that door is no longer the settings drawer. The drawer's "admin
+// console" entry was an exact duplicate of the rail's 🔧 admin launcher (same
+// isAdmin() gate, same setSelectedChannel payload, same destination) and was
+// deleted; the gate itself is unchanged, so this spec keeps its name and its
+// job and simply asserts it on the surviving surface. Filename kept
+// deliberately: six sibling specs cross-reference it as THE M-7 gate spec.
 //
 // Three-class parity matrix per `feedback_e2e_user_class_parity_matrix`:
 // admin-gated is the EXEMPT shape — only ONE class (admin user) sees
 // the surface. The spec still loops the three classes to assert the
-// OPPOSITE polarity (non-admin user + visitor see NO drawer entry +
+// OPPOSITE polarity (non-admin user + visitor see NO admin launcher +
 // can't open the admin pane).
 //
 // Visitor sub-case: visitors can't easily be seeded into the e2e
 // harness today (no per-test visitor mint API; the captcha + Turnstile
 // gate complicates it). The visitor branch is covered by the vitest
-// unit at SettingsDrawer.test.tsx (visitor subject in localStorage →
-// admin entry hidden); the Playwright spec covers the two seeded
+// unit at RailActions.test.tsx (isAdmin() false → launcher unmounted;
+// SettingsDrawer.test.tsx pins that no drawer copy survived); the
+// Playwright spec covers the two seeded
 // user classes (vjt non-admin, admin-vjt admin). The vitest pin is
 // the load-bearing assertion for visitors; Playwright is the
 // production-fidelity confirmation for the gate logic.
 //
 // Per `feedback_cicchetto_browser_smoke`: this spec exercises the
-// real CSS render path that vitest jsdom can't — admin-console-entry
-// button needs to be visible (display, opacity, transform) inside
-// the open SettingsDrawer overlay.
+// real CSS render path that vitest jsdom can't — the admin launcher
+// needs to be visible (display, opacity, transform) inside the
+// expanded RailActions menu, which is absolutely positioned, capped by
+// a JS-measured max-height and overlays the members list.
 
 import { expect, test } from "../fixtures/test";
-import { openSettingsDrawer, expectShellReady } from "../fixtures/cicchettoPage";
+import { openRailMenu, expectShellReady } from "../fixtures/cicchettoPage";
 import { getSeededAdmin, getSeededVjt } from "../fixtures/seedData";
 
 // admin-vjt has no network bind — loginAs's `.sidebar-network-section h3`
@@ -58,27 +67,24 @@ const cases = [
 ];
 
 for (const c of cases) {
-  test(`M-7 SettingsDrawer admin entry — ${c.label}`, async ({ page }) => {
+  test(`M-7 admin launcher gate — ${c.label}`, async ({ page }) => {
     await adminFriendlyLogin(page, c.seed());
 
-    // Open the settings drawer via the cog button.
-    await openSettingsDrawer(page);
-    const drawer = page.getByRole("dialog", { name: /settings/i });
-    await expect(drawer).toBeVisible();
-    await expect(drawer).toHaveClass(/open/);
+    // #500 — every rail affordance lives behind the launcher menu.
+    await openRailMenu(page);
 
     if (c.expectAdminEntry) {
-      const entry = page.getByTestId("admin-console-entry");
+      const entry = page.getByTestId("mobile-panel-admin");
       await expect(entry).toBeVisible();
       // Per `feedback_css_block_button_wraps_inline_prefix`:
-      // textContent assertion catches the ::before / inline-prefix
-      // clip case that pure visibility checks miss.
-      await expect(entry).toHaveText(/admin console/i);
+      // text assertion catches the ::before / inline-prefix clip case
+      // that pure visibility checks miss. #473 gave every rail row a
+      // visible NAME beside the glyph — that name is the contract.
+      await expect(entry).toHaveText(/admin/i);
 
-      // Click → drawer dismisses → admin pane mounts. Pane replaces
-      // the channel/empty fallback in `.shell-main`.
+      // Tap → the nav mutex closes members/settings/archive and sets
+      // selection; the pane replaces the channel/empty fallback.
       await entry.click();
-      await expect(drawer).not.toHaveClass(/open/);
       const pane = page.getByTestId("admin-pane");
       await expect(pane).toBeVisible();
       await expect(pane.getByRole("heading", { name: /admin console/i })).toBeVisible();
@@ -88,18 +94,16 @@ for (const c of cases) {
       await page.getByTestId("admin-pane-close").click();
       await expect(page.getByTestId("admin-pane")).toHaveCount(0);
     } else {
-      // Non-admin: entry MUST be absent from the DOM (Show gate
-      // unmounts the button when is_admin !== true). Pair the
-      // negative-polarity assertion with a positive twin (the
-      // registered-user "detach" button, issue #43 — replaced the old
-      // single "log out" for `kind === "user"` subjects) so a testid
-      // typo can't silently green BOTH assertion paths.
+      // Non-admin: the launcher MUST be absent from the DOM (the Show
+      // gate unmounts it when is_admin !== true). Pair the negative
+      // polarity with a positive twin in the SAME menu — the
+      // registered-user "detach" entry (#986 moved it here from the
+      // drawer; a user is a persistent identity, so it renders) — so a
+      // testid typo cannot silently green BOTH assertion paths.
       await expect(page.getByTestId("detach-btn")).toBeVisible();
+      await expect(page.getByTestId("mobile-panel-admin")).toHaveCount(0);
+      // And the retired drawer door must not have grown back.
       await expect(page.getByTestId("admin-console-entry")).toHaveCount(0);
-
-      // Even forcibly opening the SPA against an admin-only URL
-      // wouldn't matter since M-7 has no admin route — but the
-      // testid absence is the load-bearing assertion.
     }
   });
 }

--- a/cicchetto/e2e/tests/m8-admin-visitors-delete.spec.ts
+++ b/cicchetto/e2e/tests/m8-admin-visitors-delete.spec.ts
@@ -21,7 +21,7 @@
 // actually holds in the e2e harness.
 
 import { expect, test } from "../fixtures/test";
-import { openSettingsDrawer } from "../fixtures/cicchettoPage";
+import { openAdminConsole } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 
@@ -48,10 +48,7 @@ test("M-8 admin Visitors tab lists + deletes a minted visitor (inline confirm tw
       [admin.token, admin.subjectJson] as const,
     );
     await page.goto("/");
-    await openSettingsDrawer(page);
-    await expect(page.getByRole("dialog", { name: /settings/i })).toBeVisible();
-    await page.getByTestId("admin-console-entry").click();
-    await expect(page.getByTestId("admin-pane")).toBeVisible();
+    await openAdminConsole(page);
     await page.getByTestId("admin-tab-visitors").click();
     await expect(page.getByTestId("admin-visitors-table")).toBeVisible({ timeout: 10_000 });
 

--- a/cicchetto/e2e/tests/m9b-admin-sessions-actions.spec.ts
+++ b/cicchetto/e2e/tests/m9b-admin-sessions-actions.spec.ts
@@ -28,7 +28,7 @@
 // every other admin spec — out of scope here.
 
 import { expect, test } from "@playwright/test";
-import { openSettingsDrawer, expectShellReady } from "../fixtures/cicchettoPage";
+import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
 import { patchNetworkConnectionState } from "../fixtures/grappaApi";
 import { getSeededAdmin, getSeededM9bVictim, NETWORK_SLUG } from "../fixtures/seedData";
 
@@ -67,11 +67,7 @@ async function adminFriendlyLogin(
 }
 
 async function openAdminSessionsTab(page: import("@playwright/test").Page): Promise<void> {
-  await openSettingsDrawer(page);
-  const drawer = page.getByRole("dialog", { name: /settings/i });
-  await expect(drawer).toBeVisible();
-  await page.getByTestId("admin-console-entry").click();
-  await expect(page.getByTestId("admin-pane")).toBeVisible();
+  await openAdminConsole(page);
   await page.getByTestId("admin-tab-sessions").click();
   await expect(page.getByTestId("admin-sessions-table")).toBeVisible({ timeout: 10_000 });
 }

--- a/cicchetto/e2e/tests/u-3-cap-honesty-mapping.spec.ts
+++ b/cicchetto/e2e/tests/u-3-cap-honesty-mapping.spec.ts
@@ -42,7 +42,7 @@
 // afterEach restores caps to permissive defaults.
 
 import { expect, test } from "../fixtures/test";
-import { openSettingsDrawer, expectShellReady } from "../fixtures/cicchettoPage";
+import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
 import {
   ADMIN_IDENTIFIER,
   ADMIN_PASSWORD,
@@ -271,11 +271,7 @@ test("U-3 (UD4) — admin Sessions tab renders per-network cap-count summary", a
   await page.goto("/");
   await expectShellReady(page);
 
-  await openSettingsDrawer(page);
-  const drawer = page.getByRole("dialog", { name: /settings/i });
-  await expect(drawer).toBeVisible();
-  await page.getByTestId("admin-console-entry").click();
-  await expect(page.getByTestId("admin-pane")).toBeVisible();
+  await openAdminConsole(page);
 
   // Sessions is the default tab on M-9b (no click needed), but the
   // explicit click below mirrors the operator flow exactly + future-

--- a/cicchetto/e2e/tests/u5-admin-networks-live-counts.spec.ts
+++ b/cicchetto/e2e/tests/u5-admin-networks-live-counts.spec.ts
@@ -20,7 +20,7 @@
 // review).
 
 import { expect, test } from "@playwright/test";
-import { openSettingsDrawer, expectShellReady } from "../fixtures/cicchettoPage";
+import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
 import { patchNetworkConnectionState } from "../fixtures/grappaApi";
 import { getSeededAdmin, getSeededM9bVictim, NETWORK_SLUG } from "../fixtures/seedData";
 
@@ -41,11 +41,7 @@ async function adminFriendlyLogin(
 }
 
 async function openAdminPane(page: import("@playwright/test").Page): Promise<void> {
-  await openSettingsDrawer(page);
-  const drawer = page.getByRole("dialog", { name: /settings/i });
-  await expect(drawer).toBeVisible();
-  await page.getByTestId("admin-console-entry").click();
-  await expect(page.getByTestId("admin-pane")).toBeVisible();
+  await openAdminConsole(page);
 }
 
 test("U-5 Networks live user-count drops after a session is terminated", async ({ page }) => {

--- a/cicchetto/e2e/tests/ux-4-z-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/ux-4-z-cluster-journey.spec.ts
@@ -86,13 +86,7 @@
 // `afterEach` so subsequent specs see the seeder baseline.
 
 import { expect, test } from "../fixtures/test";
-import {
-  closeMembersDrawer,
-  loginAs,
-  openSettingsMobile,
-  selectChannel,
-  sidebarWindow,
-} from "../fixtures/cicchettoPage";
+import { closeMembersDrawer, loginAs, openSettingsMobile, selectChannel, sidebarWindow, openAdminConsole, closeSettings } from "../fixtures/cicchettoPage";
 import { joinChannel, partChannel } from "../fixtures/grappaApi";
 import {
   AUTOJOIN_CHANNELS,
@@ -503,12 +497,14 @@ test("@webkit UX-4-Z cluster — case-fix + home + sidebar collapse + close-fall
     await openSettingsMobile(adminPage);
     const adminDrawer = adminPage.locator(".settings-drawer.open");
     await expect(adminDrawer).toBeVisible({ timeout: 5_000 });
-    // The "Admin Console" entry sets selection to kind=admin which
-    // mounts AdminPane via Shell.tsx's `<Show when=...>`.
-    await adminPage.getByTestId("admin-console-entry").tap();
-    await expect(adminPage.getByTestId("admin-pane")).toBeVisible({
-      timeout: 10_000,
-    });
+    await closeSettings(adminPage);
+    // #986 — the rail's 🔧 admin launcher sets selection to kind=admin, which
+    // mounts AdminPane via Shell.tsx's `<Show when=...>`. (It replaced the
+    // drawer's duplicate "Admin Console" entry; the drawer assertion above
+    // still stands as the bucket-L "settings reachable on home" check, so it
+    // is closed rather than dropped — a drawer left open would intercept the
+    // rail tap.)
+    await openAdminConsole(adminPage);
     // Settings STILL reachable on the admin window (bucket L rule extends to
     // the admin kind). #71 INC-2 — on mobile the door is the ☰ rail opener
     // (admin is a non-channel kind, so ShellChrome renders it).

--- a/cicchetto/e2e/tests/ux-6-d-keyboard-pattern.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-d-keyboard-pattern.spec.ts
@@ -154,15 +154,13 @@ test.describe("UX-6 D cluster close — iOS PWA keyboard pattern @webkit", () =>
     const adminCtx = await promoteVjtToAdmin();
     try {
       await loginAs(page, getSeededVjt());
-      // GREEN-CI batch 2 — mobile admin entry is via the members-drawer
-      // launcher footer (`mobile-panel-admin`), NOT via the desktop
-      // shell-chrome cog. Mirrors ux-6-c-mobile-admin-launcher.spec.ts
-      // pattern: select channel → open members drawer → tap admin
-      // launcher. Original spec used `.querySelector('[data-testid=
-      // "shell-chrome-settings"]').click()` which on mobile resolves
-      // the settings drawer but with admin-console-entry positioned
-      // outside the viewport (drawer is full-height bottom sheet),
-      // so the subsequent click never lands.
+      // GREEN-CI batch 2 — the admin door is the rail launcher
+      // (`mobile-panel-admin`), NOT the desktop shell-chrome cog. Mirrors
+      // ux-6-c-mobile-admin-launcher.spec.ts: select channel → open members
+      // drawer → tap admin launcher. The original spec routed through the
+      // settings drawer, where the admin entry sat outside the viewport on a
+      // full-height bottom sheet and the click never landed — #986 deleted
+      // that entry outright, so the rail is now the only door anyway.
       await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
       await page.getByLabel(/open members sidebar/i).tap();
       const drawer = page.locator(".shell-members.open");

--- a/cicchetto/src/RailActions.tsx
+++ b/cicchetto/src/RailActions.tsx
@@ -1,8 +1,11 @@
+import { useNavigate } from "@solidjs/router";
 import { type Component, createEffect, createSignal, onCleanup, Show } from "solid-js";
 import { archiveSlugForSelection } from "./lib/archiveContext";
 import { channelKey } from "./lib/channelKey";
 import { syncedSetChannelPresencePref } from "./lib/displayPrefs";
+import { canDetach, confirmDetach, confirmQuit } from "./lib/lifecycle";
 import { membersByChannel } from "./lib/members";
+import { mentionsBundleBySlug } from "./lib/mentionsWindow";
 import { spaceAbove } from "./lib/menuPosition";
 import {
   type MobilePanelSetters,
@@ -10,6 +13,7 @@ import {
   openArchivePanel,
   openHomePanel,
   openListPanel,
+  openMentionsPanel,
   openSettingsPanel,
   openThemesPanel,
 } from "./lib/mobilePanel";
@@ -55,20 +59,47 @@ import {
 // gesture. A full-viewport scrim (the modal family's idiom) would swallow that
 // first click — wrong for a lightweight rail popover.
 //
-// The six window/panel launchers close the menu after firing (single-shot, like
-// every overlay). `denoise` does NOT close it — it is a per-channel state toggle
-// the operator flips in place (watching the accent flip, re-toggling), not a
+// Every launcher closes the menu after firing (single-shot, like every
+// overlay) — including the two lifecycle entries, which hand the operator to
+// a modal and must not leave a live menu waiting underneath it for the
+// Cancel. `denoise` does NOT close it — it is a per-channel state toggle the
+// operator flips in place (watching the accent flip, re-toggling), not a
 // navigation away.
 //
-// Buttons, in order: home · rooms · themes · archive · settings · admin ·
-// denoise. Each carries its NAME as visible text next to the glyph (#473: bare
-// emoji had to be guessed / long-pressed).
+// Buttons, in order: home · rooms · mentions · themes · archive · settings ·
+// admin · denoise · detach · quit. Each carries its NAME as visible text next
+// to the glyph (#473: bare emoji had to be guessed / long-pressed).
 //
 // Gating is CAPABILITY-only — no form-factor gates (#473):
-//   * home / themes / settings / archive — always.
+//   * home / themes / settings / archive / quit — always.
 //   * rooms — needs a network context (`archiveSlugForSelection()`).
+//   * mentions — needs a bundle to re-open for that network context.
 //   * admin — `isAdmin()`.
 //   * denoise — channel-gated (a channel window is selected).
+//   * detach — `canDetach()`: a persistent identity has a bouncer to leave
+//     running, an ephemeral visitor does not.
+//
+// #986 — three arrivals, and the two lifecycle verbs among them are why this
+// menu now carries a destructive class of action:
+//
+//   * `@` mentions moved OFF `.shell-chrome`, the band #985 removes. It was
+//     gated `isMobile() && bundle` there, because on desktop it would have
+//     duplicated the Sidebar mentions row (#71 INC-2). That gate does NOT
+//     travel with it: #473 already settled that the rail carries the same set
+//     on both form factors, and `home` is the standing precedent — a sidebar
+//     row AND a rail launcher, deliberately. A form-factor gate here would be
+//     the one thing this component says it does not do.
+//   * `detach` / `quit` moved out of the settings drawer, each behind the
+//     shared #195 confirm modal via lib/lifecycle's `confirmDetach` /
+//     `confirmQuit`. ONE confirm paradigm: the drawer's two-tap
+//     `InlineConfirmButton` arm is NOT reproduced here (the component keeps
+//     serving its ~20 other call sites unchanged — only its use as a
+//     lifecycle-verb gate ends). The modal body is subject-TRUE; the copy
+//     block in lib/lifecycle.ts records why one sentence could not honestly
+//     serve three different events.
+//
+// The lifecycle pair sits LAST, after the navigation set — the conventional
+// slot for a destructive verb, and one the confirm modal makes affordable.
 //
 // #473 — `archive` is ALWAYS shown, like settings — NOT selection-gated: the
 // grouped `ArchiveModal` is the SINGLE archive surface and must be reachable
@@ -97,6 +128,25 @@ export type Props = {
 const RAIL_MENU_TOP_GAP = 8;
 
 const RailActions: Component<Props> = (props) => {
+  // #986 — the two lifecycle verbs land the operator on /login once the
+  // teardown resolves. `logout()` nulls the token and main.tsx's RequireAuth
+  // would redirect on its own, but the explicit navigation makes the landing
+  // deterministic instead of effect-ordered (the shape SettingsDrawer used
+  // before these buttons moved here).
+  const navigate = useNavigate();
+  const toLogin = (): void => navigate("/login", { replace: true });
+
+  // #188 item 6 / #986 — which network's mentions bundle can be re-opened?
+  // Derived from the current selection exactly as `rooms` derives its network
+  // (`archiveSlugForSelection`), and null unless that network HAS a bundle:
+  // there is nothing to re-open otherwise. Returns null while the mentions
+  // panel is itself selected, which correctly hides the redundant entry.
+  const mentionsSlug = (): string | null => {
+    const slug = archiveSlugForSelection();
+    if (slug === null) return null;
+    return mentionsBundleBySlug()[slug] ? slug : null;
+  };
+
   // The channel this rail is currently showing, or null on non-channel windows
   // — drives the channel-gated denoise toggle (any channel: the toggle writes a
   // pref that persists to reconnect, so it is meaningful on parked channels
@@ -253,6 +303,37 @@ const RailActions: Component<Props> = (props) => {
             )}
           </Show>
 
+          {/* #986 — mentions launcher (@). The ONE door back into a network's
+              "you were /away" bundle now that `.shell-chrome` is losing its
+              copy (#985). Gated on there BEING a bundle for the current
+              network context — capability, not form factor (see moduledoc).
+              Routes through the same nav mutex as home / rooms / admin. */}
+          <Show when={mentionsSlug()}>
+            {(slug) => (
+              <button
+                type="button"
+                class="shell-chrome-btn rail-action rail-action-mentions"
+                aria-label="open mentions"
+                data-testid="rail-action-mentions"
+                onClick={() => {
+                  openMentionsPanel(props.setters, () =>
+                    setSelectedChannel({
+                      networkSlug: slug(),
+                      channelName: "",
+                      kind: "mentions",
+                    }),
+                  );
+                  close();
+                }}
+              >
+                <span class="rail-action-icon" aria-hidden="true">
+                  @
+                </span>
+                <span class="rail-action-label">mentions</span>
+              </button>
+            )}
+          </Show>
+
           {/* #75/#332 — themes launcher: opens the settings drawer on the themes
               sub-page (openThemesPanel deep-links via settingsNav). Always. */}
           <button
@@ -377,6 +458,51 @@ const RailActions: Component<Props> = (props) => {
               );
             }}
           </Show>
+
+          {/* #986 — detach: leave cic, KEEP the bouncer running. Offered to a
+              persistent identity only, via lib/lifecycle's `canDetach()` —
+              the SAME `isPersistentIdentity` question `quit()` routes on, so
+              the affordance and the teardown cannot drift. The confirm modal
+              is what makes this a rail entry rather than the drawer's
+              unconfirmed button: it says what stays up before the tap. */}
+          <Show when={canDetach()}>
+            <button
+              type="button"
+              class="shell-chrome-btn rail-action rail-action-detach"
+              aria-label="detach from cicchetto"
+              data-testid="detach-btn"
+              onClick={() => {
+                confirmDetach(toLogin);
+                close();
+              }}
+            >
+              <span class="rail-action-icon" aria-hidden="true">
+                {"\u{1F50C}"}
+              </span>
+              <span class="rail-action-label">detach</span>
+            </button>
+          </Show>
+
+          {/* #986 — quit: close cic AND tear the live session down.
+              Universal, and the ONE entry whose consequence is genuinely
+              different per subject — a user parks and comes back, an anon
+              visitor is deleted. `confirmQuit` picks the sentence that is
+              true for whoever is looking at it. */}
+          <button
+            type="button"
+            class="shell-chrome-btn rail-action rail-action-quit"
+            aria-label="quit IRC"
+            data-testid="quit-irc-btn"
+            onClick={() => {
+              confirmQuit(toLogin);
+              close();
+            }}
+          >
+            <span class="rail-action-icon" aria-hidden="true">
+              {"\u{1F6AA}"}
+            </span>
+            <span class="rail-action-label">quit</span>
+          </button>
         </div>
       </Show>
 

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from "@solidjs/router";
 import {
   type Component,
   createEffect,
@@ -14,15 +13,15 @@ import DeleteAccountModal from "./DeleteAccountModal";
 import InlineConfirmButton from "./InlineConfirmButton";
 import { windowCandidates } from "./lib/activeWindows";
 import { ApiError, displayNick, type Network, visitorNetworkNick } from "./lib/api";
-import { getSubject, isPersistentIdentity, token } from "./lib/auth";
+import { getSubject, token } from "./lib/auth";
 import { canonicalChannel } from "./lib/channelKey";
 import { getColoredNicklist } from "./lib/colorNicklist";
 import { syncedSetColoredNicklist, syncedSetTimeFormat } from "./lib/displayPrefs";
 import { type FontSizeKey, getFontSize, setFontSize } from "./lib/fontSize";
 import { friendlyApiError } from "./lib/friendlyApiError";
 import { getHideNextActive, setHideNextActive } from "./lib/hideNextActive";
-import { detach, quit, updateIdentity } from "./lib/lifecycle";
-import { isAdmin, networks, user } from "./lib/networks";
+import { updateIdentity } from "./lib/lifecycle";
+import { networks, user } from "./lib/networks";
 import { mirrorNotificationPrefs } from "./lib/notificationPrefs";
 import { popOverlay, pushOverlay } from "./lib/overlayScrollLock";
 import {
@@ -70,8 +69,10 @@ import WatchlistsSettings from "./WatchlistsSettings";
 // `<Show>` blocks whose signals live in this component's body (general =
 // upload retention + visitor identity; display = text size / timestamp /
 // colored nicklist; push = notifications). The main page keeps, BELOW the
-// index, the subject-gated affordances that aren't sub-pages: admin console,
-// share session, detach, quit, delete account, done.
+// index, the subject-gated affordances that aren't sub-pages: share session,
+// delete account, done. (#986 retired three of them: admin console was an
+// exact duplicate of the rail's admin action, and detach + quit moved into
+// the rail actions menu behind a per-subject confirm modal.)
 //
 // open prop drives the .open class; the drawer stays mounted across
 // open/close so onMount-loaded state (devices + prefs) doesn't refetch
@@ -86,18 +87,9 @@ import WatchlistsSettings from "./WatchlistsSettings";
 export type Props = {
   open: boolean;
   onClose: () => void;
-  // M-7 — fires when the operator clicks the "admin console" entry.
-  // Shell.tsx handles closing the drawer + selecting the admin
-  // window (UX-4 bucket N: selection-driven AdminPane mount;
-  // pre-bucket-N Shell flipped a separate `adminOpen` signal).
-  // Required even though only admin renderings invoke it — both
-  // SettingsDrawer call sites in Shell (desktop + mobile) pass the
-  // same selection-set handler.
-  onOpenAdmin: () => void;
 };
 
 const SettingsDrawer: Component<Props> = (props) => {
-  const navigate = useNavigate();
   const [size, setSize] = createSignal<FontSizeKey>(getFontSize());
   const [timeFmt, setTimeFmt] = createSignal<TimeFormatKey>(getTimeFormat());
   const [coloredNicklist, setColoredNicklistSig] = createSignal<boolean>(getColoredNicklist());
@@ -149,21 +141,15 @@ const SettingsDrawer: Component<Props> = (props) => {
     const s = getSubject();
     return s?.kind === "visitor" && s.incognito === true;
   };
-  // #126 / #477 — detach is offered to every PERSISTENT identity (a
-  // registered user OR a NickServ-identified visitor, `registered === true`
-  // derived server-side); an ephemeral visitor and the not-yet-loaded null
-  // subject get quit-only. Routed through the shared `isPersistentIdentity`
-  // predicate (lib/auth.ts) — the SAME persistence question `quit()` asks,
-  // so the drawer affordance and the teardown path can never drift apart.
-  const showDetach = (): boolean => isPersistentIdentity(getSubject());
-  // "quit IRC" is destructive (parks every network, bouncer offline), so
-  // it arms via the shared two-tap InlineConfirmButton. Parent owns the
-  // armed flag per that component's contract.
-  const [quitArmed, setQuitArmed] = createSignal(false);
+  // #986 — the `showDetach()` gate + the two-tap `quitArmed` latch moved to
+  // the rail with the buttons they served (`canDetach()` in lib/lifecycle
+  // asks the same `isPersistentIdentity` question; the latch has no
+  // successor — the shared confirm modal replaced the two-tap arm).
   // #157 — "delete account" is an IRREVERSIBLE total wipe, surfaced as a
   // SEPARATE affordance from quit (quit PRESERVES a persistent identity;
-  // delete nukes it). It opens a confirm MODAL (type-your-name gate) —
-  // stronger than quit's two-tap arm. Offered ONLY to a registered
+  // delete nukes it). It opens a confirm MODAL (type-your-name gate) — the
+  // ONE typed gate in the product (#986: detach and quit explain and ask,
+  // this one asks you to spell the identity out). Offered ONLY to a registered
   // NON-admin user or a registered visitor; admins (issue #157) + anon
   // visitors are excluded. Reads the reactive `/me` resource (authoritative
   // for is_admin / registered) so a mid-session demote/refetch flips it.
@@ -217,25 +203,9 @@ const SettingsDrawer: Component<Props> = (props) => {
     setHideNextActive((e.currentTarget as HTMLInputElement).checked);
   };
 
-  // #126 — detach: leave cic, KEEP the bouncer up. Persistent identities
-  // only (gated by `showDetach()`). `detach()` revokes the web session;
-  // the explicit navigate mirrors onQuit's post-logout landing.
-  const onDetach = async () => {
-    await detach();
-    navigate("/login", { replace: true });
-  };
-
-  // #126 — quit: close cic AND tear down the live session. Universal;
-  // `quit()` (lib/lifecycle.ts) routes per subject — user parks all
-  // networks (the former quitAll, also driven by the /quit compose verb +
-  // the sidebar ×), registered visitor drops the upstream then detaches
-  // (row kept), ephemeral visitor detaches (server purges the anon row).
-  // logout() inside nulls the token → RequireAuth redirects; the explicit
-  // navigate makes the landing deterministic.
-  const onQuit = async () => {
-    await quit();
-    navigate("/login", { replace: true });
-  };
+  // #986 — the `onDetach` / `onQuit` handlers moved to RailActions with
+  // their buttons, and now fire through lib/lifecycle's `confirmDetach` /
+  // `confirmQuit` so the modal states the per-subject consequence first.
 
   // #211 phase 6 — the #126 disconnect ⇄ reconnect handlers are RETIRED
   // (per-network park/reconnect moved to the home page; global disconnect
@@ -271,7 +241,10 @@ const SettingsDrawer: Component<Props> = (props) => {
   const [identitySaved, setIdentitySaved] = createSignal(false);
   // Two-tap arm for the apply button (parent owns the flag per
   // InlineConfirmButton's contract) — the reconnect is disruptive
-  // (session bounces), so it gets the same confirm gate as quit.
+  // (session bounces), so it arms rather than firing on the first tap. #986
+  // retired the settings copies of this control for the LIFECYCLE verbs only
+  // — as a per-row apply gate it is unchanged, here and at its ~20 other
+  // call sites.
   const [identityArmed, setIdentityArmed] = createSignal(false);
 
   // Default the editor's target ONCE per open-session: the currently-focused
@@ -337,13 +310,13 @@ const SettingsDrawer: Component<Props> = (props) => {
   };
 
   // The drawer stays mounted across open/close (CSS .open toggle, not a
-  // <Show>), so an armed quit button would survive a close → reopen and
-  // sit one stray tap from killing the bouncer. Disarm on every close.
-  // #157: also close the delete-account modal so a reopened drawer never
-  // strands the irreversible confirm dialog open.
+  // <Show>), so transient armed state would survive a close → reopen.
+  // #157: close the delete-account modal so a reopened drawer never strands
+  // the irreversible confirm dialog open. (#986 — the quit two-tap latch this
+  // effect also disarmed left with the button; the rail's confirm modal is a
+  // store-driven singleton that owns its own lifetime.)
   createEffect(() => {
     if (!props.open) {
-      setQuitArmed(false);
       setDeleteOpen(false);
       // #152 — disarm the identity apply + clear transient save state so a
       // reopened drawer never sits one tap from a reconnect or shows a
@@ -785,8 +758,9 @@ const SettingsDrawer: Component<Props> = (props) => {
             pushes into a dedicated sub-page (a `<Show>`-gated block that
             replaces the index in place); the header × stays visible for both.
             Below the index sit the subject-gated affordances that are NOT
-            sub-pages (admin console, share session, detach, quit, delete
-            account, done). */}
+            sub-pages (share session, delete account, done — #986 moved the
+            lifecycle verbs to the rail and dropped the duplicate admin
+            entry). */}
         <Show when={settingsPage() === "main"}>
           {/* Index rows, in order: general, display, themes, push
               (notifications), watch lists, aliases, on-connect commands,
@@ -959,19 +933,12 @@ const SettingsDrawer: Component<Props> = (props) => {
             </button>
           </Show>
 
-          <Show when={isAdmin()}>
-            <button
-              type="button"
-              class="admin-console-entry"
-              onClick={() => {
-                props.onClose();
-                props.onOpenAdmin();
-              }}
-              data-testid="admin-console-entry"
-            >
-              admin console
-            </button>
-          </Show>
+          {/* #986 — the `admin console` entry is GONE. It was an exact
+            duplicate of the rail's 🔧 admin action: same `isAdmin()` gate,
+            same `setSelectedChannel({ kind: "admin" })` payload, same
+            destination. Its `onOpenAdmin` prop and both Shell wirings went
+            with it — a dead prop left behind is how the next reader concludes
+            the two paths differed. */}
 
           {/* #392 — session-share entry. isVisitor()-gated (mint 403s for
               users — the modal is never reachable for a password subject).
@@ -993,48 +960,23 @@ const SettingsDrawer: Component<Props> = (props) => {
             </button>
           </Show>
 
-          {/* #126 — canonical session-lifecycle verbs ("log out" retired).
-            detach (leave cic, KEEP the bouncer) + disconnect ⇄ reconnect
-            (drop / restore the upstream, STAY in cic) are
-            persistent-identity-only (user + NickServ visitor); quit
-            (close cic AND tear down) is universal. An ephemeral visitor +
-            the not-yet-loaded null subject get quit alone. */}
-          <Show when={showDetach()}>
-            <button
-              type="button"
-              class="logout"
-              data-testid="detach-btn"
-              onClick={() => {
-                void onDetach();
-              }}
-            >
-              detach
-            </button>
-          </Show>
+          {/* #986 — the canonical session-lifecycle verbs (detach + quit) are
+            NO LONGER here. They moved into the rail actions menu
+            (RailActions.tsx), each behind the shared #195 confirm modal that
+            states, per subject, what the verb actually destroys. Two doors to
+            a destructive verb — one confirmed and one not — is worse than
+            either alone, so the drawer copies went with the move rather than
+            staying as an unconfirmed shortcut.
 
-          {/* #211 phase 6 — the visitor disconnect ⇄ reconnect toggle is
-            RETIRED. Per-network park/reconnect now lives on the HOME PAGE
-            for both subjects (ruling D); global disconnect is `quit`
-            (park-all). */}
-
-          {/* quit — universal destructive teardown, two-tap armed. */}
-          <InlineConfirmButton
-            idleLabel="quit"
-            confirmLabel="really quit IRC?"
-            armed={quitArmed()}
-            onArm={() => setQuitArmed(true)}
-            onConfirm={() => {
-              void onQuit();
-            }}
-            testId="quit-irc-btn"
-            extraClass="settings-quit"
-          />
+            `delete account` below STAYS: it is the one irreversible door, it
+            keeps its own type-your-name gate, and its geometry is #987. */}
 
           {/* #157 — delete account: IRREVERSIBLE total wipe, DISTINCT from
-            quit. Separate label + separate confirm (a type-your-name modal,
-            stronger than quit's two-tap). Offered ONLY to a registered
-            non-admin user or a registered visitor; admins + anon visitors
-            never see it. */}
+            quit (which PRESERVES a persistent identity). It keeps the
+            type-your-name modal — #986's ruling is that the typed gate is
+            about IRREVERSIBILITY, not subject kind, so it stays here and
+            ONLY here. Offered to a registered non-admin user or a registered
+            visitor; admins + anon visitors never see it. */}
           <Show when={showDeleteAccount()}>
             <button
               type="button"

--- a/cicchetto/src/Shell.tsx
+++ b/cicchetto/src/Shell.tsx
@@ -41,13 +41,7 @@ import { settingsOpenTick } from "./lib/settingsNav";
 import { isMobile } from "./lib/theme";
 import { bindEdgeGesture } from "./lib/touchGesture";
 import { loadUploadTtlSeconds } from "./lib/uploadOrchestrator";
-import {
-  ADMIN_WINDOW_NAME,
-  ADMIN_WINDOW_SLUG,
-  HOME_WINDOW_NAME,
-  HOME_WINDOW_SLUG,
-  kindHasScrollback,
-} from "./lib/windowKinds";
+import { HOME_WINDOW_NAME, HOME_WINDOW_SLUG, kindHasScrollback } from "./lib/windowKinds";
 import { isActiveChannelJoined } from "./lib/windowState";
 import MediaViewerModal from "./MediaViewerModal";
 import MembersPane from "./MembersPane";
@@ -180,12 +174,15 @@ const Shell: Component = () => {
   // signal). Triggers:
   //   * Sidebar admin row click (UX-4 bucket N — primary, always-
   //     visible affordance for admins).
-  //   * SettingsDrawer "admin console" entry (M-7 secondary trigger,
-  //     kept as a fallback per the "two doors, one room" rule).
+  //   * RailActions 🔧 admin launcher (#473, reachable from every
+  //     window kind on both form factors).
   // Both call setSelectedChannel({kind: "admin", ...ADMIN_*}).
+  // #986 removed a THIRD trigger — the SettingsDrawer "admin console"
+  // entry — as an exact duplicate of the rail one (same gate, same
+  // payload, same destination), along with its `onOpenAdmin` prop.
   //
   // Visibility gate `isAdmin()` lives in `lib/networks.ts` — single
-  // source of truth shared with SettingsDrawer (drawer entry) +
+  // source of truth shared with RailActions (the 🔧 launcher) +
   // Sidebar (admin row). Pane mount further gates on `isAdmin()`
   // here so a stale selection (kind === "admin" persisted across
   // a demote) can't reach AdminPane content for a non-admin user.
@@ -193,9 +190,8 @@ const Shell: Component = () => {
   // Demote-mid-session: when `me.is_admin` flips to false (another
   // admin demotes this operator, OR the bearer rotates to a
   // non-admin user), the createEffect below redirects selection
-  // back to home if currently on admin. Sidebar admin row vanishes
-  // via the same `isAdmin()` predicate. Drawer entry hides via the
-  // mirror predicate in SettingsDrawer.
+  // back to home if currently on admin. Sidebar admin row + the rail
+  // 🔧 launcher vanish via the same `isAdmin()` predicate.
 
   // M-7 demote redirect — when the operator loses admin AND is
   // currently on the admin window, navigate back to home so the
@@ -703,17 +699,7 @@ const Shell: Component = () => {
             <RailActions setters={{ membersOpen, setMembersOpen, setSettingsOpen }} />
           </aside>
 
-          <SettingsDrawer
-            open={settingsOpen()}
-            onClose={() => setSettingsOpen(false)}
-            onOpenAdmin={() =>
-              setSelectedChannel({
-                networkSlug: ADMIN_WINDOW_SLUG,
-                channelName: ADMIN_WINDOW_NAME,
-                kind: "admin",
-              })
-            }
-          />
+          <SettingsDrawer open={settingsOpen()} onClose={() => setSettingsOpen(false)} />
         </div>
       }
     >
@@ -954,17 +940,7 @@ const Shell: Component = () => {
           <RailActions setters={{ membersOpen, setMembersOpen, setSettingsOpen }} />
         </aside>
 
-        <SettingsDrawer
-          open={settingsOpen()}
-          onClose={() => setSettingsOpen(false)}
-          onOpenAdmin={() =>
-            setSelectedChannel({
-              networkSlug: ADMIN_WINDOW_SLUG,
-              channelName: ADMIN_WINDOW_NAME,
-              kind: "admin",
-            })
-          }
-        />
+        <SettingsDrawer open={settingsOpen()} onClose={() => setSettingsOpen(false)} />
       </div>
     </Show>
   );

--- a/cicchetto/src/ShellChrome.tsx
+++ b/cicchetto/src/ShellChrome.tsx
@@ -1,8 +1,4 @@
-import { type Component, Show } from "solid-js";
-import { archiveSlugForSelection } from "./lib/archiveContext";
-import { mentionsBundleBySlug } from "./lib/mentionsWindow";
-import { setSelectedChannel } from "./lib/selection";
-import { isMobile } from "./lib/theme";
+import type { Component } from "solid-js";
 
 // UX-4 bucket L (2026-05-19) — sticky chrome bar at the top of
 // `.shell-main`. Always rendered, regardless of selected window kind
@@ -12,8 +8,6 @@ import { isMobile } from "./lib/theme";
 //
 // Slots (left → right):
 //   * Spacer — pushes the right group to the far right.
-//   * Mentions button (@) — MOBILE-ONLY re-open door for a network's
-//     "you were /away" bundle (desktop uses the Sidebar mentions row).
 //   * Rail opener (☰) — #71 INC-2: was the settings cog. R1 moved the cog
 //     into the always-present right rail (RailActions), so on the mobile
 //     NON-channel windows (where this bar renders) the settings cog is
@@ -25,14 +19,19 @@ import { isMobile } from "./lib/theme";
 // was a THIRD archive entry point (mobile non-channel windows) that opened
 // a per-network modal; the archive rework makes the RailActions drawer's
 // always-on archive button the single archive door (reachable via this same
-// ☰ rail opener), so the inline button became redundant. `archiveContext`
-// still backs the @ mentions-slot network derivation below.
+// ☰ rail opener), so the inline button became redundant.
+//
+// #986 — the @ mentions button left too, by the same argument and for a
+// second reason: it was the only door back into a network's "you were /away"
+// bundle on a phone, and #985 removes this whole band. It is a RailActions
+// entry now (`rail-action-mentions`), reachable via the same ☰ — so what
+// remains here is the opener and nothing else, which is exactly the state
+// #985 needs in order to float a lone ☰ and drop `.shell-chrome`.
 //
 // #71 INC-2 — ShellChrome is now MOBILE-ONLY: the desktop copy was removed
 // (its row freed the top for the topic; the cog moved to the permanent
 // desktop rail). It renders only in Shell.tsx's mobile branch, on
-// non-channel windows (channel windows get the TopicBar instead). The
-// `isMobile()` gate on the @ button is belt-and-suspenders.
+// non-channel windows (channel windows get the TopicBar instead).
 //
 // UX-5 bucket A (2026-05-19) — the left hamburger slot was dropped.
 //
@@ -58,41 +57,9 @@ export type Props = {
 };
 
 const ShellChrome: Component<Props> = (props) => {
-  // #188 item 6 — which network's mentions bundle should the open button
-  // consult? Derive the network from the current selection like the
-  // archive button (`archiveSlugForSelection`), and render the button
-  // ONLY when that network has a bundle — there's nothing to open
-  // otherwise. #71 INC-2 — now MOBILE-ONLY (see the `isMobile()` gate on
-  // the button below): on desktop the per-network Sidebar mentions row
-  // (Sidebar.tsx) is the re-open affordance, so the @ here would just
-  // duplicate it. Mobile has no sidebar, so the @ stays as the only
-  // mentions re-open door (auto-nav on bundle arrival covers the first
-  // open). `archiveSlugForSelection` returns null while the mentions panel
-  // itself is open, which correctly hides the (redundant) re-open button.
-  const mentionsOpenSlug = (): string | null => {
-    const slug = archiveSlugForSelection();
-    if (slug === null) return null;
-    return mentionsBundleBySlug()[slug] ? slug : null;
-  };
-
   return (
     <header class="shell-chrome" data-testid="shell-chrome">
       <span class="shell-chrome-spacer" />
-      <Show when={isMobile() && mentionsOpenSlug()}>
-        {(slug) => (
-          <button
-            type="button"
-            class="shell-chrome-btn shell-chrome-mentions"
-            aria-label="open mentions"
-            data-testid="shell-chrome-mentions"
-            onClick={() =>
-              setSelectedChannel({ networkSlug: slug(), channelName: "", kind: "mentions" })
-            }
-          >
-            @
-          </button>
-        )}
-      </Show>
       {/* #71 INC-2 — rail opener (☰). Opens the same `.shell-members` drawer
           the channel-window TopicBar hamburger opens (paletto: ONE drawer, one
           ☰ glyph across both openers). The settings cog it replaced now lives

--- a/cicchetto/src/__tests__/RailActions.test.tsx
+++ b/cicchetto/src/__tests__/RailActions.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { __resetForTest as resetOverlayLock } from "../lib/overlayScrollLock";
 
@@ -28,6 +28,52 @@ vi.mock("../lib/channelKey", () => ({
 const adminHolder = { value: false };
 vi.mock("../lib/networks", () => ({
   isAdmin: () => adminHolder.value,
+  // #986 — pulled in transitively by lib/lifecycle (updateIdentity refetches
+  // /me). Unused by the rail, but a named import must resolve.
+  refetchUser: vi.fn(),
+}));
+
+// #986 — the two lifecycle entries land the operator on /login once the
+// teardown resolves. House pattern (DeleteAccountModal.test / SettingsDrawer
+// .test): stub the router hook rather than wrapping every render in a Router.
+const navigateMock = vi.fn();
+vi.mock("@solidjs/router", () => ({
+  useNavigate: () => navigateMock,
+}));
+
+// #188/#986 — the @ mentions entry only surfaces when the network implied by
+// the current selection HAS a bundle to re-open. Mutable holder per test.
+const mentionsBundles = vi.hoisted(() => ({ value: {} as Record<string, unknown> }));
+vi.mock("../lib/mentionsWindow", () => ({
+  mentionsBundleBySlug: () => mentionsBundles.value,
+}));
+
+// #986 — the subject drives BOTH the detach gate and which of the three quit
+// bodies the modal shows. Spread the REAL auth module so the shared
+// `isPersistentIdentity` predicate runs for real against the stubbed
+// getSubject — the classification IS what is under test. lib/lifecycle stays
+// UNMOCKED so the copy asserted below is the copy that ships; only its
+// side-effecting leaves (logout / quitAll / the REST verbs) are stubbed.
+const subjectHolder = vi.hoisted(() => ({
+  current: null as
+    | { kind: "user"; id: string; name: string }
+    | { kind: "visitor"; id: string; nick: string; registered?: boolean }
+    | null,
+}));
+vi.mock("../lib/auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/auth")>()),
+  logout: vi.fn().mockResolvedValue(undefined),
+  token: () => "test-bearer",
+  getSubject: () => subjectHolder.current,
+}));
+
+vi.mock("../lib/quit", () => ({
+  quitAll: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../lib/api", () => ({
+  deleteAccount: vi.fn().mockResolvedValue(undefined),
+  updateNetworkIdentity: vi.fn().mockResolvedValue(undefined),
 }));
 
 type Sel = { networkSlug: string; channelName: string; kind: string } | null;
@@ -49,6 +95,7 @@ const openThemesPanel = vi.fn();
 const openAdminPanel = vi.fn();
 const openSettingsPanel = vi.fn();
 const openArchivePanel = vi.fn();
+const openMentionsPanel = vi.fn();
 vi.mock("../lib/mobilePanel", () => ({
   openHomePanel: (...a: unknown[]) => openHomePanel(...a),
   openListPanel: (...a: unknown[]) => openListPanel(...a),
@@ -56,8 +103,11 @@ vi.mock("../lib/mobilePanel", () => ({
   openAdminPanel: (...a: unknown[]) => openAdminPanel(...a),
   openSettingsPanel: (...a: unknown[]) => openSettingsPanel(...a),
   openArchivePanel: (...a: unknown[]) => openArchivePanel(...a),
+  openMentionsPanel: (...a: unknown[]) => openMentionsPanel(...a),
 }));
 
+import ConfirmModal from "../ConfirmModal";
+import { dismissConfirm } from "../lib/confirmDialog";
 import RailActions from "../RailActions";
 
 const channelSel: Sel = { networkSlug: "freenode", channelName: "#italia", kind: "channel" };
@@ -72,6 +122,9 @@ beforeEach(() => {
   adminHolder.value = false;
   selHolder.value = null;
   roomsSlugHolder.value = "freenode";
+  mentionsBundles.value = {};
+  subjectHolder.current = null;
+  dismissConfirm();
 });
 
 afterEach(() => {
@@ -340,5 +393,231 @@ describe("RailActions launcher (#500)", () => {
     expect(screen.getByTestId("rail-actions-launcher")).toHaveAttribute("aria-expanded", "false");
     expect(screen.queryByTestId("action-cluster-cog")).toBeNull();
     expect(openSettingsPanel).not.toHaveBeenCalled();
+  });
+});
+
+// #986 — the three arrivals. The @ mentions door left `.shell-chrome` (whose
+// band #985 removes) and the two lifecycle verbs left the settings drawer,
+// where detach fired with NO confirmation at all and quit armed a two-tap
+// that said "really quit IRC?" to every subject alike. Here they are rail
+// entries behind the shared #195 confirm modal.
+//
+// The load-bearing assertions are about the modal BODY, mounted for real:
+// a naive "the modal opens" test passes with one shared sentence, which is
+// precisely the defect this issue exists to close.
+describe("RailActions — @ mentions (#986)", () => {
+  it("shows the entry when the selected network has a bundle to re-open", () => {
+    selHolder.value = channelSel;
+    mentionsBundles.value = { freenode: {} };
+    render(() => <RailActions setters={setters} />);
+    openMenu();
+    const entry = screen.getByTestId("rail-action-mentions");
+    expect(entry).toBeInTheDocument();
+    expect(entry).toHaveTextContent("mentions");
+  });
+
+  it("hides the entry when that network has no bundle — nothing to re-open", () => {
+    selHolder.value = channelSel;
+    mentionsBundles.value = {};
+    render(() => <RailActions setters={setters} />);
+    openMenu();
+    expect(screen.queryByTestId("rail-action-mentions")).toBeNull();
+  });
+
+  it("hides the entry with no network context at all (home)", () => {
+    roomsSlugHolder.value = null;
+    mentionsBundles.value = { freenode: {} };
+    render(() => <RailActions setters={setters} />);
+    openMenu();
+    expect(screen.queryByTestId("rail-action-mentions")).toBeNull();
+  });
+
+  it("routes through the shared nav mutex to the mentions window", () => {
+    selHolder.value = channelSel;
+    mentionsBundles.value = { freenode: {} };
+    render(() => <RailActions setters={setters} />);
+    openMenu();
+    fireEvent.click(screen.getByTestId("rail-action-mentions"));
+    expect(openMentionsPanel).toHaveBeenCalledWith(setters, expect.any(Function));
+    // The nav thunk is what actually selects the window — run it and assert
+    // the payload, rather than trusting that the mutex helper was called.
+    const navThunk = openMentionsPanel.mock.calls[0]?.[1] as (() => void) | undefined;
+    if (navThunk === undefined) throw new Error("openMentionsPanel got no nav thunk");
+    navThunk();
+    expect(setSelectedChannel).toHaveBeenCalledWith({
+      networkSlug: "freenode",
+      channelName: "",
+      kind: "mentions",
+    });
+  });
+
+  // #473's capability-only rule, applied. The @ was `isMobile()`-gated in
+  // ShellChrome to avoid duplicating the desktop Sidebar mentions row (#71
+  // INC-2); in the rail that gate would be the one thing this component says
+  // it never does, and `home` is the standing precedent for a rail launcher
+  // that doubles a sidebar row.
+  it("carries NO form-factor gate — desktop gets it too", () => {
+    selHolder.value = channelSel;
+    mentionsBundles.value = { freenode: {} };
+    render(() => <RailActions setters={setters} />);
+    openMenu();
+    // isMobile is never consulted: the module is not even imported, so a
+    // reintroduced gate would have to add it back. Assert the outcome the
+    // rule produces — the entry is there with no viewport stubbing at all.
+    expect(screen.getByTestId("rail-action-mentions")).toBeInTheDocument();
+  });
+});
+
+describe("RailActions — detach + quit (#986)", () => {
+  const USER = { kind: "user" as const, id: "u1", name: "alice" };
+  const REGISTERED_VISITOR = {
+    kind: "visitor" as const,
+    id: "v1",
+    nick: "vjt",
+    registered: true,
+  };
+  const ANON_VISITOR = { kind: "visitor" as const, id: "v2", nick: "guest", registered: false };
+
+  const mountWithSubject = (subject: typeof subjectHolder.current): void => {
+    subjectHolder.current = subject;
+    render(() => (
+      <>
+        <RailActions setters={setters} />
+        <ConfirmModal />
+      </>
+    ));
+    openMenu();
+  };
+
+  const quitBodyFor = (subject: typeof subjectHolder.current): string => {
+    mountWithSubject(subject);
+    fireEvent.click(screen.getByTestId("quit-irc-btn"));
+    return screen.getByTestId("confirm-modal-body").textContent ?? "";
+  };
+
+  it("offers quit to every subject and detach only to a persistent identity", () => {
+    mountWithSubject(ANON_VISITOR);
+    expect(screen.getByTestId("quit-irc-btn")).toBeInTheDocument();
+    expect(screen.queryByTestId("detach-btn")).toBeNull();
+
+    cleanup();
+    mountWithSubject(USER);
+    expect(screen.getByTestId("detach-btn")).toBeInTheDocument();
+
+    cleanup();
+    mountWithSubject(REGISTERED_VISITOR);
+    expect(screen.getByTestId("detach-btn")).toBeInTheDocument();
+  });
+
+  it("carries a name next to the glyph, like every other rail row", () => {
+    mountWithSubject(USER);
+    expect(screen.getByTestId("detach-btn")).toHaveTextContent("detach");
+    expect(screen.getByTestId("quit-irc-btn")).toHaveTextContent("quit");
+  });
+
+  // THE assertion of this issue. Three subjects, three visibly different
+  // sentences in the rendered modal — not three calls that happen to open a
+  // modal carrying one shared string.
+  it("renders a DIFFERENT quit modal body for each of the three subject shapes", () => {
+    const user = quitBodyFor(USER);
+    cleanup();
+    const registeredVisitor = quitBodyFor(REGISTERED_VISITOR);
+    cleanup();
+    const anon = quitBodyFor(ANON_VISITOR);
+
+    expect(user).not.toBe("");
+    expect(new Set([user, registeredVisitor, anon]).size).toBe(3);
+    // …and each says the thing that is TRUE for it: only the anon session is
+    // destroyed, both persistent ones survive.
+    expect(anon).toMatch(/delete|permanently/i);
+    expect(user).toMatch(/survive/i);
+    expect(registeredVisitor).toMatch(/survive/i);
+    expect(user).not.toMatch(/delete/i);
+    expect(registeredVisitor).not.toMatch(/delete/i);
+  });
+
+  it("opens ONE confirm paradigm — the shared modal, never a two-tap arm", () => {
+    mountWithSubject(USER);
+    const quit = screen.getByTestId("quit-irc-btn");
+    fireEvent.click(quit);
+    // The old settings control re-labelled itself to "really quit IRC?" on
+    // the first tap and fired on the second. The rail entry does neither: it
+    // keeps its label and hands off to the modal.
+    expect(quit).toHaveTextContent("quit");
+    expect(quit).not.toHaveTextContent(/really quit/i);
+    expect(screen.getByTestId("confirm-modal")).toBeInTheDocument();
+  });
+
+  it("a tap tears NOTHING down until the modal is confirmed", async () => {
+    const quitMod = await import("../lib/quit");
+    const auth = await import("../lib/auth");
+    mountWithSubject(USER);
+
+    fireEvent.click(screen.getByTestId("quit-irc-btn"));
+    expect(quitMod.quitAll).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("confirm-modal-cancel"));
+    expect(quitMod.quitAll).not.toHaveBeenCalled();
+    expect(auth.logout).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("confirming quit parks all networks and lands on /login", async () => {
+    const quitMod = await import("../lib/quit");
+    mountWithSubject(USER);
+
+    fireEvent.click(screen.getByTestId("quit-irc-btn"));
+    fireEvent.click(screen.getByTestId("confirm-modal-confirm"));
+
+    expect(quitMod.quitAll).toHaveBeenCalled();
+    await vi.waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/login", { replace: true }));
+  });
+
+  it("confirming detach revokes the web session WITHOUT parking anything", async () => {
+    const quitMod = await import("../lib/quit");
+    const auth = await import("../lib/auth");
+    mountWithSubject(USER);
+
+    fireEvent.click(screen.getByTestId("detach-btn"));
+    fireEvent.click(screen.getByTestId("confirm-modal-confirm"));
+
+    expect(auth.logout).toHaveBeenCalled();
+    // detach is the ABSENCE of teardown — the bouncer stays up.
+    expect(quitMod.quitAll).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/login", { replace: true }));
+  });
+
+  // The full row order with EVERY gate satisfied. Shell.test.tsx asserts the
+  // same list against a mounted Shell but its auth fixture has no subject, so
+  // detach is absent there; this is the one place the complete contract —
+  // navigation set first, lifecycle pair last — is pinned.
+  it("puts the lifecycle pair LAST, after the whole navigation set", () => {
+    adminHolder.value = true;
+    selHolder.value = channelSel;
+    mentionsBundles.value = { freenode: {} };
+    subjectHolder.current = USER;
+    const { container } = render(() => <RailActions setters={setters} />);
+    openMenu();
+    const order = Array.from(
+      container.querySelectorAll<HTMLElement>(".rail-actions-menu .rail-action"),
+    ).map((b) => b.getAttribute("data-testid"));
+    expect(order).toEqual([
+      "mobile-panel-home",
+      "mobile-panel-list",
+      "rail-action-mentions",
+      "mobile-panel-themes",
+      "mobile-panel-archive",
+      "action-cluster-cog",
+      "mobile-panel-admin",
+      "presence-toggle",
+      "detach-btn",
+      "quit-irc-btn",
+    ]);
+  });
+
+  it("closes the menu on tap so no live menu waits under the modal", () => {
+    mountWithSubject(USER);
+    fireEvent.click(screen.getByTestId("quit-irc-btn"));
+    expect(screen.queryByTestId("action-cluster-cog")).toBeNull();
   });
 });

--- a/cicchetto/src/__tests__/SettingsDrawer.test.tsx
+++ b/cicchetto/src/__tests__/SettingsDrawer.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
-import { createSignal } from "solid-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@solidjs/router", () => ({
@@ -37,9 +36,11 @@ const subjectHolder = vi.hoisted(() => ({
       }
     | null,
 }));
-// Spread the REAL auth module so `showDetach`'s `isPersistentIdentity`
-// predicate runs for real against the stubbed getSubject (the drawer +
-// lib/lifecycle both route on it now). Only side-effecting exports stubbed.
+// Spread the REAL auth module so the `isPersistentIdentity` predicate runs
+// for real against the stubbed getSubject. #986 moved the drawer's detach
+// gate out (lib/lifecycle's `canDetach()` asks the same question for the
+// rail), so what this stub still serves here is the visitor / incognito
+// share-session gating. Only side-effecting exports stubbed.
 vi.mock("../lib/auth", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../lib/auth")>()),
   logout: vi.fn().mockResolvedValue(undefined),
@@ -47,12 +48,13 @@ vi.mock("../lib/auth", async (importOriginal) => ({
   getSubject: () => subjectHolder.current,
 }));
 
-// #126 — the drawer routes detach/quit through lib/lifecycle. The
-// lifecycle module is NOT mocked here (so the existing detach→logout /
-// quit→quitAll wiring assertions still hold via the underlying auth/quit
-// mocks); lifecycle's own per-subject routing has dedicated coverage in
-// lib/lifecycle.test.ts. We mock the api verbs the drawer touches
-// (updateIdentity) so a click doesn't hit the network.
+// #986 — the drawer no longer routes detach/quit at all: those verbs moved
+// to the rail actions menu behind the shared confirm modal (RailActions.tsx
+// owns their rendering + copy tests; lib/lifecycle.test.ts owns the per-
+// subject routing). The drawer still reaches lib/lifecycle for
+// `updateIdentity`, so the api verbs stay mocked to keep a click off the
+// network. `../lib/quit` stays mocked as a guard: any assertion below that
+// the drawer parks something would now be a bug.
 vi.mock("../lib/api", () => ({
   // #211 phase 7 — the identity editor PATCHes /networks/:slug/identity via
   // lib/lifecycle's updateIdentity, which calls api.updateNetworkIdentity.
@@ -267,8 +269,8 @@ vi.mock("../DeleteAccountModal", async () => {
 
 import SettingsDrawer from "../SettingsDrawer";
 
-const wrap = (open: boolean, onClose = vi.fn(), onOpenAdmin = vi.fn()) =>
-  render(() => <SettingsDrawer open={open} onClose={onClose} onOpenAdmin={onOpenAdmin} />);
+const wrap = (open: boolean, onClose = vi.fn()) =>
+  render(() => <SettingsDrawer open={open} onClose={onClose} />);
 
 // #460 — the settings main page is an index of nav rows; general / display /
 // push (notifications) content now lives in dedicated sub-pages reached by
@@ -316,19 +318,14 @@ describe("SettingsDrawer", () => {
     expect(timeFormat.setTimeFormat).toHaveBeenCalledWith("hm");
   });
 
-  it("null subject (loading) shows quit alone (no 'log out', no detach); two-tap detaches", async () => {
-    // #126 — "log out" is retired. The not-yet-loaded null subject gets
-    // only the universal quit verb; clicking through the two-tap routes
-    // to quit() → (null subject) logout().
-    const auth = await import("../lib/auth");
+  it("#986 — carries NO session-lifecycle verb for the loading null subject", () => {
+    // #126 retired "log out"; #986 moved detach + quit out of the drawer
+    // entirely. Two doors to a destructive verb — one confirmed and one not
+    // — is worse than either, so nothing lifecycle-shaped stayed behind.
     wrap(true);
     expect(screen.queryByText(/^log out$/i)).toBeNull();
     expect(screen.queryByTestId("detach-btn")).toBeNull();
-    fireEvent.click(screen.getByTestId("quit-irc-btn")); // arm
-    fireEvent.click(screen.getByTestId("quit-irc-btn")); // confirm
-    await waitFor(() => {
-      expect(auth.logout).toHaveBeenCalled();
-    });
+    expect(screen.queryByTestId("quit-irc-btn")).toBeNull();
   });
 
   it("backdrop click fires onClose", () => {
@@ -692,115 +689,57 @@ describe("SettingsDrawer (visitor subject)", () => {
     });
   });
 
-  it("renders the universal quit verb for the loading null subject", () => {
+  it("#986 — the loading null subject sees no lifecycle affordance here", () => {
     wrap(true);
-    // #126 — the lifecycle affordance is quit alone for the not-yet-loaded
-    // subject ("log out" retired). (#299 removed the theme radio selector.)
-    expect(screen.getByTestId("quit-irc-btn")).toBeInTheDocument();
+    // #126 retired "log out"; #986 moved quit to the rail. (#299 removed the
+    // theme radio selector.)
+    expect(screen.queryByTestId("quit-irc-btn")).toBeNull();
     expect(screen.queryByText(/^log out$/i)).toBeNull();
   });
 });
 
-// M-cluster M-7 — admin console entry gate. Per
-// `feedback_e2e_user_class_parity_matrix`: the admin entry is
-// admin-gated EXEMPT (only one of the three subject classes sees it).
-// The vitest covers visibility polarity; the Playwright e2e covers
-// end-to-end login → drawer-open → entry-visibility per subject class.
-describe("SettingsDrawer (M-7 admin console entry)", () => {
-  it("hides admin entry when subject is non-admin user", () => {
+// #986 — the M-7 admin console entry is GONE from the drawer. It was an
+// exact duplicate of the rail's 🔧 admin action: same `isAdmin()` gate, same
+// `setSelectedChannel({ kind: "admin" })` payload, same destination. The gate
+// itself did not disappear — RailActions.test.tsx owns its polarity now — so
+// what is left to assert here is that no second door survived, for ANY
+// subject class, including the admin who is the only one who ever saw it.
+describe("SettingsDrawer (#986 — the duplicate admin console entry is gone)", () => {
+  it("withholds an admin entry even from an admin (the rail 🔧 is the one door)", () => {
     meHolder.current = {
       kind: "user",
       id: "u1",
-      name: "alice",
-      is_admin: false,
+      name: "vjt",
+      is_admin: true,
       inserted_at: "x",
     };
     wrap(true);
     expect(screen.queryByTestId("admin-console-entry")).toBeNull();
     expect(screen.queryByText(/admin console/i)).toBeNull();
   });
-
-  it("hides admin entry when subject is a visitor", () => {
-    meHolder.current = {
-      kind: "visitor",
-      id: "v1",
-      nick: "anon-vjt",
-      expires_at: "2026-05-17T00:00:00Z",
-    };
-    wrap(true);
-    expect(screen.queryByTestId("admin-console-entry")).toBeNull();
-  });
-
-  it("hides admin entry when subject is not yet loaded (me() === null)", () => {
-    meHolder.current = null;
-    wrap(true);
-    expect(screen.queryByTestId("admin-console-entry")).toBeNull();
-  });
-
-  it("shows admin entry when user is admin", () => {
-    meHolder.current = {
-      kind: "user",
-      id: "u1",
-      name: "vjt",
-      is_admin: true,
-      inserted_at: "x",
-    };
-    wrap(true);
-    const entry = screen.getByTestId("admin-console-entry");
-    expect(entry).toBeInTheDocument();
-    // textContent guard per
-    // `feedback_css_block_button_wraps_inline_prefix` — pseudo-element
-    // sigils / inline prefixes can clip the visible label even when
-    // the button itself is present.
-    expect(entry.textContent).toContain("admin console");
-  });
-
-  it("clicking admin entry fires onClose THEN onOpenAdmin (drawer dismiss → pane mount handoff)", () => {
-    meHolder.current = {
-      kind: "user",
-      id: "u1",
-      name: "vjt",
-      is_admin: true,
-      inserted_at: "x",
-    };
-    const onClose = vi.fn();
-    const onOpenAdmin = vi.fn();
-    wrap(true, onClose, onOpenAdmin);
-    fireEvent.click(screen.getByTestId("admin-console-entry"));
-    expect(onClose).toHaveBeenCalledTimes(1);
-    expect(onOpenAdmin).toHaveBeenCalledTimes(1);
-    // Order matters — drawer dismisses BEFORE pane mounts so the two
-    // overlays don't briefly co-exist. Assert call-order via mock
-    // invocation ordinals.
-    const closeOrder = onClose.mock.invocationCallOrder[0];
-    const openOrder = onOpenAdmin.mock.invocationCallOrder[0];
-    expect(closeOrder !== undefined && openOrder !== undefined && closeOrder < openOrder).toBe(
-      true,
-    );
-  });
 });
 
 describe("SettingsDrawer (bucket L — chrome polish)", () => {
   it("renders × close button in the header (desktop parity)", () => {
-    wrap(true, vi.fn(), vi.fn());
+    wrap(true, vi.fn());
     expect(screen.getByTestId("settings-drawer-close")).toBeInTheDocument();
   });
 
   it("clicking × close fires onClose", () => {
     const onClose = vi.fn();
-    wrap(true, onClose, vi.fn());
+    wrap(true, onClose);
     fireEvent.click(screen.getByTestId("settings-drawer-close"));
     expect(onClose).toHaveBeenCalled();
   });
 
   it("renders bottom done button (mobile thumb-reach)", () => {
-    wrap(true, vi.fn(), vi.fn());
+    wrap(true, vi.fn());
     expect(screen.getByTestId("settings-drawer-done")).toBeInTheDocument();
   });
 
   it("clicking done fires onClose", () => {
     const onClose = vi.fn();
-    wrap(true, onClose, vi.fn());
+    wrap(true, onClose);
     fireEvent.click(screen.getByTestId("settings-drawer-done"));
     expect(onClose).toHaveBeenCalled();
   });
@@ -959,73 +898,48 @@ describe("SettingsDrawer (share session — visitor only)", () => {
   });
 });
 
-// Issue #43 / #126 — a registered user gets "detach" (leave cic, KEEP
-// the bouncer) + a destructive two-tap "quit" (park ALL networks +
-// detach). Under #126 "log out" is retired and the same persistent
-// -identity verbs extend to the NickServ visitor (separate describe
-// below); ephemeral visitors + the loading null subject get quit alone.
-describe("SettingsDrawer (issue #43 — detach + quit for a user)", () => {
-  beforeEach(() => {
-    subjectHolder.current = { kind: "user", id: "u1", name: "alice" };
-  });
+// Issue #43 / #126 / #986 — the session-lifecycle verbs are no longer this
+// component's. `detach` (leave cic, KEEP the bouncer) and `quit` (park every
+// network and go offline) are rail-actions entries behind the shared confirm
+// modal; RailActions.test.tsx owns their gating, their wiring and — the point
+// of #986 — the three per-subject modal bodies. What survives here is the
+// guard that no drawer copy stayed armed differently from the rail copy, for
+// any of the three subject classes.
+describe("SettingsDrawer (#986 — the lifecycle verbs left the drawer)", () => {
+  const CLASSES = [
+    { name: "registered user", subject: { kind: "user" as const, id: "u1", name: "alice" } },
+    {
+      name: "registered visitor",
+      subject: { kind: "visitor" as const, id: "v1", nick: "vjt", registered: true },
+    },
+    {
+      name: "ephemeral visitor",
+      subject: { kind: "visitor" as const, id: "v2", nick: "guest" },
+    },
+  ];
 
-  it("renders detach + quit for a registered user (no bare 'log out')", () => {
-    wrap(true);
-    expect(screen.getByTestId("detach-btn")).toHaveTextContent(/^detach$/i);
-    expect(screen.getByTestId("quit-irc-btn")).toHaveTextContent(/^quit$/i);
-    expect(screen.queryByText(/log out/i)).toBeNull();
-  });
+  for (const c of CLASSES) {
+    it(`withholds detach + quit from a ${c.name} (both moved to the rail)`, () => {
+      subjectHolder.current = c.subject;
+      wrap(true);
+      expect(screen.queryByTestId("detach-btn")).toBeNull();
+      expect(screen.queryByTestId("quit-irc-btn")).toBeNull();
+      // #126 relics, still retired.
+      expect(screen.queryByText(/^log out$/i)).toBeNull();
+      expect(screen.queryByTestId("disconnect-btn")).toBeNull();
+      expect(screen.queryByTestId("reconnect-btn")).toBeNull();
+    });
+  }
 
-  it("clicking detach calls auth.logout, NOT quit.quitAll", async () => {
+  it("never tears anything down — the drawer holds no teardown path at all", async () => {
     const auth = await import("../lib/auth");
     const quit = await import("../lib/quit");
+    subjectHolder.current = { kind: "user", id: "u1", name: "alice" };
     wrap(true);
-    fireEvent.click(screen.getByTestId("detach-btn"));
-    expect(auth.logout).toHaveBeenCalled();
+    // No two-tap arm to walk, and nothing else in the drawer may substitute
+    // for one: opening it must not reach logout / park-all by any route.
+    expect(auth.logout).not.toHaveBeenCalled();
     expect(quit.quitAll).not.toHaveBeenCalled();
-  });
-
-  it("a single tap on quit arms it (shows confirm copy) but does NOT quit", async () => {
-    const quit = await import("../lib/quit");
-    wrap(true);
-    fireEvent.click(screen.getByTestId("quit-irc-btn"));
-    expect(screen.getByTestId("quit-irc-btn")).toHaveTextContent(/really quit IRC/i);
-    expect(quit.quitAll).not.toHaveBeenCalled();
-  });
-
-  it("two-tap on quit calls quit.quitAll", async () => {
-    const quit = await import("../lib/quit");
-    wrap(true);
-    fireEvent.click(screen.getByTestId("quit-irc-btn")); // arm
-    fireEvent.click(screen.getByTestId("quit-irc-btn")); // confirm
-    await waitFor(() => {
-      expect(quit.quitAll).toHaveBeenCalled();
-    });
-  });
-
-  it("closing the drawer disarms an armed quit button", async () => {
-    const [open, setOpen] = createSignal(true);
-    render(() => <SettingsDrawer open={open()} onClose={vi.fn()} onOpenAdmin={vi.fn()} />);
-    fireEvent.click(screen.getByTestId("quit-irc-btn")); // arm
-    expect(screen.getByTestId("quit-irc-btn")).toHaveTextContent(/really quit IRC/i);
-    setOpen(false); // close
-    await Promise.resolve();
-    setOpen(true); // reopen
-    await Promise.resolve();
-    expect(screen.getByTestId("quit-irc-btn")).toHaveTextContent(/^quit$/i);
-  });
-
-  it("ephemeral visitor gets quit alone — no detach, no disconnect/reconnect, no 'log out'", () => {
-    // #126 — an ephemeral (non-registered) visitor has no persistent
-    // identity, so the persistent-identity verbs are withheld; quit is
-    // the only (universal) verb. registered omitted = not registered.
-    subjectHolder.current = { kind: "visitor", id: "v1", nick: "guest" };
-    wrap(true);
-    expect(screen.getByTestId("quit-irc-btn")).toBeInTheDocument();
-    expect(screen.queryByTestId("detach-btn")).toBeNull();
-    expect(screen.queryByTestId("disconnect-btn")).toBeNull();
-    expect(screen.queryByTestId("reconnect-btn")).toBeNull();
-    expect(screen.queryByText(/^log out$/i)).toBeNull();
   });
 });
 
@@ -1033,8 +947,10 @@ describe("SettingsDrawer (issue #43 — detach + quit for a user)", () => {
 // identity, so it gets the SAME persistent-identity verbs as a user
 // (detach + disconnect ⇄ reconnect) PLUS the universal quit. The
 // disconnect/reconnect button face follows the whereis-derived
-// `connected` flag from /me.
-describe("SettingsDrawer (#126 — registered-visitor lifecycle verbs)", () => {
+// `connected` flag from /me. (#986 — detach + quit themselves moved to the
+// rail; what this describe still owns is the registered visitor's per-network
+// identity editor and the retired-toggle guard.)
+describe("SettingsDrawer (#126 — registered-visitor drawer surface)", () => {
   beforeEach(() => {
     subjectHolder.current = {
       kind: "visitor",
@@ -1044,7 +960,7 @@ describe("SettingsDrawer (#126 — registered-visitor lifecycle verbs)", () => {
     };
   });
 
-  it("#211 phase 6 — detach + quit, NO disconnect/reconnect toggle", () => {
+  it("#211 phase 6 — NO disconnect/reconnect toggle", () => {
     meHolder.current = {
       kind: "visitor",
       id: "v1",
@@ -1053,8 +969,6 @@ describe("SettingsDrawer (#126 — registered-visitor lifecycle verbs)", () => {
       registered: true,
     };
     wrap(true);
-    expect(screen.getByTestId("detach-btn")).toHaveTextContent(/^detach$/i);
-    expect(screen.getByTestId("quit-irc-btn")).toHaveTextContent(/^quit$/i);
     // The disconnect ⇄ reconnect toggle is RETIRED — per-network
     // park/reconnect lives on the home page now (ruling D).
     expect(screen.queryByTestId("disconnect-btn")).toBeNull();
@@ -1514,12 +1428,12 @@ describe("SettingsDrawer (#460 — settings index)", () => {
     expect(screen.queryByTestId("themes-settings-entry")).toBeNull();
   });
 
-  it("share session, quit + done stay on the main index page (not moved into a sub-page)", () => {
+  it("share session + done stay on the main index page (not moved into a sub-page)", () => {
     subjectHolder.current = { kind: "visitor", id: "v1", nick: "alice" };
     wrap(true);
-    // These affordances live BELOW the index on the main page.
+    // These affordances live BELOW the index on the main page. (#986 — quit
+    // used to be asserted here too; it is a rail entry now.)
     expect(screen.getByTestId("share-session-entry")).toBeInTheDocument();
-    expect(screen.getByTestId("quit-irc-btn")).toBeInTheDocument();
     expect(screen.getByTestId("settings-drawer-done")).toBeInTheDocument();
   });
 });

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -240,7 +240,7 @@ vi.mock("../lib/theme", () => ({
 
 // Spread the real auth module (importOriginal — same pattern the
 // uploadOrchestrator mock below uses) so the pure `isPersistentIdentity`
-// predicate resolves for real: #477 routes SettingsDrawer.showDetach + the
+// predicate resolves for real: #477 routes the detach gate + the
 // quit path through it, and Shell renders SettingsDrawer, so a bare factory
 // mock lacking that export crashes the drawer the moment Shell mounts it.
 // Only the side-effecting exports are stubbed.
@@ -1219,7 +1219,7 @@ describe("#361 / #473 — rooms (list) launcher in the RailActions drawer", () =
     });
   });
 
-  it("#473 drawer order: home · rooms · themes · archive · settings · admin · denoise", async () => {
+  it("#473/#986 drawer order: home · rooms · mentions · themes · archive · settings · admin · denoise · quit", async () => {
     mobileState.value = true;
     userHolder.current = {
       kind: "user",
@@ -1235,7 +1235,7 @@ describe("#361 / #473 — rooms (list) launcher in the RailActions drawer", () =
     });
     // #500 — open the launcher; the actions live in the expanded menu now. The
     // launcher itself also carries `.rail-action`, so scope the order query to
-    // the MENU to assert only the seven action buttons.
+    // the MENU to assert only the action buttons.
     openRailMenu();
     const menu = container.querySelector(".shell-members .rail-actions-menu");
     const order = Array.from(menu?.querySelectorAll<HTMLElement>(".rail-action") ?? []).map((b) =>
@@ -1245,14 +1245,23 @@ describe("#361 / #473 — rooms (list) launcher in the RailActions drawer", () =
     // now a first-class button (always-on, between themes and the cog); denoise
     // is the channel-gated trailer, present on this channel window. testids kept
     // where the button survives.
+    // #986 — mentions joins the navigation set (this fixture seeds a freenode
+    // bundle) and the lifecycle pair closes the list, AFTER it: the
+    // conventional slot for a destructive verb. `detach-btn` is absent here
+    // and that is CORRECT — the auth mock above returns `getSubject() => null`,
+    // and a null subject is not a persistent identity, so `canDetach()` is
+    // false. The full ten-row order with a real subject is asserted in
+    // RailActions.test.tsx, which owns that gate.
     expect(order).toEqual([
       "mobile-panel-home",
       "mobile-panel-list",
+      "rail-action-mentions",
       "mobile-panel-themes",
       "mobile-panel-archive",
       "action-cluster-cog",
       "mobile-panel-admin",
       "presence-toggle",
+      "quit-irc-btn",
     ]);
     // The mobile-only launcher footer is gone entirely.
     expect(container.querySelector(".shell-members .mobile-panel-actions")).toBeNull();
@@ -1266,9 +1275,11 @@ describe("#361 / #473 — rooms (list) launcher in the RailActions drawer", () =
 // auto-redirects to home on demote.
 //
 // UX-4 bucket N (2026-05-19) — pane mount is now selection-driven:
-// `<Show when={sel.kind === "admin" && isAdmin()}>`. The drawer
-// "admin console" entry sets selection to the admin window; the
-// dedicated sidebar admin row does the same. Demote-mid-session
+// `<Show when={sel.kind === "admin" && isAdmin()}>`. The rail's 🔧 admin
+// launcher sets selection to the admin window; the dedicated sidebar admin
+// row does the same. (#986 removed a third, duplicate door — the settings
+// drawer's "admin console" entry — and its `onOpenAdmin` prop with it, so
+// the tests below drive the rail.) Demote-mid-session
 // redirects selection back to home (was: flip adminOpen=false; now:
 // setSelectedChannel(home), which collapses the admin Show AND lands
 // the operator on a deterministic window). Tests below pin both paths.
@@ -1278,24 +1289,25 @@ describe("Shell — M-7/N admin pane lifecycle", () => {
     selectionState.setSelSig({ networkSlug: "freenode", channelName: "#a", kind: "channel" });
     const { container } = render(() => <Shell />);
     expect(container.querySelector(".admin-pane")).toBeNull();
-    // Drawer entry hidden for non-admin (gated in SettingsDrawer).
+    // #986 — the drawer entry is gone outright; the rail launcher is the one
+    // door and stays isAdmin()-gated.
     expect(container.querySelector(".admin-console-entry")).toBeNull();
+    openRailMenu();
+    expect(screen.queryByTestId("mobile-panel-admin")).toBeNull();
   });
 
-  it("admin user can open the admin pane via the drawer entry; channel pane unmounts", async () => {
+  it("admin user can open the admin pane via the rail launcher; channel pane unmounts", async () => {
     userHolder.current = { kind: "user", id: "u1", name: "vjt", is_admin: true, inserted_at: "x" };
     selectionState.setSelSig({ networkSlug: "freenode", channelName: "#a", kind: "channel" });
     const { container } = render(() => <Shell />);
     // Pre-click — channel content visible, no admin pane.
     expect(container.querySelector(".admin-pane")).toBeNull();
     expect(container.querySelector(".scrollback-pane")).toBeInTheDocument();
-    // Open settings overlay → click admin console entry. #500 — the cog is
-    // behind the rail launcher, so open it first.
+    // #500/#986 — the actions are behind the rail launcher; the 🔧 admin
+    // entry is the ONE door to the pane now.
     openRailMenu();
-    fireEvent.click(screen.getByLabelText(/open settings/i));
-    const entry = await screen.findByTestId("admin-console-entry");
-    fireEvent.click(entry);
-    // UX-4 bucket N — selection-driven: drawer entry sets selection to
+    fireEvent.click(await screen.findByTestId("mobile-panel-admin"));
+    // UX-4 bucket N — selection-driven: the launcher sets selection to the
     // admin window. Shell's `<Show when={sel.kind === "admin" && isAdmin()}>`
     // flips true on the next reactive cycle.
     await waitFor(() => {
@@ -1314,9 +1326,9 @@ describe("Shell — M-7/N admin pane lifecycle", () => {
 
   it("clicking admin pane close button returns to home (selection-driven)", async () => {
     userHolder.current = { kind: "user", id: "u1", name: "vjt", is_admin: true, inserted_at: "x" };
-    // Start on admin window directly — equivalent to the post-drawer-
-    // entry state. Avoids re-asserting the drawer wiring here (covered
-    // by the prior test).
+    // Start on admin window directly — equivalent to the post-launcher
+    // state. Avoids re-asserting the rail wiring here (covered by the
+    // prior test).
     selectionState.setSelSig({ networkSlug: "$admin", channelName: "$admin", kind: "admin" });
     const { container } = render(() => <Shell />);
     await waitFor(() => expect(container.querySelector(".admin-pane")).toBeInTheDocument());

--- a/cicchetto/src/__tests__/ShellChrome.test.tsx
+++ b/cicchetto/src/__tests__/ShellChrome.test.tsx
@@ -12,14 +12,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // #473 — the standalone archive button (📂) was REMOVED from ShellChrome.
 // It was a third archive entry point; archive now lives as an always-on
 // button in the RailActions drawer (reachable via this same ☰ opener), so
-// the inline button + its `setArchiveModalNetwork` wiring are gone. The @
-// mentions button remains (it derives its network via archiveContext).
+// the inline button + its `setArchiveModalNetwork` wiring are gone.
+//
+// #986 — the @ mentions button went the same way, into the RailActions menu
+// (`rail-action-mentions`, tested there — including the gate that used to
+// live here). That leaves this bar holding NOTHING but the opener, which is
+// the precondition #985 needs to drop `.shell-chrome` entirely and float a
+// lone ☰. The tests below are what stops the @ drifting back: this component
+// no longer imports selection, mentionsWindow or theme at all.
 //
 // UX-5 bucket A (2026-05-19) — the hamburger slot was dropped from
 // ShellChrome entirely. Pre-bucket the chrome rendered a hamburger
 // that duplicated TopicBar's `.topic-bar-hamburger` on mobile and
 // toggled a no-op `.open` class on desktop. Hamburger-related tests
-// moved out; only the rail opener + @ mentions surfaces remain.
+// moved out; only the rail opener remains.
 //
 // UX-5 bucket BM (2026-05-20) — the `ChromeButtons` named export was
 // dropped (BT introduced it for the mobile-channel `inlineChromeSlot`
@@ -28,46 +34,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // ShellChrome body). The `describe("ChromeButtons inline export")`
 // block was deleted with the export.
 
-// Selection is mocked per test. Returning null = empty (no window).
-let mockSelected: {
-  networkSlug: string;
-  channelName: string;
-  kind: "channel" | "query" | "server" | "home" | "mentions";
-} | null = null;
-const mockSetSelectedChannel = vi.fn();
-vi.mock("../lib/selection", () => ({
-  selectedChannel: () => mockSelected,
-  setSelectedChannel: (...args: unknown[]) => mockSetSelectedChannel(...args),
-  applySeedEnvelope: vi.fn(),
-}));
-
-// #188 — the open-mentions button only surfaces when a bundle exists for
-// the selected window's network. A mutable holder lets each test control
-// which slugs have a bundle.
-const mentionsBundles = vi.hoisted(() => ({ value: {} as Record<string, unknown> }));
-vi.mock("../lib/mentionsWindow", () => ({
-  mentionsBundleBySlug: () => mentionsBundles.value,
-}));
-
-// Post-bundle desktop fix — ShellChrome's archive button is now gated on
-// `isMobile()` so desktop doesn't render it (Sidebar's `<details
-// class="sidebar-archive">` already exposes parked rows inline). Mirror
-// the Shell.test.tsx pattern: a mutable hoisted holder so individual
-// describe blocks can flip mobile/desktop.
-const mobileState = vi.hoisted(() => ({ value: true }));
-vi.mock("../lib/theme", () => ({
-  isMobile: () => mobileState.value,
-  // #358 — customTheme's apply effect reads this; a constant is enough here.
-  prefersDark: () => false,
-}));
-
 import ShellChrome from "../ShellChrome";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockSelected = null;
-  mobileState.value = true;
-  mentionsBundles.value = {};
 });
 
 describe("ShellChrome (bucket L)", () => {
@@ -95,7 +65,6 @@ describe("ShellChrome (bucket L)", () => {
   });
 
   it("UX-5 bucket A — does NOT render a hamburger button (slot dropped)", () => {
-    mockSelected = { networkSlug: "freenode", channelName: "#italia", kind: "channel" };
     const { container } = render(() => <ShellChrome onOpenRail={vi.fn()} />);
     expect(container.querySelectorAll(".shell-chrome-hamburger").length).toBe(0);
     expect(screen.queryByLabelText(/open channel sidebar/i)).toBeNull();
@@ -106,59 +75,21 @@ describe("ShellChrome (bucket L)", () => {
   // was a third archive entry point). Guard against a regression that
   // reintroduces it: it must never render, on any window kind or viewport.
   it("does NOT render an archive button (#473 — archive lives in the RailActions drawer)", () => {
-    mockSelected = { networkSlug: "freenode", channelName: "#italia", kind: "channel" };
     render(() => <ShellChrome onOpenRail={vi.fn()} />);
     expect(screen.queryByTestId("shell-chrome-archive")).toBeNull();
   });
 
-  // #188 item 6 — a button next to the rail opener opens the mentions
-  // panel. It derives the network from the current selection and renders
-  // ONLY when that network has a bundle to consult.
-  describe("open-mentions button (#188)", () => {
-    it("shows the button when the selected network has a mentions bundle", () => {
-      mockSelected = { networkSlug: "freenode", channelName: "#italia", kind: "channel" };
-      mentionsBundles.value = { freenode: {} };
-      render(() => <ShellChrome onOpenRail={vi.fn()} />);
-      expect(screen.getByTestId("shell-chrome-mentions")).toBeInTheDocument();
-    });
-
-    it("hides the button when the selected network has no bundle", () => {
-      mockSelected = { networkSlug: "freenode", channelName: "#italia", kind: "channel" };
-      mentionsBundles.value = {};
-      render(() => <ShellChrome onOpenRail={vi.fn()} />);
-      expect(screen.queryByTestId("shell-chrome-mentions")).toBeNull();
-    });
-
-    it("hides the button when no window carries a network context (home)", () => {
-      mockSelected = { networkSlug: "home", channelName: "home", kind: "home" };
-      mentionsBundles.value = { home: {} };
-      render(() => <ShellChrome onOpenRail={vi.fn()} />);
-      expect(screen.queryByTestId("shell-chrome-mentions")).toBeNull();
-    });
-
-    // #71 INC-2 — the @ open-mentions button is now MOBILE-ONLY. On desktop the
-    // per-network Sidebar mentions row (Sidebar.tsx) replaces it, so ShellChrome
-    // must NOT render the @ on desktop even when a bundle exists — else it would
-    // duplicate the sidebar row. Mobile has no sidebar, so the @ stays here as
-    // the only mentions re-open door (auto-nav on arrival covers the first open).
-    it("#71 INC-2 — hides the @ on desktop even with a bundle (sidebar row replaces it)", () => {
-      mobileState.value = false;
-      mockSelected = { networkSlug: "freenode", channelName: "#italia", kind: "channel" };
-      mentionsBundles.value = { freenode: {} };
-      render(() => <ShellChrome onOpenRail={vi.fn()} />);
-      expect(screen.queryByTestId("shell-chrome-mentions")).toBeNull();
-    });
-
-    it("clicking it opens the mentions pseudo-window for the selected network", () => {
-      mockSelected = { networkSlug: "freenode", channelName: "#italia", kind: "channel" };
-      mentionsBundles.value = { freenode: {} };
-      render(() => <ShellChrome onOpenRail={vi.fn()} />);
-      fireEvent.click(screen.getByTestId("shell-chrome-mentions"));
-      expect(mockSetSelectedChannel).toHaveBeenCalledWith({
-        networkSlug: "freenode",
-        channelName: "",
-        kind: "mentions",
-      });
-    });
+  // #986 — the @ mentions button moved into the RailActions menu. The gate
+  // that decided whether to show it (a bundle exists for the selected
+  // network) went WITH it and is asserted in RailActions.test.tsx; what this
+  // owns is that no copy stayed behind. Rendered with no store mocks at all
+  // — the component reads no stores any more, so a reintroduced @ would have
+  // to re-import them and this bar would stop being the lone-☰ band #985
+  // is about to delete.
+  it("#986 — renders the opener and NOTHING else (no @ mentions button)", () => {
+    const { container } = render(() => <ShellChrome onOpenRail={vi.fn()} />);
+    expect(screen.queryByTestId("shell-chrome-mentions")).toBeNull();
+    expect(screen.queryByLabelText(/open mentions/i)).toBeNull();
+    expect(container.querySelectorAll("button")).toHaveLength(1);
   });
 });

--- a/cicchetto/src/lib/__tests__/mobilePanel.test.ts
+++ b/cicchetto/src/lib/__tests__/mobilePanel.test.ts
@@ -9,7 +9,7 @@ vi.mock("../archive", () => ({
   setArchiveModalOpen: (v: unknown) => setArchiveModalOpen(v),
 }));
 
-import { openHomePanel, openMembersPanel } from "../mobilePanel";
+import { openHomePanel, openMembersPanel, openMentionsPanel } from "../mobilePanel";
 
 function setters() {
   return {
@@ -48,5 +48,25 @@ describe("openMembersPanel (#308 edge-swipe)", () => {
     expect(s.setMembersOpen).toHaveBeenCalledWith(true);
     // Unlike toggleMembersPanel, an OPEN gesture never closes an open drawer.
     expect(s.setMembersOpen).not.toHaveBeenCalledWith(false);
+  });
+});
+
+describe("openMentionsPanel (#986)", () => {
+  beforeEach(() => {
+    setArchiveModalOpen.mockReset();
+  });
+
+  test("closes members, settings and archive then navigates to the bundle", () => {
+    // #986 — the @ re-open door left `.shell-chrome` for the rail, so it must
+    // take the SAME nav mutex the other window launchers take. It is a nav
+    // launcher, not an own-signal one: opening it while the members drawer is
+    // still up would leave the bundle behind a drawer on mobile.
+    const s = setters();
+    const navigate = vi.fn();
+    openMentionsPanel(s, navigate);
+    expect(s.setMembersOpen).toHaveBeenCalledWith(false);
+    expect(s.setSettingsOpen).toHaveBeenCalledWith(false);
+    expect(setArchiveModalOpen).toHaveBeenCalledWith(false);
+    expect(navigate).toHaveBeenCalledTimes(1);
   });
 });

--- a/cicchetto/src/lib/auth.ts
+++ b/cicchetto/src/lib/auth.ts
@@ -222,7 +222,7 @@ export function getSubject(): api.Subject | null {
 // (`registered === true`, derived server-side from password_encrypted).
 // The inverse — an ephemeral (anon) visitor, or the not-yet-loaded null
 // subject — is torn down by a bare logout (its anon row is purged
-// server-side). This collapses the class-branching quit()/showDetach used
+// server-side). This collapses the class-branching quit()/detach-gate used
 // to hand-roll (`kind === "user" || (visitor && registered)`): both asked
 // the SAME question — persistence, not class.
 //

--- a/cicchetto/src/lib/lifecycle.test.ts
+++ b/cicchetto/src/lib/lifecycle.test.ts
@@ -43,11 +43,13 @@ vi.mock("./networks", () => ({
   refetchUser: vi.fn(),
 }));
 
-import { deleteAccount, detach, quit } from "./lifecycle";
+import { acceptConfirm, confirmRequest, dismissConfirm } from "./confirmDialog";
+import { canDetach, confirmDetach, confirmQuit, deleteAccount, detach, quit } from "./lifecycle";
 
 beforeEach(() => {
   vi.clearAllMocks();
   subjectHolder.current = null;
+  dismissConfirm();
 });
 
 describe("detach", () => {
@@ -171,5 +173,120 @@ describe("deleteAccount (#157)", () => {
 
     await expect(deleteAccount()).rejects.toThrow("forbidden");
     expect(auth.clearLocalAuth).not.toHaveBeenCalled();
+  });
+});
+
+// #986 — the rail-actions confirm gate. `detach` / `quit` are no longer a
+// bare button + a two-tap arm in the settings drawer: they are rail entries
+// behind the shared #195 confirm modal, and the modal BODY must state the
+// consequence that actually applies to the subject in front of it. The
+// defect this closes is one shared sentence for three different events, so
+// the load-bearing assertion is that the three bodies genuinely DIFFER —
+// a "the modal opens" test would pass with the old six words intact.
+describe("canDetach (#986)", () => {
+  it("offers detach to a registered user", () => {
+    subjectHolder.current = { kind: "user", id: "u1", name: "alice" };
+    expect(canDetach()).toBe(true);
+  });
+
+  it("offers detach to a registered visitor (same persistence answer)", () => {
+    subjectHolder.current = { kind: "visitor", id: "v1", nick: "vjt", registered: true };
+    expect(canDetach()).toBe(true);
+  });
+
+  it("withholds detach from an ephemeral visitor — no bouncer to leave running", () => {
+    subjectHolder.current = { kind: "visitor", id: "v2", nick: "anon", registered: false };
+    expect(canDetach()).toBe(false);
+  });
+
+  it("withholds detach from the not-yet-loaded null subject", () => {
+    subjectHolder.current = null;
+    expect(canDetach()).toBe(false);
+  });
+});
+
+describe("confirmQuit copy (#986)", () => {
+  const bodyFor = (subject: typeof subjectHolder.current): string => {
+    subjectHolder.current = subject;
+    confirmQuit(vi.fn());
+    const req = confirmRequest();
+    if (req === null) throw new Error("confirmQuit did not raise a confirm request");
+    return req.body;
+  };
+
+  const USER = { kind: "user", id: "u1", name: "alice" } as const;
+  const REGISTERED = { kind: "visitor", id: "v1", nick: "vjt", registered: true } as const;
+  const EPHEMERAL = { kind: "visitor", id: "v2", nick: "anon", registered: false } as const;
+
+  it("gives the three subject shapes three DIFFERENT bodies", () => {
+    const user = bodyFor(USER);
+    const registeredVisitor = bodyFor(REGISTERED);
+    const ephemeral = bodyFor(EPHEMERAL);
+
+    expect(new Set([user, registeredVisitor, ephemeral]).size).toBe(3);
+  });
+
+  it("promises survival to both persistent identities and destruction to the anon one", () => {
+    // The MEANING, not the wording: only the ephemeral copy may say the
+    // session is deleted, and neither persistent copy may.
+    expect(bodyFor(EPHEMERAL)).toMatch(/delete|permanently/i);
+    expect(bodyFor(USER)).toMatch(/survive/i);
+    expect(bodyFor(USER)).not.toMatch(/delete/i);
+    expect(bodyFor(REGISTERED)).toMatch(/survive/i);
+    expect(bodyFor(REGISTERED)).not.toMatch(/delete/i);
+  });
+
+  it("takes the ephemeral copy for the not-yet-loaded null subject (the arm quit() routes it to)", () => {
+    expect(bodyFor(null)).toBe(bodyFor(EPHEMERAL));
+  });
+
+  it("adds NO typed re-entry gate — the modal explains and asks", () => {
+    subjectHolder.current = USER;
+    confirmQuit(vi.fn());
+    // #986 ruling: the type-your-name gate is exclusive to delete account.
+    // The confirm request carries no input contract at all — just a body,
+    // an affirmative label, and (unused here) the #816 third door.
+    expect(confirmRequest()?.alternative).toBeNull();
+  });
+});
+
+describe("confirmDetach / confirmQuit wiring (#986)", () => {
+  it("fires detach + the caller's landing only on the affirmative", async () => {
+    const auth = await import("./auth");
+    const onDone = vi.fn();
+    subjectHolder.current = { kind: "user", id: "u1", name: "alice" };
+
+    confirmDetach(onDone);
+    expect(auth.logout).not.toHaveBeenCalled();
+
+    acceptConfirm();
+    await vi.waitFor(() => expect(onDone).toHaveBeenCalledTimes(1));
+    expect(auth.logout).toHaveBeenCalled();
+  });
+
+  it("dismissing the quit modal tears NOTHING down", async () => {
+    const auth = await import("./auth");
+    const quitMod = await import("./quit");
+    const onDone = vi.fn();
+    subjectHolder.current = { kind: "user", id: "u1", name: "alice" };
+
+    confirmQuit(onDone);
+    dismissConfirm();
+
+    expect(quitMod.quitAll).not.toHaveBeenCalled();
+    expect(auth.logout).not.toHaveBeenCalled();
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it("confirming quit runs the subject's real teardown (user → park-all)", async () => {
+    const quitMod = await import("./quit");
+    const onDone = vi.fn();
+    subjectHolder.current = { kind: "user", id: "u1", name: "alice" };
+
+    confirmQuit(onDone);
+    acceptConfirm();
+
+    await vi.waitFor(() => expect(onDone).toHaveBeenCalledTimes(1));
+    expect(quitMod.quitAll).toHaveBeenCalled();
   });
 });

--- a/cicchetto/src/lib/lifecycle.ts
+++ b/cicchetto/src/lib/lifecycle.ts
@@ -3,6 +3,7 @@ import {
   updateNetworkIdentity as apiUpdateNetworkIdentity,
 } from "./api";
 import { clearLocalAuth, getSubject, isPersistentIdentity, logout, token } from "./auth";
+import { requestConfirm } from "./confirmDialog";
 import { refetchUser } from "./networks";
 import { quitAll } from "./quit";
 
@@ -67,6 +68,99 @@ export async function quit(): Promise<void> {
   // ephemeral (anon) visitor: detach only — the anon branch of
   // `DELETE /auth/logout` stops every attached session + purges the row.
   await logout();
+}
+
+// #986 — the two verbs above are rail-actions entries now, each behind the
+// shared #195 confirm modal. The GATE and the COPY live here, beside the
+// verbs they describe, exactly as windowClose.ts colocates
+// `confirmLeaveChannel` with the PART it fires: a modal that misdescribes
+// the consequence is worse than no modal at all, and the only way copy and
+// teardown cannot drift is to derive both from the same subject read.
+//
+// The two-tap `InlineConfirmButton` this replaces asked "really quit IRC?"
+// — six words that were the SAME for an anon visitor (whose row the server
+// hard-deletes on the way out) and a registered user (whose account and
+// scrollback survive untouched). Those are not the same event, so they do
+// not get the same sentence.
+//
+// No typed re-entry gate here, deliberately: that friction belongs to
+// `delete account` alone, the one door that destroys a persistent identity
+// (#986 ruling). detach and quit explain, then ask.
+
+const DETACH_BODY =
+  "Leave cicchetto in this browser. The bouncer keeps running: your networks stay " +
+  "connected and your scrollback keeps filling, so it is all still here when you come back.";
+
+const QUIT_BODY_USER =
+  "Park every network and take the bouncer offline. Your account, its settings and its " +
+  "scrollback survive — log back in whenever you want to reconnect.";
+
+const QUIT_BODY_REGISTERED_VISITOR =
+  "Park every network and take the bouncer offline. Your session is registered, so the " +
+  "server keeps it: your nick and its scrollback survive — identify again to come back.";
+
+const QUIT_BODY_EPHEMERAL =
+  "Leave IRC and end this session. It is not registered, so the server DELETES it on the " +
+  "way out — windows, scrollback, settings, all of it, permanently. There is nothing to " +
+  "come back to.";
+
+/**
+ * canDetach — is `detach` a meaningful verb for the current subject? True
+ * for a persistent identity only: an ephemeral visitor has no bouncer to
+ * leave running, so "leave cic, keep the session" is not on offer.
+ *
+ * Routed through the shared `isPersistentIdentity` predicate — the SAME
+ * question `quit()` asks one screen up — so the affordance and the teardown
+ * path can never answer it differently.
+ */
+export function canDetach(): boolean {
+  return isPersistentIdentity(getSubject());
+}
+
+// The three consequences of `quit`, keyed off the subject the way `quit()`
+// itself is. A persistent identity survives, so the split inside that arm is
+// about the NOUN the operator owns (an account they log back into vs a
+// registered session they re-identify to) — not about the teardown, which is
+// one `quitAll` for both. The null (not-yet-loaded) subject falls to the
+// ephemeral copy because that is the arm `quit()` routes it to.
+function quitBody(): string {
+  const subject = getSubject();
+  if (subject !== null && isPersistentIdentity(subject)) {
+    return subject.kind === "user" ? QUIT_BODY_USER : QUIT_BODY_REGISTERED_VISITOR;
+  }
+  return QUIT_BODY_EPHEMERAL;
+}
+
+/**
+ * confirmDetach — open the shared confirm modal for `detach`, firing the
+ * verb and then `onDone` only on the affirmative. `onDone` is the caller's
+ * landing (the rail passes `navigate("/login")`): `logout()` nulls the token
+ * and RequireAuth would redirect anyway, but the explicit navigation makes
+ * the landing deterministic rather than effect-ordered.
+ */
+export function confirmDetach(onDone: () => void): void {
+  requestConfirm({
+    title: "Detach",
+    body: DETACH_BODY,
+    confirmLabel: "Detach",
+    onConfirm: () => void detach().then(onDone),
+    alternative: null,
+  });
+}
+
+/**
+ * confirmQuit — open the shared confirm modal for `quit`, with the body that
+ * is TRUE for the current subject. Same fire-then-land shape as
+ * `confirmDetach`.
+ */
+export function confirmQuit(onDone: () => void): void {
+  requestConfirm({
+    title: "Quit IRC",
+    body: quitBody(),
+    confirmLabel: "Quit IRC",
+    onConfirm: () => void quit().then(onDone),
+    alternative: null,
+  });
 }
 
 /**

--- a/cicchetto/src/lib/mobilePanel.ts
+++ b/cicchetto/src/lib/mobilePanel.ts
@@ -131,6 +131,15 @@ export function openHomePanel(setters: MobilePanelSetters, navigate: () => void)
   openNavWindow(setters, navigate);
 }
 
+// #986 — mentions launcher. The @ re-open door left `.shell-chrome` (the
+// band #985 removes) for the rail, so the ONE way back into a network's
+// "you were /away" bundle now routes through the same nav mutex as home /
+// rooms / admin. Shell sets `selectedChannel` → kind "mentions" for the
+// network the current selection implies.
+export function openMentionsPanel(setters: MobilePanelSetters, navigate: () => void): void {
+  openNavWindow(setters, navigate);
+}
+
 // #361 — list launcher (channel directory / $list) in the mobile drawer
 // footer. Pre-bucket the ONLY mobile way to open the $list window was to
 // TYPE `/list`; the desktop sidebar's 📇 $list row had no mobile

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -3654,8 +3654,8 @@ html.resize-dragging * {
 
    `:where()` keeps the selector at element-only specificity (0,0,1), so a
    per-class rule at (0,1,0) always wins the properties it DECLARES:
-   .settings-back, .logout, .watchlists-remove, .inline-confirm-btn and the
-   theme cards keep their own paint. The look IS .settings-back's (transparent
+   .settings-back, .watchlists-remove, .inline-confirm-btn and the theme
+   cards keep their own paint. The look IS .settings-back's (transparent
    + accent + border) — the drawer's existing idiom promoted to the base
    rather than a new one invented beside it.
 
@@ -3668,9 +3668,10 @@ html.resize-dragging * {
        reports, in panes that never reported it — fixing the class, not the
        instance. Revert path if the density is unwanted: exempt those two
        classes with an explicit min-height of their own.
-     * .logout / .admin-console-entry / .delete-account-entry declare
-       font-family but no font-size, so they move off the UA's 13.3px onto
-       the drawer's --font-size — the same unification #497 made for inputs.
+     * .delete-account-entry declares font-family but no font-size, so it
+       moves off the UA's 13.3px onto the drawer's --font-size — the same
+       unification #497 made for inputs. (#986 retired its two former
+       companions here, .logout and .admin-console-entry.)
    NO border-radius here: the drawer is square by documented intent (see the
    .settings-section comment, "sharp corners, irssi aesthetic"), and NO drawer
    button class declares one, so a radius on the base would round all of them.
@@ -3727,36 +3728,18 @@ html.resize-dragging * {
   cursor: pointer;
 }
 
-.settings-drawer button.logout {
-  margin-top: auto;
-  background: transparent;
-  color: var(--mode-op);
-  border: 1px solid var(--border);
-  padding: 0.5rem 1rem;
-  font-family: var(--font-mono);
-  cursor: pointer;
-}
+/* #986 — `.logout` (detach), `.admin-console-entry` and
+   `.inline-confirm-btn.settings-quit` are GONE with the buttons they
+   painted: detach + quit are rail actions now, and the admin entry was a
+   duplicate of the rail's. `.logout` carried the `margin-top: auto` that
+   pushed the tail of the stack to the drawer floor; nothing inherits it,
+   because the index above is long enough to overflow in every shipped
+   viewport and an auto margin buys nothing in an overflowing flex column.
 
-/* M-cluster M-7 — admin console entry button. Shares logout's visual
-   shape (border + monospace), distinct color (accent over mode-op) so
-   operators perceive it as a privileged action. `.logout`'s
-   `margin-top: auto` keeps logout at the bottom; admin sits just
-   above it via the flex flow with a small gap on top so the two
-   buttons don't visually merge into one. */
-.settings-drawer button.admin-console-entry {
-  margin-top: 0.5rem;
-  background: transparent;
-  color: var(--accent);
-  border: 1px solid var(--border);
-  padding: 0.5rem 1rem;
-  font-family: var(--font-mono);
-  cursor: pointer;
-}
-
-/* #157 — delete-account entry button. Visually DISTINCT from logout /
-   quit: red border + red text (a danger affordance) so the operator
-   perceives it as the nuclear option, never a sibling of quit. Sits just
-   above the "done" button at the bottom of the stack. */
+   #157 — delete-account entry button. Visually DISTINCT from every other
+   drawer control: red border + red text (a danger affordance) so the
+   operator perceives it as the nuclear option. Sits just above the "done"
+   button at the bottom of the stack. */
 .settings-drawer button.delete-account-entry {
   margin-top: 0.5rem;
   background: transparent;
@@ -4219,19 +4202,6 @@ html.resize-dragging * {
 .inline-confirm-btn.confirming {
   color: #c00;
   border-color: #c00;
-}
-
-/* Issue #43 — "quit IRC" reuses the shared InlineConfirmButton but sits
-   in the settings drawer's full-width button stack (next to `.logout` /
-   `.admin-console-entry`), not a dense admin row. Override the compact
-   base sizing to match its neighbours; the base `.confirming` rule still
-   supplies the red armed treatment. `.logout`'s `margin-top: auto` keeps
-   the detach button (and this quit button right below it) anchored to
-   the drawer bottom. */
-.settings-drawer button.inline-confirm-btn.settings-quit {
-  margin-top: 0.5rem;
-  padding: 0.5rem 1rem;
-  font-size: inherit;
 }
 
 /* #473 — the Sidebar `.sidebar-archive-row` / `.sidebar-archive-delete`

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -32202,3 +32202,67 @@ true there and FALSE here: services accept a RESETPASS from an unidentified
 user — that is what the verb is for. All grappa lacks in that case is a
 stored secret to rotate, and the follow-up IDENTIFY binds the new one
 through the ordinary `+r` rendezvous.
+
+## 2026-08-07 — the lifecycle verbs move to the rail, and learn to say what they destroy (#986)
+
+`detach` and `quit` left the settings drawer for the **rail actions menu**,
+each behind the shared #195 confirm modal. The `@` mentions door moved with
+them, off `.shell-chrome`; the drawer's `admin console` entry was deleted
+outright as a duplicate. Four moves, one destination, one reason each.
+
+**The modal body is subject-routed because the consequence is.** The control
+this replaces was an `InlineConfirmButton` two-tap that said *"really quit
+IRC?"* — the same six words to a registered user, whose account and
+scrollback survive a park-all untouched, and to an anonymous visitor, whose
+row the server HARD-DELETES on the way out (`Visitors.purge_if_anon` →
+`destroy_visitor`, CASCADE). Those are not the same event, so `confirmQuit`
+picks one of three sentences and `confirmDetach` a fourth. The split lives in
+`lib/lifecycle.ts`, beside the verbs, exactly as `windowClose.ts` colocates
+`confirmLeaveChannel` with the PART it fires: copy that drifts from its verb
+is a modal that lies, and colocation is the only structural defence.
+
+The split ROUTES on `isPersistentIdentity` — the shared #477 predicate,
+reused not re-derived, so the affordance (`canDetach()`) and the teardown
+(`quit()`) cannot answer the persistence question differently. Only INSIDE
+the persistent arm does `kind` choose between the user's noun (an account you
+log back into) and the visitor's (a registered session you re-identify to);
+the teardown for both is one `quitAll`. The not-yet-loaded null subject takes
+the ephemeral copy because that is the arm `quit()` routes it to.
+
+**One typed gate in the product, and it is not here.** vjt's ruling:
+`delete account` keeps its type-your-name modal, for BOTH registered subjects
+(a registered visitor's delete is `AccountDeletion.delete_account/1`, "the
+ONLY door that destroys the persistent identity"), because the gate is about
+IRREVERSIBILITY, not subject kind. detach and quit explain and ask. No
+friction was added for symmetry — the value is in saying it BEFORE the tap.
+`delete account` therefore did NOT move; it stays in settings and its
+geometry is #987.
+
+**The two-tap component is not retired; its use as a lifecycle gate is.**
+`InlineConfirmButton` still serves ~20 call sites (every admin tab, passkeys,
+vhost reconnect, archive delete) unchanged. Only the two settings-drawer
+copies died, and the drawer entries died with them: two doors to a
+destructive verb, one confirmed and one not, is worse than either alone.
+
+**`@` mentions drops its form-factor gate.** In `.shell-chrome` it was
+`isMobile() && bundle`, because on desktop it would have duplicated the
+Sidebar mentions row (#71 INC-2). In the rail it is bundle-gated only:
+#473 already ruled the rail carries the same set on both form factors, and
+`home` is the standing precedent for a rail launcher that doubles a sidebar
+row. Keeping the gate would have been the one thing `RailActions` documents
+that it never does. This is what lets #985 drop the whole band — what is left
+in `ShellChrome` is a lone ☰.
+
+**Removing the drawer's admin entry retired a latent e2e flake.** ~20 admin
+specs hand-rolled `admin-console-entry.click()`, and `openAdminConsole` had
+grown a `not.toBeInViewport()` wait because that entry CLOSES the drawer,
+which slides out over 200ms at z-index 100 anchored right — long enough to
+swallow a click aimed at the 9th admin tab (~9% flake once #508's iOS font
+floor perturbed the timing). The rail launcher opens no drawer, so the wait
+has no subject any more. Every one of those specs now goes through the
+primitive; the migration the old comment tracked as a follow-up is done.
+
+**Unmeasured, declared:** `.logout` carried `margin-top: auto`, which pushed
+the tail of the drawer's button stack to the floor. Nothing inherits it — the
+index above overflows in every shipped viewport, where an auto margin buys
+nothing — but that is reasoning, not a screenshot.


### PR DESCRIPTION
Branch 2 of 3 in the cic 0.13.3 cluster. #985 and #988 depend on this landing.

## What moved

`detach` · `quit` · the `@` mentions door — three affordances, one
destination (the rail actions menu). The settings drawer's `admin console`
entry was deleted as an exact duplicate of the rail's 🔧.

## The point of the change

The control being replaced was an `InlineConfirmButton` two-tap reading
**"really quit IRC?"** — six words shown identically to a registered user,
whose account and scrollback survive a park-all untouched, and to an
anonymous visitor, whose row the server HARD-DELETES on the way out
(`Visitors.purge_if_anon` → `destroy_visitor`, CASCADE). Those are not the
same event.

So the shared #195 confirm modal carries a body chosen for the subject in
front of it — four sentences across the two verbs. The three-way `quit`
split ROUTES on `isPersistentIdentity` (the shared #477 predicate, reused
not re-derived, so `canDetach()` and `quit()` cannot answer the persistence
question differently); only inside the persistent arm does `kind` pick the
noun the operator owns. The load-bearing test asserts the three bodies
genuinely DIFFER — a "the modal opens" test would pass with one shared
string, which is the defect this closes.

**No typed re-entry gate here.** Per vjt's ruling, that friction is
exclusive to `delete account`, for BOTH registered subjects, because the
gate is about irreversibility rather than subject kind. `delete account`
did not move; its geometry is #987.

**`InlineConfirmButton` is not retired.** It keeps serving ~20 call sites
unchanged, including the vhost apply gate in this very drawer. Only its use
as a lifecycle-verb gate ends, in the two settings call sites the issue
names.

## Two judgment calls, flagged for veto

1. **The `@` mentions entry drops its `isMobile()` gate.** In
   `.shell-chrome` it was mobile-only so it would not duplicate the desktop
   Sidebar mentions row (#71 INC-2). In the rail I made it bundle-gated
   only: #473 documents the rail as capability-gated with *no form-factor
   gates*, and `home` is the standing precedent — a sidebar row AND a rail
   launcher, deliberately. Cheap to reverse if you want it mobile-only.
2. **`.logout` carried `margin-top: auto`**, which pushed the tail of the
   drawer's button stack to the floor. I deleted the rule with the button
   and gave the margin no successor: the index above overflows in every
   shipped viewport, where an auto margin in a flex column buys nothing.
   That is reasoning, not a screenshot.

## Blast radius the issue did not mention

Removing the drawer's admin entry would have reddened ~20 e2e specs that
hand-rolled `admin-console-entry.click()`. They now go through the
`openAdminConsole` primitive — the migration that helper's own comment
tracked as a follow-up. That also retires the flake it was written to
absorb: reaching admin via the drawer clicked an entry that CLOSED the
drawer, whose 200ms slide-out at z-index 100 could swallow a click aimed at
the 9th admin tab (~9% once #508's iOS font floor perturbed the timing). The
rail launcher opens no drawer, so the `not.toBeInViewport()` wait is gone.

`m7-admin-gate-settings-drawer.spec.ts` keeps its filename on purpose — six
sibling specs cross-reference it as THE M-7 gate spec, and the gate is
unchanged; only the surface moved. Its header records that.

## Measured

- `scripts/bun.sh run check` — exit 0 (biome + `tsc --noEmit`).
- `scripts/bun.sh run test` — exit 0, **244 files / 4545 tests**, on the
  final tree with a clean `git status --porcelain` before and after.

## NOT measured — do not read the green above as covering these

- **No e2e run at all.** The local stack lane was not requested, and this
  branch touches 27 spec files. The `e2e` job on this PR is the first real
  execution of every retargeted spec and of the new modal-copy assertions.
- **No `tsc` over `e2e/`** — there is no static gate there (biome ignores
  the directory, and `tsc -p e2e/` emits `.js`), and `e2e/node_modules` is
  not installed in this worktree. A type error in the 27 touched specs
  surfaces only when Playwright runs them.
- **No browser.** No screenshot, no rendered geometry: the two emoji rows
  and the drawer's lost bottom-pin are unverified visually.