### PR TITLE
grappa(#1075): expose live admin overview stats for the operator top bar

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -569,4 +569,14 @@ config :logger, :console,
     :silent_for_ms
   ]
 
+# #1075 — os_mon is loaded for `:cpu_sup.avg1/0` alone (the admin top bar's
+# loadavg). Its two other services are started by default and are pure noise
+# here: `memsup` polls system memory and raises `system_memory_high_watermark`
+# alarms, `disksup` does the same for filesystem occupancy. Nothing in grappa
+# subscribes to those alarms or acts on them, so all they can do is log at the
+# operator. One sampler in, no alarm traffic.
+config :os_mon,
+  start_memsup: false,
+  start_disksup: false
+
 import_config "#{config_env()}.exs"

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -34636,3 +34636,90 @@ divider never leaves the viewport. Hidden frames are excluded by construction
 (they are the frames the operator cannot see), and the end state is pinned
 visible AND parked on the divider so the green cannot come from a pane that
 stayed hidden or never rendered a divider.
+---
+
+### 2026-08-09 — #1075 — the admin bar counts sources, not rows
+
+Server half of the operator top bar (#1073 is the cic half): session count,
+visitor counts, hostname, loadavg, version, live while the console is open.
+
+**The obvious shape is the expensive one.** Two of the five stats look
+already-solved — `GET /admin/sessions` and `GET /admin/visitors` both return
+lists, so the bar could count rows. Measured, that is `O(N × 250ms)`:
+`LiveIntrospection.list_sessions/0` issues a `GenServer.call` per live pid
+(joined channels, then peer address, each with a 250ms degradation budget)
+and `Visitors.list_all_with_live_state/0` does the same per credential. On a
+push cadence that is real session-mailbox traffic to produce two integers.
+
+The 20% that does not fit the existing infrastructure is exactly that: the
+tabs want enriched ROWS, the bar wants SCALARS. So `Grappa.AdminOverview` is
+a new projection — but it reuses the *sources*, not the payloads.
+`LiveIntrospection.count_live/0` scans the SAME `Grappa.SessionRegistry` the
+Sessions tab enumerates, with the same `:session`-tag-pinned match spec, and
+messages no pid; `Visitors.count_all/0` counts the same population
+`list_all/0` returns. The bar and the tabs cannot disagree about what exists.
+
+**The DB/live pair goes where the domain has one, and nowhere else.** The
+first draft of this payload was `sessions: {live, intended}` alongside
+`visitors: {total, live}`, for symmetry with the house rule that an admin
+listing carries both truths. That was wrong and was withdrawn before
+implementation: the only available `intended` is
+`Credentials.list_credentials_for_all_users/0`, scoped `user_id IS NOT NULL`
+(visitor sessions are spawned from `Visitors.list_active/0` instead), while
+`live` counts pids across BOTH subject kinds. The pair would read
+`live > intended` permanently and mean nothing.
+
+So `visitors` carries `{total, live}` — the Visitors tab carries that
+duality, `live_state: null` being its U-0 honesty signal, and here the
+scalar form says "1 visitor exists, none connected" without opening the tab.
+`sessions` is a single live number, because the Sessions tab is
+registry-driven by construction ("one row = one live pid") and its own
+moduledoc routes the DB-intent signal to `/admin/visitors` and
+`/admin/credentials` rather than carrying it. **A fabricated pair is worse
+than an honest single number** — the rule is "don't compute one truth from
+the other", not "always print two columns".
+
+**Cadence: a tick in the channel process, not a supervised sampler.** The
+counts change because something happened and could ride
+`Topic.admin_events/0`; loadavg cannot — it is sampled, with no event to
+hang off. Rather than run an event path AND a sampler, `AdminChannel` pushes
+the whole payload on an interval, armed on join and re-armed per tick. It
+lives in the channel pid deliberately: the bar exists only while an operator
+has the console open, so the sampling should too, and it dies with the
+socket with no fan-out to manage. The interval comes from the boot →
+`:persistent_term` seam (`AdminOverview.boot/0`, mirroring
+`Admission.Config`), re-read per tick so a hot-deployed change lands on the
+next one. Hostname and version are constants for the life of a connection
+and ride the join push rather than the stream.
+
+**loadavg: `:os_mon`, and it is the host's.** `:cpu_sup.avg1/0`, not
+`/proc/loadavg` — production is a FreeBSD jail, which has no `/proc`;
+cpu_sup shells out to a per-OS port program, which is the reason to pay for
+the dependency. `config/config.exs` turns off os_mon's `memsup` and
+`disksup`: they raise watermark alarms on thresholds nothing here subscribes
+to. An unavailable sampler yields `nil`, never `0.0` — "cannot measure" and
+"idle" are different facts and only one should render as a calm bar. A jail
+shares the host kernel, so the number is the HOST's load; clients must label
+it or an operator will read it as "grappa is busy".
+
+**The nginx allowlist section of the issue was already false.** #1075 asked
+for a proxy change, citing the sibling comments that made #269 nest under
+`/admin/sessions/` and annotate `/db_latency`. #485 deleted that constraint:
+`infra/snippets/locations-api.conf` states the allowlist "is GONE" and
+forwards `location /` to the BEAM unfiltered, and two substrates have no
+nginx at all. `/admin/overview` therefore sits at the top level of the admin
+scope; `:admin_authn` is the whole gate.
+
+**The symptom outlived the cause, though, and is worth knowing.** An
+unregistered `/admin/*` path does not 404 — it falls through to the BEAM's
+own SPA history-fallback and answers `200 text/html`. That surfaced in this
+change's red, where the auth-gate assertions failed on "expected 403, got
+200" rather than on a missing route. Same operator-visible shape the old
+nginx `try_files` produced; different owner. Not addressed here — it is a
+router catch-all question, not an admin-bar one.
+
+**Not established.** That any of this works inside the FreeBSD jail. The
+issue's "Done when" asks for it explicitly and it has not been done: `cpu_sup`
+was exercised only in the Linux dev container, and its FreeBSD port program
+is a different binary. Whether `avg1/0` answers inside a jail is an
+expectation here, not a measurement.

--- a/lib/grappa/admin_overview.ex
+++ b/lib/grappa/admin_overview.ex
@@ -1,0 +1,194 @@
+defmodule Grappa.AdminOverview do
+  @moduledoc """
+  Scalar projection behind the admin top bar (#1075, companion to the cic
+  half in #1073): session count, visitor counts, hostname, loadavg and the
+  running version.
+
+  ## Why this is a projection and not a count of the tab lists
+
+  The obvious shape — have the bar fetch `GET /admin/sessions` and
+  `GET /admin/visitors` and count the rows — is the wrong one. Both list
+  surfaces are *enriched* per row: `LiveIntrospection.list_sessions/0`
+  issues a `GenServer.call` PER live pid (joined channels + peer address,
+  each with a 250ms degradation budget) and
+  `Visitors.list_all_with_live_state/0` does one registry lookup plus one
+  such call per credential. On a push cadence that is `O(N × 250ms)` of
+  session-mailbox traffic to produce two integers.
+
+  The 20% that does not fit the existing infrastructure is exactly this:
+  the tabs want enriched ROWS, the bar wants SCALARS. So this module
+  counts with one `Registry.select/2` (no pid is ever messaged) plus one
+  `Repo.aggregate/3`, and shares the *sources* with the tabs rather than
+  their payloads — the bar and the Sessions tab enumerate the same
+  `Grappa.SessionRegistry`, so they cannot disagree about which pids exist.
+
+  ## The DB/live pair sits where the domain has one — and only there
+
+  CLAUDE.md: DB state and live state are separate sources of truth, and an
+  admin listing must carry both. That rule is applied here per-resource,
+  not cosmetically across the whole payload:
+
+    * `visitors` carries `{total, live}` because the Visitors tab carries
+      the same duality (a DB row whose `Session.Server` is missing renders
+      `live_state: null` — the U-0 honesty signal). `total` is DB rows,
+      `live` is distinct visitor ids holding at least one pid. Neither is
+      computed from the other; they are ALLOWED to disagree, and the
+      disagreement is the diagnostic.
+
+    * `sessions` is live-only, deliberately. The Sessions tab is
+      registry-driven by construction — "one row = one live pid" — and its
+      own moduledoc routes the DB-intent signal to `/admin/visitors` and
+      `/admin/credentials` rather than carrying it. There is no DB twin to
+      report: the nearest candidate,
+      `Credentials.list_credentials_for_all_users/0`, is scoped
+      `user_id IS NOT NULL` (visitor sessions are spawned from
+      `Visitors.list_active/0` instead), so pairing it against a pid count
+      that spans BOTH subject kinds would produce a systematically
+      lopsided pair that means nothing. A fabricated pair is worse than an
+      honest single number.
+
+  ## Loadavg is sampled, and it is the HOST's
+
+  `:cpu_sup.avg1/0` (os_mon) rather than `/proc/loadavg`: production is a
+  FreeBSD jail, which has no `/proc`. cpu_sup shells out to a per-OS port
+  program, which is the reason to pay for the dependency. `:os_mon` is in
+  `extra_applications`; `config/config.exs` keeps `memsup`/`disksup` off,
+  since they raise alarms on thresholds nothing here acts on.
+
+  A jail shares the host kernel, so the number is the **host's** load, not
+  grappa's. Clients must label it accordingly or an operator will read it
+  as "grappa is busy".
+
+  An unavailable sampler yields `nil`, never `0.0` — "we cannot measure"
+  and "the box is idle" are different facts, and only one of them should
+  render as a calm bar.
+
+  ## Cadence
+
+  Counts change because something happened; loadavg does not — it is a
+  sampled quantity with no event to hang off. Rather than run two
+  mechanisms, `GrappaWeb.AdminChannel` ticks the whole payload on
+  `push_interval_ms/0` for as long as an admin console is open. The tick
+  lives in the channel process, not in a supervised singleton: it exists
+  only while someone is looking, and it dies with the socket.
+
+  `push_interval_ms/0` re-reads `:persistent_term` per tick, so a
+  hot-deployed interval change takes effect on the next one. A 1s sample
+  of a 1-minute average is noise; the default is deliberately coarse.
+  """
+
+  use Boundary,
+    top_level?: true,
+    deps: [Grappa.LiveIntrospection, Grappa.Version, Grappa.Visitors],
+    exports: []
+
+  alias Grappa.{LiveIntrospection, Version, Visitors}
+
+  @typedoc """
+  The admin-bar payload. `loadavg` is `nil` when the sampler is
+  unavailable — the honesty signal, distinct from a measured `0.0`.
+  """
+  @type t :: %{
+          sessions: non_neg_integer(),
+          visitors: %{total: non_neg_integer(), live: non_neg_integer()},
+          hostname: String.t(),
+          loadavg: float() | nil,
+          version: String.t()
+        }
+
+  @key {__MODULE__, :push_interval_ms}
+  @default_push_interval_ms 5_000
+
+  @doc """
+  Reads the push cadence from `Application.get_env/3` once and stores it in
+  `:persistent_term`. Called from `Grappa.Application.start/2` — the
+  CLAUDE.md-designated boot boundary for a non-process DI seam (mirrors
+  `Grappa.Admission.Config.boot/0`).
+  """
+  @spec boot() :: :ok
+  def boot do
+    interval =
+      :grappa
+      |> Application.get_env(:admin_overview, [])
+      |> Keyword.get(:push_interval_ms, @default_push_interval_ms)
+
+    :persistent_term.put(@key, validate_interval!(interval))
+    :ok
+  end
+
+  @doc """
+  Milliseconds between admin-bar pushes. Lock-free `:persistent_term` read.
+
+  Carries the compiled default so a node that hot-reloads this module
+  before `boot/0` has ever run still ticks at a sane cadence instead of
+  raising in a channel callback.
+  """
+  @spec push_interval_ms() :: pos_integer()
+  def push_interval_ms, do: :persistent_term.get(@key, @default_push_interval_ms)
+
+  @doc """
+  The current admin-bar payload. One registry scan + one `COUNT` + two
+  cheap machine reads; messages no session pid.
+  """
+  @spec snapshot() :: t()
+  def snapshot do
+    live = LiveIntrospection.count_live()
+
+    %{
+      sessions: live.sessions,
+      visitors: %{total: Visitors.count_all(), live: live.visitors},
+      hostname: hostname(),
+      loadavg: derive_loadavg(sample_avg1()),
+      version: Version.current()
+    }
+  end
+
+  @doc """
+  Pure fold of `:cpu_sup.avg1/0`'s reply into the wire value.
+
+  cpu_sup reports a fixed-point integer scaled by 256; anything else the
+  sampler can hand back (an `{:error, _}` tuple, `:undefined`, the
+  `:unavailable` marker this module substitutes when os_mon is absent) is
+  "unknown", which is `nil`. Split out from the sampling so the whole
+  matrix is unit-testable without an os_mon in the loop.
+  """
+  @spec derive_loadavg(term()) :: float() | nil
+  def derive_loadavg(avg1) when is_integer(avg1) and avg1 >= 0,
+    do: Float.round(avg1 / 256, 2)
+
+  def derive_loadavg(_), do: nil
+
+  if Mix.env() == :test do
+    @doc false
+    @spec put_test_push_interval_ms(pos_integer()) :: :ok
+    def put_test_push_interval_ms(ms) when is_integer(ms) and ms > 0,
+      do: :persistent_term.put(@key, ms)
+  end
+
+  # Narrow on purpose. `UndefinedFunctionError` is os_mon not being in the
+  # release at all; the `:exit` is `:cpu_sup` not being started (its
+  # supervisor disabled, or the port program missing for this OS). Both are
+  # "no sampler", which this reports as `nil` — a VISIBLE degradation on the
+  # wire, not a swallowed failure. Any other exception is a real bug and is
+  # left to crash.
+  defp sample_avg1 do
+    :cpu_sup.avg1()
+  rescue
+    UndefinedFunctionError -> :unavailable
+  catch
+    :exit, _ -> :unavailable
+  end
+
+  defp hostname do
+    {:ok, name} = :inet.gethostname()
+    to_string(name)
+  end
+
+  defp validate_interval!(ms) when is_integer(ms) and ms > 0, do: ms
+
+  defp validate_interval!(other) do
+    raise ArgumentError,
+          "config :grappa, :admin_overview, push_interval_ms must be a positive " <>
+            "integer, got: #{inspect(other)}"
+  end
+end

--- a/lib/grappa/application.ex
+++ b/lib/grappa/application.ex
@@ -6,6 +6,8 @@ defmodule Grappa.Application do
     deps: [
       Grappa.Admission,
       Grappa.AdminEvents,
+      # #1075 — start/2 calls AdminOverview.boot/0 (admin-bar cadence DI-seam).
+      Grappa.AdminOverview,
       Grappa.Bootstrap,
       Grappa.Cic.Bundle,
       Grappa.Health,
@@ -67,6 +69,12 @@ defmodule Grappa.Application do
     # lock-free on the push hot path instead of a runtime `Application.get_env/2`
     # read (banned by CLAUDE.md). Mirrors `Grappa.Admission.Config.boot/0`.
     :ok = Grappa.Push.BadgeSource.boot()
+
+    # #1075 — stash the admin-bar push cadence in `:persistent_term` so
+    # `GrappaWeb.AdminChannel` reads it lock-free on every tick instead of a
+    # runtime `Application.get_env/2` (banned by CLAUDE.md). Mirrors
+    # `Grappa.Admission.Config.boot/0`.
+    :ok = Grappa.AdminOverview.boot()
 
     # #364 J/cross-module-S2: stash the #267 per-message window_counts push
     # DI-seam impl in `:persistent_term` so `WindowCounts.PushSource.impl/0`

--- a/lib/grappa/live_introspection.ex
+++ b/lib/grappa/live_introspection.ex
@@ -107,6 +107,43 @@ defmodule Grappa.LiveIntrospection do
     |> Enum.frequencies()
   end
 
+  @doc """
+  Scalar live counts for the admin top bar (#1075): total registered
+  `Session.Server` pids, and how many DISTINCT visitors hold at least one
+  of them.
+
+  Deliberately does NOT reuse `list_sessions/0`. That verb messages every
+  pid (joined channels + peer address, 250ms budget each) to enrich its
+  rows; a bar refreshing two integers on a timer must not pay
+  `O(N × 250ms)` of session-mailbox traffic. One `Registry.select/2`, no
+  pid touched — but the SAME registry `list_sessions/0` enumerates, so the
+  bar and the Sessions tab can never disagree about which pids exist.
+
+  Visitors are counted distinct because a visitor is multi-network: two
+  credentials means two pids but one visitor, which is exactly how the
+  Visitors tab renders it (one row per visitor, carrying a per-network
+  live list).
+
+  Same match-spec discipline as `list_sessions/0` — the literal `:session`
+  key tag is pinned, so a future registration with a different key shape
+  is skipped rather than miscounted.
+  """
+  @spec count_live() :: %{sessions: non_neg_integer(), visitors: non_neg_integer()}
+  def count_live do
+    subjects =
+      Registry.select(Grappa.SessionRegistry, [
+        {{{:session, :"$1", :_}, :_, :_}, [], [:"$1"]}
+      ])
+
+    live_visitors =
+      subjects
+      |> Enum.filter(&match?({:visitor, _}, &1))
+      |> Enum.uniq()
+      |> length()
+
+    %{sessions: length(subjects), visitors: live_visitors}
+  end
+
   defp build_entry(subject, network_id, pid) do
     info = Process.info(pid, [:message_queue_len, :memory]) || []
     {channels, channels_degraded} = fetch_joined_channels(subject, network_id)

--- a/lib/grappa/visitors.ex
+++ b/lib/grappa/visitors.ex
@@ -599,6 +599,18 @@ defmodule Grappa.Visitors do
   end
 
   @doc """
+  How many visitor rows exist, regardless of expiry state — the DB half of
+  the admin bar's visitor pair (#1075).
+
+  Deliberately the same population `list_all/0` returns (the M-4 admin
+  view, expired-but-not-yet-reaped sliver included) so the bar's `total`
+  and the Visitors tab's row count are the same number by construction.
+  The live half comes from the registry, never from this count.
+  """
+  @spec count_all() :: non_neg_integer()
+  def count_all, do: Repo.aggregate(Visitor, :count, :id)
+
+  @doc """
   Every visitor row, regardless of expiry state, ordered by
   `inserted_at` ascending. Operator-facing — the M-4 admin console
   needs the not-yet-reaped expired sliver too, to answer "why is

--- a/lib/grappa_web.ex
+++ b/lib/grappa_web.ex
@@ -17,6 +17,7 @@ defmodule GrappaWeb do
         Grappa.Accounts.Revocations,
         Grappa.Admission,
         Grappa.AdminEvents,
+        Grappa.AdminOverview,
         Grappa.Auth.IdentifierClassifier,
         Grappa.ChannelDirectory,
         Grappa.Cic.Bundle,

--- a/lib/grappa_web/channels/admin_channel.ex
+++ b/lib/grappa_web/channels/admin_channel.ex
@@ -52,7 +52,7 @@ defmodule GrappaWeb.AdminChannel do
   """
   use GrappaWeb, :channel
 
-  alias Grappa.AdminEvents
+  alias Grappa.{AdminEvents, AdminOverview}
   alias Grappa.PubSub.Topic
 
   @impl Phoenix.Channel
@@ -76,6 +76,13 @@ defmodule GrappaWeb.AdminChannel do
   @impl Phoenix.Channel
   def handle_info(:after_join, socket) do
     push(socket, "snapshot", %{events: AdminEvents.snapshot()})
+    push_overview(socket)
+    {:noreply, socket}
+  end
+
+  # #1075 — the admin top bar's cadence. See `push_overview/1`.
+  def handle_info(:overview_tick, socket) do
+    push_overview(socket)
     {:noreply, socket}
   end
 
@@ -96,6 +103,25 @@ defmodule GrappaWeb.AdminChannel do
   # down the admin socket.
   @impl Phoenix.Channel
   def handle_in(_, _, socket), do: {:reply, :ok, socket}
+
+  # #1075 — push the admin-bar projection, then arm the next tick.
+  #
+  # The counts could ride `Topic.admin_events/0` (they change because
+  # something happened), but loadavg cannot: it is a sampled quantity with
+  # no event to hang off. Rather than run an event path AND a sampler, one
+  # tick carries all five stats.
+  #
+  # The timer lives in THIS process, not in a supervised singleton: the bar
+  # only exists while an operator has the console open, so the sampling
+  # should too — it starts on join and dies with the socket, with no
+  # cross-console fan-out to manage. The interval is re-read per tick, so a
+  # hot-deployed change lands on the next one.
+  @spec push_overview(Phoenix.Socket.t()) :: :ok
+  defp push_overview(socket) do
+    push(socket, "overview", AdminOverview.snapshot())
+    Process.send_after(self(), :overview_tick, AdminOverview.push_interval_ms())
+    :ok
+  end
 
   @spec authorize(Phoenix.Socket.t()) :: :ok | {:error, :forbidden}
   defp authorize(%{assigns: %{is_admin: true}}), do: :ok

--- a/lib/grappa_web/controllers/admin/overview_controller.ex
+++ b/lib/grappa_web/controllers/admin/overview_controller.ex
@@ -1,0 +1,42 @@
+defmodule GrappaWeb.Admin.OverviewController do
+  @moduledoc """
+  Admin read-path for the operator top bar (#1075). Behind the
+  `:admin_authn` pipeline; visitor + non-admin user subjects collapse to
+  403 upstream.
+
+  ## GET /admin/overview
+
+  Returns `200 OK` with the scalar projection `Grappa.AdminOverview.snapshot/0`
+  builds — the SAME payload `GrappaWeb.AdminChannel` pushes as `"overview"`
+  on join and on each tick (one feature, one code path, every door). This
+  door exists so a client can populate the bar without a socket, and so
+  `curl` remains an operator tool.
+
+      %{
+        "sessions" => 3,
+        "visitors" => %{"total" => 5, "live" => 2},
+        "hostname" => "m42",
+        "loadavg"  => 0.42,     # or null when the sampler is unavailable
+        "version"  => "0.13.0-abc1234"
+      }
+
+  ## No proxy change is required for this route
+
+  Admin routes in this app used to need a matching entry in an nginx
+  allowlist, and several sibling routes still carry comments saying so
+  (`/db_latency`, and #269's deliberate nesting under `/admin/sessions/`).
+  That constraint is gone: #485 collapsed every nginx substrate to a dumb
+  reverse proxy — `infra/snippets/locations-api.conf` forwards `location /`
+  to the BEAM unfiltered and states the allowlist "is GONE". The gate for
+  this route is `:admin_authn` alone, which is why it can sit at the top
+  level of the admin scope instead of being nested under an existing
+  prefix.
+  """
+  use GrappaWeb, :controller
+
+  alias Grappa.AdminOverview
+
+  @doc "Render the admin-bar projection (`GET /admin/overview`)."
+  @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def index(conn, _), do: json(conn, AdminOverview.snapshot())
+end

--- a/lib/grappa_web/router.ex
+++ b/lib/grappa_web/router.ex
@@ -115,6 +115,13 @@ defmodule GrappaWeb.Router do
     pipe_through [:api, :authn, :admin_authn]
 
     get "/me", MeController, :index
+    # #1075 — scalar projection for the operator top bar (#1073): session
+    # count, visitor total/live, hostname, loadavg, version. Top-level and
+    # NOT nested under an existing prefix: the nginx allowlist that made
+    # #269 nest under `/admin/sessions/` was deleted with the nginx
+    # container in #485 (`infra/snippets/locations-api.conf`), so a new
+    # admin path needs no proxy edit. `:admin_authn` is the whole gate.
+    get "/overview", OverviewController, :index
     get "/visitors", VisitorsController, :index
     delete "/visitors/:id", VisitorsController, :delete
     # #982 — recovery door for a locked-out visitor. Mints the SAME

--- a/mix.exs
+++ b/mix.exs
@@ -120,7 +120,13 @@ defmodule Grappa.MixProject do
   def application do
     [
       mod: {Grappa.Application, []},
-      extra_applications: [:logger, :runtime_tools, :ssl, :crypto, :inets]
+      # #1075 — `:os_mon` is here for ONE function: `:cpu_sup.avg1/0`, the
+      # loadavg on the admin top bar. Not `/proc/loadavg`: production is a
+      # FreeBSD jail, which has no `/proc`; cpu_sup shells out to a per-OS
+      # port program, which is the whole reason to pay for the dependency.
+      # `config/config.exs` keeps os_mon's memsup + disksup off — they are
+      # chatty about thresholds nothing here acts on.
+      extra_applications: [:logger, :os_mon, :runtime_tools, :ssl, :crypto, :inets]
     ]
   end
 

--- a/test/grappa/admin_overview_test.exs
+++ b/test/grappa/admin_overview_test.exs
@@ -1,0 +1,136 @@
+defmodule Grappa.AdminOverviewTest do
+  @moduledoc """
+  Tests for `Grappa.AdminOverview` (#1075) — the scalar projection behind
+  the admin top bar (#1073).
+
+  ## Why a projection and not a count of the tab lists
+
+  `LiveIntrospection.list_sessions/0` and `Visitors.list_all_with_live_state/0`
+  each issue a `GenServer.call` PER live pid with a 250ms degradation
+  budget. Counting their rows on a push cadence is `O(N × 250ms)` for two
+  integers. This module counts via one `Registry.select/2` + one
+  `Repo.aggregate/3` and never touches a session pid.
+
+  ## Isolation
+
+  `async: false` — reads the singleton `Grappa.SessionRegistry`
+  (`max_cases: 1` keeps the suite serial). `AdmissionStateHelpers.reset_all/0`
+  clears leftover `Session.Server`s so counts start from a known-empty
+  registry, same shape as `Grappa.LiveIntrospectionTest`.
+  """
+  use Grappa.DataCase, async: false
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.{AdminOverview, AdmissionStateHelpers}
+
+  setup do
+    AdmissionStateHelpers.reset_all()
+    :ok
+  end
+
+  # Register the calling process under the same registry-key shape
+  # `Grappa.Session.Server.registry_key/2` uses, so the count sees it
+  # exactly as it sees a real session. Mirror of the idiom in
+  # `Grappa.LiveIntrospectionTest`.
+  defp register_session(subject, network_id) do
+    {:ok, _} =
+      Registry.register(Grappa.SessionRegistry, {:session, subject, network_id}, nil)
+
+    :ok
+  end
+
+  describe "snapshot/0 — session count" do
+    test "reports zero against an empty registry" do
+      assert %{sessions: 0} = AdminOverview.snapshot()
+    end
+
+    test "counts one per registered pid, across subject kinds" do
+      :ok = register_session({:user, Ecto.UUID.generate()}, 1)
+      :ok = register_session({:visitor, Ecto.UUID.generate()}, 1)
+
+      assert %{sessions: 2} = AdminOverview.snapshot()
+    end
+  end
+
+  describe "snapshot/0 — visitor counts are a DB/live PAIR" do
+    test "total counts DB rows the registry knows nothing about" do
+      # The U-0 honesty signal in scalar form: DB intent exists, BEAM
+      # does not. `total` must NOT be derived from `live`, nor the
+      # reverse — they are two sources of truth and are allowed to
+      # disagree (CLAUDE.md "DB state and live state are separate").
+      _ = visitor_fixture()
+      _ = visitor_fixture()
+
+      assert %{visitors: %{total: 2, live: 0}} = AdminOverview.snapshot()
+    end
+
+    test "live counts DISTINCT visitors, not visitor sessions" do
+      visitor = visitor_fixture()
+      # One visitor, two networks — two pids, ONE visitor. Mirrors the
+      # Visitors tab, which renders one row per visitor carrying a
+      # per-network live list.
+      :ok = register_session({:visitor, visitor.id}, 1)
+      :ok = register_session({:visitor, visitor.id}, 2)
+
+      assert %{sessions: 2, visitors: %{total: 1, live: 1}} = AdminOverview.snapshot()
+    end
+
+    test "a user session never counts as a live visitor" do
+      _ = visitor_fixture()
+      :ok = register_session({:user, Ecto.UUID.generate()}, 1)
+
+      assert %{sessions: 1, visitors: %{total: 1, live: 0}} = AdminOverview.snapshot()
+    end
+  end
+
+  describe "snapshot/0 — machine facts" do
+    test "version is the same string CTCP VERSION answers with" do
+      assert %{version: version} = AdminOverview.snapshot()
+      assert version == Grappa.Version.current()
+    end
+
+    test "hostname is the node's own hostname, non-empty" do
+      {:ok, expected} = :inet.gethostname()
+
+      assert %{hostname: hostname} = AdminOverview.snapshot()
+      assert hostname == to_string(expected)
+      assert hostname != ""
+    end
+
+    test "loadavg is a non-negative float (os_mon's cpu_sup is loaded)" do
+      # Guards the `:os_mon` extra_application: without it `:cpu_sup.avg1/0`
+      # is undefined and this collapses to the nil branch.
+      assert %{loadavg: loadavg} = AdminOverview.snapshot()
+      assert is_float(loadavg), "expected a float loadavg, got: #{inspect(loadavg)}"
+      assert loadavg >= 0.0
+    end
+  end
+
+  describe "derive_loadavg/1 — the pure fold" do
+    test "scales cpu_sup's fixed-point integer by 256" do
+      assert AdminOverview.derive_loadavg(256) == 1.0
+      assert AdminOverview.derive_loadavg(0) == 0.0
+      assert AdminOverview.derive_loadavg(128) == 0.5
+    end
+
+    test "rounds to two decimals — the bar has no room for more" do
+      assert AdminOverview.derive_loadavg(100) == 0.39
+    end
+
+    test "an unavailable sampler is nil, never a fabricated zero" do
+      # A zero loadavg and an absent sampler are DIFFERENT facts. Coercing
+      # the error to 0.0 would render an idle box on a machine we cannot
+      # measure — the bar must show "unknown", not "calm".
+      assert AdminOverview.derive_loadavg({:error, :disabled}) == nil
+      assert AdminOverview.derive_loadavg(:undefined) == nil
+    end
+  end
+
+  describe "push_interval_ms/0" do
+    test "is a positive integer so the channel tick can never busy-loop" do
+      interval = AdminOverview.push_interval_ms()
+      assert is_integer(interval) and interval > 0
+    end
+  end
+end

--- a/test/grappa_web/channels/admin_channel_test.exs
+++ b/test/grappa_web/channels/admin_channel_test.exs
@@ -20,7 +20,7 @@ defmodule GrappaWeb.AdminChannelTest do
 
   import Grappa.AuthFixtures
 
-  alias Grappa.{AdminEvents, Repo, SessionLog}
+  alias Grappa.{AdminEvents, AdminOverview, Repo, SessionLog}
   alias Grappa.AdminEvents.Wire
   alias Grappa.PubSub.Topic
   alias GrappaWeb.UserSocket
@@ -128,6 +128,47 @@ defmodule GrappaWeb.AdminChannelTest do
       {:ok, _, _} = subscribe_and_join(socket, "grappa:admin:events", %{})
 
       assert_push "snapshot", %{events: []}
+    end
+  end
+
+  describe "overview push (#1075)" do
+    test "join pushes the overview snapshot the top bar renders" do
+      # Hostname and version are constants for the life of the socket;
+      # they ride the join push rather than the stream. The counts ride
+      # it too so the bar is populated before the first tick elapses
+      # (cold-WS-subscribe parity with the events snapshot above).
+      admin = user_fixture(is_admin: true)
+      socket = build_socket(admin.name, {:user, admin.id}, is_admin: true)
+
+      {:ok, _, _} = subscribe_and_join(socket, "grappa:admin:events", %{})
+
+      assert_push "overview", %{
+        sessions: sessions,
+        visitors: %{total: _, live: _},
+        hostname: hostname,
+        version: version
+      }
+
+      assert is_integer(sessions)
+      assert is_binary(hostname) and hostname != ""
+      assert version == Grappa.Version.current()
+    end
+
+    test "the tick re-pushes without the client asking" do
+      # Loadavg is a SAMPLED quantity — it has no event to hang off, so
+      # the channel ticks. Squeeze the interval to keep the test honest
+      # about cadence without sleeping the production default.
+      previous = AdminOverview.push_interval_ms()
+      :ok = AdminOverview.put_test_push_interval_ms(50)
+      on_exit(fn -> AdminOverview.put_test_push_interval_ms(previous) end)
+
+      admin = user_fixture(is_admin: true)
+      socket = build_socket(admin.name, {:user, admin.id}, is_admin: true)
+
+      {:ok, _, _} = subscribe_and_join(socket, "grappa:admin:events", %{})
+
+      assert_push "overview", _
+      assert_push "overview", _, 1_000
     end
   end
 

--- a/test/grappa_web/controllers/admin/overview_controller_test.exs
+++ b/test/grappa_web/controllers/admin/overview_controller_test.exs
@@ -1,0 +1,83 @@
+defmodule GrappaWeb.Admin.OverviewControllerTest do
+  @moduledoc """
+  `GET /admin/overview` (#1075) — the scalar projection behind the admin
+  top bar. Behind `:admin_authn`: visitor + non-admin user subjects
+  collapse to 403 upstream of the action.
+
+  `async: false` — the snapshot counts the singleton
+  `Grappa.SessionRegistry` (`max_cases: 1` keeps the suite serial).
+  """
+  use GrappaWeb.ConnCase, async: false
+
+  import Grappa.AuthFixtures
+
+  alias Grappa.{Accounts, AdmissionStateHelpers}
+
+  setup do
+    AdmissionStateHelpers.reset_all()
+    :ok
+  end
+
+  defp admin_session do
+    {user, session} = user_and_session()
+    {:ok, _} = Accounts.update_admin_flags(user, %{is_admin: true})
+    session
+  end
+
+  describe "GET /admin/overview — auth gate" do
+    test "no bearer returns 401", %{conn: conn} do
+      assert conn |> get("/admin/overview") |> json_response(401) ==
+               %{"error" => "unauthorized"}
+    end
+
+    test "visitor subject returns 403", %{conn: conn} do
+      {_, session} = visitor_and_session()
+
+      assert conn |> put_bearer(session.id) |> get("/admin/overview") |> json_response(403) ==
+               %{"error" => "forbidden"}
+    end
+
+    test "non-admin user returns 403", %{conn: conn} do
+      {_, session} = user_and_session()
+
+      assert conn |> put_bearer(session.id) |> get("/admin/overview") |> json_response(403) ==
+               %{"error" => "forbidden"}
+    end
+  end
+
+  describe "GET /admin/overview — the snapshot" do
+    test "200 carries all five stats the bar renders", %{conn: conn} do
+      session = admin_session()
+
+      body = conn |> put_bearer(session.id) |> get("/admin/overview") |> json_response(200)
+
+      assert %{
+               "sessions" => sessions,
+               "visitors" => %{"total" => total, "live" => live},
+               "hostname" => hostname,
+               "loadavg" => loadavg,
+               "version" => version
+             } = body
+
+      assert is_integer(sessions) and sessions >= 0
+      assert is_integer(total) and total >= 0
+      assert is_integer(live) and live >= 0
+      assert is_binary(hostname) and hostname != ""
+      assert is_float(loadavg)
+      assert version == Grappa.Version.current()
+    end
+
+    test "200 reflects a visitor row the registry has no pid for", %{conn: conn} do
+      # The DB/live pair on the wire: the bar shows `live/total`, so an
+      # operator reads "1 visitor exists, none is connected" without
+      # opening the tab. Derived-from-each-other counts could never say
+      # this.
+      session = admin_session()
+      _ = visitor_fixture()
+
+      body = conn |> put_bearer(session.id) |> get("/admin/overview") |> json_response(200)
+
+      assert %{"visitors" => %{"total" => 1, "live" => 0}} = body
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Server half of the admin top bar (#1075). Adds `Grappa.AdminOverview` — a
scalar projection carrying session count, visitor counts, hostname, loadavg
and version — behind `GET /admin/overview` and an `"overview"` push on the
admin channel. The cic half (#1073) consumes this and is not in this PR.

## The shape

```
GET /admin/overview        (identical payload pushed as "overview")
{ "sessions": 3,
  "visitors": {"total": 5, "live": 2},
  "hostname": "m42", "loadavg": 0.42, "version": "0.13.0-abc1234" }
```

**Why a new projection and not a count of the existing lists.** Two of the
five stats look already-solved, since `/admin/sessions` and `/admin/visitors`
both return lists. Counting their rows costs `O(N × 250ms)`:
`LiveIntrospection.list_sessions/0` issues a `GenServer.call` per live pid for
joined channels and again for the peer address, each with a 250ms degradation
budget, and `Visitors.list_all_with_live_state/0` does the same per credential.
That is real session-mailbox traffic, on a timer, for two integers.

The tabs want enriched **rows**; the bar wants **scalars**. So this reuses the
*sources* rather than the payloads: `LiveIntrospection.count_live/0` scans the
same `Grappa.SessionRegistry` the Sessions tab enumerates, with the same
`:session`-tag-pinned match spec, and messages no pid; `Visitors.count_all/0`
counts the same population `list_all/0` returns. The bar and the tabs cannot
disagree about what exists.

**Why `visitors` is a pair and `sessions` is not.** The first draft had
`sessions: {live, intended}` for symmetry with the house rule that an admin
listing carries both DB and live truth. It was withdrawn before implementation:
the only available `intended` is `Credentials.list_credentials_for_all_users/0`,
scoped `user_id IS NOT NULL`, while `live` counts pids across both subject
kinds — the pair would read `live > intended` permanently and mean nothing.

`visitors` carries `{total, live}` because the Visitors tab carries that
duality (`live_state: null` is its U-0 honesty signal), and the scalar form
says "1 visitor exists, none connected" without opening the tab. `sessions` is
a single live number because the Sessions tab is registry-driven by
construction ("one row = one live pid") and its own moduledoc routes the
DB-intent signal to `/admin/visitors` and `/admin/credentials`. A fabricated
pair is worse than an honest single number; the rule is "don't compute one
truth from the other", not "always print two columns".

**Cadence.** A tick in the channel process, not a supervised sampler. The
counts change because something happened and could ride
`Topic.admin_events/0`; loadavg cannot — it is sampled, with no event to hang
off. One tick carries all five instead of running two mechanisms. It lives in
the channel pid deliberately: the bar exists only while an operator has the
console open, so the sampling should too, and it dies with the socket. The
interval comes from the boot → `:persistent_term` seam and is re-read per tick.

**loadavg.** `:cpu_sup.avg1/0`, not `/proc/loadavg` — production is a FreeBSD
jail with no `/proc`. `:os_mon` is added to `extra_applications`; `memsup` and
`disksup` are turned off in `config/config.exs` because they raise watermark
alarms nothing here subscribes to. An unavailable sampler yields `nil`, never
`0.0`: "cannot measure" and "idle" are different facts and only one should
render as a calm bar.

## The issue's nginx section is out of date — no proxy change here

#1075 asks for an nginx allowlist entry and cites the sibling comments that
made #269 nest under `/admin/sessions/` and annotate `/db_latency`. That
constraint died with #485: `infra/snippets/locations-api.conf` states the
REST/admin allowlist "is GONE" and forwards `location /` to the BEAM
unfiltered, and two substrates have no nginx at all. `/admin/overview`
therefore sits at the top level of the admin scope, and `:admin_authn` is the
whole gate.

**The symptom outlived the cause, though — filed separately as #1097.** An
unregistered `/admin/*` path can answer `200 text/html` instead of a JSON 404:
it falls through to the BEAM's own SPA history-fallback. That surfaced in this
change's red, where the auth-gate assertions failed on "expected 403, got 200"
rather than on a missing route.

Narrower than it first looks, and the first telling of it here was too broad:
`SpaController.wants_html?/1` already 404s JSON for a client sending an explicit
non-HTML `Accept`. The gap is that cic sends no `Accept` at all and a browser
`fetch()` defaults to `*/*`, which that predicate treats as "wants HTML". Not
addressed in this PR — it is a router catch-all question, not an admin-bar one.

## Deploy class: COLD, for three independent reasons

`Grappa.Deploy.Preflight` trips on all three of the files this touches:

| predicate | file | why it is here |
| --- | --- | --- |
| `mix_deps?` (`preflight.ex:407`) | `mix.exs` | `:os_mon` in `extra_applications` |
| `application?` (`:410`) | `lib/grappa/application.ex` | the `AdminOverview.boot/0` call |
| `config?` (`:651`) | `config/config.exs` | the memsup/disksup switch-off |

Dropping any one of them would not make it hot. **This cannot be hot-deployed**,
and the `mix.exs` entry is not optional cosmetics: measured in the production
jail, `:os_mon` is absent from `_build/prod/rel/grappa/lib` in both prod and the
dryrun, so a release-run node answers `undef` on `cpu_sup:avg1`. It lives only
in the jail's system Erlang. `extra_applications` is what puts it in the
artifact.

## The jail has since been measured — by vjt, not by this branch

The "not verified in the jail" item below was real when the branch was written
and is the reason the probe happened. Probed with the jail's native Erlang,
os_mon started by hand (vjt, 2026-08-09):

- **Works, and the 256 divisor is confirmed at the right end.** `avg1=135` /
  `avg5=165` against `sysctl vm.loadavg` reporting `{0.45 0.62 0.69}` on the
  same box: `165/256 = 0.64` vs `0.62` lands on the nose, while
  `135/256 = 0.53` vs `0.45` drifts because the two reads are not simultaneous.
  The 5-minute agreement is what identifies the scale — the divisor is a
  measurement now, not an inherited constant.
- **`memsup` off is a necessity, not tidiness.** Started whole, os_mon raises
  `{set,{system_memory_high_watermark,[]}}` in that jail immediately.
- **The load is the host's, confirmed.** `sysctl vm.loadavg` reads identically
  inside the jail and on the host, so the label #1073 owes its reader is
  correctness, not courtesy.

Prod itself was NOT touched by this branch, and no worker goes near m42.

## Test plan

- [x] Red read before implementing: 19 failures / 31 tests (`rc=3`). The
      implementation was set aside as a patch to produce it, so the red is
      the real one and not a predicted one.
- [x] `scripts/check.sh` green on the committed tree — compile
      (`--warnings-as-errors`, Boundary), format, Credo strict, deps.audit,
      Sobelow, doctor, `5573 tests / 0 failures`, Dialyzer `Total errors: 0`,
      `mix docs`, wire-type drift gate, full bats set.
- [x] **The FreeBSD jail — measured by vjt, see above.** Not by this branch:
      no worker touches m42. `cpu_sup` answers there and the 256 divisor is
      confirmed against `sysctl vm.loadavg`.
- [ ] No integration or e2e run (the stack lane was held by another worker).

## Note for the client half (#1073)

A jail shares the host kernel, so `loadavg` is the **host's**, not grappa's.
The bar has to label it or an operator will read it as "grappa is busy".
