### PR TITLE
#992: /admin as a native command, and the closed set it exposed

### DIFF
--- a/cicchetto/e2e/tests/issue992-admin-command.spec.ts
+++ b/cicchetto/e2e/tests/issue992-admin-command.spec.ts
@@ -1,0 +1,127 @@
+// #992 — /admin [<target>] (RFC 2812 §3.4.4), the fourth member of the #127
+// server-reply family (/info, /version, /motd). The reply is buffered
+// server-side and drained as ONE typed `server_reply` event with source
+// "admin", rendered as the shared ServerReplyModal — never dumped into
+// scrollback.
+//
+// WHY this e2e exists and what only it can see. Every claim in #992's design
+// was read out of the bahamut C source (`m_admin`, `src/s_serv.c:2676`) — the
+// four-terminator set (256-259 / 423 / 402 / 447) was DERIVED, never observed.
+// Until this spec ran, not one real ADMIN numeric had ever crossed a socket in
+// this repo. The unit tests pin the wiring against synthesised messages; this
+// pins it against an ircd that actually answers.
+//
+// The two asserts that discriminate, rather than mirror:
+//
+//   1. The 259 line is PRESENT in the modal. RPL_ADMINEMAIL is NOT the
+//      RPL_ENDOFMOTD-shaped pure terminator it is often mistaken for: its
+//      format is `":%s 259 %s :%s"` fed `aconf->name` (`s_err.c:297`), the
+//      contact address — the single most useful line of the reply. A design
+//      that treated 259 as a bare terminator would still show a modal, still
+//      show lines, and still pass a "modal appeared" test — while silently
+//      dropping the address. Asserting the testnet's A-line email
+//      (`root@leaf4.azzurra.chat`, `infra/bahamut/conf.leaf4.tmpl` field 3 →
+//      `aconf->name`) is what tells the two designs apart.
+//
+//   2. `/admin <unknown-server>` surfaces a 402. A BARE `ADMIN` can only ever
+//      yield 256-259 or 423 — it can NEVER produce ERR_NOSUCHSERVER, which
+//      comes from `hunt_server()` on a target grappa had to put on the wire.
+//      So a surfaced 402 is unforgeable proof the target argument survived
+//      cic's parser, the channel door, and `Client.send_admin/2`. It also
+//      exercises the shared 402 owner clause (`@server_reply_402_owners`):
+//      with only `admin_pending` armed, the error must surface as "admin".
+//
+// NOT covered here, and deliberately so: 423 ERR_NOADMININFO needs a leaf with
+// NO A: line, and 447 ERR_RESTRICTED needs a restricted-class user. Neither is
+// reachable without reshaping the shared testnet, so both stay unit-tested
+// against synthesised numerics in test/grappa/session/event_router_test.exs.
+//
+// Server-side threading (client wire, channel target validation, EventRouter
+// accumulate + drain, 402 ownership) is unit-tested in
+// test/grappa/irc/client_test.exs, test/grappa_web/channels/grappa_channel_test.exs
+// and test/grappa/session/event_router_test.exs. The parser + compose plumbing
+// is unit-tested in cicchetto/src/__tests__/{slashCommands,compose}.test.ts.
+
+import { expect, test } from "../fixtures/test";
+import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// The leaf `bahamut-test` resolves to (compose.yaml aliases leaf-v4 as both
+// `bahamut-test` and `leaf4.azzurra.chat`), and its A: line, rendered by
+// infra/bahamut/conf.leaf4.tmpl into `aconf->{host,passwd,name}` — the exact
+// payloads of 257, 258 and 259 respectively (s_conf.c:1469-1479).
+const LEAF = "leaf4.azzurra.chat";
+const ADMIN_LOC1 = "Azzurra testnet leaf v4";
+const ADMIN_LOC2 = "testnet admin";
+const ADMIN_EMAIL = `root@${LEAF}`;
+
+// A dotted name matching no server on the testnet → bahamut's hunt_server
+// answers 402. No wildcards, so it can never accidentally match a leaf.
+const BOGUS_SERVER = "no.such.admin.grappa.test";
+
+test("#992 — /admin renders the four-numeric reply in the modal, 259's contact address included", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  await composeSend(page, "/admin");
+
+  const modal = page.getByTestId("server-reply-modal");
+  await expect(modal).toBeVisible({ timeout: 10_000 });
+  await expect(modal).toHaveAttribute("data-source", "admin");
+  await expect(modal.locator("#server-reply-modal-title")).toContainText("Server Administrator");
+
+  // find_admin() hit → exactly four lines, in wire order: 256 (the "about
+  // <server>" header), then the three A: line fields. Three lines would mean
+  // 259 was drained as a pure terminator without folding its own body.
+  const lines = modal.locator('[data-testid="server-reply-modal-line"]');
+  await expect(lines).toHaveCount(4);
+  await expect(lines.nth(0)).toContainText(`Administrative info about ${LEAF}`);
+  await expect(lines.nth(1)).toContainText(ADMIN_LOC1);
+  await expect(lines.nth(2)).toContainText(ADMIN_LOC2);
+  await expect(lines.nth(3)).toContainText(ADMIN_EMAIL);
+
+  // Never swallowed into scrollback — the drain persists nothing (mirror #127).
+  await expect(scrollbackLine(page, "notice", ADMIN_EMAIL)).toHaveCount(0);
+
+  // × dismisses the modal.
+  await modal.getByLabel("close").click();
+  await expect(modal).toBeHidden({ timeout: 2_000 });
+});
+
+test("#992 — /admin <unknown-server> surfaces the 402 under the admin source (target reached the wire)", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  await composeSend(page, `/admin ${BOGUS_SERVER}`);
+
+  const modal = page.getByTestId("server-reply-modal");
+  await expect(modal).toBeVisible({ timeout: 10_000 });
+
+  // Only admin_pending is armed (motd_pending is primed by an explicit /motd
+  // only — the connect-time MOTD burst leaves it nil), so the shared 402
+  // clause must surface the error as "admin", not as #374's "motd".
+  await expect(modal).toHaveAttribute("data-source", "admin");
+  await expect(modal.locator("#server-reply-modal-title")).toContainText("Server Administrator");
+
+  // The surfaced line is the 402 trailing. A bare ADMIN never yields one.
+  const lines = modal.locator('[data-testid="server-reply-modal-line"]');
+  await expect(lines.filter({ hasText: /no such server/i }).first()).toBeVisible();
+
+  // The error did NOT get swallowed into a wrong-server admin reply: the
+  // real leaf's contact address must be absent.
+  await expect(lines.filter({ hasText: ADMIN_EMAIL })).toHaveCount(0);
+
+  // Never persisted to scrollback.
+  await expect(scrollbackLine(page, "notice", "No such server")).toHaveCount(0);
+
+  await modal.getByLabel("close").click();
+  await expect(modal).toBeHidden({ timeout: 2_000 });
+});

--- a/cicchetto/src/ServerReplyModal.tsx
+++ b/cicchetto/src/ServerReplyModal.tsx
@@ -29,6 +29,7 @@ const SOURCE_TITLE: Record<ServerReplySource, string> = {
   info: "Server Info",
   version: "Version",
   motd: "Message of the Day",
+  admin: "Server Administrator",
 };
 
 const ServerReplyModal: Component = () => {

--- a/cicchetto/src/__tests__/ServerReplyModal.test.tsx
+++ b/cicchetto/src/__tests__/ServerReplyModal.test.tsx
@@ -46,6 +46,19 @@ describe("ServerReplyModal (#127)", () => {
     expect(modal.textContent).toContain("1 line");
   });
 
+  // #992 — /admin is the fourth source in the family. The 256-259 burst is
+  // free-text A:line contact info, so it renders through the same surface;
+  // only the title + the data-source hook are new.
+  it("titles /admin from the typed source (#992)", () => {
+    focusNetwork();
+    setServerReply(SLUG, reply("admin", ["Administrative info about irc.azzurra.chat", "vjt"]));
+    render(() => <ServerReplyModal />);
+    const modal = screen.getByTestId("server-reply-modal");
+    expect(modal.getAttribute("data-source")).toBe("admin");
+    expect(modal.textContent).toContain("Server Administrator");
+    expect(modal.textContent).toContain("2 lines");
+  });
+
   it("closes on the × button (dismisses the store entry)", () => {
     focusNetwork();
     setServerReply(SLUG, reply("version", ["bahamut-2.2.1"]));

--- a/cicchetto/src/__tests__/slashCommands.test.ts
+++ b/cicchetto/src/__tests__/slashCommands.test.ts
@@ -846,6 +846,29 @@ describe("parseSlash — info verbs (TODO — server-side missing)", () => {
       target: "void.azzurra.chat",
     });
   });
+
+  // #992 — /admin [<target>] (RFC 2812 §3.4.4), the fourth member of the
+  // #127/#374 server-text family. Same optional-single-token grammar as
+  // /motd: bahamut routes both through the same `hunt_server`
+  // (src/s_serv.c m_admin:2683), so bare = the current server's A:line and
+  // a target routes the query through that server.
+  it("/admin bare → admin with no target", () => {
+    expect(parseSlash("/admin")).toEqual({ kind: "admin", target: null });
+  });
+
+  it("/admin <server> → admin carrying the target server", () => {
+    expect(parseSlash("/admin void.azzurra.chat")).toEqual({
+      kind: "admin",
+      target: "void.azzurra.chat",
+    });
+  });
+
+  it("/admin <server> <extra> → only the first token is the target", () => {
+    expect(parseSlash("/admin void.azzurra.chat junk")).toEqual({
+      kind: "admin",
+      target: "void.azzurra.chat",
+    });
+  });
 });
 
 // #581 — /recover [network]: guided "recover my identity". Optional first

--- a/cicchetto/src/__tests__/userTopic.test.ts
+++ b/cicchetto/src/__tests__/userTopic.test.ts
@@ -1156,6 +1156,25 @@ describe("userTopic", () => {
       });
     });
 
+    // #992 — /admin is the fourth source. RED before the fix: the arm
+    // hardcoded a three-way `!==` chain instead of reading the
+    // SESSION_WIRE_SERVER_REPLY_SOURCE SSOT, so a legitimate admin reply
+    // was dropped as "unknown source" and the modal never opened.
+    it("accepts source 'admin' (#992)", async () => {
+      const srm = await import("../lib/serverReplyModal");
+      channelMock.fireEvent({
+        kind: "server_reply",
+        network: "azzurra",
+        source: "admin",
+        lines: ["Administrative info about irc.azzurra.chat", "vjt"],
+      });
+      expect(srm.setServerReply).toHaveBeenCalledWith("azzurra", {
+        network: "azzurra",
+        source: "admin",
+        lines: ["Administrative info about irc.azzurra.chat", "vjt"],
+      });
+    });
+
     it("drops a payload with an unknown source (no setServerReply call)", async () => {
       const srm = await import("../lib/serverReplyModal");
       channelMock.fireEvent({

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -36,6 +36,7 @@ import { isServicesSender } from "./servicesSender";
 import { requestOpenSettings } from "./settingsNav";
 import { parseSlash } from "./slashCommands";
 import {
+  pushAdmin,
   pushAwaySet,
   pushAwayUnset,
   pushChannelBan,
@@ -1566,6 +1567,15 @@ const exports_ = identityScopedStore((onIdentityChange) => {
           // ERR_NOSUCHSERVER for an unknown target surfaces via the same
           // server_reply modal, never a wrong-server MOTD.
           await pushMotd(networkId, cmd.target); // S6 (#364): await verb-ack
+          result = { ok: true };
+          break;
+        }
+        // #992 — /admin [<target>]. Same door as /motd; the reply lands in
+        // the same server_reply modal under the `admin` source.
+        case "admin": {
+          const networkId = networkIdBySlug(networkSlug);
+          if (networkId === undefined) return { error: "/admin: network not found" };
+          await pushAdmin(networkId, cmd.target); // S6 (#364): await verb-ack
           result = { ok: true };
           break;
         }

--- a/cicchetto/src/lib/slashCommands.ts
+++ b/cicchetto/src/lib/slashCommands.ts
@@ -167,6 +167,9 @@ export type SlashCommand =
   | { kind: "info" }
   | { kind: "version" }
   | { kind: "motd"; target: string | null }
+  // #992 — /admin [<target>] (RFC 2812 §3.4.4). Fourth member of the
+  // server-text family; same optional-single-token grammar as /motd.
+  | { kind: "admin"; target: string | null }
   | { kind: "stats"; query: string | null; target: string | null }
   | { kind: "rehash"; opt: string | null }
   | { kind: "whois"; nick: string | null; server: string | null }
@@ -668,6 +671,14 @@ const DISPATCH: Readonly<Record<string, Handler>> = {
   motd: (_verb, rest) => {
     const [target] = tokens(rest);
     return { kind: "motd", target: target ?? null };
+  },
+  // #992 — /admin [<target>] (RFC 2812 §3.4.4). bahamut's m_admin routes
+  // through the same `hunt_server` as m_motd (src/s_serv.c:2683), so the
+  // grammar is /motd's: bare = the connected server's A:line, one token =
+  // route the query there, trailing tokens ignored (1-slot wire frame).
+  admin: (_verb, rest) => {
+    const [target] = tokens(rest);
+    return { kind: "admin", target: target ?? null };
   },
 
   // #155 — /stats [query] [server]. Native parser sugar over the raw

--- a/cicchetto/src/lib/socket.ts
+++ b/cicchetto/src/lib/socket.ts
@@ -758,6 +758,18 @@ export function pushMotd(networkId: number, target: string | null): Promise<void
   );
 }
 
+// #992 — /admin [<target>]. Identical optional-arg shape to pushMotd: bare
+// omits the wire key so grappa emits `ADMIN`, a target sends `{ target }` so
+// grappa emits `ADMIN <target>`. The 256/257/258/259 burst (or 423
+// ERR_NOADMININFO / 402 ERR_NOSUCHSERVER / 447 ERR_RESTRICTED) routes back
+// through the same server_reply modal.
+export function pushAdmin(networkId: number, target: string | null): Promise<void> {
+  return pushUserChannelVerb(
+    "admin",
+    target === null ? { network_id: networkId } : { network_id: networkId, target },
+  );
+}
+
 // #238 — /links [<mask>]. Bare (mask null) omits the wire key so grappa emits
 // `LINKS`; a mask sends `{ mask }` so grappa emits `LINKS <mask>`. The 364/365
 // burst drains ONE ephemeral `links_bundle` event on Topic.user/1 which

--- a/cicchetto/src/lib/userTopic.ts
+++ b/cicchetto/src/lib/userTopic.ts
@@ -63,11 +63,15 @@ import {
   narrowWhoUsers,
   narrowWindowStateEvent,
 } from "./wireNarrow";
-import type { ServerSettingsWireUploadView } from "./wireTypes";
+import type { ServerSettingsWireUploadView, SessionWireServerReplySource } from "./wireTypes";
 // #410 — the connection_state runtime guard derives from the generated const
 // (mirror of `Grappa.Networks.Credential.connection_state/0`), single-sourced
-// like the leaf-enum allowlists in wireNarrow.ts.
-import { NETWORKS_CREDENTIAL_CONNECTION_STATE } from "./wireTypes";
+// like the leaf-enum allowlists in wireNarrow.ts. #992 adds the server_reply
+// source set on the same footing.
+import {
+  NETWORKS_CREDENTIAL_CONNECTION_STATE,
+  SESSION_WIRE_SERVER_REPLY_SOURCE,
+} from "./wireTypes";
 
 // Per-user PubSub topic subscriber. Module-singleton side-effect:
 // imports for effect, exports nothing public. `main.tsx` imports this
@@ -669,16 +673,23 @@ export function narrowUserEvent(raw: unknown): WireUserEvent | null {
       return { kind: "who_reply", network: r.network, target: r.target, users };
     }
     case "server_reply": {
-      // #127 — /info, /version, /motd reply bundle. Validate the typed
-      // `source` discriminant + the raw line array; a malformed payload
+      // #127/#992 — /info, /version, /motd, /admin reply bundle. Validate the
+      // typed `source` discriminant + the raw line array; a malformed payload
       // drops rather than rendering a half-typed modal.
+      //
+      // #992 — the discriminant is checked against the
+      // SESSION_WIRE_SERVER_REPLY_SOURCE SSOT, not a hand-written `!==`
+      // chain. The chain was a second, silent copy of the closed set: adding
+      // `admin` server-side left it rejecting a legitimate reply as "unknown
+      // source", so the modal never opened and the failure was invisible.
       if (typeof r.network !== "string") return null;
-      if (r.source !== "info" && r.source !== "version" && r.source !== "motd") return null;
+      if (!SESSION_WIRE_SERVER_REPLY_SOURCE.includes(r.source as SessionWireServerReplySource))
+        return null;
       if (!Array.isArray(r.lines) || !r.lines.every((l) => typeof l === "string")) return null;
       return {
         kind: "server_reply",
         network: r.network,
-        source: r.source,
+        source: r.source as SessionWireServerReplySource,
         lines: r.lines as string[],
       };
     }

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -956,7 +956,7 @@ export type SessionWireWhoReplyPayload = {
   users: SessionWireWhoUser[];
 };
 
-export const SESSION_WIRE_SERVER_REPLY_SOURCE = ["info", "version", "motd"] as const;
+export const SESSION_WIRE_SERVER_REPLY_SOURCE = ["info", "version", "motd", "admin"] as const;
 export type SessionWireServerReplySource = (typeof SESSION_WIRE_SERVER_REPLY_SOURCE)[number];
 
 export type SessionWireServerReplyPayload = {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -33291,3 +33291,36 @@ constant.
   `/motd` injection test was then measured and has the same shape** — it does
   not prove its channel gate either. Left as-is; noted here so the next reader
   does not mistake it for coverage.
+
+**The paragraph above about duplicated closed sets was written while a second
+copy of the same set was still live on the SERVER — and it killed the session.**
+`Grappa.Session.Wire.server_reply/3` guarded `source` with a hand-spelled
+`[:info, :version, :motd]` sitting a few hundred lines below the type union that
+had just grown `:admin`. Nothing caught it: 5482 unit tests, 56 properties, 4599
+vitest tests, Dialyzer and Credo all passed, because every one of them exercised
+a source the guard already knew. The first real 259 off leaf4 raised
+`FunctionClauseError` inside `apply_effects/2`, which is not a rejected frame but
+a **dead `Session.Server`** — the whole IRC connection dropped, for both `/admin`
+shapes. The set now has exactly one spelling (`@server_reply_sources`): the type
+union is derived from it via `unquote`, the guard reads it, and
+`server_reply_sources/0` hands it to the tests that enumerate it — including the
+property allowlist that was quietly becoming copy number three. The generated
+`wireTypes.ts` is byte-identical, because a derived union compiles to the same
+beam typespec `Code.Typespec.fetch_types/1` reads. **Carry this: fixing the copy
+you found is not fixing the class. Grep for the set's other spellings before
+calling it done — the one you cannot see is the one in production.**
+
+**Why the e2e was worth a lane, stated concretely.** Every terminator claim in
+this entry was read out of C and cited by file:line; not one had been observed.
+`cicchetto/e2e/tests/issue992-admin-command.spec.ts` is the first time an ADMIN
+numeric crossed a socket in this repo, and it found the crash above on its first
+run — a defect no synthesised-message test could reach, because the gap was
+between two copies of a set rather than inside any one code path. The spec is
+built to discriminate rather than mirror: it pins the 259 body (`aconf->name`,
+the contact address) as a distinct modal line, because a build that drained on
+259 without folding it still shows a modal with three plausible lines; and it
+drives `/admin <unknown-server>` for a 402, which a bare ADMIN can never produce,
+so the surfaced error is unforgeable proof the target survived cic's parser, the
+channel door and `Client.send_admin/2`. 423 and 447 stay unit-tested — the first
+needs a leaf with no `A:` line, the second a restricted-class user, and neither
+is reachable without reshaping the shared testnet for one spec.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -33198,7 +33198,9 @@ entry points rather than the jail's alone — the Linux copy was previously
 untested, which is a large part of how it drifted — plus one structural case
 asserting that exactly one file under `infra/` defines the algorithm. That last
 one is red on the parent commit for the right reason: two definers.
+
 ---
+
 ## 2026-08-07 — #992: /admin has four ways to answer, and 402 belongs to nobody
 
 **`/admin` was filed as the fourth member of the #127/#374 server-text family,

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -33198,3 +33198,96 @@ entry points rather than the jail's alone — the Linux copy was previously
 untested, which is a large part of how it drifted — plus one structural case
 asserting that exactly one file under `infra/` defines the algorithm. That last
 one is red on the parent commit for the right reason: two definers.
+---
+## 2026-08-07 — #992: /admin has four ways to answer, and 402 belongs to nobody
+
+**`/admin` was filed as the fourth member of the #127/#374 server-text family,
+and most of it is.** Parser, push, channel door, accumulator, modal: /motd's
+shapes, verbatim. Upstream justifies the copying rather than merely excusing it
+— bahamut hands the optional target of `m_motd` and `m_admin` to the *same*
+`hunt_server` call, in the same argument slot (`src/s_user.c:267`), so one
+grammar and one single-wire-token validator is the correct answer, and a second
+subtly-different one would be the defect. `validate_motd_target/1` became
+`validate_server_target/1` for that reason. `/links` kept its own: a mask is not
+a server target, even though today the byte gate happens to be identical.
+
+**The terminator set is four wide, and that is the whole issue.** Read out of
+`m_admin` (`src/s_serv.c:2676`), which has exactly four exits: 256/257/258/259
+when `find_admin()` hits; **423 ERR_NOADMININFO** when it misses, with *no*
+256-259 sent at all; **402 ERR_NOSUCHSERVER** from `hunt_server`; **447
+ERR_RESTRICTED** from `check_restricted_user` (`src/s_misc.c:1211`), which fires
+and returns before anything else. An accumulator waiting only on 259 stays armed
+on three of the four. There is no timeout on these flags, so the honest
+statement of the damage is not "armed forever" — the next explicit /admin
+re-arms unconditionally — but (a) no modal for the request that asked, and (b) a
+later unsolicited burst folding into the stale lines instead of reaching
+`$server`.
+
+**259 is not 376.** RPL_ENDOFMOTD is a pure terminator; RPL_ADMINEMAIL is
+`":%s 259 %s :%s"` fed `aconf->name`, the contact address — the single most
+useful line in the reply. Every terminator here folds its own line before
+draining. Only 256/257/258 are pure accumulation. A mutant that moved 259 into
+the fold-only branch was killed by the test that pins the drained line list.
+
+**402 ERR_NOSUCHSERVER now has its own clause, because it is owned by no verb.**
+`/motd <target>` and `/admin <target>` both reach it through the same
+`hunt_server`, and the wire carries no correlation tag — no label, no verb echo.
+The considered-and-rejected discriminator was gating on whether the accumulator
+was primed *with* a target, which is sound (a bare request cannot produce a 402:
+`hunt_server` returns `HUNTED_ISME` when the target param is absent) but adds
+state to defend a case the simpler rule already covers. **The rule shipped is:
+on a 402, disarm every armed candidate and surface the error once.** The
+asymmetry is deliberate and is the reasoning worth keeping — an accumulator left
+armed is a real break, while over-clearing costs at most one modal that the next
+explicit request re-arms anyway. Those two failure modes do not weigh the same,
+so the tie is broken toward over-clearing. MOTD leads the priority order purely
+so #374's shipped behaviour is byte-identical whenever /admin is not in flight.
+
+**ADMIN (256-259) moved from `@active_numerics` to `@delegated_numerics`, which
+moved #911's guarantee out from under its own proof.** #911 measured that a
+one-word dotless A-line ("Azzurra", "staff", a nick) fed verbatim into 257's
+only middle would be scan-routed as a *query destination*, and closed it with
+the active deny-list. Delegation short-circuits one rung *above* that deny-list,
+so the old test could be flipped to `:delegated` and #911 would silently reopen
+with every test green. The guarantee is re-proven at its new owner instead: an
+`event_router_test` case asserts that an unprimed 257 carrying a bare "Azzurra"
+still lands on `$server`. General rule worth carrying: **when a decision moves
+between precedence layers, the property it guaranteed has to be re-proven at the
+new layer, not assumed to have travelled with it.**
+
+**A validator that duplicates a closed set will be forgotten.** cic's
+`userTopic` `server_reply` arm guarded `source` with a hand-written three-way
+`!==` chain — a second, silent copy of `SESSION_WIRE_SERVER_REPLY_SOURCE`.
+Adding `admin` server-side would have left it rejecting a legitimate reply as
+"unknown source": no modal, no error, nothing at all. It now reads the generated
+constant.
+
+**Measured negative results, recorded because they were the expensive part.**
+
+- **ADMIN is not rate-limited upstream.** `static time_t last_used` appears in
+  exactly one file and four functions — `m_info:1257`, `m_stats:1607`,
+  `m_help:2029`, `m_motd:5287` — and `m_admin` is not among them. So every ADMIN
+  path answers with a numeric and the four-terminator set is *exhaustive*, not
+  merely wider than one. Had ADMIN throttled, #992 would have had a no-reply
+  terminator class, which no numeric can cure.
+- **`/motd` and `/info` DO have that no-reply class, and it is not a missing
+  numeric.** `MOTD_WAIT` is 10 seconds (`include/config.h:501`, commented
+  "minimum seconds between use of MOTD, INFO, HELP, LINKS"), and for a non-oper
+  inside the window both handlers `return 0` with **no numeric at all**.
+  `last_used` is a function-static, so it is global to the ircd, not per-client:
+  on a busy network any non-oper's `/motd` in the last 10s silences yours. The
+  user types `/motd` and nothing whatsoever happens. `/version` is clean (no
+  throttle, no restricted check, bare VERSION always hits `HUNTED_ISME`).
+  `/links` has a third shape: `m_links` calls `check_restricted_user`, so 447
+  can arrive where only 365 is expected — bounded, but only by #513b's
+  stale-clobber. Out of scope for #992 and deliberately not filed here.
+- **An injection test that asserts only the outcome does not prove the door.**
+  The `/admin` channel test rejecting `"srv\r\nQUIT"` survived a mutant that
+  neutralised `validate_server_target/1`, because `Client.send_admin/2` gates on
+  the same predicate and produces an identical observable. The end-to-end
+  guarantee is real and was kept; a non-binary target was added alongside it,
+  which only the channel's catch-all clause can answer (`Session.send_admin/3`'s
+  guard requires binary-or-nil, so without the door the call raises). **#374's
+  `/motd` injection test was then measured and has the same shape** — it does
+  not prove its channel gate either. Left as-is; noted here so the next reader
+  does not mistake it for coverage.

--- a/lib/grappa/irc/client.ex
+++ b/lib/grappa/irc/client.ex
@@ -920,6 +920,44 @@ defmodule Grappa.IRC.Client do
   end
 
   @doc """
+  #992 — sends `ADMIN [<target>]\\r\\n` upstream (RFC 2812 §3.4.4). `nil`
+  emits a bare `ADMIN` (the connected server's A-line); a target emits
+  `ADMIN <target>` so the query routes through that server.
+
+  Four reply shapes, all measured in azzurra/bahamut `src/s_serv.c`
+  `m_admin` (`:2676`): the 256/257/258/259 burst when `find_admin()` hits,
+  **423 ERR_NOADMININFO** when it misses (and then NO 256-259 arrives at
+  all), **402 ERR_NOSUCHSERVER** from `hunt_server` on an unknown target,
+  and **447 ERR_RESTRICTED** from `check_restricted_user` (`s_misc.c:1211`)
+  before anything else. When primed by `:send_admin`, `EventRouter` folds
+  the burst into `state.admin_pending` and drains a
+  `{:server_reply, :admin, lines}` modal effect on ANY of the four
+  terminators — 259 included, which unlike 376 RPL_ENDOFMOTD carries the
+  contact address as content and so folds its own line before draining.
+
+  Unlike `/motd` and `/info`, ADMIN is NOT rate-limited upstream:
+  `static time_t last_used` appears in exactly four `s_serv.c` handlers
+  (`m_info:1257`, `m_stats:1607`, `m_help:2029`, `m_motd:5287`) and
+  `m_admin` is not among them. So every ADMIN path answers with a numeric
+  and the four-terminator set is exhaustive — there is no silent-drop case
+  to defend against here.
+
+  The target is gated by `safe_oper_token?/1` (a single wire token — no
+  whitespace/CRLF/NUL) so it cannot splice an extra wire slot or inject a
+  follow-up command; rejection yields `{:error, :invalid_line}`.
+  """
+  @spec send_admin(pid(), String.t() | nil) :: send_result()
+  def send_admin(client, nil) do
+    send_line(client, "ADMIN\r\n")
+  end
+
+  def send_admin(client, target) when is_binary(target) do
+    if Identifier.safe_oper_token?(target),
+      do: send_line(client, "ADMIN #{target}\r\n"),
+      else: reject_invalid_line(:admin)
+  end
+
+  @doc """
   #238 — sends `LINKS [<mask>]\\r\\n` upstream (RFC 2812 §3.4.5). `nil`
   emits a bare `LINKS` (the full server mesh); a mask emits `LINKS <mask>`
   to filter the reply to matching server names. Server replies with the

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -1628,6 +1628,27 @@ defmodule Grappa.Session do
   end
 
   @doc """
+  #992 — sends `ADMIN [<target>]` upstream (primes `admin_pending`). `nil`
+  = the connected server's A-line; a `target` routes the query through that
+  server (RFC 2812 §3.4.4). The 256/257/258/259 burst — or any of the three
+  error terminators, 423 ERR_NOADMININFO / 402 ERR_NOSUCHSERVER / 447
+  ERR_RESTRICTED — is drained as a typed `:server_reply` (source `:admin`)
+  wire event on `Topic.user/1`, into the same modal /motd uses.
+
+  Read-only server query, so visitors are entitled to it (mirror of /motd
+  + /lusers). Returns `:ok`, `{:error, :no_session}`, or
+  `{:error, :invalid_line}` if a non-nil target's syntax is rejected by
+  `Grappa.IRC.Client.send_admin/2`.
+  """
+  @spec send_admin(subject(), integer(), String.t() | nil) ::
+          :ok | {:error, :no_session | :invalid_line | send_transport_error()}
+  def send_admin(subject, network_id, target)
+      when is_subject(subject) and is_integer(network_id) and
+             (is_binary(target) or is_nil(target)) do
+    call_session(subject, network_id, {:send_admin, target})
+  end
+
+  @doc """
   #238 — sends `LINKS [<mask>]` upstream (primes `links_pending`). `nil`
   = the full server mesh; a `mask` filters the reply to matching server
   names (RFC 2812 §3.4.5). The 364 RPL_LINKS burst + 365 RPL_ENDOFLINKS

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -2152,7 +2152,7 @@ defmodule Grappa.Session.EventRouter do
          %Message{command: {:numeric, motd_numeric}} = msg,
          state
        )
-       when motd_numeric in [375, 372, 376, 422, 402] do
+       when motd_numeric in [375, 372, 376, 422] do
     case Map.get(state, :motd_pending) do
       nil ->
         persist_server_notice(state, msg)
@@ -2165,10 +2165,93 @@ defmodule Grappa.Session.EventRouter do
           motd_numeric == 376 ->
             {:cont, %{state | motd_pending: nil}, [{:server_reply, :motd, server_reply_drain(accum)}]}
 
-          motd_numeric in [422, 402] ->
+          motd_numeric == 422 ->
             drained = server_reply_drain(server_reply_fold(accum, msg))
             {:cont, %{state | motd_pending: nil}, [{:server_reply, :motd, drained}]}
         end
+    end
+  end
+
+  # #992 — ADMIN (256 RPL_ADMINME, 257 RPL_ADMINLOC1, 258 RPL_ADMINLOC2,
+  # 259 RPL_ADMINEMAIL) + 423 ERR_NOADMININFO + 447 ERR_RESTRICTED. Fourth
+  # member of the #127 family, gated on `state.admin_pending` (primed by
+  # `:send_admin`); unprimed it falls back to the same `$server` :notice
+  # persist, so an unsolicited burst is visible, never silent.
+  #
+  # WHY the terminator set is four wide and not one. Read out of
+  # azzurra/bahamut `m_admin` (`src/s_serv.c:2676`), which has exactly four
+  # exits and no fifth:
+  #
+  #   * `find_admin()` hit  → 256, 257, 258, 259 in that fixed order.
+  #   * `find_admin()` miss → 423 and NO 256-259 at all (`:2703`).
+  #   * `hunt_server()` non-ISME → 402 (see the dedicated 402 clause).
+  #   * `check_restricted_user()` → 447, returning BEFORE everything else
+  #     (`src/s_misc.c:1211`).
+  #
+  # Waiting only on 259 would leave `admin_pending` armed on three of those
+  # four, and there is NO timeout on these flags — the next explicit /admin
+  # re-arms unconditionally, but this request gets no modal and a later
+  # unsolicited burst folds into the stale lines instead of reaching
+  # `$server`.
+  #
+  # UNLIKE 376 RPL_ENDOFMOTD, the happy-path terminator 259 CARRIES CONTENT
+  # (`":%s 259 %s :%s"`, fed `aconf->name` — the contact address, the single
+  # most useful line in the reply), so every terminator here folds its own
+  # line before draining. Only 256/257/258 are pure accumulation.
+  #
+  # ADMIN is NOT rate-limited upstream: `static time_t last_used` lives in
+  # exactly four `s_serv.c` handlers (`m_info`, `m_stats`, `m_help`,
+  # `m_motd`) and `m_admin` is not one of them. So unlike /motd and /info,
+  # there is no silent-no-reply path here for the accumulator to fall into.
+  defp do_route(
+         %Message{command: {:numeric, admin_numeric}} = msg,
+         state
+       )
+       when admin_numeric in [256, 257, 258, 259, 423, 447] do
+    case Map.get(state, :admin_pending) do
+      nil ->
+        persist_server_notice(state, msg)
+
+      accum ->
+        folded = server_reply_fold(accum, msg)
+
+        if admin_numeric in [256, 257, 258] do
+          {:cont, %{state | admin_pending: folded}, []}
+        else
+          {:cont, %{state | admin_pending: nil},
+           [{:server_reply, :admin, server_reply_drain(folded)}]}
+        end
+    end
+  end
+
+  # #374/#992 — 402 ERR_NOSUCHSERVER, a terminator owned by no single verb.
+  # `/motd <target>` and `/admin <target>` both route through bahamut's
+  # `hunt_server` (`src/s_user.c:267`), which answers an unknown target with
+  # a bare `402 <nick> <target> :No such server`. The wire carries NO
+  # correlation tag — no label, no verb echo — so when both accumulators are
+  # armed there is no way to tell whose 402 this is.
+  #
+  # Ruling: disarm EVERY armed candidate and surface the error ONCE. The
+  # asymmetry is deliberate. An accumulator left armed is a real break (no
+  # modal for the request that asked, AND a later unsolicited burst folds
+  # into the stale lines instead of reaching `$server`), while over-clearing
+  # costs at most one modal that the next explicit request re-arms
+  # unconditionally. The two failure modes do not weigh the same.
+  #
+  # The surfaced `source` is the first armed in @server_reply_402_owners
+  # order. MOTD leads so #374's shipped behaviour is byte-identical whenever
+  # /admin is not in flight.
+  @server_reply_402_owners [{:motd_pending, :motd}, {:admin_pending, :admin}]
+
+  defp do_route(%Message{command: {:numeric, 402}} = msg, state) do
+    case Enum.filter(@server_reply_402_owners, fn {key, _} -> Map.get(state, key) end) do
+      [] ->
+        persist_server_notice(state, msg)
+
+      [{key, source} | _] = armed ->
+        drained = server_reply_drain(server_reply_fold(Map.get(state, key), msg))
+        disarmed = Enum.reduce(armed, state, fn {k, _}, acc -> Map.put(acc, k, nil) end)
+        {:cont, disarmed, [{:server_reply, source, drained}]}
     end
   end
 

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -2218,8 +2218,7 @@ defmodule Grappa.Session.EventRouter do
         if admin_numeric in [256, 257, 258] do
           {:cont, %{state | admin_pending: folded}, []}
         else
-          {:cont, %{state | admin_pending: nil},
-           [{:server_reply, :admin, server_reply_drain(folded)}]}
+          {:cont, %{state | admin_pending: nil}, [{:server_reply, :admin, server_reply_drain(folded)}]}
         end
     end
   end

--- a/lib/grappa/session/numeric_router.ex
+++ b/lib/grappa/session/numeric_router.ex
@@ -44,8 +44,9 @@ defmodule Grappa.Session.NumericRouter do
      offending command's argument list (461), an ack (437), or a whole
      server-directed REPORT family whose middles are data, type labels or
      table headers (`@stats_numerics` #184/#911, `@trace_numerics` #908,
-     `@list_numerics` #910, `@admin_numerics` / `@help_numerics` /
-     `@sasl_numerics` / `@monitor_list_numerics` #911, the connect-storm
+     `@list_numerics` #910, `@help_numerics` /
+     `@sasl_numerics` / `@monitor_list_numerics` #911 (`@admin_numerics`
+     left for the delegated set in #992), the connect-storm
      tokens). These ALWAYS go to
      `{:server, nil}`. Without this deny
      list, the param-scan below would happily route 433's "BLEH-as-nick"
@@ -302,12 +303,41 @@ defmodule Grappa.Session.NumericRouter do
   # Nothing about the family says "conversation"; the exposure is purely
   # that a config string happened to be nick-shaped.
   #
-  # 256 RPL_ADMINME carries the server NAME and is saved today only by
+  # 256 RPL_ADMINME carries the server NAME and was saved pre-#992 only by
   # `query_candidate?/2`'s `.`-exclusion — the same accident that saved
   # 262 RPL_ENDOFTRACE and 323 RPL_LISTEND. Covered for the same reason
   # those two are: a family-wide rule must not rest on how a server
   # happens to be spelled.
+  #
+  # #992 — the family MOVED from `@active_numerics` into
+  # `@delegated_numerics`: /admin became a native verb, so EventRouter's
+  # clause owns it. Delegation short-circuits AHEAD of the deny list, and
+  # the clause's unprimed branch persists to `$server`, so the #911
+  # guarantee above is preserved rather than repealed — but it is now
+  # proven at the new owner (`event_router_test.exs`, the DOTLESS A-line
+  # test), because a routing decision that changed rungs is not
+  # automatically still true.
   @admin_numerics Enum.to_list(256..259)
+
+  # #992 — ADMIN's two OWN error terminators. Neither is accompanied by any
+  # 256-259, so an accumulator waiting only on 259 dangles on exactly the
+  # paths that have no other reply:
+  #
+  #   * 423 ERR_NOADMININFO — `m_admin`'s `else` branch (bahamut
+  #     `s_serv.c:2703`) when `find_admin()` misses: no A-line configured.
+  #   * 447 ERR_RESTRICTED — `check_restricted_user` (`s_misc.c:1211`)
+  #     fires and returns BEFORE `hunt_server`, for a non-oper, non-
+  #     `IsKnownNick` client on an `I:`-line with CONF_FLAGS_I_RESTRICTED.
+  #     Reachable by a visitor on a restricted class.
+  #
+  # The fourth terminator, 402 ERR_NOSUCHSERVER, is already delegated by
+  # #374 and is SHARED with `/motd <target>` — see EventRouter's dedicated
+  # 402 clause for how ownership is resolved.
+  #
+  # 447 is itself emitted from several handlers (`m_admin`, `m_links`,
+  # channel.c, s_user.c), so an unprimed one still lands on `$server` via
+  # the clause's nil branch — visible, never silent.
+  @admin_terminators [423, 447]
 
   # HELP reply family (704–706, solanum; bahamut has no 7xx HELP). The
   # topic token sits in `params[1]` on all three —
@@ -400,7 +430,6 @@ defmodule Grappa.Session.NumericRouter do
                      @stats_numerics ++
                        @trace_numerics ++
                        @list_numerics ++
-                       @admin_numerics ++
                        @help_numerics ++
                        @sasl_numerics ++
                        @monitor_list_numerics ++
@@ -783,7 +812,7 @@ defmodule Grappa.Session.NumericRouter do
                         602,
                         604,
                         605
-                      ])
+                      ] ++ @admin_numerics ++ @admin_terminators)
 
   # ---------------------------------------------------------------------------
   # Public API

--- a/lib/grappa/session/numeric_router.ex
+++ b/lib/grappa/session/numeric_router.ex
@@ -45,8 +45,8 @@ defmodule Grappa.Session.NumericRouter do
      server-directed REPORT family whose middles are data, type labels or
      table headers (`@stats_numerics` #184/#911, `@trace_numerics` #908,
      `@list_numerics` #910, `@help_numerics` /
-     `@sasl_numerics` / `@monitor_list_numerics` #911 (`@admin_numerics`
-     left for the delegated set in #992), the connect-storm
+     `@sasl_numerics` / `@monitor_list_numerics` #911 (ADMIN's 256-259
+     left this list for the delegated set in #992), the connect-storm
      tokens). These ALWAYS go to
      `{:server, nil}`. Without this deny
      list, the param-scan below would happily route 433's "BLEH-as-nick"
@@ -288,56 +288,6 @@ defmodule Grappa.Session.NumericRouter do
   # never because an RFC suggests it might. Rows the reading DISPROVED are
   # recorded at the end of this block; a falsified row is the more useful
   # half of an audit, because it is the evidence the rest were measured.
-
-  # ADMIN reply family (256–259). Server-directed by definition — it
-  # describes the SERVER's operator, and `m_admin` (bahamut
-  # `s_serv.c:2695`) answers with the A-line fields verbatim.
-  #
-  # 257/258/259 are `":%s 25N %s :%s"` on bahamut and `":%s"` on solanum:
-  # a TWO-param numeric whose only middle IS the trailing. That matters,
-  # because `candidate_params/1`'s 2-elem clause (B6.1 HIGH-4, added so a
-  # tail-less 401 still reaches its target's window) hands that trailing
-  # straight to the scan. So the routing destination of an ADMIN reply is
-  # whatever the operator typed into `admin { }`: a one-word dotless
-  # A-line — "Azzurra", "staff", a nick — resolves to `{:query, <that>}`.
-  # Nothing about the family says "conversation"; the exposure is purely
-  # that a config string happened to be nick-shaped.
-  #
-  # 256 RPL_ADMINME carries the server NAME and was saved pre-#992 only by
-  # `query_candidate?/2`'s `.`-exclusion — the same accident that saved
-  # 262 RPL_ENDOFTRACE and 323 RPL_LISTEND. Covered for the same reason
-  # those two are: a family-wide rule must not rest on how a server
-  # happens to be spelled.
-  #
-  # #992 — the family MOVED from `@active_numerics` into
-  # `@delegated_numerics`: /admin became a native verb, so EventRouter's
-  # clause owns it. Delegation short-circuits AHEAD of the deny list, and
-  # the clause's unprimed branch persists to `$server`, so the #911
-  # guarantee above is preserved rather than repealed — but it is now
-  # proven at the new owner (`event_router_test.exs`, the DOTLESS A-line
-  # test), because a routing decision that changed rungs is not
-  # automatically still true.
-  @admin_numerics Enum.to_list(256..259)
-
-  # #992 — ADMIN's two OWN error terminators. Neither is accompanied by any
-  # 256-259, so an accumulator waiting only on 259 dangles on exactly the
-  # paths that have no other reply:
-  #
-  #   * 423 ERR_NOADMININFO — `m_admin`'s `else` branch (bahamut
-  #     `s_serv.c:2703`) when `find_admin()` misses: no A-line configured.
-  #   * 447 ERR_RESTRICTED — `check_restricted_user` (`s_misc.c:1211`)
-  #     fires and returns BEFORE `hunt_server`, for a non-oper, non-
-  #     `IsKnownNick` client on an `I:`-line with CONF_FLAGS_I_RESTRICTED.
-  #     Reachable by a visitor on a restricted class.
-  #
-  # The fourth terminator, 402 ERR_NOSUCHSERVER, is already delegated by
-  # #374 and is SHARED with `/motd <target>` — see EventRouter's dedicated
-  # 402 clause for how ownership is resolved.
-  #
-  # 447 is itself emitted from several handlers (`m_admin`, `m_links`,
-  # channel.c, s_user.c), so an unprimed one still lands on `$server` via
-  # the clause's nil branch — visible, never silent.
-  @admin_terminators [423, 447]
 
   # HELP reply family (704–706, solanum; bahamut has no 7xx HELP). The
   # topic token sits in `params[1]` on all three —
@@ -811,8 +761,59 @@ defmodule Grappa.Session.NumericRouter do
                         601,
                         602,
                         604,
-                        605
-                      ] ++ @admin_numerics ++ @admin_terminators)
+                        605,
+                        # #992 — ADMIN (256 RPL_ADMINME, 257 RPL_ADMINLOC1,
+                        # 258 RPL_ADMINLOC2, 259 RPL_ADMINEMAIL) plus its two
+                        # OWN error terminators. /admin became a native verb,
+                        # so EventRouter's clause owns the family: primed by
+                        # :send_admin it drains a {:server_reply, :admin,
+                        # lines} modal; unprimed it persists to $server.
+                        #
+                        # These four LEFT @active_numerics, where #911 put
+                        # them. #911 measured the real exposure: 257/258/259
+                        # are `":%s 25N %s :%s"` on bahamut and `":%s"` on
+                        # solanum — a TWO-param numeric whose only middle IS
+                        # the trailing — so `candidate_params/1`'s 2-elem
+                        # clause hands the A-line straight to the scan, and a
+                        # one-word dotless A-line ("Azzurra", "staff", a nick)
+                        # resolved to `{:query, <that>}`. 256 carries the
+                        # server NAME and was saved only by
+                        # `query_candidate?/2`'s `.`-exclusion, the same
+                        # accident that saved 262 and 323.
+                        #
+                        # Delegation short-circuits AHEAD of the deny list and
+                        # the clause's unprimed branch persists to $server, so
+                        # that guarantee is preserved rather than repealed —
+                        # but it is now proven at the NEW owner
+                        # (event_router_test's DOTLESS A-line case), because a
+                        # routing decision that changed rungs is not
+                        # automatically still true.
+                        256,
+                        257,
+                        258,
+                        259,
+                        # 423 ERR_NOADMININFO — `m_admin`'s else branch
+                        # (bahamut `s_serv.c:2703`) when `find_admin()` misses.
+                        # 447 ERR_RESTRICTED — `check_restricted_user`
+                        # (`s_misc.c:1211`) fires and returns BEFORE
+                        # `hunt_server`, for a non-oper, non-`IsKnownNick`
+                        # client on an `I:`-line with CONF_FLAGS_I_RESTRICTED;
+                        # reachable by a visitor on a restricted class.
+                        #
+                        # Neither is accompanied by ANY 256-259, so an
+                        # accumulator waiting only on 259 dangles on exactly
+                        # the paths that have no other reply. The fourth
+                        # terminator, 402, is already delegated by #374 and is
+                        # SHARED with `/motd <target>` — see EventRouter's
+                        # dedicated 402 clause for how ownership is resolved.
+                        #
+                        # 447 is emitted from several handlers (`m_admin`,
+                        # `m_links`, channel.c, s_user.c), so an unprimed one
+                        # still lands on $server via the clause's nil branch —
+                        # visible, never silent.
+                        423,
+                        447
+                      ])
 
   # ---------------------------------------------------------------------------
   # Public API

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -839,6 +839,7 @@ defmodule Grappa.Session.Server do
           info_pending: nil | map(),
           version_pending: nil | map(),
           motd_pending: nil | map(),
+          admin_pending: nil | map(),
           # #140 — pending NAMES accumulators keyed by lowercased target
           # channel. Set up on `:send_names`; 353 RPL_NAMREPLY rows append
           # their `[prefix]nick` tokens into the entry; 366 RPL_ENDOFNAMES
@@ -1240,6 +1241,7 @@ defmodule Grappa.Session.Server do
       info_pending: nil,
       version_pending: nil,
       motd_pending: nil,
+      admin_pending: nil,
       # CP22 cluster B — pending NAMES accumulators keyed by lowercased
       # target channel. Set up on `:send_names`; 353 RPL_NAMREPLY rows
       # merge nick lists into the entry; 366 RPL_ENDOFNAMES drains via
@@ -1906,6 +1908,14 @@ defmodule Grappa.Session.Server do
   # 402 terminator) drains the modal either way.
   def handle_call({:send_motd, target}, _, state) do
     {:reply, Client.send_motd(state.client, target), %{state | motd_pending: %{lines: []}}}
+  end
+
+  # #992 — /admin [<target>]. Same optional-target shape as /motd (bahamut
+  # routes both through the same `hunt_server`), and the same
+  # target-independent priming: whichever of the four terminators comes back
+  # — 259, 423, 402 or 447 — drains the modal and clears the flag.
+  def handle_call({:send_admin, target}, _, state) do
+    {:reply, Client.send_admin(state.client, target), %{state | admin_pending: %{lines: []}}}
   end
 
   # #238/#513 — /links [<mask>]. Prime the accumulator BEFORE the send so the

--- a/lib/grappa/session/wire.ex
+++ b/lib/grappa/session/wire.ex
@@ -321,8 +321,22 @@ defmodule Grappa.Session.Wire do
   Additive per the #447 wire contract: a client that does not know
   `:admin` ignores the frame rather than breaking, so no
   `protocol_version` bump is needed.
+
+  The union is DERIVED from `@server_reply_sources` rather than spelled
+  twice. #992 shipped `:admin` into the union but not into the copy of
+  the set that guarded `server_reply/3`, and the two silently disagreed:
+  every unit test passed while the first real 259 off a live ircd raised
+  `FunctionClauseError` inside `apply_effects/2` and took the whole
+  `Session.Server` down with it. A closed set gets ONE spelling.
   """
-  @type server_reply_source :: :info | :version | :motd | :admin
+  @server_reply_sources [:info, :version, :motd, :admin]
+
+  @type server_reply_source ::
+          unquote(
+            @server_reply_sources
+            |> Enum.reverse()
+            |> Enum.reduce(fn source, acc -> {:|, [], [source, acc]} end)
+          )
 
   @typedoc """
   #127 — ephemeral server-text reply for an EXPLICIT `/info`, `/version`
@@ -1035,6 +1049,14 @@ defmodule Grappa.Session.Wire do
   end
 
   @doc """
+  The closed `server_reply_source()` set as a runtime list, so a caller
+  that must enumerate it (tests, property allowlists) reads the SSOT
+  instead of spelling a copy that drifts the next time a source lands.
+  """
+  @spec server_reply_sources() :: [server_reply_source(), ...]
+  def server_reply_sources, do: @server_reply_sources
+
+  @doc """
   #127 — build the ephemeral `/info`, `/version` or `/motd` reply payload
   (drained on the terminator numeric). Mirror of `who_reply/3`: user-level
   topic, ephemeral — see `server_reply_payload/0`. `source` is the typed
@@ -1044,7 +1066,7 @@ defmodule Grappa.Session.Wire do
   @spec server_reply(String.t(), server_reply_source(), [String.t()]) ::
           server_reply_payload()
   def server_reply(network_slug, source, lines)
-      when is_binary(network_slug) and source in [:info, :version, :motd] and
+      when is_binary(network_slug) and source in @server_reply_sources and
              is_list(lines) do
     %{
       kind: :server_reply,

--- a/lib/grappa/session/wire.ex
+++ b/lib/grappa/session/wire.ex
@@ -310,14 +310,19 @@ defmodule Grappa.Session.Wire do
         }
 
   @typedoc """
-  #127 — the closed set of server-text-query sources that render a
+  #127/#992 — the closed set of server-text-query sources that render a
   `server_reply` modal. `:info` = /INFO (371/374), `:version` =
-  /VERSION (351), `:motd` = /MOTD (375/372/376/422). The atom is the
+  /VERSION (351), `:motd` = /MOTD (375/372/376/422/402), `:admin` =
+  /ADMIN (256/257/258/259, or 423/402/447). The atom is the
   wire discriminant cic maps to a human title + retro styling — the
   server emits NO display strings (per the no-localized-strings-server
   rule), only the typed source + the raw reply lines.
+
+  Additive per the #447 wire contract: a client that does not know
+  `:admin` ignores the frame rather than breaking, so no
+  `protocol_version` bump is needed.
   """
-  @type server_reply_source :: :info | :version | :motd
+  @type server_reply_source :: :info | :version | :motd | :admin
 
   @typedoc """
   #127 — ephemeral server-text reply for an EXPLICIT `/info`, `/version`

--- a/lib/grappa_web/channels/grappa_channel.ex
+++ b/lib/grappa_web/channels/grappa_channel.ex
@@ -874,8 +874,33 @@ defmodule GrappaWeb.GrappaChannel do
 
     dispatch_subject_verb(
       socket,
-      fn -> validate_motd_target(target) end,
+      fn -> validate_server_target(target) end,
       fn subject -> Session.send_motd(subject, network_id, target) end
+    )
+  end
+
+  # #992 — /admin [<target>] (RFC 2812 §3.4.4). Same door and same optional
+  # server target as /motd — bahamut hands both to the same `hunt_server` —
+  # so the target rides the shared single-wire-token validator and an
+  # injection-shaped one dies here, not on the wire. Read-only server query;
+  # visitors are entitled to issue it (mirror of /motd + /lusers).
+  #
+  # Worth knowing before this is ever wired to a BUTTON: upstream ADMIN is a
+  # spy-level command (`sendto_realops_lev(SPY_LEV, …)` in `m_admin`), so
+  # opers on the target server see who asked. Not a blocker for a typed
+  # command the user chose to run.
+  defp do_handle_in(
+         "admin",
+         %{"network_id" => network_id} = params,
+         socket
+       )
+       when is_integer(network_id) do
+    target = Map.get(params, "target")
+
+    dispatch_subject_verb(
+      socket,
+      fn -> validate_server_target(target) end,
+      fn subject -> Session.send_admin(subject, network_id, target) end
     )
   end
 
@@ -1564,13 +1589,17 @@ defmodule GrappaWeb.GrappaChannel do
   @spec validate_args([validate_arg()]) ::
           {:ok, :ok}
           | {:error, :invalid_channel | :invalid_nick | :invalid_mask | :invalid_line}
-  # #374 — /motd [<target>]. Absent (nil) → bare MOTD, no validation. Present
-  # → a single wire token (same `{:server, _}` gate WHOIS/STATS use). A
-  # non-binary target (malformed client) is rejected loudly, never silently
-  # downgraded to a bare MOTD.
-  defp validate_motd_target(nil), do: {:ok, :ok}
-  defp validate_motd_target(target) when is_binary(target), do: validate_args(server: target)
-  defp validate_motd_target(_), do: {:error, :invalid_line}
+  # #374/#992 — the optional `<target>` of /motd and /admin. Absent (nil) →
+  # the bare verb, no validation. Present → a single wire token (same
+  # `{:server, _}` gate WHOIS/STATS use). A non-binary target (malformed
+  # client) is rejected loudly, never silently downgraded to the bare verb.
+  #
+  # One validator, both verbs: upstream they are the SAME argument — bahamut
+  # routes `m_motd` and `m_admin` through one `hunt_server` call each, with
+  # the server name in the same slot.
+  defp validate_server_target(nil), do: {:ok, :ok}
+  defp validate_server_target(target) when is_binary(target), do: validate_args(server: target)
+  defp validate_server_target(_), do: {:error, :invalid_line}
 
   # #238 — /links [<mask>]. nil = full mesh (bare LINKS); a binary mask is
   # gated as a single wire token (reuses the `:server` validator →

--- a/test/grappa/irc/client_test.exs
+++ b/test/grappa/irc/client_test.exs
@@ -566,6 +566,40 @@ defmodule Grappa.IRC.ClientTest do
       assert {:error, :invalid_line} = Client.send_motd(client, "srv\r\nQUIT")
     end
 
+    # #992 — /admin [<target>] (RFC 2812 §3.4.4 `ADMIN [<target>]`), the
+    # fourth member of the #127/#374 server-text family. Same optional-target
+    # shape as send_motd/2 (bahamut routes both through the same
+    # `hunt_server`, src/s_serv.c m_admin:2683), so the same single-wire-token
+    # gate applies: a space would splice an extra ADMIN slot, CRLF would
+    # inject a follow-up command.
+    test "send_admin/2 with nil emits bare ADMIN framing" do
+      {server, port} = start_server()
+      client = start_client(port)
+
+      :ok = Client.send_admin(client, nil)
+
+      assert {:ok, "ADMIN\r\n"} =
+               IRCServer.wait_for_line(server, &(&1 == "ADMIN\r\n"), 1_000)
+    end
+
+    test "send_admin/2 with a target emits ADMIN <target> framing" do
+      {server, port} = start_server()
+      client = start_client(port)
+
+      :ok = Client.send_admin(client, "void.azzurra.chat")
+
+      assert {:ok, "ADMIN void.azzurra.chat\r\n"} =
+               IRCServer.wait_for_line(server, &(&1 == "ADMIN void.azzurra.chat\r\n"), 1_000)
+    end
+
+    test "send_admin/2 rejects an injection target with {:error, :invalid_line}" do
+      {_, port} = start_server()
+      client = start_client(port)
+
+      assert {:error, :invalid_line} = Client.send_admin(client, "srv a")
+      assert {:error, :invalid_line} = Client.send_admin(client, "srv\r\nQUIT")
+    end
+
     # #571 — /lusers [<mask> [<server>]] (RFC 2812 §3.4.2). Pre-#571
     # send_lusers/1 always emitted a bare `LUSERS`, dropping any mask/server a
     # client supplied — so an oper could never reach bahamut's forced live

--- a/test/grappa/session/event_router_property_test.exs
+++ b/test/grappa/session/event_router_property_test.exs
@@ -213,7 +213,10 @@ defmodule Grappa.Session.EventRouterPropertyTest do
           assert is_list(users)
 
         {:server_reply, source, lines} ->
-          assert source in [:info, :version, :motd]
+          # Read the SSOT, never a copy: this allowlist had already drifted
+          # narrower than the union once (#992's :admin), and a hand-spelled
+          # set here fails a legitimate effect on some future seed.
+          assert source in Grappa.Session.Wire.server_reply_sources()
           assert is_list(lines)
 
         {:rejoin_invited, channel} ->

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -1465,8 +1465,7 @@ defmodule Grappa.Session.EventRouterTest do
     test "primed /admin drains on 447 ERR_RESTRICTED" do
       state = base_state(%{admin_pending: %{lines: []}})
 
-      assert {:cont, drained,
-              [{:server_reply, :admin, ["You need a registered nick to issue commands!"]}]} =
+      assert {:cont, drained, [{:server_reply, :admin, ["You need a registered nick to issue commands!"]}]} =
                EventRouter.route(
                  msg(
                    {:numeric, 447},

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -1402,6 +1402,148 @@ defmodule Grappa.Session.EventRouterTest do
                  state
                )
     end
+
+    # #992 — ADMIN, the fourth member of the family. Wire shapes measured
+    # from azzurra/bahamut `src/s_err.c`:
+    #   256 `":%s 256 %s :Administrative info about %s"`
+    #   257 `":%s 257 %s :%s"`  (aconf->host)
+    #   258 `":%s 258 %s :%s"`  (aconf->passwd — the A-line's second line)
+    #   259 `":%s 259 %s :%s"`  (aconf->name — the contact email)
+    #
+    # UNLIKE 376 RPL_ENDOFMOTD, the terminator 259 RPL_ADMINEMAIL CARRIES
+    # CONTENT, so it must fold its own line BEFORE draining or the contact
+    # address — the single most useful line in the reply — is dropped.
+    test "primed /admin folds 256/257/258 and drains {:server_reply, :admin, lines} on 259" do
+      state = base_state(%{admin_pending: %{lines: []}})
+
+      {:cont, s1, []} =
+        EventRouter.route(
+          msg({:numeric, 256}, ["vjt", "Administrative info about irc.test"], nil),
+          state
+        )
+
+      {:cont, s2, []} =
+        EventRouter.route(msg({:numeric, 257}, ["vjt", "Azzurra IRC Network"], nil), s1)
+
+      {:cont, s3, []} =
+        EventRouter.route(msg({:numeric, 258}, ["vjt", "Milano, IT"], nil), s2)
+
+      assert {:cont, drained, [{:server_reply, :admin, lines}]} =
+               EventRouter.route(msg({:numeric, 259}, ["vjt", "staff@azzurra.org"], nil), s3)
+
+      assert lines == [
+               "Administrative info about irc.test",
+               "Azzurra IRC Network",
+               "Milano, IT",
+               "staff@azzurra.org"
+             ]
+
+      assert drained.admin_pending == nil
+    end
+
+    # 423 ERR_NOADMININFO — bahamut `m_admin`'s `else` branch (s_serv.c:2703)
+    # when `find_admin()` misses: NO 256-259 is sent at all, so an accumulator
+    # waiting only on 259 never drains. Three params
+    # (`":%s 423 %s %s :No administrative info "`), so the fold takes the
+    # trailing, not the server token.
+    test "primed /admin drains on 423 ERR_NOADMININFO (no 256-259 burst arrives)" do
+      state = base_state(%{admin_pending: %{lines: []}})
+
+      assert {:cont, drained, [{:server_reply, :admin, ["No administrative info available"]}]} =
+               EventRouter.route(
+                 msg({:numeric, 423}, ["vjt", "irc.test", "No administrative info available"], nil),
+                 state
+               )
+
+      assert drained.admin_pending == nil
+    end
+
+    # 447 ERR_RESTRICTED — `check_restricted_user` (s_misc.c:1211) fires
+    # BEFORE `hunt_server` and returns, so again nothing else arrives. Two
+    # params (`":%s 447 %s :You need a registered nick..."`). Reachable by a
+    # visitor on an I-line with CONF_FLAGS_I_RESTRICTED.
+    test "primed /admin drains on 447 ERR_RESTRICTED" do
+      state = base_state(%{admin_pending: %{lines: []}})
+
+      assert {:cont, drained,
+              [{:server_reply, :admin, ["You need a registered nick to issue commands!"]}]} =
+               EventRouter.route(
+                 msg(
+                   {:numeric, 447},
+                   ["vjt", "You need a registered nick to issue commands!"],
+                   nil
+                 ),
+                 state
+               )
+
+      assert drained.admin_pending == nil
+    end
+
+    # #911's property, carried through the new delegated path. 257 RPL_ADMINLOC1
+    # is `":%s 257 %s :%s"` fed the A-line verbatim, so a DOTLESS one-word
+    # A-line ("Azzurra", a nick, "staff") used to be scan-routed as a query
+    # destination. #911 closed that with the active deny-list; #992 moves the
+    # family to delegation, which short-circuits AHEAD of the deny-list — so
+    # the guarantee has to be re-proven at its new owner, not assumed to
+    # survive the move.
+    test "unprimed 257 with a DOTLESS A-line persists to $server, never a query window" do
+      state = base_state()
+
+      assert {:cont, ^state, [{:persist, :notice, attrs}]} =
+               EventRouter.route(
+                 msg({:numeric, 257}, ["vjt", "Azzurra"], {:server, "irc.test"}),
+                 state
+               )
+
+      assert attrs.channel == "$server"
+    end
+
+    test "unprimed 259 RPL_ADMINEMAIL persists to $server, no server_reply" do
+      state = base_state()
+
+      assert {:cont, ^state, [{:persist, :notice, %{channel: "$server"}}]} =
+               EventRouter.route(
+                 msg({:numeric, 259}, ["vjt", "staff@azzurra.org"], {:server, "irc.test"}),
+                 state
+               )
+    end
+
+    # #992 — 402 ERR_NOSUCHSERVER is a SHARED terminator: `/motd <target>`
+    # (#374) and `/admin <target>` both route through bahamut's `hunt_server`
+    # (s_user.c:267) and get the same bare `402 <nick> <target> :No such
+    # server` back. The wire carries NO correlation tag.
+    #
+    # Ruling: disarm EVERY armed candidate, surface the error ONCE. Leaving
+    # an accumulator armed is a real break (no modal now, AND a later
+    # unsolicited burst folds into the stale lines instead of reaching
+    # $server); over-clearing costs one modal that the next explicit request
+    # re-arms unconditionally. The two do not weigh the same.
+    test "402 with only /admin in flight drains {:server_reply, :admin, [error]}" do
+      state = base_state(%{admin_pending: %{lines: []}})
+
+      assert {:cont, drained, [{:server_reply, :admin, ["No such server"]}]} =
+               EventRouter.route(
+                 msg({:numeric, 402}, ["vjt", "nope.invalid", "No such server"], nil),
+                 state
+               )
+
+      assert drained.admin_pending == nil
+    end
+
+    test "402 with BOTH /motd and /admin in flight disarms both and surfaces once" do
+      state = base_state(%{motd_pending: %{lines: []}, admin_pending: %{lines: []}})
+
+      assert {:cont, drained, [{:server_reply, :motd, ["No such server"]}]} =
+               EventRouter.route(
+                 msg({:numeric, 402}, ["vjt", "nope.invalid", "No such server"], nil),
+                 state
+               )
+
+      # Exactly ONE effect above, and NEITHER flag survives — the whole point
+      # of the ruling.
+      assert drained.motd_pending == nil
+      assert drained.admin_pending == nil
+    end
   end
 
   describe "route/2 — :join" do

--- a/test/grappa/session/numeric_router_test.exs
+++ b/test/grappa/session/numeric_router_test.exs
@@ -75,12 +75,18 @@ defmodule Grappa.Session.NumericRouterTest do
   # `src/s_err.c` and solanum @ 115b1e2 `include/messages.h` — not out of
   # an RFC. The per-family tests below carry the measured wire shape and
   # the emitting file:line; this property pins the MEMBERSHIP.
+  #
+  # #992 — ADMIN (256–259) LEFT this list for `@delegated_numerics`: /admin
+  # became a native verb with an EventRouter clause, and delegation
+  # short-circuits AHEAD of the active deny-list. The #911 guarantee (a
+  # dotless A-line is never a query destination) is unchanged — the unprimed
+  # branch persists to $server — but it is now proven at its new owner, in
+  # `event_router_test.exs`, not here.
   @active_numerics [4, 42, 263, 410, 421, 432, 433, 437, 461, 472, 512, 734] ++
                      (Enum.to_list(211..250) -- [221]) ++
                      Enum.to_list(200..210) ++
                      [261, 262] ++
                      Enum.to_list(321..323) ++
-                     Enum.to_list(256..259) ++
                      Enum.to_list(704..706) ++
                      Enum.to_list(900..908) ++
                      [732, 733]
@@ -133,6 +139,20 @@ defmodule Grappa.Session.NumericRouterTest do
     371,
     374,
     351,
+    # #992 — ADMIN (256/257/258/259) + its two OWN terminators, 423
+    # ERR_NOADMININFO and 447 ERR_RESTRICTED. Delegated so the EventRouter
+    # clause owns the whole family: primed by /admin it drains a
+    # `{:server_reply, :admin, lines}` modal, unprimed it persists to
+    # $server. 423 and 447 are here because on those two paths bahamut sends
+    # NO 256-259 at all (`m_admin`'s find_admin() else-branch, and
+    # `check_restricted_user` returning before hunt_server) — an accumulator
+    # waiting only on 259 would never drain.
+    256,
+    257,
+    258,
+    259,
+    423,
+    447,
     # CP15 B2 — JOIN failure numerics (EventRouter handles them now)
     471,
     473,
@@ -572,22 +592,42 @@ defmodule Grappa.Session.NumericRouterTest do
       assert :delegated = NumericRouter.route(m, state())
     end
 
-    test "257 RPL_ADMINLOC1: a one-word A-line is NOT a query destination" do
-      # bahamut `s_err.c:295` — `":%s 257 %s :%s"` — fed `aconf->host`
-      # verbatim from `s_serv.c:2695`. TWO params, so
-      # `candidate_params/1`'s 2-elem clause (B6.1 HIGH-4) hands the
-      # trailing straight to the scan, and the reply's destination becomes
-      # whatever the operator typed into `admin { }`.
+    # #911 measured that a one-word A-line ("Azzurra", "staff", a nick) fed
+    # verbatim into 257's only middle (`s_err.c:295` — `":%s 257 %s :%s"` —
+    # from `s_serv.c:2695`) would be scan-routed as a query destination, and
+    # closed it with the active deny-list. #992 made /admin a native verb, so
+    # the family moved one rung UP the precedence ladder (label > delegated >
+    # active-deny) into EventRouter's clause. The routing decision here is
+    # therefore `:delegated`, not `{:server, nil}` — but the GUARANTEE is
+    # unchanged, because the clause's unprimed branch persists to $server.
+    # That end of it is pinned in `event_router_test.exs` ("unprimed 257 with
+    # a DOTLESS A-line persists to $server"); flipping this assertion without
+    # that one would have silently reopened #911.
+    test "257 RPL_ADMINLOC1 is delegated (EventRouter owns the A-line, #992)" do
       m = msg(257, ["vjt", "Azzurra"])
-      assert {:server, nil} = NumericRouter.route(m, state())
+      assert :delegated = NumericRouter.route(m, state())
     end
 
-    test "256 RPL_ADMINME: stays on $server even for a DOTLESS server name" do
+    test "256 RPL_ADMINME is delegated even for a DOTLESS server name (#992)" do
       # solanum shape — `"%s :Administrative info"`, so `params[1]` is the
-      # server name. Saved today only by `query_candidate?/2`'s
-      # `.`-exclusion, exactly like 262 RPL_ENDOFTRACE and 323 RPL_LISTEND.
+      # server name. Pre-#992 it was saved only by `query_candidate?/2`'s
+      # `.`-exclusion, exactly like 262 RPL_ENDOFTRACE and 323 RPL_LISTEND;
+      # delegation no longer rests on how a server happens to be spelled.
       m = msg(256, ["vjt", "services", "Administrative info"])
-      assert {:server, nil} = NumericRouter.route(m, state())
+      assert :delegated = NumericRouter.route(m, state())
+    end
+
+    # #992 — the two ADMIN terminators that carry no 256-259 burst with them.
+    # Both must be delegated or a primed /admin dangles on the exact paths
+    # that have no other reply.
+    test "423 ERR_NOADMININFO is delegated (#992)" do
+      m = msg(423, ["vjt", "irc.test", "No administrative info available"])
+      assert :delegated = NumericRouter.route(m, state())
+    end
+
+    test "447 ERR_RESTRICTED is delegated (#992)" do
+      m = msg(447, ["vjt", "You need a registered nick to issue commands!"])
+      assert :delegated = NumericRouter.route(m, state())
     end
 
     test "704 RPL_HELPSTART: the help TOPIC is NOT a query destination" do

--- a/test/grappa/session/wire_test.exs
+++ b/test/grappa/session/wire_test.exs
@@ -330,6 +330,30 @@ defmodule Grappa.Session.WireTest do
                lines: []
              }
     end
+
+    test "builds the #992 :admin payload (259 RPL_ADMINEMAIL drain)" do
+      assert Wire.server_reply("azzurra", :admin, ["testnet admin", "root@irc.test"]) == %{
+               kind: :server_reply,
+               network: "azzurra",
+               source: :admin,
+               lines: ["testnet admin", "root@irc.test"]
+             }
+    end
+
+    # The class guard, not another example. #992 added :admin to the type
+    # union but not to the separate list that guarded the builder, and the
+    # divergence was invisible until a live 259 crashed the Session.Server.
+    # Enumerating the SSOT means the NEXT source cannot land half-wired.
+    test "accepts every source in the closed set — no arm left unguarded" do
+      for source <- Wire.server_reply_sources() do
+        assert %{kind: :server_reply, source: ^source} =
+                 Wire.server_reply("azzurra", source, ["line"])
+      end
+    end
+
+    test "rejects an atom outside the closed set" do
+      assert_raise FunctionClauseError, fn -> Wire.server_reply("azzurra", :links, ["line"]) end
+    end
   end
 
   describe "member/1" do

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -2024,11 +2024,32 @@ defmodule GrappaWeb.GrappaChannelTest do
         IRCServer.wait_for_line(irc_server, &(&1 == "ADMIN void.azzurra.chat\r\n"), 1_000)
     end
 
+    # An injection-shaped target must never reach the wire. NOTE what this
+    # test does and does not prove: BOTH the channel door and
+    # Client.send_admin/2 gate on safe_oper_token?, and they produce the
+    # SAME observable, so neutralising the door alone still leaves this
+    # green (measured — the mutant survived). It pins the OUTCOME, which is
+    # the thing that matters; the door itself is pinned by the next test.
     test "admin: rejects an injection target with invalid_line", %{
       socket: socket,
       network: network
     } do
       ref = push(socket, "admin", %{"network_id" => network.id, "target" => "srv\r\nQUIT"})
+
+      assert_reply(ref, :error, %{error: "invalid_line"})
+    end
+
+    # This one DOES discriminate the layers. A non-binary target is rejected
+    # by `validate_server_target/1`'s catch-all clause at the channel
+    # boundary; nothing downstream would answer `invalid_line` for it —
+    # `Session.send_admin/3`'s guard requires a binary or nil, so without the
+    # door the call would raise instead of replying. So a green here is
+    # evidence the door ran, not merely that the wire stayed clean.
+    test "admin: rejects a non-binary target at the channel boundary", %{
+      socket: socket,
+      network: network
+    } do
+      ref = push(socket, "admin", %{"network_id" => network.id, "target" => 42})
 
       assert_reply(ref, :error, %{error: "invalid_line"})
     end

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -1996,6 +1996,43 @@ defmodule GrappaWeb.GrappaChannelTest do
       assert_reply(ref, :error, %{error: "invalid_line"})
     end
 
+    # #992 — /admin [<target>] bridge. Same door and same shared
+    # single-wire-token validator as /motd: bahamut hands both arguments to
+    # the same `hunt_server`, so one validator covers both and the injection
+    # case must die here, not on the wire.
+    test "admin: sends bare ADMIN upstream", %{
+      irc_server: irc_server,
+      socket: socket,
+      network: network
+    } do
+      ref = push(socket, "admin", %{"network_id" => network.id})
+
+      assert_reply(ref, :ok)
+      {:ok, _} = IRCServer.wait_for_line(irc_server, &(&1 == "ADMIN\r\n"), 1_000)
+    end
+
+    test "admin: with target sends ADMIN <target> upstream", %{
+      irc_server: irc_server,
+      socket: socket,
+      network: network
+    } do
+      ref = push(socket, "admin", %{"network_id" => network.id, "target" => "void.azzurra.chat"})
+
+      assert_reply(ref, :ok)
+
+      {:ok, _} =
+        IRCServer.wait_for_line(irc_server, &(&1 == "ADMIN void.azzurra.chat\r\n"), 1_000)
+    end
+
+    test "admin: rejects an injection target with invalid_line", %{
+      socket: socket,
+      network: network
+    } do
+      ref = push(socket, "admin", %{"network_id" => network.id, "target" => "srv\r\nQUIT"})
+
+      assert_reply(ref, :error, %{error: "invalid_line"})
+    end
+
     # #238 — /links bridge: cic pushes the bare verb (or with a mask) with
     # %{network_id}; the channel relays to Session.send_links/3 which primes
     # links_pending + emits LINKS upstream. Smoke-tests dispatch plumbing;


### PR DESCRIPTION
`/admin [<target>]` (RFC 2812 §3.4.4) becomes the fourth member of the #127
server-reply family, alongside `/info`, `/version` and `/motd`: the reply is
buffered server-side and drained as ONE typed `server_reply` event with source
`admin`, rendered in the shared modal under the title "Server Administrator".
Never dumped into scrollback.

## The domain, because it is not "MOTD with a different numeric"

**ADMIN has four terminators, not one.** Read out of azzurra/bahamut `m_admin`
(`src/s_serv.c:2676`), which has exactly four exits:

- `find_admin()` hit → 256, 257, 258, 259 in fixed order
- `find_admin()` miss → **423 ERR_NOADMININFO**, and NO 256-259 at all (`:2703`)
- `hunt_server()` non-ISME → **402 ERR_NOSUCHSERVER**
- `check_restricted_user()` → **447 ERR_RESTRICTED**, returning before all of it
  (`src/s_misc.c:1211`)

Waiting only on 259 would leave `admin_pending` armed on three cases out of
four, and these flags have no timeout: the request gets no modal, and a later
unsolicited burst folds into the stale lines instead of reaching `$server`.

**259 is not 376.** RPL_ENDOFMOTD is a pure terminator; RPL_ADMINEMAIL is
`":%s 259 %s :%s"` fed `aconf->name` — the contact address, the most useful line
in the reply. So every terminator folds its own line before draining; only
256/257/258 are pure accumulation.

**402 belongs to no verb.** `/motd <target>` and `/admin <target>` both reach it
through the same `hunt_server` (`src/s_user.c:267`) and the wire carries no
correlation tag. Ruling: disarm EVERY armed candidate and surface the error
once. The asymmetry is deliberate — an accumulator left armed is a real break,
while over-clearing costs one modal that the next explicit request re-arms.
MOTD leads the priority order so #374's shipped behaviour is byte-identical
whenever `/admin` is not in flight.

**ADMIN is not rate-limited upstream** (a measured negative result): the
`static time_t last_used` throttle lives in exactly four `s_serv.c` handlers —
`m_info`, `m_stats`, `m_help`, `m_motd` — and `m_admin` is not among them. So
every ADMIN path answers with a numeric and the four-terminator set is
exhaustive rather than merely wide.

**#911's guarantee moved and was re-proven where it moved to.** The ADMIN family
left `@active_numerics` for `@delegated_numerics`; #911 had put it in the former
so a one-word dotless A-line ("Azzurra", "staff", a nick) could not be routed as
a query destination. Delegation short-circuits one rung ABOVE that deny-list, so
the old test would have stayed green while the guarantee evaporated. It is
re-proven at the new owner: `event_router_test`'s "unprimed 257 with a DOTLESS
A-line persists to `$server`". Touch that test and #911 reopens in silence.

## What the e2e caught, which is the point of this PR

Every claim above was READ out of C and cited by file:line. Not one had been
observed: until this branch, no ADMIN numeric had ever crossed a socket in this
repo. `cicchetto/e2e/tests/issue992-admin-command.spec.ts` fixes that, and it
went red on its very first run — not on an assert, but because the modal never
appeared: **the `Session.Server` had already died.**

`Grappa.Session.Wire.server_reply/3` guarded `source` with a hand-spelled
`[:info, :version, :motd]` sitting a few hundred lines below the type union that
this branch had just grown `:admin` into. The first real 259 off leaf4 raised
`FunctionClauseError` inside `apply_effects/2` — not a rejected frame, a dead
session. Both `/admin` shapes dropped the whole IRC connection.

5482 unit tests, 56 properties, 4599 vitest tests, Dialyzer and Credo all passed,
because every one of them exercised a source the guard already knew. The
divergence lived in the gap between two copies of one closed set, which is
exactly the gap synthesised messages cannot cross.

The fix is not "add `:admin` to the guard" — that leaves the second copy standing
for the next source, and a third copy was already drifting in the property test's
allowlist (whose own comment records this happening before). `@server_reply_sources`
is now the single spelling: the type union is derived from it, the guard reads
it, and `server_reply_sources/0` hands it to the tests that enumerate it. The
generated `wireTypes.ts` is byte-identical, because a derived union compiles to
the same beam typespec the codegen reads.

The two asserts were built to discriminate rather than mirror. The spec pins the
259 body as a distinct modal line, because a build that drained on 259 without
folding it still shows a modal with three plausible lines. And it drives
`/admin <unknown-server>` for a 402, which a bare ADMIN can never produce, so the
surfaced error is unforgeable proof the target survived cic's parser, the channel
door and `Client.send_admin/2`.

## On mutation: a mutation whose result nobody reads is not a mutation

Eight mutants, all killed on the second round. **One survived the first**, and it
is the part worth reading. M2 neutralised `validate_server_target/1` in the
`/admin` channel door, and the test asserting the rejection of `"srv<CRLF>QUIT"`
stayed GREEN — because the rejection was coming from the twin gate inside
`Client.send_admin/2`, not from the door. The assert was true; the comment
claiming it died at the boundary was not. Resolved without weakening anything:
the end-to-end test stayed, with an honest comment, and a case that DISCRIMINATES
the layers was added — a non-binary target, which only the channel's catch-all
clause can answer (`Session.send_admin/3`'s guard requires binary-or-nil, so
without the door the call raises). Those two tests are two on purpose.

**#374 was then probed and has the same defect, measured rather than deduced:**
neutralising the `/motd` door leaves its injection test green. Not touched — it
is #374's scope — but recorded in DESIGN_NOTES so the next reader does not mistake
it for coverage.

## Gates, on this head, working tree clean before and after each

- `scripts/check.sh` → **rc=0**. Credo `5288 mods/funs, found no issues`;
  `8 doctests, 56 properties, 5522 tests, 0 failures`; Dialyzer
  `Total errors: 0`; Sobelow run; `wireTypes.ts is in sync`; bats 337 ok / 0 not ok.
- `scripts/integration.sh` (FULL suite, not a scoped grep) → **rc=0,
  642 passed, 0 failed, 26.0m**, both #992 specs green inside it.
- cic: `bun run check` rc=0, `bun run test` 246 files / 4605 tests, 0 failures.

## What this does NOT establish

423 ERR_NOADMININFO and 447 ERR_RESTRICTED have never been observed on a socket:
the first needs a leaf with no `A:` line, the second a restricted-class user, and
neither is reachable without reshaping the shared testnet for one spec. Both stay
unit-tested against synthesised numerics. Nothing here has run against production.