### PR TITLE
cic(#1039): one inset for both mobile hosts of the rail opener

### DIFF
--- a/cicchetto/e2e/tests/issue1039-hamburger-corner.spec.ts
+++ b/cicchetto/e2e/tests/issue1039-hamburger-corner.spec.ts
@@ -1,0 +1,168 @@
+// @webkit — #1039. The mobile ☰ rail opener must land on the SAME pixel on
+// every window kind, so switching windows never moves the one door into the
+// rail.
+//
+// The defect: two containers host that one control. On a channel it is a flex
+// child of `.topic-bar`, placed by the bar's own `padding: 0.5rem 1rem`; on
+// every other kind it is #985's float, placed by `margin: 0.25rem 0.5rem`.
+// Both anchor to the same box — `.shell-main` → `.drop-upload-zone` (no
+// padding) → `.topic-bar` on one side, `.shell-main` → `.shell-chrome` on the
+// other — so the two offsets are directly comparable, and they disagreed:
+// 0.25rem higher and 0.5rem further right on a non-channel window.
+//
+// Why an e2e and not a vitest: the defect IS rendered geometry, and the two
+// hosts are different elements in different subtrees — no unit can compare
+// where they land. jsdom has no layout engine. The SOURCE-level half (both
+// rules reading one token, so they cannot drift apart again) is pinned in
+// `src/__tests__/hamburgerCorner.test.ts`; what only a real engine answers is
+// whether the two rectangles actually coincide.
+//
+// Mobile-only by construction (`ShellChrome` mounts only in Shell's
+// `isMobile()` branch, and `.topic-bar-hamburger` is `display: none` above
+// 768px), so this runs on webkit-iphone-15 alone — the @webkit tag; the
+// chromium project grepInverts it.
+//
+// NOT covered here: the third host. `.admin-pane-header` (#1033, 2026-08-07)
+// puts the same ☰ at the pane's top-LEFT, deliberately — the top-right corner
+// of the admin pane is taken by its close × and refresh. That is a contract to
+// settle, not an offset to unify, and it is filed separately; asserting it here
+// would encode a decision nobody has made.
+//
+// Parity matrix per `feedback_e2e_user_class_parity_matrix`: this is a UI shape
+// contract, subject-shape-agnostic. The registered seed suffices.
+
+import type { Locator } from "@playwright/test";
+import {
+  composeSend,
+  loginAs,
+  selectChannel,
+  sidebarWindow,
+  waitForQueryWindowReady,
+} from "../fixtures/cicchettoPage";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+// Per-run-unique: a literal nick / channel collides with itself upstream on
+// rapid reruns (--repeat-each), the rule every peer-driven spec here follows.
+const RUN = crypto.randomUUID().slice(0, 8);
+const PEER = `F1039${RUN}`;
+const WRAP_CHANNEL = `#t1039-${RUN}`;
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Both hosts derive from one `rem` pair, so an exact match is the expectation
+// and any slack here is only against layout rounding. Half a pixel is two
+// orders below the defect it must still catch (0.25rem = 3.5px vertical,
+// 0.5rem = 7px horizontal at the 14px root), so it discriminates.
+const SUBPIXEL_PX = 0.5;
+
+type Box = { x: number; y: number; width: number; height: number };
+
+async function boxOf(locator: Locator, what: string): Promise<Box> {
+  await expect(locator, `${what} must be on screen before it can be measured`).toBeVisible({
+    timeout: 15_000,
+  });
+  const box = await locator.boundingBox();
+  if (box === null) throw new Error(`${what}: visible but has no bounding box`);
+  return box;
+}
+
+test.setTimeout(120_000);
+
+test("@webkit #1039 — the ☰ occupies the same rectangle on a channel and on a query window", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  const marker = `t1039-${RUN}`;
+  // Long enough to wrap several times in the narrow mobile strip; under
+  // bahamut's TOPICLEN so the peer's exact-echo await matches (as #262).
+  const longTopic =
+    `${marker} a deliberately long channel topic whose only job is to make the ` +
+    `topic bar's text column outgrow the hamburger, so the hamburger's vertical ` +
+    `anchor is put under load instead of being measured only in the easy case`;
+
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  // PRECONDITION — we are on the CHANNEL branch, so the ☰ we measure is the
+  // TopicBar's. Without this the whole test could compare the float to itself.
+  await expect(page.locator(".shell-chrome")).toHaveCount(0);
+  const channelBox = await boxOf(page.locator(".topic-bar-hamburger"), "the channel ☰");
+
+  const peer = await IrcPeer.connect({ nick: PEER });
+  try {
+    // Share a channel so the peer is addressable, then open + focus the query.
+    await peer.join(CHANNEL);
+    await composeSend(page, `/q ${PEER}`);
+    await waitForQueryWindowReady(page, NETWORK_SLUG, PEER);
+
+    // PRECONDITION — the non-channel branch: no TopicBar, so this really is
+    // the float and not the same element measured twice.
+    await expect(page.locator(".topic-bar")).toHaveCount(0);
+    const queryBox = await boxOf(page.getByTestId("shell-chrome-rail-opener"), "the query ☰");
+
+    // THE OUTCOME. Same rectangle, not merely same size: x/y is where #1039
+    // said it jumps, width/height is what makes "same rectangle" true rather
+    // than "same corner of two different boxes".
+    const detail =
+      `channel ☰ at (${channelBox.x}, ${channelBox.y}) ${channelBox.width}×${channelBox.height}; ` +
+      `query ☰ at (${queryBox.x}, ${queryBox.y}) ${queryBox.width}×${queryBox.height}`;
+    for (const axis of ["x", "y", "width", "height"] as const) {
+      expect(
+        Math.abs(queryBox[axis] - channelBox[axis]),
+        `${axis} must agree across the kind switch — ${detail}`,
+      ).toBeLessThanOrEqual(SUBPIXEL_PX);
+    }
+
+    // ---- the vertical anchor under load -------------------------------
+    // The horizontal case is a constant; the vertical one is not. On a channel
+    // the ☰ used to be CENTRED in a bar that grows with the topic, so matching
+    // only the single-line case would leave it jumping the moment the text
+    // column outgrew it. `align-self: flex-start` is what pins it. Prove that
+    // on a bar whose text column really is the taller child.
+    await peer.join(WRAP_CHANNEL);
+    await peer.topic(WRAP_CHANNEL, longTopic);
+    await composeSend(page, `/join ${WRAP_CHANNEL}`);
+    await expect(sidebarWindow(page, NETWORK_SLUG, WRAP_CHANNEL)).toBeVisible({ timeout: 15_000 });
+    await selectChannel(page, NETWORK_SLUG, WRAP_CHANNEL, { ownNick: NETWORK_NICK });
+    // Anti-false-green: the long topic is RENDERED before anything is measured.
+    await expect(page.locator(".topic-bar-topic")).toContainText(marker, { timeout: 15_000 });
+
+    // #262 clamps the strip to 2 lines, which may well keep the text column
+    // UNDER the 48px ☰ — in which case a natural long topic does not exercise
+    // the anchor at all and asserting on it would be a green that proves
+    // nothing. So report the natural numbers, then force the column taller by
+    // dropping the clamp inline (the #262 spec's own isolation technique) and
+    // assert on a bar that is genuinely header-driven.
+    const naturalHeader = (await boxOf(page.locator(".topic-bar-header"), "the header block"))
+      .height;
+    await page.locator(".topic-bar-topic-text").evaluate((el) => {
+      const node = el as HTMLElement;
+      node.style.maxHeight = "none"; // #262's backstop
+      node.style.webkitLineClamp = "unset"; // #307's clamp
+      void node.offsetHeight; // force synchronous reflow
+    });
+    const grownHeader = (await boxOf(page.locator(".topic-bar-header"), "the grown header block"))
+      .height;
+    const wrapBox = await boxOf(page.locator(".topic-bar-hamburger"), "the ☰ on a grown bar");
+
+    // The leg is DISCRIMINATING: the text column really is the taller child
+    // now, so a centred ☰ would sit (grownHeader - height) / 2 lower.
+    expect(
+      grownHeader,
+      `the header block (${grownHeader}px, ${naturalHeader}px before the clamp was dropped) must ` +
+        `outgrow the ☰ (${wrapBox.height}px) or this leg cannot tell a pinned anchor from a centred one`,
+    ).toBeGreaterThan(wrapBox.height);
+
+    expect(
+      Math.abs(wrapBox.y - channelBox.y),
+      `the ☰ must not move when the topic column outgrows it — pinned at y=${channelBox.y}, ` +
+        `measured y=${wrapBox.y} on a ${grownHeader}px header (a centred ☰ lands ~${
+          channelBox.y + (grownHeader - wrapBox.height) / 2
+        })`,
+    ).toBeLessThanOrEqual(SUBPIXEL_PX);
+  } finally {
+    await composeSend(page, `/part ${WRAP_CHANNEL}`).catch(() => {});
+    await peer.disconnect("t1039 done").catch(() => {});
+  }
+});

--- a/cicchetto/src/__tests__/hamburgerCorner.test.ts
+++ b/cicchetto/src/__tests__/hamburgerCorner.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { ruleBody, themeCss } from "./helpers/themeCss";
+
+// #1039 — the mobile ☰ rail opener jumped when you switched window kind: on a
+// channel it rides inline in `.topic-bar`, on every other kind it is #985's
+// float over `.shell-chrome`, and the two placed it with different offsets
+// (`0.5rem`/`1rem` vs `0.25rem`/`0.5rem`). Both anchor to the same box — on a
+// channel `.shell-main` → `.drop-upload-zone` (no padding) → `.topic-bar`, on
+// every other kind `.shell-main` → `.shell-chrome` — so the disagreement was
+// visible as a jump up and to the right.
+//
+// These are SOURCE-level guards, the same shape and for the same reason as
+// `shellChromeFloat.test.ts`: jsdom has no layout engine, so the rendered
+// geometry is not observable in any gate that runs locally. The rendered
+// outcome — the glyph landing on the same pixel across a kind switch, and
+// staying put when the topic wraps to a second line — is pinned in
+// `e2e/tests/issue1039-hamburger-corner.spec.ts`.
+//
+// What this file is FOR is the drift the issue actually asks to prevent: "a
+// spec that pins the two offsets to the same value, so the next refactor of
+// either container cannot silently drift them apart again". So it deliberately
+// does NOT hardcode `0.5rem` / `1rem` anywhere — it asserts that the two
+// readers name the SAME custom property and that `:root` defines it. A future
+// re-tune of the inset is one edit and stays green; a future re-hardcode of
+// either side is red.
+
+/** The balanced `{…}` body starting at `open`, so a scan cannot run past a block's close. */
+function balancedBlock(source: string, open: number): string {
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === "{") depth += 1;
+    else if (source[i] === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(open + 1, i);
+    }
+  }
+  throw new Error(`unbalanced block at ${open}`);
+}
+
+/** The first two values of a `padding` / `margin` shorthand: block, then inline. */
+function insetPair(body: string, prop: "padding" | "margin"): string[] {
+  const match = new RegExp(`(?:^|[\\s;])${prop}:\\s*([^;]+);`).exec(body);
+  if (match?.[1] === undefined) throw new Error(`no \`${prop}\` shorthand in: ${body.trim()}`);
+  // No value here contains a space inside parens (`var(--x)` has none), so a
+  // plain whitespace split is the whole parse.
+  return match[1].trim().split(/\s+/);
+}
+
+const TOPIC_BAR = insetPair(ruleBody(".topic-bar"), "padding");
+const FLOAT = insetPair(ruleBody(".shell-chrome .shell-chrome-rail-opener"), "margin");
+
+describe("#1039 both mobile ☰ hosts read one inset", () => {
+  it("the two hosts name the SAME custom property on each axis", () => {
+    // THE guard. `.topic-bar`'s `padding: <block> <inline>` and the float's
+    // `margin: <top> <right> 0 0` agree position-for-position on the two axes
+    // that place the glyph, so re-hardcoding either side is red here.
+    expect(FLOAT[0]).toBe(TOPIC_BAR[0]); // block / top
+    expect(FLOAT[1]).toBe(TOPIC_BAR[1]); // inline / right
+  });
+
+  it("that property is a real `:root` token, not a coincidence of two var names", () => {
+    // Without this, two rules could agree on `var(--nonexistent)` and the test
+    // above would pass while both offsets resolved to nothing.
+    const root = ruleBody(":root");
+    for (const value of [TOPIC_BAR[0], TOPIC_BAR[1]]) {
+      const name = /^var\((--[a-z-]+)\)$/.exec(value ?? "")?.[1];
+      expect(name, `${value} is not a bare var() reference`).toBeDefined();
+      expect(root).toMatch(new RegExp(`${name}:\\s*[\\d.]+rem;`));
+    }
+  });
+
+  it("the float still collapses its other two sides", () => {
+    // `margin: <top> <right> 0 0`. The bottom is what keeps the float out of
+    // the flow it overflows; the left is what keeps `justify-content: flex-end`
+    // resolving the right edge against the margin-right above. Read the 4-value
+    // shorthand as such, or position 1 is not "right" at all.
+    expect(FLOAT).toHaveLength(4);
+    expect(FLOAT[2]).toBe("0");
+    expect(FLOAT[3]).toBe("0");
+  });
+
+  it("the channel ☰ pins to the top of the bar instead of centring in it", () => {
+    // `.topic-bar`'s `align-items: center` (#644) centres BOTH children. That
+    // is identical to top-pinning while the 48px ☰ is the tallest child, and
+    // drifts the moment `.topic-bar-header` outgrows it — a two-line topic
+    // (#344/#644) pushes the ☰ down by half the excess, and the float has no
+    // such term. Matching only the single-line case would have left the jump.
+    const mobileHamburger = /\.topic-bar \.topic-bar-hamburger\s*\{([^}]*align-self[^}]*)\}/.exec(
+      themeCss,
+    )?.[1];
+    expect(
+      mobileHamburger,
+      "no `.topic-bar .topic-bar-hamburger` rule sets align-self",
+    ).toBeDefined();
+    expect(mobileHamburger).toMatch(/align-self:\s*flex-start/);
+    // Mobile-only: the desktop rule is the `display: none` gate, and pinning
+    // there would be dead weight on a hidden button.
+    expect(mobileHamburger).toMatch(/display:\s*inline-flex/);
+  });
+
+  it("no ≤768px override redeclares the bar's padding behind the token's back", () => {
+    // `ruleBody` reads TOP-LEVEL rules only, so a `.topic-bar` rule nested in
+    // the mobile media block would win at runtime and be invisible to the
+    // assertions above. The one indented `.topic-bar` rule that exists today is
+    // the #319 landscape-compact tier, gated `min-width: 769px` — desktop,
+    // where the ☰ is `display: none` and this whole contract is moot.
+    // Comments stripped first: a brace inside CSS prose would derail the walk.
+    // `[ \t]` and not `\s` — `\s` spans newlines, so `^\s+\.topic-bar` also
+    // matches the TOP-LEVEL rule one blank line down, and the guard reds out on
+    // the very declaration it is meant to protect.
+    const stripped = themeCss.replace(/\/\*[\s\S]*?\*\//g, "");
+    let scanned = 0;
+    for (const media of stripped.matchAll(/@media ([^{]*)\{/g)) {
+      if (!/max-width:\s*768px/.test(media[1] ?? "")) continue;
+      scanned += 1;
+      const body = balancedBlock(stripped, (media.index ?? 0) + (media[0]?.length ?? 0) - 1);
+      expect(body, "a mobile `.topic-bar` rule can silently retarget the inset").not.toMatch(
+        /(^|\n)[ \t]*\.topic-bar[ \t]*\{/,
+      );
+    }
+    // The mobile breakpoint exists — otherwise the loop above is vacuous and
+    // this test passes by scanning nothing.
+    expect(scanned).toBeGreaterThan(0);
+  });
+});

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -194,6 +194,35 @@
      floor (feedback_cic_tap_target_rem_pitfall). Theme-independent, so it
      lives on base :root, NOT in the per-theme blocks. */
   --tap-min: 44px;
+  /* #1039 — the inset of the pane's TOP CHROME from `.shell-main`'s edges.
+     ONE pair of numbers, read by BOTH mobile hosts of the ☰ rail opener, which
+     is the same control in the same corner on every window kind:
+
+       * channel     → `.topic-bar`'s own padding (the ☰ is its last flex child)
+       * non-channel → `.shell-chrome .shell-chrome-rail-opener`'s margin (#985
+                       floats the lone ☰ over a zero-height row)
+
+     Both anchor to the same box — on a channel `.shell-main` → `.drop-upload-
+     zone` (no padding) → `.topic-bar`, on every other kind `.shell-main` →
+     `.shell-chrome` — so the two are comparable at the pixel, and before #1039
+     they disagreed (`0.5rem`/`1rem` vs `0.25rem`/`0.5rem`): the ☰ visibly
+     jumped up-and-right when you switched window kind.
+
+     The BAR's numbers won, not the float's. The bar's padding is not a free
+     choice — it is also the only breathing room the channel name and the topic
+     strip get, so retargeting it at the float's tighter values would have
+     squeezed the text against the pane edge, a design change #1039 did not ask
+     for. The float's margin IS free: its own comment calls it "breathing room,
+     NOT a notch allowance" and it has no second consumer. Constrained beats
+     free. Moving the float 0.25rem down / 0.5rem in can only REDUCE the #985
+     corner-overlap it accepted, never grow it.
+
+     Theme-independent, like the sibling chrome tokens above: this is geometry,
+     not palette. Drift between the two readers is pinned by
+     `src/__tests__/hamburgerCorner.test.ts`; the rendered outcome by
+     `e2e/tests/issue1039-hamburger-corner.spec.ts`. */
+  --pane-chrome-inset-block: 0.5rem;
+  --pane-chrome-inset-inline: 1rem;
   /* #913 — the iOS top safe-area inset, as a variable. Everything else in this
      file writes `env(safe-area-inset-top)` inline, which is right for a
      padding: the engine substitutes it and nobody has to read it back. The
@@ -1891,7 +1920,12 @@ html.resize-dragging * {
   /* gap now separates the header block from the hamburger; the intra-column
      namebox↔topic gap lives on `.topic-bar-header`. */
   gap: 0.5rem;
-  padding: 0.5rem 1rem;
+  /* #1039 — computed value UNCHANGED (0.5rem 1rem); it is the literal that is
+     gone. On mobile this padding IS the ☰'s inset from the pane's top-right
+     corner, and the float on every other window kind now reads the same token
+     — so the two cannot drift apart again without one edit changing both. See
+     the `--pane-chrome-inset-*` note on `:root`. */
+  padding: var(--pane-chrome-inset-block) var(--pane-chrome-inset-inline);
   border-bottom: 1px solid var(--border);
   background: var(--bg);
 }
@@ -2428,10 +2462,16 @@ html.resize-dragging * {
    (`:root.theme-has-bg .scrollback-pane::before`). Descendant selector rather
    than order-dependent overriding, matching `.rail-actions .rail-action`.
    The margin is what keeps the glyph off the pane's very corner — it is
-   breathing room, NOT a notch allowance (see above). */
+   breathing room, NOT a notch allowance (see above).
+   #1039 — that breathing room is no longer this rule's to pick. It was
+   `0.25rem 0.5rem`, the TopicBar hosts the same ☰ at `0.5rem`/`1rem`, and
+   nothing registered the two against each other — so the glyph jumped up and
+   to the right the moment you left a channel window. Both now read one token
+   pair; the bar's values won because the bar's padding has a second consumer
+   and this margin does not (see the `--pane-chrome-inset-*` note on `:root`). */
 .shell-chrome .shell-chrome-rail-opener {
   background: var(--bg);
-  margin: 0.25rem 0.5rem 0 0;
+  margin: var(--pane-chrome-inset-block) var(--pane-chrome-inset-inline) 0 0;
 }
 
 .shell-chrome-btn {
@@ -6334,6 +6374,18 @@ html.resize-dragging * {
      hand-rolled 44px box — replaced by the shared 48px token.) */
   .topic-bar .topic-bar-hamburger {
     display: inline-flex;
+    /* #1039 — the ☰ pins to the TOP of the bar; only the text block stays
+       centred. `.topic-bar`'s `align-items: center` (#644) centres BOTH
+       children, which is identical while the 48px ☰ is the tallest child but
+       drifts the moment `.topic-bar-header` outgrows it — a two-line topic
+       (#344/#644) pushes the ☰ down by half the excess, and the float on
+       non-channel windows has no such term. Matching only the single-line case
+       would have left that jump in place. `align-self`, not a padding/margin
+       correction: #644's acceptance bar was "no magic padding constant", and a
+       third offset that evens the score against the float is exactly the
+       band-aid #1039 rules out. Mobile-only because the ☰ is display:none
+       above this breakpoint. */
+    align-self: flex-start;
   }
 
   /* Members drawer slide-in from right (unchanged from pre-C6) */

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -33694,3 +33694,64 @@ non-fatal — so a rotted call would warn once and be swallowed BY DESIGN.
 derived, not a hand-kept list, so the next entry point is covered the
 day a script names it; two companion cases keep it from passing
 vacuously if a script moves or the regex rots.
+
+## 2026-08-08 — #1039: the ☰ had two placers, so one of them had to stop choosing
+
+On mobile the rail opener is one control in one corner, but two containers
+put it there: `.topic-bar`'s own `padding: 0.5rem 1rem` on a channel window,
+and #985's float `margin: 0.25rem 0.5rem` on every other kind. Both anchor to
+the same box — `.shell-main` → `.drop-upload-zone` (no padding) → `.topic-bar`
+on one side, `.shell-main` → `.shell-chrome` on the other — so the two numbers
+were directly comparable and simply disagreed. Switching window kind moved the
+one door into the rail up and to the right.
+
+**The bar's numbers won, and the float adopted them.** Not a coin toss: the
+bar's padding is not a free choice, because it is also the only breathing room
+the channel name and the topic strip get, so retargeting it at the float's
+tighter values would have squeezed the text against the pane edge — a design
+change the issue did not ask for. The float's margin IS free; its own comment
+calls it "breathing room, NOT a notch allowance" and it has no second
+consumer. Constrained beats free. The move also runs the float 0.25rem down
+and 0.5rem in, which can only reduce the corner overlap #985 knowingly
+accepted, never grow it. `.topic-bar`'s computed padding is unchanged — the
+literal is what went away, replaced by the `--pane-chrome-inset-*` pair both
+rules now read.
+
+**The vertical half was never an offset; it was the wrong anchor.** #644's
+`align-items: center` centres BOTH children of the bar, which equals
+top-pinning only while the 48px ☰ is the tallest child. A topic that outgrows
+it pushes the ☰ down by half the excess, and the float has no such term — so
+equalising the two paddings alone would have fixed the single-line case and
+left the jump. `align-self: flex-start` on the mobile hamburger pins it.
+Deliberately not a compensating padding: #644's acceptance bar was "no magic
+padding constant", and a third offset that evens the score against the float
+is the band-aid this issue exists to reject.
+
+**A third host exists and was left alone on purpose.** #1033 landed the day
+before and put the same ☰ in `.admin-pane-header`, top-LEFT, because the admin
+pane's top-right corner is taken by its close × and refresh
+(`ShellChrome.tsx:73-90`). So the glyph still moves when you enter the admin
+window — much further than #1039's 3.5px. That is not an offset to unify but a
+contract nobody has stated: does "top-right corner" bind every window kind, or
+is the admin console a different surface? Reversing a deliberate placement one
+day after merge, without its author, inside a geometry fix, is the thing
+CLAUDE.md calls putting a patch around the problem. Filed as #1042 with the
+measurements, plus a source-derived (unrendered) observation that the admin ☰
+appears to survive into the 769–899px band where Shell is already on its
+desktop branch.
+
+**The guard is source-level and had to be proven able to fail.**
+`hamburgerCorner.test.ts` cannot see geometry — jsdom has no layout engine —
+so it pins the drift instead: the two readers must name the SAME custom
+property per axis, and `:root` must define it. It hardcodes neither `0.5rem`
+nor `1rem`, so a future re-tune of the inset is one edit and stays green while
+a re-hardcode of either side goes red. Five mutants were run against it — the
+float re-hardcoded to its old literal, the `:root` definition renamed out from
+under both readers, the float's collapsed bottom side revived, `align-self`
+deleted, and a mobile `.topic-bar` override injected — and each killed exactly
+one assertion (`1 failed | 4 passed`), so no assertion is doing another's job
+and none of them is asleep. The rendered outcome — the two rectangles actually
+coinciding, and the ☰ holding still on a bar whose text column outgrows it —
+is `e2e/tests/issue1039-hamburger-corner.spec.ts`, whose second leg drops
+#262's clamp inline and asserts the header really did outgrow the button
+before asserting the button did not move, so the leg cannot pass vacuously.


### PR DESCRIPTION
Fixes the ☰ jumping between window kinds on mobile (#1039), by removing one of
the two places that were choosing where it goes.

## The defect

Two containers host one control. On a channel it is a flex child of
`.topic-bar`, placed by the bar's own `padding: 0.5rem 1rem`; on every other
kind it is #985's float, placed by `margin: 0.25rem 0.5rem`. Both anchor to
the same box — `.shell-main` → `.drop-upload-zone` (no padding) → `.topic-bar`
on one side, `.shell-main` → `.shell-chrome` on the other — so the two numbers
are directly comparable and simply disagreed: **0.25rem higher, 0.5rem further
right** on a non-channel window. Nothing registered them against each other.

## The fix

A `--pane-chrome-inset-block` / `-inline` pair on `:root`, read by both rules.
Three commits: the CSS + source guard, the e2e, the decision log.

**The bar's numbers won and the float adopted them** — not a coin toss. The
bar's padding is not a free choice: it is also the only breathing room the
channel name and the topic strip get, so retargeting it at the float's tighter
values would squeeze the text against the pane edge, a design change #1039 did
not ask for. The float's margin IS free — its own comment calls it *"breathing
room, NOT a notch allowance"* and it has no second consumer. Constrained beats
free. The move runs the float 0.25rem down / 0.5rem in, which can only reduce
the corner overlap #985 knowingly accepted. `.topic-bar`'s **computed padding
is unchanged**; only the literal is gone.

**The vertical half was an anchor, not an offset.** #644's `align-items:
center` centres both children, which equals top-pinning only while the 48px ☰
is the tallest child; a topic that outgrows it pushes the ☰ down by half the
excess and the float has no such term. So equalising the paddings alone would
have fixed the single-line case and left the jump. `align-self: flex-start`
pins it — deliberately not a compensating padding, since #644's acceptance bar
was "no magic padding constant" and a third offset evening the score is the
band-aid the issue rejects.

## Gates

- `bun run test` — **249 files / 4659 tests green**, including the 5 new ones
  and `shellChromeFloat.test.ts` (#985's guards, untouched by this).
- `bun run check` — 0 errors (60 pre-existing warnings, unchanged).
- `tsc -p e2e/tsconfig.json` — 26 pre-existing errors in the suite, **none in
  the new spec**. (e2e is excluded from biome, so this was run by hand.)
- **The source guard was proven able to fail.** Five mutants, each killing
  exactly one assertion (`1 failed | 4 passed`), baseline restored green:

  | mutant | red line |
  |---|---|
  | float re-hardcodes the old literal (the regression itself) | `expected '0.25rem' to be 'var(--pane-chrome-inset-block)'` |
  | `:root` stops defining the token both readers name | `expected '…--font-mono…' to match /--pane-chrome-inset-block:\s*[\d.]+re…/` |
  | float stops collapsing its bottom side | `expected '0.25rem' to be '0'` |
  | hamburger goes back to centring | `expected '…display: inline-flex…' to match /align-self:\s*flex-start/` |
  | a mobile `.topic-bar` override retargets the padding | `expected '…\n  .shell-mobile {…' not to match /(^\|\n)[ \t]*\.topic-bar[ \t]*\{/` |

  One-per-assertion matters: it proves no assertion is covering for another.

## The e2e, and what it costs

`issue1039-hamburger-corner.spec.ts` (`@webkit`, iphone-15) measures the
TopicBar ☰ on a channel and the ShellChrome float on a query and asserts
x/y/width/height agree within half a pixel — two orders below the 3.5px/7px
defect. Each side has a precondition (`.shell-chrome` absent on the channel,
`.topic-bar` absent on the query) so it cannot pass by measuring one element
twice.

The second leg loads the vertical anchor. #262 clamps the strip to two lines,
which may keep the text column UNDER the 48px ☰ — in which case a natural long
topic exercises nothing — so the leg drops the clamp inline (#262's own
isolation technique), **asserts the header really did outgrow the button**, and
only then asserts the ☰ has not moved. Failure messages carry both heights and
where a centred ☰ would have landed.

**It has not been run.** No STACK lane and no local browser on darwin. The CI
on this PR is its first execution and its only measure.

## Known, deliberate residue → #1042

A **third** host landed in #1033 the day before #1039 was written:
`.admin-pane-header` puts the same ☰ at the pane's top-**LEFT**, because the
admin pane's top-right corner is taken by its close × and refresh
(`ShellChrome.tsx:73-90`). So the glyph still moves when you enter the admin
window — much further than 3.5px.

Not touched here. That is not an offset to unify but a contract nobody has
stated, and reversing a deliberate placement one day after merge, without its
author, inside a geometry fix, is exactly the patch-around-the-problem this
issue exists to reject. Filed as **#1042** with the measurements, plus a
second, **source-derived and unrendered** observation: the admin ☰ is hidden at
`min-width: 900px` while Shell's desktop branch starts at 769px, so it looks
like it survives into that 131px band as a no-op button. Needs an 800px render
to confirm or kill.

## What I do not claim

- That the corner match is **verified**. Every number in this PR is read off
  the CSS, not off a `getBoundingClientRect`. The e2e is the measure and it
  has not run.
- That the wrap case was **observed** breaking. It is derived from
  `align-items: center` plus a `.topic-bar-header` that can exceed 48px; #262
  clamps the strip, so it is entirely possible the natural case never did. The
  e2e's second leg forces the condition rather than assuming it, and reports
  the natural height alongside — read that number in the run log before
  treating `align-self` as a cure rather than a guard.
- That #1039 is closed as vjt feels it. With the admin host in another corner,
  "the ☰ never moves" remains false until #1042 is answered.