### PR TITLE
cic(#1003): let Tab see past nick decoration, without folding identity

### DIFF
--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -2216,8 +2216,9 @@ describe("compose tabComplete (members-only, irssi-exact)", () => {
   it("folds case (not the bracket range) on the prefix match (#525)", async () => {
     // #525 CASEMAPPING=ascii: `[` is NOT folded, so a member `Foo[1]` and
     // the typed `foo[` are the SAME nick (case-only) and completion
-    // matches on the common `nick[away]` shape; a brace `foo{` would be a
-    // DIFFERENT nick.
+    // matches on the common `nick[away]` shape. A brace `foo{` is a
+    // DIFFERENT nick — but since #1003 it still REACHES `Foo[1]` on the
+    // decoration level, behind the literals; see the cousin test below.
     await setMembers(["Foo[1]"]);
     const compose = await import("../lib/compose");
     const r = compose.tabComplete(k, "foo[", 4, true);
@@ -2338,6 +2339,18 @@ describe("compose tabComplete (members-only, irssi-exact)", () => {
     expect(compose.tabComplete(k, "al", 2, true)?.newInput).toBe("alex: ");
     const draft = compose.getDraft(k);
     expect(compose.tabComplete(k, draft, draft.length, true)?.newInput).toBe("_alfa_: ");
+  });
+
+  // #525 vs #1003: the fold keeps `foo{` and `Foo[1]` DISTINCT identities,
+  // but the second completion level treats `{` and `[` alike — so `Foo[1]`
+  // IS offered, and strictly after every literal match. Pins the exact
+  // claim made in the matcher's comment.
+  it("offers a brace/bracket cousin only behind the literal matches", async () => {
+    await setMembers(["foo{x}", "Foo[1]"]);
+    const compose = await import("../lib/compose");
+    expect(compose.tabComplete(k, "foo{", 4, true)?.newInput).toBe("foo{x}: ");
+    const draft = compose.getDraft(k);
+    expect(compose.tabComplete(k, draft, draft.length, true)?.newInput).toBe("Foo[1]: ");
   });
 
   it("a decoration-only word matches nothing (it would match everyone)", async () => {

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -2293,6 +2293,59 @@ describe("compose tabComplete (members-only, irssi-exact)", () => {
     expect(compose.getDraft(k)).toBe("alex: ");
   });
 
+  // #1003 — IRC nicks wear decoration (`_omino_`, `gio-vanni`, `bob^`).
+  // Typing the bare word must still reach them. Second level ONLY: an
+  // exact prefix match always comes first, so the decoration-blind pass
+  // never steals the slot a literal match already owns.
+  it("matches a decorated nick from the undecorated prefix", async () => {
+    await setMembers(["_omino_"]);
+    const compose = await import("../lib/compose");
+    expect(compose.tabComplete(k, "omi", 3, true)?.newInput).toBe("_omino_: ");
+  });
+
+  it("inserts the REAL nick, decoration included", async () => {
+    await setMembers(["_omino_"]);
+    const compose = await import("../lib/compose");
+    compose.tabComplete(k, "omi", 3, true);
+    expect(compose.getDraft(k)).toBe("_omino_: ");
+  });
+
+  it("strips decoration off the TYPED word too (symmetric)", async () => {
+    await setMembers(["omino"]);
+    const compose = await import("../lib/compose");
+    expect(compose.tabComplete(k, "_omi", 4, true)?.newInput).toBe("omino: ");
+  });
+
+  it("matches across an inner hyphen", async () => {
+    await setMembers(["gio-vanni"]);
+    const compose = await import("../lib/compose");
+    expect(compose.tabComplete(k, "giov", 4, true)?.newInput).toBe("gio-vanni: ");
+  });
+
+  it("offers the exact match FIRST and the decorated one on the second Tab", async () => {
+    await setMembers(["omino", "_oMiNo_"]);
+    const compose = await import("../lib/compose");
+    expect(compose.tabComplete(k, "omi", 3, true)?.newInput).toBe("omino: ");
+    let draft = compose.getDraft(k);
+    expect(compose.tabComplete(k, draft, draft.length, true)?.newInput).toBe("_oMiNo_: ");
+    draft = compose.getDraft(k);
+    expect(compose.tabComplete(k, draft, draft.length, true)?.newInput).toBe("omi");
+  });
+
+  it("does not let a decoration-only match outrank a literal one", async () => {
+    await setMembers(["_alfa_", "alex"]);
+    const compose = await import("../lib/compose");
+    expect(compose.tabComplete(k, "al", 2, true)?.newInput).toBe("alex: ");
+    const draft = compose.getDraft(k);
+    expect(compose.tabComplete(k, draft, draft.length, true)?.newInput).toBe("_alfa_: ");
+  });
+
+  it("a decoration-only word matches nothing (it would match everyone)", async () => {
+    await setMembers(["alice", "bob"]);
+    const compose = await import("../lib/compose");
+    expect(compose.tabComplete(k, "_", 1, true)).toBeNull();
+  });
+
   it("a real keystroke (setDraft) discards the cycle", async () => {
     await setMembers(["alice", "alex"]);
     const compose = await import("../lib/compose");
@@ -2396,6 +2449,14 @@ describe("compose tabComplete — channel names (#30)", () => {
     await setJoinedWindows({ [channelKey("freenode", "#other")]: "joined" });
     const compose = await import("../lib/compose");
     expect(compose.tabComplete(k, "#sni", 4, true)).toBeNull();
+  });
+
+  // #1003 — the nick decoration strip stops at the sigil: `#foo-bar` is a
+  // DIFFERENT channel from `#foobar`, not the same one wearing a hyphen.
+  it("never strips decoration on the channel branch", async () => {
+    await setJoinedWindows({ [channelKey("freenode", "#sniffo-bis")]: "joined" });
+    const compose = await import("../lib/compose");
+    expect(compose.tabComplete(k, "#sniffob", 8, true)).toBeNull();
   });
 
   it("a sigil-less token still completes NICKS, not channels", async () => {

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -1932,10 +1932,18 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       anchorStart = start;
       // ASCII fold (not a bare toLowerCase) so `Foo` completes a member
       // `foo` — bahamut is CASEMAPPING=ascii (#525), folding `A-Z` ONLY.
-      // `[ ] \ ~` are NOT folded, so `foo{` does NOT complete `Foo[1]`
-      // (they are DISTINCT nicks). toLowerCase is avoided because it
-      // Unicode-over-folds non-ASCII (`CAFÉ`→`café`), not the brackets.
-      // Mirror of `Grappa.IRC.Identifier.canonical_nick/1`.
+      // `[ ] \ ~` are NOT folded, so for IDENTITY `foo{` and `Foo[1]` stay
+      // DISTINCT nicks. toLowerCase is avoided because it Unicode-over-folds
+      // non-ASCII (`CAFÉ`→`café`), not the brackets. Mirror of
+      // `Grappa.IRC.Identifier.canonical_nick/1`.
+      //
+      // Careful, this is only HALF the completion rule (#1003): the second
+      // level below counts `{ | }` as decoration alongside `[ ] \`, so
+      // `foo{<TAB>` CAN reach `Foo[1]` — strictly BEHIND every literal
+      // match, never displacing one. That is not an identity merge and does
+      // not soften #525: nothing here is a key, and what gets inserted is
+      // always the real nick. Keep both halves stated — a reader who sees
+      // only this paragraph will "fix" the second level as a leftover.
       prefix = asciiFold(typedWord);
       // ": " only when the word is the first token on the line — and only
       // for a NICK. A channel is a topic of conversation, never an

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -79,6 +79,16 @@ import { windowStateByChannel } from "./windowState";
 // network instead of assuming the RFC set.
 const CHANNEL_SIGIL = /^[#&+!]/;
 
+// #1003 — IRC nicks wear decoration (`_omino_`, `bob^`, `gio-vanni`), so
+// Tab must reach `_omino_` from the bare `omi`. Deliberately NOT taught to
+// `asciiFold`: that helper is protocol IDENTITY (the cic mirror of
+// `Grappa.IRC.Identifier.canonical_nick/1`, shared with nickColor /
+// notifyWatch / channelKey / pingCorrelation), and folding `_` there would
+// make `foo` and `f_o_o` the SAME person for highlight, colour and
+// presence. This one is local to the completion matcher, where a wrong
+// guess costs a second Tab, not an identity merge.
+const stripNickDecoration = (s: string): string => s.replace(/[[\]\\`_^{|}-]/g, "");
+
 // Per-channel compose state. Owns:
 //   * `composeByChannel` — { draft, history, historyCursor } per key.
 //     `historyCursor === null` = at-bottom (typing fresh draft);
@@ -1935,12 +1945,30 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       oldEnd = cursor;
     }
 
-    const candidates = CHANNEL_SIGIL.test(typedWord)
+    const isChannel = CHANNEL_SIGIL.test(typedWord);
+    const candidates = isChannel
       ? joinedChannelsOnNetwork(key)
       : (membersByChannel()[key] ?? []).map((m) => m.nick);
-    const matches = candidates
-      .filter((c) => asciiFold(c).startsWith(prefix))
-      .sort((a, b) => a.localeCompare(b));
+    const byName = (a: string, b: string) => a.localeCompare(b);
+    const literal = candidates.filter((c) => asciiFold(c).startsWith(prefix)).sort(byName);
+    // Second level (#1003), nicks only: the same prefix test with the
+    // decoration removed from BOTH sides. It runs AFTER the literal
+    // matches — the order IS the behaviour, so with `omino` and `_oMiNo_`
+    // both present the first Tab still yields the literal `omino`. A
+    // decoration-only word (`_`) strips to nothing and would match every
+    // member, so it stays on the literal level. The channel branch never
+    // strips: `#foo-bar` is a DIFFERENT channel from `#foobar`.
+    const looseWord = isChannel ? "" : stripNickDecoration(prefix);
+    const loose =
+      looseWord === ""
+        ? []
+        : candidates
+            .filter(
+              (c) =>
+                !literal.includes(c) && stripNickDecoration(asciiFold(c)).startsWith(looseWord),
+            )
+            .sort(byName);
+    const matches = [...literal, ...loose];
     if (matches.length === 0) return null;
 
     const span = matches.length + 1; // matches + the revert slot


### PR DESCRIPTION
Refs #1003.

## Il difetto

`omi<TAB>` non raggiunge un membro che si chiama `_omino_`. Il matcher del
completamento (`compose.ts`) e un solo test di prefisso su
`asciiFold(candidate)`, e `asciiFold` folda `A-Z` e nient'altro.

## Perche NON si insegna la decorazione ad `asciiFold`

`asciiFold` e IDENTITA DI PROTOCOLLO: il mirror cic di
`Grappa.IRC.Identifier.canonical_nick/1`, condiviso con `nickColor`,
`notifyWatch`, `channelKey`, `pingCorrelation`. Renderlo cieco a `_ - ^ [ ] { | } \`
farebbe diventare `foo` e `f_o_o` **la stessa persona** per highlight, colore e
presence — un merge di identita, molto peggio del completamento mancato.

## La forma

- Helper `stripNickDecoration` **locale al matcher**, non esportato.
- Filtro a **DUE LIVELLI**: prima i match letterali di oggi, POI quelli
  decoration-stripped (deduplicati). Con `omino` e `_oMiNo_` entrambi in canale
  il primo Tab da ancora `omino`, il secondo l'altro. **L'ordine e il
  comportamento**, non un dettaglio.
- Strip **simmetrico**: si applica anche alla parola digitata (`_omi` → `omino`).
- Cio che si INSERISCE resta il nick vero, decorazione compresa.
- Il ramo canali non strippa mai (`#foo-bar` e un canale DIVERSO da `#foobar`).
- Una parola tutta decorazione (`_`) strippa a vuoto e matcherebbe chiunque:
  resta sul livello letterale.

Fuori scopo per scelta: matching fuzzy, e lo strip sul ramo canali.

## Conseguenza deliberata (accettata, non subita)

Al secondo livello `{ | }` sono decorazione quanto `[ ] \`, quindi
**`foo{<TAB>` ora puo raggiungere `Foo[1]`**. Quando scatta: solo sul livello 2,
cioe **dietro OGNI match letterale**, mai al posto di uno — misurato, non
promesso (con `foo{x}` e `Foo[1]` in canale il primo Tab da `foo{x}`, il
secondo `Foo[1]`). Perche l'identita resta intatta: #525 vive nella fold, che
non tocca `[ ] \ ~` e continua a tenere i due nick DISTINTI; qui non si deriva
nessuna chiave e cio che si inserisce e sempre il nick vero, quindi niente
viene fuso per highlight, colore o presence.

Il commento sopra `asciiFold(typedWord)` diceva l'esatto contrario ed era
diventato mezzo falso: ora enuncia **entrambe** le meta (identita distinta +
raggiungibilita al livello 2), cosi il prossimo lettore non cancella il livello
2 credendolo un residuo. Il commento gemello nel test #525 aveva la stessa
frase stantia ed e corretto con lui.

## Test plan

- [x] 8 assert nuovi in `compose.test.ts`, **rossi prima** (6 rossi sul codice
      pre-fix; 2 — il ramo canali e l'ordine literal-prima — verdi per costruzione
      e pinnati da mutazione).
- [x] **Mutazione per ogni assert**, ognuna verificata rossa:
      secondo livello rimosso (6 rossi) · ordine dei livelli invertito (2) ·
      strip non simmetrico (1) · guardia sullo strip vuoto rimossa (3) ·
      strip esteso ai canali (1) · inserimento del nick strippato (6).
      L'assert `foo{`→`foo{x}`-poi-`Foo[1]` muore sia a ordine invertito sia a
      livello 2 rimosso.
- [x] `bun run check` (biome + tsc) RC=0.
- [x] `bun run test`: 245 file / 4575 test verdi, RC=0.
- [ ] e2e: **non girata**.
