### PR TITLE
fix(#1008): composer keeps its typing aids — drop autocorrect=off, keep autocapitalize

### DIFF
--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -538,11 +538,25 @@ const ComposeBox: Component<Props> = (props) => {
           // mechanism behind it (the iOS auto-capitalisation hypothesis was
           // falsified on a real device). Correct on its own merits: with no
           // attribute WebKit applies `sentences`, and this box eats nicks,
-          // channel names and `/commands`. Same trio spelling as the other
-          // identifier inputs (PerformSettings, Login). `spellcheck` is left
-          // alone on purpose — message bodies are prose.
+          // channel names and `/commands`.
+          //
+          // #1008 — and it stops there. `autocorrect="off"` was copied in
+          // alongside it from the IDENTIFIER inputs (PerformSettings, Login,
+          // AliasSettings) and shipped in v0.13.3; on WebKit that attribute
+          // also suppresses the QuickType predictive bar, not merely the
+          // silent correction, and a reporter on #sniffo could no longer type
+          // on a phone. **This box is prose, and prose keeps its typing
+          // aids** — the same line `spellcheck` already sits on, which is why
+          // `spellcheck` is likewise left alone. Do not re-add `autocorrect`
+          // here by copying the pair from an identifier field: those fields
+          // want it, a message body does not.
+          //
+          // Accepted cost, ruled on knowingly in #1008: autocorrection may
+          // occasionally rewrite an unusual word — a bare nick typed without
+          // tab-completion among them. Being unable to type at all is worse.
+          // Having BOTH needs a contenteditable composer with mention spans
+          // marked non-correctable; that is its own issue, not a rider here.
           autocapitalize="none"
-          autocorrect="off"
           // #737 — a paced drain rewrites this draft every acked line for as
           // long as the pacing lasts. The store refuses operator writes while
           // it does (that is the real guard, and it covers the global paste

--- a/cicchetto/src/__tests__/ComposeBox.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBox.test.tsx
@@ -118,6 +118,36 @@ describe("ComposeBox", () => {
     expect(screen.getByRole("button", { name: /send/i })).toBeInTheDocument();
   });
 
+  // #1008 — the composer is PROSE, and the two attributes fall on opposite
+  // sides of that line. `autocapitalize="none"` is right and stays: with no
+  // attribute WebKit applies `sentences` and the box upper-cases nicks,
+  // channel names and `/commands`. `autocorrect="off"` was copied in beside
+  // it from the identifier inputs and shipped in v0.13.3; on WebKit it also
+  // kills the QuickType predictive bar, which made the box unusable on a
+  // phone.
+  //
+  // The composer had NO attribute guard at all before this — `6a12346e`
+  // added the pair and touched no test — so this is the first one, and it
+  // exists to stop the pair being re-copied wholesale. The identifier half
+  // of the contrast is already pinned, and deliberately stays pinned, by
+  // `Login.test.tsx`'s "keeps autocapitalize/autocorrect/spellcheck/
+  // autocomplete on the nick field".
+  //
+  // What this canNOT witness: whether the predictive bar actually appears.
+  // jsdom has no iOS text-input UI and neither does Playwright's webkit.
+  // This asserts the DOM attribute that governs it, nothing more; the
+  // acceptance criterion is a device check.
+  it("#1008 — composer keeps autocapitalize=none but carries NO autocorrect (prose, not an identifier)", () => {
+    render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+    const ta = screen.getByPlaceholderText(/message #a/i);
+
+    expect(ta).toHaveAttribute("autocapitalize", "none");
+    expect(ta.hasAttribute("autocorrect")).toBe(false);
+    // `spellcheck` is the attribute that already sat on the prose side of
+    // this line; it must not have been dragged off it either.
+    expect(ta.hasAttribute("spellcheck")).toBe(false);
+  });
+
   // UX-6 bucket F (2026-05-21) — send button reshaped: aria-label +
   // SVG paper-plane glyph (vjt iPhone-dogfood Bug 7). SVG (not a
   // Unicode codepoint) so the glyph survives Linux/Windows monospace


### PR DESCRIPTION
Same-day regression of **v0.13.3**. One attribute removed from one element.

## What changed

`6a12346e` (today 12:51) put `autocapitalize="none"` and `autocorrect="off"`
together on the composer textarea. This keeps the first and drops the second.

`autocapitalize="none"` is right and stays — it is what actually fixed the
upper-cased nicks, and with no attribute WebKit applies `sentences` to a box
that holds nicks, channel names and `/commands`. `autocorrect="off"` was
copied wholesale from the **identifier** inputs, and on WebKit it suppresses
the QuickType predictive bar rather than merely the silent correction. A
reporter on `#sniffo` could no longer type on a phone.

**The root cause is not the attribute — it is copying a pattern across a
context boundary.** Those fields hold identifiers; this one holds prose. The
source comment already drew that line for `spellcheck` ("message bodies are
prose") and `autocorrect` had been placed on the wrong side of it. The comment
now says so explicitly, at the site, so the pair does not get re-copied.

## Scope, verified by grep rather than by memory

Only `ComposeBox.tsx` changed. `autocorrect="off"` is untouched on every
identifier input — PerformSettings (3), Login (3), AliasSettings (4),
ServiceModal (1), SettingsDrawer (3), WatchlistsSettings (2),
RegistrationWizardModal (3).

## The trade-off, ruled on knowingly

With autocorrection back, WebKit may occasionally rewrite an unusual word —
a bare nick typed without tab-completion among them. Per the issue: being
unable to type at all is worse than the odd mangled nick. Getting **both**
needs a contenteditable composer with mention/command spans marked
non-correctable; that is its own issue, not a rider on this one.

## Test

The composer had **no attribute guard at all** — the regressing commit touched
no test — so this adds the first one. It asserts `autocapitalize` present and
`none`, `autocorrect` **absent**, and `spellcheck` still absent. The
identifier half of the contrast stays pinned where it already lives, in
`Login.test.tsx`'s "keeps autocapitalize/autocorrect/spellcheck/autocomplete
on the nick field" — not duplicated here.

**Mutation, 3/3, every assert killed:**

| mutation on the source | result |
|---|---|
| re-add `autocorrect="off"` (the v0.13.3 state) | 1 failed / 86 passed |
| delete `autocapitalize="none"` | 1 failed / 86 passed |
| add `spellcheck={false}` | 1 failed / 86 passed |

Each named this test; baseline green (87/87) after every revert.

## Gates

* `scripts/bun.sh run test` — **245 files / 4575 tests green**. A measured
  `origin/main` baseline is 245 / 4574, so this adds exactly the one test.
* `scripts/bun.sh run check` — biome + tsc, **rc=0**, 48 warnings, 0 errors.

## 🔴 Not proven here, and it is the actual acceptance criterion

**No test in this repo can witness the QuickType bar.** jsdom has no text-input
UI, and Playwright's webkit is not iOS — neither synthesizes the predictive
bar. What is asserted is the DOM attribute that governs it, and nothing more.

**"The predictive bar is present while typing in the composer" remains a
device check on a real iPhone, owed to vjt by hand.** A green tick on this PR
must not be read as that acceptance criterion having been met. Likewise the
second criterion — that a first-token `nickname` or `/command` still is not
upper-cased — is argued from `autocapitalize="none"` being retained, not
measured on a device.
