### PR TITLE
cic(#981): no unread badge on a window you are at the bottom of

### DIFF
--- a/cicchetto/e2e/tests/issue981-no-badge-at-tail.spec.ts
+++ b/cicchetto/e2e/tests/issue981-no-badge-at-tail.spec.ts
@@ -1,0 +1,172 @@
+// #981 — no unread badge on a window whose tail the operator is watching.
+//
+// The report (vjt, 2026-08-07): a channel is selected, the pane is already at
+// the bottom, a message lands — the badge blinks `1` and clears itself. The
+// blink is the gap between the badge memo (synchronous, the row is past the
+// cursor the instant it lands) and the read-at-the-tail cursor arm (debounced
+// `READ_AT_TAIL_SETTLE_MS = 500`). The ruling is the wider one: while you are
+// at the bottom of a window, no badge at all.
+//
+// Why this cannot be a jsdom test: the suppression is gated on the pane's
+// GEOMETRY (`atBottomNow`), and jsdom's zero-height boxes read as at-the-tail
+// unconditionally — measured under #887, deleting that gate leaves the whole
+// ScrollbackPane suite green. jsdom can only pin the pieces either side of the
+// geometry; the geometry itself lives here.
+//
+// ── How this spec avoids being vacuous ──────────────────────────────────────
+// It asserts an ABSENCE across a window that is 500 ms wide, so two things
+// have to be true or it proves nothing:
+//
+//   1. The observation must be CONTINUOUS and must OUTLIVE the mechanism it
+//      denies. A `toHaveCount(0)` check — even a retrying one — samples, and
+//      every sample can legitimately land in a gap: it would pass against the
+//      broken build simply by arriving after the arm had cleared the badge.
+//      So a MutationObserver is armed BEFORE the message is sent and records
+//      every appearance of the badge for the whole run, and the wait after the
+//      row lands is longer than the debounce plus browser slop.
+//   2. The instrument must be provably able to SEE a badge. An empty
+//      recording is only meaningful if a non-empty one was reachable, so the
+//      same observer, with the same selector, is then made to record a real
+//      badge: switch away from the channel and send again. If that positive
+//      control comes back empty the recording apparatus is broken and the
+//      negative above is worthless — which is exactly what the assertion says.
+//
+// Per `feedback_e2e_user_class_parity_matrix`: this pins a rendering CONTRACT,
+// not a verb across user classes — one seeded registered user is right.
+
+import type { Page } from "@playwright/test";
+import { expect, test } from "../fixtures/test";
+import { loginAs, selectChannel, sidebarMessageBadge } from "../fixtures/cicchettoPage";
+import { restoreReadCursorToTail } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+const PEER_NICK = "badge981-buddy";
+const SERVER_WINDOW = "Server";
+const RUN_ID = crypto.randomUUID().slice(0, 8);
+
+// Longer than the pane's read-at-the-tail debounce (500 ms) plus generous
+// browser slop. The recording must outlive the blink it denies; a negative
+// that expires before the mechanism does proves nothing.
+const PAST_READ_AT_TAIL_SETTLE_MS = 1_500;
+
+// The badge for the channel under test, as a plain CSS selector the page can
+// evaluate (the Playwright locator is section-scoped and cannot cross into
+// `page.evaluate`). Desktop-only class: this spec is untagged, so it runs on
+// the chromium project alone.
+const BADGE_SELECTOR = `li[data-window-name="${CHANNEL}"] .sidebar-msg-unread`;
+
+type BadgeSighting = { text: string; atMs: number };
+
+declare global {
+  interface Window {
+    __cic981Sightings?: BadgeSighting[];
+  }
+}
+
+// Arm a MutationObserver that records every state of the badge, once per DOM
+// mutation anywhere in the document. Solid renders the badge by INSERTING the
+// element, so an appearance is always a mutation; the observer callback runs
+// at the end of the task that inserted it, while the element is still there.
+async function armBadgeObserver(page: Page): Promise<void> {
+  await page.evaluate((selector) => {
+    window.__cic981Sightings = [];
+    const sample = (): void => {
+      for (const el of document.querySelectorAll(selector)) {
+        const text = (el.textContent ?? "").trim();
+        if (text !== "") window.__cic981Sightings?.push({ text, atMs: Date.now() });
+      }
+    };
+    sample();
+    new MutationObserver(sample).observe(document.body, {
+      subtree: true,
+      childList: true,
+      characterData: true,
+    });
+  }, BADGE_SELECTOR);
+}
+
+async function readSightings(page: Page): Promise<BadgeSighting[]> {
+  return await page.evaluate(() => window.__cic981Sightings ?? []);
+}
+
+async function clearSightings(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    window.__cic981Sightings = [];
+  });
+}
+
+test.describe("#981 badge on a window read at the tail", () => {
+  // Cascade rule: leave #bofh fully read for whatever runs next.
+  test.afterAll(async () => {
+    if (!CHANNEL) return;
+    const vjt = getSeededVjt();
+    await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
+  });
+
+  test("never shows, not even for an instant, while the operator watches the tail", async ({
+    page,
+  }) => {
+    if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+    const vjt = getSeededVjt();
+
+    // Caught up and parked at the tail — the state the report is about.
+    await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+    await expect(sidebarMessageBadge(page, NETWORK_SLUG, CHANNEL)).toHaveCount(0, {
+      timeout: 10_000,
+    });
+
+    // Let the activation settle so the pane has MEASURED its distance to the
+    // tail (the suppression withholds itself until it has — see
+    // `tailGeometryMeasured`). Without this the spec could pass on a pane that
+    // never got to answer.
+    await page.waitForTimeout(PAST_READ_AT_TAIL_SETTLE_MS);
+
+    await armBadgeObserver(page);
+
+    const peer = await IrcPeer.connect({ nick: PEER_NICK });
+    try {
+      const body = `#981 watched arrival ${RUN_ID}`;
+      await peer.join(CHANNEL);
+      peer.privmsg(CHANNEL, body);
+
+      // The row really arrived and the pane tail-followed it into view. This
+      // is the non-vacuity floor for the negative below: no arrival, nothing
+      // to suppress, and the empty recording would mean nothing.
+      await expect(page.locator('[data-testid="scrollback-line"]', { hasText: body })).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // Past the whole debounce window with the observer running: on the
+      // pre-#981 build the badge is up for ~500 ms of this wait.
+      await page.waitForTimeout(PAST_READ_AT_TAIL_SETTLE_MS);
+
+      const sightings = await readSightings(page);
+      expect(
+        sightings,
+        `badge appeared while the pane sat at the tail: ${JSON.stringify(sightings)}`,
+      ).toEqual([]);
+
+      // ── POSITIVE CONTROL, same observer, same selector ──────────────────
+      // Switch away and send again. The badge MUST be recorded now; if it is
+      // not, the apparatus above was blind and its silence meant nothing.
+      await clearSightings(page);
+      await selectChannel(page, NETWORK_SLUG, SERVER_WINDOW, { awaitWsReady: false });
+      peer.privmsg(CHANNEL, `#981 defocused arrival ${RUN_ID}`);
+
+      await expect(sidebarMessageBadge(page, NETWORK_SLUG, CHANNEL)).toHaveText("1", {
+        timeout: 10_000,
+      });
+      const control = await readSightings(page);
+      expect(
+        control.length,
+        "the MutationObserver recorded nothing for a badge Playwright can see — the negative above is not evidence",
+      ).toBeGreaterThan(0);
+    } finally {
+      await peer.disconnect("#981 watched-arrival done");
+    }
+  });
+});

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -38,6 +38,7 @@ import {
 } from "./lib/presenceFilter";
 import { canonicalQueryNick, openQueryWindowState } from "./lib/queryWindows";
 import { getReadCursor } from "./lib/readCursor";
+import { setReadingAtTailKey } from "./lib/readingAtTail";
 import { isSettled, nextFollowMode, resolveIntent, type ScrollIntent } from "./lib/scrollAuthority";
 import {
   dismissFarBehind,
@@ -1086,6 +1087,20 @@ const ScrollbackPane: Component<Props> = (props) => {
   // steps build the divergence on.
   const [followMode, setFollowMode] = createSignal(true);
   const [atBottomNow, setAtBottomNow] = createSignal(true);
+  // #981 — has `atBottomNow` been MEASURED for the window now on screen?
+  //
+  // Every activation re-arms it TRUE as an intent default (the 2026-06-01
+  // scroll-contamination re-arm in the key effect) BEFORE any geometry is
+  // read; the real measurement lands later, in the activation's rAF×2 or on
+  // the next scroll event. The read-at-the-tail cursor arm tolerates that gap
+  // — it re-reads the DOM 500 ms later and `setCursorIfAdvances` is
+  // forward-only — but the badge suppression published from it cannot: acting
+  // on the default would blink the ARRIVING window's badge to 0 and back
+  // within two frames, which is the "vanishes on select" complaint #887 was
+  // filed about. False from every switch until a measurement lands, and every
+  // unmeasured path therefore publishes "not reading" — failing toward
+  // SHOWING the badge, the honest direction.
+  const [tailGeometryMeasured, setTailGeometryMeasured] = createSignal(false);
   // #285 reopen — FAIL-OPEN touch-action gate. The CSS base is `pan-y`; this
   // signal drives the `.scrollback-locked` class that LOCKS the pane to
   // `touch-action: none` ONLY when a trustworthy measurement proves the content
@@ -2138,6 +2153,14 @@ const ScrollbackPane: Component<Props> = (props) => {
           setFollowMode(true);
           setAtBottomNow(true);
         }
+        // #981 — every branch above ran INSIDE the rAF×2, i.e. against settled
+        // layout: the marker branch read the distance-to-tail, the else branch
+        // placed the pane AT the tail, and `marker-or-preserve` deliberately
+        // left the reader where they were (above the tail). All three are
+        // answers about THIS window's geometry, so the suppression may act on
+        // `atBottomNow` from here on. The early returns above are not: they
+        // leave the flag false and the badge shown.
+        setTailGeometryMeasured(true);
         // Scroll has settled at the correct position — reveal.
         if (withHide) setActivating(false);
       });
@@ -2259,6 +2282,10 @@ const ScrollbackPane: Component<Props> = (props) => {
         // own input takes it back.
         setFollowMode(true);
         setAtBottomNow(true);
+        // #981 — and that `true` is an INTENT default, not a measurement of
+        // the arriving window. Withhold the badge suppression until the
+        // activation below (or the next scroll) measures the real distance.
+        setTailGeometryMeasured(false);
 
         // CP29 R-4: capture the boundary as the highest message id present
         // RIGHT NOW. `messages()` is the same store the rows memo reads;
@@ -2473,17 +2500,22 @@ const ScrollbackPane: Component<Props> = (props) => {
   // left over from the previous window must never write the switched-to one
   // (same hazard, same shape, as the #239 presence arm below). `key()` is read
   // for exactly that reason: a channel switch must re-arm, not inherit.
+  //
+  // THE predicate, in one place: `readingAtTail`. The arm below acts on it,
+  // and #981 publishes it so the badge derivation can suppress the count for
+  // the window it is true of. Two consumers, one expression — reassembling it
+  // at the reader is how the two would drift apart.
+  const readingAtTail = (): boolean =>
+    isDocumentVisible() && atBottomNow() && (rows()?.length ?? 0) > 0;
   let readAtTailSettleTimer: number | undefined;
   createEffect(() => {
     key();
-    const rowCount = rows()?.length ?? 0;
-    const visible = isDocumentVisible();
-    const atTail = atBottomNow();
+    const reading = readingAtTail();
     if (readAtTailSettleTimer !== undefined) {
       window.clearTimeout(readAtTailSettleTimer);
       readAtTailSettleTimer = undefined;
     }
-    if (!visible || !atTail || rowCount === 0) return;
+    if (!reading) return;
     readAtTailSettleTimer = window.setTimeout(settleCursorToVisibleTail, READ_AT_TAIL_SETTLE_MS);
   });
   onCleanup(() => {
@@ -2491,6 +2523,19 @@ const ScrollbackPane: Component<Props> = (props) => {
       window.clearTimeout(readAtTailSettleTimer);
     }
   });
+
+  // #981 — publish that same answer for `selection.ts` (`perChannelUnread`),
+  // which suppresses the unread badge for the window it names. The extra
+  // `tailGeometryMeasured` term is not a second predicate: it withholds the
+  // answer while `atBottomNow` is still the activation's intent default (see
+  // its declaration), and withholding publishes `null` — the badge shows.
+  //
+  // ONE writer, by construction: exactly one pane is mounted at a time, and
+  // it clears the signal when it goes away.
+  createEffect(() => {
+    setReadingAtTailKey(tailGeometryMeasured() && readingAtTail() ? key() : null);
+  });
+  onCleanup(() => setReadingAtTailKey(null));
 
   // #239 — advance the server read-cursor over the TRAILING run of hidden
   // control messages while this window is DISPLAYED. The #222 presence filter
@@ -3201,6 +3246,10 @@ const ScrollbackPane: Component<Props> = (props) => {
       setFollowMode(nextFollowMode(followMode(), "scroll-up"));
     }
     lastScrollTop = st;
+    // #981 — a scroll event carries a real distance-to-tail read (computed
+    // above), including the untouched middle branch: whatever `atBottomNow`
+    // now says about this window, it says it from measured layout.
+    setTailGeometryMeasured(true);
 
     // BUGHUNT-2 B7: snapshot the current visible-tail for the CURRENT
     // (key) so the leave-arm in `on(key, …)` can recover the leaving

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -9,6 +9,10 @@ import {
   pushOverlay,
   __resetForTest as resetOverlayLock,
 } from "../lib/overlayScrollLock";
+// #981 — the REAL shared signal the pane publishes its read-at-the-tail
+// answer into (the badge derivation in selection.ts reads it). Not mocked:
+// the pane is its only writer and what these tests assert IS the write.
+import { readingAtTailKey } from "../lib/readingAtTail";
 // #230 — the mocked `loadMore` (see vi.mock("../lib/scrollback")) so the
 // wheel-up-on-underfill trigger can be asserted directly.
 import { loadMore } from "../lib/scrollback";
@@ -4310,6 +4314,80 @@ describe("ScrollbackPane", () => {
       // visibility gate worth keeping), so nothing may be marked read.
       await new Promise((r) => setTimeout(r, 900));
       expect(mockSetCursorIfAdvances).not.toHaveBeenCalled();
+    });
+  });
+
+  // #981 — the pane PUBLISHES the same read-at-the-tail answer the cursor arm
+  // above acts on, so `selection.ts` can suppress the badge for the window
+  // being read without re-deriving (and eventually forking) the predicate.
+  //
+  // The geometric term is not bindable here — jsdom reports zero-height boxes,
+  // so `atBottomNow` reads "at the tail" whatever the test does (measured
+  // under #887: deleting that gate left every pane test green). What IS
+  // bindable, and what these tests own, is everything around it: the tab
+  // visibility term, the mount/unmount lifecycle, and the refusal to answer
+  // for a window whose geometry has not been measured yet. The geometry
+  // itself is an e2e.
+  describe("#981 — the pane publishes which window it is reading at the tail", () => {
+    it("publishes its own key while visible with rows rendered", async () => {
+      setScrollback({ "freenode #grappa": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+
+      await waitFor(() => expect(readingAtTailKey()).toBe("freenode #grappa"));
+    });
+
+    it("publishes nothing while the tab is hidden (a backgrounded tab is not being read)", async () => {
+      setScrollback({ "freenode #grappa": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      await waitFor(() => expect(readingAtTailKey()).toBe("freenode #grappa"));
+
+      setDocVisible(false);
+
+      await waitFor(() => expect(readingAtTailKey()).toBeNull());
+    });
+
+    it("publishes nothing for an EMPTY window (there is nothing on screen to read)", async () => {
+      setScrollback({});
+      render(() => <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(readingAtTailKey()).toBeNull();
+    });
+
+    it("clears on unmount — a pane that is gone is reading nothing", async () => {
+      setScrollback({ "freenode #grappa": fixture });
+      const { unmount } = render(() => (
+        <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+      ));
+      await waitFor(() => expect(readingAtTailKey()).toBe("freenode #grappa"));
+
+      unmount();
+
+      expect(readingAtTailKey()).toBeNull();
+    });
+
+    // The switch re-arms `atBottomNow` TRUE as an INTENT default before any
+    // geometry is read (the 2026-06-01 scroll-contamination re-arm in the key
+    // effect), and only the activation rAF×2 later replaces it with a real
+    // measurement. Publishing across that gap would blink the ARRIVING
+    // window's badge to 0 and back — the "vanishes on select" complaint #887
+    // was filed about, in miniature. So the answer is withheld until the
+    // arriving window's geometry has actually been measured.
+    it("withholds the answer across a window switch until geometry is measured", async () => {
+      const [chan, setChan] = createSignal("#a");
+      setScrollback({ "freenode #a": fixture, "freenode #b": fixture });
+      render(() => <ScrollbackPane networkSlug="freenode" channelName={chan()} kind="channel" />);
+      // jsdom leaves scrollTo undefined; the switch's smooth-scroll interrupt
+      // calls it (see the #608 W9 spec, same stub).
+      (screen.getByTestId("scrollback") as HTMLDivElement).scrollTo = vi.fn();
+      await waitFor(() => expect(readingAtTailKey()).toBe("freenode #a"));
+
+      setChan("#b");
+
+      // Synchronously after the switch: the arriving window is unmeasured.
+      expect(readingAtTailKey()).toBeNull();
+      // ...and once the activation has settled, it answers for the new window.
+      await waitFor(() => expect(readingAtTailKey()).toBe("freenode #b"));
     });
   });
 

--- a/cicchetto/src/__tests__/unreadBadgeAtTail.test.ts
+++ b/cicchetto/src/__tests__/unreadBadgeAtTail.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { channelKey } from "../lib/channelKey";
+
+// #981 — no badge on a window the operator is sitting at the bottom of.
+//
+// The complaint (vjt, 2026-08-07): a channel is selected, the pane is already
+// at the tail, a message lands — the badge blinks `1` and clears itself. The
+// blink is the gap between the memo (synchronous) and the read-at-the-tail
+// cursor arm (debounced 500 ms), so the fix suppresses the count for exactly
+// the window the pane reports it is reading, via `readingAtTail`.
+//
+// Its own file, sibling to `unreadBadgeFocused.test.ts` and for the same
+// reason: it runs the REAL scrollback + readCursor stores, because the #693
+// far-behind guard below can only be set up by driving the production loader.
+//
+// What these tests DO NOT cover: the geometry itself. `atBottomNow` is a DOM
+// measurement and jsdom reports zero-height boxes, so scrolled-up-vs-at-tail
+// is not bindable here (measured under #887: deleting the gate left all 171
+// pane tests green). These tests drive the pane's PUBLISHED answer directly;
+// the pane's own publishing rules are pinned in `ScrollbackPane.test.tsx`, and
+// the end-to-end "the badge never appears" property is an e2e.
+
+vi.mock(import("../lib/api"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    listNetworks: vi.fn().mockResolvedValue([]),
+    listChannels: vi.fn().mockResolvedValue([]),
+    listMessages: vi.fn().mockResolvedValue([]),
+    listMessagesAfter: vi.fn().mockResolvedValue([]),
+    countMessagesAfter: vi.fn().mockResolvedValue(0),
+    sendMessage: vi.fn(),
+    me: vi.fn().mockResolvedValue({
+      kind: "user",
+      id: "u-test",
+      name: "alice",
+      is_admin: false,
+      inserted_at: "2026-01-01T00:00:00Z",
+      read_cursors: {},
+    }),
+    login: vi.fn(),
+    logout: vi.fn(),
+    setOn401Handler: vi.fn(),
+  };
+});
+
+// Keep the cursor store REAL (applyJoinReply / getReadCursor are the setup
+// verbs) but stub the one member that would hit the network.
+vi.mock("../lib/readCursor", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/readCursor")>();
+  return { ...actual, setReadCursor: vi.fn().mockResolvedValue(undefined) };
+});
+
+const SLUG = "freenode";
+const CHANNEL = "#grappa";
+
+beforeEach(() => {
+  vi.resetModules();
+  localStorage.clear();
+  vi.clearAllMocks();
+  vi.spyOn(document, "hasFocus").mockReturnValue(true);
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => "visible",
+  });
+  localStorage.setItem("grappa-token", "tok");
+});
+
+const seedThreeMessages = async (channel: string): Promise<ReturnType<typeof channelKey>> => {
+  const scrollback = await import("../lib/scrollback");
+  const key = channelKey(SLUG, channel);
+  for (const id of [1, 2, 3]) {
+    scrollback.appendToScrollback(key, {
+      id,
+      network: SLUG,
+      channel,
+      server_time: id,
+      kind: "privmsg",
+      sender: "bob",
+      body: `msg ${id}`,
+      meta: {},
+    });
+  }
+  return key;
+};
+
+describe("#981 unread badge on the window being read at the tail", () => {
+  it("suppresses the count for the window the pane reports reading", async () => {
+    const selection = await import("../lib/selection");
+    const { setReadingAtTailKey } = await import("../lib/readingAtTail");
+    const key = await seedThreeMessages(CHANNEL);
+
+    // Without the pane's report the count is the plain #887 number.
+    expect(selection.messagesUnread()[key]).toBe(3);
+
+    setReadingAtTailKey(key);
+
+    expect(selection.messagesUnread()[key]).toBeUndefined();
+    expect(selection.unreadCounts()[key]).toBeUndefined();
+  });
+
+  it("suppresses event counts too — no badge means no badge", async () => {
+    const scrollback = await import("../lib/scrollback");
+    const selection = await import("../lib/selection");
+    const { setReadingAtTailKey } = await import("../lib/readingAtTail");
+    const key = channelKey(SLUG, CHANNEL);
+    scrollback.appendToScrollback(key, {
+      id: 1,
+      network: SLUG,
+      channel: CHANNEL,
+      server_time: 1,
+      kind: "join",
+      sender: "bob",
+      body: "",
+      meta: {},
+    });
+    expect(selection.eventsUnread()[key]).toBe(1);
+
+    setReadingAtTailKey(key);
+
+    expect(selection.eventsUnread()[key]).toBeUndefined();
+  });
+
+  it("restores the count the moment the pane stops reporting (leave, scroll up, hide)", async () => {
+    const selection = await import("../lib/selection");
+    const { setReadingAtTailKey } = await import("../lib/readingAtTail");
+    const key = await seedThreeMessages(CHANNEL);
+
+    setReadingAtTailKey(key);
+    expect(selection.messagesUnread()[key]).toBeUndefined();
+
+    // `null` is what the pane publishes for every not-reading state: unmount,
+    // backgrounded tab, scrolled up, geometry not yet measured.
+    setReadingAtTailKey(null);
+
+    expect(selection.messagesUnread()[key]).toBe(3);
+  });
+
+  it("suppresses ONLY the reported window — every other badge stands", async () => {
+    const selection = await import("../lib/selection");
+    const { setReadingAtTailKey } = await import("../lib/readingAtTail");
+    const readKey = await seedThreeMessages(CHANNEL);
+    const otherKey = await seedThreeMessages("#other");
+
+    setReadingAtTailKey(readKey);
+
+    expect(selection.messagesUnread()[readKey]).toBeUndefined();
+    expect(selection.messagesUnread()[otherKey]).toBe(3);
+  });
+
+  // #693 — a far-behind window's cursor is FROZEN on purpose and its loaded
+  // rows are the tail, deliberately disjoint from the unread region. The
+  // server-measured seed is the honest number and the operator being at the
+  // bottom of those few rows does not mean they have read the thousands
+  // above. Suppressing here would zero the one badge that cannot come back
+  // on its own.
+  it("keeps a FAR-BEHIND window's badge even while the pane reads its tail", async () => {
+    const api = await import("../lib/api");
+    vi.mocked(api.countMessagesAfter).mockResolvedValue(3000);
+    vi.mocked(api.listMessages).mockResolvedValue([
+      {
+        id: 3100,
+        network: SLUG,
+        channel: CHANNEL,
+        server_time: 3100,
+        kind: "privmsg",
+        sender: "bob",
+        body: "newest",
+        meta: {},
+      },
+    ]);
+    const { applyJoinReply } = await import("../lib/readCursor");
+    const { loadInitialScrollback, farBehindByChannel } = await import("../lib/scrollback");
+    const selection = await import("../lib/selection");
+    const { setReadingAtTailKey } = await import("../lib/readingAtTail");
+    const key = channelKey(SLUG, CHANNEL);
+
+    applyJoinReply(SLUG, CHANNEL, 100);
+    await loadInitialScrollback(SLUG, CHANNEL);
+    expect(farBehindByChannel()[key]).toEqual({ missed: 3000, resumeFrom: 100 });
+
+    selection.setServerSeedCount(key, { messages: 3000, events: 0 });
+    expect(selection.messagesUnread()[key]).toBe(3000);
+
+    setReadingAtTailKey(key);
+
+    expect(selection.messagesUnread()[key]).toBe(3000);
+  });
+});

--- a/cicchetto/src/lib/readingAtTail.ts
+++ b/cicchetto/src/lib/readingAtTail.ts
@@ -1,0 +1,34 @@
+// #981 — the one bit of pane state the badge derivation needs: WHICH window,
+// if any, the operator is currently reading at its tail.
+//
+// The unread badge is a pure derivation in `selection.ts` (`perChannelUnread`)
+// over rows past the read cursor. It has no idea where the operator is
+// looking, and `atBottomNow` — the geometric "within threshold of the tail"
+// measurement — is pane-LOCAL signal state in `ScrollbackPane`. Suppressing
+// the badge on the window being read therefore needs the pane's answer to
+// cross module boundaries, and this signal is that crossing.
+//
+// Contract:
+//   * ONE writer — `ScrollbackPane`, the component that owns the geometry.
+//     Exactly one pane is mounted at a time (see the `visibleTailSnapshot`
+//     note there), so the value is unambiguous; the pane clears it on unmount.
+//   * The value is the pane's own read-at-the-tail predicate, published whole
+//     — visible tab AND at the tail AND something rendered — NOT a raw
+//     geometry bit. Reassembling that predicate at the reader would fork it
+//     from the read-at-the-tail cursor arm it must stay identical to.
+//   * `null` = nobody is reading at a tail: no pane, hidden tab, scrolled up,
+//     empty window, or geometry not yet measured for the arriving window.
+//     Every unknown collapses to `null`, so the failure direction is "show
+//     the badge" — the honest one.
+
+import { createSignal } from "solid-js";
+import type { ChannelKey } from "./channelKey";
+import { moduleRoot } from "./moduleRoot";
+
+const exports_ = moduleRoot(() => {
+  const [readingAtTailKey, setReadingAtTailKey] = createSignal<ChannelKey | null>(null);
+  return { readingAtTailKey, setReadingAtTailKey };
+});
+
+export const readingAtTailKey = exports_.readingAtTailKey;
+export const setReadingAtTailKey = exports_.setReadingAtTailKey;

--- a/cicchetto/src/lib/selection.ts
+++ b/cicchetto/src/lib/selection.ts
@@ -11,6 +11,7 @@ import { nickEquals } from "./nickEquals";
 import { presenceRowVisible } from "./presenceFilter";
 import { queryWindowsByNetwork } from "./queryWindows";
 import { getReadCursor, readCursors, setReadCursor } from "./readCursor";
+import { readingAtTailKey } from "./readingAtTail";
 import {
   farBehindByChannel,
   loadInitialScrollback,
@@ -51,6 +52,9 @@ import { windowIsPresent } from "./windowState";
 //     scrollback.ts) the derived counts fall on their own — in the
 //     FOCUSED window exactly as in every other one (#887; the old
 //     focused-window zeroing overwrite is gone, see `perChannelUnread`).
+//     The one window that IS zeroed is the one the pane reports it is
+//     reading at the tail (#981, `readingAtTail`) — a narrower rule than
+//     the #887 one, and honest for the reason spelled out at the memo.
 //
 // 2026-06-01 (unread-badges-from-cursor cluster, bucket B2): the four
 // increment stores (`unreadCounts`, `messagesUnread`, `eventsUnread`,
@@ -474,6 +478,39 @@ const exports = identityScopedStore((onIdentityChange) => {
     // The one window whose count still cannot fall is a far-behind one
     // (#693 freezes its cursor on purpose). That is now SAID rather than
     // hidden — #888 marks the badge as a distance, not a stuck counter.
+    //
+    // #981 (2026-08-07) — a NARROWER suppression is back, and the paragraph
+    // above is why it is allowed to be. DO NOT delete this for the #887
+    // reason without re-reading both:
+    //
+    // #887's objection was that the suppression was DISHONEST — it hid the
+    // badge without advancing the cursor, so the count vanished on select and
+    // returned whole on leave. That objection no longer holds: the cursor
+    // now advances WHILE the operator reads (the read-at-the-tail arm), so a
+    // window suppressed here genuinely becomes read within the arm's settle
+    // and the number does not come back. What is hidden is the 500 ms gap
+    // between "the row landed" (this memo, synchronous) and "the arm marked
+    // it read" (debounced) — the blink vjt reported as a badge flashing `1`
+    // on a pane he was already at the bottom of.
+    //
+    // The predicate is NOT re-derived here. `readingAtTailKey` is the pane's
+    // own read-at-the-tail gate — visible tab AND geometrically at the tail
+    // AND rows rendered — published whole, so the badge is suppressed for
+    // exactly the window the cursor arm is about to mark read. Reassembling
+    // it from `selectedChannel` (an intent, not a geometry) or from
+    // `followMode` would fork it, and the fork would be the #887 complaint
+    // again the first time the two disagreed. A backgrounded tab publishes
+    // `null` and keeps accruing.
+    //
+    // A far-behind window (#693) is deliberately excluded: its cursor is
+    // frozen, the arm cannot advance it, and the rows the operator is at the
+    // bottom of are NOT the unread region. Suppressing there would hide the
+    // one count that can never come back on its own.
+    const readingKey = readingAtTailKey();
+    if (readingKey !== null && !farBehind[readingKey] && result[readingKey] !== undefined) {
+      result[readingKey] = { messages: 0, events: 0 };
+    }
+
     return result;
   });
 


### PR DESCRIPTION
Fixes the badge that blinks `1` on a pane the operator is already at the bottom of (GH #981).

## The defect, read from the code

The badge is a pure derivation (`perChannelUnread`, `selection.ts`) counting rows past the read cursor. It knows nothing about where the operator is looking — the focused-window suppression was deliberately deleted by #887. What replaced it is the read-at-the-tail arm in `ScrollbackPane`, which advances the cursor over what is on screen but is **debounced at `READ_AT_TAIL_SETTLE_MS = 500`**. So: row lands → memo recomputes → badge `1` immediately; 500 ms later the arm advances the cursor (the local advance is synchronous) → badge `0`. **The blink window IS that constant**, not a network round-trip.

## The change

- **`lib/readingAtTail.ts`** — a shared signal carrying which window, if any, the pane is reading at its tail. One writer: the pane that owns the geometry; cleared on unmount.
- **`ScrollbackPane`** — the read-at-the-tail gate is now ONE expression (`isDocumentVisible() && atBottomNow() && rows > 0`), read by both the cursor arm and the publisher. Not forked: `atBottomNow` is the geometry, deliberately distinct from `followMode` (the intent), and the suppression must read the geometry exactly like the arm does.
- **`selection.ts`** — `perChannelUnread` zeroes the window the pane names.

### The extra term, and why it is not a second predicate

Every window switch re-arms `atBottomNow` **true as an intent default** (the 2026-06-01 scroll-contamination re-arm) before any layout is read; the real measurement lands in the activation's rAF×2. The cursor arm tolerates that — it re-reads the DOM 500 ms later and its write is forward-only — but a suppression acting on the default would blink the **arriving** window's badge to 0 and back within two frames, which is the "vanishes on select" complaint #887 was filed about. `tailGeometryMeasured` withholds the answer until a measurement lands. Every unmeasured path publishes `null`, so the failure direction is **show the badge**.

### Why this is allowed to reinstate part of #887 — and why that is written in the code

#887's objection was that suppression was DISHONEST: it hid the badge *without advancing the cursor*, so the count vanished on select and came back whole (1832) on leave. That objection no longer holds, because the cursor now advances while the operator reads. The paragraph saying so sits at the #887 note in `selection.ts`, where the next reader will look before deleting this again.

### Guards, one test each

- **A backgrounded tab keeps accruing** — visibility is folded into what the pane publishes; a hidden tab publishes `null`.
- **A far-behind window (#693) keeps its badge** — its cursor is frozen on purpose and the rows it sits at the bottom of are not the unread region.

## Tests

- `src/__tests__/unreadBadgeAtTail.test.ts` (new) — the memo: suppressed when reported, restored when not, only the reported window, far-behind stands.
- `src/__tests__/ScrollbackPane.test.tsx` — the publisher: visibility, empty window, unmount, and withhold-across-a-switch.
- `e2e/tests/issue981-no-badge-at-tail.spec.ts` (new) — the badge never appears, not even for an instant.

**On the e2e's non-vacuity.** A `toHaveCount(0)` across a 500 ms window passes against the broken build by sampling late. So the observation is CONTINUOUS (a MutationObserver armed before the send, recording every appearance) and outlives the debounce; the row-visible assertion proves something actually arrived; and a POSITIVE CONTROL — the same observer, same selector, made to record a real badge on a defocused window — proves the instrument was not blind.

## Measured / not measured

- Measured: full cic suite (245 files / 4540 tests) and `bun run check` green from the worktree root, clean tree before and after. Both new guards mutation-checked — deleting the far-behind term reddens its test, deleting the freshness term reddens the switch test.
- **Not measured**: the e2e has never been run (no lane; e2e also has no static gate — biome ignores `e2e/` and its `node_modules` are container-only). CI is its first execution.
- **Not measured**: nothing on a device. The 500 ms figure is the constant in the source, not a stopwatch reading — I make no claim about how long the blink looks.
- **Watch item for CI**: `issue887-focused-unread-badge.spec.ts` asserts an intermediate `afterReading > 0` after a 1200 px wheel down a ~120-row unread region. If that wheel now reaches the tail, suppression zeroes it instantly where the 500 ms debounce used to leave a window. That would be a genuine collision between #887's spec and #981's ruling, not a flake.

A DESIGN_NOTES entry is written and held out of this branch to avoid conflicting with the other open PRs; it is handed over at merge.