### PR TITLE
#407: declare the modal chrome once, named for the shape it is

### DIFF
--- a/cicchetto/e2e/tests/issue407-modal-backdrop-full-bottom-edge.spec.ts
+++ b/cicchetto/e2e/tests/issue407-modal-backdrop-full-bottom-edge.spec.ts
@@ -1,0 +1,88 @@
+// #407 — the one shape the extraction left without a witness.
+//
+// `.modal-backdrop` carries the scrim's paint and centring and DELIBERATELY no
+// geometry: on its own it is `position: fixed` with `left/right/top: 0` and no
+// bottom and no height — a zero-height box. Every scrim must also wear exactly
+// one geometry variant. `.modal-backdrop-viewport` adds the #143 keyboard-aware
+// height; `.modal-backdrop-full` adds the one declaration that makes the scrim
+// span the layout viewport: `bottom: 0`.
+//
+// `modalChrome.test.ts` pins all of that, but jsdom applies no stylesheet — it
+// proves what the cascade is ASKED to do, never what a browser paints. Two of
+// the three shapes already have a real-browser witness: issue219 clicks
+// `.names-modal-close` and waits for the modal to hide, and issue232 clicks
+// `.mode-modal-backdrop` at (6, 6). The `-full` geometry had none, and the two
+// modals that use it (confirm, delete-account) both dismiss on scrim click with
+// no spec clicking either.
+//
+// WHY THE BOTTOM AND NOT THE CORNER issue232 USES. A click at (6, 6) lands on
+// any box anchored at `top: 0`, so it passes whether or not the scrim has a
+// height at all — it cannot tell `.modal-backdrop-full` from the bare base.
+// `bottom: 0` is the single declaration the variant contributes, so the click
+// has to go where only that declaration can carry it: the bottom edge.
+//
+// RED / GREEN: drop `bottom: 0` from `.modal-backdrop-full`, or ship the scrim
+// wearing the base with no geometry variant, and the scrim collapses to zero
+// height — the box assertion names it, and the click falls through to the
+// window chrome behind while the modal stays open. Restore either and it
+// passes. The bottom-left corner is clear of occluders by construction: the
+// only rules at or above the scrim's z-index are `.error-banners` (z 1000) and
+// `.diag-float` (z 99999), and both are anchored to the TOP.
+//
+// The confirm modal is opened through the destructive close × (#195) and then
+// DISMISSED, which is the safe branch — it never PARTs. The spec asserts the
+// channel is still there afterwards, so a regression that turned dismissal into
+// confirmation could not hide behind a green scrim test. Registered vjt seed;
+// desktop chromium (untagged — an iPhone run would measure the VISUAL viewport,
+// which is the other variant's business).
+
+import {
+  confirmModal,
+  loginAs,
+  selectChannel,
+  sidebarCloseButton,
+  sidebarWindow,
+} from "../fixtures/cicchettoPage";
+import { AUTOJOIN_CHANNELS, getSeededVjt, NETWORK_NICK, NETWORK_SLUG } from "../fixtures/seedData";
+import { expect, test } from "../fixtures/test";
+
+const CHANNEL = AUTOJOIN_CHANNELS[0];
+
+test.setTimeout(60_000);
+
+test("#407 the -full scrim spans to the viewport bottom, and a click there dismisses", async ({
+  page,
+}) => {
+  const vjt = getSeededVjt();
+  await loginAs(page, vjt);
+  await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
+
+  // #195 — the destructive close × opens the leave-channel confirm.
+  await sidebarCloseButton(page, NETWORK_SLUG, CHANNEL).click();
+  const confirm = confirmModal(page);
+  await expect(confirm).toBeVisible({ timeout: 5_000 });
+
+  const scrim = page.locator(".confirm-modal-backdrop");
+  await expect(scrim).toHaveClass(/\bmodal-backdrop\b/);
+  await expect(scrim).toHaveClass(/\bmodal-backdrop-full\b/);
+
+  const viewport = page.viewportSize();
+  if (viewport === null) throw new Error("no viewport size — headless config changed");
+  const box = await scrim.boundingBox();
+  if (box === null) throw new Error("the scrim has no box: it is not rendered");
+
+  // Named first, so a collapsed scrim reports as a geometry failure rather than
+  // as an out-of-bounds click position further down.
+  expect(Math.round(box.y), "the scrim must start at the viewport top").toBe(0);
+  expect(Math.round(box.y + box.height), "the scrim must reach the viewport bottom").toBe(
+    viewport.height,
+  );
+
+  // The hit test the box assertion cannot stand in for: the scrim must actually
+  // RECEIVE a pointer event down there, not merely measure as if it would.
+  await scrim.click({ position: { x: 6, y: box.height - 6 } });
+  await expect(confirm).toHaveCount(0, { timeout: 5_000 });
+
+  // Dismissed, not confirmed — the channel is still in the sidebar.
+  await expect(sidebarWindow(page, NETWORK_SLUG, CHANNEL)).toHaveCount(1);
+});

--- a/cicchetto/src/BanlistModal.tsx
+++ b/cicchetto/src/BanlistModal.tsx
@@ -160,7 +160,10 @@ const BanlistModal: Component = () => {
       {(t) => (
         // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack
         // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
-        <div class="banlist-modal-backdrop" onClick={closeBanlistModal}>
+        <div
+          class="modal-backdrop modal-backdrop-viewport banlist-modal-backdrop"
+          onClick={closeBanlistModal}
+        >
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
           <div
             role="dialog"
@@ -180,7 +183,7 @@ const BanlistModal: Component = () => {
               </h2>
               <button
                 type="button"
-                class="banlist-modal-close"
+                class="modal-chrome-button banlist-modal-close"
                 aria-label="close ban list"
                 onClick={closeBanlistModal}
               >

--- a/cicchetto/src/ConfirmModal.tsx
+++ b/cicchetto/src/ConfirmModal.tsx
@@ -48,7 +48,7 @@ const ConfirmModal: Component = () => {
         // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
         // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is a non-interactive scrim
         <div
-          class="confirm-modal-backdrop"
+          class="modal-backdrop modal-backdrop-full confirm-modal-backdrop"
           onClick={dismissConfirm}
           data-testid="confirm-modal-backdrop"
         >

--- a/cicchetto/src/DeleteAccountModal.tsx
+++ b/cicchetto/src/DeleteAccountModal.tsx
@@ -80,7 +80,7 @@ const DeleteAccountModal: Component<Props> = (props) => {
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape) */}
       {/* biome-ignore lint/a11y/noStaticElementInteractions: backdrop is a non-interactive scrim */}
       <div
-        class="delete-account-backdrop"
+        class="modal-backdrop modal-backdrop-full delete-account-backdrop"
         onClick={props.onClose}
         data-testid="delete-account-backdrop"
       >

--- a/cicchetto/src/LinksModal.tsx
+++ b/cicchetto/src/LinksModal.tsx
@@ -226,7 +226,7 @@ const LinksModal: Component = () => {
         return (
           // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
           // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
-          <div class="links-modal-backdrop" onClick={close}>
+          <div class="modal-backdrop modal-backdrop-viewport links-modal-backdrop" onClick={close}>
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
             <div
               role="dialog"
@@ -244,7 +244,7 @@ const LinksModal: Component = () => {
                 <div class="links-modal-controls">
                   <button
                     type="button"
-                    class="links-modal-zoom"
+                    class="modal-chrome-button links-modal-zoom"
                     aria-label="zoom out"
                     onClick={() =>
                       zoomAround(
@@ -260,7 +260,7 @@ const LinksModal: Component = () => {
                   </button>
                   <button
                     type="button"
-                    class="links-modal-zoom"
+                    class="modal-chrome-button links-modal-zoom"
                     aria-label="reset view"
                     onClick={resetView}
                   >
@@ -268,7 +268,7 @@ const LinksModal: Component = () => {
                   </button>
                   <button
                     type="button"
-                    class="links-modal-zoom"
+                    class="modal-chrome-button links-modal-zoom"
                     aria-label="zoom in"
                     onClick={() =>
                       zoomAround(
@@ -284,7 +284,7 @@ const LinksModal: Component = () => {
                   </button>
                   <button
                     type="button"
-                    class="links-modal-close"
+                    class="modal-chrome-button links-modal-close"
                     aria-label="close links"
                     onClick={close}
                   >

--- a/cicchetto/src/ModeModal.tsx
+++ b/cicchetto/src/ModeModal.tsx
@@ -213,7 +213,10 @@ const ModeModal: Component = () => {
       {(t) => (
         // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
         // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
-        <div class="mode-modal-backdrop" onClick={closeModeModal}>
+        <div
+          class="modal-backdrop modal-backdrop-viewport mode-modal-backdrop"
+          onClick={closeModeModal}
+        >
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
           <div
             role="dialog"
@@ -233,7 +236,7 @@ const ModeModal: Component = () => {
               </h2>
               <button
                 type="button"
-                class="mode-modal-close"
+                class="modal-chrome-button mode-modal-close"
                 aria-label="close modes"
                 onClick={closeModeModal}
               >

--- a/cicchetto/src/NamesModal.tsx
+++ b/cicchetto/src/NamesModal.tsx
@@ -92,7 +92,7 @@ const NamesModal: Component = () => {
         return (
           // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
           // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
-          <div class="names-modal-backdrop" onClick={close}>
+          <div class="modal-backdrop modal-backdrop-viewport names-modal-backdrop" onClick={close}>
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
             <div
               role="dialog"
@@ -109,7 +109,7 @@ const NamesModal: Component = () => {
                 </h2>
                 <button
                   type="button"
-                  class="names-modal-close"
+                  class="modal-chrome-button names-modal-close"
                   aria-label="close names"
                   onClick={close}
                 >

--- a/cicchetto/src/PrivacyModal.tsx
+++ b/cicchetto/src/PrivacyModal.tsx
@@ -50,7 +50,10 @@ const PrivacyModal: Component = () => {
       {(host) => (
         // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
         // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim, click is convenience-only
-        <div class="image-upload-modal-backdrop" onClick={onCancel}>
+        <div
+          class="modal-backdrop modal-backdrop-full image-upload-modal-backdrop"
+          onClick={onCancel}
+        >
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
           <div
             role="dialog"

--- a/cicchetto/src/RecoverModal.tsx
+++ b/cicchetto/src/RecoverModal.tsx
@@ -81,7 +81,7 @@ const RecoverModal: Component = () => {
       {(st) => (
         // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
         // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
-        <div class="recover-modal-backdrop" onClick={close}>
+        <div class="modal-backdrop modal-backdrop-viewport recover-modal-backdrop" onClick={close}>
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
           <div
             role="dialog"
@@ -101,7 +101,12 @@ const RecoverModal: Component = () => {
                 </span>
                 Recover your identity
               </h2>
-              <button type="button" class="recover-modal-close" aria-label="close" onClick={close}>
+              <button
+                type="button"
+                class="modal-chrome-button recover-modal-close"
+                aria-label="close"
+                onClick={close}
+              >
                 ×
               </button>
             </header>

--- a/cicchetto/src/RegistrationWizardModal.tsx
+++ b/cicchetto/src/RegistrationWizardModal.tsx
@@ -223,7 +223,10 @@ const RegistrationWizardModal: Component = () => {
         return (
           // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
           // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
-          <div class="registration-wizard-backdrop" onClick={close}>
+          <div
+            class="modal-backdrop modal-backdrop-viewport registration-wizard-backdrop"
+            onClick={close}
+          >
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
             <div
               role="dialog"
@@ -245,7 +248,7 @@ const RegistrationWizardModal: Component = () => {
                 </h2>
                 <button
                   type="button"
-                  class="registration-wizard-close"
+                  class="modal-chrome-button registration-wizard-close"
                   aria-label="close"
                   onClick={close}
                 >

--- a/cicchetto/src/ServerReplyModal.tsx
+++ b/cicchetto/src/ServerReplyModal.tsx
@@ -56,7 +56,10 @@ const ServerReplyModal: Component = () => {
         return (
           // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
           // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
-          <div class="server-reply-modal-backdrop" onClick={close}>
+          <div
+            class="modal-backdrop modal-backdrop-viewport server-reply-modal-backdrop"
+            onClick={close}
+          >
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
             <div
               role="dialog"
@@ -77,7 +80,7 @@ const ServerReplyModal: Component = () => {
                 </h2>
                 <button
                   type="button"
-                  class="server-reply-modal-close"
+                  class="modal-chrome-button server-reply-modal-close"
                   aria-label="close"
                   onClick={close}
                 >

--- a/cicchetto/src/ServiceModal.tsx
+++ b/cicchetto/src/ServiceModal.tsx
@@ -83,7 +83,10 @@ const ServiceModal: Component = () => {
         return (
           // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
           // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
-          <div class="service-modal-backdrop" onClick={close}>
+          <div
+            class="modal-backdrop modal-backdrop-viewport service-modal-backdrop"
+            onClick={close}
+          >
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
             <div
               role="dialog"
@@ -104,7 +107,7 @@ const ServiceModal: Component = () => {
                 </h2>
                 <button
                   type="button"
-                  class="service-modal-close"
+                  class="modal-chrome-button service-modal-close"
                   aria-label="close"
                   onClick={close}
                 >

--- a/cicchetto/src/ShareSessionModal.tsx
+++ b/cicchetto/src/ShareSessionModal.tsx
@@ -165,7 +165,7 @@ const ShareSessionModal: Component = () => {
     <Show when={shareModalOpen()}>
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape) */}
       {/* biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim */}
-      <div class="share-modal-backdrop" onClick={close}>
+      <div class="modal-backdrop modal-backdrop-viewport share-modal-backdrop" onClick={close}>
         {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
         <div
           role="dialog"
@@ -180,7 +180,7 @@ const ShareSessionModal: Component = () => {
             <h2 id="share-modal-title">{SHARE_SESSION_LABEL}</h2>
             <button
               type="button"
-              class="share-modal-close"
+              class="modal-chrome-button share-modal-close"
               data-testid="share-modal-close"
               aria-label="close"
               onClick={close}

--- a/cicchetto/src/UmodeModal.tsx
+++ b/cicchetto/src/UmodeModal.tsx
@@ -81,7 +81,10 @@ const UmodeModal: Component = () => {
       {(t) => (
         // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
         // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
-        <div class="mode-modal-backdrop" onClick={closeUmodeModal}>
+        <div
+          class="modal-backdrop modal-backdrop-viewport mode-modal-backdrop"
+          onClick={closeUmodeModal}
+        >
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
           <div
             role="dialog"
@@ -96,7 +99,7 @@ const UmodeModal: Component = () => {
               <h2 id="umode-modal-title">User modes: {t.networkSlug}</h2>
               <button
                 type="button"
-                class="mode-modal-close"
+                class="modal-chrome-button mode-modal-close"
                 aria-label="close user modes"
                 onClick={closeUmodeModal}
               >

--- a/cicchetto/src/WhoModal.tsx
+++ b/cicchetto/src/WhoModal.tsx
@@ -222,7 +222,7 @@ const WhoModal: Component = () => {
         return (
           // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop close-on-outside; Esc via the shared overlay stack (keybindings → runTopmostOverlayEscape)
           // biome-ignore lint/a11y/noStaticElementInteractions: backdrop is non-interactive scrim
-          <div class="who-modal-backdrop" onClick={close}>
+          <div class="modal-backdrop modal-backdrop-viewport who-modal-backdrop" onClick={close}>
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: inner dialog onClick only stops backdrop-click propagation; Esc closes via the shared overlay stack */}
             <div
               role="dialog"
@@ -239,7 +239,7 @@ const WhoModal: Component = () => {
                 </h2>
                 <button
                   type="button"
-                  class="who-modal-close"
+                  class="modal-chrome-button who-modal-close"
                   aria-label="close who"
                   onClick={close}
                 >

--- a/cicchetto/src/__tests__/modalChrome.test.ts
+++ b/cicchetto/src/__tests__/modalChrome.test.ts
@@ -1,0 +1,383 @@
+/// <reference types="node" />
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { themeCss } from "./helpers/themeCss";
+
+// #407 — the modal × and the modal scrim were each styled by copying a rule:
+// ten byte-identical `*-close` blocks and thirteen `*-backdrop` blocks that
+// resolve to two shapes. #740 already fixed this defect shape once
+// (.login-quiet-button / .scrollback-inline-button) with a base class worn
+// beside the per-instance one; this is the same move on the modal chrome.
+//
+// An extraction is a promise not to change any pixel, so the guard is not
+// "a base rule exists" — it is that the DECLARATIONS every call site resolves
+// to are byte-for-byte what they were before the base existed. The three maps
+// at the foot of this file were transcribed from the stylesheet as it stood at
+// 6e81170 (origin/main, pre-extraction) and must survive it unchanged.
+//
+// jsdom applies no stylesheet, so this reads the source. It proves what the
+// cascade is asked to do, never what a browser paints — the visible outcome
+// (the × actually closing the modal) is an e2e concern, not this file's.
+
+/** Per-instance classes that the extracted bases must leave pixel-identical. */
+const CLOSE_SITES = [
+  "banlist-modal-close",
+  "links-modal-close",
+  "mode-modal-close",
+  "names-modal-close",
+  "recover-modal-close",
+  "registration-wizard-close",
+  "server-reply-modal-close",
+  "service-modal-close",
+  "share-modal-close",
+  "who-modal-close",
+];
+
+/** Scrims that #143 shrank to the visible region so the iOS keyboard fits. */
+const BACKDROP_VIEWPORT_SITES = [
+  "banlist-modal-backdrop",
+  "links-modal-backdrop",
+  "mode-modal-backdrop",
+  "names-modal-backdrop",
+  "recover-modal-backdrop",
+  "registration-wizard-backdrop",
+  "server-reply-modal-backdrop",
+  "service-modal-backdrop",
+  "share-modal-backdrop",
+  "who-modal-backdrop",
+];
+
+/** Scrims still spanning the layout viewport — the pre-#143 geometry. */
+const BACKDROP_FULL_SITES = [
+  "confirm-modal-backdrop",
+  "delete-account-backdrop",
+  "image-upload-modal-backdrop",
+];
+
+const SITES = [...CLOSE_SITES, ...BACKDROP_VIEWPORT_SITES, ...BACKDROP_FULL_SITES];
+
+type Rule = { selectors: string[]; body: string };
+
+/**
+ * Every INNERMOST rule that starts at column 0, as `{ selectors, body }` with
+ * comments stripped. The `[^{}]` classes cannot span a brace, so an `@media`
+ * prelude is never captured as a selector; the column-0 test then drops the
+ * rules nested inside one, which resolve under a condition this file does not
+ * model. The "bare class selectors only" assertion below is what makes that
+ * safe: it fails if a site is ever reached from inside a media query.
+ */
+function topLevelRules(): Rule[] {
+  const stripped = themeCss.replace(/\/\*[\s\S]*?\*\//g, "");
+  const rules: Rule[] = [];
+  for (const match of stripped.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    const prelude = match[1] ?? "";
+    const lines = prelude.split("\n").filter((line) => line.trim() !== "");
+    if (lines.length === 0 || !lines.every((line) => /^\S/.test(line))) continue;
+    rules.push({
+      selectors: prelude
+        .split(",")
+        .map((selector) => selector.trim())
+        .filter(Boolean),
+      body: match[2] ?? "",
+    });
+  }
+  return rules;
+}
+
+/** Split on top-level spaces — `max(1rem, env(safe-area-inset-top))` is ONE. */
+function splitBoxValue(value: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (const character of value) {
+    if (character === "(") depth += 1;
+    if (character === ")") depth -= 1;
+    if (character === " " && depth === 0) {
+      if (current) parts.push(current);
+      current = "";
+      continue;
+    }
+    current += character;
+  }
+  if (current) parts.push(current);
+  return parts;
+}
+
+/**
+ * Box shorthands expand to their longhands, so the fold compares what the box
+ * model RESOLVES to rather than which spelling got there.
+ *
+ * Not cosmetic. `.links-modal-close` reached its margin as `margin: -0.6rem 0`
+ * in one rule and `margin-right: -0.5rem` in a second — the same four values
+ * the other nine × rules spell in a single shorthand. And the two backdrop
+ * geometries spell the same edges as `inset: 0` and as `left/right/top: 0`.
+ * Left unexpanded, the pin would call an identical box a difference, and would
+ * miss a real one hidden under a different spelling.
+ */
+function declarations(body: string): [string, string][] {
+  return body
+    .split(";")
+    .map((declaration) => declaration.trim())
+    .filter(Boolean)
+    .flatMap((declaration): [string, string][] => {
+      const colon = declaration.indexOf(":");
+      const property = declaration.slice(0, colon).trim();
+      const value = declaration
+        .slice(colon + 1)
+        .trim()
+        .replace(/\s+/g, " ");
+      const edges =
+        property === "inset"
+          ? ["top", "right", "bottom", "left"]
+          : property === "margin" || property === "padding"
+            ? [`${property}-top`, `${property}-right`, `${property}-bottom`, `${property}-left`]
+            : null;
+      if (edges === null) return [[property, value]];
+      const [top, right = top, bottom = top, left = right] = splitBoxValue(value);
+      return [top, right, bottom, left].map(
+        (edge, index) => [edges[index] as string, edge as string] as [string, string],
+      );
+    });
+}
+
+/**
+ * Fold every rule matching one of `classes` into a single property→value map,
+ * in source order, then the `:hover` pass on top.
+ *
+ * Source order alone is the right fold ONLY because every rule that reaches a
+ * site is a bare single-class selector — all (0,1,0), all (0,2,0) hovered — so
+ * nothing out-specifies anything. That premise is not assumed, it is asserted.
+ */
+function resolve(classes: string[]): {
+  rest: Record<string, string>;
+  hover: Record<string, string>;
+} {
+  const rules = topLevelRules();
+  const bare = new Set(classes.map((name) => `.${name}`));
+  const hovered = new Set(classes.map((name) => `.${name}:hover`));
+  const rest: Record<string, string> = {};
+  for (const rule of rules) {
+    if (!rule.selectors.some((selector) => bare.has(selector))) continue;
+    for (const [property, value] of declarations(rule.body)) rest[property] = value;
+  }
+  const hover = { ...rest };
+  for (const rule of rules) {
+    if (!rule.selectors.some((selector) => hovered.has(selector))) continue;
+    for (const [property, value] of declarations(rule.body)) hover[property] = value;
+  }
+  return { rest, hover };
+}
+
+function tsxFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return tsxFiles(path);
+    return entry.name.endsWith(".tsx") ? [path] : [];
+  });
+}
+
+/**
+ * The class list each call site actually wears, read off the markup rather
+ * than assumed — the extraction moves paint onto a base class the elements
+ * have to be given, and a typo there is silent in CSS.
+ */
+function callSiteClassLists(): Map<string, { files: string[]; classList: string[] }> {
+  const found = new Map<string, { files: string[]; classList: string[] }>();
+  for (const file of tsxFiles("src")) {
+    if (file.includes("__tests__")) continue;
+    for (const match of readFileSync(file, "utf8").matchAll(/class="([^"]+)"/g)) {
+      const classList = (match[1] ?? "").split(/\s+/).filter(Boolean);
+      const owned = classList.filter((name) => SITES.includes(name));
+      if (owned.length === 0) continue;
+      expect(owned, `${file}: one element wearing two site classes`).toHaveLength(1);
+      const key = owned[0] as string;
+      const seen = found.get(key);
+      if (seen) {
+        expect(seen.classList, `${key} worn with two different class lists`).toEqual(classList);
+        seen.files.push(file);
+      } else {
+        found.set(key, { files: [file], classList });
+      }
+    }
+  }
+  return found;
+}
+
+function resolveSite(name: string): {
+  rest: Record<string, string>;
+  hover: Record<string, string>;
+} {
+  const site = callSiteClassLists().get(name);
+  if (site === undefined) throw new Error(`${name} has no call site in the markup`);
+  return resolve(site.classList);
+}
+
+describe("#407 — the modal chrome extraction changes no pixel", () => {
+  it("reaches every call site through bare class selectors only", () => {
+    // The premise `resolve` folds on. A descendant selector, a media query or
+    // a second class would each out- or under-specify the base and make the
+    // source-order fold below a fiction.
+    const offenders = topLevelRules()
+      .flatMap((rule) => rule.selectors)
+      .filter((selector) => SITES.some((name) => selector.includes(`.${name}`)))
+      .filter((selector) => !/^\.[a-z0-9-]+(:hover)?$/.test(selector));
+    expect(offenders).toEqual([]);
+
+    const stripped = themeCss.replace(/\/\*[\s\S]*?\*\//g, "");
+    const reachable = new Set(topLevelRules().flatMap((rule) => rule.selectors));
+    for (const name of SITES) {
+      const mentions = [...stripped.matchAll(new RegExp(`\\.${name}\\b[^,{]*`, "g"))].map((match) =>
+        (match[0] ?? "").trim(),
+      );
+      for (const mention of mentions) {
+        expect(reachable.has(mention), `.${name}: "${mention}" is not a top-level rule`).toBe(true);
+      }
+    }
+  });
+
+  it("has every call site wearing exactly the class list its pin was taken from", () => {
+    const sites = callSiteClassLists();
+    expect([...sites.keys()].sort()).toEqual([...SITES].sort());
+    expect(Object.fromEntries([...sites].map(([name, { files }]) => [name, files.sort()]))).toEqual(
+      CALL_SITES,
+    );
+  });
+
+  it.each(CLOSE_SITES)("%s resolves to the one × shape", (name) => {
+    expect(resolveSite(name)).toEqual(CLOSE);
+  });
+
+  it.each(BACKDROP_VIEWPORT_SITES)("%s resolves to the one keyboard-aware scrim", (name) => {
+    expect(resolveSite(name)).toEqual(BACKDROP_VIEWPORT);
+  });
+
+  it.each(BACKDROP_FULL_SITES)("%s resolves to the one layout-viewport scrim", (name) => {
+    expect(resolveSite(name)).toEqual(BACKDROP_FULL);
+  });
+
+  it("keeps the two scrim geometries distinct rather than flattening them", () => {
+    // The divergence is real and deliberate: #143 shrank the info modals'
+    // backdrop to the VISIBLE region so the iOS keyboard cannot park the modal
+    // under itself. The three below never got that treatment. Silently
+    // upgrading them here would be a pixel change wearing an extraction's
+    // clothes, so each geometry is a named variant and neither is the default.
+    expect(Object.keys(BACKDROP_VIEWPORT.rest)).not.toContain("bottom");
+    expect(Object.keys(BACKDROP_FULL.rest)).not.toContain("height");
+    expect(Object.keys(BACKDROP_FULL.rest)).not.toContain("padding-top");
+  });
+});
+
+/** Which files wear each site class. A modal losing its × would show up here. */
+const CALL_SITES: Record<string, string[]> = {
+  "banlist-modal-backdrop": ["src/BanlistModal.tsx"],
+  "banlist-modal-close": ["src/BanlistModal.tsx"],
+  "confirm-modal-backdrop": ["src/ConfirmModal.tsx"],
+  "delete-account-backdrop": ["src/DeleteAccountModal.tsx"],
+  "image-upload-modal-backdrop": ["src/PrivacyModal.tsx"],
+  "links-modal-backdrop": ["src/LinksModal.tsx"],
+  "links-modal-close": ["src/LinksModal.tsx"],
+  "mode-modal-backdrop": ["src/ModeModal.tsx", "src/UmodeModal.tsx"],
+  "mode-modal-close": ["src/ModeModal.tsx", "src/UmodeModal.tsx"],
+  "names-modal-backdrop": ["src/NamesModal.tsx"],
+  "names-modal-close": ["src/NamesModal.tsx"],
+  "recover-modal-backdrop": ["src/RecoverModal.tsx"],
+  "recover-modal-close": ["src/RecoverModal.tsx"],
+  "registration-wizard-backdrop": ["src/RegistrationWizardModal.tsx"],
+  "registration-wizard-close": ["src/RegistrationWizardModal.tsx"],
+  "server-reply-modal-backdrop": ["src/ServerReplyModal.tsx"],
+  "server-reply-modal-close": ["src/ServerReplyModal.tsx"],
+  "service-modal-backdrop": ["src/ServiceModal.tsx"],
+  "service-modal-close": ["src/ServiceModal.tsx"],
+  "share-modal-backdrop": ["src/ShareSessionModal.tsx"],
+  "share-modal-close": ["src/ShareSessionModal.tsx"],
+  "who-modal-backdrop": ["src/WhoModal.tsx"],
+  "who-modal-close": ["src/WhoModal.tsx"],
+};
+
+// The three shapes, transcribed from the stylesheet at 6e81170. That all ten
+// × sites already resolved to ONE of them, character for character, is not an
+// assumption in this file — it is what the ten assertions above measured
+// BEFORE any base class existed. Their surviving the extraction unchanged is
+// the whole claim.
+
+const CLOSE = {
+  rest: {
+    display: "inline-flex",
+    "align-items": "center",
+    "justify-content": "center",
+    "min-width": "var(--tap-min)",
+    "min-height": "var(--tap-min)",
+    "margin-top": "-0.6rem",
+    "margin-right": "-0.5rem",
+    "margin-bottom": "-0.6rem",
+    "margin-left": "0",
+    "padding-top": "0",
+    "padding-right": "0",
+    "padding-bottom": "0",
+    "padding-left": "0",
+    background: "transparent",
+    color: "var(--muted)",
+    border: "none",
+    "font-family": "var(--font-mono)",
+    "font-size": "1.5rem",
+    "line-height": "1",
+    cursor: "pointer",
+  },
+  hover: {
+    display: "inline-flex",
+    "align-items": "center",
+    "justify-content": "center",
+    "min-width": "var(--tap-min)",
+    "min-height": "var(--tap-min)",
+    "margin-top": "-0.6rem",
+    "margin-right": "-0.5rem",
+    "margin-bottom": "-0.6rem",
+    "margin-left": "0",
+    "padding-top": "0",
+    "padding-right": "0",
+    "padding-bottom": "0",
+    "padding-left": "0",
+    background: "transparent",
+    color: "var(--fg)",
+    border: "none",
+    "font-family": "var(--font-mono)",
+    "font-size": "1.5rem",
+    "line-height": "1",
+    cursor: "pointer",
+  },
+};
+
+const BACKDROP_VIEWPORT_REST = {
+  position: "fixed",
+  left: "0",
+  right: "0",
+  top: "0",
+  height: "var(--viewport-height, 100dvh)",
+  background: "rgba(0, 0, 0, 0.6)",
+  display: "flex",
+  "align-items": "center",
+  "justify-content": "center",
+  "z-index": "1000",
+  "padding-top": "max(1rem, env(safe-area-inset-top))",
+  "padding-right": "1rem",
+  "padding-bottom": "max(1.5rem, env(safe-area-inset-bottom))",
+  "padding-left": "1rem",
+};
+
+const BACKDROP_FULL_REST = {
+  position: "fixed",
+  top: "0",
+  right: "0",
+  bottom: "0",
+  left: "0",
+  background: "rgba(0, 0, 0, 0.6)",
+  display: "flex",
+  "align-items": "center",
+  "justify-content": "center",
+  "z-index": "1000",
+};
+
+// A scrim has no hover affordance, and the extraction must not hand it one.
+const BACKDROP_VIEWPORT = { rest: BACKDROP_VIEWPORT_REST, hover: BACKDROP_VIEWPORT_REST };
+const BACKDROP_FULL = { rest: BACKDROP_FULL_REST, hover: BACKDROP_FULL_REST };

--- a/cicchetto/src/__tests__/modalChrome.test.ts
+++ b/cicchetto/src/__tests__/modalChrome.test.ts
@@ -221,6 +221,39 @@ function resolveSite(name: string): {
   return resolve(site.classList);
 }
 
+/** Every bare class in the sheet whose own rules resolve to exactly `shape`. */
+function classesResolvingTo(shape: Record<string, string>): string[] {
+  const names = new Set(
+    topLevelRules()
+      .flatMap((rule) => rule.selectors)
+      .filter((selector) => /^\.[a-z0-9-]+$/.test(selector))
+      .map((selector) => selector.slice(1)),
+  );
+  return [...names]
+    .filter((name) => {
+      const { rest } = resolve([name]);
+      const keys = Object.keys(rest);
+      return (
+        keys.length === Object.keys(shape).length && keys.every((key) => rest[key] === shape[key])
+      );
+    })
+    .sort();
+}
+
+/** Every element in the markup wearing the scrim base, as [file, classList]. */
+function backdropElements(): [string, string[]][] {
+  const found: [string, string[]][] = [];
+  for (const file of tsxFiles("src")) {
+    if (file.includes("__tests__")) continue;
+    for (const match of readFileSync(file, "utf8").matchAll(/class="([^"]+)"/g)) {
+      const classList = (match[1] ?? "").split(/\s+/).filter(Boolean);
+      if (classList.includes("modal-backdrop")) found.push([file, classList]);
+    }
+  }
+  expect(found.length, "no element wears .modal-backdrop").toBeGreaterThan(0);
+  return found;
+}
+
 describe("#407 — the modal chrome extraction changes no pixel", () => {
   it("reaches every call site through bare class selectors only", () => {
     // The premise `resolve` folds on. A descendant selector, a media query or
@@ -266,6 +299,28 @@ describe("#407 — the modal chrome extraction changes no pixel", () => {
 
   it.each(BACKDROP_FULL_SITES)("%s resolves to the one layout-viewport scrim", (name) => {
     expect(resolveSite(name)).toEqual(BACKDROP_FULL);
+  });
+
+  it("leaves no rule outside the bases carrying a base's whole shape", () => {
+    // The #740 failure mode: the shared rule lands, the clones stay beside it,
+    // and the next control is copied from whichever was nearer. Keyed on the
+    // WHOLE resolved shape rather than a few marker properties — a control
+    // that genuinely differs (`.links-modal-zoom`, two properties apart) is
+    // not a clone and must not be carved out by an exclusion list.
+    expect(classesResolvingTo(CLOSE.rest)).toEqual(["modal-chrome-button"]);
+    expect(classesResolvingTo(BACKDROP_BASE)).toEqual(["modal-backdrop"]);
+  });
+
+  it("gives every scrim exactly one geometry", () => {
+    // `.modal-backdrop` declares no bottom and no height on purpose, so a
+    // scrim that reaches the markup without a geometry variant is an
+    // invisible zero-height box — silent in CSS, and silent in a unit test
+    // that only checks the classes it expects to find.
+    const geometries = ["modal-backdrop-full", "modal-backdrop-viewport"];
+    for (const [file, classList] of backdropElements()) {
+      const worn = classList.filter((name) => geometries.includes(name));
+      expect(worn, `${file}: ${classList.join(" ")}`).toHaveLength(1);
+    }
   });
 
   it("keeps the two scrim geometries distinct rather than flattening them", () => {
@@ -369,6 +424,21 @@ const ZOOM_DELTA = { "margin-right": "0", "font-size": "1.4rem" };
 const ZOOM = {
   rest: { ...CLOSE.rest, ...ZOOM_DELTA },
   hover: { ...CLOSE.hover, ...ZOOM_DELTA },
+};
+
+// What `.modal-backdrop` declares on its own: paint and centring, no geometry.
+// Spelled out rather than derived from the two maps below, so the clone guard
+// keeps working off a transcription of the stylesheet and not off itself.
+const BACKDROP_BASE = {
+  position: "fixed",
+  left: "0",
+  right: "0",
+  top: "0",
+  background: "rgba(0, 0, 0, 0.6)",
+  display: "flex",
+  "align-items": "center",
+  "justify-content": "center",
+  "z-index": "1000",
 };
 
 const BACKDROP_VIEWPORT_REST = {

--- a/cicchetto/src/__tests__/modalChrome.test.ts
+++ b/cicchetto/src/__tests__/modalChrome.test.ts
@@ -12,8 +12,8 @@ import { themeCss } from "./helpers/themeCss";
 //
 // An extraction is a promise not to change any pixel, so the guard is not
 // "a base rule exists" — it is that the DECLARATIONS every call site resolves
-// to are byte-for-byte what they were before the base existed. The three maps
-// at the foot of this file were transcribed from the stylesheet as it stood at
+// to are byte-for-byte what they were before the base existed. The maps at the
+// foot of this file were transcribed from the stylesheet as it stood at
 // 6e81170 (origin/main, pre-extraction) and must survive it unchanged.
 //
 // jsdom applies no stylesheet, so this reads the source. It proves what the
@@ -33,6 +33,14 @@ const CLOSE_SITES = [
   "share-modal-close",
   "who-modal-close",
 ];
+
+/**
+ * Not a ×, but the same chrome shape: the links modal's zoom controls sit in
+ * the same header row and were cut from the same block, two properties apart.
+ * They are in the census because leaving them out would leave one 14-line copy
+ * of the base standing next to the base — the very thing #407 is removing.
+ */
+const CHROME_SITES = ["links-modal-zoom"];
 
 /** Scrims that #143 shrank to the visible region so the iOS keyboard fits. */
 const BACKDROP_VIEWPORT_SITES = [
@@ -55,7 +63,7 @@ const BACKDROP_FULL_SITES = [
   "image-upload-modal-backdrop",
 ];
 
-const SITES = [...CLOSE_SITES, ...BACKDROP_VIEWPORT_SITES, ...BACKDROP_FULL_SITES];
+const SITES = [...CLOSE_SITES, ...CHROME_SITES, ...BACKDROP_VIEWPORT_SITES, ...BACKDROP_FULL_SITES];
 
 type Rule = { selectors: string[]; body: string };
 
@@ -195,7 +203,7 @@ function callSiteClassLists(): Map<string, { files: string[]; classList: string[
       const seen = found.get(key);
       if (seen) {
         expect(seen.classList, `${key} worn with two different class lists`).toEqual(classList);
-        seen.files.push(file);
+        if (!seen.files.includes(file)) seen.files.push(file);
       } else {
         found.set(key, { files: [file], classList });
       }
@@ -248,6 +256,10 @@ describe("#407 — the modal chrome extraction changes no pixel", () => {
     expect(resolveSite(name)).toEqual(CLOSE);
   });
 
+  it.each(CHROME_SITES)("%s resolves to the × shape and exactly two deltas", (name) => {
+    expect(resolveSite(name)).toEqual(ZOOM);
+  });
+
   it.each(BACKDROP_VIEWPORT_SITES)("%s resolves to the one keyboard-aware scrim", (name) => {
     expect(resolveSite(name)).toEqual(BACKDROP_VIEWPORT);
   });
@@ -277,6 +289,7 @@ const CALL_SITES: Record<string, string[]> = {
   "image-upload-modal-backdrop": ["src/PrivacyModal.tsx"],
   "links-modal-backdrop": ["src/LinksModal.tsx"],
   "links-modal-close": ["src/LinksModal.tsx"],
+  "links-modal-zoom": ["src/LinksModal.tsx"],
   "mode-modal-backdrop": ["src/ModeModal.tsx", "src/UmodeModal.tsx"],
   "mode-modal-close": ["src/ModeModal.tsx", "src/UmodeModal.tsx"],
   "names-modal-backdrop": ["src/NamesModal.tsx"],
@@ -346,6 +359,16 @@ const CLOSE = {
     "line-height": "1",
     cursor: "pointer",
   },
+};
+
+// Spelled as the × shape plus its overrides, because that IS the finding: the
+// zoom control differs from the ten × buttons in two properties out of twenty.
+// Written out longhand instead, a later drift in a shared property would read
+// as an intended difference.
+const ZOOM_DELTA = { "margin-right": "0", "font-size": "1.4rem" };
+const ZOOM = {
+  rest: { ...CLOSE.rest, ...ZOOM_DELTA },
+  hover: { ...CLOSE.hover, ...ZOOM_DELTA },
 };
 
 const BACKDROP_VIEWPORT_REST = {

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -3565,17 +3565,112 @@ html.resize-dragging * {
   flex-shrink: 0;
 }
 
-/* Privacy modal — full-viewport backdrop + centred dialog. */
+/* ------------------------------------------------------------------ *
+ * Shared modal chrome (#407)
+ *
+ * The quiet button in a dialog header and the dim scrim behind the
+ * dialog, each declared once. Both were reached by copying a rule — ten
+ * `*-close` blocks and thirteen `*-backdrop` blocks — so a tap-target or
+ * safe-area fix landed on whichever modal someone had open and left the
+ * rest behind.
+ *
+ * Named for the SHAPE, not the role: eleven controls wear it and one of
+ * them is the links modal's zoom, not a ×. Calling the base
+ * `.modal-close` would have made that one keep its own fourteen-line
+ * copy, which is the defect. Same reasoning as #740's
+ * `.login-quiet-button`.
+ *
+ * Worn BESIDE the per-instance class (`class="modal-chrome-button
+ * share-modal-close"`), also the #740 convention: the base carries the
+ * paint, the per-instance name stays a selector contract for tests and
+ * e2e and a home for any real delta. `modalChrome.test.ts` pins what
+ * each site resolves to and holds the clones out.
+ * ------------------------------------------------------------------ */
 
-.image-upload-modal-backdrop {
+.modal-chrome-button {
+  /* #143 — 44px Apple-HIG tap target, matching the #133 card-× precedent
+     (`.whois-card-close` et al). Negative block margins pull the tall hit
+     box back out of the header row so the title stays vertically compact
+     (margins don't shrink the pointer target). The inline-end pull is for
+     the LAST control in the row; one that is not overrides it. */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: var(--tap-min);
+  min-height: var(--tap-min);
+  margin: -0.6rem -0.5rem -0.6rem 0;
+  padding: 0;
+  background: transparent;
+  color: var(--muted);
+  border: none;
+  font-family: var(--font-mono);
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.modal-chrome-button:hover {
+  color: var(--fg);
+}
+
+/* The scrim's paint and centring — but NOT its geometry. Every
+   `.modal-backdrop` must also wear exactly one of the two variants below;
+   on its own this rule is a zero-height box, which is deliberate. The two
+   geometries are a real divergence, so neither gets to be the default
+   nobody notices they inherited. */
+.modal-backdrop {
   position: fixed;
-  inset: 0;
+  left: 0;
+  right: 0;
+  top: 0;
   background: rgba(0, 0, 0, 0.6);
+  /* #987 — `center`, not `stretch`. On a flex backdrop `stretch` forces the
+     child to the full cross-axis extent, so the modal was viewport-tall
+     whatever it held and its own `max-height: var(--viewport-height)` read
+     like a cap that never bit: the box was already at that height because
+     the backdrop had put it there. Centred, the box sizes to content, the
+     max-height becomes a real ceiling, and the `overflow-y: auto` +
+     `touch-action: pan-y` already on the modal start earning their keep in
+     the tall case (large text, keyboard up) instead of being dead weight in
+     the short one. */
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1000;
 }
+
+/* Spans the LAYOUT viewport — the pre-#143 geometry. With the iOS keyboard
+   up the visible region is shorter than the layout viewport, so a centred
+   modal can end up partly under the keyboard. Named as its own variant
+   rather than quietly upgraded to the one below: that would move pixels,
+   and #407 is an extraction. */
+.modal-backdrop-full {
+  bottom: 0;
+}
+
+/* #143 — spans only the VISIBLE region (the same keyboard-aware var the
+   modal caps its max-height on), so `align-items: center` centres within
+   what the user can see. Across the layout viewport the backdrop filled the
+   full height while the visible region (visualViewport.height) is shorter
+   when the iOS keyboard is up — parking the modal's lower half under the
+   keyboard. No offsetTop anchor is needed: UX-6-D's `installSmartScrollPin`
+   clamps `vv.offsetTop`→0 (offsetTop is WebKit-broken, #297779; the
+   `translateY(offsetTop)` cancel failed across D6/D8 — see DESIGN_NOTES
+   2026-05-21 UX-6-D).
+
+   The padding is #143's safe-area inset, mirroring `.settings-drawer`
+   (~:1702). The backdrop spans the full visible region, so a full-height
+   modal would otherwise tuck its header under the iOS notch / status bar
+   (and the home indicator at the bottom). `max()` keeps the plain 1rem
+   /1.5rem padding on non-notched devices where the env() insets are 0.
+   With `align-items: center` a short modal stays centred; a full-height
+   one shrinks to the padding box and lands between the safe areas. */
+.modal-backdrop-viewport {
+  height: var(--viewport-height, 100dvh);
+  padding: max(1rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom)) 1rem;
+}
+
+/* Privacy modal — full-viewport backdrop + centred dialog. */
 
 .image-upload-modal {
   background: var(--bg);
@@ -4108,24 +4203,6 @@ html.resize-dragging * {
 /* #157 — delete-account confirm modal (type-your-name irreversibility
    gate). Mirrors the archive-modal scaffold; red-bordered to signal the
    destructive context. */
-.delete-account-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  /* #987 — `center`, not `stretch`. On a flex backdrop `stretch` forces the
-     child to the full cross-axis extent, so the modal was viewport-tall
-     whatever it held and its own `max-height: var(--viewport-height)` read
-     like a cap that never bit: the box was already at that height because the
-     backdrop had put it there. Centred, the box sizes to content, the
-     max-height becomes a real ceiling, and the `overflow-y: auto` +
-     `touch-action: pan-y` already on the modal start earning their keep in the
-     tall case (large text, keyboard up) instead of being dead weight in the
-     short one. `.confirm-modal-backdrop` (~:3878) has always had this. */
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-}
 
 .delete-account-modal {
   background: var(--bg);
@@ -4221,15 +4298,6 @@ html.resize-dragging * {
    channel, disconnect network). Replaces the removed #172 hold-to-close
    gesture. Centered dialog over a dim scrim; structure mirrors
    .delete-account-* (the closest existing confirm modal). */
-.confirm-modal-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-}
 
 .confirm-modal {
   background: var(--bg);
@@ -7167,38 +7235,6 @@ html.resize-dragging * {
    close button) but pins header + footer and scrolls only the body so
    the "#channel — N people" heading + "End of /NAMES list" count stay
    visible on large channels. */
-.names-modal-backdrop,
-.who-modal-backdrop,
-.links-modal-backdrop {
-  position: fixed;
-  left: 0;
-  right: 0;
-  top: 0;
-  /* #143 — span only the VISIBLE region (same keyboard-aware var the
-     modal caps its max-height on) instead of `inset: 0`, so
-     `align-items: center` centers within what the user can see. With
-     `inset: 0` the backdrop filled the full LAYOUT viewport while the
-     visible region (visualViewport.height) is shorter when the iOS
-     keyboard is up — parking the modal's lower half under the keyboard.
-     No offsetTop anchor is needed: UX-6-D's `installSmartScrollPin`
-     clamps `vv.offsetTop`→0 (offsetTop is WebKit-broken, #297779; the
-     `translateY(offsetTop)` cancel failed across D6/D8 — see
-     DESIGN_NOTES 2026-05-21 UX-6-D). */
-  height: var(--viewport-height, 100dvh);
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  /* #143 — safe-area insets, mirroring `.settings-drawer` (~:1702). The
-     backdrop spans the full visible region, so a full-height modal would
-     otherwise tuck its header under the iOS notch / status bar at the top
-     (and the home indicator at the bottom). `max()` keeps the plain 1rem
-     /1.5rem padding on non-notched devices where the env() insets are 0.
-     With `align-items: center` a short modal stays centred; a full-height
-     one shrinks to the padding box and lands between the safe areas. */
-  padding: max(1rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom)) 1rem;
-}
 
 .names-modal,
 .who-modal {
@@ -7236,33 +7272,6 @@ html.resize-dragging * {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.names-modal-close,
-.who-modal-close {
-  /* #143 — 44px Apple-HIG tap target, matching the #133 card-× precedent
-     (`.whois-card-close` et al). Negative block margins pull the tall
-     hit box back out of the header row so the title stays vertically
-     compact (margins don't shrink the pointer target). */
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: var(--tap-min);
-  min-height: var(--tap-min);
-  margin: -0.6rem -0.5rem -0.6rem 0;
-  padding: 0;
-  background: transparent;
-  color: var(--muted);
-  border: none;
-  font-family: var(--font-mono);
-  font-size: 1.5rem;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.names-modal-close:hover,
-.who-modal-close:hover {
-  color: var(--fg);
 }
 
 .names-modal-body,
@@ -7539,32 +7548,12 @@ html.resize-dragging * {
   flex: 0 0 auto;
 }
 
-.links-modal-zoom,
-.links-modal-close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: var(--tap-min);
-  min-height: var(--tap-min);
-  margin: -0.6rem 0;
-  padding: 0;
-  background: transparent;
-  color: var(--muted);
-  border: none;
-  font-family: var(--font-mono);
+/* The zoom pair is not the last control in the header row, so it does not
+   take the base's inline-end pull; its glyphs also sit a notch smaller than
+   the close button. Everything else is `.modal-chrome-button`. */
+.links-modal-zoom {
+  margin-right: 0;
   font-size: 1.4rem;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.links-modal-close {
-  margin-right: -0.5rem;
-  font-size: 1.5rem;
-}
-
-.links-modal-zoom:hover,
-.links-modal-close:hover {
-  color: var(--fg);
 }
 
 .links-modal-body {
@@ -7803,20 +7792,6 @@ html.resize-dragging * {
  * gradients (vjt: "a bit retro, but not skeuomorphic"). Theme-safe: only
  * existing --tokens, no new colors. */
 
-.mode-modal-backdrop {
-  position: fixed;
-  left: 0;
-  right: 0;
-  top: 0;
-  height: var(--viewport-height, 100dvh);
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: max(1rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom)) 1rem;
-}
-
 .mode-modal {
   background: var(--bg);
   color: var(--fg);
@@ -7860,27 +7835,6 @@ html.resize-dragging * {
   text-transform: none;
   letter-spacing: normal;
   font-size: 0.85rem;
-}
-
-.mode-modal-close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: var(--tap-min);
-  min-height: var(--tap-min);
-  margin: -0.6rem -0.5rem -0.6rem 0;
-  padding: 0;
-  background: transparent;
-  color: var(--muted);
-  border: none;
-  font-family: var(--font-mono);
-  font-size: 1.5rem;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.mode-modal-close:hover {
-  color: var(--fg);
 }
 
 .mode-modal-body {
@@ -8716,19 +8670,6 @@ html.resize-dragging * {
  * lines, a phosphor accent on the header sigil + a blinking block cursor in
  * the footer — a 2026 nod to classic-IRC MOTD/INFO screens. Theme-safe: all
  * colors come from the existing CSS vars, so it inherits every theme. */
-.server-reply-modal-backdrop {
-  position: fixed;
-  left: 0;
-  right: 0;
-  top: 0;
-  height: var(--viewport-height, 100dvh);
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: max(1rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom)) 1rem;
-}
 
 .server-reply-modal {
   background: var(--bg);
@@ -8771,27 +8712,6 @@ html.resize-dragging * {
 .server-reply-modal-sigil {
   color: var(--link, var(--fg));
   margin-right: 0.5rem;
-}
-
-.server-reply-modal-close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: var(--tap-min);
-  min-height: var(--tap-min);
-  margin: -0.6rem -0.5rem -0.6rem 0;
-  padding: 0;
-  background: transparent;
-  color: var(--muted);
-  border: none;
-  font-family: var(--font-mono);
-  font-size: 1.5rem;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.server-reply-modal-close:hover {
-  color: var(--fg);
 }
 
 .server-reply-modal-body {
@@ -8849,19 +8769,6 @@ html.resize-dragging * {
  * a leading phosphor `>` sigil + a borderless mono input, so the modal reads
  * as a confined terminal console for the service. Theme-safe: all colors come
  * from the existing CSS vars. */
-.service-modal-backdrop {
-  position: fixed;
-  left: 0;
-  right: 0;
-  top: 0;
-  height: var(--viewport-height, 100dvh);
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: max(1rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom)) 1rem;
-}
 
 .service-modal {
   background: var(--bg);
@@ -8904,27 +8811,6 @@ html.resize-dragging * {
 .service-modal-sigil {
   color: var(--link, var(--fg));
   margin-right: 0.5rem;
-}
-
-.service-modal-close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: var(--tap-min);
-  min-height: var(--tap-min);
-  margin: -0.6rem -0.5rem -0.6rem 0;
-  padding: 0;
-  background: transparent;
-  color: var(--muted);
-  border: none;
-  font-family: var(--font-mono);
-  font-size: 1.5rem;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.service-modal-close:hover {
-  color: var(--fg);
 }
 
 .service-modal-body {
@@ -9010,19 +8896,6 @@ html.resize-dragging * {
  * services console (backdrop scrim, pinned header, scrollable body) but
  * step-driven: an intro/email/password/register/code/verify sequence with
  * a Back/Retry/Next footer. Theme-safe — all colors from CSS vars. */
-.registration-wizard-backdrop {
-  position: fixed;
-  left: 0;
-  right: 0;
-  top: 0;
-  height: var(--viewport-height, 100dvh);
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: max(1rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom)) 1rem;
-}
 
 .registration-wizard {
   background: var(--bg);
@@ -9060,27 +8933,6 @@ html.resize-dragging * {
 
 .registration-wizard-sigil {
   margin-right: 0.5rem;
-}
-
-.registration-wizard-close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: var(--tap-min);
-  min-height: var(--tap-min);
-  margin: -0.6rem -0.5rem -0.6rem 0;
-  padding: 0;
-  background: transparent;
-  color: var(--muted);
-  border: none;
-  font-family: var(--font-mono);
-  font-size: 1.5rem;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.registration-wizard-close:hover {
-  color: var(--fg);
 }
 
 .registration-wizard-steps {
@@ -9223,19 +9075,6 @@ html.resize-dragging * {
 
 /* #581 — "recover my identity" progress modal. Server-driven step list +
  * terminal outcome. Mirrors the registration-wizard / service-modal shell. */
-.recover-modal-backdrop {
-  position: fixed;
-  left: 0;
-  right: 0;
-  top: 0;
-  height: var(--viewport-height, 100dvh);
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: max(1rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom)) 1rem;
-}
 
 .recover-modal {
   background: var(--bg);
@@ -9273,27 +9112,6 @@ html.resize-dragging * {
 
 .recover-modal-sigil {
   margin-right: 0.5rem;
-}
-
-.recover-modal-close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: var(--tap-min);
-  min-height: var(--tap-min);
-  margin: -0.6rem -0.5rem -0.6rem 0;
-  padding: 0;
-  background: transparent;
-  color: var(--muted);
-  border: none;
-  font-family: var(--font-mono);
-  font-size: 1.5rem;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.recover-modal-close:hover {
-  color: var(--fg);
 }
 
 .recover-modal-body {
@@ -9883,19 +9701,6 @@ html.resize-dragging * {
    surface that supersedes the #376 inline card: list rows + a mask-builder
    add row + a per-row remove ×. The op-gate is a HINT (`.banlist-modal-deemph`
    dims but never disables — vjt decision #2). */
-.banlist-modal-backdrop {
-  position: fixed;
-  left: 0;
-  right: 0;
-  top: 0;
-  height: var(--viewport-height, 100dvh);
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: max(1rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom)) 1rem;
-}
 
 .banlist-modal {
   background: var(--bg);
@@ -9939,27 +9744,6 @@ html.resize-dragging * {
   text-transform: none;
   letter-spacing: normal;
   font-size: 0.85rem;
-}
-
-.banlist-modal-close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: var(--tap-min);
-  min-height: var(--tap-min);
-  margin: -0.6rem -0.5rem -0.6rem 0;
-  padding: 0;
-  background: transparent;
-  color: var(--muted);
-  border: none;
-  font-family: var(--font-mono);
-  font-size: 1.5rem;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.banlist-modal-close:hover {
-  color: var(--fg);
 }
 
 .banlist-modal-body {
@@ -11994,20 +11778,6 @@ audio.media-viewer-media {
   font-size: 0.85em;
 }
 
-.share-modal-backdrop {
-  position: fixed;
-  left: 0;
-  right: 0;
-  top: 0;
-  height: var(--viewport-height, 100dvh);
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: max(1rem, env(safe-area-inset-top)) 1rem max(1.5rem, env(safe-area-inset-bottom)) 1rem;
-}
-
 .share-modal {
   background: var(--bg);
   color: var(--fg);
@@ -12049,27 +11819,6 @@ audio.media-viewer-media {
   font-weight: normal;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-}
-
-.share-modal-close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: var(--tap-min);
-  min-height: var(--tap-min);
-  margin: -0.6rem -0.5rem -0.6rem 0;
-  padding: 0;
-  background: transparent;
-  color: var(--muted);
-  border: none;
-  font-family: var(--font-mono);
-  font-size: 1.5rem;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.share-modal-close:hover {
-  color: var(--fg);
 }
 
 .share-modal-qr-heading {

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35213,6 +35213,7 @@ follow-up slices — the machinery, the gate and the measurement pattern are wha
 this one had to establish. `wireTypesAssert.ts` is NOT in that count: it is a
 compile-time bridge between `api.ts` hand-mirrors and `wireTypes.ts`, and it
 disappears when those mirrors do, not when the narrowers do.
+
 ## 2026-08-09 — #407: an extraction is a promise, and a promise needs a witness
 
 Twenty-four modal controls each carried a copy of one of three declaration

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35213,3 +35213,70 @@ follow-up slices — the machinery, the gate and the measurement pattern are wha
 this one had to establish. `wireTypesAssert.ts` is NOT in that count: it is a
 compile-time bridge between `api.ts` hand-mirrors and `wireTypes.ts`, and it
 disappears when those mirrors do, not when the narrowers do.
+## 2026-08-09 — #407: an extraction is a promise, and a promise needs a witness
+
+Twenty-four modal controls each carried a copy of one of three declaration
+blocks: eleven dialog-header buttons, ten keyboard-aware scrims, three older
+scrims. The cost is visible in the history — #143 (44px tap target, safe-area
+insets) and #987 (`align-items: center`, not `stretch`) each landed on whichever
+modal their author had open, and the rest kept the old numbers.
+
+**The pin landed first, against the stylesheet with no base in it.** Deduping
+CSS is a promise not to move a pixel, and the promise is worth what it can be
+checked against. `modalChrome.test.ts` resolves each call site the way the
+cascade would — every rule reaching it, folded in source order, `:hover` on top
+— and compares it to a map transcribed from the sheet at 6e81170. It passed
+before the extraction existed; the extraction commit does not touch the test
+file, so the same literals are green on both sides. Two premises that would make
+the fold a fiction are asserted rather than assumed: that nothing reaches these
+classes except a bare single-class selector (so specificity is uniform and
+source order decides), and that the class list being resolved is the one the
+markup actually wears.
+
+**Box shorthands must expand to longhands, or the pin lies in both directions.**
+Nine of the ten × rules spelled their margin as one shorthand;
+`.links-modal-close` reached the same four values through `margin: -0.6rem 0`
+plus a `margin-right` longhand in a second rule with the same selector. The two
+scrim geometries spelled the same edges as `inset: 0` and as `left/right/top: 0`.
+Compared as written, identical boxes read as differences and a real difference
+could hide under a spelling.
+
+**Name the base for the SHAPE, not the role — the role name would have kept a
+clone alive.** The issue proposed `.modal-close`. Grepping the sheet made that
+look right; reading it did not. `.links-modal-close` is the second selector of
+`.links-modal-zoom, .links-modal-close`, and the links modal's zoom buttons wear
+the same block two properties apart (`margin-right: 0`, because they are not the
+last control in the row, and `font-size: 1.4rem`). A base called `.modal-close`
+could not honestly take the zoom, so the zoom would have kept its own
+fourteen-declaration copy standing beside the thing meant to end copies.
+`.modal-chrome-button` takes all eleven and the zoom keeps only its two deltas.
+Same reasoning, same convention as #740's `.login-quiet-button`: worn beside the
+per-instance class, which stays a selector contract — which is why not one
+existing e2e selector had to move.
+
+**The scrim gets a base and TWO named geometries, and no default.**
+`.modal-backdrop` carries the paint and the centring and deliberately no
+geometry; `.modal-backdrop-full` spans the layout viewport, `.modal-backdrop-viewport`
+spans only the visible region (the #143 keyboard fix). Ten scrims have that fix
+and three do not, and with the iOS keyboard up that is a difference in behaviour,
+not in spelling. Either choice of default is a bad one: defaulting to `-full`
+hands the next modal the worse behaviour without anyone choosing it, and
+defaulting to `-viewport` moves three modals' pixels under cover of a refactor.
+So the base alone is a zero-height box and every site names its geometry. That
+failure mode — a scrim shipped with no variant, invisible but present — is
+silent in CSS, so it is asserted against the markup.
+
+**The clone guard is keyed on the whole shape, so it needs no exclusion list.**
+It asks which classes in the sheet resolve to exactly a base's declaration set
+and expects the base alone. `.links-modal-zoom` differs in two properties out of
+twenty and falls out of the rule by itself, rather than being carved out by a
+list the next reader would extend instead of question.
+
+**What the file cannot prove.** jsdom applies no stylesheet: this is an
+assertion about what the cascade is asked to do, never about what a browser
+paints. Existing e2e already hit-tests two of the three shapes in a real browser
+— `issue219` clicks `.names-modal-close` and waits for the modal to hide,
+`issue232` clicks `.mode-modal-backdrop` at (6,6), a corner click that a
+mis-sized scrim would miss. The `-full` geometry has no such witness; the confirm
+and delete-account scrims both dismiss on backdrop click and neither is clicked
+by any spec.


### PR DESCRIPTION
## What

Twenty-four modal controls each carried a copy of one of three declaration blocks — eleven dialog-header buttons, ten keyboard-aware scrims, three older scrims. `#143` (44px tap target, safe-area insets) and `#987` (`align-items: center`, not `stretch`) are both visible in the history as fixes that landed on whichever modal their author had open, leaving the rest on the old numbers.

Net: **382 stylesheet lines out, 157 in.** No e2e selector moved.

## The pin lands first, and the extraction does not touch it

Deduping CSS is a promise not to move a pixel, and a promise is worth what it can be checked against. The first two commits add `modalChrome.test.ts` and pass **against the stylesheet with no base class in it**. It resolves each call site the way the cascade would — every rule reaching it, folded in source order, `:hover` on top — and compares it to maps transcribed from the sheet at `6e81170`.

The extraction commit changes **zero lines of that test file**. Same twenty-four expected maps, green on both sides of the change. That is the evidence, not a claim.

Two premises that would make the fold a fiction are asserted, not assumed:

- nothing reaches these classes except a bare single-class selector, so specificity is uniform and source order decides;
- the class list being resolved is the one the markup actually wears.

**Box shorthands expand to longhands**, which is not tidiness. Nine of the ten × rules spell their margin as one shorthand; `.links-modal-close` reaches the same four values through `margin: -0.6rem 0` plus a `margin-right` longhand in a second rule with the same selector. The two scrim geometries spell the same edges as `inset: 0` and as `left/right/top: 0`. Compared as written, identical boxes read as differences and a real difference hides under a spelling.

## Why the base is `.modal-chrome-button` and not `.modal-close`

The issue proposed `.modal-close`. Grepping made that look right; reading did not. `.links-modal-close` is the **second selector** of `.links-modal-zoom, .links-modal-close` — the links modal's zoom buttons wear the same block, two properties apart (`margin-right: 0`, because they are not the last control in the row, and `font-size: 1.4rem`).

A base honestly called `.modal-close` could not take the zoom, so the zoom would have kept a fourteen-declaration copy of the base standing right beside it: the defect surviving under a new name. `.modal-chrome-button` takes all eleven; the zoom keeps only its two deltas.

Same reasoning and same convention as **#740** (`.login-quiet-button`, worn beside the per-instance class, which stays a selector contract) — which is why not one existing test or e2e selector had to change.

## The scrim gets two named geometries and no default

`.modal-backdrop` carries the paint and the centring and deliberately **no geometry**. `.modal-backdrop-full` spans the layout viewport; `.modal-backdrop-viewport` spans only the visible region — the `#143` keyboard fix. Ten scrims have that fix and three do not, and with the iOS keyboard up that is a difference in behaviour, not in spelling.

Either default is a bad one: `-full` would hand the next modal the worse behaviour without anyone choosing it, and `-viewport` would move three modals' pixels under cover of a refactor. So the base alone is a zero-height box and every site names its geometry.

## Guards, and what killed them

Both guards were verified by mutation, each mutant run and reverted:

| mutant | result |
|---|---|
| `.share-modal-close` font-size 1.5rem → 1.4rem | 1 failed / 25 passed — `share-modal-close resolves to the one × shape` |
| `.banlist-modal-backdrop` z-index 1000 → 1001 | 1 failed / 25 passed — `banlist-modal-backdrop resolves to the one keyboard-aware scrim` |
| add `.some-shell .who-modal-close { }` | 1 failed / 25 passed — `reaches every call site through bare class selectors only` |
| copy the base block verbatim as `.newfangled-modal-close` | 1 failed / 28 passed — `leaves no rule outside the bases carrying a base's whole shape` |
| drop the geometry variant from one scrim's markup | 2 failed / 27 passed — the geometry guard **and** the pin (removing a variant is both) |

The clone guard is keyed on the **whole** resolved shape, so `.links-modal-zoom` — two properties apart — falls out of the rule by itself rather than needing an exclusion list.

## Gates

- `bun run check` — exit 0. 61 warnings / 5 infos, **the same counts as `origin/main`**; none added.
- `bun run test` — 266 files, 4941 tests, all passing, on the rebased tree.
- Working tree verified clean before *and* after both gates.

## What this does NOT prove

jsdom paints nothing: every assertion here is about what the cascade is *asked* to do. Existing e2e already hit-tests two of the three shapes in a real browser — `issue219` clicks `.names-modal-close` and waits for the modal to hide; `issue232` clicks `.mode-modal-backdrop` at `(6, 6)`, a corner click a mis-sized scrim would miss.

**The `-full` geometry had no browser witness, so this PR adds one** — `e2e/tests/issue407-modal-backdrop-full-bottom-edge.spec.ts`, a single untagged test (chromium only, so the e2e count moves by exactly +1).

It clicks the confirm modal's scrim at the **bottom** edge, not the corner `issue232` uses. That distinction is the whole point: a click at `(6, 6)` lands on anything anchored at `top: 0`, so it passes whether the scrim has a height or not and cannot tell `.modal-backdrop-full` from the bare base. `bottom: 0` is the single declaration the variant contributes, so the click goes where only that declaration can carry it. The box is measured first so a collapse reports as a geometry failure rather than as an out-of-bounds click position; the measurement is the diagnostic, the click is the oracle.

**It has not been run.** No e2e lane was available (`_build` is shared and held). It is expected to run in this PR's integration job. Its static gate did run and is green — and was proven to actually read the file: injecting a type error makes `bun run check` exit 1 naming `issue407-modal-backdrop-full-bottom-edge.spec.ts` at the injected line, restored clean afterwards. That is a typecheck, not a pass: **if the spec is wrong, CI is where it shows.**
