### PR TITLE
cic(#394): single-flight the unattended GET /me

### DIFF
--- a/cicchetto/src/__tests__/api.test.ts
+++ b/cicchetto/src/__tests__/api.test.ts
@@ -33,7 +33,7 @@ describe("api 401 handler", () => {
     const handler = vi.fn();
     api.setOn401Handler(handler);
     stubFetch(401, { error: "unauthorized" });
-    await expect(api.me("dead-token")).rejects.toBeInstanceOf(api.ApiError);
+    await expect(api.me("dead-token", "shared")).rejects.toBeInstanceOf(api.ApiError);
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
@@ -41,7 +41,7 @@ describe("api 401 handler", () => {
     const handler = vi.fn();
     api.setOn401Handler(handler);
     stubFetch(404, { errors: { detail: "not_found" } });
-    await expect(api.me("any-token")).rejects.toBeInstanceOf(api.ApiError);
+    await expect(api.me("any-token", "shared")).rejects.toBeInstanceOf(api.ApiError);
     expect(handler).not.toHaveBeenCalled();
   });
 
@@ -49,7 +49,7 @@ describe("api 401 handler", () => {
     const handler = vi.fn();
     api.setOn401Handler(handler);
     stubFetch(200, { kind: "user", id: "u1", name: "alice", is_admin: false, inserted_at: "x" });
-    await expect(api.me("good-token")).resolves.toBeDefined();
+    await expect(api.me("good-token", "shared")).resolves.toBeDefined();
     expect(handler).not.toHaveBeenCalled();
   });
 
@@ -58,7 +58,7 @@ describe("api 401 handler", () => {
     api.setOn401Handler(handler);
     api.setOn401Handler(null);
     stubFetch(401, { error: "unauthorized" });
-    await expect(api.me("any-token")).rejects.toBeInstanceOf(api.ApiError);
+    await expect(api.me("any-token", "shared")).rejects.toBeInstanceOf(api.ApiError);
     expect(handler).not.toHaveBeenCalled();
   });
 
@@ -82,7 +82,7 @@ describe("api 401 handler", () => {
     api.setOn401Handler(() => {});
     stubFetch(401, { error: "unauthorized" });
     try {
-      await api.me("dead-token");
+      await api.me("dead-token", "shared");
       expect.unreachable();
     } catch (e) {
       expect(e).toBeInstanceOf(api.ApiError);
@@ -895,7 +895,7 @@ describe("#739 — an UNAUTHENTICATED endpoint's 401 must not wipe the shared be
     const handler = vi.fn();
     api.setOn401Handler(handler);
     stubFetch(401, { error: "unauthorized" });
-    await expect(api.me("dead-token")).rejects.toBeInstanceOf(api.ApiError);
+    await expect(api.me("dead-token", "shared")).rejects.toBeInstanceOf(api.ApiError);
     expect(handler).toHaveBeenCalledTimes(1);
   });
 });
@@ -927,5 +927,119 @@ describe("#739 — startPasskeyModeChange only offers modes the server accepts",
       "disabled",
     ];
     expect(modes).toHaveLength(2);
+  });
+});
+
+// #394 — single-flight on the unattended `GET /me` door.
+//
+// `/me` has two callers that fire with no user gesture behind them: the boot
+// `user` resource (lib/networks.ts) and the badge reconcile, which re-pulls on
+// EVERY `visibilitychange` → visible (main.tsx). Each goes through `bootFetch`,
+// so one logical `/me` can occupy the wire for up to 26.5s (3 × 8s attempt
+// ceiling + 2.5s backoff). A second trigger inside that window used to put a
+// second request on the wire for the same answer.
+//
+// The property under test is the request COUNT at the transport boundary. That
+// is not a mirror of an internal call sequence — it is the observable the issue
+// is about (the edge counted requests), and the pile-up is made of exactly it.
+// The fan-out half is asserted alongside, so a "coalescer" that strands a
+// caller cannot pass.
+//
+// `fresh` is the read-after-write escape: a caller that has just written (the
+// HomePane connect-a-network refetch, the BootErrorBoundary retry) must not be
+// served an answer that was already on the wire before its write.
+
+const ME_BODY = {
+  kind: "user",
+  id: "u1",
+  name: "alice",
+  is_admin: false,
+  inserted_at: "x",
+} as const;
+
+type DeferredWire = {
+  /** How many requests reached the wire. THE number under test. */
+  count: () => number;
+  /** Settles the nth request. Throws if it was never issued — an absent
+   *  request must read as a failure, never as a silently skipped assertion. */
+  settle: (nth: number, status: number, body: unknown) => void;
+};
+
+/** Stubs `fetch` with one that never settles on its own, so a test can hold
+ *  requests in flight and count what the transport actually saw. */
+function stubDeferredFetch(): DeferredWire {
+  const resolvers: Array<(res: Response) => void> = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() => new Promise<Response>((resolve) => resolvers.push(resolve))),
+  );
+  return {
+    count: () => resolvers.length,
+    settle: (nth, status, body) => {
+      const resolve = resolvers[nth];
+      if (!resolve) throw new Error(`no request #${nth} on the wire (saw ${resolvers.length})`);
+      resolve(
+        new Response(JSON.stringify(body), {
+          status,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    },
+  };
+}
+
+describe("api.me single-flight (#394)", () => {
+  it("serves two concurrent shared callers from ONE request", async () => {
+    const wire = stubDeferredFetch();
+    const boot = api.me("tok-shared", "shared");
+    const resume = api.me("tok-shared", "shared");
+    expect(wire.count()).toBe(1);
+    wire.settle(0, 200, { ...ME_BODY, badge_count: 3 });
+    expect((await boot).badge_count).toBe(3);
+    expect((await resume).badge_count).toBe(3);
+  });
+
+  it("does not let a `fresh` caller inherit an answer that predates its write", async () => {
+    const wire = stubDeferredFetch();
+    const unattended = api.me("tok-raw", "shared");
+    const afterWrite = api.me("tok-raw", "fresh");
+    expect(wire.count()).toBe(2);
+    wire.settle(0, 200, { ...ME_BODY, badge_count: 1 });
+    wire.settle(1, 200, { ...ME_BODY, badge_count: 7 });
+    expect((await unattended).badge_count).toBe(1);
+    expect((await afterWrite).badge_count).toBe(7);
+  });
+
+  it("coalesces, it does not cache: a settled answer is never replayed", async () => {
+    const wire = stubDeferredFetch();
+    const first = api.me("tok-settled", "shared");
+    wire.settle(0, 200, { ...ME_BODY, badge_count: 1 });
+    expect((await first).badge_count).toBe(1);
+    const second = api.me("tok-settled", "shared");
+    expect(wire.count()).toBe(2);
+    wire.settle(1, 200, { ...ME_BODY, badge_count: 4 });
+    expect((await second).badge_count).toBe(4);
+  });
+
+  it("never hands one bearer's in-flight answer to another bearer", async () => {
+    const wire = stubDeferredFetch();
+    const alice = api.me("tok-a", "shared");
+    const bob = api.me("tok-b", "shared");
+    expect(wire.count()).toBe(2);
+    wire.settle(0, 200, { ...ME_BODY, id: "u-alice" });
+    wire.settle(1, 200, { ...ME_BODY, id: "u-bob" });
+    expect((await alice).id).toBe("u-alice");
+    expect((await bob).id).toBe("u-bob");
+  });
+
+  it("clears the shared slot when the request fails", async () => {
+    const wire = stubDeferredFetch();
+    const failing = api.me("tok-fail", "shared");
+    wire.settle(0, 500, { errors: { detail: "boom" } });
+    await expect(failing).rejects.toBeInstanceOf(api.ApiError);
+    const retry = api.me("tok-fail", "shared");
+    expect(wire.count()).toBe(2);
+    wire.settle(1, 200, { ...ME_BODY, badge_count: 2 });
+    expect((await retry).badge_count).toBe(2);
   });
 });

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -1617,12 +1617,58 @@ export async function deletePasskey(token: string, id: string, password: string)
   if (!res.ok) throw await readError(res, false);
 }
 
-// #717 — one of the three BOOT-CRITICAL GETs (with `listNetworks` and
-// `listChannels`). They feed the resource chain the CRT splash gates on, so
-// they go through `bootFetch`: per-attempt timeout + bounded retry on a
-// transport failure. See lib/bootFetch.ts for why the other ~100 call sites
-// in this module deliberately do NOT.
-export async function me(token: string): Promise<MeResponse> {
+/**
+ * #394 — how a `/me` caller wants its answer.
+ *
+ * `"shared"` — unattended read. May be served by a request already on the
+ * wire for the same bearer. Every caller that fires without a user gesture
+ * behind it (boot, resume) belongs here.
+ *
+ * `"fresh"` — read-after-write. Always puts its own request on the wire,
+ * because an answer that left before the write cannot contain it. Every
+ * caller that has just mutated server state belongs here.
+ */
+export type MeFreshness = "shared" | "fresh";
+
+// #394 — the one `/me` currently on the wire for `token`, or null.
+// Cleared on settle, success or failure: this coalesces, it does not cache.
+// Keyed by bearer so a rotation can never hand identity A's answer to B —
+// the #818 class of bug, one layer down.
+let sharedMe: { token: string; response: Promise<MeResponse> } | null = null;
+
+/**
+ * `GET /me`.
+ *
+ * #717 — one of the three BOOT-CRITICAL GETs (with `listNetworks` and
+ * `listChannels`). They feed the resource chain the CRT splash gates on, so
+ * they go through `bootFetch`: per-attempt timeout + bounded retry on a
+ * transport failure. See lib/bootFetch.ts for why the other ~100 call sites
+ * in this module deliberately do NOT.
+ *
+ * #394 — and therefore one logical `/me` can hold the wire for up to 26.5s
+ * (3 × 8s attempt ceiling + 2.5s backoff). Two callers fire unattended: the
+ * boot `user` resource, and the badge reconcile on every `visibilitychange`
+ * → visible. Nothing stopped a second trigger inside that window from
+ * issuing a second request for the same answer, and each duplicate makes
+ * the next one slower — the loop #394 describes. `"shared"` callers now fan
+ * out from a single request. NOT extended to `listNetworks` /
+ * `listChannels`: they carry the same shape but no repeating unattended
+ * trigger, and BootErrorBoundary's recovery spec deliberately pins a
+ * `listNetworks` double.
+ */
+export function me(token: string, freshness: MeFreshness): Promise<MeResponse> {
+  if (freshness === "shared" && sharedMe?.token === token) return sharedMe.response;
+
+  const response = fetchMe(token).finally(() => {
+    // Only the slot THIS call installed may be cleared: a `fresh` call, or a
+    // rotation, replaces the slot while an older request is still settling.
+    if (sharedMe?.response === response) sharedMe = null;
+  });
+  sharedMe = { token, response };
+  return response;
+}
+
+async function fetchMe(token: string): Promise<MeResponse> {
   const res = await bootFetch("/me", {
     headers: buildHeaders(token),
   });

--- a/cicchetto/src/lib/networks.ts
+++ b/cicchetto/src/lib/networks.ts
@@ -65,9 +65,13 @@ const exports = identityScopedStore((onIdentityChange) => {
   const [user, { mutate: mutateUserResource, refetch: refetchUserResource }] = createResource<
     MeResponse | null,
     string | null
-  >(token, async (t) => {
+  >(token, async (t, info) => {
     if (!t) return null;
-    const m = await me(t);
+    // #394 — an explicit `refetchUser()` is a read-after-write (HomePane's
+    // connect-a-network, the BootErrorBoundary retry): it must not be served
+    // an answer that left before the write. A source-driven load (boot, token
+    // rotation) is unattended and may share one.
+    const m = await me(t, info.refetching ? "fresh" : "shared");
     // #818 — refuse to hydrate for an identity that is no longer current.
     // `createResource` discards the stale VALUE (a rotation refetches and only
     // the latest promise feeds `user()`), but it cannot cancel an await: the

--- a/cicchetto/src/main.tsx
+++ b/cicchetto/src/main.tsx
@@ -112,7 +112,10 @@ moduleRoot(() => mountDisplayPrefsSync());
 mountBadgeReconcile(async () => {
   const t = token();
   if (!t) return null;
-  return (await me(t)).badge_count ?? 0;
+  // #394 — "shared": this fires on every visibilitychange with no user
+  // gesture behind it, so it is exactly the caller that must fan out from a
+  // `/me` already on the wire instead of adding one.
+  return (await me(t, "shared")).badge_count ?? 0;
 });
 
 // UX-3 PENT — VisualViewport-driven height tracking. Writes


### PR DESCRIPTION
Refs #394.

## What I was asked, and what I found first

The instruction was: go read the cic side and say whether concurrent or
duplicated in-flight `GET /me` is actually **possible today**, and under what
sequence. If not, the issue closes as a proved negative. It is possible. Three
sequences, all reachable without a bug anywhere else.

`/me` has exactly two production callers:

- `src/lib/networks.ts:70` — the boot `user` resource, keyed on `token()`.
- `src/main.tsx:115` — the badge reconcile, injected into
  `mountBadgeReconcile`, which fires on **every** `visibilitychange` → visible
  (`src/lib/badge.ts:117-131`) with no in-flight guard of any kind.

Both go through `bootFetch` (`src/lib/bootFetch.ts`), whose worst-case
lifetime for ONE logical call is **26.5s** — 3 attempts × an 8s
`AbortSignal.timeout`, plus 500ms + 2000ms backoff. That number is what makes
the sequences reachable rather than theoretical:

1. **Repeated foregrounding.** Two `visibilitychange` → visible transitions
   inside that window put two `/me` on the wire. iOS PWA app-switching
   produces exactly this cadence, and nothing on either side remembers the
   first one.
2. **Boot × resume.** The cold-launch `user` load and a badge reconcile are
   different doors with zero shared state; overlapping them needs only a
   foreground event during boot.
3. **`refetchUser()` over an in-flight load.** Solid's `refetch` does not
   coalesce with a load already in flight and does not cancel it. Callers:
   `HomePane.tsx:195` (after `addNetwork`) and `BootErrorBoundary.tsx:169`
   (the retry button).

Note also that the amplification has a second half *inside* one call: when
`/me` genuinely exceeds 8s, `bootFetch` aborts (that is a 499 at the edge, by
construction) and retries — up to three server-side executions for one logical
read. Single-flight does not touch that; a per-attempt ceiling change would,
and I did not make one.

## What I refuse to claim

- **Any magnitude.** Reading code gives structure, never frequency. I do not
  know how often any of these three sequences fires in production, how long a
  real `/me` takes, or what fraction of the 20 aborts in your window they
  account for. Unmeasured, and I did not probe prod.
- **That this fixes the 277:1.** It is not a reproduction target and it is not
  an acceptance criterion here. Your re-measurement excludes it as a current
  property at 26×; nothing in this PR was validated against it and no number
  in this PR should be read as having moved it.
- **That the duplicate requests were ever the dominant cost.** They are a
  structural hole. Closing a hole is not evidence the hole was load-bearing.
- **That the aborts cluster in time.** Unanswerable on existing data — the log
  format carries neither `$request_time` nor `$request_id`. Untouched, per
  your instruction.
- **Anything about the second failure mode** (comment 2: iOS PWA silent stall,
  no requests for 5m23s). Different bug, different remedy, not in this PR.
  `lib/visibilityHeartbeat.ts` (#318) is adjacent but is the *server-side
  presence freshness* complement, not a client refetch-on-resume watchdog.

## The change

`"shared"` callers fan out from a single in-flight request, keyed by bearer.
The slot clears on settle — success **or** failure. This coalesces, it does
not cache.

`"fresh"` is an explicit second mode, and it is the part I would push back on
if you wanted a single global coalescer. A read-after-write caller must not be
served an answer that left the client before its write: `HomePane`'s
connect-a-network refetch would show the new network as still "available to
connect", and `BootErrorBoundary`'s retry would inherit the failure of the
request it joined — a retry button that reads as dead, which is the exact
`#717` symptom that boundary exists to remove. `createResource`'s
`info.refetching` already discriminates source-driven loads from explicit
refetches, so no new state carries the distinction.

Bearer-keying is not decoration: an unkeyed slot hands identity A's `/me` to
identity B, which is the `#818` class of bug one layer down.

**Deliberately NOT extended to `listNetworks` / `listChannels`.** They have
the same shape and `/networks/azzurra/channels` took 4 of the 20 aborts in
your window, so the argument for generalising is real. Two reasons I did not:
neither has a *repeating unattended* trigger (the amplifier here is the
visibility listener, and it only calls `/me`), and `BootErrorBoundary`'s
recovery spec deliberately pins `listNetworks` firing **twice** on one press,
with a measured rationale in the source. Collapsing that is a separate call
with its own spec to rewrite, not a free ride on this one. If you want it,
`bootFetch` is the right home and the mode threads through unchanged.

## Where I think you may be wrong

Your framing puts single-flight and "a longer timeout" as complementary, with
single-flight as the one that breaks the loop. Between callers, yes. But the
tightest loop in the code is *within* one call: `bootFetch` aborts its own
request at 8s and immediately re-issues it. If a slow `/me` returns, that path
manufactures the 499-then-retry pattern all by itself, with a single caller
and single-flight fully armed. I did not change it — 8s is #717's number and
moving it needs a measurement I do not have — but I do not think this PR
should be read as having cut the amplification loop end to end.

## Guard

`src/__tests__/api.test.ts` — 5 specs. The property under test is the request
count **at the transport boundary**, which is not a mirror of an internal call
sequence: it is the observable the issue is about, and what a pile-up is made
of. The fan-out half is asserted alongside so a coalescer that strands a
caller cannot pass.

It can fail. The spec was written first and run against unfixed code:

```
AssertionError: expected [ [Function], [Function] ] to have a length of 1 but got 2
  ❯ src/__tests__/api.test.ts:990:18
Tests  1 failed | 54 passed (55)
```

Then four mutants against the finished implementation, each injected into
`src/lib/api.ts` and reverted:

| mutant | result |
|---|---|
| no coalescing at all (the original red) | `1 failed \| 54 passed` — kills "serves two concurrent shared callers from ONE request" |
| `fresh` coalesces too | `1 failed \| 54 passed` — kills "does not let a `fresh` caller inherit an answer that predates its write" |
| clear the slot on failure only | `1 failed \| 54 passed` — kills "coalesces, it does not cache" |
| clear the slot on success only | `2 failed \| 53 passed` — kills "clears the shared slot when the request fails", **and** a pre-existing 401 spec: a rejected slot that never clears poisons every later `/me` for that bearer. Reported as-is; the second casualty is the mutant showing how bad that failure mode is, not a redundant assertion. |
| key ignores the bearer | `2 failed \| 53 passed` — kills "never hands one bearer's in-flight answer to another bearer" first; the second casualty is caused by the mutant itself (removing the key lets one test's leaked slot reach the next, which is precisely the isolation the key provides) |

Every one of the 5 assertions is killed by a mutant that targets it
specifically. None survived all five, so none is dead weight.

## Gates

Run from the worktree, cic-only, no lane.

- `scripts/bun.sh run check` — rc=0 (biome + tsc; tsc reached and clean, none
  of the 61 pre-existing biome warnings are in the four files touched)
- `scripts/bun.sh run test` — rc=0, `251 passed (251)` files
- Test **count diff across the gate: 4718 → 4723 (+5)** — the five specs were
  actually collected, not silently skipped.