### PR TITLE
cic(#975): drop the channel topic/modes cache when it stops being true

### DIFF
--- a/cicchetto/e2e/tests/issue975-mode-cache-invalidation.spec.ts
+++ b/cicchetto/e2e/tests/issue975-mode-cache-invalidation.spec.ts
@@ -1,0 +1,100 @@
+// #975 — `/mode` on a channel you have LEFT must not answer with the modes
+// you saw while you were in it.
+//
+// Reported by Sonic on #it-opers: `/mode #channel-I-was-in-earlier` printed
+// modes, and they were the ones from his last visit. `modesByChannel` had
+// one filler (the 324 the server queries on JOIN, pushed on the per-channel
+// WS topic) and no emptier, so the entry outlived the PART forever and the
+// modal presented it as CURRENT.
+//
+// The witness needs the live upstream: the whole mechanism is a real JOIN
+// eliciting a real 324, then a real PART echo arriving on the per-channel
+// topic. jsdom can prove the store drops a key; only this can prove the key
+// was ever filled by the round-trip it is supposed to be filled by, and that
+// the operator-visible answer changes.
+//
+// Shape:
+//   1. a peer creates a per-run UNIQUE channel (→ op) and sets +m, a mode
+//      no bahamut channel carries by default, so its presence in the modal
+//      is unambiguously the cached 324 and not a default.
+//   2. vjt joins → the modal shows "moderated" PRESSED. This half also
+//      guards the #216 join-time query: if it ever stops firing, this fails
+//      here rather than making step 4 pass for the wrong reason.
+//   3. vjt PARTs.
+//   4. `/mode <channel>` again → the modal says the modes are unknown and
+//      renders NO toggles. Pre-fix it rendered the same grid as step 2,
+//      "moderated" still pressed — the reported symptom, exactly.
+//
+// Anti-pollution: unique channel per run, peer disconnected in `finally`
+// (which drops the channel once vjt has parted).
+
+import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { partChannel } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+test("#975 — /mode on a parted channel reports unknown, not the modes cached while joined", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  const channel = `#t975-${Date.now()}`;
+
+  await loginAs(page, vjt);
+  // Focus the autojoin channel first: confirms login + WS-ready before the
+  // /join, and gives the composer a home to return to after the PART (the
+  // `/mode <channel>` in step 4 is typed from here, not from the window
+  // that no longer exists).
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
+
+  const peer = await IrcPeer.connect({ nick: `t975peer-${Date.now() % 100000}` });
+  try {
+    await peer.join(channel);
+    await peer.mode(channel, "+m");
+
+    await composeSend(page, `/join ${channel}`);
+    await expect(
+      page.locator(".sidebar-network-section li").filter({ hasText: channel }),
+    ).toHaveCount(1, { timeout: 15_000 });
+    await selectChannel(page, NETWORK_SLUG, channel, { ownNick: NETWORK_NICK });
+
+    // Step 2 — the cache is genuinely populated by the join-time 324.
+    const modeIndicator = page.locator(".topic-bar-modes");
+    await expect(modeIndicator).toBeVisible({ timeout: 15_000 });
+    await expect(modeIndicator).toContainText("m");
+
+    const modal = page.getByTestId("mode-modal");
+    await composeSend(page, `/mode ${channel}`);
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+    await expect(modal.getByLabel(/moderated/i)).toHaveAttribute("aria-pressed", "true");
+    await expect(modal.getByTestId("mode-modal-unknown")).toHaveCount(0);
+    await modal.getByLabel("close modes").click();
+    await expect(modal).toBeHidden({ timeout: 5_000 });
+
+    // Step 3 — PART via REST; the own-PART echo on the per-channel topic is
+    // what drives the drop. The sidebar row vanishing is that echo having
+    // been processed (`setParted` is the projection), so it is the barrier
+    // for the drop too — same handler, same event.
+    await partChannel(vjt.token, NETWORK_SLUG, channel);
+    await expect(
+      page.locator(".sidebar-network-section li").filter({ hasText: channel }),
+    ).toHaveCount(0, { timeout: 10_000 });
+
+    // Step 4 — the operator asks again. Selection has moved off the parted
+    // window; re-anchor on the autojoin channel so the composer is live and
+    // the network slug the verb resolves against is unambiguous.
+    await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
+    await composeSend(page, `/mode ${channel}`);
+    await expect(modal).toBeVisible({ timeout: 5_000 });
+    await expect(modal.getByTestId("mode-modal-unknown")).toBeVisible();
+
+    // The grid is GONE, not merely all-off: an all-off grid asserts "this
+    // channel has no modes set", which is a different (and equally false)
+    // claim from "cic does not know".
+    await expect(modal.locator(".mode-modal-toggle")).toHaveCount(0);
+    await expect(modal.locator('[aria-pressed="true"]')).toHaveCount(0);
+    await expect(modal.locator(".mode-modal-param-row")).toHaveCount(0);
+  } finally {
+    await peer.disconnect("t975 done").catch(() => {});
+  }
+});

--- a/cicchetto/e2e/tests/issue975-mode-cache-invalidation.spec.ts
+++ b/cicchetto/e2e/tests/issue975-mode-cache-invalidation.spec.ts
@@ -66,7 +66,10 @@ test("#975 — /mode on a parted channel reports unknown, not the modes cached w
     const modal = page.getByTestId("mode-modal");
     await composeSend(page, `/mode ${channel}`);
     await expect(modal).toBeVisible({ timeout: 5_000 });
-    await expect(modal.getByLabel(/moderated/i)).toHaveAttribute("aria-pressed", "true");
+    // By testid, not by accessible name: bahamut has BOTH +m ("moderated")
+    // and +M ("moderated (reg'd)"), so any /moderated/ name locator is
+    // ambiguous and asserts on whichever the grid happened to render first.
+    await expect(modal.getByTestId("mode-toggle-m")).toHaveAttribute("aria-pressed", "true");
     await expect(modal.getByTestId("mode-modal-unknown")).toHaveCount(0);
     await modal.getByLabel("close modes").click();
     await expect(modal).toBeHidden({ timeout: 5_000 });

--- a/cicchetto/src/ModeModal.tsx
+++ b/cicchetto/src/ModeModal.tsx
@@ -126,6 +126,18 @@ const ModeModal: Component = () => {
     return networks()?.find((n) => n.slug === t.networkSlug)?.id;
   };
 
+  // #975 — "no cache entry" and "an entry that lists no modes" are
+  // DIFFERENT facts and the modal must not conflate them. The cache is only
+  // ever seeded by the 324 the server queries on JOIN, so a missing key
+  // means the session is not in the channel and cic simply does not know;
+  // rendering the toggle grid all-off would state `+` (no modes set) as
+  // fact. An entry present with an empty `modes` array is a real answer and
+  // still renders the grid.
+  const modesKnown = (): boolean => {
+    const k = key();
+    return k !== null && modesByChannel()[k] !== undefined;
+  };
+
   // Current channel modes (letters + params) from the server-seeded cache.
   const currentModes = (): string[] => {
     const k = key();
@@ -229,37 +241,46 @@ const ModeModal: Component = () => {
               </button>
             </header>
             <div class="mode-modal-body">
-              <For each={toggles()}>
-                {(m) => (
-                  <Show
-                    when={m.takesParam}
-                    fallback={
-                      <button
-                        type="button"
-                        class="mode-modal-toggle"
-                        classList={{ "mode-modal-toggle-active": isActive(m.letter) }}
-                        aria-pressed={isActive(m.letter)}
-                        aria-disabled={!canEdit()}
-                        aria-label={`${m.label} (+${m.letter})`}
-                        onClick={() => onToggle(m)}
-                      >
-                        <span class="mode-modal-toggle-flag">+{m.letter}</span>
-                        <span class="mode-modal-toggle-label">{m.label}</span>
-                        <span class="mode-modal-toggle-desc">{m.desc}</span>
-                      </button>
-                    }
-                  >
-                    <ParamModeRow
-                      mode={m}
-                      active={() => isActive(m.letter)}
-                      paramValue={() => currentParams()[m.letter] ?? null}
-                      canEdit={canEdit}
-                      onSet={(value) => onSetParam(m, value)}
-                      onUnset={() => onUnsetParam(m)}
-                    />
-                  </Show>
-                )}
-              </For>
+              <Show
+                when={modesKnown()}
+                fallback={
+                  <p class="mode-modal-unknown" data-testid="mode-modal-unknown">
+                    modes unknown — not in this channel
+                  </p>
+                }
+              >
+                <For each={toggles()}>
+                  {(m) => (
+                    <Show
+                      when={m.takesParam}
+                      fallback={
+                        <button
+                          type="button"
+                          class="mode-modal-toggle"
+                          classList={{ "mode-modal-toggle-active": isActive(m.letter) }}
+                          aria-pressed={isActive(m.letter)}
+                          aria-disabled={!canEdit()}
+                          aria-label={`${m.label} (+${m.letter})`}
+                          onClick={() => onToggle(m)}
+                        >
+                          <span class="mode-modal-toggle-flag">+{m.letter}</span>
+                          <span class="mode-modal-toggle-label">{m.label}</span>
+                          <span class="mode-modal-toggle-desc">{m.desc}</span>
+                        </button>
+                      }
+                    >
+                      <ParamModeRow
+                        mode={m}
+                        active={() => isActive(m.letter)}
+                        paramValue={() => currentParams()[m.letter] ?? null}
+                        canEdit={canEdit}
+                        onSet={(value) => onSetParam(m, value)}
+                        onUnset={() => onUnsetParam(m)}
+                      />
+                    </Show>
+                  )}
+                </For>
+              </Show>
             </div>
           </div>
         </div>

--- a/cicchetto/src/ModeModal.tsx
+++ b/cicchetto/src/ModeModal.tsx
@@ -254,9 +254,15 @@ const ModeModal: Component = () => {
                     <Show
                       when={m.takesParam}
                       fallback={
+                        // The testid is the only unambiguous handle on a
+                        // toggle: bahamut ships both +m ("moderated") and +M
+                        // ("moderated (reg'd)"), so the accessible name does
+                        // not identify a mode. Keyed by letter, like the
+                        // ParamModeRow testids above.
                         <button
                           type="button"
                           class="mode-modal-toggle"
+                          data-testid={`mode-toggle-${m.letter}`}
                           classList={{ "mode-modal-toggle-active": isActive(m.letter) }}
                           aria-pressed={isActive(m.letter)}
                           aria-disabled={!canEdit()}

--- a/cicchetto/src/__tests__/ModeModal.test.tsx
+++ b/cicchetto/src/__tests__/ModeModal.test.tsx
@@ -78,6 +78,32 @@ describe("ModeModal", () => {
     expect(getByText("secret")).toBeTruthy();
   });
 
+  // #975 — with the PART-time cache drop in place, "no entry for this
+  // channel" is the COMMON case (any channel the session is not in), so the
+  // modal has to say it rather than draw an all-off grid that reads as "+".
+  it("says the modes are unknown when the channel has no cache entry", () => {
+    mockMembers[KEY] = [];
+    openModeModal("bahamut", "#bofh");
+
+    const { getByTestId, queryByText } = render(() => <ModeModal />);
+    expect(getByTestId("mode-modal-unknown").textContent).toContain("modes unknown");
+    // The toggle grid is GONE, not merely all-off — an all-off grid is the
+    // lie this issue is about.
+    expect(queryByText("secret")).toBeNull();
+  });
+
+  it("renders the grid for a channel whose modes are known to be none", () => {
+    // An entry present with an empty array is a real 324 answer ("+"), not
+    // the unknown state. Conflating the two is the bug.
+    mockModes[KEY] = { modes: [], params: {} };
+    mockMembers[KEY] = [{ nick: "vjt-grappa", modes: ["@"] }];
+    openModeModal("bahamut", "#bofh");
+
+    const { queryByTestId, getByText } = render(() => <ModeModal />);
+    expect(queryByTestId("mode-modal-unknown")).toBeNull();
+    expect(getByText("secret")).toBeTruthy();
+  });
+
   it("shows active modes as pressed", () => {
     mockModes[KEY] = { modes: ["s"], params: {} };
     mockMembers[KEY] = [{ nick: "vjt-grappa", modes: ["@"] }];

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -209,6 +209,7 @@ vi.mock("../lib/channelTopic", () => ({
   compactModeString: (modes: string[]) => (modes.length > 0 ? `+${modes.join("")}` : ""),
   seedTopic: vi.fn(),
   seedModes: vi.fn(),
+  dropChannelTopicState: vi.fn(),
 }));
 
 vi.mock("../lib/mentions", () => ({

--- a/cicchetto/src/__tests__/channelTopic.test.ts
+++ b/cicchetto/src/__tests__/channelTopic.test.ts
@@ -11,11 +11,19 @@ vi.mock("../lib/channelKey", () => ({
   channelKey: (slug: string, name: string) => `${slug} ${name}`,
 }));
 
+// Reached transitively via identityScopedStore → auth → api (#975). The
+// store itself never calls it; the stub only keeps the import graph inert.
+vi.mock(import("../lib/api"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, setOn401Handler: vi.fn() };
+});
+
 import { channelKey } from "../lib/channelKey";
 
 describe("channelTopic store", () => {
   beforeEach(() => {
     vi.resetModules();
+    localStorage.clear();
   });
 
   afterEach(() => {
@@ -78,5 +86,93 @@ describe("channelTopic store", () => {
     expect(mod.compactModeString(["n", "t"])).toBe("+nt");
     expect(mod.compactModeString([])).toBe("");
     expect(mod.compactModeString(["m"])).toBe("+m");
+  });
+});
+
+// #975 — the store had one filler and no emptier, so an entry seeded while
+// joined outlived the PART and ModeModal presented it as CURRENT. Both maps
+// are wiped at the two boundaries where the data stops being true. The
+// assertions below are on ABSENCE of the key, not on an emptied value: a
+// present-but-empty entry is exactly the wrong answer (an empty toggle set
+// rendered as fact), which is what the modal's "unknown" branch keys off.
+describe("channelTopic drop on own-PART", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    localStorage.clear();
+  });
+
+  it("dropChannelTopicState removes the key from BOTH maps", async () => {
+    const mod = await import("../lib/channelTopic");
+    const key = channelKey("freenode", "#grappa");
+    mod.seedTopic(key, { text: "hi", set_by: "vjt", set_at: null });
+    mod.seedModes(key, { modes: ["n", "t"], params: {} });
+
+    mod.dropChannelTopicState(key);
+
+    expect(key in mod.topicByChannel()).toBe(false);
+    expect(key in mod.modesByChannel()).toBe(false);
+  });
+
+  it("leaves other channels untouched", async () => {
+    const mod = await import("../lib/channelTopic");
+    const parted = channelKey("freenode", "#grappa");
+    const stillIn = channelKey("freenode", "#bofh");
+    mod.seedModes(parted, { modes: ["s"], params: {} });
+    mod.seedModes(stillIn, { modes: ["n"], params: {} });
+    mod.seedTopic(stillIn, { text: "keep me", set_by: null, set_at: null });
+
+    mod.dropChannelTopicState(parted);
+
+    expect(mod.modesByChannel()[stillIn]).toEqual({ modes: ["n"], params: {} });
+    expect(mod.topicByChannel()[stillIn]?.text).toBe("keep me");
+  });
+
+  it("dropping an unknown key does not rebuild the maps (no consumer wakeup)", async () => {
+    const mod = await import("../lib/channelTopic");
+    const key = channelKey("freenode", "#grappa");
+    mod.seedModes(key, { modes: ["n"], params: {} });
+    const before = mod.modesByChannel();
+
+    mod.dropChannelTopicState(channelKey("freenode", "#never-joined"));
+
+    expect(mod.modesByChannel()).toBe(before);
+  });
+});
+
+describe("channelTopic identity rotation (token change)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    localStorage.clear();
+  });
+
+  it("empties both maps when the bearer rotates", async () => {
+    localStorage.setItem("grappa-token", "tokA");
+    const auth = await import("../lib/auth");
+    const mod = await import("../lib/channelTopic");
+    mod.seedTopic(channelKey("freenode", "#grappa"), {
+      text: "hi",
+      set_by: "vjt",
+      set_at: null,
+    });
+    mod.seedModes(channelKey("freenode", "#bofh"), { modes: ["s"], params: {} });
+
+    auth.setToken("tokB");
+    // Solid runs the on(token) cleanup in the next microtask flush.
+    await Promise.resolve();
+
+    expect(mod.topicByChannel()).toEqual({});
+    expect(mod.modesByChannel()).toEqual({});
+  });
+
+  it("does NOT empty on the initial bearer set (cold-start login)", async () => {
+    const auth = await import("../lib/auth");
+    const mod = await import("../lib/channelTopic");
+    const key = channelKey("freenode", "#grappa");
+
+    auth.setToken("tokA");
+    await Promise.resolve();
+    mod.seedModes(key, { modes: ["n"], params: {} });
+
+    expect(mod.modesByChannel()[key]).toEqual({ modes: ["n"], params: {} });
   });
 });

--- a/cicchetto/src/__tests__/subscribe.test.ts
+++ b/cicchetto/src/__tests__/subscribe.test.ts
@@ -3096,6 +3096,78 @@ describe("subscribe — BUG5b: own-action events do not bump unread", () => {
       expect(ws.setParted).not.toHaveBeenCalled();
     });
 
+    // #975 — the channelTopic store is NOT mocked in this suite, so these
+    // three assert the real store's contents rather than a call spy: the
+    // reported symptom is "the modal shows the modes I had before I left",
+    // and only the store's actual key answers that.
+    it("own-PART drops the channel's cached topic + modes (#975)", async () => {
+      localStorage.setItem("grappa-token", "tok");
+      localStorage.setItem(
+        "grappa-subject",
+        JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+      );
+      await seedStubs();
+      await loadStores();
+      const ct = await import("../lib/channelTopic");
+      const key = channelKey("freenode", "#grappa");
+      await vi.waitFor(() => {
+        expect(mockChannel.on).toHaveBeenCalled();
+      });
+      ct.seedModes(key, { modes: ["n", "t"], params: {} });
+      ct.seedTopic(key, { text: "old topic", set_by: "op", set_at: null });
+
+      fireMessageEvent("#grappa", { id: 52, kind: "part", sender: "alice" });
+
+      expect(key in ct.modesByChannel()).toBe(false);
+      expect(key in ct.topicByChannel()).toBe(false);
+    });
+
+    it("peer PART leaves the cached topic + modes alone (#975)", async () => {
+      localStorage.setItem("grappa-token", "tok");
+      localStorage.setItem(
+        "grappa-subject",
+        JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+      );
+      await seedStubs();
+      await loadStores();
+      const ct = await import("../lib/channelTopic");
+      const key = channelKey("freenode", "#grappa");
+      await vi.waitFor(() => {
+        expect(mockChannel.on).toHaveBeenCalled();
+      });
+      ct.seedModes(key, { modes: ["n", "t"], params: {} });
+
+      fireMessageEvent("#grappa", { id: 53, kind: "part", sender: "bob" });
+
+      expect(ct.modesByChannel()[key]).toEqual({ modes: ["n", "t"], params: {} });
+    });
+
+    it("a stale part echo on a still-present window keeps the fresh cache (#975/#495)", async () => {
+      // setParted no-ops when a re-join is already "pending" (#495), so the
+      // window survives the echo — and so must the modes seeded by that
+      // re-join. The drop is gated on that OUTCOME, not on a copy of the
+      // guard, which is what makes the two impossible to drift apart.
+      localStorage.setItem("grappa-token", "tok");
+      localStorage.setItem(
+        "grappa-subject",
+        JSON.stringify({ kind: "user", id: "u1", name: "alice" }),
+      );
+      await seedStubs();
+      await loadStores();
+      const ws = await import("../lib/windowState");
+      const ct = await import("../lib/channelTopic");
+      const key = channelKey("freenode", "#grappa");
+      await vi.waitFor(() => {
+        expect(mockChannel.on).toHaveBeenCalled();
+      });
+      ct.seedModes(key, { modes: ["n", "t"], params: {} });
+      vi.mocked(ws.windowIsPresent).mockReturnValue(true);
+
+      fireMessageEvent("#grappa", { id: 54, kind: "part", sender: "alice" });
+
+      expect(ct.modesByChannel()[key]).toEqual({ modes: ["n", "t"], params: {} });
+    });
+
     it("window-state events do NOT route as messages (no scrollback append, no unread)", async () => {
       localStorage.setItem("grappa-token", "tok");
       localStorage.setItem(

--- a/cicchetto/src/lib/channelTopic.ts
+++ b/cicchetto/src/lib/channelTopic.ts
@@ -1,6 +1,6 @@
 import { createSignal } from "solid-js";
 import type { ChannelKey } from "./channelKey";
-import { moduleRoot } from "./moduleRoot";
+import { identityScopedStore } from "./identityScopedStore";
 
 // Per-channel topic + modes store. Module-singleton reactive signals.
 //
@@ -12,12 +12,19 @@ import { moduleRoot } from "./moduleRoot";
 // `compactModeString` is a pure function exported for use in TopicBar and
 // tests alike — formats `["n", "t"]` → `"+nt"`.
 //
-// Lifecycle: module-singleton signals, no identity-scoped cleanup needed
-// for this store (data is overwritten on each WS push; stale data
-// from a previous channel join is harmless — the next channel join will
-// push fresh state, and self-PART/self-KICK on the server clears the
-// per-channel cache so the next topic_changed re-seeds with the new
-// channel-instance values).
+// Lifecycle (#975). Both maps hold state that is only true WHILE the
+// session is in the channel, so both are emptied at the two boundaries
+// where that stops being true:
+//   * own-PART → `dropChannelTopicState(key)` from subscribe.ts, beside
+//     the `setParted(key)` windowState projection.
+//   * logout / bearer rotation → the `identityScopedStore` resets below,
+//     like scrollback.ts / selection.ts / members.ts / readCursor.ts.
+// Pre-#975 there was NO emptier at all: the pre-PART entry survived
+// forever and ModeModal presented it as the channel's CURRENT modes. The
+// old comment here claimed no cleanup was needed because "the next join
+// pushes fresh state" — true, but it answers the wrong question: between
+// the part and any re-join the cache is a confident lie. Absence is the
+// honest answer, and it is what ModeModal now renders as "modes unknown".
 //
 // UX-5 BJ (2026-05-19): the per-channel creation timestamp store
 // (329 RPL_CREATIONTIME → `createdByChannel` / `seedChannelCreated`)
@@ -41,9 +48,20 @@ export type ModesEntry = {
   params: Record<string, string | null>;
 };
 
-const exports_ = moduleRoot(() => {
+const exports_ = identityScopedStore((onIdentityChange) => {
   const [topicByChannel, setTopicByChannel] = createSignal<Record<ChannelKey, TopicEntry>>({});
   const [modesByChannel, setModesByChannel] = createSignal<Record<ChannelKey, ModesEntry>>({});
+
+  onIdentityChange(() => setTopicByChannel({}));
+  onIdentityChange(() => setModesByChannel({}));
+
+  const dropKey = <T>(key: ChannelKey) => {
+    return (prev: Record<ChannelKey, T>): Record<ChannelKey, T> => {
+      if (!(key in prev)) return prev;
+      const { [key]: _drop, ...rest } = prev;
+      return rest;
+    };
+  };
 
   const seedTopic = (key: ChannelKey, entry: TopicEntry): void => {
     setTopicByChannel((prev) => ({ ...prev, [key]: entry }));
@@ -53,11 +71,22 @@ const exports_ = moduleRoot(() => {
     setModesByChannel((prev) => ({ ...prev, [key]: entry }));
   };
 
+  // Both maps go together: topic and modes are the same datum class
+  // (server-pushed while joined, unobservable once parted) and splitting
+  // their lifecycle would leave two twin structures behaving differently
+  // for no reason a later reader could recover. Idempotent — dropping an
+  // unknown key returns the same object, so no consumer wakes for nothing.
+  const dropChannelTopicState = (key: ChannelKey): void => {
+    setTopicByChannel(dropKey(key));
+    setModesByChannel(dropKey(key));
+  };
+
   return {
     topicByChannel,
     modesByChannel,
     seedTopic,
     seedModes,
+    dropChannelTopicState,
   };
 });
 
@@ -65,6 +94,7 @@ export const topicByChannel = exports_.topicByChannel;
 export const modesByChannel = exports_.modesByChannel;
 export const seedTopic = exports_.seedTopic;
 export const seedModes = exports_.seedModes;
+export const dropChannelTopicState = exports_.dropChannelTopicState;
 
 /**
  * #263 — flattens a multi-line topic draft to a SINGLE wire line.

--- a/cicchetto/src/lib/subscribe.ts
+++ b/cicchetto/src/lib/subscribe.ts
@@ -5,7 +5,7 @@ import { socketUserName, token } from "./auth";
 import { incrementBadge, setBadge } from "./badge";
 import { playBeep } from "./beep";
 import { type ChannelKey, channelKey, decodeChannelKey } from "./channelKey";
-import { seedModes, seedTopic } from "./channelTopic";
+import { dropChannelTopicState, seedModes, seedTopic } from "./channelTopic";
 import { isDocumentVisible } from "./documentVisibility";
 import { highlightPatterns } from "./highlightList";
 import { seedIsupport } from "./isupport";
@@ -36,7 +36,14 @@ import { followQueryNick, selectedChannel, setServerSeedCount } from "./selectio
 import { joinChannel } from "./socket";
 import { socketHealth } from "./socketHealth";
 import { SERVER_WINDOW_NAME } from "./windowKinds";
-import { setFailed, setJoined, setKicked, setParted, windowStateByChannel } from "./windowState";
+import {
+  setFailed,
+  setJoined,
+  setKicked,
+  setParted,
+  windowIsPresent,
+  windowStateByChannel,
+} from "./windowState";
 import { narrowChannelEvent } from "./wireNarrow";
 
 // WS subscription installer. Reactive side-effect module: imports for
@@ -508,6 +515,14 @@ moduleRoot(() => {
             // map. Server intentionally does NOT broadcast `kind:
             // "parted"` — cic derives the projection here.
             setParted(key);
+            // #975: the channel's topic + modes are only observable while
+            // we are IN it (the 324 that seeds modes is the server's
+            // on-JOIN `MODE #chan` query), so they die with the window.
+            // Gated on the OUTCOME of setParted rather than re-deriving
+            // its #495 stale-echo guard: when that guard no-ops (a late
+            // part echo landing on a re-join already "pending") the key is
+            // still present and the freshly-seeded state must survive.
+            if (!windowIsPresent(key)) dropChannelTopicState(key);
           }
 
           routeMessage(slug, key, name, message, ownNick);

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -6112,6 +6112,16 @@ html.resize-dragging * {
   overscroll-behavior: contain;
 }
 
+/* #975 — the "cic has no 324 for this channel" state, shown INSTEAD of the
+ * toggle grid. Muted like every other non-answer in the chrome; deliberately
+ * not styled as an error, since not being in a channel is not a fault. */
+.mode-modal-unknown {
+  margin: 0;
+  padding: 0.5rem 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
 /* Chunky toggle button: flag chip + bold label + muted description on
  * one row. Inactive = flat outline; active = inset double-frame in the
  * accent color (the "switch is ON" retro affordance). */


### PR DESCRIPTION
Addresses **defect (2) only** of #975 — the cache that is never invalidated.
Defect (1), the refresh path, is deliberately untouched (see Scope below).

## The hole

`cicchetto/src/lib/channelTopic.ts` exposed `seedTopic` / `seedModes` and
nothing else. Modes arrive only via the 324 the server queries in its
`:joined` arm (#216 — ircds do not send 324 unsolicited), pushed on the
per-channel WS topic. Nothing ever removed a key, so an entry seeded while
joined outlived the PART for the tab's lifetime, and `/mode #chan-I-left`
— a pure local read — answered with it. Reported by Sonic on #it-opers.

It was the last per-channel signal map with no lifecycle at all:
`scrollback` / `selection` / `members` / `readCursor` all have an
identity-scoped reset.

## What changed

- **own-PART → `dropChannelTopicState(key)`**, in `subscribe.ts` beside
  the existing `setParted(key)` projection.
- **logout / rotation →** the store moves from `moduleRoot` to
  `identityScopedStore`, the shared factory the siblings already use.
- **`topicByChannel` goes with `modesByChannel`.** Same datum class, same
  hole. Splitting the lifecycle would leave twin structures behaving
  differently for no reason a later reader could recover.
- **`ModeModal` distinguishes entry-ABSENT from entry-EMPTY.** With the
  drop in place, "no entry" is the common case, and the old
  `?.modes ?? []` fed an all-off grid — which states "+" (no modes set)
  as fact. Absent now renders `modes unknown — not in this channel`
  instead of the grid; an empty `modes` array is a real 324 answer and
  still renders it.

### Why the drop reads `windowIsPresent` rather than re-testing state

`setParted` carries the #495 stale-echo guard: a part echo landing on a key
already back at `"pending"` is a no-op, because it is the echo of an
EARLIER part that lost the race to a re-join. Copying that condition into
the drop would create two guards free to drift. Gating on the OUTCOME —
the window still being present means the projection declined, so the
freshly-seeded modes must survive — keeps one. There is a test for exactly
that case.

## Measured

- `scripts/bun.sh run check` → exit 0 (biome + `tsc --noEmit`; biome does
  not read `e2e/`, so that was typechecked separately).
- `scripts/bun.sh run test` → **244 files / 4540 tests, all green**, tree
  clean before and after.
- `tsc -p e2e/tsconfig.json --noEmit` → 0 errors in the new spec (the 26
  it reports are pre-existing, in other files, none touched here).
- **Mutation-checked, not just green.** Each new assertion was proven to
  bite by breaking the thing it guards: dropping only `topicByChannel`
  (2 red), removing the `subscribe.ts` call (1 red), making the drop
  unconditional so the #495 case regresses (1 red), forcing
  `modesKnown()` true (1 red). All restored.

## NOT measured — do not read this as verified

- **The e2e has never been run.** The STACK lane is orchestrator-allocated
  and was not requested for this bucket. `issue975-mode-cache-invalidation`
  typechecks and follows the `issue216` shape, and that is the entire
  extent of the claim.
- No browser, no screenshot: the copy string and the muted style are
  reasoned from the existing `.mode-modal-readonly` treatment, not looked at.

## Scope, and a sibling instance left open

Defect (1) needs a server surface that issues `MODE #chan` for a channel
the session is not in AND a route home for the 324 (today it fans out on
the per-channel topic, which a not-joined channel has no subscription to).
Not here. **(2) alone converts a wrong answer into an absent one** — it
does not make `/mode` on a foreign channel work.

**A KICK is the same class and is NOT fixed.** After a kick you are equally
out of the channel and the cached modes go equally stale, but `setKicked`
keeps the window present (`:kicked` pseudo-row), so the gate declines and
the modal still shows the pre-kick modes. Flagged rather than widened
silently.

## Product call inside

The issue asks whether the modal should say "modes unknown" instead of
showing an empty toggle set. Implemented as unknown, on the grounds that an
empty set presented as current is a lie. It is one string if vjt disagrees;
the structural half (absence is not an answer) is what matters.

DESIGN_NOTES entry is staged at `/tmp/w1-designnotes-975.md` rather than
committed, so parallel workers do not conflict on the file.