### PR TITLE
Address informational replies to the connection that asked (#1088)

### DIFF
--- a/cicchetto/e2e/tests/issue1088-addressed-informational-replies.spec.ts
+++ b/cicchetto/e2e/tests/issue1088-addressed-informational-replies.spec.ts
@@ -1,0 +1,82 @@
+// #1088 — an informational modal must open only on the client that asked.
+//
+// Reported by an operator running an IRC client in front of their own grappa:
+// every `/who` the client issued opened the WHO modal in cicchetto, on a
+// device that had asked for nothing. The cause was structural, not cosmetic —
+// every one of these replies (`who_reply`, `names_reply`, `whois_bundle`,
+// `whowas_bundle`, `server_reply`, `banlist_bundle`, `links_bundle`) was
+// broadcast on `grappa:user:{name}`, a topic that partitions by SUBJECT and
+// has no per-connection dimension. One question, a modal on every device.
+//
+// The fix addresses the reply to the connection that issued the command
+// (`Grappa.PubSub.Topic.socket/2`), so this spec needs TWO clients of the
+// SAME account — one asking, one watching. A single-page spec cannot see the
+// defect at all: the asking client was always served correctly.
+//
+// Anti-hollow-green: "the bystander shows no modal" is worthless if the
+// bystander is simply dead. So the bystander must PROVE it is live and
+// receiving on the very same account, by rendering a channel message that
+// arrives after the /who — and still show no modal.
+//
+// Barrier: the asking client's modal is the durable signal that the server
+// produced and delivered the reply. Both deliveries would ride the same
+// server-side fan-out, so once the asker has rendered it, a bystander that
+// was going to receive it has already been sent it.
+
+import { expect, test } from "../fixtures/test";
+import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// Unique per run so the spec survives `--repeat-each`: a fixed nick would
+// collide with the still-connected peer of the previous iteration.
+const uniqueNick = () => `i1088-${Math.random().toString(36).slice(2, 8)}`;
+
+test("#1088 — /who opens the modal only on the client that issued it", async ({ page, browser }) => {
+  const vjt = getSeededVjt();
+  const peerNick = uniqueNick();
+
+  // The bystander: a second device of the SAME account, in its own browser
+  // context so it holds a genuinely separate WebSocket (a second tab of one
+  // context would too, but a fresh context also keeps storage disjoint).
+  const bystanderCtx = await browser.newContext();
+  const bystander = await bystanderCtx.newPage();
+
+  const peer = await IrcPeer.connect({ nick: peerNick });
+
+  try {
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+    await loginAs(bystander, vjt);
+    await selectChannel(bystander, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+    await peer.join(CHANNEL);
+
+    // The asking client. Nobody typed anything on the bystander.
+    await composeSend(page, `/who ${CHANNEL}`);
+
+    const askerModal = page.getByTestId("who-modal");
+    await expect(askerModal).toBeVisible({ timeout: 5_000 });
+    await expect(askerModal.locator(".who-modal-row", { hasText: peerNick })).toBeVisible();
+
+    // The bystander is alive on this account and its stream is flowing: it
+    // renders a channel message sent AFTER the reply was delivered to the
+    // asker. Without this the assertion below would also pass on a bystander
+    // whose socket never came up.
+    const liveness = `i1088 bystander is live ${peerNick}`;
+    peer.privmsg(CHANNEL, liveness);
+    await expect(scrollbackLine(bystander, "privmsg", liveness)).toHaveCount(1, {
+      timeout: 10_000,
+    });
+
+    // The defect: pre-fix this modal was open here too, on a client that
+    // issued no command.
+    await expect(bystander.getByTestId("who-modal")).toHaveCount(0);
+  } finally {
+    await peer.disconnect("#1088 done");
+    await bystanderCtx.close();
+  }
+});

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -165,6 +165,21 @@ any casing and you land on the canonical window. Events push on the
 matching topic as `"event"` frames; treat unknown `kind` values as
 ignorable per §2.
 
+**Not every user-topic event reaches every connection (#1088).** The reply
+to an informational command you issued — `who_reply`, `names_reply`,
+`whois_bundle`, `whowas_bundle`, `server_reply`, `banlist_bundle`,
+`links_bundle` — is delivered on your user topic **only to the connection
+that issued the command**. Nothing changes for the client that asked: same
+topic, same `"event"` frame, same payload. What changed is that your other
+devices no longer receive it, so do not treat one of these as a cue to
+refresh shared state — it is an answer to a question this socket asked.
+
+Two consequences worth designing for: if your socket drops before the ircd
+answers, the reply is dropped with it (re-issue the command); and `lusers_bundle`
+is the one member of the family that still fans out to every connection,
+because the server also emits it unsolicited at connect — gate it on your own
+consume-once request flag.
+
 ---
 
 ## 5. Wire format

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -34723,3 +34723,71 @@ issue's "Done when" asks for it explicitly and it has not been done: `cpu_sup`
 was exercised only in the Linux dev container, and its FreeBSD port program
 is a different binary. Whether `avg1/0` answers inside a jail is an
 expectation here, not a measurement.
+## 2026-08-09 — #1088: an informational reply belongs to a connection, not a subject
+
+The report is an operator whose IRC client kept opening the WHO modal in
+cicchetto on a device that had asked for nothing. The measurement in the issue
+is right and it is structural: `who_reply`, `names_reply`, `whois_bundle`,
+`whowas_bundle`, `server_reply`, `banlist_bundle` and `links_bundle` all ride
+`Topic.user/1`, and the whole topic vocabulary partitions by user, network and
+channel — never by connection. There was no dimension in which "the client that
+asked" could be expressed, so the answer to one question was delivered to every
+device of the account.
+
+**Form A, delivery narrowed, and the wire did not change.** The issue offered
+addressed delivery (A) or a client-local consume-once latch per surface (B, the
+#248 LUSERS pattern generalised); the maintainer preferred killing the fan-out,
+which is A. What the issue anticipated — "carrying a client id on the wire is
+acceptable" — turned out to be unnecessary: the requesting connection is the
+socket that carried the command, so the server already knows it and nothing has
+to be added to the payload in either direction. `UserSocket.connect/3` mints a
+`socket_ref` per WebSocket, the user-topic channel subscribes to
+`Topic.socket/2` on join, and `Session.Broadcaster.to_requester/3` publishes
+there instead of on the user topic. cicchetto is unchanged, to the line: the
+addressed frame arrives on the same channel, with the same `"event"` name and
+the same payload, at the same `userTopic.ts` arm. That also settles the case
+the reporter is in — a requester that is not a cicchetto client at all gets no
+modal anywhere, which B could not have delivered.
+
+**The accumulator is where a request already meets its reply.** The ircd answers
+minutes of numerics later and carries no correlation tag, so the only structure
+that spans the gap is the per-verb `*_pending` accumulator that #127/#140/#169/
+#376 already built to tell a solicited reply from an unsolicited one. `reply_to`
+rides there, exactly like #606's `source`, and the drain lifts it into the
+effect tuple; every one of the seven effects grew the same trailing element, so
+`apply_effects` has one way to read it rather than two. `nil` — an accumulator
+primed before a hot deploy, or a reply nobody asked for — falls back to the
+per-user fan-out: losing a reply is worse than showing it too widely.
+
+**Two collapses are inherited, not introduced.** `whois_pending` keys per target
+nick, so two clients WHOIS-ing one nick inside a single 318 window share an
+accumulator and the last writer wins — the same collapse #606 accepted for
+`source`, for the same reason (the numerics carry no request identity, so a
+second accumulator could not be matched to a second reply anyway). And a reply
+whose requester disconnected before the ircd answered is now dropped rather than
+shown to the survivors. Both are stated where they happen.
+
+**LUSERS keeps the fan-out, and that is the boundary of the class.** It is the
+one member whose accumulator is created by the REPLY rather than the request:
+bahamut auto-emits the sequence on connect-welcome with nobody having asked, and
+251 resets the accumulator on arrival, so a `reply_to` primed by `/lusers` would
+either be wiped by its own reply or, if carried across the reset, address a
+later unsolicited emit to a stale socket. Nothing is lost by leaving it —
+#248's consume-once client latch already denies the card to a bystander. That
+latch answers "did anyone ask", the axis this issue explicitly does not touch;
+it happens to answer "did I ask" too.
+
+**`links_bundle` was in the class and not in the issue's table.** The issue calls
+its list exhaustive for the arms in `userTopic.ts`; `links_bundle` (#238) is a
+seventh unconditional modal setter with the identical shape and is addressed
+here too.
+
+**Not established.** The e2e (`issue1088-addressed-informational-replies.spec.ts`)
+drives the reported scenario with two browser contexts on one account and is
+built to be falsifiable — the asking client's modal is the barrier, and the
+bystander proves it is live by rendering a post-reply channel message before the
+absence is asserted. It had not been run at the time of writing, and neither had
+the full integration suite. The per-surface behaviour is asserted for `/who` and
+`/whois` at the channel door and for `/who` at the session level; the other
+eight verbs are believed on the strength of a shared mechanism, not measured one
+by one.

--- a/lib/grappa/pubsub/topic.ex
+++ b/lib/grappa/pubsub/topic.ex
@@ -40,6 +40,11 @@ defmodule Grappa.PubSub.Topic do
       direction (edge → session) and audience (per-session subscribers,
       not browser clients) — never exposed via `parse/1` or `valid?/1`
       so an external `Channel.join/3` cannot subscribe to it.
+    * `grappa:user:{user_name}/socket:{socket_ref}` — per-CONNECTION
+      addressed delivery (#1088). The ONLY shape whose audience is one
+      WebSocket rather than a whole subject: the carrier for a reply
+      that belongs to the client that asked for it. Like `ws_presence/1`
+      it is excluded from `parse/1` / `valid?/1` — see `socket/2`.
 
   Topic-shape evolution must go through this module: every broadcaster,
   every subscriber-side validator, and every router-side wildcard share
@@ -98,6 +103,39 @@ defmodule Grappa.PubSub.Topic do
       "/network:" <>
       network_slug <>
       "/channel:" <> Grappa.IRC.Identifier.canonical_target(channel_name)
+  end
+
+  @doc """
+  Builds the per-CONNECTION addressed-delivery topic (#1088).
+
+  Every other shape here partitions by SUBJECT: a user's `/who` reply
+  broadcast on `user/1` reaches every browser tab, phone and desktop
+  authenticated as that user, so a modal requested on one device opened
+  on all the others. This shape adds the missing dimension — the
+  `socket_ref` is minted once per WebSocket in `UserSocket.connect/3`
+  and the socket's user-topic channel subscribes to it on join, so a
+  broadcast here reaches exactly the connection that issued the request.
+
+  Still user-rooted (`grappa:user:{name}/socket:{ref}`) so the segment
+  ordering matches every sibling shape and a topic string carries its
+  own authz discriminator. Excluded from `parse/1` / `valid?/1` for the
+  same reason as `ws_presence/1`: those validate the public topic
+  grammar `GrappaWeb.GrappaChannel.join/3` accepts, and an addressed
+  topic must never be joinable — a client that could type its way onto
+  another connection's topic would read replies addressed to it. The
+  exclusion is structural, not a rule to remember: `parse/1`'s
+  second-segment clause matches `"network:" <> slug` only, so
+  `"socket:" <> ref` falls through to `:error`.
+
+  The reference is opaque and never leaves the server: the requesting
+  connection is known from the socket that carried the request, so
+  nothing about it rides the wire in either direction.
+  """
+  @spec socket(String.t(), String.t()) :: t()
+  def socket(user_name, socket_ref)
+      when is_binary(user_name) and user_name != "" and
+             is_binary(socket_ref) and socket_ref != "" do
+    "grappa:user:" <> user_name <> "/socket:" <> socket_ref
   end
 
   @doc """

--- a/lib/grappa/session.ex
+++ b/lib/grappa/session.ex
@@ -116,6 +116,26 @@ defmodule Grappa.Session do
   @type subject :: {:user, Ecto.UUID.t()} | {:visitor, Ecto.UUID.t()}
 
   @typedoc """
+  #1088 — the connection an informational reply is addressed to: the
+  `socket_ref` `GrappaWeb.UserSocket.connect/3` minted for the WebSocket
+  that issued the command, or `nil` when no live connection owns the
+  request.
+
+  Every `send_*` verb whose answer arrives asynchronously as a modal or
+  card (`/who`, `/names`, `/whois`, `/whowas`, `/banlist`, `/info`,
+  `/version`, `/motd`, `/admin`, `/links`) carries one: it rides the
+  session's `*_pending` accumulator, which is the only place that already
+  correlates a request with the reply the ircd sends back minutes of
+  numerics later. `nil` degrades to the per-user fan-out — see
+  `Grappa.Session.Broadcaster.to_requester/3` for both directions.
+
+  NOT a subject, NOT a credential, and NOT `Grappa.ClientId`: it
+  identifies one transport, which is precisely the dimension the
+  user-rooted topic vocabulary lacks.
+  """
+  @type reply_to :: String.t() | nil
+
+  @typedoc """
   REV-E (H11): the dead-socket / closed-mid-write error shape that any
   `Session.send_*` wrapper can return once the Session.Server's
   underlying `IRC.Client.send_*` call observes a dead socket. Mirrors
@@ -1614,11 +1634,12 @@ defmodule Grappa.Session do
   a typed `:server_reply` (source `:info`) wire event on `Topic.user/1` —
   cic renders a dismissable modal. Returns `:ok` or `{:error, :no_session}`.
   """
-  @spec send_info(subject(), integer()) ::
+  @spec send_info(subject(), integer(), reply_to()) ::
           :ok | {:error, :no_session | send_transport_error()}
-  def send_info(subject, network_id)
-      when is_subject(subject) and is_integer(network_id) do
-    call_session(subject, network_id, :send_info)
+  def send_info(subject, network_id, reply_to)
+      when is_subject(subject) and is_integer(network_id) and
+             (is_binary(reply_to) or is_nil(reply_to)) do
+    call_session(subject, network_id, {:send_info, reply_to})
   end
 
   @doc """
@@ -1627,11 +1648,12 @@ defmodule Grappa.Session do
   `:version`) wire event on `Topic.user/1`. Returns `:ok` or
   `{:error, :no_session}`.
   """
-  @spec send_version(subject(), integer()) ::
+  @spec send_version(subject(), integer(), reply_to()) ::
           :ok | {:error, :no_session | send_transport_error()}
-  def send_version(subject, network_id)
-      when is_subject(subject) and is_integer(network_id) do
-    call_session(subject, network_id, :send_version)
+  def send_version(subject, network_id, reply_to)
+      when is_subject(subject) and is_integer(network_id) and
+             (is_binary(reply_to) or is_nil(reply_to)) do
+    call_session(subject, network_id, {:send_version, reply_to})
   end
 
   @doc """
@@ -1646,12 +1668,13 @@ defmodule Grappa.Session do
   `Grappa.IRC.Client.send_motd/2` (mirror of `send_who/3`; the channel door
   validates first, but the context contract stays honest for every door).
   """
-  @spec send_motd(subject(), integer(), String.t() | nil) ::
+  @spec send_motd(subject(), integer(), String.t() | nil, reply_to()) ::
           :ok | {:error, :no_session | :invalid_line | send_transport_error()}
-  def send_motd(subject, network_id, target)
+  def send_motd(subject, network_id, target, reply_to)
       when is_subject(subject) and is_integer(network_id) and
-             (is_binary(target) or is_nil(target)) do
-    call_session(subject, network_id, {:send_motd, target})
+             (is_binary(target) or is_nil(target)) and
+             (is_binary(reply_to) or is_nil(reply_to)) do
+    call_session(subject, network_id, {:send_motd, target, reply_to})
   end
 
   @doc """
@@ -1667,12 +1690,13 @@ defmodule Grappa.Session do
   `{:error, :invalid_line}` if a non-nil target's syntax is rejected by
   `Grappa.IRC.Client.send_admin/2`.
   """
-  @spec send_admin(subject(), integer(), String.t() | nil) ::
+  @spec send_admin(subject(), integer(), String.t() | nil, reply_to()) ::
           :ok | {:error, :no_session | :invalid_line | send_transport_error()}
-  def send_admin(subject, network_id, target)
+  def send_admin(subject, network_id, target, reply_to)
       when is_subject(subject) and is_integer(network_id) and
-             (is_binary(target) or is_nil(target)) do
-    call_session(subject, network_id, {:send_admin, target})
+             (is_binary(target) or is_nil(target)) and
+             (is_binary(reply_to) or is_nil(reply_to)) do
+    call_session(subject, network_id, {:send_admin, target, reply_to})
   end
 
   @doc """
@@ -1694,13 +1718,14 @@ defmodule Grappa.Session do
   in-flight request's bundle. A stuck request (withheld 365 / 481 denial)
   self-heals: past the staleness window a fresh /links clobbers + re-sends.
   """
-  @spec send_links(subject(), integer(), String.t() | nil) ::
+  @spec send_links(subject(), integer(), String.t() | nil, reply_to()) ::
           :ok
           | {:error, :no_session | :invalid_line | :links_in_flight | send_transport_error()}
-  def send_links(subject, network_id, mask)
+  def send_links(subject, network_id, mask, reply_to)
       when is_subject(subject) and is_integer(network_id) and
-             (is_binary(mask) or is_nil(mask)) do
-    call_session(subject, network_id, {:send_links, mask})
+             (is_binary(mask) or is_nil(mask)) and
+             (is_binary(reply_to) or is_nil(reply_to)) do
+    call_session(subject, network_id, {:send_links, mask, reply_to})
   end
 
   @doc """
@@ -1761,11 +1786,12 @@ defmodule Grappa.Session do
   Returns `:ok`, `{:error, :no_session}`, or `{:error, :invalid_line}`
   if the channel syntax is rejected by `Grappa.IRC.Client.send_banlist/2`.
   """
-  @spec send_banlist(subject(), integer(), String.t()) ::
+  @spec send_banlist(subject(), integer(), String.t(), reply_to()) ::
           :ok | {:error, :no_session | :invalid_line | send_transport_error()}
-  def send_banlist(subject, network_id, channel)
-      when is_subject(subject) and is_integer(network_id) and is_binary(channel) do
-    call_session(subject, network_id, {:send_banlist, channel})
+  def send_banlist(subject, network_id, channel, reply_to)
+      when is_subject(subject) and is_integer(network_id) and is_binary(channel) and
+             (is_binary(reply_to) or is_nil(reply_to)) do
+    call_session(subject, network_id, {:send_banlist, channel, reply_to})
   end
 
   @doc """
@@ -1791,16 +1817,34 @@ defmodule Grappa.Session do
   The channel boundary normalizes an unknown/absent client token to
   `:user`, so the atom reaching here is always one of the two.
 
+  `origin` and `reply_to` (#1088) are orthogonal axes and both survive:
+  `origin` says WHICH STORE inside a client consumes the bundle,
+  `reply_to` says WHICH CLIENT receives it at all. #606's rule (a `:rail`
+  bundle never forges the `/whois` card; a `:user` bundle also refreshes
+  the rail when it is showing that nick) is a client-local rule and is
+  untouched — it now applies on the requesting client only, which is
+  where both stores live. The one behaviour that goes away is the
+  cross-device free refresh: a `/whois` typed on the phone no longer
+  refreshes the laptop's rail. That is the fan-out this issue removes,
+  not a #606 regression.
+
   Returns `:ok`, `{:error, :no_session}`, or `{:error, :invalid_line}`
   if the nick or server syntax is rejected by
   `Grappa.IRC.Client.send_whois/3`.
   """
-  @spec send_whois(subject(), integer(), String.t(), String.t() | nil, :user | :rail) ::
-          :ok | {:error, :no_session | :invalid_line | send_transport_error()}
-  def send_whois(subject, network_id, nick, server, origin)
+  @spec send_whois(
+          subject(),
+          integer(),
+          String.t(),
+          String.t() | nil,
+          :user | :rail,
+          reply_to()
+        ) :: :ok | {:error, :no_session | :invalid_line | send_transport_error()}
+  def send_whois(subject, network_id, nick, server, origin, reply_to)
       when is_subject(subject) and is_integer(network_id) and is_binary(nick) and
-             (is_binary(server) or is_nil(server)) and origin in [:user, :rail] do
-    call_session(subject, network_id, {:send_whois, nick, server, origin})
+             (is_binary(server) or is_nil(server)) and origin in [:user, :rail] and
+             (is_binary(reply_to) or is_nil(reply_to)) do
+    call_session(subject, network_id, {:send_whois, nick, server, origin, reply_to})
   end
 
   @doc """
@@ -1817,17 +1861,18 @@ defmodule Grappa.Session do
   Returns `:ok`, `{:error, :no_session}`, or `{:error, :invalid_line}`
   if the nick syntax is rejected by `Grappa.IRC.Client.send_whowas/2`.
   """
-  @spec send_whowas(subject(), integer(), String.t()) ::
+  @spec send_whowas(subject(), integer(), String.t(), reply_to()) ::
           :ok | {:error, :no_session | :invalid_line | send_transport_error()}
-  def send_whowas(subject, network_id, nick)
-      when is_subject(subject) and is_integer(network_id) and is_binary(nick) do
-    call_session(subject, network_id, {:send_whowas, nick})
+  def send_whowas(subject, network_id, nick, reply_to)
+      when is_subject(subject) and is_integer(network_id) and is_binary(nick) and
+             (is_binary(reply_to) or is_nil(reply_to)) do
+    call_session(subject, network_id, {:send_whowas, nick, reply_to})
   end
 
   @doc """
   Sends `WHO <target>` upstream and primes the per-target accumulator in
   `state.who_pending` so EventRouter folds 352 RPL_WHOREPLY rows into a
-  bundle, drained into ONE ephemeral `{:who_reply, target, users}` event
+  bundle, drained into ONE ephemeral `{:who_reply, target, users, reply_to}` event
   when 315 RPL_ENDOFWHO arrives. `<target>` is a channel OR a host/nick
   mask (#221, RFC 2812 §3.6.1).
 
@@ -1844,10 +1889,11 @@ defmodule Grappa.Session do
   Returns `:ok`, `{:error, :no_session}`, or `{:error, :invalid_line}`
   if the target syntax is rejected by `Grappa.IRC.Client.send_who/2`.
   """
-  @spec send_who(subject(), integer(), String.t()) ::
+  @spec send_who(subject(), integer(), String.t(), reply_to()) ::
           :ok | {:error, :no_session | :invalid_line | send_transport_error()}
-  def send_who(subject, network_id, target)
-      when is_subject(subject) and is_integer(network_id) and is_binary(target) do
+  def send_who(subject, network_id, target, reply_to)
+      when is_subject(subject) and is_integer(network_id) and is_binary(target) and
+             (is_binary(reply_to) or is_nil(reply_to)) do
     # #540 A2 / #537 — the target is NOT necessarily a channel: it may be a
     # mask (#221) or bahamut's extended-WHO flag args (`+s <server>`). Folding
     # it corrupts a case-sensitive arg — the `+`-sigil token `+A HelloWorld`
@@ -1855,7 +1901,7 @@ defmodule Grappa.Session do
     # the bouncer. The raw target ships upstream; the Server derives the
     # accumulator KEY network-aware (`fold_key/2`, for concurrent channel-WHO
     # separation) separately in its handler.
-    call_session(subject, network_id, {:send_who, target})
+    call_session(subject, network_id, {:send_who, target, reply_to})
   end
 
   @doc """
@@ -1877,11 +1923,12 @@ defmodule Grappa.Session do
   Returns `:ok`, `{:error, :no_session}`, or `{:error, :invalid_line}`
   if the channel syntax is rejected by `Grappa.IRC.Client.send_names/2`.
   """
-  @spec send_names(subject(), integer(), String.t()) ::
+  @spec send_names(subject(), integer(), String.t(), reply_to()) ::
           :ok | {:error, :no_session | :invalid_line | send_transport_error()}
-  def send_names(subject, network_id, channel)
-      when is_subject(subject) and is_integer(network_id) and is_binary(channel) do
-    call_session(subject, network_id, {:send_names, channel})
+  def send_names(subject, network_id, channel, reply_to)
+      when is_subject(subject) and is_integer(network_id) and is_binary(channel) and
+             (is_binary(reply_to) or is_nil(reply_to)) do
+    call_session(subject, network_id, {:send_names, channel, reply_to})
   end
 
   @doc """

--- a/lib/grappa/session/broadcaster.ex
+++ b/lib/grappa/session/broadcaster.ex
@@ -68,6 +68,36 @@ defmodule Grappa.Session.Broadcaster do
   end
 
   @doc """
+  Broadcasts `payload` to the ONE connection that asked for it (#1088),
+  falling back to the per-user fan-out when no requester is known.
+
+  `reply_to` is the `socket_ref` `UserSocket.connect/3` minted for the
+  WebSocket that issued the command, carried through the session's
+  `*_pending` accumulator and lifted back out by the drain. An informational
+  reply (`/who`, `/whois`, `/motd`, …) is the answer to a question one
+  client asked; on `to_user/2` it opened a modal on every other device of
+  the same subject.
+
+  `nil` — the safe default, mirroring #606's absent-`source` rule — routes
+  to `to_user/2`, i.e. exactly the pre-#1088 behaviour. Reached by a reply
+  with no requester at all (bahamut's connect-welcome auto-emit) and by an
+  accumulator primed before a hot deploy. Losing a reply is worse than
+  showing it too widely, so the degradation direction is deliberate.
+
+  A dead requester (the tab closed, reloaded, or lost its socket before
+  the ircd answered) leaves the topic with no subscriber and the reply is
+  dropped. That is the intended semantics, not a gap: the question died
+  with the connection that asked it, and a modal has no meaning on a page
+  that never issued the command.
+  """
+  @spec to_requester(ctx(), String.t() | nil, map()) :: :ok | {:error, term()}
+  def to_requester(ctx, nil, payload), do: to_user(ctx, payload)
+
+  def to_requester(ctx, reply_to, payload) when is_binary(reply_to) do
+    Grappa.PubSub.broadcast_event(Topic.socket(ctx.subject_label, reply_to), payload)
+  end
+
+  @doc """
   Broadcasts `payload` on the per-channel topic
   (`grappa:user:{subject_label}/network:{network_slug}/channel:{channel}`)
   — the carrier for post-join-handshake events (messages, topic, modes,

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -198,22 +198,29 @@ defmodule Grappa.Session.EventRouter do
           | {:channel_created, String.t(), DateTime.t()}
           | {:away_confirmed, :present | :away}
           | {:members_seeded, String.t(), %{(nick :: String.t()) => modes :: [String.t()]}}
-          | {:names_reply, channel :: String.t(), roster :: [{String.t(), [String.t()]}]}
-          | {:who_reply, target :: String.t(), users :: [map()]}
-          | {:server_reply, source :: :info | :version | :motd, lines :: [String.t()]}
+          | {:names_reply, channel :: String.t(), roster :: [{String.t(), [String.t()]}],
+             Grappa.Session.reply_to()}
+          | {:who_reply, target :: String.t(), users :: [map()], Grappa.Session.reply_to()}
+          | {:server_reply, source :: :info | :version | :motd, lines :: [String.t()],
+             Grappa.Session.reply_to()}
           | {:joined, String.t()}
           | {:join_failed, channel :: String.t(), reason :: String.t(), numeric :: pos_integer()}
           | {:parted, String.t()}
           | {:kicked, channel :: String.t(), by :: String.t(), reason :: String.t() | nil}
-          | {:whois_bundle, target :: String.t(), accum :: map()}
+          # #1088 — every effect whose reply is an ANSWER to a client command
+          # carries the requesting connection as its last element. The router
+          # lifts it out of the `*_pending` accumulator it just drained; `nil`
+          # means no connection owns this reply and `Session.Server` falls
+          # back to the per-user fan-out.
+          | {:whois_bundle, target :: String.t(), accum :: map(), Grappa.Session.reply_to()}
           | {:peer_away, peer :: String.t(), away_message :: String.t()}
           | {:invite_ack, channel :: String.t(), peer :: String.t()}
           | {:rejoin_invited, channel :: String.t()}
           | {:invited, channel :: String.t(), inviter :: String.t()}
           | {:lusers_bundle, accum :: map()}
-          | {:whowas_bundle, target :: String.t(), accum :: map()}
-          | {:banlist_bundle, channel :: String.t(), accum :: map()}
-          | {:links_bundle, accum :: map()}
+          | {:whowas_bundle, target :: String.t(), accum :: map(), Grappa.Session.reply_to()}
+          | {:banlist_bundle, channel :: String.t(), accum :: map(), Grappa.Session.reply_to()}
+          | {:links_bundle, accum :: map(), Grappa.Session.reply_to()}
           | {:umode_changed, modes :: [String.t()]}
           | {:supported_umodes_changed, modes :: [String.t()]}
           | {:session_identity_changed, :acquired | :lost}
@@ -1302,7 +1309,11 @@ defmodule Grappa.Session.EventRouter do
     case Map.fetch(pending, nick_key) do
       {:ok, accum} ->
         next_state = %{state | whois_pending: Map.delete(pending, nick_key)}
-        {:cont, next_state, [{:whois_bundle, Map.get(accum, :target_display, target), accum}]}
+        {:cont, next_state,
+         [
+           {:whois_bundle, Map.get(accum, :target_display, target), accum,
+            Map.get(accum, :reply_to)}
+         ]}
 
       :error ->
         {:cont, state, []}
@@ -1610,7 +1621,7 @@ defmodule Grappa.Session.EventRouter do
         # restore server wire order before emitting.
         users = Enum.reverse(Map.get(accum, :replies, []))
 
-        {:cont, next_state, [{:who_reply, target_display, users}]}
+        {:cont, next_state, [{:who_reply, target_display, users, Map.get(accum, :reply_to)}]}
 
       _ ->
         {:cont, state, []}
@@ -2002,7 +2013,11 @@ defmodule Grappa.Session.EventRouter do
       {:ok, accum} ->
         next_state = %{state | whowas_pending: Map.delete(pending, nick_key)}
 
-        {:cont, next_state, [{:whowas_bundle, Map.get(accum, :target_display, target), accum}]}
+        {:cont, next_state,
+         [
+           {:whowas_bundle, Map.get(accum, :target_display, target), accum,
+            Map.get(accum, :reply_to)}
+         ]}
 
       :error ->
         {:cont, state, []}
@@ -2027,7 +2042,15 @@ defmodule Grappa.Session.EventRouter do
         next_state = %{state | whowas_pending: Map.delete(pending, nick_key)}
         target_display = Map.get(accum, :target_display, target)
 
-        {:cont, next_state, [{:whowas_bundle, target_display, %{target_display: target_display, not_found: true}}]}
+        # The not-found bundle is built fresh rather than drained, so
+        # `reply_to` is lifted off the accumulator explicitly — a 406 is as
+        # much an answer to the operator's /whowas as a 369 is, and must
+        # reach the same one connection.
+        {:cont, next_state,
+         [
+           {:whowas_bundle, target_display, %{target_display: target_display, not_found: true},
+            Map.get(accum, :reply_to)}
+         ]}
 
       :error ->
         {:cont, state, []}
@@ -2076,7 +2099,11 @@ defmodule Grappa.Session.EventRouter do
     case Map.fetch(pending, chan_key) do
       {:ok, accum} ->
         next_state = %{state | banlist_pending: Map.delete(pending, chan_key)}
-        {:cont, next_state, [{:banlist_bundle, Map.get(accum, :channel_display, channel), accum}]}
+        {:cont, next_state,
+         [
+           {:banlist_bundle, Map.get(accum, :channel_display, channel), accum,
+            Map.get(accum, :reply_to)}
+         ]}
 
       :error ->
         {:cont, state, []}
@@ -2129,7 +2156,8 @@ defmodule Grappa.Session.EventRouter do
         {:cont, state, []}
 
       accum when is_map(accum) ->
-        {:cont, %{state | links_pending: nil}, [{:links_bundle, accum}]}
+        {:cont, %{state | links_pending: nil},
+         [{:links_bundle, accum, Map.get(accum, :reply_to)}]}
     end
   end
 
@@ -2170,11 +2198,14 @@ defmodule Grappa.Session.EventRouter do
             {:cont, %{state | motd_pending: server_reply_fold(accum, msg)}, []}
 
           motd_numeric == 376 ->
-            {:cont, %{state | motd_pending: nil}, [{:server_reply, :motd, server_reply_drain(accum)}]}
+            {:cont, %{state | motd_pending: nil},
+             [{:server_reply, :motd, server_reply_drain(accum), Map.get(accum, :reply_to)}]}
 
           motd_numeric == 422 ->
             drained = server_reply_drain(server_reply_fold(accum, msg))
-            {:cont, %{state | motd_pending: nil}, [{:server_reply, :motd, drained}]}
+
+            {:cont, %{state | motd_pending: nil},
+             [{:server_reply, :motd, drained, Map.get(accum, :reply_to)}]}
         end
     end
   end
@@ -2225,7 +2256,8 @@ defmodule Grappa.Session.EventRouter do
         if admin_numeric in [256, 257, 258] do
           {:cont, %{state | admin_pending: folded}, []}
         else
-          {:cont, %{state | admin_pending: nil}, [{:server_reply, :admin, server_reply_drain(folded)}]}
+          {:cont, %{state | admin_pending: nil},
+           [{:server_reply, :admin, server_reply_drain(folded), Map.get(folded, :reply_to)}]}
         end
     end
   end
@@ -2255,9 +2287,15 @@ defmodule Grappa.Session.EventRouter do
         persist_server_notice(state, msg)
 
       [{key, source} | _] = armed ->
-        drained = server_reply_drain(server_reply_fold(Map.get(state, key), msg))
+        accum = Map.get(state, key)
+        drained = server_reply_drain(server_reply_fold(accum, msg))
         disarmed = Enum.reduce(armed, state, fn {k, _}, acc -> Map.put(acc, k, nil) end)
-        {:cont, disarmed, [{:server_reply, source, drained}]}
+        # #1088 — the surfaced error is addressed to whoever asked for the
+        # verb that WON the ownership order, which is the same request whose
+        # `source` is surfaced. When both are armed the loser is disarmed
+        # without a modal, exactly as before: over-clearing already cost a
+        # modal, and it now costs it on one connection instead of all of them.
+        {:cont, disarmed, [{:server_reply, source, drained, Map.get(accum, :reply_to)}]}
     end
   end
 
@@ -2279,7 +2317,8 @@ defmodule Grappa.Session.EventRouter do
         persist_server_notice(state, msg)
 
       accum ->
-        {:cont, %{state | info_pending: nil}, [{:server_reply, :info, server_reply_drain(accum)}]}
+        {:cont, %{state | info_pending: nil},
+         [{:server_reply, :info, server_reply_drain(accum), Map.get(accum, :reply_to)}]}
     end
   end
 
@@ -2292,9 +2331,11 @@ defmodule Grappa.Session.EventRouter do
       nil ->
         persist_server_notice(state, msg)
 
-      _ ->
+      accum ->
         line = rest |> Enum.filter(&is_binary/1) |> Enum.join(" ")
-        {:cont, %{state | version_pending: nil}, [{:server_reply, :version, [line]}]}
+
+        {:cont, %{state | version_pending: nil},
+         [{:server_reply, :version, [line], Map.get(accum, :reply_to)}]}
     end
   end
 
@@ -4034,7 +4075,7 @@ defmodule Grappa.Session.EventRouter do
   # Returns `{state_with_entry_removed, effects}`. Effects shape:
   #   - no entry: `[]` (route's members_seeded effect still fires — a
   #     bare JOIN seeds members but never opens a names modal).
-  #   - entry exists: `[{:names_reply, channel, roster}]`. `roster` is
+  #   - entry exists: `[{:names_reply, channel, roster, reply_to}]`. `roster` is
   #     the arrival-order `[{nick, modes}]` list — each accumulated
   #     `[prefix]nick` token split via `split_mode_prefix/1`. The
   #     mIRC-tier sort + wire projection happen in
@@ -4055,7 +4096,7 @@ defmodule Grappa.Session.EventRouter do
         next_state = %{state | names_pending: Map.delete(pending, chan_key)}
         target_display = Map.get(accum, :target_display, channel)
         roster = accum |> Map.get(:names, []) |> Enum.map(&split_mode_prefix/1)
-        {next_state, [{:names_reply, target_display, roster}]}
+        {next_state, [{:names_reply, target_display, roster, Map.get(accum, :reply_to)}]}
     end
   end
 

--- a/lib/grappa/session/event_router.ex
+++ b/lib/grappa/session/event_router.ex
@@ -198,11 +198,9 @@ defmodule Grappa.Session.EventRouter do
           | {:channel_created, String.t(), DateTime.t()}
           | {:away_confirmed, :present | :away}
           | {:members_seeded, String.t(), %{(nick :: String.t()) => modes :: [String.t()]}}
-          | {:names_reply, channel :: String.t(), roster :: [{String.t(), [String.t()]}],
-             Grappa.Session.reply_to()}
+          | {:names_reply, channel :: String.t(), roster :: [{String.t(), [String.t()]}], Grappa.Session.reply_to()}
           | {:who_reply, target :: String.t(), users :: [map()], Grappa.Session.reply_to()}
-          | {:server_reply, source :: :info | :version | :motd, lines :: [String.t()],
-             Grappa.Session.reply_to()}
+          | {:server_reply, source :: :info | :version | :motd, lines :: [String.t()], Grappa.Session.reply_to()}
           | {:joined, String.t()}
           | {:join_failed, channel :: String.t(), reason :: String.t(), numeric :: pos_integer()}
           | {:parted, String.t()}
@@ -1309,10 +1307,10 @@ defmodule Grappa.Session.EventRouter do
     case Map.fetch(pending, nick_key) do
       {:ok, accum} ->
         next_state = %{state | whois_pending: Map.delete(pending, nick_key)}
+
         {:cont, next_state,
          [
-           {:whois_bundle, Map.get(accum, :target_display, target), accum,
-            Map.get(accum, :reply_to)}
+           {:whois_bundle, Map.get(accum, :target_display, target), accum, Map.get(accum, :reply_to)}
          ]}
 
       :error ->
@@ -2015,8 +2013,7 @@ defmodule Grappa.Session.EventRouter do
 
         {:cont, next_state,
          [
-           {:whowas_bundle, Map.get(accum, :target_display, target), accum,
-            Map.get(accum, :reply_to)}
+           {:whowas_bundle, Map.get(accum, :target_display, target), accum, Map.get(accum, :reply_to)}
          ]}
 
       :error ->
@@ -2099,10 +2096,10 @@ defmodule Grappa.Session.EventRouter do
     case Map.fetch(pending, chan_key) do
       {:ok, accum} ->
         next_state = %{state | banlist_pending: Map.delete(pending, chan_key)}
+
         {:cont, next_state,
          [
-           {:banlist_bundle, Map.get(accum, :channel_display, channel), accum,
-            Map.get(accum, :reply_to)}
+           {:banlist_bundle, Map.get(accum, :channel_display, channel), accum, Map.get(accum, :reply_to)}
          ]}
 
       :error ->
@@ -2156,8 +2153,7 @@ defmodule Grappa.Session.EventRouter do
         {:cont, state, []}
 
       accum when is_map(accum) ->
-        {:cont, %{state | links_pending: nil},
-         [{:links_bundle, accum, Map.get(accum, :reply_to)}]}
+        {:cont, %{state | links_pending: nil}, [{:links_bundle, accum, Map.get(accum, :reply_to)}]}
     end
   end
 
@@ -2204,8 +2200,7 @@ defmodule Grappa.Session.EventRouter do
           motd_numeric == 422 ->
             drained = server_reply_drain(server_reply_fold(accum, msg))
 
-            {:cont, %{state | motd_pending: nil},
-             [{:server_reply, :motd, drained, Map.get(accum, :reply_to)}]}
+            {:cont, %{state | motd_pending: nil}, [{:server_reply, :motd, drained, Map.get(accum, :reply_to)}]}
         end
     end
   end
@@ -2334,8 +2329,7 @@ defmodule Grappa.Session.EventRouter do
       accum ->
         line = rest |> Enum.filter(&is_binary/1) |> Enum.join(" ")
 
-        {:cont, %{state | version_pending: nil},
-         [{:server_reply, :version, [line], Map.get(accum, :reply_to)}]}
+        {:cont, %{state | version_pending: nil}, [{:server_reply, :version, [line], Map.get(accum, :reply_to)}]}
     end
   end
 

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -1911,13 +1911,11 @@ defmodule Grappa.Session.Server do
   # the request to the reply burst that answers it. The drain lifts it back
   # out into the effect; `apply_effects` addresses the bundle with it.
   def handle_call({:send_info, reply_to}, _, state) do
-    {:reply, Client.send_info(state.client),
-     %{state | info_pending: %{lines: [], reply_to: reply_to}}}
+    {:reply, Client.send_info(state.client), %{state | info_pending: %{lines: [], reply_to: reply_to}}}
   end
 
   def handle_call({:send_version, reply_to}, _, state) do
-    {:reply, Client.send_version(state.client),
-     %{state | version_pending: %{lines: [], reply_to: reply_to}}}
+    {:reply, Client.send_version(state.client), %{state | version_pending: %{lines: [], reply_to: reply_to}}}
   end
 
   # #374 — /motd [<target>]. The optional target routes the query through a
@@ -1925,8 +1923,7 @@ defmodule Grappa.Session.Server do
   # /motd. Priming motd_pending is target-independent — the reply burst (or
   # 402 terminator) drains the modal either way.
   def handle_call({:send_motd, target, reply_to}, _, state) do
-    {:reply, Client.send_motd(state.client, target),
-     %{state | motd_pending: %{lines: [], reply_to: reply_to}}}
+    {:reply, Client.send_motd(state.client, target), %{state | motd_pending: %{lines: [], reply_to: reply_to}}}
   end
 
   # #992 — /admin [<target>]. Same optional-target shape as /motd (bahamut
@@ -1934,8 +1931,7 @@ defmodule Grappa.Session.Server do
   # target-independent priming: whichever of the four terminators comes back
   # — 259, 423, 402 or 447 — drains the modal and clears the flag.
   def handle_call({:send_admin, target, reply_to}, _, state) do
-    {:reply, Client.send_admin(state.client, target),
-     %{state | admin_pending: %{lines: [], reply_to: reply_to}}}
+    {:reply, Client.send_admin(state.client, target), %{state | admin_pending: %{lines: [], reply_to: reply_to}}}
   end
 
   # #238/#513 — /links [<mask>]. Prime the accumulator BEFORE the send so the

--- a/lib/grappa/session/server.ex
+++ b/lib/grappa/session/server.ex
@@ -775,6 +775,18 @@ defmodule Grappa.Session.Server do
           # ever connected, process uptime when we died pre-connect.
           started_at: DateTime.t(),
           connected_at: DateTime.t() | nil,
+          # #1088 — EVERY accumulator below that is primed by a `:send_*`
+          # request also carries a `:reply_to` key: the `socket_ref` of the
+          # WebSocket that asked, or `nil`. It is routing metadata, not
+          # payload — the drain lifts it into the effect's last element and
+          # `apply_effects` addresses the bundle with it, while the wire
+          # builders extract their fields explicitly so it never reaches the
+          # client (same invisibility as `:__primed_at_ms`). The effect-shape
+          # comments below name the pre-#1088 arity; the current union is
+          # `t:Grappa.Session.EventRouter.effect/0`, which is the SSOT.
+          # `lusers_pending` is the one exception — see the `:lusers_bundle`
+          # arm of `apply_effects/2` for why it keeps the fan-out.
+          #
           # C2 — per-target WHOIS accumulator. Keyed by lowercased target
           # nick. Entry shape (all fields optional except target_display):
           # `%{target_display, user, host, realname, server, server_info,
@@ -1894,28 +1906,36 @@ defmodule Grappa.Session.Server do
   # what separates an on-demand /motd from the connect-time auto-MOTD). Priming
   # before the send is safe: replies can only arrive after the send returns
   # (same mailbox-serialized ordering :send_who relies on).
-  def handle_call(:send_info, _, state) do
-    {:reply, Client.send_info(state.client), %{state | info_pending: %{lines: []}}}
+  # #1088 — `reply_to` is stashed in the accumulator alongside the lines,
+  # because the accumulator is the only structure that already survives from
+  # the request to the reply burst that answers it. The drain lifts it back
+  # out into the effect; `apply_effects` addresses the bundle with it.
+  def handle_call({:send_info, reply_to}, _, state) do
+    {:reply, Client.send_info(state.client),
+     %{state | info_pending: %{lines: [], reply_to: reply_to}}}
   end
 
-  def handle_call(:send_version, _, state) do
-    {:reply, Client.send_version(state.client), %{state | version_pending: %{lines: []}}}
+  def handle_call({:send_version, reply_to}, _, state) do
+    {:reply, Client.send_version(state.client),
+     %{state | version_pending: %{lines: [], reply_to: reply_to}}}
   end
 
   # #374 — /motd [<target>]. The optional target routes the query through a
   # named server (or 402 ERR_NOSUCHSERVER when unknown); nil keeps the bare
   # /motd. Priming motd_pending is target-independent — the reply burst (or
   # 402 terminator) drains the modal either way.
-  def handle_call({:send_motd, target}, _, state) do
-    {:reply, Client.send_motd(state.client, target), %{state | motd_pending: %{lines: []}}}
+  def handle_call({:send_motd, target, reply_to}, _, state) do
+    {:reply, Client.send_motd(state.client, target),
+     %{state | motd_pending: %{lines: [], reply_to: reply_to}}}
   end
 
   # #992 — /admin [<target>]. Same optional-target shape as /motd (bahamut
   # routes both through the same `hunt_server`), and the same
   # target-independent priming: whichever of the four terminators comes back
   # — 259, 423, 402 or 447 — drains the modal and clears the flag.
-  def handle_call({:send_admin, target}, _, state) do
-    {:reply, Client.send_admin(state.client, target), %{state | admin_pending: %{lines: []}}}
+  def handle_call({:send_admin, target, reply_to}, _, state) do
+    {:reply, Client.send_admin(state.client, target),
+     %{state | admin_pending: %{lines: [], reply_to: reply_to}}}
   end
 
   # #238/#513 — /links [<mask>]. Prime the accumulator BEFORE the send so the
@@ -1934,7 +1954,7 @@ defmodule Grappa.Session.Server do
   # brick /links — past @links_stale_ms a fresh request clobbers + re-sends.
   # `is_integer(ts)` guard first: `now - nil` would raise, and `n < nil` is
   # `true` under Erlang term order — never compare against a possibly-nil ts.
-  def handle_call({:send_links, mask}, _, state) do
+  def handle_call({:send_links, mask, reply_to}, _, state) do
     now = System.monotonic_time(:millisecond)
 
     case state.links_pending do
@@ -1943,7 +1963,10 @@ defmodule Grappa.Session.Server do
 
       _ ->
         {:reply, Client.send_links(state.client, mask),
-         %{state | links_pending: %{entries: [], mask: mask, requested_at: now}}}
+         %{
+           state
+           | links_pending: %{entries: [], mask: mask, requested_at: now, reply_to: reply_to}
+         }}
     end
   end
 
@@ -2041,11 +2064,15 @@ defmodule Grappa.Session.Server do
   # MODE line ships the RAW `channel` upstream (wire stays as-typed). On
   # send_line failure the accumulator stays primed — harmless until the
   # next /banlist replaces the entry.
-  def handle_call({:send_banlist, channel}, _, state) when is_binary(channel) do
+  def handle_call({:send_banlist, channel, reply_to}, _, state) when is_binary(channel) do
     chan_key = fold_key(state, channel)
 
     next_pending =
-      prime_pending(state.banlist_pending, chan_key, %{channel_display: chan_key, entries: []})
+      prime_pending(state.banlist_pending, chan_key, %{
+        channel_display: chan_key,
+        entries: [],
+        reply_to: reply_to
+      })
 
     next_state = %{state | banlist_pending: next_pending}
     {:reply, Client.send_banlist(state.client, channel), next_state}
@@ -2072,13 +2099,24 @@ defmodule Grappa.Session.Server do
   # fixed by splitting the key (the ircd numerics carry no request identity):
   # the cic consumer rule (rail takes its own + the shown nick's user bundle)
   # turns that collapse into a harmless cache hit, not a race.
-  def handle_call({:send_whois, target, server, origin}, _, state)
+  # #1088 — `reply_to` shares that per-target key and therefore that collapse:
+  # if two CLIENTS whois the same nick inside one 318 window, the bundle goes
+  # to whoever asked last and the first sees nothing. Not fixed by splitting
+  # the key, for the same reason #606 declined to: the ircd numerics carry no
+  # request identity, so the second bundle could not be told from the first
+  # even with two accumulators. Losing a duplicate answer to a duplicate
+  # question beats the fan-out this issue is removing.
+  def handle_call({:send_whois, target, server, origin, reply_to}, _, state)
       when is_binary(target) and (is_binary(server) or is_nil(server)) and
              origin in [:user, :rail] do
     nick_key = fold_key(state, target)
 
     next_pending =
-      prime_pending(state.whois_pending, nick_key, %{target_display: target, source: origin})
+      prime_pending(state.whois_pending, nick_key, %{
+        target_display: target,
+        source: origin,
+        reply_to: reply_to
+      })
 
     next_state = %{state | whois_pending: next_pending}
     {:reply, Client.send_whois(state.client, target, server), next_state}
@@ -2093,11 +2131,15 @@ defmodule Grappa.Session.Server do
   # same target (running /whowas twice without a 369 in between drops
   # the first). On send_line failure the accumulator stays primed —
   # harmless until the next /whowas replaces the entry.
-  def handle_call({:send_whowas, target}, _, state) when is_binary(target) do
+  def handle_call({:send_whowas, target, reply_to}, _, state) when is_binary(target) do
     nick_key = fold_key(state, target)
 
     next_pending =
-      prime_pending(state.whowas_pending, nick_key, %{target_display: target, entries: []})
+      prime_pending(state.whowas_pending, nick_key, %{
+        target_display: target,
+        entries: [],
+        reply_to: reply_to
+      })
 
     next_state = %{state | whowas_pending: next_pending}
     {:reply, Client.send_whowas(state.client, target), next_state}
@@ -2118,9 +2160,16 @@ defmodule Grappa.Session.Server do
   # On send_line failure the accumulator stays primed — a transient send
   # error doesn't strand the WHO flow because no numerics will arrive to
   # drain it; the @pending_ttl_ms sweep on the next prime reaps it.
-  def handle_call({:send_who, target}, _, state) when is_binary(target) do
+  def handle_call({:send_who, target, reply_to}, _, state) when is_binary(target) do
     chan_key = fold_key(state, target)
-    next_pending = prime_pending(state.who_pending, chan_key, %{target_display: target, replies: []})
+
+    next_pending =
+      prime_pending(state.who_pending, chan_key, %{
+        target_display: target,
+        replies: [],
+        reply_to: reply_to
+      })
+
     next_state = %{state | who_pending: next_pending}
     {:reply, Client.send_who(state.client, target), next_state}
   end
@@ -2140,11 +2189,15 @@ defmodule Grappa.Session.Server do
   # ephemeral names_reply (Topic.user); the operator's focused window is
   # irrelevant, so no origin_window is threaded (modal renders
   # network-scoped, last-write-wins).
-  def handle_call({:send_names, target}, _, state) when is_binary(target) do
+  def handle_call({:send_names, target, reply_to}, _, state) when is_binary(target) do
     chan_key = fold_key(state, target)
 
     next_pending =
-      prime_pending(state.names_pending, chan_key, %{target_display: chan_key, names: []})
+      prime_pending(state.names_pending, chan_key, %{
+        target_display: chan_key,
+        names: [],
+        reply_to: reply_to
+      })
 
     next_state = %{state | names_pending: next_pending}
     {:reply, Client.send_names(state.client, target), next_state}
@@ -5091,13 +5144,18 @@ defmodule Grappa.Session.Server do
   # modal. Same mIRC-tier sort + per-member projection as :members_seeded
   # (the authoritative sidebar set) — this is a parallel VIEW, not a
   # second source of truth.
-  defp apply_effects([{:names_reply, channel, roster} | rest], state) do
+  defp apply_effects([{:names_reply, channel, roster, reply_to} | rest], state) do
     members =
       roster
       |> Enum.map(fn {nick, modes} -> %{nick: nick, modes: modes} end)
       |> Enum.sort_by(&{member_sort_tier(&1.modes), &1.nick})
 
-    :ok = Broadcaster.to_user(state, SessionWire.names_reply(state.network_slug, channel, members))
+    :ok =
+      Broadcaster.to_requester(
+        state,
+        reply_to,
+        SessionWire.names_reply(state.network_slug, channel, members)
+      )
 
     apply_effects(rest, state)
   end
@@ -5111,8 +5169,13 @@ defmodule Grappa.Session.Server do
   # so the sigil-tier sort the names arm applies does not fit — the flat
   # per-user table is shown in arrival order. Projection to the JSON-safe
   # wire shape lives in `SessionWire.who_reply/3`.
-  defp apply_effects([{:who_reply, target, users} | rest], state) do
-    :ok = Broadcaster.to_user(state, SessionWire.who_reply(state.network_slug, target, users))
+  defp apply_effects([{:who_reply, target, users, reply_to} | rest], state) do
+    :ok =
+      Broadcaster.to_requester(
+        state,
+        reply_to,
+        SessionWire.who_reply(state.network_slug, target, users)
+      )
 
     apply_effects(rest, state)
   end
@@ -5122,8 +5185,13 @@ defmodule Grappa.Session.Server do
   # ephemeral, NOT persisted (mirrors :who_reply). cic's serverReplyModal
   # keys by network and renders a dismissable retro modal; it maps `source`
   # to a human title (the server emits no display strings).
-  defp apply_effects([{:server_reply, source, lines} | rest], state) do
-    :ok = Broadcaster.to_user(state, SessionWire.server_reply(state.network_slug, source, lines))
+  defp apply_effects([{:server_reply, source, lines, reply_to} | rest], state) do
+    :ok =
+      Broadcaster.to_requester(
+        state,
+        reply_to,
+        SessionWire.server_reply(state.network_slug, source, lines)
+      )
 
     apply_effects(rest, state)
   end
@@ -5355,8 +5423,13 @@ defmodule Grappa.Session.Server do
   # aggregated payload on the user-level topic. Per spec #2: ephemeral
   # — NOT persisted in scrollback. cic's `whoisCard.ts` keys by network
   # and replaces on each new bundle.
-  defp apply_effects([{:whois_bundle, target, accum} | rest], state) do
-    :ok = Broadcaster.to_user(state, SessionWire.whois_bundle(state.network_slug, target, accum))
+  defp apply_effects([{:whois_bundle, target, accum, reply_to} | rest], state) do
+    :ok =
+      Broadcaster.to_requester(
+        state,
+        reply_to,
+        SessionWire.whois_bundle(state.network_slug, target, accum)
+      )
 
     apply_effects(rest, state)
   end
@@ -5367,8 +5440,13 @@ defmodule Grappa.Session.Server do
   # field). cic dispatches in `userTopic.ts`'s `whowas_bundle` arm into
   # the per-network `whowasCard.ts` store (last-write-wins replacement
   # per network). NOT persisted — operator types /whowas to refresh.
-  defp apply_effects([{:whowas_bundle, target, accum} | rest], state) do
-    :ok = Broadcaster.to_user(state, SessionWire.whowas_bundle(state.network_slug, target, accum))
+  defp apply_effects([{:whowas_bundle, target, accum, reply_to} | rest], state) do
+    :ok =
+      Broadcaster.to_requester(
+        state,
+        reply_to,
+        SessionWire.whowas_bundle(state.network_slug, target, accum)
+      )
 
     apply_effects(rest, state)
   end
@@ -5378,8 +5456,13 @@ defmodule Grappa.Session.Server do
   # `channel` fields). cic dispatches in `userTopic.ts`'s `banlist_bundle`
   # arm into the per-network `banlistCard.ts` store (last-write-wins per
   # network). NOT persisted — operator types /banlist to refresh.
-  defp apply_effects([{:banlist_bundle, channel, accum} | rest], state) do
-    :ok = Broadcaster.to_user(state, SessionWire.banlist_bundle(state.network_slug, channel, accum))
+  defp apply_effects([{:banlist_bundle, channel, accum, reply_to} | rest], state) do
+    :ok =
+      Broadcaster.to_requester(
+        state,
+        reply_to,
+        SessionWire.banlist_bundle(state.network_slug, channel, accum)
+      )
 
     apply_effects(rest, state)
   end
@@ -5418,6 +5501,22 @@ defmodule Grappa.Session.Server do
   # `lusers_bundle` arm into the per-network `lusersBundle.ts` store
   # (last-write-wins replacement). NOT persisted — operator types
   # /lusers to refresh.
+  #
+  # #1088 — the ONE member of the informational family that keeps the
+  # per-user fan-out, and it is a boundary, not an oversight. Every sibling
+  # accumulator is created by the REQUEST (`prime_pending` in the `:send_*`
+  # handler), which is what lets it carry the requesting connection. This one
+  # is created by the REPLY: bahamut emits the same 7-numeric sequence on
+  # connect-welcome with nobody having asked, and 251 RPL_LUSERCLIENT resets
+  # the accumulator on arrival — so a `reply_to` primed by `/lusers` would
+  # either be wiped by its own reply or, if preserved across the reset,
+  # survive a never-terminated request and address the NEXT auto-emit to a
+  # stale socket. Nothing is lost by leaving it: #248 already gates the card
+  # on a consume-once client-local latch set when the operator types
+  # `/lusers`, so a bystander client drops this bundle. That latch answers
+  # "did anyone ask", the axis this issue does not touch; it happens to
+  # answer "did I ask" too. Addressing this bundle would trade a working
+  # guarantee for a stale-addressing hazard.
   defp apply_effects([{:lusers_bundle, accum} | rest], state) do
     :ok = Broadcaster.to_user(state, SessionWire.lusers_bundle(state.network_slug, accum))
 
@@ -5430,8 +5529,13 @@ defmodule Grappa.Session.Server do
   # `userTopic.ts`'s `links_bundle` arm into the per-network `linksModal.ts`
   # store (last-write-wins replacement) and renders the interactive
   # topology map. NOT persisted — operator types /links to refresh.
-  defp apply_effects([{:links_bundle, accum} | rest], state) do
-    :ok = Broadcaster.to_user(state, SessionWire.links_bundle(state.network_slug, accum))
+  defp apply_effects([{:links_bundle, accum, reply_to} | rest], state) do
+    :ok =
+      Broadcaster.to_requester(
+        state,
+        reply_to,
+        SessionWire.links_bundle(state.network_slug, accum)
+      )
 
     apply_effects(rest, state)
   end

--- a/lib/grappa_web/channels/grappa_channel.ex
+++ b/lib/grappa_web/channels/grappa_channel.ex
@@ -24,7 +24,10 @@ defmodule GrappaWeb.GrappaChannel do
      fastlane (encoded once and written directly to the transport →
      another WS frame). Net effect: 1 broadcast → 2 frames per
      message. This was BUG 6 — the sidebar unread badge bumped by 2
-     on every PRIVMSG.
+     on every PRIVMSG. The rule is about the channel's OWN topic: a
+     FOREIGN topic carries no fastlane, so subscribing to one is the
+     supported way to receive on a second channel (#1088's
+     `subscribe_socket_topic/2`, mirroring `AdminChannel`'s #215 leg).
   4. Kick off the after-join snapshot via `Process.send_after/3` with
      `:after_join` so the costly DB + session queries run after the
      join callback returns — `join/3` must be fast (Phoenix blocks the
@@ -149,9 +152,10 @@ defmodule GrappaWeb.GrappaChannel do
   dispatcher and the per-socket fastlane — a single WS frame per
   connected socket on the topic. The wire-shape contract lives at the
   broadcasting boundary (`Grappa.Session.Server` via
-  `Grappa.Scrollback.Wire.message_payload/1`). This module does NOT
-  define `handle_info({:event, _}, _)` — there is no manual subscribe
-  and the fastlane bypasses `handle_info/2` entirely.
+  `Grappa.Scrollback.Wire.message_payload/1`). For the channel's own
+  topic the fastlane bypasses `handle_info/2` entirely; the ONE
+  `handle_info(%Phoenix.Socket.Broadcast{}, _)` clause here serves
+  #1088's foreign per-connection topic, which has no fastlane.
 
   Accepted topic shapes (single source of truth in `Grappa.PubSub.Topic`):
 
@@ -240,9 +244,11 @@ defmodule GrappaWeb.GrappaChannel do
       # in `GrappaWeb.GrappaChannelTest`.
       parsed = canonicalize_topic(parsed)
 
-      # NO manual `Phoenix.PubSub.subscribe/2` here — the framework's
-      # fastlane subscription (installed by Phoenix.Channel.Server.init/1)
-      # is the ONLY subscriber needed. See moduledoc + BUG 6.
+      # NO manual `Phoenix.PubSub.subscribe/2` on THIS channel's own topic —
+      # the framework's fastlane subscription (installed by
+      # Phoenix.Channel.Server.init/1) is the ONLY subscriber needed. See
+      # moduledoc + BUG 6.
+      subscribe_socket_topic(parsed, socket)
       Process.send_after(self(), {:after_join, parsed}, 0)
       {:ok, join_reply(parsed), socket}
     else
@@ -250,6 +256,52 @@ defmodule GrappaWeb.GrappaChannel do
       {:error, :forbidden} -> {:error, %{error: "forbidden"}}
     end
   end
+
+  # #1088 — addressed delivery. This IS a manual `Phoenix.PubSub.subscribe/2`
+  # and it does NOT reintroduce BUG 6: the doubled push happened because a
+  # manual subscription sat on the SAME topic as the framework's fastlane, so
+  # one broadcast was written twice to one transport. `Topic.socket/2` is a
+  # DIFFERENT topic that no fastlane is installed on — the only subscriber is
+  # this process, delivery arrives as a `%Phoenix.Socket.Broadcast{}` in
+  # `handle_info/2`, and `push/3` turns it into exactly one frame. Same
+  # foreign-topic idiom `GrappaWeb.AdminChannel` already uses for #215's
+  # session log.
+  #
+  # Subscribed here rather than in `:after_join` on purpose: `after_join` is
+  # a `send_after(…, 0)`, so it races the first inbound verb, and a reply
+  # broadcast before the subscription lands is silently dropped. Also cheap
+  # (an ETS insert), which `join/3` requires — Phoenix blocks the client
+  # until it returns.
+  #
+  # ONLY the user topic subscribes. A socket holds one GrappaChannel process
+  # per joined topic (user + network + one per channel), all sharing the same
+  # `socket_ref`; subscribing from each would deliver N copies of one reply to
+  # one browser. The user topic is the right one because cic joins it first
+  # and dispatches every informational reply from `lib/userTopic.ts` — an
+  # addressed reply must arrive on the same client-side door the fan-out used,
+  # which is what makes this change invisible to cic.
+  @spec subscribe_socket_topic(Topic.parsed(), Phoenix.Socket.t()) :: :ok
+  defp subscribe_socket_topic({:user, user_name}, socket) do
+    :ok =
+      Phoenix.PubSub.subscribe(
+        Grappa.PubSub,
+        Topic.socket(user_name, socket.assigns.socket_ref)
+      )
+  end
+
+  defp subscribe_socket_topic(_, _), do: :ok
+
+  # #1088 — the connection an informational reply must come back to. Read off
+  # the socket that carried the command rather than off the payload: the
+  # client never names itself, so a hostile or buggy one cannot claim another
+  # connection's replies, and the whole change stays invisible to cic.
+  #
+  # Every GrappaChannel process of a socket sees the same value (it is a
+  # connect-time assign), so it does not matter which topic the verb was
+  # pushed on — the reply is delivered on the socket's user topic, which is
+  # where cic dispatches informational events from.
+  @spec reply_to(Phoenix.Socket.t()) :: Session.reply_to()
+  defp reply_to(socket), do: socket.assigns.socket_ref
 
   # UX-4 bucket A — canonicalise the channel segment of a per-channel
   # topic so the read-side (cursor, window_counts, snapshot) resolves the
@@ -400,6 +452,20 @@ defmodule GrappaWeb.GrappaChannel do
   def handle_info({:after_join, {:network, _, _}}, socket) do
     # No snapshot for network-level topics — they carry connection-state
     # events only; topic+modes are delivered per-channel.
+    {:noreply, socket}
+  end
+
+  # #1088 — the addressed-delivery leg. Only the user-topic channel is
+  # subscribed to `Topic.socket/2` (see `subscribe_socket_topic/2`), and that
+  # topic carries no fastlane, so the broadcast lands here as a struct and is
+  # forwarded verbatim: same `"event"` name, same payload the fan-out used to
+  # carry, one frame. cic cannot tell the difference — which is the point.
+  #
+  # No catch-all `handle_info/2` follows, deliberately: an unmatched message
+  # in a channel process should crash loudly rather than be absorbed by a net
+  # that hides the next bug (CLAUDE.md, "no silent-swallow at boundaries").
+  def handle_info(%Phoenix.Socket.Broadcast{event: event, payload: payload}, socket) do
+    push(socket, event, payload)
     {:noreply, socket}
   end
 
@@ -699,7 +765,7 @@ defmodule GrappaWeb.GrappaChannel do
     dispatch_subject_verb(
       socket,
       fn -> validate_args(channel: channel) end,
-      fn subject -> Session.send_banlist(subject, network_id, channel) end
+      fn subject -> Session.send_banlist(subject, network_id, channel, reply_to(socket)) end
     )
   end
 
@@ -763,7 +829,7 @@ defmodule GrappaWeb.GrappaChannel do
     dispatch_subject_verb(
       socket,
       fn -> validate_args(nick: nick, server: server) end,
-      fn subject -> Session.send_whois(subject, network_id, nick, server, origin) end
+      fn subject -> Session.send_whois(subject, network_id, nick, server, origin, reply_to(socket)) end
     )
   end
 
@@ -778,7 +844,7 @@ defmodule GrappaWeb.GrappaChannel do
     dispatch_subject_verb(
       socket,
       fn -> validate_args(nick: nick) end,
-      fn subject -> Session.send_whois(subject, network_id, nick, nil, origin) end
+      fn subject -> Session.send_whois(subject, network_id, nick, nil, origin, reply_to(socket)) end
     )
   end
 
@@ -796,7 +862,7 @@ defmodule GrappaWeb.GrappaChannel do
     dispatch_subject_verb(
       socket,
       fn -> validate_args(nick: nick) end,
-      fn subject -> Session.send_whowas(subject, network_id, nick) end
+      fn subject -> Session.send_whowas(subject, network_id, nick, reply_to(socket)) end
     )
   end
 
@@ -840,7 +906,7 @@ defmodule GrappaWeb.GrappaChannel do
     dispatch_subject_verb(
       socket,
       fn -> {:ok, :ok} end,
-      fn subject -> Session.send_info(subject, network_id) end
+      fn subject -> Session.send_info(subject, network_id, reply_to(socket)) end
     )
   end
 
@@ -853,7 +919,7 @@ defmodule GrappaWeb.GrappaChannel do
     dispatch_subject_verb(
       socket,
       fn -> {:ok, :ok} end,
-      fn subject -> Session.send_version(subject, network_id) end
+      fn subject -> Session.send_version(subject, network_id, reply_to(socket)) end
     )
   end
 
@@ -875,7 +941,7 @@ defmodule GrappaWeb.GrappaChannel do
     dispatch_subject_verb(
       socket,
       fn -> validate_server_target(target) end,
-      fn subject -> Session.send_motd(subject, network_id, target) end
+      fn subject -> Session.send_motd(subject, network_id, target, reply_to(socket)) end
     )
   end
 
@@ -900,7 +966,7 @@ defmodule GrappaWeb.GrappaChannel do
     dispatch_subject_verb(
       socket,
       fn -> validate_server_target(target) end,
-      fn subject -> Session.send_admin(subject, network_id, target) end
+      fn subject -> Session.send_admin(subject, network_id, target, reply_to(socket)) end
     )
   end
 
@@ -924,7 +990,7 @@ defmodule GrappaWeb.GrappaChannel do
     dispatch_subject_verb(
       socket,
       fn -> validate_links_mask(mask) end,
-      fn subject -> Session.send_links(subject, network_id, mask) end
+      fn subject -> Session.send_links(subject, network_id, mask, reply_to(socket)) end
     )
   end
 
@@ -973,7 +1039,7 @@ defmodule GrappaWeb.GrappaChannel do
       # wire back-compat with cic (pushWho still sends `{network_id,
       # channel}`); the value may be a mask or a multi-token flag string.
       fn -> validate_args(who_target: channel) end,
-      fn subject -> Session.send_who(subject, network_id, channel) end
+      fn subject -> Session.send_who(subject, network_id, channel, reply_to(socket)) end
     )
   end
 
@@ -995,7 +1061,7 @@ defmodule GrappaWeb.GrappaChannel do
     dispatch_subject_verb(
       socket,
       fn -> validate_args(channel: channel) end,
-      fn subject -> Session.send_names(subject, network_id, channel) end
+      fn subject -> Session.send_names(subject, network_id, channel, reply_to(socket)) end
     )
   end
 

--- a/lib/grappa_web/channels/user_socket.ex
+++ b/lib/grappa_web/channels/user_socket.ex
@@ -270,6 +270,7 @@ defmodule GrappaWeb.UserSocket do
         # the session implicitly (it is read off the socket that carried the
         # command), so it never rides the wire in either direction.
         |> assign(:socket_ref, Ecto.UUID.generate())
+
       # S3.1 + CP24 bucket E web/S5: register every WS pid (user AND
       # visitor) with WSPresence. The transport process (self() at
       # connect time) is the pid that owns the WS connection; when it

--- a/lib/grappa_web/channels/user_socket.ex
+++ b/lib/grappa_web/channels/user_socket.ex
@@ -78,6 +78,11 @@ defmodule GrappaWeb.UserSocket do
   controller-side `Subject.from_assigns/1` lift — V4 visitor-parity
   (2026-05-15).
 
+  Both branches also assign `:socket_ref` (#1088) — a per-CONNECTION
+  reference, distinct from every subject-level identifier on the socket,
+  used to address an informational reply back to the client that asked
+  for it instead of fanning it out to every device of the subject.
+
   Any failure (missing / empty subprotocol token, malformed UUID,
   unknown row, revoked, expired user session, expired or vanished
   visitor) returns `:error`
@@ -246,7 +251,25 @@ defmodule GrappaWeb.UserSocket do
   defp authenticate_and_assign(token, socket) do
     with {:ok, session} <- Accounts.authenticate(token),
          {:ok, socket} <- assign_subject(socket, session) do
-      socket = assign(socket, :current_session_id, session.id)
+      socket =
+        socket
+        |> assign(:current_session_id, session.id)
+        # #1088 — the per-CONNECTION discriminator. Minted here, at the one
+        # boundary where "a WebSocket" is created, so every channel process
+        # of this socket shares it and it dies with the transport.
+        #
+        # Nothing already on the socket can stand in for it, which is the
+        # whole reason it exists: `:current_session_id` is the
+        # `accounts_sessions` row, so two tabs of one login share it, and
+        # `Grappa.ClientId` is admission policy keyed per (client, network),
+        # not per connection. Both would re-create the fan-out they were
+        # asked to remove.
+        #
+        # Opaque and server-only: `GrappaChannel` subscribes the user-topic
+        # channel to `Topic.socket/2` on join, and a request carries it to
+        # the session implicitly (it is read off the socket that carried the
+        # command), so it never rides the wire in either direction.
+        |> assign(:socket_ref, Ecto.UUID.generate())
       # S3.1 + CP24 bucket E web/S5: register every WS pid (user AND
       # visitor) with WSPresence. The transport process (self() at
       # connect time) is the pid that owns the WS connection; when it

--- a/test/grappa/pubsub/topic_test.exs
+++ b/test/grappa/pubsub/topic_test.exs
@@ -131,6 +131,35 @@ defmodule Grappa.PubSub.TopicTest do
     end
   end
 
+  describe "socket/2 (#1088)" do
+    test "builds the per-connection addressed-delivery topic" do
+      assert Topic.socket("vjt", "ref-1") == "grappa:user:vjt/socket:ref-1"
+    end
+
+    test "two connections of one subject get two distinct topics" do
+      refute Topic.socket("vjt", "ref-1") == Topic.socket("vjt", "ref-2")
+    end
+
+    test "raises on an empty socket_ref" do
+      assert_raise FunctionClauseError, fn -> Topic.socket("vjt", "") end
+    end
+
+    test "raises on an empty user_name" do
+      assert_raise FunctionClauseError, fn -> Topic.socket("", "ref-1") end
+    end
+
+    # The security property, not an incidental one: the shape carries a
+    # connection's private replies, so it must stay outside the grammar
+    # `GrappaChannel.join/3` accepts. `parse/1`'s second-segment clause
+    # matches `"network:" <> slug` only, which is what excludes it — this
+    # pins that, so a future `"socket:"` clause added for convenience turns
+    # the topic joinable and this red.
+    test "is NOT joinable — excluded from the public topic grammar" do
+      assert Topic.parse(Topic.socket("vjt", "ref-1")) == :error
+      refute Topic.valid?(Topic.socket("vjt", "ref-1"))
+    end
+  end
+
   describe "parse/1" do
     test "parses a user topic" do
       assert Topic.parse("grappa:user:vjt") == {:ok, {:user, "vjt"}}

--- a/test/grappa/session/event_router_property_test.exs
+++ b/test/grappa/session/event_router_property_test.exs
@@ -173,7 +173,7 @@ defmodule Grappa.Session.EventRouterPropertyTest do
           assert is_binary(by)
           assert is_binary(reason) or is_nil(reason)
 
-        {:whois_bundle, target, accum} ->
+        {:whois_bundle, target, accum, _} ->
           assert is_binary(target)
           assert is_map(accum)
 
@@ -188,7 +188,7 @@ defmodule Grappa.Session.EventRouterPropertyTest do
         {:lusers_bundle, accum} ->
           assert is_map(accum)
 
-        {:whowas_bundle, target, accum} ->
+        {:whowas_bundle, target, accum, _} ->
           assert is_binary(target)
           assert is_map(accum)
 
@@ -204,15 +204,15 @@ defmodule Grappa.Session.EventRouterPropertyTest do
         # `lib/grappa/session/event_router.ex` so no legitimate typed
         # effect flunks on a future seed (the recurring maintenance the
         # bucket-H comment above anticipated).
-        {:names_reply, channel, roster} ->
+        {:names_reply, channel, roster, _} ->
           assert is_binary(channel)
           assert is_list(roster)
 
-        {:who_reply, target, users} ->
+        {:who_reply, target, users, _} ->
           assert is_binary(target)
           assert is_list(users)
 
-        {:server_reply, source, lines} ->
+        {:server_reply, source, lines, _} ->
           # Read the SSOT, never a copy: this allowlist had already drifted
           # narrower than the union once (#992's :admin), and a hand-spelled
           # set here fails a legitimate effect on some future seed.

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -5370,7 +5370,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       # 2 effects: members_seeded (always) + names_reply (gated on the
       # pending entry). NOT persisted notices — the modal is ephemeral.
-      assert [{:members_seeded, "#bofh", _}, {:names_reply, "#bofh", roster}] = effects
+      assert [{:members_seeded, "#bofh", _}, {:names_reply, "#bofh", roster, nil}] = effects
 
       # Arrival-order, prefix-split {nick, modes} tuples. The mIRC-tier
       # sort happens in server.ex apply_effects, NOT here.
@@ -5387,8 +5387,8 @@ defmodule Grappa.Session.EventRouterTest do
       {:cont, _, effects_nj} = EventRouter.route(m, not_joined)
       {:cont, _, effects_j} = EventRouter.route(m, joined)
 
-      assert [{:members_seeded, "#bofh", _}, {:names_reply, "#bofh", roster_nj}] = effects_nj
-      assert [{:members_seeded, "#bofh", _}, {:names_reply, "#bofh", roster_j}] = effects_j
+      assert [{:members_seeded, "#bofh", _}, {:names_reply, "#bofh", roster_nj, nil}] = effects_nj
+      assert [{:members_seeded, "#bofh", _}, {:names_reply, "#bofh", roster_j, nil}] = effects_j
       assert roster_nj == [{"alice", ["@"]}, {"bob", ["+"]}]
       assert roster_j == roster_nj
     end
@@ -5413,7 +5413,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       {:cont, new_state, effects} = EventRouter.route(m, state)
       assert new_state.names_pending == %{}
-      assert [{:members_seeded, "#ghost", _}, {:names_reply, "#ghost", []}] = effects
+      assert [{:members_seeded, "#ghost", _}, {:names_reply, "#ghost", [], nil}] = effects
     end
 
     test "366 lookup is case-insensitive on target channel — names_reply carries the canonical channel (RFC 2812 §2.2)" do
@@ -5432,7 +5432,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       {:cont, new_state, effects} = EventRouter.route(m, state)
       assert new_state.names_pending == %{}
-      assert [{:members_seeded, "#bofh", _}, {:names_reply, "#bofh", [{"alice", []}]}] = effects
+      assert [{:members_seeded, "#bofh", _}, {:names_reply, "#bofh", [{"alice", []}], nil}] = effects
     end
   end
 

--- a/test/grappa/session/event_router_test.exs
+++ b/test/grappa/session/event_router_test.exs
@@ -1331,7 +1331,7 @@ defmodule Grappa.Session.EventRouterTest do
     # Explicit /motd primes state.motd_pending; the 375/372 burst folds and
     # 376 RPL_ENDOFMOTD drains ONE {:server_reply, :motd, lines} effect in
     # wire order — NOTHING persisted (mirror of the /who 315 drain).
-    test "primed /motd folds 375/372 and drains {:server_reply, :motd, lines} on 376" do
+    test "primed /motd folds 375/372 and drains {:server_reply, :motd, lines, reply_to} on 376" do
       state = base_state(%{motd_pending: %{lines: []}})
 
       {:cont, s1, []} =
@@ -1343,7 +1343,7 @@ defmodule Grappa.Session.EventRouterTest do
       {:cont, s3, []} =
         EventRouter.route(msg({:numeric, 372}, ["vjt", "- line two"], nil), s2)
 
-      assert {:cont, drained, [{:server_reply, :motd, lines}]} =
+      assert {:cont, drained, [{:server_reply, :motd, lines, _}]} =
                EventRouter.route(msg({:numeric, 376}, ["vjt", "End of /MOTD command"], nil), s3)
 
       assert lines == ["- irc.test Message of the Day -", "- line one", "- line two"]
@@ -1353,10 +1353,10 @@ defmodule Grappa.Session.EventRouterTest do
 
     # 422 ERR_NOMOTD carries the ONLY line (no 375/372 burst), so it folds
     # its own body before draining — an explicit /motd never dangles.
-    test "primed /motd with no MOTD drains {:server_reply, :motd, [line]} on 422" do
+    test "primed /motd with no MOTD drains {:server_reply, :motd, [line], reply_to} on 422" do
       state = base_state(%{motd_pending: %{lines: []}})
 
-      assert {:cont, drained, [{:server_reply, :motd, ["MOTD File is missing"]}]} =
+      assert {:cont, drained, [{:server_reply, :motd, ["MOTD File is missing"], _}]} =
                EventRouter.route(msg({:numeric, 422}, ["vjt", "MOTD File is missing"], nil), state)
 
       assert drained.motd_pending == nil
@@ -1379,10 +1379,10 @@ defmodule Grappa.Session.EventRouterTest do
     # the accumulator) so the failure surfaces to the operator who asked and
     # never dangles — mirror of the 422 ERR_NOMOTD terminator. NEVER swallowed
     # into a wrong-server MOTD.
-    test "primed /motd to an unknown server drains {:server_reply, :motd, [error]} on 402" do
+    test "primed /motd to an unknown server drains {:server_reply, :motd, [error], reply_to} on 402" do
       state = base_state(%{motd_pending: %{lines: []}})
 
-      assert {:cont, drained, [{:server_reply, :motd, ["No such server"]}]} =
+      assert {:cont, drained, [{:server_reply, :motd, ["No such server"], _}]} =
                EventRouter.route(
                  msg({:numeric, 402}, ["vjt", "nope.invalid", "No such server"], nil),
                  state
@@ -1408,7 +1408,7 @@ defmodule Grappa.Session.EventRouterTest do
 
     # /info primes state.info_pending; 371 RPL_INFO burst folds, 374
     # RPL_ENDOFINFO drains {:server_reply, :info, lines}.
-    test "primed /info folds 371 and drains {:server_reply, :info, lines} on 374" do
+    test "primed /info folds 371 and drains {:server_reply, :info, lines, reply_to} on 374" do
       state = base_state(%{info_pending: %{lines: []}})
 
       {:cont, s1, []} =
@@ -1417,7 +1417,7 @@ defmodule Grappa.Session.EventRouterTest do
       {:cont, s2, []} =
         EventRouter.route(msg({:numeric, 371}, ["vjt", "Built 2026"], nil), s1)
 
-      assert {:cont, drained, [{:server_reply, :info, ["grappa test server", "Built 2026"]}]} =
+      assert {:cont, drained, [{:server_reply, :info, ["grappa test server", "Built 2026"], _}]} =
                EventRouter.route(msg({:numeric, 374}, ["vjt", "End of /INFO list"], nil), s2)
 
       assert drained.info_pending == nil
@@ -1425,12 +1425,12 @@ defmodule Grappa.Session.EventRouterTest do
 
     # /version primes state.version_pending; 351 RPL_VERSION is single-shot,
     # drains one assembled line immediately (no terminator).
-    test "primed /version drains {:server_reply, :version, [line]} on 351" do
+    test "primed /version drains {:server_reply, :version, [line], reply_to} on 351" do
       state = base_state(%{version_pending: %{lines: []}})
 
       m = msg({:numeric, 351}, ["vjt", "bahamut-2.2.1", "irc.test", "options"], nil)
 
-      assert {:cont, drained, [{:server_reply, :version, [line]}]} =
+      assert {:cont, drained, [{:server_reply, :version, [line], _}]} =
                EventRouter.route(m, state)
 
       assert line == "bahamut-2.2.1 irc.test options"
@@ -1466,7 +1466,7 @@ defmodule Grappa.Session.EventRouterTest do
     # UNLIKE 376 RPL_ENDOFMOTD, the terminator 259 RPL_ADMINEMAIL CARRIES
     # CONTENT, so it must fold its own line BEFORE draining or the contact
     # address — the single most useful line in the reply — is dropped.
-    test "primed /admin folds 256/257/258 and drains {:server_reply, :admin, lines} on 259" do
+    test "primed /admin folds 256/257/258 and drains {:server_reply, :admin, lines, reply_to} on 259" do
       state = base_state(%{admin_pending: %{lines: []}})
 
       {:cont, s1, []} =
@@ -1481,7 +1481,7 @@ defmodule Grappa.Session.EventRouterTest do
       {:cont, s3, []} =
         EventRouter.route(msg({:numeric, 258}, ["vjt", "Milano, IT"], nil), s2)
 
-      assert {:cont, drained, [{:server_reply, :admin, lines}]} =
+      assert {:cont, drained, [{:server_reply, :admin, lines, _}]} =
                EventRouter.route(msg({:numeric, 259}, ["vjt", "staff@azzurra.org"], nil), s3)
 
       assert lines == [
@@ -1502,7 +1502,7 @@ defmodule Grappa.Session.EventRouterTest do
     test "primed /admin drains on 423 ERR_NOADMININFO (no 256-259 burst arrives)" do
       state = base_state(%{admin_pending: %{lines: []}})
 
-      assert {:cont, drained, [{:server_reply, :admin, ["No administrative info available"]}]} =
+      assert {:cont, drained, [{:server_reply, :admin, ["No administrative info available"], _}]} =
                EventRouter.route(
                  msg({:numeric, 423}, ["vjt", "irc.test", "No administrative info available"], nil),
                  state
@@ -1518,7 +1518,7 @@ defmodule Grappa.Session.EventRouterTest do
     test "primed /admin drains on 447 ERR_RESTRICTED" do
       state = base_state(%{admin_pending: %{lines: []}})
 
-      assert {:cont, drained, [{:server_reply, :admin, ["You need a registered nick to issue commands!"]}]} =
+      assert {:cont, drained, [{:server_reply, :admin, ["You need a registered nick to issue commands!"], _}]} =
                EventRouter.route(
                  msg(
                    {:numeric, 447},
@@ -1570,10 +1570,10 @@ defmodule Grappa.Session.EventRouterTest do
     # unsolicited burst folds into the stale lines instead of reaching
     # $server); over-clearing costs one modal that the next explicit request
     # re-arms unconditionally. The two do not weigh the same.
-    test "402 with only /admin in flight drains {:server_reply, :admin, [error]}" do
+    test "402 with only /admin in flight drains {:server_reply, :admin, [error], reply_to}" do
       state = base_state(%{admin_pending: %{lines: []}})
 
-      assert {:cont, drained, [{:server_reply, :admin, ["No such server"]}]} =
+      assert {:cont, drained, [{:server_reply, :admin, ["No such server"], _}]} =
                EventRouter.route(
                  msg({:numeric, 402}, ["vjt", "nope.invalid", "No such server"], nil),
                  state
@@ -1585,7 +1585,7 @@ defmodule Grappa.Session.EventRouterTest do
     test "402 with BOTH /motd and /admin in flight disarms both and surfaces once" do
       state = base_state(%{motd_pending: %{lines: []}, admin_pending: %{lines: []}})
 
-      assert {:cont, drained, [{:server_reply, :motd, ["No such server"]}]} =
+      assert {:cont, drained, [{:server_reply, :motd, ["No such server"], _}]} =
                EventRouter.route(
                  msg({:numeric, 402}, ["vjt", "nope.invalid", "No such server"], nil),
                  state
@@ -3820,7 +3820,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       m = msg({:numeric, 318}, ["vjt", "Alice", "End of /WHOIS list"], {:server, "irc.test.org"})
 
-      {:cont, new_state, [{:whois_bundle, target, accum}]} = EventRouter.route(m, state)
+      {:cont, new_state, [{:whois_bundle, target, accum, _}]} = EventRouter.route(m, state)
       assert target == "Alice"
       assert accum[:user] == "alice_u"
       assert accum[:realname] == "Alice Liddell"
@@ -3843,7 +3843,7 @@ defmodule Grappa.Session.EventRouterTest do
       # Server may echo a different case for the target than what the user typed.
       m = msg({:numeric, 318}, ["vjt", "ALICE", "End of /WHOIS list"], {:server, "irc.test.org"})
 
-      {:cont, new_state, [{:whois_bundle, _, accum}]} = EventRouter.route(m, state)
+      {:cont, new_state, [{:whois_bundle, _, accum, _}]} = EventRouter.route(m, state)
       assert accum[:user] == "u"
       assert new_state.whois_pending == %{}
     end
@@ -4102,7 +4102,7 @@ defmodule Grappa.Session.EventRouterTest do
         end)
 
       end_msg = msg({:numeric, 318}, ["vjt", "alice", "End of /WHOIS list"])
-      {:cont, _, [{:whois_bundle, target, accum}]} = EventRouter.route(end_msg, final_state)
+      {:cont, _, [{:whois_bundle, target, accum, _}]} = EventRouter.route(end_msg, final_state)
 
       payload = Wire.whois_bundle("test-net", target, accum)
 
@@ -4344,7 +4344,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       end_msg = msg({:numeric, 318}, ["vjt", "alice", "End of /WHOIS list"], {:server, "irc.libera.chat"})
 
-      {:cont, _, [{:whois_bundle, target, accum}]} = EventRouter.route(end_msg, final_state)
+      {:cont, _, [{:whois_bundle, target, accum, _}]} = EventRouter.route(end_msg, final_state)
       payload = Wire.whois_bundle("libera", target, accum)
 
       assert payload.account == "AliceAccount"
@@ -4425,7 +4425,7 @@ defmodule Grappa.Session.EventRouterTest do
       # for O(1) fold, and SessionWire.whois_bundle/3 reverses on emit. Drain
       # the bundle at 318 and check the wire payload is in arrival order.
       m318 = msg({:numeric, 318}, ["vjt", "alice", "End of /WHOIS list"], {:server, "irc.libera.chat"})
-      {:cont, _, [{:whois_bundle, "alice", accum}]} = EventRouter.route(m318, s2)
+      {:cont, _, [{:whois_bundle, "alice", accum, _}]} = EventRouter.route(m318, s2)
 
       payload = Wire.whois_bundle("libera", "alice", accum)
 
@@ -4790,7 +4790,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       m = msg({:numeric, 369}, ["vjt", "Alice", "End of WHOWAS"], {:server, "irc.test.org"})
 
-      {:cont, new_state, [{:whowas_bundle, target, accum}]} = EventRouter.route(m, state)
+      {:cont, new_state, [{:whowas_bundle, target, accum, _}]} = EventRouter.route(m, state)
       assert target == "Alice"
       assert length(accum[:entries]) == 1
       assert new_state.whowas_pending == %{}
@@ -4813,7 +4813,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       m = msg({:numeric, 369}, ["vjt", "ALICE", "End of WHOWAS"], {:server, "irc.test.org"})
 
-      {:cont, new_state, [{:whowas_bundle, _, accum}]} = EventRouter.route(m, state)
+      {:cont, new_state, [{:whowas_bundle, _, accum, _}]} = EventRouter.route(m, state)
       assert hd(accum[:entries])[:user] == "u"
       assert new_state.whowas_pending == %{}
     end
@@ -4828,7 +4828,7 @@ defmodule Grappa.Session.EventRouterTest do
           {:server, "irc.test.org"}
         )
 
-      {:cont, new_state, [{:whowas_bundle, target, accum}]} = EventRouter.route(m, state)
+      {:cont, new_state, [{:whowas_bundle, target, accum, _}]} = EventRouter.route(m, state)
       assert target == "ghost"
       assert accum[:not_found] == true
       assert new_state.whowas_pending == %{}
@@ -4922,7 +4922,7 @@ defmodule Grappa.Session.EventRouterTest do
       {:cont, s2, []} = EventRouter.route(m2, s1)
 
       m368 = msg({:numeric, 368}, ["vjt", "#test", "End of Channel Ban List"], {:server, "irc.test.org"})
-      {:cont, _, [{:banlist_bundle, _, accum}]} = EventRouter.route(m368, s2)
+      {:cont, _, [{:banlist_bundle, _, accum, _}]} = EventRouter.route(m368, s2)
 
       # The EFFECT accum stores entries reversed (head = most recent 367,
       # O(1) prepend); `Wire.banlist_bundle/3` reverses to restore the wire
@@ -4948,7 +4948,7 @@ defmodule Grappa.Session.EventRouterTest do
           {:server, "irc.test.org"}
         )
 
-      {:cont, new_state, [{:banlist_bundle, channel, accum}]} = EventRouter.route(m, state)
+      {:cont, new_state, [{:banlist_bundle, channel, accum, _}]} = EventRouter.route(m, state)
       # The router carries `channel_display` through VERBATIM (whatever was
       # primed) — proven here with a mixed-case value so a stray fold in the
       # router would fail. In production the facade (`Session.send_banlist/3`)
@@ -4985,7 +4985,7 @@ defmodule Grappa.Session.EventRouterTest do
       m368 =
         msg({:numeric, 368}, ["vjt", "#CHAN", "End"], {:server, "irc.test.org"})
 
-      {:cont, s2, [{:banlist_bundle, _, accum}]} = EventRouter.route(m368, s1)
+      {:cont, s2, [{:banlist_bundle, _, accum, _}]} = EventRouter.route(m368, s1)
       assert length(accum[:entries]) == 1
       assert s2.banlist_pending == %{}
     end
@@ -5047,7 +5047,7 @@ defmodule Grappa.Session.EventRouterTest do
       assert new_state.who_pending == %{}
     end
 
-    test "315 RPL_ENDOFWHO emits ONE {:who_reply, target, users} effect + drops entry" do
+    test "315 RPL_ENDOFWHO emits ONE {:who_reply, target, users, reply_to} effect + drops entry" do
       state =
         base_state(%{
           who_pending: %{
@@ -5084,7 +5084,7 @@ defmodule Grappa.Session.EventRouterTest do
       {:cont, new_state, effects} = EventRouter.route(m, state)
       # No scrollback persist — one ephemeral who_reply, entry dropped.
       assert new_state.who_pending == %{}
-      assert [{:who_reply, target, users}] = effects
+      assert [{:who_reply, target, users, _}] = effects
       assert target == "#bofh"
       # who_fold prepends each row LIFO, so the stored list is reverse-wire
       # order; the drain reverses it back. Fixture stores [bob, alice]
@@ -5145,7 +5145,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       {:cont, new_state, effects} = EventRouter.route(m, state)
       assert new_state.who_pending == %{}
-      assert [{:who_reply, target, users}] = effects
+      assert [{:who_reply, target, users, _}] = effects
       # target_display carries the full original arg string for the modal.
       assert target == "+s server.azzurra.chat"
       assert Enum.map(users, & &1.nick) == ["alice"]
@@ -5159,7 +5159,7 @@ defmodule Grappa.Session.EventRouterTest do
 
       m = msg({:numeric, 315}, ["vjt", "#BOFH", "End of /WHO list"], {:server, "irc.test.org"})
 
-      {:cont, new_state, [{:who_reply, target, users}]} = EventRouter.route(m, state)
+      {:cont, new_state, [{:who_reply, target, users, _}]} = EventRouter.route(m, state)
       assert new_state.who_pending == %{}
       # Carries the canonical `target_display` (original case), empty roster.
       assert target == "#BOFH"
@@ -5194,7 +5194,7 @@ defmodule Grappa.Session.EventRouterTest do
       # Pre-#169 a joined channel routed the notices INTO #bofh's scrollback.
       # Now it is always a single ephemeral who_reply — no :persist effect,
       # so the joined channel window stays clean.
-      {:cont, _, [{:who_reply, target, users}]} = EventRouter.route(m, state)
+      {:cont, _, [{:who_reply, target, users, _}]} = EventRouter.route(m, state)
       assert target == "#bofh"
       assert Enum.map(users, & &1.nick) == ["alice"]
     end
@@ -5264,7 +5264,7 @@ defmodule Grappa.Session.EventRouterTest do
           {:server, "irc.libera.chat"}
         )
 
-      {:cont, new_state, [{:who_reply, target, users}]} = EventRouter.route(m, state)
+      {:cont, new_state, [{:who_reply, target, users, _}]} = EventRouter.route(m, state)
       assert new_state.who_pending == %{}
       assert target == "*!*@*.libera.chat"
       assert Enum.map(users, & &1.nick) == ["alice"]
@@ -5286,7 +5286,7 @@ defmodule Grappa.Session.EventRouterTest do
           {:server, "irc.libera.chat"}
         )
 
-      {:cont, new_state, [{:who_reply, target, users}]} = EventRouter.route(m, state)
+      {:cont, new_state, [{:who_reply, target, users, _}]} = EventRouter.route(m, state)
       assert new_state.who_pending == %{}
       assert target == "*!*@nonexistent"
       assert users == []
@@ -5351,7 +5351,7 @@ defmodule Grappa.Session.EventRouterTest do
       assert new_state.names_pending == %{}
     end
 
-    test "366 with pending entry drains ONE {:names_reply, channel, prefix-split roster} after members_seeded" do
+    test "366 with pending entry drains ONE {:names_reply, channel, prefix-split roster, reply_to} after members_seeded" do
       state =
         base_state(%{
           members: %{},
@@ -5759,7 +5759,7 @@ defmodule Grappa.Session.EventRouterTest do
       assert entry.description == ""
     end
 
-    test "365 RPL_ENDOFLINKS flushes {:links_bundle, accum} and clears links_pending" do
+    test "365 RPL_ENDOFLINKS flushes {:links_bundle, accum, reply_to} and clears links_pending" do
       state =
         base_state(%{
           links_pending: %{
@@ -5777,7 +5777,7 @@ defmodule Grappa.Session.EventRouterTest do
           {:server, "hub.azzurra.org"}
         )
 
-      {:cont, new_state, [{:links_bundle, accum}]} = EventRouter.route(m, state)
+      {:cont, new_state, [{:links_bundle, accum, _}]} = EventRouter.route(m, state)
       assert new_state.links_pending == nil
       # Accumulator carries the entries as-stored (reversed); the wire
       # builder restores wire order.
@@ -5794,7 +5794,7 @@ defmodule Grappa.Session.EventRouterTest do
           {:server, "hub.azzurra.org"}
         )
 
-      {:cont, new_state, [{:links_bundle, accum}]} = EventRouter.route(m, state)
+      {:cont, new_state, [{:links_bundle, accum, _}]} = EventRouter.route(m, state)
       assert new_state.links_pending == nil
       assert accum[:entries] == []
     end

--- a/test/grappa/session/server_test.exs
+++ b/test/grappa/session/server_test.exs
@@ -2294,7 +2294,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = await_handshake(server)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
-      assert :ok = Session.send_links({:user, user.id}, network.id, "all")
+      assert :ok = Session.send_links({:user, user.id}, network.id, "all", nil)
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "LINKS all\r\n"), 1_000)
 
       # Restricted mask: a bare 365 with zero 364 rows.
@@ -2319,7 +2319,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = await_handshake(server)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
-      assert :ok = Session.send_links({:user, user.id}, network.id, nil)
+      assert :ok = Session.send_links({:user, user.id}, network.id, nil, nil)
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "LINKS\r\n"), 1_000)
 
       IRCServer.feed(server, ":irc.test.org 364 grappa-test hub.test hub.test :0 Hub\r\n")
@@ -2343,12 +2343,12 @@ defmodule Grappa.Session.ServerTest do
       :ok = await_handshake(server)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
-      assert :ok = Session.send_links({:user, user.id}, network.id, nil)
+      assert :ok = Session.send_links({:user, user.id}, network.id, nil, nil)
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "LINKS\r\n"), 1_000)
 
       # Second request within the window: refused, NOT clobbering the pending.
       assert {:error, :links_in_flight} =
-               Session.send_links({:user, user.id}, network.id, nil)
+               Session.send_links({:user, user.id}, network.id, nil, nil)
 
       # The first request's 364/365 still drains a bundle (its accumulator was
       # never reset by the refused second call — the pre-#513 lost-bundle bug).
@@ -2372,7 +2372,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = await_handshake(server)
       IRCServer.feed(server, ":irc.test.org 001 grappa-test :Welcome\r\n")
 
-      assert :ok = Session.send_links({:user, user.id}, network.id, nil)
+      assert :ok = Session.send_links({:user, user.id}, network.id, nil, nil)
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "LINKS\r\n"), 1_000)
 
       # Restricted network: 481 denial, NO 365 — links_pending stays set (481
@@ -2384,7 +2384,7 @@ defmodule Grappa.Session.ServerTest do
 
       # Within the window the pending is honoured → refused (no clobber).
       assert {:error, :links_in_flight} =
-               Session.send_links({:user, user.id}, network.id, nil)
+               Session.send_links({:user, user.id}, network.id, nil, nil)
 
       # Age the pending past @links_stale_ms — simulates a request abandoned
       # long ago (a real 481 that never got a 365). The clobber recovery is
@@ -2393,7 +2393,7 @@ defmodule Grappa.Session.ServerTest do
         %{s | links_pending: %{s.links_pending | requested_at: System.monotonic_time(:millisecond) - 20_000}}
       end)
 
-      assert :ok = Session.send_links({:user, user.id}, network.id, nil)
+      assert :ok = Session.send_links({:user, user.id}, network.id, nil, nil)
       {:ok, _} = IRCServer.wait_for_line(server, &(&1 == "LINKS\r\n"), 1_000)
 
       :ok = GenServer.stop(pid, :normal, 1_000)
@@ -9595,7 +9595,7 @@ defmodule Grappa.Session.ServerTest do
       network: network,
       pid: pid
     } do
-      assert :ok = Session.send_banlist({:user, user.id}, network.id, "#test")
+      assert :ok = Session.send_banlist({:user, user.id}, network.id, "#test", nil)
 
       assert {:ok, "MODE #test b\r\n"} =
                IRCServer.wait_for_line(server, &(&1 == "MODE #test b\r\n"), 1_000)
@@ -9650,12 +9650,12 @@ defmodule Grappa.Session.ServerTest do
       assert {:error, :no_session} = Session.send_ban({:user, uid}, 9_999, "#x", "a")
       assert {:error, :no_session} = Session.send_unban({:user, uid}, 9_999, "#x", "*!*@h")
       assert {:error, :no_session} = Session.send_invite({:user, uid}, 9_999, "#x", "a")
-      assert {:error, :no_session} = Session.send_banlist({:user, uid}, 9_999, "#x")
+      assert {:error, :no_session} = Session.send_banlist({:user, uid}, 9_999, "#x", nil)
       assert {:error, :no_session} = Session.send_umode({:user, uid}, 9_999, "+i")
       assert {:error, :no_session} = Session.send_mode({:user, uid}, 9_999, "#x", "+m", [])
-      assert {:error, :no_session} = Session.send_whois({:user, uid}, 9_999, "alice", nil, :user)
-      assert {:error, :no_session} = Session.send_who({:user, uid}, 9_999, "#bofh")
-      assert {:error, :no_session} = Session.send_names({:user, uid}, 9_999, "#bofh")
+      assert {:error, :no_session} = Session.send_whois({:user, uid}, 9_999, "alice", nil, :user, nil)
+      assert {:error, :no_session} = Session.send_who({:user, uid}, 9_999, "#bofh", nil)
+      assert {:error, :no_session} = Session.send_names({:user, uid}, 9_999, "#bofh", nil)
     end
   end
 
@@ -9679,7 +9679,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "/whois <nick> sends WHOIS upstream", %{server: server, user: user, network: network, pid: pid} do
-      assert :ok = Session.send_whois({:user, user.id}, network.id, "alice", nil, :user)
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "alice", nil, :user, nil)
 
       assert {:ok, "WHOIS alice\r\n"} =
                IRCServer.wait_for_line(server, &(&1 == "WHOIS alice\r\n"), 1_000)
@@ -9705,7 +9705,7 @@ defmodule Grappa.Session.ServerTest do
           %{state | whois_pending: %{"ghost" => %{target_display: "ghost", __primed_at_ms: stale_at}}}
         end)
 
-      assert :ok = Session.send_whois({:user, user.id}, network.id, "fresh", nil, :user)
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "fresh", nil, :user, nil)
       _ = IRCServer.wait_for_line(server, &(&1 == "WHOIS fresh\r\n"), 1_000)
 
       state = SessionStateHelpers.fetch(pid)
@@ -9728,7 +9728,7 @@ defmodule Grappa.Session.ServerTest do
           %{state | whois_pending: %{"recent" => %{target_display: "recent", __primed_at_ms: recent_at}}}
         end)
 
-      assert :ok = Session.send_whois({:user, user.id}, network.id, "fresh", nil, :user)
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "fresh", nil, :user, nil)
       _ = IRCServer.wait_for_line(server, &(&1 == "WHOIS fresh\r\n"), 1_000)
 
       state = SessionStateHelpers.fetch(pid)
@@ -9775,7 +9775,7 @@ defmodule Grappa.Session.ServerTest do
     } do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
-      assert :ok = Session.send_whois({:user, user.id}, network.id, "alice", nil, :user)
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "alice", nil, :user, nil)
       _ = IRCServer.wait_for_line(server, &(&1 == "WHOIS alice\r\n"), 1_000)
 
       IRCServer.feed(server, ":irc.test.org 311 grappa-test alice alice_u alice.host * :Alice Liddell\r\n")
@@ -9815,7 +9815,7 @@ defmodule Grappa.Session.ServerTest do
     } do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
-      assert :ok = Session.send_whois({:user, user.id}, network.id, "alice", nil, :rail)
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "alice", nil, :rail, nil)
       _ = IRCServer.wait_for_line(server, &(&1 == "WHOIS alice\r\n"), 1_000)
 
       IRCServer.feed(server, ":irc.test.org 311 grappa-test alice alice_u alice.host * :Alice\r\n")
@@ -9836,7 +9836,7 @@ defmodule Grappa.Session.ServerTest do
     } do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
-      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil, :user)
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil, :user, nil)
       _ = IRCServer.wait_for_line(server, &(&1 == "WHOIS ghost\r\n"), 1_000)
 
       IRCServer.feed(server, ":irc.test.org 318 grappa-test ghost :End of /WHOIS list\r\n")
@@ -9865,7 +9865,7 @@ defmodule Grappa.Session.ServerTest do
       assert {:ok, _} = Session.send_privmsg({:user, user.id}, network.id, "ghost", "hi")
       assert QueryWindows.open?({:user, user.id}, network.id, "ghost")
 
-      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil, :user)
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil, :user, nil)
       _ = IRCServer.wait_for_line(server, &(&1 == "WHOIS ghost\r\n"), 1_000)
 
       # Subscribe AFTER the outbound send so the mailbox holds only the 401s.
@@ -9917,7 +9917,7 @@ defmodule Grappa.Session.ServerTest do
       # row would ALSO be duplicated into the WHOIS card's extra_lines.
       assert {:ok, _} = Session.send_privmsg({:user, user.id}, network.id, "ghost", "hi")
 
-      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil, :user)
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil, :user, nil)
       _ = IRCServer.wait_for_line(server, &(&1 == "WHOIS ghost\r\n"), 1_000)
 
       :ok =
@@ -9970,7 +9970,7 @@ defmodule Grappa.Session.ServerTest do
       # bundle is approximate by construction (P-0a).
       assert {:ok, _} = Session.send_privmsg({:user, user.id}, network.id, "ghost", "hi")
 
-      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil, :user)
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil, :user, nil)
       _ = IRCServer.wait_for_line(server, &(&1 == "WHOIS ghost\r\n"), 1_000)
 
       :ok =
@@ -9982,7 +9982,7 @@ defmodule Grappa.Session.ServerTest do
 
       # Re-prime BETWEEN the absorption and the first WHOIS's own reply — the
       # interleaving that actually destroys the record.
-      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil, :user)
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "ghost", nil, :user, nil)
 
       IRCServer.feed(server, ":irc.test.org 401 grappa-test ghost :No such nick/channel\r\n")
       IRCServer.feed(server, ":irc.test.org 318 grappa-test ghost :End of /WHOIS list\r\n")
@@ -10013,7 +10013,7 @@ defmodule Grappa.Session.ServerTest do
     } do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
-      assert :ok = Session.send_whois({:user, user.id}, network.id, "alice", nil, :user)
+      assert :ok = Session.send_whois({:user, user.id}, network.id, "alice", nil, :user, nil)
       _ = IRCServer.wait_for_line(server, &(&1 == "WHOIS alice\r\n"), 1_000)
 
       IRCServer.feed(server, ":irc.test.org 311 grappa-test ALICE alice_u alice.host * :Alice\r\n")
@@ -10133,7 +10133,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       # Operator issues /whowas alice — primes whowas_pending["alice"].
-      assert :ok = Grappa.Session.send_whowas({:user, user.id}, network.id, "alice")
+      assert :ok = Grappa.Session.send_whowas({:user, user.id}, network.id, "alice", nil)
 
       # Bahamut emits the WHOWAS reply: 314 (historical user), 312
       # (server + ctime logoff_time), 369 (terminator).
@@ -10176,7 +10176,7 @@ defmodule Grappa.Session.ServerTest do
          } do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
-      assert :ok = Grappa.Session.send_whowas({:user, user.id}, network.id, "ghost")
+      assert :ok = Grappa.Session.send_whowas({:user, user.id}, network.id, "ghost", nil)
 
       IRCServer.feed(
         server,
@@ -10208,7 +10208,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
 
       # Operator issues /banlist #test — primes banlist_pending["#test"].
-      assert :ok = Grappa.Session.send_banlist({:user, user.id}, network.id, "#test")
+      assert :ok = Grappa.Session.send_banlist({:user, user.id}, network.id, "#test", nil)
 
       # Bahamut emits the ban list: 367 rows then 368 terminator.
       IRCServer.feed(
@@ -10277,7 +10277,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "/names #channel sends NAMES upstream", %{server: server, user: user, network: network, pid: pid} do
-      assert :ok = Session.send_names({:user, user.id}, network.id, "#bofh")
+      assert :ok = Session.send_names({:user, user.id}, network.id, "#bofh", nil)
 
       assert {:ok, "NAMES #bofh\r\n"} =
                IRCServer.wait_for_line(server, &(&1 == "NAMES #bofh\r\n"), 1_000)
@@ -10294,7 +10294,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.channel(user.name, network.slug, "$server"))
 
-      assert :ok = Session.send_names({:user, user.id}, network.id, "#bofh")
+      assert :ok = Session.send_names({:user, user.id}, network.id, "#bofh", nil)
       _ = IRCServer.wait_for_line(server, &(&1 == "NAMES #bofh\r\n"), 1_000)
 
       IRCServer.feed(server, ":irc.test.org 353 grappa-test = #bofh :carol @alice +bob\r\n")
@@ -10347,7 +10347,7 @@ defmodule Grappa.Session.ServerTest do
         500 -> flunk("expected initial members_seeded after JOIN")
       end
 
-      assert :ok = Session.send_names({:user, user.id}, network.id, "#bofh")
+      assert :ok = Session.send_names({:user, user.id}, network.id, "#bofh", nil)
       _ = IRCServer.wait_for_line(server, &(&1 == "NAMES #bofh\r\n"), 1_000)
 
       IRCServer.feed(server, ":irc.test.org 353 grappa-test = #bofh :grappa-test @alice +bob\r\n")
@@ -10400,7 +10400,7 @@ defmodule Grappa.Session.ServerTest do
     end
 
     test "/who #channel sends WHO upstream", %{server: server, user: user, network: network, pid: pid} do
-      assert :ok = Session.send_who({:user, user.id}, network.id, "#bofh")
+      assert :ok = Session.send_who({:user, user.id}, network.id, "#bofh", nil)
 
       assert {:ok, "WHO #bofh\r\n"} =
                IRCServer.wait_for_line(server, &(&1 == "WHO #bofh\r\n"), 1_000)
@@ -10413,7 +10413,7 @@ defmodule Grappa.Session.ServerTest do
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
       :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.channel(user.name, network.slug, "$server"))
 
-      assert :ok = Session.send_who({:user, user.id}, network.id, "#bofh")
+      assert :ok = Session.send_who({:user, user.id}, network.id, "#bofh", nil)
       _ = IRCServer.wait_for_line(server, &(&1 == "WHO #bofh\r\n"), 1_000)
 
       IRCServer.feed(
@@ -10454,6 +10454,55 @@ defmodule Grappa.Session.ServerTest do
       :ok = GenServer.stop(pid, :normal, 1_000)
     end
 
+    # #1088 — the addressing itself, at the level where it is decided. The
+    # test above is now also the safe-default pin: it passes `reply_to: nil`
+    # and still expects `Topic.user/1`, so a request with no owning
+    # connection (an accumulator primed before a hot deploy) keeps the
+    # pre-#1088 fan-out rather than vanishing.
+    #
+    # This one pins the other branch, and the `refute` is the half that
+    # matters: reaching the requester is not enough if the bundle ALSO still
+    # fans out — that was the bug, and a "did the right client get it" test
+    # alone would stay green through it.
+    test "a /who issued by a connection is delivered to that connection's topic only (#1088)",
+         %{server: server, user: user, network: network, pid: pid} do
+      socket_ref = "sock-#{System.unique_integer([:positive])}"
+      addressed = Topic.socket(user.name, socket_ref)
+      fanned_out = Topic.user(user.name)
+
+      # Subscribed to BOTH, and the assertions key on `%Broadcast{}.topic`:
+      # that is what makes this falsifiable. Matching on the payload alone
+      # would pass on the pre-#1088 fan-out too, since this process is an
+      # ear on the user topic as well.
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, addressed)
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, fanned_out)
+
+      assert :ok = Session.send_who({:user, user.id}, network.id, "#bofh", socket_ref)
+      _ = IRCServer.wait_for_line(server, &(&1 == "WHO #bofh\r\n"), 1_000)
+
+      IRCServer.feed(
+        server,
+        ":irc.test.org 352 grappa-test #bofh au ah irc.test.org alice H@ :0 Alice Liddell\r\n"
+      )
+
+      IRCServer.feed(server, ":irc.test.org 315 grappa-test #bofh :End of /WHO list\r\n")
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: ^addressed,
+                       event: "event",
+                       payload: %{kind: :who_reply, target: "#bofh", users: [%{nick: "alice"}]}
+                     },
+                     1_500
+
+      refute_receive %Phoenix.Socket.Broadcast{
+                       topic: ^fanned_out,
+                       payload: %{kind: :who_reply}
+                     },
+                     200
+
+      :ok = GenServer.stop(pid, :normal, 1_000)
+    end
+
     # #221 — /who <mask> END-TO-END. The bug: a masked WHO produced TOTAL
     # SILENCE (no 352, no 315, nothing in cic). Two independent breaks —
     # (1) the outbound WHO was channel-gated so the mask never left, and
@@ -10467,7 +10516,7 @@ defmodule Grappa.Session.ServerTest do
 
       mask = "*!*@*.libera.chat"
 
-      assert :ok = Session.send_who({:user, user.id}, network.id, mask)
+      assert :ok = Session.send_who({:user, user.id}, network.id, mask, nil)
 
       # Break (1): the mask actually leaves the bouncer.
       assert {:ok, _} =
@@ -10502,7 +10551,7 @@ defmodule Grappa.Session.ServerTest do
 
       mask = "*!*@nonexistent.example"
 
-      assert :ok = Session.send_who({:user, user.id}, network.id, mask)
+      assert :ok = Session.send_who({:user, user.id}, network.id, mask, nil)
       _ = IRCServer.wait_for_line(server, &(&1 == "WHO #{mask}\r\n"), 1_000)
 
       # No 352 — just the terminator (zero-match case).

--- a/test/grappa_web/channels/grappa_channel_request_budget_test.exs
+++ b/test/grappa_web/channels/grappa_channel_request_budget_test.exs
@@ -50,7 +50,12 @@ defmodule GrappaWeb.GrappaChannelRequestBudgetTest do
       |> socket("user_socket:#{user_name}", %{
         user_name: user_name,
         current_subject: {:user, user.id},
-        current_session_id: session.id
+        current_session_id: session.id,
+        # #1088 — `UserSocket.connect/3` mints a socket_ref per connection on
+        # both branches, and `GrappaChannel.join/3` reads it to subscribe to
+        # the addressed topic, so a fixture without one is not a production
+        # socket.
+        socket_ref: Ecto.UUID.generate()
       })
       |> subscribe_and_join(GrappaChannel, Topic.user(user_name))
 

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -99,7 +99,12 @@ defmodule GrappaWeb.GrappaChannelTest do
       # fixture must carry it too (a generated bearer is fine — the budget
       # only revokes on the sever crossing, which the generous test config
       # never reaches). Overridable for the budget/sever tests.
-      current_session_id: Keyword.get(opts, :session_id, Ecto.UUID.generate())
+      current_session_id: Keyword.get(opts, :session_id, Ecto.UUID.generate()),
+      # #1088 — `UserSocket.connect/3` mints one per CONNECTION, so two
+      # fixture sockets are two connections. Generated per call on purpose:
+      # a shared constant would make the addressed-delivery tests below pass
+      # for the wrong reason (one topic, two subscribers = the fan-out again).
+      socket_ref: Keyword.get(opts, :socket_ref, Ecto.UUID.generate())
     })
   end
 
@@ -2694,6 +2699,132 @@ defmodule GrappaWeb.GrappaChannelTest do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #1088 — an informational reply belongs to the connection that asked
+  # ---------------------------------------------------------------------------
+  #
+  # Reported by an operator whose IRC client issued `/who` against their own
+  # grappa: the WHO modal opened in cicchetto, on a client that had asked for
+  # nothing. Every one of these replies rode `Topic.user/1`, which partitions
+  # by SUBJECT and has no per-connection dimension, so one question produced a
+  # modal on every device of that subject.
+  #
+  # The oracle here is a REAL second connection, not a bare PubSub subscriber:
+  # a bystander socket joined to the same user topic, in its own process (the
+  # transport pid is whoever calls `subscribe_and_join/3`, so a second socket
+  # in THIS process would be indistinguishable from the first). It reports
+  # what it saw; the requesting socket must see the reply and the bystander
+  # must see nothing.
+  describe "#1088 — addressed informational replies" do
+    setup do
+      {irc_server, port} = start_irc_server()
+      {user, network} = setup_user_and_network_with_session(port)
+      welcome_session_on_channel(irc_server, "#snap")
+
+      {:ok, _, socket} =
+        user.name
+        |> build_socket(subject: {:user, user.id})
+        |> subscribe_and_join(Topic.user(user.name), %{})
+
+      %{irc_server: irc_server, socket: socket, user: user, network: network}
+    end
+
+    test "a /who reply reaches the requesting connection only", %{
+      irc_server: irc_server,
+      socket: socket,
+      user: user,
+      network: network
+    } do
+      bystander = start_bystander(user)
+
+      ref = push(socket, "who", %{"network_id" => network.id, "channel" => "#snap"})
+      assert_reply(ref, :ok)
+      {:ok, _} = IRCServer.wait_for_line(irc_server, &(&1 == "WHO #snap\r\n"), 1_000)
+
+      IRCServer.feed(
+        irc_server,
+        ":irc.test.org 352 grappa-snap #snap alice host irc.test.org alice H :0 Alice\r\n"
+      )
+
+      IRCServer.feed(irc_server, ":irc.test.org 315 grappa-snap #snap :End of /WHO list.\r\n")
+
+      # The operator who typed it gets the modal…
+      assert_push("event", %{kind: :who_reply, target: "#snap"})
+
+      # …and the other device of the same account gets nothing. Removing the
+      # addressing turns exactly this assertion red: the bystander's join is
+      # a plain second socket, which is what the report describes.
+      assert bystander_verdict(bystander) == :nothing
+    end
+
+    test "a /whois bundle reaches the requesting connection only", %{
+      irc_server: irc_server,
+      socket: socket,
+      user: user,
+      network: network
+    } do
+      bystander = start_bystander(user)
+
+      ref = push(socket, "whois", %{"network_id" => network.id, "nick" => "alice"})
+      assert_reply(ref, :ok)
+      {:ok, _} = IRCServer.wait_for_line(irc_server, &(&1 == "WHOIS alice\r\n"), 1_000)
+
+      IRCServer.feed(
+        irc_server,
+        ":irc.test.org 311 grappa-snap alice user host * :Alice\r\n"
+      )
+
+      IRCServer.feed(irc_server, ":irc.test.org 318 grappa-snap alice :End of /WHOIS list.\r\n")
+
+      assert_push("event", %{kind: :whois_bundle, target: "alice", source: :user})
+      assert bystander_verdict(bystander) == :nothing
+    end
+
+    # The addressed topic must never be reachable by typing it. It is
+    # deliberately absent from `Topic.parse/1`'s grammar, so a client that
+    # learned (or guessed) another connection's ref still cannot subscribe to
+    # the replies addressed to it.
+    test "the per-connection topic is not joinable", %{user: user, socket: socket} do
+      assert {:error, %{error: "unknown_topic"}} =
+               user.name
+               |> build_socket(subject: {:user, user.id})
+               |> subscribe_and_join(Topic.socket(user.name, socket.assigns.socket_ref), %{})
+    end
+  end
+
+  # Joins a second socket for `user` on the user topic, from its own process
+  # so its pushes land in ITS mailbox rather than the test's. Returns a task
+  # that resolves to `:leaked` if any informational reply arrived, `:nothing`
+  # otherwise. Blocks until the join has completed, so the caller can issue
+  # the command knowing the bystander was already listening — a bystander that
+  # joined late would report `:nothing` for the wrong reason.
+  defp start_bystander(user) do
+    parent = self()
+
+    task =
+      Task.async(fn ->
+        {:ok, _, _} =
+          user.name
+          |> build_socket(subject: {:user, user.id})
+          |> subscribe_and_join(Topic.user(user.name), %{})
+
+        send(parent, {:bystander_joined, self()})
+
+        receive do
+          %Phoenix.Socket.Message{event: "event", payload: %{kind: kind}}
+          when kind in [:who_reply, :whois_bundle, :names_reply, :whowas_bundle] ->
+            :leaked
+        after
+          300 -> :nothing
+        end
+      end)
+
+    assert_receive {:bystander_joined, _}, 2_000
+    task
+  end
+
+  defp bystander_verdict(task), do: Task.await(task, 2_000)
 
   describe "join rejects malformed topics" do
     test "rejects Phase 1 grappa:network: shape (regression check)" do

--- a/test/grappa_web/channels/grappa_channel_test.exs
+++ b/test/grappa_web/channels/grappa_channel_test.exs
@@ -2710,12 +2710,20 @@ defmodule GrappaWeb.GrappaChannelTest do
   # by SUBJECT and has no per-connection dimension, so one question produced a
   # modal on every device of that subject.
   #
-  # The oracle here is a REAL second connection, not a bare PubSub subscriber:
-  # a bystander socket joined to the same user topic, in its own process (the
-  # transport pid is whoever calls `subscribe_and_join/3`, so a second socket
-  # in THIS process would be indistinguishable from the first). It reports
-  # what it saw; the requesting socket must see the reply and the bystander
-  # must see nothing.
+  # The oracle is the FAN-OUT ITSELF, observed as a plain `Phoenix.PubSub`
+  # subscriber on the user topic — which is structurally what a second device
+  # is, since the fan-out reaches other clients precisely by being published
+  # there. Two shapes arrive in this one mailbox and they are distinguishable:
+  # the joined channel delivers `%Phoenix.Socket.Message{}` (what the asking
+  # socket sees), the plain subscription delivers `%Phoenix.Socket.Broadcast{}`
+  # (what every other device would have seen).
+  #
+  # A second REAL socket is deliberately NOT used here:
+  # `Phoenix.ChannelTest.socket/3` may only be called from the test process, so
+  # a bystander cannot own its own mailbox, and a second socket in THIS process
+  # is indistinguishable from the first. The two-real-clients demonstration
+  # lives in `cicchetto/e2e/tests/issue1088-addressed-informational-replies.spec.ts`,
+  # which drives two browser contexts on one account.
   describe "#1088 — addressed informational replies" do
     setup do
       {irc_server, port} = start_irc_server()
@@ -2727,17 +2735,19 @@ defmodule GrappaWeb.GrappaChannelTest do
         |> build_socket(subject: {:user, user.id})
         |> subscribe_and_join(Topic.user(user.name), %{})
 
+      # The bystander's ear. Subscribed AFTER the join so it cannot swallow the
+      # after-join snapshot, and BEFORE any verb is issued so it cannot miss a
+      # reply for having arrived late.
+      :ok = Phoenix.PubSub.subscribe(Grappa.PubSub, Topic.user(user.name))
+
       %{irc_server: irc_server, socket: socket, user: user, network: network}
     end
 
-    test "a /who reply reaches the requesting connection only", %{
+    test "a /who reply reaches the asking socket and is NOT fanned out", %{
       irc_server: irc_server,
       socket: socket,
-      user: user,
       network: network
     } do
-      bystander = start_bystander(user)
-
       ref = push(socket, "who", %{"network_id" => network.id, "channel" => "#snap"})
       assert_reply(ref, :ok)
       {:ok, _} = IRCServer.wait_for_line(irc_server, &(&1 == "WHO #snap\r\n"), 1_000)
@@ -2752,33 +2762,30 @@ defmodule GrappaWeb.GrappaChannelTest do
       # The operator who typed it gets the modal…
       assert_push("event", %{kind: :who_reply, target: "#snap"})
 
-      # …and the other device of the same account gets nothing. Removing the
-      # addressing turns exactly this assertion red: the bystander's join is
-      # a plain second socket, which is what the report describes.
-      assert bystander_verdict(bystander) == :nothing
+      # …and nothing was published where the other devices are listening. This
+      # is the assertion the defect killed: pre-#1088 the same reply arrived
+      # here too, on every connection of the account.
+      refute_receive %Phoenix.Socket.Broadcast{payload: %{kind: :who_reply}}, 200
     end
 
-    test "a /whois bundle reaches the requesting connection only", %{
+    test "a /whois bundle reaches the asking socket and is NOT fanned out", %{
       irc_server: irc_server,
       socket: socket,
-      user: user,
       network: network
     } do
-      bystander = start_bystander(user)
-
       ref = push(socket, "whois", %{"network_id" => network.id, "nick" => "alice"})
       assert_reply(ref, :ok)
       {:ok, _} = IRCServer.wait_for_line(irc_server, &(&1 == "WHOIS alice\r\n"), 1_000)
 
-      IRCServer.feed(
-        irc_server,
-        ":irc.test.org 311 grappa-snap alice user host * :Alice\r\n"
-      )
-
+      IRCServer.feed(irc_server, ":irc.test.org 311 grappa-snap alice user host * :Alice\r\n")
       IRCServer.feed(irc_server, ":irc.test.org 318 grappa-snap alice :End of /WHOIS list.\r\n")
 
+      # #606 survives: the bundle still carries `source: :user`, so the
+      # scrollback card and the rail cache stay disjoint on the client that
+      # asked. Addressing is a different axis from origin.
       assert_push("event", %{kind: :whois_bundle, target: "alice", source: :user})
-      assert bystander_verdict(bystander) == :nothing
+
+      refute_receive %Phoenix.Socket.Broadcast{payload: %{kind: :whois_bundle}}, 200
     end
 
     # The addressed topic must never be reachable by typing it. It is
@@ -2792,39 +2799,6 @@ defmodule GrappaWeb.GrappaChannelTest do
                |> subscribe_and_join(Topic.socket(user.name, socket.assigns.socket_ref), %{})
     end
   end
-
-  # Joins a second socket for `user` on the user topic, from its own process
-  # so its pushes land in ITS mailbox rather than the test's. Returns a task
-  # that resolves to `:leaked` if any informational reply arrived, `:nothing`
-  # otherwise. Blocks until the join has completed, so the caller can issue
-  # the command knowing the bystander was already listening — a bystander that
-  # joined late would report `:nothing` for the wrong reason.
-  defp start_bystander(user) do
-    parent = self()
-
-    task =
-      Task.async(fn ->
-        {:ok, _, _} =
-          user.name
-          |> build_socket(subject: {:user, user.id})
-          |> subscribe_and_join(Topic.user(user.name), %{})
-
-        send(parent, {:bystander_joined, self()})
-
-        receive do
-          %Phoenix.Socket.Message{event: "event", payload: %{kind: kind}}
-          when kind in [:who_reply, :whois_bundle, :names_reply, :whowas_bundle] ->
-            :leaked
-        after
-          300 -> :nothing
-        end
-      end)
-
-    assert_receive {:bystander_joined, _}, 2_000
-    task
-  end
-
-  defp bystander_verdict(task), do: Task.await(task, 2_000)
 
   describe "join rejects malformed topics" do
     test "rejects Phase 1 grappa:network: shape (regression check)" do


### PR DESCRIPTION
## The defect

An operator whose IRC client issued `/who` kept seeing the WHO modal open in
cicchetto, on a device that had asked for nothing.

The cause is structural, not a stray call site. `who_reply`, `names_reply`,
`whois_bundle`, `whowas_bundle`, `server_reply`, `banlist_bundle` and
`links_bundle` all ride `Topic.user/1`, and the whole topic vocabulary
partitions by user, network and channel — never by connection. There was no
dimension in which "the client that asked" could be expressed, so the answer to
one question was delivered to every device of the account.

## The shape of the fix

Suppress the fan-out rather than teach every client to ignore what it did not
ask for.

- `UserSocket.connect/3` mints a `socket_ref` per WebSocket, on **both** the
  user and the visitor branch.
- The user-topic channel subscribes to the new `Topic.socket/2` in `join/3`.
  That topic is deliberately absent from `Topic.parse/1`, so it cannot be
  reached by typing it — a foreign topic means no fastlane, which is the same
  idiom `AdminChannel` uses for #215.
- `Broadcaster.to_requester/3` publishes there.
- `reply_to` rides the per-verb `*_pending` accumulator — the only structure
  that already spans the gap between a request and the numerics that answer it
  minutes later, exactly as #606's `source` does.
- `nil` falls back to the per-user fan-out (the pre-#1088 behaviour). An
  accumulator primed before a hot deploy, or a reply nobody asked for, is shown
  too widely rather than lost. The degradation direction is deliberate.

## No new field on the wire — and that is on purpose

The issue floated carrying a client id on the wire. It is not needed, and this
PR does not add it: the requesting connection **is** the socket that carried the
command, so the server already knows it without being told. `wireTypes.ts` and
cicchetto are untouched — zero lines. The frame arrives on the same channel,
with the same `"event"` name and the same payload, at the same `userTopic.ts`
arm.

This is called out explicitly because a reviewer will look for the new field the
issue hypothesised and needs to find the reason it is absent. It also covers the
reported case, where the requester is not a cicchetto client at all: no modal
opens anywhere.

## Two scope judgements

**`links_bundle` is INCLUDED — this is a correction of the issue.** The issue's
table declared itself exhaustive and counted six arms. There are seven:
`userTopic.ts:1410` (#238) has the identical shape and was missing from the
list.

**`lusers_bundle` is EXCLUDED, and #248 does not regress.** It is the one member
whose accumulator is created by the *reply* rather than the request — bahamut
auto-emits at connect and the 251 resets it, so there is no requester to address
it to. The welcome auto-emit stays suppressed by #248's client-side
consume-once latch, which is untouched. The issue names this as a non-goal.

## Honest limits (not gaps)

- `whois_pending` closes per nick: two clients asking about the same nick inside
  the same 318 window collapse, and the last one wins. This is the same collapse
  #606 accepted for `source`.
- A reply whose requester disconnected before the ircd answered is dropped, not
  shown to the survivors. The question died with the connection that asked it,
  and a modal has no meaning on a page that never issued the command.

## Evidence

- **Unit oracle, red measured — not predicted.** Reverting
  `Broadcaster.to_requester/3` to the pre-#1088 fan-out kills exactly the two
  new `refute_receive` assertions in `GrappaChannelTest` and nothing else:
  `154 tests, 2 failures`, both failing on the `refute_receive` line. Restored,
  the file is `154 tests, 0 failures`.
- **e2e green with a control red.** The new spec
  (`issue1088-addressed-informational-replies.spec.ts`, driving two browser
  contexts on one account) passes; removing the cure kills only its line 77
  (`Expected: 0, Received: 1` on the bystander's WHO modal) while the asker and
  the liveness probe stay green. The spec adds **exactly one test**.
- **Full `scripts/check.sh` green** on the rebased tree — format, Dialyzer
  (`Failed Modules: 0`), Credo, Sobelow, zero compile warnings, full ExUnit.

### What I will not claim

The full `scripts/integration.sh` suite passed `674 passed (31.2m)` rc=0, but on
base `7a907188` — **before** the rebase onto `da3900e2`. That gate stands on a
dead base. `git log 7a907188..origin/main` over the files this PR touches is
empty, so the risk is low, but it is not a green on this tree: **CI is the only
e2e gate on the rebased tree.**

I also do not assert the "674 vs 672 = +2 new specs ran" arithmetic that was
suggested: this PR's spec adds one test, not two, and I never measured main's
own count. The proof that the spec ran is the named line in the log, not a
difference between two numbers I did not both measure.
