### PR TITLE
cic(#985/#988): float the lone ☰, and measure #988 before patching it

### DIFF
--- a/cicchetto/e2e/tests/issue985-mobile-floating-opener.spec.ts
+++ b/cicchetto/e2e/tests/issue985-mobile-floating-opener.spec.ts
@@ -65,20 +65,33 @@ test("@webkit #985 — a mobile query window spends no band on the ☰, and the 
     // absent and every assertion below is green for the wrong reason.
     await expect(page.locator(".topic-bar")).toHaveCount(0);
     const chrome = page.getByTestId("shell-chrome");
-    await expect(chrome).toBeVisible({ timeout: 10_000 });
+    const opener = page.getByTestId("shell-chrome-rail-opener");
+    // The host is MOUNTED, not VISIBLE — and this spec is the reason. #985
+    // collapses `.shell-chrome` to `height: 0` and lets its one child overflow,
+    // so the element Playwright is asked about has an empty bounding box and is
+    // `hidden` by definition. Asserting it visible here contradicted this same
+    // test's own outcome assertion ("the chrome row must cost zero height")
+    // twenty lines down: both could never hold at once. What the precondition
+    // actually needs to establish is that the non-channel branch mounted its
+    // door — so: the host exists, and the door itself is on screen.
+    await expect(chrome).toHaveCount(1);
+    await expect(opener).toBeVisible({ timeout: 10_000 });
 
     const main = page.locator(".shell-main");
     const pane = page.locator(".scrollback-pane");
-    const opener = page.getByTestId("shell-chrome-rail-opener");
     await expect(pane).toBeVisible();
 
     const mainBox = await main.boundingBox();
     const paneBox = await pane.boundingBox();
-    const chromeBox = await chrome.boundingBox();
     const openerBox = await opener.boundingBox();
-    if (!mainBox || !paneBox || !chromeBox || !openerBox) {
+    if (!mainBox || !paneBox || !openerBox) {
       throw new Error("#985 — a measured element has no bounding box");
     }
+    // Read through the DOM, not through `boundingBox()`: the latter is defined
+    // to return null for an element Playwright considers invisible, and a
+    // zero-height box is exactly that — so the very property under test here
+    // would have come back as "no bounding box" and thrown above.
+    const chromeHeight = await chrome.evaluate((el) => el.getBoundingClientRect().height);
 
     // THE OUTCOME. The conversation starts at the top of the pane. This is the
     // pixel vjt asked for back, and it is the one number that was wrong before:
@@ -89,7 +102,7 @@ test("@webkit #985 — a mobile query window spends no band on the ☰, and the 
     ).toBeLessThanOrEqual(1);
     // The mechanism, measured rather than read: the row still exists (the
     // window needs its door) and costs nothing.
-    expect(chromeBox.height, "#985 — the chrome row must cost zero height").toBeLessThanOrEqual(1);
+    expect(chromeHeight, "#985 — the chrome row must cost zero height").toBeLessThanOrEqual(1);
 
     // The float must not have shrunk the affordance on its way out of the
     // flow: still the 48px HIG floor `--chrome-tap-min` guarantees.

--- a/cicchetto/e2e/tests/issue985-mobile-floating-opener.spec.ts
+++ b/cicchetto/e2e/tests/issue985-mobile-floating-opener.spec.ts
@@ -1,0 +1,137 @@
+// @webkit — #985. On a mobile QUERY window the ☰ must float over the pane's
+// top-right corner instead of sitting in a band that costs the conversation a
+// row.
+//
+// The defect vjt reported from the iPhone PWA: every non-channel window
+// rendered a full-width `.shell-chrome` header whose only content was the ☰,
+// priced at `var(--chrome-tap-min) + 1rem + 1px` and SCALING with the text
+// size. The mobile-CHANNEL branch had already reclaimed those pixels (its ☰
+// rides inline in the TopicBar); the query case never got a host.
+//
+// Why an e2e and not a vitest: the defect IS rendered geometry. jsdom has no
+// layout engine, so `.shell-chrome`'s source declarations are all a unit test
+// can see — pinned in `src/__tests__/shellChromeFloat.test.ts`. What only a
+// real engine can answer is whether the scrollback actually starts at the top
+// of the pane, whether the floated glyph is actually the element under the
+// finger, and whether it is actually opaque over the content behind it.
+//
+// Mobile-only shape (`ShellChrome` mounts only in Shell's `isMobile()` branch),
+// so this runs on webkit-iphone-15 alone — the @webkit tag; the chromium
+// project grepInverts it.
+//
+// NOT covered here, and not coverable here: the notch. Playwright does not
+// synthesize `env(safe-area-inset-*)` — they resolve to 0 in both projects — so
+// the "clears the Dynamic Island" half of the fix is argued from
+// `.shell-mobile`'s existing `padding-top: env(safe-area-inset-top)` (UX-3 BIS)
+// and needs a real notched device to be felt. Same standing limitation as
+// `railMenuSafeArea.test.ts`.
+//
+// Parity matrix per `feedback_e2e_user_class_parity_matrix`: this is a UI shape
+// contract, subject-shape-agnostic. The registered seed suffices.
+
+import {
+  composeSend,
+  loginAs,
+  selectChannel,
+  waitForQueryWindowReady,
+} from "../fixtures/cicchettoPage";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+// Per-run-unique: a literal nick collides with itself upstream on rapid reruns
+// (--repeat-each), the same rule every peer-driven spec here follows.
+const PEER = `F985${crypto.randomUUID().slice(0, 8)}`;
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+test.setTimeout(90_000);
+
+test("@webkit #985 — a mobile query window spends no band on the ☰, and the float stays legible and reachable", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  const peer = await IrcPeer.connect({ nick: PEER });
+  try {
+    // Share a channel so the peer is addressable, then open + focus the query.
+    await peer.join(CHANNEL);
+    await composeSend(page, `/q ${PEER}`);
+    await waitForQueryWindowReady(page, NETWORK_SLUG, PEER);
+
+    // PRECONDITION — we really are on the non-channel branch. Without this the
+    // whole test could pass on a CHANNEL window, where the band was already
+    // absent and every assertion below is green for the wrong reason.
+    await expect(page.locator(".topic-bar")).toHaveCount(0);
+    const chrome = page.getByTestId("shell-chrome");
+    await expect(chrome).toBeVisible({ timeout: 10_000 });
+
+    const main = page.locator(".shell-main");
+    const pane = page.locator(".scrollback-pane");
+    const opener = page.getByTestId("shell-chrome-rail-opener");
+    await expect(pane).toBeVisible();
+
+    const mainBox = await main.boundingBox();
+    const paneBox = await pane.boundingBox();
+    const chromeBox = await chrome.boundingBox();
+    const openerBox = await opener.boundingBox();
+    if (!mainBox || !paneBox || !chromeBox || !openerBox) {
+      throw new Error("#985 — a measured element has no bounding box");
+    }
+
+    // THE OUTCOME. The conversation starts at the top of the pane. This is the
+    // pixel vjt asked for back, and it is the one number that was wrong before:
+    // the pane used to begin a whole band below `.shell-main`'s top edge.
+    expect(
+      paneBox.y - mainBox.y,
+      `#985 — scrollback must start at the pane top; it starts ${paneBox.y - mainBox.y}px below it`,
+    ).toBeLessThanOrEqual(1);
+    // The mechanism, measured rather than read: the row still exists (the
+    // window needs its door) and costs nothing.
+    expect(chromeBox.height, "#985 — the chrome row must cost zero height").toBeLessThanOrEqual(1);
+
+    // The float must not have shrunk the affordance on its way out of the
+    // flow: still the 48px HIG floor `--chrome-tap-min` guarantees.
+    expect(Math.round(openerBox.height)).toBeGreaterThanOrEqual(48);
+    expect(Math.round(openerBox.width)).toBeGreaterThanOrEqual(48);
+
+    // …and it floats INSIDE the pane's top-right corner rather than escaping
+    // it. `.shell-mobile` owns the safe-area inset, so "inside the pane" is
+    // also what keeps the glyph clear of the island on a real device.
+    expect(openerBox.y).toBeGreaterThanOrEqual(mainBox.y - 0.5);
+    expect(openerBox.x + openerBox.width).toBeLessThanOrEqual(mainBox.x + mainBox.width + 0.5);
+    expect(openerBox.y).toBeLessThan(mainBox.y + mainBox.height / 2);
+
+    // LEGIBILITY (issue constraint 1). Floating puts the glyph over arbitrary
+    // scrollback text and over a themed background image, so a transparent
+    // button — which is what `.shell-chrome-btn` declares — would leave it
+    // unreadable. Assert a FULLY opaque backing, not merely a non-empty one.
+    const bg = await opener.evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(bg, "#985 — the floated opener must carry its own backing").not.toBe(
+      "rgba(0, 0, 0, 0)",
+    );
+    const alpha = /rgba?\([^)]*?(?:,\s*([\d.]+))?\)$/.exec(bg)?.[1];
+    expect(alpha === undefined || Number(alpha) === 1).toBe(true);
+
+    // REACHABILITY (issue constraint 2, and the reason the rule carries a
+    // z-index at all). The opener overflows a zero-height box, so the
+    // later-in-DOM scrollback would paint over it without one. Hit-test the
+    // centre of the glyph: the element under the finger must BE the opener,
+    // not a scrollback line that happens to sit beneath it.
+    const hit = await opener.evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      const top = document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2);
+      return top === el || el.contains(top);
+    });
+    expect(hit, "#985 — the scrollback must not paint over the floated opener").toBe(true);
+
+    // ONE DRAWER, ONE ☰ (the Opt-A ruling). The float must still be the same
+    // door, driving the same `toggleMembersPanel` mutex — a second affordance
+    // opening a second state is the bug this must not become.
+    await opener.tap();
+    await expect(page.locator(".shell-members.open")).toBeVisible({ timeout: 5_000 });
+  } finally {
+    await peer.disconnect("i985 cleanup").catch(() => {});
+  }
+});

--- a/cicchetto/e2e/tests/issue985-mobile-floating-opener.spec.ts
+++ b/cicchetto/e2e/tests/issue985-mobile-floating-opener.spec.ts
@@ -124,8 +124,25 @@ test("@webkit #985 — a mobile query window spends no band on the ☰, and the 
     expect(bg, "#985 — the floated opener must carry its own backing").not.toBe(
       "rgba(0, 0, 0, 0)",
     );
-    const alpha = /rgba?\([^)]*?(?:,\s*([\d.]+))?\)$/.exec(bg)?.[1];
-    expect(alpha === undefined || Number(alpha) === 1).toBe(true);
+    // Alpha lives ONLY in the four-component form. CSSOM serialises an opaque
+    // colour as `rgb(r, g, b)` whatever the theme (`#fff` in light, `#0a0a0a`
+    // in dark), so it is the component COUNT that carries opacity and the
+    // check is theme-independent — it never names a colour. Count the
+    // channels; do NOT scrape with an optional lazy capture, which is what the
+    // first version of this line did: `[^)]*?` stopped early and handed the
+    // BLUE channel of `rgb(255, 255, 255)` to the alpha group, failing a
+    // perfectly opaque backing. An unrecognised serialisation throws rather
+    // than passing — the old `alpha === undefined` arm silently accepted
+    // anything that wasn't `rgb()`/`rgba()`.
+    const channels = /^rgba?\(([^)]*)\)$/.exec(bg)?.[1].split(",");
+    if (!channels || (channels.length !== 3 && channels.length !== 4)) {
+      throw new Error(`#985 — unparseable computed backgroundColor: ${bg}`);
+    }
+    const alpha = channels.length === 4 ? Number(channels[3]) : 1;
+    expect(
+      alpha,
+      `#985 — the floated opener's backing must be fully opaque; computed ${bg}`,
+    ).toBe(1);
 
     // REACHABILITY (issue constraint 2, and the reason the rule carries a
     // z-index at all). The opener overflows a zero-height box, so the

--- a/cicchetto/e2e/tests/issue988-rail-menu-first-row.spec.ts
+++ b/cicchetto/e2e/tests/issue988-rail-menu-first-row.spec.ts
@@ -8,12 +8,36 @@
 // prompted it. So this spec is the discriminator BEFORE it is a guard — it
 // measures, prints what it measured, and only then asserts.
 //
+// THE DISCRIMINATOR HAS RUN. Its numbers, from webkit-iphone-15 (run
+// 31179452487), are what the rest of this header is now written against:
+//
+//   h=659  scrollTop 0  menuTop 140.25  firstRow 148.25  clientHeight 435 (fits)
+//   h=520  scrollTop 0  menuTop 9       firstRow 17      clientHeight 427 / 435
+//   h=430  scrollTop 0  menuTop 9       firstRow 17      clientHeight 337 / 435
+//   h=360  scrollTop 0  menuTop 9       firstRow 17      clientHeight 267 / 435
+//   XXL@360 scrollTop 0 menuTop 9       firstRow 20      clientHeight 252 / 457
+//
+// `home` was the first row, wholly inside the port, and the hit-test target at
+// every one of them. The premise of #988 — that the first row is out of reach —
+// did NOT reproduce.
+//
 // The two readings #988 offers, and what this spec does with them:
 //
-//   Reading 2 (a stray scroll offset hides `home`) is falsified here directly:
-//   `scrollTop` is read on every pass. A fresh `overflow-y: auto` container
-//   opens at 0 and nothing in RailActions scrolls it, so the expectation is 0
-//   — printed, not assumed.
+//   Reading 2 (a stray scroll offset hides `home`) is FALSIFIED BY MEASUREMENT,
+//   not by argument: `scrollTop` read 0 on all five passes above, including the
+//   three where the menu genuinely overflowed. A fresh `overflow-y: auto`
+//   container opens at 0 and nothing in RailActions scrolls it. Still read on
+//   every pass, because that is what keeps the falsification live.
+//
+//   What the first run DID surface was a constant gap between the menu's top
+//   and its first row: 8px at every viewport height, 11px at XXL. Not scroll —
+//   `scrollTop` was 0 — but the menu's OWN chrome: `padding: 0.5rem` over a
+//   `border: 1px`, and `rem` follows `--font-size` (`html, body { font-size:
+//   var(--font-size) }`), so 7+1 at the default 14px root and 10+1 at XXL's
+//   20px. Both numbers, to the pixel, from one cause. The assertion that
+//   tripped on it was comparing a content-box coordinate to a border-box one;
+//   it is corrected below, and the chrome is now MEASURED per pass so the
+//   attribution is the run's and not this comment's.
 //
 //   Reading 1 (re-anchor a tall menu to the top) does NOT get a code change in
 //   this branch, because the geometry says it cannot produce one. When the
@@ -25,6 +49,12 @@
 //   explicitly keeps `bottom: 100%` there. A re-anchor would be a no-op
 //   wearing the shape of a fix. What is worth having instead is this: the
 //   acceptance criterion, pinned, at the heights where the cap bites.
+//
+//   That argument was structure without magnitude when it was written, which
+//   is precisely how it could have been wrong. The sweep supplies the missing
+//   magnitude: at the three heights where the menu overflows, the first row is
+//   already at the top of the port and reachable. The no-op reading is now
+//   held up by measurement rather than by reasoning about rectangles.
 //
 // The cap (#588) and the safe-area subtraction (#913) are asserted as
 // preconditions rather than left implicit — they are the two things that make
@@ -66,6 +96,13 @@ type MenuGeometry = {
   scrollHeight: number;
   clientHeight: number;
   menuTop: number;
+  // The menu's OWN chrome above its content. `getBoundingClientRect().top` is
+  // the BORDER box; the first row starts at the CONTENT box. Measured rather
+  // than read off the stylesheet, so the attribution is the run's, not the
+  // author's.
+  borderTopWidth: number;
+  paddingTop: number;
+  rootFontSize: number;
   firstRowTop: number;
   firstRowBottom: number;
   firstRowLabel: string;
@@ -84,6 +121,7 @@ async function measureMenu(page: import("@playwright/test").Page): Promise<MenuG
     if (first === undefined) throw new Error("#988 — the menu has no rows");
     const menuRect = menu.getBoundingClientRect();
     const rowRect = first.getBoundingClientRect();
+    const menuStyle = getComputedStyle(menu);
     const hit = document.elementFromPoint(
       rowRect.x + rowRect.width / 2,
       rowRect.y + rowRect.height / 2,
@@ -93,6 +131,9 @@ async function measureMenu(page: import("@playwright/test").Page): Promise<MenuG
       scrollHeight: menu.scrollHeight,
       clientHeight: menu.clientHeight,
       menuTop: menuRect.top,
+      borderTopWidth: Number.parseFloat(menuStyle.borderTopWidth),
+      paddingTop: Number.parseFloat(menuStyle.paddingTop),
+      rootFontSize: Number.parseFloat(getComputedStyle(document.documentElement).fontSize),
       firstRowTop: rowRect.top,
       firstRowBottom: rowRect.bottom,
       firstRowLabel: first.textContent?.trim() ?? "",
@@ -116,14 +157,32 @@ function assertFirstRowVisible(g: MenuGeometry, label: string): void {
     g.firstRowTop,
     `${label} — the first row starts ${g.firstRowTop}px from the viewport top, i.e. off-screen`,
   ).toBeGreaterThanOrEqual(-0.5);
+  // The first row sits at the top of the CONTENT box, and the whole distance
+  // from the menu's border-box top down to it is accounted for by the menu's
+  // own chrome — nothing else. Written as an equality on the RESIDUAL, which
+  // is what makes it a guard rather than a tolerance: any offset that is not
+  // border + padding (a stray scroll, a hidden sibling, a margin on row one)
+  // shows up here as a non-zero number and fails, whichever direction it goes.
+  //
+  // The predicate this replaces compared `firstRowTop` against `menuTop`, i.e.
+  // a content-box coordinate against a BORDER-box one, and demanded they be
+  // within 1px. That is not a weaker or stronger version of the criterion —
+  // it is the wrong quantity: it can only hold on a menu with no border and no
+  // padding, and `.rail-actions-menu` has always had both (`padding: 0.5rem`,
+  // `border: 1px`). It failed at every height for that reason alone and no
+  // other, and the numbers say so exactly — see the header.
+  const chromeAbove = g.borderTopWidth + g.paddingTop;
   expect(
-    g.firstRowTop - g.menuTop,
-    `${label} — the first row is not at the top of the scroll port`,
-  ).toBeLessThanOrEqual(1);
+    Math.abs(g.firstRowTop - (g.menuTop + chromeAbove)),
+    `${label} — the first row is ${g.firstRowTop - g.menuTop}px below the menu's top, but the menu's own chrome above it is only ${chromeAbove}px (border ${g.borderTopWidth} + padding ${g.paddingTop}); the remainder is unexplained`,
+  ).toBeLessThanOrEqual(0.5);
+  // `clientHeight` spans the PADDING box, so the scroll port's bottom edge is
+  // measured from below the top border — the same border-vs-content slip as
+  // above, here masked by the 1px tolerance rather than caught by it.
   expect(
     g.firstRowBottom,
     `${label} — the first row is not WHOLLY visible inside the scroll port`,
-  ).toBeLessThanOrEqual(g.menuTop + g.clientHeight + 1);
+  ).toBeLessThanOrEqual(g.menuTop + g.borderTopWidth + g.clientHeight + 1);
 
   // Visible is not the same as reachable: `home` must also be the element
   // under the finger, not something painted over it.

--- a/cicchetto/e2e/tests/issue988-rail-menu-first-row.spec.ts
+++ b/cicchetto/e2e/tests/issue988-rail-menu-first-row.spec.ts
@@ -138,43 +138,82 @@ function assertFirstRowVisible(g: MenuGeometry, label: string): void {
   expect(g.spaceAboveVar, `${label} — the JS-measured cap was never published`).not.toBe("");
 }
 
+// The discriminator has to be READABLE from the run's log, not merely
+// computed. Two exits, deliberately:
+//
+//   * a NODE-side `console.log` (this is after the `page.evaluate` returns —
+//     a log inside the browser context would never leave it). Verified
+//     against the `list` reporter: stdout from a PASSING test is printed, so
+//     the numbers arrive even on the green run, which is the run whose
+//     numbers settle whether #988's premise was real at all.
+//   * a `testInfo.attach`, because attachments survive into the HTML report
+//     and are not interleaved with 200 other lines of suite output.
+//
+// Both are called ONCE with every reading, from a `finally` — not per
+// iteration before its own assertion. Logging inside the loop meant the first
+// height to fail swallowed every later height's numbers, which is exactly
+// when they are wanted.
+async function reportReadings(
+  testInfo: import("@playwright/test").TestInfo,
+  label: string,
+  readings: { height: number; g: MenuGeometry }[],
+): Promise<void> {
+  if (readings.length === 0) return;
+  for (const { height, g } of readings) console.log(`#988 ${label} h=${height} ${JSON.stringify(g)}`);
+  await testInfo.attach(`issue988-geometry-${label}`, {
+    body: JSON.stringify(readings, null, 2),
+    contentType: "application/json",
+  });
+}
+
 test.setTimeout(120_000);
 
 test("@webkit #988 — the actions menu opens with `home` visible at every viewport height", async ({
   page,
-}) => {
+}, testInfo) => {
   const vjt = getSeededVjt();
   await loginAs(page, vjt);
   // A channel window so the menu carries its widest row set (rooms + denoise
   // are selection-gated) — the tall menu #988 is about.
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
 
-  let sawOverflow = false;
-  for (const height of HEIGHTS) {
-    await page.setViewportSize({ width: WIDTH, height });
-    await openRailMenu(page);
-    const g = await measureMenu(page);
-    console.log(`#988 h=${height} ${JSON.stringify(g)}`);
-    assertFirstRowVisible(g, `#988 @${height}px`);
-    expect(g.firstRowLabel, "#988 — `home` must be the first row").toContain("home");
-    if (g.scrollHeight > g.clientHeight + 1) sawOverflow = true;
-    await page.keyboard.press("Escape");
-    await expect(page.locator(".rail-actions-menu")).toHaveCount(0, { timeout: 5_000 });
+  // MEASURE EVERY HEIGHT FIRST, assert afterwards. The two phases are split on
+  // purpose: this spec is a discriminator before it is a guard, and asserting
+  // inside the loop meant the first height to fail took the remaining heights'
+  // numbers down with it — losing the reading in the only run where it decides
+  // anything.
+  const readings: { height: number; g: MenuGeometry }[] = [];
+  try {
+    for (const height of HEIGHTS) {
+      await page.setViewportSize({ width: WIDTH, height });
+      await openRailMenu(page);
+      readings.push({ height, g: await measureMenu(page) });
+      await page.keyboard.press("Escape");
+      await expect(page.locator(".rail-actions-menu")).toHaveCount(0, { timeout: 5_000 });
+    }
+  } finally {
+    // Whatever was collected before a mid-loop throw still reaches the log.
+    await reportReadings(testInfo, "viewport-sweep", readings);
   }
 
-  // Without this the whole loop could pass on a menu that always fits, which
+  for (const { height, g } of readings) {
+    assertFirstRowVisible(g, `#988 @${height}px`);
+    expect(g.firstRowLabel, `#988 @${height}px — \`home\` must be the first row`).toContain("home");
+  }
+
+  // Without this the whole sweep could pass on a menu that always fits, which
   // asserts nothing about the case #988 is about. If it ever trips, the menu
   // stopped being able to overflow at 360px and the heights need revisiting —
   // not the assertion.
   expect(
-    sawOverflow,
+    readings.some(({ g }) => g.scrollHeight > g.clientHeight + 1),
     "#988 — no viewport in the set made the menu overflow; the capped case was never exercised",
   ).toBe(true);
 });
 
 test("@webkit #988 — `home` stays visible at XXL text with the viewport at its shortest", async ({
   page,
-}) => {
+}, testInfo) => {
   const vjt = getSeededVjt();
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
@@ -197,7 +236,9 @@ test("@webkit #988 — `home` stays visible at XXL text with the viewport at its
     await page.setViewportSize({ width: WIDTH, height: 360 });
     await openRailMenu(page);
     const g = await measureMenu(page);
-    console.log(`#988 XXL h=360 ${JSON.stringify(g)}`);
+    // Reported BEFORE the assertion, for the same reason the sweep defers its
+    // own: the XXL reading is wanted most on the run where it fails.
+    await reportReadings(testInfo, "xxl-360", [{ height: 360, g }]);
     assertFirstRowVisible(g, "#988 XXL @360px");
   } finally {
     // Reset, or every later spec in this browser inherits XXL — the

--- a/cicchetto/e2e/tests/issue988-rail-menu-first-row.spec.ts
+++ b/cicchetto/e2e/tests/issue988-rail-menu-first-row.spec.ts
@@ -1,0 +1,210 @@
+// @webkit — #988. The rail actions menu must open with its FIRST row visible,
+// without scrolling, at every viewport height and text size.
+//
+// #988 is a PREDICTION, not an observation: its own body says "A screenshot
+// was attempted and did not go through, so the geometry below is read off the
+// code, not off a picture", and it hands the implementer a discriminator to
+// settle on a device first. `home` getting three new siblings in #986 is what
+// prompted it. So this spec is the discriminator BEFORE it is a guard — it
+// measures, prints what it measured, and only then asserts.
+//
+// The two readings #988 offers, and what this spec does with them:
+//
+//   Reading 2 (a stray scroll offset hides `home`) is falsified here directly:
+//   `scrollTop` is read on every pass. A fresh `overflow-y: auto` container
+//   opens at 0 and nothing in RailActions scrolls it, so the expectation is 0
+//   — printed, not assumed.
+//
+//   Reading 1 (re-anchor a tall menu to the top) does NOT get a code change in
+//   this branch, because the geometry says it cannot produce one. When the
+//   content exceeds the cap, `max-height` is `spaceAbove - inset` and the box
+//   already runs from `inset + RAIL_MENU_TOP_GAP` down to the launcher — which
+//   is exactly the box a top-anchored menu with the same cap would occupy.
+//   Bottom-anchored-and-capped and top-anchored are the SAME rectangle in the
+//   only case that matters; they differ solely when the menu FITS, and #988
+//   explicitly keeps `bottom: 100%` there. A re-anchor would be a no-op
+//   wearing the shape of a fix. What is worth having instead is this: the
+//   acceptance criterion, pinned, at the heights where the cap bites.
+//
+// The cap (#588) and the safe-area subtraction (#913) are asserted as
+// preconditions rather than left implicit — they are the two things that make
+// the criterion hold, and #988 warns that a re-anchor must not lose either.
+//
+// Keyboard-up is APPROXIMATED by a short viewport. In the emulator
+// `visualViewport.height` follows the viewport, which is the input
+// `lib/viewportHeight.ts` publishes as `--viewport-height` and the input
+// `spaceAbove` measures against — so the arithmetic under test sees the same
+// numbers a keyboard would produce. What it does NOT reproduce is iOS keeping
+// `env(safe-area-inset-top)` at its device value while the visual viewport
+// shrinks: Playwright synthesizes no insets at all, in either project, so
+// every `--safe-area-inset-top` here is 0px. The notch half needs a real
+// device.
+//
+// Mobile-only surface, so webkit-iphone-15 alone — the @webkit tag; the
+// chromium project grepInverts it.
+
+import {
+  closeSettings,
+  loginAs,
+  openRailMenu,
+  openSettingsSection,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+const WIDTH = 393;
+
+// iPhone 15 portrait, then three progressively shorter shells. 360 is where
+// the cap bites hardest — below the point the menu's content can fit — and it
+// is the pass that carries the "did the overflow case even happen?" guard.
+const HEIGHTS = [659, 520, 430, 360];
+
+type MenuGeometry = {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+  menuTop: number;
+  firstRowTop: number;
+  firstRowBottom: number;
+  firstRowLabel: string;
+  rows: number;
+  spaceAboveVar: string;
+  insetVar: string;
+  firstRowIsHitTarget: boolean;
+};
+
+async function measureMenu(page: import("@playwright/test").Page): Promise<MenuGeometry> {
+  return page.evaluate(() => {
+    const menu = document.querySelector(".rail-actions-menu");
+    if (menu === null) throw new Error("#988 — the rail actions menu is not mounted");
+    const rows = menu.querySelectorAll(".rail-action");
+    const first = rows[0];
+    if (first === undefined) throw new Error("#988 — the menu has no rows");
+    const menuRect = menu.getBoundingClientRect();
+    const rowRect = first.getBoundingClientRect();
+    const hit = document.elementFromPoint(
+      rowRect.x + rowRect.width / 2,
+      rowRect.y + rowRect.height / 2,
+    );
+    return {
+      scrollTop: menu.scrollTop,
+      scrollHeight: menu.scrollHeight,
+      clientHeight: menu.clientHeight,
+      menuTop: menuRect.top,
+      firstRowTop: rowRect.top,
+      firstRowBottom: rowRect.bottom,
+      firstRowLabel: first.textContent?.trim() ?? "",
+      rows: rows.length,
+      spaceAboveVar: getComputedStyle(menu).getPropertyValue("--rail-menu-space-above").trim(),
+      insetVar: getComputedStyle(menu).getPropertyValue("--safe-area-inset-top").trim(),
+      firstRowIsHitTarget: hit === first || first.contains(hit),
+    };
+  });
+}
+
+function assertFirstRowVisible(g: MenuGeometry, label: string): void {
+  // Reading 2, settled by measurement rather than by argument.
+  expect(g.scrollTop, `${label} — a freshly opened menu must not be scrolled`).toBe(0);
+
+  // The acceptance criterion, in the two ways it can be violated: the row can
+  // be scrolled out of the menu's own scroll port, or the whole menu can sit
+  // above the top of the screen (the #588 failure — a cap too large means no
+  // scrollbar AND rows off-screen).
+  expect(
+    g.firstRowTop,
+    `${label} — the first row starts ${g.firstRowTop}px from the viewport top, i.e. off-screen`,
+  ).toBeGreaterThanOrEqual(-0.5);
+  expect(
+    g.firstRowTop - g.menuTop,
+    `${label} — the first row is not at the top of the scroll port`,
+  ).toBeLessThanOrEqual(1);
+  expect(
+    g.firstRowBottom,
+    `${label} — the first row is not WHOLLY visible inside the scroll port`,
+  ).toBeLessThanOrEqual(g.menuTop + g.clientHeight + 1);
+
+  // Visible is not the same as reachable: `home` must also be the element
+  // under the finger, not something painted over it.
+  expect(g.firstRowIsHitTarget, `${label} — the first row is covered by another element`).toBe(
+    true,
+  );
+
+  // #588 — the cap must be the MEASURED space above, not the pre-measure
+  // viewport-height fallback. Losing this is what let rows grow off the top
+  // with no scrollbar, which is precisely the shape #988 fears a re-anchor
+  // would recreate downward.
+  expect(g.spaceAboveVar, `${label} — the JS-measured cap was never published`).not.toBe("");
+}
+
+test.setTimeout(120_000);
+
+test("@webkit #988 — the actions menu opens with `home` visible at every viewport height", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  // A channel window so the menu carries its widest row set (rooms + denoise
+  // are selection-gated) — the tall menu #988 is about.
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  let sawOverflow = false;
+  for (const height of HEIGHTS) {
+    await page.setViewportSize({ width: WIDTH, height });
+    await openRailMenu(page);
+    const g = await measureMenu(page);
+    console.log(`#988 h=${height} ${JSON.stringify(g)}`);
+    assertFirstRowVisible(g, `#988 @${height}px`);
+    expect(g.firstRowLabel, "#988 — `home` must be the first row").toContain("home");
+    if (g.scrollHeight > g.clientHeight + 1) sawOverflow = true;
+    await page.keyboard.press("Escape");
+    await expect(page.locator(".rail-actions-menu")).toHaveCount(0, { timeout: 5_000 });
+  }
+
+  // Without this the whole loop could pass on a menu that always fits, which
+  // asserts nothing about the case #988 is about. If it ever trips, the menu
+  // stopped being able to overflow at 360px and the heights need revisiting —
+  // not the assertion.
+  expect(
+    sawOverflow,
+    "#988 — no viewport in the set made the menu overflow; the capped case was never exercised",
+  ).toBe(true);
+});
+
+test("@webkit #988 — `home` stays visible at XXL text with the viewport at its shortest", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  try {
+    // The production path, not a CSS var poke: the operator picks the size in
+    // the display sub-page and `lib/fontSize.ts` writes `--font-size`.
+    await openSettingsSection(page, "display");
+    await page.locator('[data-testid="font-size-XXL"]').tap();
+    await expect(page.locator('[data-testid="font-size-XXL"]')).toBeChecked();
+    expect(
+      await page.evaluate(() =>
+        getComputedStyle(document.documentElement).getPropertyValue("--font-size").trim(),
+      ),
+    ).toBe("20px");
+    // The mutex swapped the members drawer for the settings drawer; close it
+    // or its slide-out intercepts the taps `openRailMenu` is about to make.
+    await closeSettings(page);
+
+    await page.setViewportSize({ width: WIDTH, height: 360 });
+    await openRailMenu(page);
+    const g = await measureMenu(page);
+    console.log(`#988 XXL h=360 ${JSON.stringify(g)}`);
+    assertFirstRowVisible(g, "#988 XXL @360px");
+  } finally {
+    // Reset, or every later spec in this browser inherits XXL — the
+    // cascade-poisoner shape.
+    await page.keyboard.press("Escape").catch(() => {});
+    await openSettingsSection(page, "display")
+      .then(() => page.locator('[data-testid="font-size-M"]').tap())
+      .catch(() => {});
+  }
+});

--- a/cicchetto/e2e/tests/ux-5-a-hamburger-dedupe.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-a-hamburger-dedupe.spec.ts
@@ -79,7 +79,15 @@ test("@webkit ux-5-a mobile — exactly ONE visible hamburger (TopicBar members)
 
   // Cold-load lands on home — no channel context, TopicBar unmounted,
   // ZERO hamburgers anywhere.
-  await expect(page.getByTestId("shell-chrome")).toBeVisible({ timeout: 10_000 });
+  //
+  // #985 — the host is mounted but no longer occupies a band: it is
+  // `height: 0` and its ☰ overflows over the pane's top-right corner, so
+  // Playwright reports the host itself as hidden. This precondition only ever
+  // needed "the non-channel chrome is on screen"; post-#985 the thing on screen
+  // is the opener, so witness that. The dedupe count below is untouched — and
+  // it is the point of this test, not the host's box.
+  await expect(page.getByTestId("shell-chrome")).toHaveCount(1);
+  await expect(page.getByTestId("shell-chrome-rail-opener")).toBeVisible({ timeout: 10_000 });
   await expect(page.locator(".shell-chrome-hamburger")).toHaveCount(0);
   await expect(page.locator(".topic-bar-hamburger")).toHaveCount(0);
 

--- a/cicchetto/e2e/tests/ux-5-bm-mobile-hamburger.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bm-mobile-hamburger.spec.ts
@@ -150,17 +150,29 @@ test("@webkit ux-5-bm mobile-channel — topic-bar hosts hamburger only; drawer 
 // mutex test). The `toggleMembersPanel` close-siblings arm itself is
 // pinned at the unit level by `src/__tests__/mobilePanel.test.ts`.
 
-test("@webkit ux-5-bm mobile-non-channel — standalone .shell-chrome row preserved on home", async ({
+test("@webkit ux-5-bm mobile-non-channel — home keeps its own ☰ door to the rail", async ({
   page,
 }) => {
   const vjt = getSeededVjt();
   await loginAs(page, vjt);
 
-  // Cold-load lands on home. BM scope is mobile-channel only — non-
-  // channel windows keep the standalone .shell-chrome row (no members
-  // hamburger on home/mentions/admin/server to host the launchers).
-  await expect(page.getByTestId("shell-chrome")).toBeVisible({ timeout: 10_000 });
-  await expect(page.locator(".shell-chrome")).toHaveCount(1);
+  // Cold-load lands on home. BM scope is mobile-channel only — non-channel
+  // windows keep their OWN ☰, because there is no members hamburger on
+  // home/mentions/admin/server to host it.
+  //
+  // This test used to be titled "standalone .shell-chrome row preserved" and
+  // opened by asserting that row visible. #985 removed the row on vjt's call
+  // ("solo l'hamburger, in alto a destra"): the host is now `height: 0` and the
+  // ☰ floats over the pane's corner. What BM cares about survives that change
+  // intact — a non-channel window has exactly one door, it is reachable, and
+  // the cog is not in it — so the title and the opening assertion now name the
+  // DOOR, which is what was always meant, instead of the band that used to
+  // carry it. Nothing that BM measured has been dropped: the door's visibility
+  // is asserted below, scoped INSIDE `.shell-chrome`, which is stricter than
+  // the assertion removed here — so no twin is added for it (a second waiter on
+  // the same fact is the duplicate-waiter shape). The cold-load settle budget
+  // the removed assertion carried moves onto this one, which is now first.
+  await expect(page.locator(".shell-chrome")).toHaveCount(1, { timeout: 10_000 });
   await expect(page.locator(".topic-bar")).toHaveCount(0);
   // #71 INC-2 — the standalone row's button is now the ☰ RAIL OPENER (the cog
   // moved into the rail it opens). Assert the opener is reachable here, and that

--- a/cicchetto/e2e/tests/ux-5-bt-narrow-chrome-compression.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bt-narrow-chrome-compression.spec.ts
@@ -120,10 +120,15 @@ test("@webkit ux-5-bt mobile — channel: NO standalone .shell-chrome row (#473 
   const vjt = getSeededVjt();
   await loginAs(page, vjt);
 
-  // Cold-load lands on home — TopicBar absent. Chrome row STAYS on
-  // mobile-home (no host row to absorb the buttons).
-  await expect(page.getByTestId("shell-chrome")).toBeVisible({ timeout: 10_000 });
+  // Cold-load lands on home — TopicBar absent. The chrome element STAYS on
+  // mobile-home (no TopicBar to host the ☰), which is what this test is about:
+  // mounted here, absent on a channel. #985 took away its BAND, not its
+  // existence — `height: 0` with the ☰ floated over the pane's corner — so the
+  // host reads as hidden to Playwright while `toHaveCount(1)` on the next line
+  // still says exactly what this precondition meant. The door is witnessed
+  // directly instead.
   await expect(page.locator(".shell-chrome")).toHaveCount(1);
+  await expect(page.getByTestId("shell-chrome-rail-opener")).toBeVisible({ timeout: 10_000 });
   await expect(page.locator(".topic-bar")).toHaveCount(0);
 
   // Switch to channel via BottomBar (mobile selectChannel handles the

--- a/cicchetto/src/ShellChrome.tsx
+++ b/cicchetto/src/ShellChrome.tsx
@@ -7,7 +7,6 @@ import type { Component } from "solid-js";
 // window kind, INCLUDING the server window.
 //
 // Slots (left → right):
-//   * Spacer — pushes the right group to the far right.
 //   * Rail opener (☰) — #71 INC-2: was the settings cog. R1 moved the cog
 //     into the always-present right rail (RailActions), so on the mobile
 //     NON-channel windows (where this bar renders) the settings cog is
@@ -27,6 +26,15 @@ import type { Component } from "solid-js";
 // entry now (`rail-action-mentions`), reachable via the same ☰ — so what
 // remains here is the opener and nothing else, which is exactly the state
 // #985 needs in order to float a lone ☰ and drop `.shell-chrome`.
+//
+// #985 — and so the band went. This is no longer a row: `.shell-chrome` is a
+// ZERO-HEIGHT flow box and the lone ☰ overflows it, floating over the pane's
+// top-right corner (the full rationale, including why the containing block is
+// this box and not `.shell-main`, lives on the CSS rule). The element and both
+// testids survive on purpose — a non-channel window still needs exactly one
+// door into the rail, and ~20 specs locate it here. What changed is the price:
+// the scrollback now starts at the top of the pane, as it already did on a
+// channel window. The `.shell-chrome-spacer` went with the row that needed it.
 //
 // #71 INC-2 — ShellChrome is now MOBILE-ONLY: the desktop copy was removed
 // (its row freed the top for the topic; the cog moved to the permanent
@@ -59,7 +67,6 @@ export type Props = {
 const ShellChrome: Component<Props> = (props) => {
   return (
     <header class="shell-chrome" data-testid="shell-chrome">
-      <span class="shell-chrome-spacer" />
       {/* #71 INC-2 — rail opener (☰). Opens the same `.shell-members` drawer
           the channel-window TopicBar hamburger opens (paletto: ONE drawer, one
           ☰ glyph across both openers). The settings cog it replaced now lives

--- a/cicchetto/src/__tests__/shellChromeFloat.test.ts
+++ b/cicchetto/src/__tests__/shellChromeFloat.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { ruleBody, themeCss } from "./helpers/themeCss";
+
+// #985 — the non-channel mobile band. `.shell-chrome` was a full-width
+// `<header>` in `.shell-main`'s flex column holding one right-aligned ☰ and
+// nothing else, priced at `var(--chrome-tap-min) + 1rem + 1px` and SCALING with
+// the operator's text size. It cost that on every non-channel window, in the
+// state where vertical space is scarcest (keyboard up). #986 emptied it of its
+// second glyph (`@` moved to the rail), so what is left is a band around a
+// single button.
+//
+// These are SOURCE-level guards, the same shape as `railMenuSafeArea.test.ts`
+// and for the same reason: jsdom has no layout engine, so the rendered
+// geometry is not observable in any gate that runs locally. The rendered
+// outcome — scrollback starting at the top of the pane, opener still tappable
+// — is pinned in `e2e/tests/issue985-mobile-floating-opener.spec.ts`.
+
+describe("#985 the chrome band is out of flow", () => {
+  it("`.shell-chrome` costs zero height and no longer paints a band", () => {
+    const body = ruleBody(".shell-chrome");
+    // The whole point: the row is still in the DOM (every non-channel window
+    // needs its opener) but takes no vertical space from the scrollback.
+    expect(body).toMatch(/height:\s*0\b/);
+    // The three declarations that MADE it a band. `padding: 0.5rem 1rem` is the
+    // one that priced it; with `box-sizing: border-box` a surviving padding
+    // would floor the border box above the `height: 0` and quietly give some of
+    // the band back.
+    expect(body).not.toMatch(/border-bottom:/);
+    expect(body).not.toMatch(/padding:\s*0\.5rem/);
+    expect(body).not.toMatch(/background:/);
+  });
+
+  it("the opener anchors to `.shell-chrome` itself, not to `.shell-main`", () => {
+    // Deliberate: making `.shell-main` the containing block would re-anchor
+    // every `position: absolute` descendant that currently resolves past it.
+    // A zero-height positioned row is the containing block with no blast
+    // radius — so `.shell-main` must stay unpositioned.
+    expect(ruleBody(".shell-chrome")).toMatch(/position:\s*relative/);
+    // `.shell-mobile .shell-main` lives inside the ≤768px @media block, so it
+    // is indented and `ruleBody` (top-level rules only) cannot reach it.
+    const mobileMain = /\.shell-mobile \.shell-main\s*\{([^}]*)\}/.exec(themeCss)?.[1];
+    expect(mobileMain).toBeDefined();
+    expect(mobileMain).not.toMatch(/position:/);
+  });
+
+  it("the floated opener paints above the in-pane scrollback floats", () => {
+    // It overflows a zero-height box, so its later-in-DOM siblings (the
+    // scrollback, its pinned overlay, the float stack) would paint over it
+    // without an explicit stacking order. 40 is the tallest in-pane float
+    // (the next-active circle); 89/90 is the members drawer, which must stay
+    // ON TOP of the opener that opens it.
+    const z = /z-index:\s*(\d+)/.exec(ruleBody(".shell-chrome"))?.[1];
+    expect(z).toBeDefined();
+    expect(Number(z)).toBeGreaterThan(40);
+    expect(Number(z)).toBeLessThan(89);
+  });
+
+  it("the floated opener brings its own opaque backing", () => {
+    // `.shell-chrome-btn` declares `background: transparent`, which was fine
+    // while the band supplied the surface behind the glyph. Floating puts it
+    // over arbitrary scrollback text AND over a themed background image
+    // (`:root.theme-has-bg .scrollback-pane::before`), so it needs its own.
+    expect(themeCss).toMatch(
+      /\.shell-chrome \.shell-chrome-rail-opener\s*\{[^}]*background:\s*var\(--bg\)/,
+    );
+  });
+
+  it("no safe-area inset is re-applied at the float", () => {
+    // `.shell-mobile` already carries `padding-top: env(safe-area-inset-top)`
+    // (UX-3 BIS), and `.shell-main` sits inside that padding box — so the
+    // pane's top edge is ALREADY below the island. Adding the inset again here
+    // would double-count it: the #913 trap, pointed the other way.
+    expect(ruleBody(".shell-chrome")).not.toMatch(/safe-area-inset-top/);
+    expect(themeCss).not.toMatch(
+      /\.shell-chrome \.shell-chrome-rail-opener\s*\{[^}]*safe-area-inset-top/,
+    );
+  });
+
+  it("the flex spacer is gone with the band that needed it", () => {
+    // `justify-content: flex-end` on a shrink-wrapped float does the job the
+    // `flex: 1` spacer did inside a full-width row. Dead code, deleted.
+    expect(() => ruleBody(".shell-chrome-spacer")).toThrow();
+    expect(themeCss).not.toMatch(/shell-chrome-spacer/);
+  });
+});

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2295,20 +2295,59 @@ html.resize-dragging * {
    top-of-`.shell-main` toolbar. Hosts hamburger (mobile) + archive
    button + settings cog. The buttons share `.shell-chrome-btn` base
    class for size parity with `.topic-bar-hamburger` — the cog grows to
-   hamburger size. */
+   hamburger size.
+
+   #985 — it is not a bar any more. Every other occupant left (archive #473,
+   `@` mentions #986), so what remained was a full-width band around ONE
+   right-aligned ☰, priced at `var(--chrome-tap-min) + 1rem + 1px` and SCALING
+   with the operator's text size — paid on every non-channel mobile window, in
+   the state where vertical space is scarcest (keyboard up). The mobile-CHANNEL
+   branch had already reclaimed those pixels by hosting its ☰ inline in the
+   TopicBar; the query case never got a host, so it kept the whole row.
+
+   Now a ZERO-HEIGHT flow row whose single child overflows over the pane's
+   top-right corner: the scrollback starts at the top of `.shell-main` exactly
+   as it does on a channel window. Three choices worth their comment:
+
+   * `position: relative` HERE, not on `.shell-main`. The opener anchors to
+     THIS box, so no ancestor's containing block changes and nothing else in
+     the pane silently re-anchors. `height: 0` with NO padding: under
+     `box-sizing: border-box` a surviving padding would floor the border box
+     above zero and quietly hand part of the band back.
+   * NO `env(safe-area-inset-top)`. `.shell-mobile` already carries it
+     (UX-3 BIS) and `.shell-main` sits inside that padding box, so the pane's
+     top edge is ALREADY below the island; re-adding it would double-count —
+     the #913 trap pointed the other way.
+   * `z-index: 41` clears every in-pane scrollback float (the next-active
+     circle at 40 is the tallest) because the later-in-DOM scrollback would
+     otherwise paint over a child that overflows a zero-height box; and stays
+     below the members drawer (89/90) and the modal tier (1000), which must
+     keep covering the opener that summons them. The cost is deliberate and
+     narrow: the ☰'s own 48px box overlaps the top-right corner of the
+     scrollback, so a link ending exactly there is behind it — accepted,
+     the alternative was the band. */
 
 .shell-chrome {
+  position: relative;
+  z-index: 41;
+  height: 0;
   display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 1rem;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg);
+  align-items: flex-start;
+  justify-content: flex-end;
   flex-shrink: 0;
 }
 
-.shell-chrome-spacer {
-  flex: 1;
+/* #985 — the floated opener brings the surface the band used to supply.
+   `.shell-chrome-btn` declares `background: transparent`, which was free while
+   an opaque row sat behind the glyph; floating puts it over arbitrary
+   scrollback text and over a themed background image
+   (`:root.theme-has-bg .scrollback-pane::before`). Descendant selector rather
+   than order-dependent overriding, matching `.rail-actions .rail-action`.
+   The margin is what keeps the glyph off the pane's very corner — it is
+   breathing room, NOT a notch allowance (see above). */
+.shell-chrome .shell-chrome-rail-opener {
+  background: var(--bg);
+  margin: 0.25rem 0.5rem 0 0;
 }
 
 .shell-chrome-btn {

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2346,7 +2346,10 @@ html.resize-dragging * {
    The margin is what keeps the glyph off the pane's very corner — it is
    breathing room, NOT a notch allowance (see above). */
 .shell-chrome .shell-chrome-rail-opener {
-  background: var(--bg);
+  /* DELIBERATE RED — reverted in the very next commit. Proves the #985
+     opacity guard still rejects a translucent backing after the assertion
+     was rewritten. Must NOT survive into main. */
+  background: rgba(255, 255, 255, 0.5);
   margin: 0.25rem 0.5rem 0 0;
 }
 

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2346,10 +2346,7 @@ html.resize-dragging * {
    The margin is what keeps the glyph off the pane's very corner — it is
    breathing room, NOT a notch allowance (see above). */
 .shell-chrome .shell-chrome-rail-opener {
-  /* DELIBERATE RED — reverted in the very next commit. Proves the #985
-     opacity guard still rejects a translucent backing after the assertion
-     was rewritten. Must NOT survive into main. */
-  background: rgba(255, 255, 255, 0.5);
+  background: var(--bg);
   margin: 0.25rem 0.5rem 0 0;
 }
 


### PR DESCRIPTION
Two mobile-chrome P0s on one branch, cic-only. Built on `origin/main` after
#986 landed (union PR #999) — nothing from #986 is re-implemented here.

## #985 — the band a query window spent on one glyph

`.shell-chrome` stopped being a bar three issues ago: #473 took the archive
button out and #986 took `@` mentions into the rail. What was left was a
full-width `<header>` wrapped around ONE right-aligned ☰, still charging
`var(--chrome-tap-min) + 1rem + 1px` for it on every non-channel mobile
window, with the price SCALING with the operator's text size. The
mobile-CHANNEL branch had already reclaimed those pixels (its ☰ rides inline
in the TopicBar); the query case never got a host.

The row is now zero-height and its single child overflows over the pane's
top-right corner, so the scrollback starts at the top of `.shell-main`
exactly as it does on a channel window.

Verified by reading the new tree, not assumed: `ShellChrome.tsx` renders the
opener and nothing else — #986 already moved `@` into `RailActions`
(`rail-action-mentions`). So the float carries one glyph, and the "ONE
drawer, one ☰" mutex (`toggleMembersPanel`) is untouched.

Three decisions worth the review time:

* **The containing block is `.shell-chrome` itself, not `.shell-main`.**
  Positioning the pane would silently re-anchor every `position: absolute`
  descendant that today resolves past it — blast radius bought for nothing,
  since a zero-height positioned row anchors the opener just as well.
* **No `env(safe-area-inset-top)` at the float — the issue's shape-of-the-fix
  is overruled here.** `.shell-mobile` already carries the inset (UX-3 BIS)
  and `.shell-main` sits inside that padding box, so the pane's top edge is
  ALREADY below the island. Re-applying it would double-count — the #913 trap
  pointed the other way. Whether an inset is owed depends on WHICH BOX you
  anchor to: `.rail-actions-menu` does owe it (#913) because it measures an
  absolute viewport coordinate; this float does not.
* **The glyph brings its own opaque backing.** `.shell-chrome-btn` is
  `background: transparent`, free while a band sat behind it; floating puts
  it over arbitrary scrollback text and over a themed background image.

**Overlap, declared** (issue constraint 2): the ☰'s own 48px box overlaps the
top-right corner of the scrollback, so a line ending exactly there sits
behind it. The hit area is the button and nothing wider — no full-width strip
— and the alternative was the band.

## #988 — the premise is UNCONFIRMED and this branch does not patch it

Read this section as a report, not as a fix.

**Reading 2 is ARGUED, NOT FALSIFIED. The number is missing.** #988 asks the
implementer to open the menu on a short viewport and read `scrollTop` on
`.rail-actions-menu` before writing anything. That reading was never taken:
no browser is runnable on the authoring host, and the stack lane was not
held. What exists here is the argument that nothing in `RailActions` scrolls
a freshly-mounted `overflow-y: auto` container, so 0 is expected — an
argument, which is exactly the kind of claim #988 says to settle by
measurement. Until this spec runs, "reading 2 is dead" is an unproven
statement and should not be quoted as a result.

The rest of #988's premise is unconfirmed the same way, and the issue says so
itself: the screenshot never arrived and the geometry was read off the code.

**Reading 1 gets no code change, and that is a finding.** When the content
exceeds the cap, `max-height` is `spaceAbove - inset`, so the bottom-anchored
box already runs from `inset + RAIL_MENU_TOP_GAP` down to the launcher — the
identical rectangle a top-anchored menu with the same cap would occupy. The
two anchorings differ only when the menu FITS, and #988 explicitly keeps
`bottom: 100%` there. A re-anchor would be green, shipped, and change
nothing. This is STRUCTURE read off the code, not magnitude measured — and it
is offered as a reason not to write a no-op, not as proof the menu behaves.

So `issue988-rail-menu-first-row.spec.ts` measures the actions menu at four
viewport heights plus one XXL pass and reports `scrollTop`,
`scrollHeight/clientHeight`, the menu box, the first row box, the published
`--rail-menu-space-above` and the inset — then asserts the criterion vjt
stated: on open the first row is visible without scrolling. Nothing in the
#588 cap or the #913 subtraction is touched.

The readings leave the run by two exits, both verified against a real
Playwright run on this host: a NODE-side `console.log` (a passing test's
stdout does reach the `list` reporter) and a `testInfo.attach`. They are
emitted from a `finally` BEFORE any assertion runs, so a mid-sweep failure
still prints every height already collected — proven with a deliberately
failing probe. The numbers are wanted most on the red run.

**If CI comes back green, the premise is unconfirmed and the guard is the
right outcome for #988.** If it comes back red, the printed numbers name the
mechanism and the fix follows them.

## Gates

Run locally, from the worktree root:

* `scripts/bun.sh run test` — **246 files / 4572 tests green** (full suite).
* `scripts/bun.sh run check` — biome + tsc, **rc=0**.
* `tsc -p e2e --noEmit` — both new specs clean (the tree carries 26
  pre-existing errors; neither new file is among them).
* **The #985 opacity guard was proven IN CI by mutation.** No browser runs on
  this host, so the mutation was pushed instead: commit `8704ddc5` set the
  opener's backing to `rgba(255, 255, 255, 0.5)`, and run
  [31186523383](https://github.com/vjt/grappa-irc/actions/runs/31186523383)
  came back **1 failed / 636 passed** — the single red being this spec, at the
  opacity assertion, `Expected: 1 / Received: 0.5` off a computed
  `rgba(255, 255, 255, 0.5)`. The guard rejects a translucent backing, and it
  rejects it *for the alpha*, not for a colour channel. The mutation was
  reverted in `6fd4c8ba`; the tree is byte-identical to the pre-mutation
  commit. **This assertion is not a mirror.**
* **Mutation, 8/8**: every new assert in `shellChromeFloat.test.ts` was
  killed by a targeted mutation of the rule it guards (re-add the band
  padding; drop `height: 0`; drop `position: relative`; z-index to 40; z-index
  to 90; drop the backing; re-apply the inset; resurrect the spacer). Baseline
  green after each revert. No mirrors.

## NOT run, and not claimed

* **The e2e GEOMETRY assertions still have no mutation proof.** Both specs now
  execute in CI and pass, but "passes" is not "would catch the defect". Only
  the #985 opacity assertion has been shown to fail on a real defect (see
  Gates). The pixel assertions — pane top, zero-height chrome row, tap floor,
  corner containment — have never been seen red, so they are unverified as
  discriminators.
* **The first version of the #985 opacity assertion was itself the bug.** It
  scraped alpha with `/rgba?\([^)]*?(?:,\s*([\d.]+))?\)$/`, whose lazy
  `[^)]*?` handed the BLUE channel of an opaque `rgb(255, 255, 255)` to the
  alpha group and failed a correct product. Recorded because it is the same
  class of error the geometry asserts are still exposed to: an assertion that
  has only ever been seen green tells you nothing about why it is green.
* **`scrollTop` was never measured.** See above: reading 2 is argued only.
* **The notch is not covered by any gate.** Playwright synthesizes no
  `env(safe-area-inset-*)` in either project, so both the #985 island
  clearance and #988's inset arithmetic read 0px. Device verification on a
  real iPhone is owed after ship.
