### PR TITLE
cic(#1050, #1051): one corner, two controls, two different remedies

### DIFF
--- a/cicchetto/e2e/tests/issue1050-list-window-no-float.spec.ts
+++ b/cicchetto/e2e/tests/issue1050-list-window-no-float.spec.ts
@@ -1,0 +1,89 @@
+// @webkit — #1050. On the mobile /list window the floating ☰ sat on top of the
+// directory pane's own close ✕, and the ☰ won: the tap that should leave the
+// directory opened the rail instead.
+//
+// Two independent controls, one corner. `.directory-close` is the LAST child of
+// `.directory-pane-header` (#125), so it lands top-right in normal flow; since
+// #985 `.shell-chrome` is a zero-height row whose lone ☰ overflows into that
+// same corner at `z-index: 41`. #1039 is what brought them together — it
+// retargeted the float's margin onto the topic bar's `--pane-chrome-inset-*`
+// tokens, moving the glyph off the very corner and straight onto the ✕. The
+// admin window paid this first and was given an inline mount in its own header;
+// the owner's call for the directory is the opposite one, that this window does
+// not want the rail at all, so the whole row goes.
+//
+// WHY A NEW SPEC. Nothing existing covers it: all seven specs that assert
+// `shell-chrome-rail-opener` (issue1039-hamburger-corner,
+// issue71-inc2-mobile-rail-openers, issue985-mobile-floating-opener,
+// ux-4-z-cluster-journey, ux-5-a-hamburger-dedupe, ux-5-bm-mobile-hamburger,
+// ux-5-bt-narrow-chrome-compression) run on a channel, query, home or admin
+// window. The suppression therefore breaks no assertion — and without this one
+// it would come back unnoticed.
+//
+// WHY THE OUTCOME IS "THE ✕ CLOSES", not "the ✕ is visible. Visibility is
+// exactly what the bug already satisfied: the float painted OVER a perfectly
+// visible button. Only the click distinguishes the two.
+//
+// Mobile-only shape — `ShellChrome` has a single mount, inside Shell's
+// `isMobile()` branch — so this runs on webkit-iphone-15 alone via @webkit; the
+// chromium project grepInverts the tag.
+//
+// Parity per `feedback_e2e_user_class_parity_matrix`: a UI shape contract, no
+// subject-shaped branch. The registered seed suffices.
+
+import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+test.setTimeout(90_000);
+
+test("@webkit #1050 — the /list window drops the floating ☰, and its ✕ actually closes the directory", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  // Reach the directory the way a phone does: the rail's rooms button. This
+  // also proves the rail is still reachable from the window we START on — the
+  // suppression is scoped to `list`, not a general retreat from bucket L.
+  await openRailMenu(page);
+  await page.getByTestId("mobile-panel-list").tap();
+
+  const pane = page.locator(".directory-pane");
+  await expect(pane).toBeVisible({ timeout: 15_000 });
+
+  // THE SUPPRESSION. Whole row, not a hidden glyph: a `display: none` on the
+  // button would leave `.shell-chrome` in the tree carrying its `z-index: 41`
+  // and its zero-height box over the pane header, so the row's ABSENCE is the
+  // thing worth asserting.
+  await expect(page.getByTestId("shell-chrome")).toHaveCount(0);
+  await expect(page.getByTestId("shell-chrome-rail-opener")).toHaveCount(0);
+  await expect(page.locator(".shell-chrome")).toHaveCount(0);
+
+  // THE MECHANISM, measured rather than argued: the element under the finger at
+  // the ✕'s own centre IS the ✕. Pre-fix this resolved to the floated ☰.
+  const closeBtn = pane.locator(".directory-close");
+  await expect(closeBtn).toBeVisible();
+  const hit = await closeBtn.evaluate((el) => {
+    const r = el.getBoundingClientRect();
+    const top = document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2);
+    return top === el || el.contains(top);
+  });
+  expect(hit, "#1050 — nothing may paint over the directory's close ✕").toBe(true);
+
+  // THE OUTCOME. Not "the ✕ is visible" — the bug satisfied that. The tap has
+  // to LEAVE the directory. Playwright's hit-target check would already fail
+  // here if something intercepted the pointer, and the pane going away is the
+  // user-visible half.
+  await closeBtn.tap();
+  await expect(pane).toHaveCount(0, { timeout: 10_000 });
+
+  // …and #125's contract holds: closing restores the previous window rather
+  // than dropping the operator on a blank pane. Back on a channel, the ☰ is
+  // hosted in the TopicBar again, which is also the proof that the row's
+  // absence above was scoped to `list` and not a global regression.
+  await expect(page.locator(".topic-bar")).toHaveCount(1, { timeout: 10_000 });
+});

--- a/cicchetto/e2e/tests/issue1050-list-window-no-float.spec.ts
+++ b/cicchetto/e2e/tests/issue1050-list-window-no-float.spec.ts
@@ -65,14 +65,88 @@ test("@webkit #1050 — the /list window drops the floating ☰, and its ✕ act
 
   // THE MECHANISM, measured rather than argued: the element under the finger at
   // the ✕'s own centre IS the ✕. Pre-fix this resolved to the floated ☰.
+  //
+  // The probe returns the whole hit stack, not a bare boolean, and it costs
+  // nothing until something fails. The first red here was unreadable: a lone
+  // `false` says a layer won the corner but never names it, and the artifacts
+  // do not settle it either — `elementFromPoint` returns null for a point
+  // outside the viewport, so "covered by an invisible layer" and "pushed
+  // off-screen" produce the identical failure. `elementsFromPoint` names every
+  // layer in the stack, including transparent ones, so the NEXT red diagnoses
+  // itself instead of costing another CI round.
   const closeBtn = pane.locator(".directory-close");
   await expect(closeBtn).toBeVisible();
-  const hit = await closeBtn.evaluate((el) => {
+
+  // BARRIER, and the reason the first run of this spec was red. We reached
+  // /list through the rail, so `openRailMenu` opened the members drawer;
+  // `openListPanel` closes it (the #291/#361 nav mutex), but `.shell-members`
+  // on mobile is `position: fixed; right: 0; z-index: 90` with
+  // `transform: translateX(100%)` and `transition: transform 200ms ease-out`.
+  // Closing is therefore a 200ms SLIDE, and for the first tens of ms the
+  // drawer still covers the pane's top-right corner — the exact point tested
+  // below — at a z-index above everything in the pane. The three `toHaveCount`
+  // assertions above are already satisfied when they run, so they cost almost
+  // nothing and the probe landed inside the slide: the drawer won
+  // `elementFromPoint`, honestly, and the spec read it as a float that had not
+  // been suppressed.
+  //
+  // Nothing about the assertion is relaxed to fix that — the drawer covering
+  // the corner mid-animation is the animation WORKING, and it is not the state
+  // #1050 is about. What was missing is the pre-state, so it is established
+  // here: the drawer is gone AND its box no longer meets the ✕. Polled on the
+  // geometry rather than slept for 200ms, so the barrier does not hardcode the
+  // transition and cannot rot if the duration changes.
+  //
+  // This is NOT webkit-specific, despite only webkit having reported it: the
+  // chromium project `grepInvert`s `@webkit`, so chromium has never run this
+  // spec. The race is in the flow, not the engine.
+  await expect(page.locator(".shell-members.open")).toHaveCount(0);
+  await expect
+    .poll(
+      () =>
+        closeBtn.evaluate((el) => {
+          const drawer = document.querySelector(".shell-members");
+          if (drawer === null) return true;
+          const x = el.getBoundingClientRect();
+          const d = drawer.getBoundingClientRect();
+          return d.left >= x.right || d.right <= x.left || d.top >= x.bottom || d.bottom <= x.top;
+        }),
+      { timeout: 10_000, message: "#1050 — the rail drawer never finished sliding off the ✕" },
+    )
+    .toBe(true);
+
+  const probe = await closeBtn.evaluate((el) => {
+    const describe = (n: Element | null) =>
+      n === null
+        ? "null"
+        : `${n.tagName.toLowerCase()}${[...n.classList].map((c) => `.${c}`).join("")}` +
+          (n.getAttribute("data-testid") ? `[${n.getAttribute("data-testid")}]` : "");
     const r = el.getBoundingClientRect();
-    const top = document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2);
-    return top === el || el.contains(top);
+    const x = r.x + r.width / 2;
+    const y = r.y + r.height / 2;
+    const top = document.elementFromPoint(x, y);
+    return {
+      hit: top === el || el.contains(top),
+      inViewport: x >= 0 && y >= 0 && x < window.innerWidth && y < window.innerHeight,
+      point: [Math.round(x), Math.round(y)],
+      viewport: [window.innerWidth, window.innerHeight],
+      rect: [Math.round(r.x), Math.round(r.y), Math.round(r.width), Math.round(r.height)],
+      stack: document.elementsFromPoint(x, y).slice(0, 6).map(describe),
+    };
   });
-  expect(hit, "#1050 — nothing may paint over the directory's close ✕").toBe(true);
+
+  // Split from the hit test on purpose. A ✕ pushed off-screen fails the hit
+  // test too, for a reason that has nothing to do with anything painting over
+  // it — and #1050 is about the corner collision, not about layout drift. Two
+  // assertions, so the failure says which of the two happened.
+  expect(
+    probe.inViewport,
+    `#1050 — the directory's ✕ must be inside the viewport. ${JSON.stringify(probe)}`,
+  ).toBe(true);
+  expect(
+    probe.hit,
+    `#1050 — nothing may paint over the directory's close ✕. ${JSON.stringify(probe)}`,
+  ).toBe(true);
 
   // THE OUTCOME. Not "the ✕ is visible" — the bug satisfied that. The tap has
   // to LEAVE the directory. Playwright's hit-target check would already fail

--- a/cicchetto/e2e/tests/issue1051-card-close-above-float.spec.ts
+++ b/cicchetto/e2e/tests/issue1051-card-close-above-float.spec.ts
@@ -1,0 +1,122 @@
+// @webkit — #1051. On a non-channel window the floating ☰ painted over the ✕
+// of the top-pinned lookup cards (WHOIS / WHOWAS / LUSERS), so the card could
+// not be dismissed.
+//
+// Same corner, same root cause as #1050, opposite remedy. The cards mount in
+// `.scrollback-overlay` (#133, top-pinned, `pointer-events: none` on the
+// container and `auto` per card) and each card's ✕ is `margin-left: auto` in
+// its header — the card's top-right. `.shell-chrome` floats its lone ☰ into
+// that same corner at `z-index: 41` (#985). The overlay was at 5, so 41 > 5 and
+// the ☰ won the hit test. #1050 could delete the row because /list does not
+// want the rail; a server or query window DOES (bucket L — on mobile this ☰ is
+// the only door to settings), so here the overlay is raised instead, to 42.
+// vjt's ruling: the card wins, because if a card is open the intent is to close
+// it, and closing it uncovers the ☰ anyway.
+//
+// WHY AN E2E. The stacking NUMBERS are pinned in
+// `src/__tests__/shellChromeFloat.test.ts` — including the guard that fails if
+// the overlay ever drops back under the float, which the pre-existing
+// `40 < z(.shell-chrome) < 89` assertion could not do. What a source-level
+// guard cannot answer is the one thing the operator felt: which element is
+// actually under the finger. jsdom has no layout engine and no hit testing.
+//
+// WHY A QUERY WINDOW and not the `$server` one vjt reported from: the issue's
+// own measurement says the radius is EVERY non-channel window — the gate is
+// `Shell.tsx:920`, not a server-specific branch — and the query window has a
+// proven mobile driver in `issue985-mobile-floating-opener`. Same branch, same
+// float, fewer moving parts.
+//
+// Mobile-only shape (`ShellChrome` mounts once, in Shell's `isMobile()`
+// branch), so webkit-iphone-15 alone via @webkit.
+//
+// Parity per `feedback_e2e_user_class_parity_matrix`: a UI shape contract with
+// no subject-shaped branch. The registered seed suffices.
+
+import {
+  composeSend,
+  loginAs,
+  selectChannel,
+  waitForQueryWindowReady,
+} from "../fixtures/cicchettoPage";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+const PEER = `F1051${crypto.randomUUID().slice(0, 7)}`;
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+test.setTimeout(90_000);
+
+test("@webkit #1051 — on a non-channel window the card's ✕ is the topmost element at its own coordinates", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  const peer = await IrcPeer.connect({ nick: PEER });
+  try {
+    await peer.join(CHANNEL);
+    await composeSend(page, `/q ${PEER}`);
+    await waitForQueryWindowReady(page, NETWORK_SLUG, PEER);
+
+    // PRECONDITION — we are on the NON-channel branch, the only one that
+    // floats the ☰. Without this the whole test could pass on a channel
+    // window, where the opener rides in the TopicBar and nothing ever
+    // overlapped: every assertion below would be green for the wrong reason.
+    await expect(page.locator(".topic-bar")).toHaveCount(0);
+    const opener = page.getByTestId("shell-chrome-rail-opener");
+    await expect(opener).toBeVisible({ timeout: 10_000 });
+
+    await composeSend(page, `/whois ${PEER}`);
+    const card = page.locator(".scrollback-overlay").getByTestId("whois-card");
+    await expect(card).toBeVisible({ timeout: 15_000 });
+
+    const closeBtn = card.locator(".whois-card-close");
+    await expect(closeBtn).toBeVisible();
+
+    // THE COLLISION IS REAL, not hypothetical. Assert the two boxes actually
+    // intersect before asserting who wins — otherwise a layout change that
+    // simply moved them apart would leave this spec green while retiring the
+    // thing it guards, and the z-index could quietly go back to 5.
+    const openerBox = await opener.boundingBox();
+    const closeBox = await closeBtn.boundingBox();
+    if (!openerBox || !closeBox) {
+      throw new Error("#1051 — a measured element has no bounding box");
+    }
+    const overlaps =
+      openerBox.x < closeBox.x + closeBox.width &&
+      closeBox.x < openerBox.x + openerBox.width &&
+      openerBox.y < closeBox.y + closeBox.height &&
+      closeBox.y < openerBox.y + openerBox.height;
+    expect(
+      overlaps,
+      "#1051 — the ☰ and the card's ✕ must still share the corner for this guard to mean anything",
+    ).toBe(true);
+
+    // THE OUTCOME. At the ✕'s own centre, the topmost element is the ✕ —
+    // pre-fix this resolved to the floated ☰, which is precisely why the card
+    // could not be dismissed.
+    const hit = await closeBtn.evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      const top = document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2);
+      return top === el || el.contains(top);
+    });
+    expect(hit, "#1051 — the floated ☰ must not paint over the card's ✕").toBe(true);
+
+    // …and the tap therefore does what it says. Playwright's hit-target check
+    // would fail here on an intercepted pointer, so this is the user-visible
+    // half of the same claim.
+    await closeBtn.tap();
+    await expect(card).toHaveCount(0, { timeout: 10_000 });
+
+    // THE OTHER HALF OF THE RULING. Raising the overlay must not have buried
+    // the rail: with the card gone the ☰ is reachable again, which is what
+    // makes "the card wins" acceptable in the first place (bucket L survives —
+    // unlike #1050, this window keeps its door).
+    await opener.tap();
+    await expect(page.locator(".shell-members.open")).toBeVisible({ timeout: 10_000 });
+  } finally {
+    await peer.disconnect("i1051 cleanup").catch(() => {});
+  }
+});

--- a/cicchetto/src/Shell.tsx
+++ b/cicchetto/src/Shell.tsx
@@ -917,7 +917,21 @@ const Shell: Component = () => {
               header instead, so the opener stays reachable on the admin window
               (bucket L, asserted in ux-4-z-cluster-journey) and the testid stays
               singular — the two mounts are mutually exclusive by this gate. */}
-          <Show when={selectedChannel()?.kind !== "channel" && !isAdminPaneVisible()}>
+          {/* #1050 — `list` is the third exclusion, for the same collision the
+              admin note above describes but with the opposite remedy. The
+              directory pane's close ✕ is the LAST child of its header, i.e. the
+              top-right corner the #985 float lands in at z-index 41, so the ☰
+              won the hit test and the tap that should leave the directory
+              opened the rail instead. Admin re-homed the button into its own
+              pane header; here the owner's call is that this window does not
+              want the rail at all, so the row simply goes. Bucket L ("settings
+              reachable from every window kind") is knowingly relaxed for this
+              ONE kind — every other non-channel kind keeps the float. Whole-row
+              and not a `display: none` on the glyph: the row is what carries
+              the z-index, and its zero-height box would stay over the header.
+              Reads `selKind()` — the same memo the mobile `<Match>` below
+              switches on — rather than re-deriving the kind here. */}
+          <Show when={selKind() !== "channel" && selKind() !== "list" && !isAdminPaneVisible()}>
             <ShellChrome
               onOpenRail={() =>
                 toggleMembersPanel({ membersOpen, setMembersOpen, setSettingsOpen })

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -1051,6 +1051,32 @@ describe("Shell — mobile layout (isMobile = true)", () => {
       expect(container.querySelector(".topic-bar")).toBeNull();
     });
 
+    // #1050 — the /list window is the third exclusion, joining channel (the
+    // TopicBar hosts the ☰ in flow) and admin (AdminPane mounts the same
+    // opener inline in its own header). The directory pane already puts its
+    // close ✕ in the top-right corner, and since #985 the floated ☰ lands
+    // there too at z-index 41 — so the tap that should leave the directory
+    // opened the rail instead. Owner's call: this window does not want the
+    // rail at all, so the ROW goes. Whole-row, not `display: none` on the
+    // glyph: hiding the button would leave `.shell-chrome` in the tree with
+    // its z-index and its zero-height box still over the pane header.
+    it("mobile /list window: the standalone .shell-chrome row is SUPPRESSED (#1050)", async () => {
+      mobileState.value = true;
+      selectionState.setSelSig({
+        networkSlug: "freenode",
+        channelName: LIST_WINDOW_NAME,
+        kind: "list",
+      });
+      const { container } = render(() => <Shell />);
+      // Barrier on the branch actually mounting, so an empty render cannot
+      // pass this by rendering nothing at all.
+      await waitFor(() => {
+        expect(container.querySelector(".directory-pane")).not.toBeNull();
+      });
+      expect(container.querySelector(".shell-chrome")).toBeNull();
+      expect(container.querySelector("[data-testid='shell-chrome-rail-opener']")).toBeNull();
+    });
+
     it("#71 INC-2 — desktop channel window: NO .shell-chrome row (removed); cog lives in the permanent rail; NO launcher footer", async () => {
       mobileState.value = false;
       selectionState.setSelSig({ networkSlug: "freenode", channelName: "#a", kind: "channel" });

--- a/cicchetto/src/__tests__/shellChromeFloat.test.ts
+++ b/cicchetto/src/__tests__/shellChromeFloat.test.ts
@@ -45,14 +45,47 @@ describe("#985 the chrome band is out of flow", () => {
 
   it("the floated opener paints above the in-pane scrollback floats", () => {
     // It overflows a zero-height box, so its later-in-DOM siblings (the
-    // scrollback, its pinned overlay, the float stack) would paint over it
-    // without an explicit stacking order. 40 is the tallest in-pane float
-    // (the next-active circle); 89/90 is the members drawer, which must stay
-    // ON TOP of the opener that opens it.
+    // scrollback, the float stack) would paint over it without an explicit
+    // stacking order. 40 is the tallest in-pane float (the next-active
+    // circle); 89/90 is the members drawer, which must stay ON TOP of the
+    // opener that opens it.
+    //
+    // #1051 — the pinned overlay USED to be named in this list and no longer
+    // is. It carries the WHOIS / WHOWAS / LUSERS cards, whose ✕ sits in the
+    // same top-right corner as this float, and 41 > 5 meant the ☰ won the hit
+    // test: on a non-channel window the card could not be dismissed. The card
+    // now wins (`.scrollback-overlay` at 42) — see the sibling test below,
+    // which is the one that fails if that is ever undone.
     const z = /z-index:\s*(\d+)/.exec(ruleBody(".shell-chrome"))?.[1];
     expect(z).toBeDefined();
     expect(Number(z)).toBeGreaterThan(40);
     expect(Number(z)).toBeLessThan(89);
+  });
+
+  // #1051 — the guard the rewritten comment above needs. The numeric assertion
+  // in that test is on `.shell-chrome` ALONE, so raising or dropping the
+  // overlay leaves it green either way: without this, the rule inverts in
+  // silence and the next reader restores the bug on purpose.
+  it("the pinned card overlay paints ABOVE the floated opener, below the toasts", () => {
+    const zOf = (sel: string): number => {
+      const raw = /z-index:\s*(\d+)/.exec(ruleBody(sel))?.[1];
+      expect(raw).toBeDefined();
+      return Number(raw);
+    };
+    const overlay = zOf(".scrollback-overlay");
+    // The whole point of #1051: the card's ✕ has to beat the ☰ that lands on
+    // the same corner. Fails the moment the overlay goes back under.
+    expect(overlay).toBeGreaterThan(zOf(".shell-chrome"));
+    // Ceiling. 89/90 (drawer backdrop + drawers) is the bound the issue names,
+    // but the REAL one is lower: `.toast-stack` at 60 must keep painting over
+    // a card, or a toast raised while a WHOIS is up is invisible.
+    expect(overlay).toBeLessThan(zOf(".toast-stack"));
+    // Consequence the issue did not name, pinned so it stays deliberate: the
+    // overlay now also clears `.scrollback-float-stack` (40, scroll-to-bottom
+    // + next-active). Same ruling applied consistently — while a card is open
+    // the card wins the pane's chrome — and a full-height card can cover those
+    // buttons until it is dismissed.
+    expect(overlay).toBeGreaterThan(zOf(".scrollback-float-stack"));
   });
 
   it("the floated opener brings its own opaque backing", () => {

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -2494,14 +2494,18 @@ html.resize-dragging * {
      (UX-3 BIS) and `.shell-main` sits inside that padding box, so the pane's
      top edge is ALREADY below the island; re-adding it would double-count —
      the #913 trap pointed the other way.
-   * `z-index: 41` clears every in-pane scrollback float (the next-active
+   * `z-index: 41` clears the in-pane scrollback float stack (the next-active
      circle at 40 is the tallest) because the later-in-DOM scrollback would
      otherwise paint over a child that overflows a zero-height box; and stays
      below the members drawer (89/90) and the modal tier (1000), which must
      keep covering the opener that summons them. The cost is deliberate and
      narrow: the ☰'s own 48px box overlaps the top-right corner of the
      scrollback, so a link ending exactly there is behind it — accepted,
-     the alternative was the band. */
+     the alternative was the band.
+     #1051 — one exception was carved out of "every in-pane float": the pinned
+     card overlay is at 42 and paints OVER this. Its cards put a ✕ in the very
+     corner this ☰ floats into, and under 41 they could not be dismissed at
+     all. */
 
 .shell-chrome {
   position: relative;
@@ -2589,20 +2593,33 @@ html.resize-dragging * {
    place in the channel buffer (the bug). `pointer-events: none` lets taps
    fall through to the scrollback in the uncovered area below; each direct
    child re-enables pointer events for its own box so the card body and its
-   close affordance stay interactive. z-index sits above the scroll list,
-   below the scroll-to-bottom button (z-index: 10). `max-height: 100%`
+   close affordance stay interactive. `max-height: 100%`
    bounds the layer to `.scrollback-pane` (the ComposeBox is a sibling
    OUTSIDE the pane), so a pathologically tall card — e.g. a WHOIS with
    dozens of channels on a short viewport — can at most cover the whole
    scroll list, never spill over and intercept taps on the compose box;
    `overflow-y: auto` lets such a card's overflow scroll rather than
-   clip the close affordance (which sits in the header, at the top). */
+   clip the close affordance (which sits in the header, at the top).
+
+   #1051 — z-index was 5, under everything in the pane's chrome, and that made
+   the cards undismissable on a non-channel window: `.shell-chrome` floats its
+   lone ☰ over the pane's top-RIGHT corner (#985) at 41, each card puts its ✕
+   in that same corner (`margin-left: auto` in the card header), and 41 > 5, so
+   the ☰ won the hit test. 42 is the whole fix — vjt's ruling is that the card
+   wins, because if a card is open the intent is to close it, and closing it
+   uncovers the ☰ anyway. Ceiling is NOT the 89/90 drawer tier: `.toast-stack`
+   sits at 60 and must keep painting over a card, or a toast raised while a
+   WHOIS is up is invisible. Consequence worth stating, since 42 also clears
+   `.scrollback-float-stack` (40): a full-height card now covers the
+   scroll-to-bottom / next-active buttons until it is dismissed. That is the
+   same ruling applied consistently, not an oversight. Pinned in
+   `__tests__/shellChromeFloat.test.ts`. */
 .scrollback-overlay {
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
-  z-index: 5;
+  z-index: 42;
   display: flex;
   flex-direction: column;
   max-height: 100%;
@@ -3110,8 +3127,11 @@ html.resize-dragging * {
    state (the pane rides above the compose box + soft keyboard) and they
    never overlap. `pointer-events: none` on the box lets taps fall through
    the inter-button gap to the scrollback; each button re-enables its own.
-   z-index above `.scrollback-overlay` (cards) — matches the old mobile
-   next-active circle (z-index 40). */
+   z-index 40 matches the old mobile next-active circle.
+   #1051 — this used to say "above `.scrollback-overlay` (cards)". It is not,
+   any more: the overlay went to 42 so a card's ✕ can beat the floated ☰ at 41,
+   which necessarily lifted it over this stack too. A full-height card covers
+   these buttons until it is dismissed — accepted, same ruling. */
 .scrollback-float-stack {
   position: absolute;
   right: 1rem;

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -33982,3 +33982,70 @@ bar for that is "same or stronger, never looser":
   (Escape does NOT take the column away, already pinned in unit), and
   the `selectChannel` that follows stays the real proof that nothing
   intercepts.
+
+## 2026-08-08 — #1050 + #1051: one corner, two controls, and two different remedies
+
+Since #985 the non-channel mobile chrome is a zero-height row whose lone ☰
+overflows into the pane's top-RIGHT corner at `z-index: 41`. #1039 then
+retargeted that float's margin onto the shared `--pane-chrome-inset-*`
+tokens so the channel ☰ and the float land on the same rectangle — right,
+and the reason both of these landed at once: the glyph moved `0.25rem`
+down and `0.5rem` inward, off the very corner and onto whatever the pane
+already put there. Two panes already put something there.
+
+**They share a root and do NOT share a remedy**, which is the whole
+content of this note. The gate at `Shell.tsx` decides whether the row
+exists; the question each window has to answer is whether it wants the
+rail at all.
+
+- **/list does not (#1050).** The directory's ✕ is the last child of its
+  header, i.e. that corner, and the ☰ won the hit test — the tap meant to
+  leave the directory opened the rail. Owner's call, 2026-08-08: this
+  window does not want the rail, so the ROW goes — a third exclusion
+  beside `channel` (the TopicBar hosts the ☰ in flow) and `admin` (which
+  re-homed the same button into its own pane header). Bucket L is
+  knowingly relaxed for this one kind. Whole row, not a `display: none`
+  on the glyph: the row is what carries the z-index, and its zero-height
+  box would stay over the header. The gate reads `selKind()`, the memo
+  the mobile `<Match>` already switches on, rather than re-deriving.
+- **A server or query window does (#1051).** On mobile this ☰ is the only
+  door to settings, so the row stays and the CARD is raised instead. The
+  WHOIS / WHOWAS / LUSERS cards live in `.scrollback-overlay` (#133) at
+  `z-index: 5`, each with its ✕ at `margin-left: auto` in the card
+  header — the same corner, and 41 > 5, so the card could not be
+  dismissed at all. vjt's ruling is that the card wins: if a card is open
+  the intent is to close it, and closing it uncovers the ☰ anyway.
+
+**The ceiling is 60, not 89.** The issue bounds the new value below the
+89/90 drawer tier, which is true but not tight: `.toast-stack` sits at
+60 and has to keep painting over a card, or a toast raised while a WHOIS
+is up is invisible. 42 is the value — one above the float.
+
+**A second inversion the issue did not name.** `.scrollback-float-stack`
+(40 — scroll-to-bottom + next-active) carried a comment reading "z-index
+above `.scrollback-overlay` (cards)". Raising the overlay to 42
+necessarily lifts it over that stack too, so a full-height card now
+covers those buttons until it is dismissed. Accepted as the same ruling
+applied consistently, and the comment was corrected in the same change
+rather than left to mislead. The alternative — lifting the float stack
+back over the overlay — cascades: it would then also clear
+`.shell-chrome` at 41, inverting #985's rule instead.
+
+**The guard that could not fail.** `shellChromeFloat.test.ts` asserts
+`40 < z(.shell-chrome) < 89` under the heading "the floated opener paints
+above the in-pane scrollback floats", and its comment named the pinned
+overlay among those floats. That assertion is on `.shell-chrome` ALONE,
+so raising the overlay leaves it green while inverting the rule it
+documents — the next reader restores the bug on purpose. The comment was
+rewritten and a sibling test added that compares the two numbers
+directly (`overlay > .shell-chrome`, `< .toast-stack`, `>
+.scrollback-float-stack`), so the inversion now has something that fails
+for it. A guard that cannot fail is not a guard.
+
+**Test shape, both sides.** For #1050 the outcome asserted is that the
+tap CLOSES the directory, not that the ✕ is visible — visibility is
+exactly what the bug already satisfied, since the float painted over a
+perfectly visible button. For #1051 it is `document.elementFromPoint` at
+the ✕'s own centre, preceded by an assertion that the two boxes still
+INTERSECT: without that precondition a layout change that merely moved
+them apart would keep the spec green while retiring what it guards.


### PR DESCRIPTION
Two issues, one branch: **#1050** (the /list pane's ✕) and **#1051** (the
WHOIS / WHOWAS / LUSERS card ✕). Same root, adjacent code, and separating
them would only manufacture a conflict.

## The shared root

Since #985 the non-channel mobile chrome is a zero-height row whose lone
☰ overflows into the pane's top-**right** corner at `z-index: 41`. #1039
then retargeted that float's margin onto the shared
`--pane-chrome-inset-*` tokens so the channel ☰ and the float land on the
same rectangle — correct, and the reason both of these surfaced at once:
the glyph moved `0.25rem` down and `0.5rem` inward, off the very corner
and onto whatever the pane already put there. Two panes already put
something there.

## The remedies are NOT transferable

The gate decides whether the row exists; each window has to answer
whether it wants the rail at all.

| | #1050 `/list` | #1051 server / query |
|---|---|---|
| wants the rail? | no (owner's call) | yes — bucket L, on mobile this ☰ is the only door |
| remedy | suppress the **row** | raise the **card** |
| where | third exclusion in the `Shell.tsx` gate | `.scrollback-overlay` 5 → 42 |

**#1050** — whole row, not a `display: none` on the glyph: the row is
what carries the z-index, and its zero-height box would stay over the
header. Third exclusion beside `channel` (the TopicBar hosts the ☰ in
flow) and `admin` (which re-homed the same button into its own pane
header). Bucket L is knowingly relaxed for this one kind. The gate reads
`selKind()` — the memo the mobile `<Match>` already switches on — rather
than re-deriving the kind.

**#1051** — the cards live in `.scrollback-overlay` (#133) with each ✕ at
`margin-left: auto` in the card header, i.e. that same corner; 41 > 5, so
they could not be dismissed at all. vjt's ruling: the card wins, since
closing it uncovers the ☰ anyway.

## Two things the issues did not name

**The ceiling is 60, not 89.** Below the 89/90 drawer tier is true but
not tight — `.toast-stack` sits at **60** and must keep painting over a
card, or a toast raised while a WHOIS is up is invisible. 42 is the
value: one above the float.

**A second inversion.** `.scrollback-float-stack` (40 — scroll-to-bottom
+ next-active) carried a comment reading *"z-index above
`.scrollback-overlay` (cards)"*. Raising the overlay necessarily lifts it
over that stack too, so a full-height card now covers those buttons until
dismissed. Accepted as the same ruling applied consistently, and the
comment is corrected here rather than left to mislead. The alternative
cascades: lifting the float stack back over the overlay would also clear
`.shell-chrome` at 41 and invert #985's rule instead.

## The guard that could not fail

`shellChromeFloat.test.ts:46` asserts `40 < z(.shell-chrome) < 89` under
the heading *"the floated opener paints above the in-pane scrollback
floats"*, and its comment names **the pinned overlay itself** among those
floats. The assertion is on `.shell-chrome` alone, so raising the overlay
leaves it green while inverting the rule it documents. Both halves are
handled in this change: the comment is rewritten, and a sibling test
compares the numbers directly — `overlay > .shell-chrome`, `<
.toast-stack`, `> .scrollback-float-stack`. Red first, literal:

```
× the pinned card overlay paints ABOVE the floated opener, below the toasts
AssertionError: expected 5 to be greater than 41
  78|     expect(overlay).toBeGreaterThan(zOf(".shell-chrome"));
```

and for the #1050 gate, on the pre-fix tree:

```
× mobile /list window: the standalone .shell-chrome row is SUPPRESSED (#1050)
AssertionError: expected <header …(2)>…(1)</header> to be null
  1076|       expect(container.querySelector(".shell-chrome")).toBeNull();
```

(the `.directory-pane` barrier above it had already passed, so the branch
really had mounted).

## Test plan

- [x] `scripts/bun.sh run test` — **251 files / 4720 tests passed**.
- [x] `scripts/bun.sh run check` (biome + tsc) — **exit 0**.
- [x] `tsc --noEmit -p e2e` — 30 errors, all pre-existing, **none in the
      two new specs** (the e2e tree has no static gate; checked by hand).
- [ ] Integration CI — both new specs are `@webkit`, so they run on
      webkit-iphone-15 only. Not run locally.

**Spec shape follows the defect.** #1050 asserts the tap **closes** the
directory, not that the ✕ is visible — visibility is exactly what the bug
already satisfied, since the float painted over a perfectly visible
button. #1051 asserts `document.elementFromPoint` at the ✕'s own centre,
gated on a prior assertion that the two boxes still **intersect**:
without it, a layout change that merely moved them apart would keep the
spec green while quietly retiring what it guards.

Constraints honoured: `--pane-chrome-inset-*` and the float's margin are
untouched (#1039's outcome, asserted in
`issue1039-hamburger-corner.spec.ts`), and `.directory-close` is neither
moved nor restyled.

Refs #1050, #1051.