### PR TITLE
test(#499): pin the circuit-open precondition instead of racing its cooldown

### DIFF
--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35107,3 +35107,71 @@ second copy of the flow set in a module that has no business owning one —
 worse than the gap. The set is closed by construction upstream:
 `Admission.check_capacity/1` takes a `capacity_input` whose `flow` is typed
 `flow()`.
+
+## 2026-08-09 — #499: the circuit was not bleeding across tests, it was healing inside one
+
+**The filed diagnosis did not survive measurement.** Issue #499 attributed an
+intermittent `login_test.exs` red to `Grappa.Admission.NetworkCircuit`'s
+singleton ETS table bleeding across tests serially — sqlite recycles rowids, so
+a fresh network inherits an id a previous test already tripped the circuit for.
+It proposed two test-infra routes: reset the ETS table between tests, or hand
+the affected tests non-colliding ids. Neither was implemented, because neither
+addresses what actually happens.
+
+Two facts falsify the premise. First, `login_test.exs` has called
+`AdmissionStateHelpers.reset_network_circuit/0` from a per-test `setup` since
+2026-05-14 (an inline ETS-delete loop before that) — the very mitigation the
+issue proposes as the fix had been in that file for two months before the issue
+was filed. Second, the instrumented failure shows no foreign row at all. The
+`network_circuit_open` case, run under host load with the ETS snapshot printed
+at the cast drain, reported one row — `{1, 3, _, :open, _}`, count exactly at
+threshold, written by that same test — and `NetworkCircuit.check/1` on the very
+next line already returning `:ok`. Nothing bled in. The circuit the test had
+just opened had already closed itself.
+
+**`check/1` is the only clock-dependent reader, and the test-env cooldown is
+shorter than the tests that depend on it.** An `:open` row reads back as `:ok`
+the instant `now >= cooled_at_ms`; no writer is involved, so no reset can
+prevent it. `config/test.exs` sets `network_circuit_cooldown_ms: 50` (±25%
+jitter → 38..62ms) to keep the cooldown-expiry cases cheap to sleep through.
+That is shorter than the work a *consumer* test does between opening the circuit
+and reading it back, so under load the precondition evaporates and the consumer
+asserts against a circuit it never closed. The same shape existed at ten sites
+across six files: every one of them established "circuit is open" through the
+production transition and then read it back through a clock-dependent path
+(`check/1`, or `AdminWire`'s `retry_after_seconds`).
+
+**The cure is a precondition that cannot decay.**
+`AdmissionStateHelpers.open_circuit!/1` drives the real `record_failure/1`
+transition, raises if it did not land, then pins `cooled_at_ms` a minute out.
+The production module is untouched — its runtime shape is deliberate, and the
+defect was never in it. The split is principled rather than an exclusion list:
+tests where open-ness is a PRECONDITION use the helper; the four whose SUBJECT
+is the clock — the `retry_after` upper bound, cooldown expiry, and the
+`:cooldown_expired` telemetry pair — keep driving the real cooldown, because
+pinning it would delete what they test.
+
+**Raising the cooldown was rejected.** It is the same band-aid one size larger:
+the race window widens but stays a race, and it would have slowed the two
+expiry tests by exactly the amount of headroom bought. A flake is cured by
+making the setup deterministic, not by giving it more room to be lucky in.
+
+**The guard is deterministic where the bug was probabilistic.** The new case
+sleeps twice the configured cooldown — clearing the jitter ceiling — and
+asserts the circuit still reads open. Deleting the pin from the helper turns
+exactly that one assertion red, every run, with `right: :ok`: the circuit
+self-healing, named. Measured incidence for the original symptom: 3 reds in 30
+loaded runs before, 0 in 20 after, with the deterministic guard as the proof
+and the load runs as corroboration.
+
+**What this did not fix, and should not be read as fixing.** Under the same
+load `login_test.exs` reds on eleven other cases that never touch the circuit —
+`433` nick negotiation, handshake waits, the mode-2 admission guard. They share
+a substrate (the in-process `IRCServer` fake plus `pool_size: 1` sqlite), not a
+cause. One of them is circuit-adjacent enough to be worth naming: the `#960`
+boundary case fails on its FIRST assertion, with `Login.login` returning
+`{:error, :connect_timeout}` while the session process logs
+`{:connect_failed, :econnrefused}` — the login surfaces a timeout for what was
+actually a refusal, losing the diagnosis. That is a separate defect on the login
+path, not circuit isolation, and it is left for its own issue rather than
+widened into this one.

--- a/test/grappa/admission/network_circuit_test.exs
+++ b/test/grappa/admission/network_circuit_test.exs
@@ -57,11 +57,7 @@ defmodule Grappa.Admission.NetworkCircuitTest do
     end
 
     test "isolated per-network_id" do
-      for _ <- 1..NetworkCircuit.threshold() do
-        :ok = NetworkCircuit.record_failure(1)
-      end
-
-      _ = :sys.get_state(NetworkCircuit)
+      :ok = AdmissionStateHelpers.open_circuit!(1)
 
       assert {:error, :open, _} = NetworkCircuit.check(1)
       assert NetworkCircuit.check(2) == :ok
@@ -81,11 +77,8 @@ defmodule Grappa.Admission.NetworkCircuitTest do
     end
 
     test "clears open circuit" do
-      for _ <- 1..NetworkCircuit.threshold() do
-        :ok = NetworkCircuit.record_failure(1)
-      end
+      :ok = AdmissionStateHelpers.open_circuit!(1)
 
-      _ = :sys.get_state(NetworkCircuit)
       assert {:error, :open, _} = NetworkCircuit.check(1)
 
       :ok = NetworkCircuit.record_success(1)
@@ -130,6 +123,25 @@ defmodule Grappa.Admission.NetworkCircuitTest do
       Process.sleep(NetworkCircuit.cooldown_ms() + 30)
 
       assert NetworkCircuit.check(1) == :ok
+    end
+  end
+
+  describe "#499 — AdmissionStateHelpers.open_circuit!/1" do
+    test "the pinned open state outlives the configured cooldown" do
+      # The guard for every consumer test that treats "circuit is open" as a
+      # precondition. `check/1` self-heals on the wall clock, and the test-env
+      # cooldown (~50ms) is shorter than the work a consumer does before
+      # reading the circuit back — that decay, not cross-test ETS bleed, is
+      # what reddened `login_test.exs`'s network_circuit_open case. Sleeping
+      # 2x the configured cooldown clears the ±25% jitter ceiling, so dropping
+      # the pin from the helper turns this RED deterministically.
+      net_id = 3001
+
+      :ok = AdmissionStateHelpers.open_circuit!(net_id)
+
+      Process.sleep(NetworkCircuit.cooldown_ms() * 2)
+
+      assert {:error, :open, _} = NetworkCircuit.check(net_id)
     end
   end
 
@@ -181,12 +193,7 @@ defmodule Grappa.Admission.NetworkCircuitTest do
       attach_circuit_event([:grappa, :admission, :circuit, :open])
       net_id = 1002
 
-      # Open the circuit.
-      for _ <- 1..NetworkCircuit.threshold() do
-        :ok = NetworkCircuit.record_failure(net_id)
-      end
-
-      _ = :sys.get_state(NetworkCircuit)
+      :ok = AdmissionStateHelpers.open_circuit!(net_id)
 
       # Drain the first (and only) event.
       assert_receive {:telemetry, [:grappa, :admission, :circuit, :open], %{}, %{network_id: ^net_id}},
@@ -205,11 +212,7 @@ defmodule Grappa.Admission.NetworkCircuitTest do
       attach_circuit_event([:grappa, :admission, :circuit, :close])
       net_id = 1003
 
-      for _ <- 1..NetworkCircuit.threshold() do
-        :ok = NetworkCircuit.record_failure(net_id)
-      end
-
-      _ = :sys.get_state(NetworkCircuit)
+      :ok = AdmissionStateHelpers.open_circuit!(net_id)
 
       :ok = NetworkCircuit.record_success(net_id)
       _ = :sys.get_state(NetworkCircuit)

--- a/test/grappa/admission_test.exs
+++ b/test/grappa/admission_test.exs
@@ -9,7 +9,7 @@ defmodule Grappa.AdmissionTest do
 
   alias Grappa.{Admission, AdmissionStateHelpers, Repo, SessionRegistry}
   alias Grappa.Admission.Captcha.{Disabled, HCaptcha, Turnstile}
-  alias Grappa.Admission.{Config, NetworkCircuit}
+  alias Grappa.Admission.Config
   alias Grappa.Networks.Network
   alias Grappa.Session.Server, as: SessionServer
 
@@ -25,11 +25,7 @@ defmodule Grappa.AdmissionTest do
   describe "check_capacity/1 — network circuit gate" do
     test "open circuit short-circuits with {:network_circuit_open, retry_after}",
          %{network: net} do
-      for _ <- 1..NetworkCircuit.threshold() do
-        :ok = NetworkCircuit.record_failure(net.id)
-      end
-
-      _ = :sys.get_state(NetworkCircuit)
+      :ok = AdmissionStateHelpers.open_circuit!(net.id)
 
       input = %{
         network_id: net.id,
@@ -509,11 +505,7 @@ defmodule Grappa.AdmissionTest do
     test "emits :capacity, :reject when circuit open", %{network: net} do
       attach_reject_event()
 
-      for _ <- 1..NetworkCircuit.threshold() do
-        :ok = NetworkCircuit.record_failure(net.id)
-      end
-
-      _ = :sys.get_state(NetworkCircuit)
+      :ok = AdmissionStateHelpers.open_circuit!(net.id)
 
       input = %{
         network_id: net.id,

--- a/test/grappa/operator_test.exs
+++ b/test/grappa/operator_test.exs
@@ -184,11 +184,8 @@ defmodule Grappa.OperatorTest do
 
       AdmissionStateHelpers.reset_network_circuit()
 
-      for _ <- 1..NetworkCircuit.threshold() do
-        :ok = NetworkCircuit.record_failure(network.id)
-      end
+      :ok = AdmissionStateHelpers.open_circuit!(network.id)
 
-      _ = :sys.get_state(NetworkCircuit)
       assert {:error, :open, _} = NetworkCircuit.check(network.id)
 
       assert {:ok, nil} = Operator.reset_circuit(network.id)

--- a/test/grappa/visitors/login_test.exs
+++ b/test/grappa/visitors/login_test.exs
@@ -716,12 +716,7 @@ defmodule Grappa.Visitors.LoginTest do
 
     test "network_circuit_open → {:error, {:network_circuit_open, retry_after}}",
          %{network: net} do
-      for _ <- 1..NetworkCircuit.threshold() do
-        :ok = NetworkCircuit.record_failure(net.id)
-      end
-
-      # Flush GenServer cast queue before checking.
-      _ = :sys.get_state(NetworkCircuit)
+      :ok = AdmissionStateHelpers.open_circuit!(net.id)
 
       # Task 5: Login surfaces the tuple shape so FallbackController can
       # emit Retry-After. Bare atom would lose the cooldown payload.

--- a/test/grappa_web/controllers/admin/circuit_controller_test.exs
+++ b/test/grappa_web/controllers/admin/circuit_controller_test.exs
@@ -59,11 +59,8 @@ defmodule GrappaWeb.Admin.CircuitControllerTest do
       slug = "c-reset-#{System.unique_integer([:positive])}"
       {:ok, net} = Networks.find_or_create_network(%{slug: slug})
 
-      for _ <- 1..NetworkCircuit.threshold() do
-        :ok = NetworkCircuit.record_failure(net.id)
-      end
+      :ok = AdmissionStateHelpers.open_circuit!(net.id)
 
-      _ = :sys.get_state(NetworkCircuit)
       assert {:error, :open, _} = NetworkCircuit.check(net.id)
 
       session = admin_session()

--- a/test/grappa_web/controllers/admin/networks_controller_test.exs
+++ b/test/grappa_web/controllers/admin/networks_controller_test.exs
@@ -104,11 +104,7 @@ defmodule GrappaWeb.Admin.NetworksControllerTest do
       slug = "g-dirty-#{System.unique_integer([:positive])}"
       {:ok, net} = Networks.find_or_create_network(%{slug: slug})
 
-      for _ <- 1..NetworkCircuit.threshold() do
-        :ok = NetworkCircuit.record_failure(net.id)
-      end
-
-      _ = :sys.get_state(NetworkCircuit)
+      :ok = AdmissionStateHelpers.open_circuit!(net.id)
 
       session = admin_session()
       conn = conn |> put_bearer(session.id) |> get("/admin/networks")

--- a/test/support/admission_state_helpers.ex
+++ b/test/support/admission_state_helpers.ex
@@ -67,6 +67,11 @@ defmodule Grappa.AdmissionStateHelpers do
   @reset_registry_attempts 600
   @reset_registry_poll_ms 25
 
+  # How far ahead `open_circuit!/1` pins `cooled_at_ms`. Any value that
+  # outlives a single test works; a minute matches the forged row the
+  # H7 case in `network_circuit_test.exs` already uses.
+  @pinned_cooldown_ms 60_000
+
   @doc """
   Clear every per-`network_id` row from the `NetworkCircuit` ETS table,
   every per-`(subject, network_id)` row from the `Backoff` ETS table,
@@ -94,10 +99,60 @@ defmodule Grappa.AdmissionStateHelpers do
   @spec reset_network_circuit() :: :ok
   def reset_network_circuit do
     for {network_id, _, _, _, _} <- NetworkCircuit.entries() do
-      :ets.delete(:admission_network_circuit_state, network_id)
+      :ets.delete(NetworkCircuit.table_name(), network_id)
     end
 
     :ok
+  end
+
+  @doc """
+  Drive `NetworkCircuit` to `:open` for `network_id` through the
+  production `record_failure/1` transition, then pin the row's
+  `cooled_at_ms` a minute out so the open state cannot decay while the
+  test is still running. Raises if the transition did not happen.
+
+  ## Why the pin (GH #499)
+
+  `NetworkCircuit.check/1` is the only clock-dependent reader: an
+  `:open` row reads as `:ok` the moment `now >= cooled_at_ms`, without
+  anything having rewritten it. `config/test.exs` sets
+  `network_circuit_cooldown_ms: 50` (±25% jitter → 38..62ms) so the
+  cooldown-expiry tests stay cheap — which is far shorter than the work
+  a *consumer* test does between opening the circuit and reading it
+  back. The circuit then self-heals mid-test and the consumer observes
+  a closed circuit it never closed.
+
+  Measured on `login_test.exs`'s `network_circuit_open` case under
+  host load: the row was `{count: 3, :open}` at the drain and
+  `check/1` on the very next line already returned `:ok` — a
+  self-inflicted expiry, no cross-test bleed involved.
+
+  So: tests where "the circuit is open" is a PRECONDITION use this
+  helper and get a fact that does not decay. Tests whose SUBJECT is the
+  clock — the retry_after bound, cooldown expiry, the
+  `:cooldown_expired` telemetry — must keep driving the real cooldown
+  and deliberately do NOT use it.
+  """
+  @spec open_circuit!(integer()) :: :ok
+  def open_circuit!(network_id) when is_integer(network_id) do
+    for _ <- 1..NetworkCircuit.threshold() do
+      :ok = NetworkCircuit.record_failure(network_id)
+    end
+
+    # record_failure/1 is a cast; drain the mailbox before reading back.
+    _ = :sys.get_state(NetworkCircuit)
+
+    case :ets.lookup(NetworkCircuit.table_name(), network_id) do
+      [{^network_id, count, window_start_ms, :open, _}] ->
+        pinned_cooled_at = System.monotonic_time(:millisecond) + @pinned_cooldown_ms
+        true = :ets.insert(NetworkCircuit.table_name(), {network_id, count, window_start_ms, :open, pinned_cooled_at})
+
+        :ok
+
+      other ->
+        raise "AdmissionStateHelpers.open_circuit!: #{NetworkCircuit.threshold()} failures " <>
+                "on network_id=#{network_id} did not open the circuit; row is #{inspect(other)}"
+    end
   end
 
   @doc """


### PR DESCRIPTION
Refs #499.

## The filed diagnosis did not survive measurement

#499 attributes an intermittent `login_test.exs` red to `NetworkCircuit`'s
singleton ETS table bleeding across tests serially (recycled sqlite rowids), and
proposes two test-infra routes: reset the ETS table between tests, or use
non-colliding ids. **Neither is implemented here, because neither addresses what
happens.**

Two facts falsify the premise:

1. `login_test.exs` has called `AdmissionStateHelpers.reset_network_circuit/0`
   from a per-test `setup` since **2026-05-14** (`8494a1de`), and an inline ETS
   delete loop before that. The mitigation the issue proposes as the fix had been
   in that file for two months before the issue was filed.
2. The instrumented failure shows **no foreign row**. Running the
   `network_circuit_open` case under host load with the ETS snapshot printed at
   the cast drain:

   ```
   snap_after_flush=[{1, 3, -576460741210, :open, -576460741150}]
   pre_check=:ok  login_elapsed_us=5749  result={:error, :no_server}
   ```

   One row, `count` exactly at threshold, written by that same test — and
   `check/1` on the very next line already returning `:ok`. Nothing bled in. The
   circuit the test had just opened had already closed itself.

## The actual mechanism

`NetworkCircuit.check/1` is the only clock-dependent reader: an `:open` row reads
back as `:ok` the instant `now >= cooled_at_ms`, with no writer involved — so no
reset can prevent it. `config/test.exs` sets `network_circuit_cooldown_ms: 50`
(±25% jitter → 38..62ms) to keep the cooldown-expiry cases cheap to sleep
through. That is shorter than the work a *consumer* test does between opening the
circuit and reading it back.

The same shape existed at ten sites across six files: establish "circuit is open"
through the production transition, then read it back through a clock-dependent
path (`check/1`, or `AdminWire`'s `retry_after_seconds`).

## The change

`AdmissionStateHelpers.open_circuit!/1` drives the real `record_failure/1`
transition, raises if it did not land, then pins `cooled_at_ms` a minute out, so
the precondition is a fact that cannot decay. The production module is untouched.

The split is principled, not an exclusion list: tests where open-ness is a
**precondition** use the helper; the four whose **subject** is the clock — the
`retry_after` upper bound, cooldown expiry, and the `:cooldown_expired` telemetry
pair — keep driving the real cooldown, because pinning would delete what they
test.

**Raising the cooldown was rejected**: same band-aid one size larger. The window
widens but stays a race, and it would slow the two expiry tests by exactly the
headroom bought.

## Evidence

- **Deterministic mutation.** Removing the pin from the helper reds exactly one
  assertion, every run: `assert {:error, :open, _} = check(net_id)` → `right: :ok`.
  23 tests, 1 failure. Restored → 23/0.
- **Incidence, measured on this worktree.** `login_test.exs` alone, unloaded:
  2 reds in the first 20 runs, then 0 in 25. Under 14-core host load, the
  `network_circuit_open` case fired **3 times in 30 runs** before, **0 in 20
  after**.
- **Full gate green.** `scripts/check.sh` rc=0 — 5599 tests / 0 failures,
  dialyzer 0 errors, format/credo/sobelow/doctor/bats clean; working tree clean
  before and after.

## What this does NOT fix

Under the same load `login_test.exs` reds on eleven other cases that never touch
the circuit (`433` nick negotiation, handshake waits, the mode-2 admission
guard). They share a substrate — the in-process `IRCServer` fake plus
`pool_size: 1` sqlite — not a cause.

One is worth naming because it is circuit-adjacent and could be mistaken for this
bug: the `#960 boundary` case fails on its **first** assertion, with
`Login.login` returning `{:error, :connect_timeout}` while the session process
logs `{:connect_failed, :econnrefused}` — the login surfaces a timeout for what
was actually a refusal, losing the diagnosis. That is a separate defect on the
login path; left for its own issue rather than widened into this one.