### PR TITLE
cic(#1105): the reply quote must reveal the caret, not just place it

### DIFF
--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -1143,6 +1143,49 @@ export async function synthSwipe(
   );
 }
 
+// The compose caret + scroll geometry, read off the live element.
+export type ComposeCaretGeometry = {
+  selStart: number | null;
+  selEnd: number | null;
+  valueLen: number;
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+};
+
+export async function composeCaretGeometry(page: Page): Promise<ComposeCaretGeometry> {
+  return await composeTextarea(page).evaluate((el: HTMLTextAreaElement) => ({
+    selStart: el.selectionStart,
+    selEnd: el.selectionEnd,
+    valueLen: el.value.length,
+    scrollTop: el.scrollTop,
+    scrollHeight: el.scrollHeight,
+    clientHeight: el.clientHeight,
+  }));
+}
+
+// The oracle shared by every "caret at the end, and visible" door: #173's
+// history recall and #1105's reply quote both route through
+// `lib/composeCaret.placeCaretAtEndInView`, so they are owed the same proof
+// and must not carry two drifting copies of it — the production duplication
+// is exactly what let #1105 ship.
+//
+// `minOverflowPx` is REQUIRED and per-caller on purpose: it is the guard
+// against a vacuous pass. A draft that does not overflow the rows=1 textarea
+// sits at scrollTop 0 legitimately, so without it "the caret is in view" is
+// true for the wrong reason. Each caller states how much overflow its own
+// fixture is expected to produce, rather than inheriting a number that
+// silently stops being true.
+export function expectEndCaretVisible(g: ComposeCaretGeometry, minOverflowPx: number): void {
+  expect(g.scrollHeight).toBeGreaterThan(g.clientHeight + minOverflowPx);
+  expect(g.selStart).toBe(g.valueLen);
+  expect(g.selEnd).toBe(g.valueLen);
+  // The defect: scrollTop left at 0 hides the end-caret. Fixed: scrolled to
+  // the bottom, so the caret's line is within [scrollTop, +clientHeight].
+  expect(g.scrollTop).toBeGreaterThan(0);
+  expect(g.scrollTop).toBeGreaterThanOrEqual(g.scrollHeight - g.clientHeight - 2);
+}
+
 // #902 — the inbound-INVITE banner, the surface that replaced the greyed
 // `:invited` pseudo-row.
 //

--- a/cicchetto/e2e/tests/issue1105-reply-quote-caret-visible.spec.ts
+++ b/cicchetto/e2e/tests/issue1105-reply-quote-caret-visible.spec.ts
@@ -1,0 +1,127 @@
+// #1105 — replying to a message that does not fit on one line left the caret
+// BELOW the visible area of the compose box: the quote was inserted and the
+// caret placed at the end, but the textarea was never scrolled, so you typed
+// blind. Reported on IRC right after the #1067 reply gesture shipped.
+//
+// The compose textarea is `rows={1}` with `resize: none`, so any draft that
+// wraps turns it into an internal scroll container, and `setSelectionRange`
+// does not scroll. #173 had already met and fixed exactly this on history
+// recall — inside `ComposeBox`. `appendToCompose` carried its own, incomplete
+// copy of "caret at end", which is precisely why the reply door shipped
+// broken. The fix converges both on `lib/composeCaret.placeCaretAtEndInView`,
+// so this spec and the #173 one share ONE oracle (`expectEndCaretVisible`) —
+// a second copy of the assertion would repeat, on the test side, the mistake
+// the production code just stopped making.
+//
+// WHY e2e and not a unit test: jsdom does no layout, so `scrollHeight` is 0
+// on every element and any assertion about the caret being "in view" passes
+// vacuously there. The unit test in `src/__tests__/replyQuote.test.ts` stubs
+// the overflow and can therefore only pin the ASSIGNMENT; that a real engine
+// then puts the caret inside the client box is what this spec measures.
+//
+// GATE REALITY (feedback_playwright_webkit_not_ios_scroll): chromium, untagged
+// — Playwright webkit is not real iOS, and the gesture is synthesized in-page
+// on the row, reaching the production listener by bubbling to `.scrollback`
+// exactly as a finger does. The FEEL on a real phone stays vjt's dogfood; what
+// is asserted here is the GEOMETRY.
+import type { Page } from "@playwright/test";
+import {
+  composeCaretGeometry,
+  composeSend,
+  composeTextarea,
+  expectEndCaretVisible,
+  loginAs,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
+test.setTimeout(90_000);
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+// The issue measured the threshold at a 390px viewport: a 46-char quote
+// already wraps and already hides the caret. This body is deliberately far
+// past it — around six wrapped lines — so the required overflow below is a
+// wide margin rather than a coin toss on font metrics, while staying well
+// inside one PRIVMSG so the server-side split budget (#246) never turns it
+// into two scrollback rows.
+const FILLER =
+  "che va a capo parecchie volte perche' il textarea e' rows=1 e non cresce, " +
+  "quindi il caret finisce sotto la piega e non si vede piu' nulla";
+
+// A body unique per run: the e2e sqlite scrollback persists across
+// KEEP_STACK=1 re-runs, and a static string would match two rows on the
+// second run and trip Playwright strict mode.
+function uniqueBody(): string {
+  return `issue1105 ${Date.now()} ${FILLER}`;
+}
+
+// Six-ish wrapped lines minus generous slack. Its job is to fail loudly if the
+// fixture ever stops overflowing, because then "the caret is in view" would be
+// true for the wrong reason.
+const MIN_OVERFLOW_PX = 40;
+
+// A left→right drag on the message row whose text contains `body`. Touch
+// synthesis is per-spec throughout this suite (#123, #308, #1041, #1067, …)
+// because each spec samples something different mid-drag; only the ORACLE is
+// shared. Here nothing mid-drag matters — just that the reply fires.
+async function swipeRowRight(page: Page, body: string): Promise<void> {
+  await page.evaluate((text: string) => {
+    const rows = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-testid="scrollback-line"]'),
+    );
+    const row = rows.find((r) => r.textContent?.includes(text));
+    if (row === undefined) throw new Error(`no scrollback row containing ${text}`);
+    const fire = (type: "touchstart" | "touchmove" | "touchend", x: number, y: number): void => {
+      const t = new Touch({ identifier: 1, target: row, clientX: x, clientY: y });
+      const active = type === "touchend" ? [] : [t];
+      row.dispatchEvent(
+        new TouchEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          touches: active,
+          targetTouches: active,
+          changedTouches: [t],
+        }),
+      );
+    };
+    // Starts well clear of the left edge: #1041 gave the edge the same
+    // right-swipe (it opens the sidebar), and zone separation is what keeps
+    // one finger from doing both.
+    fire("touchstart", 120, 400);
+    fire("touchmove", 175, 404);
+    fire("touchmove", 235, 407);
+    fire("touchend", 280, 408);
+  }, body);
+}
+
+test("issue1105 — replying to a wrapping message scrolls the compose caret into view", async ({
+  page,
+}) => {
+  if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
+  const body = uniqueBody();
+
+  await loginAs(page, getSeededVjt());
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+  await composeSend(page, body);
+  await expect(page.locator('[data-testid="scrollback-line"]', { hasText: body })).toBeVisible({
+    timeout: 5_000,
+  });
+
+  // Pre-state: an already-scrolled compose would make the outcome true for the
+  // wrong reason.
+  const ta = composeTextarea(page);
+  await expect(ta).toHaveValue("");
+  expect((await composeCaretGeometry(page)).scrollTop).toBe(0);
+
+  await swipeRowRight(page, body);
+
+  const quote = `<${NETWORK_NICK}> ${body}<< `;
+  await expect(ta).toHaveValue(quote, { timeout: 5_000 });
+
+  // THE regression: caret at the end of the quote AND that line inside the
+  // client box. Before the fix scrollTop stayed 0 with the caret below it.
+  expectEndCaretVisible(await composeCaretGeometry(page), MIN_OVERFLOW_PX);
+});

--- a/cicchetto/e2e/tests/issue173-compose-recall-caret-visible.spec.ts
+++ b/cicchetto/e2e/tests/issue173-compose-recall-caret-visible.spec.ts
@@ -25,8 +25,10 @@
 // the caret-scroll turns both red (scrollTop stays 0).
 
 import {
+  composeCaretGeometry,
   composeSend,
   composeTextarea,
+  expectEndCaretVisible,
   loginAs,
   selectChannel,
   synthSwipe,
@@ -40,32 +42,12 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 // over, so an end-caret left at scrollTop 0 is unambiguously off-screen.
 const LONG_BODY = Array.from({ length: 12 }, (_, i) => `recall line ${i}`).join("\n");
 
-// Read the caret + scroll geometry the fix must establish.
-async function caretGeometry(ta: ReturnType<typeof composeTextarea>) {
-  return await ta.evaluate((el: HTMLTextAreaElement) => ({
-    selStart: el.selectionStart,
-    selEnd: el.selectionEnd,
-    valueLen: el.value.length,
-    scrollTop: el.scrollTop,
-    scrollHeight: el.scrollHeight,
-    clientHeight: el.clientHeight,
-  }));
-}
-
-// The shared assertion: caret deterministically at the end of the recalled
-// line AND the textarea scrolled so that end-caret is within the viewport.
-// `overflowSlack` guards against a vacuous pass on a non-overflowing draft.
-function expectEndCaretVisible(g: Awaited<ReturnType<typeof caretGeometry>>): void {
-  // Sanity: the recalled draft really overflows (else "in view" is trivial).
-  expect(g.scrollHeight).toBeGreaterThan(g.clientHeight + 40);
-  // Caret placed at the END of the recalled line (irssi recall semantics).
-  expect(g.selStart).toBe(g.valueLen);
-  expect(g.selEnd).toBe(g.valueLen);
-  // The bug: scrollTop left at 0 hides the end-caret. Fixed: scrolled to the
-  // bottom so the end-caret's line is within [scrollTop, scrollTop+clientHeight].
-  expect(g.scrollTop).toBeGreaterThan(0);
-  expect(g.scrollTop).toBeGreaterThanOrEqual(g.scrollHeight - g.clientHeight - 2);
-}
+// #1105 lifted `caretGeometry` + `expectEndCaretVisible` into the shared
+// fixture: the reply quote is a second door onto the very same "end-caret must
+// be visible" rule, and two copies of the oracle would be the test-side twin
+// of the production duplication that let #1105 through. LONG_BODY is 12 lines,
+// so 40px of required overflow is a wide margin here.
+const MIN_OVERFLOW_PX = 40;
 
 test("issue173 — keydown ArrowUp recall scrolls the end-caret into view", async ({ page }) => {
   if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
@@ -86,7 +68,7 @@ test("issue173 — keydown ArrowUp recall scrolls the end-caret into view", asyn
   await ta.press("ArrowUp");
   await expect(ta).toHaveValue(LONG_BODY, { timeout: 2_000 });
 
-  expectEndCaretVisible(await caretGeometry(ta));
+  expectEndCaretVisible(await composeCaretGeometry(page), MIN_OVERFLOW_PX);
 });
 
 test("issue173 — gesture (fast up-flick) recall scrolls the end-caret into view", async ({
@@ -114,5 +96,5 @@ test("issue173 — gesture (fast up-flick) recall scrolls the end-caret into vie
   await synthSwipe(page, { startX: 100, startY: 300, endX: 100, endY: 220, slowMs: 0 });
   await expect(ta).toHaveValue(LONG_BODY, { timeout: 2_000 });
 
-  expectEndCaretVisible(await caretGeometry(ta));
+  expectEndCaretVisible(await composeCaretGeometry(page), MIN_OVERFLOW_PX);
 });

--- a/cicchetto/src/ComposeBox.tsx
+++ b/cicchetto/src/ComposeBox.tsx
@@ -12,6 +12,7 @@ import {
   submit,
   tabComplete,
 } from "./lib/compose";
+import { placeCaretAtEndInView } from "./lib/composeCaret";
 import { composePlaceholder } from "./lib/composePlaceholder";
 import { diagPush } from "./lib/diagLog";
 import { networkBySlug } from "./lib/networks";
@@ -188,14 +189,12 @@ const ComposeBox: Component<Props> = (props) => {
   // ONE helper, both recall entry points (swipe touchend + keydown ArrowUp/
   // ArrowDown) — the defect and the fix are identical for both, so this is the
   // general "after any recall the caret is visible" rule, not a gesture patch.
+  // #1105 moved the body itself out to `lib/composeCaret`: the reply quote hit
+  // the same defect because it kept a second, incomplete copy of it.
   const scrollRecallCaretIntoView = (): void => {
     const el = textareaEl;
     if (el === undefined) return;
-    queueMicrotask(() => {
-      const end = el.value.length;
-      el.setSelectionRange(end, end);
-      el.scrollTop = el.scrollHeight;
-    });
+    placeCaretAtEndInView(el);
   };
 
   // #178 + #203 — gesture recall gating, split by direction.

--- a/cicchetto/src/__tests__/replyQuote.test.ts
+++ b/cicchetto/src/__tests__/replyQuote.test.ts
@@ -89,6 +89,22 @@ describe("appendToCompose", () => {
     expect(document.activeElement).toBe(ta);
   });
 
+  // #1105 — the caret is placed at the end, but the rows=1 textarea is an
+  // internal scroll container: a draft that wraps leaves it pinned at
+  // scrollTop 0 with the caret below the fold. jsdom does no layout, so
+  // `scrollHeight` is 0 on every element and a bare assertion here would pass
+  // vacuously — the overflow is stubbed so this pins the assignment itself.
+  // That a real viewport then shows the caret is the e2e spec's job.
+  it("scrolls the overflowing textarea down to the caret", async () => {
+    const ta = mountCompose();
+    Object.defineProperty(ta, "scrollHeight", { value: 75, configurable: true });
+    setDraft(KEY, "x".repeat(110));
+    appendToCompose(NET, CHAN, "coda");
+    ta.value = getDraft(KEY);
+    await Promise.resolve();
+    expect(ta.scrollTop).toBe(75);
+  });
+
   it("is a no-op when no compose textarea is mounted", () => {
     setDraft(KEY, "resta");
     appendToCompose(NET, CHAN, "x");

--- a/cicchetto/src/lib/composeAppend.ts
+++ b/cicchetto/src/lib/composeAppend.ts
@@ -1,5 +1,6 @@
 import { channelKey } from "./channelKey";
 import { getDraft, setDraft } from "./compose";
+import { placeCaretAtEndInView } from "./composeCaret";
 
 // Append `text` to a window's compose draft and leave the caret at the very
 // end, focused and ready to keep typing.
@@ -26,9 +27,8 @@ export function appendToCompose(networkSlug: string, channelName: string, text: 
   // layout viewport up by ~vv.offsetTop to "centre" the textarea — the root
   // cause of the UX-6-D bugs chased for 8 iterations.
   ta.focus({ preventScroll: true });
-  // A Solid signal write does not immediately reflect in the textarea; place
-  // the caret on the next microtask, once the controlled value has flushed.
-  queueMicrotask(() => {
-    ta.setSelectionRange(next.length, next.length);
-  });
+  // #1105 — the caret must also be REVEALED: a quote that wraps leaves the
+  // rows=1 textarea scrolled to the top with the caret underneath. Shared with
+  // the history-recall path so the two cannot drift again.
+  placeCaretAtEndInView(ta);
 }

--- a/cicchetto/src/lib/composeCaret.ts
+++ b/cicchetto/src/lib/composeCaret.ts
@@ -1,0 +1,31 @@
+// #173 + #1105 — "caret at the end, and visible", the ONE copy.
+//
+// The compose textarea is `rows={1}` with `resize: none`, so any draft that
+// wraps past the first line turns it into an internal scroll container. The
+// browser does NOT scroll on `setSelectionRange`, so placing the caret at the
+// end of an overflowing draft leaves the element pinned at `scrollTop === 0`
+// with the caret below the fold — you type blind.
+//
+// #173 met this on history recall and fixed it inside `ComposeBox`. #1105 met
+// the SAME defect on the reply quote, because `appendToCompose` carried its
+// own copy of "caret at end" without the scroll. Two copies were two places to
+// forget the second line in, and one of them did. Hence one function: any new
+// caller that wants the caret at the end gets the reveal for free.
+//
+// Scope: END-of-draft callers only. Paste (`pasteRoute.insertPastedText`) and
+// tab-complete land the caret at an arbitrary offset, where
+// `scrollTop = scrollHeight` would scroll past it — those need
+// caret-position-aware scrolling, which is a different mechanism.
+//
+// `queueMicrotask` is load-bearing: a Solid signal write does not reflect in
+// the textarea synchronously, so both the caret and the measurement must run
+// after the controlled value has committed to the DOM. Reading the length off
+// the live element (rather than the string the caller just wrote) keeps the
+// two in step even if the commit is late.
+export function placeCaretAtEndInView(el: HTMLTextAreaElement): void {
+  queueMicrotask(() => {
+    const end = el.value.length;
+    el.setSelectionRange(end, end);
+    el.scrollTop = el.scrollHeight;
+  });
+}


### PR DESCRIPTION
Fixes the reply-quote caret reported in #1105.

## The defect

Replying to a message that does not fit on one line left the caret below the
visible area of the compose box: the quote was written, the caret placed at
the end, and the textarea never scrolled — so the answer was typed blind. The
threshold is not "very long": the issue measures a 46-character quote already
hiding it, because the compose textarea is `rows={1}` with `resize: none`, so
any draft that wraps becomes an internal scroll container, and
`setSelectionRange` does not scroll.

## Why it shipped, and what changed

`#173` had already met and fixed this exact defect on history recall, inside
`ComposeBox.scrollRecallCaretIntoView`. `appendToCompose` carried its own copy
of "caret at the end" **without** the `scrollTop = scrollHeight` line. Two
copies were two places to forget the second line in, and one of them did.

So this does not paste the missing line into the second place. Both callers now
route through one helper, `cicchetto/src/lib/composeCaret.placeCaretAtEndInView`
— a third caller inherits the reveal instead of re-earning the bug. That was
the open question in the issue's "Suggested fix", and the answer is: converge.

Deliberately **out** of the shared helper: `pasteRoute.insertPastedText` and
tab-complete. Both land the caret at an arbitrary offset, where scrolling to
the bottom would scroll *past* it; they need caret-position-aware scrolling,
which is a different mechanism, not this one-liner. They are named in the
helper's doc comment so the boundary is explicit rather than accidental.

`focus({ preventScroll: true })` is untouched — the UX-6 D9 guard against
WebKit's `_zoomToFocusRect` is orthogonal, because what moves here is the
textarea's own `scrollTop`, not the page.

One deliberate behaviour detail: the shared helper reads the caret offset off
the live element rather than off the string the caller just wrote. The two are
equivalent once the Solid controlled value has committed, which the existing
`queueMicrotask` already waits for, and reading the element keeps them from
disagreeing if that commit is ever late.

## Tests

**Unit** (`src/__tests__/replyQuote.test.ts`) — stubs `scrollHeight` and says
so in the comment. jsdom does no layout, so every element reports 0 and an
unstubbed assertion on `scrollTop` would pass vacuously; this pins the
*assignment* only. Measured red before the fix (`expected +0 to be 75`, one
failing assertion out of twelve) and green after.

**e2e** (`e2e/tests/issue1105-reply-quote-caret-visible.spec.ts`) — the real
regression: post a message long enough to wrap at a 390px viewport, swipe it
into the compose box, assert the end-caret's line is within
`[scrollTop, scrollTop + clientHeight]`. Chromium, untagged, per the house rule
that Playwright WebKit is not real iOS; what is asserted is geometry, the feel
on a device stays dogfood.

The e2e oracle (`composeCaretGeometry` + `expectEndCaretVisible`) moves into
the shared fixture and `#173`'s spec now consumes it. Leaving a second copy of
the assertion beside it would repeat, on the test side, exactly the duplication
this PR just removed from production. Its overflow floor became a **required**
per-caller argument rather than a constant inside the helper: it exists to stop
a vacuous pass on a draft that does not overflow, so each fixture should have
to state how much overflow it actually produces instead of inheriting a number
that quietly stops being true.

Touch synthesis stays in the spec: six specs in this suite already build their
own `TouchEvent`s because each samples something different mid-drag, and
hoisting a gesture helper shaped by another spec's needs would be a worse
abstraction than the shared oracle is a good one.

## Gates

Both cic gates green, exit codes read from file:

```
scripts/bun.sh run check  -> RC=0   (biome + tsc over src)
scripts/bun.sh run test   -> RC=0   (261 files, 4850 tests, 0 failures)
```

Working tree clean before and after.

## What is NOT covered

- **The e2e spec has not been run.** The e2e stack was not available to this
  change; CI is its first execution.
- **`cicchetto/e2e` has no static gate** — `tsc` and biome are both scoped to
  `src`. To narrow that hole rather than just declare it, `tsc --noEmit -p
  e2e/tsconfig.json` was run by hand: it reports **26 pre-existing errors
  across 18 files**, and **zero** in the three files this PR touches. Those 26
  are untouched here and look worth their own issue.
- **The second caller is covered by construction, not by a witness.**
  `Shell.tsx`'s off-compose printable-key handler goes through the same
  `appendToCompose`, and therefore the same helper, but has no e2e of its own.
- **No device verification.** Whether this feels right on real iOS is dogfood,
  not something this PR measured.
