### PR TITLE
e2e(#1050): ask the barrier the same oracle the assertion asks

### DIFF
--- a/cicchetto/e2e/tests/issue1050-list-window-no-float.spec.ts
+++ b/cicchetto/e2e/tests/issue1050-list-window-no-float.spec.ts
@@ -93,9 +93,25 @@ test("@webkit #1050 — the /list window drops the floating ☰, and its ✕ act
   // Nothing about the assertion is relaxed to fix that — the drawer covering
   // the corner mid-animation is the animation WORKING, and it is not the state
   // #1050 is about. What was missing is the pre-state, so it is established
-  // here: the drawer is gone AND its box no longer meets the ✕. Polled on the
-  // geometry rather than slept for 200ms, so the barrier does not hardcode the
+  // here, and NOT slept for 200ms: the barrier does not hardcode the
   // transition and cannot rot if the duration changes.
+  //
+  // THE BARRIER POLLS THE HIT STACK, and the first version of it polled
+  // `getBoundingClientRect` instead — which in webkit is a LIE mid-slide.
+  // Measured on the two identical reds of main `346f7c62` (trace.zip, ms on
+  // the trace clock): the rect barrier answered true at `1302140`, the probe
+  // 17ms later at `1302157` found `aside.shell-members` on top, and the
+  // screencast frames bracketing both (`1302132`, `1302174`) show the drawer
+  // PAINTED at `left≈325` then `left≈378` — still over a ✕ that lives at
+  // `[350..379]`. During an accelerated `transform` transition webkit can
+  // already report the FINAL rect from `getBoundingClientRect` while paint and
+  // `elementFromPoint` are still using the interpolated one. Two oracles, one
+  // instant, opposite answers.
+  //
+  // So the barrier now asks the SAME oracle the assertion below asks. It waits
+  // ONLY for the drawer to leave the ✕'s hit stack — deliberately not for the
+  // ✕ to win it, which would fold the #1050 regression itself into a barrier
+  // timeout and cost the diagnostic stack dump that the probe prints.
   //
   // This is NOT webkit-specific, despite only webkit having reported it: the
   // chromium project `grepInvert`s `@webkit`, so chromium has never run this
@@ -107,11 +123,12 @@ test("@webkit #1050 — the /list window drops the floating ☰, and its ✕ act
         closeBtn.evaluate((el) => {
           const drawer = document.querySelector(".shell-members");
           if (drawer === null) return true;
-          const x = el.getBoundingClientRect();
-          const d = drawer.getBoundingClientRect();
-          return d.left >= x.right || d.right <= x.left || d.top >= x.bottom || d.bottom <= x.top;
+          const r = el.getBoundingClientRect();
+          return !document
+            .elementsFromPoint(r.x + r.width / 2, r.y + r.height / 2)
+            .includes(drawer);
         }),
-      { timeout: 10_000, message: "#1050 — the rail drawer never finished sliding off the ✕" },
+      { timeout: 10_000, message: "#1050 — the rail drawer never left the ✕'s hit stack" },
     )
     .toBe(true);
 


### PR DESCRIPTION
## What this is

`main` `integration` is RED at `346f7c62`, twice, on one spec out of 662:

```
✘ 543 [webkit-iphone-15] tests/issue1050-list-window-no-float.spec.ts:42:1
```

The suspicion was that #1063's `navigateStaleClients` was navigating the page
out from under the spec. **It was not.** The artifacts say so positively, and
they also name the real cause.

## Why the spec fails

The barrier that waits out the members-drawer slide polls
`getBoundingClientRect`. In webkit that is a lie for the duration of an
accelerated `transform` transition: the rect can already read the FINAL value
while paint and `elementFromPoint` are still using the interpolated one.

Measured from `trace.zip`, ms on the trace clock:

| t | event |
|---|---|
| 1302116 | `expect(.shell-members.open).toHaveCount(0)` — passes |
| **1302140** | **rect barrier → TRUE** |
| **1302157** | probe → `aside.shell-members` on top → RED |

The screencast frames bracketing the barrier — `1302132` and `1302174` — show
the drawer **painted** at `left≈325` then `left≈378`, over a ✕ that occupies
`[350..379]`. Two oracles, 17ms apart, opposite answers. Attempt 2 of the run
fails byte-identically, and its frame 66ms before the error shows the same
thing at `left≈311`.

Why it only shows on webkit: it does not. The chromium project
`grepInvert`s `@webkit`, so chromium has **never run this spec**. The shape is
mobile-only (fixed drawer, `tap`).

## What rules out the service worker

Both traces contain exactly **one** document navigation
(`GET /` then `service-worker.js`, no second document fetch, no frame-id
change), and in both the ✕'s element handle survives across barrier → probe.
A `client.navigate()` would have detached it and reported a destroyed
execution context. The `matchAll`-visibility gate did not fire.

## The change

The barrier now asks the SAME oracle the assertion asks — it waits for the
drawer to leave the ✕'s hit STACK:

- it waits for the DRAWER to leave, **not** for the ✕ to win. Waiting for the
  win would fold the #1050 regression itself into a barrier timeout and burn
  the diagnostic layer dump the probe prints;
- point outside the viewport → `elementsFromPoint` returns `[]` → barrier
  passes → the `inViewport` assertion fires, which is the right one for that
  case;
- no `waitForTimeout`, no transition duration baked into the spec;
- the assertion is untouched. The float ☰ coming back still fails it, with the
  stack naming the layer.

## The mutation that proves it — and the attribution experiment

The red is deterministic on CI, so CI is the bench. This branch is
`346f7c62` + the barrier change, with **#1063 still in it**. Criterion
registered before the run:

- **GREEN** ⇒ the barrier was the defect, #1063 is innocent, and reverting
  #1068 would not have turned `main` green.
- **RED** ⇒ the mechanism above is wrong, and the revert is the right move.

`main` with the rect barrier is the other arm: RED twice out of two.

## Test plan

- [ ] `integration` green on this PR (path-filtered on `cicchetto/e2e/**`, so it runs)
- [ ] spec 543 `[webkit-iphone-15]` passes
- [ ] no other spec moves