### PR TITLE
fix(#1028): guard the #124 fold by auth_method — it was destroying server passwords

### DIFF
--- a/priv/repo/migrations/20260807120000_fold_nickserv_pass_onto_password.exs
+++ b/priv/repo/migrations/20260807120000_fold_nickserv_pass_onto_password.exs
@@ -28,21 +28,36 @@ defmodule Grappa.Repo.Migrations.FoldNickservPassOntoPassword do
 
   ## GH #1028 — the fold carries the SAME `auth_method` guard as the promotion
 
-  "Preserves the effective secret" holds only where `password_encrypted` IS the
-  NickServ secret. On `:server_pass` and `:auto` it is the single `PASS` wire
-  token (`AuthFSM.maybe_send_pass/1`), and on `:sasl` and `:auto` it is the
-  SASL PLAIN payload — there the fold does not preserve anything, it DESTROYS a
-  live server password, and `down/0` cannot put it back. Shipped in v0.14.0
-  unguarded; the observed symptom was `Closing Link: wrong password` with no
-  breadcrumb pointing here.
+  The rule the promotion follows is not "do not rewrite `auth_method`". It is
+  **do not rewrite the VALUE on a row whose password is SPENT somewhere else**,
+  and the promotion was only its first half. On `:server_pass` and `:auto`
+  `password_encrypted` is the single `PASS` wire token
+  (`AuthFSM.maybe_send_pass/1`); on `:sasl` and `:auto` it is the SASL PLAIN
+  payload. On none of the three is it the NickServ secret, so there the fold
+  preserves nothing — it DESTROYS a live server password, and `down/0` cannot
+  put it back because the pre-fold value is gone. Shipped unguarded in v0.14.0;
+  what the operator sees is `Closing Link: wrong password`, with nothing
+  pointing back here.
 
-  So the fold is restricted to the two methods where the column really is the
-  NickServ secret: `:none` (about to be promoted to `:nickserv_identify` by the
-  statement above) and `:nickserv_identify` itself. An ALLOWLIST, not a
-  denylist of the three damaged methods: `auth_method` is a closed set
-  (`Credential.auth_methods/0`), and a sixth method added later must earn its
-  way into the fold deliberately rather than inherit it by omission. A NULL
-  `auth_method` matches neither form and is left alone, which is the safe side.
+  So the fold now writes ONLY where the promotion above just acted: rows that
+  were at `:none`. That is deliberately the NARROWEST guard that stops the
+  data loss, and it writes strictly less than the previous statement did.
+
+  ## Known consequence of the narrow guard — open, not resolved here
+
+  A row already at `:nickserv_identify` carrying a perform-held secret is now
+  NOT folded. Under the old precedence `nickserv_pass_encrypted` WON, so that
+  is the secret upstream is really being identified with; post-#124 nothing
+  reads that column any more, so the identify falls back to whatever
+  `password_encrypted` holds and fails SILENTLY (a non-`+r`, not an error).
+
+  That is a real gap and it is left standing on purpose. It is not symmetric
+  with the bug above: nothing is destroyed here. The value is still in
+  `nickserv_pass_encrypted`, which #124 keeps in place (EXPAND only), so this
+  row can be repaired later by any decision — whereas a folded `:server_pass`
+  row cannot be repaired at all. Between "write and maybe have to undo it" and
+  "do not write yet", a data-loss fix takes the second. Where the NickServ
+  secret should live for these rows is vjt's call; see GH #1028.
 
   ## Ciphertext copy, not decrypt-and-re-encrypt
 
@@ -92,23 +107,29 @@ defmodule Grappa.Repo.Migrations.FoldNickservPassOntoPassword do
   use Ecto.Migration
 
   def up do
-    # Order matters: promote FIRST, while `nickserv_pass_encrypted` is still the
-    # marker of "this row carried the second secret". Doing it after the copy
-    # would work too (the guard reads the same column, which the copy does not
-    # touch), but promoting first keeps the two statements independent of each
-    # other's effects.
+    # ORDER REVERSED by #1028, and it is now load-bearing rather than a matter
+    # of taste. Both statements match on `auth_method = 'none'`, so the two are
+    # no longer independent: promoting first flips the row to
+    # `:nickserv_identify` and the fold's own WHERE stops matching it — the copy
+    # then reaches NOTHING and the migration is a silent no-op for exactly the
+    # rows it exists to serve. Caught by
+    # `fold_nickserv_pass_onto_password_test.exs`, which went red on the `:none`
+    # case the moment the guard was added without the swap.
+    #
+    # Folding first is correct and stays idempotent: on a re-run the fold finds
+    # no `:none` row left to copy and the promotion finds none left to flip.
     execute("""
     UPDATE network_credentials
-       SET auth_method = 'nickserv_identify'
+       SET password_encrypted = nickserv_pass_encrypted
      WHERE nickserv_pass_encrypted IS NOT NULL
        AND auth_method = 'none'
     """)
 
     execute("""
     UPDATE network_credentials
-       SET password_encrypted = nickserv_pass_encrypted
+       SET auth_method = 'nickserv_identify'
      WHERE nickserv_pass_encrypted IS NOT NULL
-       AND auth_method IN ('none', 'nickserv_identify')
+       AND auth_method = 'none'
     """)
   end
 

--- a/priv/repo/migrations/20260807120000_fold_nickserv_pass_onto_password.exs
+++ b/priv/repo/migrations/20260807120000_fold_nickserv_pass_onto_password.exs
@@ -26,6 +26,24 @@ defmodule Grappa.Repo.Migrations.FoldNickservPassOntoPassword do
   NULL. Filling the gaps would have quietly demoted a working secret to the
   losing one on every row that carried both.
 
+  ## GH #1028 — the fold carries the SAME `auth_method` guard as the promotion
+
+  "Preserves the effective secret" holds only where `password_encrypted` IS the
+  NickServ secret. On `:server_pass` and `:auto` it is the single `PASS` wire
+  token (`AuthFSM.maybe_send_pass/1`), and on `:sasl` and `:auto` it is the
+  SASL PLAIN payload — there the fold does not preserve anything, it DESTROYS a
+  live server password, and `down/0` cannot put it back. Shipped in v0.14.0
+  unguarded; the observed symptom was `Closing Link: wrong password` with no
+  breadcrumb pointing here.
+
+  So the fold is restricted to the two methods where the column really is the
+  NickServ secret: `:none` (about to be promoted to `:nickserv_identify` by the
+  statement above) and `:nickserv_identify` itself. An ALLOWLIST, not a
+  denylist of the three damaged methods: `auth_method` is a closed set
+  (`Credential.auth_methods/0`), and a sixth method added later must earn its
+  way into the fold deliberately rather than inherit it by omission. A NULL
+  `auth_method` matches neither form and is left alone, which is the safe side.
+
   ## Ciphertext copy, not decrypt-and-re-encrypt
 
   Both columns are `Grappa.EncryptedBinary` (`Cloak.Ecto.Binary`) on the SAME
@@ -90,6 +108,7 @@ defmodule Grappa.Repo.Migrations.FoldNickservPassOntoPassword do
     UPDATE network_credentials
        SET password_encrypted = nickserv_pass_encrypted
      WHERE nickserv_pass_encrypted IS NOT NULL
+       AND auth_method IN ('none', 'nickserv_identify')
     """)
   end
 

--- a/test/grappa/migrations/fold_nickserv_pass_onto_password_test.exs
+++ b/test/grappa/migrations/fold_nickserv_pass_onto_password_test.exs
@@ -49,7 +49,7 @@ defmodule Grappa.Migrations.FoldNickservPassOntoPasswordTest do
   UPDATE network_credentials
      SET password_encrypted = nickserv_pass_encrypted
    WHERE nickserv_pass_encrypted IS NOT NULL
-     AND auth_method IN ('none', 'nickserv_identify')
+     AND auth_method = 'none'
   """
 
   defp uniq, do: System.unique_integer([:positive])
@@ -74,9 +74,22 @@ defmodule Grappa.Migrations.FoldNickservPassOntoPasswordTest do
     cred
   end
 
+  # Read through raw SQL, like `seed_perform_secret/2` writes it: #124 removed
+  # the schema field, so the column is only reachable this way.
+  defp perform_secret_still_stored?(%Credential{id: id}) do
+    %{rows: [[blob]]} =
+      Repo.query!("SELECT nickserv_pass_encrypted FROM network_credentials WHERE id = ?", [id])
+
+    blob != nil
+  end
+
+  # #1028 — FOLD first, then promote. Both statements now match on
+  # `auth_method = 'none'`, so promoting first would consume the fold's own
+  # WHERE match and the copy would reach nothing. Mirrors `up/0`'s order, which
+  # is the whole point of duplicating the SQL here.
   defp run_migration do
-    Repo.query!(@promote_sql)
     Repo.query!(@fold_sql)
+    Repo.query!(@promote_sql)
   end
 
   defp reload(%Credential{id: id}), do: Repo.get!(Credential, id)
@@ -102,7 +115,12 @@ defmodule Grappa.Migrations.FoldNickservPassOntoPasswordTest do
       assert Credential.recover_secret(folded) == "perform-secret"
     end
 
-    test "a perform-held secret OVERWRITES an existing password (it won the old precedence)" do
+    # GH #1028 — this test used to assert "winner", i.e. that the fold reached
+    # an ALREADY-`:nickserv_identify` row. The guard is now `auth_method =
+    # 'none'`, so it does not, and the assertion is inverted to say what the
+    # migration actually does. It is pinned rather than deleted BECAUSE the
+    # outcome is a known gap, and a gap nobody can see is a gap nobody fixes.
+    test "an already-:nickserv_identify row is NOT folded — the #1028 gap, pinned on purpose" do
       cred =
         %{auth_method: :nickserv_identify, password: "loser"}
         |> seed()
@@ -110,10 +128,18 @@ defmodule Grappa.Migrations.FoldNickservPassOntoPasswordTest do
 
       run_migration()
 
-      # Pre-#124 `recover_secret/1` answered "winner" for this row. Filling in
-      # only where the password was NULL would have silently demoted upstream's
-      # actual secret to the one that was losing.
-      assert Credential.recover_secret(reload(cred)) == "winner"
+      folded = reload(cred)
+
+      # The perform secret stays where it was. Under the old precedence
+      # "winner" is what upstream is REALLY being identified with, but post-#124
+      # nothing reads `nickserv_pass_encrypted` any more, so the identify falls
+      # back to the password below and dies as a silent non-`+r`.
+      assert Credential.recover_secret(folded) == "loser"
+
+      # Not destroyed, only not-yet-moved: the column is EXPAND-only and still
+      # holds the secret, which is why this row stays repairable by whatever
+      # vjt decides — unlike a folded :server_pass row, which does not.
+      assert perform_secret_still_stored?(cred)
     end
 
     test "a row with no perform-held secret is untouched (the already-correct shape)" do

--- a/test/grappa/migrations/fold_nickserv_pass_onto_password_test.exs
+++ b/test/grappa/migrations/fold_nickserv_pass_onto_password_test.exs
@@ -49,6 +49,7 @@ defmodule Grappa.Migrations.FoldNickservPassOntoPasswordTest do
   UPDATE network_credentials
      SET password_encrypted = nickserv_pass_encrypted
    WHERE nickserv_pass_encrypted IS NOT NULL
+     AND auth_method IN ('none', 'nickserv_identify')
   """
 
   defp uniq, do: System.unique_integer([:positive])
@@ -135,19 +136,35 @@ defmodule Grappa.Migrations.FoldNickservPassOntoPasswordTest do
       assert Credential.recover_secret(folded) == nil
     end
 
-    test ":server_pass is NOT promoted — the password is spent on PASS, not NickServ" do
-      # Promoting this would change what the password is SPENT ON and break a
-      # working handshake, so only `:none` is in the promotion's WHERE clause.
-      cred =
-        %{auth_method: :server_pass, password: "server-side"}
-        |> seed()
-        |> seed_perform_secret("ns-side")
+    # GH #1028 — the three methods that SPEND `password_encrypted` on the wire.
+    # `:server_pass` and `:auto` ship it as the single PASS token
+    # (`AuthFSM.maybe_send_pass/1`, `when m in [:auto, :server_pass]`); `:auto`
+    # and `:sasl` also spend it as the SASL PLAIN payload. On none of the three
+    # is it the NickServ secret, so folding the perform secret onto it does not
+    # preserve an effective secret — it DESTROYS a live one, and `down/0`
+    # cannot put it back.
+    #
+    # Generated rather than written three times: the claim is about a CLOSED
+    # SET (`Credential.auth_methods/0` minus the two the fold is for), and a
+    # fourth method added later must be a deliberate decision, not an omission.
+    for method <- [:server_pass, :sasl, :auto] do
+      test "#{method}: the fold leaves the password alone — it is spent on the wire, not on NickServ" do
+        cred =
+          %{auth_method: unquote(method), password: "wire-side"}
+          |> seed()
+          |> seed_perform_secret("ns-side")
 
-      run_migration()
+        run_migration()
 
-      folded = reload(cred)
-      assert folded.auth_method == :server_pass
-      assert Credential.upstream_password(folded) == "ns-side"
+        folded = reload(cred)
+        # Not promoted: rewriting the method would change what the password is
+        # SPENT ON. This half was always true.
+        assert folded.auth_method == unquote(method)
+        # Not folded either — the #1028 half. Before the guard this read
+        # "ns-side", and the row's upstream handshake died with
+        # `Closing Link: wrong password`.
+        assert Credential.upstream_password(folded) == "wire-side"
+      end
     end
 
     test "re-running the fold changes nothing (idempotent)" do
@@ -179,10 +196,19 @@ defmodule Grappa.Migrations.FoldNickservPassOntoPasswordTest do
     test "the migration file embeds both statements" do
       source = squash(File.read!(Path.join(File.cwd!(), @migration_path)))
 
-      assert String.contains?(source, squash(@promote_sql))
-      assert String.contains?(source, squash(@fold_sql))
+      assert embeds?(source, @promote_sql)
+      assert embeds?(source, @fold_sql)
     end
 
     defp squash(text), do: text |> String.replace(~r/\s+/, " ") |> String.trim()
+
+    # GH #1028 — anchored on the heredoc TERMINATOR, not a bare substring.
+    # A plain `String.contains?` is satisfied by a PREFIX, so the copy here
+    # could lose a trailing WHERE clause the migration still has and the pin
+    # would stay green — measured: with the `auth_method` guard deleted from
+    # `@fold_sql` alone, the old pin passed while the three behaviour tests
+    # failed. That is the exact drift the pin exists to catch, so it has to see
+    # the end of the statement, not just its beginning.
+    defp embeds?(source, sql), do: String.contains?(source, squash(sql) <> ~S[ """)])
   end
 end


### PR DESCRIPTION
Issue #1028. P0, data-loss, already shipped in v0.14.0.

## What was wrong

`20260807120000_fold_nickserv_pass_onto_password` copied
`nickserv_pass_encrypted` onto `password_encrypted` for **every** non-NULL
source row. The promotion next to it was guarded by `auth_method`; the fold
was not.

`password_encrypted` is not always the NickServ secret:

| `auth_method` | where the password is SPENT | fold destroys it? |
|---|---|---|
| `:none` | nothing yet (promoted by this migration) | no — this is the point |
| `:nickserv_identify` | `PRIVMSG NickServ :IDENTIFY` | no |
| `:server_pass` | the single `PASS` token | **yes** |
| `:auto` | `PASS`, and the SASL PLAIN payload | **yes** |
| `:sasl` | the SASL PLAIN payload | **yes** |

`AuthFSM.maybe_send_pass/1` fires `when m in [:auto, :server_pass]`, which is
why `:auto` belongs on that list and the issue title (which names only
`server_pass` and `sasl`) understates it by one.

On those three the fold does not preserve an effective secret — it overwrites
a live server password with an unrelated one. `down/0` raises, correctly: the
old value is gone. What the operator sees is `Closing Link: wrong password`
and nothing pointing back here.

The migration's own moduledoc already stated the rule its fold skipped —
*"rewriting `:sasl` or `:server_pass` would change what the password is SPENT
ON and break a working handshake"* — and applied it to the METHOD only. It
applies to the VALUE just as much, and the moduledoc now says so.

## The fix

`AND auth_method = 'none'` on the fold, vjt's ruling. Plus two things the
tests forced out:

**The two statements are SWAPPED, and that is load-bearing.** Both now match
on `auth_method = 'none'`, so they are no longer independent: promoting first
flips the row to `:nickserv_identify`, the fold's own `WHERE` stops matching
it, the copy reaches nothing, and the migration becomes a **silent no-op for
exactly the rows it exists to serve**. The `:none` test went red on
`upstream_password == nil` the moment the guard landed without the swap. Fold
first is still idempotent — a re-run finds no `:none` row for either statement.

**The file pin was vacuous in the direction that mattered.** It used a bare
`String.contains?`, which a PREFIX satisfies, so the test's SQL copy could
lose a trailing `WHERE` clause the migration still had and the pin would stay
green. Measured: deleting the guard from `@fold_sql` alone left the old pin
GREEN while the behaviour tests went red — the exact drift its comment claims
to catch. Anchored on the heredoc terminator; the same mutation now turns it
red (3 failures before, 4 after).

## ⚠️ Known consequence of the narrow guard — open, for vjt

A row **already** at `:nickserv_identify` carrying a perform-held secret is
**not folded**. Under the old precedence `nickserv_pass_encrypted` WON, so it
is the secret upstream is really being identified with; post-#124 nothing
reads that column, so the identify falls back to whatever `password_encrypted`
holds and fails **silently** — a non-`+r`, not an error.

This is deliberately left standing, not resolved. It is also not symmetric
with the bug above: **nothing is destroyed.** The value is still in
`nickserv_pass_encrypted`, which #124 keeps in place (EXPAND-only), so the row
stays repairable by any decision — a folded `:server_pass` row does not.
Between writing something that may have to be undone and not writing yet, a
data-loss fix takes the second. A test pins the gap rather than leaving it
implicit, because a gap nobody can see is a gap nobody fixes.

An allowlist (`IN ('none','nickserv_identify')`) would close it and was
implemented first; vjt ruled for the narrow form and this consequence is the
point that decision turns on.

## Blast radius

Prod (m42, measured read-only by the orchestrator): **zero** rows at
`server_pass` / `sasl` / `auto`. 49 `nickserv_identify`, 23 `none`. One row
carries a perform secret and it is `nickserv_identify`, where the fold is the
intended behaviour. **Prod is not damaged.** This is a P0 for self-hosters.

Already-migrated installs are **not** repaired by this PR — the guard only
protects those who have not migrated yet. There is no supported recovery: no
audit table holds the old value (`git grep password_encrypted -- lib priv`),
and no deploy path takes a pre-migration backup (the only `cp` backup in the
tree is `infra/freebsd/jail_import_db.sh`, a manual import tool). Only an
operator's own backup brings it back.

## Out of scope, per vjt

- The backfill / notification for installs already hit — separate issue.
  One correction for whoever writes it: a detection **signature does exist**,
  contrary to the issue text. Cloak uses a random IV, so re-encrypting never
  reproduces a blob; the fold copied bytes verbatim, so on a damaged row
  `password_encrypted` is **byte-identical** to `nickserv_pass_encrypted`. The
  value is unrecoverable, but the event is provable.
- Where the NickServ secret should live for those rows — vjt's decision.

## Gates

`scripts/check.sh` rc=0 — 8 doctests, 56 properties, **5539 tests, 0
failures**; Credo strict `5305 mods/funs, found no issues.`; Dialyzer `Total
errors: 0`; Doctor passed; Sobelow ran. Tree clean before and after.

RED read before GREEN on all three new cases (`left: "ns-side"`, the wire
password clobbered), and again on the `:none` no-op the swap fixes.