### PR TITLE
cic(#1074): admin on a phone — no h-scroll, and the row detail opens in place

### DIFF
--- a/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
@@ -9,8 +9,7 @@
 // the parent's `pan-y` clamps back to `pan-y` only. Result: the
 // table renders an overflow-x scrollbar (visual cue) but iOS rejects
 // the horizontal pan, so the operator cannot read columns past the
-// viewport (sessions 656px / networks 631px / visitors 517px at
-// iPhone 15 content width 361px).
+// viewport.
 //
 // Fix (CSS-only, two declarations):
 //   1. `.admin-pane { touch-action: pan-x pan-y }` — relaxes the
@@ -18,6 +17,25 @@
 //   2. `.admin-tab-panel { overflow-x: auto; touch-action: pan-x pan-y }`
 //      — table scrolls inside the panel (not the page); the panel
 //      itself owns the gesture authority for pan-x.
+//
+// #1074 INVERTED the other half of this contract. The gesture
+// PERMISSION survives verbatim and is still asserted below: a table
+// that fits must not trap a horizontal swipe, and a future hand
+// re-tightening either declaration back to `pan-y` would silently
+// re-break the pane. What flipped is the positive-width twin. This
+// spec used to name Networks as `DETERMINISTIC_WIDE_TAB` and assert it
+// was WIDER than its panel, to prove the permission wasn't trivially
+// passing on an empty tab. Networks now drops its secondary columns
+// into the row's detail like every other tab, so the claim is the
+// opposite one: on a phone, NO admin tab is wider than its panel.
+//
+// The row-detail case at the bottom is the other half of the same
+// knot. The detail panel sat OUTSIDE the table, rendered before it,
+// precisely because the table was wider than a phone; opening a row
+// therefore pushed the list down and sent the viewport to the top
+// ("l'expansion delle righe non deve portare top"). It is an expand
+// row now, and the oracle is that the row it belongs to does not move
+// when it opens.
 //
 // Per `feedback_e2e_user_class_parity_matrix`: AdminPane is admin-
 // gated (EXEMPT). This spec runs the admin arm only; non-admin
@@ -28,6 +46,7 @@
 // has no IRC bind (m9b session-count == 2 hardcode); vjt has the bind
 // + autojoined #bofh so it can reach the mobile launcher footer.
 
+import type { Page } from "@playwright/test";
 import { expect, test } from "../fixtures/test";
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import {
@@ -42,14 +61,15 @@ import {
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const GRAPPA_BASE_URL = "http://grappa-test:4000";
 
-// Tabs whose default panel is wide enough on iPhone 15 to require
-// pan-x. Networks is the only deterministic-wide tab in the e2e seed
-// (2 seeded networks render a 631px-wide table on a 361px content
-// area). Visitors / Sessions tabs are empty in the baseline seed so
-// their wide-content assertion would false-fail; the cross-ancestor
-// touch-action check covers them via the loop below regardless.
-const WIDE_TABLE_TABS = ["visitors", "sessions", "networks"] as const;
-const DETERMINISTIC_WIDE_TAB = "networks" as const;
+// The tabs the pre-#1074 contract named as candidates for pan-x.
+// Networks is still the only one with rows in the baseline seed, so it
+// is still the only one whose width assertion carries information —
+// hence `DETERMINISTIC_POPULATED_TAB` below. Visitors / Sessions are
+// empty here and would pass the fits-the-panel check trivially; they
+// stay in the loop for the touch-action half, which does not depend on
+// content.
+const ADMIN_TABLE_TABS = ["visitors", "sessions", "networks"] as const;
+const DETERMINISTIC_POPULATED_TAB = "networks" as const;
 
 test.setTimeout(90_000);
 
@@ -68,11 +88,7 @@ async function findVjtUserId(adminToken: string): Promise<string> {
   return vjt.id;
 }
 
-async function setAdminFlag(
-  adminToken: string,
-  userId: string,
-  isAdmin: boolean,
-): Promise<void> {
+async function setAdminFlag(adminToken: string, userId: string, isAdmin: boolean): Promise<void> {
   const res = await fetch(`${GRAPPA_BASE_URL}/admin/users/${encodeURIComponent(userId)}`, {
     method: "PATCH",
     headers: {
@@ -101,9 +117,7 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
     await setAdminFlag(admin.token, vjtUserId, false);
   });
 
-  test("@webkit admin on mobile — wide admin tables permit pan-x via touch-action", async ({
-    page,
-  }) => {
+  async function openAdminPane(page: Page): Promise<void> {
     const admin = getSeededAdmin();
     await setAdminFlag(admin.token, vjtUserId, true);
 
@@ -113,27 +127,32 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
     await expect(sidebarWindow(page, NETWORK_SLUG, CHANNEL)).toBeVisible();
 
     await page.getByLabel(/open members sidebar/i).tap();
-    const drawer = page.locator(".shell-members.open");
-    await expect(drawer).toBeVisible({ timeout: 5_000 });
     // #500 — the admin button lives behind the rail launcher menu now.
     await openRailMenu(page);
     await page.locator(".rail-actions-menu [data-testid='mobile-panel-admin']").tap();
+    await expect(page.getByTestId("admin-pane")).toBeVisible({ timeout: 5_000 });
+  }
+
+  test("@webkit admin on mobile — admin tables permit pan-x and need none of it", async ({
+    page,
+  }) => {
+    await openAdminPane(page);
 
     const pane = page.getByTestId("admin-pane");
-    await expect(pane).toBeVisible({ timeout: 5_000 });
 
     // Pre-fix: `.admin-pane` declared `touch-action: pan-y` and the
     // CSS-spec INTERSECTION rule meant any descendant declaring
     // `pan-x pan-y` got clamped back to `pan-y` only. iOS rejected
     // the horizontal pan, the scrollbar appeared but the table did
-    // not move. Asserting both ancestor + scroller carry `pan-x` (in
-    // addition to `pan-y`) keeps the bug from regressing — a future
-    // hand re-tightening either one back to `pan-y` would re-break
-    // mobile h-scroll silently.
+    // not move. The permission stays asserted even though nothing
+    // needs to pan any more: a tab whose content grows past the
+    // viewport again (a long vhost address, a wide error) must still
+    // be readable, and a swipe that does nothing is the bug this
+    // bucket was opened for.
     const paneTouch = await pane.evaluate((el) => window.getComputedStyle(el).touchAction);
     expect(paneTouch, "admin-pane touch-action must allow pan-x").toMatch(/pan-x/);
 
-    for (const tab of WIDE_TABLE_TABS) {
+    for (const tab of ADMIN_TABLE_TABS) {
       await page.getByTestId(`admin-tab-${tab}`).tap();
       const panel = page.locator(`#admin-tab-${tab}`);
       await expect(panel).toBeVisible({ timeout: 5_000 });
@@ -152,75 +171,78 @@ test.describe("UX-6-G — admin pane horizontal scroll on mobile", () => {
       ).toMatch(/pan-x/);
       expect(
         panelStyle.overflowX,
-        `admin-tab-panel(${tab}) overflow-x must be auto/scroll for the table to be scrollable`,
+        `admin-tab-panel(${tab}) overflow-x must be auto/scroll so overflow scrolls the panel, not the page`,
       ).toMatch(/auto|scroll/);
-      // Positive twin: on the deterministic-wide tab, assert the panel
-      // actually has wider content than its viewport so the pan-x
-      // permission isn't trivially passing on an empty tab. The other
-      // wide-table tabs (visitors/sessions) are empty in the baseline
-      // seed and would false-fail this check.
-      if (tab === DETERMINISTIC_WIDE_TAB) {
+      // #1074 — the inverted twin. Networks is the tab with rows in the
+      // baseline seed, so it is the one where "nothing is wider than
+      // the panel" is a claim about real content rather than about an
+      // empty tab.
+      if (tab === DETERMINISTIC_POPULATED_TAB) {
         expect(
           panelStyle.scrollW,
-          `admin-tab-panel(${tab}) must contain wider content than its viewport for pan-x to be meaningful`,
-        ).toBeGreaterThan(panelStyle.clientW);
+          `admin-tab-panel(${tab}) must not be wider than its panel on a phone`,
+        ).toBeLessThanOrEqual(panelStyle.clientW);
       }
     }
   });
 
-  test("@webkit admin on mobile — pan-x gesture actually scrolls the wide table", async ({
-    page,
-  }) => {
-    const admin = getSeededAdmin();
-    await setAdminFlag(admin.token, vjtUserId, true);
+  test("@webkit admin on mobile — the populated tab has nothing to pan to", async ({ page }) => {
+    await openAdminPane(page);
 
-    const vjt = getSeededVjt();
-    await loginAs(page, vjt);
-    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
-    await expect(sidebarWindow(page, NETWORK_SLUG, CHANNEL)).toBeVisible();
-
-    await page.getByLabel(/open members sidebar/i).tap();
-    // #500 — the admin button lives behind the rail launcher menu now.
-    await openRailMenu(page);
-    await page.locator(".rail-actions-menu [data-testid='mobile-panel-admin']").tap();
-    await expect(page.getByTestId("admin-pane")).toBeVisible({ timeout: 5_000 });
-
-    await page.getByTestId("admin-tab-networks").tap();
-    const panel = page.locator("#admin-tab-networks");
+    await page.getByTestId(`admin-tab-${DETERMINISTIC_POPULATED_TAB}`).tap();
+    const panel = page.locator(`#admin-tab-${DETERMINISTIC_POPULATED_TAB}`);
     await expect(panel).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("admin-networks-table")).toBeVisible({ timeout: 10_000 });
 
-    // Drive panel.scrollLeft directly — the touch-action assertion in
-    // the sibling spec covers the gesture-permission half; this case
-    // ensures the panel is genuinely scrollable (not just paint-only)
-    // by exercising the same `el.scrollLeft` channel WebKit's pan
-    // handler eventually mutates. Pre-fix the table was a descendant
-    // of `.admin-networks-tab` which (sans `overflow-x: auto` on the
-    // parent panel) had no scrollLeft to mutate.
+    // The behavioural twin of the width assertion above, driven through
+    // the same `el.scrollLeft` channel WebKit's pan handler mutates.
+    // Pre-#1074 this asked for scrollLeft=100 and demanded it stick;
+    // now the demand is that the browser CLAMP it back to 0, because
+    // there is no overflow to travel into. A tab that quietly grows
+    // wide again fails here, not only in the computed-width check.
     const before = await panel.evaluate((el) => el.scrollLeft);
     expect(before, "panel starts at scrollLeft=0").toBe(0);
-    await panel.evaluate((el) => {
+    const after = await panel.evaluate((el) => {
       el.scrollLeft = 100;
+      return el.scrollLeft;
     });
-    const after = await panel.evaluate((el) => el.scrollLeft);
-    expect(after, "panel.scrollLeft must accept programmatic h-scroll").toBeGreaterThan(0);
+    expect(after, "no admin tab may have horizontal content to scroll into").toBe(0);
+  });
+
+  test("@webkit admin on mobile — opening a row's detail does not move the row", async ({
+    page,
+  }) => {
+    await openAdminPane(page);
+
+    await page.getByTestId(`admin-tab-${DETERMINISTIC_POPULATED_TAB}`).tap();
+    await expect(page.getByTestId("admin-networks-table")).toBeVisible({ timeout: 10_000 });
+
+    const expander = page.locator("[data-testid^='admin-network-expand-']").first();
+    await expect(expander).toBeVisible({ timeout: 5_000 });
+    const before = await expander.boundingBox();
+    expect(before, "expander must have a box before the tap").not.toBeNull();
+
+    await expander.tap();
+    await expect(expander).toHaveAttribute("aria-expanded", "true", { timeout: 5_000 });
+    await expect(page.locator(".adm-detail").first()).toBeVisible({ timeout: 5_000 });
+
+    // The whole complaint, as one number. When the panel rendered
+    // before the table, opening it inserted a card ABOVE this row and
+    // pushed it down the page — and `scrollIntoView` then dragged the
+    // viewport up to the card, leaving the operator somewhere they had
+    // not asked to be. In the row's own position the row stays put.
+    const after = await expander.boundingBox();
+    expect(after, "expander must still have a box after the tap").not.toBeNull();
+    expect(
+      Math.abs((after?.y ?? 0) - (before?.y ?? 0)),
+      "the row an operator tapped must not move when its detail opens",
+    ).toBeLessThanOrEqual(1);
   });
 
   test("@webkit admin on mobile — vertical scroll inside the pane still works", async ({
     page,
   }) => {
-    const admin = getSeededAdmin();
-    await setAdminFlag(admin.token, vjtUserId, true);
-
-    const vjt = getSeededVjt();
-    await loginAs(page, vjt);
-    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
-    await expect(sidebarWindow(page, NETWORK_SLUG, CHANNEL)).toBeVisible();
-
-    await page.getByLabel(/open members sidebar/i).tap();
-    // #500 — the admin button lives behind the rail launcher menu now.
-    await openRailMenu(page);
-    await page.locator(".rail-actions-menu [data-testid='mobile-panel-admin']").tap();
-    await expect(page.getByTestId("admin-pane")).toBeVisible({ timeout: 5_000 });
+    await openAdminPane(page);
 
     // Negative twin: relaxing `.admin-pane` from `pan-y` to `pan-x pan-y`
     // must keep pan-y intact (a careless rewrite to `pan-x` alone would

--- a/cicchetto/src/AdminCredentialsTab.tsx
+++ b/cicchetto/src/AdminCredentialsTab.tsx
@@ -87,6 +87,10 @@ function credKey(c: AdminCredential): string {
   return `${c.user_id}:${c.network_id}`;
 }
 
+// binding + nick + auth + connection + live + actions. Feeds the
+// detail row's `colspan`.
+const CREDENTIAL_COLUMNS = 6;
+
 const AdminCredentialsTab: Component = () => {
   const [credentials, setCredentials] = createSignal<AdminCredential[] | null>(null);
   const [users, setUsers] = createSignal<AdminUser[]>([]);
@@ -107,17 +111,11 @@ const AdminCredentialsTab: Component = () => {
   const [detailId, setDetailId] = createSignal<string | null>(null);
   const [sessionActionToast, setSessionActionToast] = createSignal<string | null>(null);
 
-  // The binding the edit panel is open on. DERIVED from `editingKey` +
-  // the fetched list rather than stored a second time, so a refetch
-  // cannot leave the panel titled with a stale nick, and a binding
-  // unbound by another admin closes it by itself. `editForm` still holds
-  // the DRAFT — that is the operator's typing, and a refetch must not
-  // stomp it.
-  const editingCredential = (): AdminCredential | undefined =>
-    (credentials() ?? []).find((c) => credKey(c) === editingKey());
-
-  const detailCredential = (): AdminCredential | undefined =>
-    (credentials() ?? []).find((c) => credKey(c) === detailId());
+  // Both panels render INSIDE the `<For>`, beneath the row they belong
+  // to (#1074), so neither needs a derived "which binding is this
+  // about": the row is right there, and a binding unbound by another
+  // admin takes its own panel with it. `editForm` still holds the DRAFT
+  // — that is the operator's typing, and a refetch must not stomp it.
 
   const refresh = async (): Promise<void> => {
     const t = token();
@@ -437,75 +435,6 @@ const AdminCredentialsTab: Component = () => {
           <AdminEmpty message="no credentials" testId="admin-credentials-empty" />
         </Show>
 
-        <Show when={detailCredential()}>
-          {(c) => (
-            <AdminDetailPanel
-              title={`${userName(c().user_id)} @ ${c().network_slug}`}
-              subtitle="the columns the table drops on a phone"
-              onClose={() => setDetailId(null)}
-              closeLabel="close binding details"
-              data-testid={`admin-credential-detail-${credKey(c())}`}
-            >
-              <AdminFacts
-                facts={[
-                  { label: "nick", value: c().nick },
-                  { label: "auth", value: c().auth_method },
-                  {
-                    label: "connection",
-                    value: (
-                      <AdminBadge tone={connectionTone(c().connection_state)}>
-                        {c().connection_state}
-                      </AdminBadge>
-                    ),
-                  },
-                ]}
-              />
-            </AdminDetailPanel>
-          )}
-        </Show>
-
-        <Show when={editForm() !== null && editingCredential()}>
-          {(c) => (
-            <AdminDetailPanel
-              title={`Edit ${userName(c().user_id)} @ ${c().network_slug}`}
-              subtitle="only changed fields are sent; a password or auth-method change stops the live session"
-              onClose={onCancelEdit}
-              closeLabel="cancel credential edit"
-              data-testid={`admin-credential-edit-form-${credKey(c())}`}
-            >
-              <form
-                class="adm-form-grid"
-                onSubmit={(e) => {
-                  e.preventDefault();
-                  void onSubmitEdit(c());
-                }}
-              >
-                <CredentialEditFields
-                  form={editForm() as EditForm}
-                  onChange={(next) => setEditForm(next)}
-                  credKey={credKey(c())}
-                />
-                <div class="adm-form-grid-actions">
-                  <button
-                    type="submit"
-                    class="adm-btn adm-btn--ok"
-                    data-testid={`admin-credential-edit-submit-${credKey(c())}`}
-                  >
-                    Save
-                  </button>
-                  <button
-                    type="button"
-                    class="adm-btn adm-btn--danger"
-                    onClick={onCancelEdit}
-                    data-testid={`admin-credential-edit-cancel-${credKey(c())}`}
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </form>
-            </AdminDetailPanel>
-          )}
-        </Show>
         <Show when={credentials() !== null && (credentials() ?? []).length > 0}>
           <AdminCard
             hostsRefresh
@@ -531,31 +460,32 @@ const AdminCredentialsTab: Component = () => {
               <tbody>
                 <For each={credentials() ?? []}>
                   {(c) => (
-                    <tr
-                      class="admin-credentials-row"
-                      data-testid={`admin-credential-row-${credKey(c)}`}
-                    >
-                      <td>
-                        <AdminRowName
-                          open={detailId() === credKey(c)}
-                          onToggle={() =>
-                            setDetailId(detailId() === credKey(c) ? null : credKey(c))
-                          }
-                          label={`details for ${userName(c.user_id)} on ${c.network_slug}`}
-                          testId={`admin-credential-details-${credKey(c)}`}
-                        >
-                          {userName(c.user_id)} @ {c.network_slug}
-                        </AdminRowName>
-                      </td>
-                      <td class="adm-col-detail">{c.nick}</td>
-                      <td class="adm-col-detail">{c.auth_method}</td>
-                      <td class="adm-col-detail">
-                        <AdminBadge tone={connectionTone(c.connection_state)}>
-                          {c.connection_state}
-                        </AdminBadge>
-                      </td>
-                      <td>
-                        {/* The three live-pid readings were a bare ternary
+                    <>
+                      <tr
+                        class="admin-credentials-row"
+                        data-testid={`admin-credential-row-${credKey(c)}`}
+                      >
+                        <td>
+                          <AdminRowName
+                            open={detailId() === credKey(c)}
+                            onToggle={() =>
+                              setDetailId(detailId() === credKey(c) ? null : credKey(c))
+                            }
+                            label={`details for ${userName(c.user_id)} on ${c.network_slug}`}
+                            testId={`admin-credential-details-${credKey(c)}`}
+                          >
+                            {userName(c.user_id)} @ {c.network_slug}
+                          </AdminRowName>
+                        </td>
+                        <td class="adm-col-detail">{c.nick}</td>
+                        <td class="adm-col-detail">{c.auth_method}</td>
+                        <td class="adm-col-detail">
+                          <AdminBadge tone={connectionTone(c.connection_state)}>
+                            {c.connection_state}
+                          </AdminBadge>
+                        </td>
+                        <td>
+                          {/* The three live-pid readings were a bare ternary
                               emitting raw text (one arm even carrying its own
                               "●"). They are the U-0 honesty signal, so they get
                               the same badge vocabulary as every other state —
@@ -563,50 +493,122 @@ const AdminCredentialsTab: Component = () => {
                               verbatim by AdminCredentialsTab.test.tsx, and it
                               says something a colour cannot. The "●" is gone
                               because `.adm-badge` already draws the dot. */}
-                        <AdminBadge
-                          tone={
-                            c.live_state === null ? "neutral" : c.live_state.alive ? "ok" : "danger"
-                          }
+                          <AdminBadge
+                            tone={
+                              c.live_state === null
+                                ? "neutral"
+                                : c.live_state.alive
+                                  ? "ok"
+                                  : "danger"
+                            }
+                          >
+                            {c.live_state === null
+                              ? "BEAM has no pid"
+                              : c.live_state.alive
+                                ? "alive"
+                                : "pid dead"}
+                          </AdminBadge>
+                        </td>
+                        <td class="admin-credentials-actions adm-table-sticky-actions">
+                          <button
+                            type="button"
+                            class="adm-btn"
+                            onClick={() => onArmEdit(c)}
+                            data-testid={`admin-credential-edit-${credKey(c)}`}
+                          >
+                            Edit
+                          </button>
+                          <InlineConfirmButton
+                            idleLabel="Unbind"
+                            confirmLabel="Confirm unbind"
+                            armed={confirmingKey() === credKey(c)}
+                            onArm={() => setConfirmingKey(credKey(c))}
+                            onConfirm={() => onDelete(c)}
+                            testId={`admin-credential-unbind-${credKey(c)}`}
+                            extraClass="delete-btn"
+                          />
+                        </td>
+                      </tr>
+                      <Show when={detailId() === credKey(c)}>
+                        <AdminDetailPanel
+                          title={`${userName(c.user_id)} @ ${c.network_slug}`}
+                          subtitle="the columns the table drops on a phone"
+                          onClose={() => setDetailId(null)}
+                          closeLabel="close binding details"
+                          columns={CREDENTIAL_COLUMNS}
+                          data-testid={`admin-credential-detail-${credKey(c)}`}
                         >
-                          {c.live_state === null
-                            ? "BEAM has no pid"
-                            : c.live_state.alive
-                              ? "alive"
-                              : "pid dead"}
-                        </AdminBadge>
-                      </td>
-                      <td class="admin-credentials-actions adm-table-sticky-actions">
-                        <button
-                          type="button"
-                          class="adm-btn"
-                          onClick={() => onArmEdit(c)}
-                          data-testid={`admin-credential-edit-${credKey(c)}`}
+                          <AdminFacts
+                            facts={[
+                              { label: "nick", value: c.nick },
+                              { label: "auth", value: c.auth_method },
+                              {
+                                label: "connection",
+                                value: (
+                                  <AdminBadge tone={connectionTone(c.connection_state)}>
+                                    {c.connection_state}
+                                  </AdminBadge>
+                                ),
+                              },
+                            ]}
+                          />
+                        </AdminDetailPanel>
+                      </Show>
+                      {/* Both halves of the guard matter, and the pre-#1074
+                        expand row had them for the same reason:
+                        `editingKey` names the row and `editForm` holds the
+                        draft, and `onArmEdit` sets them in that order.
+                        Gating on the row alone renders the panel for one
+                        tick with a null draft, and `CredentialEditFields`
+                        reads `props.form.nick` unconditionally. */}
+                      <Show when={editForm() !== null && editingKey() === credKey(c)}>
+                        <AdminDetailPanel
+                          title={`Edit ${userName(c.user_id)} @ ${c.network_slug}`}
+                          subtitle="only changed fields are sent; a password or auth-method change stops the live session"
+                          onClose={onCancelEdit}
+                          closeLabel="cancel credential edit"
+                          columns={CREDENTIAL_COLUMNS}
+                          data-testid={`admin-credential-edit-form-${credKey(c)}`}
                         >
-                          Edit
-                        </button>
-                        <InlineConfirmButton
-                          idleLabel="Unbind"
-                          confirmLabel="Confirm unbind"
-                          armed={confirmingKey() === credKey(c)}
-                          onArm={() => setConfirmingKey(credKey(c))}
-                          onConfirm={() => onDelete(c)}
-                          testId={`admin-credential-unbind-${credKey(c)}`}
-                          extraClass="delete-btn"
-                        />
-                      </td>
-                    </tr>
+                          <form
+                            class="adm-form-grid"
+                            onSubmit={(e) => {
+                              e.preventDefault();
+                              void onSubmitEdit(c);
+                            }}
+                          >
+                            <CredentialEditFields
+                              form={editForm() as EditForm}
+                              onChange={(next) => setEditForm(next)}
+                              credKey={credKey(c)}
+                            />
+                            <div class="adm-form-grid-actions">
+                              <button
+                                type="submit"
+                                class="adm-btn adm-btn--ok"
+                                data-testid={`admin-credential-edit-submit-${credKey(c)}`}
+                              >
+                                Save
+                              </button>
+                              <button
+                                type="button"
+                                class="adm-btn adm-btn--danger"
+                                onClick={onCancelEdit}
+                                data-testid={`admin-credential-edit-cancel-${credKey(c)}`}
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                          </form>
+                        </AdminDetailPanel>
+                      </Show>
+                    </>
                   )}
                 </For>
               </tbody>
             </AdminTable>
           </AdminCard>
         </Show>
-        {/* Both halves of the guard matter, and the original expand row
-            had them for the same reason: `editingKey` names the row and
-            `editForm` holds the draft, and `onArmEdit` sets them in that
-            order. Gating on the row alone renders the panel for one tick
-            with a null draft, and `CredentialEditFields` reads
-            `props.form.nick` unconditionally. */}
       </div>
     </div>
   );

--- a/cicchetto/src/AdminNetworksTab.tsx
+++ b/cicchetto/src/AdminNetworksTab.tsx
@@ -1,8 +1,9 @@
-import { type Component, createSignal, For, onMount, Show } from "solid-js";
+import { type Component, createSignal, For, type JSX, onMount, Show } from "solid-js";
 import { createStore, produce } from "solid-js/store";
 import AdminBadge from "./admin/AdminBadge";
 import AdminCard from "./admin/AdminCard";
 import AdminDetailPanel from "./admin/AdminDetailPanel";
+import AdminFacts from "./admin/AdminFacts";
 import { AdminEmpty, AdminError, AdminLoading } from "./admin/AdminStatus";
 import AdminTable from "./admin/AdminTable";
 import AdminToolbar, { AdminRefreshButton } from "./admin/AdminToolbar";
@@ -30,6 +31,7 @@ import {
   adminUpdateServer,
 } from "./lib/api";
 import { token } from "./lib/auth";
+import { isMobile } from "./lib/theme";
 
 // M-cluster M-10 — Networks admin tab. Operator surface for the
 // admission caps + circuit-breaker recovery + on-demand visitor reap.
@@ -103,6 +105,10 @@ const FIELD_TEST_ID_SLUG: Record<keyof RowEdit, string> = {
   max_concurrent_user_sessions: "max-user-sessions",
   max_per_ip: "max-per-ip",
 };
+
+// slug + the six secondary columns + actions. Feeds the detail row's
+// `colspan` at desktop width; on a phone only slug + actions survive.
+const NETWORK_COLUMNS = 8;
 
 function reapKey(): string {
   return "force-reap";
@@ -195,12 +201,42 @@ const AdminNetworksTab: Component = () => {
     );
   };
 
-  // The network the detail panel is open on. DERIVED from
-  // `expandedNetworkId` + the fetched list, so a refetch cannot leave
-  // the panel titled with a stale slug and a network deleted by another
-  // admin closes it by itself.
-  const expandedNetwork = (): AdminNetwork | undefined =>
-    (networks() ?? []).find((n) => n.id === expandedNetworkId());
+  // The detail renders INSIDE the `<For>`, beneath the row it belongs
+  // to (#1074), so it needs no derived "which network is this about":
+  // the row is right there, and a network deleted by another admin
+  // takes its own panel with it.
+
+  // Column count for the detail row's `colspan`. On a phone the six
+  // secondary columns are gone, so the row is slug + actions.
+  const networkColumns = (): number => (isMobile() ? 2 : NETWORK_COLUMNS);
+
+  // The two cells that move between the row and the detail depending on
+  // width. ONE definition each: the cap editor is a live control, and a
+  // second copy of it would mean two elements answering to one test id
+  // and two inputs writing the same draft.
+  const capEditor = (net: AdminNetwork, field: keyof RowEdit): JSX.Element => (
+    <CapInput
+      slug={net.slug}
+      field={field}
+      value={edits[net.slug]?.[field] ?? ""}
+      onInput={(v) => onEditCap(net.slug, field, v)}
+    />
+  );
+
+  const liveCount = (net: AdminNetwork, kind: "visitors" | "users"): JSX.Element => {
+    const cap = (): number | null =>
+      kind === "visitors" ? net.max_concurrent_visitor_sessions : net.max_concurrent_user_sessions;
+    return (
+      <span
+        data-testid={`admin-network-live-${kind}-${net.slug}`}
+        title={`${effectiveLive(net)[kind]} live ${
+          kind === "visitors" ? "visitor" : "user"
+        } sessions of ${renderCap(cap())} cap`}
+      >
+        {effectiveLive(net)[kind]}/{renderCap(cap())}
+      </span>
+    );
+  };
 
   const refresh = async (): Promise<void> => {
     const t = token();
@@ -640,96 +676,30 @@ const AdminNetworksTab: Component = () => {
           <AdminEmpty message="no networks" testId="admin-networks-empty" />
         </Show>
 
-        <Show when={expandedNetwork()}>
-          {(n) => (
-            <AdminDetailPanel
-              title={n().slug}
-              subtitle="server pool and featured channels for this network"
-              onClose={() => setExpandedNetworkId(null)}
-              closeLabel={`collapse ${n().slug}`}
-              data-testid={`admin-network-servers-${n().slug}`}
-            >
-              <ServersDisclosure
-                net={n()}
-                servers={serversByNetworkId[n().id] ?? []}
-                form={
-                  serverForm[n().id] ?? {
-                    host: "",
-                    port: "6697",
-                    tls: true,
-                    source: "",
-                  }
-                }
-                onFormChange={(patch) =>
-                  setServerForm(
-                    produce((draft) => {
-                      const cur = draft[n().id] ?? {
-                        host: "",
-                        port: "6697",
-                        tls: true,
-                        source: "",
-                      };
-                      draft[n().id] = { ...cur, ...patch };
-                    }),
-                  )
-                }
-                onAddServer={(e) => {
-                  void onAddServer(n(), e);
-                }}
-                onToggleTls={(s) => {
-                  void onToggleServerTls(n(), s);
-                }}
-                onSaveSource={(s, raw) => {
-                  void onSaveServerSource(n(), s, raw);
-                }}
-                confirmingServerKey={serverConfirmKey()}
-                onArmServerDelete={(key) => setServerConfirmKey(key)}
-                onDeleteServer={(s) => {
-                  void onDeleteServer(n(), s);
-                }}
-              />
-              <FeaturedChannelsDisclosure
-                net={n()}
-                featured={featuredByNetworkId[n().id] ?? []}
-                form={featuredForm[n().id] ?? emptyFeaturedForm()}
-                onFormChange={(patch) =>
-                  setFeaturedForm(
-                    produce((draft) => {
-                      const cur = draft[n().id] ?? emptyFeaturedForm();
-                      draft[n().id] = { ...cur, ...patch };
-                    }),
-                  )
-                }
-                onAddFeatured={(e) => {
-                  void onAddFeaturedChannel(n(), e);
-                }}
-                onToggleEnabled={(fc) => {
-                  void onToggleFeaturedEnabled(n(), fc);
-                }}
-                confirmingFeaturedKey={featuredConfirmKey()}
-                onArmFeaturedDelete={(key) => setFeaturedConfirmKey(key)}
-                onDeleteFeatured={(fc) => {
-                  void onDeleteFeaturedChannel(n(), fc);
-                }}
-              />
-            </AdminDetailPanel>
-          )}
-        </Show>
         <Show when={networks() !== null && (networks() ?? []).length > 0}>
           <AdminCard
             title="Networks"
             subtitle="expand a row for its server pool and featured channels"
           >
-            <AdminTable class="admin-networks-table" data-testid="admin-networks-table">
+            <AdminTable data-testid="admin-networks-table">
               <thead>
                 <tr>
                   <th class="adm-table-grow">slug</th>
-                  <th>visitors (live/cap)</th>
-                  <th>max visitor sessions</th>
-                  <th>users (live/cap)</th>
-                  <th>max user sessions</th>
-                  <th>max per ip</th>
-                  <th>circuit</th>
+                  {/* #1074 — dropped on a phone and shown in the row's
+                      detail instead, like every other tab. A JSX branch
+                      rather than the `.adm-col-detail` display:none the
+                      read-only tabs use: three of these cells are cap
+                      EDITORS, and the detail has to render the control
+                      itself, not a copy of its value. Two live controls
+                      with one test id is not a layout, it is a bug. */}
+                  <Show when={!isMobile()}>
+                    <th>visitors (live/cap)</th>
+                    <th>max visitor sessions</th>
+                    <th>users (live/cap)</th>
+                    <th>max user sessions</th>
+                    <th>max per ip</th>
+                    <th>circuit</th>
+                  </Show>
                   <th class="adm-table-sticky-actions">actions</th>
                 </tr>
               </thead>
@@ -751,52 +721,16 @@ const AdminNetworksTab: Component = () => {
                             {expandedNetworkId() === net.id ? "▾" : "▸"} {net.slug}
                           </button>
                         </td>
-                        <td
-                          data-testid={`admin-network-live-visitors-${net.slug}`}
-                          title={`${effectiveLive(net).visitors} live visitor sessions of ${renderCap(
-                            net.max_concurrent_visitor_sessions,
-                          )} cap`}
-                        >
-                          {effectiveLive(net).visitors}/
-                          {renderCap(net.max_concurrent_visitor_sessions)}
-                        </td>
-                        <td>
-                          <CapInput
-                            slug={net.slug}
-                            field="max_concurrent_visitor_sessions"
-                            value={edits[net.slug]?.max_concurrent_visitor_sessions ?? ""}
-                            onInput={(v) =>
-                              onEditCap(net.slug, "max_concurrent_visitor_sessions", v)
-                            }
-                          />
-                        </td>
-                        <td
-                          data-testid={`admin-network-live-users-${net.slug}`}
-                          title={`${effectiveLive(net).users} live user sessions of ${renderCap(
-                            net.max_concurrent_user_sessions,
-                          )} cap`}
-                        >
-                          {effectiveLive(net).users}/{renderCap(net.max_concurrent_user_sessions)}
-                        </td>
-                        <td>
-                          <CapInput
-                            slug={net.slug}
-                            field="max_concurrent_user_sessions"
-                            value={edits[net.slug]?.max_concurrent_user_sessions ?? ""}
-                            onInput={(v) => onEditCap(net.slug, "max_concurrent_user_sessions", v)}
-                          />
-                        </td>
-                        <td>
-                          <CapInput
-                            slug={net.slug}
-                            field="max_per_ip"
-                            value={edits[net.slug]?.max_per_ip ?? ""}
-                            onInput={(v) => onEditCap(net.slug, "max_per_ip", v)}
-                          />
-                        </td>
-                        <td>
-                          <CircuitBadge net={net} />
-                        </td>
+                        <Show when={!isMobile()}>
+                          <td>{liveCount(net, "visitors")}</td>
+                          <td>{capEditor(net, "max_concurrent_visitor_sessions")}</td>
+                          <td>{liveCount(net, "users")}</td>
+                          <td>{capEditor(net, "max_concurrent_user_sessions")}</td>
+                          <td>{capEditor(net, "max_per_ip")}</td>
+                          <td>
+                            <CircuitBadge net={net} />
+                          </td>
+                        </Show>
                         <td class="admin-networks-actions adm-table-sticky-actions">
                           <button
                             type="button"
@@ -831,6 +765,106 @@ const AdminNetworksTab: Component = () => {
                           />
                         </td>
                       </tr>
+                      <Show when={expandedNetworkId() === net.id}>
+                        <AdminDetailPanel
+                          title={net.slug}
+                          subtitle="server pool and featured channels for this network"
+                          onClose={() => setExpandedNetworkId(null)}
+                          closeLabel={`collapse ${net.slug}`}
+                          columns={networkColumns()}
+                          data-testid={`admin-network-servers-${net.slug}`}
+                        >
+                          {/* The columns the row drops on a phone. The cap
+                              editors are the SAME controls, relocated —
+                              there is no read-only copy of them anywhere,
+                              so editing a cap stays possible on a phone
+                              and Save stays up on the row. */}
+                          <Show when={isMobile()}>
+                            <AdminFacts
+                              facts={[
+                                {
+                                  label: "visitors (live/cap)",
+                                  value: liveCount(net, "visitors"),
+                                },
+                                {
+                                  label: "max visitor sessions",
+                                  value: capEditor(net, "max_concurrent_visitor_sessions"),
+                                },
+                                { label: "users (live/cap)", value: liveCount(net, "users") },
+                                {
+                                  label: "max user sessions",
+                                  value: capEditor(net, "max_concurrent_user_sessions"),
+                                },
+                                { label: "max per ip", value: capEditor(net, "max_per_ip") },
+                                { label: "circuit", value: <CircuitBadge net={net} /> },
+                              ]}
+                            />
+                          </Show>
+                          <ServersDisclosure
+                            net={net}
+                            servers={serversByNetworkId[net.id] ?? []}
+                            form={
+                              serverForm[net.id] ?? {
+                                host: "",
+                                port: "6697",
+                                tls: true,
+                                source: "",
+                              }
+                            }
+                            onFormChange={(patch) =>
+                              setServerForm(
+                                produce((draft) => {
+                                  const cur = draft[net.id] ?? {
+                                    host: "",
+                                    port: "6697",
+                                    tls: true,
+                                    source: "",
+                                  };
+                                  draft[net.id] = { ...cur, ...patch };
+                                }),
+                              )
+                            }
+                            onAddServer={(e) => {
+                              void onAddServer(net, e);
+                            }}
+                            onToggleTls={(s) => {
+                              void onToggleServerTls(net, s);
+                            }}
+                            onSaveSource={(s, raw) => {
+                              void onSaveServerSource(net, s, raw);
+                            }}
+                            confirmingServerKey={serverConfirmKey()}
+                            onArmServerDelete={(key) => setServerConfirmKey(key)}
+                            onDeleteServer={(s) => {
+                              void onDeleteServer(net, s);
+                            }}
+                          />
+                          <FeaturedChannelsDisclosure
+                            net={net}
+                            featured={featuredByNetworkId[net.id] ?? []}
+                            form={featuredForm[net.id] ?? emptyFeaturedForm()}
+                            onFormChange={(patch) =>
+                              setFeaturedForm(
+                                produce((draft) => {
+                                  const cur = draft[net.id] ?? emptyFeaturedForm();
+                                  draft[net.id] = { ...cur, ...patch };
+                                }),
+                              )
+                            }
+                            onAddFeatured={(e) => {
+                              void onAddFeaturedChannel(net, e);
+                            }}
+                            onToggleEnabled={(fc) => {
+                              void onToggleFeaturedEnabled(net, fc);
+                            }}
+                            confirmingFeaturedKey={featuredConfirmKey()}
+                            onArmFeaturedDelete={(key) => setFeaturedConfirmKey(key)}
+                            onDeleteFeatured={(fc) => {
+                              void onDeleteFeaturedChannel(net, fc);
+                            }}
+                          />
+                        </AdminDetailPanel>
+                      </Show>
                     </>
                   )}
                 </For>

--- a/cicchetto/src/AdminSessionsTab.tsx
+++ b/cicchetto/src/AdminSessionsTab.tsx
@@ -52,6 +52,10 @@ import { token } from "./lib/auth";
 // in parallel on every refresh + post-action; the summary is a
 // read-only at-a-glance signal, not a separate state model.
 
+// who + state + the six `adm-col-detail` columns + actions. Feeds the
+// detail row's `colspan`.
+const SESSION_COLUMNS = 9;
+
 type ActionKind = "disconnect" | "terminate";
 
 function confirmKey(id: string, kind: ActionKind): string {
@@ -171,12 +175,6 @@ const AdminSessionsTab: Component = () => {
     testId: "admin-sessions-refresh",
   });
 
-  // The session the detail panel is open on. DERIVED from `detailId` +
-  // the fetched list, so a refetch cannot leave the panel showing a
-  // session that is gone — it closes itself instead.
-  const detailSession = (): AdminSession | undefined =>
-    (sessions() ?? []).find((s) => adminSessionId(s) === detailId());
-
   onMount(() => {
     void refresh();
   });
@@ -246,37 +244,6 @@ const AdminSessionsTab: Component = () => {
           <AdminEmpty message="no sessions" testId="admin-sessions-empty" />
         </Show>
 
-        <Show when={detailSession()}>
-          {(s) => (
-            <AdminDetailPanel
-              title={renderWho(s())}
-              subtitle="the columns the table drops on a phone"
-              onClose={() => setDetailId(null)}
-              closeLabel="close session details"
-              data-testid={`admin-session-detail-${adminSessionId(s())}`}
-            >
-              <AdminFacts
-                facts={[
-                  {
-                    label: "network",
-                    value: networkSlugById().get(s().network_id) ?? String(s().network_id),
-                  },
-                  { label: "upstream", value: renderUpstream(s().live_state) },
-                  { label: "mailbox", value: String(s().live_state.mailbox_len) },
-                  { label: "memory", value: renderKb(s().live_state.memory_bytes) },
-                  { label: "last seen", value: renderLastSeen(s().last_seen_at) },
-                  {
-                    label: "degraded",
-                    value: renderDegraded(
-                      s().live_state.introspection_degraded,
-                      adminSessionId(s()),
-                    ),
-                  },
-                ]}
-              />
-            </AdminDetailPanel>
-          )}
-        </Show>
         <Show when={sessions() !== null && (sessions() ?? []).length > 0}>
           <AdminCard
             hostsRefresh
@@ -311,61 +278,91 @@ const AdminSessionsTab: Component = () => {
                   {(s) => {
                     const id = adminSessionId(s);
                     return (
-                      <tr class="admin-sessions-row" data-testid={`admin-session-row-${id}`}>
-                        <td>
-                          <AdminRowName
-                            open={detailId() === id}
-                            onToggle={() => setDetailId(detailId() === id ? null : id)}
-                            label={`details for ${renderWho(s)}`}
-                            testId={`admin-session-details-${id}`}
+                      <>
+                        <tr class="admin-sessions-row" data-testid={`admin-session-row-${id}`}>
+                          <td>
+                            <AdminRowName
+                              open={detailId() === id}
+                              onToggle={() => setDetailId(detailId() === id ? null : id)}
+                              label={`details for ${renderWho(s)}`}
+                              testId={`admin-session-details-${id}`}
+                            >
+                              {renderWho(s)}
+                            </AdminRowName>
+                          </td>
+                          <td>
+                            <LiveBadge live={s.live_state} />
+                          </td>
+                          <td class="adm-col-detail" data-testid={`admin-session-network-${id}`}>
+                            {networkSlugById().get(s.network_id) ?? String(s.network_id)}
+                          </td>
+                          <td
+                            class="adm-col-detail adm-table-truncate"
+                            data-testid={`admin-session-upstream-${id}`}
                           >
-                            {renderWho(s)}
-                          </AdminRowName>
-                        </td>
-                        <td>
-                          <LiveBadge live={s.live_state} />
-                        </td>
-                        <td class="adm-col-detail" data-testid={`admin-session-network-${id}`}>
-                          {networkSlugById().get(s.network_id) ?? String(s.network_id)}
-                        </td>
-                        <td
-                          class="adm-col-detail adm-table-truncate"
-                          data-testid={`admin-session-upstream-${id}`}
-                        >
-                          {renderUpstream(s.live_state)}
-                        </td>
-                        <td class="adm-col-detail">{s.live_state.mailbox_len}</td>
-                        <td class="adm-col-detail">{renderKb(s.live_state.memory_bytes)}</td>
-                        <td
-                          class="adm-col-detail"
-                          title={s.last_seen_at ?? "no browser login on record"}
-                        >
-                          {renderLastSeen(s.last_seen_at)}
-                        </td>
-                        <td class="adm-col-detail">
-                          {renderDegraded(s.live_state.introspection_degraded, id)}
-                        </td>
-                        <td class="admin-sessions-actions adm-table-sticky-actions">
-                          <InlineConfirmButton
-                            idleLabel="Disconnect"
-                            confirmLabel="Confirm disconnect"
-                            armed={confirmingKey() === confirmKey(id, "disconnect")}
-                            onArm={() => setConfirmingKey(confirmKey(id, "disconnect"))}
-                            onConfirm={() => runAction(s, "disconnect", adminDisconnectSession)}
-                            testId={`admin-session-disconnect-${id}`}
-                            extraClass="disconnect-btn"
-                          />
-                          <InlineConfirmButton
-                            idleLabel="Terminate"
-                            confirmLabel="Confirm terminate"
-                            armed={confirmingKey() === confirmKey(id, "terminate")}
-                            onArm={() => setConfirmingKey(confirmKey(id, "terminate"))}
-                            onConfirm={() => runAction(s, "terminate", adminTerminateSession)}
-                            testId={`admin-session-terminate-${id}`}
-                            extraClass="terminate-btn"
-                          />
-                        </td>
-                      </tr>
+                            {renderUpstream(s.live_state)}
+                          </td>
+                          <td class="adm-col-detail">{s.live_state.mailbox_len}</td>
+                          <td class="adm-col-detail">{renderKb(s.live_state.memory_bytes)}</td>
+                          <td
+                            class="adm-col-detail"
+                            title={s.last_seen_at ?? "no browser login on record"}
+                          >
+                            {renderLastSeen(s.last_seen_at)}
+                          </td>
+                          <td class="adm-col-detail">
+                            {renderDegraded(s.live_state.introspection_degraded, id)}
+                          </td>
+                          <td class="admin-sessions-actions adm-table-sticky-actions">
+                            <InlineConfirmButton
+                              idleLabel="Disconnect"
+                              confirmLabel="Confirm disconnect"
+                              armed={confirmingKey() === confirmKey(id, "disconnect")}
+                              onArm={() => setConfirmingKey(confirmKey(id, "disconnect"))}
+                              onConfirm={() => runAction(s, "disconnect", adminDisconnectSession)}
+                              testId={`admin-session-disconnect-${id}`}
+                              extraClass="disconnect-btn"
+                            />
+                            <InlineConfirmButton
+                              idleLabel="Terminate"
+                              confirmLabel="Confirm terminate"
+                              armed={confirmingKey() === confirmKey(id, "terminate")}
+                              onArm={() => setConfirmingKey(confirmKey(id, "terminate"))}
+                              onConfirm={() => runAction(s, "terminate", adminTerminateSession)}
+                              testId={`admin-session-terminate-${id}`}
+                              extraClass="terminate-btn"
+                            />
+                          </td>
+                        </tr>
+                        <Show when={detailId() === id}>
+                          <AdminDetailPanel
+                            title={renderWho(s)}
+                            subtitle="the columns the table drops on a phone"
+                            onClose={() => setDetailId(null)}
+                            closeLabel="close session details"
+                            columns={SESSION_COLUMNS}
+                            data-testid={`admin-session-detail-${id}`}
+                          >
+                            <AdminFacts
+                              facts={[
+                                {
+                                  label: "network",
+                                  value:
+                                    networkSlugById().get(s.network_id) ?? String(s.network_id),
+                                },
+                                { label: "upstream", value: renderUpstream(s.live_state) },
+                                { label: "mailbox", value: String(s.live_state.mailbox_len) },
+                                { label: "memory", value: renderKb(s.live_state.memory_bytes) },
+                                { label: "last seen", value: renderLastSeen(s.last_seen_at) },
+                                {
+                                  label: "degraded",
+                                  value: renderDegraded(s.live_state.introspection_degraded, id),
+                                },
+                              ]}
+                            />
+                          </AdminDetailPanel>
+                        </Show>
+                      </>
                     );
                   }}
                 </For>

--- a/cicchetto/src/AdminUsersTab.tsx
+++ b/cicchetto/src/AdminUsersTab.tsx
@@ -67,6 +67,11 @@ type CreateForm = {
 
 const EMPTY_CREATE: CreateForm = { name: "", password: "", is_admin: false };
 
+// name + admin + live sessions + inserted + actions. Feeds the detail
+// row's `colspan`; derived from the count so adding a column cannot
+// silently desync it.
+const USER_COLUMNS = 5;
+
 const AdminUsersTab: Component = () => {
   const [users, setUsers] = createSignal<AdminUser[] | null>(null);
   const [error, setError] = createSignal<string | null>(null);
@@ -87,16 +92,12 @@ const AdminUsersTab: Component = () => {
 
   // Which row's detail panel is open. Mobile-only in effect: on desktop
   // every column is on screen and `AdminRowName` renders plain text.
+  //
+  // Both panels render INSIDE the `<For>`, beneath the row they belong
+  // to (#1074), so neither needs a derived "which user is this about"
+  // lookup: the row is right there. A row deleted by another admin
+  // takes its own panel with it.
   const [detailId, setDetailId] = createSignal<string | null>(null);
-
-  // The row the rotation panel is editing. DERIVED from `rotatingId` +
-  // the fetched list, never a second copy of the user: a refetch must
-  // not leave the panel showing a stale name, and a row that vanished
-  // (deleted by another admin) closes the panel by itself.
-  const rotatingUser = (): AdminUser | undefined =>
-    (users() ?? []).find((u) => u.id === rotatingId());
-
-  const detailUser = (): AdminUser | undefined => (users() ?? []).find((u) => u.id === detailId());
 
   const refresh = async (): Promise<void> => {
     const t = token();
@@ -288,71 +289,6 @@ const AdminUsersTab: Component = () => {
           <AdminEmpty message="no users" testId="admin-users-empty" />
         </Show>
 
-        <Show when={detailUser()}>
-          {(u) => (
-            <AdminDetailPanel
-              title={u().name}
-              subtitle="the columns the table drops on a phone"
-              onClose={() => setDetailId(null)}
-              closeLabel="close user details"
-              data-testid={`admin-user-detail-${u().id}`}
-            >
-              <AdminFacts
-                facts={[
-                  { label: "live sessions", value: String(u().live_session_count) },
-                  { label: "inserted", value: formatInstant(u().inserted_at) },
-                ]}
-              />
-            </AdminDetailPanel>
-          )}
-        </Show>
-        <Show when={rotatingUser()}>
-          {(u) => (
-            <AdminDetailPanel
-              title={`Rotate password for ${u().name}`}
-              subtitle="PUT /admin/users/:id/password"
-              onClose={onCancelRotate}
-              closeLabel="cancel password rotation"
-              data-testid={`admin-user-rotate-form-${u().id}`}
-            >
-              <form
-                class="adm-form-grid"
-                onSubmit={(e) => {
-                  e.preventDefault();
-                  void onSubmitRotate(u());
-                }}
-              >
-                <input
-                  placeholder="new password"
-                  aria-label={`new password for ${u().name}`}
-                  type="password"
-                  value={passwordInput()}
-                  onInput={(e) => setPasswordInput((e.currentTarget as HTMLInputElement).value)}
-                  data-testid={`admin-user-rotate-input-${u().id}`}
-                  required
-                />
-                <div class="adm-form-grid-actions">
-                  <button
-                    type="submit"
-                    class="adm-btn adm-btn--ok"
-                    disabled={passwordInput() === ""}
-                    data-testid={`admin-user-rotate-submit-${u().id}`}
-                  >
-                    Rotate
-                  </button>
-                  <button
-                    type="button"
-                    class="adm-btn adm-btn--danger"
-                    onClick={onCancelRotate}
-                    data-testid={`admin-user-rotate-cancel-${u().id}`}
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </form>
-            </AdminDetailPanel>
-          )}
-        </Show>
         <Show when={users() !== null && (users() ?? []).length > 0}>
           <AdminCard
             hostsRefresh
@@ -377,59 +313,126 @@ const AdminUsersTab: Component = () => {
               <tbody>
                 <For each={users() ?? []}>
                   {(u) => (
-                    <tr class="admin-users-row" data-testid={`admin-user-row-${u.id}`}>
-                      <td>
-                        <AdminRowName
-                          open={detailId() === u.id}
-                          onToggle={() => setDetailId(detailId() === u.id ? null : u.id)}
-                          label={`details for ${u.name}`}
-                          testId={`admin-user-details-${u.id}`}
-                        >
-                          {u.name}
-                        </AdminRowName>
-                      </td>
-                      <td>
-                        {/* The WORD stays: admin-users.spec.ts reads this
+                    <>
+                      <tr class="admin-users-row" data-testid={`admin-user-row-${u.id}`}>
+                        <td>
+                          <AdminRowName
+                            open={detailId() === u.id}
+                            onToggle={() => setDetailId(detailId() === u.id ? null : u.id)}
+                            label={`details for ${u.name}`}
+                            testId={`admin-user-details-${u.id}`}
+                          >
+                            {u.name}
+                          </AdminRowName>
+                        </td>
+                        <td>
+                          {/* The WORD stays: admin-users.spec.ts reads this
                               cell as text (`td.nth(1)` matching /yes|no/), and
                               it is a yes/no question a colour alone cannot
                               answer. Neutral rather than danger for "no" — a
                               non-admin account is the normal case. */}
-                        <AdminBadge tone={u.is_admin ? "ok" : "neutral"}>
-                          {u.is_admin ? "yes" : "no"}
-                        </AdminBadge>
-                      </td>
-                      <td class="adm-col-detail">{u.live_session_count}</td>
-                      <td class="adm-col-detail">{formatInstant(u.inserted_at)}</td>
-                      <td class="admin-users-actions adm-table-sticky-actions">
-                        <button
-                          type="button"
-                          class={`adm-btn ${u.is_admin ? "adm-btn--danger" : "adm-btn--ok"}`}
-                          onClick={() => {
-                            void onToggleAdmin(u);
-                          }}
-                          data-testid={`admin-user-toggle-admin-${u.id}`}
+                          <AdminBadge tone={u.is_admin ? "ok" : "neutral"}>
+                            {u.is_admin ? "yes" : "no"}
+                          </AdminBadge>
+                        </td>
+                        <td class="adm-col-detail">{u.live_session_count}</td>
+                        <td class="adm-col-detail">{formatInstant(u.inserted_at)}</td>
+                        <td class="admin-users-actions adm-table-sticky-actions">
+                          <button
+                            type="button"
+                            class={`adm-btn ${u.is_admin ? "adm-btn--danger" : "adm-btn--ok"}`}
+                            onClick={() => {
+                              void onToggleAdmin(u);
+                            }}
+                            data-testid={`admin-user-toggle-admin-${u.id}`}
+                          >
+                            {u.is_admin ? "Demote" : "Promote"}
+                          </button>
+                          <button
+                            type="button"
+                            class="adm-btn"
+                            onClick={() => onArmRotate(u.id)}
+                            data-testid={`admin-user-rotate-password-${u.id}`}
+                          >
+                            Rotate password
+                          </button>
+                          <InlineConfirmButton
+                            idleLabel="Delete"
+                            confirmLabel="Confirm delete"
+                            armed={confirmingId() === u.id}
+                            onArm={() => setConfirmingId(u.id)}
+                            onConfirm={() => onDelete(u)}
+                            testId={`admin-user-delete-${u.id}`}
+                            extraClass="delete-btn"
+                          />
+                        </td>
+                      </tr>
+                      <Show when={detailId() === u.id}>
+                        <AdminDetailPanel
+                          title={u.name}
+                          subtitle="the columns the table drops on a phone"
+                          onClose={() => setDetailId(null)}
+                          closeLabel="close user details"
+                          columns={USER_COLUMNS}
+                          data-testid={`admin-user-detail-${u.id}`}
                         >
-                          {u.is_admin ? "Demote" : "Promote"}
-                        </button>
-                        <button
-                          type="button"
-                          class="adm-btn"
-                          onClick={() => onArmRotate(u.id)}
-                          data-testid={`admin-user-rotate-password-${u.id}`}
+                          <AdminFacts
+                            facts={[
+                              { label: "live sessions", value: String(u.live_session_count) },
+                              { label: "inserted", value: formatInstant(u.inserted_at) },
+                            ]}
+                          />
+                        </AdminDetailPanel>
+                      </Show>
+                      <Show when={rotatingId() === u.id}>
+                        <AdminDetailPanel
+                          title={`Rotate password for ${u.name}`}
+                          subtitle="PUT /admin/users/:id/password"
+                          onClose={onCancelRotate}
+                          closeLabel="cancel password rotation"
+                          columns={USER_COLUMNS}
+                          data-testid={`admin-user-rotate-form-${u.id}`}
                         >
-                          Rotate password
-                        </button>
-                        <InlineConfirmButton
-                          idleLabel="Delete"
-                          confirmLabel="Confirm delete"
-                          armed={confirmingId() === u.id}
-                          onArm={() => setConfirmingId(u.id)}
-                          onConfirm={() => onDelete(u)}
-                          testId={`admin-user-delete-${u.id}`}
-                          extraClass="delete-btn"
-                        />
-                      </td>
-                    </tr>
+                          <form
+                            class="adm-form-grid"
+                            onSubmit={(e) => {
+                              e.preventDefault();
+                              void onSubmitRotate(u);
+                            }}
+                          >
+                            <input
+                              placeholder="new password"
+                              aria-label={`new password for ${u.name}`}
+                              type="password"
+                              value={passwordInput()}
+                              onInput={(e) =>
+                                setPasswordInput((e.currentTarget as HTMLInputElement).value)
+                              }
+                              data-testid={`admin-user-rotate-input-${u.id}`}
+                              required
+                            />
+                            <div class="adm-form-grid-actions">
+                              <button
+                                type="submit"
+                                class="adm-btn adm-btn--ok"
+                                disabled={passwordInput() === ""}
+                                data-testid={`admin-user-rotate-submit-${u.id}`}
+                              >
+                                Rotate
+                              </button>
+                              <button
+                                type="button"
+                                class="adm-btn adm-btn--danger"
+                                onClick={onCancelRotate}
+                                data-testid={`admin-user-rotate-cancel-${u.id}`}
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                          </form>
+                        </AdminDetailPanel>
+                      </Show>
+                    </>
                   )}
                 </For>
               </tbody>

--- a/cicchetto/src/AdminVisitorsTab.tsx
+++ b/cicchetto/src/AdminVisitorsTab.tsx
@@ -64,6 +64,10 @@ import { connectionStateEmoji } from "./lib/connectionStateEmoji";
 // admins delete or visitors reap; until then a refresh button is
 // the only re-fetch surface.
 
+// id + networks + ip + expires + joined + actions. Feeds the detail
+// row's `colspan`.
+const VISITOR_COLUMNS = 6;
+
 const AdminVisitorsTab: Component = () => {
   const [visitors, setVisitors] = createSignal<AdminVisitor[] | null>(null);
   const [confirmingId, setConfirmingId] = createSignal<string | null>(null);
@@ -167,9 +171,6 @@ const AdminVisitorsTab: Component = () => {
     testId: "admin-visitors-refresh",
   });
 
-  const detailVisitor = (): AdminVisitor | undefined =>
-    (visitors() ?? []).find((v) => v.id === detailId());
-
   onMount(() => {
     void refresh();
   });
@@ -187,26 +188,6 @@ const AdminVisitorsTab: Component = () => {
 
         <Show when={visitors() !== null && (visitors() ?? []).length === 0}>
           <AdminEmpty message="no visitors" testId="admin-visitors-empty" />
-        </Show>
-
-        <Show when={detailVisitor()}>
-          {(v) => (
-            <AdminDetailPanel
-              title={v().networks[0]?.nick ?? "visitor"}
-              subtitle="the columns the table drops on a phone"
-              onClose={() => setDetailId(null)}
-              closeLabel="close visitor details"
-              data-testid={`admin-visitor-detail-${v().id}`}
-            >
-              <AdminFacts
-                facts={[
-                  { label: "ip", value: v().ip ?? "—" },
-                  { label: "expires", value: renderExpires(v()) },
-                  { label: "joined", value: renderInserted(v().inserted_at) },
-                ]}
-              />
-            </AdminDetailPanel>
-          )}
         </Show>
 
         <Show when={visitors() !== null && (visitors() ?? []).length > 0}>
@@ -237,66 +218,69 @@ const AdminVisitorsTab: Component = () => {
               <tbody>
                 <For each={visitors() ?? []}>
                   {(v) => (
-                    <tr class="admin-visitors-row" data-testid={`admin-visitor-row-${v.id}`}>
-                      <td>
-                        {/* A dot, like every other state in the pane. Colour
+                    <>
+                      <tr class="admin-visitors-row" data-testid={`admin-visitor-row-${v.id}`}>
+                        <td>
+                          {/* A dot, like every other state in the pane. Colour
                             alone is not an accessible answer to a yes/no
                             question, so the `aria-label` carries the word —
                             no visually-hidden copy, same reasoning as
                             `NetworkStateEmoji` below. Neutral rather than
                             danger for "no": an anonymous visitor is the
                             normal case, not a fault. */}
-                        <AdminBadge
-                          tone={v.identified ? "ok" : "neutral"}
-                          class="adm-badge--dot"
-                          ariaLabel={v.identified ? "identified" : "not identified"}
-                        >
-                          {""}
-                        </AdminBadge>
-                      </td>
-                      <td>
-                        {/* #211 phase 7 — a visitor is multi-network; render
+                          <AdminBadge
+                            tone={v.identified ? "ok" : "neutral"}
+                            class="adm-badge--dot"
+                            ariaLabel={v.identified ? "identified" : "not identified"}
+                          >
+                            {""}
+                          </AdminBadge>
+                        </td>
+                        <td>
+                          {/* #211 phase 7 — a visitor is multi-network; render
                             one line per attached network with its own
                             live-state badge + nick + slug. Empty = a
                             credential-less identity. */}
-                        <Show
-                          when={v.networks.length > 0}
-                          fallback={<span class="muted">no networks</span>}
-                        >
-                          <ul class="admin-visitor-networks">
-                            <For each={v.networks}>
-                              {(net) => (
-                                <li
-                                  data-testid={`admin-visitor-network-${v.id}-${net.network_slug}`}
-                                >
-                                  <LiveBadge live={net.live_state} />
-                                  <span class="admin-visitor-network-nick">{net.nick}</span>
-                                  <span class="admin-visitor-network-slug">{net.network_slug}</span>
-                                  <NetworkStateEmoji state={net.connection_state} />
-                                </li>
-                              )}
-                            </For>
-                          </ul>
-                        </Show>
-                        {/* The opener sits at the END of this cell, not on
+                          <Show
+                            when={v.networks.length > 0}
+                            fallback={<span class="muted">no networks</span>}
+                          >
+                            <ul class="admin-visitor-networks">
+                              <For each={v.networks}>
+                                {(net) => (
+                                  <li
+                                    data-testid={`admin-visitor-network-${v.id}-${net.network_slug}`}
+                                  >
+                                    <LiveBadge live={net.live_state} />
+                                    <span class="admin-visitor-network-nick">{net.nick}</span>
+                                    <span class="admin-visitor-network-slug">
+                                      {net.network_slug}
+                                    </span>
+                                    <NetworkStateEmoji state={net.connection_state} />
+                                  </li>
+                                )}
+                              </For>
+                            </ul>
+                          </Show>
+                          {/* The opener sits at the END of this cell, not on
                             a name column, because a visitor HAS no name
                             column — its identity is the per-network nick
                             list above. Mobile-only, like every other
                             `AdminRowName`. */}
-                        <AdminRowName
-                          open={detailId() === v.id}
-                          onToggle={() => setDetailId(detailId() === v.id ? null : v.id)}
-                          label={`details for visitor ${v.id}`}
-                          testId={`admin-visitor-details-${v.id}`}
-                        >
-                          details
-                        </AdminRowName>
-                      </td>
-                      <td class="adm-col-detail">{v.ip ?? "—"}</td>
-                      <td class="adm-col-detail">{renderExpires(v)}</td>
-                      <td class="adm-col-detail">{renderInserted(v.inserted_at)}</td>
-                      <td class="adm-table-sticky-actions">
-                        {/* #269 — the per-network Disconnect ⇄ Reconnect toggle
+                          <AdminRowName
+                            open={detailId() === v.id}
+                            onToggle={() => setDetailId(detailId() === v.id ? null : v.id)}
+                            label={`details for visitor ${v.id}`}
+                            testId={`admin-visitor-details-${v.id}`}
+                          >
+                            details
+                          </AdminRowName>
+                        </td>
+                        <td class="adm-col-detail">{v.ip ?? "—"}</td>
+                        <td class="adm-col-detail">{renderExpires(v)}</td>
+                        <td class="adm-col-detail">{renderInserted(v.inserted_at)}</td>
+                        <td class="adm-table-sticky-actions">
+                          {/* #269 — the per-network Disconnect ⇄ Reconnect toggle
                             lives HERE, ahead of Delete, so the actions column
                             reads the same as the Sessions tab's.
 
@@ -309,36 +293,55 @@ const AdminVisitorsTab: Component = () => {
                             The affordance keys off LIVE truth (net.live_state),
                             NOT the DB connection_state, so a `:connected` row
                             whose pid is gone correctly offers Reconnect. */}
-                        <For each={v.networks}>
-                          {(net) => (
-                            <InlineConfirmButton
-                              idleLabel={`${net.live_state !== null ? "Disconnect" : "Reconnect"}${
-                                v.networks.length > 1 ? ` ${net.network_slug}` : ""
-                              }`}
-                              confirmLabel={`Confirm ${
-                                net.live_state !== null ? "disconnect" : "reconnect"
-                              }`}
-                              armed={confirmingToggleKey() === toggleKey(v, net)}
-                              onArm={() => setConfirmingToggleKey(toggleKey(v, net))}
-                              onConfirm={() => runToggle(v, net)}
-                              testId={`admin-visitor-toggle-${v.id}-${net.network_slug}`}
-                              extraClass={
-                                net.live_state !== null ? "disconnect-btn" : "reconnect-btn"
-                              }
-                            />
-                          )}
-                        </For>
-                        <InlineConfirmButton
-                          idleLabel="Delete"
-                          confirmLabel="Confirm delete"
-                          armed={confirmingId() === v.id}
-                          onArm={() => setConfirmingId(v.id)}
-                          onConfirm={() => onDeleteConfirm(v)}
-                          testId={`admin-visitor-delete-${v.id}`}
-                          extraClass="delete-btn"
-                        />
-                      </td>
-                    </tr>
+                          <For each={v.networks}>
+                            {(net) => (
+                              <InlineConfirmButton
+                                idleLabel={`${net.live_state !== null ? "Disconnect" : "Reconnect"}${
+                                  v.networks.length > 1 ? ` ${net.network_slug}` : ""
+                                }`}
+                                confirmLabel={`Confirm ${
+                                  net.live_state !== null ? "disconnect" : "reconnect"
+                                }`}
+                                armed={confirmingToggleKey() === toggleKey(v, net)}
+                                onArm={() => setConfirmingToggleKey(toggleKey(v, net))}
+                                onConfirm={() => runToggle(v, net)}
+                                testId={`admin-visitor-toggle-${v.id}-${net.network_slug}`}
+                                extraClass={
+                                  net.live_state !== null ? "disconnect-btn" : "reconnect-btn"
+                                }
+                              />
+                            )}
+                          </For>
+                          <InlineConfirmButton
+                            idleLabel="Delete"
+                            confirmLabel="Confirm delete"
+                            armed={confirmingId() === v.id}
+                            onArm={() => setConfirmingId(v.id)}
+                            onConfirm={() => onDeleteConfirm(v)}
+                            testId={`admin-visitor-delete-${v.id}`}
+                            extraClass="delete-btn"
+                          />
+                        </td>
+                      </tr>
+                      <Show when={detailId() === v.id}>
+                        <AdminDetailPanel
+                          title={v.networks[0]?.nick ?? "visitor"}
+                          subtitle="the columns the table drops on a phone"
+                          onClose={() => setDetailId(null)}
+                          closeLabel="close visitor details"
+                          columns={VISITOR_COLUMNS}
+                          data-testid={`admin-visitor-detail-${v.id}`}
+                        >
+                          <AdminFacts
+                            facts={[
+                              { label: "ip", value: v.ip ?? "—" },
+                              { label: "expires", value: renderExpires(v) },
+                              { label: "joined", value: renderInserted(v.inserted_at) },
+                            ]}
+                          />
+                        </AdminDetailPanel>
+                      </Show>
+                    </>
                   )}
                 </For>
               </tbody>

--- a/cicchetto/src/__tests__/adminMobileRowDetail.test.tsx
+++ b/cicchetto/src/__tests__/adminMobileRowDetail.test.tsx
@@ -1,0 +1,208 @@
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AdminNetwork, AdminUser } from "../lib/api";
+
+// #1074 — a row's detail opens WHERE THE ROW IS, and no admin tab is
+// wider than the viewport on a phone.
+//
+// The two are one knot. The detail panel used to be a sibling of the
+// table card, rendered BEFORE it, with an `el.scrollIntoView()` on
+// mount: tapping a row far down the list sent the viewport to the top.
+// It sat out there because the tables were deliberately wider than a
+// phone and anything inside a `<td colspan>` inherits the TABLE's
+// width. Take the width away and the panel can go home.
+//
+// THE form factor under test. `isMobile()` is what `AdminRowName` and
+// the Networks column split branch on; jsdom has no matchMedia, so
+// without this mock the whole file would silently measure DESKTOP —
+// where the disclosure does not even render.
+vi.mock("../lib/theme", () => ({
+  isMobile: () => true,
+  prefersDark: () => false,
+  applyTheme: vi.fn(),
+}));
+
+vi.mock("../lib/auth", () => ({
+  token: () => "test-bearer",
+}));
+
+vi.mock("../lib/api", async () => {
+  const actual = await vi.importActual<typeof import("../lib/api")>("../lib/api");
+  return {
+    ...actual,
+    adminListUsers: vi.fn(),
+    adminCreateUser: vi.fn(),
+    adminUpdateUserAdmin: vi.fn(),
+    adminUpdateUserPassword: vi.fn(),
+    adminDeleteUser: vi.fn(),
+    adminListNetworks: vi.fn(),
+    adminPatchNetworkCaps: vi.fn(),
+    adminRunReaper: vi.fn(),
+    adminResetCircuit: vi.fn(),
+    adminCreateNetwork: vi.fn(),
+    adminDeleteNetwork: vi.fn(),
+    adminListServers: vi.fn(),
+    adminListFeaturedChannels: vi.fn(),
+  };
+});
+
+vi.mock("../lib/socket", () => ({
+  joinAdminEvents: vi.fn(),
+}));
+
+import AdminNetworksTab from "../AdminNetworksTab";
+import AdminUsersTab from "../AdminUsersTab";
+import {
+  adminListFeaturedChannels,
+  adminListNetworks,
+  adminListServers,
+  adminListUsers,
+} from "../lib/api";
+
+const ALICE: AdminUser = {
+  id: "00000000-0000-0000-0000-000000000001",
+  name: "alice",
+  is_admin: false,
+  inserted_at: "2026-05-31T00:00:00Z",
+  updated_at: "2026-05-31T00:00:00Z",
+  live_session_count: 0,
+};
+
+const BOB: AdminUser = {
+  id: "00000000-0000-0000-0000-000000000002",
+  name: "bob",
+  is_admin: true,
+  inserted_at: "2026-05-31T00:00:00Z",
+  updated_at: "2026-05-31T00:00:00Z",
+  live_session_count: 2,
+};
+
+const BAHAMUT: AdminNetwork = {
+  id: 1,
+  slug: "bahamut-test",
+  services_flavor: null,
+  visitor_enabled: false,
+  visitor_autoconnect: false,
+  max_concurrent_visitor_sessions: 100,
+  max_concurrent_user_sessions: 3,
+  max_per_ip: 5,
+  inserted_at: "2026-05-01T00:00:00Z",
+  updated_at: "2026-05-15T00:00:00Z",
+  circuit_state: null,
+  live_counts: { visitors: 0, users: 0 },
+};
+
+const AZZURRA: AdminNetwork = {
+  ...BAHAMUT,
+  id: 2,
+  slug: "azzurra",
+  max_per_ip: 3,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("#1074 — the row detail opens in the row's own position", () => {
+  // Every position assertion opens the FIRST of two rows. Opening the
+  // last one would let `nextElementSibling` be null and `closest("tr")`
+  // be null for a panel still parked outside the table — null === null
+  // is a green that proves nothing.
+  it("renders the Users detail as the row's next sibling, inside the same table body", async () => {
+    vi.mocked(adminListUsers).mockResolvedValue([ALICE, BOB]);
+    render(() => <AdminUsersTab />);
+
+    const aliceRow = await screen.findByTestId(`admin-user-row-${ALICE.id}`);
+    const bobRow = screen.getByTestId(`admin-user-row-${BOB.id}`);
+    expect(aliceRow.nextElementSibling).toBe(bobRow);
+
+    fireEvent.click(screen.getByTestId(`admin-user-details-${ALICE.id}`));
+
+    const panel = await screen.findByTestId(`admin-user-detail-${ALICE.id}`);
+    const panelRow = panel.closest("tr");
+    expect(panelRow).not.toBeNull();
+    expect(aliceRow.nextElementSibling).toBe(panelRow);
+    expect(panelRow?.parentElement).toBe(aliceRow.parentElement);
+  });
+
+  it("renders the Users password rotation form in the row's position too", async () => {
+    vi.mocked(adminListUsers).mockResolvedValue([ALICE, BOB]);
+    render(() => <AdminUsersTab />);
+
+    const aliceRow = await screen.findByTestId(`admin-user-row-${ALICE.id}`);
+    fireEvent.click(screen.getByTestId(`admin-user-rotate-password-${ALICE.id}`));
+
+    const form = await screen.findByTestId(`admin-user-rotate-form-${ALICE.id}`);
+    const formRow = form.closest("tr");
+    expect(formRow).not.toBeNull();
+    expect(aliceRow.nextElementSibling).toBe(formRow);
+  });
+});
+
+describe("#1074 — Networks drops its secondary columns on a phone", () => {
+  it("leaves the row with its slug and its actions, and nothing to pan to", async () => {
+    vi.mocked(adminListNetworks).mockResolvedValue([BAHAMUT]);
+    render(() => <AdminNetworksTab />);
+
+    const row = await screen.findByTestId(`admin-network-row-${BAHAMUT.slug}`);
+    expect(row.querySelectorAll("td")).toHaveLength(2);
+
+    // The header must drop the SAME columns — a `<th>` left behind is a
+    // column the browser still reserves width for.
+    const table = screen.getByTestId("admin-networks-table");
+    expect(table.querySelectorAll("thead th")).toHaveLength(2);
+  });
+
+  it("moves the cap editors and the circuit badge into the row's detail, not out of reach", async () => {
+    vi.mocked(adminListNetworks).mockResolvedValue([BAHAMUT]);
+    vi.mocked(adminListServers).mockResolvedValue([]);
+    vi.mocked(adminListFeaturedChannels).mockResolvedValue([]);
+    render(() => <AdminNetworksTab />);
+
+    await screen.findByTestId(`admin-network-row-${BAHAMUT.slug}`);
+    // Closed: the editors are nowhere — not hidden in a `display: none`
+    // cell, which would leave two of every control in the DOM once the
+    // detail renders its own copy.
+    expect(screen.queryByTestId(`admin-network-max-per-ip-${BAHAMUT.slug}`)).toBeNull();
+    expect(screen.queryByTestId(`admin-network-circuit-${BAHAMUT.slug}`)).toBeNull();
+
+    fireEvent.click(screen.getByTestId(`admin-network-expand-${BAHAMUT.slug}`));
+
+    const panel = await screen.findByTestId(`admin-network-servers-${BAHAMUT.slug}`);
+    await waitFor(() =>
+      expect(screen.queryByTestId(`admin-network-max-per-ip-${BAHAMUT.slug}`)).not.toBeNull(),
+    );
+    for (const testId of [
+      `admin-network-max-visitor-sessions-${BAHAMUT.slug}`,
+      `admin-network-max-user-sessions-${BAHAMUT.slug}`,
+      `admin-network-max-per-ip-${BAHAMUT.slug}`,
+      `admin-network-circuit-${BAHAMUT.slug}`,
+      `admin-network-live-visitors-${BAHAMUT.slug}`,
+      `admin-network-live-users-${BAHAMUT.slug}`,
+    ]) {
+      expect(panel.contains(screen.getByTestId(testId)), testId).toBe(true);
+    }
+
+    // Save stays on the row: the editors are in the panel, the verb that
+    // commits them must not be a second scroll away.
+    const row = screen.getByTestId(`admin-network-row-${BAHAMUT.slug}`);
+    expect(row.contains(screen.getByTestId(`admin-network-save-${BAHAMUT.slug}`))).toBe(true);
+  });
+
+  it("opens that detail in the row's own position", async () => {
+    vi.mocked(adminListNetworks).mockResolvedValue([BAHAMUT, AZZURRA]);
+    vi.mocked(adminListServers).mockResolvedValue([]);
+    vi.mocked(adminListFeaturedChannels).mockResolvedValue([]);
+    render(() => <AdminNetworksTab />);
+
+    const row = await screen.findByTestId(`admin-network-row-${BAHAMUT.slug}`);
+    expect(row.nextElementSibling).toBe(screen.getByTestId(`admin-network-row-${AZZURRA.slug}`));
+
+    fireEvent.click(screen.getByTestId(`admin-network-expand-${BAHAMUT.slug}`));
+
+    const panel = await screen.findByTestId(`admin-network-servers-${BAHAMUT.slug}`);
+    const panelRow = panel.closest("tr");
+    expect(panelRow).not.toBeNull();
+    expect(row.nextElementSibling).toBe(panelRow);
+  });
+});

--- a/cicchetto/src/admin/AdminDetailPanel.tsx
+++ b/cicchetto/src/admin/AdminDetailPanel.tsx
@@ -1,34 +1,34 @@
-import { type Component, type JSX, onMount } from "solid-js";
+import type { Component, JSX } from "solid-js";
+import AdminExpandRow from "./AdminExpandRow";
 
 // Admin redesign (2026-08-07 review) — the detail surface for the row a
-// table has open.
+// table has open, for the four single-at-a-time disclosures (Networks'
+// servers + featured, Credentials' edit, Users' password rotation and
+// row details).
 //
-// It replaces `AdminExpandRow` for the three single-at-a-time
-// disclosures (Networks' servers + featured, Credentials' edit,
-// Users' password rotation), and the reason is width, not taste.
+// It renders IN the table, in the row's own position: an
+// `AdminExpandRow` immediately beneath the row it belongs to.
 //
-// An expand row lives in a `<td colspan>` of a table that is
-// deliberately WIDER than the viewport — the UX-6-G contract keeps admin
-// tables wide and horizontally pannable rather than collapsing them to
-// cards. Anything inside that cell inherits the TABLE's width, so a form
-// in there is unreachable on a phone without swiping sideways, and no
-// amount of grid columns inside it helps: two columns of a 900px table
-// are still 900px.
+// This panel spent one iteration OUTSIDE the table, rendered before it
+// and pulled into view with `scrollIntoView` on mount, because an
+// expand row lives in a `<td colspan>` and inherits the TABLE's width —
+// and the tables were deliberately wider than a phone. Tapping a row
+// far down the list then sent the viewport to the top of the tab, which
+// is the complaint #1074 opens with. The width is gone now (every tab
+// drops its secondary columns below the mobile breakpoint), so the cell
+// is viewport-wide and there is nothing left to scroll to.
 //
-// A previous attempt pinned the cell with `position: sticky; left: 0`
-// and capped its children at `92vw`. That put a horizontally-scrolling
-// nested table inside a sticky viewport-capped cell of another
-// horizontally-scrolling table; the two scroll contexts fought, and
-// panning the outer one clipped the nested table. Reverted.
+// `.adm-detail-body` is an inline-size query container, so the panel
+// contributes no intrinsic width of its own: a wide form inside it can
+// never widen the table it now sits in.
 //
-// Rendering the panel OUTSIDE the table removes the cause instead of
-// fighting it: this is an ordinary block in the tab's scroll body, so it
-// is viewport-wide and its contents wrap. The panel names the row it
-// belongs to, since it is no longer physically attached to it.
+// The title still names the row. It is redundant beside the row on
+// screen and it is not redundant to a screen reader, which meets the
+// panel as a section of its own.
 //
-// NOT used for the Vhosts grants disclosure, which is a different shape:
-// that one is always mounted for EVERY row, so hoisting it would put N
-// panels under the table instead of one. It keeps `AdminExpandRow`.
+// NOT used for the Vhosts grants disclosure, which is a different
+// shape: that one is always mounted for EVERY row. It uses
+// `AdminExpandRow` directly.
 
 export type Props = {
   /** Names the row this panel is editing, e.g. `Editing azzurra`. */
@@ -36,44 +36,15 @@ export type Props = {
   subtitle?: string;
   onClose: () => void;
   closeLabel: string;
+  /** Column count of the host table, for the expand row's `colspan`. */
+  columns: number;
   children: JSX.Element;
   "data-testid"?: string;
 };
 
-const AdminDetailPanel: Component<Props> = (props) => {
-  let el: HTMLElement | undefined;
-
-  // Scroll the panel into view when it opens.
-  //
-  // This is not a nicety, it is the other half of moving out of the
-  // table. Inside a row, the editor appeared exactly where the operator
-  // had just tapped. Out here it is a sibling of the table, and tapping
-  // Edit on a row while scrolled anywhere down the list opened a panel
-  // the operator could not see — which reads, correctly, as the button
-  // doing nothing. The panel renders BEFORE the table for the same
-  // reason (so closing it leaves you at the top of the list rather than
-  // stranded past it); this covers the case where the table is what you
-  // were looking at.
-  //
-  // `block: "nearest"` so an already-visible panel does not jump.
-  //
-  // Feature-detected because jsdom does not implement `scrollIntoView`
-  // at all — this is a real environment gap, not defensive padding, and
-  // without the check every vitest case that opens a panel throws.
-  onMount(() => {
-    if (typeof el?.scrollIntoView === "function") {
-      el.scrollIntoView({ block: "nearest" });
-    }
-  });
-
-  return (
-    <section
-      class="adm-detail"
-      data-testid={props["data-testid"]}
-      ref={(node) => {
-        el = node;
-      }}
-    >
+const AdminDetailPanel: Component<Props> = (props) => (
+  <AdminExpandRow columns={props.columns} class="adm-detail-row">
+    <section class="adm-detail" data-testid={props["data-testid"]}>
       <header class="adm-detail-head">
         <div>
           <h3 class="adm-card-title">{props.title}</h3>
@@ -90,7 +61,7 @@ const AdminDetailPanel: Component<Props> = (props) => {
       </header>
       <div class="adm-detail-body">{props.children}</div>
     </section>
-  );
-};
+  </AdminExpandRow>
+);
 
 export default AdminDetailPanel;

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -5088,11 +5088,10 @@ html.resize-dragging * {
    narrower cell: a squeezed column is still a column, and the point is
    to get the table under the viewport width, not to make it tighter.
 
-   `ux-6-g-admin-mobile-h-scroll` still holds. It requires pan-x to be
-   PERMITTED on every admin tab, which is untouched, and requires exactly
-   one tab — `DETERMINISTIC_WIDE_TAB`, Networks — to actually be wider
-   than the viewport. Networks therefore keeps all its columns and gets a
-   frozen first column instead (below). */
+   `ux-6-g-admin-mobile-h-scroll` still holds, in its #1074 form: pan-x
+   stays PERMITTED on every admin tab (a table that fits must still not
+   trap a horizontal gesture), and no tab is wider than its panel on a
+   phone. Networks was the one exemption and is not one any more. */
 .adm-col-detail {
   display: none;
 }
@@ -5157,22 +5156,13 @@ html.resize-dragging * {
   overflow-wrap: anywhere;
 }
 
-/* Networks keeps every column on a phone — `ux-6-g` pins it as the one
-   tab that must stay wider than the viewport — so it gets the mitigation
-   instead of the fix: the slug freezes at the left edge while the rest
-   pans, mirroring the actions column pinned at the right. Panning a wide
-   table is survivable when you can still see whose row you are reading;
-   it is not when you cannot. */
-@media (max-width: 899px) {
-  .admin-networks-table td:first-child,
-  .admin-networks-table th:first-child {
-    position: sticky;
-    left: 0;
-    background: var(--adm-surface-0);
-    border-right: 1px solid var(--adm-line-strong);
-    box-shadow: 6px 0 6px -6px color-mix(in oklab, var(--fg), transparent 80%);
-  }
-}
+/* Networks used to freeze its slug column at the left edge while the
+   rest panned — the mitigation for being the one tab `ux-6-g` pinned as
+   deliberately wider than a phone. #1074 removed the reason: its six
+   secondary columns now move into the row's detail like every other
+   tab's (a JSX branch in `AdminNetworksTab`, not `.adm-col-detail`,
+   because three of them are live cap EDITORS and the detail has to host
+   the control itself). Nothing pans, so nothing needs pinning. */
 
 /* Nested tables STACK when their CONTAINER is narrow: one block per row,
    label beside value, no horizontal scroll at all. Container, not
@@ -5431,8 +5421,17 @@ html.resize-dragging * {
    and the two scroll contexts fought — panning the outer one clipped the
    nested Servers table, while panning the nested one directly worked
    fine. Trading a swipe for a rendering glitch is a bad trade, and the
-   real fix is structural (don't nest scroll containers), which is more
-   than a CSS tweak. */
+   real fix is structural (don't nest scroll containers).
+   #1074 took the structural route: on a phone the table is no wider than
+   the panel, so the cell needs neither a pin nor a cap. */
+
+/* The detail row (`admin/AdminDetailPanel.tsx`) is prose and forms, not
+   table data, so it opts out of `.adm-table`'s blanket `nowrap`. Without
+   this a long title or fact value would set the TABLE's width from
+   inside the very cell that exists to avoid that. */
+.adm-detail-row td {
+  white-space: normal;
+}
 
 /* Every button inside an admin table or form is the same size. The
    InlineConfirmButton family (Delete / Unbind / Revoke / Reset Circuit)

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -34522,3 +34522,52 @@ stays covered on real webkit by the untouched `issue79` spec.
 real finger, whether the grab handles actually appear once `is-selecting` lifts
 the callout, whether a long-press on Android races Chrome's own native
 selection. All three need a device; none is asserted anywhere in the change.
+
+## 2026-08-09 — #1074: the panel is out of the table because the table is too wide
+
+Two complaints from the admin brief, and the issue is right that they are one
+knot: the row detail sends the viewport to the top of the tab, and the tables
+pan sideways on a phone. The second is the cause of the first.
+
+**The panel sat outside the table because a `<td colspan>` inherits the TABLE's
+width.** `AdminDetailPanel` was a sibling of the table card, rendered BEFORE it,
+with `scrollIntoView({block: "nearest"})` on mount — the panel had to be
+somewhere the operator could see it, and out there it was viewport-wide. Tap a
+row far down the list and the viewport travelled. Both halves were deliberate
+and both are gone: kill the width and the cell is viewport-wide by itself, so
+the panel is an `AdminExpandRow` beneath its own row and there is nothing to
+scroll to. The previously-reverted mitigation (`position: sticky; left: 0` on
+the cell with a `92vw` cap) is NOT what was retried — it fought two scroll
+contexts against each other; this removes the outer one instead.
+
+**Networks was the last wide tab, and its secondary cells could not use the
+`.adm-col-detail` mechanism.** The other four tabs hide their secondary columns
+with `display: none` and re-render the same VALUES as facts in the panel. Three
+of Networks' six are live cap EDITORS, and the panel has to host the control
+itself, not a copy of its value — two `<input>`s answering to one test id, both
+writing the same draft, is a bug wearing a layout's clothes. So Networks
+branches on `isMobile()` in JSX and the cells are REMOVED, not hidden, with one
+definition of each (`capEditor` / `liveCount`) rendered into whichever host the
+width picked. Save stays on the row: the editors moved, the verb that commits
+them must not be a second scroll away. That is a second mechanism for the same
+outcome, on purpose — the boundary is read-only value vs. live control, and it
+is named in both files.
+
+**The `ux-6-g` contract inverted rather than died.** Pan-x PERMISSION survives
+verbatim on `.admin-pane` + `.admin-tab-panel` — a table that fits must still
+not trap a horizontal swipe, and re-tightening either declaration back to
+`pan-y` is still a silent regression. What flipped is the positive twin: the
+spec used to name Networks `DETERMINISTIC_WIDE_TAB` and assert it was WIDER than
+its panel; it now asserts no tab is. The programmatic `scrollLeft = 100` case
+inverted the same way — it must clamp back to 0. The frozen first column that
+mitigated Networks' width went with the width.
+
+**Not established.** Nothing here was seen on a phone. The vitest oracles are
+DOM position (the detail row is its row's `nextElementSibling`) and DOM
+presence (the editors are in the panel, absent from the row); the width claims
+and the "the row does not move" claim live only in the e2e spec, which was not
+run — the e2e stack is single-tenant per docker daemon and was not free. The
+spec's width assertion also covers Networks only: Visitors and Sessions are
+empty in the baseline seed, and Users/Credentials are populated but were never
+measured at 393px, so "no admin tab scrolls horizontally" is asserted for the
+one tab the issue scoped and believed for the rest on the strength of `a669e8cf`.


### PR DESCRIPTION
Refs #1074.

## What

The two complaints are one knot, and the issue says so: the detail panel lived
OUTSIDE the table and rendered BEFORE it, with `scrollIntoView` on mount — so
opening a row far down the list sent the viewport to the top. That was not a
taste call. An expand row lives in a `<td colspan>` and inherits the TABLE's
width, and the tables were deliberately wider than a phone. Take the width away
and the cell is viewport-wide, the panel goes home under its own row, and there
is nothing left to scroll to.

## How

- **`AdminDetailPanel` is an `AdminExpandRow` now.** One place owns the shape;
  the 7 call sites (Users ×2, Credentials ×2, Networks, Sessions, Visitors) move
  inside the `<For>`, directly beneath their row, and pass the host table's
  column count for the `colspan`. `scrollIntoView` is gone. So are the derived
  `detailUser` / `editingCredential` / `expandedNetwork` &c. helpers: the row is
  right there, and a row deleted by another admin takes its own panel with it.
- **Networks drops its six secondary columns on a phone.** By a JSX
  `isMobile()` branch, not the `.adm-col-detail` `display: none` the other four
  tabs use: three of those cells are live cap EDITORS, and the detail has to
  host the control itself, not a copy of its value. Two `<input>`s answering to
  one test id and writing one draft is a bug wearing a layout's clothes. So the
  cells are REMOVED rather than hidden, with one definition each (`capEditor` /
  `liveCount`) rendered into whichever host the width picked. Save stays on the
  row — the editors moved, the verb that commits them must not be a second
  scroll away.
- **The frozen first column is retired** (`.admin-networks-table td:first-child`):
  it was the mitigation for Networks' width, and the width is gone.
- **`ux-6-g` inverts rather than dies.** The pan-x PERMISSION is asserted
  verbatim on `.admin-pane` + `.admin-tab-panel` — a table that fits must still
  not trap a horizontal swipe. What flips is the positive twin: Networks used to
  be `DETERMINISTIC_WIDE_TAB`, asserted WIDER than its panel; the claim now is
  that no tab is. The programmatic `scrollLeft = 100` must clamp back to 0. A
  new case measures the literal complaint: the row an operator taps does not
  move when its detail opens.

## Gates

| gate | rc |
|---|---|
| `bun run check` (biome + tsc) | 0 |
| `bun run test` | 0 — 259 files, 4796 tests |
| `bun run build` | 0 |

Five new tests in `adminMobileRowDetail.test.tsx`, red 5/5 before the
implementation. Two of them were green on the first pass for the wrong reason
(`null === null`, because they opened the LAST of two rows); rewritten to open
the FIRST row so neither `nextElementSibling` nor `closest("tr")` can be null.

## What I am NOT claiming

- **The e2e spec was not run.** The e2e stack is single-tenant per docker daemon
  and was not free. Every width assertion and the "the row does not move" case
  live there and are unverified.
- **None of this was seen on a phone.** The vitest oracles are DOM position and
  DOM presence; whether the result READS well at 393px needs an eye.
- **The e2e spec is not type-checked either.** cicchetto's `tsc` includes only
  `src`, biome runs only on `src`, and `@playwright/test` is absent from the
  container (`tsc -p e2e/tsconfig.json` → `TS2688`).
- **The width claim covers Networks only.** Visitors and Sessions are empty in
  the baseline seed; Users and Credentials are populated but were never measured
  at 393px. With `.adm-table { white-space: nowrap }` and three buttons in the
  actions cell, my arithmetic suspects Users may still overflow — but the issue
  states the other tabs fit after `a669e8cf`, and I trust a measurement taken on
  the device over my estimate. If CI says otherwise the remedy is one
  `@media (max-width: 768px)` block letting the actions cell wrap, and I did not
  ship it because I could not measure it.
- **Desktop detail width changed shape, not size downward.** The panel now
  inherits the table's width instead of the tab panel's; on desktop the Networks
  table can be wider than its container, so the nested tables get more room, not
  less. Reasoned, not measured.

No admin header/nav file is touched — `AdminPane`, `AdminNav` and `AdminToolbar`
are byte-identical, to stay clear of #1073/#1075.