### PR TITLE
cic(#1040): expand the rail actions on the home window

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -844,15 +844,6 @@ export async function openRailMenu(page: Page): Promise<void> {
   if (isMobileViewport(page) && (await page.locator(".shell-members.open").count()) === 0) {
     await openMembersDrawer(page);
   }
-  // #1040 — on the HOME window the rail is expanded in flow and no launcher is
-  // rendered: the menu IS the rail's content, so there is no door to open and
-  // the loop below would burn its deadline waiting for a button that does not
-  // exist. This helper's contract is "the rail actions are reachable", which on
-  // home is already true the moment the rail is on screen (on mobile, the
-  // moment the drawer above finishes sliding in). Keyed on the menu being
-  // VISIBLE rather than on the window kind, so a channel window whose launcher
-  // regressed still fails loudly below instead of passing through here.
-  if (await menu.isVisible()) return;
   // #653 — drive the launcher off the app's OWN state, not off a single blind
   // click. `openMembersDrawer` now settles the slide, which removes the biggest
   // source of late movement, but the rail keeps re-laying-out while the stores
@@ -870,6 +861,18 @@ export async function openRailMenu(page: Page): Promise<void> {
   const deadline = Date.now() + 15_000;
   for (;;) {
     try {
+      // #1040 — on HOME the rail is expanded in flow and renders NO launcher:
+      // the menu IS the rail's content, so there is no door to open. Probed
+      // here, inside the loop, and NOT once before it: the rail resolves its
+      // shape only after `selectedChannel()` hydrates, and it renders the
+      // COLLAPSED shape (launcher, no menu) in the meantime — measured on the
+      // #1048 CI traces, two DOM snapshots 128ms apart, the first with a bare
+      // launcher and the second with `.rail-actions.expanded`. A one-shot probe
+      // ahead of the loop reads that first snapshot, finds no menu, and then
+      // waits out the whole deadline on a launcher home is about to unmount.
+      // `isVisible` does not auto-wait, so it is only ever sound when something
+      // else owns the waiting — here, the loop does.
+      if (await menu.isVisible()) return;
       // #752 — the timeout is what makes the deadline reachable. `getAttribute`
       // auto-waits for the element to ATTACH, and `playwright.config.ts` sets no
       // `actionTimeout` (default 0 = no limit), so a launcher that never mounts

--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -844,6 +844,15 @@ export async function openRailMenu(page: Page): Promise<void> {
   if (isMobileViewport(page) && (await page.locator(".shell-members.open").count()) === 0) {
     await openMembersDrawer(page);
   }
+  // #1040 — on the HOME window the rail is expanded in flow and no launcher is
+  // rendered: the menu IS the rail's content, so there is no door to open and
+  // the loop below would burn its deadline waiting for a button that does not
+  // exist. This helper's contract is "the rail actions are reachable", which on
+  // home is already true the moment the rail is on screen (on mobile, the
+  // moment the drawer above finishes sliding in). Keyed on the menu being
+  // VISIBLE rather than on the window kind, so a channel window whose launcher
+  // regressed still fails loudly below instead of passing through here.
+  if (await menu.isVisible()) return;
   // #653 — drive the launcher off the app's OWN state, not off a single blind
   // click. `openMembersDrawer` now settles the slide, which removes the biggest
   // source of late movement, but the rail keeps re-laying-out while the stores

--- a/cicchetto/e2e/tests/issue1040-home-rail-expanded.spec.ts
+++ b/cicchetto/e2e/tests/issue1040-home-rail-expanded.spec.ts
@@ -1,0 +1,141 @@
+// #1040 — on the HOME window the rail actions are expanded, in flow, with the
+// buttons visible. Everywhere else #500's launcher stays the single door.
+//
+// The trap this spec is built around: "expanded" is trivially fakeable by
+// leaving the overlay OPEN. That build would satisfy any assertion of the shape
+// "the cog is visible on home" while shipping a popover pinned to the bottom
+// edge of the rail, floating over an empty column, still capped by a max-height
+// measured for a menu that opens upward. So the oracle here is CONTAINMENT, not
+// visibility: `.rail-actions-menu` must lie inside the box of its
+// `.rail-actions` container. That is true only in normal flow — the container
+// wraps a static child and grows to it. With the menu still `position:
+// absolute; bottom: 100%`, the container is a launcher-tall strip and the menu
+// sits entirely ABOVE it, so its top is a few hundred px past the container's
+// and this fails.
+//
+// The second test is the exception's fence: a channel window must still open
+// the way #500 left it — launcher present, menu absent until tapped, and when
+// tapped it floats ABOVE the launcher rather than in flow. Without it, "expand
+// the rail" could quietly become "expand the rail everywhere", which is the
+// regression #500 exists to prevent (a big channel's nick list back under the
+// fold).
+//
+// Both form factors, because the issue asks for both and the mount sites
+// differ: on desktop the rail is a permanent grid column, on mobile it is the
+// slide-in drawer. The `@webkit` third test is the mobile arm (only tagged
+// specs reach the iPhone project); the geometry oracle stays on the desktop one
+// — inside a transformed, animating drawer a box comparison measures the slide
+// as much as the layout.
+//
+// NOT claimed here: the felt result on a real phone. Playwright's webkit is not
+// iOS Safari (no real momentum, no notch — `env()` resolves to 0), so whether
+// the column reads well under a thumb, and whether a short device scrolls it
+// comfortably, are vjt's device-verify calls.
+
+import { expect, test } from "../fixtures/test";
+import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0]; // #bofh — vjt's seeded autojoin channel
+
+test("#1040 — the home rail lays its actions out expanded, in flow, with no launcher", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+
+  // Precondition: cold load lands on the home window. Without this the test
+  // could be measuring some other kind's rail and pass for the wrong reason.
+  await expect(page.locator(".home-pane")).toBeVisible({ timeout: 15_000 });
+
+  // Called for its POST-CONDITION, not its gesture: on home it taps nothing,
+  // because there is no launcher to tap. Going through the shared door anyway
+  // keeps this spec honest about what every other spec's path now does here.
+  await openRailMenu(page);
+
+  const rail = page.locator(".rail-actions");
+  const menu = page.locator(".rail-actions-menu");
+  await expect(menu).toBeVisible();
+
+  // THE ASK: the buttons are visible, reached with no interaction.
+  await expect(page.getByTestId("action-cluster-cog")).toBeVisible();
+  await expect(page.getByTestId("mobile-panel-home")).toBeVisible();
+  await expect(page.getByTestId("mobile-panel-archive")).toBeVisible();
+
+  // And the door is gone — on home it could only ever COLLAPSE the column this
+  // issue exists to expand.
+  await expect(page.getByTestId("rail-actions-launcher")).toHaveCount(0);
+
+  // THE SHAPE: in flow, not a popover left open. The container must actually
+  // contain the column.
+  const railBox = await rail.boundingBox();
+  const menuBox = await menu.boundingBox();
+  expect(railBox, "the rail container must have a layout box").not.toBeNull();
+  expect(menuBox, "the action column must have a layout box").not.toBeNull();
+  if (railBox && menuBox) {
+    expect(
+      menuBox.y,
+      "the column must start inside its container, not above it",
+    ).toBeGreaterThanOrEqual(railBox.y - 1);
+    expect(
+      menuBox.y + menuBox.height,
+      "the column must end inside its container",
+    ).toBeLessThanOrEqual(railBox.y + railBox.height + 1);
+  }
+
+  // Reachable AND live: the cog still routes through the shared mutex.
+  await page.getByTestId("action-cluster-cog").click();
+  await expect(page.locator(".settings-drawer.open")).toBeVisible({ timeout: 5_000 });
+});
+
+test("#1040 — a channel window keeps #500's collapsed launcher, floating above it", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  // The launcher is back, and the actions are NOT in the DOM until it is tapped
+  // — #500 verbatim, on the kind that still has a nick list to protect.
+  const launcher = page.getByTestId("rail-actions-launcher");
+  await expect(launcher).toBeVisible();
+  await expect(page.locator(".rail-actions-menu")).toHaveCount(0);
+
+  await openRailMenu(page);
+  const menu = page.locator(".rail-actions-menu");
+  await expect(menu).toBeVisible();
+
+  // Still a popover: it opens UPWARD, so it sits above the launcher rather than
+  // inside the container's flow. This is the inverse of the containment assert
+  // in the first test — the two together say the change is home-only.
+  const menuBox = await menu.boundingBox();
+  const launcherBox = await launcher.boundingBox();
+  expect(menuBox, "the menu must have a layout box").not.toBeNull();
+  expect(launcherBox, "the launcher must have a layout box").not.toBeNull();
+  if (menuBox && launcherBox) {
+    expect(
+      menuBox.y + menuBox.height,
+      "the collapsed menu must still float above the launcher",
+    ).toBeLessThanOrEqual(launcherBox.y + 1);
+  }
+});
+
+// The mobile arm. Same contract, different mount: the rail is the slide-in
+// drawer, so the operator's ONE gesture is opening it — and what they must find
+// inside is the buttons, not a launcher charging a second tap. `openRailMenu`
+// slides the drawer in and, finding the menu already on screen, taps nothing.
+//
+// No box comparison here: the drawer is a transformed, animating surface, so a
+// containment assert would be measuring the slide as much as the layout. The
+// flow-vs-popover shape is pinned on the desktop test above; what is
+// form-factor-specific is that the drawer opens straight onto the actions.
+test("@webkit #1040 — the mobile rail drawer opens straight onto the actions", async ({ page }) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await expect(page.locator(".home-pane")).toBeVisible({ timeout: 15_000 });
+
+  await openRailMenu(page);
+  await expect(page.locator(".shell-members.open .rail-actions-menu")).toBeVisible();
+  await expect(page.getByTestId("action-cluster-cog")).toBeVisible();
+  await expect(page.getByTestId("rail-actions-launcher")).toHaveCount(0);
+});

--- a/cicchetto/e2e/tests/issue157-delete-account.spec.ts
+++ b/cicchetto/e2e/tests/issue157-delete-account.spec.ts
@@ -242,7 +242,18 @@ test.describe("issue #157 — delete account", () => {
       // delete-account absence keeps a real positive control via the
       // registered cases above.
       await expect(page.getByTestId("delete-account-btn")).toHaveCount(0);
-      await expect(page.getByTestId("quit-irc-btn")).toHaveCount(0);
+      // Scoped to the DRAWER, which is what the paragraph above says this
+      // asserts. It used to be page-wide and passed for a reason that had
+      // nothing to do with the drawer: #986's rail quit was in the DOM only
+      // while the launcher menu was open, so "nowhere on the page" and "not in
+      // the drawer" happened to coincide. #1040 expands the rail on home — the
+      // window a minted visitor lands on — so the rail's quit is now always
+      // rendered and the page-wide count is 1. Narrowing alone would be a
+      // weaker claim, so the count-1 is ACCOUNTED FOR rather than tolerated:
+      // the one quit that exists is the rail's.
+      const drawer = page.getByRole("dialog", { name: /settings/i });
+      await expect(drawer.getByTestId("quit-irc-btn")).toHaveCount(0);
+      await expect(page.locator(".rail-actions").getByTestId("quit-irc-btn")).toHaveCount(1);
       await closeSettings(page);
       await openRailMenu(page);
       await expect(page.getByTestId("quit-irc-btn")).toBeVisible();

--- a/cicchetto/e2e/tests/ux-5-bt-narrow-chrome-compression.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bt-narrow-chrome-compression.spec.ts
@@ -76,10 +76,21 @@ test("ux-5-bt desktop — #71 INC-2: NO chrome row; topic-bar + rail cog; sideba
     timeout: 10_000,
   });
   await expect(page.locator(".shell-chrome")).toHaveCount(0);
-  // #500 — close the launcher menu before switching windows; its full-viewport
-  // backdrop would otherwise intercept the selectChannel sidebar click.
+  // #1040 — on home the rail IS the expanded menu, so there is nothing here to
+  // close and the old `Escape` + count-0 pair asserted the collapsed contract.
+  // Two things it claimed are both false now, and neither was ever the point:
+  // the "full-viewport backdrop" it named does not exist (RailActions dismisses
+  // on an outside pointerdown, with no covering scrim — so nothing has been
+  // intercepting the click below for some time), and Escape is deliberately
+  // INERT on home (a permanent column the operator could close with a keypress
+  // is one they could not bring back). Assert the #1040 contract instead —
+  // Escape does NOT take the column away — which is strictly more than the old
+  // line said, and let the `selectChannel` below keep being the real proof that
+  // nothing intercepts the sidebar click.
   await page.keyboard.press("Escape");
-  await expect(page.locator(".rail-actions-menu")).toHaveCount(0, { timeout: 5_000 });
+  await expect(page.locator(".rail-actions.expanded .rail-actions-menu")).toHaveCount(1, {
+    timeout: 5_000,
+  });
 
   // Switch to a joined channel — topic-bar mounts (no chrome row above it on
   // desktop anymore; the freed top is the topic's per INC-2).

--- a/cicchetto/src/RailActions.tsx
+++ b/cicchetto/src/RailActions.tsx
@@ -52,6 +52,23 @@ import {
 // pinned launcher stays in view while a long list scrolls internally, on
 // desktop as it already did on mobile).
 //
+// #1040 — HOME is the exception, and it is an exception to the REASON, not to
+// the rule. #500's cost was a nick-list cost; `RailContext` renders nothing for
+// home, so that window's rail is an empty column with one launcher pinned to
+// its bottom, charging a tap to reach buttons that had nowhere to be pushed to.
+// On home the actions therefore lay out EXPANDED and in flow from the top of
+// the rail, and the launcher is not rendered at all. Every other kind keeps
+// #500 verbatim — the launcher stays the single door everywhere else.
+//
+// The expanded state is not "the overlay, left open": the popover geometry
+// (absolute, `bottom: 100%`, a max-height measured from the space above the
+// launcher) exists to float over a list, and it is switched off in CSS via the
+// `.rail-actions.expanded` container class. The dismiss machinery is switched
+// off with it — no overlay refcount, no Escape, no outside-click — because a
+// permanent column that Escape can close is a column the operator cannot bring
+// back, and a refcount held for the life of a window freezes the scrollback
+// snapshot behind it (#608).
+//
 // Menu open state is a plain local signal — ephemeral UI state, like Shell's
 // `membersOpen` / `settingsOpen`. cic-never-originates-state governs IRC WINDOW
 // state (join/part/kick), NOT a client-local drawer toggle.
@@ -182,11 +199,31 @@ const RailActions: Component<Props> = (props) => {
       : null;
   };
 
+  // #1040 — home is the ONE kind where the actions are not collapsed. #500's
+  // cost was a NICK LIST cost (the column pushed the list below the fold), and
+  // `RailContext` renders nothing for home, so on this window there is no list
+  // to protect and the launcher charges a tap for nothing. Derived from the
+  // selection rather than held as a second signal: "which kind am I showing" is
+  // state that already exists.
+  const expanded = (): boolean => selectedChannel()?.kind === "home";
+
   // #500 — collapsible-menu open state (ephemeral UI-local, see moduledoc).
   const [open, setOpen] = createSignal(false);
   const close = (): void => {
     setOpen(false);
   };
+  // #1040 — a menu opened on a channel is retired on arrival at home. Every
+  // rail action already closes it, and an outside pointerdown closes it too,
+  // but neither covers a selection change the rail did not cause (the #986
+  // demote redirect lands on home on its own). Without this the transient
+  // menu's overlay refcount would stay pushed for as long as the operator sits
+  // on home — a permanent column holding a scroll-lock, which is what freezes
+  // ScrollbackPane's snapshot (#608) — and the menu would be handed back
+  // already open on the way out. One reset at the source beats gating each of
+  // the three popover mechanisms below on `!expanded()` separately.
+  createEffect(() => {
+    if (expanded()) setOpen(false);
+  });
   // Reuse the shared overlay verb: Escape close + refcount scroll-lock (keeps
   // the rail's touch-action/pan-y contract while the menu overlays the list).
   createOverlayLock(() => open(), ".rail-actions-menu", close);
@@ -255,15 +292,28 @@ const RailActions: Component<Props> = (props) => {
 
   return (
     // biome-ignore lint/a11y/useSemanticElements: role="group" gives the button cluster an accessible name; biome suggests <fieldset>, a form-control grouping (needs <legend>, paints a border) — wrong for a rail toolbar of action buttons.
-    <div class="rail-actions" role="group" aria-label="window actions" ref={rootRef}>
-      <Show when={open()}>
+    <div
+      class="rail-actions"
+      classList={{ expanded: expanded() }}
+      role="group"
+      aria-label="window actions"
+      ref={rootRef}
+    >
+      <Show when={expanded() || open()}>
         {/* #500 — the expanded menu overlays the nick area above the launcher.
             Holds every action, unchanged. `createOverlayLock` targets this
             element's selector; outside-click dismiss is the pointerdown listener
-            above (no covering scrim). */}
+            above (no covering scrim).
+            #1040 — on home the SAME element is the rail's own content: the
+            `.expanded` class on the container above takes the absolute /
+            upward / capped geometry back off it (default.css). */}
         <div
           class="rail-actions-menu"
-          role="menu"
+          // #1040 — `menu` describes a popup a menubutton owns. On home there
+          // is no launcher and nothing pops up, so the role would be an orphan
+          // claim; the container's `role="group" aria-label="window actions"`
+          // already names the cluster.
+          role={expanded() ? undefined : "menu"}
           style={
             // #588/#913 — publish the JS-measured space above the launcher; the
             // stylesheet's `max-height` subtracts the safe-area inset from it
@@ -613,22 +663,28 @@ const RailActions: Component<Props> = (props) => {
 
       {/* #500 — the ONE permanently-pinned launcher. Always at the bottom of the
           rail, always reachable (it never shares vertical flow with the nick
-          list). Toggles the overlay menu above. */}
-      <button
-        type="button"
-        class="shell-chrome-btn rail-action rail-actions-launcher"
-        classList={{ open: open() }}
-        aria-haspopup="menu"
-        aria-expanded={open() ? "true" : "false"}
-        aria-label="window actions"
-        data-testid="rail-actions-launcher"
-        onClick={() => setOpen((v) => !v)}
-      >
-        <span class="rail-action-icon" aria-hidden="true">
-          {"\u{2630}"}
-        </span>
-        <span class="rail-action-label">actions</span>
-      </button>
+          list). Toggles the overlay menu above.
+          #1040 — absent on home, where the menu it would open is already the
+          rail's content. A door is only an affordance from outside the room:
+          rendered there it would be a permanent row whose only power is to
+          COLLAPSE the column this issue exists to expand. */}
+      <Show when={!expanded()}>
+        <button
+          type="button"
+          class="shell-chrome-btn rail-action rail-actions-launcher"
+          classList={{ open: open() }}
+          aria-haspopup="menu"
+          aria-expanded={open() ? "true" : "false"}
+          aria-label="window actions"
+          data-testid="rail-actions-launcher"
+          onClick={() => setOpen((v) => !v)}
+        >
+          <span class="rail-action-icon" aria-hidden="true">
+            {"\u{2630}"}
+          </span>
+          <span class="rail-action-label">actions</span>
+        </button>
+      </Show>
     </div>
   );
 };

--- a/cicchetto/src/__tests__/RailActions.test.tsx
+++ b/cicchetto/src/__tests__/RailActions.test.tsx
@@ -1,6 +1,11 @@
 import { cleanup, fireEvent, render, screen } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { __resetForTest as resetOverlayLock } from "../lib/overlayScrollLock";
+import {
+  overlayCount,
+  __resetForTest as resetOverlayLock,
+  runTopmostOverlayEscape,
+} from "../lib/overlayScrollLock";
 
 // #473 — RailActions is the ONE labelled button drawer at the bottom of the
 // members rail. It carries every rail affordance — home · rooms · themes ·
@@ -96,7 +101,21 @@ vi.mock("../lib/api", () => ({
 }));
 
 type Sel = { networkSlug: string; channelName: string; kind: string } | null;
-const selHolder: { value: Sel } = { value: null };
+// #1040 — a REAL signal behind the holder, not the plain object this was. The
+// rail now varies by window KIND (home expands the column, every other kind
+// keeps #500's launcher), so a test that lands on home mid-life has to notify
+// consumers: a plain getter stores the new value and re-renders nothing (the
+// same upgrade Shell.test.tsx made for its selection mock, for the same
+// reason). The `.value` accessor keeps every existing call site untouched.
+const [selSignal, setSelSignal] = createSignal<Sel>(null);
+const selHolder = {
+  get value(): Sel {
+    return selSignal();
+  },
+  set value(v: Sel) {
+    setSelSignal(v);
+  },
+};
 const setSelectedChannel = vi.fn();
 vi.mock("../lib/selection", () => ({
   selectedChannel: () => selHolder.value,
@@ -165,7 +184,13 @@ afterEach(() => {
 // THEN assert the action is reachable + clickable) — proving the #500 bug is
 // fixed instead of photographing the old always-expanded layout.
 const LAUNCHER = "rail-actions-launcher";
+// #1040 — the contract is "the actions are reachable", not "click the
+// launcher": on home they are already expanded in flow and no launcher exists
+// to click. Keyed on the MENU being rendered rather than on the kind, so a
+// channel window whose launcher went missing still fails loudly here instead of
+// silently no-opping. Same adaptation the e2e `openRailMenu` fixture needed.
 function openMenu(): void {
+  if (document.querySelector(".rail-actions-menu") !== null) return;
   fireEvent.click(screen.getByTestId(LAUNCHER));
 }
 
@@ -755,5 +780,89 @@ describe("RailActions — mute snooze picker (#950)", () => {
     mutedHolder.value = { "#italia": { until: NOW_SECONDS + 60 } };
     openWith(channelSel);
     expect(screen.getByTestId("rail-action-mute")).toHaveTextContent(/muted/i);
+  });
+});
+
+// #1040 — HOME is the one window where #500's collapse buys nothing. #500
+// collapsed the column because a big channel's NICK LIST pushed it below the
+// fold; `RailContext` renders nothing for home, so there is no list, no
+// overflow, and the tap the launcher costs buys no space back. vjt: "in home il
+// menu actions deve essere espanso, e i bottoni visibili".
+//
+// The expanded state is NOT "the overlay, left open". These tests pin the three
+// things that separate the two readings, each of which the issue calls out:
+//   * the buttons are in the DOM with no interaction, and the LAUNCHER is gone
+//     (a door is not needed from inside the room),
+//   * no overlay refcount is held — a permanent column is not a popover, and a
+//     stuck refcount freezes ScrollbackPane (#608),
+//   * Escape cannot close it — there would be no visible way to bring it back.
+// The collapsed contract for every OTHER kind is pinned by the #500 describe
+// above, which runs on a channel selection.
+describe("RailActions expanded home rail (#1040)", () => {
+  const homeSel: Sel = { networkSlug: "$home", channelName: "$home", kind: "home" };
+
+  // createOverlayLock defers its push a microtask (the #608 leak-safe shape),
+  // so the refcount must be read after one turn of the loop, not synchronously.
+  const settle = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+  it("renders every action with no interaction, and no launcher to tap", () => {
+    selHolder.value = homeSel;
+    const { container } = render(() => <RailActions setters={setters} />);
+    // No openMenu() anywhere in this test — that is the point.
+    expect(screen.getByTestId("action-cluster-cog")).toBeInTheDocument();
+    expect(screen.getByTestId("mobile-panel-home")).toBeInTheDocument();
+    expect(screen.getByTestId("mobile-panel-archive")).toBeInTheDocument();
+    expect(screen.queryByTestId(LAUNCHER)).toBeNull();
+    // The CSS switches the popover geometry off this class (position/max-height
+    // /margin — pinned in railExpandedHome.test.ts), so its absence would leave
+    // the column laid out as a bottom-anchored overlay.
+    expect(container.querySelector(".rail-actions")).toHaveClass("expanded");
+  });
+
+  it("an action still fires through the shared mutex, and the column stays up", () => {
+    selHolder.value = homeSel;
+    render(() => <RailActions setters={setters} />);
+    fireEvent.click(screen.getByTestId("action-cluster-cog"));
+    expect(openSettingsPanel).toHaveBeenCalledWith(setters);
+    // `close()` runs on every action; on home it must not empty the rail — the
+    // column is the window's content, not a single-shot popover.
+    expect(screen.getByTestId("action-cluster-cog")).toBeInTheDocument();
+  });
+
+  it("holds no overlay refcount and cannot be closed by Escape", async () => {
+    selHolder.value = homeSel;
+    render(() => <RailActions setters={setters} />);
+    await settle();
+    // A permanent column that pushed the refcount would scroll-lock the app for
+    // as long as the operator stays on home, and freeze the scrollback's
+    // overlay snapshot with it (#608).
+    expect(overlayCount()).toBe(0);
+    // Escape closing it would strand the operator: there is no launcher left to
+    // reopen it with.
+    expect(runTopmostOverlayEscape()).toBe(false);
+    expect(screen.getByTestId("action-cluster-cog")).toBeInTheDocument();
+  });
+
+  it("retires a menu opened on a channel when the operator lands on home", async () => {
+    selHolder.value = channelSel;
+    render(() => <RailActions setters={setters} />);
+    openMenu();
+    await settle();
+    expect(overlayCount()).toBe(1);
+
+    // Arriving on home by a door that is NOT a rail action (the #986 demote
+    // redirect, a sidebar row while the pointerdown dismiss is mid-flight)
+    // would otherwise leave the transient menu's refcount held under a column
+    // that is not transient at all …
+    selHolder.value = homeSel;
+    await settle();
+    expect(overlayCount()).toBe(0);
+    expect(screen.getByTestId("action-cluster-cog")).toBeInTheDocument();
+
+    // … and hand the menu straight back, already expanded, on the way out.
+    selHolder.value = channelSel;
+    await settle();
+    expect(screen.getByTestId(LAUNCHER)).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByTestId("action-cluster-cog")).toBeNull();
   });
 });

--- a/cicchetto/src/__tests__/RailActions.test.tsx
+++ b/cicchetto/src/__tests__/RailActions.test.tsx
@@ -865,4 +865,28 @@ describe("RailActions expanded home rail (#1040)", () => {
     expect(screen.getByTestId(LAUNCHER)).toHaveAttribute("aria-expanded", "false");
     expect(screen.queryByTestId("action-cluster-cog")).toBeNull();
   });
+
+  // #1048 — the shape the rail wears BEFORE the selection resolves. Shell lands
+  // on `$home` provisionally so the app is never blank, but it does so in an
+  // effect: for the first paint `selectedChannel()` is still `null`, `expanded()`
+  // is false, and the rail shows #500's COLLAPSED shape — a launcher with no
+  // menu — then swaps. The #1048 CI traces caught it as two DOM snapshots 128ms
+  // apart, and six specs went red because the e2e `openRailMenu` fixture read
+  // that first snapshot ONCE and then waited out its deadline on a launcher home
+  // was about to unmount. Pinned here so the flash is a known, deliberate state
+  // rather than a thing rediscovered from a red gate: any probe of this rail has
+  // to keep looking, which is why that fixture's menu check now lives inside its
+  // retry loop. Remove the flash and that fixture comment goes stale with it.
+  it("wears the collapsed shape until the selection resolves, then expands", () => {
+    selHolder.value = null;
+    const { container } = render(() => <RailActions setters={setters} />);
+    expect(screen.getByTestId(LAUNCHER)).toBeInTheDocument();
+    expect(container.querySelector(".rail-actions-menu")).toBeNull();
+    expect(container.querySelector(".rail-actions")).not.toHaveClass("expanded");
+
+    selHolder.value = homeSel;
+    expect(screen.queryByTestId(LAUNCHER)).toBeNull();
+    expect(container.querySelector(".rail-actions-menu")).not.toBeNull();
+    expect(container.querySelector(".rail-actions")).toHaveClass("expanded");
+  });
 });

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -10,7 +10,12 @@ import { swipeHorizontally } from "./helpers/touchEvents";
 // both screen- and container-scoped queries find them afterwards. This mirrors
 // the e2e contract (open launcher, THEN assert reachable) — the Shell-level
 // wiring these tests pin is proven THROUGH the real collapse, not around it.
+// #1040 — on the home window the rail is expanded in flow and there is no
+// launcher to click, so the contract is "the actions are reachable", not "tap
+// the door". Keyed on the MENU being rendered, not on the kind: a channel
+// window whose launcher went missing still fails loudly here.
 function openRailMenu(): void {
+  if (document.querySelector(".rail-actions-menu") !== null) return;
   fireEvent.click(screen.getByTestId("rail-actions-launcher"));
 }
 
@@ -700,18 +705,19 @@ describe("Shell — three-pane integration", () => {
     expect(container.querySelector(".settings-drawer")?.classList.contains("open")).toBe(true);
   });
 
-  it("empty-state: the rail launcher renders and reveals the ⚙ settings button", () => {
+  it("cold-load lands on home, where the ⚙ settings button needs no launcher", () => {
     render(() => <Shell />);
-    // #500 — the always-present affordance is now the launcher; the cog is
-    // reachable through it (settings must be reachable from every window kind).
-    expect(screen.getByTestId("rail-actions-launcher")).toBeInTheDocument();
-    openRailMenu();
+    // Cold load lands on home synchronously (UX-4 B/N, asserted above), and
+    // #1040 expands the rail there: settings must be reachable from every
+    // window kind, and on THIS kind it is reachable with no interaction at all.
+    // #500's launcher is the door for every other kind — its absence here is
+    // the contract, not a gap.
     expect(screen.getByLabelText(/open settings/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("rail-actions-launcher")).toBeNull();
   });
 
-  it("clicking empty-state ⚙ opens the settings drawer", () => {
+  it("clicking the home rail's ⚙ opens the settings drawer", () => {
     const { container } = render(() => <Shell />);
-    openRailMenu();
     fireEvent.click(screen.getByLabelText(/open settings/i));
     const settings = container.querySelector(".settings-drawer");
     expect(settings?.classList.contains("open")).toBe(true);
@@ -750,12 +756,11 @@ describe("Shell — three-pane integration", () => {
       selectionState.setSelSig({ networkSlug: "$home", channelName: "$home", kind: "home" });
       const { container } = render(() => <Shell />);
       // #71 INC-2 — desktop has no ShellChrome row anymore; the permanent rail
-      // is present on every desktop window, home included. #500 — its
-      // always-present affordance is the launcher, so anchor the wait on it.
+      // is present on every desktop window, home included. #1040 — on home that
+      // rail's always-present affordance is the EXPANDED action column (the
+      // launcher is #500's door for the other kinds), so anchor the wait on it.
       await waitFor(() => {
-        expect(
-          container.querySelector(".shell-members [data-testid='rail-actions-launcher']"),
-        ).toBeInTheDocument();
+        expect(container.querySelector(".shell-members .rail-actions-menu")).toBeInTheDocument();
       });
       expect(container.querySelectorAll(".shell-chrome-hamburger").length).toBe(0);
       expect(container.querySelectorAll(".topic-bar-hamburger").length).toBe(0);

--- a/cicchetto/src/__tests__/railExpandedHome.test.ts
+++ b/cicchetto/src/__tests__/railExpandedHome.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { ruleBody } from "./helpers/themeCss";
+
+// #1040 — the CSS half of the expanded home rail. RailActions.test.tsx pins the
+// component half (which kind expands, what stops being rendered, what refcount
+// is not held); this pins the geometry, which is where the whole difference
+// between "expanded column" and "overlay left open" actually lives.
+//
+// The base `.rail-actions-menu` is built for a popover floating over a nick
+// list: `position: absolute`, `bottom: 100%` (it opens UPWARD), and a
+// `max-height` derived from the JS-measured space above the launcher (#588 →
+// #913). Every one of those exists because a menu opening upward over a list
+// has only the space above it. Home has no list — `RailContext` renders nothing
+// for the kind — so the constraint is gone and the column lays out in flow.
+//
+// Leaving any single one of these on would ship a subtly broken rail rather
+// than a loud one: still absolute → the column overlays whatever the rail
+// holds and the aside collapses to nothing; still `margin-top: auto` → the
+// buttons hug the bottom edge instead of reading from the top; still capped by
+// `--rail-menu-space-above` → the cap is measured only while the transient menu
+// is open, so on home it falls back to the pre-measure viewport value and the
+// rows can grow past the rail. Source-level guards, because jsdom resolves
+// neither `calc()` nor a flex layout — the felt result is the e2e's job
+// (issue1040-home-rail-expanded.spec.ts).
+
+describe("#1040 expanded home rail geometry", () => {
+  it("un-floors the container so the column reads from the top of the rail", () => {
+    const body = ruleBody(".rail-actions.expanded");
+    // The base rule's `margin-top: auto` is what pins the launcher to the
+    // BOTTOM of the flex rail. An expanded column pinned to the bottom is the
+    // popover shape wearing a different position value.
+    expect(body).toMatch(/margin-top:\s*0/);
+  });
+
+  it("lets the column shrink and scroll instead of spilling out of the aside", () => {
+    const body = ruleBody(".rail-actions.expanded");
+    // `.shell-members` is `overflow-y: visible` (#500 moved the scroll into
+    // `.members-pane`), and home renders no `.members-pane` at all — so a
+    // `flex-shrink: 0` column taller than the rail does not scroll, it spills
+    // out of the aside and the bottom rows become unreachable.
+    expect(body).toMatch(/flex-shrink:\s*1/);
+    expect(body).toMatch(/min-height:\s*0/);
+  });
+
+  it("takes the popover geometry off the menu itself", () => {
+    const body = ruleBody(".rail-actions.expanded .rail-actions-menu");
+    // Out of the absolute/upward/`bottom: 100%` anchoring …
+    expect(body).toMatch(/position:\s*static/);
+    // … and out of the cap that only means something while a transient menu is
+    // measuring the space above a launcher that no longer exists here.
+    expect(body).toMatch(/max-height:\s*none/);
+  });
+
+  it("keeps the scroll owner and its touch contract intact", () => {
+    // The base rule already carries `overflow-y: auto` + `overscroll-behavior:
+    // contain` + `touch-action: pan-y`, and the `.rail-actions-menu *`
+    // descendant carve-out (#913) that makes iOS actually honour the pan. The
+    // expanded rule must NOT re-declare the scroll away — reusing the proven
+    // machinery is the whole reason the menu, not the container, stays the
+    // scroller.
+    const base = ruleBody(".rail-actions-menu");
+    expect(base).toMatch(/overflow-y:\s*auto/);
+    expect(base).toMatch(/touch-action:\s*pan-y/);
+    expect(ruleBody(".rail-actions.expanded .rail-actions-menu")).not.toMatch(/overflow-y:\s*/);
+  });
+});

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2049,6 +2049,53 @@ html.resize-dragging * {
   touch-action: pan-y;
 }
 
+/* #1040 — the HOME rail, expanded. Every declaration here undoes one thing the
+   popover shape needs and home does not have.
+
+   The container stops FLOORING itself: `margin-top: auto` pins the launcher to
+   the bottom of the flex rail, which is right for a door and wrong for the
+   window's content — with nothing above it on home, an expanded column pinned
+   to the bottom edge is just the popover wearing a different position. The
+   border-top goes with it: it separated the launcher from the list above, and
+   there is no list.
+
+   It also has to be able to SHRINK. `.shell-members` is `overflow-y: visible`
+   (#500 moved the scroll into `.members-pane`) and home renders no
+   `.members-pane` at all, so a `flex-shrink: 0` column taller than the rail
+   would not scroll — it would spill out of the aside with its bottom rows
+   unreachable, the exact failure #500 fixed at the other end. `flex-shrink: 1`
+   + `min-height: 0` bounds it to the rail and lets the child scroll; the child
+   is the scroller because the base `.rail-actions-menu` already carries
+   `overflow-y: auto` + `overscroll-behavior: contain` + the `pan-y` descendant
+   carve-out (#913) that makes iOS honour the pan. Reuse it, don't re-derive it
+   one level up. */
+.rail-actions.expanded {
+  margin-top: 0;
+  border-top: none;
+  flex-shrink: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* The menu itself leaves the popover coordinate system: in normal flow, no
+   z-index of its own, and NOT capped by `--rail-menu-space-above` — that number
+   is measured only while a transient menu is open (RailActions.tsx gates the
+   measurement on `open()`), so on home the var() would fall through to the
+   pre-measure viewport fallback and cap the column at a height nothing
+   computed. The chrome goes too: the border + padding + background drew a
+   floating panel against the rail behind it, and the container already supplies
+   both. `min-height: 0` is what lets it scroll as a flex child. */
+.rail-actions.expanded .rail-actions-menu {
+  position: static;
+  z-index: auto;
+  max-height: none;
+  min-height: 0;
+  padding: 0;
+  border: none;
+  background: none;
+}
+
 /* #500 — the launcher carries the same `.rail-action` full-width row chrome
    (glyph + "actions" label, inherited flex-start). A caret (▸ rotating to ▾)
    trails the label as a lightweight "toggles a menu" affordance; `margin-left:

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -33946,3 +33946,39 @@ oracle is CONTAINMENT (the menu's box lies inside its container's box —
 true only in flow), because a "the cog is visible on home" assertion
 passes just as well against the default-open overlay this note exists to
 rule out.
+
+**The rail changes shape mid-load, and that is what six specs tripped
+on.** The re-keying above is right; doing it ONCE, before the loop, was
+not. Shell lands on `$home` provisionally so the app is never blank, but
+it does that in an effect: for the first paint `selectedChannel()` is
+still `null`, `expanded()` is false, and the rail paints #500's
+COLLAPSED shape — a launcher, no menu — then swaps. The #1048 CI traces
+caught it exactly, two DOM snapshots 128 ms apart, the first
+`<div class="rail-actions">` with a bare launcher and the second
+`<div class="rail-actions expanded">` with the column. A `isVisible()`
+probe placed ahead of the retry loop reads that first snapshot, finds no
+menu, and then spends the whole 15 s deadline on a launcher home is
+about to unmount. The probe now lives INSIDE the loop, where the
+deadline covers both shapes; `RailActions.test.tsx` pins the transition
+so the flash is a known state and not something a red gate rediscovers.
+
+**Two of the six were the product being right.** They are worth
+separating from the four above, because their fix is a spec edit and the
+bar for that is "same or stronger, never looser":
+
+- `issue157` asserted `quit-irc-btn` page-wide at 0 while the settings
+  drawer was open. Its own comment says what it means — "the drawer must
+  show NEITHER" — and page-wide only ever coincided with that because
+  #986's rail quit was in the DOM solely while the launcher menu was
+  open. On home it is always rendered. Scoping to the drawer alone would
+  be the weaker claim, so the count-1 is ACCOUNTED FOR instead of
+  tolerated: the drawer shows none AND the one quit that exists is the
+  rail's.
+- `ux-5-bt` pressed Escape and asserted `.rail-actions-menu` gone,
+  naming a "full-viewport backdrop" that would otherwise intercept the
+  next click. That scrim does not exist — RailActions dismisses on an
+  outside pointerdown, deliberately without one — so the line had been
+  protecting nothing for a while. It now asserts the #1040 contract
+  (Escape does NOT take the column away, already pinned in unit), and
+  the `selectChannel` that follows stays the real proof that nothing
+  intercepts.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -33876,3 +33876,73 @@ is why the module already held the pattern twice — a literal in the
 guard and a second literal in the `replace`. #1047 was one character on
 that pattern, i.e. precisely the edit a hand-kept second copy loses, so
 the global variant is now derived from the first's `.source`.
+---
+
+## 2026-08-08 — #1040: home is the window where #500's collapse buys nothing
+
+vjt, on #grappa: *"in home il menu actions deve essere espanso"*, *"e i
+bottoni visibili"*. The rail actions are collapsed behind one launcher
+everywhere; on the home window they now lay out as an expanded column and
+the launcher is not rendered at all.
+
+**This is an exception to the REASON, not to the rule.** #500 collapsed
+the always-expanded column because on a big channel the nick list
+overflowed and pushed it below the fold — unreachable on desktop,
+squeezed on mobile. That is a nick-list cost. `RailContext` renders
+nothing for home (no MembersPane, no server card, no whois card), so on
+that window the rail is an empty column with a single launcher pinned to
+its bottom, charging a tap to reveal buttons that had nowhere to be
+pushed to in the first place. Home is also the window an operator lands
+on with nothing selected: it is the one place where the actions ARE the
+content. Every other kind keeps #500 verbatim, and the launcher stays
+the single door there.
+
+**Expanded is not "the overlay, left open" — and that distinction is the
+whole implementation.** The menu's geometry is built for a popover
+floating over a list: `position: absolute`, `bottom: 100%` (it opens
+UPWARD), and a `max-height` derived from the JS-measured space above the
+launcher (#588 → #913). Each of those exists *because* a menu opening
+upward over a list has only the space above it. A default-open overlay
+would have kept all three: a column pinned to the bottom edge, floating
+over nothing, capped by a number measured for a launcher that no longer
+exists (the measurement is gated on `open()`, so on home the var() would
+fall through to the pre-measure viewport fallback). So the CSS switches
+the coordinate system off via one container class,
+`.rail-actions.expanded`, and the column lays out in flow from the top.
+
+**The container also has to be able to shrink.** `.shell-members` is
+`overflow-y: visible` — #500 moved the scroll into `.members-pane` — and
+home renders no `.members-pane` at all. A `flex-shrink: 0` column taller
+than the rail would therefore not scroll, it would spill out of the
+aside with its bottom rows unreachable: the #500 defect, re-created at
+the other end. `flex-shrink: 1` + `min-height: 0` bounds it to the rail,
+and the SCROLLER stays the menu element, which already carries
+`overflow-y: auto` + `overscroll-behavior: contain` + the `pan-y`
+descendant carve-out (#913) that makes iOS honour the pan. Reuse the
+machinery, don't re-derive it one level up.
+
+**The dismiss machinery is switched off with the geometry.** A permanent
+column is not a popover: it holds no overlay refcount (a lock held for
+the life of a window freezes ScrollbackPane's overlay snapshot — #608),
+registers no Escape (Escape would close it into a state with no visible
+way back, since the launcher is gone), and registers no outside-click.
+All three follow from ONE reset — `createEffect(() => { if (expanded())
+setOpen(false) })` — rather than three separate `!expanded()` gates.
+That reset also covers the case the rail does not cause: arriving on
+home via the #986 demote redirect with the menu open would otherwise
+strand the refcount, and hand the menu back already open on the way out.
+
+**The launcher's absence is the contract, not a gap.** Rendered on home
+it would be a permanent row whose only power is to COLLAPSE the column
+this issue exists to expand. Two shared test doors had to learn this —
+`openMenu` in RailActions.test.tsx and `openRailMenu` in the e2e
+`cicchettoPage` fixture — and both were re-keyed on "is the menu
+rendered", NOT on the window kind: a channel window whose launcher
+regressed still fails loudly through them.
+
+**Not claimed.** Whether the column reads well under a thumb, and
+whether a short device scrolls it comfortably, are device calls. The e2e
+oracle is CONTAINMENT (the menu's box lies inside its container's box —
+true only in flow), because a "the cog is visible on home" assertion
+passes just as well against the default-open overlay this note exists to
+rule out.


### PR DESCRIPTION
Refs #1040.

On the home window the rail actions lay out **expanded, in flow, with the
buttons visible**, and the launcher is not rendered. Every other window kind
keeps #500's collapse verbatim.

## Why home is the exception

#500 collapsed the always-expanded column for a **nick-list** reason: on a big
channel the list overflowed and pushed the column below the fold (desktop:
unreachable; mobile: squeezed). `RailContext` renders nothing for home — no
members pane, no server card, no whois card — so on that window the rail is an
empty column with one launcher pinned to its bottom, charging a tap to reveal
buttons that had nowhere to be pushed to. **On home that #500 cost is zero**,
which is the whole ground for the exception. Home is also the window an operator
lands on with nothing selected: the one place where the actions ARE the content.

## Expanded ≠ "the overlay, left open"

The menu's geometry is popover geometry — `position: absolute`, `bottom: 100%`
(it opens UPWARD), `max-height` from the JS-measured space above the launcher
(#588 → #913) — and each part exists because a menu opening upward over a list
has only the space above it. Leaving the overlay open would keep all three: a
column pinned to the bottom edge, floating over nothing, capped by a number
measured for a launcher that no longer exists (the measurement is gated on
`open()`, so the `var()` falls through to the pre-measure viewport fallback).
One container class, `.rail-actions.expanded`, takes the coordinate system off.

The container also has to **shrink**: `.shell-members` is `overflow-y: visible`
(#500 moved the scroll into `.members-pane`) and home renders no `.members-pane`
at all, so a `flex-shrink: 0` column taller than the rail would spill out of the
aside with its bottom rows unreachable — the #500 defect re-created at the other
end. The scroller stays the menu element, which already owns `overflow-y: auto`,
`overscroll-behavior: contain` and the #913 `pan-y` descendant carve-out.

## Dismiss machinery, and why it is one line

No overlay refcount (one held for a window's lifetime freezes ScrollbackPane's
snapshot — #608), no Escape (it would close the column into a state with no
launcher to reopen it), no outside-click. All three fall out of ONE reset on the
expanded edge rather than three `!expanded()` gates — and that reset is also what
catches an arrival on home the rail did not cause, e.g. the #986 demote redirect
landing there with a menu open.

## Blast radius on the shared doors

`openMenu` (RailActions.test.tsx) and `openRailMenu` (e2e `cicchettoPage`
fixture) are the two doors ~58 spec files reach the rail through. Both are
re-keyed on **"is the menu rendered"**, never on the window kind, so a channel
window whose launcher regressed still fails loudly through them instead of
passing silently. The three Shell specs that anchored on the launcher over the
home window now assert the stronger outcome: the cog reachable with **zero**
interaction.

## Test plan

- [x] `bun run test` — 251 files / 4707 tests green.
- [x] `bun run check` (biome + tsc) — exit 0.
- [x] Red before green: the 8 new assertions failed on the pre-fix tree
      (`Unable to find an element by: [data-testid="action-cluster-cog"]` for the
      component half, `CSS rule not found: .rail-actions.expanded` for the CSS
      half).
- [ ] e2e `issue1040-home-rail-expanded.spec.ts` — **CI runs it, not me** (no
      stack lane locally). Its oracle is CONTAINMENT — the menu's box lies inside
      its container's box, which is true only in normal flow — because "the cog
      is visible on home" passes just as well against the default-open overlay
      this PR rules out. A second test fences the exception (a channel window
      still floats its menu above the launcher); a third, `@webkit`-tagged, is
      the mobile drawer arm.

## Device-verify (NOT covered by the e2e)

Playwright's webkit is not iOS Safari — no real momentum, `env()` resolves to 0.
So these are vjt's calls on a real phone, and this PR does not claim them:

- whether the expanded column reads well under a thumb in the rail drawer;
- whether a SHORT device scrolls it comfortably (the column owns its own scroll
  now, but iOS pan election is exactly the class #913 had to fix twice);
- whether the rail's `fit-content(14rem)` desktop track sizing to the wider
  content looks right next to the centre pane.