### PR TITLE
cic(#1126): quote an /me as an action, and shut the CTCP door behind it

### DIFF
--- a/cicchetto/src/ScrollbackPane.tsx
+++ b/cicchetto/src/ScrollbackPane.tsx
@@ -15,6 +15,7 @@ import { isContentKind, ownNickForNetwork, type ScrollbackMessage } from "./lib/
 import { acceptInvite, confirmJoinChannel } from "./lib/channelJoin";
 import { channelKey, decodeChannelKey } from "./lib/channelKey";
 import { type TopicJoinLine, topicByChannel, topicJoinLine } from "./lib/channelTopic";
+import { stripCtcpAction } from "./lib/ctcpAction";
 import { isDocumentVisible } from "./lib/documentVisibility";
 import { highlightPatterns } from "./lib/highlightList";
 import { type InviteAckEntry, inviteAckBySlug } from "./lib/inviteAck";
@@ -448,22 +449,6 @@ const userhostSuffix = (msg: ScrollbackMessage): string => {
   const user = msg.meta.sender_user;
   const host = msg.meta.sender_host;
   return typeof user === "string" && typeof host === "string" ? ` [${user}@${host}]` : "";
-};
-
-// Strip the CTCP ACTION envelope (`\x01ACTION ...\x01`) from a body for
-// rendering. The server stores the wire-form body verbatim per the
-// CLAUDE.md "preserved as-is" rule (round-trip fidelity for ACTION
-// and other CTCP verbs); the display layer unwraps the envelope when
-// the kind discriminator already classifies the row as `:action`.
-// Defensive: if the envelope isn't there (e.g. a future server-side
-// pre-strip lands), fall through to the raw body.
-const CTCP_ACTION_PREFIX = "\x01ACTION ";
-const CTCP_DELIMITER = "\x01";
-const stripCtcpAction = (body: string | null): string => {
-  if (!body) return "";
-  if (!body.startsWith(CTCP_ACTION_PREFIX)) return body;
-  const inner = body.slice(CTCP_ACTION_PREFIX.length);
-  return inner.endsWith(CTCP_DELIMITER) ? inner.slice(0, -1) : inner;
 };
 
 type NickHandlers = {

--- a/cicchetto/src/__tests__/compose.test.ts
+++ b/cicchetto/src/__tests__/compose.test.ts
@@ -1052,6 +1052,47 @@ describe("compose submit — slash command dispatch", () => {
     expect(result).toEqual({ ok: true });
   });
 
+  // #1126 — the protocol half of the reply-quote defect. `sendBodyLines` is the
+  // ONE free-text outbound door (privmsg, /me, /msg); `ctcpFrame` is the ONE
+  // sanctioned producer of \x01, applied AFTER this scrub. So an operator-typed
+  // (or pasted, or quote-injected) \x01 can never reach the wire as framing we
+  // did not intend. Fixing `replyQuote` alone would leave this door open to the
+  // next path that learns to write into the compose box.
+  it("scrubs \\x01 out of a free-text privmsg before it reaches the wire — #1126", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "<vjt> \x01ACTION si dà alla fuga\x01<< no");
+    const result = await compose.submit(k, "freenode", "#a");
+
+    expect(sb.sendMessage).toHaveBeenCalledWith(
+      "freenode",
+      "#a",
+      "<vjt> ACTION si dà alla fuga<< no",
+    );
+    const body = vi.mocked(sb.sendMessage).mock.calls[0]?.[2] ?? "";
+    expect(body).not.toContain("\x01");
+    expect(result).toEqual({ ok: true });
+  });
+
+  // The scrub sits UPSTREAM of the framer, so /me still gets its envelope: the
+  // two delimiters below are ours, built by `ctcpFrame`, not passed through.
+  it("scrubs a pasted \\x01 from /me yet still frames the action — #1126", async () => {
+    localStorage.setItem("grappa-token", "tok");
+    const sb = await import("../lib/scrollback");
+    vi.mocked(sb.sendMessage).mockResolvedValue();
+
+    const compose = await import("../lib/compose");
+    const k = channelKey("freenode", "#a");
+    compose.setDraft(k, "/me waves\x01PING x\x01");
+    await compose.submit(k, "freenode", "#a");
+
+    expect(sb.sendMessage).toHaveBeenCalledWith("freenode", "#a", "\x01ACTION wavesPING x\x01");
+  });
+
   // #591/#640 — /ctcp <target> <verb> builds a single \x01VERB\x01 frame. #640:
   // a CTCP QUERY is a control-surface probe, so the echo is keyed to the SOURCE
   // window (the submit's channelName, "#a") and the wire recipient ("bob")

--- a/cicchetto/src/__tests__/replyQuote.test.ts
+++ b/cicchetto/src/__tests__/replyQuote.test.ts
@@ -70,9 +70,41 @@ describe("replyQuote", () => {
     expect(replyQuote(msg({ sender: "" }))).toBeNull();
   });
 
-  it("quotes a notice and an action — both have an author and a body", () => {
+  it("quotes a notice like speech — it has an author and a body", () => {
     expect(replyQuote(msg({ kind: "notice" }))).toBe("<vjt> ciao mondo<< ");
-    expect(replyQuote(msg({ kind: "action" }))).toBe("<vjt> ciao mondo<< ");
+  });
+
+  // #1126 — a real action row carries the wire envelope (`\x01ACTION …\x01`);
+  // the server stores it verbatim per the CLAUDE.md "preserved as-is" rule.
+  // The pre-#1126 quote ran the raw body through `mircPlainText`, which leaves
+  // \x01 alone by design, so BOTH the `ACTION` verb and the two delimiters
+  // ended up in the compose box and from there onto the wire.
+  it("quotes an action in ACTION form, envelope stripped — #1126", () => {
+    expect(replyQuote(msg({ kind: "action", body: "\x01ACTION si dà alla fuga\x01" }))).toBe(
+      "* vjt si dà alla fuga<< ",
+    );
+  });
+
+  // The delimiters are the protocol half of the defect: a \x01 we generated
+  // inside an ordinary PRIVMSG. Asserted separately from the shape above so a
+  // future reshaping of the quote cannot quietly take the guard with it.
+  it("leaves no \\x01 in the quote of an action — #1126", () => {
+    const quote = replyQuote(msg({ kind: "action", body: "\x01ACTION waves\x01" })) ?? "";
+    expect(quote).not.toContain("\x01");
+    expect(quote).not.toContain("ACTION");
+  });
+
+  // `stripCtcpAction` is deliberately defensive about a missing envelope (a
+  // future server-side pre-strip, or a row persisted before the wire form was
+  // stored). The action SHAPE must not depend on the envelope being there.
+  it("still uses action form when the envelope is absent — #1126", () => {
+    expect(replyQuote(msg({ kind: "action", body: "ciao mondo" }))).toBe("* vjt ciao mondo<< ");
+  });
+
+  // An envelope with nothing inside is not a quotable action: after the strip
+  // the body is empty, and `* vjt << ` is not a reply to anything.
+  it("refuses an action whose envelope is empty — #1126", () => {
+    expect(replyQuote(msg({ kind: "action", body: "\x01ACTION \x01" }))).toBeNull();
   });
 });
 

--- a/cicchetto/src/lib/compose.ts
+++ b/cicchetto/src/lib/compose.ts
@@ -15,6 +15,7 @@ import { openBanlistModal } from "./banlistModal";
 import { buildBanMask } from "./banMask";
 import { setQuery } from "./channelDirectory";
 import { type ChannelKey, canonicalChannel, channelKey, decodeChannelKey } from "./channelKey";
+import { scrubCtcpDelimiters } from "./ctcpAction";
 import { documentTeardownEpoch, documentTornDownSince } from "./documentTeardown";
 import { friendlyError } from "./friendlyError";
 import { addHighlight, delHighlight } from "./highlightList";
@@ -284,7 +285,13 @@ export const sendBodyLines = async (
   action: boolean,
   onProgress?: (sent: number, total: number, residue: string) => void,
 ): Promise<void> => {
-  const lines = splitMessageLines(body);
+  // #1126 — the exit guard. This is the ONE free-text outbound door, and
+  // `ctcpFrame` (applied below, AFTER the scrub) is the ONE sanctioned producer
+  // of \x01. Anything the operator typed, pasted, or had written into their
+  // compose box by another verb is text, never framing. Scrubbing here rather
+  // than at each writer means the next path that learns to fill the compose box
+  // inherits the guarantee instead of having to remember it.
+  const lines = splitMessageLines(scrubCtcpDelimiters(body));
   const total = lines.length;
   let sent = 0;
   // Consecutive paced retries of the CURRENT line; reset when `sent` advances.

--- a/cicchetto/src/lib/ctcpAction.ts
+++ b/cicchetto/src/lib/ctcpAction.ts
@@ -1,0 +1,34 @@
+// The CTCP ACTION envelope, and the one place that knows its shape.
+//
+// The server stores the wire-form body verbatim per the CLAUDE.md CTCP
+// "preserved as-is" rule (round-trip fidelity for ACTION and other verbs), so
+// every consumer that wants the text a human actually saw has to unwrap it.
+//
+// #1126 — this used to be a module-local `const` inside `ScrollbackPane.tsx`,
+// which meant the RENDER layer unwrapped the envelope and the REPLY layer did
+// not: replying to an `/me` quoted `<nick> \x01ACTION text\x01<< ` and shipped
+// both delimiters back onto the wire inside an ordinary PRIVMSG. One parser,
+// one shape, both doors.
+
+export const CTCP_DELIMITER = "\x01";
+const CTCP_ACTION_PREFIX = `${CTCP_DELIMITER}ACTION `;
+
+// The inner text of an action body, or the body unchanged when the envelope
+// isn't there. Defensive on purpose: a future server-side pre-strip, or a row
+// persisted before the wire form was stored, must still render.
+export const stripCtcpAction = (body: string | null): string => {
+  if (!body) return "";
+  if (!body.startsWith(CTCP_ACTION_PREFIX)) return body;
+  const inner = body.slice(CTCP_ACTION_PREFIX.length);
+  return inner.endsWith(CTCP_DELIMITER) ? inner.slice(0, -1) : inner;
+};
+
+// Scrub every CTCP delimiter out of operator-typed free text.
+//
+// `\x01` is framing, and cic has exactly ONE sanctioned producer of it
+// (`ctcpFrame` in compose.ts). A delimiter arriving in free text is either a
+// paste or a bug upstream; either way it is not framing the operator chose, so
+// it must not survive to the wire. Scrub rather than reject — the byte is
+// invisible, so refusing the whole message would be an unexplainable failure,
+// and the tree's posture for a stray \x01 is already "scrub it" (#641).
+export const scrubCtcpDelimiters = (text: string): string => text.replaceAll(CTCP_DELIMITER, "");

--- a/cicchetto/src/lib/replyQuote.ts
+++ b/cicchetto/src/lib/replyQuote.ts
@@ -1,5 +1,6 @@
 import { isContentKind, type ScrollbackMessage } from "./api";
 import { appendToCompose } from "./composeAppend";
+import { stripCtcpAction } from "./ctcpAction";
 import { mircPlainText } from "./mircFormat";
 
 // #1067 — the reply verb, shared by the left→right swipe on a message row and
@@ -22,12 +23,23 @@ export const REPLY_QUOTE_TAIL = "<< ";
 export function replyQuote(msg: ScrollbackMessage): string | null {
   if (!isContentKind(msg.kind)) return null;
   if (msg.sender === "") return null;
+  // #1126 — an action's stored body is the raw `\x01ACTION …\x01` wire form.
+  // Unwrap it FIRST, with the same helper the render layer uses, so the quote
+  // holds the text the operator actually saw. `mircPlainText` deliberately
+  // leaves \x01 alone (its call sites need the envelope to round-trip), so
+  // stripping there would have been the wrong door.
+  const raw = msg.kind === "action" ? stripCtcpAction(msg.body) : (msg.body ?? "");
   // The wire body can carry mIRC control bytes (\x02 bold, \x03 colour…). The
   // operator is quoting what they SEE, and a control byte round-tripped through
   // compose would be re-sent as formatting they never chose.
-  const body = mircPlainText(msg.body ?? "").trim();
+  const body = mircPlainText(raw).trim();
   if (body === "") return null;
-  return `<${msg.sender}> ${body}${REPLY_QUOTE_TAIL}`;
+  // #1126 — an action is NOT speech. Quoting `* vjt waves` as `<vjt> waves`
+  // puts a sentence in someone's mouth that they never said, so the quote keeps
+  // the `* nick …` form the scrollback renders. Ruled on the least-surprise
+  // tiebreak; privmsg/notice keep the `<nick> …` shape unchanged.
+  const head = msg.kind === "action" ? `* ${msg.sender}` : `<${msg.sender}>`;
+  return `${head} ${body}${REPLY_QUOTE_TAIL}`;
 }
 
 // Drop the quote into the window's compose box with the caret at the end. A


### PR DESCRIPTION
Replying to an `/me` quoted the raw CTCP wire form and re-emitted both
`\x01` delimiters inside an ordinary PRIVMSG. Two defects in one line, per
#1126: the `ACTION` verb leaked into the visible text, and we generated
CTCP framing bytes in a non-CTCP message.

## The form ruling — stated, so it can be overturned in one line

The issue deliberately left open whether the quote should stay an ACTION
or become speech. **This PR implements the action form:**

```
* Fairy si da' alla fuga<<
```

not

```
<Fairy> si da' alla fuga<<
```

Reason: an action is not speech. Quoting `* Fairy waves` as `<Fairy> waves`
attributes to someone a sentence they never said, and the reader of the
original saw an action, not a line of dialogue. Least surprise is the form
the scrollback already renders. privmsg and notice are untouched.

This is a judgement call, not a derivation. If the preference is speech
form, it is one line in `replyQuote` plus two test expectations.

## The three commits

1. **Extraction.** `stripCtcpAction` was a module-local `const` in
   `ScrollbackPane.tsx`, so the render layer could unwrap the envelope and
   nothing else could. Moved verbatim to `lib/ctcpAction.ts` and imported
   back — no second copy of a CTCP parser.
2. **The quote.** `replyQuote` unwraps the envelope with that same helper.
   Not in `mircPlainText`: its other call sites need the envelope to
   round-trip verbatim per the CLAUDE.md "preserved as-is" rule, so
   stripping there would have fixed one door by breaking several.
3. **The exit guard.** Fixing the quote closes the path the defect walked
   through; it does not close the door.

## The door census

Four outbound PRIVMSG sites. Only one carries operator free text:

| Site | Body | In scope |
|---|---|---|
| `compose.ts:296` `sendBodyLines` (privmsg, `/me`, `/msg`) | operator free text | **yes — guarded** |
| `compose.ts:828/830` `/ctcp` | `ctcpFrame(verb, args)` | no — see below |
| `compose.ts:865` `/ping` | generated token | no |
| `uploadOrchestrator.ts:453` | generated URL | no |

So the guard is one call in one place, and it sits **upstream** of
`ctcpFrame` — the one sanctioned producer of `\x01` — which is why `/me`
still gets its envelope. Scrub rather than reject: the byte is invisible,
so refusing the whole message would be an unexplainable failure, and the
tree's posture for a stray `\x01` is already "scrub it" (#641).

**Known adjacent hole, deliberately out of scope.** `/ctcp <target> <verb>
<args>` passes operator-typed verb and args straight into `ctcpFrame`, so a
pasted `\x01` there yields an interior delimiter — the same malformed-frame
class as #641. It is a different door (an operator explicitly driving a
control surface, not free text) and widening this PR to cover it would
change `/ctcp` semantics. Flagged, not fixed.

## Verification

Every number below was read on this branch, not carried over from the issue.

- Issue line references re-confirmed against `origin/main` (`ed67d244`):
  `ScrollbackPane.tsx:460-467`, `api.ts:660`, `mircFormat.test.ts:31-34`
  are exact; `replyQuote.ts:23-31` is the function body, with the
  `mircPlainText` call at `:28`.
- `bun run check` (biome + `tsc --noEmit` over `src/` and `e2e/`) — exit 0.
- Full vitest suite — 4918 passed, 265 files, exit 0.
- **Mutation, each reverted by hand and the red read literally:**
  - drop the envelope strip: 3 failures, the received string carrying the
    escaped `ACTION` envelope where the plain text was expected; the
    action-form test survives.
  - revert to `<nick>` form: 2 failures, `expected '<vjt> si da' alla
    fuga<< ' to be '* vjt si da' alla fuga<< '`; the delimiter test
    survives.
  - drop the outbound scrub: the 2 compose guard tests die.

  Each mutant kills a disjoint set, so no assertion is standing in for
  another.

## Notes for review

- The pre-existing test `quotes a notice and an action` passed an action
  body with **no** CTCP envelope, so it never exercised the defect it
  nominally covered. Replaced with cases carrying the real wire form.
- **#1123** touches the tail of this same quote (reply-of-reply
  truncation). Not worked here — whoever lands second should re-read the
  other.
- No e2e spec added. The unit layer pins both the shape and the outbound
  bytes; an e2e would re-assert the same two strings through a browser.
  Say the word if a live-peer spec is wanted.
