### PR TITLE
cic/#1059: keep the send button a mouse-event target across its own activation

### DIFF
--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -420,6 +420,12 @@ const ComposeBox: Component<Props> = (props) => {
 
   // ---- Submit ------------------------------------------------------
 
+  // #1059 — the send button's empty-draft refusal. It is read TWICE, and the
+  // pair is the whole fix: once to grey the button (`aria-disabled`) and once
+  // to refuse the activation. What it must NEVER drive again is the
+  // `disabled` attribute — see the button below for why.
+  const nothingToSend = (): boolean => getDraft(key()).trim() === "";
+
   // #904 — no component-local in-flight gate any more. The store owns the
   // one-deep queue keyed on the WINDOW, and it is the only thing that can
   // tell a second Enter (queue it) from a third (refuse it) — a `sending()`
@@ -597,7 +603,29 @@ const ComposeBox: Component<Props> = (props) => {
           // of the visual swap. Screen readers announce the busy state instead
           // of only the disabled state.
           aria-busy={isSending(key())}
-          disabled={getDraft(key()).trim() === ""}
+          // #1059 — `aria-disabled`, NEVER `disabled`. A disabled form control
+          // is not a mouse-event target, and #925 moved this button's send
+          // from `click` to `pointerup`, which on a real tap runs BEFORE
+          // `mousedown`: the send empties the draft, an attribute-driven
+          // refusal would flip `disabled` on mid-tap, and the `mousedown`
+          // carrying the #59 focus-steal cancel below would never be
+          // dispatched. Focus leaves the textarea and iOS collapses the
+          // keyboard — tapping Send dismissed it while Enter did not, which is
+          // exactly the asymmetry #1059 was reported with.
+          //
+          // The invariant: THE SEND BUTTON MUST REMAIN A MOUSE-EVENT TARGET
+          // ACROSS ITS OWN ACTIVATION, because that is where the
+          // keyboard-preserve cancel lives. `:565` already carries this lesson
+          // for the textarea (readOnly, not disabled, for the same keyboard).
+          // Deferring the flip by a frame would also close the window and is
+          // deliberately NOT the fix: it makes the guard timing-dependent,
+          // which is the shape of the bug, not of its remedy.
+          //
+          // The refusal it replaces is not lost — it moved into `onPointerUp`,
+          // where an activation is what has to be refused. `.compose-box
+          // button[aria-disabled="true"]` carries the greying that
+          // `:disabled` used to (default.css).
+          aria-disabled={nothingToSend()}
           // #59: keep the textarea focused when sending via the button.
           // Tapping a <button> moves focus off the textarea, which collapses
           // the native on-screen keyboard (Android especially). The cancel
@@ -630,6 +658,12 @@ const ComposeBox: Component<Props> = (props) => {
             if (!releasedInside(e.currentTarget.getBoundingClientRect(), e.clientX, e.clientY)) {
               return;
             }
+            // #1059 — the empty-draft refusal, now that the button is no
+            // longer `disabled` and so genuinely receives this event. The pump
+            // would no-op an empty body anyway, but an activation that reaches
+            // it has already armed the click swallow, so refuse it here where
+            // the control's own affordance says it is refused.
+            if (nothingToSend()) return;
             sentFromPointer = true;
             void doSubmit();
           }}

--- a/cicchetto/src/__tests__/ComposeBox.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBox.test.tsx
@@ -414,6 +414,46 @@ describe("ComposeBox", () => {
       expect(btn.hasAttribute("disabled")).toBe(false);
     });
 
+    // The two below reach the MECHANISM, not just the attribute, and they can
+    // do so in jsdom for a reason that is worth stating: Solid DELEGATES
+    // `mousedown` (it is in dom-expressions' DelegatedEvents set) and its
+    // delegated dispatcher skips a node's handler when `node.disabled` —
+    // `if (handler && !node.disabled)`, solid-js/web eventHandler. So the #59
+    // cancel dies on a disabled send button in EVERY browser, not only where
+    // the browser itself withholds the event. That is also the answer to the
+    // Android half #1059 left open: `keepKeyboard` is isIos()-gated, so this
+    // per-button handler is Android's only protection, and Solid's guard is
+    // not platform-conditional. Measured here, not read off a spec.
+    it("still cancels the mousedown with an empty draft — the #59 guard must not be inert at rest", () => {
+      vi.mocked(compose_.getDraft).mockReturnValue("");
+      const btn = renderBoxedButton();
+      const md = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
+      btn.dispatchEvent(md);
+      expect(md.defaultPrevented).toBe(true);
+    });
+
+    it("still cancels the mousedown that FOLLOWS its own send — the #1059 tap, in order", () => {
+      // The real iOS tap: pointerup → mousedown → mouseup → click. #925 put
+      // the send on the first of those, so by the time the second arrives the
+      // draft is already empty. Replay exactly that and require the cancel to
+      // survive it — this is the sequence the reporter's keyboard died on.
+      const [draft, setDraft_] = createSignal("hi");
+      vi.mocked(compose_.getDraft).mockImplementation(() => draft());
+      vi.mocked(compose_.submit).mockImplementation(async () => {
+        setDraft_("");
+        return { ok: true };
+      });
+
+      const btn = renderBoxedButton();
+      btn.dispatchEvent(pointer("pointerdown", ...CENTRE));
+      btn.dispatchEvent(pointer("pointerup", ...CENTRE));
+      expect(draft()).toBe("");
+
+      const md = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
+      btn.dispatchEvent(md);
+      expect(md.defaultPrevented).toBe(true);
+    });
+
     it("refuses an activation on an empty draft at the control, not at the pump", () => {
       // Keeping the button enabled means a real browser now DOES deliver this
       // pointerup (before the fix the control was inert), so the refusal has

--- a/cicchetto/src/__tests__/ComposeBox.test.tsx
+++ b/cicchetto/src/__tests__/ComposeBox.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { createSignal } from "solid-js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // #904 — the send queue lives in the store, keyed on the window, and
 // ComposeBox is a VIEW over it: the spinner, the readOnly refusal and the
@@ -226,71 +226,73 @@ describe("ComposeBox", () => {
   //   synthesize mouse events for still sends. The synthetic click that
   //   follows a normal tap must NOT send a second time.
   //
-  // Needs a non-empty draft throughout — the button is disabled (and so
-  // fires no pointer events at all) while the draft is empty.
+  // Needs a non-empty draft throughout — an empty one is refused at the top
+  // of the activation handler, so no send would go out to assert on. (Before
+  // #1059 the refusal was the `disabled` attribute, and the button was inert
+  // rather than refusing; the sibling block below is why that changed.)
+  // jsdom's getBoundingClientRect returns an all-zero rect, which the
+  // release-inside guard reads as "the pointer came up off the button".
+  // Give the button a real box so the geometry under test is the one the
+  // production predicate sees, not a degenerate one.
+  const BUTTON_RECT = { left: 300, right: 344, top: 500, bottom: 544 };
+
+  function renderBoxedButton(): HTMLElement {
+    render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
+    const btn = screen.getByRole("button", { name: /send message/i });
+    Object.defineProperty(btn, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({
+        ...BUTTON_RECT,
+        width: BUTTON_RECT.right - BUTTON_RECT.left,
+        height: BUTTON_RECT.bottom - BUTTON_RECT.top,
+        x: BUTTON_RECT.left,
+        y: BUTTON_RECT.top,
+        toJSON() {},
+      }),
+    });
+    return btn;
+  }
+
+  // jsdom's PointerEvent constructor is unreliable (same workaround as
+  // ResizeHandle.test.tsx): a MouseEvent carries every field the handlers
+  // read — clientX/clientY, pointerId, preventDefault.
+  function pointer(type: string, x: number, y: number): Event {
+    const e = new MouseEvent(type, { bubbles: true, cancelable: true, clientX: x, clientY: y });
+    Object.defineProperty(e, "pointerId", { value: 1 });
+    return e;
+  }
+
+  const CENTRE: [number, number] = [322, 522];
+
   describe("#925 — send button activation", () => {
-    // jsdom's getBoundingClientRect returns an all-zero rect, which the
-    // release-inside guard reads as "the pointer came up off the button".
-    // Give the button a real box so the geometry under test is the one the
-    // production predicate sees, not a degenerate one.
-    const BUTTON_RECT = { left: 300, right: 344, top: 500, bottom: 544 };
-
-    function renderWithDraft(): HTMLElement {
-      render(() => <ComposeBox networkSlug="freenode" channelName="#a" />);
-      const btn = screen.getByRole("button", { name: /send message/i });
-      Object.defineProperty(btn, "getBoundingClientRect", {
-        configurable: true,
-        value: () => ({
-          ...BUTTON_RECT,
-          width: BUTTON_RECT.right - BUTTON_RECT.left,
-          height: BUTTON_RECT.bottom - BUTTON_RECT.top,
-          x: BUTTON_RECT.left,
-          y: BUTTON_RECT.top,
-          toJSON() {},
-        }),
-      });
-      return btn;
-    }
-
-    // jsdom's PointerEvent constructor is unreliable (same workaround as
-    // ResizeHandle.test.tsx): a MouseEvent carries every field the handlers
-    // read — clientX/clientY, pointerId, preventDefault.
-    function pointer(type: string, x: number, y: number): Event {
-      const e = new MouseEvent(type, { bubbles: true, cancelable: true, clientX: x, clientY: y });
-      Object.defineProperty(e, "pointerId", { value: 1 });
-      return e;
-    }
-
-    const CENTRE: [number, number] = [322, 522];
-
     beforeEach(() => {
       vi.mocked(compose_.getDraft).mockReturnValue("hi");
       vi.mocked(compose_.submit).mockResolvedValue({ ok: true });
     });
 
     it("does NOT cancel pointerdown — that is the gesture-start signal", () => {
-      const btn = renderWithDraft();
+      const btn = renderBoxedButton();
       const e = pointer("pointerdown", ...CENTRE);
       btn.dispatchEvent(e);
       expect(e.defaultPrevented).toBe(false);
     });
 
     it("#59 — cancels mousedown instead, so focus never leaves the textarea", () => {
-      const btn = renderWithDraft();
+      const btn = renderBoxedButton();
       const e = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
       btn.dispatchEvent(e);
       expect(e.defaultPrevented).toBe(true);
     });
 
     it("sends on pointerup, without waiting for a click", () => {
-      const btn = renderWithDraft();
+      const btn = renderBoxedButton();
       btn.dispatchEvent(pointer("pointerdown", ...CENTRE));
       btn.dispatchEvent(pointer("pointerup", ...CENTRE));
       expect(compose_.submit).toHaveBeenCalledTimes(1);
     });
 
     it("swallows the synthetic click that follows, so a tap sends ONCE", () => {
-      const btn = renderWithDraft();
+      const btn = renderBoxedButton();
       btn.dispatchEvent(pointer("pointerdown", ...CENTRE));
       btn.dispatchEvent(pointer("pointerup", ...CENTRE));
       // detail=1 is what a pointer-generated click reports.
@@ -305,7 +307,7 @@ describe("ComposeBox", () => {
       // sent for it, so swallowing it would drop the send outright. Armed
       // first, deliberately: this is the state a click-less pointer send
       // leaves behind, and the one an Enter must survive.
-      const btn = renderWithDraft();
+      const btn = renderBoxedButton();
       btn.dispatchEvent(pointer("pointerdown", ...CENTRE));
       btn.dispatchEvent(pointer("pointerup", ...CENTRE));
       const click = new MouseEvent("click", { bubbles: true, cancelable: true, detail: 0 });
@@ -316,14 +318,14 @@ describe("ComposeBox", () => {
     });
 
     it("does not send when the finger slides off the button before release", () => {
-      const btn = renderWithDraft();
+      const btn = renderBoxedButton();
       btn.dispatchEvent(pointer("pointerdown", ...CENTRE));
       btn.dispatchEvent(pointer("pointerup", BUTTON_RECT.left - 60, BUTTON_RECT.top - 60));
       expect(compose_.submit).not.toHaveBeenCalled();
     });
 
     it("re-arms after a press that produced no click, so the next tap still sends", () => {
-      const btn = renderWithDraft();
+      const btn = renderBoxedButton();
       // First press: sends on pointerup, and iOS synthesizes no click for it.
       btn.dispatchEvent(pointer("pointerdown", ...CENTRE));
       btn.dispatchEvent(pointer("pointerup", ...CENTRE));
@@ -335,7 +337,92 @@ describe("ComposeBox", () => {
     });
 
     it("ignores a pointerup whose pointerdown never landed on the button", () => {
-      const btn = renderWithDraft();
+      const btn = renderBoxedButton();
+      btn.dispatchEvent(pointer("pointerup", ...CENTRE));
+      expect(compose_.submit).not.toHaveBeenCalled();
+    });
+  });
+
+  // #1059 — the invariant #925 broke: the send button must remain a
+  // MOUSE-EVENT TARGET across its own activation, because that is where the
+  // #59 keyboard-preserve cancel lives (`onMouseDown` → preventDefault, plus
+  // the document-level keepKeyboard capture listener on iOS). A tap on iOS
+  // runs `pointerup` → `mousedown` → `mouseup` → `click`; #925 moved the send
+  // from `click` (after the mousedown) to `pointerup` (before it), so the
+  // draft-clear the send performs now lands BETWEEN the two. While the
+  // refusal was spelled `disabled`, that clear turned the button into a
+  // disabled form control mid-tap, and a browser does not dispatch mouse
+  // events to one — the cancel never ran and iOS collapsed the keyboard.
+  //
+  // WHAT THESE TESTS CAN AND CANNOT SEE. jsdom does NOT reproduce the
+  // suppression: measured here, `dispatchEvent(new MouseEvent("mousedown"))`
+  // on a `disabled` button runs both the element's own handler and a
+  // document-level capture listener (only `.click()` is suppressed). So a
+  // test phrased as "the mousedown still reaches the cancel" passes on the
+  // BROKEN code too — a guard that cannot fail. These assert the INVARIANT
+  // instead of the symptom: the button is never a disabled form control, at
+  // rest or at the instant of activation. The symptom itself — a real
+  // keyboard on real WebKit — is device-only and is NOT claimed here.
+  describe("#1059 — the send button stays a mouse-event target", () => {
+    beforeEach(() => {
+      vi.mocked(compose_.submit).mockResolvedValue({ ok: true });
+    });
+
+    afterEach(() => {
+      vi.mocked(compose_.getDraft).mockReturnValue("");
+    });
+
+    it("expresses an empty draft with aria-disabled, never the disabled attribute", () => {
+      vi.mocked(compose_.getDraft).mockReturnValue("");
+      const btn = renderBoxedButton();
+      expect(btn.hasAttribute("disabled")).toBe(false);
+      expect(btn.getAttribute("aria-disabled")).toBe("true");
+    });
+
+    it("drops aria-disabled once the draft has something to send", () => {
+      vi.mocked(compose_.getDraft).mockReturnValue("hi");
+      const btn = renderBoxedButton();
+      expect(btn.hasAttribute("disabled")).toBe(false);
+      expect(btn.getAttribute("aria-disabled")).toBe("false");
+    });
+
+    it("is still a mouse-event target immediately after its own activation empties the draft", () => {
+      // The production pump takes the text out of the draft SYNCHRONOUSLY, at
+      // the head of `submit` (`takeDraft(key)`, ahead of its first await), so
+      // the emptied draft is observable before the pointerup handler returns
+      // — which is precisely why the flip lands inside the tap. Mirror that
+      // here: an async function body runs synchronously up to its first
+      // await, so this write happens inside `doSubmit`'s call to `submit`.
+      const [draft, setDraft_] = createSignal("hi");
+      vi.mocked(compose_.getDraft).mockImplementation(() => draft());
+      vi.mocked(compose_.submit).mockImplementation(async () => {
+        setDraft_("");
+        return { ok: true };
+      });
+
+      const btn = renderBoxedButton();
+      btn.dispatchEvent(pointer("pointerdown", ...CENTRE));
+      btn.dispatchEvent(pointer("pointerup", ...CENTRE));
+
+      // The send went out…
+      expect(compose_.submit).toHaveBeenCalledTimes(1);
+      // …and the draft it emptied greyed the button without withdrawing it
+      // from mouse-event dispatch, so the `mousedown` that follows this
+      // pointerup still reaches the #59 cancel.
+      expect(draft()).toBe("");
+      expect(btn.getAttribute("aria-disabled")).toBe("true");
+      expect(btn.hasAttribute("disabled")).toBe(false);
+    });
+
+    it("refuses an activation on an empty draft at the control, not at the pump", () => {
+      // Keeping the button enabled means a real browser now DOES deliver this
+      // pointerup (before the fix the control was inert), so the refusal has
+      // to be expressed in the handler. The pump would also no-op an empty
+      // body, but a send that reaches it has already burned the swallow flag
+      // and the in-flight slot.
+      vi.mocked(compose_.getDraft).mockReturnValue("   ");
+      const btn = renderBoxedButton();
+      btn.dispatchEvent(pointer("pointerdown", ...CENTRE));
       btn.dispatchEvent(pointer("pointerup", ...CENTRE));
       expect(compose_.submit).not.toHaveBeenCalled();
     });

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -3412,7 +3412,12 @@ html.resize-dragging * {
   cursor: pointer;
 }
 
-.compose-box button:disabled {
+/* #1059 — keyed on `aria-disabled`, not `:disabled`. The send button must
+   never become a disabled form control: one is not a mouse-event target, and
+   the `mousedown` it would stop receiving is where the #59 keyboard-preserve
+   cancel lives (ComposeBox.tsx states the full arc). This selector is the
+   greying half of that swap — `:disabled` no longer matches anything here. */
+.compose-box button[aria-disabled="true"] {
   opacity: 0.5;
   cursor: not-allowed;
 }

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -34202,3 +34202,73 @@ can no longer tell "swept" from "reported". A third visibility atom would
 have preserved it at the cost of landing on every consumer of a closed
 type, for a diagnostic; instead the `:info` line at the demotion carries
 what the snapshot loses — how long each socket had been silent.
+
+---
+
+## 2026-08-08 — #1059: the send button must stay a mouse-event target across its own activation
+
+A live prod regression, reported in-channel by Fairy on iOS 26.6 with cic
+installed as a PWA: tapping **Send** dismissed the on-screen keyboard,
+pressing **Enter** did not. That asymmetry was the whole diagnosis before a
+line of code was read — the Enter path submits from the textarea's own
+keydown and focus never leaves it; the button path moves focus.
+
+The regression window was #925 (`6cf9529e`), shipped in `0.14.0-ff0511cd`.
+#925 moved the send from `click` to `pointerup` for a good reason (a press
+iOS routes into a long-press synthesises no mouse events at all, so a
+click-carried send silently did nothing — vjt measured that for #366). But
+on a real tap the order is `pointerup` → `mousedown` → `mouseup` → `click`,
+so activation moved from *after* the `mousedown` to *before* it. The send
+empties the draft, the draft drove `disabled`, and the button therefore
+became a disabled form control **between its own activation and the
+`mousedown` that carries the #59 focus-steal cancel**. Focus left the
+textarea; iOS collapsed the keyboard.
+
+**The invariant, written into the code:** the send button must remain a
+mouse-event target across its own activation, because that is where the
+keyboard-preserve cancel lives. `ComposeBox.tsx:565` already carried the
+identical lesson one element over — the textarea is `readOnly`, never
+`disabled`, for exactly this keyboard. The button now matches it: the
+empty-draft refusal is `aria-disabled` plus an early return in the
+activation handler, and `default.css` greys off `[aria-disabled="true"]`
+instead of `:disabled`.
+
+Deferring the `disabled` flip by a frame would also have closed the window
+and was rejected deliberately: it makes the guard timing-dependent, which is
+the shape of this bug rather than of its remedy.
+
+### What was read, what was measured, and what is still owed
+
+The issue was explicit that its steps 3–4 were read off WebKit's documented
+behaviour for disabled form controls, not observed on hardware. Two
+measurements changed what could be claimed:
+
+1. **jsdom does not reproduce the browser-level suppression.**
+   `dispatchEvent(new MouseEvent("mousedown"))` on a `disabled` button runs
+   both the element's own handler and a document-level capture listener;
+   only `.click()` is suppressed. So a regression test phrased as "the
+   mousedown still reaches the cancel" would have passed on the broken code
+   too — a guard that cannot fail, which reads as coverage and is worse than
+   none. Written, run against the unfixed code, and only trusted once red.
+
+2. **The suppression was never only WebKit's.** Solid *delegates*
+   `mousedown` (it is in dom-expressions' `DelegatedEvents`), and its
+   delegated dispatcher skips a node's handler when the node is disabled —
+   `if (handler && !node.disabled)` in `solid-js/web`'s `eventHandler`. The
+   per-button `onMouseDown` was therefore inert on a disabled send button in
+   **every** browser, independently of whether the browser withheld the
+   event. That is reproducible in jsdom, and it is what the regression tests
+   actually pin: the cancel must not be inert at rest, and it must survive
+   the tap replayed in order (pointerup → send → draft empty → mousedown).
+
+Point 2 also settles the Android half #1059 flagged and declined to claim.
+`keepKeyboard`'s document-level listener is `isIos()`-gated, so the
+per-button handler is Android's *only* protection — and Solid's guard is not
+platform-conditional, so Android lost it too. What is shown is that the
+handler did not run; whether an Android keyboard visibly collapsed is not
+claimed.
+
+**Still owed, and not ours:** real-device verification that a tap on Send
+now keeps the iOS keyboard up. No test here observes a keyboard — jsdom has
+none, and Playwright's webkit is not iOS (the same limit that kept #508's
+native-picker fix reasoned rather than device-proven). vjt has the iPhone.


### PR DESCRIPTION
Fixes the live prod regression in #1059: on iOS, tapping **Send** dismissed the
on-screen keyboard while pressing **Enter** did not.

## The bug

#925 (`6cf9529e`) moved the send from `click` to `pointerup` — correctly, since
a press iOS routes into a long-press synthesises no mouse events at all. But on
a real tap the order is `pointerup` → `mousedown` → `mouseup` → `click`, so
activation moved from *after* the `mousedown` to *before* it. The send empties
the draft, the draft drove `disabled`, and the button became a disabled form
control **between its own activation and the `mousedown` that carries the #59
focus-steal cancel**. Focus left the textarea; iOS collapsed the keyboard.

## The fix

`aria-disabled` instead of `disabled`, plus an early return in the activation
handler, so the element never stops being a mouse-event target. `default.css`
greys off `[aria-disabled="true"]`.

The invariant is written into the code: **the send button must remain a
mouse-event target across its own activation, because that is where the
keyboard-preserve cancel lives.** `ComposeBox.tsx:565` already carried the
identical lesson one element over — the textarea is `readOnly`, never
`disabled`, for exactly this keyboard.

Deferring the `disabled` flip by a frame would also close the window; rejected
deliberately, as #1059 suggested — it makes the guard timing-dependent, which
is the shape of the bug rather than of its remedy.

## What I refused to claim, and what the guard can actually do

**I did not confirm the issue's steps 3–4 as written.** The issue was explicit
that "WebKit does not dispatch mouse events to disabled form controls" was read
off documented behaviour, not observed. I did not observe it either — no iOS
device here. What I did instead was measure two things that changed what is
claimable:

1. **jsdom does NOT reproduce the browser-level suppression.** Measured:
   `dispatchEvent(new MouseEvent("mousedown"))` on a `disabled` button runs both
   the element's own handler *and* a document-level capture listener; only
   `.click()` is suppressed. So the natural regression test — "the mousedown
   still reaches the cancel" — passes on the **broken** code too. That guard
   cannot fail, and a guard that cannot fail reads as coverage while being
   worse than none. I did not ship it.

2. **The suppression was never only WebKit's.** Solid *delegates* `mousedown`
   (it is in dom-expressions' `DelegatedEvents`) and its delegated dispatcher
   skips a node's handler when the node is disabled — `if (handler &&
   !node.disabled)`, `solid-js/web` `eventHandler`. So the per-button
   `onMouseDown` was inert on a disabled send button in **every** browser,
   independently of the browser's own behaviour — and *that* is reproducible in
   jsdom.

So the guard that shipped pins the mechanism, not the symptom. Six tests, all
proven red against the unfixed code before being trusted:

- the cancel must not be inert at rest (empty draft → `mousedown` still
  `defaultPrevented`);
- the cancel must survive the #1059 tap **replayed in order** — pointerdown →
  pointerup → send → draft empties → mousedown → still cancelled. This is the
  reporter's sequence, and it is red pre-fix;
- the button is never a disabled form control, at rest or at the instant its
  own activation empties the draft;
- the empty-draft refusal now lives in the handler (the control is no longer
  inert, so it has to refuse rather than not-exist).

Mutation-checked, both halves separately: restoring `disabled=` kills 3
assertions and the two mechanism tests; removing the early return kills exactly
one (`1 failed | 90 passed`).

## The Android half, which #1059 flagged and declined to claim

Point 2 settles it. `keepKeyboard`'s document listener is `isIos()`-gated, so
the per-button handler is Android's **only** protection, and Solid's guard is
not platform-conditional — Android lost it too. What is shown is that the
handler did not run. Whether an Android keyboard visibly collapsed is not
claimed, and no test here observes a keyboard.

## ⚠️ Real-device verification is owed and is NOT mine

**Nothing here observes a keyboard.** jsdom has none; Playwright's webkit is not
iOS (the same limit that left #508's native-picker fix reasoned rather than
device-proven). Specifically still needing @vjt's iPhone:

- that tapping Send now **keeps the keyboard up** on real iOS — the reported
  symptom, end to end;
- that the greyed empty-draft button still **reads and feels disabled** now that
  it is `aria-disabled` rather than `:disabled` (opacity/cursor swap is
  like-for-like in CSS, but the tap affordance is a device judgement);
- Android, if anyone has one handy — same tap, keyboard should stay up.

## Gates

- `scripts/bun.sh run test` — 4741 passed (252 files), exit 0.
- `scripts/bun.sh run check` — exit 0. Biome warnings went 61 → 60; the
  `:disabled` → `[aria-disabled]` swap removed one descending-specificity
  warning.
- Working tree clean before and after both.
- e2e not run locally (it needs an exclusive lane); it rides this PR's CI. No
  e2e spec asserts on the send button's `disabled` state — checked.