### PR TITLE
e2e(#653): shrink the viewport through the tracker, not around it

### DIFF
--- a/cicchetto/e2e/tests/names143-modal-mobile.spec.ts
+++ b/cicchetto/e2e/tests/names143-modal-mobile.spec.ts
@@ -23,12 +23,12 @@
 // chromium's layout viewport == its visual viewport (there is no OS
 // keyboard), so it CANNOT reproduce the real iOS layout/visual
 // divergence that triggers the occlusion. This spec therefore asserts
-// the CSS CONTRACT, not the iOS physics: with `--viewport-height` pinned
-// to a keyboard-shrunk value (exactly what `installViewportHeightTracker`
-// writes from `vv.height` on iOS — unit-covered in
-// viewportHeight.test.ts), the modal stays fully inside that visible
-// region. Real on-device occlusion still needs Mezmerize dogfood before
-// final close — flagged on #grappa.
+// the CSS CONTRACT, not the iOS physics: with the visible region shrunk
+// to a keyboard-sized value by the production tracker itself (the same
+// `installViewportHeightTracker` write that `vv.height` drives on iOS —
+// unit-covered in viewportHeight.test.ts), the modal stays fully inside
+// that region. Real on-device occlusion still needs Mezmerize dogfood
+// before final close — flagged on #grappa.
 
 import type { Page } from "@playwright/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
@@ -54,22 +54,60 @@ async function openNamesModal(page: Page) {
 test("#143 — NamesModal stays within the keyboard-shrunk visible viewport", async ({ page }) => {
   const modal = await openNamesModal(page);
 
-  // Simulate the iOS keyboard-up state: pin the visible-region var to a
-  // value far below the window height. `installViewportHeightTracker`
-  // would write this from `vv.height`; we set it directly because
-  // chromium has no keyboard to shrink the visual viewport.
+  // Simulate the iOS keyboard-up state the way docs/TESTING.md mandates
+  // and issue66/issue253 already do: stub the SOURCE (`vv.height`) and
+  // dispatch the `resize` the production code listens for, so
+  // `installViewportHeightTracker` — the single writer of both vars
+  // (lib/viewportHeight.ts:110) — shrinks the region itself.
+  //
+  // A bare `setProperty("--viewport-height", …)` is the documented trap,
+  // and it is what this spec used to do: the tracker re-reads the REAL
+  // `vv.height` on resize, focus, visibilitychange, pageshow AND a
+  // post-boot settle schedule, so any one of them silently restores the
+  // full height mid-test. Stubbing the source makes EVERY one of those
+  // writes land on FAKE_VISIBLE_PX instead of racing them — the pin
+  // survives the writer rather than being clobbered by it.
   await page.evaluate((px) => {
-    document.documentElement.style.setProperty("--viewport-height", `${px}px`);
+    const vv = window.visualViewport;
+    if (!vv) throw new Error("names143 spec: window.visualViewport unavailable");
+    Object.defineProperty(vv, "height", { configurable: true, get: () => px });
+    vv.dispatchEvent(new Event("resize"));
   }, FAKE_VISIBLE_PX);
+
+  // Guard: the shrink is in effect BEFORE any geometry is read, so a
+  // failure below means "the modal overflows the visible region" (the
+  // #143 bug) and never "the simulation didn't take".
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(() =>
+          document.documentElement.style.getPropertyValue("--viewport-height").trim(),
+        ),
+      { timeout: 5_000 },
+    )
+    .toBe(`${FAKE_VISIBLE_PX}px`);
 
   // The modal must stay fully inside [0, FAKE_VISIBLE_PX]; its bottom
   // edge cannot fall into the keyboard region. Pre-fix, the backdrop
   // centered in the full layout viewport, parking the lower half below.
+  // Polled, not read once: the re-centre is a layout pass the resize
+  // schedules. The poll reports the offending number on failure, which
+  // is what made the clobber diagnosable in the first place.
+  await expect
+    .poll(
+      async () => {
+        const box = await modal.boundingBox();
+        return box ? box.y + box.height : Number.POSITIVE_INFINITY;
+      },
+      { timeout: 5_000 },
+    )
+    .toBeLessThanOrEqual(FAKE_VISIBLE_PX + 1);
+
+  // Top edge, from the now-settled layout the poll above proved landed.
   const box = await modal.boundingBox();
   expect(box).not.toBeNull();
   if (box) {
     expect(box.y).toBeGreaterThanOrEqual(-1);
-    expect(box.y + box.height).toBeLessThanOrEqual(FAKE_VISIBLE_PX + 1);
   }
 });
 


### PR DESCRIPTION
## Il difetto

`cicchetto/e2e/tests/names143-modal-mobile.spec.ts`, test *"#143 — NamesModal stays
within the keyboard-shrunk visible viewport"*, progetto **chromium**. Rosso 2 volte su
4 run pieni della notte del 2026-08-07, **bit-identico** in entrambi:

```
Expected: <= 301
Received:    438.03125
```

- run `31199650841` **attempt 1** (main `03aa1260`) — l'attempt 2 e' un rerun verde,
  quindi `--log-failed` torna vuoto: serve `--attempt 1 --log`.
- run `31216867403` (PR #1022, `b415fb99`)

Non e' jitter: e' un binario "pin tenuto / pin raso".

## La causa

Misurata sugli snapshot DOM del trace del run `31216867403`. La spec pinnava la regione
visibile con un `setProperty("--viewport-height", "300px")` **nudo**:

```
snapshot after@  del page.evaluate .................... --viewport-height: 300px
snapshot before@ del locator che boundingBox aspetta .. --viewport-height: 720px   (~20ms dopo)
```

Il modale si ricentra nella finestra **intera** 1280x720: `(720 + 156.0625)/2 = 438.03125`.
Lo screenshot del fallimento lo conferma — modale al centro verticale della finestra piena,
backdrop scuro su tutta l'altezza, nessuna banda di chrome nel frame.
**L'ipotesi #985 (chrome di shell contro viewport ristretto) e' refutata per questo rosso.**

Il writer e' `writeViewport()` in `cicchetto/src/lib/viewportHeight.ts:112-113` — le uniche
due `setProperty` di quelle var in tutto `cicchetto/src`, installate una volta da
`main.tsx:130`. Ci arrivano **sei** vie, tutte in `installViewportHeightTracker`:
boot `:152`, la schedule di settle `[100,400,900]ms` (`:104`+`:125`), `vv.resize` `:153`,
`visibilitychange` `:160`, `pageshow` `:164`, `focus` `:165`.

## La cura

Stubba la **sorgente**, non la var:

```ts
Object.defineProperty(vv, "height", { configurable: true, get: () => px });
vv.dispatchEvent(new Event("resize"));
```

Cosi' ogni write successiva del tracker rilegge lo stub e riscrive lo **stesso** 300px: il
clobber diventa un no-op idempotente, e la cura regge a **tutti e sei** i trigger invece che
al solo sospettato. In piu': `expect.poll` sulla var `--viewport-height == "300px"` prima di
leggere geometria, e bordo inferiore **pollato** anziche' letto una volta.

Nessun timeout alzato, nessun assert indebolito: budget sempre `[0, 300]`, `FAKE_VISIBLE_PX = 300`.

Non e' inventata: e' la regola gia' scritta in **`docs/TESTING.md:430`** (*"**NEVER**
`setProperty("--viewport-height", ...)` and THEN dispatch `resize`: the tracker's own listener
immediately clobbers the inline var back to the real (full) `vv.height`"*), e il pattern che
`issue66-keyboard-overlap.spec.ts:88` e `issue253-kbd-resize-scroll-preserve.spec.ts:57`
gia' usano.

## Le misure

**La controprova come da copione** — setProperty nudo, nessun trigger forzato, N=10 chromium,
criterio dichiarato prima (>=1/10 rosso):

> `10 passed (49.1s)`, rc=0

**L'isolamento non riproduce il flake.** Un verde sulla cura, da solo, non avrebbe provato
niente — ed e' il motivo per cui la controprova viene prima.

**La controprova forzata.** `viewportHeight.ts:153` scrive **sincrono** sul `resize`, quindi
`setProperty` nudo + `dispatchEvent(resize)` e' letteralmente la trappola vietata da
`docs/TESTING.md:430`. N=5, criterio >=1/5:

> `5 failed`, rc=1 — `Expected: <= 301` / `Received: 470.375`, 5 occorrenze su 5

Il numero **non e' 438.03125**, e la differenza e' spiegata per intero dall'aritmetica:
entrambi valgono `(720 + altezza_modale)/2`. CI: `h = 2*438.03125 - 720 = 156.0625`.
Locale: `h = 2*470.375 - 720 = 220.75`. **Stessa firma** "centrato nella finestra piena da
720", modale di altezza diversa (lista membri diversa fra CI e stack locale).

**La cura**, stesso comando, stesso harness, N=10:

> `10 passed (48.7s)`, rc=0

Stesso trigger sui due lati: pinnare la var perde 5/5, stubbare la sorgente regge 10/10.
Questo e' l'unico confronto che discrimina.

## Cosa questa PR NON stabilisce

- **Quale dei sei trigger del tracker spari in CI.** Io ho forzato `resize`; quello
  ambientale resta senza nome — il trace non registra i listener. La schedule a 900ms e'
  solo *compatibile* coi tempi.
- **Che la cura risolva il flake di CI.** Provato solo: col writer che spara, pinnare la var
  perde e stubbare la sorgente regge. Il flake ha sparato 1 volta su 4 run pieni.
- **Il 10/10 della cura e' PRE-rebase.** Misurato su `fd386e60`, base `dbdefa6b`. Main si e'
  mosso durante il gate lungo (`6c4babd4`, il merge di #976), il ramo e' stato ribasato e
  **non ho rigirato la cura** sull'albero ribasato. La spec e' **byte-identica** fra i due
  commit (`git diff fd386e60:<spec> c19bf81c:<spec>` = 0 byte): e' cambiata solo la base.
  La controprova forzata invece e' **5/5 rossa su entrambi gli alberi**.
- **La suite piena post-rebase non e' mai girata in locale.** La lane e2e era contesa ed e'
  stata rilasciata a un altro worker; per regola di casa il gate arriva dalla CI di questa PR.
  L'unica suite piena locale (`641 passed`, `1 failed`) e' su albero **superato** e non attesta.
- **`issue580` non e' dichiarata flake.** In quella run superata
  `issue580-send-snap-independent-of-post.spec.ts:209` e' uscita rossa
  (`Expected <= 50` / `Received 360`). Non l'ho rigirata e non ho baseline su main. Quel che
  ho: e' girata al #307, **prima** di names143 (#414/#415, entrambi verdi), quindi l'ordine
  esclude questa spec come avvelenatrice, e il diff tocca **un solo file e2e**.
  "Non e' mia" non e' "e' un flake".

## Debito segnalato, non nascosto

Lo stub `defineProperty(vv,"height") + dispatchEvent(resize)` e' ora alla **terza copia**
(`issue66-keyboard-overlap.spec.ts:88` inline, `issue253-kbd-resize-scroll-preserve.spec.ts:57`
helper locale, e questa). CLAUDE.md (*"Implement once, reuse everywhere"* + *"Total consistency
or nothing"*) vuole l'estrazione in un fixture condiviso, plausibilmente
`cicchetto/e2e/fixtures/cicchettoPage.ts`. Rinviata **di proposito**: toccherebbe due spec
attualmente verdi senza poterle rigirare. Va in una PR separata, migrando tutte e tre
(mai due su tre: mezza migrazione crea due pattern e il prossimo copia quello sbagliato).

Il flake resta tracciato sulla EPIC #653, che resta aperta.