### PR TITLE
union(#1008 + #546): land the composer autocorrect fix and the peer-NOTICE routing together

### DIFF
--- a/cicchetto/e2e/tests/issue546-peer-notice-no-query-window.spec.ts
+++ b/cicchetto/e2e/tests/issue546-peer-notice-no-query-window.spec.ts
@@ -1,0 +1,123 @@
+// #546 — a NOTICE from a plain peer must NOT open a query window.
+//
+// Azzurra staff (morph, Sonic, Mezmerize, Hypnotize — #it-opers 2026-07-30)
+// asked grappa to follow the irssi/HexChat convention:
+//
+//   query window already open → the query.  Otherwise → the status window.
+//
+// Until #546 a peer NOTICE persisted at `channel = sender`, which the
+// server-side auto-open (#422) then turned into a sidebar tab — Azzurra's
+// welcome notice is sent from a USER, not a service, so every operator got a
+// stray tab on connect. This reverses UX-6-L (2026-05-20) / #422 Option B for
+// the NOTICE arm only; an inbound PRIVMSG still opens the conversation.
+//
+// Why e2e and not just ExUnit: the VISIBLE outcome is a sidebar tab that must
+// not appear, and its appearance is a three-hop consequence (route → persist →
+// `query_windows_list` fan-out → sidebar projection) that jsdom cannot stage.
+// Per feedback_ux_e2e_mandatory.
+//
+// The negative assertion is GATED on a positive barrier: the notice must first
+// be observed on `$server`. Without that gate, "no tab appeared" would pass on
+// a session that never processed the line at all — a green that proves nothing.
+
+import { expect, test } from "../fixtures/test";
+import {
+  composeSend,
+  composeTextarea,
+  loginAs,
+  scrollbackLine,
+  selectChannel,
+  sidebarWindow,
+} from "../fixtures/cicchettoPage";
+import { assertMessagePersisted } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Fresh nick per run/retry: a fixed one is a 433/ghost time bomb under CI
+// rerun + bahamut per-IP clone limits (the #600 red), and a leftover
+// `query_windows` row from a prior run would pre-open the very window test 1
+// asserts is absent — the spec would fail for a reason that is not the code.
+const peerNick = (): string => `n546-${crypto.randomUUID().slice(0, 5)}`;
+
+test("#546 — a peer NOTICE with no open query window opens NO tab and lands in $server", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+  await expect(composeTextarea(page)).toBeVisible();
+
+  const nick = peerNick();
+  const body = `unsolicited heads up ${nick}`;
+  const peer = await IrcPeer.connect({ nick });
+  try {
+    // Pre-condition: no window for this peer (fresh nick, so this is a
+    // statement about the fixture, not about the fix).
+    await expect(sidebarWindow(page, NETWORK_SLUG, nick)).toHaveCount(0);
+
+    peer.notice(NETWORK_NICK, body);
+
+    // BARRIER — server-side proof the notice arrived AND where it was routed.
+    // Pre-#546 this timed out: the row went to a query window keyed on `nick`.
+    await assertMessagePersisted({
+      token: vjt.token,
+      networkSlug: NETWORK_SLUG,
+      channel: "$server",
+      sender: nick,
+      body,
+      kind: "notice",
+    });
+
+    // The visible outcome: still no tab for the peer. The barrier above makes
+    // this a claim about routing rather than about timing.
+    await expect(sidebarWindow(page, NETWORK_SLUG, nick)).toHaveCount(0);
+
+    // ...and the row is readable where it went — the $server window.
+    await selectChannel(page, NETWORK_SLUG, "$server", { awaitWsReady: false });
+    await expect(scrollbackLine(page, "notice", body)).toBeVisible({ timeout: 10_000 });
+  } finally {
+    await peer.disconnect("#546 no-tab done");
+  }
+});
+
+test("#546 — a peer NOTICE lands in the query window when it is already open", async ({ page }) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+  await expect(composeTextarea(page)).toBeVisible();
+
+  const nick = peerNick();
+  const body = `answering your query ${nick}`;
+  const peer = await IrcPeer.connect({ nick });
+  try {
+    // `/query <nick>` is the sanctioned user-action open: cic pushes
+    // `open_query_window`, the server upserts the row and broadcasts the
+    // list back. That row IS what `query_window_open?/3` reads.
+    await composeSend(page, `/query ${nick}`);
+    await expect(sidebarWindow(page, NETWORK_SLUG, nick)).toHaveCount(1, { timeout: 10_000 });
+
+    peer.notice(NETWORK_NICK, body);
+
+    // Server-side: the row is keyed on the PEER, not `$server`.
+    await assertMessagePersisted({
+      token: vjt.token,
+      networkSlug: NETWORK_SLUG,
+      channel: nick,
+      sender: nick,
+      body,
+      kind: "notice",
+    });
+
+    // Visible: it renders inside that window.
+    await selectChannel(page, NETWORK_SLUG, nick, { awaitWsReady: false });
+    await expect(scrollbackLine(page, "notice", body)).toBeVisible({ timeout: 10_000 });
+  } finally {
+    // Bare `/query` closes the focused query window — leave the seeded user's
+    // sidebar as we found it (the row is per-user and would otherwise
+    // accumulate one dead window per run).
+    await composeSend(page, "/query").catch(() => {});
+    await peer.disconnect("#546 open-window done");
+  }
+});

--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -538,11 +538,25 @@ const ComposeBox: Component<Props> = (props) => {
           // mechanism behind it (the iOS auto-capitalisation hypothesis was
           // falsified on a real device). Correct on its own merits: with no
           // attribute WebKit applies `sentences`, and this box eats nicks,
-          // channel names and `/commands`. Same trio spelling as the other
-          // identifier inputs (PerformSettings, Login). `spellcheck` is left
-          // alone on purpose — message bodies are prose.
+          // channel names and `/commands`.
+          //
+          // #1008 — and it stops there. `autocorrect="off"` was copied in
+          // alongside it from the IDENTIFIER inputs (PerformSettings, Login,
+          // AliasSettings) and shipped in v0.13.3; on WebKit that attribute
+          // also suppresses the QuickType predictive bar, not merely the
+          // silent correction, and a reporter on #sniffo could no longer type
+          // on a phone. **This box is prose, and prose keeps its typing
+          // aids** — the same line `spellcheck` already sits on, which is why
+          // `spellcheck` is likewise left alone. Do not re-add `autocorrect`
+          // here by copying the pair from an identifier field: those fields
+          // want it, a message body does not.
+          //
+          // Accepted cost, ruled on knowingly in #1008: autocorrection may
+          // occasionally rewrite an unusual word — a bare nick typed without
+          // tab-completion among them. Being unable to type at all is worse.
+          // Having BOTH needs a contenteditable composer with mention spans
+          // marked non-correctable; that is its own issue, not a rider here.
           autocapitalize="none"
-          autocorrect="off"
           // #737 — a paced drain rewrites this draft every acked line for as
           // long as the pacing lasts. The store refuses operator writes while
           // it does (that is the real guard, and it covers the global paste

--- a/cicchetto/src/__tests__/ComposeBox.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBox.test.tsx
@@ -118,6 +118,36 @@ describe("ComposeBox", () => {
     expect(screen.getByRole("button", { name: /send/i })).toBeInTheDocument();
   });
 
+  // #1008 — the composer is PROSE, and the two attributes fall on opposite
+  // sides of that line. `autocapitalize="none"` is right and stays: with no
+  // attribute WebKit applies `sentences` and the box upper-cases nicks,
+  // channel names and `/commands`. `autocorrect="off"` was copied in beside
+  // it from the identifier inputs and shipped in v0.13.3; on WebKit it also
+  // kills the QuickType predictive bar, which made the box unusable on a
+  // phone.
+  //
+  // The composer had NO attribute guard at all before this — `6a12346e`
+  // added the pair and touched no test — so this is the first one, and it
+  // exists to stop the pair being re-copied wholesale. The identifier half
+  // of the contrast is already pinned, and deliberately stays pinned, by
+  // `Login.test.tsx`'s "keeps autocapitalize/autocorrect/spellcheck/
+  // autocomplete on the nick field".
+  //
+  // What this canNOT witness: whether the predictive bar actually appears.
+  // jsdom has no iOS text-input UI and neither does Playwright's webkit.
+  // This asserts the DOM attribute that governs it, nothing more; the
+  // acceptance criterion is a device check.
+  it("#1008 — composer keeps autocapitalize=none but carries NO autocorrect (prose, not an identifier)", () => {
+    render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+    const ta = screen.getByPlaceholderText(/message #a/i);
+
+    expect(ta).toHaveAttribute("autocapitalize", "none");
+    expect(ta.hasAttribute("autocorrect")).toBe(false);
+    // `spellcheck` is the attribute that already sat on the prose side of
+    // this line; it must not have been dragged off it either.
+    expect(ta.hasAttribute("spellcheck")).toBe(false);
+  });
+
   // UX-6 bucket F (2026-05-21) — send button reshaped: aria-label +
   // SVG paper-plane glyph (vjt iPhone-dogfood Bug 7). SVG (not a
   // Unicode codepoint) so the glyph survives Linux/Windows monospace

--- a/cicchetto/src/lib/serviceModal.ts
+++ b/cicchetto/src/lib/serviceModal.ts
@@ -36,7 +36,7 @@ export type ServiceModalTarget = {
 //
 // The server routes a services-sender NOTICE/PRIVMSG to `$server` — UNLESS the
 // operator has that service's own query window open, in which case it lands
-// THERE (#400, `EventRouter.service_route_channel/2`). Reading only `$server`
+// THERE (#400, `EventRouter.open_query_or_server/2`). Reading only `$server`
 // made the console look dead exactly for the operator who had a NickServ query
 // open: modal up, help wall piling into the query behind it, mirror empty
 // forever. The mirror is a view over wherever the notices land, so it spans

--- a/cicchetto/src/lib/subscribe.ts
+++ b/cicchetto/src/lib/subscribe.ts
@@ -723,6 +723,14 @@ moduleRoot(() => {
             // (delivered via query_windows_list); cic only re-keys + appends
             // here (pure renderer), it does NOT originate the window.
             //
+            // #546 narrowed WHAT reaches this arm, without changing it: a
+            // peer's own NOTICE no longer lands at `channel == ownNick` at
+            // all (it routes to `$server`, or to the peer's own topic when
+            // that query is already open). What still arrives here is the
+            // server-emitted CTCP-query visibility row above. No cic edit
+            // was needed for #546 precisely because this is a renderer —
+            // the routing it mirrors moved underneath it.
+            //
             // sender !== ownNick guard: don't route our OWN outbound NOTICEs
             // (they ride the topic too as fan-out echo). Service-to-self
             // NOTICEs (NickServ etc.) never hit this branch — our server

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -21374,6 +21374,12 @@ Two disjoint fixture doors close the gap, zero assertions removed:
   "cog" — `.shell-main` is the honest signal.
 ## 2026-07-28 — #422: inbound DM opens the query window SERVER-SIDE (+ leading day-separator)
 
+> **Superseded in part by #546 (2026-08-07).** The NOTICE arm of this entry no
+> longer holds: a peer NOTICE routes to `$server` unless the query is already
+> open, so it mints nothing. Everything else here — server-owned origination,
+> the `dm_with || channel` key, `dm_eligible?/1` as the sole predicate, cic as a
+> pure renderer — stands unchanged, and is in fact the mechanism #546 reuses.
+
 **The bug.** Query-window auto-open lived ONLY in the client
 (`cicchetto/src/lib/subscribe.ts` dm-listener → `openQueryWindowState`).
 `QueryWindows.open/4` had a single `lib/` call site: the `open_query_window`
@@ -32782,3 +32788,94 @@ about width still restart the pool at 5 and 10 themselves. The ceiling
 correspondingly stops binding here: 14 tests × ~80 migrations per run becomes
 14 × 3, and the file drops from 8.6s to 0.4s. The undiagnosed replay red is
 still undiagnosed — it simply no longer has a home in this test.
+---
+
+## 2026-08-07 — #546: a peer NOTICE stops opening a query window (reverses the NOTICE arm of UX-6-L / #422 Option B)
+
+**The ruling, and whose it is.** Azzurra staff (morph, Sonic, Mezmerize,
+Hypnotize — `#it-opers`, 2026-07-30) asked grappa to follow the irssi/HexChat
+convention: **query window already open → the query; otherwise → `$server`.**
+vjt queued the issue, so the ruling is made. This is NOT a bug that slipped
+through — it reverses a documented decision, which is why it needed one.
+
+**The rejected third branch, recorded on purpose.** Sonic proposed "no query
+open but a channel in common → route into the channels"; morph refused ("nei
+canali no, irssi manda in status") and Sonic conceded. It is the part most
+likely to be re-litigated by somebody who finds the two-branch rule
+surprising. It was considered and declined.
+
+**The change is one deleted branch, not a new one.** The requested behaviour
+already existed — `service_route_channel/2` (#400) has implemented exactly
+"open → the window, else `$server`" since services traffic needed it. All
+#546 does is widen which senders reach it: `route_non_channel_notice_non_chanserv/3`
+dropped its `Identifier.services_sender?/1` arm, so every nick sender takes
+the same test. The helper is renamed `open_query_or_server/2` because it is no
+longer about services. Deleting the carve-out was morph's own argument for the
+change and is the whole of it: the allowlist branch, the `$server` re-key and
+the `*Serv` handling existed **only** because the default was "notices open
+windows". Flip the default and the scaffolding is redundant — a parallel
+branch alongside the old one would have been the double structure CLAUDE.md
+forbids.
+
+**What did NOT generalise, and why the asymmetry is deliberate.** The PRIVMSG
+door still gates on the services allowlist. A peer's DM opens the
+conversation — that is what a DM is for; only NOTICEs became non-opening. So
+`Identifier.services_sender?/1` keeps exactly one job: separating "a reply from
+a robot you queried" from "somebody talking to you". The UX-4 bucket G
+regression guard (ops nicks ending in `-serv`, e.g. `Conserv`, must not be
+swallowed) MOVED to the PRIVMSG door with it — on the NOTICE door the allowlist
+no longer discriminates, so a NOTICE-shaped assertion could not tell a
+re-broadened allowlist from the general rule. A guard that cannot fail is not a
+guard.
+
+**The CTCP short-circuit stays, on a new justification.** `CTCP.framed?/1`
+sends any CTCP-framed NOTICE to `$server` (#591). Its original reason — "else
+pinging somebody leaves a tab open with a row of control characters" — is gone
+with the minting. It earns its keep on the other side of the new rule: without
+it, a peer the operator has a query OPEN with would get raw `\x01PING …\x01`
+filed into that conversation. Protocol stays out of conversations whether or
+not one is open, and a test pins it at `query_window_open? = true`.
+
+**Two things the issue asked us to assume, proven instead.**
+
+*"`query_window_open?/3` needs checking against archive state, not just row
+existence."* It does not, and it must not. `query_windows` has no `archived`
+column: `Window` carries `target_nick` + `opened_at`, `QueryWindows.close/4`
+**DELETEs** the row, and `Scrollback.list_archive/3` DERIVES the archive as
+"every target with scrollback MINUS the active keyset", whose query half
+(`ArchiveController.build_active_keyset/3` → `QueryWindows.list_for_subject/1`)
+is precisely the rows `open?/3` tests. Open and archived are **complementary by
+construction** — there is no third state. The ruling's conjunction ("open AND
+not archived") is one condition in this schema; the second is implied by the
+first. Adding an archive check would duplicate derived state (Design discipline
+1) and could only ever disagree with itself.
+
+*"The CTCP VERSION visibility row goes quiet — the one concrete regression."*
+It does not, because that row never rides the NOTICE door. It is emitted by the
+inbound-**PRIVMSG** CTCP arm, persisted at `channel = own_nick` with
+`dm_with = sender` (`Scrollback.dm_peer/4`: target == own_nick ⇒ peer =
+sender), and the auto-open keys on `dm_with || channel`. #546 touches only
+`route_non_channel_notice_non_chanserv/3`. The row survives untouched — and is
+now pinned by a `server_test.exs` case, because "it still works" is a claim
+about a path this change does not visit, and without a pin nobody learns when
+it stops being true. Whether a CTCP *query* should mint a window at all is a
+separate question about the PRIVMSG door that morph and Sonic's ruling does not
+settle; it was left alone rather than widened in silently.
+
+**cic needed no edit, and that is #422 Option B paying out.** The dm-listener
+dropped its `openQueryWindowState` calls when the server took over origination,
+so it is a pure renderer: the routing moved underneath it and it rendered the
+new destination without knowing. #546 only narrowed what reaches its
+own-nick NOTICE arm (now just the server-emitted CTCP visibility row); the
+comment there says so rather than leaving the next reader to derive it.
+
+**Test shape.** Classifier-level: both arms of the rule, the absent-callback
+default (`$server` — the reversal must hold on the production path, not only
+when a stub says `false`), the predicate's three arguments, and a PRIVMSG case
+proving the change did not leak doors. Full-stack: the reversal is asserted
+with a **positive barrier first** — the row must be observed arriving on
+`$server` before "no query window" is refuted, because a bare `refute_receive`
+would pass just as well on a session that never processed the line.
+`e2e/tests/issue546-peer-notice-no-query-window.spec.ts` drives the visible
+outcome against a real peer: the tab that must not appear, and the window the
+notice lands in when it is already open.

--- a/lib/grappa/irc/ctcp.ex
+++ b/lib/grappa/irc/ctcp.ex
@@ -42,9 +42,11 @@ defmodule Grappa.IRC.CTCP do
   this asks the complement: "is this protocol rather than something
   somebody said". A CTCP reply (`\x01PING 1234\x01`, `\x01VERSION …\x01`)
   arrives as a NOTICE from a peer's nick and would otherwise be routed
-  like any peer NOTICE — persisted under that peer and minting a query
-  window for them, with a row of control characters in it. Pinging
-  somebody would leave a tab open with them.
+  like any peer NOTICE. When that meant "persist under the peer and mint
+  a query window", pinging somebody left a tab open with them holding a
+  row of control characters. #546 removed the minting, but not the
+  reason for this predicate: a peer the operator has a query OPEN with
+  would still get the raw `\x01…\x01` filed into that conversation.
 
   Lenient on the closing `\x01` for the same reason `action?/1` is: the
   trailing delimiter is optional and clients omit it.

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -2584,17 +2584,11 @@ defmodule Grappa.Session.EventRouter do
 
       Identifier.valid_nick?(sender) ->
         # #546 — ANY nick sender, service or peer, takes the open-window
-        # test. A notice is not an invitation to a conversation: it lands
-        # in the query only when that query is already open, else in the
-        # status window (irssi/HexChat; morph + Sonic, #it-opers
-        # 2026-07-30). This used to be an unconditional `{sender, body}`
-        # with `Identifier.services_sender?/1` bolted on ABOVE it to carve
-        # the *Serv nicks back out — scaffolding that existed only because
-        # the default was "notices open windows". Flipping the default
-        # collapses both into this one rule; the allowlist branch is gone
-        # from this door (it still gates the PRIVMSG door, where a
-        # DM-shaped services reply must not mint a window and a peer's DM
-        # must).
+        # test: a notice is announcement, not an invitation to a
+        # conversation. This was an unconditional `{sender, body}` with a
+        # `services_sender?/1` arm above it carving the *Serv nicks back
+        # out; flipping the default collapsed both into this one rule.
+        # Rationale + the rejected third branch: DESIGN_NOTES 2026-08-07.
         {open_query_or_server(sender, state), body}
 
       true ->

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -402,16 +402,23 @@ defmodule Grappa.Session.EventRouter do
         reply = "NOTICE #{sender} :\x01VERSION grappa #{version}\x01"
 
         # Persist the inbound query so cic surfaces it. Routing rule
-        # mirrors how a real inbound PRIVMSG/NOTICE would land:
-        # private CTCP query (target == own_nick) persists on the
-        # own-nick topic — that's where cic's dm-listener handler
-        # observes inbound DM-shaped traffic, re-keys it onto the
-        # sender's window, and (per CP23 NOTICE auto-open arm) opens
-        # the sender's query window with an unread badge. Persisting
-        # at channel = sender bypasses the dm-listener entirely;
-        # the broadcast lands on a topic cic isn't subscribed to
-        # until that window already exists, defeating auto-open.
+        # mirrors how a real inbound PRIVMSG would land: a private CTCP
+        # query (target == own_nick) persists on the own-nick topic —
+        # that's where cic's dm-listener observes inbound DM-shaped
+        # traffic and re-keys it onto the sender's window. The window
+        # itself is minted SERVER-side (#422): `build_persist/6` sets
+        # `dm_with = sender` via `Scrollback.dm_peer/4`, and
+        # `Session.Server.maybe_open_query_window/2` keys on
+        # `dm_with || channel`. Persisting at channel = sender instead
+        # would land the broadcast on a topic cic isn't subscribed to
+        # until that window already exists.
         # Channel-targeted CTCP keeps target as channel (no re-key).
+        #
+        # #546 does NOT reach this arm: it reverses the NOTICE door
+        # (`route_non_channel_notice/3`), and a CTCP query arrives as a
+        # PRIVMSG. So this visibility row still opens the peer's window —
+        # the issue predicted it would go quiet, and it does not. Pinned
+        # by a `server_test.exs` case rather than left to be re-derived.
         # #537 — `canonical_target/1` (fold at every identifier boundary)
         # so a DM CTCP target (a peer nick) folds into a canonical window
         # KEY; the sigil-gated form left it raw-cased.
@@ -2534,8 +2541,8 @@ defmodule Grappa.Session.EventRouter do
   # `[ #chan ]:` branch rewrites body to drop the prefix and keeps
   # PRIORITY (a channel-scoped notice belongs to the channel window even
   # when a ChanServ query window is open — #400 open-Q 3); other branches
-  # return body unchanged. `state` is threaded only for the #400 services
-  # re-key lookup (see `service_route_channel/2`).
+  # return body unchanged. `state` is threaded for the open-window lookup
+  # (see `open_query_or_server/2`).
   @spec route_non_channel_notice(String.t(), String.t(), state()) :: {String.t(), String.t()}
   defp route_non_channel_notice(sender, body, state) do
     # A CTCP-framed NOTICE is a REPLY to something we asked — a PING round
@@ -2545,6 +2552,13 @@ defmodule Grappa.Session.EventRouter do
     # pinging somebody left a tab open with them containing a row of
     # control characters. Case 4's own comment says "non-CTCP NOTICE" —
     # the intent was always this, the predicate was missing.
+    #
+    # #546 did NOT make this redundant, though it removed the original
+    # symptom (no nick branch mints a window any more). The short-circuit
+    # now earns its keep on the OTHER side of the new rule: without it, a
+    # peer the operator has a query OPEN with would have their raw
+    # `\x01PING …\x01` filed into that conversation. Protocol stays out of
+    # conversations whether or not one is open.
     #
     # `$server` keeps the row (losing it would hide a reply nobody
     # asked for) while `dm_eligible?/1` mints nothing. The BODY stays
@@ -2565,16 +2579,23 @@ defmodule Grappa.Session.EventRouter do
           {String.t(), String.t()}
   defp route_non_channel_notice_non_chanserv(sender, body, state) do
     cond do
-      Identifier.services_sender?(sender) ->
-        {service_route_channel(sender, state), body}
-
       String.contains?(sender, ".") ->
         {"$server", body}
 
       Identifier.valid_nick?(sender) ->
-        # Regular user nick → me; persist on channel = sender_nick so it
-        # lands in the same query window a PRIVMSG-to-own-nick would.
-        {sender, body}
+        # #546 — ANY nick sender, service or peer, takes the open-window
+        # test. A notice is not an invitation to a conversation: it lands
+        # in the query only when that query is already open, else in the
+        # status window (irssi/HexChat; morph + Sonic, #it-opers
+        # 2026-07-30). This used to be an unconditional `{sender, body}`
+        # with `Identifier.services_sender?/1` bolted on ABOVE it to carve
+        # the *Serv nicks back out — scaffolding that existed only because
+        # the default was "notices open windows". Flipping the default
+        # collapses both into this one rule; the allowlist branch is gone
+        # from this door (it still gates the PRIVMSG door, where a
+        # DM-shaped services reply must not mint a window and a peer's DM
+        # must).
+        {open_query_or_server(sender, state), body}
 
       true ->
         # Anonymous-sender sentinel ("*") or other non-nick senders we
@@ -2584,25 +2605,39 @@ defmodule Grappa.Session.EventRouter do
     end
   end
 
-  # #400 — where a services-sender arrival (NOTICE or DM-shaped PRIVMSG)
-  # lands. The default re-keys to the synthetic `$server` window so the
-  # traffic surfaces in the server-messages tab and bypasses cic's
-  # dm-listener auto-open (no stray query window per service). EXCEPTION:
-  # when the operator already has an OPEN query window with this service —
-  # they `/msg`'d it by hand — the reply belongs in THAT window, not
-  # `$server` where they'd stare at an empty query while the answer landed
-  # elsewhere. Neither invariant weakens: an existing window is not being
-  # *opened* (auto-open untouched), and `$server` stays the fallback for
-  # unsolicited service traffic (NickServ-at-connect, the common case).
+  # Where a nick-shaped arrival lands: the sender's query window if the
+  # operator ALREADY has one open with them, else the synthetic `$server`
+  # window (server-messages tab). Arrived with #400 for services only
+  # ("unsolicited service traffic must not mint a tab per service, but a
+  # `/msg`'d service's reply belongs in the window you asked from") and
+  # generalised by #546 to every NOTICE sender. It never OPENS anything —
+  # `$server` is not `dm_eligible?/1`, so the auto-open
+  # (`Session.Server.maybe_open_query_window/2`) mints nothing off a row
+  # routed here. That is the whole mechanism by which a notice stops
+  # spawning windows: routing, not a second carve-out at the open site.
+  #
+  # Two doors, deliberately asymmetric:
+  #   * NOTICE (`route_non_channel_notice_non_chanserv/3`) — EVERY nick
+  #     sender. A notice is announcement, not conversation.
+  #   * PRIVMSG (`privmsg_default/3`) — services senders ONLY. A peer's DM
+  #     still opens the conversation; that is what a DM is for.
   #
   # The open-window fact is a per-(subject, network) DB read. EventRouter
   # is a pure classifier ("No Repo"), so the lookup is injected as the
   # opaque `state.query_window_open?` callback (see the type's docstring).
-  # Absent → false → `$server`, keeping the sandbox-free classifier suite
-  # and today's behaviour intact. Shared by the NOTICE arm and
-  # `privmsg_default/3` so the two doors can't drift.
-  @spec service_route_channel(String.t(), state()) :: String.t()
-  defp service_route_channel(sender, state) do
+  # Absent → false → `$server`, which post-#546 is also the correct default
+  # for a peer, so the sandbox-free classifier suite needs no DI seam to
+  # observe production routing.
+  #
+  # "Open" is the SOLE condition, and "not archived" is implied by it, not a
+  # second check: `query_windows` has no `archived` column — `close/4`
+  # DELETEs the row, and `Scrollback.list_archive/3` DERIVES the archive as
+  # "has scrollback MINUS the active keyset", whose query half is exactly
+  # these rows. Open and archived are complementary by construction. Adding
+  # an archive test here would duplicate derived state (CLAUDE.md, Design
+  # discipline 1) and could only ever disagree with itself.
+  @spec open_query_or_server(String.t(), state()) :: String.t()
+  defp open_query_or_server(sender, state) do
     open? = Map.get(state, :query_window_open?, fn _, _, _ -> false end)
 
     if open?.(state.subject, state.network_id, sender),
@@ -2722,12 +2757,16 @@ defmodule Grappa.Session.EventRouter do
     # services advertisements to the channel everyone is watching.
     # #400: a DM-shaped services PRIVMSG re-keys to `$server` UNLESS the
     # operator has that service's query window open (then it lands there).
-    # `service_route_channel/2` is shared with the NOTICE arm so both doors
-    # observe the same open-window rule. Channel-target services traffic is
-    # unaffected — it belongs in the channel window regardless (#78).
+    # `open_query_or_server/2` is shared with the NOTICE arm so the two
+    # doors observe the same open-window rule. Channel-target services
+    # traffic is unaffected — it belongs in the channel window regardless
+    # (#78). #546 generalised the NOTICE door to every sender but NOT this
+    # one: the services allowlist is still what separates "a reply from a
+    # robot you queried" from "somebody talking to you", and only the
+    # former should stay out of a window of its own.
     route_channel =
       if Identifier.services_sender?(sender) and not channel_target?(channel),
-        do: service_route_channel(sender, state),
+        do: open_query_or_server(sender, state),
         else: channel
 
     {state, eff} = build_persist(state, kind, route_channel, sender, body, %{})

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -4523,8 +4523,10 @@ defmodule Grappa.Session.Server do
   # without knowing whether a window exists. The window-existence POLICY is
   # the server's — it owns window state — so the gate lives here, using the
   # SAME `state.query_window_open?` predicate EventRouter's
-  # `service_route_channel/2` uses for the identical "route to the window iff
-  # already open, else $server; never auto-open" decision.
+  # `open_query_or_server/2` uses for the identical "route to the window iff
+  # already open, else $server; never auto-open" decision. #546 widened that
+  # helper's caller set (every NOTICE sender, not just services); the
+  # decision it encodes — and this numeric gate's reuse of it — is unchanged.
   #
   # The concrete bug: a 401 ERR_NOSUCHNICK from a /ctcp or /ping to a
   # nonexistent nick scans to {:query, target}; with no window open it used

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -530,12 +530,19 @@ defmodule Grappa.Session.EventRouterTest do
       assert attrs.body == body
     end
 
-    test "a plain NOTICE from a regular nick still lands in that peer's window" do
-      state = base_state()
+    test "a plain NOTICE from a regular nick lands in that peer's window when it is OPEN" do
+      # #546 answered the question this test was parked on. It used to read
+      # "still lands in that peer's window" with `base_state()` and the note
+      # "whether THAT is right is #546/#548's question, not this change's" —
+      # #591 deliberately left the plain-notice routing alone so it could not
+      # pre-empt the ruling. The ruling came: a plain peer notice reaches the
+      # peer's window ONLY when the query is already open.
+      #
+      # The contrast with the CTCP test above is what this test is for, and
+      # #546 sharpened it: give BOTH an open window and they still diverge —
+      # framing goes to `$server`, conversation goes to the peer.
+      state = base_state(%{query_window_open?: fn _, _, _ -> true end})
 
-      # The carve-out above is for CTCP framing ONLY. An ordinary peer
-      # notice keeps its existing routing — whether THAT is right is
-      # #546/#548's question, not this change's.
       m = msg(:notice, ["vjt", "just a notice"], {:nick, "alice", "u", "h"})
 
       assert {:cont, _, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -951,7 +951,7 @@ defmodule Grappa.Session.EventRouterTest do
     # the allowlist no longer decides anything — a non-allowlist nick with no
     # open window lands on `$server` too. The test stays because the OUTCOME
     # is still the contract; the allowlist's remaining job is the PRIVMSG
-    # door (see the `Conserv` PRIVMSG guard below).
+    # door, guarded by the `Conserv` test in the `:privmsg` describe.
     test "#371 SeenServ / StatServ / DebugServ NOTICEs route to $server" do
       state = base_state()
 
@@ -969,26 +969,18 @@ defmodule Grappa.Session.EventRouterTest do
       end
     end
 
-    # UX-4 bucket G — closed-allowlist regression guard: ops nicks that
-    # end in "serv" (Conserv, Dataserv, Reserv on real networks) used to
-    # match the `~r/Serv$/i` regex and route to $server, swallowing the
-    # operator's query-window content. #546 moved this guard to the PRIVMSG
-    # door: on the NOTICE door the allowlist stopped discriminating (both
-    # arms take the open-window test), so a NOTICE-shaped assertion could no
-    # longer tell a re-broadened allowlist from the general rule. A PRIVMSG
-    # still can — a services PRIVMSG re-keys to `$server`, a peer's does not.
-    test "ops nick Conserv (ends in -serv but not in allowlist) keeps its PRIVMSG query window" do
-      state = base_state()
-
-      m =
-        msg(:privmsg, ["vjt", "you got opped"], {:nick, "Conserv", "u", "host.example.com"})
-
-      assert {:cont, ^state, [{:persist, :privmsg, attrs}]} =
-               EventRouter.route(m, state)
-
-      assert attrs.channel == "vjt"
-      assert attrs.sender == "Conserv"
-    end
+    # UX-4 bucket G's closed-allowlist regression guard (ops nicks ending in
+    # "serv" — Conserv, Dataserv — must not be swallowed into `$server`)
+    # used to live HERE as a NOTICE. #546 deleted it from this door rather
+    # than rewriting it: the allowlist no longer discriminates on the NOTICE
+    # door (both arms take the open-window test), so a NOTICE-shaped
+    # assertion could not fail if somebody re-broadened the allowlist, and a
+    # guard that cannot fail is not a guard. The guard survives where it can
+    # still fail — the PRIVMSG door, which already carries it verbatim:
+    # "PRIVMSG from regular user nick (Conserv — not in allowlist) routes to
+    # query window (regression guard)" in the `:privmsg` describe. Verified
+    # by mutation, not by assumption: dropping `services_sender?/1` from
+    # `privmsg_default/3` turns that test red.
 
     # #546 — THE reversal. A NOTICE from a plain peer used to persist on
     # `channel = sender`, which `maybe_open_query_window/2` then turned into

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -791,8 +791,15 @@ defmodule Grappa.Session.EventRouterTest do
 
     # CP13 server-window cluster: NOTICE-to-non-channel-target priority chain.
     # Replaces the pre-CP13 greedy "anything not a channel → $server" rule
-    # with: ChanServ-bracketed → channel; *Serv$ sender → $server;
-    # hostname sender → $server; user nick sender → query window.
+    # with: ChanServ-bracketed → channel; CTCP-framed → $server; hostname
+    # sender → $server; nick sender → the query window IF ALREADY OPEN, else
+    # $server.
+    #
+    # #546 reversed the last link: it used to be "user nick sender → query
+    # window" unconditionally, with a services allowlist bolted on to carve
+    # the *Serv nicks back out to $server. The allowlist branch is GONE from
+    # this door — services and peers now take the same open-window test, so
+    # every *Serv test below is green by the GENERAL rule, not a carve-out.
 
     test "ChanServ-bracketed body persists on captured channel with prefix stripped" do
       state = base_state()
@@ -836,13 +843,13 @@ defmodule Grappa.Session.EventRouterTest do
           {:nick, "ChanServ", "s", "h"}
         )
 
-      # ChanServ doesn't match a hostname (no '.' in nick), and "ChanServ"
-      # matches @services_sender_regex → $server.
+      # ChanServ doesn't match a hostname (no '.' in nick), so it takes the
+      # nick branch — and with no open query window (#546) that is $server.
       assert {:cont, ^state, [{:persist, :notice, %{channel: "$server", sender: "ChanServ"}}]} =
                EventRouter.route(m, state)
     end
 
-    test "NickServ sender routes to $server (services allowlist)" do
+    test "NickServ sender routes to $server (no open query window)" do
       state = base_state()
 
       m =
@@ -895,10 +902,11 @@ defmodule Grappa.Session.EventRouterTest do
       assert attrs.meta == %{ctcp_verb: "PING", ctcp_args: "1706743200000"}
     end
 
-    # #591 — a plain (non-CTCP) peer NOTICE stays exactly as before: empty
-    # meta, no ctcp tag. Proves the classification is strictly additive.
+    # #591 — a plain (non-CTCP) peer NOTICE carries empty meta, no ctcp tag.
+    # Proves the classification is strictly additive. The OPEN window is what
+    # keeps this row in `bob` post-#546; the meta assertion is the point.
     test "plain peer NOTICE gets no ctcp meta (additive)" do
-      state = base_state()
+      state = base_state(%{query_window_open?: fn _, _, _ -> true end})
 
       m = msg(:notice, ["vjt", "hey are you around?"], {:nick, "bob", "u", "h"})
 
@@ -909,14 +917,34 @@ defmodule Grappa.Session.EventRouterTest do
       assert attrs.meta == %{}
     end
 
+    # #546 — the CTCP short-circuit outranks the open window. A CTCP-framed
+    # NOTICE is a REPLY to something we asked (a /ping round trip): protocol,
+    # not conversation, so it stays on `$server` even for a peer the operator
+    # has a query open with — cic correlates the token from `$server` and
+    # synthesises the RTT line in the window /ping was typed in (#591).
+    # WITHOUT this, generalising the nick branch would start dumping raw
+    # \x01 rows into open conversations.
+    test "#546 CTCP-framed peer NOTICE stays on $server EVEN with an open query window" do
+      state = base_state(%{query_window_open?: fn _, _, _ -> true end})
+
+      m = msg(:notice, ["vjt", "\x01PING 1706743200000\x01"], {:nick, "bob", "u", "h"})
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+
+      assert attrs.channel == "$server"
+      assert attrs.body == "\x01PING 1706743200000\x01"
+    end
+
     # #371 — Azzurra (bahamut) pseudo-services SeenServ / StatServ /
     # DebugServ were absent from the allowlist, so their NOTICE replies
     # fell through to the peer-nick query-window arm (a stray empty
     # window) instead of the synthetic `$server` channel. Added to
     # `Grappa.IRC.Identifier` `@services` in lockstep with the cic-side
-    # twin (`cicchetto/src/lib/servicesSender.ts`). The `Conserv` guard
-    # above proves a non-allowlist -serv nick still routes to a query
-    # window, so this asserts the allowlist membership is what flips it.
+    # twin (`cicchetto/src/lib/servicesSender.ts`). #546 NOTE: on THIS door
+    # the allowlist no longer decides anything — a non-allowlist nick with no
+    # open window lands on `$server` too. The test stays because the OUTCOME
+    # is still the contract; the allowlist's remaining job is the PRIVMSG
+    # door (see the `Conserv` PRIVMSG guard below).
     test "#371 SeenServ / StatServ / DebugServ NOTICEs route to $server" do
       state = base_state()
 
@@ -937,24 +965,64 @@ defmodule Grappa.Session.EventRouterTest do
     # UX-4 bucket G — closed-allowlist regression guard: ops nicks that
     # end in "serv" (Conserv, Dataserv, Reserv on real networks) used to
     # match the `~r/Serv$/i` regex and route to $server, swallowing the
-    # operator's query-window content. The allowlist (now in Identifier)
-    # rejects them — they're regular user nicks and fall through to the
-    # peer-nick query window arm.
-    test "ops nick Conserv (ends in -serv but not in allowlist) routes to query window" do
+    # operator's query-window content. #546 moved this guard to the PRIVMSG
+    # door: on the NOTICE door the allowlist stopped discriminating (both
+    # arms take the open-window test), so a NOTICE-shaped assertion could no
+    # longer tell a re-broadened allowlist from the general rule. A PRIVMSG
+    # still can — a services PRIVMSG re-keys to `$server`, a peer's does not.
+    test "ops nick Conserv (ends in -serv but not in allowlist) keeps its PRIVMSG query window" do
       state = base_state()
 
       m =
-        msg(:notice, ["vjt", "you got opped"], {:nick, "Conserv", "u", "host.example.com"})
+        msg(:privmsg, ["vjt", "you got opped"], {:nick, "Conserv", "u", "host.example.com"})
+
+      assert {:cont, ^state, [{:persist, :privmsg, attrs}]} =
+               EventRouter.route(m, state)
+
+      assert attrs.channel == "vjt"
+      assert attrs.sender == "Conserv"
+    end
+
+    # #546 — THE reversal. A NOTICE from a plain peer used to persist on
+    # `channel = sender`, which `maybe_open_query_window/2` then turned into
+    # a query window: Azzurra's welcome notice (sent from a USER, not a
+    # service) opened a tab for everyone on connect. irssi/HexChat send a
+    # notice to the status window unless the query is already open; morph +
+    # Sonic settled on exactly that on #it-opers (2026-07-30). This reverses
+    # UX-6-L / #422 Option B's "peer NOTICE opens the window" arm.
+    test "#546 peer NOTICE with NO open query window routes to $server" do
+      state = base_state(%{query_window_open?: fn _, _, _ -> false end})
+
+      m =
+        msg(
+          :notice,
+          ["vjt", "yo, you alive?"],
+          {:nick, "alice", "u", "host.example.com"}
+        )
 
       assert {:cont, ^state, [{:persist, :notice, attrs}]} =
                EventRouter.route(m, state)
 
-      assert attrs.channel == "Conserv"
-      assert attrs.sender == "Conserv"
+      assert attrs.channel == "$server"
+      assert attrs.sender == "alice"
+      assert attrs.body == "yo, you alive?"
     end
 
-    test "regular user nick → persist on channel = sender_nick (query window)" do
+    # The callback is ABSENT in the plain classifier suite (no DI seam
+    # injected) — it must default to "not open", i.e. `$server`. Pins that
+    # the reversal holds on the default path, not only when a test hands in
+    # a `false` stub.
+    test "#546 peer NOTICE with NO open-window callback injected routes to $server" do
       state = base_state()
+
+      m = msg(:notice, ["vjt", "yo, you alive?"], {:nick, "alice", "u", "host.example.com"})
+
+      assert {:cont, ^state, [{:persist, :notice, %{channel: "$server", sender: "alice"}}]} =
+               EventRouter.route(m, state)
+    end
+
+    test "#546 peer NOTICE WITH an open query window routes to the peer's window" do
+      state = base_state(%{query_window_open?: fn _, _, _ -> true end})
 
       m =
         msg(
@@ -969,6 +1037,40 @@ defmodule Grappa.Session.EventRouterTest do
       assert attrs.channel == "alice"
       assert attrs.sender == "alice"
       assert attrs.body == "yo, you alive?"
+    end
+
+    # The open-window lookup must be asked about the PEER, with this
+    # session's subject + network — the same three arguments the services
+    # door passes. A lookup keyed on anything else (own nick, the wire
+    # target) would answer a different question and route by accident.
+    test "#546 the open-window predicate is called with (subject, network_id, peer nick)" do
+      parent = self()
+
+      state =
+        base_state(%{
+          query_window_open?: fn subject, network_id, nick ->
+            send(parent, {:open_check, subject, network_id, nick})
+            false
+          end
+        })
+
+      m = msg(:notice, ["vjt", "yo"], {:nick, "alice", "u", "host.example.com"})
+      EventRouter.route(m, state)
+
+      assert_received {:open_check, {:user, _}, 42, "alice"}
+    end
+
+    # #546 must NOT leak into the PRIVMSG door: a DM from a peer still opens
+    # the conversation. Only NOTICEs became non-opening.
+    test "#546 peer PRIVMSG still lands in the DM window with NO open query window" do
+      state = base_state(%{query_window_open?: fn _, _, _ -> false end})
+
+      m = msg(:privmsg, ["vjt", "you around?"], {:nick, "alice", "u", "host.example.com"})
+
+      assert {:cont, ^state, [{:persist, :privmsg, attrs}]} = EventRouter.route(m, state)
+
+      assert attrs.channel == "vjt"
+      assert attrs.dm_with == "alice"
     end
 
     test "anonymous sender (no prefix) falls back to $server" do

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -2555,7 +2555,97 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
-    test "inbound peer NOTICE to own nick opens a server-side query window" do
+    # #546 — REVERSED. Until now an inbound peer NOTICE minted the query
+    # window (UX-6-L / #422 Option B). Azzurra's welcome notice is sent from
+    # a plain USER, so every operator got a tab on connect. irssi/HexChat put
+    # a notice in the status window unless the query is already open; morph +
+    # Sonic settled on that rule (#it-opers, 2026-07-30).
+    #
+    # The refute needs a BARRIER or it is vacuous — a `refute_receive` alone
+    # would pass on a session that never processed the line at all. So the
+    # positive half comes first: the row must ARRIVE on the `$server` window.
+    # Only then is "no query window" a statement about routing.
+    test "#546 inbound peer NOTICE routes to $server and opens NO query window" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
+
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
+      :ok =
+        Phoenix.PubSub.subscribe(
+          Grappa.PubSub,
+          Topic.channel(user.name, network.slug, "$server")
+        )
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      IRCServer.feed(server, ":bob!~b@host NOTICE vjt :ping\r\n")
+
+      # Barrier: the notice landed, and it landed on `$server`.
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{
+                         kind: :message,
+                         message: %{kind: :notice, sender: "bob", body: "ping", channel: "$server"}
+                       }
+                     },
+                     2_000
+
+      # ...and minted nothing: no `query_windows_list` broadcast, no DB row.
+      refute_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{kind: :query_windows_list}
+                     },
+                     300
+
+      refute QueryWindows.open?({:user, user.id}, network.id, "bob")
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # #546, the other arm: an ALREADY-OPEN query window keeps the notice.
+    # This is the half that makes the rule irssi-shaped rather than a blanket
+    # "notices go to status" — and it is the arm `open_query_or_server/2`
+    # already implemented for services since #400.
+    test "#546 inbound peer NOTICE lands in the peer's window when it is already open" do
+      {server, port} = start_server()
+      {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
+
+      {:ok, _} = QueryWindows.open({:user, user.id}, network.id, "bob", user.name)
+
+      :ok =
+        Phoenix.PubSub.subscribe(
+          Grappa.PubSub,
+          Topic.channel(user.name, network.slug, "bob")
+        )
+
+      pid = start_session_for(user, network)
+      :ok = await_handshake(server)
+
+      IRCServer.feed(server, ":bob!~b@host NOTICE vjt :ping\r\n")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       event: "event",
+                       payload: %{
+                         kind: :message,
+                         message: %{kind: :notice, sender: "bob", body: "ping", channel: "bob"}
+                       }
+                     },
+                     2_000
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
+    # #546 regression the issue called out as the one concrete casualty: the
+    # "CTCP VERSION query → grappa X" visibility row. It does NOT ride the
+    # NOTICE door at all — it is emitted by the inbound-PRIVMSG CTCP arm,
+    # persisted at `channel = own_nick` with `dm_with = sender`, and the
+    # auto-open keys off `dm_with || channel` (#422). So it survives the
+    # reversal untouched. Pinned here because "it still works" is a claim
+    # about a path #546 does not visit, and nobody should have to re-derive
+    # that from the routing table six months from now.
+    test "#546 a peer CTCP VERSION query still opens the peer's query window" do
       {server, port} = start_server()
       {user, network, _} = setup_user_and_network(port, %{nick: "vjt"})
 
@@ -2564,7 +2654,7 @@ defmodule Grappa.Session.ServerTest do
       pid = start_session_for(user, network)
       :ok = await_handshake(server)
 
-      IRCServer.feed(server, ":bob!~b@host NOTICE vjt :ping\r\n")
+      IRCServer.feed(server, ":bob!~b@host PRIVMSG vjt :\x01VERSION\x01\r\n")
 
       net_id = network.id
 
@@ -2572,7 +2662,7 @@ defmodule Grappa.Session.ServerTest do
                        event: "event",
                        payload: %{kind: :query_windows_list, windows: %{^net_id => entries}}
                      },
-                     1_000
+                     2_000
 
       assert Enum.any?(entries, &(&1.target_nick == "bob"))
       assert QueryWindows.open?({:user, user.id}, net_id, "bob")


### PR DESCRIPTION
Union of **PR #1009** (#1008 — composer autocorrect) and **PR #1011** (#546 — peer NOTICE routing),
cherry-picked onto `main` at `c841bf10` in that order. 5 commits: 1 + 4.

## Why a union and not two merges

Each PR is green **against `main`**, neither is green **against the other**. A PR's green attests
`branch + base` — never `branch + the other branch about to land beside it`. Two separate merges would
have bought two half-hour `integration` runs and still left the one combination nobody had checked.
One union = one gate, one merge, and the check we actually wanted.

The two superseded PRs are closed by content, not by keyword — the orchestrator closes them.

## What is in it

- **#1008 / PR #1009** — `ComposeBox.tsx` + `ComposeBox.test.tsx`: the composer keeps
  `autocapitalize=none` but carries no `autocorrect` (it is prose, not an identifier).
- **#546 / PR #1011** — a peer NOTICE lands in the query window only if that window is already open;
  `event_router.ex`, `ctcp.ex`, `server.ex`, `subscribe.ts`, `serviceModal.ts`, their unit tests, and a
  new e2e spec `issue546-peer-notice-no-query-window.spec.ts`.

## That the content survived, by measurement and not by eye

Cherry-pick applied with **zero conflicts**. The brief expected one in `docs/DESIGN_NOTES.md` because
both PRs were thought to carry an entry — in fact **#1009 touches no docs at all**, so the only entry is
#1011's and it came across whole.

Each PR's patch-set was hashed over content lines only (`^[+-]`, minus file headers) before and after
the pick, and the two slices of the union diff compared against them:

| slice | lines | sha256 before = after |
|---|---|---|
| #1009 (`origin/main..f0df603b`) | 52 | `37b53760…` ✅ |
| #1011 minus DESIGN_NOTES (`f0df603b..HEAD`) | 503 | `fc1fb9ba…` ✅ |
| #1011 DESIGN_NOTES only | 97 | `2d86e764…` ✅ |

All three slices are byte-identical and **non-empty** — the line counts are reported precisely because
two empty sets also compare equal, and that false pass has been hit here before.

## Gates on the united tree

- `scripts/bun.sh run check` → **EXIT=0**. The script is `biome check src && tsc --noEmit`, so exit 0
  means tsc ran and was silent; the 48 biome warnings are pre-existing and non-fatal.
- `scripts/bun.sh run test` → **EXIT=0**, 246 files, **4595 tests**.

Counted against the parts: #1011 alone (`c1777a6b`, its own worktree) is 246 files / **4594** tests, and
#1009's diff adds exactly **one** `it()` to an existing file. 4594 + 1 = 4595, same file count. The union
neither lost a test nor double-counted one.

## Sample wanted on `names143`

`main` went red at `03aa1260` on a single spec, `names143-modal-mobile.spec.ts:54` (#143, NamesModal
inside the keyboard-narrowed viewport), 637/1 — while the same tree was 638/0 in PR #1006, and #1011 saw
it pass. This union's `integration` run is one more sample on that spec. Reporting the outcome only;
the diagnosis is not mine to draw from one run.

## Not done here

Not merged, not deployed, no CI polling, and the two superseded PRs left open.