### PR TITLE
union: #1018 mute-skip + #1020 cic build swap, gated together

### DIFF
--- a/cicchetto/e2e/tests/issue1018-mute-skips-next-active.spec.ts
+++ b/cicchetto/e2e/tests/issue1018-mute-skips-next-active.spec.ts
@@ -1,0 +1,119 @@
+// GH #1018 — a MUTED conversation (#866) is not a stop on the next-active
+// cycle (#235: Alt+A, Ctrl+N/P, the on-screen affordance).
+//
+// Why an e2e and not just the unit test on `orderUnreadWindows`:
+//
+//   * the mute is created through the SettingsDrawer picker, so the folded
+//     key the picker WRITES and the key the cycle READS are proven to be the
+//     same string. Two unit suites on either side of that seam cannot see a
+//     fold mismatch between them — the same argument
+//     `push-866-conversation-mute.spec.ts` makes for the push port.
+//   * the outcome under test is "which window did the operator land on",
+//     which is only observable here.
+//
+// Scope guard under test too (#866 Q4): the muted channel keeps its sidebar
+// unread badge. The mute changes the NAVIGATION order, not the counters.
+//
+// Desktop only, deliberately: all three doors dispatch the SAME verb
+// (`jumpToNextActiveWindow`), and #235's own spec already gates the mobile
+// button against that verb. This spec's variable is the mute, not the door.
+//
+// Removing the feature turns this red at the first jump: the muted channel
+// heads the cycle (older activity, same tier) and Alt+A lands there.
+
+import {
+  loginAs,
+  openSettingsSection,
+  selectChannel,
+  sidebarMessageBadge,
+  sidebarWindow,
+} from "../fixtures/cicchettoPage";
+import { clearMutedConversations, partChannel } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+const PEER_NICK = "i1018-noise";
+const MUTED_CHANNEL = "#1018-muted";
+const LOUD_CHANNEL = "#1018-loud";
+
+const NEXT_ACTIVE_BTN = '[data-testid="next-active-btn"]';
+const NEXT_ACTIVE_COUNT = '[data-testid="next-active-btn"] .next-active-count';
+
+test("Alt+A skips the muted channel and lands on the unmuted one, badge intact", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+
+  const peer = await IrcPeer.connect({ nick: PEER_NICK });
+  try {
+    await peer.join(MUTED_CHANNEL);
+    await peer.join(LOUD_CHANNEL);
+
+    // Join operator-side and visit each window: the picker offers the
+    // conversations the operator actually has, and the visit baselines each
+    // read cursor to the tail so the unread below is the traffic this spec
+    // produces, not seed backlog.
+    for (const channel of [MUTED_CHANNEL, LOUD_CHANNEL]) {
+      await page.locator(".compose-box textarea").fill(`/join ${channel}`);
+      await page.locator(".compose-box textarea").press("Enter");
+      await selectChannel(page, NETWORK_SLUG, channel, { ownNick: NETWORK_NICK });
+    }
+
+    await openSettingsSection(page, "push");
+    const picker = page.locator('[data-testid="pref-mute-picker"]');
+    await expect(picker.locator(`option[value="${MUTED_CHANNEL}"]`)).toHaveCount(1);
+    await picker.selectOption(MUTED_CHANNEL);
+    // The row is drawn from the server's normalized echo, so its presence
+    // proves the PUT landed — no sleep, no arbitrary timeout.
+    await expect(page.locator(`[data-testid="pref-muted-${MUTED_CHANNEL}"]`)).toBeVisible({
+      timeout: 10_000,
+    });
+    // ...and the sibling is demonstrably NOT muted: the two arms below differ
+    // in exactly one variable.
+    await expect(page.locator(`[data-testid="pref-muted-${LOUD_CHANNEL}"]`)).toHaveCount(0);
+    await page.locator('[data-testid="settings-drawer-backdrop"]').click({ force: true });
+
+    // Park focus on the neutral $server window — NOT part of the cycle — so
+    // both channels accrue unread.
+    await selectChannel(page, NETWORK_SLUG, NETWORK_SLUG, { awaitWsReady: false });
+
+    // The MUTED channel speaks FIRST: with the mute gone it is the older
+    // activity in the same tier, i.e. the head of the cycle. That ordering is
+    // what makes the assertion below discriminating.
+    peer.privmsg(MUTED_CHANNEL, "1018 muted room, still noisy");
+    await expect(sidebarMessageBadge(page, NETWORK_SLUG, MUTED_CHANNEL)).toBeVisible({
+      timeout: 10_000,
+    });
+    peer.privmsg(LOUD_CHANNEL, "1018 the room you actually read");
+    await expect(sidebarMessageBadge(page, NETWORK_SLUG, LOUD_CHANNEL)).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // TWO windows carry unread, but only ONE is a stop on the cycle.
+    await expect(page.locator(NEXT_ACTIVE_COUNT)).toHaveText("1", { timeout: 10_000 });
+
+    await page.keyboard.press("Alt+a");
+    await expect(sidebarWindow(page, NETWORK_SLUG, LOUD_CHANNEL)).toHaveClass(/selected/, {
+      timeout: 10_000,
+    });
+
+    // The unmuted room is read now. The muted one is STILL unread — and the
+    // affordance is gone rather than offering it (#1018 Q2: when every
+    // remaining unread window is muted the cycle is a no-op).
+    await expect(page.locator(NEXT_ACTIVE_BTN)).toHaveCount(0, { timeout: 10_000 });
+
+    // #866 Q4 scope guard: the mute took the window off the CYCLE, not off
+    // the counters — its sidebar unread badge is untouched.
+    await expect(sidebarMessageBadge(page, NETWORK_SLUG, MUTED_CHANNEL)).toBeVisible();
+  } finally {
+    await peer.disconnect("#1018 done");
+    // The mute is PERSISTED per subject and vjt is shared by the whole suite —
+    // leaving it behind silences #1018-muted for every later spec, and the
+    // victim fails with nothing pointing back here.
+    await clearMutedConversations(vjt.token).catch(() => {});
+    await partChannel(vjt.token, NETWORK_SLUG, MUTED_CHANNEL).catch(() => {});
+    await partChannel(vjt.token, NETWORK_SLUG, LOUD_CHANNEL).catch(() => {});
+  }
+});

--- a/cicchetto/e2e/tests/issue1018-mute-skips-next-active.spec.ts
+++ b/cicchetto/e2e/tests/issue1018-mute-skips-next-active.spec.ts
@@ -30,7 +30,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { clearMutedConversations, partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
-import { getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "i1018-noise";
@@ -45,6 +45,18 @@ test("Alt+A skips the muted channel and lands on the unmuted one, badge intact",
 }) => {
   const vjt = getSeededVjt();
   await loginAs(page, vjt);
+  // Focus the seeded autojoin channel before anything else, for TWO
+  // reasons that both bite silently if skipped:
+  //   * the compose box below only exists once a scrollback-kind window
+  //     is selected — Shell's `kindHasScrollback` Match owns ComposeBox,
+  //     and boot auto-selects $home, which has none. Without this the
+  //     `/join` fill waits 30s on a locator that never mounts.
+  //   * the per-test reset clears every read cursor and re-seeds this
+  //     channel with 200 rows, so it starts FULLY unread and would be a
+  //     second stop on the cycle. Focusing it baselines the cursor to
+  //     the tail, which is what makes the count assertion below read the
+  //     two windows this spec drives and nothing else.
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
 
   const peer = await IrcPeer.connect({ nick: PEER_NICK });
   try {

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -14,8 +14,8 @@ import InlineConfirmButton from "./InlineConfirmButton";
 import { windowCandidates } from "./lib/activeWindows";
 import { ApiError, displayNick, type Network, visitorNetworkNick } from "./lib/api";
 import { getSubject, token } from "./lib/auth";
-import { canonicalChannel } from "./lib/channelKey";
 import { getColoredNicklist } from "./lib/colorNicklist";
+import { windowMuteKey } from "./lib/conversationMute";
 import { syncedSetColoredNicklist, syncedSetTimeFormat } from "./lib/displayPrefs";
 import { type FontSizeKey, getFontSize, setFontSize } from "./lib/fontSize";
 import { friendlyApiError } from "./lib/friendlyApiError";
@@ -542,7 +542,7 @@ const SettingsDrawer: Component<Props> = (props) => {
     const muted = prefs().muted_targets ?? {};
     const byKey = new Map<string, string>();
     for (const candidate of windowCandidates()) {
-      const key = canonicalChannel(candidate.channelName);
+      const key = windowMuteKey(candidate);
       if (Object.hasOwn(muted, key) || byKey.has(key)) continue;
       byKey.set(key, candidate.channelName);
     }

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -359,14 +359,23 @@ vi.mock("../lib/api", () => ({
   adminListSessionLog: vi.fn().mockResolvedValue([]),
 }));
 
-vi.mock("../lib/channelKey", () => ({
-  channelKey: (slug: string, name: string) => `${slug} ${name}`,
-  decodeChannelKey: (key: string) => {
-    const sep = key.indexOf(" ");
-    if (sep < 0) return null;
-    return { slug: key.slice(0, sep), name: key.slice(sep + 1) };
-  },
-}));
+// Only the composite-key pair is stubbed (identity, not folding — the
+// fixtures key on raw names). `canonicalChannel` stays REAL via importActual:
+// the #1018 mute lookup folds through it inside `activeWindows`, and a
+// hand-rolled stand-in here would be this suite re-implementing production's
+// fold.
+vi.mock("../lib/channelKey", async () => {
+  const actual = await vi.importActual<typeof import("../lib/channelKey")>("../lib/channelKey");
+  return {
+    ...actual,
+    channelKey: (slug: string, name: string) => `${slug} ${name}`,
+    decodeChannelKey: (key: string) => {
+      const sep = key.indexOf(" ");
+      if (sep < 0) return null;
+      return { slug: key.slice(0, sep), name: key.slice(sep + 1) };
+    },
+  };
+});
 
 // windowState — Shell + TopicBar gate the members aside / hamburger /
 // nick count on the joined-channel predicate. Default to "joined for

--- a/cicchetto/src/__tests__/activeWindows.test.ts
+++ b/cicchetto/src/__tests__/activeWindows.test.ts
@@ -46,15 +46,15 @@ const names = (list: ActiveWindow[]): string[] => list.map((w) => w.channelName)
 describe("orderUnreadWindows", () => {
   it("returns empty when there are no candidates", () => {
     expect(
-      orderUnreadWindows({ candidates: [], unread: {}, mentions: {}, activityId: {} }),
+      orderUnreadWindows({ candidates: [], unread: {}, mentions: {}, activityId: {}, muted: {} }),
     ).toEqual([]);
   });
 
   it("returns empty when no candidate has unread activity", () => {
     const c = [chan("#a"), query("bob")];
-    expect(orderUnreadWindows({ candidates: c, unread: {}, mentions: {}, activityId: {} })).toEqual(
-      [],
-    );
+    expect(
+      orderUnreadWindows({ candidates: c, unread: {}, mentions: {}, activityId: {}, muted: {} }),
+    ).toEqual([]);
   });
 
   it("includes only windows whose unread count is greater than zero", () => {
@@ -62,6 +62,7 @@ describe("orderUnreadWindows", () => {
     const b = chan("#b");
     const out = orderUnreadWindows({
       candidates: [a, b],
+      muted: {},
       unread: counts([
         [a, 0],
         [b, 3],
@@ -77,6 +78,7 @@ describe("orderUnreadWindows", () => {
     const bob = query("bob");
     const out = orderUnreadWindows({
       candidates: [a, bob],
+      muted: {},
       unread: counts([
         [a, 3],
         [bob, 1],
@@ -96,6 +98,7 @@ describe("orderUnreadWindows", () => {
     const plain = chan("#plain");
     const out = orderUnreadWindows({
       candidates: [ment, plain],
+      muted: {},
       unread: counts([
         [ment, 1],
         [plain, 5],
@@ -117,6 +120,7 @@ describe("orderUnreadWindows", () => {
     const out = orderUnreadWindows({
       // flat order c,a,b — but chronology must override it.
       candidates: [c, a, b],
+      muted: {},
       unread: counts([
         [a, 1],
         [b, 1],
@@ -137,6 +141,7 @@ describe("orderUnreadWindows", () => {
     const y = chan("#y");
     const out = orderUnreadWindows({
       candidates: [x, y],
+      muted: {},
       unread: counts([
         [x, 1],
         [y, 1],
@@ -153,6 +158,7 @@ describe("orderUnreadWindows", () => {
     const alice = query("alice");
     const out = orderUnreadWindows({
       candidates: [zoe, alice],
+      muted: {},
       unread: counts([
         [zoe, 1],
         [alice, 1],
@@ -171,12 +177,160 @@ describe("orderUnreadWindows", () => {
     const o = chan("#o");
     const out = orderUnreadWindows({
       candidates: [m, o],
+      muted: {},
       unread: counts([[o, 1]]),
       // #m carries a mention but nothing unread — no jump target.
       mentions: counts([[m, 2]]),
       activityId: {},
     });
     expect(names(out)).toEqual(["#o"]);
+  });
+});
+
+// #1018 — a conversation the operator MUTED (#866) is not a stop on the
+// cycle. The mute is keyed by the FOLDED conversation, per-subject and
+// network-agnostic (`MutedTargets`), and expiry was already resolved by
+// the reader (`notificationPrefs()`), so the ordering takes the live map
+// and asks a pure membership question — no clock, no second fold.
+//
+// Badges and counters are NOT touched (#866 Q4): this filters the
+// NAVIGATION order only.
+
+describe("orderUnreadWindows — muted conversations (#1018)", () => {
+  it("skips a muted channel and lands on the next unread window", () => {
+    const noisy = chan("#noisy");
+    const quiet = chan("#quiet");
+    const out = orderUnreadWindows({
+      candidates: [noisy, quiet],
+      muted: { "#noisy": { until: null } },
+      unread: counts([
+        [noisy, 9],
+        [quiet, 1],
+      ]),
+      mentions: {},
+      // the muted channel is the OLDER activity, so without the filter it
+      // would head the list.
+      activityId: counts([
+        [noisy, 100],
+        [quiet, 200],
+      ]),
+    });
+    expect(names(out)).toEqual(["#quiet"]);
+  });
+
+  it("keys a muted QUERY on the PEER, never on own nick", () => {
+    const bob = query("bob");
+    const carol = query("carol");
+    const out = orderUnreadWindows({
+      candidates: [bob, carol],
+      // "vjt" is the operator's own nick — an inbound DM row carries it in
+      // `channel`, and keying on that would collapse every DM onto ONE mute
+      // entry. Muting own nick must silence NOTHING here.
+      muted: { vjt: { until: null } },
+      unread: counts([
+        [bob, 1],
+        [carol, 1],
+      ]),
+      mentions: {},
+      activityId: counts([
+        [bob, 100],
+        [carol, 200],
+      ]),
+    });
+    expect(names(out)).toEqual(["bob", "carol"]);
+
+    const outMutedPeer = orderUnreadWindows({
+      candidates: [bob, carol],
+      muted: { bob: { until: null } },
+      unread: counts([
+        [bob, 1],
+        [carol, 1],
+      ]),
+      mentions: {},
+      activityId: counts([
+        [bob, 100],
+        [carol, 200],
+      ]),
+    });
+    expect(names(outMutedPeer)).toEqual(["carol"]);
+  });
+
+  it("folds the window name against the stored key (a mute is case-insensitive, A-Z only)", () => {
+    const shouty = chan("#NoIsY");
+    const bracket = chan("#chan{1}");
+    const out = orderUnreadWindows({
+      candidates: [shouty, bracket],
+      // `#chan[1]` is a DIFFERENT conversation from `#chan{1}` — the fold
+      // touches `A-Z` only (#525), so the bracket window is NOT muted.
+      muted: { "#noisy": { until: null }, "#chan[1]": { until: null } },
+      unread: counts([
+        [shouty, 1],
+        [bracket, 1],
+      ]),
+      mentions: {},
+      activityId: {},
+    });
+    expect(names(out)).toEqual(["#chan{1}"]);
+  });
+
+  it("keeps skipping a muted window that carries a MENTION (#866 Q2: the mute wins)", () => {
+    const muted = chan("#muted");
+    const plain = chan("#plain");
+    const out = orderUnreadWindows({
+      candidates: [muted, plain],
+      muted: { "#muted": { until: null } },
+      unread: counts([
+        [muted, 1],
+        [plain, 1],
+      ]),
+      mentions: counts([[muted, 3]]),
+      activityId: {},
+    });
+    expect(names(out)).toEqual(["#plain"]);
+  });
+
+  it("returns empty when EVERY unread window is muted — the cycle is a no-op", () => {
+    const a = chan("#a");
+    const bob = query("bob");
+    const out = orderUnreadWindows({
+      candidates: [a, bob],
+      muted: { "#a": { until: null }, bob: { until: null } },
+      unread: counts([
+        [a, 1],
+        [bob, 1],
+      ]),
+      mentions: {},
+      activityId: {},
+    });
+    expect(out).toEqual([]);
+  });
+
+  it("tolerates a server that sends no muted_targets at all (cic ships ahead of the BEAM)", () => {
+    const a = chan("#a");
+    const out = orderUnreadWindows({
+      candidates: [a],
+      muted: undefined,
+      unread: counts([[a, 1]]),
+      mentions: {},
+      activityId: {},
+    });
+    expect(names(out)).toEqual(["#a"]);
+  });
+
+  it("does not skip a window whose mute has ELAPSED — the reader already dropped it", () => {
+    // `notificationPrefs()` (withLiveMutes) resolves expiry before the map
+    // reaches here, so an elapsed snooze arrives as an ABSENT key. This
+    // pins that the ordering adds no second clock of its own: an entry that
+    // is still present silences, whatever its `until` says.
+    const a = chan("#a");
+    const out = orderUnreadWindows({
+      candidates: [a],
+      muted: {},
+      unread: counts([[a, 1]]),
+      mentions: {},
+      activityId: {},
+    });
+    expect(names(out)).toEqual(["#a"]);
   });
 });
 

--- a/cicchetto/src/lib/activeWindows.ts
+++ b/cicchetto/src/lib/activeWindows.ts
@@ -1,11 +1,14 @@
 import { createMemo, untrack } from "solid-js";
 import { type ChannelKey, channelKey } from "./channelKey";
+import { isConversationMuted, windowMuteKey } from "./conversationMute";
 import { mentionCounts } from "./mentions";
 import { moduleRoot } from "./moduleRoot";
 import { channelsBySlug, networks } from "./networks";
+import { notificationPrefs } from "./notificationPrefs";
 import { queryWindowsByNetwork } from "./queryWindows";
 import { scrollbackByChannel } from "./scrollback";
 import { messagesUnread, selectedChannel, setSelectedChannel } from "./selection";
+import type { MutedTargets } from "./userSettings";
 
 // GH #235 — "jump to next active window" (irssi Alt+A).
 //
@@ -69,6 +72,17 @@ export type OrderInput = {
    * no local rows yet) — correctly the "oldest" activity.
    */
   activityId: Record<ChannelKey, number>;
+  /**
+   * The subject's muted conversations (#866), as the READER hands them over
+   * — `notificationPrefs()` has already dropped elapsed snoozes, so an
+   * entry present here silences and no clock is consulted below. #1018: a
+   * muted window is not a stop on the cycle. `undefined` (a BEAM older than
+   * this bundle) means "no mutes".
+   *
+   * Required, not optional: a door that forgets the mute is a compile error
+   * rather than a window that silently keeps stealing the jump.
+   */
+  muted: MutedTargets | undefined;
 };
 
 // Tier-0 predicate: a window is "priority" when it is a query (DM) OR
@@ -81,7 +95,8 @@ export function isPriorityWindow(w: ActiveWindow, mentions: Record<ChannelKey, n
   return w.kind === "query" || (mentions[key] ?? 0) > 0;
 }
 
-// Pure ordering. Filter to windows with unread activity, then sort:
+// Pure ordering. Filter to windows with unread activity that the operator
+// has not muted, then sort:
 //   1. tier — mention/highlight OR query (DM) come first (0), ordinary
 //      channel traffic second (1);
 //   2. activity time ascending — chronological, oldest activity first
@@ -89,7 +104,7 @@ export function isPriorityWindow(w: ActiveWindow, mentions: Record<ChannelKey, n
 //   3. flat (sidebar) index — stable tie-break for equal activity ids
 //      (e.g. two seed-only windows).
 export function orderUnreadWindows(input: OrderInput): ActiveWindow[] {
-  const { candidates, unread, mentions, activityId } = input;
+  const { candidates, unread, mentions, activityId, muted } = input;
   const ranked = candidates
     .map((w, flatIndex) => {
       const key = channelKey(w.networkSlug, w.channelName);
@@ -98,10 +113,16 @@ export function orderUnreadWindows(input: OrderInput): ActiveWindow[] {
         unread: unread[key] ?? 0,
         tier: isPriorityWindow(w, mentions) ? 0 : 1,
         activityId: activityId[key] ?? 0,
+        muted: isConversationMuted(muted, windowMuteKey(w)),
         flatIndex,
       };
     })
-    .filter((r) => r.unread > 0);
+    // #1018 — the mute drops the window from the CYCLE, and it beats the
+    // tier: a mention inside a muted room is still not a stop (#866 Q2,
+    // "the mute always wins"). Everything else about the window is
+    // untouched — its sidebar unread badge and the mention counters keep
+    // rendering exactly as before (#866 Q4).
+    .filter((r) => r.unread > 0 && !r.muted);
 
   ranked.sort((a, b) => {
     if (a.tier !== b.tier) return a.tier - b.tier;
@@ -178,6 +199,10 @@ const root = moduleRoot(() => {
       unread: messagesUnread(),
       mentions: mentionCounts(),
       activityId: buildActivityIds(),
+      // #1018 — read through `notificationPrefs()`, never the stored signal:
+      // that reader resolves an elapsed snooze, so a mute that ran out puts
+      // its window back on the cycle with no clock handling here.
+      muted: notificationPrefs().muted_targets,
     }),
   );
   return { activeWindows };

--- a/cicchetto/src/lib/conversationMute.ts
+++ b/cicchetto/src/lib/conversationMute.ts
@@ -1,0 +1,64 @@
+// #866 / #1018 — the per-conversation mute LOOKUP: how a conversation is
+// keyed into `NotificationPrefs.muted_targets`, and how membership is asked.
+//
+// Extracted here (from `pushTriggers.ts`, its first and until #1018 only
+// consumer) because three call sites now need the identical answer and a
+// second hand-rolled derivation is exactly how the DM case rots:
+//
+//   * `pushTriggers.shouldNotify`  — should this arriving row notify?
+//   * `activeWindows.orderUnreadWindows` — is this window a stop on the
+//     Alt+A / Ctrl+N-P / affordance cycle? (#1018)
+//   * `SettingsDrawer.muteCandidates` — which conversations does the picker
+//     offer, and which are already muted?
+//
+// Expiry is deliberately absent: the READER resolves it
+// (`notificationPrefs()` → `withLiveMutes` client-side,
+// `UserSettings.get_notification_prefs/1` server-side), so nothing here
+// needs a `now` and the push truth-table needs no clock column (#866 Q3).
+
+import { canonicalChannel } from "./channelKey";
+import type { MutedTargets } from "./userSettings";
+
+/**
+ * The key under which a conversation is muted: the FOLDED identifier of the
+ * thing an operator points at when they say "silence this tab" — the channel
+ * for a channel, the PEER for a DM.
+ *
+ * Never the `channel` field of a DM row: an inbound DM carries
+ * `channel = own_nick`, so keying on it collapses every DM onto ONE entry and
+ * muting one peer silences them all. Callers pass the peer explicitly.
+ *
+ * `canonicalChannel` (the mirror of `Identifier.canonical_target/1`) folds a
+ * nick exactly as it folds a channel — a sigil sits outside `A-Z` — which is
+ * why one fold serves both shapes. Per-subject and network-agnostic by
+ * design: `#grappa` on two networks is ONE mute (#866 Q5).
+ */
+export function conversationMuteKey(target: string): string {
+  return canonicalChannel(target);
+}
+
+/**
+ * The mute key of a sidebar WINDOW (#1018). For a query window `channelName`
+ * IS the peer nick — `activeWindows.windowCandidates` builds it from
+ * `qw.targetNick` — which is exactly the identifier the DM notify path folds,
+ * so ONE expression serves both kinds without ever touching a row's `channel`
+ * field. Structurally typed rather than importing `ActiveWindow`, to keep the
+ * mute lookup free of a dependency on the window projection.
+ */
+export function windowMuteKey(window: { channelName: string }): string {
+  return conversationMuteKey(window.channelName);
+}
+
+/**
+ * Is `key` (already folded via `conversationMuteKey`) muted?
+ *
+ * `Object.hasOwn`, not `muted[key] !== undefined`: the map arrives from
+ * `JSON.parse`, so it carries Object.prototype and a peer legitimately nicked
+ * `constructor` or `toString` would otherwise read as muted.
+ *
+ * `undefined` (a BEAM older than this bundle, #618) means "no mutes", never
+ * "everything muted" — the tolerant direction.
+ */
+export function isConversationMuted(muted: MutedTargets | undefined, key: string): boolean {
+  return muted !== undefined && Object.hasOwn(muted, key);
+}

--- a/cicchetto/src/lib/pushTriggers.ts
+++ b/cicchetto/src/lib/pushTriggers.ts
@@ -24,6 +24,7 @@
 
 import { type MessageKind, NOTIFY_KINDS } from "./api";
 import { canonicalChannel } from "./channelKey";
+import { conversationMuteKey, isConversationMuted } from "./conversationMute";
 import { matchesWatchlist } from "./mentionMatch";
 import { asciiFold, nickEquals } from "./nickEquals";
 import type { NotificationPrefs } from "./userSettings";
@@ -92,7 +93,7 @@ export function shouldNotify(
   // including a direct mention (vjt's Q2: the mute always wins, because the
   // polite default for "I silenced this room" is that it stays silent).
   // That is why it sits here and not inside the two branches.
-  if (isMuted(prefs, conversationKey(message, isDm))) return false;
+  if (isConversationMuted(prefs.muted_targets, conversationKey(message, isDm))) return false;
 
   if (isDm) {
     return dmMatch(message, prefs);
@@ -100,29 +101,18 @@ export function shouldNotify(
   return channelMatch(message, prefs, ownNick, patterns);
 }
 
-// The identity of the CONVERSATION the row belongs to — the thing an
-// operator points at when they say "mute this tab". For a channel that is
-// the channel; for a DM it is the PEER, never `message.channel`, which an
-// inbound DM sets to own_nick (so keying on it would collapse every DM
-// onto one mute). Same fold as the two whitelists: `canonicalChannel` is
-// the mirror of `Identifier.canonical_target/1` and folds a nick exactly
-// as it folds a channel.
-function conversationKey(message: ShouldNotifyMessage, isDm: boolean): string {
-  return canonicalChannel(isDm ? message.sender : message.channel);
-}
-
-// `until` is deliberately NOT read here. Expiry belongs to the READER
-// (`notificationPrefs()` client-side, `get_notification_prefs/1` on the
-// server) so this predicate stays pure and the shared truth-table needs no
-// `now` column — vjt's Q3. A stored-but-elapsed mute reaching this point
-// still silences; that only happens to a caller that bypassed the reader.
+// Which CONVERSATION this row belongs to, in mute terms: the channel for a
+// channel row, the PEER for a DM — never `message.channel`, which an inbound
+// DM sets to own_nick (so keying on it would collapse every DM onto one
+// mute). The fold itself, and the membership test above, live in
+// `conversationMute.ts` — shared with the #1018 next-active cycle and the
+// settings picker so the three can never disagree on a key.
 //
-// `Object.hasOwn`, not `muted[key] !== undefined`: the map arrives from
-// `JSON.parse`, so it carries Object.prototype and a peer legitimately
-// nicked `constructor` or `toString` would otherwise read as muted.
-function isMuted(prefs: NotificationPrefs, key: string): boolean {
-  const muted = prefs.muted_targets;
-  return muted !== undefined && Object.hasOwn(muted, key);
+// `until` is deliberately not read on this path: expiry belongs to the
+// READER, which is what keeps this predicate pure `/4` and the shared
+// truth-table free of a `now` column (#866 Q3).
+function conversationKey(message: ShouldNotifyMessage, isDm: boolean): string {
+  return conversationMuteKey(isDm ? message.sender : message.channel);
 }
 
 function dmMatch(message: ShouldNotifyMessage, prefs: NotificationPrefs): boolean {

--- a/compose.yaml
+++ b/compose.yaml
@@ -183,7 +183,17 @@ services:
     volumes:
       - ./cicchetto:/app
       - ./runtime/bun-cache:/cache
-      - ./runtime/cicchetto-dist:/app/dist
+      # #1020 — vite empties `dist/` before it writes, and `./runtime/
+      # cicchetto-dist` is the dir the BEAM serves PER REQUEST, so pointing
+      # this mount at it made every deploy serve an empty SPA for the whole
+      # build. The deploy wrappers (scripts/deploy.sh, scripts/deploy-cic.sh,
+      # infra/docker/deploy.sh) set CIC_BUILD_OUT to a staging sibling and
+      # rename it into place afterwards — one env var rather than a second
+      # service, so there is still ONE build definition.
+      # The DEFAULT stays the served dir on purpose: it is what a bare
+      # `compose --profile prod up` uses via grappa's depends_on, and there
+      # nothing is serving yet — no live server, no window to protect.
+      - ${CIC_BUILD_OUT:-./runtime/cicchetto-dist}:/app/dist
     tmpfs:
       # UID/GID must track the `user:` field above — bun writes to
       # HOME=/tmp, so a hardcoded uid=1000 tmpfs while the process runs

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -33326,3 +33326,63 @@ so the surfaced error is unforgeable proof the target survived cic's parser, the
 channel door and `Client.send_admin/2`. 423 and 447 stay unit-tested — the first
 needs a leaf with no `A:` line, the second a restricted-class user, and neither
 is reachable without reshaping the shared testnet for one spec.
+
+## 2026-08-07 — #1020: the cic build emptied the dist it was serving, so the build moved next door
+
+`--emptyOutDir` was never the defect. Vite refuses to clean an out-of-root
+`outDir` without explicit consent, and `outDir` is out of root by design (root
+is `cicchetto/`, the bundle lands in `runtime/cicchetto-dist` so Docker and the
+jail share one server-side anchor). The cleanup is *wanted*: vite emits
+content-hashed chunks, and without it every deploy accretes the previous
+bundle's assets forever and the dist stops being a truthful picture of what is
+served. **The timing was the defect.** Vite empties `outDir` BEFORE it writes,
+and `Grappa.Cic.Bundle.root/0` resolves that same directory PER REQUEST
+(`Plug.Static` + the SPA history-fallback), so every deploy blanked the SPA for
+the whole build — and a build that FAILED left it blanked, because `set -eu`
+walked away from an already-emptied tree.
+
+The fix is the shape `infra/packaging/build.sh` already had: build into a
+sibling nobody is serving, then rename it in. One implementation,
+`infra/lib/cic_dist.sh`, sourced by all three serving substrates — the jail's
+POSIX `/bin/sh` body, the native-Linux bash script, and the three compose
+launchers. `infra/packaging/build.sh` needs no change; it is the shape being
+generalised.
+
+**The swap has a window, and it is ENOENT rather than empty.** There is no
+portable two-directory exchange (`RENAME_EXCHANGE` is Linux-only and out of
+reach from `sh`), so the promote is two renames with the served path absent
+between them — two syscalls against the whole vite build it replaces. A client
+gets the old bundle or the new one, never a mix. Die mid-swap and both complete
+trees survive as `.prev` and `.next`; only a crash inside the microsecond gap
+leaves the served path missing, and re-running the build fixes it. A symlink
+flip WOULD have been atomic and was rejected for a concrete reason: the served
+path is TRACKED (`runtime/cicchetto-dist/.gitkeep`), and turning a tracked
+directory into a symlink is a type change git reports as dirt — the same class
+of dirty tree that once stalled a deploy's `git pull --ff-only` on a deleted
+`.gitkeep`.
+
+That `.gitkeep` moved from a repair to a property. Three scripts used to
+`touch` it back after the build because `emptyOutDir` ate it; the promote now
+plants it in the staged tree BEFORE the rename, so the tracked path is never
+absent at all rather than being restored shortly after it goes missing.
+
+**The Docker seam is a defaulted variable, on purpose.** The compose oneshot
+writes to whatever is bind-mounted at `/app/dist`, so the mount source became
+`${CIC_BUILD_OUT:-./runtime/cicchetto-dist}`. The deploy wrappers set it to the
+staging sibling and promote afterwards; the DEFAULT stays the served dir
+because a bare `compose --profile prod up` reaches the build through grappa's
+`depends_on` with nobody to promote — and there nothing is serving yet, so
+there is no window to protect. A second compose service would have been the
+alternative and was rejected: two build definitions is exactly the drift
+`cic_version_export_test.bats` exists to police.
+
+**What was proved and what was not.** The jail and native-Linux scripts are
+RUN in bats against a fake vite that empties its `outDir` first and records
+what the served directory holds at that instant — the assertion is on the
+timing, not on any string, and it reads MISSING on the parent commit. The
+Docker substrate has structure only (the compose mount pin, plus a scan that
+every launcher aims the build at `CIC_BUILD_OUT` and promotes): the build
+happens inside a container, so no bats can observe it. Nobody watched a real
+jail serve an empty dist during a build either — the window is read out of
+`--emptyOutDir` plus serve-at-request-time, and it is stated as such rather
+than dressed up as an incident.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -33386,3 +33386,43 @@ happens inside a container, so no bats can observe it. Nobody watched a real
 jail serve an empty dist during a build either — the window is read out of
 `--emptyOutDir` plus serve-at-request-time, and it is stated as such rather
 than dressed up as an incident.
+## 2026-08-07 — #1018: the mute reaches the next-active ordering, and the key gets ONE home
+
+vjt, on IRC: *"una finestra in mute dovrebbe essere esclusa dal giro che fa il
+bottone alt+a"*. #866 stored the per-conversation mute; #235 owns the
+next-active ordering. Nothing joined them, so a busy muted channel kept
+stealing the jump the operator uses to reach the windows they actually read.
+
+**Where the filter went, and why not somewhere cheaper.** `activeWindows.ts` is
+already the ONE ordering behind all three doors (Alt+A, Ctrl+N/P, the on-screen
+affordance), so the change is a single new input on `orderUnreadWindows` and all
+three inherit it — no forked ordering, which is exactly what #235 unified away.
+The input is REQUIRED, not optional: a future door that forgets the mute is a
+compile error rather than a window that silently keeps stealing the jump. The
+alternative — filtering the candidate list at the memo — was rejected for the
+opposite reason: it would have been a filter a caller can quietly omit.
+
+**The key is the trap, so the derivation now has one home.** The mute is keyed
+by the FOLDED conversation: the channel for a channel, the PEER for a DM. Get
+the DM case wrong and every DM collapses onto one entry, silencing an arbitrary
+peer. That derivation existed in `pushTriggers.ts` (private) and, open-coded, in
+the settings picker; #1018 would have made three. `lib/conversationMute.ts` now
+owns all of it — `conversationMuteKey` (the fold), `windowMuteKey` (the window
+shape, structurally typed so the mute lookup does not depend on the window
+projection), `isConversationMuted` (the `Object.hasOwn` membership test, which
+is what keeps a peer nicked `constructor` from reading as muted). The three
+consumers ask the same question of the same function.
+
+**No clock.** Expiry stays where #866 Q3 put it — in the READER. The memo passes
+`notificationPrefs().muted_targets`, which has already dropped elapsed snoozes,
+so an expired mute puts its window back on the cycle with no `now` anywhere in
+the ordering.
+
+**Scope, deliberately narrow.** #866 Q4 ruled that a muted target still COUNTS;
+this extends the mute into navigation only. A muted window keeps its sidebar
+unread badge and its mention counters — the e2e asserts the badge is still there
+after the cycle has skipped past it. Consequence accepted, not a scope leak: the
+affordance's own count and auto-hide DO drop the muted window, because they read
+the same ordered list. A button that says "2" and cycles through 1 would be the
+lie. And when every unread window is muted the cycle is a no-op (Q2), which the
+empty list gives for free.

--- a/infra/docker/deploy.sh
+++ b/infra/docker/deploy.sh
@@ -704,13 +704,19 @@ cmd_update() {
 	}
 
 	substrate_cic() {
-		mkdir -p runtime/cicchetto-dist
+		# #1020 — build into a staging sibling and rename it in. The BEAM
+		# serves runtime/cicchetto-dist per request and vite empties its
+		# outDir first, so building in place blanked the SPA for the whole
+		# build — on a box that is UPDATING, i.e. one that is already live.
+		local cic_served="runtime/cicchetto-dist"
+		local cic_build_out
+		cic_build_out="$(cic_dist_docker_stage "$cic_served")"
 		# AFTER substrate_pull, so the bundle carries the version the box is
 		# moving TO, not the one it is on (the pull may have bumped VERSION).
 		export_cic_version
 		say "Rebuilding the cicchetto bundle"
-		"${COMPOSE[@]}" --profile prod run --rm cicchetto-build
-		touch runtime/cicchetto-dist/.gitkeep
+		CIC_BUILD_OUT="$cic_build_out" "${COMPOSE[@]}" --profile prod run --rm cicchetto-build
+		cic_dist_promote "$cic_served" "$cic_build_out"
 	}
 
 	substrate_migrate() {
@@ -745,6 +751,12 @@ EOF
 
 	# shellcheck source=infra/lib/deploy_common.sh
 	. "$REPO_ROOT/infra/lib/deploy_common.sh"
+	# #1020 build-beside-then-swap, used by substrate_cic above. Sourced HERE
+	# and not at the top of the file: only source mode builds a bundle (the
+	# release path ships a prebuilt image), so the get.sh mirror — which
+	# reproduces exactly what a checkout-less host sources — needs no new file.
+	# shellcheck source=infra/lib/cic_dist.sh
+	. "$REPO_ROOT/infra/lib/cic_dist.sh"
 	# Empty-array-safe expansion for bash 3.2 under `set -u`.
 	deploy_main ${libargs[@]+"${libargs[@]}"}
 }

--- a/infra/freebsd/jail_cic_build.sh
+++ b/infra/freebsd/jail_cic_build.sh
@@ -11,11 +11,18 @@
 # /usr/local/www/cic symlink, and no nginx in the jail at all: the m42
 # HOST vhost proxies straight to the BEAM.
 #
-# `--outDir ../runtime/cicchetto-dist` aligns the jail with the Docker
-# substrate (`compose.yaml` bind-mounts `./runtime/cicchetto-dist:
-# /app/dist` so the same final path holds the bundle on host). The
-# shared path is what `Grappa.Cic.Bundle.@bundle_path` reads
-# unconditionally — both substrates, one server-side anchor.
+# `runtime/cicchetto-dist` aligns the jail with the Docker substrate
+# (`compose.yaml` bind-mounts it into the build oneshot so the same final
+# path holds the bundle on host). The shared path is what
+# `Grappa.Cic.Bundle.@bundle_path` reads unconditionally — both
+# substrates, one server-side anchor.
+#
+# #1020: vite does NOT write there directly. The BEAM serves that
+# directory per REQUEST, and `--emptyOutDir` wiped it at the START of the
+# build, so the SPA was unloadable for the whole build and stayed broken
+# if the build failed. The build now targets a staging sibling and
+# infra/lib/cic_dist.sh renames it into place — see that file for the
+# swap's failure window.
 
 set -eu
 
@@ -24,7 +31,11 @@ set -eu
 exec su -l grappa -c '
 set -eu
 cd /home/grappa/grappa/cicchetto
-mkdir -p ../runtime/cicchetto-dist
+# #1020 — build-beside-then-swap. Sourced (not executed) so the promote
+# runs in THIS shell, as grappa, with the same relative cwd the build uses.
+. ../infra/lib/cic_dist.sh
+served=../runtime/cicchetto-dist
+staged="$(cic_dist_staging "$served")"
 # #538/#652 — vite bakes GRAPPA_VERSION into <meta cicchetto-version>. Derive it
 # from the repo-root VERSION file via the POSIX version.sh (this jail runs
 # /bin/sh + npm, no bash/bun port). Single source of truth; same env channel every cic build
@@ -48,8 +59,9 @@ else
 	npm install >"$log" 2>&1 || { tail -20 "$log"; exit 1; }
 fi
 tail -3 "$log"
-npm run build -- --outDir ../runtime/cicchetto-dist --emptyOutDir >"$log" 2>&1 || { tail -30 "$log"; exit 1; }
+npm run build -- --outDir "$staged" --emptyOutDir >"$log" 2>&1 || { tail -30 "$log"; exit 1; }
 tail -8 "$log"
+cic_dist_promote "$served" "$staged"
 echo "--- runtime/cicchetto-dist contents ---"
-ls -la ../runtime/cicchetto-dist/
+ls -la "$served"/
 '

--- a/infra/lib/cic_dist.sh
+++ b/infra/lib/cic_dist.sh
@@ -1,0 +1,122 @@
+# shellcheck shell=sh
+# infra/lib/cic_dist.sh — build BESIDE the served cic bundle, then swap (#1020).
+#
+# Every substrate used to point vite's `outDir` straight at the directory the
+# running BEAM serves (`Grappa.Cic.Bundle.root/0` → Plug.Static + the SPA
+# history-fallback, resolved per REQUEST). Vite empties `outDir` before it
+# writes anything, so the served tree went EMPTY at the start of the build and
+# stayed incomplete until it finished: for that whole window the SPA did not
+# load at all, and a build that FAILED left it empty for good.
+#
+# `--emptyOutDir` is not the defect — the cleanup is wanted (vite emits
+# content-hashed chunks; without it every deploy accretes the previous bundle's
+# assets forever) and the flag is only vite's consent prompt for an out-of-root
+# `outDir`. The TIMING is the defect. So: build into a sibling nobody serves,
+# then rename it into place.
+#
+# This file is SOURCED, never executed — POSIX sh, no `local`, no bashisms, so
+# the FreeBSD jail's /bin/sh build body can source it as-is (same contract as
+# beam_wait.sh / deploy_common.sh).
+#
+# Consumers (one algorithm, no per-substrate copy):
+#   - infra/freebsd/jail_cic_build.sh   npm + vite, inside `su -l grappa`
+#   - infra/linux/cic_build.sh          bun + vite, via `sudo -u grappa`
+#   - scripts/deploy.sh                 the compose oneshot (dev/operator)
+#   - scripts/deploy-cic.sh             the compose oneshot, cic-only deploy
+#   - infra/docker/deploy.sh            the compose oneshot, standalone install
+#
+# infra/packaging/build.sh is NOT a consumer: it already builds into a staging
+# tree under `staging/usr/share/grappa/` that no server is serving. It is the
+# shape this lib generalises.
+#
+# ## The swap, and its failure window
+#
+# `mv` is rename(2) — atomic per call, but there is no portable two-directory
+# EXCHANGE (Linux's RENAME_EXCHANGE is not reachable from sh, and FreeBSD has
+# no equivalent), so the promote is two renames:
+#
+#     mv <served> <served>.prev     # served path momentarily ABSENT
+#     mv <staged> <served>
+#
+# Between them the served path does not EXIST — Plug.Static's `from:` misses
+# and requests fall through to the SPA history-fallback / 404. That window is
+# two syscalls wide against the whole vite build it replaces, and it is
+# ENOENT rather than a half-written tree, so a client either gets the old
+# bundle or the new one, never a mix of both.
+#
+# Die mid-swap and nothing is lost: `<served>.prev` holds the complete previous
+# bundle and `<served>.next` the complete new one; whichever rename landed, the
+# next run starts by clearing `.prev` and re-staging `.next`. Only a crash in
+# the ~microsecond gap leaves the served path missing, and the fix is to re-run
+# the build.
+#
+# Both paths are siblings inside `runtime/` on purpose: rename(2) cannot cross
+# filesystems, and a cross-device `mv` degrades to copy-then-delete, which is
+# neither atomic nor fast. A consumer that stages somewhere else loses that.
+
+# Echo the staging path for a served bundle directory. ONE derivation, because
+# every consumer needs the name twice — once to aim the builder at it, once to
+# promote it — and two spellings of it is a silent no-op deploy.
+cic_dist_staging() {
+	if [ -z "${1:-}" ]; then
+		echo "cic_dist_staging: refusing to derive a staging path from an empty served path" >&2
+		return 1
+	fi
+	printf '%s.next\n' "$1"
+}
+
+# Prepare the staging dir the compose oneshot bind-mounts, and echo it in the
+# `./`-prefixed shape compose needs (a source with no `./` or `/` is parsed as
+# a NAMED VOLUME, not a host path). The dir must pre-exist or Docker creates it
+# root-owned and the UID-1000 container cannot write vite's output into it.
+cic_dist_docker_stage() {
+	_cic_staged="$(cic_dist_staging "$1")" || return 1
+	rm -rf "${_cic_staged}"
+	mkdir -p "${_cic_staged}"
+	printf './%s\n' "${_cic_staged}"
+}
+
+# Swap a freshly built bundle into the served path. Leaves the served tree
+# UNTOUCHED on any refusal — callers run under `set -e`, so an aborted build
+# never reaches here and the previous bundle keeps serving.
+cic_dist_promote() {
+	_cic_served="${1:-}"
+	_cic_staged="${2:-}"
+	if [ -z "${_cic_served}" ] || [ -z "${_cic_staged}" ]; then
+		echo "cic_dist_promote: served and staged paths are both required" >&2
+		return 1
+	fi
+
+	# A vite build can exit 0 having written nothing reachable (wrong outDir,
+	# a plugin that swallowed its own failure). Promoting that would swap an
+	# EMPTY tree into the served path — the exact outage this lib exists to
+	# stop, just moved later. index.html is the one file the server must find:
+	# Bundle.current_hash/0 parses it and the history-fallback serves it.
+	if [ ! -f "${_cic_staged}/index.html" ]; then
+		echo "cic_dist_promote: ${_cic_staged}/index.html is missing — refusing to promote a tree that is not a bundle; the previous one keeps serving" >&2
+		return 1
+	fi
+
+	# `runtime/cicchetto-dist/.gitkeep` is TRACKED (it bakes the bind-mount
+	# target so a fresh clone does not get it auto-created root-owned — see
+	# .gitignore). It belongs to the tree that LANDS, planted BEFORE the swap
+	# rather than restored after it: a post-hoc `touch` is a repair with its
+	# own window, and the tracked path missing for even an instant is what
+	# left a `D .gitkeep` stalling `git pull --ff-only` on a deploy once.
+	touch "${_cic_staged}/.gitkeep"
+
+	_cic_prev="${_cic_served}.prev"
+	rm -rf "${_cic_prev}"
+	# `mv a b` where b is an EXISTING DIRECTORY moves a INSIDE b. The served
+	# path must therefore be gone — not emptied, GONE — before the second
+	# rename, or the new bundle lands at <served>/<staged-basename>/ and the
+	# server keeps serving the old one with no error anywhere.
+	if [ -d "${_cic_served}" ]; then
+		mv "${_cic_served}" "${_cic_prev}"
+	fi
+	mv "${_cic_staged}" "${_cic_served}"
+	# Only now is the previous bundle disposable. Dropping it is what keeps
+	# `--emptyOutDir`'s stale-chunk cleanup: the old content-hashed assets go
+	# with the old directory instead of accreting in the served one.
+	rm -rf "${_cic_prev}"
+}

--- a/infra/linux/cic_build.sh
+++ b/infra/linux/cic_build.sh
@@ -19,6 +19,17 @@ CIC_DIR="${REPO_ROOT}/cicchetto"
 OUT_DIR="${REPO_ROOT}/runtime/cicchetto-dist"
 GRAPPA_USER="${GRAPPA_USER:-grappa}"
 
+# #1020 — OUT_DIR is what the running BEAM serves, per request. Vite must not
+# write into it: it builds into a staging sibling and the shared lib renames
+# that into place afterwards. Sourced from the SCRIPT's own dir, not from
+# REPO_ROOT — the lib ships with this script, and the arg only names the
+# checkout the bundle is built FROM.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CIC_DIST_LIB="${SCRIPT_DIR}/../lib/cic_dist.sh"
+# shellcheck source=infra/lib/cic_dist.sh
+. "${CIC_DIST_LIB}"
+STAGE_DIR="$(cic_dist_staging "${OUT_DIR}")"
+
 # #538/#652 — vite bakes GRAPPA_VERSION into <meta cicchetto-version>. Derive it
 # from the repo-root VERSION file (the single source of truth) via version.sh; `sudo -u`
 # scrubs the env, so it is injected into the run_as_grappa command string below.
@@ -33,19 +44,22 @@ run_as_grappa() {
 	sudo -u "${GRAPPA_USER}" -H bash -c "export PATH=\"\$HOME/.local/bin:\$HOME/.asdf/shims:\$PATH\"; $1"
 }
 
-echo "[cic_build] bun install && bun run build (outDir=${OUT_DIR})"
+echo "[cic_build] bun install && bun run build (outDir=${STAGE_DIR} → ${OUT_DIR})"
 # Buffer output and only show it on failure — a clean build is noisy
 # (vite + tsc output) and the interesting signal is the exit code;
 # same pipefail-avoidance lesson as jail_cic_build.sh's header.
 log="$(mktemp)"
 trap 'rm -f "${log}"' EXIT
-if ! run_as_grappa "export GRAPPA_VERSION='${GRAPPA_VERSION}'; cd '${CIC_DIR}' && bun install && bun run build -- --outDir '${OUT_DIR}' --emptyOutDir" >"${log}" 2>&1; then
+if ! run_as_grappa "export GRAPPA_VERSION='${GRAPPA_VERSION}'; cd '${CIC_DIR}' && bun install && bun run build -- --outDir '${STAGE_DIR}' --emptyOutDir" >"${log}" 2>&1; then
 	echo "[cic_build] ERROR: build failed — output:" >&2
 	cat "${log}" >&2
 	exit 1
 fi
-# Vite's `emptyOutDir` wipes .gitkeep on every build. Restore the
-# tracked placeholder so a cold deploy leaves the worktree clean.
-run_as_grappa "touch '${OUT_DIR}/.gitkeep'"
+# Swap as grappa, like every other step here: the renames need write on
+# runtime/, and doing them as root would plant a root-owned .gitkeep inside a
+# grappa-owned tree. The tracked placeholder is planted by the promote itself
+# now, so the post-build `touch` this replaces is gone — it only ever existed
+# to undo the in-place wipe.
+run_as_grappa ". '${CIC_DIST_LIB}'; cic_dist_promote '${OUT_DIR}' '${STAGE_DIR}'"
 
 echo "[cic_build] done — ${OUT_DIR}"

--- a/scripts/deploy-cic.sh
+++ b/scripts/deploy-cic.sh
@@ -29,6 +29,8 @@ set -euo pipefail
 
 # shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
+# shellcheck source=infra/lib/cic_dist.sh
+. "$(dirname "$0")/../infra/lib/cic_dist.sh"
 
 # #364 docker S10: assert main-checkout + main-branch BEFORE the dist
 # rebuild swaps the on-disk bundle nginx serves. Pre-fix this script had
@@ -39,7 +41,11 @@ require_main_checkout "deploy-cic.sh"
 
 cd "$REPO_ROOT"
 
-mkdir -p runtime/cicchetto-dist
+# #1020 — build into a staging sibling, NOT into the dir the live BEAM is
+# serving. CIC_BUILD_OUT is scoped to the build command so the rest of this
+# script (and any later compose call) sees the normal mount.
+CIC_SERVED="runtime/cicchetto-dist"
+CIC_BUILD_OUT="$(cic_dist_docker_stage "$CIC_SERVED")"
 
 # #538 — derive the single-source version for the cic build. The
 # cicchetto-build container mounts only ./cicchetto, so it can't read the repo
@@ -47,11 +53,10 @@ mkdir -p runtime/cicchetto-dist
 GRAPPA_VERSION="$("$REPO_ROOT/infra/packaging/version.sh")"
 export GRAPPA_VERSION
 echo "Building cicchetto dist..."
-docker compose "${COMPOSE_ARGS[@]}" --profile prod run --rm cicchetto-build
-# Vite's `emptyOutDir` wipes .gitkeep on every build (the tracked
-# placeholder is bait for fresh-clone Docker auto-mkdir-as-root —
-# see .gitignore L44-46). Restore it so `git status` stays clean.
-touch runtime/cicchetto-dist/.gitkeep
+CIC_BUILD_OUT="$CIC_BUILD_OUT" docker compose "${COMPOSE_ARGS[@]}" --profile prod run --rm cicchetto-build
+# Swap the finished bundle in. The tracked .gitkeep is planted by the promote,
+# so the post-build `touch` that used to undo vite's wipe is gone.
+cic_dist_promote "$CIC_SERVED" "$CIC_BUILD_OUT"
 
 echo "Notifying grappa of new bundle hash..."
 # Container `curl` against loopback inside the grappa pod —

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -32,6 +32,8 @@ set -euo pipefail
 
 # shellcheck source=scripts/_lib.sh
 . "$(dirname "$0")/_lib.sh"
+# shellcheck source=infra/lib/cic_dist.sh
+. "$(dirname "$0")/../infra/lib/cic_dist.sh"
 
 # #364 docker S10: assert main-checkout + main-branch BEFORE any side
 # effect (the git pull below mutates REPO_ROOT). in_container's own
@@ -134,17 +136,24 @@ substrate_cic() {
 	# Refresh cicchetto SPA dist into ./runtime/cicchetto-dist. Host
 	# bind-mount (not a named volume) so the container UID can write into a
 	# dir that already exists with the right ownership.
-	mkdir -p runtime/cicchetto-dist
+	#
+	# #1020 — the build lands in a staging sibling and is RENAMED into the
+	# served dir on success: vite empties its outDir first, and the BEAM
+	# serves runtime/cicchetto-dist per request, so building in place served
+	# an empty SPA for the whole build (and forever, if the build failed).
+	local cic_served="runtime/cicchetto-dist"
+	local cic_build_out
+	cic_build_out="$(cic_dist_docker_stage "$cic_served")"
 	# #538 — derive the single-source version for the cic build. The
 	# cicchetto-build container mounts only ./cicchetto, so it can't read the
 	# repo root; pass GRAPPA_VERSION (from the VERSION file, #652) through the env.
 	GRAPPA_VERSION="$("$REPO_ROOT/infra/packaging/version.sh")"
 	export GRAPPA_VERSION
 	echo "Building cicchetto dist..."
-	docker compose "${COMPOSE_ARGS[@]}" --profile prod run --rm cicchetto-build
-	# Vite's emptyOutDir wipes .gitkeep on every build; restore it so
-	# `git status` stays clean.
-	touch runtime/cicchetto-dist/.gitkeep
+	CIC_BUILD_OUT="$cic_build_out" docker compose "${COMPOSE_ARGS[@]}" --profile prod run --rm cicchetto-build
+	# The promote plants the tracked .gitkeep in the tree that lands, so the
+	# post-build `touch` that used to undo vite's wipe is gone.
+	cic_dist_promote "$cic_served" "$cic_build_out"
 }
 
 substrate_migrate() {

--- a/test/infra/cic_dist_swap_test.bats
+++ b/test/infra/cic_dist_swap_test.bats
@@ -1,0 +1,440 @@
+#!/usr/bin/env bats
+#
+# #1020 — a cic build must NEVER empty the directory a running server is
+# serving. Every substrate used to aim vite's `outDir` straight at
+# `runtime/cicchetto-dist`, which the BEAM resolves PER REQUEST
+# (Grappa.Cic.Bundle.root/0 → Plug.Static + the SPA history-fallback), and
+# vite empties `outDir` BEFORE it writes: the served tree was blank for the
+# whole build and stayed blank if the build failed.
+#
+# What makes these tests able to go red, rather than mirrors of the fix: the
+# fake builders below EMULATE vite (empty the outDir first, write the bundle
+# last) and, at the most dangerous instant — right after the wipe — record
+# what the SERVED directory contains. On the parent commit outDir IS the
+# served dir, so that recording reads MISSING and the assertion fails. It is
+# a property of the timing, not of any string in the script.
+#
+# Coverage, and its limit, stated plainly:
+#   * infra/lib/cic_dist.sh          exercised directly (the swap semantics)
+#   * infra/freebsd/jail_cic_build.sh  RUN, with su + npm stubbed  (prod)
+#   * infra/linux/cic_build.sh         RUN, with sudo + bun stubbed
+#   * the Docker substrate             STRUCTURE only — the build happens
+#     inside a container against a compose bind mount, so no bats can run it.
+#     Pinned instead: compose.yaml's mount source is the CIC_BUILD_OUT seam,
+#     and every compose launcher sets it on the build command and promotes
+#     afterwards. Nothing here proves a real container wrote where we think.
+
+load ../bats_helpers
+
+REPO_SRC=""
+
+setup() {
+    REPO_SRC="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    LIB="$REPO_SRC/infra/lib/cic_dist.sh"
+
+    SERVED="$BATS_TEST_TMPDIR/runtime/cicchetto-dist"
+    STAGED="$SERVED.next"
+    mkdir -p "$SERVED/assets"
+}
+
+# A served tree that is complete and CURRENTLY BEING SERVED: index.html, one
+# content-hashed chunk, and the tracked placeholder.
+seed_served_bundle() {
+    mkdir -p "$SERVED/assets"
+    printf 'OLD\n' > "$SERVED/index.html"
+    printf 'old chunk\n' > "$SERVED/assets/index-oldhash.js"
+    touch "$SERVED/.gitkeep"
+}
+
+# A finished build waiting to be promoted.
+seed_staged_bundle() {
+    mkdir -p "$STAGED/assets"
+    printf 'NEW\n' > "$STAGED/index.html"
+    printf 'new chunk\n' > "$STAGED/assets/index-newhash.js"
+}
+
+# ======================================================================
+# infra/lib/cic_dist.sh — the swap itself
+# ======================================================================
+
+@test "staging: the path is derived once, beside the served dir" {
+    # shellcheck source=/dev/null
+    . "$LIB"
+    run cic_dist_staging /srv/grappa/runtime/cicchetto-dist
+    [ "$status" -eq 0 ]
+    [ "$output" = "/srv/grappa/runtime/cicchetto-dist.next" ]
+}
+
+@test "staging: an empty served path is refused, not turned into rm -rf .next" {
+    # shellcheck source=/dev/null
+    . "$LIB"
+    run cic_dist_staging ""
+    [ "$status" -ne 0 ]
+}
+
+@test "promote: the served tree goes complete-old to complete-new" {
+    # shellcheck source=/dev/null
+    . "$LIB"
+    seed_served_bundle
+    seed_staged_bundle
+
+    run cic_dist_promote "$SERVED" "$STAGED"
+    [ "$status" -eq 0 ]
+
+    [ "$(cat "$SERVED/index.html")" = "NEW" ]
+    [ -f "$SERVED/assets/index-newhash.js" ]
+    # The stale-chunk cleanup --emptyOutDir used to provide, preserved: the
+    # previous content-hashed assets leave with the previous directory.
+    refute test -f "$SERVED/assets/index-oldhash.js"
+    # No debris: a leftover .next would be promoted blind by the next run,
+    # a leftover .prev would grow one dead bundle per deploy.
+    refute test -e "$STAGED"
+    refute test -e "$SERVED.prev"
+}
+
+@test "promote: the tracked .gitkeep is in the tree that LANDS" {
+    # shellcheck source=/dev/null
+    . "$LIB"
+    seed_served_bundle
+    seed_staged_bundle
+    refute test -f "$STAGED/.gitkeep"
+
+    run cic_dist_promote "$SERVED" "$STAGED"
+    [ "$status" -eq 0 ]
+    # Not restored afterwards — present the instant the tree becomes the
+    # served one, so `git status` never sees `D runtime/cicchetto-dist/.gitkeep`.
+    [ -f "$SERVED/.gitkeep" ]
+}
+
+@test "promote: a staged tree with no index.html is refused and the old bundle keeps serving" {
+    # shellcheck source=/dev/null
+    . "$LIB"
+    seed_served_bundle
+    mkdir -p "$STAGED/assets"
+    printf 'orphan chunk\n' > "$STAGED/assets/index-newhash.js"
+
+    run cic_dist_promote "$SERVED" "$STAGED"
+    [ "$status" -ne 0 ]
+    [ "$(cat "$SERVED/index.html")" = "OLD" ]
+    [ -f "$SERVED/assets/index-oldhash.js" ]
+}
+
+@test "promote: the new bundle does not land NESTED inside the served dir" {
+    # `mv a b` where b is an existing DIRECTORY moves a INSIDE b. That failure
+    # is silent — the server keeps serving the old bundle and every step
+    # reports success — so it gets its own case rather than riding on the
+    # content assertions above.
+    # shellcheck source=/dev/null
+    . "$LIB"
+    seed_served_bundle
+    seed_staged_bundle
+
+    run cic_dist_promote "$SERVED" "$STAGED"
+    [ "$status" -eq 0 ]
+    refute test -e "$SERVED/cicchetto-dist.next"
+}
+
+@test "promote: a served dir that does not exist yet is created by the swap" {
+    # shellcheck source=/dev/null
+    . "$LIB"
+    rm -rf "$SERVED"
+    seed_staged_bundle
+
+    run cic_dist_promote "$SERVED" "$STAGED"
+    [ "$status" -eq 0 ]
+    [ "$(cat "$SERVED/index.html")" = "NEW" ]
+}
+
+@test "docker stage: the staging dir is cleared, created, and echoed compose-shaped" {
+    # shellcheck source=/dev/null
+    . "$LIB"
+    mkdir -p "$STAGED"
+    printf 'debris from a crashed run\n' > "$STAGED/index.html"
+
+    cd "$BATS_TEST_TMPDIR"
+    run cic_dist_docker_stage runtime/cicchetto-dist
+    [ "$status" -eq 0 ]
+    # A compose bind-mount source without a leading ./ is parsed as a NAMED
+    # VOLUME, so the prefix is load-bearing, not cosmetic.
+    [ "$output" = "./runtime/cicchetto-dist.next" ]
+    [ -d "$STAGED" ]
+    refute test -e "$STAGED/index.html"
+}
+
+# ======================================================================
+# Shared fake builder — emulates vite closely enough to catch the timing
+# ======================================================================
+
+# Writes a stub named $1 into $FAKE_DIR that behaves like `vite build`:
+# empties --outDir first, RECORDS what the served dir holds at that instant,
+# then writes a bundle. Honors $FAKE_BUILD_RC to model a failed build.
+write_fake_builder() {
+    cat > "$FAKE_DIR/$1" <<'EOF'
+#!/bin/sh
+# `<tool> install` / `<tool> ci` — nothing to do, just succeed.
+case "${1:-}" in
+    install|ci) exit 0 ;;
+esac
+
+outdir=""
+prev=""
+for arg in "$@"; do
+    [ "$prev" = "--outDir" ] && outdir="$arg"
+    prev="$arg"
+done
+[ -n "$outdir" ] || { echo "fake builder: no --outDir in: $*" >&2; exit 2; }
+printf '%s\n' "$outdir" >> "$OUTDIR_LOG"
+
+# Vite's prepare-out-dir step: the directory is emptied BEFORE anything is
+# written. This is the whole defect — if outdir IS the served dir, the SPA
+# is gone from here until the build finishes.
+mkdir -p "$outdir"
+rm -rf "$outdir"/* "$outdir"/.[!.]* 2>/dev/null || true
+
+# The observation that makes this suite able to fail: what does a browser
+# hitting the live server get RIGHT NOW, mid-build?
+if [ -f "$SERVED/index.html" ]; then
+    cat "$SERVED/index.html" > "$MIDBUILD_OBSERVED"
+else
+    echo MISSING > "$MIDBUILD_OBSERVED"
+fi
+
+[ "${FAKE_BUILD_RC:-0}" = 0 ] || { echo "fake builder: failing on purpose" >&2; exit "$FAKE_BUILD_RC"; }
+
+mkdir -p "$outdir/assets"
+printf 'NEW\n' > "$outdir/index.html"
+printf 'new chunk\n' > "$outdir/assets/index-newhash.js"
+EOF
+    chmod +x "$FAKE_DIR/$1"
+}
+
+setup_builder_harness() {
+    FAKE_DIR="$BATS_TEST_TMPDIR/fake"
+    mkdir -p "$FAKE_DIR"
+    # Ahead of the real toolchain for the whole test, including the child
+    # shells `su`/`sudo` spawn — those inherit this PATH.
+    export PATH="$FAKE_DIR:$PATH"
+    OUTDIR_LOG="$BATS_TEST_TMPDIR/outdir.log"
+    MIDBUILD_OBSERVED="$BATS_TEST_TMPDIR/midbuild.observed"
+    : > "$OUTDIR_LOG"
+    export OUTDIR_LOG MIDBUILD_OBSERVED SERVED FAKE_BUILD_RC=0
+
+    # Empty HOME: infra/linux/cic_build.sh prepends ~/.local/bin and
+    # ~/.asdf/shims to PATH, and a real bun there would shadow the stub.
+    export HOME="$BATS_TEST_TMPDIR/home"
+    mkdir -p "$HOME"
+}
+
+# A throwaway checkout with the pieces a cic build reads: the version single
+# source of truth, the shared swap lib, a cicchetto dir, and runtime/.
+seed_fake_checkout() {
+    FAKE_ROOT="$1"
+    mkdir -p "$FAKE_ROOT/cicchetto" "$FAKE_ROOT/infra/packaging" "$FAKE_ROOT/infra/lib" "$FAKE_ROOT/runtime"
+    cp "$REPO_SRC/infra/packaging/version.sh" "$FAKE_ROOT/infra/packaging/version.sh"
+    chmod +x "$FAKE_ROOT/infra/packaging/version.sh"
+    cp "$LIB" "$FAKE_ROOT/infra/lib/cic_dist.sh"
+    printf '9.9.9\n' > "$FAKE_ROOT/VERSION"
+    printf '{"name":"cicchetto"}\n' > "$FAKE_ROOT/cicchetto/package.json"
+}
+
+# ======================================================================
+# infra/freebsd/jail_cic_build.sh — the PRODUCTION substrate
+# ======================================================================
+
+setup_jail_harness() {
+    setup_builder_harness
+    FAKE_ROOT="$BATS_TEST_TMPDIR/jail/home/grappa/grappa"
+    seed_fake_checkout "$FAKE_ROOT"
+    SERVED="$FAKE_ROOT/runtime/cicchetto-dist"
+    STAGED="$SERVED.next"
+    export SERVED
+    seed_served_bundle
+
+    write_fake_builder npm
+
+    # `su -l grappa -c BODY` → run BODY under /bin/sh, with the jail's
+    # hardcoded /home/grappa/grappa rewritten onto the throwaway checkout.
+    # The RELOCATION is the only edit: the body that runs is the real script's
+    # body, so the build command, the outDir and the promote are the shipped
+    # ones. A change to the hardcoded root makes the cd miss and reddens here.
+    cat > "$FAKE_DIR/su" <<EOF
+#!/bin/sh
+body=""
+while [ \$# -gt 0 ]; do
+    case "\$1" in
+        -c) body="\$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+printf '%s' "\$body" | sed "s#/home/grappa/grappa#$FAKE_ROOT#g" > "$BATS_TEST_TMPDIR/su-body.sh"
+exec /bin/sh "$BATS_TEST_TMPDIR/su-body.sh"
+EOF
+    chmod +x "$FAKE_DIR/su"
+}
+
+@test "jail: the served bundle is still serving while vite builds" {
+    setup_jail_harness
+    run "$REPO_SRC/infra/freebsd/jail_cic_build.sh"
+    [ "$status" -eq 0 ]
+
+    # THE red on the parent commit: there, outDir is the served dir, so the
+    # wipe had already taken the SPA down by this point.
+    [ "$(cat "$MIDBUILD_OBSERVED")" = "OLD" ]
+    refute grep -qFx "$SERVED" "$OUTDIR_LOG"
+}
+
+@test "jail: the new bundle lands, stale chunks and debris do not" {
+    setup_jail_harness
+    run "$REPO_SRC/infra/freebsd/jail_cic_build.sh"
+    [ "$status" -eq 0 ]
+
+    [ "$(cat "$SERVED/index.html")" = "NEW" ]
+    [ -f "$SERVED/.gitkeep" ]
+    refute test -f "$SERVED/assets/index-oldhash.js"
+    refute test -e "$STAGED"
+}
+
+@test "jail: a FAILED build leaves the previous bundle serving" {
+    setup_jail_harness
+    FAKE_BUILD_RC=1
+    export FAKE_BUILD_RC
+
+    run "$REPO_SRC/infra/freebsd/jail_cic_build.sh"
+    [ "$status" -ne 0 ]
+
+    # On the parent this directory was emptied at the start of the build and
+    # `set -eu` walked away from the wreckage.
+    [ "$(cat "$SERVED/index.html")" = "OLD" ]
+    [ -f "$SERVED/assets/index-oldhash.js" ]
+    [ -f "$SERVED/.gitkeep" ]
+}
+
+# ======================================================================
+# infra/linux/cic_build.sh
+# ======================================================================
+
+setup_linux_harness() {
+    setup_builder_harness
+    FAKE_ROOT="$BATS_TEST_TMPDIR/linux"
+    seed_fake_checkout "$FAKE_ROOT"
+    SERVED="$FAKE_ROOT/runtime/cicchetto-dist"
+    STAGED="$SERVED.next"
+    export SERVED
+    seed_served_bundle
+
+    write_fake_builder bun
+
+    # sudo -u grappa -H bash -c '<cmd>' → run <cmd> in-process (same shape as
+    # deploy_linux_test.bats): real privilege-dropping is not what is under test.
+    cat > "$FAKE_DIR/sudo" <<'EOF'
+#!/bin/sh
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -u) shift 2 ;;
+        -H|-E|-n|-i|-s) shift ;;
+        --) shift; break ;;
+        -*) shift ;;
+        *) break ;;
+    esac
+done
+exec "$@"
+EOF
+    chmod +x "$FAKE_DIR/sudo"
+}
+
+@test "linux: the served bundle is still serving while vite builds" {
+    setup_linux_harness
+    run "$REPO_SRC/infra/linux/cic_build.sh" "$FAKE_ROOT"
+    [ "$status" -eq 0 ]
+
+    [ "$(cat "$MIDBUILD_OBSERVED")" = "OLD" ]
+    refute grep -qFx "$SERVED" "$OUTDIR_LOG"
+}
+
+@test "linux: the new bundle lands, stale chunks and debris do not" {
+    setup_linux_harness
+    run "$REPO_SRC/infra/linux/cic_build.sh" "$FAKE_ROOT"
+    [ "$status" -eq 0 ]
+
+    [ "$(cat "$SERVED/index.html")" = "NEW" ]
+    [ -f "$SERVED/.gitkeep" ]
+    refute test -f "$SERVED/assets/index-oldhash.js"
+    refute test -e "$STAGED"
+}
+
+@test "linux: a FAILED build leaves the previous bundle serving" {
+    setup_linux_harness
+    FAKE_BUILD_RC=1
+    export FAKE_BUILD_RC
+
+    run "$REPO_SRC/infra/linux/cic_build.sh" "$FAKE_ROOT"
+    [ "$status" -ne 0 ]
+
+    [ "$(cat "$SERVED/index.html")" = "OLD" ]
+    [ -f "$SERVED/assets/index-oldhash.js" ]
+    [ -f "$SERVED/.gitkeep" ]
+}
+
+# ======================================================================
+# Docker — structure only, and it says so
+# ======================================================================
+
+# The compose oneshot writes to whatever host dir is bind-mounted at
+# /app/dist, so the seam that keeps it off the served tree lives in
+# compose.yaml. Byte-pinned: the default must stay the served dir (a bare
+# `compose --profile prod up` has no live server to protect and reaches the
+# build through grappa's depends_on, with nobody to promote afterwards).
+@test "docker: the cicchetto-build mount source is the CIC_BUILD_OUT seam" {
+    grep -qF '${CIC_BUILD_OUT:-./runtime/cicchetto-dist}:/app/dist' "$REPO_SRC/compose.yaml"
+}
+
+# Comments are prose; only code counts. Same stripping as
+# cic_version_export_test.bats, for the same reason.
+code_of() {
+    sed -e 's/[[:space:]]*#.*$//' "$1"
+}
+
+DOCKER_LAUNCHERS=(
+    scripts/deploy.sh
+    scripts/deploy-cic.sh
+    infra/docker/deploy.sh
+)
+
+@test "docker: every compose launcher aims the build at a staging dir and promotes it" {
+    local offenders=() rel code
+    for rel in "${DOCKER_LAUNCHERS[@]}"; do
+        code="$(code_of "$REPO_SRC/$rel")"
+        # CIC_BUILD_OUT must be set ON the build command, not exported at
+        # large: a stray export would still be in the environment for the
+        # `up`/`restart` compose calls that follow.
+        grep -qE 'CIC_BUILD_OUT=.*run --rm cicchetto-build' <<< "$code" \
+            || offenders+=("$rel (build not aimed at CIC_BUILD_OUT)")
+        grep -q 'cic_dist_promote' <<< "$code" \
+            || offenders+=("$rel (never promotes the staged bundle)")
+    done
+    [ "${#offenders[@]}" -eq 0 ] || {
+        printf 'compose launchers that build into the SERVED dist (see #1020):\n' >&2
+        printf '  %s\n' "${offenders[@]}" >&2
+        return 1
+    }
+}
+
+@test "docker: no launcher restores .gitkeep after the build any more" {
+    # The three post-build `touch runtime/cicchetto-dist/.gitkeep` calls existed
+    # ONLY to undo vite's in-place wipe. Leaving one behind would mean the
+    # served dir is still being written to directly.
+    local offenders=() rel
+    for rel in "${DOCKER_LAUNCHERS[@]}" infra/linux/cic_build.sh infra/freebsd/jail_cic_build.sh; do
+        # An `if`, not `grep ... && offenders+=`: a non-matching grep at the
+        # head of an AND list makes the whole list return 1, and bats runs
+        # test bodies under errexit (see test/bats_helpers.bash).
+        if grep -q 'touch .*cicchetto-dist/\.gitkeep' <<< "$(code_of "$REPO_SRC/$rel")"; then
+            offenders+=("$rel")
+        fi
+    done
+    [ "${#offenders[@]}" -eq 0 ] || {
+        printf 'post-build .gitkeep restores left behind (see #1020):\n' >&2
+        printf '  %s\n' "${offenders[@]}" >&2
+        return 1
+    }
+}

--- a/test/infra/deploy_docker_test.bats
+++ b/test/infra/deploy_docker_test.bats
@@ -59,6 +59,9 @@ setup() {
     # exist in the throwaway clone for the script to run — committed so
     # pulls stay clean. Assertions below are UNCHANGED by the extraction.
     cp "$BATS_TEST_DIRNAME/../../infra/lib/deploy_common.sh" "$UPSTREAM/infra/lib/deploy_common.sh"
+    # #1020 — the cic build's build-beside-then-swap helper, sourced by the
+    # same orchestrator. A checkout has it; the throwaway clone must too.
+    cp "$BATS_TEST_DIRNAME/../../infra/lib/cic_dist.sh" "$UPSTREAM/infra/lib/cic_dist.sh"
     # version.sh delegate → committed recorder that echoes a version.
     cat > "$UPSTREAM/infra/packaging/version.sh" <<'EOF'
 #!/bin/sh
@@ -96,6 +99,15 @@ printf 'docker %s\n' "$*" >> "$ARGV_LOG"
 case "$*" in
     *"ps -q grappa"*)  echo fakecid ;;
     *"run --no-start"*) exit "$PREFLIGHT_RC" ;;
+    *"run --rm cicchetto-build"*)
+        # #1020 — model the oneshot: vite writes the bundle into whatever host
+        # dir is bind-mounted at /app/dist, which is CIC_BUILD_OUT now. Without
+        # this the promote correctly REFUSES to swap in a tree with no
+        # index.html, and every cold case dies for the wrong reason.
+        cic_out="${CIC_BUILD_OUT:-./runtime/cicchetto-dist}"
+        mkdir -p "$cic_out/assets"
+        printf '<!doctype html>\n' > "$cic_out/index.html"
+        ;;
     *"exec -T grappa curl"*reload*)
         if [ "$RELOAD_FAILS" = "1" ]; then
             printf '{"loaded":[],"failed":[{"module":"Foo","reason":"old_code_in_use"}]}'

--- a/test/infra/deploy_docker_update_test.bats
+++ b/test/infra/deploy_docker_update_test.bats
@@ -42,6 +42,9 @@ setup() {
              "$UPSTREAM/runtime" "$UPSTREAM/lib"
     cp "$REPO_SRC/infra/docker/deploy.sh" "$UPSTREAM/infra/docker/deploy.sh"
     cp "$REPO_SRC/infra/lib/deploy_common.sh" "$UPSTREAM/infra/lib/deploy_common.sh"
+    # #1020 — the cic build's build-beside-then-swap helper, sourced by the
+    # same orchestrator. A checkout has it; the throwaway clone must too.
+    cp "$REPO_SRC/infra/lib/cic_dist.sh" "$UPSTREAM/infra/lib/cic_dist.sh"
     # The REAL version carrier + extractor (#538/#652): source mode derives
     # GRAPPA_VERSION from them at init so every compose call inherits it, and a
     # cic build with an empty value is refused by vite (#692).
@@ -97,6 +100,15 @@ if [ "$1" = inspect ]; then
 fi
 case "$*" in
     *"run --no-start"*) exit "$PREFLIGHT_RC" ;;
+    *"run --rm cicchetto-build"*)
+        # #1020 — model the oneshot: vite writes the bundle into whatever host
+        # dir is bind-mounted at /app/dist, which is CIC_BUILD_OUT now. Without
+        # this the promote correctly REFUSES to swap in a tree with no
+        # index.html, and every cold case dies for the wrong reason.
+        cic_out="${CIC_BUILD_OUT:-./runtime/cicchetto-dist}"
+        mkdir -p "$cic_out/assets"
+        printf '<!doctype html>\n' > "$cic_out/index.html"
+        ;;
     *"exec -T grappa curl"*reload*)
         if [ "$RELOAD_FAILS" = "1" ]; then
             printf '{"loaded":[],"failed":[{"module":"Foo","reason":"old_code_in_use"}]}'

--- a/test/scripts/deploy_reload_verify_test.bats
+++ b/test/scripts/deploy_reload_verify_test.bats
@@ -47,6 +47,9 @@ setup() {
     # #503: deploy.sh now sources the shared deploy algorithm lib — it must
     # exist in the throwaway clone for the script to run.
     cp "$BATS_TEST_DIRNAME/../../infra/lib/deploy_common.sh" "$UPSTREAM/infra/lib/deploy_common.sh"
+    # #1020 — the cic build's build-beside-then-swap helper, sourced by the
+    # same orchestrator. A checkout has it; the throwaway clone must too.
+    cp "$BATS_TEST_DIRNAME/../../infra/lib/cic_dist.sh" "$UPSTREAM/infra/lib/cic_dist.sh"
     : > "$UPSTREAM/compose.yaml"
     # NB: deliberately NO runtime/.gitkeep here — git drops the empty dir,
     # so the clone has NO runtime/. This mimics a checkout-less install

--- a/test/scripts/deploy_worktree_guard_test.bats
+++ b/test/scripts/deploy_worktree_guard_test.bats
@@ -52,6 +52,10 @@ setup() {
     # #503: deploy.sh now sources the shared deploy algorithm lib — it must
     # exist in the checkout for the script to reach the pull step.
     cp "$BATS_TEST_DIRNAME/../../infra/lib/deploy_common.sh" "$MAIN/infra/lib/deploy_common.sh"
+    # #1020: both scripts also source the build-beside-then-swap helper, at the
+    # top — before the guards these cases are about. Missing it would kill them
+    # for the wrong reason.
+    cp "$BATS_TEST_DIRNAME/../../infra/lib/cic_dist.sh" "$MAIN/infra/lib/cic_dist.sh"
     # #538/#652 — deploy-cic.sh (and deploy.sh's cold path) derive the cic
     # version from the repo-root VERSION file via infra/packaging/version.sh.
     # The fixture needs both the script and a VERSION file to derive from, or
@@ -82,6 +86,15 @@ case "\$args" in
     *cic-bundle-changed*)  printf '%s' 'abc123';   exit 0 ;;
     *admin/reload*)        printf '%s' '{"reloaded":[],"failed":[]}'; exit 0 ;;
     *healthz*)             exit 0 ;;
+    *"run --rm cicchetto-build"*)
+        # #1020 — the oneshot writes the bundle into the CIC_BUILD_OUT staging
+        # dir; deploy-cic.sh then promotes it, and the promote refuses an empty
+        # tree. Model the write so these guard cases fail on guards only.
+        cic_out="\${CIC_BUILD_OUT:-./runtime/cicchetto-dist}"
+        mkdir -p "\$cic_out/assets"
+        printf '<!doctype html>\\n' > "\$cic_out/index.html"
+        exit 0
+        ;;
     *)                     exit 0 ;;
 esac
 EOF
@@ -161,6 +174,14 @@ args="\$*"
 case "\$args" in
     *"ps -q grappa"*)      echo "fakecontainerid"; exit 0 ;;
     *cic-bundle-changed*)  printf '%s' ''; exit 0 ;;
+    *"run --rm cicchetto-build"*)
+        # #1020, as above: the build must produce a promotable tree, or this
+        # case would die at the swap instead of reaching the 204 it is about.
+        cic_out="\${CIC_BUILD_OUT:-./runtime/cicchetto-dist}"
+        mkdir -p "\$cic_out/assets"
+        printf '<!doctype html>\\n' > "\$cic_out/index.html"
+        exit 0
+        ;;
     *)                     exit 0 ;;
 esac
 EOF


### PR DESCRIPTION
Union of **#1022 (issue #1018)** and **#1023 (issue #1020)**, cherry-picked onto `dbdefa6b` and
gated **once, together**. Supersedes both — they will be closed BY CONTENT naming this PR, since a
cherry-pick rewrites the SHAs and GitHub cannot close them by ancestry.

## Why a union rather than two merges

Each PR was gated against `dbdefa6b` **separately**, and neither has ever been gated with the
other. A PR's green attests `branch + base` — never `branch + the other branch landing beside it`.
Merging one would also have invalidated the other's in-flight run, so serial merge-and-re-gate
costs two runs; this costs one and additionally asks the question neither per-PR green asks.

Textual non-overlap is not semantic independence, so it is not the argument here — the argument is
that one run now exercises both. For the record, the only file both touch is `docs/DESIGN_NOTES.md`
(both append an entry; both entries are present, in chronological order).

## Verification before opening, per PR, as counts rather than "identical"

Two empty sets also match, so the counts are the point:

| PR | own added lines | lines the PR has that the UNION LACKS, on its own files |
|----|-----------------|--------------------------------------------------------|
| #1022 (#1018) | 422 | **0** |
| #1023 (#1020) | 686 | **0** |

All four commits cherry-picked clean, no conflicts.

## What each half brings

**#1022 — the next-active cycle skips muted windows.** `orderUnreadWindows` takes the mute as a
REQUIRED input, so all three doors (Alt+A, Ctrl+N/P, the affordance) inherit the skip without
forking the #235 ordering; a future door that forgets it is a compile error. `lib/conversationMute.ts`
becomes the one home for the mute key — the DM case being the trap, since the key is the folded
conversation (the PEER for a DM) and getting it wrong collapses every DM onto one entry.
Its `integration` was **643 passed**, i.e. +1 over the 642 baseline: the new e2e provably ran.

**#1023 — the cic bundle is built beside the served dist, then swapped.** One POSIX
`infra/lib/cic_dist.sh` sourced by all three serving substrates; build into `<served>.next`, then
rename in. Before this, `--emptyOutDir` emptied the directory being SERVED at the start of the vite
build, so for the whole build the old BEAM served an empty dist and the SPA did not load at all.
`infra/packaging/build.sh` was already the right shape and is untouched.
Its `integration` was **642 passed** — count unchanged, and expected: its new tests are bats, not
Playwright.

Found on the way and fixed as a side effect: **the jail — production — never had the `.gitkeep`
restore that linux and the docker paths carry**, so every cic build there was silently deleting a
tracked file.

## Not claimed

The empty-dist window has never been observed on a live jail — it is read from the code, as the
issue itself says; nobody touches prod. The docker path is read and its compose interpolation
verified with `docker compose config` (rc=0, both the default and the `CIC_BUILD_OUT` override
resolving to the right absolute paths), but **no real container has written where we believe**.