### PR TITLE
docker(#1027): supported compose service for the shottino --ircd bridge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -169,3 +169,40 @@ LOG_LEVEL=info
 # GRAPPA_CAPTCHA_PROVIDER=turnstile  # or hcaptcha; absent = disabled
 # GRAPPA_CAPTCHA_SITE_KEY=0xYOUR_TURNSTILE_SITE_KEY_HERE
 # GRAPPA_CAPTCHA_SECRET=
+
+# ─── #1027 shottino --ircd bridge (opt-in: `docker compose --profile ircd up`) ─
+# A real IRC server on a port, so irssi/weechat/hexchat/goguma reach grappa
+# without speaking its REST + Channels protocol. Nothing below is read unless
+# the `ircd` profile is active.
+#
+# ONE SERVICE PER USER, not per network: a downstream client names the network
+# it wants in `PASS <network>:<password>`, and that is stored per connection —
+# so three networks are three `/connect`s to this ONE port. A second grappa
+# ACCOUNT is what needs a second service on a second port.
+#
+# SHOTTINO_USER is the grappa username the bridge logs in as. Unset, the login
+# fails and `restart: unless-stopped` turns that into a restart loop — check
+# this first when the bridge will not stay up.
+# SHOTTINO_USER=you
+#
+# SHOTTINO_PASSWORD is that login's password. It is an env var and not an
+# argument on purpose: headless there is no terminal to prompt, and the
+# command line shows it to every user on the host via `ps` for as long as the
+# bridge runs — which for a bridge is permanently.
+# SHOTTINO_PASSWORD=
+#
+# SHOTTINO_IRCD_PASS is what DOWNSTREAM clients must send (`PASS
+# <network>:<this>`). MANDATORY here: a published port is off-loopback from
+# the bridge's point of view, and off loopback shottino refuses to listen
+# without it — the bridge hands over the whole IRC session, every channel,
+# every DM, and the ability to speak as you.
+# SHOTTINO_IRCD_PASS=
+#
+# Where the bridge is published on the HOST. Loopback by default, same
+# convention as GRAPPA_PUBLISH. Widen it and you are exposing that session to
+# whoever can reach the address.
+# SHOTTINO_IRCD_PUBLISH=127.0.0.1:6667
+#
+# Which grappa the bridge talks to. In-stack over grappa_internal by default;
+# point it at a public https:// URL to bridge somebody else's instance.
+# SHOTTINO_GRAPPA_URL=http://grappa:4000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,12 @@ jobs:
       # fail CI, while a user building from source on a newer compiler
       # that emits some novel diagnostic should still get a client.
       # CFLAGS_DEPS is re-appended because overriding CFLAGS drops the
-      # feature-test macros configure detected (strcasestr, cfmakeraw).
+      # feature-test macros that come in with it — cfmakeraw needs one.
+      # configure does not DETECT those: they arrive verbatim from
+      # `pkg-config --cflags ncursesw`, which is `-D_DEFAULT_SOURCE
+      # -D_XOPEN_SOURCE=600` on Debian/Ubuntu and something else on other
+      # distributions. Nothing here may depend on a particular one being
+      # present — that is why the client no longer calls strcasestr.
       - name: Build (warnings are errors)
         run: |
           make -C frontends/shottino clean

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,12 @@ priv/plts/*.plt.hash
 !/runtime/bun-cache/
 /runtime/bun-cache/*
 !/runtime/bun-cache/.gitkeep
+# Same reason for the #1027 bridge: `--profile ircd` bind-mounts this as the
+# shottino XDG data home, and Docker would create it root-owned on a fresh
+# clone. The bridge writes its token cache and ircd.log in there as UID 1000.
+!/runtime/shottino/
+/runtime/shottino/*
+!/runtime/shottino/.gitkeep
 
 # ── Docker / env
 .env

--- a/Dockerfile.shottino
+++ b/Dockerfile.shottino
@@ -1,0 +1,65 @@
+# Dockerfile.shottino — the `shottino --ircd` bridge as a compose service
+# (#1027). DISTINCT from the top-level `Dockerfile` (the single-stage dev/CI
+# toolchain image that runs the bouncer) and from `Dockerfile.release`.
+#
+# Why its own file rather than a stage in the bouncer image: shottino's build
+# dependencies are not the bouncer's. `configure` probes the ncursesw and
+# openssl pkg-config MODULES, so it wants ncurses-dev + openssl-dev + pkgconf,
+# where the bouncer image installs the ncurses RUNTIME library and no
+# pkg-config at all. Adding them there would grow an image every operator
+# pulls for a feature most will never switch on, and the top-level Dockerfile
+# is deliberately single-stage ("dev = prod = CI = one path"). So the bridge
+# gets a small image of its own, built only when its compose profile is used.
+#
+# Both stages sit on the SAME alpine tag. Dockerfile.release needs an ABI
+# lockstep gate because its build base (elixir:…-alpine) and its runtime base
+# are different images that drift apart per arch; here there is nothing to
+# prove — one base, one musl, one openssl, by construction.
+
+# ── Stage 1: build ──────────────────────────────────────────────────────────
+FROM alpine:3.24 AS build
+
+# build-base does NOT carry pkg-config on alpine, so `configure` fails at its
+# very first check without pkgconf — before it reaches either .pc module.
+# ncurses-dev ships ncursesw.pc (shottino links the WIDE build, it is UTF-8
+# end to end) and openssl-dev ships openssl.pc.
+RUN apk add --no-cache build-base ncurses-dev openssl-dev pkgconf
+
+WORKDIR /src
+# Only what the client needs. The vendored libdatachannel is a submodule and
+# belongs to the opt-in `make call` helper, which this image does not build:
+# the bridge has no terminal and places no calls.
+COPY Makefile configure ./
+COPY frontends/shottino/ ./frontends/shottino/
+RUN ./configure --prefix=/usr \
+    && make -C frontends/shottino \
+    && ./frontends/shottino/shottino --help > /dev/null
+
+# ── Stage 2: runtime ────────────────────────────────────────────────────────
+FROM alpine:3.24
+
+# The two libraries the binary links, and the trust store it needs to reach
+# grappa over TLS when the operator points it at a public URL rather than at
+# the in-stack `http://grappa:4000`.
+#   ncurses-libs    — libncursesw, linked even headless (the tty is optional,
+#                     the link is not)
+#   openssl         — libssl/libcrypto for the HTTPS + websocket transport
+#   ca-certificates — the system CA bundle
+RUN apk add --no-cache ncurses-libs openssl ca-certificates
+
+COPY --from=build /src/frontends/shottino/shottino /usr/bin/shottino
+
+# Where the bridge keeps its state. compose mounts a host directory here; the
+# client appends its own name, so the log lands at $XDG_DATA_HOME/shottino/
+# ircd.log. Set explicitly rather than left to $HOME because the log is a
+# PLAINTEXT transcript of the session and it must be somewhere the operator
+# chose — that is the whole point of the variable (see the client's README,
+# "Where preferences are kept").
+ENV XDG_DATA_HOME=/state
+WORKDIR /state
+
+EXPOSE 6667
+
+# No CMD. The bridge cannot be started without a grappa URL and a username,
+# and guessing either would produce a container that restarts forever against
+# somebody else's server. compose.yaml supplies the whole command.

--- a/compose.yaml
+++ b/compose.yaml
@@ -214,6 +214,107 @@ services:
       GRAPPA_VERSION: ${GRAPPA_VERSION:-}
     command: ["sh", "-c", "bun install --frozen-lockfile && bun run build"]
 
+  # The `shottino --ircd` bridge (#1027) — a real IRC server on a port, so
+  # irssi/weechat/hexchat/goguma can reach grappa without speaking its REST +
+  # Channels protocol. Opt-in: its own profile, so neither `docker compose up`
+  # nor `--profile prod` builds or starts it.
+  #
+  #   docker compose --profile ircd up -d
+  #
+  # ONE SERVICE PER USER, not per network. A downstream client names the
+  # network it wants in `PASS <network>:<password>`, and that name is stored
+  # per CONNECTION (struct ircd_client.network), so one bridge fronts every
+  # network that grappa account holds — three networks are three `/connect`s
+  # to this same port, the way people already use a bouncer. A SECOND grappa
+  # account needs a second service on a second port, because the login is the
+  # thing that is singular here.
+  #
+  # It builds its own small image (Dockerfile.shottino) rather than riding in
+  # the bouncer's: the C client's build dependencies are not the bouncer's,
+  # and most operators will never turn this on.
+  shottino-ircd:
+    profiles: [ircd]
+    build:
+      context: .
+      dockerfile: Dockerfile.shottino
+    image: grappa-shottino:latest
+    pull_policy: never
+    container_name: grappa-shottino-ircd
+    restart: unless-stopped
+    user: "${CONTAINER_UID:-1000}:${CONTAINER_GID:-1000}"
+    networks:
+      - grappa_internal
+    # The bouncer has to be answering before the bridge logs in. Without this
+    # the first start fails its login and `restart: unless-stopped` turns the
+    # boot race into a retry loop that reads like a bad password.
+    depends_on:
+      grappa:
+        condition: service_healthy
+    ports:
+      # Loopback by default, like GRAPPA_PUBLISH. Note what publishing does to
+      # the bridge's own security posture: from the process's point of view a
+      # published port is bound off-loopback, so shottino REFUSES to start
+      # without SHOTTINO_IRCD_PASS. That refusal is deliberate and this service
+      # does not work around it — the bridge hands over the whole IRC session.
+      - "${SHOTTINO_IRCD_PUBLISH:-127.0.0.1:6667}:6667"
+    volumes:
+      # The bridge's XDG data home. shottino creates its own directory inside,
+      # so the state lands in `runtime/shottino/shottino/` on the host — the
+      # cached token and, more to the point, `ircd.log`.
+      #
+      # THE REASON THIS MOUNT EXISTS: headless, every message of the session is
+      # written to that log in plain text, mode 0600 and never rotated, because
+      # there is no screen to put them on. The image's default $HOME would put
+      # it inside the container; the bouncer's shape would put it inside the
+      # operator's checkout. Neither is a place to grow an unbounded plaintext
+      # transcript. It goes under runtime/, where the rest of the per-env state
+      # already lives and where backup policy can see it.
+      #
+      # This service does NOT bind-mount the repo. Every other service here
+      # does, and that is exactly how the log ends up in a source tree; the
+      # bridge needs no source, so the checkout is out of reach by
+      # construction rather than by configuration.
+      - ./runtime/shottino:/state
+    environment:
+      # Both are MANDATORY for this shape and neither has a default: the login
+      # password because headless there is nobody to prompt (and passing it on
+      # the command line would show it to every user on the host via `ps`, for
+      # as long as the bridge runs — which is permanently), and the bridge
+      # password because the published port is off-loopback. They belong in
+      # .env or the host shell with the other prod secrets, never in here.
+      SHOTTINO_PASSWORD: ${SHOTTINO_PASSWORD:-}
+      SHOTTINO_IRCD_PASS: ${SHOTTINO_IRCD_PASS:-}
+    # `--foreground` because compose supervises what it started and reads the
+    # default fork-after-bind as a crash. 0.0.0.0 inside the container is what
+    # makes the published port reachable; the host-side binding above is what
+    # decides who can actually get to it.
+    #
+    # `:-` and not `:?` on SHOTTINO_USER: compose interpolates this file for
+    # EVERY command, including ones that have nothing to do with this profile,
+    # and `:?` would abort them all. Left unset it is passed through as an
+    # empty username and the bridge fails at the LOGIN, not at argument
+    # parsing — an authentication failure rather than a usage message. With
+    # `restart: unless-stopped` that reads as a restart loop, so check this
+    # variable first when the bridge will not stay up.
+    command:
+      - shottino
+      - --ircd=0.0.0.0:6667
+      - --foreground
+      - ${SHOTTINO_GRAPPA_URL:-http://grappa:4000}
+      - ${SHOTTINO_USER:-}
+    # busybox nc, already in the base image — no package added for a probe.
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 6667 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      start_period: 30s
+      retries: 3
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+
 networks:
   grappa_internal:
     driver: bridge

--- a/configure
+++ b/configure
@@ -50,15 +50,25 @@ check_compile() {
   name=$1
   code=$2
   libs=$3
-  tmp_c=$(mktemp /tmp/shottino-conf.XXXXXX.c)
-  tmp_o=$(mktemp /tmp/shottino-conf.XXXXXX)
+  # One temp DIRECTORY, then ordinary names inside it. The templates were
+  # `shottino-conf.XXXXXX.c` — X's with a suffix after them, which GNU
+  # coreutils accepts and busybox refuses outright ("mktemp: Invalid
+  # argument"). On any busybox userland (alpine, most container images,
+  # a fair number of embedded systems) `set -e` then killed configure at
+  # the FIRST compile test, before it could report a single result. The
+  # suffix is what the compiler needs, so it moves into the filename
+  # where no mktemp has an opinion about it. TMPDIR is honoured because
+  # /tmp is not writable everywhere either.
+  tmp_d=$(mktemp -d "${TMPDIR:-/tmp}/shottino-conf.XXXXXX")
+  tmp_c="$tmp_d/conf.c"
+  tmp_o="$tmp_d/conf"
   printf '%s\n' "$code" > "$tmp_c"
   if ! $cc -o "$tmp_o" "$tmp_c" $libs >/dev/null 2>&1; then
-    rm -f "$tmp_c" "$tmp_o"
+    rm -rf "$tmp_d"
     echo "configure: failed compile/link test: $name" >&2
     exit 1
   fi
-  rm -f "$tmp_c" "$tmp_o"
+  rm -rf "$tmp_d"
 }
 
 check_cmd "$cc"

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1494,7 +1494,9 @@ ssh m42 "curl -fsSL -D - -o /dev/null https://irc.sindro.me/ 2>&1 \
 Committed `compose.yaml` ships deployment-agnostic defaults: grappa
 publishes on `${GRAPPA_PUBLISH:-127.0.0.1:4000}` (loopback only);
 `--profile prod` adds only the `cicchetto-build` oneshot (#485 dropped
-the in-stack nginx — the BEAM self-serves the SPA + owns its headers).
+the in-stack nginx — the BEAM self-serves the SPA + owns its headers);
+`--profile ircd` adds the `shottino-ircd` bridge (#1027, its own section
+below) and nothing else does.
 Anyone can clone + `docker compose up`; nothing depends on a particular
 LAN, hostname, or vlan.
 
@@ -1512,6 +1514,66 @@ the override, NEVER in the committed base. The CSP is host-agnostic —
 `'self'` covers same-origin ws/wss automatically, so
 `GrappaWeb.Plugs.SecurityHeaders` needs no per-host edit; don't
 hardcode hostnames in it.
+
+## The `shottino --ircd` bridge as a compose service (#1027)
+
+For people who want a normal IRC client — irssi, weechat, hexchat,
+goguma — pointed at grappa instead of the web PWA. `shottino --ircd`
+listens as an IRC **server** and translates; this is the supported way
+to run it under compose rather than arranging one by hand.
+
+Opt-in, on its own profile: neither `docker compose up` nor
+`--profile prod` builds it or starts it.
+
+```
+# .env (see .env.example for the whole block)
+SHOTTINO_USER=you
+SHOTTINO_PASSWORD=…            # the grappa login
+SHOTTINO_IRCD_PASS=…           # what downstream clients must send
+
+docker compose --profile ircd up -d
+```
+
+Then, from any IRC client:
+
+```
+/connect 127.0.0.1 6667
+/quote PASS azzurra:<SHOTTINO_IRCD_PASS>
+```
+
+**One service per USER, not per network.** The network is chosen per
+CONNECTION in `PASS <network>:<password>` and held per downstream client
+(`struct ircd_client.network`, eight slots), so one bridge fronts every
+network that grappa account holds: three networks are three `/connect`s
+to this same port, the way people already use a bouncer. What is
+singular here is the LOGIN — a second grappa account needs a second
+service on a second port.
+
+**The bridge password is not optional.** A published port is
+off-loopback from the process's point of view, and off loopback shottino
+refuses to listen without `SHOTTINO_IRCD_PASS`. That is deliberate and
+the service does not work around it: whoever reaches that port owns the
+whole IRC session — every channel, every DM, and the ability to speak as
+you. `SHOTTINO_IRCD_PUBLISH` defaults to `127.0.0.1:6667`; widening it
+is a decision about who that is.
+
+**The log is the sharp edge.** Headless there is no screen, so every
+message of the session goes to `ircd.log` in plain text, mode 0600, and
+it is **never rotated** — it grows for as long as the bridge runs. The
+service mounts `./runtime/shottino` as the bridge's XDG data home, so it
+lands at `runtime/shottino/shottino/ircd.log`, under `runtime/` with the
+rest of the per-env state where a backup or retention policy can see it.
+Two things put it there rather than somewhere worse: the image sets
+`XDG_DATA_HOME`, and — unlike every other service in the stack — this
+one does **not** bind-mount the repo, so the operator's checkout is out
+of reach by construction. Know the file is there before pointing a
+backup at anything.
+
+**When it will not stay up**, check `SHOTTINO_USER` first: unset, it is
+passed through as an empty username and the failure is an authentication
+failure at login, not an argument error, which `restart: unless-stopped`
+turns into a loop. The bridge waits for grappa's healthcheck before it
+starts, so a boot race is not the explanation.
 
 ## Runtime Data
 

--- a/frontends/shottino/Makefile
+++ b/frontends/shottino/Makefile
@@ -154,8 +154,10 @@ tests/test_media: tests/test_media.c tests/test.h media.c media.h termcolor.c te
 
 # The only suite that needs the app's own build environment: it includes
 # shottino.c, so it takes the same feature-test macros ($(CFLAGS_DEPS),
-# which is what puts strcasestr and cfmakeraw in scope) and links what
-# shottino links.
+# which is what puts cfmakeraw in scope) and links what shottino links.
+# Those macros are NOT something configure detects — they ride in from
+# `pkg-config --cflags ncursesw` and differ per distribution, so no source
+# file may rely on a particular one being set.
 tests/test_layout: tests/test_layout.c tests/test.h shottino.c call/whip.c call/whip.h json.c wire.c alias.c mirc.c termcolor.c http.c media.c ircd.c ws.c llm.c
 	$(CC) $(CPPFLAGS) $(TEST_CFLAGS) $(CFLAGS_DEPS) -o $@ tests/test_layout.c call/whip.c json.c wire.c alias.c mirc.c termcolor.c http.c media.c ircd.c ws.c llm.c $(LDLIBS)
 

--- a/frontends/shottino/README.md
+++ b/frontends/shottino/README.md
@@ -154,7 +154,8 @@ address needs no brackets (`--ircd=::1`) but one **with** a port does
 a positional argument, and the positional it would eat is your password.
 
 It **detaches into the background** once it is up, printing the pid, the log
-path (`~/.local/share/shottino/ircd.log`) and how to stop it. **That log holds
+path (`~/.local/share/shottino/ircd.log`, or under `$XDG_DATA_HOME` when that
+is set — see "Where preferences are kept") and how to stop it. **That log holds
 the session's messages in plain text** — headless there is no screen for them,
 so every line goes there instead. Mode 0600, in a 0700 directory, and never
 rotated: it is the bridge's only diagnostic, and it grows for as long as the
@@ -452,6 +453,14 @@ somebody pressed Tab.
 ### Where preferences are kept
 
 Two files under `~/.local/share/shottino`, both mode 0600:
+
+Everything shottino keeps between runs — these files, the cached tokens, the
+block list and the `--ircd` log — lives in one directory: `$XDG_DATA_HOME/shottino`
+when that variable is set, and `~/.local/share/shottino` when it is not, which
+is what the XDG specification says the fallback is. Setting `XDG_DATA_HOME` is
+how a service unit or a container puts that state somewhere other than a home
+directory it did not choose; an empty value counts as unset.
+
 
 | file | holds |
 | --- | --- |

--- a/frontends/shottino/README.md
+++ b/frontends/shottino/README.md
@@ -167,6 +167,12 @@ is still an error you see and a non-zero exit — not a line in a log file you d
 not know to look at. Pass `--foreground` under a service manager, which
 supervises the process it started and reads a fork as a crash.
 
+Under docker compose there is a supported service for exactly this shape —
+`docker compose --profile ircd up -d`, built from `Dockerfile.shottino`. It
+sets `--foreground`, takes the two passwords from the environment, and puts
+the log under `runtime/` instead of wherever `$HOME` happens to point. See
+"The `shottino --ircd` bridge as a compose service" in `docs/OPERATIONS.md`.
+
 **One connection is one network.** An IRC client has one nick, one MOTD and one
 channel namespace per connection, while grappa has several networks at once and
 `#ops` on two of them is two different rooms. So the client names the network it

--- a/frontends/shottino/shottino.c
+++ b/frontends/shottino/shottino.c
@@ -6269,17 +6269,39 @@ static void migrate_identity_path(const char *legacy, const char *current) {
 
 /* The directory this client owns on the machine, created on demand.
  * Everything shottino keeps between runs — cached tokens, the bridge
- * log, the block list — lives here. */
+ * log, the block list — lives here.
+ *
+ * `$XDG_DATA_HOME/shottino` when that variable says something, falling
+ * back to `~/.local/share/shottino` — which is what the specification
+ * says the fallback IS, so the default path does not move.
+ *
+ * The variable is honoured because the path this builds already claims
+ * to obey it: a directory spelled `.local/share` and then chosen by
+ * $HOME alone is a promise the code does not keep, and the surprise
+ * lands on exactly the deployments that set the variable on purpose. A
+ * service unit or a container has a $HOME it did not choose — often a
+ * read-only image path or a bind-mounted source tree — and pointing the
+ * state elsewhere is the whole reason the variable exists.
+ *
+ * An empty value counts as unset: `XDG_DATA_HOME=` in an env block would
+ * otherwise resolve to `/shottino` at the root of the filesystem. */
 static char *shottino_state_dir(void) {
-    const char *home = getenv("HOME");
-    if (!home || !home[0]) home = ".";
-    char *dir = xasprintf("%s/.local", home);
-    mkdir(dir, 0700);
-    free(dir);
-    dir = xasprintf("%s/.local/share", home);
-    mkdir(dir, 0700);
-    free(dir);
-    dir = xasprintf("%s/.local/share/shottino", home);
+    const char *xdg = getenv("XDG_DATA_HOME");
+    char *base;
+    if (xdg && xdg[0]) {
+        base = xasprintf("%s", xdg);
+        mkdir(base, 0700);
+    } else {
+        const char *home = getenv("HOME");
+        if (!home || !home[0]) home = ".";
+        char *parent = xasprintf("%s/.local", home);
+        mkdir(parent, 0700);
+        free(parent);
+        base = xasprintf("%s/.local/share", home);
+        mkdir(base, 0700);
+    }
+    char *dir = xasprintf("%s/shottino", base);
+    free(base);
     mkdir(dir, 0700);
     return dir;
 }

--- a/frontends/shottino/shottino.c
+++ b/frontends/shottino/shottino.c
@@ -2743,6 +2743,41 @@ static char *read_all(struct tls_conn *conn, size_t *out_len) {
     return buf;
 }
 
+/* Case-insensitive substring search — ours, not the libc's.
+ *
+ * `strcasestr` is a GNU/BSD extension: it is declared only when a
+ * feature-test macro puts it in scope, and nothing in this build asks for
+ * one. What the compiler saw instead came from `pkg-config --cflags
+ * ncursesw`, which ships `-D_DEFAULT_SOURCE` on Debian and Ubuntu and
+ * something else elsewhere — so whether a declaration existed at all was
+ * decided by a third-party .pc file. That is not a contract to build on,
+ * and termcolor.c had already written the loop by hand for this reason.
+ *
+ * ASCII-only by construction: `tolower` is locale-aware and would fold
+ * bytes above 127 according to LC_CTYPE, so the same haystack would match
+ * differently on two hosts. Header names and HTML tags are ASCII; the
+ * text around them need not be.
+ *
+ * Returns where the match starts, because two callers read the bytes that
+ * follow it; `contains_ci` is the bool face for the ones that do not. */
+static char fold_ascii_byte(char c) {
+    return (c >= 'A' && c <= 'Z') ? (char)(c - 'A' + 'a') : c;
+}
+
+static const char *find_ci(const char *haystack, const char *needle) {
+    if (!haystack || !needle || !needle[0]) return NULL;
+    for (const char *p = haystack; *p; p++) {
+        size_t i = 0;
+        while (needle[i] && p[i] && fold_ascii_byte(p[i]) == fold_ascii_byte(needle[i])) i++;
+        if (!needle[i]) return p;
+    }
+    return NULL;
+}
+
+static bool contains_ci(const char *haystack, const char *needle) {
+    return find_ci(haystack, needle) != NULL;
+}
+
 /* Generalised request: an explicit content type and an explicit body
  * length, so a body containing NUL bytes (a file upload) survives. The
  * JSON wrapper below is the common case and keeps its old signature. */
@@ -2786,7 +2821,7 @@ static struct http_response http_read_response(struct tls_conn *conn) {
     size_t blen = raw_len >= hdr_len ? raw_len - hdr_len : 0;
     char *payload = NULL;
     size_t payload_len = 0;
-    if (strcasestr(raw, "Transfer-Encoding: chunked")) {
+    if (find_ci(raw, "Transfer-Encoding: chunked")) {
         payload = http_decode_chunked(body_start, blen, &payload_len);
         if (!payload) die("out of memory");
     } else {
@@ -4577,17 +4612,6 @@ static enum media_kind media_kind_of(const char *url) {
     /* The convention, and only where the path stayed silent. */
     if (strstr(lower, "/uploads/") && !url_token_has_extension(lower)) return MEDIA_IMAGE;
     return MEDIA_NONE;
-}
-
-static bool contains_ci(const char *haystack, const char *needle) {
-    if (!needle || !needle[0]) return false;
-    size_t nlen = strlen(needle);
-    for (const char *p = haystack; *p; p++) {
-        size_t i = 0;
-        while (i < nlen && p[i] && tolower((unsigned char)p[i]) == tolower((unsigned char)needle[i])) i++;
-        if (i == nlen) return true;
-    }
-    return false;
 }
 
 /* Nick identity, under the SAME casemapping windows use: strcasecmp
@@ -11030,7 +11054,7 @@ static char *html_to_text(const char *html) {
             if (strncasecmp(html + i, "<script", 7) == 0) skip = "</script";
             else if (strncasecmp(html + i, "<style", 6) == 0) skip = "</style";
             if (skip) {
-                const char *end = strcasestr(html + i, skip);
+                const char *end = find_ci(html + i, skip);
                 i = end ? (size_t)(end - html) : n;
             }
             while (i < n && html[i] != '>') i++;
@@ -16409,7 +16433,7 @@ static void fetch_result_free(struct fetch_result *r) {
 /* Copy a header's value out of a NUL-terminated header block. */
 static void header_value(const char *headers, const char *name, char *out, size_t out_sz) {
     out[0] = 0;
-    const char *p = strcasestr(headers, name);
+    const char *p = find_ci(headers, name);
     if (!p) return;
     p += strlen(name);
     while (*p == ' ' || *p == '\t') p++;
@@ -16491,7 +16515,7 @@ static bool http_fetch(struct app *app, const char *url, struct fetch_result *ou
     out->status = status_sp ? atoi(status_sp + 1) : 0;
     header_value(buf, "Location:", out->location, sizeof(out->location));
     header_value(buf, "Content-Type:", out->content_type, sizeof(out->content_type));
-    bool chunked = strcasestr(buf, "Transfer-Encoding: chunked") != NULL;
+    bool chunked = find_ci(buf, "Transfer-Encoding: chunked") != NULL;
     char *body_start = sep + 4;
     size_t hdr_len = (size_t)(body_start - buf);
     size_t blen = len >= hdr_len ? len - hdr_len : 0;

--- a/frontends/shottino/tests/test.h
+++ b/frontends/shottino/tests/test.h
@@ -21,6 +21,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+/* mkdir, for the temporary XDG data home built below. */
+#include <sys/stat.h>
 /* mkdtemp lives in stdlib.h on glibc and in unistd.h on macOS. */
 #include <unistd.h>
 
@@ -145,7 +147,78 @@ static inline void test_use_temp_home(void) {
         test_temp_home_remove();
         exit(1);
     }
+    /* XDG_DATA_HOME as well, and for the same reason.
+     *
+     * shottino_state_dir() prefers that variable over $HOME. A developer
+     * who exports it — which is ordinary on a Linux desktop — would
+     * otherwise have every suite that compiles shottino.c write its
+     * settings and tokens into their REAL data directory, with the
+     * temporary HOME above sitting there looking like it prevented
+     * exactly that. Moving HOME alone stopped being enough the moment
+     * the variable was honoured, so the two move together.
+     *
+     * It is SET rather than unset, and set to where $HOME would have put
+     * it, so the suites keep seeing the ordinary layout. */
+    char data_home[sizeof(test_temp_home) + 16];
+    snprintf(data_home, sizeof(data_home), "%s/.local", test_temp_home);
+    mkdir(data_home, 0700);
+    snprintf(data_home, sizeof(data_home), "%s/.local/share", test_temp_home);
+    mkdir(data_home, 0700);
+    if (setenv("XDG_DATA_HOME", data_home, 1) != 0) {
+        fprintf(stderr, "FATAL %s: setenv(XDG_DATA_HOME): %s\n", __FILE__, strerror(errno));
+        test_temp_home_remove();
+        exit(1);
+    }
     atexit(test_temp_home_remove);
+}
+
+/* A state directory of its OWN, for one test that needs to start empty.
+ *
+ * Three tests used to write this by hand as `setenv("HOME", mkdtemp(...))`
+ * and put HOME back at the end. That stopped isolating anything the
+ * moment shottino_state_dir() began preferring XDG_DATA_HOME: the swap
+ * still looked deliberate, and the test went on reading and writing the
+ * suite-wide directory that every other test uses. Two of the three
+ * failed outright; the third would have passed for the wrong reason,
+ * which is the worse outcome. So the swap lives here once, moves BOTH
+ * variables, and there is no hand-rolled fourth copy to get wrong.
+ *
+ * XDG_DATA_HOME is pointed at `<dir>/.local/share` rather than at `<dir>`
+ * so the on-disk layout is the one a real installation has — tests that
+ * name `.local/share/shottino/...` in a path are describing what a user
+ * would find, and should keep doing so. */
+struct test_state_dir {
+    char dir[64];
+    char *saved_home;
+    char *saved_data_home;
+};
+
+static inline bool test_state_dir_take(struct test_state_dir *s, const char *template) {
+    snprintf(s->dir, sizeof(s->dir), "%s", template);
+    s->saved_home = NULL;
+    s->saved_data_home = NULL;
+    if (!mkdtemp(s->dir)) return false;
+    const char *home = getenv("HOME");
+    const char *data_home = getenv("XDG_DATA_HOME");
+    if (home) s->saved_home = strdup(home);
+    if (data_home) s->saved_data_home = strdup(data_home);
+    char under[sizeof(s->dir) + 16];
+    snprintf(under, sizeof(under), "%s/.local", s->dir);
+    mkdir(under, 0700);
+    snprintf(under, sizeof(under), "%s/.local/share", s->dir);
+    mkdir(under, 0700);
+    return setenv("HOME", s->dir, 1) == 0 && setenv("XDG_DATA_HOME", under, 1) == 0;
+}
+
+static inline void test_state_dir_release(struct test_state_dir *s) {
+    if (s->saved_home) setenv("HOME", s->saved_home, 1);
+    else unsetenv("HOME");
+    if (s->saved_data_home) setenv("XDG_DATA_HOME", s->saved_data_home, 1);
+    else unsetenv("XDG_DATA_HOME");
+    free(s->saved_home);
+    free(s->saved_data_home);
+    s->saved_home = NULL;
+    s->saved_data_home = NULL;
 }
 
 /* CAPTURING STDERR, which two suites now need: it is the media helper's

--- a/frontends/shottino/tests/test_windows.c
+++ b/frontends/shottino/tests/test_windows.c
@@ -115,6 +115,46 @@ TEST(the_case_insensitive_search_is_ours_and_returns_where_it_matched) {
     CHECK(find_ci("caf\xc3\x89", "caf\xc3\xa9") == NULL);
 }
 
+/* Where this client keeps its state is an XDG question, and the name of
+ * the directory it builds says so. Honouring the variable is what lets a
+ * service unit or a container put the token cache and the bridge log
+ * somewhere other than a home directory it does not really have.
+ *
+ * The suite's own temporary HOME is what makes this safe to assert: see
+ * test_use_temp_home, which points BOTH the home and the XDG variable at
+ * a directory it made. */
+TEST(the_state_directory_follows_the_xdg_variable) {
+    /* As the suite starts: XDG_DATA_HOME agrees with HOME, so the answer
+     * is the historical `~/.local/share/shottino` either way. */
+    char *before = shottino_state_dir();
+    CHECK(find_ci(before, "/.local/share/shottino") != NULL);
+    free(before);
+
+    char elsewhere[96];
+    snprintf(elsewhere, sizeof(elsewhere), "%s/somewhere-else", getenv("HOME"));
+    CHECK_LONG(mkdir(elsewhere, 0700), 0);
+    CHECK_LONG(setenv("XDG_DATA_HOME", elsewhere, 1), 0);
+
+    char want[128];
+    snprintf(want, sizeof(want), "%s/shottino", elsewhere);
+    char *moved = shottino_state_dir();
+    CHECK_STR(moved, want);
+    free(moved);
+
+    /* An empty value is not a location. Falling back to HOME beats
+     * creating `/shottino` off the root of the filesystem. */
+    CHECK_LONG(setenv("XDG_DATA_HOME", "", 1), 0);
+    char *empty = shottino_state_dir();
+    CHECK(find_ci(empty, "/.local/share/shottino") != NULL);
+    free(empty);
+
+    /* Put the suite's own value back — every later test that touches
+     * state must keep landing inside the temporary home. */
+    char restore[96];
+    snprintf(restore, sizeof(restore), "%s/.local/share", getenv("HOME"));
+    CHECK_LONG(setenv("XDG_DATA_HOME", restore, 1), 0);
+}
+
 /* contains_ci is the bool face of the same search, and the seven mention
  * and filter callers must keep agreeing with it. */
 TEST(the_bool_face_agrees_with_the_pointer_one) {
@@ -2526,11 +2566,8 @@ TEST(the_context_budget_leaves_room_for_the_fixed_parts) {
  * was a different bug; what they shared was that the damage was instant
  * and total. */
 TEST(a_config_write_leaves_the_previous_version_behind) {
-    char home[] = "/tmp/shottino-backup-XXXXXX";
-    CHECK(mkdtemp(home) != NULL);
-    char *old_home = getenv("HOME");
-    char *saved = old_home ? strdup(old_home) : NULL;
-    setenv("HOME", home, 1);
+    struct test_state_dir sd;
+    CHECK(test_state_dir_take(&sd, "/tmp/shottino-backup-XXXXXX"));
 
     struct app *app = window_app();
     CHECK(app != NULL);
@@ -2577,9 +2614,7 @@ TEST(a_config_write_leaves_the_previous_version_behind) {
     unlink(path);
     unlink(backup);
     free_app(app);
-    if (saved) setenv("HOME", saved, 1);
-    else unsetenv("HOME");
-    free(saved);
+    test_state_dir_release(&sd);
 }
 
 /* An empty system prompt is a STATE, not an absence.
@@ -4423,11 +4458,8 @@ TEST(an_arriving_call_rings_only_where_it_should) {
  * devices and the three display toggles were set-and-lose, while the
  * settings panel presented both halves identically. */
 TEST(a_preference_survives_a_restart) {
-    char home[] = "/tmp/shottino-prefs-test-XXXXXX";
-    CHECK(mkdtemp(home) != NULL);
-    char *old_home = getenv("HOME");
-    char *saved = old_home ? strdup(old_home) : NULL;
-    setenv("HOME", home, 1);
+    struct test_state_dir sd;
+    CHECK(test_state_dir_take(&sd, "/tmp/shottino-prefs-test-XXXXXX"));
 
     struct app *a = window_app();
     /* Through the same door /set uses, so the test cannot pass by
@@ -4458,7 +4490,7 @@ TEST(a_preference_survives_a_restart) {
     /* llm.* is llm.conf's business — writing it here too would give one
      * value two files to disagree from. */
     char path[512];
-    snprintf(path, sizeof(path), "%s/.local/share/shottino/shottino.conf", home);
+    snprintf(path, sizeof(path), "%s/.local/share/shottino/shottino.conf", sd.dir);
     FILE *f = fopen(path, "r");
     CHECK(f != NULL);
     char buf[4096];
@@ -4476,9 +4508,7 @@ TEST(a_preference_survives_a_restart) {
     unlink(path);
     free_app(a);
     free_app(b);
-    if (saved) setenv("HOME", saved, 1);
-    else unsetenv("HOME");
-    free(saved);
+    test_state_dir_release(&sd);
 }
 
 /* A standing grant belongs to a PERSON, not to a nick.
@@ -4509,11 +4539,8 @@ static void identify(struct app *app, const char *nick, const char *account) {
  * upgrading would log everyone out and orphan every bot directory,
  * leaving the notes on disk under a name nothing looks for. */
 TEST(an_identity_keeps_its_notes_across_the_rename) {
-    char home[] = "/tmp/shottino-migrate-XXXXXX";
-    CHECK(mkdtemp(home) != NULL);
-    char *old_home = getenv("HOME");
-    char *saved = old_home ? strdup(old_home) : NULL;
-    setenv("HOME", home, 1);
+    struct test_state_dir sd;
+    CHECK(test_state_dir_take(&sd, "/tmp/shottino-migrate-XXXXXX"));
 
     struct app *app = window_app();
     snprintf(app->url.base, sizeof(app->url.base), "https://grappa.example.net");
@@ -4554,9 +4581,7 @@ TEST(an_identity_keeps_its_notes_across_the_rename) {
     rmdir(now);
     free(state);
     free_app(app);
-    if (saved) setenv("HOME", saved, 1);
-    else unsetenv("HOME");
-    free(saved);
+    test_state_dir_release(&sd);
 }
 
 TEST(a_standing_grant_survives_a_restart) {
@@ -5007,6 +5032,7 @@ int main(void) {
 
     RUN(names_are_compared_under_the_ircds_casemapping);
     RUN(the_case_insensitive_search_is_ours_and_returns_where_it_matched);
+    RUN(the_state_directory_follows_the_xdg_variable);
     RUN(the_bool_face_agrees_with_the_pointer_one);
     RUN(a_channel_opened_twice_in_two_spellings_is_one_window);
     RUN(a_query_answered_in_another_case_reuses_its_window);

--- a/frontends/shottino/tests/test_windows.c
+++ b/frontends/shottino/tests/test_windows.c
@@ -103,9 +103,15 @@ TEST(the_case_insensitive_search_is_ours_and_returns_where_it_matched) {
     /* Empty needle and empty haystack, because callers pass user text. */
     CHECK(find_ci("anything", "") == NULL);
     CHECK(find_ci("", "x") == NULL);
-    /* Bytes above 127 are compared as bytes: `tolower` is locale-aware
-     * and would fold them differently on a different LC_CTYPE, so a
-     * UTF-8 haystack must not depend on where it is run. */
+    /* Two different UTF-8 sequences are two different strings.
+     *
+     * NOT covered here, deliberately said out loud: that the fold is
+     * BYTE-level rather than `tolower`. In the "C" locale the two are
+     * indistinguishable — which is the locale every test run has — so
+     * swapping the implementation for `tolower` leaves this suite green.
+     * It was measured, not assumed. The reason to fold by byte anyway is
+     * a host whose LC_CTYPE is not C, and reproducing that needs a
+     * generated locale this suite is not going to depend on. */
     CHECK(find_ci("caf\xc3\x89", "caf\xc3\xa9") == NULL);
 }
 

--- a/frontends/shottino/tests/test_windows.c
+++ b/frontends/shottino/tests/test_windows.c
@@ -71,6 +71,52 @@ TEST(names_are_compared_under_the_ircds_casemapping) {
     CHECK(!irc_name_eq("#caf\xc3\x89", "#caf\xc3\xa9"));
 }
 
+/* The other case-insensitive match in this file, and the one that is not
+ * about IRC names: `find_ci` is what the HTTP and HTML paths use to look
+ * for a header or a closing tag whose case they do not control.
+ *
+ * It is hand-written for the same reason `irc_name_eq` is — `strcasestr`
+ * is a GNU/BSD extension, declared only when a feature-test macro happens
+ * to be in scope, and which macros are in scope here is decided by the
+ * Cflags of whatever ncursesw.pc the build host ships. That is not a
+ * contract, so the search is ours. */
+TEST(the_case_insensitive_search_is_ours_and_returns_where_it_matched) {
+    const char *headers = "HTTP/1.1 302 Found\r\nlocation: https://example.net/x\r\n";
+    /* The POINT of returning a pointer rather than a bool: two callers
+     * read the bytes that follow the match. */
+    const char *at = find_ci(headers, "Location:");
+    CHECK(at != NULL);
+    CHECK_STR(at, "location: https://example.net/x\r\n");
+    /* Folding runs in both directions, not just needle-to-haystack. */
+    CHECK(find_ci("TRANSFER-ENCODING: CHUNKED", "transfer-encoding: chunked") != NULL);
+    CHECK(find_ci("transfer-encoding: chunked", "Transfer-Encoding: chunked") != NULL);
+    /* Absent is NULL, and a near-miss is absent. */
+    CHECK(find_ci(headers, "Content-Type:") == NULL);
+    CHECK(find_ci("abc", "abcd") == NULL);
+    /* The match must be found at the very end of the haystack too — an
+     * off-by-one in the scan bound is exactly what a "close enough"
+     * hand-rolled search gets wrong. */
+    CHECK_STR(find_ci("xxYYY", "yyy"), "YYY");
+    /* Overlapping candidates: the first real match wins, not the first
+     * character that happened to agree. */
+    CHECK_STR(find_ci("aab", "AB"), "ab");
+    /* Empty needle and empty haystack, because callers pass user text. */
+    CHECK(find_ci("anything", "") == NULL);
+    CHECK(find_ci("", "x") == NULL);
+    /* Bytes above 127 are compared as bytes: `tolower` is locale-aware
+     * and would fold them differently on a different LC_CTYPE, so a
+     * UTF-8 haystack must not depend on where it is run. */
+    CHECK(find_ci("caf\xc3\x89", "caf\xc3\xa9") == NULL);
+}
+
+/* contains_ci is the bool face of the same search, and the seven mention
+ * and filter callers must keep agreeing with it. */
+TEST(the_bool_face_agrees_with_the_pointer_one) {
+    CHECK(contains_ci("hello VJT there", "vjt"));
+    CHECK(!contains_ci("hello there", "vjt"));
+    CHECK(!contains_ci("anything", ""));
+}
+
 TEST(a_channel_opened_twice_in_two_spellings_is_one_window) {
     struct app *app = window_app();
     CHECK(app != NULL);
@@ -4954,6 +5000,8 @@ int main(void) {
     test_use_temp_home();
 
     RUN(names_are_compared_under_the_ircds_casemapping);
+    RUN(the_case_insensitive_search_is_ours_and_returns_where_it_matched);
+    RUN(the_bool_face_agrees_with_the_pointer_one);
     RUN(a_channel_opened_twice_in_two_spellings_is_one_window);
     RUN(a_query_answered_in_another_case_reuses_its_window);
     RUN(a_row_files_under_its_windows_canonical_key);

--- a/test/grappa/config/env_registry_drift_test.exs
+++ b/test/grappa/config/env_registry_drift_test.exs
@@ -11,12 +11,27 @@ defmodule Grappa.Config.EnvRegistryDriftTest do
   instead of at a prod boot.
 
   DERIVED, not manifested (CLAUDE.md design-rule 1 — derive, don't
-  duplicate): `app_vars/0` is parsed at test time from the two files that
-  actually consume env vars — `config/runtime.exs` (`System.get_env` /
-  `fetch_env!`) and `bin/start.sh` (`${VAR:=}` / `${VAR:?}` / `${VAR:-}`
-  operator knobs). A hand-kept manifest would be a parallel list that
-  drifts from the reads — the exact failure this pin exists to catch. No
-  production module: nothing at runtime needs the list.
+  duplicate): the known-var set is parsed at test time from the THREE
+  files that actually consume env vars — `config/runtime.exs`
+  (`System.get_env` / `fetch_env!`) and `bin/start.sh` (`${VAR:=}` /
+  `${VAR:?}` / `${VAR:-}` operator knobs), which together are `app_vars/0`,
+  plus `compose.yaml` itself (`compose_orchestration_reads/0`), which
+  consumes vars to orchestrate the containers rather than to run the app.
+  A hand-kept manifest would be a parallel list that drifts from the
+  reads — the exact failure this pin exists to catch. No production
+  module: nothing at runtime needs the list.
+
+  The third surface was hand-kept until #1027 and duly drifted the first
+  time a service was added: two of three consuming files were derived and
+  the third was a literal list, so five vars that compose demonstrably
+  reads (`ports:`, `command:`, a sidecar's own `environment:`) failed the
+  pin as "dead knobs". Deriving it is the repair; adding five names would
+  have propagated the asymmetry.
+
+  Orchestration vars are ALLOWED in `.env.example`, not REQUIRED there —
+  only `app_vars/0` is required. So a compose-only knob may still go
+  undocumented (`GRAPPA_VERSION`, `CIC_BUILD_OUT` are, today). Widening
+  the requirement is a separate call, deliberately not made here.
 
   Scope is deliberately the Docker contract (`compose.yaml` +
   `.env.example`) only — what the registry comment claims. The FreeBSD /
@@ -26,10 +41,10 @@ defmodule Grappa.Config.EnvRegistryDriftTest do
   var missing there already crashes loud via runtime.exs `raise`.
 
   Two exemptions (the "20% domain boundary"): `@docker_orchestration`
-  (UID/GID, publish ports, `MIX_ENV` — drive Docker, not the app; allowed
-  as extras), and `@env_example_exempt` (`.env.example` omits
-  `DATABASE_PATH` because compose COMPUTES it and an `environment:`
-  literal shadows any `.env` value — documenting it would be a lie).
+  (the residue no derivation can reach — see its own comment), and
+  `@env_example_exempt` (`.env.example` omits `DATABASE_PATH` because
+  compose COMPUTES it and an `environment:` literal shadows any `.env`
+  value — documenting it would be a lie).
   """
 
   # async: true — pure file parsing, no global state.
@@ -40,18 +55,25 @@ defmodule Grappa.Config.EnvRegistryDriftTest do
   @compose "compose.yaml"
   @env_example ".env.example"
 
-  # Docker-orchestration vars: read by compose.yaml / .env.example to
-  # drive the container runtime, NOT by the app. Allowed as extras.
-  # NGINX_PUBLISH is a DEPRECATED alias (#485 dropped the nginx container);
-  # compose.yaml no longer reads it, but it stays a commented note in
-  # .env.example for one release, so it must remain allowed here.
-  @docker_orchestration MapSet.new([
-                          "CONTAINER_UID",
-                          "CONTAINER_GID",
-                          "MIX_ENV",
-                          "GRAPPA_PUBLISH",
-                          "NGINX_PUBLISH"
-                        ])
+  # RESIDUE, not a manifest. Everything a derivation can reach is derived
+  # (`app_vars/0`, `compose_orchestration_reads/0`); these two are the only
+  # names left that no reader can see, and each is here for a stated
+  # reason, not for convenience. Adding a third entry is almost certainly
+  # wrong — check first whether the var has a reader the derivation should
+  # be looking at instead. UID/GID and the publish ports USED to sit here
+  # and no longer do: compose reads them, so compose is where they come
+  # from now.
+  #
+  #   MIX_ENV        — read only INSIDE the grappa `environment:` block,
+  #                    the one region the orchestration derivation must
+  #                    subtract (see compose_orchestration_reads/0). It is
+  #                    also the one non-app key that block forwards, so it
+  #                    is what keeps the compose orphan pin honest.
+  #   NGINX_PUBLISH  — a DEPRECATED alias (#485 dropped the nginx
+  #                    container). NOTHING reads it any more; it survives
+  #                    for one release as a commented note in
+  #                    .env.example, so no derivation can justify it.
+  @docker_orchestration MapSet.new(["MIX_ENV", "NGINX_PUBLISH"])
 
   # .env.example legitimately omits DATABASE_PATH — compose computes it.
   @env_example_exempt MapSet.new(["DATABASE_PATH"])
@@ -68,17 +90,55 @@ defmodule Grappa.Config.EnvRegistryDriftTest do
     |> MapSet.new()
   end
 
-  # Operator-facing shell knobs: `${VAR:=default}` / `${VAR:?msg}` /
-  # `${VAR:-default}`. Deliberately NOT plain `${VAR}` — that also matches
-  # computed locals (GRAPPA_MAX_PORTS, GRAPPA_MAX_PROCS), derived not env.
+  # An operator-facing knob: `${VAR:=default}` / `${VAR:?msg}` /
+  # `${VAR:-default}`. Deliberately NOT plain `${VAR}` — in bin/start.sh
+  # that also matches computed locals (GRAPPA_MAX_PORTS, GRAPPA_MAX_PROCS),
+  # derived not env. One regex for both files, because compose interpolates
+  # with the same shell syntax.
+  #
+  # Two known limits, both accepted, neither silent-safe to forget:
+  #   - a knob written BARE (no default, no `:?`) is invisible here. Both
+  #     files write the operator form everywhere today.
+  #   - this is a text scan, not a parse: the operator form written inside
+  #     a COMMENT counts as a read. compose.yaml has exactly one such
+  #     ghost (`NOT ${VAR:-}`, prose in the grappa `environment:` block),
+  #     and it is invisible today only because that block is subtracted
+  #     below. A ghost written elsewhere would silently widen the allowed
+  #     set — it can never hide a var, only excuse one.
+  @knob ~r/\$\{([A-Z][A-Z0-9_]*):[?=-]/
+
   defp shell_env_reads do
-    ~r/\$\{([A-Z][A-Z0-9_]*):[?=-]/
+    @knob
     |> Regex.scan(read!(@start_sh), capture: :all_but_first)
     |> List.flatten()
     |> MapSet.new()
   end
 
   defp app_vars, do: MapSet.union(runtime_env_reads(), shell_env_reads())
+
+  # Vars compose.yaml consumes to orchestrate the CONTAINERS — publish
+  # ports, uid/gid, bind-mount targets, the command line and `environment:`
+  # of a sidecar service. Real consumption, just not by the Elixir app, so
+  # `app_vars/0` will never contain them.
+  #
+  # The grappa service's own `environment:` block is SUBTRACTED, and that
+  # subtraction is the whole reason this function is safe. Every key in
+  # that block is written `KEY: ${KEY:-…}`, so a var there interpolates
+  # ITSELF: fold it in and the orphan pins below would accept whatever
+  # compose happens to forward, purely because compose forwards it. The
+  # gate would still be green and would no longer be able to fail. The
+  # block is the surface `compose_grappa_env_keys/0` polices against
+  # `app_vars/0`; it must not double as evidence for its own defence.
+  defp compose_orchestration_reads do
+    compose = read!(@compose)
+
+    @knob
+    |> Regex.scan(String.replace(compose, compose_grappa_env_block(), ""),
+      capture: :all_but_first
+    )
+    |> List.flatten()
+    |> MapSet.new()
+  end
 
   # ── declaration-file parsers ───────────────────────────────────────
 
@@ -98,36 +158,34 @@ defmodule Grappa.Config.EnvRegistryDriftTest do
     |> MapSet.new()
   end
 
-  # Keys of the grappa service's `environment:` block in compose.yaml.
-  # Anchored to the `  grappa:` service (bounded by the next 2-space
-  # service header) so a sibling service's environment: is never read;
-  # within it the block ends at the next 4-space sibling key. Comment /
-  # blank lines inside the block are skipped, not treated as the end.
-  defp compose_grappa_env_keys do
+  # The grappa service's `environment:` block, verbatim. Anchored to the
+  # `  grappa:` service (bounded by the next 2-space service header) so a
+  # sibling service's environment: is never read; the block itself ends at
+  # the first line indented <= 4 spaces. Comment / blank lines inside are
+  # not an end — neither is indented enough to match.
+  #
+  # Two readers, and they want opposite things from it: the key pin below
+  # polices exactly this region, and compose_orchestration_reads/0 above
+  # removes exactly this region. One extraction, so the two can never
+  # disagree about where the block stops.
+  defp compose_grappa_env_block do
     [_, after_grappa] = String.split(read!(@compose), ~r/^  grappa:\n/m, parts: 2)
     [grappa_svc | _] = String.split(after_grappa, ~r/^  [a-z]/m, parts: 2)
     [_, body] = String.split(grappa_svc, ~r/\n {4}environment:\n/, parts: 2)
 
     body
     |> String.split("\n")
-    |> Enum.reduce_while([], fn line, acc ->
-      cond do
-        match = Regex.run(~r/^ {6}([A-Z][A-Z0-9_]*):/, line) ->
-          [_, key] = match
-          {:cont, [key | acc]}
+    |> Enum.take_while(&(not Regex.match?(~r/^ {0,4}\S/, &1)))
+    |> Enum.join("\n")
+  end
 
-        Regex.match?(~r/^ {6}#/, line) ->
-          {:cont, acc}
-
-        Regex.match?(~r/^\s*$/, line) ->
-          {:cont, acc}
-
-        # Any line indented <= 4 spaces ends the 6-space block.
-        Regex.match?(~r/^ {0,4}\S/, line) ->
-          {:halt, acc}
-
-        true ->
-          {:cont, acc}
+  defp compose_grappa_env_keys do
+    compose_grappa_env_block()
+    |> String.split("\n")
+    |> Enum.flat_map(fn line ->
+      case Regex.run(~r/^ {6}([A-Z][A-Z0-9_]*):/, line) do
+        [_, key] -> [key]
+        nil -> []
       end
     end)
     |> MapSet.new()
@@ -163,6 +221,23 @@ defmodule Grappa.Config.EnvRegistryDriftTest do
       refute "GRAPPA_MAX_PORTS" in reads
       refute "GRAPPA_MAX_PROCS" in reads
     end
+
+    test "compose reads see the container knobs but NOT the app env it forwards" do
+      reads = compose_orchestration_reads()
+
+      # Outside the grappa `environment:` block: `user:`, `ports:`, and a
+      # sidecar service's own environment: — all genuine orchestration.
+      assert "CONTAINER_UID" in reads
+      assert "GRAPPA_PUBLISH" in reads
+      assert "SHOTTINO_IRCD_PASS" in reads
+
+      # INSIDE it. These must not leak in, or the orphan pins below pass by
+      # tautology: compose writes `SECRET_KEY_BASE: ${SECRET_KEY_BASE:-}`,
+      # so a leak would let every forwarded key vouch for itself and the
+      # gate could no longer fail. This refute IS the subtraction's witness.
+      refute "SECRET_KEY_BASE" in reads
+      refute "LOG_LEVEL" in reads
+    end
   end
 
   # ── the pins (Docker contract only) ─────────────────────────────────
@@ -197,8 +272,12 @@ defmodule Grappa.Config.EnvRegistryDriftTest do
     end
 
     test "declares NO var outside the app + Docker-orchestration surface" do
-      orphans =
-        MapSet.difference(env_file_decls(@env_example), MapSet.union(app_vars(), @docker_orchestration))
+      consumed =
+        app_vars()
+        |> MapSet.union(compose_orchestration_reads())
+        |> MapSet.union(@docker_orchestration)
+
+      orphans = MapSet.difference(env_file_decls(@env_example), consumed)
 
       assert MapSet.size(orphans) == 0,
              ".env.example documents vars nothing consumes (dead knob?): #{inspect(sorted(orphans))}"


### PR DESCRIPTION
Requested by a self-hoster on IRC (#1027): run a normal IRC client against
grappa with `docker compose up` instead of arranging a bridge by hand.

```
SHOTTINO_USER=you SHOTTINO_PASSWORD=… SHOTTINO_IRCD_PASS=…   # .env
docker compose --profile ircd up -d
```

The issue was right that no code was missing from `--ircd`. Verifying its
three measured constraints turned up more than packaging, so the series is
five commits and the first three are build prerequisites, not scope creep:
without them the alpine image cannot compile the client at all.

## The two constraints that did not survive verification

**The log path constraint names the wrong mechanism.** The issue says the
image's `XDG_DATA_HOME=/app/.local/share` is what lands the plaintext bridge
log inside the operator's checkout, and prescribes pointing that variable at
`runtime/`. But `shottino_state_dir()` reads **`HOME`** and never looked at
`XDG_DATA_HOME` at all. The outcome described is real; the cause is
`HOME=/app`. Applying the prescription literally would have been a **silent
no-op**: the log stays exactly where it was and the fix looks applied. So the
client now honours the variable it already appeared to obey — the path it
builds by hand *is* the XDG default — with `$HOME/.local/share` unchanged as
the fallback.

**"One network = one service/port" is one inference too far.** One connection
is one network — true, and the client's README says so. But the network name
is held **per downstream connection** (`struct ircd_client.network`, eight
slots), so a single bridge fronts every network that grappa account holds:
three networks are three `/connect`s to the *same* port, the way people
already use a bouncer. Three ports would have been three logins of the same
user. What is singular here is the **login**, so the axis is one service per
USER, and a second grappa *account* is what needs a second service.

## The build constraint was right, and understated

Three separate blockers, not one:

1. `build-base` does not carry pkg-config on alpine, so `configure` dies at
   its first check before reaching either `.pc` module.
2. `configure`'s compile probes used `mktemp` templates with a suffix after
   the X's. GNU coreutils accepts that; busybox refuses it outright, and under
   `set -eu` that ends the script at the first probe on every busybox
   userland.
3. `strcasestr` is a GNU/BSD extension and nothing in this build asks for a
   feature-test macro. What put a declaration in scope on Debian/Ubuntu was
   **`pkg-config --cflags ncursesw`** — `-D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600`
   there, `-D_BSD_SOURCE -DNCURSES_WIDECHAR` on alpine. Whether four call
   sites compiled correctly was decided by a third-party .pc file. `termcolor.c`
   had already written the loop by hand for exactly this reason, and
   `shottino.c` had its own `contains_ci` doing the same in bool form, so the
   fix is to generalise that one rather than add a primitive. Two comments
   claiming `configure` *detects* those macros are corrected: it does not, it
   passes `pkg-config --cflags` through verbatim.

## What the service does

- Own profile — neither `docker compose up` nor `--profile prod` builds or
  starts it. Own 18 MB image (`Dockerfile.shottino`), because the C client's
  build dependencies are not the bouncer's and most operators will never
  switch this on; both stages sit on one alpine tag, so unlike
  `Dockerfile.release` there is no ABI drift to prove.
- **No repo bind-mount.** Every other service here has one, and that is
  precisely how the log ended up in a source tree. The bridge needs no source,
  so the checkout is out of reach *by construction* rather than by
  configuration — a stronger guarantee than pointing a variable somewhere
  better. `./runtime/shottino` is mounted as its XDG data home instead.
- Both passwords come from `.env` with the other prod secrets, neither with a
  default. Off-loopback the bridge refuses to listen without
  `SHOTTINO_IRCD_PASS`, and a published port is off-loopback from the
  process's point of view; the service does not work around that.

## Gates

Rebased onto `origin/main` after it moved seven commits (#440, #462) — every
number below was re-measured on the rebased tree, not carried over.

| gate | result |
| --- | --- |
| shottino build, `-Werror` (ubuntu 24.04, the CI platform) | rc 0, no diagnostics |
| `make check` (ASan + UBSan) | 18 suites pass; 2 pre-existing `test_layout` failures |
| **alpine end-to-end** — `./configure && make` on busybox/musl, no coreutils, no added feature macro | builds clean, binary runs |
| `docker build --no-cache -f Dockerfile.shottino` | rc 0, 18.1 MB, `--help` runs |
| bats `test/bin test/infra test/scripts` | 366/366 |
| `scripts/shellcheck.sh` | rc 0, 71 scripts |
| `docker compose --profile ircd config` | rc 0; service absent without the profile |

The two `test_layout` failures reproduce **identically on unmodified
`origin/main`** in the same image, and `frontends/shottino` is byte-identical
between my baseline commit and current `origin/main`, so the baseline still
holds. They are environment-dependent — CI is green on the same platform —
and are not touched here.

Mutation-tested the new helper rather than trusting a green: returning the
haystack start instead of the match position fails 4 checks, folding only one
side fails 5. A third mutation — swapping the byte fold for `tolower` — did
**not** fail, because in the "C" locale the two are indistinguishable. That
assertion's comment now says so instead of implying coverage it does not have.

Touches **no** `infra/lib/deploy_common.sh` and no `substrate_*` consumer
(`git diff origin/main..HEAD` on those paths is empty), so it does not collide
with #440.

## What this PR does not claim

- **Not** that the pre-`find_ci` narrowing was reachable in production. The
  pattern was measured in isolation; no path from a real user action to it was
  traced.
- **Not** that the distribution packages were affected. `dpkg-buildflags` and
  PKGBUILD may override `CPPFLAGS` and re-expose the declaration; not measured.
- **Not** that the bridge works end to end. It compiles, the image builds and
  runs `--help`, and compose renders and validates — but no client has
  connected through it to a live grappa. That needs the integration stack.
- **Not** that the off-loopback refusal fires as described. The guard is at
  `shottino.c:21894` and I read it; observing it needs a reachable grappa,
  because it runs *after* the login by design.
- `configure` sits outside `scripts/shellcheck.sh`'s derived roots
  (`bin infra scripts`), so this change is unlinted by the #441 gate. Linting
  it by hand shows one SC2086, **identical on `origin/main`** and deliberate
  (`$libs` must word-split). Flagging the coverage gap, not widening the gate.