### PR TITLE
cic(#1041): left-edge swipe mounts the mobile sidebar, hiding destroys it

### DIFF
--- a/cicchetto/e2e/tests/issue1041-left-edge-sidebar.spec.ts
+++ b/cicchetto/e2e/tests/issue1041-left-edge-sidebar.spec.ts
@@ -1,0 +1,203 @@
+// #1041 — the left-edge swipe opens the mobile channel sidebar, and that
+// sidebar is ABSENT from the DOM whenever it is not on screen: mounted when the
+// gesture commits, destroyed when it hides. Both halves are asserted here as
+// VISIBLE outcomes (element count + on-screen geometry), not as a class flip.
+//
+// Same harness + same limits as #308 INC-A's sibling spec:
+//   * chromium, untagged — chromium's TouchEvent/Touch constructors are
+//     reliable (webkit's are not — Playwright webkit ≠ real iOS scroll), so the
+//     gesture is synthesized in-page. A NARROW viewport forces isMobile() true
+//     so `.shell-mobile` mounts and the edge directive binds.
+//   * The FEEL (does the drag read right under a real finger, does iOS momentum
+//     survive, does the enter animation look like a drawer rather than a pop)
+//     is a DEVICE call: synthetic events drive no pixel-scroll and chromium is
+//     not iOS Safari. That part is vjt's on-device dogfood, declared as such —
+//     this spec does not cover it and must not be read as if it did.
+import type { Page } from "@playwright/test";
+import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+// iPhone-15-ish portrait: narrow enough for isMobile() (max-width query).
+test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// The mobile drawer instance specifically — the desktop branch mounts the same
+// `.shell-sidebar` class in its grid, and scoping under `.shell-mobile` keeps
+// this spec honest if that ever renders side by side.
+const SIDEBAR = ".shell-mobile .shell-sidebar";
+
+type Pt = { x: number; y: number };
+
+// Synthesize a touch gesture on `.shell-mobile`: touchstart at pts[0], a
+// touchmove per interior point, touchend at the last. Returns whether ANY
+// touchmove was preventDefaulted — dispatchEvent returns false iff a listener
+// called preventDefault (the claim signal). Verbatim shape from the #308 spec.
+async function synthEdgeGesture(page: Page, pts: Pt[]): Promise<{ prevented: boolean }> {
+  return await page.evaluate((points) => {
+    const root = document.querySelector(".shell-mobile");
+    if (!(root instanceof HTMLElement)) throw new Error(".shell-mobile not found");
+    const mk = (p: { x: number; y: number }) =>
+      new Touch({ identifier: 1, target: root, clientX: p.x, clientY: p.y });
+    const fire = (type: "touchstart" | "touchmove" | "touchend", p: { x: number; y: number }) => {
+      const t = mk(p);
+      const active = type === "touchend" ? [] : [t];
+      return root.dispatchEvent(
+        new TouchEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          touches: active,
+          targetTouches: active,
+          changedTouches: [t],
+        }),
+      );
+    };
+    const first = points[0];
+    const last = points[points.length - 1];
+    if (!first || !last) throw new Error("need at least a start and an end point");
+    fire("touchstart", first);
+    let prevented = false;
+    for (let i = 1; i < points.length - 1; i++) {
+      const p = points[i];
+      if (p && !fire("touchmove", p)) prevented = true;
+    }
+    fire("touchend", last);
+    return { prevented };
+  }, pts);
+}
+
+// left→center: the opening gesture.
+function leftEdgeOpenSwipe(): Pt[] {
+  return [
+    { x: 5, y: 400 },
+    { x: 70, y: 404 },
+    { x: 140, y: 408 },
+    { x: 195, y: 410 },
+  ];
+}
+
+async function openChannel(page: Page): Promise<void> {
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  await loginAs(page, getSeededVjt());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+}
+
+// Fully slid in: the panel's left edge has reached the viewport's. Asserting
+// GEOMETRY, not the `.open` class — a drawer that is classed open while parked
+// at translateX(-100%) is off-screen and the operator sees nothing. Polled
+// because the enter animation takes 200ms.
+async function expectSlidIn(page: Page): Promise<void> {
+  await expect
+    .poll(async () => (await page.locator(SIDEBAR).boundingBox())?.x ?? null)
+    .toBe(0);
+}
+
+test("issue1041 — left-edge right-swipe mounts the sidebar and slides it on screen", async ({
+  page,
+}) => {
+  await openChannel(page);
+
+  // The premise: on mobile the sidebar is not hidden, it is ABSENT.
+  await expect(page.locator(SIDEBAR)).toHaveCount(0);
+
+  const { prevented } = await synthEdgeGesture(page, leftEdgeOpenSwipe());
+
+  expect(prevented).toBe(true); // claimed the horizontal gesture
+  await expect(page.locator(SIDEBAR)).toBeVisible();
+  await expectSlidIn(page);
+  // …and it is the real Sidebar, not an empty shell: the channel row is there.
+  await expect(page.locator(`${SIDEBAR} [data-window-name="${CHANNEL}"]`)).toBeVisible();
+});
+
+test("issue1041 — the backdrop tap hides the sidebar and DESTROYS it (no hidden box left behind)", async ({
+  page,
+}) => {
+  await openChannel(page);
+  await synthEdgeGesture(page, leftEdgeOpenSwipe());
+  await expectSlidIn(page);
+
+  // Tap the backdrop clear of the panel (the drawer caps at 18rem = 288px on a
+  // 390px viewport, so x=350 is uncovered backdrop).
+  await page.locator(".shell-drawer-backdrop.open").click({ position: { x: 350, y: 400 } });
+
+  // THE ask: not `display:none`, not `translateX(-100%)` — gone. This is what
+  // separates #1041 from the always-mounted `.shell-members` drawer, and it is
+  // the assertion that fails if someone "simplifies" the deferred unmount into
+  // a permanent mount with a class toggle.
+  await expect(page.locator(SIDEBAR)).toHaveCount(0);
+});
+
+test("issue1041 — picking the ALREADY-selected row still dismisses the drawer", async ({
+  page,
+}) => {
+  await openChannel(page);
+  await synthEdgeGesture(page, leftEdgeOpenSwipe());
+  await expectSlidIn(page);
+
+  // Deliberately the row that is already active: a Shell-side effect watching
+  // `selectedChannel()` — the obvious alternative to Sidebar's restored
+  // `onSelect` prop — sees no change here and would leave the drawer stuck open
+  // over the window the operator just asked for. This case is why the prop came
+  // back, so it is the case that has to be pinned.
+  await page.locator(`${SIDEBAR} [data-window-name="${CHANNEL}"] .sidebar-window-btn`).click();
+
+  await expect(page.locator(SIDEBAR)).toHaveCount(0);
+});
+
+// THE hard constraint (#308), inherited by the new arm: a vertical drag that
+// STARTS at the left edge is never claimed → never preventDefaulted → the
+// browser owns the vertical scroll, and nothing mounts. If this ever
+// preventDefaults, native scroll on the left third of every mobile screen is
+// broken.
+test("issue1041 — a vertical drag from the left edge never hijacks scroll (no mount, no preventDefault)", async ({
+  page,
+}) => {
+  await openChannel(page);
+
+  const { prevented } = await synthEdgeGesture(page, [
+    { x: 5, y: 200 },
+    { x: 7, y: 300 },
+    { x: 4, y: 430 },
+    { x: 5, y: 520 },
+  ]);
+
+  expect(prevented).toBe(false); // vertical was left entirely to the browser
+  await expect(page.locator(SIDEBAR)).toHaveCount(0);
+});
+
+test("issue1041 — a rightward swipe from the CENTER does not mount the sidebar (zone separation)", async ({
+  page,
+}) => {
+  await openChannel(page);
+
+  const { prevented } = await synthEdgeGesture(page, [
+    { x: 195, y: 400 },
+    { x: 275, y: 404 },
+    { x: 365, y: 408 },
+  ]);
+
+  expect(prevented).toBe(false); // center gesture is not armed → never claims
+  await expect(page.locator(SIDEBAR)).toHaveCount(0);
+});
+
+// An open overlay is a CHILD of `.shell-mobile`, so its touches still bubble to
+// the edge directive. Without the overlay guard in Shell the left swipe would
+// stack a second drawer underneath the members drawer that is already up.
+test("issue1041 — the left swipe is refused while the members drawer is open", async ({ page }) => {
+  await openChannel(page);
+
+  // #308 INC-A's own gesture: right→center opens members.
+  await synthEdgeGesture(page, [
+    { x: 385, y: 400 },
+    { x: 320, y: 404 },
+    { x: 250, y: 408 },
+    { x: 195, y: 410 },
+  ]);
+  await expect(page.locator(".shell-members.open")).toBeVisible();
+
+  await synthEdgeGesture(page, leftEdgeOpenSwipe());
+
+  await expect(page.locator(SIDEBAR)).toHaveCount(0);
+  await expect(page.locator(".shell-members.open")).toBeVisible(); // untouched
+});

--- a/cicchetto/src/Shell.tsx
+++ b/cicchetto/src/Shell.tsx
@@ -34,7 +34,7 @@ import { mentionsBundleBySlug } from "./lib/mentionsWindow";
 import { openMembersPanel, toggleMembersPanel } from "./lib/mobilePanel";
 import { channelsBySlug, isAdmin, networkBySlug, networks, user } from "./lib/networks";
 import { nickEquals } from "./lib/nickEquals";
-import { createOverlayLock } from "./lib/overlayScrollLock";
+import { createOverlayLock, overlayCount } from "./lib/overlayScrollLock";
 import { queryWindowsByNetwork } from "./lib/queryWindows";
 import { closeToPreviousWindow, selectedChannel, setSelectedChannel } from "./lib/selection";
 import { settingsOpenTick } from "./lib/settingsNav";
@@ -77,10 +77,18 @@ import WhoModal from "./WhoModal";
 //
 // UX-5 bucket A (2026-05-19) — the left `sidebarOpen` drawer was
 // dropped. The desktop sidebar is always visible (no toggle needed);
-// the mobile branch doesn't render `.shell-sidebar` at all (channels
+// the mobile branch didn't render `.shell-sidebar` at all (channels
 // live in BottomBar). The ShellChrome hamburger that toggled this
 // signal is removed end-to-end — it duplicated TopicBar's members
 // hamburger on mobile and toggled a no-op `.open` class on desktop.
+//
+// #1041 (2026-08-08) brings a left drawer BACK on mobile, but not the
+// dropped shape: there is no hamburger and no always-mounted panel.
+// The only door is the left-edge swipe, and the sidebar is mounted on
+// the gesture and destroyed on hide (`sidebarMounted` / `sidebarSlidIn`
+// below). BottomBar remains the primary channel nav — this is an
+// additive second door, the same framing as #308 INC-A's right-edge
+// swipe.
 //
 // Mobile layout (≤768px, isMobile() reactive signal from theme.ts):
 //   * JSX branches on isMobile() — NOT just CSS display toggling.
@@ -94,9 +102,85 @@ import WhoModal from "./WhoModal";
 // printable key off-compose), and tab-complete (Tab in compose textarea).
 // install() is idempotent; uninstall fires on unmount.
 
+// #1041 — hard floor for the mobile sidebar's exit before it is disposed.
+// Deliberately LONGER than the CSS `transition: transform 200ms` (default.css,
+// `.shell-mobile .shell-sidebar`) rather than equal to it: `transitionend` is
+// the primary dispose edge and this is only the backstop for the cases where it
+// never fires (the element was never painted, or the transition was
+// interrupted). Pinning the two to the same number would make a CSS tweak
+// silently truncate the animation instead of merely shortening the slack.
+const SIDEBAR_EXIT_FLOOR_MS = 400;
+
 const Shell: Component = () => {
   const [membersOpen, setMembersOpen] = createSignal(false);
   const [settingsOpen, setSettingsOpen] = createSignal(false);
+
+  // #1041 — the mobile left-edge swipe opens the channel sidebar, and that
+  // sidebar is ABSENT from the DOM whenever it is not on screen: mounted when
+  // the gesture commits, disposed at the end of the exit transition.
+  //
+  // Why unmount at all, when `.shell-members` (the right drawer) stays mounted
+  // behind the edge: `Sidebar` owns no local state — zero createSignal /
+  // createEffect / createMemo / onMount of its own — so a remount rebuilds it
+  // identically from the same global stores, and nothing is lost. What
+  // unmounting removes is not DOM nodes but the LIVE reactive subscriptions
+  // (channelsBySlug, queryWindowsByNetwork, windowStateByChannel, the unread
+  // badges…) that would otherwise re-run on every message on every network to
+  // repaint something behind the left edge. That is the weight #1041 refuses to
+  // add to the mobile app. It also sidesteps #782's failure mode on the right
+  // drawer: an always-mounted pane needed an `onScreen` prop threaded in purely
+  // to stop invisible work, and a prop can be forgotten — an absent component
+  // cannot.
+  //
+  // TWO signals, deliberately out of phase at both ends. `sidebarMounted` gates
+  // existence (the `<Show>`); `sidebarSlidIn` drives the `.open` transform.
+  //   * ENTER: a node that mounts and gets `.open` in the same task never
+  //     paints at `translateX(-100%)`, so the transition has no start value and
+  //     the bar appears with no animation. Two rAFs buy one painted frame at
+  //     the closed transform first.
+  //   * EXIT: dropping the node the instant the class flips kills the exit
+  //     animation, so disposal waits for the transform's `transitionend` — with
+  //     SIDEBAR_EXIT_FLOOR_MS as the backstop, because that event does not fire
+  //     for an unpainted or interrupted transition.
+  const [sidebarMounted, setSidebarMounted] = createSignal(false);
+  const [sidebarSlidIn, setSidebarSlidIn] = createSignal(false);
+  let sidebarExitTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const disposeSidebar = (): void => {
+    if (sidebarExitTimer !== undefined) {
+      clearTimeout(sidebarExitTimer);
+      sidebarExitTimer = undefined;
+    }
+    setSidebarMounted(false);
+    setSidebarSlidIn(false);
+  };
+
+  const openSidebar = (): void => {
+    if (sidebarExitTimer !== undefined) {
+      clearTimeout(sidebarExitTimer);
+      sidebarExitTimer = undefined;
+    }
+    setSidebarMounted(true);
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() => {
+        // Re-check on the far side of two frames: a close that landed in the
+        // meantime armed the exit timer, and sliding in now would flash the bar
+        // open on its way out. An open→close→open inside those two frames
+        // cleared the timer again, so this correctly slides in for the reopen.
+        if (sidebarMounted() && sidebarExitTimer === undefined) setSidebarSlidIn(true);
+      }),
+    );
+  };
+
+  const closeSidebar = (): void => {
+    if (!sidebarMounted()) return;
+    setSidebarSlidIn(false);
+    sidebarExitTimer = setTimeout(disposeSidebar, SIDEBAR_EXIT_FLOOR_MS);
+  };
+
+  onCleanup(() => {
+    if (sidebarExitTimer !== undefined) clearTimeout(sidebarExitTimer);
+  });
 
   // #356 — cross-module "open settings" request. A bare watch-family compose
   // verb (/notify, /watch, /hilight, …) can't reach the local setSettingsOpen,
@@ -167,6 +251,12 @@ const Shell: Component = () => {
     ".shell-mobile .shell-members .members-pane",
   );
   createOverlayLock(() => isMobile() && isAdminPaneVisible(), ".admin-pane");
+  // #1041 — same treatment for the mobile left drawer: it is `position: fixed`
+  // and owns its own scroll, so it needs the lock for its whole on-screen life.
+  // Keyed on `sidebarMounted` rather than `sidebarSlidIn` so the lock survives
+  // the exit transition, dropping only when the node actually goes away. No
+  // onEscape — like the two above it is a scroll-lock-only drawer.
+  createOverlayLock(() => isMobile() && sidebarMounted(), ".shell-mobile .shell-sidebar");
 
   // UX-4 bucket N — admin pane lifecycle is now selection-driven.
   // `selectedChannel.kind === "admin"` is the SINGLE source of truth
@@ -714,26 +804,43 @@ const Shell: Component = () => {
             BottomBar (window picker, horizontal scroll, UNDER compose)
           Members pane: slide-in-from-right drawer toggled by the single
           hamburger in TopicBar (aria-label "open members sidebar").
-          Channel sidebar (.shell-sidebar) is NOT rendered on mobile —
+          Channel sidebar (.shell-sidebar) is not part of this layout —
           channels are navigated via BottomBar. This is a full JSX branch,
           not a CSS-display toggle, so the sidebar DOM is absent entirely.
+          #1041 mounts it TRANSIENTLY below, as a `position: fixed` left
+          drawer that exists only while the left-edge swipe has it on
+          screen: it never takes a grid track and it is gone again the
+          moment it hides, so "absent unless on screen" still holds.
       */}
       <div
         class="shell shell-mobile"
-        // #308 INC-A — right-edge swipe (right→center) opens the members drawer,
-        // an ADDITIVE second door onto the permanent right rail (the BottomBar
-        // stays the primary nav — #71 ruling). Bound at element level with a
-        // non-passive touchmove + explicit onCleanup (Solid delegates touch to a
-        // passive document listener, and function refs are not re-invoked at
-        // unmount — #308 landmines 1 + 3). Claims late, so a vertical drag is
-        // left entirely to native scroll (the hard constraint). Mobile-only: the
-        // ref lives in the isMobile() JSX branch, so it attaches only here.
+        // #308 INC-A — right-edge swipe (right→center) opens the members drawer;
+        // #1041 — left-edge swipe (left→center) opens the channel sidebar. Both
+        // are ADDITIVE second doors onto a rail (the BottomBar stays the primary
+        // nav — #71 ruling). Bound at element level with a non-passive touchmove
+        // + explicit onCleanup (Solid delegates touch to a passive document
+        // listener, and function refs are not re-invoked at unmount — #308
+        // landmines 1 + 3). Claims late, so a vertical drag is left entirely to
+        // native scroll (the hard constraint). Mobile-only: the ref lives in the
+        // isMobile() JSX branch, so it attaches only here.
         ref={(el) =>
           onCleanup(
             bindEdgeGesture(el, {
               viewportWidth: () => window.innerWidth,
               onOpenMembers: () =>
                 openMembersPanel({ membersOpen, setMembersOpen, setSettingsOpen }),
+              // #1041 — refuse the gesture while ANY overlay is up rather than
+              // teaching the mobilePanel mutex a fourth member. A backdrop or a
+              // modal is a child of `.shell-mobile`, so its touches still bubble
+              // to this listener and a left swipe would otherwise stack a second
+              // drawer under an open one. `overlayCount()` is the state that
+              // already answers "is something covering the shell" for every
+              // present AND future overlay — derive it, don't mirror it. Read
+              // outside a tracking scope, so this subscribes to nothing.
+              onOpenSidebar: () => {
+                if (overlayCount() > 0) return;
+                openSidebar();
+              },
             }),
           )
         }
@@ -919,6 +1026,43 @@ const Shell: Component = () => {
             RailActions drawer archive button; self-gated on `archiveModalOpen()`
             — renders nothing when closed. */}
         <ArchiveModal />
+
+        {/* #1041 — the mobile channel sidebar, opened by the left-edge swipe.
+            Its own backdrop instance (the members drawer above has a separate
+            one): each drawer owns the surface that dismisses IT, so a tap can
+            never close the wrong one. Rendered only while the sidebar exists,
+            and it fades on the same 200ms as the panel. */}
+        <Show when={sidebarMounted()}>
+          <div
+            class="shell-drawer-backdrop"
+            classList={{ open: sidebarSlidIn() }}
+            onClick={closeSidebar}
+            aria-hidden="true"
+          />
+          {/* Same `.shell-sidebar` element the desktop grid mounts — the mobile
+              @media block turns it into a fixed left drawer. `<Sidebar />` is
+              mounted BARE here: NextActiveButton already has a mobile variant
+              elsewhere in this branch, and ResizeHandle is desktop-only.
+              #1041 restores Sidebar's `onSelect` prop, dropped in UX-5 bucket A
+              on the grounds that no drawer was left to close — a premise this
+              issue expires. Picking a window dismisses the drawer; the prop
+              fires on EVERY row activation, including a re-tap of the already
+              selected row (which a selection-watching effect would miss). */}
+          <aside
+            class="shell-sidebar"
+            classList={{ open: sidebarSlidIn() }}
+            onTransitionEnd={(e) => {
+              // Dispose at the END of the exit slide, never at the class flip.
+              // Descendants bubble their own transitions through here, hence
+              // the target check; the timer in closeSidebar covers the case
+              // where this never fires at all.
+              if (e.target !== e.currentTarget || e.propertyName !== "transform") return;
+              if (!sidebarSlidIn()) disposeSidebar();
+            }}
+          >
+            <Sidebar onSelect={closeSidebar} />
+          </aside>
+        </Show>
 
         {/* #473 — the mobile members drawer IS the right rail, reachable on
             EVERY window (channel: TopicBar ☰; non-channel: ShellChrome ☰ above —

--- a/cicchetto/src/Shell.tsx
+++ b/cicchetto/src/Shell.tsx
@@ -827,8 +827,21 @@ const Shell: Component = () => {
           onCleanup(
             bindEdgeGesture(el, {
               viewportWidth: () => window.innerWidth,
-              onOpenMembers: () =>
-                openMembersPanel({ membersOpen, setMembersOpen, setSettingsOpen }),
+              // #1041 — the sidebar joins the panel mutex from THIS side, at the
+              // call site. Once a left drawer can be up, its backdrop is a child
+              // of `.shell-mobile`, so a right-edge touch that lands on it
+              // bubbles here and arms this arm with the other drawer still on
+              // screen. Honour the gesture and retire the sidebar rather than
+              // refuse it (the left arm's posture): a pull toward the members
+              // rail means "show me the members", and a silently dropped
+              // directional gesture is the surprising reading. `closeSidebar` is
+              // a no-op when nothing is mounted, so the plain #308 case is
+              // untouched. It runs FIRST so both animations start on the same
+              // frame — one drawer leaves as the other arrives.
+              onOpenMembers: () => {
+                closeSidebar();
+                openMembersPanel({ membersOpen, setMembersOpen, setSettingsOpen });
+              },
               // #1041 — refuse the gesture while ANY overlay is up rather than
               // teaching the mobilePanel mutex a fourth member. A backdrop or a
               // modal is a child of `.shell-mobile`, so its touches still bubble
@@ -837,6 +850,10 @@ const Shell: Component = () => {
               // already answers "is something covering the shell" for every
               // present AND future overlay — derive it, don't mirror it. Read
               // outside a tracking scope, so this subscribes to nothing.
+              // The asymmetry with the members arm above is deliberate: that arm
+              // faces ONE sibling drawer it can retire, this one faces every
+              // modal in the shell — and "close whatever is covering me" is not
+              // a swipe's decision to make.
               onOpenSidebar: () => {
                 if (overlayCount() > 0) return;
                 openSidebar();

--- a/cicchetto/src/Sidebar.tsx
+++ b/cicchetto/src/Sidebar.tsx
@@ -51,6 +51,16 @@ import WindowBadges from "./WindowBadges";
 // branch never mounts Sidebar (uses BottomBar instead). The prop
 // had no remaining consumer.
 //
+// #1041 (2026-08-08) — restored, because that premise expired: the
+// mobile branch now mounts Sidebar inside a left drawer opened by the
+// left-edge swipe, and picking a window has to dismiss it. Optional
+// (the desktop mount passes nothing — there is no drawer there), the
+// same shape BottomBar's `onSelect` already carries. It fires on every
+// row activation, INCLUDING a re-tap of the already-selected row: a
+// Shell-side effect watching `selectedChannel()` would look like the
+// same thing but silently no-ops on that tap, leaving the drawer stuck
+// open over the window the operator just asked to see.
+//
 // CP15 B5 — windowState visual cues:
 //   * Channel/query rows whose state ∈ {failed, kicked, parked} get
 //     `.sidebar-window-greyed` so the operator sees the row is no
@@ -94,9 +104,9 @@ const RowState: Component<{ state: string | null }> = (props) => (
   <Show when={props.state}>{(state) => <span class="sr-only"> ({state()})</span>}</Show>
 );
 
-export type Props = Record<string, never>;
+export type Props = { onSelect?: () => void };
 
-const Sidebar: Component<Props> = () => {
+const Sidebar: Component<Props> = (props) => {
   const isSelected = (slug: string, name: string): boolean => {
     const s = selectedChannel();
     return s !== null && s.networkSlug === slug && s.channelName === name;
@@ -167,6 +177,9 @@ const Sidebar: Component<Props> = () => {
     // windows leaves existing behaviour untouched.
     if (isActiveSelection(target)) requestScrollToBottom();
     setSelectedChannel(target);
+    // #1041 — after the selection, so the mobile drawer's exit runs against the
+    // window the operator just landed on rather than the one they left.
+    props.onSelect?.();
   };
 
   // #229 — compact umode string for the network-header indicator, e.g.

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { createSignal } from "solid-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LIST_WINDOW_NAME } from "../lib/windowKinds";
+import { swipeHorizontally } from "./helpers/touchEvents";
 
 // #500 — RailActions collapsed every rail affordance behind ONE launcher, so a
 // rail action is reachable only after the launcher is tapped. Open it before
@@ -861,6 +862,43 @@ describe("Shell — mobile layout (isMobile = true)", () => {
     mobileState.value = true;
     const { container } = render(() => <Shell />);
     expect(container.querySelector(".shell-sidebar")).toBeNull();
+  });
+
+  // #1041 — the two mobile drawers must never share the screen, and the
+  // RIGHT-edge arm is where that is decided once the left one can be up. The
+  // sidebar's backdrop is a CHILD of `.shell-mobile`, so a touch starting on it
+  // bubbles to the edge listener and arms the right-edge arm with the left
+  // drawer still on screen. vjt's ruling: honour the gesture (a pull toward the
+  // members rail means "show me the members" — refusing it silently is the
+  // surprising reading) and let honouring it RETIRE the sidebar, extending the
+  // panel mutex the members opener already applies to settings + archive.
+  //
+  // The pre-state is asserted as `.open` (translateX(0)), not mere presence: a
+  // sidebar parked off-screen would make the gesture act on nothing and the
+  // guard could not fail. The post-state is asserted as element COUNT, the same
+  // oracle the e2e spec uses for the deferred unmount.
+  describe("#1041 — right-edge swipe while the left sidebar is on screen", () => {
+    it("opens the members drawer AND retires the sidebar (never two drawers)", async () => {
+      mobileState.value = true;
+      const { container } = render(() => <Shell />);
+      const shell = container.querySelector(".shell-mobile") as HTMLElement;
+
+      swipeHorizontally(shell, 5, 200, 300);
+      await waitFor(() => {
+        expect(container.querySelector(".shell-sidebar.open")).not.toBeNull();
+      });
+      expect(container.querySelector(".shell-members.open")).toBeNull();
+
+      // Start the second gesture on the sidebar's backdrop — the element
+      // actually under the finger at the right edge while the drawer is up.
+      const backdrop = container.querySelector(".shell-drawer-backdrop") as HTMLElement;
+      swipeHorizontally(backdrop, window.innerWidth - 5, window.innerWidth - 200, 300);
+
+      expect(container.querySelector(".shell-members.open")).not.toBeNull();
+      await waitFor(() => {
+        expect(container.querySelectorAll(".shell-sidebar").length).toBe(0);
+      });
+    });
   });
 
   // C6.1: on mobile, a .bottom-bar element IS rendered (BottomBar).

--- a/cicchetto/src/__tests__/edgeGesture.test.ts
+++ b/cicchetto/src/__tests__/edgeGesture.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 import { bindEdgeGesture } from "../lib/touchGesture";
+import { fireTouch } from "./helpers/touchEvents";
 
 // #308 INC-A — the edge-swipe directive glue, exercised in jsdom by synthesizing
 // touch events. jsdom can't reproduce real iOS scroll physics (that's the
@@ -12,23 +13,6 @@ import { bindEdgeGesture } from "../lib/touchGesture";
 // preventDefault is never called and native vertical scroll is left alone.
 
 const W = 400; // viewport width fed to the directive (jsdom has no layout)
-
-type Pt = { clientX: number; clientY: number };
-
-// Dispatch a touch-shaped Event. jsdom lacks a full TouchEvent constructor, so
-// we shape a cancelable Event with the .touches/.changedTouches the directive
-// reads — exercising the real listener code path. Returns the event so callers
-// can assert defaultPrevented (the preventDefault-at-claim signal).
-function fireTouch(el: HTMLElement, type: string, ...points: Pt[]): Event {
-  const ev = new Event(type, { bubbles: true, cancelable: true });
-  const list = points as unknown as TouchList;
-  Object.defineProperty(ev, "touches", {
-    value: type === "touchend" ? ([] as unknown as TouchList) : list,
-  });
-  Object.defineProperty(ev, "changedTouches", { value: list });
-  el.dispatchEvent(ev);
-  return ev;
-}
 
 let el: HTMLDivElement;
 let onOpenMembers: Mock<() => void>;

--- a/cicchetto/src/__tests__/edgeGesture.test.ts
+++ b/cicchetto/src/__tests__/edgeGesture.test.ts
@@ -30,18 +30,20 @@ function fireTouch(el: HTMLElement, type: string, ...points: Pt[]): Event {
   return ev;
 }
 
+let el: HTMLDivElement;
+let onOpenMembers: Mock<() => void>;
+let onOpenSidebar: Mock<() => void>;
+let dispose: () => void;
+
+beforeEach(() => {
+  el = document.createElement("div");
+  document.body.appendChild(el);
+  onOpenMembers = vi.fn<() => void>();
+  onOpenSidebar = vi.fn<() => void>();
+  dispose = bindEdgeGesture(el, { viewportWidth: () => W, onOpenMembers, onOpenSidebar });
+});
+
 describe("bindEdgeGesture (right edge → open members)", () => {
-  let el: HTMLDivElement;
-  let onOpenMembers: Mock<() => void>;
-  let dispose: () => void;
-
-  beforeEach(() => {
-    el = document.createElement("div");
-    document.body.appendChild(el);
-    onOpenMembers = vi.fn<() => void>();
-    dispose = bindEdgeGesture(el, { viewportWidth: () => W, onOpenMembers });
-  });
-
   it("opens the members pane on a horizontal-left swipe from the right edge", () => {
     fireTouch(el, "touchstart", { clientX: W - 5, clientY: 300 });
     fireTouch(el, "touchmove", { clientX: W - 60, clientY: 305 });
@@ -95,5 +97,93 @@ describe("bindEdgeGesture (right edge → open members)", () => {
     fireTouch(el, "touchmove", { clientX: W - 60, clientY: 305 });
     fireTouch(el, "touchend", { clientX: W - 170, clientY: 312 });
     expect(onOpenMembers).not.toHaveBeenCalled();
+  });
+
+  // Direction gate, right edge: the members drawer lives at the right, so only
+  // right→center (a LEFT swipe) reveals it. A RIGHTWARD pull from the right
+  // edge points off-screen — it must open nothing, least of all the LEFT
+  // drawer, whose own arm is the opposite zone.
+  it("opens nothing on a RIGHTWARD swipe from the right edge (direction gate)", () => {
+    fireTouch(el, "touchstart", { clientX: W - 5, clientY: 300 });
+    const claimed = fireTouch(el, "touchmove", { clientX: W + 40, clientY: 304 });
+    fireTouch(el, "touchend", { clientX: W + 90, clientY: 306 });
+    expect(claimed.defaultPrevented).toBe(true); // armed + horizontal: it DID claim
+    expect(onOpenMembers).not.toHaveBeenCalled();
+    expect(onOpenSidebar).not.toHaveBeenCalled();
+  });
+});
+
+// #1041 — the mirror arm: left→center opens the left channel sidebar. Same
+// claim-late gate, same terminal classification, opposite zone AND opposite
+// direction. These cases exist so the two arms can never collapse into one
+// another: a left-edge gesture must NEVER reach onOpenMembers and vice versa.
+describe("bindEdgeGesture (left edge → open sidebar)", () => {
+  it("opens the sidebar on a horizontal-right swipe from the left edge", () => {
+    fireTouch(el, "touchstart", { clientX: 5, clientY: 300 });
+    fireTouch(el, "touchmove", { clientX: 60, clientY: 305 });
+    fireTouch(el, "touchmove", { clientX: 130, clientY: 310 });
+    fireTouch(el, "touchend", { clientX: 170, clientY: 312 });
+    expect(onOpenSidebar).toHaveBeenCalledTimes(1);
+    expect(onOpenMembers).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it("preventDefaults the move only AFTER it claims the horizontal gesture", () => {
+    fireTouch(el, "touchstart", { clientX: 5, clientY: 300 });
+    const claimed = fireTouch(el, "touchmove", { clientX: 60, clientY: 305 });
+    expect(claimed.defaultPrevented).toBe(true);
+    dispose();
+  });
+
+  // THE hard constraint on the new arm: a vertical-dominant drag from the left
+  // edge is never claimed → never preventDefaulted → native vertical scroll is
+  // byte-for-byte untouched, and no drawer opens.
+  it("NEVER claims a vertical drag from the left edge (vertical scroll survives)", () => {
+    fireTouch(el, "touchstart", { clientX: 5, clientY: 100 });
+    const m1 = fireTouch(el, "touchmove", { clientX: 7, clientY: 200 });
+    const m2 = fireTouch(el, "touchmove", { clientX: 4, clientY: 300 });
+    fireTouch(el, "touchend", { clientX: 5, clientY: 360 });
+    expect(m1.defaultPrevented).toBe(false);
+    expect(m2.defaultPrevented).toBe(false);
+    expect(onOpenSidebar).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  // Direction gate, left edge: a LEFTWARD pull from the left edge points
+  // off-screen. It must open nothing — in particular it must not fall through
+  // to the members arm, which reads the same "left" swipeDirection.
+  it("opens nothing on a LEFTWARD swipe from the left edge (direction gate)", () => {
+    fireTouch(el, "touchstart", { clientX: 18, clientY: 300 });
+    const claimed = fireTouch(el, "touchmove", { clientX: -20, clientY: 304 });
+    fireTouch(el, "touchend", { clientX: -60, clientY: 306 });
+    expect(claimed.defaultPrevented).toBe(true); // armed + horizontal: it DID claim
+    expect(onOpenSidebar).not.toHaveBeenCalled();
+    expect(onOpenMembers).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it("ignores a horizontal swipe that starts in the CENTER (zone separation)", () => {
+    fireTouch(el, "touchstart", { clientX: W / 2, clientY: 300 });
+    const m = fireTouch(el, "touchmove", { clientX: W / 2 + 80, clientY: 305 });
+    fireTouch(el, "touchend", { clientX: W / 2 + 160, clientY: 308 });
+    expect(m.defaultPrevented).toBe(false);
+    expect(onOpenSidebar).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it("does not open on a sub-threshold horizontal twitch from the edge", () => {
+    fireTouch(el, "touchstart", { clientX: 5, clientY: 300 });
+    fireTouch(el, "touchmove", { clientX: 15, clientY: 301 });
+    fireTouch(el, "touchend", { clientX: 18, clientY: 302 });
+    expect(onOpenSidebar).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it("stops responding after dispose (listeners removed)", () => {
+    dispose();
+    fireTouch(el, "touchstart", { clientX: 5, clientY: 300 });
+    fireTouch(el, "touchmove", { clientX: 60, clientY: 305 });
+    fireTouch(el, "touchend", { clientX: 170, clientY: 312 });
+    expect(onOpenSidebar).not.toHaveBeenCalled();
   });
 });

--- a/cicchetto/src/__tests__/helpers/touchEvents.ts
+++ b/cicchetto/src/__tests__/helpers/touchEvents.ts
@@ -1,0 +1,31 @@
+// Synthetic touch events for jsdom. jsdom ships no TouchEvent constructor, so
+// we shape a cancelable Event carrying the `.touches` / `.changedTouches` the
+// gesture code reads — which exercises the REAL listener path rather than
+// calling the pure geometry helpers directly. Returns the event so callers can
+// assert `defaultPrevented` (the claim signal).
+//
+// Bubbling is deliberate and load-bearing for the call-site tests: the edge
+// listener sits on `.shell-mobile`, and a touch that starts on a drawer
+// backdrop reaches it by bubbling, exactly as it does in a browser.
+
+export type TouchPoint = { clientX: number; clientY: number };
+
+export function fireTouch(el: HTMLElement, type: string, ...points: TouchPoint[]): Event {
+  const ev = new Event(type, { bubbles: true, cancelable: true });
+  const list = points as unknown as TouchList;
+  Object.defineProperty(ev, "touches", {
+    value: type === "touchend" ? ([] as unknown as TouchList) : list,
+  });
+  Object.defineProperty(ev, "changedTouches", { value: list });
+  el.dispatchEvent(ev);
+  return ev;
+}
+
+// One full edge swipe: start → two moves → end. The intermediate moves are what
+// let the directive claim mid-drag (it claims late, never on touchstart).
+export function swipeHorizontally(el: HTMLElement, fromX: number, toX: number, y: number): void {
+  fireTouch(el, "touchstart", { clientX: fromX, clientY: y });
+  fireTouch(el, "touchmove", { clientX: fromX + (toX - fromX) / 3, clientY: y + 5 });
+  fireTouch(el, "touchmove", { clientX: fromX + ((toX - fromX) * 2) / 3, clientY: y + 8 });
+  fireTouch(el, "touchend", { clientX: toX, clientY: y + 10 });
+}

--- a/cicchetto/src/lib/touchGesture.ts
+++ b/cicchetto/src/lib/touchGesture.ts
@@ -60,29 +60,40 @@ export const horizontalClaim = (
   return ax >= ay * k;
 };
 
-// Parameters for the right-edge → open-members gesture (INC-A gesture 1).
-// `viewportWidth` is injected (not read off the element) so the geometry is
-// testable in jsdom, which has no layout; the call site passes
-// `() => window.innerWidth`.
+// Parameters for the two edge → open-drawer gestures. `viewportWidth` is
+// injected (not read off the element) so the geometry is testable in jsdom,
+// which has no layout; the call site passes `() => window.innerWidth`.
 export type EdgeGestureParams = {
   viewportWidth: () => number;
   onOpenMembers: () => void;
+  onOpenSidebar: () => void;
 };
 
-// Bind the right-edge swipe (right→center opens the members drawer) on `el`.
-// Additive gesture — the BottomBar stays the primary nav (#71 ruling); this is
-// just a second door onto the existing right rail. Returns a disposer the caller
-// wraps in `onCleanup` (function refs fire only at mount and are NOT re-invoked
-// with undefined at unmount as in React — #308 landmine 3 — so cleanup is
-// explicit). Listeners are bound at ELEMENT level with a non-passive touchmove
-// (Solid delegates touch to a single PASSIVE document listener where
-// preventDefault silently no-ops — #308 landmine 1). The gesture is armed only
-// when the touch begins in the right-edge zone, and it CLAIMS (preventDefault)
-// late — only once horizontal intent is proven — so a vertical drag is left
-// entirely to native scroll (the hard constraint).
+// Bind BOTH edge swipes on `el`: right→center opens the members drawer (#308
+// INC-A gesture 1), left→center opens the channel sidebar (#1041). Additive
+// gestures — the BottomBar stays the primary nav (#71 ruling); each is just a
+// second door onto a rail. Returns a disposer the caller wraps in `onCleanup`
+// (function refs fire only at mount and are NOT re-invoked with undefined at
+// unmount as in React — #308 landmine 3 — so cleanup is explicit). Listeners
+// are bound at ELEMENT level with a non-passive touchmove (Solid delegates
+// touch to a single PASSIVE document listener where preventDefault silently
+// no-ops — #308 landmine 1). The gesture is armed only when the touch begins in
+// an edge zone, and it CLAIMS (preventDefault) late — only once horizontal
+// intent is proven — so a vertical drag is left entirely to native scroll (the
+// hard constraint).
+//
+// Terminal classification only: the drawer is decided at `touchend`, nothing is
+// reported during the drag. Per vjt's #1041 ruling ("non ci formalizziamo,
+// l'animazione può partire a touchend") a follow-the-finger panel is explicitly
+// NOT required, and it is what would force a progress channel through here.
+//
+// The zone AND the direction must agree — a rightward pull from the right edge
+// (or a leftward one from the left edge) points off-screen and opens nothing.
+// Keeping the armed zone rather than a bare boolean is what makes the two arms
+// unable to collapse into one another.
 export function bindEdgeGesture(el: HTMLElement, params: EdgeGestureParams): () => void {
   let start: Point | null = null;
-  let armed = false; // touch began in the right-edge zone
+  let armedZone: "left-edge" | "right-edge" | null = null; // null = not armed
   let claimed = false; // horizontal intent proven → we own the gesture
 
   const onStart = (e: TouchEvent): void => {
@@ -90,15 +101,16 @@ export function bindEdgeGesture(el: HTMLElement, params: EdgeGestureParams): () 
     claimed = false;
     if (t === undefined) {
       start = null;
-      armed = false;
+      armedZone = null;
       return;
     }
     start = { x: t.clientX, y: t.clientY };
-    armed = touchZone(t.clientX, params.viewportWidth()) === "right-edge";
+    const zone = touchZone(t.clientX, params.viewportWidth());
+    armedZone = zone === "center" ? null : zone;
   };
 
   const onMove = (e: TouchEvent): void => {
-    if (!armed || start === null || e.touches.length !== 1) return;
+    if (armedZone === null || start === null || e.touches.length !== 1) return;
     const t = e.touches[0];
     if (t === undefined) return;
     if (!claimed) {
@@ -112,18 +124,20 @@ export function bindEdgeGesture(el: HTMLElement, params: EdgeGestureParams): () 
 
   const onEnd = (e: TouchEvent): void => {
     const s = start;
+    const zone = armedZone;
     const wasClaimed = claimed;
     start = null;
-    armed = false;
+    armedZone = null;
     claimed = false;
-    if (!wasClaimed || s === null) return;
+    if (!wasClaimed || s === null || zone === null) return;
     const t = e.changedTouches[0];
     if (t === undefined) return;
-    // right→center is a LEFT swipe (x decreases); swipeDirection floors the
-    // travel at SWIPE_MIN_PX, so a claimed-but-short pull does not open.
-    if (swipeDirection(s, { x: t.clientX, y: t.clientY }) === "left") {
-      params.onOpenMembers();
-    }
+    // right→center is a LEFT swipe (x decreases), left→center a RIGHT one;
+    // swipeDirection floors the travel at SWIPE_MIN_PX, so a claimed-but-short
+    // pull does not open either drawer.
+    const direction = swipeDirection(s, { x: t.clientX, y: t.clientY });
+    if (zone === "right-edge" && direction === "left") params.onOpenMembers();
+    if (zone === "left-edge" && direction === "right") params.onOpenSidebar();
   };
 
   el.addEventListener("touchstart", onStart, { passive: true });

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -6250,8 +6250,10 @@ html.resize-dragging * {
 
 @media (max-width: 768px) {
   /* C6.1: mobile grid shape — scrollback expands, compose + bottom-bar
-     take min content height. shell-sidebar is NOT rendered in the mobile
-     JSX branch; only .shell-mobile (+ .shell-main, .shell-members) exist.
+     take min content height. The mobile JSX branch renders .shell-mobile
+     (+ .shell-main, .shell-members); #1041 added .shell-sidebar, but ONLY
+     for the life of the left-edge-swipe drawer, and as `position: fixed`
+     — so it never takes a grid track and this shape is unchanged.
      grid-template-rows: 1fr auto auto = scrollback | compose | bottom-bar */
   .shell-mobile {
     display: grid;
@@ -6386,6 +6388,61 @@ html.resize-dragging * {
        band-aid #1039 rules out. Mobile-only because the ☰ is display:none
        above this breakpoint. */
     align-self: flex-start;
+  }
+
+  /* #1041 — the mobile channel sidebar: the SAME `.shell-sidebar` aside the
+     desktop grid mounts, turned into a fixed drawer that slides in from the
+     LEFT. Written as the mirror of `.shell-members` below on purpose — a fixed
+     mobile drawer has exactly one set of geometry problems (keyboard-shrunk
+     viewport, safe areas, the `touch-action: none` blanket) and they get the
+     same answers here.
+     The one real difference: this element is in the DOM only while it is on
+     screen (Shell.tsx mounts it on the left-edge swipe and disposes it at the
+     end of the exit transition), so `translateX(-100%)` below is a transition
+     START value, not a parking spot for a permanently mounted panel. Base
+     `.shell-sidebar` already supplies background / border-right / overflow-y /
+     flex column; only the fixed-drawer geometry is bespoke. */
+  .shell-mobile .shell-sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    /* UX-5 bucket BV — iOS lies about 100vh (and dvh/svh) while the on-screen
+       keyboard is up; `--viewport-height` tracks `visualViewport.height` via
+       lib/viewportHeight.ts and shrinks in lockstep. Same fallback chain as
+       `.shell-members`: `100dvh` for the boot window before the JS sets the var
+       and for browsers without VisualViewport. */
+    height: var(--viewport-height, 100dvh);
+    /* #205 — `position: fixed` puts this OUTSIDE `.shell`'s padding box, so it
+       owns its notch / Dynamic-Island and home-indicator clearance. The 1.5rem
+       bottom floor mirrors UX-5 BD on the members drawer: env() is 0px on
+       non-notched iPhones, which left the last row cramped under the Safari
+       chrome / gesture indicator. */
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: max(1.5rem, env(safe-area-inset-bottom));
+    width: 80vw;
+    max-width: 18rem;
+    z-index: 90;
+    transform: translateX(-100%);
+    transition: transform 200ms ease-out;
+    overscroll-behavior: contain;
+  }
+
+  /* UX-6 bucket A v2 — `touch-action` is NOT inherited (CSS UI L4). The drawer
+     is `position: fixed`, so it escapes `.shell-mobile { touch-action: none }`
+     and must re-assert `pan-y` or its window list cannot scroll — but setting
+     it on the scroller ALONE leaves the `<ul>` / `<li>` / `<button>` rows at
+     `auto`, and iOS routes a drag whose hit-test target is a row to a different
+     scroll ancestor, so the scroller's `pan-y` never fires. Same
+     universal-selector carve-out the members pane needs, same specificity
+     guard: a future horizontal gesture inside the window list (swipe-to-close a
+     row, say) MUST be declared more specific than this (0,3,0). */
+  .shell-mobile .shell-sidebar,
+  .shell-mobile .shell-sidebar * {
+    touch-action: pan-y;
+  }
+
+  .shell-mobile .shell-sidebar.open {
+    transform: translateX(0);
   }
 
   /* Members drawer slide-in from right (unchanged from pre-C6) */


### PR DESCRIPTION
Refs #1041.

## What lands

On mobile the channel sidebar was not hidden, it was **absent** — the shell branches on `isMobile()` in JSX and `.shell-sidebar` lived only in the desktop fallback. This adds a left-edge swipe that mounts it, and disposes it again when it hides. It stays absent whenever it is not on screen, which was vjt's condition for taking the feature at all.

Three commits:

1. **`bindEdgeGesture` gains a left-edge arm.** The armed state stops being a boolean and becomes the armed *zone*. That is the load-bearing bit: with a boolean plus a direction test the two arms silently collapse into one another, because `swipeDirection` answers `"left"` both for a right-edge open and for a left-edge overshoot. Zone **and** direction must now agree, so an off-screen pull claims the gesture and opens nothing. Terminal classification is unchanged — per vjt's ruling the follow-the-finger panel is out of scope, and a `touchmove` progress channel is precisely what that ruling avoids paying for.
2. **The drawer.** Two signals out of phase at both ends (see below), an own backdrop, an overlay scroll-lock, the gesture wiring, and the CSS written as the deliberate mirror of `.shell-members`.
3. **The e2e.**

## Why unmount, and why two signals

`.shell-members` is the counter-example already in the tree: mounted whether open or shut, and #782 had to thread an `onScreen` prop into `RailContext` purely to stop it spending a WHOIS on a card parked behind the right edge. A component that does not exist cannot forget to check whether it is visible.

Unmounting is cheap for *this* component specifically — `Sidebar` owns no local state (no `createSignal` / `createEffect` / `createMemo` / `onMount` of its own), so a remount rebuilds it identically from the same global stores. What disposal reclaims is not DOM nodes but the live reactive subscriptions that would otherwise re-run on every message on every network to repaint something off-screen.

Hence `sidebarMounted` (existence) and `sidebarSlidIn` (the `.open` transform), deliberately out of phase:

* **Enter** — a node that mounts and gets `.open` in the same task never paints at `translateX(-100%)`, so the transition has no start value and the bar pops instead of sliding. Two rAFs buy one painted frame first.
* **Exit** — dropping the node the instant the class flips kills the exit animation, so disposal waits for the transform's `transitionend`, with a timeout **floor** (longer than the CSS duration on purpose, not pinned to it) because `transitionend` does not fire for an unpainted or interrupted transition, and a missed event would leak the very subtree this went to trouble to dispose.

## Two decisions worth arguing with

**The overlay refusal instead of a fourth mutex member.** An open backdrop or modal is a *child* of `.shell-mobile`, so its touches still bubble to the edge listener and a left swipe would stack a second drawer under the first. Rather than teach the `mobilePanel` mutex a fourth member — which ripples through every setters call site, including the `RailActions` ones another worktree is currently in — the callback reads `overlayCount()`, the state that already answers "is something covering the shell" for every present *and* future overlay.

**`Sidebar` needed a change after all.** The issue expected none and asked for it to be reported rather than edited silently, so: its `onSelect` prop is restored. UX-5 bucket A dropped it because no drawer was left to close; #1041 expires that premise. A Shell-side effect watching `selectedChannel()` looks equivalent and is not — it no-ops when the operator taps the row that is *already* active, leaving the drawer stuck open over the window they just asked to see. That exact case is pinned in the e2e, so removing the prop turns a spec red instead of degrading quietly.

## Gates

| Gate | Result |
|---|---|
| `bun run check` (biome + tsc) | exit 0 |
| `bun run test` (vitest) | 4667 passed / 249 files |
| `tsc -p e2e/tsconfig.json` on the new spec | 0 diagnostics (the rest of the e2e tree emits pre-existing errors) |

**The e2e was NOT run locally.** It needs the stack lane, which another worktree holds right now, so the PR's own CI is the gate for it — per the standing "contended lane → gate from the PR's CI" rule. Nothing here should be read as "the e2e passed".

## Device-verify (NOT covered by the e2e)

jsdom reproduces neither of the two gesture landmines, and chromium is not iOS Safari. Synthetic `TouchEvent`s drive no pixel-scroll. So the following are **device calls for vjt's dogfood**, deliberately not parked and not pretended-covered:

* Whether the 200ms slide-in, started at `touchend`, reads as a drawer rather than a pop under a real finger.
* Whether native vertical scroll on the left third of the screen genuinely survives. The claim-late gate is unit-tested and e2e-tested at the `preventDefault` level, but iOS momentum/fling is not reproducible off-device.
* Whether the `pan-y` carve-out actually lets the window list scroll inside the drawer, and whether iOS Safari's back-swipe/chrome-reveal fights the left-edge band on a notched device. The left edge is where iOS's own interactive-pop gesture lives — this is the highest-risk item on the list and only a real iPhone can answer it.
* Whether `--viewport-height` + the safe-area insets keep the bottom of the window list clear with the keyboard up.