### PR TITLE
Mobile: drop the outer bottom safe-area inset (#1127)

### DIFF
--- a/cicchetto/e2e/tests/ux-3-empty-toolbar-island.spec.ts
+++ b/cicchetto/e2e/tests/ux-3-empty-toolbar-island.spec.ts
@@ -24,12 +24,19 @@
 //
 // Verification strategy. Walk document.styleSheets, find the
 // `.shell-mobile` rule (lives under the `@media (max-width: 768px)`
-// branch — CSSMediaRule), assert it declares both
-// `padding-top: env(safe-area-inset-top)` and
-// `padding-bottom: env(safe-area-inset-bottom)`. Webkit-iphone-15
+// branch — CSSMediaRule), assert it declares
+// `padding-top: env(safe-area-inset-top)`. Webkit-iphone-15
 // emulation matches viewport but doesn't inject real env() values —
 // computed paddingTop resolves to 0px regardless — so this is a
 // SOURCE-shape assertion, not a metric assertion.
+//
+// #1127 (2026-08-09) flipped the BOTTOM edge: the home-indicator inset
+// lifted the shell off the bottom and exposed the transparent area behind
+// it (a black band under the tab strip), so `.shell-mobile` now declares
+// `padding-bottom: 0` and the shell reaches the physical bottom. The edge
+// is still asserted here, with the opposite expectation — and the
+// declaration must still be PRESENT, since base `.shell` would otherwise
+// cascade the inset back in at equal specificity.
 //
 // Also assert `.topic-bar` rule NO LONGER contains `env(` /
 // `safe-area-inset-top` (the previous fix is reverted at the bar
@@ -99,7 +106,7 @@ test("@webkit UX-3 BIS — .shell.shell-mobile carries safe-area inset; bars do 
 
   // .shell-mobile rule lives inside @media (max-width: 768px) — must
   // recurse through CSSMediaRule.cssRules to find it. The rule MUST
-  // declare both top + bottom inset.
+  // declare the top inset, and MUST declare a flush bottom edge (#1127).
   const shell = await findRulePadding(page, ".shell-mobile");
   expect(shell).not.toBeNull();
   // The longhands MAY be authored or expanded; tolerate either.
@@ -107,8 +114,10 @@ test("@webkit UX-3 BIS — .shell.shell-mobile carries safe-area inset; bars do 
   const shellBottom = shell?.paddingBottom ?? "";
   expect(shellTop).toContain("env(");
   expect(shellTop).toContain("safe-area-inset-top");
-  expect(shellBottom).toContain("env(");
-  expect(shellBottom).toContain("safe-area-inset-bottom");
+  // Zero, and declared: an empty string here means the longhand is gone
+  // and base `.shell`'s inset cascades in. CSSOM may serialize the
+  // authored `0` as `0px`, so accept either spelling.
+  expect(shellBottom).toMatch(/^0(px)?$/);
 
   // .topic-bar MUST NOT carry the inset anymore — pin the UX-3 BIS
   // revert so a future operator can't re-introduce the double-clear

--- a/cicchetto/e2e/tests/ux-6-d-keyboard-pattern.spec.ts
+++ b/cicchetto/e2e/tests/ux-6-d-keyboard-pattern.spec.ts
@@ -21,10 +21,21 @@
 // (a) html.is-ios class lands on iPhone UA (boot-time detection)
 // (b) --vh CSS var writes from visualViewport.height
 // (c) --viewport-height legacy CSS var writes from same source
-// (d) D1 `:has(:focus){padding-bottom:0}` rule applies when input
-//     has focus
 // (e) Smart-pin: window.scrollTo(0,0) clamps any drift
 // (f) Admin → Debug tab renders the diag panel + DiagFloat toggle
+//
+// Arm (d) is GONE (#1127, 2026-08-09). It asserted that focusing a text
+// field collapsed `.shell-mobile`'s computed padding-bottom to 0px via the
+// D1 `:has(:focus)` override. #1127 zeroed the shell's bottom inset
+// outright — the home-indicator inset lifted the shell off the bottom edge
+// and exposed the transparent band behind it — so the override was deleted
+// as dead code and the arm lost its subject. Note the arm was already
+// vacuous in Playwright: headless WebKit resolves `env()` to 0, so the
+// computed padding read 0px with or without the override applying. The
+// D11 rationale it encoded now lives on the `padding-bottom: 0`
+// declaration in default.css, which is where anyone re-adding an inset on
+// that edge will read it. Arm letters are kept stable so the (e)/(f)
+// references elsewhere don't shift.
 
 import { loginAs, openRailMenu, selectChannel } from "../fixtures/cicchettoPage";
 import {
@@ -116,24 +127,6 @@ test.describe("UX-6 D cluster close — iOS PWA keyboard pattern @webkit", () =>
     expect(vpHeightVar).toMatch(/^\d+px$/);
     const value = Number.parseInt(vpHeightVar, 10);
     expect(value).toBeGreaterThan(100);
-  });
-
-  test("(d) D1 :has(:focus) rule collapses padding-bottom when input focused", async ({ page }) => {
-    await loginAs(page, getSeededVjt());
-    // GREEN-CI batch 2 — UX-4 bucket B made `:home` the cold-load
-    // default selection; HomePane has no `.compose-box`. Select the
-    // autojoin channel first so the ComposeBox mounts (same fix shape
-    // as ios-z-cluster-journey.spec.ts:57 lessons-learned).
-    await selectChannel(page, NETWORK_SLUG, CHANNEL, { ownNick: NETWORK_NICK });
-    const composeTa = page.locator(".compose-box textarea").first();
-    await expect(composeTa).toBeVisible({ timeout: 10_000 });
-    await composeTa.focus();
-    const paddingBottom = await page.evaluate(() => {
-      const shell = document.querySelector(".shell-mobile") as HTMLElement | null;
-      if (!shell) return "(no shell)";
-      return getComputedStyle(shell).paddingBottom;
-    });
-    expect(paddingBottom).toBe("0px");
   });
 
   test("(e) smart-pin: programmatic window scroll snaps back to 0", async ({ page }) => {

--- a/cicchetto/e2e/tests/ux-z-cluster-journey.spec.ts
+++ b/cicchetto/e2e/tests/ux-z-cluster-journey.spec.ts
@@ -109,7 +109,12 @@ test("@webkit UX-Z cluster — Dynamic Island clearance + RailActions archive + 
   });
   expect(shellPadding).not.toBeNull();
   expect(shellPadding?.top ?? "").toContain("safe-area-inset-top");
-  expect(shellPadding?.bottom ?? "").toContain("safe-area-inset-bottom");
+  // #1127 — the BOTTOM edge is flush now: the home-indicator inset lifted
+  // the shell off the bottom and exposed the transparent area behind it.
+  // Still declared (an empty string would mean base `.shell`'s inset
+  // cascades in at equal specificity), just zero; CSSOM may serialize the
+  // authored `0` as `0px`.
+  expect(shellPadding?.bottom ?? "").toMatch(/^0(px)?$/);
 
   // PART seed channel so the UX-2 archive-button arm has an archived
   // entry to render in the modal.

--- a/cicchetto/src/__tests__/helpers/themeCss.ts
+++ b/cicchetto/src/__tests__/helpers/themeCss.ts
@@ -42,6 +42,27 @@ export function focusRules(): { selectors: string; body: string }[] {
   return out;
 }
 
+/**
+ * Every body of a rule whose selector is EXACTLY `selector`, at any nesting
+ * depth — `ruleBody`'s column-0 anchor cannot see rules inside an `@media` /
+ * `@supports` block. Returns one entry per block on purpose: a selector can
+ * legitimately have more than one (`.shell-mobile` has a second block under
+ * `@supports not (height: 100dvh)`), and an assertion about which value a
+ * property ends up with has to see them all. Comments stripped, same as
+ * `ruleBody`; throws when the selector has no rule at all, so a rename can't
+ * pass vacuously.
+ */
+export function nestedRuleBodies(selector: string): string[] {
+  const stripped = themeCss.replace(/\/\*[\s\S]*?\*\//g, "");
+  const out: string[] = [];
+  for (const match of stripped.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    if ((match[1] ?? "").trim() !== selector) continue;
+    out.push(match[2] ?? "");
+  }
+  if (out.length === 0) throw new Error(`CSS rule not found: ${selector}`);
+  return out;
+}
+
 export function ruleBody(selector: string): string {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const re = new RegExp(`^${escaped}\\s*\\{([^}]*)\\}`, "m");

--- a/cicchetto/src/__tests__/ipadSafeArea.test.ts
+++ b/cicchetto/src/__tests__/ipadSafeArea.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import { ruleBody, themeCss } from "./helpers/themeCss";
+import { nestedRuleBodies, ruleBody, themeCss } from "./helpers/themeCss";
 
 // #205 — cicchetto as an installed PWA on iPadOS rendered its top chrome
 // (settings cog included) UNDER the iOS status bar, clipped and
@@ -90,5 +90,40 @@ describe("#205 iPad standalone-PWA safe area", () => {
     expect(css).toMatch(
       /\.shell-members\s*\{[\s\S]*?padding-bottom:\s*max\(1\.5rem,\s*env\(safe-area-inset-bottom\)\)/,
     );
+  });
+});
+
+// #1127 — the mobile shell's bottom edge. The guards above pin `.shell`
+// (desktop / iPad) and never mention `.shell-mobile`, so flipping the
+// mobile bottom edge used to land green either way. Same caveat as #205:
+// SOURCE-level, because jsdom resolves no `env()` and desktop Chrome
+// reports every inset as 0 — the on-device look still needs a real
+// notched iPhone.
+describe("#1127 mobile shell bottom edge", () => {
+  it(".shell-mobile declares exactly one bottom edge, and it is 0", () => {
+    // One assertion over the whole declaration list, deliberately: it has
+    // to kill three different regressions at once. Restoring the inset
+    // (`env(safe-area-inset-bottom)`) reopens the black band the issue was
+    // filed for. DELETING the declaration is just as wrong and far more
+    // tempting — base `.shell` declares the same property at the same
+    // specificity and the element carries both classes, so an absent
+    // longhand here means the inset cascades straight back in. And a
+    // second declaration appended after the `0` would silently win.
+    const declared = [
+      ...nestedRuleBodies(".shell-mobile")
+        .join("\n")
+        .matchAll(/padding-bottom:\s*([^;]+);/g),
+    ].map((m) => (m[1] ?? "").trim());
+    expect(declared).toEqual(["0"]);
+  });
+
+  it(".shell-mobile keeps the top / left / right insets", () => {
+    // Bottom edge only. The top inset clears the status bar and keeps the
+    // chrome tappable (UX-3 BIS); the sides matter in the sub-768 landscape
+    // edge on small notched devices.
+    const body = nestedRuleBodies(".shell-mobile").join("\n");
+    expect(body).toMatch(/padding-top:\s*env\(safe-area-inset-top\)/);
+    expect(body).toMatch(/padding-left:\s*env\(safe-area-inset-left\)/);
+    expect(body).toMatch(/padding-right:\s*env\(safe-area-inset-right\)/);
   });
 });

--- a/cicchetto/src/themes/default.css
+++ b/cicchetto/src/themes/default.css
@@ -6408,11 +6408,41 @@ html.resize-dragging * {
        (global, line 67) means the inset is consumed FROM the height,
        not added to it. */
     padding-top: env(safe-area-inset-top);
-    /* Home-indicator safe-area inset. (#177 removed the custom on-screen
-       keyboard, whose height reservation was folded in here; the native
-       keyboard shrinks the visual viewport on its own, so no extra
-       reservation is needed.) */
-    padding-bottom: env(safe-area-inset-bottom);
+    /* #1127 — the bottom edge is FLUSH: no home-indicator inset, so the
+       whole mobile shell (the `.bottom-bar` tab strip included) reaches
+       the physical bottom and the reclaimed band goes to content.
+
+       What the inset actually produced was NOT wasted padding inside the
+       bar: it lifted the shell off the bottom edge and exposed the
+       transparent area behind it. Measured on a 320x568x2 emulated
+       viewport with the iOS value injected by hand (`padding-bottom: 34px`
+       here, because desktop Chrome always reports `env()` as 0): the bar
+       ended 34px short, and `elementFromPoint` at the very bottom returned
+       `DIV.shell shell-mobile` computing to `rgba(0, 0, 0, 0)` while the
+       bar itself was `rgb(49, 50, 68)`. The accepted trade is that the tabs
+       now sit inside the home-indicator strip, where iOS also reads
+       gestures — do NOT re-add clearance to "fix" that without a ruling.
+
+       `0`, NOT a deleted declaration. Base `.shell` (~:1195) declares
+       `padding-bottom: env(safe-area-inset-bottom)` at the same
+       specificity, and the mobile element carries BOTH classes
+       (`<div class="shell shell-mobile">`), so dropping this line would
+       simply let the base rule cascade the inset back in.
+
+       This also retires the UX-6 D1/D11 keyboard collapse that used to
+       live below as `.shell-mobile:has(textarea:focus, input:focus) {
+       padding-bottom: 0 }`. D11's finding still holds and is the reason a
+       future bottom inset here is dangerous: with the keyboard up iOS
+       reports `env(safe-area-inset-bottom)` relative to the DEVICE, not
+       the shrunken visual viewport, so an inset here double-counts against
+       `--viewport-height` and reopens a ~34px gap above the keyboard (live
+       diag from vjt's iPhone PWA 18.7; D9 removed the override on a
+       speculative research claim and D11 had to restore it). A zero base
+       has nothing left to collapse — but anyone re-introducing an inset on
+       this edge MUST restore that override in the same change. (#177 had
+       folded the removed custom keyboard's height reservation into this
+       same declaration; nothing reserves height here now.) */
+    padding-bottom: 0;
     /* #205 — left/right insets declared EXPLICITLY here. The mobile
        element is `<div class="shell shell-mobile">` (Shell.tsx) — it
        carries BOTH classes — so it inherits base `.shell`'s new
@@ -6430,26 +6460,6 @@ html.resize-dragging * {
        for the camera housing / rounded corners, not a regression. */
     padding-left: env(safe-area-inset-left);
     padding-right: env(safe-area-inset-right);
-  }
-
-  /* UX-6 bucket D11 (2026-05-21) — D1 restored after D9 removal
-     was wrong. Research claim "double-counts with position:fixed
-     html" was speculation; live diag from vjt's iPhone PWA 18.7
-     showed gap between BottomBar and keyboard top remained ~34px
-     (= env(safe-area-inset-bottom) home indicator inset) because
-     iOS doesn't shrink the safe-area inset when keyboard is up —
-     it reports a value relative to the device, not the visible
-     viewport. With `vv.height = visible-excluding-keyboard` AND
-     `padding-bottom: env(safe-area-inset-bottom)` together, we
-     reserved 34px above what was already correctly shrunken.
-     Collapsing the padding when a text input is focused
-     (`:has(textarea:focus, input:focus)`) closes the gap. */
-  .shell-mobile:has(textarea:focus, input:focus) {
-    /* Native keyboard up → collapse the home-indicator inset (it would
-       double-count against the shrunken visual viewport). (#177: the custom
-       keyboard's height reservation was previously folded in here; with it
-       gone, this reverts to the original collapse-to-0 behavior.) */
-    padding-bottom: 0;
   }
 
   /* Legacy fallback for browsers that don't grok `dvh` (Safari < 15.4).
@@ -11635,9 +11645,11 @@ audio.media-viewer-media {
        focused the keyboard is (about to be) up: bump `--nab-lift` to clear
        the bottom bar too. This ALSO makes the reposition observable in a
        real-browser e2e (headless WebKit raises no soft keyboard, so
-       `--viewport-height` alone would not move on focus). Mirrors the
-       existing `.shell-mobile:has(textarea:focus, input:focus)`
-       keyboard-react rule (~:3444).
+       `--viewport-height` alone would not move on focus). This used to
+       mirror a `.shell-mobile:has(textarea:focus, input:focus)`
+       keyboard-react rule that collapsed the shell's bottom inset; #1127
+       zeroed that inset outright, so the lift below is now the ONLY
+       consumer of the focus signal.
 
    Bigger + a proper CIRCLE (#264 req 2 & 3): symmetric box, 50% radius,
    glyph-only body (count → corner badge below). `min-*: 48px` keeps the

--- a/docs/DESIGN_NOTES.md
+++ b/docs/DESIGN_NOTES.md
@@ -35213,3 +35213,62 @@ follow-up slices — the machinery, the gate and the measurement pattern are wha
 this one had to establish. `wireTypesAssert.ts` is NOT in that count: it is a
 compile-time bridge between `api.ts` hand-mirrors and `wireTypes.ts`, and it
 disappears when those mirrors do, not when the narrowers do.
+
+## 2026-08-09 — #1127: the wasted band was nothing painting, and zero is not the same as absent
+
+**The defect.** On a notched iPhone PWA a black band sat under the mobile
+window-tab strip. It reads like a bar that is too tall; it is not. The mobile
+shell carried `padding-bottom: env(safe-area-inset-bottom)` on its OUTER box,
+which lifted the whole shell — background included — off the physical bottom
+edge. Nothing painted in the strip it vacated. Measured on a `320x568x2`
+emulated viewport with the iOS value injected by hand (`padding-bottom: 34px`,
+because desktop Chrome always resolves `env()` to 0): `.bottom-bar` ended 34px
+short of `innerHeight`, and `elementFromPoint` at the very bottom returned
+`DIV.shell shell-mobile` computing to `rgba(0, 0, 0, 0)` while the bar itself
+was `rgb(49, 50, 68)`. **The defect does not reproduce without a real inset** —
+any claim about it made on a desktop browser is a claim about an injected
+value, not about the device.
+
+**The ruling** (vjt, on IRC): move the whole shell down, reclaim the band. So
+the bottom edge goes flush and the tabs now sit inside the home-indicator
+strip. That is an ACCEPTED trade, not an oversight: iOS also reads gestures
+there, and if a specific tab turns out to be unusable the answer is a
+measurement, not a unilateral re-add of clearance.
+
+**Zero, not absent.** The tempting edit is to delete the declaration. It is
+wrong. Base `.shell` declares `padding-bottom: env(safe-area-inset-bottom)` at
+the SAME specificity (both are single class selectors; an `@media` prelude adds
+none), and the mobile element carries both classes — `<div class="shell
+shell-mobile">`. `.shell-mobile`'s block is later in the stylesheet, so it wins
+only for as long as it declares the property. Remove the longhand and the inset
+cascades straight back in, silently, with the diff reading like a removal.
+This is the same trap #205 already documented from the other side (left/right
+were arriving from the base rule unannounced), which is why that rule owns all
+four edges explicitly.
+
+**A dead override is a liability, so it is deleted with its reason moved.**
+`.shell-mobile:has(textarea:focus, input:focus) { padding-bottom: 0 }` existed
+because with the keyboard up iOS reports the inset relative to the DEVICE, not
+the shrunken visual viewport, so an inset on this edge double-counts against
+`--viewport-height`. That override was removed once on a speculative research
+claim (UX-6 D9) and had to be restored after live diag from a real device
+(D11). With a zero base it collapses nothing, so it is gone — but its finding
+is not a historical note, it is the precondition anyone re-adding a bottom
+inset here would violate, so it now lives on the `padding-bottom: 0`
+declaration itself.
+
+**The guard, and why it is one assertion.** `ipadSafeArea.test.ts` pinned
+`.shell` and never mentioned `.shell-mobile`, so this change would have landed
+green either way. The new guard collects every `padding-bottom` declared by a
+`.shell-mobile` rule and asserts the list is exactly `["0"]`. One assertion,
+three kills: restoring the inset, deleting the longhand (the cascade trap
+above), and appending a second declaration after the zero. Proven by
+deliberate red on each.
+
+**What is NOT claimed.** Nobody has seen this on a device. jsdom resolves no
+`env()`, Playwright's iPhone emulation resolves every inset to 0, and there is
+no way to make `env(safe-area-inset-bottom)` report 34px from CSS — a
+hand-injected `padding-bottom` would be overriding the very declaration under
+test, so the simulation would be circular. The on-device look, and whether the
+bottom row of tabs still takes taps reliably inside the home-indicator strip,
+remain owed to a real notched iPhone.


### PR DESCRIPTION
Ruling from #1127: move the whole mobile shell down so the wasted bottom band goes away and that vertical space returns to content.

## What changed

`.shell-mobile` (inside `@media (max-width: 768px)`) now declares `padding-bottom: 0` instead of `env(safe-area-inset-bottom)`. The shell — `.bottom-bar` tab strip included — reaches the physical bottom edge.

**Zero, not a deleted declaration.** This is the part worth reviewing. Base `.shell` declares `padding-bottom: env(safe-area-inset-bottom)` at the *same* specificity (both single-class; an `@media` prelude adds none) and the mobile element carries **both** classes — `<div class="shell shell-mobile">`. `.shell-mobile`'s block wins only for as long as it declares the property. Delete the longhand and the inset cascades straight back in, with the diff reading like a removal. #205 already documented this trap from the other side, which is why that rule owns all four edges explicitly.

**The keyboard override is gone, its reason is not.** `.shell-mobile:has(textarea:focus, input:focus) { padding-bottom: 0 }` (UX-6 D1, removed at D9 on a speculative claim, restored at D11 from live device diag) collapses nothing against a zero base. It is deleted deliberately, and D11's finding — with the keyboard up iOS reports the inset relative to the *device*, not the shrunken visual viewport, so an inset here double-counts against `--viewport-height` — is now written on the surviving `padding-bottom: 0` declaration, where anyone re-adding an inset on this edge will read it as a precondition rather than as history.

**Bottom edge only.** Top / left / right insets are untouched and now pinned. **The tap target is untouched**: `.bottom-bar { min-height: 3rem }` is unchanged; the reclaimed space comes from the removed outer inset.

**Accepted trade, stated out loud:** the tabs now sit inside the home-indicator strip, where iOS also reads gestures. That is the ruling, not an oversight. If a specific tab turns out to be unusable on device, the answer is a measurement reported back — not unilaterally re-added clearance.

## The guard, and its red

`ipadSafeArea.test.ts` pinned `.shell` and never mentioned `.shell-mobile`, so this change would have landed green either way. It now collects every `padding-bottom` declared by a `.shell-mobile` rule and asserts the list is exactly `["0"]` — one assertion, because it must kill three distinct regressions. Proven with four deliberate mutants, each killing exactly one assertion (`src/__tests__/ipadSafeArea.test.ts`, 7 tests):

| mutant | result | killed |
|---|---|---|
| restore `env(safe-area-inset-bottom)` | `expected [ 'env(safe-area-inset-bottom)' ] to deeply equal [ '0' ]` | 1 failed / 6 passed, `:117` |
| delete the longhand (the cascade trap) | `expected [] to deeply equal [ '0' ]` | 1 failed / 6 passed, `:117` |
| append a second declaration after the `0` | `expected [ '0', 'env(safe-area-inset-bottom)' ] to deeply equal [ '0' ]` | 1 failed / 6 passed, `:117` |
| drop `padding-top: env(safe-area-inset-top)` | `expected '…' to match /padding-top:\s*env\(safe-area-inset-t…/` | 1 failed / 6 passed, top/left/right test |

New helper `nestedRuleBodies()` in `__tests__/helpers/themeCss.ts`: `ruleBody()` anchors at column 0 and cannot see rules inside an `@media` / `@supports` block. It returns *every* block for the selector on purpose — `.shell-mobile` has a second one under `@supports not (height: 100dvh)`, and an assertion about which value a property ends up with has to see them all.

## Three e2e specs asserted the old edge

- `ux-3-empty-toolbar-island.spec.ts` and `ux-z-cluster-journey.spec.ts` flip their expectation and keep guarding the edge at runtime, where CSSOM is a stronger oracle than source text. Both accept `/^0(px)?$/` (CSSOM may serialize the authored `0` as `0px`) and both would still fail on an *empty* string — i.e. on the cascade trap.
- `ux-6-d-keyboard-pattern.spec.ts` arm (d) loses its subject with the override and is deleted with its rationale. Worth noting: that arm was **already vacuous** under Playwright, which resolves every inset to 0 — it read `0px` whether or not the override applied.

## Gates

- `bun run check` (biome + `tsc --noEmit` + `tsc --noEmit -p e2e/tsconfig.json`) — **rc=0**. The 61 biome warnings / 5 infos are pre-existing descending-specificity diagnostics; the gate exits 0 with them.
- `bun run test` — **rc=0**, 265 files / 4914 tests passed.
- Working tree verified clean before and after the mutation runs.

## What I refuse to claim

- **That this looks right on a real iPhone.** Nobody has seen it. jsdom resolves no `env()`; Playwright's iPhone emulation resolves every inset to 0. **Device verification is still owed**, and so is the specific question the ruling flags: whether the bottom row of tabs still takes taps reliably inside the home-indicator strip.
- **That any before/after number here is mine.** Every measurement quoted — `.bottom-bar` ending 34px short of `innerHeight`, `elementFromPoint` returning `DIV.shell shell-mobile` at `rgba(0, 0, 0, 0)` against the bar's `rgb(49, 50, 68)` — is from the issue body, taken on a `320x568x2` emulated viewport **with the inset injected by hand** (`padding-bottom: 34px`), because desktop Chrome always reports `env()` as 0. I re-measured nothing.
- **That I could have measured it.** There is no faithful simulation available offline: `env(safe-area-inset-bottom)` cannot be given a value from CSS, and hand-injecting a `padding-bottom` would be overriding the very declaration under test — a circular check. The cascade claim in this PR is a reading of specificity and source order (`.shell` at `default.css:1158`, its bottom longhand at `:1195`; `.shell-mobile` at `:6364`), verified by mutant 2 at the source level, not by a rendered measurement.
- **That the e2e specs pass.** They were edited but **not run** — no lane, and these are `@webkit` specs needing the stack. Three specs are affected; CI is the first thing that will execute them.