### PR TITLE
infra(#1020): build the cic bundle beside the served dist, then swap

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -183,7 +183,17 @@ services:
     volumes:
       - ./cicchetto:/app
       - ./runtime/bun-cache:/cache
-      - ./runtime/cicchetto-dist:/app/dist
+      # #1020 — vite empties `dist/` before it writes, and `./runtime/
+      # cicchetto-dist` is the dir the BEAM serves PER REQUEST, so pointing
+      # this mount at it made every deploy serve an empty SPA for the whole
+      # build. The deploy wrappers (scripts/deploy.sh, scripts/deploy-cic.sh,
+      # infra/docker/deploy.sh) set CIC_BUILD_OUT to a staging sibling and
+      # rename it into place afterwards — one env var rather than a second
+      # service, so there is still ONE build definition.
+      # The DEFAULT stays the served dir on purpose: it is what a bare
+      # `compose --profile prod up` uses via grappa's depends_on, and there
+      # nothing is serving yet — no live server, no window to protect.
+      - ${CIC_BUILD_OUT:-./runtime/cicchetto-dist}:/app/dist
     tmpfs:
       # UID/GID must track the `user:` field above — bun writes to
       # HOME=/tmp, so a hardcoded uid=1000 tmpfs while the process runs

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -33326,3 +33326,63 @@ so the surfaced error is unforgeable proof the target survived cic's parser, the
 channel door and `Client.send_admin/2`. 423 and 447 stay unit-tested — the first
 needs a leaf with no `A:` line, the second a restricted-class user, and neither
 is reachable without reshaping the shared testnet for one spec.
+
+## 2026-08-07 — #1020: the cic build emptied the dist it was serving, so the build moved next door
+
+`--emptyOutDir` was never the defect. Vite refuses to clean an out-of-root
+`outDir` without explicit consent, and `outDir` is out of root by design (root
+is `cicchetto/`, the bundle lands in `runtime/cicchetto-dist` so Docker and the
+jail share one server-side anchor). The cleanup is *wanted*: vite emits
+content-hashed chunks, and without it every deploy accretes the previous
+bundle's assets forever and the dist stops being a truthful picture of what is
+served. **The timing was the defect.** Vite empties `outDir` BEFORE it writes,
+and `Grappa.Cic.Bundle.root/0` resolves that same directory PER REQUEST
+(`Plug.Static` + the SPA history-fallback), so every deploy blanked the SPA for
+the whole build — and a build that FAILED left it blanked, because `set -eu`
+walked away from an already-emptied tree.
+
+The fix is the shape `infra/packaging/build.sh` already had: build into a
+sibling nobody is serving, then rename it in. One implementation,
+`infra/lib/cic_dist.sh`, sourced by all three serving substrates — the jail's
+POSIX `/bin/sh` body, the native-Linux bash script, and the three compose
+launchers. `infra/packaging/build.sh` needs no change; it is the shape being
+generalised.
+
+**The swap has a window, and it is ENOENT rather than empty.** There is no
+portable two-directory exchange (`RENAME_EXCHANGE` is Linux-only and out of
+reach from `sh`), so the promote is two renames with the served path absent
+between them — two syscalls against the whole vite build it replaces. A client
+gets the old bundle or the new one, never a mix. Die mid-swap and both complete
+trees survive as `.prev` and `.next`; only a crash inside the microsecond gap
+leaves the served path missing, and re-running the build fixes it. A symlink
+flip WOULD have been atomic and was rejected for a concrete reason: the served
+path is TRACKED (`runtime/cicchetto-dist/.gitkeep`), and turning a tracked
+directory into a symlink is a type change git reports as dirt — the same class
+of dirty tree that once stalled a deploy's `git pull --ff-only` on a deleted
+`.gitkeep`.
+
+That `.gitkeep` moved from a repair to a property. Three scripts used to
+`touch` it back after the build because `emptyOutDir` ate it; the promote now
+plants it in the staged tree BEFORE the rename, so the tracked path is never
+absent at all rather than being restored shortly after it goes missing.
+
+**The Docker seam is a defaulted variable, on purpose.** The compose oneshot
+writes to whatever is bind-mounted at `/app/dist`, so the mount source became
+`${CIC_BUILD_OUT:-./runtime/cicchetto-dist}`. The deploy wrappers set it to the
+staging sibling and promote afterwards; the DEFAULT stays the served dir
+because a bare `compose --profile prod up` reaches the build through grappa's
+`depends_on` with nobody to promote — and there nothing is serving yet, so
+there is no window to protect. A second compose service would have been the
+alternative and was rejected: two build definitions is exactly the drift
+`cic_version_export_test.bats` exists to police.
+
+**What was proved and what was not.** The jail and native-Linux scripts are
+RUN in bats against a fake vite that empties its `outDir` first and records
+what the served directory holds at that instant — the assertion is on the
+timing, not on any string, and it reads MISSING on the parent commit. The
+Docker substrate has structure only (the compose mount pin, plus a scan that
+every launcher aims the build at `CIC_BUILD_OUT` and promotes): the build
+happens inside a container, so no bats can observe it. Nobody watched a real
+jail serve an empty dist during a build either — the window is read out of
+`--emptyOutDir` plus serve-at-request-time, and it is stated as such rather
+than dressed up as an incident.

--- a/infra/docker/deploy.sh
+++ b/infra/docker/deploy.sh
@@ -704,13 +704,19 @@ cmd_update() {
 	}
 
 	substrate_cic() {
-		mkdir -p runtime/cicchetto-dist
+		# #1020 — build into a staging sibling and rename it in. The BEAM
+		# serves runtime/cicchetto-dist per request and vite empties its
+		# outDir first, so building in place blanked the SPA for the whole
+		# build — on a box that is UPDATING, i.e. one that is already live.
+		local cic_served="runtime/cicchetto-dist"
+		local cic_build_out
+		cic_build_out="$(cic_dist_docker_stage "$cic_served")"
 		# AFTER substrate_pull, so the bundle carries the version the box is
 		# moving TO, not the one it is on (the pull may have bumped VERSION).
 		export_cic_version
 		say "Rebuilding the cicchetto bundle"
-		"${COMPOSE[@]}" --profile prod run --rm cicchetto-build
-		touch runtime/cicchetto-dist/.gitkeep
+		CIC_BUILD_OUT="$cic_build_out" "${COMPOSE[@]}" --profile prod run --rm cicchetto-build
+		cic_dist_promote "$cic_served" "$cic_build_out"
 	}
 
 	substrate_migrate() {
@@ -745,6 +751,12 @@ EOF
 
 	# shellcheck source=infra/lib/deploy_common.sh
 	. "$REPO_ROOT/infra/lib/deploy_common.sh"
+	# #1020 build-beside-then-swap, used by substrate_cic above. Sourced HERE
+	# and not at the top of the file: only source mode builds a bundle (the
+	# release path ships a prebuilt image), so the get.sh mirror — which
+	# reproduces exactly what a checkout-less host sources — needs no new file.
+	# shellcheck source=infra/lib/cic_dist.sh
+	. "$REPO_ROOT/infra/lib/cic_dist.sh"
 	# Empty-array-safe expansion for bash 3.2 under `set -u`.
 	deploy_main ${libargs[@]+"${libargs[@]}"}
 }

--- a/infra/freebsd/jail_cic_build.sh
+++ b/infra/freebsd/jail_cic_build.sh
@@ -11,11 +11,18 @@
 # /usr/local/www/cic symlink, and no nginx in the jail at all: the m42
 # HOST vhost proxies straight to the BEAM.
 #
-# `--outDir ../runtime/cicchetto-dist` aligns the jail with the Docker
-# substrate (`compose.yaml` bind-mounts `./runtime/cicchetto-dist:
-# /app/dist` so the same final path holds the bundle on host). The
-# shared path is what `Grappa.Cic.Bundle.@bundle_path` reads
-# unconditionally — both substrates, one server-side anchor.
+# `runtime/cicchetto-dist` aligns the jail with the Docker substrate
+# (`compose.yaml` bind-mounts it into the build oneshot so the same final
+# path holds the bundle on host). The shared path is what
+# `Grappa.Cic.Bundle.@bundle_path` reads unconditionally — both
+# substrates, one server-side anchor.
+#
+# #1020: vite does NOT write there directly. The BEAM serves that
+# directory per REQUEST, and `--emptyOutDir` wiped it at the START of the
+# build, so the SPA was unloadable for the whole build and stayed broken
+# if the build failed. The build now targets a staging sibling and
+# infra/lib/cic_dist.sh renames it into place — see that file for the
+# swap's failure window.
 
 set -eu
 
@@ -24,7 +31,11 @@ set -eu
 exec su -l grappa -c '
 set -eu
 cd /home/grappa/grappa/cicchetto
-mkdir -p ../runtime/cicchetto-dist
+# #1020 — build-beside-then-swap. Sourced (not executed) so the promote
+# runs in THIS shell, as grappa, with the same relative cwd the build uses.
+. ../infra/lib/cic_dist.sh
+served=../runtime/cicchetto-dist
+staged="$(cic_dist_staging "$served")"
 # #538/#652 — vite bakes GRAPPA_VERSION into <meta cicchetto-version>. Derive it
 # from the repo-root VERSION file via the POSIX version.sh (this jail runs
 # /bin/sh + npm, no bash/bun port). Single source of truth; same env channel every cic build
@@ -48,8 +59,9 @@ else
 	npm install >"$log" 2>&1 || { tail -20 "$log"; exit 1; }
 fi
 tail -3 "$log"
-npm run build -- --outDir ../runtime/cicchetto-dist --emptyOutDir >"$log" 2>&1 || { tail -30 "$log"; exit 1; }
+npm run build -- --outDir "$staged" --emptyOutDir >"$log" 2>&1 || { tail -30 "$log"; exit 1; }
 tail -8 "$log"
+cic_dist_promote "$served" "$staged"
 echo "--- runtime/cicchetto-dist contents ---"
-ls -la ../runtime/cicchetto-dist/
+ls -la "$served"/
 '

--- a/infra/lib/cic_dist.sh
+++ b/infra/lib/cic_dist.sh
@@ -1,0 +1,122 @@
+# shellcheck shell=sh
+# infra/lib/cic_dist.sh — build BESIDE the served cic bundle, then swap (#1020).
+#
+# Every substrate used to point vite's `outDir` straight at the directory the
+# running BEAM serves (`Grappa.Cic.Bundle.root/0` → Plug.Static + the SPA
+# history-fallback, resolved per REQUEST). Vite empties `outDir` before it
+# writes anything, so the served tree went EMPTY at the start of the build and
+# stayed incomplete until it finished: for that whole window the SPA did not
+# load at all, and a build that FAILED left it empty for good.
+#
+# `--emptyOutDir` is not the defect — the cleanup is wanted (vite emits
+# content-hashed chunks; without it every deploy accretes the previous bundle's
+# assets forever) and the flag is only vite's consent prompt for an out-of-root
+# `outDir`. The TIMING is the defect. So: build into a sibling nobody serves,
+# then rename it into place.
+#
+# This file is SOURCED, never executed — POSIX sh, no `local`, no bashisms, so
+# the FreeBSD jail's /bin/sh build body can source it as-is (same contract as
+# beam_wait.sh / deploy_common.sh).
+#
+# Consumers (one algorithm, no per-substrate copy):
+#   - infra/freebsd/jail_cic_build.sh   npm + vite, inside `su -l grappa`
+#   - infra/linux/cic_build.sh          bun + vite, via `sudo -u grappa`
+#   - scripts/deploy.sh                 the compose oneshot (dev/operator)
+#   - scripts/deploy-cic.sh             the compose oneshot, cic-only deploy
+#   - infra/docker/deploy.sh            the compose oneshot, standalone install
+#
+# infra/packaging/build.sh is NOT a consumer: it already builds into a staging
+# tree under `staging/usr/share/grappa/` that no server is serving. It is the
+# shape this lib generalises.
+#
+# ## The swap, and its failure window
+#
+# `mv` is rename(2) — atomic per call, but there is no portable two-directory
+# EXCHANGE (Linux's RENAME_EXCHANGE is not reachable from sh, and FreeBSD has
+# no equivalent), so the promote is two renames:
+#
+#     mv <served> <served>.prev     # served path momentarily ABSENT
+#     mv <staged> <served>
+#
+# Between them the served path does not EXIST — Plug.Static's `from:` misses
+# and requests fall through to the SPA history-fallback / 404. That window is
+# two syscalls wide against the whole vite build it replaces, and it is
+# ENOENT rather than a half-written tree, so a client either gets the old
+# bundle or the new one, never a mix of both.
+#
+# Die mid-swap and nothing is lost: `<served>.prev` holds the complete previous
+# bundle and `<served>.next` the complete new one; whichever rename landed, the
+# next run starts by clearing `.prev` and re-staging `.next`. Only a crash in
+# the ~microsecond gap leaves the served path missing, and the fix is to re-run
+# the build.
+#
+# Both paths are siblings inside `runtime/` on purpose: rename(2) cannot cross
+# filesystems, and a cross-device `mv` degrades to copy-then-delete, which is
+# neither atomic nor fast. A consumer that stages somewhere else loses that.
+
+# Echo the staging path for a served bundle directory. ONE derivation, because
+# every consumer needs the name twice — once to aim the builder at it, once to
+# promote it — and two spellings of it is a silent no-op deploy.
+cic_dist_staging() {
+	if [ -z "${1:-}" ]; then
+		echo "cic_dist_staging: refusing to derive a staging path from an empty served path" >&2
+		return 1
+	fi
+	printf '%s.next\n' "$1"
+}
+
+# Prepare the staging dir the compose oneshot bind-mounts, and echo it in the
+# `./`-prefixed shape compose needs (a source with no `./` or `/` is parsed as
+# a NAMED VOLUME, not a host path). The dir must pre-exist or Docker creates it
+# root-owned and the UID-1000 container cannot write vite's output into it.
+cic_dist_docker_stage() {
+	_cic_staged="$(cic_dist_staging "$1")" || return 1
+	rm -rf "${_cic_staged}"
+	mkdir -p "${_cic_staged}"
+	printf './%s\n' "${_cic_staged}"
+}
+
+# Swap a freshly built bundle into the served path. Leaves the served tree
+# UNTOUCHED on any refusal — callers run under `set -e`, so an aborted build
+# never reaches here and the previous bundle keeps serving.
+cic_dist_promote() {
+	_cic_served="${1:-}"
+	_cic_staged="${2:-}"
+	if [ -z "${_cic_served}" ] || [ -z "${_cic_staged}" ]; then
+		echo "cic_dist_promote: served and staged paths are both required" >&2
+		return 1
+	fi
+
+	# A vite build can exit 0 having written nothing reachable (wrong outDir,
+	# a plugin that swallowed its own failure). Promoting that would swap an
+	# EMPTY tree into the served path — the exact outage this lib exists to
+	# stop, just moved later. index.html is the one file the server must find:
+	# Bundle.current_hash/0 parses it and the history-fallback serves it.
+	if [ ! -f "${_cic_staged}/index.html" ]; then
+		echo "cic_dist_promote: ${_cic_staged}/index.html is missing — refusing to promote a tree that is not a bundle; the previous one keeps serving" >&2
+		return 1
+	fi
+
+	# `runtime/cicchetto-dist/.gitkeep` is TRACKED (it bakes the bind-mount
+	# target so a fresh clone does not get it auto-created root-owned — see
+	# .gitignore). It belongs to the tree that LANDS, planted BEFORE the swap
+	# rather than restored after it: a post-hoc `touch` is a repair with its
+	# own window, and the tracked path missing for even an instant is what
+	# left a `D .gitkeep` stalling `git pull --ff-only` on a deploy once.
+	touch "${_cic_staged}/.gitkeep"
+
+	_cic_prev="${_cic_served}.prev"
+	rm -rf "${_cic_prev}"
+	# `mv a b` where b is an EXISTING DIRECTORY moves a INSIDE b. The served
+	# path must therefore be gone — not emptied, GONE — before the second
+	# rename, or the new bundle lands at <served>/<staged-basename>/ and the
+	# server keeps serving the old one with no error anywhere.
+	if [ -d "${_cic_served}" ]; then
+		mv "${_cic_served}" "${_cic_prev}"
+	fi
+	mv "${_cic_staged}" "${_cic_served}"
+	# Only now is the previous bundle disposable. Dropping it is what keeps
+	# `--emptyOutDir`'s stale-chunk cleanup: the old content-hashed assets go
+	# with the old directory instead of accreting in the served one.
+	rm -rf "${_cic_prev}"
+}

--- a/infra/linux/cic_build.sh
+++ b/infra/linux/cic_build.sh
@@ -19,6 +19,17 @@ CIC_DIR="${REPO_ROOT}/cicchetto"
 OUT_DIR="${REPO_ROOT}/runtime/cicchetto-dist"
 GRAPPA_USER="${GRAPPA_USER:-grappa}"
 
+# #1020 — OUT_DIR is what the running BEAM serves, per request. Vite must not
+# write into it: it builds into a staging sibling and the shared lib renames
+# that into place afterwards. Sourced from the SCRIPT's own dir, not from
+# REPO_ROOT — the lib ships with this script, and the arg only names the
+# checkout the bundle is built FROM.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CIC_DIST_LIB="${SCRIPT_DIR}/../lib/cic_dist.sh"
+# shellcheck source=infra/lib/cic_dist.sh
+. "${CIC_DIST_LIB}"
+STAGE_DIR="$(cic_dist_staging "${OUT_DIR}")"
+
 # #538/#652 — vite bakes GRAPPA_VERSION into <meta cicchetto-version>. Derive it
 # from the repo-root VERSION file (the single source of truth) via version.sh; `sudo -u`
 # scrubs the env, so it is injected into the run_as_grappa command string below.
@@ -33,19 +44,22 @@ run_as_grappa() {
 	sudo -u "${GRAPPA_USER}" -H bash -c "export PATH=\"\$HOME/.local/bin:\$HOME/.asdf/shims:\$PATH\"; $1"
 }
 
-echo "[cic_build] bun install && bun run build (outDir=${OUT_DIR})"
+echo "[cic_build] bun install && bun run build (outDir=${STAGE_DIR} → ${OUT_DIR})"
 # Buffer output and only show it on failure — a clean build is noisy
 # (vite + tsc output) and the interesting signal is the exit code;
 # same pipefail-avoidance lesson as jail_cic_build.sh's header.
 log="$(mktemp)"
 trap 'rm -f "${log}"' EXIT
-if ! run_as_grappa "export GRAPPA_VERSION='${GRAPPA_VERSION}'; cd '${CIC_DIR}' && bun install && bun run build -- --outDir '${OUT_DIR}' --emptyOutDir" >"${log}" 2>&1; then
+if ! run_as_grappa "export GRAPPA_VERSION='${GRAPPA_VERSION}'; cd '${CIC_DIR}' && bun install && bun run build -- --outDir '${STAGE_DIR}' --emptyOutDir" >"${log}" 2>&1; then
 	echo "[cic_build] ERROR: build failed — output:" >&2
 	cat "${log}" >&2
 	exit 1
 fi
-# Vite's `emptyOutDir` wipes .gitkeep on every build. Restore the
-# tracked placeholder so a cold deploy leaves the worktree clean.
-run_as_grappa "touch '${OUT_DIR}/.gitkeep'"
+# Swap as grappa, like every other step here: the renames need write on
+# runtime/, and doing them as root would plant a root-owned .gitkeep inside a
+# grappa-owned tree. The tracked placeholder is planted by the promote itself
+# now, so the post-build `touch` this replaces is gone — it only ever existed
+# to undo the in-place wipe.
+run_as_grappa ". '${CIC_DIST_LIB}'; cic_dist_promote '${OUT_DIR}' '${STAGE_DIR}'"
 
 echo "[cic_build] done — ${OUT_DIR}"

--- a/scripts/deploy-cic.sh
+++ b/scripts/deploy-cic.sh
@@ -29,6 +29,8 @@ set -euo pipefail
 
 # shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
+# shellcheck source=infra/lib/cic_dist.sh
+. "$(dirname "$0")/../infra/lib/cic_dist.sh"
 
 # #364 docker S10: assert main-checkout + main-branch BEFORE the dist
 # rebuild swaps the on-disk bundle nginx serves. Pre-fix this script had
@@ -39,7 +41,11 @@ require_main_checkout "deploy-cic.sh"
 
 cd "$REPO_ROOT"
 
-mkdir -p runtime/cicchetto-dist
+# #1020 — build into a staging sibling, NOT into the dir the live BEAM is
+# serving. CIC_BUILD_OUT is scoped to the build command so the rest of this
+# script (and any later compose call) sees the normal mount.
+CIC_SERVED="runtime/cicchetto-dist"
+CIC_BUILD_OUT="$(cic_dist_docker_stage "$CIC_SERVED")"
 
 # #538 — derive the single-source version for the cic build. The
 # cicchetto-build container mounts only ./cicchetto, so it can't read the repo
@@ -47,11 +53,10 @@ mkdir -p runtime/cicchetto-dist
 GRAPPA_VERSION="$("$REPO_ROOT/infra/packaging/version.sh")"
 export GRAPPA_VERSION
 echo "Building cicchetto dist..."
-docker compose "${COMPOSE_ARGS[@]}" --profile prod run --rm cicchetto-build
-# Vite's `emptyOutDir` wipes .gitkeep on every build (the tracked
-# placeholder is bait for fresh-clone Docker auto-mkdir-as-root —
-# see .gitignore L44-46). Restore it so `git status` stays clean.
-touch runtime/cicchetto-dist/.gitkeep
+CIC_BUILD_OUT="$CIC_BUILD_OUT" docker compose "${COMPOSE_ARGS[@]}" --profile prod run --rm cicchetto-build
+# Swap the finished bundle in. The tracked .gitkeep is planted by the promote,
+# so the post-build `touch` that used to undo vite's wipe is gone.
+cic_dist_promote "$CIC_SERVED" "$CIC_BUILD_OUT"
 
 echo "Notifying grappa of new bundle hash..."
 # Container `curl` against loopback inside the grappa pod —

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -32,6 +32,8 @@ set -euo pipefail
 
 # shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
+# shellcheck source=infra/lib/cic_dist.sh
+. "$(dirname "$0")/../infra/lib/cic_dist.sh"
 
 # #364 docker S10: assert main-checkout + main-branch BEFORE any side
 # effect (the git pull below mutates REPO_ROOT). in_container's own
@@ -134,17 +136,24 @@ substrate_cic() {
 	# Refresh cicchetto SPA dist into ./runtime/cicchetto-dist. Host
 	# bind-mount (not a named volume) so the container UID can write into a
 	# dir that already exists with the right ownership.
-	mkdir -p runtime/cicchetto-dist
+	#
+	# #1020 — the build lands in a staging sibling and is RENAMED into the
+	# served dir on success: vite empties its outDir first, and the BEAM
+	# serves runtime/cicchetto-dist per request, so building in place served
+	# an empty SPA for the whole build (and forever, if the build failed).
+	local cic_served="runtime/cicchetto-dist"
+	local cic_build_out
+	cic_build_out="$(cic_dist_docker_stage "$cic_served")"
 	# #538 — derive the single-source version for the cic build. The
 	# cicchetto-build container mounts only ./cicchetto, so it can't read the
 	# repo root; pass GRAPPA_VERSION (from the VERSION file, #652) through the env.
 	GRAPPA_VERSION="$("$REPO_ROOT/infra/packaging/version.sh")"
 	export GRAPPA_VERSION
 	echo "Building cicchetto dist..."
-	docker compose "${COMPOSE_ARGS[@]}" --profile prod run --rm cicchetto-build
-	# Vite's emptyOutDir wipes .gitkeep on every build; restore it so
-	# `git status` stays clean.
-	touch runtime/cicchetto-dist/.gitkeep
+	CIC_BUILD_OUT="$cic_build_out" docker compose "${COMPOSE_ARGS[@]}" --profile prod run --rm cicchetto-build
+	# The promote plants the tracked .gitkeep in the tree that lands, so the
+	# post-build `touch` that used to undo vite's wipe is gone.
+	cic_dist_promote "$cic_served" "$cic_build_out"
 }
 
 substrate_migrate() {

--- a/test/infra/cic_dist_swap_test.bats
+++ b/test/infra/cic_dist_swap_test.bats
@@ -1,0 +1,440 @@
+#!/usr/bin/env bats
+#
+# #1020 — a cic build must NEVER empty the directory a running server is
+# serving. Every substrate used to aim vite's `outDir` straight at
+# `runtime/cicchetto-dist`, which the BEAM resolves PER REQUEST
+# (Grappa.Cic.Bundle.root/0 → Plug.Static + the SPA history-fallback), and
+# vite empties `outDir` BEFORE it writes: the served tree was blank for the
+# whole build and stayed blank if the build failed.
+#
+# What makes these tests able to go red, rather than mirrors of the fix: the
+# fake builders below EMULATE vite (empty the outDir first, write the bundle
+# last) and, at the most dangerous instant — right after the wipe — record
+# what the SERVED directory contains. On the parent commit outDir IS the
+# served dir, so that recording reads MISSING and the assertion fails. It is
+# a property of the timing, not of any string in the script.
+#
+# Coverage, and its limit, stated plainly:
+#   * infra/lib/cic_dist.sh          exercised directly (the swap semantics)
+#   * infra/freebsd/jail_cic_build.sh  RUN, with su + npm stubbed  (prod)
+#   * infra/linux/cic_build.sh         RUN, with sudo + bun stubbed
+#   * the Docker substrate             STRUCTURE only — the build happens
+#     inside a container against a compose bind mount, so no bats can run it.
+#     Pinned instead: compose.yaml's mount source is the CIC_BUILD_OUT seam,
+#     and every compose launcher sets it on the build command and promotes
+#     afterwards. Nothing here proves a real container wrote where we think.
+
+load ../bats_helpers
+
+REPO_SRC=""
+
+setup() {
+    REPO_SRC="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    LIB="$REPO_SRC/infra/lib/cic_dist.sh"
+
+    SERVED="$BATS_TEST_TMPDIR/runtime/cicchetto-dist"
+    STAGED="$SERVED.next"
+    mkdir -p "$SERVED/assets"
+}
+
+# A served tree that is complete and CURRENTLY BEING SERVED: index.html, one
+# content-hashed chunk, and the tracked placeholder.
+seed_served_bundle() {
+    mkdir -p "$SERVED/assets"
+    printf 'OLD\n' > "$SERVED/index.html"
+    printf 'old chunk\n' > "$SERVED/assets/index-oldhash.js"
+    touch "$SERVED/.gitkeep"
+}
+
+# A finished build waiting to be promoted.
+seed_staged_bundle() {
+    mkdir -p "$STAGED/assets"
+    printf 'NEW\n' > "$STAGED/index.html"
+    printf 'new chunk\n' > "$STAGED/assets/index-newhash.js"
+}
+
+# ======================================================================
+# infra/lib/cic_dist.sh — the swap itself
+# ======================================================================
+
+@test "staging: the path is derived once, beside the served dir" {
+    # shellcheck source=/dev/null
+    . "$LIB"
+    run cic_dist_staging /srv/grappa/runtime/cicchetto-dist
+    [ "$status" -eq 0 ]
+    [ "$output" = "/srv/grappa/runtime/cicchetto-dist.next" ]
+}
+
+@test "staging: an empty served path is refused, not turned into rm -rf .next" {
+    # shellcheck source=/dev/null
+    . "$LIB"
+    run cic_dist_staging ""
+    [ "$status" -ne 0 ]
+}
+
+@test "promote: the served tree goes complete-old to complete-new" {
+    # shellcheck source=/dev/null
+    . "$LIB"
+    seed_served_bundle
+    seed_staged_bundle
+
+    run cic_dist_promote "$SERVED" "$STAGED"
+    [ "$status" -eq 0 ]
+
+    [ "$(cat "$SERVED/index.html")" = "NEW" ]
+    [ -f "$SERVED/assets/index-newhash.js" ]
+    # The stale-chunk cleanup --emptyOutDir used to provide, preserved: the
+    # previous content-hashed assets leave with the previous directory.
+    refute test -f "$SERVED/assets/index-oldhash.js"
+    # No debris: a leftover .next would be promoted blind by the next run,
+    # a leftover .prev would grow one dead bundle per deploy.
+    refute test -e "$STAGED"
+    refute test -e "$SERVED.prev"
+}
+
+@test "promote: the tracked .gitkeep is in the tree that LANDS" {
+    # shellcheck source=/dev/null
+    . "$LIB"
+    seed_served_bundle
+    seed_staged_bundle
+    refute test -f "$STAGED/.gitkeep"
+
+    run cic_dist_promote "$SERVED" "$STAGED"
+    [ "$status" -eq 0 ]
+    # Not restored afterwards — present the instant the tree becomes the
+    # served one, so `git status` never sees `D runtime/cicchetto-dist/.gitkeep`.
+    [ -f "$SERVED/.gitkeep" ]
+}
+
+@test "promote: a staged tree with no index.html is refused and the old bundle keeps serving" {
+    # shellcheck source=/dev/null
+    . "$LIB"
+    seed_served_bundle
+    mkdir -p "$STAGED/assets"
+    printf 'orphan chunk\n' > "$STAGED/assets/index-newhash.js"
+
+    run cic_dist_promote "$SERVED" "$STAGED"
+    [ "$status" -ne 0 ]
+    [ "$(cat "$SERVED/index.html")" = "OLD" ]
+    [ -f "$SERVED/assets/index-oldhash.js" ]
+}
+
+@test "promote: the new bundle does not land NESTED inside the served dir" {
+    # `mv a b` where b is an existing DIRECTORY moves a INSIDE b. That failure
+    # is silent — the server keeps serving the old bundle and every step
+    # reports success — so it gets its own case rather than riding on the
+    # content assertions above.
+    # shellcheck source=/dev/null
+    . "$LIB"
+    seed_served_bundle
+    seed_staged_bundle
+
+    run cic_dist_promote "$SERVED" "$STAGED"
+    [ "$status" -eq 0 ]
+    refute test -e "$SERVED/cicchetto-dist.next"
+}
+
+@test "promote: a served dir that does not exist yet is created by the swap" {
+    # shellcheck source=/dev/null
+    . "$LIB"
+    rm -rf "$SERVED"
+    seed_staged_bundle
+
+    run cic_dist_promote "$SERVED" "$STAGED"
+    [ "$status" -eq 0 ]
+    [ "$(cat "$SERVED/index.html")" = "NEW" ]
+}
+
+@test "docker stage: the staging dir is cleared, created, and echoed compose-shaped" {
+    # shellcheck source=/dev/null
+    . "$LIB"
+    mkdir -p "$STAGED"
+    printf 'debris from a crashed run\n' > "$STAGED/index.html"
+
+    cd "$BATS_TEST_TMPDIR"
+    run cic_dist_docker_stage runtime/cicchetto-dist
+    [ "$status" -eq 0 ]
+    # A compose bind-mount source without a leading ./ is parsed as a NAMED
+    # VOLUME, so the prefix is load-bearing, not cosmetic.
+    [ "$output" = "./runtime/cicchetto-dist.next" ]
+    [ -d "$STAGED" ]
+    refute test -e "$STAGED/index.html"
+}
+
+# ======================================================================
+# Shared fake builder — emulates vite closely enough to catch the timing
+# ======================================================================
+
+# Writes a stub named $1 into $FAKE_DIR that behaves like `vite build`:
+# empties --outDir first, RECORDS what the served dir holds at that instant,
+# then writes a bundle. Honors $FAKE_BUILD_RC to model a failed build.
+write_fake_builder() {
+    cat > "$FAKE_DIR/$1" <<'EOF'
+#!/bin/sh
+# `<tool> install` / `<tool> ci` — nothing to do, just succeed.
+case "${1:-}" in
+    install|ci) exit 0 ;;
+esac
+
+outdir=""
+prev=""
+for arg in "$@"; do
+    [ "$prev" = "--outDir" ] && outdir="$arg"
+    prev="$arg"
+done
+[ -n "$outdir" ] || { echo "fake builder: no --outDir in: $*" >&2; exit 2; }
+printf '%s\n' "$outdir" >> "$OUTDIR_LOG"
+
+# Vite's prepare-out-dir step: the directory is emptied BEFORE anything is
+# written. This is the whole defect — if outdir IS the served dir, the SPA
+# is gone from here until the build finishes.
+mkdir -p "$outdir"
+rm -rf "$outdir"/* "$outdir"/.[!.]* 2>/dev/null || true
+
+# The observation that makes this suite able to fail: what does a browser
+# hitting the live server get RIGHT NOW, mid-build?
+if [ -f "$SERVED/index.html" ]; then
+    cat "$SERVED/index.html" > "$MIDBUILD_OBSERVED"
+else
+    echo MISSING > "$MIDBUILD_OBSERVED"
+fi
+
+[ "${FAKE_BUILD_RC:-0}" = 0 ] || { echo "fake builder: failing on purpose" >&2; exit "$FAKE_BUILD_RC"; }
+
+mkdir -p "$outdir/assets"
+printf 'NEW\n' > "$outdir/index.html"
+printf 'new chunk\n' > "$outdir/assets/index-newhash.js"
+EOF
+    chmod +x "$FAKE_DIR/$1"
+}
+
+setup_builder_harness() {
+    FAKE_DIR="$BATS_TEST_TMPDIR/fake"
+    mkdir -p "$FAKE_DIR"
+    # Ahead of the real toolchain for the whole test, including the child
+    # shells `su`/`sudo` spawn — those inherit this PATH.
+    export PATH="$FAKE_DIR:$PATH"
+    OUTDIR_LOG="$BATS_TEST_TMPDIR/outdir.log"
+    MIDBUILD_OBSERVED="$BATS_TEST_TMPDIR/midbuild.observed"
+    : > "$OUTDIR_LOG"
+    export OUTDIR_LOG MIDBUILD_OBSERVED SERVED FAKE_BUILD_RC=0
+
+    # Empty HOME: infra/linux/cic_build.sh prepends ~/.local/bin and
+    # ~/.asdf/shims to PATH, and a real bun there would shadow the stub.
+    export HOME="$BATS_TEST_TMPDIR/home"
+    mkdir -p "$HOME"
+}
+
+# A throwaway checkout with the pieces a cic build reads: the version single
+# source of truth, the shared swap lib, a cicchetto dir, and runtime/.
+seed_fake_checkout() {
+    FAKE_ROOT="$1"
+    mkdir -p "$FAKE_ROOT/cicchetto" "$FAKE_ROOT/infra/packaging" "$FAKE_ROOT/infra/lib" "$FAKE_ROOT/runtime"
+    cp "$REPO_SRC/infra/packaging/version.sh" "$FAKE_ROOT/infra/packaging/version.sh"
+    chmod +x "$FAKE_ROOT/infra/packaging/version.sh"
+    cp "$LIB" "$FAKE_ROOT/infra/lib/cic_dist.sh"
+    printf '9.9.9\n' > "$FAKE_ROOT/VERSION"
+    printf '{"name":"cicchetto"}\n' > "$FAKE_ROOT/cicchetto/package.json"
+}
+
+# ======================================================================
+# infra/freebsd/jail_cic_build.sh — the PRODUCTION substrate
+# ======================================================================
+
+setup_jail_harness() {
+    setup_builder_harness
+    FAKE_ROOT="$BATS_TEST_TMPDIR/jail/home/grappa/grappa"
+    seed_fake_checkout "$FAKE_ROOT"
+    SERVED="$FAKE_ROOT/runtime/cicchetto-dist"
+    STAGED="$SERVED.next"
+    export SERVED
+    seed_served_bundle
+
+    write_fake_builder npm
+
+    # `su -l grappa -c BODY` → run BODY under /bin/sh, with the jail's
+    # hardcoded /home/grappa/grappa rewritten onto the throwaway checkout.
+    # The RELOCATION is the only edit: the body that runs is the real script's
+    # body, so the build command, the outDir and the promote are the shipped
+    # ones. A change to the hardcoded root makes the cd miss and reddens here.
+    cat > "$FAKE_DIR/su" <<EOF
+#!/bin/sh
+body=""
+while [ \$# -gt 0 ]; do
+    case "\$1" in
+        -c) body="\$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+printf '%s' "\$body" | sed "s#/home/grappa/grappa#$FAKE_ROOT#g" > "$BATS_TEST_TMPDIR/su-body.sh"
+exec /bin/sh "$BATS_TEST_TMPDIR/su-body.sh"
+EOF
+    chmod +x "$FAKE_DIR/su"
+}
+
+@test "jail: the served bundle is still serving while vite builds" {
+    setup_jail_harness
+    run "$REPO_SRC/infra/freebsd/jail_cic_build.sh"
+    [ "$status" -eq 0 ]
+
+    # THE red on the parent commit: there, outDir is the served dir, so the
+    # wipe had already taken the SPA down by this point.
+    [ "$(cat "$MIDBUILD_OBSERVED")" = "OLD" ]
+    refute grep -qFx "$SERVED" "$OUTDIR_LOG"
+}
+
+@test "jail: the new bundle lands, stale chunks and debris do not" {
+    setup_jail_harness
+    run "$REPO_SRC/infra/freebsd/jail_cic_build.sh"
+    [ "$status" -eq 0 ]
+
+    [ "$(cat "$SERVED/index.html")" = "NEW" ]
+    [ -f "$SERVED/.gitkeep" ]
+    refute test -f "$SERVED/assets/index-oldhash.js"
+    refute test -e "$STAGED"
+}
+
+@test "jail: a FAILED build leaves the previous bundle serving" {
+    setup_jail_harness
+    FAKE_BUILD_RC=1
+    export FAKE_BUILD_RC
+
+    run "$REPO_SRC/infra/freebsd/jail_cic_build.sh"
+    [ "$status" -ne 0 ]
+
+    # On the parent this directory was emptied at the start of the build and
+    # `set -eu` walked away from the wreckage.
+    [ "$(cat "$SERVED/index.html")" = "OLD" ]
+    [ -f "$SERVED/assets/index-oldhash.js" ]
+    [ -f "$SERVED/.gitkeep" ]
+}
+
+# ======================================================================
+# infra/linux/cic_build.sh
+# ======================================================================
+
+setup_linux_harness() {
+    setup_builder_harness
+    FAKE_ROOT="$BATS_TEST_TMPDIR/linux"
+    seed_fake_checkout "$FAKE_ROOT"
+    SERVED="$FAKE_ROOT/runtime/cicchetto-dist"
+    STAGED="$SERVED.next"
+    export SERVED
+    seed_served_bundle
+
+    write_fake_builder bun
+
+    # sudo -u grappa -H bash -c '<cmd>' → run <cmd> in-process (same shape as
+    # deploy_linux_test.bats): real privilege-dropping is not what is under test.
+    cat > "$FAKE_DIR/sudo" <<'EOF'
+#!/bin/sh
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -u) shift 2 ;;
+        -H|-E|-n|-i|-s) shift ;;
+        --) shift; break ;;
+        -*) shift ;;
+        *) break ;;
+    esac
+done
+exec "$@"
+EOF
+    chmod +x "$FAKE_DIR/sudo"
+}
+
+@test "linux: the served bundle is still serving while vite builds" {
+    setup_linux_harness
+    run "$REPO_SRC/infra/linux/cic_build.sh" "$FAKE_ROOT"
+    [ "$status" -eq 0 ]
+
+    [ "$(cat "$MIDBUILD_OBSERVED")" = "OLD" ]
+    refute grep -qFx "$SERVED" "$OUTDIR_LOG"
+}
+
+@test "linux: the new bundle lands, stale chunks and debris do not" {
+    setup_linux_harness
+    run "$REPO_SRC/infra/linux/cic_build.sh" "$FAKE_ROOT"
+    [ "$status" -eq 0 ]
+
+    [ "$(cat "$SERVED/index.html")" = "NEW" ]
+    [ -f "$SERVED/.gitkeep" ]
+    refute test -f "$SERVED/assets/index-oldhash.js"
+    refute test -e "$STAGED"
+}
+
+@test "linux: a FAILED build leaves the previous bundle serving" {
+    setup_linux_harness
+    FAKE_BUILD_RC=1
+    export FAKE_BUILD_RC
+
+    run "$REPO_SRC/infra/linux/cic_build.sh" "$FAKE_ROOT"
+    [ "$status" -ne 0 ]
+
+    [ "$(cat "$SERVED/index.html")" = "OLD" ]
+    [ -f "$SERVED/assets/index-oldhash.js" ]
+    [ -f "$SERVED/.gitkeep" ]
+}
+
+# ======================================================================
+# Docker — structure only, and it says so
+# ======================================================================
+
+# The compose oneshot writes to whatever host dir is bind-mounted at
+# /app/dist, so the seam that keeps it off the served tree lives in
+# compose.yaml. Byte-pinned: the default must stay the served dir (a bare
+# `compose --profile prod up` has no live server to protect and reaches the
+# build through grappa's depends_on, with nobody to promote afterwards).
+@test "docker: the cicchetto-build mount source is the CIC_BUILD_OUT seam" {
+    grep -qF '${CIC_BUILD_OUT:-./runtime/cicchetto-dist}:/app/dist' "$REPO_SRC/compose.yaml"
+}
+
+# Comments are prose; only code counts. Same stripping as
+# cic_version_export_test.bats, for the same reason.
+code_of() {
+    sed -e 's/[[:space:]]*#.*$//' "$1"
+}
+
+DOCKER_LAUNCHERS=(
+    scripts/deploy.sh
+    scripts/deploy-cic.sh
+    infra/docker/deploy.sh
+)
+
+@test "docker: every compose launcher aims the build at a staging dir and promotes it" {
+    local offenders=() rel code
+    for rel in "${DOCKER_LAUNCHERS[@]}"; do
+        code="$(code_of "$REPO_SRC/$rel")"
+        # CIC_BUILD_OUT must be set ON the build command, not exported at
+        # large: a stray export would still be in the environment for the
+        # `up`/`restart` compose calls that follow.
+        grep -qE 'CIC_BUILD_OUT=.*run --rm cicchetto-build' <<< "$code" \
+            || offenders+=("$rel (build not aimed at CIC_BUILD_OUT)")
+        grep -q 'cic_dist_promote' <<< "$code" \
+            || offenders+=("$rel (never promotes the staged bundle)")
+    done
+    [ "${#offenders[@]}" -eq 0 ] || {
+        printf 'compose launchers that build into the SERVED dist (see #1020):\n' >&2
+        printf '  %s\n' "${offenders[@]}" >&2
+        return 1
+    }
+}
+
+@test "docker: no launcher restores .gitkeep after the build any more" {
+    # The three post-build `touch runtime/cicchetto-dist/.gitkeep` calls existed
+    # ONLY to undo vite's in-place wipe. Leaving one behind would mean the
+    # served dir is still being written to directly.
+    local offenders=() rel
+    for rel in "${DOCKER_LAUNCHERS[@]}" infra/linux/cic_build.sh infra/freebsd/jail_cic_build.sh; do
+        # An `if`, not `grep ... && offenders+=`: a non-matching grep at the
+        # head of an AND list makes the whole list return 1, and bats runs
+        # test bodies under errexit (see test/bats_helpers.bash).
+        if grep -q 'touch .*cicchetto-dist/\.gitkeep' <<< "$(code_of "$REPO_SRC/$rel")"; then
+            offenders+=("$rel")
+        fi
+    done
+    [ "${#offenders[@]}" -eq 0 ] || {
+        printf 'post-build .gitkeep restores left behind (see #1020):\n' >&2
+        printf '  %s\n' "${offenders[@]}" >&2
+        return 1
+    }
+}

--- a/test/infra/deploy_docker_test.bats
+++ b/test/infra/deploy_docker_test.bats
@@ -59,6 +59,9 @@ setup() {
     # exist in the throwaway clone for the script to run — committed so
     # pulls stay clean. Assertions below are UNCHANGED by the extraction.
     cp "$BATS_TEST_DIRNAME/../../infra/lib/deploy_common.sh" "$UPSTREAM/infra/lib/deploy_common.sh"
+    # #1020 — the cic build's build-beside-then-swap helper, sourced by the
+    # same orchestrator. A checkout has it; the throwaway clone must too.
+    cp "$BATS_TEST_DIRNAME/../../infra/lib/cic_dist.sh" "$UPSTREAM/infra/lib/cic_dist.sh"
     # version.sh delegate → committed recorder that echoes a version.
     cat > "$UPSTREAM/infra/packaging/version.sh" <<'EOF'
 #!/bin/sh
@@ -96,6 +99,15 @@ printf 'docker %s\n' "$*" >> "$ARGV_LOG"
 case "$*" in
     *"ps -q grappa"*)  echo fakecid ;;
     *"run --no-start"*) exit "$PREFLIGHT_RC" ;;
+    *"run --rm cicchetto-build"*)
+        # #1020 — model the oneshot: vite writes the bundle into whatever host
+        # dir is bind-mounted at /app/dist, which is CIC_BUILD_OUT now. Without
+        # this the promote correctly REFUSES to swap in a tree with no
+        # index.html, and every cold case dies for the wrong reason.
+        cic_out="${CIC_BUILD_OUT:-./runtime/cicchetto-dist}"
+        mkdir -p "$cic_out/assets"
+        printf '<!doctype html>\n' > "$cic_out/index.html"
+        ;;
     *"exec -T grappa curl"*reload*)
         if [ "$RELOAD_FAILS" = "1" ]; then
             printf '{"loaded":[],"failed":[{"module":"Foo","reason":"old_code_in_use"}]}'

--- a/test/infra/deploy_docker_update_test.bats
+++ b/test/infra/deploy_docker_update_test.bats
@@ -42,6 +42,9 @@ setup() {
              "$UPSTREAM/runtime" "$UPSTREAM/lib"
     cp "$REPO_SRC/infra/docker/deploy.sh" "$UPSTREAM/infra/docker/deploy.sh"
     cp "$REPO_SRC/infra/lib/deploy_common.sh" "$UPSTREAM/infra/lib/deploy_common.sh"
+    # #1020 — the cic build's build-beside-then-swap helper, sourced by the
+    # same orchestrator. A checkout has it; the throwaway clone must too.
+    cp "$REPO_SRC/infra/lib/cic_dist.sh" "$UPSTREAM/infra/lib/cic_dist.sh"
     # The REAL version carrier + extractor (#538/#652): source mode derives
     # GRAPPA_VERSION from them at init so every compose call inherits it, and a
     # cic build with an empty value is refused by vite (#692).
@@ -97,6 +100,15 @@ if [ "$1" = inspect ]; then
 fi
 case "$*" in
     *"run --no-start"*) exit "$PREFLIGHT_RC" ;;
+    *"run --rm cicchetto-build"*)
+        # #1020 — model the oneshot: vite writes the bundle into whatever host
+        # dir is bind-mounted at /app/dist, which is CIC_BUILD_OUT now. Without
+        # this the promote correctly REFUSES to swap in a tree with no
+        # index.html, and every cold case dies for the wrong reason.
+        cic_out="${CIC_BUILD_OUT:-./runtime/cicchetto-dist}"
+        mkdir -p "$cic_out/assets"
+        printf '<!doctype html>\n' > "$cic_out/index.html"
+        ;;
     *"exec -T grappa curl"*reload*)
         if [ "$RELOAD_FAILS" = "1" ]; then
             printf '{"loaded":[],"failed":[{"module":"Foo","reason":"old_code_in_use"}]}'

--- a/test/scripts/deploy_reload_verify_test.bats
+++ b/test/scripts/deploy_reload_verify_test.bats
@@ -47,6 +47,9 @@ setup() {
     # #503: deploy.sh now sources the shared deploy algorithm lib — it must
     # exist in the throwaway clone for the script to run.
     cp "$BATS_TEST_DIRNAME/../../infra/lib/deploy_common.sh" "$UPSTREAM/infra/lib/deploy_common.sh"
+    # #1020 — the cic build's build-beside-then-swap helper, sourced by the
+    # same orchestrator. A checkout has it; the throwaway clone must too.
+    cp "$BATS_TEST_DIRNAME/../../infra/lib/cic_dist.sh" "$UPSTREAM/infra/lib/cic_dist.sh"
     : > "$UPSTREAM/compose.yaml"
     # NB: deliberately NO runtime/.gitkeep here — git drops the empty dir,
     # so the clone has NO runtime/. This mimics a checkout-less install

--- a/test/scripts/deploy_worktree_guard_test.bats
+++ b/test/scripts/deploy_worktree_guard_test.bats
@@ -52,6 +52,10 @@ setup() {
     # #503: deploy.sh now sources the shared deploy algorithm lib — it must
     # exist in the checkout for the script to reach the pull step.
     cp "$BATS_TEST_DIRNAME/../../infra/lib/deploy_common.sh" "$MAIN/infra/lib/deploy_common.sh"
+    # #1020: both scripts also source the build-beside-then-swap helper, at the
+    # top — before the guards these cases are about. Missing it would kill them
+    # for the wrong reason.
+    cp "$BATS_TEST_DIRNAME/../../infra/lib/cic_dist.sh" "$MAIN/infra/lib/cic_dist.sh"
     # #538/#652 — deploy-cic.sh (and deploy.sh's cold path) derive the cic
     # version from the repo-root VERSION file via infra/packaging/version.sh.
     # The fixture needs both the script and a VERSION file to derive from, or
@@ -82,6 +86,15 @@ case "\$args" in
     *cic-bundle-changed*)  printf '%s' 'abc123';   exit 0 ;;
     *admin/reload*)        printf '%s' '{"reloaded":[],"failed":[]}'; exit 0 ;;
     *healthz*)             exit 0 ;;
+    *"run --rm cicchetto-build"*)
+        # #1020 — the oneshot writes the bundle into the CIC_BUILD_OUT staging
+        # dir; deploy-cic.sh then promotes it, and the promote refuses an empty
+        # tree. Model the write so these guard cases fail on guards only.
+        cic_out="\${CIC_BUILD_OUT:-./runtime/cicchetto-dist}"
+        mkdir -p "\$cic_out/assets"
+        printf '<!doctype html>\\n' > "\$cic_out/index.html"
+        exit 0
+        ;;
     *)                     exit 0 ;;
 esac
 EOF
@@ -161,6 +174,14 @@ args="\$*"
 case "\$args" in
     *"ps -q grappa"*)      echo "fakecontainerid"; exit 0 ;;
     *cic-bundle-changed*)  printf '%s' ''; exit 0 ;;
+    *"run --rm cicchetto-build"*)
+        # #1020, as above: the build must produce a promotable tree, or this
+        # case would die at the swap instead of reaching the 204 it is about.
+        cic_out="\${CIC_BUILD_OUT:-./runtime/cicchetto-dist}"
+        mkdir -p "\$cic_out/assets"
+        printf '<!doctype html>\\n' > "\$cic_out/index.html"
+        exit 0
+        ;;
     *)                     exit 0 ;;
 esac
 EOF


### PR DESCRIPTION
Fixes the deploy procedure for #1020 — *"prima buildi e poi seappa"*.

## The defect, as measured

Every serving substrate aimed vite's `outDir` at `runtime/cicchetto-dist`, the
directory `Grappa.Cic.Bundle.root/0` resolves **per request** (`Plug.Static` +
the SPA history-fallback; `root/0` stashes a path *string* in
`:persistent_term` and `File.read` runs on every call). Vite empties `outDir`
**before** it writes anything, so the served tree was blank for the whole build
— and a build that FAILED left it blank, because `set -eu` walked away from an
already-emptied directory.

`--emptyOutDir` is **not** the defect and is kept. `outDir` is out of vite's
root by design (root is `cicchetto/`, output goes to `runtime/cicchetto-dist`
so Docker and the jail share one server-side anchor, `bd1d85cb`), vite refuses
to clean an out-of-root dir without that consent, and the cleanup is *wanted* —
content-hashed chunks would otherwise accrete forever. The **timing** is the
defect.

### One correction to the brief I was given

`infra/freebsd/jail_cic_build.sh` — the **production** substrate — never had a
post-build `touch .gitkeep`. Only the linux and the three Docker launchers did
(`grep -rn gitkeep` over the parent commit: `infra/docker/deploy.sh:713`,
`infra/linux/cic_build.sh:49`, `scripts/deploy-cic.sh:54`,
`scripts/deploy.sh:147`; nothing under `infra/freebsd/`). So on the jail every
cic build silently deleted a **tracked** file and left `D
runtime/cicchetto-dist/.gitkeep` in the worktree — the same shape as the
DESIGN_NOTES 2335 incident where an unstaged `D` stalled a `git pull`. This
change closes that as a side effect (the bats case `jail: the new bundle lands`
is red on the parent for exactly that assertion), and the tree self-heals on
the first deploy that carries the fix.

## The change

`infra/lib/cic_dist.sh` — one POSIX-sh implementation, sourced (never executed,
same contract as `beam_wait.sh` / `deploy_common.sh`) by all three serving
substrates. `infra/packaging/build.sh` needs no change: it already stages, and
is the shape being generalised.

- **jail** (`infra/freebsd/jail_cic_build.sh`) and **native linux**
  (`infra/linux/cic_build.sh`): `--outDir <served>.next --emptyOutDir`, then
  promote.
- **docker**: the oneshot writes to whatever is bind-mounted at `/app/dist`, so
  the compose mount source became `${CIC_BUILD_OUT:-./runtime/cicchetto-dist}`.
  The three wrappers set it **on the build command only** (not exported at
  large, so the later `up`/`restart` compose calls see the normal mount) and
  promote afterwards. The **default stays the served dir** on purpose: a bare
  `compose --profile prod up` reaches the build through grappa's `depends_on`
  with nobody to promote, and there nothing is serving yet. A second compose
  service was the alternative and was rejected — two build definitions is
  exactly the drift `cic_version_export_test.bats` polices.

### Swap primitive and its failure window (asked for explicitly)

`mv` is `rename(2)`. There is no portable two-directory **exchange**
(`RENAME_EXCHANGE` is Linux-only and unreachable from `sh`), so the promote is
two renames:

```
mv <served> <served>.prev     # served path momentarily ABSENT
mv <staged> <served>
```

Between them the served path does not **exist** — `Plug.Static`'s `from:` misses
and the request falls through to the history-fallback / 404. It is **ENOENT,
not a half-written tree**, so a client gets the old bundle or the new one, never
a mix; and it is two syscalls against the whole vite build it replaces.

Die mid-swap and nothing is lost: `.prev` holds the complete previous bundle and
`.next` the complete new one, and the next run starts by clearing `.prev` and
re-staging `.next`. Only a crash inside the microsecond gap leaves the served
path missing; re-running the build fixes it. Both paths are siblings inside
`runtime/` so the rename cannot go cross-device and degrade to copy-then-delete.

`mv a b` where `b` is an existing DIRECTORY moves `a` INSIDE `b` — the served
path is therefore *renamed away*, not emptied, before the second `mv`, and that
failure has its own test case because it is silent (server keeps serving the
old bundle, every step reports success).

**A symlink flip would have been atomic and was rejected**: the served path is
TRACKED (`runtime/cicchetto-dist/.gitkeep`), and turning a tracked directory
into a symlink is a type change git reports as dirt — the very class of dirty
tree that stalls a deploy's `git pull --ff-only`.

### .gitkeep

Not relocated blindly: it stopped being a *repair* and became a *property of the
landing tree*. `cic_dist_promote` plants it in the staged tree **before** the
rename, so the tracked path is never absent for any interval, instead of being
restored shortly after it goes missing. The four post-build `touch` calls are
gone, and a bats case fails if one comes back.

### On failure the served tree is untouched — how that is proved

Two independent mechanisms, both tested:
1. the build writes into a directory nobody serves, so a non-zero vite exit
   under `set -eu` never reaches the promote at all;
2. the promote itself REFUSES a staged tree with no `index.html` (a build can
   exit 0 having written nothing reachable) and returns non-zero with the old
   bundle still in place.

`jail: a FAILED build leaves the previous bundle serving` and its linux twin
run the real scripts with `FAKE_BUILD_RC=1` and assert `<served>/index.html`
still reads `OLD`. Both are **red on the parent commit** (`cat: ... No such file
or directory` — the parent had already emptied it).

## Tests

`test/infra/cic_dist_swap_test.bats` — 17 cases. The fake builders **emulate
vite**: they empty `--outDir` first and, at that instant, record what the
SERVED directory holds. The assertion is on the *timing*, not on any string, so
it cannot be satisfied by a script that merely mentions the right path.

**Red on the parent commit** (production files restored to `HEAD~1`, test + lib
kept): 8 of 17 red, including both timing observations and both
failed-build cases —

```
not ok  9 jail: the served bundle is still serving while vite builds
not ok 10 jail: the new bundle lands, stale chunks and debris do not
not ok 11 jail: a FAILED build leaves the previous bundle serving
not ok 12 linux: the served bundle is still serving while vite builds
not ok 14 linux: a FAILED build leaves the previous bundle serving
not ok 15 docker: the cicchetto-build mount source is the CIC_BUILD_OUT seam
not ok 16 docker: every compose launcher aims the build at a staging dir and promotes it
not ok 17 docker: no launcher restores .gitkeep after the build any more
```

`linux: the new bundle lands` passes on the parent, correctly: building in
place *does* land the bundle and *does* clear stale chunks, and linux restored
its `.gitkeep`. It is a regression net, not a discriminator — the discriminators
are the five above.

**Mutations, both run and both read:**

| mutation | result |
|---|---|
| jail `--outDir "$staged"` → `"$served"` | `not ok 9, 10, 11`; linux 12 still `ok` (correctly scoped) |
| drop `touch "${_cic_staged}/.gitkeep"` from the promote | `not ok 4` (lib), `not ok 10` (jail), `not ok 13` (linux) |

Two harness families needed updating and the commit says why: the throwaway
clones now copy `infra/lib/cic_dist.sh` (they already copy `deploy_common.sh`,
for the same reason), and the `docker` stubs now model the oneshot *writing a
bundle* into `CIC_BUILD_OUT` — previously they answered `run --rm
cicchetto-build` with a bare `exit 0`, i.e. a build that produced nothing, which
the promote rightly refuses.

## Gates

- `scripts/bats.sh test/bin/ test/infra/ test/scripts/` → **354/354, exit 0**
- `scripts/shellcheck.sh` → **exit 0**, 71 derived scripts (the new lib is in
  the derived set: `--list` line 25)
- working tree porcelain empty before and after both gates

## HOT vs COLD, by content

Read out of `lib/grappa/deploy/preflight.ex` (not executed — that needs the
compile lane):

- **jail → HOT.** Changes are `infra/freebsd/jail_cic_build.sh` +
  `infra/lib/cic_dist.sh`: not `rc_d?`, not `systemd_unit?`, not `nginx?`, not
  `config/*.exs`, not `mix.exs`/`mix.lock`, not `application.ex`. And
  `docker_image?` is `filter_on(:docker, …)`, so `compose.yaml` is invisible to
  this substrate.
- **linux → HOT**, same reasoning.
- **docker → COLD**, via `docker_image?` (`String.starts_with?(path,
  "compose.")`). Worth stating the nuance: only the *oneshot's* mount changed,
  and `compose run --rm` re-reads the file every invocation, so nothing about
  the long-lived grappa container actually needs recreating. The `compose.`
  prefix class is deliberately conservative (H20 proved the enumeration failure
  mode twice) and I did **not** weaken it for this.

**The fix is self-applying on the jail**: `infra/freebsd/deploy.sh` runs `git
pull --ff-only` before `substrate_cic`, so the deploy that carries this change
is already the first one to build beside and swap.

## What I did NOT prove

- **The empty-dist window was never observed on a running jail.** Nobody may
  touch m42 or prod; the window is read out of `--emptyOutDir` + serve-at-
  request-time, exactly as the issue itself states. A structural reading says
  the path EXISTS; it says nothing about magnitude or frequency.
- **The Docker substrate was read, not exercised.** The build happens inside a
  container against a compose bind mount, so no bats can observe it. What is
  pinned is the compose mount source (byte-exact) and a scan that every launcher
  aims the build at `CIC_BUILD_OUT` and promotes. Nothing here proves a real
  container wrote where we think it did.
- ~~`docker compose config` was not run~~ — **since measured** (parse+interpolate
  only; no daemon, no container). `docker compose -f compose.yaml --profile prod
  config` returns **rc=0** both ways, and the mount interpolates to an absolute
  host path:

  ```
  # CIC_BUILD_OUT unset
  source: <repo>/runtime/cicchetto-dist
  target: /app/dist
  # CIC_BUILD_OUT=./runtime/cicchetto-dist.next
  source: <repo>/runtime/cicchetto-dist.next
  target: /app/dist
  ```

  What that proves is the interpolation and the resolved source path — nothing
  about a real container writing there. The Docker bullet above still stands.
- **The tests observe the window during the BUILD, not during the PROMOTE.**
  Reordering the two renames inside `cic_dist_promote` would not redden
  anything: the end state is identical and only the window width differs. That
  window is argued in the lib header, not measured.
- **The `.deb`/`.rpm` and e2e paths were left alone** — `infra/packaging/build.sh`
  already stages, and `cicchetto/e2e/compose.yaml` builds a separate
  `runtime/e2e/cicchetto-dist` that no production server serves.
