### PR TITLE
cic(#1063): tell the operator what the refresh they pressed actually did

### DIFF
--- a/cicchetto/e2e/fixtures/bundleSwap.ts
+++ b/cicchetto/e2e/fixtures/bundleSwap.ts
@@ -172,15 +172,55 @@ export async function readCurrentBundleHash(): Promise<string> {
  * carries the NEW hash.
  */
 export async function swapToBundleB(): Promise<BundleSwapResult> {
+  return swapEntryAsset(
+    (newHash) =>
+      `// UX-6-I.2 synthetic bundle B — fixture-generated.\n` +
+      `console.log("ux-6-i.2 bundle-b loaded: ${newHash}");\n` +
+      `export {};\n`,
+  );
+}
+
+/**
+ * Like `swapToBundleB`, but bundle B is the CURRENT entry's own bytes under a
+ * new name — so the reloaded page is a different bundle that still BOOTS.
+ *
+ * `swapToBundleB`'s stub is deliberately inert, which is enough when the
+ * assertion is the post-reload `<script src>` and nothing more. It is not
+ * enough for anything the SPA has to say about the reload it just came out of:
+ * a page that never boots mounts no components, so a spec waiting for an
+ * on-mount announcement there would wait for a document that cannot produce
+ * one — green only if the assertion were weak enough not to notice.
+ *
+ * Same bytes, different name, so "the bundle moved" is true in the only sense
+ * the client can observe (the hash in the script tag) while the app that comes
+ * back is the real one. The `SYNTH_HASH_PREFIX` is shared with the stub swap on
+ * purpose: `snapshotBundle`'s self-heal detects leftovers by that prefix, and a
+ * second prefix would be a second thing to remember.
+ */
+export async function swapToBootableBundleB(): Promise<BundleSwapResult> {
+  const currentHash = await readCurrentBundleHash();
+  const entry = await fs.readFile(
+    path.join(DIST_DIR, ASSETS_DIR, `index-${currentHash}.js`),
+    "utf8",
+  );
+  return swapEntryAsset(() => entry);
+}
+
+/**
+ * Point `index.html` at a fresh `/assets/index-<newHash>.js` carrying
+ * `contentsFor(newHash)`. Shared by both swaps — they differ only in what
+ * bundle B contains.
+ */
+async function swapEntryAsset(
+  contentsFor: (newHash: string) => string,
+): Promise<BundleSwapResult> {
   const oldHash = await readCurrentBundleHash();
   const newHash = `${SYNTH_HASH_PREFIX}${Date.now().toString(36)}`;
 
-  const stubJs =
-    `// UX-6-I.2 synthetic bundle B — fixture-generated.\n` +
-    `console.log("ux-6-i.2 bundle-b loaded: ${newHash}");\n` +
-    `export {};\n`;
-
-  await fs.writeFile(path.join(DIST_DIR, ASSETS_DIR, `index-${newHash}.js`), stubJs);
+  await fs.writeFile(
+    path.join(DIST_DIR, ASSETS_DIR, `index-${newHash}.js`),
+    contentsFor(newHash),
+  );
 
   const htmlPath = path.join(DIST_DIR, INDEX_HTML);
   const html = await fs.readFile(htmlPath, "utf8");

--- a/cicchetto/e2e/tests/issue1063-refresh-visible-feedback.spec.ts
+++ b/cicchetto/e2e/tests/issue1063-refresh-visible-feedback.spec.ts
@@ -1,0 +1,160 @@
+// #1063 acceptance 3 — the operator finds out what the Refresh they pressed did.
+//
+// The unit tests pin the DECISION (`bundleRefreshNotice.test.ts`) and the
+// button-level wiring (`errorBanners.test.ts`). Neither can pin the CHAIN.
+// jsdom has no service worker, no precache and no navigation, so there the
+// reload is a function that was called, and "the marker survives the reload"
+// is asserted by writing to `sessionStorage` and reading it back in the SAME
+// document. This file is the only place that claim is actually tested: a real
+// press, a real `performRefresh` (real SW update, real cache purge), a real
+// navigation, and a real `Toasts` mount in the document that comes out the
+// other side.
+//
+// THE PAIR IS THE POINT. Same gesture, same code; the only thing that differs
+// is whether the bundle underneath moved:
+//
+//   * nothing moved → "Still on <label>"    ← #1063's complaint, and new
+//   * bundle moved  → "Updated to <label>"  ← #775's toast, now also on the
+//                                             MANUAL path (the behaviour
+//                                             change #1063 accepted by ruling)
+//
+// Either test alone would still pass with a formatter that ignored the
+// outcome and said one thing always. Together they cannot.
+//
+// Not duplicated from `issue1063-update-delivery.spec.ts`: that file is
+// acceptance 5 (does a stale client reach the new bundle at all) and states
+// what a real browser cannot witness. This one is about what the operator is
+// TOLD, which is a different claim and reachable in full.
+//
+// TIMING, stated because it is the one coupling worth knowing about: a toast
+// self-expires after `TOAST_MS` (6s), so the assertion has to be polling
+// already when the reloaded document mounts. It is — there is no wait between
+// the navigation and the `expect`, which starts before the SPA has even
+// booted. Nothing here sleeps, and nothing here may be "fixed" by sleeping.
+
+import type { Page } from "@playwright/test";
+import { expect, test } from "../fixtures/test";
+import {
+  awaitServerBundleHashPush,
+  awaitServiceWorkerActive,
+  loginAs,
+} from "../fixtures/cicchettoPage";
+import { getSeededVjt } from "../fixtures/seedData";
+import { snapshotBundle, swapToBootableBundleB } from "../fixtures/bundleSwap";
+
+// #119 — the refresh banner is a slot in the stacked error region.
+const BANNER_SELECTOR = '.error-banner[data-source="bundle-refresh"]';
+const REFRESH_BUTTON = /refresh|new version/i;
+
+// The update-toned row in the single toast stack (Toasts.tsx). Scoped to the
+// tone so a presence toast in flight cannot satisfy it.
+const TOAST_TEXT = ".toast-update .toast-text";
+
+// IMPORTANT: keep in lockstep with `SHORT_HASH_LEN` in `src/lib/bundleHash.ts`.
+// Asserting on the hash the label carries is what makes these assertions about
+// the bundle actually running rather than about a fixed string.
+const SHORT_HASH_LEN = 7;
+
+// The two literal sentences the operator reads. Hard-coded on purpose: the
+// wording IS the deliverable here, and a spec that computed it from the same
+// formatter under test would agree with any wording at all.
+function stillOn(hash: string): RegExp {
+  return new RegExp(`^Still on .*\\(${hash.slice(0, SHORT_HASH_LEN)}\\)$`);
+}
+
+function updatedTo(hash: string): RegExp {
+  return new RegExp(`^Updated to .*\\(${hash.slice(0, SHORT_HASH_LEN)}\\)$`);
+}
+
+async function bootHashOf(page: Page): Promise<string> {
+  const hash = await page.evaluate(() => window.__cic_bundleHash?.bootHash() ?? null);
+  expect(hash, "boot hash must be readable from index.html").toBeTruthy();
+  return hash as string;
+}
+
+/** Log in, get past the SW's own reload, and let the real `bundle_hash` push land. */
+async function readyOnBundleA(page: Page): Promise<string> {
+  await loginAs(page, getSeededVjt());
+  // Both are load-bearing and both are documented at their definition: the SW
+  // does one reload of its own after claiming, and the server pushes the REAL
+  // hash on every user-topic join, which would overwrite a synthetic set after
+  // the fact.
+  await awaitServiceWorkerActive(page);
+  await awaitServerBundleHashPush(page);
+
+  // PRE-STATE. Nothing has been announced yet, so a toast seen later cannot be
+  // a leftover from login or from the service worker's own reload.
+  await expect(page.locator(TOAST_TEXT)).toHaveCount(0);
+
+  return bootHashOf(page);
+}
+
+/** Press the banner's Refresh and wait for the navigation it eventually causes. */
+async function pressRefresh(page: Page): Promise<void> {
+  const banner = page.locator(BANNER_SELECTOR);
+  await expect(banner).toBeVisible();
+  // `performRefresh` is async — SW update, up to 2s of `controllerchange`,
+  // then the cache purge, and only then the navigation. Arm the wait BEFORE
+  // the click so we capture that navigation instead of racing it.
+  await Promise.all([
+    page.waitForEvent("framenavigated", { timeout: 15_000 }),
+    banner.getByRole("button", { name: REFRESH_BUTTON }).click(),
+  ]);
+}
+
+test("#1063 — a Refresh that moves nothing says what it is still running", async ({ page }) => {
+  const bootHash = await readyOnBundleA(page);
+
+  // THE DIST IS NOT TOUCHED. Only the server-advertised hash moves, which is
+  // exactly the shape of the complaint: the client is told an update exists
+  // and the reload does not land on one. A real deploy the precache refuses to
+  // give up is indistinguishable from here — that is the point, and it is why
+  // the toast below states what it is running instead of diagnosing why.
+  await page.evaluate(() => {
+    window.__cic_bundleHash?.setServerHash("i1063NoSuchBundleOnDisk");
+  });
+
+  await pressRefresh(page);
+
+  // The whole feature, in the user's terms: the page came back, and it said so.
+  // Before #1063 this press was silent and the identical banner simply
+  // reappeared — indistinguishable from a mis-tap, which is the three-presses
+  // complaint from the other side.
+  await expect(page.locator(TOAST_TEXT)).toHaveText(stillOn(bootHash));
+
+  // ...and the premise held. Without this the assertion above could be green
+  // for the wrong reason (a bundle that DID move and a mislabelled toast).
+  expect(await bootHashOf(page), "the bundle must not have moved").toBe(bootHash);
+});
+
+test("#1063 — a Refresh that lands on a new bundle names the new one", async ({ page }) => {
+  const snap = await snapshotBundle();
+  try {
+    const bootHash = await readyOnBundleA(page);
+
+    // A bundle B that BOOTS — see `swapToBootableBundleB` on why the inert
+    // stub cannot serve here: a page that never boots mounts no `Toasts` and
+    // so can never make the announcement this test is waiting for.
+    const { newHash, oldHash } = await swapToBootableBundleB();
+    expect(oldHash).toBe(bootHash);
+    expect(newHash).not.toBe(oldHash);
+
+    // Mirror the `/admin/cic-bundle-changed` broadcast so the banner mounts.
+    await page.evaluate((hash: string) => {
+      window.__cic_bundleHash?.setServerHash(hash);
+    }, newHash);
+
+    await pressRefresh(page);
+
+    // #775's toast on the MANUAL path. Pre-#1063 the button wrote no marker at
+    // all, so a successful manual refresh was as silent as a failed one; this
+    // is the accepted behaviour change, asserted rather than left to the diff.
+    await expect(page.locator(TOAST_TEXT)).toHaveText(updatedTo(newHash));
+
+    // The label names the bundle that is RUNNING, not the one that asked to be
+    // replaced — the reason the marker carries the departing hash.
+    expect(await bootHashOf(page), "the reload must have landed on bundle B").toBe(newHash);
+  } finally {
+    await snap.restore();
+  }
+});

--- a/cicchetto/src/BootErrorBoundary.tsx
+++ b/cicchetto/src/BootErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import { type Component, createSignal, ErrorBoundary, type JSX } from "solid-js";
 import { ApiError } from "./lib/api";
-import { performRefresh } from "./lib/bundleHash";
+import { requestBundleRefreshNow } from "./lib/bundleRefreshNotice";
 import { isOffline } from "./lib/connectivity";
 import { friendlyApiError } from "./lib/friendlyApiError";
 import { refetchChannels, refetchNetworks, refetchUser } from "./lib/networks";
@@ -111,7 +111,12 @@ const BootFailure: Component<{ error: unknown; onRetry: () => void }> = (props) 
         onClick={() => {
           setReloading(true);
           if (props.error instanceof ApiError && !isOffline()) {
-            void performRefresh();
+            // #1063 — `"user"`, same as the refresh banner: a human pressed
+            // Refresh, so the boot that follows owes them an answer. Here the
+            // bundle very often has NOT moved (this button recovers a failed
+            // boot, it is not an update prompt), which is exactly when the
+            // "Still on X" toast is the only evidence the press did anything.
+            void requestBundleRefreshNow("user");
             return;
           }
           window.location.reload();

--- a/cicchetto/src/__tests__/Toasts.test.tsx
+++ b/cicchetto/src/__tests__/Toasts.test.tsx
@@ -81,7 +81,7 @@ describe("Toasts", () => {
   // left a marker, this one boots on a different bundle and says so — and it
   // says so from INSIDE the mounted live region.
   it("announces an auto-refresh that landed, at mount", () => {
-    markBundleRefreshApplied(Date.now(), OLD_BUNDLE);
+    markBundleRefreshApplied(Date.now(), OLD_BUNDLE, "auto");
 
     const { container } = render(() => <Toasts />);
 
@@ -91,7 +91,7 @@ describe("Toasts", () => {
   });
 
   it("says nothing when the reload landed back on the same bundle", () => {
-    markBundleRefreshApplied(Date.now(), NEW_BUNDLE);
+    markBundleRefreshApplied(Date.now(), NEW_BUNDLE, "auto");
 
     const { container } = render(() => <Toasts />);
 
@@ -112,7 +112,7 @@ describe("Toasts", () => {
       initial: false,
       ts: "2026-08-03T12:00:00Z",
     });
-    markBundleRefreshApplied(Date.now(), OLD_BUNDLE);
+    markBundleRefreshApplied(Date.now(), OLD_BUNDLE, "auto");
 
     const { container } = render(() => <Toasts />);
 
@@ -128,7 +128,7 @@ describe("Toasts", () => {
       initial: false,
       ts: "2026-08-03T12:00:00Z",
     });
-    markBundleRefreshApplied(Date.now(), OLD_BUNDLE);
+    markBundleRefreshApplied(Date.now(), OLD_BUNDLE, "auto");
 
     const { container } = render(() => <Toasts />);
     fireEvent.click(container.querySelector(".toast-update")!);

--- a/cicchetto/src/__tests__/bundleRefreshNotice.test.ts
+++ b/cicchetto/src/__tests__/bundleRefreshNotice.test.ts
@@ -25,6 +25,7 @@ import {
   dismissBundleRefreshToast,
   formatBundleRefreshToast,
   markBundleRefreshApplied,
+  requestBundleRefresh,
 } from "../lib/bundleRefreshNotice";
 import { _setScheduleExpiryForTest } from "../lib/toasts";
 
@@ -45,18 +46,18 @@ beforeEach(() => {
 
 describe("the cross-reload marker", () => {
   it("lives in sessionStorage — a sibling tab must not announce this window's refresh", () => {
-    markBundleRefreshApplied(t0, OLD_BUNDLE);
+    markBundleRefreshApplied(t0, OLD_BUNDLE, "auto");
 
     expect(sessionStorage.getItem(BUNDLE_REFRESH_NOTICE_KEY)).toBe(
-      JSON.stringify({ at: t0, from: OLD_BUNDLE }),
+      JSON.stringify({ at: t0, from: OLD_BUNDLE, origin: "auto" }),
     );
     expect(localStorage.getItem(BUNDLE_REFRESH_NOTICE_KEY)).toBeNull();
   });
 
   it("announces for the boot that immediately follows, on a different bundle", () => {
-    markBundleRefreshApplied(t0, OLD_BUNDLE);
+    markBundleRefreshApplied(t0, OLD_BUNDLE, "auto");
 
-    expect(consumeBundleRefreshNotice(t0 + 2 * SECOND, NEW_BUNDLE)).toBe(true);
+    expect(consumeBundleRefreshNotice(t0 + 2 * SECOND, NEW_BUNDLE)).toBe("changed");
   });
 
   // The reload landed on the OLD precached index.html — the three-presses-to-
@@ -64,80 +65,82 @@ describe("the cross-reload marker", () => {
   // guarantee against. Seconds old, so time waves it through; nothing changed,
   // so there is nothing to announce.
   it("SAYS NOTHING when the reload landed back on the same bundle", () => {
-    markBundleRefreshApplied(t0, OLD_BUNDLE);
+    markBundleRefreshApplied(t0, OLD_BUNDLE, "auto");
 
-    expect(consumeBundleRefreshNotice(t0 + 2 * SECOND, OLD_BUNDLE)).toBe(false);
+    expect(consumeBundleRefreshNotice(t0 + 2 * SECOND, OLD_BUNDLE)).toBe("none");
   });
 
   // Storing the DEPARTING hash rather than the target is what keeps this case:
   // a second deploy landing mid-reload still leaves the bundle we asked to
   // replace, which is the thing being announced.
   it("still announces when a second deploy landed during the reload", () => {
-    markBundleRefreshApplied(t0, OLD_BUNDLE);
+    markBundleRefreshApplied(t0, OLD_BUNDLE, "auto");
 
-    expect(consumeBundleRefreshNotice(t0 + 3 * SECOND, "Xy9zAbC1")).toBe(true);
+    expect(consumeBundleRefreshNotice(t0 + 3 * SECOND, "Xy9zAbC1")).toBe("changed");
   });
 
   it("is fresh exactly at the window edge", () => {
-    markBundleRefreshApplied(t0, OLD_BUNDLE);
+    markBundleRefreshApplied(t0, OLD_BUNDLE, "auto");
 
-    expect(consumeBundleRefreshNotice(t0 + BUNDLE_REFRESH_NOTICE_WINDOW_MS, NEW_BUNDLE)).toBe(true);
+    expect(consumeBundleRefreshNotice(t0 + BUNDLE_REFRESH_NOTICE_WINDOW_MS, NEW_BUNDLE)).toBe(
+      "changed",
+    );
   });
 
   it("STRANDS SAFELY: a marker whose reload never landed does not announce later", () => {
-    markBundleRefreshApplied(t0, OLD_BUNDLE);
+    markBundleRefreshApplied(t0, OLD_BUNDLE, "auto");
 
     expect(consumeBundleRefreshNotice(t0 + BUNDLE_REFRESH_NOTICE_WINDOW_MS + 1, NEW_BUNDLE)).toBe(
-      false,
+      "none",
     );
   });
 
   it("clears the marker even when it was unusable, so it cannot resurface", () => {
-    markBundleRefreshApplied(t0, OLD_BUNDLE);
+    markBundleRefreshApplied(t0, OLD_BUNDLE, "auto");
     consumeBundleRefreshNotice(t0 + 6 * BUNDLE_REFRESH_NOTICE_WINDOW_MS, NEW_BUNDLE);
 
     expect(sessionStorage.getItem(BUNDLE_REFRESH_NOTICE_KEY)).toBeNull();
   });
 
   it("is consumed exactly once — a second boot in the same window stays quiet", () => {
-    markBundleRefreshApplied(t0, OLD_BUNDLE);
+    markBundleRefreshApplied(t0, OLD_BUNDLE, "auto");
 
-    expect(consumeBundleRefreshNotice(t0 + SECOND, NEW_BUNDLE)).toBe(true);
-    expect(consumeBundleRefreshNotice(t0 + 2 * SECOND, NEW_BUNDLE)).toBe(false);
+    expect(consumeBundleRefreshNotice(t0 + SECOND, NEW_BUNDLE)).toBe("changed");
+    expect(consumeBundleRefreshNotice(t0 + 2 * SECOND, NEW_BUNDLE)).toBe("none");
   });
 
   it("is false with no marker at all — an ordinary boot announces nothing", () => {
-    expect(consumeBundleRefreshNotice(t0, NEW_BUNDLE)).toBe(false);
+    expect(consumeBundleRefreshNotice(t0, NEW_BUNDLE)).toBe("none");
   });
 
   it("is false on a corrupt marker, and clears it", () => {
     sessionStorage.setItem(BUNDLE_REFRESH_NOTICE_KEY, "just now");
 
-    expect(consumeBundleRefreshNotice(t0, NEW_BUNDLE)).toBe(false);
+    expect(consumeBundleRefreshNotice(t0, NEW_BUNDLE)).toBe("none");
     expect(sessionStorage.getItem(BUNDLE_REFRESH_NOTICE_KEY)).toBeNull();
   });
 
   it("is false on a marker missing its fields — an older format must not throw", () => {
     sessionStorage.setItem(BUNDLE_REFRESH_NOTICE_KEY, String(t0));
 
-    expect(consumeBundleRefreshNotice(t0 + SECOND, NEW_BUNDLE)).toBe(false);
+    expect(consumeBundleRefreshNotice(t0 + SECOND, NEW_BUNDLE)).toBe("none");
   });
 
   it("is false on a future-dated marker — a backwards clock step must not announce", () => {
-    markBundleRefreshApplied(t0 + 10 * SECOND, OLD_BUNDLE);
+    markBundleRefreshApplied(t0 + 10 * SECOND, OLD_BUNDLE, "auto");
 
-    expect(consumeBundleRefreshNotice(t0, NEW_BUNDLE)).toBe(false);
+    expect(consumeBundleRefreshNotice(t0, NEW_BUNDLE)).toBe("none");
   });
 
   // An announcement is a claim; an unknown hash on either side is not proof of
   // a change. No honest case is lost — the branch that writes the marker only
   // fires when both hashes are known and differ.
   it("is false when either bundle identity is unknown", () => {
-    markBundleRefreshApplied(t0, null);
-    expect(consumeBundleRefreshNotice(t0 + SECOND, NEW_BUNDLE)).toBe(false);
+    markBundleRefreshApplied(t0, null, "auto");
+    expect(consumeBundleRefreshNotice(t0 + SECOND, NEW_BUNDLE)).toBe("none");
 
-    markBundleRefreshApplied(t0, OLD_BUNDLE);
-    expect(consumeBundleRefreshNotice(t0 + SECOND, null)).toBe(false);
+    markBundleRefreshApplied(t0, OLD_BUNDLE, "auto");
+    expect(consumeBundleRefreshNotice(t0 + SECOND, null)).toBe("none");
   });
 });
 
@@ -156,7 +159,7 @@ describe("formatBundleRefreshToast", () => {
 
 describe("announceAppliedBundleRefresh", () => {
   it("shows exactly one toast when the refresh landed", () => {
-    markBundleRefreshApplied(t0, OLD_BUNDLE);
+    markBundleRefreshApplied(t0, OLD_BUNDLE, "auto");
 
     announceAppliedBundleRefresh(t0 + 2 * SECOND, NEW_BUNDLE, "0.10.1");
 
@@ -170,15 +173,18 @@ describe("announceAppliedBundleRefresh", () => {
   });
 
   it("shows nothing for a stranded marker", () => {
-    markBundleRefreshApplied(t0, OLD_BUNDLE);
+    markBundleRefreshApplied(t0, OLD_BUNDLE, "auto");
 
     announceAppliedBundleRefresh(t0 + BUNDLE_REFRESH_NOTICE_WINDOW_MS + 1, NEW_BUNDLE, "0.10.1");
 
     expect(bundleRefreshToasts()).toEqual([]);
   });
 
-  it("shows nothing when the reload changed nothing", () => {
-    markBundleRefreshApplied(t0, OLD_BUNDLE);
+  // #1063 narrowed this claim to the AUTO origin, which is what it always
+  // meant: a reload nobody asked for that moved nothing is a non-event. The
+  // same reload asked for by a HUMAN is the case below, and it does speak.
+  it("shows nothing when an auto reload changed nothing", () => {
+    markBundleRefreshApplied(t0, OLD_BUNDLE, "auto");
 
     announceAppliedBundleRefresh(t0 + 2 * SECOND, OLD_BUNDLE, "0.10.1");
 
@@ -190,7 +196,7 @@ describe("announceAppliedBundleRefresh", () => {
     _setScheduleExpiryForTest((fn) => {
       scheduled.push(fn);
     });
-    markBundleRefreshApplied(t0, OLD_BUNDLE);
+    markBundleRefreshApplied(t0, OLD_BUNDLE, "auto");
 
     announceAppliedBundleRefresh(t0 + SECOND, NEW_BUNDLE, "0.10.1");
     expect(bundleRefreshToasts()).toHaveLength(1);
@@ -220,7 +226,7 @@ describe("the update notice is not identity-scoped", () => {
     toasts._setScheduleExpiryForTest(() => {});
 
     nw.applyPresenceError({ network_id: 42, detail: "Monitor list is full" });
-    notice.markBundleRefreshApplied(t0, OLD_BUNDLE);
+    notice.markBundleRefreshApplied(t0, OLD_BUNDLE, "auto");
     notice.announceAppliedBundleRefresh(t0 + SECOND, NEW_BUNDLE, "0.10.1");
 
     expect(nw.presenceToasts()).toHaveLength(1);
@@ -232,5 +238,117 @@ describe("the update notice is not identity-scoped", () => {
       expect(nw.presenceToasts()).toEqual([]);
     });
     expect(notice.bundleRefreshToasts()).toHaveLength(1);
+  });
+});
+
+// #1063 — the half #775 did not have: an answer when the refresh a HUMAN asked
+// for lands on the same bundle.
+//
+// D5 is why this is not cosmetic. `performRefresh` bounds every step, and when
+// a ceiling fires the cache purge is SKIPPED — the reload happens and the old
+// precached `index.html` is served again. The operator sees the page blink and
+// come back identical, with the same banner on it. Today that is
+// indistinguishable from "I did not press hard enough", so they press again.
+describe("#1063 — a refresh the operator asked for", () => {
+  it("says what it is still running when the reload moved nothing", () => {
+    markBundleRefreshApplied(t0, OLD_BUNDLE, "user");
+
+    announceAppliedBundleRefresh(t0 + 2 * SECOND, OLD_BUNDLE, "0.10.1");
+
+    expect(bundleRefreshToasts().map((t) => t.text)).toEqual(["Still on 0.10.1 (Tsa4Tfo)"]);
+  });
+
+  // The #775 BEHAVIOUR CHANGE, asserted rather than left to the diff: pressing
+  // Refresh used to be silent on success too. It now toasts, and that is the
+  // ruling — after you press a button, silence is the surprise.
+  it("announces the new bundle on a successful manual refresh", () => {
+    markBundleRefreshApplied(t0, OLD_BUNDLE, "user");
+
+    announceAppliedBundleRefresh(t0 + 2 * SECOND, NEW_BUNDLE, "0.10.1");
+
+    expect(bundleRefreshToasts().map((t) => t.text)).toEqual(["Updated to 0.10.1 (CiYQNUz)"]);
+  });
+
+  it("still respects the time fence — a marker too old claims nothing", () => {
+    markBundleRefreshApplied(t0, OLD_BUNDLE, "user");
+
+    announceAppliedBundleRefresh(t0 + BUNDLE_REFRESH_NOTICE_WINDOW_MS + 1, OLD_BUNDLE, "0.10.1");
+
+    expect(bundleRefreshToasts()).toEqual([]);
+  });
+
+  // An unknown hash on either side is not evidence the bundle stayed the same
+  // any more than it is evidence it changed. Silence, like every other guard
+  // in this module.
+  it("claims nothing when a hash is unknown", () => {
+    markBundleRefreshApplied(t0, null, "user");
+    expect(consumeBundleRefreshNotice(t0 + SECOND, OLD_BUNDLE)).toBe("none");
+
+    markBundleRefreshApplied(t0, OLD_BUNDLE, "user");
+    expect(consumeBundleRefreshNotice(t0 + SECOND, null)).toBe("none");
+  });
+});
+
+// The marker crosses a DEPLOY, not just a reload: the document that writes it
+// is running the OLD bundle and the document that reads it is running the new
+// one. On the deploy that ships #1063 the writer therefore has no `origin`
+// field at all, and reading that as anything but "auto" would drop #775's
+// toast on the very deploy that introduces the feature.
+describe("#1063 — a marker written by the previous bundle", () => {
+  it("is read as the auto deploy branch, the only writer that existed", () => {
+    sessionStorage.setItem(BUNDLE_REFRESH_NOTICE_KEY, JSON.stringify({ at: t0, from: OLD_BUNDLE }));
+
+    expect(consumeBundleRefreshNotice(t0 + SECOND, NEW_BUNDLE)).toBe("changed");
+  });
+
+  it("and therefore stays silent when it moved nothing", () => {
+    sessionStorage.setItem(BUNDLE_REFRESH_NOTICE_KEY, JSON.stringify({ at: t0, from: OLD_BUNDLE }));
+
+    expect(consumeBundleRefreshNotice(t0 + SECOND, OLD_BUNDLE)).toBe("none");
+  });
+
+  it("rejects an origin outside the closed set rather than guessing", () => {
+    sessionStorage.setItem(
+      BUNDLE_REFRESH_NOTICE_KEY,
+      JSON.stringify({ at: t0, from: OLD_BUNDLE, origin: "banana" }),
+    );
+
+    expect(consumeBundleRefreshNotice(t0 + SECOND, NEW_BUNDLE)).toBe("none");
+  });
+});
+
+// One writer of the marker. Before #1063 the composition root wrote it and the
+// two Refresh buttons did not, so the manual press was silent by omission.
+describe("#1063 — requestBundleRefresh is the single writer", () => {
+  const withProbe = async (origin: "user" | "auto" | "silent"): Promise<boolean> => {
+    let reloaded = false;
+    const hook = window.__cic_bundleHash;
+    if (hook) {
+      hook.__refreshProbe = () => {
+        reloaded = true;
+      };
+    }
+    await requestBundleRefresh(t0, OLD_BUNDLE, origin);
+    if (hook) hook.__refreshProbe = undefined;
+    return reloaded;
+  };
+
+  it("marks with the origin it was given, and reloads", async () => {
+    expect(await withProbe("user")).toBe(true);
+
+    expect(JSON.parse(sessionStorage.getItem(BUNDLE_REFRESH_NOTICE_KEY) ?? "null")).toEqual({
+      at: t0,
+      from: OLD_BUNDLE,
+      origin: "user",
+    });
+  });
+
+  // #695 throws a document away for AGE. It reloads like the others and has
+  // nothing whatsoever to tell anyone — not even "still on X", because nobody
+  // asked it anything.
+  it("writes no marker at all when silent, and still reloads", async () => {
+    expect(await withProbe("silent")).toBe(true);
+
+    expect(sessionStorage.getItem(BUNDLE_REFRESH_NOTICE_KEY)).toBeNull();
   });
 });

--- a/cicchetto/src/__tests__/bundleRefreshWiring.test.ts
+++ b/cicchetto/src/__tests__/bundleRefreshWiring.test.ts
@@ -23,17 +23,21 @@ const source = (rel: string): string =>
   readFileSync(resolve(process.cwd(), rel), "utf8").replace(/\s+/g, "");
 
 describe("#775 — the marker write in the composition root", () => {
-  it("marks the notice, and only for the deploy branch", () => {
+  // #1063 moved the write itself into `requestBundleRefresh`, so what the root
+  // still owns — and still nothing can import — is the ORIGIN it picks per
+  // branch. That is now the load-bearing half: get it wrong and #695's
+  // age-reload starts announcing itself, or #674's deploy stops.
+  it("routes each reload branch to its own origin", () => {
     expect(source("src/main.tsx")).toContain(
-      'reason==="bundle")markBundleRefreshApplied(Date.now(),bootBundleHashAccessor())',
+      'requestBundleRefresh(Date.now(),bootBundleHashAccessor(),reason==="bundle"?"auto":"silent"',
     );
   });
 
   it("still guards something — the verb it names is the one the notice exports", () => {
-    // Without this, renaming `markBundleRefreshApplied` on both sides would
-    // leave the assertion above passing against a feature that no longer works.
+    // Without this, renaming `requestBundleRefresh` on both sides would leave
+    // the assertion above passing against a feature that no longer works.
     expect(source("src/lib/bundleRefreshNotice.ts")).toContain(
-      "exportfunctionmarkBundleRefreshApplied(now:number,fromHash:string|null)",
+      "exportasyncfunctionrequestBundleRefresh(now:number,fromHash:string|null,origin:BundleRefreshOrigin",
     );
   });
 });

--- a/cicchetto/src/__tests__/errorBanners.test.ts
+++ b/cicchetto/src/__tests__/errorBanners.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { shouldShowRefreshBanner } from "../lib/bundleHash";
+import { BUNDLE_REFRESH_NOTICE_KEY } from "../lib/bundleRefreshNotice";
 import { acceptInvite, declineInvite } from "../lib/channelJoin";
 import { channelKey } from "../lib/channelKey";
 import { __setConnectivityForTests } from "../lib/connectivity";
@@ -43,6 +44,11 @@ vi.mock("../lib/bundleHash", () => ({
   // in bundleHash.test.ts (formatRefreshBanner).
   refreshBannerMessage: vi.fn(() => "New version available — current 1.0.0 → available 2.0.0."),
   performRefresh: vi.fn(),
+  // #1063 — the Refresh action now goes through `bundleRefreshNotice`, which
+  // reads the departing hash off this same module. Mocked with a KNOWN value
+  // so the marker's `from` can be asserted rather than merely observed.
+  bootBundleHashAccessor: vi.fn(() => "BootHash"),
+  versionLabel: vi.fn((v: string | null, h: string | null) => `${v ?? ""} ${h ?? ""}`),
 }));
 
 // #459 — the push opt-in source is owned by pushOptin.ts (gate + accept/decline
@@ -135,6 +141,24 @@ describe("errorBanners registry", () => {
     expect(bundle?.severity).toBe("info");
     expect(bundle?.actionHint?.label).toBe("Refresh");
     expect(typeof bundle?.actionHint?.onAction).toBe("function");
+  });
+
+  // #1063 — the press has to MARK, and mark as a HUMAN press. That flag is
+  // what buys the "Still on X" answer on the boot after a reload that changed
+  // nothing; an `"auto"` here would silently restore the old silence, which is
+  // the whole complaint. Asserted through the registry's own actionHint, not
+  // through the module the button happens to call, so the wiring is what is
+  // under test.
+  it("marks the notice as a user-origin refresh when its action is pressed", () => {
+    mockShouldShowRefresh.mockReturnValue(true);
+    sessionStorage.removeItem(BUNDLE_REFRESH_NOTICE_KEY);
+
+    activeBanners()
+      .find((e) => e.source === "bundle-refresh")
+      ?.actionHint?.onAction();
+
+    const marker: unknown = JSON.parse(sessionStorage.getItem(BUNDLE_REFRESH_NOTICE_KEY) ?? "null");
+    expect(marker).toMatchObject({ from: "BootHash", origin: "user" });
   });
 
   it("sources the bundle-refresh message from refreshBannerMessage (#292)", () => {

--- a/cicchetto/src/lib/bundleRefreshNotice.ts
+++ b/cicchetto/src/lib/bundleRefreshNotice.ts
@@ -1,4 +1,4 @@
-import { versionLabel } from "./bundleHash";
+import { bootBundleHashAccessor, performRefresh, versionLabel } from "./bundleHash";
 import { createToastQueue } from "./toasts";
 
 // #775 — announcing an auto-refresh (#674) that actually landed.
@@ -93,22 +93,81 @@ const queue = createToastQueue<BundleRefreshToast>();
 export const bundleRefreshToasts = queue.toasts;
 export const dismissBundleRefreshToast = queue.dismiss;
 
+/**
+ * Who asked for the reload — the ONE thing the arriving document cannot
+ * re-derive, and the whole reason #1063 extends this marker rather than
+ * adding a second one.
+ *
+ * `"user"` is a human who pressed Refresh and is owed an answer either way.
+ * `"auto"` is #674 applying a deploy nobody asked for: worth announcing when
+ * it changed something, silence when it did not. `"silent"` never marks at
+ * all — #695 throws a document away for AGE, and that has nothing to tell
+ * anyone.
+ */
+export type BundleRefreshOrigin = "user" | "auto" | "silent";
+
+/** The origins that actually reach storage; `"silent"` writes no marker. */
+type MarkedOrigin = Exclude<BundleRefreshOrigin, "silent">;
+
+/**
+ * What the arriving document should say, if anything.
+ *
+ * `"unchanged"` is the case #1063 exists for and the only genuinely new one:
+ * the reload ran, and the bundle underneath it did not move. Today that is
+ * indistinguishable from "I did not press hard enough", because the identical
+ * banner simply reappears.
+ */
+export type BundleRefreshOutcome = "changed" | "unchanged" | "none";
+
 interface Marker {
   at: number;
   from: string | null;
+  origin: MarkedOrigin;
 }
 
 /**
- * Record, at `now`, that a bundle auto-refresh is being requested from the
- * bundle `fromHash`.
+ * Record, at `now`, that a bundle refresh is being requested from the bundle
+ * `fromHash`, by `origin`.
  *
  * The DEPARTING hash, not the target: a second deploy can land while the reload
  * is in flight, and "I am no longer on the bundle that asked to be replaced" is
  * true in that case too, where "I am on exactly the bundle we aimed at" is not.
  */
-export function markBundleRefreshApplied(now: number, fromHash: string | null): void {
-  const marker: Marker = { at: now, from: fromHash };
+export function markBundleRefreshApplied(
+  now: number,
+  fromHash: string | null,
+  origin: MarkedOrigin,
+): void {
+  const marker: Marker = { at: now, from: fromHash, origin };
   sessionStorage.setItem(BUNDLE_REFRESH_NOTICE_KEY, JSON.stringify(marker));
+}
+
+/**
+ * Mark (unless silent) and then reload through the shared SW-aware verb.
+ *
+ * ONE writer of the marker, which is the point: before #1063 the composition
+ * root wrote it and the two manual Refresh buttons did not, so pressing
+ * Refresh was silent by omission rather than by decision. Adding the write to
+ * each caller instead would have made three copies of the same two lines and
+ * the next caller would have been the one that forgot.
+ *
+ * `performRefresh` itself is left alone deliberately: it is the shared SW +
+ * cache verb, `bundleRefreshNotice` already depends on `bundleHash` for
+ * `versionLabel`, and reversing that edge to push the marker down into it
+ * would make the two modules mutually recursive for no gain.
+ */
+export async function requestBundleRefresh(
+  now: number,
+  fromHash: string | null,
+  origin: BundleRefreshOrigin,
+): Promise<void> {
+  if (origin !== "silent") markBundleRefreshApplied(now, fromHash, origin);
+  await performRefresh();
+}
+
+/** `requestBundleRefresh` with the boot hash the page is actually running. */
+export function requestBundleRefreshNow(origin: BundleRefreshOrigin): Promise<void> {
+  return requestBundleRefresh(Date.now(), bootBundleHashAccessor(), origin);
 }
 
 function readMarker(): Marker | null {
@@ -119,34 +178,48 @@ function readMarker(): Marker | null {
   try {
     const parsed: unknown = JSON.parse(raw);
     if (typeof parsed !== "object" || parsed === null) return null;
-    const { at, from } = parsed as Partial<Marker>;
+    const { at, from, origin } = parsed as Partial<Marker>;
     if (typeof at !== "number" || !Number.isFinite(at)) return null;
     if (from !== null && typeof from !== "string") return null;
-    return { at, from };
+    if (origin !== undefined && origin !== "user" && origin !== "auto") return null;
+    // ACROSS THE DEPLOY THAT SHIPS #1063, the marker is written by the OLD
+    // bundle and read by the NEW one, so the very first boot after this lands
+    // reads a marker with no `origin` at all. Before #1063 the only writer was
+    // the #674 deploy branch, so that is what an absent field means — anything
+    // else would drop #775's toast on exactly the deploy that introduces it.
+    return { at, from, origin: origin ?? "auto" };
   } catch {
     return null;
   }
 }
 
 /**
- * Read the marker and clear it: true iff this boot is the one it was written
- * for AND it booted on a different bundle.
+ * Read the marker and clear it, and say what this boot may truthfully claim.
  *
  * Always clears — an unusable marker (absent, corrupt, too old, future-dated by
- * a backwards clock step, or answered by a reload that changed nothing) must not
- * survive to be re-judged by a later boot.
+ * a backwards clock step) must not survive to be re-judged by a later boot.
+ *
+ * `"unchanged"` is #1063's addition and it is gated on `origin === "user"`. A
+ * reload nobody asked for that changed nothing is a non-event and stays silent,
+ * exactly as #674 and #695 ship today; a reload a HUMAN asked for that changed
+ * nothing is the whole complaint — the page comes back identical, the banner
+ * reappears, and "it did not work" is indistinguishable from "I mis-tapped".
  */
-export function consumeBundleRefreshNotice(now: number, bootHash: string | null): boolean {
+export function consumeBundleRefreshNotice(
+  now: number,
+  bootHash: string | null,
+): BundleRefreshOutcome {
   const marker = readMarker();
   sessionStorage.removeItem(BUNDLE_REFRESH_NOTICE_KEY);
-  if (marker === null) return false;
+  if (marker === null) return "none";
   const elapsed = now - marker.at;
-  if (elapsed < 0 || elapsed > BUNDLE_REFRESH_NOTICE_WINDOW_MS) return false;
-  // Unknown on either side is not proof of a change, and an announcement is a
-  // claim. Costs no honest case: the branch that writes the marker only fires
-  // when both hashes are known and differ.
-  if (marker.from === null || bootHash === null) return false;
-  return bootHash !== marker.from;
+  if (elapsed < 0 || elapsed > BUNDLE_REFRESH_NOTICE_WINDOW_MS) return "none";
+  // Unknown on either side is not proof of anything, and either announcement is
+  // a claim. Silence rather than a guess, the same posture
+  // `shouldShowRefreshBanner` takes.
+  if (marker.from === null || bootHash === null) return "none";
+  if (bootHash !== marker.from) return "changed";
+  return marker.origin === "user" ? "unchanged" : "none";
 }
 
 /**
@@ -162,6 +235,21 @@ export function formatBundleRefreshToast(version: string | null, hash: string | 
 }
 
 /**
+ * The toast for a refresh that ran and moved nothing.
+ *
+ * DELIBERATELY DOES NOT DIAGNOSE. "The update did not apply" would be a lie
+ * whenever there was nothing to apply — the operator can press Refresh with no
+ * deploy waiting (the boot-error recovery button does exactly that) — and this
+ * document cannot tell the two apart: `bundle_hash` is a server push that has
+ * not landed yet when `Toasts` mounts. What it CAN say is what it is running,
+ * which is the fact the operator is missing. Read next to the banner, which
+ * reappears only in the failed case, it separates them without guessing.
+ */
+export function formatBundleUnchangedToast(version: string | null, hash: string | null): string {
+  return `Still on ${versionLabel(version, hash)}`;
+}
+
+/**
  * Announce the refresh, if this boot is the one it landed in.
  *
  * The bundle identity is passed rather than read from `bundleHash` so this
@@ -174,6 +262,14 @@ export function announceAppliedBundleRefresh(
   bootHash: string | null,
   version: string | null,
 ): void {
-  if (!consumeBundleRefreshNotice(now, bootHash)) return;
-  queue.queue({ text: formatBundleRefreshToast(version, bootHash) });
+  switch (consumeBundleRefreshNotice(now, bootHash)) {
+    case "changed":
+      queue.queue({ text: formatBundleRefreshToast(version, bootHash) });
+      return;
+    case "unchanged":
+      queue.queue({ text: formatBundleUnchangedToast(version, bootHash) });
+      return;
+    case "none":
+      return;
+  }
 }

--- a/cicchetto/src/lib/bundleRefreshNotice.ts
+++ b/cicchetto/src/lib/bundleRefreshNotice.ts
@@ -72,11 +72,13 @@ export const BUNDLE_REFRESH_NOTICE_KEY = "cicchetto.bundleRefreshAt";
  * exists to avoid.
  *
  * Marking later — a `beforeReload` hook in `performRefresh`'s `finally` — would
- * measure the navigation alone and allow a much tighter window. Rejected for
- * now: `performRefresh` is shared with the manual banner click, which must not
- * mark, so the hook would put a parameter on a shared verb for one caller's
- * benefit. Five minutes is the cheaper answer while the HASH guard, not this
- * one, is what proves something actually changed.
+ * measure the navigation alone and allow a much tighter window. Still rejected,
+ * though #1063 removed the original reason: the manual banner click DOES mark
+ * now, so "one caller's benefit" no longer applies. What is left is that the
+ * hook would move the write inside the shared SW verb for a tighter fence that
+ * buys nothing — the HASH guard, not this one, is what proves something
+ * actually changed. `requestBundleRefresh` marks around `performRefresh`
+ * instead, which keeps the verb ignorant of the notice entirely.
  */
 export const BUNDLE_REFRESH_NOTICE_WINDOW_MS = 300_000;
 

--- a/cicchetto/src/lib/errorBanners.ts
+++ b/cicchetto/src/lib/errorBanners.ts
@@ -1,5 +1,6 @@
 import { createSignal, untrack } from "solid-js";
-import { performRefresh, refreshBannerMessage, shouldShowRefreshBanner } from "./bundleHash";
+import { refreshBannerMessage, shouldShowRefreshBanner } from "./bundleHash";
+import { requestBundleRefreshNow } from "./bundleRefreshNotice";
 import { acceptInvite, declineInvite } from "./channelJoin";
 import { isOffline } from "./connectivity";
 import { acceptPushOptin, declinePushOptin, shouldShowPushOptinBanner } from "./pushOptin";
@@ -201,7 +202,12 @@ export function activeBanners(): BannerEntry[] {
       source: "bundle-refresh",
       severity: "info",
       message: refreshBannerMessage(),
-      actionHint: { label: "Refresh", onAction: () => void performRefresh() },
+      // #1063 — `"user"` because a human pressed it, and that is what buys the
+      // "Still on X" answer when the reload lands on the same bundle. The
+      // silence this replaces was the complaint: the page comes back looking
+      // identical with the same banner on it, so "it did not work" and "I
+      // mis-tapped" are the same picture.
+      actionHint: { label: "Refresh", onAction: () => void requestBundleRefreshNow("user") },
     });
   }
 

--- a/cicchetto/src/main.tsx
+++ b/cicchetto/src/main.tsx
@@ -18,8 +18,8 @@ import "./lib/subscribe";
 import "./lib/userTopic";
 import { isDiagEnabled } from "./DiagFloat";
 import { mountBadgeReconcile, mountBadgeSync } from "./lib/badge";
-import { bootBundleHashAccessor, performRefresh, shouldShowRefreshBanner } from "./lib/bundleHash";
-import { markBundleRefreshApplied } from "./lib/bundleRefreshNotice";
+import { bootBundleHashAccessor, shouldShowRefreshBanner } from "./lib/bundleHash";
+import { requestBundleRefresh } from "./lib/bundleRefreshNotice";
 import { applyCachedCustomTheme, mountCustomThemeSync } from "./lib/customTheme";
 import { diagPush } from "./lib/diagLog";
 import { mountDisplayPrefsSync } from "./lib/displayPrefs";
@@ -279,10 +279,16 @@ moduleRoot(() => {
     isVisible: isDocumentVisible,
     bundleMismatch: shouldShowRefreshBanner,
     now: () => Date.now(),
-    reload: (reason) => {
-      if (reason === "bundle") markBundleRefreshApplied(Date.now(), bootBundleHashAccessor());
-      void performRefresh();
-    },
+    // #1063 — the branch still decides, the notice module still owns the
+    // write. `"auto"` announces only when the bundle actually moved (#674
+    // unchanged); `"silent"` marks nothing at all, because a document thrown
+    // away for AGE (#695) has nothing to tell anyone either way.
+    reload: (reason) =>
+      void requestBundleRefresh(
+        Date.now(),
+        bootBundleHashAccessor(),
+        reason === "bundle" ? "auto" : "silent",
+      ),
     win: window,
   });
   const heartbeat = createVisibilityHeartbeat(() => {


### PR DESCRIPTION
Acceptance 3 of #1063 — the "visible feedback" half. Fork B, Option 1, as ruled.

## The complaint

`performRefresh` bounds every step, and when a ceiling fires the cache purge is SKIPPED: the
reload happens and the old precached `index.html` is served again. The operator sees the page
blink, come back identical, with the same banner still on it. That is indistinguishable from
"I did not press hard enough" — so they press again. It is #1063's three-presses report seen
from the user's side.

Pressing Refresh was silent **by omission**: the composition root marked the cross-reload
notice for #674's auto-refresh, and the two Refresh BUTTONS did not.

## What changes for #775 — in the user's terms

This is a **behaviour change to another issue's feature**, so it is stated here rather than
left in the diff.

**Before:** you press Refresh, the page reloads, nothing is said — whether it worked or not.

**After:** the page that comes back tells you which happened.

- it worked → **"Updated to 0.13.0 (a1b2c3d)"** — *the change*: a successful manual refresh
  used to be silent and now speaks. Accepted by least surprise: after you press a button,
  silence is the surprise.
- it ran and moved nothing → **"Still on 0.13.0 (a1b2c3d)"** — the new case, and the reason
  this exists.

Untouched: #674's auto-refresh (one toast when a deploy landed while you were away, silence
when nothing changed) and #695's age-reload (completely silent, still).

### Why "Still on X" and not "the update did not apply"

The latter is a lie whenever there was nothing to apply — the boot-error Refresh button
refreshes with no deploy waiting. And this document cannot tell the two apart: `bundle_hash`
is a server push that has not landed when `Toasts` mounts. So it states the one thing it knows,
which is also the fact the operator is missing. Next to the banner — which reappears only in
the failed case — that separates them without guessing.

## Shape

The EXISTING marker grows one field. No parallel state; that is why this option won.

```
Marker { at, from }                    →  Marker { at, from, origin: "user" | "auto" }
consumeBundleRefreshNotice(): boolean  →  "changed" | "unchanged" | "none"
```

`requestBundleRefresh` becomes the single writer. Three call sites, each naming its origin:
`"auto"` for #674's deploy branch, `"silent"` for #695's age branch (writes no marker at all),
`"user"` for both Refresh buttons. `performRefresh` is deliberately untouched —
`bundleRefreshNotice` already depends on `bundleHash` for `versionLabel`, so pushing the write
down into the shared verb would make the two mutually recursive for nothing.

The marker crosses a DEPLOY, so the first boot after this lands reads one written by the OLD
bundle with no `origin`. That is read as `"auto"` — the only writer that existed — because
anything else drops #775's toast on the very deploy that introduces the feature.

## Mutation table — every mutant run, output read

| # | mutation | result |
|---|---|---|
| M1 | `"unchanged"` branch → always `"none"` | **1 failed / 79 passed** — the fork's own case, alone |
| M2 | banner press marks `"auto"` instead of `"user"` | **1 failed / 79 passed** — the button-level test, alone |
| M3 | legacy marker default `"auto"` → `"user"` | **1 failed / 37 passed** — the cross-deploy case, alone |

M2 exists because I nearly shipped a hole: the two tests this fork asked for both mark the
notice themselves, so they stay green with the button wired to `"auto"` — they test the module,
not the feature. The `errorBanners` test driven through the registry's own `actionHint.onAction`
is what closes it.

## Does #674 double-toast now? No.

One marker, read-and-cleared on every path before deciding; one consumer (`Toasts`'s `onMount`),
pushing at most one item. The two `<Toasts />` mounts (`Shell.tsx:598` desktop, `:879` mobile)
are mutually exclusive, so crossing the breakpoint can fire `onMount` twice — the second finds
the marker cleared and says nothing. Two WRITES before one reload collide on one key, last
writer wins, still one toast.

## Not claimed

No real-browser verification: this is vitest + jsdom, which has no service worker and no
precache. The mechanism itself — ceiling fires, purge skipped, old shell re-served — is
simulated by passing the same hash to the consume function, not reproduced. That needs the e2e
stack. `bun run build` not run.

## Test plan

- [x] `bun run check` (biome + tsc) — rc 0
- [x] `bun run test` — rc 0, 4778 passed / 255 files (baseline 4768)
- [x] three mutants, one assertion killed each, none survived
- [ ] `integration` on this PR
- [ ] a real browser press of Refresh with the purge skipped