### PR TITLE
Claim --help at the dispatcher, name the bad switch in the tasks (#1086)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ grappa runs as a single container against a sqlite DB. There is no config file â
 ```sh
 bin/grappa help                # every verb (boot-time + live-state + debug)
 bin/grappa help <verb>         # per-verb usage
+bin/grappa <verb> --help       # the same per-verb usage, as a flag (or -h)
 bin/grappa create-user ...     # boot-time verb (mix task inside the container)
 bin/grappa list-visitors       # live-state verb (RPC into the running BEAM)
 bin/grappa remote-shell        # iex --remsh into the live node

--- a/bin/grappa
+++ b/bin/grappa
@@ -117,6 +117,31 @@ verb_field() {
 # Kebab → snake conversion. Pure mechanical — no per-verb hardcoding.
 kebab_to_snake() { tr '-' '_' <<<"$1"; }
 
+# #1086 — true when `--help` or `-h` appears anywhere in the argument
+# list. Neither layer used to claim the flag: this dispatcher knew help
+# only as a VERB (`bin/grappa help <verb>`), and the boot tasks parse
+# `strict:`, which drops an unrecognised switch silently and then dies on
+# the first required option with a raw KeyError traceback. Worse, the
+# rpc and debug verbs took the flag for a positional argument — a live
+# `delete-visitor --help` used to RPC `delete_visitor!("--help")` at the
+# running BEAM. Claiming it here is one rule for all verbs, including the
+# ones that never reach a mix task.
+#
+# Scanned anywhere rather than in first position only, because
+# `bin/grappa bind-network --user vjt --help` is how an operator asks
+# once they are already mid-command. The cost is that an option VALUE
+# spelled exactly `--help` reads as a help request; no switch on any
+# verb takes a value that could plausibly be spelled that way.
+wants_help() {
+    local arg
+    for arg in "$@"; do
+        case "$arg" in
+            -h | --help) return 0 ;;
+        esac
+    done
+    return 1
+}
+
 # --- helpers --------------------------------------------------------------
 
 mix_task() {
@@ -473,6 +498,17 @@ dispatch_help() {
 dispatch() {
     if [ $# -eq 0 ]; then
         help_top
+        exit 0
+    fi
+    # #1086 — the flag form of help, routed to the SAME per-verb path the
+    # verb form uses. A bare `--help` with no verb is the top banner;
+    # anything else is the first argument's help. `dispatch_help` gates
+    # the verb, so an unknown one still exits 64.
+    if wants_help "$@"; then
+        case "$1" in
+            -h | --help) help_top ;;
+            *) dispatch_help "$1" ;;
+        esac
         exit 0
     fi
     local verb=$1

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -34791,3 +34791,75 @@ the full integration suite. The per-surface behaviour is asserted for `/who` and
 `/whois` at the channel door and for `/who` at the session level; the other
 eight verbs are believed on the strength of a shared mechanism, not measured one
 by one.
+
+---
+
+## 2026-08-09 — #1086: two layers each declined to claim `--help`
+
+`bin/grappa bind-network --help` crashed with a raw Elixir traceback —
+`** (KeyError) key :user not found in: []`, five frames of mix internals, at a
+self-hoster. The flag was nobody's: the dispatcher knew help only as a VERB
+(`bin/grappa help <verb>`), so a `--help` after a verb was passed through as an
+ordinary argument, and the boot tasks parse `strict:`, which drops an
+unrecognised switch into the `invalid` element every caller was discarding. The
+first `Keyword.fetch!` for the option that never got set then raised. A plain
+typo (`--nework azzurra`) produced the identical dump for the identical reason.
+
+**The blast radius was wider than the report, and in a worse direction.** The
+issue's table counts seven mix tasks whose `run/1` reaches `Keyword.fetch!`.
+But eleven of the dispatcher's twenty-one verbs never reach a mix task at all,
+and those took the flag for a POSITIONAL argument. Measured against the bats
+docker stub, `bin/grappa delete-visitor --help` RPC'd
+`Grappa.Operator.delete_visitor!("--help")` at the live BEAM and exited 0 — a
+help request reaching a mutating verb on the running node. It was harmless only
+because no visitor has that UUID.
+
+**The cure is one point per layer, not one point.** `--help` belongs to the
+dispatcher: it is the only layer that can serve all twenty-one verbs, and for
+the eleven non-mix ones no Elixir layer exists to fix. Missing-required and
+unknown-switch belong to the tasks: the dispatcher does not know any verb's
+switch table and could only learn it by duplicating it, a parallel structure
+that would drift at the first new switch — and the tasks are reachable
+directly as `scripts/mix.sh grappa.bind_network ...`, which is the invocation
+their own moduledocs document, bypassing the dispatcher entirely. Inside the
+Elixir layer the cure stays single: `Mix.Tasks.Grappa.OptionParsing` was
+already the shared home and already used `Mix.raise` for malformed input, so
+`parse!/3` joined it rather than nine patched tasks.
+
+**Nine tasks, not the seven the issue counts.** `repair_passwords` and
+`set_network_caps` have no required options and so never met the KeyError, but
+they had the silent half: a misspelled `--max-visitor-session` was discarded
+and surfaced as "no changes specified", which names the wrong thing — the
+operator did specify a change, they misspelled it. They route through the same
+call with an empty required list. `gen_wire_types` stays out: it parses
+non-strict, is codegen rather than an operator verb, and is absent from the
+verb table.
+
+**An unrecognised switch is reported in preference to the required option it
+failed to set.** `--nework azzurra` names the typo. Saying `--network` is
+missing would be true and useless — it would send the operator hunting for a
+flag they believe they typed. Unknown-versus-unparseable is told apart by
+whether the reported spelling appears in the caller's own switch table,
+comparing STRINGS only; that module already carries a long note on why it
+refuses `String.to_existing_atom`, and this stays on the safe side of it.
+
+**The flag is scanned anywhere in the argument list**, not in first position
+only, because `bin/grappa bind-network --user vjt --help` is how an operator
+asks once already mid-command. The cost is that an option VALUE spelled exactly
+`--help` reads as a help request. No switch on any verb takes a value that
+could plausibly be spelled that way; this is a judgement, not a measurement.
+
+**Three tests pinned the bug as the contract.** `bind_network_test.exs` and
+`create_user_test.exs` each asserted `assert_raise KeyError` for a missing
+required option. That is why a defect this shallow survived a suite that
+covered it: the crash was the documented behaviour. They now assert the message
+names the option.
+
+**Not closed, escalated.** For the ten boot verbs the dispatcher's help path is
+`exec scripts/mix.sh --env=dev help grappa.<task>`, which reads `@shortdoc` /
+`@moduledoc` from inside the container — so it needs the container UP. With the
+instance down, which is exactly when a self-hoster reaches for `--help`, the
+acceptance criterion "prints that verb's help and exits 0, for every verb" does
+not hold. Closing it means inline help text for the boot verbs, doubling the
+surface that has to stay in lockstep with the `@shortdoc`s. That is a product
+call, deliberately not taken here.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -36,6 +36,7 @@ worktree volumes via oneshot bindings (same machinery as
 ```
 bin/grappa help                  # list verbs grouped by category
 bin/grappa help <verb>           # per-verb help
+bin/grappa <verb> --help         # same, as a flag (or -h) — anywhere in the args
 
 # Boot-time verbs (mix tasks; auto-detect MIX_ENV from container):
 bin/grappa create-user --name <user> --password <pw>

--- a/lib/mix/tasks/grappa.add_server.ex
+++ b/lib/mix/tasks/grappa.add_server.ex
@@ -60,12 +60,14 @@ defmodule Mix.Tasks.Grappa.AddServer do
 
   @switches [network: :string, server: :string, tls: :boolean, priority: :integer, source: :string]
 
+  @required [:network, :server]
+
   # De-facto IRC-over-TLS port per RFC 7194 + ircv3 conventions.
   @tls_port 6697
 
   @impl Mix.Task
   def run(args) do
-    {opts, _, _} = OptionParser.parse(args, strict: @switches)
+    opts = OptionParsing.parse!(args, @switches, @required)
     slug = Keyword.fetch!(opts, :network)
     server = Keyword.fetch!(opts, :server)
 

--- a/lib/mix/tasks/grappa.bind_network.ex
+++ b/lib/mix/tasks/grappa.bind_network.ex
@@ -80,12 +80,14 @@ defmodule Mix.Tasks.Grappa.BindNetwork do
     source: :string
   ]
 
+  @required [:user, :network, :server, :nick, :auth]
+
   # De-facto IRC-over-TLS port per RFC 7194 + ircv3 conventions.
   @tls_port 6697
 
   @impl Mix.Task
   def run(args) do
-    {opts, _, _} = OptionParser.parse(args, strict: @switches)
+    opts = OptionParsing.parse!(args, @switches, @required)
 
     user_name = Keyword.fetch!(opts, :user)
     slug = Keyword.fetch!(opts, :network)

--- a/lib/mix/tasks/grappa.create_user.ex
+++ b/lib/mix/tasks/grappa.create_user.ex
@@ -25,15 +25,24 @@ defmodule Mix.Tasks.Grappa.CreateUser do
 
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Mix.Tasks.Grappa.Boot, Mix.Tasks.Grappa.Output]
+    deps: [
+      Grappa.Accounts,
+      Mix.Tasks.Grappa.Boot,
+      Mix.Tasks.Grappa.OptionParsing,
+      Mix.Tasks.Grappa.Output
+    ]
 
   use Mix.Task
 
-  alias Mix.Tasks.Grappa.{Boot, Output}
+  alias Mix.Tasks.Grappa.{Boot, OptionParsing, Output}
+
+  @switches [name: :string, password: :string, admin: :boolean]
+
+  @required [:name, :password]
 
   @impl Mix.Task
   def run(args) do
-    {opts, _, _} = OptionParser.parse(args, strict: [name: :string, password: :string, admin: :boolean])
+    opts = OptionParsing.parse!(args, @switches, @required)
     name = Keyword.fetch!(opts, :name)
     password = Keyword.fetch!(opts, :password)
     admin? = Keyword.get(opts, :admin, false)

--- a/lib/mix/tasks/grappa.remove_server.ex
+++ b/lib/mix/tasks/grappa.remove_server.ex
@@ -24,9 +24,13 @@ defmodule Mix.Tasks.Grappa.RemoveServer do
   alias Grappa.Networks.Servers
   alias Mix.Tasks.Grappa.{Boot, OptionParsing}
 
+  @switches [network: :string, server: :string]
+
+  @required [:network, :server]
+
   @impl Mix.Task
   def run(args) do
-    {opts, _, _} = OptionParser.parse(args, strict: [network: :string, server: :string])
+    opts = OptionParsing.parse!(args, @switches, @required)
     slug = Keyword.fetch!(opts, :network)
     server = Keyword.fetch!(opts, :server)
 

--- a/lib/mix/tasks/grappa.repair_passwords.ex
+++ b/lib/mix/tasks/grappa.repair_passwords.ex
@@ -70,15 +70,17 @@ defmodule Mix.Tasks.Grappa.RepairPasswords do
   """
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Networks, Grappa.Session, Mix.Tasks.Grappa.Boot]
+    deps: [Grappa.Networks, Grappa.Session, Mix.Tasks.Grappa.Boot, Mix.Tasks.Grappa.OptionParsing]
 
   use Mix.Task
 
   alias Grappa.Networks.{Credential, Credentials}
   alias Grappa.Session.NSInterceptor
-  alias Mix.Tasks.Grappa.Boot
+  alias Mix.Tasks.Grappa.{Boot, OptionParsing}
 
   @switches [write: :boolean]
+
+  @required []
 
   @typedoc """
   Why a row is reported instead of repaired. Every one of these means the
@@ -168,7 +170,7 @@ defmodule Mix.Tasks.Grappa.RepairPasswords do
 
   @impl Mix.Task
   def run(args) do
-    {opts, _, _} = OptionParser.parse(args, strict: @switches)
+    opts = OptionParsing.parse!(args, @switches, @required)
     # Dry run is the default, and the default is the safe direction: writing
     # is the irreversible half, so it is the half that has to be asked for.
     write? = Keyword.get(opts, :write, false)

--- a/lib/mix/tasks/grappa.seed_scrollback.ex
+++ b/lib/mix/tasks/grappa.seed_scrollback.ex
@@ -36,13 +36,14 @@ defmodule Mix.Tasks.Grappa.SeedScrollback do
       Grappa.Networks,
       Grappa.Scrollback,
       Mix.Tasks.Grappa.Boot,
+      Mix.Tasks.Grappa.OptionParsing,
       Mix.Tasks.Grappa.Output
     ]
 
   use Mix.Task
 
   alias Grappa.{Accounts, Networks, Scrollback}
-  alias Mix.Tasks.Grappa.{Boot, Output}
+  alias Mix.Tasks.Grappa.{Boot, OptionParsing, Output}
 
   @switches [
     user: :string,
@@ -52,12 +53,14 @@ defmodule Mix.Tasks.Grappa.SeedScrollback do
     sender: :string
   ]
 
+  @required [:user, :network, :channel, :count, :sender]
+
   @max_count 2_000
   @gap_ms 100
 
   @impl Mix.Task
   def run(args) do
-    {opts, _, _} = OptionParser.parse(args, strict: @switches)
+    opts = OptionParsing.parse!(args, @switches, @required)
     user_name = Keyword.fetch!(opts, :user)
     network_slug = Keyword.fetch!(opts, :network)
     channel = Keyword.fetch!(opts, :channel)

--- a/lib/mix/tasks/grappa.set_network_caps.ex
+++ b/lib/mix/tasks/grappa.set_network_caps.ex
@@ -45,13 +45,14 @@ defmodule Mix.Tasks.Grappa.SetNetworkCaps do
     deps: [
       Grappa.Networks,
       Mix.Tasks.Grappa.Boot,
+      Mix.Tasks.Grappa.OptionParsing,
       Mix.Tasks.Grappa.Output
     ]
 
   use Mix.Task
 
   alias Grappa.Networks
-  alias Mix.Tasks.Grappa.{Boot, Output}
+  alias Mix.Tasks.Grappa.{Boot, OptionParsing, Output}
 
   @switches [
     network: :string,
@@ -63,9 +64,11 @@ defmodule Mix.Tasks.Grappa.SetNetworkCaps do
     clear_max_per_ip: :boolean
   ]
 
+  @required []
+
   @impl Mix.Task
   def run(args) do
-    {opts, _, _} = OptionParser.parse(args, strict: @switches)
+    opts = OptionParsing.parse!(args, @switches, @required)
 
     validate_mutual_exclusion!(opts)
     attrs = build_attrs(opts)

--- a/lib/mix/tasks/grappa.unbind_network.ex
+++ b/lib/mix/tasks/grappa.unbind_network.ex
@@ -15,17 +15,21 @@ defmodule Mix.Tasks.Grappa.UnbindNetwork do
   """
   use Boundary,
     top_level?: true,
-    deps: [Grappa.Accounts, Grappa.Networks, Mix.Tasks.Grappa.Boot]
+    deps: [Grappa.Accounts, Grappa.Networks, Mix.Tasks.Grappa.Boot, Mix.Tasks.Grappa.OptionParsing]
 
   use Mix.Task
 
   alias Grappa.{Accounts, Networks}
   alias Grappa.Networks.Credentials
-  alias Mix.Tasks.Grappa.Boot
+  alias Mix.Tasks.Grappa.{Boot, OptionParsing}
+
+  @switches [user: :string, network: :string]
+
+  @required [:user, :network]
 
   @impl Mix.Task
   def run(args) do
-    {opts, _, _} = OptionParser.parse(args, strict: [user: :string, network: :string])
+    opts = OptionParsing.parse!(args, @switches, @required)
     user_name = Keyword.fetch!(opts, :user)
     slug = Keyword.fetch!(opts, :network)
 

--- a/lib/mix/tasks/grappa.update_network_credential.ex
+++ b/lib/mix/tasks/grappa.update_network_credential.ex
@@ -44,9 +44,11 @@ defmodule Mix.Tasks.Grappa.UpdateNetworkCredential do
     sasl_user: :string
   ]
 
+  @required [:user, :network]
+
   @impl Mix.Task
   def run(args) do
-    {opts, _, _} = OptionParser.parse(args, strict: @switches)
+    opts = OptionParsing.parse!(args, @switches, @required)
 
     user_name = Keyword.fetch!(opts, :user)
     slug = Keyword.fetch!(opts, :network)

--- a/lib/mix/tasks/grappa/option_parsing.ex
+++ b/lib/mix/tasks/grappa/option_parsing.ex
@@ -39,6 +39,36 @@ defmodule Mix.Tasks.Grappa.OptionParsing do
   @auth_strings Map.keys(@auth_map)
 
   @doc """
+  Parses `args` against `switches`, returning the option keyword list.
+
+  Raises `Mix.Error` — one line, no traceback — when a switch is
+  unrecognised, when its value will not parse, or when one of `required`
+  is absent.
+
+  `OptionParser.parse(args, strict: ...)` reports none of that on its
+  own (GH #1086): an unrecognised switch lands in the `invalid` element
+  every caller here was discarding, so `--nework azzurra` silently
+  became no `--network` at all, and the first `Keyword.fetch!` for the
+  option it failed to set dumped a raw `KeyError` traceback at the
+  operator.
+
+  An unrecognised switch is reported IN PREFERENCE to the required
+  option it failed to set. `--nework azzurra` names the typo; saying
+  `--network` is missing would send the operator hunting for a flag
+  they believe they typed.
+  """
+  @spec parse!([String.t()], keyword(), [atom()]) :: keyword()
+  def parse!(args, switches, required)
+      when is_list(args) and is_list(switches) and is_list(required) do
+    {opts, _rest, invalid} = OptionParser.parse(args, strict: switches)
+
+    reject_invalid!(invalid, switches)
+    reject_missing!(opts, required)
+
+    opts
+  end
+
+  @doc """
   Parses a `host:port` server spec into `{host, port}`. Raises on
   malformed input.
   """
@@ -84,4 +114,41 @@ defmodule Mix.Tasks.Grappa.OptionParsing do
     |> String.split(",", trim: true)
     |> Enum.map(&String.trim/1)
   end
+
+  defp reject_invalid!([], _switches), do: :ok
+
+  defp reject_invalid!(invalid, switches) do
+    known = Enum.map(switches, fn {name, _type} -> flag(name) end)
+
+    Mix.raise(Enum.map_join(invalid, "; ", &invalid_message(&1, known)))
+  end
+
+  # `OptionParser` reports an unrecognised switch and a known switch
+  # whose value will not parse through the SAME `invalid` element, so
+  # the two are told apart by whether the reported spelling appears in
+  # the caller's own switch table.
+  defp invalid_message({switch, nil}, known) do
+    if switch in known,
+      do: "missing value for #{switch}",
+      else: "unknown option #{switch}"
+  end
+
+  defp invalid_message({switch, value}, known) do
+    if switch in known,
+      do: "invalid value #{inspect(value)} for #{switch}",
+      else: "unknown option #{switch}"
+  end
+
+  defp reject_missing!(opts, required) do
+    case Enum.reject(required, &Keyword.has_key?(opts, &1)) do
+      [] -> :ok
+      [one] -> Mix.raise("missing required option #{flag(one)}")
+      many -> Mix.raise("missing required options #{Enum.map_join(many, ", ", &flag/1)}")
+    end
+  end
+
+  # `services_flavor:` in the switch table is `--services-flavor` on the
+  # command line. Derived from the atom's string form only — never the
+  # reverse direction, for the reason the `@auth_map` note above gives.
+  defp flag(name), do: "--" <> String.replace(Atom.to_string(name), "_", "-")
 end

--- a/lib/mix/tasks/grappa/option_parsing.ex
+++ b/lib/mix/tasks/grappa/option_parsing.ex
@@ -60,7 +60,7 @@ defmodule Mix.Tasks.Grappa.OptionParsing do
   @spec parse!([String.t()], keyword(), [atom()]) :: keyword()
   def parse!(args, switches, required)
       when is_list(args) and is_list(switches) and is_list(required) do
-    {opts, _rest, invalid} = OptionParser.parse(args, strict: switches)
+    {opts, _, invalid} = OptionParser.parse(args, strict: switches)
 
     reject_invalid!(invalid, switches)
     reject_missing!(opts, required)
@@ -115,10 +115,10 @@ defmodule Mix.Tasks.Grappa.OptionParsing do
     |> Enum.map(&String.trim/1)
   end
 
-  defp reject_invalid!([], _switches), do: :ok
+  defp reject_invalid!([], _), do: :ok
 
   defp reject_invalid!(invalid, switches) do
-    known = Enum.map(switches, fn {name, _type} -> flag(name) end)
+    known = Enum.map(switches, fn {name, _} -> flag(name) end)
 
     Mix.raise(Enum.map_join(invalid, "; ", &invalid_message(&1, known)))
   end

--- a/test/bin/grappa_test.bats
+++ b/test/bin/grappa_test.bats
@@ -133,6 +133,72 @@ EOF
     [ "$status" -eq 64 ]
 }
 
+# --- #1086: --help / -h as a FLAG, not just a verb -------------------------
+#
+# The dispatcher used to know help only as a verb (`bin/grappa help <verb>`).
+# A `--help` AFTER a verb was passed through as an ordinary argument: boot
+# verbs handed it to a mix task that parses `strict:`, which discarded it
+# silently and then blew up on the first required option with a raw KeyError
+# traceback. These assert the flag form reaches the SAME per-verb help path
+# the verb form already used, for every kind of verb, and that the verb's
+# real work never runs.
+
+@test "#1086 <boot-verb> --help routes to per-verb help, not to the task" {
+    run "$BIN_GRAPPA" bind-network --help
+    [ "$status" -eq 0 ]
+    grep -q 'mix.sh --env=dev help grappa.bind_network' "$ARGV_LOG"
+    # The task itself must never be invoked — that is the crash path.
+    refute grep -q 'mix.sh grappa.bind_network' "$ARGV_LOG"
+}
+
+@test "#1086 <boot-verb> -h routes to per-verb help" {
+    run "$BIN_GRAPPA" bind-network -h
+    [ "$status" -eq 0 ]
+    grep -q 'mix.sh --env=dev help grappa.bind_network' "$ARGV_LOG"
+    refute grep -q 'mix.sh grappa.bind_network' "$ARGV_LOG"
+}
+
+@test "#1086 --help is honoured after other arguments, not only first" {
+    run "$BIN_GRAPPA" bind-network --user vjt --network azzurra --help
+    [ "$status" -eq 0 ]
+    grep -q 'mix.sh --env=dev help grappa.bind_network' "$ARGV_LOG"
+    refute grep -q 'mix.sh grappa.bind_network' "$ARGV_LOG"
+}
+
+@test "#1086 <rpc-verb> --help prints inline help without touching docker" {
+    run "$BIN_GRAPPA" list-sessions --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"list-sessions"* ]]
+    [[ "$output" == *"SessionRegistry"* ]]
+    [ ! -s "$ARGV_LOG" ]
+}
+
+@test "#1086 <arg-taking verb> --help prints inline help instead of erroring" {
+    run "$BIN_GRAPPA" delete-visitor --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"uuid"* ]]
+    [ ! -s "$ARGV_LOG" ]
+}
+
+@test "#1086 <debug-verb> --help prints inline help without touching docker" {
+    run "$BIN_GRAPPA" shell --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"shell"* ]]
+    [ ! -s "$ARGV_LOG" ]
+}
+
+@test "#1086 bare --help prints the top banner and exits 0" {
+    run "$BIN_GRAPPA" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Boot-time"* ]]
+    [[ "$output" == *"bind-network"* ]]
+}
+
+@test "#1086 --help on an unknown verb still exits 64" {
+    run "$BIN_GRAPPA" frobnicate --help
+    [ "$status" -eq 64 ]
+}
+
 # --- debug verbs ----------------------------------------------------------
 
 @test "shell invokes docker compose exec grappa bash" {

--- a/test/mix/tasks/grappa/bind_network_test.exs
+++ b/test/mix/tasks/grappa/bind_network_test.exs
@@ -206,10 +206,65 @@ defmodule Mix.Tasks.Grappa.BindNetworkTest do
     end
   end
 
-  test "raises KeyError when --user is missing" do
-    assert_raise KeyError, fn ->
-      BindNetwork.run(["--network", "azzurra", "--server", "h:6697", "--nick", "n"])
-    end
+  # #1086 — this used to assert `KeyError`, pinning the very defect the
+  # issue reports: `Keyword.fetch!` on an option the strict parse had
+  # already discarded dumped a raw Elixir traceback at an operator. The
+  # test encoded the bug, which is why the bug survived.
+  test "a missing required option names it, without a traceback" do
+    error =
+      assert_raise Mix.Error, fn ->
+        BindNetwork.run(["--network", "azzurra", "--server", "h:6697", "--nick", "n"])
+      end
+
+    assert error.message =~ "--user"
+    assert error.message =~ "--auth"
+  end
+
+  # The typo case from the issue. Reporting the unknown switch takes
+  # precedence over the required option it failed to set: telling the
+  # operator "--network is missing" would send them hunting for a flag
+  # they did type.
+  test "an unknown switch is reported, naming it, rather than discarded" do
+    error =
+      assert_raise Mix.Error, fn ->
+        BindNetwork.run([
+          "--user",
+          "vjt",
+          "--nework",
+          "azzurra",
+          "--server",
+          "h:6697",
+          "--nick",
+          "n",
+          "--auth",
+          "none"
+        ])
+      end
+
+    assert error.message =~ "--nework"
+    refute error.message =~ "missing required"
+  end
+
+  test "a known switch with an unparseable value names the switch and the value" do
+    error =
+      assert_raise Mix.Error, fn ->
+        BindNetwork.run([
+          "--user",
+          "vjt",
+          "--network",
+          "azzurra",
+          "--server",
+          "h:6697",
+          "--nick",
+          "n",
+          "--auth",
+          "none",
+          "--tls=maybe"
+        ])
+      end
+
+    assert error.message =~ "--tls"
+    assert error.message =~ "maybe"
   end
 
   test "--services-flavor sets the network's services flavor on create", %{user: _user} do

--- a/test/mix/tasks/grappa/create_user_test.exs
+++ b/test/mix/tasks/grappa/create_user_test.exs
@@ -55,15 +55,24 @@ defmodule Mix.Tasks.Grappa.CreateUserTest do
     assert Accounts.get_user_by_name!("pleb").is_admin == false
   end
 
-  test "raises when --name is missing" do
-    assert_raise KeyError, fn ->
-      CreateUser.run(["--password", "correct horse battery staple"])
-    end
+  # #1086 — both of these asserted `KeyError`, pinning the defect the
+  # issue reports rather than the behaviour an operator needs. A test
+  # that encodes the bug is why the bug survived.
+  test "a missing --name names it, without a traceback" do
+    error =
+      assert_raise Mix.Error, fn ->
+        CreateUser.run(["--password", "correct horse battery staple"])
+      end
+
+    assert error.message =~ "--name"
   end
 
-  test "raises when --password is missing" do
-    assert_raise KeyError, fn ->
-      CreateUser.run(["--name", "vjt"])
-    end
+  test "a missing --password names it, without a traceback" do
+    error =
+      assert_raise Mix.Error, fn ->
+        CreateUser.run(["--name", "vjt"])
+      end
+
+    assert error.message =~ "--password"
   end
 end

--- a/test/mix/tasks/grappa/set_network_caps_test.exs
+++ b/test/mix/tasks/grappa/set_network_caps_test.exs
@@ -73,6 +73,23 @@ defmodule Mix.Tasks.Grappa.SetNetworkCapsTest do
     end
   end
 
+  # #1086 — this task has no required options, so the KeyError from the
+  # issue never reached it, but the silent half of the defect did: a
+  # misspelled cap flag was discarded by the strict parse and surfaced
+  # as "no changes specified", which names the wrong thing. The operator
+  # DID specify a change; they misspelled it.
+  test "a misspelled cap flag names the switch, not 'no changes'" do
+    error =
+      assert_raise Mix.Error, fn ->
+        capture_io(fn ->
+          SetNetworkCaps.run(["--network", "azzurra", "--max-visitor-session", "3"])
+        end)
+      end
+
+    assert error.message =~ "--max-visitor-session"
+    refute error.message =~ "no changes specified"
+  end
+
   test "raises when no cap flag is supplied" do
     assert_raise Mix.Error, ~r/no changes specified/, fn ->
       capture_io(fn ->


### PR DESCRIPTION
## The defect

`bin/grappa <verb> --help` crashed with a raw Elixir traceback —
`** (KeyError) key :user not found in: []` — at a self-hoster. Two layers each
declined to claim the flag:

1. The dispatcher knew help only as a **verb** (`bin/grappa help <verb>`), so a
   `--help` after a verb was passed through as an ordinary argument.
2. The boot tasks parse `strict:`, which drops an unrecognised switch into the
   `invalid` element every caller was discarding. The first `Keyword.fetch!`
   for the option that never got set then raised.

A plain typo (`--nework azzurra`) produced the identical dump for the identical
reason.

## Correction to the issue: the blast radius is wider, and worse

The issue's table counts seven mix tasks whose `run/1` reaches
`Keyword.fetch!`. That table is right, and it was re-measured on the current
`origin/main` — 5/5/2/2/2/2/2, matching row for row.

But eleven of the dispatcher's twenty-one verbs never reach a mix task at all,
and those took the flag for a **positional argument**. Measured against the
bats docker stub:

```
$ bin/grappa delete-visitor --help
exit=0
docker compose ... --rpc-eval grappa@grappa
  Grappa.Operator.delete_visitor!("--help")
```

A help request reaching a **mutating verb on the live BEAM**, exiting 0. It was
harmless only because no visitor has that UUID. No mix-task-side cure would
have touched it.

## Two layers, two cures — and why that is not a duplication

`--help` belongs to the dispatcher: it is the only layer that can serve all
twenty-one verbs, and for the eleven non-mix ones no Elixir layer exists.

Missing-required and unknown-switch belong to the tasks: the dispatcher does
not know any verb's switch table and could only learn it by duplicating it — a
parallel structure that drifts at the first new switch. The tasks are also
reachable directly as `scripts/mix.sh grappa.bind_network ...`, the invocation
their own moduledocs document, which bypasses the dispatcher entirely.

Inside the Elixir layer the cure stays single: `Mix.Tasks.Grappa.OptionParsing`
was already the shared home and already used `Mix.raise` for malformed input,
so `parse!/3` joined it rather than nine patched tasks.

## Nine tasks, not seven

`repair_passwords` and `set_network_caps` have no required options and so never
met the KeyError, but they had the silent half: a misspelled
`--max-visitor-session` was discarded and surfaced as "no changes specified",
which names the wrong thing — the operator *did* specify a change, they
misspelled it. Both route through the same call with an empty required list.

`gen_wire_types` stays out: it parses non-strict, is codegen rather than an
operator verb, and is absent from the verb table.

## Two judgement calls, stated

**An unrecognised switch is reported in preference to the required option it
failed to set.** `--nework azzurra` names the typo. Saying `--network` is
missing would be true and useless — it sends the operator hunting for a flag
they believe they typed.

**The flag is scanned anywhere in the argument list**, not first position only,
because `bin/grappa bind-network --user vjt --help` is how an operator asks
mid-command. The cost: an option VALUE spelled exactly `--help` reads as a help
request. No switch on any verb takes a value that could plausibly be spelled
that way — a judgement, not a measurement.

## Three tests pinned the bug as the contract

`bind_network_test.exs` and `create_user_test.exs` each asserted
`assert_raise KeyError` for a missing required option. That is why a defect
this shallow survived a suite that covered it: the crash *was* the documented
behaviour. They now assert the message names the option.

## Known limit — deliberately not closed

For the ten boot verbs the dispatcher's help path is
`exec scripts/mix.sh --env=dev help grappa.<task>`, which reads `@shortdoc` /
`@moduledoc` from inside the container, so it needs the container **up**. With
the instance down — exactly when a self-hoster reaches for `--help` — the
acceptance criterion "prints that verb's help and exits 0, for every verb" does
not hold. Closing it means inline help text for the boot verbs, doubling the
surface that has to stay in lockstep with the `@shortdoc`s. That is a product
call and is not taken in this PR.

## Evidence

**Red measured before green, both layers.**

- Dispatcher: 8 new bats tests against the untouched dispatcher → **7 red**.
  The eighth (`frobnicate --help` exits 64) was already green — it guards the
  pre-existing `die_unknown_verb` path and is a regression check, not a new
  test passing for free.
- Tasks: the 3 new `bind_network` assertions against the unwired task →
  **3 red**, then green once `parse!/3` was in.

**Each judgement call falsified in isolation** — mutations, not predictions:

| mutation | what died |
|---|---|
| `wants_help` scans only the first two arguments | **only** "`--help` honoured after other arguments" |
| the bare-`--help` arm removed | **only** "bare `--help` prints the top banner" |
| validation order swapped (missing before unknown) | **only** "an unknown switch is reported, naming it" |
| the required-option check removed | **only** the 3 missing-required tests |

**Gates.** Full `scripts/check.sh` on the rebased tree, rc read from file:
Dialyzer, Credo, Sobelow, `mix format`, `deps.audit`, full ExUnit, and the
complete bats set including the shellcheck gate.

The first `check.sh` run was **red** — Credo caught three consistency findings
of mine (`_rest` / `_type` / `_switches`; this tree names unused bindings `_`).
Fixed in its own commit, then re-run.

### What I will not claim

The three `refute grep -q 'mix.sh grappa.bind_network'` assertions — "the task
must never run" — **have not been seen red.** For boot verbs `dispatch_help`
uses `exec`, so nothing after it can run regardless of my branch; the guard is
structurally satisfied rather than proven by my code path. I could not build a
non-contrived mutation that made them fail. They are correct statements of
intent and would catch a future non-`exec` help path, but they are not
load-bearing evidence today.
