### PR TITLE
cic(#997): put the far-behind dismiss where the thumb is

### DIFF
--- a/cicchetto/e2e/tests/issue997-far-behind-thumb-reach.spec.ts
+++ b/cicchetto/e2e/tests/issue997-far-behind-thumb-reach.spec.ts
@@ -1,0 +1,165 @@
+// #997 — the far-behind dismiss was out of thumb reach.
+//
+// Reported from IRC. An operator sat at the tail of a channel under a frozen
+// `(199)` badge and could not make it fall. The diagnosis was the intended
+// one — the window is far behind, so #693 freezes the read cursor on purpose
+// and #888 marks the badge as a DISTANCE rather than a counter — but the
+// dismiss is the only gesture that unfreezes that cursor, and it lived pinned
+// to the TOP edge of the pane. They never looked up, so for the whole session
+// the badge read as a broken counter.
+//
+// The bar keeps the label; the gesture now also sits in the #280 float stack
+// at the lower right, where the thumb and the attention already are. This
+// spec pins the OUTCOME the operator could not reach: with the window far
+// behind, a tap on the corner affordance drops the badge.
+//
+// Three things are measured here rather than asserted by class name:
+//   * the control's box is at least 44×44 CSS px (the tap floor; the root
+//     font-size is 14px, so a rem-based target silently comes out short),
+//   * its centre sits in the lower-right quadrant of the scrollback pane —
+//     the placement claim itself, and the thing that was wrong,
+//   * the badge is gone afterwards, i.e. the cursor actually unfroze. A
+//     corner control that merely navigated would satisfy the first two and
+//     leave the operator exactly where they were.
+//
+// Against the unfixed client the corner control does not exist at all, so
+// the spec is RED at the locator.
+//
+// Seeding mirrors `issue947-unread-divider-count.spec.ts` (itself mirroring
+// the #693 spec): the shared seeder plants 200 rows in #bofh and this needs
+// unread > 200, so it re-seeds via the admin `resetSubject(baselineSeed)`
+// surface. The wrapped `test` fixture's afterEach truncates #bofh back to the
+// baseline; `restoreReadCursorToTail` in afterAll undoes the early cursor
+// (BUGHUNT-3 cascade rule — a spec that leaves a mid-list cursor behind makes
+// every downstream spec open its pane at a divider instead of at the tail).
+//
+// Desktop viewport on purpose. The mobile stack renders this control LARGER
+// (3.5rem / 48px floor, matching its siblings), so measuring the desktop box
+// measures the worst case of the tap floor, and the sidebar badge is the
+// clearer read of "the badge fell".
+
+import { expect, test } from "../fixtures/test";
+import { loginAs, selectChannel, sidebarMessageBadge } from "../fixtures/cicchettoPage";
+import {
+  fetchAllMessagesAsc,
+  resetSubject,
+  restoreReadCursorToTail,
+  setReadCursorToId,
+} from "../fixtures/grappaApi";
+import {
+  AUTOJOIN_CHANNELS,
+  getSeededAdmin,
+  getSeededVjt,
+  NETWORK_SLUG,
+  VJT_USER,
+} from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Larger than the 200-row server cap, so a cursor planted early leaves a gap
+// the resume cannot drain in one page — the far-behind precondition.
+const LARGE_SEED_COUNT = 260;
+const SEED_SENDER = "seed-bot";
+
+// The server's `@max_http_limit` and the client's `PAGE_LIMIT`. A gap above
+// this is what "far behind" means.
+const MAX_HTTP_LIMIT = 200;
+
+// Rows left after the planted cursor — above the cap, so the pane anchors at
+// the tail and freezes.
+const UNREAD_TARGET = 240;
+
+// Apple HIG, in ABSOLUTE px. Not `2.75rem`: the root font-size is 14px here
+// and user-configurable down to 12px, so a rem target renders 38.5px / 33px.
+const TAP_FLOOR_PX = 44;
+
+const countIn = (label: string, what: string): number => {
+  const match = label.match(/(\d+)/);
+  if (!match?.[1]) {
+    throw new Error(`#997 spec: ${what} carries no count: ${JSON.stringify(label)}`);
+  }
+  return Number(match[1]);
+};
+
+test.describe("#997 — the far-behind dismiss is in thumb reach", () => {
+  test.use({ viewport: { width: 800, height: 400 } });
+
+  test.afterAll(async () => {
+    if (!CHANNEL) return;
+    const vjt = getSeededVjt();
+    await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
+  });
+
+  test("tapping the corner affordance drops the frozen badge", async ({ page }) => {
+    if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+    const vjt = getSeededVjt();
+    const admin = getSeededAdmin();
+
+    await resetSubject(
+      admin.token,
+      VJT_USER,
+      { [NETWORK_SLUG]: AUTOJOIN_CHANNELS },
+      { [NETWORK_SLUG]: [{ name: CHANNEL, seedCount: LARGE_SEED_COUNT, seedSender: SEED_SENDER }] },
+    );
+
+    const rows = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, CHANNEL);
+    expect(rows.length).toBeGreaterThan(UNREAD_TARGET);
+
+    const lastReadRow = rows[rows.length - UNREAD_TARGET];
+    if (!lastReadRow) throw new Error("#997 spec: seeded #bofh rows missing cursor index");
+    const rowsAfterCursor = rows.filter((r) => r.id > lastReadRow.id).length;
+    // Guard the precondition: below this the pane never goes far behind and
+    // the spec would pass by testing nothing.
+    expect(rowsAfterCursor).toBeGreaterThan(MAX_HTTP_LIMIT);
+
+    // Plant the cursor BEFORE login so the channel hydrates with it and takes
+    // the cursor-present fetch arm.
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, lastReadRow.id);
+
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, CHANNEL);
+
+    // The bar renders only once the resume has probed the count and decided
+    // the gap is undrainable — the readiness signal for the far-behind arm.
+    const bar = page.locator('[data-testid="far-behind-bar"]');
+    await expect(bar).toBeAttached({ timeout: 10_000 });
+    const advertised = countIn(
+      await page.locator('[data-testid="far-behind-jump"]').innerText(),
+      "the jump-back bar",
+    );
+    expect(advertised).toBeGreaterThan(MAX_HTTP_LIMIT);
+
+    // The state the operator was stuck in: a badge carrying the #888
+    // far-behind treatment, frozen, with no amount of reading able to move it.
+    const badge = sidebarMessageBadge(page, NETWORK_SLUG, CHANNEL);
+    await expect(badge).toBeVisible({ timeout: 10_000 });
+    await expect(badge).toHaveClass(/far-behind/);
+
+    const corner = page.locator('[data-testid="far-behind-float-dismiss"]');
+    await expect(corner).toBeVisible();
+
+    // MEASURED, not asserted on the class name. A rem-sized target passes a
+    // class-name check and still comes out at 38.5px under the 14px root.
+    const box = await corner.boundingBox();
+    if (!box) throw new Error("#997 spec: the corner affordance has no layout box");
+    expect(box.width).toBeGreaterThanOrEqual(TAP_FLOOR_PX);
+    expect(box.height).toBeGreaterThanOrEqual(TAP_FLOOR_PX);
+
+    // The placement claim. The defect was not "the control is missing", it was
+    // "the control is at the top edge and nobody looks there": pin the corner
+    // it now has to be in, relative to the pane it is anchored to.
+    const paneBox = await page.locator(".scrollback-pane").boundingBox();
+    if (!paneBox) throw new Error("#997 spec: the scrollback pane has no layout box");
+    expect(box.x + box.width / 2).toBeGreaterThan(paneBox.x + paneBox.width / 2);
+    expect(box.y + box.height / 2).toBeGreaterThan(paneBox.y + paneBox.height / 2);
+
+    await corner.click();
+
+    // THE outcome. The cursor unfroze, so the badge fell — the thing the
+    // operator could not achieve. Both halves matter: a corner control that
+    // only scrolled would clear neither.
+    await expect(badge).toHaveCount(0, { timeout: 10_000 });
+    await expect(bar).toHaveCount(0);
+    await expect(corner).toHaveCount(0);
+  });
+});

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -3455,6 +3455,29 @@ const ScrollbackPane: Component<Props> = (props) => {
   // re-anchor. `defer` skips the mount run; a no-op when no animation runs.
   createEffect(on(key, () => interruptSmoothScroll(), { defer: true }));
 
+  // #693 dismiss — ONE gesture, two surfaces (#997). The bar's × and the
+  // corner affordance in the #280 float stack both call this; neither owns a
+  // handler of its own. The state this writes is the whole point of the
+  // second surface: the dismiss is the ONLY thing that unfreezes the read
+  // cursor, so a corner control that merely scrolled or jumped would leave
+  // the frozen badge exactly as stuck as the operator found it — reachable
+  // and useless is worse than unreachable. Two handlers writing "the same"
+  // state is the #975 twin-structure bug waiting to happen; one owner, one
+  // state, and a drift is a syntax error rather than a UX report.
+  const dismissFarBehindGesture = () => {
+    // Re-latch the frozen divider to whatever was marked read. Dismiss is an
+    // explicit "I've read to here" gesture — the same class as the
+    // send-relatch — so it is one of the few things allowed to move the
+    // freeze mid-session.
+    const readTo = dismissFarBehind(props.networkSlug, props.channelName);
+    if (readTo !== null) setMarkerCursorId(readTo);
+  };
+
+  // Both surfaces speak the same sentence, from one string: the corner glyph
+  // has no visible text at all, so its label is the only thing that says
+  // which state it clears.
+  const dismissFarBehindLabel = "Dismiss — mark everything up to here as read";
+
   return (
     <div class="scrollback-pane">
       {/* #133 — top-pinned overlay layer. WHOIS / WHOWAS / LUSERS are
@@ -3536,15 +3559,8 @@ const ScrollbackPane: Component<Props> = (props) => {
               type="button"
               class="scrollback-far-behind-dismiss"
               data-testid="far-behind-dismiss"
-              aria-label="Dismiss — mark everything up to here as read"
-              onClick={() => {
-                // Re-latch the frozen divider to whatever was marked read.
-                // Dismiss is an explicit "I've read to here" gesture — the
-                // same class as the send-relatch — so it is one of the few
-                // things allowed to move the freeze mid-session.
-                const readTo = dismissFarBehind(props.networkSlug, props.channelName);
-                if (readTo !== null) setMarkerCursorId(readTo);
-              }}
+              aria-label={dismissFarBehindLabel}
+              onClick={dismissFarBehindGesture}
             >
               ×
             </button>
@@ -3692,6 +3708,34 @@ const ScrollbackPane: Component<Props> = (props) => {
           one mobile next-active ever mounts. scroll-to-bottom still shows
           only when NOT at the bottom (C7.4). */}
       <div class="scrollback-float-stack">
+        {/* #997 — the far-behind dismiss, in thumb reach. The bar above stays
+            as the STATUS LABEL ("you are N behind"); the gesture that acts on
+            that state also lives here, where the operator's thumb and
+            attention already are. Reported from IRC: a frozen (199) badge read
+            as a broken counter for as long as the only way out sat pinned to
+            the top edge, unlooked-at.
+            Shares `dismissFarBehindGesture` with the bar's × — see there for
+            why a second surface is only defensible when it writes the same
+            state. The JUMP deliberately does NOT get a twin here: it goes
+            BACKWARDS into the abandoned region and does not unfreeze the
+            cursor, so a corner copy of it would be the "reachable control
+            that leaves the badge frozen" this change exists to remove — and
+            a backwards jump one gap above the forwards scroll-to-bottom is
+            the collision #280 anchored this stack to avoid.
+            Rendered FIRST so it stacks ABOVE the existing pair: scroll-to-
+            bottom keeps the corner position its muscle memory owns, and this
+            transient control never displaces it. */}
+        <Show when={farBehindByChannel()[key()]}>
+          <button
+            type="button"
+            class="far-behind-float-dismiss"
+            data-testid="far-behind-float-dismiss"
+            aria-label={dismissFarBehindLabel}
+            onClick={dismissFarBehindGesture}
+          >
+            ✓
+          </button>
+        </Show>
         <Show when={isMobile()}>
           <NextActiveButton variant="mobile" />
         </Show>

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -2128,6 +2128,84 @@ describe("ScrollbackPane", () => {
       });
     });
 
+    // #997 — the bar is pinned to the TOP edge, and the dismiss is the only
+    // gesture that unfreezes the cursor. An operator sitting at the tail never
+    // looked up: the frozen badge read as a broken counter for as long as they
+    // used the client. The label stays where it is; the gesture also lands in
+    // the #280 corner stack, where the thumb already is.
+    describe("far-behind dismiss in thumb reach (#997)", () => {
+      afterEach(() => {
+        setFarBehind({});
+        jumpToUnreadSpy.mockClear();
+        dismissFarBehindSpy.mockClear();
+      });
+
+      const renderFarBehindPane = () => {
+        seedReadCursor("freenode", "#grappa", 1);
+        setScrollback({ "freenode #grappa": fixture });
+        setFarBehind({ "freenode #grappa": { missed: 3000, resumeFrom: 1 } });
+        render(() => (
+          <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+        ));
+      };
+
+      it("puts the affordance in the corner stack, not only in the top bar", () => {
+        renderFarBehindPane();
+        const corner = screen.getByTestId("far-behind-float-dismiss");
+        // Membership in the stack IS the reach fix: the stack is the
+        // container-anchored lower-right cluster (#280), and a control outside
+        // it inherits neither the anchor nor the pointer-events re-enable.
+        expect(corner.parentElement?.className).toContain("scrollback-float-stack");
+        expect(screen.getByTestId("far-behind-bar").contains(corner)).toBe(false);
+      });
+
+      it("shows nothing in the corner for an ordinary pane", () => {
+        seedReadCursor("freenode", "#grappa", 1);
+        setScrollback({ "freenode #grappa": fixture });
+        render(() => (
+          <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+        ));
+        expect(screen.queryByTestId("far-behind-float-dismiss")).toBeNull();
+      });
+
+      it("dismisses THIS window's far-behind state, the same verb the × fires", () => {
+        renderFarBehindPane();
+        screen.getByTestId("far-behind-float-dismiss").click();
+        expect(dismissFarBehindSpy).toHaveBeenCalledWith("freenode", "#grappa");
+        // A corner control that navigated instead would leave the cursor
+        // frozen — the badge would stay stuck with the way out now in reach
+        // and still useless, which is worse than the reported defect.
+        expect(jumpToUnreadSpy).not.toHaveBeenCalled();
+      });
+
+      it("re-latches the frozen divider, exactly as the × does", async () => {
+        // The second surface must write the WHOLE state, not the part that is
+        // easy to see. Dismissing without carrying the returned id back into
+        // the frozen marker un-suppresses the divider against a cursor
+        // snapshot thousands of rows old and slams "2 unread" across the top
+        // of the buffer — the two controls would then disagree about what a
+        // dismiss means.
+        renderFarBehindPane();
+        screen.getByTestId("far-behind-float-dismiss").click();
+        // The verb clears the flag server-side; mirror that here.
+        setFarBehind({});
+        await Promise.resolve();
+        expect(screen.queryByTestId("unread-marker")).toBeNull();
+      });
+
+      it("keeps the backwards jump on the bar — opposite directions survive", () => {
+        // jump-to-first-unread goes BACKWARDS, scroll-to-bottom FORWARDS. The
+        // corner gets the dismiss and ONLY the dismiss: a backwards jump one
+        // gap above the forwards scroll would be the collision #280 anchored
+        // this stack to prevent, and it would not unfreeze anything.
+        renderFarBehindPane();
+        expect(screen.getByTestId("far-behind-jump")).toBeInTheDocument();
+        expect(
+          screen.getByTestId("far-behind-bar").contains(screen.getByTestId("far-behind-jump")),
+        ).toBe(true);
+      });
+    });
+
     // #947 — the notch after #693. The operator took the jump, so the flag is
     // gone and the divider is back; but the jump could only carry ONE page of
     // the gap, so counting the loaded rows reports the page size. The number

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2927,6 +2927,59 @@ html.resize-dragging * {
   opacity: 0.5;
 }
 
+/* #997 — the far-behind dismiss, in the float stack. The bar at the top edge
+   keeps the LABEL; this is the gesture, in the corner the thumb already
+   reaches. Palette is the BAR's (`--bg` fill, `--accent` glyph + hairline),
+   not the accent-filled scroll-to-bottom circle: it reads as the far-behind
+   thing rather than a second scroll control, which is the whole distinction
+   the two directions turn on.
+
+   44px floor in ABSOLUTE px, like both bar buttons — the root font-size is
+   14px, so a rem target comes out short on mobile. Desktop therefore renders
+   this LARGER than its 2rem sibling; the tap floor is a physical constraint
+   and wins over the visual match. */
+.far-behind-float-dismiss {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  border-radius: 50%;
+  background: var(--bg);
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  font-family: var(--font-mono);
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+/* Opaque, against the #289/#302 translucency its stack siblings carry. Those
+   are PERMANENT chrome, so letting the text behind them show through was the
+   right trade; this appears only while the window is far behind, and it is
+   the only gesture that unfreezes the read cursor. The far-behind surface
+   paints opaquely over the rows it covers — the bar does it at the top edge
+   for the same reason — so the one control that must not be misread does not
+   inherit a translucency tuned for buttons that are always there. Child
+   selector so the override reads as deliberate rather than as a specificity
+   accident. */
+.shell-mobile .scrollback-float-stack > .far-behind-float-dismiss {
+  opacity: 1;
+}
+
+/* Mobile — match the 3.5rem box its stack siblings take (#280 req 4) so the
+   column stays one consistent set of controls; the 48px floor mirrors
+   `.shell-mobile .scroll-to-bottom-btn`. */
+.shell-mobile .far-behind-float-dismiss {
+  width: 3.5rem;
+  height: 3.5rem;
+  min-width: 48px;
+  min-height: 48px;
+  font-size: 1.75rem;
+}
+
 /* C7.4: Scroll-to-bottom button. An in-flow child of the float stack (#280)
    — the stack owns the absolute anchor for POSITIONING; this is `position:
    relative` only so the #360 mention-count badge can anchor to its corner

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -32324,3 +32324,55 @@ write can witness a newline that got in.
 that eats nicks, channels and `/commands` that default is wrong on its own
 merits and is now `off`. It was the falsified hypothesis' subject, and it must
 not be read as the mechanism — it changes nothing about which keystrokes send.
+## 2026-08-07 — the far-behind label stays up top; the gesture moves to the thumb (#997)
+
+An operator on IRC sat under a frozen `(199)` badge and read it as a broken
+counter. Everything worked as designed: the window was far behind, so #693
+freezes the read cursor deliberately and #888 marks the badge as a DISTANCE
+rather than a count. But the dismiss is the ONLY gesture that unfreezes that
+cursor, and it lived pinned to the top edge of the pane. They were at the
+tail, and never looked up.
+
+**The original reasoning does not defend the top edge.** The comment above
+`.scrollback-far-behind` justifies pinning the bar OUT of the scroll flow: a
+far-behind pane has no divider to scroll to, so the activation routine parks
+it at the bottom and an in-flow boundary row would sit viewports above the
+fold — the one signal that a region was abandoned, where nobody looks. That
+argument is sound and it is an argument against an IN-FLOW marker. It says
+nothing in favour of the top specifically. The #280 float stack is also out
+of flow, also container-anchored, and is where the thumb already is.
+
+**Option 2 of the three the issue listed, chosen by vjt.** The bar stays as
+the status LABEL ("you are N behind" — a bare corner glyph cannot say that);
+the affordance also lands in the corner stack. Option 1 (move the pair down,
+lose the label) and option 3 (move the whole bar to the bottom edge, into the
+keyboard geometry #280 exists to survive and the #133 z-order) were not taken.
+
+**One owner, one state.** A second surface for the same state is only worth
+having if the two cannot disagree, so both controls call one
+`dismissFarBehindGesture` — the corner button has no handler of its own.
+Two handlers that agree today are the #975 twin-structure shape: they drift,
+and the drift here would be silent (dismissing without carrying the returned
+id back into the frozen marker un-suppresses the divider against a cursor
+snapshot thousands of rows old). Both mutations were measured against the
+unit specs: dropping the re-latch reds one test, calling `jumpToUnread`
+instead reds two.
+
+**The jump deliberately gets NO corner twin.** It goes BACKWARDS into the
+abandoned region and does not unfreeze anything, so a reachable copy of it
+would leave the badge exactly as stuck — a control in reach that does not
+work is worse than the reported defect, not better. And a backwards control
+one gap above the forwards scroll-to-bottom is precisely the two-affordances
+collision #280 anchored this stack to prevent. The two directions must stay
+distinguishable; they overlap only in placement.
+
+**The corner control is opaque, against its siblings.** `.shell-mobile
+.scrollback-float-stack > *` carries `opacity: 0.5` (#289/#302) because those
+buttons are PERMANENT chrome and the text behind them had to stay readable.
+This one appears only while the window is far behind, it is the only gesture
+that unfreezes the cursor, and the far-behind surface paints opaquely over
+the rows it covers by necessity — so it opts out, via a child selector so the
+override reads as deliberate rather than as a specificity accident. The 44px
+tap floor stays in ABSOLUTE px (root font-size is 14px; a rem target renders
+38.5px), which makes the desktop control larger than its 2rem sibling: the
+physical constraint wins over the visual match.


### PR DESCRIPTION
Refs #997.

An operator on IRC sat under a frozen `(199)` badge and read it as a broken
counter. Everything worked as designed — the window was far behind, so #693
freezes the read cursor on purpose and #888 marks the badge as a DISTANCE
rather than a count — but the dismiss is the ONLY gesture that unfreezes that
cursor, and it lived pinned to the top edge of the pane. They were at the tail
and never looked up.

The comment above `.scrollback-far-behind` justifies pinning the bar OUT of
the scroll flow, which is an argument against an in-flow marker; it says
nothing in favour of the top edge. The #280 float stack is also out of flow,
also container-anchored, and is where the thumb already is.

## Scope — option 2, as decided

The bar stays as the status LABEL ("you are N behind"); the affordance also
lands in the corner stack. The bar is not moved (option 3) and the label is
not dropped (option 1).

## The three constraints

- **One owner, one state.** Both controls call one `dismissFarBehindGesture`;
  the corner button has no handler of its own. Two handlers that agree today
  are the #975 twin-structure shape.
- **The jump gets NO corner twin.** It goes backwards and does not unfreeze
  anything, so a reachable copy would leave the badge exactly as stuck. A
  backwards control one gap above the forwards scroll-to-bottom is also the
  collision #280 anchored this stack to prevent.
- **44px tap floor in absolute px** (root font-size is 14px), which makes the
  desktop control larger than its 2rem sibling — the physical constraint wins
  over the visual match.
- **Opaque**, opting out of the `#289/#302` mobile translucency its stack
  siblings carry: those are permanent chrome, this appears only while the
  state does and is the only way out of it.

## What was measured

- `scripts/bun.sh run check` — exit 0 (biome + tsc).
- `scripts/bun.sh run test` — 4535 passed / 244 files, on the committed tree.
- `tsc -p e2e/tsconfig.json --noEmit` — the new spec contributes none of the
  26 pre-existing errors, and emitted no `.js`.
- **Mutation, both legs red.** Corner control dismissing without re-latching
  the frozen marker → 1 test red. Corner control calling `jumpToUnread`
  instead → 2 tests red. Reverted, green again.

## What is NOT measured

The e2e (`issue997-far-behind-thumb-reach.spec.ts`) has **never been run** —
no integration lane, and there is no local browser here. Its geometry
assertions (the 44px box, the lower-right quadrant) and the badge-falls
outcome are gated by this PR's CI, not by anything I observed.