### PR TITLE
#1063: unstick the update path, and correct two of the four claims

### DIFF
--- a/cicchetto/e2e/fixtures/bundleSwap.ts
+++ b/cicchetto/e2e/fixtures/bundleSwap.ts
@@ -60,6 +60,7 @@ const SNAPSHOT_DIR = "/work/dist-test-snapshot-ux-6-i2";
 
 const INDEX_HTML = "index.html";
 const ASSETS_DIR = "assets";
+const SERVICE_WORKER_JS = "service-worker.js";
 
 // Sentinel embedded in synthetic bundle B's index.html script tag +
 // stub JS filename. Used by the H1 self-heal path to detect "previous
@@ -193,6 +194,35 @@ export async function swapToBundleB(): Promise<BundleSwapResult> {
   await fs.rename(tmpPath, htmlPath);
 
   return { newHash, oldHash };
+}
+
+/**
+ * Make `service-worker.js` byte-different without changing what it does,
+ * so the browser installs and activates a genuinely NEW worker.
+ *
+ * #1063 needs this and `swapToBundleB` cannot provide it: that verb only
+ * rewrites `index.html` and drops a stub asset, so the worker bytes are
+ * unchanged, no new worker installs, and `activate` never runs. A spec
+ * that exercised the activate path against `swapToBundleB` alone would be
+ * hollow — it would pass without ever reaching the code under test.
+ *
+ * An appended comment is deliberately the whole change. The worker must
+ * keep working (later specs share this dist), and the thing under test is
+ * the lifecycle, not the worker's behaviour. Returns the token so a caller
+ * can assert the swap landed if it wants to.
+ */
+export async function swapServiceWorker(): Promise<string> {
+  const token = `sw-swap-${process.pid}-${Date.now().toString(36)}`;
+  const swPath = path.join(DIST_DIR, SERVICE_WORKER_JS);
+  const js = await fs.readFile(swPath, "utf8");
+
+  // Same atomic rename as the index.html swap: the browser must never
+  // fetch a half-written worker.
+  const tmpPath = `${swPath}.tmp-${token}`;
+  await fs.writeFile(tmpPath, `${js}\n// ${token}\n`);
+  await fs.rename(tmpPath, swPath);
+
+  return token;
 }
 
 // ── Internal helpers ───────────────────────────────────────────────

--- a/cicchetto/e2e/tests/issue1063-update-delivery.spec.ts
+++ b/cicchetto/e2e/tests/issue1063-update-delivery.spec.ts
@@ -1,0 +1,135 @@
+// #1063 — update delivery: what a real browser can and cannot witness.
+//
+// READ THIS BEFORE ADDING TO THIS FILE. #1063's acceptance 5 asks for a
+// test proving "a client booted on bundle A reaches bundle B after a
+// deploy with no manual cache clearing". Part of that is already covered
+// and part of it is NOT REACHABLE from Playwright; writing the unreachable
+// part anyway would produce a green spec that asserts nothing.
+//
+// COVERED ELSEWHERE: the CLICK path. `bundle-refresh-real-swap.spec.ts`
+// swaps the dist for real and proves one press of the banner converges on
+// the new bundle. Nothing here duplicates it.
+//
+// NOT REACHABLE, and why:
+//
+//   * The activate-navigate path's POSITIVE branch. `navigateStaleClients`
+//     only moves clients that are not visible, and Playwright cannot put a
+//     page in the background: `bringToFront` does not background its
+//     siblings, and headless chromium reports every page as visible. There
+//     is no seam that makes a real browser report a hidden window here, so
+//     the positive branch is pinned by vitest (`swLifecycle.test.ts`) and
+//     the NEGATIVE branch — the gate holding — is pinned below, where a
+//     real worker lifecycle is what makes it meaningful.
+//
+//   * "Refresh converges even when a step hangs." Tempting, and wrong.
+//     `swapToBundleB` leaves `service-worker.js` untouched, so no new
+//     worker installs and the OLD precache still holds the OLD
+//     `index.html`. Convergence there depends entirely on the cache purge,
+//     so hanging the purge and demanding convergence would assert
+//     something the fix does not deliver: #1063's ceiling trades a dead
+//     button for a reload that may not take. That trade is deliberate — a
+//     reload the operator can repeat beats a tap that does nothing — but a
+//     spec must not claim more than it.
+//
+// The two tests below are the part that IS both real and new.
+
+import { expect, test } from "../fixtures/test";
+import { awaitServiceWorkerActive, loginAs } from "../fixtures/cicchettoPage";
+import { getSeededVjt } from "../fixtures/seedData";
+import { snapshotBundle, swapServiceWorker } from "../fixtures/bundleSwap";
+
+test("#1063 — the SPA shell is served with a revalidation policy on the real wire", async ({
+  page,
+}) => {
+  await loginAs(page, getSeededVjt());
+
+  // `page.request` is an APIRequestContext: it bypasses the page AND the
+  // service worker, so this reads what the server actually put on the
+  // wire through the proxy. That is the difference from the ConnCase test,
+  // which can only see the Plug layer — a proxy is free to rewrite headers
+  // and this is where that would show.
+  const shellUrl = new URL("/", page.url()).toString();
+  const resp = await page.request.get(shellUrl);
+
+  expect(resp.status()).toBe(200);
+  // The shell is the sole carrier of the `<script src="/assets/index-<hash>.js">`
+  // tag, so a cached copy re-boots the same bundle forever.
+  expect(resp.headers()["cache-control"] ?? "").toContain("no-cache");
+});
+
+test("#1063 — activating a new worker does not reload the window in use", async ({ page }) => {
+  // The gate from `lib/swLifecycle.ts`: `activate` moves clients nobody is
+  // looking at, and deliberately spares the visible one, because a push
+  // event can trigger a worker update check hours after boot and throwing
+  // away a foreground window mid-use is worse than the stale bundle it
+  // would fix.
+  //
+  // HONEST LABEL: this also passes on pre-#1063 code, where `activate` did
+  // nothing but claim. It is not evidence that the navigate pass works —
+  // that is vitest's job. It exists because "spare the visible client" is
+  // the kind of restraint a later change removes in one line while
+  // believing it is an improvement, and this is the only place a real
+  // browser can object.
+  const snap = await snapshotBundle();
+  try {
+    await loginAs(page, getSeededVjt());
+    await awaitServiceWorkerActive(page);
+
+    // Sentinel on the document. If the window is navigated, the document
+    // is replaced and this is gone — a crisper oracle than watching for a
+    // navigation event, and it cannot be satisfied by a page that merely
+    // looks similar afterwards. Stash the active worker alongside it so
+    // the barrier below compares object identity, not a URL that never
+    // changes across an update.
+    await page.evaluate(async () => {
+      const reg = await navigator.serviceWorker.getRegistration();
+      const w = window as unknown as {
+        __i1063: { alive: boolean; before: ServiceWorker | null };
+      };
+      w.__i1063 = { alive: true, before: reg?.active ?? null };
+    });
+
+    // Byte-different worker on disk. Without this the update check finds
+    // identical bytes, no worker installs, `activate` never fires, and the
+    // assertion below would hold for a reason that has nothing to do with
+    // the gate.
+    await swapServiceWorker();
+
+    // Drive the update explicitly rather than waiting for the browser's
+    // own schedule — the setup is what has to be deterministic.
+    await page.evaluate(async () => {
+      const reg = await navigator.serviceWorker.getRegistration();
+      await reg?.update();
+    });
+
+    // BARRIER: the new worker has actually reached `activated`. Comparing
+    // `reg.active` by object identity is what makes this a real barrier —
+    // the scriptURL is unchanged across an update, so a URL check would
+    // pass instantly and turn the whole spec into a sleep.
+    await page.waitForFunction(
+      async () => {
+        const reg = await navigator.serviceWorker.getRegistration();
+        const w = window as unknown as {
+          __i1063?: { before: ServiceWorker | null };
+        };
+        // A navigated document loses `__i1063`; treat that as "stop
+        // waiting" so the failure is the explicit assertion below rather
+        // than an opaque waitForFunction timeout.
+        if (w.__i1063 === undefined) return true;
+        const active = reg?.active ?? null;
+        return active !== null && active !== w.__i1063.before;
+      },
+      undefined,
+      { timeout: 30_000 },
+    );
+
+    const alive = await page.evaluate(() => {
+      const w = window as unknown as { __i1063?: { alive: boolean } };
+      return w.__i1063?.alive ?? false;
+    });
+
+    expect(alive, "a new worker activated and the visible window was reloaded anyway").toBe(true);
+  } finally {
+    await snap.restore();
+  }
+});

--- a/cicchetto/src/__tests__/bundleHash.test.ts
+++ b/cicchetto/src/__tests__/bundleHash.test.ts
@@ -140,6 +140,10 @@ describe("formatRefreshBanner (#292 — current vs available)", () => {
     });
 
     afterEach(() => {
+      // A test that times out never reaches its inline `useRealTimers`, and
+      // fake timers left installed poison every test after it — the failure
+      // then reads as a cascade rather than as the one red that is real.
+      vi.useRealTimers();
       Object.defineProperty(window, "location", {
         writable: true,
         configurable: true,
@@ -324,6 +328,93 @@ describe("formatRefreshBanner (#292 — current vs available)", () => {
       await refreshPromise;
       expect(reloadSpy).toHaveBeenCalledTimes(1);
       vi.useRealTimers();
+    });
+
+    // #1063 — the controllerchange wait was the ONLY bounded await of the
+    // three. `reg.update()` and the caches purge were unbounded, and a hang
+    // in either never reaches the `finally` that reloads: the tap produces
+    // no reload, no error and no feedback. That silent no-op is the shape
+    // of the reported symptom ("tapping Refresh does not bring the client
+    // forward"), which is why both are pinned here.
+    //
+    // The advance is deliberately far past any ceiling rather than the
+    // exported constant: the test then asserts "bounded", not "bounded at
+    // exactly N", and cannot be greened by an import that does not exist
+    // yet.
+    const FAR_PAST_ANY_CEILING_MS = 30_000;
+
+    it("reloads even when registration.update() never settles", async () => {
+      vi.useFakeTimers();
+      Object.defineProperty(navigator, "serviceWorker", {
+        configurable: true,
+        value: {
+          getRegistration: vi.fn().mockResolvedValue({
+            // Never settles — neither resolve nor reject. A rejection is
+            // already covered by the H2 test above; this is the hang.
+            update: vi.fn(() => new Promise<void>(() => {})),
+            waiting: null,
+            installing: null,
+          }),
+          controller: null,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        },
+      });
+
+      const refreshPromise = performRefresh();
+      await vi.advanceTimersByTimeAsync(FAR_PAST_ANY_CEILING_MS);
+      await refreshPromise;
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("reloads even when the caches purge never settles", async () => {
+      vi.useFakeTimers();
+      Object.defineProperty(navigator, "serviceWorker", {
+        configurable: true,
+        value: {
+          getRegistration: vi.fn().mockResolvedValue(undefined),
+        },
+      });
+      Object.defineProperty(window, "caches", {
+        configurable: true,
+        value: {
+          // `caches.keys()` hanging is the iOS-plausible half: the purge
+          // sits between the SW handshake and the reload, so a hang here
+          // strands the user exactly as an unbounded update() does.
+          keys: vi.fn(() => new Promise<string[]>(() => {})),
+          delete: cachesDeleteSpy,
+        },
+      });
+
+      const refreshPromise = performRefresh();
+      await vi.advanceTimersByTimeAsync(FAR_PAST_ANY_CEILING_MS);
+      await refreshPromise;
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("reloads even when an individual caches.delete() never settles", async () => {
+      vi.useFakeTimers();
+      Object.defineProperty(navigator, "serviceWorker", {
+        configurable: true,
+        value: {
+          getRegistration: vi.fn().mockResolvedValue(undefined),
+        },
+      });
+      Object.defineProperty(window, "caches", {
+        configurable: true,
+        value: {
+          keys: vi.fn().mockResolvedValue(["workbox-precache-v2"]),
+          // The other half: keys() answers, the delete hangs. Bounding only
+          // `keys()` would leave this path stranded, so it gets its own
+          // assertion rather than riding on the one above.
+          delete: vi.fn(() => new Promise<boolean>(() => {})),
+        },
+      });
+
+      const refreshPromise = performRefresh();
+      await vi.advanceTimersByTimeAsync(FAR_PAST_ANY_CEILING_MS);
+      await refreshPromise;
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/cicchetto/src/__tests__/swLifecycle.test.ts
+++ b/cicchetto/src/__tests__/swLifecycle.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import { isSkipWaitingMessage, navigateStaleClients } from "../lib/swLifecycle";
+
+// #1063 — the update-lifecycle half of the service worker, extracted so
+// vitest can drive it (the SW module itself can't be imported under jsdom:
+// it declares the `ServiceWorkerGlobalScope` `self` and pulls in Workbox).
+// Same reason `swNavigate.ts` and `pushPayload.ts` exist.
+
+function client(visibilityState: "hidden" | "visible", url: string) {
+  return {
+    url,
+    visibilityState,
+    navigate: vi.fn<(u: string) => Promise<unknown>>().mockResolvedValue(null),
+  };
+}
+
+describe("navigateStaleClients (#1063)", () => {
+  it("navigates a client nobody is looking at onto its own url", async () => {
+    const hidden = client("hidden", "https://example.test/chat");
+
+    await navigateStaleClients([hidden]);
+
+    // Its OWN url, not "/" — a reload, not a reset to the root. The client
+    // is mid-route and must come back where it was.
+    expect(hidden.navigate).toHaveBeenCalledWith("https://example.test/chat");
+  });
+
+  it("leaves a visible client alone", async () => {
+    const visible = client("visible", "https://example.test/chat");
+
+    await navigateStaleClients([visible]);
+
+    // The gate. A hard reset of the window the operator is looking at is a
+    // worse defect than the stale bundle it would fix.
+    expect(visible.navigate).not.toHaveBeenCalled();
+  });
+
+  it("keeps going when one client's navigate rejects", async () => {
+    const failing = client("hidden", "https://example.test/a");
+    failing.navigate.mockRejectedValue(new Error("client is unloading"));
+    const second = client("hidden", "https://example.test/b");
+
+    await navigateStaleClients([failing, second]);
+
+    // A client can go away between matchAll and navigate. One casualty must
+    // not strand every other window on the old bundle.
+    expect(second.navigate).toHaveBeenCalledWith("https://example.test/b");
+  });
+});
+
+describe("isSkipWaitingMessage (#1063)", () => {
+  it("accepts the message performRefresh actually posts", () => {
+    // Pinned against the literal in `bundleHash.ts` performRefresh. The
+    // whole defect was a post with no listener; a typo on either side puts
+    // it straight back.
+    expect(isSkipWaitingMessage({ type: "SKIP_WAITING" })).toBe(true);
+  });
+
+  it("rejects any other message", () => {
+    // The SW also receives `{type:"navigate"}` from its own notificationclick
+    // path — skipWaiting must not fire on it.
+    expect(isSkipWaitingMessage({ type: "navigate", url: "/" })).toBe(false);
+  });
+
+  it("rejects non-object payloads without throwing", () => {
+    // A message port is an open boundary: anything at all can arrive.
+    expect(isSkipWaitingMessage(null)).toBe(false);
+    expect(isSkipWaitingMessage("SKIP_WAITING")).toBe(false);
+  });
+});

--- a/cicchetto/src/lib/bundleHash.ts
+++ b/cicchetto/src/lib/bundleHash.ts
@@ -188,51 +188,98 @@ export function refreshBannerMessage(): string {
 // proceeds best-effort: a console-noted failure at any step doesn't
 // block the reload, but the operator now has evidence of what fell
 // over if 3-press behavior reappears.
+// #1063 — ONE ceiling, applied to every step of the chain.
+//
+// Pre-#1063 only the `controllerchange` wait was bounded. `reg.update()`
+// and the caches purge were plain awaits, and a hang in either never
+// reaches the `finally` that reloads: the tap produces no reload, no
+// error and no user-visible feedback. That silent no-op is the shape of
+// the symptom #1063 reports, and the comment on the one ceiling that did
+// exist already named the risk ("iOS Safari throttling") — the guard was
+// simply applied to one await out of three.
+//
+// The value is the 2s the `controllerchange` wait already used. Nothing
+// here is worth making the operator wait longer for: every step is
+// best-effort, and arriving at the reload with a step skipped beats not
+// arriving at all.
+const REFRESH_STEP_CEILING_MS = 2000;
+
+/**
+ * Await `work`, but never longer than `REFRESH_STEP_CEILING_MS`.
+ *
+ * Never rejects and never hangs, so a caller can sequence these and still
+ * be sure it reaches its own next line. Both failure modes are distinct in
+ * the log because they mean different things to whoever is reading
+ * devtools after a refresh that did not help: `rejected` is a step that
+ * ran and failed, `exceeded` is a step that never answered at all.
+ */
+async function settleWithin(work: Promise<unknown>, label: string): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const outcome = await Promise.race([
+      work.then(() => "settled" as const),
+      new Promise<"exceeded">((resolve) => {
+        timer = setTimeout(() => resolve("exceeded"), REFRESH_STEP_CEILING_MS);
+      }),
+    ]);
+    if (outcome === "exceeded") {
+      console.warn(`performRefresh: ${label} exceeded its ${REFRESH_STEP_CEILING_MS}ms ceiling`);
+    }
+  } catch (err) {
+    console.warn(`performRefresh: ${label} rejected`, err);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// The claim barrier. Not routed through `settleWithin` because it is an
+// event wait, not a promise: the listener has to come off on BOTH exits or
+// it outlives the wait. Shares the ceiling constant so there is still only
+// one number.
+function awaitControllerChange(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const done = (): void => {
+      navigator.serviceWorker.removeEventListener("controllerchange", done);
+      clearTimeout(timer);
+      resolve();
+    };
+    navigator.serviceWorker.addEventListener("controllerchange", done);
+    const timer = setTimeout(done, REFRESH_STEP_CEILING_MS);
+  });
+}
+
+async function purgeCaches(): Promise<void> {
+  const keys = await caches.keys();
+  await Promise.all(keys.map((key) => caches.delete(key)));
+}
+
 export async function performRefresh(): Promise<void> {
   if (typeof window === "undefined") return;
   try {
     if ("serviceWorker" in navigator) {
       const reg = await navigator.serviceWorker.getRegistration();
       if (reg) {
-        try {
-          await reg.update();
-        } catch (err) {
-          console.warn("performRefresh: registration.update() rejected", err);
-        }
+        await settleWithin(reg.update(), "registration.update()");
         // Message whichever new-SW state we observe — waiting (install
         // already finished) or installing (install in flight). The
         // install handler calls skipWaiting() so it'll transition
         // promptly either way.
         const newSW = reg.waiting ?? reg.installing;
         newSW?.postMessage({ type: "SKIP_WAITING" });
-        // Wait for controllerchange (the new SW claimed all clients)
-        // with a 2s ceiling. Without this the cache purge below races
-        // the activation and we serve stale assets on the next
-        // navigate.
+        // Wait for controllerchange (the new SW claimed all clients).
+        // Without this the cache purge below races the activation and we
+        // serve stale assets on the next navigate.
         if (newSW && navigator.serviceWorker.controller) {
-          await new Promise<void>((resolve) => {
-            const onChange = (): void => {
-              navigator.serviceWorker.removeEventListener("controllerchange", onChange);
-              resolve();
-            };
-            navigator.serviceWorker.addEventListener("controllerchange", onChange);
-            // Ceiling: don't block reload forever if the SW never
-            // transitions (e.g. iOS Safari throttling).
-            setTimeout(() => {
-              navigator.serviceWorker.removeEventListener("controllerchange", onChange);
-              resolve();
-            }, 2000);
-          });
+          await awaitControllerChange();
         }
       }
     }
     if ("caches" in window) {
-      try {
-        const keys = await caches.keys();
-        await Promise.all(keys.map((key) => caches.delete(key)));
-      } catch (err) {
-        console.warn("performRefresh: caches purge failed", err);
-      }
+      // Bounded as a WHOLE: `caches.keys()` and the individual
+      // `caches.delete()` calls are each capable of hanging, and bounding
+      // only the first would leave the second stranded — the one-of-three
+      // mistake this fix exists to undo.
+      await settleWithin(purgeCaches(), "caches purge");
     }
   } finally {
     // Respect the e2e test-seam probe if installed; production code

--- a/cicchetto/src/lib/swLifecycle.ts
+++ b/cicchetto/src/lib/swLifecycle.ts
@@ -1,0 +1,96 @@
+// SW update lifecycle (#1063, 2026-08-08).
+//
+// Extracted from `service-worker.ts` so vitest can pin it — the SW module
+// declares the `ServiceWorkerGlobalScope` `self` and pulls in Workbox, so
+// it cannot be imported under jsdom. Same reason `swNavigate.ts` and
+// `pushPayload.ts` exist.
+//
+// WHY THE WORKER IS INVOLVED IN THIS AT ALL. Every other path that moves a
+// client onto a new bundle runs in the PAGE and needs the server to tell it
+// a deploy happened: the #674 auto-refresh and the manual refresh banner
+// both key off `bundle_hash`, which rides the user-topic WS join. A client
+// whose socket never delivers that push never learns, and no amount of
+// page-side logic fixes it, because the page is the thing that was not
+// told. `/service-worker.js` is served `no-cache`, so the browser re-fetches
+// it and installs the new worker regardless — `activate` is new code
+// running on behalf of an old client, and it is the only lever that does
+// not depend on the page having been informed.
+
+/**
+ * Minimal shape of the `WindowClient`s `activate` navigates. Structural so
+ * vitest can drive it with a plain object and the SW can pass the real
+ * thing.
+ */
+export type ReloadableClient = {
+  readonly url: string;
+  readonly visibilityState: DocumentVisibilityState;
+  navigate: (url: string) => Promise<unknown>;
+};
+
+/**
+ * Reload every window client that nobody is currently looking at, so it
+ * comes back on the bundle this worker just activated.
+ *
+ * THE GATE, and why it is visibility (#1063 asked for this decision to be
+ * made explicitly rather than defaulted):
+ *
+ * Unconditional was rejected. `activate` is not a proxy for "the operator
+ * just opened the app" — a push event triggers a worker update check too,
+ * so an unconditional navigate can throw away a foreground window mid-use,
+ * hours after boot. That is a worse defect than the one being fixed, and it
+ * would be the kind that only shows up in the field.
+ *
+ * Not-visible is the same principle #674 already ships page-side: apply a
+ * deploy when it cannot eat anything the operator was in the middle of.
+ * `visibilityState` is the only signal a worker has to approximate it.
+ *
+ * What this deliberately does NOT cover: a client that boots stale and
+ * stays visible. Opening the app is served the OLD `index.html` out of the
+ * old worker's precache, so the window that most needs this is often the
+ * one the gate spares. It keeps the refresh banner, which is the affordance
+ * that already exists for a window the operator is watching — and whether
+ * that banner's Refresh button actually lands is #1063's other three
+ * defects, not this one.
+ *
+ * KNOWN, from the #182 note in `service-worker.ts`: `clients.matchAll`
+ * visibility is unreliable on iOS PWAs, which often report a foregrounded
+ * window as not visible. The accepted consequence is that iOS navigates
+ * more eagerly than this gate describes. It is survivable rather than
+ * merely tolerated: #772 persists the compose draft in sessionStorage, so
+ * an in-place navigate keeps the text the operator was typing.
+ *
+ * Each client is navigated independently and failures are swallowed: a
+ * client can be torn down between `matchAll` and `navigate`, and one
+ * casualty must not strand the rest on the old bundle.
+ */
+export async function navigateStaleClients(clients: readonly ReloadableClient[]): Promise<void> {
+  await Promise.all(
+    clients
+      .filter((c) => c.visibilityState !== "visible")
+      // Its OWN url: this is a reload, not a reset to the root. The client
+      // is somewhere in the app and must come back there.
+      .map((c) =>
+        c.navigate(c.url).catch((err: unknown) => {
+          console.warn("sw.activate: navigate failed", err);
+        }),
+      ),
+  );
+}
+
+/**
+ * True for the `{type:"SKIP_WAITING"}` message `performRefresh` posts.
+ *
+ * `install` already calls `skipWaiting()` unconditionally, so on a healthy
+ * browser this handshake is redundant — but `performRefresh`'s own comment
+ * describes the post as belt-and-braces "so iOS Safari versions that
+ * throttle install-time skipWaiting still flip", and with no listener on
+ * this side that was fiction: the post was a no-op and the worker stayed
+ * waiting. Handling it is what makes the documented behaviour true. The
+ * alternative #1063 offers — delete the post and the comment — would
+ * instead remove the only lever that exists when install-time skipWaiting
+ * is throttled.
+ */
+export function isSkipWaitingMessage(data: unknown): boolean {
+  if (typeof data !== "object" || data === null) return false;
+  return (data as { type?: unknown }).type === "SKIP_WAITING";
+}

--- a/cicchetto/src/lib/swLifecycle.ts
+++ b/cicchetto/src/lib/swLifecycle.ts
@@ -15,6 +15,25 @@
 // it and installs the new worker regardless — `activate` is new code
 // running on behalf of an old client, and it is the only lever that does
 // not depend on the page having been informed.
+//
+// THE OBJECTION, AND THE MEASUREMENT THAT ANSWERS IT. cic registers with
+// `registerType: "autoUpdate"`, and the generated register code really does
+// carry `addEventListener("controlling", e => e.isUpdate && location.reload())`
+// — read out of the emitted bundle. On that reading the page already
+// reloads itself on a new worker and everything here is a redundant second
+// navigation racing the first. Measured in a real chromium instead: a
+// byte-different worker installed, activated and took control of the page
+// (`controllerchange` fired once, `navigator.serviceWorker.controller`
+// changed) and the page did NOT reload. The claimed tab kept running the
+// bundle it booted with, exactly as #1063 described.
+//
+// The limit of that measurement, so nobody has to re-derive it: the update
+// was driven by an explicit `registration.update()` — the same call
+// `performRefresh` makes — and NOT by the browser's own update check on a
+// navigation. Whether workbox-window flags that path as `isUpdate` and
+// reloads is unmeasured. If someone later finds that it does, the honest
+// consequence is that this pass is redundant for browser-initiated updates
+// and still load-bearing for the refresh path.
 
 /**
  * Minimal shape of the `WindowClient`s `activate` navigates. Structural so

--- a/cicchetto/src/service-worker.ts
+++ b/cicchetto/src/service-worker.ts
@@ -21,7 +21,10 @@
 //     `lib/grappa_web/router.ex` REST scope prefixes.
 //   - skipWaiting + clients.claim is correct for a shell-only
 //     cache where stale assets are never useful (matches the
-//     pre-B0 `registerType: "autoUpdate"` behavior).
+//     pre-B0 `registerType: "autoUpdate"` behavior). #1063
+//     (2026-08-08): claim alone was read as "clients end up on the
+//     new bundle", which it never meant — it transfers control
+//     without reloading. See `activate` below.
 //   - B2 (2026-05-14): push + notificationclick listeners, dedup
 //     via clients.matchAll when a window is focused on the source
 //     URL.
@@ -35,6 +38,7 @@ import { createHandlerBoundToURL, precacheAndRoute } from "workbox-precaching";
 import { NavigationRoute, registerRoute } from "workbox-routing";
 import { shouldSuppressPush } from "./lib/pushDedup";
 import { narrowPushPayload, type PushPayload, pushNotificationOptions } from "./lib/pushPayload";
+import { isSkipWaitingMessage, navigateStaleClients } from "./lib/swLifecycle";
 import { deliverNavigate } from "./lib/swNavigate";
 
 declare const self: ServiceWorkerGlobalScope & {
@@ -93,8 +97,29 @@ self.addEventListener("install", () => {
   self.skipWaiting();
 });
 
+// #1063 — claiming is not enough. `clients.claim()` takes control of open
+// windows; it does not reload them, so a claimed tab keeps executing the
+// bundle it booted with and stays stale indefinitely. The navigate pass is
+// what actually moves clients forward; which ones, and why not all of
+// them, is argued in `lib/swLifecycle.ts`.
 self.addEventListener("activate", (event) => {
-  event.waitUntil(self.clients.claim());
+  event.waitUntil(
+    self.clients
+      .claim()
+      // AFTER the claim, not beside it: `navigate()` requires the client to
+      // be controlled by this worker.
+      .then(() => self.clients.matchAll({ type: "window" }))
+      .then(navigateStaleClients),
+  );
+});
+
+// #1063 — the listener `performRefresh` was already posting to. Without it
+// the post was a no-op; see `isSkipWaitingMessage` for why handling it
+// beats deleting the post.
+self.addEventListener("message", (event) => {
+  if (isSkipWaitingMessage(event.data)) {
+    void self.skipWaiting();
+  }
 });
 
 // ── Web Push (B2, 2026-05-14) ──────────────────────────────────────

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -34313,3 +34313,113 @@ e2e spec was REPLACED, not deleted: it was the only e2e that clicked a dismiss
 and watched the frozen badge fall, so that outcome moves onto the surviving
 door (the bar's ×) in `issue1062-far-behind-float-stack.spec.ts`, alongside the
 removal claim scoped to the stack.
+## 2026-08-08 — #1063: two of the four claims were smaller than reported
+
+#1063 listed four defects breaking one invariant — a client that opens the app
+when an update exists must end up on the latest version — and said plainly that
+the cause of the reported symptom (an iOS PWA stuck on `0.9` while the server
+advertised `0.14`) was not identified. Both halves of that framing held up.
+Two of the four shrank under measurement; the symptom is still unattributed.
+
+**The shell was not served without a cache policy.** The issue's first defect
+rests on `SpaController.index/2` emitting no `cache-control`, so a browser
+applies heuristic freshness and keeps re-booting the same bundle hash. The
+failing assertion said otherwise, literally: `max-age=0, private,
+must-revalidate` — Phoenix's controller default. `max-age=0` plus
+`must-revalidate` already forbids the heuristic freshness the argument depends
+on. The change still landed, but its justification changed with it: the policy
+moved onto the shared `serve/2` so that an incidental framework default became
+a chosen one, and so a third document served out of the bundle root inherits it
+instead of depending on whoever adds it remembering. It is durability, not a
+fix for a stranded client, and the code comment says so at the line.
+
+**For a PWA client the shell's HTTP policy is not in the update path at all.**
+The injected precache manifest carries `{"revision":"b82723f0…","url":"index.html"}`,
+and workbox fetches a revisioned entry with `__WB_REVISION__` appended — a
+different URL per deploy, so the install is a guaranteed HTTP cache miss. What
+actually serves the shell to a controlled client is the precache, via
+`createHandlerBoundToURL("index.html")`, which holds whatever the *currently
+active* worker installed. That is the real staleness mechanism, and it is a
+worker-lifecycle problem, not a caching-header one.
+
+**`clients.claim()` was read as something it never meant.** Claim transfers
+control of open windows; it does not reload them, so a claimed tab keeps
+executing the bundle it booted with. The worker is worth involving because
+every other path that moves a client forward runs in the page and keys off the
+`bundle_hash` user-topic push: the #674 auto-refresh and the manual banner both
+need the server to have told the page. A client whose socket never delivers it
+never learns, and `/service-worker.js` is served `no-cache`, so `activate` is
+new code that runs anyway.
+
+**The gate is not-visible, and it was chosen rather than defaulted.**
+Unconditional navigate was rejected: `activate` is not a proxy for "the operator
+just opened the app", because a push event triggers a worker update check too,
+so an unconditional reload can discard a foreground window mid-use hours after
+boot. Not-visible is the principle #674 already ships page-side — apply a deploy
+when it cannot eat anything in progress — and `visibilityState` is the only
+signal a worker has to approximate it. The uncomfortable half is recorded in
+`lib/swLifecycle.ts` rather than left implicit: this does **not** cover a client
+that boots stale and stays visible, which is the common shape of opening the
+app, because opening it is served the old `index.html` out of the old worker's
+precache. That window keeps the refresh banner. Two premises the issue offered
+for gating were also out of date — #772 persists the compose draft in
+sessionStorage, so an in-place navigate no longer eats what the operator was
+typing, and per the #182 note `matchAll` visibility is unreliable on iOS PWAs,
+so iOS navigates more eagerly than the gate describes.
+
+**The ceiling trades a dead button for a reload that may not take.** Only the
+`controllerchange` wait was bounded; `reg.update()` and the caches purge were
+plain awaits, and a hang in either never reaches the `finally` that reloads — no
+reload, no error, nothing visible. `settleWithin` bounds every step. But the
+purge is what empties the stale precache, so a skipped purge means the reload
+lands on the old shell again. That is the right trade — a reload the operator
+can repeat beats a tap that does nothing — and it is a different claim from "the
+refresh works", which is why the e2e deliberately does not assert convergence
+under a hung purge. It is also the strongest argument for the visible-feedback
+half of acceptance 3, which is not implemented here: the honest mechanism reuses
+`bundleRefreshNotice.ts`'s existing marker (it already carries the departing
+hash), but making `performRefresh` write it would also make a successful manual
+click announce "Updated to X" — a change to #775's behaviour, escalated rather
+than decided.
+
+**The objection that nearly withdrew the navigate pass, and the measurement
+that answered it.** cic registers with `registerType: "autoUpdate"`, and the
+emitted bundle really does carry `addEventListener("controlling", e =>
+e.isUpdate && location.reload())`. Read statically, that says the page already
+reloads itself when a new worker takes control, the whole `activate` pass is
+redundant, and its navigation races the page's own. Measured in a real chromium
+instead: a byte-different worker installed, activated and took control — one
+`controllerchange`, controller object changed — and the page did not reload.
+The claimed tab kept running the bundle it booted with. The static reading was
+wrong and the issue was right. The limit is recorded next to the code: the
+update was driven by an explicit `registration.update()` (the call
+`performRefresh` makes), not by the browser's own check on a navigation, which
+remains unmeasured.
+
+**An unconditional navigate would break the shared e2e barrier.** Discovered by
+mutation, not by review: with the gate removed, the worker navigates the page
+out from under `awaitServiceWorkerActive`'s own `page.reload()` and the fixture
+dies with `net::ERR_ABORTED`. Every spec that uses that barrier would fail, in a
+way that names nothing. That is an argument for the gate independent of the
+UX one above, and it is the reason the gate has a named e2e of its own.
+
+**The `SKIP_WAITING` post had no listener.** `install` calls `skipWaiting()`
+unconditionally, so the handshake is redundant on a healthy browser — but
+`performRefresh`'s comment describes the post as belt-and-braces for iOS
+versions that throttle install-time `skipWaiting`, and with nothing listening
+that was fiction. Handling it makes the documented behaviour true; the
+alternative the issue offered, deleting the post, would remove the only lever
+that exists exactly when `skipWaiting` is throttled.
+
+**What is still not established.** Which defect produced the reported symptom.
+The banner appeared, which means the `bundle_hash` push arrived and
+`shouldShowRefreshBanner()` was true — the page-side trigger worked and
+execution failed, which rules out the claim-but-never-navigate defect as the
+cause. The discriminating measurement the issue names, whether the page reloads
+at all on tap, needs the device and was not taken. No iOS-specific cache
+behaviour was measured, and none is asserted anywhere in the change.
+
+**Adjacent, found and not fixed:** `performRefresh` purges *all* caches,
+including the precache the new worker just populated during its install. The
+next navigation falls back to the network, which is fine online, but the PWA has
+no offline shell until the next worker install — i.e. until the next deploy.

--- a/lib/grappa_web/controllers/spa_controller.ex
+++ b/lib/grappa_web/controllers/spa_controller.ex
@@ -64,12 +64,12 @@ defmodule GrappaWeb.SpaController do
   @doc """
   Serves `service-worker.js` with `Cache-Control: no-cache` (nginx
   parity), so browsers always re-fetch the SW script and PWA updates
-  are never pinned by HTTP caching.
+  are never pinned by HTTP caching. The header itself comes from
+  `serve/2` — see there for why it is not set per-action.
   """
   @spec service_worker(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def service_worker(conn, _) do
     conn
-    |> put_resp_header("cache-control", "no-cache")
     |> put_resp_content_type("text/javascript")
     |> serve("service-worker.js")
   end
@@ -81,9 +81,28 @@ defmodule GrappaWeb.SpaController do
   # actions that delegate here. Content-type is set by the caller with a
   # string literal (avoids an XSS.ContentType false positive on a
   # variable type).
+  #
+  # #1063 — `cache-control: no-cache` is set HERE, not per-action.
+  # Every document served out of the bundle root is an update-delivery
+  # entry point: `service-worker.js` is how a new worker reaches the
+  # browser, and `index.html` is the SOLE carrier of the
+  # `<script src="/assets/index-<hash>.js">` tag that decides which
+  # bundle boots. A stale copy of either pins a client to an old
+  # version. The policy was written for the worker and not the shell,
+  # so it is now structural: a third document added below inherits it.
+  #
+  # MEASURED, against #1063's claim that the shell had "no cache policy
+  # at all": it did — Phoenix's controller default,
+  # `max-age=0, private, must-revalidate`, which already forbids the
+  # heuristic freshness that claim rests on. This line replaces an
+  # incidental framework default with a chosen one that reads the same
+  # in both actions; it is a durability change, NOT a fix for a client
+  # observed stranded on an old bundle.
   @sobelow_skip ["Traversal.SendFile"]
   defp serve(conn, filename) do
     path = Path.join(Bundle.root(), filename)
+
+    conn = put_resp_header(conn, "cache-control", "no-cache")
 
     if File.regular?(path) do
       send_file(conn, 200, path)

--- a/test/grappa_web/spa_serving_test.exs
+++ b/test/grappa_web/spa_serving_test.exs
@@ -113,6 +113,20 @@ defmodule GrappaWeb.SpaServingTest do
       assert ["text/html" <> _] = get_resp_header(conn, "content-type")
     end
 
+    # #1063 — the shell is the SOLE carrier of the
+    # `<script src="/assets/index-<hash>.js">` tag, so a browser that holds a
+    # stale shell re-boots the same bundle on every load and the refresh
+    # banner it raises can never be satisfied. The policy was written for
+    # `service_worker/2` and left off the shell; it now lives on the shared
+    # `serve/2`, so no document served out of the bundle root can ship
+    # without it.
+    test "GET / serves the shell with a revalidation policy" do
+      conn = get(html_conn(), "/")
+      assert conn.status == 200
+      assert [cache_control] = get_resp_header(conn, "cache-control")
+      assert cache_control =~ "no-cache"
+    end
+
     test "GET /a/client/deep/link serves index.html for a browser navigation" do
       conn = get(html_conn(), "/theme/some-shared-id")
       assert conn.status == 200


### PR DESCRIPTION
Four defects were reported on `f71c45bb`. Measured against current `main`, two are
smaller than stated and two are real. What follows separates what was proved from
what was only read, because the issue asks not to be closed on the strength of
these fixes.

## Corrected by measurement

**Defect 1 — "the shell is served with no cache policy at all" is false.** `GET /`
already carried Phoenix's controller default, read literally off the failing
assertion:

```
left:  "max-age=0, private, must-revalidate"
```

That directive already forbids the heuristic freshness the claim depends on. The
commit still lands, but as durability: an incidental framework default replaced by
a chosen one, moved onto the shared `serve/2` so a third document served out of the
bundle root cannot be added without it. It is **not** a fix for the stranded client.

**The shell's HTTP policy is not even in a PWA client's update path.** Built the
bundle and read the injected manifest:

```
{"revision":"b82723f0861c5a9c647a4356b5b38153","url":"index.html"}
```

A revisioned entry is fetched with `__WB_REVISION__` appended, so the precache
install is a guaranteed HTTP cache miss. For a client with an active worker, the
shell arrives through precache, not through HTTP caching.

## Real, and fixed

**Defect 3 — reproduced.** Three new tests hang and time out at 5000ms against the
pre-fix code: `performRefresh` never resolves and `location.reload()` is never
called. `settleWithin` bounds every step. The purge is bounded as a whole, because
`caches.keys()` and each `caches.delete()` can both hang and bounding only the
first repeats the exact one-of-three mistake.

**Defect 2** — `clients.claim()` transfers control without reloading, so a claimed
tab keeps running the bundle it booted with. `activate` now navigates window
clients, gated on not-visible. The gate is argued in `lib/swLifecycle.ts` rather
than defaulted: unconditional was rejected because `activate` is not a proxy for
"the operator just opened the app" (a push triggers an update check too), and
not-visible is the principle #674 already ships page-side. Stated plainly in the
module: this does **not** cover a client that boots stale and stays visible.

**Defect 4** — the `SKIP_WAITING` post had no listener, so `performRefresh`'s
comment describing it as belt-and-braces for iOS versions that throttle
install-time `skipWaiting` was fiction. Handled rather than deleted: deleting
removes the only lever available exactly when `skipWaiting` is throttled.

## Mutation table

Every new assertion was checked by breaking the fix and reading the result.

| mutant | assertions killed |
|---|---|
| remove `serve/2` cache-control | 3 |
| `await reg.update()` unbounded | 2 |
| `void Promise.all(deletes)` | **0 — survived** |
| bound only `caches.keys()` | 1 |
| no visibility gate | 1 |
| gate inverted | 3 |
| no per-client `catch` | 1 |
| navigate to `/` not `client.url` | 2 |
| typo in the `SKIP_WAITING` token | 1 |

The survivor is kept in the table on purpose. That mutant removed the `await`, not
the bounding — it tested nothing, so it proved nothing. Rebuilding it as the real
partial fix (bound `keys()`, leave the deletes free) killed exactly one assertion
and is what shows the two purge tests are not redundant.

## Not established

- **Which defect produced the reported iOS symptom.** The banner appeared, so the
  page-side trigger worked; execution failed. The discriminating measurement the
  issue names — does the page reload at all? — needs the device.
- Any iOS-specific cache behaviour. Not measured, not asserted.

## Also worth knowing

- **The ceiling trades a dead button for a reload that may not take.** When the
  purge is skipped the old precache still serves the old `index.html`. The right
  trade — a reload the operator can repeat beats a tap that does nothing — but not
  the same claim, and it is the strongest argument for the "visible feedback" half
  of acceptance 3, which is deliberately **not** in this PR: the honest mechanism
  reuses `bundleRefreshNotice.ts`'s existing marker, which would change #775's
  behaviour on a successful manual click. That is a UX decision, not a detail.
- `performRefresh` purges **all** caches, including the precache the new worker
  just populated. Fine online; the PWA has no offline shell until the next worker
  install. Pre-existing, not in the four, not fixed here.

## Test plan

- [x] `scripts/test.sh test/grappa_web/spa_serving_test.exs` — red read before green
- [x] `scripts/bun.sh run test` — 4771 passed, 255 files
- [x] `scripts/bun.sh run check` and `run build` — the emitted bundle was grepped to
      confirm the fix survives minification, not just the source
- [x] `scripts/check.sh` — 5551 tests 0 failures, Credo clean, Dialyzer 0 errors
- [ ] **e2e is written but UNRUN** (`issue1063-update-delivery.spec.ts`). It leads
      with what it deliberately cannot test: Playwright cannot background a page, so
      the navigate gate's positive branch is vitest's to pin, and the browser pins
      the negative. The gate test also passes on pre-#1063 code and says so — it
      guards restraint, it is not evidence.
- [ ] Branch is based on `40c5576b`; `main` has since moved to `49804a8e`. CI gates
      the union.