### PR TITLE
#429: generate the runtime wire schemas, and drive the admin narrowers off them

### DIFF
--- a/cicchetto/src/__tests__/wireAdminBoundary.test.ts
+++ b/cicchetto/src/__tests__/wireAdminBoundary.test.ts
@@ -27,6 +27,15 @@ import type { WireNode } from "../lib/wireValidate";
 // `survives…` lists the fields whose mutation was ACCEPTED. Everything else
 // was rejected, so an empty list ("-") means the boundary caught every
 // mutation of every field on that arm.
+//
+// `types` is the recorded SHAPE, and it is here because without it this
+// corpus is an oracle made of the thing under test: the sampler reads the
+// generated schema and the narrower now validates against that same schema,
+// so the two move together and a wrong typespec stays green forever. (Proven,
+// not assumed — flipping `circuit_open.network_id` to `String.t()` upstream
+// left all six tests passing until this line existed.) Recording the shape
+// gives the snapshot an anchor OUTSIDE the loop: a field changing type
+// upstream now shows as a diff here, whether or not the narrower notices.
 
 const ARMS = S_AdminEventsWireEvent.u as readonly WireNode[];
 
@@ -66,6 +75,12 @@ function wrongType(value: unknown): unknown {
 
 type Narrower = (raw: unknown) => unknown;
 
+function jsonType(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
+
 function verdictOf(narrow: Narrower, payload: unknown): "accept" | "reject" {
   return narrow(payload) === null ? "reject" : "accept";
 }
@@ -102,7 +117,7 @@ function measure(narrow: Narrower, node: WireNode): Record<string, string> {
   const valid = sample(node) as Record<string, unknown>;
   const fields = Object.keys(valid).sort();
   return {
-    fields: fields.join(", "),
+    types: fields.map((f) => `${f}:${jsonType(valid[f])}`).join(", "),
     baseline: verdictOf(narrow, valid),
     unknownKey: verdictOf(narrow, { ...valid, a_field_from_the_future: 1 }),
     survivesMissing: survivors(narrow, fields, (f) => without(valid, f)),
@@ -169,226 +184,226 @@ describe("admin-events boundary — malformed-payload measurement (#429)", () =>
       {
         "cap_counts_changed": {
           "baseline": "accept",
-          "fields": "at, kind, max_concurrent_user_sessions, max_concurrent_visitor_sessions, network_id, network_slug, users, visitors",
           "survivesMissing": "-",
           "survivesNull": "max_concurrent_user_sessions, max_concurrent_visitor_sessions",
           "survivesWrongType": "-",
+          "types": "at:string, kind:string, max_concurrent_user_sessions:number, max_concurrent_visitor_sessions:number, network_id:number, network_slug:string, users:number, visitors:number",
           "unknownKey": "accept",
         },
         "capacity_reject": {
           "baseline": "accept",
-          "fields": "at, error, flow, kind, network_id, network_slug, source_ip",
           "survivesMissing": "-",
           "survivesNull": "network_slug, source_ip",
           "survivesWrongType": "-",
+          "types": "at:string, error:string, flow:string, kind:string, network_id:number, network_slug:string, source_ip:string",
           "unknownKey": "accept",
         },
         "circuit_close": {
           "baseline": "accept",
-          "fields": "at, kind, network_id, network_slug, reason",
           "survivesMissing": "-",
           "survivesNull": "network_slug",
           "survivesWrongType": "-",
+          "types": "at:string, kind:string, network_id:number, network_slug:string, reason:string",
           "unknownKey": "accept",
         },
         "circuit_open": {
           "baseline": "accept",
-          "fields": "at, cooldown_ms, kind, network_id, network_slug, threshold",
           "survivesMissing": "-",
           "survivesNull": "network_slug",
           "survivesWrongType": "-",
+          "types": "at:string, cooldown_ms:number, kind:string, network_id:number, network_slug:string, threshold:number",
           "unknownKey": "accept",
         },
         "circuit_reset": {
           "baseline": "accept",
-          "fields": "actor_user_id, actor_user_name, at, kind, network_id, network_slug",
           "survivesMissing": "-",
           "survivesNull": "actor_user_id, actor_user_name, network_slug",
           "survivesWrongType": "-",
+          "types": "actor_user_id:string, actor_user_name:string, at:string, kind:string, network_id:number, network_slug:string",
           "unknownKey": "accept",
         },
         "credential_bound": {
           "baseline": "accept",
-          "fields": "actor_user_id, actor_user_name, at, kind, network_id, network_slug, nick, user_id, user_name",
           "survivesMissing": "-",
           "survivesNull": "-",
           "survivesWrongType": "-",
+          "types": "actor_user_id:string, actor_user_name:string, at:string, kind:string, network_id:number, network_slug:string, nick:string, user_id:string, user_name:string",
           "unknownKey": "accept",
         },
         "credential_unbound": {
           "baseline": "accept",
-          "fields": "actor_user_id, actor_user_name, at, kind, network_id, network_slug, user_id, user_name",
           "survivesMissing": "-",
           "survivesNull": "-",
           "survivesWrongType": "-",
+          "types": "actor_user_id:string, actor_user_name:string, at:string, kind:string, network_id:number, network_slug:string, user_id:string, user_name:string",
           "unknownKey": "accept",
         },
         "credential_updated": {
           "baseline": "accept",
-          "fields": "actor_user_id, actor_user_name, at, kind, network_id, network_slug, session_action, user_id, user_name",
           "survivesMissing": "-",
           "survivesNull": "-",
           "survivesWrongType": "-",
+          "types": "actor_user_id:string, actor_user_name:string, at:string, kind:string, network_id:number, network_slug:string, session_action:string, user_id:string, user_name:string",
           "unknownKey": "accept",
         },
         "login_throttled": {
           "baseline": "accept",
-          "fields": "at, door, failures, kind, scope, source_ip, window_ms",
           "survivesMissing": "door, scope",
           "survivesNull": "door, scope, source_ip",
           "survivesWrongType": "door, scope",
+          "types": "at:string, door:string, failures:number, kind:string, scope:string, source_ip:string, window_ms:number",
           "unknownKey": "accept",
         },
         "network_caps_updated": {
           "baseline": "accept",
-          "fields": "actor_user_id, actor_user_name, at, kind, max_concurrent_user_sessions, max_concurrent_visitor_sessions, max_per_ip, network_id, network_slug",
           "survivesMissing": "-",
           "survivesNull": "actor_user_id, actor_user_name, max_concurrent_user_sessions, max_concurrent_visitor_sessions, max_per_ip",
           "survivesWrongType": "-",
+          "types": "actor_user_id:string, actor_user_name:string, at:string, kind:string, max_concurrent_user_sessions:number, max_concurrent_visitor_sessions:number, max_per_ip:number, network_id:number, network_slug:string",
           "unknownKey": "accept",
         },
         "network_created": {
           "baseline": "accept",
-          "fields": "actor_user_id, actor_user_name, at, kind, network_id, network_slug",
           "survivesMissing": "-",
           "survivesNull": "-",
           "survivesWrongType": "-",
+          "types": "actor_user_id:string, actor_user_name:string, at:string, kind:string, network_id:number, network_slug:string",
           "unknownKey": "accept",
         },
         "network_deleted": {
           "baseline": "accept",
-          "fields": "actor_user_id, actor_user_name, at, kind, network_id, network_slug",
           "survivesMissing": "-",
           "survivesNull": "-",
           "survivesWrongType": "-",
+          "types": "actor_user_id:string, actor_user_name:string, at:string, kind:string, network_id:number, network_slug:string",
           "unknownKey": "accept",
         },
         "reaper_swept": {
           "baseline": "accept",
-          "fields": "at, count, kind",
           "survivesMissing": "-",
           "survivesNull": "-",
           "survivesWrongType": "-",
+          "types": "at:string, count:number, kind:string",
           "unknownKey": "accept",
         },
         "server_added": {
           "baseline": "accept",
-          "fields": "actor_user_id, actor_user_name, at, host, kind, network_id, network_slug, port, server_id, tls",
           "survivesMissing": "-",
           "survivesNull": "-",
           "survivesWrongType": "-",
+          "types": "actor_user_id:string, actor_user_name:string, at:string, host:string, kind:string, network_id:number, network_slug:string, port:number, server_id:number, tls:boolean",
           "unknownKey": "accept",
         },
         "server_removed": {
           "baseline": "accept",
-          "fields": "actor_user_id, actor_user_name, at, host, kind, network_id, network_slug, port, server_id",
           "survivesMissing": "-",
           "survivesNull": "-",
           "survivesWrongType": "-",
+          "types": "actor_user_id:string, actor_user_name:string, at:string, host:string, kind:string, network_id:number, network_slug:string, port:number, server_id:number",
           "unknownKey": "accept",
         },
         "server_updated": {
           "baseline": "accept",
-          "fields": "actor_user_id, actor_user_name, at, host, kind, network_id, network_slug, port, server_id, tls",
           "survivesMissing": "-",
           "survivesNull": "-",
           "survivesWrongType": "-",
+          "types": "actor_user_id:string, actor_user_name:string, at:string, host:string, kind:string, network_id:number, network_slug:string, port:number, server_id:number, tls:boolean",
           "unknownKey": "accept",
         },
         "session_disconnected": {
           "baseline": "accept",
-          "fields": "actor_user_id, actor_user_name, at, kind, network_id, network_slug, subject_id, subject_kind",
           "survivesMissing": "-",
           "survivesNull": "actor_user_id, actor_user_name, network_slug",
           "survivesWrongType": "-",
+          "types": "actor_user_id:string, actor_user_name:string, at:string, kind:string, network_id:number, network_slug:string, subject_id:string, subject_kind:string",
           "unknownKey": "accept",
         },
         "session_terminated": {
           "baseline": "accept",
-          "fields": "actor_user_id, actor_user_name, at, kind, network_id, network_slug, subject_id, subject_kind",
           "survivesMissing": "-",
           "survivesNull": "actor_user_id, actor_user_name, network_slug",
           "survivesWrongType": "-",
+          "types": "actor_user_id:string, actor_user_name:string, at:string, kind:string, network_id:number, network_slug:string, subject_id:string, subject_kind:string",
           "unknownKey": "accept",
         },
         "upload_reaped": {
           "baseline": "accept",
-          "fields": "at, kind, slug, subject_id, subject_kind, upload_id",
           "survivesMissing": "-",
           "survivesNull": "-",
           "survivesWrongType": "-",
+          "types": "at:string, kind:string, slug:string, subject_id:string, subject_kind:string, upload_id:string",
           "unknownKey": "accept",
         },
         "uploads_swept": {
           "baseline": "accept",
-          "fields": "at, count, kind",
           "survivesMissing": "-",
           "survivesNull": "-",
           "survivesWrongType": "-",
+          "types": "at:string, count:number, kind:string",
           "unknownKey": "accept",
         },
         "user_created": {
           "baseline": "accept",
-          "fields": "actor_user_id, actor_user_name, at, is_admin, kind, user_id, user_name",
           "survivesMissing": "-",
           "survivesNull": "-",
           "survivesWrongType": "-",
+          "types": "actor_user_id:string, actor_user_name:string, at:string, is_admin:boolean, kind:string, user_id:string, user_name:string",
           "unknownKey": "accept",
         },
         "user_deleted": {
           "baseline": "accept",
-          "fields": "actor_user_id, actor_user_name, at, kind, user_id, user_name",
           "survivesMissing": "-",
           "survivesNull": "-",
           "survivesWrongType": "-",
+          "types": "actor_user_id:string, actor_user_name:string, at:string, kind:string, user_id:string, user_name:string",
           "unknownKey": "accept",
         },
         "user_password_changed": {
           "baseline": "accept",
-          "fields": "actor_user_id, actor_user_name, at, kind, user_id, user_name",
           "survivesMissing": "-",
           "survivesNull": "-",
           "survivesWrongType": "-",
+          "types": "actor_user_id:string, actor_user_name:string, at:string, kind:string, user_id:string, user_name:string",
           "unknownKey": "accept",
         },
         "user_updated": {
           "baseline": "accept",
-          "fields": "actor_user_id, actor_user_name, at, is_admin, kind, user_id, user_name",
           "survivesMissing": "-",
           "survivesNull": "-",
           "survivesWrongType": "-",
+          "types": "actor_user_id:string, actor_user_name:string, at:string, is_admin:boolean, kind:string, user_id:string, user_name:string",
           "unknownKey": "accept",
         },
         "visitor_deleted": {
           "baseline": "accept",
-          "fields": "actor_user_id, actor_user_name, at, kind, visitor_id, visitor_nick",
           "survivesMissing": "-",
           "survivesNull": "actor_user_id, actor_user_name, visitor_nick",
           "survivesWrongType": "-",
+          "types": "actor_user_id:string, actor_user_name:string, at:string, kind:string, visitor_id:string, visitor_nick:string",
           "unknownKey": "accept",
         },
         "visitor_reaped": {
           "baseline": "accept",
-          "fields": "at, kind, visitor_id, visitor_nick",
           "survivesMissing": "-",
           "survivesNull": "visitor_nick",
           "survivesWrongType": "-",
+          "types": "at:string, kind:string, visitor_id:string, visitor_nick:string",
           "unknownKey": "accept",
         },
         "visitor_share_token_minted": {
           "baseline": "accept",
-          "fields": "actor_user_id, actor_user_name, at, kind, visitor_id, visitor_nick",
           "survivesMissing": "-",
           "survivesNull": "visitor_nick",
           "survivesWrongType": "-",
+          "types": "actor_user_id:string, actor_user_name:string, at:string, kind:string, visitor_id:string, visitor_nick:string",
           "unknownKey": "accept",
         },
         "web_session_severed": {
           "baseline": "accept",
-          "fields": "at, failures, kind, subject_id, subject_kind, window_ms",
           "survivesMissing": "-",
           "survivesNull": "-",
           "survivesWrongType": "-",
+          "types": "at:string, failures:number, kind:string, subject_id:string, subject_kind:string, window_ms:number",
           "unknownKey": "accept",
         },
       }
@@ -406,18 +421,18 @@ describe("admin-events boundary — malformed-payload measurement (#429)", () =>
       {
         "admin_overview": {
           "baseline": "accept",
-          "fields": "hostname, loadavg, sessions, version, visitors",
           "survivesMissing": "-",
           "survivesNull": "loadavg",
           "survivesWrongType": "-",
+          "types": "hostname:string, loadavg:number, sessions:number, version:string, visitors:object",
           "unknownKey": "accept",
         },
         "session_log_entry": {
           "baseline": "accept",
-          "fields": "at, attempt, clean, delay_ms, duration_ms, event, id, network_id, network_slug, nick, old_nick, reason, session_id, subject_kind",
           "survivesMissing": "old_nick",
           "survivesNull": "attempt, clean, delay_ms, duration_ms, network_slug, nick, old_nick, reason",
           "survivesWrongType": "-",
+          "types": "at:string, attempt:number, clean:boolean, delay_ms:number, duration_ms:number, event:string, id:number, network_id:number, network_slug:string, nick:string, old_nick:string, reason:string, session_id:string, subject_kind:string",
           "unknownKey": "accept",
         },
       }

--- a/cicchetto/src/__tests__/wireAdminBoundary.test.ts
+++ b/cicchetto/src/__tests__/wireAdminBoundary.test.ts
@@ -1,0 +1,404 @@
+import { describe, expect, it } from "vitest";
+import {
+  narrowAdminEvent,
+  narrowAdminOverview,
+  narrowAdminSnapshot,
+  narrowSessionLogEntry,
+} from "../lib/wireNarrow";
+import { S_AdminEventsWireEvent, S_AdminOverviewWireT, S_SessionLogWireT } from "../lib/wireSchema";
+import type { WireNode } from "../lib/wireValidate";
+
+// #429 — a MEASUREMENT of what the admin-events boundary does to a malformed
+// payload, not a hand-picked set of cases.
+//
+// A narrower is the defence at the boundary, so replacing hand-written
+// narrowers with generated ones is only safe if you can say what changed for
+// every malformed shape — not just for the shapes someone remembered to write
+// a test for. This walks the GENERATED schema, synthesises one valid payload
+// per arm, then mutates it field by field (drop / null / wrong type / an
+// unknown extra key) and records the verdict.
+//
+// The snapshot below is that measurement. Its diff, in the commit that swaps
+// the implementation, IS the before/after evidence — a permissiveness
+// regression cannot land quietly, because it shows up as a field moving into
+// a `survives…` list.
+//
+// `survives…` lists the fields whose mutation was ACCEPTED. Everything else
+// was rejected, so an empty list ("-") means the boundary caught every
+// mutation of every field on that arm.
+
+const ARMS = S_AdminEventsWireEvent.u as readonly WireNode[];
+
+function sample(node: WireNode): unknown {
+  if (typeof node === "string") {
+    switch (node) {
+      case "s":
+        return "sample";
+      case "i":
+        return 1;
+      case "b":
+        return true;
+      case "z":
+        return null;
+      case "x":
+        return { opaque: true };
+    }
+  }
+  if ("l" in node) return node.l;
+  if ("e" in node) return node.e[0];
+  if ("a" in node) return [sample(node.a)];
+  if ("r" in node) return { key: sample(node.r) };
+  if ("p" in node) return node.p.map(sample);
+  if ("u" in node) return sample(node.u[0] as WireNode);
+  return Object.fromEntries(Object.entries(node.o).map(([k, v]) => [k, sample(v)]));
+}
+
+// A value of a DIFFERENT JSON type than the sampled one, derived from the
+// sample so a schema change can never leave the mutation vacuous (mutating a
+// string field to another string would test nothing).
+function wrongType(value: unknown): unknown {
+  if (typeof value === "string") return 12345;
+  if (typeof value === "number") return "12345";
+  if (typeof value === "boolean") return "true";
+  return "not-an-object";
+}
+
+type Narrower = (raw: unknown) => unknown;
+
+function verdictOf(narrow: Narrower, payload: unknown): "accept" | "reject" {
+  return narrow(payload) === null ? "reject" : "accept";
+}
+
+function verdict(payload: unknown): "accept" | "reject" {
+  return verdictOf(narrowAdminEvent, payload);
+}
+
+function survivors(
+  narrow: Narrower,
+  fields: readonly string[],
+  mutate: (field: string) => unknown,
+): string {
+  const survived = fields.filter((f) => verdictOf(narrow, mutate(f)) === "accept");
+  return survived.length === 0 ? "-" : survived.join(", ");
+}
+
+function without(obj: Record<string, unknown>, field: string): Record<string, unknown> {
+  const copy = { ...obj };
+  delete copy[field];
+  return copy;
+}
+
+function armKind(node: WireNode): string {
+  if (typeof node === "string" || !("o" in node)) throw new Error("arm is not an object node");
+  const kindNode = node.o.kind;
+  if (kindNode === undefined || typeof kindNode === "string" || !("l" in kindNode)) {
+    throw new Error("arm has no literal `kind` discriminant");
+  }
+  return String(kindNode.l);
+}
+
+function measure(narrow: Narrower, node: WireNode): Record<string, string> {
+  const valid = sample(node) as Record<string, unknown>;
+  const fields = Object.keys(valid).sort();
+  return {
+    fields: fields.join(", "),
+    baseline: verdictOf(narrow, valid),
+    unknownKey: verdictOf(narrow, { ...valid, a_field_from_the_future: 1 }),
+    survivesMissing: survivors(narrow, fields, (f) => without(valid, f)),
+    survivesNull: survivors(narrow, fields, (f) => ({ ...valid, [f]: null })),
+    survivesWrongType: survivors(narrow, fields, (f) => ({ ...valid, [f]: wrongType(valid[f]) })),
+  };
+}
+
+function measureAllArms(): Record<string, Record<string, string>> {
+  const out: Record<string, Record<string, string>> = {};
+  for (const arm of ARMS) out[armKind(arm)] = measure(narrowAdminEvent, arm);
+  return out;
+}
+
+describe("admin-events boundary — malformed-payload measurement (#429)", () => {
+  it("covers every arm the server declares", () => {
+    // The schema is the server's own union; if an arm has no measurement the
+    // corpus is lying about its coverage.
+    expect(ARMS.length).toBeGreaterThan(0);
+    expect(Object.keys(measureAllArms())).toHaveLength(ARMS.length);
+  });
+
+  it("rejects every malformed top-level shape", () => {
+    expect(verdict(null)).toBe("reject");
+    expect(verdict("circuit_open")).toBe("reject");
+    expect(verdict([])).toBe("reject");
+    expect(verdict({})).toBe("reject");
+    expect(verdict({ kind: 1, at: "t" })).toBe("reject");
+    expect(verdict({ kind: "a_kind_from_the_future", at: "t" })).toBe("reject");
+  });
+
+  it("keeps the snapshot atomic — one malformed row drops the whole set", () => {
+    const good = sample(ARMS[0] as WireNode);
+    expect(narrowAdminSnapshot({ events: [] })).toEqual({ events: [] });
+    expect(narrowAdminSnapshot({ events: [good] })).toEqual({ events: [good] });
+    expect(narrowAdminSnapshot({ events: [good, { kind: "circuit_open" }] })).toBeNull();
+    expect(narrowAdminSnapshot({ events: {} })).toBeNull();
+    expect(narrowAdminSnapshot(null)).toBeNull();
+  });
+
+  it("records what each arm does to every field mutation", () => {
+    expect(measureAllArms()).toMatchInlineSnapshot(`
+      {
+        "cap_counts_changed": {
+          "baseline": "accept",
+          "fields": "at, kind, max_concurrent_user_sessions, max_concurrent_visitor_sessions, network_id, network_slug, users, visitors",
+          "survivesMissing": "-",
+          "survivesNull": "max_concurrent_user_sessions, max_concurrent_visitor_sessions",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "capacity_reject": {
+          "baseline": "accept",
+          "fields": "at, error, flow, kind, network_id, network_slug, source_ip",
+          "survivesMissing": "-",
+          "survivesNull": "network_slug, source_ip",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "circuit_close": {
+          "baseline": "accept",
+          "fields": "at, kind, network_id, network_slug, reason",
+          "survivesMissing": "-",
+          "survivesNull": "network_slug",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "circuit_open": {
+          "baseline": "accept",
+          "fields": "at, cooldown_ms, kind, network_id, network_slug, threshold",
+          "survivesMissing": "-",
+          "survivesNull": "network_slug",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "circuit_reset": {
+          "baseline": "accept",
+          "fields": "actor_user_id, actor_user_name, at, kind, network_id, network_slug",
+          "survivesMissing": "-",
+          "survivesNull": "actor_user_id, actor_user_name, network_slug",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "credential_bound": {
+          "baseline": "accept",
+          "fields": "actor_user_id, actor_user_name, at, kind, network_id, network_slug, nick, user_id, user_name",
+          "survivesMissing": "-",
+          "survivesNull": "-",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "credential_unbound": {
+          "baseline": "accept",
+          "fields": "actor_user_id, actor_user_name, at, kind, network_id, network_slug, user_id, user_name",
+          "survivesMissing": "-",
+          "survivesNull": "-",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "credential_updated": {
+          "baseline": "accept",
+          "fields": "actor_user_id, actor_user_name, at, kind, network_id, network_slug, session_action, user_id, user_name",
+          "survivesMissing": "-",
+          "survivesNull": "-",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "login_throttled": {
+          "baseline": "accept",
+          "fields": "at, door, failures, kind, scope, source_ip, window_ms",
+          "survivesMissing": "door, scope",
+          "survivesNull": "door, scope, source_ip",
+          "survivesWrongType": "door, scope",
+          "unknownKey": "accept",
+        },
+        "network_caps_updated": {
+          "baseline": "accept",
+          "fields": "actor_user_id, actor_user_name, at, kind, max_concurrent_user_sessions, max_concurrent_visitor_sessions, max_per_ip, network_id, network_slug",
+          "survivesMissing": "-",
+          "survivesNull": "actor_user_id, actor_user_name, max_concurrent_user_sessions, max_concurrent_visitor_sessions, max_per_ip",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "network_created": {
+          "baseline": "accept",
+          "fields": "actor_user_id, actor_user_name, at, kind, network_id, network_slug",
+          "survivesMissing": "-",
+          "survivesNull": "-",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "network_deleted": {
+          "baseline": "accept",
+          "fields": "actor_user_id, actor_user_name, at, kind, network_id, network_slug",
+          "survivesMissing": "-",
+          "survivesNull": "-",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "reaper_swept": {
+          "baseline": "accept",
+          "fields": "at, count, kind",
+          "survivesMissing": "-",
+          "survivesNull": "-",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "server_added": {
+          "baseline": "accept",
+          "fields": "actor_user_id, actor_user_name, at, host, kind, network_id, network_slug, port, server_id, tls",
+          "survivesMissing": "-",
+          "survivesNull": "-",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "server_removed": {
+          "baseline": "accept",
+          "fields": "actor_user_id, actor_user_name, at, host, kind, network_id, network_slug, port, server_id",
+          "survivesMissing": "-",
+          "survivesNull": "-",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "server_updated": {
+          "baseline": "accept",
+          "fields": "actor_user_id, actor_user_name, at, host, kind, network_id, network_slug, port, server_id, tls",
+          "survivesMissing": "-",
+          "survivesNull": "-",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "session_disconnected": {
+          "baseline": "accept",
+          "fields": "actor_user_id, actor_user_name, at, kind, network_id, network_slug, subject_id, subject_kind",
+          "survivesMissing": "-",
+          "survivesNull": "actor_user_id, actor_user_name, network_slug",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "session_terminated": {
+          "baseline": "accept",
+          "fields": "actor_user_id, actor_user_name, at, kind, network_id, network_slug, subject_id, subject_kind",
+          "survivesMissing": "-",
+          "survivesNull": "actor_user_id, actor_user_name, network_slug",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "upload_reaped": {
+          "baseline": "accept",
+          "fields": "at, kind, slug, subject_id, subject_kind, upload_id",
+          "survivesMissing": "-",
+          "survivesNull": "-",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "uploads_swept": {
+          "baseline": "accept",
+          "fields": "at, count, kind",
+          "survivesMissing": "-",
+          "survivesNull": "-",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "user_created": {
+          "baseline": "accept",
+          "fields": "actor_user_id, actor_user_name, at, is_admin, kind, user_id, user_name",
+          "survivesMissing": "-",
+          "survivesNull": "-",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "user_deleted": {
+          "baseline": "accept",
+          "fields": "actor_user_id, actor_user_name, at, kind, user_id, user_name",
+          "survivesMissing": "-",
+          "survivesNull": "-",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "user_password_changed": {
+          "baseline": "accept",
+          "fields": "actor_user_id, actor_user_name, at, kind, user_id, user_name",
+          "survivesMissing": "-",
+          "survivesNull": "-",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "user_updated": {
+          "baseline": "accept",
+          "fields": "actor_user_id, actor_user_name, at, is_admin, kind, user_id, user_name",
+          "survivesMissing": "-",
+          "survivesNull": "-",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "visitor_deleted": {
+          "baseline": "accept",
+          "fields": "actor_user_id, actor_user_name, at, kind, visitor_id, visitor_nick",
+          "survivesMissing": "-",
+          "survivesNull": "actor_user_id, actor_user_name, visitor_nick",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "visitor_reaped": {
+          "baseline": "accept",
+          "fields": "at, kind, visitor_id, visitor_nick",
+          "survivesMissing": "-",
+          "survivesNull": "visitor_nick",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "visitor_share_token_minted": {
+          "baseline": "accept",
+          "fields": "actor_user_id, actor_user_name, at, kind, visitor_id, visitor_nick",
+          "survivesMissing": "-",
+          "survivesNull": "visitor_nick",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "web_session_severed": {
+          "baseline": "reject",
+          "fields": "at, failures, kind, subject_id, subject_kind, window_ms",
+          "survivesMissing": "-",
+          "survivesNull": "-",
+          "survivesWrongType": "-",
+          "unknownKey": "reject",
+        },
+      }
+    `);
+  });
+
+  // The same measurement for the two other narrowers this boundary owns.
+  // They ride the same admin channel and were migrated in the same slice, so
+  // they get the same evidence rather than a "the old tests still pass" claim.
+  it("records the same for the session-log and overview narrowers", () => {
+    expect({
+      admin_overview: measure(narrowAdminOverview, S_AdminOverviewWireT),
+      session_log_entry: measure(narrowSessionLogEntry, S_SessionLogWireT),
+    }).toMatchInlineSnapshot(`
+      {
+        "admin_overview": {
+          "baseline": "accept",
+          "fields": "hostname, loadavg, sessions, version, visitors",
+          "survivesMissing": "-",
+          "survivesNull": "loadavg",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+        "session_log_entry": {
+          "baseline": "accept",
+          "fields": "at, attempt, clean, delay_ms, duration_ms, event, id, network_id, network_slug, nick, old_nick, reason, session_id, subject_kind",
+          "survivesMissing": "old_nick",
+          "survivesNull": "attempt, clean, delay_ms, duration_ms, network_slug, nick, old_nick, reason",
+          "survivesWrongType": "-",
+          "unknownKey": "accept",
+        },
+      }
+    `);
+  });
+});

--- a/cicchetto/src/__tests__/wireAdminBoundary.test.ts
+++ b/cicchetto/src/__tests__/wireAdminBoundary.test.ts
@@ -6,6 +6,7 @@ import {
   narrowSessionLogEntry,
 } from "../lib/wireNarrow";
 import { S_AdminEventsWireEvent, S_AdminOverviewWireT, S_SessionLogWireT } from "../lib/wireSchema";
+import { ADMISSION_FLOW } from "../lib/wireTypes";
 import type { WireNode } from "../lib/wireValidate";
 
 // #429 — a MEASUREMENT of what the admin-events boundary does to a malformed
@@ -131,6 +132,27 @@ describe("admin-events boundary — malformed-payload measurement (#429)", () =>
     expect(verdict({})).toBe("reject");
     expect(verdict({ kind: 1, at: "t" })).toBe("reject");
     expect(verdict({ kind: "a_kind_from_the_future", at: "t" })).toBe("reject");
+  });
+
+  // The regression this slice was chasing, stated as behaviour rather than as
+  // a snapshot cell: every arm of the server's own `Admission.flow/0` must
+  // get through. Against the pre-#429 hand narrower this fails on exactly one
+  // member, `visitor_reconnect`, which the five-arm transcription never
+  // learned about.
+  it("admits every member of the server's declared admission-flow set", () => {
+    for (const flow of ADMISSION_FLOW) {
+      expect(
+        narrowAdminEvent({
+          kind: "capacity_reject",
+          flow,
+          error: "ip_cap_exceeded",
+          network_id: 1,
+          network_slug: "azzurra",
+          source_ip: null,
+          at: "2026-08-09T00:00:00Z",
+        }),
+      ).not.toBeNull();
+    }
   });
 
   it("keeps the snapshot atomic — one malformed row drops the whole set", () => {
@@ -362,12 +384,12 @@ describe("admin-events boundary — malformed-payload measurement (#429)", () =>
           "unknownKey": "accept",
         },
         "web_session_severed": {
-          "baseline": "reject",
+          "baseline": "accept",
           "fields": "at, failures, kind, subject_id, subject_kind, window_ms",
           "survivesMissing": "-",
           "survivesNull": "-",
           "survivesWrongType": "-",
-          "unknownKey": "reject",
+          "unknownKey": "accept",
         },
       }
     `);

--- a/cicchetto/src/__tests__/wireValidate.test.ts
+++ b/cicchetto/src/__tests__/wireValidate.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import { type Infer, validate, type WireNode } from "../lib/wireValidate";
+
+// #429 — the interpreter for the generated wire schemas. These pin the
+// grammar itself; the shapes it is pointed at live in `wireSchema.ts` and are
+// pinned by the differential corpus in `wireNarrowAdminCorpus.test.ts`.
+
+describe("validate — scalars", () => {
+  it("accepts a string for 's' and rejects every other JSON type", () => {
+    expect(validate("s", "x")).toBe("x");
+    expect(validate("s", 1)).toBeNull();
+    expect(validate("s", null)).toBeNull();
+    expect(validate("s", true)).toBeNull();
+    expect(validate("s", {})).toBeNull();
+  });
+
+  it("accepts a number for 'i', including 0 and negatives", () => {
+    expect(validate("i", 0)).toBe(0);
+    expect(validate("i", -3)).toBe(-3);
+    expect(validate("i", "3")).toBeNull();
+  });
+
+  it("accepts a boolean for 'b'", () => {
+    expect(validate("b", false)).toBe(false);
+    expect(validate("b", "false")).toBeNull();
+  });
+
+  it("accepts only null for 'z'", () => {
+    expect(validate("z", null)).toBeNull();
+    expect(validate("z", "")).toBeNull();
+  });
+
+  it("passes anything through for 'x' (the server's own term())", () => {
+    expect(validate("x", { anything: [1] })).toEqual({ anything: [1] });
+    expect(validate("x", null)).toBeNull();
+  });
+});
+
+describe("validate — literals and closed sets", () => {
+  it("accepts exactly the literal", () => {
+    expect(validate({ l: "joined" }, "joined")).toBe("joined");
+    expect(validate({ l: "joined" }, "Joined")).toBeNull();
+  });
+
+  it("accepts only members of a closed set", () => {
+    const node = { e: ["a", "b"] } as const;
+    expect(validate(node, "b")).toBe("b");
+    expect(validate(node, "c")).toBeNull();
+    expect(validate(node, 1)).toBeNull();
+  });
+});
+
+describe("validate — containers", () => {
+  it("rejects the whole array when one element is malformed", () => {
+    expect(validate({ a: "s" }, ["a", "b"])).toEqual(["a", "b"]);
+    expect(validate({ a: "s" }, ["a", 2])).toBeNull();
+    expect(validate({ a: "s" }, "a")).toBeNull();
+  });
+
+  it("validates every value of a record", () => {
+    expect(validate({ r: "i" }, { a: 1 })).toEqual({ a: 1 });
+    expect(validate({ r: "i" }, { a: "1" })).toBeNull();
+    expect(validate({ r: "i" }, [])).toBeNull();
+  });
+
+  it("requires a tuple to match arity and member types", () => {
+    const node = { p: ["s", "i"] } as const;
+    expect(validate(node, ["a", 1])).toEqual(["a", 1]);
+    expect(validate(node, ["a", 1, 2])).toBeNull();
+    expect(validate(node, ["a"])).toBeNull();
+  });
+
+  it("takes the first union arm that matches", () => {
+    const node = { u: ["s", "z"] } as const;
+    expect(validate(node, "a")).toBe("a");
+    expect(validate(node, null)).toBeNull();
+    expect(validate(node, 1)).toBeNull();
+  });
+});
+
+describe("validate — objects", () => {
+  const node = {
+    o: { kind: { l: "ping" }, count: "i", note: "s" },
+    q: ["note"],
+  } as const;
+
+  it("accepts the declared shape", () => {
+    expect(validate(node, { kind: "ping", count: 1, note: "hi" })).toEqual({
+      kind: "ping",
+      count: 1,
+      note: "hi",
+    });
+  });
+
+  it("accepts an omitted optional key and omits it from the result", () => {
+    const out = validate(node, { kind: "ping", count: 1 });
+    expect(out).toEqual({ kind: "ping", count: 1 });
+    expect(out && "note" in out).toBe(false);
+  });
+
+  it("rejects an omitted REQUIRED key", () => {
+    expect(validate(node, { kind: "ping", note: "hi" })).toBeNull();
+  });
+
+  it("rejects an optional key that is present but wrong-typed", () => {
+    expect(validate(node, { kind: "ping", count: 1, note: 7 })).toBeNull();
+  });
+
+  it("drops an undeclared key instead of rejecting (additive-only, #447)", () => {
+    expect(validate(node, { kind: "ping", count: 1, tomorrows_field: "x" })).toEqual({
+      kind: "ping",
+      count: 1,
+    });
+  });
+
+  it("rejects a non-object, an array, and null", () => {
+    expect(validate(node, "ping")).toBeNull();
+    expect(validate(node, [])).toBeNull();
+    expect(validate(node, null)).toBeNull();
+  });
+
+  it("rejects a nested object whose inner field is malformed", () => {
+    const nested = { o: { inner: { o: { n: "i" } } } } as const;
+    expect(validate(nested, { inner: { n: 1 } })).toEqual({ inner: { n: 1 } });
+    expect(validate(nested, { inner: { n: "1" } })).toBeNull();
+  });
+});
+
+describe("Infer", () => {
+  it("derives the same shape the schema validates (compile-time)", () => {
+    const node = {
+      o: { kind: { l: "ping" }, tags: { a: "s" }, slug: { u: ["s", "z"] }, note: "s" },
+      q: ["note"],
+    } as const;
+
+    // If `Infer` and the interpreter disagreed, one of these two assignments
+    // would not compile — that is the whole point of the type.
+    const shaped: Infer<typeof node> = {
+      kind: "ping",
+      tags: ["a"],
+      slug: null,
+    };
+    const parsed = validate(node, shaped);
+    expect(parsed).toEqual(shaped);
+  });
+
+  it("accepts a union schema as a discriminated union", () => {
+    const node = {
+      u: [{ o: { kind: { l: "a" }, n: "i" } }, { o: { kind: { l: "b" }, s: "s" } }],
+    } as const;
+
+    const parsed = validate(node, { kind: "b", s: "x" });
+    expect(parsed).toEqual({ kind: "b", s: "x" });
+    if (parsed !== null && parsed.kind === "b") {
+      expect(parsed.s).toBe("x");
+    }
+    expect(validate(node, { kind: "a", n: "1" })).toBeNull();
+  });
+});
+
+describe("WireNode", () => {
+  it("types every arm of the grammar the codegen emits", () => {
+    const nodes: WireNode[] = [
+      "s",
+      "i",
+      "b",
+      "x",
+      "z",
+      { l: "k" },
+      { e: ["a"] },
+      { a: "s" },
+      { r: "s" },
+      { p: ["s"] },
+      { u: ["s", "z"] },
+      { o: { a: "s" }, q: ["a"] },
+    ];
+    expect(nodes).toHaveLength(12);
+  });
+});

--- a/cicchetto/src/lib/wireNarrow.ts
+++ b/cicchetto/src/lib/wireNarrow.ts
@@ -1,6 +1,5 @@
 import type {
   AdminSnapshotPayload,
-  AdmissionFlow,
   MessageKind,
   ScrollbackMessage,
   WhoUser,
@@ -9,25 +8,21 @@ import type {
 } from "./api";
 import type { ModesEntry, TopicEntry } from "./channelTopic";
 import type { MemberEntry } from "./memberTypes";
-import type {
-  AdminEventsWireLoginThrottleDoor,
-  AdminEventsWireLoginThrottleScope,
-  AdminOverviewWireT,
-  SessionLogEvent,
-  SessionLogWireT,
-  WindowCountsSeverity,
-} from "./wireTypes";
+// #429 — the generated RUNTIME schemas. `S_*` consts are the same typespecs
+// `wireTypes.ts` mirrors at compile time, emitted as data so the boundary can
+// enforce them after tsc has erased the types.
+import { S_AdminEventsWireEvent, S_AdminOverviewWireT, S_SessionLogWireT } from "./wireSchema";
+import type { AdminOverviewWireT, SessionLogWireT, WindowCountsSeverity } from "./wireTypes";
 // #410 — the runtime allowlists derive from the codegen-emitted `as const`
 // enum arrays, so each closed set has ONE source (the server typespec via
 // wireTypes.ts), not a hand copy that can silently drift.
 import {
   ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_DOOR,
   ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_SCOPE,
-  ADMISSION_FLOW,
   SCROLLBACK_MESSAGE_KIND,
-  SESSION_LOG_EVENT,
   WINDOW_COUNTS_SEVERITY,
 } from "./wireTypes";
+import { validate } from "./wireValidate";
 
 // #267 — narrow the window_counts severity to the closed union, defaulting
 // to "none" for an unknown value (defensive: a stale server mid hot-reload
@@ -39,18 +34,6 @@ function narrowSeverity(raw: unknown): WindowCountsSeverity {
   return typeof raw === "string" && (WINDOW_COUNTS_SEVERITY as readonly string[]).includes(raw)
     ? (raw as WindowCountsSeverity)
     : "none";
-}
-
-// An ADDITIVE closed-set field: absent (an older server minted the event)
-// or unrecognised (a newer one added an arm) both narrow to `undefined`,
-// so the caller renders without it instead of dropping the event. Same
-// #410 discipline as `narrowSeverity` — the allowlist IS the
-// codegen-emitted const, never a hand copy.
-function narrowEnumMember<T extends string>(
-  raw: unknown,
-  allowed: readonly string[],
-): T | undefined {
-  return typeof raw === "string" && allowed.includes(raw) ? (raw as T) : undefined;
 }
 
 // Bucket G H4+U3 (codebase-review-2026-05-12): runtime narrowing for
@@ -472,65 +455,63 @@ export function narrowChannelEvent(raw: unknown): WireChannelEvent | null {
 // the live `liveCountsByNetworkId` projection. The narrowers gate the
 // boundary: shape mismatch → return null → caller drops + logs.
 //
-// `narrowAdminSnapshot` validates the `{events: WireAdminEvent[]}` outer
-// shape AND every element. Either the whole snapshot validates or it
-// drops — partial admission would corrupt the audit ring with malformed
-// rows.
+// #429 — the 27 arms below used to be transcribed BY HAND from the server's
+// `Grappa.AdminEvents.Wire` typespecs: ~420 lines re-stating a shape the
+// codegen already reads. They now run off `S_AdminEventsWireEvent`, emitted
+// from those same typespecs by `mix grappa.gen_wire_types` and gated by the
+// same `--check` drift check as `wireTypes.ts`.
 //
-// Adding a new admin event arm:
-//   1. Add to `WireAdminEvent` union in api.ts.
-//   2. Add an arm to `narrowAdminEvent` here.
-//   3. Add a dispatch case to `ingest()` in adminEvents.ts (tsc-enforced
-//      via `assertNever`).
-// The narrower's default-arm returning null is the runtime mirror of
-// `assertNever` — unknown server kinds drop instead of crashing.
-
-// #448 — the allowlist derives from the codegen-emitted `ADMISSION_FLOW`
-// const (the #410 posture), not a hand copy. The hand copy this replaces
-// had silently gone stale: it was missing `visitor_reconnect`, so every
-// capacity_reject raised by the visitor-reconnect door was dropped here
-// and never reached the Events tab.
-const VALID_ADMISSION_FLOWS: ReadonlySet<AdmissionFlow> = new Set(ADMISSION_FLOW);
-
-const VALID_SUBJECT_KINDS: ReadonlySet<"user" | "visitor"> = new Set(["user", "visitor"]);
-
-const VALID_CIRCUIT_CLOSE_REASONS: ReadonlySet<"success" | "cooldown_expired"> = new Set([
-  "success",
-  "cooldown_expired",
-]);
-
-// Shared helpers — every admin arm carries `at: string`; most carry
-// `network_id: number` + `network_slug: string | null`. Failing the
-// shared shape early keeps the per-arm switches compact.
-
-function isNonNullString(v: unknown): boolean {
-  return typeof v === "string";
-}
-
-function isNullableString(v: unknown): boolean {
-  return v === null || typeof v === "string";
-}
-
-// A nullable string field ADDED to an already-shipped wire shape.
+// Transcription is not free: the hand version had NO `web_session_severed`
+// arm, so every flood-sever audit row was dropped on the live push — and,
+// because `narrowAdminSnapshot` is atomic, a single such row in the ring
+// blanked the whole Events tab on reconnect. That arm exists on the server,
+// in `wireTypes.ts` and in `adminEvents.ts`'s dispatch; only the hand copy
+// lost it. Nobody could have noticed by reading the diff that omitted it.
+// See the measured before/after in `__tests__/wireAdminBoundary.test.ts`.
 //
-// The narrowers are otherwise strict — a missing field drops the row — and
-// that is right for fields present since the shape was born. It is wrong for
-// a field added later: cic deploys independently of the server
-// (`deploy-m42.sh --cic`), so a new cic against a not-yet-deployed server
-// would drop EVERY row of that shape. The wire contract says a new field may
-// appear at any time and that unknown-is-never-fatal in BOTH directions;
-// requiring a field the peer predates is the same breakage wearing the other
-// hat. Absent normalises to null at the call site.
-function isAddedNullableString(v: unknown): boolean {
-  return v === undefined || isNullableString(v);
-}
+// Adding a new admin event arm now: declare it in the server typespec, run
+// the codegen, add a dispatch case to `ingest()` in adminEvents.ts
+// (tsc-enforced via `assertNever`). Nothing to add HERE.
 
-function isNullableNumber(v: unknown): boolean {
-  return v === null || typeof v === "number";
-}
+// A closed-set field the server marked `optional(:k)` AND that carries
+// attribution DETAIL rather than the substance of the event.
+//
+// This is the part of a narrower a typespec cannot express, so it stays
+// hand-written and named. `optional(:door)` tells the schema the server may
+// OMIT the key; it cannot say what to do when a NEWER server sends a member
+// this build has never heard of. `login_throttled` is a security alert whose
+// door/scope are the attribution: dropping the alert to protect the detail
+// inverts the priority, and the admin ring is mirrored to disk and replayed
+// at boot, so rows minted by another vintage genuinely do arrive. Strip the
+// unrecognised value, keep the alert — the judgement `narrowEnumMember` made
+// inline before #429, now stated once.
+const ADDITIVE_DETAIL_FIELDS: ReadonlyMap<string, ReadonlyMap<string, readonly string[]>> = new Map(
+  [
+    [
+      "login_throttled",
+      new Map([
+        ["door", ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_DOOR as readonly string[]],
+        ["scope", ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_SCOPE as readonly string[]],
+      ]),
+    ],
+  ],
+);
 
-function isNullableBoolean(v: unknown): boolean {
-  return v === null || typeof v === "boolean";
+function dropUnrecognisedDetails(raw: unknown): unknown {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return raw;
+  const r = raw as Record<string, unknown>;
+  const details = typeof r.kind === "string" ? ADDITIVE_DETAIL_FIELDS.get(r.kind) : undefined;
+  if (details === undefined) return raw;
+
+  let out: Record<string, unknown> | null = null;
+  for (const [field, allowed] of details) {
+    const value = r[field];
+    if (value === undefined) continue;
+    if (typeof value === "string" && allowed.includes(value)) continue;
+    out ??= { ...r };
+    delete out[field];
+  }
+  return out ?? raw;
 }
 
 /**
@@ -540,431 +521,15 @@ function isNullableBoolean(v: unknown): boolean {
  * any shape mismatch. Caller (adminEvents.ts) drops + logs on null.
  */
 export function narrowAdminEvent(raw: unknown): WireAdminEvent | null {
-  if (typeof raw !== "object" || raw === null) return null;
-  const r = raw as Record<string, unknown>;
-  if (typeof r.kind !== "string") return null;
-  if (!isNonNullString(r.at)) return null;
-  switch (r.kind) {
-    case "circuit_open":
-      if (
-        typeof r.network_id !== "number" ||
-        !isNullableString(r.network_slug) ||
-        typeof r.threshold !== "number" ||
-        typeof r.cooldown_ms !== "number"
-      )
-        return null;
-      return {
-        kind: "circuit_open",
-        network_id: r.network_id,
-        network_slug: r.network_slug as string | null,
-        threshold: r.threshold,
-        cooldown_ms: r.cooldown_ms,
-        at: r.at as string,
-      };
-    case "circuit_close":
-      if (
-        typeof r.network_id !== "number" ||
-        !isNullableString(r.network_slug) ||
-        typeof r.reason !== "string" ||
-        !VALID_CIRCUIT_CLOSE_REASONS.has(r.reason as "success" | "cooldown_expired")
-      )
-        return null;
-      return {
-        kind: "circuit_close",
-        network_id: r.network_id,
-        network_slug: r.network_slug as string | null,
-        reason: r.reason as "success" | "cooldown_expired",
-        at: r.at as string,
-      };
-    case "capacity_reject":
-      if (
-        typeof r.flow !== "string" ||
-        !VALID_ADMISSION_FLOWS.has(r.flow as AdmissionFlow) ||
-        typeof r.error !== "string" ||
-        typeof r.network_id !== "number" ||
-        !isNullableString(r.network_slug) ||
-        !isNullableString(r.source_ip)
-      )
-        return null;
-      return {
-        kind: "capacity_reject",
-        flow: r.flow as AdmissionFlow,
-        error: r.error,
-        network_id: r.network_id,
-        network_slug: r.network_slug as string | null,
-        source_ip: r.source_ip as string | null,
-        at: r.at as string,
-      };
-    case "visitor_deleted":
-      if (
-        typeof r.visitor_id !== "string" ||
-        !isNullableString(r.visitor_nick) ||
-        // #211 phase 7 — `network_slug` DROPPED from the server event; a
-        // guard on it would make `isNullableString(undefined)` false →
-        // narrow to null → blank the admin events tab. Not validated.
-        !isNullableString(r.actor_user_id) ||
-        !isNullableString(r.actor_user_name)
-      )
-        return null;
-      return {
-        kind: "visitor_deleted",
-        visitor_id: r.visitor_id,
-        visitor_nick: r.visitor_nick as string | null,
-        actor_user_id: r.actor_user_id as string | null,
-        actor_user_name: r.actor_user_name as string | null,
-        at: r.at as string,
-      };
-    case "visitor_reaped":
-      if (
-        typeof r.visitor_id !== "string" ||
-        !isNullableString(r.visitor_nick)
-        // #211 phase 7 — `network_slug` DROPPED (see visitor_deleted).
-      )
-        return null;
-      return {
-        kind: "visitor_reaped",
-        visitor_id: r.visitor_id,
-        visitor_nick: r.visitor_nick as string | null,
-        at: r.at as string,
-      };
-    case "visitor_share_token_minted":
-      // #982 — the actor is NON-nullable on this one, unlike
-      // visitor_deleted: the verb is only reachable behind
-      // `:admin_authn`, so an unattributed grant is a malformed event
-      // and must narrow to null rather than render as anonymous.
-      if (
-        typeof r.visitor_id !== "string" ||
-        !isNullableString(r.visitor_nick) ||
-        typeof r.actor_user_id !== "string" ||
-        typeof r.actor_user_name !== "string"
-      )
-        return null;
-      return {
-        kind: "visitor_share_token_minted",
-        visitor_id: r.visitor_id,
-        visitor_nick: r.visitor_nick as string | null,
-        actor_user_id: r.actor_user_id,
-        actor_user_name: r.actor_user_name,
-        at: r.at as string,
-      };
-    case "reaper_swept":
-      if (typeof r.count !== "number") return null;
-      return { kind: "reaper_swept", count: r.count, at: r.at as string };
-    case "upload_reaped":
-      if (
-        typeof r.upload_id !== "string" ||
-        typeof r.slug !== "string" ||
-        typeof r.subject_kind !== "string" ||
-        !VALID_SUBJECT_KINDS.has(r.subject_kind as "user" | "visitor") ||
-        typeof r.subject_id !== "string"
-      )
-        return null;
-      return {
-        kind: "upload_reaped",
-        upload_id: r.upload_id,
-        slug: r.slug,
-        subject_kind: r.subject_kind as "user" | "visitor",
-        subject_id: r.subject_id,
-        at: r.at as string,
-      };
-    case "uploads_swept":
-      if (typeof r.count !== "number") return null;
-      return { kind: "uploads_swept", count: r.count, at: r.at as string };
-    case "session_disconnected":
-    case "session_terminated": {
-      if (
-        typeof r.subject_kind !== "string" ||
-        !VALID_SUBJECT_KINDS.has(r.subject_kind as "user" | "visitor") ||
-        typeof r.subject_id !== "string" ||
-        typeof r.network_id !== "number" ||
-        !isNullableString(r.network_slug) ||
-        !isNullableString(r.actor_user_id) ||
-        !isNullableString(r.actor_user_name)
-      )
-        return null;
-      const base = {
-        subject_kind: r.subject_kind as "user" | "visitor",
-        subject_id: r.subject_id,
-        network_id: r.network_id,
-        network_slug: r.network_slug as string | null,
-        actor_user_id: r.actor_user_id as string | null,
-        actor_user_name: r.actor_user_name as string | null,
-        at: r.at as string,
-      };
-      return r.kind === "session_disconnected"
-        ? { kind: "session_disconnected", ...base }
-        : { kind: "session_terminated", ...base };
-    }
-    case "network_caps_updated":
-      if (
-        typeof r.network_id !== "number" ||
-        typeof r.network_slug !== "string" ||
-        !isNullableNumber(r.max_concurrent_visitor_sessions) ||
-        !isNullableNumber(r.max_concurrent_user_sessions) ||
-        !isNullableNumber(r.max_per_ip) ||
-        !isNullableString(r.actor_user_id) ||
-        !isNullableString(r.actor_user_name)
-      )
-        return null;
-      return {
-        kind: "network_caps_updated",
-        network_id: r.network_id,
-        network_slug: r.network_slug,
-        max_concurrent_visitor_sessions: r.max_concurrent_visitor_sessions as number | null,
-        max_concurrent_user_sessions: r.max_concurrent_user_sessions as number | null,
-        max_per_ip: r.max_per_ip as number | null,
-        actor_user_id: r.actor_user_id as string | null,
-        actor_user_name: r.actor_user_name as string | null,
-        at: r.at as string,
-      };
-    case "circuit_reset":
-      if (
-        typeof r.network_id !== "number" ||
-        !isNullableString(r.network_slug) ||
-        !isNullableString(r.actor_user_id) ||
-        !isNullableString(r.actor_user_name)
-      )
-        return null;
-      return {
-        kind: "circuit_reset",
-        network_id: r.network_id,
-        network_slug: r.network_slug as string | null,
-        actor_user_id: r.actor_user_id as string | null,
-        actor_user_name: r.actor_user_name as string | null,
-        at: r.at as string,
-      };
-    case "user_created":
-    case "user_updated":
-      if (
-        typeof r.user_id !== "string" ||
-        typeof r.user_name !== "string" ||
-        typeof r.is_admin !== "boolean" ||
-        typeof r.actor_user_id !== "string" ||
-        typeof r.actor_user_name !== "string"
-      )
-        return null;
-      return {
-        kind: r.kind,
-        user_id: r.user_id,
-        user_name: r.user_name,
-        is_admin: r.is_admin,
-        actor_user_id: r.actor_user_id,
-        actor_user_name: r.actor_user_name,
-        at: r.at as string,
-      };
-    case "user_password_changed":
-    case "user_deleted":
-      if (
-        typeof r.user_id !== "string" ||
-        typeof r.user_name !== "string" ||
-        typeof r.actor_user_id !== "string" ||
-        typeof r.actor_user_name !== "string"
-      )
-        return null;
-      return {
-        kind: r.kind,
-        user_id: r.user_id,
-        user_name: r.user_name,
-        actor_user_id: r.actor_user_id,
-        actor_user_name: r.actor_user_name,
-        at: r.at as string,
-      };
-    case "network_created":
-    case "network_deleted":
-      if (
-        typeof r.network_id !== "number" ||
-        typeof r.network_slug !== "string" ||
-        typeof r.actor_user_id !== "string" ||
-        typeof r.actor_user_name !== "string"
-      )
-        return null;
-      return {
-        kind: r.kind,
-        network_id: r.network_id,
-        network_slug: r.network_slug,
-        actor_user_id: r.actor_user_id,
-        actor_user_name: r.actor_user_name,
-        at: r.at as string,
-      };
-    case "server_added":
-    case "server_updated":
-      if (
-        typeof r.network_id !== "number" ||
-        typeof r.network_slug !== "string" ||
-        typeof r.server_id !== "number" ||
-        typeof r.host !== "string" ||
-        typeof r.port !== "number" ||
-        typeof r.tls !== "boolean" ||
-        typeof r.actor_user_id !== "string" ||
-        typeof r.actor_user_name !== "string"
-      )
-        return null;
-      return {
-        kind: r.kind,
-        network_id: r.network_id,
-        network_slug: r.network_slug,
-        server_id: r.server_id,
-        host: r.host,
-        port: r.port,
-        tls: r.tls,
-        actor_user_id: r.actor_user_id,
-        actor_user_name: r.actor_user_name,
-        at: r.at as string,
-      };
-    case "server_removed":
-      if (
-        typeof r.network_id !== "number" ||
-        typeof r.network_slug !== "string" ||
-        typeof r.server_id !== "number" ||
-        typeof r.host !== "string" ||
-        typeof r.port !== "number" ||
-        typeof r.actor_user_id !== "string" ||
-        typeof r.actor_user_name !== "string"
-      )
-        return null;
-      return {
-        kind: "server_removed",
-        network_id: r.network_id,
-        network_slug: r.network_slug,
-        server_id: r.server_id,
-        host: r.host,
-        port: r.port,
-        actor_user_id: r.actor_user_id,
-        actor_user_name: r.actor_user_name,
-        at: r.at as string,
-      };
-    case "credential_bound":
-      if (
-        typeof r.user_id !== "string" ||
-        typeof r.user_name !== "string" ||
-        typeof r.network_id !== "number" ||
-        typeof r.network_slug !== "string" ||
-        typeof r.nick !== "string" ||
-        typeof r.actor_user_id !== "string" ||
-        typeof r.actor_user_name !== "string"
-      )
-        return null;
-      return {
-        kind: "credential_bound",
-        user_id: r.user_id,
-        user_name: r.user_name,
-        network_id: r.network_id,
-        network_slug: r.network_slug,
-        nick: r.nick,
-        actor_user_id: r.actor_user_id,
-        actor_user_name: r.actor_user_name,
-        at: r.at as string,
-      };
-    case "credential_updated":
-      if (
-        typeof r.user_id !== "string" ||
-        typeof r.user_name !== "string" ||
-        typeof r.network_id !== "number" ||
-        typeof r.network_slug !== "string" ||
-        typeof r.session_action !== "string" ||
-        (r.session_action !== "left_alone" && r.session_action !== "stopped") ||
-        typeof r.actor_user_id !== "string" ||
-        typeof r.actor_user_name !== "string"
-      )
-        return null;
-      return {
-        kind: "credential_updated",
-        user_id: r.user_id,
-        user_name: r.user_name,
-        network_id: r.network_id,
-        network_slug: r.network_slug,
-        session_action: r.session_action,
-        actor_user_id: r.actor_user_id,
-        actor_user_name: r.actor_user_name,
-        at: r.at as string,
-      };
-    case "credential_unbound":
-      if (
-        typeof r.user_id !== "string" ||
-        typeof r.user_name !== "string" ||
-        typeof r.network_id !== "number" ||
-        typeof r.network_slug !== "string" ||
-        typeof r.actor_user_id !== "string" ||
-        typeof r.actor_user_name !== "string"
-      )
-        return null;
-      return {
-        kind: "credential_unbound",
-        user_id: r.user_id,
-        user_name: r.user_name,
-        network_id: r.network_id,
-        network_slug: r.network_slug,
-        actor_user_id: r.actor_user_id,
-        actor_user_name: r.actor_user_name,
-        at: r.at as string,
-      };
-    // S6 (review 2026-07-19) — a credential door's throttle trip.
-    // source_ip is nullable (server RemoteIP honesty for unresolvable
-    // peers). door/scope are ADDITIVE and narrow to `undefined` rather
-    // than nulling the event: the admin ring is mirrored to disk and
-    // reloaded at boot, so the Events tab genuinely replays rows minted
-    // before the fields existed. The trip is the load-bearing part; the
-    // attribution is the detail, and a missing detail must not delete
-    // the alert.
-    case "login_throttled":
-      if (
-        !isNullableString(r.source_ip) ||
-        typeof r.failures !== "number" ||
-        typeof r.window_ms !== "number"
-      )
-        return null;
-      return {
-        kind: "login_throttled",
-        source_ip: r.source_ip as string | null,
-        failures: r.failures,
-        window_ms: r.window_ms,
-        at: r.at as string,
-        door: narrowEnumMember<AdminEventsWireLoginThrottleDoor>(
-          r.door,
-          ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_DOOR,
-        ),
-        scope: narrowEnumMember<AdminEventsWireLoginThrottleScope>(
-          r.scope,
-          ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_SCOPE,
-        ),
-      };
-    case "cap_counts_changed":
-      // REV-H H5 (2026-05-22): network_slug is required non-null on
-      // this arm. The server-side broadcaster early-returns when the
-      // network row was deleted, so a nil-slug payload would already
-      // never reach cic — narrowing it as required surfaces that
-      // contract at the boundary instead of letting cic render
-      // `net#{id}` for a payload that can't occur.
-      if (
-        typeof r.network_id !== "number" ||
-        typeof r.network_slug !== "string" ||
-        typeof r.visitors !== "number" ||
-        typeof r.users !== "number" ||
-        !isNullableNumber(r.max_concurrent_visitor_sessions) ||
-        !isNullableNumber(r.max_concurrent_user_sessions)
-      )
-        return null;
-      return {
-        kind: "cap_counts_changed",
-        network_id: r.network_id,
-        network_slug: r.network_slug,
-        visitors: r.visitors,
-        users: r.users,
-        max_concurrent_visitor_sessions: r.max_concurrent_visitor_sessions as number | null,
-        max_concurrent_user_sessions: r.max_concurrent_user_sessions as number | null,
-        at: r.at as string,
-      };
-    default:
-      return null;
-  }
+  return validate(S_AdminEventsWireEvent, dropUnrecognisedDetails(raw));
 }
 
 /**
  * Runtime narrower for the admin-channel `snapshot` push payload.
- * Validates the `{events: [...]}` outer shape AND every element.
- * Atomic: a single malformed element drops the whole snapshot (avoids
- * corrupting the audit ring with mid-shape rows). Caller drops + logs
- * on null.
+ * Validates the `{events: [...]}` outer shape AND every element. Atomic: a
+ * single malformed element drops the whole snapshot (avoids corrupting the
+ * audit ring with mid-shape rows) — a policy call, not a shape, which is why
+ * it is not `{ a: S_AdminEventsWireEvent }`. Caller drops + logs on null.
  */
 export function narrowAdminSnapshot(raw: unknown): AdminSnapshotPayload | null {
   if (typeof raw !== "object" || raw === null) return null;
@@ -987,20 +552,8 @@ export function narrowAdminSnapshot(raw: unknown): AdminSnapshotPayload | null {
 // `sessionLog.ts` extracts `.entry` and narrows it here. Same
 // boundary-validation contract as `narrowAdminEvent` — a malformed
 // live push (field missing / wrong-typed) drops instead of crashing
-// the store setter. `event` is validated against the closed
-// `SessionLogEvent` set so a version-skewed server that adds a new
-// kind drops (runtime mirror of the tsc-side literal union). #410 — the
-// set IS the codegen-emitted `SESSION_LOG_EVENT` const (mirror of
-// `Grappa.SessionLog.Wire` event closed set), not a hand copy.
-const VALID_SESSION_LOG_EVENTS: ReadonlySet<SessionLogEvent> = new Set(SESSION_LOG_EVENT);
+// the store setter.
 
-/**
- * Runtime narrower for a single `SessionLogWireT` row. Mirror of the
- * generated wire shape (`Grappa.SessionLog.Wire.t/0`). Returns the
- * typed row on success or `null` on any shape mismatch. Used by
- * `sessionLog.ts` on the live `session_log_event` push (the REST
- * snapshot trusts the server, same as the other `adminList*` helpers).
- */
 /**
  * Runtime narrower for the admin top bar's projection (`"overview"` push /
  * `GET /admin/overview`). Same REV-G H24 discipline as its siblings: the
@@ -1010,68 +563,35 @@ const VALID_SESSION_LOG_EVENTS: ReadonlySet<SessionLogEvent> = new Set(SESSION_L
  * `Grappa.AdminOverview.Wire` sends `nil` when `:cpu_sup` cannot be reached
  * because "cannot measure" is a different fact from "the box is idle";
  * demanding a number here would drop the whole payload exactly when the
- * sampler is down, blanking a bar whose other four stats are fine.
+ * sampler is down, blanking a bar whose other four stats are fine. #429 — the
+ * typespec already says `integer() | nil`, so the generated schema carries
+ * that nullability and no hand check has to remember it.
  */
 export function narrowAdminOverview(raw: unknown): AdminOverviewWireT | null {
-  if (typeof raw !== "object" || raw === null) return null;
-  const r = raw as Record<string, unknown>;
-  if (typeof r.visitors !== "object" || r.visitors === null) return null;
-  const v = r.visitors as Record<string, unknown>;
-  if (
-    typeof r.sessions !== "number" ||
-    typeof v.total !== "number" ||
-    typeof v.live !== "number" ||
-    typeof r.hostname !== "string" ||
-    !isNullableNumber(r.loadavg) ||
-    typeof r.version !== "string"
-  )
-    return null;
-  return {
-    sessions: r.sessions,
-    visitors: { total: v.total, live: v.live },
-    hostname: r.hostname,
-    loadavg: r.loadavg as number | null,
-    version: r.version,
-  };
+  return validate(S_AdminOverviewWireT, raw);
 }
 
+/**
+ * Runtime narrower for a single `SessionLogWireT` row. Mirror of the
+ * generated wire shape (`Grappa.SessionLog.Wire.t/0`). Returns the
+ * typed row on success or `null` on any shape mismatch. Used by
+ * `sessionLog.ts` on the live `session_log_event` push (the REST
+ * snapshot trusts the server, same as the other `adminList*` helpers).
+ *
+ * #618/#429 — `old_nick` is the second policy residue on this boundary (the
+ * first is `login_throttled`'s door/scope in `dropUnrecognisedDetails`). The
+ * server declares it REQUIRED and always sends it, so the typespec is right
+ * and the generated schema is right to demand it. But the field was ADDED
+ * after this shape shipped, and cic deploys independently of the server
+ * (`deploy-m42.sh --cic`): a cic ahead of its server would drop EVERY
+ * session-log row over one field the peer predates. That is the additive-only
+ * contract (#447) read from the client side, and no typespec can express it —
+ * "required of a current server, tolerated absent from an older one" is a
+ * statement about deploy skew, not about the shape. Default it and let the
+ * row through.
+ */
 export function narrowSessionLogEntry(raw: unknown): SessionLogWireT | null {
-  if (typeof raw !== "object" || raw === null) return null;
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
   const r = raw as Record<string, unknown>;
-  if (
-    typeof r.id !== "number" ||
-    typeof r.session_id !== "string" ||
-    typeof r.event !== "string" ||
-    !VALID_SESSION_LOG_EVENTS.has(r.event as SessionLogEvent) ||
-    typeof r.subject_kind !== "string" ||
-    !VALID_SUBJECT_KINDS.has(r.subject_kind as "user" | "visitor") ||
-    typeof r.network_id !== "number" ||
-    !isNullableString(r.network_slug) ||
-    !isNullableString(r.nick) ||
-    // #618 — added after #215 shipped this shape, so absent is tolerated.
-    !isAddedNullableString(r.old_nick) ||
-    !isNullableString(r.reason) ||
-    !isNullableBoolean(r.clean) ||
-    !isNullableNumber(r.duration_ms) ||
-    !isNullableNumber(r.delay_ms) ||
-    !isNullableNumber(r.attempt) ||
-    typeof r.at !== "string"
-  )
-    return null;
-  return {
-    id: r.id,
-    session_id: r.session_id,
-    event: r.event as SessionLogEvent,
-    subject_kind: r.subject_kind as "user" | "visitor",
-    network_id: r.network_id,
-    network_slug: r.network_slug as string | null,
-    nick: r.nick as string | null,
-    old_nick: (r.old_nick ?? null) as string | null,
-    reason: r.reason as string | null,
-    clean: r.clean as boolean | null,
-    duration_ms: r.duration_ms as number | null,
-    delay_ms: r.delay_ms as number | null,
-    attempt: r.attempt as number | null,
-    at: r.at,
-  };
+  return validate(S_SessionLogWireT, r.old_nick === undefined ? { ...r, old_nick: null } : r);
 }

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -466,7 +466,7 @@ export const S_AdminOverviewWireT = {
 // Grappa.Admission.NetworkCircuit.AdminWire.t/0
 export const S_AdmissionNetworkCircuitAdminWireT = {
   o: {
-    state: "s",
+    state: { e: ["closed", "open"] },
     failure_count: "i",
     window_start_ms: "i",
     cooled_at_ms: "i",
@@ -1296,7 +1296,7 @@ export const S_SessionLogWireListResult = { o: { session_log: { a: S_SessionLogW
 
 // Grappa.SubjectSearch.AdminWire.result_json/0
 export const S_SubjectSearchAdminWireResultJson = {
-  o: { type: "s", id: "s", network: { u: ["s", "z"] }, nick: "s" },
+  o: { type: { e: ["user", "visitor"] }, id: "s", network: { u: ["s", "z"] }, nick: "s" },
 } as const;
 
 // Grappa.Themes.Wire.t/0
@@ -1317,7 +1317,7 @@ export const S_ThemesWireT = {
 
 // Grappa.Vhosts.AdminWire.grant_json/0
 export const S_VhostsAdminWireGrantJson = {
-  o: { id: "i", vhost_id: "i", subject_type: "s", subject_id: "s" },
+  o: { id: "i", vhost_id: "i", subject_type: { e: ["user", "visitor"] }, subject_id: "s" },
 } as const;
 
 // Grappa.Vhosts.AdminWire.vhost_json/0

--- a/cicchetto/src/lib/wireSchema.ts
+++ b/cicchetto/src/lib/wireSchema.ts
@@ -1,0 +1,1496 @@
+// GENERATED FILE — DO NOT EDIT
+// Run `scripts/mix.sh grappa.gen_wire_types` to regenerate.
+// Source: lib/grappa/**/*wire.ex + lib/grappa_web/error_tokens.ex
+//
+// #429 — the RUNTIME twin of `wireTypes.ts`: the same typespecs, emitted
+// as schema literals `wireValidate.ts` interprets. `wireTypes.ts` is
+// erased by tsc; these survive to the WS/REST boundary. Consts are in
+// topological order because a forward reference would hit the TDZ.
+//
+// Node grammar: see `wireValidate.ts`.
+
+import {
+  ADMIN_EVENTS_WIRE_EVENT_KIND,
+  ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_DOOR,
+  ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_SCOPE,
+  ADMISSION_FLOW,
+  CHANNEL_DIRECTORY_STATUS,
+  ERROR_TOKENS_SHARED_ERROR_TOKEN,
+  IRCAUTH_FSMAUTH_METHOD,
+  LIVE_INTROSPECTION_SESSION_ENTRY_DEGRADED_FIELD,
+  NETWORKS_CREDENTIAL_CONNECTION_STATE,
+  NETWORKS_CREDENTIALS_ADMIN_WIRE_SESSION_ACTION,
+  NETWORKS_NETWORK_SERVICES_FLAVOR,
+  SCROLLBACK_MESSAGE_KIND,
+  SESSION_LOG_EVENT,
+  SESSION_WIRE_RECOVER_OUTCOME,
+  SESSION_WIRE_RECOVER_REASON,
+  SESSION_WIRE_RECOVER_STATUS,
+  SESSION_WIRE_RECOVER_STEP,
+  SESSION_WIRE_SERVER_REPLY_SOURCE,
+  SESSION_WIRE_WIRE_EVENT_KIND,
+  WINDOW_COUNTS_SEVERITY,
+} from "./wireTypes";
+
+// Grappa.Accounts.AdminWire.t/0
+export const S_AccountsAdminWireT = {
+  o: {
+    id: "s",
+    name: "s",
+    is_admin: "b",
+    inserted_at: "s",
+    updated_at: "s",
+    live_session_count: "i",
+  },
+} as const;
+
+// Grappa.Accounts.Wire.credential_json/0
+export const S_AccountsWireCredentialJson = { o: { id: "s", name: "s" } } as const;
+
+// Grappa.Accounts.Wire.user_json/0
+export const S_AccountsWireUserJson = {
+  o: { id: "s", name: "s", is_admin: "b", inserted_at: "s" },
+} as const;
+
+// Grappa.AdminEvents.Wire.cap_counts_changed_event/0
+export const S_AdminEventsWireCapCountsChangedEvent = {
+  o: {
+    kind: { l: "cap_counts_changed" },
+    network_id: "i",
+    network_slug: "s",
+    visitors: "i",
+    users: "i",
+    max_concurrent_visitor_sessions: { u: ["i", "z"] },
+    max_concurrent_user_sessions: { u: ["i", "z"] },
+    at: "s",
+  },
+} as const;
+
+// Grappa.Admission.flow/0
+export const S_AdmissionFlow = { e: [...ADMISSION_FLOW] } as const;
+
+// Grappa.AdminEvents.Wire.capacity_reject_event/0
+export const S_AdminEventsWireCapacityRejectEvent = {
+  o: {
+    kind: { l: "capacity_reject" },
+    flow: S_AdmissionFlow,
+    error: "s",
+    network_id: "i",
+    network_slug: { u: ["s", "z"] },
+    source_ip: { u: ["s", "z"] },
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.circuit_close_event/0
+export const S_AdminEventsWireCircuitCloseEvent = {
+  o: {
+    kind: { l: "circuit_close" },
+    network_id: "i",
+    network_slug: { u: ["s", "z"] },
+    reason: { e: ["success", "cooldown_expired"] },
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.circuit_open_event/0
+export const S_AdminEventsWireCircuitOpenEvent = {
+  o: {
+    kind: { l: "circuit_open" },
+    network_id: "i",
+    network_slug: { u: ["s", "z"] },
+    threshold: "i",
+    cooldown_ms: "i",
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.circuit_reset_event/0
+export const S_AdminEventsWireCircuitResetEvent = {
+  o: {
+    kind: { l: "circuit_reset" },
+    network_id: "i",
+    network_slug: { u: ["s", "z"] },
+    actor_user_id: { u: ["s", "z"] },
+    actor_user_name: { u: ["s", "z"] },
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.credential_bound_event/0
+export const S_AdminEventsWireCredentialBoundEvent = {
+  o: {
+    kind: { l: "credential_bound" },
+    user_id: "s",
+    user_name: "s",
+    network_id: "i",
+    network_slug: "s",
+    nick: "s",
+    actor_user_id: "s",
+    actor_user_name: "s",
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.credential_unbound_event/0
+export const S_AdminEventsWireCredentialUnboundEvent = {
+  o: {
+    kind: { l: "credential_unbound" },
+    user_id: "s",
+    user_name: "s",
+    network_id: "i",
+    network_slug: "s",
+    actor_user_id: "s",
+    actor_user_name: "s",
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.credential_updated_event/0
+export const S_AdminEventsWireCredentialUpdatedEvent = {
+  o: {
+    kind: { l: "credential_updated" },
+    user_id: "s",
+    user_name: "s",
+    network_id: "i",
+    network_slug: "s",
+    session_action: { e: ["left_alone", "stopped"] },
+    actor_user_id: "s",
+    actor_user_name: "s",
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.login_throttle_door/0
+export const S_AdminEventsWireLoginThrottleDoor = {
+  e: [...ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_DOOR],
+} as const;
+
+// Grappa.AdminEvents.Wire.login_throttle_scope/0
+export const S_AdminEventsWireLoginThrottleScope = {
+  e: [...ADMIN_EVENTS_WIRE_LOGIN_THROTTLE_SCOPE],
+} as const;
+
+// Grappa.AdminEvents.Wire.login_throttled_event/0
+export const S_AdminEventsWireLoginThrottledEvent = {
+  o: {
+    kind: { l: "login_throttled" },
+    source_ip: { u: ["s", "z"] },
+    failures: "i",
+    window_ms: "i",
+    at: "s",
+    door: S_AdminEventsWireLoginThrottleDoor,
+    scope: S_AdminEventsWireLoginThrottleScope,
+  },
+  q: ["door", "scope"],
+} as const;
+
+// Grappa.AdminEvents.Wire.network_caps_updated_event/0
+export const S_AdminEventsWireNetworkCapsUpdatedEvent = {
+  o: {
+    kind: { l: "network_caps_updated" },
+    network_id: "i",
+    network_slug: "s",
+    max_concurrent_visitor_sessions: { u: ["i", "z"] },
+    max_concurrent_user_sessions: { u: ["i", "z"] },
+    max_per_ip: { u: ["i", "z"] },
+    actor_user_id: { u: ["s", "z"] },
+    actor_user_name: { u: ["s", "z"] },
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.network_created_event/0
+export const S_AdminEventsWireNetworkCreatedEvent = {
+  o: {
+    kind: { l: "network_created" },
+    network_id: "i",
+    network_slug: "s",
+    actor_user_id: "s",
+    actor_user_name: "s",
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.network_deleted_event/0
+export const S_AdminEventsWireNetworkDeletedEvent = {
+  o: {
+    kind: { l: "network_deleted" },
+    network_id: "i",
+    network_slug: "s",
+    actor_user_id: "s",
+    actor_user_name: "s",
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.reaper_swept_event/0
+export const S_AdminEventsWireReaperSweptEvent = {
+  o: { kind: { l: "reaper_swept" }, count: "i", at: "s" },
+} as const;
+
+// Grappa.AdminEvents.Wire.server_added_event/0
+export const S_AdminEventsWireServerAddedEvent = {
+  o: {
+    kind: { l: "server_added" },
+    network_id: "i",
+    network_slug: "s",
+    server_id: "i",
+    host: "s",
+    port: "i",
+    tls: "b",
+    actor_user_id: "s",
+    actor_user_name: "s",
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.server_removed_event/0
+export const S_AdminEventsWireServerRemovedEvent = {
+  o: {
+    kind: { l: "server_removed" },
+    network_id: "i",
+    network_slug: "s",
+    server_id: "i",
+    host: "s",
+    port: "i",
+    actor_user_id: "s",
+    actor_user_name: "s",
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.server_updated_event/0
+export const S_AdminEventsWireServerUpdatedEvent = {
+  o: {
+    kind: { l: "server_updated" },
+    network_id: "i",
+    network_slug: "s",
+    server_id: "i",
+    host: "s",
+    port: "i",
+    tls: "b",
+    actor_user_id: "s",
+    actor_user_name: "s",
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.session_disconnected_event/0
+export const S_AdminEventsWireSessionDisconnectedEvent = {
+  o: {
+    kind: { l: "session_disconnected" },
+    subject_kind: { e: ["user", "visitor"] },
+    subject_id: "s",
+    network_id: "i",
+    network_slug: { u: ["s", "z"] },
+    actor_user_id: { u: ["s", "z"] },
+    actor_user_name: { u: ["s", "z"] },
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.session_terminated_event/0
+export const S_AdminEventsWireSessionTerminatedEvent = {
+  o: {
+    kind: { l: "session_terminated" },
+    subject_kind: { e: ["user", "visitor"] },
+    subject_id: "s",
+    network_id: "i",
+    network_slug: { u: ["s", "z"] },
+    actor_user_id: { u: ["s", "z"] },
+    actor_user_name: { u: ["s", "z"] },
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.upload_reaped_event/0
+export const S_AdminEventsWireUploadReapedEvent = {
+  o: {
+    kind: { l: "upload_reaped" },
+    upload_id: "s",
+    slug: "s",
+    subject_kind: { e: ["user", "visitor"] },
+    subject_id: "s",
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.uploads_swept_event/0
+export const S_AdminEventsWireUploadsSweptEvent = {
+  o: { kind: { l: "uploads_swept" }, count: "i", at: "s" },
+} as const;
+
+// Grappa.AdminEvents.Wire.user_created_event/0
+export const S_AdminEventsWireUserCreatedEvent = {
+  o: {
+    kind: { l: "user_created" },
+    user_id: "s",
+    user_name: "s",
+    is_admin: "b",
+    actor_user_id: "s",
+    actor_user_name: "s",
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.user_deleted_event/0
+export const S_AdminEventsWireUserDeletedEvent = {
+  o: {
+    kind: { l: "user_deleted" },
+    user_id: "s",
+    user_name: "s",
+    actor_user_id: "s",
+    actor_user_name: "s",
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.user_password_changed_event/0
+export const S_AdminEventsWireUserPasswordChangedEvent = {
+  o: {
+    kind: { l: "user_password_changed" },
+    user_id: "s",
+    user_name: "s",
+    actor_user_id: "s",
+    actor_user_name: "s",
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.user_updated_event/0
+export const S_AdminEventsWireUserUpdatedEvent = {
+  o: {
+    kind: { l: "user_updated" },
+    user_id: "s",
+    user_name: "s",
+    is_admin: "b",
+    actor_user_id: "s",
+    actor_user_name: "s",
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.visitor_deleted_event/0
+export const S_AdminEventsWireVisitorDeletedEvent = {
+  o: {
+    kind: { l: "visitor_deleted" },
+    visitor_id: "s",
+    visitor_nick: { u: ["s", "z"] },
+    actor_user_id: { u: ["s", "z"] },
+    actor_user_name: { u: ["s", "z"] },
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.visitor_reaped_event/0
+export const S_AdminEventsWireVisitorReapedEvent = {
+  o: { kind: { l: "visitor_reaped" }, visitor_id: "s", visitor_nick: { u: ["s", "z"] }, at: "s" },
+} as const;
+
+// Grappa.AdminEvents.Wire.visitor_share_token_minted_event/0
+export const S_AdminEventsWireVisitorShareTokenMintedEvent = {
+  o: {
+    kind: { l: "visitor_share_token_minted" },
+    visitor_id: "s",
+    visitor_nick: { u: ["s", "z"] },
+    actor_user_id: "s",
+    actor_user_name: "s",
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.web_session_severed_event/0
+export const S_AdminEventsWireWebSessionSeveredEvent = {
+  o: {
+    kind: { l: "web_session_severed" },
+    subject_kind: { e: ["user", "visitor"] },
+    subject_id: "s",
+    failures: "i",
+    window_ms: "i",
+    at: "s",
+  },
+} as const;
+
+// Grappa.AdminEvents.Wire.event/0
+export const S_AdminEventsWireEvent = {
+  u: [
+    S_AdminEventsWireCircuitOpenEvent,
+    S_AdminEventsWireCircuitCloseEvent,
+    S_AdminEventsWireCapacityRejectEvent,
+    S_AdminEventsWireVisitorDeletedEvent,
+    S_AdminEventsWireVisitorReapedEvent,
+    S_AdminEventsWireVisitorShareTokenMintedEvent,
+    S_AdminEventsWireReaperSweptEvent,
+    S_AdminEventsWireUploadReapedEvent,
+    S_AdminEventsWireUploadsSweptEvent,
+    S_AdminEventsWireSessionDisconnectedEvent,
+    S_AdminEventsWireSessionTerminatedEvent,
+    S_AdminEventsWireNetworkCapsUpdatedEvent,
+    S_AdminEventsWireCircuitResetEvent,
+    S_AdminEventsWireCapCountsChangedEvent,
+    S_AdminEventsWireUserCreatedEvent,
+    S_AdminEventsWireUserUpdatedEvent,
+    S_AdminEventsWireUserPasswordChangedEvent,
+    S_AdminEventsWireUserDeletedEvent,
+    S_AdminEventsWireNetworkCreatedEvent,
+    S_AdminEventsWireNetworkDeletedEvent,
+    S_AdminEventsWireServerAddedEvent,
+    S_AdminEventsWireServerUpdatedEvent,
+    S_AdminEventsWireServerRemovedEvent,
+    S_AdminEventsWireCredentialBoundEvent,
+    S_AdminEventsWireCredentialUpdatedEvent,
+    S_AdminEventsWireCredentialUnboundEvent,
+    S_AdminEventsWireLoginThrottledEvent,
+    S_AdminEventsWireWebSessionSeveredEvent,
+  ],
+} as const;
+
+// Grappa.AdminEvents.Wire.event_kind/0
+export const S_AdminEventsWireEventKind = { e: [...ADMIN_EVENTS_WIRE_EVENT_KIND] } as const;
+
+// Grappa.AdminOverview.Wire.visitors/0
+export const S_AdminOverviewWireVisitors = { o: { total: "i", live: "i" } } as const;
+
+// Grappa.AdminOverview.Wire.t/0
+export const S_AdminOverviewWireT = {
+  o: {
+    sessions: "i",
+    visitors: S_AdminOverviewWireVisitors,
+    hostname: "s",
+    loadavg: { u: ["i", "z"] },
+    version: "s",
+  },
+} as const;
+
+// Grappa.Admission.NetworkCircuit.AdminWire.t/0
+export const S_AdmissionNetworkCircuitAdminWireT = {
+  o: {
+    state: "s",
+    failure_count: "i",
+    window_start_ms: "i",
+    cooled_at_ms: "i",
+    retry_after_seconds: "i",
+  },
+} as const;
+
+// Grappa.ChannelDirectory.Wire.entry/0
+export const S_ChannelDirectoryWireEntry = {
+  o: { name: "s", topic: { u: ["s", "z"] }, user_count: "i", featured: "b" },
+} as const;
+
+// Grappa.ChannelDirectory.status/0
+export const S_ChannelDirectoryStatus = { e: [...CHANNEL_DIRECTORY_STATUS] } as const;
+
+// Grappa.ChannelDirectory.Wire.index_payload/0
+export const S_ChannelDirectoryWireIndexPayload = {
+  o: {
+    entries: { a: S_ChannelDirectoryWireEntry },
+    next_cursor: { u: ["s", "z"] },
+    total: "i",
+    captured_at: { u: ["s", "z"] },
+    status: S_ChannelDirectoryStatus,
+  },
+} as const;
+
+// Grappa.Cic.Wire.bundle_hash_payload/0
+export const S_CicWireBundleHashPayload = {
+  o: { kind: { l: "bundle_hash" }, hash: "s", version: "s" },
+  q: ["version"],
+} as const;
+
+// Grappa.IRC.AuthFSM.auth_method/0
+export const S_IRCAuthFSMAuthMethod = { e: [...IRCAUTH_FSMAUTH_METHOD] } as const;
+
+// Grappa.LiveIntrospection.SessionEntry.degraded_field/0
+export const S_LiveIntrospectionSessionEntryDegradedField = {
+  e: [...LIVE_INTROSPECTION_SESSION_ENTRY_DEGRADED_FIELD],
+} as const;
+
+// Grappa.LiveIntrospection.AdminWire.live_state_json/0
+export const S_LiveIntrospectionAdminWireLiveStateJson = {
+  o: {
+    nick: { u: ["s", "z"] },
+    alive: "b",
+    pid_inspect: "s",
+    mailbox_len: "i",
+    memory_bytes: "i",
+    joined_channels: { u: [{ a: "s" }, "z"] },
+    peer_address: { u: ["s", "z"] },
+    peer_port: { u: ["i", "z"] },
+    peer_name: { u: ["s", "z"] },
+    introspection_degraded: { a: S_LiveIntrospectionSessionEntryDegradedField },
+  },
+} as const;
+
+// Grappa.LiveIntrospection.AdminWire.t/0
+export const S_LiveIntrospectionAdminWireT = {
+  o: {
+    subject_kind: { e: ["user", "visitor"] },
+    subject_id: "s",
+    subject_label: { u: ["s", "z"] },
+    last_seen_at: { u: ["s", "z"] },
+    network_id: "i",
+    live_state: S_LiveIntrospectionAdminWireLiveStateJson,
+  },
+} as const;
+
+// Grappa.Networks.Network.services_flavor/0
+export const S_NetworksNetworkServicesFlavor = {
+  e: [...NETWORKS_NETWORK_SERVICES_FLAVOR],
+} as const;
+
+// Grappa.Networks.AdminWire.t/0
+export const S_NetworksAdminWireT = {
+  o: {
+    id: "i",
+    slug: "s",
+    services_flavor: { u: [S_NetworksNetworkServicesFlavor, "z"] },
+    visitor_enabled: "b",
+    visitor_autoconnect: "b",
+    max_concurrent_visitor_sessions: { u: ["i", "z"] },
+    max_concurrent_user_sessions: { u: ["i", "z"] },
+    max_per_ip: { u: ["i", "z"] },
+    inserted_at: "s",
+    updated_at: "s",
+  },
+} as const;
+
+// Grappa.Networks.Credential.auth_method/0
+export const S_NetworksCredentialAuthMethod = S_IRCAuthFSMAuthMethod;
+
+// Grappa.Networks.Credential.connection_state/0
+export const S_NetworksCredentialConnectionState = {
+  e: [...NETWORKS_CREDENTIAL_CONNECTION_STATE],
+} as const;
+
+// Grappa.Networks.Credentials.AdminWire.live_state_json/0
+export const S_NetworksCredentialsAdminWireLiveStateJson = {
+  o: {
+    nick: { u: ["s", "z"] },
+    alive: "b",
+    pid_inspect: "s",
+    mailbox_len: "i",
+    memory_bytes: "i",
+    joined_channels: { u: [{ a: "s" }, "z"] },
+    introspection_degraded: { a: S_LiveIntrospectionSessionEntryDegradedField },
+  },
+} as const;
+
+// Grappa.Networks.Credentials.AdminWire.session_action/0
+export const S_NetworksCredentialsAdminWireSessionAction = {
+  e: [...NETWORKS_CREDENTIALS_ADMIN_WIRE_SESSION_ACTION],
+} as const;
+
+// Grappa.Networks.Credentials.AdminWire.t/0
+export const S_NetworksCredentialsAdminWireT = {
+  o: {
+    user_id: "s",
+    network_id: "i",
+    network_slug: "s",
+    nick: "s",
+    ident: { u: ["s", "z"] },
+    realname: { u: ["s", "z"] },
+    sasl_user: { u: ["s", "z"] },
+    auth_method: S_NetworksCredentialAuthMethod,
+    auth_command_template: { u: ["s", "z"] },
+    autojoin_channels: { a: "s" },
+    last_joined_channels: { a: "s" },
+    connection_state: S_NetworksCredentialConnectionState,
+    connection_state_reason: { u: ["s", "z"] },
+    connection_state_changed_at: { u: ["s", "z"] },
+    inserted_at: "s",
+    updated_at: "s",
+    live_state: { u: [S_NetworksCredentialsAdminWireLiveStateJson, "z"] },
+  },
+} as const;
+
+// Grappa.Networks.FeaturedChannels.AdminWire.t/0
+export const S_NetworksFeaturedChannelsAdminWireT = {
+  o: {
+    id: "i",
+    network_id: "i",
+    name: "s",
+    description: { u: ["s", "z"] },
+    position: "i",
+    enabled: "b",
+    inserted_at: "s",
+    updated_at: "s",
+  },
+} as const;
+
+// Grappa.Networks.FeaturedChannels.Wire.link/0
+export const S_NetworksFeaturedChannelsWireLink = {
+  o: { name: "s", description: { u: ["s", "z"] } },
+} as const;
+
+// Grappa.Networks.FeaturedChannels.Wire.index_payload/0
+export const S_NetworksFeaturedChannelsWireIndexPayload = {
+  o: { channels: { a: S_NetworksFeaturedChannelsWireLink } },
+} as const;
+
+// Grappa.Networks.Servers.AdminWire.t/0
+export const S_NetworksServersAdminWireT = {
+  o: {
+    id: "i",
+    network_id: "i",
+    host: "s",
+    port: "i",
+    tls: "b",
+    priority: "i",
+    enabled: "b",
+    source_address: { u: ["s", "z"] },
+    inserted_at: "s",
+    updated_at: "s",
+  },
+} as const;
+
+// Grappa.Networks.Wire.available_network_row/0
+export const S_NetworksWireAvailableNetworkRow = { o: { slug: "s" } } as const;
+
+// Grappa.Networks.Wire.channel_json/0
+export const S_NetworksWireChannelJson = {
+  o: { name: "s", joined: "b", source: { e: ["autojoin", "joined"] } },
+} as const;
+
+// Grappa.Networks.Wire.connection_info/0
+export const S_NetworksWireConnectionInfo = {
+  o: { server: "s", port: "i", tls: "b", registered: "b", connected_at: { u: ["s", "z"] } },
+} as const;
+
+// Grappa.Networks.Wire.home_network_row/0
+export const S_NetworksWireHomeNetworkRow = {
+  o: {
+    slug: "s",
+    nick: "s",
+    connection_state: S_NetworksCredentialConnectionState,
+    connection_state_reason: { u: ["s", "z"] },
+    connection_state_changed_at: { u: ["s", "z"] },
+    recoverable: "b",
+  },
+} as const;
+
+// Grappa.Networks.Wire.connection_state_event/0
+export const S_NetworksWireConnectionStateEvent = {
+  o: {
+    kind: { l: "connection_state_changed" },
+    user_id: { u: ["s", "z"] },
+    network_id: "i",
+    network_slug: "s",
+    from: S_NetworksCredentialConnectionState,
+    to: S_NetworksCredentialConnectionState,
+    reason: { u: ["s", "z"] },
+    at: { u: ["s", "z"] },
+    network: S_NetworksWireHomeNetworkRow,
+  },
+} as const;
+
+// Grappa.Networks.Wire.credential_json/0
+export const S_NetworksWireCredentialJson = {
+  o: {
+    network: "s",
+    nick: "s",
+    ident: { u: ["s", "z"] },
+    realname: { u: ["s", "z"] },
+    sasl_user: { u: ["s", "z"] },
+    auth_method: S_NetworksCredentialAuthMethod,
+    auth_command_template: { u: ["s", "z"] },
+    autojoin_channels: { a: "s" },
+    connection_state: S_NetworksCredentialConnectionState,
+    connection_state_reason: { u: ["s", "z"] },
+    connection_state_changed_at: { u: ["s", "z"] },
+    inserted_at: "s",
+    updated_at: "s",
+  },
+} as const;
+
+// Grappa.Networks.Wire.home_data/0
+export const S_NetworksWireHomeData = {
+  o: {
+    networks: { a: S_NetworksWireHomeNetworkRow },
+    available_networks: { a: S_NetworksWireAvailableNetworkRow },
+  },
+} as const;
+
+// Grappa.Networks.Wire.network_with_nick_json/0
+export const S_NetworksWireNetworkWithNickJson = {
+  o: {
+    kind: { l: "user" },
+    id: "i",
+    slug: "s",
+    services_flavor: { u: [S_NetworksNetworkServicesFlavor, "z"] },
+    nick: "s",
+    ident: { u: ["s", "z"] },
+    realname: { u: ["s", "z"] },
+    connection_state: S_NetworksCredentialConnectionState,
+    connection_state_reason: { u: ["s", "z"] },
+    connection_state_changed_at: { u: ["s", "z"] },
+    connection: { u: [S_NetworksWireConnectionInfo, "z"] },
+    inserted_at: "s",
+    updated_at: "s",
+  },
+} as const;
+
+// Grappa.Networks.Wire.visitor_network_with_nick_json/0
+export const S_NetworksWireVisitorNetworkWithNickJson = {
+  o: {
+    kind: { l: "visitor" },
+    id: "i",
+    slug: "s",
+    services_flavor: { u: [S_NetworksNetworkServicesFlavor, "z"] },
+    nick: "s",
+    ident: { u: ["s", "z"] },
+    realname: { u: ["s", "z"] },
+    connection_state: S_NetworksCredentialConnectionState,
+    connection_state_reason: { u: ["s", "z"] },
+    connection_state_changed_at: { u: ["s", "z"] },
+    connection: { u: [S_NetworksWireConnectionInfo, "z"] },
+    inserted_at: "s",
+    updated_at: "s",
+  },
+} as const;
+
+// Grappa.Notify.Wire.entry/0
+export const S_NotifyWireEntry = { o: { network_id: "i", nick: "s", added_at: "s" } } as const;
+
+// Grappa.Notify.Wire.entries_map/0
+export const S_NotifyWireEntriesMap = { r: { a: S_NotifyWireEntry } } as const;
+
+// Grappa.Notify.Wire.notify_list_payload/0
+export const S_NotifyWireNotifyListPayload = {
+  o: { kind: { l: "notify_list" }, networks: S_NotifyWireEntriesMap },
+} as const;
+
+// Grappa.QueryWindows.Wire.windows_entry/0
+export const S_QueryWindowsWireWindowsEntry = {
+  o: { network_id: "i", target_nick: "s", opened_at: "s" },
+} as const;
+
+// Grappa.QueryWindows.Wire.windows_map/0
+export const S_QueryWindowsWireWindowsMap = { r: { a: S_QueryWindowsWireWindowsEntry } } as const;
+
+// Grappa.QueryWindows.Wire.windows_list_payload/0
+export const S_QueryWindowsWireWindowsListPayload = {
+  o: { kind: { l: "query_windows_list" }, windows: S_QueryWindowsWireWindowsMap },
+} as const;
+
+// Grappa.RateLimit.Wire.web_session_severed_event/0
+export const S_RateLimitWireWebSessionSeveredEvent = {
+  o: { kind: { l: "web_session_severed" }, code: { l: "rate_limit_flood" } },
+} as const;
+
+// Grappa.ReadCursor.Wire.read_cursor_set/0
+export const S_ReadCursorWireReadCursorSet = {
+  o: { kind: { l: "read_cursor_set" }, last_read_message_id: "i", badge_count: "i" },
+} as const;
+
+// Grappa.Scrollback.Message.kind/0
+export const S_ScrollbackMessageKind = { e: [...SCROLLBACK_MESSAGE_KIND] } as const;
+
+// Grappa.Scrollback.Meta.t/0
+export const S_ScrollbackMetaT = { r: "x" } as const;
+
+// Grappa.Scrollback.Wire.archive_changed_payload/0
+export const S_ScrollbackWireArchiveChangedPayload = {
+  o: { kind: { l: "archive_changed" }, network_slug: "s" },
+} as const;
+
+// Grappa.Scrollback.Wire.archive_purged_payload/0
+export const S_ScrollbackWireArchivePurgedPayload = {
+  o: { kind: { l: "archive_purged" }, network_slug: "s", target: "s" },
+} as const;
+
+// Grappa.Scrollback.Wire.archive_wire_entry/0
+export const S_ScrollbackWireArchiveWireEntry = {
+  o: { target: "s", kind: { e: ["channel", "query"] }, last_activity: "i", row_count: "i" },
+} as const;
+
+// Grappa.Scrollback.Wire.archive_wire_index/0
+export const S_ScrollbackWireArchiveWireIndex = {
+  o: { archive: { a: S_ScrollbackWireArchiveWireEntry } },
+} as const;
+
+// Grappa.Scrollback.Wire.t/0
+export const S_ScrollbackWireT = {
+  o: {
+    id: "i",
+    network: "s",
+    channel: "s",
+    server_time: "i",
+    kind: S_ScrollbackMessageKind,
+    sender: "s",
+    body: { u: ["s", "z"] },
+    meta: S_ScrollbackMetaT,
+  },
+} as const;
+
+// Grappa.Scrollback.Wire.event/0
+export const S_ScrollbackWireEvent = {
+  o: { kind: { l: "message" }, message: S_ScrollbackWireT },
+} as const;
+
+// Grappa.ServerSettings.Wire.upload_view/0
+export const S_ServerSettingsWireUploadView = {
+  o: {
+    active_host: { e: ["embedded", "litterbox"] },
+    image_per_file_cap_bytes: "i",
+    video_per_file_cap_bytes: "i",
+    document_per_file_cap_bytes: "i",
+    audio_per_file_cap_bytes: "i",
+    global_cap_bytes: "i",
+  },
+} as const;
+
+// Grappa.ServerSettings.Wire.changed_payload/0
+export const S_ServerSettingsWireChangedPayload = {
+  o: {
+    kind: { l: "server_settings_changed" },
+    upload: S_ServerSettingsWireUploadView,
+    http_host_aliases: { a: "s" },
+  },
+} as const;
+
+// Grappa.Session.Wire.away_confirmed_payload/0
+export const S_SessionWireAwayConfirmedPayload = {
+  o: { kind: { l: "away_confirmed" }, network: "s", state: { e: ["present", "away"] } },
+} as const;
+
+// Grappa.Session.Wire.banlist_entry/0
+export const S_SessionWireBanlistEntry = {
+  o: { mask: "s", setter: { u: ["s", "z"] }, set_ts: { u: ["s", "z"] } },
+} as const;
+
+// Grappa.Session.Wire.banlist_bundle_payload/0
+export const S_SessionWireBanlistBundlePayload = {
+  o: {
+    kind: { l: "banlist_bundle" },
+    network: "s",
+    channel: "s",
+    entries: { a: S_SessionWireBanlistEntry },
+  },
+} as const;
+
+// Grappa.Session.Wire.channel_created_payload/0
+export const S_SessionWireChannelCreatedPayload = {
+  o: { kind: { l: "channel_created" }, network: "s", channel: "s", created_at: "s" },
+} as const;
+
+// Grappa.Session.Wire.channel_modes_wire/0
+export const S_SessionWireChannelModesWire = {
+  o: { modes: { a: "s" }, params: { r: { u: ["s", "z"] } } },
+} as const;
+
+// Grappa.Session.Wire.channel_modes_changed_payload/0
+export const S_SessionWireChannelModesChangedPayload = {
+  o: {
+    kind: { l: "channel_modes_changed" },
+    network: "s",
+    channel: "s",
+    modes: S_SessionWireChannelModesWire,
+  },
+} as const;
+
+// Grappa.Session.Wire.channels_changed_payload/0
+export const S_SessionWireChannelsChangedPayload = {
+  o: { kind: { l: "channels_changed" } },
+} as const;
+
+// Grappa.Session.Wire.connection_progress_payload/0
+export const S_SessionWireConnectionProgressPayload = {
+  o: {
+    kind: { l: "connection_progress" },
+    network: "s",
+    state: { e: ["connecting", "connected"] },
+  },
+} as const;
+
+// Grappa.Session.Wire.directory_complete_payload/0
+export const S_SessionWireDirectoryCompletePayload = {
+  o: { kind: { l: "directory_complete" }, network: "s", total: "i" },
+} as const;
+
+// Grappa.Session.Wire.directory_failed_payload/0
+export const S_SessionWireDirectoryFailedPayload = {
+  o: { kind: { l: "directory_failed" }, network: "s", reason: "s" },
+} as const;
+
+// Grappa.Session.Wire.directory_progress_payload/0
+export const S_SessionWireDirectoryProgressPayload = {
+  o: { kind: { l: "directory_progress" }, network: "s", count: "i" },
+} as const;
+
+// Grappa.Session.Wire.invite_ack_payload/0
+export const S_SessionWireInviteAckPayload = {
+  o: { kind: { l: "invite_ack" }, network: "s", channel: "s", peer: "s" },
+} as const;
+
+// Grappa.Session.Wire.isupport_changed_payload/0
+export const S_SessionWireIsupportChangedPayload = {
+  o: {
+    kind: { l: "isupport_changed" },
+    network_id: "i",
+    chanmodes_a: { a: "s" },
+    chanmodes_b: { a: "s" },
+    chanmodes_c: { a: "s" },
+    chanmodes_d: { a: "s" },
+    prefix: { r: "s" },
+  },
+} as const;
+
+// Grappa.Session.Wire.join_failed_payload/0
+export const S_SessionWireJoinFailedPayload = {
+  o: {
+    kind: { l: "join_failed" },
+    network: "s",
+    channel: "s",
+    state: { l: "failed" },
+    reason: { u: ["s", "z"] },
+    numeric: { u: ["i", "z"] },
+  },
+} as const;
+
+// Grappa.Session.Wire.joined_payload/0
+export const S_SessionWireJoinedPayload = {
+  o: { kind: { l: "joined" }, network: "s", channel: "s", state: { l: "joined" } },
+} as const;
+
+// Grappa.Session.Wire.kicked_payload/0
+export const S_SessionWireKickedPayload = {
+  o: {
+    kind: { l: "kicked" },
+    network: "s",
+    channel: "s",
+    state: { l: "kicked" },
+    by: { u: ["s", "z"] },
+    reason: { u: ["s", "z"] },
+  },
+} as const;
+
+// Grappa.Session.Wire.links_entry/0
+export const S_SessionWireLinksEntry = {
+  o: {
+    server: "s",
+    linked_to: { u: ["s", "z"] },
+    hopcount: { u: ["i", "z"] },
+    description: { u: ["s", "z"] },
+  },
+} as const;
+
+// Grappa.Session.Wire.links_bundle_payload/0
+export const S_SessionWireLinksBundlePayload = {
+  o: {
+    kind: { l: "links_bundle" },
+    network: "s",
+    mask: { u: ["s", "z"] },
+    entries: { a: S_SessionWireLinksEntry },
+  },
+} as const;
+
+// Grappa.Session.Wire.lusers_bundle_payload/0
+export const S_SessionWireLusersBundlePayload = {
+  o: {
+    kind: { l: "lusers_bundle" },
+    network: "s",
+    total_users: { u: ["i", "z"] },
+    invisible: { u: ["i", "z"] },
+    servers: { u: ["i", "z"] },
+    operators: { u: ["i", "z"] },
+    unknown_connections: { u: ["i", "z"] },
+    channels_formed: { u: ["i", "z"] },
+    local_clients: { u: ["i", "z"] },
+    local_servers: { u: ["i", "z"] },
+    current_local: { u: ["i", "z"] },
+    max_local: { u: ["i", "z"] },
+    current_global: { u: ["i", "z"] },
+    max_global: { u: ["i", "z"] },
+  },
+} as const;
+
+// Grappa.Session.Wire.member/0
+export const S_SessionWireMember = { o: { nick: "s", modes: { a: "s" } } } as const;
+
+// Grappa.Session.Wire.members_index_payload/0
+export const S_SessionWireMembersIndexPayload = {
+  o: { members: { a: S_SessionWireMember } },
+} as const;
+
+// Grappa.Session.Wire.members_seeded_payload/0
+export const S_SessionWireMembersSeededPayload = {
+  o: {
+    kind: { l: "members_seeded" },
+    network: "s",
+    channel: "s",
+    members: { a: S_SessionWireMember },
+  },
+} as const;
+
+// Grappa.Session.Wire.mentions_bundle_message/0
+export const S_SessionWireMentionsBundleMessage = {
+  o: {
+    server_time: "i",
+    channel: "s",
+    sender: "s",
+    body: { u: ["s", "z"] },
+    kind: S_ScrollbackMessageKind,
+  },
+} as const;
+
+// Grappa.Session.Wire.mentions_bundle_payload/0
+export const S_SessionWireMentionsBundlePayload = {
+  o: {
+    kind: { l: "mentions_bundle" },
+    network: "s",
+    away_started_at: "s",
+    away_ended_at: "s",
+    away_reason: { u: ["s", "z"] },
+    messages: { a: S_SessionWireMentionsBundleMessage },
+  },
+} as const;
+
+// Grappa.Session.Wire.names_reply_payload/0
+export const S_SessionWireNamesReplyPayload = {
+  o: {
+    kind: { l: "names_reply" },
+    network: "s",
+    channel: "s",
+    members: { a: S_SessionWireMember },
+  },
+} as const;
+
+// Grappa.Session.Wire.own_nick_changed_payload/0
+export const S_SessionWireOwnNickChangedPayload = {
+  o: { kind: { l: "own_nick_changed" }, network_id: "i", nick: "s" },
+} as const;
+
+// Grappa.Session.Wire.peer_away_payload/0
+export const S_SessionWirePeerAwayPayload = {
+  o: { kind: { l: "peer_away" }, network: "s", peer: "s", message: "s" },
+} as const;
+
+// Grappa.Session.Wire.presence_changed_payload/0
+export const S_SessionWirePresenceChangedPayload = {
+  o: {
+    kind: { l: "presence_changed" },
+    network_id: "i",
+    nick: "s",
+    presence: { e: ["online", "offline"] },
+    initial: "b",
+    source: { e: ["monitor", "watch"] },
+    ts: "s",
+  },
+} as const;
+
+// Grappa.Session.Wire.presence_error_payload/0
+export const S_SessionWirePresenceErrorPayload = {
+  o: { kind: { l: "presence_error" }, network_id: "i", reason: { l: "list_full" }, detail: "s" },
+} as const;
+
+// Grappa.Session.Wire.presence_snapshot_payload/0
+export const S_SessionWirePresenceSnapshotPayload = {
+  o: {
+    kind: { l: "presence_snapshot" },
+    network_id: "i",
+    nicks: { r: { e: ["online", "offline", "unknown"] } },
+  },
+} as const;
+
+// Grappa.Session.Wire.recover_outcome/0
+export const S_SessionWireRecoverOutcome = { e: [...SESSION_WIRE_RECOVER_OUTCOME] } as const;
+
+// Grappa.Session.Wire.recover_reason/0
+export const S_SessionWireRecoverReason = { e: [...SESSION_WIRE_RECOVER_REASON] } as const;
+
+// Grappa.Session.Wire.recover_status/0
+export const S_SessionWireRecoverStatus = { e: [...SESSION_WIRE_RECOVER_STATUS] } as const;
+
+// Grappa.Session.Wire.recover_step/0
+export const S_SessionWireRecoverStep = { e: [...SESSION_WIRE_RECOVER_STEP] } as const;
+
+// Grappa.Session.Wire.recover_progress_payload/0
+export const S_SessionWireRecoverProgressPayload = {
+  o: {
+    kind: { l: "recover_progress" },
+    network: "s",
+    step: S_SessionWireRecoverStep,
+    status: S_SessionWireRecoverStatus,
+    reason: { u: [S_SessionWireRecoverReason, "z"] },
+  },
+} as const;
+
+// Grappa.Session.Wire.recover_result_payload/0
+export const S_SessionWireRecoverResultPayload = {
+  o: {
+    kind: { l: "recover_result" },
+    network: "s",
+    outcome: S_SessionWireRecoverOutcome,
+    reason: { u: [S_SessionWireRecoverReason, "z"] },
+  },
+} as const;
+
+// Grappa.Session.Wire.server_reply_source/0
+export const S_SessionWireServerReplySource = { e: [...SESSION_WIRE_SERVER_REPLY_SOURCE] } as const;
+
+// Grappa.Session.Wire.server_reply_payload/0
+export const S_SessionWireServerReplyPayload = {
+  o: {
+    kind: { l: "server_reply" },
+    network: "s",
+    source: S_SessionWireServerReplySource,
+    lines: { a: "s" },
+  },
+} as const;
+
+// Grappa.Session.Wire.supported_umodes_changed_payload/0
+export const S_SessionWireSupportedUmodesChangedPayload = {
+  o: { kind: { l: "supported_umodes_changed" }, network_id: "i", modes: { a: "s" } },
+} as const;
+
+// Grappa.Session.Wire.topic_entry_wire/0
+export const S_SessionWireTopicEntryWire = {
+  o: { text: { u: ["s", "z"] }, set_by: { u: ["s", "z"] }, set_at: { u: ["s", "z"] } },
+} as const;
+
+// Grappa.Session.Wire.topic_changed_payload/0
+export const S_SessionWireTopicChangedPayload = {
+  o: {
+    kind: { l: "topic_changed" },
+    network: "s",
+    channel: "s",
+    topic: S_SessionWireTopicEntryWire,
+  },
+} as const;
+
+// Grappa.Session.Wire.umode_changed_payload/0
+export const S_SessionWireUmodeChangedPayload = {
+  o: { kind: { l: "umode_changed" }, network_id: "i", modes: { a: "s" } },
+} as const;
+
+// Grappa.Session.Wire.who_user/0
+export const S_SessionWireWhoUser = {
+  o: {
+    nick: "s",
+    user: "s",
+    host: "s",
+    server: "s",
+    modes: "s",
+    hops: { u: ["i", "z"] },
+    realname: { u: ["s", "z"] },
+    channel: "s",
+  },
+} as const;
+
+// Grappa.Session.Wire.who_reply_payload/0
+export const S_SessionWireWhoReplyPayload = {
+  o: { kind: { l: "who_reply" }, network: "s", target: "s", users: { a: S_SessionWireWhoUser } },
+} as const;
+
+// Grappa.Session.Wire.whois_extra_line/0
+export const S_SessionWireWhoisExtraLine = { o: { numeric: "i", text: "s" } } as const;
+
+// Grappa.Session.Wire.whois_bundle_payload/0
+export const S_SessionWireWhoisBundlePayload = {
+  o: {
+    kind: { l: "whois_bundle" },
+    network: "s",
+    target: "s",
+    source: { e: ["user", "rail"] },
+    user: { u: ["s", "z"] },
+    host: { u: ["s", "z"] },
+    realname: { u: ["s", "z"] },
+    server: { u: ["s", "z"] },
+    server_info: { u: ["s", "z"] },
+    is_operator: "b",
+    oper_text: { u: ["s", "z"] },
+    idle_seconds: { u: ["i", "z"] },
+    signon: { u: ["i", "z"] },
+    channels: { u: [{ a: "s" }, "z"] },
+    using_ssl: "b",
+    is_registered: "b",
+    is_admin: "b",
+    is_services_admin: "b",
+    is_helper: "b",
+    is_chanop: "b",
+    is_agent: "b",
+    is_java: "b",
+    umodes: { u: ["s", "z"] },
+    away_message: { u: ["s", "z"] },
+    actually_host: { u: ["s", "z"] },
+    actually_ip: { u: ["s", "z"] },
+    account: { u: ["s", "z"] },
+    secure: "b",
+    secure_cipher: { u: ["s", "z"] },
+    certfp: { u: ["s", "z"] },
+    extra_lines: { u: [{ a: S_SessionWireWhoisExtraLine }, "z"] },
+  },
+} as const;
+
+// Grappa.Session.Wire.whowas_bundle_payload/0
+export const S_SessionWireWhowasBundlePayload = {
+  o: {
+    kind: { l: "whowas_bundle" },
+    network: "s",
+    target: "s",
+    user: { u: ["s", "z"] },
+    host: { u: ["s", "z"] },
+    realname: { u: ["s", "z"] },
+    server: { u: ["s", "z"] },
+    logoff_time: { u: ["s", "z"] },
+    not_found: "b",
+  },
+} as const;
+
+// Grappa.Session.Wire.window_invite_declined_payload/0
+export const S_SessionWireWindowInviteDeclinedPayload = {
+  o: { kind: { l: "window_invite_declined" }, network: "s", channel: "s" },
+} as const;
+
+// Grappa.Session.Wire.window_invited_payload/0
+export const S_SessionWireWindowInvitedPayload = {
+  o: {
+    kind: { l: "window_invited" },
+    network: "s",
+    channel: "s",
+    state: { l: "invited" },
+    inviter: "s",
+  },
+} as const;
+
+// Grappa.Session.Wire.window_pending_payload/0
+export const S_SessionWireWindowPendingPayload = {
+  o: { kind: { l: "window_pending" }, network: "s", channel: "s", state: { l: "pending" } },
+} as const;
+
+// Grappa.Session.Wire.wire_event_kind/0
+export const S_SessionWireWireEventKind = { e: [...SESSION_WIRE_WIRE_EVENT_KIND] } as const;
+
+// Grappa.SessionLog.event/0
+export const S_SessionLogEvent = { e: [...SESSION_LOG_EVENT] } as const;
+
+// Grappa.SessionLog.Wire.t/0
+export const S_SessionLogWireT = {
+  o: {
+    id: "i",
+    session_id: "s",
+    event: S_SessionLogEvent,
+    subject_kind: { e: ["user", "visitor"] },
+    network_id: "i",
+    network_slug: { u: ["s", "z"] },
+    nick: { u: ["s", "z"] },
+    old_nick: { u: ["s", "z"] },
+    reason: { u: ["s", "z"] },
+    clean: { u: ["b", "z"] },
+    duration_ms: { u: ["i", "z"] },
+    delay_ms: { u: ["i", "z"] },
+    attempt: { u: ["i", "z"] },
+    at: "s",
+  },
+} as const;
+
+// Grappa.SessionLog.Wire.event/0
+export const S_SessionLogWireEvent = {
+  o: { kind: { l: "session_log_event" }, entry: S_SessionLogWireT },
+} as const;
+
+// Grappa.SessionLog.Wire.list_result/0
+export const S_SessionLogWireListResult = { o: { session_log: { a: S_SessionLogWireT } } } as const;
+
+// Grappa.SubjectSearch.AdminWire.result_json/0
+export const S_SubjectSearchAdminWireResultJson = {
+  o: { type: "s", id: "s", network: { u: ["s", "z"] }, nick: "s" },
+} as const;
+
+// Grappa.Themes.Wire.t/0
+export const S_ThemesWireT = {
+  o: {
+    id: "i",
+    name: "s",
+    author: "s",
+    built_in: "b",
+    published: "b",
+    apply_count: "i",
+    in_use: "i",
+    mine: "b",
+    payload: { r: "x" },
+    inserted_at: "s",
+  },
+} as const;
+
+// Grappa.Vhosts.AdminWire.grant_json/0
+export const S_VhostsAdminWireGrantJson = {
+  o: { id: "i", vhost_id: "i", subject_type: "s", subject_id: "s" },
+} as const;
+
+// Grappa.Vhosts.AdminWire.vhost_json/0
+export const S_VhostsAdminWireVhostJson = {
+  o: {
+    id: "i",
+    address: "s",
+    in_pool: "b",
+    generally_available: "b",
+    inserted_at: "s",
+    updated_at: "s",
+  },
+} as const;
+
+// Grappa.Visitors.AdminWire.live_state_json/0
+export const S_VisitorsAdminWireLiveStateJson = {
+  o: {
+    nick: { u: ["s", "z"] },
+    alive: "b",
+    pid_inspect: "s",
+    mailbox_len: "i",
+    memory_bytes: "i",
+    joined_channels: { u: [{ a: "s" }, "z"] },
+    introspection_degraded: { a: S_LiveIntrospectionSessionEntryDegradedField },
+  },
+} as const;
+
+// Grappa.Visitors.AdminWire.network_json/0
+export const S_VisitorsAdminWireNetworkJson = {
+  o: {
+    network_slug: "s",
+    network_id: "i",
+    nick: "s",
+    connection_state: S_NetworksCredentialConnectionState,
+    live_state: { u: [S_VisitorsAdminWireLiveStateJson, "z"] },
+  },
+} as const;
+
+// Grappa.Visitors.AdminWire.t/0
+export const S_VisitorsAdminWireT = {
+  o: {
+    id: "s",
+    expires_at: { u: ["s", "z"] },
+    identified: "b",
+    ip: { u: ["s", "z"] },
+    inserted_at: "s",
+    networks: { a: S_VisitorsAdminWireNetworkJson },
+  },
+} as const;
+
+// Grappa.Visitors.Wire.credential_json/0
+export const S_VisitorsWireCredentialJson = {
+  o: { id: "s", registered: "b", incognito: "b" },
+} as const;
+
+// Grappa.Visitors.Wire.t/0
+export const S_VisitorsWireT = {
+  o: { id: "s", expires_at: { u: ["s", "z"] }, registered: "b", incognito: "b" },
+} as const;
+
+// Grappa.WindowCounts.severity/0
+export const S_WindowCountsSeverity = { e: [...WINDOW_COUNTS_SEVERITY] } as const;
+
+// Grappa.WindowCounts.Wire.event/0
+export const S_WindowCountsWireEvent = {
+  o: {
+    kind: { l: "window_counts" },
+    channel: "s",
+    messages: "i",
+    mentions: "i",
+    events: "i",
+    severity: S_WindowCountsSeverity,
+  },
+} as const;
+
+// GrappaWeb.ErrorTokens.shared_error_token/0
+export const S_ErrorTokensSharedErrorToken = { e: [...ERROR_TOKENS_SHARED_ERROR_TOKEN] } as const;
+
+// GrappaWeb.ErrorTokens.channel_error_token/0
+export const S_ErrorTokensChannelErrorToken = {
+  u: [
+    S_ErrorTokensSharedErrorToken,
+    { l: "unknown_topic" },
+    { l: "invalid_payload" },
+    { l: "user_not_found" },
+    { l: "network_not_found" },
+    { l: "no_session" },
+    { l: "not_explicit" },
+    { l: "invalid_nick" },
+    { l: "not_cached" },
+    { l: "lookup_failed" },
+    { l: "open_failed" },
+    { l: "close_failed" },
+    { l: "unknown_event" },
+    { l: "save_failed" },
+    { l: "invalid_reason" },
+    { l: "invalid_mask" },
+    { l: "upstream_unavailable" },
+    { l: "persist_failed" },
+    { l: "invalid_channel" },
+    { l: "links_in_flight" },
+    { l: "nothing_to_recover" },
+    { l: "already_identified" },
+    { l: "recovery_in_progress" },
+    { l: "rate_limited" },
+  ],
+} as const;
+
+// GrappaWeb.ErrorTokens.rest_error_token/0
+export const S_ErrorTokensRestErrorToken = {
+  u: [
+    S_ErrorTokensSharedErrorToken,
+    { l: "bad_request" },
+    { l: "unauthorized" },
+    { l: "nickserv_pass_retired" },
+    { l: "file_too_large" },
+    { l: "metadata_strip_failed" },
+    { l: "insufficient_storage" },
+    { l: "unsupported_media_type" },
+    { l: "invalid_setting" },
+    { l: "addressing_unusable" },
+    { l: "rate_limited" },
+    { l: "too_many_attempts" },
+    { l: "theme_cap_reached" },
+    { l: "list_full" },
+    { l: "not_raster" },
+    { l: "too_large" },
+    { l: "ssrf_blocked" },
+    { l: "fetch_failed" },
+    { l: "image_reencode_failed" },
+    { l: "not_connected" },
+    { l: "forbidden_vhost" },
+    { l: "invalid_credentials" },
+    { l: "invalid_two_factor" },
+    { l: "two_factor_challenge_expired" },
+    { l: "already_enabled" },
+    { l: "too_many_sessions" },
+    { l: "network_busy" },
+    { l: "network_unreachable" },
+    { l: "captcha_required" },
+    { l: "captcha_failed" },
+    { l: "service_degraded" },
+    { l: "db_unavailable" },
+    { l: "malformed_nick" },
+    { l: "malformed_ident" },
+    { l: "password_required" },
+    { l: "passkey_required" },
+    { l: "passkey_not_configured" },
+    { l: "password_mismatch" },
+    { l: "network_not_visitor_enabled" },
+    { l: "network_ambiguous" },
+    { l: "network_unconfigured" },
+    { l: "upstream_unreachable" },
+    { l: "connect_timeout" },
+    { l: "welcome_timeout" },
+    { l: "session_timeout" },
+    { l: "probe_timeout" },
+    { l: "internal" },
+    { l: "session_plan_resolve_failed" },
+    { l: "contract_migrations_pending" },
+    { l: "invalid_message" },
+    { l: "anon_collision" },
+    { l: "nick_in_use" },
+    { l: "cannot_disconnect_self" },
+    { l: "source_not_local" },
+    { l: "already_exists" },
+    { l: "already_attached" },
+    { l: "credentials_present" },
+    { l: "scrollback_present" },
+    { l: "last_admin" },
+    { l: "share_token_expired" },
+    { l: "share_token_consumed" },
+    { l: "not_invited" },
+    { l: "validation_failed" },
+  ],
+} as const;

--- a/cicchetto/src/lib/wireValidate.ts
+++ b/cicchetto/src/lib/wireValidate.ts
@@ -1,0 +1,229 @@
+// #429 — the interpreter for the generated runtime wire schemas.
+//
+// ## Why this exists
+//
+// `wireTypes.ts` is the codegen mirror of the server's `Grappa.*.Wire`
+// typespecs, and `tsc` erases every line of it. So the only thing actually
+// standing at the WS/REST boundary was `wireNarrow.ts` + `wireTypesAssert.ts`
+// + the inline narrowers in `api.ts` — ~1250 hand-written lines
+// re-transcribing, by hand, the very typespecs the codegen already reads.
+// Two hand-maintained copies of one authoritative source; the hand copy is
+// the one that can silently lose an arm (and did — see `web_session_severed`
+// in `wireNarrow.ts`'s history).
+//
+// `wireSchema.ts` emits those same typespecs as runtime data. This module is
+// the ~100 lines that read it. A new server-side Wire type therefore arrives
+// with its runtime validation already written.
+//
+// ## What it does NOT decide
+//
+// A narrower is not just types — it is the defence at the boundary, and part
+// of that defence is a judgement call the typespec cannot express:
+//
+//   * a DEFAULT that rescues an event instead of dropping it (an unknown
+//     `window_counts.severity` must not null the counts);
+//   * a TOLERANCE toward a payload minted by a peer of a different vintage
+//     (cic deploys independently of the server);
+//   * whether a given arm is load-bearing or a detail.
+//
+// Those stay hand-written at the call site, named as policy. What this file
+// removes is the mechanical part: field presence, primitive kinds, closed
+// sets, nullability, arrays, nesting. See the per-call-site notes in
+// `wireNarrow.ts`.
+//
+// ## The additive-only contract
+//
+// An object node copies ONLY the fields the schema declares and ignores
+// every other key. An unknown field is never fatal, in either direction —
+// that is the wire contract (CLAUDE.md, GH #447), and it is enforced here
+// once rather than re-argued in each hand-written arm.
+
+/**
+ * A node of the generated schema grammar. Mirrors the emission in
+ * `Mix.Tasks.Grappa.GenWireTypes.schema_ir/2` — change one, change both
+ * (the codegen's own moduledoc carries the same grammar).
+ */
+export type WireNode =
+  | "s"
+  | "i"
+  | "b"
+  | "x"
+  | "z"
+  | { readonly l: string | boolean }
+  | { readonly e: readonly string[] }
+  | { readonly a: WireNode }
+  | { readonly r: WireNode }
+  | { readonly p: readonly WireNode[] }
+  | { readonly u: readonly WireNode[] }
+  | { readonly o: { readonly [key: string]: WireNode }; readonly q?: readonly string[] };
+
+/**
+ * The TypeScript type a schema node validates to. Lets a call site assert —
+ * at compile time — that the schema it validates against and the generated
+ * type it claims to produce are the same shape. Both come out of one codegen
+ * run, so a mismatch means the interpreter drifted from the emitter, and
+ * that is exactly what the assert is for.
+ */
+export type Infer<N, D extends Depth = 9> = [D] extends [never]
+  ? unknown
+  : N extends "s"
+    ? string
+    : N extends "i"
+      ? number
+      : N extends "b"
+        ? boolean
+        : N extends "x"
+          ? unknown
+          : N extends "z"
+            ? null
+            : N extends { l: infer L }
+              ? L
+              : N extends { e: readonly (infer E)[] }
+                ? E
+                : N extends { a: infer A }
+                  ? Infer<A, Prev[D]>[]
+                  : N extends { r: infer R }
+                    ? Record<string, Infer<R, Prev[D]>>
+                    : N extends { p: infer P extends readonly unknown[] }
+                      ? { -readonly [K in keyof P]: Infer<P[K], Prev[D]> }
+                      : N extends { u: readonly (infer U)[] }
+                        ? Infer<U, Prev[D]>
+                        : N extends { o: infer O; q: readonly (infer Q extends string)[] }
+                          ? InferObject<O, Q, Prev[D]>
+                          : N extends { o: infer O }
+                            ? InferObject<O, never, Prev[D]>
+                            : never;
+
+// `WireNode` is recursive, so `Infer<N>` under an `N extends WireNode`
+// constraint is too (TS2589 — "excessively deep"). The fuel counter bounds
+// it. Nine levels is far past anything a JSON wire shape reaches; a schema
+// that hit the floor would degrade to `unknown` at the leaf rather than fail
+// to compile, and the runtime walk is unaffected either way.
+type Depth = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+type Prev = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8];
+
+type InferObject<O, Q extends string, D extends Depth> = {
+  -readonly [K in Exclude<keyof O, Q>]: Infer<O[K], D>;
+} & {
+  -readonly [K in Extract<keyof O, Q>]?: Infer<O[K], D>;
+};
+
+// `null` is a legal validated value (`"z"`, and every `T | null` field), so
+// failure cannot be signalled with it. A module-private sentinel keeps the
+// public surface at one function returning `T | null`, which is the shape
+// every existing narrower already speaks.
+const REJECT = Symbol("wireValidate.reject");
+
+/**
+ * Validate `raw` against a generated schema node.
+ *
+ * Returns the value typed as the schema describes, or `null` when the payload
+ * does not match. Top-level wire shapes are objects (or unions of objects),
+ * so `null` is unambiguous there; a nested nullable field is handled inside
+ * the walk, where the sentinel keeps the two apart.
+ */
+export function validate<const N extends WireNode>(node: N, raw: unknown): Infer<N> | null {
+  const out = walk(node, raw);
+  return out === REJECT ? null : (out as Infer<N>);
+}
+
+function walk(node: WireNode, raw: unknown): unknown | typeof REJECT {
+  if (typeof node === "string") return walkScalar(node, raw);
+  if ("l" in node) return raw === node.l ? raw : REJECT;
+  if ("e" in node) return typeof raw === "string" && node.e.includes(raw) ? raw : REJECT;
+  if ("a" in node) return walkArray(node.a, raw);
+  if ("r" in node) return walkRecord(node.r, raw);
+  if ("p" in node) return walkTuple(node.p, raw);
+  if ("u" in node) return walkUnion(node.u, raw);
+  return walkObject(node.o, node.q, raw);
+}
+
+function walkScalar(node: "s" | "i" | "b" | "x" | "z", raw: unknown): unknown | typeof REJECT {
+  switch (node) {
+    case "s":
+      return typeof raw === "string" ? raw : REJECT;
+    case "i":
+      return typeof raw === "number" ? raw : REJECT;
+    case "b":
+      return typeof raw === "boolean" ? raw : REJECT;
+    case "z":
+      return raw === null ? null : REJECT;
+    // `term()` on the server — the field is carried through unvalidated
+    // BECAUSE the typespec declines to describe it, not as a shortcut.
+    case "x":
+      return raw;
+  }
+}
+
+function walkArray(inner: WireNode, raw: unknown): unknown | typeof REJECT {
+  if (!Array.isArray(raw)) return REJECT;
+  const out: unknown[] = [];
+  for (const el of raw) {
+    const v = walk(inner, el);
+    if (v === REJECT) return REJECT;
+    out.push(v);
+  }
+  return out;
+}
+
+function walkRecord(inner: WireNode, raw: unknown): unknown | typeof REJECT {
+  if (!isPlainObject(raw)) return REJECT;
+  const out: Record<string, unknown> = {};
+  for (const [k, el] of Object.entries(raw)) {
+    const v = walk(inner, el);
+    if (v === REJECT) return REJECT;
+    out[k] = v;
+  }
+  return out;
+}
+
+function walkTuple(members: readonly WireNode[], raw: unknown): unknown | typeof REJECT {
+  if (!Array.isArray(raw) || raw.length !== members.length) return REJECT;
+  const out: unknown[] = [];
+  for (let i = 0; i < members.length; i++) {
+    const v = walk(members[i] as WireNode, raw[i]);
+    if (v === REJECT) return REJECT;
+    out.push(v);
+  }
+  return out;
+}
+
+// First matching arm wins. Every discriminated union the codegen emits leads
+// each arm with its `kind` literal, so a mismatched arm fails on its first
+// field and the scan is cheap; an ambiguous union would be a server-side
+// modelling bug, not something to resolve by scoring arms here.
+function walkUnion(arms: readonly WireNode[], raw: unknown): unknown | typeof REJECT {
+  for (const arm of arms) {
+    const v = walk(arm, raw);
+    if (v !== REJECT) return v;
+  }
+  return REJECT;
+}
+
+function walkObject(
+  fields: { readonly [key: string]: WireNode },
+  optional: readonly string[] | undefined,
+  raw: unknown,
+): unknown | typeof REJECT {
+  if (!isPlainObject(raw)) return REJECT;
+  const out: Record<string, unknown> = {};
+  for (const [key, fieldNode] of Object.entries(fields)) {
+    const present = raw[key];
+    if (present === undefined) {
+      // An `optional(:k)` key the server may omit. A REQUIRED key that is
+      // absent is a shape mismatch, not a tolerance: the typespec is where
+      // the server says which is which.
+      if (optional?.includes(key)) continue;
+      return REJECT;
+    }
+    const v = walk(fieldNode, present);
+    if (v === REJECT) return REJECT;
+    out[key] = v;
+  }
+  // Undeclared keys are dropped, never rejected — additive-only (GH #447).
+  return out;
+}
+
+function isPlainObject(raw: unknown): raw is Record<string, unknown> {
+  return typeof raw === "object" && raw !== null && !Array.isArray(raw);
+}

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35107,3 +35107,109 @@ second copy of the flow set in a module that has no business owning one —
 worse than the gap. The set is closed by construction upstream:
 `Admission.check_capacity/1` takes a `capacity_input` whose `flow` is typed
 `flow()`.
+
+---
+
+## 2026-08-09 — #429: the runtime half of the mirror, and what a typespec cannot say
+
+`wireTypes.ts` has been the generated mirror of the server's `Grappa.*.Wire`
+typespecs since #364, and `tsc` erases every line of it. So the thing actually
+standing at the WS/REST boundary was `wireNarrow.ts` + `wireTypesAssert.ts` +
+the inline narrowers in `api.ts`: roughly 1250 hand-written lines
+re-transcribing, by hand, the very typespecs the codegen already reads. Two
+hand-maintained copies of one authoritative source. #448 had just closed the
+STATIC half of that gap (`atom()` → declared union in four typespecs, so the
+mirror stops saying `string`); this is the RUNTIME half.
+
+**The fix is a second artifact, not a second generator.** `mix
+grappa.gen_wire_types` now emits `cicchetto/src/lib/wireSchema.ts` from the
+same walk that writes `wireTypes.ts`: one `as const` schema per Wire type,
+tree-shakeable, under the same `--check` drift gate. Type and schema cannot
+disagree, because one run writes both — visible immediately when #448 landed
+mid-branch and the three sets it closed appeared in the schema as
+`{ e: [...] }` on the next regeneration, with no second edit. `wireValidate.ts`
+is the ~230 lines that interpret it, and its `Infer<>` lets a call site assert
+at compile time that the schema it validates against and the type it claims to
+return are one shape.
+
+Three emitter constraints worth remembering, because each was found the hard
+way:
+
+- **Topological order, not module order.** A schema is an object literal
+  evaluated at module init, so a forward reference is a TDZ error at runtime
+  rather than a `tsc` error. The emitter sorts by dependency and raises on a
+  cycle. A pure alias (`@type a :: b()`) emits `export const S_A = S_B;`
+  WITHOUT `as const` — `as const` on an identifier is TS1355.
+- **The printer has to be biome's printer.** A generated file no human may
+  edit must already be in the formatter's normal form, or `bun run check` fails
+  on a file with no legal fix. Inline-iff-it-fits-at-this-column reproduces
+  biome's layout exactly; named imports need a CASE-INSENSITIVE sort, which
+  diverges from ASCII only where `_` meets a letter (`CREDENTIAL_…` sorts
+  before `CREDENTIALS_…` because `_` < `s` but `_` > `S`).
+- **`Infer<>` needs fuel.** `WireNode` is recursive, so `Infer<N>` under an
+  `N extends WireNode` constraint is too, and TS2589s. A depth counter bounds
+  it; nine levels is far past any JSON wire shape.
+
+**The derivable/human boundary — the actual result.** What a typespec CAN say
+turns out to be all of the mechanical part: field presence, primitive kinds,
+closed sets, nullability, arrays, nesting, and (via `optional(:k)`) whether the
+server may omit a key. Across the whole admin-channel surface — 27 event arms
+plus the overview and session-log rows — exactly three things did not derive,
+and all three are statements about something other than shape:
+
+1. **`login_throttled`'s `door`/`scope`.** `optional(:k)` says the server may
+   omit them. It cannot say what to do when a NEWER server sends a member this
+   build has not heard of. The event is a security alert and those fields are
+   its attribution: dropping the alert to protect the detail inverts the
+   priority, and the admin ring is mirrored to disk and replayed at boot, so
+   rows minted by another vintage genuinely arrive.
+2. **`session_log`'s `old_nick`.** Declared required and always sent, so the
+   typespec is right to demand it — but it was added after the shape shipped,
+   and cic deploys independently of the server (`deploy-m42.sh --cic`).
+   "Required of a current server, tolerated absent from an older one" is a
+   statement about DEPLOY SKEW, not about the shape.
+3. **`narrowAdminSnapshot`'s atomicity.** One malformed element drops the whole
+   snapshot rather than admitting a partial ring — a call about what a corrupt
+   audit trail is worth.
+
+The rule that falls out: **shape is derivable; tolerance is not.** A tolerance
+is always a claim about a PEER (a newer server, an older server, a replayed
+row), and a typespec describes one side only.
+
+**What the transcription had already lost.** `wireNarrow.ts` had no
+`web_session_severed` arm at all. `request_budget.ex` records it into the admin
+ring, `wireTypes.ts` has the type, `adminEvents.ts` dispatches it — only the
+hand copy missed it. Every flood-sever row was dropped on the live push, and
+because the snapshot narrower is atomic, one such row in the ring blanked the
+entire Events tab on reconnect. This is the same failure mode #448 found one
+layer up in `AdmissionFlow`, and it is the argument for the whole exercise: a
+transcription can lose an arm, and nobody can see it in the diff that omits it.
+
+**The measurement, and the oracle that was blind.** A narrower is the defence
+at the boundary, so the swap is only safe if you can say what changed for every
+malformed shape, not just the ones someone wrote a test for.
+`__tests__/wireAdminBoundary.test.ts` walks the generated schema, synthesises a
+valid payload per arm, mutates every field (drop / null / wrong type / unknown
+extra key) and snapshots the verdicts; the snapshot was taken against the HAND
+narrowers first, so the diff in the swap commit IS the before/after. It moved by
+exactly two cells, both on `web_session_severed`, both `reject → accept`. No
+field entered a `survives…` list: the generated boundary is nowhere more
+permissive than the one it replaced.
+
+But the first version of that corpus was **an oracle made of the thing under
+test** — the sampler reads the generated schema and the narrower now validates
+against the same schema, so the two move together. Flipping
+`circuit_open.network_id` to `String.t()` upstream, regenerating and re-running
+left all six tests passing. Recording the sampled payload's SHAPE alongside the
+verdicts gives the snapshot an anchor outside that loop; the same mutation now
+fails on exactly one line. **General rule: a pin whose expected value is
+computed from the thing it pins is green forever.**
+
+**Scope.** This slice took the admin-channel boundary only (~570 hand lines out,
+~110 in, plus the emitter and the interpreter). `narrowChannelEvent`,
+`narrowUserEvent` and the `api.ts` inline narrowers are the same mechanical
+exercise against the same emitted schemas and are deliberately left for
+follow-up slices — the machinery, the gate and the measurement pattern are what
+this one had to establish. `wireTypesAssert.ts` is NOT in that count: it is a
+compile-time bridge between `api.ts` hand-mirrors and `wireTypes.ts`, and it
+disappears when those mirrors do, not when the narrowers do.

--- a/lib/mix/tasks/grappa/gen_wire_types.ex
+++ b/lib/mix/tasks/grappa/gen_wire_types.ex
@@ -865,6 +865,17 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
   # (impossible in JSON, but a real bug if a typespec grows one) RAISES here
   # with the offending name instead of emitting code that stack-overflows.
 
+  @typep schema_key :: {module(), atom()}
+
+  @typep schema_ir ::
+           {:raw, String.t()}
+           | {:obj, [{String.t(), schema_ir()}]}
+           | {:arr, [schema_ir()]}
+
+  @typep schema_entries :: %{schema_key() => {schema_ir(), [schema_key()]}}
+
+  @typep schema_marks :: %{optional(schema_key()) => true}
+
   @doc false
   @spec generate_schema() :: String.t()
   def generate_schema do
@@ -1074,35 +1085,58 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
       entries
       |> Map.keys()
       |> Enum.sort_by(&schema_sort_key/1)
-      |> Enum.reduce({[], MapSet.new()}, fn key, {acc, perm} ->
-        visit_schema(key, entries, perm, MapSet.new(), acc)
-      end)
+      |> visit_schema_all(entries, %{}, %{}, [])
 
     Enum.reverse(order)
   end
 
   defp schema_sort_key({mod, name}), do: "#{inspect(mod)}.#{name}"
 
-  defp visit_schema(key, entries, perm, path, acc) do
-    cond do
-      MapSet.member?(perm, key) ->
-        {acc, perm}
+  # `emitted` is "already placed in the output"; `path` is "on the current DFS
+  # branch", and only the second detects a cycle. Both are plain maps rather
+  # than MapSets, and explicit recursion rather than `Enum.reduce/3`: a MapSet
+  # is opaque, threading one through reduce's type-variable accumulator loses
+  # that opacity, and Dialyzer then flags every well-typed `MapSet.member?/2`
+  # here as a call without an opaque term. A private visited-set has nothing
+  # to gain from the set API anyway.
+  @spec visit_schema_all(
+          [schema_key()],
+          schema_entries(),
+          schema_marks(),
+          schema_marks(),
+          [schema_key()]
+        ) :: {[schema_key()], schema_marks()}
+  defp visit_schema_all([], _, _, emitted, acc), do: {acc, emitted}
 
-      MapSet.member?(path, key) ->
+  defp visit_schema_all([key | rest], entries, path, emitted, acc) do
+    {acc, emitted} = visit_schema(key, entries, emitted, path, acc)
+    visit_schema_all(rest, entries, path, emitted, acc)
+  end
+
+  @spec visit_schema(
+          schema_key(),
+          schema_entries(),
+          schema_marks(),
+          schema_marks(),
+          [schema_key()]
+        ) :: {[schema_key()], schema_marks()}
+  defp visit_schema(key, entries, emitted, path, acc) do
+    cond do
+      Map.has_key?(emitted, key) ->
+        {acc, emitted}
+
+      Map.has_key?(path, key) ->
         raise "gen_wire_types: cyclic wire schema reference at #{schema_sort_key(key)}"
 
       true ->
         {_, deps} = Map.fetch!(entries, key)
-        path = MapSet.put(path, key)
 
-        {acc, perm} =
+        {acc, emitted} =
           deps
           |> Enum.sort_by(&schema_sort_key/1)
-          |> Enum.reduce({acc, perm}, fn dep, {a, p} ->
-            visit_schema(dep, entries, p, path, a)
-          end)
+          |> visit_schema_all(entries, Map.put(path, key, true), emitted, acc)
 
-        {[key | acc], MapSet.put(perm, key)}
+        {[key | acc], Map.put(emitted, key, true)}
     end
   end
 

--- a/lib/mix/tasks/grappa/gen_wire_types.ex
+++ b/lib/mix/tasks/grappa/gen_wire_types.ex
@@ -976,12 +976,12 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
 
   ## ----- Schema node IR ----------------------------------------------------
 
-  defp schema_ir(nil, _mod), do: {:raw, ~s("z")}
-  defp schema_ir({:atom, _, [nil]}, _mod), do: {:raw, ~s("z")}
-  defp schema_ir({:atom, _, [true]}, _mod), do: {:obj, [{"l", {:raw, "true"}}]}
-  defp schema_ir({:atom, _, [false]}, _mod), do: {:obj, [{"l", {:raw, "false"}}]}
+  defp schema_ir(nil, _), do: {:raw, ~s("z")}
+  defp schema_ir({:atom, _, [nil]}, _), do: {:raw, ~s("z")}
+  defp schema_ir({:atom, _, [true]}, _), do: {:obj, [{"l", {:raw, "true"}}]}
+  defp schema_ir({:atom, _, [false]}, _), do: {:obj, [{"l", {:raw, "false"}}]}
 
-  defp schema_ir({:atom, _, [a]}, _mod) when is_atom(a) do
+  defp schema_ir({:atom, _, [a]}, _) when is_atom(a) do
     {:obj, [{"l", {:raw, ~s("#{Atom.to_string(a)}")}}]}
   end
 
@@ -995,13 +995,13 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
     end
   end
 
-  defp schema_ir({:remote_type, _, [String, :t]}, _mod), do: {:raw, ~s("s")}
-  defp schema_ir({:remote_type, _, [DateTime, :t]}, _mod), do: {:raw, ~s("s")}
-  defp schema_ir({:remote_type, _, [Date, :t]}, _mod), do: {:raw, ~s("s")}
-  defp schema_ir({:remote_type, _, [NaiveDateTime, :t]}, _mod), do: {:raw, ~s("s")}
-  defp schema_ir({:remote_type, _, [Ecto.UUID, :t]}, _mod), do: {:raw, ~s("s")}
+  defp schema_ir({:remote_type, _, [String, :t]}, _), do: {:raw, ~s("s")}
+  defp schema_ir({:remote_type, _, [DateTime, :t]}, _), do: {:raw, ~s("s")}
+  defp schema_ir({:remote_type, _, [Date, :t]}, _), do: {:raw, ~s("s")}
+  defp schema_ir({:remote_type, _, [NaiveDateTime, :t]}, _), do: {:raw, ~s("s")}
+  defp schema_ir({:remote_type, _, [Ecto.UUID, :t]}, _), do: {:raw, ~s("s")}
 
-  defp schema_ir({:remote_type, _, [mod, type]}, _mod) when is_atom(mod) and is_atom(type) do
+  defp schema_ir({:remote_type, _, [mod, type]}, _) when is_atom(mod) and is_atom(type) do
     if elixir_module?(mod) do
       schema_ref(mod, type)
     else
@@ -1011,19 +1011,19 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
 
   defp schema_ir({:user_type, _, [name]}, mod) when is_atom(name), do: schema_ref(mod, name)
 
-  defp schema_ir({:integer, _, []}, _mod), do: {:raw, ~s("i")}
-  defp schema_ir({:non_neg_integer, _, []}, _mod), do: {:raw, ~s("i")}
-  defp schema_ir({:pos_integer, _, []}, _mod), do: {:raw, ~s("i")}
-  defp schema_ir({:float, _, []}, _mod), do: {:raw, ~s("i")}
-  defp schema_ir({:boolean, _, []}, _mod), do: {:raw, ~s("b")}
-  defp schema_ir({:binary, _, []}, _mod), do: {:raw, ~s("s")}
-  defp schema_ir({:atom, _, []}, _mod), do: {:raw, ~s("s")}
-  defp schema_ir({:term, _, []}, _mod), do: {:raw, ~s("x")}
-  defp schema_ir({:any, _, []}, _mod), do: {:raw, ~s("x")}
+  defp schema_ir({:integer, _, []}, _), do: {:raw, ~s("i")}
+  defp schema_ir({:non_neg_integer, _, []}, _), do: {:raw, ~s("i")}
+  defp schema_ir({:pos_integer, _, []}, _), do: {:raw, ~s("i")}
+  defp schema_ir({:float, _, []}, _), do: {:raw, ~s("i")}
+  defp schema_ir({:boolean, _, []}, _), do: {:raw, ~s("b")}
+  defp schema_ir({:binary, _, []}, _), do: {:raw, ~s("s")}
+  defp schema_ir({:atom, _, []}, _), do: {:raw, ~s("s")}
+  defp schema_ir({:term, _, []}, _), do: {:raw, ~s("x")}
+  defp schema_ir({:any, _, []}, _), do: {:raw, ~s("x")}
 
   # Bare `map()` — the type side warns and falls back to
   # `Record<string, unknown>`; the runtime side accepts any JSON object.
-  defp schema_ir({:map, _, []}, _mod), do: {:obj, [{"r", {:raw, ~s("x")}}]}
+  defp schema_ir({:map, _, []}, _), do: {:obj, [{"r", {:raw, ~s("x")}}]}
 
   defp schema_ir({:tuple, _, members}, mod) do
     {:obj, [{"p", {:arr, Enum.map(members, &schema_ir(&1, mod))}}]}
@@ -1031,7 +1031,7 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
 
   defp schema_ir([inner], mod), do: {:obj, [{"a", schema_ir(inner, mod)}]}
 
-  defp schema_ir({:open_map, _, [_key, value]}, mod), do: {:obj, [{"r", schema_ir(value, mod)}]}
+  defp schema_ir({:open_map, _, [_, value]}, mod), do: {:obj, [{"r", schema_ir(value, mod)}]}
 
   defp schema_ir({:%{}, _, fields}, mod) do
     props =
@@ -1070,7 +1070,7 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
   ## ----- Schema emission ---------------------------------------------------
 
   defp topo_sort_schema(entries) do
-    {order, _perm} =
+    {order, _} =
       entries
       |> Map.keys()
       |> Enum.sort_by(&schema_sort_key/1)
@@ -1092,7 +1092,7 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
         raise "gen_wire_types: cyclic wire schema reference at #{schema_sort_key(key)}"
 
       true ->
-        {_ir, deps} = Map.fetch!(entries, key)
+        {_, deps} = Map.fetch!(entries, key)
         path = MapSet.put(path, key)
 
         {acc, perm} =
@@ -1107,7 +1107,7 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
   end
 
   defp render_schema_const({mod, name} = key, entries) do
-    {ir, _deps} = Map.fetch!(entries, key)
+    {ir, _} = Map.fetch!(entries, key)
     const = schema_const_name(render_alias_name(mod, name))
     prefix = "export const #{const} = "
 
@@ -1193,7 +1193,7 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
 
   defp inline_ts({:arr, items}), do: "[" <> Enum.map_join(items, ", ", &inline_ts/1) <> "]"
 
-  defp block_ts({:raw, s}, _indent), do: s
+  defp block_ts({:raw, s}, _), do: s
 
   defp block_ts({:obj, kvs}, indent) do
     inner = indent + 2

--- a/lib/mix/tasks/grappa/gen_wire_types.ex
+++ b/lib/mix/tasks/grappa/gen_wire_types.ex
@@ -75,6 +75,14 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
   use Mix.Task
 
   @output_path "cicchetto/src/lib/wireTypes.ts"
+
+  # #429 — the RUNTIME half of the same mirror. `wireTypes.ts` is erased at
+  # `tsc` time, so a hand-written narrower was the only thing standing at the
+  # WS/REST boundary. This second artifact emits the SAME typespecs as runtime
+  # schema literals, so `wireValidate.ts` can enforce at runtime what
+  # `wireTypes.ts` enforces at compile time — from one source, under one
+  # `--check` drift gate.
+  @schema_output_path "cicchetto/src/lib/wireSchema.ts"
   # #428 — `**/wire.ex` matched ONLY files named exactly `wire.ex`, silently
   # skipping the 10 `admin_wire.ex` modules. `**/*wire.ex` catches every
   # `*wire.ex` (`wire.ex` + `admin_wire.ex` + any future `*_wire.ex`) so the
@@ -95,12 +103,12 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
     {opts, _, _} = OptionParser.parse(argv, switches: [check: :boolean])
     Mix.Task.run("loadpaths")
     Mix.Task.run("compile")
-    generated = generate()
+    artifacts = [{@output_path, generate()}, {@schema_output_path, generate_schema()}]
 
     if opts[:check] do
-      verify_committed(generated)
+      Enum.each(artifacts, fn {path, content} -> verify_committed(content, path) end)
     else
-      write_committed(generated)
+      Enum.each(artifacts, fn {path, content} -> write_committed(content, path) end)
     end
   end
 
@@ -114,11 +122,7 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
     Process.put(:wire_external_refs, %{})
 
     body =
-      (Path.wildcard(@wire_glob) ++ Enum.flat_map(@extra_globs, &Path.wildcard/1))
-      |> Enum.sort()
-      |> Enum.map(&module_from_path/1)
-      |> Enum.reject(&is_nil/1)
-      |> Enum.sort_by(&inspect/1)
+      wire_modules()
       |> Enum.map(&render_module/1)
       |> Enum.reject(&(&1 == ""))
       |> Enum.join("\n\n")
@@ -130,6 +134,14 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
     |> Enum.reject(&(&1 == ""))
     |> Enum.join("\n\n")
     |> wrap_with_header()
+  end
+
+  defp wire_modules do
+    (Path.wildcard(@wire_glob) ++ Enum.flat_map(@extra_globs, &Path.wildcard/1))
+    |> Enum.sort()
+    |> Enum.map(&module_from_path/1)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.sort_by(&inspect/1)
   end
 
   defp render_external_section do
@@ -289,19 +301,19 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
     """
   end
 
-  defp write_committed(content) do
-    File.write!(@output_path, content)
-    Mix.shell().info("Wrote #{@output_path}")
+  defp write_committed(content, path) do
+    File.write!(path, content)
+    Mix.shell().info("Wrote #{path}")
   end
 
-  defp verify_committed(generated) do
-    case File.read(@output_path) do
+  defp verify_committed(generated, path) do
+    case File.read(path) do
       {:ok, committed} when committed == generated ->
-        Mix.shell().info("#{@output_path} is in sync.")
+        Mix.shell().info("#{path} is in sync.")
 
       {:ok, _} ->
         Mix.shell().error("""
-        #{@output_path} is OUT OF SYNC with the Wire typespecs.
+        #{path} is OUT OF SYNC with the Wire typespecs.
 
         Run `scripts/mix.sh grappa.gen_wire_types` and commit the
         result.
@@ -310,7 +322,7 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
         exit({:shutdown, 1})
 
       {:error, :enoent} ->
-        Mix.shell().error("#{@output_path} does not exist — run `mix grappa.gen_wire_types`")
+        Mix.shell().error("#{path} does not exist — run `mix grappa.gen_wire_types`")
         exit({:shutdown, 1})
     end
   end
@@ -825,6 +837,387 @@ defmodule Mix.Tasks.Grappa.GenWireTypes do
   defp mod_to_event_union_name(mod) do
     short = mod |> Module.split() |> tl() |> hd()
     "Wire#{short}Event"
+  end
+
+  ## ----- Runtime schema renderer (#429) ------------------------------------
+  #
+  # `wireTypes.ts` is erased by `tsc`, so before #429 the ONLY thing standing
+  # at the WS/REST boundary was ~1250 hand-written lines that re-transcribed
+  # the very typespecs the generator above already reads. This pass emits the
+  # SAME typespecs a second time, as runtime data, so `wireValidate.ts` can
+  # interpret them. Two artifacts, one source, one `--check` gate: the type
+  # and its schema cannot drift, because a single run writes both.
+  #
+  # Node grammar (see `wireValidate.ts` for the interpreter + `Infer<>`):
+  #
+  #   "s" string | "i" number | "b" boolean | "x" unknown | "z" null
+  #   { l: "lit" }        atom literal / true / false
+  #   { e: [...] }        closed set of atom literals
+  #   { a: node }         array
+  #   { r: node }         Record<string, node>
+  #   { p: [node, …] }    tuple
+  #   { u: [node, …] }    union (first matching arm wins)
+  #   { o: {k: node}, q: ["optional", …] }   object
+  #
+  # Consts are emitted in TOPOLOGICAL order, not module order: a schema is a
+  # plain object literal evaluated at module init, so a forward reference
+  # would hit the TDZ at runtime rather than at `tsc`. A reference cycle
+  # (impossible in JSON, but a real bug if a typespec grows one) RAISES here
+  # with the offending name instead of emitting code that stack-overflows.
+
+  @doc false
+  @spec generate_schema() :: String.t()
+  def generate_schema do
+    Process.put(:wire_schema_enum_imports, MapSet.new())
+    entries = collect_schema_entries()
+    imports = Process.get(:wire_schema_enum_imports, MapSet.new())
+    Process.delete(:wire_schema_enum_imports)
+
+    body =
+      entries
+      |> topo_sort_schema()
+      |> Enum.map_join("\n\n", &render_schema_const(&1, entries))
+
+    wrap_schema_header(render_schema_imports(imports), body)
+  end
+
+  defp collect_schema_entries do
+    seeds =
+      for mod <- wire_modules(),
+          {name, _, _} <- module_typedefs(mod),
+          do: {mod, name}
+
+    resolve_schema_entries(seeds, %{}, 1, 8)
+  end
+
+  # Fixpoint like `do_render_external_section/3`: rendering an entry can
+  # surface refs to modules outside the wire glob, which must themselves be
+  # emitted (a dangling ref would be a `tsc` error in a GENERATED file — the
+  # worst place to discover it).
+  defp resolve_schema_entries(_, _, depth, max_depth) when depth > max_depth do
+    raise "gen_wire_types: schema ref resolution exceeded depth #{max_depth} — likely cycle"
+  end
+
+  defp resolve_schema_entries(pending, acc, depth, max_depth) do
+    fresh = pending |> Enum.uniq() |> Enum.reject(fn key -> Map.has_key?(acc, key) end)
+
+    if fresh == [] do
+      acc
+    else
+      {acc, next} =
+        Enum.reduce(fresh, {acc, []}, fn {mod, name}, {a, queue} ->
+          {ir, deps} = render_schema_entry(mod, name)
+          {Map.put(a, {mod, name}, {ir, deps}), deps ++ queue}
+        end)
+
+      resolve_schema_entries(next, acc, depth + 1, max_depth)
+    end
+  end
+
+  defp module_typedefs(mod) do
+    case Code.Typespec.fetch_types(mod) do
+      {:ok, types} -> exported_typedefs(types)
+      :error -> []
+    end
+  end
+
+  defp render_schema_entry(mod, name) do
+    typedefs = module_typedefs(mod)
+
+    case Enum.find(typedefs, fn {n, _, _} -> n == name end) do
+      nil ->
+        raise "gen_wire_types: #{inspect(mod)}.#{name}/0 is referenced by a Wire typespec but " <>
+                "has no exported @type — a generated schema cannot reference it"
+
+      {_, ast, _} ->
+        stripped = strip_typespec_metadata(ast)
+        Process.put(:wire_schema_deps, [])
+
+        ir =
+          case schema_enum_const(mod, name, stripped, typedefs) do
+            {:ok, const_name} -> enum_schema_ir(const_name)
+            :error -> schema_ir(stripped, mod)
+          end
+
+        deps = Enum.uniq(Process.get(:wire_schema_deps, []))
+        Process.delete(:wire_schema_deps)
+        {ir, deps}
+    end
+  end
+
+  # An enum's runtime allowlist is the `as const` array ALREADY emitted into
+  # wireTypes.ts — the schema spreads it rather than re-listing the literals,
+  # so the closed set has exactly one runtime home. The enum test must match
+  # the type generator's clause-for-clause: a wire module has a sibling
+  # registry (`classify_enum/2` follows same-module refs), an external one is
+  # rendered alias-at-a-time and only pure atom unions become consts there.
+  defp schema_enum_const(mod, name, stripped, typedefs) do
+    alias_name = render_alias_name(mod, name)
+
+    enum? =
+      if wire_module?(mod) do
+        types_by_name = Map.new(typedefs, fn {n, ast, _} -> {n, strip_typespec_metadata(ast)} end)
+        match?({:enum, _}, classify_enum(name, types_by_name))
+      else
+        match?({:ok, _}, pure_atom_union_arms(stripped))
+      end
+
+    if enum? do
+      const_name = screaming_const_name(alias_name)
+      imports = Process.get(:wire_schema_enum_imports, MapSet.new())
+      Process.put(:wire_schema_enum_imports, MapSet.put(imports, const_name))
+      {:ok, const_name}
+    else
+      :error
+    end
+  end
+
+  defp enum_schema_ir(const_name), do: {:obj, [{"e", {:arr, [{:raw, "..." <> const_name}]}}]}
+
+  ## ----- Schema node IR ----------------------------------------------------
+
+  defp schema_ir(nil, _mod), do: {:raw, ~s("z")}
+  defp schema_ir({:atom, _, [nil]}, _mod), do: {:raw, ~s("z")}
+  defp schema_ir({:atom, _, [true]}, _mod), do: {:obj, [{"l", {:raw, "true"}}]}
+  defp schema_ir({:atom, _, [false]}, _mod), do: {:obj, [{"l", {:raw, "false"}}]}
+
+  defp schema_ir({:atom, _, [a]}, _mod) when is_atom(a) do
+    {:obj, [{"l", {:raw, ~s("#{Atom.to_string(a)}")}}]}
+  end
+
+  defp schema_ir({:|, _, _} = union, mod) do
+    arms = flatten_union(union, [])
+
+    if Enum.all?(arms, &atom_literal_arm?/1) do
+      {:obj, [{"e", {:arr, Enum.map(arms, fn {:atom, _, [a]} -> {:raw, ~s("#{a}")} end)}}]}
+    else
+      {:obj, [{"u", {:arr, Enum.map(arms, &schema_ir(&1, mod))}}]}
+    end
+  end
+
+  defp schema_ir({:remote_type, _, [String, :t]}, _mod), do: {:raw, ~s("s")}
+  defp schema_ir({:remote_type, _, [DateTime, :t]}, _mod), do: {:raw, ~s("s")}
+  defp schema_ir({:remote_type, _, [Date, :t]}, _mod), do: {:raw, ~s("s")}
+  defp schema_ir({:remote_type, _, [NaiveDateTime, :t]}, _mod), do: {:raw, ~s("s")}
+  defp schema_ir({:remote_type, _, [Ecto.UUID, :t]}, _mod), do: {:raw, ~s("s")}
+
+  defp schema_ir({:remote_type, _, [mod, type]}, _mod) when is_atom(mod) and is_atom(type) do
+    if elixir_module?(mod) do
+      schema_ref(mod, type)
+    else
+      {:raw, erlang_schema_scalar(mod, type)}
+    end
+  end
+
+  defp schema_ir({:user_type, _, [name]}, mod) when is_atom(name), do: schema_ref(mod, name)
+
+  defp schema_ir({:integer, _, []}, _mod), do: {:raw, ~s("i")}
+  defp schema_ir({:non_neg_integer, _, []}, _mod), do: {:raw, ~s("i")}
+  defp schema_ir({:pos_integer, _, []}, _mod), do: {:raw, ~s("i")}
+  defp schema_ir({:float, _, []}, _mod), do: {:raw, ~s("i")}
+  defp schema_ir({:boolean, _, []}, _mod), do: {:raw, ~s("b")}
+  defp schema_ir({:binary, _, []}, _mod), do: {:raw, ~s("s")}
+  defp schema_ir({:atom, _, []}, _mod), do: {:raw, ~s("s")}
+  defp schema_ir({:term, _, []}, _mod), do: {:raw, ~s("x")}
+  defp schema_ir({:any, _, []}, _mod), do: {:raw, ~s("x")}
+
+  # Bare `map()` — the type side warns and falls back to
+  # `Record<string, unknown>`; the runtime side accepts any JSON object.
+  defp schema_ir({:map, _, []}, _mod), do: {:obj, [{"r", {:raw, ~s("x")}}]}
+
+  defp schema_ir({:tuple, _, members}, mod) do
+    {:obj, [{"p", {:arr, Enum.map(members, &schema_ir(&1, mod))}}]}
+  end
+
+  defp schema_ir([inner], mod), do: {:obj, [{"a", schema_ir(inner, mod)}]}
+
+  defp schema_ir({:open_map, _, [_key, value]}, mod), do: {:obj, [{"r", schema_ir(value, mod)}]}
+
+  defp schema_ir({:%{}, _, fields}, mod) do
+    props =
+      Enum.map(fields, fn
+        {{:optional, k}, v} when is_atom(k) -> {Atom.to_string(k), schema_ir(v, mod), true}
+        {k, v} when is_atom(k) -> {Atom.to_string(k), schema_ir(v, mod), false}
+      end)
+
+    shape = {:obj, Enum.map(props, fn {k, ir, _} -> {ts_object_key(k), ir} end)}
+    optional = for {k, _, true} <- props, do: {:raw, ~s("#{k}")}
+
+    case optional do
+      [] -> {:obj, [{"o", shape}]}
+      keys -> {:obj, [{"o", shape}, {"q", {:arr, keys}}]}
+    end
+  end
+
+  defp schema_ref(mod, name) do
+    Process.put(:wire_schema_deps, [{mod, name} | Process.get(:wire_schema_deps, [])])
+    {:raw, schema_const_name(render_alias_name(mod, name))}
+  end
+
+  defp schema_const_name(alias_name), do: "S_" <> alias_name
+
+  defp erlang_schema_scalar(:inet, :port_number), do: ~s("i")
+
+  defp erlang_schema_scalar(mod, type) do
+    raise "gen_wire_types: unmapped Erlang remote type #{inspect(mod)}.#{type}() in a Wire " <>
+            "typespec — add an erlang_schema_scalar/2 clause"
+  end
+
+  defp ts_object_key(key) do
+    if Regex.match?(~r/^[A-Za-z_$][A-Za-z0-9_$]*$/, key), do: key, else: ~s("#{key}")
+  end
+
+  ## ----- Schema emission ---------------------------------------------------
+
+  defp topo_sort_schema(entries) do
+    {order, _perm} =
+      entries
+      |> Map.keys()
+      |> Enum.sort_by(&schema_sort_key/1)
+      |> Enum.reduce({[], MapSet.new()}, fn key, {acc, perm} ->
+        visit_schema(key, entries, perm, MapSet.new(), acc)
+      end)
+
+    Enum.reverse(order)
+  end
+
+  defp schema_sort_key({mod, name}), do: "#{inspect(mod)}.#{name}"
+
+  defp visit_schema(key, entries, perm, path, acc) do
+    cond do
+      MapSet.member?(perm, key) ->
+        {acc, perm}
+
+      MapSet.member?(path, key) ->
+        raise "gen_wire_types: cyclic wire schema reference at #{schema_sort_key(key)}"
+
+      true ->
+        {_ir, deps} = Map.fetch!(entries, key)
+        path = MapSet.put(path, key)
+
+        {acc, perm} =
+          deps
+          |> Enum.sort_by(&schema_sort_key/1)
+          |> Enum.reduce({acc, perm}, fn dep, {a, p} ->
+            visit_schema(dep, entries, p, path, a)
+          end)
+
+        {[key | acc], MapSet.put(perm, key)}
+    end
+  end
+
+  defp render_schema_const({mod, name} = key, entries) do
+    {ir, _deps} = Map.fetch!(entries, key)
+    const = schema_const_name(render_alias_name(mod, name))
+    prefix = "export const #{const} = "
+
+    # A pure alias (`@type a :: b()`) renders to the referenced const, and
+    # `as const` on an identifier is a TS1355 error — the reference already
+    # carries the frozen literal type of its target.
+    suffix = if match?({:raw, _}, ir), do: ";", else: " as const;"
+    value = emit_ts(ir, String.length(prefix), 0, String.length(suffix))
+
+    "// #{inspect(mod)}.#{name}/0\n#{prefix}#{value}#{suffix}"
+  end
+
+  # biome's import organiser sorts named specifiers CASE-INSENSITIVELY, which
+  # only diverges from a plain ASCII sort where `_` meets a letter
+  # (`CREDENTIAL_…` vs `CREDENTIALS_…`: `_` > `S` but `_` < `s`). Sorting the
+  # ASCII way emits a file biome would rewrite, and a generated file no human
+  # may edit must already be in biome's normal form.
+  defp render_schema_imports(imports) do
+    case Enum.sort_by(imports, &String.downcase/1) do
+      [] -> ""
+      names -> emit_import_line(names)
+    end
+  end
+
+  defp emit_import_line(names) do
+    inline = "import { #{Enum.join(names, ", ")} } from \"./wireTypes\";"
+
+    if String.length(inline) <= 100 do
+      inline
+    else
+      body = Enum.map_join(names, "\n", &"  #{&1},")
+      "import {\n#{body}\n} from \"./wireTypes\";"
+    end
+  end
+
+  defp wrap_schema_header(imports, body) do
+    """
+    // GENERATED FILE — DO NOT EDIT
+    // Run `scripts/mix.sh grappa.gen_wire_types` to regenerate.
+    // Source: lib/grappa/**/*wire.ex + lib/grappa_web/error_tokens.ex
+    //
+    // #429 — the RUNTIME twin of `wireTypes.ts`: the same typespecs, emitted
+    // as schema literals `wireValidate.ts` interprets. `wireTypes.ts` is
+    // erased by tsc; these survive to the WS/REST boundary. Consts are in
+    // topological order because a forward reference would hit the TDZ.
+    //
+    // Node grammar: see `wireValidate.ts`.
+
+    #{imports}
+
+    #{body}
+    """
+  end
+
+  ## ----- biome-compatible TypeScript literal printer -----------------------
+  #
+  # The committed file has to be byte-identical to what `biome format` would
+  # produce, or `bun run check` fails on a file no human may edit. biome
+  # (like prettier) keeps a construct on one line iff it FITS in the print
+  # width, and preserves an object's line break once broken — so "inline iff
+  # it fits at this column" reproduces its output exactly. `suffix` is the
+  # text that will follow on the same line (a trailing comma, ` as const;`)
+  # and counts toward the fit, as it does in biome's own fit check.
+
+  @print_width 100
+
+  defp emit_ts(ir, col, indent, suffix) do
+    inline = inline_ts(ir)
+
+    if col + String.length(inline) + suffix <= @print_width do
+      inline
+    else
+      block_ts(ir, indent)
+    end
+  end
+
+  defp inline_ts({:raw, s}), do: s
+  defp inline_ts({:obj, []}), do: "{}"
+
+  defp inline_ts({:obj, kvs}) do
+    "{ " <> Enum.map_join(kvs, ", ", fn {k, v} -> "#{k}: #{inline_ts(v)}" end) <> " }"
+  end
+
+  defp inline_ts({:arr, items}), do: "[" <> Enum.map_join(items, ", ", &inline_ts/1) <> "]"
+
+  defp block_ts({:raw, s}, _indent), do: s
+
+  defp block_ts({:obj, kvs}, indent) do
+    inner = indent + 2
+    pad = String.duplicate(" ", inner)
+
+    body =
+      Enum.map_join(kvs, "\n", fn {k, v} ->
+        prefix = "#{pad}#{k}: "
+        prefix <> emit_ts(v, String.length(prefix), inner, 1) <> ","
+      end)
+
+    "{\n#{body}\n#{String.duplicate(" ", indent)}}"
+  end
+
+  defp block_ts({:arr, items}, indent) do
+    inner = indent + 2
+    pad = String.duplicate(" ", inner)
+
+    body =
+      Enum.map_join(items, "\n", fn item ->
+        pad <> emit_ts(item, inner, inner, 1) <> ","
+      end)
+
+    "[\n#{body}\n#{String.duplicate(" ", indent)}]"
   end
 
   ## ----- Test seams --------------------------------------------------------


### PR DESCRIPTION
## What

`wireTypes.ts` is the generated mirror of the server's `Grappa.*.Wire`
typespecs, and `tsc` erases every line of it. So the thing actually standing
at the WS/REST boundary was ~1250 hand-written lines re-transcribing, by
hand, the very typespecs the codegen already reads.

`mix grappa.gen_wire_types` now emits a **second artifact from the same
walk**: `cicchetto/src/lib/wireSchema.ts`, one `as const` schema per Wire
type, tree-shakeable, under the same `--check` drift gate. Type and schema
cannot disagree, because one run writes both. `wireValidate.ts` is the 229
lines that interpret it. The admin-channel narrowers (`narrowAdminEvent`,
`narrowAdminOverview`, `narrowSessionLogEntry`) now run off it: **569 hand
lines out, 89 in.**

The issue offered "generate the narrowers **or** replace them with one
runtime validator". This takes the second, with a correction: there was no
generated runtime source to validate against, because the generated mirror
is types. So the validator needed the schema artifact first.

## The derivable / human boundary

Across the whole admin surface — 27 event arms plus the overview and
session-log rows — the typespec covers **all of the mechanical part**: field
presence, primitive kinds, closed sets, nullability, arrays, nesting, and
(via `optional(:k)`) whether the server may omit a key.

Exactly three things did not derive, and none of them is about SHAPE:

1. **`login_throttled`'s `door`/`scope`.** `optional(:k)` says the server may
   omit them; it cannot say what to do when a NEWER server sends a member
   this build has not heard of. The event is a security alert and those
   fields are its attribution — dropping the alert to protect the detail
   inverts the priority, and the ring is replayed from disk.
2. **`session_log`'s `old_nick`.** Declared required and always sent, but
   added after the shape shipped, and cic deploys independently of the
   server. "Required of a current server, tolerated absent from an older
   one" is a statement about deploy skew.
3. **`narrowAdminSnapshot`'s atomicity** — a call about what a corrupt audit
   trail is worth.

**Shape is derivable; tolerance is not.** A tolerance is always a claim about
a PEER, and a typespec describes one side only.

## What the transcription had already lost

`wireNarrow.ts` had **no `web_session_severed` arm**. `request_budget.ex`
records it into the admin ring, `wireTypes.ts` has the type, `adminEvents.ts`
dispatches it — only the hand copy missed it. Every flood-sever row was
dropped on the live push, and because the snapshot narrower is atomic, one
such row in the ring blanked the entire Events tab on reconnect. Same failure
mode #448 found one layer up.

## Measured, not asserted

`__tests__/wireAdminBoundary.test.ts` walks the generated schema, synthesises
a valid payload per arm, mutates every field (drop / null / wrong type /
unknown extra key) and snapshots the verdicts. The snapshot was taken against
the HAND narrowers and committed first, so **the diff in the swap commit is
the before/after**:

- Two cells move, both on `web_session_severed`, both `reject → accept`.
- **No field enters a `survives…` list** — the generated boundary is nowhere
  more permissive than the one it replaced.
- The overview and session-log rows do not move at all.

Unknown extra keys are `accept` on all 28 arms: additive-only (#447) is
enforced once in the interpreter instead of re-argued per arm.

### The oracle that was blind

The first version of that corpus was an oracle made of the thing under test:
the sampler reads the generated schema, the narrower validates against the
same schema, so the two move together. Flipping `circuit_open.network_id` to
`String.t()` upstream, regenerating and re-running left **all six tests
passing**. Recording the sampled payload's shape gives the snapshot an anchor
outside that loop; the same mutation now fails on exactly one line. Fixed in
its own commit rather than quietly.

## Emitter notes

- **Topological order**, not module order: a schema is an object literal
  evaluated at module init, so a forward reference is a TDZ error at runtime
  rather than a tsc error. Cycles raise in the codegen.
- **The printer is biome's printer.** A generated file no human may edit has
  to already be in the formatter's normal form. Named imports need a
  case-insensitive sort, which diverges from ASCII only where `_` meets a
  letter.
- **`Infer<>` needs a depth counter** — `WireNode` is recursive, so
  `Infer<N>` under an `N extends WireNode` constraint TS2589s.

## Scope

Admin channel only. `narrowChannelEvent`, `narrowUserEvent` and the `api.ts`
inline narrowers are the same mechanical exercise against schemas that are
already emitted, and are left for follow-up slices — the machinery, the gate
and the measurement pattern are what this one establishes.

`wireTypesAssert.ts` is **not** part of the 1250: it is a compile-time bridge
between `api.ts` hand-mirrors and `wireTypes.ts`, and it disappears when
those mirrors do, not when the narrowers do.

## Test plan

- [x] `bun run check` (biome + tsc over `src` AND `e2e`) — no `any`, no
      `@ts-ignore`, no excluded file
- [x] `bun run test` — 265 files, 4912 tests
- [x] Mutation: a hand edit to `wireSchema.ts` makes `--check` fail on that
      file specifically while `wireTypes.ts` reports in sync
- [x] Mutation: a typespec field type change fails the corpus on exactly one
      line
- [x] `scripts/check.sh` — rc=0: 5598 tests / 0 failures, dialyzer 0 errors, both generated files in sync, 380 bats
- [ ] `scripts/integration.sh` — not run: the STACK lane was not allocated to this unit