### PR TITLE
Repair the credentials #977 concatenated, and refuse to guess the rest

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -32782,3 +32782,83 @@ about width still restart the pool at 5 and 10 themselves. The ceiling
 correspondingly stops binding here: 14 tests × ~80 migrations per run becomes
 14 × 3, and the file drops from 8.6s to 0.4s. The undiagnosed replay red is
 still undiagnosed — it simply no longer has a home in this test.
+
+## 2026-08-07 — #1001: the space is an exact signature, but only where Azzurra's rule reaches
+
+`mix grappa.repair_passwords` sweeps the credentials #977 corrupted. #983
+stopped the capture concatenating `SET PASSWD <old> <new>` into one stored
+value and #124 gave the subject a field to retype the secret in, but neither
+backfills a row that is already wrong, and at least one live account was left
+in that state.
+
+**Why the space is a signature and not a heuristic.** An Azzurra password
+cannot contain one: `do_set_password` cuts the parameter at the first space
+(`strchr(param, ' ')`) and then refuses a `newpass` that still holds one, and
+`do_resetpass` does the same. So a space in a secret Azzurra's NickServ
+governs is a concatenation artifact by construction — there is no legitimate
+value it could be. The detector does not re-derive this: it calls
+`Session.NSInterceptor.vet_password/2`, already public as the second door
+#124 needed, whose spaces arm is FIRST in the chain and therefore cannot be
+shadowed by a later one. The same call supplies the `PASSMAX` verdict, so 32
+is not hard-coded a second time where it could drift from the wire door.
+
+**Where that certainty stops, and it is #124 that stopped it.** The issue
+claimed no false positives *by construction*. That was true of
+`nickserv_pass_encrypted`, a NickServ-only column. It stopped being true the
+moment `20260807120000_fold_nickserv_pass_onto_password` ran
+`SET password_encrypted = nickserv_pass_encrypted`: `password_encrypted` is
+now the single home for the NickServ secret AND the SASL one AND the server
+password. SASL PLAIN base64-encodes its passphrase
+(`Grappa.IRC.AuthFSM.sasl_plain_payload/1`), so a space there survives and
+identifies normally; `Credential.password_changeset/2` guards only CR/LF/NUL,
+and `Credentials.update_credential_password/2` applies Azzurra's chain only
+when the method is `:nickserv_identify` — the #124 field *deliberately*
+accepts a space-containing password on a `:sasl` row. Gating #1001 behind
+#124 was right for the schema, and the right schema is precisely the one
+where the space alone no longer decides.
+
+So the sweep repairs `:nickserv_identify` and nothing else. Every other
+method with a space is reported. That is not a new mechanism: it is the verb
+the issue already owed the >2-token case ("report, do not guess"), applied to
+a second axis of ambiguity.
+
+**The rule the whole task is built on.** A missed repair costs a manual
+intervention; a wrong repair costs an unrecoverable secret (Cloak AES-GCM, no
+plaintext backup, nothing to reverse it from). The two do not weigh the same,
+so every remaining doubt resolves to *report*. Consequences, each with a spec:
+dry run is the default and writing must be asked for; the split is a literal
+single space with **no `trim:`**, so a run of spaces or a trailing one yields
+an extra empty token and lands in "reported" — which is the correct answer
+rather than an accident, because services refused such a rotation outright
+and neither token is known to be live; a recovered password that services
+would themselves refuse is reported instead of written; and no output line
+ever carries the secret or any token of it.
+
+At exactly two tokens, "keep the last" and "keep the second" agree, which is
+why the >2 case is reported rather than resolved by picking one rule: at
+three tokens they diverge and only the operator knows which rotation is live.
+
+**The sweep reads every subject, and that needed a second reader.**
+`Credentials.list_all_credentials/0` is scoped `user_id IS NOT NULL` for #211
+— correct for the subject-scoped admin surfaces it backs, where a `user_id:
+nil` row renders as a phantom. But `Session.Server.rotate_stored_password/2`
+has a `{:visitor, visitor_id}` clause beside the `{:user, user_id}` one, so a
+visitor credential carries and corrupts the same secret. A task whose only
+output is a count, printing "0 candidates" with a corrupted visitor row in the
+table, is not a coverage gap but a false statement — the log-honesty class.
+Hence `list_credentials_every_subject/0` as a sibling with a doc explaining
+why the two radii are both deliberate, rather than widening the existing one.
+
+**The task stays in the tree** (vjt reversed the earlier "delete it once it
+has run"). It is idempotent and inert on a healthy database. Its standing
+value is the inverse reading: with #983 holding the capture and #124 offering
+the cure, nothing should be able to corrupt a credential any more, so a run
+that finds one is the signal of a NEW bug rather than backlog being worked
+off. The output says exactly that whenever the count is non-zero.
+
+**Left open, deliberately.** A genuinely corrupted `:sasl` row — the capture
+door is blind to `auth_method`, so one is possible — lands in "reported" and
+is not repaired automatically. That is one repair fewer in exchange for zero
+destroyed secrets. An explicit operator override was considered and NOT built:
+it is a separate unit if it is ever wanted, and a half-built hook would be
+worse than none.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -901,8 +901,39 @@ name too.
 
 - **`bin/grappa` (the dispatcher) is docker-only — it FAILS in the
   jail** (`docker: not found`). It's a dev/RPi tool.
-- **Mix tasks don't work either** in the jail: a second BEAM collides
-  with the live node's Endpoint `:4000` in the shared netns.
+- **Mix tasks: the `:4000` reason below is STALE — treat the caution as
+  unverified, not as a rule.** This bullet used to read "mix tasks don't
+  work in the jail: a second BEAM collides with the live node's Endpoint
+  `:4000` in the shared netns". That collision was fixed on 2026-07-23:
+  `Mix.Tasks.Grappa.Boot.start_app_silent/0` suppresses BOTH
+  `Grappa.Bootstrap` and `GrappaWeb.Endpoint`, and runs `mix app.config`
+  so `config/runtime.exs` is evaluated under `MIX_ENV=prod`. The jail also
+  has the full source tree and Mix — `infra/freebsd/deploy.sh` runs
+  `git pull`, `mix deps.get`, `mix compile`, `mix release --overwrite`
+  and even `mix run --no-start -e 'Grappa.Deploy.Preflight.cli(…)'` on
+  every deploy. So the recipe is:
+
+  ```sh
+  jexec grappa su -l grappa -c 'cd /home/grappa/grappa;
+    set -a; . /usr/local/etc/grappa/grappa.env; set +a;
+    MIX_ENV=prod mix grappa.<task>'
+  ```
+
+  **What is still NOT established:** whether a second BEAM writing the
+  same SQLite file while the live node is running is safe in practice.
+  WAL allows concurrent readers and one writer, but this has not been
+  exercised against the live jail. Prefer a read-only / dry-run task
+  first, and read `database is locked` in the output as a reason to stop
+  and drive the LIVE node via `rpc` instead.
+- **`grappa.repair_passwords` (#1001) is a mix task, and dry-run is its
+  default.** Run it with no flags first — it writes nothing and prints
+  the classification. `--write` applies only the deterministic repairs
+  (`:nickserv_identify`, exactly two tokens); everything else is reported
+  for a human. A repaired password is read at (re)connect via
+  `SessionPlan.base_plan/6`, exactly like a #124 field edit, so the fix
+  takes effect on the session's next reconnect rather than immediately.
+  A non-zero count on a modern install is the signal of a NEW bug, not
+  backlog — the task's own output says so.
 - **Drive the LIVE node via the release `rpc`** instead. Source the
   env first (or `rpc` returns `:noconnection` — needs `RELEASE_COOKIE`):
 

--- a/lib/grappa/networks/credentials.ex
+++ b/lib/grappa/networks/credentials.ex
@@ -1253,6 +1253,40 @@ defmodule Grappa.Networks.Credentials do
   end
 
   @doc """
+  #1001 — every credential row, USER-bound and VISITOR-bound alike.
+
+  Deliberately NOT `list_all_credentials/0`, and the two must not be
+  unified. That one is scoped `user_id IS NOT NULL` for #211: it backs the
+  admin `/admin/credentials` listing and `bin/grappa list-credentials`,
+  operator surfaces where a `user_id: nil` row would render as a phantom
+  and drive `LiveIntrospection.lookup_session({:user, nil}, …)`. Its narrow
+  radius is a feature of a SUBJECT-scoped door.
+
+  This reader answers the opposite question — "what is in the column, for
+  anybody" — and it cannot inherit that scope. The secret-rotation path
+  reaches BOTH subjects: `Session.Server`'s `rotate_stored_password/2` has a
+  `{:visitor, visitor_id}` clause alongside the `{:user, user_id}` one, so a
+  visitor credential carries (and corrupts) `password_encrypted` exactly like
+  a user one. A repair sweep reading the user-scoped list would print
+  "0 candidates" with a corrupted visitor row sitting right there — not a
+  coverage gap but a false statement, which is the whole point of a task
+  whose only output is a count.
+
+  No `preload: [network: :servers]`: the caller reports on the stored secret,
+  never dials one. `:network` alone is preloaded, for the slug in the report.
+  """
+  @spec list_credentials_every_subject() :: [Credential.t()]
+  def list_credentials_every_subject do
+    query =
+      from(c in Credential,
+        order_by: [asc: c.inserted_at, asc: c.id],
+        preload: [:network]
+      )
+
+    Repo.all(query)
+  end
+
+  @doc """
   Returns a map of `connection_state` → USER-credential row count. Used
   by `Grappa.Bootstrap.run/0` to surface honest startup logs when zero
   credentials are `:connected` (e.g. all parked after

--- a/lib/mix/tasks/grappa.repair_passwords.ex
+++ b/lib/mix/tasks/grappa.repair_passwords.ex
@@ -91,11 +91,17 @@ defmodule Mix.Tasks.Grappa.RepairPasswords do
           | {:unusable, NSInterceptor.vet_reject_reason()}
           | {:unusable_repair, NSInterceptor.vet_reject_reason()}
 
-  @type classification ::
-          :no_password
-          | :healthy
-          | {:repairable, String.t()}
-          | {:report, report_reason()}
+  @typedoc """
+  What the concatenation branch can conclude. Narrower than
+  `classification/0` on purpose: once a stored value has been found to hold
+  a space there is something to say about it, so `:healthy` and
+  `:no_password` are no longer reachable — Dialyzer proves it, and the
+  split type records the decision tree instead of hiding it behind one
+  catch-all.
+  """
+  @type verdict :: {:repairable, String.t()} | {:report, report_reason()}
+
+  @type classification :: :no_password | :healthy | verdict()
 
   @doc """
   Classifies one credential's stored password. Pure — reads the struct, hits
@@ -125,8 +131,7 @@ defmodule Mix.Tasks.Grappa.RepairPasswords do
   # the split: `do_set_password` cuts at the FIRST space and then refuses a
   # `newpass` that still holds one, so such a rotation never took upstream
   # and NEITHER token is known to be the live password.
-  @spec classify_concatenation(String.t(), String.t() | nil, Credential.auth_method()) ::
-          classification()
+  @spec classify_concatenation(String.t(), String.t() | nil, Credential.auth_method()) :: verdict()
   defp classify_concatenation(password, nick, :nickserv_identify) do
     case String.split(password, " ") do
       # Exactly two tokens is the single-rotation case, and it is the only
@@ -143,7 +148,8 @@ defmodule Mix.Tasks.Grappa.RepairPasswords do
 
   # A repair that services would themselves refuse is not a repair — it just
   # exchanges one silently-never-identifying value for another.
-  @spec classify_repair(String.t(), String.t() | nil) :: classification()
+  @spec classify_repair(String.t(), String.t() | nil) ::
+          {:repairable, String.t()} | {:report, {:unusable_repair, NSInterceptor.vet_reject_reason()}}
   defp classify_repair(candidate, nick) do
     case NSInterceptor.vet_password(candidate, nick || "") do
       :ok -> {:repairable, candidate}
@@ -156,7 +162,7 @@ defmodule Mix.Tasks.Grappa.RepairPasswords do
   # calling a legitimately longer one unusable — the same scoping
   # `Credentials.update_credential_password/2` applies at the #124 door.
   @spec classify_unusable(NSInterceptor.vet_reject_reason(), Credential.auth_method()) ::
-          classification()
+          :healthy | {:report, {:unusable, NSInterceptor.vet_reject_reason()}}
   defp classify_unusable(reason, :nickserv_identify), do: {:report, {:unusable, reason}}
   defp classify_unusable(_, _), do: :healthy
 

--- a/lib/mix/tasks/grappa.repair_passwords.ex
+++ b/lib/mix/tasks/grappa.repair_passwords.ex
@@ -1,0 +1,277 @@
+defmodule Mix.Tasks.Grappa.RepairPasswords do
+  @shortdoc "Repairs credentials whose stored password #977 concatenated; dry-run unless --write"
+
+  @moduledoc """
+  Operator sweep for the credentials #977 corrupted, and a standing check
+  that no new one has appeared.
+
+  ## Usage
+
+      scripts/mix.sh grappa.repair_passwords            # dry run — reports, writes nothing
+      scripts/mix.sh grappa.repair_passwords --write    # applies the deterministic repairs
+
+  ## What went wrong
+
+  Before #983, the in-session `SET PASSWD <old> <new>` capture stored the
+  whole rest of the line, so the credential ended up holding `"<old> <new>"` —
+  the two passwords joined by the space `do_set_password` splits on
+  (`azzurra/services src/nickserv.c`). #983 stopped the bleeding and #124 gave
+  the subject a field to retype their own password in, but neither backfills a
+  row that is already wrong. This task is that backfill.
+
+  ## Why the space is an exact signature, and where it stops being one
+
+  An Azzurra password cannot contain a space: `do_set_password` and
+  `do_resetpass` refuse `strchr(newpass, ' ')` outright. So for a secret that
+  Azzurra's NickServ governs, a stored space is a concatenation artifact with
+  certainty — not a heuristic, and with no false positives.
+
+  That certainty does NOT extend to the whole column. After #124's fold
+  (`20260807120000_fold_nickserv_pass_onto_password`), `password_encrypted` is
+  the single home for the NickServ secret AND the SASL one AND the server
+  password. SASL PLAIN base64-encodes its passphrase
+  (`Grappa.IRC.AuthFSM`), so a space there is legitimate and identifies
+  normally; `Credential.password_changeset/2` guards only CR/LF/NUL, and
+  `Credentials.update_credential_password/2` applies Azzurra's chain only when
+  the method is `:nickserv_identify`. Reading a space on a `:sasl` row as
+  corruption and "repairing" it would truncate a live passphrase to its last
+  token — Cloak AES-GCM, no plaintext backup, nothing to reverse it from.
+
+  So the space decides only where Azzurra's rule actually governs the secret.
+  Everywhere else the answer is the verb this task already owes the >2-token
+  case: report it, and let a human decide.
+
+  ## The rule that governs every judgement call here
+
+  **A missed repair costs a manual intervention. A wrong repair costs an
+  unrecoverable secret. The two do not weigh the same.** Any remaining doubt
+  in this task resolves to *report*, never to *guess*.
+
+  ## The detector is borrowed, not re-derived
+
+  `Session.NSInterceptor.vet_password/2` is already public as the "second
+  door" #124 needed, and its spaces arm is FIRST in the chain — no later arm
+  can shadow it, which is what makes the call an exact test rather than an
+  approximation. The same call supplies the `PASSMAX` verdict, so `32` is not
+  hard-coded a second time and cannot drift from the wire door.
+
+  ## Why the task stays in the tree
+
+  It is idempotent and inert on a healthy database: it prints `0 candidates`
+  and writes nothing. It is an operator tool, not a one-shot migration.
+  Its standing value is the inverse reading — with #983 holding the capture
+  and #124 offering the cure, nothing should be able to produce a corrupted
+  credential any more, so a run that DOES find one is the signal of a new
+  bug rather than routine maintenance. The output says so.
+
+  The retired `nickserv_pass_encrypted` column is never read and never
+  written: it was never fed by the `SET PASSWD` capture path, so it is not
+  part of this corruption.
+  """
+  use Boundary,
+    top_level?: true,
+    deps: [Grappa.Networks, Grappa.Session, Mix.Tasks.Grappa.Boot]
+
+  use Mix.Task
+
+  alias Grappa.Networks.{Credential, Credentials}
+  alias Grappa.Session.NSInterceptor
+  alias Mix.Tasks.Grappa.Boot
+
+  @switches [write: :boolean]
+
+  @typedoc """
+  Why a row is reported instead of repaired. Every one of these means the
+  live password cannot be derived from what is stored — a human has to
+  supply it.
+  """
+  @type report_reason ::
+          :ambiguous_auth_method
+          | :multiple_rotations
+          | {:unusable, NSInterceptor.vet_reject_reason()}
+          | {:unusable_repair, NSInterceptor.vet_reject_reason()}
+
+  @type classification ::
+          :no_password
+          | :healthy
+          | {:repairable, String.t()}
+          | {:report, report_reason()}
+
+  @doc """
+  Classifies one credential's stored password. Pure — reads the struct, hits
+  no database, decides nothing about writing.
+
+  `{:repairable, password}` carries the value that WOULD be written; every
+  other result writes nothing.
+  """
+  @spec classify(Credential.t()) :: classification()
+  def classify(%Credential{password_encrypted: nil}), do: :no_password
+
+  def classify(%Credential{password_encrypted: password, nick: nick, auth_method: auth_method}) do
+    # The nick column is nullable; an empty one only makes the chain's
+    # "password equals your nick" arm inert, exactly as in
+    # `Credentials.vet_nickserv_password/3`.
+    case NSInterceptor.vet_password(password, nick || "") do
+      {:error, :password_with_spaces} -> classify_concatenation(password, nick, auth_method)
+      {:error, reason} -> classify_unusable(reason, auth_method)
+      :ok -> :healthy
+    end
+  end
+
+  # Split on a LITERAL single space with no `trim:`, mirroring what services
+  # do rather than what looks tidy. A run of spaces, a leading one or a
+  # trailing one all yield an extra empty token and land in
+  # `:multiple_rotations` — which is the correct answer, not an accident of
+  # the split: `do_set_password` cuts at the FIRST space and then refuses a
+  # `newpass` that still holds one, so such a rotation never took upstream
+  # and NEITHER token is known to be the live password.
+  @spec classify_concatenation(String.t(), String.t() | nil, Credential.auth_method()) ::
+          classification()
+  defp classify_concatenation(password, nick, :nickserv_identify) do
+    case String.split(password, " ") do
+      # Exactly two tokens is the single-rotation case, and it is the only
+      # deterministic one. "Keep the LAST token" and "keep the second" agree
+      # here by construction — which is precisely why >2 is reported instead:
+      # at three tokens the two rules diverge and only the operator knows
+      # which rotation is live.
+      [_, new] -> classify_repair(new, nick)
+      _ -> {:report, :multiple_rotations}
+    end
+  end
+
+  defp classify_concatenation(_, _, _), do: {:report, :ambiguous_auth_method}
+
+  # A repair that services would themselves refuse is not a repair — it just
+  # exchanges one silently-never-identifying value for another.
+  @spec classify_repair(String.t(), String.t() | nil) :: classification()
+  defp classify_repair(candidate, nick) do
+    case NSInterceptor.vet_password(candidate, nick || "") do
+      :ok -> {:repairable, candidate}
+      {:error, reason} -> {:report, {:unusable_repair, reason}}
+    end
+  end
+
+  # Azzurra's guard chain judges only a secret spoken to Azzurra's NickServ.
+  # A SASL or server password is not, and its 32-byte cap has no business
+  # calling a legitimately longer one unusable — the same scoping
+  # `Credentials.update_credential_password/2` applies at the #124 door.
+  @spec classify_unusable(NSInterceptor.vet_reject_reason(), Credential.auth_method()) ::
+          classification()
+  defp classify_unusable(reason, :nickserv_identify), do: {:report, {:unusable, reason}}
+  defp classify_unusable(_, _), do: :healthy
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _, _} = OptionParser.parse(args, strict: @switches)
+    # Dry run is the default, and the default is the safe direction: writing
+    # is the irreversible half, so it is the half that has to be asked for.
+    write? = Keyword.get(opts, :write, false)
+
+    Boot.start_app_silent()
+
+    classified = Enum.map(Credentials.list_credentials_every_subject(), &{&1, classify(&1)})
+
+    repairable = for {credential, {:repairable, new}} <- classified, do: {credential, new}
+    reported = for {credential, {:report, reason}} <- classified, do: {credential, reason}
+
+    print_scan(classified, repairable, reported)
+    print_rows("reported — nothing written, a human decides:", reported, &describe_reason/1)
+    print_rows("repairable:", repairable, fn _ -> "one rotation — would keep the last token" end)
+
+    finish(write?, repairable, reported)
+  end
+
+  @spec print_scan([{Credential.t(), classification()}], list(), list()) :: :ok
+  defp print_scan(classified, repairable, reported) do
+    blank = Enum.count(classified, &match?({_, :no_password}, &1))
+
+    IO.puts("scanned #{length(classified)} credentials, every subject (#{blank} carry no stored password)")
+    IO.puts("  #{length(repairable)} repairable")
+    IO.puts("  #{length(reported)} reported")
+
+    if repairable == [] and reported == [], do: IO.puts("0 candidates — nothing to repair."), else: :ok
+  end
+
+  @spec print_rows(String.t(), [{Credential.t(), term()}], (term() -> String.t())) :: :ok
+  defp print_rows(_, [], _), do: :ok
+
+  defp print_rows(heading, rows, describe) do
+    IO.puts("")
+    IO.puts(heading)
+    # NEVER the password, nor any token of it, nor its length: this output
+    # goes to an operator's terminal and, from there, to scrollback and
+    # pastebins. The row identity plus the reason is all that is needed to
+    # act on it.
+    Enum.each(rows, fn {credential, detail} ->
+      IO.puts("  #{label(credential)}: #{describe.(detail)}")
+    end)
+  end
+
+  @spec label(Credential.t()) :: String.t()
+  defp label(%Credential{} = credential) do
+    "##{credential.id} (#{subject(credential)} #{credential.nick} @#{credential.network.slug}, #{credential.auth_method})"
+  end
+
+  @spec subject(Credential.t()) :: String.t()
+  defp subject(%Credential{user_id: nil}), do: "visitor"
+  defp subject(%Credential{}), do: "user"
+
+  @spec describe_reason(report_reason()) :: String.t()
+  defp describe_reason(:ambiguous_auth_method),
+    do: "holds a space, but this method's secret may legitimately contain one — not decidable from here"
+
+  defp describe_reason(:multiple_rotations),
+    do: "more than one rotation is concatenated here — which one is live is not derivable"
+
+  defp describe_reason({:unusable, reason}),
+    do: "space-free, but services would refuse it (#{reason}) — it can never identify as stored"
+
+  defp describe_reason({:unusable_repair, reason}),
+    do: "one rotation, but the recovered password would itself be refused (#{reason})"
+
+  @spec finish(boolean(), [{Credential.t(), String.t()}], list()) :: :ok
+  defp finish(_, [], []), do: :ok
+
+  defp finish(false, repairable, _) do
+    new_bug_note()
+    IO.puts("")
+    IO.puts("DRY RUN — nothing written. Re-run with --write to apply the #{length(repairable)} repair(s) above.")
+  end
+
+  defp finish(true, repairable, _) do
+    new_bug_note()
+    IO.puts("")
+    Enum.each(repairable, &apply_repair/1)
+    IO.puts("repaired #{length(repairable)} credential(s).")
+  end
+
+  # Printed whenever anything at all turned up, repairable or not: after #983
+  # closed the capture and #124 opened the cure, a fresh candidate is not
+  # backlog being worked off.
+  @spec new_bug_note() :: :ok
+  defp new_bug_note do
+    IO.puts("")
+
+    IO.puts(
+      "NOTE: #983 stopped the capture concatenating and #124 lets the subject retype their own\n" <>
+        "password, so no credential should be able to become corrupted any more. A candidate found\n" <>
+        "here is the signal of a NEW bug, not routine maintenance — investigate before repairing."
+    )
+  end
+
+  # The repair goes through the #124 door itself, not a hand-rolled update:
+  # `update_credential_password/2` re-encrypts through
+  # `Credential.password_changeset/2` and re-runs Azzurra's chain, so the
+  # sweep writes exactly what a subject retyping the value into Settings ->
+  # General would. A failure is printed, never swallowed.
+  @spec apply_repair({Credential.t(), String.t()}) :: :ok
+  defp apply_repair({credential, new_password}) do
+    case Credentials.update_credential_password(credential, new_password) do
+      {:ok, _} ->
+        IO.puts("  repaired #{label(credential)}")
+
+      {:error, reason} ->
+        IO.puts(:stderr, "  FAILED #{label(credential)}: #{inspect(reason)}")
+    end
+  end
+end

--- a/test/mix/tasks/grappa/repair_passwords_test.exs
+++ b/test/mix/tasks/grappa/repair_passwords_test.exs
@@ -1,0 +1,233 @@
+defmodule Mix.Tasks.Grappa.RepairPasswordsTest do
+  # async: false — see add_server_test.exs for rationale.
+  use Grappa.DataCase, async: false
+
+  import ExUnit.CaptureIO
+  import Grappa.AuthFixtures, only: [visitor_fixture: 1]
+
+  alias Grappa.{Networks, Repo}
+  alias Grappa.Networks.{Credential, Credentials}
+  alias Mix.Tasks.Grappa.RepairPasswords
+
+  # The corrupted shape #977 produced: `SET PASSWD <old> <new>` captured
+  # rest-of-line, so the stored secret is the two passwords joined by the
+  # space `do_set_password` splits on.
+  @two_token "oldpass newpass"
+  @three_token "oldest older newest"
+  # A legitimate SASL passphrase. `auth_fsm.ex:722` base64-encodes it into
+  # PLAIN, so the spaces survive and the credential identifies normally —
+  # this value is NOT corruption, and repairing it would destroy a live
+  # secret.
+  @sasl_passphrase "my pass phrase"
+
+  setup do
+    {:ok, user} = Grappa.Accounts.create_user(%{name: "vjt", password: "correct horse battery staple"})
+    {:ok, network} = Networks.find_or_create_network(%{slug: "azzurra"})
+
+    %{user: user, network: network}
+  end
+
+  defp bind(user, network, password, auth_method) do
+    {:ok, credential} =
+      Credentials.bind_credential(user, network, %{
+        nick: "vjt",
+        password: password,
+        auth_method: auth_method
+      })
+
+    credential
+  end
+
+  defp reload(%Credential{id: id}), do: Repo.get!(Credential, id)
+
+  describe "classify/1 — the space decides only where Azzurra's rule governs the secret" do
+    test "a space-free nickserv password is healthy", %{user: user, network: network} do
+      credential = bind(user, network, "hunter2000", :nickserv_identify)
+
+      assert RepairPasswords.classify(credential) == :healthy
+    end
+
+    test "two tokens on a nickserv credential repair to the last token", %{user: user, network: network} do
+      credential = bind(user, network, @two_token, :nickserv_identify)
+
+      assert RepairPasswords.classify(credential) == {:repairable, "newpass"}
+    end
+
+    test "three tokens are reported, never guessed", %{user: user, network: network} do
+      credential = bind(user, network, @three_token, :nickserv_identify)
+
+      assert RepairPasswords.classify(credential) == {:report, :multiple_rotations}
+    end
+
+    test "a run of spaces is reported, not collapsed into two tokens", %{user: user, network: network} do
+      # `do_set_password` splits at the FIRST space and then refuses a
+      # `newpass` that still holds one, so this rotation never took
+      # upstream — neither token is known to be live.
+      credential = bind(user, network, "oldpass  newpass", :nickserv_identify)
+
+      assert RepairPasswords.classify(credential) == {:report, :multiple_rotations}
+    end
+
+    test "a trailing space is reported, not silently trimmed", %{user: user, network: network} do
+      credential = bind(user, network, "oldpass newpass ", :nickserv_identify)
+
+      assert RepairPasswords.classify(credential) == {:report, :multiple_rotations}
+    end
+
+    test "a SASL credential with spaces is reported, NEVER repaired", %{user: user, network: network} do
+      credential = bind(user, network, @sasl_passphrase, :sasl)
+
+      assert RepairPasswords.classify(credential) == {:report, :ambiguous_auth_method}
+    end
+
+    test "an :auto credential with spaces is reported — it may resolve to SASL", %{user: user, network: network} do
+      credential = bind(user, network, @sasl_passphrase, :auto)
+
+      assert RepairPasswords.classify(credential) == {:report, :ambiguous_auth_method}
+    end
+
+    test "a :server_pass credential with spaces is reported", %{user: user, network: network} do
+      credential = bind(user, network, @sasl_passphrase, :server_pass)
+
+      assert RepairPasswords.classify(credential) == {:report, :ambiguous_auth_method}
+    end
+
+    test "a :none credential with spaces is reported", %{user: user, network: network} do
+      credential = bind(user, network, @sasl_passphrase, :none)
+
+      assert RepairPasswords.classify(credential) == {:report, :ambiguous_auth_method}
+    end
+
+    test "a credential with no stored password is not a candidate", %{user: user, network: network} do
+      credential = bind(user, network, nil, :none)
+
+      assert credential.password_encrypted == nil
+      assert RepairPasswords.classify(credential) == :no_password
+    end
+
+    test "a space-free nickserv password services would refuse is reported, with the reason",
+         %{user: user, network: network} do
+      credential = bind(user, network, String.duplicate("x", 33), :nickserv_identify)
+
+      assert RepairPasswords.classify(credential) == {:report, {:unusable, :password_max_length}}
+    end
+
+    test "Azzurra's cap does not govern a SASL secret, so a long one stays healthy",
+         %{user: user, network: network} do
+      credential = bind(user, network, String.duplicate("x", 33), :sasl)
+
+      assert RepairPasswords.classify(credential) == :healthy
+    end
+
+    test "two tokens whose repair services would still refuse are reported, not written",
+         %{user: user, network: network} do
+      credential = bind(user, network, "oldpass " <> String.duplicate("x", 33), :nickserv_identify)
+
+      assert RepairPasswords.classify(credential) == {:report, {:unusable_repair, :password_max_length}}
+    end
+  end
+
+  describe "run/1 — dry run is the default and writes nothing" do
+    test "reports the candidate without touching it", %{user: user, network: network} do
+      credential = bind(user, network, @two_token, :nickserv_identify)
+
+      output = capture_io(fn -> RepairPasswords.run([]) end)
+
+      assert output =~ "1 repairable"
+      assert output =~ "DRY RUN"
+      assert reload(credential).password_encrypted == @two_token
+    end
+
+    test "never prints the stored secret or either of its tokens", %{user: user, network: network} do
+      _ = bind(user, network, @two_token, :nickserv_identify)
+
+      output = capture_io(fn -> RepairPasswords.run([]) end)
+
+      refute output =~ "oldpass"
+      refute output =~ "newpass"
+    end
+
+    test "a healthy database reports zero candidates and stays silent about a new bug",
+         %{user: user, network: network} do
+      _ = bind(user, network, "hunter2000", :nickserv_identify)
+
+      output = capture_io(fn -> RepairPasswords.run([]) end)
+
+      assert output =~ "0 candidates"
+      refute output =~ "NEW bug"
+    end
+
+    test "a candidate found after #124 is called out as the signal of a new bug",
+         %{user: user, network: network} do
+      _ = bind(user, network, @two_token, :nickserv_identify)
+
+      output = capture_io(fn -> RepairPasswords.run([]) end)
+
+      assert output =~ "NEW bug"
+    end
+  end
+
+  describe "run/1 --write" do
+    test "repairs a two-token nickserv credential to the last token", %{user: user, network: network} do
+      credential = bind(user, network, @two_token, :nickserv_identify)
+
+      capture_io(fn -> RepairPasswords.run(["--write"]) end)
+
+      assert reload(credential).password_encrypted == "newpass"
+    end
+
+    test "leaves a SASL passphrase untouched", %{user: user, network: network} do
+      credential = bind(user, network, @sasl_passphrase, :sasl)
+
+      capture_io(fn -> RepairPasswords.run(["--write"]) end)
+
+      assert reload(credential).password_encrypted == @sasl_passphrase
+    end
+
+    test "leaves a three-token credential untouched", %{user: user, network: network} do
+      credential = bind(user, network, @three_token, :nickserv_identify)
+
+      capture_io(fn -> RepairPasswords.run(["--write"]) end)
+
+      assert reload(credential).password_encrypted == @three_token
+    end
+
+    test "never touches the retired nickserv_pass_encrypted column", %{user: user, network: network} do
+      credential = bind(user, network, @two_token, :nickserv_identify)
+
+      legacy = Grappa.Vault.encrypt!("legacy-secret")
+      Repo.query!("UPDATE network_credentials SET nickserv_pass_encrypted = ? WHERE id = ?", [legacy, credential.id])
+
+      capture_io(fn -> RepairPasswords.run(["--write"]) end)
+
+      %{rows: [[after_run]]} =
+        Repo.query!("SELECT nickserv_pass_encrypted FROM network_credentials WHERE id = ?", [credential.id])
+
+      assert after_run == legacy
+    end
+
+    test "sweeps visitor credentials, not only user ones", %{network: network} do
+      visitor = visitor_fixture(nick: "guest42", network_slug: "azzurra")
+      {:ok, anon} = Credentials.get_visitor_credential(visitor.id, network.id)
+
+      {:ok, credential} =
+        anon
+        |> Credential.password_changeset(@two_token)
+        |> Ecto.Changeset.put_change(:auth_method, :nickserv_identify)
+        |> Repo.update()
+
+      capture_io(fn -> RepairPasswords.run(["--write"]) end)
+
+      assert reload(credential).password_encrypted == "newpass"
+    end
+
+    test "is idempotent — a second pass finds nothing left to do", %{user: user, network: network} do
+      _ = bind(user, network, @two_token, :nickserv_identify)
+
+      capture_io(fn -> RepairPasswords.run(["--write"]) end)
+      output = capture_io(fn -> RepairPasswords.run(["--write"]) end)
+
+      assert output =~ "0 candidates"
+    end
+  end
+end

--- a/test/mix/tasks/grappa/repair_passwords_test.exs
+++ b/test/mix/tasks/grappa/repair_passwords_test.exs
@@ -19,6 +19,12 @@ defmodule Mix.Tasks.Grappa.RepairPasswordsTest do
   # this value is NOT corruption, and repairing it would destroy a live
   # secret.
   @sasl_passphrase "my pass phrase"
+  # The maximally dangerous shape: a SASL passphrase of EXACTLY two tokens
+  # is indistinguishable from a #977 concatenation by token count alone, so
+  # only the auth_method gate keeps it from being "repaired" to "phrase".
+  # The three-token value above would survive a broken gate on the token
+  # count, which is the wrong reason to stay green.
+  @sasl_two_token "pass phrase"
 
   setup do
     {:ok, user} = Grappa.Accounts.create_user(%{name: "vjt", password: "correct horse battery staple"})
@@ -176,12 +182,12 @@ defmodule Mix.Tasks.Grappa.RepairPasswordsTest do
       assert reload(credential).password_encrypted == "newpass"
     end
 
-    test "leaves a SASL passphrase untouched", %{user: user, network: network} do
-      credential = bind(user, network, @sasl_passphrase, :sasl)
+    test "leaves a two-token SASL passphrase untouched", %{user: user, network: network} do
+      credential = bind(user, network, @sasl_two_token, :sasl)
 
       capture_io(fn -> RepairPasswords.run(["--write"]) end)
 
-      assert reload(credential).password_encrypted == @sasl_passphrase
+      assert reload(credential).password_encrypted == @sasl_two_token
     end
 
     test "leaves a three-token credential untouched", %{user: user, network: network} do


### PR DESCRIPTION
## Summary

`mix grappa.repair_passwords` sweeps the credentials #977 corrupted. #983 stopped the capture concatenating `SET PASSWD <old> <new>` into one stored value and #124 gave the subject a field to retype the secret in, but neither backfills a row that is already wrong.

**The issue's premise had to be corrected, and the correction is the substance of this PR.** The body claims a stored space means corruption *with no false positives by construction*. That was true of `nickserv_pass_encrypted`, a NickServ-only column. It stopped being true when #124's fold ran `SET password_encrypted = nickserv_pass_encrypted`: `password_encrypted` is now the single home for the NickServ secret **and** the SASL one **and** the server password. SASL PLAIN base64-encodes its passphrase (`auth_fsm.ex:722`), so a space there is legitimate and identifies normally; `password_changeset/2` guards only CR/LF/NUL (`credential.ex:491`), and `update_credential_password/2` applies Azzurra's chain only for `:nickserv_identify` (`credentials.ex:664`) — the #124 field *deliberately* accepts a space-containing password on a `:sasl` row. Implemented literally, the sweep would have truncated `"my pass phrase"` to `"phrase"`: Cloak AES-GCM, no plaintext backup, nothing to reverse it from. Gating this issue behind #124 was right for the schema, and the right schema is exactly the one where the space alone no longer decides. Written up as [a comment on #1001](https://github.com/vjt/grappa-irc/issues/1001#issuecomment-5219853366).

**Classification** — the verb the issue already owed the >2-token case, applied to a second axis. No new mechanism:

| condition | outcome |
|---|---|
| `:nickserv_identify` + space + exactly 2 tokens | **repaired** (last token) |
| `:nickserv_identify` + space + >2 tokens | reported |
| `:sasl` / `:auto` / `:server_pass` / `:none` + space | **reported, never repaired** |
| `:nickserv_identify`, space-free, but services would refuse it | reported, never written |

**The rule everything follows from:** a missed repair costs a manual intervention, a wrong repair costs an unrecoverable secret, and the two do not weigh the same. Hence: dry run is the default; the split is a literal single space with **no `trim:`** (a run of spaces means services refused the rotation outright, so neither token is known to be live); a recovered password services would themselves refuse is reported rather than written; and no output line ever carries the secret or any token of it.

**The detector is borrowed, not re-derived.** `NSInterceptor.vet_password/2` is already public as the second door #124 needed, and its spaces arm is FIRST in the chain, so no later arm can shadow it — that is what makes the call exact rather than approximate. It supplies the `PASSMAX` verdict too, so `32` is not hard-coded where it could drift from the wire door.

**A second reader was needed.** `list_all_credentials/0` is scoped `user_id IS NOT NULL` for #211, correctly, for the subject-scoped admin surfaces it backs. But `Session.Server.rotate_stored_password/2` has a `{:visitor, visitor_id}` clause beside the `{:user, user_id}` one, so a visitor credential corrupts identically. A task whose only output is a count, printing "0 candidates" with a corrupted visitor row in the table, is not a coverage gap but a false statement. Added as a sibling with a doc explaining why both radii are deliberate, rather than by widening the existing one.

**The task stays in the tree** (per vjt's correction): idempotent, inert on a healthy database, and its standing value is the inverse reading — a run that finds anything after #983 and #124 is the signal of a NEW bug, which the output says.

## Test plan

- [x] TDD red first: 23 specs run before the module existed — `23 tests, 23 failures`, all `module is not available`
- [x] `23 tests, 0 failures` after
- [x] **10 mutants injected, 10 killed, 0 survived**, injector aborting unless a substitution matched exactly once, tree committed before each, revert verified clean after each
- [x] A mutation exposed a defect in the *specs*, not the code: removing the auth_method gate left `leaves a SASL passphrase untouched` green, because `"my pass phrase"` is three tokens and the token count was protecting it. Replaced with a two-token SASL passphrase — the shape indistinguishable from a #977 concatenation by count alone. That mutant now kills 5 specs instead of 4 (fixed in its own commit)
- [x] Dialyzer's two `extra_range` warnings treated as design signals, not noise: `verdict/0` split out so each branch carries the reasons it can actually produce
- [x] `scripts/check.sh` rc=0 on the pre-rebase head, tree clean before and after — Credo `no issues`, `deps.audit` `No vulnerabilities found.`, `8 doctests, 56 properties, 5483 tests, 0 failures`, Dialyzer `Total errors: 0`, Sobelow run, bats 336 ok / 0 not ok

## Not asserted

- **No e2e, and no empty spec written in its place.** There is no client surface — this is a mix task. One written for appearances would be worse than none.
- **The task has never been run against a real database**, in production or in dev. Everything known about it comes from the sandboxed suite.
- **The OPERATIONS recipe for running a mix task inside the jail is not verified against m42.** What is established from the repo: the jail has the full source tree and Mix (`deploy.sh` runs `git pull`, `mix deps.get`, `mix compile`, `mix release`, and `mix run --no-start` in the preflight), and the `:4000` collision the old bullet cited was fixed on 2026-07-23 when `Boot.start_app_silent/0` began suppressing the Endpoint. What is **not** established is whether a second BEAM writing the same SQLite file while the live node runs is safe. The doc says so in those terms rather than giving a clean all-clear.
- **That a repair takes effect on the session's next reconnect** is read off `SessionPlan.base_plan/6`, by the same route a #124 field edit takes — inferred from the code, not observed.
- **`scripts/check.sh` was green on `2376d38f`, the pre-rebase head.** The rebase onto `c841bf10` is proven content-identical (patch-set byte-identical excluding docs; docs additive, `80/0` and `33/2`, the two deletions being the stale OPERATIONS bullet replaced on purpose), but the gate has not been re-run on the rebased head. CI decides that.
- **A genuinely corrupted `:sasl` row is reported, not repaired** — one repair fewer for zero destroyed secrets. The operator override discussed for that case was deliberately **not** built, and no half-finished hook was left for it.
