### PR TITLE
#1061: make the offline halt un-forgettable, and instrument the burn we have NOT found

### DIFF
--- a/cicchetto/e2e/tests/issue1061-offline-does-nothing.spec.ts
+++ b/cicchetto/e2e/tests/issue1061-offline-does-nothing.spec.ts
@@ -26,19 +26,33 @@
 //
 // ── ON STUBBING `navigator.onLine` RATHER THAN GOING REALLY OFFLINE ──
 //
-// Test 2 uses Playwright's REAL `context.setOffline()`: genuinely no network,
-// a genuine `offline` event, a genuinely false `navigator.onLine`. That is the
-// stronger instrument and it is used wherever it can be.
+// Test 2 uses Playwright's REAL `context.setOffline()`: genuinely no network, a
+// genuine `offline` event, a genuinely false `navigator.onLine`.
 //
 // It cannot be used for test 1, because a cold start that BEGINS offline still
 // has to load the app, and the service worker has no `fetch` handler to serve
-// it from cache. A page that never loads tests nothing. So test 1 stubs the
-// one input the guard reads. That stub is not a proxy for the behaviour under
-// test — it IS the guard's input — and its liveness is proved by the paired
-// positive rather than assumed.
+// it from cache. A page that never loads tests nothing. So test 1 stubs the one
+// input the guard reads. That stub is not a proxy for the behaviour under test
+// — it IS the guard's input — and its liveness is proved by the paired positive
+// rather than assumed.
+//
+// ── THE TWO TESTS USE DIFFERENT ORACLES, AND THAT IS A MEASUREMENT ──
+//
+// The first RED probe of this file (fix neutered, `scripts/integration.sh
+// --grep "#1061"`) came back: test 1 FAILED on its first outcome assertion
+// (`Expected: 0 / Received: 1`), test 2 **PASSED**. A real offline context does
+// not surface cic's attempts to `page.on("websocket")` at all — Chromium
+// refuses them below the level Playwright reports — so the browser-level oracle
+// is BLIND in exactly the case test 2 exists to cover, and the test could not
+// have failed however broken the code was.
+//
+// So test 2 now asserts on `connectAttempts` (see the helper), with the socket
+// count kept as a secondary. Test 1 keeps the browser-level oracle, where it
+// demonstrably works. Neither test was weakened to go green: test 2 was made
+// able to go RED at all.
 
 import { expect, test } from "../fixtures/test";
-import { loginAs } from "../fixtures/cicchettoPage";
+import { expectShellReady, loginAs } from "../fixtures/cicchettoPage";
 import { getSeededVjt } from "../fixtures/seedData";
 
 // Eight rungs of phoenix's default backoff ladder. Long enough that a client
@@ -79,6 +93,34 @@ async function backgroundAndForeground(page: PageLike): Promise<void> {
   await setVisibility(page, "visible");
 }
 
+/**
+ * The monotonic count of connects cic's own door actually made.
+ *
+ * MEASURED, not assumed: with Playwright's real `context.setOffline(true)`,
+ * `page.on("websocket")` does NOT fire for the attempts cic makes — Chromium
+ * refuses the connection below the level Playwright reports. The first RED
+ * probe of test 2 therefore passed with the guard NEUTERED, i.e. the
+ * browser-level oracle is structurally blind in the real-offline case and a
+ * spec resting on it alone could not fail.
+ *
+ * `connectAttempts` is ticked inside `connectUnlessOffline`, on the branch that
+ * dials and never on the suppressed one (pinned by mutation M5). It is an
+ * app-level self-report and therefore the WEAKER oracle — which is why test 1,
+ * where the browser-level count does work, keeps using that instead. Here it is
+ * the only instrument that can see the attempt at all.
+ */
+async function connectAttempts(page: PageLike): Promise<number> {
+  return page.evaluate(() => {
+    const h = (
+      window as unknown as {
+        __cic_socketHealth?: { state: () => { connectAttempts: number } };
+      }
+    ).__cic_socketHealth;
+    if (!h) throw new Error("__cic_socketHealth hook missing");
+    return h.state().connectAttempts;
+  });
+}
+
 test("cold start offline opens no socket at all, across foreground/background transitions (#1061)", async ({
   page,
 }) => {
@@ -92,7 +134,28 @@ test("cold start offline opens no socket at all, across foreground/background tr
   });
   const sockets = countAppSockets(page);
 
-  await loginAs(page, vjt);
+  // NOT `loginAs`. Its last step is `waitForUserTopicReady`, which polls for
+  // the WS user-topic JOIN ack — and an offline client, correctly, never joins
+  // anything. MEASURED: the first GREEN probe of this file failed there with
+  // `page.waitForFunction: Timeout 5000ms exceeded` at
+  // `cicchettoPage.ts:572`, i.e. the FIX working is what the shared fixture's
+  // readiness contract cannot express.
+  //
+  // So the boot is open-coded down to the same REST-driven ready signal
+  // (`expectShellReady` — `.shell-main` visible, "authed shell rendered",
+  // viewport-independent) with the WS gate omitted. That omission is not a
+  // weakened assertion: it is a premise this scenario cannot have, and the
+  // socket count below is precisely the assertion that it does not.
+  await page.addInitScript(
+    ([token, subjectJson]) => {
+      localStorage.setItem("grappa-token", token);
+      localStorage.setItem("grappa-subject", subjectJson);
+      localStorage.setItem("cic.installChoice", "browser");
+    },
+    [vjt.token, vjt.subjectJson] as const,
+  );
+  await page.goto("/");
+  await expectShellReady(page);
 
   // The shell is up — REST is untouched by the stub, which is the point: the
   // app is fully alive and has simply been told the network is dead.
@@ -160,14 +223,20 @@ test("a warm session taken really offline stays silent until the network returns
   await context.setOffline(true);
   await page.waitForTimeout(LADDER_SETTLE_MS);
   const whileOffline = sockets();
+  const attemptsWhileOffline = await connectAttempts(page);
 
   await backgroundAndForeground(page);
   await setVisibility(page, "visible");
   await backgroundAndForeground(page);
   await page.waitForTimeout(LADDER_SETTLE_MS);
-  expect(sockets(), "an offline device must dial nothing, however often it is foregrounded").toBe(
-    whileOffline,
-  );
+
+  // The discriminating assertion. See `connectAttempts` for why the
+  // browser-level count below cannot carry this one on its own.
+  expect(
+    await connectAttempts(page),
+    "an offline device must not even TRY to dial, however often it is foregrounded",
+  ).toBe(attemptsWhileOffline);
+  expect(sockets(), "and no socket reaches the browser either").toBe(whileOffline);
 
   // ── Paired positive again: the real network comes back.
   await context.setOffline(false);

--- a/cicchetto/e2e/tests/issue1061-offline-does-nothing.spec.ts
+++ b/cicchetto/e2e/tests/issue1061-offline-does-nothing.spec.ts
@@ -1,0 +1,177 @@
+// #1061 acceptance 4 — "an e2e test that simulates `navigator.onLine === false`
+// (and the `offline` event) and asserts we do absolutely nothing — no connect
+// attempt, no scheduled retry — across the foreground/background transitions in
+// (1). This is an explicit requirement, not a nice-to-have."
+//
+// WHAT IS ACTUALLY OBSERVED. Not a signal, not a counter cic maintains about
+// itself: `page.on("websocket")` fires on every real WebSocket the browser
+// opens. So "no connect attempt" is measured at the browser, one rung below
+// anything the fix could accidentally satisfy by lying to itself. A retry
+// LADDER, likewise, is not asserted by reading a timer — it is asserted by
+// waiting out the window in which the ladder's own rungs would have fired
+// (phoenix's default `reconnectAfterMs` is [10,50,100,150,200,250,500,1000,
+// 2000] then 5s steady, so 2.5s of quiet is eight rungs that did not happen)
+// and finding the count unmoved.
+//
+// ── WHY EVERY NEGATIVE HERE IS PAIRED, and why that is not decoration ──
+//
+// A spec that only asserts "nothing happened" passes just as happily when the
+// gesture it made was inert — a stubbed event nobody listens to, a page that
+// never finished booting. #1019 removed a backgrounding negative for exactly
+// that reason: the premise could not be established, so the green meant
+// nothing. Every negative below is therefore followed by the SAME gesture
+// under the ONE changed condition (connectivity), which must produce a
+// connection. If the stub were inert, the paired positive fails and the spec
+// goes red — the assertions cannot both be satisfied by a dead harness.
+//
+// ── ON STUBBING `navigator.onLine` RATHER THAN GOING REALLY OFFLINE ──
+//
+// Test 2 uses Playwright's REAL `context.setOffline()`: genuinely no network,
+// a genuine `offline` event, a genuinely false `navigator.onLine`. That is the
+// stronger instrument and it is used wherever it can be.
+//
+// It cannot be used for test 1, because a cold start that BEGINS offline still
+// has to load the app, and the service worker has no `fetch` handler to serve
+// it from cache. A page that never loads tests nothing. So test 1 stubs the
+// one input the guard reads. That stub is not a proxy for the behaviour under
+// test — it IS the guard's input — and its liveness is proved by the paired
+// positive rather than assumed.
+
+import { expect, test } from "../fixtures/test";
+import { loginAs } from "../fixtures/cicchettoPage";
+import { getSeededVjt } from "../fixtures/seedData";
+
+// Eight rungs of phoenix's default backoff ladder. Long enough that a client
+// which resumed retrying would have done so many times over; short enough not
+// to pad the suite.
+const LADDER_SETTLE_MS = 2500;
+
+type PageLike = Parameters<typeof loginAs>[0];
+
+/** Count every app WebSocket the browser opens. Attach BEFORE `goto`. */
+function countAppSockets(page: PageLike): () => number {
+  let opened = 0;
+  page.on("websocket", (ws) => {
+    if (ws.url().includes("/socket")) opened++;
+  });
+  return () => opened;
+}
+
+/**
+ * Drive the two inputs the #254 visibility kick reads. `visibilityState` has
+ * no setter, so the property is redefined and the production event dispatched
+ * — the same idiom as `freshness-on-activation`'s `setTabHidden`.
+ */
+async function setVisibility(page: PageLike, state: "visible" | "hidden"): Promise<void> {
+  await page.evaluate((s) => {
+    Object.defineProperty(document, "visibilityState", { configurable: true, get: () => s });
+    Object.defineProperty(document, "hasFocus", {
+      configurable: true,
+      value: () => s === "visible",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event(s === "visible" ? "focus" : "blur"));
+  }, state);
+}
+
+async function backgroundAndForeground(page: PageLike): Promise<void> {
+  await setVisibility(page, "hidden");
+  await setVisibility(page, "visible");
+}
+
+test("cold start offline opens no socket at all, across foreground/background transitions (#1061)", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+
+  // Offline BEFORE any page script runs: connectivity.ts seeds its signal from
+  // `navigator.onLine` at module-evaluation time, so this is a boot that
+  // begins offline rather than one told about it afterwards.
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "onLine", { configurable: true, get: () => false });
+  });
+  const sockets = countAppSockets(page);
+
+  await loginAs(page, vjt);
+
+  // The shell is up — REST is untouched by the stub, which is the point: the
+  // app is fully alive and has simply been told the network is dead.
+  await page.waitForTimeout(LADDER_SETTLE_MS);
+  expect(sockets(), "a cold start that begins offline must not dial").toBe(0);
+
+  // Foreground once. This is the reported regression: pre-fix, one
+  // visibilitychange→visible re-armed phoenix's ladder for good, because the
+  // `offline` event that would halt it again has already fired (or, on a cold
+  // start, never fires at all).
+  await setVisibility(page, "visible");
+  await page.waitForTimeout(LADDER_SETTLE_MS);
+  expect(sockets(), "one foregrounding must not un-do the offline halt").toBe(0);
+
+  // Background and foreground twice more — nothing accumulates either.
+  await backgroundAndForeground(page);
+  await backgroundAndForeground(page);
+  await page.waitForTimeout(LADDER_SETTLE_MS);
+  expect(sockets(), "repeated transitions must not accumulate attempts").toBe(0);
+
+  // ── The paired positive. Same app, same page, same stubbed transitions;
+  // the ONLY thing that changes is connectivity. If the harness above were
+  // inert this cannot pass, so the three zeroes above are load-bearing.
+  await page.evaluate(() => {
+    Object.defineProperty(navigator, "onLine", { configurable: true, get: () => true });
+    window.dispatchEvent(new Event("online"));
+  });
+  await expect
+    .poll(sockets, { message: "the network returned — suppression must not be stranding" })
+    .toBeGreaterThan(0);
+});
+
+test("a warm session taken really offline stays silent until the network returns (#1061)", async ({
+  page,
+  context,
+}) => {
+  const vjt = getSeededVjt();
+  const sockets = countAppSockets(page);
+
+  await loginAs(page, vjt);
+  await expect
+    .poll(sockets, { message: "the app connects normally when online" })
+    .toBeGreaterThan(0);
+
+  // ── Premise check for the visibility stub, taken while ONLINE. Drop the
+  // socket and hold it down, then make the SAME stubbed transition the
+  // negatives below rely on: it must reconnect. This proves the stub reaches
+  // the #254 handler, and doubles as a no-regression check on that handler.
+  await page.evaluate(async () => {
+    const drop = (window as unknown as { __cic_dropSocketForTests?: () => Promise<void> })
+      .__cic_dropSocketForTests;
+    if (!drop) throw new Error("__cic_dropSocketForTests hook missing");
+    await drop();
+  });
+  const beforeKick = sockets();
+  await setVisibility(page, "visible");
+  await expect
+    .poll(sockets, {
+      message: "the visibility kick must be live for the negatives to mean anything",
+    })
+    .toBeGreaterThan(beforeKick);
+
+  // ── Now genuinely offline: a real `offline` event, a real false
+  // `navigator.onLine`, a real dead network. No stub involved.
+  await context.setOffline(true);
+  await page.waitForTimeout(LADDER_SETTLE_MS);
+  const whileOffline = sockets();
+
+  await backgroundAndForeground(page);
+  await setVisibility(page, "visible");
+  await backgroundAndForeground(page);
+  await page.waitForTimeout(LADDER_SETTLE_MS);
+  expect(sockets(), "an offline device must dial nothing, however often it is foregrounded").toBe(
+    whileOffline,
+  );
+
+  // ── Paired positive again: the real network comes back.
+  await context.setOffline(false);
+  await expect
+    .poll(sockets, { message: "the halt must lift the moment connectivity returns" })
+    .toBeGreaterThan(whileOffline);
+});

--- a/cicchetto/src/__tests__/ErrorBanners.test.tsx
+++ b/cicchetto/src/__tests__/ErrorBanners.test.tsx
@@ -80,9 +80,13 @@ describe("ErrorBanners", () => {
   });
 
   it("renders one stacked slot per active source (distinct DOM nodes, no overlap)", () => {
+    // #1061 — the third source is push-optin, not connectivity: the `ws` entry
+    // is now suppressed while the device is offline, so a ws+connectivity pair
+    // is a state the registry cannot produce and asserting it would pin the
+    // bug this issue removed. The stacking property under test is unchanged.
     tripWs();
-    __setConnectivityForTests(false);
     mockShouldShowRefresh.mockReturnValue(true);
+    mockShouldShowPushOptin.mockReturnValue(true);
     const { container } = render(() => <ErrorBanners />);
 
     const region = container.querySelector(".error-banners");
@@ -94,8 +98,20 @@ describe("ErrorBanners", () => {
     for (const slot of slots) expect(slot.parentElement).toBe(region);
 
     expect(container.querySelector('.error-banner[data-source="ws"]')).not.toBeNull();
-    expect(container.querySelector('.error-banner[data-source="connectivity"]')).not.toBeNull();
+    expect(container.querySelector('.error-banner[data-source="push-optin"]')).not.toBeNull();
     expect(container.querySelector('.error-banner[data-source="bundle-refresh"]')).not.toBeNull();
+  });
+
+  // #1061 defect 3 — the reported screen: "You appear to be offline" with
+  // "WebSocket connection failing — close code 1006" stacked on top of it.
+  it("renders only the connectivity slot when the device is offline, never the ws one", () => {
+    tripWs();
+    __setConnectivityForTests(false);
+    const { container } = render(() => <ErrorBanners />);
+
+    expect(container.querySelector('.error-banner[data-source="connectivity"]')).not.toBeNull();
+    expect(container.querySelector('.error-banner[data-source="ws"]')).toBeNull();
+    expect(container.querySelectorAll(".error-banner")).toHaveLength(1);
   });
 
   it("removes a source's slot automatically when it recovers (auto-clear)", () => {
@@ -111,8 +127,10 @@ describe("ErrorBanners", () => {
 
   // #207 — clicking the × dismisses one banner client-locally; siblings stay.
   it("dismisses only the clicked banner's slot, leaving siblings visible", () => {
+    // #1061 — the sibling is the bundle-refresh slot, not the connectivity
+    // one: ws + connectivity no longer co-occur.
     tripWs();
-    __setConnectivityForTests(false);
+    mockShouldShowRefresh.mockReturnValue(true);
     const { container } = render(() => <ErrorBanners />);
     expect(container.querySelectorAll(".error-banner")).toHaveLength(2);
 
@@ -123,7 +141,7 @@ describe("ErrorBanners", () => {
     if (wsClose) fireEvent.click(wsClose);
 
     expect(container.querySelector('.error-banner[data-source="ws"]')).toBeNull();
-    expect(container.querySelector('.error-banner[data-source="connectivity"]')).not.toBeNull();
+    expect(container.querySelector('.error-banner[data-source="bundle-refresh"]')).not.toBeNull();
   });
 
   // #207 — dismiss re-arms on recovery: a dismissed source that recovers and

--- a/cicchetto/src/__tests__/errorBanners.test.ts
+++ b/cicchetto/src/__tests__/errorBanners.test.ts
@@ -146,16 +146,52 @@ describe("errorBanners registry", () => {
   });
 
   it("stacks all active sources simultaneously (N sources → N entries)", () => {
+    // #1061 — this used to stack `ws` ON TOP OF `connectivity`, which is no
+    // longer a reachable state and was never a correct one (a WS close code is
+    // a SYMPTOM of being offline, not a second fault). The stacking property
+    // is what this test is for, so it now uses four sources that genuinely
+    // co-occur: the device is online and the WS is failing on its own.
     tripWs(1006, "");
+    recordSwRegError({ name: "SecurityError", message: "denied" });
+    mockShouldShowRefresh.mockReturnValue(true);
+    mockShouldShowPushOptin.mockReturnValue(true);
+    const sources = activeBanners().map((e) => e.source);
+    expect(sources).toContain("ws");
+    expect(sources).toContain("sw-registration");
+    expect(sources).toContain("bundle-refresh");
+    expect(sources).toContain("push-optin");
+    expect(activeBanners()).toHaveLength(4);
+  });
+
+  it("stacks the offline entry with the non-WS sources (N sources → N entries)", () => {
+    // The offline twin of the case above — suppression is scoped to the `ws`
+    // entry alone and must not have collapsed the stack in general.
     __setConnectivityForTests(false);
     recordSwRegError({ name: "SecurityError", message: "denied" });
     mockShouldShowRefresh.mockReturnValue(true);
     const sources = activeBanners().map((e) => e.source);
-    expect(sources).toContain("ws");
+    expect(sources).toEqual(["connectivity", "sw-registration", "bundle-refresh"]);
+  });
+
+  // #1061 defect 3 — the two banners the issue reports stacked on screen.
+  it("suppresses the 'ws' entry while the device is offline", () => {
+    tripWs(1006, "");
+    __setConnectivityForTests(false);
+    const sources = activeBanners().map((e) => e.source);
     expect(sources).toContain("connectivity");
-    expect(sources).toContain("sw-registration");
-    expect(sources).toContain("bundle-refresh");
-    expect(activeBanners()).toHaveLength(4);
+    expect(sources).not.toContain("ws");
+  });
+
+  it("restores the 'ws' entry when the device comes back online and the WS is still failing", () => {
+    // Suppression, not deletion: a genuine server-side failure that outlives
+    // the offline episode must still reach the operator. Nothing about the
+    // socket changes here — only connectivity does.
+    tripWs(1006, "");
+    __setConnectivityForTests(false);
+    expect(activeBanners().some((e) => e.source === "ws")).toBe(false);
+
+    __setConnectivityForTests(true);
+    expect(activeBanners().some((e) => e.source === "ws")).toBe(true);
   });
 
   it("orders sw-registration (warn) after the error sources and before the info prompt", () => {
@@ -247,13 +283,16 @@ describe("errorBanners dismiss", () => {
   });
 
   it("dismissBanner hides only the dismissed source, leaving the rest visible", () => {
+    // #1061 — the second source is sw-registration, not connectivity: `ws` and
+    // `connectivity` no longer co-occur, so pairing them here would assert a
+    // state the derivation cannot produce.
     tripWs(1006, "");
-    __setConnectivityForTests(false);
+    recordSwRegError({ name: "SecurityError", message: "denied" });
     expect(activeBanners()).toHaveLength(2);
 
     dismissBanner("ws");
     const visible = visibleBanners();
-    expect(visible.map((e) => e.source)).toEqual(["connectivity"]);
+    expect(visible.map((e) => e.source)).toEqual(["sw-registration"]);
     // activeBanners (the raw derivation) is unchanged — dismiss is a render
     // filter, not a mutation of the source signals.
     expect(activeBanners()).toHaveLength(2);

--- a/cicchetto/src/__tests__/hiddenProbe.test.ts
+++ b/cicchetto/src/__tests__/hiddenProbe.test.ts
@@ -1,0 +1,153 @@
+import { createRoot, createSignal } from "solid-js";
+import { describe, expect, it } from "vitest";
+import {
+  expectedTicks,
+  formatHiddenProbeLine,
+  HIDDEN_TICK_MS,
+  type HiddenCounters,
+  installHiddenProbe,
+} from "../lib/hiddenProbe";
+
+// #1061 — the background-burn instrument. What is under test is the
+// ATTRIBUTION: a line whose counters are wrong is worse than no line, because
+// it would exonerate or convict the socket on a number nobody can check.
+
+describe("expectedTicks", () => {
+  it("floors, so an unthrottled run does not read as a throttled one", () => {
+    expect(expectedTicks(2900)).toBe(2);
+    expect(expectedTicks(3000)).toBe(3);
+  });
+
+  it("is zero for an episode shorter than one tick", () => {
+    expect(expectedTicks(0)).toBe(0);
+    expect(expectedTicks(HIDDEN_TICK_MS - 1)).toBe(0);
+  });
+});
+
+describe("formatHiddenProbeLine", () => {
+  it("reads left to right: duration, tick rate, then the two socket deltas", () => {
+    expect(formatHiddenProbeLine({ hiddenMs: 42_300, ticks: 41, attempts: 0, errors: 0 })).toBe(
+      "hidden 42.3s ticks=41/42 ws-attempts=+0 ws-errors=+0",
+    );
+  });
+
+  it("shows a spinning native ladder as a non-zero error delta", () => {
+    // The signature that would CONVICT the socket: phoenix's own reconnect
+    // ladder running while hidden, one onError per failed attempt.
+    expect(formatHiddenProbeLine({ hiddenMs: 10_000, ticks: 10, attempts: 0, errors: 137 })).toBe(
+      "hidden 10.0s ticks=10/10 ws-attempts=+0 ws-errors=+137",
+    );
+  });
+});
+
+interface Harness {
+  setVisible: (v: boolean) => void;
+  lines: string[];
+  tick: () => void;
+  tickerRunning: () => boolean;
+  advance: (ms: number) => void;
+  setCounters: (c: HiddenCounters) => void;
+}
+
+function harness(opts: { enabled: boolean }): Harness {
+  const [visible, setVisible] = createSignal(true);
+  const lines: string[] = [];
+  let clock = 0;
+  let counters: HiddenCounters = { connectAttempts: 0, errorsTotal: 0 };
+  let onTick: (() => void) | null = null;
+
+  createRoot(() => {
+    installHiddenProbe({
+      isVisible: visible,
+      enabled: () => opts.enabled,
+      push: (line) => lines.push(line),
+      now: () => clock,
+      counters: () => counters,
+      startTicker: (cb) => {
+        onTick = cb;
+        return () => {
+          onTick = null;
+        };
+      },
+    });
+  });
+
+  return {
+    setVisible,
+    lines,
+    tick: () => onTick?.(),
+    tickerRunning: () => onTick !== null,
+    advance: (ms) => {
+      clock += ms;
+    },
+    setCounters: (c) => {
+      counters = c;
+    },
+  };
+}
+
+describe("installHiddenProbe", () => {
+  it("reports one line per hidden episode, with the socket deltas over it", () => {
+    const h = harness({ enabled: true });
+    h.setVisible(false);
+    h.advance(5000);
+    for (let i = 0; i < 5; i++) h.tick();
+    h.setCounters({ connectAttempts: 3, errorsTotal: 12 });
+    h.setVisible(true);
+
+    expect(h.lines).toEqual(["hidden 5.0s ticks=5/5 ws-attempts=+3 ws-errors=+12"]);
+  });
+
+  it("reports deltas, not absolutes — a counter that was already high is not this episode's fault", () => {
+    // The tallies are monotonic across the whole session, so an episode that
+    // opened at 900 errors and closed at 902 saw TWO, not 902. Reading the
+    // absolute here would convict the socket on every episode after the first
+    // bad one.
+    const h = harness({ enabled: true });
+    h.setCounters({ connectAttempts: 40, errorsTotal: 900 });
+    h.setVisible(false);
+    h.advance(1000);
+    h.tick();
+    h.setCounters({ connectAttempts: 40, errorsTotal: 902 });
+    h.setVisible(true);
+
+    expect(h.lines).toEqual(["hidden 1.0s ticks=1/1 ws-attempts=+0 ws-errors=+2"]);
+  });
+
+  it("stops the ticker when the episode ends, so the probe costs nothing while visible", () => {
+    const h = harness({ enabled: true });
+    expect(h.tickerRunning()).toBe(false);
+    h.setVisible(false);
+    expect(h.tickerRunning()).toBe(true);
+    h.setVisible(true);
+    expect(h.tickerRunning()).toBe(false);
+  });
+
+  it("records nothing at all when diagnostics are off", () => {
+    const h = harness({ enabled: false });
+    h.setVisible(false);
+    h.advance(5000);
+    h.setVisible(true);
+    expect(h.lines).toEqual([]);
+    expect(h.tickerRunning()).toBe(false);
+  });
+
+  it("emits one line per episode across repeated background/foreground cycles", () => {
+    const h = harness({ enabled: true });
+    h.setVisible(false);
+    h.advance(2000);
+    h.tick();
+    h.tick();
+    h.setVisible(true);
+    h.advance(1000);
+    h.setVisible(false);
+    h.advance(3000);
+    h.setCounters({ connectAttempts: 0, errorsTotal: 7 });
+    h.setVisible(true);
+
+    expect(h.lines).toEqual([
+      "hidden 2.0s ticks=2/2 ws-attempts=+0 ws-errors=+0",
+      "hidden 3.0s ticks=0/3 ws-attempts=+0 ws-errors=+7",
+    ]);
+  });
+});

--- a/cicchetto/src/__tests__/socket.test.ts
+++ b/cicchetto/src/__tests__/socket.test.ts
@@ -62,6 +62,44 @@ beforeEach(() => {
   h.mockPush.receive.mockReturnValue(h.mockPush);
 });
 
+// #1061 defect 1, cold-start half — a boot that BEGINS offline gets no
+// `offline` event (it already fired, or never fired at all), so
+// `haltForOffline` cannot save it and the guard has to live on the connect
+// path itself. `vi.resetModules()` in beforeEach re-evaluates connectivity.ts
+// too, so stubbing `navigator.onLine` before the dynamic import is a faithful
+// cold start rather than a signal poked after the fact.
+describe("cold start while the device is offline (#1061)", () => {
+  function stubOnLine(value: boolean): void {
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      get: () => value,
+    });
+  }
+
+  afterEach(() => {
+    stubOnLine(true);
+  });
+
+  it("does not connect on module load when the device is already offline", async () => {
+    stubOnLine(false);
+    localStorage.setItem("grappa-token", "tok-offline-boot");
+    await import("../lib/socket");
+    // The Socket is still CONSTRUCTED (the token effect builds it so the
+    // `online` handler has an instance to kick) — it is just never dialled.
+    expect(h.socketCtor).toHaveBeenCalledTimes(1);
+    expect(h.mockSocketInstance.connect).not.toHaveBeenCalled();
+  });
+
+  // The event-driven half of the scenario (foreground while offline, then
+  // `online`) does NOT live here: socket.ts registers its window/document
+  // listeners at module scope with anonymous handlers, so every
+  // `vi.resetModules()` import in this file leaves a live listener behind that
+  // no test can detach. One dispatch then fires N handlers from N module
+  // instances and the count means nothing. That scenario needs exactly one
+  // module instance per jsdom window, which is a whole FILE —
+  // `socketOffline.test.ts`.
+});
+
 describe("socket singleton", () => {
   it("connects on module load when token is non-null", async () => {
     localStorage.setItem("grappa-token", "tok-init");

--- a/cicchetto/src/__tests__/socketOffline.test.ts
+++ b/cicchetto/src/__tests__/socketOffline.test.ts
@@ -1,0 +1,101 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+// #1061 acceptance 1, in jsdom — "with the device offline, cicchetto does
+// NOTHING: no WS connect attempts, no retry ladder, including after the app is
+// foregrounded and backgrounded again while still offline, and including a
+// cold start that begins offline."
+//
+// WHY ITS OWN FILE, and why ONE test rather than four. socket.ts registers its
+// `online` / `offline` / `visibilitychange` listeners at module scope with
+// anonymous handlers — nothing can detach them. So every `vi.resetModules()`
+// re-import inside a file leaves a live listener behind, and one dispatched
+// event then fires N handlers from N module instances, each closing over its
+// OWN connectivity module (seeded from whatever `navigator.onLine` said at ITS
+// import). A count taken after that measures the harness, not the code. One
+// import per jsdom window is the only honest arrangement, and a file is the
+// unit of jsdom window in vitest.
+//
+// The single test is not a bundle of unrelated assertions: it is one
+// continuous offline session, which is exactly what the acceptance describes.
+// Splitting it would need a second module instance to observe the second half.
+
+const h = vi.hoisted(() => {
+  const mockJoinPush = { receive: vi.fn() };
+  mockJoinPush.receive.mockReturnValue(mockJoinPush);
+  const mockChannel = { join: vi.fn(() => mockJoinPush), on: vi.fn(), leave: vi.fn() };
+  const mockSocketInstance = {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    isConnected: vi.fn().mockReturnValue(false),
+    channel: vi.fn(() => mockChannel),
+    onOpen: vi.fn(),
+    onError: vi.fn(),
+    onClose: vi.fn(),
+  };
+  return { mockSocketInstance };
+});
+
+vi.mock("phoenix", () => {
+  class MockSocket {
+    constructor() {
+      Object.assign(this, h.mockSocketInstance);
+    }
+  }
+  return { Socket: MockSocket };
+});
+
+function stubOnLine(value: boolean): void {
+  Object.defineProperty(window.navigator, "onLine", { configurable: true, get: () => value });
+}
+
+function setVisibility(state: "visible" | "hidden"): void {
+  Object.defineProperty(document, "visibilityState", { configurable: true, get: () => state });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+describe("an offline session does nothing (#1061)", () => {
+  beforeAll(async () => {
+    // Offline BEFORE the import: connectivity.ts seeds its signal from
+    // `navigator.onLine` at module-evaluation time, so this is a genuine cold
+    // start that begins offline — not a signal poked after the socket already
+    // dialled once.
+    stubOnLine(false);
+    localStorage.setItem("grappa-token", "tok-offline-session");
+    await import("../lib/socket");
+  });
+
+  it("stays silent across foreground/background transitions, then connects when the network returns", () => {
+    const connect = h.mockSocketInstance.connect;
+
+    // Cold start, offline. The Socket is constructed (the `online` handler
+    // needs an instance to kick) but never dialled.
+    expect(connect).not.toHaveBeenCalled();
+
+    // One foreground while still offline. This is the reported regression: an
+    // unguarded kick re-arms phoenix's whole backoff ladder here, and because
+    // the `offline` event has already fired and will not fire again, nothing
+    // ever halts it. Once is enough to prove it — the ladder is permanent.
+    setVisibility("visible");
+    expect(connect).not.toHaveBeenCalled();
+
+    // Background and foreground again, still offline. Repeated transitions
+    // must not accumulate either.
+    setVisibility("hidden");
+    setVisibility("visible");
+    setVisibility("hidden");
+    setVisibility("visible");
+    expect(connect).not.toHaveBeenCalled();
+
+    // An `offline` event mid-session (a flap the browser reports twice) is
+    // still a halt, never a dial.
+    window.dispatchEvent(new Event("offline"));
+    setVisibility("visible");
+    expect(connect).not.toHaveBeenCalled();
+
+    // The network returns. Suppression must not be stranding: the very same
+    // socket dials exactly once, immediately.
+    stubOnLine(true);
+    window.dispatchEvent(new Event("online"));
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/cicchetto/src/__tests__/socketReconnect.test.ts
+++ b/cicchetto/src/__tests__/socketReconnect.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from "vitest";
-import { haltForOffline, kickReconnect, type ReconnectableSocket } from "../lib/socket";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { __setConnectivityForTests } from "../lib/connectivity";
+import {
+  connectUnlessOffline,
+  haltForOffline,
+  kickReconnect,
+  type ReconnectableSocket,
+} from "../lib/socket";
+import { __resetSocketHealthForTests, socketHealth } from "../lib/socketHealth";
 
 // #119 (vjt refinement) — connectivity-driven reconnect kick. phoenix.js
 // auto-reconnects natively with backoff; the DELTA we add is: on `online`
@@ -29,6 +36,16 @@ function fakeSocket(connected: boolean): ReconnectableSocket & {
     },
   } as ReconnectableSocket & { connected: boolean; connectCalls: number; disconnectCalls: number };
 }
+
+beforeEach(() => {
+  __setConnectivityForTests(true);
+  __resetSocketHealthForTests();
+});
+
+afterEach(() => {
+  __setConnectivityForTests(true);
+  __resetSocketHealthForTests();
+});
 
 describe("kickReconnect (online)", () => {
   it("is a no-op when no socket has been built yet", () => {
@@ -60,5 +77,68 @@ describe("haltForOffline (offline)", () => {
     haltForOffline(s);
     expect(s.disconnectCalls).toBe(1);
     expect(s.connectCalls).toBe(0);
+  });
+});
+
+// #1061 defect 1 — the offline halt must SURVIVE a foregrounding. The `offline`
+// event fires exactly once, so an unguarded kick does not merely retry early:
+// it re-arms phoenix's whole backoff ladder against a dead network with no
+// second event left to stop it, permanently, until connectivity returns.
+describe("kickReconnect while the device is offline (#1061)", () => {
+  it("does not reconnect — one foreground must not un-do the offline halt", () => {
+    const s = fakeSocket(false);
+    __setConnectivityForTests(false);
+    kickReconnect(s);
+    expect(s.connectCalls).toBe(0);
+  });
+
+  it("does not even disconnect — an offline kick touches nothing at all", () => {
+    // The bail is BEFORE the teardown, so a browser reporting a live socket
+    // while `onLine` is false keeps it. Tearing it down would trade a possibly
+    // working connection for a suppressed reconnect.
+    const s = fakeSocket(false);
+    __setConnectivityForTests(false);
+    kickReconnect(s);
+    expect(s.disconnectCalls).toBe(0);
+  });
+
+  it("resumes reconnecting the moment the device is back online", () => {
+    // The guard must suppress, never strand: the same socket that was refused
+    // while offline reconnects on the next kick once connectivity returns.
+    const s = fakeSocket(false);
+    __setConnectivityForTests(false);
+    kickReconnect(s);
+    expect(s.connectCalls).toBe(0);
+
+    __setConnectivityForTests(true);
+    kickReconnect(s);
+    expect(s.connectCalls).toBe(1);
+  });
+});
+
+// #1061 — the ONE door. Every production `connect()` passes through it, which
+// is what makes the guard un-forgettable rather than merely present.
+describe("connectUnlessOffline", () => {
+  it("is a no-op when no socket has been built yet", () => {
+    expect(() => connectUnlessOffline(null)).not.toThrow();
+  });
+
+  it("opens the socket and counts the attempt while online", () => {
+    const s = fakeSocket(false);
+    connectUnlessOffline(s);
+    expect(s.connectCalls).toBe(1);
+    expect(socketHealth().connectAttempts).toBe(1);
+  });
+
+  it("neither opens nor counts an attempt while offline", () => {
+    // The tally must read as "attempts MADE" — a suppressed call that still
+    // ticked the counter would make a held offline halt look like a live retry
+    // loop in the hidden-episode probe, which is the one instrument that has
+    // to be trusted for attribution.
+    const s = fakeSocket(false);
+    __setConnectivityForTests(false);
+    connectUnlessOffline(s);
+    expect(s.connectCalls).toBe(0);
+    expect(socketHealth().connectAttempts).toBe(0);
   });
 });

--- a/cicchetto/src/lib/connectivity.ts
+++ b/cicchetto/src/lib/connectivity.ts
@@ -14,11 +14,21 @@ import { type Accessor, createSignal } from "solid-js";
 // "you are offline" entry (see `errorBanners.ts`), and the deleted origin arm
 // is gone.
 //
-// Scope boundary: this module owns ONLY the UI-facing signal. The SAME
-// online/offline events also drive an immediate WS reconnect kick, but that
-// lives in `socket.ts` (next to the Socket lifecycle) — connectivity has no
-// socket knowledge, socket.ts has no banner knowledge; they just observe the
-// same two window events independently.
+// Scope boundary: this module owns ONLY the connectivity signal — it has no
+// socket knowledge and no banner knowledge. The dependency runs ONE way:
+// `socket.ts` and `errorBanners.ts` both read `isOffline()`; this module reads
+// neither of them.
+//
+// #1061 REVERSES the "they just observe the same two window events
+// independently" note this comment used to carry. Two independent readings of
+// the same browser state can DISAGREE — and when they did, the disagreement
+// was the bug in both directions: the socket kept dialling a network the
+// banner was already calling dead, and the banner stacked a WS close-code
+// entry on top of its own offline entry. One predicate, read by everyone who
+// needs it, is what makes those two states impossible. socket.ts still owns
+// its own `online`/`offline` LISTENERS (the reconnect kick is a socket
+// lifecycle concern, not a UI one); what it no longer owns is a second opinion
+// on whether the device is offline.
 
 const initialOnline = (): boolean => (typeof navigator === "undefined" ? true : navigator.onLine);
 

--- a/cicchetto/src/lib/errorBanners.ts
+++ b/cicchetto/src/lib/errorBanners.ts
@@ -158,7 +158,21 @@ export function activeBanners(): BannerEntry[] {
   // WS health — persistent handshake failures (server refused / dropped the
   // upgrade) surfaced with the real close code + reason. Auto-clears on a
   // clean reconnect (errorCount resets to 0 → below threshold).
-  if (shouldShowBanner()) {
+  //
+  // #1061 — SUPPRESSED while the device is offline. The two entries were
+  // independent, so an offline device stacked "WebSocket connection failing —
+  // close code 1006 (15 consecutive errors)" on top of "You appear to be
+  // offline". That is not two faults, it is one fault reported twice, and the
+  // second report is the WRONG one: a raw close code and a frozen error tally
+  // (`errorCount` only resets in `recordSocketOpen`, so offline it can never
+  // come down) describe a symptom of the first. The connectivity entry states
+  // the actual cause, so it is the one that survives.
+  //
+  // This is a SUPPRESSION, not a merge: nothing is lost. When the device comes
+  // back online and the WS is still failing, the entry returns on its own —
+  // and `rearmDismissed` forgets any × taken on it in the meantime, so a
+  // genuine server-side failure can never be silenced by an offline episode.
+  if (!isOffline() && shouldShowBanner()) {
     entries.push({
       source: "ws",
       severity: "error",

--- a/cicchetto/src/lib/hiddenProbe.ts
+++ b/cicchetto/src/lib/hiddenProbe.ts
@@ -1,0 +1,138 @@
+import { type Accessor, createEffect, on } from "solid-js";
+
+// #1061 — on-device instrument for "cicchetto burns a full core WHILE
+// BACKGROUNDED on a dead or flaky network". NOT a fix, and not evidence of
+// one: this exists because a static read cannot produce a MAGNITUDE, and the
+// source of the burn is still unidentified.
+//
+// WHY THIS SHAPE. The two fixes that ship with it (the offline connect guard,
+// the banner suppression) are real defects, but neither can explain the
+// reported symptom: phoenix guards its own `reconnectTimer` with `pageHidden`
+// and returns WITHOUT rescheduling (phoenix.mjs:1153), and `requestAnimationFrame`
+// does not run while hidden. So the socket path should already be silent in
+// the background — and the honest response to "should be" is to measure it,
+// not to assert it. One line per hidden episode answers exactly the question
+// the static read could not:
+//
+//   * ws-errors climbing while hidden → phoenix's native ladder IS spinning in
+//     the background, contradicting its own pageHidden guard. That would be
+//     the burn, and it would be ours.
+//   * ws-attempts climbing while hidden → something is calling OUR reconnect
+//     door while hidden. Nothing should; if it does, that is the burn.
+//   * both flat, ticks at full rate → the page is being allowed to run in the
+//     background, and the socket is NOT what it is spending the time on. The
+//     WS hypothesis is dead and the search moves elsewhere.
+//   * both flat, ticks far below expected → the page is being throttled or
+//     frozen, and whatever burns the core is not this document's main thread.
+//
+// WHAT THIS CANNOT TELL YOU, and must not be read as telling you: `ticks`
+// below expected is CONFOUNDED. A busy main thread delays a 1s timer, and so
+// does ordinary iOS background throttling — the two are indistinguishable from
+// this number alone. `ticks` is here to separate "the page ran" from "the page
+// was frozen", NOT to measure CPU. A CPU figure needs a Safari Web Inspector
+// profile against the device; nothing here substitutes for that.
+//
+// The probe itself costs one timer tick per second while hidden, and only with
+// the `cic_diag` flag on — it is not armed in an ordinary background session.
+
+export const HIDDEN_TICK_MS = 1000;
+
+// The monotonic tallies read at both ends of an episode. Both come from
+// `socketHealth`; the delta over the episode is what the line reports.
+export interface HiddenCounters {
+  connectAttempts: number;
+  errorsTotal: number;
+}
+
+export interface HiddenEpisode {
+  hiddenMs: number;
+  ticks: number;
+  attempts: number;
+  errors: number;
+}
+
+/**
+ * Ticks a 1Hz timer should have produced across `hiddenMs`, as the denominator
+ * the observed count is read against. Floored: a 2.9s episode owes 2 ticks, and
+ * reporting 2/2 rather than 2/3 keeps an unthrottled run from reading as a
+ * throttled one.
+ */
+export function expectedTicks(hiddenMs: number): number {
+  return Math.max(0, Math.floor(hiddenMs / HIDDEN_TICK_MS));
+}
+
+/** One line per hidden episode — the verdict reads left to right. */
+export function formatHiddenProbeLine(episode: HiddenEpisode): string {
+  const seconds = (episode.hiddenMs / 1000).toFixed(1);
+  return [
+    `hidden ${seconds}s`,
+    `ticks=${episode.ticks}/${expectedTicks(episode.hiddenMs)}`,
+    `ws-attempts=+${episode.attempts}`,
+    `ws-errors=+${episode.errors}`,
+  ].join(" ");
+}
+
+export interface HiddenProbeDeps {
+  isVisible: Accessor<boolean>;
+  /** `isDiagEnabled` in production — nothing runs when diagnostics are off. */
+  enabled: () => boolean;
+  push: (line: string) => void;
+  now: () => number;
+  counters: () => HiddenCounters;
+  /** Start a 1Hz ticker; returns the stop verb. */
+  startTicker: (onTick: () => void) => () => void;
+}
+
+/**
+ * Arm the hidden-episode probe. Nothing runs, and no line is recorded, unless
+ * `enabled()` was true at the moment the page went hidden.
+ *
+ * The gate is read at HIDE time and the episode carries that decision to its
+ * end: a flag flipped mid-episode would otherwise emit a line whose counters
+ * started from a baseline that was never taken.
+ */
+export function installHiddenProbe(deps: HiddenProbeDeps): void {
+  let episodeStart: number | null = null;
+  let baseline: HiddenCounters | null = null;
+  let ticks = 0;
+  let stopTicker: (() => void) | null = null;
+
+  const beginHidden = (): void => {
+    if (!deps.enabled()) return;
+    episodeStart = deps.now();
+    baseline = deps.counters();
+    ticks = 0;
+    stopTicker = deps.startTicker(() => {
+      ticks++;
+    });
+  };
+
+  const endHidden = (): void => {
+    // No open episode: the page became visible without this probe having seen
+    // it go hidden (initial mount, or diagnostics turned on mid-background).
+    // Reporting a line here would invent a baseline.
+    if (episodeStart === null || baseline === null) return;
+    stopTicker?.();
+    stopTicker = null;
+    const now = deps.counters();
+    deps.push(
+      formatHiddenProbeLine({
+        hiddenMs: deps.now() - episodeStart,
+        ticks,
+        attempts: now.connectAttempts - baseline.connectAttempts,
+        errors: now.errorsTotal - baseline.errorsTotal,
+      }),
+    );
+    episodeStart = null;
+    baseline = null;
+  };
+
+  createEffect(
+    on(deps.isVisible, (visible, prev) => {
+      // `prev === undefined` is the initial mount, which is neither a hide nor
+      // a resume.
+      if (prev === true && visible === false) beginHidden();
+      else if (prev === false && visible === true) endHidden();
+    }),
+  );
+}

--- a/cicchetto/src/lib/socket.ts
+++ b/cicchetto/src/lib/socket.ts
@@ -3,8 +3,14 @@ import { createEffect, on } from "solid-js";
 import { channelPushError } from "./api";
 import { token } from "./auth";
 import { canonicalChannel } from "./channelKey";
+import { isOffline } from "./connectivity";
 import { moduleRoot } from "./moduleRoot";
-import { recordSocketClose, recordSocketError, recordSocketOpen } from "./socketHealth";
+import {
+  recordConnectAttempt,
+  recordSocketClose,
+  recordSocketError,
+  recordSocketOpen,
+} from "./socketHealth";
 
 // Phoenix Channels singleton. Mirrors `auth.ts`'s module-singleton shape:
 // every component that needs the live event-push surface joins via the
@@ -182,10 +188,18 @@ moduleRoot(() => {
         s.disconnect();
         _socket = null;
         _userChannel = null;
-        getSocket().connect();
+        // #1061 — through the gated door. A rotation that lands while the
+        // device is offline must not be the thing that starts the ladder; the
+        // rebuilt socket opens on the next `online` kick with the fresh bearer
+        // already captured at construction.
+        connectUnlessOffline(getSocket());
         return;
       }
-      if (!s.isConnected()) s.connect();
+      // #1061 — the COLD-START arm, and the second half of defect 1: a boot
+      // that begins offline never sees an `offline` event (it already fired,
+      // or never fired at all), so `haltForOffline` cannot save it. Only the
+      // door's own check can.
+      if (!s.isConnected()) connectUnlessOffline(s);
     }),
   );
 });
@@ -223,13 +237,42 @@ export interface ReconnectableSocket {
   disconnect(callback?: () => void, code?: number, reason?: string): void;
 }
 
+// #1061 — THE ONE DOOR to phoenix's `connect()`. Every production open goes
+// through here; nothing else in this module may call `s.connect()`.
+//
+// `navigator.onLine === false` is the one direction the browser guarantees:
+// false means there is demonstrably no network (true means only "maybe"). So
+// suppressing on false can never suppress a connect that would have worked,
+// while NOT suppressing it starts phoenix's whole backoff ladder
+// ([10,50,100,150,200,250,500,1000,2000] then 5s steady) against a network we
+// have been told is dead.
+//
+// WHY THE GUARD LIVES INSIDE THE DOOR AND NOT AT THE CALL SITES: that is the
+// entire #1061 defect 1. `haltForOffline` stops the ladder on `offline`, but
+// the `offline` event fires ONCE — so a single caller that forgets the check
+// re-arms the ladder permanently, with no second event left to halt it. A
+// guard three callers must remember is a guard that will be forgotten; a door
+// that cannot be walked around is not.
+export function connectUnlessOffline(s: ReconnectableSocket | null): void {
+  if (s === null) return;
+  if (isOffline()) return;
+  recordConnectAttempt();
+  s.connect();
+}
+
 export function kickReconnect(s: ReconnectableSocket | null): void {
   if (s === null) return;
+  // #1061 — bail BEFORE the disconnect, not just before the connect. On a
+  // browser that still reports a live socket while `onLine` is false, tearing
+  // it down would trade a possibly-working connection for a suppressed
+  // reconnect: strictly worse than doing nothing, which is what an offline
+  // device has asked us to do.
+  if (isOffline()) return;
   if (s.isConnected()) return; // already up — don't tear a healthy socket
   // Force an immediate reconnect: disconnect() cancels any pending native
   // backoff timer and tears the half-open conn, so connect() opens NOW.
   s.disconnect();
-  s.connect();
+  connectUnlessOffline(s);
 }
 
 export function haltForOffline(s: ReconnectableSocket | null): void {
@@ -241,6 +284,15 @@ export function haltForOffline(s: ReconnectableSocket | null): void {
 }
 
 if (typeof window !== "undefined") {
+  // #1061 — LISTENER ORDER IS LOAD-BEARING, and it is guaranteed rather than
+  // hoped for. `kickReconnect` now reads `isOffline()`, so on the `online`
+  // event connectivity's own listener MUST have flipped the signal before this
+  // one runs, or the kick would suppress itself on the very event that means
+  // "you may dial again". ESM evaluates a module's dependencies before its
+  // body, and this module imports `./connectivity` — so connectivity's
+  // listener is always registered first, and same-target listeners fire in
+  // registration order. Do not move the offline predicate to a lazily-created
+  // module, and do not register these listeners from an importer.
   window.addEventListener("online", () => kickReconnect(_socket));
   window.addEventListener("offline", () => haltForOffline(_socket));
   // #254 — iOS PWA wake reconnect kick. On background→foreground iOS can
@@ -251,6 +303,17 @@ if (typeof window !== "undefined") {
   // message sent right after wake has a live subscription for its echo — the
   // echo stays the sole render path (no optimistic local render). Twin of the
   // `online` handler; `kickReconnect` no-ops on an already-healthy socket.
+  //
+  // #1061 defect 2 — this is a SECOND visibilitychange handler: phoenix 1.8.9
+  // registers its own (phoenix.mjs:1113) which, on visible, runs
+  // `if (!isConnected() && !closeWasClean) teardown(() => connect())`. The
+  // difference that matters is the `closeWasClean` precondition. phoenix's
+  // `disconnect()` SETS `closeWasClean = true` (phoenix.mjs:1223), so after
+  // `haltForOffline()` phoenix's own handler correctly declines to reconnect —
+  // ours, being unconditional, was the one that re-armed the ladder. The
+  // `isOffline()` guard now inside `kickReconnect` closes that; whether the
+  // duplicate handler should exist AT ALL on 1.8.9 is a design call recorded
+  // on #1061, deliberately not taken here.
   if (typeof document !== "undefined") {
     document.addEventListener("visibilitychange", () => {
       if (document.visibilityState === "visible") kickReconnect(_socket);
@@ -887,6 +950,11 @@ if (typeof window !== "undefined") {
   };
   // Resume the held socket — phoenix reconnects and auto-rejoins every
   // channel, driving the reconnect-backfill recovery path.
+  //
+  // #1061 — deliberately NOT routed through `connectUnlessOffline`. This is an
+  // explicit test verb ("resume now"), not a production open, and a spec that
+  // stubs `navigator.onLine` to drive some other scenario must still be able
+  // to bring the socket back. Production has no path here.
   window.__cic_resumeSocketForTests = async () => {
     const s = _socket;
     if (!s) return;

--- a/cicchetto/src/lib/socketHealth.ts
+++ b/cicchetto/src/lib/socketHealth.ts
@@ -38,6 +38,19 @@ export interface SocketHealth {
   lastErrorAt: number | null;
   lastCloseCode: number | null;
   lastCloseReason: string;
+  // #1061 — MONOTONIC tallies, never reset by a healthy open. `errorCount` is
+  // an episode counter (reset in recordSocketOpen), which makes it useless for
+  // "did anything retry during the last N seconds": across a recovery it can
+  // go DOWN, so a delta over a window is not a count of attempts.
+  //
+  // `connectAttempts` counts OUR connect door (`connectUnlessOffline`) only.
+  // `errorsTotal` is the proxy for PHOENIX'S OWN ladder, which calls
+  // `this.connect()` internally and never passes our door — one onError per
+  // failed attempt is the only handle we have on it. The two answer different
+  // questions and neither substitutes for the other: attempts climbing means
+  // WE are kicking, errorsTotal climbing means the native ladder is spinning.
+  connectAttempts: number;
+  errorsTotal: number;
 }
 
 export const ERROR_THRESHOLD = 5;
@@ -48,6 +61,8 @@ const initial: SocketHealth = {
   lastErrorAt: null,
   lastCloseCode: null,
   lastCloseReason: "",
+  connectAttempts: 0,
+  errorsTotal: 0,
 };
 
 const [signal, setSignal] = createSignal<SocketHealth>(initial);
@@ -55,12 +70,15 @@ const [signal, setSignal] = createSignal<SocketHealth>(initial);
 export const socketHealth: Accessor<SocketHealth> = signal;
 
 export function recordSocketOpen(): void {
+  const prev = signal();
   setSignal({
     state: "open",
     errorCount: 0,
     lastErrorAt: null,
     lastCloseCode: null,
     lastCloseReason: "",
+    connectAttempts: prev.connectAttempts,
+    errorsTotal: prev.errorsTotal,
   });
 }
 
@@ -72,7 +90,18 @@ export function recordSocketError(): void {
     lastErrorAt: Date.now(),
     lastCloseCode: prev.lastCloseCode,
     lastCloseReason: prev.lastCloseReason,
+    connectAttempts: prev.connectAttempts,
+    errorsTotal: prev.errorsTotal + 1,
   });
+}
+
+// #1061 — one tick per call to `connectUnlessOffline` that actually opened the
+// socket. Deliberately NOT incremented on a suppressed (offline) call: the
+// number must read as "attempts made", so a flat tally across an offline
+// window IS the evidence that the halt held.
+export function recordConnectAttempt(): void {
+  const prev = signal();
+  setSignal({ ...prev, connectAttempts: prev.connectAttempts + 1 });
 }
 
 // Phoenix's onClose receives the underlying CloseEvent. Capture `code`
@@ -89,6 +118,8 @@ export function recordSocketClose(closeEvent: CloseEvent | undefined): void {
     lastErrorAt: prev.lastErrorAt,
     lastCloseCode: closeEvent?.code ?? prev.lastCloseCode,
     lastCloseReason: closeEvent?.reason ?? prev.lastCloseReason,
+    connectAttempts: prev.connectAttempts,
+    errorsTotal: prev.errorsTotal,
   });
 }
 

--- a/cicchetto/src/main.tsx
+++ b/cicchetto/src/main.tsx
@@ -26,6 +26,7 @@ import { mountDisplayPrefsSync } from "./lib/displayPrefs";
 import { isDocumentVisible } from "./lib/documentVisibility";
 import { applyFontSizeFromStorage } from "./lib/fontSize";
 import { installGlobalPaste } from "./lib/globalPaste";
+import { HIDDEN_TICK_MS, installHiddenProbe } from "./lib/hiddenProbe";
 import { installKeyboardPreserve } from "./lib/keepKeyboard";
 import { applyIosClass, isStandalonePwa } from "./lib/platform";
 import { installPushResubscribe } from "./lib/pushResubscribe";
@@ -33,6 +34,7 @@ import { applyDeepLinkFromUrl, installPushTargetListener } from "./lib/pushTarge
 import { browserProbePerformance, installResumeProbe } from "./lib/resumeProbe";
 import { applySidebarWidthsFromStorage } from "./lib/sidebarWidths";
 import { notifyClientClosing, reportVisibility } from "./lib/socket";
+import { socketHealth } from "./lib/socketHealth";
 import { installStaleResumeReload } from "./lib/staleResume";
 import { recordSwRegError, recordSwRegistered } from "./lib/swRegistration";
 import { applyTheme } from "./lib/theme";
@@ -306,6 +308,25 @@ moduleRoot(() => {
     raf: (cb) => void requestAnimationFrame(cb),
     perf: browserProbePerformance(),
     win: window,
+  });
+  // #1061 — background-burn instrument. The mirror image of the resume probe:
+  // that one measures the transition INTO the foreground, this one measures
+  // the interval spent OUT of it, which is where the reported full-core drain
+  // happens and where neither rAF nor a Web Inspector session can reach
+  // without a Mac. Same gate, same one-line-per-episode discipline.
+  installHiddenProbe({
+    isVisible: isDocumentVisible,
+    enabled: isDiagEnabled,
+    push: diagPush,
+    now: () => performance.now(),
+    counters: () => {
+      const h = socketHealth();
+      return { connectAttempts: h.connectAttempts, errorsTotal: h.errorsTotal };
+    },
+    startTicker: (onTick) => {
+      const id = setInterval(onTick, HIDDEN_TICK_MS);
+      return () => clearInterval(id);
+    },
   });
 });
 


### PR DESCRIPTION
Addresses defects 1 and 3 of #1061, records the evidence for defect 2 without
acting on it, and ships the instrument #1061 asks for.

**It does NOT fix the reported CPU burn.** See "What this does not do".

## Defect 1 — the offline halt did not survive a foregrounding

`haltForOffline` stops phoenix's futile retries on the `offline` event, but that
event fires ONCE. `kickReconnect` had no `navigator.onLine` check and the #254
visibilitychange handler called it unconditionally, so a single foreground while
still offline restarted the whole backoff ladder with nothing left to halt it.
The cold-start arm had the same hole and no `offline` event at all.

The fix is ONE gated door, `connectUnlessOffline`, that every production
`connect()` passes through — not three checks at three call sites. A guard three
callers must remember is a guard that will be forgotten; that is the defect
itself. It bails before the teardown as well as before the dial, so a browser
reporting a live socket while `onLine` is false keeps it.

## Defect 3 — the WS close-code banner stacked on the connectivity one

One fault reported twice, and the second report is the wrong one: a raw 1006 and
a frozen error tally are symptoms of being offline. Suppressed, not deleted — it
returns on its own when the device is online and the WS is still failing.

**Four existing tests ASSERTED the stacked pair**, i.e. the defect was
test-locked. Rewritten to pair sources that genuinely co-occur; the stacking
property they exist for is still under test.

## Defect 2 — evidenced, deliberately not acted on

phoenix's own visibilitychange handler is conditional on `!closeWasClean`, and
`disconnect()` SETS that true (`phoenix.mjs:1113`/`:1223`). So phoenix already
declined to reconnect after the halt; **ours, being unconditional, was the sole
re-armer**. That is a stronger case for deleting the #254 handler than "there
are two of them", but it is a design call. Recorded as a comment at the site.

## Instrument

`hiddenProbe` emits one line per hidden episode (duration, timer tick rate, WS
attempt/error deltas) into `diagLog`, which DiagFloat already renders. Backed by
two monotonic tallies on `socketHealth`: `connectAttempts` for our door, and
`errorsTotal` as the only handle on phoenix's internal ladder, which calls
`connect()` on itself and never passes our door. Diag-flag gated.

The module doc states plainly that the tick count is CONFOUNDED — a busy main
thread and ordinary iOS background throttling are indistinguishable from it —
and that nothing here substitutes for a Web Inspector profile.

## Evidence

* cic vitest: **254 files / 4762 tests**, rc=0. `run check` rc=0, `run build` rc=0.
* **Mutation: 9/9 killed** (both guards, the cold-start door, the banner
  suppression, the attempt tally, and four on the probe).
* e2e RED measured on the final spec: `Expected: 0 / Received: 1` (cold start
  dialled) and `Expected: 2 / Received: 5` (three foregroundings, three dials).
  GREEN rc=0; `--repeat-each 3` → 6/6.

Two findings the probes produced that a code read could not, both written into
the spec:

1. `page.on("websocket")` is **blind** under a real offline context — the first
   RED probe PASSED with the fix neutered. Test 2 was not weakened to go green;
   it was made able to go RED at all.
2. `loginAs` cannot boot an offline client, because its last step waits for the
   WS user-topic JOIN ack — that is the FIX working, not failing.

## What this does not do

* **The CPU burn is not fixed, not attributed, not measured.** No magnitude
  appears anywhere in this PR.
* Defect 1's storm is **foreground-only**: phoenix's `reconnectTimer` is
  `pageHidden`-guarded and does not reschedule (`phoenix.mjs:1153`), so it
  cannot explain a sustained background core burn.
* The **flaky-network** case is untouched: on a flaky link `navigator.onLine`
  stays true, so neither guard fires.
* No on-device verification.

## Full integration suite

Two full runs of this branch, one single failure each, **disjoint**:
`issue535` red in run A / green in run B, `issue168` red in B / green in A.
Both are scroll-position specs; neither touches the WS path, and a scoped
`--repeat-each 3` of `issue535` is 6/6 green. That is the disjoint-reds host
signature, not a deterministic regression. I can show the failures are
non-deterministic; I cannot show this change did not raise the flake rate, and I
am not claiming it.