### PR TITLE
e2e(#944): address the peer by the granted nick across the whole IrcPeer class

### DIFF
--- a/cicchetto/e2e/tests/_smoke.spec.ts
+++ b/cicchetto/e2e/tests/_smoke.spec.ts
@@ -34,7 +34,7 @@ test("peer PRIVMSG to #bofh persists in grappa scrollback", async () => {
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
       channel: CHANNEL,
-      sender: PEER_NICK,
+      sender: peer.nick,
       body: MESSAGE_BODY,
     });
   } finally {

--- a/cicchetto/e2e/tests/b0-invite-from-server-window.spec.ts
+++ b/cicchetto/e2e/tests/b0-invite-from-server-window.spec.ts
@@ -66,7 +66,7 @@ test("B0 — /invite from $server window (no channel context) reaches upstream +
     // body, causing composeSend's `toHaveValue("", ...)` to time
     // out. After B0 the line passes through to /invite handler →
     // upstream INVITE → 341 ack → invite-ack row.
-    await composeSend(page, `/invite ${PEER_NICK} ${CHANNEL}`);
+    await composeSend(page, `/invite ${peer.nick} ${CHANNEL}`);
 
     // The invite-ack row mounts only after the FULL round-trip:
     // composeSend → grappa → upstream INVITE → 341 RPL_INVITING →
@@ -80,7 +80,7 @@ test("B0 — /invite from $server window (no channel context) reaches upstream +
     await expect(row).toBeVisible({ timeout: 10_000 });
     await expect(row).toContainText("→");
     await expect(row).toContainText("invited");
-    await expect(row).toContainText(PEER_NICK);
+    await expect(row).toContainText(peer.nick);
     await expect(row).toContainText(CHANNEL);
   } finally {
     await peer.disconnect("B0 done");

--- a/cicchetto/e2e/tests/b2-inbound-invite-cta.spec.ts
+++ b/cicchetto/e2e/tests/b2-inbound-invite-cta.spec.ts
@@ -84,7 +84,7 @@ test("B2 — inbound INVITE raises a banner naming the inviter; its [Join] mount
     // leg: the nick reaches cic on the `window_invited` payload, because the
     // banner renders before the channel's buffer is ever fetched and cannot
     // read it off the persisted INVITE row.
-    await expect(banner).toContainText(PEER_NICK);
+    await expect(banner).toContainText(peer.nick);
     await expect(banner).toContainText(TARGET_CHANNEL);
 
     // NOT auto-focused, and NOT a sidebar row: the operator is still on the
@@ -112,7 +112,7 @@ test("B2 — inbound INVITE raises a banner naming the inviter; its [Join] mount
     // the channel now, so it must be on screen with its inline CTA.
     const row = page
       .locator('[data-testid="scrollback-line"]')
-      .filter({ hasText: PEER_NICK })
+      .filter({ hasText: peer.nick })
       .filter({ hasText: TARGET_CHANNEL })
       .first();
     await expect(row).toBeVisible({ timeout: 5_000 });

--- a/cicchetto/e2e/tests/bug7-m6-ios-dm-own-msg-visible.spec.ts
+++ b/cicchetto/e2e/tests/bug7-m6-ios-dm-own-msg-visible.spec.ts
@@ -60,7 +60,7 @@ test("@webkit BUG7-M6 — cicchetto /msg DM own-msg visible on iOS-shaped input"
     // iOS-shape: tap to focus (triggers virtual-keyboard show on a
     // real device), per-keystroke type, tap send button.
     await ta.tap();
-    await ta.pressSequentially(`/msg ${PEER_NICK} ${MESSAGE_BODY}`, { delay: 20 });
+    await ta.pressSequentially(`/msg ${peer.nick} ${MESSAGE_BODY}`, { delay: 20 });
 
     const sendButton = page.getByRole("button", { name: /send message/i });
     await sendButton.tap();
@@ -68,13 +68,13 @@ test("@webkit BUG7-M6 — cicchetto /msg DM own-msg visible on iOS-shaped input"
 
     // Sidebar entry for the DM target appears (auto-open via
     // openQueryWindowState in compose.ts /msg handler).
-    await expect(sidebarWindow(page, NETWORK_SLUG, PEER_NICK)).toHaveCount(1, { timeout: 5_000 });
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(1, { timeout: 5_000 });
 
     // First door: server persistence — same as M6 chromium.
     await assertMessagePersisted({
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
-      channel: PEER_NICK,
+      channel: peer.nick,
       sender: NETWORK_NICK,
       body: MESSAGE_BODY,
     });

--- a/cicchetto/e2e/tests/c2-whois-card-inline-render.spec.ts
+++ b/cicchetto/e2e/tests/c2-whois-card-inline-render.spec.ts
@@ -45,7 +45,7 @@ test("C2 — /whois <nick> renders WhoisCard in the scrollback overlay layer", a
     await peer.join(CHANNEL);
 
     // Issue /whois from the compose box.
-    await composeSend(page, `/whois ${PEER_NICK}`);
+    await composeSend(page, `/whois ${peer.nick}`);
 
     // #133 — the card floats in the overlay layer, not inline in the
     // scroll flow. Scope the locator THROUGH `.scrollback-overlay` so a
@@ -54,7 +54,7 @@ test("C2 — /whois <nick> renders WhoisCard in the scrollback overlay layer", a
     await expect(card).toBeVisible({ timeout: 5_000 });
 
     // Header carries the target nick.
-    await expect(card.locator(".whois-card-target")).toHaveText(PEER_NICK);
+    await expect(card.locator(".whois-card-target")).toHaveText(peer.nick);
 
     // userhost field present — the peer's user/host should round-trip
     // from 311 RPL_WHOISUSER. Don't pin the exact host string (testnet

--- a/cicchetto/e2e/tests/c5-member-leftclick-opens-query.spec.ts
+++ b/cicchetto/e2e/tests/c5-member-leftclick-opens-query.spec.ts
@@ -27,27 +27,30 @@ test("C5 — left-click on member nick opens query window + switches focus", asy
   await loginAs(page, vjt);
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
 
-  // Pre-condition: no query window yet for the peer.
-  await expect(sidebarWindow(page, NETWORK_SLUG, PEER_NICK)).toHaveCount(0);
-
+  // Connect BEFORE the pre-condition so every locator below is keyed on the
+  // nick the server GRANTED (#944). A connected-but-idle peer creates no
+  // query window, so the pre-condition still observes the same state.
   const peer = await IrcPeer.connect({ nick: PEER_NICK });
   try {
+    // Pre-condition: no query window yet for the peer.
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(0);
+
     await peer.join(CHANNEL);
 
     // Wait for the peer to appear in the members list.
-    const memberBtn = page.locator(`.members-pane .member-name`, { hasText: PEER_NICK });
+    const memberBtn = page.locator(`.members-pane .member-name`, { hasText: peer.nick });
     await expect(memberBtn).toBeVisible({ timeout: 5_000 });
 
     // Click the nick — should open the query window AND switch focus.
     await memberBtn.click();
 
     // Query window appears in sidebar.
-    await expect(sidebarWindow(page, NETWORK_SLUG, PEER_NICK)).toHaveCount(1, { timeout: 5_000 });
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(1, { timeout: 5_000 });
 
     // Focus switched to the query window — sidebar entry has the
     // selection class. The exact selector matches Sidebar.tsx's
     // `.sidebar-channel-selected` (or whichever) — check the live DOM.
-    await expect(sidebarWindow(page, NETWORK_SLUG, PEER_NICK)).toHaveClass(/selected/, {
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveClass(/selected/, {
       timeout: 5_000,
     });
   } finally {

--- a/cicchetto/e2e/tests/cp14-b3-dm-history-bidirectional.spec.ts
+++ b/cicchetto/e2e/tests/cp14-b3-dm-history-bidirectional.spec.ts
@@ -76,8 +76,8 @@ test("CP14 B3 — DM query window shows both inbound and outbound history after 
     await assertMessagePersisted({
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
-      channel: PEER_NICK,
-      sender: PEER_NICK,
+      channel: peer.nick,
+      sender: peer.nick,
       body: PEER_TO_VJT,
     });
 
@@ -86,7 +86,7 @@ test("CP14 B3 — DM query window shows both inbound and outbound history after 
     // the scrollback for PEER_NICK via REST (loadInitialScrollback).
     // With CP14 B3 the server returns the inbound row even though it
     // persisted under channel = own_nick (dm_with = peer matches).
-    await selectChannel(page, NETWORK_SLUG, PEER_NICK);
+    await selectChannel(page, NETWORK_SLUG, peer.nick);
 
     // Outbound: vjt → peer (typed in the now-focused query window).
     // Server persists with channel = peer AND dm_with = peer (the
@@ -96,7 +96,7 @@ test("CP14 B3 — DM query window shows both inbound and outbound history after 
     await assertMessagePersisted({
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
-      channel: PEER_NICK,
+      channel: peer.nick,
       sender: NETWORK_NICK,
       body: VJT_TO_PEER,
     });
@@ -109,7 +109,7 @@ test("CP14 B3 — DM query window shows both inbound and outbound history after 
   // history alone — this is the bug we're fixing.
   await page.reload();
   await loginAs(page, vjt);
-  await selectChannel(page, NETWORK_SLUG, PEER_NICK);
+  await selectChannel(page, NETWORK_SLUG, peer.nick);
 
   // Both directions must be visible in the freshly-opened query
   // window. Pre-CP14-B3 only the outbound row would show.

--- a/cicchetto/e2e/tests/cp22-bwho-who-rows.spec.ts
+++ b/cicchetto/e2e/tests/cp22-bwho-who-rows.spec.ts
@@ -63,7 +63,7 @@ test("#169 — /who renders the WhoModal with parsed rows; scrollback stays clea
 
     // The peer renders as a per-user ROW carrying a PARSED user@host — proof
     // the 352 fields were parsed into the typed row, not dumped as text.
-    const peerRow = modal.locator(".who-modal-row", { hasText: PEER_NICK });
+    const peerRow = modal.locator(".who-modal-row", { hasText: peer.nick });
     await expect(peerRow).toBeVisible();
     await expect(peerRow.locator(".who-modal-userhost")).toContainText("@");
 
@@ -73,13 +73,13 @@ test("#169 — /who renders the WhoModal with parsed rows; scrollback stays clea
     // Scrollback stays CLEAN — the pre-#169 N+1 :notice dump is gone.
     await expect(scrollbackLine(page, "notice", "End of /WHO list")).toHaveCount(0);
     await expect(
-      scrollbackLine(page, "notice", `[${CHANNEL}]`).filter({ hasText: PEER_NICK }),
+      scrollbackLine(page, "notice", `[${CHANNEL}]`).filter({ hasText: peer.nick }),
     ).toHaveCount(0);
 
     // Clicking the peer nick opens a query window for it AND dismisses the modal.
-    await modal.locator(".who-modal-nick", { hasText: PEER_NICK }).click();
+    await modal.locator(".who-modal-nick", { hasText: peer.nick }).click();
     await expect(modal).toBeHidden({ timeout: 2_000 });
-    await expect(sidebarWindow(page, NETWORK_SLUG, PEER_NICK)).toHaveCount(1);
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(1);
   } finally {
     await peer.disconnect("#169 done");
   }

--- a/cicchetto/e2e/tests/issue221-whois-badges.spec.ts
+++ b/cicchetto/e2e/tests/issue221-whois-badges.spec.ts
@@ -100,11 +100,11 @@ test("#221 — WHOIS of an account+TLS user shows registered/SSL badges + accoun
     // Real /whois from the compose box → real upstream WHOIS → server folds
     // 311/312/318 → emits the real `whois_bundle` frame → our route enriches
     // it with the solanum fields → cic decodes/narrows/renders.
-    await composeSend(page, `/whois ${PEER_NICK}`);
+    await composeSend(page, `/whois ${peer.nick}`);
 
     const card = page.getByTestId("whois-card");
     await expect(card).toBeVisible({ timeout: 8_000 });
-    await expect(card.locator(".whois-card-target")).toHaveText(PEER_NICK);
+    await expect(card.locator(".whois-card-target")).toHaveText(peer.nick);
 
     // Badges: "registered" derives from the injected account (330), "SSL"
     // from the injected secure (671). Pre-fix these read ONLY is_registered

--- a/cicchetto/e2e/tests/issue222-presence-filter.spec.ts
+++ b/cicchetto/e2e/tests/issue222-presence-filter.spec.ts
@@ -58,10 +58,10 @@ test("#222 — per-channel toggle hides join/part rows, persists across reload, 
 
     const joinRow = page
       .locator('[data-testid="scrollback-line"][data-kind="join"]')
-      .filter({ hasText: peerNick });
+      .filter({ hasText: peer.nick });
     const partRow = page
       .locator('[data-testid="scrollback-line"][data-kind="part"]')
-      .filter({ hasText: peerNick });
+      .filter({ hasText: peer.nick });
     const privmsgRow = page
       .locator('[data-testid="scrollback-line"][data-kind="privmsg"]')
       .filter({ hasText: privmsgBody });

--- a/cicchetto/e2e/tests/issue235-next-active-window.spec.ts
+++ b/cicchetto/e2e/tests/issue235-next-active-window.spec.ts
@@ -68,14 +68,14 @@ async function seedTwoTierUnread(
     token,
     networkSlug: NETWORK_SLUG,
     channel: CHANNEL,
-    sender: peerNick,
+    sender: peer.nick,
     body: CHANNEL_LINE,
   });
   await expect(sidebarMessageBadge(page, NETWORK_SLUG, CHANNEL)).toBeVisible({ timeout: 10_000 });
 
   // Tier 0 — a DM opens the peer's query window (unfocused → unread).
   peer.privmsg(NETWORK_NICK, DM_LINE);
-  await expect(sidebarWindow(page, NETWORK_SLUG, peerNick)).toBeVisible({ timeout: 10_000 });
+  await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toBeVisible({ timeout: 10_000 });
 
   return peer;
 }
@@ -97,7 +97,7 @@ test("desktop: Alt+A / button jumps DM (tier 0) before channel (tier 1), then au
     // Jump 1 (button click) → the DM window wins on tier, though it
     // arrived AFTER the channel line.
     await page.locator(NEXT_ACTIVE_BTN).click();
-    await expect(sidebarWindow(page, NETWORK_SLUG, peerNick)).toHaveClass(/selected/, {
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveClass(/selected/, {
       timeout: 10_000,
     });
 
@@ -127,7 +127,7 @@ test("@webkit mobile: bottom-bar affordance jumps DM before channel, then auto-h
 
     // Mobile uses the button for both jumps (no physical Alt+A chord).
     await page.locator(NEXT_ACTIVE_BTN).click();
-    await expect(sidebarWindow(page, NETWORK_SLUG, peerNick)).toHaveClass(/selected/, {
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveClass(/selected/, {
       timeout: 10_000,
     });
 

--- a/cicchetto/e2e/tests/issue247-notify-watch.spec.ts
+++ b/cicchetto/e2e/tests/issue247-notify-watch.spec.ts
@@ -39,7 +39,6 @@ import { IrcPeer } from "../fixtures/ircClient";
 import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
 import { expect, test } from "../fixtures/test";
 
-const PEER_NICK = "i247-watched";
 const SEED_CHANNEL = AUTOJOIN_CHANNELS[0];
 
 // Body is ~6 condition-waits (each fast in isolation) + one reload +
@@ -51,9 +50,18 @@ test("#247 — /notify → dots + toasts + snapshot repaint + settings remove", 
   const vjt = getSeededVjt();
   let peer: IrcPeer | null = null;
 
+  // #944 — this spec is the one shape `peer.nick` cannot serve: the whole
+  // point is that the nick is WATCHED while nobody holds it, so it must be
+  // named before any peer exists. A per-run-unique nick removes the ghost the
+  // #604 retry exists to survive, and the equality assert at the connect below
+  // turns a residual collision into a one-line failure instead of a toast
+  // timeout. Computed in the test body, not at module scope, so a
+  // `--repeat-each` rerun inside one worker gets a fresh nick per repeat.
+  const peerNick = `i247w${crypto.randomUUID().replace(/-/g, "").slice(0, 6)}`;
+
   const entryRow = page
     .getByTestId(`watchlists-notify-${NETWORK_SLUG}`)
-    .locator(".watchlists-item", { hasText: PEER_NICK });
+    .locator(".watchlists-item", { hasText: peerNick });
   const dot = entryRow.locator(".watchlists-dot");
 
   // #356 — the list lives in the settings "watch lists" sub-page now.
@@ -71,7 +79,7 @@ test("#247 — /notify → dots + toasts + snapshot repaint + settings remove", 
     // Compose lives on channel windows — issue the add from the seed
     // channel, then open the settings watch-lists section to observe it.
     await selectChannel(page, NETWORK_SLUG, SEED_CHANNEL, { ownNick: NETWORK_NICK });
-    await composeSend(page, `/notify ${PEER_NICK}`);
+    await composeSend(page, `/notify ${peerNick}`);
     await openWatchLists();
 
     // 1. Entry present; dot settles OFFLINE via the 605 baseline (the
@@ -83,9 +91,12 @@ test("#247 — /notify → dots + toasts + snapshot repaint + settings remove", 
     // 2. Peer connects → 600 RPL_LOGON → genuine transition: toast +
     //    dot flip. Arm the toast wait BEFORE connecting so the 6s
     //    self-expiry can't outrace the first poll.
-    const onlineToast = page.locator(".toast-online", { hasText: PEER_NICK });
+    const onlineToast = page.locator(".toast-online", { hasText: peerNick });
     const onlineToastSeen = expect(onlineToast).toBeVisible({ timeout: 15_000 });
-    peer = await IrcPeer.connect({ nick: PEER_NICK });
+    peer = await IrcPeer.connect({ nick: peerNick });
+    // The watch list already names `peerNick`; if the server granted anything
+    // else the 600 would never match and step 2 would time out unexplained.
+    expect(peer.nick).toBe(peerNick);
     await onlineToastSeen;
     await expect(dot).toHaveAttribute("data-state", "online", { timeout: 10_000 });
 
@@ -100,7 +111,7 @@ test("#247 — /notify → dots + toasts + snapshot repaint + settings remove", 
     await expect(dot).toHaveAttribute("data-state", "online", { timeout: 10_000 });
 
     // 4. Peer quits → 601 RPL_LOGOFF → offline transition toast + flip.
-    const offlineToast = page.locator(".toast-offline", { hasText: PEER_NICK });
+    const offlineToast = page.locator(".toast-offline", { hasText: peerNick });
     const offlineToastSeen = expect(offlineToast).toBeVisible({ timeout: 15_000 });
     await peer.disconnect("gone (#247 e2e)");
     peer = null;
@@ -110,7 +121,7 @@ test("#247 — /notify → dots + toasts + snapshot repaint + settings remove", 
     // 5. Remove from the settings list — server round-trip, list re-renders
     //    from the notify_list broadcast (cic never edits its own store).
     await entryRow
-      .getByRole("button", { name: `Stop watching ${PEER_NICK} on ${NETWORK_SLUG}` })
+      .getByRole("button", { name: `Stop watching ${peerNick} on ${NETWORK_SLUG}` })
       .click();
     await expect(entryRow).toHaveCount(0, { timeout: 10_000 });
   } finally {

--- a/cicchetto/e2e/tests/issue265-activity-messages-only.spec.ts
+++ b/cicchetto/e2e/tests/issue265-activity-messages-only.spec.ts
@@ -74,8 +74,8 @@ async function seedEventOnlyAndMessageWindows(
   // Message window — a DM opens the peer's query window (unfocused →
   // unread content).
   peer.privmsg(NETWORK_NICK, DM_LINE);
-  await expect(sidebarWindow(page, NETWORK_SLUG, peerNick)).toBeVisible({ timeout: 10_000 });
-  await expect(sidebarMessageBadge(page, NETWORK_SLUG, peerNick)).toBeVisible({ timeout: 10_000 });
+  await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toBeVisible({ timeout: 10_000 });
+  await expect(sidebarMessageBadge(page, NETWORK_SLUG, peer.nick)).toBeVisible({ timeout: 10_000 });
 
   return peer;
 }
@@ -100,7 +100,7 @@ test("desktop: #265 next-active count includes the message (DM) window, excludes
     // And the ONE active window is the DM — a button jump lands there,
     // never on the presence-only #bofh.
     await page.locator(NEXT_ACTIVE_BTN).click();
-    await expect(sidebarWindow(page, NETWORK_SLUG, peerNick)).toHaveClass(/selected/, {
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveClass(/selected/, {
       timeout: 10_000,
     });
 
@@ -124,7 +124,7 @@ test("@webkit mobile: #265 bottom-bar next-active count excludes the event-only 
     await expect(page.locator(NEXT_ACTIVE_COUNT)).toHaveText("1", { timeout: 10_000 });
 
     await page.locator(NEXT_ACTIVE_BTN).click();
-    await expect(sidebarWindow(page, NETWORK_SLUG, peerNick)).toHaveClass(/selected/, {
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveClass(/selected/, {
       timeout: 10_000,
     });
 

--- a/cicchetto/e2e/tests/issue270-peer-away-overlap.spec.ts
+++ b/cicchetto/e2e/tests/issue270-peer-away-overlap.spec.ts
@@ -73,11 +73,11 @@ test("#270 — peer-away banner does not overlap the first DM message row", asyn
     // Operator /msg's the away peer. compose.ts auto-opens + focuses the DM
     // window and sends the first line; bahamut replies 301 with AWAY_MESSAGE,
     // so the banner mounts at the top of this fresh, near-empty DM.
-    await composeSend(page, `/msg ${PEER_NICK} ${FIRST_DM_LINE}`);
-    await expect(sidebarWindow(page, NETWORK_SLUG, PEER_NICK)).toHaveCount(1, { timeout: 15_000 });
+    await composeSend(page, `/msg ${peer.nick} ${FIRST_DM_LINE}`);
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(1, { timeout: 15_000 });
 
     // Focus the DM window — the banner mounts only when (slug, peer) match.
-    await selectChannel(page, NETWORK_SLUG, PEER_NICK, { awaitWsReady: false });
+    await selectChannel(page, NETWORK_SLUG, peer.nick, { awaitWsReady: false });
 
     // Anti-false-green: BOTH the banner AND the first DM row must be present
     // and visible BEFORE any geometry is measured. A missing row (or a hidden

--- a/cicchetto/e2e/tests/issue367-whois-oper-role-text.spec.ts
+++ b/cicchetto/e2e/tests/issue367-whois-oper-role-text.spec.ts
@@ -51,11 +51,11 @@ test("issue #367 — /whois of an opered peer renders the 313 role text row", as
     await peer.oper(OPER_NAME, OPER_PASS);
 
     // Issue /whois from cic's compose box.
-    await composeSend(page, `/whois ${PEER_NICK}`);
+    await composeSend(page, `/whois ${peer.nick}`);
 
     const card = page.getByTestId("whois-card");
     await expect(card).toBeVisible({ timeout: 5_000 });
-    await expect(card.locator(".whois-card-target")).toHaveText(PEER_NICK);
+    await expect(card.locator(".whois-card-target")).toHaveText(peer.nick);
 
     // #367 — the "oper" badge signals operator status at a glance...
     await expect(card.locator(".whois-card-tag-oper")).toBeVisible({ timeout: 5_000 });

--- a/cicchetto/e2e/tests/issue532-stale-unread-badges.spec.ts
+++ b/cicchetto/e2e/tests/issue532-stale-unread-badges.spec.ts
@@ -56,6 +56,11 @@ import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const PEER_NICK = "i532-peer";
+// The nick the server GRANTED, published to afterEach (#944). The cleanup runs
+// outside the test body where `peer` is out of scope, and a cursor restore
+// aimed at the nick we merely ASKED for would leave the real window's cursor
+// behind after a 433 retry.
+let grantedPeerNick = PEER_NICK;
 const DM_FIRST = "#532 B: first DM — read, so the cursor sits here";
 const DM_SECOND = "#532 B: second DM — the unread that the archive badge must show";
 
@@ -66,7 +71,7 @@ test.afterEach(async () => {
   // retries. Both are idempotent / no-ops for the test that didn't touch
   // them, and guarded so a mid-test failure can't cascade.
   await joinChannel(vjt.token, NETWORK_SLUG, CHANNEL).catch(() => {});
-  await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, PEER_NICK).catch(() => {});
+  await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, grantedPeerNick).catch(() => {});
 });
 
 test("#532 A — a self-PART leaves NO stale event badge on the archived channel row", async ({
@@ -128,6 +133,7 @@ test("#532 B — a closed DM window holding an unread message shows the message 
   await waitForDmListenerReady(page, NETWORK_SLUG);
 
   const peer = await IrcPeer.connect({ nick: PEER_NICK });
+  grantedPeerNick = peer.nick;
   try {
     // First inbound DM → cic auto-opens the query window (server-owned,
     // #422). Focus it so the DM renders, then focus away so selection.ts's
@@ -136,13 +142,13 @@ test("#532 B — a closed DM window holding an unread message shows the message 
     await assertMessagePersisted({
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
-      channel: PEER_NICK,
-      sender: PEER_NICK,
+      channel: peer.nick,
+      sender: peer.nick,
       body: DM_FIRST,
     });
-    await expect(sidebarWindow(page, NETWORK_SLUG, PEER_NICK)).toHaveCount(1, { timeout: 5_000 });
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(1, { timeout: 5_000 });
 
-    await selectChannel(page, NETWORK_SLUG, PEER_NICK, { awaitWsReady: false });
+    await selectChannel(page, NETWORK_SLUG, peer.nick, { awaitWsReady: false });
     // `.last()` — under `--repeat-each` the DM rows accumulate in the shared
     // backend (afterEach resets the cursor, not the scrollback), so this
     // matches every prior run's copy too; we only need the newest one
@@ -154,7 +160,7 @@ test("#532 B — a closed DM window holding an unread message shows the message 
     // pre-D the cursor could fork per-casing, but cic sends one spelling so
     // this asserts the DM cursor is set at all before we add the unread.
     await expect
-      .poll(() => getReadCursor(vjt.token, NETWORK_SLUG, PEER_NICK), {
+      .poll(() => getReadCursor(vjt.token, NETWORK_SLUG, peer.nick), {
         timeout: 5_000,
         intervals: [100, 200, 500],
       })
@@ -166,8 +172,8 @@ test("#532 B — a closed DM window holding an unread message shows the message 
     await assertMessagePersisted({
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
-      channel: PEER_NICK,
-      sender: PEER_NICK,
+      channel: peer.nick,
+      sender: peer.nick,
       body: DM_SECOND,
     });
 
@@ -175,8 +181,8 @@ test("#532 B — a closed DM window holding an unread message shows the message 
     // the server `query_windows` row (non-destructive, no confirm modal for
     // query windows) — so on the next cold load the peer is no longer an
     // active window and surfaces in Archive with its unread intact.
-    await sidebarCloseButton(page, NETWORK_SLUG, PEER_NICK).click();
-    await expect(sidebarWindow(page, NETWORK_SLUG, PEER_NICK)).toHaveCount(0, { timeout: 5_000 });
+    await sidebarCloseButton(page, NETWORK_SLUG, peer.nick).click();
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(0, { timeout: 5_000 });
   } finally {
     await peer.disconnect("#532 B done");
   }
@@ -189,7 +195,7 @@ test("#532 B — a closed DM window holding an unread message shows the message 
   const group = await expandArchiveGroup(page, NETWORK_SLUG);
 
   // The peer's closed DM is archived (rows exist, window no longer active).
-  await expect(group.locator(".archive-modal-row", { hasText: PEER_NICK })).toHaveCount(1, {
+  await expect(group.locator(".archive-modal-row", { hasText: peer.nick })).toHaveCount(1, {
     timeout: 5_000,
   });
 
@@ -197,7 +203,7 @@ test("#532 B — a closed DM window holding an unread message shows the message 
   // from the cold `/me` unread envelope. Pre-B no badge rendered at all;
   // post-B the same `.sidebar-msg-unread` the sidebar draws appears, reading
   // "1" (the single unread second DM; the first was read before close).
-  const unread = page.getByTestId(`archive-unread-${NETWORK_SLUG}-${PEER_NICK}`);
+  const unread = page.getByTestId(`archive-unread-${NETWORK_SLUG}-${peer.nick}`);
   await expect(unread.locator(".sidebar-msg-unread")).toHaveText("1", { timeout: 5_000 });
 
   await closeArchive(page);

--- a/cicchetto/e2e/tests/issue576-own-msg-unread-badge.spec.ts
+++ b/cicchetto/e2e/tests/issue576-own-msg-unread-badge.spec.ts
@@ -46,6 +46,11 @@ import { expect, test } from "../fixtures/test";
 
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 const PEER_NICK = "i576-peer";
+// The nick the server GRANTED, published to afterEach (#944). The cleanup runs
+// outside the test body where `peer` is out of scope, and a cursor restore
+// aimed at the nick we merely ASKED for would leave the real window's cursor
+// behind after a 433 retry.
+let grantedPeerNick = PEER_NICK;
 const OPENER = "#576: peer opener — read, cursor baseline sits here";
 const OWN_A = "#576: my own line A — read by definition, must not badge";
 const OWN_B = "#576: my own line B — read by definition, must not badge";
@@ -56,7 +61,7 @@ test.afterEach(async () => {
   // Restore the DM cursor to the tail so the own/peer rows this spec leaves
   // in the shared backend don't poison a later spec (or a --repeat-each
   // rerun) via a stale backward cursor. Idempotent + guarded.
-  await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, PEER_NICK).catch(() => {});
+  await restoreReadCursorToTail(vjt.token, NETWORK_SLUG, grantedPeerNick).catch(() => {});
 });
 
 test("#576 — own content lines don't badge; a later peer line does", async ({ page }) => {
@@ -69,6 +74,7 @@ test("#576 — own content lines don't badge; a later peer line does", async ({ 
   await waitForDmListenerReady(page, NETWORK_SLUG);
 
   const peer = await IrcPeer.connect({ nick: PEER_NICK });
+  grantedPeerNick = peer.nick;
   try {
     // Peer opens the DM. Focus it so it renders (the send-time advance's
     // anti-poison gate #50 needs a non-empty pane), and read it — the
@@ -77,12 +83,12 @@ test("#576 — own content lines don't badge; a later peer line does", async ({ 
     await assertMessagePersisted({
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
-      channel: PEER_NICK,
-      sender: PEER_NICK,
+      channel: peer.nick,
+      sender: peer.nick,
       body: OPENER,
     });
-    await expect(sidebarWindow(page, NETWORK_SLUG, PEER_NICK)).toHaveCount(1, { timeout: 5_000 });
-    await selectChannel(page, NETWORK_SLUG, PEER_NICK, { awaitWsReady: false });
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(1, { timeout: 5_000 });
+    await selectChannel(page, NETWORK_SLUG, peer.nick, { awaitWsReady: false });
     await expect(scrollbackLine(page, "privmsg", OPENER).last()).toBeVisible({ timeout: 5_000 });
 
     // Send two OWN lines in the focused DM. They echo back over WS and
@@ -94,7 +100,7 @@ test("#576 — own content lines don't badge; a later peer line does", async ({ 
       await assertMessagePersisted({
         token: vjt.token,
         networkSlug: NETWORK_SLUG,
-        channel: PEER_NICK,
+        channel: peer.nick,
         sender: NETWORK_NICK,
         body,
       });
@@ -111,17 +117,17 @@ test("#576 — own content lines don't badge; a later peer line does", async ({ 
     // `read_cursor_set` the last-write-wins client adopts). Now the only
     // rows past the cursor are the operator's own — pre-fix a "2" badge the
     // operator can't clear by reading; post-fix nothing at all.
-    const rows = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, PEER_NICK);
+    const rows = await fetchAllMessagesAsc(vjt.token, NETWORK_SLUG, peer.nick);
     const openerRows = rows.filter((r) => r.body === OPENER);
     const openerId = openerRows[openerRows.length - 1]?.id;
     expect(openerId, "peer opener row must exist to seed the cursor baseline").toBeTruthy();
-    await setReadCursorToId(vjt.token, NETWORK_SLUG, PEER_NICK, openerId as number);
+    await setReadCursorToId(vjt.token, NETWORK_SLUG, peer.nick, openerId as number);
 
     // #576 assertion: NO message badge on the DM window whose only unread
     // rows are the operator's own lines. Pre-fix `perChannelUnread` counted
     // them → `.sidebar-msg-unread` rendered "2"; post-fix own content is
     // excluded → the badge element is absent.
-    await expect(sidebarMessageBadge(page, NETWORK_SLUG, PEER_NICK)).toHaveCount(0, {
+    await expect(sidebarMessageBadge(page, NETWORK_SLUG, peer.nick)).toHaveCount(0, {
       timeout: 5_000,
     });
 
@@ -132,11 +138,11 @@ test("#576 — own content lines don't badge; a later peer line does", async ({ 
     await assertMessagePersisted({
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
-      channel: PEER_NICK,
-      sender: PEER_NICK,
+      channel: peer.nick,
+      sender: peer.nick,
       body: REPLY,
     });
-    await expect(sidebarMessageBadge(page, NETWORK_SLUG, PEER_NICK)).toHaveText("1", {
+    await expect(sidebarMessageBadge(page, NETWORK_SLUG, peer.nick)).toHaveText("1", {
       timeout: 5_000,
     });
   } finally {

--- a/cicchetto/e2e/tests/issue914-hide-next-active.spec.ts
+++ b/cicchetto/e2e/tests/issue914-hide-next-active.spec.ts
@@ -57,7 +57,7 @@ async function seedOneUnreadDm(
 
   const peer = await IrcPeer.connect({ nick: peerNick });
   peer.privmsg(NETWORK_NICK, DM_LINE);
-  await expect(sidebarWindow(page, NETWORK_SLUG, peerNick)).toBeVisible({ timeout: 10_000 });
+  await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toBeVisible({ timeout: 10_000 });
   return peer;
 }
 
@@ -81,12 +81,12 @@ test("desktop: the toggle hides the button and Alt+A STILL jumps", async ({ page
     // The button is gone while the window is STILL unread — i.e. hidden by the
     // preference, not by #235's auto-hide.
     await expect(page.locator(NEXT_ACTIVE_BTN)).toHaveCount(0, { timeout: 10_000 });
-    await expect(sidebarWindow(page, NETWORK_SLUG, peerNick)).not.toHaveClass(/selected/);
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).not.toHaveClass(/selected/);
 
     // THE assertion. The button is hidden; the verb must be untouched, so the
     // keybinding still jumps to the unread DM window.
     await page.keyboard.press("Alt+a");
-    await expect(sidebarWindow(page, NETWORK_SLUG, peerNick)).toHaveClass(/selected/, {
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveClass(/selected/, {
       timeout: 10_000,
     });
   } finally {
@@ -111,7 +111,7 @@ test("@webkit mobile: the same toggle hides the overlay placement", async ({ pag
     // Same single preference, other mount site: the overlay is gone while the
     // DM window is still unread.
     await expect(page.locator(NEXT_ACTIVE_BTN)).toHaveCount(0, { timeout: 10_000 });
-    await expect(sidebarWindow(page, NETWORK_SLUG, peerNick)).not.toHaveClass(/selected/);
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).not.toHaveClass(/selected/);
   } finally {
     await peer.disconnect("914 mobile done");
   }

--- a/cicchetto/e2e/tests/m1-irssi-to-chan-focused.spec.ts
+++ b/cicchetto/e2e/tests/m1-irssi-to-chan-focused.spec.ts
@@ -56,7 +56,7 @@ test("M1 — peer PRIVMSG to focused channel renders inline, no unread", async (
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
       channel: CHANNEL,
-      sender: PEER_NICK,
+      sender: peer.nick,
       body: MESSAGE_BODY,
     });
 

--- a/cicchetto/e2e/tests/m10-peer-action-ctcp-render.spec.ts
+++ b/cicchetto/e2e/tests/m10-peer-action-ctcp-render.spec.ts
@@ -57,7 +57,7 @@ test("M10 — peer ACTION renders as '* peer body' in focused channel", async ({
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
       channel: CHANNEL,
-      sender: PEER_NICK,
+      sender: peer.nick,
       body: PERSISTED_BODY,
       kind: "action",
     });

--- a/cicchetto/e2e/tests/m11-peer-nick-change-row-members.spec.ts
+++ b/cicchetto/e2e/tests/m11-peer-nick-change-row-members.spec.ts
@@ -38,11 +38,16 @@ test("M11 — peer NICK change renders nick_change row + updates members list", 
   await expect(composeTextarea(page)).toBeVisible();
 
   const peer = await IrcPeer.connect({ nick: PEER_OLD_NICK });
+  // The nick the server GRANTED, captured BEFORE the rename (#944):
+  // `peer.nick` is mutable and follows `changeNick`, so the pre-rename
+  // identity has to be held here or the post-rename asserts below would
+  // both name the NEW nick and the "old gone" check would be vacuous.
+  const grantedOldNick = peer.nick;
   try {
     await peer.join(CHANNEL);
 
     // Old nick visible in members before the rename.
-    await expect(page.locator(".members-pane li", { hasText: PEER_OLD_NICK })).toBeVisible({
+    await expect(page.locator(".members-pane li", { hasText: grantedOldNick })).toBeVisible({
       timeout: 5_000,
     });
 
@@ -55,7 +60,7 @@ test("M11 — peer NICK change renders nick_change row + updates members list", 
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
       channel: CHANNEL,
-      sender: PEER_OLD_NICK,
+      sender: grantedOldNick,
       kind: "nick_change",
     });
 
@@ -67,7 +72,7 @@ test("M11 — peer NICK change renders nick_change row + updates members list", 
     });
 
     // Members list updated atomically: old gone, new present.
-    await expect(page.locator(".members-pane li", { hasText: PEER_OLD_NICK })).toHaveCount(0, {
+    await expect(page.locator(".members-pane li", { hasText: grantedOldNick })).toHaveCount(0, {
       timeout: 5_000,
     });
     await expect(page.locator(".members-pane li", { hasText: PEER_NEW_NICK })).toBeVisible({

--- a/cicchetto/e2e/tests/m2-irssi-to-chan-defocused.spec.ts
+++ b/cicchetto/e2e/tests/m2-irssi-to-chan-defocused.spec.ts
@@ -52,7 +52,7 @@ test("M2 — peer PRIVMSG to defocused channel bumps msg-unread badge by 1", asy
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
       channel: CHANNEL,
-      sender: PEER_NICK,
+      sender: peer.nick,
       body: MESSAGE_BODY,
     });
 

--- a/cicchetto/e2e/tests/m4-irssi-to-priv-no-window.spec.ts
+++ b/cicchetto/e2e/tests/m4-irssi-to-priv-no-window.spec.ts
@@ -47,14 +47,18 @@ test("M4 — inbound DM auto-opens query window with unread, clears on focus", a
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
   await waitForDmListenerReady(page, NETWORK_SLUG);
 
-  // Pre-condition: no query window for the peer yet (fresh stack
-  // guarantees it; assert anyway so a future cross-test contamination
-  // surfaces here loudly instead of as a confusing "1 already there
-  // before peer sent" flake).
-  await expect(sidebarWindow(page, NETWORK_SLUG, PEER_NICK)).toHaveCount(0);
-
+  // Connect BEFORE the pre-condition so every locator below is keyed on the
+  // nick the server GRANTED, not the one we asked for (#944). A connected-
+  // but-idle peer opens no query window, so the pre-condition observes the
+  // same state it did when it ran above the connect.
   const peer = await IrcPeer.connect({ nick: PEER_NICK });
   try {
+    // Pre-condition: no query window for the peer yet (fresh stack
+    // guarantees it; assert anyway so a future cross-test contamination
+    // surfaces here loudly instead of as a confusing "1 already there
+    // before peer sent" flake).
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(0);
+
     peer.privmsg(NETWORK_NICK, MESSAGE_BODY);
 
     // Server-side: row persisted at channel = NETWORK_NICK (the
@@ -70,25 +74,25 @@ test("M4 — inbound DM auto-opens query window with unread, clears on focus", a
     await assertMessagePersisted({
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
-      channel: PEER_NICK,
-      sender: PEER_NICK,
+      channel: peer.nick,
+      sender: peer.nick,
       body: MESSAGE_BODY,
     });
 
     // Sidebar gains exactly one entry for the sender nick.
-    await expect(sidebarWindow(page, NETWORK_SLUG, PEER_NICK)).toHaveCount(1, { timeout: 5_000 });
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(1, { timeout: 5_000 });
 
     // Unread badge "1" — cicchetto still on #bofh, query window is
     // unfocused by definition. Asserted BEFORE the click-to-inspect
     // because clicking would clear it (selection.ts isSelected gate).
-    await expect(sidebarMessageBadge(page, NETWORK_SLUG, PEER_NICK)).toHaveText("1", {
+    await expect(sidebarMessageBadge(page, NETWORK_SLUG, peer.nick)).toHaveText("1", {
       timeout: 5_000,
     });
 
     // Focus the DM window: scrollback shows the body, badge clears.
-    await selectChannel(page, NETWORK_SLUG, PEER_NICK, { awaitWsReady: false });
+    await selectChannel(page, NETWORK_SLUG, peer.nick, { awaitWsReady: false });
     await expect(scrollbackLine(page, "privmsg", MESSAGE_BODY)).toBeVisible({ timeout: 5_000 });
-    await expect(sidebarMessageBadge(page, NETWORK_SLUG, PEER_NICK)).toHaveCount(0);
+    await expect(sidebarMessageBadge(page, NETWORK_SLUG, peer.nick)).toHaveCount(0);
   } finally {
     await peer.disconnect("M4 done");
   }

--- a/cicchetto/e2e/tests/m5-irssi-to-priv-window-open.spec.ts
+++ b/cicchetto/e2e/tests/m5-irssi-to-priv-window-open.spec.ts
@@ -37,14 +37,17 @@ test("M5 — inbound DM to focused query window renders inline, no unread", asyn
   await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
   await waitForDmListenerReady(page, NETWORK_SLUG);
 
-  // /query opens the window AND focuses it without sending anything.
-  // After this, cicchetto is on the (slug, PEER_NICK) query window, sidebar
-  // shows the entry, no scrollback yet (no DM exchanged).
-  await composeSend(page, `/query ${PEER_NICK}`);
-  await expect(sidebarWindow(page, NETWORK_SLUG, PEER_NICK)).toHaveCount(1, { timeout: 5_000 });
-
+  // Connect FIRST so the /query below names the nick the server GRANTED
+  // (#944). The peer is idle until the privmsg inside the try, so the window
+  // is still opened before any DM exists — which is what M5 pins.
   const peer = await IrcPeer.connect({ nick: PEER_NICK });
   try {
+    // /query opens the window AND focuses it without sending anything.
+    // After this, cicchetto is on the (slug, peer.nick) query window, sidebar
+    // shows the entry, no scrollback yet (no DM exchanged).
+    await composeSend(page, `/query ${peer.nick}`);
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(1, { timeout: 5_000 });
+
     peer.privmsg(NETWORK_NICK, MESSAGE_BODY);
 
     // Probe via REST against channel = PEER_NICK (peer-DM aggregation
@@ -54,8 +57,8 @@ test("M5 — inbound DM to focused query window renders inline, no unread", asyn
     await assertMessagePersisted({
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
-      channel: PEER_NICK,
-      sender: PEER_NICK,
+      channel: peer.nick,
+      sender: peer.nick,
       body: MESSAGE_BODY,
     });
 
@@ -64,7 +67,7 @@ test("M5 — inbound DM to focused query window renders inline, no unread", asyn
 
     // The M5 invariant: focused query window does NOT bump unread.
     // Mirror of M1's focused-channel rule for the query topic.
-    await expect(sidebarMessageBadge(page, NETWORK_SLUG, PEER_NICK)).toHaveCount(0);
+    await expect(sidebarMessageBadge(page, NETWORK_SLUG, peer.nick)).toHaveCount(0);
   } finally {
     await peer.disconnect("M5 done");
   }

--- a/cicchetto/e2e/tests/m6-cicchetto-to-priv-opens-query.spec.ts
+++ b/cicchetto/e2e/tests/m6-cicchetto-to-priv-opens-query.spec.ts
@@ -62,12 +62,12 @@ test("M6 — cicchetto /msg opens query window, focuses, renders own-msg", async
     // (observed 7.5s on the Raspberry Pi dev box — same timing flake as
     // cp15-b6-archive-query-revival; bisected to load, not state). See
     // DESIGN_NOTES 2026-06-09 "cp15-b6 / m6 e2e timing flake".
-    await composeSend(page, `/msg ${PEER_NICK} ${MESSAGE_BODY}`);
+    await composeSend(page, `/msg ${peer.nick} ${MESSAGE_BODY}`);
 
     // Sidebar gains an entry for the peer-nick (the DM target).
     // sidebarWindow scopes by network section, so a hypothetical
     // PEER_NICK string elsewhere doesn't false-match.
-    await expect(sidebarWindow(page, NETWORK_SLUG, PEER_NICK)).toHaveCount(1, { timeout: 15_000 });
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(1, { timeout: 15_000 });
 
     // Server-side: DM row persisted at channel = PEER_NICK with
     // sender = NETWORK_NICK. The wire shape mirrors a regular
@@ -76,7 +76,7 @@ test("M6 — cicchetto /msg opens query window, focuses, renders own-msg", async
     await assertMessagePersisted({
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
-      channel: PEER_NICK,
+      channel: peer.nick,
       sender: NETWORK_NICK,
       body: MESSAGE_BODY,
     });
@@ -85,7 +85,7 @@ test("M6 — cicchetto /msg opens query window, focuses, renders own-msg", async
     await expect(scrollbackLine(page, "privmsg", MESSAGE_BODY)).toBeVisible({ timeout: 15_000 });
 
     // Focused query window: no unread bump on own send.
-    await expect(sidebarMessageBadge(page, NETWORK_SLUG, PEER_NICK)).toHaveCount(0);
+    await expect(sidebarMessageBadge(page, NETWORK_SLUG, peer.nick)).toHaveCount(0);
   } finally {
     await peer.disconnect("M6 done");
   }

--- a/cicchetto/e2e/tests/m7-peer-join-no-bouncer-follow.spec.ts
+++ b/cicchetto/e2e/tests/m7-peer-join-no-bouncer-follow.spec.ts
@@ -53,15 +53,17 @@ test("M7 — peer JOIN on unbound channel does NOT add sidebar entry", async ({ 
     //
     // The line renders irssi-style: `nick [user@host] has joined`. We
     // assert ALL THREE components, not a tolerant `nick ... has joined`
-    // (that would pass even if the user@host regressed). The peer
-    // registers with `username: nick` (ircClient fixture), so the ident
-    // is `${PEER_NICK}` with the leading `~` Bahamut prefixes when no
-    // identd answers; the host is the peer's non-empty resolved address.
+    // (that would pass even if the user@host regressed). The two halves are
+    // NOT the same string (#944): the nick is whatever the server GRANTED,
+    // while `username` is sent once at registration from the nick we ASKED
+    // for (ircClient fixture), so a 433 retry moves the nick and leaves the
+    // ident behind. The ident carries the leading `~` Bahamut prefixes when
+    // no identd answers; the host is the peer's non-empty resolved address.
     await expect(
       scrollbackLine(
         page,
         "join",
-        new RegExp(`${PEER_NICK} \\[~?${PEER_NICK}@[^\\]]+\\] has joined`),
+        new RegExp(`${peer.nick} \\[~?${PEER_NICK}@[^\\]]+\\] has joined`),
       ),
     ).toBeVisible({
       timeout: 5_000,

--- a/cicchetto/e2e/tests/marker-target-window-regression.spec.ts
+++ b/cicchetto/e2e/tests/marker-target-window-regression.spec.ts
@@ -69,13 +69,13 @@ test("focused-window send+reply does NOT spawn unread marker", async ({ page }) 
   const peer = await IrcPeer.connect({ nick: PEER_NICK });
   try {
     // Open the DM by typing /query — the window gains focus.
-    await composeSend(page, `/query ${PEER_NICK}`);
+    await composeSend(page, `/query ${peer.nick}`);
     // Gate the own send on the query-window subscription: the server
     // broadcasts the own `/msg` echo on the (slug, peer) topic, and a
     // send before that phx.join ack fastlanes past the socket → the
     // own line never renders (the ~2/4 suite flake). No self-JOIN line
     // exists for a DM to selectChannel-await, hence the seam.
-    await waitForQueryWindowReady(page, NETWORK_SLUG, PEER_NICK);
+    await waitForQueryWindowReady(page, NETWORK_SLUG, peer.nick);
     // Send an own-PRIVMSG in the focused DM.
     await composeSend(page, own);
     // Wait for own-msg to land in the scrollback.
@@ -112,10 +112,10 @@ test("switching to tall window after focused send scrolls target to bottom", asy
   try {
     // Set up the bug pre-condition: a DM with own-msg + peer-reply
     // (this is the path that leaks markerRef on the source window).
-    await composeSend(page, `/query ${PEER_NICK}`);
+    await composeSend(page, `/query ${peer.nick}`);
     // Gate own send on the query-window subscription (own echo topic);
     // gate the peer reply on the DM-listener (own-nick topic) — see T1.
-    await waitForQueryWindowReady(page, NETWORK_SLUG, PEER_NICK);
+    await waitForQueryWindowReady(page, NETWORK_SLUG, peer.nick);
     await composeSend(page, own);
     await expect(page.locator('[data-testid="scrollback-line"]', { hasText: own })).toBeVisible({
       timeout: 5_000,

--- a/cicchetto/e2e/tests/members-prefix-op-not-clipped.spec.ts
+++ b/cicchetto/e2e/tests/members-prefix-op-not-clipped.spec.ts
@@ -87,10 +87,10 @@ test("members pane renders @-prefix + full op nick (not clipped)", async ({ page
     await peer.join(CHANNEL);
 
     const plainBtn = page.locator(".members-pane .member-plain .member-name", {
-      hasText: PEER_NICK,
+      hasText: peer.nick,
     });
     await expect(plainBtn).toBeVisible({ timeout: 5_000 });
-    await expect(plainBtn).toHaveText(` ${PEER_NICK}`);
+    await expect(plainBtn).toHaveText(` ${peer.nick}`);
 
     const plainBox = await plainBtn.boundingBox();
     expect(plainBox).not.toBeNull();

--- a/cicchetto/e2e/tests/names140-modal.spec.ts
+++ b/cicchetto/e2e/tests/names140-modal.spec.ts
@@ -58,13 +58,13 @@ test("#140 — /names renders the grouped NamesModal; clicking a nick opens a qu
     await expect(modal.locator(".names-modal-footer")).toContainText("End of /NAMES list");
 
     // The peer renders as a clickable nick button in the roster.
-    const peerNick = modal.locator(".names-modal-nick", { hasText: PEER_NICK });
+    const peerNick = modal.locator(".names-modal-nick", { hasText: peer.nick });
     await expect(peerNick).toBeVisible();
 
     // Clicking the nick opens a query window for it AND dismisses the modal.
     await peerNick.click();
     await expect(modal).toBeHidden({ timeout: 2_000 });
-    await expect(sidebarWindow(page, NETWORK_SLUG, PEER_NICK)).toHaveCount(1);
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(1);
   } finally {
     await peer.disconnect("#140 done");
   }

--- a/cicchetto/e2e/tests/nick-case-sensitivity.spec.ts
+++ b/cicchetto/e2e/tests/nick-case-sensitivity.spec.ts
@@ -33,7 +33,6 @@ import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../
 import { expect, test } from "../fixtures/test";
 
 const PEER_NICK_LOWER = "casepeer";
-const PEER_NICK_UPPER = "CASEPEER";
 const CHANNEL = AUTOJOIN_CHANNELS[0];
 
 test("nick case-sensitivity: /q with different casing focuses existing window, no duplicate", async ({
@@ -49,11 +48,17 @@ test("nick case-sensitivity: /q with different casing focuses existing window, n
   // keeps the scenario realistic + matches the bug's original
   // reproduction context.)
   const peer = await IrcPeer.connect({ nick: PEER_NICK_LOWER });
+  // Both casings derive from the nick the server GRANTED, not the one we
+  // asked for (#944). Hand-writing the uppercase twin off the constant would
+  // address a different nick after a 433 retry, and the "same nick, other
+  // casing" premise this spec rests on would quietly stop holding.
+  const lower = peer.nick;
+  const upper = peer.nick.toUpperCase();
   try {
     await peer.join(CHANNEL);
 
     // STEP 1 — Open a query window with the lowercase nick.
-    await composeSend(page, `/q ${PEER_NICK_LOWER}`);
+    await composeSend(page, `/q ${lower}`);
 
     // FLAKE-C bucket 7 (2026-05-23) — selector drift: pre-bucket
     // `.sidebar` was the outer wrapper class; UX-5 BH dropped the
@@ -65,16 +70,16 @@ test("nick case-sensitivity: /q with different casing focuses existing window, n
     // need a different scope; this spec is desktop-only via the
     // single chromium project below).
     const sidebar = page.locator(".shell-sidebar");
-    const queryRows = sidebar.locator(`.sidebar-channel-name:has-text("${PEER_NICK_LOWER}")`);
+    const queryRows = sidebar.locator(`.sidebar-channel-name:has-text("${lower}")`);
     await expect(queryRows).toHaveCount(1, { timeout: 5_000 });
     // First row's text MUST be the lowercase casing (stored canonical).
-    await expect(queryRows.first()).toHaveText(PEER_NICK_LOWER);
+    await expect(queryRows.first()).toHaveText(lower);
 
     // STEP 2 — Type /q with UPPERCASE casing. Pre-fix this would
     // have spawned a second dead row labeled "CASEPEER"; post-fix
     // the existing lowercase row stays selected and the sidebar
     // row count remains 1.
-    await composeSend(page, `/q ${PEER_NICK_UPPER}`);
+    await composeSend(page, `/q ${upper}`);
 
     // Wait for cic to react to the slash dispatch via an event-driven
     // gate rather than a hard waitForTimeout (audit 2026-05-26): the
@@ -85,7 +90,7 @@ test("nick case-sensitivity: /q with different casing focuses existing window, n
     // consecutive reads ≥100ms apart. If a phantom shows up, one of
     // the reads catches count=2 and the spec fails.
     const allCaseRows = sidebar.locator(".sidebar-channel-name", {
-      hasText: new RegExp(`^${PEER_NICK_LOWER}$`, "i"),
+      hasText: new RegExp(`^${lower}$`, "i"),
     });
     await expect.poll(async () => allCaseRows.count(), { timeout: 3_000 }).toBe(1);
     // Stability gate — re-check after a microtask flush to catch a
@@ -93,7 +98,7 @@ test("nick case-sensitivity: /q with different casing focuses existing window, n
     expect(await allCaseRows.count()).toBe(1);
     // And the existing row's display text is still the lowercase
     // canonical (NOT the user's uppercase input).
-    await expect(allCaseRows.first()).toHaveText(PEER_NICK_LOWER);
+    await expect(allCaseRows.first()).toHaveText(lower);
 
     // STEP 3 — A round-trip PRIVMSG from the peer lands in the
     // existing row's scrollback. If the bug had recurred, the

--- a/cicchetto/e2e/tests/p0a-whois-flags.spec.ts
+++ b/cicchetto/e2e/tests/p0a-whois-flags.spec.ts
@@ -75,13 +75,13 @@ test("P-0a — /whois shows 'registered' tag for a NickServ-identified peer (307
     await peer.join(CHANNEL);
 
     // Issue /whois from cic.
-    await composeSend(page, `/whois ${PEER_NICK}`);
+    await composeSend(page, `/whois ${peer.nick}`);
 
     const card = page.getByTestId("whois-card");
     await expect(card).toBeVisible({ timeout: 5_000 });
 
     // Header carries the target nick.
-    await expect(card.locator(".whois-card-target")).toHaveText(PEER_NICK);
+    await expect(card.locator(".whois-card-target")).toHaveText(peer.nick);
 
     // P-0a — the "registered" tag chip is the proof: it's only
     // rendered when `is_registered: true` arrives in the wire

--- a/cicchetto/e2e/tests/p0b-peer-away.spec.ts
+++ b/cicchetto/e2e/tests/p0b-peer-away.spec.ts
@@ -44,23 +44,23 @@ test("P-0b — /msg to away peer surfaces peer_away banner in DM window", async 
     // routes to send_privmsg server-side; the server opens the DM
     // window via the standard PRIVMSG path. Bahamut sees PRIVMSG to an
     // away peer and replies with 301 carrying AWAY_MESSAGE.
-    await composeSend(page, `/msg ${PEER_NICK} ping`);
+    await composeSend(page, `/msg ${peer.nick} ping`);
 
     // The DM window auto-opens on outbound /msg (compose.ts's
     // explicit openQueryWindowState call). Sanity check before we
     // assert the banner.
-    await expect(sidebarWindow(page, NETWORK_SLUG, PEER_NICK)).toHaveCount(1, { timeout: 5_000 });
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(1, { timeout: 5_000 });
 
     // Switch focus to the DM window — the banner mounts only when the
     // selected window matches (slug, peer).
-    await selectChannel(page, NETWORK_SLUG, PEER_NICK, { awaitWsReady: false });
+    await selectChannel(page, NETWORK_SLUG, peer.nick, { awaitWsReady: false });
 
     // Banner renders peer + the away message verbatim. Server is the
     // source of truth for the message text; the "is away" framing is
     // built by cic per feedback_no_localized_strings_server_side.
     const banner = page.locator("[data-testid='peer-away-banner']");
     await expect(banner).toBeVisible({ timeout: 5_000 });
-    await expect(banner).toContainText(PEER_NICK);
+    await expect(banner).toContainText(peer.nick);
     await expect(banner).toContainText("is away");
     await expect(banner).toContainText(AWAY_MESSAGE);
   } finally {

--- a/cicchetto/e2e/tests/p0c-whowas-card-historical.spec.ts
+++ b/cicchetto/e2e/tests/p0c-whowas-card-historical.spec.ts
@@ -38,13 +38,13 @@ test("P-0c — /whowas after peer disconnect surfaces WhowasCard with historical
 
   // Issue /whowas. Bahamut returns 314 (user/host/realname) + 312
   // (server + ctime logoff_time) + 369 (terminator).
-  await composeSend(page, `/whowas ${PEER_NICK}`);
+  await composeSend(page, `/whowas ${peer.nick}`);
 
   const card = page.getByTestId("whowas-card");
   await expect(card).toBeVisible({ timeout: 5_000 });
 
   // Header carries the target nick.
-  await expect(card.locator(".whowas-card-target")).toHaveText(PEER_NICK);
+  await expect(card.locator(".whowas-card-target")).toHaveText(peer.nick);
 
   // Userhost row renders from 314 RPL_WHOWASUSER (user@host).
   // Bahamut sets user from the connect-time USER line; we don't pin

--- a/cicchetto/e2e/tests/p0e-invite-ack.spec.ts
+++ b/cicchetto/e2e/tests/p0e-invite-ack.spec.ts
@@ -73,7 +73,7 @@ test("P-0e + P-0f — /invite to a peer surfaces invite-ack row in the $server w
     // Issue /invite from $server. compose.ts:447-454 tolerates
     // non-channel-window context when channel arg is explicit
     // (P-0f no-silent-drops bucket 0).
-    await composeSend(page, `/invite ${PEER_NICK} ${CHANNEL}`);
+    await composeSend(page, `/invite ${peer.nick} ${CHANNEL}`);
 
     // Invite-ack row mounts inline in $server scrollback via
     // ScrollbackPane.tsx:1252-1254 `<Show when={props.kind ===
@@ -82,7 +82,7 @@ test("P-0e + P-0f — /invite to a peer surfaces invite-ack row in the $server w
     await expect(row).toBeVisible({ timeout: 10_000 });
     await expect(row).toContainText("→");
     await expect(row).toContainText("invited");
-    await expect(row).toContainText(PEER_NICK);
+    await expect(row).toContainText(peer.nick);
     // P-0f — row text includes the target channel since $server
     // aggregates invites issued to any channel.
     await expect(row).toContainText(CHANNEL);

--- a/cicchetto/e2e/tests/ux-6-k-pm-unread-cursor.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-k-pm-unread-cursor.spec.ts
@@ -72,13 +72,16 @@ test("UX-6 K — focus-leave on a peer DM window advances the server-side read c
   // spec times out at the `sidebarWindow.toHaveCount(1)` check.
   await waitForDmListenerReady(page, NETWORK_SLUG);
 
-  // Pre-condition: no cursor exists for the peer window yet (fresh
-  // stack, vjt never DM'd ux6k-peer before).
-  const preCursor = await getReadCursor(vjt.token, NETWORK_SLUG, PEER_NICK);
-  expect(preCursor).toBeNull();
-
+  // Connect BEFORE the pre-condition so every lookup below is keyed on the
+  // nick the server GRANTED (#944). A connected-but-idle peer writes no read
+  // cursor, so the pre-condition observes the same state it did above.
   const peer = await IrcPeer.connect({ nick: PEER_NICK });
   try {
+    // Pre-condition: no cursor exists for the peer window yet (fresh
+    // stack, vjt never DM'd this peer before).
+    const preCursor = await getReadCursor(vjt.token, NETWORK_SLUG, peer.nick);
+    expect(preCursor).toBeNull();
+
     // Peer sends an INBOUND DM to vjt. Persisted server-side at
     // `channel = NETWORK_NICK, dm_with = PEER_NICK` — the storage
     // shape that exposed the K bug.
@@ -91,20 +94,20 @@ test("UX-6 K — focus-leave on a peer DM window advances the server-side read c
     await assertMessagePersisted({
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
-      channel: PEER_NICK,
-      sender: PEER_NICK,
+      channel: peer.nick,
+      sender: peer.nick,
       body: PM_BODY,
     });
 
     // The dm-listener handler in subscribe.ts auto-opens the query
     // window for PEER_NICK on inbound DM. Wait for the sidebar entry.
-    await expect(sidebarWindow(page, NETWORK_SLUG, PEER_NICK)).toHaveCount(1, { timeout: 5_000 });
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(1, { timeout: 5_000 });
 
     // Step 1 — focus the peer window. selection.ts's on(selectedChannel)
     // effect runs; the leave-arm fires for the OLD selection (#bofh),
     // not the new one. No cursor is set for the peer YET (focus
     // alone doesn't set; only LEAVING a window does).
-    await selectChannel(page, NETWORK_SLUG, PEER_NICK, { awaitWsReady: false });
+    await selectChannel(page, NETWORK_SLUG, peer.nick, { awaitWsReady: false });
 
     // The DM body must be visible before we leave — guards against a
     // race where we leave before loadInitialScrollback resolves and
@@ -136,7 +139,7 @@ test("UX-6 K — focus-leave on a peer DM window advances the server-side read c
     // (assertMessagePersisted doesn't return it), and the integer
     // shape is the meaningful contract.
     await expect
-      .poll(() => getReadCursor(vjt.token, NETWORK_SLUG, PEER_NICK), {
+      .poll(() => getReadCursor(vjt.token, NETWORK_SLUG, peer.nick), {
         timeout: 5_000,
         intervals: [100, 200, 500],
       })

--- a/cicchetto/e2e/tests/ux-6-l-foreground-push-beep.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-l-foreground-push-beep.spec.ts
@@ -85,13 +85,13 @@ test("inbound DM fires in-app beep (__lastBeepAt advances) on a non-focused wind
     await assertMessagePersisted({
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
-      channel: PEER_NICK_DM,
-      sender: PEER_NICK_DM,
+      channel: peer.nick,
+      sender: peer.nick,
       body: DM_BODY,
     });
 
     // Step 2: cic-side sidebar — proves DM-listener handler fired.
-    await expect(sidebarWindow(page, NETWORK_SLUG, PEER_NICK_DM)).toHaveCount(1, {
+    await expect(sidebarWindow(page, NETWORK_SLUG, peer.nick)).toHaveCount(1, {
       timeout: 5_000,
     });
 
@@ -134,7 +134,7 @@ test("channel mention fires in-app beep on a non-focused mention target", async 
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
       channel: MENTION_CHANNEL,
-      sender: PEER_NICK_MENTION,
+      sender: peer.nick,
       body: mentionBody,
     });
 
@@ -168,7 +168,7 @@ test("PRIVMSG without nick mention does NOT fire beep on a non-focused channel",
       token: vjt.token,
       networkSlug: NETWORK_SLUG,
       channel: AUTOJOIN_CHANNELS[0],
-      sender: PEER_NICK_MENTION,
+      sender: peer.nick,
       body: nonMentionBody,
     });
 


### PR DESCRIPTION
## What

`p0b-peer-away.spec.ts` addressed its peer by the constant it **requested** and never read `peer.nick`, so #604's reconciliation — *"the nick the server ACTUALLY registered"* — never reached it. #944 named that spec. It is a sample, not the population.

## Census

Scanned every spec, not just the one in the issue:

| | count |
|---|---|
| spec files | 376 |
| open an `IrcPeer` | 135 (159 connect sites) |
| **addressed the requested nick after connect** | **36** |
| already safe | 99 |

The 99 split three ways: never re-reference the nick after connect (the peer just joins and speaks), derive it per run (`stamp` / `runId` / `crypto.randomUUID`), or already read `peer.nick`.

All 36 are converted, so the tree carries one rule instead of two competing ones: **the constant is the REQUEST, `peer.nick` is the GRANT, and only the grant may be addressed.**

Note for the record: the issue lists `cp14-b3-dm-history-bidirectional`, `cp22-bwho-who-rows` and `issue30-channel-tab-completion` among specs that "already use the granted nick". Two of them did not — `cp14-b3` and `cp22-bwho` had `peer.nick` occurrences of **0** and are fixed here. `issue30` is safe for the other reason (per-run nick), as are `issue211-phase3` and `issue16`.

## The cases that are not mechanical

Four specs observed a pre-condition **before** connecting (`c5`, `m4`, `m5`, `ux-6-k`); their connect moves above it. That is inert — a connected-but-idle peer opens no query window and writes no read cursor, so the pre-condition observes the state it observed before.

Three could not be a substitution at all:

- **`m7`** asserts nick AND ident in one regex, and they are *not* the same string: `username` is sent once at registration from the nick we asked for, so a 433 retry moves the nick and leaves the ident behind. Only the nick half changes.
- **`m11`** renames its peer mid-test. `peer.nick` follows `changeNick`, so the granted nick is captured before the rename — otherwise the "old nick gone" assert would name the NEW nick and pass vacuously.
- **`issue247`** watches a nick while nobody holds it, so it must be named before any peer exists. It gets a per-run-unique nick (computed in the test body, *not* at module scope, so `--repeat-each` inside one worker gets a fresh one per repeat) plus an equality assert at the connect — turning a residual collision into a one-line failure instead of a toast timeout.

`nick-case-sensitivity` derives BOTH casings from the granted nick. Hand-writing the uppercase twin off the constant would address a different nick after a retry and quietly void the "same nick, other casing" premise the spec rests on.

## What this is not

No timeout raised, no assert weakened. On a testnet that grants what it is asked, every changed line is behaviour-preserving by construction; it diverges only in the collision case, which is the case being fixed.

**This does not explain the missing 301** that #944 also reports. See the issue comment for what the artifacts do and do not establish — in particular that two of the issue's "zero occurrences" greps are null results.

## Gates

- `bun run check` (biome + `tsc` over `src` AND `e2e/tsconfig.json`, the #484 static gate) — **rc=0, 0 TS errors**.
- Gate coverage proven by a deliberate red: injecting `const mutant: number = peer.nick` into `p0b-peer-away.spec.ts` produced `rc=1` with `e2e/tests/p0b-peer-away.spec.ts(63,11): error TS2322`, i.e. the gate does reach the files this PR changes. Reverted.
- Full `scripts/integration.sh` not run locally — the e2e lane is allocated by the maintainer. CI is the gate here.