### PR TITLE
#982 — admin-side share-token mint, to let a locked-out visitor back in

### DIFF
--- a/cicchetto/src/AdminEventsTab.tsx
+++ b/cicchetto/src/AdminEventsTab.tsx
@@ -52,6 +52,11 @@ function renderEvent(ev: WireAdminEvent): string {
       return `${visitorLabel(ev.visitor_nick, ev.visitor_id)} deleted${actorSuffix(ev.actor_user_name)}`;
     case "visitor_reaped":
       return `${visitorLabel(ev.visitor_nick, ev.visitor_id)} reaped (TTL expired)`;
+    case "visitor_share_token_minted":
+      // #982 — the actor is not optional here (see the server-side
+      // constructor), so it is named outright rather than through
+      // `actorSuffix`, which renders nothing when the name is absent.
+      return `share link minted for ${visitorLabel(ev.visitor_nick, ev.visitor_id)} by ${ev.actor_user_name}`;
     case "reaper_swept":
       return `reaper swept ${ev.count} visitor(s)`;
     case "upload_reaped":

--- a/cicchetto/src/__tests__/AdminEventsTab.test.tsx
+++ b/cicchetto/src/__tests__/AdminEventsTab.test.tsx
@@ -112,6 +112,37 @@ describe("AdminEventsTab — per-kind rendering (closed-union exhaustiveness)", 
     expect(row.textContent).toContain("S`grappa deleted by vjt");
   });
 
+  it("visitor_share_token_minted names the visitor and the acting admin (#982)", () => {
+    events = [
+      sample({
+        kind: "visitor_share_token_minted",
+        visitor_id: "v-uuid",
+        visitor_nick: "S`grappa",
+        actor_user_id: "u-uuid",
+        actor_user_name: "vjt",
+      } as WireAdminEvent),
+    ];
+    render(() => <AdminEventsTab />);
+    const row = screen.getByTestId("admin-event-visitor_share_token_minted");
+    expect(row.textContent).toContain("share link minted for S`grappa by vjt");
+  });
+
+  it("visitor_share_token_minted falls back to the id when the nick is absent", () => {
+    events = [
+      sample({
+        kind: "visitor_share_token_minted",
+        visitor_id: "v-uuid",
+        visitor_nick: null,
+        actor_user_id: "u-uuid",
+        actor_user_name: "vjt",
+      } as WireAdminEvent),
+    ];
+    render(() => <AdminEventsTab />);
+    const row = screen.getByTestId("admin-event-visitor_share_token_minted");
+    expect(row.textContent).toContain("v-uuid");
+    expect(row.textContent).toContain("by vjt");
+  });
+
   it("visitor_deleted without actor (system path)", () => {
     events = [
       sample({

--- a/cicchetto/src/__tests__/wireNarrow.test.ts
+++ b/cicchetto/src/__tests__/wireNarrow.test.ts
@@ -749,6 +749,30 @@ describe("narrowAdminEvent (REV-G H24)", () => {
     });
   });
 
+  describe("kind: visitor_share_token_minted (#982)", () => {
+    const valid = {
+      kind: "visitor_share_token_minted",
+      visitor_id: "uuid-1",
+      visitor_nick: "alice",
+      actor_user_id: "uuid-op",
+      actor_user_name: "admin",
+      at: "2026-08-07T12:00:00Z",
+    };
+    it("accepts the minted grant", () => {
+      expect(narrowAdminEvent(valid)).toEqual(valid);
+    });
+    it("accepts a credential-less identity (null nick)", () => {
+      const ev = { ...valid, visitor_nick: null };
+      expect(narrowAdminEvent(ev)).toEqual(ev);
+    });
+    it("rejects a missing actor — an unattributed grant is malformed here", () => {
+      // Unlike visitor_deleted, this event has no system path. Rendering
+      // it anonymously would hide exactly what it exists to show.
+      expect(narrowAdminEvent({ ...valid, actor_user_id: null })).toBeNull();
+      expect(narrowAdminEvent({ ...valid, actor_user_name: null })).toBeNull();
+    });
+  });
+
   describe("kind: reaper_swept / uploads_swept", () => {
     it("accepts reaper_swept", () => {
       const ev = { kind: "reaper_swept", count: 5, at: "2026-05-22T12:00:00Z" };

--- a/cicchetto/src/lib/adminEvents.ts
+++ b/cicchetto/src/lib/adminEvents.ts
@@ -82,6 +82,7 @@ function ingest(ev: WireAdminEvent): void {
     case "capacity_reject":
     case "visitor_deleted":
     case "visitor_reaped":
+    case "visitor_share_token_minted":
     case "reaper_swept":
     case "upload_reaped":
     case "uploads_swept":

--- a/cicchetto/src/lib/wireNarrow.ts
+++ b/cicchetto/src/lib/wireNarrow.ts
@@ -626,6 +626,26 @@ export function narrowAdminEvent(raw: unknown): WireAdminEvent | null {
         visitor_nick: r.visitor_nick as string | null,
         at: r.at as string,
       };
+    case "visitor_share_token_minted":
+      // #982 — the actor is NON-nullable on this one, unlike
+      // visitor_deleted: the verb is only reachable behind
+      // `:admin_authn`, so an unattributed grant is a malformed event
+      // and must narrow to null rather than render as anonymous.
+      if (
+        typeof r.visitor_id !== "string" ||
+        !isNullableString(r.visitor_nick) ||
+        typeof r.actor_user_id !== "string" ||
+        typeof r.actor_user_name !== "string"
+      )
+        return null;
+      return {
+        kind: "visitor_share_token_minted",
+        visitor_id: r.visitor_id,
+        visitor_nick: r.visitor_nick as string | null,
+        actor_user_id: r.actor_user_id,
+        actor_user_name: r.actor_user_name,
+        at: r.at as string,
+      };
     case "reaper_swept":
       if (typeof r.count !== "number") return null;
       return { kind: "reaper_swept", count: r.count, at: r.at as string };

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -96,6 +96,7 @@ export const ADMIN_EVENTS_WIRE_EVENT_KIND = [
   "capacity_reject",
   "visitor_deleted",
   "visitor_reaped",
+  "visitor_share_token_minted",
   "reaper_swept",
   "upload_reaped",
   "uploads_swept",
@@ -161,6 +162,15 @@ export type AdminEventsWireVisitorReapedEvent = {
   kind: "visitor_reaped";
   visitor_id: string;
   visitor_nick: string | null;
+  at: string;
+};
+
+export type AdminEventsWireVisitorShareTokenMintedEvent = {
+  kind: "visitor_share_token_minted";
+  visitor_id: string;
+  visitor_nick: string | null;
+  actor_user_id: string;
+  actor_user_name: string;
   at: string;
 };
 
@@ -407,6 +417,7 @@ export type AdminEventsWireEvent =
   | AdminEventsWireCapacityRejectEvent
   | AdminEventsWireVisitorDeletedEvent
   | AdminEventsWireVisitorReapedEvent
+  | AdminEventsWireVisitorShareTokenMintedEvent
   | AdminEventsWireReaperSweptEvent
   | AdminEventsWireUploadReapedEvent
   | AdminEventsWireUploadsSweptEvent

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -32782,3 +32782,78 @@ about width still restart the pool at 5 and 10 themselves. The ceiling
 correspondingly stops binding here: 14 tests × ~80 migrations per run becomes
 14 × 3, and the file drops from 8.6s to 0.4s. The undiagnosed replay red is
 still undiagnosed — it simply no longer has a home in this test.
+## 2026-08-07 — #982: an admin door that mints an identity, and why that was accepted
+
+`POST /admin/visitors/:id/share-token` lets an admin mint a share link
+that grants a session for someone else's visitor identity. Stated
+plainly: **an operator can become any visitor.** That is not an
+oversight in the design — it is the design, accepted explicitly by the
+project owner, and this entry exists so the next reader finds the
+reasoning instead of the capability.
+
+**Why it is worth it.** A visitor has no password; the browser session
+IS the identity. There is no credential to re-issue, no email to send a
+reset to, no second factor to fall back on. When the device dies or the
+profile is wiped, the account is simply unreachable, and the only
+operator tool before this was `DELETE /admin/visitors/:id` — which
+throws the session away rather than returning it. The alternative to an
+abusable recovery path is no recovery path, and for a passwordless
+identity that is the strictly worse trade. The owner weighed it and
+took the capability.
+
+**What the code owes in exchange is visibility, not prevention.** Every
+mint records a `:visitor_share_token_minted` admin event naming the
+acting admin, and emits `[:grappa, :admin, :visitor, :share_token,
+:minted]` — deliberately NOT folded into the visitor-side
+`[:grappa, :visitor, :share_token, :minted]`, because a shared event
+makes "did an operator do this?" unanswerable from telemetry, which is
+the only question the audit surface is for. The event's actor fields
+are the sole NON-nullable ones in `Grappa.AdminEvents.Wire`: every
+other actor-bearing event has a legitimate system path (the reaper,
+`bin/grappa`), this one has none, so `nil` is not "the system did it",
+it is an unattributed grant — the exact thing the event exists to
+prevent. The constructor's guard refuses it rather than recording it
+anonymously, and cic's narrower drops the malformed shape to `null`.
+
+**The TTL and the one-shot were not widened.** Ten minutes and single
+use are what stop a leaked link from being a standing key, and the
+admin door makes leakage *more* likely, not less: the link now travels
+to a third party over a channel the server cannot see. Operator
+guidance is in `docs/OPERATIONS.md`.
+
+**One mint path, one redeem path.** Both doors sign through the new
+`GrappaWeb.ShareToken` (salt, TTL, `mint/1`, `verify/1`), and
+`POST /auth/share/consume` is untouched. A second `Phoenix.Token.sign`
+site carrying its own copy of the salt would fail in the worst
+direction — the mint keeps returning 200 while consume rejects, so the
+operator hands out a dead link and the locked-out visitor stays locked
+out, with no error anywhere to read. The controller-level `salt/0` +
+`max_age_seconds/0` accessors that preceded this had zero callers; the
+tests re-declared the literals instead, which is the drift the shared
+module removes.
+
+**The incognito refusal is repeated, not inherited.** `%Visitor{incognito:
+true}` gets 403 at BOTH doors (#363). A gate applied at only one of two
+callers is how a product decision gets undone through the back entrance,
+so the admin action re-states it rather than assuming the visitor-side
+check covers the surface.
+
+### Side effect: the representative-nick derivation had to stop being copied
+
+The event carries `visitor_nick` so the console names a person rather
+than a UUID. That label — the identity-anchor credential's nick — was
+already derived inline in three places (`Grappa.Operator`,
+`Grappa.Visitors.Reaper`, `Grappa.Themes`), so a fourth caller forced
+the extraction: `Grappa.Networks.Credentials.representative_visitor_nick/1`,
+now used by all four.
+
+It lives in `Credentials` rather than `Visitors` for a reason that is
+structural, not stylistic. #211 phase 7 moved the nick off the visitor
+row onto the per-network credential, so the credential context owns it —
+and, decisively, `Grappa.Visitors` already deps on `Grappa.Themes`, so a
+helper placed in `Visitors` could never be reached from `Themes` without
+inverting that edge into a Boundary cycle. `Grappa.Networks` is the one
+boundary all four callers already depend on. `Themes` keeps its own
+absent-nick handling (leave the changeset alone, so the wire falls back
+to the guest label) while the two events render `nil` as the id: shared
+derivation, per-caller consequence — the verb reused, not the noun.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1339,6 +1339,41 @@ the matching pre-migration SHA and cold-deploy it before starting. The
 `schema_migrations` head printed in step 3 is the authoritative check
 that the DB and the target code SHA agree on the migration set.
 
+## Letting a locked-out visitor back in (#982)
+
+A visitor has no password — the browser session IS the identity. If the
+device dies, the profile is wiped, or the cookie goes away, the account
+is unreachable and there is nothing to "reset". The recovery verb is:
+
+```
+POST /admin/visitors/:id/share-token      # admin bearer, :admin_authn
+→ 200 {"token": "...", "expires_at": "2026-08-07T12:10:00Z"}
+```
+
+Hand the person `https://<host>/#/share/<token>`; consuming it mints
+them a fresh session for the SAME visitor identity.
+
+**The link is a bearer credential for that visitor's session.** Anyone
+holding it within the window becomes that visitor — there is no second
+factor, because the identity has no first one. Therefore:
+
+* **Send it over a private channel.** A pasted link in a public
+  channel, a shared ticket, or an unencrypted mail thread is a handed-
+  over account. Prefer the same channel you would use for a password.
+* **It expires in 10 minutes and redeems exactly once.** Both limits
+  are deliberate and must not be widened for convenience — they are
+  what keep a leaked link from becoming a standing key. If the person
+  misses the window, mint another one; that is cheaper than a longer
+  TTL.
+* **Every mint is recorded** as a `visitor_share_token_minted` admin
+  event naming the admin who pressed it, visible in the console's
+  Events tab, with telemetry distinct from the visitor's own share
+  mint. The capability is abusable by an admin by construction (see
+  `docs/DESIGN_NOTES.md`); the audit trail is the mitigation, so do
+  not expect the mint to be deniable.
+* **Incognito visitors are refused (403).** An incognito session is
+  deliberately non-portable (#363); there is nothing to restore.
+
 ## CSP / security headers (BEAM-emitted, NOT nginx — #485)
 
 The Content-Security-Policy + sibling security headers

--- a/lib/grappa/admin_events/wire.ex
+++ b/lib/grappa/admin_events/wire.ex
@@ -32,6 +32,11 @@ defmodule Grappa.AdminEvents.Wire do
   system-initiated events (`bin/grappa` rpc-eval verbs, scheduled
   reaper sweeps). Cic renders "by <name>" only when both are set.
 
+  `:visitor_share_token_minted` (#982) is the one exception: its actor
+  fields are non-nullable, because the verb is reachable ONLY behind
+  `:admin_authn` and an unattributed session grant is precisely what
+  the event exists to surface.
+
   Admission-side telemetry events (`:circuit_open`, `:circuit_close`,
   `:capacity_reject`) DO NOT carry actor attribution — they fire
   inside admission-layer modules with no controller-side conn in
@@ -50,6 +55,7 @@ defmodule Grappa.AdminEvents.Wire do
           | :capacity_reject
           | :visitor_deleted
           | :visitor_reaped
+          | :visitor_share_token_minted
           | :reaper_swept
           | :upload_reaped
           | :uploads_swept
@@ -113,6 +119,20 @@ defmodule Grappa.AdminEvents.Wire do
           kind: :visitor_reaped,
           visitor_id: String.t(),
           visitor_nick: String.t() | nil,
+          at: String.t()
+        }
+
+  @typedoc """
+  #982 — an admin minted a share link that grants a session for someone
+  else's visitor identity. The actor fields are NON-nullable here, unlike
+  every other actor-bearing event: there is no system path to this verb.
+  """
+  @type visitor_share_token_minted_event :: %{
+          kind: :visitor_share_token_minted,
+          visitor_id: String.t(),
+          visitor_nick: String.t() | nil,
+          actor_user_id: String.t(),
+          actor_user_name: String.t(),
           at: String.t()
         }
 
@@ -417,6 +437,7 @@ defmodule Grappa.AdminEvents.Wire do
           | capacity_reject_event()
           | visitor_deleted_event()
           | visitor_reaped_event()
+          | visitor_share_token_minted_event()
           | reaper_swept_event()
           | upload_reaped_event()
           | uploads_swept_event()
@@ -509,6 +530,28 @@ defmodule Grappa.AdminEvents.Wire do
 
     %{
       kind: :visitor_deleted,
+      visitor_id: visitor_id,
+      visitor_nick: visitor_nick,
+      actor_user_id: actor_user_id,
+      actor_user_name: actor_user_name,
+      at: now()
+    }
+  end
+
+  @doc false
+  @spec visitor_share_token_minted(String.t(), String.t() | nil, String.t(), String.t()) ::
+          visitor_share_token_minted_event()
+  def visitor_share_token_minted(visitor_id, visitor_nick, actor_user_id, actor_user_name)
+      when is_binary(visitor_id) and (is_binary(visitor_nick) or is_nil(visitor_nick)) and
+             is_binary(actor_user_id) and is_binary(actor_user_name) do
+    # Deliberately NOT `validate_actor/2`: that helper permits the
+    # both-nil system shape, which is right for events the reaper and
+    # `bin/grappa` also raise. This verb exists only behind
+    # `:admin_authn`, so a nil actor is not a system path — it is an
+    # unattributed session grant, which is the single thing this event
+    # was added to make impossible to miss. The guard refuses it.
+    %{
+      kind: :visitor_share_token_minted,
       visitor_id: visitor_id,
       visitor_nick: visitor_nick,
       actor_user_id: actor_user_id,

--- a/lib/grappa/networks/credentials.ex
+++ b/lib/grappa/networks/credentials.ex
@@ -491,6 +491,42 @@ defmodule Grappa.Networks.Credentials do
   end
 
   @doc """
+  The visitor identity's display LABEL — the anchor credential's nick,
+  or `nil` when the identity holds no credential (or holds one with no
+  nick yet).
+
+  Every operator-facing surface that names a visitor without a network
+  in hand needs this, and before #982 each derived it inline: the
+  `:visitor_deleted` event (`Grappa.Operator`), the `:visitor_reaped`
+  event (`Grappa.Visitors.Reaper`), and the published-theme author
+  snapshot (`Grappa.Themes`). Adding a fourth caller (the #982 admin
+  share-token mint) is what forced the extraction.
+
+  It lives HERE and not in `Grappa.Visitors` for two reasons, the second
+  structural: #211 phase 7 moved the nick off the visitor row onto the
+  per-network credential, so the credential context owns it; and
+  `Grappa.Visitors` already deps on `Grappa.Themes`, so a helper over
+  there could never be reached from `Themes` without inverting that edge
+  into a cycle. `Grappa.Networks` is the one boundary all four callers
+  already depend on.
+
+  Callers keep their own absent-nick handling — the events render `nil`
+  as the id, the theme snapshot leaves the changeset untouched so the
+  wire falls back to the guest label. Shared derivation, per-caller
+  consequence.
+
+  Raw as stored, NOT ASCII-folded: a display label, not a fold-MATCH
+  site (consistent with the raw-cased members map / `state.nick`).
+  """
+  @spec representative_visitor_nick(Ecto.UUID.t()) :: String.t() | nil
+  def representative_visitor_nick(visitor_id) when is_binary(visitor_id) do
+    case representative_visitor_credential(visitor_id) do
+      {:ok, %Credential{nick: nick}} -> nick
+      {:error, :not_found} -> nil
+    end
+  end
+
+  @doc """
   #481 — the USER twin of `representative_visitor_credential/1`: the
   identity-anchor credential (lowest `network_id`) a user already holds,
   used to SEED a self-serve network accretion so a new network starts on

--- a/lib/grappa/operator.ex
+++ b/lib/grappa/operator.ex
@@ -262,20 +262,8 @@ defmodule Grappa.Operator do
   @spec emit_visitor_deleted(Visitor.t(), actor()) :: :ok
   defp emit_visitor_deleted(%Visitor{} = v, actor) do
     {actor_id, actor_name} = unpack_actor(actor)
-    AdminEvents.record(AdminWire.visitor_deleted(v.id, visitor_nick(v), actor_id, actor_name))
-  end
-
-  # #211 phase 7 — the visitor's display nick lives per-network on the
-  # credential now (the `visitors.nick` scalar is dropped). For an
-  # identity-wide label (delete event, operator log) use the representative
-  # (identity-anchor) credential's nick; `nil` when the identity holds no
-  # credential (a fresh/mangled row).
-  @spec visitor_nick(Visitor.t()) :: String.t() | nil
-  defp visitor_nick(%Visitor{id: id}) do
-    case Credentials.representative_visitor_credential(id) do
-      {:ok, %Credential{nick: nick}} -> nick
-      {:error, :not_found} -> nil
-    end
+    nick = Credentials.representative_visitor_nick(v.id)
+    AdminEvents.record(AdminWire.visitor_deleted(v.id, nick, actor_id, actor_name))
   end
 
   # #211 phase 7 — a visitor is multi-network; its nick lives per-network on
@@ -290,8 +278,8 @@ defmodule Grappa.Operator do
     :ok
   end
 
-  defp log_delete_outcome(id, visitor, :ok) do
-    IO.puts("deleted visitor #{id} (#{visitor_nick(visitor)})")
+  defp log_delete_outcome(id, %Visitor{id: visitor_id}, :ok) do
+    IO.puts("deleted visitor #{id} (#{Credentials.representative_visitor_nick(visitor_id)})")
     :ok
   end
 

--- a/lib/grappa/themes.ex
+++ b/lib/grappa/themes.ex
@@ -454,7 +454,7 @@ defmodule Grappa.Themes do
   # A STORED snapshot, NOT a live lookup: visitors are reaped, and a reaped
   # visitor's published theme re-homes to the system user (`visitor_id` → nil),
   # so the author label must not depend on the visitor still existing. Derived
-  # from the credential anchor (`Networks.Credentials.representative_visitor_credential/1`,
+  # from the credential anchor (`Networks.Credentials.representative_visitor_nick/1`,
   # the same identity nick the subject wire + admin tab show), NOT the caller
   # subject (an admin may publish another subject's theme) and NOT the Visitor
   # row (#211 phase 7 dropped the row's nick — it lives per-network on the
@@ -465,12 +465,9 @@ defmodule Grappa.Themes do
   # untouched so the wire falls back to the guest label.
   defp maybe_snapshot_author_nick(changeset, %Theme{visitor_id: visitor_id}, true)
        when is_binary(visitor_id) do
-    case Credentials.representative_visitor_credential(visitor_id) do
-      {:ok, %{nick: nick}} when is_binary(nick) ->
-        Ecto.Changeset.change(changeset, author_nick: nick)
-
-      _ ->
-        changeset
+    case Credentials.representative_visitor_nick(visitor_id) do
+      nick when is_binary(nick) -> Ecto.Changeset.change(changeset, author_nick: nick)
+      nil -> changeset
     end
   end
 

--- a/lib/grappa/visitors/reaper.ex
+++ b/lib/grappa/visitors/reaper.ex
@@ -146,15 +146,10 @@ defmodule Grappa.Visitors.Reaper do
   end
 
   # Representative (identity-anchor) nick for the reap event label, read
-  # before the delete cascades the credentials. `nil` for a credential-less
-  # identity.
+  # before the delete cascades the credentials away.
   @spec reaped_nick(Visitors.Visitor.t()) :: String.t() | nil
-  defp reaped_nick(%Visitors.Visitor{id: id}) do
-    case Credentials.representative_visitor_credential(id) do
-      {:ok, %Credential{nick: nick}} -> nick
-      {:error, :not_found} -> nil
-    end
-  end
+  defp reaped_nick(%Visitors.Visitor{id: id}),
+    do: Credentials.representative_visitor_nick(id)
 
   # #590 — `Visitors.delete/1` can now degrade a sustained SQLITE_BUSY to
   # `{:error, :db_unavailable}`; the sweep's per-row `{:error, reason}` arm logs

--- a/lib/grappa_web/controllers/admin/visitors_controller.ex
+++ b/lib/grappa_web/controllers/admin/visitors_controller.ex
@@ -23,12 +23,40 @@ defmodule GrappaWeb.Admin.VisitorsController do
 
   Returns `204 No Content` on success; `404 not_found` on unknown id
   (typed via `FallbackController`).
+
+  ## POST /admin/visitors/:id/share-token (#982) — the let-them-back-in verb
+
+  A visitor has no password: the browser session IS the identity. Lose
+  the device, wipe the profile, drop the cookie, and the account is
+  unreachable — the only operator tool before this was `DELETE`, which
+  throws the session away rather than returning it.
+
+  This mints the SAME token `POST /me/share-token` mints, through the
+  same `GrappaWeb.ShareToken`, redeemed by the same unchanged
+  `POST /auth/share/consume`. The operator hands the resulting link to
+  the person who lost access.
+
+  **The capability is abusable by an admin and that was accepted
+  deliberately** by the project owner, on the grounds that a
+  passwordless identity has no other recovery path (issue #982; the
+  reasoning is in `docs/DESIGN_NOTES.md`). What this code owes in
+  return is making the abuse VISIBLE, not preventing it: every mint
+  records a `:visitor_share_token_minted` admin event naming the
+  acting admin, and emits telemetry distinct from the visitor-side
+  mint so "did an operator do this?" stays answerable.
+
+  Incognito visitors are refused 403, exactly as the visitor-side mint
+  refuses them (#363). Returns `200` + `{token, expires_at}`;
+  `403 forbidden` for incognito; `404 not_found` for an unknown id.
   """
   use GrappaWeb, :controller
 
-  alias Grappa.{Operator, Visitors}
-  alias Grappa.Visitors.AdminWire
+  alias Grappa.{AdminEvents, Operator, Visitors}
+  alias Grappa.AdminEvents.Wire, as: EventsWire
+  alias Grappa.Networks.Credentials
+  alias Grappa.Visitors.{AdminWire, Visitor}
   alias GrappaWeb.Admin.AuthPlug
+  alias GrappaWeb.ShareToken
 
   @doc """
   List every visitor row joined to its live `Session.Server`
@@ -56,4 +84,59 @@ defmodule GrappaWeb.Admin.VisitorsController do
       send_resp(conn, :no_content, "")
     end
   end
+
+  @doc """
+  Mint a share link for a visitor who can no longer authenticate as
+  themselves (#982). Returns `200` + `{token, expires_at}`; wrapping it
+  into `https://<host>/#/share/<token>` stays the client's job, as on
+  the visitor-side mint.
+
+  Refuses an incognito visitor with 403 (#363) and an unknown id with
+  404, the same 404 the `DELETE` verb returns.
+  """
+  @spec share_token(Plug.Conn.t(), map()) ::
+          Plug.Conn.t() | {:error, :not_found | :forbidden}
+  def share_token(conn, %{"id" => id}) when is_binary(id) do
+    with {:ok, visitor} <- fetch_visitor(id),
+         :ok <- refuse_incognito(visitor) do
+      {token, expires_at} = ShareToken.mint(visitor.id)
+      {actor_id, actor_name} = AuthPlug.actor_from_conn(conn)
+
+      # Distinct from the visitor-side `[:grappa, :visitor, :share_token,
+      # :minted]` on purpose: folding both into one event would make
+      # "was this grant operator-issued?" unanswerable from telemetry.
+      :telemetry.execute(
+        [:grappa, :admin, :visitor, :share_token, :minted],
+        %{count: 1},
+        %{visitor_id: visitor.id, actor_user_id: actor_id}
+      )
+
+      AdminEvents.record(
+        EventsWire.visitor_share_token_minted(
+          visitor.id,
+          Credentials.representative_visitor_nick(visitor.id),
+          actor_id,
+          actor_name
+        )
+      )
+
+      json(conn, %{token: token, expires_at: DateTime.to_iso8601(expires_at)})
+    end
+  end
+
+  @spec fetch_visitor(Ecto.UUID.t()) :: {:ok, Visitor.t()} | {:error, :not_found}
+  defp fetch_visitor(id) do
+    case Visitors.get(id) do
+      %Visitor{} = visitor -> {:ok, visitor}
+      nil -> {:error, :not_found}
+    end
+  end
+
+  # #363 — an incognito session is deliberately non-portable, and the
+  # visitor-side mint closes this door already. Refusing in only ONE of
+  # the two doors would undo a product decision through the back
+  # entrance, so the gate is repeated per caller rather than assumed.
+  @spec refuse_incognito(Visitor.t()) :: :ok | {:error, :forbidden}
+  defp refuse_incognito(%Visitor{incognito: true}), do: {:error, :forbidden}
+  defp refuse_incognito(%Visitor{}), do: :ok
 end

--- a/lib/grappa_web/controllers/share_token_controller.ex
+++ b/lib/grappa_web/controllers/share_token_controller.ex
@@ -20,6 +20,13 @@ defmodule GrappaWeb.ShareTokenController do
   second device is the precise gap this flow closes — visitors have no
   password, so the link IS the auth mechanism.
 
+  Since #982 this is no longer the ONLY mint: an admin can mint the
+  same token for a locked-out visitor via `POST
+  /admin/visitors/:id/share-token`. The consume below stays the single
+  redeem surface for both origins, and both mints go through
+  `GrappaWeb.ShareToken` — see that module for why the salt and TTL
+  cannot live in a controller any more.
+
   ## Why Phoenix.Token + ETS (no DB)
 
   Threat model is benign (operator clicks own link twice). Short TTL
@@ -50,18 +57,7 @@ defmodule GrappaWeb.ShareTokenController do
   alias Grappa.Networks.Credentials
   alias Grappa.Visitors.{ShareTokens, Visitor}
   alias Grappa.Visitors.Wire, as: VisitorsWire
-  alias GrappaWeb.RemoteIP
-
-  @salt "visitor-share-v1"
-  @max_age_seconds 600
-
-  @doc false
-  @spec salt() :: String.t()
-  def salt, do: @salt
-
-  @doc false
-  @spec max_age_seconds() :: unquote(@max_age_seconds)
-  def max_age_seconds, do: @max_age_seconds
+  alias GrappaWeb.{RemoteIP, ShareToken}
 
   @doc """
   `POST /me/share-token` — visitor-only mint.
@@ -89,8 +85,7 @@ defmodule GrappaWeb.ShareTokenController do
         {:error, :forbidden}
 
       {:visitor, %Visitor{id: visitor_id}} ->
-        token = Phoenix.Token.sign(GrappaWeb.Endpoint, @salt, visitor_id)
-        expires_at = DateTime.add(DateTime.utc_now(), @max_age_seconds, :second)
+        {token, expires_at} = ShareToken.mint(visitor_id)
 
         :telemetry.execute(
           [:grappa, :visitor, :share_token, :minted],
@@ -150,7 +145,7 @@ defmodule GrappaWeb.ShareTokenController do
              | :db_unavailable
              | Ecto.Changeset.t()}
   def consume(conn, %{"token" => token}) when is_binary(token) and token != "" do
-    with {:ok, visitor_id} <- verify_token(token),
+    with {:ok, visitor_id} <- ShareToken.verify(token),
          :ok <- mark_consumed(token) do
       # The one-shot claim is now HELD by this request (mark_consumed
       # returned :ok — we won any race). #593 — every failure past this
@@ -233,17 +228,6 @@ defmodule GrappaWeb.ShareTokenController do
     )
 
     {:error, reason}
-  end
-
-  @spec verify_token(String.t()) ::
-          {:ok, Ecto.UUID.t()}
-          | {:error, :unauthorized | :share_token_expired}
-  defp verify_token(token) do
-    case Phoenix.Token.verify(GrappaWeb.Endpoint, @salt, token, max_age: @max_age_seconds) do
-      {:ok, visitor_id} when is_binary(visitor_id) -> {:ok, visitor_id}
-      {:error, :expired} -> {:error, :share_token_expired}
-      {:error, _} -> {:error, :unauthorized}
-    end
   end
 
   # Translates `ShareTokens.mark_consumed/1`'s `{:error,

--- a/lib/grappa_web/router.ex
+++ b/lib/grappa_web/router.ex
@@ -117,6 +117,10 @@ defmodule GrappaWeb.Router do
     get "/me", MeController, :index
     get "/visitors", VisitorsController, :index
     delete "/visitors/:id", VisitorsController, :delete
+    # #982 — recovery door for a locked-out visitor. Mints the SAME
+    # token `POST /me/share-token` does; `/auth/share/consume` stays the
+    # only redeem surface.
+    post "/visitors/:id/share-token", VisitorsController, :share_token
     get "/sessions", SessionsController, :index
     post "/sessions/:id/disconnect", SessionsController, :disconnect
     # #269 — Reconnect half of the admin Visitors-tab toggle (visitor-only).

--- a/lib/grappa_web/share_token.ex
+++ b/lib/grappa_web/share_token.ex
@@ -1,0 +1,85 @@
+defmodule GrappaWeb.ShareToken do
+  @moduledoc """
+  The visitor share-link token itself: salt, TTL, signing, verification.
+
+  ## Why this is a module and not two copies
+
+  TWO doors mint this token — `POST /me/share-token`
+  (`GrappaWeb.ShareTokenController`, the visitor's own device-to-device
+  share) and `POST /admin/visitors/:id/share-token`
+  (`GrappaWeb.Admin.VisitorsController`, #982's recovery door for a
+  visitor who lost access and, having no password, cannot mint their
+  own). ONE door redeems it: `POST /auth/share/consume`.
+
+  A second `Phoenix.Token.sign/3` call site carrying its own copy of the
+  salt and the TTL would be two secrets that agree only by inspection —
+  and the failure is silent in the worst direction: the mint keeps
+  returning 200 with a token the consume endpoint rejects, so the
+  operator hands out a dead link and the locked-out visitor stays
+  locked out. Signing and verification live together here so a change
+  to either constant moves both doors at once.
+
+  ## Why `Phoenix.Token` and not the DB
+
+  Unchanged from the original design: the threat model is benign, the
+  TTL is short (10 min), and the one-shot ledger
+  (`Grappa.Visitors.ShareTokens`) is ETS, so losing it on a BEAM
+  restart opens at most a TTL-bounded reuse window for tokens already
+  signed. Zero migrations, HOT-deploy friendly.
+
+  #982 does NOT widen either constant. Ten minutes and single use are
+  what keep a leaked link from being a standing key, and the admin door
+  hands the link to a third party over some channel the server cannot
+  see — the exact case the short TTL is for.
+  """
+
+  @salt "visitor-share-v1"
+  @max_age_seconds 600
+
+  @doc """
+  The `Phoenix.Token` salt. Public so tests assert against the real
+  value rather than re-declaring it.
+  """
+  @spec salt() :: String.t()
+  def salt, do: @salt
+
+  @doc """
+  Token lifetime in seconds — the same number the mint reports as
+  `expires_at` and the consume enforces as `max_age`.
+  """
+  @spec max_age_seconds() :: unquote(@max_age_seconds)
+  def max_age_seconds, do: @max_age_seconds
+
+  @doc """
+  Sign a token for `visitor_id`. Returns `{token, expires_at}`, where
+  `expires_at` is the absolute UTC instant at which `verify/1` starts
+  refusing it — cic renders the countdown from it.
+
+  Cannot fail: `Phoenix.Token.sign/3` is pure over the endpoint's
+  secret. Both doors therefore have nothing to roll back at this step.
+  """
+  @spec mint(Ecto.UUID.t()) :: {String.t(), DateTime.t()}
+  def mint(visitor_id) when is_binary(visitor_id) do
+    token = Phoenix.Token.sign(GrappaWeb.Endpoint, @salt, visitor_id)
+    {token, DateTime.add(DateTime.utc_now(), @max_age_seconds, :second)}
+  end
+
+  @doc """
+  Verify a token and recover the visitor id it was signed for.
+
+  The two failure atoms are already wire-shaped for
+  `GrappaWeb.FallbackController`: `:share_token_expired` → 410 Gone (the
+  link was real and ran out), `:unauthorized` → 401 (the signature does
+  not hold). Keeping them distinct is what lets cic tell "ask for a new
+  link" apart from "this link is not ours".
+  """
+  @spec verify(String.t()) ::
+          {:ok, Ecto.UUID.t()} | {:error, :unauthorized | :share_token_expired}
+  def verify(token) when is_binary(token) do
+    case Phoenix.Token.verify(GrappaWeb.Endpoint, @salt, token, max_age: @max_age_seconds) do
+      {:ok, visitor_id} when is_binary(visitor_id) -> {:ok, visitor_id}
+      {:error, :expired} -> {:error, :share_token_expired}
+      {:error, _} -> {:error, :unauthorized}
+    end
+  end
+end

--- a/test/grappa/admin_events/wire_test.exs
+++ b/test/grappa/admin_events/wire_test.exs
@@ -133,6 +133,34 @@ defmodule Grappa.AdminEvents.WireTest do
     end
   end
 
+  describe "visitor_share_token_minted/4 (#982)" do
+    test "renders with the acting admin" do
+      event = Wire.visitor_share_token_minted("v-uuid", "S`grappa", "u-uuid", "vjt")
+
+      assert event.kind == :visitor_share_token_minted
+      assert event.visitor_id == "v-uuid"
+      assert event.visitor_nick == "S`grappa"
+      assert event.actor_user_id == "u-uuid"
+      assert event.actor_user_name == "vjt"
+    end
+
+    test "a credential-less identity still records, with a nil nick" do
+      event = Wire.visitor_share_token_minted("v-uuid", nil, "u-uuid", "vjt")
+      assert event.visitor_nick == nil
+    end
+
+    test "refuses a nil actor — there is no system path to this verb" do
+      # Unlike `visitor_deleted/4`, which the reaper and `bin/grappa`
+      # also drive, this event can ONLY originate behind `:admin_authn`.
+      # Accepting `nil` would let an unattributed grant look legitimate
+      # in the console, which is the one thing this event exists to
+      # prevent.
+      assert_raise FunctionClauseError, fn ->
+        Wire.visitor_share_token_minted("v-uuid", "S`grappa", nil, nil)
+      end
+    end
+  end
+
   describe "visitor_reaped/2 + reaper_swept/1" do
     test "visitor_reaped" do
       event = Wire.visitor_reaped("v-uuid", "nick")

--- a/test/grappa_web/controllers/admin/visitors_controller_test.exs
+++ b/test/grappa_web/controllers/admin/visitors_controller_test.exs
@@ -29,11 +29,17 @@ defmodule GrappaWeb.Admin.VisitorsControllerTest do
   import ExUnit.CaptureIO
   import Grappa.AuthFixtures
 
-  alias Grappa.{Accounts, AdmissionStateHelpers, Repo, Session}
+  alias Grappa.{Accounts, AdminEvents, AdmissionStateHelpers, Repo, Session}
   alias Grappa.Visitors.Visitor
+  alias GrappaWeb.ShareToken
 
   setup do
     AdmissionStateHelpers.reset_all()
+    # #982 — the share-token mint records an admin event. Emptying the
+    # ring buffer here lets the refusal cases assert NOTHING was
+    # recorded, which is the half of "incognito is refused" that a
+    # status-code assertion alone cannot see.
+    :sys.replace_state(AdminEvents, fn _ -> %AdminEvents{buffer: []} end)
     :ok
   end
 
@@ -206,6 +212,188 @@ defmodule GrappaWeb.Admin.VisitorsControllerTest do
       assert net["live_state"] == nil
       refute Map.has_key?(net, "password_encrypted")
       refute Map.has_key?(row, "password_encrypted")
+    end
+  end
+
+  describe "POST /admin/visitors/:id/share-token — auth gate (#982)" do
+    test "no bearer returns 401 (Authn upstream)", %{conn: conn} do
+      conn = post(conn, "/admin/visitors/#{Ecto.UUID.generate()}/share-token")
+      assert json_response(conn, 401) == %{"error" => "unauthorized"}
+    end
+
+    test "visitor subject returns 403 from the plug, not the action", %{conn: conn} do
+      # The refusal must come from `:admin_authn`, so it lands even for
+      # an id that exists — the action never runs and nothing is minted.
+      target = visitor_fixture()
+      {_, session} = visitor_and_session()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> post("/admin/visitors/#{target.id}/share-token")
+
+      assert json_response(conn, 403) == %{"error" => "forbidden"}
+      assert AdminEvents.snapshot() == []
+    end
+
+    test "non-admin user returns 403 from the plug, not the action", %{conn: conn} do
+      target = visitor_fixture()
+      {_, session} = user_and_session()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> post("/admin/visitors/#{target.id}/share-token")
+
+      assert json_response(conn, 403) == %{"error" => "forbidden"}
+      assert AdminEvents.snapshot() == []
+    end
+  end
+
+  describe "POST /admin/visitors/:id/share-token — admin user (#982)" do
+    test "200 + a token the shared verifier accepts for that visitor", %{conn: conn} do
+      visitor = visitor_fixture()
+      session = admin_session()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> post("/admin/visitors/#{visitor.id}/share-token")
+
+      body = json_response(conn, 200)
+
+      # Verified through the production verifier, not a re-implemented
+      # `Phoenix.Token.verify` — a test that re-derives the salt would
+      # keep passing if the two doors drifted apart.
+      assert ShareToken.verify(body["token"]) == {:ok, visitor.id}
+
+      {:ok, expires_at, _} = DateTime.from_iso8601(body["expires_at"])
+      ttl = DateTime.diff(expires_at, DateTime.utc_now())
+      assert ttl > ShareToken.max_age_seconds() - 30
+      assert ttl <= ShareToken.max_age_seconds()
+    end
+
+    test "the minted token redeems at /auth/share/consume for the SAME visitor", %{conn: conn} do
+      # The point of the whole issue: ONE redeem surface. If the admin
+      # door minted a token the visitor-side consume did not accept,
+      # every other assertion here could still pass.
+      visitor = visitor_fixture()
+      session = admin_session()
+
+      minted =
+        conn
+        |> put_bearer(session.id)
+        |> post("/admin/visitors/#{visitor.id}/share-token")
+        |> json_response(200)
+
+      consumed =
+        build_conn()
+        |> post("/auth/share/consume", %{"token" => minted["token"]})
+        |> json_response(200)
+
+      assert consumed["subject"]["kind"] == "visitor"
+      assert consumed["subject"]["id"] == visitor.id
+      assert is_binary(consumed["token"])
+      assert consumed["token"] != ""
+    end
+
+    test "the admin-minted token is one-shot like the visitor-minted one", %{conn: conn} do
+      visitor = visitor_fixture()
+      session = admin_session()
+
+      minted =
+        conn
+        |> put_bearer(session.id)
+        |> post("/admin/visitors/#{visitor.id}/share-token")
+        |> json_response(200)
+
+      assert build_conn()
+             |> post("/auth/share/consume", %{"token" => minted["token"]})
+             |> json_response(200)
+
+      assert build_conn()
+             |> post("/auth/share/consume", %{"token" => minted["token"]})
+             |> json_response(410) == %{"error" => "share_token_consumed"}
+    end
+
+    test "incognito visitor is refused 403 and nothing is minted", %{conn: conn} do
+      # #363 — an incognito session is deliberately non-portable. The
+      # visitor-side mint refuses it; an admin door that skipped the
+      # check would undo the product decision through the back entrance.
+      visitor = visitor_fixture(incognito: true)
+      session = admin_session()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> post("/admin/visitors/#{visitor.id}/share-token")
+
+      assert json_response(conn, 403) == %{"error" => "forbidden"}
+      assert AdminEvents.snapshot() == []
+    end
+
+    test "unknown id is 404, like the DELETE verb", %{conn: conn} do
+      session = admin_session()
+
+      conn =
+        conn
+        |> put_bearer(session.id)
+        |> post("/admin/visitors/#{Ecto.UUID.generate()}/share-token")
+
+      assert json_response(conn, 404) == %{"error" => "not_found"}
+      assert AdminEvents.snapshot() == []
+    end
+
+    test "records a visitor_share_token_minted event naming the acting admin", %{conn: conn} do
+      slug = "az-#{System.unique_integer([:positive])}"
+      {:ok, _} = Grappa.Networks.find_or_create_network(%{slug: slug})
+      nick = "ghost-#{System.unique_integer([:positive])}"
+      visitor = visitor_fixture(network_slug: slug, nick: nick)
+
+      {user, session} = user_and_session()
+      {:ok, admin} = Accounts.update_admin_flags(user, %{is_admin: true})
+
+      conn
+      |> put_bearer(session.id)
+      |> post("/admin/visitors/#{visitor.id}/share-token")
+      |> json_response(200)
+
+      assert [event] = AdminEvents.snapshot()
+      assert event.kind == :visitor_share_token_minted
+      assert event.visitor_id == visitor.id
+      assert event.visitor_nick == nick
+      assert event.actor_user_id == admin.id
+      assert event.actor_user_name == admin.name
+    end
+
+    test "emits admin-distinct telemetry, not the visitor-side mint event", %{conn: conn} do
+      # Mitigation 3 of the issue: folding both mints into one event
+      # makes "did an operator do this?" unanswerable from telemetry.
+      visitor = visitor_fixture()
+      session = admin_session()
+      parent = self()
+      handler = "admin-share-token-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach_many(
+        handler,
+        [
+          [:grappa, :admin, :visitor, :share_token, :minted],
+          [:grappa, :visitor, :share_token, :minted]
+        ],
+        fn name, _, meta, _ -> send(parent, {:telemetry, name, meta}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+
+      conn
+      |> put_bearer(session.id)
+      |> post("/admin/visitors/#{visitor.id}/share-token")
+      |> json_response(200)
+
+      assert_received {:telemetry, [:grappa, :admin, :visitor, :share_token, :minted], meta}
+      assert meta.visitor_id == visitor.id
+      refute_received {:telemetry, [:grappa, :visitor, :share_token, :minted], _}
     end
   end
 end

--- a/test/grappa_web/controllers/share_token_controller_test.exs
+++ b/test/grappa_web/controllers/share_token_controller_test.exs
@@ -33,9 +33,13 @@ defmodule GrappaWeb.ShareTokenControllerTest do
 
   alias Grappa.Repo.BusyRetry
   alias Grappa.Visitors.ShareTokens
+  alias GrappaWeb.ShareToken
 
-  @max_age_seconds 600
-  @salt "visitor-share-v1"
+  # #982 — read from the production module rather than re-declared here.
+  # Two doors mint this token now; a test carrying its own copy of the
+  # salt would stay green through a drift that breaks both of them.
+  @max_age_seconds ShareToken.max_age_seconds()
+  @salt ShareToken.salt()
 
   describe "POST /me/share-token — mint" do
     test "visitor subject returns 200 + signed token + expires_at", %{conn: conn} do


### PR DESCRIPTION
Admin-side mint of the visitor share token, so an operator can let a locked-out
visitor back in. Issue #982.

## The gap

A visitor has no password — the browser session IS the identity. Lose the
device, wipe the profile, drop the cookie, and the account is unreachable:
there is no credential to re-issue and nothing to reset. The recovery machinery
already existed (`POST /me/share-token` mints, `POST /auth/share/consume`
redeems), but the mint authenticates the caller *as the visitor* — precisely
what a locked-out visitor cannot do. The only operator tool was
`DELETE /admin/visitors/:id`, which throws the session away rather than
returning it.

## What lands

`POST /admin/visitors/:id/share-token`, in `GrappaWeb.Admin.VisitorsController`,
under the existing `:api + :authn + :admin_authn` scope. No per-controller
checks: `:admin_authn` is the gate. Response mirrors the visitor side —
`{token, expires_at}`; wrapping into `https://<host>/#/share/<token>` stays the
client's job.

It mints **the same token**: both doors now go through the new
`GrappaWeb.ShareToken` (salt, TTL, `mint/1`, `verify/1`), and
`/auth/share/consume` is untouched as the single redeem surface. A second
`Phoenix.Token.sign` site with its own copy of the salt fails in the worst
direction — the mint keeps answering 200 while consume rejects, so the operator
hands out a dead link and nobody sees an error. The controller-level `salt/0` /
`max_age_seconds/0` accessors this replaces had **zero callers**; the test file
re-declared both literals, which is the drift the shared module removes.

TTL (600s) and one-shot are unchanged.

## The accepted abuse, and what pays for it

An admin can mint a session grant for someone else's identity. vjt accepted
this explicitly — the alternative for a passwordless identity is *no* recovery
path. So the code owes visibility, not prevention:

- every mint records `:visitor_share_token_minted` naming the acting admin;
- telemetry is `[:grappa, :admin, :visitor, :share_token, :minted]`,
  deliberately **not** folded into the visitor-side event, or "did an operator
  do this?" stops being answerable;
- that event's actor fields are the **only non-nullable** ones in
  `AdminEvents.Wire`. Every other actor-bearing event has a real system path
  (reaper, `bin/grappa`); this verb is reachable only behind `:admin_authn`, so
  `nil` is not "the system did it" — it is an unattributed grant. The
  constructor's guard refuses it; cic's narrower drops the shape to `null`.

## The one not to get wrong

Incognito visitors are refused 403 at **both** doors (#363). The gate is
re-stated in the admin action rather than assumed — a check applied at one of
two callers is how a product decision gets undone through the back entrance.

## Carried in: the representative-nick derivation

The event carries `visitor_nick` so the console names a person, not a UUID.
That derivation was already inline in four places (`Operator` ×2, `Reaper`,
`Themes`); a fifth copy was not acceptable, so it is now
`Credentials.representative_visitor_nick/1`. It lives in `Credentials` for a
structural reason, not a stylistic one: `Grappa.Visitors` already deps on
`Grappa.Themes`, so a helper in `Visitors` could never be reached from `Themes`
without inverting that edge into a Boundary cycle. `Grappa.Networks` is the one
boundary all callers already share. Each caller keeps its own absent-nick
consequence — the events render `nil` as the id, `Themes` leaves the changeset
alone so the wire falls back to the guest label.

## Verification

- `scripts/check.sh` — **rc=0**, `8 doctests, 56 properties, 5455 tests, 0 failures`;
  `git status --porcelain` empty before and after.
- `scripts/bun.sh run check` — **rc=0** (biome + tsc; tsc is the real gate here,
  three exhaustive `assertNever` switches grew an arm).
- `scripts/bun.sh run test` — **4579 cic tests green**.
- **6 mutants injected, 6 killed** (injector aborts unless it matches exactly
  once; committed before the run):
  1. incognito gate neutered → 1 red
  2. wire constructor accepts a nil actor → 1 red
  3. admin door mints with a private salt → **3 red** (verify, consume,
     one-shot — the "one redeem surface" claim)
  4. audit record dropped → 1 red
  5. telemetry folded into the visitor-side event → 1 red
  6. cic narrower stops requiring an actor → 1 red

## Not claimed

- **No e2e, and no empty spec written instead.** There is no cic control that
  calls this endpoint, so the outcome is not client-visible and there is
  nothing for a browser to drive. Whether the admin console grows the button is
  a separate unit.
- The `AdminEventsTab` row is covered by cic unit tests only; it has not been
  seen rendered in a browser.
