### PR TITLE
cic(#1073): host the admin console on the channel top bar, with live stats

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -791,9 +791,16 @@ export async function openMembersDrawer(page: Page): Promise<void> {
   for (;;) {
     if (await drawer.isVisible().catch(() => false)) break;
     try {
-      const topicHamburger = page.getByLabel(/open members sidebar/i);
-      if ((await topicHamburger.count()) > 0) {
-        await topicHamburger.first().click({ timeout: 3_000 });
+      // #1073 — located by CLASS, not by accessible name. The bar itself is
+      // now shared: the channel window and the admin console both render
+      // `PaneTopBar`, and its ☰ is deliberately named differently by each host
+      // ("open members sidebar" vs "open actions") because the two doors mean
+      // different things to a screen reader. The class is what they have in
+      // common, and it is the thing this helper actually needs — the in-flow
+      // opener, whichever pane is mounted.
+      const paneHamburger = page.locator(".topic-bar-hamburger");
+      if ((await paneHamburger.count()) > 0) {
+        await paneHamburger.first().click({ timeout: 3_000 });
       } else {
         await page.getByTestId("shell-chrome-rail-opener").click({ timeout: 3_000 });
       }

--- a/cicchetto/e2e/tests/issue1039-hamburger-corner.spec.ts
+++ b/cicchetto/e2e/tests/issue1039-hamburger-corner.spec.ts
@@ -22,11 +22,15 @@
 // 768px), so this runs on webkit-iphone-15 alone — the @webkit tag; the
 // chromium project grepInverts it.
 //
-// NOT covered here: the third host. `.admin-pane-header` (#1033, 2026-08-07)
-// puts the same ☰ at the pane's top-LEFT, deliberately — the top-right corner
-// of the admin pane is taken by its close × and refresh. That is a contract to
-// settle, not an offset to unify, and it is filed separately; asserting it here
-// would encode a decision nobody has made.
+// The third host used to be the open question here: `.admin-pane-header`
+// (#1033, 2026-08-07) put the same ☰ at the pane's top-LEFT, deliberately,
+// because the top-right corner was taken by its close × and refresh. #1073
+// settled it by deleting the disagreement rather than unifying an offset — the
+// admin pane now renders `.topic-bar` itself, so its ☰ is the same trailing
+// child measured below and lands in the same corner by construction. No arm is
+// added here for it: this spec's two hosts differ in their BOX (a floated
+// zero-height row vs a real band), which is the thing that could drift apart,
+// and admin is no longer a third box.
 //
 // Parity matrix per `feedback_e2e_user_class_parity_matrix`: this is a UI shape
 // contract, subject-shape-agnostic. The registered seed suffices.

--- a/cicchetto/e2e/tests/issue1073-admin-topbar-stats.spec.ts
+++ b/cicchetto/e2e/tests/issue1073-admin-topbar-stats.spec.ts
@@ -1,0 +1,134 @@
+// #1073 — the admin console's top bar IS the channel windows' bar, with live
+// key stats in its left group.
+//
+// What this spec is for, and what it deliberately is not: the vitest suites
+// already pin the wiring (`adminOverview.test.ts` — the push, the snapshot
+// semantics, the nullable loadavg; `AdminPane.test.tsx` — the stats mounted in
+// the bar's content slot). None of that proves the bar READS right, because
+// jsdom computes no layout and the constraint vjt and Hypnotize actually set
+// is a layout one: *"si, non invadente"*, *"deve essere piccola, che già la
+// tastiera occupa una madonna"*. Per `feedback_cicchetto_browser_smoke` this
+// spec is the browser smoke for the two facts only a real engine can settle —
+// the row does not wrap, and the ☰ stays at the far end of it — plus the one
+// end-to-end fact no unit can reach: the numbers come off a LIVE server push,
+// not a fixture.
+//
+// Per `feedback_e2e_user_class_parity_matrix`: admin-gated, the EXEMPT shape —
+// only the admin class reaches this surface at all, and the gate itself is
+// asserted at m7-admin-gate-settings-drawer.
+//
+// The stats' visibility IS the barrier. `AdminOverviewStats` renders nothing
+// until the first `"overview"` push lands, so `toBeVisible()` waits on the
+// arrival of real server data rather than on a timer.
+
+import { expect, test } from "../fixtures/test";
+import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { getSeededAdmin } from "../fixtures/seedData";
+
+// admin-vjt has no network bind, so `loginAs`'s network-section shell-ready
+// selector would time out. Same shape as m7-admin-gate / m11-admin-events.
+async function adminLogin(page: import("@playwright/test").Page): Promise<void> {
+  const seed = getSeededAdmin();
+  await page.addInitScript(
+    ([token, subjectJson]) => {
+      localStorage.setItem("grappa-token", token);
+      localStorage.setItem("grappa-subject", subjectJson);
+      localStorage.setItem("cic.installChoice", "browser");
+    },
+    [seed.token, seed.subjectJson] as const,
+  );
+  await page.goto("/");
+  await expectShellReady(page);
+}
+
+const CELLS = [
+  "admin-overview-sessions",
+  "admin-overview-visitors",
+  "admin-overview-hostname",
+  "admin-overview-loadavg",
+  "admin-overview-version",
+] as const;
+
+// The five cells share one text line iff their boxes share one top edge.
+// Tops rather than heights: a cell's height varies with its own glyph (the ⚡
+// and the 👤 are not the digits' size), so equal heights would prove nothing
+// and unequal heights would prove nothing either. Sub-pixel layout is real, so
+// compare within 1px rather than exactly.
+async function expectOneLine(pane: import("@playwright/test").Locator): Promise<void> {
+  let first: number | null = null;
+  for (const id of CELLS) {
+    const box = await pane.getByTestId(id).boundingBox();
+    expect(box, `${id} must have a layout box`).not.toBeNull();
+    const top = (box as { y: number }).y;
+    if (first === null) {
+      first = top;
+      continue;
+    }
+    expect(Math.abs(top - first), `${id} must sit on the same line as the first cell`).toBeLessThan(
+      1.5,
+    );
+  }
+}
+
+test("#1073 the admin bar carries live stats, on one line, in the shared band", async ({
+  page,
+}) => {
+  await adminLogin(page);
+  const pane = await openAdminConsole(page);
+
+  // Barrier AND assertion: nothing renders until the server's first push.
+  const stats = pane.locator(".topic-bar .admin-overview-stats");
+  await expect(stats).toBeVisible({ timeout: 10_000 });
+
+  // The numbers are the SERVER's, so the spec asserts their shape rather than
+  // their value — a bound value would be asserting the seed, not the wire.
+  await expect(pane.getByTestId("admin-overview-sessions")).toHaveText(/\d/);
+  await expect(pane.getByTestId("admin-overview-visitors")).toHaveText(/\d+\/\d+/);
+  await expect(pane.getByTestId("admin-overview-version")).toHaveText(/^v\d+\.\d+\.\d+/);
+  await expect(pane.getByTestId("admin-overview-hostname")).not.toHaveText("");
+
+  // The loadavg's two correctness rules, as they reach a real screen. It is
+  // the HOST's load (the jail shares the host kernel), so the word is on the
+  // cell and not only in a tooltip; and an unreachable sampler renders as an
+  // em dash with NO digit, because `0.00` would report a calm machine that
+  // nobody can actually see. Both readings are legal here — CI may or may not
+  // have `:cpu_sup` — and the alternation is the point: what is illegal is a
+  // bare unlabelled number, or a fabricated zero.
+  await expect(pane.getByTestId("admin-overview-loadavg")).toHaveText(/^host (—|\d+\.\d{2})$/);
+
+  // ONE LINE. The whole reason the row clips instead of wrapping.
+  await expectOneLine(pane);
+
+  // The band is the shared one and stayed a band: no × (deleted — the rail's
+  // `home` row is the exit) and no refresh glyph (moved into the rail).
+  await expect(pane.locator(".admin-pane-header")).toHaveCount(0);
+  await expect(page.getByTestId("admin-pane-close")).toHaveCount(0);
+  await expect(pane.locator(".topic-bar [data-testid$='-refresh']")).toHaveCount(0);
+});
+
+test("#1073 @webkit on a phone the stats keep the ☰ at the far end", async ({ page }) => {
+  await adminLogin(page);
+  const pane = await openAdminConsole(page);
+
+  const stats = pane.locator(".topic-bar .admin-overview-stats");
+  await expect(stats).toBeVisible({ timeout: 10_000 });
+
+  // 393px is where the constraint bites: title + five stats + ☰ on one line.
+  // The ☰'s side is meant to be a consequence of it being the bar's LAST
+  // child, not of an override — so the failing shape to catch is the stats
+  // pushing it out of the bar, or off the screen entirely.
+  const hamburger = pane.locator(".topic-bar-hamburger");
+  await expect(hamburger).toBeVisible();
+  await expect(hamburger).toBeInViewport({ ratio: 1 });
+
+  const statsBox = await stats.boundingBox();
+  const hamBox = await hamburger.boundingBox();
+  expect(statsBox).not.toBeNull();
+  expect(hamBox).not.toBeNull();
+  const s = statsBox as { x: number; width: number };
+  const h = hamBox as { x: number };
+  expect(h.x).toBeGreaterThanOrEqual(s.x + s.width - 1);
+
+  // Still one line at phone width — the case the desktop test cannot make.
+  await expectOneLine(pane);
+});

--- a/cicchetto/e2e/tests/m7-admin-gate-settings-drawer.spec.ts
+++ b/cicchetto/e2e/tests/m7-admin-gate-settings-drawer.spec.ts
@@ -89,9 +89,14 @@ for (const c of cases) {
       await expect(pane).toBeVisible();
       await expect(pane.getByRole("heading", { name: /admin console/i })).toBeVisible();
 
-      // Close button returns to the channel/empty state — pane
-      // unmounts entirely (not just hidden via CSS).
-      await page.getByTestId("admin-pane-close").click();
+      // #1073 — the close × is gone (vjt: *"la x sparisce"*). What it did was
+      // set selection to home, and the rail already carries that row, so the
+      // exit path asserted here is the one that remains: open the rail from the
+      // console's own ☰, pick home. The post-condition is unchanged and is what
+      // this arm was ever about — the pane unmounts entirely, not just hidden
+      // via CSS.
+      await openRailMenu(page);
+      await page.getByTestId("mobile-panel-home").click();
       await expect(page.getByTestId("admin-pane")).toHaveCount(0);
     } else {
       // Non-admin: the launcher MUST be absent from the DOM (the Show

--- a/cicchetto/e2e/tests/ux-4-z-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/ux-4-z-cluster-journey.spec.ts
@@ -506,9 +506,14 @@ test("@webkit UX-4-Z cluster — case-fix + home + sidebar collapse + close-fall
     // rail tap.)
     await openAdminConsole(adminPage);
     // Settings STILL reachable on the admin window (bucket L rule extends to
-    // the admin kind). #71 INC-2 — on mobile the door is the ☰ rail opener
-    // (admin is a non-channel kind, so ShellChrome renders it).
-    await expect(adminPage.getByTestId("shell-chrome-rail-opener")).toBeVisible();
+    // the admin kind). #71 INC-2 — on mobile the door is the ☰ rail opener.
+    // #1073 — that door is no longer the `shell-chrome-rail-opener` testid:
+    // `ShellChrome` never rendered on the admin window (Shell suppresses the
+    // row for this kind), the pane hosted the button inline, and the pane's
+    // band is now the shared `.topic-bar`, whose own trailing ☰ replaced it.
+    // The ACCESSIBLE NAME is unchanged, so the door is named rather than
+    // located by a testid that always belonged to the other host.
+    await expect(adminPage.getByLabel(/open actions/i)).toBeVisible();
     await adminPage.close();
   }
 });

--- a/cicchetto/src/AdminNetworksTab.tsx
+++ b/cicchetto/src/AdminNetworksTab.tsx
@@ -617,7 +617,6 @@ const AdminNetworksTab: Component = () => {
                 rather than moving to the pane header like the tabs whose
                 toolbar was title-plus-refresh and nothing else. */}
             <AdminRefreshButton
-              compact={false}
               onClick={() => {
                 void refresh();
               }}

--- a/cicchetto/src/AdminOverviewStats.tsx
+++ b/cicchetto/src/AdminOverviewStats.tsx
@@ -1,4 +1,5 @@
 import { type Component, Show } from "solid-js";
+import type { AdminOverviewWireT } from "./lib/wireTypes";
 
 /**
  * #1073 — the admin bar's left group: the five live stats vjt asked for,
@@ -36,18 +37,19 @@ import { type Component, Show } from "solid-js";
  *    `0.00`. The unknown case renders an em dash, carries the reason in its
  *    `title`, and contains no digit at all.
  */
-export type Overview = {
-  sessions: number;
-  visitors: { total: number; live: number };
-  hostname: string;
-  /** `null` = the sampler was unreachable. NOT the same as `0`. */
-  loadavg: number | null;
-  version: string;
-};
-
 export type Props = {
-  /** `null` until the first push lands — the bar renders nothing until then. */
-  overview: Overview | null;
+  /**
+   * The wire shape, GENERATED from `Grappa.AdminOverview.Wire` by `mix
+   * grappa.gen_wire_types` — never a hand-written twin of it. This component
+   * held a local copy of the same five fields while #1075 was still in
+   * flight; `scripts/check.sh` runs the generator with `--check`, so the copy
+   * would have gone on compiling happily while the server's shape moved under
+   * it. Reading the generated type is what makes a server-side field rename
+   * fail here instead of at an operator's screen.
+   *
+   * `null` until the first push lands — the bar renders nothing until then.
+   */
+  overview: AdminOverviewWireT | null;
 };
 
 const LOADAVG_UNKNOWN = "—";
@@ -93,8 +95,11 @@ const AdminOverviewStats: Component<Props> = (props) => {
             </span>
             {overview().visitors.live}/{overview().visitors.total}
           </span>
+          {/* The only cell whose width is not bounded by its own shape — a
+              hostname can be anything — so it is the one that yields when the
+              row runs out of bar. See `.admin-overview-stat-host`. */}
           <span
-            class="admin-overview-stat"
+            class="admin-overview-stat admin-overview-stat-host"
             data-testid="admin-overview-hostname"
             title="the host this grappa runs on"
           >

--- a/cicchetto/src/AdminOverviewStats.tsx
+++ b/cicchetto/src/AdminOverviewStats.tsx
@@ -1,0 +1,123 @@
+import { type Component, Show } from "solid-js";
+
+/**
+ * #1073 — the admin bar's left group: the five live stats vjt asked for,
+ * rendered into `PaneTopBar`'s content slot where the channel bar puts its
+ * namebox and topic strip.
+ *
+ * Pure presentation. It is handed the numbers and owns only how they read;
+ * the store that fetches them is a separate concern, so this whole surface
+ * is testable without a socket.
+ *
+ * ## It has to stay ONE row
+ *
+ * vjt: *"si, non invadente"*; Hypnotize: *"deve essere piccola, che già la
+ * tastiera occupa una madonna"*. Vertical space on a phone with the keyboard
+ * up is the binding constraint, so five stats get five compact cells on one
+ * line — glyph plus value — with the full wording in `title` rather than on
+ * screen.
+ *
+ * ## Two of its rules are correctness, not taste
+ *
+ * Both come from what #1075 measured server-side, and both are easy to undo
+ * by accident:
+ *
+ * 1. **The loadavg is the HOST's.** A jail shares the host kernel — `sysctl
+ *    vm.loadavg` reads identically inside the jail and on the host (measured
+ *    in production, 2026-08-09). An unlabelled number on a grappa console is
+ *    read as "grappa is busy", which is a different and unsupported claim. So
+ *    the word `host` is part of the cell, not a footnote.
+ *
+ * 2. **`null` is not zero.** The server deliberately reports `nil` rather
+ *    than `0.0` when the sampler cannot be reached, because "cannot measure"
+ *    and "the box is idle" are different facts and only one of them should
+ *    render as a calm bar. Coercing here would throw that away — `Number(null)`
+ *    is `0`, so a formatter applied without thinking produces a confident
+ *    `0.00`. The unknown case renders an em dash, carries the reason in its
+ *    `title`, and contains no digit at all.
+ */
+export type Overview = {
+  sessions: number;
+  visitors: { total: number; live: number };
+  hostname: string;
+  /** `null` = the sampler was unreachable. NOT the same as `0`. */
+  loadavg: number | null;
+  version: string;
+};
+
+export type Props = {
+  /** `null` until the first push lands — the bar renders nothing until then. */
+  overview: Overview | null;
+};
+
+const LOADAVG_UNKNOWN = "—";
+
+// Deliberately the ONLY place a loadavg becomes a string, and it takes the
+// null branch first. Written as a total function over `number | null` rather
+// than as a `<Show>` with a cast so there is no arm where a formatter can be
+// reached with a null in hand.
+const loadavgText = (loadavg: number | null): string =>
+  loadavg === null ? LOADAVG_UNKNOWN : loadavg.toFixed(2);
+
+const loadavgTitle = (loadavg: number | null): string =>
+  loadavg === null
+    ? "host load average unavailable — the sampler did not answer"
+    : "host load average, 1 min. This jail shares the host kernel, so it is " +
+      "the HOST's load, not grappa's.";
+
+const AdminOverviewStats: Component<Props> = (props) => {
+  return (
+    <Show when={props.overview}>
+      {(overview) => (
+        <div class="admin-overview-stats" data-testid="admin-overview-stats">
+          <span
+            class="admin-overview-stat"
+            data-testid="admin-overview-sessions"
+            title="live IRC sessions (one per registered Session.Server pid)"
+          >
+            <span class="admin-overview-stat-icon" aria-hidden="true">
+              {"⚡"}
+            </span>
+            {overview().sessions}
+          </span>
+          {/* live-over-total, never one number: the server sends two because
+              they are two sources of truth and are allowed to disagree. "2 of 5
+              visitors are connected" is a diagnostic; "5 visitors" is not. */}
+          <span
+            class="admin-overview-stat"
+            data-testid="admin-overview-visitors"
+            title="visitors: live sessions over total rows in the database"
+          >
+            <span class="admin-overview-stat-icon" aria-hidden="true">
+              {"\u{1F464}"}
+            </span>
+            {overview().visitors.live}/{overview().visitors.total}
+          </span>
+          <span
+            class="admin-overview-stat"
+            data-testid="admin-overview-hostname"
+            title="the host this grappa runs on"
+          >
+            {overview().hostname}
+          </span>
+          <span
+            class="admin-overview-stat"
+            data-testid="admin-overview-loadavg"
+            title={loadavgTitle(overview().loadavg)}
+          >
+            host {loadavgText(overview().loadavg)}
+          </span>
+          <span
+            class="admin-overview-stat"
+            data-testid="admin-overview-version"
+            title="running grappa version"
+          >
+            v{overview().version}
+          </span>
+        </div>
+      )}
+    </Show>
+  );
+};
+
+export default AdminOverviewStats;

--- a/cicchetto/src/AdminPane.tsx
+++ b/cicchetto/src/AdminPane.tsx
@@ -13,7 +13,7 @@ import AdminNav, { type AdminNavGroup, type AdminNavTab } from "./admin/AdminNav
 import { AdminRefreshButton } from "./admin/AdminToolbar";
 import { refreshInCardHead, refreshSlot } from "./admin/refreshSlot";
 import { startAdminEventsSubscription, uninstallAdminEvents } from "./lib/adminEvents";
-import { RailOpenerButton } from "./ShellChrome";
+import PaneTopBar from "./PaneTopBar";
 
 // M-7 — Admin console pane. Replaces the channel content in
 // Shell.tsx when an admin operator clicks "admin console" in
@@ -58,11 +58,16 @@ export type Props = {
   onClose: () => void;
   /**
    * Admin redesign (2026-08-07) — opens the right rail (`.shell-members`), the
-   * mobile door to settings. Rendered as the header's leading ☰ so the admin
-   * window shows ONE band of chrome instead of the near-empty `.shell-chrome`
-   * row stacked above the pane's own title; Shell suppresses that row for the
-   * admin kind. CSS-hidden at ≥900px, where the desktop Shell branch renders no
-   * `ShellChrome` at all and the rail is permanent.
+   * mobile door to settings. Rendered inline in this pane's own band so the
+   * admin window shows ONE band of chrome instead of the near-empty
+   * `.shell-chrome` row stacked above the pane's own title; Shell suppresses
+   * that row for the admin kind. CSS-hidden at ≥900px, where the desktop Shell
+   * branch renders no `ShellChrome` at all and the rail is permanent.
+   *
+   * #1073 — the glyph is now `PaneTopBar`'s trailing ☰ rather than an inline
+   * `RailOpenerButton`, which is what moves it from the band's left edge to its
+   * right one. Same door, same accessible name ("open actions"), one fewer
+   * mount of the same button.
    */
   onOpenRail: () => void;
 };
@@ -135,8 +140,11 @@ const AdminPane: Component<Props> = (props) => {
 
   return (
     <section class="admin-pane" data-testid="admin-pane">
-      <header class="admin-pane-header">
-        <RailOpenerButton onOpenRail={props.onOpenRail} />
+      {/* #1073 — the SAME band the channel windows use, not a clone of it on
+          the `--adm-*` layer. Everything admin-shaped goes in the content slot;
+          the ☰ comes with the band, and comes LAST, which is what finally puts
+          it on the same side as the channel bar's. */}
+      <PaneTopBar onOpenRail={props.onOpenRail} railLabel="open actions">
         <h1>admin console</h1>
         {/* The active tab's refresh, hoisted out of its own toolbar — see
             `admin/refreshSlot.ts` for why that toolbar went away. The
@@ -167,7 +175,7 @@ const AdminPane: Component<Props> = (props) => {
         >
           ×
         </button>
-      </header>
+      </PaneTopBar>
       <AdminNav
         groups={GROUPS}
         tabs={TABS}

--- a/cicchetto/src/AdminPane.tsx
+++ b/cicchetto/src/AdminPane.tsx
@@ -3,6 +3,7 @@ import AdminCredentialsTab from "./AdminCredentialsTab";
 import AdminDebugTab from "./AdminDebugTab";
 import AdminEventsTab from "./AdminEventsTab";
 import AdminNetworksTab from "./AdminNetworksTab";
+import AdminOverviewStats from "./AdminOverviewStats";
 import AdminSessionLogTab from "./AdminSessionLogTab";
 import AdminSessionsTab from "./AdminSessionsTab";
 import AdminSettingsTab from "./AdminSettingsTab";
@@ -11,6 +12,7 @@ import AdminVhostsTab from "./AdminVhostsTab";
 import AdminVisitorsTab from "./AdminVisitorsTab";
 import AdminNav, { type AdminNavGroup, type AdminNavTab } from "./admin/AdminNav";
 import { startAdminEventsSubscription, uninstallAdminEvents } from "./lib/adminEvents";
+import { adminOverview } from "./lib/adminOverview";
 import PaneTopBar from "./PaneTopBar";
 
 // M-7 — Admin console pane. Replaces the channel content in
@@ -150,6 +152,13 @@ const AdminPane: Component<Props> = (props) => {
           it on the same side as the channel bar's. */}
       <PaneTopBar onOpenRail={props.onOpenRail} railLabel="open actions">
         <h1>admin console</h1>
+        {/* #1073 — the live key stats, fed by the `"overview"` push the admin
+            channel already carries (`lib/adminOverview.ts`). Read here rather
+            than inside the component so the component stays presentation-only
+            and testable without a socket. Nothing renders until the first push
+            lands: the bar is the title alone for that instant, which beats
+            five placeholder zeroes. */}
+        <AdminOverviewStats overview={adminOverview()} />
       </PaneTopBar>
       <AdminNav
         groups={GROUPS}

--- a/cicchetto/src/AdminPane.tsx
+++ b/cicchetto/src/AdminPane.tsx
@@ -17,8 +17,15 @@ import PaneTopBar from "./PaneTopBar";
 
 // M-7 — Admin console pane. Replaces the channel content in
 // Shell.tsx when an admin operator clicks "admin console" in
-// SettingsDrawer. Outer pane = header + close + tab nav + active
-// tab body.
+// SettingsDrawer. Outer pane = top bar + tab nav + active tab body.
+//
+// #1073 — the pane has no close × and no `onClose`. vjt: *"la x
+// sparisce"*. Mount is selection-driven (below), so picking any
+// window from the rail the ☰ opens already leaves the console; the
+// rail carries `home` and `rooms`, and "close admin" would have been
+// a second verb for the work `home` already does. The demote-redirect
+// effect in Shell.tsx is now the ONLY programmatic way out, and it
+// lands on the same window the deleted button did.
 //
 // M-8 added Visitors; M-9b added Sessions; M-10 added Networks;
 // M-11 adds Events (real-time stream of admin-relevant events
@@ -55,7 +62,6 @@ import PaneTopBar from "./PaneTopBar";
 // action/overflow-x/max-height CSS contract 4 specs depend on (#2/#3/#5).
 
 export type Props = {
-  onClose: () => void;
   /**
    * Admin redesign (2026-08-07) — opens the right rail (`.shell-members`), the
    * mobile door to settings. Rendered inline in this pane's own band so the
@@ -166,15 +172,6 @@ const AdminPane: Component<Props> = (props) => {
             />
           )}
         </Show>
-        <button
-          type="button"
-          class="admin-pane-close"
-          aria-label="close admin console"
-          onClick={props.onClose}
-          data-testid="admin-pane-close"
-        >
-          ×
-        </button>
       </PaneTopBar>
       <AdminNav
         groups={GROUPS}

--- a/cicchetto/src/AdminPane.tsx
+++ b/cicchetto/src/AdminPane.tsx
@@ -10,8 +10,6 @@ import AdminUsersTab from "./AdminUsersTab";
 import AdminVhostsTab from "./AdminVhostsTab";
 import AdminVisitorsTab from "./AdminVisitorsTab";
 import AdminNav, { type AdminNavGroup, type AdminNavTab } from "./admin/AdminNav";
-import { AdminRefreshButton } from "./admin/AdminToolbar";
-import { refreshInCardHead, refreshSlot } from "./admin/refreshSlot";
 import { startAdminEventsSubscription, uninstallAdminEvents } from "./lib/adminEvents";
 import PaneTopBar from "./PaneTopBar";
 
@@ -152,26 +150,6 @@ const AdminPane: Component<Props> = (props) => {
           it on the same side as the channel bar's. */}
       <PaneTopBar onOpenRail={props.onOpenRail} railLabel="open actions">
         <h1>admin console</h1>
-        {/* The active tab's refresh, hoisted out of its own toolbar — see
-            `admin/refreshSlot.ts` for why that toolbar went away. The
-            callback form of `<Show>` so the button exists only when a tab
-            registered one: Events has no fetch to repeat and correctly
-            contributes nothing. */}
-        {/* Phone only: on desktop the button lives in the data card's own
-            header (`refreshInCardHead`), next to what it refreshes rather
-            than up in the window furniture. Never both — one button, one
-            testid, which is what the e2e specs click. */}
-        <Show when={!refreshInCardHead() && refreshSlot()}>
-          {(reg) => (
-            <AdminRefreshButton
-              compact
-              onClick={reg().onRefresh}
-              busy={reg().busy()}
-              label={reg().label}
-              testId={reg().testId}
-            />
-          )}
-        </Show>
       </PaneTopBar>
       <AdminNav
         groups={GROUPS}

--- a/cicchetto/src/PaneTopBar.tsx
+++ b/cicchetto/src/PaneTopBar.tsx
@@ -1,0 +1,81 @@
+import type { Component, JSX } from "solid-js";
+
+/**
+ * #1073 — the pane top bar, extracted from `TopicBar` so the admin console can
+ * render THE SAME BAR rather than a lookalike rebuilt on the `--adm-*` layer.
+ * vjt: *"la top bar admin dev'esser possibilmente la stessa barra che abbiamo
+ * per i canali, solo con dentro roba diversa"*.
+ *
+ * What is shared is the BAND, and the band turned out to be small and entirely
+ * channel-agnostic: a flex row carrying `--pane-chrome-inset-*` padding, a
+ * bottom border, a `flex: 1` content slot, and the ☰ as its LAST child. What
+ * is channel-specific — the namebox, the mode string, the topic strip and the
+ * two modals — never belonged to the band at all, and stays in `TopicBar`.
+ *
+ * `TopicBar`'s own props are `networkSlug`, `channelName` and
+ * `onToggleMembers`; everything else it renders is derived from stores. So the
+ * component could never have been handed different content, which is why this
+ * is an extraction and not a parameterisation.
+ *
+ * ## The ☰ side comes for free, and that is the point
+ *
+ * The admin ☰ was never a second hamburger — `AdminPane` mounts the very same
+ * `RailOpenerButton` non-channel windows use. The two surfaces disagreed about
+ * the SIDE because their hosts differ: `.shell-chrome` is a zero-height
+ * `justify-content: flex-end` floater, while `.admin-pane-header` was a real
+ * band that put its opener FIRST. Hosting admin on this bar resolves the
+ * placement by construction — the glyph is last here — instead of by another
+ * CSS override. `TopicBar.test.tsx` pins that ordering (#1073
+ * characterization) precisely because an innocent reshuffle of this JSX would
+ * otherwise move both bars at once.
+ *
+ * ## One band in, one band out
+ *
+ * The reason `AdminPane` hosts its opener inline at all (`AdminPane.tsx`) is
+ * that the admin window must show ONE band of chrome rather than a near-empty
+ * `.shell-chrome` row stacked above the pane's own header — Shell suppresses
+ * that row for the admin kind. Moving admin onto this bar preserves that: the
+ * bar IS the one band.
+ *
+ * `railLabel` is a required prop rather than a default because the two hosts
+ * genuinely name the same door differently — the channel bar's ☰ has always
+ * been *"open members sidebar"*, and changing it would rewrite the eight specs
+ * that click it by that name.
+ */
+export type Props = {
+  /**
+   * The bar's left group, rendered inside `.topic-bar-header`. That wrapper
+   * carries `flex: 1; min-width: 0`, so a caller wanting ellipsis gets the
+   * chain for free; it also carries `align-items: flex-start`, which exists
+   * for #344's intra-block line registration on the channel bar.
+   */
+  children: JSX.Element;
+  onOpenRail: () => void;
+  /** Accessible name for the ☰ — the two hosts word this door differently. */
+  railLabel: string;
+};
+
+const PaneTopBar: Component<Props> = (props) => {
+  return (
+    <div class="topic-bar">
+      <div class="topic-bar-header">{props.children}</div>
+      {/* #881 — UNCONDITIONAL. This ☰ is not a members toggle, it is the rail
+          door: on mobile it opens `.shell-members`, the permanent right rail
+          hosting Archive, Settings, Rooms and Admin. It used to sit behind
+          `windowIsJoined` on the premise that it toggled a member list, and
+          that gate took the whole navigation with it, stranding a
+          `:failed`/`:kicked`/`:parked` window with no way out. Joinedness
+          gates the LIST, never the DOOR. */}
+      <button
+        type="button"
+        class="topic-bar-hamburger shell-chrome-btn"
+        aria-label={props.railLabel}
+        onClick={props.onOpenRail}
+      >
+        {"\u{2630}"}
+      </button>
+    </div>
+  );
+};
+
+export default PaneTopBar;

--- a/cicchetto/src/RailActions.tsx
+++ b/cicchetto/src/RailActions.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "@solidjs/router";
 import { type Component, createEffect, createSignal, For, onCleanup, Show } from "solid-js";
+import { refreshInCardHead, refreshSlot } from "./admin/refreshSlot";
 import { archiveSlugForSelection } from "./lib/archiveContext";
 import { channelKey } from "./lib/channelKey";
 import { conversationMuteKey, isConversationMuted } from "./lib/conversationMute";
@@ -52,13 +53,19 @@ import {
 // pinned launcher stays in view while a long list scrolls internally, on
 // desktop as it already did on mobile).
 //
-// #1040 — HOME is the exception, and it is an exception to the REASON, not to
+// #1040 — HOME is an exception, and it is an exception to the REASON, not to
 // the rule. #500's cost was a nick-list cost; `RailContext` renders nothing for
 // home, so that window's rail is an empty column with one launcher pinned to
 // its bottom, charging a tap to reach buttons that had nowhere to be pushed to.
 // On home the actions therefore lay out EXPANDED and in flow from the top of
-// the rail, and the launcher is not rendered at all. Every other kind keeps
-// #500 verbatim — the launcher stays the single door everywhere else.
+// the rail, and the launcher is not rendered at all.
+//
+// #1073 — ADMIN is the second, on the same reason and not by analogy:
+// `RailContext` has no admin arm either and `MembersPane` is joined-channel
+// gated, so that rail is as empty above the actions as home's. It also matters
+// more there — the console's close × was deleted, so this menu is the way out
+// of it. Every OTHER kind keeps #500 verbatim: the launcher stays the single
+// door everywhere else.
 //
 // The expanded state is not "the overlay, left open": the popover geometry
 // (absolute, `bottom: 100%`, a max-height measured from the space above the
@@ -91,14 +98,19 @@ import {
 // navigation away.
 //
 // Buttons, in order: home · rooms · mentions · themes · archive · settings ·
-// admin · denoise · detach · quit. Each carries its NAME as visible text next
-// to the glyph (#473: bare emoji had to be guessed / long-pressed).
+// admin · refresh · denoise · detach · quit. Each carries its NAME as visible
+// text next to the glyph (#473: bare emoji had to be guessed / long-pressed).
 //
 // Gating is CAPABILITY-only — no form-factor gates (#473):
 //   * home / themes / settings / archive / quit — always.
 //   * rooms — needs a network context (`archiveSlugForSelection()`).
 //   * mentions — needs a bundle to re-open for that network context.
 //   * admin — `isAdmin()`.
+//   * refresh — #1073, the active admin tab's re-fetch, registered on
+//     `admin/refreshSlot`. Present only while the console is open, only for a
+//     tab that has a fetch to repeat, and only where that seam says the rail
+//     is the button's home (the phone; on desktop it renders in the data
+//     card's own head instead).
 //   * denoise — channel-gated (a channel window is selected).
 //   * detach — `canDetach()`: a persistent identity has a bouncer to leave
 //     running, an ephemeral visitor does not.
@@ -505,6 +517,51 @@ const RailActions: Component<Props> = (props) => {
               </span>
               <span class="rail-action-label">admin</span>
             </button>
+          </Show>
+
+          {/* #1073 — the active admin tab's refresh. vjt: *"il refresh può
+              tranquillamente stare tra le actions nel rail, non serve così
+              prominente"*. It used to be one of two controls in the console's
+              own band, which is more prominence than a re-fetch earns.
+
+              The rail knows nothing about admin tabs: `refreshSlot` is the
+              module singleton a tab registers itself on while mounted, so the
+              row appears only for a tab that HAS something to re-fetch (Events
+              has no fetch and correctly contributes nothing) and disappears
+              with the console. It carries the tab's own testid, unchanged by
+              the move: `admin-visitors-refresh` and its siblings are what the
+              tabs' own suites assert the registration publishes, and renaming
+              a control while relocating it hides which of the two broke.
+
+              `refreshInCardHead()` is the desktop placement, next to the data
+              rather than in the window furniture; rendering here as well would
+              put a duplicate `admin-*-refresh` in the DOM. One button either
+              way, which is the seam's whole contract. */}
+          <Show when={!refreshInCardHead() && refreshSlot()}>
+            {(reg) => (
+              <button
+                type="button"
+                class="shell-chrome-btn rail-action rail-action-refresh"
+                aria-label={reg().label}
+                aria-busy={reg().busy()}
+                data-testid={reg().testId}
+                onClick={() => {
+                  reg().onRefresh();
+                  // The rail is a drawer OVER the pane on a phone — this is
+                  // mobile-only by the gate above — so leaving it up would hide
+                  // the table the operator just asked to re-fetch. Unlike
+                  // denoise, which flips a pref in place, the whole point of
+                  // this action is the result behind the drawer.
+                  props.setters.setMembersOpen(false);
+                  close();
+                }}
+              >
+                <span class="rail-action-icon" aria-hidden="true">
+                  {"\u{21BB}"}
+                </span>
+                <span class="rail-action-label">refresh</span>
+              </button>
+            )}
           </Show>
 
           {/* #222 — per-channel join/part/quit/nick-change suppression toggle

--- a/cicchetto/src/RailActions.tsx
+++ b/cicchetto/src/RailActions.tsx
@@ -199,20 +199,30 @@ const RailActions: Component<Props> = (props) => {
       : null;
   };
 
-  // #1040 — home is the ONE kind where the actions are not collapsed. #500's
-  // cost was a NICK LIST cost (the column pushed the list below the fold), and
+  // #1040 — home is a kind where the actions are not collapsed. #500's cost was
+  // a NICK LIST cost (the column pushed the list below the fold), and
   // `RailContext` renders nothing for home, so on this window there is no list
   // to protect and the launcher charges a tap for nothing. Derived from the
   // selection rather than held as a second signal: "which kind am I showing" is
   // state that already exists.
-  const expanded = (): boolean => selectedChannel()?.kind === "home";
+  //
+  // #1073 — admin joins it on the same test, not by analogy: `RailContext` has
+  // no admin arm either, and `MembersPane` is gated on
+  // `isActiveChannelJoined()`, so the admin window's rail is as empty above the
+  // actions as home's. It also carries more weight here than on home — the
+  // console's close × was deleted, so this menu IS the way out of it.
+  const expanded = (): boolean => {
+    const kind = selectedChannel()?.kind;
+    return kind === "home" || kind === "admin";
+  };
 
   // #500 — collapsible-menu open state (ephemeral UI-local, see moduledoc).
   const [open, setOpen] = createSignal(false);
   const close = (): void => {
     setOpen(false);
   };
-  // #1040 — a menu opened on a channel is retired on arrival at home. Every
+  // #1040 — a menu opened on a channel is retired on arrival at an expanded
+  // kind (home, and admin since #1073). Every
   // rail action already closes it, and an outside pointerdown closes it too,
   // but neither covers a selection change the rail did not cause (the #986
   // demote redirect lands on home on its own). Without this the transient

--- a/cicchetto/src/Shell.tsx
+++ b/cicchetto/src/Shell.tsx
@@ -641,19 +641,13 @@ const Shell: Component = () => {
             <Switch fallback={<CrtSplash />}>
               <Match when={isAdminPaneVisible()}>
                 {/* UX-4 bucket N — AdminPane mount driven by selection +
-                    isAdmin guard. onClose navigates back to home, mirroring
-                    the demote-redirect effect; both paths terminate at the
-                    same landing window. */}
+                    isAdmin guard. #1073 deleted the pane's close × and its
+                    `onClose` with it: selection is what unmounts this pane,
+                    and the rail the ☰ opens already carries `home`. The
+                    demote-redirect effect still lands on that same window. */}
                 <AdminPane
                   onOpenRail={() =>
                     toggleMembersPanel({ membersOpen, setMembersOpen, setSettingsOpen })
-                  }
-                  onClose={() =>
-                    setSelectedChannel({
-                      networkSlug: HOME_WINDOW_SLUG,
-                      channelName: HOME_WINDOW_NAME,
-                      kind: "home",
-                    })
                   }
                 />
               </Match>
@@ -930,13 +924,6 @@ const Shell: Component = () => {
               <AdminPane
                 onOpenRail={() =>
                   toggleMembersPanel({ membersOpen, setMembersOpen, setSettingsOpen })
-                }
-                onClose={() =>
-                  setSelectedChannel({
-                    networkSlug: HOME_WINDOW_SLUG,
-                    channelName: HOME_WINDOW_NAME,
-                    kind: "home",
-                  })
                 }
               />
             </Match>

--- a/cicchetto/src/TopicBar.tsx
+++ b/cicchetto/src/TopicBar.tsx
@@ -17,6 +17,7 @@ import { createOverlayLock } from "./lib/overlayScrollLock";
 import { pushChannelTopicClear } from "./lib/socket";
 import { windowIsJoined } from "./lib/windowState";
 import { MircBody } from "./MircText";
+import PaneTopBar from "./PaneTopBar";
 
 // Top bar of the middle pane. Hosts:
 //  * channel-name + modes box (#275): the channel name (bold accent) on line
@@ -268,7 +269,7 @@ const TopicBar: Component<Props> = (props) => {
   };
 
   return (
-    <div class="topic-bar">
+    <>
       {/* UX-4 bucket L (2026-05-19): TopicBar's left channel-sidebar
           hamburger was dropped (sidebar is always-visible on desktop,
           not rendered on mobile — no toggle needed). The settings cog
@@ -277,20 +278,25 @@ const TopicBar: Component<Props> = (props) => {
           every window" rule.
           UX-5 bucket A (2026-05-19): ShellChrome's own hamburger was
           also dropped — it was a desktop no-op and duplicated this
-          bar's right members hamburger on mobile. TopicBar's
-          `.topic-bar-hamburger` below (channel-only, CSS-hidden on
-          desktop via @media) is now the SINGLE hamburger across the
-          whole shell. */}
-      {/* #644 — the two text columns (namebox + topic strip) are grouped under
-          ONE wrapper so `.topic-bar { align-items: center }` centres this block
-          and the hamburger as UNITS (auto-centre, no magic constant), while
-          `.topic-bar-header { align-items: flex-start }` PRESERVES #344's
-          intra-block line-registration (topic line-1 beside the channel name,
-          line-2 beside +modes). Before this wrapper the columns top-aligned to
-          the taller 48px hamburger / stretched bar and floated high with empty
-          space below (#644). The members hamburger stays a SIBLING of this
-          wrapper (below), outside the centred block. */}
-      <div class="topic-bar-header">
+          bar's right members hamburger on mobile. `.topic-bar-hamburger`
+          (CSS-hidden on desktop via @media) is now the SINGLE hamburger
+          across the whole shell — and since #1073 it lives in
+          `PaneTopBar`, which is also where the admin console gets it.
+          #1073 — the band itself (`.topic-bar` + the `.topic-bar-header`
+          slot + the trailing ☰) moved to `PaneTopBar` so the admin
+          console renders the SAME bar with different content in it. What
+          stays here is what was always channel-shaped: the namebox, the
+          mode string, the topic strip and the two modals. The #644
+          grouping rationale — the two text columns centre as ONE unit
+          against the ☰, while the wrapper's own `flex-start` preserves
+          #344's line registration — now lives on the slot, in
+          `PaneTopBar`.
+          The modals are SIBLINGS of the bar rather than children of it
+          now. They are `position: fixed` at `z-index: 201` with no
+          selector descending from `.topic-bar`, so the move is inert;
+          and while closed `<Show>` renders no element, which is what
+          keeps the bar's child list at exactly two. */}
+      <PaneTopBar onOpenRail={props.onToggleMembers} railLabel="open members sidebar">
         {/* #275 — channel name + modes STACKED in ONE width-capped clickable
           box. The whole box opens the /mode viewer/editor modal (reuse
           `openModeModal` — the SAME verb `/mode #chan`, bare `/mode`, and the
@@ -351,28 +357,9 @@ const TopicBar: Component<Props> = (props) => {
             </Show>
           </span>
         </button>
-      </div>
+      </PaneTopBar>
       {/* #71 INC-2 — the presence-filter toggle (👁/🙈) moved to the right-rail
           RailActions drawer (channel-gated). It is no longer rendered here. */}
-      {/* #881 — UNCONDITIONAL. This ☰ is not a members toggle, it is the
-          rail door: on mobile it opens `.shell-members`, which since #71
-          INC-2 / #473 is the permanent right rail hosting Archive, Settings,
-          Rooms and Admin — and it is the ONLY door a channel window has
-          (ShellChrome's opener renders for `kind !== "channel"`). It used to
-          sit behind `windowIsJoined`, on the premise that it toggled a member
-          list; the member list is gated in Shell.tsx and this gate took the
-          whole navigation with it, stranding a `:failed`/`:kicked`/`:parked`
-          window with no way out. vjt's ruling: a non-joined window is not a
-          different window shape — same surface as a joined one, MINUS the
-          members list. So joinedness gates the list, never the door. */}
-      <button
-        type="button"
-        class="topic-bar-hamburger shell-chrome-btn"
-        aria-label="open members sidebar"
-        onClick={props.onToggleMembers}
-      >
-        ☰
-      </button>
 
       {/* Topic modal (#263) — opens read-only for everyone on strip click;
           shows full topic, setter, timestamp. An op (canEditTopic) also sees a
@@ -474,7 +461,7 @@ const TopicBar: Component<Props> = (props) => {
           </div>
         </div>
       </Show>
-    </div>
+    </>
   );
 };
 

--- a/cicchetto/src/__tests__/AdminOverviewStats.test.tsx
+++ b/cicchetto/src/__tests__/AdminOverviewStats.test.tsx
@@ -1,0 +1,105 @@
+import { render } from "@solidjs/testing-library";
+import { describe, expect, it } from "vitest";
+import AdminOverviewStats from "../AdminOverviewStats";
+
+// #1073 — the admin bar's left group. Pure presentation: it is handed the
+// numbers and decides how they read. Two of its rules are correctness, not
+// taste, and both come from what #1075 measured on the server side:
+//
+//   1. the loadavg is the HOST's, because a jail shares the host kernel
+//      (`sysctl vm.loadavg` reads identically inside and out) — an unlabelled
+//      number is read as "grappa is busy", which is a different claim;
+//   2. an unavailable sampler arrives as `null`, and `null` is NOT zero. The
+//      server refuses to fabricate a 0.0 for "cannot measure"; the bar must
+//      not undo that by rendering the two the same.
+
+const full = () => ({
+  sessions: 3,
+  visitors: { total: 5, live: 2 },
+  hostname: "m42",
+  loadavg: 0.42,
+  version: "0.15.0",
+});
+
+describe("AdminOverviewStats", () => {
+  it("renders every stat the bar carries", () => {
+    const { container } = render(() => <AdminOverviewStats overview={full()} />);
+    const text = container.textContent ?? "";
+    expect(text).toContain("3");
+    expect(text).toContain("m42");
+    expect(text).toContain("0.15.0");
+  });
+
+  it("shows visitors as live-over-total, not one number", () => {
+    // The DB/live pair is the whole point of the server sending two numbers:
+    // "2 of 5 visitors are connected" is a diagnostic, "5 visitors" is not.
+    const { getByTestId } = render(() => <AdminOverviewStats overview={full()} />);
+    expect(getByTestId("admin-overview-visitors").textContent).toContain("2/5");
+  });
+
+  describe("the loadavg is the HOST's", () => {
+    it("labels it as the host's, never as a bare load", () => {
+      const { getByTestId } = render(() => <AdminOverviewStats overview={full()} />);
+      const el = getByTestId("admin-overview-loadavg");
+      // Either the visible text or the accessible description must say whose
+      // load this is; a bare "0.42" is the reading we are preventing.
+      const described = `${el.textContent ?? ""} ${el.getAttribute("title") ?? ""}`;
+      expect(described.toLowerCase()).toContain("host");
+    });
+
+    it("still shows the number", () => {
+      const { getByTestId } = render(() => <AdminOverviewStats overview={full()} />);
+      expect(getByTestId("admin-overview-loadavg").textContent).toContain("0.42");
+    });
+  });
+
+  describe("an unavailable sampler is not a calm machine", () => {
+    it("renders null distinctly from zero", () => {
+      const { getByTestId: getUnknown } = render(() => (
+        <AdminOverviewStats overview={{ ...full(), loadavg: null }} />
+      ));
+      const { getByTestId: getZero } = render(() => (
+        <AdminOverviewStats overview={{ ...full(), loadavg: 0 }} />
+      ));
+
+      const unknown = getUnknown("admin-overview-loadavg").textContent ?? "";
+      const zero = getZero("admin-overview-loadavg").textContent ?? "";
+
+      expect(unknown).not.toBe(zero);
+    });
+
+    it("a null loadavg shows no digit at all", () => {
+      // The failure mode this guards is rendering `null` through a formatter
+      // that coerces it — `Number(null)` is 0, and `(null).toFixed` throwing
+      // would at least be loud. A quiet "0.00" would tell the operator the box
+      // is idle when the truth is that we cannot see it.
+      const { getByTestId } = render(() => (
+        <AdminOverviewStats overview={{ ...full(), loadavg: null }} />
+      ));
+      expect(getByTestId("admin-overview-loadavg").textContent ?? "").not.toMatch(/\d/);
+    });
+
+    it("says WHY it is blank, not just that it is", () => {
+      const { getByTestId } = render(() => (
+        <AdminOverviewStats overview={{ ...full(), loadavg: null }} />
+      ));
+      const title = getByTestId("admin-overview-loadavg").getAttribute("title") ?? "";
+      expect(title.toLowerCase()).toContain("unavailable");
+    });
+
+    it("a measured zero is shown as a number, not as unknown", () => {
+      const { getByTestId } = render(() => (
+        <AdminOverviewStats overview={{ ...full(), loadavg: 0 }} />
+      ));
+      expect(getByTestId("admin-overview-loadavg").textContent ?? "").toMatch(/0/);
+    });
+  });
+
+  it("renders nothing at all before the first push has landed", () => {
+    // The bar mounts with the console; the join push follows. Rendering
+    // placeholder zeroes in that window would be the same lie as coercing a
+    // null loadavg — briefly, but on every open.
+    const { container } = render(() => <AdminOverviewStats overview={null} />);
+    expect(container.querySelector(".admin-overview-stats")).toBeNull();
+  });
+});

--- a/cicchetto/src/__tests__/AdminPane.test.tsx
+++ b/cicchetto/src/__tests__/AdminPane.test.tsx
@@ -157,6 +157,45 @@ describe("AdminPane", () => {
     expect(screen.getByLabelText(/close admin console/i)).toBeInTheDocument();
   });
 
+  // #1073 — the band is the channel windows' bar, not a lookalike. vjt: *"la
+  // top bar admin dev'esser possibilmente la stessa barra che abbiamo per i
+  // canali, solo con dentro roba diversa"*. `.admin-pane-header` was a second
+  // implementation of the same idea on the `--adm-*` layer, and the two
+  // disagreed about which side the ☰ sits on.
+  describe("#1073 — the band is the shared pane top bar", () => {
+    it("renders `.topic-bar`, and the private `.admin-pane-header` is gone", () => {
+      const { container } = render(() => <AdminPane onClose={vi.fn()} onOpenRail={vi.fn()} />);
+      expect(container.querySelector(".topic-bar")).not.toBeNull();
+      expect(container.querySelector(".admin-pane-header")).toBeNull();
+    });
+
+    // The side is not a CSS override, it is the child order — the same fact
+    // `TopicBar.test.tsx` pins for the channel host.
+    it("puts the ☰ LAST, which is what places it on the right", () => {
+      const { container } = render(() => <AdminPane onClose={vi.fn()} onOpenRail={vi.fn()} />);
+      const bar = container.querySelector(".topic-bar");
+      expect(bar?.lastElementChild).toHaveClass("topic-bar-hamburger");
+    });
+
+    it("the ☰ opens the rail", () => {
+      const onOpenRail = vi.fn();
+      const { container } = render(() => <AdminPane onClose={vi.fn()} onOpenRail={onOpenRail} />);
+      const ham = container.querySelector(".topic-bar-hamburger");
+      expect(ham).not.toBeNull();
+      fireEvent.click(ham as Element);
+      expect(onOpenRail).toHaveBeenCalledTimes(1);
+    });
+
+    // The accessible name is UNCHANGED from the inline `RailOpenerButton` this
+    // replaces: the admin door has always been "open actions" and the channel
+    // one "open members sidebar". `ux-4-z-cluster-journey` reaches this door on
+    // the admin window, and eight specs reach the channel one by its own name.
+    it("keeps the admin door's accessible name", () => {
+      render(() => <AdminPane onClose={vi.fn()} onOpenRail={vi.fn()} />);
+      expect(screen.getByLabelText(/open actions/i)).toBeInTheDocument();
+    });
+  });
+
   it("starts admin-events subscription on mount, tears down on unmount (M-11)", () => {
     startSub.mockClear();
     uninstall.mockClear();

--- a/cicchetto/src/__tests__/AdminPane.test.tsx
+++ b/cicchetto/src/__tests__/AdminPane.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 // M-cluster M-8 / M-9b / M-10 / M-11 + UX-6-B2 — AdminPane mounts
 // Visitors + Sessions + Networks + Events + Settings tabs inside
 // their respective tabpanels. Mock all five so this suite stays
-// focused on the OUTER PANE contract (header + close + tab nav +
+// focused on the OUTER PANE contract (header + tab nav +
 // active-tab switching + admin-events subscription lifecycle).
 vi.mock("../AdminVisitorsTab", () => ({
   default: () => <div data-testid="admin-visitors-tab-mock">visitors-tab</div>,
@@ -50,12 +50,12 @@ import AdminPane from "../AdminPane";
 
 describe("AdminPane", () => {
   it("renders the 'admin console' header", () => {
-    render(() => <AdminPane onClose={vi.fn()} onOpenRail={vi.fn()} />);
+    render(() => <AdminPane onOpenRail={vi.fn()} />);
     expect(screen.getByRole("heading", { name: /admin console/i })).toBeInTheDocument();
   });
 
   it("renders all five tabs with Sessions as the default-active tab", () => {
-    render(() => <AdminPane onClose={vi.fn()} onOpenRail={vi.fn()} />);
+    render(() => <AdminPane onOpenRail={vi.fn()} />);
     const visitorsTab = screen.getByTestId("admin-tab-visitors");
     const sessionsTab = screen.getByTestId("admin-tab-sessions");
     const networksTab = screen.getByTestId("admin-tab-networks");
@@ -77,7 +77,7 @@ describe("AdminPane", () => {
   });
 
   it("mounts AdminSessionsTab inside the active tabpanel by default", () => {
-    render(() => <AdminPane onClose={vi.fn()} onOpenRail={vi.fn()} />);
+    render(() => <AdminPane onOpenRail={vi.fn()} />);
     expect(screen.getByTestId("admin-sessions-tab-mock")).toBeInTheDocument();
     expect(screen.queryByTestId("admin-visitors-tab-mock")).toBeNull();
     expect(screen.queryByTestId("admin-networks-tab-mock")).toBeNull();
@@ -86,7 +86,7 @@ describe("AdminPane", () => {
   });
 
   it("clicking the Visitors tab swaps the active panel + flips aria-selected", () => {
-    render(() => <AdminPane onClose={vi.fn()} onOpenRail={vi.fn()} />);
+    render(() => <AdminPane onOpenRail={vi.fn()} />);
     fireEvent.click(screen.getByTestId("admin-tab-visitors"));
     expect(screen.getByTestId("admin-visitors-tab-mock")).toBeInTheDocument();
     expect(screen.queryByTestId("admin-sessions-tab-mock")).toBeNull();
@@ -97,7 +97,7 @@ describe("AdminPane", () => {
   });
 
   it("clicking the Networks tab swaps the active panel + flips aria-selected", () => {
-    render(() => <AdminPane onClose={vi.fn()} onOpenRail={vi.fn()} />);
+    render(() => <AdminPane onOpenRail={vi.fn()} />);
     fireEvent.click(screen.getByTestId("admin-tab-networks"));
     expect(screen.getByTestId("admin-networks-tab-mock")).toBeInTheDocument();
     expect(screen.queryByTestId("admin-events-tab-mock")).toBeNull();
@@ -105,7 +105,7 @@ describe("AdminPane", () => {
   });
 
   it("clicking the Events tab swaps the active panel + flips aria-selected", () => {
-    render(() => <AdminPane onClose={vi.fn()} onOpenRail={vi.fn()} />);
+    render(() => <AdminPane onOpenRail={vi.fn()} />);
     fireEvent.click(screen.getByTestId("admin-tab-events"));
     expect(screen.getByTestId("admin-events-tab-mock")).toBeInTheDocument();
     expect(screen.queryByTestId("admin-visitors-tab-mock")).toBeNull();
@@ -116,7 +116,7 @@ describe("AdminPane", () => {
   });
 
   it("clicking the Session Log tab swaps the active panel + flips aria-selected (#215)", () => {
-    render(() => <AdminPane onClose={vi.fn()} onOpenRail={vi.fn()} />);
+    render(() => <AdminPane onOpenRail={vi.fn()} />);
     fireEvent.click(screen.getByTestId("admin-tab-session_log"));
     expect(screen.getByTestId("admin-session-log-tab-mock")).toBeInTheDocument();
     expect(screen.queryByTestId("admin-visitors-tab-mock")).toBeNull();
@@ -127,7 +127,7 @@ describe("AdminPane", () => {
   });
 
   it("clicking the Settings tab swaps the active panel + flips aria-selected (UX-6-B2)", () => {
-    render(() => <AdminPane onClose={vi.fn()} onOpenRail={vi.fn()} />);
+    render(() => <AdminPane onOpenRail={vi.fn()} />);
     fireEvent.click(screen.getByTestId("admin-tab-settings"));
     expect(screen.getByTestId("admin-settings-tab-mock")).toBeInTheDocument();
     expect(screen.queryByTestId("admin-visitors-tab-mock")).toBeNull();
@@ -138,23 +138,22 @@ describe("AdminPane", () => {
   });
 
   it("clicking back to Visitors after Sessions returns the original panel", () => {
-    render(() => <AdminPane onClose={vi.fn()} onOpenRail={vi.fn()} />);
+    render(() => <AdminPane onOpenRail={vi.fn()} />);
     fireEvent.click(screen.getByTestId("admin-tab-sessions"));
     fireEvent.click(screen.getByTestId("admin-tab-visitors"));
     expect(screen.getByTestId("admin-visitors-tab-mock")).toBeInTheDocument();
     expect(screen.queryByTestId("admin-sessions-tab-mock")).toBeNull();
   });
 
-  it("close button fires onClose", () => {
-    const onClose = vi.fn();
-    render(() => <AdminPane onClose={onClose} onOpenRail={vi.fn()} />);
-    fireEvent.click(screen.getByTestId("admin-pane-close"));
-    expect(onClose).toHaveBeenCalledTimes(1);
-  });
-
-  it("close button carries an a11y label", () => {
-    render(() => <AdminPane onClose={vi.fn()} onOpenRail={vi.fn()} />);
-    expect(screen.getByLabelText(/close admin console/i)).toBeInTheDocument();
+  // #1073 — vjt: *"la x sparisce"*. Not relocated: DELETED. Selection is what
+  // mounts and unmounts this pane, and the rail the ☰ opens already carries
+  // `home` and `rooms`, so a "close admin" verb would be a second name for the
+  // work `home` already does. The pane consequently has no `onClose` prop at
+  // all — there is no caller left to hand one to.
+  it("carries no close ×: leaving the console is the rail's job", () => {
+    render(() => <AdminPane onOpenRail={vi.fn()} />);
+    expect(screen.queryByTestId("admin-pane-close")).toBeNull();
+    expect(screen.queryByLabelText(/close admin console/i)).toBeNull();
   });
 
   // #1073 — the band is the channel windows' bar, not a lookalike. vjt: *"la
@@ -164,7 +163,7 @@ describe("AdminPane", () => {
   // disagreed about which side the ☰ sits on.
   describe("#1073 — the band is the shared pane top bar", () => {
     it("renders `.topic-bar`, and the private `.admin-pane-header` is gone", () => {
-      const { container } = render(() => <AdminPane onClose={vi.fn()} onOpenRail={vi.fn()} />);
+      const { container } = render(() => <AdminPane onOpenRail={vi.fn()} />);
       expect(container.querySelector(".topic-bar")).not.toBeNull();
       expect(container.querySelector(".admin-pane-header")).toBeNull();
     });
@@ -172,14 +171,14 @@ describe("AdminPane", () => {
     // The side is not a CSS override, it is the child order — the same fact
     // `TopicBar.test.tsx` pins for the channel host.
     it("puts the ☰ LAST, which is what places it on the right", () => {
-      const { container } = render(() => <AdminPane onClose={vi.fn()} onOpenRail={vi.fn()} />);
+      const { container } = render(() => <AdminPane onOpenRail={vi.fn()} />);
       const bar = container.querySelector(".topic-bar");
       expect(bar?.lastElementChild).toHaveClass("topic-bar-hamburger");
     });
 
     it("the ☰ opens the rail", () => {
       const onOpenRail = vi.fn();
-      const { container } = render(() => <AdminPane onClose={vi.fn()} onOpenRail={onOpenRail} />);
+      const { container } = render(() => <AdminPane onOpenRail={onOpenRail} />);
       const ham = container.querySelector(".topic-bar-hamburger");
       expect(ham).not.toBeNull();
       fireEvent.click(ham as Element);
@@ -191,7 +190,7 @@ describe("AdminPane", () => {
     // one "open members sidebar". `ux-4-z-cluster-journey` reaches this door on
     // the admin window, and eight specs reach the channel one by its own name.
     it("keeps the admin door's accessible name", () => {
-      render(() => <AdminPane onClose={vi.fn()} onOpenRail={vi.fn()} />);
+      render(() => <AdminPane onOpenRail={vi.fn()} />);
       expect(screen.getByLabelText(/open actions/i)).toBeInTheDocument();
     });
   });
@@ -199,7 +198,7 @@ describe("AdminPane", () => {
   it("starts admin-events subscription on mount, tears down on unmount (M-11)", () => {
     startSub.mockClear();
     uninstall.mockClear();
-    const { unmount } = render(() => <AdminPane onClose={vi.fn()} onOpenRail={vi.fn()} />);
+    const { unmount } = render(() => <AdminPane onOpenRail={vi.fn()} />);
     expect(startSub).toHaveBeenCalledTimes(1);
     expect(uninstall).toHaveBeenCalledTimes(0);
     unmount();

--- a/cicchetto/src/__tests__/AdminPane.test.tsx
+++ b/cicchetto/src/__tests__/AdminPane.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from "@solidjs/testing-library";
-import { describe, expect, it, vi } from "vitest";
+import type { Channel } from "phoenix";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // M-cluster M-8 / M-9b / M-10 / M-11 + UX-6-B2 — AdminPane mounts
 // Visitors + Sessions + Networks + Events + Settings tabs inside
@@ -42,6 +43,10 @@ vi.mock("../lib/adminEvents", () => ({
 }));
 
 import AdminPane from "../AdminPane";
+// NOT mocked: the overview store is a plain signal with no socket of its own
+// (adminEvents.ts owns the channel), so the pane's wiring to it is exercised
+// for real by installing a fake channel and firing the server's push.
+import { installAdminOverview, resetAdminOverview } from "../lib/adminOverview";
 
 // M-cluster M-7 / M-8 / M-9b / M-10 / M-11 — admin console pane.
 // Per `feedback_e2e_user_class_parity_matrix`: AdminPane itself is
@@ -192,6 +197,88 @@ describe("AdminPane", () => {
     it("keeps the admin door's accessible name", () => {
       render(() => <AdminPane onOpenRail={vi.fn()} />);
       expect(screen.getByLabelText(/open actions/i)).toBeInTheDocument();
+    });
+  });
+
+  // #1073 — the issue's "Done when": the bar's LEFT side carries the live key
+  // stats. They are mounted in `PaneTopBar`'s content slot, the same slot the
+  // channel bar fills with its namebox and topic strip.
+  describe("#1073 — the live stats in the bar's left group", () => {
+    const OVERVIEW = {
+      sessions: 3,
+      visitors: { total: 5, live: 2 },
+      hostname: "m42",
+      loadavg: 0.42,
+      version: "0.15.0",
+    };
+
+    function fakeChannel(): { channel: Channel; fire: (p: unknown) => void } {
+      let cb: ((p: unknown) => void) | null = null;
+      const channel = {
+        on: (name: string, handler: unknown) => {
+          if (name === "overview") cb = handler as (p: unknown) => void;
+          return 0;
+        },
+        leave: () => ({ receive: () => ({ receive: () => undefined }) }),
+      } as unknown as Channel;
+      return { channel, fire: (p) => cb?.(p) };
+    }
+
+    beforeEach(() => resetAdminOverview());
+    afterEach(() => resetAdminOverview());
+
+    it("renders the stats once the first push has landed", () => {
+      const fake = fakeChannel();
+      installAdminOverview(fake.channel);
+      fake.fire(OVERVIEW);
+
+      const { container } = render(() => <AdminPane onOpenRail={vi.fn()} />);
+
+      const stats = container.querySelector(".admin-overview-stats");
+      expect(stats).not.toBeNull();
+      expect(stats?.textContent ?? "").toContain("m42");
+    });
+
+    it("puts them INSIDE the bar's content slot, not loose in the pane", () => {
+      // `.topic-bar-header` is the slot; anything outside it is a second row of
+      // chrome, which is the thing #1073 removes rather than adds.
+      const fake = fakeChannel();
+      installAdminOverview(fake.channel);
+      fake.fire(OVERVIEW);
+
+      const { container } = render(() => <AdminPane onOpenRail={vi.fn()} />);
+
+      expect(container.querySelector(".topic-bar-header .admin-overview-stats")).not.toBeNull();
+    });
+
+    it("still puts the ☰ last, with the stats in front of it", () => {
+      const fake = fakeChannel();
+      installAdminOverview(fake.channel);
+      fake.fire(OVERVIEW);
+
+      const { container } = render(() => <AdminPane onOpenRail={vi.fn()} />);
+
+      expect(container.querySelector(".topic-bar")?.lastElementChild).toHaveClass(
+        "topic-bar-hamburger",
+      );
+    });
+
+    it("renders the bar with no stats at all before the first push", () => {
+      const { container } = render(() => <AdminPane onOpenRail={vi.fn()} />);
+      expect(container.querySelector(".topic-bar")).not.toBeNull();
+      expect(container.querySelector(".admin-overview-stats")).toBeNull();
+    });
+
+    it("updates in place when the next tick arrives", () => {
+      const fake = fakeChannel();
+      installAdminOverview(fake.channel);
+      fake.fire(OVERVIEW);
+
+      const { container } = render(() => <AdminPane onOpenRail={vi.fn()} />);
+      fake.fire({ ...OVERVIEW, sessions: 9, hostname: "m43" });
+
+      expect(container.querySelectorAll(".admin-overview-stats").length).toBe(1);
+      expect(container.querySelector(".admin-overview-stats")?.textContent ?? "").toContain("m43");
     });
   });
 

--- a/cicchetto/src/__tests__/RailActions.test.tsx
+++ b/cicchetto/src/__tests__/RailActions.test.tsx
@@ -122,6 +122,25 @@ vi.mock("../lib/selection", () => ({
   setSelectedChannel: (...args: unknown[]) => setSelectedChannel(...args),
 }));
 
+// #1073 — the active admin tab's refresh registers itself here and the rail
+// renders it. Both halves of the seam are mocked: WHICH tab registered (the
+// registration, `null` outside the console) and WHERE the button belongs (the
+// desktop card head vs the rail). The seam's own behaviour — register on
+// mount, identity-compared cleanup — is covered by the tabs' suites.
+const refreshHolder = vi.hoisted(() => ({
+  value: null as {
+    onRefresh: () => void;
+    busy: () => boolean;
+    label: string;
+    testId: string;
+  } | null,
+}));
+const inCardHeadHolder = vi.hoisted(() => ({ value: false }));
+vi.mock("../admin/refreshSlot", () => ({
+  refreshSlot: () => refreshHolder.value,
+  refreshInCardHead: () => inCardHeadHolder.value,
+}));
+
 const roomsSlugHolder: { value: string | null } = { value: "freenode" };
 vi.mock("../lib/archiveContext", () => ({
   archiveSlugForSelection: () => roomsSlugHolder.value,
@@ -149,6 +168,7 @@ import { dismissConfirm } from "../lib/confirmDialog";
 import RailActions from "../RailActions";
 
 const channelSel: Sel = { networkSlug: "freenode", channelName: "#italia", kind: "channel" };
+const adminSel: Sel = { networkSlug: "$admin", channelName: "$admin", kind: "admin" };
 
 const setters = {
   membersOpen: () => false,
@@ -163,6 +183,8 @@ beforeEach(() => {
   mentionsBundles.value = {};
   subjectHolder.current = null;
   mutedHolder.value = {};
+  refreshHolder.value = null;
+  inCardHeadHolder.value = false;
   dismissConfirm();
 });
 
@@ -925,12 +947,68 @@ describe("RailActions expanded home rail (#1040)", () => {
   // above already pins that they stay off; a second copy of those tests would
   // measure the gate twice and the kind not at all.
   it("gives the admin console the same expanded rail (#1073)", async () => {
-    selHolder.value = { networkSlug: "$admin", channelName: "$admin", kind: "admin" };
+    selHolder.value = adminSel;
     const { container } = render(() => <RailActions setters={setters} />);
     expect(container.querySelector(".rail-actions")).toHaveClass("expanded");
     expect(screen.queryByTestId(LAUNCHER)).toBeNull();
     expect(screen.getByTestId("mobile-panel-home")).toBeInTheDocument();
     await settle();
     expect(overlayCount()).toBe(0);
+  });
+});
+
+// #1073 — vjt: *"il refresh può tranquillamente stare tra le actions nel
+// rail, non serve così prominente"*. It leaves the console's band, where it
+// was one of only two controls, and becomes a rail row like any other.
+//
+// The registration is what makes this possible without RailActions knowing
+// anything about admin tabs: it carries the tab's OWN testid, so the button
+// the e2e specs click keeps its name across the move.
+describe("the admin refresh, moved into the rail (#1073)", () => {
+  const reg = (testId: string): NonNullable<typeof refreshHolder.value> => ({
+    onRefresh: vi.fn(),
+    busy: () => false,
+    label: "refresh visitors list",
+    testId,
+  });
+
+  it("renders the registered refresh under its own testid and fires it", () => {
+    selHolder.value = adminSel;
+    const registration = reg("admin-visitors-refresh");
+    refreshHolder.value = registration;
+    render(() => <RailActions setters={setters} />);
+    const btn = screen.getByTestId("admin-visitors-refresh");
+    expect(btn).toHaveAttribute("aria-label", "refresh visitors list");
+    fireEvent.click(btn);
+    expect(registration.onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  // On a phone the rail is a drawer laid OVER the pane, so leaving it up
+  // would hide the very table the operator just asked to re-fetch.
+  it("dismisses the rail so the refreshed pane is what you land on", () => {
+    selHolder.value = adminSel;
+    refreshHolder.value = reg("admin-sessions-refresh");
+    render(() => <RailActions setters={setters} />);
+    fireEvent.click(screen.getByTestId("admin-sessions-refresh"));
+    expect(setters.setMembersOpen).toHaveBeenCalledWith(false);
+  });
+
+  // Two ways for the row to be wrong, and they fail differently: a DESKTOP
+  // duplicate would put two `admin-*-refresh` nodes in the DOM (the specs
+  // click by that id), while a row rendered with no registration would be a
+  // button wired to nothing.
+  it("renders nothing on desktop, where the button belongs in the card head", () => {
+    selHolder.value = adminSel;
+    refreshHolder.value = reg("admin-visitors-refresh");
+    inCardHeadHolder.value = true;
+    render(() => <RailActions setters={setters} />);
+    expect(screen.queryByTestId("admin-visitors-refresh")).toBeNull();
+  });
+
+  it("renders nothing when no tab has registered a refresh", () => {
+    selHolder.value = adminSel;
+    render(() => <RailActions setters={setters} />);
+    expect(screen.queryByTestId("admin-visitors-refresh")).toBeNull();
+    expect(screen.queryByTestId("rail-action-refresh")).toBeNull();
   });
 });

--- a/cicchetto/src/__tests__/RailActions.test.tsx
+++ b/cicchetto/src/__tests__/RailActions.test.tsx
@@ -911,4 +911,26 @@ describe("RailActions expanded home rail (#1040)", () => {
     expect(container.querySelector(".rail-actions-menu")).not.toBeNull();
     expect(container.querySelector(".rail-actions")).toHaveClass("expanded");
   });
+
+  // #1073 — admin is the SECOND kind, on the same reasoning rather than by
+  // analogy: `RailContext` has no admin arm and `MembersPane` is gated on
+  // `isActiveChannelJoined()`, so on the admin window the rail carries nothing
+  // above the actions either. There is no list to protect, and the launcher
+  // charges a tap for nothing. vjt asked for the rail to open with the menu
+  // "already expanded, as on home", which is what the door out of the console
+  // is now made of — #1073 deleted the pane's close ×.
+  //
+  // Only the shape and the refcount are re-asserted here. The three popover
+  // mechanisms are gated on the same `expanded()` this widens, so the home arm
+  // above already pins that they stay off; a second copy of those tests would
+  // measure the gate twice and the kind not at all.
+  it("gives the admin console the same expanded rail (#1073)", async () => {
+    selHolder.value = { networkSlug: "$admin", channelName: "$admin", kind: "admin" };
+    const { container } = render(() => <RailActions setters={setters} />);
+    expect(container.querySelector(".rail-actions")).toHaveClass("expanded");
+    expect(screen.queryByTestId(LAUNCHER)).toBeNull();
+    expect(screen.getByTestId("mobile-panel-home")).toBeInTheDocument();
+    await settle();
+    expect(overlayCount()).toBe(0);
+  });
 });

--- a/cicchetto/src/__tests__/Shell.test.tsx
+++ b/cicchetto/src/__tests__/Shell.test.tsx
@@ -1407,7 +1407,14 @@ describe("Shell — M-7/N admin pane lifecycle", () => {
     expect(container.querySelector(".scrollback-pane")).toBeNull();
   });
 
-  it("clicking admin pane close button returns to home (selection-driven)", async () => {
+  // #1073 — this used to click the pane's × and assert selection landed on
+  // home. The × was deleted (vjt: *"la x sparisce"*) and `onClose` with it, so
+  // there is no Shell-owned close wiring left to pin. What replaces it is the
+  // assertion that Shell hands the pane no such door of its own: the way out is
+  // the rail's `home` row acting on selection, driven end to end by
+  // `m7-admin-gate-settings-drawer`. The OTHER path to the same landing window
+  // — the demote-mid-session redirect — keeps its own test, immediately below.
+  it("mounts the admin pane with no close affordance of its own (#1073)", async () => {
     userHolder.current = { kind: "user", id: "u1", name: "vjt", is_admin: true, inserted_at: "x" };
     // Start on admin window directly — equivalent to the post-launcher
     // state. Avoids re-asserting the rail wiring here (covered by the
@@ -1415,13 +1422,7 @@ describe("Shell — M-7/N admin pane lifecycle", () => {
     selectionState.setSelSig({ networkSlug: "$admin", channelName: "$admin", kind: "admin" });
     const { container } = render(() => <Shell />);
     await waitFor(() => expect(container.querySelector(".admin-pane")).toBeInTheDocument());
-    fireEvent.click(screen.getByTestId("admin-pane-close"));
-    // UX-4 bucket N — onClose navigates selection to home.
-    expect(selectionState.setSelectedChannelMock).toHaveBeenCalledWith({
-      networkSlug: "$home",
-      channelName: "$home",
-      kind: "home",
-    });
+    expect(screen.queryByTestId("admin-pane-close")).toBeNull();
   });
 
   it("UX-4 N — demote-mid-session redirects selection to home when on admin window", async () => {

--- a/cicchetto/src/__tests__/TopicBar.test.tsx
+++ b/cicchetto/src/__tests__/TopicBar.test.tsx
@@ -686,4 +686,31 @@ describe("TopicBar", () => {
       expect(container.querySelector(".topic-bar-header .topic-bar-hamburger")).toBeNull();
     });
   });
+
+  // #1073 — characterization, written BEFORE the bar's shell was extracted so
+  // the extraction has something to be measured against.
+  //
+  // The admin console adopts this same bar, and the reason its ☰ lands on the
+  // RIGHT there is not a new CSS rule: it is that the glyph is `.topic-bar`'s
+  // LAST flex child here. `.admin-pane-header` used to put its opener FIRST,
+  // which is why the two surfaces disagreed about the side. Nothing pinned the
+  // order, so an innocent reshuffle of this JSX could move the channel ☰ and
+  // silently take the admin bar with it.
+  describe("#1073 — the shell the admin bar reuses", () => {
+    it("renders exactly two element children: the header block, then the ☰", () => {
+      const { container } = render(() => <TopicBar {...baseProps()} />);
+      const bar = container.querySelector(".topic-bar");
+      expect(bar).not.toBeNull();
+      const kids = Array.from(bar?.children ?? []);
+      expect(kids).toHaveLength(2);
+      expect(kids[0]).toHaveClass("topic-bar-header");
+      expect(kids[1]).toHaveClass("topic-bar-hamburger");
+    });
+
+    it("puts the ☰ LAST, which is what places it on the right", () => {
+      const { container } = render(() => <TopicBar {...baseProps()} />);
+      const bar = container.querySelector(".topic-bar");
+      expect(bar?.lastElementChild).toHaveClass("topic-bar-hamburger");
+    });
+  });
 });

--- a/cicchetto/src/__tests__/adminEvents.test.ts
+++ b/cicchetto/src/__tests__/adminEvents.test.ts
@@ -18,6 +18,7 @@ import {
   startAdminEventsSubscription,
   uninstallAdminEvents,
 } from "../lib/adminEvents";
+import { adminOverview } from "../lib/adminOverview";
 
 // Fake Channel that captures the .on handlers so the test can fire
 // snapshot / event payloads at will. Matches the slim slice of
@@ -28,16 +29,19 @@ function makeFakeChannel(): {
   fireEvent: (event: WireAdminEvent) => void;
   fireRawSnapshot: (payload: unknown) => void;
   fireRawEvent: (payload: unknown) => void;
+  fireOverview: (payload: unknown) => void;
   leftCount: () => number;
 } {
   let snapshotCb: ((p: unknown) => void) | null = null;
   let eventCb: ((p: unknown) => void) | null = null;
+  let overviewCb: ((p: unknown) => void) | null = null;
   let leftCount = 0;
 
   const channel = {
     on: (name: string, cb: unknown) => {
       if (name === "snapshot") snapshotCb = cb as (p: unknown) => void;
       if (name === "event") eventCb = cb as (p: unknown) => void;
+      if (name === "overview") overviewCb = cb as (p: unknown) => void;
       return 0;
     },
     leave: () => {
@@ -52,6 +56,7 @@ function makeFakeChannel(): {
     fireEvent: (event) => eventCb?.(event),
     fireRawSnapshot: (payload) => snapshotCb?.(payload),
     fireRawEvent: (payload) => eventCb?.(payload),
+    fireOverview: (payload) => overviewCb?.(payload),
     leftCount: () => leftCount,
   };
 }
@@ -60,6 +65,7 @@ beforeEach(() => {
   uninstallAdminEvents();
   expect(adminEvents()).toEqual([]);
   expect(liveCountsByNetworkId()).toEqual({});
+  expect(adminOverview()).toBeNull();
   joinAdminEventsMock.mockReset();
 });
 
@@ -489,6 +495,43 @@ describe("adminEvents — bucket 4 mutation kinds", () => {
       expect(list[0]?.kind).toBe(ev.kind);
     });
   }
+});
+
+// #1073 / #1075 — the admin top bar's `"overview"` push rides THIS channel.
+//
+// adminEvents.ts owns the join/leave, so it also installs the sibling
+// consumers: sessionLog (#215) and now adminOverview. The alternative — a
+// second `joinAdminEvents()` from the bar — would open a second WS channel
+// for a payload the server already pushes here, and would need its own
+// lifecycle to tear down. One channel, three consumers.
+describe("adminEvents — the overview consumer rides the same channel (#1073)", () => {
+  const OVERVIEW = {
+    sessions: 3,
+    visitors: { total: 5, live: 2 },
+    hostname: "m42",
+    loadavg: 0.42,
+    version: "0.15.0",
+  };
+
+  it("installAdminEvents registers the overview handler too (no second join)", () => {
+    const fake = makeFakeChannel();
+    installAdminEvents(fake.channel);
+
+    fake.fireOverview(OVERVIEW);
+
+    expect(adminOverview()).toEqual(OVERVIEW);
+  });
+
+  it("uninstallAdminEvents resets the overview store with the rest", () => {
+    const fake = makeFakeChannel();
+    installAdminEvents(fake.channel);
+    fake.fireOverview(OVERVIEW);
+    expect(adminOverview()).not.toBeNull();
+
+    uninstallAdminEvents();
+
+    expect(adminOverview()).toBeNull();
+  });
 });
 
 // REV-G H24 (2026-05-22) — runtime narrower boundary regression.

--- a/cicchetto/src/__tests__/adminOverview.test.ts
+++ b/cicchetto/src/__tests__/adminOverview.test.ts
@@ -1,0 +1,177 @@
+import type { Channel } from "phoenix";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AdminOverviewWireT } from "../lib/wireTypes";
+
+// #1073 / #1075 — adminOverview store: the `"overview"` push that feeds the
+// admin top bar's left group. Rides the SAME admin channel as adminEvents and
+// sessionLog (`grappa:admin:events`); the wiring is installed via
+// `installAdminOverview(channel)`, called from adminEvents.ts's
+// `installAdminEvents` — one channel, three consumers, no second WS join.
+//
+// Unlike the two ring stores, this one holds a SNAPSHOT: each tick replaces
+// the previous value rather than accumulating, because the server samples the
+// same five facts every interval.
+
+import { adminOverview, installAdminOverview, resetAdminOverview } from "../lib/adminOverview";
+
+const snapshot = (overrides: Partial<AdminOverviewWireT>): AdminOverviewWireT => ({
+  sessions: 3,
+  visitors: { total: 5, live: 2 },
+  hostname: "m42",
+  loadavg: 0.42,
+  version: "0.15.0",
+  ...overrides,
+});
+
+// Fake Channel that captures the `overview` handler so the test can fire
+// payloads at will. Matches the slim slice of phoenix.js's Channel API the
+// production module touches (mirror of sessionLog.test.ts's makeFakeChannel).
+function makeFakeChannel(): {
+  channel: Channel;
+  fire: (payload: AdminOverviewWireT) => void;
+  fireRaw: (payload: unknown) => void;
+  handlerNames: () => string[];
+} {
+  let cb: ((p: unknown) => void) | null = null;
+  const names: string[] = [];
+  const channel = {
+    on: (name: string, handler: unknown) => {
+      names.push(name);
+      if (name === "overview") cb = handler as (p: unknown) => void;
+      return 0;
+    },
+    leave: () => ({ receive: () => ({ receive: () => undefined }) }),
+  } as unknown as Channel;
+  return {
+    channel,
+    fire: (p) => cb?.(p),
+    fireRaw: (p) => cb?.(p),
+    handlerNames: () => names,
+  };
+}
+
+beforeEach(() => {
+  resetAdminOverview();
+  expect(adminOverview()).toBeNull();
+});
+
+describe("adminOverview store — install + ingest", () => {
+  it("is null until the first push lands", () => {
+    const fake = makeFakeChannel();
+    installAdminOverview(fake.channel);
+    expect(adminOverview()).toBeNull();
+    expect(fake.handlerNames()).toContain("overview");
+  });
+
+  it("holds the pushed snapshot", () => {
+    const fake = makeFakeChannel();
+    installAdminOverview(fake.channel);
+
+    fake.fire(snapshot({}));
+
+    expect(adminOverview()).toEqual(snapshot({}));
+  });
+
+  it("REPLACES on the next tick rather than accumulating", () => {
+    // The server re-samples all five facts every interval, so the store is a
+    // snapshot and not a ring: the bar must show the latest reading, and an
+    // accumulating store would either grow unbounded or show a stale head.
+    const fake = makeFakeChannel();
+    installAdminOverview(fake.channel);
+
+    fake.fire(snapshot({ sessions: 1, loadavg: 0.1 }));
+    fake.fire(snapshot({ sessions: 9, loadavg: 3.5 }));
+
+    expect(adminOverview()?.sessions).toBe(9);
+    expect(adminOverview()?.loadavg).toBe(3.5);
+  });
+
+  it("accepts a null loadavg — an unreachable sampler is a valid reading", () => {
+    // The load-bearing case. `loadavg` is `float() | nil` on the wire because
+    // "cannot measure" is a different fact from "idle"; a narrower that
+    // demanded a number would drop the WHOLE payload whenever the sampler is
+    // down, blanking a bar whose other four stats are perfectly good.
+    const fake = makeFakeChannel();
+    installAdminOverview(fake.channel);
+
+    fake.fire(snapshot({ loadavg: null }));
+
+    expect(adminOverview()).not.toBeNull();
+    expect(adminOverview()?.loadavg).toBeNull();
+    expect(adminOverview()?.hostname).toBe("m42");
+  });
+});
+
+describe("adminOverview store — lifecycle", () => {
+  it("install is idempotent for the same channel reference", () => {
+    const fake = makeFakeChannel();
+    installAdminOverview(fake.channel);
+    installAdminOverview(fake.channel);
+    expect(fake.handlerNames().filter((n) => n === "overview").length).toBe(1);
+  });
+
+  it("reset clears the store and allows a fresh install on a new channel", () => {
+    const first = makeFakeChannel();
+    installAdminOverview(first.channel);
+    first.fire(snapshot({ hostname: "first" }));
+    expect(adminOverview()?.hostname).toBe("first");
+
+    resetAdminOverview();
+    expect(adminOverview()).toBeNull();
+
+    const second = makeFakeChannel();
+    installAdminOverview(second.channel);
+    second.fire(snapshot({ hostname: "second" }));
+    expect(adminOverview()?.hostname).toBe("second");
+  });
+
+  it("a push on the OLD channel after reset is ignored", () => {
+    const first = makeFakeChannel();
+    installAdminOverview(first.channel);
+    resetAdminOverview();
+
+    first.fire(snapshot({ hostname: "stale" }));
+
+    expect(adminOverview()).toBeNull();
+  });
+});
+
+describe("adminOverview store — narrower boundary", () => {
+  it("drops a malformed payload without crashing", () => {
+    const fake = makeFakeChannel();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    installAdminOverview(fake.channel);
+
+    expect(() => fake.fireRaw({ sessions: "three", hostname: "m42" })).not.toThrow();
+
+    expect(adminOverview()).toBeNull();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("keeps the last good reading when a malformed push arrives", () => {
+    // Nulling the store on a bad tick would blank the bar on every skewed
+    // push. A stale-but-true reading beats a blank one, and the next good
+    // tick is one interval away.
+    const fake = makeFakeChannel();
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    installAdminOverview(fake.channel);
+
+    fake.fire(snapshot({ hostname: "good" }));
+    fake.fireRaw({ nonsense: true });
+
+    expect(adminOverview()?.hostname).toBe("good");
+  });
+
+  it("rejects a payload whose visitors pair is missing or wrong-shaped", () => {
+    const fake = makeFakeChannel();
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    installAdminOverview(fake.channel);
+
+    fake.fireRaw({ ...snapshot({}), visitors: 5 });
+    fake.fireRaw({ ...snapshot({}), visitors: { total: 5 } });
+    fake.fireRaw(null);
+
+    expect(adminOverview()).toBeNull();
+  });
+});

--- a/cicchetto/src/admin/AdminCard.tsx
+++ b/cicchetto/src/admin/AdminCard.tsx
@@ -39,7 +39,6 @@ const AdminCard: Component<Props> = (props) => (
         <Show when={props.hostsRefresh === true && refreshInCardHead() && refreshSlot()}>
           {(reg) => (
             <AdminRefreshButton
-              compact={false}
               onClick={reg().onRefresh}
               busy={reg().busy()}
               label={reg().label}

--- a/cicchetto/src/admin/AdminToolbar.tsx
+++ b/cicchetto/src/admin/AdminToolbar.tsx
@@ -31,26 +31,23 @@ export type RefreshButtonProps = {
   busy: boolean;
   label: string;
   testId: string;
-  /**
-   * Glyph only, no "refresh" word — for the pane header, where the button
-   * sits beside the close × in a row with no room for a label. Required
-   * rather than optional: there are two call sites and which one you are
-   * is never ambiguous, so a default would only hide the choice. The
-   * `aria-label` carries the name either way.
-   */
-  compact: boolean;
 };
 
+// #1073 — the `compact` variant (glyph only, no word) existed for ONE call
+// site: the console's own band, where the button sat beside the close × with
+// no room for a label. Both of those left the band, and the two remaining
+// call sites are card heads with room for the word, so the branch is gone
+// rather than kept as a prop nobody passes.
 export const AdminRefreshButton: Component<RefreshButtonProps> = (props) => (
   <button
     type="button"
-    class={`adm-btn adm-refresh-btn ${props.compact ? "adm-refresh-btn--compact" : ""}`.trim()}
+    class="adm-btn adm-refresh-btn"
     aria-label={props.label}
     aria-busy={props.busy}
     onClick={props.onClick}
     data-testid={props.testId}
   >
-    {props.compact ? "↻" : "↻ refresh"}
+    {"\u{21BB} refresh"}
   </button>
 );
 

--- a/cicchetto/src/admin/refreshSlot.ts
+++ b/cicchetto/src/admin/refreshSlot.ts
@@ -11,9 +11,11 @@ import { isMobile } from "../lib/theme";
 // carries something the nav cannot (Networks: the Sweep-visitors verb
 // plus a line explaining what the caps column means).
 //
-// That leaves refresh with nowhere to live, and it belongs next to the
-// pane's close button: one row of chrome, at the top, always in the
-// same place regardless of tab.
+// That leaves refresh with nowhere to live. It first went into the pane's
+// own band, beside the close ×; #1073 moved it again, into the rail's
+// actions — vjt: *"il refresh puo' tranquillamente stare tra le actions
+// nel rail, non serve cosi' prominente"*. The band it was in is now the
+// shared channel bar and carries no controls of its own at all.
 //
 // The wiring is a module-level signal rather than a context or a prop
 // chain because there is exactly one AdminPane mounted at a time and
@@ -23,9 +25,11 @@ import { isMobile } from "../lib/theme";
 // only when the active tab actually has something to re-fetch (Events
 // has no fetch at all, and correctly contributes nothing).
 //
-// The registration carries the tab's own `testId`, so the button in the
-// header is still `admin-visitors-refresh` / `admin-sessions-refresh` /
-// … — the ids the e2e specs click. Moving the button must not rename it.
+// The registration carries the tab's own `testId`, so wherever the button
+// is rendered it is still `admin-visitors-refresh` /
+// `admin-sessions-refresh` / … — the ids the tabs' own suites assert. The
+// button has now moved twice; neither move renamed it, which is what keeps
+// a relocation distinguishable from a removal.
 
 export type RefreshRegistration = {
   onRefresh: () => void;
@@ -43,8 +47,9 @@ export const refreshSlot = registration;
 /**
  * Where the registered refresh button is rendered.
  *
- * On a phone it goes in the pane header, beside the close ×: there is
- * one row of chrome up there and no room for anything else.
+ * On a phone it is a row in the rail's actions (`RailActions`), reached
+ * through the console's ☰. #1073 — the pane's band carries no controls,
+ * and a re-fetch does not earn one of the two slots it used to hold.
  *
  * On desktop the pane header is a wide, near-empty band and the card the
  * data actually lives in has its own right-aligned actions slot, so the
@@ -54,7 +59,9 @@ export const refreshSlot = registration;
  * ONE button either way, carrying the tab's own testid. Rendering it in
  * both places and hiding one with CSS would put a duplicate
  * `admin-*-refresh` in the DOM, which is exactly what the e2e specs
- * click.
+ * click. The two renderers therefore read this predicate with opposite
+ * polarity and nothing else decides: `AdminCard` on true, `RailActions`
+ * on false.
  */
 export function refreshInCardHead(): boolean {
   return !isMobile();

--- a/cicchetto/src/lib/adminEvents.ts
+++ b/cicchetto/src/lib/adminEvents.ts
@@ -1,5 +1,6 @@
 import type { Channel } from "phoenix";
 import { createSignal } from "solid-js";
+import { installAdminOverview, resetAdminOverview } from "./adminOverview";
 import { assertNever, type WireAdminEvent } from "./api";
 import { installSessionLog, resetSessionLog } from "./sessionLog";
 import { joinAdminEvents } from "./socket";
@@ -156,6 +157,11 @@ export function installAdminEvents(channel: Channel): void {
   // the sibling session-log handler here (its store + ingest live in
   // sessionLog.ts). One channel, two consumers — no second WS join.
   installSessionLog(channel);
+
+  // #1073 — and so does the admin top bar's `"overview"` projection (store +
+  // ingest in adminOverview.ts). Same reason, same shape: a third consumer of
+  // one channel beats a second join for a payload already pushed here.
+  installAdminOverview(channel);
 }
 
 export function uninstallAdminEvents(): void {
@@ -169,6 +175,9 @@ export function uninstallAdminEvents(): void {
   // just left; clear its view state too so the next mount re-fills from
   // the REST snapshot + fresh live pushes.
   resetSessionLog();
+  // #1073 — same for the top bar's projection: the next open re-fills from
+  // the join push.
+  resetAdminOverview();
 }
 
 // Production wrapper: join + install in one call so AdminPane.onMount

--- a/cicchetto/src/lib/adminOverview.ts
+++ b/cicchetto/src/lib/adminOverview.ts
@@ -1,0 +1,70 @@
+import type { Channel } from "phoenix";
+import { createSignal } from "solid-js";
+import { narrowAdminOverview } from "./wireNarrow";
+import type { AdminOverviewWireT } from "./wireTypes";
+
+// #1073 / #1075 — the admin top bar's live projection.
+//
+// The server exposes the same five facts through two doors (one feature,
+// every door): `GET /admin/overview` and an `"overview"` push on the EXISTING
+// admin channel (`grappa:admin:events`, already joined by `adminEvents.ts`),
+// re-sent on a timer because `loadavg` is a SAMPLED quantity with no event to
+// hang off. cic takes the push door only: the bar exists exactly as long as
+// the channel does, so the join push is its cold start and the tick is its
+// refresh — a REST fetch on mount would duplicate the first push.
+//
+// This module owns ONLY the store + the channel handler. Rather than open a
+// second admin channel, the handler is installed on the SAME channel
+// `adminEvents.ts` owns — `installAdminEvents(channel)` calls
+// `installAdminOverview(channel)`, `uninstallAdminEvents()` calls
+// `resetAdminOverview()` — exactly as `sessionLog.ts` (#215) does. One
+// channel, three consumers, no second WS join.
+//
+// Per CLAUDE.md "Window state model lives on the server" — this store MIRRORS
+// a server-sampled projection; cic NEVER originates or derives it.
+//
+// ## A snapshot, not a ring
+//
+// Unlike its two channel-mates, each push REPLACES the previous value: the
+// server re-samples all five facts every interval, so there is no history to
+// accumulate and the bar wants the latest reading. `null` means "no push has
+// landed yet" and the bar renders no stats at all — placeholder zeroes would
+// be the same lie as coercing an absent loadavg to 0.00, briefly, on every
+// console open.
+
+const [overview, setOverview] = createSignal<AdminOverviewWireT | null>(null);
+export const adminOverview = overview;
+
+let installed: Channel | null = null;
+
+// A malformed push KEEPS the last good reading rather than nulling the store.
+// Blanking the bar on a skewed tick would hide four good stats for one bad
+// field, and the next honest tick is only an interval away.
+function ingest(raw: unknown): void {
+  const next = narrowAdminOverview(raw);
+  if (next === null) {
+    console.warn("[adminOverview] dropped malformed overview payload", raw);
+    return;
+  }
+  setOverview(next);
+}
+
+// Install the `overview` handler on the admin channel. Idempotent for the
+// lifetime of a Channel instance (mirror of `installSessionLog`).
+export function installAdminOverview(channel: Channel): void {
+  if (installed === channel) return;
+  installed = channel;
+  channel.on("overview", (payload: unknown) => {
+    if (installed !== channel) return;
+    ingest(payload);
+  });
+}
+
+// Clear the store + drop the channel reference so the next admin-pane open
+// starts from the fresh join push. The channel itself is `leave()`d by
+// `uninstallAdminEvents` — the shared channel owner — so this only resets the
+// view state.
+export function resetAdminOverview(): void {
+  installed = null;
+  setOverview(null);
+}

--- a/cicchetto/src/lib/wireNarrow.ts
+++ b/cicchetto/src/lib/wireNarrow.ts
@@ -12,6 +12,7 @@ import type { MemberEntry } from "./memberTypes";
 import type {
   AdminEventsWireLoginThrottleDoor,
   AdminEventsWireLoginThrottleScope,
+  AdminOverviewWireT,
   SessionLogEvent,
   SessionLogWireT,
   WindowCountsSeverity,
@@ -1000,6 +1001,40 @@ const VALID_SESSION_LOG_EVENTS: ReadonlySet<SessionLogEvent> = new Set(SESSION_L
  * `sessionLog.ts` on the live `session_log_event` push (the REST
  * snapshot trusts the server, same as the other `adminList*` helpers).
  */
+/**
+ * Runtime narrower for the admin top bar's projection (`"overview"` push /
+ * `GET /admin/overview`). Same REV-G H24 discipline as its siblings: the
+ * caller (adminOverview.ts) drops + logs on null rather than trusting a cast.
+ *
+ * `loadavg` is checked as NULLABLE, and that is the load-bearing line.
+ * `Grappa.AdminOverview.Wire` sends `nil` when `:cpu_sup` cannot be reached
+ * because "cannot measure" is a different fact from "the box is idle";
+ * demanding a number here would drop the whole payload exactly when the
+ * sampler is down, blanking a bar whose other four stats are fine.
+ */
+export function narrowAdminOverview(raw: unknown): AdminOverviewWireT | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.visitors !== "object" || r.visitors === null) return null;
+  const v = r.visitors as Record<string, unknown>;
+  if (
+    typeof r.sessions !== "number" ||
+    typeof v.total !== "number" ||
+    typeof v.live !== "number" ||
+    typeof r.hostname !== "string" ||
+    !isNullableNumber(r.loadavg) ||
+    typeof r.version !== "string"
+  )
+    return null;
+  return {
+    sessions: r.sessions,
+    visitors: { total: v.total, live: v.live },
+    hostname: r.hostname,
+    loadavg: r.loadavg as number | null,
+    version: r.version,
+  };
+}
+
 export function narrowSessionLogEntry(raw: unknown): SessionLogWireT | null {
   if (typeof raw !== "object" || raw === null) return null;
   const r = raw as Record<string, unknown>;

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -4362,32 +4362,6 @@ html.resize-dragging * {
   color: var(--adm-text-dim);
 }
 
-.admin-pane-close {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  color: var(--adm-text-dim);
-  border: 1px solid var(--adm-line);
-  border-radius: var(--adm-radius-sm);
-  font-family: var(--adm-font);
-  font-size: 1.1rem;
-  width: var(--tap-min);
-  height: var(--tap-min);
-  cursor: pointer;
-  line-height: 1;
-}
-
-.admin-pane-close:hover {
-  background: var(--adm-surface-2);
-  color: var(--adm-text);
-}
-
-.admin-pane-close:focus-visible {
-  outline: 2px solid var(--adm-accent);
-  outline-offset: 2px;
-}
-
 /* Admin redesign Layer 2/3 — `AdminNav` (cicchetto/src/admin/AdminNav.tsx).
    Mobile-first: a horizontal scrolling chip strip (`.adm-nav` row +
    `.adm-nav-group` row), grouped by a non-interactive label. The

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -4345,13 +4345,6 @@ html.resize-dragging * {
   margin: -1rem -1rem 1rem;
 }
 
-/* The refresh sits at the band's trailing edge, not adrift after the title.
-   Transitional: #1073 moves this button into the rail's actions on mobile,
-   which is when this rule and its consumer both go. */
-.admin-pane .topic-bar .adm-refresh-btn {
-  margin-left: auto;
-}
-
 .admin-pane .topic-bar h1 {
   font-family: var(--adm-font);
   font-size: 0.85rem;

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -4329,43 +4329,30 @@ html.resize-dragging * {
   overscroll-behavior: contain;
 }
 
-.admin-pane-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--adm-space-3);
-  border-bottom: 1px solid var(--adm-line);
-  padding-bottom: 0.5rem;
-  margin-bottom: 1rem;
+/* #1073 — the band is `.topic-bar` now (`PaneTopBar`), so everything the old
+   `.admin-pane-header` block declared to BE a band — the flex row, the gap, the
+   bottom border — comes from the channel bar's own rule and is deliberately not
+   restated here. Nor is the ☰'s `--adm-*` restyle: the glyph is
+   `.topic-bar-hamburger`, and looking like the channel one is the point.
+
+   What is left is the two facts that belong to the HOST rather than to the bar.
+   `.admin-pane` carries `padding: 1rem`, which would inset the band and stop
+   its border short of both edges — the channel bar is flush with its pane, so
+   the negative inline/block-start margins cancel that padding for this one
+   child. The `1rem` block-end margin is the old header's, kept verbatim: it is
+   the gap to `.adm-nav`. */
+.admin-pane > .topic-bar {
+  margin: -1rem -1rem 1rem;
 }
 
-/* Admin redesign (2026-08-07) — the ☰ rail opener, hosted here on mobile so
-   the admin window carries ONE chrome band instead of the `.shell-chrome` row
-   stacked above this header (Shell suppresses that row for the admin kind).
-   Restyled onto the `--adm-*` layer so it reads as part of the pane's chrome
-   rather than the IRC client's; the base `.shell-chrome-btn` rule keeps the tap
-   floor and the focus ring, and this (0,2,0) selector lands after it. */
-.admin-pane-header .shell-chrome-rail-opener {
-  color: var(--adm-text-dim);
-  border-color: var(--adm-line);
-  border-radius: var(--adm-radius-sm);
-}
-
-/* The refresh sits with the close ×, not adrift between the title and
-   it. The header is `space-between` over four children (☰, title,
-   refresh, ×), which spread the middle two evenly and left refresh
-   floating in the gap; pushing it right groups the two controls into one
-   cluster at the corner where controls belong. */
-.admin-pane-header .adm-refresh-btn {
+/* The refresh sits at the band's trailing edge, not adrift after the title.
+   Transitional: #1073 moves this button into the rail's actions on mobile,
+   which is when this rule and its consumer both go. */
+.admin-pane .topic-bar .adm-refresh-btn {
   margin-left: auto;
 }
 
-.admin-pane-header .shell-chrome-rail-opener:hover {
-  background: var(--adm-surface-2);
-  color: var(--adm-text);
-}
-
-.admin-pane-header h1 {
+.admin-pane .topic-bar h1 {
   font-family: var(--adm-font);
   font-size: 0.85rem;
   font-weight: 600;
@@ -4488,17 +4475,14 @@ html.resize-dragging * {
     column-gap: 0;
   }
 
-  .admin-pane-header {
+  .admin-pane > .topic-bar {
     grid-column: 1 / -1;
   }
 
-  /* The ☰ is a MOBILE door: Shell's desktop branch renders no `ShellChrome`
-     at all and the rail is permanent there, so there is nothing to open. Same
-     posture as `.topic-bar-hamburger`, which is CSS-hidden above this
-     breakpoint for the same reason. */
-  .admin-pane-header .shell-chrome-rail-opener {
-    display: none;
-  }
+  /* The desktop hide of the ☰ is NOT restated here. #1073 made the admin door
+     `.topic-bar-hamburger`, and that glyph is already `display: none` above
+     this breakpoint for exactly the same reason — the rail is permanent on
+     desktop, so there is nothing to open. One rule, both hosts. */
 
   .adm-nav {
     grid-column: 1;

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -4355,6 +4355,60 @@ html.resize-dragging * {
   color: var(--adm-text-dim);
 }
 
+/* #1073 — the admin host's slot holds two things ON ONE LINE (the title and
+   the stats), where the channel host stacks two text columns. `flex-start` is
+   right for the channel bar — it is what registers topic line-1 beside the
+   channel name (#344) — and wrong here, where it would hang the small stats
+   text off the top of the taller title. Overridden for this host only; the
+   shared rule keeps its meaning. */
+.admin-pane .topic-bar-header {
+  align-items: baseline;
+}
+
+/* #1073 — the five live stats beside the title, fed by the admin channel's
+   `"overview"` push.
+
+   ONE ROW, ALWAYS. vjt: *"si, non invadente"*; Hypnotize: *"deve essere
+   piccola, che già la tastiera occupa una madonna"*. With the keyboard up on a
+   phone, vertical space is the binding constraint — a second line here costs
+   more than any stat on it is worth. So the row never wraps and clips instead,
+   and the ONE cell whose width is unbounded by its own shape (the hostname)
+   carries the ellipsis chain and yields first, leaving the four numeric cells
+   legible at 393px. */
+.admin-overview-stats {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: baseline;
+  gap: 0.5rem;
+  min-width: 0;
+  overflow: hidden;
+  font-family: var(--adm-font);
+  font-size: 0.7rem;
+  color: var(--adm-text-dim);
+  /* The numbers are re-sampled every tick; proportional digits would shift
+     every cell to their right on each one. */
+  font-variant-numeric: tabular-nums;
+}
+
+.admin-overview-stat {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.2rem;
+  white-space: nowrap;
+}
+
+.admin-overview-stat-host {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+}
+
+.admin-overview-stat-icon {
+  font-size: 0.75rem;
+  line-height: 1;
+}
+
 /* Admin redesign Layer 2/3 — `AdminNav` (cicchetto/src/admin/AdminNav.tsx).
    Mobile-first: a horizontal scrolling chip strip (`.adm-nav` row +
    `.adm-nav-group` row), grouped by a non-interactive label. The


### PR DESCRIPTION
Refs #1073. The admin console's top bar is now the SAME bar the channel
windows use, carrying the live key stats on the left and the rail's ☰ on
the right, with the × and the refresh gone from the band.

vjt: *"la top bar admin dev'esser possibilmente la stessa barra che
abbiamo per i canali, solo con dentro roba diversa"*, and *"si, non
invadente"*; Hypnotize: *"deve essere piccola, che già la tastiera occupa
una madonna"*.

## What the shape is

`PaneTopBar` is the BAND extracted from `TopicBar`, and the band turned
out to be small and entirely channel-agnostic: a flex row with the
`--pane-chrome-inset-*` padding, a bottom border, a `flex: 1` content
slot, and the ☰ as its LAST child. The namebox, the modes, the topic
strip and the two modals never belonged to the band and stayed put —
which is why this is an extraction, not a parameterisation.

The ☰'s side then comes for free. It was never a second hamburger:
`AdminPane` already mounted the same `RailOpenerButton`. The two
surfaces disagreed about the SIDE because their hosts differed —
`.shell-chrome` is a zero-height `flex-end` floater, `.admin-pane-header`
was a real band that put its opener first. Hosting admin on this bar
resolves the placement by construction instead of by another override.
`.admin-pane-header` is gone from both the DOM and the CSS; the two
rules that survive belong to the HOST, not to the bar (the negative
margins that cancel `.admin-pane`'s `padding: 1rem` so the band is flush
like the channel one, and the desktop `grid-column`).

The ☰'s accessible name is UNCHANGED at *"open actions"*, inherited from
the inline opener it replaces. Renaming a door while moving it makes the
move indistinguishable from a removal. The channel bar's stays *"open
members sidebar"* — eight specs click it by that name.

The × is DELETED, along with `onClose` (vjt: *"la x sparisce"*).
Selection is what mounts and unmounts the pane, and the rail already
carries `home`, so "close admin" was a second verb for work `home`
already does.

## The stats

`AdminOverviewStats` reads the GENERATED `AdminOverviewWireT`. It
shipped in this branch with a hand-written local twin of the same five
fields, because #1075 had not generated one yet and waiting would have
frozen the drift on main; that copy is now REPLACED, not left beside the
generated type. `scripts/check.sh` runs the generator with `--check`,
which is what makes a server-side rename fail at the build rather than
on an operator's screen — and a hand-written twin compiles happily
straight through that rename.

The consumer rides the EXISTING admin channel. `AdminPane` already joins
`grappa:admin:events`; the server already pushes `"overview"` there on
join and on a timer (the timer because `loadavg` is sampled and has no
event to hang off). So this follows #215's shape exactly: `adminEvents.ts`
owns the join/leave and installs the sibling handler, `adminOverview.ts`
owns only the store and the ingest. One channel, three consumers, no
second WS join. There is a REST door too (`GET /admin/overview`) and cic
deliberately ignores it: the bar lives exactly as long as the channel
does, so the join push IS its cold start.

Two rules that would fail quietly, both inherited from what #1075
measured server-side:

* the loadavg is labelled **host** — a jail shares the host kernel, so
  an unlabelled figure reads as "grappa is busy", a different and
  unsupported claim;
* **`null` is not zero** — the narrower accepts a nullable `loadavg`
  (demanding a number would drop the whole payload exactly when the
  sampler is down, blanking four good stats), and the unknown case
  renders an em dash with no digit at all. `Number(null)` is `0`, so a
  formatter applied without thinking reports a calm machine nobody can
  see.

A malformed push keeps the LAST GOOD reading rather than nulling the
store: blanking on one skewed tick hides four good stats for one bad
field, and the next honest tick is an interval away.

The `<h1>` stays for now. Whether a title plus five stats is too much
for one phone line is a product call, not one to make while wiring the
data.

## Three things worth flagging

**1. Two broken consumers that were not on the list.** Deleting the ×
and moving the ☰ turned up two consumers beyond the obvious unit suites:
`ux-4-z-cluster-journey`, which reached the admin door by the testid
`shell-chrome-rail-opener` — a testid that has ALWAYS named the other
host — and the `openMembersDrawer` fixture, which picked the opener by
ACCESSIBLE NAME. The fixture now locates `.topic-bar-hamburger` by
class, which is what the two hosts genuinely have in common; the names
differ on purpose, because the two doors mean different things to a
screen reader.

**2. The e2e files here have NO static gate.** `cicchetto/tsconfig.json`
includes `src` only and biome is pointed at `src`, so nothing in
`cicchetto/e2e` is typechecked or linted — a change to a spec has not
even a compile behind it. The new spec is also NOT RUN: the e2e lane was
not this session's to take. Its second test is the likelier to need a
fix, since no existing spec opens the admin console on the iPhone
project and its login-and-open path has no precedent to inherit.

**3. A corrected sentence in `refreshSlot.ts`'s moduledoc.** It claimed
e2e specs click the `admin-*-refresh` testids. They do not — the per-tab
vitest suites assert them. The sentence was true at the seam's first
move and stopped being true afterwards.

## Gates

* `scripts/bun.sh run test` — RC=0, 261 files / 4849 tests
* `scripts/bun.sh run check` — RC=0 (biome + tsc)
* NOT run: e2e (lane not taken), and no browser or device has seen this.
  The band's flush-to-the-pane fit is reasoned on the stylesheet, not
  measured.