### PR TITLE
cic(#949): clamp the context menu to the safe box, not the physical one

### DIFF
--- a/cicchetto/src/ContextMenu.tsx
+++ b/cicchetto/src/ContextMenu.tsx
@@ -20,6 +20,21 @@ import { computeMenuPosition } from "./lib/menuPosition";
 // proven in the Playwright e2e (issue487-context-menu-viewport-clamp.spec.ts)
 // since jsdom gives no real viewport dimensions. Opacity-gated until measured
 // so the pre-measure frame never flashes off-screen.
+//
+// #949 — "inside the viewport" was the LAYOUT viewport, whose origin under
+// `viewport-fit=cover` is the physical top of the display. #913 fixed the same
+// arithmetic for the rail menu and named this door as carrying the residue.
+// The bounds now come from `.context-menu-safe-area`: a fixed, unpainted box
+// laid out at `inset: env(safe-area-inset-*)`, measured with
+// `getBoundingClientRect()`. That indirection is the point. #913 established
+// that JS must NOT read the inset back out of a custom property —
+// `getComputedStyle().getPropertyValue()` on an unregistered one can hand back
+// the token stream rather than a length, and the NaN that follows is swallowed
+// by any `|| 0` into a fix that looks applied and does nothing. A rect is a
+// resolved length by construction: the engine still owns `env()`, and JS reads
+// geometry, which is the one thing it can always trust. The box also yields
+// all four insets from one measurement, which is what the X axis (landscape
+// notch) and the bottom edge (home indicator) need.
 
 export type ContextMenuItem = {
   label: string;
@@ -50,6 +65,7 @@ const ContextMenu: Component<Props> = (props) => {
   };
 
   let menuRef: HTMLDivElement | undefined;
+  let safeAreaRef: HTMLDivElement | undefined;
   const [placement, setPlacement] = createSignal({
     top: props.position.y,
     left: props.position.x,
@@ -62,8 +78,9 @@ const ContextMenu: Component<Props> = (props) => {
     // signal), so `onMount` alone would strand the menu at the first coords.
     const clickX = props.position.x;
     const clickY = props.position.y;
-    if (!menuRef) return;
+    if (!menuRef || !safeAreaRef) return;
     const rect = menuRef.getBoundingClientRect();
+    const safe = safeAreaRef.getBoundingClientRect();
     setPlacement(
       computeMenuPosition({
         clickX,
@@ -80,6 +97,10 @@ const ContextMenu: Component<Props> = (props) => {
         // keyboard-up divergence is a device-dogfood item, not an e2e one.
         viewportWidth: window.visualViewport?.width ?? window.innerWidth,
         viewportHeight: window.visualViewport?.height ?? window.innerHeight,
+        // #949 — the safe box, in layout-viewport coordinates. Where there is
+        // no inset (every desktop browser, every engine in the e2e suite) this
+        // is exactly {0, w, h, 0} and the placement is bit-identical to #487's.
+        safeArea: { top: safe.top, right: safe.right, bottom: safe.bottom, left: safe.left },
       }),
     );
     setPlaced(true);
@@ -94,6 +115,10 @@ const ContextMenu: Component<Props> = (props) => {
     // out-of-pane chrome). Rendering at the document root keeps the z-300/301
     // layers above everything, themed or not.
     <Portal>
+      {/* #949 — the safe-area ruler. Unpainted and untouchable; it exists only
+          so `getBoundingClientRect()` can hand the placement math the four
+          insets as resolved lengths. */}
+      <div ref={safeAreaRef} class="context-menu-safe-area" aria-hidden="true" />
       {/* Backdrop: click-outside closes the menu. Rendered as button for a11y. */}
       <button
         type="button"

--- a/cicchetto/src/__tests__/ContextMenu.test.tsx
+++ b/cicchetto/src/__tests__/ContextMenu.test.tsx
@@ -1,0 +1,98 @@
+import { render } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+import { describe, expect, it, vi } from "vitest";
+import ContextMenu from "../ContextMenu";
+
+// #949 — the WIRING half of the safe-area clamp. The arithmetic is pinned as a
+// pure fn (lib/menuPosition.test.ts) and the stylesheet rules at source level
+// (contextMenuSafeArea.test.ts); neither notices if `ContextMenu` stops
+// rendering the ruler or stops feeding its rect to the math, which would leave
+// the fix dead while both other suites stay green.
+//
+// jsdom reports every rect as zero, so the two boxes that matter are stubbed —
+// the same shape RailActions.test.tsx uses for #913's JS half. That makes these
+// behavioural tests of the component's contract (which numbers it reads, and
+// what it does with them), not layout tests: jsdom does not paint, and the felt
+// result on a notched device is still only confirmable by dogfood.
+
+const ITEMS = [
+  { label: "whois", enabled: true, action: vi.fn() },
+  { label: "query", enabled: true, action: vi.fn() },
+];
+
+// A portrait iPhone 15 under `viewport-fit=cover`: the ruler is laid out at
+// `inset: env(safe-area-inset-*)`, so its rect is the safe box in
+// layout-viewport coordinates — 59px of status bar at the top, 34px of home
+// indicator at the bottom of an 852px display.
+const IPHONE_15_SAFE = { top: 59, right: 393, bottom: 818, left: 0 };
+
+function stubRect(selector: string, rect: Partial<DOMRect>): HTMLElement {
+  const el = document.querySelector(selector);
+  if (!(el instanceof HTMLElement)) throw new Error(`${selector} did not render`);
+  el.getBoundingClientRect = (): DOMRect => rect as DOMRect;
+  return el;
+}
+
+// The placement effect tracks `props.position`, so re-rendering at fresh
+// coordinates is what re-runs it against the stubbed rects.
+function renderThenPlace(
+  safe: Partial<DOMRect>,
+  menu: Partial<DOMRect>,
+  at: { x: number; y: number },
+): HTMLElement {
+  const [position, setPosition] = createSignal({ x: 1, y: 1 });
+  render(() => <ContextMenu items={ITEMS} position={position()} onClose={vi.fn()} />);
+  stubRect(".context-menu-safe-area", safe);
+  const menuEl = stubRect(".context-menu", menu);
+  setPosition(at);
+  return menuEl;
+}
+
+describe("ContextMenu safe-area placement (#949)", () => {
+  it("renders the safe-area ruler, hidden from the accessibility tree", () => {
+    render(() => <ContextMenu items={ITEMS} position={{ x: 10, y: 10 }} onClose={vi.fn()} />);
+    const ruler = document.querySelector(".context-menu-safe-area");
+    // Deleting this element is the cheapest way to silently un-fix #949: the
+    // effect bails on a missing ref and the menu keeps its raw press coords.
+    expect(ruler).not.toBeNull();
+    expect(ruler?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("pins an oversized menu below the top inset, not at the physical top", () => {
+    // 900px of menu against jsdom's 768px viewport: oversized either way, so
+    // the only question is WHICH origin it pins to. y=0 is the #913 defect —
+    // under viewport-fit=cover that coordinate is behind the status bar, and
+    // the menu's own overflow scroll cannot recover a box that STARTS there.
+    const menuEl = renderThenPlace(
+      IPHONE_15_SAFE,
+      { top: 0, left: 0, right: 200, bottom: 900, width: 200, height: 900 },
+      { x: 100, y: 400 },
+    );
+    expect(menuEl.style.top).toBe("59px");
+  });
+
+  it("never opens the menu inside the leading inset", () => {
+    // Landscape: the notch and the rounded corner eat a column on the leading
+    // edge, and unlike the status bar iOS does still deliver touches there — so
+    // a press CAN arrive at x=10 and must not be honoured as an origin.
+    const menuEl = renderThenPlace(
+      { top: 0, right: 793, bottom: 372, left: 59 },
+      { top: 0, left: 0, right: 200, bottom: 120, width: 200, height: 120 },
+      { x: 10, y: 100 },
+    );
+    expect(menuEl.style.left).toBe("59px");
+  });
+
+  it("honours the press coordinates when there is no inset to dodge", () => {
+    // The no-notch case — every desktop browser and every engine in the e2e
+    // suite, where env(safe-area-inset-*) resolves to 0. The fix must be a
+    // NO-OP here, or it is a regression of #487 dressed up as a fix.
+    const menuEl = renderThenPlace(
+      { top: 0, right: 1024, bottom: 768, left: 0 },
+      { top: 0, left: 0, right: 200, bottom: 120, width: 200, height: 120 },
+      { x: 100, y: 400 },
+    );
+    expect(menuEl.style.left).toBe("100px");
+    expect(menuEl.style.top).toBe("400px");
+  });
+});

--- a/cicchetto/src/__tests__/contextMenuSafeArea.test.ts
+++ b/cicchetto/src/__tests__/contextMenuSafeArea.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { ruleBody, themeCss } from "./helpers/themeCss";
+
+// #949 — the context menu carried #913's defect at a second door. #913 fixed
+// `.rail-actions-menu`, whose cap measured the space above the launcher from
+// `getBoundingClientRect().top`: under `viewport-fit=cover` that origin is the
+// PHYSICAL top of the display, behind the status bar. `d129bfb0` recorded that
+// the `placeAxis` / context-menu clamp had the same origin bug "on both edges"
+// and wanted its own issue. This is the stylesheet half of it.
+//
+// Two rules carry the fix and they answer different questions:
+//   * `.context-menu-safe-area` is a RULER — a fixed, unpainted box inset by
+//     all four `env(safe-area-inset-*)` values, whose `getBoundingClientRect()`
+//     hands the placement math the safe box as resolved lengths. It exists
+//     because #913 established JS must not read the inset out of a custom
+//     property: `getComputedStyle().getPropertyValue()` on an unregistered one
+//     can return the token stream, and the resulting NaN is swallowed by any
+//     `|| 0` into a no-op that looks like a fix. A rect cannot be a token
+//     stream.
+//   * `.context-menu`'s `max-height` is the SIZE cap, and it stays in CSS
+//     because the placement effect measures the menu's rendered height — a cap
+//     applied inline after that measurement would position a box against a
+//     height it no longer has.
+//
+// SOURCE-LEVEL guards, for the reason #913 and #205 already record: Playwright
+// resolves `env(safe-area-inset-*)` to 0 on every engine in the suite and jsdom
+// resolves neither `env()` nor `calc()`, so no gate we run can observe the
+// on-device geometry. The wiring is pinned in ContextMenu.test.tsx and the
+// arithmetic in lib/menuPosition.test.ts; the FELT result on a notched iPhone
+// is confirmable only by dogfood.
+
+describe("#949 context menu safe-area clamp", () => {
+  it(":root exposes the bottom inset alongside #913's top one", () => {
+    // The height cap subtracts BOTH vertical insets, and the `0px` fallback is
+    // load-bearing on each: without it an engine that does not know the
+    // variable invalidates the whole declaration, dropping the cap entirely —
+    // which is the uncapped #487 overflow, back.
+    expect(ruleBody(":root")).toMatch(/--safe-area-inset-top:\s*env\(safe-area-inset-top,\s*0px\)/);
+    expect(ruleBody(":root")).toMatch(
+      /--safe-area-inset-bottom:\s*env\(safe-area-inset-bottom,\s*0px\)/,
+    );
+  });
+
+  it("the ruler is fixed, so its rect shares the menu's coordinate space", () => {
+    // `position: fixed` is what makes the rect comparable to the press
+    // coordinates and to the menu's own fixed box. An absolutely-positioned
+    // ruler would report its offset parent's frame and quietly mis-place
+    // everything by that parent's origin.
+    expect(ruleBody(".context-menu-safe-area")).toMatch(/position:\s*fixed/);
+  });
+
+  it("the ruler is inset by all four safe-area values, each with a 0px fallback", () => {
+    // Asserted per-edge rather than against the `inset:` shorthand as written:
+    // a longhand rewrite must keep passing, and a DROPPED edge must fail. The
+    // bottom and the two sides are not decoration — the bottom is the home
+    // indicator, and in landscape the sides are the notch and the rounded
+    // corners, which is the other half of `d129bfb0`'s "both edges".
+    const body = ruleBody(".context-menu-safe-area");
+    for (const edge of ["top", "right", "bottom", "left"]) {
+      expect(body).toMatch(new RegExp(`env\\(safe-area-inset-${edge},\\s*0px\\)`));
+    }
+  });
+
+  it("the ruler cannot be touched, so it never eats the backdrop's click-outside", () => {
+    // It is a sibling of `.context-menu-backdrop` inside the same portal and
+    // covers nearly the same area. Without this it would swallow the press
+    // that is supposed to close the menu.
+    expect(ruleBody(".context-menu-safe-area")).toMatch(/pointer-events:\s*none/);
+  });
+
+  it("the ruler is declared once, so the measured box is the one written here", () => {
+    // The rect is read from live layout, so ANY second rule reaching this class
+    // silently redefines what the placement math measures.
+    expect(themeCss.match(/\.context-menu-safe-area/g)?.length).toBe(1);
+  });
+
+  it(".context-menu caps its height against the viewport MINUS both vertical insets", () => {
+    const body = ruleBody(".context-menu");
+    expect(body).toMatch(/max-height:[^;]*var\(--viewport-height,\s*100vh\)/);
+    expect(body).toMatch(/max-height:[^;]*var\(--safe-area-inset-top,\s*0px\)/);
+    expect(body).toMatch(/max-height:[^;]*var\(--safe-area-inset-bottom,\s*0px\)/);
+  });
+
+  it("the cap is clamped at zero, because a negative max-height is no cap at all", () => {
+    // Subtracting two insets from a keyboard-shrunk `--viewport-height` can go
+    // negative. An out-of-range max-height is an ignored declaration, and an
+    // ignored cap is the #487 overflow — the same trap #588/#913 hit.
+    expect(ruleBody(".context-menu")).toMatch(/max-height:\s*max\(\s*0px\s*,/);
+  });
+
+  it("the menu still scrolls whatever the cap leaves over", () => {
+    // The cap only relocates the overflow; `overflow-y: auto` is what makes the
+    // hidden rows reachable. Capping without it reproduces #487's unclickable
+    // tail with extra steps.
+    expect(ruleBody(".context-menu")).toMatch(/overflow-y:\s*auto/);
+  });
+});

--- a/cicchetto/src/lib/menuPosition.test.ts
+++ b/cicchetto/src/lib/menuPosition.test.ts
@@ -9,41 +9,93 @@ import { computeMenuPosition, placeAxis, spaceAbove } from "./menuPosition";
 // (issue487-context-menu-viewport-clamp.spec.ts); these tests pin the
 // flip/clamp arithmetic.
 //
-// placeAxis is the 1D primitive applied independently to X and Y:
+// placeAxis is the 1D primitive applied independently to X and Y, over a
+// half-open interval [start, end) rather than [0, viewport):
 //   * fits after the click         → keep the click coord (open down/right)
 //   * overflows the far edge        → FLIP before the click (open up/left,
 //                                     pointer stays on the menu edge)
-//   * flip would underflow origin   → CLAMP to the last fully-visible coord
-//   * menu bigger than the viewport → pin to 0 (CSS max-height + scroll)
+//   * flip would underflow `start`  → CLAMP to the last fully-visible coord
+//   * menu bigger than the interval → pin to `start` (CSS max-height + scroll)
+//
+// #949 — the interval used to be hardcoded to [0, viewport). Zero is the
+// LAYOUT viewport origin, which under `viewport-fit=cover` (index.html) is the
+// physical top of the display, behind the status bar; `viewport` is likewise
+// the physical bottom, behind the home indicator. Both pins addressed occluded
+// coordinates. The bounds are now supplied by the caller, which reads them off
+// a fixed `inset: env(safe-area-inset-*)` frame — see ContextMenu.tsx.
 
 describe("placeAxis (1D flip/clamp primitive)", () => {
   it("keeps the click coord when the menu fits after it", () => {
-    expect(placeAxis(100, 120, 1000)).toBe(100);
+    expect(placeAxis(100, 120, 0, 1000)).toBe(100);
   });
 
   it("flips before the click point when the menu overflows the far edge", () => {
-    // click 950, menu 120, viewport 1000 → 1070 > 1000 → flip: 950 - 120
-    expect(placeAxis(950, 120, 1000)).toBe(830);
+    // click 950, menu 120, end 1000 → 1070 > 1000 → flip: 950 - 120
+    expect(placeAxis(950, 120, 0, 1000)).toBe(830);
   });
 
   it("keeps a click that lands exactly at the far edge", () => {
-    // click 880, menu 120, viewport 1000 → 880 + 120 == 1000 → fits, no flip
-    expect(placeAxis(880, 120, 1000)).toBe(880);
+    // click 880, menu 120, end 1000 → 880 + 120 == 1000 → fits, no flip
+    expect(placeAxis(880, 120, 0, 1000)).toBe(880);
   });
 
-  it("clamps to fully-visible when a flip would underflow the origin", () => {
-    // click 100, menu 180, viewport 200 → overflow (280>200) AND menu fits
-    // (180<200); flip 100-180=-80 < 0 → clamp to viewport-size = 20
-    expect(placeAxis(100, 180, 200)).toBe(20);
+  it("clamps to fully-visible when a flip would underflow the interval start", () => {
+    // click 100, menu 180, [0,200) → overflow (280>200) AND menu fits
+    // (180<200); flip 100-180=-80 < 0 → clamp to end-size = 20
+    expect(placeAxis(100, 180, 0, 200)).toBe(20);
   });
 
-  it("pins to the edge when the menu is taller/wider than the viewport", () => {
-    expect(placeAxis(150, 300, 200)).toBe(0);
-    expect(placeAxis(150, 200, 200)).toBe(0); // equal counts as oversized
+  it("pins to the interval start when the menu is bigger than the interval", () => {
+    expect(placeAxis(150, 300, 0, 200)).toBe(0);
+    expect(placeAxis(150, 200, 0, 200)).toBe(0); // equal counts as oversized
+  });
+
+  // #949 — the four cases above with a non-zero `start` / a pulled-in `end`.
+  // Every one of them used to answer with a coordinate inside an inset.
+
+  it("pins to the safe start, not to zero, when the menu is oversized", () => {
+    // The #913 defect at this door: an oversized menu pinned to y=0, which
+    // under viewport-fit=cover is the physical top of the display. On a
+    // notched iPhone the first row rendered behind the status bar and the
+    // menu's own overflow scroll could not bring it back — the box itself
+    // starts inside the occluded strip.
+    expect(placeAxis(150, 900, 59, 818)).toBe(59);
+  });
+
+  it("clamps a flip against the safe start, not against zero", () => {
+    // The [0,200) clamp case above, shifted into a safe [59, 259): click 100,
+    // menu 180 → 280 > 259 → flip to -80, which is below the safe START, so we
+    // clamp. The last FULLY VISIBLE origin is end-size = 79, not 20.
+    expect(placeAxis(100, 180, 59, 259)).toBe(79);
+  });
+
+  it("flips against the safe end, not against the physical bottom", () => {
+    // click 800, menu 120, safe [59, 818): 800+120=920 > 818 → flip to 680.
+    // Against the physical bottom (852) it would have "fitted" at 800 and the
+    // tail would have run under the home indicator.
+    expect(placeAxis(800, 120, 59, 818)).toBe(680);
+  });
+
+  it("never returns a coordinate before the safe start, even for a click inside the inset", () => {
+    // A press can land inside the LEFT inset in landscape (iOS does not
+    // swallow touches there the way it does under the status bar), and the
+    // menu would then open from a column the display corner is eating.
+    expect(placeAxis(10, 120, 59, 818)).toBe(59);
   });
 });
 
 describe("computeMenuPosition (both axes)", () => {
+  // A safe area equal to the full viewport: what every non-notched browser and
+  // every engine in the Playwright suite reports (env(safe-area-inset-*) → 0).
+  // Keeping the pre-#949 expectations under this shape is the point — the fix
+  // must be a NO-OP where there is no inset.
+  const noInset = (width: number, height: number) => ({
+    top: 0,
+    right: width,
+    bottom: height,
+    left: 0,
+  });
+
   it("passes through when the menu fits below-and-right of the click", () => {
     expect(
       computeMenuPosition({
@@ -53,6 +105,7 @@ describe("computeMenuPosition (both axes)", () => {
         menuHeight: 200,
         viewportWidth: 1280,
         viewportHeight: 720,
+        safeArea: noInset(1280, 720),
       }),
     ).toEqual({ left: 100, top: 200 });
   });
@@ -65,6 +118,7 @@ describe("computeMenuPosition (both axes)", () => {
       menuHeight: 200,
       viewportWidth: 1280,
       viewportHeight: 720,
+      safeArea: noInset(1280, 720),
     });
     expect(p.top).toBe(500); // 700 - 200
     expect(p.left).toBe(100); // X fits — unchanged
@@ -78,6 +132,7 @@ describe("computeMenuPosition (both axes)", () => {
       menuHeight: 200,
       viewportWidth: 1280,
       viewportHeight: 720,
+      safeArea: noInset(1280, 720),
     });
     expect(p.left).toBe(1150); // 1270 - 120
     expect(p.top).toBe(100);
@@ -92,6 +147,7 @@ describe("computeMenuPosition (both axes)", () => {
         menuHeight: 200,
         viewportWidth: 1280,
         viewportHeight: 720,
+        safeArea: noInset(1280, 720),
       }),
     ).toEqual({ left: 1156, top: 516 });
   });
@@ -105,8 +161,96 @@ describe("computeMenuPosition (both axes)", () => {
       menuHeight: 200,
       viewportWidth: 390,
       viewportHeight: 180,
+      safeArea: noInset(390, 180),
     });
     expect(p.top).toBe(0);
+  });
+
+  // #949 — a portrait iPhone 15 under viewport-fit=cover: 393×852 layout
+  // viewport, 59px status-bar inset at the top, 34px home-indicator inset at
+  // the bottom. The safe box is therefore [59, 818) on Y and [0, 393) on X.
+  const iphone15Portrait = { top: 59, right: 393, bottom: 818, left: 0 };
+
+  it("keeps an oversized menu clear of the status bar instead of pinning to y=0", () => {
+    const p = computeMenuPosition({
+      clickX: 100,
+      clickY: 400,
+      menuWidth: 200,
+      menuHeight: 900,
+      viewportWidth: 393,
+      viewportHeight: 852,
+      safeArea: iphone15Portrait,
+    });
+    expect(p.top).toBe(59);
+  });
+
+  it("keeps a bottom-edge flip clear of the home indicator", () => {
+    // Against the physical bottom (852) the menu "fits" at y=800 and its tail
+    // runs into the home-indicator strip. Against the safe bottom (818) it
+    // flips to 800-120=680.
+    const p = computeMenuPosition({
+      clickX: 100,
+      clickY: 800,
+      menuWidth: 200,
+      menuHeight: 120,
+      viewportWidth: 393,
+      viewportHeight: 852,
+      safeArea: iphone15Portrait,
+    });
+    expect(p.top).toBe(680);
+  });
+
+  it("respects the side insets in landscape, where the notch eats a column", () => {
+    // Landscape iPhone: 852×393, notch on the leading edge → 59px left inset,
+    // 59px right inset, 21px bottom. Safe box: X [59, 793), Y [0, 372).
+    const p = computeMenuPosition({
+      clickX: 700,
+      clickY: 100,
+      menuWidth: 200,
+      menuHeight: 120,
+      viewportWidth: 852,
+      viewportHeight: 393,
+      safeArea: { top: 0, right: 793, bottom: 372, left: 59 },
+    });
+    // 700 + 200 = 900 > 793 → flip to 500. Against the physical width (852)
+    // it would have "fitted" at 700 and run under the rounded corner.
+    expect(p.left).toBe(500);
+  });
+
+  // The keyboard-up case is where the VISUAL viewport and the safe-area frame
+  // disagree, and the placement has to take whichever bound is tighter. The
+  // frame is laid out against the LAYOUT viewport, which iOS does NOT shrink
+  // for the on-screen keyboard; `viewportHeight` (visualViewport.height) is
+  // what shrinks. Both are measured from the same origin, so they compose as a
+  // plain min/max — see the note in computeMenuPosition.
+  it("takes the visual viewport's bottom when the keyboard has pulled it above the safe bottom", () => {
+    const p = computeMenuPosition({
+      clickX: 100,
+      clickY: 400,
+      menuWidth: 200,
+      menuHeight: 120,
+      viewportWidth: 393,
+      viewportHeight: 516, // keyboard up: 852 - ~336
+      safeArea: iphone15Portrait, // bottom still 818, the keyboard is not an inset
+    });
+    // 400 + 120 = 520 > 516 → flip to 280. Trusting the 818 safe bottom would
+    // have left the menu under the keyboard — the #487 symptom.
+    expect(p.top).toBe(280);
+  });
+
+  it("keeps the safe TOP even when the visual viewport is the tighter bottom", () => {
+    // Both bounds bite at once: the keyboard caps the bottom at 516 and the
+    // status bar the top at 59, and a 600px menu fits neither.
+    const p = computeMenuPosition({
+      clickX: 100,
+      clickY: 300,
+      menuWidth: 200,
+      menuHeight: 600,
+      viewportWidth: 393,
+      viewportHeight: 516,
+      safeArea: iphone15Portrait,
+    });
+    expect(p.top).toBe(59);
   });
 });
 

--- a/cicchetto/src/lib/menuPosition.ts
+++ b/cicchetto/src/lib/menuPosition.ts
@@ -5,15 +5,28 @@
 // (issue487-context-menu-viewport-clamp.spec.ts). jsdom returns 0-sized rects,
 // so a jsdom placement test would be hollow — hence the seam.
 //
-// placeAxis is the 1D primitive, applied independently to X and Y:
+// placeAxis is the 1D primitive, applied independently to X and Y, over the
+// half-open interval [start, end):
 //   * fits after the click          → keep the click coord (menu opens down/right)
 //   * overflows the far edge         → FLIP before the click (menu opens up/left),
 //                                      keeping the pointer on the menu edge like a
 //                                      native context menu
-//   * flip would underflow origin    → CLAMP to the last fully-visible coord (menu
+//   * flip would underflow `start`   → CLAMP to the last fully-visible coord (menu
 //                                      slides off the cursor but stays whole)
-//   * menu bigger than the viewport  → pin to 0 and let the CSS max-height +
+//   * menu bigger than the interval  → pin to `start` and let the CSS max-height +
 //                                      overflow-y:auto scroll the overflow
+//
+// #949 — that interval used to be hardcoded [0, viewport). Under
+// `viewport-fit=cover` (index.html) 0 is the PHYSICAL top of the display, so
+// the oversize pin put the first row behind the status bar, and `viewport` is
+// the physical bottom, so a flip could tuck the tail under the home indicator
+// (in landscape, the same on X against the notch/rounded corners). Both edges
+// carried the #913 defect at a different door. The interval is now the
+// caller's, taken from a fixed `inset: env(safe-area-inset-*)` frame the
+// engine lays out — see ContextMenu.tsx for why that frame, and not a JS read
+// of `env()`, is the seam.
+
+export type SafeArea = { top: number; right: number; bottom: number; left: number };
 
 export type MenuMeasurement = {
   clickX: number;
@@ -22,21 +35,44 @@ export type MenuMeasurement = {
   menuHeight: number;
   viewportWidth: number;
   viewportHeight: number;
+  safeArea: SafeArea;
 };
 
 export type MenuPlacement = { left: number; top: number };
 
-export function placeAxis(click: number, size: number, viewport: number): number {
-  if (size >= viewport) return 0;
-  if (click + size <= viewport) return click;
+export function placeAxis(click: number, size: number, start: number, end: number): number {
+  if (size >= end - start) return start;
+  if (click + size <= end) return Math.max(click, start);
   const flipped = click - size;
-  return flipped >= 0 ? flipped : viewport - size;
+  return flipped >= start ? flipped : end - size;
 }
 
+// The two bounds come from different places and both can bite:
+//   * `safeArea` is a laid-out box, so its edges are LAYOUT-viewport
+//     coordinates — it knows the notch, and does NOT know the keyboard (iOS
+//     never shrinks the layout viewport for it).
+//   * `viewport{Width,Height}` is the VISUAL viewport, which knows the
+//     keyboard and not the notch. #487 chose it deliberately: `innerHeight`
+//     stays full-screen with the keyboard up and would let the menu render
+//     underneath it.
+// They compose as a plain `min` because both are measured from the layout
+// viewport's origin — true while `visualViewport.offsetTop/Left` are 0, which
+// holds for this non-scrolling, non-zoomable app shell. A pinch-zoomed page
+// would need the offsets added in; the pre-#949 code made the same assumption.
 export function computeMenuPosition(m: MenuMeasurement): MenuPlacement {
   return {
-    left: placeAxis(m.clickX, m.menuWidth, m.viewportWidth),
-    top: placeAxis(m.clickY, m.menuHeight, m.viewportHeight),
+    left: placeAxis(
+      m.clickX,
+      m.menuWidth,
+      m.safeArea.left,
+      Math.min(m.viewportWidth, m.safeArea.right),
+    ),
+    top: placeAxis(
+      m.clickY,
+      m.menuHeight,
+      m.safeArea.top,
+      Math.min(m.viewportHeight, m.safeArea.bottom),
+    ),
   };
 }
 

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -236,6 +236,12 @@
      and the cap disappears (the #588 overflow, back). Theme-independent, so it
      lives on base :root. */
   --safe-area-inset-top: env(safe-area-inset-top, 0px);
+  /* #949 — the bottom (home-indicator) inset, same contract, same reason: the
+     `.context-menu` height cap subtracts BOTH vertical insets from a value
+     (`--viewport-height`) that JS writes, so the subtraction has to happen in
+     CSS. Sibling of the top inset above; the `0px` fallback is load-bearing
+     for the same reason. */
+  --safe-area-inset-bottom: env(safe-area-inset-bottom, 0px);
   /* grappa-irc#69: theme the scrollbars. `scrollbar-color` and
      `scrollbar-width` inherit, so declaring them on :root themes every
      scrollable descendant (.scrollback, members pane, admin tables…)
@@ -6325,9 +6331,46 @@ html.resize-dragging * {
      flip/clamp (lib/menuPosition.ts) pins an oversized menu to the top edge;
      this caps it to the viewport height and scrolls the overflow so every
      item stays reachable. --viewport-height mirrors the mobile shell's
-     keyboard-aware height (main.tsx); 100vh is the desktop fallback. */
-  max-height: var(--viewport-height, 100vh);
+     keyboard-aware height (main.tsx); 100vh is the desktop fallback.
+     #949 — the cap has to lose BOTH vertical insets, and it has to do so
+     HERE rather than inline from JS: the placement effect measures the menu's
+     rendered height, so a cap applied after that measurement would place the
+     box against a height it no longer has. CSS caps first, JS then measures a
+     box that is already the right size — the same division of labour as
+     `.rail-actions-menu` (#913), which likewise lets the engine own `env()`.
+     Over-subtracts by the bottom inset while the keyboard is up (the home
+     indicator is behind the keyboard, so --viewport-height has already
+     excluded it): a menu shorter than it could be, never one that overflows.
+     `max(0px, …)` because a negative max-height is an ignored declaration —
+     i.e. no cap at all, which is the #487 overflow handed straight back. */
+  max-height: max(
+    0px,
+    calc(
+      var(--viewport-height, 100vh) -
+      var(--safe-area-inset-top, 0px) -
+      var(--safe-area-inset-bottom, 0px)
+    )
+  );
   overflow-y: auto;
+}
+
+/* #949 — the ruler the placement math measures (ContextMenu.tsx). Fixed, so
+   its rect is in the same layout-viewport coordinate space as the press
+   coordinates and the menu's own `position: fixed` box; inset by all four
+   safe-area values, so that rect IS the safe box. Nothing paints and nothing
+   hit-tests: `pointer-events: none` keeps it off the backdrop's click-outside,
+   and it carries no background, border or content.
+   The `0px` fallbacks are load-bearing, not defensive — an `inset` shorthand
+   with one unknown `env()` is invalid as a whole, which would collapse the
+   ruler to `auto` on every side and hand back a zero-sized rect: a safe box of
+   [0,0] on both axes, i.e. every menu pinned to the corner. With the fallbacks
+   an engine that knows no insets reports the full viewport, which is exactly
+   the pre-#949 behaviour. */
+.context-menu-safe-area {
+  position: fixed;
+  inset: env(safe-area-inset-top, 0px) env(safe-area-inset-right, 0px)
+    env(safe-area-inset-bottom, 0px) env(safe-area-inset-left, 0px);
+  pointer-events: none;
 }
 
 .context-menu-item {


### PR DESCRIPTION
Addresses #949. #913's residue at the second door its own commit named.

## What was wrong

`placeAxis` clamped over `[0, viewport)`. `index.html` has opted into
`viewport-fit=cover` since #205, so `0` is the **physical** top of the display
and `viewport` the physical bottom:

- the oversize pin returned `0` — behind the status bar, and the menu's own
  `overflow-y: auto` cannot recover a box that *starts* in the occluded strip;
- a flip could return `viewport - size` — tail under the home indicator;
- in landscape the same arithmetic on X addressed the notch and the rounded
  corners. `d129bfb0` said "both edges"; it is four.

`.context-menu`'s `max-height: var(--viewport-height, 100vh)` was literally the
pre-#913 spelling of the rule #913 rewrote for `.rail-actions-menu`.

## The fix

`placeAxis(click, size, start, end)` — the interval is the caller's. The caller
reads it off **`.context-menu-safe-area`**: a fixed, unpainted, `pointer-events:
none` box laid out at `inset: env(safe-area-inset-*)`, measured with
`getBoundingClientRect()`.

That indirection is the design, not plumbing. #913 established that JS must not
read an inset back out of a custom property: `getComputedStyle()
.getPropertyValue()` on an unregistered one can return the token stream, and the
`NaN` that follows is swallowed by any `|| 0` into a fix that looks applied and
does nothing. **A rect is a resolved length by construction** — the engine keeps
`env()`, JS reads geometry. One measurement yields all four insets, and it lands
in the same coordinate space as the press coordinates and the menu's own fixed
box, so nothing is converted.

The two bounds compose as a `min`. The ruler is laid out against the **layout**
viewport: it knows the notch, not the keyboard (iOS never shrinks the layout
viewport for it). `visualViewport.height` — #487's deliberate choice — knows the
keyboard, not the notch. Both share an origin while `visualViewport.offsetTop`
is 0, which holds for this non-scrolling, non-zoomable shell; the pre-#949 code
made the same assumption.

The height cap stays in **CSS**: the placement effect measures the menu's
*rendered* height, so a cap applied inline after that measurement would position
the box against a height it no longer has. Same division of labour as
`.rail-actions-menu`.

## What this does NOT prove

Where there is no inset the safe box is the full viewport and the placement is
bit-identical to #487's — which is why the existing e2e stays green, and why it
proves nothing here. Playwright resolves `env(safe-area-inset-*)` to 0 on every
engine in the suite and jsdom resolves neither `env()` nor `calc()`. The guards
are split three ways, none of which sees a real notch:

| guard | pins |
|---|---|
| `lib/menuPosition.test.ts` | the arithmetic, over an explicit interval |
| `__tests__/ContextMenu.test.tsx` | the wiring, against stubbed rects |
| `__tests__/contextMenuSafeArea.test.ts` | the stylesheet, at source level |

**The felt behaviour on a notched iPhone is confirmed by none of them.**

## No e2e, deliberately

A Playwright spec was considered and **declined**. Playwright resolves
`env(safe-area-inset-*)` to 0 on every engine in the suite, so at inset 0 this
change is bit-identical to the code it replaces: the spec would be green against
the broken build too. **A guard that cannot fail is not a guard** — it is a
green tick that buys false confidence, which is precisely how #588's assertion
stayed green for the whole life of #913.

The only way to make it bite is a differential against a stubbed inset, the
scaffolding #913 had to settle for. Here that would cost more than there: the
production path reads the inset from the ruler's **layout**, not from a
variable, so stubbing it without `!important`-overriding the very rule under
test would mean first re-routing the ruler through four `:root`
`var(--safe-area-inset-*)` indirections. That is production churn to make a test
exist, and it is not worth it.

**Device-verify owed:** the real check is vjt on a notched iPhone, portrait
**and** landscape — not `webkit-iphone-15` in CI. Until that happens this fix is
argued, not observed.

Two further instances of the same class were found and deliberately left alone —
see the issue thread.

## Test plan

- [x] `bun run check` — biome + `tsc` + e2e `tsc`, exit 0
- [x] `bun run test` — 267 files / 4933 tests, exit 0
- [x] Mutation: the y=0 pin restored, the ruler element deleted, the bottom
      inset dropped from the cap, the ruler's left edge blinded — each read red,
      each naming the intended assertion
- [ ] **Device dogfood on a notched iPhone (portrait and landscape)** — owed;
      no gate in this repo can stand in for it