### PR TITLE
wire(#448): close 4 under-typed closed sets, and the events one was eating

### DIFF
--- a/cicchetto/src/__tests__/api.test.ts
+++ b/cicchetto/src/__tests__/api.test.ts
@@ -760,22 +760,15 @@ describe("REV-A C1 — WireAdminEvent superset of server event_kind/0", () => {
   });
 });
 
-describe("REV-A C2 — capacity_reject.flow superset of server Admission.flow/0", () => {
-  // Mirror of `lib/grappa/admission.ex:53-58`. Server emits the bare
-  // atom verbatim via `Wire.capacity_reject/5` (Jason stringifies);
-  // cic MUST accept every value.
-  const SERVER_ADMISSION_FLOWS = [
-    "login_fresh",
-    "login_existing",
-    "bootstrap_user",
-    "bootstrap_visitor",
-    "patch_network_connect",
-  ] as const satisfies readonly api.AdmissionFlow[];
-
-  it("AdmissionFlow includes every server-emitted flow arm", () => {
-    expect(SERVER_ADMISSION_FLOWS.length).toBe(5);
-  });
-});
+// #448 — the REV-A C2 hand-mirror of `Grappa.Admission.flow/0` used to
+// live here. It could not do the job it claimed: the list was typed
+// `satisfies readonly api.AdmissionFlow[]`, and `api.AdmissionFlow` was
+// itself the hand copy — so the pin only ever compared the copy to
+// itself, and both sat at 5 arms while the server had 6. `AdmissionFlow`
+// is now codegen-emitted from the server typespec, so the drift the pin
+// was watching for is unrepresentable; what remains worth testing is the
+// runtime narrower's behaviour, pinned in `wireNarrow.test.ts` off the
+// generated `ADMISSION_FLOW` const.
 
 describe("REV-K M20 — channelPushError extractor", () => {
   // The WS Channel error envelope is `%{error: "<token>"}` post-REV-K

--- a/cicchetto/src/__tests__/wireNarrow.test.ts
+++ b/cicchetto/src/__tests__/wireNarrow.test.ts
@@ -5,6 +5,7 @@ import {
   narrowChannelEvent,
   narrowWindowStateEvent,
 } from "../lib/wireNarrow";
+import { ADMISSION_FLOW } from "../lib/wireTypes";
 
 // Bucket G H4+U3 — runtime narrower for per-channel WS events.
 // Mirror of `narrowUserEvent` (cic M1) on the per-channel boundary.
@@ -719,6 +720,15 @@ describe("narrowAdminEvent (REV-G H24)", () => {
     });
     it("rejects unknown flow", () => {
       expect(narrowAdminEvent({ ...valid, flow: "made_up" })).toBeNull();
+    });
+    // #448 — the allowlist used to be a hand copy of the server's flow
+    // set and had gone stale: `visitor_reconnect` was missing, so every
+    // capacity_reject from the visitor-reconnect door was dropped here
+    // and never reached the Events tab. Driving the table off the
+    // codegen-emitted const is what makes that unrepresentable — a new
+    // server flow arm arrives in this test by regenerating wireTypes.
+    it.each(ADMISSION_FLOW)("survives the narrower for server flow %s", (flow) => {
+      expect(narrowAdminEvent({ ...valid, flow })).toEqual({ ...valid, flow });
     });
   });
 

--- a/cicchetto/src/lib/api.ts
+++ b/cicchetto/src/lib/api.ts
@@ -1274,26 +1274,19 @@ export type WireUserEvent =
 // distinct topic (`grappa:admin:events`) with its own authz gate
 // (`is_admin: true`); folding onto WireUserEvent would tie the admin
 // stream to the per-user routing.
-// REV-A C2 — closed union mirroring server-side `Grappa.Admission.flow/0`
-// (lib/grappa/admission.ex:53-58). Pre-REV-A this surface lived inline on
-// the `capacity_reject` arm as `"user" | "visitor"` — a type lie: server
-// emits the bare atom verbatim (Jason stringifies → 5 possible string
-// values) so cic was tsc-blind to 3 of 5. A 5-arm regression pin lives
-// in `__tests__/api.test.ts` to fail loudly if server's `flow/0` grows
-// a 6th arm.
-export type AdmissionFlow =
-  | "login_fresh"
-  | "login_existing"
-  | "bootstrap_user"
-  | "bootstrap_visitor"
-  | "patch_network_connect";
+// #448 — re-export of the codegen-emitted mirror of `Grappa.Admission.flow/0`.
+// REV-A C2 hand-wrote this union because the server typed the wire field
+// `atom()`, so codegen could only emit `string`; the hand copy then went
+// stale silently — it listed 5 arms while the server had grown a 6th
+// (`:visitor_reconnect`), which `wireNarrow` was dropping on the floor.
+// Deriving it from the server typespec is what makes that class of drift
+// unrepresentable.
+export type { AdmissionFlow } from "./wireTypes";
 
-// #428 — mirror of AdminEventsWireEvent; capacity_reject.flow kept tight (AdmissionFlow) until the server closes the atom() set (follow-up).
-export type WireAdminEvent =
-  | Exclude<AdminEventsWireEvent, { kind: "capacity_reject" }>
-  | (Omit<Extract<AdminEventsWireEvent, { kind: "capacity_reject" }>, "flow"> & {
-      flow: AdmissionFlow;
-    });
+// #448 — the server now types `capacity_reject.flow` as the closed
+// `Admission.flow()` union, so the generated mirror is already tight and
+// this is a bare re-export (was: an `Omit<…, "flow"> &` hand-narrowing).
+export type WireAdminEvent = AdminEventsWireEvent;
 
 export type AdminSnapshotPayload = { events: WireAdminEvent[] };
 
@@ -1844,15 +1837,13 @@ export async function adminListSessionLog(
 // typed; cic owns rendering ("never tripped" / "OPEN, retry in 12s" / etc).
 //
 // `state` is a typed string-literal union per CLAUDE.md "Atoms or
-// `@type t :: literal | literal` — never untyped strings". Server-side
-// `NetworkCircuit` emits only `:open | :closed` today; a future
-// `:half_open` would be a deliberate edit here + a new arm in the
-// renderer.
-export type AdminCircuitStateKind = "open" | "closed";
-
-export type AdminCircuitState = Omit<AdmissionNetworkCircuitAdminWireT, "state"> & {
-  state: AdminCircuitStateKind;
-};
+// `@type t :: literal | literal` — never untyped strings". #448: the
+// server's wire typespec now carries that union itself, so the generated
+// mirror is already tight and this is a bare re-export (was: a hand
+// `Omit<…, "state"> &` re-narrowing plus an `AdminCircuitStateKind` alias
+// with no reader left). A future `:half_open` arrives here by
+// regenerating, not by editing.
+export type AdminCircuitState = AdmissionNetworkCircuitAdminWireT;
 
 // U-3 (UD4): per-network live-session counts split by subject_kind.
 // Mirrors `Grappa.Admission.live_counts/0`. Always present on every
@@ -1922,9 +1913,10 @@ export async function adminPatchNetworkCaps(
 // (loopback/link-local pre-filtered) the admin picks from when creating a vhost.
 export type AdminVhost = VhostsAdminWireVhostJson;
 
-export type AdminVhostGrant = Omit<VhostsAdminWireGrantJson, "subject_type"> & {
-  subject_type: "user" | "visitor";
-};
+// #448 — bare re-export: the server types `subject_type` as the closed
+// `:user | :visitor` atom union, so the generated mirror already narrows
+// it (was: a hand `Omit<…, "subject_type"> &`).
+export type AdminVhostGrant = VhostsAdminWireGrantJson;
 
 export type AdminVhostsResponse = {
   vhosts: AdminVhost[];
@@ -2019,9 +2011,8 @@ export async function adminRevokeVhostGrant(token: string, grantId: number): Pro
 // ("network - nick"); it is null for a user (no single network). Nests
 // under `/admin/vhosts/` so it rides the existing nginx allowlist alt (no
 // proxy change). Server shape: `Grappa.SubjectSearch.AdminWire`.
-export type AdminSubjectSearchResult = Omit<SubjectSearchAdminWireResultJson, "type"> & {
-  type: "user" | "visitor";
-};
+// #448 — bare re-export, same reason as `AdminVhostGrant`.
+export type AdminSubjectSearchResult = SubjectSearchAdminWireResultJson;
 
 export type AdminSubjectSearchResponse = { results: AdminSubjectSearchResult[] };
 

--- a/cicchetto/src/lib/wireNarrow.ts
+++ b/cicchetto/src/lib/wireNarrow.ts
@@ -23,6 +23,7 @@ import type {
 import {
   ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_DOOR,
   ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_SCOPE,
+  ADMISSION_FLOW,
   SCROLLBACK_MESSAGE_KIND,
   SESSION_LOG_EVENT,
   WINDOW_COUNTS_SEVERITY,
@@ -484,13 +485,12 @@ export function narrowChannelEvent(raw: unknown): WireChannelEvent | null {
 // The narrower's default-arm returning null is the runtime mirror of
 // `assertNever` — unknown server kinds drop instead of crashing.
 
-const VALID_ADMISSION_FLOWS: ReadonlySet<AdmissionFlow> = new Set([
-  "login_fresh",
-  "login_existing",
-  "bootstrap_user",
-  "bootstrap_visitor",
-  "patch_network_connect",
-]);
+// #448 — the allowlist derives from the codegen-emitted `ADMISSION_FLOW`
+// const (the #410 posture), not a hand copy. The hand copy this replaces
+// had silently gone stale: it was missing `visitor_reconnect`, so every
+// capacity_reject raised by the visitor-reconnect door was dropped here
+// and never reached the Events tab.
+const VALID_ADMISSION_FLOWS: ReadonlySet<AdmissionFlow> = new Set(ADMISSION_FLOW);
 
 const VALID_SUBJECT_KINDS: ReadonlySet<"user" | "visitor"> = new Set(["user", "visitor"]);
 

--- a/cicchetto/src/lib/wireTypes.ts
+++ b/cicchetto/src/lib/wireTypes.ts
@@ -4,6 +4,16 @@
 
 // === External types (referenced by Wire modules) ===
 
+export const ADMISSION_FLOW = [
+  "login_fresh",
+  "login_existing",
+  "bootstrap_user",
+  "bootstrap_visitor",
+  "patch_network_connect",
+  "visitor_reconnect",
+] as const;
+export type AdmissionFlow = (typeof ADMISSION_FLOW)[number];
+
 export const CHANNEL_DIRECTORY_STATUS = ["fresh", "stale", "empty", "refreshing"] as const;
 export type ChannelDirectoryStatus = (typeof CHANNEL_DIRECTORY_STATUS)[number];
 
@@ -141,7 +151,7 @@ export type AdminEventsWireCircuitCloseEvent = {
 
 export type AdminEventsWireCapacityRejectEvent = {
   kind: "capacity_reject";
-  flow: string;
+  flow: AdmissionFlow;
   error: string;
   network_id: number;
   network_slug: string | null;
@@ -459,7 +469,7 @@ export type AdminOverviewWireT = {
 // === Grappa.Admission.NetworkCircuit.AdminWire ===
 
 export type AdmissionNetworkCircuitAdminWireT = {
-  state: string;
+  state: "closed" | "open";
   failure_count: number;
   window_start_ms: number;
   cooled_at_ms: number;
@@ -1300,7 +1310,7 @@ export type SessionLogWireListResult = {
 // === Grappa.SubjectSearch.AdminWire ===
 
 export type SubjectSearchAdminWireResultJson = {
-  type: string;
+  type: "user" | "visitor";
   id: string;
   network: string | null;
   nick: string;
@@ -1335,7 +1345,7 @@ export type VhostsAdminWireVhostJson = {
 export type VhostsAdminWireGrantJson = {
   id: number;
   vhost_id: number;
-  subject_type: string;
+  subject_type: "user" | "visitor";
   subject_id: string;
 };
 

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35054,3 +35054,55 @@ spelled the boot verbs out with flags, advertising an `--host`/`--port` pair
 `bind-network`'s required `--server`. An operator following the runbook hit
 exactly the #1086 crash. Rather than gate a third surface, the copy is deleted:
 the runbook now lists the verb names and points at `--help`.
+## 2026-08-09 — #448: a faithful mirror of a too-wide type propagates the hole
+
+Four wire fields modelled a closed set and were typed `String.t()` or a bare
+`atom()`: `Vhosts.AdminWire.grant_json.subject_type`,
+`SubjectSearch.AdminWire.result_json.type`,
+`Admission.NetworkCircuit.AdminWire.t.state`, and
+`AdminEvents.Wire.capacity_reject_event.flow`. `mix grappa.gen_wire_types`
+mirrors the server typespec faithfully, so each arrived in `wireTypes.ts` as a
+generic `string`, and `api.ts` re-narrowed it by hand with an
+`Omit<…, field> & { field: <union> }`. That hand-narrowing is precisely what
+#428 set out to delete. **Codegen cannot be tighter than its source: mirroring
+an over-wide type propagates the hole instead of closing it.**
+
+**The renderers now put the atom, not an eager string.** `Atom.to_string/1`
+(and the literal `"user"`/`"visitor"` in `base_grant_json/3`) were doing the
+work Jason does anyway, and doing it one layer too early: the string erased the
+closed set before the typespec could name it. The wire is unchanged — measured,
+not assumed: the seven representative shapes encode to byte-identical JSON
+before and after (same SHA-256 per shape), because Jason serializes `:user` to
+exactly `"user"`. The vhost-grant controller test, which asserts
+`body["subject_type"] == "user"` on the real HTTP response, is the end-to-end
+witness that the additive-only contract was not touched.
+
+**`flow` references the union rather than restating it.** The
+`capacity_reject_event` type now reads `Admission.flow()`. `Grappa.Admission`
+is outside the wire glob, so the codegen's external-type resolver emits it once
+as `ADMISSION_FLOW` + `AdmissionFlow` in `wireTypes.ts`; a future flow arm
+reaches cic by regenerating, with no edit in the wire module.
+
+**The hand copy this replaced had already gone stale, silently and with teeth.**
+`api.ts`'s hand-written `AdmissionFlow` listed five arms; the server's
+`Admission.flow/0` has had six since `:visitor_reconnect` was added.
+`wireNarrow.ts` built its runtime allowlist from that same five-item list, so
+every `capacity_reject` raised by the visitor-reconnect door was dropped at the
+narrower and never reached the admin Events tab — the operator lost exactly the
+rejections they would most want to see. The `api.test.ts` "regression pin" that
+was supposed to catch this could not: its list was typed
+`satisfies readonly api.AdmissionFlow[]`, and `api.AdmissionFlow` *was* the hand
+copy, so the pin only ever compared the copy to itself. A pin whose oracle is
+the thing under test is not a pin. It is deleted; the allowlist now derives from
+the generated `ADMISSION_FLOW` const (the #410 posture), and the behavioural
+assertion that survives lives in `wireNarrow.test.ts`, table-driven off that
+same const — a new server arm arrives in the test by regenerating.
+
+**What is still not enforced at runtime.** `Wire.capacity_reject/5`'s guard
+stays `is_atom(flow)`. The tightened `@spec` is a dialyzer gate on *static*
+call sites; the live path enters through `from_telemetry/3`'s metadata map,
+which is `map()`, so no static check reaches it. Closing that would mean a
+second copy of the flow set in a module that has no business owning one —
+worse than the gap. The set is closed by construction upstream:
+`Admission.check_capacity/1` takes a `capacity_input` whose `flow` is typed
+`flow()`.

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35054,6 +35054,7 @@ spelled the boot verbs out with flags, advertising an `--host`/`--port` pair
 `bind-network`'s required `--server`. An operator following the runbook hit
 exactly the #1086 crash. Rather than gate a third surface, the copy is deleted:
 the runbook now lists the verb names and points at `--help`.
+
 ## 2026-08-09 — #448: a faithful mirror of a too-wide type propagates the hole
 
 Four wire fields modelled a closed set and were typed `String.t()` or a bare

--- a/lib/grappa/admin_events/wire.ex
+++ b/lib/grappa/admin_events/wire.ex
@@ -46,7 +46,7 @@ defmodule Grappa.AdminEvents.Wire do
   operator-driven reset surface).
   """
 
-  alias Grappa.Networks
+  alias Grappa.{Admission, Networks}
 
   @typedoc "Closed enum of admin event kinds. Mirror on cic side: `WireAdminEvent[\"kind\"]`."
   @type event_kind ::
@@ -96,9 +96,15 @@ defmodule Grappa.AdminEvents.Wire do
           at: String.t()
         }
 
+  @typedoc """
+  `flow` names WHICH admission door was refused. It is the caller's
+  `t:Grappa.Admission.flow/0` atom verbatim (Jason stringifies it), so the
+  type REFERENCES that union rather than restating it — a new flow arm
+  reaches the generated TS mirror with no edit here (#448).
+  """
   @type capacity_reject_event :: %{
           kind: :capacity_reject,
-          flow: atom(),
+          flow: Admission.flow(),
           error: String.t(),
           network_id: integer(),
           network_slug: String.t() | nil,
@@ -500,8 +506,13 @@ defmodule Grappa.AdminEvents.Wire do
   end
 
   @doc false
-  @spec capacity_reject(atom(), term(), integer(), String.t() | nil, String.t() | nil) ::
-          capacity_reject_event()
+  @spec capacity_reject(
+          Admission.flow(),
+          term(),
+          integer(),
+          String.t() | nil,
+          String.t() | nil
+        ) :: capacity_reject_event()
   def capacity_reject(flow, error, network_id, network_slug, source_ip)
       when is_atom(flow) and is_integer(network_id) and
              (is_binary(network_slug) or is_nil(network_slug)) and

--- a/lib/grappa/admission/network_circuit/admin_wire.ex
+++ b/lib/grappa/admission/network_circuit/admin_wire.ex
@@ -29,8 +29,14 @@ defmodule Grappa.Admission.NetworkCircuit.AdminWire do
 
   alias Grappa.Admission.NetworkCircuit
 
+  @typedoc """
+  `state` carries the ETS entry's **atom** verbatim. Jason serializes it
+  to the identical wire bytes an eager `Atom.to_string/1` produced, and
+  the closed union is what lets the generated TS mirror narrow to
+  `"closed" | "open"` instead of a bare `string` (#448).
+  """
   @type t :: %{
-          state: String.t(),
+          state: :closed | :open,
           failure_count: non_neg_integer(),
           window_start_ms: integer(),
           cooled_at_ms: integer(),
@@ -52,7 +58,7 @@ defmodule Grappa.Admission.NetworkCircuit.AdminWire do
       )
       when is_integer(now_ms) do
     %{
-      state: Atom.to_string(state),
+      state: state,
       failure_count: count,
       window_start_ms: window_start_ms,
       cooled_at_ms: cooled_at_ms,

--- a/lib/grappa/subject_search/admin_wire.ex
+++ b/lib/grappa/subject_search/admin_wire.ex
@@ -4,14 +4,17 @@ defmodule Grappa.SubjectSearch.AdminWire do
   Sibling of `Grappa.Vhosts.AdminWire`; explicit per-field projection (no
   wildcard `Map.take/2`) so a future field is a deliberate edit here.
 
-  The closed-set `:type` atom is stringified to `"user"` / `"visitor"` so
-  it matches the vhost-grant body's `subject_type` 1:1 — cic mirrors the
+  The closed-set `:type` atom rides the wire as the atom itself — Jason
+  serializes it to `"user"` / `"visitor"`, matching the vhost-grant
+  body's `subject_type` 1:1. Typing it as the atom union (rather than
+  stringifying eagerly into a `String.t()` field) is what lets the
+  generated TS mirror narrow to a literal union (#448); cic mirrors the
   tag, it originates no state.
   """
   alias Grappa.SubjectSearch.Result
 
   @type result_json :: %{
-          type: String.t(),
+          type: :user | :visitor,
           id: String.t(),
           network: String.t() | nil,
           nick: String.t()
@@ -21,6 +24,6 @@ defmodule Grappa.SubjectSearch.AdminWire do
   @spec result_to_admin_json(Result.t()) :: result_json()
   def result_to_admin_json(%Result{type: type, id: id, network: network, nick: nick})
       when type in [:user, :visitor] do
-    %{type: Atom.to_string(type), id: id, network: network, nick: nick}
+    %{type: type, id: id, network: network, nick: nick}
   end
 end

--- a/lib/grappa/vhosts/admin_wire.ex
+++ b/lib/grappa/vhosts/admin_wire.ex
@@ -20,7 +20,7 @@ defmodule Grappa.Vhosts.AdminWire do
   @type grant_json :: %{
           id: integer(),
           vhost_id: integer(),
-          subject_type: String.t(),
+          subject_type: :user | :visitor,
           subject_id: String.t()
         }
 
@@ -41,17 +41,24 @@ defmodule Grappa.Vhosts.AdminWire do
   Renders a grant row to the admin JSON shape. The subject is projected
   as a `(subject_type, subject_id)` pair (the XOR FK, never both) so the
   wire is subject-polymorphic without leaking which column is NULL.
+
+  `subject_type` carries the **atom**, not an eager string: Jason
+  serializes it to the identical wire bytes, and the closed atom union
+  is what lets the generated TS mirror be a literal union instead of a
+  bare `string` (#448).
   """
   @spec grant_to_admin_json(Grant.t()) :: grant_json()
   def grant_to_admin_json(%Grant{user_id: uid} = g) when is_binary(uid) do
-    base_grant_json(g, "user", uid)
+    base_grant_json(g, :user, uid)
   end
 
   def grant_to_admin_json(%Grant{visitor_id: vid} = g) when is_binary(vid) do
-    base_grant_json(g, "visitor", vid)
+    base_grant_json(g, :visitor, vid)
   end
 
-  defp base_grant_json(%Grant{} = g, subject_type, subject_id) do
+  @spec base_grant_json(Grant.t(), :user | :visitor, String.t()) :: grant_json()
+  defp base_grant_json(%Grant{} = g, subject_type, subject_id)
+       when subject_type in [:user, :visitor] do
     %{
       id: g.id,
       vhost_id: g.vhost_id,

--- a/lib/grappa_web/subject.ex
+++ b/lib/grappa_web/subject.ex
@@ -32,7 +32,7 @@ defmodule GrappaWeb.Subject do
   def to_session({:visitor, %Visitor{id: id}}), do: {:visitor, id}
 
   @doc """
-  Map a web-layer subject to the `Grappa.Admission.flow/0` used when
+  Map a web-layer subject to the `t:Grappa.Admission.flow/0` used when
   spawning/reconnecting that subject's upstream from a runtime web
   surface. U-2: the network-total cap atom + circuit are subject-keyed
   via the flow. A user connect/accretion is `:patch_network_connect`; a

--- a/test/grappa/admission/network_circuit/admin_wire_test.exs
+++ b/test/grappa/admission/network_circuit/admin_wire_test.exs
@@ -17,7 +17,7 @@ defmodule Grappa.Admission.NetworkCircuit.AdminWireTest do
       entry = {42, 3, 1_000, :closed, 0}
 
       assert %{
-               state: "closed",
+               state: :closed,
                failure_count: 3,
                window_start_ms: 1_000,
                cooled_at_ms: 0,
@@ -31,7 +31,7 @@ defmodule Grappa.Admission.NetworkCircuit.AdminWireTest do
       entry = {42, 5, 1_000, :open, cooled_at}
 
       assert %{
-               state: "open",
+               state: :open,
                failure_count: 5,
                retry_after_seconds: 8
              } = AdminWire.entry_to_admin_json(entry, now)
@@ -44,7 +44,7 @@ defmodule Grappa.Admission.NetworkCircuit.AdminWireTest do
       now = 10_000
       entry = {42, 5, 1_000, :open, now - 500}
 
-      assert %{state: "open", retry_after_seconds: 0} =
+      assert %{state: :open, retry_after_seconds: 0} =
                AdminWire.entry_to_admin_json(entry, now)
     end
 

--- a/test/grappa/subject_search_test.exs
+++ b/test/grappa/subject_search_test.exs
@@ -144,22 +144,22 @@ defmodule Grappa.SubjectSearchTest do
   end
 
   describe "AdminWire.result_to_admin_json/1" do
-    test "maps a :user result to string-tagged JSON with a null network" do
+    test "maps a :user result to atom-tagged JSON with a null network" do
       result = %Result{type: :user, id: "u-123", network: nil, nick: "vjt"}
 
       assert AdminWire.result_to_admin_json(result) == %{
-               type: "user",
+               type: :user,
                id: "u-123",
                network: nil,
                nick: "vjt"
              }
     end
 
-    test "maps a :visitor result to string-tagged JSON carrying the network slug" do
+    test "maps a :visitor result to atom-tagged JSON carrying the network slug" do
       result = %Result{type: :visitor, id: "v-456", network: "azzurra", nick: "guest"}
 
       assert AdminWire.result_to_admin_json(result) == %{
-               type: "visitor",
+               type: :visitor,
                id: "v-456",
                network: "azzurra",
                nick: "guest"


### PR DESCRIPTION
Refs #448.

Four `admin_wire`/`wire` fields modelled a **closed set** but were typed
`String.t()` or a bare `atom()`. `mix grappa.gen_wire_types` mirrors the
server typespec faithfully, so each landed in `wireTypes.ts` as a generic
`string` and `api.ts` had to re-narrow it by hand with
`Omit<…, field> & { field: <union> }` — the exact drift-prone hand-mirror
#428 set out to delete. **Codegen cannot be tighter than its source: a
faithful mirror of an over-wide type propagates the hole instead of
closing it.**

| # | field | was | now |
|---|-------|-----|-----|
| 1 | `Vhosts.AdminWire.grant_json.subject_type` | `String.t()` | `:user \| :visitor` |
| 2 | `SubjectSearch.AdminWire.result_json.type` | `String.t()` | `:user \| :visitor` |
| 3 | `NetworkCircuit.AdminWire.t.state` | `String.t()` | `:closed \| :open` |
| 4 | `AdminEvents.Wire.capacity_reject_event.flow` | `atom()` | `Admission.flow()` |

The renderers now put the **atom**. `Atom.to_string/1` (and the literal
`"user"`/`"visitor"`) was doing Jason's job one layer too early: the eager
string erased the closed set before the typespec could name it. `flow`
*references* `t:Grappa.Admission.flow/0` rather than restating it — that
module sits outside the wire glob, so codegen resolves it through the
external-type path into an `ADMISSION_FLOW` const, and a future flow arm
reaches cic by regenerating.

The four `api.ts` overrides are now bare re-exports. `AdminCircuitStateKind`
went with them; nothing read it once `AdminCircuitState` stopped being a
hand-assembled intersection.

## The wire did not change — measured, not assumed

Seven representative shapes (both arms of each changed renderer, plus a
capacity_reject, `at:` pinned) encoded before and after: **7/7 SHA-256
identical, `diff` rc=0**. A second probe read the in-memory values on the
same build to rule out a stale `_build` faking it — `atom?=true` on all
three. The vhost-grant controller test, asserting
`body["subject_type"] == "user"` on the real HTTP response, needed no edit
and is the end-to-end witness.

## The stale hand copy this uncovered

`api.ts`'s hand-written `AdmissionFlow` listed **five** arms; the server's
`Admission.flow/0` has had **six** since `:visitor_reconnect` (reachable:
`operator.ex:756` → `check_capacity` → `Telemetry.capacity_reject`).
`wireNarrow.ts` built its **runtime** allowlist from that same list, so
every `capacity_reject` from the visitor-reconnect door was dropped at the
narrower and never reached the admin Events tab — the operator lost exactly
the rejections they would most want to see.

The `api.test.ts` pin meant to catch this could not: its list was typed
`satisfies readonly api.AdmissionFlow[]` and `api.AdmissionFlow` *was* the
hand copy, so the pin only ever compared the copy to itself. It is deleted
rather than re-pinned at six — re-pinning rebuilds the same self-reference.
The allowlist now derives from the generated `ADMISSION_FLOW` const (the
#410 posture) and the surviving assertion is behavioural, table-driven off
that const in `wireNarrow.test.ts`.

## Verification

- **Mutation, Elixir:** four out-of-union values, one per module →
  dialyzer `rc=2`, 6 errors, each naming its own file (4/4 killed, no
  masking). Reverted → `rc=0`, 0 errors.
- **Mutation, TypeScript:** with all four overrides removed, four
  out-of-union literals → `tsc rc=1`, 4× TS2322; the `flow` error
  enumerates all six arms, proving the generated union carries
  `visitor_reconnect`. Reverted → `rc=0`.
- **Displacement:** restoring the old five-item allowlist fails **exactly
  one** new assertion — `survives the narrower for server flow
  visitor_reconnect`, `expected null to deeply equal {…}`.
- `scripts/check.sh` **rc=0** on the committed tree (compile
  `--warnings-as-errors`, format, credo `--strict`, deps.audit, sobelow,
  doctor 100.0% spec coverage, 5587 tests / 0 failures, dialyzer 0 errors,
  `mix docs`, `gen_wire_types --check` → *in sync*, bats 374).
- `scripts/bun.sh run test` **rc=0** — 263 files, 4885 tests;
  `run check` and a standalone `tsc --noEmit` both rc=0.

## Not claimed

`Wire.capacity_reject/5`'s guard stays `is_atom(flow)`: the tightened
`@spec` gates **static** call sites, while the live path enters through
`from_telemetry/3` over `map()` metadata. Adding a runtime allowlist would
mean a second copy of the flow set in a module with no business owning one.
The set is closed by construction upstream — an argument, not a guard.

The dropped `visitor_reconnect` events are proven in the narrower under
test and the flow is proven reachable by reading the call chain; no
production log was inspected.

Separately noted, **not** touched: `SERVER_ADMIN_EVENT_KINDS` in
`api.test.ts` pins 13 kinds while `event_kind/0` has 28. Same staleness
class, but a subset assertion — it under-covers rather than lies.