### PR TITLE
cic(#950): the #866 mute snooze gets the door it never had

### DIFF
--- a/cicchetto/e2e/tests/issue473-rail-actions-drawer.spec.ts
+++ b/cicchetto/e2e/tests/issue473-rail-actions-drawer.spec.ts
@@ -77,6 +77,14 @@ const RAIL_BUTTONS: ReadonlyArray<{ testid: string; label: string }> = [
   { testid: "mobile-panel-archive", label: "archive" },
   { testid: "action-cluster-cog", label: "settings" },
   { testid: "presence-toggle", label: "denoise" },
+  // #950 — the mute/snooze row, added to the CONTRACT deliberately rather than
+  // loosening the count it broke: the rail genuinely hosts one more labelled
+  // row now. Gated on the selected CONVERSATION (channel or query), and both
+  // tests below run on a channel window, so it renders on BOTH engines — which
+  // is why it belongs in the shared table and not behind a form-factor arm.
+  // Its label reads "mute" while the conversation is unmuted, the state every
+  // arm of this file is in (nothing here mutes anything).
+  { testid: "rail-action-mute", label: "mute" },
   // #986 — the lifecycle pair, moved out of the settings drawer. `detach` is
   // canDetach()-gated: vjt is a persistent user, so it renders.
   { testid: "detach-btn", label: "detach" },

--- a/cicchetto/e2e/tests/issue950-rail-mute-snooze.spec.ts
+++ b/cicchetto/e2e/tests/issue950-rail-mute-snooze.spec.ts
@@ -1,0 +1,135 @@
+// issue950-rail-mute-snooze — the TIME-BOXED mute, from the rail (#950).
+//
+// #866 shipped every part of the snooze except a way to reach it: the storage
+// carries `until`, both readers (cic's `withLiveMutes`, the server's
+// `get_notification_prefs/1`) resolve it, and the tests on both sides cover it
+// — but every UI mute wrote `{ until: null }`, so no integer ever existed
+// outside a fixture. This spec is the proof that one now does, end to end.
+//
+// Sibling of `push-866-conversation-mute.spec.ts`, and deliberately NOT a copy:
+// that spec proves a PERMANENT mute created in the settings drawer holds a push
+// back. This one proves
+//
+//   * the RAIL picker — a different door, gated on the selected conversation —
+//     writes a mute at all, and
+//   * what it writes is a SNOOZE. The drawer's global list renders a remaining
+//     span ("… left") only for an entry whose `until` is an integer, so that
+//     row is the visible outcome that separates this feature from #866's. A
+//     picker that wrote `until: null` (the pre-#950 behaviour) would still
+//     silence the channel and would still leave the push arm below green — and
+//     would fail HERE.
+//
+// The push arms remain, because a mute that only paints a settings row is not
+// a mute: the suppression is decided server-side from the integer this client
+// computed, which is the one thing no unit test on either side can observe.
+//
+// Removing the feature turns the spec red at the picker (absent from the rail).
+// Making the picker write a permanent mute again turns it red at the "… left"
+// row while leaving the push arms green — the discrimination this spec exists
+// for.
+
+import { loginAs, openRailMenu, openSettingsSection, selectChannel } from "../fixtures/cicchettoPage";
+import { clearMutedConversations, partChannel } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import {
+  assertNoPushDelivery,
+  awaitPushDelivery,
+  enablePushFromSettings,
+  pushCatcherEndpoint,
+  resetPushCatcher,
+  resetPushSubscriptions,
+  setPageVisibility,
+  stubPushManager,
+} from "../fixtures/push";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+const PEER_NICK = "i950-snoozer";
+const SNOOZED_CHANNEL = "#950-snoozed";
+const LOUD_CHANNEL = "#950-loud";
+const SUB_ID = "rail-mute-snooze";
+
+test("a one-hour snooze picked from the rail silences the channel and says how long it has left", async ({
+  page,
+  context,
+}) => {
+  const vjt = getSeededVjt();
+  await resetPushCatcher();
+  await resetPushSubscriptions(vjt.token);
+  await stubPushManager(context, { endpoint: pushCatcherEndpoint(SUB_ID) });
+  await context.grantPermissions(["notifications"]);
+
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
+
+  await enablePushFromSettings(page, context, { id: SUB_ID, token: vjt.token });
+
+  const peer = await IrcPeer.connect({ nick: PEER_NICK });
+  try {
+    await peer.join(SNOOZED_CHANNEL);
+    await peer.join(LOUD_CHANNEL);
+
+    for (const channel of [SNOOZED_CHANNEL, LOUD_CHANNEL]) {
+      await page.locator(".compose-box textarea").fill(`/join ${channel}`);
+      await page.locator(".compose-box textarea").press("Enter");
+      await selectChannel(page, NETWORK_SLUG, channel, { ownNick: NETWORK_NICK });
+    }
+
+    // The rail picker is CONTEXT-SENSITIVE: it mutes whatever conversation is
+    // selected, so selecting the target IS half the gesture.
+    await selectChannel(page, NETWORK_SLUG, SNOOZED_CHANNEL, { ownNick: NETWORK_NICK });
+    await openRailMenu(page);
+    const picker = page.getByTestId("rail-mute-picker");
+    await expect(picker).toBeVisible();
+    await picker.selectOption("1h");
+
+    // The menu closes on the choice (a snooze resolves, unlike the denoise
+    // toggle beside it) — the first observable consequence of the pick.
+    await expect(page.locator(".rail-actions-menu")).toHaveCount(0);
+
+    await openSettingsSection(page, "push");
+
+    // Drawn from the server's echo, so the row's presence proves the PUT landed
+    // and came back normalized. No sleep, no arbitrary timeout.
+    await expect(page.getByTestId(`pref-muted-${SNOOZED_CHANNEL}`)).toBeVisible({
+      timeout: 10_000,
+    });
+    // THE discriminator: a remaining span exists only for an integer `until`.
+    // "1h 0m left" at the top of the hour, "59m left" a minute in — both match,
+    // and a permanent mute renders no such element at all.
+    await expect(page.getByTestId(`pref-muted-until-${SNOOZED_CHANNEL}`)).toHaveText(
+      /^(1h \d+m|5\dm) left$/,
+    );
+    // ...and the sibling channel is demonstrably not muted, so the two push
+    // arms below differ in exactly one variable.
+    await expect(page.getByTestId(`pref-muted-${LOUD_CHANNEL}`)).toHaveCount(0);
+    await expect(page.getByTestId("pref-channel-mentions")).toBeChecked();
+
+    await page.getByTestId("settings-drawer-backdrop").click({ force: true });
+
+    // Focus a third window so neither target is "being read", and background the
+    // device so #182's foreground suppression is not what decides either arm.
+    await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
+    await setPageVisibility(page, false);
+
+    // Negative arm — a MENTION inside the snoozed hour. The server compares the
+    // integer this client wrote against its own clock and holds the push.
+    peer.privmsg(SNOOZED_CHANNEL, `${NETWORK_NICK}: not for the next hour`);
+    await assertNoPushDelivery(SUB_ID, 1_500);
+
+    // Positive arm — the same shape in the unmuted sibling, so the negative arm
+    // cannot be passing because push broke outright.
+    peer.privmsg(LOUD_CHANNEL, `${NETWORK_NICK}: but you will hear this`);
+    const deliveries = await awaitPushDelivery(SUB_ID);
+    expect(deliveries.length).toBeGreaterThanOrEqual(1);
+  } finally {
+    await peer.disconnect("#950 snooze done");
+    // The mute is PERSISTED per subject and vjt is shared by the whole suite —
+    // an hour-long snooze left behind silences #950-snoozed for every later
+    // spec, which would fail on a missing notification with nothing pointing
+    // back here.
+    await clearMutedConversations(vjt.token).catch(() => {});
+    await partChannel(vjt.token, NETWORK_SLUG, SNOOZED_CHANNEL).catch(() => {});
+    await partChannel(vjt.token, NETWORK_SLUG, LOUD_CHANNEL).catch(() => {});
+  }
+});

--- a/cicchetto/e2e/tests/issue950-rail-mute-snooze.spec.ts
+++ b/cicchetto/e2e/tests/issue950-rail-mute-snooze.spec.ts
@@ -87,6 +87,14 @@ test("a one-hour snooze picked from the rail silences the channel and says how l
     // toggle beside it) — the first observable consequence of the pick.
     await expect(page.locator(".rail-actions-menu")).toHaveCount(0);
 
+    // Re-open the rail: the row itself now reads "muted", because the write
+    // mirrored the SERVER's echo back into the shared prefs signal. This is a
+    // second visible outcome AND the honest barrier for everything below — the
+    // write is two round-trips (GET then PUT) and nothing else in the UI would
+    // otherwise tell the spec it had landed.
+    await openRailMenu(page);
+    await expect(page.getByTestId("rail-action-mute")).toContainText("muted");
+
     await openSettingsSection(page, "push");
 
     // Drawn from the server's echo, so the row's presence proves the PUT landed

--- a/cicchetto/src/RailActions.tsx
+++ b/cicchetto/src/RailActions.tsx
@@ -1,7 +1,8 @@
 import { useNavigate } from "@solidjs/router";
-import { type Component, createEffect, createSignal, onCleanup, Show } from "solid-js";
+import { type Component, createEffect, createSignal, For, onCleanup, Show } from "solid-js";
 import { archiveSlugForSelection } from "./lib/archiveContext";
 import { channelKey } from "./lib/channelKey";
+import { conversationMuteKey, isConversationMuted } from "./lib/conversationMute";
 import { syncedSetChannelPresencePref } from "./lib/displayPrefs";
 import { canDetach, confirmDetach, confirmQuit } from "./lib/lifecycle";
 import { membersByChannel } from "./lib/members";
@@ -17,7 +18,13 @@ import {
   openSettingsPanel,
   openThemesPanel,
 } from "./lib/mobilePanel";
+import { MUTE_SNOOZE_OPTIONS, type MuteSnoozeValue, snoozeUntil } from "./lib/muteSnooze";
 import { isAdmin } from "./lib/networks";
+import {
+  applyConversationMute,
+  clearConversationMute,
+  notificationPrefs,
+} from "./lib/notificationPrefs";
 import { createOverlayLock } from "./lib/overlayScrollLock";
 import { channelPresenceVisible } from "./lib/presenceFilter";
 import { selectedChannel, setSelectedChannel } from "./lib/selection";
@@ -127,6 +134,11 @@ export type Props = {
 // remains on top of it. Fed to `spaceAbove`.
 const RAIL_MENU_TOP_GAP = 8;
 
+// #950 — the picker's one non-duration row. Outside `MuteSnoozeValue` on
+// purpose: unmuting is not a snooze offer, it is the inverse verb, and giving
+// it a member of that union would let a caller ask `snoozeUntil` for it.
+const UNMUTE_VALUE = "off";
+
 const RailActions: Component<Props> = (props) => {
   // #986 — the two lifecycle verbs land the operator on /login once the
   // teardown resolves. `logout()` nulls the token and main.tsx's RequireAuth
@@ -155,6 +167,18 @@ const RailActions: Component<Props> = (props) => {
     const sel = selectedChannel();
     return sel && sel.kind === "channel"
       ? { networkSlug: sel.networkSlug, channelName: sel.channelName }
+      : null;
+  };
+
+  // #950 — the CONVERSATION this rail is showing: a channel or a query, the
+  // two window kinds a mute can be keyed on. Wider than `channel()` above by
+  // exactly one kind, and deliberately a separate memo: denoise is a
+  // per-CHANNEL presence pref (a query has no join/part traffic), the mute is
+  // per-conversation.
+  const conversation = (): { channelName: string } | null => {
+    const sel = selectedChannel();
+    return sel && (sel.kind === "channel" || sel.kind === "query")
+      ? { channelName: sel.channelName }
       : null;
   };
 
@@ -455,6 +479,87 @@ const RailActions: Component<Props> = (props) => {
                   </span>
                   <span class="rail-action-label">denoise</span>
                 </button>
+              );
+            }}
+          </Show>
+
+          {/* #950 — the mute / snooze picker. #866 shipped the storage, both
+              expiry readers and the tests, and NOTHING ever wrote a non-null
+              `until`: the snooze was unreachable. This is the door.
+
+              Gated on a selected CONVERSATION — channel OR query — because the
+              mute is keyed on the conversation and for a DM that key is the
+              PEER (an inbound DM is stored with `channel = own_nick`, so
+              keying on a row's channel would collapse every DM onto one
+              entry). On a query window `channelName` IS the peer nick, so ONE
+              expression serves both kinds, exactly as `windowMuteKey` does for
+              the sidebar projection.
+
+              A <select> rather than a row of buttons: the offers are a small
+              closed set, and a native control gives the iOS wheel / Android
+              dialog for free inside a menu whose height is already capped
+              (#588). Its CLOSED-state appearance is the app-wide form-control
+              rule — deliberately NOT re-implemented here (see #963/PR #965).
+
+              Unlike `denoise` next to it, this CLOSES the menu: a toggle is
+              flipped in place and watched, a snooze is a choice that resolves
+              and is done. The unmute row appears only when this conversation
+              is muted, so the one door can also undo itself; the settings
+              drawer keeps the GLOBAL list of every mute.
+
+              The write rejects on failure and there is no banner surface in a
+              menu that just closed, so a failed PUT is logged — same posture
+              as the sibling denoise PUT. */}
+          <Show when={conversation()}>
+            {(conv) => {
+              const key = (): string => conversationMuteKey(conv().channelName);
+              const isMuted = (): boolean =>
+                isConversationMuted(notificationPrefs().muted_targets, key());
+              const onPick = (picked: string): void => {
+                if (picked === "") return;
+                const write =
+                  picked === UNMUTE_VALUE
+                    ? clearConversationMute(key())
+                    : applyConversationMute(
+                        key(),
+                        snoozeUntil(picked as MuteSnoozeValue, new Date()),
+                      );
+                write.catch((e: unknown) => console.warn("mute: PUT failed", e));
+                close();
+              };
+              return (
+                // biome-ignore lint/a11y/noLabelWithoutControl: the <select> below IS this label's control (implicit association); biome misses it because the control is nested behind two sibling spans.
+                <label
+                  class="shell-chrome-btn rail-action rail-action-mute"
+                  data-testid="rail-action-mute"
+                >
+                  <span class="rail-action-icon" aria-hidden="true">
+                    {isMuted() ? "\u{1F507}" : "\u{1F514}"}
+                  </span>
+                  <span class="rail-action-label">{isMuted() ? "muted" : "mute"}</span>
+                  <select
+                    class="rail-action-mute-select"
+                    aria-label="mute this conversation"
+                    data-testid="rail-mute-picker"
+                    // Resets to the placeholder after every pick so the same
+                    // offer can be chosen twice in a row (re-snoozing).
+                    value=""
+                    onChange={(e) => {
+                      const el = e.currentTarget as HTMLSelectElement;
+                      const picked = el.value;
+                      el.value = "";
+                      onPick(picked);
+                    }}
+                  >
+                    <option value="">{isMuted() ? "change…" : "silence…"}</option>
+                    <For each={MUTE_SNOOZE_OPTIONS}>
+                      {(option) => <option value={option.value}>{option.label}</option>}
+                    </For>
+                    <Show when={isMuted()}>
+                      <option value={UNMUTE_VALUE}>unmute now</option>
+                    </Show>
+                  </select>
+                </label>
               );
             }}
           </Show>

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -27,7 +27,7 @@ import { friendlyApiError } from "./lib/friendlyApiError";
 import { getHideNextActive, setHideNextActive } from "./lib/hideNextActive";
 import { deleteAccountBody, updateIdentity, updateNetworkPassword } from "./lib/lifecycle";
 import { networks, user } from "./lib/networks";
-import { mirrorNotificationPrefs } from "./lib/notificationPrefs";
+import { mirrorNotificationPrefs, notificationPrefs } from "./lib/notificationPrefs";
 import { popOverlay, pushOverlay } from "./lib/overlayScrollLock";
 import {
   deletePushSubscription,
@@ -57,6 +57,7 @@ import {
   DEFAULT_NOTIFICATION_PREFS,
   getNotificationPrefs,
   getVhostSettings,
+  type MutedTargets,
   type NotificationPrefs,
   putNotificationPrefs,
   putVhostSelection,
@@ -530,10 +531,20 @@ const SettingsDrawer: Component<Props> = (props) => {
     void savePrefs(next);
   };
 
+  // #950 — the mute map comes from the SHARED mirror, not from this drawer's
+  // private `prefs()` snapshot. The drawer is mounted once and loads its form
+  // at mount (see the moduledoc): that was sound while it was the only writer
+  // of `muted_targets`, but the rail picker is a second one and it feeds the
+  // mirror the server's echo. Reading the snapshot here would show a global
+  // list missing the mute the operator just made — derive, don't duplicate.
+  // Every write still goes through `savePrefs`, whose echo lands in the same
+  // mirror, so this drawer's own picker is unchanged in behaviour.
+  const mutedTargets = (): MutedTargets => notificationPrefs().muted_targets ?? {};
+
   // #866 — the per-conversation mute list, sorted by the stored (folded) key
   // so the rows do not reshuffle when one is added.
   const mutedConversations = (): { key: string; until: number | null }[] =>
-    Object.entries(prefs().muted_targets ?? {})
+    Object.entries(mutedTargets())
       .map(([key, target]) => ({ key, until: target.until }))
       .sort((a, b) => a.key.localeCompare(b.key));
 
@@ -544,7 +555,7 @@ const SettingsDrawer: Component<Props> = (props) => {
   // offering it twice would imply otherwise. Already-muted keys drop out, so
   // the picker cannot re-add a row that is on screen right below it.
   const muteCandidates = (): { key: string; label: string }[] => {
-    const muted = prefs().muted_targets ?? {};
+    const muted = mutedTargets();
     const byKey = new Map<string, string>();
     for (const candidate of windowCandidates()) {
       const key = windowMuteKey(candidate);
@@ -561,18 +572,16 @@ const SettingsDrawer: Component<Props> = (props) => {
   // the same shape via `withConversationMute`.
   const muteConversation = (key: string) => {
     if (key === "") return;
-    const current = prefs();
     void savePrefs({
-      ...current,
-      muted_targets: withConversationMute(current.muted_targets, key, null),
+      ...prefs(),
+      muted_targets: withConversationMute(mutedTargets(), key, null),
     });
   };
 
   const unmuteConversation = (key: string) => {
-    const current = prefs();
     void savePrefs({
-      ...current,
-      muted_targets: withoutConversationMute(current.muted_targets, key),
+      ...prefs(),
+      muted_targets: withoutConversationMute(mutedTargets(), key),
     });
   };
 

--- a/cicchetto/src/SettingsDrawer.tsx
+++ b/cicchetto/src/SettingsDrawer.tsx
@@ -15,8 +15,13 @@ import { windowCandidates } from "./lib/activeWindows";
 import { ApiError, displayNick, type Network, visitorNetworkNick } from "./lib/api";
 import { getSubject, token } from "./lib/auth";
 import { getColoredNicklist } from "./lib/colorNicklist";
-import { windowMuteKey } from "./lib/conversationMute";
+import {
+  windowMuteKey,
+  withConversationMute,
+  withoutConversationMute,
+} from "./lib/conversationMute";
 import { syncedSetColoredNicklist, syncedSetTimeFormat } from "./lib/displayPrefs";
+import { formatDuration } from "./lib/duration";
 import { type FontSizeKey, getFontSize, setFontSize } from "./lib/fontSize";
 import { friendlyApiError } from "./lib/friendlyApiError";
 import { getHideNextActive, setHideNextActive } from "./lib/hideNextActive";
@@ -551,23 +556,24 @@ const SettingsDrawer: Component<Props> = (props) => {
       .sort((a, b) => a.key.localeCompare(b.key));
   };
 
-  // `until: null` — permanent. The shape carries the snooze field from day
-  // one (Q1) but this cut exposes no picker for it, so every mute the UI
-  // creates is permanent until removed.
+  // `until: null` — permanent. This picker mutes indefinitely; the TIME-BOXED
+  // mute is the rail's picker (#950), which writes an integer `until` through
+  // the same shape via `withConversationMute`.
   const muteConversation = (key: string) => {
     if (key === "") return;
     const current = prefs();
     void savePrefs({
       ...current,
-      muted_targets: { ...(current.muted_targets ?? {}), [key]: { until: null } },
+      muted_targets: withConversationMute(current.muted_targets, key, null),
     });
   };
 
   const unmuteConversation = (key: string) => {
     const current = prefs();
-    const next = { ...(current.muted_targets ?? {}) };
-    delete next[key];
-    void savePrefs({ ...current, muted_targets: next });
+    void savePrefs({
+      ...current,
+      muted_targets: withoutConversationMute(current.muted_targets, key),
+    });
   };
 
   const onMasterToggle = async (checked: boolean) => {
@@ -1575,6 +1581,22 @@ const SettingsDrawer: Component<Props> = (props) => {
                     {(muted) => (
                       <li class="watchlists-item" data-testid={`pref-muted-${muted.key}`}>
                         <span class="watchlists-keyword">{muted.key}</span>
+                        {/* #950 — a time-boxed mute (written by the rail
+                            picker) says how long it has left; a permanent one
+                            renders nothing extra. Computed at render from the
+                            client's clock — the same clock the client-side
+                            expiry filter uses — so the number the operator
+                            reads and the moment cic stops silencing agree,
+                            even if the server's clock does not (see
+                            lib/muteSnooze.ts on the unexamined skew). */}
+                        <Show when={muted.until !== null}>
+                          <span class="muted" data-testid={`pref-muted-until-${muted.key}`}>
+                            {formatDuration(
+                              Math.max(0, (muted.until as number) - Math.floor(Date.now() / 1000)),
+                            )}{" "}
+                            left
+                          </span>
+                        </Show>
                         <button
                           type="button"
                           class="watchlists-remove"

--- a/cicchetto/src/__tests__/RailActions.test.tsx
+++ b/cicchetto/src/__tests__/RailActions.test.tsx
@@ -21,8 +21,27 @@ import { __resetForTest as resetOverlayLock } from "../lib/overlayScrollLock";
 // the REAL presenceFilter + members stores drive the denoise toggle wiring
 // (use production code, don't re-implement logic).
 
-vi.mock("../lib/channelKey", () => ({
+// #950 — `channelKey` stays stubbed (the denoise pref key), but the REST of the
+// module is real: `conversationMute` folds the mute key through
+// `canonicalChannel`, and that fold is exactly what the picker must emit.
+vi.mock("../lib/channelKey", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/channelKey")>()),
   channelKey: (slug: string, name: string) => `${slug} ${name}`,
+}));
+
+// #950 — the mute WRITE is a server round-trip (GET-then-PUT, see
+// notificationPrefs.ts). Stub the two verbs and the mirrored signal so the
+// picker's gating and its argument are what these tests constrain; the verbs
+// themselves are covered in notificationPrefs.test.ts.
+const applyConversationMute = vi.fn().mockResolvedValue(undefined);
+const clearConversationMute = vi.fn().mockResolvedValue(undefined);
+const mutedHolder = vi.hoisted(() => ({
+  value: {} as Record<string, { until: number | null }> | undefined,
+}));
+vi.mock("../lib/notificationPrefs", () => ({
+  applyConversationMute: (...a: unknown[]) => applyConversationMute(...a),
+  clearConversationMute: (...a: unknown[]) => clearConversationMute(...a),
+  notificationPrefs: () => ({ muted_targets: mutedHolder.value }),
 }));
 
 const adminHolder = { value: false };
@@ -124,6 +143,7 @@ beforeEach(() => {
   roomsSlugHolder.value = "freenode";
   mentionsBundles.value = {};
   subjectHolder.current = null;
+  mutedHolder.value = {};
   dismissConfirm();
 });
 
@@ -610,6 +630,7 @@ describe("RailActions — detach + quit (#986)", () => {
       "action-cluster-cog",
       "mobile-panel-admin",
       "presence-toggle",
+      "rail-action-mute",
       "detach-btn",
       "quit-irc-btn",
     ]);
@@ -619,5 +640,120 @@ describe("RailActions — detach + quit (#986)", () => {
     mountWithSubject(USER);
     fireEvent.click(screen.getByTestId("quit-irc-btn"));
     expect(screen.queryByTestId("action-cluster-cog")).toBeNull();
+  });
+});
+
+// #950 — the mute/snooze picker. #866 shipped the storage, both expiry readers
+// and the tests; NOTHING wrote an integer `until`, so the snooze was
+// unreachable. This is the door.
+//
+// Two properties separate it from its neighbour `denoise`:
+//   * the GATE is a selected CONVERSATION — a channel OR a query — because the
+//     mute is keyed on the conversation, and for a DM that key is the PEER
+//     (#866: an inbound DM is stored with `channel = own_nick`, so keying on
+//     the row's channel would collapse every DM onto one entry).
+//   * a snooze is a CHOICE, not a toggle: it resolves in place and THEN closes
+//     the menu, where denoise deliberately stays open to be re-flipped.
+describe("RailActions — mute snooze picker (#950)", () => {
+  const querySel: Sel = { networkSlug: "freenode", channelName: "Alice", kind: "query" };
+  const NOW_MS = 1_800_000_000_000;
+  const NOW_SECONDS = NOW_MS / 1000;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const openWith = (sel: Sel): void => {
+    selHolder.value = sel;
+    render(() => <RailActions setters={setters} />);
+    openMenu();
+  };
+
+  const pick = (value: string): void => {
+    const picker = screen.getByTestId("rail-mute-picker") as HTMLSelectElement;
+    picker.value = value;
+    fireEvent.change(picker);
+  };
+
+  it("is absent on a window that is not a conversation (home / server / admin)", () => {
+    openWith({ networkSlug: "$home", channelName: "home", kind: "home" });
+    expect(screen.queryByTestId("rail-mute-picker")).toBeNull();
+  });
+
+  it("offers the snooze durations on a channel window", () => {
+    openWith(channelSel);
+    const picker = screen.getByTestId("rail-mute-picker") as HTMLSelectElement;
+    const values = Array.from(picker.options).map((o) => o.value);
+    expect(values).toEqual(expect.arrayContaining(["1h", "8h", "tomorrow", "forever"]));
+  });
+
+  it("is offered on a QUERY window too — a DM is a conversation", () => {
+    openWith(querySel);
+    expect(screen.getByTestId("rail-mute-picker")).toBeInTheDocument();
+  });
+
+  it("writes now + one hour under the folded channel key", () => {
+    openWith({ ...channelSel, channelName: "#Italia" });
+    pick("1h");
+    expect(applyConversationMute).toHaveBeenCalledWith("#italia", NOW_SECONDS + 3_600);
+  });
+
+  // The DM row of the #866 truth table, at the door: the key is the PEER, and
+  // it is folded. A picker keyed on anything else silences the wrong thing.
+  it("keys a DM snooze on the folded PEER nick", () => {
+    openWith(querySel);
+    pick("8h");
+    expect(applyConversationMute).toHaveBeenCalledWith("alice", NOW_SECONDS + 28_800);
+  });
+
+  it("writes a null until for the permanent offer", () => {
+    openWith(channelSel);
+    pick("forever");
+    expect(applyConversationMute).toHaveBeenCalledWith("#italia", null);
+  });
+
+  it("closes the menu once the choice is made — a snooze is not a toggle", () => {
+    openWith(channelSel);
+    pick("1h");
+    expect(screen.queryByTestId("action-cluster-cog")).toBeNull();
+  });
+
+  it("stays put — and writes nothing — when the placeholder row is re-picked", () => {
+    openWith(channelSel);
+    pick("");
+    expect(applyConversationMute).not.toHaveBeenCalled();
+    expect(screen.getByTestId("action-cluster-cog")).toBeInTheDocument();
+  });
+
+  it("offers unmute only for a conversation that is currently muted", () => {
+    mutedHolder.value = { "#italia": { until: NOW_SECONDS + 60 } };
+    openWith(channelSel);
+    const picker = screen.getByTestId("rail-mute-picker") as HTMLSelectElement;
+    expect(Array.from(picker.options).map((o) => o.value)).toContain("off");
+  });
+
+  it("offers no unmute for a conversation nobody muted", () => {
+    openWith(channelSel);
+    const picker = screen.getByTestId("rail-mute-picker") as HTMLSelectElement;
+    expect(Array.from(picker.options).map((o) => o.value)).not.toContain("off");
+  });
+
+  it("unmuting routes through the clear verb, not a mute with a past expiry", () => {
+    mutedHolder.value = { "#italia": { until: null } };
+    openWith(channelSel);
+    pick("off");
+    expect(clearConversationMute).toHaveBeenCalledWith("#italia");
+    expect(applyConversationMute).not.toHaveBeenCalled();
+  });
+
+  it("says on the row itself whether the conversation is already silenced", () => {
+    mutedHolder.value = { "#italia": { until: NOW_SECONDS + 60 } };
+    openWith(channelSel);
+    expect(screen.getByTestId("rail-action-mute")).toHaveTextContent(/muted/i);
   });
 });

--- a/cicchetto/src/__tests__/SettingsDrawer.test.tsx
+++ b/cicchetto/src/__tests__/SettingsDrawer.test.tsx
@@ -646,6 +646,34 @@ describe("SettingsDrawer muted conversations — #866", () => {
     expect(screen.queryByTestId("pref-muted-list")).toBeNull();
   });
 
+  // #950 — the drawer stays MOUNTED across open/close and loaded its prefs
+  // once, at mount. That was safe while it was the only writer of
+  // `muted_targets`; the rail picker is a second one, and it feeds the shared
+  // mirror the server's echo. A list still reading the drawer's private
+  // snapshot then shows a mute set that is missing what the operator just did
+  // — this list is the GLOBAL view, so that is a lie, and it is the exact
+  // shape the #950 e2e caught (one PUT, 200, and no row).
+  it("shows a mute another surface wrote after the drawer had already loaded (#950)", async () => {
+    const { mirrorNotificationPrefs } = await import("../lib/notificationPrefs");
+    const userSettings = await import("../lib/userSettings");
+    await openPush();
+
+    // What `applyConversationMute` does on its PUT's echo — no drawer re-open,
+    // no second GET, exactly as the rail leaves things.
+    mirrorNotificationPrefs({
+      ...userSettings.DEFAULT_NOTIFICATION_PREFS,
+      muted_targets: { "#sbiffo": { until: null } },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("pref-muted-#sbiffo")).toBeInTheDocument();
+    });
+    // ...and the picker stops offering what is now muted, from the same map.
+    await waitFor(() => {
+      expect(optionValues()).toEqual(["", "alice"]);
+    });
+  });
+
   // #950 — this list is the GLOBAL view of every mute, and from now on the
   // entries are not all alike: the rail picker writes time-boxed ones. A row
   // that renders a snooze exactly like a permanent mute lies about when the

--- a/cicchetto/src/__tests__/SettingsDrawer.test.tsx
+++ b/cicchetto/src/__tests__/SettingsDrawer.test.tsx
@@ -645,6 +645,51 @@ describe("SettingsDrawer muted conversations — #866", () => {
     expect(optionValues()).toEqual(["", "#sbiffo", "alice"]);
     expect(screen.queryByTestId("pref-muted-list")).toBeNull();
   });
+
+  // #950 — this list is the GLOBAL view of every mute, and from now on the
+  // entries are not all alike: the rail picker writes time-boxed ones. A row
+  // that renders a snooze exactly like a permanent mute lies about when the
+  // conversation comes back.
+  describe("a snoozed row is distinguishable from a permanent one (#950)", () => {
+    const NOW_SECONDS = 1_800_000_000;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(NOW_SECONDS * 1000);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    const openWithMutes = async (
+      muted: Record<string, { until: number | null }>,
+    ): Promise<void> => {
+      const userSettings = await import("../lib/userSettings");
+      (userSettings.getNotificationPrefs as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ...userSettings.DEFAULT_NOTIFICATION_PREFS,
+        muted_targets: muted,
+      });
+      await openPush();
+    };
+
+    it("shows how long a snooze has left", async () => {
+      await openWithMutes({ "#sbiffo": { until: NOW_SECONDS + 3_600 } });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("pref-muted-until-#sbiffo")).toHaveTextContent("1h 0m");
+      });
+    });
+
+    it("shows nothing of the kind for a permanent mute", async () => {
+      await openWithMutes({ "#sbiffo": { until: null } });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("pref-muted-#sbiffo")).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId("pref-muted-until-#sbiffo")).toBeNull();
+    });
+  });
 });
 
 // V6 visitor-parity: the NOTIFICATIONS + theme surface is subject-

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -1267,7 +1267,7 @@ describe("#361 / #473 — rooms (list) launcher in the RailActions drawer", () =
     });
   });
 
-  it("#473/#986 drawer order: home · rooms · mentions · themes · archive · settings · admin · denoise · quit", async () => {
+  it("#473/#986/#950 drawer order: home · rooms · mentions · themes · archive · settings · admin · denoise · mute · quit", async () => {
     mobileState.value = true;
     userHolder.current = {
       kind: "user",
@@ -1309,6 +1309,10 @@ describe("#361 / #473 — rooms (list) launcher in the RailActions drawer", () =
       "action-cluster-cog",
       "mobile-panel-admin",
       "presence-toggle",
+      // #950 — the mute/snooze picker joins the per-conversation pair, right
+      // after denoise: both are gated on the selected window, and this fixture
+      // has a channel selected.
+      "rail-action-mute",
       "quit-irc-btn",
     ]);
     // The mobile-only launcher footer is gone entirely.

--- a/cicchetto/src/__tests__/notificationPrefs.test.ts
+++ b/cicchetto/src/__tests__/notificationPrefs.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setToken } from "../lib/auth";
 import {
+  applyConversationMute,
+  clearConversationMute,
   mirrorNotificationPrefs,
   notificationPrefs,
   refreshNotificationPrefs,
@@ -176,5 +178,118 @@ describe("notificationPrefs muted_targets expiry — #866", () => {
 
     expect(notificationPrefs().muted_targets).toBeUndefined();
     expect(notificationPrefs().channel_mentions).toBe(true);
+  });
+});
+
+// #950 — the WRITE side of the mute, reached from outside the settings drawer
+// (the rail picker). The drawer owns a hydrated form copy of the prefs; a rail
+// tap has none, which is the whole reason this verb exists and why it reads the
+// server before it writes.
+describe("conversation mute writer — #950", () => {
+  const SERVER_STATE: NotificationPrefs = {
+    ...DEFAULT_NOTIFICATION_PREFS,
+    channel_mentions: false,
+    channel_messages_only: ["#italia"],
+    muted_targets: { "#already": { until: null } },
+  };
+
+  const mockGetThenPut = () => {
+    const spy = vi.spyOn(globalThis, "fetch");
+    spy.mockImplementation((_url, init) => {
+      const method = (init as RequestInit | undefined)?.method ?? "GET";
+      if (method === "GET") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ notification_prefs: SERVER_STATE }), { status: 200 }),
+        );
+      }
+      // The server echoes back what it normalized — the drawer and this writer
+      // both adopt the ECHO, never the locally-composed body. The request body
+      // is the bare prefs map; only the RESPONSE is wrapped.
+      const sent = JSON.parse((init as RequestInit).body as string);
+      return Promise.resolve(
+        new Response(JSON.stringify({ notification_prefs: sent }), { status: 200 }),
+      );
+    });
+    return spy;
+  };
+
+  const putBody = (spy: ReturnType<typeof mockGetThenPut>): NotificationPrefs => {
+    const put = spy.mock.calls.find(
+      (call) => (call[1] as RequestInit | undefined)?.method === "PUT",
+    );
+    if (put === undefined) throw new Error("no PUT was issued");
+    return JSON.parse((put[1] as RequestInit).body as string);
+  };
+
+  it("writes the chosen until as a positive integer under the folded key", async () => {
+    const spy = mockGetThenPut();
+
+    await applyConversationMute("#noisy", 1_800_000_600);
+
+    expect(putBody(spy).muted_targets).toMatchObject({ "#noisy": { until: 1_800_000_600 } });
+  });
+
+  it("keeps the mutes that were already there instead of replacing the map", async () => {
+    const spy = mockGetThenPut();
+
+    await applyConversationMute("#noisy", 1_800_000_600);
+
+    expect(putBody(spy).muted_targets).toMatchObject({ "#already": { until: null } });
+  });
+
+  it("writes a permanent mute when the offer carries no expiry", async () => {
+    const spy = mockGetThenPut();
+
+    await applyConversationMute("#noisy", null);
+
+    expect(putBody(spy).muted_targets).toMatchObject({ "#noisy": { until: null } });
+  });
+
+  it("clearConversationMute drops just that key", async () => {
+    const spy = mockGetThenPut();
+
+    await clearConversationMute("#already");
+
+    const muted = putBody(spy).muted_targets ?? {};
+    expect(Object.hasOwn(muted, "#already")).toBe(false);
+  });
+
+  // The discriminating one. The mirrored signal is DEFAULT until a user-topic
+  // (re)join hydrates it, so a writer that PUT `notificationPrefs()` would ship
+  // `channel_mentions: true` and an EMPTY whitelist over a subject who had
+  // turned both off — silently undoing settings from a rail tap. Reading the
+  // server first is what makes the write additive.
+  it("PUTs the SERVER's prefs, never the un-hydrated mirror", async () => {
+    mirrorNotificationPrefs(DEFAULT_NOTIFICATION_PREFS);
+    const spy = mockGetThenPut();
+
+    await applyConversationMute("#noisy", 1_800_000_600);
+
+    const body = putBody(spy);
+    expect(body.channel_mentions).toBe(false);
+    expect(body.channel_messages_only).toEqual(["#italia"]);
+  });
+
+  it("adopts the server echo so the live beep path honours the new mute at once", async () => {
+    mockGetThenPut();
+
+    await applyConversationMute("#noisy", 1_800_000_600);
+
+    expect(notificationPrefs().muted_targets).toMatchObject({ "#noisy": { until: 1_800_000_600 } });
+    expect(notificationPrefs().channel_mentions).toBe(false);
+  });
+
+  it("without a session it neither fetches nor pretends to have written", async () => {
+    setToken(null);
+    const spy = vi.spyOn(globalThis, "fetch");
+
+    await expect(applyConversationMute("#noisy", 1_800_000_600)).rejects.toThrow("no session");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("propagates a failed write instead of reporting a mute that never landed", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope", { status: 500 }));
+
+    await expect(applyConversationMute("#noisy", 1_800_000_600)).rejects.toBeDefined();
   });
 });

--- a/cicchetto/src/lib/__tests__/muteSnooze.test.ts
+++ b/cicchetto/src/lib/__tests__/muteSnooze.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { MUTE_SNOOZE_OPTIONS, snoozeUntil } from "../muteSnooze";
+
+// #950 — the snooze offer table and the ONE place a chosen offer becomes the
+// unix-seconds integer `muted_targets[key].until` carries. Pure: `now` is a
+// parameter, so every arm here is deterministic without fake timers.
+
+describe("snoozeUntil — #950", () => {
+  // 2026-08-08 14:30:00 local time.
+  const now = new Date(2026, 7, 8, 14, 30, 0, 0);
+  const nowSeconds = Math.floor(now.getTime() / 1000);
+
+  it("turns the 1-hour offer into now + 3600 seconds", () => {
+    expect(snoozeUntil("1h", now)).toBe(nowSeconds + 3_600);
+  });
+
+  it("turns the 8-hour offer into now + 28800 seconds", () => {
+    expect(snoozeUntil("8h", now)).toBe(nowSeconds + 28_800);
+  });
+
+  it("resolves 'until tomorrow' to the NEXT local midnight, not now + 24h", () => {
+    const expected = Math.floor(new Date(2026, 7, 9, 0, 0, 0, 0).getTime() / 1000);
+    expect(snoozeUntil("tomorrow", now)).toBe(expected);
+    // ...which is strictly less than a rolling 24 hours from 14:30.
+    expect(snoozeUntil("tomorrow", now)).toBeLessThan(nowSeconds + 86_400);
+  });
+
+  it("keeps 'until tomorrow' in the future one minute before midnight", () => {
+    const lateNight = new Date(2026, 7, 8, 23, 59, 0, 0);
+    const until = snoozeUntil("tomorrow", lateNight);
+    expect(until).not.toBeNull();
+    expect(until as number).toBeGreaterThan(Math.floor(lateNight.getTime() / 1000));
+  });
+
+  it("gives the permanent offer a null until — the shape's 'never expires'", () => {
+    expect(snoozeUntil("forever", now)).toBeNull();
+  });
+
+  it("emits whole seconds the server will accept as a positive integer", () => {
+    for (const option of MUTE_SNOOZE_OPTIONS) {
+      const until = snoozeUntil(option.value, now);
+      if (until === null) continue;
+      expect(Number.isInteger(until)).toBe(true);
+      expect(until).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("MUTE_SNOOZE_OPTIONS — #950", () => {
+  it("offers the three #866 durations plus the permanent mute, in that order", () => {
+    expect(MUTE_SNOOZE_OPTIONS.map((o) => o.value)).toEqual(["1h", "8h", "tomorrow", "forever"]);
+  });
+
+  it("labels every offer for a human, never with the raw token", () => {
+    for (const option of MUTE_SNOOZE_OPTIONS) {
+      expect(option.label).not.toBe(option.value);
+      expect(option.label.length).toBeGreaterThan(2);
+    }
+  });
+});

--- a/cicchetto/src/lib/conversationMute.ts
+++ b/cicchetto/src/lib/conversationMute.ts
@@ -62,3 +62,30 @@ export function windowMuteKey(window: { channelName: string }): string {
 export function isConversationMuted(muted: MutedTargets | undefined, key: string): boolean {
   return muted !== undefined && Object.hasOwn(muted, key);
 }
+
+/**
+ * The map with `key` muted until `until` — unix SECONDS for a snooze (#950),
+ * `null` for a permanent mute. Re-muting an already-muted conversation
+ * REPLACES its expiry, which is what "snooze this again for 8 hours" means.
+ *
+ * The two writers (the drawer's picker and the rail's, #950) share this so the
+ * stored shape is composed in ONE place: `undefined` (a BEAM with no mute
+ * support yet) seeds an empty map rather than spreading into `undefined`.
+ */
+export function withConversationMute(
+  muted: MutedTargets | undefined,
+  key: string,
+  until: number | null,
+): MutedTargets {
+  return { ...(muted ?? {}), [key]: { until } };
+}
+
+/** The map without `key`. Absent key ⇒ unchanged map, never an error. */
+export function withoutConversationMute(
+  muted: MutedTargets | undefined,
+  key: string,
+): MutedTargets {
+  const next = { ...(muted ?? {}) };
+  delete next[key];
+  return next;
+}

--- a/cicchetto/src/lib/muteSnooze.ts
+++ b/cicchetto/src/lib/muteSnooze.ts
@@ -1,0 +1,65 @@
+// #950 — the snooze OFFER table for the per-conversation mute (#866).
+//
+// `muted_targets[key].until` has carried unix seconds since #866 shipped, and
+// both readers already resolve it (`notificationPrefs.withLiveMutes` here,
+// `UserSettings.get_notification_prefs/1` on the server). Nothing WROTE a
+// non-null one: every UI mute was `{ until: null }`, so the snooze was dead
+// storage. This module is the writer's vocabulary — the offers a human picks
+// from, and the one conversion from an offer to the integer.
+//
+// Pure, `now` injected: the durations are arithmetic, "until tomorrow" is a
+// LOCAL-calendar question (the next midnight where the operator is), and both
+// must be testable without fake timers.
+//
+// Clock note, deliberately unresolved (#950): this integer is computed on the
+// CLIENT's clock and compared against the SERVER's (`System.os_time(:second)`)
+// and the client's own (`Date.now()`). A skewed device therefore snoozes for
+// skew ± the chosen span. That is pre-existing in the shape — #866 filed the
+// two-clock question and nobody has examined it — and is NOT quietly corrected
+// here: a fix belongs where the skew is measured, not inside a duration table.
+
+export type MuteSnoozeValue = "1h" | "8h" | "tomorrow" | "forever";
+
+export type MuteSnoozeOption = {
+  value: MuteSnoozeValue;
+  /** What the operator reads in the picker. cic owns the human strings. */
+  label: string;
+};
+
+/**
+ * The offers, in menu order: #866's three time-boxes, then the permanent mute
+ * the drawer picker has always written. Permanent is offered HERE too so the
+ * rail entry is a complete answer to "silence this conversation" — otherwise
+ * the one-tap door could only ever snooze.
+ */
+export const MUTE_SNOOZE_OPTIONS: readonly MuteSnoozeOption[] = [
+  { value: "1h", label: "for 1 hour" },
+  { value: "8h", label: "for 8 hours" },
+  { value: "tomorrow", label: "until tomorrow" },
+  { value: "forever", label: "until I unmute" },
+];
+
+const HOUR_SECONDS = 3_600;
+
+/**
+ * The `until` an offer means, in unix SECONDS — or null for the permanent
+ * mute, which is the shape's own "never expires".
+ *
+ * "until tomorrow" is the next LOCAL midnight, not a rolling 24 hours: an
+ * operator silencing a channel at 23:00 means "until the morning", and a
+ * rolling day would hold it through all of tomorrow as well.
+ */
+export function snoozeUntil(value: MuteSnoozeValue, now: Date): number | null {
+  switch (value) {
+    case "1h":
+      return Math.floor(now.getTime() / 1000) + HOUR_SECONDS;
+    case "8h":
+      return Math.floor(now.getTime() / 1000) + 8 * HOUR_SECONDS;
+    case "tomorrow": {
+      const midnight = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 0, 0, 0, 0);
+      return Math.floor(midnight.getTime() / 1000);
+    }
+    case "forever":
+      return null;
+  }
+}

--- a/cicchetto/src/lib/notificationPrefs.ts
+++ b/cicchetto/src/lib/notificationPrefs.ts
@@ -27,11 +27,14 @@
 
 import { createSignal } from "solid-js";
 import { token } from "./auth";
+import { withConversationMute, withoutConversationMute } from "./conversationMute";
 import { identityScopedStore } from "./identityScopedStore";
 import {
   DEFAULT_NOTIFICATION_PREFS,
   getNotificationPrefs,
+  type MutedTargets,
   type NotificationPrefs,
+  putNotificationPrefs,
 } from "./userSettings";
 
 // #866 Q3 — expiry lives in the READ, on both ports. The server drops
@@ -91,3 +94,43 @@ const exports_ = identityScopedStore((onIdentityChange) => {
 export const notificationPrefs = exports_.notificationPrefs;
 export const mirrorNotificationPrefs = exports_.mirrorNotificationPrefs;
 export const refreshNotificationPrefs = exports_.refreshNotificationPrefs;
+
+// #950 — the mute WRITE verb for callers outside the settings drawer (the rail
+// picker). The drawer holds its own hydrated copy of the prefs form and PUTs
+// that; a rail tap holds nothing, so this verb GETs the authoritative map
+// first, merges the one key, and PUTs the result.
+//
+// The GET is not belt-and-braces. `notificationPrefs()` is the DEFAULT map
+// until a user-topic (re)join hydrates it, and the endpoint is a FULL replace:
+// PUTting the un-hydrated mirror would push `channel_mentions: true` and empty
+// whitelists over a subject who had configured otherwise — a rail tap silently
+// undoing their settings. One extra round-trip on a rare, deliberate action
+// buys a write that is additive by construction.
+//
+// Rejects rather than swallowing: the caller decides what to say about a mute
+// that did not land (CLAUDE.md — no silent-swallow at boundaries).
+async function writeMutedTargets(
+  mutate: (muted: MutedTargets | undefined) => MutedTargets,
+): Promise<void> {
+  const t = token();
+  if (t === null) throw new Error("no session");
+  const current = await getNotificationPrefs(t);
+  const saved = await putNotificationPrefs(t, {
+    ...current,
+    muted_targets: mutate(current.muted_targets),
+  });
+  mirrorNotificationPrefs(saved);
+}
+
+/**
+ * Mute `key` (already folded via `conversationMuteKey`) until `until` — unix
+ * seconds for a snooze, `null` for a permanent mute.
+ */
+export function applyConversationMute(key: string, until: number | null): Promise<void> {
+  return writeMutedTargets((muted) => withConversationMute(muted, key, until));
+}
+
+/** Unmute `key`, whatever its expiry was. */
+export function clearConversationMute(key: string): Promise<void> {
+  return writeMutedTargets((muted) => withoutConversationMute(muted, key));
+}

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2104,6 +2104,17 @@ html.resize-dragging * {
   color: var(--accent);
 }
 
+/* #950 — the mute/snooze row. LAYOUT ONLY: the <select>'s own chrome (tokens,
+   tap floor, `appearance: none` + our caret, focus ring) is the app-wide
+   form-control rule, and re-declaring any of it here is the drift that rule
+   exists to end. `margin-inline-start: auto` pushes the control to the
+   trailing edge like the launcher's caret; the width cap keeps the longest
+   offer from pushing the row's own label out of the menu. */
+.rail-action-mute .rail-action-mute-select {
+  margin-inline-start: auto;
+  max-width: 55%;
+}
+
 /* #275 — channel name + modes stacked in ONE width-capped clickable box.
    The box opens the /mode viewer/editor modal (reuse openModeModal — the
    same verb `/mode` and the old inline indicator used). `flex-direction:

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -33755,3 +33755,78 @@ coinciding, and the ☰ holding still on a bar whose text column outgrows it —
 is `e2e/tests/issue1039-hamburger-corner.spec.ts`, whose second leg drops
 #262's clamp inline and asserts the header really did outgrow the button
 before asserting the button did not move, so the leg cannot pass vacuously.
+## 2026-08-08 — #950: the snooze had every part except a door
+
+**The gap was declared, not suspected.** #866 shipped the mute
+end-to-end and its `%{folded_target => %{"until" => unix | nil}}` shape
+has carried the snooze field from day one. Both readers already resolve
+it — `UserSettings.get_notification_prefs/1` drops elapsed entries on
+READ (Q3: no sweeper, no clock in `Push.Triggers`), and
+`notificationPrefs.withLiveMutes` is its client twin. What never existed
+was a WRITER: `SettingsDrawer.muteConversation` wrote the literal
+`{ until: null }`, so the whole snooze half was unreachable storage.
+
+**The picker is in the rail, gated on the selected CONVERSATION.** Not
+the settings drawer: the drawer's list stays what it was, the GLOBAL
+view of every mute, and #866's own text says a buried settings pane is
+not where "silence this tab" belongs. `RailActions` already carries the
+context-sensitive precedent next door (`denoise`, channel-gated), so the
+mute row sits beside it. The gate is one kind WIDER than denoise's:
+channel OR query, because a mute is keyed on the conversation and for a
+DM that key is the PEER (`conversationMuteKey`) — denoise is a
+presence-row pref and a query has no join/part traffic to filter.
+
+**A toggle stays, a choice closes.** `denoise` deliberately does NOT
+close the rail menu: the operator flips it and watches the accent. A
+snooze is not flippable — it resolves to one of four answers and is
+done, so it closes the menu the way every other rail entry does. That
+asymmetry is the reason the two rows look alike but behave differently.
+
+**A native `<select>`, and its chrome is NOT ours to write.** The offers
+are a small closed set and a real `<select>` gets the iOS wheel /
+Android dialog for free inside a menu whose height is already capped
+(#588). Its closed-state appearance is the app-wide form-control rule
+being widened by #963 (PR #965) — the `#950` CSS is layout only
+(trailing-edge placement + a width cap). Re-implementing
+`appearance: none` here would be the second copy of exactly the rule
+#963 exists to unify.
+
+**"until tomorrow" is the next LOCAL midnight, not a rolling day.** An
+operator silencing a channel at 23:00 means "until the morning". A
+rolling 24h would hold it through all of tomorrow too.
+
+**The write reads the server first.** `applyConversationMute` GETs the
+authoritative prefs, merges the one key, and PUTs. The mirrored signal
+is the DEFAULT map until a user-topic (re)join hydrates it and the
+endpoint is a FULL replace, so PUTting the mirror would push
+`channel_mentions: true` and empty whitelists over a subject who had
+configured otherwise — a rail tap silently undoing their settings. One
+extra round-trip on a deliberate, rare action buys a write that is
+additive by construction. The drawer keeps its own writer (it holds a
+hydrated form copy and owns the saving/error UI); what the two SHARE is
+the shape, via `conversationMute.withConversationMute/3` +
+`withoutConversationMute/2`.
+
+**The drawer list now distinguishes the two.** Entries are no longer all
+alike, so a snoozed row renders its remaining span ("58m left", via the
+existing `formatDuration`) and a permanent one renders nothing extra. A
+list that painted them identically would lie about when the
+conversation comes back — and it is also the visible outcome the e2e
+asserts, which is what separates a genuine snooze from a picker that
+regressed to `until: null` while leaving the push arms green.
+
+**Two premises from the issue, corrected.** #950 says the first real
+integer would also be "the first real test of that reader" server-side.
+It is not: `test/grappa/user_settings_test.exs` already covers both arms
+of the projection (a future `until` survives, an elapsed one is dropped
+on READ) plus the PUT's rejection of a non-integer / non-positive one.
+No server change was needed for #950 at all — the far side was complete.
+
+**Clock skew: still unexamined, deliberately.** The integer is computed
+on the CLIENT's clock and compared against the SERVER's
+(`System.os_time(:second)`) as well as the client's own (`Date.now()`),
+so a skewed device snoozes for skew ± the chosen span. That is
+pre-existing in #866's shape; #950 does not quietly correct it inside a
+duration table. A fix belongs where the skew can be measured (a
+server-supplied `now`, or a duration-not-instant wire shape), which is a
+different change with a different blast radius.


### PR DESCRIPTION
#866 shipped every part of the snooze except a way to reach it. Storage carries
`until`, both readers resolve it (`UserSettings.get_notification_prefs/1` on
READ, `notificationPrefs.withLiveMutes` client-side), and both are tested — but
every UI mute wrote the literal `{ until: null }`, so no integer ever existed
outside a fixture. This is the writer.

## What it does

* **A mute/snooze picker in `RailActions`**, beside `denoise`, gated on the
  selected **conversation** — channel OR query. One kind wider than denoise on
  purpose: the mute is keyed on the conversation and for a DM that key is the
  **peer** (`conversationMuteKey`), while denoise is a presence-row pref and a
  query has no join/part traffic to filter.
* Offers **1 hour / 8 hours / until tomorrow / until I unmute**, plus **unmute**
  when the conversation is already muted. "Until tomorrow" is the next **local
  midnight**, not a rolling 24h — silencing a channel at 23:00 means "until the
  morning".
* Unlike denoise, the row **closes the menu**: a toggle is flipped and watched,
  a snooze resolves to one answer and is done.
* **The settings drawer keeps the global list** — it is not replaced. It now
  also says how long a snooze has left, because entries stopped being alike the
  moment an integer could exist.

## No server change

The far side was already complete. **A premise in the issue is wrong and I am
correcting it rather than inheriting it:** #950 says the first real integer
would also be "the first real test of that reader" server-side. It is not —
`test/grappa/user_settings_test.exs:588-630` already covers both arms (a future
`until` survives, an elapsed one is dropped on READ) plus the PUT's rejection of
a non-integer / non-positive one. Not one line of Elixir changed here.

## Two things the e2e caught that unit tests could not

1. **The drawer held a stale duplicate.** It stays mounted across open/close and
   loads its prefs once, at mount — sound while it was the ONLY writer of
   `muted_targets`, because its own writes fed its own snapshot. A second writer
   turned that snapshot into a lie: one PUT, 200, and no row in the list that is
   supposed to be the GLOBAL view. The mute map is now **derived** from the
   shared `notificationPrefs()` mirror both writers feed the server's echo to.
2. **The write reads the server before writing.** The mirror is the DEFAULT map
   until a user-topic join hydrates it and the endpoint is a full replace, so
   PUTting the mirror would push `channel_mentions: true` and empty whitelists
   over a subject who had configured otherwise — a rail tap silently undoing
   their settings.

## The #473 contract was EXTENDED, deliberately

`issue473-rail-actions-drawer.spec.ts` enumerates every labelled rail button and
derives its `toHaveCount` from ONE table; both engines went red on the count,
which is that guard doing its job. The row was added **to the table** — the file
itself says a new rail entry belongs there and only there. The assertion was not
loosened, no engine was skipped.

## Gates

* `bun run check` rc=0 · vitest **4685 passed** (21 new)
* **Full `scripts/integration.sh`: 645 tests, 641 passed** — the CI baseline at
  my base `ff0511cd` was 644, so **+1** proves the new spec was collected and
  ran. `issue950-rail-mute-snooze` **green**; both #473 arms green.
* The 4 remaining reds are attributed, not waved off:
  * `issue219-overlay-scroll-hold`, `issue535-visibility-return`,
    `cp15-b6-part-archive-rejoin` — **green in isolation** on this branch: the
    #653 "green alone, red under full-gate load" signature.
  * `issue168-scroll-authority:169` — red in isolation too, so **not** load. Run
    on a bare worktree of my base `ff0511cd` with none of my code: **red,
    identical**. On today's `origin/main` (`5c8b4fde`): **green**. It is
    pre-existing at my base and already fixed on main — a rebase at merge
    carries the fix in.

## What I am NOT claiming

* **The picker is not presentable until #963 / PR #965 lands.** Outside the
  settings drawer a `<select>` has no base rule today, so it renders at UA
  default. #965 widens the form-control rule to the bare `select` element, which
  covers this control. The CSS here is **layout only** (trailing-edge placement
  + width cap) — re-implementing `appearance: none` would be the second copy of
  exactly the rule #963 exists to unify. **This PR depends on #965 for looks.**
* **A failed PUT is invisible.** The menu closes on the choice and there is no
  banner surface behind it, so a failed write is a `console.warn` — the same
  posture as the sibling denoise PUT. The operator learns about it by opening
  the drawer.
* **Clock skew is unexamined.** The integer is computed on the client's clock
  and compared against the server's and the client's own, so a skewed device
  snoozes for skew ± the chosen span. Pre-existing in #866's shape; deliberately
  NOT corrected quietly inside a duration table. A fix belongs where the skew
  can be measured.

Rationale, alternatives and the two corrected premises: `docs/DESIGN_NOTES.md`
2026-08-08.