### PR TITLE
cic(#1019): leaving a far-behind window is the bar's ×

### DIFF
--- a/cicchetto/e2e/tests/issue1019-farbehind-leave-dismiss.spec.ts
+++ b/cicchetto/e2e/tests/issue1019-farbehind-leave-dismiss.spec.ts
@@ -23,24 +23,51 @@
 //     clause, and the one that would catch a dismiss that cleared the badge
 //     without moving the cursor the resume re-reads.
 //
+// Measured RED on the parent commit (`dbdefa6b`, the fix absent): the run
+// reached assertion 1 and stopped there —
+//   `expect(locator).toHaveCount(expected) failed / Expected: 0 / Received: 1`
+//   `14 × locator resolved to 1 element - unexpected value "1"`
+// i.e. every precondition held (bar attached, badge far-behind, cursor still
+// where it was planted) and only the outcome was missing. The failure lands on
+// the outcome, not on a locator and not in setup, which is what makes this a
+// guard rather than a mirror.
+//
+// ── What this file does NOT cover, and why it is absent rather than faked ──
+//
 // Q1 was ruled by vjt on the issue: only (a), a window switch INSIDE cic,
-// dismisses. Test 2 pins the negative half of that ruling — backgrounding the
-// tab / losing window focus must NOT dismiss (`documentVisibility` gates the
-// visibility-hide writer, which stays frozen).
+// dismisses; (b) tab backgrounding and (c) OS window blur must NOT. Those two
+// negatives are NOT asserted here. A test that drove them via a second tab and
+// `page.bringToFront()` was written, run, and REMOVED after measurement: on
+// both the local host and the CI runner the polled precondition
+// `document.visibilityState === "visible" && document.hasFocus()` stayed
+// **true** for the full 10s budget on the supposedly backgrounded page. Both
+// conjuncts true means neither the visibility edge nor the focus edge ever
+// fired, so `documentVisibility.ts`'s `computeVisible()` never changed value
+// and the `on(isDocumentVisible)` arm in `ScrollbackPane` was never asked the
+// question. The spec proved nothing about the product — it could not even
+// establish its own premise — and a negative that cannot fail is worse than an
+// absent one.
 //
-// NOT covered here, deliberately, and named so nobody reads this file as a
-// completeness claim: `channel → home / mentions / admin` unmounts the pane
-// and lands in `onCleanup`, where `props` already read the ARRIVING virtual
-// selection, so the leaving window cannot be named. That switch leaves the
-// far-behind state STANDING (the safe side — the region stays recoverable)
-// and the PR says so at the call site. This spec therefore leaves for the
-// SERVER window, which shares the `kindHasScrollback` Match with channels and
-// so keeps the pane mounted and fires the key arm — the same gesture
-// `cursor-forward-only.spec.ts` uses to drive the leave writer.
+// The honest place for those two negatives is the vitest guardrail in
+// `ScrollbackPane.test.tsx`, which drives the visibility-hide writer directly
+// and was mutation-measured (routing `settleCursorToVisibleTail` to the
+// dismiss turns it red). Synthesising a `visibilitychange` from
+// `page.evaluate` would have produced a green here, but it would mean
+// asserting against a stubbed browser API inside a real browser — the one
+// place a stub buys nothing.
 //
-// Against the parent commit the leave writer reaches a frozen door, the
-// cursor never moves and the badge never falls, so the spec is RED at the
-// first outcome assertion rather than at a locator.
+// Also NOT covered, for a product reason rather than a harness one:
+// `channel → home / mentions / admin` unmounts the pane and lands in
+// `onCleanup`, where `props` already read the ARRIVING virtual selection, so
+// the leaving window cannot be named. That switch leaves the far-behind state
+// STANDING (the safe side — the region stays recoverable) and the PR says so
+// at the call site. This spec therefore leaves for the SERVER window, which
+// shares the `kindHasScrollback` Match with channels and so keeps the pane
+// mounted and fires the key arm — the same gesture
+// `cursor-forward-only.spec.ts` uses to drive the leave writer, and one that
+// introduces no new name into the shared testnet namespace.
+//
+// ── Mechanics ──
 //
 // Seeding mirrors `issue997-far-behind-thumb-reach.spec.ts` (same bar, same
 // precondition): the shared seeder plants 200 rows in #bofh and this needs a
@@ -51,14 +78,14 @@
 // mid-list cursor behind makes every downstream spec open its pane at a
 // divider instead of at the tail).
 //
-// No sleep is used as synchronisation anywhere: every step waits on an
-// observable condition (the bar attaching, the badge reaching count 0, the
-// server cursor reaching the tail, `isDocumentVisible`'s two inputs flipping).
-// The cursor is written server-side at SETTLE cadence, so the timeouts here
-// are WAIT BUDGETS on those conditions, never the thing being measured.
+// No sleep is used as synchronisation: every step waits on an observable
+// condition (the bar attaching, the badge reaching count 0, the server cursor
+// reaching the tail). The cursor is written server-side at SETTLE cadence, so
+// the timeouts here are WAIT BUDGETS on those conditions, never the thing
+// being measured.
 //
-// Desktop viewport on purpose, matching #997: the sidebar badge is the
-// clearer read of "the badge fell" than the mobile tab treatment.
+// Desktop viewport on purpose, matching #997: the sidebar badge is the clearer
+// read of "the badge fell" than the mobile tab treatment.
 
 import { expect, test } from "../fixtures/test";
 import { loginAs, selectChannel, sidebarMessageBadge } from "../fixtures/cicchettoPage";
@@ -96,43 +123,6 @@ const UNREAD_TARGET = 240;
 // sleep: it bounds an `expect.poll` / `toHaveCount` CONDITION.
 const OUTCOME_TIMEOUT_MS = 10_000;
 
-interface FarBehindFixture {
-  readonly tailId: number;
-  readonly cursorPlantedAt: number;
-}
-
-// Plant the far-behind precondition and prove it, before any browser exists.
-// Returns the two ids the assertions are written against.
-async function seedFarBehindChannel(channel: string): Promise<FarBehindFixture> {
-  const vjt = getSeededVjt();
-  const admin = getSeededAdmin();
-
-  await resetSubject(
-    admin.token,
-    VJT_USER,
-    { [NETWORK_SLUG]: AUTOJOIN_CHANNELS },
-    { [NETWORK_SLUG]: [{ name: channel, seedCount: LARGE_SEED_COUNT, seedSender: SEED_SENDER }] },
-  );
-
-  const rows = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, channel);
-  expect(rows.length).toBeGreaterThan(UNREAD_TARGET);
-
-  const lastReadRow = rows[rows.length - UNREAD_TARGET];
-  const tailRow = rows[rows.length - 1];
-  if (!lastReadRow || !tailRow) throw new Error("#1019 spec: seeded #bofh rows missing an index");
-
-  // Guard the precondition: below this the pane never goes far behind and the
-  // spec would pass by testing nothing.
-  const rowsAfterCursor = rows.filter((r) => r.id > lastReadRow.id).length;
-  expect(rowsAfterCursor).toBeGreaterThan(MAX_HTTP_LIMIT);
-
-  // Plant the cursor BEFORE login so the channel hydrates with it and takes
-  // the cursor-present fetch arm.
-  await setReadCursorToId(vjt.token, NETWORK_SLUG, channel, lastReadRow.id);
-
-  return { tailId: tailRow.id, cursorPlantedAt: lastReadRow.id };
-}
-
 test.describe("#1019 — leaving a far-behind window marks it read", () => {
   test.use({ viewport: { width: 800, height: 400 } });
 
@@ -147,7 +137,30 @@ test.describe("#1019 — leaving a far-behind window marks it read", () => {
   }) => {
     if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
     const vjt = getSeededVjt();
-    const { tailId, cursorPlantedAt } = await seedFarBehindChannel(CHANNEL);
+    const admin = getSeededAdmin();
+
+    await resetSubject(
+      admin.token,
+      VJT_USER,
+      { [NETWORK_SLUG]: AUTOJOIN_CHANNELS },
+      { [NETWORK_SLUG]: [{ name: CHANNEL, seedCount: LARGE_SEED_COUNT, seedSender: SEED_SENDER }] },
+    );
+
+    const rows = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, CHANNEL);
+    expect(rows.length).toBeGreaterThan(UNREAD_TARGET);
+
+    const lastReadRow = rows[rows.length - UNREAD_TARGET];
+    const tailRow = rows[rows.length - 1];
+    if (!lastReadRow || !tailRow) throw new Error("#1019 spec: seeded #bofh rows missing an index");
+
+    // Guard the precondition: below this the pane never goes far behind and
+    // the spec would pass by testing nothing.
+    const rowsAfterCursor = rows.filter((r) => r.id > lastReadRow.id).length;
+    expect(rowsAfterCursor).toBeGreaterThan(MAX_HTTP_LIMIT);
+
+    // Plant the cursor BEFORE login so the channel hydrates with it and takes
+    // the cursor-present fetch arm.
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, CHANNEL, lastReadRow.id);
 
     await loginAs(page, vjt);
     await selectChannel(page, NETWORK_SLUG, CHANNEL);
@@ -165,7 +178,7 @@ test.describe("#1019 — leaving a far-behind window marks it read", () => {
     // Nothing has moved it yet: the pane has been open and rendered, and the
     // cursor is still exactly where it was planted. Without this the next
     // assertion could be satisfied by a write that had already happened.
-    expect(await getReadCursor(vjt.token, NETWORK_SLUG, CHANNEL)).toBe(cursorPlantedAt);
+    expect(await getReadCursor(vjt.token, NETWORK_SLUG, CHANNEL)).toBe(lastReadRow.id);
 
     // THE gesture. The server window shares the `kindHasScrollback` Match with
     // channels, so the pane stays mounted and the key arm fires with #bofh as
@@ -173,22 +186,22 @@ test.describe("#1019 — leaving a far-behind window marks it read", () => {
     // direct call to the dismiss.
     await selectChannel(page, NETWORK_SLUG, NETWORK_SLUG, { awaitWsReady: false });
 
-    // Outcome 1 — the badge fell. This is the operator-visible result and the
-    // whole point of the issue.
+    // Outcome 1 — the badge fell. This is the operator-visible result, the
+    // whole point of the issue, and the assertion the parent commit fails.
     await expect(badge).toHaveCount(0, { timeout: OUTCOME_TIMEOUT_MS });
 
     // Outcome 2 — the SERVER cursor moved to the tail, i.e. the same
     // `setReadCursor` fan-out the × performs. `toBeGreaterThanOrEqual` rather
     // than `toBe`: the dismiss marks the newest LOCAL row, and a presence row
     // (a peer JOIN on the shared testnet) can land after the seed snapshot and
-    // legitimately push the tail past `tailId`. The load-bearing claim is that
-    // it crossed the whole abandoned region, which the second assertion pins.
+    // legitimately push the tail past `tailRow.id`. The load-bearing claim is
+    // that it crossed the whole abandoned region, which the next line pins.
     await expect
       .poll(async () => await getReadCursor(vjt.token, NETWORK_SLUG, CHANNEL), {
         timeout: OUTCOME_TIMEOUT_MS,
       })
-      .toBeGreaterThanOrEqual(tailId);
-    expect(tailId).toBeGreaterThan(cursorPlantedAt);
+      .toBeGreaterThanOrEqual(tailRow.id);
+    expect(tailRow.id).toBeGreaterThan(lastReadRow.id);
 
     // Outcome 3 — coming back shows no bar and no phantom count. The resume
     // re-reads the cursor this dismiss advanced, so a dismiss that cleared the
@@ -196,66 +209,5 @@ test.describe("#1019 — leaving a far-behind window marks it read", () => {
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { awaitWsReady: false });
     await expect(bar).toHaveCount(0, { timeout: OUTCOME_TIMEOUT_MS });
     await expect(badge).toHaveCount(0);
-  });
-
-  test("backgrounding the tab does NOT dismiss — only a window switch does", async ({
-    page,
-    context,
-  }) => {
-    if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
-    const vjt = getSeededVjt();
-    const { cursorPlantedAt } = await seedFarBehindChannel(CHANNEL);
-
-    await loginAs(page, vjt);
-    await selectChannel(page, NETWORK_SLUG, CHANNEL);
-
-    const bar = page.locator('[data-testid="far-behind-bar"]');
-    await expect(bar).toBeAttached({ timeout: OUTCOME_TIMEOUT_MS });
-    const badge = sidebarMessageBadge(page, NETWORK_SLUG, CHANNEL);
-    await expect(badge).toBeVisible({ timeout: OUTCOME_TIMEOUT_MS });
-
-    // Drive a REAL background: a second tab brought to front. That flips both
-    // inputs `documentVisibility.ts` reads — `visibilityState` and
-    // `hasFocus()` — through the browser's own event path, not a synthesised
-    // `visibilitychange`. Q1's rejected cases (b) and (c) are exactly this.
-    const other = await context.newPage();
-    await other.goto("about:blank");
-    await other.bringToFront();
-
-    // Precondition, polled, NOT assumed: if the harness cannot actually
-    // background the page, this fails loudly instead of letting the negative
-    // pass vacuously.
-    await expect
-      .poll(
-        async () =>
-          await page.evaluate(
-            () => document.visibilityState === "visible" && document.hasFocus(),
-          ),
-        { timeout: OUTCOME_TIMEOUT_MS },
-      )
-      .toBe(false);
-
-    // The barrier is the round trip, not a sleep: coming back to the front is
-    // an observable edge, and it happens strictly after the hide edge that
-    // would have dismissed. If the visibility writer had a back door, the
-    // badge would already be gone by the time focus returns.
-    await page.bringToFront();
-    await expect
-      .poll(
-        async () =>
-          await page.evaluate(
-            () => document.visibilityState === "visible" && document.hasFocus(),
-          ),
-        { timeout: OUTCOME_TIMEOUT_MS },
-      )
-      .toBe(true);
-    await other.close();
-
-    // Still far behind: the freeze held, and the cursor is untouched
-    // server-side. The cursor assertion is the one that cannot be faked by a
-    // slow render.
-    await expect(bar).toBeAttached();
-    await expect(badge).toBeVisible();
-    expect(await getReadCursor(vjt.token, NETWORK_SLUG, CHANNEL)).toBe(cursorPlantedAt);
   });
 });

--- a/cicchetto/e2e/tests/issue1019-farbehind-leave-dismiss.spec.ts
+++ b/cicchetto/e2e/tests/issue1019-farbehind-leave-dismiss.spec.ts
@@ -1,0 +1,261 @@
+// #1019 — leaving a far-behind window IS the bar's ×.
+//
+// vjt, on IRC: *"il focus out su una finestra con molto scrollback e con la
+// top bar dovrebbe fare mark as read, come se avessimo premuto la X"*. The
+// far-behind bar (#693/#888) had two exits and both cost a deliberate click;
+// an operator who simply moves on to another window used to carry a frozen
+// badge that no amount of reading could clear, because #693 freezes the read
+// cursor on purpose and the leave writer is one of the four the freeze holds
+// back.
+//
+// The fix ROUTES the leave writer to `dismissFarBehind` instead of thawing
+// `setCursorIfAdvances` for it. That distinction is invisible from the
+// outside, so what this spec pins is the OUTCOME, three ways:
+//
+//   * the sidebar badge falls once the operator selects another window —
+//     the thing they could not achieve without finding the × at the top edge;
+//   * the SERVER-side cursor lands at (or past) the tail — the same
+//     `setReadCursor` fan-out the × performs, which is what "identical in
+//     effect to clicking ×" in the Acceptance clause actually means. A purely
+//     local badge clear would satisfy the first assertion and leave every
+//     other device still far behind;
+//   * coming BACK shows no bar and no phantom count — the second Acceptance
+//     clause, and the one that would catch a dismiss that cleared the badge
+//     without moving the cursor the resume re-reads.
+//
+// Q1 was ruled by vjt on the issue: only (a), a window switch INSIDE cic,
+// dismisses. Test 2 pins the negative half of that ruling — backgrounding the
+// tab / losing window focus must NOT dismiss (`documentVisibility` gates the
+// visibility-hide writer, which stays frozen).
+//
+// NOT covered here, deliberately, and named so nobody reads this file as a
+// completeness claim: `channel → home / mentions / admin` unmounts the pane
+// and lands in `onCleanup`, where `props` already read the ARRIVING virtual
+// selection, so the leaving window cannot be named. That switch leaves the
+// far-behind state STANDING (the safe side — the region stays recoverable)
+// and the PR says so at the call site. This spec therefore leaves for the
+// SERVER window, which shares the `kindHasScrollback` Match with channels and
+// so keeps the pane mounted and fires the key arm — the same gesture
+// `cursor-forward-only.spec.ts` uses to drive the leave writer.
+//
+// Against the parent commit the leave writer reaches a frozen door, the
+// cursor never moves and the badge never falls, so the spec is RED at the
+// first outcome assertion rather than at a locator.
+//
+// Seeding mirrors `issue997-far-behind-thumb-reach.spec.ts` (same bar, same
+// precondition): the shared seeder plants 200 rows in #bofh and this needs a
+// gap ABOVE the 200-row page cap, so it re-seeds via the admin
+// `resetSubject(baselineSeed)` surface. The wrapped `test` fixture's afterEach
+// truncates #bofh back to the baseline; `restoreReadCursorToTail` in afterAll
+// undoes the early cursor (BUGHUNT-3 cascade rule — a spec that leaves a
+// mid-list cursor behind makes every downstream spec open its pane at a
+// divider instead of at the tail).
+//
+// No sleep is used as synchronisation anywhere: every step waits on an
+// observable condition (the bar attaching, the badge reaching count 0, the
+// server cursor reaching the tail, `isDocumentVisible`'s two inputs flipping).
+// The cursor is written server-side at SETTLE cadence, so the timeouts here
+// are WAIT BUDGETS on those conditions, never the thing being measured.
+//
+// Desktop viewport on purpose, matching #997: the sidebar badge is the
+// clearer read of "the badge fell" than the mobile tab treatment.
+
+import { expect, test } from "../fixtures/test";
+import { loginAs, selectChannel, sidebarMessageBadge } from "../fixtures/cicchettoPage";
+import {
+  fetchAllMessagesAsc,
+  getReadCursor,
+  resetSubject,
+  restoreReadCursorToTail,
+  setReadCursorToId,
+} from "../fixtures/grappaApi";
+import {
+  AUTOJOIN_CHANNELS,
+  getSeededAdmin,
+  getSeededVjt,
+  NETWORK_SLUG,
+  VJT_USER,
+} from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Larger than the 200-row server cap, so a cursor planted early leaves a gap
+// the resume cannot drain in one page — the far-behind precondition.
+const LARGE_SEED_COUNT = 260;
+const SEED_SENDER = "seed-bot";
+
+// The server's `@max_http_limit` and the client's `PAGE_LIMIT`. A gap above
+// this is what "far behind" means.
+const MAX_HTTP_LIMIT = 200;
+
+// Rows left after the planted cursor — above the cap, so the pane anchors at
+// the tail and freezes.
+const UNREAD_TARGET = 240;
+
+// Wait budget for the settle-cadence server write to land and fan back. Not a
+// sleep: it bounds an `expect.poll` / `toHaveCount` CONDITION.
+const OUTCOME_TIMEOUT_MS = 10_000;
+
+interface FarBehindFixture {
+  readonly tailId: number;
+  readonly cursorPlantedAt: number;
+}
+
+// Plant the far-behind precondition and prove it, before any browser exists.
+// Returns the two ids the assertions are written against.
+async function seedFarBehindChannel(channel: string): Promise<FarBehindFixture> {
+  const vjt = getSeededVjt();
+  const admin = getSeededAdmin();
+
+  await resetSubject(
+    admin.token,
+    VJT_USER,
+    { [NETWORK_SLUG]: AUTOJOIN_CHANNELS },
+    { [NETWORK_SLUG]: [{ name: channel, seedCount: LARGE_SEED_COUNT, seedSender: SEED_SENDER }] },
+  );
+
+  const rows = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, channel);
+  expect(rows.length).toBeGreaterThan(UNREAD_TARGET);
+
+  const lastReadRow = rows[rows.length - UNREAD_TARGET];
+  const tailRow = rows[rows.length - 1];
+  if (!lastReadRow || !tailRow) throw new Error("#1019 spec: seeded #bofh rows missing an index");
+
+  // Guard the precondition: below this the pane never goes far behind and the
+  // spec would pass by testing nothing.
+  const rowsAfterCursor = rows.filter((r) => r.id > lastReadRow.id).length;
+  expect(rowsAfterCursor).toBeGreaterThan(MAX_HTTP_LIMIT);
+
+  // Plant the cursor BEFORE login so the channel hydrates with it and takes
+  // the cursor-present fetch arm.
+  await setReadCursorToId(vjt.token, NETWORK_SLUG, channel, lastReadRow.id);
+
+  return { tailId: tailRow.id, cursorPlantedAt: lastReadRow.id };
+}
+
+test.describe("#1019 — leaving a far-behind window marks it read", () => {
+  test.use({ viewport: { width: 800, height: 400 } });
+
+  test.afterAll(async () => {
+    if (!CHANNEL) return;
+    const vjt = getSeededVjt();
+    await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
+  });
+
+  test("selecting another window drops the frozen badge and advances the server cursor", async ({
+    page,
+  }) => {
+    if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+    const vjt = getSeededVjt();
+    const { tailId, cursorPlantedAt } = await seedFarBehindChannel(CHANNEL);
+
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, CHANNEL);
+
+    // The bar renders only once the resume has probed the count and decided
+    // the gap is undrainable — the readiness signal for the far-behind arm,
+    // and the gate that says the freeze is actually in force.
+    const bar = page.locator('[data-testid="far-behind-bar"]');
+    await expect(bar).toBeAttached({ timeout: OUTCOME_TIMEOUT_MS });
+
+    const badge = sidebarMessageBadge(page, NETWORK_SLUG, CHANNEL);
+    await expect(badge).toBeVisible({ timeout: OUTCOME_TIMEOUT_MS });
+    await expect(badge).toHaveClass(/far-behind/);
+
+    // Nothing has moved it yet: the pane has been open and rendered, and the
+    // cursor is still exactly where it was planted. Without this the next
+    // assertion could be satisfied by a write that had already happened.
+    expect(await getReadCursor(vjt.token, NETWORK_SLUG, CHANNEL)).toBe(cursorPlantedAt);
+
+    // THE gesture. The server window shares the `kindHasScrollback` Match with
+    // channels, so the pane stays mounted and the key arm fires with #bofh as
+    // the LEAVING key — a real selection change through the sidebar, not a
+    // direct call to the dismiss.
+    await selectChannel(page, NETWORK_SLUG, NETWORK_SLUG, { awaitWsReady: false });
+
+    // Outcome 1 — the badge fell. This is the operator-visible result and the
+    // whole point of the issue.
+    await expect(badge).toHaveCount(0, { timeout: OUTCOME_TIMEOUT_MS });
+
+    // Outcome 2 — the SERVER cursor moved to the tail, i.e. the same
+    // `setReadCursor` fan-out the × performs. `toBeGreaterThanOrEqual` rather
+    // than `toBe`: the dismiss marks the newest LOCAL row, and a presence row
+    // (a peer JOIN on the shared testnet) can land after the seed snapshot and
+    // legitimately push the tail past `tailId`. The load-bearing claim is that
+    // it crossed the whole abandoned region, which the second assertion pins.
+    await expect
+      .poll(async () => await getReadCursor(vjt.token, NETWORK_SLUG, CHANNEL), {
+        timeout: OUTCOME_TIMEOUT_MS,
+      })
+      .toBeGreaterThanOrEqual(tailId);
+    expect(tailId).toBeGreaterThan(cursorPlantedAt);
+
+    // Outcome 3 — coming back shows no bar and no phantom count. The resume
+    // re-reads the cursor this dismiss advanced, so a dismiss that cleared the
+    // badge locally without persisting would rebuild the bar right here.
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { awaitWsReady: false });
+    await expect(bar).toHaveCount(0, { timeout: OUTCOME_TIMEOUT_MS });
+    await expect(badge).toHaveCount(0);
+  });
+
+  test("backgrounding the tab does NOT dismiss — only a window switch does", async ({
+    page,
+    context,
+  }) => {
+    if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+    const vjt = getSeededVjt();
+    const { cursorPlantedAt } = await seedFarBehindChannel(CHANNEL);
+
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, CHANNEL);
+
+    const bar = page.locator('[data-testid="far-behind-bar"]');
+    await expect(bar).toBeAttached({ timeout: OUTCOME_TIMEOUT_MS });
+    const badge = sidebarMessageBadge(page, NETWORK_SLUG, CHANNEL);
+    await expect(badge).toBeVisible({ timeout: OUTCOME_TIMEOUT_MS });
+
+    // Drive a REAL background: a second tab brought to front. That flips both
+    // inputs `documentVisibility.ts` reads — `visibilityState` and
+    // `hasFocus()` — through the browser's own event path, not a synthesised
+    // `visibilitychange`. Q1's rejected cases (b) and (c) are exactly this.
+    const other = await context.newPage();
+    await other.goto("about:blank");
+    await other.bringToFront();
+
+    // Precondition, polled, NOT assumed: if the harness cannot actually
+    // background the page, this fails loudly instead of letting the negative
+    // pass vacuously.
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate(
+            () => document.visibilityState === "visible" && document.hasFocus(),
+          ),
+        { timeout: OUTCOME_TIMEOUT_MS },
+      )
+      .toBe(false);
+
+    // The barrier is the round trip, not a sleep: coming back to the front is
+    // an observable edge, and it happens strictly after the hide edge that
+    // would have dismissed. If the visibility writer had a back door, the
+    // badge would already be gone by the time focus returns.
+    await page.bringToFront();
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate(
+            () => document.visibilityState === "visible" && document.hasFocus(),
+          ),
+        { timeout: OUTCOME_TIMEOUT_MS },
+      )
+      .toBe(true);
+    await other.close();
+
+    // Still far behind: the freeze held, and the cursor is untouched
+    // server-side. The cursor assertion is the one that cannot be faked by a
+    // slow render.
+    await expect(bar).toBeAttached();
+    await expect(badge).toBeVisible();
+    expect(await getReadCursor(vjt.token, NETWORK_SLUG, CHANNEL)).toBe(cursorPlantedAt);
+  });
+});

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -1663,6 +1663,16 @@ const ScrollbackPane: Component<Props> = (props) => {
   // CURRENT pane (props.networkSlug, props.channelName — captured in
   // the closure at component-init time, won't change before unmount
   // because the component IS this (slug, channel) instance).
+  //
+  // #1019 does NOT reach this path, deliberately. Leaving a far-behind
+  // window for another CHAT window is the dismiss (the `on(key, …)` arm
+  // above); leaving it for home/mentions/admin is not, because at the
+  // dispose tick `props` already read the ARRIVING virtual selection (the
+  // same reason `setReadCursor` carries the #160 virtual-window guard). The
+  // leaving window cannot be named from here, and naming it would mean
+  // duplicating a "last mounted key" the key arm already owns. So a
+  // channel→home switch leaves the far-behind state standing — the region
+  // stays recoverable, which is the safe side of the gap.
   onCleanup(settleCursorToVisibleTail);
 
   createEffect(
@@ -2210,15 +2220,32 @@ const ScrollbackPane: Component<Props> = (props) => {
       // `prevKey === undefined` only on the mount run (no `defer` here);
       // `prevKey === newKey` shouldn't happen. Skip both.
       if (prevKey === undefined || prevKey === newKey) return;
-      const snapshotted = visibleTailSnapshot.get(prevKey);
-      const prevMsgs = scrollbackByChannel()[prevKey];
-      const storeTail =
-        prevMsgs && prevMsgs.length > 0 ? (prevMsgs[prevMsgs.length - 1]?.id ?? null) : null;
-      const id = snapshotted ?? storeTail;
-      if (id !== null) {
-        const decoded = decodeChannelKey(prevKey);
-        if (decoded !== null) {
-          setCursorIfAdvances(decoded.slug, decoded.name, id);
+      const decoded = decodeChannelKey(prevKey);
+      if (decoded !== null) {
+        if (farBehindByChannel()[prevKey]) {
+          // #1019 — walking away from a far-behind window IS the bar's ×.
+          // The cursor is FROZEN here (#693), so the settle below would be a
+          // silent no-op and the operator would carry a stuck badge until they
+          // noticed the bar. Leaving is the same sentence the × speaks, so it
+          // gets the same verb — ROUTED here rather than let through
+          // `setCursorIfAdvances`, which must keep freezing out the other three
+          // writers (scroll-settle, visibility-hide, scroll-to-bottom): none of
+          // them is a statement about being done with the window, and thawing
+          // the door for one thaws it for all four.
+          //
+          // No `setMarkerCursorId` re-latch, unlike the × (which stays in this
+          // window and would otherwise slam a stale divider across the top).
+          // The pane has already moved on; the sibling activation effect owns
+          // the arriving window's marker, and a later return re-latches from
+          // the cursor this dismiss just advanced.
+          dismissFarBehind(decoded.slug, decoded.name);
+        } else {
+          const snapshotted = visibleTailSnapshot.get(prevKey);
+          const prevMsgs = scrollbackByChannel()[prevKey];
+          const storeTail =
+            prevMsgs && prevMsgs.length > 0 ? (prevMsgs[prevMsgs.length - 1]?.id ?? null) : null;
+          const id = snapshotted ?? storeTail;
+          if (id !== null) setCursorIfAdvances(decoded.slug, decoded.name, id);
         }
       }
       // Free the snapshot for the leaving key — we won't visit this

--- a/cicchetto/src/__tests__/ScrollbackPane.test.tsx
+++ b/cicchetto/src/__tests__/ScrollbackPane.test.tsx
@@ -2206,6 +2206,119 @@ describe("ScrollbackPane", () => {
       });
     });
 
+    // #1019 — the third exit, and it costs no click. The bar's two exits are
+    // both deliberate gestures, and #693 froze the cursor precisely so that
+    // nothing passive could take them. But WALKING AWAY from a window is not
+    // passive: it is the same "I'm done with those" sentence the × speaks, so
+    // it gets the same effect. The freeze itself is untouched — the leave
+    // writer is ROUTED to the dismiss, not released through
+    // `setCursorIfAdvances`, which must keep holding back the other three.
+    describe("leaving a far-behind window dismisses it (#1019)", () => {
+      afterEach(() => {
+        setFarBehind({});
+        jumpToUnreadSpy.mockClear();
+        dismissFarBehindSpy.mockClear();
+      });
+
+      // A real selection change, driven the way the #608 switch specs drive
+      // one: a signal on `channelName`, so the pane's `on(key, prevKey)` leave
+      // arm fires against a genuinely-changed key. Directly calling
+      // `dismissFarBehind` would assert nothing about who calls it.
+      const switchAwayFrom = async (farBehindOn: string | null) => {
+        const [chan, setChan] = createSignal("#a");
+        setScrollback({ "freenode #a": fixture, "freenode #b": fixture });
+        if (farBehindOn !== null) {
+          setFarBehind({ [farBehindOn]: { missed: 3000, resumeFrom: 1 } });
+        }
+        render(() => <ScrollbackPane networkSlug="freenode" channelName={chan()} kind="channel" />);
+        // jsdom leaves scrollTo undefined; the key-change smooth-scroll
+        // interrupt calls it on the switch (same stub as the #608 specs).
+        (screen.getByTestId("scrollback") as HTMLDivElement).scrollTo = vi.fn();
+        dismissFarBehindSpy.mockClear();
+        mockSetCursorIfAdvances.mockClear();
+        setChan("#b");
+        // Synchronous flush only: the #887 read-at-the-tail arm lands its own
+        // write 500 ms later, and this assertion is about the leave.
+        await Promise.resolve();
+      };
+
+      it("marks the LEAVING window read, the same verb the × fires", async () => {
+        await switchAwayFrom("freenode #a");
+        expect(dismissFarBehindSpy).toHaveBeenCalledWith("freenode", "#a");
+      });
+
+      it("does not offer the abandoned tail to the frozen forward-only door", async () => {
+        // The whole point of routing rather than relaxing: if the leave still
+        // walks through `setCursorIfAdvances`, then either the freeze drops it
+        // (nothing happens, the defect stands) or the freeze was loosened for
+        // everybody — the #693 regression this issue must not cause.
+        await switchAwayFrom("freenode #a");
+        expect(mockSetCursorIfAdvances).not.toHaveBeenCalledWith(
+          "freenode",
+          "#a",
+          expect.anything(),
+        );
+      });
+
+      it("leaves an ordinary window on its existing settle path", async () => {
+        await switchAwayFrom(null);
+        expect(mockSetCursorIfAdvances).toHaveBeenCalledWith("freenode", "#a", 3);
+        expect(dismissFarBehindSpy).not.toHaveBeenCalled();
+      });
+
+      it("does not dismiss a window it is switching TO", async () => {
+        // The arm reads `prevKey`. Keying it off the pane's live props would
+        // burn the ARRIVING window's abandoned region on every switch into it.
+        await switchAwayFrom("freenode #b");
+        expect(dismissFarBehindSpy).not.toHaveBeenCalled();
+      });
+
+      it("keeps the visibility-hide writer frozen — backgrounding is not leaving", async () => {
+        // Q1 ruled by vjt: only a window switch inside cic dismisses. A phone
+        // lock is not a statement about one window, and routing it here would
+        // burn the region on every screen blank.
+        seedReadCursor("freenode", "#grappa", 1);
+        setScrollback({ "freenode #grappa": fixture });
+        setFarBehind({ "freenode #grappa": { missed: 3000, resumeFrom: 1 } });
+        render(() => (
+          <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+        ));
+        dismissFarBehindSpy.mockClear();
+        setDocVisible(false);
+        await new Promise((r) => setTimeout(r, 0));
+        expect(dismissFarBehindSpy).not.toHaveBeenCalled();
+      });
+
+      it("keeps the scroll-settle writer frozen — reading at the tail is not leaving", async () => {
+        // The other back door onto the same cursor. Reading the newest rows of
+        // a far-behind window says nothing about the thousands below them.
+        const rows: ScrollbackMessage[] = Array.from({ length: 30 }, (_, i) => ({
+          id: i + 1,
+          network: "freenode",
+          channel: "#grappa",
+          server_time: i + 1,
+          kind: "privmsg",
+          sender: "alice",
+          body: `row ${i + 1}`,
+          meta: {},
+        }));
+        setScrollback({ "freenode #grappa": rows });
+        setFarBehind({ "freenode #grappa": { missed: 3000, resumeFrom: 1 } });
+        const { container } = render(() => (
+          <ScrollbackPane networkSlug="freenode" channelName="#grappa" kind="channel" />
+        ));
+        const list = container.querySelector('[data-testid="scrollback"]') as HTMLDivElement;
+        // A real input event arms the settle gate (BUGHUNT-2), so the timer
+        // genuinely fires — otherwise this would pass on the gate, not the freeze.
+        list.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+        dismissFarBehindSpy.mockClear();
+        list.scrollTop = 100;
+        list.dispatchEvent(new Event("scroll"));
+        await new Promise((r) => setTimeout(r, 700));
+        expect(dismissFarBehindSpy).not.toHaveBeenCalled();
+      });
+    });
+
     // #947 — the notch after #693. The operator took the jump, so the flag is
     // gone and the divider is back; but the jump could only carry ONE page of
     // the gap, so counting the loaded rows reports the page size. The number

--- a/cicchetto/src/lib/selection.ts
+++ b/cicchetto/src/lib/selection.ts
@@ -554,13 +554,24 @@ const exports = identityScopedStore((onIdentityChange) => {
   // Token guard: identity-rotation can null the bearer mid-effect.
   // #693 — the far-behind freeze. A pane that anchored at the tail renders
   // rows thousands of ids above the operator's real read position, and every
-  // writer that funnels through here (scroll-settle, focus-leave, the
-  // visibility-hide arm, the scroll-to-bottom gesture) offers the newest
-  // RENDERED id. Forward-only would happily take it and mark the entire
-  // abandoned region read — server-side, fanned to every other device,
-  // destroying the position the jump affordance exists to return to. Freeze
-  // the cursor for as long as the window is far behind; `dismissFarBehind`
-  // (scrollback.ts) is the one deliberate way past it.
+  // writer that funnels through here (scroll-settle, the visibility-hide arm,
+  // the scroll-to-bottom gesture) offers the newest RENDERED id. Forward-only
+  // would happily take it and mark the entire abandoned region read —
+  // server-side, fanned to every other device, destroying the position the
+  // jump affordance exists to return to. Freeze the cursor for as long as the
+  // window is far behind; `dismissFarBehind` (scrollback.ts) is the one
+  // deliberate way past it.
+  //
+  // #1019 — focus-leave USED to be a fourth name on that list and is not
+  // anymore, and the difference is who decides, not how strong the guard is.
+  // Leaving a window is a deliberate "I'm done with those", so the leave arm
+  // (ScrollbackPane's `on(key, prevKey)` effect) now routes a far-behind
+  // window to `dismissFarBehind` and never reaches this door with it. The
+  // door itself did NOT move: the remaining three are passive — scrolling,
+  // backgrounding, tapping to the bottom — and each still gets frozen out
+  // here. Do not "simplify" that routing back into a caller-kind flag on this
+  // function: the freeze is the invariant, and a parameter that can turn it
+  // off is one careless call site away from being gone for all four.
   //
   // This is the single door for cursor advancement, so the guard belongs
   // here, not in each of the four callers.


### PR DESCRIPTION
Issue #1019.

## What

The far-behind bar (#693) has two exits and both cost a deliberate click on
a control pinned to the top edge. vjt's ask: *"il focus out su una finestra
con molto scrollback e con la top bar dovrebbe fare mark as read, come se
avessimo premuto la X"*. Walking away from the window IS that sentence, so
it now gets that effect — same `dismissFarBehind` verb, same `setReadCursor`
fan-out, no click.

## The one thing that must not happen

`setCursorIfAdvances` (`selection.ts`) is **untouched**. The leave writer is
ROUTED to `dismissFarBehind` before it ever reaches that door; it is not
released through it. The three writers the freeze still holds back —
scroll-settle, visibility-hide, scroll-to-bottom — are all passive
(scrolling, backgrounding, tapping to the bottom), and none of them is a
statement about being done with the window. Thawing the shared door for one
caller thaws it for all four and gives back #693 whole.

A caller-kind parameter on `setCursorIfAdvances` was considered and
rejected: an invariant you can pass `false` to is one careless call site
from being gone. That reasoning is written into the comment so the next
reader does not "simplify" it back.

Two guardrail specs pin it, and both were measured by mutation: routing the
shared `settleCursorToVisibleTail` to the dismiss turns them red.

## The three open questions

- **Q1 — what is "focus out"?** Ruled by vjt on the issue: **(a) only**, a
  window switch inside cic. Tab backgrounding (`documentVisibility`) and OS
  window blur do NOT dismiss. Pinned by the visibility-hide guardrail spec.
- **Q2 — is the tail the right mark?** Not a choice: the Acceptance clause
  requires the effect to be identical to the ×, so it is the same verb,
  reached through the same function, marking the newest LOCAL row.
- **Q3 — does the freeze survive?** Stated out loud rather than left
  implicit, because it is the accepted cost of (a): **the far-behind state
  no longer outlives one window switch.** The abandoned region is
  recoverable only by taking the jump BEFORE leaving. vjt accepted that
  when he chose (a); #693 filed the freeze to protect exactly that
  position, so it belongs in the record.

## Scope boundary I am NOT claiming

`channel → home / mentions / admin` unmounts the pane and lands in
`onCleanup`, where `props` already read the **arriving virtual** selection
(the same reason `setReadCursor` carries the #160 virtual-window guard, and
the reason Shell's own comment says `onCleanup` cannot read the leaving
pane reliably). The leaving window cannot be named from there without
duplicating a "last mounted key" that the key arm already owns, so that
switch leaves the far-behind state standing. That is the safe side of the
gap — the region stays recoverable — and it is documented at the call site.

## Divider

No `setMarkerCursorId` re-latch, unlike the ×. The × stays in the window and
would otherwise slam a stale divider across the top; the leave arm has
already moved on, and the arriving window's marker belongs to the activation
effect. A later return re-latches from the cursor this dismiss advanced
(optimistic local advance in `setReadCursor`), so there is no bar and no
phantom count — the second Acceptance clause.

## Notes

- #997 landed first and moved the dismiss into a second surface; this branch
  is cut from current `origin/main` and touches no markup — the bar and the
  corner affordance are untouched.
- Tests drive a **real selection change** at the `ScrollbackPane` level (a
  signal on `channelName`), never a direct `dismissFarBehind` call, per the
  Acceptance clause.

## Gates

- `bun run check` (biome + tsc) — rc=0
- `bun run test` — **4606/4606 passed**, 246 files
- RED read before GREEN: the two behaviour specs failed on the unmodified
  tree, and the two freeze guardrails were proven capable of red by
  mutation.
- No e2e run and no Elixir gate: this is cic-only, no lane taken.