### PR TITLE
e2e(#484): give the Playwright suite a static gate, and clear the 26 errors it never had one for

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,8 +351,17 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      # `check` is biome check src && tsc --noEmit — the same gate the
-      # local pre-commit path runs, so CI and the developer see one rule.
+      # #484 — `check` also typechecks `e2e/`, whose `@playwright/test` and
+      # `@types/node` are declared by e2e/package.json rather than cicchetto's,
+      # so the install above does not provide them. No `--frozen-lockfile`:
+      # e2e tracks no lockfile on purpose (see cicchetto/e2e/.gitignore — the
+      # runner image installs from package.json alone), and its three devDeps
+      # are exact-pinned, so the resolution is deterministic without one.
+      - name: Install e2e type dependencies
+        run: bun install --cwd e2e
+
+      # `check` is biome check (src + e2e) && tsc --noEmit for both projects —
+      # the same gate the local path runs, so CI and the developer see one rule.
       - name: Biome + typecheck
         run: bun run check
 

--- a/cicchetto/biome.json
+++ b/cicchetto/biome.json
@@ -6,7 +6,7 @@
     "useIgnoreFile": true
   },
   "files": {
-    "includes": ["src/**", "*.ts", "*.tsx", "*.json"]
+    "includes": ["src/**", "e2e/**", "*.ts", "*.tsx", "*.json"]
   },
   "formatter": {
     "enabled": true,

--- a/cicchetto/e2e/fixtures/bundleSwap.ts
+++ b/cicchetto/e2e/fixtures/bundleSwap.ts
@@ -211,16 +211,11 @@ export async function swapToBootableBundleB(): Promise<BundleSwapResult> {
  * `contentsFor(newHash)`. Shared by both swaps — they differ only in what
  * bundle B contains.
  */
-async function swapEntryAsset(
-  contentsFor: (newHash: string) => string,
-): Promise<BundleSwapResult> {
+async function swapEntryAsset(contentsFor: (newHash: string) => string): Promise<BundleSwapResult> {
   const oldHash = await readCurrentBundleHash();
   const newHash = `${SYNTH_HASH_PREFIX}${Date.now().toString(36)}`;
 
-  await fs.writeFile(
-    path.join(DIST_DIR, ASSETS_DIR, `index-${newHash}.js`),
-    contentsFor(newHash),
-  );
+  await fs.writeFile(path.join(DIST_DIR, ASSETS_DIR, `index-${newHash}.js`), contentsFor(newHash));
 
   const htmlPath = path.join(DIST_DIR, INDEX_HTML);
   const html = await fs.readFile(htmlPath, "utf8");

--- a/cicchetto/e2e/fixtures/cicchettoPage.ts
+++ b/cicchetto/e2e/fixtures/cicchettoPage.ts
@@ -60,7 +60,7 @@
 // cicchetto/src/lib/theme.ts MOBILE_QUERY = `(max-width: 768px)`.
 // Playwright's iPhone 15 device has viewport 393×852 → mobile branch.
 
-import { type Locator, type Page, expect } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
 import type { SeededUser } from "./grappaApi";
 
 const SHELL_READY_TIMEOUT_MS = 10_000;
@@ -218,9 +218,7 @@ export function sidebarWindow(page: Page, networkSlug: string, windowName: strin
     // (the slug attribute already disambiguates it from channel/query
     // tabs).
     if (isServerWindow) {
-      return section.locator(
-        `.bottom-bar-network-header[data-network-slug="${networkSlug}"]`,
-      );
+      return section.locator(`.bottom-bar-network-header[data-network-slug="${networkSlug}"]`);
     }
     // Channel + query tabs: exact match via data-window-name on the
     // `.bottom-bar-tab` button. Exclude the network-header tab
@@ -284,8 +282,7 @@ export function sidebarCloseButton(page: Page, networkSlug: string, windowName: 
     });
     // The tab + close are now flat siblings; locate the tab by text,
     // then walk to the next sibling close × via xpath following-sibling.
-    return section
-      .locator(`.bottom-bar-tab:has-text("${windowName}") + .bottom-bar-close`);
+    return section.locator(`.bottom-bar-tab:has-text("${windowName}") + .bottom-bar-close`);
   }
   return sidebarWindow(page, networkSlug, windowName).locator(".sidebar-close");
 }
@@ -635,9 +632,8 @@ export async function awaitServiceWorkerActive(page: Page): Promise<void> {
 export async function awaitServerBundleHashPush(page: Page): Promise<void> {
   await page.waitForFunction(
     () => {
-      const bh = (
-        window as unknown as { __cic_bundleHash?: { serverHash?: () => string | null } }
-      ).__cic_bundleHash;
+      const bh = (window as unknown as { __cic_bundleHash?: { serverHash?: () => string | null } })
+        .__cic_bundleHash;
       return bh?.serverHash?.() != null;
     },
     null,
@@ -661,10 +657,9 @@ export function scrollbackLines(page: Page) {
 // non-contiguous tokens must match, e.g. a presence line that now
 // carries an irssi-style `[user@host]` between the nick and the verb.
 export function scrollbackLine(page: Page, kind: string, bodyMatch: string | RegExp) {
-  return page.locator(
-    `[data-testid="scrollback-line"][data-kind="${kind}"]`,
-    { hasText: bodyMatch },
-  );
+  return page.locator(`[data-testid="scrollback-line"][data-kind="${kind}"]`, {
+    hasText: bodyMatch,
+  });
 }
 
 // #237 — the on-JOIN inline topic line. NOT a `scrollback-line` (it is a
@@ -947,10 +942,7 @@ export type SettingsSection =
 // (viewport-aware — it opens the rail drawer first on mobile), then the cog is
 // tapped. Re-navigating an already-open drawer is a no-op on the open step and
 // assumes it is on the main index.
-export async function openSettingsSection(
-  page: Page,
-  section: SettingsSection,
-): Promise<Locator> {
+export async function openSettingsSection(page: Page, section: SettingsSection): Promise<Locator> {
   if ((await page.locator(".settings-drawer.open").count()) === 0) {
     await openRailMenu(page);
     await page.getByTestId("action-cluster-cog").click();
@@ -1050,9 +1042,7 @@ export async function closeSettings(page: Page): Promise<void> {
 // click directly via DevTools — same end-state effect, no synthesis
 // race. Verified across UX-6-A scroll spec + UX-4-Z journey spec.
 export async function closeMembersDrawer(page: Page): Promise<void> {
-  await page
-    .locator(".shell-drawer-backdrop.open")
-    .click({ position: { x: 20, y: 200 } });
+  await page.locator(".shell-drawer-backdrop.open").click({ position: { x: 20, y: 200 } });
   await expect(page.locator(".shell-members.open")).toHaveCount(0, { timeout: 5_000 });
 }
 
@@ -1115,32 +1105,29 @@ export async function synthSwipe(
   page: Page,
   args: { startX: number; startY: number; endX: number; endY: number; slowMs: number },
 ): Promise<void> {
-  await page.evaluate(
-    async ({ startX, startY, endX, endY, slowMs }) => {
-      const ta = document.querySelector(".compose-box textarea");
-      if (!(ta instanceof HTMLTextAreaElement)) throw new Error("compose textarea not found");
-      const touch = (x: number, y: number) =>
-        new Touch({ identifier: 1, target: ta, clientX: x, clientY: y });
-      const fire = (type: "touchstart" | "touchmove" | "touchend", x: number, y: number) => {
-        const t = touch(x, y);
-        const ended = type === "touchend";
-        ta.dispatchEvent(
-          new TouchEvent(type, {
-            bubbles: true,
-            cancelable: true,
-            touches: ended ? [] : [t],
-            targetTouches: ended ? [] : [t],
-            changedTouches: [t],
-          }),
-        );
-      };
-      fire("touchstart", startX, startY);
-      if (slowMs > 0) await new Promise((r) => setTimeout(r, slowMs));
-      fire("touchmove", endX, endY);
-      fire("touchend", endX, endY);
-    },
-    args,
-  );
+  await page.evaluate(async ({ startX, startY, endX, endY, slowMs }) => {
+    const ta = document.querySelector(".compose-box textarea");
+    if (!(ta instanceof HTMLTextAreaElement)) throw new Error("compose textarea not found");
+    const touch = (x: number, y: number) =>
+      new Touch({ identifier: 1, target: ta, clientX: x, clientY: y });
+    const fire = (type: "touchstart" | "touchmove" | "touchend", x: number, y: number) => {
+      const t = touch(x, y);
+      const ended = type === "touchend";
+      ta.dispatchEvent(
+        new TouchEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          touches: ended ? [] : [t],
+          targetTouches: ended ? [] : [t],
+          changedTouches: [t],
+        }),
+      );
+    };
+    fire("touchstart", startX, startY);
+    if (slowMs > 0) await new Promise((r) => setTimeout(r, slowMs));
+    fire("touchmove", endX, endY);
+    fire("touchend", endX, endY);
+  }, args);
 }
 
 // The compose caret + scroll geometry, read off the live element.

--- a/cicchetto/e2e/fixtures/grappaApi.ts
+++ b/cicchetto/e2e/fixtures/grappaApi.ts
@@ -40,9 +40,7 @@ export async function login(identifier: string, password: string): Promise<Login
     body: JSON.stringify({ identifier, password }),
   });
   if (!response.ok) {
-    throw new Error(
-      `grappaApi.login: ${identifier} → ${response.status} ${await response.text()}`,
-    );
+    throw new Error(`grappaApi.login: ${identifier} → ${response.status} ${await response.text()}`);
   }
   return (await response.json()) as LoginResult;
 }
@@ -80,9 +78,7 @@ export async function mintVisitor(nick: string, incognito = false): Promise<Mint
     body: JSON.stringify(loginBody),
   });
   if (!response.ok) {
-    throw new Error(
-      `grappaApi.mintVisitor: ${nick} → ${response.status} ${await response.text()}`,
-    );
+    throw new Error(`grappaApi.mintVisitor: ${nick} → ${response.status} ${await response.text()}`);
   }
   const body = (await response.json()) as {
     token: string;
@@ -161,9 +157,7 @@ export async function loginVisitor(
     subject: { kind: "visitor"; id: string; registered?: boolean; incognito?: boolean };
   };
   if (body.subject.kind !== "visitor") {
-    throw new Error(
-      `grappaApi.loginVisitor: expected visitor subject, got ${body.subject.kind}`,
-    );
+    throw new Error(`grappaApi.loginVisitor: expected visitor subject, got ${body.subject.kind}`);
   }
   return {
     id: body.subject.id,
@@ -361,9 +355,7 @@ export async function terminateSession(adminToken: string, sessionId: string): P
     headers: { authorization: `Bearer ${adminToken}` },
   });
   if (!res.ok) {
-    throw new Error(
-      `grappaApi.terminateSession: ${sessionId} → ${res.status} ${await res.text()}`,
-    );
+    throw new Error(`grappaApi.terminateSession: ${sessionId} → ${res.status} ${await res.text()}`);
   }
 }
 
@@ -376,10 +368,7 @@ export async function terminateSession(adminToken: string, sessionId: string): P
 //
 // Idempotent: 404 (visitor already deleted by the test under
 // assertion) is treated as success.
-export async function adminDeleteVisitor(
-  adminToken: string,
-  visitorId: string,
-): Promise<void> {
+export async function adminDeleteVisitor(adminToken: string, visitorId: string): Promise<void> {
   const url = `${GRAPPA_BASE_URL}/admin/visitors/${encodeURIComponent(visitorId)}`;
   const res = await fetch(url, {
     method: "DELETE",
@@ -514,10 +503,7 @@ function sleep(ms: number): Promise<void> {
 // record as offering it. Without this probe a spec asserting absence
 // stays green when the row stops being archive-eligible at all — passing
 // for the wrong reason.
-export async function listArchiveTargets(
-  token: string,
-  networkSlug: string,
-): Promise<string[]> {
+export async function listArchiveTargets(token: string, networkSlug: string): Promise<string[]> {
   const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(networkSlug)}/archive`;
   const res = await fetch(url, { headers: { authorization: `Bearer ${token}` } });
   if (!res.ok) {
@@ -851,8 +837,6 @@ export async function setCredentialAutojoin(
   });
   if (!res.ok) {
     const text = await res.text().catch(() => "<no body>");
-    throw new Error(
-      `setCredentialAutojoin(${userId}/${networkId}) → ${res.status} ${text}`,
-    );
+    throw new Error(`setCredentialAutojoin(${userId}/${networkId}) → ${res.status} ${text}`);
   }
 }

--- a/cicchetto/e2e/fixtures/ircClient.ts
+++ b/cicchetto/e2e/fixtures/ircClient.ts
@@ -14,7 +14,7 @@
 // `disconnect` tears it down. Pair `try/finally` in the spec to keep
 // peer leaks out of the runner between tests.
 
-import { Client } from "irc-framework";
+import { Client, type IrcEventMap, type IrcEventName } from "irc-framework";
 import { awaitPrivmsg } from "./privmsgWait";
 
 const HOST = process.env.E2E_IRC_HOST ?? "bahamut-test";
@@ -101,12 +101,7 @@ export class IrcPeer {
       });
     }
 
-    const registered = once<{ nick: string }>(
-      client,
-      "registered",
-      REGISTER_TIMEOUT_MS,
-      `register ${opts.nick}`,
-    );
+    const registered = once(client, "registered", REGISTER_TIMEOUT_MS, `register ${opts.nick}`);
 
     // Ghost/collision hardening (#604). If the requested nick is already held —
     // a residual ghost from a prior run, or a live collision under bahamut's
@@ -556,18 +551,23 @@ export class IrcPeer {
 // attached for the life of the peer: harmless-looking, but `waitForLine`'s
 // runs a regex over every wire line thereafter, and the next helper written
 // in this shape inherits it.
-function once<T = unknown>(
+// Both waits are keyed by the event NAME, not by a caller-supplied payload
+// type: `IrcEventName` is closed, so a listener on an event irc-framework never
+// emits no longer compiles (the `rpl_youreoper` trap this file documents under
+// `oper()`), and the payload type follows from the name instead of from
+// whatever the call site guessed.
+function once<E extends IrcEventName>(
   client: Client,
-  event: string,
+  event: E,
   timeoutMs: number,
   label: string,
-): Promise<T> {
+): Promise<IrcEventMap[E]> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
       client.removeListener(event, handler);
       reject(new Error(`IrcPeer: timeout waiting for ${label} (${timeoutMs}ms)`));
     }, timeoutMs);
-    const handler = (payload: T) => {
+    const handler = (payload: IrcEventMap[E]) => {
       clearTimeout(timer);
       client.removeListener(event, handler);
       resolve(payload);
@@ -576,19 +576,19 @@ function once<T = unknown>(
   });
 }
 
-function onceMatching<T>(
+function onceMatching<E extends IrcEventName>(
   client: Client,
-  event: string,
-  predicate: (payload: T) => boolean,
+  event: E,
+  predicate: (payload: IrcEventMap[E]) => boolean,
   timeoutMs: number,
   label: string,
-): Promise<T> {
+): Promise<IrcEventMap[E]> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
       client.removeListener(event, handler);
       reject(new Error(`IrcPeer: timeout waiting for ${label} (${timeoutMs}ms)`));
     }, timeoutMs);
-    const handler = (payload: T) => {
+    const handler = (payload: IrcEventMap[E]) => {
       if (!predicate(payload)) return;
       clearTimeout(timer);
       client.removeListener(event, handler);

--- a/cicchetto/e2e/fixtures/ircClient.ts
+++ b/cicchetto/e2e/fixtures/ircClient.ts
@@ -332,8 +332,7 @@ export class IrcPeer {
     const ack = onceMatching(
       this.client,
       "raw",
-      (event: { line?: string }) =>
-        typeof event.line === "string" && / 306 /.test(event.line),
+      (event: { line?: string }) => typeof event.line === "string" && / 306 /.test(event.line),
       AWAY_TIMEOUT_MS,
       `away ack (306 RPL_NOWAWAY) for ${this.nick}`,
     );
@@ -391,7 +390,7 @@ export class IrcPeer {
       (event: { target: string; raw_modes: string }) =>
         event.target === channel && event.raw_modes === rawModes,
       MODE_TIMEOUT_MS,
-      `mode ${channel} ${rawModes}${extraArg ? " " + extraArg : ""}`,
+      `mode ${channel} ${rawModes}${extraArg ? ` ${extraArg}` : ""}`,
     );
     this.client.mode(channel, rawModes, extraArg);
     await modeEcho;

--- a/cicchetto/e2e/fixtures/pageDiagnostics.ts
+++ b/cicchetto/e2e/fixtures/pageDiagnostics.ts
@@ -1,0 +1,33 @@
+// Forward the page's own error output into the Playwright run log.
+//
+// #484 — this existed as four hand-copied `page.on("console", …)` blocks, and
+// all four carried the same defect: they filtered on `msg.type() === "warn"`.
+// Playwright's `ConsoleMessage.type()` returns `"warning"`, never `"warn"`, so
+// the branch was statically dead and every cic `console.warn` was dropped from
+// the log of the specs that had gone out of their way to capture it. The
+// duplication is what let one wrong literal be wrong four times, so the fix is
+// one helper rather than four corrected copies.
+//
+// Diagnostics only: this attaches listeners and prints. It asserts nothing and
+// fails nothing — a spec that wants to FAIL on console noise must assert on it.
+
+import type { ConsoleMessage, Page } from "@playwright/test";
+
+type ConsoleType = ReturnType<ConsoleMessage["type"]>;
+
+// Severities worth surfacing. Typed against Playwright's own union, so the
+// `"warn"` typo that started this is now a compile error rather than a branch
+// that quietly never runs.
+const FORWARDED_TYPES = new Set<ConsoleType>(["error", "warning"]);
+
+export function forwardPageDiagnostics(page: Page): void {
+  page.on("console", (msg) => {
+    if (!FORWARDED_TYPES.has(msg.type())) return;
+    // eslint-disable-next-line no-console
+    console.log(`[cic:${msg.type()}] ${msg.text()}`);
+  });
+  page.on("pageerror", (err) => {
+    // eslint-disable-next-line no-console
+    console.log(`[cic:pageerror] ${err.message}`);
+  });
+}

--- a/cicchetto/e2e/fixtures/privmsgWait.test.ts
+++ b/cicchetto/e2e/fixtures/privmsgWait.test.ts
@@ -5,7 +5,7 @@
 // e2e-only `irc-framework` dependency.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { type PrivmsgEvent, awaitPrivmsg, type PrivmsgSource } from "./privmsgWait";
+import { awaitPrivmsg, type PrivmsgEvent, type PrivmsgSource } from "./privmsgWait";
 
 type FakeSource = PrivmsgSource & {
   emit: (nick: string, message: string) => void;

--- a/cicchetto/e2e/fixtures/privmsgWait.ts
+++ b/cicchetto/e2e/fixtures/privmsgWait.ts
@@ -73,8 +73,7 @@ export async function awaitPrivmsg(source: PrivmsgSource, spec: PrivmsgWaitSpec)
     rejectWait = reject;
   });
 
-  const matches = (event: PrivmsgEvent) =>
-    event.nick === fromNick && event.message.includes(body);
+  const matches = (event: PrivmsgEvent) => event.nick === fromNick && event.message.includes(body);
 
   const handler = (event: PrivmsgEvent) => {
     const at = Date.now();

--- a/cicchetto/e2e/fixtures/push.ts
+++ b/cicchetto/e2e/fixtures/push.ts
@@ -34,7 +34,7 @@
 // assertions, scrollback queries, channel selection still come from
 // cicchettoPage.ts — push specs use both.
 
-import { type BrowserContext, type Page, expect } from "@playwright/test";
+import { type BrowserContext, expect, type Page } from "@playwright/test";
 import { openSettingsSection } from "./cicchettoPage";
 
 const PUSH_CATCHER_URL = process.env.E2E_PUSH_CATCHER_URL ?? "http://push-catcher:3000";

--- a/cicchetto/e2e/fixtures/test.ts
+++ b/cicchetto/e2e/fixtures/test.ts
@@ -71,20 +71,22 @@ interface CspViolation {
   lineNumber: number;
 }
 
+// `void` is Playwright's own spelling for an auto-fixture that produces no
+// value (`test.extend<{ myFixture: void }>`), so the three below are the
+// documented shape and not the confusing-void the rule is written against.
+// biome-ignore-start lint/suspicious/noConfusingVoidType: Playwright's auto-fixture declaration shape
 export const test = base.extend<{
   _vjtReset: void;
   _cspGuard: void;
   _unrouteGuard: void;
 }>({
+  // biome-ignore-end lint/suspicious/noConfusingVoidType: Playwright's auto-fixture declaration shape
   _cspGuard: [
     async ({ context }, use) => {
       const violations: CspViolation[] = [];
-      await context.exposeBinding(
-        "__grappaCspViolation",
-        (_source, violation: CspViolation) => {
-          violations.push(violation);
-        },
-      );
+      await context.exposeBinding("__grappaCspViolation", (_source, violation: CspViolation) => {
+        violations.push(violation);
+      });
       await context.addInitScript(() => {
         document.addEventListener("securitypolicyviolation", (e) => {
           const report = (
@@ -125,6 +127,11 @@ export const test = base.extend<{
   // purpose — the last two times this was a throwaway local diff, the
   // evidence was lost before the question got answered.
   _vjtReset: [
+    // The empty destructuring pattern is load-bearing: Playwright reads the
+    // first parameter's pattern to decide which fixtures to instantiate, and
+    // rejects a non-destructured one outright. `{}` is how a fixture declares
+    // it needs none — it is an API contract, not a stray empty pattern.
+    // biome-ignore lint/correctness/noEmptyPattern: Playwright fixture-dependency declaration
     async ({}, use, testInfo) => {
       await use();
       const admin = getSeededAdmin();

--- a/cicchetto/e2e/fixtures/uploadJourney.ts
+++ b/cicchetto/e2e/fixtures/uploadJourney.ts
@@ -24,7 +24,7 @@
 // fallback probe) before the POST, so its budget is 6× the image
 // path's. A shared default would silently misbudget one of them.
 
-import { type Locator, type Page, expect } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
 import { scrollbackLine } from "./cicchettoPage";
 
 export interface PickerFile {

--- a/cicchetto/e2e/package.json
+++ b/cicchetto/e2e/package.json
@@ -11,7 +11,6 @@
   "devDependencies": {
     "@playwright/test": "1.59.1",
     "@types/node": "22.10.0",
-    "irc-framework": "4.14.0",
-    "typescript": "5.7.2"
+    "irc-framework": "4.14.0"
   }
 }

--- a/cicchetto/e2e/playwright.config.ts
+++ b/cicchetto/e2e/playwright.config.ts
@@ -32,10 +32,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: 0,
   workers: 1,
-  reporter: [
-    ["list"],
-    ["html", { outputFolder: "playwright-report", open: "never" }],
-  ],
+  reporter: [["list"], ["html", { outputFolder: "playwright-report", open: "never" }]],
   use: {
     baseURL,
     // Self-signed nginx-test cert — accepted across every spec.

--- a/cicchetto/e2e/tests/_smoke.spec.ts
+++ b/cicchetto/e2e/tests/_smoke.spec.ts
@@ -13,10 +13,10 @@
 // session ↔ scrollback path is alive end-to-end". UI-shaped specs land
 // in S3 once this baseline is green.
 
-import { test, expect } from "../fixtures/test";
-import { IrcPeer } from "../fixtures/ircClient";
 import { assertMessagePersisted } from "../fixtures/grappaApi";
-import { getSeededVjt, NETWORK_SLUG, AUTOJOIN_CHANNELS } from "../fixtures/seedData";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "vjt-peer";
 const CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/admin-credentials.spec.ts
+++ b/cicchetto/e2e/tests/admin-credentials.spec.ts
@@ -9,10 +9,10 @@
 // asserts, and cleans up best-effort. We don't touch the seeded
 // vjt/bahamut-test credential (it's load-bearing for other specs).
 
-import { expect, test } from "../fixtures/test";
 import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
-import { getSeededAdmin } from "../fixtures/seedData";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 async function adminLogin(
   page: import("@playwright/test").Page,
@@ -124,9 +124,9 @@ test("admin binds a new credential via the bind form — row appears", async ({ 
     await page.getByTestId("admin-credentials-bind-nick").fill("boundnick");
     await page.getByTestId("admin-credentials-bind-submit").click();
 
-    await expect(
-      page.getByTestId(`admin-credential-row-${userId}:${networkId}`),
-    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId(`admin-credential-row-${userId}:${networkId}`)).toBeVisible({
+      timeout: 10_000,
+    });
   } finally {
     if (userId !== null && networkId !== null) {
       await unbindBestEffort(admin.token, userId, networkId);
@@ -155,15 +155,13 @@ test("admin edits a credential (realname change) — left_alone toast", async ({
     await page.getByTestId(`admin-credential-edit-${credKey}`).click();
     await expect(page.getByTestId(`admin-credential-edit-form-${credKey}`)).toBeVisible();
 
-    await page
-      .getByTestId(`admin-credential-edit-realname-${credKey}`)
-      .fill("Updated Real Name");
+    await page.getByTestId(`admin-credential-edit-realname-${credKey}`).fill("Updated Real Name");
     await page.getByTestId(`admin-credential-edit-submit-${credKey}`).click();
 
     // Toast surfaces left_alone (cosmetic change, no session impact).
-    await expect(
-      page.getByTestId("admin-credentials-session-action-toast"),
-    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("admin-credentials-session-action-toast")).toBeVisible({
+      timeout: 5_000,
+    });
     await expect(page.getByTestId("admin-credentials-session-action-toast")).toContainText(
       /left alone/i,
     );

--- a/cicchetto/e2e/tests/admin-network-crud.spec.ts
+++ b/cicchetto/e2e/tests/admin-network-crud.spec.ts
@@ -9,10 +9,10 @@
 // other specs — never delete those. Tests create unique slugs (timestamp
 // suffix) and best-effort delete in finally.
 
-import { expect, test } from "../fixtures/test";
 import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
-import { getSeededAdmin } from "../fixtures/seedData";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 function userIdFromSubject(subjectJson: string): string {
   const subj = JSON.parse(subjectJson) as { kind: string; id: string };

--- a/cicchetto/e2e/tests/admin-server-crud.spec.ts
+++ b/cicchetto/e2e/tests/admin-server-crud.spec.ts
@@ -8,10 +8,10 @@
 // Uses a freshly-created ephemeral network per test (so we don't
 // pollute the seeded networks' server lists).
 
-import { expect, test } from "../fixtures/test";
 import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
-import { getSeededAdmin } from "../fixtures/seedData";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 async function adminLogin(
   page: import("@playwright/test").Page,
@@ -71,19 +71,18 @@ test("admin adds a server to a network via the disclosure", async ({ page }) => 
     await page.getByTestId(`admin-network-expand-${slug}`).click();
     await expect(page.getByTestId(`admin-network-add-server-form-${slug}`)).toBeVisible();
 
-    await page
-      .getByTestId(`admin-network-add-server-host-${slug}`)
-      .fill("irc.example.test");
+    await page.getByTestId(`admin-network-add-server-host-${slug}`).fill("irc.example.test");
     await page.getByTestId(`admin-network-add-server-port-${slug}`).fill("6697");
     await page.getByTestId(`admin-network-add-server-submit-${slug}`).click();
 
     // New row lands in the servers table.
-    await expect(
-      page.getByTestId(`admin-network-servers-table-${slug}`),
-    ).toBeVisible({ timeout: 5_000 });
-    await expect(
-      page.locator(`[data-testid^='admin-network-server-row-${slug}-']`),
-    ).toHaveCount(1, { timeout: 5_000 });
+    await expect(page.getByTestId(`admin-network-servers-table-${slug}`)).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.locator(`[data-testid^='admin-network-server-row-${slug}-']`)).toHaveCount(
+      1,
+      { timeout: 5_000 },
+    );
   } finally {
     if (networkId !== null) await deleteNetworkBestEffort(admin.token, networkId);
   }
@@ -154,9 +153,7 @@ test("admin sees a per-network source rejected via the add-server form (non-loca
     await expect(page.getByTestId("admin-networks-error")).toContainText("source_not_local", {
       timeout: 5_000,
     });
-    await expect(
-      page.locator(`[data-testid^='admin-network-server-row-${slug}-']`),
-    ).toHaveCount(0);
+    await expect(page.locator(`[data-testid^='admin-network-server-row-${slug}-']`)).toHaveCount(0);
   } finally {
     if (networkId !== null) await deleteNetworkBestEffort(admin.token, networkId);
   }

--- a/cicchetto/e2e/tests/admin-users.spec.ts
+++ b/cicchetto/e2e/tests/admin-users.spec.ts
@@ -13,10 +13,10 @@
 // Cleanup: tests create unique usernames (timestamp suffix) and
 // best-effort delete via REST in finally to avoid leaking rows.
 
-import { expect, test } from "../fixtures/test";
 import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
-import { getSeededAdmin } from "../fixtures/seedData";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 async function adminLogin(
   page: import("@playwright/test").Page,
@@ -70,7 +70,7 @@ test("admin lists users, creates a new user, sees the row land", async ({ page }
 
     // Extract id from the row data-testid for cleanup.
     const testId = await row.getAttribute("data-testid");
-    if (testId !== null && testId.startsWith("admin-user-row-")) {
+    if (testId?.startsWith("admin-user-row-")) {
       createdId = testId.slice("admin-user-row-".length);
     }
   } finally {

--- a/cicchetto/e2e/tests/admin-visitors-layout.spec.ts
+++ b/cicchetto/e2e/tests/admin-visitors-layout.spec.ts
@@ -27,10 +27,10 @@
 // Reuses the m8-admin-visitors-delete scaffold (mint a throwaway visitor
 // via REST, log in as the seeded admin, open AdminPane → Visitors tab).
 
-import { expect, test } from "../fixtures/test";
 import { openAdminConsole } from "../fixtures/cicchettoPage";
-import { getSeededAdmin } from "../fixtures/seedData";
 import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 test("admin Visitors tab: per-network cell is separated + delete button stays in its row", async ({
   page,

--- a/cicchetto/e2e/tests/archive-desktop-only.spec.ts
+++ b/cicchetto/e2e/tests/archive-desktop-only.spec.ts
@@ -24,7 +24,6 @@
 // uses `devices["Desktop Chrome"]` (1280×720 viewport, well above the
 // (max-width: 768px) mobile breakpoint).
 
-import { expect, test } from "../fixtures/test";
 import {
   expandArchiveGroup,
   loginAs,
@@ -35,6 +34,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { joinChannel, partChannel } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -86,9 +86,7 @@ test("desktop — rail archive button is present across every window kind and op
   await expect(modal.locator("#archive-modal-title")).toHaveText("Archive");
 });
 
-test("desktop — archive modal rows inherit the canonical monospace style", async ({
-  page,
-}) => {
+test("desktop — archive modal rows inherit the canonical monospace style", async ({ page }) => {
   const vjt = getSeededVjt();
   await loginAs(page, vjt);
 

--- a/cicchetto/e2e/tests/b0-invite-from-server-window.spec.ts
+++ b/cicchetto/e2e/tests/b0-invite-from-server-window.spec.ts
@@ -29,10 +29,10 @@
 // dedicated channel (`#b0-invite-test`) AHEAD of any other user so
 // vjt is the first joiner → Bahamut grants +o → /invite goes through.
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "b0-invitee";
 const CHANNEL = "#b0-invite-test";

--- a/cicchetto/e2e/tests/b2-inbound-invite-cta.spec.ts
+++ b/cicchetto/e2e/tests/b2-inbound-invite-cta.spec.ts
@@ -29,7 +29,6 @@
 // banner region's stacking or the click-to-join WS round-trip — exactly the
 // class of bug jsdom misses.
 
-import { expect, test } from "../fixtures/test";
 import {
   inviteBanner,
   inviteBannerJoin,
@@ -40,6 +39,7 @@ import {
 import { partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "b2-inviter";
 const TARGET_CHANNEL = "#b2-target";

--- a/cicchetto/e2e/tests/b4-linkify-url-anchor-wrap.spec.ts
+++ b/cicchetto/e2e/tests/b4-linkify-url-anchor-wrap.spec.ts
@@ -19,10 +19,10 @@
 // pins the DOM shape under a real browser; click semantics are
 // covered by the unit tests in ScrollbackPane.test.tsx.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "b4-linker";
 const CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/bug7-ios-own-msg-visible.spec.ts
+++ b/cicchetto/e2e/tests/bug7-ios-own-msg-visible.spec.ts
@@ -34,16 +34,11 @@
 // `@webkit` tag opts this spec into the `webkit-iphone-15` project
 // (playwright.config.ts grep). Default chromium project skips it.
 
-import { type Page } from "@playwright/test";
-import { test, expect } from "../fixtures/test";
-import {
-  composeTextarea,
-  loginAs,
-  scrollbackLine,
-  selectChannel,
-} from "../fixtures/cicchettoPage";
+import type { Page } from "@playwright/test";
+import { composeTextarea, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 // Per-run unique tag so retries / parallel runs don't strict-mode-collide
@@ -62,7 +57,9 @@ async function distanceToBottom(page: Page): Promise<number> {
   });
 }
 
-test("@webkit BUG7 — own message visible in scrollback after iOS-shaped compose-send", async ({ page }) => {
+test("@webkit BUG7 — own message visible in scrollback after iOS-shaped compose-send", async ({
+  page,
+}) => {
   const vjt = getSeededVjt();
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });

--- a/cicchetto/e2e/tests/bug7-m6-ios-dm-own-msg-visible.spec.ts
+++ b/cicchetto/e2e/tests/bug7-m6-ios-dm-own-msg-visible.spec.ts
@@ -16,8 +16,7 @@
 //
 // `@webkit` opts into the webkit-iphone-15 project.
 
-import { type Page } from "@playwright/test";
-import { test, expect } from "../fixtures/test";
+import type { Page } from "@playwright/test";
 import {
   composeTextarea,
   loginAs,
@@ -28,6 +27,7 @@ import {
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "bug7m6-peer";
 const CHANNEL = AUTOJOIN_CHANNELS[0];
@@ -45,7 +45,9 @@ async function distanceToBottom(page: Page): Promise<number> {
   });
 }
 
-test("@webkit BUG7-M6 — cicchetto /msg DM own-msg visible on iOS-shaped input", async ({ page }) => {
+test("@webkit BUG7-M6 — cicchetto /msg DM own-msg visible on iOS-shaped input", async ({
+  page,
+}) => {
   const vjt = getSeededVjt();
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });

--- a/cicchetto/e2e/tests/bughunt-1-b-archive-mobile-seed.spec.ts
+++ b/cicchetto/e2e/tests/bughunt-1-b-archive-mobile-seed.spec.ts
@@ -22,7 +22,6 @@
 // touch + isMobile() = true). Desktop chromium project skips the tagged
 // test via `grepInvert: /@webkit/`.
 
-import { expect, test } from "../fixtures/test";
 import {
   expandArchiveGroup,
   loginAs,
@@ -32,6 +31,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { joinChannel, partChannel } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/bundle-refresh-banner.spec.ts
+++ b/cicchetto/e2e/tests/bundle-refresh-banner.spec.ts
@@ -11,9 +11,13 @@
 // run. The banner's job is to render the bootBundleHash != serverHash
 // invariant, which this spec validates end-to-end.
 
-import { expect, test } from "../fixtures/test";
-import { loginAs, awaitServiceWorkerActive, awaitServerBundleHashPush } from "../fixtures/cicchettoPage";
+import {
+  awaitServerBundleHashPush,
+  awaitServiceWorkerActive,
+  loginAs,
+} from "../fixtures/cicchettoPage";
 import { getSeededVjt } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // #119 — the bundle-refresh banner folded into the unified stacked error
 // region as one typed source; it renders as a `.error-banner` slot with
@@ -270,13 +274,17 @@ test("UX-6-I — refresh button forces SW update + cache purge before reload", a
 
     // Stub caches API to record deletion calls.
     if ("caches" in window) {
-      (window.caches as CacheStorage & {
-        keys: () => Promise<string[]>;
-        delete: (key: string) => Promise<boolean>;
-      }).keys = async () => ["workbox-precache-v2-https://test/", "workbox-runtime"];
-      (window.caches as CacheStorage & {
-        delete: (key: string) => Promise<boolean>;
-      }).delete = async (key: string) => {
+      (
+        window.caches as CacheStorage & {
+          keys: () => Promise<string[]>;
+          delete: (key: string) => Promise<boolean>;
+        }
+      ).keys = async () => ["workbox-precache-v2-https://test/", "workbox-runtime"];
+      (
+        window.caches as CacheStorage & {
+          delete: (key: string) => Promise<boolean>;
+        }
+      ).delete = async (key: string) => {
         probe.cacheDeletes.push(key);
         return true;
       };
@@ -315,14 +323,16 @@ test("UX-6-I — refresh button forces SW update + cache purge before reload", a
   );
 
   const probe = await page.evaluate(() => {
-    return (window as Window & {
-      __ux6i_probe?: {
-        updateCalls: number;
-        waitingSkipCalls: number;
-        cacheDeletes: string[];
-        reloaded: boolean;
-      };
-    }).__ux6i_probe;
+    return (
+      window as Window & {
+        __ux6i_probe?: {
+          updateCalls: number;
+          waitingSkipCalls: number;
+          cacheDeletes: string[];
+          reloaded: boolean;
+        };
+      }
+    ).__ux6i_probe;
   });
 
   expect(probe?.reloaded).toBe(true);

--- a/cicchetto/e2e/tests/bundle-refresh-banner.spec.ts
+++ b/cicchetto/e2e/tests/bundle-refresh-banner.spec.ts
@@ -238,12 +238,20 @@ test("UX-6-I — refresh button forces SW update + cache purge before reload", a
         installing: null,
       };
       const swContainer = navigator.serviceWorker as ServiceWorkerContainer & {
-        getRegistration: () => Promise<typeof fakeReg>;
         controller: { state: string } | null;
         addEventListener: (event: string, handler: EventListener) => void;
         removeEventListener: (event: string, handler: EventListener) => void;
       };
-      swContainer.getRegistration = async () => fakeReg;
+      // `getRegistration` resolves a real `ServiceWorkerRegistration`, which
+      // `fakeReg` deliberately is not (the stub carries only the three members
+      // `performRefresh` touches). Intersecting a narrower signature onto the
+      // container makes the property's type the intersection of BOTH return
+      // types, which nothing satisfies — so install it the same way
+      // `controller` below is installed, by definition rather than assignment.
+      Object.defineProperty(swContainer, "getRegistration", {
+        configurable: true,
+        value: async () => fakeReg,
+      });
       Object.defineProperty(swContainer, "controller", {
         configurable: true,
         value: { state: "activated" },
@@ -325,20 +333,3 @@ test("UX-6-I — refresh button forces SW update + cache purge before reload", a
   expect(probe?.cacheDeletes).toContain("workbox-precache-v2-https://test/");
   expect(probe?.cacheDeletes).toContain("workbox-runtime");
 });
-
-declare global {
-  interface Window {
-    // Mirror of the prod surface in `cicchetto/src/lib/bundleHash.ts` —
-    // page-side `window.__cic_bundleHash` is defined by the SPA at
-    // boot; the type re-declaration here gives this spec strong
-    // typing without an import (the spec doesn't run through tsc).
-    __cic_bundleHash?: {
-      setServerHash: (hash: string) => void;
-      setServerVersion: (version: string | null) => void;
-      reset: () => void;
-      bootHash: () => string | null;
-      bootVersion: () => string | null;
-      __refreshProbe?: () => void;
-    };
-  }
-}

--- a/cicchetto/e2e/tests/bundle-refresh-real-swap.spec.ts
+++ b/cicchetto/e2e/tests/bundle-refresh-real-swap.spec.ts
@@ -37,10 +37,14 @@
 // validated each release per the H2-reviewer wait-loop in
 // `performRefresh()`.
 
-import { expect, test } from "../fixtures/test";
-import { loginAs, awaitServiceWorkerActive, awaitServerBundleHashPush } from "../fixtures/cicchettoPage";
-import { getSeededVjt } from "../fixtures/seedData";
 import { snapshotBundle, swapToBundleB } from "../fixtures/bundleSwap";
+import {
+  awaitServerBundleHashPush,
+  awaitServiceWorkerActive,
+  loginAs,
+} from "../fixtures/cicchettoPage";
+import { getSeededVjt } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // #119 — bundle-refresh banner folded into the unified stacked error region;
 // renders as a `.error-banner` slot with data-source="bundle-refresh".
@@ -106,9 +110,7 @@ test("UX-6-I.2 — single-press refresh converges to new bundle (real swap)", as
     // fails, SW precache served the OLD index.html again (the original
     // 3-press bug).
     const reloadedHash = await page.evaluate(() => {
-      const script = document.querySelector<HTMLScriptElement>(
-        'script[src*="/assets/index-"]',
-      );
+      const script = document.querySelector<HTMLScriptElement>('script[src*="/assets/index-"]');
       const m = script?.getAttribute("src")?.match(/\/assets\/index-([^."]+)\.js/);
       return m?.[1] ?? null;
     });

--- a/cicchetto/e2e/tests/c2-whois-card-inline-render.spec.ts
+++ b/cicchetto/e2e/tests/c2-whois-card-inline-render.spec.ts
@@ -24,10 +24,10 @@
 // tested in `test/grappa/session/event_router_test.exs` +
 // `cicchetto/src/__tests__/WhoisCard.test.tsx`.
 
-import { test, expect } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "c2-target";
 const CHANNEL = AUTOJOIN_CHANNELS[0];
@@ -67,9 +67,9 @@ test("C2 — /whois <nick> renders WhoisCard in the scrollback overlay layer", a
     // shrink back toward the old ~14px glyph regresses here.
     const closeBtn = card.locator(".whois-card-close");
     const box = await closeBtn.boundingBox();
-    expect(box).not.toBeNull();
-    expect(box!.width).toBeGreaterThanOrEqual(40);
-    expect(box!.height).toBeGreaterThanOrEqual(40);
+    if (!box) throw new Error("whois card close button has no layout box");
+    expect(box.width).toBeGreaterThanOrEqual(40);
+    expect(box.height).toBeGreaterThanOrEqual(40);
 
     // Close button dismisses the card.
     await closeBtn.click();

--- a/cicchetto/e2e/tests/c5-member-leftclick-opens-query.spec.ts
+++ b/cicchetto/e2e/tests/c5-member-leftclick-opens-query.spec.ts
@@ -14,10 +14,10 @@
 //   - members list still renders #bofh (we left the channel in the
 //     sidebar — close semantics for query windows is unrelated).
 
-import { test, expect } from "../fixtures/test";
 import { loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "c5-buddy";
 const CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/channel-directory.spec.ts
+++ b/cicchetto/e2e/tests/channel-directory.spec.ts
@@ -26,20 +26,11 @@
 // (from fixtures/test) also resets autojoin to AUTOJOIN_CHANNELS
 // after every test.
 
-import { test, expect } from "../fixtures/test";
-import {
-  loginAs,
-  selectChannel,
-  sidebarWindow,
-} from "../fixtures/cicchettoPage";
+import { loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
-import {
-  AUTOJOIN_CHANNELS,
-  getSeededVjt,
-  NETWORK_NICK,
-  NETWORK_SLUG,
-} from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // "$list" — LIST_WINDOW_NAME from src/lib/windowKinds.ts. Hardcoded
 // here because the e2e tsconfig does not resolve src/ imports. A
@@ -58,129 +49,122 @@ test.afterEach(async () => {
   await partChannel(vjt.token, NETWORK_SLUG, PEER_CHANNEL).catch(() => {});
 });
 
-test(
-  "channel-directory — browse, no /messages fetch (#81 guard), search filter, one-click join",
-  async ({ page }) => {
-    const vjt = getSeededVjt();
+test("channel-directory — browse, no /messages fetch (#81 guard), search filter, one-click join", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
 
-    // Connect an IRC peer and join PEER_CHANNEL so it exists in bahamut
-    // before grappa issues LIST. The peer stays connected for the whole
-    // test so the channel is non-empty in bahamut's 322 replies.
-    const peer = await IrcPeer.connect({
-      nick: `e2edir-${crypto.randomUUID().slice(0, 4)}`,
+  // Connect an IRC peer and join PEER_CHANNEL so it exists in bahamut
+  // before grappa issues LIST. The peer stays connected for the whole
+  // test so the channel is non-empty in bahamut's 322 replies.
+  const peer = await IrcPeer.connect({
+    nick: `e2edir-${crypto.randomUUID().slice(0, 4)}`,
+  });
+  try {
+    await peer.join(PEER_CHANNEL);
+
+    await loginAs(page, vjt);
+
+    // Focus #bofh and wait for its scrollback to land so the initial
+    // GET /messages for the autojoin channel has already fired BEFORE
+    // we arm the request collector.
+    await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], {
+      ownNick: NETWORK_NICK,
     });
-    try {
-      await peer.join(PEER_CHANNEL);
 
-      await loginAs(page, vjt);
+    // Arm the /messages request collector from this point forward, SCOPED
+    // to the $list window under test (#534/#653). The regression the #81
+    // guard catches — a kindHasScrollback("list") slip — would fetch
+    // scrollback for the SELECTED window, i.e. cic's listMessages hits
+    // GET .../channels/%24list/messages (encodeURIComponent("$list")).
+    // Record ONLY that path: an unrelated forward gap-fill on the live
+    // autojoin #bofh (.../channels/%23bofh/messages?after=...) is legitimate
+    // background activity — a peer is connected and seed traffic is real —
+    // NOT the regression, and under full-gate load it can fire inside this
+    // window and trip a global-zero collector (the load-only flake).
+    // Keying on the $list channel segment keeps the assertion STRICT (a
+    // genuine $list scrollback fetch still reds it below) while making it
+    // deterministic — this is NOT a toHaveLength(<=1) relaxation nor a
+    // blanket substring filter that would blind the guard.
+    const listMessagesPath = `/channels/${encodeURIComponent(LIST_WINDOW_NAME)}/messages`;
+    const messagesRequests: string[] = [];
+    page.on("request", (req) => {
+      const url = req.url();
+      if (url.includes(listMessagesPath)) {
+        messagesRequests.push(url);
+      }
+    });
 
-      // Focus #bofh and wait for its scrollback to land so the initial
-      // GET /messages for the autojoin channel has already fired BEFORE
-      // we arm the request collector.
-      await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], {
-        ownNick: NETWORK_NICK,
-      });
+    // Open the 📇 channels directory window for this network.
+    // sidebarWindow resolves `li[data-window-name="$list"]` on
+    // desktop; .sidebar-window-btn is the clickable button inside it.
+    await sidebarWindow(page, NETWORK_SLUG, LIST_WINDOW_NAME)
+      .locator(".sidebar-window-btn")
+      .click();
 
-      // Arm the /messages request collector from this point forward, SCOPED
-      // to the $list window under test (#534/#653). The regression the #81
-      // guard catches — a kindHasScrollback("list") slip — would fetch
-      // scrollback for the SELECTED window, i.e. cic's listMessages hits
-      // GET .../channels/%24list/messages (encodeURIComponent("$list")).
-      // Record ONLY that path: an unrelated forward gap-fill on the live
-      // autojoin #bofh (.../channels/%23bofh/messages?after=...) is legitimate
-      // background activity — a peer is connected and seed traffic is real —
-      // NOT the regression, and under full-gate load it can fire inside this
-      // window and trip a global-zero collector (the load-only flake).
-      // Keying on the $list channel segment keeps the assertion STRICT (a
-      // genuine $list scrollback fetch still reds it below) while making it
-      // deterministic — this is NOT a toHaveLength(<=1) relaxation nor a
-      // blanket substring filter that would blind the guard.
-      const listMessagesPath = `/channels/${encodeURIComponent(LIST_WINDOW_NAME)}/messages`;
-      const messagesRequests: string[] = [];
-      page.on("request", (req) => {
-        const url = req.url();
-        if (url.includes(listMessagesPath)) {
-          messagesRequests.push(url);
-        }
-      });
+    // DirectoryPane is now mounted. The search box and Refresh button
+    // render outside the <Show when={page()}> guard and are immediate.
+    await expect(page.locator(".directory-search")).toBeVisible({
+      timeout: 5_000,
+    });
+    const refreshBtn = page.locator(".directory-refresh");
+    await expect(refreshBtn).toBeVisible({ timeout: 5_000 });
 
-      // Open the 📇 channels directory window for this network.
-      // sidebarWindow resolves `li[data-window-name="$list"]` on
-      // desktop; .sidebar-window-btn is the clickable button inside it.
-      await sidebarWindow(page, NETWORK_SLUG, LIST_WINDOW_NAME)
-        .locator(".sidebar-window-btn")
-        .click();
+    // (3) Assert NO /messages request was fired for the $list window
+    // selection. Checked here — before any join that would legitimately
+    // trigger GET /messages for the newly-joined channel window.
+    expect(
+      messagesRequests,
+      "GET /messages must NOT fire when selecting kind=list — grappa-irc#81 guard",
+    ).toHaveLength(0);
 
-      // DirectoryPane is now mounted. The search box and Refresh button
-      // render outside the <Show when={page()}> guard and are immediate.
-      await expect(page.locator(".directory-search")).toBeVisible({
-        timeout: 5_000,
-      });
-      const refreshBtn = page.locator(".directory-refresh");
-      await expect(refreshBtn).toBeVisible({ timeout: 5_000 });
+    // Force a fresh server-side LIST so PEER_CHANNEL (just created
+    // above) is captured even if a stale snapshot already exists.
+    await refreshBtn.click();
 
-      // (3) Assert NO /messages request was fired for the $list window
-      // selection. Checked here — before any join that would legitimately
-      // trigger GET /messages for the newly-joined channel window.
-      expect(
-        messagesRequests,
-        "GET /messages must NOT fire when selecting kind=list — grappa-irc#81 guard",
-      ).toHaveLength(0);
+    // (2a) PEER_CHANNEL appears in the directory. Generous timeout:
+    // the LIST → Session.Server 322 capture → 323 → progress ping
+    // → cic re-GET round-trip is fully async; allow 15 s.
+    const peerRow = page.locator(".directory-row-join").filter({ hasText: PEER_CHANNEL });
+    await expect(peerRow).toBeVisible({ timeout: 15_000 });
 
-      // Force a fresh server-side LIST so PEER_CHANNEL (just created
-      // above) is captured even if a stale snapshot already exists.
-      await refreshBtn.click();
+    // (2b) The seeded autojoin channel also appears.
+    const bofhRow = page.locator(".directory-row-join").filter({ hasText: AUTOJOIN_CHANNELS[0] });
+    await expect(bofhRow).toBeVisible({ timeout: 5_000 });
 
-      // (2a) PEER_CHANNEL appears in the directory. Generous timeout:
-      // the LIST → Session.Server 322 capture → 323 → progress ping
-      // → cic re-GET round-trip is fully async; allow 15 s.
-      const peerRow = page
-        .locator(".directory-row-join")
-        .filter({ hasText: PEER_CHANNEL });
-      await expect(peerRow).toBeVisible({ timeout: 15_000 });
+    // (4) Search filter: typing the unique fragment ("e2edir") routes a
+    // server-side query re-GET. Only PEER_CHANNEL should match;
+    // AUTOJOIN_CHANNELS[0] (#bofh) should be absent.
+    await page.locator(".directory-search").fill("e2edir");
+    await expect(peerRow).toBeVisible({ timeout: 5_000 });
+    await expect(bofhRow).toBeHidden({ timeout: 5_000 });
 
-      // (2b) The seeded autojoin channel also appears.
-      const bofhRow = page
-        .locator(".directory-row-join")
-        .filter({ hasText: AUTOJOIN_CHANNELS[0] });
-      await expect(bofhRow).toBeVisible({ timeout: 5_000 });
+    // Clear the filter so all rows are back before the join step.
+    await page.locator(".directory-search").fill("");
+    await expect(bofhRow).toBeVisible({ timeout: 5_000 });
 
-      // (4) Search filter: typing the unique fragment ("e2edir") routes a
-      // server-side query re-GET. Only PEER_CHANNEL should match;
-      // AUTOJOIN_CHANNELS[0] (#bofh) should be absent.
-      await page.locator(".directory-search").fill("e2edir");
-      await expect(peerRow).toBeVisible({ timeout: 5_000 });
-      await expect(bofhRow).toBeHidden({ timeout: 5_000 });
+    // (5) One-click join: assert PEER_CHANNEL is not yet in the sidebar,
+    // click its join control, then assert the sidebar gains an entry
+    // (mirrors m8: sidebarWindow toHaveCount(1)).
+    await expect(sidebarWindow(page, NETWORK_SLUG, PEER_CHANNEL)).toHaveCount(0);
+    await peerRow.click();
+    await expect(sidebarWindow(page, NETWORK_SLUG, PEER_CHANNEL)).toHaveCount(1, {
+      timeout: 10_000,
+    });
 
-      // Clear the filter so all rows are back before the join step.
-      await page.locator(".directory-search").fill("");
-      await expect(bofhRow).toBeVisible({ timeout: 5_000 });
-
-      // (5) One-click join: assert PEER_CHANNEL is not yet in the sidebar,
-      // click its join control, then assert the sidebar gains an entry
-      // (mirrors m8: sidebarWindow toHaveCount(1)).
-      await expect(
-        sidebarWindow(page, NETWORK_SLUG, PEER_CHANNEL),
-      ).toHaveCount(0);
-      await peerRow.click();
-      await expect(
-        sidebarWindow(page, NETWORK_SLUG, PEER_CHANNEL),
-      ).toHaveCount(1, { timeout: 10_000 });
-
-      // #244 — a user-initiated directory tap now JOINs *and* foregrounds
-      // the new channel's window (amends #125's original no-auto-open). So
-      // the tap flips selKind() list → channel, unmounting DirectoryPane;
-      // the `.directory-row-badge` (a DirectoryPane-only element) is no
-      // longer observable in a mounted pane. Assert the foreground signal
-      // instead: the newly-joined channel is the SELECTED sidebar window.
-      // The badge itself is unit-covered in DirectoryPane.test.tsx; the
-      // foreground behaviour is the #244 P0 fix, covered end-to-end in
-      // issue244-directory-tap-foreground.spec.ts.
-      await expect(
-        sidebarWindow(page, NETWORK_SLUG, PEER_CHANNEL),
-      ).toHaveClass(/selected/, { timeout: 10_000 });
-    } finally {
-      await peer.disconnect("e2e channel-directory done");
-    }
-  },
-);
+    // #244 — a user-initiated directory tap now JOINs *and* foregrounds
+    // the new channel's window (amends #125's original no-auto-open). So
+    // the tap flips selKind() list → channel, unmounting DirectoryPane;
+    // the `.directory-row-badge` (a DirectoryPane-only element) is no
+    // longer observable in a mounted pane. Assert the foreground signal
+    // instead: the newly-joined channel is the SELECTED sidebar window.
+    // The badge itself is unit-covered in DirectoryPane.test.tsx; the
+    // foreground behaviour is the #244 P0 fix, covered end-to-end in
+    // issue244-directory-tap-foreground.spec.ts.
+    await expect(sidebarWindow(page, NETWORK_SLUG, PEER_CHANNEL)).toHaveClass(/selected/, {
+      timeout: 10_000,
+    });
+  } finally {
+    await peer.disconnect("e2e channel-directory done");
+  }
+});

--- a/cicchetto/e2e/tests/cic-members-panel-scope.spec.ts
+++ b/cicchetto/e2e/tests/cic-members-panel-scope.spec.ts
@@ -30,14 +30,9 @@
 // presence assertion below covers the same joined-state contract
 // (both gate on the same `windowIsJoined(key())` predicate).
 
-import { test, expect } from "../fixtures/test";
-import {
-  composeSend,
-  loginAs,
-  selectChannel,
-  sidebarWindow,
-} from "../fixtures/cicchettoPage";
+import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 // UX-5 bucket BT (2026-05-19) — UX-4 bucket C merged the Server window

--- a/cicchetto/e2e/tests/cp13-s10-mirc-bold.spec.ts
+++ b/cicchetto/e2e/tests/cp13-s10-mirc-bold.spec.ts
@@ -12,10 +12,10 @@
 //   - cic mIRC parser splits into 3 runs (plain / bold / plain)
 //   - bold run renders as `.scrollback-mirc-bold` <span>
 
-import { test, expect } from "../fixtures/test";
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const TEST_CHANNEL = "#bofh";
 

--- a/cicchetto/e2e/tests/cp13-s5-msg-ghost-401.spec.ts
+++ b/cicchetto/e2e/tests/cp13-s5-msg-ghost-401.spec.ts
@@ -22,7 +22,6 @@
 // NOR the sidebar unread badge for the query window — both
 // regressions share one predicate (lib/operatorActionEcho.ts).
 
-import { test, expect } from "../fixtures/test";
 import {
   composeTextarea,
   loginAs,
@@ -30,12 +29,11 @@ import {
   sidebarMessageBadge,
 } from "../fixtures/cicchettoPage";
 import { getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const TEST_CHANNEL = "#bofh";
 
-test("CP13 S5 — /msg to nonexistent nick: 401 lands in the query window live", async ({
-  page,
-}) => {
+test("CP13 S5 — /msg to nonexistent nick: 401 lands in the query window live", async ({ page }) => {
   const vjt = getSeededVjt();
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, TEST_CHANNEL);
@@ -66,9 +64,9 @@ test("CP13 S5 — /msg to nonexistent nick: 401 lands in the query window live",
   // timeout because the round-trip is grappa→bahamut→401→grappa→
   // persist→broadcast→cicchetto, and the WS subscription on the
   // newly-opened query topic has to settle first.
-  await expect(
-    page.locator(".scrollback-pane .scrollback-notice-error"),
-  ).toHaveCount(1, { timeout: 15_000 });
+  await expect(page.locator(".scrollback-pane .scrollback-notice-error")).toHaveCount(1, {
+    timeout: 15_000,
+  });
 
   // The 401 NOTICE is server feedback to the operator's own /msg —
   // it must NOT inflate the in-pane unread-marker NOR the sidebar

--- a/cicchetto/e2e/tests/cp13-server-window-cluster-ux.spec.ts
+++ b/cicchetto/e2e/tests/cp13-server-window-cluster-ux.spec.ts
@@ -11,7 +11,6 @@
 //   - S9: $server has a ComposeBox; plain-text submit is rejected
 //     with a friendly error; slash-commands pass the gate.
 
-import { test, expect } from "../fixtures/test";
 import {
   composeTextarea,
   loginAs,
@@ -20,6 +19,7 @@ import {
   sidebarWindow,
 } from "../fixtures/cicchettoPage";
 import { getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SERVER_WINDOW_LABEL = "Server";
 const TEST_CHANNEL = "#bofh";

--- a/cicchetto/e2e/tests/cp14-b1-scroll-marker-vs-bottom.spec.ts
+++ b/cicchetto/e2e/tests/cp14-b1-scroll-marker-vs-bottom.spec.ts
@@ -55,15 +55,11 @@
 // this, the entire content fits on-screen and "is the tail at the bottom"
 // becomes unmeasurable.
 
-import { test, expect } from "../fixtures/test";
-import { type Page } from "@playwright/test";
-import {
-  loginAs,
-  scrollbackLines,
-  selectChannel,
-} from "../fixtures/cicchettoPage";
+import type { Page } from "@playwright/test";
+import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { restoreReadCursorToTail, setReadCursorToId } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/cp14-b2-scroll-up-loadmore.spec.ts
+++ b/cicchetto/e2e/tests/cp14-b2-scroll-up-loadmore.spec.ts
@@ -20,14 +20,10 @@
 // REST page reliably overflows and "is the scrollback longer than
 // the viewport" is measurable.
 
-import { test, expect } from "../fixtures/test";
-import { type Page } from "@playwright/test";
-import {
-  loginAs,
-  scrollbackLines,
-  selectChannel,
-} from "../fixtures/cicchettoPage";
+import type { Page } from "@playwright/test";
+import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/cp14-b3-dm-history-bidirectional.spec.ts
+++ b/cicchetto/e2e/tests/cp14-b3-dm-history-bidirectional.spec.ts
@@ -25,7 +25,6 @@
 // chronological order. Reload simulates the production "I logged in,
 // scrollback should show what happened while I was away" path.
 
-import { test, expect } from "../fixtures/test";
 import {
   composeSend,
   loginAs,
@@ -36,6 +35,7 @@ import {
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "b3-peer";
 const CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/cp15-b5-window-state-pending-to-joined.spec.ts
+++ b/cicchetto/e2e/tests/cp15-b5-window-state-pending-to-joined.spec.ts
@@ -34,15 +34,10 @@
 // CHANNEL CLEANUP: same shape as M8 — random per-run suffix + afterEach
 // PARTs the channel so the credential's autojoin set stays clean.
 
-import { test, expect } from "../fixtures/test";
-import {
-  composeSend,
-  loginAs,
-  selectChannel,
-  sidebarWindow,
-} from "../fixtures/cicchettoPage";
+import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { partChannel } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 const NEW_CHANNEL = `#cp15-b5-${crypto.randomUUID().slice(0, 8)}`;

--- a/cicchetto/e2e/tests/cp15-b6-archive-query-revival.spec.ts
+++ b/cicchetto/e2e/tests/cp15-b6-archive-query-revival.spec.ts
@@ -34,7 +34,6 @@
 // spec — afterEach only disconnects the upstream peer, which cleans the
 // upstream nick. No explicit window close needed.
 
-import { test, expect } from "../fixtures/test";
 import {
   composeSend,
   expandArchiveGroup,
@@ -46,6 +45,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 const PEER_NICK = `cp15b6q-${crypto.randomUUID().slice(0, 6)}`;
@@ -99,9 +99,11 @@ test("CP15 B6 — /msg peer + close → archive entry; clicking the archive row 
   // removes the flake without masking a genuine hang. See DESIGN_NOTES
   // 2026-06-09 "cp15-b6 / m6 e2e timing flake".
   await composeSend(page, `/msg ${PEER_NICK} hello-archive`);
-  const queryRow = page.locator(".sidebar-network-section", {
-    has: page.locator(".sidebar-network-header", { hasText: NETWORK_SLUG }),
-  }).locator("li", { hasText: PEER_NICK });
+  const queryRow = page
+    .locator(".sidebar-network-section", {
+      has: page.locator(".sidebar-network-header", { hasText: NETWORK_SLUG }),
+    })
+    .locator("li", { hasText: PEER_NICK });
   await expect(queryRow).toHaveCount(1, { timeout: 15_000 });
 
   // Confirm the row landed server-side via REST before closing — the

--- a/cicchetto/e2e/tests/cp15-b6-kicked-greyed-state.spec.ts
+++ b/cicchetto/e2e/tests/cp15-b6-kicked-greyed-state.spec.ts
@@ -20,16 +20,11 @@
 // CHANNEL CLEANUP: random per-run suffix; peer disconnects in
 // afterEach (its quit drops the channel since vjt got kicked).
 
-import { test, expect } from "../fixtures/test";
-import {
-  composeSend,
-  loginAs,
-  selectChannel,
-  sidebarWindow,
-} from "../fixtures/cicchettoPage";
-import { IrcPeer } from "../fixtures/ircClient";
+import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { partChannel } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 const NEW_CHANNEL = `#cp15-b6-k-${crypto.randomUUID().slice(0, 8)}`;

--- a/cicchetto/e2e/tests/cp15-b6-parked-disconnect-reconnect.spec.ts
+++ b/cicchetto/e2e/tests/cp15-b6-parked-disconnect-reconnect.spec.ts
@@ -52,9 +52,9 @@
 // SpawnOrchestrator → autojoin loop, which re-JOINs SEED_CHANNEL and
 // gets the row back to its baseline live state.
 
-import { test, expect } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 const PARK_REASON = "testing parked state cp19";
@@ -197,9 +197,7 @@ test("CP19 T32 — /disconnect parks network + redirects to Home; Reconnect ungr
   // in UX-4 bucket C; the `title` attr now lives on
   // `.sidebar-network-header .sidebar-channel-name` (Sidebar.tsx
   // L319-326).
-  const networkHeader = networkSection.locator(
-    ".sidebar-network-header .sidebar-channel-name",
-  );
+  const networkHeader = networkSection.locator(".sidebar-network-header .sidebar-channel-name");
   await expect(networkHeader).toHaveAttribute("title", PARK_REASON, { timeout: 5_000 });
 
   // Operator unparks via the Home card's Reconnect chip. Server-side:

--- a/cicchetto/e2e/tests/cp15-b6-part-archive-rejoin.spec.ts
+++ b/cicchetto/e2e/tests/cp15-b6-part-archive-rejoin.spec.ts
@@ -30,7 +30,6 @@
 // joined state, matching the seed → no afterEach restoration needed.
 // The PART side-effect on autojoin survives across runs otherwise.
 
-import { test, expect } from "../fixtures/test";
 import {
   composeSend,
   expandArchiveGroup,
@@ -41,6 +40,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { joinChannel, partChannel } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/cp15-b6-pending-to-failed-invite-only.spec.ts
+++ b/cicchetto/e2e/tests/cp15-b6-pending-to-failed-invite-only.spec.ts
@@ -23,15 +23,10 @@
 // CHANNEL CLEANUP: random per-run suffix; afterEach has the peer PART
 // the channel + cic operator never joined so no autojoin row exists.
 
-import { test, expect } from "../fixtures/test";
-import {
-  composeSend,
-  loginAs,
-  selectChannel,
-  sidebarWindow,
-} from "../fixtures/cicchettoPage";
+import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 const NEW_CHANNEL = `#cp15-b6-i-${crypto.randomUUID().slice(0, 8)}`;

--- a/cicchetto/e2e/tests/cp22-bwho-who-rows.spec.ts
+++ b/cicchetto/e2e/tests/cp22-bwho-who-rows.spec.ts
@@ -24,7 +24,6 @@
 // in test/grappa/session/event_router_test.exs; the userhost_cache upsert
 // (S2.4, feeds /ban masks) still fires from the 352 route, unchanged.
 
-import { expect, test } from "../fixtures/test";
 import {
   composeSend,
   loginAs,
@@ -34,6 +33,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "issue169-who-target";
 const CHANNEL = AUTOJOIN_CHANNELS[0];
@@ -72,9 +72,9 @@ test("#169 — /who renders the WhoModal with parsed rows; scrollback stays clea
 
     // Scrollback stays CLEAN — the pre-#169 N+1 :notice dump is gone.
     await expect(scrollbackLine(page, "notice", "End of /WHO list")).toHaveCount(0);
-    await expect(scrollbackLine(page, "notice", `[${CHANNEL}]`).filter({ hasText: PEER_NICK })).toHaveCount(
-      0,
-    );
+    await expect(
+      scrollbackLine(page, "notice", `[${CHANNEL}]`).filter({ hasText: PEER_NICK }),
+    ).toHaveCount(0);
 
     // Clicking the peer nick opens a query window for it AND dismisses the modal.
     await modal.locator(".who-modal-nick", { hasText: PEER_NICK }).click();

--- a/cicchetto/e2e/tests/cursor-forward-only.spec.ts
+++ b/cicchetto/e2e/tests/cursor-forward-only.spec.ts
@@ -34,16 +34,11 @@
 // scroll-on-window-switch, ux-5-bk, ux-6-k, p0e-invite-ack) see
 // a fully-read channel.
 
-import { expect, test } from "../fixtures/test";
-import { type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { restoreReadCursorToTail, setReadCursorToId } from "../fixtures/grappaApi";
-import {
-  AUTOJOIN_CHANNELS,
-  getSeededVjt,
-  NETWORK_NICK,
-  NETWORK_SLUG,
-} from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const REST_PAGE_SIZE = 50;
@@ -72,10 +67,7 @@ async function fetchCursor(token: string, channel: string): Promise<number | nul
   return body.read_cursors?.[NETWORK_SLUG]?.[channel] ?? null;
 }
 
-async function fetchScrollbackPage(
-  token: string,
-  channel: string,
-): Promise<Array<{ id: number }>> {
+async function fetchScrollbackPage(token: string, channel: string): Promise<Array<{ id: number }>> {
   const url = `${GRAPPA_TEST_BASE}/networks/${encodeURIComponent(NETWORK_SLUG)}/channels/${encodeURIComponent(channel)}/messages`;
   const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
   if (!res.ok) {
@@ -242,9 +234,7 @@ test.describe("BUGHUNT-2 cursor — forward-only contract", () => {
     // `visible` and `store` (mid-pane) — any row ID in that range
     // satisfies `visible < baseline ≤ store`.
     const page0 = await fetchScrollbackPage(vjt.token, CHANNEL);
-    const candidates = page0.filter(
-      (r) => r.id > (visible as number) && r.id <= (store as number),
-    );
+    const candidates = page0.filter((r) => r.id > (visible as number) && r.id <= (store as number));
     if (candidates.length === 0) {
       throw new Error(
         `no baseline candidate between visible=${visible} and store=${store}; ` +

--- a/cicchetto/e2e/tests/error-banners.spec.ts
+++ b/cicchetto/e2e/tests/error-banners.spec.ts
@@ -10,9 +10,13 @@
 // two non-overlapping slots inside the one container — a spec that only showed
 // ONE error would hollow-green the overlap fix.
 
-import { expect, test } from "../fixtures/test";
-import { loginAs, awaitServiceWorkerActive, awaitServerBundleHashPush } from "../fixtures/cicchettoPage";
+import {
+  awaitServerBundleHashPush,
+  awaitServiceWorkerActive,
+  loginAs,
+} from "../fixtures/cicchettoPage";
 import { getSeededVjt } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const REGION = ".error-banners";
 const WS = '.error-banner[data-source="ws"]';

--- a/cicchetto/e2e/tests/error-banners.spec.ts
+++ b/cicchetto/e2e/tests/error-banners.spec.ts
@@ -216,26 +216,3 @@ test("sw-registration STACKS below the WS source without overlapping (#120)", as
   if (!wsBox || !swBox) throw new Error("banner slots have no layout box");
   expect(wsBox.y + wsBox.height).toBeLessThanOrEqual(swBox.y + 1);
 });
-
-declare global {
-  interface Window {
-    __cic_socketHealth?: {
-      recordOpen: () => void;
-      recordError: () => void;
-      recordClose: (e: { code: number; reason: string } | undefined) => void;
-      reset: () => void;
-      state: () => { state: "connecting" | "open" | "error" };
-    };
-    __cic_bundleHash?: {
-      setServerHash: (hash: string) => void;
-      reset: () => void;
-      bootHash: () => string | null;
-    };
-    __cic_swRegistration?: {
-      recordError: (e: { name: string; message: string }) => void;
-      recordRegistered: (reg?: unknown) => void;
-      reset: () => void;
-      state: () => { state: "unknown" | "registered" | "error"; error: { name: string; message: string } | null };
-    };
-  }
-}

--- a/cicchetto/e2e/tests/featured-channels.spec.ts
+++ b/cicchetto/e2e/tests/featured-channels.spec.ts
@@ -10,10 +10,10 @@
 // Uses a freshly-created ephemeral network per test so we don't pollute
 // the seeded networks' featured lists.
 
-import { expect, test } from "../fixtures/test";
 import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
-import { getSeededAdmin } from "../fixtures/seedData";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 async function adminLogin(
   page: import("@playwright/test").Page,
@@ -80,9 +80,10 @@ test("admin adds a featured channel to a network via the disclosure", async ({ p
     await expect(page.getByTestId(`admin-network-featured-table-${slug}`)).toBeVisible({
       timeout: 5_000,
     });
-    await expect(
-      page.locator(`[data-testid^='admin-network-featured-row-${slug}-']`),
-    ).toHaveCount(1, { timeout: 5_000 });
+    await expect(page.locator(`[data-testid^='admin-network-featured-row-${slug}-']`)).toHaveCount(
+      1,
+      { timeout: 5_000 },
+    );
   } finally {
     if (networkId !== null) await deleteNetworkBestEffort(admin.token, networkId);
   }
@@ -96,14 +97,11 @@ test("admin deletes a featured channel via inline-confirm", async ({ page }) => 
   try {
     networkId = await createNetwork(admin.token, slug);
 
-    const fRes = await fetch(
-      `${GRAPPA_BASE_URL}/admin/networks/${networkId}/featured_channels`,
-      {
-        method: "POST",
-        headers: { "content-type": "application/json", authorization: `Bearer ${admin.token}` },
-        body: JSON.stringify({ name: "#delme", description: "bye" }),
-      },
-    );
+    const fRes = await fetch(`${GRAPPA_BASE_URL}/admin/networks/${networkId}/featured_channels`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${admin.token}` },
+      body: JSON.stringify({ name: "#delme", description: "bye" }),
+    });
     expect(fRes.ok).toBe(true);
     const fBody = (await fRes.json()) as { id: number };
     const featuredId = fBody.id;

--- a/cicchetto/e2e/tests/freshness-on-activation.spec.ts
+++ b/cicchetto/e2e/tests/freshness-on-activation.spec.ts
@@ -165,10 +165,3 @@ test("#159 — tab RE-FOREGROUND (hidden→visible) after a socket-stays-open ga
     await peer.disconnect("#159 vis test done");
   }
 });
-
-declare global {
-  interface Window {
-    __cic_suppressChannelDeliveryForTests?: (slug: string, name: string) => void;
-    __cic_resumeChannelDeliveryForTests?: (slug: string, name: string) => void;
-  }
-}

--- a/cicchetto/e2e/tests/freshness-on-activation.spec.ts
+++ b/cicchetto/e2e/tests/freshness-on-activation.spec.ts
@@ -18,10 +18,10 @@
 // contract. RED against pre-fix code (row never appears without reload) → GREEN
 // once activation/visibility drive `refreshScrollback`.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -61,10 +61,7 @@ async function suppressChannelDelivery(
 // `document.hasFocus()`, so both must be overridden; dispatch the
 // production listeners' events so the Solid signal updates synchronously.
 // Same idiom as ux-5-bu-unread-focus.spec.ts's `setTabHidden`.
-async function setTabHidden(
-  page: Parameters<typeof loginAs>[0],
-  hidden: boolean,
-): Promise<void> {
+async function setTabHidden(page: Parameters<typeof loginAs>[0], hidden: boolean): Promise<void> {
   await page.evaluate((isHidden) => {
     Object.defineProperty(document, "visibilityState", {
       configurable: true,

--- a/cicchetto/e2e/tests/i2b-image-upload-litterbox-host.spec.ts
+++ b/cicchetto/e2e/tests/i2b-image-upload-litterbox-host.spec.ts
@@ -20,8 +20,7 @@
 //      specs see a clean default (per `feedback_no_silent_drops_closed`
 //      pattern from ux-6-b-admin-settings.spec.ts).
 
-import { expect, test } from "../fixtures/test";
-import { type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import {
@@ -31,6 +30,7 @@ import {
   NETWORK_NICK,
   NETWORK_SLUG,
 } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 import { LITTERBOX_MODAL_HEADING, pickFile } from "../fixtures/uploadJourney";
 
 const FIXTURE_URL = "https://litter.catbox.moe/i2-fixture.png";

--- a/cicchetto/e2e/tests/ios-z-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/ios-z-cluster-journey.spec.ts
@@ -34,7 +34,6 @@
 // localStorage at end so subsequent specs in the same browser context
 // don't inherit XL font-size.
 
-import { expect, test } from "../fixtures/test";
 import {
   confirmModal,
   confirmModalYes,
@@ -45,12 +44,8 @@ import {
   sidebarWindow,
 } from "../fixtures/cicchettoPage";
 import { joinChannel } from "../fixtures/grappaApi";
-import {
-  AUTOJOIN_CHANNELS,
-  getSeededVjt,
-  NETWORK_NICK,
-  NETWORK_SLUG,
-} from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0]; // #bofh
 
@@ -65,9 +60,7 @@ test.afterEach(async () => {
   await joinChannel(vjt.token, NETWORK_SLUG, CHANNEL).catch(() => {});
 });
 
-test("@webkit iOS-Z cluster — viewport + safe-area + close× + font-size", async ({
-  page,
-}) => {
+test("@webkit iOS-Z cluster — viewport + safe-area + close× + font-size", async ({ page }) => {
   const vjt = getSeededVjt();
   await loginAs(page, vjt);
 
@@ -137,9 +130,7 @@ test("@webkit iOS-Z cluster — viewport + safe-area + close× + font-size", asy
     const section = page.locator(".bottom-bar-network", {
       has: page.locator(`.bottom-bar-network-header[data-network-slug="${NETWORK_SLUG}"]`),
     });
-    await expect(
-      section.locator('.bottom-bar-close[aria-label="Close Server"]'),
-    ).toHaveCount(0);
+    await expect(section.locator('.bottom-bar-close[aria-label="Close Server"]')).toHaveCount(0);
 
     // iOS-4 — font-size XL persists across reload. #71 INC-2 — the settings
     // cog lives in the rail's ActionCluster now; #460 moved font size into the
@@ -153,9 +144,7 @@ test("@webkit iOS-Z cluster — viewport + safe-area + close× + font-size", asy
     await page.locator('[data-testid="font-size-XL"]').tap();
     await expect(page.locator('[data-testid="font-size-XL"]')).toBeChecked();
     const xlSize = await page.evaluate(() =>
-      getComputedStyle(document.documentElement)
-        .getPropertyValue("--font-size")
-        .trim(),
+      getComputedStyle(document.documentElement).getPropertyValue("--font-size").trim(),
     );
     expect(xlSize).toBe("18px");
 
@@ -166,9 +155,7 @@ test("@webkit iOS-Z cluster — viewport + safe-area + close× + font-size", asy
     await openSettingsSection(page, "display");
     await expect(page.locator('[data-testid="font-size-XL"]')).toBeChecked();
     const reloadedSize = await page.evaluate(() =>
-      getComputedStyle(document.documentElement)
-        .getPropertyValue("--font-size")
-        .trim(),
+      getComputedStyle(document.documentElement).getPropertyValue("--font-size").trim(),
     );
     expect(reloadedSize).toBe("18px");
   } finally {

--- a/cicchetto/e2e/tests/issue100-reconnecting-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue100-reconnecting-badge.spec.ts
@@ -26,9 +26,9 @@
 // cp15-b6-parked-disconnect-reconnect so the next spec inherits a live
 // session.
 
-import { test, expect } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 const PARK_REASON = "testing reconnect badge #100";
@@ -103,8 +103,7 @@ test("#100 — reconnecting badge shows while a parked network reconnects, then 
   await page.evaluate(() => {
     const w = window as unknown as { __cic_reconnectBadgeSeen?: boolean };
     w.__cic_reconnectBadgeSeen = false;
-    const seen = () =>
-      document.querySelector('[data-testid="reconnecting-badge"]') !== null;
+    const seen = () => document.querySelector('[data-testid="reconnecting-badge"]') !== null;
     if (seen()) {
       w.__cic_reconnectBadgeSeen = true;
       return;
@@ -126,7 +125,9 @@ test("#100 — reconnecting badge shows while a parked network reconnects, then 
   // The latch flips true the moment the badge enters the DOM — proves the
   // transient "reconnecting…" badge surfaced on the reconnect.
   await page.waitForFunction(
-    () => (window as unknown as { __cic_reconnectBadgeSeen?: boolean }).__cic_reconnectBadgeSeen === true,
+    () =>
+      (window as unknown as { __cic_reconnectBadgeSeen?: boolean }).__cic_reconnectBadgeSeen ===
+      true,
     undefined,
     { timeout: 20_000 },
   );

--- a/cicchetto/e2e/tests/issue1019-farbehind-leave-dismiss.spec.ts
+++ b/cicchetto/e2e/tests/issue1019-farbehind-leave-dismiss.spec.ts
@@ -87,7 +87,6 @@
 // Desktop viewport on purpose, matching #997: the sidebar badge is the clearer
 // read of "the badge fell" than the mobile tab treatment.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, selectChannel, sidebarMessageBadge } from "../fixtures/cicchettoPage";
 import {
   fetchAllMessagesAsc,
@@ -103,6 +102,7 @@ import {
   NETWORK_SLUG,
   VJT_USER,
 } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/issue1040-home-rail-expanded.spec.ts
+++ b/cicchetto/e2e/tests/issue1040-home-rail-expanded.spec.ts
@@ -32,9 +32,9 @@
 // the column reads well under a thumb, and whether a short device scrolls it
 // comfortably, are vjt's device-verify calls.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0]; // #bofh — vjt's seeded autojoin channel
 

--- a/cicchetto/e2e/tests/issue1041-left-edge-sidebar.spec.ts
+++ b/cicchetto/e2e/tests/issue1041-left-edge-sidebar.spec.ts
@@ -88,9 +88,7 @@ async function openChannel(page: Page): Promise<void> {
 // at translateX(-100%) is off-screen and the operator sees nothing. Polled
 // because the enter animation takes 200ms.
 async function expectSlidIn(page: Page): Promise<void> {
-  await expect
-    .poll(async () => (await page.locator(SIDEBAR).boundingBox())?.x ?? null)
-    .toBe(0);
+  await expect.poll(async () => (await page.locator(SIDEBAR).boundingBox())?.x ?? null).toBe(0);
 }
 
 test("issue1041 — left-edge right-swipe mounts the sidebar and slides it on screen", async ({

--- a/cicchetto/e2e/tests/issue1047-alias-range-param.spec.ts
+++ b/cicchetto/e2e/tests/issue1047-alias-range-param.spec.ts
@@ -24,11 +24,11 @@
 // SINGLE subject arm (vjt), justified as in #385: alias expansion is
 // client-side and subject-agnostic; there is no subject-shaped branch here.
 
-import { test, expect } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL, partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 const NEW_CHANNEL = `#i1047-${crypto.randomUUID().slice(0, 8)}`;
@@ -113,8 +113,6 @@ test("#1047 — `alias k kick $1 $2-` kicks with the WHOLE reason, upstream-witn
 
   // ORACLE 2 — the cic surface renders the same whole reason.
   await expect(
-    page
-      .locator('[data-testid="scrollback-line"][data-kind="kick"]')
-      .filter({ hasText: REASON }),
+    page.locator('[data-testid="scrollback-line"][data-kind="kick"]').filter({ hasText: REASON }),
   ).toBeVisible({ timeout: 10_000 });
 });

--- a/cicchetto/e2e/tests/issue1061-offline-does-nothing.spec.ts
+++ b/cicchetto/e2e/tests/issue1061-offline-does-nothing.spec.ts
@@ -51,9 +51,9 @@
 // demonstrably works. Neither test was weakened to go green: test 2 was made
 // able to go RED at all.
 
-import { expect, test } from "../fixtures/test";
 import { expectShellReady, loginAs } from "../fixtures/cicchettoPage";
 import { getSeededVjt } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // Eight rungs of phoenix's default backoff ladder. Long enough that a client
 // which resumed retrying would have done so many times over; short enough not

--- a/cicchetto/e2e/tests/issue1062-far-behind-float-stack.spec.ts
+++ b/cicchetto/e2e/tests/issue1062-far-behind-float-stack.spec.ts
@@ -39,7 +39,6 @@
 // Desktop viewport, as the spec it replaces: the removal is a DOM claim, not a
 // geometry one, and the sidebar badge is the clearer read of "the badge fell".
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, selectChannel, sidebarMessageBadge } from "../fixtures/cicchettoPage";
 import {
   fetchAllMessagesAsc,
@@ -54,6 +53,7 @@ import {
   NETWORK_SLUG,
   VJT_USER,
 } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/issue1063-refresh-visible-feedback.spec.ts
+++ b/cicchetto/e2e/tests/issue1063-refresh-visible-feedback.spec.ts
@@ -33,14 +33,14 @@
 // booted. Nothing here sleeps, and nothing here may be "fixed" by sleeping.
 
 import type { Page } from "@playwright/test";
-import { expect, test } from "../fixtures/test";
+import { snapshotBundle, swapToBootableBundleB } from "../fixtures/bundleSwap";
 import {
   awaitServerBundleHashPush,
   awaitServiceWorkerActive,
   loginAs,
 } from "../fixtures/cicchettoPage";
 import { getSeededVjt } from "../fixtures/seedData";
-import { snapshotBundle, swapToBootableBundleB } from "../fixtures/bundleSwap";
+import { expect, test } from "../fixtures/test";
 
 // #119 — the refresh banner is a slot in the stacked error region.
 const BANNER_SELECTOR = '.error-banner[data-source="bundle-refresh"]';

--- a/cicchetto/e2e/tests/issue1063-update-delivery.spec.ts
+++ b/cicchetto/e2e/tests/issue1063-update-delivery.spec.ts
@@ -33,10 +33,10 @@
 //
 // The two tests below are the part that IS both real and new.
 
-import { expect, test } from "../fixtures/test";
+import { snapshotBundle, swapServiceWorker } from "../fixtures/bundleSwap";
 import { awaitServiceWorkerActive, loginAs } from "../fixtures/cicchettoPage";
 import { getSeededVjt } from "../fixtures/seedData";
-import { snapshotBundle, swapServiceWorker } from "../fixtures/bundleSwap";
+import { expect, test } from "../fixtures/test";
 
 test("#1063 — the SPA shell is served with a revalidation policy on the real wire", async ({
   page,

--- a/cicchetto/e2e/tests/issue1067-swipe-reply-message-menu.spec.ts
+++ b/cicchetto/e2e/tests/issue1067-swipe-reply-message-menu.spec.ts
@@ -17,12 +17,7 @@
 //     (compose filled, row snapped back, menu open, nothing select-all'd) and
 //     must not be read as covering the rest.
 import type { Page } from "@playwright/test";
-import {
-  composeSend,
-  composeTextarea,
-  loginAs,
-  selectChannel,
-} from "../fixtures/cicchettoPage";
+import { composeSend, composeTextarea, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
@@ -88,7 +83,12 @@ async function swipeRow(page: Page, body: string, points: Pt[]): Promise<Gesture
         if (row.classList.contains("scrollback-line-swiping")) swipingClassDuring = true;
       }
       fire("touchend", last);
-      return { prevented, transformDuring, transformAfter: row.style.transform, swipingClassDuring };
+      return {
+        prevented,
+        transformDuring,
+        transformAfter: row.style.transform,
+        swipingClassDuring,
+      };
     },
     { body, points },
   );
@@ -324,7 +324,9 @@ test("issue1067 — the menu's Copy item writes the whole rendered row to the pa
   await menuItem(page, "Copy").click();
 
   await expect
-    .poll(async () => await page.evaluate(() => (window as unknown as { __copied: string[] }).__copied))
+    .poll(
+      async () => await page.evaluate(() => (window as unknown as { __copied: string[] }).__copied),
+    )
     .toHaveLength(1);
   const copied = await page.evaluate(
     () => (window as unknown as { __copied: string[] }).__copied[0] ?? "",

--- a/cicchetto/e2e/tests/issue1073-admin-topbar-stats.spec.ts
+++ b/cicchetto/e2e/tests/issue1073-admin-topbar-stats.spec.ts
@@ -21,9 +21,9 @@
 // until the first `"overview"` push lands, so `toBeVisible()` waits on the
 // arrival of real server data rather than on a timer.
 
-import { expect, test } from "../fixtures/test";
 import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // admin-vjt has no network bind, so `loginAs`'s network-section shell-ready
 // selector would time out. Same shape as m7-admin-gate / m11-admin-events.

--- a/cicchetto/e2e/tests/issue1088-addressed-informational-replies.spec.ts
+++ b/cicchetto/e2e/tests/issue1088-addressed-informational-replies.spec.ts
@@ -23,10 +23,10 @@
 // server-side fan-out, so once the asker has rendered it, a bystander that
 // was going to receive it has already been sent it.
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -34,7 +34,10 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 // collide with the still-connected peer of the previous iteration.
 const uniqueNick = () => `i1088-${Math.random().toString(36).slice(2, 8)}`;
 
-test("#1088 — /who opens the modal only on the client that issued it", async ({ page, browser }) => {
+test("#1088 — /who opens the modal only on the client that issued it", async ({
+  page,
+  browser,
+}) => {
   const vjt = getSeededVjt();
   const peerNick = uniqueNick();
 

--- a/cicchetto/e2e/tests/issue1089-switch-into-unread-flicker.spec.ts
+++ b/cicchetto/e2e/tests/issue1089-switch-into-unread-flicker.spec.ts
@@ -52,8 +52,7 @@
 // the #625 in-page sampler (a rAF loop, because case 2 is one frame wide and any
 // post-hoc snapshot false-greens).
 
-import { expect, test } from "../fixtures/test";
-import { type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import {
   loginAs,
   scrollbackLines,
@@ -64,6 +63,7 @@ import {
 import { restoreReadCursorToTail, setReadCursorToId } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -194,7 +194,9 @@ async function installFlickerProbe(page: Page, windowMs: number): Promise<void> 
 // On failure this dump is the whole story: one entry per CHANGE of the
 // (visibility, divider offset) pair, so a one-frame excursion shows as a
 // visible=…, marker=<off-screen px> entry between two on-divider entries.
-function compress(frames: readonly Frame[]): Array<{ t: number; vis: string; marker: number | null; top: number }> {
+function compress(
+  frames: readonly Frame[],
+): Array<{ t: number; vis: string; marker: number | null; top: number }> {
   const out: Array<{ t: number; vis: string; marker: number | null; top: number }> = [];
   let prev = "";
   for (const f of frames) {
@@ -295,7 +297,8 @@ test.describe("issue #1089 — switching into an unread window must not flicker"
     // Witness: the perturbation actually landed INSIDE the sampled window. A
     // flat timeline (the append arriving after the sampler expired) would green
     // this test without ever exercising the re-assert.
-    const grew = Math.max(...frames.map((f) => f.height)) > Math.min(...frames.map((f) => f.height));
+    const grew =
+      Math.max(...frames.map((f) => f.height)) > Math.min(...frames.map((f) => f.height));
     expect(grew, "the live append did not land while the sampler was running").toBe(true);
   });
 });
@@ -363,7 +366,9 @@ async function assertNoVisibleJump(page: Page, tag: string): Promise<Frame[]> {
     () =>
       (window as unknown as { __i1089writes: Array<Record<string, unknown>> }).__i1089writes ?? [],
   );
-  console.log(`[#1089 ${tag}] frames=${frames.length} timeline=${JSON.stringify(compress(frames))}`);
+  console.log(
+    `[#1089 ${tag}] frames=${frames.length} timeline=${JSON.stringify(compress(frames))}`,
+  );
   console.log(`[#1089 ${tag}] writes=${JSON.stringify(writes)}`);
 
   expect(frames.length).toBeGreaterThan(10);
@@ -375,9 +380,7 @@ async function assertNoVisibleJump(page: Page, tag: string): Promise<Frame[]> {
   expect(settled.marker as number).toBeLessThan(settled.client);
   // Parked on the divider, not tailed (the pane must have something below to
   // scroll to, or a "no jump" green would be vacuous).
-  expect(settled.height - settled.top - settled.client).toBeGreaterThan(
-    SCROLL_BOTTOM_THRESHOLD_PX,
-  );
+  expect(settled.height - settled.top - settled.client).toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
 
   // #1089 CORE — no VISIBLE frame shows the divider outside the viewport. On
   // main both post-reveal displacements land here: the tail snap parks it

--- a/cicchetto/e2e/tests/issue123-compose-swipe-velocity.spec.ts
+++ b/cicchetto/e2e/tests/issue123-compose-swipe-velocity.spec.ts
@@ -44,7 +44,6 @@
 // guard the wiring + CSS, not the physics. No hollow green: each fails on a
 // real regression.
 
-import { expect, test } from "../fixtures/test";
 import {
   composeSend,
   composeTextarea,
@@ -53,6 +52,7 @@ import {
   synthSwipe,
 } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/issue126-detach-lifecycle.spec.ts
+++ b/cicchetto/e2e/tests/issue126-detach-lifecycle.spec.ts
@@ -30,14 +30,13 @@
 // specs. The afterEach reconnects vjt's network defensively (a pre-#126
 // RED run of this spec would tear the seeded session down).
 
-import { test, expect } from "../fixtures/test";
-import { openRailMenu, loginAs } from "../fixtures/cicchettoPage";
+import { loginAs, openRailMenu } from "../fixtures/cicchettoPage";
 import {
-  reapVisitors,
   GRAPPA_BASE_URL,
   login,
   mintVisitor,
   patchNetworkConnectionState,
+  reapVisitors,
 } from "../fixtures/grappaApi";
 import {
   AUTOJOIN_CHANNELS,
@@ -46,6 +45,7 @@ import {
   VJT_IDENTIFIER,
   VJT_PASSWORD,
 } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/issue127-server-reply-modal.spec.ts
+++ b/cicchetto/e2e/tests/issue127-server-reply-modal.spec.ts
@@ -24,9 +24,9 @@
 // The server-side accumulator + terminator drain + the connect-time-MOTD
 // gating are unit-tested in test/grappa/session/event_router_test.exs.
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/issue135-visitor-home-landing.spec.ts
+++ b/cicchetto/e2e/tests/issue135-visitor-home-landing.spec.ts
@@ -17,10 +17,10 @@
 // Seeding: featured channels added via the admin REST path, removed in
 // `finally`. Network id resolved by slug from GET /admin/networks.
 
-import { test, expect } from "../fixtures/test";
 import { expectShellReady } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // Unique per run: avoids featured-list bleed across retries / parallel
 // runs on the shared seeded network. crypto.randomUUID() is available in
@@ -38,11 +38,7 @@ async function resolveNetworkId(adminToken: string, slug: string): Promise<numbe
   return row.id;
 }
 
-async function addFeatured(
-  adminToken: string,
-  networkId: number,
-  name: string,
-): Promise<number> {
+async function addFeatured(adminToken: string, networkId: number, name: string): Promise<number> {
   const res = await fetch(`${GRAPPA_BASE_URL}/admin/networks/${networkId}/featured_channels`, {
     method: "POST",
     headers: { "content-type": "application/json", authorization: `Bearer ${adminToken}` },
@@ -58,10 +54,10 @@ async function deleteFeaturedBestEffort(
   featuredId: number,
 ): Promise<void> {
   try {
-    await fetch(
-      `${GRAPPA_BASE_URL}/admin/networks/${networkId}/featured_channels/${featuredId}`,
-      { method: "DELETE", headers: { authorization: `Bearer ${adminToken}` } },
-    );
+    await fetch(`${GRAPPA_BASE_URL}/admin/networks/${networkId}/featured_channels/${featuredId}`, {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${adminToken}` },
+    });
   } catch {
     // best-effort teardown
   }

--- a/cicchetto/e2e/tests/issue14-own-action-render.spec.ts
+++ b/cicchetto/e2e/tests/issue14-own-action-render.spec.ts
@@ -19,7 +19,6 @@
 // assert BOTH the REST-persisted kind AND the rendered action row, plus
 // the negative invariant that no privmsg row carries the same tag.
 
-import { test, expect } from "../fixtures/test";
 import {
   composeSend,
   composeTextarea,
@@ -29,6 +28,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = "#bofh";
 

--- a/cicchetto/e2e/tests/issue142-quit-mirc-render.spec.ts
+++ b/cicchetto/e2e/tests/issue142-quit-mirc-render.spec.ts
@@ -18,10 +18,10 @@
 // engine computes. The vitest unit tests pin the parser; this pins the
 // rendered visual on the quit line.
 
-import { test, expect } from "../fixtures/test";
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const TEST_CHANNEL = "#bofh";
 

--- a/cicchetto/e2e/tests/issue148-visitor-oper.spec.ts
+++ b/cicchetto/e2e/tests/issue148-visitor-oper.spec.ts
@@ -25,10 +25,15 @@
 // /oper is that O:line NAME field, NOT the visitor's nick — so any visitor
 // nick can oper with `testoper`/`testoperpass`.
 
-import { expect, test } from "../fixtures/test";
-import { expectShellReady, composeSend, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import {
+  composeSend,
+  expectShellReady,
+  scrollbackLine,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
 import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // Verbatim trailing text bahamut sends for numeric 381 RPL_YOUREOPER —
 // `:%s 381 %s :You are now an IRC Operator` (azzurra/bahamut src/s_err.c).
@@ -90,9 +95,9 @@ test("issue #148 — visitor /oper ships OPER upstream and renders the 381 notic
 
     // VISIBLE SUCCESS: the 381 RPL_YOUREOPER notice renders in $server.
     // Pre-#148 this never arrives (visitor_not_allowed short-circuit) → RED.
-    await expect(
-      scrollbackLine(page, "notice", RPL_YOUREOPER_TEXT).first(),
-    ).toBeVisible({ timeout: 15_000 });
+    await expect(scrollbackLine(page, "notice", RPL_YOUREOPER_TEXT).first()).toBeVisible({
+      timeout: 15_000,
+    });
 
     // And the visitor_not_allowed rejection is NOT surfaced anywhere (the
     // compose alert renders the raw token for this unmapped channel-error).

--- a/cicchetto/e2e/tests/issue151-server-placeholder.spec.ts
+++ b/cicchetto/e2e/tests/issue151-server-placeholder.spec.ts
@@ -20,9 +20,9 @@
 // Per `feedback_ux_e2e_mandatory`: every cic UX-touching change ships with
 // a Playwright e2e via scripts/integration.sh.
 
-import { expect, test } from "../fixtures/test";
 import { composeTextarea, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 test("#151 — server-window compose placeholder shows the network slug, not the $server sentinel", async ({
   page,

--- a/cicchetto/e2e/tests/issue152-ident-realname.spec.ts
+++ b/cicchetto/e2e/tests/issue152-ident-realname.spec.ts
@@ -22,9 +22,9 @@
 //      reconnect primitive re-registers upstream with the changed ident
 //      AND rejoins the channel (the visitor can speak in it again).
 
-import { expect, test } from "../fixtures/test";
-import { expectShellReady,
+import {
   composeSend,
+  expectShellReady,
   openSettingsSection,
   selectChannel,
   waitForUserTopicReady,
@@ -32,6 +32,7 @@ import { expectShellReady,
 import { reapVisitors } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 test("issue #152 — login-Advanced ident + settings live-apply reach upstream", async ({
   browser,

--- a/cicchetto/e2e/tests/issue153-visitor-state-verbs.spec.ts
+++ b/cicchetto/e2e/tests/issue153-visitor-state-verbs.spec.ts
@@ -27,9 +27,9 @@
 // depending on the leaf's split-mode first-joiner-op behavior — ircops
 // issue MODE freely on any channel they're in (see ircClient.oper docs).
 
-import { expect, test } from "../fixtures/test";
-import { expectShellReady,
+import {
   composeSend,
+  expectShellReady,
   scrollbackLine,
   selectChannel,
   waitForUserTopicReady,
@@ -37,6 +37,7 @@ import { expectShellReady,
 import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // Stable core phrase of bahamut's 381 RPL_YOUREOPER trailing text
 // (`:%s 381 %s :You are now an IRC Operator`) — matched as a regex so
@@ -92,9 +93,9 @@ test("issue #153 — visitor /quote and /mode reach upstream and take effect", a
     // in $server as a :notice — proves the oper took (and, incidentally,
     // that #148's visitor-oper carve-out still holds).
     await composeSend(page, "/oper testoper testoperpass");
-    await expect(
-      scrollbackLine(page, "notice", RPL_YOUREOPER_TEXT).first(),
-    ).toBeVisible({ timeout: 15_000 });
+    await expect(scrollbackLine(page, "notice", RPL_YOUREOPER_TEXT).first()).toBeVisible({
+      timeout: 15_000,
+    });
 
     // Gate the compose /join on the user-topic JOIN ack (window_pending
     // fastlanes only to subscribed sockets — see waitForUserTopicReady).

--- a/cicchetto/e2e/tests/issue154-mode-reliability.spec.ts
+++ b/cicchetto/e2e/tests/issue154-mode-reliability.spec.ts
@@ -32,16 +32,17 @@
 // which the testnet already carries.
 
 import type { Browser } from "@playwright/test";
-import { expect, test } from "../fixtures/test";
-import { expectShellReady,
+import {
   composeSend,
   composeTextarea,
+  expectShellReady,
   scrollbackLine,
   selectChannel,
   waitForUserTopicReady,
 } from "../fixtures/cicchettoPage";
 import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // Boot cic straight into Shell as a freshly-minted visitor (no captcha/anon
 // dance) — identical seeding to issue148/issue153.
@@ -143,9 +144,9 @@ test("issue #154(2) — an own-nick /umode renders a 'sets user mode' row in $se
     // VISIBLE outcome: a `data-kind="mode"` row rendered as "sets user mode"
     // (own-nick form — no "on <channel>" suffix). RED pre-fix (nothing lands),
     // GREEN post-fix.
-    await expect(
-      scrollbackLine(page, "mode", /sets user mode/i).first(),
-    ).toBeVisible({ timeout: 15_000 });
+    await expect(scrollbackLine(page, "mode", /sets user mode/i).first()).toBeVisible({
+      timeout: 15_000,
+    });
   } finally {
     await ctx.close();
     await reapVisitors(admin.token, visitor.id);

--- a/cicchetto/e2e/tests/issue155-native-stats-rehash.spec.ts
+++ b/cicchetto/e2e/tests/issue155-native-stats-rehash.spec.ts
@@ -36,10 +36,15 @@
 // GREEN post-fix: the native slash builds the raw frame, pushRaw ships it,
 // and the reply numerics render as :notice rows in $server.
 
-import { expect, test } from "../fixtures/test";
-import { expectShellReady, composeSend, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import {
+  composeSend,
+  expectShellReady,
+  scrollbackLine,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
 import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // Verbatim trailing text bahamut-azzurra sends (src/s_err.c):
 //   242 RPL_STATSUPTIME   `:%s 242 %s :Server Up %d days, %d:%02d:%02d`
@@ -97,18 +102,18 @@ test("issue #155 — native /stats and /rehash ship upstream and render reply nu
     // sent → no 242. GREEN: pushRaw ships "STATS u", 242 RPL_STATSUPTIME
     // renders as a :notice in $server.
     await composeSend(page, "/stats u");
-    await expect(
-      scrollbackLine(page, "notice", RPL_STATSUPTIME_TEXT).first(),
-    ).toBeVisible({ timeout: 15_000 });
+    await expect(scrollbackLine(page, "notice", RPL_STATSUPTIME_TEXT).first()).toBeVisible({
+      timeout: 15_000,
+    });
 
     // (2) NATIVE /rehash. RED pre-fix: unknown command → nothing sent → no
     // reply. GREEN: pushRaw ships "REHASH"; the non-oper visitor gets 481
     // ERR_NOPRIVILEGES back — the server's reply to our frame — rendered as
     // a :notice in $server.
     await composeSend(page, "/rehash");
-    await expect(
-      scrollbackLine(page, "notice", ERR_NOPRIVILEGES_TEXT).first(),
-    ).toBeVisible({ timeout: 15_000 });
+    await expect(scrollbackLine(page, "notice", ERR_NOPRIVILEGES_TEXT).first()).toBeVisible({
+      timeout: 15_000,
+    });
 
     // The native verbs never surface the parser's unknown-command error.
     await expect(page.getByText(/unknown command/i)).toHaveCount(0);

--- a/cicchetto/e2e/tests/issue157-delete-account.spec.ts
+++ b/cicchetto/e2e/tests/issue157-delete-account.spec.ts
@@ -26,10 +26,15 @@
 // (`Grappa.AccountDeletionTest`) + cic vitest (SettingsDrawer gating +
 // DeleteAccountModal). Honest scope, mirroring issue126-detach-lifecycle.
 
-import { test, expect } from "../fixtures/test";
-import { openSettingsDrawer, expectShellReady, openRailMenu, closeSettings } from "../fixtures/cicchettoPage";
+import {
+  closeSettings,
+  expectShellReady,
+  openRailMenu,
+  openSettingsDrawer,
+} from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL, login, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PASSWORD = "test-password-not-secret";
 

--- a/cicchetto/e2e/tests/issue16-keyed-join-members-seed.spec.ts
+++ b/cicchetto/e2e/tests/issue16-keyed-join-members-seed.spec.ts
@@ -29,10 +29,10 @@
 // afterEach only tears down the peer.
 
 import type { Page } from "@playwright/test";
-import { test, expect } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 const KEY = "k16-secret-key";

--- a/cicchetto/e2e/tests/issue160-virtual-tab-no-cursor.spec.ts
+++ b/cicchetto/e2e/tests/issue160-virtual-tab-no-cursor.spec.ts
@@ -20,10 +20,10 @@
 // read-cursor POST returned 4xx (the fail2ban trigger). RED before the
 // setReadCursor guard (a $home 404 is captured); GREEN after.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { restoreReadCursorToTail } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/issue161-forward-paging.spec.ts
+++ b/cicchetto/e2e/tests/issue161-forward-paging.spec.ts
@@ -45,7 +45,6 @@
 // needed; `restoreReadCursorToTail` in afterAll undoes the early cursor
 // (BUGHUNT-3 cascade rule).
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import {
   fetchAllMessagesAsc,
@@ -60,6 +59,7 @@ import {
   NETWORK_SLUG,
   VJT_USER,
 } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/issue168-scroll-authority.spec.ts
+++ b/cicchetto/e2e/tests/issue168-scroll-authority.spec.ts
@@ -37,8 +37,7 @@
 // `#bofh` via the e2e seeder sidecar; tiny 800×300 viewport so the 50-row
 // REST page overflows and scroll geometry is measurable).
 
-import { test, expect } from "../fixtures/test";
-import { type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import {
   composeSend,
   loginAs,
@@ -48,6 +47,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { restoreReadCursorToTail, setReadCursorToId } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -64,7 +64,11 @@ async function scrollbackGeometry(
   return await page.evaluate(() => {
     const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
     if (!el) throw new Error("scrollback container not found");
-    return { scrollTop: el.scrollTop, scrollHeight: el.scrollHeight, clientHeight: el.clientHeight };
+    return {
+      scrollTop: el.scrollTop,
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    };
   });
 }
 
@@ -151,9 +155,9 @@ test.describe("issue #168 — send pins to bottom, never jumps to the unread mar
     // (a) Pane is pinned at the BOTTOM after the send. RED pre-fix: the
     // marker anchor parked the view mid-pane and the send did not follow,
     // so distance-to-tail stayed well above threshold.
-    await expect.poll(async () => await distanceToBottom(page)).toBeLessThanOrEqual(
-      SCROLL_BOTTOM_THRESHOLD_PX,
-    );
+    await expect
+      .poll(async () => await distanceToBottom(page))
+      .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
 
     // (b) The just-sent line is visible — the view did NOT jump to / stay
     // stuck at the unread divider (which sits above the fold). RED pre-fix:
@@ -189,9 +193,9 @@ test.describe("issue #168 — send pins to bottom, never jumps to the unread mar
     // Cold-mount into an unread channel now lands on the MARKER, not the tail
     // (#168 completion, 2026-07-03b — vjt point-2 reversed the #46
     // cold-mount-tail wontfix). So activation already sits ABOVE the fold.
-    await expect.poll(async () => await distanceToBottom(page)).toBeGreaterThan(
-      SCROLL_BOTTOM_THRESHOLD_PX,
-    );
+    await expect
+      .poll(async () => await distanceToBottom(page))
+      .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
 
     // Operator PAGES UP with a real wheel gesture. This ALSO clears the
     // marker-activation latch (arms the operator-input gate), so the subsequent
@@ -213,9 +217,9 @@ test.describe("issue #168 — send pins to bottom, never jumps to the unread mar
 
     const sentLine = scrollbackLines(page).filter({ hasText: marker });
     await expect(sentLine).toHaveCount(1, { timeout: 10_000 });
-    await expect.poll(async () => await distanceToBottom(page)).toBeLessThanOrEqual(
-      SCROLL_BOTTOM_THRESHOLD_PX,
-    );
+    await expect
+      .poll(async () => await distanceToBottom(page))
+      .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
     await expect(sentLine).toBeInViewport();
   });
 });

--- a/cicchetto/e2e/tests/issue171-per-ip-clone-cap.spec.ts
+++ b/cicchetto/e2e/tests/issue171-per-ip-clone-cap.spec.ts
@@ -23,14 +23,9 @@
 // seeded headroom (100) so no later spec inherits a cap=1 on the shared
 // runner IP.
 
-import { expect, test } from "../fixtures/test";
+import { GRAPPA_BASE_URL, login, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { ADMIN_IDENTIFIER, ADMIN_PASSWORD } from "../fixtures/seedData";
-import {
-  GRAPPA_BASE_URL,
-  reapVisitors,
-  login,
-  mintVisitor,
-} from "../fixtures/grappaApi";
+import { expect, test } from "../fixtures/test";
 
 // The anon visitor network. Its seeded `max_per_ip` is the headroom
 // value later specs rely on (see compose.yaml azzurra seeder).

--- a/cicchetto/e2e/tests/issue173-compose-recall-caret-visible.spec.ts
+++ b/cicchetto/e2e/tests/issue173-compose-recall-caret-visible.spec.ts
@@ -33,8 +33,8 @@ import {
   selectChannel,
   synthSwipe,
 } from "../fixtures/cicchettoPage";
-import { expect, test } from "../fixtures/test";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/issue175-who-realname-mirc.spec.ts
+++ b/cicchetto/e2e/tests/issue175-who-realname-mirc.spec.ts
@@ -19,10 +19,10 @@
 //   - The raw \x02 control byte does NOT appear in the row's textContent
 //     (proof the bytes were consumed, not dumped raw — the #175 bug).
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -53,9 +53,9 @@ test("#175 — a peer's bold-formatted WHO realname renders a .scrollback-mirc-b
     // proof the realname routed through MircBody, not a raw `{u.realname}`.
     const peerRow = modal.locator(".who-modal-row", { hasText: peerNick });
     await expect(peerRow).toBeVisible();
-    await expect(
-      peerRow.locator(".scrollback-mirc-bold", { hasText: boldTag }),
-    ).toHaveCount(1, { timeout: 5_000 });
+    await expect(peerRow.locator(".scrollback-mirc-bold", { hasText: boldTag })).toHaveCount(1, {
+      timeout: 5_000,
+    });
 
     // The raw \x02 control byte must NOT leak into the DOM (the #175 bug).
     const rowText = (await peerRow.textContent()) ?? "";

--- a/cicchetto/e2e/tests/issue176-who-layout.spec.ts
+++ b/cicchetto/e2e/tests/issue176-who-layout.spec.ts
@@ -22,10 +22,10 @@
 //   - Realname ON ITS OWN LINE: the realname line sits visually BELOW the nick
 //     (boundingBox().y strictly greater) — not an inline sibling on one row.
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/issue177-keyboard-removed.spec.ts
+++ b/cicchetto/e2e/tests/issue177-keyboard-removed.spec.ts
@@ -17,7 +17,6 @@
 // inline (mobile suppresses it on channel windows, UX-5 BM), so the drawer
 // open is reliable here.
 
-import { expect, test } from "../fixtures/test";
 import {
   composeSend,
   composeTextarea,
@@ -27,6 +26,7 @@ import {
   selectChannel,
 } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/issue178-nonempty-compose-recall.spec.ts
+++ b/cicchetto/e2e/tests/issue178-nonempty-compose-recall.spec.ts
@@ -17,10 +17,15 @@
 // chromium-only: the TouchEvent constructor + synthetic swipe physics are
 // reliable on chromium, not webkit (same limitation the #123 spec notes).
 
-import { expect, test } from "../fixtures/test";
-import { composeSend, composeTextarea, loginAs, selectChannel } from "../fixtures/cicchettoPage";
-import { synthSwipe } from "../fixtures/cicchettoPage";
+import {
+  composeSend,
+  composeTextarea,
+  loginAs,
+  selectChannel,
+  synthSwipe,
+} from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/issue179-nick-in-selection.spec.ts
+++ b/cicchetto/e2e/tests/issue179-nick-in-selection.spec.ts
@@ -31,7 +31,6 @@
 // Android behavior needs a physical device / emulator (device-verified
 // post-ship). Do NOT read this file's green status as "Android covered."
 
-import { test, expect } from "../fixtures/test";
 import {
   composeSend,
   composeTextarea,
@@ -40,6 +39,7 @@ import {
   selectChannel,
 } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 // Date.now() suffix (house pattern): the e2e sqlite scrollback persists

--- a/cicchetto/e2e/tests/issue184-stats-window-routing.spec.ts
+++ b/cicchetto/e2e/tests/issue184-stats-window-routing.spec.ts
@@ -26,19 +26,16 @@
 // GREEN post-fix: 219 renders as a :notice in $server; no "u" window exists,
 // server-side or client-side.
 
-import { expect, test } from "../fixtures/test";
-import { expectShellReady,
+import {
   composeSend,
+  expectShellReady,
   scrollbackLine,
   selectChannel,
   sidebarWindow,
 } from "../fixtures/cicchettoPage";
-import {
-  reapVisitors,
-  GRAPPA_BASE_URL,
-  mintVisitor,
-} from "../fixtures/grappaApi";
+import { GRAPPA_BASE_URL, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // The stats letter we query. `u` (uptime) is deliberately reused from #155:
 // bahamut's `m_stats case 'u'` is un-gated (public, no oper) and does NOT
@@ -99,9 +96,9 @@ test("issue #184 — /stats reply renders in $server, never a query window named
     // POSITIVE (RED pre-fix): the letter-carrying 219 renders as a :notice
     // in the $server pane (still focused). Pre-fix it was routed to query
     // "u" and this pane never saw it.
-    await expect(
-      scrollbackLine(page, "notice", RPL_ENDOFSTATS_TEXT).first(),
-    ).toBeVisible({ timeout: 15_000 });
+    await expect(scrollbackLine(page, "notice", RPL_ENDOFSTATS_TEXT).first()).toBeVisible({
+      timeout: 15_000,
+    });
 
     // NEGATIVE, client-side (RED pre-fix): NO sidebar window/tab named after
     // the stats letter. `sidebarWindow` matches on the production

--- a/cicchetto/e2e/tests/issue187-visitor-window-restore.spec.ts
+++ b/cicchetto/e2e/tests/issue187-visitor-window-restore.spec.ts
@@ -22,15 +22,16 @@
 // GREEN post-fix: the restore arm re-selects #r187 → the row is `.selected`.
 
 import type { Browser } from "@playwright/test";
-import { expect, test } from "../fixtures/test";
-import { expectShellReady,
+import {
   composeSend,
+  expectShellReady,
   selectChannel,
   sidebarWindow,
   waitForUserTopicReady,
 } from "../fixtures/cicchettoPage";
 import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // Boot cic straight into Shell as a freshly-minted visitor (no captcha/anon
 // dance) — identical seeding to issue148/issue153/issue154.

--- a/cicchetto/e2e/tests/issue188-mentions-panel-polish.spec.ts
+++ b/cicchetto/e2e/tests/issue188-mentions-panel-polish.spec.ts
@@ -21,15 +21,10 @@
 //
 // Untagged → runs in the chromium (desktop) project.
 
-import { expect, test } from "../fixtures/test";
-import {
-  composeSend,
-  loginAs,
-  scrollbackLine,
-  selectChannel,
-} from "../fixtures/cicchettoPage";
+import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "m188-peer";
 const CHANNEL_A = AUTOJOIN_CHANNELS[0]; // "#bofh" — already joined at login

--- a/cicchetto/e2e/tests/issue189-perform.spec.ts
+++ b/cicchetto/e2e/tests/issue189-perform.spec.ts
@@ -12,7 +12,7 @@
 // surface behaving identically for every subject class (the server stores it on
 // the credential via the same shape). No subject-shaped branch to parameterize.
 
-import { openSettingsDrawer, loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { loginAs, openSettingsDrawer, selectChannel } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";

--- a/cicchetto/e2e/tests/issue195-leave-confirm-modal.spec.ts
+++ b/cicchetto/e2e/tests/issue195-leave-confirm-modal.spec.ts
@@ -21,7 +21,6 @@
 // network and the afterEach reconnects it (same pattern as
 // cp15-b6-parked-disconnect-reconnect), polling until autojoin restores #bofh.
 
-import { expect, test } from "../fixtures/test";
 import {
   confirmModal,
   confirmModalBody,
@@ -34,6 +33,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { joinChannel, partChannel, patchNetworkConnectionState } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const LEAVE_CHANNEL = "#x195-leave";
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/issue200-ws-sub-teardown.spec.ts
+++ b/cicchetto/e2e/tests/issue200-ws-sub-teardown.spec.ts
@@ -37,11 +37,11 @@
 //      subscription. The interactive `/join` focus is synchronous +
 //      race-free (compose.ts), independent of the per-channel broadcast.
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { joinChannel, partChannel } from "../fixtures/grappaApi";
 import { forwardPageDiagnostics } from "../fixtures/pageDiagnostics";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 // Mirrors `channelKey(slug, name)` — `${slug} ${canonicalChannel(name)}`.

--- a/cicchetto/e2e/tests/issue200-ws-sub-teardown.spec.ts
+++ b/cicchetto/e2e/tests/issue200-ws-sub-teardown.spec.ts
@@ -40,6 +40,7 @@
 import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { joinChannel, partChannel } from "../fixtures/grappaApi";
+import { forwardPageDiagnostics } from "../fixtures/pageDiagnostics";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
@@ -63,12 +64,7 @@ test.afterEach(async () => {
 
 test("#200 — own-PART tears down the per-channel WS subscription (no leak)", async ({ page }) => {
   const vjt = getSeededVjt();
-  page.on("console", (msg) => {
-    if (msg.type() === "error" || msg.type() === "warn") {
-      // eslint-disable-next-line no-console
-      console.log(`[cic:${msg.type()}] ${msg.text()}`);
-    }
-  });
+  forwardPageDiagnostics(page);
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
   await expect(sidebarWindow(page, NETWORK_SLUG, CHANNEL)).toHaveCount(1);
@@ -94,12 +90,7 @@ test("#200 — after own-PART teardown, compose /join re-subscribes AND focuses 
   page,
 }) => {
   const vjt = getSeededVjt();
-  page.on("console", (msg) => {
-    if (msg.type() === "error" || msg.type() === "warn") {
-      // eslint-disable-next-line no-console
-      console.log(`[cic:${msg.type()}] ${msg.text()}`);
-    }
-  });
+  forwardPageDiagnostics(page);
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
   await expect.poll(() => joinedTopicKeys(page), { timeout: 10_000 }).toContain(TOPIC_KEY);

--- a/cicchetto/e2e/tests/issue203-empty-compose-swipe-recall.spec.ts
+++ b/cicchetto/e2e/tests/issue203-empty-compose-swipe-recall.spec.ts
@@ -19,7 +19,6 @@
 // dogfood pass (flagged to orch), but this spec deterministically proves
 // the handler WIRING: an empty-compose up-flick now reaches recallPrev.
 
-import { expect, test } from "../fixtures/test";
 import {
   composeSend,
   composeTextarea,
@@ -28,6 +27,7 @@ import {
   synthSwipe,
 } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/issue211-phase3-multinet-visitor.spec.ts
+++ b/cicchetto/e2e/tests/issue211-phase3-multinet-visitor.spec.ts
@@ -26,16 +26,21 @@
 // `.shell-members .members-pane`, no mobile drawer).
 
 import type { Browser, Page } from "@playwright/test";
-import { test, expect } from "../fixtures/test";
-import { expectShellReady, composeSend, selectChannel, waitForUserTopicReady } from "../fixtures/cicchettoPage";
-import { IrcPeer } from "../fixtures/ircClient";
 import {
-  reapVisitors,
+  composeSend,
+  expectShellReady,
+  selectChannel,
+  waitForUserTopicReady,
+} from "../fixtures/cicchettoPage";
+import {
   GRAPPA_BASE_URL,
-  mintVisitor,
   type MintedVisitor,
+  mintVisitor,
+  reapVisitors,
 } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
 import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const VISITOR_NETWORK = "azzurra";
 
@@ -123,9 +128,9 @@ test("issue #211 phase 3 — fresh visitor lands JOINED with own nick + a live P
     // the line into scrollback.
     peer = await IrcPeer.connect({ nick: `peer-p3-${stamp % 100000}` });
     await peer.join(channel);
-    await expect(
-      membersPane.locator(".member-name", { hasText: peer.nick }),
-    ).toBeVisible({ timeout: 15_000 });
+    await expect(membersPane.locator(".member-name", { hasText: peer.nick })).toBeVisible({
+      timeout: 15_000,
+    });
 
     const wireMsg = `phase3-live-${stamp}`;
     peer.privmsg(channel, wireMsg);

--- a/cicchetto/e2e/tests/issue211-phase6-matrix.spec.ts
+++ b/cicchetto/e2e/tests/issue211-phase6-matrix.spec.ts
@@ -35,16 +35,11 @@
 // Runs on chromium desktop (members pane renders directly).
 
 import type { Browser, Page } from "@playwright/test";
-import { test, expect } from "../fixtures/test";
 import { expectShellReady, selectChannel, waitForUserTopicReady } from "../fixtures/cicchettoPage";
+import { GRAPPA_BASE_URL, joinChannel, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
-import {
-  reapVisitors,
-  GRAPPA_BASE_URL,
-  joinChannel,
-  mintVisitor,
-} from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // Two full connect chains + a peer round-trip on each network — well
 // past the default; give it plenty of testnet-latency headroom.

--- a/cicchetto/e2e/tests/issue211-phase6-matrix.spec.ts
+++ b/cicchetto/e2e/tests/issue211-phase6-matrix.spec.ts
@@ -91,13 +91,15 @@ async function bootVisitor(
 
 // Poll GET /networks until it lists at least `n` rows (the async
 // autoconnect fan-out settles after the sync anchor connect).
-async function waitForNetworks(token: string, n: number): Promise<Array<{ slug: string }>> {
+type NetworkRow = { slug: string; connection_state: string };
+
+async function waitForNetworks(token: string, n: number): Promise<NetworkRow[]> {
   for (let i = 0; i < 40; i++) {
     const res = await fetch(`${GRAPPA_BASE_URL}/networks`, {
       headers: { authorization: `Bearer ${token}` },
     });
     if (res.ok) {
-      const rows = (await res.json()) as Array<{ slug: string }>;
+      const rows = (await res.json()) as NetworkRow[];
       if (rows.length >= n) return rows;
     }
     await new Promise((r) => setTimeout(r, 500));

--- a/cicchetto/e2e/tests/issue211-phase7-multinet-reconnect.spec.ts
+++ b/cicchetto/e2e/tests/issue211-phase7-multinet-reconnect.spec.ts
@@ -40,16 +40,16 @@
 // both networks in one socket resume.
 
 import type { Browser, Page } from "@playwright/test";
-import { test, expect } from "../fixtures/test";
 import { expectShellReady, selectChannel, waitForUserTopicReady } from "../fixtures/cicchettoPage";
-import { IrcPeer } from "../fixtures/ircClient";
 import {
-  reapVisitors,
   assertMessagePersisted,
   GRAPPA_BASE_URL,
   mintVisitor,
+  reapVisitors,
 } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
 import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const ANCHOR = "azzurra";
 const SECOND = "azzurra2";
@@ -137,22 +137,8 @@ async function setNetworkNick(token: string, slug: string, nick: string): Promis
     headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
     body: JSON.stringify({ nick }),
   });
-  if (!res.ok) throw new Error(`setNetworkNick: ${slug}=${nick} → ${res.status} ${await res.text()}`);
-}
-
-async function patchConnectionState(
-  token: string,
-  slug: string,
-  state: "connected" | "parked",
-): Promise<void> {
-  const res = await fetch(`${GRAPPA_BASE_URL}/networks/${slug}`, {
-    method: "PATCH",
-    headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
-    body: JSON.stringify({ connection_state: state }),
-  });
-  if (!res.ok) {
-    throw new Error(`patchConnectionState: ${slug}=${state} → ${res.status} ${await res.text()}`);
-  }
+  if (!res.ok)
+    throw new Error(`setNetworkNick: ${slug}=${nick} → ${res.status} ${await res.text()}`);
 }
 
 async function fetchMembers(token: string, slug: string, channel: string): Promise<string[]> {
@@ -188,11 +174,7 @@ async function waitForOwnNickInMembers(
 // passed) while the upstream is still mid-register, so a bare joinChannel
 // races the register. Retry on 404 until the JOIN sticks (same
 // poll-until-ready discipline the park/reconnect specs use for autojoin).
-async function joinChannelWhenReady(
-  token: string,
-  slug: string,
-  channel: string,
-): Promise<void> {
+async function joinChannelWhenReady(token: string, slug: string, channel: string): Promise<void> {
   let last = "";
   for (let i = 0; i < 60; i++) {
     const res = await fetch(`${GRAPPA_BASE_URL}/networks/${slug}/channels`, {
@@ -209,9 +191,7 @@ async function joinChannelWhenReady(
     }
     await new Promise((r) => setTimeout(r, 500));
   }
-  throw new Error(
-    `joinChannelWhenReady: ${slug}/${channel} never became joinable (last: ${last})`,
-  );
+  throw new Error(`joinChannelWhenReady: ${slug}/${channel} never became joinable (last: ${last})`);
 }
 
 test("issue #211 phase 7 — one visitor on TWO networks survives a real cic WS drop and reappears LIVE on BOTH", async ({
@@ -354,9 +334,7 @@ test("issue #211 phase 7 — one visitor on TWO networks survives a real cic WS 
       }
       await window.__cic_dropSocketForTests();
     });
-    await page.waitForFunction(
-      () => window.__cic_socketHealth?.state().state !== "open",
-    );
+    await page.waitForFunction(() => window.__cic_socketHealth?.state().state !== "open");
 
     // Peers send a PRIVMSG on EACH network while cic is confirmed
     // disconnected. Both are persisted server-side (Session.Server persist

--- a/cicchetto/e2e/tests/issue211-phase7-multinet-reconnect.spec.ts
+++ b/cicchetto/e2e/tests/issue211-phase7-multinet-reconnect.spec.ts
@@ -174,7 +174,7 @@ async function waitForOwnNickInMembers(
   ownNick: string,
 ): Promise<void> {
   for (let i = 0; i < 40; i++) {
-    const members = await fetchMembers(token, slug, channel).catch(() => []);
+    const members = await fetchMembers(token, slug, channel).catch((): string[] => []);
     if (members.includes(ownNick)) return;
     await new Promise((r) => setTimeout(r, 500));
   }
@@ -454,13 +454,3 @@ test("issue #211 phase 7 — one visitor on TWO networks survives a real cic WS 
     await reapVisitors(admin.token, visitor?.id);
   }
 });
-
-declare global {
-  interface Window {
-    __cic_dropSocketForTests?: () => Promise<void>;
-    __cic_resumeSocketForTests?: () => Promise<void>;
-    __cic_socketHealth?: {
-      state: () => { state: string };
-    };
-  }
-}

--- a/cicchetto/e2e/tests/issue216-channel-modes-on-join.spec.ts
+++ b/cicchetto/e2e/tests/issue216-channel-modes-on-join.spec.ts
@@ -25,10 +25,10 @@
 // Anti-#bofh-pollution: a per-run UNIQUE channel, and vjt PARTs it in
 // `finally` (the peer disconnects, dropping its membership too).
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 test("#216 — channel modes set before join are visible on join, and tapping opens the /mode modal", async ({
   page,
@@ -74,9 +74,7 @@ test("#216 — channel modes set before join are visible on join, and tapping op
     // accessible name ("secret (+s)", the button's aria-label) — a bare
     // getByText("secret") now matches BOTH the label span and the
     // HelpServ-verbatim description ("Channel is secret …", #667).
-    await expect(
-      modal.getByRole("button", { name: "secret (+s)" }),
-    ).toBeVisible();
+    await expect(modal.getByRole("button", { name: "secret (+s)" })).toBeVisible();
 
     // The "topic lock" (+t) toggle is ACTIVE (pressed) — the peer set it.
     const topicLock = modal.getByLabel(/topic lock/i);

--- a/cicchetto/e2e/tests/issue218-statusmsg-notice.spec.ts
+++ b/cicchetto/e2e/tests/issue218-statusmsg-notice.spec.ts
@@ -24,11 +24,17 @@
 // Pre-fix, step 5's server-side assertion would TIME OUT: the row
 // persisted to a query window keyed on the peer's nick, never `#chan`.
 
-import { expect, test } from "../fixtures/test";
-import { composeSend, loginAs, scrollbackLine, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import {
+  composeSend,
+  loginAs,
+  scrollbackLine,
+  selectChannel,
+  sidebarWindow,
+} from "../fixtures/cicchettoPage";
 import { assertMessagePersisted, partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // Fresh per-run channel so the founder-op + autojoin side-effects don't
 // pollute other specs (mirrors issue16 / cp15-b6). Lowercased — grappa

--- a/cicchetto/e2e/tests/issue219-general-overlay-scroll-hold.spec.ts
+++ b/cicchetto/e2e/tests/issue219-general-overlay-scroll-hold.spec.ts
@@ -122,9 +122,7 @@ test("#219-general (regression guard) — message-follow is untouched: at the ta
     await page.waitForTimeout(300);
 
     // The pane followed to the bottom (the new line is at the tail).
-    const followed = await sc.evaluate(
-      (el) => el.scrollHeight - el.scrollTop - el.clientHeight,
-    );
+    const followed = await sc.evaluate((el) => el.scrollHeight - el.scrollTop - el.clientHeight);
     expect(followed).toBeLessThanOrEqual(50);
   } finally {
     await peer.disconnect("#219-general follow done");

--- a/cicchetto/e2e/tests/issue220-link-double-fire.spec.ts
+++ b/cicchetto/e2e/tests/issue220-link-double-fire.spec.ts
@@ -24,7 +24,7 @@
 // was not) created — the browser fires the `page` event as soon as the
 // target is created, before any load.
 
-import { loginAs, composeSend, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
@@ -47,137 +47,135 @@ test.describe("#220 link-bearing surfaces double-fire", () => {
     );
   });
 
-  test(
-    "/list row: tapping a topic link browses (opens popup) and does NOT join; tapping the row body joins",
-    async ({ page, context }) => {
-      const vjt = getSeededVjt();
-      const channel = `#e2e220-${crypto.randomUUID().slice(0, 8)}`;
+  test("/list row: tapping a topic link browses (opens popup) and does NOT join; tapping the row body joins", async ({
+    page,
+    context,
+  }) => {
+    const vjt = getSeededVjt();
+    const channel = `#e2e220-${crypto.randomUUID().slice(0, 8)}`;
 
-      // A peer creates the channel (first joiner → auto chanop +o) and
-      // sets a URL-bearing topic, then STAYS joined so bahamut includes
-      // the channel in LIST replies (only non-empty channels appear).
-      // vjt never joins it — so the /list row is UNJOINED and a tap there
-      // exercises the join path (the P0 harm being fixed). The creator's
-      // +o beats the default +t topic-lock, so no oper bypass is needed.
-      const peer = await IrcPeer.connect({
-        nick: `e2e220-${crypto.randomUUID().slice(0, 4)}`,
-      });
-      try {
-        await peer.join(channel);
-        await peer.topic(channel, `docs at ${LINK_URL} — join us`);
-
-        await loginAs(page, vjt);
-
-        // Open the channel directory for this network.
-        await sidebarWindow(page, NETWORK_SLUG, LIST_WINDOW_NAME)
-          .locator(".sidebar-window-btn")
-          .click();
-        await expect(page.locator(".directory-search")).toBeVisible({ timeout: 5_000 });
-
-        // Force a fresh LIST so the just-created channel is captured.
-        await page.locator(".directory-refresh").click();
-
-        const row = page.locator(".directory-row").filter({
-          has: page.locator(".directory-row-name", { hasText: channel }),
-        });
-        await expect(row).toBeVisible({ timeout: 15_000 });
-
-        // The topic link renders inside the row.
-        const link = row.locator(".scrollback-link");
-        await expect(link).toHaveAttribute("href", LINK_URL);
-
-        // Precondition: the channel is NOT in vjt's sidebar (unjoined).
-        await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toHaveCount(0);
-
-        // Tap the LINK → it browses (a popup page opens) …
-        const popupPromise = context.waitForEvent("page", { timeout: 5_000 });
-        await link.click();
-        const popup = await popupPromise;
-        expect(popup).not.toBeNull();
-        await popup.close();
-
-        // … and it must NOT join: the row's onActivate never fired. Give
-        // any (buggy) async join a real window to appear before asserting
-        // absence, so this can't pass by racing.
-        await page.waitForTimeout(1_000);
-        await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toHaveCount(0);
-
-        // Tapping the row BODY (the channel-name span, away from the link)
-        // still joins — the surface action is intact.
-        await row.locator(".directory-row-name").click();
-        await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toHaveCount(1, {
-          timeout: 10_000,
-        });
-      } finally {
-        await peer.disconnect("e2e220 list done");
-        await partChannel(vjt.token, NETWORK_SLUG, channel).catch(() => {});
-      }
-    },
-  );
-
-  test(
-    "topic bar: tapping a link opens the topic modal and does NOT navigate; the modal link is a working anchor",
-    async ({ page, context }) => {
-      const vjt = getSeededVjt();
-      // A per-run unique channel — NOT the shared seeded autojoin #bofh.
-      // Mutating #bofh's topic would leak into later specs (the vjt-reset
-      // fixture restores autojoin + scrollback, but NOT channel topics),
-      // the seed-expansion cascade hazard. vjt creates + joins this one,
-      // sets the topic, and we PART it in the finally.
-      const channel = `#e2e220t-${crypto.randomUUID().slice(0, 8)}`;
+    // A peer creates the channel (first joiner → auto chanop +o) and
+    // sets a URL-bearing topic, then STAYS joined so bahamut includes
+    // the channel in LIST replies (only non-empty channels appear).
+    // vjt never joins it — so the /list row is UNJOINED and a tap there
+    // exercises the join path (the P0 harm being fixed). The creator's
+    // +o beats the default +t topic-lock, so no oper bypass is needed.
+    const peer = await IrcPeer.connect({
+      nick: `e2e220-${crypto.randomUUID().slice(0, 4)}`,
+    });
+    try {
+      await peer.join(channel);
+      await peer.topic(channel, `docs at ${LINK_URL} — join us`);
 
       await loginAs(page, vjt);
-      await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
 
-      try {
-        // Join the fresh channel, then set a URL-bearing topic on it.
-        // vjt is the creator (→ chanop), so /topic lands past the default
-        // +t lock (same path as slash-commands-bundle). The
-        // unsolicited-TOPIC handler drives the channelTopic store →
-        // TopicBar strip.
-        await composeSend(page, `/join ${channel}`);
-        await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toBeVisible({ timeout: 10_000 });
-        await selectChannel(page, NETWORK_SLUG, channel, { ownNick: NETWORK_NICK });
-        await composeSend(page, `/topic docs at ${LINK_URL} — see here`);
+      // Open the channel directory for this network.
+      await sidebarWindow(page, NETWORK_SLUG, LIST_WINDOW_NAME)
+        .locator(".sidebar-window-btn")
+        .click();
+      await expect(page.locator(".directory-search")).toBeVisible({ timeout: 5_000 });
 
-        const strip = page.locator(".topic-bar-topic");
-        const stripLink = strip.locator(".scrollback-link");
-        // #268 — the TopicBar strip is painted from the channelTopic store,
-        // which is driven by the SAME unsolicited-TOPIC echo that bahamut
-        // fake-lag delays after a fresh JOIN (see slash-commands-bundle #23 +
-        // docs/DESIGN_NOTES.md 2026-07-16). Under full-suite load the echo can
-        // land past 10s (bahamut banks ~10s of command penalty), so this
-        // condition-wait gets the same 15s headroom as the #23 topic assert —
-        // above the cap, still a wait-for-condition, not a sleep.
-        await expect(stripLink).toHaveAttribute("href", LINK_URL, { timeout: 15_000 });
+      // Force a fresh LIST so the just-created channel is captured.
+      await page.locator(".directory-refresh").click();
 
-        // Tap the link in the strip → the bar's surface action wins: the
-        // modal opens, and NO popup is created (the link does not navigate).
-        let popupOpened = false;
-        const onPage = () => {
-          popupOpened = true;
-        };
-        context.on("page", onPage);
-        await stripLink.click();
+      const row = page.locator(".directory-row").filter({
+        has: page.locator(".directory-row-name", { hasText: channel }),
+      });
+      await expect(row).toBeVisible({ timeout: 15_000 });
 
-        const dialog = page.getByRole("dialog", { name: /channel topic/i });
-        await expect(dialog).toBeVisible({ timeout: 5_000 });
+      // The topic link renders inside the row.
+      const link = row.locator(".scrollback-link");
+      await expect(link).toHaveAttribute("href", LINK_URL);
 
-        // Give a (buggy) navigation a window to fire before asserting none.
-        await page.waitForTimeout(1_000);
-        context.off("page", onPage);
-        expect(popupOpened, "topic-bar link must NOT navigate — the bar opens the modal").toBe(
-          false,
-        );
+      // Precondition: the channel is NOT in vjt's sidebar (unjoined).
+      await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toHaveCount(0);
 
-        // Inside the modal the link is a working anchor (default policy):
-        // correct href + opens in a new tab. Link handling is deferred here.
-        const modalLink = dialog.locator(".scrollback-link");
-        await expect(modalLink).toHaveAttribute("href", LINK_URL);
-        await expect(modalLink).toHaveAttribute("target", "_blank");
-      } finally {
-        await partChannel(vjt.token, NETWORK_SLUG, channel).catch(() => {});
-      }
-    },
-  );
+      // Tap the LINK → it browses (a popup page opens) …
+      const popupPromise = context.waitForEvent("page", { timeout: 5_000 });
+      await link.click();
+      const popup = await popupPromise;
+      expect(popup).not.toBeNull();
+      await popup.close();
+
+      // … and it must NOT join: the row's onActivate never fired. Give
+      // any (buggy) async join a real window to appear before asserting
+      // absence, so this can't pass by racing.
+      await page.waitForTimeout(1_000);
+      await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toHaveCount(0);
+
+      // Tapping the row BODY (the channel-name span, away from the link)
+      // still joins — the surface action is intact.
+      await row.locator(".directory-row-name").click();
+      await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toHaveCount(1, {
+        timeout: 10_000,
+      });
+    } finally {
+      await peer.disconnect("e2e220 list done");
+      await partChannel(vjt.token, NETWORK_SLUG, channel).catch(() => {});
+    }
+  });
+
+  test("topic bar: tapping a link opens the topic modal and does NOT navigate; the modal link is a working anchor", async ({
+    page,
+    context,
+  }) => {
+    const vjt = getSeededVjt();
+    // A per-run unique channel — NOT the shared seeded autojoin #bofh.
+    // Mutating #bofh's topic would leak into later specs (the vjt-reset
+    // fixture restores autojoin + scrollback, but NOT channel topics),
+    // the seed-expansion cascade hazard. vjt creates + joins this one,
+    // sets the topic, and we PART it in the finally.
+    const channel = `#e2e220t-${crypto.randomUUID().slice(0, 8)}`;
+
+    await loginAs(page, vjt);
+    await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
+
+    try {
+      // Join the fresh channel, then set a URL-bearing topic on it.
+      // vjt is the creator (→ chanop), so /topic lands past the default
+      // +t lock (same path as slash-commands-bundle). The
+      // unsolicited-TOPIC handler drives the channelTopic store →
+      // TopicBar strip.
+      await composeSend(page, `/join ${channel}`);
+      await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toBeVisible({ timeout: 10_000 });
+      await selectChannel(page, NETWORK_SLUG, channel, { ownNick: NETWORK_NICK });
+      await composeSend(page, `/topic docs at ${LINK_URL} — see here`);
+
+      const strip = page.locator(".topic-bar-topic");
+      const stripLink = strip.locator(".scrollback-link");
+      // #268 — the TopicBar strip is painted from the channelTopic store,
+      // which is driven by the SAME unsolicited-TOPIC echo that bahamut
+      // fake-lag delays after a fresh JOIN (see slash-commands-bundle #23 +
+      // docs/DESIGN_NOTES.md 2026-07-16). Under full-suite load the echo can
+      // land past 10s (bahamut banks ~10s of command penalty), so this
+      // condition-wait gets the same 15s headroom as the #23 topic assert —
+      // above the cap, still a wait-for-condition, not a sleep.
+      await expect(stripLink).toHaveAttribute("href", LINK_URL, { timeout: 15_000 });
+
+      // Tap the link in the strip → the bar's surface action wins: the
+      // modal opens, and NO popup is created (the link does not navigate).
+      let popupOpened = false;
+      const onPage = () => {
+        popupOpened = true;
+      };
+      context.on("page", onPage);
+      await stripLink.click();
+
+      const dialog = page.getByRole("dialog", { name: /channel topic/i });
+      await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+      // Give a (buggy) navigation a window to fire before asserting none.
+      await page.waitForTimeout(1_000);
+      context.off("page", onPage);
+      expect(popupOpened, "topic-bar link must NOT navigate — the bar opens the modal").toBe(false);
+
+      // Inside the modal the link is a working anchor (default policy):
+      // correct href + opens in a new tab. Link handling is deferred here.
+      const modalLink = dialog.locator(".scrollback-link");
+      await expect(modalLink).toHaveAttribute("href", LINK_URL);
+      await expect(modalLink).toHaveAttribute("target", "_blank");
+    } finally {
+      await partChannel(vjt.token, NETWORK_SLUG, channel).catch(() => {});
+    }
+  });
 });

--- a/cicchetto/e2e/tests/issue221-solanum-whois.spec.ts
+++ b/cicchetto/e2e/tests/issue221-solanum-whois.spec.ts
@@ -23,8 +23,8 @@
 // visitor-multinet path, so it is stable regardless of the visitor
 // accretion-connect timing.
 
-import { expect, test } from "../fixtures/test";
 import { IrcPeer } from "../fixtures/ircClient";
+import { expect, test } from "../fixtures/test";
 
 // The solanum node carries the `bahamut-test2` docker-network alias (#221
 // kept it so the azzurra2 seed resolves unchanged) — the SECOND network's
@@ -62,9 +62,7 @@ test("#221 — solanum answers a mask WHO with 352 channel='*' + 315 echoing the
 
     // Poll the captured lines for the 315 terminator (always emitted, even
     // on zero matches — m_who.c:294), then assert the shape.
-    await expect
-      .poll(() => lines.some((l) => / 315 /.test(l)), { timeout: 10_000 })
-      .toBe(true);
+    await expect.poll(() => lines.some((l) => / 315 /.test(l)), { timeout: 10_000 }).toBe(true);
 
     const reply352 = lines.find((l) => / 352 /.test(l));
     const reply315 = lines.find((l) => / 315 /.test(l));

--- a/cicchetto/e2e/tests/issue221-who-mask.spec.ts
+++ b/cicchetto/e2e/tests/issue221-who-mask.spec.ts
@@ -16,9 +16,9 @@
 // in issue221-solanum-whois.spec.ts, run against the real solanum ircd
 // where nick-masks match.
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -40,4 +40,3 @@ test("#221 — /who <mask> surfaces the WhoModal (feedback, not pre-#221 silence
   const modal = page.getByTestId("who-modal");
   await expect(modal).toBeVisible({ timeout: 8_000 });
 });
-

--- a/cicchetto/e2e/tests/issue221-whois-badges.spec.ts
+++ b/cicchetto/e2e/tests/issue221-whois-badges.spec.ts
@@ -30,10 +30,10 @@
 // for gap (a) is the numeric ROUTING (WHO round-trip), covered by
 // issue221-solanum-whois.spec.ts.
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "whois221-target";
 const CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/issue222-presence-filter.spec.ts
+++ b/cicchetto/e2e/tests/issue222-presence-filter.spec.ts
@@ -28,10 +28,10 @@
 // Per feedback_ux_e2e_mandatory: every cic UX-touching change ships with a
 // Playwright e2e via scripts/integration.sh.
 
-import { expect, test } from "../fixtures/test";
-import { composeSend, loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
+import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 test("#222 — per-channel toggle hides join/part rows, persists across reload, PRIVMSG stays", async ({
   page,

--- a/cicchetto/e2e/tests/issue229-umodes-on-connect.spec.ts
+++ b/cicchetto/e2e/tests/issue229-umodes-on-connect.spec.ts
@@ -28,9 +28,9 @@
 // +g GLOBOPS, +S SSL) renders in the modal. The modal shows the full known
 // table, so those toggles are present even though vjt holds none of them.
 
-import { expect, test } from "../fixtures/test";
-import { expectShellReady, composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { composeSend, expectShellReady, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 test("#229 — own umodes are visible from connect (cold-snapshot after reload), and tapping opens the umode modal", async ({
   page,

--- a/cicchetto/e2e/tests/issue230-mobile-touch-underfill-loadmore.spec.ts
+++ b/cicchetto/e2e/tests/issue230-mobile-touch-underfill-loadmore.spec.ts
@@ -50,8 +50,7 @@
 // prior spec left behind. A TALL viewport (2000px) makes those ~50 rows
 // underfill the container; the server still holds ~150 older rows for loadMore.
 
-import { expect, test } from "../fixtures/test";
-import { type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import {
   fetchAllMessagesAsc,
@@ -59,6 +58,7 @@ import {
   setReadCursorToId,
 } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -71,7 +71,11 @@ async function scrollbackGeometry(
   return await page.evaluate(() => {
     const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
     if (!el) throw new Error("scrollback container not found");
-    return { scrollTop: el.scrollTop, scrollHeight: el.scrollHeight, clientHeight: el.clientHeight };
+    return {
+      scrollTop: el.scrollTop,
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    };
   });
 }
 
@@ -85,7 +89,8 @@ async function synthTouchDrag(page: Page, startY: number, endY: number): Promise
     ({ startY, endY }) => {
       const el = document.querySelector('[data-testid="scrollback"]');
       if (!el) throw new Error("scrollback container not found");
-      const touch = (y: number) => new Touch({ identifier: 1, target: el, clientX: 100, clientY: y });
+      const touch = (y: number) =>
+        new Touch({ identifier: 1, target: el, clientX: 100, clientY: y });
       const fire = (type: "touchstart" | "touchmove", y: number): void => {
         const t = touch(y);
         el.dispatchEvent(

--- a/cicchetto/e2e/tests/issue230-wheel-underfill-loadmore.spec.ts
+++ b/cicchetto/e2e/tests/issue230-wheel-underfill-loadmore.spec.ts
@@ -46,11 +46,11 @@
 // switch documents). A TALL viewport (2000px) makes those ~50 rows underfill
 // the container; the server still holds 150 older rows for loadMore to fetch.
 
-import { expect, test } from "../fixtures/test";
-import { type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { restoreReadCursorToTail, setReadCursorToId } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -73,10 +73,7 @@ async function scrollbackGeometry(
 
 // Latest REST page (DESC by server_time) — used to pick the HEAD id for the
 // read-cursor seed. Same shape cp14-b1 / issue168 / scroll-on-window-switch use.
-async function fetchScrollbackPage(
-  token: string,
-  channel: string,
-): Promise<Array<{ id: number }>> {
+async function fetchScrollbackPage(token: string, channel: string): Promise<Array<{ id: number }>> {
   const url = `http://grappa-test:4000/networks/${encodeURIComponent(
     NETWORK_SLUG,
   )}/channels/${encodeURIComponent(channel)}/messages`;

--- a/cicchetto/e2e/tests/issue231-lusers-current-window.spec.ts
+++ b/cicchetto/e2e/tests/issue231-lusers-current-window.spec.ts
@@ -31,9 +31,9 @@
 // This test issues /lusers explicitly, which marks the request solicited
 // and exercises the slash → push → broadcast → render path end-to-end.
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 test("#231 — /lusers surfaces LusersCard in the CURRENT (channel) window, not $server", async ({
   page,

--- a/cicchetto/e2e/tests/issue232-modal-esc.spec.ts
+++ b/cicchetto/e2e/tests/issue232-modal-esc.spec.ts
@@ -46,24 +46,23 @@ test.setTimeout(60_000);
 // autofocus) pre-fix, so a focus-outside Esc never reached their old onKeyDown.
 // Each opens via a read-only compose command (no server-state mutation → safe
 // on the shared testnet session).
-const ESC_MODALS: { name: string; testid: string; open: (page: Page) => Promise<void> }[] =
-  [
-    {
-      name: "ModeModal (/mode)",
-      testid: "mode-modal",
-      open: (page) => composeSend(page, `/mode ${CHANNEL}`),
-    },
-    {
-      name: "NamesModal (/names)",
-      testid: "names-modal",
-      open: (page) => composeSend(page, `/names ${CHANNEL}`),
-    },
-    {
-      name: "ServerReplyModal (/info)",
-      testid: "server-reply-modal",
-      open: (page) => composeSend(page, "/info"),
-    },
-  ];
+const ESC_MODALS: { name: string; testid: string; open: (page: Page) => Promise<void> }[] = [
+  {
+    name: "ModeModal (/mode)",
+    testid: "mode-modal",
+    open: (page) => composeSend(page, `/mode ${CHANNEL}`),
+  },
+  {
+    name: "NamesModal (/names)",
+    testid: "names-modal",
+    open: (page) => composeSend(page, `/names ${CHANNEL}`),
+  },
+  {
+    name: "ServerReplyModal (/info)",
+    testid: "server-reply-modal",
+    open: (page) => composeSend(page, "/info"),
+  },
+];
 
 for (const m of ESC_MODALS) {
   test(`#232 ${m.name} closes on Esc pressed from body focus (was focus-trapped)`, async ({

--- a/cicchetto/e2e/tests/issue235-next-active-window.spec.ts
+++ b/cicchetto/e2e/tests/issue235-next-active-window.spec.ts
@@ -20,7 +20,6 @@
 // DM. Neither window is focused when the activity lands (focus parks on
 // the neutral $server window), so both accrue unread.
 
-import { expect, test } from "../fixtures/test";
 import {
   loginAs,
   selectChannel,
@@ -31,6 +30,7 @@ import {
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const CHANNEL_LINE = "235 ordinary channel traffic";

--- a/cicchetto/e2e/tests/issue239-hidden-msg-unread.spec.ts
+++ b/cicchetto/e2e/tests/issue239-hidden-msg-unread.spec.ts
@@ -34,7 +34,6 @@
 // Per feedback_ux_e2e_mandatory: every cic UX-touching change ships a real
 // Playwright e2e via scripts/integration.sh.
 
-import { expect, test } from "../fixtures/test";
 import {
   loginAs,
   openRailMenu,
@@ -45,6 +44,7 @@ import {
 import { restoreReadCursorToTail } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const SERVER_WINDOW = "Server";

--- a/cicchetto/e2e/tests/issue243-tap-active-scroll-bottom.spec.ts
+++ b/cicchetto/e2e/tests/issue243-tap-active-scroll-bottom.spec.ts
@@ -23,13 +23,13 @@
 // this rides the scroll-spec precedent (issue168, contamination, cp14-b1),
 // which assert scroll geometry only.
 
-import { type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { restoreReadCursorToTail } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
-const CHANNEL = AUTOJOIN_CHANNELS[0]!;
+const CHANNEL = AUTOJOIN_CHANNELS[0];
 const SCROLL_BOTTOM_THRESHOLD_PX = 50;
 
 async function distFromBottom(page: Page): Promise<number | null> {

--- a/cicchetto/e2e/tests/issue244-directory-tap-foreground.spec.ts
+++ b/cicchetto/e2e/tests/issue244-directory-tap-foreground.spec.ts
@@ -21,11 +21,11 @@
 //      branch (the onActivate handler is shared, but the selected marker +
 //      layout differ; jsdom is blind to both).
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { joinChannel, partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // "$list" — LIST_WINDOW_NAME from src/lib/windowKinds.ts. Hardcoded here
 // because the e2e tsconfig does not resolve src/ imports. A rename of the
@@ -33,173 +33,168 @@ import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../
 const LIST_WINDOW_NAME = "$list";
 
 test.describe("#244 directory tap foregrounds the joined window", () => {
-  test(
-    "DESKTOP — tapping an unjoined /list row joins it AND foregrounds its window",
-    async ({ page }) => {
-      const vjt = getSeededVjt();
-      // Per-run unique channel: a peer creates it (first joiner → +o) and
-      // STAYS joined so bahamut includes it in LIST replies (only non-empty
-      // channels appear in 322s). vjt never joins it → the /list row is
-      // UNJOINED, so a tap exercises the join+foreground path being fixed.
-      const channel = `#e2e244-${crypto.randomUUID().slice(0, 8)}`;
-      const peer = await IrcPeer.connect({
-        nick: `e2e244-${crypto.randomUUID().slice(0, 4)}`,
+  test("DESKTOP — tapping an unjoined /list row joins it AND foregrounds its window", async ({
+    page,
+  }) => {
+    const vjt = getSeededVjt();
+    // Per-run unique channel: a peer creates it (first joiner → +o) and
+    // STAYS joined so bahamut includes it in LIST replies (only non-empty
+    // channels appear in 322s). vjt never joins it → the /list row is
+    // UNJOINED, so a tap exercises the join+foreground path being fixed.
+    const channel = `#e2e244-${crypto.randomUUID().slice(0, 8)}`;
+    const peer = await IrcPeer.connect({
+      nick: `e2e244-${crypto.randomUUID().slice(0, 4)}`,
+    });
+    try {
+      await peer.join(channel);
+      await loginAs(page, vjt);
+
+      // Focus a real channel first so the "before" selection is a
+      // DIFFERENT window than the one we're about to tap. The foreground
+      // assertion is only meaningful as a TRANSITION away from here.
+      await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
+      await expect(sidebarWindow(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0])).toHaveClass(
+        /selected/,
+        { timeout: 10_000 },
+      );
+
+      // Open the channel directory for this network.
+      await sidebarWindow(page, NETWORK_SLUG, LIST_WINDOW_NAME)
+        .locator(".sidebar-window-btn")
+        .click();
+      await expect(page.locator(".directory-search")).toBeVisible({ timeout: 5_000 });
+
+      // Force a fresh LIST so the just-created channel is captured.
+      await page.locator(".directory-refresh").click();
+
+      const row = page.locator(".directory-row").filter({
+        has: page.locator(".directory-row-name", { hasText: channel }),
       });
-      try {
-        await peer.join(channel);
-        await loginAs(page, vjt);
+      await expect(row).toBeVisible({ timeout: 15_000 });
 
-        // Focus a real channel first so the "before" selection is a
-        // DIFFERENT window than the one we're about to tap. The foreground
-        // assertion is only meaningful as a TRANSITION away from here.
-        await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
-        await expect(sidebarWindow(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0])).toHaveClass(
-          /selected/,
-          { timeout: 10_000 },
-        );
+      // Precondition: the channel is NOT in vjt's sidebar (unjoined).
+      await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toHaveCount(0);
 
-        // Open the channel directory for this network.
-        await sidebarWindow(page, NETWORK_SLUG, LIST_WINDOW_NAME)
-          .locator(".sidebar-window-btn")
-          .click();
-        await expect(page.locator(".directory-search")).toBeVisible({ timeout: 5_000 });
+      // TAP the unjoined row → JOIN + FOREGROUND (#244).
+      await row.locator(".directory-row-name").click();
 
-        // Force a fresh LIST so the just-created channel is captured.
-        await page.locator(".directory-refresh").click();
-
-        const row = page.locator(".directory-row").filter({
-          has: page.locator(".directory-row-name", { hasText: channel }),
-        });
-        await expect(row).toBeVisible({ timeout: 15_000 });
-
-        // Precondition: the channel is NOT in vjt's sidebar (unjoined).
-        await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toHaveCount(0);
-
-        // TAP the unjoined row → JOIN + FOREGROUND (#244).
-        await row.locator(".directory-row-name").click();
-
-        // The channel enters the sidebar …
-        await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toHaveCount(1, {
-          timeout: 10_000,
-        });
-        // … AND becomes the selected window (the P0 fix). Focus originated at
-        // the tap, not at the join completing.
-        await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toHaveClass(/selected/, {
-          timeout: 10_000,
-        });
-        // The previously-focused window is no longer selected.
-        await expect(sidebarWindow(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0])).not.toHaveClass(
-          /selected/,
-        );
-      } finally {
-        await peer.disconnect("e2e244 desktop done");
-        await partChannel(vjt.token, NETWORK_SLUG, channel).catch(() => {});
-      }
-    },
-  );
-
-  test(
-    "DESKTOP no-steal — a server-originated (automatic) join does NOT foreground; selection stays put",
-    async ({ page }) => {
-      const vjt = getSeededVjt();
-      // A peer creates + holds a channel so the REST join below succeeds and
-      // is a real, non-empty channel. vjt does NOT tap it — the join is
-      // issued out-of-band via REST, mimicking an automatic re-join /
-      // cross-device join (server broadcasts window_pending → joined on the
-      // user topic, the exact path a reconnect auto-rejoin uses).
-      const channel = `#e2e244ns-${crypto.randomUUID().slice(0, 8)}`;
-      const peer = await IrcPeer.connect({
-        nick: `e2e244n-${crypto.randomUUID().slice(0, 4)}`,
+      // The channel enters the sidebar …
+      await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toHaveCount(1, {
+        timeout: 10_000,
       });
-      try {
-        await peer.join(channel);
-        await loginAs(page, vjt);
-
-        // Focus a channel — this is the window that MUST retain focus.
-        await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
-        await expect(sidebarWindow(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0])).toHaveClass(
-          /selected/,
-          { timeout: 10_000 },
-        );
-
-        // Out-of-band JOIN via REST (NOT a directory tap). Server flips the
-        // window state and broadcasts window_pending → joined on the user
-        // topic; cic mirrors state via setPending/setJoined but must NOT
-        // originate selection (#200/#125 invariant, preserved by #244).
-        await joinChannel(vjt.token, NETWORK_SLUG, channel);
-
-        // The join landed: its tab appears in the sidebar (the broadcast was
-        // processed) — so the no-steal assertion below can't pass by the
-        // join simply never arriving.
-        await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toHaveCount(1, {
-          timeout: 10_000,
-        });
-        // Give any (buggy) focus-steal a real window to fire before asserting
-        // absence, so this can't pass by racing the broadcast.
-        await page.waitForTimeout(1_000);
-
-        // Selection STAYED on the original window; the auto-joined channel is
-        // NOT foregrounded.
-        await expect(sidebarWindow(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0])).toHaveClass(
-          /selected/,
-        );
-        await expect(sidebarWindow(page, NETWORK_SLUG, channel)).not.toHaveClass(/selected/);
-      } finally {
-        await peer.disconnect("e2e244 no-steal done");
-        await partChannel(vjt.token, NETWORK_SLUG, channel).catch(() => {});
-      }
-    },
-  );
-
-  test(
-    "MOBILE @webkit — tapping an unjoined /list row foregrounds its window (BottomBar branch)",
-    async ({ page }) => {
-      const vjt = getSeededVjt();
-      const channel = `#e2e244m-${crypto.randomUUID().slice(0, 8)}`;
-      const peer = await IrcPeer.connect({
-        nick: `e2e244m-${crypto.randomUUID().slice(0, 4)}`,
+      // … AND becomes the selected window (the P0 fix). Focus originated at
+      // the tap, not at the join completing.
+      await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toHaveClass(/selected/, {
+        timeout: 10_000,
       });
-      try {
-        await peer.join(channel);
-        await loginAs(page, vjt);
+      // The previously-focused window is no longer selected.
+      await expect(sidebarWindow(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0])).not.toHaveClass(
+        /selected/,
+      );
+    } finally {
+      await peer.disconnect("e2e244 desktop done");
+      await partChannel(vjt.token, NETWORK_SLUG, channel).catch(() => {});
+    }
+  });
 
-        // On mobile the $list entry lives behind compose `/list` (the
-        // DirectoryPane has no BottomBar tab). Focus a channel to get a
-        // compose box, then open the directory from it. expectUnmount:
-        // selecting the list window unmounts the ComposeBox (Shell renders
-        // it only for kindHasScrollback kinds), so wait for the unmount
-        // rather than the textarea-empty signal (which races the unmount).
-        await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
-        await expect(sidebarWindow(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0])).toHaveClass(
-          /selected/,
-          { timeout: 10_000 },
-        );
-        await composeSend(page, "/list", { expectUnmount: true });
-        await expect(page.locator(".directory-search")).toBeVisible({ timeout: 5_000 });
+  test("DESKTOP no-steal — a server-originated (automatic) join does NOT foreground; selection stays put", async ({
+    page,
+  }) => {
+    const vjt = getSeededVjt();
+    // A peer creates + holds a channel so the REST join below succeeds and
+    // is a real, non-empty channel. vjt does NOT tap it — the join is
+    // issued out-of-band via REST, mimicking an automatic re-join /
+    // cross-device join (server broadcasts window_pending → joined on the
+    // user topic, the exact path a reconnect auto-rejoin uses).
+    const channel = `#e2e244ns-${crypto.randomUUID().slice(0, 8)}`;
+    const peer = await IrcPeer.connect({
+      nick: `e2e244n-${crypto.randomUUID().slice(0, 4)}`,
+    });
+    try {
+      await peer.join(channel);
+      await loginAs(page, vjt);
 
-        await page.locator(".directory-refresh").click();
-        const row = page.locator(".directory-row").filter({
-          has: page.locator(".directory-row-name", { hasText: channel }),
-        });
-        await expect(row).toBeVisible({ timeout: 15_000 });
-        await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toHaveCount(0);
+      // Focus a channel — this is the window that MUST retain focus.
+      await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
+      await expect(sidebarWindow(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0])).toHaveClass(
+        /selected/,
+        { timeout: 10_000 },
+      );
 
-        // Tap the unjoined row (touch gesture — iPhone 15 profile has
-        // hasTouch). onActivate is shared with desktop; the fix foregrounds.
-        await row.locator(".directory-row-name").tap();
+      // Out-of-band JOIN via REST (NOT a directory tap). Server flips the
+      // window state and broadcasts window_pending → joined on the user
+      // topic; cic mirrors state via setPending/setJoined but must NOT
+      // originate selection (#200/#125 invariant, preserved by #244).
+      await joinChannel(vjt.token, NETWORK_SLUG, channel);
 
-        await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toHaveCount(1, {
-          timeout: 10_000,
-        });
-        // BottomBar tab for the channel carries `.selected` (sidebarWindow
-        // resolves the BottomBar `.bottom-bar-tab` on mobile).
-        await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toHaveClass(/selected/, {
-          timeout: 10_000,
-        });
-      } finally {
-        await peer.disconnect("e2e244 mobile done");
-        await partChannel(vjt.token, NETWORK_SLUG, channel).catch(() => {});
-      }
-    },
-  );
+      // The join landed: its tab appears in the sidebar (the broadcast was
+      // processed) — so the no-steal assertion below can't pass by the
+      // join simply never arriving.
+      await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toHaveCount(1, {
+        timeout: 10_000,
+      });
+      // Give any (buggy) focus-steal a real window to fire before asserting
+      // absence, so this can't pass by racing the broadcast.
+      await page.waitForTimeout(1_000);
+
+      // Selection STAYED on the original window; the auto-joined channel is
+      // NOT foregrounded.
+      await expect(sidebarWindow(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0])).toHaveClass(/selected/);
+      await expect(sidebarWindow(page, NETWORK_SLUG, channel)).not.toHaveClass(/selected/);
+    } finally {
+      await peer.disconnect("e2e244 no-steal done");
+      await partChannel(vjt.token, NETWORK_SLUG, channel).catch(() => {});
+    }
+  });
+
+  test("MOBILE @webkit — tapping an unjoined /list row foregrounds its window (BottomBar branch)", async ({
+    page,
+  }) => {
+    const vjt = getSeededVjt();
+    const channel = `#e2e244m-${crypto.randomUUID().slice(0, 8)}`;
+    const peer = await IrcPeer.connect({
+      nick: `e2e244m-${crypto.randomUUID().slice(0, 4)}`,
+    });
+    try {
+      await peer.join(channel);
+      await loginAs(page, vjt);
+
+      // On mobile the $list entry lives behind compose `/list` (the
+      // DirectoryPane has no BottomBar tab). Focus a channel to get a
+      // compose box, then open the directory from it. expectUnmount:
+      // selecting the list window unmounts the ComposeBox (Shell renders
+      // it only for kindHasScrollback kinds), so wait for the unmount
+      // rather than the textarea-empty signal (which races the unmount).
+      await selectChannel(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0], { ownNick: NETWORK_NICK });
+      await expect(sidebarWindow(page, NETWORK_SLUG, AUTOJOIN_CHANNELS[0])).toHaveClass(
+        /selected/,
+        { timeout: 10_000 },
+      );
+      await composeSend(page, "/list", { expectUnmount: true });
+      await expect(page.locator(".directory-search")).toBeVisible({ timeout: 5_000 });
+
+      await page.locator(".directory-refresh").click();
+      const row = page.locator(".directory-row").filter({
+        has: page.locator(".directory-row-name", { hasText: channel }),
+      });
+      await expect(row).toBeVisible({ timeout: 15_000 });
+      await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toHaveCount(0);
+
+      // Tap the unjoined row (touch gesture — iPhone 15 profile has
+      // hasTouch). onActivate is shared with desktop; the fix foregrounds.
+      await row.locator(".directory-row-name").tap();
+
+      await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toHaveCount(1, {
+        timeout: 10_000,
+      });
+      // BottomBar tab for the channel carries `.selected` (sidebarWindow
+      // resolves the BottomBar `.bottom-bar-tab` on mobile).
+      await expect(sidebarWindow(page, NETWORK_SLUG, channel)).toHaveClass(/selected/, {
+        timeout: 10_000,
+      });
+    } finally {
+      await peer.disconnect("e2e244 mobile done");
+      await partChannel(vjt.token, NETWORK_SLUG, channel).catch(() => {});
+    }
+  });
 });

--- a/cicchetto/e2e/tests/issue245-scroll-remeasure-on-resize.spec.ts
+++ b/cicchetto/e2e/tests/issue245-scroll-remeasure-on-resize.spec.ts
@@ -35,7 +35,7 @@
 // engages and the real iOS height path (`body { height: calc(var(--vh) *
 // 100) }`) is exercised.
 
-import { type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { resetSubject } from "../fixtures/grappaApi";
 import {

--- a/cicchetto/e2e/tests/issue247-notify-watch.spec.ts
+++ b/cicchetto/e2e/tests/issue247-notify-watch.spec.ts
@@ -33,11 +33,11 @@
 // mid-spec failure can't strand the watch entry in vjt's durable list
 // for later specs.
 
-import { openSettingsDrawer, composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
-import { expect, test } from "../fixtures/test";
+import { composeSend, loginAs, openSettingsDrawer, selectChannel } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "i247-watched";
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/issue248-lusers-no-auto-surface.spec.ts
+++ b/cicchetto/e2e/tests/issue248-lusers-no-auto-surface.spec.ts
@@ -37,9 +37,9 @@
 // Per feedback_ux_e2e_mandatory: every cic UX-behavior change ships with
 // a Playwright e2e via scripts/integration.sh.
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 const PARK_REASON = "testing #248 lusers auto-surface";

--- a/cicchetto/e2e/tests/issue250-android-nick-select.spec.ts
+++ b/cicchetto/e2e/tests/issue250-android-nick-select.spec.ts
@@ -34,9 +34,9 @@
 // the default `auto` and the assertion fails. The `@webkit` twin is a
 // regression guard that iOS keeps the nick selectable after the change.
 
-import { test, expect } from "../fixtures/test";
 import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 // Date.now() suffix (house pattern): the e2e sqlite scrollback persists

--- a/cicchetto/e2e/tests/issue252-vhost-selector.spec.ts
+++ b/cicchetto/e2e/tests/issue252-vhost-selector.spec.ts
@@ -24,8 +24,8 @@
 // Per feedback_cicchetto_browser_smoke + feedback_ux_e2e_mandatory this
 // exercises the real CSS/DOM render path jsdom can't.
 
+import { expectShellReady, openAdminConsole, openSettingsDrawer } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
-import { openSettingsDrawer, expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
 import { getSeededAdmin, getSeededVjt } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 

--- a/cicchetto/e2e/tests/issue254-own-echo-live.spec.ts
+++ b/cicchetto/e2e/tests/issue254-own-echo-live.spec.ts
@@ -34,10 +34,10 @@
 // SUFFICIENT — the fix still HOLDS for the real-iOS-device verification batch
 // (#245/#250/#253/#254/#255).
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/issue255-close-x-touch-action.spec.ts
+++ b/cicchetto/e2e/tests/issue255-close-x-touch-action.spec.ts
@@ -35,9 +35,9 @@
 // reported surface). Both go through scripts/integration.sh --grep "#255".
 
 import type { Page } from "@playwright/test";
-import { test, expect } from "../fixtures/test";
 import { loginAs, selectChannel, sidebarCloseButton } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // #bofh is autojoined → its tab renders a close-× on BOTH layouts.
 const CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/issue256-vhost-inpool-enforce.spec.ts
+++ b/cicchetto/e2e/tests/issue256-vhost-inpool-enforce.spec.ts
@@ -16,10 +16,10 @@
 // pool"). #256 is a cic-only change, so the RED→GREEN leg here is the UI
 // enforce-forward (tick → checked + disabled), not the read-side OR.
 
-import { expect, test } from "../fixtures/test";
 import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
-import { getSeededAdmin } from "../fixtures/seedData";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 async function adminLogin(
   page: import("@playwright/test").Page,

--- a/cicchetto/e2e/tests/issue257-vhost-subject-autocomplete.spec.ts
+++ b/cicchetto/e2e/tests/issue257-vhost-subject-autocomplete.spec.ts
@@ -15,10 +15,10 @@
 // autocomplete lands a grant whose subject_id is the visitor UUID, not the
 // typed nick — is the value proof.
 
-import { expect, test } from "../fixtures/test";
 import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 async function adminLogin(
   page: import("@playwright/test").Page,
@@ -100,9 +100,7 @@ test("#257 — picking a visitor from the grant autocomplete stores its stable i
     // displaying "network - nickname".
     await input.fill(visitor.nick);
 
-    const option = page.getByTestId(
-      `subject-autocomplete-option-${vhostId}-visitor-${visitor.id}`,
-    );
+    const option = page.getByTestId(`subject-autocomplete-option-${vhostId}-visitor-${visitor.id}`);
     await expect(option).toBeVisible({ timeout: 10_000 });
     await expect(option).toContainText(`${visitor.network_slug} - ${visitor.nick}`);
 

--- a/cicchetto/e2e/tests/issue259-install-hint.spec.ts
+++ b/cicchetto/e2e/tests/issue259-install-hint.spec.ts
@@ -107,9 +107,7 @@ test.describe("issue259 install-hint — per-platform branch rendering", () => {
     expect(await arrow.innerText()).toContain("⋯");
   });
 
-  test("@webkit issue259 — standalone-mode PWA suppresses the install splash", async ({
-    page,
-  }) => {
+  test("@webkit issue259 — standalone-mode PWA suppresses the install splash", async ({ page }) => {
     // A launched-from-home-screen PWA has no Safari chrome to point at, so
     // the splash must not mount at all. isStandalonePwa() reads
     // navigator.standalone (iOS pre-17) — stub it true before boot.

--- a/cicchetto/e2e/tests/issue260-sticky-network-tab.spec.ts
+++ b/cicchetto/e2e/tests/issue260-sticky-network-tab.spec.ts
@@ -27,15 +27,15 @@
 // chromium run of `#260` is intentionally empty.
 
 import type { Page } from "@playwright/test";
-import { expect, test } from "../fixtures/test";
 import { loginAs, waitForUserTopicReady } from "../fixtures/cicchettoPage";
 import {
-  reapVisitors,
   GRAPPA_BASE_URL,
   type MintedVisitor,
   mintVisitor,
+  reapVisitors,
 } from "../fixtures/grappaApi";
 import { getSeededAdmin, getSeededVjt } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // Two separate ircds → distinct nick namespaces → ONE visitor can hold
 // both live with no 433 autokill (the #211 phase-7 topology). Two live
@@ -68,12 +68,12 @@ async function snapshotStrip(page: Page, scrollTo: number | "max"): Promise<Stri
     if (!bar) throw new Error("snapshotStrip: no .bottom-bar in the DOM");
     bar.scrollLeft = mode === "max" ? bar.scrollWidth : mode;
     const barRect = bar.getBoundingClientRect();
-    const headers = Array.from(
-      bar.querySelectorAll<HTMLElement>(".bottom-bar-network-header"),
-    ).map((h) => {
-      const r = h.getBoundingClientRect();
-      return { slug: h.getAttribute("data-network-slug") ?? "", left: r.left, right: r.right };
-    });
+    const headers = Array.from(bar.querySelectorAll<HTMLElement>(".bottom-bar-network-header")).map(
+      (h) => {
+        const r = h.getBoundingClientRect();
+        return { slug: h.getAttribute("data-network-slug") ?? "", left: r.left, right: r.right };
+      },
+    );
     const groups = Array.from(bar.querySelectorAll<HTMLElement>(".bottom-bar-network")).map((g) => {
       const r = g.getBoundingClientRect();
       const slug =

--- a/cicchetto/e2e/tests/issue262-topic-clamp-mobile.spec.ts
+++ b/cicchetto/e2e/tests/issue262-topic-clamp-mobile.spec.ts
@@ -25,12 +25,7 @@
 // it can set the topic before vjt joins); vjt PARTs it in `finally` and the
 // peer disconnects (dropping its membership → channel destroyed).
 
-import {
-  composeSend,
-  loginAs,
-  selectChannel,
-  sidebarWindow,
-} from "../fixtures/cicchettoPage";
+import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";

--- a/cicchetto/e2e/tests/issue264-next-active-btn-mobile.spec.ts
+++ b/cicchetto/e2e/tests/issue264-next-active-btn-mobile.spec.ts
@@ -53,8 +53,8 @@
 // channel accrues unread; the peer disconnects in `finally`.
 
 import { loginAs, selectChannel, sidebarMessageBadge } from "../fixtures/cicchettoPage";
-import { IrcPeer } from "../fixtures/ircClient";
 import { assertMessagePersisted } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
@@ -145,12 +145,14 @@ test("#264 @webkit — mobile next-active button is a keyboard-safe circle (≥4
       Math.abs(unfocused.width - unfocused.height),
       `circle must be symmetric: width ${unfocused.width}px vs height ${unfocused.height}px`,
     ).toBeLessThanOrEqual(SQUARE_TOLERANCE_PX);
-    expect(unfocused.width, `width ${unfocused.width}px must be ≥ ${MIN_TAP_PX}px (HIG)`).toBeGreaterThanOrEqual(
-      MIN_TAP_PX,
-    );
-    expect(unfocused.height, `height ${unfocused.height}px must be ≥ ${MIN_TAP_PX}px (HIG)`).toBeGreaterThanOrEqual(
-      MIN_TAP_PX,
-    );
+    expect(
+      unfocused.width,
+      `width ${unfocused.width}px must be ≥ ${MIN_TAP_PX}px (HIG)`,
+    ).toBeGreaterThanOrEqual(MIN_TAP_PX);
+    expect(
+      unfocused.height,
+      `height ${unfocused.height}px must be ≥ ${MIN_TAP_PX}px (HIG)`,
+    ).toBeGreaterThanOrEqual(MIN_TAP_PX);
     expect(
       isRound(unfocused.borderRadius, unfocused.width),
       `border-radius ${unfocused.borderRadius} must render the ${unfocused.width}px box as a circle`,

--- a/cicchetto/e2e/tests/issue265-activity-messages-only.spec.ts
+++ b/cicchetto/e2e/tests/issue265-activity-messages-only.spec.ts
@@ -22,7 +22,6 @@
 // or a missing-locator timeout. Under the total gate #bofh's `eventsUnread`
 // bumps the count to 2; under the message-scoped gate it contributes 0.
 
-import { expect, test } from "../fixtures/test";
 import {
   loginAs,
   selectChannel,
@@ -33,6 +32,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const DM_LINE = "265 direct message counts";

--- a/cicchetto/e2e/tests/issue267-mention-server-authoritative.spec.ts
+++ b/cicchetto/e2e/tests/issue267-mention-server-authoritative.spec.ts
@@ -203,13 +203,3 @@ test("#267 — mention on an unfocused channel fans out from the server to both 
     await ctxB.close();
   }
 });
-
-declare global {
-  interface Window {
-    __cic_dropSocketForTests?: () => Promise<void>;
-    __cic_resumeSocketForTests?: () => Promise<void>;
-    __cic_socketHealth?: {
-      state: () => { state: string };
-    };
-  }
-}

--- a/cicchetto/e2e/tests/issue267-mention-server-authoritative.spec.ts
+++ b/cicchetto/e2e/tests/issue267-mention-server-authoritative.spec.ts
@@ -27,20 +27,11 @@
 //      server to BOTH tabs' badges (one shared truth, not two
 //      independently-computed counts).
 
-import { expect, test } from "../fixtures/test";
-import {
-  loginAs,
-  selectChannel,
-  sidebarMentionBadge,
-} from "../fixtures/cicchettoPage";
+import { loginAs, selectChannel, sidebarMentionBadge } from "../fixtures/cicchettoPage";
 import { assertMessagePersisted, restoreReadCursorToTail } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
-import {
-  AUTOJOIN_CHANNELS,
-  getSeededVjt,
-  NETWORK_NICK,
-  NETWORK_SLUG,
-} from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const SERVER_WINDOW = "Server";

--- a/cicchetto/e2e/tests/issue269-visitor-reconnect-toggle.spec.ts
+++ b/cicchetto/e2e/tests/issue269-visitor-reconnect-toggle.spec.ts
@@ -22,10 +22,10 @@
 // toggle reads Disconnect + the badge reads "● N chan". Not DOM cosmetics
 // alone: the session genuinely goes down then up on the SPECIFIC network.
 
-import { expect, test } from "../fixtures/test";
 import { openAdminConsole } from "../fixtures/cicchettoPage";
-import { getSeededAdmin } from "../fixtures/seedData";
 import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 async function adminOpenVisitorsTab(
   page: import("@playwright/test").Page,

--- a/cicchetto/e2e/tests/issue270-peer-away-overlap.spec.ts
+++ b/cicchetto/e2e/tests/issue270-peer-away-overlap.spec.ts
@@ -22,7 +22,6 @@
 // P-0b away-peer + DM setup on the real testnet path (no stub) and the
 // issue278 overlapArea geometry style.
 
-import { test, expect } from "../fixtures/test";
 import {
   composeSend,
   loginAs,
@@ -33,6 +32,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "t270-away-peer";
 const AWAY_MESSAGE = "Gone fishing — back at 5pm";

--- a/cicchetto/e2e/tests/issue274-pwa-icons.spec.ts
+++ b/cicchetto/e2e/tests/issue274-pwa-icons.spec.ts
@@ -45,8 +45,7 @@ test.describe("#274 real PWA icon set", () => {
     // Non-vacuous: prove we fetched the real cic manifest, not a fallback.
     expect(manifest.id, "manifest.id").toBe("/cic");
 
-    const icons: Array<{ src: string; sizes: string; purpose: string }> =
-      manifest.icons;
+    const icons: Array<{ src: string; sizes: string; purpose: string }> = manifest.icons;
     expect(Array.isArray(icons) && icons.length > 0, "manifest.icons").toBe(true);
 
     // #274 contract: a full-bleed `any` set AND a safe-zone `maskable` set,
@@ -61,10 +60,10 @@ test.describe("#274 real PWA icon set", () => {
 
     for (const purpose of ["any", "maskable"] as const) {
       const set = icons.filter((i) => i.purpose === purpose);
-      expect(
-        set.map((i) => i.sizes).sort(),
-        `${purpose} set sizes`,
-      ).toEqual(["192x192", "512x512"]);
+      expect(set.map((i) => i.sizes).sort(), `${purpose} set sizes`).toEqual([
+        "192x192",
+        "512x512",
+      ]);
     }
 
     // Every declared icon must actually be served, be a PNG, and match its
@@ -72,10 +71,7 @@ test.describe("#274 real PWA icon set", () => {
     for (const icon of icons) {
       const asset = await request.get(icon.src);
       expect(asset.status(), `GET ${icon.src}`).toBe(200);
-      expect(
-        asset.headers()["content-type"],
-        `${icon.src} content-type`,
-      ).toContain("image/png");
+      expect(asset.headers()["content-type"], `${icon.src} content-type`).toContain("image/png");
       const { width, height } = pngDimensions(await asset.body());
       const n = sizeOf(icon.sizes);
       expect({ src: icon.src, width, height }).toEqual({
@@ -105,9 +101,7 @@ test.describe("#274 real PWA icon set", () => {
     expect(buf.readUInt16LE(4), "ICO image count").toBeGreaterThan(0);
   });
 
-  test("the SVG favicon (/icon.svg — the single source vector) is served", async ({
-    request,
-  }) => {
+  test("the SVG favicon (/icon.svg — the single source vector) is served", async ({ request }) => {
     const res = await request.get("/icon.svg");
     expect(res.status(), "GET /icon.svg").toBe(200);
     expect(res.headers()["content-type"], "content-type").toContain("image/svg+xml");

--- a/cicchetto/e2e/tests/issue276-away-emoji-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue276-away-emoji-badge.spec.ts
@@ -27,10 +27,10 @@
 // for the next spec. Away is transient (not persisted), but a leaked
 // badge would confuse a later assertion on the same sidebar row.
 
-import { test, expect } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { fetchAllMessagesAsc } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 const SERVER_WINDOW = "$server";
@@ -87,8 +87,6 @@ test("#276 — self /away shows the 💤 badge (not the word away) + writes no $
   // :notice rows from connect, so filter for the away-ack numerics
   // specifically — any such row is the bug this issue removes.
   const serverRows = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, SERVER_WINDOW);
-  const awayAckRows = serverRows.filter(
-    (r) => r.meta?.numeric === 305 || r.meta?.numeric === 306,
-  );
+  const awayAckRows = serverRows.filter((r) => r.meta?.numeric === 305 || r.meta?.numeric === 306);
   expect(awayAckRows).toEqual([]);
 });

--- a/cicchetto/e2e/tests/issue278-next-active-send-overlap.spec.ts
+++ b/cicchetto/e2e/tests/issue278-next-active-send-overlap.spec.ts
@@ -41,9 +41,14 @@
 // mounts a compose box), so the channel accrues unread while we have a
 // compose box to focus; the peer disconnects in `finally`.
 
-import { composeTextarea, loginAs, selectChannel, sidebarMessageBadge } from "../fixtures/cicchettoPage";
-import { IrcPeer } from "../fixtures/ircClient";
+import {
+  composeTextarea,
+  loginAs,
+  selectChannel,
+  sidebarMessageBadge,
+} from "../fixtures/cicchettoPage";
 import { assertMessagePersisted } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
@@ -153,7 +158,10 @@ test("#278 @webkit — with the keyboard open the next-active circle does not ov
       const vp = page.viewportSize();
       expect(vp, "viewport size must be known").not.toBeNull();
       if (vp) {
-        expect(na.y, `next-active top ${na.y.toFixed(0)} must be ≥ 0 (on-screen)`).toBeGreaterThanOrEqual(0);
+        expect(
+          na.y,
+          `next-active top ${na.y.toFixed(0)} must be ≥ 0 (on-screen)`,
+        ).toBeGreaterThanOrEqual(0);
         expect(
           na.y + na.height,
           `next-active bottom ${(na.y + na.height).toFixed(0)} must be ≤ viewport height ${vp.height}`,

--- a/cicchetto/e2e/tests/issue280-button-coexist.spec.ts
+++ b/cicchetto/e2e/tests/issue280-button-coexist.spec.ts
@@ -37,19 +37,23 @@
 // (auto-hidden via `<Show when={hasActiveWindows()}>`) would trivially
 // satisfy a no-overlap / size check.
 
-import { type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import {
   composeTextarea,
   loginAs,
   scrollbackLines,
   selectChannel,
 } from "../fixtures/cicchettoPage";
-import { assertMessagePersisted, partChannel, restoreReadCursorToTail } from "../fixtures/grappaApi";
+import {
+  assertMessagePersisted,
+  partChannel,
+  restoreReadCursorToTail,
+} from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
-const CHANNEL = AUTOJOIN_CHANNELS[0]!;
+const CHANNEL = AUTOJOIN_CHANNELS[0];
 const SCROLL_BOTTOM_THRESHOLD_PX = 50;
 
 const SCROLL_TO_BOTTOM = '[data-testid="scroll-to-bottom"]';

--- a/cicchetto/e2e/tests/issue281-account-switch-no-replay.spec.ts
+++ b/cicchetto/e2e/tests/issue281-account-switch-no-replay.spec.ts
@@ -59,7 +59,11 @@
 // genuine phantom, and (b) the real B login spawns NO upstream Session.Server,
 // so it can't dangle a session / cascade (feedback_e2e_real_login_poisons_shared_stack).
 
-import { waitForChannelReady, waitForScrollbackRefreshed, openRailMenu } from "../fixtures/cicchettoPage";
+import {
+  openRailMenu,
+  waitForChannelReady,
+  waitForScrollbackRefreshed,
+} from "../fixtures/cicchettoPage";
 import { login } from "../fixtures/grappaApi";
 import {
   ADMIN_IDENTIFIER,
@@ -128,7 +132,8 @@ test.describe("issue #281 — account switch replay", () => {
         setItem.call(this, key, value);
       };
       Storage.prototype.removeItem = function (key: string): void {
-        if (key === "grappa-token") w.__cic281Identity?.push({ token: null, at: performance.now() });
+        if (key === "grappa-token")
+          w.__cic281Identity?.push({ token: null, at: performance.now() });
         removeItem.call(this, key);
       };
     });
@@ -221,8 +226,7 @@ test.describe("issue #281 — account switch replay", () => {
           const isAMessages =
             path.includes(`/networks/${slug}/channels/`) && path.includes("/messages");
           const isAFeatured =
-            path === `/networks/${slug}/featured` ||
-            path.startsWith(`/networks/${slug}/featured?`);
+            path === `/networks/${slug}/featured` || path.startsWith(`/networks/${slug}/featured?`);
           return isAMessages || isAFeatured;
         }),
         identity: w.__cic281Identity,

--- a/cicchetto/e2e/tests/issue282-vhost-reconnect-button.spec.ts
+++ b/cicchetto/e2e/tests/issue282-vhost-reconnect-button.spec.ts
@@ -29,10 +29,14 @@
 // renders regardless of whether the e2e testnet seeds a vhost inventory.
 
 import type { Browser, Page } from "@playwright/test";
-import { expect, test } from "../fixtures/test";
-import { openSettingsDrawer, expectShellReady, waitForUserTopicReady } from "../fixtures/cicchettoPage";
+import {
+  expectShellReady,
+  openSettingsDrawer,
+  waitForUserTopicReady,
+} from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const ANCHOR = "azzurra";
 

--- a/cicchetto/e2e/tests/issue283-home-disconnect.spec.ts
+++ b/cicchetto/e2e/tests/issue283-home-disconnect.spec.ts
@@ -22,7 +22,6 @@
 // (4) confirming actually parks the network (REST is source-of-truth);
 // (5) the row swaps to the parked state with a Reconnect chip.
 
-import { expect, test } from "../fixtures/test";
 import {
   confirmModal,
   confirmModalBody,
@@ -33,6 +32,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { patchNetworkConnectionState, type SeededUser } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const GRAPPA_BASE_URL = "http://grappa-test:4000";
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/issue284-password-always-visible.spec.ts
+++ b/cicchetto/e2e/tests/issue284-password-always-visible.spec.ts
@@ -30,7 +30,9 @@ test.describe("#284 password always-visible + optional", () => {
     await expect(page.getByLabel(/nick or email/i)).toBeVisible({ timeout: 10_000 });
   });
 
-  test("password is visible on the main form by default (not behind Advanced)", async ({ page }) => {
+  test("password is visible on the main form by default (not behind Advanced)", async ({
+    page,
+  }) => {
     // No Advanced expand — the password is right there on the first screen.
     await expect(page.getByLabel(/password/i)).toBeVisible();
 

--- a/cicchetto/e2e/tests/issue285-scroll-lock-resizeobserver.spec.ts
+++ b/cicchetto/e2e/tests/issue285-scroll-lock-resizeobserver.spec.ts
@@ -141,7 +141,7 @@ test("@webkit #285 reopen — .scrollback base is fail-open pan-y and the lock g
   // the dead `touch-action: none` the old fail-CLOSED base baked. Strip + read
   // + restore synchronously inside one evaluate so Solid's reactive classList
   // can't re-assert mid-read (no race).
-  const baseTouchAction = await scrollback.evaluate((el) => {
+  const baseTouchAction = await scrollback.evaluate((el: HTMLElement) => {
     const prev = el.className;
     el.className = "scrollback";
     const ta = getComputedStyle(el).touchAction;

--- a/cicchetto/e2e/tests/issue285-scroll-lock-resizeobserver.spec.ts
+++ b/cicchetto/e2e/tests/issue285-scroll-lock-resizeobserver.spec.ts
@@ -35,7 +35,7 @@
 // engages and the real iOS height path drives `.scrollback`'s clientHeight —
 // mirrors issue245-scroll-remeasure-on-resize.spec.ts (its direct sibling).
 
-import { type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { resetSubject } from "../fixtures/grappaApi";
 import {

--- a/cicchetto/e2e/tests/issue289-float-btn-opacity.spec.ts
+++ b/cicchetto/e2e/tests/issue289-float-btn-opacity.spec.ts
@@ -27,19 +27,23 @@
 // (an `opacity`-less element, or one gated out via `<Show>`) would
 // trivially satisfy an opacity check.
 
-import { type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import {
   composeTextarea,
   loginAs,
   scrollbackLines,
   selectChannel,
 } from "../fixtures/cicchettoPage";
-import { assertMessagePersisted, partChannel, restoreReadCursorToTail } from "../fixtures/grappaApi";
+import {
+  assertMessagePersisted,
+  partChannel,
+  restoreReadCursorToTail,
+} from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
-const CHANNEL = AUTOJOIN_CHANNELS[0]!;
+const CHANNEL = AUTOJOIN_CHANNELS[0];
 const SCROLL_BOTTOM_THRESHOLD_PX = 50;
 
 const SCROLL_TO_BOTTOM = '[data-testid="scroll-to-bottom"]';
@@ -125,9 +129,7 @@ async function scrollChannelUp(page: Page): Promise<void> {
 // CHANNEL scrolled up. Returns the peer + bg channel so the caller's
 // `finally` can tear them down. Shared by the #289 opacity test and the
 // #302 hover-latch test — one setup, two contracts.
-async function surfaceBothFloatButtons(
-  page: Page,
-): Promise<{ peer: IrcPeer; bgChannel: string }> {
+async function surfaceBothFloatButtons(page: Page): Promise<{ peer: IrcPeer; bgChannel: string }> {
   const vjt = getSeededVjt();
   const peerNick = `t289-${Date.now() % 100000}`;
   const bgChannel = "#t289op";
@@ -249,9 +251,7 @@ test.describe("#302 — mobile float buttons don't latch :hover 'selected' after
     try {
       // Precondition: this project emulates a hover-less (touch) pointer —
       // the whole bug is that such a pointer must never latch `:hover`.
-      const hoverNone = await page.evaluate(
-        () => window.matchMedia("(hover: none)").matches,
-      );
+      const hoverNone = await page.evaluate(() => window.matchMedia("(hover: none)").matches);
       expect(
         hoverNone,
         "webkit-iphone-15 must emulate a hover-less pointer for this contract to witness the fix",

--- a/cicchetto/e2e/tests/issue290-services-modal.spec.ts
+++ b/cicchetto/e2e/tests/issue290-services-modal.spec.ts
@@ -27,8 +27,8 @@
 // compose.test.ts. This spec is the browser integration proof.
 
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
-import { expect, test } from "../fixtures/test";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/issue291-mobile-home-button.spec.ts
+++ b/cicchetto/e2e/tests/issue291-mobile-home-button.spec.ts
@@ -78,9 +78,7 @@ test.describe("#291 — home launcher in the rail actions drawer", () => {
     await setAdminFlag(admin.token, vjtUserId, false);
   });
 
-  test("@webkit home launcher: all rail buttons ≥44px, tap returns to home", async ({
-    page,
-  }) => {
+  test("@webkit home launcher: all rail buttons ≥44px, tap returns to home", async ({ page }) => {
     const admin = getSeededAdmin();
     await setAdminFlag(admin.token, vjtUserId, true);
 

--- a/cicchetto/e2e/tests/issue294-builtin-bg-picker.spec.ts
+++ b/cicchetto/e2e/tests/issue294-builtin-bg-picker.spec.ts
@@ -14,7 +14,12 @@
 // iso-rerun at --repeat-each N. Server-side persistence of a `builtin` payload
 // is already pinned by the Elixir token_model + controller tests.
 
-import { loginAs, openSettingsDrawer, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
+import {
+  loginAs,
+  openSettingsDrawer,
+  selectChannel,
+  sidebarWindow,
+} from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 

--- a/cicchetto/e2e/tests/issue299-theme-cards.spec.ts
+++ b/cicchetto/e2e/tests/issue299-theme-cards.spec.ts
@@ -88,7 +88,9 @@ test.describe("#299 — theme cards (tap-select + progressive disclosure)", () =
 
     // Tap the first card → its (and ONLY its) action row appears.
     await selects.first().tap();
-    await expect(page.locator("[data-testid^='theme-actions-']")).toHaveCount(1, { timeout: 5_000 });
+    await expect(page.locator("[data-testid^='theme-actions-']")).toHaveCount(1, {
+      timeout: 5_000,
+    });
 
     // The revealed copy button is a proper ≥44px tap target.
     const copyBtn = page.locator("[data-testid^='theme-copy-']").first();
@@ -100,7 +102,9 @@ test.describe("#299 — theme cards (tap-select + progressive disclosure)", () =
 
     // Tapping a DIFFERENT card moves the disclosure — still exactly one row.
     await selects.nth(1).tap();
-    await expect(page.locator("[data-testid^='theme-actions-']")).toHaveCount(1, { timeout: 5_000 });
+    await expect(page.locator("[data-testid^='theme-actions-']")).toHaveCount(1, {
+      timeout: 5_000,
+    });
   });
 
   test("a minted visitor copies a built-in and gets manage actions on the owned copy", async ({
@@ -198,9 +202,7 @@ test.describe("#299 — theme cards (tap-select + progressive disclosure)", () =
       // Re-open the gallery (forces a fresh fetch): the nick snapshot STILL
       // shows — NOT "system" (the new owner), NOT the "guest" fallback.
       await reopenGalleryDesktop(page);
-      const authorAfter = page.locator(
-        `[data-testid="theme-card-${themeId}"] .theme-card-author`,
-      );
+      const authorAfter = page.locator(`[data-testid="theme-card-${themeId}"] .theme-card-author`);
       await expect(authorAfter).toBeVisible({ timeout: 5_000 });
       await expect(authorAfter).toContainText(visitor.nick);
     } finally {
@@ -225,6 +227,13 @@ test.describe("#299 — theme cards (tap-select + progressive disclosure)", () =
         cleanupErrors.push(err);
       }
       if (cleanupErrors.length > 0) {
+        // Deliberate: a failed cleanup leaves a visitor (and a published
+        // gallery theme) behind on the shared stack, which poisons every spec
+        // that runs after this one — so it MUST fail the test even though a
+        // throw from `finally` can mask an in-flight body error. The masking is
+        // the accepted cost of never letting a leak pass silently; the comment
+        // above states the same intent.
+        // biome-ignore lint/correctness/noUnsafeFinally: a cleanup leak must fail loud, see above
         throw new AggregateError(cleanupErrors, "issue299 cleanup failed");
       }
     }

--- a/cicchetto/e2e/tests/issue30-channel-tab-completion.spec.ts
+++ b/cicchetto/e2e/tests/issue30-channel-tab-completion.spec.ts
@@ -43,7 +43,6 @@
 // round-trip. jsdom/vitest can seed the store but cannot prove the store is
 // the thing the completion reads in a real browser on a real socket.
 
-import { IrcPeer } from "../fixtures/ircClient";
 import {
   composeSend,
   composeTextarea,
@@ -51,6 +50,7 @@ import {
   loginAs,
   selectChannel,
 } from "../fixtures/cicchettoPage";
+import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 

--- a/cicchetto/e2e/tests/issue310-scroll-to-bottom-btn-cursor.spec.ts
+++ b/cicchetto/e2e/tests/issue310-scroll-to-bottom-btn-cursor.spec.ts
@@ -45,7 +45,7 @@
 // touch CONTRACT, not a device-physics repro; the deterministic cursor-persist
 // assertion is the authoritative mechanism proof on both.
 
-import { type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { getReadCursor, restoreReadCursorToTail, setReadCursorToId } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
@@ -71,10 +71,7 @@ async function distFromBottom(page: Page): Promise<number> {
 // Latest REST page (DESC by server_time; rows[0] is the newest) — used to pick a
 // known message id for the mid-page cursor seed + the tail id we expect the tap
 // to advance to. Mirror of the #168 local helper.
-async function fetchScrollbackPage(
-  token: string,
-  channel: string,
-): Promise<Array<{ id: number }>> {
+async function fetchScrollbackPage(token: string, channel: string): Promise<Array<{ id: number }>> {
   const url = `http://grappa-test:4000/networks/${encodeURIComponent(
     NETWORK_SLUG,
   )}/channels/${encodeURIComponent(channel)}/messages`;

--- a/cicchetto/e2e/tests/issue319-landscape-compact-shell.spec.ts
+++ b/cicchetto/e2e/tests/issue319-landscape-compact-shell.spec.ts
@@ -32,9 +32,9 @@
 // Parity matrix per `feedback_e2e_user_class_parity_matrix`: this is a
 // UI-shape/layout contract, subject-shape-agnostic. Registered seed suffices.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -44,7 +44,7 @@ test.use({ viewport: { width: 844, height: 390 } });
 
 test.setTimeout(60_000);
 
-test("#319 landscape 5\" — slim proportioned rails, center gets the majority, single-line topic", async ({
+test('#319 landscape 5" — slim proportioned rails, center gets the majority, single-line topic', async ({
   page,
 }) => {
   const vjt = getSeededVjt();
@@ -105,9 +105,7 @@ test("#319 landscape 5\" — slim proportioned rails, center gets the majority, 
   // name of width). scrollWidth ≤ clientWidth means the text is not clipped.
   const channelName = page.locator(".topic-bar-channel").first();
   await expect(channelName).toBeVisible();
-  const nameFits = await channelName.evaluate(
-    (el) => el.scrollWidth <= el.clientWidth + 1,
-  );
+  const nameFits = await channelName.evaluate((el) => el.scrollWidth <= el.clientWidth + 1);
   expect(nameFits, "#319 — channel name must not be ellipsis-truncated in landscape-compact").toBe(
     true,
   );

--- a/cicchetto/e2e/tests/issue327-bottombar-scroll-into-view.spec.ts
+++ b/cicchetto/e2e/tests/issue327-bottombar-scroll-into-view.spec.ts
@@ -32,9 +32,19 @@
 // `finally` (before the wrapped-test vjt reset), so the shared bahamut-test
 // stack is left exactly as found.
 
-import { loginAs, selectChannel, sidebarMessageBadge, sidebarWindow } from "../fixtures/cicchettoPage";
+import {
+  loginAs,
+  selectChannel,
+  sidebarMessageBadge,
+  sidebarWindow,
+} from "../fixtures/cicchettoPage";
+import {
+  assertMessagePersisted,
+  joinChannel,
+  partChannel,
+  restoreReadCursorToTail,
+} from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
-import { assertMessagePersisted, joinChannel, partChannel, restoreReadCursorToTail } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 

--- a/cicchetto/e2e/tests/issue332-mobile-themes-wrap-glyph.spec.ts
+++ b/cicchetto/e2e/tests/issue332-mobile-themes-wrap-glyph.spec.ts
@@ -41,12 +41,7 @@ import {
   selectChannel,
   sidebarWindow,
 } from "../fixtures/cicchettoPage";
-import {
-  AUTOJOIN_CHANNELS,
-  NETWORK_NICK,
-  NETWORK_SLUG,
-  getSeededVjt,
-} from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/issue333-themes-personal-gallery.spec.ts
+++ b/cicchetto/e2e/tests/issue333-themes-personal-gallery.spec.ts
@@ -18,8 +18,8 @@
 // before/after the fix targets. Desktop chromium: the sections + scroll are
 // layout-agnostic and the editor is a JS flow.
 
-import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { openSettingsDrawer } from "../fixtures/cicchettoPage";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
@@ -133,7 +133,8 @@ test.describe("#333 — themes personal/gallery + copy UX + delete confirm", () 
       await openThemes(page);
 
       // Copy a gallery theme → owned copy with the base's name.
-      const firstCardName = await page.locator("[data-testid^='theme-select-'] .theme-card-name")
+      const firstCardName = await page
+        .locator("[data-testid^='theme-select-'] .theme-card-name")
         .first()
         .innerText();
       const selects = page.locator("[data-testid^='theme-select-']");

--- a/cicchetto/e2e/tests/issue350-link-tap-keyboard.spec.ts
+++ b/cicchetto/e2e/tests/issue350-link-tap-keyboard.spec.ts
@@ -25,9 +25,9 @@
 // keeps focus. RED pre-fix (short tap on a selectable surface is let
 // through → not prevented). Real-device keyboard smoke stays vjt's iPhone.
 
-import { test, expect } from "../fixtures/test";
 import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 // Date.now() suffix (house pattern, see text-selection-restored spec): the
@@ -57,7 +57,11 @@ test("@webkit iOS — a short tap on a scrollback link keeps the keyboard (mouse
   const result = await link.evaluate((linkEl) => {
     const ta = document.querySelector(".compose-box textarea");
     if (!(ta instanceof HTMLTextAreaElement)) {
-      return { error: "no compose textarea" as string | null, prevented: false, activeIsCompose: false };
+      return {
+        error: "no compose textarea" as string | null,
+        prevented: false,
+        activeIsCompose: false,
+      };
     }
     // Precondition: compose focused — the bug only bites while an input
     // has focus (that's when keepKeyboard arms its focus-shift prevent).

--- a/cicchetto/e2e/tests/issue352-global-paste.spec.ts
+++ b/cicchetto/e2e/tests/issue352-global-paste.spec.ts
@@ -15,15 +15,10 @@
 // dispatched on document.body drives the production listener deterministically,
 // the same path a real Ctrl+V takes minus the OS-clipboard permission dance.
 
-import { expect, test } from "../fixtures/test";
-import {
-  composeTextarea,
-  confirmModal,
-  loginAs,
-  selectChannel,
-} from "../fixtures/cicchettoPage";
-import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import type { Page } from "@playwright/test";
+import { composeTextarea, confirmModal, loginAs, selectChannel } from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/issue356-notify-highlight-feedback.spec.ts
+++ b/cicchetto/e2e/tests/issue356-notify-highlight-feedback.spec.ts
@@ -20,10 +20,16 @@
 // parameterize (the parity-matrix rule applies only to subject-shaped
 // surfaces). The deep presence protocol arm lives in issue247-notify-watch.
 
-import { openSettingsDrawer, composeSend, composeTextarea, loginAs, selectChannel } from "../fixtures/cicchettoPage";
-import { expect, test } from "../fixtures/test";
+import {
+  composeSend,
+  composeTextarea,
+  loginAs,
+  openSettingsDrawer,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 const PEER_NICK = "i356-watched";
@@ -96,7 +102,10 @@ test("#356 — bare /notify and bare /hilight open the watch-lists section; home
   await expect(subpage).toHaveCount(0);
 
   // Home no longer shows the standalone watched list (moved to settings).
-  await page.locator(".sidebar-channel-name").filter({ hasText: /^Home$/ }).click();
+  await page
+    .locator(".sidebar-channel-name")
+    .filter({ hasText: /^Home$/ })
+    .click();
   await expect(page.locator(".watched-panel")).toHaveCount(0);
   await expect(page.getByTestId(`watched-panel-${NETWORK_SLUG}`)).toHaveCount(0);
 });

--- a/cicchetto/e2e/tests/issue360-scroll-to-bottom-mention-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue360-scroll-to-bottom-mention-badge.spec.ts
@@ -24,7 +24,7 @@
 // scroll-geometry-spec precedent (#168, #243, #280-coexist) which pins
 // geometry on one engine rather than the user-class parity matrix.
 
-import { type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { loginAs, scrollbackLine, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { assertMessagePersisted, partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
@@ -241,7 +241,7 @@ test.describe("#360 — mention-aware scroll-to-bottom badge", () => {
       for (let i = 0; i < TRAILING; i++) buffer.push(filler(LEADING + MIDDLE + i));
       for (let i = 0; i < buffer.length; i++) {
         if (i >= FLOOD_SAFE_BURST) await sleep(PACE_MS);
-        peer.privmsg(channel, buffer[i]!);
+        peer.privmsg(channel, buffer[i]);
       }
 
       // Confirm the burst persisted server-side. The peer sends on ONE ordered

--- a/cicchetto/e2e/tests/issue360-scroll-to-bottom-mention-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue360-scroll-to-bottom-mention-badge.spec.ts
@@ -28,6 +28,7 @@ import { type Page } from "@playwright/test";
 import { loginAs, scrollbackLine, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { assertMessagePersisted, partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
+import { forwardPageDiagnostics } from "../fixtures/pageDiagnostics";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
@@ -211,16 +212,7 @@ test.describe("#360 — mention-aware scroll-to-bottom badge", () => {
     test.setTimeout(150_000);
     // Surface cic console errors / uncaught page errors so a wiring regression
     // (e.g. the badge signal throwing) is legible in the run log.
-    page.on("console", (msg) => {
-      if (msg.type() === "error" || msg.type() === "warn") {
-        // eslint-disable-next-line no-console
-        console.log(`[cic:${msg.type()}] ${msg.text()}`);
-      }
-    });
-    page.on("pageerror", (err) => {
-      // eslint-disable-next-line no-console
-      console.log(`[cic:pageerror] ${err.message}`);
-    });
+    forwardPageDiagnostics(page);
 
     const vjt = getSeededVjt();
     const channel = `#i360m-${Date.now() % 100000}`;

--- a/cicchetto/e2e/tests/issue361-mobile-list-launcher.spec.ts
+++ b/cicchetto/e2e/tests/issue361-mobile-list-launcher.spec.ts
@@ -24,12 +24,7 @@
 // base user sees it.
 
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
-import {
-  AUTOJOIN_CHANNELS,
-  getSeededVjt,
-  NETWORK_NICK,
-  NETWORK_SLUG,
-} from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/issue363-incognito.spec.ts
+++ b/cicchetto/e2e/tests/issue363-incognito.spec.ts
@@ -11,8 +11,8 @@
 // Copy is deliberately NOT asserted: the checkbox keys off its data-testid,
 // so vjt's final (pending) wording swap can never break this spec.
 
-import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { openSettingsDrawer } from "../fixtures/cicchettoPage";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 

--- a/cicchetto/e2e/tests/issue364-usertopic-rejoin-on-rotation.spec.ts
+++ b/cicchetto/e2e/tests/issue364-usertopic-rejoin-on-rotation.spec.ts
@@ -26,7 +26,12 @@
 // user, so the rebuilt socket authenticates as the identical identity.
 
 import type { Page } from "@playwright/test";
-import { composeSend, loginAs, selectChannel, waitForUserTopicReady } from "../fixtures/cicchettoPage";
+import {
+  composeSend,
+  loginAs,
+  selectChannel,
+  waitForUserTopicReady,
+} from "../fixtures/cicchettoPage";
 import { login } from "../fixtures/grappaApi";
 import {
   AUTOJOIN_CHANNELS,
@@ -68,8 +73,9 @@ test("#364 — user-topic events + push verbs survive a token rotation with unch
   // subject+network in the registry), then rotate to it in-context.
   const rotated = await login(VJT_IDENTIFIER, VJT_PASSWORD);
   await page.evaluate((tok) => {
-    (window as unknown as { __cic_setTokenForTests?: (t: string | null) => void })
-      .__cic_setTokenForTests?.(tok);
+    (
+      window as unknown as { __cic_setTokenForTests?: (t: string | null) => void }
+    ).__cic_setTokenForTests?.(tok);
   }, rotated.token);
 
   // Rotation-aware gate: userTopic clears the ready stamp on the

--- a/cicchetto/e2e/tests/issue367-whois-oper-role-text.spec.ts
+++ b/cicchetto/e2e/tests/issue367-whois-oper-role-text.spec.ts
@@ -24,10 +24,10 @@
 // regex applies. The bare-313 fallback (badge only, no row) can't be forced
 // on a live ircd, so it is covered by the WhoisCard.test.tsx unit.
 
-import { test, expect } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "oper367-target";
 const CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/issue374-motd-target-server.spec.ts
+++ b/cicchetto/e2e/tests/issue374-motd-target-server.spec.ts
@@ -18,9 +18,9 @@
 // and test/grappa/session/event_router_test.exs. The parser + compose plumbing
 // is unit-tested in cicchetto/src/__tests__/{slashCommands,compose}.test.ts.
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/issue375-rehash-option.spec.ts
+++ b/cicchetto/e2e/tests/issue375-rehash-option.spec.ts
@@ -28,10 +28,15 @@
 // GREEN post-fix: `/rehash MOTD` sends `line: "REHASH MOTD"`; bare `/rehash`
 // still sends exactly `"REHASH"` (the null-filter drops the absent option).
 
-import { expect, test } from "../fixtures/test";
-import { expectShellReady, composeSend, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import {
+  composeSend,
+  expectShellReady,
+  scrollbackLine,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
 import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // 481 ERR_NOPRIVILEGES trailing text bahamut-azzurra sends (src/s_err.c):
 //   `:%s 481 %s :Permission Denied, You do not have the correct irc
@@ -103,9 +108,9 @@ test("issue #375 — /rehash <option> forwards the option on the raw wire, bare 
     // …and it genuinely reached upstream: the non-oper gets 481 back, the
     // server's reply to the frame we shipped, rendered as a :notice in
     // $server. (Non-oper 481 is scoped-agnostic — safe, no config reload.)
-    await expect(
-      scrollbackLine(page, "notice", ERR_NOPRIVILEGES_TEXT).first(),
-    ).toBeVisible({ timeout: 15_000 });
+    await expect(scrollbackLine(page, "notice", ERR_NOPRIVILEGES_TEXT).first()).toBeVisible({
+      timeout: 15_000,
+    });
 
     // (2) REGRESSION GUARD — bare /rehash still ships EXACTLY `REHASH` (full
     // config reload). The null-filter must not leak a trailing space or a

--- a/cicchetto/e2e/tests/issue38-keyed-tab-dismiss-after-rejoin-fail.spec.ts
+++ b/cicchetto/e2e/tests/issue38-keyed-tab-dismiss-after-rejoin-fail.spec.ts
@@ -42,7 +42,6 @@
 // failed — clears last_joined, and restarts the session, which drops
 // the failed NEW_CHANNEL window). afterEach only tears down the peer.
 
-import { test, expect } from "../fixtures/test";
 import {
   composeSend,
   confirmModal,
@@ -60,6 +59,7 @@ import {
   NETWORK_NICK,
   NETWORK_SLUG,
 } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 const KEY = "k38-secret-key";
@@ -128,8 +128,9 @@ test("issue #38 — × dismisses a 475-failed +k autojoin channel row", async ({
 
   // The seeded channel re-JOINed (live, not greyed) — confirms autojoin
   // ran on the fresh session.
-  await expect(sidebarWindow(page, NETWORK_SLUG, SEED_CHANNEL).locator(".sidebar-window-greyed"))
-    .toHaveCount(0, { timeout: 20_000 });
+  await expect(
+    sidebarWindow(page, NETWORK_SLUG, SEED_CHANNEL).locator(".sidebar-window-greyed"),
+  ).toHaveCount(0, { timeout: 20_000 });
 
   // NEW_CHANNEL lands as a greyed, not-joined row. Both sidebar sources
   // are proven here: `toHaveCount(1)` confirms source A (the GET

--- a/cicchetto/e2e/tests/issue385-user-aliases.spec.ts
+++ b/cicchetto/e2e/tests/issue385-user-aliases.spec.ts
@@ -22,10 +22,11 @@
 // (the server stores them per-subject via the same XOR-FK shape). No
 // subject-shaped branch to parameterize.
 
-import { openSettingsDrawer,
+import {
   composeSend,
   composeTextarea,
   loginAs,
+  openSettingsDrawer,
   scrollbackLine,
   selectChannel,
 } from "../fixtures/cicchettoPage";

--- a/cicchetto/e2e/tests/issue386-banlist-modal-kb.spec.ts
+++ b/cicchetto/e2e/tests/issue386-banlist-modal-kb.spec.ts
@@ -139,9 +139,12 @@ test("#386 — /kb <nick> bans (*!*@host) then kicks — the peer witnesses both
     await sawKick;
 
     // Visible cic outcome: the kicked peer leaves the operator's members pane.
-    await expect(page.locator(".members-pane .member-name", { hasText: peer.nick })).toHaveCount(0, {
-      timeout: 15_000,
-    });
+    await expect(page.locator(".members-pane .member-name", { hasText: peer.nick })).toHaveCount(
+      0,
+      {
+        timeout: 15_000,
+      },
+    );
   } finally {
     await peer.disconnect("bye").catch(() => {});
     await composeSend(page, `/part ${channel}`).catch(() => {});

--- a/cicchetto/e2e/tests/issue392-home-restyle-share.spec.ts
+++ b/cicchetto/e2e/tests/issue392-home-restyle-share.spec.ts
@@ -18,8 +18,8 @@
 // Desktop chromium (untagged): the drawer + modal are layout-agnostic and
 // the QR is inline SVG, not a device camera.
 
-import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { openSettingsDrawer } from "../fixtures/cicchettoPage";
+import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 

--- a/cicchetto/e2e/tests/issue402-mobile-window-surfaces.spec.ts
+++ b/cicchetto/e2e/tests/issue402-mobile-window-surfaces.spec.ts
@@ -43,7 +43,6 @@
 // branch), so this runs on the webkit-iphone-15 project alone — the
 // @webkit tag; the chromium project grepInverts it.
 
-import { expect, test } from "../fixtures/test";
 import {
   closeArchive,
   composeSend,
@@ -56,6 +55,7 @@ import {
 import { listArchiveTargets, partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // Per-run-unique: bahamut holds channel state for a window after
 // disconnect, so a literal collides on rapid reruns (--repeat-each).

--- a/cicchetto/e2e/tests/issue405-fresh-account-journey.spec.ts
+++ b/cicchetto/e2e/tests/issue405-fresh-account-journey.spec.ts
@@ -34,7 +34,7 @@
 // dispatch (nick → resolve against Accounts → account, not guest) runs
 // through the real cic form, unstubbed.
 
-import { type Page, expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import { FRESH_PASSWORD, FRESH_USER } from "../fixtures/seedData";
 
 async function loginViaForm(page: Page, identifier: string, password: string): Promise<void> {
@@ -93,9 +93,7 @@ test.describe("#405 fresh non-admin account first-login journey", () => {
     });
   });
 
-  test("bare account name logs in as a USER and shows the self-serve home", async ({
-    page,
-  }) => {
+  test("bare account name logs in as a USER and shows the self-serve home", async ({ page }) => {
     await loginViaForm(page, FRESH_USER, FRESH_PASSWORD);
     await expectUserHomeSelfServe(page);
   });

--- a/cicchetto/e2e/tests/issue422-inbound-dm-opens-query.spec.ts
+++ b/cicchetto/e2e/tests/issue422-inbound-dm-opens-query.spec.ts
@@ -25,10 +25,10 @@
 // subject-agnostic, one user-class spec suffices). No `@webkit` tag →
 // desktop/chromium project only, so the `.shell-sidebar` selector applies.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, waitForDmListenerReady } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // Per-run-unique peer nick — bahamut holds a ghosted nick for a linger
 // window after disconnect, so a fixed literal 433s on rapid reruns

--- a/cicchetto/e2e/tests/issue427-alias-shadow-builtins.spec.ts
+++ b/cicchetto/e2e/tests/issue427-alias-shadow-builtins.spec.ts
@@ -15,10 +15,11 @@
 // (the expander is client-side; the settings sub-page + user_settings REST
 // behave identically for every subject class).
 
-import { openSettingsDrawer,
+import {
   composeSend,
   composeTextarea,
   loginAs,
+  openSettingsDrawer,
   scrollbackLine,
   selectChannel,
 } from "../fixtures/cicchettoPage";

--- a/cicchetto/e2e/tests/issue43-split-logout.spec.ts
+++ b/cicchetto/e2e/tests/issue43-split-logout.spec.ts
@@ -33,7 +33,7 @@
 // surface only, not the (pre-covered) destructive composite. Every
 // interaction below is client-side state — zero server mutation.
 
-import { openRailMenu, loginAs } from "../fixtures/cicchettoPage";
+import { loginAs, openRailMenu } from "../fixtures/cicchettoPage";
 import { getSeededVjt } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 

--- a/cicchetto/e2e/tests/issue455-emphasis-markers.spec.ts
+++ b/cicchetto/e2e/tests/issue455-emphasis-markers.spec.ts
@@ -15,10 +15,10 @@
 // two properties vjt called out: non-greedy (two independent pairs on one
 // line) and the path/identifier false-positive guard.
 
-import { test, expect } from "../fixtures/test";
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const TEST_CHANNEL = "#bofh";
 const tag = (prefix: string) => `${prefix}-${crypto.randomUUID().slice(0, 6)}`;

--- a/cicchetto/e2e/tests/issue458-presence-page-yield.spec.ts
+++ b/cicchetto/e2e/tests/issue458-presence-page-yield.spec.ts
@@ -75,9 +75,7 @@ test("#458 — presence pref persists, cold-load respects it, and revealing refe
     await expect(toggle).toBeVisible({ timeout: 5_000 });
     const hidePut = page.waitForResponse(
       (r) =>
-        r.url().includes("/me/settings/display-prefs") &&
-        r.request().method() === "PUT" &&
-        r.ok(),
+        r.url().includes("/me/settings/display-prefs") && r.request().method() === "PUT" && r.ok(),
     );
     await toggle.click();
     await hidePut;

--- a/cicchetto/e2e/tests/issue460-settings-index.spec.ts
+++ b/cicchetto/e2e/tests/issue460-settings-index.spec.ts
@@ -21,9 +21,9 @@
 // covered by the vitest unit). There is no subject-shaped branch to
 // parameterize here.
 
-import { openSettingsDrawer, composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
-import { expect, test } from "../fixtures/test";
+import { composeSend, loginAs, openSettingsDrawer, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/issue473-rail-actions-drawer.spec.ts
+++ b/cicchetto/e2e/tests/issue473-rail-actions-drawer.spec.ts
@@ -41,7 +41,6 @@
 // contract — the rail is present on both form factors but the mobile door is a
 // collapsed drawer, a distinct touch path a real iOS user produces.
 
-import { expect, test } from "../fixtures/test";
 import {
   closeMembersDrawer,
   expandArchiveGroup,
@@ -54,6 +53,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { joinChannel, partChannel } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0]; // #bofh — the seeded autojoin channel
 

--- a/cicchetto/e2e/tests/issue474-server-info-rail.spec.ts
+++ b/cicchetto/e2e/tests/issue474-server-info-rail.spec.ts
@@ -26,10 +26,10 @@
 // the real store-fed card. Desktop viewport → the rail column is visible
 // with no drawer toggle (permanent surface), so no members-open dance.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { expectRailFieldsStacked } from "../fixtures/railFieldGeometry";
 import { getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SERVER_WINDOW_LABEL = "Server";
 

--- a/cicchetto/e2e/tests/issue476-user-identity-editor.spec.ts
+++ b/cicchetto/e2e/tests/issue476-user-identity-editor.spec.ts
@@ -25,15 +25,10 @@
 // is over the REST members endpoint (layout-independent), so this is a
 // pure form-logic + live-upstream-effect proof.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, openSettingsSection } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL, patchNetworkConnectionState } from "../fixtures/grappaApi";
-import {
-  AUTOJOIN_CHANNELS,
-  getSeededVjt,
-  NETWORK_NICK,
-  NETWORK_SLUG,
-} from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // A connect gate + a live identity apply (server-side reconnect + autojoin)
 // + a restore-and-reconnect in the finally — well past the default. Give it

--- a/cicchetto/e2e/tests/issue476-user-identity-editor.spec.ts
+++ b/cicchetto/e2e/tests/issue476-user-identity-editor.spec.ts
@@ -121,7 +121,7 @@ async function waitForOwnNickInMembers(
   attempts = 60,
 ): Promise<void> {
   for (let i = 0; i < attempts; i++) {
-    const members = await fetchMembers(token, slug, channel).catch(() => []);
+    const members = await fetchMembers(token, slug, channel).catch((): string[] => []);
     if (members.includes(ownNick)) return;
     await new Promise((r) => setTimeout(r, 500));
   }

--- a/cicchetto/e2e/tests/issue477-quit-persistence.spec.ts
+++ b/cicchetto/e2e/tests/issue477-quit-persistence.spec.ts
@@ -42,11 +42,11 @@
 // the SOLE input the detach gate reads (issue126 seeds `registered: false`
 // symmetrically for its ephemeral case).
 
-import { openRailMenu, loginAs } from "../fixtures/cicchettoPage";
+import type { Browser, Page } from "@playwright/test";
+import { loginAs, openRailMenu } from "../fixtures/cicchettoPage";
 import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin, getSeededVjt } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
-import { type Browser, type Page } from "@playwright/test";
 
 // #986 — the lifecycle verbs left the settings drawer for the rail actions
 // menu. The persistence QUESTION this spec is about (`isPersistentIdentity`,

--- a/cicchetto/e2e/tests/issue482-invite-survives-reload.spec.ts
+++ b/cicchetto/e2e/tests/issue482-invite-survives-reload.spec.ts
@@ -30,7 +30,6 @@
 // Needs the live upstream + a session surviving a browser reload, which
 // jsdom/vitest cannot do (per feedback_cicchetto_browser_smoke).
 
-import { expect, test } from "../fixtures/test";
 import {
   expandArchiveGroup,
   expectShellReady,
@@ -43,6 +42,7 @@ import {
 import { partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // Per-run-unique — bahamut lingers channel/nick state after disconnect, so
 // static literals collide on rapid reruns (feedback: per-run-unique names).

--- a/cicchetto/e2e/tests/issue487-context-menu-viewport-clamp.spec.ts
+++ b/cicchetto/e2e/tests/issue487-context-menu-viewport-clamp.spec.ts
@@ -18,7 +18,7 @@
 // short-viewport cases stand in for the mobile "keyboard up → --viewport-height
 // shrinks" scenario without the mobile drawer's opener complexity.
 
-import { expect, test, type Page } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 

--- a/cicchetto/e2e/tests/issue496-home-restyle.spec.ts
+++ b/cicchetto/e2e/tests/issue496-home-restyle.spec.ts
@@ -50,7 +50,11 @@ async function forceRegisteredMe(page: Page): Promise<void> {
     const resp = await route.fetch();
     const body = (await resp.json()) as Record<string, unknown>;
     body.registered = true;
-    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    });
   });
 }
 
@@ -116,7 +120,9 @@ const SUBJECTS: SubjectCase[] = [
 
 test.describe("#496 — home restyle: per-subject session copy + no Map button", () => {
   for (const subject of SUBJECTS) {
-    test(`${subject.label}: session copy renders and the Map button is hidden`, async ({ page }) => {
+    test(`${subject.label}: session copy renders and the Map button is hidden`, async ({
+      page,
+    }) => {
       const teardown = await subject.arrive(page);
       try {
         // (1) The per-subject session-lifetime copy renders with its fact.

--- a/cicchetto/e2e/tests/issue498-badge-follows-live-nick.spec.ts
+++ b/cicchetto/e2e/tests/issue498-badge-follows-live-nick.spec.ts
@@ -87,10 +87,7 @@ async function runCommand(page: Parameters<typeof loginAs>[0], command: string):
 // and `own_nick_changed` is broadcast AFTER the server has published the
 // new live nick into the registry — so seeing it here guarantees the
 // server-side count already resolves the new nick.
-async function expectOwnMember(
-  page: Parameters<typeof loginAs>[0],
-  nick: string,
-): Promise<void> {
+async function expectOwnMember(page: Parameters<typeof loginAs>[0], nick: string): Promise<void> {
   const membersPane = page.locator(".shell-members .members-pane");
   await expect(membersPane).toBeVisible({ timeout: 10_000 });
   await expect(membersPane.locator(".member-name", { hasText: nick })).toBeVisible({

--- a/cicchetto/e2e/tests/issue498-badge-follows-live-nick.spec.ts
+++ b/cicchetto/e2e/tests/issue498-badge-follows-live-nick.spec.ts
@@ -218,16 +218,3 @@ test("#498 — a mention of the LIVE (renamed) nick lifts the server badge on co
     await peer.disconnect("i498 done");
   }
 });
-
-declare global {
-  interface Window {
-    __cic_dropSocketForTests?: () => Promise<void>;
-    __cic_socketHealth?: {
-      recordOpen: () => void;
-      recordError: () => void;
-      recordClose: (e: { code: number; reason: string } | undefined) => void;
-      reset: () => void;
-      state: () => { state: "connecting" | "open" | "error" };
-    };
-  }
-}

--- a/cicchetto/e2e/tests/issue500-rail-launcher-overflow.spec.ts
+++ b/cicchetto/e2e/tests/issue500-rail-launcher-overflow.spec.ts
@@ -22,10 +22,10 @@
 // The mobile launcher + menu path is exercised by the sibling specs, which now
 // reach every rail action through `openRailMenu`.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0]; // #bofh — vjt's seeded autojoin channel
 // vjt + PEER_COUNT peers. Four extra members overflow the short viewport below

--- a/cicchetto/e2e/tests/issue508-ios-select-tappable.spec.ts
+++ b/cicchetto/e2e/tests/issue508-ios-select-tappable.spec.ts
@@ -22,9 +22,9 @@
 // removing the base `html.is-ios` none would red the control half — so
 // neither a stale rule nor a dropped fix can pass silently.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs } from "../fixtures/cicchettoPage";
 import { getSeededVjt } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 test("@webkit iOS — <select> is exempt from the inherited user-select:none so the native picker opens on a direct tap of the control, not only via its label", async ({
   page,

--- a/cicchetto/e2e/tests/issue510-join-comma-focus.spec.ts
+++ b/cicchetto/e2e/tests/issue510-join-comma-focus.spec.ts
@@ -23,12 +23,7 @@
 // vjt creates two fresh per-run channels via ONE `/join #x,#y` (→ sole op
 // of each) and PARTs both in `finally`, keeping the shared testnet tidy.
 
-import {
-  composeSend,
-  composeTextarea,
-  loginAs,
-  selectChannel,
-} from "../fixtures/cicchettoPage";
+import { composeSend, composeTextarea, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 

--- a/cicchetto/e2e/tests/issue511-failed-autojoin-dismiss-durable.spec.ts
+++ b/cicchetto/e2e/tests/issue511-failed-autojoin-dismiss-durable.spec.ts
@@ -50,7 +50,6 @@
 // an assertion failed mid-spec, and restarts the session). afterEach only tears
 // down the peer.
 
-import { expect, test } from "../fixtures/test";
 import {
   composeSend,
   confirmModal,
@@ -69,6 +68,7 @@ import {
   NETWORK_NICK,
   NETWORK_SLUG,
 } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 const KEY = "k511-secret-key";

--- a/cicchetto/e2e/tests/issue532-stale-unread-badges.spec.ts
+++ b/cicchetto/e2e/tests/issue532-stale-unread-badges.spec.ts
@@ -32,7 +32,6 @@
 // ReadCursor, CollapseNickReadCursors) — they have no distinct browser
 // surface, so they are deliberately out of scope here.
 
-import { expect, test } from "../fixtures/test";
 import {
   closeArchive,
   expandArchiveGroup,
@@ -53,6 +52,7 @@ import {
 } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const PEER_NICK = "i532-peer";
@@ -111,9 +111,7 @@ test("#532 A — a self-PART leaves NO stale event badge on the archived channel
   // message another spec might land on the shared #bofh — that would add a
   // message badge, never an event badge, and A is strictly about events.
   await expect(
-    page
-      .getByTestId(`archive-unread-${NETWORK_SLUG}-${CHANNEL}`)
-      .locator(".sidebar-events-unread"),
+    page.getByTestId(`archive-unread-${NETWORK_SLUG}-${CHANNEL}`).locator(".sidebar-events-unread"),
   ).toHaveCount(0);
 
   await closeArchive(page);

--- a/cicchetto/e2e/tests/issue535-visibility-return-preserve-scroll.spec.ts
+++ b/cicchetto/e2e/tests/issue535-visibility-return-preserve-scroll.spec.ts
@@ -39,17 +39,12 @@
 // it to the tail (BUGHUNT-3 cascade rule — a leaked mid-page cursor forks the
 // next spec's divider assertions).
 
-import { expect, test } from "../fixtures/test";
-import { type Page } from "@playwright/test";
-import {
-  loginAs,
-  scrollbackLine,
-  scrollbackLines,
-  selectChannel,
-} from "../fixtures/cicchettoPage";
+import type { Page } from "@playwright/test";
+import { loginAs, scrollbackLine, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL, restoreReadCursorToTail, setReadCursorToId } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -65,7 +60,11 @@ async function scrollbackGeometry(
   return await page.evaluate(() => {
     const el = document.querySelector('[data-testid="scrollback"]') as HTMLDivElement | null;
     if (!el) throw new Error("scrollback container not found");
-    return { scrollTop: el.scrollTop, scrollHeight: el.scrollHeight, clientHeight: el.clientHeight };
+    return {
+      scrollTop: el.scrollTop,
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    };
   });
 }
 
@@ -109,10 +108,7 @@ async function setTabHidden(page: Page, hidden: boolean): Promise<void> {
 // Fetch the newest REST page (DESC; [0] === newest === tail). Used to learn the
 // tail id (seed cursor to head = fully read → no divider) and a mid-page id
 // (seed a divider). Same shape as scroll-on-window-switch.spec.ts.
-async function fetchScrollbackPage(
-  token: string,
-  channel: string,
-): Promise<Array<{ id: number }>> {
+async function fetchScrollbackPage(token: string, channel: string): Promise<Array<{ id: number }>> {
   const url = `${GRAPPA_BASE_URL}/networks/${encodeURIComponent(
     NETWORK_SLUG,
   )}/channels/${encodeURIComponent(channel)}/messages`;
@@ -255,9 +251,9 @@ test.describe("#535 — visibility-return preserves the mid-backlog reader's pos
     // top and distance collapsed to <= threshold.
     await expect(marker).toHaveCount(1);
     await expect(marker).toBeInViewport();
-    await expect.poll(async () => await distanceFromBottom(page)).toBeGreaterThan(
-      SCROLL_BOTTOM_THRESHOLD_PX,
-    );
+    await expect
+      .poll(async () => await distanceFromBottom(page))
+      .toBeGreaterThan(SCROLL_BOTTOM_THRESHOLD_PX);
     const markerOffset = await page.evaluate(() => {
       const el = document.querySelector('[data-testid="scrollback"]') as HTMLElement | null;
       const m = document.querySelector('[data-testid="unread-marker"]') as HTMLElement | null;

--- a/cicchetto/e2e/tests/issue535-visibility-return-preserve-scroll.spec.ts
+++ b/cicchetto/e2e/tests/issue535-visibility-return-preserve-scroll.spec.ts
@@ -379,10 +379,3 @@ test.describe("#535 — visibility-return preserves the mid-backlog reader's pos
     }
   });
 });
-
-declare global {
-  interface Window {
-    __cic_suppressChannelDeliveryForTests?: (slug: string, name: string) => void;
-    __cic_resumeChannelDeliveryForTests?: (slug: string, name: string) => void;
-  }
-}

--- a/cicchetto/e2e/tests/issue540-who-flag-args.spec.ts
+++ b/cicchetto/e2e/tests/issue540-who-flag-args.spec.ts
@@ -19,9 +19,9 @@
 // OPENS (feedback), not a specific matched row (bahamut cloaks hosts and the
 // membership varies).
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 // The bahamut hub the default `bahamut-test` network dials (compose.yaml:

--- a/cicchetto/e2e/tests/issue546-peer-notice-no-query-window.spec.ts
+++ b/cicchetto/e2e/tests/issue546-peer-notice-no-query-window.spec.ts
@@ -20,7 +20,6 @@
 // be observed on `$server`. Without that gate, "no tab appeared" would pass on
 // a session that never processed the line at all — a green that proves nothing.
 
-import { expect, test } from "../fixtures/test";
 import {
   composeSend,
   composeTextarea,
@@ -32,6 +31,7 @@ import {
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/issue554-operator-kill-terminal.spec.ts
+++ b/cicchetto/e2e/tests/issue554-operator-kill-terminal.spec.ts
@@ -18,15 +18,10 @@
 // mirroring issue100-reconnecting-badge, so the next spec on the shared
 // testnet inherits a live session.
 
-import { test, expect } from "../fixtures/test";
-import { IrcPeer } from "../fixtures/ircClient";
-import {
-  AUTOJOIN_CHANNELS,
-  getSeededVjt,
-  NETWORK_NICK,
-  NETWORK_SLUG,
-} from "../fixtures/seedData";
 import { GRAPPA_BASE_URL, patchNetworkConnectionState } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const OPER_NAME = "testoper";
 const OPER_PASS = "testoperpass";
@@ -37,9 +32,7 @@ const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 // margin. Same budget as the sibling park/reconnect specs.
 test.setTimeout(90_000);
 
-async function networkState(
-  token: string,
-): Promise<{ state: string; reason: string | null }> {
+async function networkState(token: string): Promise<{ state: string; reason: string | null }> {
   const res = await fetch(`${GRAPPA_BASE_URL}/networks`, {
     headers: { authorization: `Bearer ${token}` },
   });

--- a/cicchetto/e2e/tests/issue554-operator-kill-terminal.spec.ts
+++ b/cicchetto/e2e/tests/issue554-operator-kill-terminal.spec.ts
@@ -98,6 +98,6 @@ test("#554 — operator KILL marks the network :failed with a killed reason and 
     await new Promise((r) => setTimeout(r, 8_000));
     expect((await networkState(vjt.token)).state).toBe("failed");
   } finally {
-    await peer.disconnect();
+    await peer.disconnect("#554 kill test done");
   }
 });

--- a/cicchetto/e2e/tests/issue557-kill-slash-wiring.spec.ts
+++ b/cicchetto/e2e/tests/issue557-kill-slash-wiring.spec.ts
@@ -24,7 +24,6 @@
 // `line: "KILL spammer :flooding the channel"`; bare `/kill spammer` sends
 // exactly `"KILL spammer"` (no trailing colon, no stray null/space).
 
-import { expect, test } from "../fixtures/test";
 import {
   composeSend,
   expectShellReady,
@@ -33,6 +32,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // A non-oper KILL reply. bahamut's m_kill rejects a non-oper (481
 // ERR_NOPRIVILEGES) — routed to `$server` by the numeric_router :scan

--- a/cicchetto/e2e/tests/issue576-own-msg-unread-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue576-own-msg-unread-badge.spec.ts
@@ -25,7 +25,6 @@
 // regress the report describes) and focus away. Pre-fix the badge shows
 // the own lines; post-fix it shows nothing until a PEER line arrives.
 
-import { expect, test } from "../fixtures/test";
 import {
   composeSend,
   loginAs,
@@ -43,6 +42,7 @@ import {
 } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const PEER_NICK = "i576-peer";

--- a/cicchetto/e2e/tests/issue578-links-map-render.spec.ts
+++ b/cicchetto/e2e/tests/issue578-links-map-render.spec.ts
@@ -32,7 +32,10 @@ type Box = { left: number; top: number; right: number; bottom: number };
 const boxesOverlap = (a: Box, b: Box): boolean => {
   const EPS = 0.5;
   return (
-    a.left < b.right - EPS && b.left < a.right - EPS && a.top < b.bottom - EPS && b.top < a.bottom - EPS
+    a.left < b.right - EPS &&
+    b.left < a.right - EPS &&
+    a.top < b.bottom - EPS &&
+    b.top < a.bottom - EPS
   );
 };
 

--- a/cicchetto/e2e/tests/issue579-lusers-routed-to-server.spec.ts
+++ b/cicchetto/e2e/tests/issue579-lusers-routed-to-server.spec.ts
@@ -33,9 +33,9 @@
 // Per feedback_ux_e2e_mandatory: every cic UX-behavior change ships with a
 // Playwright e2e via scripts/integration.sh.
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/issue580-send-snap-independent-of-post.spec.ts
+++ b/cicchetto/e2e/tests/issue580-send-snap-independent-of-post.spec.ts
@@ -50,8 +50,7 @@
 // measurable; mid-page cursor so cold-mount lands on the marker, above the
 // fold).
 
-import { test, expect } from "../fixtures/test";
-import { type Locator, type Page } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 import {
   composeTextarea,
   loginAs,
@@ -61,6 +60,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { restoreReadCursorToTail, setReadCursorToId } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -81,10 +81,7 @@ async function distanceToBottom(page: Page): Promise<number> {
 
 // Latest REST page in wire shape (DESC by server_time) — used to pick a known
 // message id for the mid-page cursor seed (mirror of issue168).
-async function fetchScrollbackPage(
-  token: string,
-  channel: string,
-): Promise<Array<{ id: number }>> {
+async function fetchScrollbackPage(token: string, channel: string): Promise<Array<{ id: number }>> {
   const url = `http://grappa-test:4000/networks/${encodeURIComponent(
     NETWORK_SLUG,
   )}/channels/${encodeURIComponent(channel)}/messages`;
@@ -200,9 +197,9 @@ test.describe("issue #580 — own send snaps to the bottom independent of the PO
     // The pane snapped to the BOTTOM at submit time — NOT hostage to the POST.
     // RED pre-fix: the snap sat after the throwing await, so the view stayed
     // parked on the marker and distance-to-tail stayed above threshold.
-    await expect.poll(async () => await distanceToBottom(page)).toBeLessThanOrEqual(
-      SCROLL_BOTTOM_THRESHOLD_PX,
-    );
+    await expect
+      .poll(async () => await distanceToBottom(page))
+      .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
     await expect(sentLine).toBeInViewport();
   });
 
@@ -217,9 +214,9 @@ test.describe("issue #580 — own send snaps to the bottom independent of the PO
     const sentLine = await sendAndAwaitEcho(page, `#778 snap-under-banner ${Date.now()}`);
 
     // The pane has tail-followed the echo; the failure is still parked.
-    await expect.poll(async () => await distanceToBottom(page)).toBeLessThanOrEqual(
-      SCROLL_BOTTOM_THRESHOLD_PX,
-    );
+    await expect
+      .poll(async () => await distanceToBottom(page))
+      .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
     await expect(sentLine).toBeInViewport();
 
     // NOW let the POST fail. The `.compose-box-error` line mounts below the pane
@@ -235,9 +232,9 @@ test.describe("issue #580 — own send snaps to the bottom independent of the PO
     // 50px threshold but taller than a row). GREEN: the container ResizeObserver
     // re-pins a follower to the tail on any box change.
     await expect(sentLine).toBeInViewport();
-    await expect.poll(async () => await distanceToBottom(page)).toBeLessThanOrEqual(
-      SCROLL_BOTTOM_THRESHOLD_PX,
-    );
+    await expect
+      .poll(async () => await distanceToBottom(page))
+      .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
   });
 });
 

--- a/cicchetto/e2e/tests/issue589-ios-admin-select.spec.ts
+++ b/cicchetto/e2e/tests/issue589-ios-admin-select.spec.ts
@@ -27,10 +27,10 @@
 // text-selection-restored.spec.ts's @webkit half. Real-device dogfood remains
 // the final iOS verification (vjt post-ship).
 
-import { expect, test } from "../fixtures/test";
 import { openAdminConsole } from "../fixtures/cicchettoPage";
-import { getSeededAdmin } from "../fixtures/seedData";
 import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 test.setTimeout(60_000);
 

--- a/cicchetto/e2e/tests/issue591-ctcp-ping.spec.ts
+++ b/cicchetto/e2e/tests/issue591-ctcp-ping.spec.ts
@@ -19,7 +19,6 @@
 //      window the /ping was typed in (irssi behaviour; RTT decoupled from the
 //      reply's routing).
 
-import { expect, test } from "../fixtures/test";
 import {
   composeSend,
   composeTextarea,
@@ -30,6 +29,7 @@ import {
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -59,9 +59,9 @@ test("#591 — own /ctcp query self-echoes as '→ CTCP VERB args to target', no
   });
 
   // DOM: rendered as the CTCP query line (data-kind=privmsg), envelope gone.
-  await expect(
-    scrollbackLine(page, "privmsg", `→ CTCP VERSION ${tag} to ${CHANNEL}`),
-  ).toBeVisible({ timeout: 10_000 });
+  await expect(scrollbackLine(page, "privmsg", `→ CTCP VERSION ${tag} to ${CHANNEL}`)).toBeVisible({
+    timeout: 10_000,
+  });
 });
 
 test("#591 — /ping shows the round-trip time in the source window", async ({ page }) => {

--- a/cicchetto/e2e/tests/issue605-rail-width-cap.spec.ts
+++ b/cicchetto/e2e/tests/issue605-rail-width-cap.spec.ts
@@ -38,9 +38,9 @@
 // where morph saw the starve.
 
 import type { Page } from "@playwright/test";
-import { expect, test } from "../fixtures/test";
 import { loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SERVER_WINDOW_LABEL = "Server";
 

--- a/cicchetto/e2e/tests/issue606-query-rail-whois.spec.ts
+++ b/cicchetto/e2e/tests/issue606-query-rail-whois.spec.ts
@@ -30,10 +30,7 @@ import {
   waitForQueryWindowReady,
 } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
-import {
-  expectFieldsTwoColumn,
-  expectRailFieldsStacked,
-} from "../fixtures/railFieldGeometry";
+import { expectFieldsTwoColumn, expectRailFieldsStacked } from "../fixtures/railFieldGeometry";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 

--- a/cicchetto/e2e/tests/issue625-single-send-scroll-jump.spec.ts
+++ b/cicchetto/e2e/tests/issue625-single-send-scroll-jump.spec.ts
@@ -29,8 +29,7 @@
 // Harness mirrors issue580 (DB-seeded 200-row #bofh; tiny 800×300 viewport so
 // the buffer overflows and scroll geometry is measurable).
 
-import { test, expect } from "../fixtures/test";
-import { type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import {
   composeSend,
   loginAs,
@@ -40,6 +39,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { restoreReadCursorToTail, setReadCursorToId } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -120,7 +120,12 @@ async function installScrollProbe(page: Page, windowMs: number): Promise<void> {
           return desc.get?.call(this);
         },
         set(v: number) {
-          w.__i625writes.push({ t: Math.round(now()), kind: "scrollTop=", detail: String(Math.round(v)), before: Math.round(getTop()) });
+          w.__i625writes.push({
+            t: Math.round(now()),
+            kind: "scrollTop=",
+            detail: String(Math.round(v)),
+            before: Math.round(getTop()),
+          });
           desc.set?.call(this, v);
         },
       });
@@ -129,13 +134,23 @@ async function installScrollProbe(page: Page, windowMs: number): Promise<void> {
     const rawSIV = Element.prototype.scrollIntoView;
     Element.prototype.scrollIntoView = function (arg?: boolean | ScrollIntoViewOptions) {
       if (this === el || el.contains(this as Node)) {
-        w.__i625writes.push({ t: Math.round(now()), kind: "scrollIntoView", detail: JSON.stringify(arg ?? null), before: Math.round(getTop()) });
+        w.__i625writes.push({
+          t: Math.round(now()),
+          kind: "scrollIntoView",
+          detail: JSON.stringify(arg ?? null),
+          before: Math.round(getTop()),
+        });
       }
       return rawSIV.call(this, arg as ScrollIntoViewOptions);
     };
 
     const sample = () => {
-      w.__i625samples.push({ t: Math.round(now()), top: Math.round(getTop()), height: el.scrollHeight, client: el.clientHeight });
+      w.__i625samples.push({
+        t: Math.round(now()),
+        top: Math.round(getTop()),
+        height: el.scrollHeight,
+        client: el.clientHeight,
+      });
     };
     sample();
     el.addEventListener("scroll", sample, { passive: true });
@@ -150,7 +165,10 @@ async function installScrollProbe(page: Page, windowMs: number): Promise<void> {
 // On failure this dump is the whole story: `writes` names every container scroll
 // write + its timestamp (the delayed double-scroll shows as a second entry ~0.5s
 // in), `topChanges` is the compressed scrollTop timeline.
-async function dumpEvidence(page: Page, tag: string): Promise<{ samples: Sample[]; writes: WriteEvent[] }> {
+async function dumpEvidence(
+  page: Page,
+  tag: string,
+): Promise<{ samples: Sample[]; writes: WriteEvent[] }> {
   const samples = await page.evaluate(
     () => (window as unknown as { __i625samples: Sample[] }).__i625samples,
   );
@@ -214,9 +232,15 @@ test.describe("issue #625 — a single send must not jump the pane up before set
     // #625 CORE — no DELAYED second scroll write. A single send performs ONE
     // tail-follow; the regression's redundant follow-on poll fires its fail-safe
     // scroll ~0.5s later. RED on main; GREEN once that write is suppressed.
-    expect(writes.length, `expected the send's tail-follow write; writes=${JSON.stringify(writes)}`).toBeGreaterThanOrEqual(1);
+    expect(
+      writes.length,
+      `expected the send's tail-follow write; writes=${JSON.stringify(writes)}`,
+    ).toBeGreaterThanOrEqual(1);
     const late = delayedWrites(writes);
-    expect(late, `delayed scroll write(s) after the send's tail-follow: ${JSON.stringify(writes)}`).toEqual([]);
+    expect(
+      late,
+      `delayed scroll write(s) after the send's tail-follow: ${JSON.stringify(writes)}`,
+    ).toEqual([]);
 
     // Visible-symptom guard: following a send, the pane never travels UP.
     const maxDist = Math.max(...samples.map(distOf));
@@ -265,9 +289,15 @@ test.describe("issue #625 — a single send must not jump the pane up before set
     // #625 CORE — same invariant as the at-tail case: a single send must not fire
     // a DELAYED second scroll write. (Here the follow-on rows change is the marker
     // collapse, which cannot settle and hits the fail-safe.)
-    expect(writes.length, `expected the send's tail-follow write; writes=${JSON.stringify(writes)}`).toBeGreaterThanOrEqual(1);
+    expect(
+      writes.length,
+      `expected the send's tail-follow write; writes=${JSON.stringify(writes)}`,
+    ).toBeGreaterThanOrEqual(1);
     const late = delayedWrites(writes);
-    expect(late, `delayed scroll write(s) after the send's tail-follow: ${JSON.stringify(writes)}`).toEqual([]);
+    expect(
+      late,
+      `delayed scroll write(s) after the send's tail-follow: ${JSON.stringify(writes)}`,
+    ).toEqual([]);
 
     // #608: a send follows the tail unconditionally → the pane reaches the bottom.
     // Once there, it STAYS (a delayed writer would drag it back UP).

--- a/cicchetto/e2e/tests/issue630-flood-protection.spec.ts
+++ b/cicchetto/e2e/tests/issue630-flood-protection.spec.ts
@@ -79,8 +79,20 @@ test("sustained inbound flood 429s then severs the web session; a second subject
   // Flood the metered REST write door with the vjt bearer, wave-batched so
   // the browser's per-origin connection cap doesn't stretch the burst into
   // refill territory. Capture every status + the FIRST 429's parsed body.
+  // The return type is spelled out because `throttleBody` is only ever
+  // assigned from inside `one()`: without it TS narrows the binding to its
+  // `null` initializer and types every `result.throttleBody?.…` read below as
+  // `never` — the assertions would still run, but against a type that says the
+  // 429 envelope cannot exist.
   const result = await page.evaluate(
-    async ({ url, total, wave }) => {
+    async ({
+      url,
+      total,
+      wave,
+    }): Promise<{
+      statuses: number[];
+      throttleBody: { error?: string; retry_after_ms?: number } | null;
+    }> => {
       const token = localStorage.getItem("grappa-token");
       const statuses: number[] = [];
       let throttleBody: { error?: string; retry_after_ms?: number } | null = null;

--- a/cicchetto/e2e/tests/issue630-flood-protection.spec.ts
+++ b/cicchetto/e2e/tests/issue630-flood-protection.spec.ts
@@ -111,9 +111,7 @@ test("sustained inbound flood 429s then severs the web session; a second subject
       };
 
       for (let sent = 0; sent < total; sent += wave) {
-        const batch = await Promise.all(
-          Array.from({ length: Math.min(wave, total - sent) }, one),
-        );
+        const batch = await Promise.all(Array.from({ length: Math.min(wave, total - sent) }, one));
         statuses.push(...batch);
       }
       return { statuses, throttleBody };

--- a/cicchetto/e2e/tests/issue637-service-ping.spec.ts
+++ b/cicchetto/e2e/tests/issue637-service-ping.spec.ts
@@ -15,13 +15,21 @@
 // If NickServ ever stops echoing, this goes red loudly (element-not-found)
 // rather than silently passing — the #78 "green while broken" trap.
 
-import { expect, test } from "../fixtures/test";
-import { composeSend, composeTextarea, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
+import {
+  composeSend,
+  composeTextarea,
+  loginAs,
+  scrollbackLine,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
-test("#637 — /ping NickServ (a real service, token-less echo) renders the round-trip line", async ({ page }) => {
+test("#637 — /ping NickServ (a real service, token-less echo) renders the round-trip line", async ({
+  page,
+}) => {
   const vjt = getSeededVjt();
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
@@ -33,7 +41,7 @@ test("#637 — /ping NickServ (a real service, token-less echo) renders the roun
   // window (#bofh).
   await composeSend(page, "/ping NickServ");
 
-  await expect(
-    scrollbackLine(page, "notice", /CTCP PING reply from NickServ: \d+ ms/),
-  ).toBeVisible({ timeout: 20_000 });
+  await expect(scrollbackLine(page, "notice", /CTCP PING reply from NickServ: \d+ ms/)).toBeVisible(
+    { timeout: 20_000 },
+  );
 });

--- a/cicchetto/e2e/tests/issue640-ping-self-echo.spec.ts
+++ b/cicchetto/e2e/tests/issue640-ping-self-echo.spec.ts
@@ -16,7 +16,6 @@
 // see any of this: it is the compose → REST → self-echo + reply → WS → render
 // path against a real bahamut (feedback_ux_e2e_mandatory).
 
-import { expect, test } from "../fixtures/test";
 import {
   composeSend,
   composeTextarea,
@@ -27,6 +26,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -113,9 +113,9 @@ test("#640 — /ctcp <peer> VERSION self-echoes in the SOURCE window, opens no q
   await composeSend(page, `/ctcp ${victim} VERSION ${tag}`);
 
   // Echo in the SOURCE window, target from meta (not the routing key).
-  await expect(
-    scrollbackLine(page, "privmsg", `→ CTCP VERSION ${tag} to ${victim}`),
-  ).toBeVisible({ timeout: 10_000 });
+  await expect(scrollbackLine(page, "privmsg", `→ CTCP VERSION ${tag} to ${victim}`)).toBeVisible({
+    timeout: 10_000,
+  });
 
   await expect(sidebarWindow(page, NETWORK_SLUG, victim)).toHaveCount(0);
 });

--- a/cicchetto/e2e/tests/issue641-ctcp-notice-render.spec.ts
+++ b/cicchetto/e2e/tests/issue641-ctcp-notice-render.spec.ts
@@ -17,11 +17,11 @@
 // WRONG reason. A stray VERSION reply has NO correlation machinery — it hits
 // the exact fall-through the bug reports.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const SERVER_WINDOW_LABEL = "Server";

--- a/cicchetto/e2e/tests/issue648-clickable-channel.spec.ts
+++ b/cicchetto/e2e/tests/issue648-clickable-channel.spec.ts
@@ -17,7 +17,6 @@
 // issue195-leave-confirm-modal (the shared ConfirmModal drive + the
 // count-0 "no modal" negative assertion).
 
-import { test, expect } from "../fixtures/test";
 import {
   confirmModal,
   confirmModalBody,
@@ -30,6 +29,7 @@ import {
 import { joinChannel, partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // vjt is autojoined here (seedData.AUTOJOIN_CHANNELS) — the window the peer
 // posts the `#channel`-bearing PRIVMSG into.

--- a/cicchetto/e2e/tests/issue66-keyboard-overlap.spec.ts
+++ b/cicchetto/e2e/tests/issue66-keyboard-overlap.spec.ts
@@ -30,12 +30,7 @@
 // (playwright.config.ts grep) so `html.is-ios` engages and the real iOS
 // height path (`body { height: calc(var(--vh) * 100) }`) is exercised.
 
-import {
-  composeTextarea,
-  loginAs,
-  scrollbackLine,
-  selectChannel,
-} from "../fixtures/cicchettoPage";
+import { composeTextarea, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";

--- a/cicchetto/e2e/tests/issue671-auto-away-on-disconnect.spec.ts
+++ b/cicchetto/e2e/tests/issue671-auto-away-on-disconnect.spec.ts
@@ -41,10 +41,10 @@
 // client observes, so it ships with a Playwright e2e via
 // scripts/integration.sh.
 
-import { test, expect } from "../fixtures/test";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "i671-away-watcher";
 const CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/issue677-directory-pagination.spec.ts
+++ b/cicchetto/e2e/tests/issue677-directory-pagination.spec.ts
@@ -20,9 +20,9 @@
 // (21 specs); the real backend still serves login + everything else.
 
 import type { Page } from "@playwright/test";
-import { expect, test } from "../fixtures/test";
 import { loginAs, sidebarWindow } from "../fixtures/cicchettoPage";
 import { getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // LIST_WINDOW_NAME from src/lib/windowKinds.ts. Hardcoded — the e2e
 // tsconfig does not resolve src/ imports; a rename must be mirrored here.
@@ -53,9 +53,7 @@ function fullPage(prefix: string, nextCursor: string | null, total: number) {
 const isDirectoryGet = (url: URL) => url.pathname.endsWith("/directory");
 
 async function openList(page: Page): Promise<void> {
-  await sidebarWindow(page, NETWORK_SLUG, LIST_WINDOW_NAME)
-    .locator(".sidebar-window-btn")
-    .click();
+  await sidebarWindow(page, NETWORK_SLUG, LIST_WINDOW_NAME).locator(".sidebar-window-btn").click();
 }
 
 test("#677 defect 1 — the directory pages past 100 rows on scroll", async ({ page }) => {

--- a/cicchetto/e2e/tests/issue687-crt-boot-stages.spec.ts
+++ b/cicchetto/e2e/tests/issue687-crt-boot-stages.spec.ts
@@ -29,7 +29,7 @@
 // future change to BOOT_FETCH_TIMEOUT_MS shortens that, this spec goes
 // red rather than silently asserting against the failure screen.
 
-import { type Locator, type Page, expect, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 
 const ME_USER = {
   kind: "user",

--- a/cicchetto/e2e/tests/issue71-inc1-sidebar-own-nick.spec.ts
+++ b/cicchetto/e2e/tests/issue71-inc1-sidebar-own-nick.spec.ts
@@ -17,15 +17,10 @@
 // project (Desktop Chrome, 1280×720, above the (max-width: 768px) mobile
 // breakpoint), same gate as archive-desktop-only.spec.ts.
 
-import { expect, test } from "../fixtures/test";
-import {
-  expandArchiveGroup,
-  loginAs,
-  openArchive,
-  sidebarWindow,
-} from "../fixtures/cicchettoPage";
+import { expandArchiveGroup, loginAs, openArchive, sidebarWindow } from "../fixtures/cicchettoPage";
 import { joinChannel, partChannel } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/issue71-inc2-mobile-rail-openers.spec.ts
+++ b/cicchetto/e2e/tests/issue71-inc2-mobile-rail-openers.spec.ts
@@ -17,9 +17,9 @@
 // @webkit / iPhone 15 — the drawer + openers are mobile-only (desktop has the
 // always-visible permanent rail; see issue71-inc2-permanent-rail-desktop).
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const OPENER_GLYPH = "\u{2630}"; // ☰ — identical glyph in both openers (paletto 2)

--- a/cicchetto/e2e/tests/issue71-inc2-permanent-rail-desktop.spec.ts
+++ b/cicchetto/e2e/tests/issue71-inc2-permanent-rail-desktop.spec.ts
@@ -25,7 +25,6 @@
 // chrome. The mobile openers (paletto 3) are covered by
 // issue71-inc2-mobile-rail-openers.spec.ts.
 
-import { expect, test } from "../fixtures/test";
 import {
   composeSend,
   expandArchiveGroup,
@@ -36,9 +35,10 @@ import {
   selectChannel,
   sidebarWindow,
 } from "../fixtures/cicchettoPage";
-import { IrcPeer } from "../fixtures/ircClient";
 import { joinChannel, partChannel } from "../fixtures/grappaApi";
+import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL_A = AUTOJOIN_CHANNELS[0]; // #bofh — seeded autojoin
 const CHANNEL_B = "#i71inc2"; // fresh channel joined for the away round-trip
@@ -130,7 +130,9 @@ test.describe("#71 INC-2 — permanent right rail (desktop)", () => {
       await expect
         .poll(
           async () =>
-            await mentionsRow.evaluate((el) => getComputedStyle(el).borderLeftWidth).catch(() => ""),
+            await mentionsRow
+              .evaluate((el) => getComputedStyle(el).borderLeftWidth)
+              .catch(() => ""),
           { timeout: 5_000, message: "mentions row should carry the 2px grouping rail" },
         )
         .toBe("2px");
@@ -152,7 +154,9 @@ test.describe("#71 INC-2 — permanent right rail (desktop)", () => {
       await expect
         .poll(
           async () =>
-            await mentionsRow.evaluate((el) => getComputedStyle(el).borderLeftWidth).catch(() => ""),
+            await mentionsRow
+              .evaluate((el) => getComputedStyle(el).borderLeftWidth)
+              .catch(() => ""),
           { timeout: 5_000, message: "mentions row rail must survive the archive move" },
         )
         .toBe("2px");

--- a/cicchetto/e2e/tests/issue75-theme-editor.spec.ts
+++ b/cicchetto/e2e/tests/issue75-theme-editor.spec.ts
@@ -29,9 +29,7 @@ type PWPage = import("@playwright/test").Page;
 
 // The inline `--accent` custom property customTheme.ts writes on <html>.
 function readAccent(page: PWPage): Promise<string> {
-  return page.evaluate(() =>
-    document.documentElement.style.getPropertyValue("--accent").trim(),
-  );
+  return page.evaluate(() => document.documentElement.style.getPropertyValue("--accent").trim());
 }
 
 // Set an <input type="color"> value deterministically across engines (fill
@@ -52,9 +50,7 @@ async function openThemesGalleryDesktop(page: PWPage): Promise<void> {
 }
 
 test.describe("#75 — theme editor (producer path)", () => {
-  test("new theme: live preview + save persists across reload via the server", async ({
-    page,
-  }) => {
+  test("new theme: live preview + save persists across reload via the server", async ({ page }) => {
     await loginAs(page, getSeededVjt());
     await openThemesGalleryDesktop(page);
 
@@ -150,10 +146,7 @@ test.describe("#75 — theme editor (producer path)", () => {
     await page.getByTestId("theme-editor-font").selectOption("jetbrains-mono");
     await expect
       .poll(
-        () =>
-          page.evaluate(() =>
-            document.documentElement.style.getPropertyValue("--font-mono"),
-          ),
+        () => page.evaluate(() => document.documentElement.style.getPropertyValue("--font-mono")),
         { timeout: 5_000 },
       )
       .toContain("jetbrains-mono");

--- a/cicchetto/e2e/tests/issue79-ios-select-keyboard-open.spec.ts
+++ b/cicchetto/e2e/tests/issue79-ios-select-keyboard-open.spec.ts
@@ -26,7 +26,6 @@
 // reds the tap half. The FEEL (selection actually appearing, and the tap
 // dismissing the keyboard on-device) is a real-device test (vjt post-ship).
 
-import { test, expect } from "../fixtures/test";
 import {
   composeSend,
   composeTextarea,
@@ -35,6 +34,7 @@ import {
   selectChannel,
 } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 // Date.now() suffix (house pattern): the e2e sqlite scrollback persists

--- a/cicchetto/e2e/tests/issue793-invite-link.spec.ts
+++ b/cicchetto/e2e/tests/issue793-invite-link.spec.ts
@@ -22,20 +22,15 @@
 // unnecessary.
 
 import type { Page } from "@playwright/test";
-import { expect, test } from "../fixtures/test";
 import {
   confirmModal,
   confirmModalBody,
   confirmModalYes,
   sidebarWindow,
 } from "../fixtures/cicchettoPage";
-import {
-  joinChannel,
-  listChannelNames,
-  partChannel,
-  type SeededUser,
-} from "../fixtures/grappaApi";
+import { joinChannel, listChannelNames, partChannel, type SeededUser } from "../fixtures/grappaApi";
 import { getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // Lowercase throughout: raw == ASCII-folded, so the sidebar window key (the
 // folded key IS the display) equals the spelling asserted on. The raw-vs-

--- a/cicchetto/e2e/tests/issue80-paste-flood-guard.spec.ts
+++ b/cicchetto/e2e/tests/issue80-paste-flood-guard.spec.ts
@@ -22,7 +22,7 @@
 // jsdom cannot show. A real ClipboardEvent + DataTransfer (both constructible
 // in chromium) drives the production onPaste handler deterministically.
 
-import { expect, test } from "../fixtures/test";
+import type { Page } from "@playwright/test";
 import {
   composeTextarea,
   confirmModal,
@@ -30,12 +30,12 @@ import {
   confirmModalBody,
   confirmModalCancel,
   confirmModalYes,
-  scrollbackLine,
   loginAs,
+  scrollbackLine,
   selectChannel,
 } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
-import type { Page } from "@playwright/test";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -95,9 +95,7 @@ test("#80 — multi-line paste: dialog opens, Cancel drops it, Paste inserts it"
   await expect(ta).toBeFocused();
 });
 
-test("#816 — a one-message paste is frictionless; two messages already guard", async ({
-  page,
-}) => {
+test("#816 — a one-message paste is frictionless; two messages already guard", async ({ page }) => {
   if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
   const vjt = getSeededVjt();
   await loginAs(page, vjt);

--- a/cicchetto/e2e/tests/issue881-mobile-nonjoined-rail-doors.spec.ts
+++ b/cicchetto/e2e/tests/issue881-mobile-nonjoined-rail-doors.spec.ts
@@ -37,7 +37,6 @@
 // isMobile() branch), so this runs on the webkit-iphone-15 project alone — the
 // @webkit tag; the chromium project grepInverts it.
 
-import { expect, test } from "../fixtures/test";
 import {
   closeArchive,
   composeSend,
@@ -49,6 +48,7 @@ import {
 import { partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // Per-run-unique: bahamut holds channel state for a window after disconnect, so
 // a literal collides on rapid reruns (--repeat-each).

--- a/cicchetto/e2e/tests/issue887-focused-unread-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue887-focused-unread-badge.spec.ts
@@ -23,7 +23,6 @@
 // the right shape.
 
 import type { Page } from "@playwright/test";
-import { expect, test } from "../fixtures/test";
 import { loginAs, selectChannel, sidebarMessageBadge } from "../fixtures/cicchettoPage";
 import {
   fetchAllMessagesAsc,
@@ -32,6 +31,7 @@ import {
 } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const PEER_NICK = "badge887-buddy";
@@ -170,9 +170,9 @@ test.describe("#887 focused-window unread badge", () => {
       peer.privmsg(CHANNEL, body);
 
       // The row lands and the pane tail-follows it into view.
-      await expect(
-        page.locator('[data-testid="scrollback-line"]', { hasText: body }),
-      ).toBeVisible({ timeout: 10_000 });
+      await expect(page.locator('[data-testid="scrollback-line"]', { hasText: body })).toBeVisible({
+        timeout: 10_000,
+      });
 
       // …and settles back to no badge, with the operator having touched
       // nothing. Without the read-at-the-tail arm this sticks at 1 forever:

--- a/cicchetto/e2e/tests/issue902-invite-banner-mobile.spec.ts
+++ b/cicchetto/e2e/tests/issue902-invite-banner-mobile.spec.ts
@@ -34,7 +34,6 @@
 // this proves DOM + layout wiring at that viewport, not iOS gesture
 // behaviour.
 
-import { expect, test } from "../fixtures/test";
 import {
   composeSend,
   inviteBanner,
@@ -46,6 +45,7 @@ import {
 import { partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // Per-run-unique names — bahamut holds a ghosted nick + lingering channel
 // state for a window after disconnect, so literals collide on rapid
@@ -128,5 +128,4 @@ test("@webkit #902 — an inbound INVITE reaches a phone via the banner, not the
   // Joined ⇒ the window left `:invited` ⇒ the registry stops deriving the
   // entry. Nothing dismissed it.
   await expect(banner).toHaveCount(0, { timeout: 10_000 });
-
 });

--- a/cicchetto/e2e/tests/issue913-rail-menu-safe-area.spec.ts
+++ b/cicchetto/e2e/tests/issue913-rail-menu-safe-area.spec.ts
@@ -28,9 +28,9 @@
 // stubbable at all; the felt behaviour on a notched device is still vjt's to
 // confirm, and this spec does not claim it.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0]; // #bofh — vjt's seeded autojoin channel
 

--- a/cicchetto/e2e/tests/issue947-unread-divider-count.spec.ts
+++ b/cicchetto/e2e/tests/issue947-unread-divider-count.spec.ts
@@ -38,7 +38,6 @@
 // cascade rule — a spec that leaves a mid-list cursor behind makes every
 // downstream spec open its pane at a divider instead of at the tail).
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import {
   fetchAllMessagesAsc,
@@ -53,6 +52,7 @@ import {
   NETWORK_SLUG,
   VJT_USER,
 } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -154,7 +154,9 @@ test.describe("#947 — the unread divider counts the conversation, not the page
       .locator('[data-testid="unread-marker"], [data-testid="scrollback-line"]')
       .evaluateAll((nodes) =>
         nodes.map((n) =>
-          n.getAttribute("data-testid") === "unread-marker" ? "MARKER" : n.getAttribute("data-msg-id"),
+          n.getAttribute("data-testid") === "unread-marker"
+            ? "MARKER"
+            : n.getAttribute("data-msg-id"),
         ),
       );
     const markerAt = flow.indexOf("MARKER");

--- a/cicchetto/e2e/tests/issue95-ws-token-subprotocol.spec.ts
+++ b/cicchetto/e2e/tests/issue95-ws-token-subprotocol.spec.ts
@@ -10,9 +10,9 @@
 // need a real socket engine; the webkit-iphone-15 project adds nothing
 // to a transport-auth assertion.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/issue950-rail-mute-snooze.spec.ts
+++ b/cicchetto/e2e/tests/issue950-rail-mute-snooze.spec.ts
@@ -28,7 +28,12 @@
 // row while leaving the push arms green — the discrimination this spec exists
 // for.
 
-import { loginAs, openRailMenu, openSettingsSection, selectChannel } from "../fixtures/cicchettoPage";
+import {
+  loginAs,
+  openRailMenu,
+  openSettingsSection,
+  selectChannel,
+} from "../fixtures/cicchettoPage";
 import { clearMutedConversations, partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import {

--- a/cicchetto/e2e/tests/issue962-settings-drawer-row-squash.spec.ts
+++ b/cicchetto/e2e/tests/issue962-settings-drawer-row-squash.spec.ts
@@ -24,9 +24,9 @@
 // agnostic CSS layout contract — registered vjt suffices.
 
 import type { Page } from "@playwright/test";
-import { expect, test } from "../fixtures/test";
 import { loginAs, openSettingsDrawer } from "../fixtures/cicchettoPage";
 import { getSeededVjt } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // Seed the XXL font-size preference on the production localStorage key so
 // `applyFontSizeFromStorage()` writes `--font-size` before the first paint,

--- a/cicchetto/e2e/tests/issue973-query-unread-badge-clears.spec.ts
+++ b/cicchetto/e2e/tests/issue973-query-unread-badge-clears.spec.ts
@@ -30,7 +30,6 @@
 // authoritative 001 (#604), so every locator below is derived from the nick
 // the server actually registered, never from the constant we asked for.
 
-import { expect, test } from "../fixtures/test";
 import {
   loginAs,
   selectChannel,
@@ -40,6 +39,7 @@ import {
 import { restoreReadCursorToTail } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const SERVER_WINDOW = "Server";

--- a/cicchetto/e2e/tests/issue981-no-badge-at-tail.spec.ts
+++ b/cicchetto/e2e/tests/issue981-no-badge-at-tail.spec.ts
@@ -35,11 +35,11 @@
 // not a verb across user classes — one seeded registered user is right.
 
 import type { Page } from "@playwright/test";
-import { expect, test } from "../fixtures/test";
 import { loginAs, selectChannel, sidebarMessageBadge } from "../fixtures/cicchettoPage";
 import { restoreReadCursorToTail } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const PEER_NICK = "badge981-buddy";

--- a/cicchetto/e2e/tests/issue984-query-rail-scroll-owner.spec.ts
+++ b/cicchetto/e2e/tests/issue984-query-rail-scroll-owner.spec.ts
@@ -48,8 +48,7 @@ const CHANNEL = AUTOJOIN_CHANNELS[0];
 // many rows inside a narrow card — the same shape as a real gecos, just longer.
 // A short bundle would false-pass against the BROKEN build (nothing overflows,
 // nothing is pushed anywhere), which is the trap #500's spec calls out.
-const LONG_GECOS =
-  "a deliberately long realname so the rail whois card overflows a short viewport";
+const LONG_GECOS = "a deliberately long realname so the rail whois card overflows a short viewport";
 
 // Short enough that the stacked WHOIS card cannot fit — the fold has to bite.
 const SHORT_VIEWPORT = { width: 1280, height: 220 };

--- a/cicchetto/e2e/tests/issue985-mobile-floating-opener.spec.ts
+++ b/cicchetto/e2e/tests/issue985-mobile-floating-opener.spec.ts
@@ -121,9 +121,7 @@ test("@webkit #985 — a mobile query window spends no band on the ☰, and the 
     // button — which is what `.shell-chrome-btn` declares — would leave it
     // unreadable. Assert a FULLY opaque backing, not merely a non-empty one.
     const bg = await opener.evaluate((el) => getComputedStyle(el).backgroundColor);
-    expect(bg, "#985 — the floated opener must carry its own backing").not.toBe(
-      "rgba(0, 0, 0, 0)",
-    );
+    expect(bg, "#985 — the floated opener must carry its own backing").not.toBe("rgba(0, 0, 0, 0)");
     // Alpha lives ONLY in the four-component form. CSSOM serialises an opaque
     // colour as `rgb(r, g, b)` whatever the theme (`#fff` in light, `#0a0a0a`
     // in dark), so it is the component COUNT that carries opacity and the
@@ -139,10 +137,9 @@ test("@webkit #985 — a mobile query window spends no band on the ☰, and the 
       throw new Error(`#985 — unparseable computed backgroundColor: ${bg}`);
     }
     const alpha = channels.length === 4 ? Number(channels[3]) : 1;
-    expect(
-      alpha,
-      `#985 — the floated opener's backing must be fully opaque; computed ${bg}`,
-    ).toBe(1);
+    expect(alpha, `#985 — the floated opener's backing must be fully opaque; computed ${bg}`).toBe(
+      1,
+    );
 
     // REACHABILITY (issue constraint 2, and the reason the rule carries a
     // z-index at all). The opener overflows a zero-height box, so the

--- a/cicchetto/e2e/tests/issue988-rail-menu-first-row.spec.ts
+++ b/cicchetto/e2e/tests/issue988-rail-menu-first-row.spec.ts
@@ -218,7 +218,8 @@ async function reportReadings(
   readings: { height: number; g: MenuGeometry }[],
 ): Promise<void> {
   if (readings.length === 0) return;
-  for (const { height, g } of readings) console.log(`#988 ${label} h=${height} ${JSON.stringify(g)}`);
+  for (const { height, g } of readings)
+    console.log(`#988 ${label} h=${height} ${JSON.stringify(g)}`);
   await testInfo.attach(`issue988-geometry-${label}`, {
     body: JSON.stringify(readings, null, 2),
     contentType: "application/json",

--- a/cicchetto/e2e/tests/issue992-admin-command.spec.ts
+++ b/cicchetto/e2e/tests/issue992-admin-command.spec.ts
@@ -42,9 +42,9 @@
 // and test/grappa/session/event_router_test.exs. The parser + compose plumbing
 // is unit-tested in cicchetto/src/__tests__/{slashCommands,compose}.test.ts.
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/links238-modal.spec.ts
+++ b/cicchetto/e2e/tests/links238-modal.spec.ts
@@ -55,10 +55,10 @@ test("#238 — /links renders the topology map from the real 364/365 burst", asy
   expect(nodeCount).toBeGreaterThanOrEqual(2);
 
   // Ground-truth log of the discovered topology (server names off the wire).
-  const servers = await nodes.evaluateAll((els) =>
-    els.map((el) => el.getAttribute("data-server")),
-  );
-  // biome-ignore lint/suspicious/noConsole: e2e ground-truth breadcrumb for the 364 param-order verification
+  const servers = await nodes.evaluateAll((els) => els.map((el) => el.getAttribute("data-server")));
+  // Ground-truth breadcrumb for the #364 param-order verification. (`noConsole`
+  // is not in biome's recommended set, so the suppression this line used to
+  // carry was itself flagged as unused once e2e/ entered the lint scope.)
   console.log(`[#238] LINKS topology (${nodeCount} servers):`, servers);
 
   // Every node carries a non-empty server name (a real hostname, not garbage).

--- a/cicchetto/e2e/tests/login-advanced-scroll-reachability.spec.ts
+++ b/cicchetto/e2e/tests/login-advanced-scroll-reachability.spec.ts
@@ -87,10 +87,12 @@ test.describe("login Advanced section stays reachable on a short viewport", () =
       .poll(
         async () => {
           await page.mouse.wheel(0, 600);
-          return await connect.isVisible().then(() => connect.evaluate((el) => {
-            const r = el.getBoundingClientRect();
-            return r.top >= 0 && r.bottom <= window.innerHeight;
-          }));
+          return await connect.isVisible().then(() =>
+            connect.evaluate((el) => {
+              const r = el.getBoundingClientRect();
+              return r.top >= 0 && r.bottom <= window.innerHeight;
+            }),
+          );
         },
         { timeout: 10_000 },
       )
@@ -144,4 +146,3 @@ test.describe("login on a tall viewport — fix must not break the common case",
     await expect(page.getByRole("button", { name: /^connect$/i })).toBeInViewport();
   });
 });
-

--- a/cicchetto/e2e/tests/m-z-admin-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/m-z-admin-cluster-journey.spec.ts
@@ -38,8 +38,8 @@
 
 import { expect, test } from "@playwright/test";
 import { expectShellReady, openAdminConsole, openRailMenu } from "../fixtures/cicchettoPage";
-import { getSeededAdmin } from "../fixtures/seedData";
 import { mintVisitor } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
 
 const GRAPPA_BASE_URL = "http://grappa-test:4000";
 const AZZURRA_SLUG = "azzurra";
@@ -59,10 +59,6 @@ async function adminFriendlyLogin(
   );
   await page.goto("/");
   await expectShellReady(page);
-}
-
-async function openAdminPane(page: import("@playwright/test").Page): Promise<void> {
-  await openAdminConsole(page);
 }
 
 // PATCH /admin/networks/:slug — partial body shape per M-10. Only
@@ -148,9 +144,7 @@ test("M-Z admin operator journey: drawer → 4 tabs → cap-saturation event lan
     // (`network_busy`) → server emits `:capacity_reject` admin event
     // via Admission.Telemetry → AdminEvents.record → broadcast on
     // grappa:admin:events → cic Events tab renders new row.
-    const mintErr = await mintVisitor(`mz-cap-reject-${Date.now()}`).catch(
-      (e: Error) => e.message,
-    );
+    const mintErr = await mintVisitor(`mz-cap-reject-${Date.now()}`).catch((e: Error) => e.message);
     expect(typeof mintErr).toBe("string");
     expect(mintErr).toMatch(/503/);
 

--- a/cicchetto/e2e/tests/m1-irssi-to-chan-focused.spec.ts
+++ b/cicchetto/e2e/tests/m1-irssi-to-chan-focused.spec.ts
@@ -18,7 +18,6 @@
 // expect.poll over the locators handles WS arrival latency. No
 // arbitrary sleeps.
 
-import { test, expect } from "../fixtures/test";
 import {
   composeTextarea,
   loginAs,
@@ -29,6 +28,7 @@ import {
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "m1-peer";
 const CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/m10-admin-networks-cap-editor.spec.ts
+++ b/cicchetto/e2e/tests/m10-admin-networks-cap-editor.spec.ts
@@ -55,9 +55,7 @@ test("M-10 admin Networks tab lists seeded network rows", async ({ page }) => {
   // `feedback_seed_expansion_audit`: a hardcoded seed count is fragile
   // to seed growth; the two named rows are the real intent).
   const rows = page.locator("[data-testid^='admin-network-row-']");
-  await expect
-    .poll(async () => await rows.count(), { timeout: 15_000 })
-    .toBeGreaterThanOrEqual(2);
+  await expect.poll(async () => await rows.count(), { timeout: 15_000 }).toBeGreaterThanOrEqual(2);
   await expect(page.getByTestId("admin-network-row-bahamut-test")).toBeVisible();
   await expect(page.getByTestId("admin-network-row-azzurra")).toBeVisible();
 });

--- a/cicchetto/e2e/tests/m10-peer-action-ctcp-render.spec.ts
+++ b/cicchetto/e2e/tests/m10-peer-action-ctcp-render.spec.ts
@@ -16,7 +16,6 @@
 // and routes to kind=:action. The body persisted in scrollback is the
 // inner text (no \x01 envelope on the rendered side).
 
-import { test, expect } from "../fixtures/test";
 import {
   composeTextarea,
   loginAs,
@@ -27,6 +26,7 @@ import {
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "m10-peer";
 const CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/m11-peer-nick-change-row-members.spec.ts
+++ b/cicchetto/e2e/tests/m11-peer-nick-change-row-members.spec.ts
@@ -13,7 +13,6 @@
 // IRC wire: NICK newname (no parameters beyond the new nick). Bahamut
 // echoes the rename to every channel both nicks share with the originator.
 
-import { test, expect } from "../fixtures/test";
 import {
   composeTextarea,
   loginAs,
@@ -24,6 +23,7 @@ import {
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_OLD_NICK = "m11-peer";
 // Per-run unique new nick so retries / parallel runs don't collide on
@@ -42,9 +42,9 @@ test("M11 — peer NICK change renders nick_change row + updates members list", 
     await peer.join(CHANNEL);
 
     // Old nick visible in members before the rename.
-    await expect(
-      page.locator(".members-pane li", { hasText: PEER_OLD_NICK }),
-    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator(".members-pane li", { hasText: PEER_OLD_NICK })).toBeVisible({
+      timeout: 5_000,
+    });
 
     await peer.changeNick(PEER_NEW_NICK);
 
@@ -62,17 +62,17 @@ test("M11 — peer NICK change renders nick_change row + updates members list", 
     // DOM scrollback row: `* old is now known as new`. Substring match
     // on the new nick is unique per run (crypto-suffix), so no
     // strict-mode collision across retries.
-    await expect(
-      scrollbackLine(page, "nick_change", PEER_NEW_NICK),
-    ).toBeVisible({ timeout: 5_000 });
+    await expect(scrollbackLine(page, "nick_change", PEER_NEW_NICK)).toBeVisible({
+      timeout: 5_000,
+    });
 
     // Members list updated atomically: old gone, new present.
-    await expect(
-      page.locator(".members-pane li", { hasText: PEER_OLD_NICK }),
-    ).toHaveCount(0, { timeout: 5_000 });
-    await expect(
-      page.locator(".members-pane li", { hasText: PEER_NEW_NICK }),
-    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator(".members-pane li", { hasText: PEER_OLD_NICK })).toHaveCount(0, {
+      timeout: 5_000,
+    });
+    await expect(page.locator(".members-pane li", { hasText: PEER_NEW_NICK })).toBeVisible({
+      timeout: 5_000,
+    });
 
     // Presence kinds (nick_change is one) do NOT bump messagesUnread —
     // the focused-channel msg badge stays absent. eventsUnread split

--- a/cicchetto/e2e/tests/m12-motd-server-window-routes-notice.spec.ts
+++ b/cicchetto/e2e/tests/m12-motd-server-window-routes-notice.spec.ts
@@ -24,11 +24,7 @@
 //     (CP13 S9 — slash-only enforced inside compose.ts).
 
 import { test, expect } from "../fixtures/test";
-import {
-  composeTextarea,
-  loginAs,
-  scrollbackLine,
-} from "../fixtures/cicchettoPage";
+import { composeTextarea, loginAs } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
 
@@ -102,7 +98,11 @@ test("M12 — MOTD persists into $server channel + cicchetto Server window rende
   // (audit 2026-05-26): pin kind=notice so a regression that routes
   // MOTD as e.g. :privmsg or drops the row entirely still fails the
   // spec, even if other unrelated $server traffic is present.
-  const motdRow = scrollbackLine(page, "notice");
+  // Kind-only: any :notice row will do, so this is the bare locator rather
+  // than `scrollbackLine`, which also takes a body match (it was being called
+  // with the body argument missing — Playwright read the resulting
+  // `hasText: undefined` as "no filter", so the intent survived by accident).
+  const motdRow = page.locator('[data-testid="scrollback-line"][data-kind="notice"]');
   await expect(motdRow.first()).toBeVisible({ timeout: 5_000 });
 
   // CP13 S9: ComposeBox now renders on the Server window — slash-only

--- a/cicchetto/e2e/tests/m12-motd-server-window-routes-notice.spec.ts
+++ b/cicchetto/e2e/tests/m12-motd-server-window-routes-notice.spec.ts
@@ -23,10 +23,10 @@
 //     scrollback contains a notice line, compose box IS PRESENT
 //     (CP13 S9 — slash-only enforced inside compose.ts).
 
-import { test, expect } from "../fixtures/test";
 import { composeTextarea, loginAs } from "../fixtures/cicchettoPage";
 import { GRAPPA_BASE_URL } from "../fixtures/grappaApi";
 import { getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SERVER_CHANNEL = "$server";
 
@@ -69,7 +69,9 @@ async function assertMotdPersisted(token: string): Promise<void> {
   );
 }
 
-test("M12 — MOTD persists into $server channel + cicchetto Server window renders with compose box", async ({ page }) => {
+test("M12 — MOTD persists into $server channel + cicchetto Server window renders with compose box", async ({
+  page,
+}) => {
   const vjt = getSeededVjt();
 
   // Server-side first door: at least one :notice row exists for the

--- a/cicchetto/e2e/tests/m2-irssi-to-chan-defocused.spec.ts
+++ b/cicchetto/e2e/tests/m2-irssi-to-chan-defocused.spec.ts
@@ -15,20 +15,11 @@
 // re-trigger the JOIN-self auto-focus path and confuse the focus
 // invariant we want to assert against.
 
-import { test, expect } from "../fixtures/test";
-import {
-  loginAs,
-  selectChannel,
-  sidebarMessageBadge,
-} from "../fixtures/cicchettoPage";
+import { loginAs, selectChannel, sidebarMessageBadge } from "../fixtures/cicchettoPage";
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
-import {
-  AUTOJOIN_CHANNELS,
-  getSeededVjt,
-  NETWORK_NICK,
-  NETWORK_SLUG,
-} from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "m2-peer";
 const CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/m3-cicchetto-to-chan-own-msg-echo.spec.ts
+++ b/cicchetto/e2e/tests/m3-cicchetto-to-chan-own-msg-echo.spec.ts
@@ -19,7 +19,6 @@
 // webkit-paint shaped specs (BUG7's territory) come in a second pass
 // once chromium is green across the matrix.
 
-import { test, expect } from "../fixtures/test";
 import {
   composeSend,
   loginAs,
@@ -29,6 +28,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const MESSAGE_BODY = "M3: cicchetto-driven outbound";

--- a/cicchetto/e2e/tests/m4-irssi-to-priv-no-window.spec.ts
+++ b/cicchetto/e2e/tests/m4-irssi-to-priv-no-window.spec.ts
@@ -20,7 +20,6 @@
 // Assertion order matters: badge MUST be checked BEFORE the click-
 // to-inspect, otherwise the focus-switch clears the badge mid-test.
 
-import { test, expect } from "../fixtures/test";
 import {
   loginAs,
   scrollbackLine,
@@ -32,6 +31,7 @@ import {
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "m4-peer";
 const CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/m5-irssi-to-priv-window-open.spec.ts
+++ b/cicchetto/e2e/tests/m5-irssi-to-priv-window-open.spec.ts
@@ -11,7 +11,6 @@
 // Together they pin the selection.ts isSelected gate for query
 // windows — the same rule M1/M2 prove for channels.
 
-import { test, expect } from "../fixtures/test";
 import {
   composeSend,
   loginAs,
@@ -24,6 +23,7 @@ import {
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "m5-peer";
 const CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/m6-cicchetto-to-priv-opens-query.spec.ts
+++ b/cicchetto/e2e/tests/m6-cicchetto-to-priv-opens-query.spec.ts
@@ -20,7 +20,6 @@
 // window — `/msg` does that automatically inside compose.ts. We just
 // wait for the query window's sidebar entry to appear after submit.
 
-import { test, expect } from "../fixtures/test";
 import {
   composeSend,
   loginAs,
@@ -33,6 +32,7 @@ import {
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "m6-peer";
 const CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/m7-admin-gate-settings-drawer.spec.ts
+++ b/cicchetto/e2e/tests/m7-admin-gate-settings-drawer.spec.ts
@@ -29,9 +29,9 @@
 // expanded RailActions menu, which is absolutely positioned, capped by
 // a JS-measured max-height and overlays the members list.
 
-import { expect, test } from "../fixtures/test";
-import { openRailMenu, expectShellReady } from "../fixtures/cicchettoPage";
+import { expectShellReady, openRailMenu } from "../fixtures/cicchettoPage";
 import { getSeededAdmin, getSeededVjt } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // admin-vjt has no network bind — loginAs's `.sidebar-network-section h3`
 // shell-ready selector would time out. Wait on the always-visible

--- a/cicchetto/e2e/tests/m7-peer-join-no-bouncer-follow.spec.ts
+++ b/cicchetto/e2e/tests/m7-peer-join-no-bouncer-follow.spec.ts
@@ -18,15 +18,10 @@
 // test contamination isn't a concern; the unique name is for grep-
 // readability in trace failures.
 
-import { test, expect } from "../fixtures/test";
-import {
-  loginAs,
-  scrollbackLine,
-  selectChannel,
-  sidebarWindow,
-} from "../fixtures/cicchettoPage";
+import { loginAs, scrollbackLine, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "m7-peer";
 const BOUND_CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/m8-admin-visitors-delete.spec.ts
+++ b/cicchetto/e2e/tests/m8-admin-visitors-delete.spec.ts
@@ -20,10 +20,10 @@
 // cold-start. This spec re-enables M-8 to verify the post-UD7 budget
 // actually holds in the e2e harness.
 
-import { expect, test } from "../fixtures/test";
 import { openAdminConsole } from "../fixtures/cicchettoPage";
-import { getSeededAdmin } from "../fixtures/seedData";
 import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
+import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 test("M-8 admin Visitors tab lists + deletes a minted visitor (inline confirm two-step)", async ({
   page,

--- a/cicchetto/e2e/tests/m8-cicchetto-join-sidebar-autofocus.spec.ts
+++ b/cicchetto/e2e/tests/m8-cicchetto-join-sidebar-autofocus.spec.ts
@@ -24,15 +24,10 @@
 // unique random suffix, and `afterEach` PARTs whatever was joined so
 // the credential's autojoin set stays clean.
 
-import { test, expect } from "../fixtures/test";
-import {
-  composeSend,
-  loginAs,
-  selectChannel,
-  sidebarWindow,
-} from "../fixtures/cicchettoPage";
+import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { assertMessagePersisted, partChannel } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 // Random per-run suffix so /join's autojoin-persistence side-effect
@@ -76,4 +71,3 @@ test("M8 — cicchetto /join adds sidebar entry + auto-focuses the new channel",
     timeout: 5_000,
   });
 });
-

--- a/cicchetto/e2e/tests/m9-cicchetto-part-x-click.spec.ts
+++ b/cicchetto/e2e/tests/m9-cicchetto-part-x-click.spec.ts
@@ -30,7 +30,6 @@
 // `p.muted` empty pane is dead code in the path this spec triggers.
 // Assert on the home pane render instead.
 
-import { test, expect } from "../fixtures/test";
 import {
   confirmModal,
   confirmModalYes,
@@ -40,6 +39,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { assertMessagePersisted, joinChannel } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -96,4 +96,3 @@ test("M9 — sidebar X-button PARTs the channel and dismisses the window", async
   // selection routing is covered by the dedicated selection.ts
   // bucket-E tests + ux-4-z-cluster-journey.spec.ts.
 });
-

--- a/cicchetto/e2e/tests/marker-target-window-regression.spec.ts
+++ b/cicchetto/e2e/tests/marker-target-window-regression.spec.ts
@@ -23,7 +23,6 @@
 // jsdom can't see either (no layout, no `::before`-style ref-drift).
 // This spec is the only line of defense.
 
-import { expect, test } from "../fixtures/test";
 import {
   composeSend,
   loginAs,
@@ -34,6 +33,7 @@ import {
 import { restoreReadCursorToTail } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "marker-target-buddy";
 const CHANNEL = AUTOJOIN_CHANNELS[0];
@@ -79,9 +79,9 @@ test("focused-window send+reply does NOT spawn unread marker", async ({ page }) 
     // Send an own-PRIVMSG in the focused DM.
     await composeSend(page, own);
     // Wait for own-msg to land in the scrollback.
-    await expect(
-      page.locator('[data-testid="scrollback-line"]', { hasText: own }),
-    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('[data-testid="scrollback-line"]', { hasText: own })).toBeVisible({
+      timeout: 5_000,
+    });
     // Gate the inbound peer reply on the DM-listener (own-nick topic)
     // subscription — peer→own DMs persist channel=ownNick and fan out
     // there; an early privmsg would fastlane past the unsubscribed
@@ -90,9 +90,9 @@ test("focused-window send+reply does NOT spawn unread marker", async ({ page }) 
     // Peer replies on the same DM topic.
     peer.privmsg(NETWORK_NICK, reply);
     // Wait for the reply to land.
-    await expect(
-      page.locator('[data-testid="scrollback-line"]', { hasText: reply }),
-    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('[data-testid="scrollback-line"]', { hasText: reply })).toBeVisible({
+      timeout: 5_000,
+    });
     // The invariant: NO unread-marker. The user was reading live the
     // whole time — both messages arrived during their focus session.
     await expect(page.locator('[data-testid="unread-marker"]')).toHaveCount(0);
@@ -117,14 +117,14 @@ test("switching to tall window after focused send scrolls target to bottom", asy
     // gate the peer reply on the DM-listener (own-nick topic) — see T1.
     await waitForQueryWindowReady(page, NETWORK_SLUG, PEER_NICK);
     await composeSend(page, own);
-    await expect(
-      page.locator('[data-testid="scrollback-line"]', { hasText: own }),
-    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('[data-testid="scrollback-line"]', { hasText: own })).toBeVisible({
+      timeout: 5_000,
+    });
     await waitForDmListenerReady(page, NETWORK_SLUG);
     peer.privmsg(NETWORK_NICK, reply);
-    await expect(
-      page.locator('[data-testid="scrollback-line"]', { hasText: reply }),
-    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('[data-testid="scrollback-line"]', { hasText: reply })).toBeVisible({
+      timeout: 5_000,
+    });
 
     // Pad the channel with extra rows so scrollHeight > clientHeight
     // and "at bottom vs at top" is observable. The autojoin channel

--- a/cicchetto/e2e/tests/members-prefix-op-not-clipped.spec.ts
+++ b/cicchetto/e2e/tests/members-prefix-op-not-clipped.spec.ts
@@ -31,10 +31,10 @@
 // non-clipped width) is per-tier, NOT per-channel — any channel where
 // vjt is +o suffices.
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "members-prefix-buddy";
 const CHANNEL = "#members-prefix-test";

--- a/cicchetto/e2e/tests/message-replay-on-reconnect.spec.ts
+++ b/cicchetto/e2e/tests/message-replay-on-reconnect.spec.ts
@@ -112,13 +112,3 @@ test("message replay on reconnect — peer PRIVMSG during WS gap appears after r
       await peer.disconnect("test cleanup");
     }
   });
-
-declare global {
-  interface Window {
-    __cic_dropSocketForTests?: () => Promise<void>;
-    __cic_resumeSocketForTests?: () => Promise<void>;
-    __cic_socketHealth?: {
-      state: () => { state: string };
-    };
-  }
-}

--- a/cicchetto/e2e/tests/message-replay-on-reconnect.spec.ts
+++ b/cicchetto/e2e/tests/message-replay-on-reconnect.spec.ts
@@ -25,90 +25,89 @@
 // have a peer send a PRIVMSG while cic is disconnected, reconnect.
 // The message must appear in the scrollback pane WITHOUT a refresh.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "replay-peer";
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const MSG_DURING_GAP = "msg-during-ws-gap";
 const MSG_BEFORE_GAP = "msg-before-ws-gap";
 
-test("message replay on reconnect — peer PRIVMSG during WS gap appears after re-join without refresh",
-  async ({ page }) => {
-    const vjt = getSeededVjt();
-    await loginAs(page, vjt);
+test("message replay on reconnect — peer PRIVMSG during WS gap appears after re-join without refresh", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
 
-    // Focus the channel so its scrollback pane renders + its per-channel
-    // topic is subscribed. The reconnect-backfill cursor (lastSeenIdByKey)
-    // requires at least one rendered row to know where to resume from.
-    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+  // Focus the channel so its scrollback pane renders + its per-channel
+  // topic is subscribed. The reconnect-backfill cursor (lastSeenIdByKey)
+  // requires at least one rendered row to know where to resume from.
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
 
-    const peer = await IrcPeer.connect({ nick: PEER_NICK });
-    try {
-      await peer.join(CHANNEL);
+  const peer = await IrcPeer.connect({ nick: PEER_NICK });
+  try {
+    await peer.join(CHANNEL);
 
-      // Phase 1 — send a baseline message WHILE connected. This row is
-      // what populates `lastSeenIdByKey` so the backfill cursor is set.
-      peer.privmsg(CHANNEL, MSG_BEFORE_GAP);
-      await expect(scrollbackLine(page, "privmsg", MSG_BEFORE_GAP)).toBeVisible();
+    // Phase 1 — send a baseline message WHILE connected. This row is
+    // what populates `lastSeenIdByKey` so the backfill cursor is set.
+    peer.privmsg(CHANNEL, MSG_BEFORE_GAP);
+    await expect(scrollbackLine(page, "privmsg", MSG_BEFORE_GAP)).toBeVisible();
 
-      // Phase 2 — drop the cic socket AND HOLD it down. The drop emits
-      // phx_close on every joined Channel (including this one). Unlike an
-      // unexpected disconnect, `__cic_dropSocketForTests` does NOT
-      // auto-reconnect: phoenix.js's explicit `disconnect()` resets its
-      // reconnectTimer, so the socket stays down until the explicit resume
-      // in Phase 3b. The hook resolves only once the WS close has landed.
-      await page.evaluate(async () => {
-        if (!window.__cic_dropSocketForTests) {
-          throw new Error("__cic_dropSocketForTests hook missing");
-        }
-        await window.__cic_dropSocketForTests();
-      });
-      // The socket is now held down, so `socketHealth.state` is STABLY
-      // non-open — this gate is deterministic. (The pre-hardening variant
-      // reconnected immediately and this poll raced phoenix's fast reopen,
-      // timing out ~40% under load — see socket.ts + GH #186.)
-      await page.waitForFunction(
-        () => window.__cic_socketHealth?.state().state !== "open",
-      );
+    // Phase 2 — drop the cic socket AND HOLD it down. The drop emits
+    // phx_close on every joined Channel (including this one). Unlike an
+    // unexpected disconnect, `__cic_dropSocketForTests` does NOT
+    // auto-reconnect: phoenix.js's explicit `disconnect()` resets its
+    // reconnectTimer, so the socket stays down until the explicit resume
+    // in Phase 3b. The hook resolves only once the WS close has landed.
+    await page.evaluate(async () => {
+      if (!window.__cic_dropSocketForTests) {
+        throw new Error("__cic_dropSocketForTests hook missing");
+      }
+      await window.__cic_dropSocketForTests();
+    });
+    // The socket is now held down, so `socketHealth.state` is STABLY
+    // non-open — this gate is deterministic. (The pre-hardening variant
+    // reconnected immediately and this poll raced phoenix's fast reopen,
+    // timing out ~40% under load — see socket.ts + GH #186.)
+    await page.waitForFunction(() => window.__cic_socketHealth?.state().state !== "open");
 
-      // Phase 3 — peer sends a PRIVMSG while cic is CONFIRMED disconnected
-      // (the gate above passed). Server persists it (Session.Server's
-      // persist runs synchronously) and broadcasts on the per-channel
-      // topic; with cic's WS held down, the broadcast has no subscriber and
-      // the row is dropped from the live stream. Only the DB row remains.
-      peer.privmsg(CHANNEL, MSG_DURING_GAP);
+    // Phase 3 — peer sends a PRIVMSG while cic is CONFIRMED disconnected
+    // (the gate above passed). Server persists it (Session.Server's
+    // persist runs synchronously) and broadcasts on the per-channel
+    // topic; with cic's WS held down, the broadcast has no subscriber and
+    // the row is dropped from the live stream. Only the DB row remains.
+    peer.privmsg(CHANNEL, MSG_DURING_GAP);
 
-      // Phase 3b — resume the socket. Held down deterministically until
-      // now, so the gap PRIVMSG above was guaranteed sent with no live cic
-      // subscriber. `connect()` reconnects and phoenix auto-rejoins every
-      // channel; each per-channel rejoin's onJoinOk fires the backfill.
-      await page.evaluate(async () => {
-        if (!window.__cic_resumeSocketForTests) {
-          throw new Error("__cic_resumeSocketForTests hook missing");
-        }
-        await window.__cic_resumeSocketForTests();
-      });
+    // Phase 3b — resume the socket. Held down deterministically until
+    // now, so the gap PRIVMSG above was guaranteed sent with no live cic
+    // subscriber. `connect()` reconnects and phoenix auto-rejoins every
+    // channel; each per-channel rejoin's onJoinOk fires the backfill.
+    await page.evaluate(async () => {
+      if (!window.__cic_resumeSocketForTests) {
+        throw new Error("__cic_resumeSocketForTests hook missing");
+      }
+      await window.__cic_resumeSocketForTests();
+    });
 
-      // Phase 4 — once cic reconnects, the re-join's onJoinOk callback
-      // fires the backfill flow. The
-      // missed PRIVMSG is fetched via REST `?after=<lastSeenId>` and
-      // appended through the same `appendToScrollback` verb the live
-      // WS handler uses — appearing in the scrollback pane WITHOUT a
-      // page refresh.
-      //
-      // Generous timeout because phoenix.js has a backoff on rejoin
-      // (1s/2s/5s/10s/30s). First retry typically lands within ~1s
-      // but CI under load can take longer.
-      await expect(scrollbackLine(page, "privmsg", MSG_DURING_GAP)).toBeVisible({ timeout: 30_000 });
+    // Phase 4 — once cic reconnects, the re-join's onJoinOk callback
+    // fires the backfill flow. The
+    // missed PRIVMSG is fetched via REST `?after=<lastSeenId>` and
+    // appended through the same `appendToScrollback` verb the live
+    // WS handler uses — appearing in the scrollback pane WITHOUT a
+    // page refresh.
+    //
+    // Generous timeout because phoenix.js has a backoff on rejoin
+    // (1s/2s/5s/10s/30s). First retry typically lands within ~1s
+    // but CI under load can take longer.
+    await expect(scrollbackLine(page, "privmsg", MSG_DURING_GAP)).toBeVisible({ timeout: 30_000 });
 
-      // Both messages present, in order. The dedupe-by-id contract in
-      // `appendToScrollback` guarantees no duplicates even if the
-      // backfill response and a hypothetical live re-broadcast race.
-      await expect(scrollbackLine(page, "privmsg", MSG_BEFORE_GAP)).toBeVisible();
-    } finally {
-      await peer.disconnect("test cleanup");
-    }
-  });
+    // Both messages present, in order. The dedupe-by-id contract in
+    // `appendToScrollback` guarantees no duplicates even if the
+    // backfill response and a hypothetical live re-broadcast race.
+    await expect(scrollbackLine(page, "privmsg", MSG_BEFORE_GAP)).toBeVisible();
+  } finally {
+    await peer.disconnect("test cleanup");
+  }
+});

--- a/cicchetto/e2e/tests/mirc-full-format-render.spec.ts
+++ b/cicchetto/e2e/tests/mirc-full-format-render.spec.ts
@@ -10,10 +10,10 @@
 // resolves differently. The vitest unit tests pin the parser/classes;
 // this pins the rendered visual.
 
-import { test, expect } from "../fixtures/test";
 import { loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const TEST_CHANNEL = "#bofh";
 
@@ -38,10 +38,7 @@ test("full mIRC: peer PRIVMSG renders strikethrough + monospace + hex-color span
   try {
     await peer.join(TEST_CHANNEL);
     // \x1e strikethrough toggle, \x11 monospace toggle, \x04RRGGBB hex.
-    peer.privmsg(
-      TEST_CHANNEL,
-      `\x1e${strikeTag}\x1e \x11${monoTag}\x11 \x04ff8800${hexTag}\x04`,
-    );
+    peer.privmsg(TEST_CHANNEL, `\x1e${strikeTag}\x1e \x11${monoTag}\x11 \x04ff8800${hexTag}\x04`);
 
     const lines = scrollbackLines(page);
 
@@ -51,9 +48,7 @@ test("full mIRC: peer PRIVMSG renders strikethrough + monospace + hex-color span
     ).toHaveCount(1, { timeout: 10_000 });
 
     // Monospace run → .scrollback-mirc-monospace span.
-    await expect(
-      lines.locator(".scrollback-mirc-monospace", { hasText: monoTag }),
-    ).toHaveCount(1);
+    await expect(lines.locator(".scrollback-mirc-monospace", { hasText: monoTag })).toHaveCount(1);
 
     // Hex color run → the run span's text is exactly hexTag and its
     // computed color is #ff8800 = rgb(255, 136, 0).

--- a/cicchetto/e2e/tests/multiline-compose-fanout.spec.ts
+++ b/cicchetto/e2e/tests/multiline-compose-fanout.spec.ts
@@ -10,9 +10,9 @@
 // the per-line sends — the whole point of the fix; jsdom unit tests only
 // assert the split, not that grappa + leaf accept the frames.
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/names140-modal.spec.ts
+++ b/cicchetto/e2e/tests/names140-modal.spec.ts
@@ -23,10 +23,10 @@
 // test/grappa/session/{event_router,server,wire}_test.exs; the grouping
 // + dismiss render logic in cicchetto/src/__tests__/NamesModal.test.tsx.
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "names140-peer";
 const CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/nick-case-incoming.spec.ts
+++ b/cicchetto/e2e/tests/nick-case-incoming.spec.ts
@@ -26,7 +26,6 @@
 // case-folding, so one user-class spec suffices). No `@webkit` tag →
 // desktop/chromium project only, so the `.shell-sidebar` selector applies.
 
-import { expect, test } from "../fixtures/test";
 import {
   composeSend,
   loginAs,
@@ -36,6 +35,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK_LOWER = "foldreplypeer";
 const PEER_NICK_PROPER = "FoldReplyPeer";

--- a/cicchetto/e2e/tests/nick-case-sensitivity.spec.ts
+++ b/cicchetto/e2e/tests/nick-case-sensitivity.spec.ts
@@ -27,10 +27,10 @@
 // cic's case-folding (subject-agnostic) so a single user-class spec
 // is sufficient here.
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK_LOWER = "casepeer";
 const PEER_NICK_UPPER = "CASEPEER";

--- a/cicchetto/e2e/tests/nick-follow-query.spec.ts
+++ b/cicchetto/e2e/tests/nick-follow-query.spec.ts
@@ -23,7 +23,6 @@
 // subject-agnostic, so one user-class spec suffices). No `@webkit` tag →
 // desktop/chromium project only, so the `.shell-sidebar` selector applies.
 
-import { expect, test } from "../fixtures/test";
 import {
   composeSend,
   loginAs,
@@ -34,6 +33,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // Real grappa session (not a seed-per-spec DB) — unique suffixes so retries
 // / sibling specs don't strict-mode-collide on persisted scrollback or on a
@@ -133,9 +133,7 @@ test("query window follows a peer NICK change — relabels, keeps history, route
     // The send is the wait's trigger (#806): the peer is listening before
     // it fires, and the delivery budget starts once it has fired — the
     // round trip inside `composeSend` is not charged to delivery.
-    await peer.waitForPrivmsg(NETWORK_NICK, FOLLOWUP_BODY, () =>
-      composeSend(page, FOLLOWUP_BODY),
-    ); // fails with cause SILENCE if grappa still routed to the stale nick
+    await peer.waitForPrivmsg(NETWORK_NICK, FOLLOWUP_BODY, () => composeSend(page, FOLLOWUP_BODY)); // fails with cause SILENCE if grappa still routed to the stale nick
     await expect(
       page.locator('[data-testid="scrollback-line"]', { hasText: FOLLOWUP_BODY }),
     ).toBeVisible({ timeout: 5_000 });

--- a/cicchetto/e2e/tests/notif-tap-focus.spec.ts
+++ b/cicchetto/e2e/tests/notif-tap-focus.spec.ts
@@ -31,10 +31,10 @@
 // `query_windows` row) selected a window that was never opened: dead
 // selection, no sidebar row.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, sidebarWindow } from "../fixtures/cicchettoPage";
 import { buildPushDeepLink, dispatchNavigateMessage } from "../fixtures/pushTap";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 // Peer nicks with NO query window open in cic — the deep-link targets a
 // DM whose window must be created by the tap itself (the
@@ -45,7 +45,11 @@ const DM_PEER_WARM = "notif146-warm";
 
 // Seeds auth the same way loginAs does, then boots straight at the
 // deep-link — mirrors the SW's `openWindow(url)` on a closed PWA.
-async function coldBootAt(page: Parameters<typeof loginAs>[0], vjt: ReturnType<typeof getSeededVjt>, url: string): Promise<void> {
+async function coldBootAt(
+  page: Parameters<typeof loginAs>[0],
+  vjt: ReturnType<typeof getSeededVjt>,
+  url: string,
+): Promise<void> {
   await page.addInitScript(
     ([token, subjectJson]) => {
       localStorage.setItem("grappa-token", token);

--- a/cicchetto/e2e/tests/notif-tap-sw-controlled.spec.ts
+++ b/cicchetto/e2e/tests/notif-tap-sw-controlled.spec.ts
@@ -15,10 +15,10 @@
 // it. If the deep-link routing survives the network-served path but
 // NOT the SW-served path, this is RED while the shipped gate is GREEN.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, sidebarWindow } from "../fixtures/cicchettoPage";
 import { buildPushDeepLink } from "../fixtures/pushTap";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const DM_PEER = "notif146-swctl";
 

--- a/cicchetto/e2e/tests/notif-tap-sw-handler.spec.ts
+++ b/cicchetto/e2e/tests/notif-tap-sw-handler.spec.ts
@@ -18,10 +18,10 @@
 // selected). RED against the `await focus(); postMessage()` ordering,
 // GREEN once delivery no longer depends on focus() resolving.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, sidebarWindow } from "../fixtures/cicchettoPage";
 import { buildPushDeepLink } from "../fixtures/pushTap";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 test("#146 recurrence — real SW notificationclick delivers the navigate even when focus() rejects", async ({
   page,

--- a/cicchetto/e2e/tests/p0a-whois-flags.spec.ts
+++ b/cicchetto/e2e/tests/p0a-whois-flags.spec.ts
@@ -27,11 +27,11 @@
 // from which the other 10 P-0a numerics follow by same-shape
 // inductive reasoning.
 
-import { test, expect } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { awaitMail, extractFromMail, resetMailpit } from "../fixtures/mailpit";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "p0a-target";
 const PEER_PASSWORD = "p0a-test-password-not-secret";

--- a/cicchetto/e2e/tests/p0b-peer-away.spec.ts
+++ b/cicchetto/e2e/tests/p0b-peer-away.spec.ts
@@ -12,7 +12,6 @@
 // Per `feedback_ux_e2e_mandatory`: every cic UX-touching change ships
 // with a Playwright e2e via scripts/integration.sh.
 
-import { test, expect } from "../fixtures/test";
 import {
   composeSend,
   loginAs,
@@ -22,6 +21,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "p0b-away-peer";
 const AWAY_MESSAGE = "Gone fishing — back at 5pm";

--- a/cicchetto/e2e/tests/p0c-whowas-card-historical.spec.ts
+++ b/cicchetto/e2e/tests/p0c-whowas-card-historical.spec.ts
@@ -17,10 +17,10 @@
 // Per `feedback_ux_e2e_mandatory`: every cic UX-touching change ships
 // with a Playwright e2e via scripts/integration.sh.
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "p0c-whowas-peer";
 const CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/p0e-invite-ack.spec.ts
+++ b/cicchetto/e2e/tests/p0e-invite-ack.spec.ts
@@ -31,10 +31,10 @@
 // per-spec-distinct so concurrent test runs don't collide on +o
 // ownership.
 
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "p0e-invitee";
 const CHANNEL = "#p0e-invite-test";

--- a/cicchetto/e2e/tests/push-181-resubscribe-supersede.spec.ts
+++ b/cicchetto/e2e/tests/push-181-resubscribe-supersede.spec.ts
@@ -26,10 +26,10 @@
 // behaviour iOS exhibits.
 
 import type { BrowserContext } from "@playwright/test";
-import { expect, test } from "../fixtures/test";
 import { loginAs, openSettingsSection, selectChannel } from "../fixtures/cicchettoPage";
 import { resetPushCatcher, resetPushSubscriptions } from "../fixtures/push";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const ENDPOINT_A = "https://push.example/e2e/resub-A";
 const ENDPOINT_B = "https://push.example/e2e/resub-B";
@@ -160,7 +160,5 @@ test("silent drop → controllerchange re-subscribes with supersedes; device lis
   expect(body.supersedes).toBe(ENDPOINT_A);
 
   // Server superseded the ghost: exactly ONE device remains (B), not two.
-  await expect
-    .poll(async () => listDeviceCount(vjt.token), { timeout: 5_000 })
-    .toBe(1);
+  await expect.poll(async () => listDeviceCount(vjt.token), { timeout: 5_000 }).toBe(1);
 });

--- a/cicchetto/e2e/tests/push-459-optin-banner.spec.ts
+++ b/cicchetto/e2e/tests/push-459-optin-banner.spec.ts
@@ -67,7 +67,9 @@ test("#459 — the push opt-in banner offers push on login", async ({ page }) =>
   await expect(banner.locator(".error-banner-dismiss")).toBeVisible();
 });
 
-test("#459 — [of course!] runs the accept path and does not persist a decline", async ({ page }) => {
+test("#459 — [of course!] runs the accept path and does not persist a decline", async ({
+  page,
+}) => {
   const vjt = getSeededVjt();
   await stubOptinNotification(page);
   await loginAs(page, vjt);
@@ -81,7 +83,9 @@ test("#459 — [of course!] runs the accept path and does not persist a decline"
   // count is the unambiguous witness that [of course!] took the accept path.
   await expect
     .poll(() =>
-      page.evaluate(() => (window as unknown as { __optinReqPermCalls: number }).__optinReqPermCalls),
+      page.evaluate(
+        () => (window as unknown as { __optinReqPermCalls: number }).__optinReqPermCalls,
+      ),
     )
     .toBeGreaterThan(0);
 

--- a/cicchetto/e2e/tests/push-964-device-row.spec.ts
+++ b/cicchetto/e2e/tests/push-964-device-row.spec.ts
@@ -30,7 +30,6 @@
 // row. It also proves the other half of the marker contract: the marker is
 // per-BROWSER, not per-user, so the same account elsewhere sees no marker.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, openSettingsSection, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import {
@@ -44,6 +43,7 @@ import {
   stubPushManager,
 } from "../fixtures/push";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "n964-dmer";
 const SUB_ID = "964-device-row";

--- a/cicchetto/e2e/tests/push-focus-suppression.spec.ts
+++ b/cicchetto/e2e/tests/push-focus-suppression.spec.ts
@@ -22,7 +22,6 @@
 //   * visible + BLURRED  → triggering DM → push-catcher DOES receive it.  ← #192
 //   * visible + REFOCUSED → triggering DM → push-catcher receives NOTHING.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import {
@@ -37,6 +36,7 @@ import {
   stubPushManager,
 } from "../fixtures/push";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "focus-suppressor";
 const SUB_ID = "focus-suppression";

--- a/cicchetto/e2e/tests/push-foreground-suppression.spec.ts
+++ b/cicchetto/e2e/tests/push-foreground-suppression.spec.ts
@@ -25,7 +25,6 @@
 // not exercised here (the integration stack has no real push vendor, so
 // the SW never receives a real PushEvent).
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import {
@@ -39,6 +38,7 @@ import {
   stubPushManager,
 } from "../fixtures/push";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "fg-suppressor";
 const SUB_ID = "foreground-suppression";

--- a/cicchetto/e2e/tests/push-install-toggle-subscribe.spec.ts
+++ b/cicchetto/e2e/tests/push-install-toggle-subscribe.spec.ts
@@ -21,7 +21,6 @@
 //   * The toggle is checked.
 //   * No banner (banner is the unhappy-path surface).
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, openSettingsSection, selectChannel } from "../fixtures/cicchettoPage";
 import {
   pushCatcherEndpoint,
@@ -30,6 +29,7 @@ import {
   stubPushManager,
 } from "../fixtures/push";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SUB_ID = "install-happy";
 
@@ -54,8 +54,7 @@ test("master toggle enables push: subscribe → POST /push/subscriptions → dev
   // response status. POST may fire before the devices-list refresh,
   // so we set up the waiter before the click.
   const subscribePostPromise = page.waitForResponse(
-    (resp) =>
-      resp.url().endsWith("/push/subscriptions") && resp.request().method() === "POST",
+    (resp) => resp.url().endsWith("/push/subscriptions") && resp.request().method() === "POST",
     { timeout: 5_000 },
   );
 

--- a/cicchetto/e2e/tests/push-permission-denied.spec.ts
+++ b/cicchetto/e2e/tests/push-permission-denied.spec.ts
@@ -20,10 +20,10 @@
 // copy + a separate spec if/when it earns regression coverage. The
 // current B5 plan calls out the denied path specifically.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, openSettingsSection, sidebarWindow } from "../fixtures/cicchettoPage";
 import { resetPushSubscriptions, stubPushManagerDenied } from "../fixtures/push";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 test("push permission denied — toggle stays OFF, banner explains", async ({ page, context }) => {
   const vjt = getSeededVjt();

--- a/cicchetto/e2e/tests/push-prefs-whitelist.spec.ts
+++ b/cicchetto/e2e/tests/push-prefs-whitelist.spec.ts
@@ -24,7 +24,6 @@
 // `should_notify?/4` predicate-level (test/grappa/push/triggers_test.exs);
 // this spec covers the UI → REST → server eval roundtrip.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, openSettingsSection, selectChannel } from "../fixtures/cicchettoPage";
 import { partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
@@ -39,6 +38,7 @@ import {
   stubPushManager,
 } from "../fixtures/push";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "b5-prefser";
 const ALLOW_CHANNEL = "#b5-allow";

--- a/cicchetto/e2e/tests/push-trigger-channel-mention.spec.ts
+++ b/cicchetto/e2e/tests/push-trigger-channel-mention.spec.ts
@@ -32,7 +32,6 @@
 // vendor-shaped headers". Body decryption is a job for B6 manual
 // PWA smoke (where a real iOS device renders the actual notif).
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
@@ -47,6 +46,7 @@ import {
   stubPushManager,
 } from "../fixtures/push";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "b5-mentioner";
 const TARGET_CHANNEL = "#b5-mention";

--- a/cicchetto/e2e/tests/push-trigger-dm.spec.ts
+++ b/cicchetto/e2e/tests/push-trigger-dm.spec.ts
@@ -17,7 +17,6 @@
 // of cic state, and we want the DM unfocused so dedup doesn't
 // short-circuit (dedup is the dedup spec).
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import {
@@ -30,6 +29,7 @@ import {
   stubPushManager,
 } from "../fixtures/push";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "b5-dmer";
 const SUB_ID = "dm";

--- a/cicchetto/e2e/tests/r6-own-action-no-events-badge.spec.ts
+++ b/cicchetto/e2e/tests/r6-own-action-no-events-badge.spec.ts
@@ -46,7 +46,6 @@
 // Cleanup: re-JOIN of #bofh restores the seed state. No afterEach
 // restoration needed.
 
-import { expect, test } from "../fixtures/test";
 import {
   loginAs,
   selectChannel,
@@ -55,6 +54,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { joinChannel, partChannel, restoreReadCursorToTail } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/recover-identity-real.spec.ts
+++ b/cicchetto/e2e/tests/recover-identity-real.spec.ts
@@ -77,23 +77,18 @@
 // against the same container and the spec is re-runnable N times on ONE
 // stack.
 
-import { expect, test } from "@playwright/test";
 import type { Browser } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import {
   composeSend,
   expectShellReady,
   selectChannel,
   waitForUserTopicReady,
 } from "../fixtures/cicchettoPage";
-import {
-  GRAPPA_BASE_URL,
-  loginVisitor,
-  mintVisitor,
-  reapVisitors,
-} from "../fixtures/grappaApi";
-import { getSeededAdmin } from "../fixtures/seedData";
-import { awaitMail, extractFromMail, resetMailpit } from "../fixtures/mailpit";
+import { GRAPPA_BASE_URL, loginVisitor, mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
+import { awaitMail, extractFromMail, resetMailpit } from "../fixtures/mailpit";
+import { getSeededAdmin } from "../fixtures/seedData";
 
 // Boot cic as a visitor (local per-spec helper — the established pattern; each
 // visitor spec inlines its own). Seeds the two auth localStorage keys the SPA
@@ -102,7 +97,10 @@ import { IrcPeer } from "../fixtures/ircClient";
 async function bootVisitor(
   browser: Browser,
   visitor: { id: string; nick: string; token: string },
-): Promise<{ ctx: Awaited<ReturnType<Browser["newContext"]>>; page: import("@playwright/test").Page }> {
+): Promise<{
+  ctx: Awaited<ReturnType<Browser["newContext"]>>;
+  page: import("@playwright/test").Page;
+}> {
   const ctx = await browser.newContext();
   const page = await ctx.newPage();
   await page.addInitScript(
@@ -111,7 +109,10 @@ async function bootVisitor(
       localStorage.setItem("grappa-subject", subjectJson);
       localStorage.setItem("cic.installChoice", "browser");
     },
-    [visitor.token, JSON.stringify({ kind: "visitor", id: visitor.id, nick: visitor.nick })] as const,
+    [
+      visitor.token,
+      JSON.stringify({ kind: "visitor", id: visitor.id, nick: visitor.nick }),
+    ] as const,
   );
   await page.goto("/");
   await expectShellReady(page);
@@ -183,9 +184,9 @@ test.describe("#581 recover-identity (real services)", () => {
 
       await page.locator(".sidebar-home-btn").click();
       // The launcher never renders for an anon (non-recoverable) credential.
-      await expect(
-        page.getByTestId(`home-recover-identity-${visitor.network_slug}`),
-      ).toHaveCount(0);
+      await expect(page.getByTestId(`home-recover-identity-${visitor.network_slug}`)).toHaveCount(
+        0,
+      );
     } finally {
       if (ctx) await ctx.close();
       await reapVisitors(admin.token, visitor?.id);

--- a/cicchetto/e2e/tests/refresh-on-join-ws-gap-recovery.spec.ts
+++ b/cicchetto/e2e/tests/refresh-on-join-ws-gap-recovery.spec.ts
@@ -38,92 +38,91 @@
 // just rejoins); CP26 covered the original gap-recovery contract that
 // R-5 preserves.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "refresh-peer";
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const MSG_BEFORE_GAP = "msg-r5-before-ws-gap";
 const MSG_DURING_GAP = "msg-r5-during-ws-gap";
 
-test("CP29 R-5 — peer PRIVMSG during WS gap recovered via refresh-on-WS-join-ok",
-  async ({ page }) => {
-    const vjt = getSeededVjt();
-    await loginAs(page, vjt);
+test("CP29 R-5 — peer PRIVMSG during WS gap recovered via refresh-on-WS-join-ok", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
 
-    // Focus the channel so its scrollback pane renders + its per-channel
-    // topic is subscribed. The reconnectBackfill high-water mark
-    // (consumed by refreshScrollback's getResumeCursor) requires at
-    // least one rendered row to know where to resume from — the live
-    // baseline message below populates it.
-    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+  // Focus the channel so its scrollback pane renders + its per-channel
+  // topic is subscribed. The reconnectBackfill high-water mark
+  // (consumed by refreshScrollback's getResumeCursor) requires at
+  // least one rendered row to know where to resume from — the live
+  // baseline message below populates it.
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
 
-    const peer = await IrcPeer.connect({ nick: PEER_NICK });
-    try {
-      await peer.join(CHANNEL);
+  const peer = await IrcPeer.connect({ nick: PEER_NICK });
+  try {
+    await peer.join(CHANNEL);
 
-      // Phase 1 — baseline message WHILE connected. Rendered live → the
-      // high-water mark for this topic gets set to the row's id via
-      // recordSeen inside subscribe.ts's routeMessage.
-      peer.privmsg(CHANNEL, MSG_BEFORE_GAP);
-      await expect(scrollbackLine(page, "privmsg", MSG_BEFORE_GAP)).toBeVisible();
+    // Phase 1 — baseline message WHILE connected. Rendered live → the
+    // high-water mark for this topic gets set to the row's id via
+    // recordSeen inside subscribe.ts's routeMessage.
+    peer.privmsg(CHANNEL, MSG_BEFORE_GAP);
+    await expect(scrollbackLine(page, "privmsg", MSG_BEFORE_GAP)).toBeVisible();
 
-      // Phase 2 — drop the cic socket AND HOLD it down. The drop emits
-      // phx_close on every joined Channel. Unlike an unexpected disconnect,
-      // `__cic_dropSocketForTests` does NOT auto-reconnect: phoenix.js's
-      // explicit `disconnect()` resets its reconnectTimer, so the socket
-      // stays down until the explicit resume in Phase 3b. The hook resolves
-      // only once the WS close has landed.
-      await page.evaluate(async () => {
-        if (!window.__cic_dropSocketForTests) {
-          throw new Error("__cic_dropSocketForTests hook missing");
-        }
-        await window.__cic_dropSocketForTests();
-      });
-      // The socket is now held down, so `socketHealth.state` is STABLY
-      // non-open — this gate is deterministic. (The pre-hardening variant
-      // reconnected immediately and this poll raced phoenix's fast reopen,
-      // timing out ~40% under load — see socket.ts + GH #186.)
-      await page.waitForFunction(
-        () => window.__cic_socketHealth?.state().state !== "open",
-      );
+    // Phase 2 — drop the cic socket AND HOLD it down. The drop emits
+    // phx_close on every joined Channel. Unlike an unexpected disconnect,
+    // `__cic_dropSocketForTests` does NOT auto-reconnect: phoenix.js's
+    // explicit `disconnect()` resets its reconnectTimer, so the socket
+    // stays down until the explicit resume in Phase 3b. The hook resolves
+    // only once the WS close has landed.
+    await page.evaluate(async () => {
+      if (!window.__cic_dropSocketForTests) {
+        throw new Error("__cic_dropSocketForTests hook missing");
+      }
+      await window.__cic_dropSocketForTests();
+    });
+    // The socket is now held down, so `socketHealth.state` is STABLY
+    // non-open — this gate is deterministic. (The pre-hardening variant
+    // reconnected immediately and this poll raced phoenix's fast reopen,
+    // timing out ~40% under load — see socket.ts + GH #186.)
+    await page.waitForFunction(() => window.__cic_socketHealth?.state().state !== "open");
 
-      // Phase 3 — peer sends a PRIVMSG while cic is CONFIRMED disconnected
-      // (the gate above passed). Server persists (Session.Server's persist
-      // runs synchronously) and broadcasts on the per-channel topic; cic's
-      // WS is held down, so the broadcast has no subscriber and the row is
-      // dropped from the live stream. Only the DB row remains.
-      peer.privmsg(CHANNEL, MSG_DURING_GAP);
+    // Phase 3 — peer sends a PRIVMSG while cic is CONFIRMED disconnected
+    // (the gate above passed). Server persists (Session.Server's persist
+    // runs synchronously) and broadcasts on the per-channel topic; cic's
+    // WS is held down, so the broadcast has no subscriber and the row is
+    // dropped from the live stream. Only the DB row remains.
+    peer.privmsg(CHANNEL, MSG_DURING_GAP);
 
-      // Phase 3b — resume the socket. Held down deterministically until
-      // now, so the gap PRIVMSG above was guaranteed sent with no live cic
-      // subscriber. phoenix reconnects and auto-rejoins every channel; the
-      // per-channel rejoin's onJoinOk fires refreshScrollback.
-      await page.evaluate(async () => {
-        if (!window.__cic_resumeSocketForTests) {
-          throw new Error("__cic_resumeSocketForTests hook missing");
-        }
-        await window.__cic_resumeSocketForTests();
-      });
+    // Phase 3b — resume the socket. Held down deterministically until
+    // now, so the gap PRIVMSG above was guaranteed sent with no live cic
+    // subscriber. phoenix reconnects and auto-rejoins every channel; the
+    // per-channel rejoin's onJoinOk fires refreshScrollback.
+    await page.evaluate(async () => {
+      if (!window.__cic_resumeSocketForTests) {
+        throw new Error("__cic_resumeSocketForTests hook missing");
+      }
+      await window.__cic_resumeSocketForTests();
+    });
 
-      // Phase 4 — cic reconnects. The per-channel rejoin's onJoinOk
-      // callback calls refreshScrollback; the resume cursor is the
-      // high-water mark from Phase 1, so refreshScrollback fetches
-      // every row with id > that mark — including the gap message —
-      // and appends through appendToScrollback (id-deduped).
-      //
-      // Generous timeout because phoenix.js has a backoff on rejoin
-      // (1s/2s/5s/10s/30s). First retry typically lands within ~1s
-      // but CI under load can take longer.
-      await expect(scrollbackLine(page, "privmsg", MSG_DURING_GAP)).toBeVisible({ timeout: 30_000 });
+    // Phase 4 — cic reconnects. The per-channel rejoin's onJoinOk
+    // callback calls refreshScrollback; the resume cursor is the
+    // high-water mark from Phase 1, so refreshScrollback fetches
+    // every row with id > that mark — including the gap message —
+    // and appends through appendToScrollback (id-deduped).
+    //
+    // Generous timeout because phoenix.js has a backoff on rejoin
+    // (1s/2s/5s/10s/30s). First retry typically lands within ~1s
+    // but CI under load can take longer.
+    await expect(scrollbackLine(page, "privmsg", MSG_DURING_GAP)).toBeVisible({ timeout: 30_000 });
 
-      // Both messages present, in chronological order. Dedupe-by-id
-      // in appendToScrollback guarantees no duplicates even if a
-      // hypothetical live re-broadcast races the refresh fetch.
-      await expect(scrollbackLine(page, "privmsg", MSG_BEFORE_GAP)).toBeVisible();
-    } finally {
-      await peer.disconnect("test cleanup");
-    }
-  });
+    // Both messages present, in chronological order. Dedupe-by-id
+    // in appendToScrollback guarantees no duplicates even if a
+    // hypothetical live re-broadcast races the refresh fetch.
+    await expect(scrollbackLine(page, "privmsg", MSG_BEFORE_GAP)).toBeVisible();
+  } finally {
+    await peer.disconnect("test cleanup");
+  }
+});

--- a/cicchetto/e2e/tests/refresh-on-join-ws-gap-recovery.spec.ts
+++ b/cicchetto/e2e/tests/refresh-on-join-ws-gap-recovery.spec.ts
@@ -127,13 +127,3 @@ test("CP29 R-5 — peer PRIVMSG during WS gap recovered via refresh-on-WS-join-o
       await peer.disconnect("test cleanup");
     }
   });
-
-declare global {
-  interface Window {
-    __cic_dropSocketForTests?: () => Promise<void>;
-    __cic_resumeSocketForTests?: () => Promise<void>;
-    __cic_socketHealth?: {
-      state: () => { state: string };
-    };
-  }
-}

--- a/cicchetto/e2e/tests/registration-wizard.spec.ts
+++ b/cicchetto/e2e/tests/registration-wizard.spec.ts
@@ -96,10 +96,7 @@ function networksJson() {
 // through to the real nginx-test via route.continue(); every API path is
 // answered locally so no request reaches a real grappa/IRC backend. The
 // NickServ `messages` POST is captured into `sent` for the body-spy.
-async function stubRest(
-  page: import("@playwright/test").Page,
-  sent: SentMessage[],
-): Promise<void> {
+async function stubRest(page: import("@playwright/test").Page, sent: SentMessage[]): Promise<void> {
   await page.route("**/*", async (route) => {
     const req = route.request();
     const { pathname } = new URL(req.url());
@@ -120,7 +117,10 @@ async function stubRest(
       return;
     }
     if (pathname === "/networks" && req.method() === "GET") {
-      await route.fulfill({ contentType: "application/json", body: JSON.stringify(networksJson()) });
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(networksJson()),
+      });
       return;
     }
     // Per-network channel list — none needed for the home pane assertions.
@@ -218,10 +218,7 @@ async function boot(page: import("@playwright/test").Page): Promise<void> {
   await page.addInitScript(
     ([name]) => {
       localStorage.setItem("grappa-token", "faked-token");
-      localStorage.setItem(
-        "grappa-subject",
-        JSON.stringify({ kind: "user", id: "u1", name }),
-      );
+      localStorage.setItem("grappa-subject", JSON.stringify({ kind: "user", id: "u1", name }));
       localStorage.setItem("cic.installChoice", "browser");
     },
     [USER_NAME] as const,
@@ -301,8 +298,9 @@ test.describe("#349 registration wizard (faked, fast lane)", () => {
     // to a joined channel (Phoenix.PubSub doesn't replay to late joiners).
     await page.waitForFunction(
       (u) =>
-        (window as unknown as { __cic_userTopicReady?: Set<string> }).__cic_userTopicReady?.has(u) ??
-        false,
+        (window as unknown as { __cic_userTopicReady?: Set<string> }).__cic_userTopicReady?.has(
+          u,
+        ) ?? false,
       USER_NAME,
     );
 

--- a/cicchetto/e2e/tests/rev-g-h22-sw-denylist.spec.ts
+++ b/cicchetto/e2e/tests/rev-g-h22-sw-denylist.spec.ts
@@ -27,10 +27,10 @@
 //
 // Sibling test covers /api/server-settings → JSON not SPA shell.
 
-import { expect, test } from "../fixtures/test";
 import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { loginAs } from "../fixtures/cicchettoPage";
 import { getSeededVjt } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 async function waitForServiceWorkerControl(page: import("@playwright/test").Page): Promise<void> {
   // cic's SW uses skipWaiting + clients.claim so the first navigation

--- a/cicchetto/e2e/tests/s21-topic-clear-error-surface.spec.ts
+++ b/cicchetto/e2e/tests/s21-topic-clear-error-surface.spec.ts
@@ -20,9 +20,9 @@
 // jsdom/vitest cannot exercise — the e2e harness is the only place to prove
 // the end-to-end verb-ack round-trip.
 
-import { expect, test } from "../fixtures/test";
 import { composeTextarea, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 // Body (55 z's) > 49 → fails @channel_regex `^[#&+!][^\s,\x07]{1,49}$`.

--- a/cicchetto/e2e/tests/scroll-multi-roundtrip-contamination.spec.ts
+++ b/cicchetto/e2e/tests/scroll-multi-roundtrip-contamination.spec.ts
@@ -29,7 +29,7 @@
 // re-arms auto-follow. The leaving pane's user-scrolled-up state is
 // per-window and MUST NOT leak through the shared DOM node.
 
-import { type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import {
   composeSend,
   loginAs,
@@ -38,8 +38,8 @@ import {
   sidebarWindow,
 } from "../fixtures/cicchettoPage";
 import { restoreReadCursorToTail } from "../fixtures/grappaApi";
-import { expect, test } from "../fixtures/test";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const REST_PAGE_SIZE = 50;

--- a/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
+++ b/cicchetto/e2e/tests/scroll-on-window-switch.spec.ts
@@ -78,8 +78,7 @@
 // overflows the scrollback area; without overflow, "lands at bottom"
 // is vacuously true and "divider above the fold" is unmeasurable.
 
-import { expect, test } from "../fixtures/test";
-import { type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import {
   composeSend,
   loginAs,
@@ -88,12 +87,8 @@ import {
   sidebarWindow,
 } from "../fixtures/cicchettoPage";
 import { restoreReadCursorToTail, setReadCursorToId } from "../fixtures/grappaApi";
-import {
-  AUTOJOIN_CHANNELS,
-  getSeededVjt,
-  NETWORK_NICK,
-  NETWORK_SLUG,
-} from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -519,4 +514,3 @@ test.describe("scroll-on-window-switch — re-selecting a window snaps correctly
     await expect(marker).toHaveCount(0, { timeout: 5_000 });
   });
 });
-

--- a/cicchetto/e2e/tests/scroll-to-bottom-button-contamination.spec.ts
+++ b/cicchetto/e2e/tests/scroll-to-bottom-button-contamination.spec.ts
@@ -33,13 +33,13 @@
 // a proof the fix addresses the prod report — that needs a real iOS
 // device. Kept @webkit-only since the bug is iOS-shaped.
 
-import { type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { composeSend, loginAs, scrollbackLines, selectChannel } from "../fixtures/cicchettoPage";
 import { restoreReadCursorToTail } from "../fixtures/grappaApi";
-import { expect, test } from "../fixtures/test";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
-const CHANNEL = AUTOJOIN_CHANNELS[0]!;
+const CHANNEL = AUTOJOIN_CHANNELS[0];
 const SCROLL_BOTTOM_THRESHOLD_PX = 50;
 const EMPTY_QUERY_PEER = "no-dm-peer-btn";
 
@@ -67,13 +67,17 @@ test.beforeEach(async () => {
 });
 
 test.describe("scroll-to-bottom button (iOS) — tap then window roundtrip lands at bottom", () => {
-  test("@webkit tap scroll-to-bottom, bounce to empty query and back, lands at bottom", async ({ page }) => {
+  test("@webkit tap scroll-to-bottom, bounce to empty query and back, lands at bottom", async ({
+    page,
+  }) => {
     const vjt = getSeededVjt();
     await loginAs(page, vjt);
 
     // Focus #bofh, confirm the first REST page is in.
     await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
-    await expect.poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 }).toBeGreaterThanOrEqual(50);
+    await expect
+      .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
+      .toBeGreaterThanOrEqual(50);
 
     // Open an empty query (the "other" window) so it exists to switch to,
     // then return to #bofh. Done up front so the loadMore + tap below all
@@ -82,9 +86,9 @@ test.describe("scroll-to-bottom button (iOS) — tap then window roundtrip lands
     await composeSend(page, `/query ${EMPTY_QUERY_PEER}`);
     await expect(page.locator(".scrollback-empty")).toBeVisible({ timeout: 5_000 });
     await selectChannel(page, NETWORK_SLUG, CHANNEL);
-    await expect.poll(async () => (await distFromBottom(page)) ?? 999, { timeout: 5_000 }).toBeLessThanOrEqual(
-      SCROLL_BOTTOM_THRESHOLD_PX,
-    );
+    await expect
+      .poll(async () => (await distFromBottom(page)) ?? 999, { timeout: 5_000 })
+      .toBeLessThanOrEqual(SCROLL_BOTTOM_THRESHOLD_PX);
 
     // Exhaust loadMore: scroll to top until the row count stops growing —
     // "load 5-6 pages of history". Leaves the pane near the top, so the
@@ -111,7 +115,9 @@ test.describe("scroll-to-bottom button (iOS) — tap then window roundtrip lands
     // the channel tab are tapped directly (mobile tablist).
     await selectChannel(page, NETWORK_SLUG, EMPTY_QUERY_PEER);
     await selectChannel(page, NETWORK_SLUG, CHANNEL);
-    await expect.poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 }).toBeGreaterThanOrEqual(50);
+    await expect
+      .poll(async () => await scrollbackLines(page).count(), { timeout: 10_000 })
+      .toBeGreaterThanOrEqual(50);
 
     // Contract: #bofh lands at the bottom after the roundtrip — NOT blank.
     await expect

--- a/cicchetto/e2e/tests/slash-commands-bundle.spec.ts
+++ b/cicchetto/e2e/tests/slash-commands-bundle.spec.ts
@@ -30,15 +30,10 @@
 //     Asserting end-to-end would require a live ChanServ NOTICE
 //     reply which the test ircd doesn't bridge.
 
-import { test, expect } from "../fixtures/test";
-import {
-  composeSend,
-  loginAs,
-  selectChannel,
-  sidebarWindow,
-} from "../fixtures/cicchettoPage";
+import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { assertMessagePersisted, partChannel } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -201,9 +196,7 @@ test.describe("slash-commands bundle (24eb1d8 — issues #20, #22, #23)", () => 
     await expect(queryWindow).toHaveCount(0, { timeout: 5_000 });
   });
 
-  test("/quote PING reaches the upstream wire without crashing the session", async ({
-    page,
-  }) => {
+  test("/quote PING reaches the upstream wire without crashing the session", async ({ page }) => {
     const vjt = getSeededVjt();
     const cookie = runId();
 

--- a/cicchetto/e2e/tests/text-selection-restored.spec.ts
+++ b/cicchetto/e2e/tests/text-selection-restored.spec.ts
@@ -10,7 +10,6 @@
 // so computed style is the testable boundary. Real-device dogfood
 // remains the final iOS verification.
 
-import { test, expect } from "../fixtures/test";
 import {
   composeSend,
   composeTextarea,
@@ -19,6 +18,7 @@ import {
   selectChannel,
 } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 // Date.now() suffix (house pattern, see ux-6-f spec): the e2e sqlite

--- a/cicchetto/e2e/tests/u-2-admission-split.spec.ts
+++ b/cicchetto/e2e/tests/u-2-admission-split.spec.ts
@@ -36,7 +36,7 @@
 // afterEach restores caps to permissive defaults so subsequent specs
 // see the seeder baseline.
 
-import { expect, test } from "../fixtures/test";
+import { login, patchNetworkConnectionState } from "../fixtures/grappaApi";
 import {
   ADMIN_IDENTIFIER,
   ADMIN_PASSWORD,
@@ -44,7 +44,7 @@ import {
   getSeededVjt,
   NETWORK_SLUG,
 } from "../fixtures/seedData";
-import { login, patchNetworkConnectionState } from "../fixtures/grappaApi";
+import { expect, test } from "../fixtures/test";
 
 const GRAPPA_BASE_URL = "http://grappa-test:4000";
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
@@ -157,12 +157,12 @@ for (const arm of [
     // only at fresh-spawn time. Idempotent: prior specs may have
     // left vjt parked already → server returns 400 `not_parked` for
     // a re-park; treat that as success (the goal state is reached).
-    await patchNetworkConnectionState(vjt.token, NETWORK_SLUG, { connection_state: "parked" }).catch(
-      (e: unknown) => {
-        if (e instanceof Error && /not_connected|not_parked/.test(e.message)) return;
-        throw e;
-      },
-    );
+    await patchNetworkConnectionState(vjt.token, NETWORK_SLUG, {
+      connection_state: "parked",
+    }).catch((e: unknown) => {
+      if (e instanceof Error && /not_connected|not_parked/.test(e.message)) return;
+      throw e;
+    });
 
     // Admin saturates ONE cap dimension. cap=0 = degenerate lock-down;
     // any count >= 0 trips the rejection.

--- a/cicchetto/e2e/tests/u-3-cap-honesty-mapping.spec.ts
+++ b/cicchetto/e2e/tests/u-3-cap-honesty-mapping.spec.ts
@@ -41,8 +41,8 @@
 //
 // afterEach restores caps to permissive defaults.
 
-import { expect, test } from "../fixtures/test";
 import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
+import { login, patchNetworkConnectionState } from "../fixtures/grappaApi";
 import {
   ADMIN_IDENTIFIER,
   ADMIN_PASSWORD,
@@ -52,15 +52,12 @@ import {
   M9B_USER,
   NETWORK_SLUG,
 } from "../fixtures/seedData";
-import { login, patchNetworkConnectionState } from "../fixtures/grappaApi";
+import { expect, test } from "../fixtures/test";
 
 const GRAPPA_BASE_URL = "http://grappa-test:4000";
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 
-type CapKnob =
-  | "max_concurrent_user_sessions"
-  | "max_concurrent_visitor_sessions"
-  | "max_per_ip";
+type CapKnob = "max_concurrent_user_sessions" | "max_concurrent_visitor_sessions" | "max_per_ip";
 
 async function adminPatchCaps(
   adminToken: string,
@@ -300,8 +297,6 @@ test("U-3 (UD4) — admin Sessions tab renders per-network cap-count summary", a
   const usersCell = await page.getByTestId(`admin-sessions-summary-users-${slug}`).textContent();
   expect(usersCell).toMatch(/^\d+\/(\d+|∞)$/);
 
-  const perIpCell = await page
-    .getByTestId(`admin-sessions-summary-per-ip-${slug}`)
-    .textContent();
+  const perIpCell = await page.getByTestId(`admin-sessions-summary-per-ip-${slug}`).textContent();
   expect(perIpCell).toMatch(/^(\d+|∞)$/);
 });

--- a/cicchetto/e2e/tests/u-z-cap-honesty-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/u-z-cap-honesty-cluster-journey.spec.ts
@@ -92,7 +92,7 @@
 // restores vjt to :connected so subsequent specs see the seeder
 // baseline. Mirrors u-2 + u-3 cleanup pattern.
 
-import { expect, test } from "../fixtures/test";
+import { login, patchNetworkConnectionState } from "../fixtures/grappaApi";
 import {
   ADMIN_IDENTIFIER,
   ADMIN_PASSWORD,
@@ -100,15 +100,12 @@ import {
   getSeededVjt,
   NETWORK_SLUG,
 } from "../fixtures/seedData";
-import { login, patchNetworkConnectionState } from "../fixtures/grappaApi";
+import { expect, test } from "../fixtures/test";
 
 const GRAPPA_BASE_URL = "http://grappa-test:4000";
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 
-type CapKnob =
-  | "max_concurrent_user_sessions"
-  | "max_concurrent_visitor_sessions"
-  | "max_per_ip";
+type CapKnob = "max_concurrent_user_sessions" | "max_concurrent_visitor_sessions" | "max_per_ip";
 
 async function adminPatchCaps(
   adminToken: string,

--- a/cicchetto/e2e/tests/unread-cursor-cluster.spec.ts
+++ b/cicchetto/e2e/tests/unread-cursor-cluster.spec.ts
@@ -30,8 +30,7 @@
 // badges CONTRACT, not a new IRC verb across user classes — single
 // seeded-registered-user shape is correct.
 
-import { expect, test } from "../fixtures/test";
-import { type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import {
   composeSend,
   loginAs,
@@ -40,12 +39,8 @@ import {
 } from "../fixtures/cicchettoPage";
 import { restoreReadCursorToTail } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
-import {
-  AUTOJOIN_CHANNELS,
-  getSeededVjt,
-  NETWORK_NICK,
-  NETWORK_SLUG,
-} from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const PEER_NICK = "unread-cursor-buddy";
@@ -58,10 +53,7 @@ const PEER_NICK = "unread-cursor-buddy";
 const POST_SEND_SETTLE_MS = 800;
 
 function ownNickRows(page: Page, body: string) {
-  return page.locator(
-    `[data-testid="scrollback-line"][data-kind="privmsg"]`,
-    { hasText: body },
-  );
+  return page.locator(`[data-testid="scrollback-line"][data-kind="privmsg"]`, { hasText: body });
 }
 
 test.describe("unread-badges-from-cursor cluster (A → D + Z)", () => {
@@ -87,9 +79,7 @@ test.describe("unread-badges-from-cursor cluster (A → D + Z)", () => {
   //   - session B's `messagesUnread` memo (bucket B2) recomputes
   //     `count_after(cursor)` on #bofh → drops the row → badge stays
   //     at 0 (or whatever pre-existing count was)
-  test("session A's send in #bofh does NOT bump session B's #bofh badge", async ({
-    browser,
-  }) => {
+  test("session A's send in #bofh does NOT bump session B's #bofh badge", async ({ browser }) => {
     if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
     const vjt = getSeededVjt();
 
@@ -195,9 +185,7 @@ test.describe("unread-badges-from-cursor cluster (A → D + Z)", () => {
   //     publishes `lastOwnSend` → the pane's send-relatch effect
   //     re-latches `markerCursorId` to the advanced cursor → marker
   //     collapses on the next render.
-  test("focused send collapses the in-pane unread marker immediately", async ({
-    page,
-  }) => {
+  test("focused send collapses the in-pane unread marker immediately", async ({ page }) => {
     if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
     const vjt = getSeededVjt();
 
@@ -275,9 +263,7 @@ test.describe("unread-badges-from-cursor cluster (A → D + Z)", () => {
   // (The sibling symptom — sidebar badge flicker on focus-leave — is a
   // sub-frame paint event Playwright cannot reliably observe; the same
   // unit test guards its root cause.)
-  test("own message sent then a fast away-and-back is NOT shown unread", async ({
-    page,
-  }) => {
+  test("own message sent then a fast away-and-back is NOT shown unread", async ({ page }) => {
     if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
     const vjt = getSeededVjt();
 

--- a/cicchetto/e2e/tests/unread-divider-beyond-window.spec.ts
+++ b/cicchetto/e2e/tests/unread-divider-beyond-window.spec.ts
@@ -25,19 +25,14 @@
 // downstream specs inherit a mid-list cursor → marker injects → scroll
 // lands mid-pane → cascade.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import {
   fetchAllMessagesAsc,
   restoreReadCursorToTail,
   setReadCursorToId,
 } from "../fixtures/grappaApi";
-import {
-  AUTOJOIN_CHANNELS,
-  getSeededVjt,
-  NETWORK_NICK,
-  NETWORK_SLUG,
-} from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/unread-off-by-one-on-leave.spec.ts
+++ b/cicchetto/e2e/tests/unread-off-by-one-on-leave.spec.ts
@@ -24,7 +24,6 @@
 // shared seeded `vjt @ bahamut-test/#bofh`, so `afterAll` restores the
 // cursor to tail for downstream specs.
 
-import { expect, test } from "../fixtures/test";
 import {
   loginAs,
   scrollbackLine,
@@ -33,12 +32,8 @@ import {
 } from "../fixtures/cicchettoPage";
 import { restoreReadCursorToTail } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
-import {
-  AUTOJOIN_CHANNELS,
-  getSeededVjt,
-  NETWORK_NICK,
-  NETWORK_SLUG,
-} from "../fixtures/seedData";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const PEER_NICK = "unread-offbyone-buddy";
@@ -56,9 +51,7 @@ test.describe("#163 off-by-one unread on leave (pinned to bottom)", () => {
     await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, CHANNEL);
   });
 
-  test("#163 last message stays read after leaving pinned-to-bottom", async ({
-    page,
-  }) => {
+  test("#163 last message stays read after leaving pinned-to-bottom", async ({ page }) => {
     if (!CHANNEL) throw new Error("AUTOJOIN_CHANNELS empty");
     const vjt = getSeededVjt();
 
@@ -102,10 +95,9 @@ test.describe("#163 off-by-one unread on leave (pinned to bottom)", () => {
       // of `tailBody`, so `count_after(cursor)` === 1 and the badge
       // materializes showing "1". With the at-bottom short-circuit the
       // cursor is the true tail → count 0 → badge absent.
-      await expect(sidebarMessageBadge(page, NETWORK_SLUG, CHANNEL)).toHaveCount(
-        0,
-        { timeout: 5_000 },
-      );
+      await expect(sidebarMessageBadge(page, NETWORK_SLUG, CHANNEL)).toHaveCount(0, {
+        timeout: 5_000,
+      });
 
       // Re-select #bofh. Load-bearing assertion #2: NO `── 1 unread
       // message ──` divider is re-injected. The marker derives from the

--- a/cicchetto/e2e/tests/uploads3-multifile.spec.ts
+++ b/cicchetto/e2e/tests/uploads3-multifile.spec.ts
@@ -17,10 +17,10 @@
 // Playwright e2e — vitest jsdom can't follow the multipart → IRC-echo
 // chain twice in sequence.
 
-import { expect, test } from "../fixtures/test";
 import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -52,9 +52,7 @@ test("uploads-3 #118 — multi-file picker uploads ALL files sequentially → tw
   // minting its own bytes-access slug.
   const texts = await rows.allTextContents();
   const slugs = new Set(
-    texts.flatMap((t) =>
-      Array.from(t.matchAll(/\/uploads\/([a-z2-7]{26})/g)).map((m) => m[1]),
-    ),
+    texts.flatMap((t) => Array.from(t.matchAll(/\/uploads\/([a-z2-7]{26})/g)).map((m) => m[1])),
   );
   expect(slugs.size).toBeGreaterThanOrEqual(2);
 });

--- a/cicchetto/e2e/tests/uploads4-pane-drop.spec.ts
+++ b/cicchetto/e2e/tests/uploads4-pane-drop.spec.ts
@@ -21,10 +21,10 @@
 // wires the SAME DropUploadZone component (tsc-checked); the browser
 // behaviour is asserted once, on the browser where it is a real gesture.
 
-import { expect, test } from "../fixtures/test";
 import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -37,15 +37,18 @@ async function fireFileDrag(
   scrollback: ReturnType<typeof scrollbackLine>,
   type: "dragenter" | "dragover" | "drop",
 ): Promise<void> {
-  await scrollback.evaluate((el, { hex, evType }) => {
-    const bytes = Uint8Array.from((hex.match(/../g) ?? []).map((h) => Number.parseInt(h, 16)));
-    const file = new File([bytes], "dropped-on-scrollback.png", { type: "image/png" });
-    const dt = new DataTransfer();
-    dt.items.add(file);
-    el.dispatchEvent(
-      new DragEvent(evType, { bubbles: true, cancelable: true, dataTransfer: dt }),
-    );
-  }, { hex: TINY_PNG_HEX, evType: type });
+  await scrollback.evaluate(
+    (el, { hex, evType }) => {
+      const bytes = Uint8Array.from((hex.match(/../g) ?? []).map((h) => Number.parseInt(h, 16)));
+      const file = new File([bytes], "dropped-on-scrollback.png", { type: "image/png" });
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      el.dispatchEvent(
+        new DragEvent(evType, { bubbles: true, cancelable: true, dataTransfer: dt }),
+      );
+    },
+    { hex: TINY_PNG_HEX, evType: type },
+  );
 }
 
 test("uploads-4 #351 — a file dropped over the SCROLLBACK uploads (whole pane is the drop target)", async ({

--- a/cicchetto/e2e/tests/ux-1-archive-delete.spec.ts
+++ b/cicchetto/e2e/tests/ux-1-archive-delete.spec.ts
@@ -27,7 +27,6 @@
 // will inherit. That's fine; specs already cope with non-empty
 // scrollback.
 
-import { expect, test } from "../fixtures/test";
 import {
   closeArchive,
   expandArchiveGroup,
@@ -38,6 +37,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { joinChannel, partChannel } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/ux-2-mobile-archive.spec.ts
+++ b/cicchetto/e2e/tests/ux-2-mobile-archive.spec.ts
@@ -33,7 +33,6 @@
 // full visitor/nickserv/registered loop runs in the UX-4-Z composed
 // journey.
 
-import { expect, test } from "../fixtures/test";
 import {
   expandArchiveGroup,
   loginAs,
@@ -43,6 +42,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { joinChannel, partChannel } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/ux-3-empty-toolbar-island.spec.ts
+++ b/cicchetto/e2e/tests/ux-3-empty-toolbar-island.spec.ts
@@ -42,11 +42,16 @@
 // shape bucket, single visitor login sufficient. Parity matrix
 // runs in UX-Z.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs } from "../fixtures/cicchettoPage";
 import { getSeededVjt } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
-type SelectorPadding = { selector: string; padding: string; paddingTop: string; paddingBottom: string };
+type SelectorPadding = {
+  selector: string;
+  padding: string;
+  paddingTop: string;
+  paddingBottom: string;
+};
 
 async function findRulePadding(
   page: import("@playwright/test").Page,

--- a/cicchetto/e2e/tests/ux-3-oct-keyboard-stack.spec.ts
+++ b/cicchetto/e2e/tests/ux-3-oct-keyboard-stack.spec.ts
@@ -30,9 +30,9 @@
 // Per `feedback_e2e_user_class_parity_matrix`: CSS shape + JS-side-
 // effect bucket. Single visitor login is sufficient.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs } from "../fixtures/cicchettoPage";
 import { getSeededVjt } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 test("@webkit UX-3 OCT — viewport meta carries interactive-widget=resizes-content", async ({
   page,
@@ -142,9 +142,7 @@ test("@webkit UX-3 OCT — .shell-mobile reads var(--viewport-height) with 100dv
       try {
         const found = visit(sheet.cssRules);
         if (found) return found;
-      } catch {
-        continue;
-      }
+      } catch {}
     }
     return null;
   });

--- a/cicchetto/e2e/tests/ux-4-z-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/ux-4-z-cluster-journey.spec.ts
@@ -85,8 +85,15 @@
 // Cleanup: re-join the autojoin channel + reset font-size in
 // `afterEach` so subsequent specs see the seeder baseline.
 
-import { expect, test } from "../fixtures/test";
-import { closeMembersDrawer, loginAs, openSettingsMobile, selectChannel, sidebarWindow, openAdminConsole, closeSettings } from "../fixtures/cicchettoPage";
+import {
+  closeMembersDrawer,
+  closeSettings,
+  loginAs,
+  openAdminConsole,
+  openSettingsMobile,
+  selectChannel,
+  sidebarWindow,
+} from "../fixtures/cicchettoPage";
 import { joinChannel, partChannel } from "../fixtures/grappaApi";
 import {
   AUTOJOIN_CHANNELS,
@@ -95,6 +102,7 @@ import {
   NETWORK_NICK,
   NETWORK_SLUG,
 } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0]; // #bofh
 
@@ -174,9 +182,7 @@ test("@webkit UX-4-Z cluster — case-fix + home + sidebar collapse + close-fall
       hasText: NETWORK_SLUG,
     });
     await expect(homeRow).toBeVisible();
-    await expect(homeRow.locator(".home-pane-network-nick")).toContainText(
-      NETWORK_NICK,
-    );
+    await expect(homeRow.locator(".home-pane-network-nick")).toContainText(NETWORK_NICK);
 
     // ─── Bucket L — settings reachable from every window kind ─────────
     // #71 INC-2 — on mobile the settings cog lives in the rail's

--- a/cicchetto/e2e/tests/ux-5-a-hamburger-dedupe.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-a-hamburger-dedupe.spec.ts
@@ -26,9 +26,9 @@
 // suffices; the per-class loop pattern is reserved for behavior that
 // branches on identity.
 
-import { test, expect } from "../fixtures/test";
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/ux-5-b-home-emoji.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-b-home-emoji.spec.ts
@@ -18,9 +18,9 @@
 // One registered class pass is sufficient. Chromium-only — mobile
 // uses BottomBar and the home row is not present there.
 
-import { test, expect } from "../fixtures/test";
 import { loginAs, openRailMenu } from "../fixtures/cicchettoPage";
 import { getSeededVjt } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 test.setTimeout(60_000);
 
@@ -52,9 +52,9 @@ test("ux-5-b — home sidebar row renders the 🏠 emoji icon", async ({ page })
   // past Playwright's toBeVisible heuristic in some cases).
   await expect(homeEmoji).toBeVisible();
   const box = await homeEmoji.boundingBox();
-  expect(box).not.toBeNull();
-  expect(box!.width).toBeGreaterThan(0);
-  expect(box!.height).toBeGreaterThan(0);
+  if (!box) throw new Error("home emoji has no layout box");
+  expect(box.width).toBeGreaterThan(0);
+  expect(box.height).toBeGreaterThan(0);
 
   // Belt-and-suspenders: the emoji span lives INSIDE the home button
   // (sibling of the "Home" label span), not as a stray standalone

--- a/cicchetto/e2e/tests/ux-5-bc-park-respawn.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bc-park-respawn.spec.ts
@@ -41,9 +41,9 @@
 // where /connect succeeds at the HTTP boundary but the spawn dance
 // half-completes (Session.Server up, autojoin loop silently failing).
 
-import { expect, test } from "../fixtures/test";
-import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import { patchNetworkConnectionState } from "../fixtures/grappaApi";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const GRAPPA_BASE_URL = "http://grappa-test:4000";
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
@@ -91,9 +91,7 @@ async function patchConnectionWithClientId(
   });
 }
 
-async function fetchChannels(
-  token: string,
-): Promise<Array<{ name: string; joined: boolean }>> {
+async function fetchChannels(token: string): Promise<Array<{ name: string; joined: boolean }>> {
   const res = await fetch(`${GRAPPA_BASE_URL}/networks/${NETWORK_SLUG}/channels`, {
     headers: { authorization: `Bearer ${token}` },
   });
@@ -101,10 +99,7 @@ async function fetchChannels(
   return (await res.json()) as Array<{ name: string; joined: boolean }>;
 }
 
-async function fetchChannelMembers(
-  token: string,
-  channel: string,
-): Promise<string[]> {
+async function fetchChannelMembers(token: string, channel: string): Promise<string[]> {
   const res = await fetch(
     `${GRAPPA_BASE_URL}/networks/${NETWORK_SLUG}/channels/${encodeURIComponent(channel)}/members`,
     {
@@ -148,11 +143,7 @@ test("UX-5 BC — park then /connect from the same source IP succeeds (self-excl
   // → /connect 200s. The tight-cap load-bearing case is unit-covered
   // (networks_controller_test UX-5 BC); this proves the gated /connect
   // path admits the returning subject end-to-end.
-  const bearer = await loginWithClientId(
-    vjt.identifier,
-    vjt.password,
-    BUCKET_BC_CLIENT_ID,
-  );
+  const bearer = await loginWithClientId(vjt.identifier, vjt.password, BUCKET_BC_CLIENT_ID);
 
   // Step 1 — park (T32 X-button equivalent). The DB row flips to
   // :parked, Session.Server terminates. accounts_session stays alive

--- a/cicchetto/e2e/tests/ux-5-bc2-nick-render.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bc2-nick-render.spec.ts
@@ -30,10 +30,10 @@
 // Parity matrix: UI shape contract, subject-shape-agnostic. Registered
 // seed (vjt + #bofh autojoin) suffices.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/ux-5-bd-bottom-safe-area-floor.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bd-bottom-safe-area-floor.spec.ts
@@ -39,7 +39,6 @@
 // `max(1.5rem, env(...))` declaration shape so future refactors that
 // drop the env() arm still fail loud.
 
-import { expect, test } from "../fixtures/test";
 import {
   loginAs,
   openRailMenu,
@@ -47,6 +46,7 @@ import {
   selectChannel,
 } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -79,9 +79,7 @@ async function readDeclaredCssValue(
         try {
           const found = visit(sheet.cssRules);
           if (found) return found;
-        } catch {
-          continue;
-        }
+        } catch {}
       }
       return null;
     },
@@ -155,9 +153,7 @@ test("@webkit ux-5-bd — .archive-modal computed padding-bottom >= 1.5rem floor
   // DOM only after the launcher is tapped). Reveal it, then tap the archive row
   // from `.rail-actions-menu` where it now renders.
   await openRailMenu(page);
-  await page
-    .locator(".rail-actions-menu [data-testid='mobile-panel-archive']")
-    .tap();
+  await page.locator(".rail-actions-menu [data-testid='mobile-panel-archive']").tap();
   const modal = page.locator(".archive-modal");
   await expect(modal).toBeVisible({ timeout: 5_000 });
 

--- a/cicchetto/e2e/tests/ux-5-bj-no-join-splash.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bj-no-join-splash.spec.ts
@@ -19,15 +19,10 @@
 //     to document that the auto-focus side-effect was the only piece
 //     of the entangled `createEffect` that needed to survive.
 
-import { test, expect } from "../fixtures/test";
-import {
-  composeSend,
-  loginAs,
-  selectChannel,
-  sidebarWindow,
-} from "../fixtures/cicchettoPage";
+import { composeSend, loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { partChannel } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 const NEW_CHANNEL = `#ux-5-bj-${crypto.randomUUID().slice(0, 8)}`;

--- a/cicchetto/e2e/tests/ux-5-bk-join-fail-dupe.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bk-join-fail-dupe.spec.ts
@@ -35,7 +35,6 @@
 // CHANNEL CLEANUP: random per-run suffix; afterEach has the peer PART
 // the channel.
 
-import { test, expect } from "../fixtures/test";
 import {
   composeSend,
   expandArchiveGroup,
@@ -45,6 +44,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 const KEYED_CHANNEL = `#ux-5-bk-${crypto.randomUUID().slice(0, 8)}`;

--- a/cicchetto/e2e/tests/ux-5-bm-mobile-hamburger.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bm-mobile-hamburger.spec.ts
@@ -34,9 +34,9 @@
 // Parity matrix per `feedback_e2e_user_class_parity_matrix`: UI shape
 // contract, subject-shape-agnostic. Registered seed suffices.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -56,9 +56,7 @@ test("ux-5-bm desktop — members aside carries the RailActions drawer", async (
   // #500 — the cog + archive live behind the rail launcher menu now; open it
   // (desktop: taps the launcher) then assert the cog is reachable.
   await openRailMenu(page);
-  await expect(
-    page.locator(".rail-actions-menu [data-testid='action-cluster-cog']"),
-  ).toBeVisible();
+  await expect(page.locator(".rail-actions-menu [data-testid='action-cluster-cog']")).toBeVisible();
 
   // #473 — the members aside DOES carry the `.rail-actions` drawer now (the
   // retired mobile-only `.mobile-panel-actions` footer became one rail present
@@ -66,9 +64,9 @@ test("ux-5-bm desktop — members aside carries the RailActions drawer", async (
   // always-on cog + archive rows live in the launcher menu it opens.
   const rail = page.locator(".shell-members .rail-actions");
   await expect(rail).toHaveCount(1);
-  await expect(
-    page.locator(".rail-actions-menu [data-testid='mobile-panel-archive']"),
-  ).toHaveCount(1);
+  await expect(page.locator(".rail-actions-menu [data-testid='mobile-panel-archive']")).toHaveCount(
+    1,
+  );
 });
 
 test("@webkit ux-5-bm mobile-channel — topic-bar hosts hamburger only; drawer hosts settings+archive launchers; mutex enforced", async ({
@@ -112,12 +110,12 @@ test("@webkit ux-5-bm mobile-channel — topic-bar hosts hamburger only; drawer 
   // #500 folded the buttons behind the launcher menu — open it (the members
   // drawer is already open, so this only taps the launcher), then assert.
   await openRailMenu(page);
-  await expect(
-    page.locator(".rail-actions-menu [data-testid='action-cluster-cog']"),
-  ).toHaveCount(1);
-  await expect(
-    page.locator(".rail-actions-menu [data-testid='mobile-panel-archive']"),
-  ).toHaveCount(1);
+  await expect(page.locator(".rail-actions-menu [data-testid='action-cluster-cog']")).toHaveCount(
+    1,
+  );
+  await expect(page.locator(".rail-actions-menu [data-testid='mobile-panel-archive']")).toHaveCount(
+    1,
+  );
 
   // Tap the rail's settings cog → launcher menu + drawer close, SettingsDrawer opens.
   await page.locator(".rail-actions-menu [data-testid='action-cluster-cog']").tap();
@@ -179,6 +177,8 @@ test("@webkit ux-5-bm mobile-non-channel — home keeps its own ☰ door to the 
   // the cog is NOT in the chrome bar — it lives in the rail's RailActions drawer
   // now (#473). The retired `shell-chrome-cog` testid is gone from the DOM, so
   // assert against the LIVE `action-cluster-cog` to keep the check meaningful.
-  await expect(page.locator(".shell-chrome [data-testid='shell-chrome-rail-opener']")).toBeVisible();
+  await expect(
+    page.locator(".shell-chrome [data-testid='shell-chrome-rail-opener']"),
+  ).toBeVisible();
   await expect(page.locator(".shell-chrome [data-testid='action-cluster-cog']")).toHaveCount(0);
 });

--- a/cicchetto/e2e/tests/ux-5-bo-mobile-settings-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bo-mobile-settings-scroll.spec.ts
@@ -43,7 +43,6 @@
 // Parity matrix per `feedback_e2e_user_class_parity_matrix`: subject-
 // shape-agnostic CSS contract — registered vjt suffices.
 
-import { expect, test } from "../fixtures/test";
 import {
   loginAs,
   openRailMenu,
@@ -51,6 +50,7 @@ import {
   selectChannel,
 } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -142,9 +142,7 @@ test("@webkit ux-5-bo — archive modal asserts touch-action: pan-y + overscroll
   // DOM only after the launcher is tapped). Reveal it, then tap the archive row
   // from `.rail-actions-menu` where it now renders.
   await openRailMenu(page);
-  await page
-    .locator(".rail-actions-menu [data-testid='mobile-panel-archive']")
-    .tap();
+  await page.locator(".rail-actions-menu [data-testid='mobile-panel-archive']").tap();
   const modal = page.locator(".archive-modal");
   await expect(modal).toBeVisible({ timeout: 5_000 });
 

--- a/cicchetto/e2e/tests/ux-5-br-home-reconnect.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-br-home-reconnect.spec.ts
@@ -35,13 +35,8 @@
 // to-end). Reuses U-3 (UD3) FallbackController mapping (`network_busy`
 // for user-cap, `too_many_sessions` for client-cap).
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, waitForUserTopicReady } from "../fixtures/cicchettoPage";
-import {
-  login,
-  patchNetworkConnectionState,
-  type SeededUser,
-} from "../fixtures/grappaApi";
+import { login, patchNetworkConnectionState, type SeededUser } from "../fixtures/grappaApi";
 import {
   ADMIN_IDENTIFIER,
   ADMIN_PASSWORD,
@@ -50,14 +45,12 @@ import {
   NETWORK_NICK,
   NETWORK_SLUG,
 } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const GRAPPA_BASE_URL = "http://grappa-test:4000";
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 
-type CapKnob =
-  | "max_concurrent_user_sessions"
-  | "max_concurrent_visitor_sessions"
-  | "max_per_ip";
+type CapKnob = "max_concurrent_user_sessions" | "max_concurrent_visitor_sessions" | "max_per_ip";
 
 async function adminPatchCaps(
   adminToken: string,
@@ -157,7 +150,9 @@ test("UX-5 BR — Home pane [Reconnect] chip reconnects a parked network", async
   );
 
   // Click the explicit [Reconnect] chip — the canonical action target.
-  const reconnectChip = parkedRow.getByRole("button", { name: new RegExp(`reconnect ${NETWORK_SLUG}`, "i") });
+  const reconnectChip = parkedRow.getByRole("button", {
+    name: new RegExp(`reconnect ${NETWORK_SLUG}`, "i"),
+  });
   await expect(reconnectChip).toBeVisible();
 
   // Gate on the user-topic JOIN ACK before clicking (audit 2026-05-26:
@@ -269,7 +264,9 @@ test("UX-5 BR — chip surfaces friendly error inline when cap is exceeded", asy
   const parkedRow = homePane.locator(".home-pane-network-row-parked", {
     has: page.locator(".home-pane-network-slug", { hasText: NETWORK_SLUG }),
   });
-  const reconnectChip = parkedRow.getByRole("button", { name: new RegExp(`reconnect ${NETWORK_SLUG}`, "i") });
+  const reconnectChip = parkedRow.getByRole("button", {
+    name: new RegExp(`reconnect ${NETWORK_SLUG}`, "i"),
+  });
   await reconnectChip.click();
 
   // Inline error span renders the friendly mapping. Match a substring

--- a/cicchetto/e2e/tests/ux-5-bs-resizable-sidebars.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bs-resizable-sidebars.spec.ts
@@ -24,16 +24,19 @@
 // Parity matrix per `feedback_e2e_user_class_parity_matrix`: subject-
 // shape-agnostic (UI shape contract). Registered vjt suffices.
 
-import { test, expect } from "../fixtures/test";
 import { devices } from "@playwright/test";
 import { loginAs, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test.setTimeout(60_000);
 
-async function asideWidth(page: import("@playwright/test").Page, selector: string): Promise<number> {
+async function asideWidth(
+  page: import("@playwright/test").Page,
+  selector: string,
+): Promise<number> {
   const box = await page.locator(selector).boundingBox();
   if (!box) throw new Error(`${selector} has no bounding box`);
   return Math.round(box.width);

--- a/cicchetto/e2e/tests/ux-5-bt-narrow-chrome-compression.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bt-narrow-chrome-compression.spec.ts
@@ -46,7 +46,6 @@
 // Parity matrix per `feedback_e2e_user_class_parity_matrix`: UI shape
 // contract, subject-shape-agnostic. Registered seed suffices.
 
-import { expect, test } from "../fixtures/test";
 import {
   closeMembersDrawer,
   loginAs,
@@ -55,6 +54,7 @@ import {
   sidebarWindow,
 } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -70,9 +70,7 @@ test("ux-5-bt desktop — #71 INC-2: NO chrome row; topic-bar + rail cog; sideba
   // (cog moved to the permanent right rail); #500 folded the cog behind the rail
   // launcher menu, so open it (desktop: taps the launcher) then assert the cog.
   await openRailMenu(page);
-  await expect(
-    page.locator(".rail-actions-menu [data-testid='action-cluster-cog']"),
-  ).toBeVisible({
+  await expect(page.locator(".rail-actions-menu [data-testid='action-cluster-cog']")).toBeVisible({
     timeout: 10_000,
   });
   await expect(page.locator(".shell-chrome")).toHaveCount(0);
@@ -105,9 +103,7 @@ test("ux-5-bt desktop — #71 INC-2: NO chrome row; topic-bar + rail cog; sideba
   // #500 — re-open the launcher menu on the channel window; the cog is reachable
   // in the rail (not the topic-bar).
   await openRailMenu(page);
-  await expect(
-    page.locator(".rail-actions-menu [data-testid='action-cluster-cog']"),
-  ).toBeVisible();
+  await expect(page.locator(".rail-actions-menu [data-testid='action-cluster-cog']")).toBeVisible();
 
   // Sidebar network-name nit: header span computed weight is bold +
   // header button uses flex-start justification. getComputedStyle
@@ -163,12 +159,12 @@ test("@webkit ux-5-bt mobile — channel: NO standalone .shell-chrome row (#473 
   // + archive rows are present in the rail launcher menu. openRailMenu opens the
   // members drawer then the launcher (mobile), revealing the buttons.
   await openRailMenu(page);
-  await expect(
-    page.locator(".rail-actions-menu [data-testid='action-cluster-cog']"),
-  ).toHaveCount(1);
-  await expect(
-    page.locator(".rail-actions-menu [data-testid='mobile-panel-archive']"),
-  ).toHaveCount(1);
+  await expect(page.locator(".rail-actions-menu [data-testid='action-cluster-cog']")).toHaveCount(
+    1,
+  );
+  await expect(page.locator(".rail-actions-menu [data-testid='mobile-panel-archive']")).toHaveCount(
+    1,
+  );
   // #500 — opening the launcher opened the members drawer + menu; close both so
   // the hamburger tap-target checks + the re-open below run against the clean
   // topic-bar state (the open drawer/backdrop would otherwise occlude the tap).

--- a/cicchetto/e2e/tests/ux-5-bu-unread-focus.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bu-unread-focus.spec.ts
@@ -27,10 +27,10 @@
 // dispatch. Per `feedback_cicchetto_browser_smoke`.
 
 import type { Page } from "@playwright/test";
-import { expect, test } from "../fixtures/test";
 import { composeSend, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "bu-clearbuddy";
 const CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/ux-5-bv-mobile-keyboard-react.spec.ts
+++ b/cicchetto/e2e/tests/ux-5-bv-mobile-keyboard-react.spec.ts
@@ -52,9 +52,9 @@
 // Per `feedback_e2e_user_class_parity_matrix`: CSS-layer shape +
 // JS-mounted side-effect bucket. Single visitor login suffices.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -87,9 +87,7 @@ async function readDeclaredHeight(
         try {
           const found = visit(sheet.cssRules);
           if (found) return found;
-        } catch {
-          continue;
-        }
+        } catch {}
       }
       return null;
     },
@@ -145,9 +143,7 @@ test("@webkit ux-5-bv — .image-upload-modal caps max-height to var(--viewport-
   expect(heightDecl).toContain("100dvh");
 });
 
-test("@webkit ux-5-bv — .home-pane caps max-height to var(--viewport-height)", async ({
-  page,
-}) => {
+test("@webkit ux-5-bv — .home-pane caps max-height to var(--viewport-height)", async ({ page }) => {
   const vjt = getSeededVjt();
   await loginAs(page, vjt);
 

--- a/cicchetto/e2e/tests/ux-6-a-mobile-members-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-a-mobile-members-scroll.spec.ts
@@ -38,9 +38,9 @@
 // Parity matrix per `feedback_e2e_user_class_parity_matrix`:
 // subject-shape-agnostic CSS contract — registered vjt suffices.
 
-import { expect, test } from "../fixtures/test";
 import { closeMembersDrawer, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
@@ -137,9 +137,8 @@ test("@webkit ux-6-a — html.overlay-open suspends root touch-action so gesture
       html: getComputedStyle(document.documentElement).touchAction,
       body: getComputedStyle(document.body).touchAction,
       root: getComputedStyle(document.getElementById("root") ?? document.body).touchAction,
-      rootChild: getComputedStyle(
-        document.querySelector("#root > div") ?? document.body,
-      ).touchAction,
+      rootChild: getComputedStyle(document.querySelector("#root > div") ?? document.body)
+        .touchAction,
     };
   });
   expect(chain.html).toBe("none");
@@ -260,8 +259,6 @@ test("@webkit ux-6-a v2 — .member-name:hover underline is gated on (hover: hov
     .locator(".shell-mobile .shell-members .members-pane li .member-name")
     .first();
   await memberName.hover();
-  const decoration = await memberName.evaluate(
-    (el) => getComputedStyle(el).textDecorationLine,
-  );
+  const decoration = await memberName.evaluate((el) => getComputedStyle(el).textDecorationLine);
   expect(decoration).toBe("none");
 });

--- a/cicchetto/e2e/tests/ux-6-b-admin-settings.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-b-admin-settings.spec.ts
@@ -27,7 +27,7 @@
 // seedData) to PUT it back in afterEach.
 
 import { expect, test } from "@playwright/test";
-import { openAdminConsole, expectShellReady } from "../fixtures/cicchettoPage";
+import { expectShellReady, openAdminConsole } from "../fixtures/cicchettoPage";
 import { getSeededAdmin } from "../fixtures/seedData";
 
 async function adminFriendlyLogin(
@@ -70,9 +70,7 @@ test.describe("UX-6-B admin Settings tab", () => {
     expect(res.ok()).toBe(true);
   });
 
-  test("renders default settings + can flip active host litterbox → embedded", async ({
-    page,
-  }) => {
+  test("renders default settings + can flip active host litterbox → embedded", async ({ page }) => {
     await adminFriendlyLogin(page, getSeededAdmin());
     await openAdminPaneAndSettingsTab(page);
 
@@ -101,9 +99,7 @@ test.describe("UX-6-B admin Settings tab", () => {
     await expect(perFile).toHaveClass(/admin-settings-field-error/, { timeout: 5_000 });
   });
 
-  test("PUT /admin/settings fans out server_settings_changed on user-topics", async ({
-    page,
-  }) => {
+  test("PUT /admin/settings fans out server_settings_changed on user-topics", async ({ page }) => {
     await adminFriendlyLogin(page, getSeededAdmin());
     await openAdminPaneAndSettingsTab(page);
 

--- a/cicchetto/e2e/tests/ux-6-b-embedded-upload.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-b-embedded-upload.spec.ts
@@ -33,10 +33,10 @@
 // the embedded path posts to grappa itself, which is deterministic
 // in the e2e harness (sqlite + local disk + Reaper).
 
-import { expect, test } from "../fixtures/test";
 import { TINY_PNG_HEX } from "../fixtures/bytes";
 import { loginAs, scrollbackLine, selectChannel } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 import { EMBEDDED_MODAL_HEADING, pickFile, uploadViaPicker } from "../fixtures/uploadJourney";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/ux-6-c-mobile-admin-launcher.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-c-mobile-admin-launcher.spec.ts
@@ -28,7 +28,6 @@
 // #bofh; promoting it temporarily gives the full surface (admin gate + joined
 // channel + rail drawer) without ripple-affecting other specs.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import {
   AUTOJOIN_CHANNELS,
@@ -38,6 +37,7 @@ import {
   NETWORK_SLUG,
   VJT_USER,
 } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const GRAPPA_BASE_URL = "http://grappa-test:4000";
@@ -59,11 +59,7 @@ async function findVjtUserId(adminToken: string): Promise<string> {
   return vjt.id;
 }
 
-async function setAdminFlag(
-  adminToken: string,
-  userId: string,
-  isAdmin: boolean,
-): Promise<void> {
+async function setAdminFlag(adminToken: string, userId: string, isAdmin: boolean): Promise<void> {
   const res = await fetch(`${GRAPPA_BASE_URL}/admin/users/${encodeURIComponent(userId)}`, {
     method: "PATCH",
     headers: {
@@ -194,9 +190,9 @@ test.describe("UX-6-C / #473 — admin launcher in the rail actions drawer", () 
     // (on desktop the rail is always on screen, so this taps the launcher
     // directly) before reaching the admin button.
     await openRailMenu(page);
-    await expect(
-      page.locator(".rail-actions-menu [data-testid='mobile-panel-admin']"),
-    ).toHaveCount(1);
+    await expect(page.locator(".rail-actions-menu [data-testid='mobile-panel-admin']")).toHaveCount(
+      1,
+    );
     // The retired mobile-only `.mobile-panel-actions` footer is gone entirely —
     // guard that the migration left no stray footer anywhere.
     await expect(page.locator(".mobile-panel-actions")).toHaveCount(0);

--- a/cicchetto/e2e/tests/ux-6-d-keyboard-pattern.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-d-keyboard-pattern.spec.ts
@@ -26,9 +26,16 @@
 // (e) Smart-pin: window.scrollTo(0,0) clamps any drift
 // (f) Admin → Debug tab renders the diag panel + DiagFloat toggle
 
-import { expect, test } from "../fixtures/test";
 import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
-import { AUTOJOIN_CHANNELS, getSeededAdmin, getSeededVjt, NETWORK_NICK, NETWORK_SLUG, VJT_USER } from "../fixtures/seedData";
+import {
+  AUTOJOIN_CHANNELS,
+  getSeededAdmin,
+  getSeededVjt,
+  NETWORK_NICK,
+  NETWORK_SLUG,
+  VJT_USER,
+} from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const GRAPPA_BASE_URL = "http://grappa-test:4000";
 const CHANNEL = AUTOJOIN_CHANNELS[0];
@@ -50,11 +57,7 @@ async function findVjtUserId(adminToken: string): Promise<string> {
   return vjt.id;
 }
 
-async function setAdminFlag(
-  adminToken: string,
-  userId: string,
-  isAdmin: boolean,
-): Promise<void> {
+async function setAdminFlag(adminToken: string, userId: string, isAdmin: boolean): Promise<void> {
   const res = await fetch(`${GRAPPA_BASE_URL}/admin/users/${encodeURIComponent(userId)}`, {
     method: "PATCH",
     headers: {
@@ -90,9 +93,7 @@ async function promoteVjtToAdmin(): Promise<{ revert: () => Promise<void> }> {
 test.describe("UX-6 D cluster close — iOS PWA keyboard pattern @webkit", () => {
   test("(a) html.is-ios class lands on iPhone UA after boot", async ({ page }) => {
     await loginAs(page, getSeededVjt());
-    const isIos = await page.evaluate(() =>
-      document.documentElement.classList.contains("is-ios"),
-    );
+    const isIos = await page.evaluate(() => document.documentElement.classList.contains("is-ios"));
     expect(isIos).toBe(true);
   });
 
@@ -117,9 +118,7 @@ test.describe("UX-6 D cluster close — iOS PWA keyboard pattern @webkit", () =>
     expect(value).toBeGreaterThan(100);
   });
 
-  test("(d) D1 :has(:focus) rule collapses padding-bottom when input focused", async ({
-    page,
-  }) => {
+  test("(d) D1 :has(:focus) rule collapses padding-bottom when input focused", async ({ page }) => {
     await loginAs(page, getSeededVjt());
     // GREEN-CI batch 2 — UX-4 bucket B made `:home` the cold-load
     // default selection; HomePane has no `.compose-box`. Select the

--- a/cicchetto/e2e/tests/ux-6-e-narrow-server-dedup.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-e-narrow-server-dedup.spec.ts
@@ -19,9 +19,9 @@
 // visitor login is sufficient. Per `feedback_ux_e2e_mandatory`, every
 // cic UX-behavior change ships a Playwright e2e.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs } from "../fixtures/cicchettoPage";
 import { getSeededVjt, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 test("@webkit UX-6-E — narrow mode renders one network entry; no standalone 'Server' tab", async ({
   page,
@@ -50,15 +50,11 @@ test("@webkit UX-6-E — narrow mode renders one network entry; no standalone 'S
   await expect(standaloneServer).toHaveCount(0);
 });
 
-test("@webkit UX-6-E — clicking the network-header focuses the server window", async ({
-  page,
-}) => {
+test("@webkit UX-6-E — clicking the network-header focuses the server window", async ({ page }) => {
   const vjt = getSeededVjt();
   await loginAs(page, vjt);
 
-  const header = page.locator(
-    `.bottom-bar-network-header[data-network-slug="${NETWORK_SLUG}"]`,
-  );
+  const header = page.locator(`.bottom-bar-network-header[data-network-slug="${NETWORK_SLUG}"]`);
   await expect(header).toBeVisible({ timeout: 10_000 });
 
   // Pre-tap: header isn't selected (login lands on home).

--- a/cicchetto/e2e/tests/ux-6-f-send-button-glyph.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-f-send-button-glyph.spec.ts
@@ -31,10 +31,10 @@
 // see font-fallback substitution anyway; the SVG path closes the
 // font-tofu concern at source).
 
-import { expect, test } from "../fixtures/test";
 import { composeTextarea, loginAs, selectChannel } from "../fixtures/cicchettoPage";
 import { assertMessagePersisted } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const MESSAGE_BODY = `ux-6-f-arrow-glyph-${Date.now()}`;

--- a/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-g-admin-mobile-h-scroll.spec.ts
@@ -47,7 +47,6 @@
 // + autojoined #bofh so it can reach the mobile launcher footer.
 
 import type { Page } from "@playwright/test";
-import { expect, test } from "../fixtures/test";
 import { loginAs, openRailMenu, selectChannel, sidebarWindow } from "../fixtures/cicchettoPage";
 import {
   AUTOJOIN_CHANNELS,
@@ -57,6 +56,7 @@ import {
   NETWORK_SLUG,
   VJT_USER,
 } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const GRAPPA_BASE_URL = "http://grappa-test:4000";

--- a/cicchetto/e2e/tests/ux-6-j-push-deep-link.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-j-push-deep-link.spec.ts
@@ -18,9 +18,9 @@
 // commit), cold-path because main.tsx never called the URL reader.
 // post-J the same URLs route into the selection signal.
 
-import { expect, test } from "../fixtures/test";
 import { loginAs } from "../fixtures/cicchettoPage";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 test.describe("UX-6-J — push notification deep-link routing", () => {
   test("warm-path: SW postMessage navigate routes selection (channel)", async ({ page }) => {
@@ -80,7 +80,11 @@ test.describe("UX-6-J — push notification deep-link routing", () => {
     await loginAs(page, vjt);
 
     // Capture initial selected-row text so we can confirm no flip.
-    const initial = await page.locator("li.selected").first().innerText().catch(() => "");
+    const initial = await page
+      .locator("li.selected")
+      .first()
+      .innerText()
+      .catch(() => "");
 
     // Dispatch a navigate message with a parse-failure URL.
     await page.evaluate(() => {
@@ -97,20 +101,30 @@ test.describe("UX-6-J — push notification deep-link routing", () => {
     // `initial` and the toBe(initial) on the final read still catches
     // it; the poll just gives the dispatcher a microtask flush window.
     await expect
-      .poll(async () => page.locator("li.selected").first().innerText().catch(() => ""), {
-        timeout: 1_000,
-        intervals: [50, 100, 200, 400],
-      })
+      .poll(
+        async () =>
+          page
+            .locator("li.selected")
+            .first()
+            .innerText()
+            .catch(() => ""),
+        {
+          timeout: 1_000,
+          intervals: [50, 100, 200, 400],
+        },
+      )
       .toBe(initial);
-    const after = await page.locator("li.selected").first().innerText().catch(() => "");
+    const after = await page
+      .locator("li.selected")
+      .first()
+      .innerText()
+      .catch(() => "");
     expect(after).toBe(initial);
     // Use NETWORK_NICK so the unused-import lint stays quiet.
     expect(NETWORK_NICK).toBeTruthy();
   });
 
-  test("cold-path: opening at /?network=X&channel=Y routes selection on boot", async ({
-    page,
-  }) => {
+  test("cold-path: opening at /?network=X&channel=Y routes selection on boot", async ({ page }) => {
     const vjt = getSeededVjt();
     const channel = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/ux-6-k-pm-unread-cursor.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-k-pm-unread-cursor.spec.ts
@@ -41,7 +41,6 @@
 // what the production bug surfaces as: it's the cursor persistence
 // that was broken.
 
-import { test, expect } from "../fixtures/test";
 import {
   loginAs,
   scrollbackLine,
@@ -52,6 +51,7 @@ import {
 import { assertMessagePersisted, getReadCursor } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK = "ux6k-peer";
 const CHANNEL = AUTOJOIN_CHANNELS[0];

--- a/cicchetto/e2e/tests/ux-6-l-foreground-push-beep.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-l-foreground-push-beep.spec.ts
@@ -28,6 +28,7 @@ import { expect, test } from "../fixtures/test";
 import { loginAs, selectChannel, sidebarWindow, waitForDmListenerReady } from "../fixtures/cicchettoPage";
 import { assertMessagePersisted, partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
+import { forwardPageDiagnostics } from "../fixtures/pageDiagnostics";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 
 const PEER_NICK_DM = "ux6l-dmer";
@@ -51,16 +52,7 @@ test("inbound DM fires in-app beep (__lastBeepAt advances) on a non-focused wind
   // Surface browser console + any uncaught errors — the DM-listener
   // race manifests as "DM persisted server-side, cic never received
   // broadcast"; chasing that without console output is masochism.
-  page.on("console", (msg) => {
-    if (msg.type() === "error" || msg.type() === "warn") {
-      // eslint-disable-next-line no-console
-      console.log(`[cic:${msg.type()}] ${msg.text()}`);
-    }
-  });
-  page.on("pageerror", (err) => {
-    // eslint-disable-next-line no-console
-    console.log(`[cic:pageerror] ${err.message}`);
-  });
+  forwardPageDiagnostics(page);
   await loginAs(page, vjt);
   // Stay focused on #bofh — peer DM lands in a NEW window we're NOT
   // looking at, so beep MUST fire (same focus-rule as the mention

--- a/cicchetto/e2e/tests/ux-6-l-foreground-push-beep.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-l-foreground-push-beep.spec.ts
@@ -24,12 +24,17 @@
 // server suppresses the OS push at source — the beep is the
 // foreground alert).
 
-import { expect, test } from "../fixtures/test";
-import { loginAs, selectChannel, sidebarWindow, waitForDmListenerReady } from "../fixtures/cicchettoPage";
+import {
+  loginAs,
+  selectChannel,
+  sidebarWindow,
+  waitForDmListenerReady,
+} from "../fixtures/cicchettoPage";
 import { assertMessagePersisted, partChannel } from "../fixtures/grappaApi";
 import { IrcPeer } from "../fixtures/ircClient";
 import { forwardPageDiagnostics } from "../fixtures/pageDiagnostics";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const PEER_NICK_DM = "ux6l-dmer";
 const PEER_NICK_MENTION = "ux6l-mentioner";
@@ -94,9 +99,7 @@ test("inbound DM fires in-app beep (__lastBeepAt advances) on a non-focused wind
     // call site fires playBeep BEFORE routeMessage (which is what
     // appends to scrollback + opens the sidebar window). If sidebar
     // is present, beep MUST have fired.
-    await expect
-      .poll(async () => await readLastBeepAt(page), { timeout: 5_000 })
-      .not.toBeNull();
+    await expect.poll(async () => await readLastBeepAt(page), { timeout: 5_000 }).not.toBeNull();
   } finally {
     await peer.disconnect("ux6l DM done");
   }
@@ -135,9 +138,7 @@ test("channel mention fires in-app beep on a non-focused mention target", async 
       body: mentionBody,
     });
 
-    await expect
-      .poll(async () => await readLastBeepAt(page), { timeout: 5_000 })
-      .not.toBeNull();
+    await expect.poll(async () => await readLastBeepAt(page), { timeout: 5_000 }).not.toBeNull();
   } finally {
     await peer.disconnect("ux6l mention done");
     await partChannel(vjt.token, NETWORK_SLUG, MENTION_CHANNEL).catch(() => {});

--- a/cicchetto/e2e/tests/ux-z-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/ux-z-cluster-journey.spec.ts
@@ -42,7 +42,6 @@
 // If a future operator wires the visitor + nickserv arms, restore the
 // loop and drive them; today the test is honestly "registered only."
 
-import { expect, test } from "../fixtures/test";
 import {
   expandArchiveGroup,
   loginAs,
@@ -52,6 +51,7 @@ import {
 } from "../fixtures/cicchettoPage";
 import { joinChannel, partChannel } from "../fixtures/grappaApi";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 

--- a/cicchetto/e2e/tests/visitor-session-sharing.spec.ts
+++ b/cicchetto/e2e/tests/visitor-session-sharing.spec.ts
@@ -18,10 +18,10 @@
 // Per `feedback_e2e_user_class_parity_matrix`: this flow is
 // visitor-only by design (mint endpoint 403s for users). One-class spec.
 
-import { expect, test } from "../fixtures/test";
-import { openSettingsDrawer, expectShellReady } from "../fixtures/cicchettoPage";
+import { expectShellReady, openSettingsDrawer } from "../fixtures/cicchettoPage";
 import { mintVisitor, reapVisitors } from "../fixtures/grappaApi";
 import { getSeededAdmin } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
 
 test("visitor session-sharing — mint on device A, consume on device B, both connected", async ({
   browser,

--- a/cicchetto/e2e/types/cic-window.d.ts
+++ b/cicchetto/e2e/types/cic-window.d.ts
@@ -1,0 +1,84 @@
+// The ONE declaration of cic's page-side e2e/devtools probe surface.
+//
+// Before #484 each spec that touched a probe re-declared it inline in its own
+// `declare global` block. Five copies of `__cic_socketHealth` and two of
+// `__cic_bundleHash` had drifted into mutually incompatible shapes (TS2717 ×5),
+// and the widest of them was still narrower than the real surface. Convergence
+// here is on ONE shape, not on N compatible ones.
+//
+// SSOT is the production code — these are hand-mirrored from:
+//   src/lib/socketHealth.ts     __cic_socketHealth
+//   src/lib/bundleHash.ts       __cic_bundleHash
+//   src/lib/swRegistration.ts   __cic_swRegistration
+//   src/lib/socket.ts           __cic_dropSocketForTests, __cic_resumeSocketForTests,
+//                               __visibilityAck
+//   src/lib/subscribe.ts        __cic_{suppress,resume}ChannelDeliveryForTests,
+//                               __cic_joinedTopicKeys
+// The mirror is hand-kept: `e2e/tsconfig.json` cannot import from `src/` (those
+// modules pull in solid-js, which e2e/node_modules does not have). A probe that
+// changes shape in `src/` must be changed here too — a stale mirror types the
+// spec against a surface the page no longer exposes.
+//
+// Spec-LOCAL probes (a `window.__cic981Sightings` a single spec installs with
+// `addInitScript`) are not part of this surface and stay declared in their spec.
+
+export {};
+
+declare global {
+  interface Window {
+    // src/lib/socketHealth.ts — SocketHealth, inlined (see mirror note above).
+    __cic_socketHealth?: {
+      recordOpen: () => void;
+      recordError: () => void;
+      recordClose: (e: { code: number; reason: string } | undefined) => void;
+      reset: () => void;
+      state: () => {
+        state: "connecting" | "open" | "error";
+        errorCount: number;
+        lastErrorAt: number | null;
+        lastCloseCode: number | null;
+        lastCloseReason: string;
+        connectAttempts: number;
+        errorsTotal: number;
+      };
+    };
+
+    // src/lib/bundleHash.ts
+    __cic_bundleHash?: {
+      setServerHash: (hash: string) => void;
+      setServerVersion: (version: string | null) => void;
+      reset: () => void;
+      bootHash: () => string | null;
+      bootVersion: () => string | null;
+      serverHash: () => string | null;
+      __refreshProbe?: () => void;
+    };
+
+    // src/lib/swRegistration.ts — SwRegistrationHealth, inlined.
+    __cic_swRegistration?: {
+      recordError: (e: { name: string; message: string }) => void;
+      recordRegistered: (reg?: ServiceWorkerRegistration) => void;
+      reset: () => void;
+      state: () => {
+        state: "unknown" | "registered" | "error";
+        error: { name: string; message: string } | null;
+      };
+    };
+
+    // src/lib/socket.ts
+    __cic_dropSocketForTests?: () => Promise<void>;
+    __cic_resumeSocketForTests?: () => Promise<void>;
+    __visibilityAck?: boolean;
+
+    // src/lib/subscribe.ts
+    __cic_suppressChannelDeliveryForTests?: (slug: string, name: string) => void;
+    __cic_resumeChannelDeliveryForTests?: (slug: string, name: string) => void;
+    __cic_joinedTopicKeys?: () => string[];
+
+    // src/lib/pushTarget.ts — set once the reader has ROUTED a parsed target,
+    // so a spec can tell "the deep link applied" from "session restore happened
+    // to select the same window".
+    __cicPushTargetApplied?: boolean;
+    __cicInviteLinkApplied?: boolean;
+  }
+}

--- a/cicchetto/e2e/types/irc-framework.d.ts
+++ b/cicchetto/e2e/types/irc-framework.d.ts
@@ -1,0 +1,120 @@
+// Types for `irc-framework@4.14.0`, which ships none (TS7016).
+//
+// Why ours and not `@types/irc-framework`: there is no such package —
+// `bun info @types/irc-framework` answers 404 from the npm registry
+// (2026-08-09). The alternatives were a bare `declare module "irc-framework";`
+// (implicit `any` for the whole peer fixture — the escape hatch #484 exists to
+// remove) or this: the slice of the library `fixtures/ircClient.ts` actually
+// drives. Same shape as the `PrivmsgSource` slice `fixtures/privmsgWait.ts`
+// already declares for its two methods.
+//
+// `IrcEventName` is the load-bearing part. irc-framework is an EventEmitter
+// with untyped, stringly-named events, and a listener on a name the library
+// never emits is silently dead — `ircClient.ts:oper()` waited on an
+// `rpl_youreoper` event that does not exist and hung until its timeout for as
+// long as it had no caller (fixed in #367 by matching the raw 381 line). That
+// is the same defect class as #484's `msg.type() === "warn"`. A closed union of
+// event names makes it a compile error instead.
+//
+// Payload shapes are transcribed from the library's own `emit` sites:
+//   src/connection.js                    raw, close, socket close
+//   src/commands/handlers/registration.js  registered
+//   src/commands/handlers/user.js          nick, nick in use
+//   src/commands/handlers/channel.js       join, part, kick, topic
+//   src/commands/handlers/misc.js          mode
+//   src/commands/handlers/messaging.js     notice, privmsg
+// Only the fields the fixture reads are declared; the library sends more
+// (`tags`, `batch`, `time`, …). Add an event here when a spec needs one.
+
+declare module "irc-framework" {
+  export interface IrcEventMap {
+    // connection.js — `from_server` false for our own outbound frames.
+    raw: { line: string; from_server: boolean };
+    // connection.js / transports — the argument is an error-or-false whose
+    // shape the library does not commit to; no caller reads it.
+    close: unknown;
+    "socket close": unknown;
+
+    registered: { nick: string };
+    nick: { nick: string; ident: string; hostname: string; new_nick: string };
+    "nick in use": { nick: string; reason: string };
+
+    join: { nick: string; ident: string; hostname: string; gecos: string; channel: string };
+    part: { nick: string; ident: string; hostname: string; channel: string; message: string };
+    kick: {
+      kicked: string;
+      nick: string;
+      ident: string;
+      hostname: string;
+      channel: string;
+      message: string;
+    };
+    topic: { channel: string; topic: string };
+
+    mode: {
+      target: string;
+      nick: string;
+      raw_modes: string;
+      raw_params: string[];
+      modes: { mode: string; param: string | null }[];
+    };
+
+    notice: {
+      from_server: boolean;
+      nick: string;
+      ident: string;
+      hostname: string;
+      target: string;
+      message: string;
+    };
+    privmsg: {
+      from_server: boolean;
+      nick: string;
+      ident: string;
+      hostname: string;
+      target: string;
+      message: string;
+    };
+  }
+
+  export type IrcEventName = keyof IrcEventMap;
+
+  export interface IrcConnectOptions {
+    host: string;
+    port: number;
+    nick: string;
+    username?: string;
+    gecos?: string;
+    password?: string;
+    tls?: boolean;
+    auto_reconnect?: boolean;
+  }
+
+  export class Client {
+    constructor(options?: Partial<IrcConnectOptions>);
+
+    readonly user: { nick: string; username: string; gecos: string };
+
+    on<E extends IrcEventName>(event: E, handler: (payload: IrcEventMap[E]) => void): this;
+    once<E extends IrcEventName>(event: E, handler: (payload: IrcEventMap[E]) => void): this;
+    removeListener<E extends IrcEventName>(
+      event: E,
+      handler: (payload: IrcEventMap[E]) => void,
+    ): this;
+
+    connect(options?: IrcConnectOptions): void;
+    quit(message?: string): void;
+
+    // `raw(array)` adds the IRC trailing-param `:` itself; the varargs form
+    // joins on spaces. Both are used by the fixture.
+    raw(input: string[] | string, ...rest: (string | number)[]): void;
+
+    say(target: string, message: string): void;
+    action(target: string, message: string): void;
+    notice(target: string, message: string): void;
+    join(channel: string, key?: string): void;
+    part(channel: string, message?: string): void;
+    mode(channel: string, mode: string, extraArgs?: string | string[]): void;
+    changeNick(nick: string): void;
+  }
+}

--- a/cicchetto/package.json
+++ b/cicchetto/package.json
@@ -8,8 +8,8 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
-    "check": "biome check src && tsc --noEmit",
-    "check:fix": "biome check --write src",
+    "check": "biome check && tsc --noEmit && tsc --noEmit -p e2e/tsconfig.json",
+    "check:fix": "biome check --write",
     "test": "vitest run",
     "test:watch": "vitest",
     "gen:emoji": "bun scripts/gen-emoji.ts"

--- a/cicchetto/vitest.config.ts
+++ b/cicchetto/vitest.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vitest/config";
 import solid from "vite-plugin-solid";
+import { defineConfig } from "vitest/config";
 
 // SolidJS components compile to fine-grained reactive primitives — vitest
 // needs the same `vite-plugin-solid` transform the dev server uses, or

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -34,7 +34,7 @@ scripts/test.sh --cover                  # coverage
 
 # cic (Solid / TS)
 scripts/bun.sh run test                  # vitest
-scripts/bun.sh run check                 # biome + tsc (lint + typecheck)
+scripts/bun.sh run check                 # biome + tsc — src AND e2e (#484)
 
 # Full CI gate locally
 scripts/check.sh                         # mix ci.check + wireTypes drift gate + bats
@@ -128,9 +128,24 @@ a raw `docker run oven/bun:1 …` to replicate it (that trips the docker
 guardrail above); the e2e stage already IS that clean build, through the
 wrapper.
 
+**`run check` is the ONLY static gate over `cicchetto/e2e` (#484).**
+`scripts/check.sh` runs no cic gates at all, and the Playwright runner
+esbuild-strips types without checking them, so before #484 the e2e suite had
+no typecheck and no lint anywhere — 26 type errors had accumulated across 18
+files, four of them always-false comparisons. `check` is now `biome check &&
+tsc --noEmit && tsc --noEmit -p e2e/tsconfig.json`, and biome's
+`files.includes` covers `e2e/**`. Both compile through **cicchetto's**
+TypeScript (`e2e/package.json` no longer carries one of its own — one repo,
+one compiler version, pinned by `cicchetto/bun.lock`). The e2e project's own
+deps (`@playwright/test`, `@types/node`, `irc-framework`) come from
+`e2e/package.json`; `scripts/bun.sh` installs them on demand exactly as it
+does `cicchetto/node_modules`, and the CI job runs `bun install --cwd e2e`
+before `bun run check`. To run just the e2e half:
+`scripts/bun.sh x tsc --noEmit -p e2e/tsconfig.json`.
+
 **`scripts/bun.sh run check` counts a biome FORMAT violation as an
-ERROR, and hides which file it came from.** `check` is `biome check src
-&& tsc --noEmit`: a line biome would reflow (a long `foo({ a, b, c })`
+ERROR, and hides which file it came from.** `check` starts with `biome
+check`: a line biome would reflow (a long `foo({ a, b, c })`
 call it wants multiline, say) is enough to exit 1 — and `&&` then skips
 `tsc` entirely, so the type gate never runs. The diagnosis is the hard
 part, because biome truncates its own output: your file's error can sit
@@ -139,10 +154,10 @@ never touched, and the summary reads only `Found 1 error`. `grep "error
 TS"` finds nothing, because it is not a tsc error. `mix format` does not
 cover cic, so nothing else catches it first.
 
-So **format before you gate**: after editing any `cicchetto/src/**`
-file, run `scripts/bun.sh x biome check --write <the files you touched>`
-— your files ONLY, never `--write src`, which reformats unrelated files
-and balloons the diff. To read the real diagnostic instead of the
+So **format before you gate**: after editing any `cicchetto/src/**` or
+`cicchetto/e2e/**` file, run `scripts/bun.sh x biome check --write <the files
+you touched>` — your files ONLY, never a bare `--write`, which reformats
+unrelated files and balloons the diff. To read the real diagnostic instead of the
 summary, isolate it: `scripts/bun.sh x biome check <your files>
 --max-diagnostics=100`. Do NOT append `--max-diagnostics` to `bun run
 check` — the composite script forwards it to `tsc`, which rejects it.
@@ -157,7 +172,7 @@ The authoritative source is the comment block at the top of each
 
 * **`scripts/test.sh`** → `scripts/mix.sh --env=test test --warnings-as-errors "$@"`. Forces `MIX_ENV=test` (auto-detect would use the live container's env, usually dev/prod, breaking sandbox).
 * **`scripts/check.sh`** → `scripts/mix.sh --env=dev ci.check` + `mix grappa.gen_wire_types --check` (wireTypes drift gate) + `scripts/bats.sh`. The `ci.check` alias (in `mix.exs`) chains: compile (warnings as errors), format check, credo, deps.audit, hex.audit, sobelow, `cmd env MIX_ENV=test mix doctor`, `cmd env MIX_ENV=test mix test --warnings-as-errors`, dialyzer, docs. Doctor shells out to `:test` since #621: in `:dev` it counts a module's functions from the source AST but reads doc/spec presence from the beam, so every `Mix.env() == :test`-gated helper is scored as undocumented, and `elixirc_paths` omits `test/support` there. `:test` is a strict superset on both axes, and matches the workflow's single `mix doctor` step. The `ci` workflow runs the same gates — including the wireTypes drift check since #767 — but it re-lists them by hand in YAML rather than invoking this script, so the two lists mirror each other only for as long as someone keeps them in step. A gate added here is not in CI until it is added there too; #767 was one instance of that (the drift gate was local-only, and a stale `wireTypes.ts` survived a merge with CI green).
-* **`scripts/bun.sh`** → oneshot `oven/bun:1` against `cicchetto/`. `run test` = vitest. `run check` = biome + tsc. `install`, `add`, etc. forward to bun.
+* **`scripts/bun.sh`** → oneshot `oven/bun:1` against `cicchetto/`. `run test` = vitest. `run check` = biome + tsc over `src` AND `e2e`. `install`, `add`, etc. forward to bun.
 * **`scripts/bats.sh`** → host-side bats v1.9.0 (submodule at `vendor/bats-core`) against `test/bin/`, `test/infra/` and `test/scripts/`. NOT containerised — bats tests host-side bash (`bin/grappa`, the deploy scripts, the cloud installer).
 * **`scripts/release-image.sh`** → the RELEASE image (`Dockerfile.release`), not the compose dev stack. `build` buildx-loads it locally; `fresh-boot` wipes the scratch volume and bare-runs it with nothing but `PHX_HOST` (the documented one-liner — the point is that everything else must come from the image and the volume); `warm-boot` does the same on the EXISTING volume; `oneshot <args…>` runs a throwaway container against that volume; `logs` / `down [--volume]` clean up. This is the reproduction for #862 and #867, both of which were found by hand-typing docker commands because no wrapper reached this artifact.
 * **`scripts/integration.sh`** → `scripts/testnet.sh up` → `docker compose run --rm playwright-runner npx playwright test "$@"` → trap-on-exit `scripts/testnet.sh down`. `KEEP_STACK=1` opts out of tear-down.

--- a/scripts/bun.sh
+++ b/scripts/bun.sh
@@ -5,7 +5,7 @@
 #   scripts/bun.sh install
 #   scripts/bun.sh add phoenix
 #   scripts/bun.sh run build
-#   scripts/bun.sh run check                    # biome + tsc (lint + typecheck)
+#   scripts/bun.sh run check                    # biome + tsc over src AND e2e (#484)
 #   scripts/bun.sh run test                     # vitest (cic unit tests in jsdom)
 #
 # Canonical "which test runner do I use?" docs: docs/TESTING.md.
@@ -88,12 +88,23 @@ run_bun() {
 # check` would die with `vitest: command not found` (exit 127). Install
 # on demand. The install-family verbs manage node_modules themselves —
 # skip the pre-install for those (no point, and avoids double work).
+#
+# e2e/node_modules is the same story since #484: `run check` now also
+# typechecks cicchetto/e2e, whose @playwright/test + @types/node + the
+# irc-framework runtime are declared by e2e/package.json, not cicchetto's. A
+# fresh worktree would fail the gate on "Cannot find type definition file for
+# 'node'" — an absent toolchain reported as a type error. Same self-heal, same
+# reason. (e2e tracks no lockfile by design; see cicchetto/e2e/.gitignore.)
 case "${1:-}" in
     install | add | remove | update | outdated | pm | ci | link | unlink) ;;
     *)
         if [ ! -d "$CICCHETTO_DIR/node_modules" ]; then
             printf 'scripts/bun.sh: cicchetto/node_modules missing — running bun install...\n' >&2
             run_bun "$BUN_IMAGE" bun install >&2
+        fi
+        if [ ! -d "$CICCHETTO_DIR/e2e/node_modules" ]; then
+            printf 'scripts/bun.sh: cicchetto/e2e/node_modules missing — running bun install --cwd e2e...\n' >&2
+            run_bun "$BUN_IMAGE" bun install --cwd e2e >&2
         fi
         ;;
 esac


### PR DESCRIPTION
## Summary

`cicchetto/e2e` had no static gate of any kind: biome's `files.includes`
stopped at `src/**`, the root tsconfig includes only `src`, `scripts/check.sh`
runs no cic gates at all, and the Playwright runner esbuild-strips types
without checking them. This closes that, in four commits: fix the type debt,
fix the lint debt, wire the gate that stops both coming back, and one thing the
gate found on its first run.

**Measured, not inherited.** The issue counted 19 errors across 14 files.
On this branch's base (`e89f7702`) `tsc --noEmit -p e2e/tsconfig.json` reported
**26 across 18**, and all four of the extra files landed after the issue was
filed — the debt was still growing because nothing stopped it. Both compilers
in the tree (cicchetto's 7.0.2 and the 5.7.2 e2e used to pin) agree on 26
before and on 0 after.

## The gate

`cicchetto`'s `check` script, because it is the one that actually runs: the
`cicchetto (types + lint + unit)` CI job invokes `bun run check` + `bun run
test` on every push, and nothing else looks at this code.

```
check: biome check && tsc --noEmit && tsc --noEmit -p e2e/tsconfig.json
```

Bare `biome check` rather than `biome check src e2e`, so `files.includes` in
`biome.json` is the single place that says what is linted. `typescript` comes
out of `e2e/package.json` — it pinned 5.7.2 against cicchetto's 7.0.2 and
nothing invoked it, and two compilers over one tree is a way for the gate and
the developer to disagree. `scripts/bun.sh` self-heals `e2e/node_modules` the
same way it already self-heals `cicchetto/node_modules`; CI installs it
explicitly before `check`.

No exclude list, no `any`, no `@ts-ignore`, no widened `skipLibCheck`, no file
dropped from a tsconfig to make it green.

**Proven by mutation, both halves, red read before green:**

| mutation | gate | result |
|---|---|---|
| re-introduce `msg.type() === "warn"` in a spec | `bun run check` | RC=1, `TS2367 … '"warn"' have no overlap` |
| swap two imports in `_smoke.spec.ts` | `bun run check` | RC=1, `assist/source/organizeImports` |
| both reverted | `bun run check` | RC=0 |

## The recurring shapes were duplication, not typos

**`declare global` (TS2717 ×5).** Five specs re-declared `__cic_socketHealth`
and two re-declared `__cic_bundleHash`, in mutually incompatible shapes, and
the widest copy was still narrower than the real page surface. They converge on
ONE declaration in `e2e/types/cic-window.d.ts`, mirrored from the `src/lib/*`
modules that install the probes — one shape, not N compatible ones. Spec-LOCAL
probes stay declared in their spec; they are not a shared surface.

**`=== "warn"` (TS2367 ×4).** Four hand-copied `page.on("console", …)`
forwarders, all four filtering on a value Playwright never returns (it is
`"warning"`), so every cic `console.warn` was dropped from the log of the specs
that had gone out of their way to capture it. One wrong literal was wrong four
times because the block was copied four times; the fix is one
`fixtures/pageDiagnostics.ts` whose severity set is typed against Playwright's
own union, so the next typo is a compile error rather than a branch that never
runs.

**`irc-framework` (TS7016).** No `@types/irc-framework` exists (the registry
answers 404), so the choice was a bare `declare module` — implicit `any` for
the whole peer fixture, the escape hatch this issue exists to remove — or types
of ours. `e2e/types/irc-framework.d.ts` declares the slice the fixture drives,
payloads transcribed from the library's own `emit` sites, same shape as the
`PrivmsgSource` slice `privmsgWait.ts` already declares. The load-bearing part
is `IrcEventName`: `once` / `onceMatching` are now keyed by event NAME, so a
listener on an event the library never emits is a compile error — the
`rpl_youreoper` trap this fixture already documents in a comment, and the same
defect class as `=== "warn"`.

## The always-false audit

A gate is a sample, not a list, so this started from a census rather than from
the four sites the issue names.

**Method.** Every `===` / `!==` against a string literal in `e2e/` was
rewritten in place to an impossible sentinel and the project recompiled once.
A site that then reports TS2367 is one the compiler can see; a site that stays
silent is one where an operand is `string`/`any` and TS2367 physically cannot
fire. That partitions the suite by *what the gate can prove*, instead of by
what a reader noticed.

**Census (126 literal comparisons; 26 of them inside comments):**

- **34 code sites are compiler-covered.** With the branch green, TS2367 = 0
  over all of them — the compiler now vouches for every literal it can type.
- **66 code sites are compiler-blind**, and every literal in them was checked
  by hand against its producer. All correct. They fall into four groups: HTTP
  verbs off `Request.method()` (returns `string`); DOM strings
  (`location.protocol`, `tagName`, `getAttribute`); our own wire tokens
  arriving through untyped JSON (`frame[3] === "visibility"`, `kind ===
  "whois_bundle"`, `connection_state === "connected"` — each verified against
  `socket.ts` / `session.ex` / the router); and self-contained local literals.
- `==` / `!=` do not occur: biome's `noDoubleEquals` now forbids them here.

**The four `=== "warn"` sites gate no assertion** — all are diagnostic
forwarders, so the effect was a debuggability hole, as the issue says.

**What the sweep did surface** is the same failure mode one layer up, and it is
worth a look independently of this PR. The dangerous shape is *record behind a
predicate, then assert the record is empty*: if the recorder silently stops
matching, the assertion passes for the wrong reason. Five specs have it. Two
are anchored — `issue282` proves `patches` non-empty at line 174 before relying
on its emptiness at 162, `issue1089` proves `frames.length > 10` before its
`toEqual([])` — and `issue981` is exemplary, carrying an explicit POSITIVE
CONTROL with a comment saying why the negative would otherwise mean nothing.
**Three are unanchored:** `issue160-virtual-tab-no-cursor` (two `toEqual([])`),
`channel-directory` (`toHaveLength(0)`), `ux-5-bu-unread-focus`
(`toHaveLength(0)`). Their literals are right today — I verified the read-cursor
route and method against the router and `readCursor.ts` — so nothing is passing
vacuously right now, and nothing here is silenced or "fixed" to look green.
Filed separately rather than folded into this PR.

## Reviewer notes

- Commit 2 is large and almost entirely mechanical (278 import-order + 175
  format fixes across 323 files). It will conflict with any in-flight branch
  touching `e2e/`; worth sequencing the merge accordingly. Reviewing it
  commit-by-commit is much easier than as a whole.
- Three `biome-ignore`s survive, each because the rule cannot see an API
  contract: Playwright resolves a fixture's dependencies by parsing its first
  parameter pattern, so the empty `{}` is the declaration form
  (`noEmptyPattern`); `void` is Playwright's own spelling for an auto-fixture
  that yields no value (`noConfusingVoidType`); and `issue299`'s `throw` from
  `finally` is deliberate, because a cleanup leak poisons every later spec on
  the shared stack and must fail loud (`noUnsafeFinally`).
- `biome check e2e` reports **zero** diagnostics, not merely zero errors. That
  is stricter than `src`, which still carries 61 warnings — it is cheaper to
  hold a clean line than to recover one.

## Test plan

- [x] `tsc --noEmit -p e2e/tsconfig.json` → RC=0, 0 errors (was 26/18 on the base)
- [x] `biome check e2e` → RC=0, 0 diagnostics (was 455 errors / 42 warnings / 4 infos)
- [x] `bun run check` → RC=0 (955 files linted, both tsc projects clean)
- [x] `bun run test` → RC=0, 263 files / 4880 tests
- [x] gate mutation: type error → red (read), lint error → red (read), reverted → green
- [x] rebased onto `c6478eae`, gates re-run green on the rebased tree
- [ ] CI `cicchetto (types + lint + unit)` green — this PR changes that job, so
      its own run is the first real execution of the new install step
- [ ] the full e2e suite is NOT run from this branch (no lane), so the
      behaviour-touching edits below are unwitnessed

### What this changes at runtime, and what it does not

Almost everything here is types, imports and whitespace. Four edits are not:

1. `issue554` now calls `peer.disconnect("#554 kill test done")` — the reason
   was a required parameter being passed nothing, so the peer used to send a
   bare `QUIT` and now sends `QUIT :#554 kill test done`. The spec observes the
   credential state server-side, not the quit text.
2. The four console forwarders become `forwardPageDiagnostics(page)`, which
   really does forward `console.warn` now (that is the fix), and adds a
   `pageerror` forwarder to `issue200`'s two tests, which had none. Log output
   only — the helper asserts nothing.
3. `m12` selects `[data-testid="scrollback-line"][data-kind="notice"]` directly
   instead of calling `scrollbackLine(page, "notice")` with its body argument
   missing. Playwright read the resulting `hasText: undefined` as "no filter",
   so the locator is the same one, now spelled deliberately.
4. `bundle-refresh` installs its `getRegistration` stub with
   `Object.defineProperty` instead of assignment — the same way the `controller`
   stub two lines below it is already installed.

The three unanchored negative assertions found by the audit are reported, not
touched.
