### PR TITLE
cic(#1072): give the home window its typography back

### DIFF
--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -10565,13 +10565,16 @@ html.resize-dragging * {
   padding: var(--adm-space-4);
   /* Admin redesign follow-up (2026-08-07) — the home window adopts the
      console's dashboard shape: cards on a raised backdrop rather than
-     rules and bare text. Data stays monospace (a slug, a nick, a state
-     are identifiers); the chrome around it goes proportional. */
+     rules and bare text.
+     #1072 — the SHAPE stayed, the TYPE went back: the whole window is
+     monospace at the client's own size again, because "dashboard for the
+     console, irssi for the client" is a line the maintainer redrew after
+     seeing `--adm-font` land here. */
   display: flex;
   flex-direction: column;
   gap: var(--adm-space-4);
   background: var(--adm-surface-1);
-  font-family: var(--adm-font);
+  font-family: var(--font-mono);
   font-size: var(--font-size);
   color: var(--adm-text);
   min-height: 0;
@@ -10743,6 +10746,12 @@ button.home-pane-network-title:hover .home-pane-network-slug {
   gap: 0.4rem;
   color: var(--adm-accent);
   border-color: var(--adm-accent);
+  /* #1072 — `.adm-btn` supplies the metrics AND the console's type. The
+     metrics are wanted (44px, shared radius); the type is not, so it is
+     named back here rather than by dropping the class. */
+  font-family: var(--font-mono);
+  font-size: var(--font-size);
+  font-weight: bold;
 }
 
 .home-pane-network-browse:hover {
@@ -10781,12 +10790,14 @@ button.home-pane-network-title:hover .home-pane-network-slug {
 
 .home-pane-section-title {
   margin: 0 0 var(--adm-space-3) 0;
-  font-family: var(--adm-font);
   color: var(--adm-text-dim);
-  font-size: 0.68rem;
-  font-weight: 600;
+  /* #1072 — back to the client's own scale: 0.68rem uppercase at 600 is
+     the console's eyebrow label, and it is the single biggest "smaller
+     and less retro" in the window. */
+  font-size: 0.95rem;
+  font-weight: normal;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.08em;
 }
 
 /* #496 — one-line intros that precede a list (networks / available /
@@ -11201,11 +11212,11 @@ button.home-pane-network-title:hover .home-pane-network-slug {
   padding: 0.1rem var(--adm-space-2);
   border: 1px solid transparent;
   border-radius: 999px;
-  font-family: var(--adm-font);
   text-transform: uppercase;
-  font-size: 0.72rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
+  /* #1072 — the badge SHAPE stays; its type goes back to the relative
+     0.8em bold the rest of the client uses for a state label. */
+  font-size: 0.8em;
+  font-weight: bold;
 }
 
 .home-pane-network-row-connected .home-pane-network-state {
@@ -11257,6 +11268,12 @@ button.home-pane-network-title:hover .home-pane-network-slug {
   align-items: center;
   justify-content: center;
   box-sizing: border-box;
+  /* #1072 — the chips all carry `.adm-btn` for its metrics, which also
+     drags the console's sans in. Named back once here, on the class the
+     three chips already share, rather than three times below. Reconnect
+     still overrides the weight it always had. */
+  font-family: var(--font-mono);
+  font-size: var(--font-size);
 }
 
 .home-pane-network-reconnect {


### PR DESCRIPTION
Refs #1072.

## What

`18b7ac30` put the home window on the admin console's type scale. vjt
asked for the previous one back — *"erano più retrò e più grandi i
font"*. This gives back the type and only the type.

| rule | back to |
| --- | --- |
| `.home-pane` | `font-family: var(--font-mono)` |
| `.home-pane-section-title` | `0.95rem` / `normal` / `0.08em`, no `--adm-font` |
| `.home-pane-network-state` | `0.8em` / `bold`, no `--adm-font`, no letter-spacing |
| `.home-pane-network-browse` | `--font-mono` / `var(--font-size)` / `bold` |
| `.home-pane-network-action` | `--font-mono` / `var(--font-size)` |

## The scope call, stated plainly

The issue body says "revert the commit"; its title, its before/after
table and all three acceptance bullets say *typography*, and bullet 3
already carves the 44px tap floor out of the revert. So this is **not**
a `git revert` — the cards, the raised backdrop, the pill state badge,
the danger Disconnect and the tap floor all stay. vjt complained about
fonts; only fonts moved. If he wants the dashboard shape gone too, that
is a separate one-line follow-up rather than something to assume here.

## The buttons

`16898b52` put `.adm-btn` on every home button and deleted their
duplicated rules. `.adm-btn` supplies metrics *and* type; only the
metrics are wanted. Dropping the class would take the tap floor with
it, so the type is named back on the two home classes those buttons
already carry — `.home-pane-network-action` (Disconnect / Reconnect /
Map) and `.home-pane-network-browse` (Browse / Register / Recover).
Both sit after `.adm-btn` at equal specificity, so source order decides.

A `.home-pane .adm-btn { … }` catch-all was considered and rejected: at
(0,2,0) it would also override `.home-pane-available-connect`'s
`0.95rem`, which predates this whole episode.

## What I am NOT claiming

- **Colour is untouched.** `.home-pane-section-title` is
  `--adm-text-dim` where it was `--accent` at `opacity: 0.85`. That is a
  real visible difference and arguably part of "less retro", but it is
  not a font token and it is not in the issue's table. Say the word and
  it is one line.
- **No test.** Nothing in `src/` or `e2e/` references these classes;
  there is no behaviour here, only declared values. A spec asserting
  `font-family === var(--font-mono)` would restate the stylesheet, so I
  did not write one. **This change is unverified beyond the gates** — it
  wants an eyeball.
- The issue's table labels the fourth row "featured link". It is
  actually `.home-pane-network-state`; `.home-pane-featured-link` is
  `font: inherit` and was never retyped.

## Gates

| gate | rc |
| --- | --- |
| `bun run check` | 0 |
| `bun run test` | 0 — 255 files, 4768 tests |
| `bun run build` | 0 |

No e2e run: the stack is contended and I was told to ask before taking it.