### PR TITLE
cic(#579): send /lusers' mask and target server instead of dropping them

### DIFF
--- a/cicchetto/e2e/tests/issue579-lusers-routed-to-server.spec.ts
+++ b/cicchetto/e2e/tests/issue579-lusers-routed-to-server.spec.ts
@@ -1,0 +1,93 @@
+// #579 — `/lusers <mask> <server>` must actually route the query to the
+// named server.
+//
+// Bug: cic's parser was `lusers: (_verb, _rest) => ({ kind: "lusers" })`, so
+// both RFC 2812 §3.4.2 arguments were discarded and every /lusers reached the
+// wire as a bare LUSERS. The operator who named a server read the LOCAL
+// server's counts believing they had queried the one they typed — a wrong
+// answer with no error.
+//
+// Why this spec drives the TWO-token form and not `/lusers <mask>`:
+// bahamut's `send_lusers` never `match()`es the mask (azzurra/bahamut
+// src/s_serv.c:2100-2315 — `parv[1]` is never dereferenced and there is no
+// `match()` in the function), so a mask ALONE has no observable effect on
+// this ircd; a spec built on it would be green whether or not the fix is
+// present. Routing is the observable half: `m_lusers` calls `hunt_server`
+// only when BOTH tokens are present (src/s_serv.c:2085), and the server that
+// answers reports ITS OWN figures via RPL_LUSERME (`m_client` / `m_server`)
+// — the card's "this server" field.
+//
+// The assertion is a DIFFERENCE BETWEEN TWO ROUTED REPLIES, not a comparison
+// against the local one. The testnet is a real mesh (hub + leaf-v4 + leaf-v6
+// + services) and the bouncer's session lands on a leaf via the
+// `bahamut-test` alias — but which leaf is not pinned anywhere the client can
+// see, and an older spec (issue540) still describes the session as dialling
+// the hub. Comparing hub-vs-leaf4 sidesteps that entirely: whichever of them
+// happens to be the session's own server, the two are DIFFERENT servers, so
+// their per-server counts must differ (a hub carries the leaves' links and no
+// clients; a leaf carries clients and one link). Pre-#579 both commands
+// reached the wire as the same bare LUSERS, so both replies came from the
+// session's own server and the two snapshots were identical — this spec fails
+// on that code.
+//
+// Per feedback_ux_e2e_mandatory: every cic UX-behavior change ships with a
+// Playwright e2e via scripts/integration.sh.
+
+import { expect, test } from "../fixtures/test";
+import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Two servers that exist on the testnet mesh under these exact names: the
+// hub (issue540 queries `+s hub.azzurra.chat` and matches rows) and leaf-v4
+// (compose.yaml aliases it `leaf4.azzurra.chat`; m12-motd matches
+// `leaf[46].azzurra.chat` in its NOTICEs). The mask is `*` — bahamut ignores
+// it, and `hunt_server` reads the target from the SECOND slot, so the mask is
+// only there to make the two-token frame well-formed (a server with no mask
+// is `:invalid_line` server-side and unconstructible client-side).
+const HUB = "hub.azzurra.chat";
+const LEAF = "leaf4.azzurra.chat";
+
+// Collapse whitespace before comparing. `toHaveText` normalizes internally,
+// so comparing a raw textContent against it could report "different" for a
+// pure whitespace difference — a green that proves nothing. Both sides go
+// through this.
+const norm = (s: string | null): string => (s ?? "").replace(/\s+/g, " ").trim();
+
+// 60s — two round trips through the mesh plus login/select. bahamut caches
+// LUSERS for 180s per server (LUSERS_CACHE_TIME), so the figures are stable
+// within a run; the budget is for the mesh hops, not for settling.
+test.setTimeout(60_000);
+
+test("#579 — /lusers <mask> <server> routes: two named servers answer with their own counts", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  const card = page.getByTestId("lusers-card");
+  const thisServer = page.getByTestId("lusers-card-this-server");
+
+  // First routed query. Pre-#579 the server token never left the browser and
+  // this was a bare LUSERS answered by the session's own server.
+  await composeSend(page, `/lusers * ${HUB}`);
+  await expect(card).toBeVisible({ timeout: 15_000 });
+  const hubCounts = norm(await thisServer.textContent());
+  expect(hubCounts).not.toBe("");
+
+  // Second routed query, to a DIFFERENT server. The solicited gate (#248) is
+  // consume-once per request, so this reply surfaces too and replaces the
+  // snapshot (last-solicited-write-wins).
+  await composeSend(page, `/lusers * ${LEAF}`);
+
+  // The barrier and the assertion are the same act: poll until the per-server
+  // line differs. It can only differ once the SECOND reply lands, and it can
+  // only be a different value if that reply came from a different server —
+  // which is the whole claim. On pre-#579 code both replies carry the local
+  // server's identical figures and this times out red.
+  await expect
+    .poll(async () => norm(await thisServer.textContent()), { timeout: 15_000 })
+    .not.toBe(hubCounts);
+});

--- a/cicchetto/src/LusersCard.tsx
+++ b/cicchetto/src/LusersCard.tsx
@@ -73,7 +73,11 @@ const LusersCard: Component<Props> = (props) => {
             </Show>
             <Show when={s.local_clients !== null || s.local_servers !== null}>
               <dt>this server</dt>
-              <dd>
+              {/* #579 — the one per-SERVER field on the card (RPL_LUSERME's
+                  m_client / m_server), so it is what changes when the two-token
+                  `/lusers <mask> <server>` form routes the query elsewhere. The
+                  e2e reads it by testid rather than by dt/dd adjacency. */}
+              <dd data-testid="lusers-card-this-server">
                 {fmt(s.local_clients)} clients
                 <Show when={s.local_servers !== null}>, {fmt(s.local_servers)} servers</Show>
               </dd>

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -1309,7 +1309,7 @@ describe("compose submit — slash command dispatch", () => {
   // the incoming bundle surfaces the card. Without the mark, the store's
   // #248 gate drops the bundle (same path the connect-welcome auto-emit
   // takes) and the operator's explicit /lusers would show nothing.
-  it("/lusers marks the request solicited then pushes LUSERS via pushLusers(networkId)", async () => {
+  it("/lusers marks the request solicited then pushes LUSERS via pushLusers(networkId, null, null)", async () => {
     const socket = await import("../lib/socket");
     const lusersBundle = await import("../lib/lusersBundle");
     const compose = await import("../lib/compose");
@@ -1318,7 +1318,33 @@ describe("compose submit — slash command dispatch", () => {
     const result = await compose.submit(k, "freenode", "#a");
 
     expect(lusersBundle.markLusersRequested).toHaveBeenCalledWith("freenode");
-    expect(socket.pushLusers).toHaveBeenCalledWith(1);
+    expect(socket.pushLusers).toHaveBeenCalledWith(1, null, null);
+    expect(result).toEqual({ ok: true });
+  });
+
+  // #579 — the typed args survive the whole submit path. Pre-#579 the parser
+  // dropped them, so `/lusers <mask>` reached the wire as a bare LUSERS and
+  // the operator silently read network-wide counts instead of the filtered
+  // ones they asked for.
+  it("/lusers <mask> threads the mask through pushLusers", async () => {
+    const socket = await import("../lib/socket");
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/lusers *.azzurra.org");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(socket.pushLusers).toHaveBeenCalledWith(1, "*.azzurra.org", null);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("/lusers <mask> <server> threads both through pushLusers", async () => {
+    const socket = await import("../lib/socket");
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/lusers *.azzurra.org void.azzurra.chat");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(socket.pushLusers).toHaveBeenCalledWith(1, "*.azzurra.org", "void.azzurra.chat");
     expect(result).toEqual({ ok: true });
   });
 

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -1323,9 +1323,9 @@ describe("compose submit — slash command dispatch", () => {
   });
 
   // #579 — the typed args survive the whole submit path. Pre-#579 the parser
-  // dropped them, so `/lusers <mask>` reached the wire as a bare LUSERS and
-  // the operator silently read network-wide counts instead of the filtered
-  // ones they asked for.
+  // dropped them, so `/lusers <mask> <server>` reached the wire as a bare
+  // LUSERS: no routing, and the operator read the local server's counts
+  // while believing they had queried the one they named.
   it("/lusers <mask> threads the mask through pushLusers", async () => {
     const socket = await import("../lib/socket");
     const compose = await import("../lib/compose");

--- a/cicchetto/src/__tests__/slashCommands.test.ts
+++ b/cicchetto/src/__tests__/slashCommands.test.ts
@@ -916,13 +916,55 @@ describe("parseSlash — keyword highlight (/hilight, /highlight alias, /dehilig
   });
 });
 
-describe("parseSlash — /lusers (P-0d)", () => {
-  it("parses bare /lusers", () => {
-    expect(parseSlash("/lusers")).toEqual({ kind: "lusers" });
+describe("parseSlash — /lusers (P-0d, args #579)", () => {
+  it("parses bare /lusers (no mask, no server)", () => {
+    expect(parseSlash("/lusers")).toEqual({ kind: "lusers", mask: null, server: null });
   });
 
-  it("ignores any trailing args (LUSERS is param-less)", () => {
-    expect(parseSlash("/lusers ignored")).toEqual({ kind: "lusers" });
+  it("/lusers <mask> → mask, null server", () => {
+    expect(parseSlash("/lusers *.azzurra.org")).toEqual({
+      kind: "lusers",
+      mask: "*.azzurra.org",
+      server: null,
+    });
+  });
+
+  it("/lusers <mask> <server> → both, in RFC 2812 §3.4.2 order", () => {
+    expect(parseSlash("/lusers *.azzurra.org void.azzurra.chat")).toEqual({
+      kind: "lusers",
+      mask: "*.azzurra.org",
+      server: "void.azzurra.chat",
+    });
+  });
+
+  it("ignores tokens past the second (LUSERS is a 2-slot wire frame)", () => {
+    expect(parseSlash("/lusers *.azzurra.org void.azzurra.chat junk")).toEqual({
+      kind: "lusers",
+      mask: "*.azzurra.org",
+      server: "void.azzurra.chat",
+    });
+  });
+
+  // #579 — the client mirror of the server's `:invalid_line` for a server
+  // with no mask (grappa_channel `validate_lusers_args/2`): the positional
+  // parse cannot BUILD that shape, so there is nothing to reject at runtime.
+  // This pins that property — it fails the moment the handler reads the first
+  // token as the server (i.e. copies /whois's `<server> <nick>` order, which
+  // for a one-token form yields exactly the rejected mask-less shape).
+  it("never yields a server without a mask, for any argument shape", () => {
+    for (const line of [
+      "/lusers",
+      "/lusers *.azzurra.org",
+      "/lusers void.azzurra.chat",
+      "/lusers *.azzurra.org void.azzurra.chat",
+      "/lusers *.azzurra.org void.azzurra.chat junk",
+      "/lusers    *.azzurra.org   void.azzurra.chat  ",
+    ]) {
+      const cmd = parseSlash(line);
+      expect(cmd.kind).toBe("lusers");
+      if (cmd.kind !== "lusers") continue;
+      if (cmd.server !== null) expect(cmd.mask).not.toBeNull();
+    }
   });
 });
 

--- a/cicchetto/src/__tests__/socket.test.ts
+++ b/cicchetto/src/__tests__/socket.test.ts
@@ -475,6 +475,62 @@ describe("pushAwaySet / pushAwayUnset (S3.4 — /away channel push)", () => {
   });
 });
 
+// #579 — /lusers [<mask> [<server>]]. The two RFC 2812 §3.4.2 args were
+// dropped client-side, so a filtered request silently answered network-wide.
+// These assert the WIRE PAYLOAD, not that a function was called: a null arg
+// must OMIT its key (pushMotd/pushLinks' shape — grappa's
+// `validate_lusers_args/2` clauses match on absent, and an unfiltered LUSERS
+// is what a bare form must still produce), a present one must carry its value.
+describe("pushLusers (#579 — mask + target server on the wire)", () => {
+  const okReply = (): void => {
+    const okCb = h.mockPush.receive.mock.calls.find(([ev]) => ev === "ok")?.[1] as () => void;
+    okCb();
+  };
+
+  it("bare /lusers sends network_id only — no mask, no server key", async () => {
+    localStorage.setItem("grappa-token", "tok-1");
+    const socket = await import("../lib/socket");
+    socket.joinUser("alice");
+
+    const promise = socket.pushLusers(7, null, null);
+    okReply();
+    await promise;
+
+    expect(h.mockChannel.push).toHaveBeenCalledWith("lusers", { network_id: 7 });
+  });
+
+  it("/lusers <mask> carries the mask and still omits server", async () => {
+    localStorage.setItem("grappa-token", "tok-1");
+    const socket = await import("../lib/socket");
+    socket.joinUser("alice");
+
+    const promise = socket.pushLusers(7, "*.azzurra.org", null);
+    okReply();
+    await promise;
+
+    expect(h.mockChannel.push).toHaveBeenCalledWith("lusers", {
+      network_id: 7,
+      mask: "*.azzurra.org",
+    });
+  });
+
+  it("/lusers <mask> <server> carries both", async () => {
+    localStorage.setItem("grappa-token", "tok-1");
+    const socket = await import("../lib/socket");
+    socket.joinUser("alice");
+
+    const promise = socket.pushLusers(7, "*.azzurra.org", "void.azzurra.chat");
+    okReply();
+    await promise;
+
+    expect(h.mockChannel.push).toHaveBeenCalledWith("lusers", {
+      network_id: 7,
+      mask: "*.azzurra.org",
+      server: "void.azzurra.chat",
+    });
+  });
+});
+
 // S21 (codebase review 2026-07-08) — /topic -delete was fire-and-forget:
 // `pushChannelTopicClear` returned void with no `.receive` chain, so a
 // server {:error,_} or a WS-down was swallowed. It now shares the

--- a/cicchetto/src/__tests__/socket.test.ts
+++ b/cicchetto/src/__tests__/socket.test.ts
@@ -476,11 +476,11 @@ describe("pushAwaySet / pushAwayUnset (S3.4 — /away channel push)", () => {
 });
 
 // #579 — /lusers [<mask> [<server>]]. The two RFC 2812 §3.4.2 args were
-// dropped client-side, so a filtered request silently answered network-wide.
-// These assert the WIRE PAYLOAD, not that a function was called: a null arg
-// must OMIT its key (pushMotd/pushLinks' shape — grappa's
-// `validate_lusers_args/2` clauses match on absent, and an unfiltered LUSERS
-// is what a bare form must still produce), a present one must carry its value.
+// dropped client-side, so the routed two-token form could not be issued at
+// all. These assert the WIRE PAYLOAD, not that a function was called: a null
+// arg must OMIT its key (pushMotd/pushLinks' shape — grappa's
+// `validate_lusers_args/2` clauses match on absent, and a bare LUSERS is what
+// the bare form must still produce), a present one must carry its value.
 describe("pushLusers (#579 — mask + target server on the wire)", () => {
   const okReply = (): void => {
     const okCb = h.mockPush.receive.mock.calls.find(([ev]) => ev === "ok")?.[1] as () => void;

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -1515,7 +1515,8 @@ const exports_ = identityScopedStore((onIdentityChange) => {
         // typed `:lusers_bundle` wire event in userTopic.ts and renders
         // the LusersCard pinned at the top of the current window (#231).
         // #579 — the mask + target server ride along (they were dropped at
-        // the parser, so a filtered request silently answered network-wide).
+        // the parser, so a routed request silently answered from the local
+        // server and any mask never reached the wire at all).
         case "lusers": {
           const networkId = networkIdBySlug(networkSlug);
           if (networkId === undefined) return { error: "/lusers: network not found" };

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -1510,10 +1510,12 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           result = { ok: true };
           break;
         }
-        // P-0d — /lusers. Bare verb, no args. Pushes on user-level channel;
+        // P-0d — /lusers [<mask> [<server>]]. Pushes on user-level channel;
         // server emits the 7-numeric LUSERS bundle. cic dispatches the
         // typed `:lusers_bundle` wire event in userTopic.ts and renders
         // the LusersCard pinned at the top of the current window (#231).
+        // #579 — the mask + target server ride along (they were dropped at
+        // the parser, so a filtered request silently answered network-wide).
         case "lusers": {
           const networkId = networkIdBySlug(networkSlug);
           if (networkId === undefined) return { error: "/lusers: network not found" };
@@ -1523,7 +1525,7 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           // auto-emit), so an operator /lusers that skipped this mark
           // would show nothing.
           markLusersRequested(networkSlug);
-          await pushLusers(networkId); // S6 (#364): await verb-ack
+          await pushLusers(networkId, cmd.mask, cmd.server); // S6 (#364): await verb-ack
           result = { ok: true };
           break;
         }

--- a/cicchetto/src/lib/slashCommands.ts
+++ b/cicchetto/src/lib/slashCommands.ts
@@ -637,9 +637,14 @@ const DISPATCH: Readonly<Record<string, Handler>> = {
   },
 
   // #579 — /lusers [<mask> [<server>]] (RFC 2812 §3.4.2). Pre-#579 `rest` was
-  // dropped, so `/lusers *.azzurra.org` silently returned the UNFILTERED
-  // network-wide counts — the wrong answer with no error, the failure mode
+  // dropped, so a user's arguments vanished with no error — the failure mode
   // #374 closed for /motd. #571 already threads both tokens server-side.
+  // What the args buy on bahamut (azzurra/bahamut src/s_serv.c, read for
+  // #579): `m_lusers` routes via `hunt_server` only when BOTH tokens are
+  // present, and the answering server reports ITS OWN local counts — that
+  // two-token form is the one with a visible effect. `send_lusers` never
+  // match()es the mask, so a mask ALONE is accepted and ignored there (an
+  // RFC-honouring ircd is free to filter on it, hence we still send it).
   // Two-optional-token split, same shape as /stats' `query` + `target`.
   // ORDER NOTE: /whois's two-arg form is `<server> <nick>` (server FIRST,
   // RFC 2812 §3.6.2) — LUSERS is the other way round, mask FIRST. Reading the

--- a/cicchetto/src/lib/slashCommands.ts
+++ b/cicchetto/src/lib/slashCommands.ts
@@ -159,7 +159,11 @@ export type SlashCommand =
   // optional first token is the network slug (bare → the active window's
   // network, resolved in compose.ts). Same optional-arg grammar as /links.
   | { kind: "recover"; network: string | null }
-  | { kind: "lusers" }
+  // #579 — /lusers [<mask> [<server>]] (RFC 2812 §3.4.2). Both optional and
+  // POSITIONAL: `server` can never be present without `mask`, which is how the
+  // client mirrors the server's `:invalid_line` rejection of that shape — the
+  // illegal state is unconstructible here rather than built-then-refused.
+  | { kind: "lusers"; mask: string | null; server: string | null }
   | { kind: "info" }
   | { kind: "version" }
   | { kind: "motd"; target: string | null }
@@ -632,11 +636,23 @@ const DISPATCH: Readonly<Record<string, Handler>> = {
     return { kind: "recover", network: network ?? null };
   },
 
-  lusers: (_verb, _rest) => ({ kind: "lusers" }),
+  // #579 — /lusers [<mask> [<server>]] (RFC 2812 §3.4.2). Pre-#579 `rest` was
+  // dropped, so `/lusers *.azzurra.org` silently returned the UNFILTERED
+  // network-wide counts — the wrong answer with no error, the failure mode
+  // #374 closed for /motd. #571 already threads both tokens server-side.
+  // Two-optional-token split, same shape as /stats' `query` + `target`.
+  // ORDER NOTE: /whois's two-arg form is `<server> <nick>` (server FIRST,
+  // RFC 2812 §3.6.2) — LUSERS is the other way round, mask FIRST. Reading the
+  // first token as a server would produce the one shape the server rejects as
+  // `:invalid_line`; the invariant test pins the order.
+  // Tokens past the second are ignored (LUSERS is a 2-slot wire frame).
+  lusers: (_verb, rest) => {
+    const [mask, server] = tokens(rest);
+    return { kind: "lusers", mask: mask ?? null, server: server ?? null };
+  },
 
   // #127 — /info, /version. No-arg server-text queries; the reply renders
-  // in a dismissable retro modal (ServerReplyModal). Mirror the /lusers
-  // no-arg shape.
+  // in a dismissable retro modal (ServerReplyModal).
   info: (_verb, _rest) => ({ kind: "info" }),
   version: (_verb, _rest) => ({ kind: "version" }),
   // #374 — /motd [<target>] (RFC 2812 §3.4.1). Bare = current server's

--- a/cicchetto/src/lib/socket.ts
+++ b/cicchetto/src/lib/socket.ts
@@ -712,13 +712,26 @@ export function pushWho(networkId: number, channel: string): Promise<void> {
   return pushUserChannelVerb("who", { network_id: networkId, channel });
 }
 
-// P-0d — /lusers → LUSERS upstream — bare verb, no args. Pushes on
+// P-0d — /lusers [<mask> [<server>]] → LUSERS upstream. Pushes on
 // the user-level channel; server emits the 7-numeric bundle which
 // EventRouter folds and 266 RPL_GLOBALUSERS flushes into a typed
 // :lusers_bundle wire event on Topic.user/1. cic dispatches in
 // userTopic.ts and renders the LusersCard in the current window (#231).
-export function pushLusers(networkId: number): Promise<void> {
-  return pushUserChannelVerb("lusers", { network_id: networkId });
+// #579 — both RFC 2812 §3.4.2 args thread through; a null one OMITS its
+// wire key (pushMotd/pushLinks' optional-arg shape) so grappa's
+// `validate_lusers_args/2` sees the same absent-arg shape a pre-#579
+// client sends. `server` needs `mask`: the parser cannot produce one
+// without the other, and grappa refuses that shape as `:invalid_line`.
+export function pushLusers(
+  networkId: number,
+  mask: string | null,
+  server: string | null,
+): Promise<void> {
+  return pushUserChannelVerb("lusers", {
+    network_id: networkId,
+    ...(mask === null ? {} : { mask }),
+    ...(server === null ? {} : { server }),
+  });
 }
 
 // #127 — /info, /version, /motd. Push on the user-level channel; server


### PR DESCRIPTION
Refs #579. Client-only; the server has accepted the full RFC 2812 §3.4.2
shape since #571.

## What

`lusers: (_verb, _rest) => ({ kind: "lusers" })` discarded `rest`, so a
user's arguments never reached the wire. The parsed type is now
`{ kind: "lusers"; mask: string | null; server: string | null }`, split
positionally like `/stats`' `query` + `target`, and both tokens thread
through `pushLusers` to the existing `lusers` verb.

Naming follows the server's `server` (not `target`), per the issue.

## `server` without `mask`

That is the shape `validate_lusers_args/2` rejects as `:invalid_line`. A
positional parse cannot BUILD it, so there is no reachable input for a
client-side rejection to refuse — the mirror is an unconstructible state
rather than a runtime guard, and the guard would be dead code.

An invariant test pins the property instead, and it is not vacuous:
`/whois`'s two-arg form is `<server> <nick>` (server FIRST), so copying
that order here would make the one-token form yield exactly the mask-less
shape the server refuses. Measured — the test fails against that mutation.

## What the args actually do on bahamut

Read `azzurra/bahamut` `src/s_serv.c` while writing this: `m_lusers` calls
`hunt_server` only when BOTH tokens are present, and the answering server
reports its own local counts — the two-token routed form is the one with a
visible effect. `send_lusers` never `match()`es the mask, so a mask alone
is accepted and ignored there; its forced cache-bypass wants oper AND a
fourth parameter, which grappa's 2-slot path cannot produce. We still send
the mask: an RFC-honouring ircd may filter on it, and dropping user input
is the bug. The third commit corrects the earlier comments accordingly.

## Wire

Additive: the `lusers` verb is unchanged and a null arg omits its key
(pushMotd/pushLinks' shape), so a bare `/lusers` sends byte-identical
params to a pre-#579 client. No `protocol_version` bump.

## Gates

- `bun run check` (biome + tsc) — exit 0.
- `bun run test` — 244 files / 4538 tests, exit 0.
- Mutation-measured: the payload tests fail against a `pushLusers` that
  ignores its new args; the parser invariant fails against the `/whois`
  argument order.

## Not verified

No e2e. Per the source above, the single-token form is NOT observable on
bahamut by construction. The two-token form would be — the e2e testnet is
a real mesh (hub + leaf-v4 + leaf-v6) and `/lusers * hub.azzurra.chat`
should return the hub's local counts rather than leaf4's — but I could not
run the e2e lane in this pass, and I am not shipping a spec I never
executed. Flagged for the orchestrator rather than guessed at.