### PR TITLE
cli(#1086): boot verbs answer --help inline, with the flag table gated

### DIFF
--- a/bin/grappa
+++ b/bin/grappa
@@ -276,12 +276,225 @@ verb_shell() {
 
 # --- per-verb help -------------------------------------------------------
 #
-# Boot verbs delegate to `mix help grappa.<task>` (mix's built-in reads
-# @shortdoc/@moduledoc). Live-state + debug verbs have inline heredocs.
+# EVERY verb has an inline `verb_help_<snake>` heredoc — one rule, no
+# per-kind branch in `dispatch_help`.
+#
+# #1086 second slice: the ten boot verbs used to delegate to
+# `scripts/mix.sh --env=dev help grappa.<task>`, letting mix print the
+# task's @shortdoc/@moduledoc. Two reasons that went away:
+#
+#   1. It answered a DIFFERENT question. The moduledoc documents the mix
+#      task — it spells the command `scripts/mix.sh grappa.create_user`,
+#      not `bin/grappa create-user`, and carries developer prose (Boundary
+#      declarations, the #251/#266 vhost-precedence history) that an
+#      operator asking "what flags does this take" did not ask for.
+#   2. It cost a container. With no live grappa container, scripts/mix.sh
+#      falls through _lib.sh's `in_container_or_oneshot` to
+#      `docker compose run --rm --no-deps` — booting an image to print a
+#      paragraph, and failing outright where docker is unavailable.
+#
+# The duplication this creates against @shortdoc/@moduledoc is DELIBERATE
+# and bounded: the prose is written for a different reader, but the FLAG
+# TABLE is the same contract twice, so it is gated. Every boot verb's
+# flag lines must name exactly the task's `@switches`, both directions —
+# see test/mix/tasks/grappa/operator_help_drift_test.exs. Generating the
+# whole block from the moduledoc was rejected: see the test's moduledoc
+# for why the `wireTypes.ts` codegen precedent does not transfer.
+#
+# FORMAT CONTRACT for the boot blocks: a flag DECLARATION sits at 8+
+# columns with `--flag` as its first token; prose sits at 4. The gate
+# reads the former and ignores the latter, so a prose sentence that wraps
+# onto a `--flag` does not register as a switch. Keep prose off column 8.
 
-help_boot_verb() {
-    local task=$1
-    exec "$SCRIPTS_DIR/mix.sh" --env=dev help "$task"
+verb_help_create_user() { cat <<'EOF'
+create-user --name <name> --password <secret> [--admin]
+    Create a Grappa user account. The password is hashed with Argon2
+    before insertion; the new user's id is printed on success.
+
+    Required:
+        --name <name>          account name
+        --password <secret>    plaintext, hashed on the way in
+    Optional:
+        --admin                grant is_admin at creation - the
+                               one-command first-admin bootstrap
+EOF
+}
+
+verb_help_bind_network() { cat <<'EOF'
+bind-network --user <name> --network <slug> --server <host:port>
+             --nick <nick> --auth <mode> [options]
+    Idempotently create the network, one server entry and the
+    per-(user, network) credential in a single call. Rebinding an
+    existing credential is a changeset error - use
+    update-network-credential to mutate one. Adding a server that is
+    already there is a silent no-op.
+
+    TLS posture is port-sniffed when neither --tls nor --no-tls is
+    given: 6697 means on, any other port means off.
+
+    Required:
+        --user <name>          Grappa account that owns the binding
+        --network <slug>       network slug (created when absent)
+        --server <host:port>   upstream endpoint
+        --nick <nick>          nick to use upstream
+        --auth <mode>          auto | sasl | server_pass |
+                               nickserv_identify | none
+    Optional:
+        --tls / --no-tls       force the TLS posture (default: sniffed)
+        --password <secret>    NickServ / server password
+        --autojoin <list>      comma-separated channel list
+        --realname <text>      IRC realname field
+        --sasl-user <name>     SASL account when it differs from the nick
+        --services-flavor <f>  services suite running on the network
+        --source <ip>          pin the outbound source address. Literal
+                               IPv4/IPv6 only, no hostname, no CIDR. It
+                               WINS over a subject's vhost selection and
+                               the rotation pool (#266).
+EOF
+}
+
+verb_help_add_server() { cat <<'EOF'
+add-server --network <slug> --server <host:port> [options]
+    Append another endpoint to an existing network's fail-over list.
+    The network must already exist - this verb never creates one.
+    Re-adding the same (network, host, port) is a no-op.
+
+    TLS posture is port-sniffed when neither --tls nor --no-tls is
+    given: 6697 means on, any other port means off. The old
+    always-on default was a footgun: a plain :6667 leaf added without
+    an explicit flag produces a handshake that never completes, and
+    the failure surfaces as :connect_timeout ~8s into every spawn.
+
+    Required:
+        --network <slug>       network the endpoint belongs to
+        --server <host:port>   endpoint to add
+    Optional:
+        --tls / --no-tls       force the TLS posture (default: sniffed)
+        --priority <n>         fail-over order, lower first (default 0)
+        --source <ip>          pin the outbound source address. Literal
+                               IPv4/IPv6 only, no hostname, no CIDR.
+EOF
+}
+
+verb_help_remove_server() { cat <<'EOF'
+remove-server --network <slug> --server <host:port>
+    Remove one (host, port) endpoint. The network row and its other
+    servers stay in place - use unbind-network to drop a binding.
+    Idempotent: removing an already-gone endpoint exits 0.
+
+    Required:
+        --network <slug>       network the endpoint belongs to
+        --server <host:port>   endpoint to remove
+EOF
+}
+
+verb_help_set_network_caps() { cat <<'EOF'
+set-network-caps --network <slug> <cap flag...>
+    Set or clear the admission caps on a network row. Pass only the
+    caps you want to change; the others keep their current value.
+    Setting a cap and clearing the same cap are mutually exclusive.
+
+    A cap of 0 is a degenerate lock-down (admit none); a cleared cap
+    is NULL, meaning unlimited.
+
+    Required:
+        --network <slug>       network to update
+    At least one of:
+        --max-visitor-sessions <n>     cap concurrent visitor sessions
+        --max-user-sessions <n>        cap concurrent user sessions
+        --max-per-ip <n>               cap concurrent sessions per IP
+        --clear-max-visitor-sessions   drop the visitor cap
+        --clear-max-user-sessions      drop the user cap
+        --clear-max-per-ip             drop the per-IP cap
+EOF
+}
+
+verb_help_unbind_network() { cat <<'EOF'
+unbind-network --user <name> --network <slug>
+    Remove the per-(user, network) credential and stop the live
+    session. The network row is never deleted, even when its last
+    binding goes away. Idempotent: unbinding nothing exits 0.
+
+    Required:
+        --user <name>          account that owns the binding
+        --network <slug>       network to unbind from
+EOF
+}
+
+verb_help_update_network_credential() { cat <<'EOF'
+update-network-credential --user <name> --network <slug> [options]
+    Mutate an existing credential. Pass only the fields you want to
+    change - every other field keeps its current value. Use
+    bind-network to create a binding; this verb only updates.
+
+    Required:
+        --user <name>          account that owns the binding
+        --network <slug>       network the credential belongs to
+    Optional:
+        --nick <nick>          nick to use upstream
+        --password <secret>    NickServ / server password
+        --auth <mode>          auto | sasl | server_pass |
+                               nickserv_identify | none
+        --autojoin <list>      REPLACES the channel list (comma-
+                               separated); omit it to keep the
+                               current one
+        --realname <text>      IRC realname field
+        --sasl-user <name>     SASL account when it differs from the nick
+EOF
+}
+
+verb_help_seed_scrollback() { cat <<'EOF'
+seed-scrollback --user <name> --network <slug> --channel <#chan>
+                --count <n> --sender <nick>
+    e2e fixture verb, NOT a production one: persist N synthetic
+    :privmsg rows so a scrollback spec gets a deterministically tall
+    pane without driving an IRC peer through bahamut-test, whose
+    fakelag throttle makes seeds over ~5 messages non-deterministic.
+
+    Each row's server_time increases monotonically from
+    now - count * 100ms, so the rows sort naturally and span a
+    timeline a test can place a read cursor inside.
+
+    Required:
+        --user <name>          account that owns the scrollback
+        --network <slug>       network slug
+        --channel <#chan>      channel to seed
+        --count <n>            row count; over 2000 is refused
+        --sender <nick>        synthetic peer nick on every row
+EOF
+}
+
+verb_help_gen_encryption_key() { cat <<'EOF'
+gen-encryption-key
+    Print a fresh base64-encoded 32-byte key for Grappa.Vault (Cloak
+    AES-GCM). Save it as GRAPPA_ENCRYPTION_KEY in your .env and back
+    it up separately: losing the key means losing the ability to
+    decrypt every stored upstream credential.
+
+    Run once per deployment, at first install. Rotating later needs a
+    re-encryption migration, which does not exist yet.
+
+    Takes no flags.
+EOF
+}
+
+verb_help_gen_vapid() { cat <<'EOF'
+gen-vapid
+    Print a fresh ECDSA P-256 VAPID keypair (RFC 8292) for Web Push
+    signing, as env lines ready to paste into the grappa service's
+    environment: block:
+
+        VAPID_PUBLIC_KEY=BJk...
+        VAPID_PRIVATE_KEY=z3p...
+        VAPID_SUBJECT=mailto:you@example.org   (optional)
+
+    Run once per deployment, at first install. Rotating the keypair
+    invalidates every push_subscriptions row - browsers reject pushes
+    signed by an unknown application server key - so expect users to
+    re-toggle push in cic settings afterwards.
+
+    Takes no flags.
+EOF
 }
 
 verb_help_delete_visitor() { cat <<'EOF'
@@ -491,8 +704,11 @@ declare -ag VERB_DISPLAY_ORDER=(
 
 # --- dispatch ------------------------------------------------------------
 
-# Per-verb help dispatch. Boot verbs delegate to `mix help grappa.<task>`;
-# all others have an explicit `verb_help_<snake>` function.
+# Per-verb help dispatch. EVERY verb, whatever its kind, has an explicit
+# `verb_help_<snake>` function — so this routes by name alone, with no
+# per-kind branch. A verb added to the VERBS table without one dies with
+# `command not found` rather than printing nothing; the bats suite walks
+# the whole table asserting help exits 0.
 dispatch_help() {
     if [ $# -eq 0 ]; then
         help_top
@@ -500,15 +716,9 @@ dispatch_help() {
     fi
     local verb=$1
     [ -n "${VERBS[$verb]:-}" ] || die_unknown_verb "$verb"
-    local kind
-    kind="$(verb_field "$verb" 1)"
-    if [ "$kind" = "boot" ]; then
-        help_boot_verb "$(verb_field "$verb" 2)"
-    else
-        local snake
-        snake="$(kebab_to_snake "$verb")"
-        "verb_help_${snake}"
-    fi
+    local snake
+    snake="$(kebab_to_snake "$verb")"
+    "verb_help_${snake}"
 }
 
 # Main verb dispatch. Routes by `kind`:

--- a/bin/grappa
+++ b/bin/grappa
@@ -360,6 +360,26 @@ list-visitors
 EOF
 }
 
+verb_help_db_latency() { cat <<'EOF'
+db-latency
+    Print the #357 SQLite write-latency / repo query-latency
+    aggregate as tab-separated tables. Same Grappa.DbLatency snapshot
+    the admin GET /admin/db_latency returns - one feature, one code
+    path, every door.
+
+    Counters are cumulative since the last reset, so the reading is
+    only as meaningful as the window: run db-latency-reset, wait out
+    the sample window (~25s under load), then read.
+EOF
+}
+
+verb_help_db_latency_reset() { cat <<'EOF'
+db-latency-reset
+    Zero the Grappa.DbLatency counters, opening a fresh sample window
+    for db-latency. Nothing else is affected.
+EOF
+}
+
 verb_help_remote_shell() { cat <<'EOF'
 remote-shell [--batch -e <expr>]
     Attach to the live BEAM via Erlang distribution.
@@ -461,6 +481,8 @@ declare -ag VERB_DISPLAY_ORDER=(
     list-sessions
     list-credentials
     list-visitors
+    db-latency
+    db-latency-reset
     remote-shell
     open-db
     shell

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -34962,6 +34962,7 @@ installed from **Firefox will not appear in the system share sheet** even with
 this shipped. The original requester installed from Firefox, so their case
 stays uncovered on that browser; the feature works for Chromium-based installs.
 There is no fix available to us — it is not a bug in this implementation.
+
 ## 2026-08-09 — #1086: the boot verbs answer for themselves, and the flag table is gated
 
 The first slice of #1086 left the ten boot verbs delegating their help to

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -34962,3 +34962,94 @@ installed from **Firefox will not appear in the system share sheet** even with
 this shipped. The original requester installed from Firefox, so their case
 stays uncovered on that browser; the feature works for Chromium-based installs.
 There is no fix available to us — it is not a bug in this implementation.
+## 2026-08-09 — #1086: the boot verbs answer for themselves, and the flag table is gated
+
+The first slice of #1086 left the ten boot verbs delegating their help to
+`exec scripts/mix.sh --env=dev help grappa.<task>` and escalated the rest. This
+closes it: all twenty-three verbs now answer `--help` from an inline
+`verb_help_<snake>` heredoc, and `dispatch_help` lost its per-kind branch.
+
+**The escalation's premise was wrong, and the honest reasons are different
+ones.** The previous entry says the delegated help "needs the container UP".
+It does not. `scripts/mix.sh` ends in `_lib.sh`'s `in_container_or_oneshot`,
+which `exec`s into the live container only when one is running and you are not
+in a worktree, and otherwise falls through to `in_oneshot` —
+`docker compose run --rm --no-deps grappa`. With the instance down the help
+still prints. The reasons that survive measurement are smaller and real:
+
+  * **It answered a different question.** `mix help grappa.create_user` prints
+    the `@moduledoc`, which documents the MIX TASK: it spells the command
+    `scripts/mix.sh grappa.create_user`, not `bin/grappa create-user`, and
+    carries developer prose — Boundary-declaration paragraphs, the #251/#266
+    vhost-precedence history, the post-mortem of the nine-day cold-start
+    mystery in `grappa.add_server`. An operator asking which flags a verb takes
+    gets none of that as an answer.
+  * **It cost a container to print a paragraph.** The oneshot path boots an
+    image; where docker is absent it does not run at all. Measured on this
+    worktree with `docker` refusing to exec and `SCRIPTS_DIR` pointing at an
+    empty directory, every one of the ten exited **127**; after the change,
+    every one exits **0**.
+
+**The packaged-host argument does NOT hold, and was not used.** It is tempting
+to say a `.deb`/AUR install has no compose and therefore no oneshot. True, but
+irrelevant: neither package ships this dispatcher. `/usr/bin/grappa` there is
+`infra/packaging/grappa-wrapper.sh`, a thin wrapper over the mix-release boot
+script whose verbs are `migrate`, `gen-secrets`, `remote`, `version`, `eval` —
+a different program that happens to share a name. It has no `create-user`.
+
+**Hand-written, not generated — and the `wireTypes.ts` precedent does not
+transfer.** The obvious alternative was generating the blocks from the
+`@shortdoc`/`@moduledoc` at build time with a drift gate, as
+`mix grappa.gen_wire_types --check` does for `cicchetto/src/lib/wireTypes.ts`.
+That generator derives from `@type` SPECS — a machine-readable declaration with
+exactly one correct rendering in the target language. `@moduledoc` is prose
+written for a different reader, and prose has no single correct rendering into
+a second audience's document. Generating it verbatim ships developer material
+to operators; generating a curated subset means marking which prose is
+operator-facing, i.e. writing the operator's text a second time inside the
+`.ex` and then adding a build step to move it — the same duplication with more
+machinery.
+
+**What IS the same contract twice is the flag table, so that is what is
+gated.** `test/mix/tasks/grappa/operator_help_drift_test.exs` reads the VERBS
+table out of `bin/grappa`, pulls each boot verb's heredoc, collects every
+`--flag` on a flag-declaration line, parses the task's `@switches` off its AST,
+and asserts the two sets are equal in BOTH directions. A boolean switch may be
+spelled `--x`, `--no-x` or both. The verb list is derived from the dispatcher,
+so a new boot verb is gated without touching the test; a companion assertion
+fails if the extractor ever matches nothing, which would otherwise make the
+whole gate pass vacuously.
+
+**Required-ness is deliberately NOT gated.** `@required` is not the whole truth:
+`grappa.set_network_caps` declares `@required []` while `--network` is
+unconditionally required, raised later by `fetch_slug!/1` so that "you passed no
+cap at all" is reported before "you passed no network". Gating against
+`@required` would force the help to call `--network` optional, which is false.
+
+**Two pre-existing defects fell out of writing the completeness test.**
+`db-latency` and `db-latency-reset` (#357) were in the VERBS table but in
+neither `VERB_DISPLAY_ORDER` nor the help functions: they were invisible in the
+banner, and `bin/grappa help db-latency` exited **127** with
+`verb_help_db_latency: command not found` — on `origin/main`, since #357.
+Both now have help and a banner row, and two bats assertions walk the table so
+the class cannot recur.
+
+**A gate that reads a repo file needs that file MOUNTED, or it grades the
+wrong tree.** The gate came up red on its first run against a worktree whose
+help was already correct: `scripts/_lib.sh`'s `WORKTREE_VOLUMES` bind-mounts
+`lib`, `test`, `config`, `priv/repo`, `infra`, `cicchetto/src` and a handful of
+named root files over the base `./:/app` bind — `bin/` was not among them, so
+`File.read!("bin/grappa")` inside the container read MAIN's dispatcher. This is
+a recurring class, not a surprise: #652 added the `VERSION` override for the
+same reason, #369 theme 8 added `CLAUDE.md`, #369 X1 added `compose.yaml` +
+`.env.example`. `bin` now joins them, RO. **The general rule: a drift-pin test
+that reads a repo path outside `lib/test/config/priv/repo/infra/cicchetto/src`
+must add that path to `WORKTREE_VOLUMES` in the same commit, or it can never be
+verified GREEN from a worktree before merge.**
+
+**And a third copy of the flag table, already drifted.** `docs/OPERATIONS.md`
+spelled the boot verbs out with flags, advertising an `--host`/`--port` pair
+`add-server` never had (it takes `--server host:port`) and omitting
+`bind-network`'s required `--server`. An operator following the runbook hit
+exactly the #1086 crash. Rather than gate a third surface, the copy is deleted:
+the runbook now lists the verb names and points at `--help`.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -23,6 +23,19 @@ dispatcher cd's to the main repo for docker compose and forwards
 worktree volumes via oneshot bindings (same machinery as
 `scripts/*.sh`).
 
+**Where the flag table lives: `bin/grappa <verb> --help`** (or
+`bin/grappa help <verb>`, or `-h` — anywhere in the args). Every verb
+answers inline, needing neither a running container nor docker at all,
+so it works exactly when you reach for it: mid-incident, on a cold host,
+before the first build. That is the ONE authoritative flag list per
+verb — for the boot verbs it is gated against the mix task's
+`@switches`, both directions, by
+`test/mix/tasks/grappa/operator_help_drift_test.exs`. This runbook
+deliberately no longer repeats it (#1086): the copy it used to carry had
+already drifted, advertising an `--host`/`--port` pair `add-server`
+never had and omitting `bind-network`'s required `--server`, so anyone
+following the runbook hit the very crash #1086 was filed for.
+
 > **2026-05-31 admin-panel CRUD cluster:** every mix-task verb below
 > now has a REST equivalent under `/admin/*` (admin-gated). Prefer
 > the **AdminPane in cic** (browser UI) for ad-hoc operator actions
@@ -38,17 +51,18 @@ bin/grappa help                  # list verbs grouped by category
 bin/grappa help <verb>           # per-verb help
 bin/grappa <verb> --help         # same, as a flag (or -h) — anywhere in the args
 
-# Boot-time verbs (mix tasks; auto-detect MIX_ENV from container):
-bin/grappa create-user --name <user> --password <pw>
-bin/grappa bind-network --user <user> --network <slug> --nick <nick> --auth <method> [--source <ip>] [--services-flavor <azzurra|atheme|oftc|unknown>]
-bin/grappa add-server --network <slug> --host <host> --port <port> [--tls] [--source <ip>]
-bin/grappa remove-server --network <slug> --host <host> --port <port>
-bin/grappa set-network-caps --network <slug> [--max-visitor-sessions N] [--max-user-sessions N] [--max-per-ip N]
-bin/grappa unbind-network --user <user> --network <slug>
-bin/grappa update-network-credential ...
-bin/grappa seed-scrollback ...
-bin/grappa gen-encryption-key
-bin/grappa gen-vapid
+# Boot-time verbs (mix tasks; auto-detect MIX_ENV from container).
+# Flags: `bin/grappa <verb> --help` — see the note above.
+bin/grappa create-user               # create a Grappa user account
+bin/grappa bind-network              # bind a (user, network) credential
+bin/grappa add-server                # add a server entry to a network
+bin/grappa remove-server             # remove a server entry from a network
+bin/grappa set-network-caps          # set / clear per-network admission caps
+bin/grappa unbind-network            # remove a (user, network) credential
+bin/grappa update-network-credential # edit autojoin / nick / SASL fields
+bin/grappa seed-scrollback           # seed dev + e2e scrollback
+bin/grappa gen-encryption-key        # generate a Cloak.Vault key
+bin/grappa gen-vapid                 # generate a VAPID keypair (push)
 
 # Live-state verbs (--rpc-eval against the live BEAM via T-2 dist shell):
 bin/grappa delete-visitor <uuid>     # sync terminate + Repo.delete; frees cap slot
@@ -58,6 +72,8 @@ bin/grappa reap-visitors             # force-run Visitors.Reaper.sweep (otherwis
 bin/grappa list-sessions             # tab-separated: subject, network_id, pid, mailbox, memory
 bin/grappa list-credentials          # tab-separated: user, network, nick, state (ALL states)
 bin/grappa list-visitors             # tab-separated: id, nick, network, expires_at, identified
+bin/grappa db-latency                # #357 SQLite write/query-latency aggregate
+bin/grappa db-latency-reset          # zero the counters, opening a fresh window
 
 # Live-state attach:
 bin/grappa remote-shell              # iex --remsh against live BEAM

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -135,6 +135,14 @@ if [ "$SRC_ROOT" != "$REPO_ROOT" ]; then
         # verify a fix GREEN before merge. RO — tests only read them.
         -v "$SRC_ROOT/compose.yaml:/app/compose.yaml:ro"
         -v "$SRC_ROOT/.env.example:/app/.env.example:ro"
+        # Same drift-pin reasoning again for the operator dispatcher
+        # (#1086): operator_help_drift_test.exs reads bin/grappa to assert
+        # each boot verb's inline help names exactly its mix task's
+        # @switches. bin/ is not under the dir mounts above, so without
+        # this override a worktree run reads MAIN's dispatcher — which is
+        # how the gate first came up red against a worktree whose help
+        # was correct. RO — tests only read it.
+        -v "$SRC_ROOT/bin:/app/bin:ro"
     )
 fi
 

--- a/test/bin/grappa_test.bats
+++ b/test/bin/grappa_test.bats
@@ -199,6 +199,48 @@ EOF
     [ "$status" -eq 64 ]
 }
 
+# --- VERBS table completeness --------------------------------------------
+#
+# db-latency + db-latency-reset (#357) were in VERBS but in neither
+# VERB_DISPLAY_ORDER nor the help functions, so they were invisible in the
+# banner and `bin/grappa help db-latency` died with 127
+# (`verb_help_db_latency: command not found`). Both halves of that are a
+# CLASS, not two typos: the banner is rendered by walking
+# VERB_DISPLAY_ORDER, and per-verb help is dispatched by name, so either
+# omission silently orphans a verb. These walk the table instead.
+
+# Every verb in the VERBS table, whatever its kind.
+table_verbs() {
+    sed -nE 's/^[[:space:]]*\[([a-z-]+)\]="(boot|rpc|attach|debug|meta)\|.*/\1/p' "$BIN_GRAPPA"
+}
+
+@test "the VERBS extractor is not silently empty (guard against a dead loop)" {
+    run table_verbs
+    [ "$status" -eq 0 ]
+    [ "$(wc -l <<<"$output")" -ge 20 ]
+    [[ "$output" == *"db-latency"* ]]
+}
+
+@test "the banner lists every verb in the table (VERB_DISPLAY_ORDER covers VERBS)" {
+    run "$BIN_GRAPPA" help
+    [ "$status" -eq 0 ]
+    local banner="$output" verb
+    while read -r verb; do
+        [[ "$banner" == *"$verb"* ]] || {
+            printf 'verb %q is in VERBS but absent from the banner\n' "$verb" >&2
+            return 1
+        }
+    done < <(table_verbs)
+}
+
+@test "every verb in the table has per-verb help that exits 0" {
+    local verb
+    while read -r verb; do
+        run "$BIN_GRAPPA" help "$verb"
+        [ "$status" -eq 0 ]
+    done < <(table_verbs)
+}
+
 # --- debug verbs ----------------------------------------------------------
 
 @test "shell invokes docker compose exec grappa bash" {

--- a/test/bin/grappa_test.bats
+++ b/test/bin/grappa_test.bats
@@ -116,10 +116,12 @@ EOF
     [[ "$output" != *"STUB"* ]]
 }
 
-@test "help <boot-verb> delegates to scripts/mix.sh help grappa.<task>" {
+@test "help <boot-verb> prints inline help and never reaches mix" {
     run "$BIN_GRAPPA" help create-user
     [ "$status" -eq 0 ]
-    grep -q 'mix.sh --env=dev help grappa.create_user' "$ARGV_LOG"
+    [[ "$output" == *"create-user"* ]]
+    [[ "$output" == *"--password"* ]]
+    [ ! -s "$ARGV_LOG" ]
 }
 
 @test "help <debug-verb> prints inline help" {
@@ -146,23 +148,25 @@ EOF
 @test "#1086 <boot-verb> --help routes to per-verb help, not to the task" {
     run "$BIN_GRAPPA" bind-network --help
     [ "$status" -eq 0 ]
-    grep -q 'mix.sh --env=dev help grappa.bind_network' "$ARGV_LOG"
-    # The task itself must never be invoked — that is the crash path.
-    refute grep -q 'mix.sh grappa.bind_network' "$ARGV_LOG"
+    [[ "$output" == *"bind-network"* ]]
+    [[ "$output" == *"--auth"* ]]
+    # Neither the task NOR `mix help` may be reached: the first is the
+    # crash path, the second is the delegation this slice removed.
+    [ ! -s "$ARGV_LOG" ]
 }
 
 @test "#1086 <boot-verb> -h routes to per-verb help" {
     run "$BIN_GRAPPA" bind-network -h
     [ "$status" -eq 0 ]
-    grep -q 'mix.sh --env=dev help grappa.bind_network' "$ARGV_LOG"
-    refute grep -q 'mix.sh grappa.bind_network' "$ARGV_LOG"
+    [[ "$output" == *"bind-network"* ]]
+    [ ! -s "$ARGV_LOG" ]
 }
 
 @test "#1086 --help is honoured after other arguments, not only first" {
     run "$BIN_GRAPPA" bind-network --user vjt --network azzurra --help
     [ "$status" -eq 0 ]
-    grep -q 'mix.sh --env=dev help grappa.bind_network' "$ARGV_LOG"
-    refute grep -q 'mix.sh grappa.bind_network' "$ARGV_LOG"
+    [[ "$output" == *"bind-network"* ]]
+    [ ! -s "$ARGV_LOG" ]
 }
 
 @test "#1086 <rpc-verb> --help prints inline help without touching docker" {
@@ -233,12 +237,75 @@ table_verbs() {
     done < <(table_verbs)
 }
 
-@test "every verb in the table has per-verb help that exits 0" {
+@test "every verb in the table has per-verb help that exits 0 and prints something" {
+    # `prints something` only became assertable once the boot verbs
+    # answered inline (#1086): while they delegated, the stubbed
+    # scripts/mix.sh exited 0 with nothing on stdout.
     local verb
     while read -r verb; do
         run "$BIN_GRAPPA" help "$verb"
         [ "$status" -eq 0 ]
+        [ -n "$output" ]
     done < <(table_verbs)
+}
+
+# --- #1086 second slice: boot-verb help is INLINE ------------------------
+#
+# The ten boot verbs used to answer `--help` with
+# `exec scripts/mix.sh --env=dev help grappa.<task>`, i.e. mix's built-in
+# reader of the task's @shortdoc/@moduledoc. That answered a different
+# question than the one asked — the moduledoc documents
+# `scripts/mix.sh grappa.create_user`, not `bin/grappa create-user` — and
+# it cost a container: with no live grappa container, scripts/mix.sh falls
+# through _lib.sh's `in_container_or_oneshot` to
+# `docker compose run --rm --no-deps`, booting an image to print a
+# paragraph. These are the tests that state the REASON.
+
+# The boot verbs, read off the VERBS table so a verb added there is
+# covered without editing this file.
+boot_verbs() {
+    sed -nE 's/^[[:space:]]*\[([a-z-]+)\]="boot\|.*/\1/p' "$BIN_GRAPPA"
+}
+
+@test "#1086 the boot-verb extractor sees the whole table (guard against a dead loop)" {
+    run boot_verbs
+    [ "$status" -eq 0 ]
+    [ "$(wc -l <<<"$output")" -eq 10 ]
+    [[ "$output" == *"create-user"* ]]
+    [[ "$output" == *"gen-vapid"* ]]
+}
+
+@test "#1086 every boot verb answers --help with no working docker and no scripts/ dir" {
+    # Hostile environment: `docker` on PATH refuses to run at all, and
+    # SCRIPTS_DIR points at an empty directory, so `$SCRIPTS_DIR/mix.sh`
+    # does not exist. Any surviving delegation exits non-zero here — as
+    # all ten did before this slice, with 127.
+    cat > "$FAKE_DIR/docker" <<'EOF'
+#!/usr/bin/env bash
+printf 'docker: refusing to run in the no-docker help test\n' >&2
+exit 127
+EOF
+    chmod +x "$FAKE_DIR/docker"
+    mkdir -p "$BATS_TEST_TMPDIR/empty-scripts"
+    export SCRIPTS_DIR="$BATS_TEST_TMPDIR/empty-scripts"
+
+    local verb
+    while read -r verb; do
+        run "$BIN_GRAPPA" "$verb" --help
+        [ "$status" -eq 0 ]
+        # The help names the verb the operator typed (kebab), not the mix
+        # task the moduledoc documents.
+        [[ "$output" == *"$verb"* ]]
+        [ "${#output}" -gt 80 ]
+    done < <(boot_verbs)
+}
+
+@test "#1086 boot-verb help names bin/grappa's verb, never the mix task spelling" {
+    run "$BIN_GRAPPA" help update-network-credential
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"update-network-credential"* ]]
+    refute grep -q 'grappa.update_network_credential' <<<"$output"
+    refute grep -q 'scripts/mix.sh' <<<"$output"
 }
 
 # --- debug verbs ----------------------------------------------------------

--- a/test/mix/tasks/grappa/operator_help_drift_test.exs
+++ b/test/mix/tasks/grappa/operator_help_drift_test.exs
@@ -151,12 +151,12 @@ defmodule Mix.Tasks.Grappa.OperatorHelpDriftTest do
   # and reading the source is the point: this gate must fail on an edit
   # that never gets recompiled into anything the dispatcher can see.
   defp declared_switches(task) do
-    {_ast, switches} =
+    {_, switches} =
       "lib/mix/tasks/#{task}.ex"
       |> File.read!()
       |> Code.string_to_quoted!()
       |> Macro.prewalk([], fn
-        {:@, _, [{:switches, _, [list]}]} = node, _acc when is_list(list) -> {node, list}
+        {:@, _, [{:switches, _, [list]}]} = node, _ when is_list(list) -> {node, list}
         node, acc -> {node, acc}
       end)
 

--- a/test/mix/tasks/grappa/operator_help_drift_test.exs
+++ b/test/mix/tasks/grappa/operator_help_drift_test.exs
@@ -1,0 +1,165 @@
+defmodule Mix.Tasks.Grappa.OperatorHelpDriftTest do
+  @moduledoc """
+  #1086 — the flag table of every boot verb exists TWICE, and this is the
+  gate that keeps the two copies honest.
+
+  `bin/grappa <verb> --help` answers inline, from a `verb_help_<snake>`
+  heredoc in the dispatcher. The same flags are declared, authoritatively,
+  as the mix task's `@switches`. A switch added, renamed or dropped in the
+  task with no matching edit in the dispatcher gives the operator a help
+  text that lies — this test fails on the first byte of that drift, in
+  BOTH directions (a flag in the help that no switch backs, and a switch
+  with no flag in the help).
+
+  ## Why the help is hand-written and not generated
+
+  The obvious alternative was to generate the help blocks from
+  `@shortdoc`/`@moduledoc` at build time, mirroring `wireTypes.ts` (which
+  `mix grappa.gen_wire_types` derives from `Wire` typespecs, drift-gated
+  by `--check` in `scripts/check.sh` + CI). That precedent does not
+  transfer, for three reasons:
+
+    * **The generator derives TYPES, not prose.** `gen_wire_types` reads
+      `@type` specs — a machine-readable declaration with exactly one
+      correct rendering in TypeScript. `@moduledoc` is prose, and prose
+      has no single correct rendering into a second audience's document.
+
+    * **The two documents answer different questions.** The moduledoc
+      documents the MIX TASK: it spells the command
+      `scripts/mix.sh grappa.create_user`, not `bin/grappa create-user`,
+      and carries developer material — Boundary-declaration paragraphs
+      (`grappa.create_user`, `grappa.gen_encryption_key`), the #251/#266
+      vhost-precedence history, the post-mortem of the 9-day cold-start
+      mystery (`grappa.add_server`). Emitting it verbatim ships that to an
+      operator who asked which flags a verb takes. Emitting a curated
+      subset means marking which prose is operator-facing — i.e. writing
+      the operator's text a second time, in the `.ex` file, and then
+      adding a build step to move it.
+
+    * **What actually drifts is the flag table**, and that IS
+      machine-readable. So it is gated here, and only it. Divergent prose
+      between the two surfaces is not a defect; a divergent flag list is.
+
+  ## What is gated, and what deliberately is not
+
+  Gated: the SET of flags, both directions, per verb. A boolean switch may
+  be written `--x`, `--no-x`, or both — `--tls / --no-tls` and `--admin`
+  are equally acceptable spellings.
+
+  NOT gated: which flags are required. `@required` is not the whole truth
+  today — `grappa.set_network_caps` declares `@required []` while
+  `--network` is unconditionally required, raised later by `fetch_slug!/1`
+  so that "you passed no cap at all" is reported before "you passed no
+  network". Gating required-ness against `@required` would force the help
+  to call `--network` optional, which is false. Required-ness stays prose.
+  """
+  use ExUnit.Case, async: true
+
+  @dispatcher "bin/grappa"
+  @source File.read!(@dispatcher)
+  @external_resource @dispatcher
+
+  # kebab verb -> mix task name, read off the dispatcher's VERBS table so a
+  # newly added boot verb is gated without editing this file.
+  @boot_verbs Enum.map(
+                Regex.scan(~r/^\s*\[([a-z-]+)\]="boot\|([a-z_.]+)\|/m, @source),
+                fn [_, verb, task] -> {verb, task} end
+              )
+
+  test "the boot-verb extractor is not silently empty" do
+    # Without this, a regex that stops matching generates ZERO tests below
+    # and the whole gate passes vacuously.
+    occurrences = length(Regex.scan(~r/="boot\|/, @source))
+
+    assert occurrences > 0, "no boot verbs in #{@dispatcher} — the VERBS table shape changed"
+    assert length(@boot_verbs) == occurrences
+  end
+
+  for {verb, task} <- @boot_verbs do
+    @verb verb
+    @task task
+
+    test "#{verb} help lists exactly the @switches of #{task}" do
+      switches = declared_switches(@task)
+      declared = MapSet.new(Keyword.keys(switches))
+      mentioned = @verb |> help_body() |> mentioned_switches(switches)
+
+      assert MapSet.equal?(mentioned, declared), """
+      bin/grappa's `#{@verb}` help and #{@task}'s @switches disagree.
+
+        in the help but not a switch: #{inspect(MapSet.to_list(MapSet.difference(mentioned, declared)))}
+        a switch but not in the help: #{inspect(MapSet.to_list(MapSet.difference(declared, mentioned)))}
+      """
+    end
+  end
+
+  # The heredoc body of `verb_help_<snake>() { cat <<'EOF' ... EOF }`.
+  defp help_body(verb) do
+    snake = String.replace(verb, "-", "_")
+    pattern = Regex.compile!("^verb_help_#{snake}\\(\\) \\{ cat <<'EOF'\n(.*?)\nEOF\n\\}", "ms")
+
+    case Regex.run(pattern, @source) do
+      [_, body] -> body
+      nil -> flunk("no verb_help_#{snake}() heredoc in #{@dispatcher}")
+    end
+  end
+
+  # A flag DECLARATION line is one indented into a `Required:` / `Optional:`
+  # section (8 spaces or more) whose first token is a `--flag`; every
+  # `--flag` token on such a line counts, so `--tls / --no-tls` declares
+  # both spellings.
+  #
+  # The indent is load-bearing, not decoration. Prose in these blocks sits
+  # at 4 columns and wraps: a sentence that happens to break onto
+  # `--max-* and its --clear-* twin ...` would otherwise be read as
+  # declaring two switches called `max_` and `clear_`. Requiring the
+  # section indent makes wrapped prose safe by construction, and a flag
+  # line written at the WRONG indent still fails loudly — as a switch the
+  # help does not mention.
+  @flag_line ~r/^ {8,}--[a-z0-9-]/
+
+  defp mentioned_switches(body, switches) do
+    body
+    |> String.split("\n")
+    |> Enum.filter(&Regex.match?(@flag_line, &1))
+    |> Enum.flat_map(&Regex.scan(~r/--[a-z0-9-]+/, &1))
+    |> Enum.map(fn [flag] -> to_switch(flag, switches) end)
+    |> MapSet.new()
+  end
+
+  # `--no-tls` is OptionParser's negation of the boolean switch `:tls`, not
+  # a switch of its own.
+  defp to_switch(flag, switches) do
+    atom = flag |> String.trim_leading("-") |> String.replace("-", "_") |> String.to_atom()
+
+    negated_boolean(atom, switches) || atom
+  end
+
+  defp negated_boolean(atom, switches) do
+    case Atom.to_string(atom) do
+      "no_" <> rest ->
+        stripped = String.to_atom(rest)
+        if Keyword.get(switches, stripped) == :boolean, do: stripped
+
+      _ ->
+        nil
+    end
+  end
+
+  # @switches straight off the task's AST. Module attributes are not
+  # retained at runtime, so the source is the only place to read them —
+  # and reading the source is the point: this gate must fail on an edit
+  # that never gets recompiled into anything the dispatcher can see.
+  defp declared_switches(task) do
+    {_ast, switches} =
+      "lib/mix/tasks/#{task}.ex"
+      |> File.read!()
+      |> Code.string_to_quoted!()
+      |> Macro.prewalk([], fn
+        {:@, _, [{:switches, _, [list]}]} = node, _acc when is_list(list) -> {node, list}
+        node, acc -> {node, acc}
+      end)
+
+    switches
+  end
+end


### PR DESCRIPTION
Second slice of #1086. The first one taught the dispatcher to claim
`--help`; the ten boot verbs still delegated the ANSWER to
`exec scripts/mix.sh --env=dev help grappa.<task>`. Per the ruling on
the issue, they now answer inline. All twenty-three verbs do, and
`dispatch_help` lost its per-kind branch.

## Two reasons on record for this were wrong. Neither is used here.

**"It needs the container UP."** It does not. `scripts/mix.sh` ends in
`_lib.sh`'s `in_container_or_oneshot`, which `exec`s into the live
container only when one is running and you are not in a worktree, and
otherwise falls through to `in_oneshot` —
`docker compose run --rm --no-deps grappa`. With the instance down the
help still prints.

**"A packaged host has no compose, so the oneshot does not exist
there."** True about compose, irrelevant here: **neither the `.deb` nor
the AUR package ships this dispatcher.** `/usr/bin/grappa` on a packaged
host is `infra/packaging/grappa-wrapper.sh` (`nfpm.yaml:159`,
`aur/PKGBUILD:137`) — a thin wrapper over the mix-release boot script
whose verbs are `migrate`, `gen-secrets`, `remote`, `version`, `eval`.
It has no `create-user`. Inlining help in `bin/grappa` does nothing for
that host.

## The reason that survives measurement

**It answered a different question, and it cost a container to do it.**
`mix help grappa.create_user` prints the `@moduledoc`, which documents
the MIX TASK: it spells the command `scripts/mix.sh grappa.create_user`,
not `bin/grappa create-user`, and carries developer prose — Boundary
declarations, the #251/#266 vhost-precedence history, the nine-day
cold-start post-mortem in `grappa.add_server`. None of that answers
"which flags does this verb take". And the oneshot boots an image to
print a paragraph; where docker is unavailable it does not run at all.

Measured on this worktree with `docker` refusing to exec and
`SCRIPTS_DIR` pointing at an empty directory:

| | before | after |
|---|---|---|
| `bin/grappa <boot-verb> --help`, all ten | exit **127** | exit **0** |

## Hand-written, not generated — and why `wireTypes.ts` does not transfer

The issue asked which of (a) hand-write or (b) generate-from-`@shortdoc`
with a drift gate. **(a), with the flag table gated.**

`mix grappa.gen_wire_types` derives `wireTypes.ts` from `@type` **specs**
— a machine-readable declaration with exactly one correct rendering in
the target language. `@moduledoc` is **prose written for a different
reader**, and prose has no single correct rendering into a second
audience's document. Generating it verbatim ships Boundary paragraphs to
operators; generating a curated subset means marking which prose is
operator-facing, i.e. writing the operator's text a second time inside
the `.ex` and then adding a build step to move it — the same duplication
with more machinery.

**What IS the same contract twice is the flag table, so that is what is
gated.** `test/mix/tasks/grappa/operator_help_drift_test.exs` reads the
VERBS table out of `bin/grappa`, pulls each boot verb's heredoc,
collects every `--flag` on a flag-declaration line, parses `@switches`
off the task's AST, and asserts set equality **in both directions**. A
boolean may be spelled `--x`, `--no-x` or both. The verb list is derived
from the dispatcher, so a new boot verb is gated without touching the
test.

**Required-ness is deliberately NOT gated.** `@required` is not the
whole truth: `grappa.set_network_caps` declares `@required []` while
`--network` is unconditionally required, raised later by `fetch_slug!/1`
so "you passed no cap at all" is reported before "you passed no
network". Gating against `@required` would force the help to call
`--network` optional, which is false.

## Three things found on the way

1. **Pre-existing on `origin/main`, fixed in its own commit
   (`7f8cddc0`):** `db-latency` and `db-latency-reset` (#357) were in
   the VERBS table but in neither `VERB_DISPLAY_ORDER` nor the help
   functions — invisible in the banner, and `bin/grappa help db-latency`
   exited **127** with `verb_help_db_latency: command not found`. Three
   bats assertions now walk the table rather than naming verbs.

2. **A third copy of the flag table, already drifted — deleted, not
   gated.** `docs/OPERATIONS.md` advertised an `--host`/`--port` pair
   `add-server` never had (it takes `--server host:port`) and omitted
   `bind-network`'s required `--server`. Anyone following the runbook
   hit exactly the #1086 crash. The copy is replaced by a **pointer**,
   not a hole: the runbook now says where the flag table lives
   (`bin/grappa <verb> --help`), that it needs neither a container nor
   docker, and that it is gated.

3. **`bin/` joins `WORKTREE_VOLUMES` (`scripts/_lib.sh`).** The gate
   first came up red against a worktree whose help was already correct:
   `bin/` is not under the mounted dirs, so `File.read!("bin/grappa")`
   inside the container read MAIN's dispatcher. Same recurring class as
   #652 (`VERSION`), #369 theme 8 (`CLAUDE.md`), #369 X1
   (`compose.yaml` / `.env.example`).

## Evidence

- `scripts/check.sh` → **rc 0**. 8 doctests, 56 properties, **5598
  tests, 0 failures**; credo `--strict` no issues; dialyzer
  `Total errors: 0`; doctor passed. Working tree identical before and
  after the run.
- bats: baseline on the branch point **374/374, rc 0** → after
  **~380/380, rc 0**.
- Drift gate: 11 tests, 0 failures.

**Mutations, one assertion killed each:**

| mutation | killed |
|---|---|
| add `dry_run: :boolean` to `grappa.create_user`'s `@switches` | `create-user` — *a switch but not in the help: [:dry_run]* |
| rename `--sasl-user` → `--sasl-username` in the help only | `bind-network` — both directions named |
| delete the `--priority` line from `add-server`'s help | `add-server` — *a switch but not in the help: [:priority]* |
| change the VERBS table separator so the extractor matches nothing | the anti-vacuity guard — and the ten per-verb tests **vanished**, which is precisely what that guard exists to catch |
| drop `db-latency` from `VERB_DISPLAY_ORDER` | the banner-coverage bats test, only it |
| delete the two `verb_help_db_latency*` functions | the help-exits-0 bats test, only it |

## What I decline to assert

- **The gate does not prove the help is CORRECT, only that it names the
  right flags.** A wrong description, a wrong default, a wrong value
  syntax all pass. Prose is not gated and cannot be.
- **The 8-column indent convention is a convention, not a parser.** A
  flag written at the wrong indent fails loudly (as a switch the help
  omits), but the rule is coupled to formatting. It replaced "any line
  whose first token is `--`" only because dry-running that wider rule
  caught real prose wrapping onto `--max-*`.
- **`--no-<bool>` is accepted but never required.** If a boolean switch
  gains a meaningful negation, the gate will not notice it is
  undocumented.
- **The oneshot fallback was read from the code and inferred, not
  executed.** What I executed is the hostile-environment case (no
  working docker, no `scripts/` dir), which is the case this change is
  actually for.
- **`bats #44` red, mentioned in the briefing, does not reproduce** —
  the full set was 374/374 green at the branch point. I did not chase
  it and cannot say what it referred to.