### PR TITLE
cic(#1018): the next-active cycle skips muted windows

### DIFF
--- a/cicchetto/e2e/tests/issue1018-mute-skips-next-active.spec.ts
+++ b/cicchetto/e2e/tests/issue1018-mute-skips-next-active.spec.ts
@@ -1,0 +1,119 @@
+// GH #1018 — a MUTED conversation (#866) is not a stop on the next-active
+// cycle (#235: Alt+A, Ctrl+N/P, the on-screen affordance).
+//
+// Why an e2e and not just the unit test on `orderUnreadWindows`:
+//
+//   * the mute is created through the SettingsDrawer picker, so the folded
+//     key the picker WRITES and the key the cycle READS are proven to be the
+//     same string. Two unit suites on either side of that seam cannot see a
+//     fold mismatch between them — the same argument
+//     `push-866-conversation-mute.spec.ts` makes for the push port.
+//   * the outcome under test is "which window did the operator land on",
+//     which is only observable here.
+//
+// Scope guard under test too (#866 Q4): the muted channel keeps its sidebar
+// unread badge. The mute changes the NAVIGATION order, not the counters.
+//
+// Desktop only, deliberately: all three doors dispatch the SAME verb
+// (`jumpToNextActiveWindow`), and #235's own spec already gates the mobile
+// button against that verb. This spec's variable is the mute, not the door.
+//
+// Removing the feature turns this red at the first jump: the muted channel
+// heads the cycle (older activity, same tier) and Alt+A lands there.
+
+import {
+  loginAs,
+  openSettingsSection,
+  selectChannel,
+  sidebarMessageBadge,
+  sidebarWindow,
+} from "../fixtures/cicchettoPage";
+import { clearMutedConversations, partChannel } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+const PEER_NICK = "i1018-noise";
+const MUTED_CHANNEL = "#1018-muted";
+const LOUD_CHANNEL = "#1018-loud";
+
+const NEXT_ACTIVE_BTN = '[data-testid="next-active-btn"]';
+const NEXT_ACTIVE_COUNT = '[data-testid="next-active-btn"] .next-active-count';
+
+test("Alt+A skips the muted channel and lands on the unmuted one, badge intact", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+
+  const peer = await IrcPeer.connect({ nick: PEER_NICK });
+  try {
+    await peer.join(MUTED_CHANNEL);
+    await peer.join(LOUD_CHANNEL);
+
+    // Join operator-side and visit each window: the picker offers the
+    // conversations the operator actually has, and the visit baselines each
+    // read cursor to the tail so the unread below is the traffic this spec
+    // produces, not seed backlog.
+    for (const channel of [MUTED_CHANNEL, LOUD_CHANNEL]) {
+      await page.locator(".compose-box textarea").fill(`/join ${channel}`);
+      await page.locator(".compose-box textarea").press("Enter");
+      await selectChannel(page, NETWORK_SLUG, channel, { ownNick: NETWORK_NICK });
+    }
+
+    await openSettingsSection(page, "push");
+    const picker = page.locator('[data-testid="pref-mute-picker"]');
+    await expect(picker.locator(`option[value="${MUTED_CHANNEL}"]`)).toHaveCount(1);
+    await picker.selectOption(MUTED_CHANNEL);
+    // The row is drawn from the server's normalized echo, so its presence
+    // proves the PUT landed — no sleep, no arbitrary timeout.
+    await expect(page.locator(`[data-testid="pref-muted-${MUTED_CHANNEL}"]`)).toBeVisible({
+      timeout: 10_000,
+    });
+    // ...and the sibling is demonstrably NOT muted: the two arms below differ
+    // in exactly one variable.
+    await expect(page.locator(`[data-testid="pref-muted-${LOUD_CHANNEL}"]`)).toHaveCount(0);
+    await page.locator('[data-testid="settings-drawer-backdrop"]').click({ force: true });
+
+    // Park focus on the neutral $server window — NOT part of the cycle — so
+    // both channels accrue unread.
+    await selectChannel(page, NETWORK_SLUG, NETWORK_SLUG, { awaitWsReady: false });
+
+    // The MUTED channel speaks FIRST: with the mute gone it is the older
+    // activity in the same tier, i.e. the head of the cycle. That ordering is
+    // what makes the assertion below discriminating.
+    peer.privmsg(MUTED_CHANNEL, "1018 muted room, still noisy");
+    await expect(sidebarMessageBadge(page, NETWORK_SLUG, MUTED_CHANNEL)).toBeVisible({
+      timeout: 10_000,
+    });
+    peer.privmsg(LOUD_CHANNEL, "1018 the room you actually read");
+    await expect(sidebarMessageBadge(page, NETWORK_SLUG, LOUD_CHANNEL)).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // TWO windows carry unread, but only ONE is a stop on the cycle.
+    await expect(page.locator(NEXT_ACTIVE_COUNT)).toHaveText("1", { timeout: 10_000 });
+
+    await page.keyboard.press("Alt+a");
+    await expect(sidebarWindow(page, NETWORK_SLUG, LOUD_CHANNEL)).toHaveClass(/selected/, {
+      timeout: 10_000,
+    });
+
+    // The unmuted room is read now. The muted one is STILL unread — and the
+    // affordance is gone rather than offering it (#1018 Q2: when every
+    // remaining unread window is muted the cycle is a no-op).
+    await expect(page.locator(NEXT_ACTIVE_BTN)).toHaveCount(0, { timeout: 10_000 });
+
+    // #866 Q4 scope guard: the mute took the window off the CYCLE, not off
+    // the counters — its sidebar unread badge is untouched.
+    await expect(sidebarMessageBadge(page, NETWORK_SLUG, MUTED_CHANNEL)).toBeVisible();
+  } finally {
+    await peer.disconnect("#1018 done");
+    // The mute is PERSISTED per subject and vjt is shared by the whole suite —
+    // leaving it behind silences #1018-muted for every later spec, and the
+    // victim fails with nothing pointing back here.
+    await clearMutedConversations(vjt.token).catch(() => {});
+    await partChannel(vjt.token, NETWORK_SLUG, MUTED_CHANNEL).catch(() => {});
+    await partChannel(vjt.token, NETWORK_SLUG, LOUD_CHANNEL).catch(() => {});
+  }
+});

--- a/cicchetto/e2e/tests/issue1018-mute-skips-next-active.spec.ts
+++ b/cicchetto/e2e/tests/issue1018-mute-skips-next-active.spec.ts
@@ -30,7 +30,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { clearMutedConversations, partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
-import { getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "i1018-noise";
@@ -45,6 +45,18 @@ test("Alt+A skips the muted channel and lands on the unmuted one, badge intact",
 }) => {
   const vjt = getSeededVjt();
   await loginAs(page, vjt);
+  // Focus the seeded autojoin channel before anything else, for TWO
+  // reasons that both bite silently if skipped:
+  //   * the compose box below only exists once a scrollback-kind window
+  //     is selected — Shell's `kindHasScrollback` Match owns ComposeBox,
+  //     and boot auto-selects $home, which has none. Without this the
+  //     `/join` fill waits 30s on a locator that never mounts.
+  //   * the per-test reset clears every read cursor and re-seeds this
+  //     channel with 200 rows, so it starts FULLY unread and would be a
+  //     second stop on the cycle. Focusing it baselines the cursor to
+  //     the tail, which is what makes the count assertion below read the
+  //     two windows this spec drives and nothing else.
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
 
   const peer = await IrcPeer.connect({ nick: PEER_NICK });
   try {

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -14,8 +14,8 @@ import InlineConfirmButton from "./InlineConfirmButton";
 import { windowCandidates } from "./lib/activeWindows";
 import { ApiError, displayNick, type Network, visitorNetworkNick } from "./lib/api";
 import { getSubject, token } from "./lib/auth";
-import { canonicalChannel } from "./lib/channelKey";
 import { getColoredNicklist } from "./lib/colorNicklist";
+import { windowMuteKey } from "./lib/conversationMute";
 import { syncedSetColoredNicklist, syncedSetTimeFormat } from "./lib/displayPrefs";
 import { type FontSizeKey, getFontSize, setFontSize } from "./lib/fontSize";
 import { friendlyApiError } from "./lib/friendlyApiError";
@@ -542,7 +542,7 @@ const SettingsDrawer: Component<Props> = (props) => {
     const muted = prefs().muted_targets ?? {};
     const byKey = new Map<string, string>();
     for (const candidate of windowCandidates()) {
-      const key = canonicalChannel(candidate.channelName);
+      const key = windowMuteKey(candidate);
       if (Object.hasOwn(muted, key) || byKey.has(key)) continue;
       byKey.set(key, candidate.channelName);
     }

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -359,14 +359,23 @@ vi.mock("../lib/api", () => ({
   adminListSessionLog: vi.fn().mockResolvedValue([]),
 }));
 
-vi.mock("../lib/channelKey", () => ({
-  channelKey: (slug: string, name: string) => `${slug} ${name}`,
-  decodeChannelKey: (key: string) => {
-    const sep = key.indexOf(" ");
-    if (sep < 0) return null;
-    return { slug: key.slice(0, sep), name: key.slice(sep + 1) };
-  },
-}));
+// Only the composite-key pair is stubbed (identity, not folding — the
+// fixtures key on raw names). `canonicalChannel` stays REAL via importActual:
+// the #1018 mute lookup folds through it inside `activeWindows`, and a
+// hand-rolled stand-in here would be this suite re-implementing production's
+// fold.
+vi.mock("../lib/channelKey", async () => {
+  const actual = await vi.importActual<typeof import("../lib/channelKey")>("../lib/channelKey");
+  return {
+    ...actual,
+    channelKey: (slug: string, name: string) => `${slug} ${name}`,
+    decodeChannelKey: (key: string) => {
+      const sep = key.indexOf(" ");
+      if (sep < 0) return null;
+      return { slug: key.slice(0, sep), name: key.slice(sep + 1) };
+    },
+  };
+});
 
 // windowState — Shell + TopicBar gate the members aside / hamburger /
 // nick count on the joined-channel predicate. Default to "joined for

--- a/cicchetto/src/__tests__/activeWindows.test.ts
+++ b/cicchetto/src/__tests__/activeWindows.test.ts
@@ -46,15 +46,15 @@ const names = (list: ActiveWindow[]): string[] => list.map((w) => w.channelName)
 describe("orderUnreadWindows", () => {
   it("returns empty when there are no candidates", () => {
     expect(
-      orderUnreadWindows({ candidates: [], unread: {}, mentions: {}, activityId: {} }),
+      orderUnreadWindows({ candidates: [], unread: {}, mentions: {}, activityId: {}, muted: {} }),
     ).toEqual([]);
   });
 
   it("returns empty when no candidate has unread activity", () => {
     const c = [chan("#a"), query("bob")];
-    expect(orderUnreadWindows({ candidates: c, unread: {}, mentions: {}, activityId: {} })).toEqual(
-      [],
-    );
+    expect(
+      orderUnreadWindows({ candidates: c, unread: {}, mentions: {}, activityId: {}, muted: {} }),
+    ).toEqual([]);
   });
 
   it("includes only windows whose unread count is greater than zero", () => {
@@ -62,6 +62,7 @@ describe("orderUnreadWindows", () => {
     const b = chan("#b");
     const out = orderUnreadWindows({
       candidates: [a, b],
+      muted: {},
       unread: counts([
         [a, 0],
         [b, 3],
@@ -77,6 +78,7 @@ describe("orderUnreadWindows", () => {
     const bob = query("bob");
     const out = orderUnreadWindows({
       candidates: [a, bob],
+      muted: {},
       unread: counts([
         [a, 3],
         [bob, 1],
@@ -96,6 +98,7 @@ describe("orderUnreadWindows", () => {
     const plain = chan("#plain");
     const out = orderUnreadWindows({
       candidates: [ment, plain],
+      muted: {},
       unread: counts([
         [ment, 1],
         [plain, 5],
@@ -117,6 +120,7 @@ describe("orderUnreadWindows", () => {
     const out = orderUnreadWindows({
       // flat order c,a,b — but chronology must override it.
       candidates: [c, a, b],
+      muted: {},
       unread: counts([
         [a, 1],
         [b, 1],
@@ -137,6 +141,7 @@ describe("orderUnreadWindows", () => {
     const y = chan("#y");
     const out = orderUnreadWindows({
       candidates: [x, y],
+      muted: {},
       unread: counts([
         [x, 1],
         [y, 1],
@@ -153,6 +158,7 @@ describe("orderUnreadWindows", () => {
     const alice = query("alice");
     const out = orderUnreadWindows({
       candidates: [zoe, alice],
+      muted: {},
       unread: counts([
         [zoe, 1],
         [alice, 1],
@@ -171,12 +177,160 @@ describe("orderUnreadWindows", () => {
     const o = chan("#o");
     const out = orderUnreadWindows({
       candidates: [m, o],
+      muted: {},
       unread: counts([[o, 1]]),
       // #m carries a mention but nothing unread — no jump target.
       mentions: counts([[m, 2]]),
       activityId: {},
     });
     expect(names(out)).toEqual(["#o"]);
+  });
+});
+
+// #1018 — a conversation the operator MUTED (#866) is not a stop on the
+// cycle. The mute is keyed by the FOLDED conversation, per-subject and
+// network-agnostic (`MutedTargets`), and expiry was already resolved by
+// the reader (`notificationPrefs()`), so the ordering takes the live map
+// and asks a pure membership question — no clock, no second fold.
+//
+// Badges and counters are NOT touched (#866 Q4): this filters the
+// NAVIGATION order only.
+
+describe("orderUnreadWindows — muted conversations (#1018)", () => {
+  it("skips a muted channel and lands on the next unread window", () => {
+    const noisy = chan("#noisy");
+    const quiet = chan("#quiet");
+    const out = orderUnreadWindows({
+      candidates: [noisy, quiet],
+      muted: { "#noisy": { until: null } },
+      unread: counts([
+        [noisy, 9],
+        [quiet, 1],
+      ]),
+      mentions: {},
+      // the muted channel is the OLDER activity, so without the filter it
+      // would head the list.
+      activityId: counts([
+        [noisy, 100],
+        [quiet, 200],
+      ]),
+    });
+    expect(names(out)).toEqual(["#quiet"]);
+  });
+
+  it("keys a muted QUERY on the PEER, never on own nick", () => {
+    const bob = query("bob");
+    const carol = query("carol");
+    const out = orderUnreadWindows({
+      candidates: [bob, carol],
+      // "vjt" is the operator's own nick — an inbound DM row carries it in
+      // `channel`, and keying on that would collapse every DM onto ONE mute
+      // entry. Muting own nick must silence NOTHING here.
+      muted: { vjt: { until: null } },
+      unread: counts([
+        [bob, 1],
+        [carol, 1],
+      ]),
+      mentions: {},
+      activityId: counts([
+        [bob, 100],
+        [carol, 200],
+      ]),
+    });
+    expect(names(out)).toEqual(["bob", "carol"]);
+
+    const outMutedPeer = orderUnreadWindows({
+      candidates: [bob, carol],
+      muted: { bob: { until: null } },
+      unread: counts([
+        [bob, 1],
+        [carol, 1],
+      ]),
+      mentions: {},
+      activityId: counts([
+        [bob, 100],
+        [carol, 200],
+      ]),
+    });
+    expect(names(outMutedPeer)).toEqual(["carol"]);
+  });
+
+  it("folds the window name against the stored key (a mute is case-insensitive, A-Z only)", () => {
+    const shouty = chan("#NoIsY");
+    const bracket = chan("#chan{1}");
+    const out = orderUnreadWindows({
+      candidates: [shouty, bracket],
+      // `#chan[1]` is a DIFFERENT conversation from `#chan{1}` — the fold
+      // touches `A-Z` only (#525), so the bracket window is NOT muted.
+      muted: { "#noisy": { until: null }, "#chan[1]": { until: null } },
+      unread: counts([
+        [shouty, 1],
+        [bracket, 1],
+      ]),
+      mentions: {},
+      activityId: {},
+    });
+    expect(names(out)).toEqual(["#chan{1}"]);
+  });
+
+  it("keeps skipping a muted window that carries a MENTION (#866 Q2: the mute wins)", () => {
+    const muted = chan("#muted");
+    const plain = chan("#plain");
+    const out = orderUnreadWindows({
+      candidates: [muted, plain],
+      muted: { "#muted": { until: null } },
+      unread: counts([
+        [muted, 1],
+        [plain, 1],
+      ]),
+      mentions: counts([[muted, 3]]),
+      activityId: {},
+    });
+    expect(names(out)).toEqual(["#plain"]);
+  });
+
+  it("returns empty when EVERY unread window is muted — the cycle is a no-op", () => {
+    const a = chan("#a");
+    const bob = query("bob");
+    const out = orderUnreadWindows({
+      candidates: [a, bob],
+      muted: { "#a": { until: null }, bob: { until: null } },
+      unread: counts([
+        [a, 1],
+        [bob, 1],
+      ]),
+      mentions: {},
+      activityId: {},
+    });
+    expect(out).toEqual([]);
+  });
+
+  it("tolerates a server that sends no muted_targets at all (cic ships ahead of the BEAM)", () => {
+    const a = chan("#a");
+    const out = orderUnreadWindows({
+      candidates: [a],
+      muted: undefined,
+      unread: counts([[a, 1]]),
+      mentions: {},
+      activityId: {},
+    });
+    expect(names(out)).toEqual(["#a"]);
+  });
+
+  it("does not skip a window whose mute has ELAPSED — the reader already dropped it", () => {
+    // `notificationPrefs()` (withLiveMutes) resolves expiry before the map
+    // reaches here, so an elapsed snooze arrives as an ABSENT key. This
+    // pins that the ordering adds no second clock of its own: an entry that
+    // is still present silences, whatever its `until` says.
+    const a = chan("#a");
+    const out = orderUnreadWindows({
+      candidates: [a],
+      muted: {},
+      unread: counts([[a, 1]]),
+      mentions: {},
+      activityId: {},
+    });
+    expect(names(out)).toEqual(["#a"]);
   });
 });
 

--- a/cicchetto/src/lib/activeWindows.ts
+++ b/cicchetto/src/lib/activeWindows.ts
@@ -1,11 +1,14 @@
 import { createMemo, untrack } from "solid-js";
 import { type ChannelKey, channelKey } from "./channelKey";
+import { isConversationMuted, windowMuteKey } from "./conversationMute";
 import { mentionCounts } from "./mentions";
 import { moduleRoot } from "./moduleRoot";
 import { channelsBySlug, networks } from "./networks";
+import { notificationPrefs } from "./notificationPrefs";
 import { queryWindowsByNetwork } from "./queryWindows";
 import { scrollbackByChannel } from "./scrollback";
 import { messagesUnread, selectedChannel, setSelectedChannel } from "./selection";
+import type { MutedTargets } from "./userSettings";
 
 // GH #235 — "jump to next active window" (irssi Alt+A).
 //
@@ -69,6 +72,17 @@ export type OrderInput = {
    * no local rows yet) — correctly the "oldest" activity.
    */
   activityId: Record<ChannelKey, number>;
+  /**
+   * The subject's muted conversations (#866), as the READER hands them over
+   * — `notificationPrefs()` has already dropped elapsed snoozes, so an
+   * entry present here silences and no clock is consulted below. #1018: a
+   * muted window is not a stop on the cycle. `undefined` (a BEAM older than
+   * this bundle) means "no mutes".
+   *
+   * Required, not optional: a door that forgets the mute is a compile error
+   * rather than a window that silently keeps stealing the jump.
+   */
+  muted: MutedTargets | undefined;
 };
 
 // Tier-0 predicate: a window is "priority" when it is a query (DM) OR
@@ -81,7 +95,8 @@ export function isPriorityWindow(w: ActiveWindow, mentions: Record<ChannelKey, n
   return w.kind === "query" || (mentions[key] ?? 0) > 0;
 }
 
-// Pure ordering. Filter to windows with unread activity, then sort:
+// Pure ordering. Filter to windows with unread activity that the operator
+// has not muted, then sort:
 //   1. tier — mention/highlight OR query (DM) come first (0), ordinary
 //      channel traffic second (1);
 //   2. activity time ascending — chronological, oldest activity first
@@ -89,7 +104,7 @@ export function isPriorityWindow(w: ActiveWindow, mentions: Record<ChannelKey, n
 //   3. flat (sidebar) index — stable tie-break for equal activity ids
 //      (e.g. two seed-only windows).
 export function orderUnreadWindows(input: OrderInput): ActiveWindow[] {
-  const { candidates, unread, mentions, activityId } = input;
+  const { candidates, unread, mentions, activityId, muted } = input;
   const ranked = candidates
     .map((w, flatIndex) => {
       const key = channelKey(w.networkSlug, w.channelName);
@@ -98,10 +113,16 @@ export function orderUnreadWindows(input: OrderInput): ActiveWindow[] {
         unread: unread[key] ?? 0,
         tier: isPriorityWindow(w, mentions) ? 0 : 1,
         activityId: activityId[key] ?? 0,
+        muted: isConversationMuted(muted, windowMuteKey(w)),
         flatIndex,
       };
     })
-    .filter((r) => r.unread > 0);
+    // #1018 — the mute drops the window from the CYCLE, and it beats the
+    // tier: a mention inside a muted room is still not a stop (#866 Q2,
+    // "the mute always wins"). Everything else about the window is
+    // untouched — its sidebar unread badge and the mention counters keep
+    // rendering exactly as before (#866 Q4).
+    .filter((r) => r.unread > 0 && !r.muted);
 
   ranked.sort((a, b) => {
     if (a.tier !== b.tier) return a.tier - b.tier;
@@ -178,6 +199,10 @@ const root = moduleRoot(() => {
       unread: messagesUnread(),
       mentions: mentionCounts(),
       activityId: buildActivityIds(),
+      // #1018 — read through `notificationPrefs()`, never the stored signal:
+      // that reader resolves an elapsed snooze, so a mute that ran out puts
+      // its window back on the cycle with no clock handling here.
+      muted: notificationPrefs().muted_targets,
     }),
   );
   return { activeWindows };

--- a/cicchetto/src/lib/conversationMute.ts
+++ b/cicchetto/src/lib/conversationMute.ts
@@ -1,0 +1,64 @@
+// #866 / #1018 — the per-conversation mute LOOKUP: how a conversation is
+// keyed into `NotificationPrefs.muted_targets`, and how membership is asked.
+//
+// Extracted here (from `pushTriggers.ts`, its first and until #1018 only
+// consumer) because three call sites now need the identical answer and a
+// second hand-rolled derivation is exactly how the DM case rots:
+//
+//   * `pushTriggers.shouldNotify`  — should this arriving row notify?
+//   * `activeWindows.orderUnreadWindows` — is this window a stop on the
+//     Alt+A / Ctrl+N-P / affordance cycle? (#1018)
+//   * `SettingsDrawer.muteCandidates` — which conversations does the picker
+//     offer, and which are already muted?
+//
+// Expiry is deliberately absent: the READER resolves it
+// (`notificationPrefs()` → `withLiveMutes` client-side,
+// `UserSettings.get_notification_prefs/1` server-side), so nothing here
+// needs a `now` and the push truth-table needs no clock column (#866 Q3).
+
+import { canonicalChannel } from "./channelKey";
+import type { MutedTargets } from "./userSettings";
+
+/**
+ * The key under which a conversation is muted: the FOLDED identifier of the
+ * thing an operator points at when they say "silence this tab" — the channel
+ * for a channel, the PEER for a DM.
+ *
+ * Never the `channel` field of a DM row: an inbound DM carries
+ * `channel = own_nick`, so keying on it collapses every DM onto ONE entry and
+ * muting one peer silences them all. Callers pass the peer explicitly.
+ *
+ * `canonicalChannel` (the mirror of `Identifier.canonical_target/1`) folds a
+ * nick exactly as it folds a channel — a sigil sits outside `A-Z` — which is
+ * why one fold serves both shapes. Per-subject and network-agnostic by
+ * design: `#grappa` on two networks is ONE mute (#866 Q5).
+ */
+export function conversationMuteKey(target: string): string {
+  return canonicalChannel(target);
+}
+
+/**
+ * The mute key of a sidebar WINDOW (#1018). For a query window `channelName`
+ * IS the peer nick — `activeWindows.windowCandidates` builds it from
+ * `qw.targetNick` — which is exactly the identifier the DM notify path folds,
+ * so ONE expression serves both kinds without ever touching a row's `channel`
+ * field. Structurally typed rather than importing `ActiveWindow`, to keep the
+ * mute lookup free of a dependency on the window projection.
+ */
+export function windowMuteKey(window: { channelName: string }): string {
+  return conversationMuteKey(window.channelName);
+}
+
+/**
+ * Is `key` (already folded via `conversationMuteKey`) muted?
+ *
+ * `Object.hasOwn`, not `muted[key] !== undefined`: the map arrives from
+ * `JSON.parse`, so it carries Object.prototype and a peer legitimately nicked
+ * `constructor` or `toString` would otherwise read as muted.
+ *
+ * `undefined` (a BEAM older than this bundle, #618) means "no mutes", never
+ * "everything muted" — the tolerant direction.
+ */
+export function isConversationMuted(muted: MutedTargets | undefined, key: string): boolean {
+  return muted !== undefined && Object.hasOwn(muted, key);
+}

--- a/cicchetto/src/lib/pushTriggers.ts
+++ b/cicchetto/src/lib/pushTriggers.ts
@@ -24,6 +24,7 @@
 
 import { type MessageKind, NOTIFY_KINDS } from "./api";
 import { canonicalChannel } from "./channelKey";
+import { conversationMuteKey, isConversationMuted } from "./conversationMute";
 import { matchesWatchlist } from "./mentionMatch";
 import { asciiFold, nickEquals } from "./nickEquals";
 import type { NotificationPrefs } from "./userSettings";
@@ -92,7 +93,7 @@ export function shouldNotify(
   // including a direct mention (vjt's Q2: the mute always wins, because the
   // polite default for "I silenced this room" is that it stays silent).
   // That is why it sits here and not inside the two branches.
-  if (isMuted(prefs, conversationKey(message, isDm))) return false;
+  if (isConversationMuted(prefs.muted_targets, conversationKey(message, isDm))) return false;
 
   if (isDm) {
     return dmMatch(message, prefs);
@@ -100,29 +101,18 @@ export function shouldNotify(
   return channelMatch(message, prefs, ownNick, patterns);
 }
 
-// The identity of the CONVERSATION the row belongs to — the thing an
-// operator points at when they say "mute this tab". For a channel that is
-// the channel; for a DM it is the PEER, never `message.channel`, which an
-// inbound DM sets to own_nick (so keying on it would collapse every DM
-// onto one mute). Same fold as the two whitelists: `canonicalChannel` is
-// the mirror of `Identifier.canonical_target/1` and folds a nick exactly
-// as it folds a channel.
-function conversationKey(message: ShouldNotifyMessage, isDm: boolean): string {
-  return canonicalChannel(isDm ? message.sender : message.channel);
-}
-
-// `until` is deliberately NOT read here. Expiry belongs to the READER
-// (`notificationPrefs()` client-side, `get_notification_prefs/1` on the
-// server) so this predicate stays pure and the shared truth-table needs no
-// `now` column — vjt's Q3. A stored-but-elapsed mute reaching this point
-// still silences; that only happens to a caller that bypassed the reader.
+// Which CONVERSATION this row belongs to, in mute terms: the channel for a
+// channel row, the PEER for a DM — never `message.channel`, which an inbound
+// DM sets to own_nick (so keying on it would collapse every DM onto one
+// mute). The fold itself, and the membership test above, live in
+// `conversationMute.ts` — shared with the #1018 next-active cycle and the
+// settings picker so the three can never disagree on a key.
 //
-// `Object.hasOwn`, not `muted[key] !== undefined`: the map arrives from
-// `JSON.parse`, so it carries Object.prototype and a peer legitimately
-// nicked `constructor` or `toString` would otherwise read as muted.
-function isMuted(prefs: NotificationPrefs, key: string): boolean {
-  const muted = prefs.muted_targets;
-  return muted !== undefined && Object.hasOwn(muted, key);
+// `until` is deliberately not read on this path: expiry belongs to the
+// READER, which is what keeps this predicate pure `/4` and the shared
+// truth-table free of a `now` column (#866 Q3).
+function conversationKey(message: ShouldNotifyMessage, isDm: boolean): string {
+  return conversationMuteKey(isDm ? message.sender : message.channel);
 }
 
 function dmMatch(message: ShouldNotifyMessage, prefs: NotificationPrefs): boolean {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -33326,3 +33326,43 @@ so the surfaced error is unforgeable proof the target survived cic's parser, the
 channel door and `Client.send_admin/2`. 423 and 447 stay unit-tested — the first
 needs a leaf with no `A:` line, the second a restricted-class user, and neither
 is reachable without reshaping the shared testnet for one spec.
+## 2026-08-07 — #1018: the mute reaches the next-active ordering, and the key gets ONE home
+
+vjt, on IRC: *"una finestra in mute dovrebbe essere esclusa dal giro che fa il
+bottone alt+a"*. #866 stored the per-conversation mute; #235 owns the
+next-active ordering. Nothing joined them, so a busy muted channel kept
+stealing the jump the operator uses to reach the windows they actually read.
+
+**Where the filter went, and why not somewhere cheaper.** `activeWindows.ts` is
+already the ONE ordering behind all three doors (Alt+A, Ctrl+N/P, the on-screen
+affordance), so the change is a single new input on `orderUnreadWindows` and all
+three inherit it — no forked ordering, which is exactly what #235 unified away.
+The input is REQUIRED, not optional: a future door that forgets the mute is a
+compile error rather than a window that silently keeps stealing the jump. The
+alternative — filtering the candidate list at the memo — was rejected for the
+opposite reason: it would have been a filter a caller can quietly omit.
+
+**The key is the trap, so the derivation now has one home.** The mute is keyed
+by the FOLDED conversation: the channel for a channel, the PEER for a DM. Get
+the DM case wrong and every DM collapses onto one entry, silencing an arbitrary
+peer. That derivation existed in `pushTriggers.ts` (private) and, open-coded, in
+the settings picker; #1018 would have made three. `lib/conversationMute.ts` now
+owns all of it — `conversationMuteKey` (the fold), `windowMuteKey` (the window
+shape, structurally typed so the mute lookup does not depend on the window
+projection), `isConversationMuted` (the `Object.hasOwn` membership test, which
+is what keeps a peer nicked `constructor` from reading as muted). The three
+consumers ask the same question of the same function.
+
+**No clock.** Expiry stays where #866 Q3 put it — in the READER. The memo passes
+`notificationPrefs().muted_targets`, which has already dropped elapsed snoozes,
+so an expired mute puts its window back on the cycle with no `now` anywhere in
+the ordering.
+
+**Scope, deliberately narrow.** #866 Q4 ruled that a muted target still COUNTS;
+this extends the mute into navigation only. A muted window keeps its sidebar
+unread badge and its mention counters — the e2e asserts the badge is still there
+after the cycle has skipped past it. Consequence accepted, not a scope leak: the
+affordance's own count and auto-hide DO drop the muted window, because they read
+the same ordered list. A button that says "2" and cycles through 1 would be the
+lie. And when every unread window is muted the cycle is a no-op (Q2), which the
+empty list gives for free.


### PR DESCRIPTION
Issue #1018. A conversation the operator muted (#866) was invisible to the
#235 next-active ordering, so a busy muted channel kept stealing the Alt+A
jump.

## What changed

- **`activeWindows.orderUnreadWindows` takes the mute as a required input.**
  It is the ONE ordering behind all three doors (Alt+A, Ctrl+N/P, the
  affordance button), so all three inherit the skip without forking the
  ordering #235 unified. Required rather than optional on purpose: a future
  door that forgets the mute is a compile error, not a window that silently
  keeps stealing the jump.
- **`lib/conversationMute.ts` — one home for the mute key.** The DM case is
  the trap: the key is the FOLDED conversation (the channel for a channel,
  the PEER for a DM), and getting it wrong collapses every DM onto one entry.
  That derivation was private in `pushTriggers` and open-coded in the
  settings picker; this issue would have made three. Now `pushTriggers`,
  `activeWindows` and `SettingsDrawer` ask the same functions
  (`conversationMuteKey` / `windowMuteKey` / `isConversationMuted`).
- **No clock.** Expiry stays in the reader (#866 Q3): the memo passes
  `notificationPrefs().muted_targets`, already stripped of elapsed snoozes.

## Rulings taken (the issue's open questions)

1. **All three doors** — they are one verb; splitting them would fork #235.
2. **Every unread window muted → the cycle is a no-op**, falls out of the
   empty list.
3. **A mention inside a muted window is still skipped** — same as #866 Q2,
   the mute wins.

## Scope guard (#866 Q4)

Badges and mention counters are untouched; the muted window keeps its sidebar
unread badge (asserted in the e2e). The affordance's own count *does* drop the
muted window, because it reads the same ordered list — a button reading \"2\"
that cycles through 1 would be the lie.

## Gates

- \`scripts/bun.sh run test\` — **246 files / 4607 tests, exit 0.** Red first:
  the five new mute cases failed against the parent commit before the filter
  existed.
- \`scripts/bun.sh run check\` (biome + tsc) — exit 0, working tree unchanged
  before/after.
- **e2e NOT run** — \`issue1018-mute-skips-next-active.spec.ts\` is written but
  needs the integration stack, i.e. a lane I have not been allocated. It
  mutes through the SettingsDrawer picker (so the key the picker writes and
  the key the cycle reads are proven identical), then asserts Alt+A lands on
  the unmuted room, the affordance hides while the muted room is still
  unread, and the muted room's badge survives.

Two test-side edits ride along: `activeWindows.test.ts` passes the new input
everywhere, and `Shell.test.tsx`'s `channelKey` mock now keeps the REAL
`canonicalChannel` via `importActual` (the mute fold reaches it through
`activeWindows`; a hand-rolled stand-in would be the suite re-implementing
production's fold).