### PR TITLE
fix(#224): a stale :visible socket is demoted, not waited on

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -559,7 +559,13 @@ config :logger, :console,
     :stop_ms,
     :spawn_ms,
     :welcome_ms,
-    :autojoin_ms
+    :autojoin_ms,
+    # #224 — how long each demoted socket had been silent when the
+    # WSPresence stale sweep flipped it to :hidden. The demotion makes the
+    # entry indistinguishable from a page that reported hidden, so the
+    # `/admin/ws_presence` snapshot can no longer show it; this line is
+    # where that age survives.
+    :silent_for_ms
   ]
 
 import_config "#{config_env()}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -282,3 +282,13 @@ config :grappa, Grappa.Vault,
       {Cloak.Ciphers.AES.GCM,
        tag: "AES.GCM.V1", key: Base.decode64!("Ot80AYbRqJG9htfEztMBqz6Eo9ALMWgu9Ze6w0CbbPg="), iv_length: 12}
   ]
+
+# #224 — park the WSPresence stale-demotion sweep for the whole run.
+# WSPresence is an application-wide singleton (see the `max_cases: 1`
+# note above), so its periodic tick is NOT scoped to the test that cares
+# about it: a tick landing inside a `mark_stale_for_test/2` window would
+# demote a pid the #671 cases still expect to be REPORTED-visible, i.e. a
+# rare cross-test failure with no local cause. Tests that exercise the
+# sweep drive it deterministically — either `send(pid, :sweep)` against
+# the singleton, or their own short-interval instance.
+config :grappa, Grappa.WSPresence, sweep_ms: 3_600_000

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -34049,3 +34049,94 @@ perfectly visible button. For #1051 it is `document.elementFromPoint` at
 the ✕'s own centre, preceded by an assertion that the two boxes still
 INTERSECT: without that precondition a layout change that merely moved
 them apart would keep the spec green while retiring what it guards.
+## 2026-08-08 — #224: the socket was alive, so no transport timeout could reach it
+
+A prod socket sat `:visible` for ~2 days with nothing foregrounded.
+Auto-away fires on the `any_visible?/1` `true → false` TRANSITION, and
+the three doors that compute it (`set_visibility`, `client_closing`, pid
+`DOWN`) all need a write that never came — the hidden/close signal was
+lost and the socket never died. Killing that one socket by hand let both
+of the user's `Session.Server`s reach `:away_auto` within the debounce,
+so it was the sole blocker.
+
+**The question that decided the design: was the stuck socket still
+heartbeating?** The issue offered "tie liveness to the transport
+idle-timeout" as a cheap structural fix, and "~450k reductions" as if it
+settled the question. It does not — reductions accrue from work done FOR
+a socket too, and every push fanned out to that user passed through it.
+Magnitude cannot be read off code.
+
+It is settleable from structure, though, and the answer is yes:
+
+- Phoenix's websocket `:timeout` defaults to **60_000 ms**
+  (`Phoenix.Transports.WebSocket.default_config/0`), and
+  `Phoenix.Socket.Transport.load_config/2` merges the endpoint's
+  `websocket:` keyword list OVER that default. `endpoint.ex` sets no
+  `:timeout`, so 60s is in force — "not configured" is true of the
+  source and false of the behaviour.
+- Bandit honours it: `Bandit.WebSocket.Handler.handle_connection/2`
+  returns `{:persistent, timeout}`, which ThousandIsland arms as a
+  `Process.send_after(self(), :read_timeout, …)`.
+- That timer is reset ONLY from `handle_continuation/2`, which is
+  reached from the `:tcp`/`:ssl` inbound-data clause. Bandit's generic
+  `handle_info/2` — the one every outbound PubSub push arrives through —
+  returns `{:noreply, …}` directly and never touches it.
+
+So outbound traffic cannot hold a socket open. A socket that survives two
+days received inbound frames at least every 60 seconds, which on this
+wire means phx heartbeats, which means the client's JS timers were
+running. The connection was never what died; the visibility report was.
+**Direction 2 is not merely unbuilt, it is unavailable** — the mechanism
+already exists, already runs, and correctly declined to fire.
+
+(The same argument, at 90 minutes rather than 2 days, is already written
+into `WSPresence`'s #318 "efficacy caveat". It was reached independently
+here from the transport source, which is why it is recorded as structure
+rather than as a quote.)
+
+**The fix.** A periodic tick demotes each no-longer-`fresh?/3`
+`:visible` entry to `{:hidden, nil}` and runs the SAME
+`emit_transition/4` door as every other write. Nothing new is stored:
+the stamp (`last_visible_at`), the predicate (`fresh?/3`), the window
+(`stale_ms`) and the door all predate it.
+
+Three things that are not obvious:
+
+- **Demote, don't just emit.** Writing the entry is what makes a re-tick
+  idempotent — the alternative is a flag beside the entry saying "already
+  emitted", i.e. exactly the parallel bookkeeping that drifts. A mutant
+  that emitted without writing re-fired `:ws_all_hidden` on every tick,
+  forever.
+- **The demotion IS the disarm.** A returning client (heartbeat resumes
+  after a suspend) reports `:visible` against a `:hidden` entry, which is
+  a genuine `false → true` flip and cancels the debounce. Against a
+  still-`:visible` entry that report emits NOTHING — so a sweep that only
+  emitted would arm auto-away and leave nothing able to cancel it. The
+  arm and the disarm are one change, not two.
+- **#671's RAW/FRESH split survives.** It is tempting to read the sweep
+  as making the fresh view fully evented, and collapse the two predicates
+  into one. It does not: a pid that goes stale and dies BEFORE the next
+  tick is removed by `DOWN` before the sweep can see it, and only the RAW
+  `before?` at that door still produces its transition. Reading the fresh
+  view there resurrects the #671 bug in a window one tick wide. The sweep
+  closes the gap #671 left open (nothing arrives at all); it does not
+  replace it.
+
+**One knob in prod, two in the code.** `:sweep_ms` defaults to
+`:stale_ms`, and nothing in production sets it, so worst-case detection
+is `2 × stale_ms` = 120s against a 600s debounce. It is separately
+injectable for one reason: `WSPresence` is an application-wide singleton
+under `max_cases: 1`, so its timer is not scoped to the test that cares
+about it, and a tick landing inside another test's
+`mark_stale_for_test/2` window would demote a pid that test still expects
+to be reported-visible — a cross-test failure with no local cause.
+`config/test.exs` parks it at an hour; the sweep tests drive the tick
+themselves, and one starts its own short-interval instance so the timer's
+existence and re-arming are proven rather than assumed.
+
+**What the demotion costs.** A demoted entry is indistinguishable from a
+page that reported hidden, so `/admin/ws_presence` (#318's diagnostic)
+can no longer tell "swept" from "reported". A third visibility atom would
+have preserved it at the cost of landing on every consumer of a closed
+type, for a diagnostic; instead the `:info` line at the demotion carries
+what the snapshot loses — how long each socket had been silent.

--- a/lib/grappa/application.ex
+++ b/lib/grappa/application.ex
@@ -205,7 +205,11 @@ defmodule Grappa.Application do
         # WSPresence: tracks live WS socket pids per user_name to drive auto-away
         # (S3.1). Must come before SessionSupervisor so session processes can subscribe
         # to its notifications as soon as they start. Restart: :permanent (infrastructure).
-        Grappa.WSPresence,
+        #
+        # Opts are the CLAUDE.md boot-time injection of the #224 demotion
+        # sweep's interval (prod sets nothing and inherits `stale_ms`); test
+        # env parks the timer because the singleton is shared across the run.
+        {Grappa.WSPresence, ws_presence_opts()},
         # Grappa.Admission.NetworkCircuit (T31): both ETS-backed
         # singletons that must exist before the first session spawn or
         # admission check. NetworkCircuit funnels writes through its
@@ -531,6 +535,14 @@ defmodule Grappa.Application do
   # pattern in `test/grappa/admin_events_test.exs`.
   @spec attach_admin_telemetry?() :: boolean()
   defp attach_admin_telemetry?, do: Application.get_env(:grappa, :attach_admin_telemetry, true)
+
+  # #224 — WSPresence start opts (`:stale_ms`, `:sweep_ms`). Prod configures
+  # neither and takes the module defaults; test env parks `:sweep_ms` so the
+  # demotion tick cannot fire inside another test's `mark_stale_for_test/2`
+  # window. Boot-time `Application.get_env/2` is the CLAUDE.md-designated
+  # boundary for reaching config on the way into a child's start_link.
+  @spec ws_presence_opts() :: keyword()
+  defp ws_presence_opts, do: Application.get_env(:grappa, Grappa.WSPresence, [])
 
   # #215 Option B — AdminEvents disk mirror. On in prod; off in test env
   # (the singleton's Repo write would hit a foreign sandbox connection).

--- a/lib/grappa/ws_presence.ex
+++ b/lib/grappa/ws_presence.ex
@@ -58,19 +58,60 @@ defmodule Grappa.WSPresence do
   re-reads the live property each tick) — stops refreshing, goes stale,
   and push resumes within `stale_ms` instead of ~90 min.
 
-  Scope: read-time staleness fixes PUSH suppression only. The auto-away
-  FSM keys off the visibility TRANSITION (an emitted event), and no event
-  fires when a pid merely ages out with no write — so a stale `:visible`
-  pid does not itself TRIP auto-away. But ageing out must not DISARM it
-  either: the transition doors (`set_visibility` / `client_closing` /
-  DOWN) compute `before?`/`after?` over RAW `:visible` membership
-  (`any_reported_visible_in?/2`), NOT the fresh push view — so a device
-  that went stale and THEN dies / closes / reports hidden still produces
-  the `true → false` flip that fires `:ws_all_hidden`. Auto-away stays
-  bounded by the real socket DOWN / `client_closing` / explicit hide;
-  the fresh filter is confined to `any_visible?/1` push suppression
-  (#671 — before this, a stale-then-dead socket lost the transition and
-  auto-away never armed).
+  Ageing out must not DISARM auto-away: the transition doors
+  (`set_visibility` / `client_closing` / DOWN) compute `before?`/`after?`
+  over RAW `:visible` membership (`any_reported_visible_in?/2`), NOT the
+  fresh push view — so a device that went stale and THEN dies / closes /
+  reports hidden still produces the `true → false` flip that fires
+  `:ws_all_hidden` (#671 — before this, a stale-then-dead socket lost the
+  transition and auto-away never armed).
+
+  ## Stale demotion sweep (#224)
+
+  Read-time staleness alone fixed PUSH suppression only: `any_visible?/1`
+  discounted a stale pid, but no EVENT fired when a pid merely aged out
+  with no write, so a stale `:visible` pid never TRIPPED auto-away. In the
+  field a socket sat `:visible` for ~2 days with nothing foregrounded and
+  auto-away was blocked the whole time — the hidden/close signal was lost
+  and the pid `:DOWN` never came.
+
+  A periodic sweep closes it: every `stale_ms` the server demotes each
+  `:visible` pid that is no longer `fresh?/3` to `{:hidden, nil}` and runs
+  the SAME `emit_transition/4` door as every other write, so the last
+  device ageing out fires `:ws_all_hidden` and auto-away arms. Worst-case
+  detection is therefore `2 × stale_ms` (a pid can go stale just after a
+  tick) — noise against the 10-minute auto-away debounce.
+
+  Three things this deliberately does NOT do:
+
+    * **No new state.** The stamp (`last_visible_at`), the predicate
+      (`fresh?/3`), the window (`stale_ms`) and the emission door already
+      existed; the sweep only reads them. Demoting the entry — rather than
+      recording "already emitted" beside it — is what makes a re-tick
+      idempotent, so there is no parallel bookkeeping to drift.
+    * **No second knob in production.** The sweep period DEFAULTS to
+      `stale_ms`, and nothing in prod sets it otherwise, so there is one
+      number to reason about. `:sweep_ms` is overridable only so the test
+      suite can park the shared singleton's timer (see `start_link/1`).
+    * **It does not obsolete the RAW/FRESH split (#671).** A pid that goes
+      stale and dies BEFORE the next tick is removed by DOWN and the sweep
+      never sees it, so the DOWN door must still flip on RAW membership or
+      that transition is lost — exactly the #671 bug, in a window one tick
+      wide. The sweep closes the gap #671 left open (nothing arrives at
+      all); it does not replace it.
+
+  Because the sweep keeps the stored entry honest, the disarm side follows
+  for free: a demoted pid whose client resumes heartbeating reports
+  `:visible` against a `:hidden` entry, which is a genuine `false → true`
+  flip and fires `:ws_visible`. Without the demotion the re-report would
+  land on a still-`:visible` entry and emit NOTHING — so a sweep that only
+  emitted, without writing, would arm auto-away and never disarm it.
+
+  Transport liveness is NOT an alternative here. Phoenix's websocket
+  `:timeout` defaults to 60s and Bandit enforces it against INBOUND data
+  only (outbound pushes do not reset it), so a socket that survives days
+  is one whose client is still sending phx heartbeats. It is the
+  visibility report that stopped, not the connection.
 
   Efficacy caveat: whether a backgrounded iOS PWA actually stops sending
   fresh `visible` reports is unconfirmed off-device — the prod socket
@@ -180,7 +221,11 @@ defmodule Grappa.WSPresence do
   # margin; this MUST stay ≥ 2× the client heartbeat interval.
   @default_stale_ms 60_000
 
-  defstruct sockets: %{}, notify_pids: %{}, refs_to_user: %{}, stale_ms: @default_stale_ms
+  defstruct sockets: %{},
+            notify_pids: %{},
+            refs_to_user: %{},
+            stale_ms: @default_stale_ms,
+            sweep_ms: @default_stale_ms
 
   @typedoc "Per-pid reported PWA foreground visibility."
   @type visibility :: :visible | :hidden
@@ -195,7 +240,8 @@ defmodule Grappa.WSPresence do
           sockets: %{String.t() => %{pid() => pid_state()}},
           notify_pids: %{String.t() => pid()},
           refs_to_user: %{reference() => String.t()},
-          stale_ms: non_neg_integer()
+          stale_ms: non_neg_integer(),
+          sweep_ms: non_neg_integer()
         }
 
   # ---------------------------------------------------------------------------
@@ -206,9 +252,19 @@ defmodule Grappa.WSPresence do
   Starts the WSPresence GenServer as a named singleton. Used by the
   application supervision tree.
 
-  Opts: `:stale_ms` — the read-time staleness window for `any_visible?/1`
-  (#318); defaults to `#{@default_stale_ms}`. Injected here (boot-time)
-  rather than read from Application env at runtime.
+  Opts:
+
+    * `:stale_ms` — the read-time staleness window for `any_visible?/1`
+      (#318); defaults to `#{@default_stale_ms}`.
+    * `:sweep_ms` — how often the #224 demotion tick runs; defaults to
+      `:stale_ms`, which is the only value production sets. It exists as a
+      separate opt so the test suite can park the app-wide singleton's
+      timer: WSPresence is shared across the whole `mix test` run, and a
+      tick landing inside a `mark_stale_for_test/2` window would demote a
+      pid a test still expects to be reported-visible.
+
+  Both are injected here (boot-time) rather than read from Application env
+  at runtime.
   """
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts) when is_list(opts) do
@@ -419,7 +475,10 @@ defmodule Grappa.WSPresence do
 
   @impl GenServer
   def init(opts) do
-    {:ok, %__MODULE__{stale_ms: Keyword.get(opts, :stale_ms, @default_stale_ms)}}
+    stale_ms = Keyword.get(opts, :stale_ms, @default_stale_ms)
+    sweep_ms = Keyword.get(opts, :sweep_ms, stale_ms)
+    schedule_sweep(sweep_ms)
+    {:ok, %__MODULE__{stale_ms: stale_ms, sweep_ms: sweep_ms}}
   end
 
   @impl GenServer
@@ -591,9 +650,78 @@ defmodule Grappa.WSPresence do
     end
   end
 
+  # #224 — the stale-visible demotion tick. See "Stale demotion sweep" in
+  # the moduledoc. Re-arms first so a raise inside the pass cannot silently
+  # stop the sweep for the life of the node (WSPresence is `:permanent`, so
+  # a crash restarts it empty — but a lost timer would leave it running and
+  # blind).
+  def handle_info(:sweep, state) do
+    schedule_sweep(state.sweep_ms)
+    {:noreply, demote_stale(state)}
+  end
+
   # ---------------------------------------------------------------------------
   # Private helpers
   # ---------------------------------------------------------------------------
+
+  @spec schedule_sweep(non_neg_integer()) :: reference()
+  defp schedule_sweep(sweep_ms), do: Process.send_after(self(), :sweep, sweep_ms)
+
+  # Demote every no-longer-fresh `:visible` pid to `:hidden`, firing the
+  # visibility transition per user through the normal door. Keys are taken
+  # up front: the pass replaces values only, never adds or removes a user.
+  @spec demote_stale(t()) :: t()
+  defp demote_stale(state) do
+    now = now_ms()
+
+    state.sockets
+    |> Map.keys()
+    |> Enum.reduce(state, fn user_name, acc -> demote_stale_user(acc, user_name, now) end)
+  end
+
+  @spec demote_stale_user(t(), String.t(), integer()) :: t()
+  defp demote_stale_user(state, user_name, now) do
+    existing = Map.get(state.sockets, user_name, %{})
+
+    demoted =
+      Map.new(existing, fn
+        {pid, {:visible, last}} = entry ->
+          if fresh?(last, now, state.stale_ms), do: entry, else: {pid, {:hidden, nil}}
+
+        entry ->
+          entry
+      end)
+
+    if demoted == existing do
+      state
+    else
+      log_demotions(user_name, existing, demoted, now)
+      before? = any_reported_visible_in?(state, user_name)
+      state1 = put_user_sockets(state, user_name, demoted)
+      after? = any_reported_visible_in?(state1, user_name)
+      emit_transition(user_name, before?, after?, state1)
+      state1
+    end
+  end
+
+  # A demoted pid becomes indistinguishable from one whose page reported
+  # hidden, so the `/admin/ws_presence` snapshot can no longer tell the two
+  # apart (deliberate: a third visibility atom would land on every
+  # consumer for a diagnostic). The log line carries what the snapshot
+  # loses — how long the socket had been silent when it was demoted.
+  @spec log_demotions(String.t(), %{pid() => pid_state()}, %{pid() => pid_state()}, integer()) ::
+          :ok
+  defp log_demotions(user_name, existing, demoted, now) do
+    ages =
+      for {pid, {:visible, last}} <- existing,
+          match?({:hidden, _}, Map.fetch!(demoted, pid)),
+          do: if(is_integer(last), do: now - last, else: nil)
+
+    Logger.info("ws_presence: demoted #{length(ages)} stale :visible socket(s) to :hidden",
+      user_name: user_name,
+      silent_for_ms: inspect(ages)
+    )
+  end
 
   # The ONE write door for `sockets`, and the place the "no empty maps"
   # invariant is kept: a user whose last socket just went away is REMOVED,
@@ -628,18 +756,21 @@ defmodule Grappa.WSPresence do
 
   # RAW `:visible` membership, IGNORING freshness — the AUTO-AWAY
   # transition predicate (#671). The `before?`/`after?` of every
-  # lifecycle-event door (`set_visibility`, `client_closing`, DOWN) reads
-  # THIS, not `any_visible_in?/2`. Rationale: read-time staleness (#318)
-  # emits no event when a pid merely ages out, so a device that stopped
-  # heartbeating (phone asleep, JS timers suspended) is silently dropped
-  # from the FRESH view — and if `before?` also read the fresh view, the
-  # `true → false` flip on the eventual DOWN / close / hidden report would
-  # have ALREADY happened invisibly, so `emit_transition/4` saw
-  # `false → false` and never fired `:ws_all_hidden`, so auto-away never
-  # armed. A stale-but-still-`:visible` pid is a REPORTED-visible device:
-  # auto-away stays bounded by the real socket DOWN / close / explicit
-  # hide, NOT disarmed by silent ageout. (Ageout still does not TRIP
-  # auto-away — no event fires on ageout — it just no longer DISARMS it.)
+  # lifecycle-event door (`set_visibility`, `client_closing`, DOWN, and
+  # the #224 sweep) reads THIS, not `any_visible_in?/2`. Rationale: a pid
+  # that stopped heartbeating (phone asleep, JS timers suspended) drops
+  # out of the FRESH view the moment it ages out, with no write — and if
+  # `before?` also read the fresh view, the `true → false` flip on the
+  # eventual DOWN / close / hidden report would have ALREADY happened
+  # invisibly, so `emit_transition/4` would see `false → false` and never
+  # fire `:ws_all_hidden`, so auto-away would never arm.
+  #
+  # The #224 sweep does NOT retire this. It demotes an aged-out pid on a
+  # tick, so most ageouts now DO trip auto-away — but a pid that goes
+  # stale and dies before the next tick is gone from the map before the
+  # sweep can see it, and only the RAW `before?` at the DOWN door still
+  # produces its transition. Reading the fresh view there would lose it:
+  # the #671 bug, in a window one tick wide.
   @spec any_reported_visible_in?(t(), String.t()) :: boolean()
   defp any_reported_visible_in?(state, user_name) do
     state.sockets

--- a/lib/grappa/ws_presence.ex
+++ b/lib/grappa/ws_presence.ex
@@ -718,7 +718,7 @@ defmodule Grappa.WSPresence do
           do: if(is_integer(last), do: now - last, else: nil)
 
     Logger.info("ws_presence: demoted #{length(ages)} stale :visible socket(s) to :hidden",
-      user_name: user_name,
+      user: user_name,
       silent_for_ms: inspect(ages)
     )
   end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -9189,6 +9189,56 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    # #224 — the same FULL chain as the #182 test above, but the device never
+    # reports anything: it just STOPS affirming visibility. In the field that
+    # was a socket sitting `:visible` for ~2 days (browser killed / machine
+    # asleep / half-open TCP) with no hidden report, no `client_closing` and
+    # no pid DOWN — so none of the three transition doors ran and auto-away
+    # was blocked indefinitely. What makes it reachable is the demotion sweep;
+    # what this asserts is the user-visible end of it, a real AWAY line.
+    test "a socket that stops affirming visibility stops blocking auto-away (#224)" do
+      {server, port} = start_server_with_001()
+      {user, network, _} = setup_user_and_network(port)
+      pid = start_session_for(user, network)
+
+      :ok = await_handshake(server)
+      {:ok, _} = IRCServer.wait_for_line(server, &String.starts_with?(&1, "JOIN"), 1_000)
+
+      :ok = WSPresence.reset_for_test()
+      device = spawn(fn -> Process.sleep(:infinity) end)
+      :ok = WSPresence.register(user.name, device)
+      :ok = WSPresence.set_visibility(user.name, device, true)
+
+      # The device goes silent. Nothing reports hidden, the socket stays up.
+      :ok = WSPresence.mark_stale_for_test(user.name, device)
+
+      # Pre-state: silence here is NOT the fix working — it is the bug. The
+      # debounce must be unarmed at this point or the assertion after the
+      # sweep proves nothing about the sweep.
+      assert SessionStateHelpers.auto_away_timer(SessionStateHelpers.fetch(pid)) == nil
+
+      send(Process.whereis(WSPresence), :sweep)
+
+      # No immediate AWAY (the 10-min debounce), and this doubles as the
+      # settle for the WSPresence → PubSub → Session.Server hop.
+      assert {:error, :timeout} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "AWAY :auto"), 200)
+
+      assert SessionStateHelpers.auto_away_timer(SessionStateHelpers.fetch(pid)) != nil
+
+      send(pid, :auto_away_debounce_fire)
+
+      assert {:ok, away_line} =
+               IRCServer.wait_for_line(server, &String.starts_with?(&1, "AWAY :auto"), 1_000)
+
+      assert String.starts_with?(away_line, "AWAY :auto-away")
+      state = SessionStateHelpers.fetch(pid)
+      assert AwayState.state_of(SessionStateHelpers.away_state(state)) == :away_auto
+
+      Process.exit(device, :kill)
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
     test "set_auto_away when :away_explicit is a no-op (explicit takes precedence)" do
       {server, port} = start_server_with_001()
       {user, network, _} = setup_user_and_network(port)

--- a/test/grappa/ws_presence_test.exs
+++ b/test/grappa/ws_presence_test.exs
@@ -509,13 +509,18 @@ defmodule Grappa.WSPresenceTest do
       refute_receive {:ws_all_hidden, "pia"}, 100
       assert WSPresence.any_visible?("pia")
 
-      # But the stale one really was demoted: its death is now a no-op
-      # transition rather than the last-visible-device leaving.
-      Process.exit(stale, :kill)
+      # Kill the FRESH one, and the user must now go all-hidden — which can
+      # only happen if the stale sibling really was written to `:hidden`.
+      # Leave it `:visible` (a sweep that emits without demoting) and it is
+      # still RAW-visible here, so nothing fires. Killing the STALE one
+      # instead would prove nothing: that is a no-op transition either way.
+      # Contrast the #671 case above, where no sweep runs and the stale
+      # sibling DOES keep the user present.
+      Process.exit(fresh, :kill)
+      assert_receive {:ws_all_hidden, "pia"}, 200
       assert_ws_count("pia", 1)
-      refute_receive {:ws_all_hidden, "pia"}, 100
 
-      send(fresh, :stop)
+      send(stale, :stop)
     end
 
     test "a demoted socket reporting visible again fires :ws_visible (the disarm)" do

--- a/test/grappa/ws_presence_test.exs
+++ b/test/grappa/ws_presence_test.exs
@@ -27,6 +27,13 @@ defmodule Grappa.WSPresenceTest do
     :ok
   end
 
+  # #224 — drive the demotion tick on the shared singleton. Its own timer is
+  # parked for the whole run (`config/test.exs`), so the tick a test wants is
+  # the tick it asks for; nothing arrives on its own.
+  defp sweep_now do
+    send(Process.whereis(WSPresence), :sweep)
+  end
+
   defp stub_pid do
     spawn(fn ->
       receive do
@@ -412,6 +419,145 @@ defmodule Grappa.WSPresenceTest do
       refute_receive {:ws_all_hidden, "lena"}, 100
 
       send(stale, :stop)
+    end
+  end
+
+  describe "#224 — the stale-demotion sweep trips auto-away" do
+    # #224 — in the field a socket sat `:visible` for ~2 days with nothing
+    # foregrounded: the hidden/close signal was lost and the pid never went
+    # DOWN, so none of the three transition doors ever ran and auto-away was
+    # blocked indefinitely. Read-time staleness (#318) discounted the pid for
+    # PUSH but emitted nothing, so the FSM never heard about it.
+    #
+    # The sweep demotes an aged-out `:visible` entry to `:hidden` and runs the
+    # same emission door as every other write. The demotion (rather than a
+    # bare emit) is what makes a re-tick idempotent AND what lets a returning
+    # client emit `:ws_visible` again — both pinned below.
+    #
+    # The singleton's own timer is parked in `config/test.exs`, so these drive
+    # the tick explicitly; the last case starts its own instance to prove the
+    # timer exists and re-arms.
+
+    test "a stale :visible socket is demoted and fires :ws_all_hidden" do
+      p = stub_pid()
+      :ok = WSPresence.register_with_notify("mara", p, self())
+      :ok = WSPresence.set_visibility("mara", p, true)
+      assert_receive {:ws_visible, "mara"}, 200
+
+      # The device stops affirming visibility — no hidden report, no close,
+      # no DOWN. Exactly the field shape.
+      :ok = WSPresence.mark_stale_for_test("mara", p)
+      # Pre-state: nothing has fired yet, and the socket is still tracked.
+      # Without this the assertion below could pass on a leftover event.
+      refute_receive {:ws_all_hidden, "mara"}, 50
+      assert WSPresence.ws_count("mara") == 1
+
+      sweep_now()
+
+      assert_receive {:ws_all_hidden, "mara"}, 200
+      # Demoted, not dropped: the socket is still connected.
+      assert WSPresence.ws_count("mara") == 1
+
+      send(p, :stop)
+    end
+
+    test "a second sweep does not re-fire :ws_all_hidden" do
+      p = stub_pid()
+      :ok = WSPresence.register_with_notify("nadia", p, self())
+      :ok = WSPresence.set_visibility("nadia", p, true)
+      assert_receive {:ws_visible, "nadia"}, 200
+      :ok = WSPresence.mark_stale_for_test("nadia", p)
+
+      sweep_now()
+      assert_receive {:ws_all_hidden, "nadia"}, 200
+
+      # The demotion consumed the ageout; the entry is now plain `:hidden`,
+      # so there is nothing left to transition. A sweep that only EMITTED
+      # would re-arm the debounce here on every tick, forever.
+      sweep_now()
+      refute_receive {:ws_all_hidden, "nadia"}, 100
+
+      send(p, :stop)
+    end
+
+    test "a FRESH :visible socket survives the sweep untouched" do
+      p = stub_pid()
+      :ok = WSPresence.register_with_notify("otto", p, self())
+      :ok = WSPresence.set_visibility("otto", p, true)
+      assert_receive {:ws_visible, "otto"}, 200
+
+      sweep_now()
+
+      refute_receive {:ws_all_hidden, "otto"}, 100
+      # Still visible to BOTH views — the sweep must not fire wide.
+      assert WSPresence.any_visible?("otto")
+    end
+
+    test "only the stale socket is demoted when a fresh sibling is visible" do
+      stale = stub_pid()
+      fresh = stub_pid()
+      :ok = WSPresence.register_with_notify("pia", stale, self())
+      :ok = WSPresence.register_with_notify("pia", fresh, self())
+      :ok = WSPresence.set_visibility("pia", stale, true)
+      :ok = WSPresence.set_visibility("pia", fresh, true)
+      assert_receive {:ws_visible, "pia"}, 200
+
+      :ok = WSPresence.mark_stale_for_test("pia", stale)
+      sweep_now()
+
+      # One device is still foreground, so the user has NOT gone all-hidden.
+      refute_receive {:ws_all_hidden, "pia"}, 100
+      assert WSPresence.any_visible?("pia")
+
+      # But the stale one really was demoted: its death is now a no-op
+      # transition rather than the last-visible-device leaving.
+      Process.exit(stale, :kill)
+      assert_ws_count("pia", 1)
+      refute_receive {:ws_all_hidden, "pia"}, 100
+
+      send(fresh, :stop)
+    end
+
+    test "a demoted socket reporting visible again fires :ws_visible (the disarm)" do
+      p = stub_pid()
+      :ok = WSPresence.register_with_notify("quinn", p, self())
+      :ok = WSPresence.set_visibility("quinn", p, true)
+      assert_receive {:ws_visible, "quinn"}, 200
+
+      :ok = WSPresence.mark_stale_for_test("quinn", p)
+      sweep_now()
+      assert_receive {:ws_all_hidden, "quinn"}, 200
+
+      # The client comes back (heartbeat resumes after a suspend). This MUST
+      # emit, or the sweep arms auto-away with nothing able to cancel it:
+      # against a still-`:visible` entry the report is a no-op transition.
+      :ok = WSPresence.set_visibility("quinn", p, true)
+      assert_receive {:ws_visible, "quinn"}, 200
+
+      send(p, :stop)
+    end
+
+    test "the sweep timer is armed at init and re-arms after each tick" do
+      # Its own instance, with a short window, so the ONLY thing that can
+      # produce the events below is the periodic timer — nothing here sends
+      # `:sweep`. The singleton cannot serve: its tick is parked for the run.
+      {:ok, srv} = GenServer.start_link(WSPresence, stale_ms: 40, sweep_ms: 20)
+      p = stub_pid()
+      :ok = GenServer.call(srv, {:register, "rosa", p, self()})
+
+      :ok = GenServer.call(srv, {:set_visibility, "rosa", p, true})
+      assert_receive {:ws_visible, "rosa"}, 200
+      # First tick after the stamp ages past 40ms.
+      assert_receive {:ws_all_hidden, "rosa"}, 1_000
+
+      # Re-arm: a second ageout is noticed with no further help. An `init`
+      # that scheduled once would pass the assertion above and fail here.
+      :ok = GenServer.call(srv, {:set_visibility, "rosa", p, true})
+      assert_receive {:ws_visible, "rosa"}, 200
+      assert_receive {:ws_all_hidden, "rosa"}, 1_000
+
+      send(p, :stop)
+      GenServer.stop(srv)
     end
   end
 


### PR DESCRIPTION
## The defect

A prod socket sat `:visible` for ~2 days with nothing foregrounded. Auto-away
fires on the `any_visible?/1` `true → false` TRANSITION, and all three doors
that compute it (`set_visibility`, `client_closing`, pid `DOWN`) need a write
that never came. Read-time staleness (#318) already discounted the pid for PUSH
suppression, but it emits nothing when a pid merely ages out, so the FSM never
heard about it. Killing that one socket by hand let both `Session.Server`s reach
`:away_auto` within the debounce — it was the sole blocker.

## The question that decided the design, and its answer

The issue lists three directions, and which one is right turns on a fact nobody
had established: **was the stuck socket still heartbeating?** If not, a
transport idle-timeout would have reaped it and that is the cheap structural
fix. If yes, no timeout can ever help.

**It was heartbeating.** Not because of the "~450k reductions" the issue offers
— that number settles nothing, since reductions accrue from work done FOR a
socket too and every push fanned out to that user passed through it. The answer
comes from structure:

- Phoenix defaults the websocket `:timeout` to **60_000 ms**
  (`Phoenix.Transports.WebSocket.default_config/0`), and
  `Phoenix.Socket.Transport.load_config/2` merges the endpoint's `websocket:`
  list **over** that default. `endpoint.ex` sets no `:timeout`, so 60s is in
  force. "Not configured" is true of the source and false of the behaviour —
  worth flagging, since the triage comment on the issue reads the absence as
  meaning no timeout exists.
- Bandit honours it: `Bandit.WebSocket.Handler.handle_connection/2` returns
  `{:persistent, timeout}`, armed by ThousandIsland as a `:read_timeout` timer.
- That timer resets **only** via `handle_continuation/2`, reached from the
  `:tcp`/`:ssl` inbound clause. Bandit's generic `handle_info/2` — where every
  outbound PubSub push arrives — returns `{:noreply, …}` and never touches it.

So outbound traffic cannot hold a socket open, and one alive for two days was
receiving inbound frames at least every 60s: phx heartbeats, i.e. live JS
timers. **Direction 2 is not unbuilt, it is unavailable** — the mechanism
already exists, already runs, and correctly declined to fire. The connection was
never what died; the visibility report was.

(`WSPresence`'s own #318 "efficacy caveat" makes the same argument at 90 minutes.
I reached it from the transport source before reading that line, which is why
it is recorded as a derivation rather than a citation.)

## The fix

A periodic tick demotes each no-longer-`fresh?/3` `:visible` entry to
`{:hidden, nil}` and runs the **same** `emit_transition/4` door as every other
write. No new state: the stamp, the predicate, the window and the door all
existed. Three non-obvious points:

- **Demote, don't just emit.** Writing the entry is what makes a re-tick
  idempotent; the alternative is an "already emitted" flag beside it — the
  parallel bookkeeping that drifts. Measured, not asserted: the emit-only mutant
  re-fires `:ws_all_hidden` on every tick, forever.
- **The demotion IS the disarm.** A returning client reports `:visible` against
  a `:hidden` entry, which is a real `false → true` flip and cancels the
  debounce. Against a still-`:visible` entry that report emits nothing — so a
  sweep that only emitted would arm auto-away with nothing able to cancel it.
  Arm and disarm are one change.
- **#671's RAW/FRESH split survives.** Tempting to read the sweep as making the
  fresh view fully evented and collapse the two predicates. It does not: a pid
  that goes stale and dies before the next tick is removed by `DOWN` before the
  sweep sees it, and only the RAW `before?` there still produces its transition.
  Collapsing resurrects the #671 bug in a window one tick wide.

`:sweep_ms` defaults to `:stale_ms` (prod sets neither), so worst-case detection
is 120s against a 600s debounce. It is separately injectable for exactly one
reason, stated in the code: `WSPresence` is an app-wide singleton under
`max_cases: 1`, so a tick landing inside another test's `mark_stale_for_test/2`
window would demote a pid that test still expects reported-visible — a
cross-test failure with no local cause. `config/test.exs` parks it.

## Tests

`test/grappa/session/server_test.exs` — the user-visible outcome, the full chain
to a real `AWAY :auto-away` line on the wire: a device reports visible, then
just STOPS affirming it (no hidden report, no close, no DOWN), and auto-away
arms and fires. It asserts the debounce timer is `nil` BEFORE the sweep, so the
post-sweep assertion cannot pass on a pre-armed timer.

Six unit cases in `ws_presence_test.exs` cover demotion, idempotence, the
disarm, the fresh-sibling case, and the timer arming **and re-arming** (its own
short-interval instance; nothing sends `:sweep`, so only the periodic timer can
produce the events).

**The red was read, on two mutants, after committing the fix.**

- **M1, sweep is a no-op:** `35 tests, 5 failures`. The five are every new
  positive; the survivor is "a FRESH `:visible` socket survives the sweep
  untouched" — the negative that must stay green, proving the guard cannot fire
  wide. All 29 pre-existing cases stayed green, so the sweep regresses nothing
  and nothing pre-existing was already covering it. The e2e case fails with
  `left: nil` on the debounce timer.
- **M2, emit but don't write:** `35 tests, 4 failures` — a different set,
  killing exactly the cases that justify demotion over emission.

M2 caught a vacuous test of mine: the fresh-sibling case originally killed the
STALE socket and refuted `:ws_all_hidden`, which is a no-op transition in all
three worlds. It passed against both mutants and proved nothing. Rewritten to
kill the FRESH one, which only goes all-hidden if the stale sibling really was
written — that is the second commit.

## Gate

`scripts/check.sh` → **exit 0** (captured, not inferred): Credo `5318 mods/funs,
found no issues`, Sobelow, `Doctor validation has passed!`, Dialyzer
`Total errors: 0, Skipped: 0`, `8 doctests, 56 properties, 5550 tests, 0
failures`, bats. First run failed Credo on two unregistered Logger metadata
keys; fixed by using the existing `:user` and declaring `:silent_for_ms`.

No `scripts/integration.sh` run — the STACK lane is w2's and I did not take it.
I do not believe this needs one: the change is server-internal with no wire,
REST or cic surface, and the outcome is already proven to a real IRC `AWAY` line
against the in-process `Grappa.IRCServer` fake, in the COMPILE lane. If you
disagree, schedule it rather than take my word.

## What I refused to claim

- **That the field socket's client was foregrounded.** I established that it was
  sending inbound frames, which is what kills direction 2. WHY the visibility
  report stopped while phx heartbeats continued is not established — a lost
  push during a channel rejoin fits, so does a `visibilitychange` that never
  fired. The fix does not depend on knowing, which is the point of making it
  freshness-based rather than edge-based.
- **That this was reproduced against the real prod socket.** No worker touched
  m42. Everything here is repo-cold plus the local suite.
- **That the demotion is free.** A demoted entry is indistinguishable from a
  page that reported hidden, so `/admin/ws_presence` can no longer tell "swept"
  from "reported". A third visibility atom would preserve it at the cost of
  landing on every consumer of a closed type; instead the `:info` line carries
  the age. If the diagnostic matters more than I judged, that is the knob to
  turn.
- **That `2 × stale_ms` is a measured latency.** It is an upper bound from the
  construction, not an observation.

## Where I think the brief is wrong

Two places, both small.

1. It frames the "~450k reductions" warning as a reason the question might be
   unanswerable, and offers "design for both cases" as the legitimate fallback.
   The warning is right about the reductions and I did not use them — but the
   question turned out to be answerable from a different direction entirely
   (the timeout's reset path), which is stronger than either horn. The lesson I
   would draw is narrower than the brief's: reading code gives you structure,
   and here the STRUCTURE was sufficient because the survival of the socket was
   itself the measurement. Two days of survival under an enforced 60s idle
   timeout is a fact about magnitude that the code makes readable.
2. §4 says "a periodic sweep that flips a long-stale `:visible` to `:hidden` is
   cheap". True, but it undersells what makes it correct: the flip is not a
   tidy-up, it is the carrier of BOTH transitions. Had I built the "cheap"
   version as described — sweep, emit, leave the entry alone — auto-away would
   arm and never disarm, which is a worse bug than the one being fixed. The
   write is the design, not the housekeeping.