### PR TITLE
cic(#1077): dim a muted conversation's badges

### DIFF
--- a/cicchetto/src/WindowBadges.tsx
+++ b/cicchetto/src/WindowBadges.tsx
@@ -1,6 +1,8 @@
 import { type Component, Show } from "solid-js";
-import type { ChannelKey } from "./lib/channelKey";
+import { type ChannelKey, decodeChannelKey } from "./lib/channelKey";
+import { conversationMuteKey, isConversationMuted } from "./lib/conversationMute";
 import { mentionCounts } from "./lib/mentions";
+import { notificationPrefs } from "./lib/notificationPrefs";
 import { farBehindByChannel } from "./lib/scrollback";
 import { eventsUnread, messagesUnread } from "./lib/selection";
 
@@ -37,6 +39,17 @@ export type WindowBadgesVariant = keyof typeof BADGE_CLASSES;
 // the token itself is one string so the two surfaces cannot drift apart.
 export const FAR_BEHIND_CLASS = "far-behind";
 
+// #1077 — the modifier that says "this conversation is muted". Same shape as
+// FAR_BEHIND_CLASS for the same reason: one token, qualified per badge class
+// in the stylesheet, so the two surfaces cannot drift.
+//
+// It REVISES #866 Q4, which had answered "does the mute change the badge?"
+// with no. It still does not change what the badge MEANS or what it counts —
+// only how loudly it says it. Dimming, deliberately not a second colour: a
+// different hue would make the muted badge a different KIND of thing, and
+// the ask was for the same thing, quieter.
+export const MUTED_CLASS = "conversation-muted";
+
 export type BadgeKind = "messages" | "events";
 
 // What the badge SAYS, as opposed to what it shows. A bare "1832" inside a
@@ -65,6 +78,25 @@ const WindowBadges: Component<Props> = (props) => {
   const messages = () => messagesUnread()[props.channelKey] ?? 0;
   const events = () => eventsUnread()[props.channelKey] ?? 0;
   const mentions = () => mentionCounts()[props.channelKey] ?? 0;
+  // #1077 — the SAME predicate the cycle-skip consults (`activeWindows`
+  // .orderUnreadWindows, #1018), so the badge cannot drift from the mute it
+  // is reporting. `notificationPrefs()` is read as a signal, not snapshotted:
+  // lifting a mute must restore full brightness without a reload.
+  //
+  // The mute key is network-AGNOSTIC (#866 Q5) while a ChannelKey is
+  // network-scoped, so only the name half feeds it — taken through the paired
+  // `decodeChannelKey` rather than a hand-rolled `indexOf(" ")`, because the
+  // key shape has exactly one decoder by contract. A query window's
+  // `channelName` IS the peer nick, so this covers DMs with no second branch.
+  // The fold is idempotent, so folding an already-folded name is free and the
+  // call site stays honest about what kind of string it needs.
+  const muted = () => {
+    const decoded = decodeChannelKey(props.channelKey);
+    return (
+      decoded !== null &&
+      isConversationMuted(notificationPrefs().muted_targets, conversationMuteKey(decoded.name))
+    );
+  };
 
   // BOTH unread badges take the treatment, not just the message one: the
   // far-behind branch of `perChannelUnread` skips local counting wholesale
@@ -87,7 +119,7 @@ const WindowBadges: Component<Props> = (props) => {
       <Show when={messages() > 0}>
         <span
           class={classes().messages}
-          classList={{ [FAR_BEHIND_CLASS]: farBehind() }}
+          classList={{ [FAR_BEHIND_CLASS]: farBehind(), [MUTED_CLASS]: muted() }}
           role="img"
           title={farBehind() ? badgeLabel(messages(), "messages", true) : undefined}
           aria-label={badgeLabel(messages(), "messages", farBehind())}
@@ -98,7 +130,7 @@ const WindowBadges: Component<Props> = (props) => {
       <Show when={events() > 0}>
         <span
           class={classes().events}
-          classList={{ [FAR_BEHIND_CLASS]: farBehind() }}
+          classList={{ [FAR_BEHIND_CLASS]: farBehind(), [MUTED_CLASS]: muted() }}
           role="img"
           title={farBehind() ? badgeLabel(events(), "events", true) : undefined}
           aria-label={badgeLabel(events(), "events", farBehind())}
@@ -107,7 +139,9 @@ const WindowBadges: Component<Props> = (props) => {
         </span>
       </Show>
       <Show when={mentions() > 0}>
-        <span class={classes().mention}>@{mentions()}</span>
+        <span class={classes().mention} classList={{ [MUTED_CLASS]: muted() }}>
+          @{mentions()}
+        </span>
       </Show>
     </>
   );

--- a/cicchetto/src/__tests__/BottomBar.test.tsx
+++ b/cicchetto/src/__tests__/BottomBar.test.tsx
@@ -58,7 +58,12 @@ vi.mock("../lib/mentions", () => ({
   setServerMention: vi.fn(),
 }));
 
-vi.mock("../lib/channelKey", () => ({
+// #1077 — spread the ORIGINAL and override only the encoder, so
+// `canonicalChannel` / `decodeChannelKey` resolve for real: the badge's mute
+// lookup reaches them through `conversationMute`, and a partial mock that
+// omits an export fails at first ACCESS rather than at mock time.
+vi.mock("../lib/channelKey", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/channelKey")>()),
   channelKey: (slug: string, name: string) => `${slug} ${name}`,
 }));
 

--- a/cicchetto/src/__tests__/Sidebar.test.tsx
+++ b/cicchetto/src/__tests__/Sidebar.test.tsx
@@ -112,13 +112,14 @@ vi.mock("../lib/mentionsWindow", () => ({
   mentionsBundleBySlug: () => mockMentionsBundles,
 }));
 
-vi.mock("../lib/channelKey", () => ({
+// #1077 — spread the ORIGINAL and override only the encoder. The rest of the
+// module is real: `decodeChannelKey` was re-implemented here byte for byte
+// (a copy of production logic in a test, which CLAUDE.md forbids), and
+// `canonicalChannel` was simply absent — which the badge's mute lookup, which
+// reaches it through `conversationMute`, needs to resolve.
+vi.mock("../lib/channelKey", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/channelKey")>()),
   channelKey: (slug: string, name: string) => `${slug} ${name}`,
-  decodeChannelKey: (key: string) => {
-    const sepIdx = key.indexOf(" ");
-    if (sepIdx < 0) return null;
-    return { slug: key.slice(0, sepIdx), name: key.slice(sepIdx + 1) };
-  },
 }));
 
 vi.mock("../lib/queryWindows", () => ({

--- a/cicchetto/src/__tests__/WindowBadges.test.tsx
+++ b/cicchetto/src/__tests__/WindowBadges.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // #888 — the far-behind unread badge.
@@ -34,17 +35,34 @@ vi.mock("../lib/mentions", () => ({
   mentionCounts: () => mockMentions.value,
 }));
 
+// #1077 — a REAL signal behind the mute list, not a plain holder. The
+// acceptance is explicitly reactive ("unmuting restores full brightness
+// without a reload"), and a getter over a mutable object satisfies a
+// re-rendered assertion while a snapshot read would too. Only a signal that
+// notifies mid-life can tell the two apart. `conversationMute` itself stays
+// REAL — the badge must consult the same predicate the cycle-skip does, and
+// stubbing it would assert the stub.
+const [mutedTargets, setMutedTargets] = createSignal<
+  Record<string, { until: number | null }> | undefined
+>({});
+vi.mock("../lib/notificationPrefs", () => ({
+  notificationPrefs: () => ({ muted_targets: mutedTargets() }),
+}));
+
 import { channelKey } from "../lib/channelKey";
-import WindowBadges, { badgeLabel, FAR_BEHIND_CLASS } from "../WindowBadges";
+import { conversationMuteKey } from "../lib/conversationMute";
+import WindowBadges, { badgeLabel, FAR_BEHIND_CLASS, MUTED_CLASS } from "../WindowBadges";
 
 const BEHIND = channelKey("freenode", "#italia");
 const NORMAL = channelKey("freenode", "#bnc");
+const DM = channelKey("freenode", "Vjt");
 
 beforeEach(() => {
   mockFarBehind.value = {};
-  mockMessages.value = { [BEHIND]: 1832, [NORMAL]: 3 };
+  mockMessages.value = { [BEHIND]: 1832, [NORMAL]: 3, [DM]: 7 };
   mockEvents.value = { [BEHIND]: 40, [NORMAL]: 2 };
   mockMentions.value = {};
+  setMutedTargets({});
 });
 
 describe("#888 far-behind badge treatment", () => {
@@ -138,5 +156,83 @@ describe("#888 far-behind badge treatment", () => {
     mockEvents.value = {};
     const { container } = render(() => <WindowBadges channelKey={NORMAL} variant="sidebar" />);
     expect(container.querySelector("span")).toBeNull();
+  });
+});
+
+// #1077 — a muted conversation's badges dim. #866 Q4 had answered "does the
+// mute change the badge?" with no; this revises that to "yes, visually". The
+// counts and the cycle are untouched — `orderUnreadWindows` is not involved
+// here at all — so what these tests constrain is the modifier and nothing else.
+describe("#1077 muted badge treatment", () => {
+  it("dims all three badges of a muted channel", () => {
+    mockMentions.value = { [BEHIND]: 4 };
+    setMutedTargets({ [conversationMuteKey("#italia")]: { until: null } });
+    const { container } = render(() => <WindowBadges channelKey={BEHIND} variant="sidebar" />);
+
+    // All three, not just the two counters: #866 Q2 already ruled that a
+    // mention inside a muted room is not a stop, so a full-strength `@4`
+    // beside two dimmed counters would contradict a decision already made.
+    for (const sel of [".sidebar-msg-unread", ".sidebar-events-unread", ".sidebar-mention"]) {
+      expect(container.querySelector(sel)?.classList.contains(MUTED_CLASS)).toBe(true);
+    }
+    // A treatment, not a rewrite — the numbers are the same numbers.
+    expect(container.querySelector(".sidebar-msg-unread")?.textContent).toBe("1832");
+    expect(container.querySelector(".sidebar-mention")?.textContent).toBe("@4");
+  });
+
+  it("dims a muted DM, keyed on the peer nick and folded", () => {
+    // The window is `Vjt`; the mute was stored for `vjt`. The badge must fold
+    // to match, exactly as the notify path and the cycle-skip do — a raw
+    // compare here would leave a mixed-case query window shouting.
+    setMutedTargets({ [conversationMuteKey("vjt")]: { until: null } });
+    const { container } = render(() => <WindowBadges channelKey={DM} variant="sidebar" />);
+    expect(container.querySelector(".sidebar-msg-unread")?.classList.contains(MUTED_CLASS)).toBe(
+      true,
+    );
+  });
+
+  it("leaves an unmuted window at full strength", () => {
+    setMutedTargets({ [conversationMuteKey("#italia")]: { until: null } });
+    const { container } = render(() => <WindowBadges channelKey={NORMAL} variant="sidebar" />);
+    // The mute belongs to a DIFFERENT conversation; nothing about it may reach
+    // this one.
+    expect(container.querySelector(".sidebar-msg-unread")?.classList.contains(MUTED_CLASS)).toBe(
+      false,
+    );
+  });
+
+  it("restores full brightness the moment the mute is lifted, with no re-render", () => {
+    setMutedTargets({ [conversationMuteKey("#italia")]: { until: null } });
+    const { container } = render(() => <WindowBadges channelKey={BEHIND} variant="sidebar" />);
+    const msg = container.querySelector(".sidebar-msg-unread");
+    expect(msg?.classList.contains(MUTED_CLASS)).toBe(true);
+
+    // The SAME node, after the mute list changes underneath it. Re-rendering
+    // here would pass even against a snapshot read, which is the whole defect
+    // the acceptance names.
+    setMutedTargets({});
+    expect(msg?.classList.contains(MUTED_CLASS)).toBe(false);
+  });
+
+  it("composes with the far-behind treatment rather than replacing it", () => {
+    mockFarBehind.value = { [BEHIND]: { missed: 1832, resumeFrom: 10 } };
+    setMutedTargets({ [conversationMuteKey("#italia")]: { until: null } });
+    const { container } = render(() => <WindowBadges channelKey={BEHIND} variant="sidebar" />);
+    const msg = container.querySelector(".sidebar-msg-unread");
+    expect(msg?.classList.contains(FAR_BEHIND_CLASS)).toBe(true);
+    expect(msg?.classList.contains(MUTED_CLASS)).toBe(true);
+  });
+
+  it("applies the same modifier on the mobile bottom-bar variant", () => {
+    mockMentions.value = { [BEHIND]: 4 };
+    setMutedTargets({ [conversationMuteKey("#italia")]: { until: null } });
+    const { container } = render(() => <WindowBadges channelKey={BEHIND} variant="bottom-bar" />);
+    for (const sel of [
+      ".bottom-bar-msg-unread",
+      ".bottom-bar-events-unread",
+      ".bottom-bar-mention",
+    ]) {
+      expect(container.querySelector(sel)?.classList.contains(MUTED_CLASS)).toBe(true);
+    }
   });
 });

--- a/cicchetto/src/lib/activeWindows.ts
+++ b/cicchetto/src/lib/activeWindows.ts
@@ -119,9 +119,11 @@ export function orderUnreadWindows(input: OrderInput): ActiveWindow[] {
     })
     // #1018 — the mute drops the window from the CYCLE, and it beats the
     // tier: a mention inside a muted room is still not a stop (#866 Q2,
-    // "the mute always wins"). Everything else about the window is
-    // untouched — its sidebar unread badge and the mention counters keep
-    // rendering exactly as before (#866 Q4).
+    // "the mute always wins"). The COUNTS are untouched — the badges still
+    // render, still show the same numbers, and the window still sits in the
+    // sidebar. #1077 revised #866 Q4 on one axis only: those badges now
+    // render DIMMED (`WindowBadges.MUTED_CLASS`, same predicate as here), a
+    // visual weight change and nothing else.
     .filter((r) => r.unread > 0 && !r.muted);
 
   ranked.sort((a, b) => {

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -1729,6 +1729,32 @@ html.resize-dragging * {
   padding: 0 calc(0.3rem - 1px);
 }
 
+/* #1077 — a muted conversation's badges dim. Same hue, less brightness: the
+   ask was explicitly NOT a second colour, because a different hue would make
+   the muted badge a different KIND of thing rather than the same thing said
+   quietly.
+
+   `opacity`, which is also why it composes: `.far-behind` paints border,
+   background and colour and never touches opacity, so a window that is muted
+   AND far behind keeps both treatments instead of one winning.
+
+   All three badges, not just the two counters. #866 Q2 already ruled that a
+   mention inside a muted room is not a stop; a full-strength `@4` beside two
+   dimmed counters would contradict a decision the codebase has already made.
+
+   The events badge is written separately because it already sits at 0.7 and
+   `opacity` does not compound across declarations on one element — 0.45 there
+   would make it BRIGHTER than it is unmuted. 0.32 is the product, spelled out
+   rather than computed so the value you read is the value that renders. */
+.sidebar-msg-unread.conversation-muted,
+.sidebar-mention.conversation-muted {
+  opacity: 0.45;
+}
+
+.sidebar-events-unread.conversation-muted {
+  opacity: 0.32;
+}
+
 /* CP15 B5 — greyed window-row treatment for failed/kicked/parked
    channels and DM targets. Italic + dim mirror `.sidebar-channel-name.parted`
    (the per-channel "you've parted" visual) but apply at the row button
@@ -6854,6 +6880,18 @@ html.resize-dragging * {
 .bottom-bar-events-unread.far-behind {
   border: 1px solid var(--muted);
   padding: 0 calc(0.2rem - 1px);
+}
+
+/* #1077 — the mobile twin. Same modifier token from `WindowBadges`, same
+   values: the dimming is a statement about the conversation, and the
+   conversation is the same one on both surfaces. */
+.bottom-bar-msg-unread.conversation-muted,
+.bottom-bar-mention.conversation-muted {
+  opacity: 0.45;
+}
+
+.bottom-bar-events-unread.conversation-muted {
+  opacity: 0.32;
 }
 
 /* UX-3 DEC: dropped `.bottom-bar-tab-wrap` <span> — tab + close ×


### PR DESCRIPTION
Refs #1077.

## What

A muted conversation's badges now render dimmed — **same hue, lower
intensity**, per vjt's explicit constraint ("non colore diverso ma meno
bright"). Counts, cycle order and mute semantics are untouched.

`WindowBadges.tsx` gains `MUTED_CLASS`, following the `FAR_BEHIND_CLASS`
precedent exactly: one exported token, applied via `classList`, qualified
per badge class in the stylesheet. One component, both surfaces.

## Decisions worth reading

- **It revises #866 Q4.** That question — "does the mute change the
  badge?" — was answered *no*, deliberately. This changes it to *yes,
  visually only*. The `activeWindows.ts` comment stating the old answer
  is updated rather than left contradicting the code.
- **All three badges, mention included.** #866 Q2 already ruled a
  mention inside a muted room is not a stop; a full-strength `@4` beside
  two dimmed counters would contradict that. The issue flagged this as a
  possible shrink — say the word and the mention stays bright.
- **`opacity`, and that is why it composes.** `.far-behind` paints
  border/background/colour and never touches opacity, so muted + far
  behind keeps both treatments.
- **The events badge gets its own value (0.32, not 0.45).** It already
  sits at `opacity: 0.7`, and opacity does not compound across
  declarations on one element — reusing 0.45 would have made it
  *brighter* muted than unmuted. Written out rather than `calc`'d so the
  value you read is the value that renders.
- **Key derivation.** `decodeChannelKey` (the paired decoder), then
  `conversationMuteKey`, then the shared `isConversationMuted`. Not a
  hand-rolled `indexOf(" ")` and not a raw `===`: identifier matches
  fold, and the key shape has exactly one decoder by contract.

## Tests

Six new cases in `WindowBadges.test.tsx`, red before the change:
muted channel (all three badges) · muted DM keyed on the folded peer nick
· an unmuted neighbour left alone · **reactive unmute on the same DOM
node, no re-render** · composition with far-behind · the bottom-bar
variant.

The reactivity case is the load-bearing one, and I measured it rather
than assuming: replacing the signal read with a snapshot computed once at
setup kills **exactly that one assertion** and leaves the other twelve
green.

## The collateral, stated up front

`Sidebar.test.tsx` and `BottomBar.test.tsx` mocked `../lib/channelKey`
partially, without `canonicalChannel` — which now resolves through
`conversationMute`, so 102 tests in those two files went red. Both mocks
now spread `importOriginal` and override only the encoder they actually
mean to stub. Sidebar's also carried a byte-for-byte re-implementation of
`decodeChannelKey`; that is production logic copied into a test, and it
is gone.

I did **not** take the alternative of dropping the `conversationMuteKey`
fold to avoid touching the mocks. The name half of a `ChannelKey` is
already folded, so the fold is a no-op today and the issue says as much —
but "the string happens to be folded upstream" is the assumption
CLAUDE.md's identifier invariant exists to forbid, and it would break
silently if `channelKey()` ever stopped folding.

## What I am NOT claiming

- **The chosen opacities are unverified against real pixels.** 0.45 /
  0.32 are reasoned, not measured — I did not look at a rendered sidebar
  in either theme. If "meno bright" wants to be more or less than this,
  it is two numbers in `default.css`.
- **No e2e.** The stack is contended and I was told to ask first. The
  reactive-unmute acceptance is proven in vitest at the DOM level, not
  in a browser.
- **Custom themes are untested.** The rule is `opacity`, so it is
  theme-independent by construction, but I only reasoned that — I did
  not load a theme with a different badge palette.
- The issue's premise that #1038 may make the mute key network-scoped is
  not in play here: `origin/main` still has it network-agnostic, and this
  builds on that. If #1038 lands, this call site is one of the ones that
  needs the slug, and `decodeChannelKey` already hands it over.

## Gates

| gate | rc |
| --- | --- |
| `bun run check` | 0 |
| `bun run test` | 0 — 255 files, 4774 tests |
| `bun run build` | 0 |