### PR TITLE
e2e(#1050): harden the corner barrier, and make it report itself

### DIFF
--- a/cicchetto/e2e/tests/issue1050-list-window-no-float.spec.ts
+++ b/cicchetto/e2e/tests/issue1050-list-window-no-float.spec.ts
@@ -116,6 +116,32 @@ test("@webkit #1050 — the /list window drops the floating ☰, and its ✕ act
   // This is NOT webkit-specific, despite only webkit having reported it: the
   // chromium project `grepInvert`s `@webkit`, so chromium has never run this
   // spec. The race is in the flow, not the engine.
+  //
+  // TWO THINGS THE HIT-STACK BARRIER STILL GOT WRONG, both fixed below and both
+  // established by reading, not by a red this closes.
+  //
+  // ONE — the release condition was INSTANTANEOUS where a barrier must be
+  // DURABLE. "the drawer is not under this point right now" is a property of a
+  // LIVE animation: instrumenting the barrier locally, it holds ~5–15ms before
+  // the slide ends (`getAnimations().length === 1`, drawer left at 377..389
+  // against a final 393) in 9 runs out of 10. The assertion then samples at
+  // some LATER, unbounded instant — 4–15ms locally, 48ms in the CI trace. A
+  // barrier that samples a moving target and hopes is a coin flip by design, no
+  // matter which engine internal decides the toss. So it now also requires the
+  // transition to be FINISHED: `getAnimations().length === 0`. That is the
+  // durable pre-state; "momentarily off the point" never was one.
+  //
+  // TWO — an EMPTY hit stack was read as "clear". `elementsFromPoint` returns
+  // an empty list for a point outside the viewport, which is precisely the
+  // conflation the probe below was rewritten to eliminate, quietly reintroduced
+  // one block earlier: a ✕ pushed off-screen would release the barrier
+  // instantly. An empty stack is now NOT free — it is a state to keep waiting
+  // through, and the probe's own `inViewport` assertion stays the one that
+  // names it.
+  //
+  // Neither relaxes anything, and neither can mask the #1050 regression: the
+  // float is `.shell-chrome`, a DIFFERENT element, never consulted here; and if
+  // the drawer genuinely failed to leave, the hit-stack half would still fail.
   await expect(page.locator(".shell-members.open")).toHaveCount(0);
   await expect
     .poll(
@@ -123,10 +149,10 @@ test("@webkit #1050 — the /list window drops the floating ☰, and its ✕ act
         closeBtn.evaluate((el) => {
           const drawer = document.querySelector(".shell-members");
           if (drawer === null) return true;
+          if (drawer.getAnimations().length > 0) return false;
           const r = el.getBoundingClientRect();
-          return !document
-            .elementsFromPoint(r.x + r.width / 2, r.y + r.height / 2)
-            .includes(drawer);
+          const stack = document.elementsFromPoint(r.x + r.width / 2, r.y + r.height / 2);
+          return stack.length > 0 && !stack.includes(drawer);
         }),
       { timeout: 10_000, message: "#1050 — the rail drawer never left the ✕'s hit stack" },
     )

--- a/cicchetto/e2e/tests/issue1050-list-window-no-float.spec.ts
+++ b/cicchetto/e2e/tests/issue1050-list-window-no-float.spec.ts
@@ -37,11 +37,78 @@ import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
+// ONE oracle, read by BOTH the barrier and the probe. They ask the same
+// question about the same corner at two different instants, and the whole
+// #1050 CI archaeology turned on comparing their answers — so they must not be
+// two hand-rolled readings that can drift apart.
+//
+// Runs inside the page: passed to `evaluate`, never called from node, so it
+// may close over nothing. Everything it can cheaply see about the corner goes
+// in, because the expensive half of a red here is not the failure, it is not
+// knowing which of paint, hit-test and layout disagreed at that instant.
+function inspectCorner(el: Element) {
+  const describe = (n: Element) =>
+    `${n.tagName.toLowerCase()}${[...n.classList].map((c) => `.${c}`).join("")}` +
+    (n.getAttribute("data-testid") ? `[${n.getAttribute("data-testid")}]` : "");
+  const drawer = document.querySelector(".shell-members");
+  const r = el.getBoundingClientRect();
+  const x = r.x + r.width / 2;
+  const y = r.y + r.height / 2;
+  const stack = document.elementsFromPoint(x, y);
+  const top = stack.length === 0 ? null : stack[0];
+  const nAnim = drawer === null ? 0 : drawer.getAnimations().length;
+  return {
+    t: Math.round(performance.now()),
+    hit: top !== null && (top === el || el.contains(top)),
+    inViewport: x >= 0 && y >= 0 && x < window.innerWidth && y < window.innerHeight,
+    clear: drawer === null || (nAnim === 0 && stack.length > 0 && !stack.includes(drawer)),
+    point: [Math.round(x), Math.round(y)],
+    viewport: [window.innerWidth, window.innerHeight],
+    rect: [Math.round(r.x), Math.round(r.y), Math.round(r.width), Math.round(r.height)],
+    nMembers: document.querySelectorAll(".shell-members").length,
+    nAnim,
+    drawerLeft: drawer === null ? null : Math.round(drawer.getBoundingClientRect().left),
+    drawerTransform: drawer === null ? null : getComputedStyle(drawer).transform,
+    stack: stack.slice(0, 6).map(describe),
+  };
+}
+
+type CornerReading = ReturnType<typeof inspectCorner>;
+
+// SELF-REPORTING, ON GREEN TOO. The one red this spec has produced in CI cost
+// a full reconstruction from the trace's screencast — barrier release instant
+// against painted drawer edge, fitted to the transition curve — to establish
+// something the barrier itself could simply have said: how many times it
+// polled, and what it saw each time. It polled ONCE and released 48ms before
+// the probe, with the drawer still ~59px over the point. None of that is in
+// any artifact; all of it was in the barrier's own hands.
+//
+// So every reading is printed unconditionally. It costs nothing while the spec
+// passes and it turns the next red from archaeology into a read. Two exits and
+// a `finally`, mirroring `issue988-rail-menu-first-row`: node-side
+// `console.log` (the `list` reporter prints stdout from PASSING tests, which
+// is the run whose numbers matter most here) plus a `testInfo.attach`, which
+// survives into the HTML report instead of being interleaved with the rest of
+// the suite. From a `finally`, so a barrier that times out still reports the
+// samples that led there.
+async function reportCorner(
+  testInfo: import("@playwright/test").TestInfo,
+  label: string,
+  readings: CornerReading[],
+): Promise<void> {
+  if (readings.length === 0) return;
+  for (const r of readings) console.log(`#1050 ${label} ${JSON.stringify(r)}`);
+  await testInfo.attach(`issue1050-corner-${label}`, {
+    body: JSON.stringify(readings, null, 2),
+    contentType: "application/json",
+  });
+}
+
 test.setTimeout(90_000);
 
 test("@webkit #1050 — the /list window drops the floating ☰, and its ✕ actually closes the directory", async ({
   page,
-}) => {
+}, testInfo) => {
   const vjt = getSeededVjt();
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
@@ -66,8 +133,8 @@ test("@webkit #1050 — the /list window drops the floating ☰, and its ✕ act
   // THE MECHANISM, measured rather than argued: the element under the finger at
   // the ✕'s own centre IS the ✕. Pre-fix this resolved to the floated ☰.
   //
-  // The probe returns the whole hit stack, not a bare boolean, and it costs
-  // nothing until something fails. The first red here was unreadable: a lone
+  // The probe returns the whole hit stack, not a bare boolean, and it is
+  // reported whatever the outcome. The first red here was unreadable: a lone
   // `false` says a layer won the corner but never names it, and the artifacts
   // do not settle it either — `elementFromPoint` returns null for a point
   // outside the viewport, so "covered by an invisible layer" and "pushed
@@ -108,6 +175,14 @@ test("@webkit #1050 — the /list window drops the floating ☰, and its ✕ act
   // `elementFromPoint` are still using the interpolated one. Two oracles, one
   // instant, opposite answers.
   //
+  // ⚠️ IF YOU RE-MEASURE THOSE FRAMES: the trace's own metadata LIES about
+  // their size. `0-trace.trace` declares the screencast at `1179x1977` while
+  // the JPEGs on disk are `391x657` — a factor of 3, the device pixel ratio,
+  // applied in the wrong direction. Reading the frames at the declared size
+  // yields the OPPOSITE conclusion about where the drawer edge was, which is
+  // exactly the wrong turn taken once already while diagnosing this. Check with
+  // `sips -g pixelWidth <frame>.jpeg` before converting a pixel to a CSS px.
+  //
   // So the barrier now asks the SAME oracle the assertion below asks. It waits
   // ONLY for the drawer to leave the ✕'s hit stack — deliberately not for the
   // ✕ to win it, which would fold the #1050 regression itself into a barrier
@@ -143,40 +218,24 @@ test("@webkit #1050 — the /list window drops the floating ☰, and its ✕ act
   // float is `.shell-chrome`, a DIFFERENT element, never consulted here; and if
   // the drawer genuinely failed to leave, the hit-stack half would still fail.
   await expect(page.locator(".shell-members.open")).toHaveCount(0);
-  await expect
-    .poll(
-      () =>
-        closeBtn.evaluate((el) => {
-          const drawer = document.querySelector(".shell-members");
-          if (drawer === null) return true;
-          if (drawer.getAnimations().length > 0) return false;
-          const r = el.getBoundingClientRect();
-          const stack = document.elementsFromPoint(r.x + r.width / 2, r.y + r.height / 2);
-          return stack.length > 0 && !stack.includes(drawer);
-        }),
-      { timeout: 10_000, message: "#1050 — the rail drawer never left the ✕'s hit stack" },
-    )
-    .toBe(true);
+  const barrierReadings: CornerReading[] = [];
+  try {
+    await expect
+      .poll(
+        async () => {
+          const reading = await closeBtn.evaluate(inspectCorner);
+          barrierReadings.push(reading);
+          return reading.clear;
+        },
+        { timeout: 10_000, message: "#1050 — the rail drawer never left the ✕'s hit stack" },
+      )
+      .toBe(true);
+  } finally {
+    await reportCorner(testInfo, "barrier", barrierReadings);
+  }
 
-  const probe = await closeBtn.evaluate((el) => {
-    const describe = (n: Element | null) =>
-      n === null
-        ? "null"
-        : `${n.tagName.toLowerCase()}${[...n.classList].map((c) => `.${c}`).join("")}` +
-          (n.getAttribute("data-testid") ? `[${n.getAttribute("data-testid")}]` : "");
-    const r = el.getBoundingClientRect();
-    const x = r.x + r.width / 2;
-    const y = r.y + r.height / 2;
-    const top = document.elementFromPoint(x, y);
-    return {
-      hit: top === el || el.contains(top),
-      inViewport: x >= 0 && y >= 0 && x < window.innerWidth && y < window.innerHeight,
-      point: [Math.round(x), Math.round(y)],
-      viewport: [window.innerWidth, window.innerHeight],
-      rect: [Math.round(r.x), Math.round(r.y), Math.round(r.width), Math.round(r.height)],
-      stack: document.elementsFromPoint(x, y).slice(0, 6).map(describe),
-    };
-  });
+  const probe = await closeBtn.evaluate(inspectCorner);
+  await reportCorner(testInfo, "probe", [probe]);
 
   // Split from the hit test on purpose. A ✕ pushed off-screen fails the hit
   // test too, for a reason that has nothing to do with anything painting over

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -184,6 +184,16 @@ artifacts: screenshot, video, trace.zip) and
 `cicchetto/e2e/playwright-report/`. Open a trace with
 `npx playwright show-trace <path>/trace.zip`.
 
+**A trace's screencast metadata lies about frame size.** Unzipped,
+`0-trace.trace` declares the screencast at the DEVICE resolution
+(e.g. `1179x1977` for `webkit-iphone-15`) while the JPEGs it points at
+are written at the CSS resolution (`391x657`) — off by the device pixel
+ratio, and off in the direction that makes a measured pixel look 3×
+further along than it is. Measuring a frame against the declared size
+flips the conclusion, which is how the #1050 diagnosis went the wrong
+way once. Run `sips -g pixelWidth -g pixelHeight <frame>.jpeg` and scale
+against THAT before turning a frame pixel into a CSS px.
+
 Those are the BROWSER half. On a non-zero exit `scripts/integration.sh`
 also dumps one log file per container to `cicchetto/e2e/container-logs/`
 (#702), from inside its EXIT trap — before the tear-down in that same


### PR DESCRIPTION
Two hardening changes to the `#1050` spec's drawer barrier, plus the
instrumentation that would have made the last CI red readable. Both defects
were established by **reading the barrier and instrumenting it locally** — not
by a red this closes.

**This does NOT claim to fix the observed CI red.** The failing attempt of run
`31280208433` does not reproduce here: 20 local runs of the untouched spec on
the same containerised webkit, 0 red. The CI incidence rate is unknown — one
red on a denominator I cannot see. What follows stands on its own; whether it
also removes that red is untested, which is why there is no closing keyword.

## Commit 1 — a barrier must establish a state that STAYS established

**Defect A, the release condition was instantaneous.** "the drawer is not
under this point right now" is a property of a LIVE animation. Instrumented
locally it holds ~5–15ms before the slide ends — `getAnimations().length` still
`1`, drawer left at 377..389 against a final 393 — in 9 runs out of 10. The
assertion then samples at some later, unbounded instant: 4–15ms locally, 48ms
in the CI trace. A barrier that samples a moving target and hopes is a coin
flip by design, and naming the engine internal that decides the toss is not
required to call it one. The condition now also requires
`getAnimations().length === 0` — the transition FINISHED. That is a durable
pre-state; "momentarily off the point" never was one.

**Defect B, an empty hit stack was read as "clear".** `elementsFromPoint`
returns an empty list for a point outside the viewport — precisely the
conflation the probe below it was rewritten to eliminate, quietly reintroduced
one block earlier. A ✕ pushed off-screen would have released the barrier
instantly. An empty stack is now a state to keep waiting through; the probe's
own `inViewport` assertion stays the one that names it.

Neither relaxes an assertion, and neither can mask the `#1050` regression: the
float is `.shell-chrome`, a DIFFERENT element this barrier never consults, and
a drawer that genuinely failed to leave would still fail the hit-stack half.

## Commit 2 — self-reporting, on green runs too

The one red this spec produced cost a full reconstruction from the trace's
screencast — barrier release instant against painted drawer edge, fitted to the
200ms ease-out curve — to establish two facts the barrier could simply have
stated: that it polled **once**, and that it released 48ms before the probe with
the drawer still ~59px over the point. None of that is in any artifact; all of
it was in the barrier's own hands.

Barrier and probe now read the corner through one shared `inspectCorner`.
Sharing the oracle matters as much as printing it: the diagnosis turned on
comparing what the two saw at two instants, which is worthless if they are two
hand-rolled readings free to drift. Each reading carries the ✕'s rect, the hit
stack, the drawer's animation count, its computed transform and its gBCR left.

Reporting mirrors `issue988-rail-menu-first-row`: node-side `console.log` (the
`list` reporter prints stdout from passing tests) plus a `testInfo.attach` that
survives into the HTML report, both from a `finally` so a timed-out barrier
still hands over the samples that led there.

`docs/TESTING.md` gains the other half of that CI round: a trace declares its
screencast at the DEVICE resolution while writing the JPEGs at the CSS one, so
measuring a frame against the declared size overstates every offset by the
device pixel ratio — and flips the conclusion, as it did here once.

## Gates

`scripts/integration.sh --project webkit-iphone-15 --grep "#1050" --repeat-each 10`
→ **10 passed (47.4s)**, `rc=0`.

`tsc -p e2e/tsconfig.json --noEmit` → 26 errors, byte-identical to the
pre-change baseline, none in this spec. (`cicchetto/e2e/` has no static gate in
CI and `biome check` exits 0 without reading files under it, so that is the
only meaningful static signal available here.)

**The telemetry witnesses defect A on this host.** Across the 30 barrier
samples the 10 runs emitted, **9 samples in 9 distinct runs** have the drawer
already out of the hit stack while `nAnim === 1` and `drawerLeft` at 384–393
against a final 393. Those are exactly the instants where the OLD condition
would have released and the new one keeps waiting one more poll — the 9-in-10
figure, observed rather than predicted.

Defect B has **no witness in this run**: the stack was never empty here. It is
fixed on the strength of the read, not of a measurement.

## Not run

The full `scripts/integration.sh` suite. This touches one spec file and one doc,
and CI is being watched separately.