### PR TITLE
cic(#1089): re-assert the unread divider synchronously, not two frames late

### DIFF
--- a/cicchetto/e2e/tests/issue1089-switch-into-unread-flicker.spec.ts
+++ b/cicchetto/e2e/tests/issue1089-switch-into-unread-flicker.spec.ts
@@ -1,0 +1,412 @@
+// Issue #1089 — switching INTO a window that has unread must not flicker.
+//
+// ## The field report (vjt, prod)
+//
+// Entering a window with unread messages: the content paints once, then jumps.
+// Discriminating fact established in the issue: it happens on EVERY switch, not
+// only the first one after a reload — so it is not a cold-mount cause.
+//
+// ## What the measurement found (and what it acquitted)
+//
+// The issue nominated the marker RE-ASSERT running without the #130 flicker
+// hide (`scrollToActivation("marker-or-tail", false)`). Sampling every frame
+// through a switch says the hide is not the mechanism. Two displacements are,
+// and both happen AFTER the establishing write has already parked the pane on
+// the divider and revealed it:
+//
+//   1. a `tail-only` activation (the ResizeObserver arm: the container box does
+//      change between the $server pane and a channel pane, and the switch
+//      pre-arms `followMode` as an intent default) tail-snapping straight
+//      through the live marker activation — divider 365px off-screen ABOVE for
+//      ~400ms;
+//   2. the read-context page landing. The eager join-ok refresh only loads rows
+//      AFTER the read cursor, so entering an unread window ALWAYS fetches the
+//      ~50 rows of context below it; that page prepends ~1049px ABOVE the
+//      viewport, and the correction — deferred to an rAF×2 — concedes one
+//      COMPOSITED frame with the divider shoved off the bottom.
+//
+// Both are cured by giving the applier's marker-activation dispatch a SYNC leg
+// (see `dispatchScrollWrite`), which is the idiom the overlay-freeze case in
+// the same switch already uses. With the pane parked on the divider from the
+// commit frame onward, (1) stops firing as well.
+//
+// ## The oracle — what the OPERATOR sees, not which function ran
+//
+//   while the pane is VISIBLE, the unread divider never leaves the viewport.
+//
+// Measured per animation frame as the divider's offset from the scroll
+// container's visible top (`getBoundingClientRect` delta) — the same geometry
+// scroll-on-window-switch asserts once, sampled continuously instead. Frames
+// where the pane is `visibility: hidden` are EXCLUDED by construction: those are
+// exactly the frames the operator cannot see, so the assertion stays honest
+// about what "flicker" means. It cannot be satisfied by hiding forever — the
+// settle assertions pin the end state visible AND parked on the divider.
+//
+// A scrollTop-only oracle would be weaker: rows prepend above the viewport and
+// shift scrollTop without moving anything on screen (that is case 2 above, whose
+// scrollTop does NOT change while the content does). The divider's on-screen
+// offset is the pixel the reader actually looks at.
+//
+// Harness mirrors scroll-on-window-switch scenario 3 (warm #bofh in the
+// background, focus $server, then click #bofh — a real key-change SWITCH) and
+// the #625 in-page sampler (a rAF loop, because case 2 is one frame wide and any
+// post-hoc snapshot false-greens).
+
+import { expect, test } from "../fixtures/test";
+import { type Page } from "@playwright/test";
+import {
+  loginAs,
+  scrollbackLines,
+  selectChannel,
+  sidebarWindow,
+  waitForScrollbackRefreshed,
+} from "../fixtures/cicchettoPage";
+import { restoreReadCursorToTail, setReadCursorToId } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Mirror of ScrollbackPane.SCROLL_BOTTOM_THRESHOLD_PX = 50 (not exported; kept
+// in lockstep by hand — same as issue168 / issue625 / scroll-on-window-switch).
+const SCROLL_BOTTOM_THRESHOLD_PX = 50;
+
+// REST default page size (Grappa.Web.MessagesController.@default_limit).
+const REST_PAGE_SIZE = 50;
+
+// Sampling window. Both displacements are driven by work that outlives the
+// switch: the post-switch fetches are a NETWORK round trip, and the deferred
+// #608 writers run for up to SETTLE_MAX_FRAMES ≈ 0.5s. 2.5s outlasts both plus
+// the 0.5s scroll-settle timer.
+const SAMPLE_WINDOW_MS = 2500;
+
+// `block:"start"` lands the divider at the container's top edge; sub-pixel
+// rounding and the row's own top border can push the measured delta slightly
+// negative. Same -5 tolerance scroll-on-window-switch uses for the same read.
+const MARKER_TOP_TOLERANCE_PX = 5;
+
+// Mirror of the viewport height configured below — used as the "on screen"
+// bound in the pre-perturbation settle poll.
+const VIEWPORT_HEIGHT = 300;
+
+// Latency injected on the POST-SWITCH `/messages` fetches. NOT a workaround —
+// it puts the test in the regime the defect lives in. Entering a window fires
+// `loadInitialScrollback` (anchored: the read-context page BELOW the cursor)
+// plus the catch-up `refreshScrollback`; on the local stack those land in
+// single-digit ms, i.e. INSIDE the establishing write's hide window, and the
+// pane is revealed already correct — nothing is left to displace it. On a real
+// link (the maintainer's report is from mobile) they land hundreds of ms later,
+// AFTER the reveal, which is where both displacements live. Measured on main
+// across three runs with no delay: the same spec went green, green, RED
+// depending on which side of the reveal the fetch happened to land. A defect
+// that reproduces only when the network is slow is still a defect; the delay
+// picks the regime deterministically instead of leaving a coin-flip spec.
+const POST_SWITCH_LATENCY_MS = 400;
+
+type Frame = {
+  t: number;
+  vis: string;
+  top: number;
+  height: number;
+  client: number;
+  // Divider offset from the container's visible top; null when no divider is
+  // in the DOM at that frame (mid-recreation).
+  marker: number | null;
+};
+
+// Install an in-page per-frame sampler on the scrollback container. Read-only:
+// it never writes scroll state, so it cannot mask or create the defect. The
+// container node is SHARED across window switches (Shell's <Show> is non-keyed
+// — the very reason the pane resets scroll explicitly), but we re-query per
+// frame anyway so the probe survives any future re-mount.
+async function installFlickerProbe(page: Page, windowMs: number): Promise<void> {
+  await page.evaluate((windowMsArg) => {
+    type Frame = {
+      t: number;
+      vis: string;
+      top: number;
+      height: number;
+      client: number;
+      marker: number | null;
+    };
+    type WriteEvent = { t: number; kind: string; detail: string; before: number };
+    const w = window as unknown as { __i1089frames: Frame[]; __i1089writes: WriteEvent[] };
+    w.__i1089frames = [];
+    w.__i1089writes = [];
+    const t0 = performance.now();
+
+    // Name every scroll write on the container so the timeline distinguishes
+    // the establishing write from the re-assert. Diagnostic only: both wrappers
+    // delegate to the native behaviour, so production timing is unchanged.
+    const target = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+    const desc = Object.getOwnPropertyDescriptor(Element.prototype, "scrollTop");
+    if (target && desc?.get && desc?.set) {
+      Object.defineProperty(target, "scrollTop", {
+        configurable: true,
+        get() {
+          return desc.get?.call(this);
+        },
+        set(v: number) {
+          w.__i1089writes.push({
+            t: Math.round(performance.now() - t0),
+            kind: "scrollTop=",
+            detail: String(Math.round(v)),
+            before: Math.round(desc.get?.call(target) as number),
+          });
+          desc.set?.call(this, v);
+        },
+      });
+      const rawSIV = Element.prototype.scrollIntoView;
+      Element.prototype.scrollIntoView = function (arg?: boolean | ScrollIntoViewOptions) {
+        if (this === target || target.contains(this as Node)) {
+          w.__i1089writes.push({
+            t: Math.round(performance.now() - t0),
+            kind: "scrollIntoView",
+            detail: `${(this as HTMLElement).dataset?.testid ?? (this as HTMLElement).className} ${JSON.stringify(arg ?? null)}`,
+            before: Math.round(desc.get?.call(target) as number),
+          });
+        }
+        return rawSIV.call(this, arg as ScrollIntoViewOptions);
+      };
+    }
+    const loop = () => {
+      const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
+      const t = Math.round(performance.now() - t0);
+      if (el) {
+        const m = el.querySelector('[data-testid="unread-marker"]') as HTMLElement | null;
+        w.__i1089frames.push({
+          t,
+          vis: getComputedStyle(el).visibility,
+          top: Math.round(el.scrollTop),
+          height: el.scrollHeight,
+          client: el.clientHeight,
+          marker: m
+            ? Math.round(m.getBoundingClientRect().top - el.getBoundingClientRect().top)
+            : null,
+        });
+      }
+      if (t < windowMsArg) requestAnimationFrame(loop);
+    };
+    requestAnimationFrame(loop);
+  }, windowMs);
+}
+
+// On failure this dump is the whole story: one entry per CHANGE of the
+// (visibility, divider offset) pair, so a one-frame excursion shows as a
+// visible=…, marker=<off-screen px> entry between two on-divider entries.
+function compress(frames: readonly Frame[]): Array<{ t: number; vis: string; marker: number | null; top: number }> {
+  const out: Array<{ t: number; vis: string; marker: number | null; top: number }> = [];
+  let prev = "";
+  for (const f of frames) {
+    const sig = `${f.vis}|${f.marker}|${f.top}`;
+    if (sig !== prev) {
+      out.push({ t: f.t, vis: f.vis, marker: f.marker, top: f.top });
+      prev = sig;
+    }
+  }
+  return out;
+}
+
+test.describe("issue #1089 — switching into an unread window must not flicker", () => {
+  test.use({ viewport: { width: 800, height: 300 } });
+
+  // Cascade rule (feedback_cascade_poisoner_pattern): this spec seeds a
+  // MID-PAGE #bofh cursor on the shared seeded vjt. Restore the tail so the
+  // next spec inherits a fully-read channel instead of a phantom divider.
+  test.afterAll(async () => {
+    if (!CHANNEL) return;
+    const vjt = getSeededVjt();
+    await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
+  });
+
+  test("SWITCH into channel-with-unreads: the divider never leaves the viewport on a visible frame", async ({
+    page,
+  }) => {
+    const vjt = getSeededVjt();
+    if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+
+    await seedMidPageCursor(vjt.token, CHANNEL);
+    await loginAs(page, vjt);
+    await parkOnServerWindow(page);
+    await warmUpChannel(page, CHANNEL);
+
+    await delayMessageFetches(page, POST_SWITCH_LATENCY_MS);
+    await installFlickerProbe(page, SAMPLE_WINDOW_MS);
+
+    // THE SWITCH — a real key-change from $server to #bofh.
+    await sidebarWindow(page, NETWORK_SLUG, CHANNEL).locator(".sidebar-window-btn").click();
+
+    await expect
+      .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
+      .toBeGreaterThanOrEqual(REST_PAGE_SIZE);
+    await expect(page.locator('[data-testid="unread-marker"]')).toHaveCount(1);
+
+    await page.waitForTimeout(SAMPLE_WINDOW_MS + 200);
+    await assertNoVisibleJump(page, "switch");
+  });
+
+  test("live append while parked on the divider: the re-assert must not paint a displaced frame", async ({
+    page,
+  }) => {
+    const vjt = getSeededVjt();
+    if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+
+    await seedMidPageCursor(vjt.token, CHANNEL);
+    await loginAs(page, vjt);
+    await parkOnServerWindow(page);
+    await warmUpChannel(page, CHANNEL);
+
+    await sidebarWindow(page, NETWORK_SLUG, CHANNEL).locator(".sidebar-window-btn").click();
+    await expect
+      .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
+      .toBeGreaterThanOrEqual(REST_PAGE_SIZE);
+    await expect(page.locator('[data-testid="unread-marker"]')).toHaveCount(1);
+    // Settled ON the divider before we perturb anything — the marker latch is
+    // still armed (it clears only on operator input on the pane or an own send,
+    // and we do neither), which is the state a reader is in right after
+    // entering an unread window.
+    await expect
+      .poll(async () => await markerOffset(page), { timeout: 10_000 })
+      .toBeLessThan(VIEWPORT_HEIGHT);
+
+    // A peer speaks in the channel the operator just entered — an ordinary
+    // busy-channel event, and the rows change that re-enters the applier while
+    // the latch is armed. It appends BELOW the fold, so nothing above the
+    // divider changes: the divider's on-screen offset must not move at all.
+    //
+    // Connect + join BEFORE the probe: registration and JOIN take seconds, and
+    // a probe installed first would have expired by the time the line lands —
+    // the sampler would record a flat, untouched timeline and green vacuously.
+    const peer = await IrcPeer.connect({ nick: `i1089-${Date.now().toString(36).slice(-6)}` });
+    try {
+      await peer.join(CHANNEL);
+      await installFlickerProbe(page, SAMPLE_WINDOW_MS);
+      const body = `i1089 live append ${Date.now()}`;
+      peer.privmsg(CHANNEL, body);
+      await expect(scrollbackLines(page).filter({ hasText: body })).toHaveCount(1, {
+        timeout: 15_000,
+      });
+      await page.waitForTimeout(SAMPLE_WINDOW_MS + 200);
+    } finally {
+      await peer.disconnect("i1089 done");
+    }
+
+    const frames = await assertNoVisibleJump(page, "live-append");
+    // Witness: the perturbation actually landed INSIDE the sampled window. A
+    // flat timeline (the append arriving after the sampler expired) would green
+    // this test without ever exercising the re-assert.
+    const grew = Math.max(...frames.map((f) => f.height)) > Math.min(...frames.map((f) => f.height));
+    expect(grew, "the live append did not land while the sampler was running").toBe(true);
+  });
+});
+
+// Cursor 25 rows from the tail → the divider injects deep in the page, far
+// enough from the top that a scrollTop=0 frame puts it thousands of px
+// off-screen (an unmistakable excursion, not a rounding wobble).
+async function seedMidPageCursor(token: string, channel: string): Promise<void> {
+  const page0 = await fetchScrollbackPage(token, channel);
+  expect(page0.length).toBeGreaterThanOrEqual(REST_PAGE_SIZE);
+  const cursorRow = page0[25];
+  if (!cursorRow) throw new Error("seeded page too short for cursor placement");
+  await setReadCursorToId(token, NETWORK_SLUG, channel, cursorRow.id);
+}
+
+// Warmth gate: cic eagerly refreshes every joined channel on its Phoenix
+// join-ok, so #bofh loads in the background without us focusing it. A cold
+// switch would early-return in `scrollToActivation` (empty pane) and never arm
+// the path under test.
+//
+// Await the BACKFILL SEAM, not the first HTTP response: the eager refresh loads
+// the whole seeded channel, and awaiting only one response lets the switch
+// happen while just the after-cursor rows are in the store. The divider then
+// sits within `LOAD_MORE_THRESHOLD_PX` of the top, cic auto-pages older history,
+// and that prepend adds a jolt of its own — a DIFFERENT defect from the one
+// under test, which would otherwise be attributed to this spec's subject.
+async function warmUpChannel(page: Page, channel: string): Promise<void> {
+  await waitForScrollbackRefreshed(page, NETWORK_SLUG, channel);
+}
+
+// FROM-window: the $server tab mounts ScrollbackPane WITHOUT touching #bofh's
+// read cursor (focusing #bofh first would fire the leave-arm and advance the
+// cursor to the tail, erasing the unread under test).
+async function parkOnServerWindow(page: Page): Promise<void> {
+  await selectChannel(page, NETWORK_SLUG, NETWORK_SLUG, { awaitWsReady: false });
+  await expect(page.locator('[data-testid="scrollback"]')).toBeVisible({ timeout: 10_000 });
+}
+
+// Hold every subsequent scrollback fetch for `ms` before letting it through.
+// Route-level only: the response body is the real server's, untouched.
+async function delayMessageFetches(page: Page, ms: number): Promise<void> {
+  await page.route(/\/messages(\?|$)/, async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+    await route.continue();
+  });
+}
+
+async function markerOffset(page: Page): Promise<number> {
+  return await page.evaluate(() => {
+    const el = document.querySelector('[data-testid="scrollback"]') as HTMLElement | null;
+    const m = document.querySelector('[data-testid="unread-marker"]') as HTMLElement | null;
+    if (!el || !m) return Number.NaN;
+    return m.getBoundingClientRect().top - el.getBoundingClientRect().top;
+  });
+}
+
+// The shared verdict: the end state is parked-on-divider-and-visible (so a
+// green cannot come from a hidden or divider-less pane), and NO visible frame
+// in the sampled window showed the divider outside the viewport.
+async function assertNoVisibleJump(page: Page, tag: string): Promise<Frame[]> {
+  const frames = await page.evaluate(
+    () => (window as unknown as { __i1089frames: Frame[] }).__i1089frames,
+  );
+  const writes = await page.evaluate(
+    () =>
+      (window as unknown as { __i1089writes: Array<Record<string, unknown>> }).__i1089writes ?? [],
+  );
+  console.log(`[#1089 ${tag}] frames=${frames.length} timeline=${JSON.stringify(compress(frames))}`);
+  console.log(`[#1089 ${tag}] writes=${JSON.stringify(writes)}`);
+
+  expect(frames.length).toBeGreaterThan(10);
+  const settled = frames[frames.length - 1] as Frame;
+  expect(settled.height).toBeGreaterThan(settled.client);
+  expect(settled.vis).toBe("visible");
+  expect(settled.marker).not.toBeNull();
+  expect(settled.marker as number).toBeGreaterThanOrEqual(-MARKER_TOP_TOLERANCE_PX);
+  expect(settled.marker as number).toBeLessThan(settled.client);
+  // Parked on the divider, not tailed (the pane must have something below to
+  // scroll to, or a "no jump" green would be vacuous).
+  expect(settled.height - settled.top - settled.client).toBeGreaterThan(
+    SCROLL_BOTTOM_THRESHOLD_PX,
+  );
+
+  // #1089 CORE — no VISIBLE frame shows the divider outside the viewport. On
+  // main both post-reveal displacements land here: the tail snap parks it
+  // hundreds of px ABOVE the fold for ~400ms, and the read-context prepend
+  // shoves it ~1049px BELOW for one composited frame.
+  const offscreen = frames.filter(
+    (f) =>
+      f.vis === "visible" &&
+      f.marker !== null &&
+      (f.marker < -MARKER_TOP_TOLERANCE_PX || f.marker >= f.client),
+  );
+  expect(
+    offscreen,
+    `visible frame(s) with the divider off-screen — the operator saw the jump: ${JSON.stringify(
+      offscreen,
+    )}`,
+  ).toEqual([]);
+  return frames;
+}
+
+// Fetch the latest scrollback page via REST (same shape as
+// scroll-on-window-switch / issue625) — used to place the cursor mid-page.
+async function fetchScrollbackPage(token: string, channel: string): Promise<Array<{ id: number }>> {
+  const url = `http://grappa-test:4000/networks/${encodeURIComponent(
+    NETWORK_SLUG,
+  )}/channels/${encodeURIComponent(channel)}/messages`;
+  const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!response.ok) {
+    throw new Error(`fetchScrollbackPage: ${response.status} ${await response.text()}`);
+  }
+  return (await response.json()) as Array<{ id: number }>;
+}

--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -2860,13 +2860,33 @@ const ScrollbackPane: Component<Props> = (props) => {
         );
         return;
       }
-      case "marker-activation":
+      case "marker-activation": {
         // W2/W3 — jump to the rendered unread divider (or the tail if none).
         // `scrollToActivation` owns the rAF×2 + the frozen bail (unreachable
         // here: overlay-freeze outranks marker-activation, so we only dispatch
         // marker-activation when not frozen).
+        //
+        // #1089 — SYNC leg first, then the deferred one, exactly as the
+        // overlay-freeze case above does and for the same reason ("no transient
+        // frame for a reader to catch"). This dispatch reacts to a rows change,
+        // and the rows change has ALREADY mutated the DOM by the time the
+        // applier runs — we are post-commit, pre-paint. Deferring the whole
+        // correction to `scrollToActivation`'s rAF×2 therefore concedes one
+        // COMPOSITED frame at the displaced position. Measured entering an
+        // unread window: the read-context page (`loadInitialScrollback`'s
+        // anchored `before` fetch — the eager join-ok refresh only loads rows
+        // AFTER the read cursor, so this page always arrives on focus) prepends
+        // ~1049px ABOVE the viewport, and for one frame the reader saw the
+        // divider shoved off the bottom of the pane before the correction pulled
+        // it back — "it paints once, then jumps". The applier gated this intent
+        // on a rendered divider, so the node is here; the rAF×2 that follows
+        // still owns the settled read (`followMode`/`atBottomNow` from the real
+        // distance) and corrects any pre-layout inaccuracy of this leg.
+        const marker = listRef.querySelector('[data-testid="unread-marker"]') as HTMLElement | null;
+        marker?.scrollIntoView?.({ block: "start" });
         scrollToActivation("marker-or-tail", false);
         return;
+      }
       case "tail-follow":
         // W5 — stick to the tail via the MEASURED-settle wait (#608 STEP 6),
         // replacing the fixed rAF×2 which is not a layout flush on iOS WebKit and

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -34571,3 +34571,68 @@ spec's width assertion also covers Networks only: Visitors and Sessions are
 empty in the baseline seed, and Users/Credentials are populated but were never
 measured at 393px, so "no admin tab scrolls horizontally" is asserted for the
 one tab the issue scoped and believed for the rest on the strength of `a669e8cf`.
+
+---
+
+## 2026-08-09 — #1089: entering an unread window flickered, and it was not the hide
+
+The report: switching into a window that has unread paints once, then jumps. The
+issue arrived half-diagnosed and named a suspect — the applier's marker
+RE-ASSERT runs `scrollToActivation("marker-or-tail", false)`, i.e. WITHOUT the
+#130 flicker hide, while the establishing write runs with it. The issue also
+said, correctly, that the suspicion had not been measured.
+
+**Measured, the hide is innocent.** Sampling `visibility` + the divider's
+on-screen offset every animation frame through a switch shows the establishing
+write parking the pane on the divider and revealing it correctly. What comes
+AFTER the reveal is the flicker, and there are two of them:
+
+1. **A `tail-only` activation writing straight through a live marker
+   activation.** The ResizeObserver arm (`moved && followMode()`) fires because
+   the container box does change between the $server pane and a channel pane,
+   and the switch pre-arms `followMode` as an intent default. It tail-snapped
+   the reader ~18ms after the reveal, leaving the divider 365px off-screen ABOVE
+   for ~400ms. `marker-activation` outranks `tail-follow` in `resolveIntent`, so
+   this write should never have happened — `applyActivation` declares only its
+   own intent plus overlay-freeze, which is the STEP-3 behaviour-preserving
+   choice made explicit in its doc comment, and this is the hole it leaves.
+2. **The read-context page landing.** The eager join-ok `refreshScrollback`
+   resumes from the READ CURSOR, so entering an unread window has only the
+   unread rows loaded and `loadInitialScrollback`'s anchored `before` page
+   ALWAYS arrives on focus. It prepends ~1049px ABOVE the viewport; scrollTop
+   does not change, so the content moves under the reader and the correction —
+   deferred to `scrollToActivation`'s rAF×2 — concedes one COMPOSITED frame with
+   the divider shoved off the bottom.
+
+**The cure is one sync leg, and it is the file's own idiom.** The applier's
+marker-activation dispatch now scrolls the divider into view SYNCHRONOUSLY
+before delegating to `scrollToActivation`, exactly as the `overlay-freeze` case
+two branches above already does ("re-assert SYNC — no transient frame for a
+reader to catch — then AGAIN across rAF×2"). The applier runs post-commit,
+pre-paint, so the sync leg lands in the same frame as the rows change that
+displaced the pane; the rAF×2 still owns the settled read (`followMode` /
+`atBottomNow` from the real distance) and corrects any pre-layout inaccuracy.
+
+**Displacement (1) needed no code.** A precedence fix in `applyActivation` (also
+declaring the derived marker-activation intent so a `tail-only` activation
+yields) was written, measured, and REMOVED: with the pane parked on the divider
+from the commit frame onward, the tail write stops happening at all, and
+deleting the precedence fix left the spec green. It was inert, so it did not
+ship. The underlying gap — `applyActivation` cannot lose to anything but
+overlay-freeze — is still there and is worth its own issue; it is simply not
+what produced this bug.
+
+**The regime matters more than the assertion.** On the local e2e stack the
+post-switch fetches return in single-digit ms, INSIDE the establishing write's
+hide window, and the pane is revealed already correct — the same spec ran green,
+green, RED on unmodified main depending on which side of the reveal the fetch
+happened to land. The spec therefore injects 400ms of latency on the post-switch
+`/messages` route: not a workaround, but the regime the maintainer's mobile
+report comes from, chosen deterministically instead of by coin flip.
+
+**Oracle.** `cicchetto/e2e/tests/issue1089-switch-into-unread-flicker.spec.ts`
+asserts the visible outcome, per frame: while the pane is VISIBLE, the unread
+divider never leaves the viewport. Hidden frames are excluded by construction
+(they are the frames the operator cannot see), and the end state is pinned
+visible AND parked on the divider so the green cannot come from a pane that
+stayed hidden or never rendered a divider.


### PR DESCRIPTION
Refs #1089.

## What the measurement found

The issue nominated a suspect — the applier's marker RE-ASSERT runs
`scrollToActivation("marker-or-tail", false)`, without the #130 flicker hide —
and said, correctly, that the suspicion had not been measured. Measured, **the
hide is innocent**: the establishing write parks the pane on the divider and
reveals it correctly. The flicker is what lands *after* the reveal.

Sampling `visibility` plus the divider's on-screen offset every animation frame
through a switch, with the post-switch fetch at real-network latency, shows two
displacements:

1. **A `tail-only` activation writing through a live marker activation.** The
   ResizeObserver arm (`moved && followMode()`) fires — the container box does
   change between the $server pane and a channel pane, and the switch pre-arms
   `followMode` as an intent default. It tail-snapped ~18ms after the reveal and
   held the divider 365px off-screen ABOVE for ~400ms.
2. **The read-context page landing.** The eager join-ok `refreshScrollback`
   resumes from the READ CURSOR, so entering an unread window has only the unread
   rows loaded and `loadInitialScrollback`'s anchored `before` page ALWAYS arrives
   on focus. It prepends ~1049px ABOVE the viewport; `scrollTop` does not change,
   so the content moves under the reader, and the correction — deferred to an
   rAF×2 — concedes one COMPOSITED frame with the divider shoved off the bottom.

Timeline (viewport 300px, 400ms on the post-switch fetch):

```
main:  t=79 VIS divider 0px → t=91 VIS divider -368px (held ~400ms) → t=473 VIS +703px → t=512 0px
fixed: t=41 HID divider 0px → t=75 VIS 0px → t=480 VIS +23px → t=512 0px
```

## The change

One sync leg, in the idiom the same `switch` already uses for `overlay-freeze`
("re-assert SYNC — no transient frame for a reader to catch — then AGAIN across
rAF×2"). The applier runs post-commit, pre-paint, so scrolling the divider into
view synchronously lands in the same frame as the rows change that displaced the
pane; the rAF×2 still owns the settled read (`followMode` / `atBottomNow` from
the real distance) and corrects any pre-layout inaccuracy.

Displacement 1 needed no code of its own: with the pane parked from the commit
frame onward, the tail write stops firing. A precedence fix in `applyActivation`
written for it was measured **inert** — removing it left the spec green — so it
was dropped. The gap it addressed (`applyActivation` can only lose to
overlay-freeze, so it does not apply the documented precedence order) is real and
worth its own issue; it is simply not what produced this bug.

## The spec

`cicchetto/e2e/tests/issue1089-switch-into-unread-flicker.spec.ts` asserts the
visible outcome, per frame: **while the pane is VISIBLE, the unread divider never
leaves the viewport.** Hidden frames are excluded by construction — they are the
frames the operator cannot see — and the end state is pinned visible AND parked
on the divider, so the green cannot come from a pane that stayed hidden or never
rendered a divider.

It injects 400ms on the post-switch `/messages` route. Not a workaround: on the
local stack those fetches land inside the hide window and nothing is left to
displace the pane — the same spec ran green, green, RED on unmodified main
depending on which side of the reveal the fetch happened to land. The delay picks
the regime the report comes from (mobile, real link) deterministically instead of
leaving a coin-flip spec.

## Test plan

- [x] `integration.sh --project chromium --grep "#1089" --repeat-each 3` — `6 passed`, rc 0, on the rebased base
- [x] Control red: same spec, cure removed — `3 failed / 3 passed`, rc 1 (both displacements visible in the dump)
- [x] `bun run check` — rc 0
- [x] `bun run test` — 259 files / 4813 tests passed
- [x] 10 neighbouring scroll/marker specs — `1 failed / 19 passed`; the failure (`issue168 › operator paged UP → send snaps back to the bottom`) reproduces IDENTICALLY with the cure removed and is 3/3 green in isolation, i.e. a pre-existing order cascade in that batch, not this diff
- [ ] Full `scripts/integration.sh` suite — not run locally