### PR TITLE
feat(#1070): carry the sender's wire shape in meta.sender_kind

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -348,6 +348,7 @@ config :logger, :console,
     # re-prefix them. In the allowlist to satisfy the known_keys↔metadata
     # sync test even though no Logger call carries it today.
     :sender_prefix,
+    :sender_kind,
     # #591 — CTCP frame classification (Grappa.IRC.CTCP.verb_args/1) tagged onto
     # a :notice (peer's CTCP reply) or :privmsg (own /ctcp /ping self-echo) row.
     # In the allowlist to satisfy the known_keys↔metadata sync test even though

--- a/lib/grappa/scrollback/meta.ex
+++ b/lib/grappa/scrollback/meta.ex
@@ -164,6 +164,8 @@ defmodule Grappa.Scrollback.Meta do
             | :sender_user
             | :sender_host
             | :sender_prefix
+            | :sender_kind
+            | :sender_kind
             | :ctcp_verb
             | :ctcp_args
             | :ctcp_target
@@ -171,7 +173,7 @@ defmodule Grappa.Scrollback.Meta do
           ) => term()
         }
 
-  @known_keys ~w[target new_nick modes args numeric severity who who_target names names_target raw_verb raw_sender raw_params sender_user sender_host sender_prefix ctcp_verb ctcp_args ctcp_target nick_fallback]a
+  @known_keys ~w[target new_nick modes args numeric severity who who_target names names_target raw_verb raw_sender raw_params sender_user sender_host sender_prefix sender_kind ctcp_verb ctcp_args ctcp_target nick_fallback]a
 
   @doc """
   The atom-key allowlist. Exposed so the test suite can assert that

--- a/lib/grappa/scrollback/meta.ex
+++ b/lib/grappa/scrollback/meta.ex
@@ -165,7 +165,6 @@ defmodule Grappa.Scrollback.Meta do
             | :sender_host
             | :sender_prefix
             | :sender_kind
-            | :sender_kind
             | :ctcp_verb
             | :ctcp_args
             | :ctcp_target
@@ -199,6 +198,7 @@ defmodule Grappa.Scrollback.Meta do
           | :sender_user
           | :sender_host
           | :sender_prefix
+          | :sender_kind
           | :ctcp_verb
           | :ctcp_args
           | :ctcp_target

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -428,7 +428,12 @@ defmodule Grappa.Session.EventRouter do
             else: Identifier.canonical_target(target, casemapping(state))
 
         notice_body = "CTCP VERSION query → grappa #{version}"
-        {state2, persist_eff} = build_persist(state, :notice, dm_channel, sender, notice_body, %{})
+        # sender_meta/1, not %{}: this row's sender is a peer nick off a real
+        # wire prefix, and leaving it bare would make an absent key mean
+        # either "prefix-less" or "a CTCP visibility row" — the ambiguity
+        # #1070 exists to remove, one layer down.
+        {state2, persist_eff} =
+          build_persist(state, :notice, dm_channel, sender, notice_body, sender_meta(msg))
 
         {:cont, state2, [{:reply, reply}, persist_eff]}
 
@@ -2785,8 +2790,16 @@ defmodule Grappa.Session.EventRouter do
         do: state.nick,
         else: Identifier.canonical_target(target, casemapping(state))
 
+    # Same as the VERSION row above: a real peer nick, so the key belongs.
     {state2, persist_eff} =
-      build_persist(state, :notice, dm_channel, sender, "CTCP PING query → answered", %{})
+      build_persist(
+        state,
+        :notice,
+        dm_channel,
+        sender,
+        "CTCP PING query → answered",
+        sender_meta(msg)
+      )
 
     {:cont, state2, [{:reply, reply}, persist_eff]}
   end
@@ -3082,6 +3095,9 @@ defmodule Grappa.Session.EventRouter do
   # Additive, same contract as `sender_prefix` above: a consumer that does
   # not know the key behaves exactly as before, and rows persisted earlier
   # simply lack it.
+  # The value set is closed — "user" | "server" — but Elixir typespecs do
+  # not admit string literals ("unexpected expression in typespec"), so it
+  # cannot be stated here. The two clauses below are what guarantee it.
   @spec sender_meta(Message.t()) ::
           %{optional(:sender_kind | :sender_user | :sender_host) => String.t()}
   defp sender_meta(%Message{prefix: {:server, _}}), do: %{sender_kind: "server"}

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -458,7 +458,9 @@ defmodule Grappa.Session.EventRouter do
        when is_binary(channel) and is_binary(body) and
               byte_size(channel) > 0 and
               binary_part(channel, 0, 1) in ["#", "&", "!", "+"] do
-    {state, eff} = build_persist(state, :notice, channel, Message.sender_nick(msg), body, %{})
+    {state, eff} =
+      build_persist(state, :notice, channel, Message.sender_nick(msg), body, sender_meta(msg))
+
     {:cont, state, [eff]}
   end
 
@@ -2344,7 +2346,16 @@ defmodule Grappa.Session.EventRouter do
     # correlate a PING reply's token back to the /ping it sent (RTT synthesized
     # client-side). A non-CTCP notice (NickServ, MOTD, plain peer notice) is
     # `:none` → empty meta, so this is strictly additive.
-    {state, eff} = build_persist(state, :notice, channel, sender, body_to_persist, ctcp_meta(body))
+    {state, eff} =
+      build_persist(
+        state,
+        :notice,
+        channel,
+        sender,
+        body_to_persist,
+        Map.merge(ctcp_meta(body), sender_meta(msg))
+      )
+
     {:cont, state, [eff]}
   end
 
@@ -3055,6 +3066,34 @@ defmodule Grappa.Session.EventRouter do
 
   defp prefix_userhost(%Message{}), do: %{}
 
+  # #1070 — which SHAPE the sender had on the wire.
+  #
+  # `sender_nick/1` returns the same bare string for `{:nick, …}` and
+  # `{:server, …}`, and that string is all a consumer gets. For anything
+  # rendering scrollback back into IRC that is not enough: the prefix
+  # shape is the ONLY thing telling another client whether a NOTICE came
+  # from a user or a server, and clients route the two differently.
+  #
+  # The `$server` window is where the two become indistinguishable —
+  # `persist_server_notice/2` files MOTD and INFO numerics there as
+  # `:notice` with a SERVER sender, while a private notice to the user's
+  # own nick lands on the same window, same kind, with a USER sender.
+  #
+  # Additive, same contract as `sender_prefix` above: a consumer that does
+  # not know the key behaves exactly as before, and rows persisted earlier
+  # simply lack it.
+  @spec sender_meta(Message.t()) ::
+          %{optional(:sender_kind | :sender_user | :sender_host) => String.t()}
+  defp sender_meta(%Message{prefix: {:server, _}}), do: %{sender_kind: "server"}
+
+  defp sender_meta(%Message{prefix: {:nick, _, _, _}} = msg),
+    do: Map.put(prefix_userhost(msg), :sender_kind, "user")
+
+  # Prefix-less: the line is the local connection's own, and `sender_nick/1`
+  # already reports the `"*"` sentinel. No kind is claimed rather than
+  # guessing one — an absent key is the documented back-compat path.
+  defp sender_meta(%Message{}), do: %{}
+
   # #25: content kinds whose sender shows an irssi-style @/%/+ glyph. The
   # glyph must reflect the sender's grade AT SEND TIME, not their current
   # grade — so it's snapshotted into meta here, not derived live by cic.
@@ -3124,7 +3163,9 @@ defmodule Grappa.Session.EventRouter do
 
     if is_binary(body) do
       sender = Message.sender_nick(msg)
-      {state, eff} = build_persist(state, :notice, "$server", sender, body, %{})
+      # sender_meta/1, not %{}: this is the exact call that makes a server
+      # hostname and a user nick indistinguishable downstream (#1070).
+      {state, eff} = build_persist(state, :notice, "$server", sender, body, sender_meta(msg))
       {:cont, state, [eff]}
     else
       {:cont, state, []}

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -732,7 +732,10 @@ defmodule Grappa.Session.EventRouterTest do
       assert attrs.channel == "#italia"
       assert attrs.sender == "irc.azzurra.chat"
       assert attrs.body == "auth banner"
-      assert attrs.meta == %{}
+      # #1070 — a server CAN notice a channel, and the sender string alone
+      # cannot be told from a nick. The kind says which it was; nothing
+      # else is added, so the rest of the contract is unchanged.
+      assert attrs.meta == %{sender_kind: "server"}
     end
 
     # BUG2 fix-up: server-origin NOTICEs (target = own nick, not a channel)
@@ -906,12 +909,58 @@ defmodule Grappa.Session.EventRouterTest do
       # \x01 preserved verbatim (round-trip fidelity — CLAUDE.md).
       assert attrs.body == "\x01PING 1706743200000\x01"
       # Typed classification cic reads instead of touching \x01.
-      assert attrs.meta == %{ctcp_verb: "PING", ctcp_args: "1706743200000"}
+      assert attrs.meta ==
+               %{
+                 ctcp_verb: "PING",
+                 ctcp_args: "1706743200000",
+                 sender_kind: "user",
+                 sender_user: "u",
+                 sender_host: "h"
+               }
     end
 
     # #591 — a plain (non-CTCP) peer NOTICE carries empty meta, no ctcp tag.
     # Proves the classification is strictly additive. The OPEN window is what
     # keeps this row in `bob` post-#546; the meta assertion is the point.
+    # #1070 — sender_nick/1 returns the same bare string for a nick and a
+    # server, and that string is all a consumer gets. The `$server` window
+    # is where the two actually collide: MOTD numerics land there with a
+    # SERVER sender while a private notice lands there with a USER one,
+    # same kind, same shape. meta.sender_kind is what tells them apart.
+    test "a server-prefixed NOTICE carries sender_kind = server" do
+      state = base_state()
+      m = msg(:notice, ["#italia", "auth banner"], {:server, "irc.azzurra.chat"})
+
+      assert {:cont, _, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+      assert attrs.meta.sender_kind == "server"
+      # A server prefix has no user@host to report, and none is invented.
+      refute Map.has_key?(attrs.meta, :sender_user)
+      refute Map.has_key?(attrs.meta, :sender_host)
+    end
+
+    test "a nick-prefixed NOTICE carries sender_kind = user and its user@host" do
+      state = base_state(%{query_window_open?: fn _, _, _ -> true end})
+      m = msg(:notice, ["vjt", "hey"], {:nick, "bob", "u", "h"})
+
+      assert {:cont, _, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+      assert attrs.meta.sender_kind == "user"
+      assert attrs.meta.sender_user == "u"
+      assert attrs.meta.sender_host == "h"
+    end
+
+    # A +x-cloaked prefix drops half the mask. prefix_userhost/1 already
+    # refuses to report a partial one; the KIND is still known, so it is
+    # still reported — the two facts are independent.
+    test "a partial prefix still reports the kind, without a half mask" do
+      state = base_state(%{query_window_open?: fn _, _, _ -> true end})
+      m = msg(:notice, ["vjt", "hey"], {:nick, "bob", nil, "h"})
+
+      assert {:cont, _, [{:persist, :notice, attrs}]} = EventRouter.route(m, state)
+      assert attrs.meta.sender_kind == "user"
+      refute Map.has_key?(attrs.meta, :sender_user)
+      refute Map.has_key?(attrs.meta, :sender_host)
+    end
+
     test "plain peer NOTICE gets no ctcp meta (additive)" do
       state = base_state(%{query_window_open?: fn _, _, _ -> true end})
 
@@ -921,7 +970,11 @@ defmodule Grappa.Session.EventRouterTest do
                EventRouter.route(m, state)
 
       assert attrs.channel == "bob"
-      assert attrs.meta == %{}
+      # The claim is about ctcp classification, so assert that and not the
+      # whole map: #1070 adds sender_kind here, and an exact-equality
+      # assertion would read as a ctcp regression when it is not one.
+      refute Map.has_key?(attrs.meta, :ctcp)
+      assert attrs.meta.sender_kind == "user"
     end
 
     # #546 — the CTCP short-circuit outranks the open window. A CTCP-framed

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -10892,9 +10892,14 @@ defmodule Grappa.Session.ServerTest do
       refute_receive %Phoenix.Socket.Broadcast{event: "event"}, 100
 
       [row] = Scrollback.fetch({:user, user.id}, network.id, "$server", nil, 10, nil, false)
-      # MOTD path persists with empty meta — confirms it came from the
-      # delegated handler, not the routed path (which would set numeric+severity).
-      assert row.meta == %{}
+      # Confirms it came from the delegated handler, not the routed path —
+      # which is what `numeric` + `severity` would prove, so assert their
+      # ABSENCE rather than an empty map. #1070 adds `sender_kind` to every
+      # notice row, and an exact-equality assertion here would read as a
+      # routing regression when the discriminator is untouched.
+      refute Map.has_key?(row.meta, :numeric)
+      refute Map.has_key?(row.meta, :severity)
+      assert row.meta.sender_kind == "server"
 
       :ok = GenServer.stop(pid, :normal, 1_000)
     end


### PR DESCRIPTION
Addresses #1070 (closed by hand after release, per repo convention).

### What it does

Adds `sender_meta/1` next to the existing `prefix_userhost/1` and threads it through the
three NOTICE persists — the channel arm, the non-channel arm (merged with `ctcp_meta/1`
so the CTCP classification is untouched), and `persist_server_notice/2`.
`sender_user` / `sender_host` come along on the nick branch, since they fall out of the
same tuple and are already allowlisted.

### Two things "additive" did not mean, both found by the suite

**`meta` is allowlisted.** `Meta.@known_keys` rejects an unregistered key, so the
changeset failed and the row never persisted. That surfaced as *a broadcast that never
arrived* — six tests failing with "no matching message after 2000ms" — rather than as a
meta mismatch, which took a baseline run on clean `main` to attribute correctly.
`sender_kind` is now registered in `@known_keys`, in both typespecs, and in the Logger
`:metadata` allowlist that `meta_test.exs` asserts against.

**Three tests asserted `meta == %{}` by exact equality.** Two meant something narrower
than they said:

- *"plain peer NOTICE gets no ctcp meta"* → now `refute Map.has_key?(meta, :ctcp)`, which
  is the claim in the title.
- *"MOTD does NOT double-persist via the routing path"* → the comment says the
  discriminator is `numeric` + `severity`, so it now asserts their absence. An empty map
  was standing in for that, and would have read as a routing regression here when routing
  is untouched.

The third is a server-prefixed **channel** NOTICE, and now expects the kind — a server
can notice a channel, which is precisely the case a consumer cannot otherwise resolve.

Worth flagging because it means the allowlist and those equality assertions are the real
cost of any future `meta` key, not the threading.

### New tests

- a server-prefixed NOTICE carries `sender_kind: "server"`, and no `sender_user` /
  `sender_host` is invented for it
- a nick-prefixed NOTICE carries `"user"` plus its real user@host
- a partial (+x-cloaked) prefix still reports the kind while `prefix_userhost/1` keeps
  refusing the half mask — the two facts are independent

### Verification

1599 tests, 0 failures across `test/grappa/session/`, `test/grappa/scrollback/` and
`test/grappa/irc/`. Compiles with `--warnings-as-errors`. `mix format` clean.

### Scope

The other ~19 `sender_nick/1` call sites are untouched. The NOTICE paths are where #1070
reports the ambiguity, and each remaining kind deserves its own look at whether its sender
can be a server at all — better as follow-ups than as one sweep. Happy to do them if you
would rather have it in one go.

### Where this came from

Building an isolated test stack for bicchierino, an IRC-facade bridge to grappa. It got
the prefix wrong in both directions within a day — bare nick for user notices, then
`nick!user@host` for server ones — because the kind was the only signal available. It now
guesses with "sender contains a dot", exact against bahamut and a guess elsewhere. With
this key it can stop guessing.


### Consequence worth stating

The `messages` table now holds two shapes of `meta` for the same `kind: :notice`,
discriminated only by which code path wrote the row: the five NOTICE persists carry
`sender_kind`, and the kinds deliberately left out of scope (privmsg, join, part, mode,
topic) do not. That is the cost of scoping this to where #1070 reports the ambiguity
rather than sweeping all 22 `sender_nick/1` call sites in one change.
