### PR TITLE
grappa(#1075): record the jail measurement, and give the overview a Wire module

### DIFF
--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -441,6 +441,21 @@ export type AdminEventsWireEvent =
   | AdminEventsWireLoginThrottledEvent
   | AdminEventsWireWebSessionSeveredEvent;
 
+// === Grappa.AdminOverview.Wire ===
+
+export type AdminOverviewWireVisitors = {
+  total: number;
+  live: number;
+};
+
+export type AdminOverviewWireT = {
+  sessions: number;
+  visitors: AdminOverviewWireVisitors;
+  hostname: string;
+  loadavg: number | null;
+  version: string;
+};
+
 // === Grappa.Admission.NetworkCircuit.AdminWire ===
 
 export type AdmissionNetworkCircuitAdminWireT = {

--- a/config/config.exs
+++ b/config/config.exs
@@ -575,6 +575,11 @@ config :logger, :console,
 # alarms, `disksup` does the same for filesystem occupancy. Nothing in grappa
 # subscribes to those alarms or acts on them, so all they can do is log at the
 # operator. One sampler in, no alarm traffic.
+#
+# This is a necessity, not a preference, and it was measured: starting os_mon
+# whole inside the production jail raises
+# `{set,{system_memory_high_watermark,[]}}` IMMEDIATELY (vjt, 2026-08-09).
+# Turning the two services off is what keeps that alarm out of the log.
 config :os_mon,
   start_memsup: false,
   start_disksup: false

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -34718,11 +34718,36 @@ change's red, where the auth-gate assertions failed on "expected 403, got
 nginx `try_files` produced; different owner. Not addressed here — it is a
 router catch-all question, not an admin-bar one.
 
-**Not established.** That any of this works inside the FreeBSD jail. The
-issue's "Done when" asks for it explicitly and it has not been done: `cpu_sup`
-was exercised only in the Linux dev container, and its FreeBSD port program
-is a different binary. Whether `avg1/0` answers inside a jail is an
-expectation here, not a measurement.
+**Since measured, in the production jail (vjt, 2026-08-09).** This paragraph
+originally recorded the jail as unverified — true when written, and the reason
+the probe happened. Probed with the jail's native Erlang, os_mon started by
+hand:
+
+- **It works, and the 256 divisor is confirmed at the right end.** `avg1=135`
+  / `avg5=165` against `sysctl vm.loadavg` reporting `{0.45 0.62 0.69}` on the
+  same box: `165/256 = 0.64` against `0.62` lands on the nose, while
+  `135/256 = 0.53` against `0.45` drifts because the two reads are not
+  simultaneous. The 5-minute agreement is what identifies the scale — the
+  divisor is a measurement now, not an inherited constant.
+- **`:os_mon` is absent from the release.** Not in
+  `_build/prod/rel/grappa/lib` in prod OR in the dryrun; it lives only in the
+  jail's system Erlang, so a release-run node answers `undef` on
+  `cpu_sup:avg1`. `extra_applications` is what puts it in the artifact — which
+  is why the feature works at all, and why it cannot ship hot.
+- **This is a COLD deploy, for three independent reasons.**
+  `Grappa.Deploy.Preflight` trips on `mix.exs` (`mix_deps?`),
+  `lib/grappa/application.ex` (`application?`, the `boot/0` call site) and
+  `config/config.exs` (`config?`). Dropping any one of them would not make it
+  hot.
+- **`memsup` off is a necessity.** Started whole, os_mon raises
+  `{set,{system_memory_high_watermark,[]}}` in that jail immediately.
+- **The host-load reading is confirmed.** `sysctl vm.loadavg` returns the same
+  value inside the jail and on the host, so the label #1073 owes its reader is
+  correctness, not courtesy.
+
+**Still not established.** The full integration and e2e suites, which were not
+run for this change.
+
 ## 2026-08-09 — #1088: an informational reply belongs to a connection, not a subject
 
 The report is an operator whose IRC client kept opening the WHO modal in

--- a/lib/grappa/admin_overview.ex
+++ b/lib/grappa/admin_overview.ex
@@ -102,21 +102,10 @@ defmodule Grappa.AdminOverview do
   use Boundary,
     top_level?: true,
     deps: [Grappa.LiveIntrospection, Grappa.Version, Grappa.Visitors],
-    exports: []
+    exports: [Wire]
 
+  alias Grappa.AdminOverview.Wire
   alias Grappa.{LiveIntrospection, Version, Visitors}
-
-  @typedoc """
-  The admin-bar payload. `loadavg` is `nil` when the sampler is
-  unavailable — the honesty signal, distinct from a measured `0.0`.
-  """
-  @type t :: %{
-          sessions: non_neg_integer(),
-          visitors: %{total: non_neg_integer(), live: non_neg_integer()},
-          hostname: String.t(),
-          loadavg: float() | nil,
-          version: String.t()
-        }
 
   @key {__MODULE__, :push_interval_ms}
   @default_push_interval_ms 5_000
@@ -152,7 +141,7 @@ defmodule Grappa.AdminOverview do
   The current admin-bar payload. One registry scan + one `COUNT` + two
   cheap machine reads; messages no session pid.
   """
-  @spec snapshot() :: t()
+  @spec snapshot() :: Wire.t()
   def snapshot do
     live = LiveIntrospection.count_live()
 

--- a/lib/grappa/admin_overview.ex
+++ b/lib/grappa/admin_overview.ex
@@ -51,13 +51,35 @@ defmodule Grappa.AdminOverview do
 
   `:cpu_sup.avg1/0` (os_mon) rather than `/proc/loadavg`: production is a
   FreeBSD jail, which has no `/proc`. cpu_sup shells out to a per-OS port
-  program, which is the reason to pay for the dependency. `:os_mon` is in
-  `extra_applications`; `config/config.exs` keeps `memsup`/`disksup` off,
-  since they raise alarms on thresholds nothing here acts on.
+  program, which is the reason to pay for the dependency.
+
+  **The 256 divisor is measured, not folklore.** `avg1/0` returns the load
+  as a fixed-point integer scaled by 256, and that scaling was checked
+  inside the production jail against `sysctl vm.loadavg` on the same box at
+  the same moment (vjt, 2026-08-09): `avg1=135` against a reported `0.45`
+  (135/256 = 0.53), and `avg5=165` against `0.62` (165/256 = 0.64). The 1
+  minute figure drifts because the two reads are not simultaneous; the 5
+  minute one lands on the nose, which is what identifies the scale.
+
+  **`:os_mon` is not in the release without `extra_applications`.** The
+  same probe found os_mon absent from `_build/prod/rel/grappa/lib` in both
+  prod and the dryrun — it exists only in the jail's system Erlang, so a
+  release-run node answers `undef` on `cpu_sup:avg1`. Adding it to
+  `extra_applications` in `mix.exs` is what puts it in the artifact, and
+  that makes this feature a **COLD deploy** — see
+  `Grappa.Deploy.Preflight`, which trips on `mix.exs` (`mix_deps`),
+  `lib/grappa/application.ex` (`application`, the `boot/0` call site) and
+  `config/config.exs` (`config`). Three independent reasons; none of them
+  is hot-reloadable.
+
+  `config/config.exs` keeps `memsup`/`disksup` off, and that is a
+  necessity rather than tidiness: with os_mon started whole, that jail
+  raises `{set,{system_memory_high_watermark,[]}}` immediately.
 
   A jail shares the host kernel, so the number is the **host's** load, not
-  grappa's. Clients must label it accordingly or an operator will read it
-  as "grappa is busy".
+  grappa's — confirmed by the same probe, `sysctl vm.loadavg` reading
+  identically inside the jail and on the host. Clients must label it
+  accordingly or an operator will read it as "grappa is busy".
 
   An unavailable sampler yields `nil`, never `0.0` — "we cannot measure"
   and "the box is idle" are different facts, and only one of them should

--- a/lib/grappa/admin_overview/wire.ex
+++ b/lib/grappa/admin_overview/wire.ex
@@ -1,0 +1,62 @@
+defmodule Grappa.AdminOverview.Wire do
+  @moduledoc """
+  Wire shape for the admin top bar's projection (#1075 / #1073).
+
+  Exists so the payload has ONE declared shape that both ends read from.
+  `mix grappa.gen_wire_types` globs `**/*wire.ex` and mirrors the typespecs
+  below into `cicchetto/src/lib/wireTypes.ts`, and `scripts/check.sh` runs
+  that task with `--check` — so a field added here without regenerating
+  fails the build, and cic cannot drift into a hand-written copy of this
+  map. That drift gate is the whole reason this module is not just a
+  `@type` sitting on `Grappa.AdminOverview`.
+
+  ## `loadavg` is nullable ON PURPOSE
+
+  `float() | nil`, and the `nil` is load-bearing rather than defensive:
+  `:cpu_sup` may be unreachable (os_mon absent from the release, the port
+  program missing for the platform), and "cannot measure" is a different
+  fact from "the box is idle". Collapsing it to `0.0` anywhere along this
+  wire — here, in the JSON, or in the client's formatter — renders a calm
+  bar for a machine nobody can see. The generated TS type carries the
+  `| null` so a client that forgets has to be told by its own compiler.
+
+  ## `visitors` is a PAIR, `sessions` is not
+
+  Not an oversight and not asymmetry for its own sake. `visitors` carries
+  DB `total` alongside live `live` because the Visitors tab carries that
+  same duality (`live_state: null` is its U-0 honesty signal), and the two
+  are allowed to disagree — the disagreement is the diagnostic. `sessions`
+  has no DB twin to report: the Sessions tab is registry-driven by
+  construction ("one row = one live pid") and routes the DB-intent signal
+  to `/admin/visitors` and `/admin/credentials` instead. See
+  `Grappa.AdminOverview`'s moduledoc for the pair that was drafted, and
+  withdrawn, before this shape settled.
+  """
+
+  @typedoc """
+  Visitor counts: `total` is DB rows, `live` is DISTINCT visitors holding
+  at least one registered `Session.Server`. Neither is computed from the
+  other.
+  """
+  @type visitors :: %{
+          total: non_neg_integer(),
+          live: non_neg_integer()
+        }
+
+  @typedoc """
+  The admin-bar payload, served by `GET /admin/overview` and pushed as
+  `"overview"` on the admin channel — the same map through both doors.
+
+  `hostname` is the node's own host. `loadavg` is the 1-minute average and
+  is the HOST's, not grappa's: a jail shares the host kernel (measured in
+  production, 2026-08-09), so a client MUST label it or an operator reads
+  it as "grappa is busy". `nil` means the sampler was unreachable.
+  """
+  @type t :: %{
+          sessions: non_neg_integer(),
+          visitors: visitors(),
+          hostname: String.t(),
+          loadavg: float() | nil,
+          version: String.t()
+        }
+end

--- a/lib/mix/tasks/grappa/gen_wire_types.ex
+++ b/lib/mix/tasks/grappa/gen_wire_types.ex
@@ -526,6 +526,10 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
               :integer,
               :non_neg_integer,
               :pos_integer,
+              # #1073 — the admin-bar loadavg is the first float on the wire.
+              # Absent from this list it never reached `do_render/1` stripped,
+              # and the task died on the raw abstract-format tuple.
+              :float,
               :boolean,
               :map,
               :binary,
@@ -642,6 +646,9 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
   defp do_render({:integer, _, []}), do: "number"
   defp do_render({:non_neg_integer, _, []}), do: "number"
   defp do_render({:pos_integer, _, []}), do: "number"
+  # JSON has ONE numeric type, so a float lands on `number` exactly as the
+  # integers do. TypeScript cannot express the int/float split either.
+  defp do_render({:float, _, []}), do: "number"
   defp do_render({:boolean, _, []}), do: "boolean"
   defp do_render({:binary, _, []}), do: "string"
   defp do_render({:atom, _, []}), do: "string"

--- a/test/mix/tasks/grappa/gen_wire_types_test.exs
+++ b/test/mix/tasks/grappa/gen_wire_types_test.exs
@@ -59,6 +59,21 @@ defmodule Mix.Tasks.Grappa.GenWireTypesTest do
       assert GenWireTypes.render_type([{:remote_type, [], [String, :t]}]) == "string[]"
     end
 
+    # #1073 — the admin-bar loadavg is the first `float()` on the wire, and it
+    # is nullable on purpose (`nil` = the sampler was unreachable, which is a
+    # different fact from a measured `0.0`). Before this, `float()` was absent
+    # from the primitive allowlist in `strip_typespec_metadata/1`, so it never
+    # reached `do_render/1` in stripped form and the task died with a
+    # FunctionClauseError on the raw Erlang abstract-format tuple. JSON has one
+    # numeric type, so it renders like the integers already do.
+    test "renders float() as number" do
+      assert GenWireTypes.render_type({:float, [], []}) == "number"
+    end
+
+    test "renders float() | nil as number | null" do
+      assert GenWireTypes.render_type({:|, [], [{:float, [], []}, nil]}) == "number | null"
+    end
+
     test "renders bare map() as Record<string, unknown>" do
       assert GenWireTypes.render_type({:map, [], []}) == "Record<string, unknown>"
     end


### PR DESCRIPTION
## Summary

Follow-up to #1075, which is already merged (`da3900e2`). Three commits,
no behaviour change to the running system:

1. **`docs(#1075)`** — write down where the `256` divisor came from, and state
   the deploy class.
2. **`fix(codegen)`** — the wire-type generator did not know about `float()`.
3. **`feat(#1075)`** — give the admin overview a `*.Wire` module so cic gets a
   generated type instead of a hand-written one.

## 1. The code was already right; the reasons were not written down

`derive_loadavg/1` already divided by 256 and `:os_mon` was already in
`extra_applications`. What was missing is that both sat there on faith. vjt
probed the production jail with its native Erlang (2026-08-09) — no worker
goes near m42 — and the numbers now live next to the code:

- **The 256 divisor is confirmed at the right end.** `avg1=135` / `avg5=165`
  against `sysctl vm.loadavg` reporting `{0.45 0.62 0.69}` on the same box.
  `165/256 = 0.64` vs `0.62` lands on the nose; `135/256 = 0.53` vs `0.45`
  drifts only because the two reads are not simultaneous. The 5-minute
  agreement is what identifies the scale.
- **`:os_mon` is absent from the release.** Not in
  `_build/prod/rel/grappa/lib` in prod OR in the dryrun — it lives only in the
  jail's system Erlang, so a release-run node answers `undef` on
  `cpu_sup:avg1`. `extra_applications` is what puts it in the artifact.
- **Turning `memsup`/`disksup` off is a necessity, not tidiness.** Started
  whole, os_mon raises `{set,{system_memory_high_watermark,[]}}` in that jail
  immediately.

**Deploy class, which nothing stated before: #1075 ships COLD, for three
independent reasons.** `Grappa.Deploy.Preflight` trips on `mix.exs`
(`mix_deps?`), `lib/grappa/application.ex` (`application?`, the `boot/0` call
site) and `config/config.exs` (`config?`). Dropping any one would not make it
hot.

The DESIGN_NOTES paragraph that said the jail was unverified is **replaced**
rather than appended to — leaving it would have parked a statement that is no
longer true next to its own refutation. What survives is a narrower "still not
established" naming only the integration and e2e suites, which really were not
run.

## 2. `float()` was missing from the codegen

`float()` was absent from the primitive allowlist in
`strip_typespec_metadata/1`, so it never reached `do_render/1` in stripped form
and `mix grappa.gen_wire_types` died with a `FunctionClauseError` on the raw
Erlang abstract-format tuple `{:type, _, :float, []}`. Nothing had noticed
because no Wire typespec had ever used a float — the admin-bar loadavg is the
first, and it is `float() | nil`.

Renders as `number`, exactly as the three integer types already do: JSON has
one numeric type and TypeScript cannot express the int/float split either. Two
tests, one for the bare float and one for the nullable union that is the actual
use. The red was read first: 5 failures, `FunctionClauseError`.

## 3. A Wire module, so cic cannot drift

The payload had no `*.Wire` module, so cic had no generated type and the client
half (#1073) was about to hand-write one — precisely the drift
`mix grappa.gen_wire_types --check` exists to prevent, and CLAUDE.md puts wire
conversion on the context rather than the client.

The generated type keeps **`loadavg: number | null`**, which is the point of
routing it through here: a client that forgets the unavailable case is told by
its own compiler instead of rendering a confident `0.00` for a machine nobody
can measure.

`Grappa.AdminOverview` now specs `snapshot/0` as `Wire.t()` and exports `Wire`
from its boundary. The module deliberately does **not** `use Boundary` itself —
that would form its own boundary and it could not be exported, which is exactly
what Boundary said when it did. Same shape as `Grappa.SessionLog.Wire`.

The map `snapshot/0` builds is byte-identical.

## Test plan

- [x] Red read before the codegen fix: 5 failures, `FunctionClauseError` on the
      abstract-format tuple.
- [x] `scripts/check.sh` green on the committed tree, base `da3900e2` still
      current at push time — compile (`--warnings-as-errors`, Boundary),
      format, Credo strict (`found no issues`), deps.audit, Sobelow, doctor,
      `5575 tests / 0 failures`, Dialyzer `Total errors: 0`, `mix docs`, the
      wire-type drift gate, full bats set (`0` not-ok). Working tree clean
      before and after.
- [ ] No integration or e2e run — the stack lane belongs to another worker.
- [ ] Nothing re-verified on m42. The jail numbers quoted above are vjt's
      measurement, not this branch's.
