### PR TITLE
cic(#954): a destroyed document is not a failed send

### DIFF
--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -2192,6 +2192,142 @@ describe("#904 — one-deep send queue", () => {
   });
 });
 
+// #954 — the #904 pump owes the composer its text back on every failing path.
+// One "failure" is not one: a POST aborted because the DOCUMENT was destroyed
+// (reload, the #674 auto-refresh, a closed tab) may already have been accepted
+// and persisted by the server. Handing that text back re-arms the composer —
+// and #772 mirrors the draft into sessionStorage, so it survives the reload
+// and greets the operator with a line the channel is already showing. One
+// distracted Enter sends it twice.
+//
+// The abort itself is indistinguishable: `fetch` rejects with the same
+// `TypeError: Failed to fetch` for a dead Wi-Fi, a vanished server and a
+// destroyed document, so these tests drive the DOCUMENT-LIFECYCLE event
+// (`pagehide`), never an error string.
+describe("#954 — a send aborted by the document going away is not re-armed", () => {
+  const k = channelKey("freenode", "#a");
+
+  // Same controlled-ack shape the #904 block uses: the in-flight window is a
+  // real observable state, so the teardown can be placed INSIDE it.
+  const deferredSend = async () => {
+    const sb = await import("../lib/scrollback");
+    const acks: Array<{ body: string; resolve: () => void; reject: (e: unknown) => void }> = [];
+    vi.mocked(sb.sendMessage).mockImplementation(
+      (_slug: string, _target: string, body: string) =>
+        new Promise<void>((resolve, reject) => {
+          acks.push({ body, resolve, reject });
+        }),
+    );
+    return acks;
+  };
+
+  // What a destroyed document does to an in-flight POST: the page teardown
+  // fires, then the request rejects as a bare network failure.
+  const abortedByTeardown = (ack: { reject: (e: unknown) => void } | undefined): void => {
+    window.dispatchEvent(new Event("pagehide"));
+    ack?.reject(new TypeError("Failed to fetch"));
+  };
+
+  it("drops the in-flight line instead of putting it back in the composer", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const acks = await deferredSend();
+    const compose = await import("../lib/compose");
+
+    compose.setDraft(k, "probe954 already in the channel");
+    const done = compose.submit(k, "freenode", "#a");
+    await Promise.resolve();
+
+    abortedByTeardown(acks[0]);
+    expect(await done).toHaveProperty("error");
+
+    expect(compose.getDraft(k)).toBe("");
+  });
+
+  it("so the reload does not restore it either — the outcome the operator sees", async () => {
+    // The whole point, end to end. #772 mirrors the store into sessionStorage,
+    // so "handed back" and "armed after the reload" are the same fact; this is
+    // the one that reproduces the issue's own snapshot, where the message was
+    // in the scrollback AND staged in the composer.
+    localStorage.setItem("grappa-token", "tok");
+    const acks = await deferredSend();
+    const before = await import("../lib/compose");
+
+    before.setDraft(k, "probe954 already in the channel");
+    const done = before.submit(k, "freenode", "#a");
+    await Promise.resolve();
+    abortedByTeardown(acks[0]);
+    await done;
+
+    vi.resetModules();
+    const after = await import("../lib/compose");
+
+    expect(after.getDraft(k)).toBe("");
+  });
+
+  it("still hands back an ORDINARY failure — the guard cannot fire wide", async () => {
+    // The negative that makes the positive mean something. Same rejection
+    // class, same `TypeError: Failed to fetch`, NO teardown: a dead link owes
+    // the operator their text, and swallowing it here would be a lost message.
+    localStorage.setItem("grappa-token", "tok");
+    const acks = await deferredSend();
+    const compose = await import("../lib/compose");
+
+    compose.setDraft(k, "probe954 never left the building");
+    const done = compose.submit(k, "freenode", "#a");
+    await Promise.resolve();
+
+    acks[0]?.reject(new TypeError("Failed to fetch"));
+    expect(await done).toHaveProperty("error");
+
+    expect(compose.getDraft(k)).toBe("probe954 never left the building");
+  });
+
+  it("is not condemned by a teardown that happened BEFORE it was dispatched", async () => {
+    // A `pagehide` also fires on bfcache entry and the iOS PWA freeze, and
+    // those documents come back. A latched flag would drop every send failure
+    // for the rest of this document's life; the epoch is compared across the
+    // flight, so an earlier teardown is simply history.
+    localStorage.setItem("grappa-token", "tok");
+    const acks = await deferredSend();
+    const compose = await import("../lib/compose");
+
+    window.dispatchEvent(new Event("pagehide"));
+
+    compose.setDraft(k, "typed after coming back");
+    const done = compose.submit(k, "freenode", "#a");
+    await Promise.resolve();
+    acks[0]?.reject(new TypeError("Failed to fetch"));
+    await done;
+
+    expect(compose.getDraft(k)).toBe("typed after coming back");
+  });
+
+  it("still hands back the QUEUED line — nothing ever dispatched it", async () => {
+    // The precision the drop needs. Only the line that was IN THE AIR can be
+    // owned by the server; the one-deep queue behind it never left the client,
+    // so dropping it would lose a message outright rather than trade a
+    // duplicate for it.
+    localStorage.setItem("grappa-token", "tok");
+    const acks = await deferredSend();
+    const sb = await import("../lib/scrollback");
+    const compose = await import("../lib/compose");
+
+    compose.setDraft(k, "in flight");
+    const done = compose.submit(k, "freenode", "#a");
+    await Promise.resolve();
+    compose.setDraft(k, "queued behind it");
+    await compose.submit(k, "freenode", "#a");
+
+    abortedByTeardown(acks[0]);
+    await done;
+
+    expect(compose.getDraft(k)).toBe("queued behind it");
+    expect(vi.mocked(sb.sendMessage).mock.calls.length).toBe(1);
+    expect(compose.isQueueFull(k)).toBe(false);
+    expect(compose.isSending(k)).toBe(false);
+  });
+});
+
 describe("compose tabComplete (members-only, irssi-exact)", () => {
   const k = channelKey("freenode", "#a");
 

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -15,6 +15,7 @@ import { openBanlistModal } from "./banlistModal";
 import { buildBanMask } from "./banMask";
 import { setQuery } from "./channelDirectory";
 import { type ChannelKey, canonicalChannel, channelKey, decodeChannelKey } from "./channelKey";
+import { documentTeardownEpoch, documentTornDownSince } from "./documentTeardown";
 import { friendlyError } from "./friendlyError";
 import { addHighlight, delHighlight } from "./highlightList";
 import { identityScopedStore } from "./identityScopedStore";
@@ -1836,10 +1837,16 @@ const exports_ = identityScopedStore((onIdentityChange) => {
     // minutes late, and it comes back AFTER the line that failed — the order
     // they were typed in.
     let inHand: string | null = null;
+    // #954 — the document-lifecycle epoch as of the dispatch currently in the
+    // air, re-sampled per iteration so a teardown can only condemn the line it
+    // actually overlapped. Sampled here too, because `takeDraft` throwing would
+    // reach the `finally` before the loop ever assigns it.
+    let teardownAtDispatch = documentTeardownEpoch();
     try {
       let text = takeDraft(key);
       for (;;) {
         inHand = text;
+        teardownAtDispatch = documentTeardownEpoch();
         const outcome = await dispatchDraft(key, networkSlug, channelName, text);
         // A drain that kept the buffer already put its own residue there.
         inHand = "error" in outcome && !("keptBuffer" in outcome) ? text : null;
@@ -1854,7 +1861,45 @@ const exports_ = identityScopedStore((onIdentityChange) => {
       // and the pump owes the composer its text back on EVERY path — a throw
       // that evaporated it would be this issue's own defect, wearing a stack
       // trace. The throw still propagates; only the text is rescued.
-      const owed = inHand === null ? [] : [inHand];
+      //
+      // #954 — with ONE rejection class excepted: the document was destroyed
+      // while this line was in the air (a reload, the #674 auto-refresh, a
+      // closed tab). That abort is not evidence the send failed — the server
+      // may already own the message — and the text does not die with the page
+      // either, because #772 mirrors the draft into sessionStorage: handing it
+      // back here is what re-arms the composer, after the reload, with a line
+      // the channel already shows. So it is DROPPED. The trade is deliberate
+      // and it is vjt's (issue #954, 2026-08-08): the echo will render the
+      // message, whereas a loaded composer invites a second Enter.
+      //
+      // WHERE THE TRADE STOPS BEING FREE, measured, not assumed. On the
+      // #954 harness (real Bandit listener, real TCP kill at a controlled
+      // offset, N=20/row, three runs) an aborted POST persisted 20/20 at every
+      // offset from +1ms onward, either close mode — that is the regime this
+      // drop is for, and its 95% ceiling on non-persistence is 0.32%. The ONE
+      // exception is an RST landing at +0ms after the last body byte: 0/20,
+      // the message did NOT land, and dropping the text there LOSES it.
+      // Whether a destroyed document closes FIN or RST is UNMEASURED, and a
+      // killed tab plausibly looks like RST — so that sub-millisecond window
+      // on an otherwise idle path is a real, if narrow, loss. Engineering
+      // around it means a delivery-confirmation protocol (an idempotency key
+      // on the POST, or a correlation token echoed back), which #954 rules out
+      // as its own cluster. Do not paper over it here; widen the measurement
+      // first if it ever needs revisiting.
+      //
+      // The QUEUED line is handed back regardless: it was never dispatched, so
+      // no server can own it, and dropping it would lose a message outright.
+      //
+      // SCOPE, so nobody reads this as covering more than it does: a paced
+      // multi-line drain never reaches here with text in hand (`keptBuffer`
+      // leaves `inHand` null) because it mirrors its OWN residue into the
+      // draft, so an aborted line inside a paste is still re-armed. That is
+      // the same hazard at a different writer, and it is NOT the same rule —
+      // the drain's error mix includes explicit 429 refusals, which prove the
+      // line did not land and must never be dropped. Deliberately left to a
+      // decision of its own rather than guessed at here.
+      const destroyedInFlight = documentTornDownSince(teardownAtDispatch);
+      const owed = inHand === null || destroyedInFlight ? [] : [inHand];
       const queued = takeQueued(key);
       if (queued !== null) owed.push(queued);
       handBack(key, owed);

--- a/cicchetto/src/lib/documentTeardown.test.ts
+++ b/cicchetto/src/lib/documentTeardown.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// #954 — the epoch is module state armed at import, so every test re-imports
+// after a reset to get a document that has observed nothing yet. That is also
+// the only way to exercise the arming itself: the listeners are registered as
+// a side effect of the import, exactly as they are in the app.
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe("#954 — document teardown epoch", () => {
+  it("starts at an epoch nothing has moved", async () => {
+    const { documentTeardownEpoch, documentTornDownSince } = await import("./documentTeardown");
+    expect(documentTornDownSince(documentTeardownEpoch())).toBe(false);
+  });
+
+  it("moves on pagehide — the modern teardown event", async () => {
+    const { documentTeardownEpoch, documentTornDownSince } = await import("./documentTeardown");
+    const before = documentTeardownEpoch();
+    window.dispatchEvent(new Event("pagehide"));
+    expect(documentTornDownSince(before)).toBe(true);
+  });
+
+  it("moves on beforeunload — the legacy fallback for WebViews without pagehide", async () => {
+    const { documentTeardownEpoch, documentTornDownSince } = await import("./documentTeardown");
+    const before = documentTeardownEpoch();
+    window.dispatchEvent(new Event("beforeunload"));
+    expect(documentTornDownSince(before)).toBe(true);
+  });
+
+  it("does NOT move on visibilitychange — a backgrounded tab keeps its fetches", async () => {
+    // The scope pin. Widening the trigger to visibility would make every
+    // ordinary send failure in a hidden tab look like a teardown, and #954's
+    // drop would then eat text the server never received.
+    const { documentTeardownEpoch, documentTornDownSince } = await import("./documentTeardown");
+    const before = documentTeardownEpoch();
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event("blur"));
+    expect(documentTornDownSince(before)).toBe(false);
+  });
+
+  it("keeps moving after a restore — it is a counter, not a latch", async () => {
+    // A `pagehide` is not necessarily the end: bfcache entry and the iOS PWA
+    // freeze both fire it on documents that come back. A boolean would stay
+    // true for the rest of such a document's life and start condemning
+    // ordinary failures; a counter re-answers the question per flight.
+    const { documentTeardownEpoch, documentTornDownSince } = await import("./documentTeardown");
+
+    window.dispatchEvent(new Event("pagehide"));
+    // The document came back. A flight sampled NOW spans no teardown…
+    const afterRestore = documentTeardownEpoch();
+    expect(documentTornDownSince(afterRestore)).toBe(false);
+
+    // …until the next one lands.
+    window.dispatchEvent(new Event("pagehide"));
+    expect(documentTornDownSince(afterRestore)).toBe(true);
+  });
+});

--- a/cicchetto/src/lib/documentTeardown.ts
+++ b/cicchetto/src/lib/documentTeardown.ts
@@ -1,0 +1,70 @@
+// #954 — "did this document go away while my request was in the air?"
+//
+// A POST aborted because the tab is being destroyed is NOT the same failure as
+// a 4xx, a refused connection or a dead Wi-Fi: the server may already own the
+// message. The rejection cannot tell them apart — `fetch` rejects with the
+// same `TypeError: Failed to fetch` for a DNS death, a CORS refusal, a
+// vanished server AND a destroyed document. Matching on that string would
+// silently swallow real send failures, which is the opposite of what #954
+// asks for. So the discriminator is not the error at all: it is a
+// document-lifecycle event, owned here.
+//
+// A COUNTER, NOT A BOOLEAN — the part that is easy to get wrong twice:
+//
+//   * `pagehide` also fires on bfcache entry and iOS PWA freeze, and those
+//     documents come BACK. A latched flag would stay true for the rest of
+//     their life and start dropping genuine send failures.
+//   * Clearing that flag on `pageshow` does not fix it: a frozen document's
+//     in-flight fetch rejects on the THAW, i.e. after `pageshow` has already
+//     cleared the flag, so the one case this exists for would read false.
+//
+// Comparing the epoch ACROSS a flight asks the only question the caller has —
+// "did a teardown land between the dispatch and the rejection" — and is immune
+// to both. Monotonic, never reset: only differences are ever read.
+//
+// `visibilitychange` is deliberately NOT a trigger. A backgrounded tab keeps
+// its fetches, so a hidden document whose send fails is failing for an
+// ordinary reason and owes the operator their text back.
+//
+// Self-arming at import rather than an `install*` a composition root calls:
+// the epoch has to be live before the first Enter can be, and there is no
+// uninstall path worth having for a listener that dies with the document.
+// `main.tsx` registers its own `pagehide` / `beforeunload` pair for the S3.3
+// away-hint — the same seam, an unrelated payload; two listeners on one event
+// are independent, and moving this one there would make it forgettable.
+//
+// Both events, for the reason main.tsx gives: `pagehide` is the modern one and
+// the only one that fires reliably on mobile, `beforeunload` is the legacy
+// fallback for WebViews that lack it. Double-firing is free — the epoch is
+// read as "changed", never as a count of anything.
+
+let epoch = 0;
+
+/**
+ * How many document teardowns this document has observed.
+ *
+ * Meaningless on its own: sample it before a request, compare after, and a
+ * difference means the document was torn down (or frozen) while the request
+ * was in flight. See `documentTornDownSince`.
+ */
+export function documentTeardownEpoch(): number {
+  return epoch;
+}
+
+/**
+ * Was there a teardown since `epoch` was sampled?
+ *
+ * The predicate every caller wants, spelled once so no site re-derives it as a
+ * bare `!==` and gets the direction wrong.
+ */
+export function documentTornDownSince(sampled: number): boolean {
+  return epoch !== sampled;
+}
+
+if (typeof window !== "undefined") {
+  const bump = (): void => {
+    epoch += 1;
+  };
+  window.addEventListener("pagehide", bump);
+  window.addEventListener("beforeunload", bump);
+}

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -34049,3 +34049,65 @@ perfectly visible button. For #1051 it is `document.elementFromPoint` at
 the ✕'s own centre, preceded by an assertion that the two boxes still
 INTERSECT: without that precondition a layout change that merely moved
 them apart would keep the spec green while retiring what it guards.
+---
+
+## 2026-08-08 — #954: a destroyed document is not a failed send
+
+The #904 pump owes the composer its text back on every failing path, and
+that contract is right for every failure but one. When the DOCUMENT is
+destroyed mid-flight — a reload, the #674 auto-refresh applying itself,
+a closed tab — the POST aborts, but **the server may already own the
+message**. Handing that text back re-arms the composer, and because #772
+mirrors the draft into sessionStorage it survives the reload: the
+operator lands on a page showing the message in the scrollback AND
+staged in the composer. One distracted Enter sends it twice.
+
+vjt's ruling (issue #954, 08:30Z): distinguish that class in the
+`finally` and DROP the text rather than re-arming it. Explicitly not a
+delivery-confirmation protocol — no idempotency key, no correlation
+token. Losing the draft in that window is the correct trade, because the
+echo will render the message.
+
+**The discriminator is a lifecycle event, never the error.** `fetch`
+rejects with the same `TypeError: Failed to fetch` for a dead Wi-Fi, a
+DNS death, a CORS refusal, a vanished server AND a destroyed document.
+Matching on that string would silently swallow real send failures, which
+is the opposite of what the issue asks for. `lib/documentTeardown.ts`
+owns the answer instead: `pagehide` + `beforeunload`, the same seam
+`main.tsx` already uses for the S3.3 away-hint.
+
+**A counter, not a boolean — two ways that flag would have been wrong.**
+`pagehide` also fires on bfcache entry and the iOS PWA freeze, and those
+documents come back; a latch would drop every send failure for the rest
+of their life. Clearing the latch on `pageshow` does not fix it either,
+because a frozen document's fetch rejects on the THAW, after `pageshow`
+has already cleared it. Comparing the epoch ACROSS a flight asks the only
+question the pump has — "did a teardown land between the dispatch and the
+rejection" — and is immune to both. `visibilitychange` is deliberately
+not a trigger: a backgrounded tab keeps its fetches.
+
+**The queued line is still handed back.** Only the line that was in the
+air can be owned by the server; the one-deep #904 queue behind it never
+left the client, so dropping it would lose a message outright instead of
+trading a duplicate for one.
+
+**Where the trade stops being free, measured rather than assumed.** The
+#954 harness (real Bandit listener, real TCP kill at a controlled offset,
+N=20 per row, three runs) found an aborted POST persisted 20/20 at every
+offset from +1 ms onward in both close modes — 95% ceiling on
+non-persistence 0.32%. The ONE exception is an RST landing at +0 ms after
+the last body byte: **0/20, the message did not land**, and dropping the
+text there loses it. Whether a destroyed document closes FIN or RST is
+UNMEASURED, and a killed tab plausibly looks like RST. So a
+sub-millisecond window on an otherwise idle path is a real, if narrow,
+loss. Engineering around it is the delivery-confirmation protocol the
+ruling excludes; the boundary is recorded in the code comment where the
+drop happens so it is found rather than rediscovered.
+
+**Scope left open on purpose.** A paced multi-line drain (#666/#737)
+mirrors its OWN residue into the draft and never reaches the pump's
+`handBack`, so an aborted line inside a paste is still re-armed. Same
+hazard, different writer — but NOT the same rule: the drain's error mix
+includes explicit 429 refusals, which prove the line did not land and
+must never be dropped. Guessing a second rule there would have been two
+patterns for one question, so it is left to a decision of its own.


### PR DESCRIPTION
Implements vjt's ruling on #954 (08:30Z): `handBack` must not fire on the one
rejection class where the server may already own the message. Narrow fix — no
delivery-confirmation protocol, no idempotency key, no correlation token. Part
(2) (the muted "sending" row) is untouched: it is undecided and nothing here
prepares for it.

## The defect

The #904 pump takes the text out of the composer at dispatch and owes it back
on every failing path. When the DOCUMENT is destroyed mid-flight — a reload,
the #674 auto-refresh applying itself, a closed tab — the POST aborts, but the
server may already have accepted and persisted it. Handing the text back
re-arms the composer, and #772 mirrors the draft into sessionStorage, so it
survives the reload: the operator lands on a page with the message in the
scrollback AND staged in the composer. One distracted Enter sends it twice.

## The discriminator is a lifecycle event, not the error

`fetch` rejects with the same `TypeError: Failed to fetch` for a dead Wi-Fi, a
DNS death, a CORS refusal, a vanished server AND a destroyed document. Matching
on that string would silently swallow real send failures — the exact opposite
of what the issue asks for. So the answer comes from a document-lifecycle event
this codebase already has a seam for: `pagehide` + `beforeunload`, the pair
`main.tsx` registers for the S3.3 away-hint. New module `lib/documentTeardown.ts`.

**A counter, not a boolean**, because a flag is wrong twice over:

* `pagehide` also fires on bfcache entry and the iOS PWA freeze, and those
  documents come back — a latch would condemn every send failure for the rest
  of their life;
* clearing that latch on `pageshow` does not fix it, because a frozen
  document's in-flight fetch rejects on the THAW, i.e. after `pageshow` already
  cleared the flag, so the one case this exists for would read false.

Comparing the epoch ACROSS a flight asks the only question the pump has. Both
directions are pinned by tests. `visibilitychange` is deliberately not a
trigger: a backgrounded tab keeps its fetches.

**The queued line is still handed back.** Only the line in the air can be owned
by the server; the one-deep #904 queue behind it never left the client, so
dropping it would lose a message outright rather than trade a duplicate for one.

## Where the trade stops being free — the limit I am NOT claiming away

The premise "the message very probably landed" holds and holds tight in the
reachable regime: the #954 harness (real Bandit listener, real TCP kill at a
controlled offset, N=20/row, three runs) measured 20/20 persisted at every
offset from +1 ms onward in both close modes, 95% ceiling on non-persistence
0.32%.

**It does not cover the tip.** An RST landing at +0 ms after the last body byte
was **0/20 — the message did not land**, and dropping the text there LOSES it.
Whether a destroyed document closes FIN or RST is UNMEASURED, and a killed tab
plausibly looks like RST. That is a real loss in a sub-millisecond window on an
otherwise idle path. It is recorded in the code comment where the drop happens
and in DESIGN_NOTES, and deliberately NOT engineered around: doing so is the
delivery-confirmation protocol the ruling excludes.

## What I refused to claim

* **That this is proven end to end in a browser.** It is proven at the unit
  seam: `pagehide` fired inside a real in-flight window, then the abort. No e2e
  spec drives an actual mid-POST document destruction, so "a real reload during
  a real send behaves this way" is inference from the seam, not a measurement.
* **That the drop is always safe** — see the RST +0 ms row above.
* **That the class is fully closed.** See below.

## The half I found and did NOT build

A paced multi-line drain (#666/#737) mirrors its OWN residue into the draft and
never reaches the pump's `handBack` (`keptBuffer` leaves `inHand` null), so an
aborted line inside a paste is **still re-armed**. Same hazard, second writer.

I wrote that fix and then reverted it, because it is not the same rule: the
drain's error mix includes explicit 429 refusals, which prove the line did NOT
land and must never be dropped, and the retry-cap path exits non-paced while
still holding a 429. Making the drop correct there means a second, different
predicate for one question — two patterns. Better as a decision of its own than
a guess made in passing. Flagged in the code comment, in DESIGN_NOTES, and here.

## Where I think the brief may be wrong

Nowhere on the ruling — it is right, and the measurement backs it. One note on
the brief's framing: it treats "look for existing infrastructure first" as
possibly finding a ready-made signal. There isn't one (`lifecycle.ts` is the
SESSION lifecycle, `documentVisibility.ts` deliberately excludes teardown), so
this adds a module rather than reusing one. That is the answer to question 1,
not a skipped step.

## Gate

`scripts/bun.sh run check` → exit 0 (biome clean of new findings, tsc ran and
passed — the 61 warnings are the pre-existing CSS specificity set).
`scripts/bun.sh run test` → exit 0.

Test count diff, measured both ways rather than computed: **4723 → 4733**
(+10), files **251 → 252**. The baseline run had my two test additions moved
aside with the production fix still in place, so it also shows the fix causes
**zero regressions** across the 4723 pre-existing tests.

**The red was read before the green.** With the guard neutralised to its
pre-fix behaviour (`const destroyedInFlight = false`), the #954 block reports
`3 failed | 2 passed`: the three positives fail (the in-flight line comes back,
it survives the reload, and it displaces the queued line), and the two
negatives PASS — an ordinary `Failed to fetch` with no teardown still hands the
text back, and a teardown that predates the dispatch does not condemn it. A
guard that cannot fire wide, proven by the two that stayed green.