### PR TITLE
cic(#1047): give the alias grammar a tail ($N-), joined from the collapsed list

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Typed in cicchetto's compose box, parsed client-side, dispatched to REST or IRC.
 | `/away [reason]` | Set away; bare `/away` clears explicit away |
 | `/notify <nick>…` · `/watch <nick>…` | Watch nicks for presence (online/offline dots + toasts); bare opens the **watch lists** settings section |
 | `/hilight <pattern>` · `/dehilight <pattern>` | Add / remove a highlight keyword (alias `/highlight`); bare opens the **watch lists** settings section |
-| `/alias <name> <expansion>` · `/unalias <name>` | Define / remove your own slash-command alias (`/alias wii whois $1 $1` → `/wii foo` runs `/whois foo foo`). `$1`..`$9` positional, `$*` all args; with no placeholder the rest is appended. Server-synced per user; builtins can't be shadowed. Bare `/alias` opens the **aliases** settings section, where existing aliases are also editable in place (rename + change expansion) |
+| `/alias <name> <expansion>` · `/unalias <name>` | Define / remove your own slash-command alias (`/alias wii whois $1 $1` → `/wii foo` runs `/whois foo foo`). `$1`..`$9` positional, `$N-` the Nth arg and everything after it (`/alias k kick $1 $2-`), `$*` all args; with no placeholder the rest is appended. Server-synced per user; builtins can't be shadowed. Bare `/alias` opens the **aliases** settings section, where existing aliases are also editable in place (rename + change expansion) |
 | `/connect <network>` | Unpark + respawn a network |
 | `/disconnect [network] [reason]` | Park one network (persists across reboots until `/connect`) |
 | `/quit [reason]` | Park all networks, QUIT upstream, log out |

--- a/cicchetto/e2e/tests/issue1047-alias-range-param.spec.ts
+++ b/cicchetto/e2e/tests/issue1047-alias-range-param.spec.ts
@@ -1,0 +1,120 @@
+// #1047 — `$N-` alias placeholder ("argument N and everything after it"),
+// e2e.
+//
+// The unit layer (src/__tests__/slashCommands.test.ts) pins the grammar table:
+// collapsed-token join, out-of-range → empty, `$1-` vs `$*` spacing, the
+// greedy dash. This spec proves the thing a user actually reports: the
+// canonical `alias k kick $1 $2-` produces a KICK whose reason arrives WHOLE
+// at the far end of the wire — not a function returning a string.
+//
+// Pre-#1047 the same alias substituted `$2` and left the `-` behind, so the
+// reason shipped as "get-" (first word plus a literal dash). The oracle is
+// therefore doubly discriminating: the peer's inbound KICK line must carry
+// every word of a multi-word reason.
+//
+// TWO oracles, deliberately:
+//   1. UPSTREAM TRUTH — the kicked peer witnesses the raw KICK wire-line with
+//      the full reason. Nothing client-side can fake this: bahamut relayed it.
+//   2. CIC SURFACE — the kick row renders in scrollback with the same reason.
+//
+// vjt must be chanop to KICK, so vjt is the FOUNDING joiner of a fresh
+// per-run channel (the testnet bahamut auto-ops the creator — same premise
+// cp15-b6 relies on, with the roles swapped). The peer joins second.
+//
+// SINGLE subject arm (vjt), justified as in #385: alias expansion is
+// client-side and subject-agnostic; there is no subject-shaped branch here.
+
+import { test, expect } from "../fixtures/test";
+import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { GRAPPA_BASE_URL, partChannel } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
+const NEW_CHANNEL = `#i1047-${crypto.randomUUID().slice(0, 8)}`;
+// Multi-word ON PURPOSE: `$2` alone would truncate it to "reaching" and leave
+// a literal dash. Every word below has to survive.
+const REASON = "reaching for the whole tail";
+
+test.setTimeout(90_000);
+
+let peer: IrcPeer | null = null;
+
+// The durable per-subject alias map has no DELETE — PUT the empty map (the
+// "clear all" shape, as #385's spec does).
+const clearAliases = (token: string): Promise<unknown> =>
+  fetch(`${GRAPPA_BASE_URL}/me/settings/aliases`, {
+    method: "PUT",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify({ aliases: {} }),
+  }).catch(() => {});
+
+test.afterEach(async () => {
+  if (peer) {
+    await peer.disconnect("e2e cleanup").catch(() => {});
+    peer = null;
+  }
+  const vjt = getSeededVjt();
+  await clearAliases(vjt.token);
+  await partChannel(vjt.token, NETWORK_SLUG, NEW_CHANNEL).catch(() => {});
+});
+
+test("#1047 — `alias k kick $1 $2-` kicks with the WHOLE reason, upstream-witnessed", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await clearAliases(vjt.token);
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, SEED_CHANNEL, { ownNick: NETWORK_NICK });
+
+  // vjt founds the channel → bahamut grants @ (needed to KICK).
+  await composeSend(page, `/join ${NEW_CHANNEL}`);
+
+  // Gate on WS truth, not on the sidebar row: the self-JOIN scrollback line
+  // means the JOIN echo landed AND the new window took focus (so the /k below
+  // resolves its channel from the right window).
+  await expect(
+    page
+      .locator('[data-testid="scrollback-line"][data-kind="join"]')
+      .filter({ hasText: NETWORK_NICK })
+      .filter({ hasText: NEW_CHANNEL })
+      .first(),
+  ).toBeVisible({ timeout: 15_000 });
+
+  // Peer joins second (no ops). Waiting for its row in the members pane is
+  // the barrier that keeps the KICK from racing bahamut's JOIN handshake —
+  // a kick issued too early answers 401 nosuchnick and never reaches anyone.
+  peer = await IrcPeer.connect({ nick: `i1047-${crypto.randomUUID().slice(0, 6)}` });
+  await peer.join(NEW_CHANNEL);
+  const membersPane = page.locator(".members-pane");
+  await expect(membersPane.locator("li", { hasText: peer.nick })).toBeVisible({ timeout: 15_000 });
+
+  // Define the alias the issue is named after. The green notice is the
+  // round-trip barrier: the server stored it AND the store mirrored it, so
+  // the next send's expander can see it.
+  await composeSend(page, "/alias k kick $1 $2-");
+  const notice = page.locator(".compose-box-notice");
+  await expect(notice).toBeVisible({ timeout: 10_000 });
+  await expect(notice).toContainText("/k");
+
+  // Arm the upstream witness BEFORE sending — waitForLine attaches its
+  // listener synchronously, and the KICK can land inside a millisecond.
+  const kickLine = peer.waitForLine(
+    new RegExp(`KICK ${NEW_CHANNEL} ${peer.nick} :${REASON}`),
+    `KICK ${NEW_CHANNEL} carrying the whole reason`,
+    15_000,
+  );
+
+  await composeSend(page, `/k ${peer.nick} ${REASON}`);
+
+  // ORACLE 1 — upstream truth. Pre-#1047 this line read `:reaching-`.
+  const raw = await kickLine;
+  expect(raw).toContain(REASON);
+
+  // ORACLE 2 — the cic surface renders the same whole reason.
+  await expect(
+    page
+      .locator('[data-testid="scrollback-line"][data-kind="kick"]')
+      .filter({ hasText: REASON }),
+  ).toBeVisible({ timeout: 10_000 });
+});

--- a/cicchetto/src/AliasSettings.tsx
+++ b/cicchetto/src/AliasSettings.tsx
@@ -119,9 +119,10 @@ const AliasSettings: Component<{ onBack: () => void }> = (props) => {
 
       <div class="settings-section" data-testid="aliases-section">
         <p class="settings-section-blurb">
-          define your own slash-commands. use <code>$1</code>..<code>$9</code> for arguments and{" "}
-          <code>$*</code> for all of them; with no placeholder the rest is appended (e.g.{" "}
-          <code>/alias wii whois $1 $1</code>).
+          define your own slash-commands. use <code>$1</code>..<code>$9</code> for arguments,{" "}
+          <code>$2-</code> for an argument and everything after it, and <code>$*</code> for all of
+          them; with no placeholder the rest is appended (e.g. <code>/alias wii whois $1 $1</code>,{" "}
+          <code>/alias k kick $1 $2-</code>).
         </p>
         <ul class="watchlists-list" data-testid="aliases-list">
           <Show

--- a/cicchetto/src/__tests__/slashCommands.test.ts
+++ b/cicchetto/src/__tests__/slashCommands.test.ts
@@ -1395,6 +1395,96 @@ describe("#385 — expandAlias grammar edge cases", () => {
   });
 });
 
+// #1047 — `$N-` ("argument N and everything after"). The grammar gap that made
+// "first arg is a target, the rest is free text" unwritable: with `$*` the
+// target came twice, with `$2` the reason was truncated to its first word.
+//
+// SPACING RULING (the decision #1047 delegates): `$N-` joins the
+// WHITESPACE-COLLAPSED token list with single spaces — the same list `$1..$9`
+// pull from — NOT the raw tail `$*` substitutes. So `$1-` and `$*` cover the
+// same arguments and differ ONLY in spacing normalisation. Chosen for
+// consistency with the positional form `$N-` extends; the alternative
+// (raw-slice like `$*`) would have made `$1-` a synonym of `$*` and left `$2-`
+// with no defensible spelling of "where does arg 2 start in the raw string".
+// Both spellings are pinned side by side below so the difference is a
+// documented contract, not an accident someone later "fixes".
+describe("#1047 — expandAlias `$N-` range placeholder", () => {
+  it("$2- takes argument 2 and everything after it (the kick motivating example)", () => {
+    expect(expandAlias("k", "spammer go away and stay away", { k: "kick $1 $2-" })).toEqual({
+      verb: "kick",
+      rest: "spammer go away and stay away",
+    });
+  });
+
+  it("$2- is not $2: the tail is whole, not truncated to one word", () => {
+    // Pre-#1047 this yielded "#chan hello-" ($2 substituted, `-` left literal).
+    expect(expandAlias("mm", "#chan hello there world", { mm: "msg $1 $2-" })).toEqual({
+      verb: "msg",
+      rest: "#chan hello there world",
+    });
+  });
+
+  it("$1- and $* cover the same args and differ ONLY in spacing normalisation", () => {
+    const rest = "one   two \t three";
+    expect(expandAlias("a", rest, { a: "cmd $1-" })).toEqual({
+      verb: "cmd",
+      rest: "one two three",
+    });
+    expect(expandAlias("a", rest, { a: "cmd $*" })).toEqual({
+      verb: "cmd",
+      rest: "one   two \t three",
+    });
+  });
+
+  it("an out-of-range $N- expands to the empty string (silent, matching $N)", () => {
+    // Only two args, so `$5-` has nothing to join — no error, no literal left.
+    expect(expandAlias("a", "one two", { a: "cmd $1 $5-" })).toEqual({
+      verb: "cmd",
+      rest: "one",
+    });
+  });
+
+  it("$N- with no args at all is silently empty", () => {
+    expect(expandAlias("a", "", { a: "cmd $1-" })).toEqual({ verb: "cmd", rest: "" });
+  });
+
+  it("$9- reaches the ninth argument and its tail", () => {
+    const rest = "a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11";
+    expect(expandAlias("a", rest, { a: "cmd $9-" })).toEqual({
+      verb: "cmd",
+      rest: "a9 a10 a11",
+    });
+  });
+
+  it("a template whose ONLY placeholder is $N- suppresses the verbatim append", () => {
+    // The no-placeholder rule appends the rest; `$3-` must count as a
+    // placeholder or `/a x y z` would expand to `cmd z x y z`.
+    expect(expandAlias("a", "x y z", { a: "cmd $3-" })).toEqual({ verb: "cmd", rest: "z" });
+  });
+
+  it("$N- is greedy over a following literal dash", () => {
+    // mIRC/irssi shape: the `-` binds to the placeholder, never to the text
+    // after it. `$1-tail` is "all args" then "tail", not "$1" then "-tail".
+    expect(expandAlias("a", "x y", { a: "cmd $1-tail" })).toEqual({
+      verb: "cmd",
+      rest: "x ytail",
+    });
+  });
+
+  it("$10 is still $1 then a literal 0 (the range dash didn't widen the digits)", () => {
+    expect(expandAlias("a", "x", { a: "cmd $10" })).toEqual({ verb: "cmd", rest: "x0" });
+    expect(expandAlias("a", "x y", { a: "cmd $1-0" })).toEqual({ verb: "cmd", rest: "x y0" });
+  });
+
+  it("end-to-end: an alias with $N- reaches DISPATCH with the whole reason", () => {
+    expect(parseSlash("/k spammer go away and stay away", { k: "kick $1 $2-" })).toEqual({
+      kind: "kick",
+      nick: "spammer",
+      reason: "go away and stay away",
+    });
+  });
+});
+
 // #591 — /ctcp <target> <VERB> [args]. Pure-parser shape: first token is the
 // target, second is the CTCP verb (uppercased per convention), the trimmed
 // remainder is the (optional) args. compose.ts builds the \x01VERB args\x01

--- a/cicchetto/src/lib/slashCommands.ts
+++ b/cicchetto/src/lib/slashCommands.ts
@@ -60,8 +60,18 @@
 // command-side repair surface). Expansion is bounded at MAX_ALIAS_DEPTH. The
 // `%{name => expansion}` map is passed into
 // `parseSlash` by compose.ts (from the aliasList store) — this parser stays
-// pure. Grammar: `$1..$9` positional (missing → empty), `$*` all args, and
-// implicit verbatim append when the expansion holds no placeholder.
+// pure. Grammar: `$1..$9` positional (missing → empty), `$N-` the Nth arg and
+// everything after it (#1047 — out of range → empty, same silent rule), `$*`
+// all args, and implicit verbatim append when the expansion holds no
+// placeholder. `$N-` unlocks the "first arg is a target, the rest is free
+// text" shape (`alias k kick $1 $2-`) that `$*` (target twice) and `$2`
+// (reason truncated to one word) both failed to express.
+//   SPACING (#1047 ruling): `$N-` joins the whitespace-COLLAPSED token list —
+//   the list `$1..$9` read from — with single spaces, NOT the raw tail `$*`
+//   substitutes. So `$1-` and `$*` cover the same args and differ only in
+//   spacing normalisation. That is deliberate: `$N-` is the positional form
+//   extended, and for N > 1 "where does arg N start in the raw string" has no
+//   answer that survives tabs and runs of spaces.
 //
 // Services shortcuts (issue #20) — `/<x>s <cmd>` rewrites to
 // {kind: "msg", target}; a BARE `/<x>s` (issue #290) opens the dedicated
@@ -905,13 +915,19 @@ export function expandAlias(
   }
 }
 
-const ALIAS_PLACEHOLDER = /\$(\*|[1-9])/;
+const ALIAS_PLACEHOLDER = /\$(\*|[1-9]-?)/;
+// Same grammar, global — `.test/2` on a /g regex is stateful (lastIndex), so
+// the two uses need distinct objects. Derive rather than repeat the literal:
+// #1047 added one character to this pattern, and a second hand-kept copy is
+// exactly where that edit gets forgotten.
+const ALIAS_PLACEHOLDER_ALL = new RegExp(ALIAS_PLACEHOLDER.source, "g");
 
 // Substitute placeholders in `template` from `rest`. If the template holds
 // ANY placeholder, only substitutions happen ($1..$9 → the Nth arg or empty
-// string; $* → all args verbatim). If it holds NONE, the rest is appended
-// verbatim (space-separated) — one rule serving both `alias w whois` (append)
-// and `alias wii whois $1 $1` (no double-append).
+// string; $N- → the Nth arg and every one after it; $* → all args verbatim).
+// If it holds NONE, the rest is appended verbatim (space-separated) — one rule
+// serving both `alias w whois` (append) and `alias wii whois $1 $1` (no
+// double-append).
 function substituteAlias(template: string, rest: string): string {
   if (!ALIAS_PLACEHOLDER.test(template)) {
     return rest === "" ? template : `${template} ${rest}`;
@@ -919,10 +935,19 @@ function substituteAlias(template: string, rest: string): string {
   // Deliberate asymmetry: `$*` substitutes the RAW rest (internal spacing
   // preserved — "all remaining args verbatim"), while `$1..$9` pull from the
   // whitespace-collapsed token list. Don't "fix" one to match the other.
+  //
+  // #1047 — `$N-` had to pick a side and picks the COLLAPSED one: it joins
+  // `args` from N onward with single spaces, so it reads as "the positional
+  // form, extended" rather than "a second `$*`". Consequence worth knowing
+  // before calling it a bug: `$1-` and `$*` select the SAME arguments and
+  // differ only in that `$1-` normalises internal whitespace. Out of range
+  // joins nothing → empty string, matching the "missing → empty" rule above.
   const args = tokens(rest);
-  return template.replace(/\$(\*|[1-9])/g, (_m, g: string) =>
-    g === "*" ? rest : (args[Number(g) - 1] ?? ""),
-  );
+  return template.replace(ALIAS_PLACEHOLDER_ALL, (_m, g: string) => {
+    if (g === "*") return rest;
+    const from = Number(g[0]) - 1;
+    return g.endsWith("-") ? args.slice(from).join(" ") : (args[from] ?? "");
+  });
 }
 
 // Post-init aliases. Adding to DISPATCH after the literal initializer

--- a/cicchetto/src/lib/userSettings.ts
+++ b/cicchetto/src/lib/userSettings.ts
@@ -203,7 +203,7 @@ export async function putVhostSelection(
 // ---------------------------------------------------------------------------
 // aliases — user-defined command aliases (#385).
 //
-// A `%{name => expansion}` string map. Expansion grammar ($1..$9 / $* /
+// A `%{name => expansion}` string map. Expansion grammar ($1..$9 / $N- / $* /
 // implicit append), builtin-collision precedence, and recursion depth are
 // all client-side (slashCommands.ts owns the DISPATCH table). The server
 // validates only structural shape and returns the NORMALIZED map (names

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -33830,3 +33830,49 @@ pre-existing in #866's shape; #950 does not quietly correct it inside a
 duration table. A fix belongs where the skew can be measured (a
 server-supplied `now`, or a duration-not-instant wire shape), which is a
 different change with a different blast radius.
+
+## 2026-08-08 — #1047: `$N-` picks the collapsed list, so `$1-` is `$*` minus the spacing
+
+The alias grammar had `$1..$9` and `$*` and nothing between them, so the
+single most common alias shape — "first argument is a target, the rest is
+free text" — was unwritable. `alias k kick $1 $2-` substituted `$2` and
+left the `-` as literal text, shipping `kick spammer go-`; `$*` handed
+the target back a second time; `$2` truncated the reason to one word.
+mIRC and irssi have had `$N-` for decades, so users arrive expecting it.
+The change is one character on `ALIAS_PLACEHOLDER` (`[1-9]` → `[1-9]-?`)
+plus a join.
+
+**The ruling the issue delegated: `$N-` joins the COLLAPSED tokens.**
+`substituteAlias` already carried a deliberate asymmetry — `$*`
+substitutes the RAW rest (internal spacing preserved), `$1..$9` pull from
+the whitespace-collapsed token list, and the comment there says not to
+"fix" either one to match the other. `$N-` straddles both and had to
+pick. It picks the collapsed list: it reads as the positional form
+EXTENDED, not as a second `$*`. The consequence, stated plainly because
+someone will compare the two and call it a bug: **`$1-` and `$*` select
+exactly the same arguments and differ only in whitespace
+normalisation** — `"one   two"` expands to `one two` under `$1-` and
+`one   two` under `$*`.
+
+The rejected alternative was slicing the RAW string, which would have
+made `$1-` a true synonym of `$*`. It dies on `$2-`: "where does argument
+2 begin in the raw text" has no answer that survives tabs, runs of
+spaces, or a leading space, so the raw form would have needed its own
+tokenizer with its own edge cases to serve a form that is by definition
+about the tail. Consistency with the placeholder it extends beat
+consistency with the placeholder it resembles.
+
+**Out of range is silently empty**, matching the existing "missing →
+empty" rule for `$N` rather than introducing the grammar's first error
+case: `$5-` with two arguments joins nothing.
+
+**The dash is greedy.** `$1-tail` is "every argument" then the literal
+`tail`, never `$1` then `-tail` — the mIRC/irssi reading. `$10` is
+untouched (`$1` then a literal `0`), because the widened group takes a
+dash, not a second digit.
+
+**One regex, two objects.** `.test()` on a `/g` regex is stateful, which
+is why the module already held the pattern twice — a literal in the
+guard and a second literal in the `replace`. #1047 was one character on
+that pattern, i.e. precisely the edit a hand-kept second copy loses, so
+the global variant is now derived from the first's `.source`.


### PR DESCRIPTION
Issue #1047 — the alias grammar has `$1..$9` and `$*` and nothing between
them, so "argument N and everything after it" is unwritable. Reported by
morph on IRC.

## What was broken

`alias k kick $1 $2-` substituted `$2` and left the `-` behind as literal
text, so the reason shipped upstream as `go-`. The two workarounds both
fail: `$*` hands the target back a second time, `$2` truncates the reason
to one word. mIRC and irssi have had `$N-` for decades — users arrive
expecting it.

The fix is one character on `ALIAS_PLACEHOLDER` (`[1-9]` → `[1-9]-?`)
plus a join, exactly the scope the issue's non-goal fences off. No `$0`,
no named args, no modifiers.

## The decision the issue delegated: which spacing wins

`substituteAlias` carries a deliberate asymmetry that the comment at
`:919` explicitly protects — `$*` substitutes the **raw** rest (internal
spacing preserved), `$1..$9` pull from the **whitespace-collapsed** token
list, and neither is to be "fixed" to match the other. `$N-` straddles
both and has to pick one.

**It picks the collapsed list**, per the issue's recommendation: `$N-`
reads as the positional form *extended*, not as a second `$*`.

The consequence is worth stating up front, because these two forms will
be compared and the difference looks like a bug if it isn't written down:

> `$1-` and `$*` select **exactly the same arguments** and differ **only**
> in whitespace normalisation. `"one   two"` → `one two` under `$1-`,
> `one   two` under `$*`.

That sentence now lives in three places a reader can reach: the grammar
comment at `:63`, the `substituteAlias` comment, and DESIGN_NOTES. A unit
test pins both spellings side by side against the same input, so the
difference is a contract rather than an accident.

**The rejected alternative** — slicing the RAW string, which would have
made `$1-` a true synonym of `$*` — dies on `$2-`: "where does argument 2
begin in the raw text" has no answer that survives tabs, a leading space,
or runs of spaces. It would have needed its own tokenizer, with its own
edge cases, to serve a form that is by definition about the tail.
Consistency with the placeholder `$N-` extends beat consistency with the
placeholder it resembles.

## The other two rulings

- **Out of range is silently empty**, matching the existing "missing →
  empty" rule for `$N` rather than introducing the grammar's first error
  case. `$5-` with two arguments joins nothing.
- **The dash is greedy** (mIRC/irssi reading): `$1-tail` is "every
  argument" then the literal `tail`, never `$1` then `-tail`. `$10` is
  untouched — `$1` then a literal `0` — because the widened group takes a
  dash, not a second digit. Both are pinned.

## One regex, two objects

`.test()` on a `/g` regex is stateful, which is why the module already
held the pattern twice: a non-global literal for the guard, a second
global literal inside the `replace`. This change was one character on
that pattern — precisely the edit a hand-kept second copy loses — so the
global variant is now derived from the first's `.source`.

## Test plan

Red before green, on the pre-fix tree: `10 failed | 217 passed`, all ten
new. Literal:

```
$2- takes argument 2 and everything after it (the kick motivating example)
  expected { verb: 'kick', rest: 'spammer go-' }
  to deeply equal { verb: 'kick', rest: 'spammer go away and stay away' }

end-to-end: an alias with $N- reaches DISPATCH with the whole reason
  - "reason": "go away and stay away"
  + "reason": "go-"
```

- [x] Grammar table (not a single case): the kick example, `$2-` ≠ `$2`,
      `$1-` vs `$*` spacing side by side, out-of-range → empty, no args →
      empty, `$9-` and its tail, `$N-`-only template suppresses the
      verbatim append, greedy dash, `$10` regression pin, and the
      end-to-end `parseSlash` shape.
- [x] `scripts/bun.sh run test` — **250 files / 4709 tests passed**.
- [x] `scripts/bun.sh run check` (biome + tsc) — **exit 0**.
- [x] `tsc --noEmit -p e2e` — 26 errors, all pre-existing, **none in the
      new spec** (the e2e tree has no static gate; checked by hand).
- [ ] Integration CI — the e2e spec runs there, not locally.

## The e2e asserts the visible outcome

Not "a function returns a string". vjt founds a fresh channel (so bahamut
grants `@`, the roles of cp15-b6 swapped), a peer joins, vjt defines
`alias k kick $1 $2-`, and vjt kicks with a five-word reason. Two oracles:

1. **Upstream truth** — the kicked peer witnesses the raw `KICK` wire-line
   carrying every word. Nothing client-side can fake this; bahamut
   relayed it. Pre-fix that line reads `:reaching-`.
2. **cic surface** — the kick row renders in scrollback with the same
   whole reason.

## Also updated

The aliases settings blurb and the README verb table both taught the old
three-rule grammar; a form nobody is told about is a form nobody uses.

Refs #1047.