### PR TITLE
cic(#1103): accept files from the OS share sheet

### DIFF
--- a/cicchetto/e2e/tests/issue1103-manifest-share-target.spec.ts
+++ b/cicchetto/e2e/tests/issue1103-manifest-share-target.spec.ts
@@ -1,0 +1,81 @@
+// #1103 — the served PWA manifest must declare a file `share_target`, and it
+// must accept exactly what the upload endpoint accepts (2026-08-09).
+//
+// WHY a served-manifest-contract spec and NOT a share-the-file spec: the
+// behaviour is not headlessly e2e-able. The share sheet is an OS surface,
+// the registration is minted into an Android WebAPK, and Playwright can
+// neither install one nor invoke Android's share intent. What CAN be proved
+// headlessly is the FIX ARTIFACT — that the manifest nginx actually serves
+// off the built dist carries the declaration, with the method, encoding and
+// accept list a Chromium install needs to offer cicchetto at all. Same
+// posture, and the same reasoning, as the #234 orientation guard next door.
+//
+// The accept list is the part worth pinning. It is DERIVED in the build from
+// `src/lib/uploadCategory.ts`, which is a declared 1:1 mirror of the server's
+// `@mime_categories` — the closed allowlist that answers 415. A hand-edit
+// that widens the manifest without widening the server would make the OS
+// offer cicchetto for a file the upload endpoint then refuses, after the app
+// has already opened. This spec reads the SERVED artifact, so it fails on
+// that drift rather than on a source-level pin that could agree with itself.
+//
+// KNOWN LIMITATION, not a gap in this spec: on Android the registration lives
+// in the WebAPK, which is Chromium machinery. A PWA installed from Firefox
+// will not appear in the system share sheet no matter what this manifest
+// says. Nothing headless can observe that either way.
+
+// Bare @playwright/test (NOT ../fixtures/test): a stateless static-asset
+// probe must skip the vjt-scoped fixture and its per-test reset — same
+// reasoning as issue234-manifest-no-orientation-pin.spec.ts.
+import { expect, test } from "@playwright/test";
+
+test("#1103 served PWA manifest declares a POST file share target", async ({ request }) => {
+  const res = await request.get("/manifest.webmanifest");
+  expect(res.status(), "GET /manifest.webmanifest").toBe(200);
+
+  const manifest = await res.json();
+
+  // Proves we got the real cic manifest and not a 404 fallback that happens
+  // to lack the key — the same non-vacuity guard #234 uses.
+  expect(manifest.id, "manifest.id must stay /cic").toBe("/cic");
+
+  const share = manifest.share_target;
+  expect(share, "manifest must declare share_target (#1103)").toBeTruthy();
+
+  // POST + multipart is not style: the spec requires both for a target that
+  // receives FILES, and a GET target cannot carry them at all.
+  expect(share.method, "a file share target must be POST").toBe("POST");
+  expect(share.enctype, "a file share target must be multipart/form-data").toBe(
+    "multipart/form-data",
+  );
+
+  // The action is what the service worker's fetch listener matches on. If the
+  // two ever disagree the POST leaves for the network, where nothing answers
+  // it, and the share dies as a 404 with the app never opening.
+  expect(typeof share.action, "share_target.action must be a path").toBe("string");
+
+  const files = share.params?.files;
+  expect(Array.isArray(files), "share_target.params.files must be an array").toBe(true);
+  expect(files[0]?.name, "the form field the SW reads").toBe("files");
+
+  // Accepts images at minimum — the case the issue was filed for (an Android
+  // user trying to share a photo into a channel).
+  const accept: string[] = files[0]?.accept ?? [];
+  expect(accept, "the accept list must carry the image MIMEs").toEqual(
+    expect.arrayContaining(["image/png", "image/jpeg"]),
+  );
+
+  // And nothing the upload endpoint would answer 415 to. `application/zip` is
+  // not in the server's closed allowlist and must never appear here: offering
+  // cicchetto in the share sheet for a file it will refuse is the failure
+  // this pins, and it is invisible until an operator hits it.
+  expect(accept, "the accept list must not exceed the upload allowlist").not.toContain(
+    "application/zip",
+  );
+  expect(accept).not.toContain("*/*");
+
+  // FILES ONLY. Declaring `text` or `url` would register cicchetto as a
+  // destination for shared LINKS, which it has no path for — the share would
+  // open the app and vanish. Better not to appear in the sheet at all.
+  expect(share.params?.text, "no text param: cic has no path for a shared link").toBeUndefined();
+  expect(share.params?.url, "no url param: cic has no path for a shared link").toBeUndefined();
+});

--- a/cicchetto/src/__tests__/shareTarget.test.ts
+++ b/cicchetto/src/__tests__/shareTarget.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  handleShareTargetRequest,
+  isShareTargetRequest,
+  SHARE_TARGET_ACCEPT,
+  SHARE_TARGET_ACTION,
+  SHARE_TARGET_FILES_FIELD,
+  takeSharedFiles,
+} from "../lib/shareTarget";
+import {
+  AUDIO_MIMES,
+  DOCUMENT_MIMES_OFFICE,
+  DOCUMENT_MIMES_PORTABLE,
+  IMAGE_MIMES,
+  VIDEO_MIMES,
+} from "../lib/uploadCategory";
+
+// #1103 — the Web Share Target wire contract, and the half of it that runs in
+// the service worker.
+//
+// WHAT THESE TESTS ATTEST, AND WHAT THEY DO NOT. jsdom does not run a service
+// worker: there is no `ServiceWorkerGlobalScope`, no real `CacheStorage`, and
+// no browser to POST a share into. So the SW's `fetch` LISTENER — that it is
+// registered, that it fires before Workbox's router, that a real WebAPK share
+// reaches it — is NOT covered here and cannot be. What IS covered is
+// everything the listener delegates to, which is why the listener is three
+// lines and this module holds the rest: the request predicate, the form
+// parse, the stash/read round-trip, and the redirect. The listener is
+// exercised only by a real browser.
+
+const ORIGIN = "https://cic.example.test";
+
+// Minimal in-memory CacheStorage. Only the four verbs the production code
+// touches; anything else would be scaffolding pretending to be a browser.
+//
+// It keys on the ABSOLUTE url, because that is what a browser does: a
+// relative key handed to `Cache.put` is resolved against the worker's scope,
+// and `Cache.keys()` hands back absolute `Request`s. A double that stored the
+// relative string would let a read side that assumes absolute keys pass here
+// and fail in the browser.
+function fakeCaches(): CacheStorage {
+  const stores = new Map<string, Map<string, Response>>();
+  const absolute = (req: RequestInfo): string =>
+    new URL(typeof req === "string" ? req : req.url, ORIGIN).toString();
+  const cacheFor = (name: string): Map<string, Response> => {
+    const existing = stores.get(name);
+    if (existing !== undefined) return existing;
+    const fresh = new Map<string, Response>();
+    stores.set(name, fresh);
+    return fresh;
+  };
+  return {
+    open: async (name: string) => {
+      const entries = cacheFor(name);
+      return {
+        put: async (req: RequestInfo, res: Response) => {
+          entries.set(absolute(req), res);
+        },
+        match: async (req: RequestInfo) => entries.get(absolute(req)),
+        // Deliberately REVERSED. `Cache.keys()` resolves in insertion order
+        // per spec, but the read side must not lean on that: it is a detail
+        // of a browser API we do not control, and the order files reach a
+        // channel is the order the operator picked them in. Handing the keys
+        // back backwards is what makes the read side's sort load-bearing
+        // instead of decorative.
+        keys: async () => [...entries.keys()].reverse().map((url) => new Request(url)),
+      } as unknown as Cache;
+    },
+    delete: async (name: string) => stores.delete(name),
+    has: async (name: string) => stores.has(name),
+  } as unknown as CacheStorage;
+}
+
+// The multipart body is written out BY HAND rather than through `FormData`.
+// Not preference: in this environment `FormData` is jsdom's and `Request` is
+// Node's, and handing the first to the second serialises to a part with
+// `filename=""` and the literal text `undefined` for a body. A test built on
+// that would assert against a payload no browser ever sends. These bytes are
+// the shape a WebAPK share actually posts.
+type SharedPart = { name: string; type: string; body: string };
+
+const BOUNDARY = "----cicShareTargetTestBoundary";
+
+function shareRequest(parts: SharedPart[]): Request {
+  const body =
+    parts
+      .map(
+        (p) =>
+          `--${BOUNDARY}\r\n` +
+          `Content-Disposition: form-data; name="${SHARE_TARGET_FILES_FIELD}"; filename="${p.name}"\r\n` +
+          `Content-Type: ${p.type}\r\n\r\n${p.body}\r\n`,
+      )
+      .join("") + `--${BOUNDARY}--\r\n`;
+  return new Request(`${ORIGIN}${SHARE_TARGET_ACTION}`, {
+    method: "POST",
+    body,
+    headers: { "content-type": `multipart/form-data; boundary=${BOUNDARY}` },
+  });
+}
+
+const png = (name: string, body: string): SharedPart => ({ name, type: "image/png", body });
+
+let caches: CacheStorage;
+beforeEach(() => {
+  caches = fakeCaches();
+});
+
+describe("the accept list is DERIVED from the upload allowlist", () => {
+  // The manifest tells the OS which types to offer cicchetto for. Hand-writing
+  // that list would put a second, silently-drifting copy of the server's
+  // `@mime_categories` in the build config — and the drift is invisible until
+  // an operator shares a file the OS offered us and the server answers 415.
+  it("carries exactly the MIMEs the upload path accepts", () => {
+    const expected = [
+      ...IMAGE_MIMES,
+      ...VIDEO_MIMES,
+      ...DOCUMENT_MIMES_PORTABLE,
+      ...DOCUMENT_MIMES_OFFICE,
+      ...AUDIO_MIMES,
+    ];
+    expect([...SHARE_TARGET_ACCEPT].sort()).toEqual([...expected].sort());
+  });
+
+  it("is not empty (a share target accepting nothing is never offered)", () => {
+    expect(SHARE_TARGET_ACCEPT.length).toBeGreaterThan(0);
+  });
+});
+
+describe("isShareTargetRequest", () => {
+  it("matches a POST to the share action", () => {
+    expect(isShareTargetRequest(shareRequest([]))).toBe(true);
+  });
+
+  it("ignores a GET to the same path", () => {
+    // The SW must not swallow a plain navigation to the action URL — that one
+    // belongs to Workbox's navigation fallback.
+    expect(
+      isShareTargetRequest(new Request(`${ORIGIN}${SHARE_TARGET_ACTION}`, { method: "GET" })),
+    ).toBe(false);
+  });
+
+  it("ignores a POST to any other path", () => {
+    expect(isShareTargetRequest(new Request(`${ORIGIN}/api/uploads`, { method: "POST" }))).toBe(
+      false,
+    );
+  });
+
+  it("matches regardless of query string", () => {
+    expect(
+      isShareTargetRequest(
+        new Request(`${ORIGIN}${SHARE_TARGET_ACTION}?from=android`, { method: "POST" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match a path that merely starts with the action", () => {
+    expect(
+      isShareTargetRequest(
+        new Request(`${ORIGIN}${SHARE_TARGET_ACTION}-decoy`, { method: "POST" }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("handleShareTargetRequest", () => {
+  it("answers with a 303 redirect into the app shell", async () => {
+    // 303 specifically: the browser must follow it with a GET. A 302 would let
+    // it re-POST the multipart body at the shell.
+    const res = await handleShareTargetRequest(shareRequest([png("a.png", "a")]), caches);
+    expect(res.status).toBe(303);
+    const location = res.headers.get("location") ?? "";
+    expect(new URL(location, ORIGIN).origin).toBe(ORIGIN);
+  });
+
+  it("hands the files to the app through the cache, bytes intact", async () => {
+    await handleShareTargetRequest(shareRequest([png("shot.png", "hello")]), caches);
+
+    const files = await takeSharedFiles(caches);
+    expect(files.length).toBe(1);
+    expect(files[0]?.name).toBe("shot.png");
+    expect(files[0]?.type).toBe("image/png");
+    expect(await files[0]?.text()).toBe("hello");
+  });
+
+  it("keeps a multi-file share in the order it arrived", async () => {
+    await handleShareTargetRequest(
+      shareRequest([png("1.png", "one"), png("2.png", "two"), png("3.png", "three")]),
+      caches,
+    );
+
+    const files = await takeSharedFiles(caches);
+    expect(files.map((f) => f.name)).toEqual(["1.png", "2.png", "3.png"]);
+  });
+
+  it("round-trips a non-ASCII filename", async () => {
+    // The name travels in an HTTP header, which is a latin-1 byte channel: a
+    // raw UTF-8 name either throws on `put` or comes back mojibake.
+    await handleShareTargetRequest(shareRequest([png("caffè ☕.png", "x")]), caches);
+
+    const files = await takeSharedFiles(caches);
+    expect(files[0]?.name).toBe("caffè ☕.png");
+  });
+
+  it("redirects with no flag when the body is not a form", async () => {
+    // Nothing to hand over, so the app must not go looking. Landing on the
+    // bare shell is the honest degrade.
+    const res = await handleShareTargetRequest(
+      new Request(`${ORIGIN}${SHARE_TARGET_ACTION}`, { method: "POST", body: "not-a-form" }),
+      caches,
+    );
+    expect(res.status).toBe(303);
+    expect(await takeSharedFiles(caches)).toEqual([]);
+  });
+});
+
+describe("takeSharedFiles", () => {
+  it("is empty when nothing was ever shared", async () => {
+    expect(await takeSharedFiles(caches)).toEqual([]);
+  });
+
+  it("CONSUMES: a second read finds nothing", async () => {
+    // The handover is one-shot. Left behind, the same files would be
+    // re-delivered on the next cold boot — a reload re-posting an image into a
+    // channel is worse than losing it.
+    await handleShareTargetRequest(shareRequest([png("a.png", "a")]), caches);
+
+    expect((await takeSharedFiles(caches)).length).toBe(1);
+    expect(await takeSharedFiles(caches)).toEqual([]);
+  });
+});

--- a/cicchetto/src/__tests__/shareTargetDelivery.test.ts
+++ b/cicchetto/src/__tests__/shareTargetDelivery.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import type { PersistedFocus } from "../lib/lastFocusedChannel";
+import {
+  resolveShareDestination,
+  type ShareDestinationSources,
+  shareDeliveryPlan,
+} from "../lib/shareTargetDelivery";
+
+// #1103 — WHERE a shared file goes, and what happens when the answer is
+// nowhere.
+//
+// This is the decision, isolated on purpose. A share arrives with no window
+// selected, so something has to name a `(networkSlug, channelName)` pair, and
+// the product question — deliver to the window the operator was last in, or
+// ask them with a picker — is not settled. Keeping the whole policy in
+// `resolveShareDestination` means settling it later is one function, not an
+// archaeology dig through the service worker and the boot path.
+//
+// The sources are injected rather than imported so the policy is a pure
+// function of what the stores say. Same shape as `installStaleResumeReload`
+// and the other seams in this codebase.
+
+const sources = (over: Partial<ShareDestinationSources>): ShareDestinationSources => ({
+  lastFocused: () => null,
+  channelExists: () => false,
+  queryExists: () => false,
+  ...over,
+});
+
+const focus = (over: Partial<PersistedFocus>): PersistedFocus => ({
+  networkSlug: "azzurra",
+  channelName: "#bofh",
+  kind: "channel",
+  ...over,
+});
+
+const png = (name: string): File => new File(["x"], name, { type: "image/png" });
+
+describe("resolveShareDestination — the last window the operator was in", () => {
+  it("names the last focused CHANNEL when it is still live", () => {
+    const dest = resolveShareDestination(
+      sources({
+        lastFocused: () => focus({}),
+        channelExists: (slug, name) => slug === "azzurra" && name === "#bofh",
+      }),
+    );
+    expect(dest).toEqual({ networkSlug: "azzurra", channelName: "#bofh" });
+  });
+
+  it("names the last focused QUERY when it is still live", () => {
+    const dest = resolveShareDestination(
+      sources({
+        lastFocused: () => focus({ kind: "query", channelName: "vjt" }),
+        queryExists: (slug, nick) => slug === "azzurra" && nick === "vjt",
+      }),
+    );
+    expect(dest).toEqual({ networkSlug: "azzurra", channelName: "vjt" });
+  });
+
+  it("refuses a channel that is no longer live", () => {
+    // Parted while cic was closed. Enqueueing an upload for it would post the
+    // resulting URL into a channel we are not in — the send is lost and the
+    // operator is told nothing.
+    const dest = resolveShareDestination(
+      sources({ lastFocused: () => focus({}), channelExists: () => false }),
+    );
+    expect(dest).toBeNull();
+  });
+
+  it("refuses a query window that is gone", () => {
+    const dest = resolveShareDestination(
+      sources({ lastFocused: () => focus({ kind: "query", channelName: "vjt" }) }),
+    );
+    expect(dest).toBeNull();
+  });
+
+  it("refuses when nothing was ever focused", () => {
+    expect(resolveShareDestination(sources({}))).toBeNull();
+  });
+
+  for (const kind of ["home", "admin", "mentions", "list", "server"] as const) {
+    it(`refuses ${kind}: it is not a place a file can be sent`, () => {
+      // These windows have no IRC target to PRIVMSG the upload URL to.
+      // `server` is the subtle one — it has real scrollback, so it looks
+      // deliverable, but its rows are numerics the bouncer wrote, not a
+      // conversation anyone can post into.
+      const dest = resolveShareDestination(
+        sources({
+          lastFocused: () => focus({ kind }),
+          channelExists: () => true,
+          queryExists: () => true,
+        }),
+      );
+      expect(dest).toBeNull();
+    });
+  }
+});
+
+describe("shareDeliveryPlan — deliver, or say why not", () => {
+  const live = sources({
+    lastFocused: () => focus({}),
+    channelExists: () => true,
+  });
+
+  it("delivers uploadable files to the resolved window", () => {
+    const plan = shareDeliveryPlan([png("a.png")], live);
+    expect(plan).toEqual({
+      kind: "deliver",
+      destination: { networkSlug: "azzurra", channelName: "#bofh" },
+      files: [expect.objectContaining({ name: "a.png" })],
+    });
+  });
+
+  it("blocks with no-destination when nowhere is live", () => {
+    const plan = shareDeliveryPlan([png("a.png")], sources({}));
+    expect(plan).toEqual({ kind: "blocked", reason: "no-destination" });
+  });
+
+  it("blocks with nothing-uploadable on an empty share", () => {
+    // The flag said a share was coming and the cache had nothing. Opening the
+    // app and doing nothing at all is the outcome this refuses.
+    expect(shareDeliveryPlan([], live)).toEqual({ kind: "blocked", reason: "nothing-uploadable" });
+  });
+
+  it("blocks with nothing-uploadable when no file is an accepted type", () => {
+    const exe = new File(["x"], "setup.exe", { type: "application/x-msdownload" });
+    expect(shareDeliveryPlan([exe], live)).toEqual({
+      kind: "blocked",
+      reason: "nothing-uploadable",
+    });
+  });
+
+  it("delivers the uploadable subset of a mixed share", () => {
+    const exe = new File(["x"], "setup.exe", { type: "application/x-msdownload" });
+    const plan = shareDeliveryPlan([exe, png("a.png")], live);
+    expect(plan.kind).toBe("deliver");
+    // The filter is `categoryOf`, the SAME gate drag-and-drop and paste use —
+    // not a second accept list written for this door.
+    expect(plan.kind === "deliver" && plan.files.map((f) => f.name)).toEqual(["a.png"]);
+  });
+
+  it("checks the destination BEFORE the files", () => {
+    // Both wrong at once: the operator needs to hear about the window first,
+    // because that is the one they can do something about.
+    expect(shareDeliveryPlan([], sources({}))).toEqual({
+      kind: "blocked",
+      reason: "no-destination",
+    });
+  });
+});

--- a/cicchetto/src/lib/errorBanners.ts
+++ b/cicchetto/src/lib/errorBanners.ts
@@ -4,6 +4,11 @@ import { requestBundleRefreshNow } from "./bundleRefreshNotice";
 import { acceptInvite, declineInvite } from "./channelJoin";
 import { isOffline } from "./connectivity";
 import { acceptPushOptin, declinePushOptin, shouldShowPushOptinBanner } from "./pushOptin";
+import {
+  clearShareTargetBlock,
+  shareTargetBannerMessage,
+  shouldShowShareTargetBanner,
+} from "./shareTargetOutcome";
 import { shouldShowBanner, socketHealth } from "./socketHealth";
 import { shouldShowSwRegBanner, swRegistration } from "./swRegistration";
 import { type InvitedWindow, invitedWindows } from "./windowState";
@@ -42,6 +47,7 @@ export const BANNER_SOURCES = [
   "bundle-refresh",
   "push-optin",
   "invite",
+  "share-target",
 ] as const;
 export type BannerSource = (typeof BANNER_SOURCES)[number];
 
@@ -190,6 +196,25 @@ export function activeBanners(): BannerEntry[] {
       source: "sw-registration",
       severity: "warn",
       message: swRegMessage(),
+    });
+  }
+
+  // #1103 — a share the OS handed us that could not be delivered. `warn`, and
+  // above the offer-shaped entries below: the operator did something a moment
+  // ago and the app has to answer for it, which outranks any standing prompt.
+  //
+  // Reported, not derived. Every other source here reads a condition that is
+  // still true while the banner is up (offline, invited, a newer bundle); a
+  // failed share is an EVENT with nothing left behind to observe, so the
+  // reader records it and the × ends it. Hence the explicit `dismiss` verb —
+  // the default × hides until the source recurs, and there is nothing to
+  // recur.
+  if (shouldShowShareTargetBanner()) {
+    entries.push({
+      source: "share-target",
+      severity: "warn",
+      message: shareTargetBannerMessage(),
+      dismiss: { label: "Dismiss", onAction: () => clearShareTargetBlock() },
     });
   }
 

--- a/cicchetto/src/lib/shareTarget.ts
+++ b/cicchetto/src/lib/shareTarget.ts
@@ -1,0 +1,184 @@
+import {
+  AUDIO_MIMES,
+  DOCUMENT_MIMES_OFFICE,
+  DOCUMENT_MIMES_PORTABLE,
+  IMAGE_MIMES,
+  VIDEO_MIMES,
+} from "./uploadCategory";
+
+// #1103 — Web Share Target: the wire contract, and the half of it that runs
+// inside the service worker.
+//
+// Three parties read this module and no other: `vite.config.ts` (which bakes
+// the `share_target` key into the generated manifest), `service-worker.ts`
+// (which intercepts the POST), and the SPA's delivery reader
+// (`shareTargetDelivery.ts`). They must agree on the action URL, the form
+// field name and the handover cache, so those three facts live here once
+// rather than three times. Same discipline as `pwaIcons.ts` (S18), which is
+// shared between the manifest and the SW for the same reason.
+//
+// ## Why the file has to travel through a Cache
+//
+// A share is a POST navigation. The SW answers it with a redirect, the
+// browser then GETs the shell, and the SPA boots FRESH — so the `File`
+// objects cannot simply be held in a variable: they have to survive both the
+// navigation and a possible SW termination in between. The Cache API is the
+// one storage that takes a `Response` body verbatim, so each file is stashed
+// as a one-off response and read back as a `File`. The handover is one-shot:
+// `takeSharedFiles` deletes the cache as it reads, because a leftover entry
+// would re-post the same image into a channel on the next cold boot.
+//
+// ## This module keeps NO app state
+//
+// It imports only `uploadCategory` (which imports nothing), so `vite.config.ts`
+// can pull it at build time without dragging the SolidJS graph into the build
+// config. Anything that touches stores lives in `shareTargetDelivery.ts`.
+
+/**
+ * The manifest `share_target.action`, and the URL the SW matches.
+ *
+ * Not a real server route: nothing on the Phoenix side answers it, and
+ * nothing should — the SW is the only handler. A GET here falls through to
+ * the SPA shell like any other unknown path.
+ */
+export const SHARE_TARGET_ACTION = "/share-target";
+
+/** The multipart field name, declared in the manifest and read by the SW. */
+export const SHARE_TARGET_FILES_FIELD = "files";
+
+/**
+ * The query flag on the post-redirect landing URL. The SPA reads it at boot
+ * to know a share is waiting, instead of probing the cache on every load.
+ */
+export const SHARE_TARGET_PARAM = "shared";
+
+/** Where the SW sends the browser once the files are stashed. */
+export const SHARE_TARGET_LANDING = `/?${SHARE_TARGET_PARAM}=1`;
+
+/** Handover cache. Versioned so a shape change cannot read stale entries. */
+export const SHARE_TARGET_CACHE = "cic-share-target-v1";
+
+/**
+ * The MIME types the OS may offer cicchetto, DERIVED from the upload
+ * allowlist rather than written out.
+ *
+ * `uploadCategory.ts` is already a declared 1:1 mirror of the server's
+ * `@mime_categories` (uploads_controller.ex), which is the closed allowlist
+ * that answers 415. Copying those strings into the build config would put a
+ * THIRD copy in the tree, and its drift would be invisible until an operator
+ * shares a file the OS offered us and the server refuses it — after the app
+ * has already opened, which is the worst place to find out.
+ */
+export const SHARE_TARGET_ACCEPT: readonly string[] = [
+  ...IMAGE_MIMES,
+  ...VIDEO_MIMES,
+  ...DOCUMENT_MIMES_PORTABLE,
+  ...DOCUMENT_MIMES_OFFICE,
+  ...AUDIO_MIMES,
+];
+
+// Per-file cache key. Zero-padded so the read side can restore the share's
+// order by sorting keys — `Cache.keys()` resolves in insertion order per
+// spec, but the order files reach a channel is the order the operator picked
+// them in, and that is worth pinning rather than inheriting.
+const fileKey = (index: number): string => `/__share-target/${String(index).padStart(4, "0")}`;
+
+// The filename rides an HTTP header, which is a latin-1 byte channel: a raw
+// UTF-8 name throws on `put` or comes back mojibake. Percent-encoding is the
+// standard escape and round-trips exactly.
+const NAME_HEADER = "x-cic-share-filename";
+
+/** True for the POST the OS makes when the operator picks cicchetto. */
+export function isShareTargetRequest(request: Request): boolean {
+  if (request.method !== "POST") return false;
+  return new URL(request.url).pathname === SHARE_TARGET_ACTION;
+}
+
+/**
+ * Handle the share POST: stash whatever files it carries, then redirect into
+ * the shell so the SPA can pick them up.
+ *
+ * `303` and not `302`: the browser must follow with a GET. A 302 leaves it
+ * free to re-issue the multipart POST at the shell URL.
+ *
+ * A body that is not a form cannot be a share we understand, so it lands on
+ * the BARE shell — no flag, nothing stashed, and the app opens without
+ * hunting for files that are not there.
+ */
+export async function handleShareTargetRequest(
+  request: Request,
+  cacheStorage: CacheStorage,
+): Promise<Response> {
+  let files: File[] = [];
+  try {
+    const form = await request.formData();
+    // A `FormDataEntryValue` is `string | File`, so "not a string" IS the
+    // discriminator. `instanceof File` looks tighter and is wrong: the
+    // entries come from whichever realm parsed the body (the SW's, or Node's
+    // under vitest), and a cross-realm instanceof silently answers false —
+    // dropping every file while reporting a clean parse.
+    files = form.getAll(SHARE_TARGET_FILES_FIELD).filter((v): v is File => typeof v !== "string");
+  } catch (err) {
+    console.warn("[shareTarget] share POST carried no readable form", err);
+    return redirectTo("/", request.url);
+  }
+  await stashSharedFiles(cacheStorage, files);
+  return redirectTo(SHARE_TARGET_LANDING, request.url);
+}
+
+function redirectTo(path: string, base: string): Response {
+  return new Response(null, {
+    status: 303,
+    headers: { location: new URL(path, base).toString() },
+  });
+}
+
+/** Put the shared files where the next document can read them. */
+export async function stashSharedFiles(
+  cacheStorage: CacheStorage,
+  files: readonly File[],
+): Promise<void> {
+  await cacheStorage.delete(SHARE_TARGET_CACHE);
+  if (files.length === 0) return;
+  const cache = await cacheStorage.open(SHARE_TARGET_CACHE);
+  let index = 0;
+  for (const file of files) {
+    await cache.put(
+      fileKey(index),
+      new Response(file, {
+        headers: {
+          "content-type": file.type === "" ? "application/octet-stream" : file.type,
+          [NAME_HEADER]: encodeURIComponent(file.name),
+        },
+      }),
+    );
+    index += 1;
+  }
+}
+
+/**
+ * Read the shared files and CLEAR them — one-shot by construction.
+ *
+ * Returns `[]` when no share is pending, which is also what a cache-less
+ * environment yields, so a caller never has to ask whether the API exists.
+ */
+export async function takeSharedFiles(cacheStorage: CacheStorage): Promise<File[]> {
+  if (!(await cacheStorage.has(SHARE_TARGET_CACHE))) return [];
+  const cache = await cacheStorage.open(SHARE_TARGET_CACHE);
+  const keys = await cache.keys();
+  const urls = keys.map((k) => k.url).sort();
+  const files: File[] = [];
+  for (const url of urls) {
+    const res = await cache.match(url);
+    if (res === undefined) continue;
+    const encoded = res.headers.get(NAME_HEADER);
+    const type = res.headers.get("content-type") ?? "application/octet-stream";
+    // `arrayBuffer()` and not `blob()`: the response body was minted by
+    // whichever realm answered the fetch, and a foreign Blob handed to this
+    // realm's `File` constructor is a cross-realm bet. A buffer is neutral.
+    const bytes = await res.arrayBuffer();
+    files.push(new File([bytes], decodeURIComponent(encoded ?? "shared"), { type }));
+  }
+  await cacheStorage.delete(SHARE_TARGET_CACHE);
+  return files;
+}

--- a/cicchetto/src/lib/shareTargetDelivery.ts
+++ b/cicchetto/src/lib/shareTargetDelivery.ts
@@ -1,0 +1,183 @@
+import { createEffect, untrack } from "solid-js";
+import { dropUpload } from "./dropUpload";
+import { loadLastFocused } from "./lastFocusedChannel";
+import { moduleRoot } from "./moduleRoot";
+import { channelsBySlug, networkBySlug, user } from "./networks";
+import { nickEquals } from "./nickEquals";
+import { queryWindowsByNetwork } from "./queryWindows";
+import { SHARE_TARGET_PARAM, takeSharedFiles } from "./shareTarget";
+import { recordShareTargetBlock, type ShareTargetBlock } from "./shareTargetOutcome";
+import { categoryOf } from "./uploadCategory";
+
+// #1103 — the app half of Web Share Target: pick up the files the service
+// worker stashed, decide where they go, and hand them to the upload path that
+// already exists.
+//
+// ## The destination is THE open question, so it is one function
+//
+// A share arrives with no window selected — the operator was in another app.
+// Whether cicchetto should deliver to the window they were last in or ask
+// them with a picker is a product decision that has not been made. So the
+// whole policy is `resolveShareDestination` below and nothing else knows how
+// a destination is chosen: settling the question later replaces that one
+// function instead of touching the service worker, the boot path and the
+// delivery in three places.
+//
+// PROVISIONAL, pending that decision: deliver to the last focused window.
+// That reading is defensible on its own terms — the share came from OUTSIDE
+// the app, so there is no window on screen to mean anything by "here", and
+// the window the operator last used is the only place they have expressed an
+// interest in. It is not a claim that the picker would be wrong.
+//
+// ## Why the LAST FOCUSED window and not the live selection
+//
+// A share POST is answered with a redirect, so the SPA boots cold: at the
+// moment this reader runs, `selectedChannel()` is null, and Shell's cold-load
+// arm may land `$home` PROVISIONALLY before the saved window arrives
+// (Shell.tsx, #187) — a reader watching the live signal would see that home
+// and conclude "nowhere to deliver" for an operator who has a perfectly good
+// channel. `loadLastFocused` is the same record Shell restores FROM, is
+// written by the selection store on every focus change, and is readable the
+// instant `/me` resolves. No race to lose.
+//
+// It is still checked against the live stores before use, because the answer
+// to "can a file be sent here" is not the answer to "can this window be
+// focused": a channel parted while cic was closed still restores fine as a
+// selection but would swallow the upload URL.
+//
+// ## No new upload plumbing
+//
+// The files go through `dropUpload`, the same entry point drag-and-drop
+// (DropUploadZone) and clipboard paste (pasteRoute) use, which owns the
+// category filter, the privacy modal, the queue and the sequential pump.
+
+export type ShareDestination = { networkSlug: string; channelName: string };
+
+/**
+ * What the destination policy is allowed to look at. Injected rather than
+ * imported so the policy is a pure function of what the stores say — the
+ * same seam shape as `installStaleResumeReload`.
+ */
+export type ShareDestinationSources = {
+  /** The persisted last-focused window for the current identity. */
+  lastFocused: () => ReturnType<typeof loadLastFocused>;
+  /** Is this channel currently joined? */
+  channelExists: (networkSlug: string, channelName: string) => boolean;
+  /** Is a query window open with this peer? */
+  queryExists: (networkSlug: string, nick: string) => boolean;
+};
+
+export type ShareDeliveryPlan =
+  | { kind: "deliver"; destination: ShareDestination; files: File[] }
+  | { kind: "blocked"; reason: ShareTargetBlock };
+
+/**
+ * THE destination policy. Change this one function to change where a shared
+ * file lands; nothing else in the feature encodes the answer.
+ *
+ * Returns null when there is no window a file can be sent to. Only `channel`
+ * and `query` qualify: every other kind — including `server`, which has real
+ * scrollback and so looks like a candidate — has no IRC target to carry the
+ * upload URL.
+ */
+export function resolveShareDestination(sources: ShareDestinationSources): ShareDestination | null {
+  const saved = sources.lastFocused();
+  if (saved === null) return null;
+  if (saved.kind === "channel") {
+    return sources.channelExists(saved.networkSlug, saved.channelName)
+      ? { networkSlug: saved.networkSlug, channelName: saved.channelName }
+      : null;
+  }
+  if (saved.kind === "query") {
+    return sources.queryExists(saved.networkSlug, saved.channelName)
+      ? { networkSlug: saved.networkSlug, channelName: saved.channelName }
+      : null;
+  }
+  return null;
+}
+
+/**
+ * Decide what to do with a share: deliver it, or name the reason it cannot be
+ * delivered. Pure — the caller performs whichever the plan says.
+ *
+ * The destination is checked FIRST. When both are wrong the operator hears
+ * about the window, because that is the one they can act on.
+ *
+ * The file filter is `categoryOf`, the same gate drag-and-drop and paste
+ * apply, so this door cannot develop its own idea of what is uploadable.
+ */
+export function shareDeliveryPlan(
+  files: readonly File[],
+  sources: ShareDestinationSources,
+): ShareDeliveryPlan {
+  const destination = resolveShareDestination(sources);
+  if (destination === null) return { kind: "blocked", reason: "no-destination" };
+  const uploadable = files.filter((f) => categoryOf(f.type) !== null);
+  if (uploadable.length === 0) return { kind: "blocked", reason: "nothing-uploadable" };
+  return { kind: "deliver", destination, files: uploadable };
+}
+
+/**
+ * Boot entry: if this document was opened by a share, collect the files and
+ * act on the plan.
+ *
+ * NOT unit-tested, and it cannot usefully be: it reads `location`, the Cache
+ * API and three live resources. The decision it defers to IS tested; what is
+ * left here is the wiring, and the browser is the only thing that can
+ * exercise it.
+ *
+ * Deferred until `/me` and the channel list resolve, for the same reason
+ * `applyDeepLinkFromUrl` defers: the policy reads stores, and an unresolved
+ * store answers "no" to every question.
+ */
+export function applySharedFilesFromUrl(): void {
+  if (typeof window === "undefined" || !window.location) return;
+  if (new URL(window.location.href).searchParams.get(SHARE_TARGET_PARAM) === null) return;
+  if (typeof caches === "undefined") {
+    console.warn("[shareTarget] share landing reached without a Cache API");
+    return;
+  }
+
+  let applied = false;
+  moduleRoot(() => {
+    createEffect(() => {
+      if (applied) return;
+      // Falsy, not `=== undefined`: the resource reads `undefined` while it
+      // loads and `null` when it resolved to no session. Neither can answer
+      // "which window was this identity last in".
+      const me = user();
+      if (!me) return;
+      if (channelsBySlug() === undefined) return;
+      applied = true;
+      untrack(() => void consumeShare(me.id));
+    });
+  });
+}
+
+async function consumeShare(userId: string): Promise<void> {
+  const files = await takeSharedFiles(caches);
+  const plan = shareDeliveryPlan(files, liveSources(userId));
+  if (plan.kind === "blocked") {
+    console.warn("[shareTarget] share not delivered:", plan.reason);
+    recordShareTargetBlock(plan.reason);
+  } else {
+    dropUpload(plan.files, plan.destination.networkSlug, plan.destination.channelName);
+  }
+  // Drop the flag either way: a reload must not re-run a share whose files
+  // have already been consumed.
+  if (window.history && window.location) {
+    window.history.replaceState({}, "", "/");
+  }
+}
+
+function liveSources(userId: string): ShareDestinationSources {
+  return {
+    lastFocused: () => loadLastFocused(userId),
+    channelExists: (slug, name) => (channelsBySlug()?.[slug] ?? []).some((c) => c.name === name),
+    queryExists: (slug, nick) => {
+      const net = networkBySlug(slug);
+      if (net === undefined) return false;
+      return (queryWindowsByNetwork()[net.id] ?? []).some((q) => nickEquals(q.targetNick, nick));
+    },
+  };
+}

--- a/cicchetto/src/lib/shareTargetOutcome.ts
+++ b/cicchetto/src/lib/shareTargetOutcome.ts
@@ -1,0 +1,54 @@
+import { createSignal } from "solid-js";
+
+// #1103 — what to tell the operator when a shared file goes nowhere.
+//
+// Its own module, next to `swRegistration.ts` in shape and for the same
+// reason: `errorBanners.ts` derives its entries from signals owned elsewhere,
+// so the signal has to live somewhere that does not drag the upload graph
+// into the banner registry. The registry imports the two readers below and
+// nothing else.
+//
+// This is a REPORT, not state: it is written once by the boot reader when a
+// share cannot be delivered, and the operator's × ends it. Nothing derives
+// from it and nothing else writes it.
+
+/**
+ * Why a share could not be delivered.
+ *
+ * `no-destination` — the last window the operator was in is gone (or there
+ * never was one), so there is no IRC target to send to.
+ * `nothing-uploadable` — the share carried no file the upload path accepts.
+ * That covers an empty share too: from the operator's side "nothing came
+ * through" is the same sentence either way.
+ */
+export type ShareTargetBlock = "no-destination" | "nothing-uploadable";
+
+const [blocked, setBlocked] = createSignal<ShareTargetBlock | null>(null);
+
+export const shareTargetBlock = blocked;
+
+export function recordShareTargetBlock(reason: ShareTargetBlock): void {
+  setBlocked(reason);
+}
+
+export function clearShareTargetBlock(): void {
+  setBlocked(null);
+}
+
+export function shouldShowShareTargetBanner(): boolean {
+  return blocked() !== null;
+}
+
+export function shareTargetBannerMessage(): string {
+  switch (blocked()) {
+    case "no-destination":
+      return "Shared file had nowhere to go — open a channel or a query, then share again.";
+    case "nothing-uploadable":
+      return "Nothing in that share could be uploaded.";
+    default:
+      // Unreachable while the banner is gated on `shouldShowShareTargetBanner`.
+      // Empty rather than a placeholder: a banner with filler text in it is
+      // worse than one that renders nothing.
+      return "";
+  }
+}

--- a/cicchetto/src/main.tsx
+++ b/cicchetto/src/main.tsx
@@ -32,6 +32,7 @@ import { applyIosClass, isStandalonePwa } from "./lib/platform";
 import { installPushResubscribe } from "./lib/pushResubscribe";
 import { applyDeepLinkFromUrl, installPushTargetListener } from "./lib/pushTarget";
 import { browserProbePerformance, installResumeProbe } from "./lib/resumeProbe";
+import { applySharedFilesFromUrl } from "./lib/shareTargetDelivery";
 import { applySidebarWidthsFromStorage } from "./lib/sidebarWidths";
 import { notifyClientClosing, reportVisibility } from "./lib/socket";
 import { socketHealth } from "./lib/socketHealth";
@@ -200,6 +201,15 @@ bootstrapAuth();
 // is what lets an invite survive the login round-trip.
 installPushTargetListener();
 applyDeepLinkFromUrl();
+
+// #1103 — the THIRD boot-time shape, and the only one that is not a link: the
+// OS share sheet POSTs files at the service worker, which stashes them and
+// redirects here with `?shared=1`. Kept out of `applyDeepLinkFromUrl` on
+// purpose — the other two shapes name a window to FOCUS, this one carries a
+// payload to SEND, and folding a file handover into a target router would
+// have made both harder to read. Same deferral discipline though: the reader
+// waits for the stores before deciding where the files go.
+applySharedFilesFromUrl();
 
 // #181 — auto-renew a dropped push subscription on the SW-update /
 // app-resume seams. iOS silently drops `pushManager.getSubscription()`

--- a/cicchetto/src/service-worker.ts
+++ b/cicchetto/src/service-worker.ts
@@ -38,12 +38,30 @@ import { createHandlerBoundToURL, precacheAndRoute } from "workbox-precaching";
 import { NavigationRoute, registerRoute } from "workbox-routing";
 import { shouldSuppressPush } from "./lib/pushDedup";
 import { narrowPushPayload, type PushPayload, pushNotificationOptions } from "./lib/pushPayload";
+import { handleShareTargetRequest, isShareTargetRequest } from "./lib/shareTarget";
 import { isSkipWaitingMessage, navigateStaleClients } from "./lib/swLifecycle";
 import { deliverNavigate } from "./lib/swNavigate";
 
 declare const self: ServiceWorkerGlobalScope & {
   __WB_MANIFEST: Array<{ url: string; revision: string | null }>;
 };
+
+// ── Web Share Target (#1103) ───────────────────────────────────────
+//
+// FIRST, above `precacheAndRoute`, and that order is deliberate. Workbox
+// registers its own `fetch` listener the moment a route is added, and the
+// first listener to call `respondWith` wins. Workbox's routes are GET-only,
+// so it would decline this POST anyway — but "anyway" is a claim about a
+// dependency's defaults, and being first is a fact about this file.
+//
+// Nothing else is answered here: a request that is not the share POST leaves
+// without calling `respondWith`, so it falls through to Workbox exactly as
+// before. The handler itself lives in `lib/shareTarget.ts` — vitest can
+// exercise it there, and nothing in this file is reachable from a test.
+self.addEventListener("fetch", (event: FetchEvent) => {
+  if (!isShareTargetRequest(event.request)) return;
+  event.respondWith(handleShareTargetRequest(event.request, caches));
+});
 
 precacheAndRoute(self.__WB_MANIFEST);
 

--- a/cicchetto/vite.config.ts
+++ b/cicchetto/vite.config.ts
@@ -5,6 +5,17 @@ import solid from "vite-plugin-solid";
 // service-worker's Web Push notification icon (`src/lib/pwaIcons.ts`), so a
 // rename can't silently drift the SW into a 404 path.
 import { PWA_ICONS } from "./src/lib/pwaIcons";
+// #1103 — the share-target contract is shared with the service worker and the
+// app, for the same reason the icon set is: the action URL, the form field and
+// the accepted MIME list must agree in all three places or the OS offers a
+// share the app cannot answer. `lib/shareTarget.ts` imports only
+// `lib/uploadCategory.ts` (which imports nothing), so pulling it in here does
+// not drag the SolidJS graph into the build config.
+import {
+  SHARE_TARGET_ACCEPT,
+  SHARE_TARGET_ACTION,
+  SHARE_TARGET_FILES_FIELD,
+} from "./src/lib/shareTarget";
 
 // #292 — bake grappa's version into the built (and dev) index.html as
 // `<meta name="cicchetto-version">`. ONE injection point: cic reads this tag
@@ -146,6 +157,26 @@ export default defineConfig({
         // Single source of truth shared with the SW notification icon —
         // see `src/lib/pwaIcons.ts` (S18).
         icons: [...PWA_ICONS],
+        // #1103 — accept files shared from the OS share sheet.
+        //
+        // FILES ONLY, deliberately: `title` / `text` / `url` are omitted, so
+        // Android offers cicchetto for a file share and not for a shared
+        // link. Declaring them would register a door that swallows a shared
+        // URL and does nothing with it — cic has no compose-insert path for
+        // one, and an app that appears in the sheet and then eats the share
+        // is worse than an app that never appears.
+        //
+        // `POST` + `multipart/form-data` is what the spec requires for file
+        // params, and it is why `service-worker.ts` needed a `fetch` listener
+        // at all: the POST never reaches the network, the worker answers it.
+        share_target: {
+          action: SHARE_TARGET_ACTION,
+          method: "POST",
+          enctype: "multipart/form-data",
+          params: {
+            files: [{ name: SHARE_TARGET_FILES_FIELD, accept: [...SHARE_TARGET_ACCEPT] }],
+          },
+        },
       },
       injectManifest: {
         // Shell-only: precache the build's hashed JS/CSS + index.html

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -34888,3 +34888,77 @@ acceptance criterion "prints that verb's help and exits 0, for every verb" does
 not hold. Closing it means inline help text for the boot verbs, doubling the
 surface that has to stay in lockstep with the `@shortdoc`s. That is a product
 call, deliberately not taken here.
+
+---
+
+## 2026-08-09 — #1103: the OS share sheet, and the one function that decides where a file lands
+
+Cicchetto could not be picked as a share destination: the generated manifest
+declared no `share_target`, and the custom service worker had no `fetch`
+listener to receive one. Requested on #grappa by someone trying to send a
+photo from Android straight into a channel.
+
+**Files only.** `share_target.params` declares `files` and NOT `title` / `text`
+/ `url`. Declaring them would register cicchetto as a destination for shared
+LINKS, and cic has no compose-insert path for one — the share would open the
+app and vanish. An app that appears in the share sheet and then eats the share
+is worse than an app that never appears. A link share is a separate feature
+with its own question (insert into which composer?), not a free extra.
+
+**The accept list is derived, not written.** It comes from
+`cicchetto/src/lib/uploadCategory.ts`, already a declared 1:1 mirror of the
+server's `@mime_categories` in `uploads_controller.ex` — the closed allowlist
+that answers 415. A hand-written third copy in the build config would drift
+invisibly, and its failure mode is the worst kind: the OS offers cicchetto for
+a file the endpoint then refuses, discovered only after the app has opened.
+`vite.config.ts` therefore imports `lib/shareTarget.ts`, which imports only
+`uploadCategory` (which imports nothing) so the build config does not drag the
+SolidJS graph in. Same discipline as `pwaIcons.ts` (S18).
+
+**Why the files travel through a Cache.** A share is a POST navigation: the SW
+answers it with a 303, the browser then GETs the shell, and the SPA boots
+FRESH. So the `File` objects have to survive both the navigation and a
+possible SW termination in between — a variable in the worker does not.
+`303` and not `302` because the browser must follow with a GET; a 302 leaves
+it free to re-POST the multipart body at the shell. The handover is one-shot:
+the read deletes the cache as it goes, because a leftover entry would re-post
+the same image into a channel on the next cold boot.
+
+**The destination is ONE function, deliberately.** A share arrives with no
+window selected — the operator was in another app — and whether cic should
+deliver to the window they were last in or ask them with a picker is a product
+decision that has not been made. So the whole policy is
+`resolveShareDestination` in `lib/shareTargetDelivery.ts` and nothing else
+knows how a destination is chosen; settling the question later replaces that
+one function rather than touching the service worker, the boot path and the
+delivery in three places.
+
+**Provisional answer, pending that decision: the last focused window.** The
+share came from OUTSIDE the app, so there is no window on screen to mean
+anything by "here", and the last-used one is the only place the operator has
+expressed an interest in. It reads `loadLastFocused` and NOT the live
+`selectedChannel()` — at boot the selection is null, and Shell's cold-load arm
+may land `$home` PROVISIONALLY before the saved window arrives (#187), so a
+reader watching the live signal would conclude "nowhere to deliver" for an
+operator who has a perfectly good channel. The saved record is checked against
+the live stores before use, because "can a file be sent here" is a different
+question from "can this window be focused": a channel parted while cic was
+closed restores fine as a selection but would swallow the upload URL.
+
+**No new upload plumbing.** Delivery is `dropUpload`, the same entry point
+drag-and-drop and clipboard paste use, which already owns the category filter,
+the privacy modal, the queue and the sequential pump.
+
+**A share that cannot be delivered says so.** New `share-target` banner source.
+It is the first REPORTED entry in a registry whose other sources are all
+DERIVED from a condition that stays true while the banner is up (offline,
+invited, a newer bundle); a failed share is an event with nothing left behind
+to observe, so it carries an explicit `dismiss` verb instead of the default
+hide-until-it-recurs, which would have nothing to recur on.
+
+**Known limitation, stated rather than cured.** On Android the share-target
+registration is minted into the **WebAPK**, which is Chromium machinery. A PWA
+installed from **Firefox will not appear in the system share sheet** even with
+this shipped. The original requester installed from Firefox, so their case
+stays uncovered on that browser; the feature works for Chromium-based installs.
+There is no fix available to us — it is not a bug in this implementation.


### PR DESCRIPTION
Refs #1103. Cicchetto can now be picked as a share destination: the
manifest declares a file `share_target`, the service worker answers the
POST, and the files go down the upload path that already exists.

## The three pieces, as measured rather than as listed

The issue's file/line pointers were checked, and all three held:
`vite.config.ts`'s manifest block carried no `share_target`,
`service-worker.ts` had no `fetch` listener at all, and
`dropUpload` → `triggerUploads` is intact and needed nothing.

**Manifest.** `share_target` with `method: POST`,
`enctype: multipart/form-data`, and a single `files` param.

**Service worker.** A `fetch` listener registered FIRST, above
`precacheAndRoute`. Workbox's routes are GET-only so it would decline
this POST anyway, but "anyway" is a claim about a dependency's
defaults; being first is a fact about the file. Anything that is not
the share POST returns without calling `respondWith` and falls through
to Workbox untouched.

**Delivery.** `dropUpload(files, networkSlug, channelName)` — the same
entry point drag-and-drop (`DropUploadZone`) and clipboard paste
(`pasteRoute`) use. No new upload plumbing, and the category filter
stays the one gate it already was.

## The accept list is derived from the server, not invented

It comes from `src/lib/uploadCategory.ts`, which is a declared 1:1
mirror of `@mime_categories` in `uploads_controller.ex` — the closed
allowlist behind the 415. Writing the list out in the build config
would have put a THIRD copy in the tree, and its drift is invisible
until the OS offers cicchetto a file the endpoint then refuses, after
the app has already opened.

`vite.config.ts` therefore imports `lib/shareTarget.ts`, which imports
only `uploadCategory` (which imports nothing), so the build config does
not drag the SolidJS graph in — the constraint that already made
`pwaIcons.ts` a shared module. The built manifest carries all 23 MIMEs;
that was read off `dist/manifest.webmanifest`, not assumed.

## Files only, deliberately

`title` / `text` / `url` are omitted, so Android offers cicchetto for a
file share and not for a shared link. Declaring them would register a
door that swallows a URL and does nothing with it — cic has no
compose-insert path for one — and an app that appears in the share
sheet and then eats the share is worse than one that never appears.

## The destination is ONE function, and its answer is provisional

A share arrives with **no window selected**: the operator was in another
app. Whether to deliver to the window they were last in or to ask them
with a picker is a product decision that has **not been made**, so the
whole policy is `resolveShareDestination` in `lib/shareTargetDelivery.ts`
and nothing else knows how a destination is chosen. Settling it later
replaces that one function instead of touching the service worker, the
boot path and the delivery in three places. Its sources are injected, so
it is a pure function of what the stores say and the tests drive it
without a store.

Shipped meanwhile, and **provisional**: deliver to the last focused
window. The share came from outside the app, so no window on screen
means anything by "here", and the last-used one is the only place the
operator has expressed an interest in. That is a defensible reading, not
a claim that the picker would be wrong.

It reads `loadLastFocused` and **not** the live `selectedChannel()`, for
correctness rather than convenience: a share POST is answered with a
redirect, so the SPA boots cold, the selection is null at that moment,
and Shell's cold-load arm can land `$home` PROVISIONALLY before the
saved window arrives (#187). A reader watching the live signal would see
that home and report "nowhere to deliver" to an operator with a perfectly
good channel. The saved record is still validated against the live
stores, because "can a file be sent here" is not the question "can this
window be focused" answers — a channel parted while cic was closed
restores fine as a selection but would swallow the upload URL.

A share that cannot be delivered says so: a new `share-target` banner
source, the registry's first REPORTED entry (every other source derives
from a condition still true while the banner is up), hence its explicit
`dismiss` verb.

## Known limitation — stated, not cured

On Android the share-target registration is minted into the **WebAPK**,
which is Chromium machinery. **A PWA installed from Firefox will not
appear in the system share sheet** even with this shipped. The original
requester installed from Firefox, so **their case stays uncovered on
that browser**; the feature works for Chromium-based installs. There is
no fix available here — it is not a defect in this implementation. It is
recorded in DESIGN_NOTES as a declared limitation.

## What the tests attest, and what they cannot

jsdom does not run a service worker: no `ServiceWorkerGlobalScope`, no
real `CacheStorage`, no browser to POST a share into. So the **listener**
— that it is registered, that it beats Workbox to the request, that a
real WebAPK share reaches it — is **not covered and cannot be**. That is
why the listener is three lines: everything it delegates to is unit
tested (the request predicate, the multipart parse, the stash/read
round-trip, the redirect status, the percent-encoded filename, the
one-shot consume). Three mutations were run against those tests and each
killed exactly one assertion: dropping the filename encoding, dropping
the consuming delete, dropping the key sort.

The multipart body in the tests is written out **by hand**: in this
environment `FormData` is jsdom's and `Request` is Node's, and handing
the first to the second serialises a part with `filename=""` and the
literal text `undefined` for a body. A test built on that would assert
against a payload no browser sends.

`applySharedFilesFromUrl` — the boot wiring — is **not** unit tested and
says so in its own docstring: it reads `location`, the Cache API and
three live resources. The decision it defers to is what the tests pin.

**The e2e spec was NOT RUN**: the lane was not this session's to take.
And `cicchetto/e2e` has **no static gate** — tsconfig and biome both
cover `src` only — so that file has not even been typechecked.

## Gates

* `scripts/bun.sh run test` — RC=0, 263 files / 4879 tests
* `scripts/bun.sh run check` — RC=0 (biome + tsc)
* `WRITABLE_CIC=1 scripts/bun.sh run build` — RC=0; `share_target`
  verified in the emitted manifest, `cic-share-target-v1` in the emitted
  service worker
* NOT run: e2e. No browser, no device, and no real share has been
  performed end to end.